### PR TITLE
Tentatively remove runtime_registration_wrapper from cuda futures

### DIFF
--- a/libs/full/async_cuda/include/hpx/async_cuda/cuda_future.hpp
+++ b/libs/full/async_cuda/include/hpx/async_cuda/cuda_future.hpp
@@ -45,18 +45,6 @@ namespace hpx { namespace cuda { namespace experimental {
         struct future_data;
 
         // -------------------------------------------------------------
-        // a callback on an NVidia cuda thread should be registered with
-        // hpx to ensure any thread local operations are valid
-        // @TODO - get rid of this
-        struct runtime_registration_wrapper
-        {
-            runtime_registration_wrapper(hpx::runtime* rt);
-            ~runtime_registration_wrapper();
-            hpx::runtime* rt_;
-            bool registered_;
-        };
-
-        // -------------------------------------------------------------
         // helper struct to delete future data in destructor
         template <typename Allocator>
         struct release_on_exit
@@ -169,7 +157,6 @@ namespace hpx { namespace cuda { namespace experimental {
             {
                 future_data* this_ = static_cast<future_data*>(user_data);
 
-                runtime_registration_wrapper wrap(this_->rt_);
                 release_on_exit<Allocator> on_exit(this_);
 
                 if (error != cudaSuccess)

--- a/libs/full/async_cuda/src/cuda_future.cpp
+++ b/libs/full/async_cuda/src/cuda_future.cpp
@@ -12,38 +12,6 @@
 #include <hpx/async_cuda/custom_gpu_api.hpp>
 
 namespace hpx { namespace cuda { namespace experimental { namespace detail {
-    runtime_registration_wrapper::runtime_registration_wrapper(hpx::runtime* rt)
-      : rt_(rt)
-      , registered_(false)
-    {
-        if (nullptr != hpx::get_runtime_ptr())
-        {
-            return;
-        }
-
-        HPX_ASSERT(rt);
-
-        // Register this thread with HPX, this should be done once for
-        // each external OS-thread intended to invoke HPX functionality.
-        // Calling this function more than once on the same thread will
-        // report an error.
-        hpx::error_code ec(hpx::lightweight);    // ignore errors
-        hpx::register_thread(rt_, "cuda", ec);
-        registered_ = true;
-    }
-
-    runtime_registration_wrapper::~runtime_registration_wrapper()
-    {
-        // Unregister the thread from HPX, this should be done once in the end
-        // before the external thread exits, if the runtime registration
-        // wrapper actually registered the thread (it may not do so if the
-        // wrapper is constructed on a HPX worker thread).
-        if (registered_)
-        {
-            hpx::unregister_thread(rt_);
-        }
-    }
-
     hpx::future<void> get_future_with_callback(cudaStream_t stream)
     {
         return get_future_with_callback(

--- a/libs/full/runtime_distributed/include/hpx/runtime_distributed.hpp
+++ b/libs/full/runtime_distributed/include/hpx/runtime_distributed.hpp
@@ -377,6 +377,9 @@ namespace hpx {
             util::function_nonser<runtime::hpx_main_function_type> const& func,
             int& result);
 
+        void init_global_data();
+        void deinit_global_data();
+
         void wait_helper(
             std::mutex& mtx, std::condition_variable& cond, bool& running);
 

--- a/libs/full/runtime_local/include/hpx/runtime_local/runtime_local.hpp
+++ b/libs/full/runtime_local/include/hpx/runtime_local/runtime_local.hpp
@@ -393,8 +393,8 @@ namespace hpx {
         }
 
     protected:
-        void init_tss();
-        void deinit_tss();
+        void init_global_data();
+        void deinit_global_data();
 
         threads::thread_result_type run_helper(
             util::function_nonser<runtime::hpx_main_function_type> const& func,


### PR DESCRIPTION
Tentatively removing it because removing it should also fix the regression in #5366.

This is untested and I want to see what the different CUDA and HIP builders say about this change. According to @DarkDeepBlue things seem to be fine without the wrapper.

I think the wrapper is mostly unneeded, but I continuations are probably still problematic without the wrapper. When run on a non-HPX thread they would fall back to trying to get the default pool which is done through the runtime pointer.

One possible solution to this is to not have the thread-local runtime pointer be thread-local anymore. @hkaiser, @sithhell what was the original motivation for making it thread-local? The pointer itself is only ever read (except when initialized or reset during init and finalize), so I don't see any performance benefits of having it be thread-local. Is there some other reason for it?