### PR TITLE
Slight performance improvement for hpx::copy and hpx::move et.al.

### DIFF
--- a/libs/core/iterator_support/include/hpx/iterator_support/traits/is_iterator.hpp
+++ b/libs/core/iterator_support/include/hpx/iterator_support/traits/is_iterator.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2016 Hartmut Kaiser
+//  Copyright (c) 2007-2021 Hartmut Kaiser
 //  Copyright (c) 2019 Austin McCartney
 //
 //  SPDX-License-Identifier: BSL-1.0
@@ -525,10 +525,9 @@ namespace hpx { namespace traits {
     HPX_INLINE_CONSTEXPR_VARIABLE bool is_zip_iterator_v =
         is_zip_iterator<Iter>::value;
 
-
     ///////////////////////////////////////////////////////////////////////////
     // Iterators are contiguous if they are pointers (without concepts we have
-    // no generic way of determining whether an iterator is contigous)
+    // no generic way of determining whether an iterator is contiguous)
 
     namespace detail {
 

--- a/libs/full/compute_cuda/include/hpx/compute/cuda/transfer.hpp
+++ b/libs/full/compute_cuda/include/hpx/compute/cuda/transfer.hpp
@@ -1,5 +1,5 @@
 //  Copyright (c) 2016 Thomas Heller
-//  Copyright (c) 2016 Thomas Heller
+//  Copyright (c) 2016-2021 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -50,7 +50,7 @@ namespace hpx { namespace traits {
 
     ///////////////////////////////////////////////////////////////////////////
     template <typename T>
-    struct pointer_category<
+    struct pointer_copy_category<
         compute::detail::iterator<T, cuda::experimental::allocator<T>>,
         compute::detail::iterator<T, cuda::experimental::allocator<T>>,
         typename std::enable_if<!std::is_trivially_copyable<
@@ -60,7 +60,7 @@ namespace hpx { namespace traits {
     };
 
     template <typename Source, typename T>
-    struct pointer_category<Source,
+    struct pointer_copy_category<Source,
         compute::detail::iterator<T, cuda::experimental::allocator<T>>,
         typename std::enable_if<!std::is_trivially_copyable<typename hpx::util::
                                         decay<T>::type>::value &&
@@ -78,7 +78,7 @@ namespace hpx { namespace traits {
     };
 
     template <typename T, typename U, typename Dest>
-    struct pointer_category<
+    struct pointer_copy_category<
         compute::detail::iterator<T, cuda::experimental::allocator<U>>, Dest,
         typename std::enable_if<!std::is_trivially_copyable<typename hpx::util::
                                         decay<T>::type>::value &&
@@ -108,7 +108,7 @@ namespace hpx { namespace traits {
     };
 
     template <typename T>
-    struct pointer_category<
+    struct pointer_copy_category<
         compute::detail::iterator<T, cuda::experimental::allocator<T>>,
         compute::detail::iterator<T, cuda::experimental::allocator<T>>,
         typename std::enable_if<std::is_trivially_copyable<
@@ -118,7 +118,7 @@ namespace hpx { namespace traits {
     };
 
     template <typename Source, typename T>
-    struct pointer_category<Source,
+    struct pointer_copy_category<Source,
         compute::detail::iterator<T, cuda::experimental::allocator<T>>,
         typename std::enable_if<std::is_trivially_copyable<typename hpx::util::
                                         decay<T>::type>::value &&
@@ -136,7 +136,7 @@ namespace hpx { namespace traits {
     };
 
     template <typename T, typename U, typename Dest>
-    struct pointer_category<
+    struct pointer_copy_category<
         compute::detail::iterator<T, cuda::experimental::allocator<U>>, Dest,
         typename std::enable_if<std::is_trivially_copyable<typename hpx::util::
                                         decay<T>::type>::value &&

--- a/libs/parallelism/algorithms/include/hpx/algorithms/traits/pointer_category.hpp
+++ b/libs/parallelism/algorithms/include/hpx/algorithms/traits/pointer_category.hpp
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <hpx/config.hpp>
+#include <hpx/iterator_support/traits/is_iterator.hpp>
 
 #include <type_traits>
 
@@ -25,58 +26,130 @@ namespace hpx { namespace traits {
     {
     };
 
-    template <typename Source, typename Dest, typename Enable = void>
-    struct pointer_category
-    {
-        using type = general_pointer_tag;
-    };
-
-    ///////////////////////////////////////////////////////////////////////////
     namespace detail {
 
-        template <typename Source, typename Dest>
-        struct pointer_category
+        ///////////////////////////////////////////////////////////////////////
+        template <typename T, bool is_enum = std::is_enum<T>::value>
+        struct unwrap_enum
         {
-            using type = typename std::conditional<
+            using type = std::underlying_type_t<T>;
+        };
+
+        template <typename T>
+        struct unwrap_enum<T, false>
+        {
+            using type = T;
+        };
+
+        template <typename Source, typename Dest>
+        struct pointer_category_helper
+        {
+            using source = typename unwrap_enum<Source>::type;
+            using dest = typename unwrap_enum<Dest>::type;
+
+            using type = std::conditional_t<
                 std::integral_constant<bool,
-                    sizeof(Source) == sizeof(Dest)>::value &&
-                    std::is_integral<Source>::value &&
-                    std::is_integral<Dest>::value &&
-                    !std::is_volatile<Source>::value &&
-                    !std::is_volatile<Dest>::value &&
-                    (std::is_same<bool, Source>::value ==
-                        std::is_same<bool, Dest>::value),
-                trivially_copyable_pointer_tag, general_pointer_tag>::type;
+                    sizeof(source) == sizeof(dest)>::value &&
+                    std::is_integral<source>::value &&
+                    std::is_integral<dest>::value &&
+                    !std::is_volatile<source>::value &&
+                    !std::is_volatile<dest>::value &&
+                    (std::is_same<bool, source>::value ==
+                        std::is_same<bool, dest>::value),
+                trivially_copyable_pointer_tag, general_pointer_tag>;
         };
 
         // every type is layout-compatible with itself
         template <typename T>
-        struct pointer_category<T, T>
+        struct pointer_category_helper<T, T>
         {
             using type =
-                typename std::conditional<std::is_trivially_copyable<T>::value,
-                    trivially_copyable_pointer_tag, general_pointer_tag>::type;
+                std::conditional_t<std::is_trivially_copyable<T>::value,
+                    trivially_copyable_pointer_tag, general_pointer_tag>;
         };
 
         // pointers are layout compatible
         template <typename T>
-        struct pointer_category<T const*, T*>
+        struct pointer_category_helper<T*, T const*>
         {
             using type = trivially_copyable_pointer_tag;
         };
+
+        template <typename T>
+        struct pointer_category_helper<T*, T volatile*>
+        {
+            using type = trivially_copyable_pointer_tag;
+        };
+
+        template <typename T>
+        struct pointer_category_helper<T*, T const volatile*>
+        {
+            using type = trivially_copyable_pointer_tag;
+        };
+
+        ///////////////////////////////////////////////////////////////////////
+        template <typename Iter1, typename Iter2>
+        HPX_INLINE_CONSTEXPR_VARIABLE bool iterators_are_contiguous_v =
+            is_contiguous_iterator_v<Iter1>&& is_contiguous_iterator_v<Iter2>;
+
+        template <typename Source, typename Dest,
+            bool non_contiguous = !iterators_are_contiguous_v<Source, Dest>>
+        struct pointer_move_category
+        {
+            using type = general_pointer_tag;
+        };
+
+        template <typename Source, typename Dest>
+        struct pointer_move_category<Source, Dest, false>
+        {
+            using type = std::conditional_t<
+                std::is_trivially_assignable<iter_ref_t<Dest>,
+                    std::remove_reference_t<iter_ref_t<Source>>>::value,
+                typename pointer_category_helper<iter_value_t<Source>,
+                    iter_value_t<Dest>>::type,
+                general_pointer_tag>;
+        };
+
+        template <typename Source, typename Dest,
+            bool non_contiguous = !iterators_are_contiguous_v<Source, Dest>>
+        struct pointer_copy_category
+        {
+            using type = general_pointer_tag;
+        };
+
+        template <typename Source, typename Dest>
+        struct pointer_copy_category<Source, Dest, false>
+        {
+            using type = std::conditional_t<
+                std::is_trivially_assignable<iter_ref_t<Dest>,
+                    iter_ref_t<Source>>::value,
+                typename pointer_category_helper<iter_value_t<Source>,
+                    iter_value_t<Dest>>::type,
+                general_pointer_tag>;
+        };
     }    // namespace detail
 
-    // isolate iterators which are pointers and their value_types are
-    // assignable
-    template <typename Source, typename Dest>
-    struct pointer_category<Source*, Dest*>
+    // isolate iterators that refer to contiguous trivially copyable sequences or
+    // which are pointers and their value_types are assignable
+    template <typename Source, typename Dest, typename Enable = void>
+    struct pointer_copy_category
     {
-        using type =
-            typename std::conditional<std::is_assignable<Dest&, Source&>::value,
-                typename detail::pointer_category<
-                    typename std::remove_const<Source>::type, Dest>::type,
-                general_pointer_tag>::type;
+        using type = typename detail::pointer_copy_category<Source, Dest>::type;
     };
+
+    template <typename Source, typename Dest>
+    using pointer_copy_category_t =
+        typename pointer_copy_category<Source, Dest>::type;
+
+    template <typename Source, typename Dest, typename Enable = void>
+    struct pointer_move_category
+    {
+        using type = typename detail::pointer_move_category<Source, Dest>::type;
+    };
+
+    template <typename Source, typename Dest>
+    using pointer_move_category_t =
+        typename pointer_move_category<Source, Dest>::type;
 
     // Allow for matching of iterator<T const> to iterator<T> while calculating
     // pointer category.
@@ -85,4 +158,8 @@ namespace hpx { namespace traits {
     {
         using type = Iterator;
     };
+
+    template <typename Iterator>
+    using remove_const_iterator_value_type_t =
+        typename remove_const_iterator_value_type<Iterator>::type;
 }}    // namespace hpx::traits

--- a/libs/parallelism/algorithms/include/hpx/algorithms/traits/pointer_category.hpp
+++ b/libs/parallelism/algorithms/include/hpx/algorithms/traits/pointer_category.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2016-2020 Hartmut Kaiser
+//  Copyright (c) 2016-2021 Hartmut Kaiser
 //  Copyright (c) 2016 John Biddiscombe
 //
 //  SPDX-License-Identifier: BSL-1.0
@@ -47,16 +47,16 @@ namespace hpx { namespace traits {
             using source = typename unwrap_enum<Source>::type;
             using dest = typename unwrap_enum<Dest>::type;
 
-            using type = std::conditional_t<
-                std::integral_constant<bool,
-                    sizeof(source) == sizeof(dest)>::value &&
-                    std::is_integral<source>::value &&
-                    std::is_integral<dest>::value &&
-                    !std::is_volatile<source>::value &&
-                    !std::is_volatile<dest>::value &&
-                    (std::is_same<bool, source>::value ==
-                        std::is_same<bool, dest>::value),
-                trivially_copyable_pointer_tag, general_pointer_tag>;
+            using type =
+                std::conditional_t<std::integral_constant<bool,
+                                       sizeof(source) == sizeof(dest)>::value &&
+                        std::is_integral<source>::value &&
+                        std::is_integral<dest>::value &&
+                        !std::is_volatile<source>::value &&
+                        !std::is_volatile<dest>::value &&
+                        (std::is_same<bool, source>::value ==
+                            std::is_same<bool, dest>::value),
+                    trivially_copyable_pointer_tag, general_pointer_tag>;
         };
 
         // every type is layout-compatible with itself

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/copy.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/copy.hpp
@@ -265,11 +265,26 @@ namespace hpx { namespace parallel { inline namespace v1 {
 
             template <typename ExPolicy, typename InIter, typename Sent,
                 typename OutIter>
-            static constexpr util::in_out_result<InIter, OutIter> sequential(
-                ExPolicy, InIter first, Sent last, OutIter dest)
+            static constexpr std::enable_if_t<
+                !hpx::traits::is_random_access_iterator_v<InIter>,
+                util::in_out_result<InIter, OutIter>>
+            sequential(ExPolicy, InIter first, Sent last, OutIter dest)
             {
                 util::in_out_result<InIter, OutIter> result =
                     util::copy(first, last, dest);
+                util::copy_synchronize(first, dest);
+                return result;
+            }
+
+            template <typename ExPolicy, typename InIter, typename Sent,
+                typename OutIter>
+            static constexpr std::enable_if_t<
+                hpx::traits::is_random_access_iterator_v<InIter>,
+                util::in_out_result<InIter, OutIter>>
+            sequential(ExPolicy, InIter first, Sent last, OutIter dest)
+            {
+                util::in_out_result<InIter, OutIter> result =
+                    util::copy_n(first, detail::distance(first, last), dest);
                 util::copy_synchronize(first, dest);
                 return result;
             }

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/copy.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/copy.hpp
@@ -246,8 +246,8 @@ namespace hpx { namespace parallel { inline namespace v1 {
         struct copy_iteration
         {
             template <typename Iter>
-            HPX_HOST_DEVICE HPX_FORCEINLINE void operator()(
-                Iter part_begin, std::size_t part_size, std::size_t)
+            HPX_HOST_DEVICE HPX_FORCEINLINE constexpr void operator()(
+                Iter part_begin, std::size_t part_size, std::size_t) const
             {
                 using hpx::get;
                 auto iters = part_begin.get_iterator_tuple();
@@ -265,7 +265,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
 
             template <typename ExPolicy, typename InIter, typename Sent,
                 typename OutIter>
-            static util::in_out_result<InIter, OutIter> sequential(
+            static constexpr util::in_out_result<InIter, OutIter> sequential(
                 ExPolicy, InIter first, Sent last, OutIter dest)
             {
                 util::in_out_result<InIter, OutIter> result =
@@ -323,8 +323,8 @@ namespace hpx { namespace parallel { inline namespace v1 {
 
         template <typename FwdIter1, typename FwdIter2>
         struct copy_iter<FwdIter1, FwdIter2,
-            typename std::enable_if<
-                iterators_are_segmented<FwdIter1, FwdIter2>::value>::type>
+            std::enable_if_t<
+                iterators_are_segmented<FwdIter1, FwdIter2>::value>>
           : public copy<util::in_out_result<
                 typename hpx::traits::segmented_iterator_traits<
                     FwdIter1>::local_iterator,
@@ -335,8 +335,8 @@ namespace hpx { namespace parallel { inline namespace v1 {
 
         template <typename FwdIter1, typename FwdIter2>
         struct copy_iter<FwdIter1, FwdIter2,
-            typename std::enable_if<
-                iterators_are_not_segmented<FwdIter1, FwdIter2>::value>::type>
+            std::enable_if_t<
+                iterators_are_not_segmented<FwdIter1, FwdIter2>::value>>
           : public copy<util::in_out_result<FwdIter1, FwdIter2>>
         {
         };
@@ -346,9 +346,9 @@ namespace hpx { namespace parallel { inline namespace v1 {
     // clang-format off
     template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
         HPX_CONCEPT_REQUIRES_(
-            hpx::is_execution_policy<ExPolicy>::value &&
-            hpx::traits::is_iterator<FwdIter1>::value &&
-            hpx::traits::is_iterator<FwdIter2>::value)>
+            hpx::is_execution_policy_v<ExPolicy> &&
+            hpx::traits::is_iterator_v<FwdIter1> &&
+            hpx::traits::is_iterator_v<FwdIter2>)>
     // clang-format on
     HPX_DEPRECATED_V(
         1, 6, "hpx::parallel::copy is deprecated, use hpx::copy instead")
@@ -374,10 +374,13 @@ namespace hpx { namespace parallel { inline namespace v1 {
             }
 
             template <typename ExPolicy, typename InIter, typename OutIter>
-            static util::in_out_result<InIter, OutIter> sequential(
+            static constexpr util::in_out_result<InIter, OutIter> sequential(
                 ExPolicy, InIter first, std::size_t count, OutIter dest)
             {
-                return util::copy_n(first, count, dest);
+                util::in_out_result<InIter, OutIter> result =
+                    util::copy_n(first, count, dest);
+                util::copy_synchronize(first, dest);
+                return result;
             }
 
             template <typename ExPolicy, typename FwdIter1, typename FwdIter2>
@@ -416,9 +419,9 @@ namespace hpx { namespace parallel { inline namespace v1 {
     template <typename ExPolicy, typename FwdIter1, typename Size,
         typename FwdIter2,
         HPX_CONCEPT_REQUIRES_(
-            hpx::is_execution_policy<ExPolicy>::value &&
-            hpx::traits::is_iterator<FwdIter1>::value &&
-            hpx::traits::is_iterator<FwdIter2>::value)>
+            hpx::is_execution_policy_v<ExPolicy> &&
+            hpx::traits::is_iterator_v<FwdIter1> &&
+            hpx::traits::is_iterator_v<FwdIter2>)>
     // clang-format on
     HPX_DEPRECATED_V(
         1, 6, "hpx::parallel::copy_n is deprecated, use hpx::copy_n instead")
@@ -426,9 +429,9 @@ namespace hpx { namespace parallel { inline namespace v1 {
             util::in_out_result<FwdIter1, FwdIter2>>::type
         copy_n(ExPolicy&& policy, FwdIter1 first, Size count, FwdIter2 dest)
     {
-        static_assert((hpx::traits::is_forward_iterator<FwdIter1>::value),
+        static_assert((hpx::traits::is_forward_iterator_v<FwdIter1>),
             "Required at least forward iterator.");
-        static_assert((hpx::traits::is_forward_iterator<FwdIter2>::value),
+        static_assert((hpx::traits::is_forward_iterator_v<FwdIter2>),
             "Requires at least forward iterator.");
 
         // if count is representing a negative value, we do nothing
@@ -593,9 +596,9 @@ namespace hpx { namespace parallel { inline namespace v1 {
     template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
         typename Pred,
         HPX_CONCEPT_REQUIRES_(
-            hpx::is_execution_policy<ExPolicy>::value &&
-            hpx::traits::is_iterator<FwdIter1>::value &&
-            hpx::traits::is_iterator<FwdIter2>::value &&
+            hpx::is_execution_policy_v<ExPolicy> &&
+            hpx::traits::is_iterator_v<FwdIter1> &&
+            hpx::traits::is_iterator_v<FwdIter2> &&
             hpx::is_invocable_v<Pred,
                 typename std::iterator_traits<FwdIter1>::value_type
             >
@@ -608,9 +611,9 @@ namespace hpx { namespace parallel { inline namespace v1 {
         copy_if(ExPolicy&& policy, FwdIter1 first, FwdIter1 last, FwdIter2 dest,
             Pred&& pred)
     {
-        static_assert((hpx::traits::is_forward_iterator<FwdIter1>::value),
+        static_assert((hpx::traits::is_forward_iterator_v<FwdIter1>),
             "Required at least forward iterator.");
-        static_assert((hpx::traits::is_forward_iterator<FwdIter2>::value),
+        static_assert((hpx::traits::is_forward_iterator_v<FwdIter2>),
             "Requires at least forward iterator.");
 
 #if defined(HPX_GCC_VERSION) && HPX_GCC_VERSION >= 100000
@@ -637,9 +640,9 @@ namespace hpx {
         // clang-format off
         template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
             HPX_CONCEPT_REQUIRES_(
-                hpx::is_execution_policy<ExPolicy>::value &&
-                hpx::traits::is_iterator<FwdIter1>::value &&
-                hpx::traits::is_iterator<FwdIter2>::value
+                hpx::is_execution_policy_v<ExPolicy> &&
+                hpx::traits::is_iterator_v<FwdIter1> &&
+                hpx::traits::is_iterator_v<FwdIter2>
             )>
         // clang-format on
         friend typename parallel::util::detail::algorithm_result<ExPolicy,
@@ -656,8 +659,8 @@ namespace hpx {
         // clang-format off
         template <typename FwdIter1, typename FwdIter2,
             HPX_CONCEPT_REQUIRES_(
-                hpx::traits::is_iterator<FwdIter1>::value&&
-                hpx::traits::is_iterator<FwdIter2>::value
+                hpx::traits::is_iterator_v<FwdIter1> &&
+                hpx::traits::is_iterator_v<FwdIter2>
             )>
         // clang-format on
         friend FwdIter2 tag_fallback_dispatch(
@@ -680,9 +683,9 @@ namespace hpx {
         template <typename ExPolicy, typename FwdIter1, typename Size,
             typename FwdIter2,
             HPX_CONCEPT_REQUIRES_(
-                hpx::is_execution_policy<ExPolicy>::value &&
-                hpx::traits::is_iterator<FwdIter1>::value &&
-                hpx::traits::is_iterator<FwdIter2>::value
+                hpx::is_execution_policy_v<ExPolicy> &&
+                hpx::traits::is_iterator_v<FwdIter1> &&
+                hpx::traits::is_iterator_v<FwdIter2>
             )>
         // clang-format on
         friend typename hpx::parallel::util::detail::algorithm_result<ExPolicy,
@@ -690,11 +693,11 @@ namespace hpx {
         tag_fallback_dispatch(hpx::copy_n_t, ExPolicy&& policy, FwdIter1 first,
             Size count, FwdIter2 dest)
         {
-            static_assert((hpx::traits::is_forward_iterator<FwdIter1>::value),
+            static_assert((hpx::traits::is_forward_iterator_v<FwdIter1>),
                 "Required at least forward iterator.");
-            static_assert(hpx::traits::is_forward_iterator<FwdIter2>::value ||
-                    (hpx::is_sequenced_execution_policy<ExPolicy>::value &&
-                        hpx::traits::is_output_iterator<FwdIter2>::value),
+            static_assert(hpx::traits::is_forward_iterator_v<FwdIter2> ||
+                    (hpx::is_sequenced_execution_policy_v<ExPolicy> &&
+                        hpx::traits::is_output_iterator_v<FwdIter2>),
                 "Requires at least forward iterator or sequential execution.");
 
             // if count is representing a negative value, we do nothing
@@ -714,16 +717,16 @@ namespace hpx {
         // clang-format off
         template <typename FwdIter1, typename Size, typename FwdIter2,
             HPX_CONCEPT_REQUIRES_(
-                hpx::traits::is_iterator<FwdIter1>::value &&
-                hpx::traits::is_iterator<FwdIter2>::value
+                hpx::traits::is_iterator_v<FwdIter1> &&
+                hpx::traits::is_iterator_v<FwdIter2>
             )>
         // clang-format on
         friend FwdIter2 tag_fallback_dispatch(
             hpx::copy_n_t, FwdIter1 first, Size count, FwdIter2 dest)
         {
-            static_assert((hpx::traits::is_forward_iterator<FwdIter1>::value),
+            static_assert((hpx::traits::is_forward_iterator_v<FwdIter1>),
                 "Required at least forward iterator.");
-            static_assert((hpx::traits::is_output_iterator<FwdIter2>::value),
+            static_assert((hpx::traits::is_output_iterator_v<FwdIter2>),
                 "Requires at least output iterator.");
 
             // if count is representing a negative value, we do nothing
@@ -752,9 +755,9 @@ namespace hpx {
         template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
             typename Pred,
             HPX_CONCEPT_REQUIRES_(
-                hpx::is_execution_policy<ExPolicy>::value &&
-                hpx::traits::is_iterator<FwdIter1>::value &&
-                hpx::traits::is_iterator<FwdIter2>::value &&
+                hpx::is_execution_policy_v<ExPolicy> &&
+                hpx::traits::is_iterator_v<FwdIter1> &&
+                hpx::traits::is_iterator_v<FwdIter2> &&
                 hpx::is_invocable_v<Pred,
                     typename std::iterator_traits<FwdIter1>::value_type
                 >
@@ -765,11 +768,11 @@ namespace hpx {
         tag_fallback_dispatch(hpx::copy_if_t, ExPolicy&& policy, FwdIter1 first,
             FwdIter1 last, FwdIter2 dest, Pred&& pred)
         {
-            static_assert((hpx::traits::is_forward_iterator<FwdIter1>::value),
+            static_assert((hpx::traits::is_forward_iterator_v<FwdIter1>),
                 "Required at least forward iterator.");
-            static_assert(hpx::traits::is_forward_iterator<FwdIter2>::value ||
-                    (hpx::is_sequenced_execution_policy<ExPolicy>::value &&
-                        hpx::traits::is_output_iterator<FwdIter2>::value),
+            static_assert(hpx::traits::is_forward_iterator_v<FwdIter2> ||
+                    (hpx::is_sequenced_execution_policy_v<ExPolicy> &&
+                        hpx::traits::is_output_iterator_v<FwdIter2>),
                 "Requires at least forward iterator or sequential execution.");
 
             return hpx::parallel::util::get_second_element(
@@ -783,8 +786,8 @@ namespace hpx {
         // clang-format off
         template <typename FwdIter1, typename FwdIter2, typename Pred,
             HPX_CONCEPT_REQUIRES_(
-                hpx::traits::is_iterator<FwdIter1>::value &&
-                hpx::traits::is_iterator<FwdIter2>::value &&
+                hpx::traits::is_iterator_v<FwdIter1> &&
+                hpx::traits::is_iterator_v<FwdIter2> &&
                 hpx::is_invocable_v<Pred,
                     typename std::iterator_traits<FwdIter1>::value_type
                 >
@@ -793,9 +796,9 @@ namespace hpx {
         friend FwdIter2 tag_fallback_dispatch(hpx::copy_if_t, FwdIter1 first,
             FwdIter1 last, FwdIter2 dest, Pred&& pred)
         {
-            static_assert((hpx::traits::is_forward_iterator<FwdIter1>::value),
+            static_assert((hpx::traits::is_forward_iterator_v<FwdIter1>),
                 "Required at least forward iterator.");
-            static_assert((hpx::traits::is_output_iterator<FwdIter2>::value),
+            static_assert((hpx::traits::is_output_iterator_v<FwdIter2>),
                 "Requires at least output iterator.");
 
             return hpx::parallel::util::get_second_element(

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/move.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/move.hpp
@@ -107,11 +107,24 @@ namespace hpx { namespace parallel { inline namespace v1 {
             {
             }
 
-            template <typename ExPolicy, typename InIter, typename OutIter>
-            static util::in_out_result<InIter, OutIter> sequential(
-                ExPolicy, InIter first, InIter last, OutIter dest)
+            template <typename ExPolicy, typename InIter, typename Sent,
+                typename OutIter>
+            static constexpr std::enable_if_t<
+                !hpx::traits::is_random_access_iterator_v<InIter>,
+                util::in_out_result<InIter, OutIter>>
+            sequential(ExPolicy, InIter first, Sent last, OutIter dest)
             {
                 return util::move(first, last, dest);
+            }
+
+            template <typename ExPolicy, typename InIter, typename Sent,
+                typename OutIter>
+            static constexpr std::enable_if_t<
+                hpx::traits::is_random_access_iterator_v<InIter>,
+                util::in_out_result<InIter, OutIter>>
+            sequential(ExPolicy, InIter first, Sent last, OutIter dest)
+            {
+                return util::move_n(first, detail::distance(first, last), dest);
             }
 
             template <typename ExPolicy, typename FwdIter1, typename FwdIter2>

--- a/libs/parallelism/algorithms/include/hpx/parallel/util/transfer.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/util/transfer.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2016 Hartmut Kaiser
+//  Copyright (c) 2016-2021 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -39,7 +39,7 @@ namespace hpx { namespace parallel { namespace util {
         ///////////////////////////////////////////////////////////////////////
         template <typename T>
         HPX_FORCEINLINE std::enable_if_t<std::is_pointer<T>::value, char*>
-        to_address(T ptr) noexcept
+        to_ptr(T ptr) noexcept
         {
             return const_cast<char*>(
                 reinterpret_cast<char volatile const*>(ptr));
@@ -47,7 +47,7 @@ namespace hpx { namespace parallel { namespace util {
 
         template <typename T>
         HPX_FORCEINLINE std::enable_if_t<std::is_pointer<T>::value, char const*>
-        to_const_address(T ptr) noexcept
+        to_const_ptr(T ptr) noexcept
         {
             return const_cast<char const*>(
                 reinterpret_cast<char volatile const*>(ptr));
@@ -55,7 +55,7 @@ namespace hpx { namespace parallel { namespace util {
 
         template <typename Iter>
         HPX_FORCEINLINE std::enable_if_t<!std::is_pointer<Iter>::value, char*>
-        to_address(Iter ptr) noexcept
+        to_ptr(Iter ptr) noexcept
         {
             static_assert(hpx::traits::is_contiguous_iterator_v<Iter>,
                 "optimized copy/move is possible for contiguous-iterators "
@@ -68,7 +68,7 @@ namespace hpx { namespace parallel { namespace util {
         template <typename Iter>
         HPX_FORCEINLINE
             std::enable_if_t<!std::is_pointer<Iter>::value, char const*>
-            to_const_address(Iter ptr) noexcept
+            to_const_ptr(Iter ptr) noexcept
         {
             static_assert(hpx::traits::is_contiguous_iterator_v<Iter>,
                 "optimized copy/move is possible for contiguous-iterators "
@@ -85,8 +85,8 @@ namespace hpx { namespace parallel { namespace util {
         {
             using data_type = typename std::iterator_traits<InIter>::value_type;
 
-            char const* const first_ch = to_const_address(first);
-            char* const dest_ch = to_address(dest);
+            char const* const first_ch = to_const_ptr(first);
+            char* const dest_ch = to_ptr(dest);
 
             std::memmove(dest_ch, first_ch, count * sizeof(data_type));
 

--- a/libs/parallelism/algorithms/include/hpx/parallel/util/transfer.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/util/transfer.hpp
@@ -57,6 +57,10 @@ namespace hpx { namespace parallel { namespace util {
         HPX_FORCEINLINE std::enable_if_t<!std::is_pointer<Iter>::value, char*>
         to_address(Iter ptr) noexcept
         {
+            static_assert(hpx::traits::is_contiguous_iterator_v<Iter>,
+                "optimized copy/move is possible for contiguous-iterators "
+                "only");
+
             return const_cast<char*>(
                 reinterpret_cast<char volatile const*>(&*ptr));
         }
@@ -66,6 +70,10 @@ namespace hpx { namespace parallel { namespace util {
             std::enable_if_t<!std::is_pointer<Iter>::value, char const*>
             to_const_address(Iter ptr) noexcept
         {
+            static_assert(hpx::traits::is_contiguous_iterator_v<Iter>,
+                "optimized copy/move is possible for contiguous-iterators "
+                "only");
+
             return const_cast<char const*>(
                 reinterpret_cast<char volatile const*>(&*ptr));
         }


### PR DESCRIPTION
- this improves the detection of contiguous trivially copyable sequences
  for which copy and move can fall back to memcpy
- flyby: adding traits::is_contiguous_iterator
- flyby: modernize transfer algorithm implementations

The sequential version gives me about 40% speedup when copying `vector<>`s of trivially copyable types.