### PR TITLE
More changes to clang-cuda Jenkins configuration

### DIFF
--- a/.jenkins/cscs/env-clang-cuda.sh
+++ b/.jenkins/cscs/env-clang-cuda.sh
@@ -30,6 +30,11 @@ configure_extra_options+=" -DHPX_WITH_COMPILER_WARNINGS=ON"
 configure_extra_options+=" -DHPX_WITH_COMPILER_WARNINGS_AS_ERRORS=ON"
 configure_extra_options+=" -DHPX_WITH_SPINLOCK_DEADLOCK_DETECTION=ON"
 
+# The build unit test with HPX in Debug and the hello_world project in Debug
+# mode hangs on this configuration Release-Debug, Debug-Release, and
+# Release-Release do not hang.
+configure_extra_options+=" -DHPX_WITH_TESTS_EXTERNAL_BUILD=OFF"
+
 # This is a workaround for a bug in the Cray clang compiler and/or Boost. When
 # compiling in device mode, Boost detects that float128 is available, but
 # compilation later fails with an error message saying float128 is not

--- a/components/performance_counters/io/src/io_counters.cpp
+++ b/components/performance_counters/io/src/io_counters.cpp
@@ -24,6 +24,8 @@
 #include <boost/fusion/include/define_struct.hpp>
 #include <boost/fusion/include/io.hpp>
 
+#include <unistd.h>
+
 #include <cstdint>
 #include <fstream>
 #include <iterator>


### PR DESCRIPTION
On the clang-cuda configuration the build unit test hangs when mixing Debug and... Debug. Other mixes are fine. I have no idea why this is the case. The non-Cray clang 12 configuration has no problems with that particular mix.