### PR TITLE
Adapt uninitialized_move and uninitialized_move_n to C++ 20

### DIFF
--- a/docs/sphinx/api/public_api.rst
+++ b/docs/sphinx/api/public_api.rst
@@ -571,8 +571,8 @@ Functions
 - :cpp:func:`hpx::parallel::v1::uninitialized_default_construct_n`
 - :cpp:func:`hpx::parallel::v1::uninitialized_fill`
 - :cpp:func:`hpx::parallel::v1::uninitialized_fill_n`
-- :cpp:func:`hpx::parallel::v1::uninitialized_move`
-- :cpp:func:`hpx::parallel::v1::uninitialized_move_n`
+- :cpp:func:`hpx::uninitialized_move`
+- :cpp:func:`hpx::uninitialized_move_n`
 - :cpp:func:`hpx::parallel::v1::uninitialized_value_construct`
 - :cpp:func:`hpx::parallel::v1::uninitialized_value_construct_n`
 

--- a/docs/sphinx/api/public_api.rst
+++ b/docs/sphinx/api/public_api.rst
@@ -576,6 +576,9 @@ Functions
 - :cpp:func:`hpx::parallel::v1::uninitialized_value_construct`
 - :cpp:func:`hpx::parallel::v1::uninitialized_value_construct_n`
 
+- :cpp:func:`hpx::ranges::uninitialized_move`
+- :cpp:func:`hpx::ranges::uninitialized_move_n`
+
 Header ``hpx/numeric.hpp``
 ==========================
 

--- a/docs/sphinx/manual/writing_single_node_hpx_applications.rst
+++ b/docs/sphinx/manual/writing_single_node_hpx_applications.rst
@@ -740,11 +740,11 @@ Parallel algorithms
      * Copies an object to an uninitialized area of memory.
      * ``<hpx/memory.hpp>``
      * :cppreference-memory:`uninitialized_fill_n`
-   * * :cpp:func:`hpx::parallel::v1::uninitialized_move`
+   * * :cpp:func:`hpx::uninitialized_move`
      * Moves a range of objects to an uninitialized area of memory.
      * ``<hpx/memory.hpp>``
      * :cppreference-memory:`uninitialized_move`
-   * * :cpp:func:`hpx::parallel::v1::uninitialized_move_n`
+   * * :cpp:func:`hpx::uninitialized_move_n`
      * Moves a number of objects to an uninitialized area of memory.
      * ``<hpx/memory.hpp>``
      * :cppreference-memory:`uninitialized_move_n`

--- a/libs/full/include_local/include/hpx/local/memory.hpp
+++ b/libs/full/include_local/include/hpx/local/memory.hpp
@@ -16,8 +16,6 @@ namespace hpx {
     using hpx::parallel::uninitialized_default_construct_n;
     using hpx::parallel::uninitialized_fill;
     using hpx::parallel::uninitialized_fill_n;
-    using hpx::parallel::uninitialized_move;
-    using hpx::parallel::uninitialized_move_n;
     using hpx::parallel::uninitialized_value_construct;
     using hpx::parallel::uninitialized_value_construct_n;
 }    // namespace hpx

