### PR TITLE
Fixing wrong usage of std::forward

### DIFF
--- a/libs/full/collectives/include/hpx/collectives/gather.hpp
+++ b/libs/full/collectives/include/hpx/collectives/gather.hpp
@@ -260,8 +260,8 @@ namespace hpx { namespace collectives {
 
             // make sure id is kept alive as long as the returned future,
             // explicitly unwrap returned future
-            hpx::future<std::vector<arg_type>> result = async(
-                action_type(), c, this_site, std::forward<T>(local_result));
+            hpx::future<std::vector<arg_type>> result =
+                async(action_type(), c, this_site, std::move(local_result));
 
             traits::detail::get_shared_state(result)->set_on_completed(
                 [client = std::move(c)]() { HPX_UNUSED(client); });
@@ -307,8 +307,8 @@ namespace hpx { namespace collectives {
 
             // make sure id is kept alive as long as the returned future,
             // explicitly unwrap returned future
-            hpx::future<void> result = async(
-                action_type(), c, this_site, std::forward<T>(local_result));
+            hpx::future<void> result =
+                async(action_type(), c, this_site, std::move(local_result));
 
             traits::detail::get_shared_state(result)->set_on_completed(
                 [client = std::move(c)]() { HPX_UNUSED(client); });


### PR DESCRIPTION
@msimberg sorry for this oversight... Could we add this to the release, please?