### PR TITLE
Slight improvements to min/max/minmax_element algorithms

### DIFF
--- a/.jenkins/lsu/env-clang-9.sh
+++ b/.jenkins/lsu/env-clang-9.sh
@@ -18,6 +18,7 @@ configure_extra_options+=" -DHPX_WITH_MALLOC=system"
 configure_extra_options+=" -DHPX_WITH_COMPILER_WARNINGS=ON"
 configure_extra_options+=" -DHPX_WITH_COMPILER_WARNINGS_AS_ERRORS=ON"
 configure_extra_options+=" -DHPX_WITH_PARCELPORT_MPI=ON"
+configure_extra_options+=" -DHPX_WITH_LOGGING=OFF"
 
 # Make sure HWLOC does not report 'cores'. This is purely an option to enable
 # testing the topology code under conditions close to those on FreeBSD.

--- a/libs/core/logging/src/logging.cpp
+++ b/libs/core/logging/src/logging.cpp
@@ -96,17 +96,4 @@ namespace hpx { namespace util { namespace logging {
 
 }}}    // namespace hpx::util::logging
 
-#else
-
-namespace hpx { namespace util {
-
-    //////////////////////////////////////////////////////////////////////////
-    void enable_logging(
-        logging_destination, std::string const&, std::string, std::string)
-    {
-    }
-
-    void disable_logging(logging_destination dest) {}
-}}    // namespace hpx::util
-
 #endif    // HPX_HAVE_LOGGING

--- a/libs/full/init_runtime_local/src/init_logging.cpp
+++ b/libs/full/init_runtime_local/src/init_logging.cpp
@@ -1076,7 +1076,7 @@ namespace hpx { namespace util {
     {
     }
 
-    void disable_logging(logging_destination dest) {}
+    void disable_logging(logging_destination) {}
 
     //////////////////////////////////////////////////////////////////////////
     namespace detail {

--- a/libs/full/init_runtime_local/src/init_logging.cpp
+++ b/libs/full/init_runtime_local/src/init_logging.cpp
@@ -1062,12 +1062,21 @@ namespace hpx { namespace util {
 #else
 
 #include <hpx/init_runtime_local/detail/init_logging.hpp>
+#include <hpx/modules/logging.hpp>
 #include <hpx/util/get_entry_as.hpp>
 
 #include <iostream>
 #include <string>
 
 namespace hpx { namespace util {
+
+    //////////////////////////////////////////////////////////////////////////
+    void enable_logging(
+        logging_destination, std::string const&, std::string, std::string)
+    {
+    }
+
+    void disable_logging(logging_destination dest) {}
 
     //////////////////////////////////////////////////////////////////////////
     namespace detail {

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/minmax.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/minmax.hpp
@@ -73,7 +73,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
             template <typename ExPolicy, typename FwdIter, typename F,
                 typename Proj>
             static constexpr typename std::iterator_traits<FwdIter>::value_type
-            sequential_min_element_ind(ExPolicy&&, FwdIter it,
+            sequential_minmax_element_ind(ExPolicy&&, FwdIter it,
                 std::size_t count, F const& f, Proj const& proj)
             {
                 HPX_ASSERT(count != 0);
@@ -133,7 +133,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 auto f2 = [policy, f = std::forward<F>(f),
                               proj = std::forward<Proj>(proj)](
                               std::vector<FwdIter>&& positions) -> FwdIter {
-                    return min_element::sequential_min_element_ind(
+                    return min_element::sequential_minmax_element_ind(
                         policy, positions.begin(), positions.size(), f, proj);
                 };
 
@@ -290,7 +290,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
             template <typename ExPolicy, typename FwdIter, typename F,
                 typename Proj>
             static constexpr typename std::iterator_traits<FwdIter>::value_type
-            sequential_max_element_ind(ExPolicy&&, FwdIter it,
+            sequential_minmax_element_ind(ExPolicy&&, FwdIter it,
                 std::size_t count, F const& f, Proj const& proj)
             {
                 HPX_ASSERT(count != 0);
@@ -350,7 +350,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 auto f2 = [policy, f = std::forward<F>(f),
                               proj = std::forward<Proj>(proj)](
                               std::vector<FwdIter>&& positions) -> FwdIter {
-                    return max_element::sequential_max_element_ind(
+                    return max_element::sequential_minmax_element_ind(
                         policy, positions.begin(), positions.size(), f, proj);
                 };
 


### PR DESCRIPTION
These changes give me 10-15% improvement of the sequential execution speed (which should translate to some speedups for parallel execution as well).