### PR TITLE
Extend thread state logging and change default stealing parameters

### DIFF
--- a/docs/sphinx/manual/launching_and_configuring_hpx_applications.rst
+++ b/docs/sphinx/manual/launching_and_configuring_hpx_applications.rst
@@ -346,7 +346,7 @@ The ``hpx.thread_queue`` configuration section
 
    [hpx.thread_queue]
    min_tasks_to_steal_pending = ${HPX_THREAD_QUEUE_MIN_TASKS_TO_STEAL_PENDING:0}
-   min_tasks_to_steal_staged = ${HPX_THREAD_QUEUE_MIN_TASKS_TO_STEAL_STAGED:10}
+   min_tasks_to_steal_staged = ${HPX_THREAD_QUEUE_MIN_TASKS_TO_STEAL_STAGED:0}
    min_add_new_count = ${HPX_THREAD_QUEUE_MIN_ADD_NEW_COUNT:10}
    max_add_new_count = ${HPX_THREAD_QUEUE_MAX_ADD_NEW_COUNT:10}
    max_delete_count = ${HPX_THREAD_QUEUE_MAX_DELETE_COUNT:1000}
@@ -364,8 +364,7 @@ The ``hpx.thread_queue`` configuration section
    * * ``hpx.thread_queue.min_tasks_to_steal_staged``
      * The value of this property defines the number of staged |hpx| tasks have
        which to be available before neighboring cores are allowed to steal work.
-       The default is to allow stealing only if there are more tan 10 tasks
-       available.
+       The default is to allow stealing always.
    * * ``hpx.thread_queue.min_add_new_count``
      * The value of this property defines the minimal number tasks to be
        converted into |hpx| threads whenever the thread queues for a core have

--- a/libs/core/config/include/hpx/config.hpp
+++ b/libs/core/config/include/hpx/config.hpp
@@ -417,7 +417,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 // Minimum number of staged tasks required to steal tasks.
 #if !defined(HPX_THREAD_QUEUE_MIN_TASKS_TO_STEAL_STAGED)
