### PR TITLE
More precompiled headers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -322,69 +322,95 @@ hpx_option(
 if(HPX_WITH_PRECOMPILED_HEADERS)
   set(HPX_WITH_PRECOMPILED_HEADERS_INTERNAL ON)
 
+  set(system_precompiled_headers
+      <algorithm>
+      <array>
+      <atomic>
+      <bitset>
+      <cassert>
+      <cctype>
+      <cerrno>
+      <chrono>
+      <climits>
+      <cmath>
+      <complex>
+      <condition_variable>
+      <cstddef>
+      <cstdint>
+      <cstdio>
+      <cstdlib>
+      <cstring>
+      <ctime>
+      <deque>
+      <exception>
+      <execution>
+      <forward_list>
+      <fstream>
+      <functional>
+      <iomanip>
+      <ios>
+      <iosfwd>
+      <iostream>
+      <iterator>
+      <limits>
+      <list>
+      <locale>
+      <map>
+      <memory>
+      <mutex>
+      <new>
+      <numeric>
+      <ostream>
+      <random>
+      <regex>
+      <set>
+      <shared_mutex>
+      <sstream>
+      <stack>
+      <stdexcept>
+      <string>
+      <system_error>
+      <thread>
+      <tuple>
+      <type_traits>
+      <typeinfo>
+      <unordered_map>
+      <unordered_set>
+      <utility>
+      <variant>
+      <vector>
+      <hwloc.h>
+      <asio/basic_waitable_timer.hpp>
+      <asio/io_context.hpp>
+      <asio/ip/tcp.hpp>
+      <boost/config.hpp>
+      <boost/container/small_vector.hpp>
+      <boost/fusion/include/vector.hpp>
+      <boost/intrusive/slist.hpp>
+      <boost/lockfree/queue.hpp>
+      <boost/optional.hpp>
+      <boost/spirit/home/x3.hpp>
+      <boost/tokenizer.hpp>
+      <boost/utility/string_ref.hpp>
+  )
+
+  if(HPX_WITH_CXX17_FILESYSTEM)
+    list(APPEND system_precompiled_headers <filesystem>)
+  endif()
+
+  set(system_precompiled_headers_dependencies
+      hpx_dependencies_boost hpx_private_flags hpx_public_flags
+      ASIO::standalone_asio
+  )
+
   add_library(hpx_precompiled_headers OBJECT libs/src/dummy.cpp)
   target_link_libraries(
-    hpx_precompiled_headers PRIVATE hpx_public_flags hpx_private_flags
-                                    hpx_base_libraries
+    hpx_precompiled_headers
+    PRIVATE hpx_public_flags hpx_private_flags hpx_base_libraries
+            ${system_precompiled_headers_dependencies}
   )
   target_precompile_headers(
-    hpx_precompiled_headers
-    PRIVATE
-    <algorithm>
-    <array>
-    <atomic>
-    <bitset>
-    <cassert>
-    <cctype>
-    <cerrno>
-    <chrono>
-    <climits>
-    <cmath>
-    <complex>
-    <condition_variable>
-    <cstddef>
-    <cstdint>
-    <cstdio>
-    <cstdlib>
-    <cstring>
-    <ctime>
-    <deque>
-    <exception>
-    <forward_list>
-    <fstream>
-    <functional>
-    <iomanip>
-    <ios>
-    <iosfwd>
-    <iostream>
-    <iterator>
-    <limits>
-    <list>
-    <locale>
-    <map>
-    <memory>
-    <mutex>
-    <new>
-    <numeric>
-    <ostream>
-    <random>
-    <regex>
-    <set>
-    <shared_mutex>
-    <sstream>
-    <stack>
-    <stdexcept>
-    <string>
-    <system_error>
-    <thread>
-    <tuple>
-    <type_traits>
-    <typeinfo>
-    <unordered_map>
-    <unordered_set>
-    <utility>
-    <variant>
-    <vector>
+    hpx_precompiled_headers PRIVATE ${system_precompiled_headers}
   )
 
   set_target_properties(hpx_precompiled_headers PROPERTIES FOLDER "Core")
@@ -502,31 +528,11 @@ if(NOT HPX_WITH_TESTS)
     VALUE OFF
     FORCE
   )
