### PR TITLE
Make sure shared priority scheduler steals tasks on the current NUMA domain when (core) stealing is enabled

### DIFF
--- a/libs/core/schedulers/include/hpx/schedulers/shared_priority_queue_scheduler.hpp
+++ b/libs/core/schedulers/include/hpx/schedulers/shared_priority_queue_scheduler.hpp
@@ -535,7 +535,8 @@ namespace hpx { namespace threads { namespace policies {
                         debug::dec<2>(domain), "Q", debug::dec<3>(q_index));
                     return result;
                 }
-                if (!steal_numa)
+
+                if (steal_core)
                 {
                     if (q_counts_[domain] > 1)
                     {
@@ -556,7 +557,8 @@ namespace hpx { namespace threads { namespace policies {
                         }
                     }
                 }
-                else
+
+                if (steal_numa)
                 {
                     // try other numa domains BP/HP
                     for (std::size_t d = 1; d < num_domains_; ++d)


### PR DESCRIPTION
I've re-enabled the cross pool injection test with the shared priority scheduler in the hopes that this maybe fixes the hangs there, but have not tested it myself. Edit: this does not seem to fix that particular problem, so I'm leaving it disabled.