--- a/libs/parallelism/algorithms/CMakeLists.txt
+++ b/libs/parallelism/algorithms/CMakeLists.txt
@@ -121,6 +121,7 @@ set(algorithms_headers
     hpx/parallel/container_algorithms/stable_sort.hpp
     hpx/parallel/container_algorithms/transform.hpp
     hpx/parallel/container_algorithms/transform_reduce.hpp
+    hpx/parallel/container_algorithms/uninitialized_move.hpp
     hpx/parallel/container_algorithms/unique.hpp
     hpx/parallel/container_memory.hpp
     hpx/parallel/container_numeric.hpp

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/uninitialized_move.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/uninitialized_move.hpp
@@ -8,8 +8,208 @@
 
 #pragma once
 
+#if defined(DOXYGEN)
+namespace hpx {
+
+    /// Copies the elements in the range, defined by [first, last), to an
+    /// uninitialized memory area beginning at \a dest. If an exception is
+    /// thrown during the copy operation, the function has no effects.
+    ///
+    /// \note   Complexity: Performs exactly \a last - \a first assignments.
+    ///
+    /// \tparam InIter      The type of the source iterators used (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     input iterator.
+    /// \tparam FwdIter     The type of the iterator representing the
+    ///                     destination range (deduced).
+    ///                     This iterator type must meet the requirements of a
+    ///                     forward iterator.
+    ///
+    /// \param first        Refers to the beginning of the sequence of elements
+    ///                     the algorithm will be applied to.
+    /// \param last         Refers to the end of the sequence of elements the
+    ///                     algorithm will be applied to.
+    /// \param dest         Refers to the beginning of the destination range.
+    ///
+    /// The assignments in the parallel \a uninitialized_copy algorithm invoked
+    /// without an execution policy object will execute in sequential order in
+    /// the calling thread.
+    ///
+    /// \returns  The \a uninitialized_copy algorithm returns \a FwdIter.
+    ///           The \a uninitialized_copy algorithm returns the output
+    ///           iterator to the element in the destination range, one past
+    ///           the last element copied.
+    ///
+    template <typename InIter, typename FwdIter>
+    FwdIter uninitialized_copy(InIter first, InIter last, FwdIter dest);
+
+    /// Copies the elements in the range, defined by [first, last), to an
+    /// uninitialized memory area beginning at \a dest. If an exception is
+    /// thrown during the copy operation, the function has no effects.
+    ///
+    /// \note   Complexity: Performs exactly \a last - \a first assignments.
+    ///
+    /// \tparam ExPolicy    The type of the execution policy to use (deduced).
+    ///                     It describes the manner in which the execution
+    ///                     of the algorithm may be parallelized and the manner
+    ///                     in which it executes the assignments.
+    /// \tparam FwdIter1    The type of the source iterators used (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     forward iterator.
+    /// \tparam FwdIter2    The type of the iterator representing the
+    ///                     destination range (deduced).
+    ///                     This iterator type must meet the requirements of a
+    ///                     forward iterator.
+    ///
+    /// \param policy       The execution policy to use for the scheduling of
+    ///                     the iterations.
+    /// \param first        Refers to the beginning of the sequence of elements
+    ///                     the algorithm will be applied to.
+    /// \param last         Refers to the end of the sequence of elements the
+    ///                     algorithm will be applied to.
+    /// \param dest         Refers to the beginning of the destination range.
+    ///
+    /// The assignments in the parallel \a uninitialized_copy algorithm invoked
+    /// with an execution policy object of type \a sequenced_policy
+    /// execute in sequential order in the calling thread.
+    ///
+    /// The assignments in the parallel \a uninitialized_copy algorithm invoked
+    /// with an execution policy object of type \a parallel_policy or
+    /// \a parallel_task_policy are permitted to execute in an
+    /// unordered fashion in unspecified threads, and indeterminately sequenced
+    /// within each thread.
+    ///
+    /// \returns  The \a uninitialized_copy algorithm returns a
+    ///           \a hpx::future<FwdIter2>, if the execution policy is of type
+    ///           \a sequenced_task_policy or
+    ///           \a parallel_task_policy and
+    ///           returns \a FwdIter2 otherwise.
+    ///           The \a uninitialized_copy algorithm returns the output
+    ///           iterator to the element in the destination range, one past
+    ///           the last element copied.
+    ///
+    template <typename ExPolicy, typename FwdIter1, typename FwdIter2>
+    typename parallel::util::detail::algorithm_result<ExPolicy, FwdIter2>::type
+    uninitialized_copy(
+        ExPolicy&& policy, FwdIter1 first, FwdIter1 last, FwdIter2 dest);
+
+    /// Copies the elements in the range [first, first + count), starting from
+    /// first and proceeding to first + count - 1., to another range beginning
+    /// at dest. If an exception is thrown during the copy operation, the
+    /// function has no effects.
+    ///
+    /// \note   Complexity: Performs exactly \a count assignments, if
+    ///         count > 0, no assignments otherwise.
+    ///
+    /// \tparam ExPolicy    The type of the execution policy to use (deduced).
+    ///                     It describes the manner in which the execution
+    ///                     of the algorithm may be parallelized and the manner
+    ///                     in which it executes the assignments.
+    /// \tparam FwdIter1      The type of the source iterators used (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     input iterator.
+    /// \tparam Size        The type of the argument specifying the number of
+    ///                     elements to apply \a f to.
+    /// \tparam FwdIter2     The type of the iterator representing the
+    ///                     destination range (deduced).
+    ///                     This iterator type must meet the requirements of a
+    ///                     forward iterator.
+    ///
+    /// \param policy       The execution policy to use for the scheduling of
+    ///                     the iterations.
+    /// \param first        Refers to the beginning of the sequence of elements
+    ///                     the algorithm will be applied to.
+    /// \param count        Refers to the number of elements starting at
+    ///                     \a first the algorithm will be applied to.
+    /// \param dest         Refers to the beginning of the destination range.
+    ///
+    /// The assignments in the parallel \a uninitialized_copy_n algorithm
+    /// invoked with an execution policy object of type
+    /// \a sequenced_policy execute in sequential order in the
+    /// calling thread.
+    ///
+    /// The assignments in the parallel \a uninitialized_copy_n algorithm
+    /// invoked with an execution policy object of type
+    /// \a parallel_policy or
+    /// \a parallel_task_policy are permitted to execute in an
+    /// unordered fashion in unspecified threads, and indeterminately sequenced
+    /// within each thread.
+    ///
+    /// \returns  The \a uninitialized_copy_n algorithm returns a
+    ///           \a hpx::future<FwdIter2> if the execution policy is of type
+    ///           \a sequenced_task_policy or
+    ///           \a parallel_task_policy and
+    ///           returns \a FwdIter2 otherwise.
+    ///           The \a uninitialized_copy_n algorithm returns the output
+    ///           iterator to the element in the destination range, one past
+    ///           the last element copied.
+    ///
+    template <typename InIter, typename Size, typename FwdIter>
+    FwdIter uninitialized_copy_n(InIter first, Size count, FwdIter dest);
+
+    /// Copies the elements in the range [first, first + count), starting from
+    /// first and proceeding to first + count - 1., to another range beginning
+    /// at dest. If an exception is thrown during the copy operation, the
+    /// function has no effects.
+    ///
+    /// \note   Complexity: Performs exactly \a count assignments, if
+    ///         count > 0, no assignments otherwise.
+    ///
+    /// \tparam ExPolicy    The type of the execution policy to use (deduced).
+    ///                     It describes the manner in which the execution
+    ///                     of the algorithm may be parallelized and the manner
+    ///                     in which it executes the assignments.
+    /// \tparam FwdIter1      The type of the source iterators used (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     input iterator.
+    /// \tparam Size        The type of the argument specifying the number of
+    ///                     elements to apply \a f to.
+    /// \tparam FwdIter2     The type of the iterator representing the
+    ///                     destination range (deduced).
+    ///                     This iterator type must meet the requirements of a
+    ///                     forward iterator.
+    ///
+    /// \param policy       The execution policy to use for the scheduling of
+    ///                     the iterations.
+    /// \param first        Refers to the beginning of the sequence of elements
+    ///                     the algorithm will be applied to.
+    /// \param count        Refers to the number of elements starting at
+    ///                     \a first the algorithm will be applied to.
+    /// \param dest         Refers to the beginning of the destination range.
+    ///
+    /// The assignments in the parallel \a uninitialized_copy_n algorithm
+    /// invoked with an execution policy object of type
+    /// \a sequenced_policy execute in sequential order in the
+    /// calling thread.
+    ///
+    /// The assignments in the parallel \a uninitialized_copy_n algorithm
+    /// invoked with an execution policy object of type
+    /// \a parallel_policy or
+    /// \a parallel_task_policy are permitted to execute in an
+    /// unordered fashion in unspecified threads, and indeterminately sequenced
+    /// within each thread.
+    ///
+    /// \returns  The \a uninitialized_copy_n algorithm returns a
+    ///           \a hpx::future<FwdIter2> if the execution policy is of type
+    ///           \a sequenced_task_policy or
+    ///           \a parallel_task_policy and
+    ///           returns \a FwdIter2 otherwise.
+    ///           The \a uninitialized_copy_n algorithm returns the output
+    ///           iterator to the element in the destination range, one past
+    ///           the last element copied.
+    ///
+    template <typename ExPolicy, typename FwdIter1, typename Size,
+        typename FwdIter2>
+    typename parallel::util::detail::algorithm_result<ExPolicy, FwdIter2>::type
+    uninitialized_copy_n(
+        ExPolicy&& policy, FwdIter1 first, Size count, FwdIter2 dest);
+}    // namespace hpx
+
+#else    // DOXYGEN
+
 #include <hpx/config.hpp>
 #include <hpx/concepts/concepts.hpp>
+#include <hpx/functional/tag_fallback_dispatch.hpp>
 #include <hpx/iterator_support/traits/is_iterator.hpp>
 #include <hpx/parallel/util/tagged_pair.hpp>
 
@@ -20,6 +220,7 @@
 #include <hpx/parallel/util/detail/algorithm_result.hpp>
 #include <hpx/parallel/util/loop.hpp>
 #include <hpx/parallel/util/partitioner_with_cleanup.hpp>
+#include <hpx/parallel/util/result_types.hpp>
 #include <hpx/parallel/util/zip_iterator.hpp>
 
 #include <algorithm>
@@ -38,12 +239,12 @@ namespace hpx { namespace parallel { inline namespace v1 {
 
         // provide our own implementation of std::uninitialized_move as some
         // versions of MSVC horribly fail at compiling it for some types T
-        template <typename InIter1, typename InIter2>
-        InIter2 std_uninitialized_move(
-            InIter1 first, InIter1 last, InIter2 d_first)
+        template <typename InIter1, typename Sent, typename InIter2>
+        util::in_out_result<InIter1, InIter2> std_uninitialized_move(
+            InIter1 first, Sent last, InIter2 d_first)
         {
-            typedef
-                typename std::iterator_traits<InIter2>::value_type value_type;
+            using value_type =
+                typename std::iterator_traits<InIter2>::value_type;
 
             InIter2 current = d_first;
             try
@@ -53,7 +254,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                     ::new (std::addressof(*current))
                         value_type(std::move(*first));
                 }
-                return current;
+                return util::in_out_result<InIter1, InIter2>{first, current};
             }
             catch (...)
             {
@@ -67,33 +268,36 @@ namespace hpx { namespace parallel { inline namespace v1 {
 
         ///////////////////////////////////////////////////////////////////////
         template <typename InIter1, typename InIter2>
-        InIter2 sequential_uninitialized_move_n(InIter1 first,
-            std::size_t count, InIter2 dest,
+        util::in_out_result<InIter1, InIter2> sequential_uninitialized_move_n(
+            InIter1 first, std::size_t count, InIter2 dest,
             util::cancellation_token<util::detail::no_data>& tok)
         {
-            typedef
-                typename std::iterator_traits<InIter2>::value_type value_type;
+            using value_type =
+                typename std::iterator_traits<InIter2>::value_type;
 
-            return util::loop_with_cleanup_n_with_token(
-                first, count, dest, tok,
-                [](InIter1 it, InIter2 dest) -> void {
-                    ::new (std::addressof(*dest)) value_type(std::move(*it));
-                },
-                [](InIter2 dest) -> void { (*dest).~value_type(); });
+            return util::in_out_result<InIter1, InIter2>{
+                std::next(first, count),
+                util::loop_with_cleanup_n_with_token(
+                    first, count, dest, tok,
+                    [](InIter1 it, InIter2 dest) -> void {
+                        ::new (std::addressof(*dest))
+                            value_type(std::move(*it));
+                    },
+                    [](InIter2 dest) -> void { (*dest).~value_type(); })};
         }
 
         ///////////////////////////////////////////////////////////////////////
         template <typename ExPolicy, typename Iter, typename FwdIter2>
         typename util::detail::algorithm_result<ExPolicy,
-            std::pair<Iter, FwdIter2>>::type
+            util::in_out_result<Iter, FwdIter2>>::type
         parallel_sequential_uninitialized_move_n(
             ExPolicy&& policy, Iter first, std::size_t count, FwdIter2 dest)
         {
             if (count == 0)
             {
                 return util::detail::algorithm_result<ExPolicy,
-                    std::pair<Iter, FwdIter2>>::get(std::make_pair(first,
-                    dest));
+                    util::in_out_result<Iter, FwdIter2>>::
+                    get(util::in_out_result<Iter, FwdIter2>{first, dest});
             }
 
             typedef hpx::util::zip_iterator<Iter, FwdIter2> zip_iterator;
@@ -103,7 +307,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
 
             util::cancellation_token<util::detail::no_data> tok;
             return util::partitioner_with_cleanup<ExPolicy,
-                std::pair<Iter, FwdIter2>, partition_result_type>::
+                util::in_out_result<Iter, FwdIter2>, partition_result_type>::
                 call(
                     std::forward<ExPolicy>(policy),
                     hpx::util::make_zip_iterator(first, dest), count,
@@ -113,16 +317,17 @@ namespace hpx { namespace parallel { inline namespace v1 {
                         auto iters = t.get_iterator_tuple();
                         FwdIter2 dest = get<1>(iters);
                         return std::make_pair(dest,
-                            sequential_uninitialized_move_n(
-                                get<0>(iters), part_size, dest, tok));
+                            util::get_second_element(
+                                sequential_uninitialized_move_n(
+                                    get<0>(iters), part_size, dest, tok)));
                     },
                     // finalize, called once if no error occurred
                     [first, dest, count](std::vector<
                         hpx::future<partition_result_type>>&&) mutable
-                    -> std::pair<Iter, FwdIter2> {
+                    -> util::in_out_result<Iter, FwdIter2> {
                         std::advance(first, count);
                         std::advance(dest, count);
-                        return std::make_pair(first, dest);
+                        return util::in_out_result<Iter, FwdIter2>{first, dest};
                     },
                     // cleanup function, called for each partition which
                     // didn't fail, but only if at least one failed
@@ -136,34 +341,32 @@ namespace hpx { namespace parallel { inline namespace v1 {
         }
 
         ///////////////////////////////////////////////////////////////////////
-        template <typename FwdIter2>
+        template <typename IterPair>
         struct uninitialized_move
-          : public detail::algorithm<uninitialized_move<FwdIter2>, FwdIter2>
+          : public detail::algorithm<uninitialized_move<IterPair>, IterPair>
         {
             uninitialized_move()
               : uninitialized_move::algorithm("uninitialized_move")
             {
             }
 
-            template <typename ExPolicy, typename InIter1>
-            static FwdIter2 sequential(
-                ExPolicy, InIter1 first, InIter1 last, FwdIter2 dest)
+            template <typename ExPolicy, typename InIter1, typename Sent,
+                typename FwdIter2>
+            static util::in_out_result<InIter1, FwdIter2> sequential(
+                ExPolicy, InIter1 first, Sent last, FwdIter2 dest)
             {
                 return std_uninitialized_move(first, last, dest);
             }
 
-            template <typename ExPolicy, typename Iter>
+            template <typename ExPolicy, typename Iter, typename Sent,
+                typename FwdIter2>
             static typename util::detail::algorithm_result<ExPolicy,
-                FwdIter2>::type
-            parallel(ExPolicy&& policy, Iter first, Iter last, FwdIter2 dest)
+                util::in_out_result<Iter, FwdIter2>>::type
+            parallel(ExPolicy&& policy, Iter first, Sent last, FwdIter2 dest)
             {
-                return util::detail::convert_to_result(
-                    parallel_sequential_uninitialized_move_n(
-                        std::forward<ExPolicy>(policy), first,
-                        std::distance(first, last), dest),
-                    [](std::pair<Iter, FwdIter2> const& p) -> FwdIter2 {
-                        return p.second;
-                    });
+                return parallel_sequential_uninitialized_move_n(
+                    std::forward<ExPolicy>(policy), first,
+                    detail::distance(first, last), dest);
             }
         };
         /// \endcond
@@ -219,17 +422,30 @@ namespace hpx { namespace parallel { inline namespace v1 {
         HPX_CONCEPT_REQUIRES_(hpx::is_execution_policy<ExPolicy>::value&&
                 hpx::traits::is_iterator<FwdIter1>::value&&
                     hpx::traits::is_iterator<FwdIter2>::value)>
+    HPX_DEPRECATED_V(1, 7,
+        "hpx::parallel::uninitialized_move is deprecated, use "
+        "hpx::uninitialized_move "
+        "instead")
     typename util::detail::algorithm_result<ExPolicy, FwdIter2>::type
-    uninitialized_move(
-        ExPolicy&& policy, FwdIter1 first, FwdIter1 last, FwdIter2 dest)
+        uninitialized_move(
+            ExPolicy&& policy, FwdIter1 first, FwdIter1 last, FwdIter2 dest)
     {
         static_assert((hpx::traits::is_forward_iterator<FwdIter1>::value),
             "Required at least forward iterator.");
         static_assert((hpx::traits::is_forward_iterator<FwdIter2>::value),
             "Requires at least forward iterator.");
 
-        return detail::uninitialized_move<FwdIter2>().call(
-            std::forward<ExPolicy>(policy), first, last, dest);
+#if defined(HPX_GCC_VERSION) && HPX_GCC_VERSION >= 100000
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
+        return parallel::util::get_second_element(
+            detail::uninitialized_move<
+                parallel::util::in_out_result<FwdIter1, FwdIter2>>()
+                .call(std::forward<ExPolicy>(policy), first, last, dest));
+#if defined(HPX_GCC_VERSION) && HPX_GCC_VERSION >= 100000
+#pragma GCC diagnostic pop
+#endif
     }
 
     /////////////////////////////////////////////////////////////////////////////
@@ -240,11 +456,11 @@ namespace hpx { namespace parallel { inline namespace v1 {
         // provide our own implementation of std::uninitialized_move_n as some
         // versions of MSVC horribly fail at compiling it for some types T
         template <typename InIter1, typename InIter2>
-        std::pair<InIter1, InIter2> std_uninitialized_move_n(
+        util::in_out_result<InIter1, InIter2> std_uninitialized_move_n(
             InIter1 first, std::size_t count, InIter2 d_first)
         {
-            typedef
-                typename std::iterator_traits<InIter2>::value_type value_type;
+            using value_type =
+                typename std::iterator_traits<InIter2>::value_type;
 
             InIter2 current = d_first;
             try
@@ -254,7 +470,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                     ::new (std::addressof(*current))
                         value_type(std::move(*first));
                 }
-                return std::make_pair(first, current);
+                return util::in_out_result<InIter1, InIter2>{first, current};
             }
             catch (...)
             {
@@ -353,28 +569,164 @@ namespace hpx { namespace parallel { inline namespace v1 {
         HPX_CONCEPT_REQUIRES_(hpx::is_execution_policy<ExPolicy>::value&&
                 hpx::traits::is_iterator<FwdIter1>::value&&
                     hpx::traits::is_iterator<FwdIter2>::value)>
+    HPX_DEPRECATED_V(1, 7,
+        "hpx::parallel::uninitialized_move_n is deprecated, use "
+        "hpx::uninitialized_move_n "
+        "instead")
     typename util::detail::algorithm_result<ExPolicy,
-        hpx::util::tagged_pair<tag::in(FwdIter1), tag::out(FwdIter2)>>::type
-    uninitialized_move_n(
-        ExPolicy&& policy, FwdIter1 first, Size count, FwdIter2 dest)
+        std::pair<FwdIter1, FwdIter2>>::type
+        uninitialized_move_n(
+            ExPolicy&& policy, FwdIter1 first, Size count, FwdIter2 dest)
     {
-        static_assert((hpx::traits::is_forward_iterator<FwdIter1>::value),
+        static_assert(hpx::traits::is_forward_iterator<FwdIter1>::value,
             "Required at least forward iterator.");
-        static_assert((hpx::traits::is_forward_iterator<FwdIter2>::value),
+        static_assert(hpx::traits::is_forward_iterator<FwdIter2>::value,
             "Requires at least forward iterator.");
 
         // if count is representing a negative value, we do nothing
         if (detail::is_negative(count))
         {
-            return hpx::util::make_tagged_pair<tag::in, tag::out>(
-                util::detail::algorithm_result<ExPolicy,
-                    std::pair<FwdIter1, FwdIter2>>::get(std::make_pair(first,
-                    dest)));
+            return parallel::util::detail::algorithm_result<ExPolicy,
+                std::pair<FwdIter1, FwdIter2>>::get(std::make_pair(first,
+                dest));
         }
 
-        return hpx::util::make_tagged_pair<tag::in, tag::out>(
-            detail::uninitialized_move_n<std::pair<FwdIter1, FwdIter2>>().call(
-                std::forward<ExPolicy>(policy), first, std::size_t(count),
-                dest));
+#if defined(HPX_GCC_VERSION) && HPX_GCC_VERSION >= 100000
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
+        return parallel::util::get_pair(
+            parallel::v1::detail::uninitialized_move_n<
+                parallel::util::in_out_result<FwdIter1, FwdIter2>>()
+                .call(std::forward<ExPolicy>(policy), first, std::size_t(count),
+                    dest));
+#if defined(HPX_GCC_VERSION) && HPX_GCC_VERSION >= 100000
+#pragma GCC diagnostic pop
+#endif
     }
 }}}    // namespace hpx::parallel::v1
+
+namespace hpx {
+    ///////////////////////////////////////////////////////////////////////////
+    // DPO for hpx::uninitialized_move
+    HPX_INLINE_CONSTEXPR_VARIABLE struct uninitialized_move_t final
+      : hpx::functional::tag_fallback<uninitialized_move_t>
+    {
+        // clang-format off
+        template <typename InIter, typename FwdIter,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::traits::is_iterator<InIter>::value &&
+                hpx::traits::is_forward_iterator<FwdIter>::value
+            )>
+        // clang-format on
+        friend FwdIter tag_fallback_dispatch(
+            hpx::uninitialized_move_t, InIter first, InIter last, FwdIter dest)
+        {
+            static_assert(hpx::traits::is_input_iterator<InIter>::value,
+                "Required at least input iterator.");
+            static_assert(hpx::traits::is_forward_iterator<FwdIter>::value,
+                "Requires at least forward iterator.");
+
+            return parallel::util::get_second_element(
+                hpx::parallel::v1::detail::uninitialized_move<
+                    parallel::util::in_out_result<InIter, FwdIter>>()
+                    .call(hpx::execution::seq, first, last, dest));
+        }
+
+        // clang-format off
+        template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::is_execution_policy<ExPolicy>::value &&
+                hpx::traits::is_forward_iterator<FwdIter1>::value &&
+                hpx::traits::is_forward_iterator<FwdIter2>::value
+            )>
+        // clang-format on
+        friend typename parallel::util::detail::algorithm_result<ExPolicy,
+            FwdIter2>::type
+        tag_fallback_dispatch(hpx::uninitialized_move_t, ExPolicy&& policy,
+            FwdIter1 first, FwdIter1 last, FwdIter2 dest)
+        {
+            static_assert(hpx::traits::is_forward_iterator<FwdIter1>::value,
+                "Requires at least forward iterator.");
+            static_assert(hpx::traits::is_forward_iterator<FwdIter2>::value,
+                "Requires at least forward iterator.");
+
+            return parallel::util::get_second_element(
+                hpx::parallel::v1::detail::uninitialized_move<
+                    parallel::util::in_out_result<FwdIter1, FwdIter2>>()
+                    .call(std::forward<ExPolicy>(policy), first, last, dest));
+        }
+
+    } uninitialized_move{};
+
+    ///////////////////////////////////////////////////////////////////////////
+    // DPO for hpx::uninitialized_move_n
+    HPX_INLINE_CONSTEXPR_VARIABLE struct uninitialized_move_n_t final
+      : hpx::functional::tag_fallback<uninitialized_move_n_t>
+    {
+        // clang-format off
+        template <typename InIter, typename Size,
+            typename FwdIter,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::traits::is_iterator<InIter>::value &&
+                hpx::traits::is_forward_iterator<FwdIter>::value
+            )>
+        // clang-format on
+        friend std::pair<InIter, FwdIter> tag_fallback_dispatch(
+            hpx::uninitialized_move_n_t, InIter first, Size count, FwdIter dest)
+        {
+            static_assert(hpx::traits::is_input_iterator<InIter>::value,
+                "Required at least input iterator.");
+            static_assert(hpx::traits::is_forward_iterator<FwdIter>::value,
+                "Requires at least forward iterator.");
+
+            // if count is representing a negative value, we do nothing
+            if (hpx::parallel::v1::detail::is_negative(count))
+            {
+                return std::make_pair<InIter, FwdIter>(first, dest);
+            }
+
+            return parallel::util::get_pair(
+                hpx::parallel::v1::detail::uninitialized_move_n<
+                    parallel::util::in_out_result<InIter, FwdIter>>()
+                    .call(
+                        hpx::execution::seq, first, std::size_t(count), dest));
+        }
+
+        // clang-format off
+        template <typename ExPolicy, typename FwdIter1, typename Size, typename FwdIter2,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::is_execution_policy<ExPolicy>::value &&
+                hpx::traits::is_forward_iterator<FwdIter1>::value &&
+                hpx::traits::is_forward_iterator<FwdIter2>::value
+            )>
+        // clang-format on
+        friend typename parallel::util::detail::algorithm_result<ExPolicy,
+            std::pair<FwdIter1, FwdIter2>>::type
+        tag_fallback_dispatch(hpx::uninitialized_move_n_t, ExPolicy&& policy,
+            FwdIter1 first, Size count, FwdIter2 dest)
+        {
+            static_assert(hpx::traits::is_forward_iterator<FwdIter1>::value,
+                "Requires at least forward iterator.");
+            static_assert(hpx::traits::is_forward_iterator<FwdIter2>::value,
+                "Requires at least forward iterator.");
+
+            // if count is representing a negative value, we do nothing
+            if (hpx::parallel::v1::detail::is_negative(count))
+            {
+                return parallel::util::detail::algorithm_result<ExPolicy,
+                    std::pair<FwdIter1, FwdIter2>>::get(std::pair<FwdIter1,
+                    FwdIter2>(first, dest));
+            }
+
+            return parallel::util::get_pair(
+                hpx::parallel::v1::detail::uninitialized_move_n<
+                    parallel::util::in_out_result<FwdIter1, FwdIter2>>()
+                    .call(std::forward<ExPolicy>(policy), first,
+                        std::size_t(count), dest));
+        }
+
+    } uninitialized_move_n{};
+}    // namespace hpx
+
+#endif    // DOXYGEN

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/uninitialized_move.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/uninitialized_move.hpp
@@ -10,10 +10,10 @@
 
 #if defined(DOXYGEN)
 namespace hpx {
-
-    /// Copies the elements in the range, defined by [first, last), to an
+    /// Moves the elements in the range, defined by [first, last), to an
     /// uninitialized memory area beginning at \a dest. If an exception is
-    /// thrown during the copy operation, the function has no effects.
+    /// thrown during the initialization, some objects in [first, last) are
+    /// left in a valid but unspecified state.
     ///
     /// \note   Complexity: Performs exactly \a last - \a first assignments.
     ///
@@ -31,21 +31,22 @@ namespace hpx {
     ///                     algorithm will be applied to.
     /// \param dest         Refers to the beginning of the destination range.
     ///
-    /// The assignments in the parallel \a uninitialized_copy algorithm invoked
+    /// The assignments in the parallel \a uninitialized_move algorithm invoked
     /// without an execution policy object will execute in sequential order in
     /// the calling thread.
     ///
-    /// \returns  The \a uninitialized_copy algorithm returns \a FwdIter.
-    ///           The \a uninitialized_copy algorithm returns the output
+    /// \returns  The \a uninitialized_move algorithm returns \a FwdIter.
+    ///           The \a uninitialized_move algorithm returns the output
     ///           iterator to the element in the destination range, one past
-    ///           the last element copied.
+    ///           the last element moved.
     ///
     template <typename InIter, typename FwdIter>
-    FwdIter uninitialized_copy(InIter first, InIter last, FwdIter dest);
+    FwdIter uninitialized_move(InIter first, InIter last, FwdIter dest);
 
-    /// Copies the elements in the range, defined by [first, last), to an
+    /// Moves the elements in the range, defined by [first, last), to an
     /// uninitialized memory area beginning at \a dest. If an exception is
-    /// thrown during the copy operation, the function has no effects.
+    /// thrown during the initialization, some objects in [first, last) are
+    /// left in a valid but unspecified state.
     ///
     /// \note   Complexity: Performs exactly \a last - \a first assignments.
     ///
@@ -69,42 +70,39 @@ namespace hpx {
     ///                     algorithm will be applied to.
     /// \param dest         Refers to the beginning of the destination range.
     ///
-    /// The assignments in the parallel \a uninitialized_copy algorithm invoked
+    /// The assignments in the parallel \a uninitialized_move algorithm invoked
     /// with an execution policy object of type \a sequenced_policy
     /// execute in sequential order in the calling thread.
     ///
-    /// The assignments in the parallel \a uninitialized_copy algorithm invoked
+    /// The assignments in the parallel \a uninitialized_move algorithm invoked
     /// with an execution policy object of type \a parallel_policy or
     /// \a parallel_task_policy are permitted to execute in an
     /// unordered fashion in unspecified threads, and indeterminately sequenced
     /// within each thread.
     ///
-    /// \returns  The \a uninitialized_copy algorithm returns a
+    /// \returns  The \a uninitialized_move algorithm returns a
     ///           \a hpx::future<FwdIter2>, if the execution policy is of type
     ///           \a sequenced_task_policy or
     ///           \a parallel_task_policy and
     ///           returns \a FwdIter2 otherwise.
-    ///           The \a uninitialized_copy algorithm returns the output
+    ///           The \a uninitialized_move algorithm returns the output
     ///           iterator to the element in the destination range, one past
-    ///           the last element copied.
+    ///           the last element moved.
     ///
     template <typename ExPolicy, typename FwdIter1, typename FwdIter2>
     typename parallel::util::detail::algorithm_result<ExPolicy, FwdIter2>::type
-    uninitialized_copy(
+    uninitialized_move(
         ExPolicy&& policy, FwdIter1 first, FwdIter1 last, FwdIter2 dest);
 
-    /// Copies the elements in the range [first, first + count), starting from
+    /// Moves the elements in the range [first, first + count), starting from
     /// first and proceeding to first + count - 1., to another range beginning
-    /// at dest. If an exception is thrown during the copy operation, the
-    /// function has no effects.
+    /// at dest. If an exception is
+    /// thrown during the initialization, some objects in [first, first + count)
+    /// are left in a valid but unspecified state.
     ///
-    /// \note   Complexity: Performs exactly \a count assignments, if
-    ///         count > 0, no assignments otherwise.
+    /// \note   Complexity: Performs exactly \a count movements, if
+    ///         count > 0, no move operations otherwise.
     ///
-    /// \tparam ExPolicy    The type of the execution policy to use (deduced).
-    ///                     It describes the manner in which the execution
-    ///                     of the algorithm may be parallelized and the manner
-    ///                     in which it executes the assignments.
     /// \tparam FwdIter1      The type of the source iterators used (deduced).
     ///                     This iterator type must meet the requirements of an
     ///                     input iterator.
@@ -115,45 +113,34 @@ namespace hpx {
     ///                     This iterator type must meet the requirements of a
     ///                     forward iterator.
     ///
-    /// \param policy       The execution policy to use for the scheduling of
-    ///                     the iterations.
     /// \param first        Refers to the beginning of the sequence of elements
     ///                     the algorithm will be applied to.
     /// \param count        Refers to the number of elements starting at
     ///                     \a first the algorithm will be applied to.
     /// \param dest         Refers to the beginning of the destination range.
     ///
-    /// The assignments in the parallel \a uninitialized_copy_n algorithm
+    /// The assignments in the parallel \a uninitialized_move_n algorithm
     /// invoked with an execution policy object of type
     /// \a sequenced_policy execute in sequential order in the
     /// calling thread.
     ///
-    /// The assignments in the parallel \a uninitialized_copy_n algorithm
-    /// invoked with an execution policy object of type
-    /// \a parallel_policy or
-    /// \a parallel_task_policy are permitted to execute in an
-    /// unordered fashion in unspecified threads, and indeterminately sequenced
-    /// within each thread.
-    ///
-    /// \returns  The \a uninitialized_copy_n algorithm returns a
-    ///           \a hpx::future<FwdIter2> if the execution policy is of type
-    ///           \a sequenced_task_policy or
-    ///           \a parallel_task_policy and
-    ///           returns \a FwdIter2 otherwise.
-    ///           The \a uninitialized_copy_n algorithm returns the output
+    /// \returns  The \a uninitialized_move_n algorithm returns a
+    ///           returns \a FwdIter2.
+    ///           The \a uninitialized_move_n algorithm returns the output
     ///           iterator to the element in the destination range, one past
     ///           the last element copied.
     ///
     template <typename InIter, typename Size, typename FwdIter>
-    FwdIter uninitialized_copy_n(InIter first, Size count, FwdIter dest);
+    FwdIter uninitialized_move_n(InIter first, Size count, FwdIter dest);
 
-    /// Copies the elements in the range [first, first + count), starting from
+    /// Moves the elements in the range [first, first + count), starting from
     /// first and proceeding to first + count - 1., to another range beginning
-    /// at dest. If an exception is thrown during the copy operation, the
-    /// function has no effects.
+    /// at dest. If an exception is
+    /// thrown during the initialization, some objects in [first, first + count)
+    /// are left in a valid but unspecified state.
     ///
-    /// \note   Complexity: Performs exactly \a count assignments, if
-    ///         count > 0, no assignments otherwise.
+    /// \note   Complexity: Performs exactly \a count movements, if
+    ///         count > 0, no move operations otherwise.
     ///
     /// \tparam ExPolicy    The type of the execution policy to use (deduced).
     ///                     It describes the manner in which the execution
@@ -177,31 +164,31 @@ namespace hpx {
     ///                     \a first the algorithm will be applied to.
     /// \param dest         Refers to the beginning of the destination range.
     ///
-    /// The assignments in the parallel \a uninitialized_copy_n algorithm
+    /// The assignments in the parallel \a uninitialized_move_n algorithm
     /// invoked with an execution policy object of type
     /// \a sequenced_policy execute in sequential order in the
     /// calling thread.
     ///
-    /// The assignments in the parallel \a uninitialized_copy_n algorithm
+    /// The assignments in the parallel \a uninitialized_move_n algorithm
     /// invoked with an execution policy object of type
     /// \a parallel_policy or
     /// \a parallel_task_policy are permitted to execute in an
     /// unordered fashion in unspecified threads, and indeterminately sequenced
     /// within each thread.
     ///
-    /// \returns  The \a uninitialized_copy_n algorithm returns a
+    /// \returns  The \a uninitialized_move_n algorithm returns a
     ///           \a hpx::future<FwdIter2> if the execution policy is of type
     ///           \a sequenced_task_policy or
     ///           \a parallel_task_policy and
     ///           returns \a FwdIter2 otherwise.
-    ///           The \a uninitialized_copy_n algorithm returns the output
+    ///           The \a uninitialized_move_n algorithm returns the output
     ///           iterator to the element in the destination range, one past
     ///           the last element copied.
     ///
     template <typename ExPolicy, typename FwdIter1, typename Size,
         typename FwdIter2>
     typename parallel::util::detail::algorithm_result<ExPolicy, FwdIter2>::type
-    uninitialized_copy_n(
+    uninitialized_move_n(
         ExPolicy&& policy, FwdIter1 first, Size count, FwdIter2 dest);
 }    // namespace hpx
 
@@ -586,59 +573,6 @@ namespace hpx { namespace parallel { inline namespace v1 {
         /// \endcond
     }    // namespace detail
 
-    /// Moves the elements in the range [first, first + count), starting from
-    /// first and proceeding to first + count - 1., to another range beginning
-    /// at dest. If an exception is
-    /// thrown during the initialization, some objects in [first, first + count)
-    /// are left in a valid but unspecified state.
-    ///
-    /// \note   Complexity: Performs exactly \a count movements, if
-    ///         count > 0, no move operations otherwise.
-    ///
-    /// \tparam ExPolicy    The type of the execution policy to use (deduced).
-    ///                     It describes the manner in which the execution
-    ///                     of the algorithm may be parallelized and the manner
-    ///                     in which it executes the assignments.
-    /// \tparam FwdIter1    The type of the source iterators used (deduced).
-    ///                     This iterator type must meet the requirements of an
-    ///                     forward iterator.
-    /// \tparam Size        The type of the argument specifying the number of
-    ///                     elements to apply \a f to.
-    /// \tparam FwdIter2    The type of the iterator representing the
-    ///                     destination range (deduced).
-    ///                     This iterator type must meet the requirements of a
-    ///                     forward iterator.
-    ///
-    /// \param policy       The execution policy to use for the scheduling of
-    ///                     the iterations.
-    /// \param first        Refers to the beginning of the sequence of elements
-    ///                     the algorithm will be applied to.
-    /// \param count        Refers to the number of elements starting at
-    ///                     \a first the algorithm will be applied to.
-    /// \param dest         Refers to the beginning of the destination range.
-    ///
-    /// The assignments in the parallel \a uninitialized_move_n algorithm
-    /// invoked with an execution policy object of type
-    /// \a sequenced_policy execute in sequential order in the
-    /// calling thread.
-    ///
-    /// The assignments in the parallel \a uninitialized_move_n algorithm
-    /// invoked with an execution policy object of type
-    /// \a parallel_policy or
-    /// \a parallel_task_policy are permitted to execute in an
-    /// unordered fashion in unspecified threads, and indeterminately sequenced
-    /// within each thread.
-    ///
-    /// \returns  The \a uninitialized_move_n algorithm returns a
-    ///           \a hpx::future<std::pair<FwdIter1, FwdIter2>> if the execution
-    ///           policy is of type \a sequenced_task_policy or
-    ///           \a parallel_task_policy and
-    ///           returns \a std::pair<FwdIter1, FwdIter2> otherwise.
-    ///           The \a uninitialized_move_n algorithm returns the pair of
-    ///           the input iterator to the element past in the source range
-    ///           and an output iterator to the element in the destination
-    ///           range, one past the last element moved.
-    ///
     template <typename ExPolicy, typename FwdIter1, typename Size,
         typename FwdIter2,
         HPX_CONCEPT_REQUIRES_(hpx::is_execution_policy<ExPolicy>::value&&

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/uninitialized_move.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/uninitialized_move.hpp
@@ -236,7 +236,8 @@ namespace hpx { namespace parallel { inline namespace v1 {
             FwdIter2 current = dest;
             try
             {
-                for (/* */; cond(first, current); (void) ++first, ++current)
+                for (/* */; HPX_INVOKE(cond, first, current);
+                     (void) ++first, ++current)
                 {
                     ::new (std::addressof(*current))
                         value_type(std::move(*first));

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/uninitialized_move.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/uninitialized_move.hpp
@@ -13,9 +13,10 @@
 
 namespace hpx { namespace ranges {
 
-    /// Copies the elements in the range, defined by [first, last), to an
+    /// Moves the elements in the range, defined by [first, last), to an
     /// uninitialized memory area beginning at \a dest. If an exception is
-    /// thrown during the copy operation, the function has no effects.
+    /// thrown during the initialization, some objects in [first, last) are
+    /// left in a valid but unspecified state.
     ///
     /// \note   Complexity: Performs exactly \a last - \a first assignments.
     ///
@@ -39,24 +40,25 @@ namespace hpx { namespace ranges {
     /// \param last2        Refers to sentinel value denoting the end of the
     ///                     second range the algorithm will be applied to.
     ///
-    /// The assignments in the parallel \a uninitialized_copy algorithm invoked
+    /// The assignments in the parallel \a uninitialized_move algorithm invoked
     /// without an execution policy object will execute in sequential order in
     /// the calling thread.
     ///
-    /// \returns  The \a uninitialized_copy algorithm returns an
+    /// \returns  The \a uninitialized_move algorithm returns an
     ///           \a in_out_result<InIter, FwdIter>.
-    ///           The \a uninitialized_copy algorithm returns an input iterator
+    ///           The \a uninitialized_move algorithm returns an input iterator
     ///           to one past the last element copied from and the output
     ///           iterator to the element in the destination range, one past
     ///           the last element copied.
     ///
     template <typename InIter, typename Sent1, typename FwdIter, typename Sent2>
-    hpx::parallel::util::in_out_result<InIter, FwdIter> uninitialized_copy(
+    hpx::parallel::util::in_out_result<InIter, FwdIter> uninitialized_move(
         InIter first1, Sent1 last1, FwdIter first2, Sent2 last2);
 
-    /// Copies the elements in the range, defined by [first, last), to an
+    /// Moves the elements in the range, defined by [first, last), to an
     /// uninitialized memory area beginning at \a dest. If an exception is
-    /// thrown during the copy operation, the function has no effects.
+    /// thrown during the initialization, some objects in [first, last) are
+    /// left in a valid but unspecified state.
     ///
     /// \note   Complexity: Performs exactly \a last - \a first assignments.
     ///
@@ -86,22 +88,22 @@ namespace hpx { namespace ranges {
     /// \param last2        Refers to sentinel value denoting the end of the
     ///                     second range the algorithm will be applied to.
     ///
-    /// The assignments in the parallel \a uninitialized_copy algorithm invoked
+    /// The assignments in the parallel \a uninitialized_move algorithm invoked
     /// with an execution policy object of type \a sequenced_policy
     /// execute in sequential order in the calling thread.
     ///
-    /// The assignments in the parallel \a uninitialized_copy algorithm invoked
+    /// The assignments in the parallel \a uninitialized_move algorithm invoked
     /// with an execution policy object of type \a parallel_policy or
     /// \a parallel_task_policy are permitted to execute in an
     /// unordered fashion in unspecified threads, and indeterminately sequenced
     /// within each thread.
     ///
-    /// \returns  The \a uninitialized_copy algorithm returns a
+    /// \returns  The \a uninitialized_move algorithm returns a
     ///           \a hpx::future<in_out_result<InIter, FwdIter>>, if the
     ///           execution policy is of type \a sequenced_task_policy
     ///           or \a parallel_task_policy and
     ///           returns \a in_out_result<InIter, FwdIter> otherwise.
-    ///           The \a uninitialized_copy algorithm returns an input iterator
+    ///           The \a uninitialized_move algorithm returns an input iterator
     ///           to one past the last element copied from and the output
     ///           iterator to the element in the destination range, one past
     ///           the last element copied.
@@ -110,12 +112,13 @@ namespace hpx { namespace ranges {
         typename FwdIter2, typename Sent2>
     typename parallel::util::detail::algorithm_result<ExPolicy,
         parallel::util::in_out_result<FwdIter1, FwdIter2>>::type
-    uninitialized_copy(ExPolicy&& policy, FwdIter1 first1, Sent1 last1,
+    uninitialized_move(ExPolicy&& policy, FwdIter1 first1, Sent1 last1,
         FwdIter2 first2, Sent2 last2);
 
-    /// Copies the elements in the range, defined by [first, last), to an
+    /// Moves the elements in the range, defined by [first, last), to an
     /// uninitialized memory area beginning at \a dest. If an exception is
-    /// thrown during the copy operation, the function has no effects.
+    /// thrown during the initialization, some objects in [first, last) are
+    /// left in a valid but unspecified state.
     ///
     /// \note   Complexity: Performs exactly \a last - \a first assignments.
     ///
@@ -131,15 +134,15 @@ namespace hpx { namespace ranges {
     /// \param rng2         Refers to the range to which the elements
     ///                     will be copied to
     ///
-    /// The assignments in the parallel \a uninitialized_copy algorithm invoked
+    /// The assignments in the parallel \a uninitialized_move algorithm invoked
     /// without an execution policy object will execute in sequential order in
     /// the calling thread.
     ///
-    /// \returns  The \a uninitialized_copy algorithm returns an
+    /// \returns  The \a uninitialized_move algorithm returns an
     ///           \a in_out_result<typename hpx::traits::range_traits<Rng1>
     ///           ::iterator_type, typename hpx::traits::range_traits<Rng2>
     ///           ::iterator_type>.
-    ///           The \a uninitialized_copy algorithm returns an input iterator
+    ///           The \a uninitialized_move algorithm returns an input iterator
     ///           to one past the last element copied from and the output
     ///           iterator to the element in the destination range, one past
     ///           the last element copied.
@@ -148,11 +151,12 @@ namespace hpx { namespace ranges {
     hpx::parallel::util::in_out_result<
         typename hpx::traits::range_traits<Rng1>::iterator_type,
         typename hpx::traits::range_traits<Rng2>::iterator_type>
-    uninitialized_copy(Rng1&& rng1, Rng2&& rng2);
+    uninitialized_move(Rng1&& rng1, Rng2&& rng2);
 
-    /// Copies the elements in the range, defined by [first, last), to an
+    /// Moves the elements in the range, defined by [first, last), to an
     /// uninitialized memory area beginning at \a dest. If an exception is
-    /// thrown during the copy operation, the function has no effects.
+    /// thrown during the initialization, some objects in [first, last) are
+    /// left in a valid but unspecified state.
     ///
     /// \note   Complexity: Performs exactly \a last - \a first assignments.
     ///
@@ -174,24 +178,24 @@ namespace hpx { namespace ranges {
     /// \param rng2         Refers to the range to which the elements
     ///                     will be copied to
     ///
-    /// The assignments in the parallel \a uninitialized_copy algorithm invoked
+    /// The assignments in the parallel \a uninitialized_move algorithm invoked
     /// with an execution policy object of type \a sequenced_policy
     /// execute in sequential order in the calling thread.
     ///
-    /// The assignments in the parallel \a uninitialized_copy algorithm invoked
+    /// The assignments in the parallel \a uninitialized_move algorithm invoked
     /// with an execution policy object of type \a parallel_policy or
     /// \a parallel_task_policy are permitted to execute in an
     /// unordered fashion in unspecified threads, and indeterminately sequenced
     /// within each thread.
     ///
-    /// \returns  The \a uninitialized_copy algorithm returns a
+    /// \returns  The \a uninitialized_move algorithm returns a
     ///           \a hpx::future<in_out_result<InIter, FwdIter>>, if the
     ///           execution policy is of type \a sequenced_task_policy
     ///           or \a parallel_task_policy and
     ///           returns \a in_out_result<
     ///             typename hpx::traits::range_traits<Rng1>::iterator_type
     ///           , typename hpx::traits::range_traits<Rng2>::iterator_type>
-    ///           otherwise. The \a uninitialized_copy algorithm returns the
+    ///           otherwise. The \a uninitialized_move algorithm returns the
     ///           input iterator to one past the last element copied from and
     ///           the output iterator to the element in the destination range,
     ///           one past the last element copied.
@@ -201,14 +205,16 @@ namespace hpx { namespace ranges {
         hpx::parallel::util::in_out_result<
             typename hpx::traits::range_traits<Rng1>::iterator_type,
             typename hpx::traits::range_traits<Rng2>::iterator_type>>::type
-    uninitialized_copy(ExPolicy&& policy, Rng1&& rng1, Rng2&& rng2);
+    uninitialized_move(ExPolicy&& policy, Rng1&& rng1, Rng2&& rng2);
 
-    /// Copies the elements in the range [first, first + count), starting from
+    /// Moves the elements in the range [first, first + count), starting from
     /// first and proceeding to first + count - 1., to another range beginning
-    /// at dest. If an exception is thrown during the copy operation, the
-    /// function has no effects.
+    /// at dest. If an exception is
+    /// thrown during the initialization, some objects in [first, first + count)
+    /// are left in a valid but unspecified state.
     ///
-    /// \note   Complexity: Performs exactly \a last - \a first assignments.
+    /// \note   Complexity: Performs exactly \a count movements, if
+    ///         count > 0, no move operations otherwise.
     ///
     /// \tparam InIter      The type of the source iterators used (deduced).
     ///                     This iterator type must meet the requirements of an
@@ -230,27 +236,29 @@ namespace hpx { namespace ranges {
     /// \param last2        Refers to sentinel value denoting the end of the
     ///                     second range the algorithm will be applied to.
     ///
-    /// The assignments in the parallel \a uninitialized_copy_n algorithm
+    /// The assignments in the parallel \a uninitialized_move_n algorithm
     /// invoked with an execution policy object of type
     /// \a sequenced_policy execute in sequential order in the
     /// calling thread.
     ///
-    /// \returns  The \a uninitialized_copy_n algorithm returns
+    /// \returns  The \a uninitialized_move_n algorithm returns
     ///           \a in_out_result<InIter, FwdIter>.
-    ///           The \a uninitialized_copy_n algorithm returns the output
+    ///           The \a uninitialized_move_n algorithm returns the output
     ///           iterator to the element in the destination range, one past
     ///           the last element copied.
     ///
     template <typename InIter, typename Size, typename FwdIter, typename Sent2>
-    hpx::parallel::util::in_out_result<InIter, FwdIter> uninitialized_copy_n(
+    hpx::parallel::util::in_out_result<InIter, FwdIter> uninitialized_move_n(
         InIter first1, Size count, FwdIter first2, Sent2 last2);
 
-    /// Copies the elements in the range [first, first + count), starting from
+    /// Moves the elements in the range [first, first + count), starting from
     /// first and proceeding to first + count - 1., to another range beginning
-    /// at dest. If an exception is thrown during the copy operation, the
-    /// function has no effects.
+    /// at dest. If an exception is
+    /// thrown during the initialization, some objects in [first, first + count)
+    /// are left in a valid but unspecified state.
     ///
-    /// \note   Complexity: Performs exactly \a last - \a first assignments.
+    /// \note   Complexity: Performs exactly \a count movements, if
+    ///         count > 0, no move operations otherwise.
     ///
     /// \tparam ExPolicy    The type of the execution policy to use (deduced).
     ///                     It describes the manner in which the execution
@@ -278,24 +286,24 @@ namespace hpx { namespace ranges {
     /// \param last1        Refers to sentinel value denoting the end of the
     ///                     second range the algorithm will be applied to.
     ///
-    /// The assignments in the parallel \a uninitialized_copy_n algorithm
+    /// The assignments in the parallel \a uninitialized_move_n algorithm
     /// invoked with an execution policy object of type
     /// \a sequenced_policy execute in sequential order in the
     /// calling thread.
     ///
-    /// The assignments in the parallel \a uninitialized_copy_n algorithm
+    /// The assignments in the parallel \a uninitialized_move_n algorithm
     /// invoked with an execution policy object of type
     /// \a parallel_policy or
     /// \a parallel_task_policy are permitted to execute in an
     /// unordered fashion in unspecified threads, and indeterminately sequenced
     /// within each thread.
     ///
-    /// \returns  The \a uninitialized_copy_n algorithm returns a
+    /// \returns  The \a uninitialized_move_n algorithm returns a
     ///           \a hpx::future<in_out_result<FwdIter1, FwdIter2>> if the
     ///           execution policy is of type \a sequenced_task_policy or
     ///           \a parallel_task_policy and
     ///           returns \a FwdIter2 otherwise.
-    ///           The \a uninitialized_copy_n algorithm returns the output
+    ///           The \a uninitialized_move_n algorithm returns the output
     ///           iterator to the element in the destination range, one past
     ///           the last element copied.
     ///
@@ -303,7 +311,7 @@ namespace hpx { namespace ranges {
         typename FwdIter2, typename Sent2>
     typename parallel::util::detail::algorithm_result<ExPolicy,
         parallel::util::in_out_result<FwdIter1, FwdIter2>>::type
-    uninitialized_copy_n(ExPolicy&& policy, FwdIter1 first1, Size count,
+    uninitialized_move_n(ExPolicy&& policy, FwdIter1 first1, Size count,
         FwdIter2 first2, Sent2 last2);
 }}    // namespace hpx::ranges
 #else

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/uninitialized_move.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/uninitialized_move.hpp
@@ -1,0 +1,507 @@
+//  Copyright (c) 2020 ETH Zurich
+//  Copyright (c) 2014 Grant Mercer
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+/// \file parallel/container_algorithms/uninitialized_move.hpp
+
+#pragma once
+
+#if defined(DOXYGEN)
+
+namespace hpx { namespace ranges {
+
+    /// Copies the elements in the range, defined by [first, last), to an
+    /// uninitialized memory area beginning at \a dest. If an exception is
+    /// thrown during the copy operation, the function has no effects.
+    ///
+    /// \note   Complexity: Performs exactly \a last - \a first assignments.
+    ///
+    /// \tparam InIter      The type of the source iterators used (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     input iterator.
+    /// \tparam Sent1       The type of the source sentinel (deduced). This
+    ///                     sentinel type must be a sentinel for InIter.
+    /// \tparam FwdIter     The type of the iterator representing the
+    ///                     destination range (deduced).
+    ///                     This iterator type must meet the requirements of a
+    ///                     forward iterator.
+    /// \tparam Sent2       The type of the source sentinel (deduced). This
+    ///                     sentinel type must be a sentinel for InIter2.
+    ///
+    /// \param first1       Refers to the beginning of the sequence of elements
+    ///                     that will be copied from
+    /// \param last1        Refers to sentinel value denoting the end of the
+    ///                     sequence of elements the algorithm will be applied
+    /// \param first2       Refers to the beginning of the destination range.
+    /// \param last2        Refers to sentinel value denoting the end of the
+    ///                     second range the algorithm will be applied to.
+    ///
+    /// The assignments in the parallel \a uninitialized_copy algorithm invoked
+    /// without an execution policy object will execute in sequential order in
+    /// the calling thread.
+    ///
+    /// \returns  The \a uninitialized_copy algorithm returns an
+    ///           \a in_out_result<InIter, FwdIter>.
+    ///           The \a uninitialized_copy algorithm returns an input iterator
+    ///           to one past the last element copied from and the output
+    ///           iterator to the element in the destination range, one past
+    ///           the last element copied.
+    ///
+    template <typename InIter, typename Sent1, typename FwdIter, typename Sent2>
+    hpx::parallel::util::in_out_result<InIter, FwdIter> uninitialized_copy(
+        InIter first1, Sent1 last1, FwdIter first2, Sent2 last2);
+
+    /// Copies the elements in the range, defined by [first, last), to an
+    /// uninitialized memory area beginning at \a dest. If an exception is
+    /// thrown during the copy operation, the function has no effects.
+    ///
+    /// \note   Complexity: Performs exactly \a last - \a first assignments.
+    ///
+    /// \tparam ExPolicy    The type of the execution policy to use (deduced).
+    ///                     It describes the manner in which the execution
+    ///                     of the algorithm may be parallelized and the manner
+    ///                     in which it executes the assignments.
+    /// \tparam FwdIter1    The type of the source iterators used (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     input iterator.
+    /// \tparam Sent1       The type of the source sentinel (deduced). This
+    ///                     sentinel type must be a sentinel for InIter.
+    /// \tparam FwdIter2    The type of the iterator representing the
+    ///                     destination range (deduced).
+    ///                     This iterator type must meet the requirements of a
+    ///                     forward iterator.
+    /// \tparam Sent2       The type of the source sentinel (deduced). This
+    ///                     sentinel type must be a sentinel for InIter2.
+    ///
+    /// \param policy       The execution policy to use for the scheduling of
+    ///                     the iterations.
+    /// \param first1       Refers to the beginning of the sequence of elements
+    ///                     that will be copied from
+    /// \param last1        Refers to sentinel value denoting the end of the
+    ///                     sequence of elements the algorithm will be applied.
+    /// \param first2       Refers to the beginning of the destination range.
+    /// \param last2        Refers to sentinel value denoting the end of the
+    ///                     second range the algorithm will be applied to.
+    ///
+    /// The assignments in the parallel \a uninitialized_copy algorithm invoked
+    /// with an execution policy object of type \a sequenced_policy
+    /// execute in sequential order in the calling thread.
+    ///
+    /// The assignments in the parallel \a uninitialized_copy algorithm invoked
+    /// with an execution policy object of type \a parallel_policy or
+    /// \a parallel_task_policy are permitted to execute in an
+    /// unordered fashion in unspecified threads, and indeterminately sequenced
+    /// within each thread.
+    ///
+    /// \returns  The \a uninitialized_copy algorithm returns a
+    ///           \a hpx::future<in_out_result<InIter, FwdIter>>, if the
+    ///           execution policy is of type \a sequenced_task_policy
+    ///           or \a parallel_task_policy and
+    ///           returns \a in_out_result<InIter, FwdIter> otherwise.
+    ///           The \a uninitialized_copy algorithm returns an input iterator
+    ///           to one past the last element copied from and the output
+    ///           iterator to the element in the destination range, one past
+    ///           the last element copied.
+    ///
+    template <typename ExPolicy, typename FwdIter1, typename Sent1,
+        typename FwdIter2, typename Sent2>
+    typename parallel::util::detail::algorithm_result<ExPolicy,
+        parallel::util::in_out_result<FwdIter1, FwdIter2>>::type
+    uninitialized_copy(ExPolicy&& policy, FwdIter1 first1, Sent1 last1,
+        FwdIter2 first2, Sent2 last2);
+
+    /// Copies the elements in the range, defined by [first, last), to an
+    /// uninitialized memory area beginning at \a dest. If an exception is
+    /// thrown during the copy operation, the function has no effects.
+    ///
+    /// \note   Complexity: Performs exactly \a last - \a first assignments.
+    ///
+    /// \tparam Rng1        The type of the source range used (deduced).
+    ///                     The iterators extracted from this range type must
+    ///                     meet the requirements of an input iterator.
+    /// \tparam Rng2        The type of the destination range used (deduced).
+    ///                     The iterators extracted from this range type must
+    ///                     meet the requirements of an forward iterator.
+    ///
+    /// \param rng1         Refers to the range from which the elements
+    ///                     will be copied from
+    /// \param rng2         Refers to the range to which the elements
+    ///                     will be copied to
+    ///
+    /// The assignments in the parallel \a uninitialized_copy algorithm invoked
+    /// without an execution policy object will execute in sequential order in
+    /// the calling thread.
+    ///
+    /// \returns  The \a uninitialized_copy algorithm returns an
+    ///           \a in_out_result<typename hpx::traits::range_traits<Rng1>
+    ///           ::iterator_type, typename hpx::traits::range_traits<Rng2>
+    ///           ::iterator_type>.
+    ///           The \a uninitialized_copy algorithm returns an input iterator
+    ///           to one past the last element copied from and the output
+    ///           iterator to the element in the destination range, one past
+    ///           the last element copied.
+    ///
+    template <typename Rng1, typename Rng2>
+    hpx::parallel::util::in_out_result<
+        typename hpx::traits::range_traits<Rng1>::iterator_type,
+        typename hpx::traits::range_traits<Rng2>::iterator_type>
+    uninitialized_copy(Rng1&& rng1, Rng2&& rng2);
+
+    /// Copies the elements in the range, defined by [first, last), to an
+    /// uninitialized memory area beginning at \a dest. If an exception is
+    /// thrown during the copy operation, the function has no effects.
+    ///
+    /// \note   Complexity: Performs exactly \a last - \a first assignments.
+    ///
+    /// \tparam ExPolicy    The type of the execution policy to use (deduced).
+    ///                     It describes the manner in which the execution
+    ///                     of the algorithm may be parallelized and the manner
+    ///                     in which it executes the assignments.
+    /// \tparam Rng1        The type of the source range used (deduced).
+    ///                     The iterators extracted from this range type must
+    ///                     meet the requirements of an input iterator.
+    /// \tparam Rng2        The type of the destination range used (deduced).
+    ///                     The iterators extracted from this range type must
+    ///                     meet the requirements of an forward iterator.
+    ///
+    /// \param policy       The execution policy to use for the scheduling of
+    ///                     the iterations.
+    /// \param rng1         Refers to the range from which the elements
+    ///                     will be copied from
+    /// \param rng2         Refers to the range to which the elements
+    ///                     will be copied to
+    ///
+    /// The assignments in the parallel \a uninitialized_copy algorithm invoked
+    /// with an execution policy object of type \a sequenced_policy
+    /// execute in sequential order in the calling thread.
+    ///
+    /// The assignments in the parallel \a uninitialized_copy algorithm invoked
+    /// with an execution policy object of type \a parallel_policy or
+    /// \a parallel_task_policy are permitted to execute in an
+    /// unordered fashion in unspecified threads, and indeterminately sequenced
+    /// within each thread.
+    ///
+    /// \returns  The \a uninitialized_copy algorithm returns a
+    ///           \a hpx::future<in_out_result<InIter, FwdIter>>, if the
+    ///           execution policy is of type \a sequenced_task_policy
+    ///           or \a parallel_task_policy and
+    ///           returns \a in_out_result<
+    ///             typename hpx::traits::range_traits<Rng1>::iterator_type
+    ///           , typename hpx::traits::range_traits<Rng2>::iterator_type>
+    ///           otherwise. The \a uninitialized_copy algorithm returns the
+    ///           input iterator to one past the last element copied from and
+    ///           the output iterator to the element in the destination range,
+    ///           one past the last element copied.
+    ///
+    template <typename ExPolicy, typename Rng1, typename Rng2>
+    typename parallel::util::detail::algorithm_result<ExPolicy,
+        hpx::parallel::util::in_out_result<
+            typename hpx::traits::range_traits<Rng1>::iterator_type,
+            typename hpx::traits::range_traits<Rng2>::iterator_type>>::type
+    uninitialized_copy(ExPolicy&& policy, Rng1&& rng1, Rng2&& rng2);
+
+    /// Copies the elements in the range [first, first + count), starting from
+    /// first and proceeding to first + count - 1., to another range beginning
+    /// at dest. If an exception is thrown during the copy operation, the
+    /// function has no effects.
+    ///
+    /// \note   Complexity: Performs exactly \a last - \a first assignments.
+    ///
+    /// \tparam InIter      The type of the source iterators used (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     input iterator.
+    /// \tparam Size        The type of the argument specifying the number of
+    ///                     elements to apply \a f to.
+    /// \tparam FwdIter     The type of the iterator representing the
+    ///                     destination range (deduced).
+    ///                     This iterator type must meet the requirements of a
+    ///                     forward iterator.
+    /// \tparam Sent2       The type of the source sentinel (deduced). This
+    ///                     sentinel type must be a sentinel for FwdIter.
+    ///
+    /// \param first1       Refers to the beginning of the sequence of elements
+    ///                     that will be copied from
+    /// \param count        Refers to the number of elements starting at
+    ///                     \a first the algorithm will be applied to.
+    /// \param first2       Refers to the beginning of the destination range.
+    /// \param last2        Refers to sentinel value denoting the end of the
+    ///                     second range the algorithm will be applied to.
+    ///
+    /// The assignments in the parallel \a uninitialized_copy_n algorithm
+    /// invoked with an execution policy object of type
+    /// \a sequenced_policy execute in sequential order in the
+    /// calling thread.
+    ///
+    /// \returns  The \a uninitialized_copy_n algorithm returns
+    ///           \a in_out_result<InIter, FwdIter>.
+    ///           The \a uninitialized_copy_n algorithm returns the output
+    ///           iterator to the element in the destination range, one past
+    ///           the last element copied.
+    ///
+    template <typename InIter, typename Size, typename FwdIter, typename Sent2>
+    hpx::parallel::util::in_out_result<InIter, FwdIter> uninitialized_copy_n(
+        InIter first1, Size count, FwdIter first2, Sent2 last2);
+
+    /// Copies the elements in the range [first, first + count), starting from
+    /// first and proceeding to first + count - 1., to another range beginning
+    /// at dest. If an exception is thrown during the copy operation, the
+    /// function has no effects.
+    ///
+    /// \note   Complexity: Performs exactly \a last - \a first assignments.
+    ///
+    /// \tparam ExPolicy    The type of the execution policy to use (deduced).
+    ///                     It describes the manner in which the execution
+    ///                     of the algorithm may be parallelized and the manner
+    ///                     in which it executes the assignments.
+    /// \tparam FwdIter1    The type of the source iterators used (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     input iterator.
+    /// \tparam Size        The type of the argument specifying the number of
+    ///                     elements to apply \a f to.
+    /// \tparam FwdIter2    The type of the iterator representing the
+    ///                     destination range (deduced).
+    ///                     This iterator type must meet the requirements of a
+    ///                     forward iterator.
+    /// \tparam Sent2       The type of the source sentinel (deduced). This
+    ///                     sentinel type must be a sentinel for InIter2.
+    ///
+    /// \param policy       The execution policy to use for the scheduling of
+    ///                     the iterations.
+    /// \param first1       Refers to the beginning of the sequence of elements
+    ///                     that will be copied from
+    /// \param count        Refers to the number of elements starting at
+    ///                     \a first the algorithm will be applied to.
+    /// \param first2       Refers to the beginning of the destination range.
+    /// \param last1        Refers to sentinel value denoting the end of the
+    ///                     second range the algorithm will be applied to.
+    ///
+    /// The assignments in the parallel \a uninitialized_copy_n algorithm
+    /// invoked with an execution policy object of type
+    /// \a sequenced_policy execute in sequential order in the
+    /// calling thread.
+    ///
+    /// The assignments in the parallel \a uninitialized_copy_n algorithm
+    /// invoked with an execution policy object of type
+    /// \a parallel_policy or
+    /// \a parallel_task_policy are permitted to execute in an
+    /// unordered fashion in unspecified threads, and indeterminately sequenced
+    /// within each thread.
+    ///
+    /// \returns  The \a uninitialized_copy_n algorithm returns a
+    ///           \a hpx::future<in_out_result<FwdIter1, FwdIter2>> if the
+    ///           execution policy is of type \a sequenced_task_policy or
+    ///           \a parallel_task_policy and
+    ///           returns \a FwdIter2 otherwise.
+    ///           The \a uninitialized_copy_n algorithm returns the output
+    ///           iterator to the element in the destination range, one past
+    ///           the last element copied.
+    ///
+    template <typename ExPolicy, typename FwdIter1, typename Size,
+        typename FwdIter2, typename Sent2>
+    typename parallel::util::detail::algorithm_result<ExPolicy,
+        parallel::util::in_out_result<FwdIter1, FwdIter2>>::type
+    uninitialized_copy_n(ExPolicy&& policy, FwdIter1 first1, Size count,
+        FwdIter2 first2, Sent2 last2);
+}}    // namespace hpx::ranges
+#else
+
+#include <hpx/config.hpp>
+#include <hpx/algorithms/traits/projected_range.hpp>
+#include <hpx/execution/algorithms/detail/predicates.hpp>
+#include <hpx/executors/execution_policy.hpp>
+#include <hpx/iterator_support/traits/is_iterator.hpp>
+#include <hpx/parallel/algorithms/uninitialized_move.hpp>
+#include <hpx/parallel/util/detail/algorithm_result.hpp>
+#include <hpx/parallel/util/projection_identity.hpp>
+
+#include <algorithm>
+#include <cstddef>
+#include <iterator>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+namespace hpx { namespace ranges {
+    HPX_INLINE_CONSTEXPR_VARIABLE struct uninitialized_move_t final
+      : hpx::functional::tag_fallback<uninitialized_move_t>
+    {
+    private:
+        // clang-format off
+        template <typename InIter, typename Sent1, typename FwdIter, typename Sent2,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::traits::is_iterator<InIter>::value &&
+                hpx::traits::is_sentinel_for<Sent1, InIter>::value &&
+                hpx::traits::is_forward_iterator<FwdIter>::value &&
+                hpx::traits::is_sentinel_for<Sent2, FwdIter>::value
+            )>
+        // clang-format on
+        friend hpx::parallel::util::in_out_result<InIter, FwdIter>
+        tag_fallback_dispatch(hpx::ranges::uninitialized_move_t, InIter first1,
+            Sent1 last1, FwdIter first2, Sent2 last2)
+        {
+            static_assert(hpx::traits::is_input_iterator<InIter>::value,
+                "Requires at least input iterator.");
+            static_assert(hpx::traits::is_forward_iterator<FwdIter>::value,
+                "Requires at least forward iterator.");
+
+            return hpx::parallel::v1::detail::uninitialized_move_sent<
+                parallel::util::in_out_result<InIter, FwdIter>>()
+                .call(hpx::execution::seq, first1, last1, first2, last2);
+        }
+
+        // clang-format off
+        template <typename ExPolicy, typename FwdIter1, typename Sent1,
+            typename FwdIter2, typename Sent2,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::is_execution_policy<ExPolicy>::value &&
+                hpx::traits::is_forward_iterator<FwdIter1>::value &&
+                hpx::traits::is_sentinel_for<Sent1, FwdIter1>::value &&
+                hpx::traits::is_forward_iterator<FwdIter2>::value &&
+                hpx::traits::is_sentinel_for<Sent2, FwdIter2>::value
+            )>
+        // clang-format on
+        friend typename parallel::util::detail::algorithm_result<ExPolicy,
+            parallel::util::in_out_result<FwdIter1, FwdIter2>>::type
+        tag_fallback_dispatch(hpx::ranges::uninitialized_move_t,
+            ExPolicy&& policy, FwdIter1 first1, Sent1 last1, FwdIter2 first2,
+            Sent2 last2)
+        {
+            static_assert(hpx::traits::is_forward_iterator<FwdIter1>::value,
+                "Requires at least forward iterator.");
+            static_assert(hpx::traits::is_forward_iterator<FwdIter2>::value,
+                "Requires at least forward iterator.");
+
+            return hpx::parallel::v1::detail::uninitialized_move_sent<
+                parallel::util::in_out_result<FwdIter1, FwdIter2>>()
+                .call(std::forward<ExPolicy>(policy), first1, last1, first2,
+                    last2);
+        }
+
+        // clang-format off
+        template <typename Rng1, typename Rng2,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::traits::is_range<Rng1>::value &&
+                hpx::traits::is_range<Rng2>::value
+            )>
+        // clang-format on
+        friend hpx::parallel::util::in_out_result<
+            typename hpx::traits::range_traits<Rng1>::iterator_type,
+            typename hpx::traits::range_traits<Rng2>::iterator_type>
+        tag_fallback_dispatch(
+            hpx::ranges::uninitialized_move_t, Rng1&& rng1, Rng2&& rng2)
+        {
+            using iterator_type1 =
+                typename hpx::traits::range_traits<Rng1>::iterator_type;
+            using iterator_type2 =
+                typename hpx::traits::range_traits<Rng2>::iterator_type;
+
+            static_assert(hpx::traits::is_input_iterator<iterator_type1>::value,
+                "Requires at least input iterator.");
+
+            static_assert(
+                hpx::traits::is_forward_iterator<iterator_type2>::value,
+                "Requires at least forward iterator.");
+
+            return hpx::parallel::v1::detail::uninitialized_move_sent<
+                parallel::util::in_out_result<iterator_type1, iterator_type2>>()
+                .call(hpx::execution::seq, std::begin(rng1), std::end(rng1),
+                    std::begin(rng2), std::end(rng2));
+        }
+
+        // clang-format off
+        template <typename ExPolicy, typename Rng1, typename Rng2,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::is_execution_policy<ExPolicy>::value &&
+                hpx::traits::is_range<Rng1>::value &&
+                hpx::traits::is_range<Rng2>::value
+            )>
+        // clang-format on
+        friend typename parallel::util::detail::algorithm_result<ExPolicy,
+            hpx::parallel::util::in_out_result<
+                typename hpx::traits::range_traits<Rng1>::iterator_type,
+                typename hpx::traits::range_traits<Rng2>::iterator_type>>::type
+        tag_fallback_dispatch(hpx::ranges::uninitialized_move_t,
+            ExPolicy&& policy, Rng1&& rng1, Rng2&& rng2)
+        {
+            using iterator_type1 =
+                typename hpx::traits::range_traits<Rng1>::iterator_type;
+            using iterator_type2 =
+                typename hpx::traits::range_traits<Rng2>::iterator_type;
+
+            static_assert(
+                hpx::traits::is_forward_iterator<iterator_type1>::value,
+                "Requires at least forward iterator.");
+
+            static_assert(
+                hpx::traits::is_forward_iterator<iterator_type2>::value,
+                "Requires at least forward iterator.");
+
+            return hpx::parallel::v1::detail::uninitialized_move_sent<
+                parallel::util::in_out_result<iterator_type1, iterator_type2>>()
+                .call(std::forward<ExPolicy>(policy), std::begin(rng1),
+                    std::end(rng1), std::begin(rng2), std::end(rng2));
+        }
+    } uninitialized_move{};
+
+    HPX_INLINE_CONSTEXPR_VARIABLE struct uninitialized_move_n_t final
+      : hpx::functional::tag_fallback<uninitialized_move_n_t>
+    {
+    private:
+        // clang-format off
+        template <typename InIter, typename Size, typename FwdIter, typename Sent2,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::traits::is_iterator<InIter>::value &&
+                hpx::traits::is_forward_iterator<FwdIter>::value &&
+                hpx::traits::is_sentinel_for<Sent2, FwdIter>::value
+            )>
+        // clang-format on
+        friend hpx::parallel::util::in_out_result<InIter, FwdIter>
+        tag_fallback_dispatch(hpx::ranges::uninitialized_move_n_t,
+            InIter first1, Size count, FwdIter first2, Sent2 last2)
+        {
+            static_assert(hpx::traits::is_input_iterator<InIter>::value,
+                "Requires at least input iterator.");
+            static_assert(hpx::traits::is_forward_iterator<FwdIter>::value,
+                "Requires at least forward iterator.");
+
+            std::size_t d = parallel::v1::detail::distance(first2, last2);
+            return hpx::parallel::v1::detail::uninitialized_move_n<
+                parallel::util::in_out_result<InIter, FwdIter>>()
+                .call(hpx::execution::seq, first1, count <= d ? count : d,
+                    first2);
+        }
+
+        // clang-format off
+        template <typename ExPolicy, typename FwdIter1, typename Size,
+            typename FwdIter2, typename Sent2,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::is_execution_policy<ExPolicy>::value &&
+                hpx::traits::is_forward_iterator<FwdIter1>::value &&
+                hpx::traits::is_forward_iterator<FwdIter2>::value &&
+                hpx::traits::is_sentinel_for<Sent2, FwdIter2>::value
+            )>
+        // clang-format on
+        friend typename parallel::util::detail::algorithm_result<ExPolicy,
+            hpx::parallel::util::in_out_result<FwdIter1, FwdIter2>>::type
+        tag_fallback_dispatch(hpx::ranges::uninitialized_move_n_t,
+            ExPolicy&& policy, FwdIter1 first1, Size count, FwdIter2 first2,
+            Sent2 last2)
+        {
+            static_assert(hpx::traits::is_forward_iterator<FwdIter1>::value,
+                "Requires at least forward iterator.");
+            static_assert(hpx::traits::is_forward_iterator<FwdIter2>::value,
+                "Requires at least forward iterator.");
+
+            std::size_t d = parallel::v1::detail::distance(first2, last2);
+            return hpx::parallel::v1::detail::uninitialized_move_n<
+                parallel::util::in_out_result<FwdIter1, FwdIter2>>()
+                .call(std::forward<ExPolicy>(policy), first1,
+                    count <= d ? count : d, first2);
+        }
+    } uninitialized_move_n{};
+}}    // namespace hpx::ranges
+
+#endif

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/uninitialized_move.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/uninitialized_move.hpp
@@ -33,7 +33,7 @@ namespace hpx { namespace ranges {
     ///                     sentinel type must be a sentinel for InIter2.
     ///
     /// \param first1       Refers to the beginning of the sequence of elements
-    ///                     that will be copied from
+    ///                     that will be moved from
     /// \param last1        Refers to sentinel value denoting the end of the
     ///                     sequence of elements the algorithm will be applied
     /// \param first2       Refers to the beginning of the destination range.
@@ -47,9 +47,9 @@ namespace hpx { namespace ranges {
     /// \returns  The \a uninitialized_move algorithm returns an
     ///           \a in_out_result<InIter, FwdIter>.
     ///           The \a uninitialized_move algorithm returns an input iterator
-    ///           to one past the last element copied from and the output
+    ///           to one past the last element moved from and the output
     ///           iterator to the element in the destination range, one past
-    ///           the last element copied.
+    ///           the last element moved.
     ///
     template <typename InIter, typename Sent1, typename FwdIter, typename Sent2>
     hpx::parallel::util::in_out_result<InIter, FwdIter> uninitialized_move(
@@ -81,7 +81,7 @@ namespace hpx { namespace ranges {
     /// \param policy       The execution policy to use for the scheduling of
     ///                     the iterations.
     /// \param first1       Refers to the beginning of the sequence of elements
-    ///                     that will be copied from
+    ///                     that will be moved from
     /// \param last1        Refers to sentinel value denoting the end of the
     ///                     sequence of elements the algorithm will be applied.
     /// \param first2       Refers to the beginning of the destination range.
@@ -104,9 +104,9 @@ namespace hpx { namespace ranges {
     ///           or \a parallel_task_policy and
     ///           returns \a in_out_result<InIter, FwdIter> otherwise.
     ///           The \a uninitialized_move algorithm returns an input iterator
-    ///           to one past the last element copied from and the output
+    ///           to one past the last element moved from and the output
     ///           iterator to the element in the destination range, one past
-    ///           the last element copied.
+    ///           the last element moved.
     ///
     template <typename ExPolicy, typename FwdIter1, typename Sent1,
         typename FwdIter2, typename Sent2>
@@ -130,9 +130,9 @@ namespace hpx { namespace ranges {
     ///                     meet the requirements of an forward iterator.
     ///
     /// \param rng1         Refers to the range from which the elements
-    ///                     will be copied from
+    ///                     will be moved from
     /// \param rng2         Refers to the range to which the elements
-    ///                     will be copied to
+    ///                     will be moved to
     ///
     /// The assignments in the parallel \a uninitialized_move algorithm invoked
     /// without an execution policy object will execute in sequential order in
@@ -143,9 +143,9 @@ namespace hpx { namespace ranges {
     ///           ::iterator_type, typename hpx::traits::range_traits<Rng2>
     ///           ::iterator_type>.
     ///           The \a uninitialized_move algorithm returns an input iterator
-    ///           to one past the last element copied from and the output
+    ///           to one past the last element moved from and the output
     ///           iterator to the element in the destination range, one past
-    ///           the last element copied.
+    ///           the last element moved.
     ///
     template <typename Rng1, typename Rng2>
     hpx::parallel::util::in_out_result<
@@ -174,9 +174,9 @@ namespace hpx { namespace ranges {
     /// \param policy       The execution policy to use for the scheduling of
     ///                     the iterations.
     /// \param rng1         Refers to the range from which the elements
-    ///                     will be copied from
+    ///                     will be moved from
     /// \param rng2         Refers to the range to which the elements
-    ///                     will be copied to
+    ///                     will be moved to
     ///
     /// The assignments in the parallel \a uninitialized_move algorithm invoked
     /// with an execution policy object of type \a sequenced_policy
@@ -196,9 +196,9 @@ namespace hpx { namespace ranges {
     ///             typename hpx::traits::range_traits<Rng1>::iterator_type
     ///           , typename hpx::traits::range_traits<Rng2>::iterator_type>
     ///           otherwise. The \a uninitialized_move algorithm returns the
-    ///           input iterator to one past the last element copied from and
+    ///           input iterator to one past the last element moved from and
     ///           the output iterator to the element in the destination range,
-    ///           one past the last element copied.
+    ///           one past the last element moved.
     ///
     template <typename ExPolicy, typename Rng1, typename Rng2>
     typename parallel::util::detail::algorithm_result<ExPolicy,
@@ -229,7 +229,7 @@ namespace hpx { namespace ranges {
     ///                     sentinel type must be a sentinel for FwdIter.
     ///
     /// \param first1       Refers to the beginning of the sequence of elements
-    ///                     that will be copied from
+    ///                     that will be moved from
     /// \param count        Refers to the number of elements starting at
     ///                     \a first the algorithm will be applied to.
     /// \param first2       Refers to the beginning of the destination range.
@@ -245,7 +245,7 @@ namespace hpx { namespace ranges {
     ///           \a in_out_result<InIter, FwdIter>.
     ///           The \a uninitialized_move_n algorithm returns the output
     ///           iterator to the element in the destination range, one past
-    ///           the last element copied.
+    ///           the last element moved.
     ///
     template <typename InIter, typename Size, typename FwdIter, typename Sent2>
     hpx::parallel::util::in_out_result<InIter, FwdIter> uninitialized_move_n(
@@ -279,7 +279,7 @@ namespace hpx { namespace ranges {
     /// \param policy       The execution policy to use for the scheduling of
     ///                     the iterations.
     /// \param first1       Refers to the beginning of the sequence of elements
-    ///                     that will be copied from
+    ///                     that will be moved from
     /// \param count        Refers to the number of elements starting at
     ///                     \a first the algorithm will be applied to.
     /// \param first2       Refers to the beginning of the destination range.
@@ -305,7 +305,7 @@ namespace hpx { namespace ranges {
     ///           returns \a FwdIter2 otherwise.
     ///           The \a uninitialized_move_n algorithm returns the output
     ///           iterator to the element in the destination range, one past
-    ///           the last element copied.
+    ///           the last element moved.
     ///
     template <typename ExPolicy, typename FwdIter1, typename Size,
         typename FwdIter2, typename Sent2>

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_memory.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_memory.hpp
@@ -8,4 +8,5 @@
 
 #include <hpx/parallel/memory.hpp>
 
+#include <hpx/parallel/container_algorithms/uninitialized_move.hpp>
 #include <hpx/parallel/container_algorithms/destroy.hpp>

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_memory.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_memory.hpp
@@ -8,5 +8,5 @@
 
 #include <hpx/parallel/memory.hpp>
 
-#include <hpx/parallel/container_algorithms/uninitialized_move.hpp>
 #include <hpx/parallel/container_algorithms/destroy.hpp>
+#include <hpx/parallel/container_algorithms/uninitialized_move.hpp>

--- a/libs/parallelism/algorithms/include/hpx/parallel/util/result_types.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/util/result_types.hpp
@@ -88,9 +88,24 @@ namespace hpx { namespace parallel { namespace util {
 
     ///////////////////////////////////////////////////////////////////////
     template <typename I, typename O>
+    std::pair<I, O> get_pair(util::in_out_result<I, O>&& p)
+    {
+        return std::pair<I, O>{p.in, p.out};
+    }
+
+    template <typename I, typename O>
     O get_second_element(util::in_out_result<I, O>&& p)
     {
         return p.out;
+    }
+
+    template <typename I, typename O>
+    hpx::future<std::pair<I, O>> get_pair(
+        hpx::future<util::in_out_result<I, O>>&& f)
+    {
+        return hpx::make_future<std::pair<I, O>>(std::move(f), [](util::in_out_result<I, O>&& p) {
+                return std::pair<I, O>{p.in, p.out};
+            });
     }
 
     template <typename I, typename O>

--- a/libs/parallelism/algorithms/include/hpx/parallel/util/result_types.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/util/result_types.hpp
@@ -103,7 +103,8 @@ namespace hpx { namespace parallel { namespace util {
     hpx::future<std::pair<I, O>> get_pair(
         hpx::future<util::in_out_result<I, O>>&& f)
     {
-        return hpx::make_future<std::pair<I, O>>(std::move(f), [](util::in_out_result<I, O>&& p) {
+        return hpx::make_future<std::pair<I, O>>(
+            std::move(f), [](util::in_out_result<I, O>&& p) {
                 return std::pair<I, O>{p.in, p.out};
             });
     }

--- a/libs/parallelism/algorithms/tests/unit/algorithms/uninitialized_move.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/uninitialized_move.cpp
@@ -17,6 +17,7 @@ template <typename IteratorTag>
 void test_uninitialized_move()
 {
     using namespace hpx::execution;
+    test_uninitialized_move(IteratorTag());
     test_uninitialized_move(seq, IteratorTag());
     test_uninitialized_move(par, IteratorTag());
     test_uninitialized_move(par_unseq, IteratorTag());

--- a/libs/parallelism/algorithms/tests/unit/algorithms/uninitialized_move_tests.hpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/uninitialized_move_tests.hpp
@@ -33,7 +33,7 @@ void test_uninitialized_move(ExPolicy&& policy, IteratorTag)
     std::vector<std::size_t> c(10007);
     std::vector<std::size_t> d(c.size());
     std::iota(std::begin(c), std::end(c), std::rand());
-    hpx::parallel::uninitialized_move(std::forward<ExPolicy>(policy),
+    hpx::uninitialized_move(std::forward<ExPolicy>(policy),
         iterator(std::begin(c)), iterator(std::end(c)), std::begin(d));
 
     std::size_t count = 0;
@@ -57,7 +57,7 @@ void test_uninitialized_move_async(ExPolicy&& p, IteratorTag)
     std::iota(std::begin(c), std::end(c), std::rand());
 
     hpx::future<base_iterator> f =
-        hpx::parallel::uninitialized_move(std::forward<ExPolicy>(p),
+        hpx::uninitialized_move(std::forward<ExPolicy>(p),
             iterator(std::begin(c)), iterator(std::end(c)), std::begin(d));
     f.wait();
 
@@ -92,7 +92,7 @@ void test_uninitialized_move_exception(ExPolicy policy, IteratorTag)
     bool caught_exception = false;
     try
     {
-        hpx::parallel::uninitialized_move(policy,
+        hpx::uninitialized_move(policy,
             decorated_iterator(std::begin(c),
                 [&throw_after]() {
                     if (throw_after-- == 0)
@@ -133,7 +133,7 @@ void test_uninitialized_move_exception_async(ExPolicy p, IteratorTag)
     bool returned_from_algorithm = false;
     try
     {
-        hpx::future<base_iterator> f = hpx::parallel::uninitialized_move(p,
+        hpx::future<base_iterator> f = hpx::uninitialized_move(p,
             decorated_iterator(std::begin(c),
                 [&throw_after]() {
                     if (throw_after-- == 0)
@@ -182,7 +182,7 @@ void test_uninitialized_move_bad_alloc(ExPolicy policy, IteratorTag)
     bool caught_bad_alloc = false;
     try
     {
-        hpx::parallel::uninitialized_move(policy,
+        hpx::uninitialized_move(policy,
             decorated_iterator(std::begin(c),
                 [&throw_after]() {
                     if (throw_after-- == 0)
@@ -223,7 +223,7 @@ void test_uninitialized_move_bad_alloc_async(ExPolicy p, IteratorTag)
     bool returned_from_algorithm = false;
     try
     {
-        hpx::future<base_iterator> f = hpx::parallel::uninitialized_move(p,
+        hpx::future<base_iterator> f = hpx::uninitialized_move(p,
             decorated_iterator(std::begin(c),
                 [&throw_after]() {
                     if (throw_after-- == 0)

--- a/libs/parallelism/algorithms/tests/unit/algorithms/uninitialized_move_tests.hpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/uninitialized_move_tests.hpp
@@ -21,6 +21,27 @@
 #include "test_utils.hpp"
 
 ////////////////////////////////////////////////////////////////////////////
+template <typename IteratorTag>
+void test_uninitialized_move(IteratorTag)
+{
+    typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+
+    std::vector<std::size_t> c(10007);
+    std::vector<std::size_t> d(c.size());
+    std::iota(std::begin(c), std::end(c), std::rand());
+    hpx::uninitialized_move(iterator(std::begin(c)), iterator(std::end(c)), std::begin(d));
+
+    std::size_t count = 0;
+    HPX_TEST(std::equal(std::begin(c), std::end(c), std::begin(d),
+        [&count](std::size_t v1, std::size_t v2) -> bool {
+            HPX_TEST_EQ(v1, v2);
+            ++count;
+            return v1 == v2;
+        }));
+    HPX_TEST_EQ(count, d.size());
+}
+
 template <typename ExPolicy, typename IteratorTag>
 void test_uninitialized_move(ExPolicy&& policy, IteratorTag)
 {

--- a/libs/parallelism/algorithms/tests/unit/algorithms/uninitialized_move_tests.hpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/uninitialized_move_tests.hpp
@@ -30,7 +30,8 @@ void test_uninitialized_move(IteratorTag)
     std::vector<std::size_t> c(10007);
     std::vector<std::size_t> d(c.size());
     std::iota(std::begin(c), std::end(c), std::rand());
-    hpx::uninitialized_move(iterator(std::begin(c)), iterator(std::end(c)), std::begin(d));
+    hpx::uninitialized_move(
+        iterator(std::begin(c)), iterator(std::end(c)), std::begin(d));
 
     std::size_t count = 0;
     HPX_TEST(std::equal(std::begin(c), std::end(c), std::begin(d),

--- a/libs/parallelism/algorithms/tests/unit/algorithms/uninitialized_moven.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/uninitialized_moven.cpp
@@ -32,7 +32,7 @@ void test_uninitialized_move_n(ExPolicy policy, IteratorTag)
     std::vector<std::size_t> d(c.size());
     std::iota(std::begin(c), std::end(c), std::rand());
 
-    hpx::parallel::uninitialized_move_n(
+    hpx::uninitialized_move_n(
         policy, iterator(std::begin(c)), c.size(), std::begin(d));
 
     std::size_t count = 0;
@@ -55,7 +55,7 @@ void test_uninitialized_move_n_async(ExPolicy p, IteratorTag)
     std::vector<std::size_t> d(c.size());
     std::iota(std::begin(c), std::end(c), std::rand());
 
-    auto f = hpx::parallel::uninitialized_move_n(
+    auto f = hpx::uninitialized_move_n(
         p, iterator(std::begin(c)), c.size(), std::begin(d));
     f.wait();
 
@@ -109,7 +109,7 @@ void test_uninitialized_move_n_exception(ExPolicy policy, IteratorTag)
     bool caught_exception = false;
     try
     {
-        hpx::parallel::uninitialized_move_n(policy,
+        hpx::uninitialized_move_n(policy,
             decorated_iterator(std::begin(c),
                 [&throw_after]() {
                     if (throw_after-- == 0)
@@ -150,7 +150,7 @@ void test_uninitialized_move_n_exception_async(ExPolicy p, IteratorTag)
     bool returned_from_algorithm = false;
     try
     {
-        auto f = hpx::parallel::uninitialized_move_n(p,
+        auto f = hpx::uninitialized_move_n(p,
             decorated_iterator(std::begin(c),
                 [&throw_after]() {
                     if (throw_after-- == 0)
@@ -220,7 +220,7 @@ void test_uninitialized_move_n_bad_alloc(ExPolicy policy, IteratorTag)
     bool caught_bad_alloc = false;
     try
     {
-        hpx::parallel::uninitialized_move_n(policy,
+        hpx::uninitialized_move_n(policy,
             decorated_iterator(std::begin(c),
                 [&throw_after]() {
                     if (throw_after-- == 0)
@@ -261,7 +261,7 @@ void test_uninitialized_move_n_bad_alloc_async(ExPolicy p, IteratorTag)
     bool returned_from_algorithm = false;
     try
     {
-        auto f = hpx::parallel::uninitialized_move_n(p,
+        auto f = hpx::uninitialized_move_n(p,
             decorated_iterator(std::begin(c),
                 [&throw_after]() {
                     if (throw_after-- == 0)

--- a/libs/parallelism/algorithms/tests/unit/algorithms/uninitialized_moven.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/uninitialized_moven.cpp
@@ -19,6 +19,28 @@
 #include "test_utils.hpp"
 
 ////////////////////////////////////////////////////////////////////////////
+template <typename IteratorTag>
+void test_uninitialized_move_n(IteratorTag)
+{
+    typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+
+    std::vector<std::size_t> c(10007);
+    std::vector<std::size_t> d(c.size());
+    std::iota(std::begin(c), std::end(c), std::rand());
+
+    hpx::uninitialized_move_n(iterator(std::begin(c)), c.size(), std::begin(d));
+
+    std::size_t count = 0;
+    HPX_TEST(std::equal(std::begin(c), std::end(c), std::begin(d),
+        [&count](std::size_t v1, std::size_t v2) -> bool {
+            HPX_TEST_EQ(v1, v2);
+            ++count;
+            return v1 == v2;
+        }));
+    HPX_TEST_EQ(count, d.size());
+}
+
 template <typename ExPolicy, typename IteratorTag>
 void test_uninitialized_move_n(ExPolicy policy, IteratorTag)
 {
@@ -72,6 +94,7 @@ void test_uninitialized_move_n_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_uninitialized_move_n()
 {
+    test_uninitialized_move_n(IteratorTag());
     test_uninitialized_move_n(hpx::execution::seq, IteratorTag());
     test_uninitialized_move_n(hpx::execution::par, IteratorTag());
     test_uninitialized_move_n(hpx::execution::par_unseq, IteratorTag());

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/CMakeLists.txt
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/CMakeLists.txt
@@ -94,6 +94,8 @@ set(tests
     transform_reduce_binary_exception_range
     transform_reduce_binary_range
     transform_reduce_range
+    uninitialized_move_range
+    uninitialized_move_n_range
     unique_range
     unique_copy_range
 )

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/uninitialized_move_n_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/uninitialized_move_n_range.cpp
@@ -1,0 +1,153 @@
+//  Copyright (c) 2014 Grant Mercer
+//  Copyright (c) 2015 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/iterator_support/iterator_range.hpp>
+#include <hpx/local/init.hpp>
+#include <hpx/modules/testing.hpp>
+#include <hpx/parallel/container_algorithms/uninitialized_move.hpp>
+
+#include <cstddef>
+#include <iostream>
+#include <iterator>
+#include <numeric>
+#include <string>
+#include <vector>
+
+#include <hpx/iterator_support/tests/iter_sent.hpp>
+#include "test_utils.hpp"
+
+////////////////////////////////////////////////////////////////////////////
+template <typename IteratorTag>
+void test_uninitialized_move_n_sent(IteratorTag)
+{
+    std::vector<std::size_t> c(10007);
+    std::vector<std::size_t> d(c.size());
+    std::iota(std::begin(c), std::end(c), std::rand());
+    std::copy(std::begin(c), std::end(c), std::rbegin(d));
+    std::size_t sent_len = (std::rand() % 10007) + 1;
+    hpx::ranges::uninitialized_move_n(std::begin(c), sent_len, std::begin(d),
+        sentinel<std::size_t>{*(std::begin(d) + sent_len)});
+
+    std::size_t count = 0;
+    // loop till for sent_len since either the sentinel for the input or output iterator
+    // will be reached by then
+    HPX_TEST(std::equal(std::begin(c), std::begin(c) + sent_len, std::begin(d),
+        [&count](std::size_t v1, std::size_t v2) -> bool {
+            HPX_TEST_EQ(v1, v2);
+            ++count;
+            return v1 == v2;
+        }));
+
+    HPX_TEST_EQ(count, sent_len);
+}
+
+template <typename ExPolicy, typename IteratorTag>
+void test_uninitialized_move_n_sent(ExPolicy&& policy, IteratorTag)
+{
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
+
+    std::vector<std::size_t> c(10007);
+    std::vector<std::size_t> d(c.size());
+    std::iota(std::begin(c), std::end(c), std::rand());
+    std::copy(std::begin(c), std::end(c), std::rbegin(d));
+    std::size_t sent_len = (std::rand() % 10007) + 1;
+    hpx::ranges::uninitialized_move_n(policy, std::begin(c), sent_len,
+        std::begin(d), sentinel<std::size_t>{*(std::begin(d) + sent_len)});
+
+    std::size_t count = 0;
+    // loop till for sent_len since either the sentinel for the input or output iterator
+    // will be reached by then
+    HPX_TEST(std::equal(std::begin(c), std::begin(c) + sent_len, std::begin(d),
+        [&count](std::size_t v1, std::size_t v2) -> bool {
+            HPX_TEST_EQ(v1, v2);
+            ++count;
+            return v1 == v2;
+        }));
+
+    HPX_TEST_EQ(count, sent_len);
+}
+
+template <typename ExPolicy, typename IteratorTag>
+void test_uninitialized_move_n_sent_async(ExPolicy&& p, IteratorTag)
+{
+    std::vector<std::size_t> c(10007);
+    std::vector<std::size_t> d(c.size());
+    std::iota(std::begin(c), std::end(c), std::rand());
+    std::copy(std::begin(c), std::end(c), std::rbegin(d));
+    std::size_t sent_len = (std::rand() % 10007) + 1;
+    auto f = hpx::ranges::uninitialized_move_n(p, std::begin(c), sent_len,
+        std::begin(d), sentinel<std::size_t>{*(std::begin(d) + sent_len)});
+    f.wait();
+
+    std::size_t count = 0;
+    HPX_TEST(std::equal(std::begin(c), std::begin(c) + sent_len, std::begin(d),
+        [&count](std::size_t v1, std::size_t v2) -> bool {
+            HPX_TEST_EQ(v1, v2);
+            ++count;
+            return v1 == v2;
+        }));
+    HPX_TEST_EQ(count, sent_len);
+}
+
+template <typename IteratorTag>
+void test_uninitialized_move_n_sent()
+{
+    using namespace hpx::execution;
+
+    test_uninitialized_move_n_sent(IteratorTag());
+
+    test_uninitialized_move_n_sent(seq, IteratorTag());
+    test_uninitialized_move_n_sent(par, IteratorTag());
+    test_uninitialized_move_n_sent(par_unseq, IteratorTag());
+
+    test_uninitialized_move_n_sent_async(seq(task), IteratorTag());
+    test_uninitialized_move_n_sent_async(par(task), IteratorTag());
+}
+
+void uninitialized_move_n_sent_test()
+{
+    test_uninitialized_move_n_sent<std::random_access_iterator_tag>();
+    test_uninitialized_move_n_sent<std::forward_iterator_tag>();
+}
+
+int hpx_main(hpx::program_options::variables_map& vm)
+{
+    unsigned int seed = (unsigned int) std::time(nullptr);
+    if (vm.count("seed"))
+        seed = vm["seed"].as<unsigned int>();
+
+    std::cout << "using seed: " << seed << std::endl;
+    std::srand(seed);
+
+    uninitialized_move_n_sent_test();
+    return hpx::local::finalize();
+}
+
+int main(int argc, char* argv[])
+{
+    // add command line option which controls the random number generator seed
+    using namespace hpx::program_options;
+    options_description desc_commandline(
+        "Usage: " HPX_APPLICATION_STRING " [options]");
+
+    desc_commandline.add_options()("seed,s", value<unsigned int>(),
+        "the random number generator seed to use for this run");
+
+    // By default this test should run on all available cores
+    std::vector<std::string> const cfg = {"hpx.os_threads=all"};
+
+    // Initialize and run HPX
+    hpx::local::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::local::init(hpx_main, argc, argv, init_args), 0,
+        "HPX main exited with non-zero status");
+
+    return hpx::util::report_errors();
+}

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/uninitialized_move_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/uninitialized_move_range.cpp
@@ -1,0 +1,493 @@
+//  Copyright (c) 2014 Grant Mercer
+//  Copyright (c) 2015 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/iterator_support/iterator_range.hpp>
+#include <hpx/local/init.hpp>
+#include <hpx/modules/testing.hpp>
+#include <hpx/parallel/container_algorithms/uninitialized_move.hpp>
+
+#include <cstddef>
+#include <iostream>
+#include <iterator>
+#include <numeric>
+#include <string>
+#include <vector>
+
+#include <hpx/iterator_support/tests/iter_sent.hpp>
+#include "test_utils.hpp"
+
+////////////////////////////////////////////////////////////////////////////
+template <typename IteratorTag>
+void test_uninitialized_move_sent(IteratorTag)
+{
+    std::vector<std::size_t> c(10007);
+    std::vector<std::size_t> d(c.size());
+    std::iota(std::begin(c), std::end(c), std::rand());
+    std::copy(std::begin(c), std::end(c), std::rbegin(d));
+    std::size_t sent_len = (std::rand() % 10007) + 1;
+    hpx::ranges::uninitialized_move(std::begin(c),
+        sentinel<std::size_t>{*(std::begin(c) + sent_len)}, std::begin(d),
+        sentinel<std::size_t>{*(std::begin(d) + sent_len)});
+
+    std::size_t count = 0;
+    // loop till for sent_len since either the sentinel for the input or output iterator
+    // will be reached by then
+    HPX_TEST(std::equal(std::begin(c), std::begin(c) + sent_len, std::begin(d),
+        [&count](std::size_t v1, std::size_t v2) -> bool {
+            HPX_TEST_EQ(v1, v2);
+            ++count;
+            return v1 == v2;
+        }));
+
+    HPX_TEST_EQ(count, sent_len);
+}
+
+template <typename ExPolicy, typename IteratorTag>
+void test_uninitialized_move_sent(ExPolicy&& policy, IteratorTag)
+{
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
+
+    std::vector<std::size_t> c(10007);
+    std::vector<std::size_t> d(c.size());
+    std::iota(std::begin(c), std::end(c), std::rand());
+    std::copy(std::begin(c), std::end(c), std::rbegin(d));
+    std::size_t sent_len = (std::rand() % 10007) + 1;
+    hpx::ranges::uninitialized_move(policy, std::begin(c),
+        sentinel<std::size_t>{*(std::begin(c) + sent_len)}, std::begin(d),
+        sentinel<std::size_t>{*(std::begin(d) + sent_len)});
+
+    std::size_t count = 0;
+    // loop till for sent_len since either the sentinel for the input or output iterator
+    // will be reached by then
+    HPX_TEST(std::equal(std::begin(c), std::begin(c) + sent_len, std::begin(d),
+        [&count](std::size_t v1, std::size_t v2) -> bool {
+            HPX_TEST_EQ(v1, v2);
+            ++count;
+            return v1 == v2;
+        }));
+
+    HPX_TEST_EQ(count, sent_len);
+}
+
+template <typename ExPolicy, typename IteratorTag>
+void test_uninitialized_move_sent_async(ExPolicy&& p, IteratorTag)
+{
+    std::vector<std::size_t> c(10007);
+    std::vector<std::size_t> d(c.size());
+    std::iota(std::begin(c), std::end(c), std::rand());
+    std::copy(std::begin(c), std::end(c), std::rbegin(d));
+    std::size_t sent_len = (std::rand() % 10007) + 1;
+    auto f = hpx::ranges::uninitialized_move(p, std::begin(c),
+        sentinel<std::size_t>{*(std::begin(c) + sent_len)}, std::begin(d),
+        sentinel<std::size_t>{*(std::begin(d) + sent_len)});
+    f.wait();
+
+    std::size_t count = 0;
+    HPX_TEST(std::equal(std::begin(c), std::begin(c) + sent_len, std::begin(d),
+        [&count](std::size_t v1, std::size_t v2) -> bool {
+            HPX_TEST_EQ(v1, v2);
+            ++count;
+            return v1 == v2;
+        }));
+    HPX_TEST_EQ(count, sent_len);
+}
+
+template <typename IteratorTag>
+void test_uninitialized_move_sent()
+{
+    using namespace hpx::execution;
+
+    test_uninitialized_move_sent(IteratorTag());
+
+    test_uninitialized_move_sent(seq, IteratorTag());
+    test_uninitialized_move_sent(par, IteratorTag());
+    test_uninitialized_move_sent(par_unseq, IteratorTag());
+
+    test_uninitialized_move_sent_async(seq(task), IteratorTag());
+    test_uninitialized_move_sent_async(par(task), IteratorTag());
+}
+
+void uninitialized_move_sent_test()
+{
+    test_uninitialized_move_sent<std::random_access_iterator_tag>();
+    test_uninitialized_move_sent<std::forward_iterator_tag>();
+}
+
+////////////////////////////////////////////////////////////////////////////
+template <typename IteratorTag>
+void test_uninitialized_move(IteratorTag)
+{
+    using test_vector =
+        typename test::test_container<std::vector<std::size_t>, IteratorTag>;
+
+    test_vector c(10007);
+    test_vector d(c.size());
+    std::iota(std::begin(c), std::end(c), std::rand());
+    hpx::ranges::uninitialized_move(c, d);
+
+    std::size_t count = 0;
+    HPX_TEST(std::equal(std::begin(c), std::end(c), std::begin(d),
+        [&count](std::size_t v1, std::size_t v2) -> bool {
+            HPX_TEST_EQ(v1, v2);
+            ++count;
+            return v1 == v2;
+        }));
+    HPX_TEST_EQ(count, d.size());
+}
+
+template <typename ExPolicy, typename IteratorTag>
+void test_uninitialized_move(ExPolicy&& policy, IteratorTag)
+{
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
+
+    using test_vector =
+        typename test::test_container<std::vector<std::size_t>, IteratorTag>;
+
+    test_vector c(10007);
+    test_vector d(c.size());
+    std::iota(std::begin(c), std::end(c), std::rand());
+    hpx::ranges::uninitialized_move(policy, c, d);
+
+    std::size_t count = 0;
+    HPX_TEST(std::equal(std::begin(c), std::end(c), std::begin(d),
+        [&count](std::size_t v1, std::size_t v2) -> bool {
+            HPX_TEST_EQ(v1, v2);
+            ++count;
+            return v1 == v2;
+        }));
+    HPX_TEST_EQ(count, d.size());
+}
+
+template <typename ExPolicy, typename IteratorTag>
+void test_uninitialized_move_async(ExPolicy&& p, IteratorTag)
+{
+    using test_vector =
+        typename test::test_container<std::vector<std::size_t>, IteratorTag>;
+
+    test_vector c(10007);
+    test_vector d(c.size());
+    std::iota(std::begin(c), std::end(c), std::rand());
+
+    auto f = hpx::ranges::uninitialized_move(p, c, d);
+    f.wait();
+
+    std::size_t count = 0;
+    HPX_TEST(std::equal(std::begin(c), std::end(c), std::begin(d),
+        [&count](std::size_t v1, std::size_t v2) -> bool {
+            HPX_TEST_EQ(v1, v2);
+            ++count;
+            return v1 == v2;
+        }));
+    HPX_TEST_EQ(count, d.size());
+}
+
+template <typename IteratorTag>
+void test_uninitialized_move()
+{
+    using namespace hpx::execution;
+
+    test_uninitialized_move(IteratorTag());
+
+    test_uninitialized_move(seq, IteratorTag());
+    test_uninitialized_move(par, IteratorTag());
+    test_uninitialized_move(par_unseq, IteratorTag());
+
+    test_uninitialized_move_async(seq(task), IteratorTag());
+    test_uninitialized_move_async(par(task), IteratorTag());
+}
+
+void uninitialized_move_test()
+{
+    test_uninitialized_move<std::random_access_iterator_tag>();
+    test_uninitialized_move<std::forward_iterator_tag>();
+}
+
+///////////////////////////////////////////////////////////////////////////////
+template <typename IteratorTag>
+void test_uninitialized_move_exception(IteratorTag)
+{
+    using base_iterator = typename std::vector<std::size_t>::iterator;
+    using decorated_iterator =
+        typename test::decorated_iterator<base_iterator, IteratorTag>;
+    using test_vector =
+        typename test::test_container<std::vector<std::size_t>, IteratorTag>;
+
+    std::vector<std::size_t> c(10007);
+    test_vector d(c.size());
+    std::iota(std::begin(c), std::end(c), std::rand());
+
+    bool caught_exception = false;
+    try
+    {
+        hpx::ranges::uninitialized_move(
+            hpx::util::make_iterator_range(
+                decorated_iterator(
+                    std::begin(c), []() { throw std::runtime_error("test"); }),
+                decorated_iterator(std::end(c))),
+            d);
+        HPX_TEST(false);
+    }
+    catch (hpx::exception_list const& e)
+    {
+        caught_exception = true;
+        test::test_num_exceptions<hpx::execution::sequenced_policy,
+            IteratorTag>::call(hpx::execution::seq, e);
+    }
+    catch (...)
+    {
+        HPX_TEST(false);
+    }
+
+    HPX_TEST(caught_exception);
+}
+
+template <typename ExPolicy, typename IteratorTag>
+void test_uninitialized_move_exception(ExPolicy&& policy, IteratorTag)
+{
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
+
+    using base_iterator = typename std::vector<std::size_t>::iterator;
+    using decorated_iterator =
+        typename test::decorated_iterator<base_iterator, IteratorTag>;
+    using test_vector =
+        typename test::test_container<std::vector<std::size_t>, IteratorTag>;
+
+    std::vector<std::size_t> c(10007);
+    test_vector d(c.size());
+    std::iota(std::begin(c), std::end(c), std::rand());
+
+    bool caught_exception = false;
+    try
+    {
+        hpx::ranges::uninitialized_move(policy,
+            hpx::util::make_iterator_range(
+                decorated_iterator(
+                    std::begin(c), []() { throw std::runtime_error("test"); }),
+                decorated_iterator(std::end(c))),
+            d);
+        HPX_TEST(false);
+    }
+    catch (hpx::exception_list const& e)
+    {
+        caught_exception = true;
+        test::test_num_exceptions<ExPolicy, IteratorTag>::call(policy, e);
+    }
+    catch (...)
+    {
+        HPX_TEST(false);
+    }
+
+    HPX_TEST(caught_exception);
+}
+
+template <typename ExPolicy, typename IteratorTag>
+void test_uninitialized_move_exception_async(ExPolicy&& p, IteratorTag)
+{
+    using base_iterator = typename std::vector<std::size_t>::iterator;
+    using decorated_iterator =
+        typename test::decorated_iterator<base_iterator, IteratorTag>;
+    using test_vector =
+        typename test::test_container<std::vector<std::size_t>, IteratorTag>;
+
+    std::vector<std::size_t> c(10007);
+    test_vector d(c.size());
+    std::iota(std::begin(c), std::end(c), std::rand());
+
+    bool caught_exception = false;
+    bool returned_from_algorithm = false;
+    try
+    {
+        auto f = hpx::ranges::uninitialized_move(p,
+            hpx::util::make_iterator_range(
+                decorated_iterator(
+                    std::begin(c), []() { throw std::runtime_error("test"); }),
+                decorated_iterator(std::end(c))),
+            d);
+        returned_from_algorithm = true;
+        f.get();
+
+        HPX_TEST(false);
+    }
+    catch (hpx::exception_list const& e)
+    {
+        caught_exception = true;
+        test::test_num_exceptions<ExPolicy, IteratorTag>::call(p, e);
+    }
+    catch (...)
+    {
+        HPX_TEST(false);
+    }
+
+    HPX_TEST(caught_exception);
+    HPX_TEST(returned_from_algorithm);
+}
+
+template <typename IteratorTag>
+void test_uninitialized_move_exception()
+{
+    using namespace hpx::execution;
+
+    // If the execution policy object is of type vector_execution_policy,
+    // std::terminate shall be called. therefore we do not test exceptions
+    // with a vector execution policy
+    test_uninitialized_move_exception(seq, IteratorTag());
+    test_uninitialized_move_exception(par, IteratorTag());
+
+    test_uninitialized_move_exception_async(seq(task), IteratorTag());
+    test_uninitialized_move_exception_async(par(task), IteratorTag());
+}
+
+void uninitialized_move_exception_test()
+{
+    test_uninitialized_move_exception<std::random_access_iterator_tag>();
+    test_uninitialized_move_exception<std::forward_iterator_tag>();
+}
+
+//////////////////////////////////////////////////////////////////////////////
+template <typename ExPolicy, typename IteratorTag>
+void test_uninitialized_move_bad_alloc(ExPolicy&& policy, IteratorTag)
+{
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
+
+    using base_iterator = typename std::vector<std::size_t>::iterator;
+    using decorated_iterator =
+        typename test::decorated_iterator<base_iterator, IteratorTag>;
+    using test_vector =
+        typename test::test_container<std::vector<std::size_t>, IteratorTag>;
+
+    std::vector<std::size_t> c(10007);
+    test_vector d(c.size());
+    std::iota(std::begin(c), std::end(c), std::rand());
+
+    bool caught_bad_alloc = false;
+    try
+    {
+        hpx::ranges::uninitialized_move(policy,
+            hpx::util::make_iterator_range(
+                decorated_iterator(
+                    std::begin(c), []() { throw std::bad_alloc(); }),
+                decorated_iterator(std::end(c))),
+            d);
+        HPX_TEST(false);
+    }
+    catch (std::bad_alloc const&)
+    {
+        caught_bad_alloc = true;
+    }
+    catch (...)
+    {
+        HPX_TEST(false);
+    }
+
+    HPX_TEST(caught_bad_alloc);
+}
+
+template <typename ExPolicy, typename IteratorTag>
+void test_uninitialized_move_bad_alloc_async(ExPolicy&& p, IteratorTag)
+{
+    using base_iterator = typename std::vector<std::size_t>::iterator;
+    using decorated_iterator =
+        typename test::decorated_iterator<base_iterator, IteratorTag>;
+    using test_vector =
+        typename test::test_container<std::vector<std::size_t>, IteratorTag>;
+
+    std::vector<std::size_t> c(10007);
+    test_vector d(c.size());
+    std::iota(std::begin(c), std::end(c), std::rand());
+
+    bool caught_bad_alloc = false;
+    bool returned_from_algorithm = false;
+    try
+    {
+        auto f = hpx::ranges::uninitialized_move(p,
+            hpx::util::make_iterator_range(
+                decorated_iterator(
+                    std::begin(c), []() { throw std::bad_alloc(); }),
+                decorated_iterator(std::end(c))),
+            d);
+        returned_from_algorithm = true;
+        f.get();
+
+        HPX_TEST(false);
+    }
+    catch (std::bad_alloc const&)
+    {
+        caught_bad_alloc = true;
+    }
+    catch (...)
+    {
+        HPX_TEST(false);
+    }
+
+    HPX_TEST(caught_bad_alloc);
+    HPX_TEST(returned_from_algorithm);
+}
+
+template <typename IteratorTag>
+void test_uninitialized_move_bad_alloc()
+{
+    using namespace hpx::execution;
+
+    // If the execution policy object is of type vector_execution_policy,
+    // std::terminate shall be called. therefore we do not test exceptions
+    // with a vector execution policy
+    test_uninitialized_move_bad_alloc(seq, IteratorTag());
+    test_uninitialized_move_bad_alloc(par, IteratorTag());
+
+    test_uninitialized_move_bad_alloc_async(seq(task), IteratorTag());
+    test_uninitialized_move_bad_alloc_async(par(task), IteratorTag());
+}
+
+void uninitialized_move_bad_alloc_test()
+{
+    test_uninitialized_move_bad_alloc<std::random_access_iterator_tag>();
+    test_uninitialized_move_bad_alloc<std::forward_iterator_tag>();
+}
+
+int hpx_main(hpx::program_options::variables_map& vm)
+{
+    unsigned int seed = (unsigned int) std::time(nullptr);
+    if (vm.count("seed"))
+        seed = vm["seed"].as<unsigned int>();
+
+    std::cout << "using seed: " << seed << std::endl;
+    std::srand(seed);
+
+    uninitialized_move_test();
+    uninitialized_move_sent_test();
+    uninitialized_move_exception_test();
+    uninitialized_move_bad_alloc_test();
+    return hpx::local::finalize();
+}
+
+int main(int argc, char* argv[])
+{
+    // add command line option which controls the random number generator seed
+    using namespace hpx::program_options;
+    options_description desc_commandline(
+        "Usage: " HPX_APPLICATION_STRING " [options]");
+
+    desc_commandline.add_options()("seed,s", value<unsigned int>(),
+        "the random number generator seed to use for this run");
+
+    // By default this test should run on all available cores
+    std::vector<std::string> const cfg = {"hpx.os_threads=all"};
+
+    // Initialize and run HPX
+    hpx::local::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::local::init(hpx_main, argc, argv, init_args), 0,
+        "HPX main exited with non-zero status");
+
+    return hpx::util::report_errors();
+}


### PR DESCRIPTION
Adapted uninitialized _move and uninitialized_move_n to C++ 20 and added container overloads. (range and sentinel). Added container tests.

## Any background context you want to provide?
Issue #4822
Issue #3646
Issue #1668