### PR TITLE
Remove unnecessary explicit listing of library modules.rst files in CMakeLists.txt

### DIFF
--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -214,9 +214,6 @@ list(
   sphinx_libs_source_files
   "index.rst"
   "overview.rst"
-  "core/modules.rst"
-  "full/modules.rst"
-  "parallelism/modules.rst"
 )
 
 foreach(lib ${HPX_LIBS})


### PR DESCRIPTION
They're added through the `HPX_LIBS` variable just below the manual listing...