### PR TITLE
Allow using pre-downloaded (not installed) versions of Asio and/or Apex

### DIFF
--- a/cmake/HPX_SetupApex.cmake
+++ b/cmake/HPX_SetupApex.cmake
@@ -28,13 +28,22 @@ if(HPX_WITH_APEX AND NOT TARGET APEX::apex)
       set(HPX_APEX_ROOT ${APEX_ROOT})
 
     else()
-      # If APEX_ROOT not specified, local clone into hpx source dir
+      # If APEX_ROOT not specified, local clone into hpx source dir or
+      # use existing source as specified by APEX_SOURCE_DIR
       include(FetchContent)
-      fetchcontent_declare(
-        apex
-        GIT_REPOSITORY https://github.com/khuck/xpress-apex.git
-        GIT_TAG ${HPX_WITH_APEX_TAG}
-      )
+      if(APEX_SOURCE_DIR)
+        fetchcontent_declare(
+          apex
+          SOURCE_DIR
+          ${APEX_SOURCE_DIR}
+        )
+      else()
+        fetchcontent_declare(
+          apex
+          GIT_REPOSITORY https://github.com/khuck/xpress-apex.git
+          GIT_TAG ${HPX_WITH_APEX_TAG}
+        )
+      endif()
 
       fetchcontent_getproperties(apex)
       if(NOT apex_POPULATED)
@@ -52,7 +61,11 @@ if(HPX_WITH_APEX AND NOT TARGET APEX::apex)
       endif()
       set(APEX_ROOT ${apex_SOURCE_DIR})
 
-      hpx_info("APEX_ROOT is not set. Cloning APEX into ${apex_SOURCE_DIR}.")
+      if(APEX_SOURCE_DIR)
+        hpx_info("APEX_SOURCE_DIR is set. Using APEX from ${apex_SOURCE_DIR}.")
+      else()
+        hpx_info("APEX_ROOT is not set. Cloning APEX into ${apex_SOURCE_DIR}.")
+      endif()
     endif()
 
     list(APPEND CMAKE_MODULE_PATH "${APEX_ROOT}/cmake/Modules")

--- a/cmake/HPX_SetupAsio.cmake
+++ b/cmake/HPX_SetupAsio.cmake
@@ -17,6 +17,9 @@ if(NOT TARGET ASIO::standalone_asio)
       )
       set(HPX_ASIO_ROOT ${ASIO_ROOT})
     else()
+      # If ASIO_ROOT not specified, local clone into hpx source dir or
+      # use existing source as specified by ASIO_SOURCE_DIR
+
       set(HPX_WITH_CLONED_ASIO
           TRUE
           CACHE INTERNAL ""
@@ -27,11 +30,21 @@ if(NOT TARGET ASIO::standalone_asio)
       endif()
 
       include(FetchContent)
-      fetchcontent_declare(
-        asio
-        GIT_REPOSITORY https://github.com/chriskohlhoff/asio.git
-        GIT_TAG ${HPX_WITH_ASIO_TAG}
-      )
+      if(ASIO_SOURCE_DIR)
+        # Use the existing ASIO checkout at ASIO_SOURCE_DIR instead of
+        # checking it out from github
+        fetchcontent_declare(
+          asio
+          SOURCE_DIR
+          ${ASIO_SOURCE_DIR}
+        )
+      else()
+        fetchcontent_declare(
+          asio
+          GIT_REPOSITORY https://github.com/chriskohlhoff/asio.git
+          GIT_TAG ${HPX_WITH_ASIO_TAG}
+        )
+      endif()
 
       fetchcontent_getproperties(asio)
       if(NOT asio_POPULATED)
@@ -39,7 +52,11 @@ if(NOT TARGET ASIO::standalone_asio)
       endif()
       set(ASIO_ROOT ${asio_SOURCE_DIR})
 
-      hpx_info("ASIO_ROOT is not set. Cloning Asio into ${asio_SOURCE_DIR}.")
+      if(ASIO_SOURCE_DIR)
+        hpx_info("ASIO_SOURCE_DIR is set. Using Asio from ${asio_SOURCE_DIR}.")
+      else()
+        hpx_info("ASIO_ROOT is not set. Cloning Asio into ${asio_SOURCE_DIR}.")
+      endif()
 
       add_library(standalone_asio INTERFACE)
       target_include_directories(


### PR DESCRIPTION
- this adds ASIO_SOURCE_DIR and APEX_SOURCE_DIR cmake options that will prevent
  cmake from downloading the source code but to use it from the specified
  directories

This is an alternative option for resolving #5378