-  hpx_set_option(
-    HPX_WITH_TESTS_REGRESSIONS
-    VALUE OFF
-    FORCE
-  )
-  hpx_set_option(
-    HPX_WITH_TESTS_UNIT
-    VALUE OFF
-    FORCE
-  )
-  hpx_set_option(
-    HPX_WITH_TESTS_HEADERS
-    VALUE OFF
-    FORCE
-  )
-  hpx_set_option(
-    HPX_WITH_TESTS_EXTERNAL_BUILD
-    VALUE OFF
-    FORCE
-  )
-  hpx_set_option(
-    HPX_WITH_TESTS_EXAMPLES
-    VALUE OFF
-    FORCE
-  )
+  hpx_set_option(HPX_WITH_TESTS_REGRESSIONS VALUE OFF FORCE)
+  hpx_set_option(HPX_WITH_TESTS_UNIT VALUE OFF FORCE)
+  hpx_set_option(HPX_WITH_TESTS_HEADERS VALUE OFF FORCE)
+  hpx_set_option(HPX_WITH_TESTS_EXTERNAL_BUILD VALUE OFF FORCE)
+  hpx_set_option(HPX_WITH_TESTS_EXAMPLES VALUE OFF FORCE)
 endif()
 
 hpx_option(
@@ -534,8 +540,7 @@ hpx_option(
   BOOL
   "Enable the distributed runtime (default: ON). Turning off the distributed runtime completely disallows the creation and use of components and actions. Turning this option off is experimental!"
   ON
-  CATEGORY "Build Targets"
-  ADVANCED
+  CATEGORY "Build Targets" ADVANCED
 )
 
 if(HPX_WITH_DISTRIBUTED_RUNTIME)
@@ -757,8 +762,7 @@ hpx_option(
   STRING
   "HPX applications will not use more that this number of OS-Threads (empty string means dynamic) (default: ${HPX_MAX_CPU_COUNT_DEFAULT})"
   "${HPX_MAX_CPU_COUNT_DEFAULT}"
-  CATEGORY "Thread Manager"
-  ADVANCED
+  CATEGORY "Thread Manager" ADVANCED
 )
 if(HPX_WITH_MAX_CPU_COUNT)
   hpx_add_config_define(HPX_HAVE_MAX_CPU_COUNT ${HPX_WITH_MAX_CPU_COUNT})
@@ -773,8 +777,7 @@ hpx_option(
   STRING
   "HPX applications will not run on machines with more NUMA domains (default: ${HPX_MAX_NUMA_DOMAIN_COUNT_DEFAULT})"
   ${HPX_MAX_NUMA_DOMAIN_COUNT_DEFAULT}
-  CATEGORY "Thread Manager"
-  ADVANCED
+  CATEGORY "Thread Manager" ADVANCED
 )
 hpx_add_config_define(
   HPX_HAVE_MAX_NUMA_DOMAIN_COUNT ${HPX_WITH_MAX_NUMA_DOMAIN_COUNT}
@@ -783,30 +786,24 @@ hpx_add_config_define(
 hpx_option(
   HPX_WITH_THREAD_STACK_MMAP BOOL
   "Use mmap for stack allocation on appropriate platforms" ON
-  CATEGORY "Thread Manager"
-  ADVANCED
+  CATEGORY "Thread Manager" ADVANCED
 )
 
 hpx_option(
   HPX_WITH_THREAD_MANAGER_IDLE_BACKOFF BOOL
   "HPX scheduler threads do exponential backoff on idle queues (default: ON)" ON
-  CATEGORY "Thread Manager"
-  ADVANCED
+  CATEGORY "Thread Manager" ADVANCED
 )
 
 hpx_option(
   HPX_WITH_STACKTRACES BOOL "Attach backtraces to HPX exceptions (default: ON)"
-  ON
-  CATEGORY "Thread Manager"
-  ADVANCED
+  ON CATEGORY "Thread Manager" ADVANCED
 )
 
 hpx_option(
   HPX_WITH_THREAD_BACKTRACE_ON_SUSPENSION BOOL
   "Enable thread stack back trace being captured on suspension (default: OFF)"
-  OFF
-  CATEGORY "Thread Manager"
-  ADVANCED
+  OFF CATEGORY "Thread Manager" ADVANCED
 )
 
 # We create a target to contain libraries like rt, dl etc. in order to remove
@@ -827,8 +824,7 @@ if(HPX_WITH_STACKTRACES OR HPX_WITH_THREAD_BACKTRACE_ON_SUSPENSION)
   hpx_option(
     HPX_WITH_THREAD_BACKTRACE_DEPTH STRING
     "Thread stack back trace depth being captured (default: 20)" "20"
-    CATEGORY "Thread Manager"
-    ADVANCED
+    CATEGORY "Thread Manager" ADVANCED
   )
   hpx_add_config_define(
     HPX_HAVE_THREAD_BACKTRACE_DEPTH ${HPX_WITH_THREAD_BACKTRACE_DEPTH}
@@ -844,8 +840,7 @@ if(HPX_WITH_STACKTRACES OR HPX_WITH_THREAD_BACKTRACE_ON_SUSPENSION)
     hpx_option(
       HPX_WITH_STACKTRACES_STATIC_SYMBOLS BOOL
       "Thread stack back trace will resolve static symbols (default: OFF)" OFF
-      CATEGORY "Thread Manager"
-      ADVANCED
+      CATEGORY "Thread Manager" ADVANCED
     )
     hpx_add_config_define(
       HPX_HAVE_STACKTRACES_STATIC_SYMBOLS
@@ -856,8 +851,7 @@ if(HPX_WITH_STACKTRACES OR HPX_WITH_THREAD_BACKTRACE_ON_SUSPENSION)
     hpx_option(
       HPX_WITH_STACKTRACES_DEMANGLE_SYMBOLS BOOL
       "Thread stack back trace symbols will be demangled (default: ON)" ON
-      CATEGORY "Thread Manager"
-      ADVANCED
+      CATEGORY "Thread Manager" ADVANCED
     )
     if(HPX_WITH_STACKTRACES_DEMANGLE_SYMBOLS)
       hpx_add_config_define(HPX_HAVE_STACKTRACES_DEMANGLE_SYMBOLS)
@@ -871,9 +865,7 @@ if(HPX_WITH_THREAD_BACKTRACE_ON_SUSPENSION)
   hpx_option(
     HPX_WITH_THREAD_FULLBACKTRACE_ON_SUSPENSION BOOL
     "Enable thread stack back trace being captured on suspension (default: OFF)"
-    OFF
-    CATEGORY "Thread Manager"
-    ADVANCED
+    OFF CATEGORY "Thread Manager" ADVANCED
   )
   if(HPX_WITH_THREAD_FULLBACKTRACE_ON_SUSPENSION)
     hpx_add_config_define(HPX_HAVE_THREAD_FULLBACKTRACE_ON_SUSPENSION)
@@ -883,9 +875,7 @@ endif()
 hpx_option(
   HPX_WITH_THREAD_TARGET_ADDRESS BOOL
   "Enable storing target address in thread for NUMA awareness (default: OFF)"
-  OFF
-  CATEGORY "Thread Manager"
-  ADVANCED
+  OFF CATEGORY "Thread Manager" ADVANCED
 )
 
 if(HPX_WITH_THREAD_TARGET_ADDRESS)
@@ -895,8 +885,7 @@ endif()
 hpx_option(
   HPX_WITH_THREAD_QUEUE_WAITTIME BOOL
   "Enable collecting queue wait times for threads (default: OFF)" OFF
-  CATEGORY "Thread Manager"
-  ADVANCED
+  CATEGORY "Thread Manager" ADVANCED
 )
 
 if(HPX_WITH_THREAD_QUEUE_WAITTIME)
@@ -908,15 +897,13 @@ hpx_option(
   BOOL
   "Enable measuring the percentage of overhead times spent in the scheduler (default: OFF)"
   OFF
-  CATEGORY "Thread Manager"
-  ADVANCED
+  CATEGORY "Thread Manager" ADVANCED
 )
 
 hpx_option(
   HPX_WITH_THREAD_CREATION_AND_CLEANUP_RATES BOOL
   "Enable measuring thread creation and cleanup times (default: OFF)" OFF
-  CATEGORY "Thread Manager"
-  ADVANCED
+  CATEGORY "Thread Manager" ADVANCED
 )
 
 if(HPX_WITH_THREAD_IDLE_RATES)
@@ -931,8 +918,7 @@ hpx_option(
   BOOL
   "Enable keeping track of cumulative thread counts in the schedulers (default: ON)"
   ON
-  CATEGORY "Thread Manager"
-  ADVANCED
+  CATEGORY "Thread Manager" ADVANCED
 )
 
 if(HPX_WITH_THREAD_CUMULATIVE_COUNTS)
@@ -944,8 +930,7 @@ hpx_option(
   BOOL
   "Enable keeping track of counts of thread stealing incidents in the schedulers (default: OFF)"
   OFF
-  CATEGORY "Thread Manager"
-  ADVANCED
+  CATEGORY "Thread Manager" ADVANCED
 )
 
 if(HPX_WITH_THREAD_STEALING_COUNTS)
@@ -955,9 +940,7 @@ endif()
 hpx_option(
   HPX_WITH_COROUTINE_COUNTERS BOOL
   "Enable keeping track of coroutine creation and rebind counts (default: OFF)"
-  OFF
-  CATEGORY "Thread Manager"
-  ADVANCED
+  OFF CATEGORY "Thread Manager" ADVANCED
 )
 if(HPX_WITH_COROUTINE_COUNTERS)
   hpx_add_config_define(HPX_HAVE_COROUTINE_COUNTERS)
@@ -966,8 +949,7 @@ endif()
 hpx_option(
   HPX_WITH_THREAD_LOCAL_STORAGE BOOL
   "Enable thread local storage for all HPX threads (default: OFF)" OFF
-  CATEGORY "Thread Manager"
-  ADVANCED
+  CATEGORY "Thread Manager" ADVANCED
 )
 
 if(HPX_WITH_THREAD_LOCAL_STORAGE)
@@ -977,8 +959,7 @@ endif()
 hpx_option(
   HPX_WITH_SCHEDULER_LOCAL_STORAGE BOOL
   "Enable scheduler local storage for all HPX schedulers (default: OFF)" OFF
-  CATEGORY "Thread Manager"
-  ADVANCED
+  CATEGORY "Thread Manager" ADVANCED
 )
 
 if(HPX_WITH_SCHEDULER_LOCAL_STORAGE)
@@ -988,8 +969,7 @@ endif()
 hpx_option(
   HPX_WITH_SPINLOCK_POOL_NUM STRING
   "Number of elements a spinlock pool manages (default: 128)" 128
-  CATEGORY "Thread Manager"
-  ADVANCED
+  CATEGORY "Thread Manager" ADVANCED
 )
 
 hpx_add_config_define(HPX_HAVE_SPINLOCK_POOL_NUM ${HPX_WITH_SPINLOCK_POOL_NUM})
@@ -1000,8 +980,7 @@ hpx_option(
   STRING
   "[Deprecated] Maximum number of terminated threads collected before those are cleaned up (default: 100)"
   "0"
-  CATEGORY "Thread Manager"
-  ADVANCED
+  CATEGORY "Thread Manager" ADVANCED
 )
 
 if(HPX_SCHEDULER_MAX_TERMINATED_THREADS GREATER 0)
@@ -1017,8 +996,7 @@ endif()
 hpx_option(
   HPX_WITH_SPINLOCK_DEADLOCK_DETECTION BOOL
   "Enable spinlock deadlock detection (default: OFF)" OFF
-  CATEGORY "Thread Manager"
-  ADVANCED
+  CATEGORY "Thread Manager" ADVANCED
 )
 
 if(HPX_WITH_SPINLOCK_DEADLOCK_DETECTION)
@@ -1048,13 +1026,11 @@ hpx_option(
   BOOL
   "Use FetchContent to fetch Asio. By default an installed Asio will be used. (default: OFF)"
   OFF
-  CATEGORY "Build Targets"
-  ADVANCED
+  CATEGORY "Build Targets" ADVANCED
 )
 hpx_option(
   HPX_WITH_ASIO_TAG STRING "Asio repository tag or branch" "asio-1-18-2"
-  CATEGORY "Build Targets"
-  ADVANCED
+  CATEGORY "Build Targets" ADVANCED
 )
 
 # cmake-format: off
@@ -1119,8 +1095,7 @@ hpx_option(
   BOOL
   "Disable internal IO thread pool, do not change if not absolutely necessary (default: ON)"
   ON
-  CATEGORY "Thread Manager"
-  ADVANCED
+  CATEGORY "Thread Manager" ADVANCED
 )
 if(HPX_WITH_IO_POOL)
   hpx_add_config_define(HPX_HAVE_IO_POOL)
@@ -1131,8 +1106,7 @@ hpx_option(
   BOOL
   "Disable internal timer thread pool, do not change if not absolutely necessary (default: ON)"
   ON
-  CATEGORY "Thread Manager"
-  ADVANCED
+  CATEGORY "Thread Manager" ADVANCED
 )
 if(HPX_WITH_TIMER_POOL)
   hpx_add_config_define(HPX_HAVE_TIMER_POOL)
@@ -1142,8 +1116,7 @@ endif()
 hpx_option(
   HPX_WITH_AGAS_DUMP_REFCNT_ENTRIES BOOL
   "Enable dumps of the AGAS refcnt tables to logs (default: OFF)" OFF
-  CATEGORY "AGAS"
-  ADVANCED
+  CATEGORY "AGAS" ADVANCED
 )
 if(HPX_WITH_AGAS_DUMP_REFCNT_ENTRIES)
   hpx_add_config_define(HPX_HAVE_AGAS_DUMP_REFCNT_ENTRIES)
@@ -1175,9 +1148,7 @@ if(HPX_WITH_NETWORKING)
 
   hpx_option(
     HPX_WITH_PARCEL_PROFILING BOOL "Enable profiling data for parcels"
-    ${_parcel_profiling_default}
-    CATEGORY "Parcelport"
-    ADVANCED
+    ${_parcel_profiling_default} CATEGORY "Parcelport" ADVANCED
   )
 
   if(HPX_WITH_PARCEL_PROFILING)
@@ -1190,8 +1161,7 @@ if(HPX_WITH_NETWORKING)
     BOOL
     "Enable the libfabric based parcelport. This is currently an experimental feature"
     OFF
-    CATEGORY "Parcelport"
-    ADVANCED
+    CATEGORY "Parcelport" ADVANCED
   )
   if(HPX_WITH_PARCELPORT_LIBFABRIC)
     hpx_add_config_define(HPX_HAVE_PARCELPORT_LIBFABRIC)
@@ -1250,8 +1220,7 @@ if((HPX_WITH_NETWORKING AND HPX_WITH_PARCELPORT_MPI) OR HPX_WITH_ASYNC_MPI)
     STRING
     "List of environment variables checked to detect MPI (default: MV2_COMM_WORLD_RANK;PMI_RANK;OMPI_COMM_WORLD_SIZE;ALPS_APP_PE;PMIX_RANK)."
     "MV2_COMM_WORLD_RANK;PMI_RANK;OMPI_COMM_WORLD_SIZE;ALPS_APP_PE;PMIX_RANK"
-    CATEGORY "Parcelport"
-    ADVANCED
+    CATEGORY "Parcelport" ADVANCED
   )
 
   # This list is to detect whether we run inside an mpi environment. If one of
@@ -1269,9 +1238,8 @@ if((HPX_WITH_NETWORKING AND HPX_WITH_PARCELPORT_MPI) OR HPX_WITH_ASYNC_MPI)
 
   hpx_option(
     HPX_WITH_PARCELPORT_MPI_MULTITHREADED BOOL
-    "Turn on MPI multithreading support (default: ON)." ON
-    CATEGORY "Parcelport"
-    ADVANCED
+    "Turn on MPI multithreading support (default: ON)." ON CATEGORY "Parcelport"
+                                                                    ADVANCED
   )
   if(HPX_WITH_PARCELPORT_MPI_MULTITHREADED)
     hpx_add_config_define(HPX_HAVE_PARCELPORT_MPI_MULTITHREADED)
@@ -1289,8 +1257,7 @@ endif()
 hpx_option(
   HPX_WITH_EXAMPLES_OPENMP BOOL
   "Enable examples requiring OpenMP support (default: OFF)." OFF
-  CATEGORY "Build Targets"
-  ADVANCED
+  CATEGORY "Build Targets" ADVANCED
 )
 if(HPX_WITH_EXAMPLES_OPENMP)
   find_package(OpenMP)
@@ -1301,8 +1268,7 @@ endif()
 hpx_option(
   HPX_WITH_EXAMPLES_TBB BOOL
   "Enable examples requiring TBB support (default: OFF)." OFF
-  CATEGORY "Build Targets"
-  ADVANCED
+  CATEGORY "Build Targets" ADVANCED
 )
 if(HPX_WITH_EXAMPLES_TBB)
   find_package(TBB)
@@ -1313,8 +1279,7 @@ endif()
 hpx_option(
   HPX_WITH_EXAMPLES_QTHREADS BOOL
   "Enable examples requiring QThreads support (default: OFF)." OFF
-  CATEGORY "Build Targets"
-  ADVANCED
+  CATEGORY "Build Targets" ADVANCED
 )
 if(HPX_WITH_EXAMPLES_QTHREADS)
   find_package(QThreads)
@@ -1325,8 +1290,7 @@ endif()
 hpx_option(
   HPX_WITH_EXAMPLES_HDF5 BOOL
   "Enable examples requiring HDF5 support (default: OFF)." OFF
-  CATEGORY "Build Targets"
-  ADVANCED
+  CATEGORY "Build Targets" ADVANCED
 )
 if(HPX_WITH_EXAMPLES_HDF5)
   find_package(HDF5 COMPONENTS CXX)
@@ -1340,8 +1304,7 @@ if(NOT "${HPX_PLATFORM_UC}" STREQUAL "BLUEGENEQ")
   hpx_option(
     HPX_WITH_EXAMPLES_QT4 BOOL
     "Enable examples requiring Qt4 support (default: OFF)." OFF
-    CATEGORY "Build Targets"
-    ADVANCED
+    CATEGORY "Build Targets" ADVANCED
   )
   if(HPX_WITH_EXAMPLES_QT4)
     find_package(Qt4)
@@ -1367,37 +1330,32 @@ hpx_option(
   BOOL
   "Enable lock verification code (default: OFF, implicitly enabled in debug builds)"
   OFF
-  CATEGORY "Debugging"
-  ADVANCED
+  CATEGORY "Debugging" ADVANCED
 )
 hpx_option(
   HPX_WITH_VERIFY_LOCKS_GLOBALLY
   BOOL
   "Enable global lock verification code (default: OFF, implicitly enabled in debug builds)"
   OFF
-  CATEGORY "Debugging"
-  ADVANCED
+  CATEGORY "Debugging" ADVANCED
 )
 hpx_option(
   HPX_WITH_VERIFY_LOCKS_BACKTRACE
   BOOL
   "Enable thread stack back trace being captured on lock registration (to be used in combination with HPX_WITH_VERIFY_LOCKS=ON, default: OFF)"
   OFF
-  CATEGORY "Debugging"
-  ADVANCED
+  CATEGORY "Debugging" ADVANCED
 )
 hpx_option(
   HPX_WITH_THREAD_DEBUG_INFO
   BOOL
   "Enable thread debugging information (default: OFF, implicitly enabled in debug builds)"
   OFF
-  CATEGORY "Debugging"
-  ADVANCED
+  CATEGORY "Debugging" ADVANCED
 )
 hpx_option(
   HPX_WITH_THREAD_GUARD_PAGE BOOL "Enable thread guard page (default: ON)" ON
-  CATEGORY "Debugging"
-  ADVANCED
+  CATEGORY "Debugging" ADVANCED
 )
 
 if(HPX_WITH_VERIFY_LOCKS)
@@ -1426,15 +1384,13 @@ endif()
 hpx_option(
   HPX_WITH_THREAD_DESCRIPTION_FULL BOOL
   "Use function address for thread description (default: OFF)" OFF
-  CATEGORY "Debugging"
-  ADVANCED
+  CATEGORY "Debugging" ADVANCED
 )
 
 hpx_option(
   HPX_WITH_ATTACH_DEBUGGER_ON_TEST_FAILURE BOOL
   "Break the debugger if a test has failed  (default: OFF)" OFF
-  CATEGORY "Debugging"
-  ADVANCED
+  CATEGORY "Debugging" ADVANCED
 )
 if(HPX_WITH_ATTACH_DEBUGGER_ON_TEST_FAILURE)
   hpx_add_config_define(HPX_HAVE_ATTACH_DEBUGGER_ON_TEST_FAILURE)
@@ -1443,15 +1399,13 @@ endif()
 hpx_option(
   HPX_WITH_TESTS_DEBUG_LOG BOOL
   "Turn on debug logs (--hpx:debug-hpx-log) for tests (default: OFF)" OFF
-  CATEGORY "Debugging"
-  ADVANCED
+  CATEGORY "Debugging" ADVANCED
 )
 
 hpx_option(
   HPX_WITH_TESTS_DEBUG_LOG_DESTINATION STRING
-  "Destination for test debug logs (default: cout)" "cout"
-  CATEGORY "Debugging"
-  ADVANCED
+  "Destination for test debug logs (default: cout)" "cout" CATEGORY "Debugging"
+                                                                    ADVANCED
 )
 
 hpx_option(
@@ -1459,8 +1413,7 @@ hpx_option(
   STRING
   "Maximum number of threads to use for tests (default: 0, use the number of threads specified by the test)"
   0
-  CATEGORY "Debugging"
-  ADVANCED
+  CATEGORY "Debugging" ADVANCED
 )
 
 hpx_option(
@@ -1468,8 +1421,7 @@ hpx_option(
   BOOL
   "Pass --hpx:bind=none to tests that may run in parallel (cmake -j flag) (default: OFF)"
   OFF
-  CATEGORY "Debugging"
-  ADVANCED
+  CATEGORY "Debugging" ADVANCED
 )
 
 # If APEX is defined, the action timers need thread debug info.
@@ -1560,8 +1512,7 @@ hpx_option(
   BOOL
   "Enable swapping of rvalue tuples (needed for parallel::sort_by_key, default: ON)."
   ON
-  CATEGORY "Utility"
-  ADVANCED
+  CATEGORY "Utility" ADVANCED
 )
 if(HPX_WITH_TUPLE_RVALUE_SWAP)
   hpx_add_config_define(HPX_HAVE_TUPLE_RVALUE_SWAP)

--- a/init/CMakeLists.txt
+++ b/init/CMakeLists.txt
@@ -111,3 +111,7 @@ endif()
 hpx_export_internal_targets(hpx_init)
 
 add_hpx_pseudo_dependencies(core hpx_init)
+
+if(HPX_WITH_PRECOMPILED_HEADERS)
+  target_precompile_headers(hpx_init REUSE_FROM hpx_precompiled_headers)
+endif()

--- a/libs/core/config/include/hpx/config.hpp
+++ b/libs/core/config/include/hpx/config.hpp
@@ -7,13 +7,6 @@
 
 #pragma once
 
-// We need to detect if user code include boost/config.hpp before
-// including hpx/config.hpp
-// Everything else might lead to hard compile errors and possible very subtle bugs.
-#if defined(BOOST_CONFIG_HPP)
-#error Boost.Config was included before the hpx config header. This might lead to subtle failures and compile errors. Please include <hpx/config.hpp> before any other boost header
-#endif
-
 #include <hpx/config/defines.hpp>
 
 #if defined(WIN32) || defined(_WIN32) || defined(__WIN32__)

--- a/libs/core/coroutines/include/hpx/coroutines/detail/tss.hpp
+++ b/libs/core/coroutines/include/hpx/coroutines/detail/tss.hpp
@@ -20,6 +20,9 @@
 #include <utility>
 
 namespace hpx { namespace threads { namespace coroutines { namespace detail {
+    class tss_storage;
+
+#if defined(HPX_HAVE_THREAD_LOCAL_STORAGE)
     //////////////////////////////////////////////////////////////////////////
     struct tss_cleanup_function
     {
@@ -195,7 +198,6 @@ namespace hpx { namespace threads { namespace coroutines { namespace detail {
         void* tss_data = nullptr, bool cleanup_existing = false);
 
     //////////////////////////////////////////////////////////////////////////
-    class tss_storage;
 
     HPX_CORE_EXPORT tss_storage* create_tss_storage();
     HPX_CORE_EXPORT void delete_tss_storage(tss_storage*& storage);
@@ -203,4 +205,5 @@ namespace hpx { namespace threads { namespace coroutines { namespace detail {
     HPX_CORE_EXPORT std::size_t get_tss_thread_data(tss_storage* storage);
     HPX_CORE_EXPORT std::size_t set_tss_thread_data(
         tss_storage* storage, std::size_t);
+#endif
 }}}}    // namespace hpx::threads::coroutines::detail

--- a/libs/core/coroutines/src/detail/tss.cpp
+++ b/libs/core/coroutines/src/detail/tss.cpp
@@ -10,6 +10,7 @@
 // (C) Copyright 2011-2012 Vicente J. Botet Escriba
 
 #include <hpx/config.hpp>
+#if defined(HPX_HAVE_THREAD_LOCAL_STORAGE)
 #include <hpx/assert.hpp>
 #include <hpx/coroutines/coroutine.hpp>
 #include <hpx/coroutines/detail/coroutine_self.hpp>
@@ -239,3 +240,4 @@ namespace hpx { namespace threads { namespace coroutines { namespace detail {
 #endif
     }
 }}}}    // namespace hpx::threads::coroutines::detail
+#endif

--- a/libs/core/thread_pools/include/hpx/thread_pools/scheduled_thread_pool_impl.hpp
+++ b/libs/core/thread_pools/include/hpx/thread_pools/scheduled_thread_pool_impl.hpp
@@ -24,6 +24,7 @@
 #include <hpx/threading_base/scheduler_mode.hpp>
 #include <hpx/threading_base/scheduler_state.hpp>
 #include <hpx/threading_base/set_thread_state.hpp>
+#include <hpx/threading_base/set_thread_state_timed.hpp>
 #include <hpx/threading_base/thread_data.hpp>
 #include <hpx/threading_base/thread_helpers.hpp>
 #include <hpx/threading_base/thread_num_tss.hpp>

--- a/libs/core/threading_base/CMakeLists.txt
+++ b/libs/core/threading_base/CMakeLists.txt
@@ -13,6 +13,8 @@ set(threading_base_headers
     hpx/threading_base/create_work.hpp
     hpx/threading_base/detail/reset_backtrace.hpp
     hpx/threading_base/detail/reset_lco_description.hpp
+    hpx/threading_base/detail/get_default_pool.hpp
+    hpx/threading_base/detail/get_default_timer_service.hpp
     hpx/threading_base/execution_agent.hpp
     hpx/threading_base/external_timer.hpp
     hpx/threading_base/network_background_callback.hpp
@@ -22,6 +24,7 @@ set(threading_base_headers
     hpx/threading_base/scheduler_mode.hpp
     hpx/threading_base/scheduler_state.hpp
     hpx/threading_base/set_thread_state.hpp
+    hpx/threading_base/set_thread_state_timed.hpp
     hpx/threading_base/thread_data.hpp
     hpx/threading_base/thread_data_stackful.hpp
     hpx/threading_base/thread_data_stackless.hpp
@@ -60,8 +63,9 @@ set(threading_base_sources
     annotated_function.cpp
     execution_agent.cpp
     external_timer.cpp
+    get_default_pool.cpp
+    get_default_timer_service.cpp
     print.cpp
-    register_thread.cpp
     scheduler_base.cpp
     thread_data.cpp
     thread_data_stackful.cpp

--- a/libs/core/threading_base/include/hpx/threading_base/detail/get_default_pool.hpp
+++ b/libs/core/threading_base/include/hpx/threading_base/detail/get_default_pool.hpp
@@ -1,0 +1,20 @@
+//  Copyright (c) 2007-2015 Hartmut Kaiser
+//  Copyright (c)      2018 Thomas Heller
+//  Copyright (c)      2011 Bryce Lelbach
+//  Copyright (c) 2008-2009 Chirag Dekate, Anshul Tandon
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include <hpx/config.hpp>
+#include <hpx/functional/function.hpp>
+#include <hpx/threading_base/thread_pool_base.hpp>
+
+namespace hpx { namespace threads { namespace detail {
+    using get_default_pool_type = util::function_nonser<thread_pool_base*()>;
+    HPX_CORE_EXPORT void set_get_default_pool(get_default_pool_type f);
+    HPX_CORE_EXPORT thread_pool_base* get_self_or_default_pool();
+}}}    // namespace hpx::threads::detail

--- a/libs/core/threading_base/include/hpx/threading_base/detail/get_default_timer_service.hpp
+++ b/libs/core/threading_base/include/hpx/threading_base/detail/get_default_timer_service.hpp
@@ -1,0 +1,24 @@
+//  Copyright (c) 2007-2015 Hartmut Kaiser
+//  Copyright (c)      2018 Thomas Heller
+//  Copyright (c)      2011 Bryce Lelbach
+//  Copyright (c) 2008-2009 Chirag Dekate, Anshul Tandon
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include <hpx/config.hpp>
+#include <hpx/config/asio.hpp>
+#include <hpx/functional/function.hpp>
+
+#include <asio/io_context.hpp>
+
+namespace hpx { namespace threads { namespace detail {
+    using get_default_timer_service_type =
+        util::function_nonser<asio::io_context*()>;
+    HPX_CORE_EXPORT void set_get_default_timer_service(
+        get_default_timer_service_type f);
+    HPX_CORE_EXPORT asio::io_context* get_default_timer_service();
+}}}    // namespace hpx::threads::detail

--- a/libs/core/threading_base/include/hpx/threading_base/register_thread.hpp
+++ b/libs/core/threading_base/include/hpx/threading_base/register_thread.hpp
@@ -10,15 +10,13 @@
 #pragma once
 
 #include <hpx/config.hpp>
-#include <hpx/config/asio.hpp>
 #include <hpx/assert.hpp>
 #include <hpx/functional/function.hpp>
 #include <hpx/modules/errors.hpp>
+#include <hpx/threading_base/detail/get_default_pool.hpp>
 #include <hpx/threading_base/scheduler_base.hpp>
 #include <hpx/threading_base/thread_data.hpp>
 #include <hpx/threading_base/thread_pool_base.hpp>
-
-#include <asio/io_context.hpp>
 
 #include <cstddef>
 #include <cstdint>
@@ -110,19 +108,6 @@ namespace hpx { namespace threads {
         return {detail::thread_function_nullary<typename std::decay<F>::type>{
             std::forward<F>(f)}};
     }
-
-    namespace detail {
-        using get_default_pool_type =
-            util::function_nonser<thread_pool_base*()>;
-        HPX_CORE_EXPORT void set_get_default_pool(get_default_pool_type f);
-        HPX_CORE_EXPORT thread_pool_base* get_self_or_default_pool();
-
-        using get_default_timer_service_type =
-            util::function_nonser<asio::io_context*()>;
-        HPX_CORE_EXPORT void set_get_default_timer_service(
-            get_default_timer_service_type f);
-        HPX_CORE_EXPORT asio::io_context* get_default_timer_service();
-    }    // namespace detail
 
     ///////////////////////////////////////////////////////////////////////////
     /// \brief Create a new \a thread using the given data.

--- a/libs/core/threading_base/include/hpx/threading_base/set_thread_state.hpp
+++ b/libs/core/threading_base/include/hpx/threading_base/set_thread_state.hpp
@@ -7,23 +7,16 @@
 #pragma once
 
 #include <hpx/config.hpp>
-#include <hpx/config/asio.hpp>
 #include <hpx/assert.hpp>
 #include <hpx/coroutines/coroutine.hpp>
 #include <hpx/functional/bind.hpp>
 #include <hpx/functional/bind_front.hpp>
 #include <hpx/modules/errors.hpp>
 #include <hpx/modules/logging.hpp>
-#include <hpx/threading_base/create_thread.hpp>
 #include <hpx/threading_base/create_work.hpp>
-#include <hpx/threading_base/register_thread.hpp>
-#include <hpx/threading_base/thread_data.hpp>
-
-#include <asio/basic_waitable_timer.hpp>
-#include <asio/io_context.hpp>
+#include <hpx/threading_base/thread_init_data.hpp>
 
 #include <atomic>
-#include <chrono>
 #include <cstddef>
 #include <functional>
 #include <memory>
@@ -318,164 +311,5 @@ namespace hpx { namespace threads { namespace detail {
 
         return thread_result_type(
             thread_schedule_state::terminated, invalid_thread_id);
-    }
-
-    /// This thread function initiates the required set_state action (on
-    /// behalf of one of the threads#detail#set_thread_state functions).
-    template <typename SchedulingPolicy>
-    thread_result_type at_timer(SchedulingPolicy& scheduler,
-        std::chrono::steady_clock::time_point& abs_time,
-        thread_id_type const& thrd, thread_schedule_state newstate,
-        thread_restart_state newstate_ex, thread_priority priority,
-        std::atomic<bool>* started, bool retry_on_active)
-    {
-        if (HPX_UNLIKELY(!thrd))
-        {
-            HPX_THROW_EXCEPTION(null_thread_id, "threads::detail::at_timer",
-                "null thread id encountered");
-            return thread_result_type(
-                thread_schedule_state::terminated, invalid_thread_id);
-        }
-
-        // create a new thread in suspended state, which will execute the
-        // requested set_state when timer fires and will re-awaken this thread,
-        // allowing the deadline_timer to go out of scope gracefully
-        thread_id_type self_id = get_self_id();
-
-        std::shared_ptr<std::atomic<bool>> triggered(
-            std::make_shared<std::atomic<bool>>(false));
-
-        thread_init_data data(
-            util::bind_front(&wake_timer_thread, thrd, newstate, newstate_ex,
-                priority, self_id, triggered, retry_on_active),
-            "wake_timer", priority, thread_schedule_hint(),
-            thread_stacksize::small_, thread_schedule_state::suspended, true);
-
-        thread_id_type wake_id = invalid_thread_id;
-        create_thread(&scheduler, data, wake_id);
-
-        // create timer firing in correspondence with given time
-        using deadline_timer =
-            asio::basic_waitable_timer<std::chrono::steady_clock>;
-
-        asio::io_context* s = get_default_timer_service();
-        HPX_ASSERT(s);
-        deadline_timer t(*s, abs_time);
-
-        // let the timer invoke the set_state on the new (suspended) thread
-        t.async_wait([wake_id, priority, retry_on_active](
-                         std::error_code const& ec) {
-            if (ec == std::make_error_code(std::errc::operation_canceled))
-            {
-                detail::set_thread_state(wake_id,
-                    thread_schedule_state::pending, thread_restart_state::abort,
-                    priority, thread_schedule_hint(), retry_on_active, throws);
-            }
-            else
-            {
-                detail::set_thread_state(wake_id,
-                    thread_schedule_state::pending,
-                    thread_restart_state::timeout, priority,
-                    thread_schedule_hint(), retry_on_active, throws);
-            }
-        });
-
-        if (started != nullptr)
-            started->store(true);
-
-        // this waits for the thread to be reactivated when the timer fired
-        // if it returns signaled the timer has been canceled, otherwise
-        // the timer fired and the wake_timer_thread above has been executed
-        thread_restart_state statex = get_self().yield(thread_result_type(
-            thread_schedule_state::suspended, invalid_thread_id));
-
-        HPX_ASSERT(statex == thread_restart_state::abort ||
-            statex == thread_restart_state::timeout);
-
-        // NOLINTNEXTLINE(bugprone-branch-clone)
-        if (thread_restart_state::timeout != statex)    //-V601
-        {
-            triggered->store(true);
-            // wake_timer_thread has not been executed yet, cancel timer
-            t.cancel();
-        }
-        else
-        {
-            detail::set_thread_state(thrd, newstate, newstate_ex, priority);
-        }
-
-        return thread_result_type(
-            thread_schedule_state::terminated, invalid_thread_id);
-    }
-
-    /// Set a timer to set the state of the given \a thread to the given
-    /// new value after it expired (at the given time)
-    template <typename SchedulingPolicy>
-    thread_id_type set_thread_state_timed(SchedulingPolicy& scheduler,
-        hpx::chrono::steady_time_point const& abs_time,
-        thread_id_type const& thrd, thread_schedule_state newstate,
-        thread_restart_state newstate_ex, thread_priority priority,
-        thread_schedule_hint schedulehint, std::atomic<bool>* started,
-        bool retry_on_active, error_code& ec)
-    {
-        if (HPX_UNLIKELY(!thrd))
-        {
-            HPX_THROWS_IF(ec, null_thread_id,
-                "threads::detail::set_thread_state",
-                "null thread id encountered");
-            return invalid_thread_id;
-        }
-
-        // this creates a new thread which creates the timer and handles the
-        // requested actions
-        thread_init_data data(
-            util::bind(&at_timer<SchedulingPolicy>, std::ref(scheduler),
-                abs_time.value(), thrd, newstate, newstate_ex, priority,
-                started, retry_on_active),
-            "at_timer (expire at)", priority, schedulehint,
-            thread_stacksize::small_, thread_schedule_state::pending, true);
-
-        thread_id_type newid = invalid_thread_id;
-        create_thread(&scheduler, data, newid, ec);    //-V601
-        return newid;
-    }
-
-    template <typename SchedulingPolicy>
-    thread_id_type set_thread_state_timed(SchedulingPolicy& scheduler,
-        hpx::chrono::steady_time_point const& abs_time,
-        thread_id_type const& id, std::atomic<bool>* started,
-        bool retry_on_active, error_code& ec)
-    {
-        return set_thread_state_timed(scheduler, abs_time, id,
-            thread_schedule_state::pending, thread_restart_state::timeout,
-            thread_priority::normal, thread_schedule_hint(), started,
-            retry_on_active, ec);
-    }
-
-    /// Set a timer to set the state of the given \a thread to the given
-    /// new value after it expired (after the given duration)
-    template <typename SchedulingPolicy>
-    thread_id_type set_thread_state_timed(SchedulingPolicy& scheduler,
-        hpx::chrono::steady_duration const& rel_time,
-        thread_id_type const& thrd, thread_schedule_state newstate,
-        thread_restart_state newstate_ex, thread_priority priority,
-        thread_schedule_hint schedulehint, std::atomic<bool>& started,
-        bool retry_on_active, error_code& ec)
-    {
-        return set_thread_state_timed(scheduler, rel_time.from_now(), thrd,
-            newstate, newstate_ex, priority, schedulehint, started,
-            retry_on_active, ec);
-    }
-
-    template <typename SchedulingPolicy>
-    thread_id_type set_thread_state_timed(SchedulingPolicy& scheduler,
-        hpx::chrono::steady_duration const& rel_time,
-        thread_id_type const& thrd, std::atomic<bool>* started,
-        bool retry_on_active, error_code& ec)
-    {
-        return set_thread_state_timed(scheduler, rel_time.from_now(), thrd,
-            thread_schedule_state::pending, thread_restart_state::timeout,
-            thread_priority::normal, thread_schedule_hint(), started,
-            retry_on_active, ec);
     }
 }}}    // namespace hpx::threads::detail

--- a/libs/core/threading_base/include/hpx/threading_base/set_thread_state_timed.hpp
+++ b/libs/core/threading_base/include/hpx/threading_base/set_thread_state_timed.hpp
@@ -1,0 +1,188 @@
+//  Copyright (c) 2007-2017 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include <hpx/config.hpp>
+#include <hpx/config/asio.hpp>
+#include <hpx/assert.hpp>
+#include <hpx/coroutines/coroutine.hpp>
+#include <hpx/functional/bind.hpp>
+#include <hpx/functional/bind_front.hpp>
+#include <hpx/modules/errors.hpp>
+#include <hpx/threading_base/create_thread.hpp>
+#include <hpx/threading_base/detail/get_default_timer_service.hpp>
+#include <hpx/threading_base/set_thread_state.hpp>
+
+#include <asio/basic_waitable_timer.hpp>
+#include <asio/io_context.hpp>
+
+#include <atomic>
+#include <chrono>
+#include <functional>
+#include <memory>
+#include <system_error>
+
+namespace hpx { namespace threads { namespace detail {
+    /// This thread function initiates the required set_state action (on
+    /// behalf of one of the threads#detail#set_thread_state functions).
+    template <typename SchedulingPolicy>
+    thread_result_type at_timer(SchedulingPolicy& scheduler,
+        std::chrono::steady_clock::time_point& abs_time,
+        thread_id_type const& thrd, thread_schedule_state newstate,
+        thread_restart_state newstate_ex, thread_priority priority,
+        std::atomic<bool>* started, bool retry_on_active)
+    {
+        if (HPX_UNLIKELY(!thrd))
+        {
+            HPX_THROW_EXCEPTION(null_thread_id, "threads::detail::at_timer",
+                "null thread id encountered");
+            return thread_result_type(
+                thread_schedule_state::terminated, invalid_thread_id);
+        }
+
+        // create a new thread in suspended state, which will execute the
+        // requested set_state when timer fires and will re-awaken this thread,
+        // allowing the deadline_timer to go out of scope gracefully
+        thread_id_type self_id = get_self_id();
+
+        std::shared_ptr<std::atomic<bool>> triggered(
+            std::make_shared<std::atomic<bool>>(false));
+
+        thread_init_data data(
+            util::bind_front(&wake_timer_thread, thrd, newstate, newstate_ex,
+                priority, self_id, triggered, retry_on_active),
+            "wake_timer", priority, thread_schedule_hint(),
+            thread_stacksize::small_, thread_schedule_state::suspended, true);
+
+        thread_id_type wake_id = invalid_thread_id;
+        create_thread(&scheduler, data, wake_id);
+
+        // create timer firing in correspondence with given time
+        using deadline_timer =
+            asio::basic_waitable_timer<std::chrono::steady_clock>;
+
+        asio::io_context* s = get_default_timer_service();
+        HPX_ASSERT(s);
+        deadline_timer t(*s, abs_time);
+
+        // let the timer invoke the set_state on the new (suspended) thread
+        t.async_wait([wake_id, priority, retry_on_active](
+                         std::error_code const& ec) {
+            if (ec == std::make_error_code(std::errc::operation_canceled))
+            {
+                detail::set_thread_state(wake_id,
+                    thread_schedule_state::pending, thread_restart_state::abort,
+                    priority, thread_schedule_hint(), retry_on_active, throws);
+            }
+            else
+            {
+                detail::set_thread_state(wake_id,
+                    thread_schedule_state::pending,
+                    thread_restart_state::timeout, priority,
+                    thread_schedule_hint(), retry_on_active, throws);
+            }
+        });
+
+        if (started != nullptr)
+            started->store(true);
+
+        // this waits for the thread to be reactivated when the timer fired
+        // if it returns signaled the timer has been canceled, otherwise
+        // the timer fired and the wake_timer_thread above has been executed
+        thread_restart_state statex = get_self().yield(thread_result_type(
+            thread_schedule_state::suspended, invalid_thread_id));
+
+        HPX_ASSERT(statex == thread_restart_state::abort ||
+            statex == thread_restart_state::timeout);
+
+        // NOLINTNEXTLINE(bugprone-branch-clone)
+        if (thread_restart_state::timeout != statex)    //-V601
+        {
+            triggered->store(true);
+            // wake_timer_thread has not been executed yet, cancel timer
+            t.cancel();
+        }
+        else
+        {
+            detail::set_thread_state(thrd, newstate, newstate_ex, priority);
+        }
+
+        return thread_result_type(
+            thread_schedule_state::terminated, invalid_thread_id);
+    }
+
+    /// Set a timer to set the state of the given \a thread to the given
+    /// new value after it expired (at the given time)
+    template <typename SchedulingPolicy>
+    thread_id_type set_thread_state_timed(SchedulingPolicy& scheduler,
+        hpx::chrono::steady_time_point const& abs_time,
+        thread_id_type const& thrd, thread_schedule_state newstate,
+        thread_restart_state newstate_ex, thread_priority priority,
+        thread_schedule_hint schedulehint, std::atomic<bool>* started,
+        bool retry_on_active, error_code& ec)
+    {
+        if (HPX_UNLIKELY(!thrd))
+        {
+            HPX_THROWS_IF(ec, null_thread_id,
+                "threads::detail::set_thread_state",
+                "null thread id encountered");
+            return invalid_thread_id;
+        }
+
+        // this creates a new thread which creates the timer and handles the
+        // requested actions
+        thread_init_data data(
+            util::bind(&at_timer<SchedulingPolicy>, std::ref(scheduler),
+                abs_time.value(), thrd, newstate, newstate_ex, priority,
+                started, retry_on_active),
+            "at_timer (expire at)", priority, schedulehint,
+            thread_stacksize::small_, thread_schedule_state::pending, true);
+
+        thread_id_type newid = invalid_thread_id;
+        create_thread(&scheduler, data, newid, ec);    //-V601
+        return newid;
+    }
+
+    template <typename SchedulingPolicy>
+    thread_id_type set_thread_state_timed(SchedulingPolicy& scheduler,
+        hpx::chrono::steady_time_point const& abs_time,
+        thread_id_type const& id, std::atomic<bool>* started,
+        bool retry_on_active, error_code& ec)
+    {
+        return set_thread_state_timed(scheduler, abs_time, id,
+            thread_schedule_state::pending, thread_restart_state::timeout,
+            thread_priority::normal, thread_schedule_hint(), started,
+            retry_on_active, ec);
+    }
+
+    /// Set a timer to set the state of the given \a thread to the given
+    /// new value after it expired (after the given duration)
+    template <typename SchedulingPolicy>
+    thread_id_type set_thread_state_timed(SchedulingPolicy& scheduler,
+        hpx::chrono::steady_duration const& rel_time,
+        thread_id_type const& thrd, thread_schedule_state newstate,
+        thread_restart_state newstate_ex, thread_priority priority,
+        thread_schedule_hint schedulehint, std::atomic<bool>& started,
+        bool retry_on_active, error_code& ec)
+    {
+        return set_thread_state_timed(scheduler, rel_time.from_now(), thrd,
+            newstate, newstate_ex, priority, schedulehint, started,
+            retry_on_active, ec);
+    }
+
+    template <typename SchedulingPolicy>
+    thread_id_type set_thread_state_timed(SchedulingPolicy& scheduler,
+        hpx::chrono::steady_duration const& rel_time,
+        thread_id_type const& thrd, std::atomic<bool>* started,
+        bool retry_on_active, error_code& ec)
+    {
+        return set_thread_state_timed(scheduler, rel_time.from_now(), thrd,
+            thread_schedule_state::pending, thread_restart_state::timeout,
+            thread_priority::normal, thread_schedule_hint(), started,
+            retry_on_active, ec);
+    }
+}}}    // namespace hpx::threads::detail

--- a/libs/core/threading_base/include/hpx/threading_base/thread_specific_ptr.hpp
+++ b/libs/core/threading_base/include/hpx/threading_base/thread_specific_ptr.hpp
@@ -12,6 +12,7 @@
 #pragma once
 
 #include <hpx/config.hpp>
+#if defined(HPX_HAVE_THREAD_LOCAL_STORAGE)
 #include <hpx/coroutines/detail/tss.hpp>
 #include <hpx/threading_base/thread_data.hpp>
 
@@ -108,3 +109,4 @@ namespace hpx { namespace threads {
         }
     };
 }}    // namespace hpx::threads
+#endif

--- a/libs/core/threading_base/src/get_default_pool.cpp
+++ b/libs/core/threading_base/src/get_default_pool.cpp
@@ -7,17 +7,10 @@
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <hpx/assert.hpp>
-#include <hpx/threading_base/register_thread.hpp>
+#include <hpx/threading_base/detail/get_default_pool.hpp>
 #include <hpx/threading_base/scheduler_base.hpp>
 #include <hpx/threading_base/thread_description.hpp>
 #include <hpx/threading_base/thread_pool_base.hpp>
-
-#include <asio/io_context.hpp>
-
-#include <cstddef>
-#include <limits>
-#include <string>
-#include <utility>
 
 // The following implementation has been divided for Linux and Mac OSX
 #if defined(HPX_HAVE_DYNAMIC_HPX_MAIN) &&                                      \
@@ -86,42 +79,5 @@ namespace hpx { namespace threads { namespace detail {
                 }
 
                 return pool;
-            }
-
-            static get_default_timer_service_type get_default_timer_service_f;
-
-            void set_get_default_timer_service(get_default_timer_service_type f)
-            {
-                get_default_timer_service_f = f;
-            }
-
-            asio::io_context* get_default_timer_service()
-            {
-                asio::io_context* timer_service = nullptr;
-                if (detail::get_default_timer_service_f)
-                {
-                    timer_service = detail::get_default_timer_service_f();
-                    HPX_ASSERT(timer_service);
-                }
-                else
-                {
-#if defined(HPX_HAVE_TIMER_POOL)
-                    HPX_THROW_EXCEPTION(invalid_status,
-                        "hpx::threads::detail::get_default_timer_service",
-                        "No timer service installed. When running timed "
-                        "threads without a runtime a timer service has to be "
-                        "installed manually using "
-                        "hpx::threads::detail::set_get_default_timer_service.");
-#else
-                    HPX_THROW_EXCEPTION(invalid_status,
-                        "hpx::threads::detail::get_default_timer_service",
-                        "No timer service installed. Rebuild HPX with "
-                        "HPX_WITH_TIMER_POOL=ON or provide a timer service "
-                        "manually using "
-                        "hpx::threads::detail::set_get_default_timer_service.");
-#endif
-                }
-
-                return timer_service;
             }
 }}}    // namespace hpx::threads::detail

--- a/libs/core/threading_base/src/get_default_timer_service.cpp
+++ b/libs/core/threading_base/src/get_default_timer_service.cpp
@@ -1,0 +1,53 @@
+//  Copyright (c) 2007-2016 Hartmut Kaiser
+//  Copyright (c)      2011 Bryce Lelbach
+//  Copyright (c)      2020 Nikunj Gupta
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/assert.hpp>
+#include <hpx/errors/error.hpp>
+#include <hpx/errors/exception.hpp>
+#include <hpx/threading_base/detail/get_default_timer_service.hpp>
+
+#include <asio/io_context.hpp>
+
+namespace hpx { namespace threads { namespace detail {
+    static get_default_timer_service_type get_default_timer_service_f;
+
+    void set_get_default_timer_service(get_default_timer_service_type f)
+    {
+        get_default_timer_service_f = f;
+    }
+
+    asio::io_context* get_default_timer_service()
+    {
+        asio::io_context* timer_service = nullptr;
+        if (detail::get_default_timer_service_f)
+        {
+            timer_service = detail::get_default_timer_service_f();
+            HPX_ASSERT(timer_service);
+        }
+        else
+        {
+#if defined(HPX_HAVE_TIMER_POOL)
+            HPX_THROW_EXCEPTION(invalid_status,
+                "hpx::threads::detail::get_default_timer_service",
+                "No timer service installed. When running timed "
+                "threads without a runtime a timer service has to be "
+                "installed manually using "
+                "hpx::threads::detail::set_get_default_timer_service.");
+#else
+            HPX_THROW_EXCEPTION(invalid_status,
+                "hpx::threads::detail::get_default_timer_service",
+                "No timer service installed. Rebuild HPX with "
+                "HPX_WITH_TIMER_POOL=ON or provide a timer service "
+                "manually using "
+                "hpx::threads::detail::set_get_default_timer_service.");
+#endif
+        }
+
+        return timer_service;
+    }
+}}}    // namespace hpx::threads::detail

--- a/libs/core/threading_base/src/thread_helpers.cpp
+++ b/libs/core/threading_base/src/thread_helpers.cpp
@@ -18,6 +18,7 @@
 #include <hpx/threading_base/scheduler_base.hpp>
 #include <hpx/threading_base/scheduler_state.hpp>
 #include <hpx/threading_base/set_thread_state.hpp>
+#include <hpx/threading_base/set_thread_state_timed.hpp>
 #include <hpx/threading_base/thread_description.hpp>
 #include <hpx/threading_base/thread_pool_base.hpp>
 #include <hpx/timing/steady_clock.hpp>

--- a/libs/parallelism/execution/include/hpx/execution/algorithms/ensure_started.hpp
+++ b/libs/parallelism/execution/include/hpx/execution/algorithms/ensure_started.hpp
@@ -21,8 +21,9 @@
 #include <hpx/functional/bind_front.hpp>
 #include <hpx/functional/invoke_fused.hpp>
 #include <hpx/functional/tag_fallback_dispatch.hpp>
+#include <hpx/functional/unique_function.hpp>
 #include <hpx/modules/memory.hpp>
-#include <hpx/synchronization/mutex.hpp>
+#include <hpx/synchronization/spinlock.hpp>
 #include <hpx/thread_support/atomic_count.hpp>
 #include <hpx/type_support/pack.hpp>
 
@@ -32,6 +33,7 @@
 #include <cstddef>
 #include <exception>
 #include <memory>
+#include <mutex>
 #include <type_traits>
 #include <utility>
 #include <variant>
@@ -103,7 +105,7 @@ namespace hpx { namespace execution { namespace experimental {
                 using allocator_type = typename std::allocator_traits<
                     Allocator>::template rebind_alloc<shared_state>;
                 allocator_type alloc;
-                using mutex_type = hpx::util::spinlock;
+                using mutex_type = hpx::lcos::local::spinlock;
                 mutex_type mtx;
                 hpx::util::atomic_count reference_count{0};
                 std::atomic<bool> start_called{false};

--- a/libs/parallelism/lcos_local/include/hpx/lcos_local/and_gate.hpp
+++ b/libs/parallelism/lcos_local/include/hpx/lcos_local/and_gate.hpp
@@ -8,6 +8,7 @@
 
 #include <hpx/config.hpp>
 #include <hpx/assert.hpp>
+#include <hpx/functional/bind.hpp>
 #include <hpx/lcos_local/conditional_trigger.hpp>
 #include <hpx/modules/errors.hpp>
 #include <hpx/synchronization/no_mutex.hpp>

--- a/wrap/CMakeLists.txt
+++ b/wrap/CMakeLists.txt
@@ -91,3 +91,7 @@ install(
 hpx_export_internal_targets(hpx_wrap)
 
 add_hpx_pseudo_dependencies(core hpx_wrap)
+
+if(HPX_WITH_PRECOMPILED_HEADERS)
+  target_precompile_headers(hpx_wrap REUSE_FROM hpx_precompiled_headers)
+endif()


### PR DESCRIPTION
- Adds Asio and Boost headers to the precompiled headers target
- Does some small rearranging to reduce Asio includes
- ifdefs out more of thread local storage when it's disabled

Regarding the first point, `boost/config.hpp` was problematic. We force `hpx/config.hpp` to be included before `boost/config.hpp`. However, I can't find any reasoning about *why* that's the case. It looks like the current check was introduced in https://github.com/STEllAR-GROUP/hpx/commit/a370734ce21e700aa5e7a7e9a119865178b74f47, and the accompanying intel compiler config is gone since then. Does anyone know? Is it also a problem on Windows?