### PR TITLE
Adapt uninitialized_copy and uninitialized_copy_n to C++ 20

### DIFF
--- a/docs/sphinx/api/public_api.rst
+++ b/docs/sphinx/api/public_api.rst
@@ -573,13 +573,15 @@ Functions
 - :cpp:func:`hpx::parallel::v1::uninitialized_fill_n`
 - :cpp:func:`hpx::uninitialized_move`
 - :cpp:func:`hpx::uninitialized_move_n`
-- :cpp:func:`hpx::parallel::v1::uninitialized_value_construct`
-- :cpp:func:`hpx::parallel::v1::uninitialized_value_construct_n`
+- :cpp:func:`hpx::uninitialized_value_construct`
+- :cpp:func:`hpx::uninitialized_value_construct_n`
 
 - :cpp:func:`hpx::ranges::uninitialized_default_construct`
 - :cpp:func:`hpx::ranges::uninitialized_default_construct_n`
 - :cpp:func:`hpx::ranges::uninitialized_move`
 - :cpp:func:`hpx::ranges::uninitialized_move_n`
+- :cpp:func:`hpx::ranges::uninitialized_value_construct`
+- :cpp:func:`hpx::ranges::uninitialized_value_construct_n`
 
 Header ``hpx/numeric.hpp``
 ==========================

--- a/docs/sphinx/api/public_api.rst
+++ b/docs/sphinx/api/public_api.rst
@@ -565,8 +565,8 @@ more information about the parallel algorithms.
 Functions
 ---------
 
-- :cpp:func:`hpx::parallel::v1::uninitialized_copy`
-- :cpp:func:`hpx::parallel::v1::uninitialized_copy_n`
+- :cpp:func:`hpx::uninitialized_copy`
+- :cpp:func:`hpx::uninitialized_copy_n`
 - :cpp:func:`hpx::uninitialized_default_construct`
 - :cpp:func:`hpx::uninitialized_default_construct_n`
 - :cpp:func:`hpx::parallel::v1::uninitialized_fill`
@@ -576,6 +576,8 @@ Functions
 - :cpp:func:`hpx::uninitialized_value_construct`
 - :cpp:func:`hpx::uninitialized_value_construct_n`
 
+- :cpp:func:`hpx::ranges::uninitialized_copy`
+- :cpp:func:`hpx::ranges::uninitialized_copy_n`
 - :cpp:func:`hpx::ranges::uninitialized_default_construct`
 - :cpp:func:`hpx::ranges::uninitialized_default_construct_n`
 - :cpp:func:`hpx::ranges::uninitialized_move`

--- a/docs/sphinx/api/public_api.rst
+++ b/docs/sphinx/api/public_api.rst
@@ -585,6 +585,9 @@ Functions
 - :cpp:func:`hpx::ranges::uninitialized_value_construct`
 - :cpp:func:`hpx::ranges::uninitialized_value_construct_n`
 
+- :cpp:func:`hpx::ranges::uninitialized_copy`
+- :cpp:func:`hpx::ranges::uninitialized_copy_n`
+
 Header ``hpx/numeric.hpp``
 ==========================
 

--- a/docs/sphinx/api/public_api.rst
+++ b/docs/sphinx/api/public_api.rst
@@ -567,8 +567,8 @@ Functions
 
 - :cpp:func:`hpx::parallel::v1::uninitialized_copy`
 - :cpp:func:`hpx::parallel::v1::uninitialized_copy_n`
-- :cpp:func:`hpx::parallel::v1::uninitialized_default_construct`
-- :cpp:func:`hpx::parallel::v1::uninitialized_default_construct_n`
+- :cpp:func:`hpx::uninitialized_default_construct`
+- :cpp:func:`hpx::uninitialized_default_construct_n`
 - :cpp:func:`hpx::parallel::v1::uninitialized_fill`
 - :cpp:func:`hpx::parallel::v1::uninitialized_fill_n`
 - :cpp:func:`hpx::uninitialized_move`
@@ -576,6 +576,8 @@ Functions
 - :cpp:func:`hpx::parallel::v1::uninitialized_value_construct`
 - :cpp:func:`hpx::parallel::v1::uninitialized_value_construct_n`
 
+- :cpp:func:`hpx::ranges::uninitialized_default_construct`
+- :cpp:func:`hpx::ranges::uninitialized_default_construct_n`
 - :cpp:func:`hpx::ranges::uninitialized_move`
 - :cpp:func:`hpx::ranges::uninitialized_move_n`
 

--- a/docs/sphinx/manual/writing_single_node_hpx_applications.rst
+++ b/docs/sphinx/manual/writing_single_node_hpx_applications.rst
@@ -724,11 +724,11 @@ Parallel algorithms
      * Copies a number of objects to an uninitialized area of memory.
      * ``<hpx/memory.hpp>``
      * :cppreference-memory:`uninitialized_copy_n`
-   * * :cpp:func:`hpx::parallel::v1::uninitialized_default_construct`
+   * * :cpp:func:`hpx::uninitialized_default_construct`
      * Copies a range of objects to an uninitialized area of memory.
      * ``<hpx/memory.hpp>``
      * :cppreference-memory:`uninitialized_default_construct`
-   * * :cpp:func:`hpx::parallel::v1::uninitialized_default_construct_n`
+   * * :cpp:func:`hpx::uninitialized_default_construct_n`
      * Copies a number of objects to an uninitialized area of memory.
      * ``<hpx/memory.hpp>``
      * :cppreference-memory:`uninitialized_default_construct_n`

--- a/docs/sphinx/manual/writing_single_node_hpx_applications.rst
+++ b/docs/sphinx/manual/writing_single_node_hpx_applications.rst
@@ -716,11 +716,11 @@ Parallel algorithms
      * Destroys a range of objects.
      * ``<hpx/memory.hpp>``
      * :cppreference-memory:`destroy_n`
-   * * :cpp:func:`hpx::parallel::v1::uninitialized_copy`
+   * * :cpp:func:`hpx::uninitialized_copy`
      * Copies a range of objects to an uninitialized area of memory.
      * ``<hpx/memory.hpp>``
      * :cppreference-memory:`uninitialized_copy`
-   * * :cpp:func:`hpx::parallel::v1::uninitialized_copy_n`
+   * * :cpp:func:`hpx::uninitialized_copy_n`
      * Copies a number of objects to an uninitialized area of memory.
      * ``<hpx/memory.hpp>``
      * :cppreference-memory:`uninitialized_copy_n`

--- a/docs/sphinx/manual/writing_single_node_hpx_applications.rst
+++ b/docs/sphinx/manual/writing_single_node_hpx_applications.rst
@@ -748,11 +748,11 @@ Parallel algorithms
      * Moves a number of objects to an uninitialized area of memory.
      * ``<hpx/memory.hpp>``
      * :cppreference-memory:`uninitialized_move_n`
-   * * :cpp:func:`hpx::parallel::v1::uninitialized_value_construct`
+   * * :cpp:func:`hpx::uninitialized_value_construct`
      * Constructs objects in an uninitialized area of memory.
      * ``<hpx/memory.hpp>``
      * :cppreference-memory:`uninitialized_value_construct`
-   * * :cpp:func:`hpx::parallel::v1::uninitialized_value_construct_n`
+   * * :cpp:func:`hpx::uninitialized_value_construct_n`
      * Constructs objects in an uninitialized area of memory.
      * ``<hpx/memory.hpp>``
      * :cppreference-memory:`uninitialized_value_construct_n`

--- a/libs/full/include_local/include/hpx/local/memory.hpp
+++ b/libs/full/include_local/include/hpx/local/memory.hpp
@@ -14,6 +14,4 @@ namespace hpx {
     using hpx::parallel::uninitialized_copy_n;
     using hpx::parallel::uninitialized_fill;
     using hpx::parallel::uninitialized_fill_n;
-    using hpx::parallel::uninitialized_value_construct;
-    using hpx::parallel::uninitialized_value_construct_n;
 }    // namespace hpx

--- a/libs/full/include_local/include/hpx/local/memory.hpp
+++ b/libs/full/include_local/include/hpx/local/memory.hpp
@@ -10,8 +10,6 @@
 #include <hpx/parallel/memory.hpp>
 
 namespace hpx {
-    using hpx::parallel::uninitialized_copy;
-    using hpx::parallel::uninitialized_copy_n;
     using hpx::parallel::uninitialized_fill;
     using hpx::parallel::uninitialized_fill_n;
 }    // namespace hpx

--- a/libs/full/include_local/include/hpx/local/memory.hpp
+++ b/libs/full/include_local/include/hpx/local/memory.hpp
@@ -12,8 +12,6 @@
 namespace hpx {
     using hpx::parallel::uninitialized_copy;
     using hpx::parallel::uninitialized_copy_n;
-    using hpx::parallel::uninitialized_default_construct;
-    using hpx::parallel::uninitialized_default_construct_n;
     using hpx::parallel::uninitialized_fill;
     using hpx::parallel::uninitialized_fill_n;
     using hpx::parallel::uninitialized_value_construct;

--- a/libs/parallelism/algorithms/CMakeLists.txt
+++ b/libs/parallelism/algorithms/CMakeLists.txt
@@ -121,6 +121,7 @@ set(algorithms_headers
     hpx/parallel/container_algorithms/stable_sort.hpp
     hpx/parallel/container_algorithms/transform.hpp
     hpx/parallel/container_algorithms/transform_reduce.hpp
+    hpx/parallel/container_algorithms/uninitialized_default_construct.hpp
     hpx/parallel/container_algorithms/uninitialized_move.hpp
     hpx/parallel/container_algorithms/unique.hpp
     hpx/parallel/container_memory.hpp

--- a/libs/parallelism/algorithms/CMakeLists.txt
+++ b/libs/parallelism/algorithms/CMakeLists.txt
@@ -121,6 +121,7 @@ set(algorithms_headers
     hpx/parallel/container_algorithms/stable_sort.hpp
     hpx/parallel/container_algorithms/transform.hpp
     hpx/parallel/container_algorithms/transform_reduce.hpp
+    hpx/parallel/container_algorithms/uninitialized_copy.hpp
     hpx/parallel/container_algorithms/uninitialized_default_construct.hpp
     hpx/parallel/container_algorithms/uninitialized_move.hpp
     hpx/parallel/container_algorithms/uninitialized_value_construct.hpp

--- a/libs/parallelism/algorithms/CMakeLists.txt
+++ b/libs/parallelism/algorithms/CMakeLists.txt
@@ -123,6 +123,7 @@ set(algorithms_headers
     hpx/parallel/container_algorithms/transform_reduce.hpp
     hpx/parallel/container_algorithms/uninitialized_default_construct.hpp
     hpx/parallel/container_algorithms/uninitialized_move.hpp
+    hpx/parallel/container_algorithms/uninitialized_value_construct.hpp
     hpx/parallel/container_algorithms/unique.hpp
     hpx/parallel/container_memory.hpp
     hpx/parallel/container_numeric.hpp

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/uninitialized_copy.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/uninitialized_copy.hpp
@@ -209,7 +209,7 @@ namespace hpx {
 
 #include <hpx/config.hpp>
 #include <hpx/concepts/concepts.hpp>
-#include <hpx/functional/tag_fallback_invoke.hpp>
+#include <hpx/functional/tag_fallback_dispatch.hpp>
 #include <hpx/iterator_support/traits/is_iterator.hpp>
 
 #include <hpx/execution/algorithms/detail/is_negative.hpp>
@@ -550,7 +550,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
 
 namespace hpx {
     ///////////////////////////////////////////////////////////////////////////
-    // CPO for hpx::uninitialized_copy
+    // DPO for hpx::uninitialized_copy
     HPX_INLINE_CONSTEXPR_VARIABLE struct uninitialized_copy_t final
       : hpx::functional::tag_fallback<uninitialized_copy_t>
     {
@@ -561,7 +561,7 @@ namespace hpx {
                 hpx::traits::is_forward_iterator<FwdIter>::value
             )>
         // clang-format on
-        friend FwdIter tag_fallback_invoke(
+        friend FwdIter tag_fallback_dispatch(
             hpx::uninitialized_copy_t, InIter first, InIter last, FwdIter dest)
         {
             static_assert(hpx::traits::is_input_iterator<InIter>::value,
@@ -585,7 +585,7 @@ namespace hpx {
         // clang-format on
         friend typename parallel::util::detail::algorithm_result<ExPolicy,
             FwdIter2>::type
-        tag_fallback_invoke(hpx::uninitialized_copy_t, ExPolicy&& policy,
+        tag_fallback_dispatch(hpx::uninitialized_copy_t, ExPolicy&& policy,
             FwdIter1 first, FwdIter1 last, FwdIter2 dest)
         {
             static_assert(hpx::traits::is_forward_iterator<FwdIter1>::value,
@@ -602,7 +602,7 @@ namespace hpx {
     } uninitialized_copy{};
 
     ///////////////////////////////////////////////////////////////////////////
-    // CPO for hpx::uninitialized_copy_n
+    // DPO for hpx::uninitialized_copy_n
     HPX_INLINE_CONSTEXPR_VARIABLE struct uninitialized_copy_n_t final
       : hpx::functional::tag_fallback<uninitialized_copy_n_t>
     {
@@ -614,7 +614,7 @@ namespace hpx {
                 hpx::traits::is_forward_iterator<FwdIter>::value
             )>
         // clang-format on
-        friend FwdIter tag_fallback_invoke(
+        friend FwdIter tag_fallback_dispatch(
             hpx::uninitialized_copy_n_t, InIter first, Size count, FwdIter dest)
         {
             static_assert(hpx::traits::is_input_iterator<InIter>::value,
@@ -645,7 +645,7 @@ namespace hpx {
         // clang-format on
         friend typename parallel::util::detail::algorithm_result<ExPolicy,
             FwdIter2>::type
-        tag_fallback_invoke(hpx::uninitialized_copy_n_t, ExPolicy&& policy,
+        tag_fallback_dispatch(hpx::uninitialized_copy_n_t, ExPolicy&& policy,
             FwdIter1 first, Size count, FwdIter2 dest)
         {
             static_assert(hpx::traits::is_forward_iterator<FwdIter1>::value,

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/uninitialized_copy.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/uninitialized_copy.hpp
@@ -101,10 +101,6 @@ namespace hpx {
     /// \note   Complexity: Performs exactly \a count assignments, if
     ///         count > 0, no assignments otherwise.
     ///
-    /// \tparam ExPolicy    The type of the execution policy to use (deduced).
-    ///                     It describes the manner in which the execution
-    ///                     of the algorithm may be parallelized and the manner
-    ///                     in which it executes the assignments.
     /// \tparam FwdIter1      The type of the source iterators used (deduced).
     ///                     This iterator type must meet the requirements of an
     ///                     input iterator.
@@ -115,8 +111,6 @@ namespace hpx {
     ///                     This iterator type must meet the requirements of a
     ///                     forward iterator.
     ///
-    /// \param policy       The execution policy to use for the scheduling of
-    ///                     the iterations.
     /// \param first        Refers to the beginning of the sequence of elements
     ///                     the algorithm will be applied to.
     /// \param count        Refers to the number of elements starting at
@@ -124,22 +118,11 @@ namespace hpx {
     /// \param dest         Refers to the beginning of the destination range.
     ///
     /// The assignments in the parallel \a uninitialized_copy_n algorithm
-    /// invoked with an execution policy object of type
-    /// \a sequenced_policy execute in sequential order in the
-    /// calling thread.
-    ///
-    /// The assignments in the parallel \a uninitialized_copy_n algorithm
-    /// invoked with an execution policy object of type
-    /// \a parallel_policy or
-    /// \a parallel_task_policy are permitted to execute in an
-    /// unordered fashion in unspecified threads, and indeterminately sequenced
-    /// within each thread.
+    /// invoked without an execution policy object execute in sequential order
+    /// in the calling thread.
     ///
     /// \returns  The \a uninitialized_copy_n algorithm returns a
-    ///           \a hpx::future<FwdIter2> if the execution policy is of type
-    ///           \a sequenced_task_policy or
-    ///           \a parallel_task_policy and
-    ///           returns \a FwdIter2 otherwise.
+    ///           returns \a FwdIter2.
     ///           The \a uninitialized_copy_n algorithm returns the output
     ///           iterator to the element in the destination range, one past
     ///           the last element copied.

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/uninitialized_copy.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/uninitialized_copy.hpp
@@ -427,7 +427,8 @@ namespace hpx { namespace parallel { inline namespace v1 {
                     {
                         ::new (std::addressof(*current)) value_type(*first);
                     }
-                    return util::in_out_result<InIter1, FwdIter2>{first, current};
+                    return util::in_out_result<InIter1, FwdIter2>{
+                        first, current};
                 }
                 catch (...)
                 {
@@ -484,7 +485,8 @@ namespace hpx { namespace parallel { inline namespace v1 {
                     {
                         ::new (std::addressof(*current)) value_type(*first);
                     }
-                    return util::in_out_result<InIter, FwdIter2>{first, current};
+                    return util::in_out_result<InIter, FwdIter2>{
+                        first, current};
                 }
                 catch (...)
                 {

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/uninitialized_copy.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/uninitialized_copy.hpp
@@ -8,12 +8,214 @@
 
 #pragma once
 
+#if defined(DOXYGEN)
+namespace hpx {
+
+    /// Copies the elements in the range, defined by [first, last), to an
+    /// uninitialized memory area beginning at \a dest. If an exception is
+    /// thrown during the copy operation, the function has no effects.
+    ///
+    /// \note   Complexity: Performs exactly \a last - \a first assignments.
+    ///
+    /// \tparam InIter      The type of the source iterators used (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     input iterator.
+    /// \tparam FwdIter     The type of the iterator representing the
+    ///                     destination range (deduced).
+    ///                     This iterator type must meet the requirements of a
+    ///                     forward iterator.
+    ///
+    /// \param first        Refers to the beginning of the sequence of elements
+    ///                     the algorithm will be applied to.
+    /// \param last         Refers to the end of the sequence of elements the
+    ///                     algorithm will be applied to.
+    /// \param dest         Refers to the beginning of the destination range.
+    ///
+    /// The assignments in the parallel \a uninitialized_copy algorithm invoked
+    /// without an execution policy object will execute in sequential order in
+    /// the calling thread.
+    ///
+    /// \returns  The \a uninitialized_copy algorithm returns \a FwdIter.
+    ///           The \a uninitialized_copy algorithm returns the output
+    ///           iterator to the element in the destination range, one past
+    ///           the last element copied.
+    ///
+    template <typename InIter, typename FwdIter>
+    FwdIter uninitialized_copy(InIter first, InIter last, FwdIter dest);
+
+    /// Copies the elements in the range, defined by [first, last), to an
+    /// uninitialized memory area beginning at \a dest. If an exception is
+    /// thrown during the copy operation, the function has no effects.
+    ///
+    /// \note   Complexity: Performs exactly \a last - \a first assignments.
+    ///
+    /// \tparam ExPolicy    The type of the execution policy to use (deduced).
+    ///                     It describes the manner in which the execution
+    ///                     of the algorithm may be parallelized and the manner
+    ///                     in which it executes the assignments.
+    /// \tparam FwdIter1    The type of the source iterators used (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     forward iterator.
+    /// \tparam FwdIter2    The type of the iterator representing the
+    ///                     destination range (deduced).
+    ///                     This iterator type must meet the requirements of a
+    ///                     forward iterator.
+    ///
+    /// \param policy       The execution policy to use for the scheduling of
+    ///                     the iterations.
+    /// \param first        Refers to the beginning of the sequence of elements
+    ///                     the algorithm will be applied to.
+    /// \param last         Refers to the end of the sequence of elements the
+    ///                     algorithm will be applied to.
+    /// \param dest         Refers to the beginning of the destination range.
+    ///
+    /// The assignments in the parallel \a uninitialized_copy algorithm invoked
+    /// with an execution policy object of type \a sequenced_policy
+    /// execute in sequential order in the calling thread.
+    ///
+    /// The assignments in the parallel \a uninitialized_copy algorithm invoked
+    /// with an execution policy object of type \a parallel_policy or
+    /// \a parallel_task_policy are permitted to execute in an
+    /// unordered fashion in unspecified threads, and indeterminately sequenced
+    /// within each thread.
+    ///
+    /// \returns  The \a uninitialized_copy algorithm returns a
+    ///           \a hpx::future<FwdIter2>, if the execution policy is of type
+    ///           \a sequenced_task_policy or
+    ///           \a parallel_task_policy and
+    ///           returns \a FwdIter2 otherwise.
+    ///           The \a uninitialized_copy algorithm returns the output
+    ///           iterator to the element in the destination range, one past
+    ///           the last element copied.
+    ///
+    template <typename ExPolicy, typename FwdIter1, typename FwdIter2>
+    typename parallel::util::detail::algorithm_result<ExPolicy, FwdIter2>::type
+    uninitialized_copy(
+        ExPolicy&& policy, FwdIter1 first, FwdIter1 last, FwdIter2 dest);
+
+    /// Copies the elements in the range [first, first + count), starting from
+    /// first and proceeding to first + count - 1., to another range beginning
+    /// at dest. If an exception is thrown during the copy operation, the
+    /// function has no effects.
+    ///
+    /// \note   Complexity: Performs exactly \a count assignments, if
+    ///         count > 0, no assignments otherwise.
+    ///
+    /// \tparam ExPolicy    The type of the execution policy to use (deduced).
+    ///                     It describes the manner in which the execution
+    ///                     of the algorithm may be parallelized and the manner
+    ///                     in which it executes the assignments.
+    /// \tparam FwdIter1      The type of the source iterators used (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     input iterator.
+    /// \tparam Size        The type of the argument specifying the number of
+    ///                     elements to apply \a f to.
+    /// \tparam FwdIter2     The type of the iterator representing the
+    ///                     destination range (deduced).
+    ///                     This iterator type must meet the requirements of a
+    ///                     forward iterator.
+    ///
+    /// \param policy       The execution policy to use for the scheduling of
+    ///                     the iterations.
+    /// \param first        Refers to the beginning of the sequence of elements
+    ///                     the algorithm will be applied to.
+    /// \param count        Refers to the number of elements starting at
+    ///                     \a first the algorithm will be applied to.
+    /// \param dest         Refers to the beginning of the destination range.
+    ///
+    /// The assignments in the parallel \a uninitialized_copy_n algorithm
+    /// invoked with an execution policy object of type
+    /// \a sequenced_policy execute in sequential order in the
+    /// calling thread.
+    ///
+    /// The assignments in the parallel \a uninitialized_copy_n algorithm
+    /// invoked with an execution policy object of type
+    /// \a parallel_policy or
+    /// \a parallel_task_policy are permitted to execute in an
+    /// unordered fashion in unspecified threads, and indeterminately sequenced
+    /// within each thread.
+    ///
+    /// \returns  The \a uninitialized_copy_n algorithm returns a
+    ///           \a hpx::future<FwdIter2> if the execution policy is of type
+    ///           \a sequenced_task_policy or
+    ///           \a parallel_task_policy and
+    ///           returns \a FwdIter2 otherwise.
+    ///           The \a uninitialized_copy_n algorithm returns the output
+    ///           iterator to the element in the destination range, one past
+    ///           the last element copied.
+    ///
+    template <typename InIter, typename Size, typename FwdIter>
+    FwdIter uninitialized_copy_n(InIter first, Size count, FwdIter dest);
+
+    /// Copies the elements in the range [first, first + count), starting from
+    /// first and proceeding to first + count - 1., to another range beginning
+    /// at dest. If an exception is thrown during the copy operation, the
+    /// function has no effects.
+    ///
+    /// \note   Complexity: Performs exactly \a count assignments, if
+    ///         count > 0, no assignments otherwise.
+    ///
+    /// \tparam ExPolicy    The type of the execution policy to use (deduced).
+    ///                     It describes the manner in which the execution
+    ///                     of the algorithm may be parallelized and the manner
+    ///                     in which it executes the assignments.
+    /// \tparam FwdIter1      The type of the source iterators used (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     input iterator.
+    /// \tparam Size        The type of the argument specifying the number of
+    ///                     elements to apply \a f to.
+    /// \tparam FwdIter2     The type of the iterator representing the
+    ///                     destination range (deduced).
+    ///                     This iterator type must meet the requirements of a
+    ///                     forward iterator.
+    ///
+    /// \param policy       The execution policy to use for the scheduling of
+    ///                     the iterations.
+    /// \param first        Refers to the beginning of the sequence of elements
+    ///                     the algorithm will be applied to.
+    /// \param count        Refers to the number of elements starting at
+    ///                     \a first the algorithm will be applied to.
+    /// \param dest         Refers to the beginning of the destination range.
+    ///
+    /// The assignments in the parallel \a uninitialized_copy_n algorithm
+    /// invoked with an execution policy object of type
+    /// \a sequenced_policy execute in sequential order in the
+    /// calling thread.
+    ///
+    /// The assignments in the parallel \a uninitialized_copy_n algorithm
+    /// invoked with an execution policy object of type
+    /// \a parallel_policy or
+    /// \a parallel_task_policy are permitted to execute in an
+    /// unordered fashion in unspecified threads, and indeterminately sequenced
+    /// within each thread.
+    ///
+    /// \returns  The \a uninitialized_copy_n algorithm returns a
+    ///           \a hpx::future<FwdIter2> if the execution policy is of type
+    ///           \a sequenced_task_policy or
+    ///           \a parallel_task_policy and
+    ///           returns \a FwdIter2 otherwise.
+    ///           The \a uninitialized_copy_n algorithm returns the output
+    ///           iterator to the element in the destination range, one past
+    ///           the last element copied.
+    ///
+    template <typename ExPolicy, typename FwdIter1, typename Size,
+        typename FwdIter2>
+    typename parallel::util::detail::algorithm_result<ExPolicy, FwdIter2>::type
+    uninitialized_copy_n(
+        ExPolicy&& policy, FwdIter1 first, Size count, FwdIter2 dest);
+}    // namespace hpx
+
+#else    // DOXYGEN
+
 #include <hpx/config.hpp>
+#include <hpx/concepts/concepts.hpp>
+#include <hpx/functional/tag_fallback_invoke.hpp>
 #include <hpx/iterator_support/traits/is_iterator.hpp>
 
 #include <hpx/execution/algorithms/detail/is_negative.hpp>
 #include <hpx/executors/execution_policy.hpp>
 #include <hpx/parallel/algorithms/detail/dispatch.hpp>
+#include <hpx/parallel/algorithms/detail/distance.hpp>
 #include <hpx/parallel/util/detail/algorithm_result.hpp>
 #include <hpx/parallel/util/loop.hpp>
 #include <hpx/parallel/util/partitioner_with_cleanup.hpp>
@@ -35,12 +237,12 @@ namespace hpx { namespace parallel { inline namespace v1 {
 
         // provide our own implementation of std::uninitialized_copy as some
         // versions of MSVC horribly fail at compiling it for some types T
-        template <typename InIter1, typename InIter2>
+        template <typename InIter1, typename Sent, typename InIter2>
         InIter2 std_uninitialized_copy(
-            InIter1 first, InIter1 last, InIter2 d_first)
+            InIter1 first, Sent last, InIter2 d_first)
         {
-            typedef
-                typename std::iterator_traits<InIter2>::value_type value_type;
+            using value_type =
+                typename std::iterator_traits<InIter2>::value_type;
 
             InIter2 current = d_first;
             try
@@ -138,84 +340,50 @@ namespace hpx { namespace parallel { inline namespace v1 {
             {
             }
 
-            template <typename ExPolicy, typename InIter1>
+            template <typename ExPolicy, typename InIter1, typename Sent>
             static FwdIter2 sequential(
-                ExPolicy, InIter1 first, InIter1 last, FwdIter2 dest)
+                ExPolicy, InIter1 first, Sent last, FwdIter2 dest)
             {
                 return std_uninitialized_copy(first, last, dest);
             }
 
-            template <typename ExPolicy, typename Iter>
+            template <typename ExPolicy, typename Iter, typename Sent>
             static typename util::detail::algorithm_result<ExPolicy,
                 FwdIter2>::type
-            parallel(ExPolicy&& policy, Iter first, Iter last, FwdIter2 dest)
+            parallel(ExPolicy&& policy, Iter first, Sent last, FwdIter2 dest)
             {
                 return parallel_sequential_uninitialized_copy_n(
                     std::forward<ExPolicy>(policy), first,
-                    std::distance(first, last), dest);
+                    detail::distance(first, last), dest);
             }
         };
         /// \endcond
     }    // namespace detail
 
-    /// Copies the elements in the range, defined by [first, last), to an
-    /// uninitialized memory area beginning at \a dest. If an exception is
-    /// thrown during the copy operation, the function has no effects.
-    ///
-    /// \note   Complexity: Performs exactly \a last - \a first assignments.
-    ///
-    /// \tparam ExPolicy    The type of the execution policy to use (deduced).
-    ///                     It describes the manner in which the execution
-    ///                     of the algorithm may be parallelized and the manner
-    ///                     in which it executes the assignments.
-    /// \tparam FwdIter1    The type of the source iterators used (deduced).
-    ///                     This iterator type must meet the requirements of an
-    ///                     forward iterator.
-    /// \tparam FwdIter2    The type of the iterator representing the
-    ///                     destination range (deduced).
-    ///                     This iterator type must meet the requirements of a
-    ///                     forward iterator.
-    ///
-    /// \param policy       The execution policy to use for the scheduling of
-    ///                     the iterations.
-    /// \param first        Refers to the beginning of the sequence of elements
-    ///                     the algorithm will be applied to.
-    /// \param last         Refers to the end of the sequence of elements the
-    ///                     algorithm will be applied to.
-    /// \param dest         Refers to the beginning of the destination range.
-    ///
-    /// The assignments in the parallel \a uninitialized_copy algorithm invoked
-    /// with an execution policy object of type \a sequenced_policy
-    /// execute in sequential order in the calling thread.
-    ///
-    /// The assignments in the parallel \a uninitialized_copy algorithm invoked
-    /// with an execution policy object of type \a parallel_policy or
-    /// \a parallel_task_policy are permitted to execute in an
-    /// unordered fashion in unspecified threads, and indeterminately sequenced
-    /// within each thread.
-    ///
-    /// \returns  The \a uninitialized_copy algorithm returns a
-    ///           \a hpx::future<FwdIter2>, if the execution policy is of type
-    ///           \a sequenced_task_policy or
-    ///           \a parallel_task_policy and
-    ///           returns \a FwdIter2 otherwise.
-    ///           The \a uninitialized_copy algorithm returns the output
-    ///           iterator to the element in the destination range, one past
-    ///           the last element copied.
-    ///
     template <typename ExPolicy, typename FwdIter1, typename FwdIter2>
+    HPX_DEPRECATED_V(1, 7,
+        "hpx::parallel::uninitialized_copy is deprecated, use "
+        "hpx::uninitialized_copy "
+        "instead")
     inline typename std::enable_if<hpx::is_execution_policy<ExPolicy>::value,
         typename util::detail::algorithm_result<ExPolicy, FwdIter2>::type>::type
-    uninitialized_copy(
-        ExPolicy&& policy, FwdIter1 first, FwdIter1 last, FwdIter2 dest)
+        uninitialized_copy(
+            ExPolicy&& policy, FwdIter1 first, FwdIter1 last, FwdIter2 dest)
     {
-        static_assert((hpx::traits::is_forward_iterator<FwdIter1>::value),
+        static_assert(hpx::traits::is_forward_iterator<FwdIter1>::value,
             "Required at least forward iterator.");
-        static_assert((hpx::traits::is_forward_iterator<FwdIter2>::value),
+        static_assert(hpx::traits::is_forward_iterator<FwdIter2>::value,
             "Requires at least forward iterator.");
 
+#if defined(HPX_GCC_VERSION) && HPX_GCC_VERSION >= 100000
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
         return detail::uninitialized_copy<FwdIter2>().call(
             std::forward<ExPolicy>(policy), first, last, dest);
+#if defined(HPX_GCC_VERSION) && HPX_GCC_VERSION >= 100000
+#pragma GCC diagnostic pop
+#endif
     }
 
     /////////////////////////////////////////////////////////////////////////////
@@ -251,67 +419,20 @@ namespace hpx { namespace parallel { inline namespace v1 {
         /// \endcond
     }    // namespace detail
 
-    /// Copies the elements in the range [first, first + count), starting from
-    /// first and proceeding to first + count - 1., to another range beginning
-    /// at dest. If an exception is thrown during the copy operation, the
-    /// function has no effects.
-    ///
-    /// \note   Complexity: Performs exactly \a count assignments, if
-    ///         count > 0, no assignments otherwise.
-    ///
-    /// \tparam ExPolicy    The type of the execution policy to use (deduced).
-    ///                     It describes the manner in which the execution
-    ///                     of the algorithm may be parallelized and the manner
-    ///                     in which it executes the assignments.
-    /// \tparam FwdIter1      The type of the source iterators used (deduced).
-    ///                     This iterator type must meet the requirements of an
-    ///                     input iterator.
-    /// \tparam Size        The type of the argument specifying the number of
-    ///                     elements to apply \a f to.
-    /// \tparam FwdIter2     The type of the iterator representing the
-    ///                     destination range (deduced).
-    ///                     This iterator type must meet the requirements of a
-    ///                     forward iterator.
-    ///
-    /// \param policy       The execution policy to use for the scheduling of
-    ///                     the iterations.
-    /// \param first        Refers to the beginning of the sequence of elements
-    ///                     the algorithm will be applied to.
-    /// \param count        Refers to the number of elements starting at
-    ///                     \a first the algorithm will be applied to.
-    /// \param dest         Refers to the beginning of the destination range.
-    ///
-    /// The assignments in the parallel \a uninitialized_copy_n algorithm
-    /// invoked with an execution policy object of type
-    /// \a sequenced_policy execute in sequential order in the
-    /// calling thread.
-    ///
-    /// The assignments in the parallel \a uninitialized_copy_n algorithm
-    /// invoked with an execution policy object of type
-    /// \a parallel_policy or
-    /// \a parallel_task_policy are permitted to execute in an
-    /// unordered fashion in unspecified threads, and indeterminately sequenced
-    /// within each thread.
-    ///
-    /// \returns  The \a uninitialized_copy_n algorithm returns a
-    ///           \a hpx::future<FwdIter2> if the execution policy is of type
-    ///           \a sequenced_task_policy or
-    ///           \a parallel_task_policy and
-    ///           returns \a FwdIter2 otherwise.
-    ///           The \a uninitialized_copy_n algorithm returns the output
-    ///           iterator to the element in the destination range, one past
-    ///           the last element copied.
-    ///
     template <typename ExPolicy, typename FwdIter1, typename Size,
         typename FwdIter2>
+    HPX_DEPRECATED_V(1, 7,
+        "hpx::parallel::uninitialized_copy_n is deprecated, use "
+        "hpx::uninitialized_copy_n "
+        "instead")
     inline typename std::enable_if<hpx::is_execution_policy<ExPolicy>::value,
         typename util::detail::algorithm_result<ExPolicy, FwdIter2>::type>::type
-    uninitialized_copy_n(
-        ExPolicy&& policy, FwdIter1 first, Size count, FwdIter2 dest)
+        uninitialized_copy_n(
+            ExPolicy&& policy, FwdIter1 first, Size count, FwdIter2 dest)
     {
-        static_assert((hpx::traits::is_forward_iterator<FwdIter1>::value),
+        static_assert(hpx::traits::is_forward_iterator<FwdIter1>::value,
             "Required at least forward iterator.");
-        static_assert((hpx::traits::is_forward_iterator<FwdIter2>::value),
+        static_assert(hpx::traits::is_forward_iterator<FwdIter2>::value,
             "Requires at least forward iterator.");
 
         // if count is representing a negative value, we do nothing
@@ -320,8 +441,129 @@ namespace hpx { namespace parallel { inline namespace v1 {
             return util::detail::algorithm_result<ExPolicy, FwdIter2>::get(
                 std::move(dest));
         }
-
+#if defined(HPX_GCC_VERSION) && HPX_GCC_VERSION >= 100000
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
         return detail::uninitialized_copy_n<FwdIter2>().call(
             std::forward<ExPolicy>(policy), first, std::size_t(count), dest);
+#if defined(HPX_GCC_VERSION) && HPX_GCC_VERSION >= 100000
+#pragma GCC diagnostic pop
+#endif
     }
 }}}    // namespace hpx::parallel::v1
+
+namespace hpx {
+    ///////////////////////////////////////////////////////////////////////////
+    // CPO for hpx::uninitialized_copy
+    HPX_INLINE_CONSTEXPR_VARIABLE struct uninitialized_copy_t final
+      : hpx::functional::tag_fallback<uninitialized_copy_t>
+    {
+        // clang-format off
+        template <typename InIter, typename FwdIter,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::traits::is_iterator<InIter>::value &&
+                hpx::traits::is_forward_iterator<FwdIter>::value
+            )>
+        // clang-format on
+        friend FwdIter tag_fallback_invoke(
+            hpx::uninitialized_copy_t, InIter first, InIter last, FwdIter dest)
+        {
+            static_assert(hpx::traits::is_input_iterator<InIter>::value,
+                "Required at least input iterator.");
+            static_assert(hpx::traits::is_forward_iterator<FwdIter>::value,
+                "Requires at least forward iterator.");
+
+            return hpx::parallel::v1::detail::uninitialized_copy<FwdIter>()
+                .call(hpx::execution::seq, first, last, dest);
+        }
+
+        // clang-format off
+        template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::is_execution_policy<ExPolicy>::value &&
+                hpx::traits::is_forward_iterator<FwdIter1>::value &&
+                hpx::traits::is_forward_iterator<FwdIter2>::value
+            )>
+        // clang-format on
+        friend typename parallel::util::detail::algorithm_result<ExPolicy,
+            FwdIter2>::type
+        tag_fallback_invoke(hpx::uninitialized_copy_t, ExPolicy&& policy,
+            FwdIter1 first, FwdIter1 last, FwdIter2 dest)
+        {
+            static_assert(hpx::traits::is_forward_iterator<FwdIter1>::value,
+                "Requires at least forward iterator.");
+            static_assert(hpx::traits::is_forward_iterator<FwdIter2>::value,
+                "Requires at least forward iterator.");
+
+            return hpx::parallel::v1::detail::uninitialized_copy<FwdIter2>()
+                .call(std::forward<ExPolicy>(policy), first, last, dest);
+        }
+
+    } uninitialized_copy{};
+
+    ///////////////////////////////////////////////////////////////////////////
+    // CPO for hpx::uninitialized_copy_n
+    HPX_INLINE_CONSTEXPR_VARIABLE struct uninitialized_copy_n_t final
+      : hpx::functional::tag_fallback<uninitialized_copy_n_t>
+    {
+        // clang-format off
+        template <typename InIter, typename Size,
+            typename FwdIter,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::traits::is_iterator<InIter>::value &&
+                hpx::traits::is_forward_iterator<FwdIter>::value
+            )>
+        // clang-format on
+        friend FwdIter tag_fallback_invoke(
+            hpx::uninitialized_copy_n_t, InIter first, Size count, FwdIter dest)
+        {
+            static_assert(hpx::traits::is_input_iterator<InIter>::value,
+                "Required at least input iterator.");
+            static_assert(hpx::traits::is_forward_iterator<FwdIter>::value,
+                "Requires at least forward iterator.");
+
+            // if count is representing a negative value, we do nothing
+            if (hpx::parallel::v1::detail::is_negative(count))
+            {
+                return dest;
+            }
+
+            return hpx::parallel::v1::detail::uninitialized_copy_n<FwdIter2>()
+                .call(hpx::execution::seq, first, std::size_t(count), dest);
+        }
+
+        // clang-format off
+        template <typename ExPolicy, typename FwdIter1, typename Size, typename FwdIter2,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::is_execution_policy<ExPolicy>::value &&
+                hpx::traits::is_forward_iterator<FwdIter1>::value &&
+                hpx::traits::is_forward_iterator<FwdIter2>::value
+            )>
+        // clang-format on
+        friend typename parallel::util::detail::algorithm_result<ExPolicy,
+            FwdIter2>::type
+        tag_fallback_invoke(hpx::uninitialized_copy_n_t, ExPolicy&& policy,
+            FwdIter1 first, Size count, FwdIter2 dest)
+        {
+            static_assert(hpx::traits::is_forward_iterator<FwdIter1>::value,
+                "Requires at least forward iterator.");
+            static_assert(hpx::traits::is_forward_iterator<FwdIter2>::value,
+                "Requires at least forward iterator.");
+
+            // if count is representing a negative value, we do nothing
+            if (hpx::parallel::v1::detail::is_negative(count))
+            {
+                return parallel::util::detail::algorithm_result<ExPolicy,
+                    FwdIter2>::get(std::move(dest));
+            }
+
+            return hpx::parallel::v1::detail::uninitialized_copy_n<FwdIter2>()
+                .call(std::forward<ExPolicy>(policy), first, std::size_t(count),
+                    dest);
+        }
+
+    } uninitialized_copy_n{};
+}    // namespace hpx
+
+#endif    // DOXYGEN

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/uninitialized_default_construct.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/uninitialized_default_construct.hpp
@@ -11,38 +11,38 @@
 #if defined(DOXYGEN)
 namespace hpx {
 
-    /// Copies the given \a value to an uninitialized memory area, defined by
-    /// the range [first, last). If an exception is thrown during the
+    /// Constructs objects of type typename iterator_traits<ForwardIt>
+    /// ::value_type in the uninitialized storage designated by the range
+    /// by default-initialization. If an exception is thrown during the
     /// initialization, the function has no effects.
     ///
-    /// \note   Complexity: Linear in the distance between \a first and \a last
+    /// \note   Complexity: Performs exactly \a last - \a first assignments.
     ///
     /// \tparam FwdIter     The type of the source iterators used (deduced).
     ///                     This iterator type must meet the requirements of an
     ///                     forward iterator.
-    /// \tparam T           The type of the value to be assigned (deduced).
     ///
     /// \param first        Refers to the beginning of the sequence of elements
     ///                     the algorithm will be applied to.
     /// \param last         Refers to the end of the sequence of elements the
     ///                     algorithm will be applied to.
-    /// \param value        The value to be assigned.
     ///
-    /// The assignments in the parallel \a uninitialized_default_construct algorithm invoked
-    /// without an execution policy object will execute in sequential order in
-    /// the calling thread.
+    /// The assignments in the parallel \a uninitialized_default_construct
+    /// algorithm invoked without an execution policy object will execute in
+    /// sequential order in the calling thread.
     ///
-    /// \returns  The \a uninitialized_default_construct algorithm  returns nothing
+    /// \returns  The \a uninitialized_default_construct algorithm
+    ///           returns nothing
     ///
-    template <typename FwdIter, typename T>
-    void uninitialized_default_construct(
-        FwdIter first, FwdIter last, T const& value);
+    template <typename FwdIter>
+    void uninitialized_default_construct(FwdIter first, FwdIter last);
 
-    /// Copies the given \a value to an uninitialized memory area, defined by
-    /// the range [first, last). If an exception is thrown during the
+    /// Constructs objects of type typename iterator_traits<ForwardIt>
+    /// ::value_type in the uninitialized storage designated by the range
+    /// by default-initialization. If an exception is thrown during the
     /// initialization, the function has no effects.
     ///
-    /// \note   Complexity: Linear in the distance between \a first and \a last
+    /// \note   Complexity: Performs exactly \a last - \a first assignments.
     ///
     /// \tparam ExPolicy    The type of the execution policy to use (deduced).
     ///                     It describes the manner in which the execution
@@ -51,7 +51,6 @@ namespace hpx {
     /// \tparam FwdIter     The type of the source iterators used (deduced).
     ///                     This iterator type must meet the requirements of an
     ///                     forward iterator.
-    /// \tparam T           The type of the value to be assigned (deduced).
     ///
     /// \param policy       The execution policy to use for the scheduling of
     ///                     the iterations.
@@ -59,18 +58,16 @@ namespace hpx {
     ///                     the algorithm will be applied to.
     /// \param last         Refers to the end of the sequence of elements the
     ///                     algorithm will be applied to.
-    /// \param value        The value to be assigned.
     ///
-    /// The initializations in the parallel \a uninitialized_default_construct algorithm
-    /// invoked with an execution policy object of type
-    /// \a sequenced_policy execute in sequential order in the
-    /// calling thread.
+    /// The assignments in the parallel \a uninitialized_default_construct
+    /// algorithm invoked with an execution policy object of type \a
+    /// sequenced_policy execute in sequential order in the calling thread.
     ///
-    /// The initializations in the parallel \a uninitialized_default_construct algorithm
-    /// invoked with an execution policy object of type
-    /// \a parallel_policy or \a parallel_task_policy are
-    /// permitted to execute in an unordered fashion in unspecified threads,
-    /// and indeterminately sequenced within each thread.
+    /// The assignments in the parallel \a uninitialized_default_construct
+    /// algorithm invoked with an execution policy object of type \a
+    /// parallel_policy or \a parallel_task_policy are permitted to execute
+    /// in an unordered fashion in unspecified threads, and indeterminately
+    /// sequenced within each thread.
     ///
     /// \returns  The \a uninitialized_default_construct algorithm returns a
     ///           \a hpx::future<void>, if the execution policy is of type
@@ -78,48 +75,47 @@ namespace hpx {
     ///           \a parallel_task_policy and returns nothing
     ///           otherwise.
     ///
-    template <typename ExPolicy, typename FwdIter, typename T>
+    template <typename ExPolicy, typename FwdIter>
     typename parallel::util::detail::algorithm_result<ExPolicy>::type
     uninitialized_default_construct(
-        ExPolicy&& policy, FwdIter first, FwdIter last, T const& value);
+        ExPolicy&& policy, FwdIter first, FwdIter last);
 
-    /// Copies the given \a value value to the first count elements in an
-    /// uninitialized memory area beginning at first. If an exception is thrown
-    /// during the initialization, the function has no effects.
+    /// Constructs objects of type typename iterator_traits<ForwardIt>
+    /// ::value_type in the uninitialized storage designated by the range
+    /// [first, first + count) by default-initialization. If an exception
+    /// is thrown during the initialization, the function has no effects.
     ///
     /// \note   Complexity: Performs exactly \a count assignments, if
     ///         count > 0, no assignments otherwise.
     ///
     /// \tparam FwdIter     The type of the source iterators used (deduced).
-    ///                     This iterator type must meet the requirements of a
+    ///                     This iterator type must meet the requirements of an
     ///                     forward iterator.
     /// \tparam Size        The type of the argument specifying the number of
     ///                     elements to apply \a f to.
-    /// \tparam T           The type of the value to be assigned (deduced).
     ///
     /// \param first        Refers to the beginning of the sequence of elements
     ///                     the algorithm will be applied to.
     /// \param count        Refers to the number of elements starting at
     ///                     \a first the algorithm will be applied to.
-    /// \param value        The value to be assigned.
     ///
-    /// The assignments in the parallel \a uninitialized_default_construct_n algorithm
-    /// invoked without an execution policy object execute in sequential order
-    /// in the calling thread.
+    /// The assignments in the parallel \a uninitialized_default_construct_n
+    /// algorithm invoked without an execution policy object execute in
+    /// sequential order in the calling thread.
     ///
     /// \returns  The \a uninitialized_default_construct_n algorithm returns a
     ///           returns \a FwdIter.
-    ///           The \a uninitialized_default_construct_n algorithm returns the output
-    ///           iterator to the element in the range, one past
-    ///           the last element copied.
+    ///           The \a uninitialized_default_construct_n algorithm returns
+    ///           the iterator to the element in the source range, one past
+    ///           the last element constructed.
     ///
-    template <typename FwdIter, typename Size, typename T>
-    FwdIter uninitialized_default_construct_n(
-        FwdIter first, Size count, T const& value);
+    template <typename FwdIter, typename Size>
+    FwdIter uninitialized_default_construct_n(FwdIter first, Size count);
 
-    /// Copies the given \a value value to the first count elements in an
-    /// uninitialized memory area beginning at first. If an exception is thrown
-    /// during the initialization, the function has no effects.
+    /// Constructs objects of type typename iterator_traits<ForwardIt>
+    /// ::value_type in the uninitialized storage designated by the range
+    /// [first, first + count) by default-initialization. If an exception
+    /// is thrown during the initialization, the function has no effects.
     ///
     /// \note   Complexity: Performs exactly \a count assignments, if
     ///         count > 0, no assignments otherwise.
@@ -129,11 +125,10 @@ namespace hpx {
     ///                     of the algorithm may be parallelized and the manner
     ///                     in which it executes the assignments.
     /// \tparam FwdIter     The type of the source iterators used (deduced).
-    ///                     This iterator type must meet the requirements of a
+    ///                     This iterator type must meet the requirements of an
     ///                     forward iterator.
     /// \tparam Size        The type of the argument specifying the number of
     ///                     elements to apply \a f to.
-    /// \tparam T           The type of the value to be assigned (deduced).
     ///
     /// \param policy       The execution policy to use for the scheduling of
     ///                     the iterations.
@@ -141,32 +136,32 @@ namespace hpx {
     ///                     the algorithm will be applied to.
     /// \param count        Refers to the number of elements starting at
     ///                     \a first the algorithm will be applied to.
-    /// \param value        The value to be assigned.
     ///
-    /// The initializations in the parallel \a uninitialized_default_construct_n algorithm
-    /// invoked with an execution policy object of type
+    /// The assignments in the parallel \a uninitialized_default_construct_n
+    /// algorithm invoked with an execution policy object of type
     /// \a sequenced_policy execute in sequential order in the
     /// calling thread.
     ///
-    /// The initializations in the parallel \a uninitialized_default_construct_n algorithm
-    /// invoked with an execution policy object of type
-    /// \a parallel_policy or \a parallel_task_policy are
-    /// permitted to execute in an unordered fashion in unspecified threads,
-    /// and indeterminately sequenced within each thread.
+    /// The assignments in the parallel \a uninitialized_default_construct_n
+    /// algorithm invoked with an execution policy object of type
+    /// \a parallel_policy or
+    /// \a parallel_task_policy are permitted to execute in an
+    /// unordered fashion in unspecified threads, and indeterminately sequenced
+    /// within each thread.
     ///
     /// \returns  The \a uninitialized_default_construct_n algorithm returns a
-    ///           \a hpx::future<FwdIter>, if the execution policy is of type
+    ///           \a hpx::future<FwdIter> if the execution policy is of type
     ///           \a sequenced_task_policy or
-    ///           \a parallel_task_policy and returns FwdIter
-    ///           otherwise.
-    ///           The \a uninitialized_default_construct_n algorithm returns the output
-    ///           iterator to the element in the range, one past
-    ///           the last element copied.
+    ///           \a parallel_task_policy and
+    ///           returns \a FwdIter otherwise.
+    ///           The \a uninitialized_default_construct_n algorithm returns
+    ///           the iterator to the element in the source range, one past
+    ///           the last element constructed.
     ///
-    template <typename ExPolicy, typename FwdIter, typename Size, typename T>
+    template <typename ExPolicy, typename FwdIter, typename Size>
     typename parallel::util::detail::algorithm_result<ExPolicy, FwdIter>::type
     uninitialized_default_construct_n(
-        ExPolicy&& policy, FwdIter first, Size count, T const& value);
+        ExPolicy&& policy, FwdIter first, Size count);
 }    // namespace hpx
 
 #else    // DOXYGEN
@@ -316,43 +311,6 @@ namespace hpx { namespace parallel { inline namespace v1 {
         /// \endcond
     }    // namespace detail
 
-    /// Constructs objects of type typename iterator_traits<ForwardIt>::value_type
-    /// in the uninitialized storage designated by the range [first, last) by
-    /// default-initialization. If an exception is thrown during the
-    /// initialization, the function has no effects.
-    ///
-    /// \note   Complexity: Performs exactly \a last - \a first assignments.
-    ///
-    /// \tparam ExPolicy    The type of the execution policy to use (deduced).
-    ///                     It describes the manner in which the execution
-    ///                     of the algorithm may be parallelized and the manner
-    ///                     in which it executes the assignments.
-    /// \tparam FwdIter     The type of the source iterators used (deduced).
-    ///                     This iterator type must meet the requirements of an
-    ///                     forward iterator.
-    ///
-    /// \param policy       The execution policy to use for the scheduling of
-    ///                     the iterations.
-    /// \param first        Refers to the beginning of the sequence of elements
-    ///                     the algorithm will be applied to.
-    /// \param last         Refers to the end of the sequence of elements the
-    ///                     algorithm will be applied to.
-    ///
-    /// The assignments in the parallel \a uninitialized_default_construct
-    /// algorithm invoked with an execution policy object of type \a sequenced_policy
-    /// execute in sequential order in the calling thread.
-    ///
-    /// The assignments in the parallel \a uninitialized_default_construct
-    /// algorithm invoked with an execution policy object of type \a parallel_policy
-    /// or \a parallel_task_policy are permitted to execute in an
-    /// unordered fashion in unspecified threads, and indeterminately sequenced
-    /// within each thread.
-    ///
-    /// \returns  The \a uninitialized_default_construct algorithm returns a
-    ///           \a hpx::future<void>, if the execution policy is of type
-    ///           \a sequenced_task_policy or
-    ///           \a parallel_task_policy and returns \a void otherwise.
-    ///
     template <typename ExPolicy, typename FwdIter,
         HPX_CONCEPT_REQUIRES_(hpx::is_execution_policy<ExPolicy>::value&&
                 hpx::traits::is_iterator<FwdIter>::value)>
@@ -447,52 +405,6 @@ namespace hpx { namespace parallel { inline namespace v1 {
         /// \endcond
     }    // namespace detail
 
-    /// Constructs objects of type typename iterator_traits<ForwardIt>::value_type
-    /// in the uninitialized storage designated by the range [first, first + count) by
-    /// default-initialization. If an exception is thrown during the
-    /// initialization, the function has no effects.
-    ///
-    /// \note   Complexity: Performs exactly \a count assignments, if
-    ///         count > 0, no assignments otherwise.
-    ///
-    /// \tparam ExPolicy    The type of the execution policy to use (deduced).
-    ///                     It describes the manner in which the execution
-    ///                     of the algorithm may be parallelized and the manner
-    ///                     in which it executes the assignments.
-    /// \tparam FwdIter     The type of the source iterators used (deduced).
-    ///                     This iterator type must meet the requirements of an
-    ///                     forward iterator.
-    /// \tparam Size        The type of the argument specifying the number of
-    ///                     elements to apply \a f to.
-    ///
-    /// \param policy       The execution policy to use for the scheduling of
-    ///                     the iterations.
-    /// \param first        Refers to the beginning of the sequence of elements
-    ///                     the algorithm will be applied to.
-    /// \param count        Refers to the number of elements starting at
-    ///                     \a first the algorithm will be applied to.
-    ///
-    /// The assignments in the parallel \a uninitialized_default_construct_n
-    /// algorithm invoked with an execution policy object of type
-    /// \a sequenced_policy execute in sequential order in the
-    /// calling thread.
-    ///
-    /// The assignments in the parallel \a uninitialized_default_construct_n
-    /// algorithm invoked with an execution policy object of type
-    /// \a parallel_policy or
-    /// \a parallel_task_policy are permitted to execute in an
-    /// unordered fashion in unspecified threads, and indeterminately sequenced
-    /// within each thread.
-    ///
-    /// \returns  The \a uninitialized_default_construct_n algorithm returns a
-    ///           \a hpx::future<FwdIter> if the execution policy is of type
-    ///           \a sequenced_task_policy or
-    ///           \a parallel_task_policy and
-    ///           returns \a FwdIter otherwise.
-    ///           The \a uninitialized_default_construct_n algorithm returns the
-    ///           iterator to the element in the source range, one past
-    ///           the last element constructed.
-    ///
     template <typename ExPolicy, typename FwdIter, typename Size,
         HPX_CONCEPT_REQUIRES_(hpx::is_execution_policy<ExPolicy>::value&&
                 hpx::traits::is_iterator<FwdIter>::value)>

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/uninitialized_default_construct.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/uninitialized_default_construct.hpp
@@ -8,6 +8,169 @@
 
 #pragma once
 
+#if defined(DOXYGEN)
+namespace hpx {
+
+    /// Copies the given \a value to an uninitialized memory area, defined by
+    /// the range [first, last). If an exception is thrown during the
+    /// initialization, the function has no effects.
+    ///
+    /// \note   Complexity: Linear in the distance between \a first and \a last
+    ///
+    /// \tparam FwdIter     The type of the source iterators used (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     forward iterator.
+    /// \tparam T           The type of the value to be assigned (deduced).
+    ///
+    /// \param first        Refers to the beginning of the sequence of elements
+    ///                     the algorithm will be applied to.
+    /// \param last         Refers to the end of the sequence of elements the
+    ///                     algorithm will be applied to.
+    /// \param value        The value to be assigned.
+    ///
+    /// The assignments in the parallel \a uninitialized_default_construct algorithm invoked
+    /// without an execution policy object will execute in sequential order in
+    /// the calling thread.
+    ///
+    /// \returns  The \a uninitialized_default_construct algorithm  returns nothing
+    ///
+    template <typename FwdIter, typename T>
+    void uninitialized_default_construct(
+        FwdIter first, FwdIter last, T const& value);
+
+    /// Copies the given \a value to an uninitialized memory area, defined by
+    /// the range [first, last). If an exception is thrown during the
+    /// initialization, the function has no effects.
+    ///
+    /// \note   Complexity: Linear in the distance between \a first and \a last
+    ///
+    /// \tparam ExPolicy    The type of the execution policy to use (deduced).
+    ///                     It describes the manner in which the execution
+    ///                     of the algorithm may be parallelized and the manner
+    ///                     in which it executes the assignments.
+    /// \tparam FwdIter     The type of the source iterators used (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     forward iterator.
+    /// \tparam T           The type of the value to be assigned (deduced).
+    ///
+    /// \param policy       The execution policy to use for the scheduling of
+    ///                     the iterations.
+    /// \param first        Refers to the beginning of the sequence of elements
+    ///                     the algorithm will be applied to.
+    /// \param last         Refers to the end of the sequence of elements the
+    ///                     algorithm will be applied to.
+    /// \param value        The value to be assigned.
+    ///
+    /// The initializations in the parallel \a uninitialized_default_construct algorithm
+    /// invoked with an execution policy object of type
+    /// \a sequenced_policy execute in sequential order in the
+    /// calling thread.
+    ///
+    /// The initializations in the parallel \a uninitialized_default_construct algorithm
+    /// invoked with an execution policy object of type
+    /// \a parallel_policy or \a parallel_task_policy are
+    /// permitted to execute in an unordered fashion in unspecified threads,
+    /// and indeterminately sequenced within each thread.
+    ///
+    /// \returns  The \a uninitialized_default_construct algorithm returns a
+    ///           \a hpx::future<void>, if the execution policy is of type
+    ///           \a sequenced_task_policy or
+    ///           \a parallel_task_policy and returns nothing
+    ///           otherwise.
+    ///
+    template <typename ExPolicy, typename FwdIter, typename T>
+    typename parallel::util::detail::algorithm_result<ExPolicy>::type
+    uninitialized_default_construct(
+        ExPolicy&& policy, FwdIter first, FwdIter last, T const& value);
+
+    /// Copies the given \a value value to the first count elements in an
+    /// uninitialized memory area beginning at first. If an exception is thrown
+    /// during the initialization, the function has no effects.
+    ///
+    /// \note   Complexity: Performs exactly \a count assignments, if
+    ///         count > 0, no assignments otherwise.
+    ///
+    /// \tparam FwdIter     The type of the source iterators used (deduced).
+    ///                     This iterator type must meet the requirements of a
+    ///                     forward iterator.
+    /// \tparam Size        The type of the argument specifying the number of
+    ///                     elements to apply \a f to.
+    /// \tparam T           The type of the value to be assigned (deduced).
+    ///
+    /// \param first        Refers to the beginning of the sequence of elements
+    ///                     the algorithm will be applied to.
+    /// \param count        Refers to the number of elements starting at
+    ///                     \a first the algorithm will be applied to.
+    /// \param value        The value to be assigned.
+    ///
+    /// The assignments in the parallel \a uninitialized_default_construct_n algorithm
+    /// invoked without an execution policy object execute in sequential order
+    /// in the calling thread.
+    ///
+    /// \returns  The \a uninitialized_default_construct_n algorithm returns a
+    ///           returns \a FwdIter.
+    ///           The \a uninitialized_default_construct_n algorithm returns the output
+    ///           iterator to the element in the range, one past
+    ///           the last element copied.
+    ///
+    template <typename FwdIter, typename Size, typename T>
+    FwdIter uninitialized_default_construct_n(
+        FwdIter first, Size count, T const& value);
+
+    /// Copies the given \a value value to the first count elements in an
+    /// uninitialized memory area beginning at first. If an exception is thrown
+    /// during the initialization, the function has no effects.
+    ///
+    /// \note   Complexity: Performs exactly \a count assignments, if
+    ///         count > 0, no assignments otherwise.
+    ///
+    /// \tparam ExPolicy    The type of the execution policy to use (deduced).
+    ///                     It describes the manner in which the execution
+    ///                     of the algorithm may be parallelized and the manner
+    ///                     in which it executes the assignments.
+    /// \tparam FwdIter     The type of the source iterators used (deduced).
+    ///                     This iterator type must meet the requirements of a
+    ///                     forward iterator.
+    /// \tparam Size        The type of the argument specifying the number of
+    ///                     elements to apply \a f to.
+    /// \tparam T           The type of the value to be assigned (deduced).
+    ///
+    /// \param policy       The execution policy to use for the scheduling of
+    ///                     the iterations.
+    /// \param first        Refers to the beginning of the sequence of elements
+    ///                     the algorithm will be applied to.
+    /// \param count        Refers to the number of elements starting at
+    ///                     \a first the algorithm will be applied to.
+    /// \param value        The value to be assigned.
+    ///
+    /// The initializations in the parallel \a uninitialized_default_construct_n algorithm
+    /// invoked with an execution policy object of type
+    /// \a sequenced_policy execute in sequential order in the
+    /// calling thread.
+    ///
+    /// The initializations in the parallel \a uninitialized_default_construct_n algorithm
+    /// invoked with an execution policy object of type
+    /// \a parallel_policy or \a parallel_task_policy are
+    /// permitted to execute in an unordered fashion in unspecified threads,
+    /// and indeterminately sequenced within each thread.
+    ///
+    /// \returns  The \a uninitialized_default_construct_n algorithm returns a
+    ///           \a hpx::future<FwdIter>, if the execution policy is of type
+    ///           \a sequenced_task_policy or
+    ///           \a parallel_task_policy and returns FwdIter
+    ///           otherwise.
+    ///           The \a uninitialized_default_construct_n algorithm returns the output
+    ///           iterator to the element in the range, one past
+    ///           the last element copied.
+    ///
+    template <typename ExPolicy, typename FwdIter, typename Size, typename T>
+    typename parallel::util::detail::algorithm_result<ExPolicy, FwdIter>::type
+    uninitialized_default_construct_n(
+        ExPolicy&& policy, FwdIter first, Size count, T const& value);
+}    // namespace hpx
+
+#else    // DOXYGEN
+
 #include <hpx/config.hpp>
 #include <hpx/iterator_support/traits/is_iterator.hpp>
 #include <hpx/type_support/void_guard.hpp>
@@ -15,6 +178,7 @@
 #include <hpx/execution/algorithms/detail/is_negative.hpp>
 #include <hpx/executors/execution_policy.hpp>
 #include <hpx/parallel/algorithms/detail/dispatch.hpp>
+#include <hpx/parallel/algorithms/detail/distance.hpp>
 #include <hpx/parallel/util/detail/algorithm_result.hpp>
 #include <hpx/parallel/util/loop.hpp>
 #include <hpx/parallel/util/partitioner_with_cleanup.hpp>
@@ -36,19 +200,19 @@ namespace hpx { namespace parallel { inline namespace v1 {
 
         // provide our own implementation of std::uninitialized_default_construct as some
         // versions of MSVC horribly fail at compiling it for some types T
-        template <typename InIter>
-        void std_uninitialized_default_construct(InIter first, InIter last)
+        template <typename Iter, typename Sent>
+        Iter std_uninitialized_default_construct(Iter first, Sent last)
         {
-            typedef
-                typename std::iterator_traits<InIter>::value_type value_type;
+            using value_type = typename std::iterator_traits<Iter>::value_type;
 
-            InIter s_first = first;
+            Iter s_first = first;
             try
             {
                 for (/* */; first != last; ++first)
                 {
                     ::new (std::addressof(*first)) value_type;
                 }
+                return first;
             }
             catch (...)
             {
@@ -66,8 +230,8 @@ namespace hpx { namespace parallel { inline namespace v1 {
             std::size_t count,
             util::cancellation_token<util::detail::no_data>& tok)
         {
-            typedef
-                typename std::iterator_traits<InIter>::value_type value_type;
+            using value_type =
+                typename std::iterator_traits<InIter>::value_type;
 
             return util::loop_with_cleanup_n_with_token(
                 first, count, tok,
@@ -121,11 +285,11 @@ namespace hpx { namespace parallel { inline namespace v1 {
                         }
                     });
         }
-
         ///////////////////////////////////////////////////////////////////////
         template <typename FwdIter>
         struct uninitialized_default_construct
-          : public detail::algorithm<uninitialized_default_construct<FwdIter>>
+          : public detail::algorithm<uninitialized_default_construct<FwdIter>,
+                FwdIter>
         {
             uninitialized_default_construct()
               : uninitialized_default_construct::algorithm(
@@ -133,22 +297,20 @@ namespace hpx { namespace parallel { inline namespace v1 {
             {
             }
 
-            template <typename ExPolicy, typename InIter>
-            static hpx::util::unused_type sequential(
-                ExPolicy, InIter first, InIter last)
+            template <typename ExPolicy, typename Sent>
+            static FwdIter sequential(ExPolicy, FwdIter first, Sent last)
             {
-                std_uninitialized_default_construct(first, last);
-                return hpx::util::unused;
+                return std_uninitialized_default_construct(first, last);
             }
 
-            template <typename ExPolicy>
-            static typename util::detail::algorithm_result<ExPolicy>::type
-            parallel(ExPolicy&& policy, FwdIter first, FwdIter last)
+            template <typename ExPolicy, typename Sent>
+            static
+                typename util::detail::algorithm_result<ExPolicy, FwdIter>::type
+                parallel(ExPolicy&& policy, FwdIter first, Sent last)
             {
-                return util::detail::algorithm_result<ExPolicy>::get(
-                    parallel_sequential_uninitialized_default_construct_n(
-                        std::forward<ExPolicy>(policy), first,
-                        std::distance(first, last)));
+                return parallel_sequential_uninitialized_default_construct_n(
+                    std::forward<ExPolicy>(policy), first,
+                    detail::distance(first, last));
             }
         };
         /// \endcond
@@ -194,15 +356,32 @@ namespace hpx { namespace parallel { inline namespace v1 {
     template <typename ExPolicy, typename FwdIter,
         HPX_CONCEPT_REQUIRES_(hpx::is_execution_policy<ExPolicy>::value&&
                 hpx::traits::is_iterator<FwdIter>::value)>
+    HPX_DEPRECATED_V(1, 7,
+        "hpx::parallel::uninitialized_default_construct is deprecated, use "
+        "hpx::uninitialized_default_construct "
+        "instead")
     typename util::detail::algorithm_result<ExPolicy>::type
-    uninitialized_default_construct(
-        ExPolicy&& policy, FwdIter first, FwdIter last)
+        uninitialized_default_construct(
+            ExPolicy&& policy, FwdIter first, FwdIter last)
     {
         static_assert((hpx::traits::is_forward_iterator<FwdIter>::value),
             "Required at least forward iterator.");
 
-        return detail::uninitialized_default_construct<FwdIter>().call(
-            std::forward<ExPolicy>(policy), first, last);
+#if defined(HPX_GCC_VERSION) && HPX_GCC_VERSION >= 100000
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
+        using result_type =
+            typename hpx::parallel::util::detail::algorithm_result<
+                ExPolicy>::type;
+
+        return hpx::util::void_guard<result_type>(),
+               hpx::parallel::v1::detail::uninitialized_default_construct<
+                   FwdIter>()
+                   .call(std::forward<ExPolicy>(policy), first, last);
+#if defined(HPX_GCC_VERSION) && HPX_GCC_VERSION >= 100000
+#pragma GCC diagnostic pop
+#endif
     }
 
     ///////////////////////////////////////////////////////////////////////////
@@ -249,8 +428,9 @@ namespace hpx { namespace parallel { inline namespace v1 {
             {
             }
 
-            template <typename ExPolicy, typename InIter>
-            static InIter sequential(ExPolicy, InIter first, std::size_t count)
+            template <typename ExPolicy>
+            static FwdIter sequential(
+                ExPolicy, FwdIter first, std::size_t count)
             {
                 return std_uninitialized_default_construct_n(first, count);
             }
@@ -316,11 +496,15 @@ namespace hpx { namespace parallel { inline namespace v1 {
     template <typename ExPolicy, typename FwdIter, typename Size,
         HPX_CONCEPT_REQUIRES_(hpx::is_execution_policy<ExPolicy>::value&&
                 hpx::traits::is_iterator<FwdIter>::value)>
+    HPX_DEPRECATED_V(1, 7,
+        "hpx::parallel::uninitialized_default_construct_n is deprecated, use "
+        "hpx::uninitialized_default_construct_n "
+        "instead")
     typename util::detail::algorithm_result<ExPolicy, FwdIter>::type
-    uninitialized_default_construct_n(
-        ExPolicy&& policy, FwdIter first, Size count)
+        uninitialized_default_construct_n(
+            ExPolicy&& policy, FwdIter first, Size count)
     {
-        static_assert((hpx::traits::is_forward_iterator<FwdIter>::value),
+        static_assert(hpx::traits::is_forward_iterator<FwdIter>::value,
             "Requires at least forward iterator.");
 
         // if count is representing a negative value, we do nothing
@@ -330,7 +514,125 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 std::move(first));
         }
 
+#if defined(HPX_GCC_VERSION) && HPX_GCC_VERSION >= 100000
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
         return detail::uninitialized_default_construct_n<FwdIter>().call(
             std::forward<ExPolicy>(policy), first, std::size_t(count));
     }
+#if defined(HPX_GCC_VERSION) && HPX_GCC_VERSION >= 100000
+#pragma GCC diagnostic pop
+#endif
 }}}    // namespace hpx::parallel::v1
+
+namespace hpx {
+    ///////////////////////////////////////////////////////////////////////////
+    // DPO for hpx::uninitialized_default_construct
+    HPX_INLINE_CONSTEXPR_VARIABLE struct uninitialized_default_construct_t final
+      : hpx::functional::tag_fallback<uninitialized_default_construct_t>
+    {
+        // clang-format off
+        template <typename FwdIter,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::traits::is_forward_iterator<FwdIter>::value
+            )>
+        // clang-format on
+        friend void tag_fallback_dispatch(
+            hpx::uninitialized_default_construct_t, FwdIter first, FwdIter last)
+        {
+            static_assert(hpx::traits::is_forward_iterator<FwdIter>::value,
+                "Requires at least forward iterator.");
+
+            hpx::parallel::v1::detail::uninitialized_default_construct<
+                FwdIter>()
+                .call(hpx::execution::seq, first, last);
+        }
+
+        // clang-format off
+        template <typename ExPolicy, typename FwdIter,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::is_execution_policy<ExPolicy>::value &&
+                hpx::traits::is_forward_iterator<FwdIter>::value
+            )>
+        // clang-format on
+        friend typename parallel::util::detail::algorithm_result<ExPolicy>::type
+        tag_fallback_dispatch(hpx::uninitialized_default_construct_t,
+            ExPolicy&& policy, FwdIter first, FwdIter last)
+        {
+            static_assert(hpx::traits::is_forward_iterator<FwdIter>::value,
+                "Requires at least forward iterator.");
+
+            using result_type =
+                typename hpx::parallel::util::detail::algorithm_result<
+                    ExPolicy>::type;
+
+            return hpx::util::void_guard<result_type>(),
+                   hpx::parallel::v1::detail::uninitialized_default_construct<
+                       FwdIter>()
+                       .call(std::forward<ExPolicy>(policy), first, last);
+        }
+
+    } uninitialized_default_construct{};
+
+    ///////////////////////////////////////////////////////////////////////////
+    // DPO for hpx::uninitialized_default_construct_n
+    HPX_INLINE_CONSTEXPR_VARIABLE struct uninitialized_default_construct_n_t
+        final
+      : hpx::functional::tag_fallback<uninitialized_default_construct_n_t>
+    {
+        // clang-format off
+        template <typename FwdIter, typename Size,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::traits::is_forward_iterator<FwdIter>::value
+            )>
+        // clang-format on
+        friend FwdIter tag_fallback_dispatch(
+            hpx::uninitialized_default_construct_n_t, FwdIter first, Size count)
+        {
+            static_assert(hpx::traits::is_forward_iterator<FwdIter>::value,
+                "Requires at least forward iterator.");
+
+            // if count is representing a negative value, we do nothing
+            if (hpx::parallel::v1::detail::is_negative(count))
+            {
+                return first;
+            }
+
+            return hpx::parallel::v1::detail::uninitialized_default_construct_n<
+                FwdIter>()
+                .call(hpx::execution::seq, first, std::size_t(count));
+        }
+
+        // clang-format off
+        template <typename ExPolicy, typename FwdIter, typename Size,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::is_execution_policy<ExPolicy>::value &&
+                hpx::traits::is_forward_iterator<FwdIter>::value
+            )>
+        // clang-format on
+        friend typename parallel::util::detail::algorithm_result<ExPolicy,
+            FwdIter>::type
+        tag_fallback_dispatch(hpx::uninitialized_default_construct_n_t,
+            ExPolicy&& policy, FwdIter first, Size count)
+        {
+            static_assert(hpx::traits::is_forward_iterator<FwdIter>::value,
+                "Requires at least forward iterator.");
+
+            // if count is representing a negative value, we do nothing
+            if (hpx::parallel::v1::detail::is_negative(count))
+            {
+                return parallel::util::detail::algorithm_result<ExPolicy,
+                    FwdIter>::get(std::move(first));
+            }
+
+            return hpx::parallel::v1::detail::uninitialized_default_construct_n<
+                FwdIter>()
+                .call(
+                    std::forward<ExPolicy>(policy), first, std::size_t(count));
+        }
+
+    } uninitialized_default_construct_n{};
+}    // namespace hpx
+
+#endif    // DOXYGEN

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/uninitialized_value_construct.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/uninitialized_value_construct.hpp
@@ -10,39 +10,40 @@
 
 #if defined(DOXYGEN)
 namespace hpx {
+    // clang-format off
 
-    /// Copies the given \a value to an uninitialized memory area, defined by
-    /// the range [first, last). If an exception is thrown during the
+    /// Constructs objects of type typename iterator_traits<ForwardIt>
+    /// ::value_type in the uninitialized storage designated by the range
+    /// by value-initialization. If an exception is thrown during the
     /// initialization, the function has no effects.
     ///
-    /// \note   Complexity: Linear in the distance between \a first and \a last
+    /// \note   Complexity: Performs exactly \a last - \a first assignments.
     ///
     /// \tparam FwdIter     The type of the source iterators used (deduced).
     ///                     This iterator type must meet the requirements of an
     ///                     forward iterator.
-    /// \tparam T           The type of the value to be assigned (deduced).
     ///
     /// \param first        Refers to the beginning of the sequence of elements
     ///                     the algorithm will be applied to.
     /// \param last         Refers to the end of the sequence of elements the
     ///                     algorithm will be applied to.
-    /// \param value        The value to be assigned.
     ///
-    /// The assignments in the parallel \a uninitialized_default_construct algorithm invoked
-    /// without an execution policy object will execute in sequential order in
-    /// the calling thread.
+    /// The assignments in the parallel \a uninitialized_value_construct
+    /// algorithm invoked without an execution policy object will execute in
+    /// sequential order in the calling thread.
     ///
-    /// \returns  The \a uninitialized_default_construct algorithm  returns nothing
+    /// \returns  The \a uninitialized_value_construct algorithm
+    ///           returns nothing
     ///
-    template <typename FwdIter, typename T>
-    void uninitialized_default_construct(
-        FwdIter first, FwdIter last, T const& value);
+    template <typename FwdIter>
+    void uninitialized_value_construct(FwdIter first, FwdIter last);
 
-    /// Copies the given \a value to an uninitialized memory area, defined by
-    /// the range [first, last). If an exception is thrown during the
+    /// Constructs objects of type typename iterator_traits<ForwardIt>
+    /// ::value_type in the uninitialized storage designated by the range
+    /// by value-initialization. If an exception is thrown during the
     /// initialization, the function has no effects.
     ///
-    /// \note   Complexity: Linear in the distance between \a first and \a last
+    /// \note   Complexity: Performs exactly \a last - \a first assignments.
     ///
     /// \tparam ExPolicy    The type of the execution policy to use (deduced).
     ///                     It describes the manner in which the execution
@@ -51,7 +52,6 @@ namespace hpx {
     /// \tparam FwdIter     The type of the source iterators used (deduced).
     ///                     This iterator type must meet the requirements of an
     ///                     forward iterator.
-    /// \tparam T           The type of the value to be assigned (deduced).
     ///
     /// \param policy       The execution policy to use for the scheduling of
     ///                     the iterations.
@@ -59,67 +59,64 @@ namespace hpx {
     ///                     the algorithm will be applied to.
     /// \param last         Refers to the end of the sequence of elements the
     ///                     algorithm will be applied to.
-    /// \param value        The value to be assigned.
     ///
-    /// The initializations in the parallel \a uninitialized_default_construct algorithm
-    /// invoked with an execution policy object of type
-    /// \a sequenced_policy execute in sequential order in the
-    /// calling thread.
+    /// The assignments in the parallel \a uninitialized_value_construct
+    /// algorithm invoked with an execution policy object of type \a
+    /// sequenced_policy execute in sequential order in the calling thread.
     ///
-    /// The initializations in the parallel \a uninitialized_default_construct algorithm
-    /// invoked with an execution policy object of type
-    /// \a parallel_policy or \a parallel_task_policy are
-    /// permitted to execute in an unordered fashion in unspecified threads,
-    /// and indeterminately sequenced within each thread.
+    /// The assignments in the parallel \a uninitialized_value_construct
+    /// algorithm invoked with an execution policy object of type \a
+    /// parallel_policy or \a parallel_task_policy are permitted to execute
+    /// in an unordered fashion in unspecified threads, and indeterminately
+    /// sequenced within each thread.
     ///
-    /// \returns  The \a uninitialized_default_construct algorithm returns a
+    /// \returns  The \a uninitialized_value_construct algorithm returns a
     ///           \a hpx::future<void>, if the execution policy is of type
     ///           \a sequenced_task_policy or
     ///           \a parallel_task_policy and returns nothing
     ///           otherwise.
     ///
-    template <typename ExPolicy, typename FwdIter, typename T>
+    template <typename ExPolicy, typename FwdIter>
     typename parallel::util::detail::algorithm_result<ExPolicy>::type
-    uninitialized_default_construct(
-        ExPolicy&& policy, FwdIter first, FwdIter last, T const& value);
+    uninitialized_value_construct(
+        ExPolicy&& policy, FwdIter first, FwdIter last);
 
-    /// Copies the given \a value value to the first count elements in an
-    /// uninitialized memory area beginning at first. If an exception is thrown
-    /// during the initialization, the function has no effects.
+    /// Constructs objects of type typename iterator_traits<ForwardIt>
+    /// ::value_type in the uninitialized storage designated by the range
+    /// [first, first + count) by value-initialization. If an exception
+    /// is thrown during the initialization, the function has no effects.
     ///
     /// \note   Complexity: Performs exactly \a count assignments, if
     ///         count > 0, no assignments otherwise.
     ///
     /// \tparam FwdIter     The type of the source iterators used (deduced).
-    ///                     This iterator type must meet the requirements of a
+    ///                     This iterator type must meet the requirements of an
     ///                     forward iterator.
     /// \tparam Size        The type of the argument specifying the number of
     ///                     elements to apply \a f to.
-    /// \tparam T           The type of the value to be assigned (deduced).
     ///
     /// \param first        Refers to the beginning of the sequence of elements
     ///                     the algorithm will be applied to.
     /// \param count        Refers to the number of elements starting at
     ///                     \a first the algorithm will be applied to.
-    /// \param value        The value to be assigned.
     ///
-    /// The assignments in the parallel \a uninitialized_default_construct_n algorithm
-    /// invoked without an execution policy object execute in sequential order
-    /// in the calling thread.
+    /// The assignments in the parallel \a uninitialized_value_construct_n
+    /// algorithm invoked without an execution policy object execute in
+    /// sequential order in the calling thread.
     ///
-    /// \returns  The \a uninitialized_default_construct_n algorithm returns a
+    /// \returns  The \a uninitialized_value_construct_n algorithm returns a
     ///           returns \a FwdIter.
-    ///           The \a uninitialized_default_construct_n algorithm returns the output
-    ///           iterator to the element in the range, one past
-    ///           the last element copied.
+    ///           The \a uninitialized_value_construct_n algorithm returns
+    ///           the iterator to the element in the source range, one past
+    ///           the last element constructed.
     ///
-    template <typename FwdIter, typename Size, typename T>
-    FwdIter uninitialized_default_construct_n(
-        FwdIter first, Size count, T const& value);
+    template <typename FwdIter, typename Size>
+    FwdIter uninitialized_value_construct_n(FwdIter first, Size count);
 
-    /// Copies the given \a value value to the first count elements in an
-    /// uninitialized memory area beginning at first. If an exception is thrown
-    /// during the initialization, the function has no effects.
+    /// Constructs objects of type typename iterator_traits<ForwardIt>
+    /// ::value_type in the uninitialized storage designated by the range
+    /// [first, first + count) by value-initialization. If an exception
+    /// is thrown during the initialization, the function has no effects.
     ///
     /// \note   Complexity: Performs exactly \a count assignments, if
     ///         count > 0, no assignments otherwise.
@@ -129,11 +126,10 @@ namespace hpx {
     ///                     of the algorithm may be parallelized and the manner
     ///                     in which it executes the assignments.
     /// \tparam FwdIter     The type of the source iterators used (deduced).
-    ///                     This iterator type must meet the requirements of a
+    ///                     This iterator type must meet the requirements of an
     ///                     forward iterator.
     /// \tparam Size        The type of the argument specifying the number of
     ///                     elements to apply \a f to.
-    /// \tparam T           The type of the value to be assigned (deduced).
     ///
     /// \param policy       The execution policy to use for the scheduling of
     ///                     the iterations.
@@ -141,32 +137,33 @@ namespace hpx {
     ///                     the algorithm will be applied to.
     /// \param count        Refers to the number of elements starting at
     ///                     \a first the algorithm will be applied to.
-    /// \param value        The value to be assigned.
     ///
-    /// The initializations in the parallel \a uninitialized_default_construct_n algorithm
-    /// invoked with an execution policy object of type
+    /// The assignments in the parallel \a uninitialized_value_construct_n
+    /// algorithm invoked with an execution policy object of type
     /// \a sequenced_policy execute in sequential order in the
     /// calling thread.
     ///
-    /// The initializations in the parallel \a uninitialized_default_construct_n algorithm
-    /// invoked with an execution policy object of type
-    /// \a parallel_policy or \a parallel_task_policy are
-    /// permitted to execute in an unordered fashion in unspecified threads,
-    /// and indeterminately sequenced within each thread.
+    /// The assignments in the parallel \a uninitialized_value_construct_n
+    /// algorithm invoked with an execution policy object of type
+    /// \a parallel_policy or
+    /// \a parallel_task_policy are permitted to execute in an
+    /// unordered fashion in unspecified threads, and indeterminately sequenced
+    /// within each thread.
     ///
-    /// \returns  The \a uninitialized_default_construct_n algorithm returns a
-    ///           \a hpx::future<FwdIter>, if the execution policy is of type
+    /// \returns  The \a uninitialized_value_construct_n algorithm returns a
+    ///           \a hpx::future<FwdIter> if the execution policy is of type
     ///           \a sequenced_task_policy or
-    ///           \a parallel_task_policy and returns FwdIter
-    ///           otherwise.
-    ///           The \a uninitialized_default_construct_n algorithm returns the output
-    ///           iterator to the element in the range, one past
-    ///           the last element copied.
+    ///           \a parallel_task_policy and
+    ///           returns \a FwdIter otherwise.
+    ///           The \a uninitialized_value_construct_n algorithm returns
+    ///           the iterator to the element in the source range, one past
+    ///           the last element constructed.
     ///
-    template <typename ExPolicy, typename FwdIter, typename Size, typename T>
+    template <typename ExPolicy, typename FwdIter, typename Size>
     typename parallel::util::detail::algorithm_result<ExPolicy, FwdIter>::type
-    uninitialized_default_construct_n(
-        ExPolicy&& policy, FwdIter first, Size count, T const& value);
+    uninitialized_value_construct_n(
+        ExPolicy&& policy, FwdIter first, Size count);
+    // clang-format on
 }    // namespace hpx
 
 #else    // DOXYGEN
@@ -196,8 +193,6 @@ namespace hpx { namespace parallel { inline namespace v1 {
     ///////////////////////////////////////////////////////////////////////////
     // uninitialized_value_construct
     namespace detail {
-        /// \cond NOINTERNAL
-
         // provide our own implementation of std::uninitialized_value_construct
         // as some versions of MSVC horribly fail at compiling it for some types
         // T
@@ -316,46 +311,8 @@ namespace hpx { namespace parallel { inline namespace v1 {
                     detail::distance(first, last));
             }
         };
-        /// \endcond
     }    // namespace detail
 
-    /// Constructs objects of type typename iterator_traits<ForwardIt>::value_type
-    /// in the uninitialized storage designated by the range [first, last) by
-    /// default-initialization. If an exception is thrown during the
-    /// initialization, the function has no effects.
-    ///
-    /// \note   Complexity: Performs exactly \a last - \a first assignments.
-    ///
-    /// \tparam ExPolicy    The type of the execution policy to use (deduced).
-    ///                     It describes the manner in which the execution
-    ///                     of the algorithm may be parallelized and the manner
-    ///                     in which it executes the assignments.
-    /// \tparam FwdIter     The type of the source iterators used (deduced).
-    ///                     This iterator type must meet the requirements of an
-    ///                     forward iterator.
-    ///
-    /// \param policy       The execution policy to use for the scheduling of
-    ///                     the iterations.
-    /// \param first        Refers to the beginning of the sequence of elements
-    ///                     the algorithm will be applied to.
-    /// \param last         Refers to the end of the sequence of elements the
-    ///                     algorithm will be applied to.
-    ///
-    /// The assignments in the parallel \a uninitialized_value_construct
-    /// algorithm invoked with an execution policy object of type \a sequenced_policy
-    /// execute in sequential order in the calling thread.
-    ///
-    /// The assignments in the parallel \a uninitialized_value_construct
-    /// algorithm invoked with an execution policy object of type \a parallel_policy
-    /// or \a parallel_task_policy are permitted to execute in an
-    /// unordered fashion in unspecified threads, and indeterminately sequenced
-    /// within each thread.
-    ///
-    /// \returns  The \a uninitialized_value_construct algorithm returns a
-    ///           \a hpx::future<void>, if the execution policy is of type
-    ///           \a sequenced_task_policy or
-    ///           \a parallel_task_policy and returns \a void otherwise.
-    ///
     template <typename ExPolicy, typename FwdIter,
         HPX_CONCEPT_REQUIRES_(hpx::is_execution_policy<ExPolicy>::value&&
                 hpx::traits::is_iterator<FwdIter>::value)>
@@ -451,52 +408,6 @@ namespace hpx { namespace parallel { inline namespace v1 {
         /// \endcond
     }    // namespace detail
 
-    /// Constructs objects of type typename iterator_traits<ForwardIt>::value_type
-    /// in the uninitialized storage designated by the range [first, first + count) by
-    /// default-initialization. If an exception is thrown during the
-    /// initialization, the function has no effects.
-    ///
-    /// \note   Complexity: Performs exactly \a count assignments, if
-    ///         count > 0, no assignments otherwise.
-    ///
-    /// \tparam ExPolicy    The type of the execution policy to use (deduced).
-    ///                     It describes the manner in which the execution
-    ///                     of the algorithm may be parallelized and the manner
-    ///                     in which it executes the assignments.
-    /// \tparam FwdIter     The type of the source iterators used (deduced).
-    ///                     This iterator type must meet the requirements of an
-    ///                     forward iterator.
-    /// \tparam Size        The type of the argument specifying the number of
-    ///                     elements to apply \a f to.
-    ///
-    /// \param policy       The execution policy to use for the scheduling of
-    ///                     the iterations.
-    /// \param first        Refers to the beginning of the sequence of elements
-    ///                     the algorithm will be applied to.
-    /// \param count        Refers to the number of elements starting at
-    ///                     \a first the algorithm will be applied to.
-    ///
-    /// The assignments in the parallel \a uninitialized_value_construct_n
-    /// algorithm invoked with an execution policy object of type
-    /// \a sequenced_policy execute in sequential order in the
-    /// calling thread.
-    ///
-    /// The assignments in the parallel \a uninitialized_value_construct_n
-    /// algorithm invoked with an execution policy object of type
-    /// \a parallel_policy or
-    /// \a parallel_task_policy are permitted to execute in an
-    /// unordered fashion in unspecified threads, and indeterminately sequenced
-    /// within each thread.
-    ///
-    /// \returns  The \a uninitialized_value_construct_n algorithm returns a
-    ///           \a hpx::future<FwdIter> if the execution policy is of type
-    ///           \a sequenced_task_policy or
-    ///           \a parallel_task_policy and
-    ///           returns \a FwdIter otherwise.
-    ///           The \a uninitialized_value_construct_n algorithm returns the
-    ///           iterator to the element in the source range, one past
-    ///           the last element constructed.
-    ///
     template <typename ExPolicy, typename FwdIter, typename Size,
         HPX_CONCEPT_REQUIRES_(hpx::is_execution_policy<ExPolicy>::value&&
                 hpx::traits::is_iterator<FwdIter>::value)>

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/uninitialized_value_construct.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/uninitialized_value_construct.hpp
@@ -8,6 +8,169 @@
 
 #pragma once
 
+#if defined(DOXYGEN)
+namespace hpx {
+
+    /// Copies the given \a value to an uninitialized memory area, defined by
+    /// the range [first, last). If an exception is thrown during the
+    /// initialization, the function has no effects.
+    ///
+    /// \note   Complexity: Linear in the distance between \a first and \a last
+    ///
+    /// \tparam FwdIter     The type of the source iterators used (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     forward iterator.
+    /// \tparam T           The type of the value to be assigned (deduced).
+    ///
+    /// \param first        Refers to the beginning of the sequence of elements
+    ///                     the algorithm will be applied to.
+    /// \param last         Refers to the end of the sequence of elements the
+    ///                     algorithm will be applied to.
+    /// \param value        The value to be assigned.
+    ///
+    /// The assignments in the parallel \a uninitialized_default_construct algorithm invoked
+    /// without an execution policy object will execute in sequential order in
+    /// the calling thread.
+    ///
+    /// \returns  The \a uninitialized_default_construct algorithm  returns nothing
+    ///
+    template <typename FwdIter, typename T>
+    void uninitialized_default_construct(
+        FwdIter first, FwdIter last, T const& value);
+
+    /// Copies the given \a value to an uninitialized memory area, defined by
+    /// the range [first, last). If an exception is thrown during the
+    /// initialization, the function has no effects.
+    ///
+    /// \note   Complexity: Linear in the distance between \a first and \a last
+    ///
+    /// \tparam ExPolicy    The type of the execution policy to use (deduced).
+    ///                     It describes the manner in which the execution
+    ///                     of the algorithm may be parallelized and the manner
+    ///                     in which it executes the assignments.
+    /// \tparam FwdIter     The type of the source iterators used (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     forward iterator.
+    /// \tparam T           The type of the value to be assigned (deduced).
+    ///
+    /// \param policy       The execution policy to use for the scheduling of
+    ///                     the iterations.
+    /// \param first        Refers to the beginning of the sequence of elements
+    ///                     the algorithm will be applied to.
+    /// \param last         Refers to the end of the sequence of elements the
+    ///                     algorithm will be applied to.
+    /// \param value        The value to be assigned.
+    ///
+    /// The initializations in the parallel \a uninitialized_default_construct algorithm
+    /// invoked with an execution policy object of type
+    /// \a sequenced_policy execute in sequential order in the
+    /// calling thread.
+    ///
+    /// The initializations in the parallel \a uninitialized_default_construct algorithm
+    /// invoked with an execution policy object of type
+    /// \a parallel_policy or \a parallel_task_policy are
+    /// permitted to execute in an unordered fashion in unspecified threads,
+    /// and indeterminately sequenced within each thread.
+    ///
+    /// \returns  The \a uninitialized_default_construct algorithm returns a
+    ///           \a hpx::future<void>, if the execution policy is of type
+    ///           \a sequenced_task_policy or
+    ///           \a parallel_task_policy and returns nothing
+    ///           otherwise.
+    ///
+    template <typename ExPolicy, typename FwdIter, typename T>
+    typename parallel::util::detail::algorithm_result<ExPolicy>::type
+    uninitialized_default_construct(
+        ExPolicy&& policy, FwdIter first, FwdIter last, T const& value);
+
+    /// Copies the given \a value value to the first count elements in an
+    /// uninitialized memory area beginning at first. If an exception is thrown
+    /// during the initialization, the function has no effects.
+    ///
+    /// \note   Complexity: Performs exactly \a count assignments, if
+    ///         count > 0, no assignments otherwise.
+    ///
+    /// \tparam FwdIter     The type of the source iterators used (deduced).
+    ///                     This iterator type must meet the requirements of a
+    ///                     forward iterator.
+    /// \tparam Size        The type of the argument specifying the number of
+    ///                     elements to apply \a f to.
+    /// \tparam T           The type of the value to be assigned (deduced).
+    ///
+    /// \param first        Refers to the beginning of the sequence of elements
+    ///                     the algorithm will be applied to.
+    /// \param count        Refers to the number of elements starting at
+    ///                     \a first the algorithm will be applied to.
+    /// \param value        The value to be assigned.
+    ///
+    /// The assignments in the parallel \a uninitialized_default_construct_n algorithm
+    /// invoked without an execution policy object execute in sequential order
+    /// in the calling thread.
+    ///
+    /// \returns  The \a uninitialized_default_construct_n algorithm returns a
+    ///           returns \a FwdIter.
+    ///           The \a uninitialized_default_construct_n algorithm returns the output
+    ///           iterator to the element in the range, one past
+    ///           the last element copied.
+    ///
+    template <typename FwdIter, typename Size, typename T>
+    FwdIter uninitialized_default_construct_n(
+        FwdIter first, Size count, T const& value);
+
+    /// Copies the given \a value value to the first count elements in an
+    /// uninitialized memory area beginning at first. If an exception is thrown
+    /// during the initialization, the function has no effects.
+    ///
+    /// \note   Complexity: Performs exactly \a count assignments, if
+    ///         count > 0, no assignments otherwise.
+    ///
+    /// \tparam ExPolicy    The type of the execution policy to use (deduced).
+    ///                     It describes the manner in which the execution
+    ///                     of the algorithm may be parallelized and the manner
+    ///                     in which it executes the assignments.
+    /// \tparam FwdIter     The type of the source iterators used (deduced).
+    ///                     This iterator type must meet the requirements of a
+    ///                     forward iterator.
+    /// \tparam Size        The type of the argument specifying the number of
+    ///                     elements to apply \a f to.
+    /// \tparam T           The type of the value to be assigned (deduced).
+    ///
+    /// \param policy       The execution policy to use for the scheduling of
+    ///                     the iterations.
+    /// \param first        Refers to the beginning of the sequence of elements
+    ///                     the algorithm will be applied to.
+    /// \param count        Refers to the number of elements starting at
+    ///                     \a first the algorithm will be applied to.
+    /// \param value        The value to be assigned.
+    ///
+    /// The initializations in the parallel \a uninitialized_default_construct_n algorithm
+    /// invoked with an execution policy object of type
+    /// \a sequenced_policy execute in sequential order in the
+    /// calling thread.
+    ///
+    /// The initializations in the parallel \a uninitialized_default_construct_n algorithm
+    /// invoked with an execution policy object of type
+    /// \a parallel_policy or \a parallel_task_policy are
+    /// permitted to execute in an unordered fashion in unspecified threads,
+    /// and indeterminately sequenced within each thread.
+    ///
+    /// \returns  The \a uninitialized_default_construct_n algorithm returns a
+    ///           \a hpx::future<FwdIter>, if the execution policy is of type
+    ///           \a sequenced_task_policy or
+    ///           \a parallel_task_policy and returns FwdIter
+    ///           otherwise.
+    ///           The \a uninitialized_default_construct_n algorithm returns the output
+    ///           iterator to the element in the range, one past
+    ///           the last element copied.
+    ///
+    template <typename ExPolicy, typename FwdIter, typename Size, typename T>
+    typename parallel::util::detail::algorithm_result<ExPolicy, FwdIter>::type
+    uninitialized_default_construct_n(
+        ExPolicy&& policy, FwdIter first, Size count, T const& value);
+}    // namespace hpx
+
+#else    // DOXYGEN
+
 #include <hpx/config.hpp>
 #include <hpx/iterator_support/traits/is_iterator.hpp>
 #include <hpx/type_support/void_guard.hpp>
@@ -15,6 +178,7 @@
 #include <hpx/execution/algorithms/detail/is_negative.hpp>
 #include <hpx/executors/execution_policy.hpp>
 #include <hpx/parallel/algorithms/detail/dispatch.hpp>
+#include <hpx/parallel/algorithms/detail/distance.hpp>
 #include <hpx/parallel/util/detail/algorithm_result.hpp>
 #include <hpx/parallel/util/loop.hpp>
 #include <hpx/parallel/util/partitioner_with_cleanup.hpp>
@@ -37,11 +201,11 @@ namespace hpx { namespace parallel { inline namespace v1 {
         // provide our own implementation of std::uninitialized_value_construct
         // as some versions of MSVC horribly fail at compiling it for some types
         // T
-        template <typename InIter>
-        void std_uninitialized_value_construct(InIter first, InIter last)
+        template <typename InIter, typename Sent>
+        InIter std_uninitialized_value_construct(InIter first, Sent last)
         {
-            typedef
-                typename std::iterator_traits<InIter>::value_type value_type;
+            using value_type =
+                typename std::iterator_traits<InIter>::value_type;
 
             InIter s_first = first;
             try
@@ -50,6 +214,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 {
                     ::new (std::addressof(*first)) value_type();
                 }
+                return first;
             }
             catch (...)
             {
@@ -67,8 +232,8 @@ namespace hpx { namespace parallel { inline namespace v1 {
             std::size_t count,
             util::cancellation_token<util::detail::no_data>& tok)
         {
-            typedef
-                typename std::iterator_traits<InIter>::value_type value_type;
+            using value_type =
+                typename std::iterator_traits<InIter>::value_type;
 
             return util::loop_with_cleanup_n_with_token(
                 first, count, tok,
@@ -126,7 +291,8 @@ namespace hpx { namespace parallel { inline namespace v1 {
         ///////////////////////////////////////////////////////////////////////
         template <typename FwdIter>
         struct uninitialized_value_construct
-          : public detail::algorithm<uninitialized_value_construct<FwdIter>>
+          : public detail::algorithm<uninitialized_value_construct<FwdIter>,
+                FwdIter>
         {
             uninitialized_value_construct()
               : uninitialized_value_construct::algorithm(
@@ -134,22 +300,20 @@ namespace hpx { namespace parallel { inline namespace v1 {
             {
             }
 
-            template <typename ExPolicy, typename InIter>
-            static hpx::util::unused_type sequential(
-                ExPolicy, InIter first, InIter last)
+            template <typename ExPolicy, typename Sent>
+            static FwdIter sequential(ExPolicy, FwdIter first, Sent last)
             {
-                std_uninitialized_value_construct(first, last);
-                return hpx::util::unused;
+                return std_uninitialized_value_construct(first, last);
             }
 
-            template <typename ExPolicy>
-            static typename util::detail::algorithm_result<ExPolicy>::type
-            parallel(ExPolicy&& policy, FwdIter first, FwdIter last)
+            template <typename ExPolicy, typename Sent>
+            static
+                typename util::detail::algorithm_result<ExPolicy, FwdIter>::type
+                parallel(ExPolicy&& policy, FwdIter first, Sent last)
             {
-                return util::detail::algorithm_result<ExPolicy>::get(
-                    parallel_sequential_uninitialized_value_construct_n(
-                        std::forward<ExPolicy>(policy), first,
-                        std::distance(first, last)));
+                return parallel_sequential_uninitialized_value_construct_n(
+                    std::forward<ExPolicy>(policy), first,
+                    detail::distance(first, last));
             }
         };
         /// \endcond
@@ -195,15 +359,32 @@ namespace hpx { namespace parallel { inline namespace v1 {
     template <typename ExPolicy, typename FwdIter,
         HPX_CONCEPT_REQUIRES_(hpx::is_execution_policy<ExPolicy>::value&&
                 hpx::traits::is_iterator<FwdIter>::value)>
+    HPX_DEPRECATED_V(1, 7,
+        "hpx::parallel::uninitialized_value_construct is deprecated, use "
+        "hpx::uninitialized_value_construct "
+        "instead")
     typename util::detail::algorithm_result<ExPolicy>::type
-    uninitialized_value_construct(
-        ExPolicy&& policy, FwdIter first, FwdIter last)
+        uninitialized_value_construct(
+            ExPolicy&& policy, FwdIter first, FwdIter last)
     {
         static_assert((hpx::traits::is_forward_iterator<FwdIter>::value),
             "Required at least forward iterator.");
 
-        return detail::uninitialized_value_construct<FwdIter>().call(
-            std::forward<ExPolicy>(policy), first, last);
+#if defined(HPX_GCC_VERSION) && HPX_GCC_VERSION >= 100000
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
+        using result_type =
+            typename hpx::parallel::util::detail::algorithm_result<
+                ExPolicy>::type;
+
+        return hpx::util::void_guard<result_type>(),
+               hpx::parallel::v1::detail::uninitialized_value_construct<
+                   FwdIter>()
+                   .call(std::forward<ExPolicy>(policy), first, last);
+#if defined(HPX_GCC_VERSION) && HPX_GCC_VERSION >= 100000
+#pragma GCC diagnostic pop
+#endif
     }
 
     ///////////////////////////////////////////////////////////////////////////
@@ -218,8 +399,8 @@ namespace hpx { namespace parallel { inline namespace v1 {
         InIter std_uninitialized_value_construct_n(
             InIter first, std::size_t count)
         {
-            typedef
-                typename std::iterator_traits<InIter>::value_type value_type;
+            using value_type =
+                typename std::iterator_traits<InIter>::value_type;
 
             InIter s_first = first;
             try
@@ -251,8 +432,9 @@ namespace hpx { namespace parallel { inline namespace v1 {
             {
             }
 
-            template <typename ExPolicy, typename InIter>
-            static InIter sequential(ExPolicy, InIter first, std::size_t count)
+            template <typename ExPolicy>
+            static FwdIter sequential(
+                ExPolicy, FwdIter first, std::size_t count)
             {
                 return std_uninitialized_value_construct_n(first, count);
             }
@@ -318,9 +500,13 @@ namespace hpx { namespace parallel { inline namespace v1 {
     template <typename ExPolicy, typename FwdIter, typename Size,
         HPX_CONCEPT_REQUIRES_(hpx::is_execution_policy<ExPolicy>::value&&
                 hpx::traits::is_iterator<FwdIter>::value)>
+    HPX_DEPRECATED_V(1, 7,
+        "hpx::parallel::uninitialized_value_construct_n is deprecated, use "
+        "hpx::uninitialized_value_construct_n "
+        "instead")
     typename util::detail::algorithm_result<ExPolicy, FwdIter>::type
-    uninitialized_value_construct_n(
-        ExPolicy&& policy, FwdIter first, Size count)
+        uninitialized_value_construct_n(
+            ExPolicy&& policy, FwdIter first, Size count)
     {
         static_assert((hpx::traits::is_forward_iterator<FwdIter>::value),
             "Requires at least forward iterator.");
@@ -332,7 +518,123 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 std::move(first));
         }
 
+#if defined(HPX_GCC_VERSION) && HPX_GCC_VERSION >= 100000
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
         return detail::uninitialized_value_construct_n<FwdIter>().call(
             std::forward<ExPolicy>(policy), first, std::size_t(count));
+#if defined(HPX_GCC_VERSION) && HPX_GCC_VERSION >= 100000
+#pragma GCC diagnostic pop
+#endif
     }
 }}}    // namespace hpx::parallel::v1
+
+namespace hpx {
+    ///////////////////////////////////////////////////////////////////////////
+    // DPO for hpx::uninitialized_value_construct
+    HPX_INLINE_CONSTEXPR_VARIABLE struct uninitialized_value_construct_t final
+      : hpx::functional::tag_fallback<uninitialized_value_construct_t>
+    {
+        // clang-format off
+        template <typename FwdIter,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::traits::is_forward_iterator<FwdIter>::value
+            )>
+        // clang-format on
+        friend void tag_fallback_dispatch(
+            hpx::uninitialized_value_construct_t, FwdIter first, FwdIter last)
+        {
+            static_assert(hpx::traits::is_forward_iterator<FwdIter>::value,
+                "Requires at least forward iterator.");
+
+            hpx::parallel::v1::detail::uninitialized_value_construct<FwdIter>()
+                .call(hpx::execution::seq, first, last);
+        }
+
+        // clang-format off
+        template <typename ExPolicy, typename FwdIter,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::is_execution_policy<ExPolicy>::value &&
+                hpx::traits::is_forward_iterator<FwdIter>::value
+            )>
+        // clang-format on
+        friend typename parallel::util::detail::algorithm_result<ExPolicy>::type
+        tag_fallback_dispatch(hpx::uninitialized_value_construct_t,
+            ExPolicy&& policy, FwdIter first, FwdIter last)
+        {
+            static_assert(hpx::traits::is_forward_iterator<FwdIter>::value,
+                "Requires at least forward iterator.");
+
+            using result_type =
+                typename hpx::parallel::util::detail::algorithm_result<
+                    ExPolicy>::type;
+
+            return hpx::util::void_guard<result_type>(),
+                   hpx::parallel::v1::detail::uninitialized_value_construct<
+                       FwdIter>()
+                       .call(std::forward<ExPolicy>(policy), first, last);
+        }
+
+    } uninitialized_value_construct{};
+
+    ///////////////////////////////////////////////////////////////////////////
+    // DPO for hpx::uninitialized_value_construct_n
+    HPX_INLINE_CONSTEXPR_VARIABLE struct uninitialized_value_construct_n_t final
+      : hpx::functional::tag_fallback<uninitialized_value_construct_n_t>
+    {
+        // clang-format off
+        template <typename FwdIter, typename Size,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::traits::is_forward_iterator<FwdIter>::value
+            )>
+        // clang-format on
+        friend FwdIter tag_fallback_dispatch(
+            hpx::uninitialized_value_construct_n_t, FwdIter first, Size count)
+        {
+            static_assert(hpx::traits::is_forward_iterator<FwdIter>::value,
+                "Requires at least forward iterator.");
+
+            // if count is representing a negative value, we do nothing
+            if (hpx::parallel::v1::detail::is_negative(count))
+            {
+                return first;
+            }
+
+            return hpx::parallel::v1::detail::uninitialized_value_construct_n<
+                FwdIter>()
+                .call(hpx::execution::seq, first, std::size_t(count));
+        }
+
+        // clang-format off
+        template <typename ExPolicy, typename FwdIter, typename Size,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::is_execution_policy<ExPolicy>::value &&
+                hpx::traits::is_forward_iterator<FwdIter>::value
+            )>
+        // clang-format on
+        friend typename parallel::util::detail::algorithm_result<ExPolicy,
+            FwdIter>::type
+        tag_fallback_dispatch(hpx::uninitialized_value_construct_n_t,
+            ExPolicy&& policy, FwdIter first, Size count)
+        {
+            static_assert(hpx::traits::is_forward_iterator<FwdIter>::value,
+                "Requires at least forward iterator.");
+
+            // if count is representing a negative value, we do nothing
+            if (hpx::parallel::v1::detail::is_negative(count))
+            {
+                return parallel::util::detail::algorithm_result<ExPolicy,
+                    FwdIter>::get(std::move(first));
+            }
+
+            return hpx::parallel::v1::detail::uninitialized_value_construct_n<
+                FwdIter>()
+                .call(
+                    std::forward<ExPolicy>(policy), first, std::size_t(count));
+        }
+
+    } uninitialized_value_construct_n{};
+}    // namespace hpx
+
+#endif    // DOXYGEN

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms.hpp
@@ -44,5 +44,4 @@
 #include <hpx/parallel/container_algorithms/sort.hpp>
 #include <hpx/parallel/container_algorithms/stable_sort.hpp>
 #include <hpx/parallel/container_algorithms/transform.hpp>
-#include <hpx/parallel/container_algorithms/uninitialized_copy.hpp>
 #include <hpx/parallel/container_algorithms/unique.hpp>

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms.hpp
@@ -44,4 +44,5 @@
 #include <hpx/parallel/container_algorithms/sort.hpp>
 #include <hpx/parallel/container_algorithms/stable_sort.hpp>
 #include <hpx/parallel/container_algorithms/transform.hpp>
+#include <hpx/parallel/container_algorithms/uninitialized_copy.hpp>
 #include <hpx/parallel/container_algorithms/unique.hpp>

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/uninitialized_copy.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/uninitialized_copy.hpp
@@ -397,17 +397,18 @@ namespace hpx { namespace ranges {
                 hpx::traits::is_sentinel_for<Sent2, FwdIter>::value
             )>
         // clang-format on
-        friend hpx::parallel::util::in_out_result<InIter, FwdIter> tag_fallback_invoke(
-            hpx::ranges::uninitialized_copy_t,
-            InIter first1, Sent1 last1, FwdIter first2, Sent2 last2)
+        friend hpx::parallel::util::in_out_result<InIter, FwdIter>
+        tag_fallback_invoke(hpx::ranges::uninitialized_copy_t, InIter first1,
+            Sent1 last1, FwdIter first2, Sent2 last2)
         {
             static_assert(hpx::traits::is_input_iterator<InIter>::value,
                 "Requires at least input iterator.");
             static_assert(hpx::traits::is_forward_iterator<FwdIter>::value,
                 "Requires at least forward iterator.");
 
-            return hpx::parallel::v1::detail::uninitialized_copy_sent<FwdIter>().call(
-                hpx::execution::seq, first1, last1, first2, last2);
+            return hpx::parallel::v1::detail::uninitialized_copy_sent<
+                    parallel::util::in_out_result<InIter, FwdIter>>()
+                    .call(hpx::execution::seq, first1, last1, first2, last2);
         }
 
         // clang-format off
@@ -422,7 +423,7 @@ namespace hpx { namespace ranges {
             )>
         // clang-format on
         friend typename parallel::util::detail::algorithm_result<ExPolicy,
-            FwdIter2>::type
+            parallel::util::in_out_result<FwdIter1, FwdIter2>>::type
         tag_fallback_invoke(hpx::ranges::uninitialized_copy_t,
             ExPolicy&& policy, FwdIter1 first1, Sent1 last1, FwdIter2 first2,
             Sent2 last2)
@@ -432,8 +433,10 @@ namespace hpx { namespace ranges {
             static_assert(hpx::traits::is_forward_iterator<FwdIter2>::value,
                 "Requires at least forward iterator.");
 
-            return hpx::parallel::v1::detail::uninitialized_copy_sent<FwdIter2>().call(
-                std::forward<ExPolicy>(policy), first1, last1, first2, last2);
+            return hpx::parallel::v1::detail::uninitialized_copy_sent<
+                parallel::util::in_out_result<FwdIter1, FwdIter2>>()
+                .call(std::forward<ExPolicy>(policy), first1, last1, first2,
+                    last2);
         }
 
         // clang-format off
@@ -443,8 +446,11 @@ namespace hpx { namespace ranges {
                 hpx::traits::is_range<Rng2>::value
             )>
         // clang-format on
-        friend hpx::parallel::util::in_out_result<> tag_fallback_invoke(hpx::ranges::uninitialized_copy_t,
-            Rng1&& rng1, Rng2&& rng2)
+        friend hpx::parallel::util::in_out_result<
+            typename hpx::traits::range_traits<Rng1>::iterator_type,
+            typename hpx::traits::range_traits<Rng2>::iterator_type>
+        tag_fallback_invoke(
+            hpx::ranges::uninitialized_copy_t, Rng1&& rng1, Rng2&& rng2)
         {
             using iterator_type1 =
                 typename hpx::traits::range_traits<Rng1>::iterator_type;
@@ -454,12 +460,14 @@ namespace hpx { namespace ranges {
             static_assert(hpx::traits::is_input_iterator<iterator_type1>::value,
                 "Requires at least input iterator.");
 
-            static_assert(hpx::traits::is_forward_iterator<iterator_type2>::value,
+            static_assert(
+                hpx::traits::is_forward_iterator<iterator_type2>::value,
                 "Requires at least forward iterator.");
 
-            return hpx::parallel::v1::detail::uninitialized_copy_sent<iterator_type2>().call(
-                hpx::execution::seq, std::begin(rng1), std::end(rng1),
-                std::begin(rng2), std::end(rng2));
+            return hpx::parallel::v1::detail::uninitialized_copy_sent<
+                parallel::util::in_out_result<iterator_type1, iterator_type2>>()
+                .call(hpx::execution::seq, std::begin(rng1), std::end(rng1),
+                    std::begin(rng2), std::end(rng2));
         }
 
         // clang-format off
@@ -471,7 +479,9 @@ namespace hpx { namespace ranges {
             )>
         // clang-format on
         friend typename parallel::util::detail::algorithm_result<ExPolicy,
-            bool>::type
+            hpx::parallel::util::in_out_result<
+                typename hpx::traits::range_traits<Rng1>::iterator_type,
+                typename hpx::traits::range_traits<Rng2>::iterator_type>>::type
         tag_fallback_invoke(hpx::ranges::uninitialized_copy_t,
             ExPolicy&& policy, Rng1&& rng1, Rng2&& rng2)
         {
@@ -488,9 +498,10 @@ namespace hpx { namespace ranges {
                 hpx::traits::is_forward_iterator<iterator_type2>::value,
                 "Requires at least forward iterator.");
 
-            return hpx::parallel::v1::detail::uninitialized_copy_sent<iterator_type2>().call(
-                std::forward<ExPolicy>(policy), std::begin(rng1),
-                std::end(rng1), std::begin(rng2), std::end(rng2));
+            return hpx::parallel::v1::detail::uninitialized_copy_sent<
+                parallel::util::in_out_result<iterator_type1, iterator_type2>>()
+                .call(std::forward<ExPolicy>(policy), std::begin(rng1),
+                    std::end(rng1), std::begin(rng2), std::end(rng2));
         }
     } uninitialized_copy{};
 
@@ -506,19 +517,19 @@ namespace hpx { namespace ranges {
                 hpx::traits::is_sentinel_for<Sent2, FwdIter>::value
             )>
         // clang-format on
-        friend bool tag_fallback_invoke(hpx::ranges::uninitialized_copy_n_t,
-            InIter first1, Size count, FwdIter first2, Sent2 last2)
+        friend hpx::parallel::util::in_out_result<InIter, FwdIter>
+        tag_fallback_invoke(hpx::ranges::uninitialized_copy_n_t, InIter first1,
+            Size count, FwdIter first2, Sent2 last2)
         {
             static_assert(hpx::traits::is_input_iterator<InIter>::value,
                 "Requires at least input iterator.");
             static_assert(hpx::traits::is_forward_iterator<FwdIter>::value,
                 "Requires at least forward iterator.");
 
-            auto N = std::min(
-                count, parallel::v1::detail::distance(first2, last2));
-
-            return hpx::parallel::v1::detail::uninitialized_copy_n<FwdIter>()
-                .call(hpx::execution::seq, first1, std::size_t(N), first2);
+            std::size_t d = parallel::v1::detail::distance(first2, last2);
+            return hpx::parallel::v1::detail::uninitialized_copy_n<
+                parallel::util::in_out_result<InIter, FwdIter>>()
+                .call(hpx::execution::seq, first1, count <= d ? count : d, first2);
         }
 
         // clang-format off
@@ -532,7 +543,7 @@ namespace hpx { namespace ranges {
             )>
         // clang-format on
         friend typename parallel::util::detail::algorithm_result<ExPolicy,
-            bool>::type
+            hpx::parallel::util::in_out_result<FwdIter1, FwdIter2>>::type
         tag_fallback_invoke(hpx::ranges::uninitialized_copy_n_t,
             ExPolicy&& policy, FwdIter1 first1, Size count, FwdIter2 first2,
             Sent2 last2)
@@ -542,11 +553,12 @@ namespace hpx { namespace ranges {
             static_assert(hpx::traits::is_forward_iterator<FwdIter2>::value,
                 "Requires at least forward iterator.");
 
-            auto N =
-                std::min(count, parallel::v1::detail::distance(first2, last2));
-
-            return hpx::parallel::v1::detail::uninitialized_copy_n<FwdIter>()
-                .call(hpx::execution::seq, first1, std::size_t(N), first2);
+            std::size_t d = parallel::v1::detail::distance(first2, last2);
+            return hpx::parallel::v1::detail::uninitialized_copy_n<
+                parallel::util::in_out_result<FwdIter1, FwdIter2>>()
+                    .call(std::forward<ExPolicy>(policy), first1,
+                        count <= d ? count : d,
+                    first2);
         }
     } uninitialized_copy_n{};
 }}    // namespace hpx::ranges

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/uninitialized_copy.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/uninitialized_copy.hpp
@@ -13,276 +13,147 @@
 
 namespace hpx { namespace ranges {
 
-    /// Checks if the first range [first1, last1) is lexicographically less than
-    /// the second range [first2, last2). uses a provided predicate to compare
-    /// elements.
+    /// Copies the elements in the range, defined by [first, last), to an
+    /// uninitialized memory area beginning at \a dest. If an exception is
+    /// thrown during the copy operation, the function has no effects.
     ///
-    /// \note   Complexity: At most 2 * min(N1, N2) applications of the comparison
-    ///         operation, where N1 = std::distance(first1, last)
-    ///         and N2 = std::distance(first2, last2).
+    /// \note   Complexity: Performs exactly \a last - \a first assignments.
     ///
-    /// \tparam InIter1     The type of the source iterators used for the
-    ///                     first range (deduced).
+    /// \tparam InIter      The type of the source iterators used (deduced).
     ///                     This iterator type must meet the requirements of an
     ///                     input iterator.
     /// \tparam Sent1       The type of the source sentinel (deduced). This
-    ///                     sentinel type must be a sentinel for InIter1.
-    /// \tparam InIter2     The type of the source iterators used for the
-    ///                     second range (deduced).
-    ///                     This iterator type must meet the requirements of an
-    ///                     input iterator.
+    ///                     sentinel type must be a sentinel for InIter.
+    /// \tparam FwdIter     The type of the iterator representing the
+    ///                     destination range (deduced).
+    ///                     This iterator type must meet the requirements of a
+    ///                     forward iterator.
     /// \tparam Sent2       The type of the source sentinel (deduced). This
     ///                     sentinel type must be a sentinel for InIter2.
-    /// \tparam Pred        The type of an optional function/function object to use.
-    ///                     Unlike its sequential form, the parallel
-    ///                     overload of \a lexicographical_compare requires \a Pred to
-    ///                     meet the requirements of \a CopyConstructible. This defaults
-    ///                     to std::less<>
-    /// \tparam Proj1       The type of an optional projection function for FwdIter1. This
-    ///                     defaults to \a util::projection_identity
-    /// \tparam Proj2       The type of an optional projection function for FwdIter2. This
-    ///                     defaults to \a util::projection_identity
     ///
     /// \param first1       Refers to the beginning of the sequence of elements
-    ///                     of the first range the algorithm will be applied to.
-    /// \param last1        Refers to the end of the sequence of elements of
-    ///                     the first range the algorithm will be applied to.
-    /// \param first2       Refers to the beginning of the sequence of elements
-    ///                     of the second range the algorithm will be applied to.
-    /// \param last2        Refers to the end of the sequence of elements of
-    ///                     the second range the algorithm will be applied to.
-    /// \param pred         Refers to the comparison function that the first
-    ///                     and second ranges will be applied to
-    /// \param proj1        Specifies the function (or function object) which
-    ///                     will be invoked for each of the elements of the first range
-    ///                     as a projection operation before the actual predicate
-    ///                     \a is invoked.
-    /// \param proj2        Specifies the function (or function object) which
-    ///                     will be invoked for each of the elements of the second range
-    ///                     as a projection operation before the actual predicate
-    ///                     \a is invoked.
+    ///                     that will be copied from
+    /// \param last1        Refers to sentinel value denoting the end of the
+    ///                     sequence of elements the algorithm will be applied to.
+    /// \param first2       Refers to the beginning of the destination range.
+    /// \param last2        Refers to sentinel value denoting the end of the
+    ///                     second range the algorithm will be applied to.
     ///
-    /// The comparison operations in the parallel \a lexicographical_compare
-    /// algorithm invoked with an execution policy object of type
-    /// \a sequenced_policy execute in sequential order in the
-    /// calling thread.
+    /// The assignments in the parallel \a uninitialized_copy algorithm invoked
+    /// without an execution policy object will execute in sequential order in
+    /// the calling thread.
     ///
-    /// The comparison operations in the parallel \a lexicographical_compare
-    /// algorithm invoked with an execution policy object of type
-    /// \a parallel_policy
-    /// or \a parallel_task_policy are permitted to execute in an unordered
-    /// fashion in unspecified threads, and indeterminately sequenced
-    /// within each thread.
+    /// \returns  The \a uninitialized_copy algorithm returns an
+    ///           \a in_out_result<InIter, FwdIter>.
+    ///            The \a uninitialized_copy algorithm returns the input iterator
+    ///           to one past the last element copied from and the output
+    ///           iterator to the element in the destination range, one past
+    ///           the last element copied.
     ///
-    /// \note     Lexicographical comparison is an operation with the
-    ///           following properties
-    ///             - Two ranges are compared element by element
-    ///             - The first mismatching element defines which range
-    ///               is lexicographically
-    ///               \a less or \a greater than the other
-    ///             - If one range is a prefix of another, the shorter range is
-    ///               lexicographically \a less than the other
-    ///             - If two ranges have equivalent elements and are of the same length,
-    ///               then the ranges are lexicographically \a equal
-    ///             - An empty range is lexicographically \a less than any non-empty
-    ///               range
-    ///             - Two empty ranges are lexicographically \a equal
-    ///
-    /// \returns  The \a lexicographically_compare algorithm returns a
-    ///           \a hpx::future<bool> if the execution policy is of type
-    ///           \a sequenced_task_policy or
-    ///           \a parallel_task_policy and
-    ///           returns \a bool otherwise.
-    ///           The \a lexicographically_compare algorithm returns true
-    ///           if the first range is lexicographically less, otherwise
-    ///           it returns false.
-    ///           range [first2, last2), it returns false.
-    template <typename InIter1, typename Sent1, typename InIter2,
-        typename Sent2,
-        typename Proj1 = hpx::parallel::util::projection_identity,
-        typename Proj2 = hpx::parallel::util::projection_identity,
-        typename Pred = detail::less>
-    bool lexicographical_compare(InIter1 first1, Sent1 last1, InIter2 first2,
-        Sent2 last2, Pred&& pred = Pred(), Proj1&& proj1 = Proj1(),
-        Proj2&& proj2 = Proj2());
+    template <typename InIter, typename Sent1, typename FwdIter, typename Sent2>
+    hpx::parallel::util::in_out_result<InIter, FwdIter> uninitialized_copy(
+        InIter first1, Sent1 last1, FwdIter first2, Sent2 last2);
 
-    /// Checks if the first range [first1, last1) is lexicographically less than
-    /// the second range [first2, last2). uses a provided predicate to compare
-    /// elements.
+    /// Copies the elements in the range, defined by [first, last), to an
+    /// uninitialized memory area beginning at \a dest. If an exception is
+    /// thrown during the copy operation, the function has no effects.
     ///
-    /// \note   Complexity: At most 2 * min(N1, N2) applications of the comparison
-    ///         operation, where N1 = std::distance(first1, last)
-    ///         and N2 = std::distance(first2, last2).
+    /// \note   Complexity: Performs exactly \a last - \a first assignments.
     ///
     /// \tparam ExPolicy    The type of the execution policy to use (deduced).
     ///                     It describes the manner in which the execution
     ///                     of the algorithm may be parallelized and the manner
     ///                     in which it executes the assignments.
-    /// \tparam FwdIter1    The type of the source iterators used for the
-    ///                     first range (deduced).
+    /// \tparam FwdIter1    The type of the source iterators used (deduced).
     ///                     This iterator type must meet the requirements of an
-    ///                     forward iterator.
+    ///                     input iterator.
     /// \tparam Sent1       The type of the source sentinel (deduced). This
-    ///                     sentinel type must be a sentinel for FwdIter1.
-    /// \tparam FwdIter2    The type of the source iterators used for the
-    ///                     second range (deduced).
-    ///                     This iterator type must meet the requirements of an
+    ///                     sentinel type must be a sentinel for InIter.
+    /// \tparam FwdIter2    The type of the iterator representing the
+    ///                     destination range (deduced).
+    ///                     This iterator type must meet the requirements of a
     ///                     forward iterator.
     /// \tparam Sent2       The type of the source sentinel (deduced). This
-    ///                     sentinel type must be a sentinel for FwdIter2.
-    /// \tparam Pred        The type of an optional function/function object to use.
-    ///                     Unlike its sequential form, the parallel
-    ///                     overload of \a lexicographical_compare requires \a Pred to
-    ///                     meet the requirements of \a CopyConstructible. This defaults
-    ///                     to std::less<>
-    /// \tparam Proj1       The type of an optional projection function for FwdIter1. This
-    ///                     defaults to \a util::projection_identity
-    /// \tparam Proj2       The type of an optional projection function for FwdIter2. This
-    ///                     defaults to \a util::projection_identity
+    ///                     sentinel type must be a sentinel for InIter2.
     ///
     /// \param policy       The execution policy to use for the scheduling of
     ///                     the iterations.
     /// \param first1       Refers to the beginning of the sequence of elements
-    ///                     of the first range the algorithm will be applied to.
-    /// \param last1        Refers to the end of the sequence of elements of
-    ///                     the first range the algorithm will be applied to.
-    /// \param first2       Refers to the beginning of the sequence of elements
-    ///                     of the second range the algorithm will be applied to.
-    /// \param last2        Refers to the end of the sequence of elements of
-    ///                     the second range the algorithm will be applied to.
-    /// \param pred         Refers to the comparison function that the first
-    ///                     and second ranges will be applied to
-    /// \param proj1        Specifies the function (or function object) which
-    ///                     will be invoked for each of the elements of the first range
-    ///                     as a projection operation before the actual predicate
-    ///                     \a is invoked.
-    /// \param proj2        Specifies the function (or function object) which
-    ///                     will be invoked for each of the elements of the second range
-    ///                     as a projection operation before the actual predicate
-    ///                     \a is invoked.
+    ///                     that will be copied from
+    /// \param last1        Refers to sentinel value denoting the end of the
+    ///                     sequence of elements the algorithm will be applied to.
+    /// \param first2       Refers to the beginning of the destination range.
+    /// \param last2        Refers to sentinel value denoting the end of the
+    ///                     second range the algorithm will be applied to.
     ///
-    /// The comparison operations in the parallel \a lexicographical_compare
-    /// algorithm invoked with an execution policy object of type
-    /// \a sequenced_policy execute in sequential order in the
-    /// calling thread.
+    /// The assignments in the parallel \a uninitialized_copy algorithm invoked
+    /// with an execution policy object of type \a sequenced_policy
+    /// execute in sequential order in the calling thread.
     ///
-    /// The comparison operations in the parallel \a lexicographical_compare
-    /// algorithm invoked with an execution policy object of type
-    /// \a parallel_policy
-    /// or \a parallel_task_policy are permitted to execute in an unordered
-    /// fashion in unspecified threads, and indeterminately sequenced
+    /// The assignments in the parallel \a uninitialized_copy algorithm invoked
+    /// with an execution policy object of type \a parallel_policy or
+    /// \a parallel_task_policy are permitted to execute in an
+    /// unordered fashion in unspecified threads, and indeterminately sequenced
     /// within each thread.
     ///
-    /// \note     Lexicographical comparison is an operation with the
-    ///           following properties
-    ///             - Two ranges are compared element by element
-    ///             - The first mismatching element defines which range
-    ///               is lexicographically
-    ///               \a less or \a greater than the other
-    ///             - If one range is a prefix of another, the shorter range is
-    ///               lexicographically \a less than the other
-    ///             - If two ranges have equivalent elements and are of the same length,
-    ///               then the ranges are lexicographically \a equal
-    ///             - An empty range is lexicographically \a less than any non-empty
-    ///               range
-    ///             - Two empty ranges are lexicographically \a equal
-    ///
-    /// \returns  The \a lexicographically_compare algorithm returns a
-    ///           \a hpx::future<bool> if the execution policy is of type
+    /// \returns  The \a uninitialized_copy algorithm returns a
+    ///           \a hpx::future<in_out_result<InIter, FwdIter>>, if the execution policy is of type
     ///           \a sequenced_task_policy or
     ///           \a parallel_task_policy and
-    ///           returns \a bool otherwise.
-    ///           The \a lexicographically_compare algorithm returns true
-    ///           if the first range is lexicographically less, otherwise
-    ///           it returns false.
-    ///           range [first2, last2), it returns false.
-
-    template <typename ExPolicy, typename FwdIter1, typename Sent1,
-        typename FwdIter2, typename Sent2,
-        typename Proj1 = hpx::parallel::util::projection_identity,
-        typename Proj2 = hpx::parallel::util::projection_identity,
-        typename Pred = detail::less>
-    typename parallel::util::detail::algorithm_result<ExPolicy, bool>::type
-    lexicographical_compare(ExPolicy&& policy, FwdIter1 first1, Sent1 last1,
-        FwdIter2 first2, Sent2 last2, Pred&& pred = Pred(),
-        Proj1&& proj1 = Proj1(), Proj2&& proj2 = Proj2());
-
-    /// Checks if the first range rng1 is lexicographically less than
-    /// the second range rng2. uses a provided predicate to compare
-    /// elements.
+    ///           returns \a in_out_result<InIter, FwdIter> otherwise.
+    ///            The \a uninitialized_copy algorithm returns the input iterator
+    ///           to one past the last element copied from and the output
+    ///           iterator to the element in the destination range, one past
+    ///           the last element copied.
     ///
-    /// \note   Complexity: At most 2 * min(N1, N2) applications of the comparison
-    ///         operation, where N1 = std::distance(std::begin(rng1), std::end(rng1))
-    ///         and N2 = std::distance(std::begin(rng2), std::end(rng2)).
+    template <typename ExPolicy, typename FwdIter1, typename Sent1,
+        typename FwdIter2, typename Sent2>
+    typename parallel::util::detail::algorithm_result<ExPolicy,
+        parallel::util::in_out_result<FwdIter1, FwdIter2>>::type
+    uninitialized_copy(ExPolicy&& policy, FwdIter1 first1, Sent1 last1,
+        FwdIter2 first2, Sent2 last2);
+
+    /// Copies the elements in the range, defined by [first, last), to an
+    /// uninitialized memory area beginning at \a dest. If an exception is
+    /// thrown during the copy operation, the function has no effects.
+    ///
+    /// \note   Complexity: Performs exactly \a last - \a first assignments.
     ///
     /// \tparam Rng1        The type of the source range used (deduced).
     ///                     The iterators extracted from this range type must
     ///                     meet the requirements of an input iterator.
-    /// \tparam Rng2        The type of the source range used (deduced).
+    /// \tparam Rng2        The type of the destination range used (deduced).
     ///                     The iterators extracted from this range type must
-    ///                     meet the requirements of an input iterator.
-    /// \tparam Pred        The type of an optional function/function object to use.
-    ///                     Unlike its sequential form, the parallel
-    ///                     overload of \a lexicographical_compare requires \a Pred to
-    ///                     meet the requirements of \a CopyConstructible. This defaults
-    ///                     to std::less<>
-    /// \tparam Proj1       The type of an optional projection function for elements of the first range.
-    ///                     This defaults to \a util::projection_identity
-    /// \tparam Proj2       The type of an optional projection function for elements of the second range.
-    ///                     This defaults to \a util::projection_identity
+    ///                     meet the requirements of an forward iterator.
     ///
-    /// \param rng1         Refers to the sequence of elements the algorithm
-    ///                     will be applied to.
-    /// \param rng2         Refers to the sequence of elements the algorithm
-    ///                     will be applied to.
-    /// \param pred         Refers to the comparison function that the first
-    ///                     and second ranges will be applied to
-    /// \param proj1        Specifies the function (or function object) which
-    ///                     will be invoked for each of the elements of the first range
-    ///                     as a projection operation before the actual predicate
-    ///                     \a is invoked.
-    /// \param proj2        Specifies the function (or function object) which
-    ///                     will be invoked for each of the elements of the second range
-    ///                     as a projection operation before the actual predicate
-    ///                     \a is invoked.
+    /// \param rng1         Refers to the range from which the elements
+    ///                     will be copied from
+    /// \param rng2         Refers to the range to which the elements
+    ///                     will be copied to
     ///
-    /// The comparison operations in the parallel \a lexicographical_compare
-    /// algorithm invoked without an execution policy object  execute in sequential
-    /// order in the calling thread.
+    /// The assignments in the parallel \a uninitialized_copy algorithm invoked
+    /// without an execution policy object will execute in sequential order in
+    /// the calling thread.
     ///
-    /// \note     Lexicographical comparison is an operation with the
-    ///           following properties
-    ///             - Two ranges are compared element by element
-    ///             - The first mismatching element defines which range
-    ///               is lexicographically
-    ///               \a less or \a greater than the other
-    ///             - If one range is a prefix of another, the shorter range is
-    ///               lexicographically \a less than the other
-    ///             - If two ranges have equivalent elements and are of the same length,
-    ///               then the ranges are lexicographically \a equal
-    ///             - An empty range is lexicographically \a less than any non-empty
-    ///               range
-    ///             - Two empty ranges are lexicographically \a equal
+    /// \returns  The \a uninitialized_copy algorithm returns an
+    ///           \a in_out_result<typename hpx::traits::range_traits<Rng1>::iterator_type,
+    ///           typename hpx::traits::range_traits<Rng2>::iterator_type>.
+    ///           The \a uninitialized_copy algorithm returns the input iterator
+    ///           to one past the last element copied from and the output
+    ///           iterator to the element in the destination range, one past
+    ///           the last element copied.
     ///
-    /// \returns  The \a lexicographically_compare algorithm returns \a bool.
-    ///           The \a lexicographically_compare algorithm returns true
-    ///           if the first range is lexicographically less, otherwise
-    ///           it returns false.
-    ///           range [first2, last2), it returns false.
-    template <typename Rng1, typename Rng2,
-        typename Proj1 = hpx::parallel::util::projection_identity,
-        typename Proj2 = hpx::parallel::util::projection_identity,
-        typename Pred = detail::less>
-    bool lexicographical_compare(Rng1&& rng1, Rng2&& rng2, Pred&& pred = Pred(),
-        Proj1&& proj1 = Proj1(), Proj2&& proj2 = Proj2());
+    template <typename Rng1, typename Rng2>
+    hpx::parallel::util::in_out_result<
+        typename hpx::traits::range_traits<Rng1>::iterator_type,
+        typename hpx::traits::range_traits<Rng2>::iterator_type>
+    uninitialized_copy(Rng1&& rng1, Rng2&& rng2);
 
-    /// Checks if the first range rng1 is lexicographically less than
-    /// the second range rng2. uses a provided predicate to compare
-    /// elements.
+    /// Copies the elements in the range, defined by [first, last), to an
+    /// uninitialized memory area beginning at \a dest. If an exception is
+    /// thrown during the copy operation, the function has no effects.
     ///
-    /// \note   Complexity: At most 2 * min(N1, N2) applications of the comparison
-    ///         operation, where N1 = std::distance(std::begin(rng1), std::end(rng1))
-    ///         and N2 = std::distance(std::begin(rng2), std::end(rng2)).
+    /// \note   Complexity: Performs exactly \a last - \a first assignments.
     ///
     /// \tparam ExPolicy    The type of the execution policy to use (deduced).
     ///                     It describes the manner in which the execution
@@ -291,79 +162,147 @@ namespace hpx { namespace ranges {
     /// \tparam Rng1        The type of the source range used (deduced).
     ///                     The iterators extracted from this range type must
     ///                     meet the requirements of an input iterator.
-    /// \tparam Rng2        The type of the source range used (deduced).
+    /// \tparam Rng2        The type of the destination range used (deduced).
     ///                     The iterators extracted from this range type must
-    ///                     meet the requirements of an input iterator.
-    /// \tparam Pred        The type of an optional function/function object to use.
-    ///                     Unlike its sequential form, the parallel
-    ///                     overload of \a lexicographical_compare requires \a Pred to
-    ///                     meet the requirements of \a CopyConstructible. This defaults
-    ///                     to std::less<>
-    /// \tparam Proj1       The type of an optional projection function for elements of the first range.
-    ///                     This defaults to \a util::projection_identity
-    /// \tparam Proj2       The type of an optional projection function for elements of the second range.
-    ///                     This defaults to \a util::projection_identity
+    ///                     meet the requirements of an forward iterator.
     ///
     /// \param policy       The execution policy to use for the scheduling of
     ///                     the iterations.
-    /// \param rng1         Refers to the sequence of elements the algorithm
-    ///                     will be applied to.
-    /// \param rng2         Refers to the sequence of elements the algorithm
-    ///                     will be applied to.
-    /// \param pred         Refers to the comparison function that the first
-    ///                     and second ranges will be applied to
-    /// \param proj1        Specifies the function (or function object) which
-    ///                     will be invoked for each of the elements of the first range
-    ///                     as a projection operation before the actual predicate
-    ///                     \a is invoked.
-    /// \param proj2        Specifies the function (or function object) which
-    ///                     will be invoked for each of the elements of the second range
-    ///                     as a projection operation before the actual predicate
-    ///                     \a is invoked.
+    /// \param rng1         Refers to the range from which the elements
+    ///                     will be copied from
+    /// \param rng2         Refers to the range to which the elements
+    ///                     will be copied to
     ///
-    /// The comparison operations in the parallel \a lexicographical_compare
-    /// algorithm invoked with an execution policy object of type
+    /// The assignments in the parallel \a uninitialized_copy algorithm invoked
+    /// with an execution policy object of type \a sequenced_policy
+    /// execute in sequential order in the calling thread.
+    ///
+    /// The assignments in the parallel \a uninitialized_copy algorithm invoked
+    /// with an execution policy object of type \a parallel_policy or
+    /// \a parallel_task_policy are permitted to execute in an
+    /// unordered fashion in unspecified threads, and indeterminately sequenced
+    /// within each thread.
+    ///
+    /// \returns  The \a uninitialized_copy algorithm returns a
+    ///           \a hpx::future<in_out_result<InIter, FwdIter>>, if the execution policy is of type
+    ///           \a sequenced_task_policy or
+    ///           \a parallel_task_policy and
+    ///           returns \a in_out_result<typename hpx::traits::range_traits<Rng1>::iterator_type
+    ///           , typename hpx::traits::range_traits<Rng2>::iterator_type> otherwise.
+    ///            The \a uninitialized_copy algorithm returns the input iterator
+    ///           to one past the last element copied from and the output
+    ///           iterator to the element in the destination range, one past
+    ///           the last element copied.
+    ///
+    template <typename ExPolicy, typename Rng1, typename Rng2>
+    typename parallel::util::detail::algorithm_result<ExPolicy,
+        hpx::parallel::util::in_out_result<
+            typename hpx::traits::range_traits<Rng1>::iterator_type,
+            typename hpx::traits::range_traits<Rng2>::iterator_type>>::type
+    uninitialized_copy(ExPolicy&& policy, Rng1&& rng1, Rng2&& rng2);
+
+    /// Copies the elements in the range [first, first + count), starting from
+    /// first and proceeding to first + count - 1., to another range beginning
+    /// at dest. If an exception is thrown during the copy operation, the
+    /// function has no effects.
+    ///
+    /// \note   Complexity: Performs exactly \a last - \a first assignments.
+    ///
+    /// \tparam InIter      The type of the source iterators used (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     input iterator.
+    /// \tparam Size        The type of the argument specifying the number of
+    ///                     elements to apply \a f to.
+    /// \tparam FwdIter     The type of the iterator representing the
+    ///                     destination range (deduced).
+    ///                     This iterator type must meet the requirements of a
+    ///                     forward iterator.
+    /// \tparam Sent2       The type of the source sentinel (deduced). This
+    ///                     sentinel type must be a sentinel for FwdIter.
+    ///
+    /// \param first1       Refers to the beginning of the sequence of elements
+    ///                     that will be copied from
+    /// \param count        Refers to the number of elements starting at
+    ///                     \a first the algorithm will be applied to.
+    /// \param first2       Refers to the beginning of the destination range.
+    /// \param last2        Refers to sentinel value denoting the end of the
+    ///                     second range the algorithm will be applied to.
+    ///
+    /// The assignments in the parallel \a uninitialized_copy_n algorithm
+    /// invoked with an execution policy object of type
     /// \a sequenced_policy execute in sequential order in the
     /// calling thread.
     ///
-    /// The comparison operations in the parallel \a lexicographical_compare
-    /// algorithm invoked with an execution policy object of type
-    /// \a parallel_policy
-    /// or \a parallel_task_policy are permitted to execute in an unordered
-    /// fashion in unspecified threads, and indeterminately sequenced
+    /// \returns  The \a uninitialized_copy_n algorithm returns
+    ///           \a in_out_result<InIter, FwdIter>.
+    ///           The \a uninitialized_copy_n algorithm returns the output
+    ///           iterator to the element in the destination range, one past
+    ///           the last element copied.
+    ///
+    template <typename InIter, typename Size, typename FwdIter, typename Sent2>
+    hpx::parallel::util::in_out_result<InIter, FwdIter> uninitialized_copy_n(
+        InIter first1, Size count, FwdIter first2, Sent2 last2);
+
+    /// Copies the elements in the range [first, first + count), starting from
+    /// first and proceeding to first + count - 1., to another range beginning
+    /// at dest. If an exception is thrown during the copy operation, the
+    /// function has no effects.
+    ///
+    /// \note   Complexity: Performs exactly \a last - \a first assignments.
+    ///
+    /// \tparam ExPolicy    The type of the execution policy to use (deduced).
+    ///                     It describes the manner in which the execution
+    ///                     of the algorithm may be parallelized and the manner
+    ///                     in which it executes the assignments.
+    /// \tparam FwdIter1    The type of the source iterators used (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     input iterator.
+    /// \tparam Size        The type of the argument specifying the number of
+    ///                     elements to apply \a f to.
+    /// \tparam FwdIter2    The type of the iterator representing the
+    ///                     destination range (deduced).
+    ///                     This iterator type must meet the requirements of a
+    ///                     forward iterator.
+    /// \tparam Sent2       The type of the source sentinel (deduced). This
+    ///                     sentinel type must be a sentinel for InIter2.
+    ///
+    /// \param policy       The execution policy to use for the scheduling of
+    ///                     the iterations.
+    /// \param first1       Refers to the beginning of the sequence of elements
+    ///                     that will be copied from
+    /// \param count        Refers to the number of elements starting at
+    ///                     \a first the algorithm will be applied to.
+    /// \param first2       Refers to the beginning of the destination range.
+    /// \param last1        Refers to sentinel value denoting the end of the
+    ///                     second range the algorithm will be applied to.
+    ///
+    /// The assignments in the parallel \a uninitialized_copy_n algorithm
+    /// invoked with an execution policy object of type
+    /// \a sequenced_policy execute in sequential order in the
+    /// calling thread.
+    ///
+    /// The assignments in the parallel \a uninitialized_copy_n algorithm
+    /// invoked with an execution policy object of type
+    /// \a parallel_policy or
+    /// \a parallel_task_policy are permitted to execute in an
+    /// unordered fashion in unspecified threads, and indeterminately sequenced
     /// within each thread.
     ///
-    /// \note     Lexicographical comparison is an operation with the
-    ///           following properties
-    ///             - Two ranges are compared element by element
-    ///             - The first mismatching element defines which range
-    ///               is lexicographically
-    ///               \a less or \a greater than the other
-    ///             - If one range is a prefix of another, the shorter range is
-    ///               lexicographically \a less than the other
-    ///             - If two ranges have equivalent elements and are of the same length,
-    ///               then the ranges are lexicographically \a equal
-    ///             - An empty range is lexicographically \a less than any non-empty
-    ///               range
-    ///             - Two empty ranges are lexicographically \a equal
-    ///
-    /// \returns  The \a lexicographically_compare algorithm returns a
-    ///           \a hpx::future<bool> if the execution policy is of type
-    ///           \a sequenced_task_policy or
+    /// \returns  The \a uninitialized_copy_n algorithm returns a
+    ///           \a hpx::future<in_out_result<FwdIter1, FwdIter2>> if the execution
+    ///           policy is of type \a sequenced_task_policy or
     ///           \a parallel_task_policy and
-    ///           returns \a bool otherwise.
-    ///           The \a lexicographically_compare algorithm returns true
-    ///           if the first range is lexicographically less, otherwise
-    ///           it returns false.
-    ///           range [first2, last2), it returns false.
-
-    template <typename ExPolicy, typename Rng1, typename Rng2,
-        typename Proj1 = hpx::parallel::util::projection_identity,
-        typename Proj2 = hpx::parallel::util::projection_identity,
-        typename Pred = detail::less>
-    typename parallel::util::detail::algorithm_result<ExPolicy, bool>::type
-    lexicographical_compare(ExPolicy&& policy, Rng1&& rng1, Rng2&& rng2,
-        Pred&& pred = Pred(), Proj1&& proj1 = Proj1(), Proj2&& proj2 = Proj2());
+    ///           returns \a FwdIter2 otherwise.
+    ///           The \a uninitialized_copy_n algorithm returns the output
+    ///           iterator to the element in the destination range, one past
+    ///           the last element copied.
+    ///
+    template <typename ExPolicy, typename FwdIter1, typename Size,
+        typename FwdIter2, typename Sent2>
+    typename parallel::util::detail::algorithm_result<ExPolicy,
+        parallel::util::in_out_result<FwdIter1, FwdIter2>>::type
+    uninitialized_copy_n(ExPolicy&& policy, FwdIter1 first1, Size count,
+        FwdIter2 first2, Sent2 last2);
 }}    // namespace hpx::ranges
 #else
 
@@ -407,8 +346,8 @@ namespace hpx { namespace ranges {
                 "Requires at least forward iterator.");
 
             return hpx::parallel::v1::detail::uninitialized_copy_sent<
-                    parallel::util::in_out_result<InIter, FwdIter>>()
-                    .call(hpx::execution::seq, first1, last1, first2, last2);
+                parallel::util::in_out_result<InIter, FwdIter>>()
+                .call(hpx::execution::seq, first1, last1, first2, last2);
         }
 
         // clang-format off
@@ -529,7 +468,8 @@ namespace hpx { namespace ranges {
             std::size_t d = parallel::v1::detail::distance(first2, last2);
             return hpx::parallel::v1::detail::uninitialized_copy_n<
                 parallel::util::in_out_result<InIter, FwdIter>>()
-                .call(hpx::execution::seq, first1, count <= d ? count : d, first2);
+                .call(hpx::execution::seq, first1, count <= d ? count : d,
+                    first2);
         }
 
         // clang-format off
@@ -556,9 +496,8 @@ namespace hpx { namespace ranges {
             std::size_t d = parallel::v1::detail::distance(first2, last2);
             return hpx::parallel::v1::detail::uninitialized_copy_n<
                 parallel::util::in_out_result<FwdIter1, FwdIter2>>()
-                    .call(std::forward<ExPolicy>(policy), first1,
-                        count <= d ? count : d,
-                    first2);
+                .call(std::forward<ExPolicy>(policy), first1,
+                    count <= d ? count : d, first2);
         }
     } uninitialized_copy_n{};
 }}    // namespace hpx::ranges

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/uninitialized_copy.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/uninitialized_copy.hpp
@@ -34,7 +34,7 @@ namespace hpx { namespace ranges {
     /// \param first1       Refers to the beginning of the sequence of elements
     ///                     that will be copied from
     /// \param last1        Refers to sentinel value denoting the end of the
-    ///                     sequence of elements the algorithm will be applied to.
+    ///                     sequence of elements the algorithm will be applied
     /// \param first2       Refers to the beginning of the destination range.
     /// \param last2        Refers to sentinel value denoting the end of the
     ///                     second range the algorithm will be applied to.
@@ -45,7 +45,7 @@ namespace hpx { namespace ranges {
     ///
     /// \returns  The \a uninitialized_copy algorithm returns an
     ///           \a in_out_result<InIter, FwdIter>.
-    ///            The \a uninitialized_copy algorithm returns the input iterator
+    ///           The \a uninitialized_copy algorithm returns an input iterator
     ///           to one past the last element copied from and the output
     ///           iterator to the element in the destination range, one past
     ///           the last element copied.
@@ -81,7 +81,7 @@ namespace hpx { namespace ranges {
     /// \param first1       Refers to the beginning of the sequence of elements
     ///                     that will be copied from
     /// \param last1        Refers to sentinel value denoting the end of the
-    ///                     sequence of elements the algorithm will be applied to.
+    ///                     sequence of elements the algorithm will be applied.
     /// \param first2       Refers to the beginning of the destination range.
     /// \param last2        Refers to sentinel value denoting the end of the
     ///                     second range the algorithm will be applied to.
@@ -97,11 +97,11 @@ namespace hpx { namespace ranges {
     /// within each thread.
     ///
     /// \returns  The \a uninitialized_copy algorithm returns a
-    ///           \a hpx::future<in_out_result<InIter, FwdIter>>, if the execution policy is of type
-    ///           \a sequenced_task_policy or
-    ///           \a parallel_task_policy and
+    ///           \a hpx::future<in_out_result<InIter, FwdIter>>, if the
+    ///           execution policy is of type \a sequenced_task_policy
+    ///           or \a parallel_task_policy and
     ///           returns \a in_out_result<InIter, FwdIter> otherwise.
-    ///            The \a uninitialized_copy algorithm returns the input iterator
+    ///           The \a uninitialized_copy algorithm returns an input iterator
     ///           to one past the last element copied from and the output
     ///           iterator to the element in the destination range, one past
     ///           the last element copied.
@@ -136,9 +136,10 @@ namespace hpx { namespace ranges {
     /// the calling thread.
     ///
     /// \returns  The \a uninitialized_copy algorithm returns an
-    ///           \a in_out_result<typename hpx::traits::range_traits<Rng1>::iterator_type,
-    ///           typename hpx::traits::range_traits<Rng2>::iterator_type>.
-    ///           The \a uninitialized_copy algorithm returns the input iterator
+    ///           \a in_out_result<typename hpx::traits::range_traits<Rng1>
+    ///           ::iterator_type, typename hpx::traits::range_traits<Rng2>
+    ///           ::iterator_type>.
+    ///           The \a uninitialized_copy algorithm returns an input iterator
     ///           to one past the last element copied from and the output
     ///           iterator to the element in the destination range, one past
     ///           the last element copied.
@@ -184,15 +185,16 @@ namespace hpx { namespace ranges {
     /// within each thread.
     ///
     /// \returns  The \a uninitialized_copy algorithm returns a
-    ///           \a hpx::future<in_out_result<InIter, FwdIter>>, if the execution policy is of type
-    ///           \a sequenced_task_policy or
-    ///           \a parallel_task_policy and
-    ///           returns \a in_out_result<typename hpx::traits::range_traits<Rng1>::iterator_type
-    ///           , typename hpx::traits::range_traits<Rng2>::iterator_type> otherwise.
-    ///            The \a uninitialized_copy algorithm returns the input iterator
-    ///           to one past the last element copied from and the output
-    ///           iterator to the element in the destination range, one past
-    ///           the last element copied.
+    ///           \a hpx::future<in_out_result<InIter, FwdIter>>, if the
+    ///           execution policy is of type \a sequenced_task_policy
+    ///           or \a parallel_task_policy and
+    ///           returns \a in_out_result<
+    ///             typename hpx::traits::range_traits<Rng1>::iterator_type
+    ///           , typename hpx::traits::range_traits<Rng2>::iterator_type>
+    ///           otherwise. The \a uninitialized_copy algorithm returns the
+    ///           input iterator to one past the last element copied from and
+    ///           the output iterator to the element in the destination range,
+    ///           one past the last element copied.
     ///
     template <typename ExPolicy, typename Rng1, typename Rng2>
     typename parallel::util::detail::algorithm_result<ExPolicy,
@@ -289,8 +291,8 @@ namespace hpx { namespace ranges {
     /// within each thread.
     ///
     /// \returns  The \a uninitialized_copy_n algorithm returns a
-    ///           \a hpx::future<in_out_result<FwdIter1, FwdIter2>> if the execution
-    ///           policy is of type \a sequenced_task_policy or
+    ///           \a hpx::future<in_out_result<FwdIter1, FwdIter2>> if the
+    ///           execution policy is of type \a sequenced_task_policy or
     ///           \a parallel_task_policy and
     ///           returns \a FwdIter2 otherwise.
     ///           The \a uninitialized_copy_n algorithm returns the output

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/uninitialized_copy.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/uninitialized_copy.hpp
@@ -1,0 +1,538 @@
+//  Copyright (c) 2020 ETH Zurich
+//  Copyright (c) 2014 Grant Mercer
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+/// \file parallel/container_algorithms/uninitialized_copy.hpp
+
+#pragma once
+
+#if defined(DOXYGEN)
+
+namespace hpx { namespace ranges {
+
+    /// Checks if the first range [first1, last1) is lexicographically less than
+    /// the second range [first2, last2). uses a provided predicate to compare
+    /// elements.
+    ///
+    /// \note   Complexity: At most 2 * min(N1, N2) applications of the comparison
+    ///         operation, where N1 = std::distance(first1, last)
+    ///         and N2 = std::distance(first2, last2).
+    ///
+    /// \tparam InIter1     The type of the source iterators used for the
+    ///                     first range (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     input iterator.
+    /// \tparam Sent1       The type of the source sentinel (deduced). This
+    ///                     sentinel type must be a sentinel for InIter1.
+    /// \tparam InIter2     The type of the source iterators used for the
+    ///                     second range (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     input iterator.
+    /// \tparam Sent2       The type of the source sentinel (deduced). This
+    ///                     sentinel type must be a sentinel for InIter2.
+    /// \tparam Pred        The type of an optional function/function object to use.
+    ///                     Unlike its sequential form, the parallel
+    ///                     overload of \a lexicographical_compare requires \a Pred to
+    ///                     meet the requirements of \a CopyConstructible. This defaults
+    ///                     to std::less<>
+    /// \tparam Proj1       The type of an optional projection function for FwdIter1. This
+    ///                     defaults to \a util::projection_identity
+    /// \tparam Proj2       The type of an optional projection function for FwdIter2. This
+    ///                     defaults to \a util::projection_identity
+    ///
+    /// \param first1       Refers to the beginning of the sequence of elements
+    ///                     of the first range the algorithm will be applied to.
+    /// \param last1        Refers to the end of the sequence of elements of
+    ///                     the first range the algorithm will be applied to.
+    /// \param first2       Refers to the beginning of the sequence of elements
+    ///                     of the second range the algorithm will be applied to.
+    /// \param last2        Refers to the end of the sequence of elements of
+    ///                     the second range the algorithm will be applied to.
+    /// \param pred         Refers to the comparison function that the first
+    ///                     and second ranges will be applied to
+    /// \param proj1        Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements of the first range
+    ///                     as a projection operation before the actual predicate
+    ///                     \a is invoked.
+    /// \param proj2        Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements of the second range
+    ///                     as a projection operation before the actual predicate
+    ///                     \a is invoked.
+    ///
+    /// The comparison operations in the parallel \a lexicographical_compare
+    /// algorithm invoked with an execution policy object of type
+    /// \a sequenced_policy execute in sequential order in the
+    /// calling thread.
+    ///
+    /// The comparison operations in the parallel \a lexicographical_compare
+    /// algorithm invoked with an execution policy object of type
+    /// \a parallel_policy
+    /// or \a parallel_task_policy are permitted to execute in an unordered
+    /// fashion in unspecified threads, and indeterminately sequenced
+    /// within each thread.
+    ///
+    /// \note     Lexicographical comparison is an operation with the
+    ///           following properties
+    ///             - Two ranges are compared element by element
+    ///             - The first mismatching element defines which range
+    ///               is lexicographically
+    ///               \a less or \a greater than the other
+    ///             - If one range is a prefix of another, the shorter range is
+    ///               lexicographically \a less than the other
+    ///             - If two ranges have equivalent elements and are of the same length,
+    ///               then the ranges are lexicographically \a equal
+    ///             - An empty range is lexicographically \a less than any non-empty
+    ///               range
+    ///             - Two empty ranges are lexicographically \a equal
+    ///
+    /// \returns  The \a lexicographically_compare algorithm returns a
+    ///           \a hpx::future<bool> if the execution policy is of type
+    ///           \a sequenced_task_policy or
+    ///           \a parallel_task_policy and
+    ///           returns \a bool otherwise.
+    ///           The \a lexicographically_compare algorithm returns true
+    ///           if the first range is lexicographically less, otherwise
+    ///           it returns false.
+    ///           range [first2, last2), it returns false.
+    template <typename InIter1, typename Sent1, typename InIter2,
+        typename Sent2,
+        typename Proj1 = hpx::parallel::util::projection_identity,
+        typename Proj2 = hpx::parallel::util::projection_identity,
+        typename Pred = detail::less>
+    bool lexicographical_compare(InIter1 first1, Sent1 last1, InIter2 first2,
+        Sent2 last2, Pred&& pred = Pred(), Proj1&& proj1 = Proj1(),
+        Proj2&& proj2 = Proj2());
+
+    /// Checks if the first range [first1, last1) is lexicographically less than
+    /// the second range [first2, last2). uses a provided predicate to compare
+    /// elements.
+    ///
+    /// \note   Complexity: At most 2 * min(N1, N2) applications of the comparison
+    ///         operation, where N1 = std::distance(first1, last)
+    ///         and N2 = std::distance(first2, last2).
+    ///
+    /// \tparam ExPolicy    The type of the execution policy to use (deduced).
+    ///                     It describes the manner in which the execution
+    ///                     of the algorithm may be parallelized and the manner
+    ///                     in which it executes the assignments.
+    /// \tparam FwdIter1    The type of the source iterators used for the
+    ///                     first range (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     forward iterator.
+    /// \tparam Sent1       The type of the source sentinel (deduced). This
+    ///                     sentinel type must be a sentinel for FwdIter1.
+    /// \tparam FwdIter2    The type of the source iterators used for the
+    ///                     second range (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     forward iterator.
+    /// \tparam Sent2       The type of the source sentinel (deduced). This
+    ///                     sentinel type must be a sentinel for FwdIter2.
+    /// \tparam Pred        The type of an optional function/function object to use.
+    ///                     Unlike its sequential form, the parallel
+    ///                     overload of \a lexicographical_compare requires \a Pred to
+    ///                     meet the requirements of \a CopyConstructible. This defaults
+    ///                     to std::less<>
+    /// \tparam Proj1       The type of an optional projection function for FwdIter1. This
+    ///                     defaults to \a util::projection_identity
+    /// \tparam Proj2       The type of an optional projection function for FwdIter2. This
+    ///                     defaults to \a util::projection_identity
+    ///
+    /// \param policy       The execution policy to use for the scheduling of
+    ///                     the iterations.
+    /// \param first1       Refers to the beginning of the sequence of elements
+    ///                     of the first range the algorithm will be applied to.
+    /// \param last1        Refers to the end of the sequence of elements of
+    ///                     the first range the algorithm will be applied to.
+    /// \param first2       Refers to the beginning of the sequence of elements
+    ///                     of the second range the algorithm will be applied to.
+    /// \param last2        Refers to the end of the sequence of elements of
+    ///                     the second range the algorithm will be applied to.
+    /// \param pred         Refers to the comparison function that the first
+    ///                     and second ranges will be applied to
+    /// \param proj1        Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements of the first range
+    ///                     as a projection operation before the actual predicate
+    ///                     \a is invoked.
+    /// \param proj2        Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements of the second range
+    ///                     as a projection operation before the actual predicate
+    ///                     \a is invoked.
+    ///
+    /// The comparison operations in the parallel \a lexicographical_compare
+    /// algorithm invoked with an execution policy object of type
+    /// \a sequenced_policy execute in sequential order in the
+    /// calling thread.
+    ///
+    /// The comparison operations in the parallel \a lexicographical_compare
+    /// algorithm invoked with an execution policy object of type
+    /// \a parallel_policy
+    /// or \a parallel_task_policy are permitted to execute in an unordered
+    /// fashion in unspecified threads, and indeterminately sequenced
+    /// within each thread.
+    ///
+    /// \note     Lexicographical comparison is an operation with the
+    ///           following properties
+    ///             - Two ranges are compared element by element
+    ///             - The first mismatching element defines which range
+    ///               is lexicographically
+    ///               \a less or \a greater than the other
+    ///             - If one range is a prefix of another, the shorter range is
+    ///               lexicographically \a less than the other
+    ///             - If two ranges have equivalent elements and are of the same length,
+    ///               then the ranges are lexicographically \a equal
+    ///             - An empty range is lexicographically \a less than any non-empty
+    ///               range
+    ///             - Two empty ranges are lexicographically \a equal
+    ///
+    /// \returns  The \a lexicographically_compare algorithm returns a
+    ///           \a hpx::future<bool> if the execution policy is of type
+    ///           \a sequenced_task_policy or
+    ///           \a parallel_task_policy and
+    ///           returns \a bool otherwise.
+    ///           The \a lexicographically_compare algorithm returns true
+    ///           if the first range is lexicographically less, otherwise
+    ///           it returns false.
+    ///           range [first2, last2), it returns false.
+
+    template <typename ExPolicy, typename FwdIter1, typename Sent1,
+        typename FwdIter2, typename Sent2,
+        typename Proj1 = hpx::parallel::util::projection_identity,
+        typename Proj2 = hpx::parallel::util::projection_identity,
+        typename Pred = detail::less>
+    typename parallel::util::detail::algorithm_result<ExPolicy, bool>::type
+    lexicographical_compare(ExPolicy&& policy, FwdIter1 first1, Sent1 last1,
+        FwdIter2 first2, Sent2 last2, Pred&& pred = Pred(),
+        Proj1&& proj1 = Proj1(), Proj2&& proj2 = Proj2());
+
+    /// Checks if the first range rng1 is lexicographically less than
+    /// the second range rng2. uses a provided predicate to compare
+    /// elements.
+    ///
+    /// \note   Complexity: At most 2 * min(N1, N2) applications of the comparison
+    ///         operation, where N1 = std::distance(std::begin(rng1), std::end(rng1))
+    ///         and N2 = std::distance(std::begin(rng2), std::end(rng2)).
+    ///
+    /// \tparam Rng1        The type of the source range used (deduced).
+    ///                     The iterators extracted from this range type must
+    ///                     meet the requirements of an input iterator.
+    /// \tparam Rng2        The type of the source range used (deduced).
+    ///                     The iterators extracted from this range type must
+    ///                     meet the requirements of an input iterator.
+    /// \tparam Pred        The type of an optional function/function object to use.
+    ///                     Unlike its sequential form, the parallel
+    ///                     overload of \a lexicographical_compare requires \a Pred to
+    ///                     meet the requirements of \a CopyConstructible. This defaults
+    ///                     to std::less<>
+    /// \tparam Proj1       The type of an optional projection function for elements of the first range.
+    ///                     This defaults to \a util::projection_identity
+    /// \tparam Proj2       The type of an optional projection function for elements of the second range.
+    ///                     This defaults to \a util::projection_identity
+    ///
+    /// \param rng1         Refers to the sequence of elements the algorithm
+    ///                     will be applied to.
+    /// \param rng2         Refers to the sequence of elements the algorithm
+    ///                     will be applied to.
+    /// \param pred         Refers to the comparison function that the first
+    ///                     and second ranges will be applied to
+    /// \param proj1        Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements of the first range
+    ///                     as a projection operation before the actual predicate
+    ///                     \a is invoked.
+    /// \param proj2        Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements of the second range
+    ///                     as a projection operation before the actual predicate
+    ///                     \a is invoked.
+    ///
+    /// The comparison operations in the parallel \a lexicographical_compare
+    /// algorithm invoked without an execution policy object  execute in sequential
+    /// order in the calling thread.
+    ///
+    /// \note     Lexicographical comparison is an operation with the
+    ///           following properties
+    ///             - Two ranges are compared element by element
+    ///             - The first mismatching element defines which range
+    ///               is lexicographically
+    ///               \a less or \a greater than the other
+    ///             - If one range is a prefix of another, the shorter range is
+    ///               lexicographically \a less than the other
+    ///             - If two ranges have equivalent elements and are of the same length,
+    ///               then the ranges are lexicographically \a equal
+    ///             - An empty range is lexicographically \a less than any non-empty
+    ///               range
+    ///             - Two empty ranges are lexicographically \a equal
+    ///
+    /// \returns  The \a lexicographically_compare algorithm returns \a bool.
+    ///           The \a lexicographically_compare algorithm returns true
+    ///           if the first range is lexicographically less, otherwise
+    ///           it returns false.
+    ///           range [first2, last2), it returns false.
+    template <typename Rng1, typename Rng2,
+        typename Proj1 = hpx::parallel::util::projection_identity,
+        typename Proj2 = hpx::parallel::util::projection_identity,
+        typename Pred = detail::less>
+    bool lexicographical_compare(Rng1&& rng1, Rng2&& rng2, Pred&& pred = Pred(),
+        Proj1&& proj1 = Proj1(), Proj2&& proj2 = Proj2());
+
+    /// Checks if the first range rng1 is lexicographically less than
+    /// the second range rng2. uses a provided predicate to compare
+    /// elements.
+    ///
+    /// \note   Complexity: At most 2 * min(N1, N2) applications of the comparison
+    ///         operation, where N1 = std::distance(std::begin(rng1), std::end(rng1))
+    ///         and N2 = std::distance(std::begin(rng2), std::end(rng2)).
+    ///
+    /// \tparam ExPolicy    The type of the execution policy to use (deduced).
+    ///                     It describes the manner in which the execution
+    ///                     of the algorithm may be parallelized and the manner
+    ///                     in which it executes the assignments.
+    /// \tparam Rng1        The type of the source range used (deduced).
+    ///                     The iterators extracted from this range type must
+    ///                     meet the requirements of an input iterator.
+    /// \tparam Rng2        The type of the source range used (deduced).
+    ///                     The iterators extracted from this range type must
+    ///                     meet the requirements of an input iterator.
+    /// \tparam Pred        The type of an optional function/function object to use.
+    ///                     Unlike its sequential form, the parallel
+    ///                     overload of \a lexicographical_compare requires \a Pred to
+    ///                     meet the requirements of \a CopyConstructible. This defaults
+    ///                     to std::less<>
+    /// \tparam Proj1       The type of an optional projection function for elements of the first range.
+    ///                     This defaults to \a util::projection_identity
+    /// \tparam Proj2       The type of an optional projection function for elements of the second range.
+    ///                     This defaults to \a util::projection_identity
+    ///
+    /// \param policy       The execution policy to use for the scheduling of
+    ///                     the iterations.
+    /// \param rng1         Refers to the sequence of elements the algorithm
+    ///                     will be applied to.
+    /// \param rng2         Refers to the sequence of elements the algorithm
+    ///                     will be applied to.
+    /// \param pred         Refers to the comparison function that the first
+    ///                     and second ranges will be applied to
+    /// \param proj1        Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements of the first range
+    ///                     as a projection operation before the actual predicate
+    ///                     \a is invoked.
+    /// \param proj2        Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements of the second range
+    ///                     as a projection operation before the actual predicate
+    ///                     \a is invoked.
+    ///
+    /// The comparison operations in the parallel \a lexicographical_compare
+    /// algorithm invoked with an execution policy object of type
+    /// \a sequenced_policy execute in sequential order in the
+    /// calling thread.
+    ///
+    /// The comparison operations in the parallel \a lexicographical_compare
+    /// algorithm invoked with an execution policy object of type
+    /// \a parallel_policy
+    /// or \a parallel_task_policy are permitted to execute in an unordered
+    /// fashion in unspecified threads, and indeterminately sequenced
+    /// within each thread.
+    ///
+    /// \note     Lexicographical comparison is an operation with the
+    ///           following properties
+    ///             - Two ranges are compared element by element
+    ///             - The first mismatching element defines which range
+    ///               is lexicographically
+    ///               \a less or \a greater than the other
+    ///             - If one range is a prefix of another, the shorter range is
+    ///               lexicographically \a less than the other
+    ///             - If two ranges have equivalent elements and are of the same length,
+    ///               then the ranges are lexicographically \a equal
+    ///             - An empty range is lexicographically \a less than any non-empty
+    ///               range
+    ///             - Two empty ranges are lexicographically \a equal
+    ///
+    /// \returns  The \a lexicographically_compare algorithm returns a
+    ///           \a hpx::future<bool> if the execution policy is of type
+    ///           \a sequenced_task_policy or
+    ///           \a parallel_task_policy and
+    ///           returns \a bool otherwise.
+    ///           The \a lexicographically_compare algorithm returns true
+    ///           if the first range is lexicographically less, otherwise
+    ///           it returns false.
+    ///           range [first2, last2), it returns false.
+
+    template <typename ExPolicy, typename Rng1, typename Rng2,
+        typename Proj1 = hpx::parallel::util::projection_identity,
+        typename Proj2 = hpx::parallel::util::projection_identity,
+        typename Pred = detail::less>
+    typename parallel::util::detail::algorithm_result<ExPolicy, bool>::type
+    lexicographical_compare(ExPolicy&& policy, Rng1&& rng1, Rng2&& rng2,
+        Pred&& pred = Pred(), Proj1&& proj1 = Proj1(), Proj2&& proj2 = Proj2());
+}}    // namespace hpx::ranges
+#else
+
+#include <hpx/config.hpp>
+#include <hpx/algorithms/traits/projected_range.hpp>
+#include <hpx/execution/algorithms/detail/predicates.hpp>
+#include <hpx/executors/execution_policy.hpp>
+#include <hpx/iterator_support/traits/is_iterator.hpp>
+#include <hpx/parallel/algorithms/uninitialized_copy.hpp>
+#include <hpx/parallel/util/detail/algorithm_result.hpp>
+#include <hpx/parallel/util/projection_identity.hpp>
+
+#include <algorithm>
+#include <cstddef>
+#include <iterator>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+namespace hpx { namespace ranges {
+    HPX_INLINE_CONSTEXPR_VARIABLE struct uninitialized_copy_t final
+      : hpx::functional::tag_fallback<uninitialized_copy_t>
+    {
+    private:
+        // clang-format off
+        template <typename InIter, typename Sent1, typename FwdIter, typename Sent2,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::traits::is_iterator<InIter>::value &&
+                hpx::traits::is_sentinel_for<Sent1, InIter>::value &&
+                hpx::traits::is_forward_iterator<FwdIter>::value &&
+                hpx::traits::is_sentinel_for<Sent2, FwdIter>::value
+            )>
+        // clang-format on
+        friend bool tag_fallback_invoke(hpx::ranges::uninitialized_copy_t,
+            InIter first1, Sent1 last1, FwdIter first2, Sent2 last2)
+        {
+            static_assert(hpx::traits::is_input_iterator<InIter>::value,
+                "Requires at least input iterator.");
+            static_assert(hpx::traits::is_forward_iterator<FwdIter>::value,
+                "Requires at least forward iterator.");
+
+
+            return hpx::parallel::v1::detail::uninitialized_copy().call(
+                hpx::execution::seq, first1, last1, first2, last2,
+                std::forward<Pred>(pred), std::forward<Proj1>(proj1),
+                std::forward<Proj2>(proj2));
+        }
+
+        // clang-format off
+        template <typename ExPolicy, typename FwdIter1, typename Sent1,
+            typename FwdIter2, typename Sent2,
+            typename Proj1 = hpx::parallel::util::projection_identity,
+            typename Proj2 = hpx::parallel::util::projection_identity,
+            typename Pred = hpx::parallel::v1::detail::less,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::is_execution_policy<ExPolicy>::value &&
+                hpx::traits::is_forward_iterator<FwdIter1>::value &&
+                hpx::traits::is_sentinel_for<Sent1, FwdIter1>::value &&
+                hpx::traits::is_forward_iterator<FwdIter2>::value &&
+                hpx::traits::is_sentinel_for<Sent2, FwdIter2>::value &&
+                hpx::parallel::traits::is_projected<Proj1, FwdIter1>::value &&
+                hpx::parallel::traits::is_projected<Proj2, FwdIter2>::value &&
+                hpx::parallel::traits::is_indirect_callable<
+                    ExPolicy, Pred,
+                    hpx::parallel::traits::projected<Proj1, FwdIter1>,
+                    hpx::parallel::traits::projected<Proj2, FwdIter2>
+                >::value
+            )>
+        // clang-format on
+        friend typename parallel::util::detail::algorithm_result<ExPolicy,
+            bool>::type
+        tag_fallback_invoke(hpx::ranges::lexicographical_compare_t,
+            ExPolicy&& policy, FwdIter1 first1, Sent1 last1, FwdIter2 first2,
+            Sent2 last2, Pred&& pred = Pred(), Proj1&& proj1 = Proj1(),
+            Proj2&& proj2 = Proj2())
+        {
+            static_assert(hpx::traits::is_forward_iterator<FwdIter1>::value,
+                "Requires at least forward iterator.");
+            static_assert(hpx::traits::is_forward_iterator<FwdIter2>::value,
+                "Requires at least forward iterator.");
+
+            return hpx::parallel::v1::detail::lexicographical_compare().call(
+                std::forward<ExPolicy>(policy), first1, last1, first2, last2,
+                std::forward<Pred>(pred), std::forward<Proj1>(proj1),
+                std::forward<Proj2>(proj2));
+        }
+
+        // clang-format off
+        template <typename Rng1, typename Rng2,
+            typename Proj1 = hpx::parallel::util::projection_identity,
+            typename Proj2 = hpx::parallel::util::projection_identity,
+            typename Pred = hpx::parallel::v1::detail::less,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::traits::is_range<Rng1>::value &&
+                hpx::traits::is_range<Rng2>::value &&
+                hpx::parallel::traits::is_projected_range<Proj1, Rng1>::value &&
+                hpx::parallel::traits::is_projected_range<Proj2, Rng2>::value &&
+                hpx::parallel::traits::is_indirect_callable<
+                    hpx::execution::sequenced_policy, Pred,
+                    hpx::parallel::traits::projected_range<Proj1, Rng1>,
+                    hpx::parallel::traits::projected_range<Proj2, Rng2>
+                >::value
+            )>
+        // clang-format on
+        friend bool tag_fallback_invoke(hpx::ranges::lexicographical_compare_t,
+            Rng1&& rng1, Rng2&& rng2, Pred&& pred = Pred(),
+            Proj1&& proj1 = Proj1(), Proj2&& proj2 = Proj2())
+        {
+            using iterator_type1 =
+                typename hpx::traits::range_traits<Rng1>::iterator_type;
+            using iterator_type2 =
+                typename hpx::traits::range_traits<Rng2>::iterator_type;
+
+            static_assert(hpx::traits::is_input_iterator<iterator_type1>::value,
+                "Requires at least input iterator.");
+
+            static_assert(hpx::traits::is_input_iterator<iterator_type2>::value,
+                "Requires at least input iterator.");
+
+            return hpx::parallel::v1::detail::lexicographical_compare().call(
+                hpx::execution::seq, std::begin(rng1), std::end(rng1),
+                std::begin(rng2), std::end(rng2), std::forward<Pred>(pred),
+                std::forward<Proj1>(proj1), std::forward<Proj2>(proj2));
+        }
+
+        // clang-format off
+        template <typename ExPolicy, typename Rng1, typename Rng2,
+            typename Proj1 = hpx::parallel::util::projection_identity,
+            typename Proj2 = hpx::parallel::util::projection_identity,
+            typename Pred = hpx::parallel::v1::detail::less,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::is_execution_policy<ExPolicy>::value &&
+                hpx::traits::is_range<Rng1>::value &&
+                hpx::traits::is_range<Rng2>::value &&
+                hpx::parallel::traits::is_projected_range<Proj1, Rng1>::value &&
+                hpx::parallel::traits::is_projected_range<Proj2, Rng2>::value &&
+                hpx::parallel::traits::is_indirect_callable<
+                    ExPolicy, Pred,
+                    hpx::parallel::traits::projected_range<Proj1, Rng1>,
+                    hpx::parallel::traits::projected_range<Proj2, Rng2>
+                >::value
+            )>
+        // clang-format on
+        friend typename parallel::util::detail::algorithm_result<ExPolicy,
+            bool>::type
+        tag_fallback_invoke(hpx::ranges::lexicographical_compare_t,
+            ExPolicy&& policy, Rng1&& rng1, Rng2&& rng2, Pred&& pred = Pred(),
+            Proj1&& proj1 = Proj1(), Proj2&& proj2 = Proj2())
+        {
+            using iterator_type1 =
+                typename hpx::traits::range_traits<Rng1>::iterator_type;
+            using iterator_type2 =
+                typename hpx::traits::range_traits<Rng2>::iterator_type;
+
+            static_assert(
+                hpx::traits::is_forward_iterator<iterator_type1>::value,
+                "Requires at least forward iterator.");
+
+            static_assert(
+                hpx::traits::is_forward_iterator<iterator_type2>::value,
+                "Requires at least forward iterator.");
+
+            return hpx::parallel::v1::detail::lexicographical_compare().call(
+                std::forward<ExPolicy>(policy), std::begin(rng1),
+                std::end(rng1), std::begin(rng2), std::end(rng2),
+                std::forward<Pred>(pred), std::forward<Proj1>(proj1),
+                std::forward<Proj2>(proj2));
+        }
+    } uninitialized_copy{};
+}}    // namespace hpx::ranges
+
+#endif

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/uninitialized_copy.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/uninitialized_copy.hpp
@@ -397,7 +397,8 @@ namespace hpx { namespace ranges {
                 hpx::traits::is_sentinel_for<Sent2, FwdIter>::value
             )>
         // clang-format on
-        friend bool tag_fallback_invoke(hpx::ranges::uninitialized_copy_t,
+        friend hpx::parallel::util::in_out_result<InIter, FwdIter> tag_fallback_invoke(
+            hpx::ranges::uninitialized_copy_t,
             InIter first1, Sent1 last1, FwdIter first2, Sent2 last2)
         {
             static_assert(hpx::traits::is_input_iterator<InIter>::value,
@@ -405,72 +406,45 @@ namespace hpx { namespace ranges {
             static_assert(hpx::traits::is_forward_iterator<FwdIter>::value,
                 "Requires at least forward iterator.");
 
-
-            return hpx::parallel::v1::detail::uninitialized_copy().call(
-                hpx::execution::seq, first1, last1, first2, last2,
-                std::forward<Pred>(pred), std::forward<Proj1>(proj1),
-                std::forward<Proj2>(proj2));
+            return hpx::parallel::v1::detail::uninitialized_copy_sent<FwdIter>().call(
+                hpx::execution::seq, first1, last1, first2, last2);
         }
 
         // clang-format off
         template <typename ExPolicy, typename FwdIter1, typename Sent1,
             typename FwdIter2, typename Sent2,
-            typename Proj1 = hpx::parallel::util::projection_identity,
-            typename Proj2 = hpx::parallel::util::projection_identity,
-            typename Pred = hpx::parallel::v1::detail::less,
             HPX_CONCEPT_REQUIRES_(
                 hpx::is_execution_policy<ExPolicy>::value &&
                 hpx::traits::is_forward_iterator<FwdIter1>::value &&
                 hpx::traits::is_sentinel_for<Sent1, FwdIter1>::value &&
                 hpx::traits::is_forward_iterator<FwdIter2>::value &&
-                hpx::traits::is_sentinel_for<Sent2, FwdIter2>::value &&
-                hpx::parallel::traits::is_projected<Proj1, FwdIter1>::value &&
-                hpx::parallel::traits::is_projected<Proj2, FwdIter2>::value &&
-                hpx::parallel::traits::is_indirect_callable<
-                    ExPolicy, Pred,
-                    hpx::parallel::traits::projected<Proj1, FwdIter1>,
-                    hpx::parallel::traits::projected<Proj2, FwdIter2>
-                >::value
+                hpx::traits::is_sentinel_for<Sent2, FwdIter2>::value
             )>
         // clang-format on
         friend typename parallel::util::detail::algorithm_result<ExPolicy,
-            bool>::type
-        tag_fallback_invoke(hpx::ranges::lexicographical_compare_t,
+            FwdIter2>::type
+        tag_fallback_invoke(hpx::ranges::uninitialized_copy_t,
             ExPolicy&& policy, FwdIter1 first1, Sent1 last1, FwdIter2 first2,
-            Sent2 last2, Pred&& pred = Pred(), Proj1&& proj1 = Proj1(),
-            Proj2&& proj2 = Proj2())
+            Sent2 last2)
         {
             static_assert(hpx::traits::is_forward_iterator<FwdIter1>::value,
                 "Requires at least forward iterator.");
             static_assert(hpx::traits::is_forward_iterator<FwdIter2>::value,
                 "Requires at least forward iterator.");
 
-            return hpx::parallel::v1::detail::lexicographical_compare().call(
-                std::forward<ExPolicy>(policy), first1, last1, first2, last2,
-                std::forward<Pred>(pred), std::forward<Proj1>(proj1),
-                std::forward<Proj2>(proj2));
+            return hpx::parallel::v1::detail::uninitialized_copy_sent<FwdIter2>().call(
+                std::forward<ExPolicy>(policy), first1, last1, first2, last2);
         }
 
         // clang-format off
         template <typename Rng1, typename Rng2,
-            typename Proj1 = hpx::parallel::util::projection_identity,
-            typename Proj2 = hpx::parallel::util::projection_identity,
-            typename Pred = hpx::parallel::v1::detail::less,
             HPX_CONCEPT_REQUIRES_(
                 hpx::traits::is_range<Rng1>::value &&
-                hpx::traits::is_range<Rng2>::value &&
-                hpx::parallel::traits::is_projected_range<Proj1, Rng1>::value &&
-                hpx::parallel::traits::is_projected_range<Proj2, Rng2>::value &&
-                hpx::parallel::traits::is_indirect_callable<
-                    hpx::execution::sequenced_policy, Pred,
-                    hpx::parallel::traits::projected_range<Proj1, Rng1>,
-                    hpx::parallel::traits::projected_range<Proj2, Rng2>
-                >::value
+                hpx::traits::is_range<Rng2>::value
             )>
         // clang-format on
-        friend bool tag_fallback_invoke(hpx::ranges::lexicographical_compare_t,
-            Rng1&& rng1, Rng2&& rng2, Pred&& pred = Pred(),
-            Proj1&& proj1 = Proj1(), Proj2&& proj2 = Proj2())
+        friend hpx::parallel::util::in_out_result<> tag_fallback_invoke(hpx::ranges::uninitialized_copy_t,
+            Rng1&& rng1, Rng2&& rng2)
         {
             using iterator_type1 =
                 typename hpx::traits::range_traits<Rng1>::iterator_type;
@@ -480,38 +454,26 @@ namespace hpx { namespace ranges {
             static_assert(hpx::traits::is_input_iterator<iterator_type1>::value,
                 "Requires at least input iterator.");
 
-            static_assert(hpx::traits::is_input_iterator<iterator_type2>::value,
-                "Requires at least input iterator.");
+            static_assert(hpx::traits::is_forward_iterator<iterator_type2>::value,
+                "Requires at least forward iterator.");
 
-            return hpx::parallel::v1::detail::lexicographical_compare().call(
+            return hpx::parallel::v1::detail::uninitialized_copy_sent<iterator_type2>().call(
                 hpx::execution::seq, std::begin(rng1), std::end(rng1),
-                std::begin(rng2), std::end(rng2), std::forward<Pred>(pred),
-                std::forward<Proj1>(proj1), std::forward<Proj2>(proj2));
+                std::begin(rng2), std::end(rng2));
         }
 
         // clang-format off
         template <typename ExPolicy, typename Rng1, typename Rng2,
-            typename Proj1 = hpx::parallel::util::projection_identity,
-            typename Proj2 = hpx::parallel::util::projection_identity,
-            typename Pred = hpx::parallel::v1::detail::less,
             HPX_CONCEPT_REQUIRES_(
                 hpx::is_execution_policy<ExPolicy>::value &&
                 hpx::traits::is_range<Rng1>::value &&
-                hpx::traits::is_range<Rng2>::value &&
-                hpx::parallel::traits::is_projected_range<Proj1, Rng1>::value &&
-                hpx::parallel::traits::is_projected_range<Proj2, Rng2>::value &&
-                hpx::parallel::traits::is_indirect_callable<
-                    ExPolicy, Pred,
-                    hpx::parallel::traits::projected_range<Proj1, Rng1>,
-                    hpx::parallel::traits::projected_range<Proj2, Rng2>
-                >::value
+                hpx::traits::is_range<Rng2>::value
             )>
         // clang-format on
         friend typename parallel::util::detail::algorithm_result<ExPolicy,
             bool>::type
-        tag_fallback_invoke(hpx::ranges::lexicographical_compare_t,
-            ExPolicy&& policy, Rng1&& rng1, Rng2&& rng2, Pred&& pred = Pred(),
-            Proj1&& proj1 = Proj1(), Proj2&& proj2 = Proj2())
+        tag_fallback_invoke(hpx::ranges::uninitialized_copy_t,
+            ExPolicy&& policy, Rng1&& rng1, Rng2&& rng2)
         {
             using iterator_type1 =
                 typename hpx::traits::range_traits<Rng1>::iterator_type;
@@ -526,13 +488,67 @@ namespace hpx { namespace ranges {
                 hpx::traits::is_forward_iterator<iterator_type2>::value,
                 "Requires at least forward iterator.");
 
-            return hpx::parallel::v1::detail::lexicographical_compare().call(
+            return hpx::parallel::v1::detail::uninitialized_copy_sent<iterator_type2>().call(
                 std::forward<ExPolicy>(policy), std::begin(rng1),
-                std::end(rng1), std::begin(rng2), std::end(rng2),
-                std::forward<Pred>(pred), std::forward<Proj1>(proj1),
-                std::forward<Proj2>(proj2));
+                std::end(rng1), std::begin(rng2), std::end(rng2));
         }
     } uninitialized_copy{};
+
+    HPX_INLINE_CONSTEXPR_VARIABLE struct uninitialized_copy_n_t final
+      : hpx::functional::tag_fallback<uninitialized_copy_n_t>
+    {
+    private:
+        // clang-format off
+        template <typename InIter, typename Size, typename FwdIter, typename Sent2,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::traits::is_iterator<InIter>::value &&
+                hpx::traits::is_forward_iterator<FwdIter>::value &&
+                hpx::traits::is_sentinel_for<Sent2, FwdIter>::value
+            )>
+        // clang-format on
+        friend bool tag_fallback_invoke(hpx::ranges::uninitialized_copy_n_t,
+            InIter first1, Size count, FwdIter first2, Sent2 last2)
+        {
+            static_assert(hpx::traits::is_input_iterator<InIter>::value,
+                "Requires at least input iterator.");
+            static_assert(hpx::traits::is_forward_iterator<FwdIter>::value,
+                "Requires at least forward iterator.");
+
+            auto N = std::min(
+                count, parallel::v1::detail::distance(first2, last2));
+
+            return hpx::parallel::v1::detail::uninitialized_copy_n<FwdIter>()
+                .call(hpx::execution::seq, first1, std::size_t(N), first2);
+        }
+
+        // clang-format off
+        template <typename ExPolicy, typename FwdIter1, typename Size,
+            typename FwdIter2, typename Sent2,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::is_execution_policy<ExPolicy>::value &&
+                hpx::traits::is_forward_iterator<FwdIter1>::value &&
+                hpx::traits::is_forward_iterator<FwdIter2>::value &&
+                hpx::traits::is_sentinel_for<Sent2, FwdIter2>::value
+            )>
+        // clang-format on
+        friend typename parallel::util::detail::algorithm_result<ExPolicy,
+            bool>::type
+        tag_fallback_invoke(hpx::ranges::uninitialized_copy_n_t,
+            ExPolicy&& policy, FwdIter1 first1, Size count, FwdIter2 first2,
+            Sent2 last2)
+        {
+            static_assert(hpx::traits::is_forward_iterator<FwdIter1>::value,
+                "Requires at least forward iterator.");
+            static_assert(hpx::traits::is_forward_iterator<FwdIter2>::value,
+                "Requires at least forward iterator.");
+
+            auto N =
+                std::min(count, parallel::v1::detail::distance(first2, last2));
+
+            return hpx::parallel::v1::detail::uninitialized_copy_n<FwdIter>()
+                .call(hpx::execution::seq, first1, std::size_t(N), first2);
+        }
+    } uninitialized_copy_n{};
 }}    // namespace hpx::ranges
 
 #endif

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/uninitialized_copy.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/uninitialized_copy.hpp
@@ -337,7 +337,7 @@ namespace hpx { namespace ranges {
             )>
         // clang-format on
         friend hpx::parallel::util::in_out_result<InIter, FwdIter>
-        tag_fallback_invoke(hpx::ranges::uninitialized_copy_t, InIter first1,
+        tag_fallback_dispatch(hpx::ranges::uninitialized_copy_t, InIter first1,
             Sent1 last1, FwdIter first2, Sent2 last2)
         {
             static_assert(hpx::traits::is_input_iterator<InIter>::value,
@@ -363,7 +363,7 @@ namespace hpx { namespace ranges {
         // clang-format on
         friend typename parallel::util::detail::algorithm_result<ExPolicy,
             parallel::util::in_out_result<FwdIter1, FwdIter2>>::type
-        tag_fallback_invoke(hpx::ranges::uninitialized_copy_t,
+        tag_fallback_dispatch(hpx::ranges::uninitialized_copy_t,
             ExPolicy&& policy, FwdIter1 first1, Sent1 last1, FwdIter2 first2,
             Sent2 last2)
         {
@@ -388,7 +388,7 @@ namespace hpx { namespace ranges {
         friend hpx::parallel::util::in_out_result<
             typename hpx::traits::range_traits<Rng1>::iterator_type,
             typename hpx::traits::range_traits<Rng2>::iterator_type>
-        tag_fallback_invoke(
+        tag_fallback_dispatch(
             hpx::ranges::uninitialized_copy_t, Rng1&& rng1, Rng2&& rng2)
         {
             using iterator_type1 =
@@ -421,7 +421,7 @@ namespace hpx { namespace ranges {
             hpx::parallel::util::in_out_result<
                 typename hpx::traits::range_traits<Rng1>::iterator_type,
                 typename hpx::traits::range_traits<Rng2>::iterator_type>>::type
-        tag_fallback_invoke(hpx::ranges::uninitialized_copy_t,
+        tag_fallback_dispatch(hpx::ranges::uninitialized_copy_t,
             ExPolicy&& policy, Rng1&& rng1, Rng2&& rng2)
         {
             using iterator_type1 =
@@ -457,8 +457,8 @@ namespace hpx { namespace ranges {
             )>
         // clang-format on
         friend hpx::parallel::util::in_out_result<InIter, FwdIter>
-        tag_fallback_invoke(hpx::ranges::uninitialized_copy_n_t, InIter first1,
-            Size count, FwdIter first2, Sent2 last2)
+        tag_fallback_dispatch(hpx::ranges::uninitialized_copy_n_t,
+            InIter first1, Size count, FwdIter first2, Sent2 last2)
         {
             static_assert(hpx::traits::is_input_iterator<InIter>::value,
                 "Requires at least input iterator.");
@@ -484,7 +484,7 @@ namespace hpx { namespace ranges {
         // clang-format on
         friend typename parallel::util::detail::algorithm_result<ExPolicy,
             hpx::parallel::util::in_out_result<FwdIter1, FwdIter2>>::type
-        tag_fallback_invoke(hpx::ranges::uninitialized_copy_n_t,
+        tag_fallback_dispatch(hpx::ranges::uninitialized_copy_n_t,
             ExPolicy&& policy, FwdIter1 first1, Size count, FwdIter2 first2,
             Sent2 last2)
         {

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/uninitialized_default_construct.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/uninitialized_default_construct.hpp
@@ -12,45 +12,46 @@
 #if defined(DOXYGEN)
 
 namespace hpx { namespace ranges {
+    // clang-format off
 
-    /// Copies the given \a value to an uninitialized memory area, defined by
-    /// the range [first, last). If an exception is thrown during the
+    /// Constructs objects of type typename iterator_traits<ForwardIt>
+    /// ::value_type in the uninitialized storage designated by the range
+    /// by default-initialization. If an exception is thrown during the
     /// initialization, the function has no effects.
     ///
-    /// \note   Complexity: Linear in the distance between \a first and \a last
+    /// \note   Complexity: Performs exactly \a last - \a first assignments.
     ///
     /// \tparam FwdIter     The type of the source iterators used (deduced).
     ///                     This iterator type must meet the requirements of an
     ///                     forward iterator.
     /// \tparam Sent        The type of the source sentinel (deduced). This
     ///                     sentinel type must be a sentinel for FwdIter.
-    /// \tparam T           The type of the value to be assigned (deduced).
     ///
     /// \param first        Refers to the beginning of the sequence of elements
     ///                     the algorithm will be applied to.
     /// \param last         Refers to sentinel value denoting the end of the
     ///                     sequence of elements the algorithm will be applied.
-    /// \param value        The value to be assigned.
     ///
-    /// The assignments in the ranges \a uninitialized_default_construct algorithm invoked
-    /// without an execution policy object will execute in sequential order in
-    /// the calling thread.
+    /// The assignments in the parallel \a uninitialized_default_construct
+    /// algorithm invoked without an execution policy object will execute in
+    /// sequential order in the calling thread.
     ///
     /// \returns  The \a uninitialized_default_construct algorithm returns a
     ///           returns \a FwdIter.
-    ///           The \a uninitialized_default_construct algorithm returns the output
-    ///           iterator to the element in the range, one past
-    ///           the last element copied.
+    ///           The \a uninitialized_default_construct algorithm returns the
+    ///           output iterator to the element in the range, one past
+    ///           the last element constructed.
     ///
-    template <typename FwdIter, typename Sent, typename T>
+    template <typename FwdIter, typename Sent>
     FwdIter uninitialized_default_construct(
-        FwdIter first, Sent last, T const& value);
+        FwdIter first, Sent last);
 
-    /// Copies the given \a value to an uninitialized memory area, defined by
-    /// the range [first, last). If an exception is thrown during the
+    /// Constructs objects of type typename iterator_traits<ForwardIt>
+    /// ::value_type in the uninitialized storage designated by the range
+    /// by default-initialization. If an exception is thrown during the
     /// initialization, the function has no effects.
     ///
-    /// \note   Complexity: Linear in the distance between \a first and \a last
+    /// \note   Complexity: Performs exactly \a last - \a first assignments.
     ///
     /// \tparam ExPolicy    The type of the execution policy to use (deduced).
     ///                     It describes the manner in which the execution
@@ -61,7 +62,6 @@ namespace hpx { namespace ranges {
     ///                     forward iterator.
     /// \tparam Sent        The type of the source sentinel (deduced). This
     ///                     sentinel type must be a sentinel for FwdIter.
-    /// \tparam T           The type of the value to be assigned (deduced).
     ///
     /// \param policy       The execution policy to use for the scheduling of
     ///                     the iterations.
@@ -69,64 +69,66 @@ namespace hpx { namespace ranges {
     ///                     the algorithm will be applied to.
     /// \param last         Refers to sentinel value denoting the end of the
     ///                     sequence of elements the algorithm will be applied.
-    /// \param value        The value to be assigned.
     ///
-    /// The assignments in the parallel \a uninitialized_default_construct algorithm invoked
-    /// with an execution policy object of type \a sequenced_policy
-    /// execute in sequential order in the calling thread.
+    /// The assignments in the parallel \a uninitialized_default_construct
+    /// algorithm invoked with an execution policy object of type \a
+    /// sequenced_policy execute in sequential order in the calling thread.
     ///
-    /// The assignments in the parallel \a uninitialized_default_construct algorithm invoked
-    /// with an execution policy object of type \a parallel_policy or
-    /// \a parallel_task_policy are permitted to execute in an
-    /// unordered fashion in unspecified threads, and indeterminately sequenced
-    /// within each thread.
+    /// The assignments in the parallel \a uninitialized_default_construct
+    /// algorithm invoked with an execution policy object of type \a
+    /// parallel_policy or \a parallel_task_policy are permitted to execute
+    /// in an unordered fashion in unspecified threads, and indeterminately
+    /// sequenced within each thread.
     ///
     /// \returns  The \a uninitialized_default_construct algorithm returns a
-    ///           returns \a FwdIter.
-    ///           The \a uninitialized_default_construct algorithm returns the output
-    ///           iterator to the element in the range, one past
-    ///           the last element copied.
+    ///           \a hpx::future<FwdIter> if the execution policy is of type
+    ///           \a sequenced_task_policy or
+    ///           \a parallel_task_policy and
+    ///           returns \a FwdIter otherwise.
+    ///           The \a uninitialized_default_construct algorithm returns
+    ///           the iterator to the element in the source range, one past
+    ///           the last element constructed.
     ///
     template <typename ExPolicy, typename FwdIter, typename Sent>
     typename parallel::util::detail::algorithm_result<ExPolicy, FwdIter>::type
     uninitialized_default_construct(
-        ExPolicy&& policy, FwdIter first, Sent last, T const& value);
+        ExPolicy&& policy, FwdIter first, Sent last);
 
-    /// Copies the given \a value to an uninitialized memory area, defined by
-    /// the range [first, last). If an exception is thrown during the
+    /// Constructs objects of type typename iterator_traits<ForwardIt>
+    /// ::value_type in the uninitialized storage designated by the range
+    /// by default-initialization. If an exception is thrown during the
     /// initialization, the function has no effects.
     ///
-    /// \note   Complexity: Linear in the distance between \a first and \a last
+    /// \note   Complexity: Performs exactly \a last - \a first assignments.
     ///
     /// \tparam Rng         The type of the source range used (deduced).
     ///                     The iterators extracted from this range type must
     ///                     meet the requirements of an input iterator.
-    /// \tparam T           The type of the value to be assigned (deduced).
     ///
-    /// \param rng          Refers to the range to which the value
-    ///                     will be filled
-    /// \param value        The value to be assigned.
+    /// \param rng          Refers to the range to which will be default
+    ///                     constructed.
     ///
-    /// The assignments in the parallel \a uninitialized_default_construct algorithm invoked
-    /// without an execution policy object will execute in sequential order in
-    /// the calling thread.
+    /// The assignments in the parallel \a uninitialized_default_construct
+    /// algorithm invoked without an execution policy object will execute in
+    /// sequential order in the calling thread.
     ///
     /// \returns  The \a uninitialized_default_construct algorithm returns a
     ///           returns \a hpx::traits::range_traits<Rng>
     ///           ::iterator_type.
-    ///           The \a uninitialized_default_construct algorithm returns the output
-    ///           iterator to the element in the range, one past
-    ///           the last element copied.
+    ///           The \a uninitialized_default_construct algorithm returns
+    ///           the output iterator to the element in the range, one past
+    ///           the last element constructed.
     ///
-    template <typename Rng, typename T>
+    template <typename Rng>
     typename hpx::traits::range_traits<Rng>::iterator_type
-    uninitialized_default_construct(Rng&& rng, T const& value);
+    uninitialized_default_construct(Rng&& rng);
 
-    /// Copies the given \a value to an uninitialized memory area, defined by
-    /// the range [first, last). If an exception is thrown during the
+    /// Constructs objects of type typename iterator_traits<ForwardIt>
+    /// ::value_type in the uninitialized storage designated by the range
+    /// by default-initialization. If an exception is thrown during the
     /// initialization, the function has no effects.
     ///
-    /// \note   Complexity: Linear in the distance between \a first and \a last
+    /// \note   Complexity: Performs exactly \a last - \a first assignments.
     ///
     /// \tparam ExPolicy    The type of the execution policy to use (deduced).
     ///                     It describes the manner in which the execution
@@ -135,23 +137,21 @@ namespace hpx { namespace ranges {
     /// \tparam Rng         The type of the source range used (deduced).
     ///                     The iterators extracted from this range type must
     ///                     meet the requirements of an input iterator.
-    /// \tparam T           The type of the value to be assigned (deduced).
     ///
     /// \param policy       The execution policy to use for the scheduling of
     ///                     the iterations.
     /// \param rng          Refers to the range to which the value
-    ///                     will be filled
-    /// \param value        The value to be assigned.
+    ///                     will be default consutrcted
     ///
-    /// The assignments in the parallel \a uninitialized_default_construct algorithm invoked
-    /// with an execution policy object of type \a sequenced_policy
-    /// execute in sequential order in the calling thread.
+    /// The assignments in the parallel \a uninitialized_default_construct
+    /// algorithm invoked with an execution policy object of type \a
+    /// sequenced_policy execute in sequential order in the calling thread.
     ///
-    /// The assignments in the parallel \a uninitialized_default_construct algorithm invoked
-    /// with an execution policy object of type \a parallel_policy or
-    /// \a parallel_task_policy are permitted to execute in an
-    /// unordered fashion in unspecified threads, and indeterminately sequenced
-    /// within each thread.
+    /// The assignments in the parallel \a uninitialized_default_construct
+    /// algorithm invoked with an execution policy object of type \a
+    /// parallel_policy or \a parallel_task_policy are permitted to execute
+    /// in an unordered fashion in unspecified threads, and indeterminately
+    /// sequenced within each thread.
     ///
     /// \returns  The \a uninitialized_default_construct algorithm returns a
     ///           \a hpx::future<typename hpx::traits::range_traits<Rng>
@@ -159,53 +159,51 @@ namespace hpx { namespace ranges {
     ///           execution policy is of type \a sequenced_task_policy
     ///           or \a parallel_task_policy and returns \a typename
     ///           hpx::traits::range_traits<Rng>::iterator_type otherwise.
-    ///           The \a uninitialized_default_construct algorithm returns the
-    ///           iterator to one past the last element filled in the range.
+    ///           The \a uninitialized_default_construct algorithm returns
+    ///           the output iterator to the element in the range, one past
+    ///           the last element constructed.
     ///
-    template <typename ExPolicy, typename Rng, typename T>
+    template <typename ExPolicy, typename Rng>
     typename parallel::util::detail::algorithm_result<ExPolicy,
-        typename hpx::traits::range_traits<Rng1>::iterator_type>::type
-    uninitialized_default_construct(
-        ExPolicy&& policy, Rng&& rng, T const& value);
+        typename hpx::traits::range_traits<Rng>::iterator_type>::type
+    uninitialized_default_construct(ExPolicy&& policy, Rng&& rng);
 
-    /// Copies the given \a value value to the first count elements in an
-    /// uninitialized memory area beginning at first. If an exception is thrown
-    /// during the initialization, the function has no effects.
+    /// Constructs objects of type typename iterator_traits<ForwardIt>
+    /// ::value_type in the uninitialized storage designated by the range
+    /// [first, first + count) by default-initialization. If an exception
+    /// is thrown during the initialization, the function has no effects.
     ///
     /// \note   Complexity: Performs exactly \a count assignments, if
     ///         count > 0, no assignments otherwise.
     ///
     /// \tparam FwdIter     The type of the source iterators used (deduced).
-    ///                     This iterator type must meet the requirements of a
+    ///                     This iterator type must meet the requirements of an
     ///                     forward iterator.
     /// \tparam Size        The type of the argument specifying the number of
     ///                     elements to apply \a f to.
-    /// \tparam T           The type of the value to be assigned (deduced).
     ///
     /// \param first        Refers to the beginning of the sequence of elements
     ///                     the algorithm will be applied to.
     /// \param count        Refers to the number of elements starting at
     ///                     \a first the algorithm will be applied to.
-    /// \param value        The value to be assigned.
     ///
-    /// The assignments in the parallel \a uninitialized_default_construct_n algorithm
-    /// invoked with an execution policy object of type
-    /// \a sequenced_policy execute in sequential order in the
-    /// calling thread.
+    /// The assignments in the parallel \a uninitialized_default_construct_n
+    /// algorithm invoked without an execution policy object execute in
+    /// sequential order in the calling thread.
     ///
     /// \returns  The \a uninitialized_default_construct_n algorithm returns a
     ///           returns \a FwdIter.
-    ///           The \a uninitialized_default_construct_n algorithm returns the output
-    ///           iterator to the element in the range, one past
-    ///           the last element copied.
+    ///           The \a uninitialized_default_construct_n algorithm returns
+    ///           the iterator to the element in the source range, one past
+    ///           the last element constructed.
     ///
-    template <typename FwdIter, typename Size, typename T>
-    FwdIter uninitialized_default_construct_n(
-        FwdIter first, Size count, T const& value);
+    template <typename FwdIter, typename Size>
+    FwdIter uninitialized_default_construct_n(FwdIter first, Size count);
 
-    /// Copies the given \a value value to the first count elements in an
-    /// uninitialized memory area beginning at first. If an exception is thrown
-    /// during the initialization, the function has no effects.
+    /// Constructs objects of type typename iterator_traits<ForwardIt>
+    /// ::value_type in the uninitialized storage designated by the range
+    /// [first, first + count) by default-initialization. If an exception
+    /// is thrown during the initialization, the function has no effects.
     ///
     /// \note   Complexity: Performs exactly \a count assignments, if
     ///         count > 0, no assignments otherwise.
@@ -215,11 +213,10 @@ namespace hpx { namespace ranges {
     ///                     of the algorithm may be parallelized and the manner
     ///                     in which it executes the assignments.
     /// \tparam FwdIter     The type of the source iterators used (deduced).
-    ///                     This iterator type must meet the requirements of a
+    ///                     This iterator type must meet the requirements of an
     ///                     forward iterator.
     /// \tparam Size        The type of the argument specifying the number of
     ///                     elements to apply \a f to.
-    /// \tparam T           The type of the value to be assigned (deduced).
     ///
     /// \param policy       The execution policy to use for the scheduling of
     ///                     the iterations.
@@ -227,34 +224,35 @@ namespace hpx { namespace ranges {
     ///                     the algorithm will be applied to.
     /// \param count        Refers to the number of elements starting at
     ///                     \a first the algorithm will be applied to.
-    /// \param value        The value to be assigned.
     ///
-    /// The assignments in the parallel \a uninitialized_default_construct_n algorithm
-    /// invoked with an execution policy object of type
+    /// The assignments in the parallel \a uninitialized_default_construct_n
+    /// algorithm invoked with an execution policy object of type
     /// \a sequenced_policy execute in sequential order in the
     /// calling thread.
     ///
-    /// The assignments in the parallel \a uninitialized_default_construct_n algorithm
-    /// invoked with an execution policy object of type
+    /// The assignments in the parallel \a uninitialized_default_construct_n
+    /// algorithm invoked with an execution policy object of type
     /// \a parallel_policy or
     /// \a parallel_task_policy are permitted to execute in an
     /// unordered fashion in unspecified threads, and indeterminately sequenced
     /// within each thread.
     ///
     /// \returns  The \a uninitialized_default_construct_n algorithm returns a
-    ///           \a hpx::future<FwdIter>, if the execution policy is of type
+    ///           \a hpx::future<FwdIter> if the execution policy is of type
     ///           \a sequenced_task_policy or
-    ///           \a parallel_task_policy and returns FwdIter
-    ///           otherwise.
-    ///           The \a uninitialized_default_construct_n algorithm returns the output
-    ///           iterator to the element in the range, one past
-    ///           the last element copied.
+    ///           \a parallel_task_policy and
+    ///           returns \a FwdIter otherwise.
+    ///           The \a uninitialized_default_construct_n algorithm returns
+    ///           the iterator to the element in the source range, one past
+    ///           the last element constructed.
     ///
-    template <typename ExPolicy, typename FwdIter, typename Size, typename T>
+    template <typename ExPolicy, typename FwdIter, typename Size>
     typename typename parallel::util::detail::algorithm_result<ExPolicy,
         FwdIter>::type
     uninitialized_default_construct_n(
-        ExPolicy&& policy, FwdIter first, Size count, T const& value);
+        ExPolicy&& policy, FwdIter first, Size count);
+
+    // clang-format on
 }}    // namespace hpx::ranges
 #else
 

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/uninitialized_default_construct.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/uninitialized_default_construct.hpp
@@ -1,0 +1,415 @@
+//  Copyright (c) 2020 ETH Zurich
+//  Copyright (c) 2014 Grant Mercer
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+/// \file parallel/container_algorithms/uninitialized_default_construct.hpp
+
+#pragma once
+
+#if defined(DOXYGEN)
+
+namespace hpx { namespace ranges {
+
+    /// Copies the given \a value to an uninitialized memory area, defined by
+    /// the range [first, last). If an exception is thrown during the
+    /// initialization, the function has no effects.
+    ///
+    /// \note   Complexity: Linear in the distance between \a first and \a last
+    ///
+    /// \tparam FwdIter     The type of the source iterators used (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     forward iterator.
+    /// \tparam Sent        The type of the source sentinel (deduced). This
+    ///                     sentinel type must be a sentinel for FwdIter.
+    /// \tparam T           The type of the value to be assigned (deduced).
+    ///
+    /// \param first        Refers to the beginning of the sequence of elements
+    ///                     the algorithm will be applied to.
+    /// \param last         Refers to sentinel value denoting the end of the
+    ///                     sequence of elements the algorithm will be applied.
+    /// \param value        The value to be assigned.
+    ///
+    /// The assignments in the ranges \a uninitialized_default_construct algorithm invoked
+    /// without an execution policy object will execute in sequential order in
+    /// the calling thread.
+    ///
+    /// \returns  The \a uninitialized_default_construct algorithm returns a
+    ///           returns \a FwdIter.
+    ///           The \a uninitialized_default_construct algorithm returns the output
+    ///           iterator to the element in the range, one past
+    ///           the last element copied.
+    ///
+    template <typename FwdIter, typename Sent, typename T>
+    FwdIter uninitialized_default_construct(
+        FwdIter first, Sent last, T const& value);
+
+    /// Copies the given \a value to an uninitialized memory area, defined by
+    /// the range [first, last). If an exception is thrown during the
+    /// initialization, the function has no effects.
+    ///
+    /// \note   Complexity: Linear in the distance between \a first and \a last
+    ///
+    /// \tparam ExPolicy    The type of the execution policy to use (deduced).
+    ///                     It describes the manner in which the execution
+    ///                     of the algorithm may be parallelized and the manner
+    ///                     in which it executes the assignments.
+    /// \tparam FwdIter     The type of the source iterators used (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     forward iterator.
+    /// \tparam Sent        The type of the source sentinel (deduced). This
+    ///                     sentinel type must be a sentinel for FwdIter.
+    /// \tparam T           The type of the value to be assigned (deduced).
+    ///
+    /// \param policy       The execution policy to use for the scheduling of
+    ///                     the iterations.
+    /// \param first        Refers to the beginning of the sequence of elements
+    ///                     the algorithm will be applied to.
+    /// \param last         Refers to sentinel value denoting the end of the
+    ///                     sequence of elements the algorithm will be applied.
+    /// \param value        The value to be assigned.
+    ///
+    /// The assignments in the parallel \a uninitialized_default_construct algorithm invoked
+    /// with an execution policy object of type \a sequenced_policy
+    /// execute in sequential order in the calling thread.
+    ///
+    /// The assignments in the parallel \a uninitialized_default_construct algorithm invoked
+    /// with an execution policy object of type \a parallel_policy or
+    /// \a parallel_task_policy are permitted to execute in an
+    /// unordered fashion in unspecified threads, and indeterminately sequenced
+    /// within each thread.
+    ///
+    /// \returns  The \a uninitialized_default_construct algorithm returns a
+    ///           returns \a FwdIter.
+    ///           The \a uninitialized_default_construct algorithm returns the output
+    ///           iterator to the element in the range, one past
+    ///           the last element copied.
+    ///
+    template <typename ExPolicy, typename FwdIter, typename Sent>
+    typename parallel::util::detail::algorithm_result<ExPolicy, FwdIter>::type
+    uninitialized_default_construct(
+        ExPolicy&& policy, FwdIter first, Sent last, T const& value);
+
+    /// Copies the given \a value to an uninitialized memory area, defined by
+    /// the range [first, last). If an exception is thrown during the
+    /// initialization, the function has no effects.
+    ///
+    /// \note   Complexity: Linear in the distance between \a first and \a last
+    ///
+    /// \tparam Rng         The type of the source range used (deduced).
+    ///                     The iterators extracted from this range type must
+    ///                     meet the requirements of an input iterator.
+    /// \tparam T           The type of the value to be assigned (deduced).
+    ///
+    /// \param rng          Refers to the range to which the value
+    ///                     will be filled
+    /// \param value        The value to be assigned.
+    ///
+    /// The assignments in the parallel \a uninitialized_default_construct algorithm invoked
+    /// without an execution policy object will execute in sequential order in
+    /// the calling thread.
+    ///
+    /// \returns  The \a uninitialized_default_construct algorithm returns a
+    ///           returns \a hpx::traits::range_traits<Rng>
+    ///           ::iterator_type.
+    ///           The \a uninitialized_default_construct algorithm returns the output
+    ///           iterator to the element in the range, one past
+    ///           the last element copied.
+    ///
+    template <typename Rng, typename T>
+    typename hpx::traits::range_traits<Rng>::iterator_type
+    uninitialized_default_construct(Rng&& rng, T const& value);
+
+    /// Copies the given \a value to an uninitialized memory area, defined by
+    /// the range [first, last). If an exception is thrown during the
+    /// initialization, the function has no effects.
+    ///
+    /// \note   Complexity: Linear in the distance between \a first and \a last
+    ///
+    /// \tparam ExPolicy    The type of the execution policy to use (deduced).
+    ///                     It describes the manner in which the execution
+    ///                     of the algorithm may be parallelized and the manner
+    ///                     in which it executes the assignments.
+    /// \tparam Rng         The type of the source range used (deduced).
+    ///                     The iterators extracted from this range type must
+    ///                     meet the requirements of an input iterator.
+    /// \tparam T           The type of the value to be assigned (deduced).
+    ///
+    /// \param policy       The execution policy to use for the scheduling of
+    ///                     the iterations.
+    /// \param rng          Refers to the range to which the value
+    ///                     will be filled
+    /// \param value        The value to be assigned.
+    ///
+    /// The assignments in the parallel \a uninitialized_default_construct algorithm invoked
+    /// with an execution policy object of type \a sequenced_policy
+    /// execute in sequential order in the calling thread.
+    ///
+    /// The assignments in the parallel \a uninitialized_default_construct algorithm invoked
+    /// with an execution policy object of type \a parallel_policy or
+    /// \a parallel_task_policy are permitted to execute in an
+    /// unordered fashion in unspecified threads, and indeterminately sequenced
+    /// within each thread.
+    ///
+    /// \returns  The \a uninitialized_default_construct algorithm returns a
+    ///           \a hpx::future<typename hpx::traits::range_traits<Rng>
+    ///           ::iterator_type>, if the
+    ///           execution policy is of type \a sequenced_task_policy
+    ///           or \a parallel_task_policy and returns \a typename
+    ///           hpx::traits::range_traits<Rng>::iterator_type otherwise.
+    ///           The \a uninitialized_default_construct algorithm returns the
+    ///           iterator to one past the last element filled in the range.
+    ///
+    template <typename ExPolicy, typename Rng, typename T>
+    typename parallel::util::detail::algorithm_result<ExPolicy,
+        typename hpx::traits::range_traits<Rng1>::iterator_type>::type
+    uninitialized_default_construct(
+        ExPolicy&& policy, Rng&& rng, T const& value);
+
+    /// Copies the given \a value value to the first count elements in an
+    /// uninitialized memory area beginning at first. If an exception is thrown
+    /// during the initialization, the function has no effects.
+    ///
+    /// \note   Complexity: Performs exactly \a count assignments, if
+    ///         count > 0, no assignments otherwise.
+    ///
+    /// \tparam FwdIter     The type of the source iterators used (deduced).
+    ///                     This iterator type must meet the requirements of a
+    ///                     forward iterator.
+    /// \tparam Size        The type of the argument specifying the number of
+    ///                     elements to apply \a f to.
+    /// \tparam T           The type of the value to be assigned (deduced).
+    ///
+    /// \param first        Refers to the beginning of the sequence of elements
+    ///                     the algorithm will be applied to.
+    /// \param count        Refers to the number of elements starting at
+    ///                     \a first the algorithm will be applied to.
+    /// \param value        The value to be assigned.
+    ///
+    /// The assignments in the parallel \a uninitialized_default_construct_n algorithm
+    /// invoked with an execution policy object of type
+    /// \a sequenced_policy execute in sequential order in the
+    /// calling thread.
+    ///
+    /// \returns  The \a uninitialized_default_construct_n algorithm returns a
+    ///           returns \a FwdIter.
+    ///           The \a uninitialized_default_construct_n algorithm returns the output
+    ///           iterator to the element in the range, one past
+    ///           the last element copied.
+    ///
+    template <typename FwdIter, typename Size, typename T>
+    FwdIter uninitialized_default_construct_n(
+        FwdIter first, Size count, T const& value);
+
+    /// Copies the given \a value value to the first count elements in an
+    /// uninitialized memory area beginning at first. If an exception is thrown
+    /// during the initialization, the function has no effects.
+    ///
+    /// \note   Complexity: Performs exactly \a count assignments, if
+    ///         count > 0, no assignments otherwise.
+    ///
+    /// \tparam ExPolicy    The type of the execution policy to use (deduced).
+    ///                     It describes the manner in which the execution
+    ///                     of the algorithm may be parallelized and the manner
+    ///                     in which it executes the assignments.
+    /// \tparam FwdIter     The type of the source iterators used (deduced).
+    ///                     This iterator type must meet the requirements of a
+    ///                     forward iterator.
+    /// \tparam Size        The type of the argument specifying the number of
+    ///                     elements to apply \a f to.
+    /// \tparam T           The type of the value to be assigned (deduced).
+    ///
+    /// \param policy       The execution policy to use for the scheduling of
+    ///                     the iterations.
+    /// \param first        Refers to the beginning of the sequence of elements
+    ///                     the algorithm will be applied to.
+    /// \param count        Refers to the number of elements starting at
+    ///                     \a first the algorithm will be applied to.
+    /// \param value        The value to be assigned.
+    ///
+    /// The assignments in the parallel \a uninitialized_default_construct_n algorithm
+    /// invoked with an execution policy object of type
+    /// \a sequenced_policy execute in sequential order in the
+    /// calling thread.
+    ///
+    /// The assignments in the parallel \a uninitialized_default_construct_n algorithm
+    /// invoked with an execution policy object of type
+    /// \a parallel_policy or
+    /// \a parallel_task_policy are permitted to execute in an
+    /// unordered fashion in unspecified threads, and indeterminately sequenced
+    /// within each thread.
+    ///
+    /// \returns  The \a uninitialized_default_construct_n algorithm returns a
+    ///           \a hpx::future<FwdIter>, if the execution policy is of type
+    ///           \a sequenced_task_policy or
+    ///           \a parallel_task_policy and returns FwdIter
+    ///           otherwise.
+    ///           The \a uninitialized_default_construct_n algorithm returns the output
+    ///           iterator to the element in the range, one past
+    ///           the last element copied.
+    ///
+    template <typename ExPolicy, typename FwdIter, typename Size, typename T>
+    typename typename parallel::util::detail::algorithm_result<ExPolicy,
+        FwdIter>::type
+    uninitialized_default_construct_n(
+        ExPolicy&& policy, FwdIter first, Size count, T const& value);
+}}    // namespace hpx::ranges
+#else
+
+#include <hpx/config.hpp>
+#include <hpx/algorithms/traits/projected_range.hpp>
+#include <hpx/execution/algorithms/detail/predicates.hpp>
+#include <hpx/executors/execution_policy.hpp>
+#include <hpx/iterator_support/traits/is_iterator.hpp>
+#include <hpx/parallel/algorithms/uninitialized_default_construct.hpp>
+#include <hpx/parallel/util/detail/algorithm_result.hpp>
+#include <hpx/parallel/util/projection_identity.hpp>
+
+#include <algorithm>
+#include <cstddef>
+#include <iterator>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+namespace hpx { namespace ranges {
+    HPX_INLINE_CONSTEXPR_VARIABLE struct uninitialized_default_construct_t final
+      : hpx::functional::tag_fallback<uninitialized_default_construct_t>
+    {
+    private:
+        // clang-format off
+        template <typename FwdIter, typename Sent,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::traits::is_forward_iterator<FwdIter>::value &&
+                hpx::traits::is_sentinel_for<Sent, FwdIter>::value
+            )>
+        // clang-format on
+        friend FwdIter tag_fallback_dispatch(
+            hpx::ranges::uninitialized_default_construct_t, FwdIter first,
+            Sent last)
+        {
+            static_assert(hpx::traits::is_forward_iterator<FwdIter>::value,
+                "Requires at least forward iterator.");
+
+            return hpx::parallel::v1::detail::uninitialized_default_construct<
+                FwdIter>()
+                .call(hpx::execution::seq, first, last);
+        }
+
+        // clang-format off
+        template <typename ExPolicy, typename FwdIter, typename Sent,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::is_execution_policy<ExPolicy>::value &&
+                hpx::traits::is_forward_iterator<FwdIter>::value &&
+                hpx::traits::is_sentinel_for<Sent, FwdIter>::value
+            )>
+        // clang-format on
+        friend typename parallel::util::detail::algorithm_result<ExPolicy,
+            FwdIter>::type
+        tag_fallback_dispatch(hpx::ranges::uninitialized_default_construct_t,
+            ExPolicy&& policy, FwdIter first, Sent last)
+        {
+            static_assert(hpx::traits::is_forward_iterator<FwdIter>::value,
+                "Requires at least forward iterator.");
+
+            return hpx::parallel::v1::detail::uninitialized_default_construct<
+                FwdIter>()
+                .call(std::forward<ExPolicy>(policy), first, last);
+        }
+
+        // clang-format off
+        template <typename Rng,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::traits::is_range<Rng>::value
+            )>
+        // clang-format on
+        friend typename hpx::traits::range_traits<Rng>::iterator_type
+        tag_fallback_dispatch(
+            hpx::ranges::uninitialized_default_construct_t, Rng&& rng)
+        {
+            using iterator_type =
+                typename hpx::traits::range_traits<Rng>::iterator_type;
+
+            static_assert(
+                hpx::traits::is_forward_iterator<iterator_type>::value,
+                "Requires at least forward iterator.");
+
+            return hpx::parallel::v1::detail::uninitialized_default_construct<
+                iterator_type>()
+                .call(hpx::execution::seq, std::begin(rng), std::end(rng));
+        }
+
+        // clang-format off
+        template <typename ExPolicy, typename Rng,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::is_execution_policy<ExPolicy>::value &&
+                hpx::traits::is_range<Rng>::value
+            )>
+        // clang-format on
+        friend typename parallel::util::detail::algorithm_result<ExPolicy,
+            typename hpx::traits::range_traits<Rng>::iterator_type>::type
+        tag_fallback_dispatch(hpx::ranges::uninitialized_default_construct_t,
+            ExPolicy&& policy, Rng&& rng)
+        {
+            using iterator_type =
+                typename hpx::traits::range_traits<Rng>::iterator_type;
+
+            static_assert(
+                hpx::traits::is_forward_iterator<iterator_type>::value,
+                "Requires at least forward iterator.");
+
+            return hpx::parallel::v1::detail::uninitialized_default_construct<
+                iterator_type>()
+                .call(std::forward<ExPolicy>(policy), std::begin(rng),
+                    std::end(rng));
+        }
+    } uninitialized_default_construct{};
+
+    HPX_INLINE_CONSTEXPR_VARIABLE struct uninitialized_default_construct_n_t
+        final
+      : hpx::functional::tag_fallback<uninitialized_default_construct_n_t>
+    {
+    private:
+        // clang-format off
+        template <typename FwdIter, typename Size,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::traits::is_forward_iterator<FwdIter>::value
+            )>
+        // clang-format on
+        friend FwdIter tag_fallback_dispatch(
+            hpx::ranges::uninitialized_default_construct_n_t, FwdIter first,
+            Size count)
+        {
+            static_assert(hpx::traits::is_forward_iterator<FwdIter>::value,
+                "Requires at least forward iterator.");
+
+            return hpx::parallel::v1::detail::uninitialized_default_construct_n<
+                FwdIter>()
+                .call(hpx::execution::seq, first, count);
+        }
+
+        // clang-format off
+        template <typename ExPolicy, typename FwdIter, typename Size,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::is_execution_policy<ExPolicy>::value &&
+                hpx::traits::is_forward_iterator<FwdIter>::value
+            )>
+        // clang-format on
+        friend typename parallel::util::detail::algorithm_result<ExPolicy,
+            FwdIter>::type
+        tag_fallback_dispatch(hpx::ranges::uninitialized_default_construct_n_t,
+            ExPolicy&& policy, FwdIter first, Size count)
+        {
+            static_assert(hpx::traits::is_forward_iterator<FwdIter>::value,
+                "Requires at least forward iterator.");
+
+            return hpx::parallel::v1::detail::uninitialized_default_construct_n<
+                FwdIter>()
+                .call(std::forward<ExPolicy>(policy), first, count);
+        }
+    } uninitialized_default_construct_n{};
+}}    // namespace hpx::ranges
+
+#endif

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/uninitialized_value_construct.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/uninitialized_value_construct.hpp
@@ -12,45 +12,46 @@
 #if defined(DOXYGEN)
 
 namespace hpx { namespace ranges {
+    // clang-format off
 
-    /// Copies the given \a value to an uninitialized memory area, defined by
-    /// the range [first, last). If an exception is thrown during the
+    /// Constructs objects of type typename iterator_traits<ForwardIt>
+    /// ::value_type in the uninitialized storage designated by the range
+    /// by value-initialization. If an exception is thrown during the
     /// initialization, the function has no effects.
     ///
-    /// \note   Complexity: Linear in the distance between \a first and \a last
+    /// \note   Complexity: Performs exactly \a last - \a first assignments.
     ///
     /// \tparam FwdIter     The type of the source iterators used (deduced).
     ///                     This iterator type must meet the requirements of an
     ///                     forward iterator.
     /// \tparam Sent        The type of the source sentinel (deduced). This
     ///                     sentinel type must be a sentinel for FwdIter.
-    /// \tparam T           The type of the value to be assigned (deduced).
     ///
     /// \param first        Refers to the beginning of the sequence of elements
     ///                     the algorithm will be applied to.
     /// \param last         Refers to sentinel value denoting the end of the
     ///                     sequence of elements the algorithm will be applied.
-    /// \param value        The value to be assigned.
     ///
-    /// The assignments in the ranges \a uninitialized_value_construct algorithm invoked
-    /// without an execution policy object will execute in sequential order in
-    /// the calling thread.
+    /// The assignments in the parallel \a uninitialized_value_construct
+    /// algorithm invoked without an execution policy object will execute in
+    /// sequential order in the calling thread.
     ///
     /// \returns  The \a uninitialized_value_construct algorithm returns a
     ///           returns \a FwdIter.
-    ///           The \a uninitialized_value_construct algorithm returns the output
-    ///           iterator to the element in the range, one past
-    ///           the last element copied.
+    ///           The \a uninitialized_value_construct algorithm returns the
+    ///           output iterator to the element in the range, one past
+    ///           the last element constructed.
     ///
-    template <typename FwdIter, typename Sent, typename T>
+    template <typename FwdIter, typename Sent>
     FwdIter uninitialized_value_construct(
-        FwdIter first, Sent last, T const& value);
+        FwdIter first, Sent last);
 
-    /// Copies the given \a value to an uninitialized memory area, defined by
-    /// the range [first, last). If an exception is thrown during the
+    /// Constructs objects of type typename iterator_traits<ForwardIt>
+    /// ::value_type in the uninitialized storage designated by the range
+    /// by value-initialization. If an exception is thrown during the
     /// initialization, the function has no effects.
     ///
-    /// \note   Complexity: Linear in the distance between \a first and \a last
+    /// \note   Complexity: Performs exactly \a last - \a first assignments.
     ///
     /// \tparam ExPolicy    The type of the execution policy to use (deduced).
     ///                     It describes the manner in which the execution
@@ -61,7 +62,6 @@ namespace hpx { namespace ranges {
     ///                     forward iterator.
     /// \tparam Sent        The type of the source sentinel (deduced). This
     ///                     sentinel type must be a sentinel for FwdIter.
-    /// \tparam T           The type of the value to be assigned (deduced).
     ///
     /// \param policy       The execution policy to use for the scheduling of
     ///                     the iterations.
@@ -69,64 +69,66 @@ namespace hpx { namespace ranges {
     ///                     the algorithm will be applied to.
     /// \param last         Refers to sentinel value denoting the end of the
     ///                     sequence of elements the algorithm will be applied.
-    /// \param value        The value to be assigned.
     ///
-    /// The assignments in the parallel \a uninitialized_value_construct algorithm invoked
-    /// with an execution policy object of type \a sequenced_policy
-    /// execute in sequential order in the calling thread.
+    /// The assignments in the parallel \a uninitialized_value_construct
+    /// algorithm invoked with an execution policy object of type \a
+    /// sequenced_policy execute in sequential order in the calling thread.
     ///
-    /// The assignments in the parallel \a uninitialized_value_construct algorithm invoked
-    /// with an execution policy object of type \a parallel_policy or
-    /// \a parallel_task_policy are permitted to execute in an
-    /// unordered fashion in unspecified threads, and indeterminately sequenced
-    /// within each thread.
+    /// The assignments in the parallel \a uninitialized_value_construct
+    /// algorithm invoked with an execution policy object of type \a
+    /// parallel_policy or \a parallel_task_policy are permitted to execute
+    /// in an unordered fashion in unspecified threads, and indeterminately
+    /// sequenced within each thread.
     ///
     /// \returns  The \a uninitialized_value_construct algorithm returns a
-    ///           returns \a FwdIter.
-    ///           The \a uninitialized_value_construct algorithm returns the output
-    ///           iterator to the element in the range, one past
-    ///           the last element copied.
+    ///           \a hpx::future<FwdIter> if the execution policy is of type
+    ///           \a sequenced_task_policy or
+    ///           \a parallel_task_policy and
+    ///           returns \a FwdIter otherwise.
+    ///           The \a uninitialized_value_construct algorithm returns
+    ///           the iterator to the element in the source range, one past
+    ///           the last element constructed.
     ///
     template <typename ExPolicy, typename FwdIter, typename Sent>
     typename parallel::util::detail::algorithm_result<ExPolicy, FwdIter>::type
     uninitialized_value_construct(
-        ExPolicy&& policy, FwdIter first, Sent last, T const& value);
+        ExPolicy&& policy, FwdIter first, Sent last);
 
-    /// Copies the given \a value to an uninitialized memory area, defined by
-    /// the range [first, last). If an exception is thrown during the
+    /// Constructs objects of type typename iterator_traits<ForwardIt>
+    /// ::value_type in the uninitialized storage designated by the range
+    /// by value-initialization. If an exception is thrown during the
     /// initialization, the function has no effects.
     ///
-    /// \note   Complexity: Linear in the distance between \a first and \a last
+    /// \note   Complexity: Performs exactly \a last - \a first assignments.
     ///
     /// \tparam Rng         The type of the source range used (deduced).
     ///                     The iterators extracted from this range type must
     ///                     meet the requirements of an input iterator.
-    /// \tparam T           The type of the value to be assigned (deduced).
     ///
-    /// \param rng          Refers to the range to which the value
-    ///                     will be filled
-    /// \param value        The value to be assigned.
+    /// \param rng          Refers to the range to which will be value
+    ///                     constructed.
     ///
-    /// The assignments in the parallel \a uninitialized_value_construct algorithm invoked
-    /// without an execution policy object will execute in sequential order in
-    /// the calling thread.
+    /// The assignments in the parallel \a uninitialized_value_construct
+    /// algorithm invoked without an execution policy object will execute in
+    /// sequential order in the calling thread.
     ///
     /// \returns  The \a uninitialized_value_construct algorithm returns a
     ///           returns \a hpx::traits::range_traits<Rng>
     ///           ::iterator_type.
-    ///           The \a uninitialized_value_construct algorithm returns the output
-    ///           iterator to the element in the range, one past
-    ///           the last element copied.
+    ///           The \a uninitialized_value_construct algorithm returns
+    ///           the output iterator to the element in the range, one past
+    ///           the last element constructed.
     ///
-    template <typename Rng, typename T>
+    template <typename Rng>
     typename hpx::traits::range_traits<Rng>::iterator_type
-    uninitialized_value_construct(Rng&& rng, T const& value);
+    uninitialized_value_construct(Rng&& rng);
 
-    /// Copies the given \a value to an uninitialized memory area, defined by
-    /// the range [first, last). If an exception is thrown during the
+    /// Constructs objects of type typename iterator_traits<ForwardIt>
+    /// ::value_type in the uninitialized storage designated by the range
+    /// by value-initialization. If an exception is thrown during the
     /// initialization, the function has no effects.
     ///
-    /// \note   Complexity: Linear in the distance between \a first and \a last
+    /// \note   Complexity: Performs exactly \a last - \a first assignments.
     ///
     /// \tparam ExPolicy    The type of the execution policy to use (deduced).
     ///                     It describes the manner in which the execution
@@ -135,23 +137,21 @@ namespace hpx { namespace ranges {
     /// \tparam Rng         The type of the source range used (deduced).
     ///                     The iterators extracted from this range type must
     ///                     meet the requirements of an input iterator.
-    /// \tparam T           The type of the value to be assigned (deduced).
     ///
     /// \param policy       The execution policy to use for the scheduling of
     ///                     the iterations.
     /// \param rng          Refers to the range to which the value
-    ///                     will be filled
-    /// \param value        The value to be assigned.
+    ///                     will be value consutrcted
     ///
-    /// The assignments in the parallel \a uninitialized_value_construct algorithm invoked
-    /// with an execution policy object of type \a sequenced_policy
-    /// execute in sequential order in the calling thread.
+    /// The assignments in the parallel \a uninitialized_value_construct
+    /// algorithm invoked with an execution policy object of type \a
+    /// sequenced_policy execute in sequential order in the calling thread.
     ///
-    /// The assignments in the parallel \a uninitialized_value_construct algorithm invoked
-    /// with an execution policy object of type \a parallel_policy or
-    /// \a parallel_task_policy are permitted to execute in an
-    /// unordered fashion in unspecified threads, and indeterminately sequenced
-    /// within each thread.
+    /// The assignments in the parallel \a uninitialized_value_construct
+    /// algorithm invoked with an execution policy object of type \a
+    /// parallel_policy or \a parallel_task_policy are permitted to execute
+    /// in an unordered fashion in unspecified threads, and indeterminately
+    /// sequenced within each thread.
     ///
     /// \returns  The \a uninitialized_value_construct algorithm returns a
     ///           \a hpx::future<typename hpx::traits::range_traits<Rng>
@@ -159,52 +159,51 @@ namespace hpx { namespace ranges {
     ///           execution policy is of type \a sequenced_task_policy
     ///           or \a parallel_task_policy and returns \a typename
     ///           hpx::traits::range_traits<Rng>::iterator_type otherwise.
-    ///           The \a uninitialized_value_construct algorithm returns the
-    ///           iterator to one past the last element filled in the range.
+    ///           The \a uninitialized_value_construct algorithm returns
+    ///           the output iterator to the element in the range, one past
+    ///           the last element constructed.
     ///
-    template <typename ExPolicy, typename Rng, typename T>
+    template <typename ExPolicy, typename Rng>
     typename parallel::util::detail::algorithm_result<ExPolicy,
-        typename hpx::traits::range_traits<Rng1>::iterator_type>::type
-    uninitialized_value_construct(ExPolicy&& policy, Rng&& rng, T const& value);
+        typename hpx::traits::range_traits<Rng>::iterator_type>::type
+    uninitialized_value_construct(ExPolicy&& policy, Rng&& rng);
 
-    /// Copies the given \a value value to the first count elements in an
-    /// uninitialized memory area beginning at first. If an exception is thrown
-    /// during the initialization, the function has no effects.
+    /// Constructs objects of type typename iterator_traits<ForwardIt>
+    /// ::value_type in the uninitialized storage designated by the range
+    /// [first, first + count) by value-initialization. If an exception
+    /// is thrown during the initialization, the function has no effects.
     ///
     /// \note   Complexity: Performs exactly \a count assignments, if
     ///         count > 0, no assignments otherwise.
     ///
     /// \tparam FwdIter     The type of the source iterators used (deduced).
-    ///                     This iterator type must meet the requirements of a
+    ///                     This iterator type must meet the requirements of an
     ///                     forward iterator.
     /// \tparam Size        The type of the argument specifying the number of
     ///                     elements to apply \a f to.
-    /// \tparam T           The type of the value to be assigned (deduced).
     ///
     /// \param first        Refers to the beginning of the sequence of elements
     ///                     the algorithm will be applied to.
     /// \param count        Refers to the number of elements starting at
     ///                     \a first the algorithm will be applied to.
-    /// \param value        The value to be assigned.
     ///
-    /// The assignments in the parallel \a uninitialized_value_construct_n algorithm
-    /// invoked with an execution policy object of type
-    /// \a sequenced_policy execute in sequential order in the
-    /// calling thread.
+    /// The assignments in the parallel \a uninitialized_value_construct_n
+    /// algorithm invoked without an execution policy object execute in
+    /// sequential order in the calling thread.
     ///
     /// \returns  The \a uninitialized_value_construct_n algorithm returns a
     ///           returns \a FwdIter.
-    ///           The \a uninitialized_value_construct_n algorithm returns the output
-    ///           iterator to the element in the range, one past
-    ///           the last element copied.
+    ///           The \a uninitialized_value_construct_n algorithm returns
+    ///           the iterator to the element in the source range, one past
+    ///           the last element constructed.
     ///
-    template <typename FwdIter, typename Size, typename T>
-    FwdIter uninitialized_value_construct_n(
-        FwdIter first, Size count, T const& value);
+    template <typename FwdIter, typename Size>
+    FwdIter uninitialized_value_construct_n(FwdIter first, Size count);
 
-    /// Copies the given \a value value to the first count elements in an
-    /// uninitialized memory area beginning at first. If an exception is thrown
-    /// during the initialization, the function has no effects.
+    /// Constructs objects of type typename iterator_traits<ForwardIt>
+    /// ::value_type in the uninitialized storage designated by the range
+    /// [first, first + count) by value-initialization. If an exception
+    /// is thrown during the initialization, the function has no effects.
     ///
     /// \note   Complexity: Performs exactly \a count assignments, if
     ///         count > 0, no assignments otherwise.
@@ -214,11 +213,10 @@ namespace hpx { namespace ranges {
     ///                     of the algorithm may be parallelized and the manner
     ///                     in which it executes the assignments.
     /// \tparam FwdIter     The type of the source iterators used (deduced).
-    ///                     This iterator type must meet the requirements of a
+    ///                     This iterator type must meet the requirements of an
     ///                     forward iterator.
     /// \tparam Size        The type of the argument specifying the number of
     ///                     elements to apply \a f to.
-    /// \tparam T           The type of the value to be assigned (deduced).
     ///
     /// \param policy       The execution policy to use for the scheduling of
     ///                     the iterations.
@@ -226,34 +224,35 @@ namespace hpx { namespace ranges {
     ///                     the algorithm will be applied to.
     /// \param count        Refers to the number of elements starting at
     ///                     \a first the algorithm will be applied to.
-    /// \param value        The value to be assigned.
     ///
-    /// The assignments in the parallel \a uninitialized_value_construct_n algorithm
-    /// invoked with an execution policy object of type
+    /// The assignments in the parallel \a uninitialized_value_construct_n
+    /// algorithm invoked with an execution policy object of type
     /// \a sequenced_policy execute in sequential order in the
     /// calling thread.
     ///
-    /// The assignments in the parallel \a uninitialized_value_construct_n algorithm
-    /// invoked with an execution policy object of type
+    /// The assignments in the parallel \a uninitialized_value_construct_n
+    /// algorithm invoked with an execution policy object of type
     /// \a parallel_policy or
     /// \a parallel_task_policy are permitted to execute in an
     /// unordered fashion in unspecified threads, and indeterminately sequenced
     /// within each thread.
     ///
     /// \returns  The \a uninitialized_value_construct_n algorithm returns a
-    ///           \a hpx::future<FwdIter>, if the execution policy is of type
+    ///           \a hpx::future<FwdIter> if the execution policy is of type
     ///           \a sequenced_task_policy or
-    ///           \a parallel_task_policy and returns FwdIter
-    ///           otherwise.
-    ///           The \a uninitialized_value_construct_n algorithm returns the output
-    ///           iterator to the element in the range, one past
-    ///           the last element copied.
+    ///           \a parallel_task_policy and
+    ///           returns \a FwdIter otherwise.
+    ///           The \a uninitialized_value_construct_n algorithm returns
+    ///           the iterator to the element in the source range, one past
+    ///           the last element constructed.
     ///
-    template <typename ExPolicy, typename FwdIter, typename Size, typename T>
+    template <typename ExPolicy, typename FwdIter, typename Size>
     typename typename parallel::util::detail::algorithm_result<ExPolicy,
         FwdIter>::type
     uninitialized_value_construct_n(
-        ExPolicy&& policy, FwdIter first, Size count, T const& value);
+        ExPolicy&& policy, FwdIter first, Size count);
+
+    // clang-format on
 }}    // namespace hpx::ranges
 #else
 

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/uninitialized_value_construct.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/uninitialized_value_construct.hpp
@@ -1,0 +1,413 @@
+//  Copyright (c) 2020 ETH Zurich
+//  Copyright (c) 2014 Grant Mercer
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+/// \file parallel/container_algorithms/uninitialized_value_construct.hpp
+
+#pragma once
+
+#if defined(DOXYGEN)
+
+namespace hpx { namespace ranges {
+
+    /// Copies the given \a value to an uninitialized memory area, defined by
+    /// the range [first, last). If an exception is thrown during the
+    /// initialization, the function has no effects.
+    ///
+    /// \note   Complexity: Linear in the distance between \a first and \a last
+    ///
+    /// \tparam FwdIter     The type of the source iterators used (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     forward iterator.
+    /// \tparam Sent        The type of the source sentinel (deduced). This
+    ///                     sentinel type must be a sentinel for FwdIter.
+    /// \tparam T           The type of the value to be assigned (deduced).
+    ///
+    /// \param first        Refers to the beginning of the sequence of elements
+    ///                     the algorithm will be applied to.
+    /// \param last         Refers to sentinel value denoting the end of the
+    ///                     sequence of elements the algorithm will be applied.
+    /// \param value        The value to be assigned.
+    ///
+    /// The assignments in the ranges \a uninitialized_value_construct algorithm invoked
+    /// without an execution policy object will execute in sequential order in
+    /// the calling thread.
+    ///
+    /// \returns  The \a uninitialized_value_construct algorithm returns a
+    ///           returns \a FwdIter.
+    ///           The \a uninitialized_value_construct algorithm returns the output
+    ///           iterator to the element in the range, one past
+    ///           the last element copied.
+    ///
+    template <typename FwdIter, typename Sent, typename T>
+    FwdIter uninitialized_value_construct(
+        FwdIter first, Sent last, T const& value);
+
+    /// Copies the given \a value to an uninitialized memory area, defined by
+    /// the range [first, last). If an exception is thrown during the
+    /// initialization, the function has no effects.
+    ///
+    /// \note   Complexity: Linear in the distance between \a first and \a last
+    ///
+    /// \tparam ExPolicy    The type of the execution policy to use (deduced).
+    ///                     It describes the manner in which the execution
+    ///                     of the algorithm may be parallelized and the manner
+    ///                     in which it executes the assignments.
+    /// \tparam FwdIter     The type of the source iterators used (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     forward iterator.
+    /// \tparam Sent        The type of the source sentinel (deduced). This
+    ///                     sentinel type must be a sentinel for FwdIter.
+    /// \tparam T           The type of the value to be assigned (deduced).
+    ///
+    /// \param policy       The execution policy to use for the scheduling of
+    ///                     the iterations.
+    /// \param first        Refers to the beginning of the sequence of elements
+    ///                     the algorithm will be applied to.
+    /// \param last         Refers to sentinel value denoting the end of the
+    ///                     sequence of elements the algorithm will be applied.
+    /// \param value        The value to be assigned.
+    ///
+    /// The assignments in the parallel \a uninitialized_value_construct algorithm invoked
+    /// with an execution policy object of type \a sequenced_policy
+    /// execute in sequential order in the calling thread.
+    ///
+    /// The assignments in the parallel \a uninitialized_value_construct algorithm invoked
+    /// with an execution policy object of type \a parallel_policy or
+    /// \a parallel_task_policy are permitted to execute in an
+    /// unordered fashion in unspecified threads, and indeterminately sequenced
+    /// within each thread.
+    ///
+    /// \returns  The \a uninitialized_value_construct algorithm returns a
+    ///           returns \a FwdIter.
+    ///           The \a uninitialized_value_construct algorithm returns the output
+    ///           iterator to the element in the range, one past
+    ///           the last element copied.
+    ///
+    template <typename ExPolicy, typename FwdIter, typename Sent>
+    typename parallel::util::detail::algorithm_result<ExPolicy, FwdIter>::type
+    uninitialized_value_construct(
+        ExPolicy&& policy, FwdIter first, Sent last, T const& value);
+
+    /// Copies the given \a value to an uninitialized memory area, defined by
+    /// the range [first, last). If an exception is thrown during the
+    /// initialization, the function has no effects.
+    ///
+    /// \note   Complexity: Linear in the distance between \a first and \a last
+    ///
+    /// \tparam Rng         The type of the source range used (deduced).
+    ///                     The iterators extracted from this range type must
+    ///                     meet the requirements of an input iterator.
+    /// \tparam T           The type of the value to be assigned (deduced).
+    ///
+    /// \param rng          Refers to the range to which the value
+    ///                     will be filled
+    /// \param value        The value to be assigned.
+    ///
+    /// The assignments in the parallel \a uninitialized_value_construct algorithm invoked
+    /// without an execution policy object will execute in sequential order in
+    /// the calling thread.
+    ///
+    /// \returns  The \a uninitialized_value_construct algorithm returns a
+    ///           returns \a hpx::traits::range_traits<Rng>
+    ///           ::iterator_type.
+    ///           The \a uninitialized_value_construct algorithm returns the output
+    ///           iterator to the element in the range, one past
+    ///           the last element copied.
+    ///
+    template <typename Rng, typename T>
+    typename hpx::traits::range_traits<Rng>::iterator_type
+    uninitialized_value_construct(Rng&& rng, T const& value);
+
+    /// Copies the given \a value to an uninitialized memory area, defined by
+    /// the range [first, last). If an exception is thrown during the
+    /// initialization, the function has no effects.
+    ///
+    /// \note   Complexity: Linear in the distance between \a first and \a last
+    ///
+    /// \tparam ExPolicy    The type of the execution policy to use (deduced).
+    ///                     It describes the manner in which the execution
+    ///                     of the algorithm may be parallelized and the manner
+    ///                     in which it executes the assignments.
+    /// \tparam Rng         The type of the source range used (deduced).
+    ///                     The iterators extracted from this range type must
+    ///                     meet the requirements of an input iterator.
+    /// \tparam T           The type of the value to be assigned (deduced).
+    ///
+    /// \param policy       The execution policy to use for the scheduling of
+    ///                     the iterations.
+    /// \param rng          Refers to the range to which the value
+    ///                     will be filled
+    /// \param value        The value to be assigned.
+    ///
+    /// The assignments in the parallel \a uninitialized_value_construct algorithm invoked
+    /// with an execution policy object of type \a sequenced_policy
+    /// execute in sequential order in the calling thread.
+    ///
+    /// The assignments in the parallel \a uninitialized_value_construct algorithm invoked
+    /// with an execution policy object of type \a parallel_policy or
+    /// \a parallel_task_policy are permitted to execute in an
+    /// unordered fashion in unspecified threads, and indeterminately sequenced
+    /// within each thread.
+    ///
+    /// \returns  The \a uninitialized_value_construct algorithm returns a
+    ///           \a hpx::future<typename hpx::traits::range_traits<Rng>
+    ///           ::iterator_type>, if the
+    ///           execution policy is of type \a sequenced_task_policy
+    ///           or \a parallel_task_policy and returns \a typename
+    ///           hpx::traits::range_traits<Rng>::iterator_type otherwise.
+    ///           The \a uninitialized_value_construct algorithm returns the
+    ///           iterator to one past the last element filled in the range.
+    ///
+    template <typename ExPolicy, typename Rng, typename T>
+    typename parallel::util::detail::algorithm_result<ExPolicy,
+        typename hpx::traits::range_traits<Rng1>::iterator_type>::type
+    uninitialized_value_construct(ExPolicy&& policy, Rng&& rng, T const& value);
+
+    /// Copies the given \a value value to the first count elements in an
+    /// uninitialized memory area beginning at first. If an exception is thrown
+    /// during the initialization, the function has no effects.
+    ///
+    /// \note   Complexity: Performs exactly \a count assignments, if
+    ///         count > 0, no assignments otherwise.
+    ///
+    /// \tparam FwdIter     The type of the source iterators used (deduced).
+    ///                     This iterator type must meet the requirements of a
+    ///                     forward iterator.
+    /// \tparam Size        The type of the argument specifying the number of
+    ///                     elements to apply \a f to.
+    /// \tparam T           The type of the value to be assigned (deduced).
+    ///
+    /// \param first        Refers to the beginning of the sequence of elements
+    ///                     the algorithm will be applied to.
+    /// \param count        Refers to the number of elements starting at
+    ///                     \a first the algorithm will be applied to.
+    /// \param value        The value to be assigned.
+    ///
+    /// The assignments in the parallel \a uninitialized_value_construct_n algorithm
+    /// invoked with an execution policy object of type
+    /// \a sequenced_policy execute in sequential order in the
+    /// calling thread.
+    ///
+    /// \returns  The \a uninitialized_value_construct_n algorithm returns a
+    ///           returns \a FwdIter.
+    ///           The \a uninitialized_value_construct_n algorithm returns the output
+    ///           iterator to the element in the range, one past
+    ///           the last element copied.
+    ///
+    template <typename FwdIter, typename Size, typename T>
+    FwdIter uninitialized_value_construct_n(
+        FwdIter first, Size count, T const& value);
+
+    /// Copies the given \a value value to the first count elements in an
+    /// uninitialized memory area beginning at first. If an exception is thrown
+    /// during the initialization, the function has no effects.
+    ///
+    /// \note   Complexity: Performs exactly \a count assignments, if
+    ///         count > 0, no assignments otherwise.
+    ///
+    /// \tparam ExPolicy    The type of the execution policy to use (deduced).
+    ///                     It describes the manner in which the execution
+    ///                     of the algorithm may be parallelized and the manner
+    ///                     in which it executes the assignments.
+    /// \tparam FwdIter     The type of the source iterators used (deduced).
+    ///                     This iterator type must meet the requirements of a
+    ///                     forward iterator.
+    /// \tparam Size        The type of the argument specifying the number of
+    ///                     elements to apply \a f to.
+    /// \tparam T           The type of the value to be assigned (deduced).
+    ///
+    /// \param policy       The execution policy to use for the scheduling of
+    ///                     the iterations.
+    /// \param first        Refers to the beginning of the sequence of elements
+    ///                     the algorithm will be applied to.
+    /// \param count        Refers to the number of elements starting at
+    ///                     \a first the algorithm will be applied to.
+    /// \param value        The value to be assigned.
+    ///
+    /// The assignments in the parallel \a uninitialized_value_construct_n algorithm
+    /// invoked with an execution policy object of type
+    /// \a sequenced_policy execute in sequential order in the
+    /// calling thread.
+    ///
+    /// The assignments in the parallel \a uninitialized_value_construct_n algorithm
+    /// invoked with an execution policy object of type
+    /// \a parallel_policy or
+    /// \a parallel_task_policy are permitted to execute in an
+    /// unordered fashion in unspecified threads, and indeterminately sequenced
+    /// within each thread.
+    ///
+    /// \returns  The \a uninitialized_value_construct_n algorithm returns a
+    ///           \a hpx::future<FwdIter>, if the execution policy is of type
+    ///           \a sequenced_task_policy or
+    ///           \a parallel_task_policy and returns FwdIter
+    ///           otherwise.
+    ///           The \a uninitialized_value_construct_n algorithm returns the output
+    ///           iterator to the element in the range, one past
+    ///           the last element copied.
+    ///
+    template <typename ExPolicy, typename FwdIter, typename Size, typename T>
+    typename typename parallel::util::detail::algorithm_result<ExPolicy,
+        FwdIter>::type
+    uninitialized_value_construct_n(
+        ExPolicy&& policy, FwdIter first, Size count, T const& value);
+}}    // namespace hpx::ranges
+#else
+
+#include <hpx/config.hpp>
+#include <hpx/algorithms/traits/projected_range.hpp>
+#include <hpx/execution/algorithms/detail/predicates.hpp>
+#include <hpx/executors/execution_policy.hpp>
+#include <hpx/iterator_support/traits/is_iterator.hpp>
+#include <hpx/parallel/algorithms/uninitialized_value_construct.hpp>
+#include <hpx/parallel/util/detail/algorithm_result.hpp>
+#include <hpx/parallel/util/projection_identity.hpp>
+
+#include <algorithm>
+#include <cstddef>
+#include <iterator>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+namespace hpx { namespace ranges {
+    HPX_INLINE_CONSTEXPR_VARIABLE struct uninitialized_value_construct_t final
+      : hpx::functional::tag_fallback<uninitialized_value_construct_t>
+    {
+    private:
+        // clang-format off
+        template <typename FwdIter, typename Sent,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::traits::is_forward_iterator<FwdIter>::value &&
+                hpx::traits::is_sentinel_for<Sent, FwdIter>::value
+            )>
+        // clang-format on
+        friend FwdIter tag_fallback_dispatch(
+            hpx::ranges::uninitialized_value_construct_t, FwdIter first,
+            Sent last)
+        {
+            static_assert(hpx::traits::is_forward_iterator<FwdIter>::value,
+                "Requires at least forward iterator.");
+
+            return hpx::parallel::v1::detail::uninitialized_value_construct<
+                FwdIter>()
+                .call(hpx::execution::seq, first, last);
+        }
+
+        // clang-format off
+        template <typename ExPolicy, typename FwdIter, typename Sent,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::is_execution_policy<ExPolicy>::value &&
+                hpx::traits::is_forward_iterator<FwdIter>::value &&
+                hpx::traits::is_sentinel_for<Sent, FwdIter>::value
+            )>
+        // clang-format on
+        friend typename parallel::util::detail::algorithm_result<ExPolicy,
+            FwdIter>::type
+        tag_fallback_dispatch(hpx::ranges::uninitialized_value_construct_t,
+            ExPolicy&& policy, FwdIter first, Sent last)
+        {
+            static_assert(hpx::traits::is_forward_iterator<FwdIter>::value,
+                "Requires at least forward iterator.");
+
+            return hpx::parallel::v1::detail::uninitialized_value_construct<
+                FwdIter>()
+                .call(std::forward<ExPolicy>(policy), first, last);
+        }
+
+        // clang-format off
+        template <typename Rng,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::traits::is_range<Rng>::value
+            )>
+        // clang-format on
+        friend typename hpx::traits::range_traits<Rng>::iterator_type
+        tag_fallback_dispatch(
+            hpx::ranges::uninitialized_value_construct_t, Rng&& rng)
+        {
+            using iterator_type =
+                typename hpx::traits::range_traits<Rng>::iterator_type;
+
+            static_assert(
+                hpx::traits::is_forward_iterator<iterator_type>::value,
+                "Requires at least forward iterator.");
+
+            return hpx::parallel::v1::detail::uninitialized_value_construct<
+                iterator_type>()
+                .call(hpx::execution::seq, std::begin(rng), std::end(rng));
+        }
+
+        // clang-format off
+        template <typename ExPolicy, typename Rng,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::is_execution_policy<ExPolicy>::value &&
+                hpx::traits::is_range<Rng>::value
+            )>
+        // clang-format on
+        friend typename parallel::util::detail::algorithm_result<ExPolicy,
+            typename hpx::traits::range_traits<Rng>::iterator_type>::type
+        tag_fallback_dispatch(hpx::ranges::uninitialized_value_construct_t,
+            ExPolicy&& policy, Rng&& rng)
+        {
+            using iterator_type =
+                typename hpx::traits::range_traits<Rng>::iterator_type;
+
+            static_assert(
+                hpx::traits::is_forward_iterator<iterator_type>::value,
+                "Requires at least forward iterator.");
+
+            return hpx::parallel::v1::detail::uninitialized_value_construct<
+                iterator_type>()
+                .call(std::forward<ExPolicy>(policy), std::begin(rng),
+                    std::end(rng));
+        }
+    } uninitialized_value_construct{};
+
+    HPX_INLINE_CONSTEXPR_VARIABLE struct uninitialized_value_construct_n_t final
+      : hpx::functional::tag_fallback<uninitialized_value_construct_n_t>
+    {
+    private:
+        // clang-format off
+        template <typename FwdIter, typename Size,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::traits::is_forward_iterator<FwdIter>::value
+            )>
+        // clang-format on
+        friend FwdIter tag_fallback_dispatch(
+            hpx::ranges::uninitialized_value_construct_n_t, FwdIter first,
+            Size count)
+        {
+            static_assert(hpx::traits::is_forward_iterator<FwdIter>::value,
+                "Requires at least forward iterator.");
+
+            return hpx::parallel::v1::detail::uninitialized_value_construct_n<
+                FwdIter>()
+                .call(hpx::execution::seq, first, count);
+        }
+
+        // clang-format off
+        template <typename ExPolicy, typename FwdIter, typename Size,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::is_execution_policy<ExPolicy>::value &&
+                hpx::traits::is_forward_iterator<FwdIter>::value
+            )>
+        // clang-format on
+        friend typename parallel::util::detail::algorithm_result<ExPolicy,
+            FwdIter>::type
+        tag_fallback_dispatch(hpx::ranges::uninitialized_value_construct_n_t,
+            ExPolicy&& policy, FwdIter first, Size count)
+        {
+            static_assert(hpx::traits::is_forward_iterator<FwdIter>::value,
+                "Requires at least forward iterator.");
+
+            return hpx::parallel::v1::detail::uninitialized_value_construct_n<
+                FwdIter>()
+                .call(std::forward<ExPolicy>(policy), first, count);
+        }
+    } uninitialized_value_construct_n{};
+}}    // namespace hpx::ranges
+
+#endif

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_memory.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_memory.hpp
@@ -8,6 +8,8 @@
 
 #include <hpx/parallel/memory.hpp>
 
-#include <hpx/parallel/container_algorithms/uninitialized_copy.hpp>
 #include <hpx/parallel/container_algorithms/destroy.hpp>
+#include <hpx/parallel/container_algorithms/uninitialized_copy.hpp>
+#include <hpx/parallel/container_algorithms/uninitialized_default_construct.hpp>
 #include <hpx/parallel/container_algorithms/uninitialized_move.hpp>
+#include <hpx/parallel/container_algorithms/uninitialized_value_construct.hpp>

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_memory.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_memory.hpp
@@ -8,5 +8,6 @@
 
 #include <hpx/parallel/memory.hpp>
 
+#include <hpx/parallel/container_algorithms/uninitialized_copy.hpp>
 #include <hpx/parallel/container_algorithms/destroy.hpp>
 #include <hpx/parallel/container_algorithms/uninitialized_move.hpp>

--- a/libs/parallelism/algorithms/tests/unit/algorithms/uninitialized_copy_tests.hpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/uninitialized_copy_tests.hpp
@@ -33,7 +33,7 @@ void test_uninitialized_copy(ExPolicy&& policy, IteratorTag)
     std::vector<std::size_t> c(10007);
     std::vector<std::size_t> d(c.size());
     std::iota(std::begin(c), std::end(c), std::rand());
-    hpx::parallel::uninitialized_copy(std::forward<ExPolicy>(policy),
+    hpx::uninitialized_copy(std::forward<ExPolicy>(policy),
         iterator(std::begin(c)), iterator(std::end(c)), std::begin(d));
 
     std::size_t count = 0;
@@ -57,7 +57,7 @@ void test_uninitialized_copy_async(ExPolicy&& p, IteratorTag)
     std::iota(std::begin(c), std::end(c), std::rand());
 
     hpx::future<base_iterator> f =
-        hpx::parallel::uninitialized_copy(std::forward<ExPolicy>(p),
+        hpx::uninitialized_copy(std::forward<ExPolicy>(p),
             iterator(std::begin(c)), iterator(std::end(c)), std::begin(d));
     f.wait();
 
@@ -92,7 +92,7 @@ void test_uninitialized_copy_exception(ExPolicy policy, IteratorTag)
     bool caught_exception = false;
     try
     {
-        hpx::parallel::uninitialized_copy(policy,
+        hpx::uninitialized_copy(policy,
             decorated_iterator(std::begin(c),
                 [&throw_after]() {
                     if (throw_after-- == 0)
@@ -133,7 +133,7 @@ void test_uninitialized_copy_exception_async(ExPolicy p, IteratorTag)
     bool returned_from_algorithm = false;
     try
     {
-        hpx::future<base_iterator> f = hpx::parallel::uninitialized_copy(p,
+        hpx::future<base_iterator> f = hpx::uninitialized_copy(p,
             decorated_iterator(std::begin(c),
                 [&throw_after]() {
                     if (throw_after-- == 0)
@@ -182,7 +182,7 @@ void test_uninitialized_copy_bad_alloc(ExPolicy policy, IteratorTag)
     bool caught_bad_alloc = false;
     try
     {
-        hpx::parallel::uninitialized_copy(policy,
+        hpx::uninitialized_copy(policy,
             decorated_iterator(std::begin(c),
                 [&throw_after]() {
                     if (throw_after-- == 0)
@@ -223,7 +223,7 @@ void test_uninitialized_copy_bad_alloc_async(ExPolicy p, IteratorTag)
     bool returned_from_algorithm = false;
     try
     {
-        hpx::future<base_iterator> f = hpx::parallel::uninitialized_copy(p,
+        hpx::future<base_iterator> f = hpx::uninitialized_copy(p,
             decorated_iterator(std::begin(c),
                 [&throw_after]() {
                     if (throw_after-- == 0)

--- a/libs/parallelism/algorithms/tests/unit/algorithms/uninitialized_copyn.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/uninitialized_copyn.cpp
@@ -32,7 +32,7 @@ void test_uninitialized_copy_n(ExPolicy policy, IteratorTag)
     std::vector<std::size_t> d(c.size());
     std::iota(std::begin(c), std::end(c), std::rand());
 
-    hpx::parallel::uninitialized_copy_n(
+    hpx::uninitialized_copy_n(
         policy, iterator(std::begin(c)), c.size(), std::begin(d));
 
     std::size_t count = 0;
@@ -55,7 +55,7 @@ void test_uninitialized_copy_n_async(ExPolicy p, IteratorTag)
     std::vector<std::size_t> d(c.size());
     std::iota(std::begin(c), std::end(c), std::rand());
 
-    hpx::future<base_iterator> f = hpx::parallel::uninitialized_copy_n(
+    hpx::future<base_iterator> f = hpx::uninitialized_copy_n(
         p, iterator(std::begin(c)), c.size(), std::begin(d));
     f.wait();
 
@@ -109,7 +109,7 @@ void test_uninitialized_copy_n_exception(ExPolicy policy, IteratorTag)
     bool caught_exception = false;
     try
     {
-        hpx::parallel::uninitialized_copy_n(policy,
+        hpx::uninitialized_copy_n(policy,
             decorated_iterator(std::begin(c),
                 [&throw_after]() {
                     if (throw_after-- == 0)
@@ -150,7 +150,7 @@ void test_uninitialized_copy_n_exception_async(ExPolicy p, IteratorTag)
     bool returned_from_algorithm = false;
     try
     {
-        hpx::future<base_iterator> f = hpx::parallel::uninitialized_copy_n(p,
+        hpx::future<base_iterator> f = hpx::uninitialized_copy_n(p,
             decorated_iterator(std::begin(c),
                 [&throw_after]() {
                     if (throw_after-- == 0)
@@ -220,7 +220,7 @@ void test_uninitialized_copy_n_bad_alloc(ExPolicy policy, IteratorTag)
     bool caught_bad_alloc = false;
     try
     {
-        hpx::parallel::uninitialized_copy_n(policy,
+        hpx::uninitialized_copy_n(policy,
             decorated_iterator(std::begin(c),
                 [&throw_after]() {
                     if (throw_after-- == 0)
@@ -261,7 +261,7 @@ void test_uninitialized_copy_n_bad_alloc_async(ExPolicy p, IteratorTag)
     bool returned_from_algorithm = false;
     try
     {
-        hpx::future<base_iterator> f = hpx::parallel::uninitialized_copy_n(p,
+        hpx::future<base_iterator> f = hpx::uninitialized_copy_n(p,
             decorated_iterator(std::begin(c),
                 [&throw_after]() {
                     if (throw_after-- == 0)

--- a/libs/parallelism/algorithms/tests/unit/algorithms/uninitialized_default_construct_tests.hpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/uninitialized_default_construct_tests.hpp
@@ -52,7 +52,7 @@ void test_uninitialized_default_construct(ExPolicy&& policy, IteratorTag)
     std::memset(
         static_cast<void*>(p), 0xcd, data_size * sizeof(default_constructable));
 
-    hpx::parallel::uninitialized_default_construct(
+    hpx::uninitialized_default_construct(
         std::forward<ExPolicy>(policy), iterator(p), iterator(p + data_size));
 
     std::size_t count = 0;
@@ -76,7 +76,7 @@ void test_uninitialized_default_construct_async(ExPolicy&& policy, IteratorTag)
     std::memset(
         static_cast<void*>(p), 0xcd, data_size * sizeof(default_constructable));
 
-    auto f = hpx::parallel::uninitialized_default_construct(
+    auto f = hpx::uninitialized_default_construct(
         std::forward<ExPolicy>(policy), iterator(p), iterator(p + data_size));
     f.wait();
 
@@ -104,7 +104,7 @@ void test_uninitialized_default_construct2(ExPolicy&& policy, IteratorTag)
     std::memset(
         static_cast<void*>(p), 0xcd, data_size * sizeof(value_constructable));
 
-    hpx::parallel::uninitialized_default_construct(
+    hpx::uninitialized_default_construct(
         std::forward<ExPolicy>(policy), iterator(p), iterator(p + data_size));
 
     std::size_t count = 0;
@@ -128,7 +128,7 @@ void test_uninitialized_default_construct_async2(ExPolicy&& policy, IteratorTag)
     std::memset(
         static_cast<void*>(p), 0xcd, data_size * sizeof(value_constructable));
 
-    auto f = hpx::parallel::uninitialized_default_construct(
+    auto f = hpx::uninitialized_default_construct(
         std::forward<ExPolicy>(policy), iterator(p), iterator(p + data_size));
     f.wait();
 
@@ -167,7 +167,7 @@ void test_uninitialized_default_construct_exception(
     bool caught_exception = false;
     try
     {
-        hpx::parallel::uninitialized_default_construct(policy,
+        hpx::uninitialized_default_construct(policy,
             decorated_iterator(p,
                 [&throw_after]() {
                     if (throw_after-- == 0)
@@ -215,7 +215,7 @@ void test_uninitialized_default_construct_exception_async(
     bool returned_from_algorithm = false;
     try
     {
-        auto f = hpx::parallel::uninitialized_default_construct(policy,
+        auto f = hpx::uninitialized_default_construct(policy,
             decorated_iterator(p,
                 [&throw_after]() {
                     if (throw_after-- == 0)
@@ -271,7 +271,7 @@ void test_uninitialized_default_construct_bad_alloc(
     bool caught_bad_alloc = false;
     try
     {
-        hpx::parallel::uninitialized_default_construct(policy,
+        hpx::uninitialized_default_construct(policy,
             decorated_iterator(p,
                 [&throw_after]() {
                     if (throw_after-- == 0)
@@ -319,7 +319,7 @@ void test_uninitialized_default_construct_bad_alloc_async(
     bool returned_from_algorithm = false;
     try
     {
-        auto f = hpx::parallel::uninitialized_default_construct(policy,
+        auto f = hpx::uninitialized_default_construct(policy,
             decorated_iterator(p,
                 [&throw_after]() {
                     if (throw_after-- == 0)

--- a/libs/parallelism/algorithms/tests/unit/algorithms/uninitialized_default_constructn.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/uninitialized_default_constructn.cpp
@@ -50,7 +50,7 @@ void test_uninitialized_default_construct_n(ExPolicy policy, IteratorTag)
     std::memset(
         static_cast<void*>(p), 0xcd, data_size * sizeof(default_constructable));
 
-    hpx::parallel::uninitialized_default_construct_n(
+    hpx::uninitialized_default_construct_n(
         policy, iterator(p), data_size);
 
     std::size_t count = 0;
@@ -74,7 +74,7 @@ void test_uninitialized_default_construct_n_async(ExPolicy policy, IteratorTag)
     std::memset(
         static_cast<void*>(p), 0xcd, data_size * sizeof(default_constructable));
 
-    auto f = hpx::parallel::uninitialized_default_construct_n(
+    auto f = hpx::uninitialized_default_construct_n(
         policy, iterator(p), data_size);
     f.wait();
 
@@ -102,7 +102,7 @@ void test_uninitialized_default_construct_n2(ExPolicy policy, IteratorTag)
     std::memset(
         static_cast<void*>(p), 0xcd, data_size * sizeof(value_constructable));
 
-    hpx::parallel::uninitialized_default_construct_n(
+    hpx::uninitialized_default_construct_n(
         policy, iterator(p), data_size);
 
     std::size_t count = 0;
@@ -126,7 +126,7 @@ void test_uninitialized_default_construct_n_async2(ExPolicy policy, IteratorTag)
     std::memset(
         static_cast<void*>(p), 0xcd, data_size * sizeof(value_constructable));
 
-    auto f = hpx::parallel::uninitialized_default_construct_n(
+    auto f = hpx::uninitialized_default_construct_n(
         policy, iterator(p), data_size);
     f.wait();
 
@@ -191,7 +191,7 @@ void test_uninitialized_default_construct_n_exception(
     bool caught_exception = false;
     try
     {
-        hpx::parallel::uninitialized_default_construct_n(policy,
+        hpx::uninitialized_default_construct_n(policy,
             decorated_iterator(p,
                 [&throw_after]() {
                     if (throw_after-- == 0)
@@ -239,7 +239,7 @@ void test_uninitialized_default_construct_n_exception_async(
     bool returned_from_algorithm = false;
     try
     {
-        auto f = hpx::parallel::uninitialized_default_construct_n(policy,
+        auto f = hpx::uninitialized_default_construct_n(policy,
             decorated_iterator(p,
                 [&throw_after]() {
                     if (throw_after-- == 0)
@@ -320,7 +320,7 @@ void test_uninitialized_default_construct_n_bad_alloc(
     bool caught_bad_alloc = false;
     try
     {
-        hpx::parallel::uninitialized_default_construct_n(policy,
+        hpx::uninitialized_default_construct_n(policy,
             decorated_iterator(p,
                 [&throw_after]() {
                     if (throw_after-- == 0)
@@ -368,7 +368,7 @@ void test_uninitialized_default_construct_n_bad_alloc_async(
     bool returned_from_algorithm = false;
     try
     {
-        auto f = hpx::parallel::uninitialized_default_construct_n(policy,
+        auto f = hpx::uninitialized_default_construct_n(policy,
             decorated_iterator(p,
                 [&throw_after]() {
                     if (throw_after-- == 0)

--- a/libs/parallelism/algorithms/tests/unit/algorithms/uninitialized_default_constructn.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/uninitialized_default_constructn.cpp
@@ -50,8 +50,7 @@ void test_uninitialized_default_construct_n(ExPolicy policy, IteratorTag)
     std::memset(
         static_cast<void*>(p), 0xcd, data_size * sizeof(default_constructable));
 
-    hpx::uninitialized_default_construct_n(
-        policy, iterator(p), data_size);
+    hpx::uninitialized_default_construct_n(policy, iterator(p), data_size);
 
     std::size_t count = 0;
     std::for_each(p, p + data_size, [&count](default_constructable v1) {
@@ -74,8 +73,8 @@ void test_uninitialized_default_construct_n_async(ExPolicy policy, IteratorTag)
     std::memset(
         static_cast<void*>(p), 0xcd, data_size * sizeof(default_constructable));
 
-    auto f = hpx::uninitialized_default_construct_n(
-        policy, iterator(p), data_size);
+    auto f =
+        hpx::uninitialized_default_construct_n(policy, iterator(p), data_size);
     f.wait();
 
     std::size_t count = 0;
@@ -102,8 +101,7 @@ void test_uninitialized_default_construct_n2(ExPolicy policy, IteratorTag)
     std::memset(
         static_cast<void*>(p), 0xcd, data_size * sizeof(value_constructable));
 
-    hpx::uninitialized_default_construct_n(
-        policy, iterator(p), data_size);
+    hpx::uninitialized_default_construct_n(policy, iterator(p), data_size);
 
     std::size_t count = 0;
     std::for_each(p, p + data_size, [&count](value_constructable v1) {
@@ -126,8 +124,8 @@ void test_uninitialized_default_construct_n_async2(ExPolicy policy, IteratorTag)
     std::memset(
         static_cast<void*>(p), 0xcd, data_size * sizeof(value_constructable));
 
-    auto f = hpx::uninitialized_default_construct_n(
-        policy, iterator(p), data_size);
+    auto f =
+        hpx::uninitialized_default_construct_n(policy, iterator(p), data_size);
     f.wait();
 
     std::size_t count = 0;

--- a/libs/parallelism/algorithms/tests/unit/algorithms/uninitialized_value_construct_tests.hpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/uninitialized_value_construct_tests.hpp
@@ -42,7 +42,7 @@ void test_uninitialized_value_construct(ExPolicy&& policy, IteratorTag)
     std::memset(
         static_cast<void*>(p), 0xcd, data_size * sizeof(value_constructable));
 
-    hpx::parallel::uninitialized_value_construct(
+    hpx::uninitialized_value_construct(
         std::forward<ExPolicy>(policy), iterator(p), iterator(p + data_size));
 
     std::size_t count = 0;
@@ -66,7 +66,7 @@ void test_uninitialized_value_construct_async(ExPolicy&& policy, IteratorTag)
     std::memset(
         static_cast<void*>(p), 0xcd, data_size * sizeof(value_constructable));
 
-    auto f = hpx::parallel::uninitialized_value_construct(
+    auto f = hpx::uninitialized_value_construct(
         std::forward<ExPolicy>(policy), iterator(p), iterator(p + data_size));
     f.wait();
 
@@ -104,7 +104,7 @@ void test_uninitialized_value_construct_exception(ExPolicy policy, IteratorTag)
     bool caught_exception = false;
     try
     {
-        hpx::parallel::uninitialized_value_construct(policy,
+        hpx::uninitialized_value_construct(policy,
             decorated_iterator(p,
                 [&throw_after]() {
                     if (throw_after-- == 0)
@@ -152,7 +152,7 @@ void test_uninitialized_value_construct_exception_async(
     bool returned_from_algorithm = false;
     try
     {
-        auto f = hpx::parallel::uninitialized_value_construct(policy,
+        auto f = hpx::uninitialized_value_construct(policy,
             decorated_iterator(p,
                 [&throw_after]() {
                     if (throw_after-- == 0)
@@ -207,7 +207,7 @@ void test_uninitialized_value_construct_bad_alloc(ExPolicy policy, IteratorTag)
     bool caught_bad_alloc = false;
     try
     {
-        hpx::parallel::uninitialized_value_construct(policy,
+        hpx::uninitialized_value_construct(policy,
             decorated_iterator(p,
                 [&throw_after]() {
                     if (throw_after-- == 0)
@@ -255,7 +255,7 @@ void test_uninitialized_value_construct_bad_alloc_async(
     bool returned_from_algorithm = false;
     try
     {
-        auto f = hpx::parallel::uninitialized_value_construct(policy,
+        auto f = hpx::uninitialized_value_construct(policy,
             decorated_iterator(p,
                 [&throw_after]() {
                     if (throw_after-- == 0)

--- a/libs/parallelism/algorithms/tests/unit/algorithms/uninitialized_value_constructn.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/uninitialized_value_constructn.cpp
@@ -40,8 +40,7 @@ void test_uninitialized_value_construct_n(ExPolicy policy, IteratorTag)
     std::memset(
         static_cast<void*>(p), 0xcd, data_size * sizeof(value_constructable));
 
-    hpx::parallel::uninitialized_value_construct_n(
-        policy, iterator(p), data_size);
+    hpx::uninitialized_value_construct_n(policy, iterator(p), data_size);
 
     std::size_t count = 0;
     std::for_each(p, p + data_size, [&count](value_constructable v1) {
@@ -64,8 +63,8 @@ void test_uninitialized_value_construct_n_async(ExPolicy policy, IteratorTag)
     std::memset(
         static_cast<void*>(p), 0xcd, data_size * sizeof(value_constructable));
 
-    auto f = hpx::parallel::uninitialized_value_construct_n(
-        policy, iterator(p), data_size);
+    auto f =
+        hpx::uninitialized_value_construct_n(policy, iterator(p), data_size);
     f.wait();
 
     std::size_t count = 0;
@@ -122,7 +121,7 @@ void test_uninitialized_value_construct_n_exception(
     bool caught_exception = false;
     try
     {
-        hpx::parallel::uninitialized_value_construct_n(policy,
+        hpx::uninitialized_value_construct_n(policy,
             decorated_iterator(p,
                 [&throw_after]() {
                     if (throw_after-- == 0)
@@ -170,7 +169,7 @@ void test_uninitialized_value_construct_n_exception_async(
     bool returned_from_algorithm = false;
     try
     {
-        auto f = hpx::parallel::uninitialized_value_construct_n(policy,
+        auto f = hpx::uninitialized_value_construct_n(policy,
             decorated_iterator(p,
                 [&throw_after]() {
                     if (throw_after-- == 0)
@@ -250,7 +249,7 @@ void test_uninitialized_value_construct_n_bad_alloc(
     bool caught_bad_alloc = false;
     try
     {
-        hpx::parallel::uninitialized_value_construct_n(policy,
+        hpx::uninitialized_value_construct_n(policy,
             decorated_iterator(p,
                 [&throw_after]() {
                     if (throw_after-- == 0)
@@ -298,7 +297,7 @@ void test_uninitialized_value_construct_n_bad_alloc_async(
     bool returned_from_algorithm = false;
     try
     {
-        auto f = hpx::parallel::uninitialized_value_construct_n(policy,
+        auto f = hpx::uninitialized_value_construct_n(policy,
             decorated_iterator(p,
                 [&throw_after]() {
                     if (throw_after-- == 0)

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/CMakeLists.txt
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/CMakeLists.txt
@@ -98,6 +98,8 @@ set(tests
     uninitialized_default_constructn_range
     uninitialized_move_range
     uninitialized_move_n_range
+    uninitialized_value_construct_range
+    uninitialized_value_constructn_range
     unique_range
     unique_copy_range
 )

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/CMakeLists.txt
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/CMakeLists.txt
@@ -94,6 +94,8 @@ set(tests
     transform_reduce_binary_exception_range
     transform_reduce_binary_range
     transform_reduce_range
+    uninitialized_copy_range
+    uninitialized_copy_n_range
     uninitialized_default_construct_range
     uninitialized_default_constructn_range
     uninitialized_move_range

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/CMakeLists.txt
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/CMakeLists.txt
@@ -94,6 +94,8 @@ set(tests
     transform_reduce_binary_exception_range
     transform_reduce_binary_range
     transform_reduce_range
+    uninitialized_default_construct_range
+    uninitialized_default_constructn_range
     uninitialized_move_range
     uninitialized_move_n_range
     unique_range

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/uninitialized_copy_n_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/uninitialized_copy_n_range.cpp
@@ -1,0 +1,153 @@
+//  Copyright (c) 2014 Grant Mercer
+//  Copyright (c) 2015 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/iterator_support/iterator_range.hpp>
+#include <hpx/local/init.hpp>
+#include <hpx/modules/testing.hpp>
+#include <hpx/parallel/container_algorithms/uninitialized_copy.hpp>
+
+#include <cstddef>
+#include <iostream>
+#include <iterator>
+#include <numeric>
+#include <string>
+#include <vector>
+
+#include <hpx/iterator_support/tests/iter_sent.hpp>
+#include "test_utils.hpp"
+
+////////////////////////////////////////////////////////////////////////////
+template <typename IteratorTag>
+void test_uninitialized_copy_n_sent(IteratorTag)
+{
+    std::vector<std::size_t> c(10007);
+    std::vector<std::size_t> d(c.size());
+    std::iota(std::begin(c), std::end(c), std::rand());
+    std::copy(std::begin(c), std::end(c), std::rbegin(d));
+    auto sent_len = (std::rand() % 10007) + 1;
+    hpx::ranges::uninitialized_copy_n(std::begin(c), sent_len, std::begin(d),
+        sentinel<std::size_t>{*(std::begin(d) + sent_len)});
+
+    std::size_t count = 0;
+    // loop till for sent_len since either the sentinel for the input or output iterator
+    // will be reached by then
+    HPX_TEST(std::equal(std::begin(c), std::begin(c) + sent_len, std::begin(d),
+        [&count](std::size_t v1, std::size_t v2) -> bool {
+            HPX_TEST_EQ(v1, v2);
+            ++count;
+            return v1 == v2;
+        }));
+
+    HPX_TEST_EQ(count, sent_len);
+}
+
+template <typename ExPolicy, typename IteratorTag>
+void test_uninitialized_copy_n_sent(ExPolicy&& policy, IteratorTag)
+{
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
+
+    std::vector<std::size_t> c(10007);
+    std::vector<std::size_t> d(c.size());
+    std::iota(std::begin(c), std::end(c), std::rand());
+    std::copy(std::begin(c), std::end(c), std::rbegin(d));
+    auto sent_len = (std::rand() % 10007) + 1;
+    hpx::ranges::uninitialized_copy_n(policy, std::begin(c), sent_len,
+        std::begin(d), sentinel<std::size_t>{*(std::begin(d) + sent_len)});
+
+    std::size_t count = 0;
+    // loop till for sent_len since either the sentinel for the input or output iterator
+    // will be reached by then
+    HPX_TEST(std::equal(std::begin(c), std::begin(c) + sent_len, std::begin(d),
+        [&count](std::size_t v1, std::size_t v2) -> bool {
+            HPX_TEST_EQ(v1, v2);
+            ++count;
+            return v1 == v2;
+        }));
+
+    HPX_TEST_EQ(count, sent_len);
+}
+
+template <typename ExPolicy, typename IteratorTag>
+void test_uninitialized_copy_n_sent_async(ExPolicy&& p, IteratorTag)
+{
+    std::vector<std::size_t> c(10007);
+    std::vector<std::size_t> d(c.size());
+    std::iota(std::begin(c), std::end(c), std::rand());
+    std::copy(std::begin(c), std::end(c), std::rbegin(d));
+    auto sent_len = (std::rand() % 10007) + 1;
+    auto f = hpx::ranges::uninitialized_copy_n(p, std::begin(c), sent_len,
+        std::begin(d), sentinel<std::size_t>{*(std::begin(d) + sent_len)});
+    f.wait();
+
+    std::size_t count = 0;
+    HPX_TEST(std::equal(std::begin(c), std::begin(c) + sent_len, std::begin(d),
+        [&count](std::size_t v1, std::size_t v2) -> bool {
+            HPX_TEST_EQ(v1, v2);
+            ++count;
+            return v1 == v2;
+        }));
+    HPX_TEST_EQ(count, sent_len);
+}
+
+template <typename IteratorTag>
+void test_uninitialized_copy_n_sent()
+{
+    using namespace hpx::execution;
+
+    test_uninitialized_copy_n_sent(IteratorTag());
+
+    test_uninitialized_copy_n_sent(seq, IteratorTag());
+    test_uninitialized_copy_n_sent(par, IteratorTag());
+    test_uninitialized_copy_n_sent(par_unseq, IteratorTag());
+
+    test_uninitialized_copy_n_sent_async(seq(task), IteratorTag());
+    test_uninitialized_copy_n_sent_async(par(task), IteratorTag());
+}
+
+void uninitialized_copy_n_sent_test()
+{
+    test_uninitialized_copy_n_sent<std::random_access_iterator_tag>();
+    test_uninitialized_copy_n_sent<std::forward_iterator_tag>();
+}
+
+int hpx_main(hpx::program_options::variables_map& vm)
+{
+    unsigned int seed = (unsigned int) std::time(nullptr);
+    if (vm.count("seed"))
+        seed = vm["seed"].as<unsigned int>();
+
+    std::cout << "using seed: " << seed << std::endl;
+    std::srand(seed);
+
+    uninitialized_copy_n_sent_test();
+    return hpx::local::finalize();
+}
+
+int main(int argc, char* argv[])
+{
+    // add command line option which controls the random number generator seed
+    using namespace hpx::program_options;
+    options_description desc_commandline(
+        "Usage: " HPX_APPLICATION_STRING " [options]");
+
+    desc_commandline.add_options()("seed,s", value<unsigned int>(),
+        "the random number generator seed to use for this run");
+
+    // By default this test should run on all available cores
+    std::vector<std::string> const cfg = {"hpx.os_threads=all"};
+
+    // Initialize and run HPX
+    hpx::local::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::local::init(hpx_main, argc, argv, init_args), 0,
+        "HPX main exited with non-zero status");
+
+    return hpx::util::report_errors();
+}

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/uninitialized_copy_n_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/uninitialized_copy_n_range.cpp
@@ -28,7 +28,7 @@ void test_uninitialized_copy_n_sent(IteratorTag)
     std::vector<std::size_t> d(c.size());
     std::iota(std::begin(c), std::end(c), std::rand());
     std::copy(std::begin(c), std::end(c), std::rbegin(d));
-    auto sent_len = (std::rand() % 10007) + 1;
+    std::size_t sent_len = (std::rand() % 10007) + 1;
     hpx::ranges::uninitialized_copy_n(std::begin(c), sent_len, std::begin(d),
         sentinel<std::size_t>{*(std::begin(d) + sent_len)});
 
@@ -55,7 +55,7 @@ void test_uninitialized_copy_n_sent(ExPolicy&& policy, IteratorTag)
     std::vector<std::size_t> d(c.size());
     std::iota(std::begin(c), std::end(c), std::rand());
     std::copy(std::begin(c), std::end(c), std::rbegin(d));
-    auto sent_len = (std::rand() % 10007) + 1;
+    std::size_t sent_len = (std::rand() % 10007) + 1;
     hpx::ranges::uninitialized_copy_n(policy, std::begin(c), sent_len,
         std::begin(d), sentinel<std::size_t>{*(std::begin(d) + sent_len)});
 
@@ -79,7 +79,7 @@ void test_uninitialized_copy_n_sent_async(ExPolicy&& p, IteratorTag)
     std::vector<std::size_t> d(c.size());
     std::iota(std::begin(c), std::end(c), std::rand());
     std::copy(std::begin(c), std::end(c), std::rbegin(d));
-    auto sent_len = (std::rand() % 10007) + 1;
+    std::size_t sent_len = (std::rand() % 10007) + 1;
     auto f = hpx::ranges::uninitialized_copy_n(p, std::begin(c), sent_len,
         std::begin(d), sentinel<std::size_t>{*(std::begin(d) + sent_len)});
     f.wait();

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/uninitialized_copy_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/uninitialized_copy_range.cpp
@@ -1,0 +1,493 @@
+//  Copyright (c) 2014 Grant Mercer
+//  Copyright (c) 2015 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/iterator_support/iterator_range.hpp>
+#include <hpx/local/init.hpp>
+#include <hpx/modules/testing.hpp>
+#include <hpx/parallel/container_algorithms/uninitialized_copy.hpp>
+
+#include <cstddef>
+#include <iostream>
+#include <iterator>
+#include <numeric>
+#include <string>
+#include <vector>
+
+#include <hpx/iterator_support/tests/iter_sent.hpp>
+#include "test_utils.hpp"
+
+////////////////////////////////////////////////////////////////////////////
+template <typename IteratorTag>
+void test_uninitialized_copy_sent(IteratorTag)
+{
+    std::vector<std::size_t> c(10007);
+    std::vector<std::size_t> d(c.size());
+    std::iota(std::begin(c), std::end(c), std::rand());
+    std::copy(std::begin(c), std::end(c), std::rbegin(d));
+    auto sent_len = (std::rand() % 10007) + 1;
+    hpx::ranges::uninitialized_copy(std::begin(c),
+        sentinel<std::size_t>{*(std::begin(c) + sent_len)}, std::begin(d),
+        sentinel<std::size_t>{*(std::begin(d) + sent_len)});
+
+    std::size_t count = 0;
+    // loop till for sent_len since either the sentinel for the input or output iterator
+    // will be reached by then
+    HPX_TEST(std::equal(std::begin(c), std::begin(c) + sent_len, std::begin(d),
+        [&count](std::size_t v1, std::size_t v2) -> bool {
+            HPX_TEST_EQ(v1, v2);
+            ++count;
+            return v1 == v2;
+        }));
+
+    HPX_TEST_EQ(count, sent_len);
+}
+
+template <typename ExPolicy, typename IteratorTag>
+void test_uninitialized_copy_sent(ExPolicy&& policy, IteratorTag)
+{
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
+
+    std::vector<std::size_t> c(10007);
+    std::vector<std::size_t> d(c.size());
+    std::iota(std::begin(c), std::end(c), std::rand());
+    std::copy(std::begin(c), std::end(c), std::rbegin(d));
+    auto sent_len = (std::rand() % 10007) + 1;
+    hpx::ranges::uninitialized_copy(policy, std::begin(c),
+        sentinel<std::size_t>{*(std::begin(c) + sent_len)}, std::begin(d),
+        sentinel<std::size_t>{*(std::begin(d) + sent_len)});
+
+    std::size_t count = 0;
+    // loop till for sent_len since either the sentinel for the input or output iterator
+    // will be reached by then
+    HPX_TEST(std::equal(std::begin(c), std::begin(c) + sent_len, std::begin(d),
+        [&count](std::size_t v1, std::size_t v2) -> bool {
+            HPX_TEST_EQ(v1, v2);
+            ++count;
+            return v1 == v2;
+        }));
+
+    HPX_TEST_EQ(count, sent_len);
+}
+
+template <typename ExPolicy, typename IteratorTag>
+void test_uninitialized_copy_sent_async(ExPolicy&& p, IteratorTag)
+{
+    std::vector<std::size_t> c(10007);
+    std::vector<std::size_t> d(c.size());
+    std::iota(std::begin(c), std::end(c), std::rand());
+    std::copy(std::begin(c), std::end(c), std::rbegin(d));
+    auto sent_len = (std::rand() % 10007) + 1;
+    auto f = hpx::ranges::uninitialized_copy(p, std::begin(c),
+        sentinel<std::size_t>{*(std::begin(c) + sent_len)}, std::begin(d),
+        sentinel<std::size_t>{*(std::begin(d) + sent_len)});
+    f.wait();
+
+    std::size_t count = 0;
+    HPX_TEST(std::equal(std::begin(c), std::begin(c) + sent_len, std::begin(d),
+        [&count](std::size_t v1, std::size_t v2) -> bool {
+            HPX_TEST_EQ(v1, v2);
+            ++count;
+            return v1 == v2;
+        }));
+    HPX_TEST_EQ(count, sent_len);
+}
+
+template <typename IteratorTag>
+void test_uninitialized_copy_sent()
+{
+    using namespace hpx::execution;
+
+    test_uninitialized_copy_sent(IteratorTag());
+
+    test_uninitialized_copy_sent(seq, IteratorTag());
+    test_uninitialized_copy_sent(par, IteratorTag());
+    test_uninitialized_copy_sent(par_unseq, IteratorTag());
+
+    test_uninitialized_copy_sent_async(seq(task), IteratorTag());
+    test_uninitialized_copy_sent_async(par(task), IteratorTag());
+}
+
+void uninitialized_copy_sent_test()
+{
+    test_uninitialized_copy_sent<std::random_access_iterator_tag>();
+    test_uninitialized_copy_sent<std::forward_iterator_tag>();
+}
+
+////////////////////////////////////////////////////////////////////////////
+template <typename IteratorTag>
+void test_uninitialized_copy(IteratorTag)
+{
+    using test_vector =
+        typename test::test_container<std::vector<std::size_t>, IteratorTag>;
+
+    test_vector c(10007);
+    test_vector d(c.size());
+    std::iota(std::begin(c), std::end(c), std::rand());
+    hpx::ranges::uninitialized_copy(c, d);
+
+    std::size_t count = 0;
+    HPX_TEST(std::equal(std::begin(c), std::end(c), std::begin(d),
+        [&count](std::size_t v1, std::size_t v2) -> bool {
+            HPX_TEST_EQ(v1, v2);
+            ++count;
+            return v1 == v2;
+        }));
+    HPX_TEST_EQ(count, d.size());
+}
+
+template <typename ExPolicy, typename IteratorTag>
+void test_uninitialized_copy(ExPolicy&& policy, IteratorTag)
+{
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
+
+    using test_vector =
+        typename test::test_container<std::vector<std::size_t>, IteratorTag>;
+
+    test_vector c(10007);
+    test_vector d(c.size());
+    std::iota(std::begin(c), std::end(c), std::rand());
+    hpx::ranges::uninitialized_copy(policy, c, d);
+
+    std::size_t count = 0;
+    HPX_TEST(std::equal(std::begin(c), std::end(c), std::begin(d),
+        [&count](std::size_t v1, std::size_t v2) -> bool {
+            HPX_TEST_EQ(v1, v2);
+            ++count;
+            return v1 == v2;
+        }));
+    HPX_TEST_EQ(count, d.size());
+}
+
+template <typename ExPolicy, typename IteratorTag>
+void test_uninitialized_copy_async(ExPolicy&& p, IteratorTag)
+{
+    using test_vector =
+        typename test::test_container<std::vector<std::size_t>, IteratorTag>;
+
+    test_vector c(10007);
+    test_vector d(c.size());
+    std::iota(std::begin(c), std::end(c), std::rand());
+
+    auto f = hpx::ranges::uninitialized_copy(p, c, d);
+    f.wait();
+
+    std::size_t count = 0;
+    HPX_TEST(std::equal(std::begin(c), std::end(c), std::begin(d),
+        [&count](std::size_t v1, std::size_t v2) -> bool {
+            HPX_TEST_EQ(v1, v2);
+            ++count;
+            return v1 == v2;
+        }));
+    HPX_TEST_EQ(count, d.size());
+}
+
+template <typename IteratorTag>
+void test_uninitialized_copy()
+{
+    using namespace hpx::execution;
+
+    test_uninitialized_copy(IteratorTag());
+
+    test_uninitialized_copy(seq, IteratorTag());
+    test_uninitialized_copy(par, IteratorTag());
+    test_uninitialized_copy(par_unseq, IteratorTag());
+
+    test_uninitialized_copy_async(seq(task), IteratorTag());
+    test_uninitialized_copy_async(par(task), IteratorTag());
+}
+
+void uninitialized_copy_test()
+{
+    test_uninitialized_copy<std::random_access_iterator_tag>();
+    test_uninitialized_copy<std::forward_iterator_tag>();
+}
+
+///////////////////////////////////////////////////////////////////////////////
+template <typename IteratorTag>
+void test_uninitialized_copy_exception(IteratorTag)
+{
+    using base_iterator = typename std::vector<std::size_t>::iterator;
+    using decorated_iterator =
+        typename test::decorated_iterator<base_iterator, IteratorTag>;
+    using test_vector =
+        typename test::test_container<std::vector<std::size_t>, IteratorTag>;
+
+    std::vector<std::size_t> c(10007);
+    test_vector d(c.size());
+    std::iota(std::begin(c), std::end(c), std::rand());
+
+    bool caught_exception = false;
+    try
+    {
+        hpx::ranges::uninitialized_copy(
+            hpx::util::make_iterator_range(
+                decorated_iterator(
+                    std::begin(c), []() { throw std::runtime_error("test"); }),
+                decorated_iterator(std::end(c))),
+            d);
+        HPX_TEST(false);
+    }
+    catch (hpx::exception_list const& e)
+    {
+        caught_exception = true;
+        test::test_num_exceptions<hpx::execution::sequenced_policy,
+            IteratorTag>::call(hpx::execution::seq, e);
+    }
+    catch (...)
+    {
+        HPX_TEST(false);
+    }
+
+    HPX_TEST(caught_exception);
+}
+
+template <typename ExPolicy, typename IteratorTag>
+void test_uninitialized_copy_exception(ExPolicy&& policy, IteratorTag)
+{
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
+
+    using base_iterator = typename std::vector<std::size_t>::iterator;
+    using decorated_iterator =
+        typename test::decorated_iterator<base_iterator, IteratorTag>;
+    using test_vector =
+        typename test::test_container<std::vector<std::size_t>, IteratorTag>;
+
+    std::vector<std::size_t> c(10007);
+    test_vector d(c.size());
+    std::iota(std::begin(c), std::end(c), std::rand());
+
+    bool caught_exception = false;
+    try
+    {
+        hpx::ranges::uninitialized_copy(policy,
+            hpx::util::make_iterator_range(
+                decorated_iterator(
+                    std::begin(c), []() { throw std::runtime_error("test"); }),
+                decorated_iterator(std::end(c))),
+            d);
+        HPX_TEST(false);
+    }
+    catch (hpx::exception_list const& e)
+    {
+        caught_exception = true;
+        test::test_num_exceptions<ExPolicy, IteratorTag>::call(policy, e);
+    }
+    catch (...)
+    {
+        HPX_TEST(false);
+    }
+
+    HPX_TEST(caught_exception);
+}
+
+template <typename ExPolicy, typename IteratorTag>
+void test_uninitialized_copy_exception_async(ExPolicy&& p, IteratorTag)
+{
+    using base_iterator = typename std::vector<std::size_t>::iterator;
+    using decorated_iterator =
+        typename test::decorated_iterator<base_iterator, IteratorTag>;
+    using test_vector =
+        typename test::test_container<std::vector<std::size_t>, IteratorTag>;
+
+    std::vector<std::size_t> c(10007);
+    test_vector d(c.size());
+    std::iota(std::begin(c), std::end(c), std::rand());
+
+    bool caught_exception = false;
+    bool returned_from_algorithm = false;
+    try
+    {
+        auto f = hpx::ranges::uninitialized_copy(p,
+            hpx::util::make_iterator_range(
+                decorated_iterator(
+                    std::begin(c), []() { throw std::runtime_error("test"); }),
+                decorated_iterator(std::end(c))),
+            d);
+        returned_from_algorithm = true;
+        f.get();
+
+        HPX_TEST(false);
+    }
+    catch (hpx::exception_list const& e)
+    {
+        caught_exception = true;
+        test::test_num_exceptions<ExPolicy, IteratorTag>::call(p, e);
+    }
+    catch (...)
+    {
+        HPX_TEST(false);
+    }
+
+    HPX_TEST(caught_exception);
+    HPX_TEST(returned_from_algorithm);
+}
+
+template <typename IteratorTag>
+void test_uninitialized_copy_exception()
+{
+    using namespace hpx::execution;
+
+    // If the execution policy object is of type vector_execution_policy,
+    // std::terminate shall be called. therefore we do not test exceptions
+    // with a vector execution policy
+    test_uninitialized_copy_exception(seq, IteratorTag());
+    test_uninitialized_copy_exception(par, IteratorTag());
+
+    test_uninitialized_copy_exception_async(seq(task), IteratorTag());
+    test_uninitialized_copy_exception_async(par(task), IteratorTag());
+}
+
+void uninitialized_copy_exception_test()
+{
+    test_uninitialized_copy_exception<std::random_access_iterator_tag>();
+    test_uninitialized_copy_exception<std::forward_iterator_tag>();
+}
+
+//////////////////////////////////////////////////////////////////////////////
+template <typename ExPolicy, typename IteratorTag>
+void test_uninitialized_copy_bad_alloc(ExPolicy&& policy, IteratorTag)
+{
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
+
+    using base_iterator = typename std::vector<std::size_t>::iterator;
+    using decorated_iterator =
+        typename test::decorated_iterator<base_iterator, IteratorTag>;
+    using test_vector =
+        typename test::test_container<std::vector<std::size_t>, IteratorTag>;
+
+    std::vector<std::size_t> c(10007);
+    test_vector d(c.size());
+    std::iota(std::begin(c), std::end(c), std::rand());
+
+    bool caught_bad_alloc = false;
+    try
+    {
+        hpx::ranges::uninitialized_copy(policy,
+            hpx::util::make_iterator_range(
+                decorated_iterator(
+                    std::begin(c), []() { throw std::bad_alloc(); }),
+                decorated_iterator(std::end(c))),
+            d);
+        HPX_TEST(false);
+    }
+    catch (std::bad_alloc const&)
+    {
+        caught_bad_alloc = true;
+    }
+    catch (...)
+    {
+        HPX_TEST(false);
+    }
+
+    HPX_TEST(caught_bad_alloc);
+}
+
+template <typename ExPolicy, typename IteratorTag>
+void test_uninitialized_copy_bad_alloc_async(ExPolicy&& p, IteratorTag)
+{
+    using base_iterator = typename std::vector<std::size_t>::iterator;
+    using decorated_iterator =
+        typename test::decorated_iterator<base_iterator, IteratorTag>;
+    using test_vector =
+        typename test::test_container<std::vector<std::size_t>, IteratorTag>;
+
+    std::vector<std::size_t> c(10007);
+    test_vector d(c.size());
+    std::iota(std::begin(c), std::end(c), std::rand());
+
+    bool caught_bad_alloc = false;
+    bool returned_from_algorithm = false;
+    try
+    {
+        auto f = hpx::ranges::uninitialized_copy(p,
+            hpx::util::make_iterator_range(
+                decorated_iterator(
+                    std::begin(c), []() { throw std::bad_alloc(); }),
+                decorated_iterator(std::end(c))),
+            d);
+        returned_from_algorithm = true;
+        f.get();
+
+        HPX_TEST(false);
+    }
+    catch (std::bad_alloc const&)
+    {
+        caught_bad_alloc = true;
+    }
+    catch (...)
+    {
+        HPX_TEST(false);
+    }
+
+    HPX_TEST(caught_bad_alloc);
+    HPX_TEST(returned_from_algorithm);
+}
+
+template <typename IteratorTag>
+void test_uninitialized_copy_bad_alloc()
+{
+    using namespace hpx::execution;
+
+    // If the execution policy object is of type vector_execution_policy,
+    // std::terminate shall be called. therefore we do not test exceptions
+    // with a vector execution policy
+    test_uninitialized_copy_bad_alloc(seq, IteratorTag());
+    test_uninitialized_copy_bad_alloc(par, IteratorTag());
+
+    test_uninitialized_copy_bad_alloc_async(seq(task), IteratorTag());
+    test_uninitialized_copy_bad_alloc_async(par(task), IteratorTag());
+}
+
+void uninitialized_copy_bad_alloc_test()
+{
+    test_uninitialized_copy_bad_alloc<std::random_access_iterator_tag>();
+    test_uninitialized_copy_bad_alloc<std::forward_iterator_tag>();
+}
+
+int hpx_main(hpx::program_options::variables_map& vm)
+{
+    unsigned int seed = (unsigned int) std::time(nullptr);
+    if (vm.count("seed"))
+        seed = vm["seed"].as<unsigned int>();
+
+    std::cout << "using seed: " << seed << std::endl;
+    std::srand(seed);
+
+    uninitialized_copy_test();
+    uninitialized_copy_sent_test();
+    uninitialized_copy_exception_test();
+    uninitialized_copy_bad_alloc_test();
+    return hpx::local::finalize();
+}
+
+int main(int argc, char* argv[])
+{
+    // add command line option which controls the random number generator seed
+    using namespace hpx::program_options;
+    options_description desc_commandline(
+        "Usage: " HPX_APPLICATION_STRING " [options]");
+
+    desc_commandline.add_options()("seed,s", value<unsigned int>(),
+        "the random number generator seed to use for this run");
+
+    // By default this test should run on all available cores
+    std::vector<std::string> const cfg = {"hpx.os_threads=all"};
+
+    // Initialize and run HPX
+    hpx::local::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::local::init(hpx_main, argc, argv, init_args), 0,
+        "HPX main exited with non-zero status");
+
+    return hpx::util::report_errors();
+}

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/uninitialized_copy_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/uninitialized_copy_range.cpp
@@ -28,7 +28,7 @@ void test_uninitialized_copy_sent(IteratorTag)
     std::vector<std::size_t> d(c.size());
     std::iota(std::begin(c), std::end(c), std::rand());
     std::copy(std::begin(c), std::end(c), std::rbegin(d));
-    auto sent_len = (std::rand() % 10007) + 1;
+    std::size_t sent_len = (std::rand() % 10007) + 1;
     hpx::ranges::uninitialized_copy(std::begin(c),
         sentinel<std::size_t>{*(std::begin(c) + sent_len)}, std::begin(d),
         sentinel<std::size_t>{*(std::begin(d) + sent_len)});
@@ -56,7 +56,7 @@ void test_uninitialized_copy_sent(ExPolicy&& policy, IteratorTag)
     std::vector<std::size_t> d(c.size());
     std::iota(std::begin(c), std::end(c), std::rand());
     std::copy(std::begin(c), std::end(c), std::rbegin(d));
-    auto sent_len = (std::rand() % 10007) + 1;
+    std::size_t sent_len = (std::rand() % 10007) + 1;
     hpx::ranges::uninitialized_copy(policy, std::begin(c),
         sentinel<std::size_t>{*(std::begin(c) + sent_len)}, std::begin(d),
         sentinel<std::size_t>{*(std::begin(d) + sent_len)});
@@ -81,7 +81,7 @@ void test_uninitialized_copy_sent_async(ExPolicy&& p, IteratorTag)
     std::vector<std::size_t> d(c.size());
     std::iota(std::begin(c), std::end(c), std::rand());
     std::copy(std::begin(c), std::end(c), std::rbegin(d));
-    auto sent_len = (std::rand() % 10007) + 1;
+    std::size_t sent_len = (std::rand() % 10007) + 1;
     auto f = hpx::ranges::uninitialized_copy(p, std::begin(c),
         sentinel<std::size_t>{*(std::begin(c) + sent_len)}, std::begin(d),
         sentinel<std::size_t>{*(std::begin(d) + sent_len)});

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/uninitialized_default_construct_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/uninitialized_default_construct_range.cpp
@@ -1,0 +1,185 @@
+//  Copyright (c) 2018 Christopher Ogle
+//  Copyright (c) 2020 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/iterator_support/tests/iter_sent.hpp>
+#include <hpx/local/init.hpp>
+#include <hpx/modules/testing.hpp>
+#include <hpx/parallel/container_algorithms/uninitialized_fill.hpp>
+
+#include <cstddef>
+#include <iostream>
+#include <iterator>
+#include <numeric>
+#include <string>
+#include <vector>
+
+#include <hpx/iterator_support/tests/iter_sent.hpp>
+#include "test_utils.hpp"
+
+////////////////////////////////////////////////////////////////////////////
+void test_uninitialized_fill_sent()
+{
+    std::vector<std::size_t> c(200);
+    std::iota(std::begin(c), std::end(c), std::rand());
+
+    hpx::ranges::uninitialized_fill(
+        std::begin(c), sentinel<std::size_t>{*(std::begin(c) + 100)}, 10);
+
+    // verify values
+    std::size_t count = 0;
+    std::for_each(
+        std::begin(c), std::begin(c) + 100, [&count](std::size_t v) -> void {
+            HPX_TEST_EQ(v, std::size_t(10));
+            ++count;
+        });
+
+    HPX_TEST_EQ(count, (size_t) 100);
+}
+
+template <typename ExPolicy>
+void test_uninitialized_fill_sent(ExPolicy policy)
+{
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
+
+    std::vector<std::size_t> c(200);
+    std::iota(std::begin(c), std::end(c), std::rand());
+
+    hpx::ranges::uninitialized_fill(policy, std::begin(c),
+        sentinel<std::size_t>{*(std::begin(c) + 100)}, 10);
+
+    // verify values
+    std::size_t count = 0;
+    std::for_each(
+        std::begin(c), std::begin(c) + 100, [&count](std::size_t v) -> void {
+            HPX_TEST_EQ(v, std::size_t(10));
+            ++count;
+        });
+
+    HPX_TEST_EQ(count, (size_t) 100);
+}
+
+template <typename IteratorTag>
+void test_uninitialized_fill(IteratorTag)
+{
+    std::vector<std::size_t> c(10007);
+    std::iota(std::begin(c), std::end(c), std::rand());
+
+    hpx::ranges::uninitialized_fill(c, 10);
+
+    // verify values
+    std::size_t count = 0;
+    std::for_each(std::begin(c), std::end(c), [&count](std::size_t v) -> void {
+        HPX_TEST_EQ(v, std::size_t(10));
+        ++count;
+    });
+
+    HPX_TEST_EQ(count, c.size());
+}
+
+template <typename ExPolicy, typename IteratorTag>
+void test_uninitialized_fill(ExPolicy policy, IteratorTag)
+{
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
+
+    std::vector<std::size_t> c(10007);
+    std::iota(std::begin(c), std::end(c), std::rand());
+
+    hpx::ranges::uninitialized_fill(policy, c, 10);
+
+    // verify values
+    std::size_t count = 0;
+    std::for_each(std::begin(c), std::end(c), [&count](std::size_t v) -> void {
+        HPX_TEST_EQ(v, std::size_t(10));
+        ++count;
+    });
+
+    HPX_TEST_EQ(count, c.size());
+}
+
+template <typename ExPolicy, typename IteratorTag>
+void test_uninitialized_fill_async(ExPolicy p, IteratorTag)
+{
+    std::vector<std::size_t> c(10007);
+    std::iota(std::begin(c), std::end(c), std::rand());
+
+    hpx::future<void> f = hpx::ranges::uninitialized_fill(p, c, 10);
+    f.wait();
+
+    std::size_t count = 0;
+    std::for_each(std::begin(c), std::end(c), [&count](std::size_t v) -> void {
+        HPX_TEST_EQ(v, std::size_t(10));
+        ++count;
+    });
+
+    HPX_TEST_EQ(count, c.size());
+}
+
+template <typename IteratorTag>
+void test_uninitialized_fill()
+{
+    using namespace hpx::execution;
+
+    test_uninitialized_fill(IteratorTag());
+
+    test_uninitialized_fill(seq, IteratorTag());
+    test_uninitialized_fill(par, IteratorTag());
+    test_uninitialized_fill(par_unseq, IteratorTag());
+
+    test_uninitialized_fill_async(seq(task), IteratorTag());
+    test_uninitialized_fill_async(par(task), IteratorTag());
+
+    test_uninitialized_fill_sent();
+    test_uninitialized_fill_sent(seq);
+    test_uninitialized_fill_sent(par);
+    test_uninitialized_fill_sent(par_unseq);
+}
+
+void uninitialized_fill_test()
+{
+    test_uninitialized_fill<std::random_access_iterator_tag>();
+    test_uninitialized_fill<std::forward_iterator_tag>();
+}
+
+////////////////////////////////////////////////////////////////////////////
+int hpx_main(hpx::program_options::variables_map& vm)
+{
+    unsigned int seed = (unsigned int) std::time(nullptr);
+    if (vm.count("seed"))
+        seed = vm["seed"].as<unsigned int>();
+
+    std::cout << "using seed: " << seed << std::endl;
+    std::srand(seed);
+
+    uninitialized_fill_test();
+    return hpx::local::finalize();
+}
+
+int main(int argc, char* argv[])
+{
+    // add command line option which controls the random number generator seed
+    using namespace hpx::program_options;
+    options_description desc_commandline(
+        "Usage: " HPX_APPLICATION_STRING " [options]");
+
+    desc_commandline.add_options()("seed,s", value<unsigned int>(),
+        "the random number generator seed to use for this run");
+
+    // By default this test should run on all available cores
+    std::vector<std::string> const cfg = {"hpx.os_threads=all"};
+
+    // Initialize and run HPX
+    hpx::local::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::local::init(hpx_main, argc, argv, init_args), 0,
+        "HPX main exited with non-zero status");
+
+    return hpx::util::report_errors();
+}

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/uninitialized_default_construct_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/uninitialized_default_construct_range.cpp
@@ -45,7 +45,7 @@ struct value_constructable
     std::int32_t value_;
 };
 
-std::size_t const data_size = 10;
+std::size_t const data_size = 10007;
 
 ////////////////////////////////////////////////////////////////////////////
 template <typename IteratorTag>

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/uninitialized_default_construct_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/uninitialized_default_construct_range.cpp
@@ -11,10 +11,12 @@
 #include <hpx/parallel/container_algorithms/uninitialized_default_construct.hpp>
 
 #include <cstddef>
+#include <cstdint>
 #include <iostream>
 #include <iterator>
 #include <numeric>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "test_utils.hpp"
@@ -27,14 +29,14 @@ struct default_constructable
     {
     }
 
-    default_constructable(std::int32_t val)
+    explicit default_constructable(std::int32_t val)
     {
         value_ = val;
     }
 
-    bool operator!=(default_constructable const& lhs) const
+    bool operator!=(std::int32_t const& lhs) const
     {
-        return lhs.value_ != value_;
+        return lhs != value_;
     }
 
     std::int32_t value_;

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/uninitialized_default_constructn_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/uninitialized_default_constructn_range.cpp
@@ -1,0 +1,134 @@
+//  Copyright (c) 2014 Grant Mercer
+//  Copyright (c) 2015 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/iterator_support/iterator_range.hpp>
+#include <hpx/local/init.hpp>
+#include <hpx/modules/testing.hpp>
+#include <hpx/parallel/container_algorithms/uninitialized_fill.hpp>
+
+#include <cstddef>
+#include <iostream>
+#include <iterator>
+#include <numeric>
+#include <string>
+#include <vector>
+
+#include "test_utils.hpp"
+
+////////////////////////////////////////////////////////////////////////////
+template <typename IteratorTag>
+void test_uninitialized_fill_n_sent(IteratorTag)
+{
+    std::vector<std::size_t> c(10007);
+    std::size_t sent_len = (std::rand() % 10007) + 1;
+    hpx::ranges::uninitialized_fill_n(std::begin(c), sent_len, 10);
+
+    std::size_t count = 0;
+    std::for_each(std::begin(c), std::begin(c) + sent_len,
+        [&count](std::size_t v) -> void {
+            HPX_TEST_EQ(v, std::size_t(10));
+            ++count;
+        });
+
+    HPX_TEST_EQ(count, sent_len);
+}
+
+template <typename ExPolicy, typename IteratorTag>
+void test_uninitialized_fill_n_sent(ExPolicy&& policy, IteratorTag)
+{
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
+
+    std::vector<std::size_t> c(10007);
+    std::size_t sent_len = (std::rand() % 10007) + 1;
+    hpx::ranges::uninitialized_fill_n(policy, std::begin(c), sent_len, 10);
+
+    std::size_t count = 0;
+    std::for_each(std::begin(c), std::begin(c) + sent_len,
+        [&count](std::size_t v) -> void {
+            HPX_TEST_EQ(v, std::size_t(10));
+            ++count;
+        });
+
+    HPX_TEST_EQ(count, sent_len);
+}
+
+template <typename ExPolicy, typename IteratorTag>
+void test_uninitialized_fill_n_sent_async(ExPolicy&& p, IteratorTag)
+{
+    std::vector<std::size_t> c(10007);
+    std::size_t sent_len = (std::rand() % 10007) + 1;
+    auto f = hpx::ranges::uninitialized_fill_n(p, std::begin(c), sent_len, 10);
+    f.wait();
+
+    std::size_t count = 0;
+    std::for_each(std::begin(c), std::begin(c) + sent_len,
+        [&count](std::size_t v) -> void {
+            HPX_TEST_EQ(v, std::size_t(10));
+            ++count;
+        });
+
+    HPX_TEST_EQ(count, sent_len);
+}
+
+template <typename IteratorTag>
+void test_uninitialized_fill_n_sent()
+{
+    using namespace hpx::execution;
+
+    test_uninitialized_fill_n_sent(IteratorTag());
+
+    test_uninitialized_fill_n_sent(seq, IteratorTag());
+    test_uninitialized_fill_n_sent(par, IteratorTag());
+    test_uninitialized_fill_n_sent(par_unseq, IteratorTag());
+
+    test_uninitialized_fill_n_sent_async(seq(task), IteratorTag());
+    test_uninitialized_fill_n_sent_async(par(task), IteratorTag());
+}
+
+void uninitialized_fill_n_sent_test()
+{
+    test_uninitialized_fill_n_sent<std::random_access_iterator_tag>();
+    test_uninitialized_fill_n_sent<std::forward_iterator_tag>();
+}
+
+int hpx_main(hpx::program_options::variables_map& vm)
+{
+    unsigned int seed = (unsigned int) std::time(nullptr);
+    if (vm.count("seed"))
+        seed = vm["seed"].as<unsigned int>();
+
+    std::cout << "using seed: " << seed << std::endl;
+    std::srand(seed);
+
+    uninitialized_fill_n_sent_test();
+    return hpx::local::finalize();
+}
+
+int main(int argc, char* argv[])
+{
+    // add command line option which controls the random number generator seed
+    using namespace hpx::program_options;
+    options_description desc_commandline(
+        "Usage: " HPX_APPLICATION_STRING " [options]");
+
+    desc_commandline.add_options()("seed,s", value<unsigned int>(),
+        "the random number generator seed to use for this run");
+
+    // By default this test should run on all available cores
+    std::vector<std::string> const cfg = {"hpx.os_threads=all"};
+
+    // Initialize and run HPX
+    hpx::local::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::local::init(hpx_main, argc, argv, init_args), 0,
+        "HPX main exited with non-zero status");
+
+    return hpx::util::report_errors();
+}

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/uninitialized_default_constructn_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/uninitialized_default_constructn_range.cpp
@@ -11,6 +11,7 @@
 #include <hpx/parallel/container_algorithms/uninitialized_default_construct.hpp>
 
 #include <cstddef>
+#include <cstdint>
 #include <iostream>
 #include <iterator>
 #include <numeric>
@@ -27,7 +28,7 @@ struct default_constructable
     {
     }
 
-    default_constructable(std::int32_t val)
+    explicit default_constructable(std::int32_t val)
     {
         value_ = val;
     }

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/uninitialized_value_construct_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/uninitialized_value_construct_range.cpp
@@ -11,10 +11,12 @@
 #include <hpx/parallel/container_algorithms/uninitialized_value_construct.hpp>
 
 #include <cstddef>
+#include <cstdint>
 #include <iostream>
 #include <iterator>
 #include <numeric>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "test_utils.hpp"

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/uninitialized_value_construct_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/uninitialized_value_construct_range.cpp
@@ -1,0 +1,219 @@
+//  Copyright (c) 2018 Christopher Ogle
+//  Copyright (c) 2020 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/iterator_support/tests/iter_sent.hpp>
+#include <hpx/local/init.hpp>
+#include <hpx/modules/testing.hpp>
+#include <hpx/parallel/container_algorithms/uninitialized_value_construct.hpp>
+
+#include <cstddef>
+#include <iostream>
+#include <iterator>
+#include <numeric>
+#include <string>
+#include <vector>
+
+#include "test_utils.hpp"
+
+////////////////////////////////////////////////////////////////////////////
+struct value_constructable
+{
+    bool operator!=(std::int32_t lhs) const
+    {
+        return lhs != value_;
+    }
+
+    std::int32_t value_;
+};
+
+std::size_t const data_size = 10007;
+
+////////////////////////////////////////////////////////////////////////////
+template <typename IteratorTag>
+void test_uninitialized_value_construct_range_sent(IteratorTag)
+{
+    typedef std::vector<value_constructable> base_iterator;
+
+    base_iterator c(data_size, {10});
+    auto end_size = rand() % data_size;
+    c[end_size] = {20};
+
+    hpx::ranges::uninitialized_value_construct(
+        std::begin(c), sentinel<std::int32_t>{20});
+
+    std::size_t count42 = 0;
+    std::size_t count10 = 0;
+    std::for_each(std::begin(c), std::begin(c) + data_size,
+        [&count42, &count10](value_constructable v1) {
+            if (v1.value_ == 0)
+            {
+                count42++;
+            }
+            else if (v1.value_ == 10)
+            {
+                count10++;
+            }
+        });
+
+    HPX_TEST_EQ(count42, end_size);
+    HPX_TEST_EQ(count10, data_size - end_size - 1);
+}
+
+template <typename ExPolicy, typename IteratorTag>
+void test_uninitialized_value_construct_range_sent(
+    ExPolicy&& policy, IteratorTag)
+{
+    typedef std::vector<value_constructable> base_iterator;
+
+    base_iterator c(data_size, {10});
+    auto end_size = rand() % data_size;
+    c[end_size] = {20};
+
+    hpx::ranges::uninitialized_value_construct(
+        policy, std::begin(c), sentinel<std::int32_t>{20});
+
+    std::size_t count42 = 0;
+    std::size_t count10 = 0;
+    std::for_each(std::begin(c), std::begin(c) + data_size,
+        [&count42, &count10](value_constructable v1) {
+            if (v1.value_ == 0)
+            {
+                count42++;
+            }
+            else if (v1.value_ == 10)
+            {
+                count10++;
+            }
+        });
+
+    HPX_TEST_EQ(count42, end_size);
+    HPX_TEST_EQ(count10, data_size - end_size - 1);
+}
+
+template <typename IteratorTag>
+void test_uninitialized_value_construct_range(IteratorTag)
+{
+    typedef std::vector<value_constructable> base_iterator;
+
+    base_iterator c(data_size, {10});
+    hpx::ranges::uninitialized_value_construct(c);
+
+    std::size_t count = 0;
+    std::for_each(std::begin(c), std::begin(c) + data_size,
+        [&count](value_constructable v1) {
+            HPX_TEST_EQ(v1.value_, 0);
+            ++count;
+        });
+    HPX_TEST_EQ(count, data_size);
+}
+
+template <typename ExPolicy, typename IteratorTag>
+void test_uninitialized_value_construct_range(ExPolicy&& policy, IteratorTag)
+{
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
+
+    typedef std::vector<value_constructable> base_iterator;
+
+    base_iterator c(data_size, {10});
+    hpx::ranges::uninitialized_value_construct(
+        std::forward<ExPolicy>(policy), c);
+
+    std::size_t count = 0;
+    std::for_each(std::begin(c), std::begin(c) + data_size,
+        [&count](value_constructable v1) {
+            HPX_TEST_EQ(v1.value_, 0);
+            ++count;
+        });
+    HPX_TEST_EQ(count, data_size);
+}
+
+template <typename ExPolicy, typename IteratorTag>
+void test_uninitialized_value_construct_range_async(
+    ExPolicy&& policy, IteratorTag)
+{
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
+
+    typedef std::vector<value_constructable> base_iterator;
+
+    base_iterator c(data_size, {10});
+    auto f = hpx::ranges::uninitialized_value_construct(
+        std::forward<ExPolicy>(policy), c);
+    f.wait();
+
+    std::size_t count = 0;
+    std::for_each(std::begin(c), std::begin(c) + data_size,
+        [&count](value_constructable v1) {
+            HPX_TEST_EQ(v1.value_, 0);
+            ++count;
+        });
+    HPX_TEST_EQ(count, data_size);
+}
+
+template <typename IteratorTag>
+void test_uninitialized_value_construct_range()
+{
+    using namespace hpx::execution;
+
+    test_uninitialized_value_construct_range(IteratorTag());
+    test_uninitialized_value_construct_range(seq, IteratorTag());
+    test_uninitialized_value_construct_range(par, IteratorTag());
+    test_uninitialized_value_construct_range(par_unseq, IteratorTag());
+
+    test_uninitialized_value_construct_range_async(seq(task), IteratorTag());
+    test_uninitialized_value_construct_range_async(par(task), IteratorTag());
+
+    test_uninitialized_value_construct_range_sent(IteratorTag());
+    test_uninitialized_value_construct_range_sent(seq, IteratorTag());
+    test_uninitialized_value_construct_range_sent(par, IteratorTag());
+    test_uninitialized_value_construct_range_sent(par_unseq, IteratorTag());
+}
+
+void uninitialized_value_construct_range_test()
+{
+    test_uninitialized_value_construct_range<std::random_access_iterator_tag>();
+    test_uninitialized_value_construct_range<std::forward_iterator_tag>();
+}
+
+////////////////////////////////////////////////////////////////////////////
+int hpx_main(hpx::program_options::variables_map& vm)
+{
+    unsigned int seed = (unsigned int) std::time(nullptr);
+    if (vm.count("seed"))
+        seed = vm["seed"].as<unsigned int>();
+
+    std::cout << "using seed: " << seed << std::endl;
+    std::srand(seed);
+
+    uninitialized_value_construct_range_test();
+    return hpx::local::finalize();
+}
+
+int main(int argc, char* argv[])
+{
+    // add command line option which controls the random number generator seed
+    using namespace hpx::program_options;
+    options_description desc_commandline(
+        "Usage: " HPX_APPLICATION_STRING " [options]");
+
+    desc_commandline.add_options()("seed,s", value<unsigned int>(),
+        "the random number generator seed to use for this run");
+
+    // By value this test should run on all available cores
+    std::vector<std::string> const cfg = {"hpx.os_threads=all"};
+
+    // Initialize and run HPX
+    hpx::local::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::local::init(hpx_main, argc, argv, init_args), 0,
+        "HPX main exited with non-zero status");
+
+    return hpx::util::report_errors();
+}

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/uninitialized_value_constructn_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/uninitialized_value_constructn_range.cpp
@@ -11,6 +11,7 @@
 #include <hpx/parallel/container_algorithms/uninitialized_value_construct.hpp>
 
 #include <cstddef>
+#include <cstdint>
 #include <iostream>
 #include <iterator>
 #include <numeric>

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/uninitialized_value_constructn_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/uninitialized_value_constructn_range.cpp
@@ -1,0 +1,177 @@
+//  Copyright (c) 2014 Grant Mercer
+//  Copyright (c) 2015 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/iterator_support/iterator_range.hpp>
+#include <hpx/local/init.hpp>
+#include <hpx/modules/testing.hpp>
+#include <hpx/parallel/container_algorithms/uninitialized_value_construct.hpp>
+
+#include <cstddef>
+#include <iostream>
+#include <iterator>
+#include <numeric>
+#include <string>
+#include <vector>
+
+#include "test_utils.hpp"
+
+////////////////////////////////////////////////////////////////////////////
+struct value_constructable
+{
+    std::int32_t value_;
+};
+
+std::size_t const data_size = 10007;
+
+////////////////////////////////////////////////////////////////////////////
+template <typename IteratorTag>
+void test_uninitialized_value_construct_n(IteratorTag)
+{
+    using base_iterator = std::vector<value_constructable>;
+
+    base_iterator c(data_size, {10});
+    auto end_size = rand() % data_size;
+    hpx::ranges::uninitialized_value_construct_n(std::begin(c), end_size);
+
+    std::size_t count42 = 0;
+    std::size_t count10 = 0;
+    std::for_each(std::begin(c), std::begin(c) + data_size,
+        [&count42, &count10](value_constructable v1) {
+            if (v1.value_ == 0)
+            {
+                count42++;
+            }
+            else if (v1.value_ == 10)
+            {
+                count10++;
+            }
+        });
+
+    HPX_TEST_EQ(count42, end_size);
+    HPX_TEST_EQ(count10, data_size - end_size);
+}
+
+template <typename ExPolicy, typename IteratorTag>
+void test_uninitialized_value_construct_n(ExPolicy&& policy, IteratorTag)
+{
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
+
+    using base_iterator = std::vector<value_constructable>;
+
+    base_iterator c(data_size, {10});
+    auto end_size = rand() % data_size;
+    hpx::ranges::uninitialized_value_construct_n(
+        policy, std::begin(c), end_size);
+
+    std::size_t count42 = 0;
+    std::size_t count10 = 0;
+    std::for_each(std::begin(c), std::begin(c) + data_size,
+        [&count42, &count10](value_constructable v1) {
+            if (v1.value_ == 0)
+            {
+                count42++;
+            }
+            else if (v1.value_ == 10)
+            {
+                count10++;
+            }
+        });
+
+    HPX_TEST_EQ(count42, end_size);
+    HPX_TEST_EQ(count10, data_size - end_size);
+}
+
+template <typename ExPolicy, typename IteratorTag>
+void test_uninitialized_value_construct_n_async(ExPolicy&& p, IteratorTag)
+{
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
+
+    using base_iterator = std::vector<value_constructable>;
+
+    base_iterator c(data_size, {10});
+    auto end_size = rand() % data_size;
+    auto f = hpx::ranges::uninitialized_value_construct_n(
+        p, std::begin(c), end_size);
+    f.wait();
+
+    std::size_t count42 = 0;
+    std::size_t count10 = 0;
+    std::for_each(std::begin(c), std::begin(c) + data_size,
+        [&count42, &count10](value_constructable v1) {
+            if (v1.value_ == 0)
+            {
+                count42++;
+            }
+            else if (v1.value_ == 10)
+            {
+                count10++;
+            }
+        });
+
+    HPX_TEST_EQ(count42, end_size);
+    HPX_TEST_EQ(count10, data_size - end_size);
+}
+
+template <typename IteratorTag>
+void test_uninitialized_value_construct_n()
+{
+    using namespace hpx::execution;
+
+    test_uninitialized_value_construct_n(IteratorTag());
+
+    test_uninitialized_value_construct_n(seq, IteratorTag());
+    test_uninitialized_value_construct_n(par, IteratorTag());
+    test_uninitialized_value_construct_n(par_unseq, IteratorTag());
+
+    test_uninitialized_value_construct_n_async(seq(task), IteratorTag());
+    test_uninitialized_value_construct_n_async(par(task), IteratorTag());
+}
+
+void uninitialized_value_construct_n_test()
+{
+    test_uninitialized_value_construct_n<std::random_access_iterator_tag>();
+    test_uninitialized_value_construct_n<std::forward_iterator_tag>();
+}
+
+int hpx_main(hpx::program_options::variables_map& vm)
+{
+    unsigned int seed = (unsigned int) std::time(nullptr);
+    if (vm.count("seed"))
+        seed = vm["seed"].as<unsigned int>();
+
+    std::cout << "using seed: " << seed << std::endl;
+    std::srand(seed);
+
+    uninitialized_value_construct_n_test();
+    return hpx::local::finalize();
+}
+
+int main(int argc, char* argv[])
+{
+    // add command line option which controls the random number generator seed
+    using namespace hpx::program_options;
+    options_description desc_commandline(
+        "Usage: " HPX_APPLICATION_STRING " [options]");
+
+    desc_commandline.add_options()("seed,s", value<unsigned int>(),
+        "the random number generator seed to use for this run");
+
+    // By value this test should run on all available cores
+    std::vector<std::string> const cfg = {"hpx.os_threads=all"};
+
+    // Initialize and run HPX
+    hpx::local::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::local::init(hpx_main, argc, argv, init_args), 0,
+        "HPX main exited with non-zero status");
+
+    return hpx::util::report_errors();
+}


### PR DESCRIPTION
Adapted uninitialized copy and uninitialized_copy_n to C++ 20 and added container overloads. (range and sentinel). Added container tests.

## Any background context you want to provide?
Issue #4822
Issue #3646
Issue #1668