-#  define HPX_THREAD_QUEUE_MIN_TASKS_TO_STEAL_STAGED 10
+#  define HPX_THREAD_QUEUE_MIN_TASKS_TO_STEAL_STAGED 0
 #endif
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/libs/core/schedulers/include/hpx/schedulers/local_priority_queue_scheduler.hpp
+++ b/libs/core/schedulers/include/hpx/schedulers/local_priority_queue_scheduler.hpp
@@ -542,17 +542,52 @@ namespace hpx { namespace threads { namespace policies {
                 std::size_t num = num_thread % num_high_priority_queues_;
 
                 high_priority_queues_[num].data_->create_thread(data, id, ec);
+
+                LTM_(debug)
+                    .format("local_priority_queue_scheduler::create_thread, "
+                            "high priority queue: "
+                            "scheduler({}), worker_thread({}), "
+                            "thread({}), priority({})",
+                        this, num, id ? *id : invalid_thread_id, data.priority)
+#ifdef HPX_HAVE_THREAD_DESCRIPTION
+                    .format(", description({})", data.description)
+#endif
+                    ;
+
                 return;
             }
 
             if (data.priority == thread_priority::low)
             {
                 low_priority_queue_.create_thread(data, id, ec);
+
+                LTM_(debug)
+                    .format("local_priority_queue_scheduler::create_thread, "
+                            "low priority queue: "
+                            "scheduler({}), thread({}), priority({})",
+                        this, id ? *id : invalid_thread_id, data.priority)
+#ifdef HPX_HAVE_THREAD_DESCRIPTION
+                    .format(", description({})", data.description)
+#endif
+                    ;
+
                 return;
             }
 
             HPX_ASSERT(num_thread < num_queues_);
             queues_[num_thread].data_->create_thread(data, id, ec);
+
+            LTM_(debug)
+                .format("local_priority_queue_scheduler::create_thread normal "
+                        "priority queue: scheduler({}), "
+                        "worker_thread({}), "
+                        "thread({}), priority({})",
+                    this, num_thread, id ? *id : invalid_thread_id,
+                    data.priority)
+#ifdef HPX_HAVE_THREAD_DESCRIPTION
+                .format(", description({})", data.description)
+#endif
+                ;
         }
 
         /// Return the next thread to be executed, return false if none is
@@ -662,15 +697,41 @@ namespace hpx { namespace threads { namespace policies {
                 priority == thread_priority::boost)
             {
                 std::size_t num = num_thread % num_high_priority_queues_;
+
+                LTM_(debug).format(
+                    "local_priority_queue_scheduler::schedule_thread, "
+                    "high priority queue: "
+                    "scheduler({}), worker_thread({}), "
+                    "thread({}), priority({}), description({})",
+                    this, num, thrd->get_thread_id(), priority,
+                    thrd->get_description());
+
                 high_priority_queues_[num].data_->schedule_thread(thrd);
             }
             else if (priority == thread_priority::low)
             {
+                LTM_(debug).format(
+                    "local_priority_queue_scheduler::schedule_thread, "
+                    "low priority queue: "
+                    "scheduler({}), "
+                    "thread({}), priority({}), description({})",
+                    this, thrd->get_thread_id(), priority,
+                    thrd->get_description());
+
                 low_priority_queue_.schedule_thread(thrd);
             }
             else
             {
                 HPX_ASSERT(num_thread < num_queues_);
+
+                LTM_(debug).format(
+                    "local_priority_queue_scheduler::schedule_thread, "
+                    "normal priority queue: "
+                    "scheduler({}), worker_thread({}), "
+                    "thread({}), priority({}), description({})",
+                    this, num_thread, thrd->get_thread_id(), priority,
+                    thrd->get_description());
+
                 queues_[num_thread].data_->schedule_thread(thrd);
             }
         }
@@ -1117,16 +1178,18 @@ namespace hpx { namespace threads { namespace policies {
                 {
                     if (running)
                     {
-                        LTM_(error).format("queue({}): no new work available, "
-                                           "are we deadlocked?",
-                            num_thread);
+                        LTM_(error).format(
+                            "scheduler({}), worker_thread({}): no new work "
+                            "available, are we deadlocked?",
+                            this, num_thread);
                     }
                     else
                     {
                         LHPX_CONSOLE_(hpx::util::logging::level::error)
-                            .format("  [TM] queue({}): no new work available, "
-                                    "are we deadlocked?\n",
-                                num_thread);
+                            .format(
+                                "  [TM] scheduler({}), worker_thread({}): "
+                                "no new work available, are we deadlocked?\n",
+                                this, num_thread);
                     }
                 }
             }

--- a/libs/core/schedulers/include/hpx/schedulers/local_priority_queue_scheduler.hpp
+++ b/libs/core/schedulers/include/hpx/schedulers/local_priority_queue_scheduler.hpp
@@ -546,9 +546,10 @@ namespace hpx { namespace threads { namespace policies {
                 LTM_(debug)
                     .format("local_priority_queue_scheduler::create_thread, "
                             "high priority queue: "
-                            "scheduler({}), worker_thread({}), "
+                            "pool({}), scheduler({}), worker_thread({}), "
                             "thread({}), priority({})",
-                        *this, num, id ? *id : invalid_thread_id, data.priority)
+                        *this->get_parent_pool(), *this, num,
+                        id ? *id : invalid_thread_id, data.priority)
 #ifdef HPX_HAVE_THREAD_DESCRIPTION
                     .format(", description({})", data.description)
 #endif
@@ -564,8 +565,9 @@ namespace hpx { namespace threads { namespace policies {
                 LTM_(debug)
                     .format("local_priority_queue_scheduler::create_thread, "
                             "low priority queue: "
-                            "scheduler({}), thread({}), priority({})",
-                        *this, id ? *id : invalid_thread_id, data.priority)
+                            "pool({}), scheduler({}), thread({}), priority({})",
+                        *this->get_parent_pool(), *this,
+                        id ? *id : invalid_thread_id, data.priority)
 #ifdef HPX_HAVE_THREAD_DESCRIPTION
                     .format(", description({})", data.description)
 #endif
@@ -579,11 +581,11 @@ namespace hpx { namespace threads { namespace policies {
 
             LTM_(debug)
                 .format("local_priority_queue_scheduler::create_thread normal "
-                        "priority queue: scheduler({}), "
+                        "priority queue: pool({}), scheduler({}), "
                         "worker_thread({}), "
                         "thread({}), priority({})",
-                    *this, num_thread, id ? *id : invalid_thread_id,
-                    data.priority)
+                    *this->get_parent_pool(), *this, num_thread,
+                    id ? *id : invalid_thread_id, data.priority)
 #ifdef HPX_HAVE_THREAD_DESCRIPTION
                 .format(", description({})", data.description)
 #endif
@@ -701,10 +703,10 @@ namespace hpx { namespace threads { namespace policies {
                 LTM_(debug).format(
                     "local_priority_queue_scheduler::schedule_thread, "
                     "high priority queue: "
-                    "scheduler({}), worker_thread({}), "
+                    "pool({}), scheduler({}), worker_thread({}), "
                     "thread({}), priority({}), description({})",
-                    *this, num, thrd->get_thread_id(), priority,
-                    thrd->get_description());
+                    *this->get_parent_pool(), *this, num, thrd->get_thread_id(),
+                    priority, thrd->get_description());
 
                 high_priority_queues_[num].data_->schedule_thread(thrd);
             }
@@ -713,10 +715,10 @@ namespace hpx { namespace threads { namespace policies {
                 LTM_(debug).format(
                     "local_priority_queue_scheduler::schedule_thread, "
                     "low priority queue: "
-                    "scheduler({}), "
+                    "pool({}), scheduler({}), "
                     "thread({}), priority({}), description({})",
-                    *this, thrd->get_thread_id(), priority,
-                    thrd->get_description());
+                    *this->get_parent_pool(), *this, thrd->get_thread_id(),
+                    priority, thrd->get_description());
 
                 low_priority_queue_.schedule_thread(thrd);
             }
@@ -727,10 +729,10 @@ namespace hpx { namespace threads { namespace policies {
                 LTM_(debug).format(
                     "local_priority_queue_scheduler::schedule_thread, "
                     "normal priority queue: "
-                    "scheduler({}), worker_thread({}), "
+                    "pool({}), scheduler({}), worker_thread({}), "
                     "thread({}), priority({}), description({})",
-                    *this, num_thread, thrd->get_thread_id(), priority,
-                    thrd->get_description());
+                    *this->get_parent_pool(), *this, num_thread,
+                    thrd->get_thread_id(), priority, thrd->get_description());
 
                 queues_[num_thread].data_->schedule_thread(thrd);
             }
@@ -1178,18 +1180,19 @@ namespace hpx { namespace threads { namespace policies {
                 {
                     if (running)
                     {
-                        LTM_(error).format(
-                            "scheduler({}), worker_thread({}): no new work "
-                            "available, are we deadlocked?",
-                            *this, num_thread);
+                        LTM_(error).format("pool({}), scheduler({}), "
+                                           "worker_thread({}): no new work "
+                                           "available, are we deadlocked?",
+                            *this->get_parent_pool(), *this, num_thread);
                     }
                     else
                     {
                         LHPX_CONSOLE_(hpx::util::logging::level::error)
                             .format(
-                                "  [TM] scheduler({}), worker_thread({}): "
+                                "  [TM] pool({}), scheduler({}), "
+                                "worker_thread({}): "
                                 "no new work available, are we deadlocked?\n",
-                                *this, num_thread);
+                                *this->get_parent_pool(), *this, num_thread);
                     }
                 }
             }

--- a/libs/core/schedulers/include/hpx/schedulers/local_priority_queue_scheduler.hpp
+++ b/libs/core/schedulers/include/hpx/schedulers/local_priority_queue_scheduler.hpp
@@ -548,7 +548,7 @@ namespace hpx { namespace threads { namespace policies {
                             "high priority queue: "
                             "scheduler({}), worker_thread({}), "
                             "thread({}), priority({})",
-                        this, num, id ? *id : invalid_thread_id, data.priority)
+                        *this, num, id ? *id : invalid_thread_id, data.priority)
 #ifdef HPX_HAVE_THREAD_DESCRIPTION
                     .format(", description({})", data.description)
 #endif
@@ -565,7 +565,7 @@ namespace hpx { namespace threads { namespace policies {
                     .format("local_priority_queue_scheduler::create_thread, "
                             "low priority queue: "
                             "scheduler({}), thread({}), priority({})",
-                        this, id ? *id : invalid_thread_id, data.priority)
+                        *this, id ? *id : invalid_thread_id, data.priority)
 #ifdef HPX_HAVE_THREAD_DESCRIPTION
                     .format(", description({})", data.description)
 #endif
@@ -582,7 +582,7 @@ namespace hpx { namespace threads { namespace policies {
                         "priority queue: scheduler({}), "
                         "worker_thread({}), "
                         "thread({}), priority({})",
-                    this, num_thread, id ? *id : invalid_thread_id,
+                    *this, num_thread, id ? *id : invalid_thread_id,
                     data.priority)
 #ifdef HPX_HAVE_THREAD_DESCRIPTION
                 .format(", description({})", data.description)
@@ -703,7 +703,7 @@ namespace hpx { namespace threads { namespace policies {
                     "high priority queue: "
                     "scheduler({}), worker_thread({}), "
                     "thread({}), priority({}), description({})",
-                    this, num, thrd->get_thread_id(), priority,
+                    *this, num, thrd->get_thread_id(), priority,
                     thrd->get_description());
 
                 high_priority_queues_[num].data_->schedule_thread(thrd);
@@ -715,7 +715,7 @@ namespace hpx { namespace threads { namespace policies {
                     "low priority queue: "
                     "scheduler({}), "
                     "thread({}), priority({}), description({})",
-                    this, thrd->get_thread_id(), priority,
+                    *this, thrd->get_thread_id(), priority,
                     thrd->get_description());
 
                 low_priority_queue_.schedule_thread(thrd);
@@ -729,7 +729,7 @@ namespace hpx { namespace threads { namespace policies {
                     "normal priority queue: "
                     "scheduler({}), worker_thread({}), "
                     "thread({}), priority({}), description({})",
-                    this, num_thread, thrd->get_thread_id(), priority,
+                    *this, num_thread, thrd->get_thread_id(), priority,
                     thrd->get_description());
 
                 queues_[num_thread].data_->schedule_thread(thrd);
@@ -1181,7 +1181,7 @@ namespace hpx { namespace threads { namespace policies {
                         LTM_(error).format(
                             "scheduler({}), worker_thread({}): no new work "
                             "available, are we deadlocked?",
-                            this, num_thread);
+                            *this, num_thread);
                     }
                     else
                     {
@@ -1189,7 +1189,7 @@ namespace hpx { namespace threads { namespace policies {
                             .format(
                                 "  [TM] scheduler({}), worker_thread({}): "
                                 "no new work available, are we deadlocked?\n",
-                                this, num_thread);
+                                *this, num_thread);
                     }
                 }
             }

--- a/libs/core/schedulers/include/hpx/schedulers/local_queue_scheduler.hpp
+++ b/libs/core/schedulers/include/hpx/schedulers/local_queue_scheduler.hpp
@@ -316,9 +316,8 @@ namespace hpx { namespace threads { namespace policies {
 
             LTM_(debug)
                 .format("local_queue_scheduler::create_thread: scheduler({}), "
-                        "worker_thread({}), thread({}), priority({})",
-                    this, num_thread, id ? *id : invalid_thread_id,
-                    data.priority)
+                        "worker_thread({}), thread({})",
+                    *this, num_thread, id ? *id : invalid_thread_id)
 #ifdef HPX_HAVE_THREAD_DESCRIPTION
                 .format(", description({})", data.description)
 #endif
@@ -489,8 +488,8 @@ namespace hpx { namespace threads { namespace policies {
 
             LTM_(debug).format("local_queue_scheduler::schedule_thread: "
                                "scheduler({}), worker_thread({}), "
-                               "thread({}), priority({}), description({})",
-                this, num_thread, thrd->get_thread_id(), priority,
+                               "thread({}), description({})",
+                *this, num_thread, thrd->get_thread_id(),
                 thrd->get_description());
 
             queues_[num_thread]->schedule_thread(thrd);
@@ -842,16 +841,18 @@ namespace hpx { namespace threads { namespace policies {
                 {
                     if (running)
                     {
-                        LTM_(error).format("queue({}): no new work available, "
-                                           "are we deadlocked?",
-                            num_thread);
+                        LTM_(error).format(
+                            "scheduler({}), queue({}): no new work available, "
+                            "are we deadlocked?",
+                            *this, num_thread);
                     }
                     else
                     {
                         LHPX_CONSOLE_(hpx::util::logging::level::error)
-                            .format("  [TM] queue({}): no new work available, "
+                            .format("  [TM] scheduler({}), queue({}): no new "
+                                    "work available, "
                                     "are we deadlocked?\n",
-                                num_thread);
+                                *this, num_thread);
                     }
                 }
             }

--- a/libs/core/schedulers/include/hpx/schedulers/local_queue_scheduler.hpp
+++ b/libs/core/schedulers/include/hpx/schedulers/local_queue_scheduler.hpp
@@ -313,6 +313,16 @@ namespace hpx { namespace threads { namespace policies {
 
             HPX_ASSERT(num_thread < queue_size);
             queues_[num_thread]->create_thread(data, id, ec);
+
+            LTM_(debug)
+                .format("local_queue_scheduler::create_thread: scheduler({}), "
+                        "worker_thread({}), thread({}), priority({})",
+                    this, num_thread, id ? *id : invalid_thread_id,
+                    data.priority)
+#ifdef HPX_HAVE_THREAD_DESCRIPTION
+                .format(", description({})", data.description)
+#endif
+                ;
         }
 
         /// Return the next thread to be executed, return false if none is
@@ -476,6 +486,13 @@ namespace hpx { namespace threads { namespace policies {
             HPX_ASSERT(thrd->get_scheduler_base() == this);
 
             HPX_ASSERT(num_thread < queues_.size());
+
+            LTM_(debug).format("local_queue_scheduler::schedule_thread: "
+                               "scheduler({}), worker_thread({}), "
+                               "thread({}), priority({}), description({})",
+                this, num_thread, thrd->get_thread_id(), priority,
+                thrd->get_description());
+
             queues_[num_thread]->schedule_thread(thrd);
         }
 

--- a/libs/core/schedulers/include/hpx/schedulers/local_queue_scheduler.hpp
+++ b/libs/core/schedulers/include/hpx/schedulers/local_queue_scheduler.hpp
@@ -315,9 +315,11 @@ namespace hpx { namespace threads { namespace policies {
             queues_[num_thread]->create_thread(data, id, ec);
 
             LTM_(debug)
-                .format("local_queue_scheduler::create_thread: scheduler({}), "
+                .format("local_queue_scheduler::create_thread: pool({}), "
+                        "scheduler({}), "
                         "worker_thread({}), thread({})",
-                    *this, num_thread, id ? *id : invalid_thread_id)
+                    *this->get_parent_pool(), *this, num_thread,
+                    id ? *id : invalid_thread_id)
 #ifdef HPX_HAVE_THREAD_DESCRIPTION
                 .format(", description({})", data.description)
 #endif
@@ -487,10 +489,10 @@ namespace hpx { namespace threads { namespace policies {
             HPX_ASSERT(num_thread < queues_.size());
 
             LTM_(debug).format("local_queue_scheduler::schedule_thread: "
-                               "scheduler({}), worker_thread({}), "
+                               "pool({}), scheduler({}), worker_thread({}), "
                                "thread({}), description({})",
-                *this, num_thread, thrd->get_thread_id(),
-                thrd->get_description());
+                *this->get_parent_pool(), *this, num_thread,
+                thrd->get_thread_id(), thrd->get_description());
 
             queues_[num_thread]->schedule_thread(thrd);
         }
@@ -841,18 +843,18 @@ namespace hpx { namespace threads { namespace policies {
                 {
                     if (running)
                     {
-                        LTM_(error).format(
-                            "scheduler({}), queue({}): no new work available, "
-                            "are we deadlocked?",
-                            *this, num_thread);
+                        LTM_(error).format("pool({}), scheduler({}), "
+                                           "queue({}): no new work available, "
+                                           "are we deadlocked?",
+                            *this->get_parent_pool(), *this, num_thread);
                     }
                     else
                     {
                         LHPX_CONSOLE_(hpx::util::logging::level::error)
-                            .format("  [TM] scheduler({}), queue({}): no new "
-                                    "work available, "
-                                    "are we deadlocked?\n",
-                                *this, num_thread);
+                            .format("  [TM] pool({}), scheduler({}), "
+                                    "queue({}): no new work available, are we "
+                                    "deadlocked?\n",
+                                *this->get_parent_pool(), *this, num_thread);
                     }
                 }
             }

--- a/libs/core/thread_pools/include/hpx/thread_pools/scheduling_loop.hpp
+++ b/libs/core/thread_pools/include/hpx/thread_pools/scheduling_loop.hpp
@@ -40,11 +40,12 @@ namespace hpx { namespace threads { namespace detail {
         thread_schedule_state const old_state,
         thread_schedule_state const new_state)
     {
-        LTM_(debug).format(
-            "scheduling_loop state change: scheduler({}), worker_thread({}), "
-            "thread({}), description({}), old state({}), new state({})",
-            scheduler, num_thread, thrd, thrd->get_description(),
-            get_thread_state_name(old_state), get_thread_state_name(new_state));
+        LTM_(debug).format("scheduling_loop state change: pool({}), "
+                           "scheduler({}), worker_thread({}), thread({}), "
+                           "description({}), old state({}), new state({})",
+            *scheduler.get_parent_pool(), scheduler, num_thread, thrd,
+            thrd->get_description(), get_thread_state_name(old_state),
+            get_thread_state_name(new_state));
     }
 
     inline void write_state_log_warning(
@@ -52,11 +53,12 @@ namespace hpx { namespace threads { namespace detail {
         thread_data* const thrd, thread_schedule_state const state,
         char const* info)
     {
-        LTM_(warning).format(
-            "scheduling_loop state change failed: scheduler({}), worker thread "
-            "({}), thread({}), description({}), state({}), {}",
-            scheduler, num_thread, thrd->get_thread_id(),
-            thrd->get_description(), get_thread_state_name(state), info);
+        LTM_(warning).format("scheduling_loop state change failed: pool({}), "
+                             "scheduler({}), worker thread ({}), thread({}), "
+                             "description({}), state({}), {}",
+            *scheduler.get_parent_pool(), scheduler, num_thread,
+            thrd->get_thread_id(), thrd->get_description(),
+            get_thread_state_name(state), info);
     }
 
     ///////////////////////////////////////////////////////////////////////
@@ -825,11 +827,11 @@ namespace hpx { namespace threads { namespace detail {
                 else if (HPX_UNLIKELY(
                              thread_schedule_state::active == state_val))
                 {
-                    LTM_(warning).format(
-                        "scheduler({}), worker_thread({}), thread({}), "
-                        "description({}), rescheduling",
-                        scheduler, num_thread, thrd->get_thread_id(),
-                        thrd->get_description());
+                    LTM_(warning).format("pool({}), scheduler({}), "
+                                         "worker_thread({}), thread({}), "
+                                         "description({}), rescheduling",
+                        *scheduler.get_parent_pool(), scheduler, num_thread,
+                        thrd->get_thread_id(), thrd->get_description());
                     // re-schedule thread, if it is still marked as active
                     // this might happen, if some thread has been added to the
                     // scheduler queue already but the state has not been reset

--- a/libs/core/thread_pools/include/hpx/thread_pools/scheduling_loop.hpp
+++ b/libs/core/thread_pools/include/hpx/thread_pools/scheduling_loop.hpp
@@ -35,9 +35,10 @@
 
 namespace hpx { namespace threads { namespace detail {
     ///////////////////////////////////////////////////////////////////////
-    inline void write_state_log(policies::scheduler_base* scheduler,
-        std::size_t num_thread, thread_data* thrd,
-        thread_schedule_state old_state, thread_schedule_state new_state)
+    inline void write_state_log(policies::scheduler_base const& scheduler,
+        std::size_t const num_thread, thread_data* const thrd,
+        thread_schedule_state const old_state,
+        thread_schedule_state const new_state)
     {
         LTM_(debug).format(
             "scheduling_loop state change: scheduler({}), worker_thread({}), "
@@ -46,8 +47,9 @@ namespace hpx { namespace threads { namespace detail {
             get_thread_state_name(old_state), get_thread_state_name(new_state));
     }
 
-    inline void write_state_log_warning(policies::scheduler_base* scheduler,
-        std::size_t num_thread, thread_data* thrd, thread_schedule_state state,
+    inline void write_state_log_warning(
+        policies::scheduler_base const& scheduler, std::size_t const num_thread,
+        thread_data* const thrd, thread_schedule_state const state,
         char const* info)
     {
         LTM_(warning).format(
@@ -659,8 +661,8 @@ namespace hpx { namespace threads { namespace detail {
                                 thrd_stat.get_previous() ==
                                     thread_schedule_state::pending))
                         {
-                            detail::write_state_log(&scheduler, num_thread,
-                                thrd, thrd_stat.get_previous(),
+                            detail::write_state_log(scheduler, num_thread, thrd,
+                                thrd_stat.get_previous(),
                                 thread_schedule_state::active);
 
                             tfunc_time_wrapper tfunc_time_collector(idle_rate);
@@ -713,8 +715,8 @@ namespace hpx { namespace threads { namespace detail {
 #endif
                             }
 
-                            detail::write_state_log(&scheduler, num_thread,
-                                thrd, thread_schedule_state::active,
+                            detail::write_state_log(scheduler, num_thread, thrd,
+                                thread_schedule_state::active,
                                 thrd_stat.get_previous());
 
 #ifdef HPX_HAVE_THREAD_CUMULATIVE_COUNTS
@@ -727,7 +729,7 @@ namespace hpx { namespace threads { namespace detail {
                             // executing this HPX-thread, we just continue with
                             // the next one
                             thrd_stat.disable_restore();
-                            detail::write_state_log_warning(&scheduler,
+                            detail::write_state_log_warning(scheduler,
                                 num_thread, thrd, state_val, "no execution");
                             continue;
                         }
@@ -738,7 +740,7 @@ namespace hpx { namespace threads { namespace detail {
                             // some other worker-thread got in between and changed
                             // the state of this thread, we just continue with
                             // the next one
-                            detail::write_state_log_warning(&scheduler,
+                            detail::write_state_log_warning(scheduler,
                                 num_thread, thrd, state_val, "no state change");
                             continue;
                         }
@@ -824,8 +826,9 @@ namespace hpx { namespace threads { namespace detail {
                              thread_schedule_state::active == state_val))
                 {
                     LTM_(warning).format(
-                        "tfunc({}): thread({}), description({}), rescheduling",
-                        num_thread, thrd->get_thread_id(),
+                        "scheduler({}), worker_thread({}), thread({}), "
+                        "description({}), rescheduling",
+                        scheduler, num_thread, thrd->get_thread_id(),
                         thrd->get_description());
                     // re-schedule thread, if it is still marked as active
                     // this might happen, if some thread has been added to the

--- a/libs/core/threading_base/include/hpx/threading_base/create_thread.hpp
+++ b/libs/core/threading_base/include/hpx/threading_base/create_thread.hpp
@@ -88,8 +88,10 @@ namespace hpx { namespace threads { namespace detail {
 
         // NOLINTNEXTLINE(bugprone-branch-clone)
         LTM_(info)
-            .format("register_thread({}): initial_state({}), run_now({})", id,
-                get_thread_state_name(data.initial_state), data.run_now)
+            .format("create_thread: scheduler({}), thread({}), "
+                    "initial_state({}), run_now({})",
+                *scheduler, id, get_thread_state_name(data.initial_state),
+                data.run_now)
 #ifdef HPX_HAVE_THREAD_DESCRIPTION
             .format(", description({})", data.description)
 #endif

--- a/libs/core/threading_base/include/hpx/threading_base/create_thread.hpp
+++ b/libs/core/threading_base/include/hpx/threading_base/create_thread.hpp
@@ -88,10 +88,10 @@ namespace hpx { namespace threads { namespace detail {
 
         // NOLINTNEXTLINE(bugprone-branch-clone)
         LTM_(info)
-            .format("create_thread: scheduler({}), thread({}), "
+            .format("create_thread: pool({}), scheduler({}), thread({}), "
                     "initial_state({}), run_now({})",
-                *scheduler, id, get_thread_state_name(data.initial_state),
-                data.run_now)
+                *scheduler->get_parent_pool(), *scheduler, id,
+                get_thread_state_name(data.initial_state), data.run_now)
 #ifdef HPX_HAVE_THREAD_DESCRIPTION
             .format(", description({})", data.description)
 #endif

--- a/libs/core/threading_base/include/hpx/threading_base/create_work.hpp
+++ b/libs/core/threading_base/include/hpx/threading_base/create_work.hpp
@@ -44,9 +44,10 @@ namespace hpx { namespace threads { namespace detail {
 #endif
 
         LTM_(info)
-            .format("create_work: scheduler({}), initial_state({}), "
+            .format("create_work: pool({}), scheduler({}), initial_state({}), "
                     "thread_priority({})",
-                *scheduler, get_thread_state_name(data.initial_state),
+                *scheduler->get_parent_pool(), *scheduler,
+                get_thread_state_name(data.initial_state),
                 get_thread_priority_name(data.priority))
 #ifdef HPX_HAVE_THREAD_DESCRIPTION
             .format(", description({})", data.description)

--- a/libs/core/threading_base/include/hpx/threading_base/create_work.hpp
+++ b/libs/core/threading_base/include/hpx/threading_base/create_work.hpp
@@ -44,8 +44,9 @@ namespace hpx { namespace threads { namespace detail {
 #endif
 
         LTM_(info)
-            .format("create_work: initial_state({}), thread_priority({})",
-                get_thread_state_name(data.initial_state),
+            .format("create_work: scheduler({}), initial_state({}), "
+                    "thread_priority({})",
+                *scheduler, get_thread_state_name(data.initial_state),
                 get_thread_priority_name(data.priority))
 #ifdef HPX_HAVE_THREAD_DESCRIPTION
             .format(", description({})", data.description)

--- a/libs/core/threading_base/include/hpx/threading_base/scheduler_base.hpp
+++ b/libs/core/threading_base/include/hpx/threading_base/scheduler_base.hpp
@@ -66,7 +66,7 @@ namespace hpx { namespace threads { namespace policies {
 
         virtual ~scheduler_base() = default;
 
-        threads::thread_pool_base* get_parent_pool()
+        threads::thread_pool_base* get_parent_pool() const
         {
             HPX_ASSERT(parent_pool_ != nullptr);
             return parent_pool_;

--- a/libs/core/threading_base/include/hpx/threading_base/scheduler_base.hpp
+++ b/libs/core/threading_base/include/hpx/threading_base/scheduler_base.hpp
@@ -28,6 +28,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <exception>
+#include <iosfwd>
 #include <memory>
 #include <mutex>
 #include <utility>
@@ -426,6 +427,9 @@ namespace hpx { namespace threads { namespace policies {
         std::shared_ptr<coroutines::detail::tss_storage> thread_data_;
 #endif
     };
+
+    HPX_CORE_EXPORT std::ostream& operator<<(
+        std::ostream& os, scheduler_base const& scheduler);
 }}}    // namespace hpx::threads::policies
 
 #include <hpx/config/warnings_suffix.hpp>

--- a/libs/core/threading_base/include/hpx/threading_base/thread_pool_base.hpp
+++ b/libs/core/threading_base/include/hpx/threading_base/thread_pool_base.hpp
@@ -183,7 +183,7 @@ namespace hpx { namespace threads {
 
         virtual void print_pool(std::ostream&) = 0;
 
-        pool_id_type get_pool_id()
+        pool_id_type get_pool_id() const
         {
             return id_;
         }
@@ -553,6 +553,9 @@ namespace hpx { namespace threads {
         threads::policies::callback_notifier& notifier_;
         /// \endcond
     };
+
+    HPX_CORE_EXPORT std::ostream& operator<<(
+        std::ostream& os, thread_pool_base const& thread_pool);
 }}    // namespace hpx::threads
 
 #include <hpx/config/warnings_suffix.hpp>

--- a/libs/core/threading_base/src/execution_agent.cpp
+++ b/libs/core/threading_base/src/execution_agent.cpp
@@ -206,8 +206,9 @@ namespace hpx { namespace threads {
                 hpx::threads::thread_schedule_state::pending)
             {
                 LTM_(warning).format(
-                    "resume: old thread state is already pending thread state, "
-                    "aborting state change, thread({}), description({})",
+                    "execution_agent::do_resume: old thread state is already "
+                    "pending thread state, aborting state change, thread({}), "
+                    "description({})",
                     id, get_thread_id_data(id)->get_description());
                 return;
             }
@@ -220,16 +221,17 @@ namespace hpx { namespace threads {
                 hpx::execution_base::this_thread::yield_k(
                     k, "hpx::threads::execution_agent::resume");
                 ++k;
-                LTM_(warning).format("resume: thread is active, retrying state "
-                                     "change, thread({}), description({})",
+                LTM_(warning).format(
+                    "execution_agent::do_resume: thread is active, retrying "
+                    "state change, thread({}), description({})",
                     id, get_thread_id_data(id)->get_description());
                 continue;
             }
             case thread_schedule_state::terminated:
             {
                 LTM_(warning).format(
-                    "resume: thread is terminated, aborting state change, "
-                    "thread({}), description({})",
+                    "execution_agent::do_resume: thread is terminated, "
+                    "aborting state change, thread({}), description({})",
                     id, get_thread_id_data(id)->get_description());
                 return;
             }
@@ -244,7 +246,8 @@ namespace hpx { namespace threads {
                 // should not happen...
                 HPX_ASSERT_MSG(false,
                     hpx::util::format(
-                        "resume: previous state was {}", previous_state_val)
+                        "execution_agent::do_resume: previous state was {}",
+                        previous_state_val)
                         .c_str());
                 break;
             }
@@ -256,9 +259,9 @@ namespace hpx { namespace threads {
             // at some point will ignore this thread by simply skipping it
             // (if it's not pending anymore).
 
-            LTM_(info).format(
-                "resume: thread({}), description({}), old state({})", id,
-                get_thread_id_data(id)->get_description(),
+            LTM_(info).format("execution_agent::do_resume: thread({}), "
+                              "description({}), old state({})",
+                id, get_thread_id_data(id)->get_description(),
                 get_thread_state_name(previous_state_val));
 
             // So all what we do here is to set the new state.
@@ -270,7 +273,8 @@ namespace hpx { namespace threads {
 
             // state has changed since we fetched it from the thread, retry
             LTM_(error).format(
-                "resume: state has been changed since it was fetched, "
+                "execution_agent::do_resume: state has been changed since it "
+                "was fetched, "
                 "retrying, thread({}), description({}), old state({})",
                 id, get_thread_id_data(id)->get_description(),
                 get_thread_state_name(previous_state_val));
@@ -281,6 +285,10 @@ namespace hpx { namespace threads {
         if (!(previous_state_val == thread_schedule_state::pending ||
                 previous_state_val == thread_schedule_state::pending_boost))
         {
+            LTM_(debug).format("execution_agent::do_resume: resuming thread, "
+                               "thread({}), description({})",
+                id, get_thread_id_data(id)->get_description());
+
             auto* data = get_thread_id_data(id);
             auto scheduler = data->get_scheduler_base();
             auto hint = thread_schedule_hint(

--- a/libs/core/threading_base/src/scheduler_base.cpp
+++ b/libs/core/threading_base/src/scheduler_base.cpp
@@ -27,6 +27,7 @@
 #include <limits>
 #include <memory>
 #include <mutex>
+#include <ostream>
 #include <set>
 #include <string>
 #include <utility>
@@ -423,4 +424,11 @@ namespace hpx { namespace threads { namespace policies {
         }
     }
 #endif
+
+    std::ostream& operator<<(std::ostream& os, scheduler_base const& scheduler)
+    {
+        os << scheduler.get_description() << "(" << &scheduler << ")";
+
+        return os;
+    }
 }}}    // namespace hpx::threads::policies

--- a/libs/core/threading_base/src/thread_pool_base.cpp
+++ b/libs/core/threading_base/src/thread_pool_base.cpp
@@ -20,6 +20,7 @@
 #include <cstdint>
 #include <memory>
 #include <mutex>
+#include <ostream>
 #include <string>
 #include <thread>
 
@@ -106,5 +107,14 @@ namespace hpx { namespace threads {
         std::size_t /* pool_threads */, std::size_t threads_offset)
     {
         thread_offset_ = threads_offset;
+    }
+
+    std::ostream& operator<<(
+        std::ostream& os, thread_pool_base const& thread_pool)
+    {
+        auto id = thread_pool.get_pool_id();
+        os << id.name() << "(" << id.index() << ")";
+
+        return os;
     }
 }}    // namespace hpx::threads


### PR DESCRIPTION
This PR is the result of some debuggin in DLA-Future of a deadlock caused by a combination of our scheduler and a blocking MPI call being made in an HPX thread. We know that the latter is very naughty, but at the same time it can lead to performance benefits in this particular case (lots of small tasks if one does not do the blocking call). We're looking into alternatives, but one of the changes here also helps for the particular situation. I'm happy to drop it though as it's only a question of default configuration values. That said, the changes here are:

- Add more extensive logging to the scheduling loop. Previously the state of an HPX thread was logged only once the context was changed back to the scheduler. This PR adds logging both before and after threads are scheduled so that one can see when they start and stop. This helps with recognizing if a task has been started but never finishes. I've also added more information to the messages (thread pool, scheduler). I also log when attmpting to steal threads, but the number of threads is lower than the threshold.
- Change the `idle_loop_count` to count up again like the other counters. The counter was decremented in most places, but incremented in another (https://github.com/STEllAR-GROUP/hpx/blob/bb51c2c8cbd0dc68026f3bd92b0b746b7a273d86/libs/core/schedulers/include/hpx/schedulers/queue_helpers.hpp#L53). This alone did not cause a deadlock, but it was part of it. The `idle_loop_count` never reached a value where `enable_stealing_staged` would be true. @hkaiser I know you changed this to count down in https://github.com/STEllAR-GROUP/hpx/pull/3768. However, I don't see which cases become more cumbersome when incrementing the counter (https://github.com/STEllAR-GROUP/hpx/pull/3768#discussion_r272145021). Do you remember what those were? Does `idle_loop_count` need to be reset to `max_idle_loop_count` somewhere outside the scheduling loop?
- Finally, change default value of `min_tasks_to_steal_staged` to 0. This is not a must, mostly convenience.