### PR TITLE
Modernize a variety of facilities related to parallel algorithms

### DIFF
--- a/libs/core/thread_support/include/hpx/thread_support/spinlock.hpp
+++ b/libs/core/thread_support/include/hpx/thread_support/spinlock.hpp
@@ -29,12 +29,12 @@ namespace hpx { namespace util { namespace detail {
         HPX_CORE_EXPORT void yield_k(unsigned) noexcept;
 
     public:
-        spinlock() noexcept
+        constexpr spinlock() noexcept
           : m(false)
         {
         }
 
-        bool try_lock() noexcept
+        HPX_FORCEINLINE bool try_lock() noexcept
         {
             // First do a relaxed load to check if lock is free in order to prevent
             // unnecessary cache misses if someone does while(!try_lock())
@@ -56,7 +56,7 @@ namespace hpx { namespace util { namespace detail {
             } while (!try_lock());
         }
 
-        void unlock() noexcept
+        HPX_FORCEINLINE void unlock() noexcept
         {
             m.store(false, std::memory_order_release);
         }

--- a/libs/full/segmented_algorithms/include/hpx/parallel/segmented_algorithms/detail/scan.hpp
+++ b/libs/full/segmented_algorithms/include/hpx/parallel/segmented_algorithms/detail/scan.hpp
@@ -94,8 +94,8 @@ namespace hpx { namespace parallel { inline namespace v1 {
                         if (part_size > 1)
                         {
                             // MSVC complains if 'op' is captured by reference
-                            util::detail::loop_n<execution_policy_type>(
-                                part_begin + 1, part_size - 1,
+                            util::loop_n<execution_policy_type>(part_begin + 1,
+                                part_size - 1,
                                 [&ret, op, conv](FwdIter const& curr) {
                                     ret = hpx::util::invoke(op, ret,
                                         hpx::util::invoke(conv, *curr));
@@ -108,7 +108,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                         if (results.size() > 1)
                         {
                             // MSVC complains if 'op' is captured by reference
-                            util::detail::loop_n<execution_policy_type>(
+                            util::loop_n<execution_policy_type>(
                                 results.begin() + 1, results.size() - 1,
                                 [&ret, op](
                                     typename std::vector<T>::iterator const&

--- a/libs/parallelism/algorithms/include/hpx/algorithms/traits/projected.hpp
+++ b/libs/parallelism/algorithms/include/hpx/algorithms/traits/projected.hpp
@@ -158,6 +158,13 @@ namespace hpx { namespace parallel { namespace traits {
     {
     };
 
+    template <typename F, typename Iter>
+    using is_projected_t = typename is_projected<F, Iter>::type;
+
+    template <typename F, typename Iter>
+    HPX_INLINE_CONSTEXPR_VARIABLE bool is_projected_v =
+        is_projected<F, Iter>::value;
+
     ///////////////////////////////////////////////////////////////////////////
     template <typename Proj, typename Iter>
     struct projected
@@ -235,4 +242,13 @@ namespace hpx { namespace parallel { namespace traits {
             hpx::util::pack<typename std::decay<Projected>::type...>>
     {
     };
+
+    template <typename ExPolicy, typename F, typename... Projected>
+    using is_indirect_callable_t =
+        typename is_indirect_callable<ExPolicy, F, Projected...>::type;
+
+    template <typename ExPolicy, typename F, typename... Projected>
+    HPX_INLINE_CONSTEXPR_VARIABLE bool is_indirect_callable_v =
+        is_indirect_callable<ExPolicy, F, Projected...>::value;
+
 }}}    // namespace hpx::parallel::traits

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/adjacent_difference.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/adjacent_difference.hpp
@@ -82,7 +82,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                               std::size_t part_size) mutable {
                     // VS2015RC bails out when op is captured by ref
                     using hpx::get;
-                    util::detail::loop_n<std::decay_t<ExPolicy>>(
+                    util::loop_n<std::decay_t<ExPolicy>>(
                         part_begin, part_size, [op](zip_iterator it) {
                             get<2>(*it) =
                                 hpx::util::invoke(op, get<0>(*it), get<1>(*it));

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/all_any_none.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/all_any_none.hpp
@@ -292,9 +292,8 @@ namespace hpx { namespace parallel { inline namespace v1 {
                               proj = std::forward<Proj>(proj)](
                               FwdIter part_begin,
                               std::size_t part_count) mutable -> bool {
-                    util::detail::loop_n<std::decay_t<ExPolicy>>(part_begin,
-                        part_count, tok,
-                        [&op, &tok, &proj](FwdIter const& curr) {
+                    util::loop_n<std::decay_t<ExPolicy>>(part_begin, part_count,
+                        tok, [&op, &tok, &proj](FwdIter const& curr) {
                             if (hpx::util::invoke(
                                     op, hpx::util::invoke(proj, *curr)))
                             {
@@ -392,9 +391,8 @@ namespace hpx { namespace parallel { inline namespace v1 {
                               proj = std::forward<Proj>(proj)](
                               FwdIter part_begin,
                               std::size_t part_count) mutable -> bool {
-                    util::detail::loop_n<std::decay_t<ExPolicy>>(part_begin,
-                        part_count, tok,
-                        [&op, &tok, &proj](FwdIter const& curr) {
+                    util::loop_n<std::decay_t<ExPolicy>>(part_begin, part_count,
+                        tok, [&op, &tok, &proj](FwdIter const& curr) {
                             if (hpx::util::invoke(
                                     op, hpx::util::invoke(proj, *curr)))
                             {
@@ -492,9 +490,8 @@ namespace hpx { namespace parallel { inline namespace v1 {
                               proj = std::forward<Proj>(proj)](
                               FwdIter part_begin,
                               std::size_t part_count) mutable -> bool {
-                    util::detail::loop_n<std::decay_t<ExPolicy>>(part_begin,
-                        part_count, tok,
-                        [&op, &tok, &proj](FwdIter const& curr) {
+                    util::loop_n<std::decay_t<ExPolicy>>(part_begin, part_count,
+                        tok, [&op, &tok, &proj](FwdIter const& curr) {
                             if (!hpx::util::invoke(
                                     op, hpx::util::invoke(proj, *curr)))
                             {

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/copy.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/copy.hpp
@@ -550,8 +550,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                     std::size_t curr = 0;
 
                     // MSVC complains if proj is captured by ref below
-                    util::detail::loop_n<std::decay_t<ExPolicy>>(part_begin,
-                        part_size,
+                    util::loop_n<std::decay_t<ExPolicy>>(part_begin, part_size,
                         [&pred, proj, &curr](zip_iterator it) mutable {
                             bool f = hpx::util::invoke(
                                 pred, hpx::util::invoke(proj, get<0>(*it)));
@@ -571,8 +570,8 @@ namespace hpx { namespace parallel { inline namespace v1 {
                     next.get();    // rethrow exceptions
 
                     std::advance(dest, curr.get());
-                    util::detail::loop_n<std::decay_t<ExPolicy>>(part_begin,
-                        part_size, [&dest](zip_iterator it) mutable {
+                    util::loop_n<std::decay_t<ExPolicy>>(part_begin, part_size,
+                        [&dest](zip_iterator it) mutable {
                             if (get<1>(*it))
                                 *dest++ = get<0>(*it);
                         });

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/count.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/count.hpp
@@ -155,9 +155,9 @@ namespace hpx {
 #include <hpx/config.hpp>
 #include <hpx/algorithms/traits/segmented_iterator_traits.hpp>
 #include <hpx/concepts/concepts.hpp>
+#include <hpx/functional/bind_back.hpp>
 #include <hpx/functional/invoke.hpp>
 #include <hpx/functional/tag_fallback_dispatch.hpp>
-#include <hpx/functional/bind_back.hpp>
 #include <hpx/iterator_support/range.hpp>
 #include <hpx/iterator_support/traits/is_iterator.hpp>
 #include <hpx/pack_traversal/unwrap.hpp>
@@ -232,8 +232,8 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 operator()(Iter part_begin, std::size_t part_size)
             {
                 typename std::iterator_traits<Iter>::difference_type ret = 0;
-                util::detail::loop_n<execution_policy_type>(part_begin,
-                    part_size, hpx::util::bind_back(*this, std::ref(ret)));
+                util::loop_n<execution_policy_type>(part_begin, part_size,
+                    hpx::util::bind_back(*this, std::ref(ret)));
                 return ret;
             }
 

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/destroy.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/destroy.hpp
@@ -162,7 +162,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
             return util::foreach_partitioner<ExPolicy>::call(
                 std::forward<ExPolicy>(policy), first, count,
                 [](Iter first, std::size_t count, std::size_t) {
-                    return util::detail::loop_n<std::decay_t<ExPolicy>>(
+                    return util::loop_n<std::decay_t<ExPolicy>>(
                         first, count, [](Iter it) -> void {
                             using value_type =
                                 typename std::iterator_traits<Iter>::value_type;

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/equal.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/equal.hpp
@@ -285,8 +285,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                               proj2 = std::forward<Proj2>(proj2)](
                               zip_iterator it,
                               std::size_t part_count) mutable -> bool {
-                    util::detail::loop_n<std::decay_t<ExPolicy>>(it, part_count,
-                        tok,
+                    util::loop_n<std::decay_t<ExPolicy>>(it, part_count, tok,
                         [&f, &proj1, &proj2, &tok](zip_iterator const& curr) {
                             reference t = *curr;
                             if (!hpx::util::invoke(f,
@@ -391,8 +390,8 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 util::cancellation_token<> tok;
                 auto f1 = [f, tok](zip_iterator it,
                               std::size_t part_count) mutable -> bool {
-                    util::detail::loop_n<std::decay_t<ExPolicy>>(it, part_count,
-                        tok, [&f, &tok](zip_iterator const& curr) {
+                    util::loop_n<std::decay_t<ExPolicy>>(it, part_count, tok,
+                        [&f, &tok](zip_iterator const& curr) {
                             reference t = *curr;
                             if (!hpx::util::invoke(
                                     f, hpx::get<0>(t), hpx::get<1>(t)))

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/exclusive_scan.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/exclusive_scan.hpp
@@ -130,7 +130,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                     *dst++ = val;
 
                     // MSVC 2015 fails if op is captured by reference
-                    util::detail::loop_n<std::decay_t<ExPolicy>>(
+                    util::loop_n<std::decay_t<ExPolicy>>(
                         dst, part_size - 1, [=, &val](FwdIter2 it) {
                             *it = hpx::util::invoke(op, val, *it);
                         });

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/for_each.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/for_each.hpp
@@ -350,8 +350,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
             HPX_HOST_DEVICE HPX_FORCEINLINE constexpr void execute(
                 Iter part_begin, std::size_t part_size)
             {
-                util::detail::loop_n<execution_policy_type>(part_begin,
-                    part_size,
+                util::loop_n<execution_policy_type>(part_begin, part_size,
                     invoke_projected<fun_type, proj_type>{f_, proj_});
             }
 
@@ -403,7 +402,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
             HPX_HOST_DEVICE HPX_FORCEINLINE constexpr void execute(
                 Iter part_begin, std::size_t part_size, std::true_type)
             {
-                util::detail::loop_n<execution_policy_type>(
+                util::loop_n<execution_policy_type>(
                     part_begin, part_size, invoke_projected<F>(f_));
             }
 
@@ -411,7 +410,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
             HPX_HOST_DEVICE HPX_FORCEINLINE constexpr void execute(
                 Iter part_begin, std::size_t part_size, std::false_type)
             {
-                util::detail::loop_n_ind<execution_policy_type>(
+                util::loop_n_ind<execution_policy_type>(
                     part_begin, part_size, f_);
             }
 
@@ -465,8 +464,8 @@ namespace hpx { namespace parallel { inline namespace v1 {
             HPX_HOST_DEVICE static constexpr Iter sequential(
                 ExPolicy&&, InIter first, std::size_t count, F&& f, Proj&& proj)
             {
-                return util::detail::loop_n<std::decay_t<ExPolicy>>(first,
-                    count, invoke_projected<F, std::decay_t<Proj>>{f, proj});
+                return util::loop_n<std::decay_t<ExPolicy>>(first, count,
+                    invoke_projected<F, std::decay_t<Proj>>{f, proj});
             }
 
             template <typename ExPolicy, typename InIter, typename F>
@@ -474,7 +473,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 InIter first, std::size_t count, F&& f,
                 util::projection_identity)
             {
-                return util::detail::loop_n_ind<std::decay_t<ExPolicy>>(
+                return util::loop_n_ind<std::decay_t<ExPolicy>>(
                     first, count, std::forward<F>(f));
             }
 
@@ -523,7 +522,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
             sequential(
                 ExPolicy&&, InIterB first, InIterE last, F&& f, Proj&& proj)
             {
-                return util::detail::loop_n<std::decay_t<ExPolicy>>(first,
+                return util::loop_n<std::decay_t<ExPolicy>>(first,
                     static_cast<std::size_t>(detail::distance(first, last)),
                     invoke_projected<F, std::decay_t<Proj>>{f, proj});
             }
@@ -548,7 +547,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
             sequential(ExPolicy&&, InIterB first, InIterE last, F&& f,
                 util::projection_identity)
             {
-                return util::detail::loop_n_ind<std::decay_t<ExPolicy>>(first,
+                return util::loop_n_ind<std::decay_t<ExPolicy>>(first,
                     static_cast<std::size_t>(detail::distance(first, last)),
                     std::forward<F>(f));
             }

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/for_each.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/for_each.hpp
@@ -385,7 +385,6 @@ namespace hpx { namespace parallel { inline namespace v1 {
             HPX_HOST_DEVICE HPX_FORCEINLINE void operator()(Iter part_begin,
                 std::size_t part_size, std::size_t /*part_index*/)
             {
-                hpx::util::annotate_function annotate(f_);
                 execute(part_begin, part_size);
             }
         };

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/inclusive_scan.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/inclusive_scan.hpp
@@ -147,7 +147,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                     FwdIter2 dst = get<1>(part_begin.get_iterator_tuple());
 
                     // MSVC 2015 fails if op is captured by reference
-                    util::detail::loop_n<std::decay_t<ExPolicy>>(
+                    util::loop_n<std::decay_t<ExPolicy>>(
                         dst, part_size, [=, &val](FwdIter2 it) {
                             *it = hpx::util::invoke(op, val, *it);
                         });

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/is_partitioned.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/is_partitioned.hpp
@@ -198,7 +198,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                     if (part_count == 1)
                         return fst_bool;
 
-                    util::detail::loop_n<std::decay_t<ExPolicy>>(++part_begin,
+                    util::loop_n<std::decay_t<ExPolicy>>(++part_begin,
                         --part_count, tok,
                         [&fst_bool, &pred_projected, &tok](
                             Iter const& a) -> void {

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/is_sorted.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/is_sorted.hpp
@@ -290,7 +290,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                               FwdIter part_begin,
                               std::size_t part_size) mutable -> bool {
                     FwdIter trail = part_begin++;
-                    util::detail::loop_n<std::decay_t<ExPolicy>>(part_begin,
+                    util::loop_n<std::decay_t<ExPolicy>>(part_begin,
                         part_size - 1,
                         [&trail, &tok, &pred_projected](FwdIter it) -> void {
                             if (hpx::util::invoke(

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/minmax.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/minmax.hpp
@@ -50,7 +50,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
 
             FwdIter smallest = it;
 
-            util::detail::loop_n<std::decay_t<ExPolicy>>(++it, count - 1,
+            util::loop_n<std::decay_t<ExPolicy>>(++it, count - 1,
                 [&f, &smallest, &proj, value = HPX_INVOKE(proj, *smallest)](
                     FwdIter const& curr) mutable -> void {
                     auto curr_value = HPX_INVOKE(proj, *curr);
@@ -83,7 +83,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
 
                 auto smallest = *it;
 
-                util::detail::loop_n<std::decay_t<ExPolicy>>(++it, count - 1,
+                util::loop_n<std::decay_t<ExPolicy>>(++it, count - 1,
                     [&f, &smallest, &proj, value = HPX_INVOKE(proj, *smallest)](
                         FwdIter const& curr) mutable -> void {
                         auto curr_value = HPX_INVOKE(proj, **curr);
@@ -267,7 +267,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
 
             FwdIter greatest = it;
 
-            util::detail::loop_n<std::decay_t<ExPolicy>>(++it, count - 1,
+            util::loop_n<std::decay_t<ExPolicy>>(++it, count - 1,
                 [&f, &greatest, &proj, value = HPX_INVOKE(proj, *greatest)](
                     FwdIter const& curr) mutable -> void {
                     auto curr_value = HPX_INVOKE(proj, *curr);
@@ -300,7 +300,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
 
                 auto greatest = *it;
 
-                util::detail::loop_n<std::decay_t<ExPolicy>>(++it, count - 1,
+                util::loop_n<std::decay_t<ExPolicy>>(++it, count - 1,
                     [&f, &greatest, &proj, value = HPX_INVOKE(proj, *greatest)](
                         FwdIter const& curr) mutable -> void {
                         auto curr_value = HPX_INVOKE(proj, **curr);
@@ -486,7 +486,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 return result;
 
             auto value = HPX_INVOKE(proj, *it);
-            util::detail::loop_n<std::decay_t<ExPolicy>>(++it, count - 1,
+            util::loop_n<std::decay_t<ExPolicy>>(++it, count - 1,
                 [&f, &result, &proj, min_value = value, max_value = value](
                     FwdIter const& curr) mutable -> void {
                     auto curr_value = HPX_INVOKE(proj, *curr);
@@ -526,7 +526,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
 
                 auto result = *it;
 
-                util::detail::loop_n<std::decay_t<ExPolicy>>(++it, count - 1,
+                util::loop_n<std::decay_t<ExPolicy>>(++it, count - 1,
                     [&f, &result, &proj,
                         min_value = HPX_INVOKE(proj, *result.first),
                         max_value = HPX_INVOKE(proj, *result.second)](

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/partition.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/partition.hpp
@@ -1159,8 +1159,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                     std::size_t true_count = 0;
 
                     // MSVC complains if pred or proj is captured by ref below
-                    util::detail::loop_n<std::decay_t<ExPolicy>>(part_begin,
-                        part_size,
+                    util::loop_n<std::decay_t<ExPolicy>>(part_begin, part_size,
                         [pred, proj, &true_count](zip_iterator it) mutable {
                             using hpx::util::invoke;
                             bool f = invoke(pred, invoke(proj, get<0>(*it)));
@@ -1197,8 +1196,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                     std::advance(dest_true, count_true);
                     std::advance(dest_false, count_false);
 
-                    util::detail::loop_n<std::decay_t<ExPolicy>>(part_begin,
-                        part_size,
+                    util::loop_n<std::decay_t<ExPolicy>>(part_begin, part_size,
                         [&dest_true, &dest_false](zip_iterator it) mutable {
                             if (get<1>(*it))
                                 *dest_true++ = get<0>(*it);

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/remove.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/remove.hpp
@@ -319,8 +319,8 @@ namespace hpx { namespace parallel { inline namespace v1 {
                               zip_iterator part_begin,
                               std::size_t part_size) -> std::size_t {
                     // MSVC complains if pred or proj is captured by ref below
-                    util::detail::loop_n<std::decay_t<ExPolicy>>(part_begin,
-                        part_size, [pred, proj](zip_iterator it) mutable {
+                    util::loop_n<std::decay_t<ExPolicy>>(part_begin, part_size,
+                        [pred, proj](zip_iterator it) mutable {
                             bool f = hpx::util::invoke(
                                 pred, hpx::util::invoke(proj, get<0>(*it)));
 
@@ -359,7 +359,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                     if (dest == get<0>(part_begin.get_iterator_tuple()))
                     {
                         // Self-assignment must be detected.
-                        util::detail::loop_n<execution_policy_type>(
+                        util::loop_n<execution_policy_type>(
                             part_begin, part_size, [&dest](zip_iterator it) {
                                 if (!get<1>(*it))
                                 {
@@ -373,7 +373,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                     else
                     {
                         // Self-assignment can't be performed.
-                        util::detail::loop_n<execution_policy_type>(
+                        util::loop_n<execution_policy_type>(
                             part_begin, part_size, [&dest](zip_iterator it) {
                                 if (!get<1>(*it))
                                     *dest++ = std::move(get<0>(*it));

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/transform.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/transform.hpp
@@ -205,6 +205,7 @@ namespace hpx {
 #include <utility>
 
 namespace hpx { namespace parallel { inline namespace v1 {
+
     ///////////////////////////////////////////////////////////////////////////
     // transform
     namespace detail {
@@ -253,9 +254,9 @@ namespace hpx { namespace parallel { inline namespace v1 {
         template <typename ExPolicy, typename F, typename Proj>
         struct transform_iteration
         {
-            typedef typename std::decay<ExPolicy>::type execution_policy_type;
-            typedef typename std::decay<F>::type fun_type;
-            typedef typename std::decay<Proj>::type proj_type;
+            using execution_policy_type = std::decay_t<ExPolicy>;
+            using fun_type = std::decay_t<F>;
+            using proj_type = std::decay_t<Proj>;
 
             fun_type f_;
             proj_type proj_;
@@ -283,44 +284,32 @@ namespace hpx { namespace parallel { inline namespace v1 {
             {
             }
 #endif
-
             transform_iteration& operator=(
                 transform_iteration const&) = default;
             transform_iteration& operator=(transform_iteration&&) = default;
 
-            template <typename Iter>
+            template <typename Iter, typename F_ = fun_type>
             HPX_HOST_DEVICE HPX_FORCEINLINE
                 std::pair<typename hpx::tuple_element<0,
                               typename Iter::iterator_tuple_type>::type,
                     typename hpx::tuple_element<1,
                         typename Iter::iterator_tuple_type>::type>
-                execute(Iter part_begin, std::size_t part_size)
+                operator()(Iter part_begin, std::size_t part_size, std::size_t)
             {
+                hpx::util::annotate_function _(f_);
+
                 auto iters = part_begin.get_iterator_tuple();
                 return util::transform_loop_n<execution_policy_type>(
                     hpx::get<0>(iters), part_size, hpx::get<1>(iters),
                     transform_projected<F, Proj>(f_, proj_));
-            }
-
-            template <typename Iter>
-            HPX_HOST_DEVICE HPX_FORCEINLINE
-                std::pair<typename hpx::tuple_element<0,
-                              typename Iter::iterator_tuple_type>::type,
-                    typename hpx::tuple_element<1,
-                        typename Iter::iterator_tuple_type>::type>
-                operator()(Iter part_begin, std::size_t part_size,
-                    std::size_t /*part_index*/)
-            {
-                hpx::util::annotate_function annotate(f_);
-                return execute(part_begin, part_size);
             }
         };
 
         template <typename ExPolicy, typename F>
         struct transform_iteration<ExPolicy, F, util::projection_identity>
         {
-            typedef typename std::decay<ExPolicy>::type execution_policy_type;
-            typedef typename std::decay<F>::type fun_type;
+            using execution_policy_type = std::decay_t<ExPolicy>;
+            using fun_type = std::decay_t<F>;
 
             fun_type f_;
 
@@ -345,35 +334,23 @@ namespace hpx { namespace parallel { inline namespace v1 {
             {
             }
 #endif
-
             transform_iteration& operator=(
                 transform_iteration const&) = default;
             transform_iteration& operator=(transform_iteration&&) = default;
 
-            template <typename Iter>
+            template <typename Iter, typename F_ = fun_type>
             HPX_HOST_DEVICE HPX_FORCEINLINE
                 std::pair<typename hpx::tuple_element<0,
                               typename Iter::iterator_tuple_type>::type,
                     typename hpx::tuple_element<1,
                         typename Iter::iterator_tuple_type>::type>
-                execute(Iter part_begin, std::size_t part_size)
+                operator()(Iter part_begin, std::size_t part_size, std::size_t)
             {
+                hpx::util::annotate_function _(f_);
+
                 auto iters = part_begin.get_iterator_tuple();
                 return util::transform_loop_n_ind<execution_policy_type>(
                     hpx::get<0>(iters), part_size, hpx::get<1>(iters), f_);
-            }
-
-            template <typename Iter>
-            HPX_HOST_DEVICE HPX_FORCEINLINE
-                std::pair<typename hpx::tuple_element<0,
-                              typename Iter::iterator_tuple_type>::type,
-                    typename hpx::tuple_element<1,
-                        typename Iter::iterator_tuple_type>::type>
-                operator()(Iter part_begin, std::size_t part_size,
-                    std::size_t /*part_index*/)
-            {
-                hpx::util::annotate_function annotate(f_);
-                return execute(part_begin, part_size);
             }
         };
 
@@ -387,24 +364,26 @@ namespace hpx { namespace parallel { inline namespace v1 {
             {
             }
 
+            // sequential execution with non-trivial projection
             template <typename ExPolicy, typename InIterB, typename InIterE,
                 typename OutIter, typename F, typename Proj>
-            HPX_HOST_DEVICE static constexpr util::in_out_result<InIterB,
-                OutIter>
+            HPX_HOST_DEVICE static util::in_out_result<InIterB, OutIter>
             sequential(ExPolicy&& policy, InIterB first, InIterE last,
                 OutIter dest, F&& f, Proj&& proj)
             {
+                hpx::util::annotate_function _(f);
                 return util::transform_loop(std::forward<ExPolicy>(policy),
                     first, last, dest, transform_projected<F, Proj>(f, proj));
             }
 
+            // sequential execution without projection
             template <typename ExPolicy, typename InIterB, typename InIterE,
                 typename OutIter, typename F>
-            HPX_HOST_DEVICE static constexpr util::in_out_result<InIterB,
-                OutIter>
+            HPX_HOST_DEVICE static util::in_out_result<InIterB, OutIter>
             sequential(ExPolicy&& policy, InIterB first, InIterE last,
                 OutIter dest, F&& f, util::projection_identity)
             {
+                hpx::util::annotate_function _(f);
                 return util::transform_loop_ind(std::forward<ExPolicy>(policy),
                     first, last, dest, std::forward<F>(f));
             }
@@ -443,18 +422,18 @@ namespace hpx { namespace parallel { inline namespace v1 {
     template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
         typename F, typename Proj = util::projection_identity,
         HPX_CONCEPT_REQUIRES_(
-            hpx::is_execution_policy<ExPolicy>::value &&
-            hpx::traits::is_iterator<FwdIter1>::value &&
-            hpx::traits::is_iterator<FwdIter2>::value &&
-            traits::is_projected<Proj, FwdIter1>::value &&
-            traits::is_indirect_callable<ExPolicy, F,
-                traits::projected<Proj, FwdIter1>>::value
+            hpx::is_execution_policy_v<ExPolicy> &&
+            hpx::traits::is_iterator_v<FwdIter1> &&
+            hpx::traits::is_iterator_v<FwdIter2> &&
+            traits::is_projected_v<Proj, FwdIter1> &&
+            traits::is_indirect_callable_v<ExPolicy, F,
+                traits::projected<Proj, FwdIter1>>
         )>
     // clang-format on
     HPX_DEPRECATED_V(1, 6,
-        "hpx::parallel::transform is deprecated, use hpx::transform instead")
-        typename util::detail::algorithm_result<ExPolicy,
-            util::in_out_result<FwdIter1, FwdIter2>>::type
+        "hpx::parallel::transform is deprecated, use hpx::transform "
+        "instead") typename util::detail::algorithm_result<ExPolicy,
+        util::in_out_result<FwdIter1, FwdIter2>>::type
         transform(ExPolicy&& policy, FwdIter1 first, FwdIter1 last,
             FwdIter2 dest, F&& f, Proj&& proj = Proj())
     {
@@ -469,32 +448,31 @@ namespace hpx { namespace parallel { inline namespace v1 {
     ///////////////////////////////////////////////////////////////////////////
     // transform binary predicate
     namespace detail {
+
         /// \cond NOINTERNAL
         template <typename F, typename Proj1, typename Proj2>
         struct transform_binary_projected
         {
-            typename std::decay<F>::type& f_;
-            typename std::decay<Proj1>::type& proj1_;
-            typename std::decay<Proj2>::type& proj2_;
+            std::decay_t<F>& f_;
+            std::decay_t<Proj1>& proj1_;
+            std::decay_t<Proj2>& proj2_;
 
             template <typename Iter1, typename Iter2>
             HPX_HOST_DEVICE HPX_FORCEINLINE auto operator()(
-                Iter1 curr1, Iter2 curr2) -> decltype(hpx::util::invoke(f_,
-                hpx::util::invoke(proj1_, *curr1),
-                hpx::util::invoke(proj2_, *curr2)))
+                Iter1 curr1, Iter2 curr2)
             {
-                return hpx::util::invoke(f_, hpx::util::invoke(proj1_, *curr1),
-                    hpx::util::invoke(proj2_, *curr2));
+                return HPX_INVOKE(
+                    f_, HPX_INVOKE(proj1_, *curr1), HPX_INVOKE(proj2_, *curr2));
             }
         };
 
         template <typename ExPolicy, typename F, typename Proj1, typename Proj2>
         struct transform_binary_iteration
         {
-            typedef typename std::decay<ExPolicy>::type execution_policy_type;
-            typedef typename std::decay<F>::type fun_type;
-            typedef typename std::decay<Proj1>::type proj1_type;
-            typedef typename std::decay<Proj2>::type proj2_type;
+            using execution_policy_type = std::decay_t<ExPolicy>;
+            using fun_type = std::decay_t<F>;
+            using proj1_type = std::decay_t<Proj1>;
+            using proj2_type = std::decay_t<Proj2>;
 
             fun_type f_;
             proj1_type proj1_;
@@ -530,13 +508,12 @@ namespace hpx { namespace parallel { inline namespace v1 {
             {
             }
 #endif
-
             transform_binary_iteration& operator=(
                 transform_binary_iteration const&) = default;
             transform_binary_iteration& operator=(
                 transform_binary_iteration&&) = default;
 
-            template <typename Iter>
+            template <typename Iter, typename F_ = fun_type>
             HPX_HOST_DEVICE HPX_FORCEINLINE
                 hpx::tuple<typename hpx::tuple_element<0,
                                typename Iter::iterator_tuple_type>::type,
@@ -544,15 +521,73 @@ namespace hpx { namespace parallel { inline namespace v1 {
                         typename Iter::iterator_tuple_type>::type,
                     typename hpx::tuple_element<2,
                         typename Iter::iterator_tuple_type>::type>
-                operator()(Iter part_begin, std::size_t part_size,
-                    std::size_t /*part_index*/)
+                operator()(Iter part_begin, std::size_t part_size, std::size_t)
             {
+                hpx::util::annotate_function _(f_);
+
                 auto iters = part_begin.get_iterator_tuple();
                 return util::transform_binary_loop_n<execution_policy_type>(
                     hpx::get<0>(iters), part_size, hpx::get<1>(iters),
                     hpx::get<2>(iters),
-                    transform_binary_projected<F, Proj1, Proj2>{
+                    transform_binary_projected<F_, Proj1, Proj2>{
                         f_, proj1_, proj2_});
+            }
+        };
+
+        template <typename ExPolicy, typename F>
+        struct transform_binary_iteration<ExPolicy, F,
+            util::projection_identity, util::projection_identity>
+        {
+            using execution_policy_type = std::decay_t<ExPolicy>;
+            using fun_type = std::decay_t<F>;
+
+            fun_type f_;
+
+            template <typename F_>
+            HPX_HOST_DEVICE transform_binary_iteration(
+                F_&& f, util::projection_identity, util::projection_identity)
+              : f_(std::forward<F_>(f))
+            {
+            }
+
+#if !defined(__NVCC__) && !defined(__CUDACC__)
+            transform_binary_iteration(
+                transform_binary_iteration const&) = default;
+            transform_binary_iteration(transform_binary_iteration&&) = default;
+#else
+            HPX_HOST_DEVICE
+            transform_binary_iteration(transform_binary_iteration const& rhs)
+              : f_(rhs.f_)
+            {
+            }
+
+            HPX_HOST_DEVICE
+            transform_binary_iteration(transform_binary_iteration&& rhs)
+              : f_(std::move(rhs.f_))
+            {
+            }
+#endif
+            transform_binary_iteration& operator=(
+                transform_binary_iteration const&) = default;
+            transform_binary_iteration& operator=(
+                transform_binary_iteration&&) = default;
+
+            template <typename Iter, typename F_ = fun_type>
+            HPX_HOST_DEVICE HPX_FORCEINLINE
+                hpx::tuple<typename hpx::tuple_element<0,
+                               typename Iter::iterator_tuple_type>::type,
+                    typename hpx::tuple_element<1,
+                        typename Iter::iterator_tuple_type>::type,
+                    typename hpx::tuple_element<2,
+                        typename Iter::iterator_tuple_type>::type>
+                operator()(Iter part_begin, std::size_t part_size, std::size_t)
+            {
+                hpx::util::annotate_function _(f_);
+
+                auto iters = part_begin.get_iterator_tuple();
+                return util::transform_binary_loop_ind_n<execution_policy_type>(
+                    hpx::get<0>(iters), part_size, hpx::get<1>(iters),
+                    hpx::get<2>(iters), f_);
             }
         };
 
@@ -566,16 +601,31 @@ namespace hpx { namespace parallel { inline namespace v1 {
             {
             }
 
+            // sequential execution with non-trivial projection
             template <typename ExPolicy, typename InIter1, typename InIter2,
                 typename OutIter, typename F, typename Proj1, typename Proj2>
             static util::in_in_out_result<InIter1, InIter2, OutIter> sequential(
                 ExPolicy&&, InIter1 first1, InIter1 last1, InIter2 first2,
                 OutIter dest, F&& f, Proj1&& proj1, Proj2&& proj2)
             {
+                hpx::util::annotate_function _(f);
                 return util::transform_binary_loop<ExPolicy>(first1, last1,
                     first2, dest,
                     transform_binary_projected<F, Proj1, Proj2>{
                         f, proj1, proj2});
+            }
+
+            // sequential execution without projection
+            template <typename ExPolicy, typename InIter1, typename InIter2,
+                typename OutIter, typename F>
+            static util::in_in_out_result<InIter1, InIter2, OutIter> sequential(
+                ExPolicy&&, InIter1 first1, InIter1 last1, InIter2 first2,
+                OutIter dest, F&& f, util::projection_identity,
+                util::projection_identity)
+            {
+                hpx::util::annotate_function _(f);
+                return util::transform_binary_loop_ind<ExPolicy>(
+                    first1, last1, first2, dest, f);
             }
 
             template <typename ExPolicy, typename FwdIter1B, typename FwdIter1E,
@@ -619,15 +669,15 @@ namespace hpx { namespace parallel { inline namespace v1 {
         typename Proj1 = util::projection_identity,
         typename Proj2 = util::projection_identity,
         HPX_CONCEPT_REQUIRES_(
-            hpx::is_execution_policy<
-                ExPolicy>::value&& hpx::traits::is_iterator<FwdIter1>::value &&
-            hpx::traits::is_iterator<FwdIter2>::value &&
-            hpx::traits::is_iterator<FwdIter3>::value &&
-            traits::is_projected<Proj1, FwdIter1>::value &&
-            traits::is_projected<Proj2, FwdIter2>::value &&
-            traits::is_indirect_callable<ExPolicy, F,
+            hpx::is_execution_policy_v<ExPolicy> &&
+            hpx::traits::is_iterator_v<FwdIter1> &&
+            hpx::traits::is_iterator_v<FwdIter2> &&
+            hpx::traits::is_iterator_v<FwdIter3> &&
+            traits::is_projected_v<Proj1, FwdIter1> &&
+            traits::is_projected_v<Proj2, FwdIter2> &&
+            traits::is_indirect_callable_v<ExPolicy, F,
                 traits::projected<Proj1, FwdIter1>,
-                traits::projected<Proj2, FwdIter2>>::value
+                traits::projected<Proj2, FwdIter2>>
         )>
     // clang-format on
     HPX_DEPRECATED_V(1, 6,
@@ -662,6 +712,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
     ///////////////////////////////////////////////////////////////////////////
     // transform binary predicate
     namespace detail {
+
         /// \cond NOINTERNAL
         template <typename IterTuple>
         struct transform_binary2
@@ -672,6 +723,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
             {
             }
 
+            // sequential execution with non-trivial projection
             template <typename ExPolicy, typename InIter1, typename InIter2,
                 typename OutIter, typename F, typename Proj1, typename Proj2>
             static util::in_in_out_result<InIter1, InIter2, OutIter> sequential(
@@ -679,10 +731,24 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 InIter2 last2, OutIter dest, F&& f, Proj1&& proj1,
                 Proj2&& proj2)
             {
+                hpx::util::annotate_function _(f);
                 return util::transform_binary_loop<ExPolicy>(first1, last1,
                     first2, last2, dest,
                     transform_binary_projected<F, Proj1, Proj2>{
                         f, proj1, proj2});
+            }
+
+            // sequential execution without projection
+            template <typename ExPolicy, typename InIter1, typename InIter2,
+                typename OutIter, typename F>
+            static util::in_in_out_result<InIter1, InIter2, OutIter> sequential(
+                ExPolicy&&, InIter1 first1, InIter1 last1, InIter2 first2,
+                InIter2 last2, OutIter dest, F&& f, util::projection_identity,
+                util::projection_identity)
+            {
+                hpx::util::annotate_function _(f);
+                return util::transform_binary_loop_ind<ExPolicy>(
+                    first1, last1, first2, last2, dest, f);
             }
 
             template <typename ExPolicy, typename FwdIter1B, typename FwdIter1E,
@@ -701,13 +767,16 @@ namespace hpx { namespace parallel { inline namespace v1 {
                             std::forward<F>(f), std::forward<Proj1>(proj1),
                             std::forward<Proj2>(proj2));
 
+                    // different version of clang-formt do different things
+                    // clang-format off
                     return util::detail::get_in_in_out_result(
                         util::foreach_partitioner<ExPolicy>::call(
                             std::forward<ExPolicy>(policy),
                             hpx::util::make_zip_iterator(first1, first2, dest),
-                            (std::min)(detail::distance(first1, last1),
+                            (std::min) (detail::distance(first1, last1),
                                 detail::distance(first2, last2)),
                             std::move(f1), util::projection_identity()));
+                    // clang-format on
                 }
 
                 using result_type =
@@ -727,15 +796,15 @@ namespace hpx { namespace parallel { inline namespace v1 {
         typename Proj1 = util::projection_identity,
         typename Proj2 = util::projection_identity,
         HPX_CONCEPT_REQUIRES_(
-            hpx::is_execution_policy<
-                ExPolicy>::value&& hpx::traits::is_iterator<FwdIter1>::value &&
-            hpx::traits::is_iterator<FwdIter2>::value &&
-            hpx::traits::is_iterator<FwdIter3>::value &&
-            traits::is_projected<Proj1, FwdIter1>::value &&
-            traits::is_projected<Proj2, FwdIter2>::value &&
-            traits::is_indirect_callable<ExPolicy, F,
+            hpx::is_execution_policy_v<ExPolicy> &&
+            hpx::traits::is_iterator_v<FwdIter1> &&
+            hpx::traits::is_iterator_v<FwdIter2> &&
+            hpx::traits::is_iterator_v<FwdIter3> &&
+            traits::is_projected_v<Proj1, FwdIter1> &&
+            traits::is_projected_v<Proj2, FwdIter2> &&
+            traits::is_indirect_callable_v<ExPolicy, F,
                 traits::projected<Proj1, FwdIter1>,
-                traits::projected<Proj2, FwdIter2>>::value
+                traits::projected<Proj2, FwdIter2>>
         )>
     // clang-format on
     HPX_DEPRECATED_V(1, 6,
@@ -778,8 +847,7 @@ namespace hpx { namespace traits {
             parallel::v1::detail::transform_iteration<ExPolicy, F, Proj> const&
                 f) noexcept
         {
-            return get_function_address<typename std::decay<F>::type>::call(
-                f.f_);
+            return get_function_address<std::decay_t<F>>::call(f.f_);
         }
     };
 
@@ -791,8 +859,7 @@ namespace hpx { namespace traits {
             parallel::v1::detail::transform_iteration<ExPolicy, F, Proj> const&
                 f) noexcept
         {
-            return get_function_annotation<typename std::decay<F>::type>::call(
-                f.f_);
+            return get_function_annotation<std::decay_t<F>>::call(f.f_);
         }
     };
 
@@ -804,8 +871,7 @@ namespace hpx { namespace traits {
             parallel::v1::detail::transform_binary_iteration<ExPolicy, F, Proj1,
                 Proj2> const& f) noexcept
         {
-            return get_function_address<typename std::decay<F>::type>::call(
-                f.f_);
+            return get_function_address<std::decay_t<F>>::call(f.f_);
         }
     };
 
@@ -817,8 +883,7 @@ namespace hpx { namespace traits {
             parallel::v1::detail::transform_binary_iteration<ExPolicy, F, Proj1,
                 Proj2> const& f) noexcept
         {
-            return get_function_annotation<typename std::decay<F>::type>::call(
-                f.f_);
+            return get_function_annotation<std::decay_t<F>>::call(f.f_);
         }
     };
 
@@ -831,8 +896,7 @@ namespace hpx { namespace traits {
             parallel::v1::detail::transform_iteration<ExPolicy, F, Proj> const&
                 f) noexcept
         {
-            return get_function_annotation_itt<
-                typename std::decay<F>::type>::call(f.f_);
+            return get_function_annotation_itt<std::decay_t<F>>::call(f.f_);
         }
     };
 
@@ -844,8 +908,7 @@ namespace hpx { namespace traits {
             parallel::v1::detail::transform_binary_iteration<ExPolicy, F, Proj1,
                 Proj2> const& f) noexcept
         {
-            return get_function_annotation_itt<
-                typename std::decay<F>::type>::call(f.f_);
+            return get_function_annotation_itt<std::decay_t<F>>::call(f.f_);
         }
     };
 #endif
@@ -863,8 +926,8 @@ namespace hpx {
         template <typename FwdIter1, typename FwdIter2,
             typename F,
             HPX_CONCEPT_REQUIRES_(
-                hpx::traits::is_iterator<FwdIter1>::value &&
-                hpx::traits::is_iterator<FwdIter2>::value
+                hpx::traits::is_iterator_v<FwdIter1> &&
+                hpx::traits::is_iterator_v<FwdIter2>
             )>
         // clang-format on
         friend FwdIter2 tag_fallback_dispatch(hpx::transform_t, FwdIter1 first,
@@ -885,9 +948,9 @@ namespace hpx {
         template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
             typename F,
             HPX_CONCEPT_REQUIRES_(
-                hpx::is_execution_policy<ExPolicy>::value &&
-                hpx::traits::is_iterator<FwdIter1>::value &&
-                hpx::traits::is_iterator<FwdIter2>::value
+                hpx::is_execution_policy_v<ExPolicy> &&
+                hpx::traits::is_iterator_v<FwdIter1> &&
+                hpx::traits::is_iterator_v<FwdIter2>
             )>
         // clang-format on
         friend typename parallel::util::detail::algorithm_result<ExPolicy,
@@ -910,9 +973,9 @@ namespace hpx {
         template <typename FwdIter1, typename FwdIter2, typename FwdIter3,
             typename F,
             HPX_CONCEPT_REQUIRES_(
-                hpx::traits::is_iterator<FwdIter1>::value &&
-                hpx::traits::is_iterator<FwdIter2>::value &&
-                hpx::traits::is_iterator<FwdIter3>::value
+                hpx::traits::is_iterator_v<FwdIter1> &&
+                hpx::traits::is_iterator_v<FwdIter2> &&
+                hpx::traits::is_iterator_v<FwdIter3>
             )>
         // clang-format on
         friend FwdIter3 tag_fallback_dispatch(hpx::transform_t, FwdIter1 first1,
@@ -937,10 +1000,10 @@ namespace hpx {
             typename FwdIter2, typename FwdIter3,
             typename F,
             HPX_CONCEPT_REQUIRES_(
-                hpx::is_execution_policy<ExPolicy>::value &&
-                hpx::traits::is_iterator<FwdIter1>::value &&
-                hpx::traits::is_iterator<FwdIter2>::value &&
-                hpx::traits::is_iterator<FwdIter3>::value
+                hpx::is_execution_policy_v<ExPolicy> &&
+                hpx::traits::is_iterator_v<FwdIter1> &&
+                hpx::traits::is_iterator_v<FwdIter2> &&
+                hpx::traits::is_iterator_v<FwdIter3>
             )>
         // clang-format on
         friend typename parallel::util::detail::algorithm_result<ExPolicy,

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/transform.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/transform.hpp
@@ -184,7 +184,6 @@ namespace hpx {
 #include <hpx/functional/traits/is_invocable.hpp>
 #include <hpx/iterator_support/traits/is_iterator.hpp>
 #include <hpx/parallel/util/result_types.hpp>
-#include <hpx/threading_base/annotated_function.hpp>
 
 #include <hpx/algorithms/traits/projected.hpp>
 #include <hpx/executors/execution_policy.hpp>
@@ -296,8 +295,6 @@ namespace hpx { namespace parallel { inline namespace v1 {
                         typename Iter::iterator_tuple_type>::type>
                 operator()(Iter part_begin, std::size_t part_size, std::size_t)
             {
-                hpx::util::annotate_function _(f_);
-
                 auto iters = part_begin.get_iterator_tuple();
                 return util::transform_loop_n<execution_policy_type>(
                     hpx::get<0>(iters), part_size, hpx::get<1>(iters),
@@ -346,8 +343,6 @@ namespace hpx { namespace parallel { inline namespace v1 {
                         typename Iter::iterator_tuple_type>::type>
                 operator()(Iter part_begin, std::size_t part_size, std::size_t)
             {
-                hpx::util::annotate_function _(f_);
-
                 auto iters = part_begin.get_iterator_tuple();
                 return util::transform_loop_n_ind<execution_policy_type>(
                     hpx::get<0>(iters), part_size, hpx::get<1>(iters), f_);
@@ -371,7 +366,6 @@ namespace hpx { namespace parallel { inline namespace v1 {
             sequential(ExPolicy&& policy, InIterB first, InIterE last,
                 OutIter dest, F&& f, Proj&& proj)
             {
-                hpx::util::annotate_function _(f);
                 return util::transform_loop(std::forward<ExPolicy>(policy),
                     first, last, dest, transform_projected<F, Proj>(f, proj));
             }
@@ -383,7 +377,6 @@ namespace hpx { namespace parallel { inline namespace v1 {
             sequential(ExPolicy&& policy, InIterB first, InIterE last,
                 OutIter dest, F&& f, util::projection_identity)
             {
-                hpx::util::annotate_function _(f);
                 return util::transform_loop_ind(std::forward<ExPolicy>(policy),
                     first, last, dest, std::forward<F>(f));
             }
@@ -523,8 +516,6 @@ namespace hpx { namespace parallel { inline namespace v1 {
                         typename Iter::iterator_tuple_type>::type>
                 operator()(Iter part_begin, std::size_t part_size, std::size_t)
             {
-                hpx::util::annotate_function _(f_);
-
                 auto iters = part_begin.get_iterator_tuple();
                 return util::transform_binary_loop_n<execution_policy_type>(
                     hpx::get<0>(iters), part_size, hpx::get<1>(iters),
@@ -582,8 +573,6 @@ namespace hpx { namespace parallel { inline namespace v1 {
                         typename Iter::iterator_tuple_type>::type>
                 operator()(Iter part_begin, std::size_t part_size, std::size_t)
             {
-                hpx::util::annotate_function _(f_);
-
                 auto iters = part_begin.get_iterator_tuple();
                 return util::transform_binary_loop_ind_n<execution_policy_type>(
                     hpx::get<0>(iters), part_size, hpx::get<1>(iters),
@@ -608,7 +597,6 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 ExPolicy&&, InIter1 first1, InIter1 last1, InIter2 first2,
                 OutIter dest, F&& f, Proj1&& proj1, Proj2&& proj2)
             {
-                hpx::util::annotate_function _(f);
                 return util::transform_binary_loop<ExPolicy>(first1, last1,
                     first2, dest,
                     transform_binary_projected<F, Proj1, Proj2>{
@@ -623,7 +611,6 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 OutIter dest, F&& f, util::projection_identity,
                 util::projection_identity)
             {
-                hpx::util::annotate_function _(f);
                 return util::transform_binary_loop_ind<ExPolicy>(
                     first1, last1, first2, dest, f);
             }
@@ -731,7 +718,6 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 InIter2 last2, OutIter dest, F&& f, Proj1&& proj1,
                 Proj2&& proj2)
             {
-                hpx::util::annotate_function _(f);
                 return util::transform_binary_loop<ExPolicy>(first1, last1,
                     first2, last2, dest,
                     transform_binary_projected<F, Proj1, Proj2>{
@@ -746,7 +732,6 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 InIter2 last2, OutIter dest, F&& f, util::projection_identity,
                 util::projection_identity)
             {
-                hpx::util::annotate_function _(f);
                 return util::transform_binary_loop_ind<ExPolicy>(
                     first1, last1, first2, last2, dest, f);
             }
@@ -767,7 +752,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                             std::forward<F>(f), std::forward<Proj1>(proj1),
                             std::forward<Proj2>(proj2));
 
-                    // different version of clang-formt do different things
+                    // different versions of clang-format do different things
                     // clang-format off
                     return util::detail::get_in_in_out_result(
                         util::foreach_partitioner<ExPolicy>::call(

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/transform_exclusive_scan.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/transform_exclusive_scan.hpp
@@ -132,7 +132,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                     FwdIter2 dst = get<1>(part_begin.get_iterator_tuple());
                     *dst++ = val;
 
-                    util::detail::loop_n<std::decay_t<ExPolicy>>(
+                    util::loop_n<std::decay_t<ExPolicy>>(
                         dst, part_size - 1, [&op, &val](FwdIter2 it) -> void {
                             *it = hpx::util::invoke(op, val, *it);
                         });

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/transform_inclusive_scan.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/transform_inclusive_scan.hpp
@@ -153,7 +153,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                     T val = curr.get();
                     FwdIter2 dst = get<1>(part_begin.get_iterator_tuple());
 
-                    util::detail::loop_n<std::decay_t<ExPolicy>>(
+                    util::loop_n<std::decay_t<ExPolicy>>(
                         dst, part_size, [&op, &val](FwdIter2 it) -> void {
                             *it = hpx::util::invoke(op, val, *it);
                         });

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/unique.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/unique.hpp
@@ -115,7 +115,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                     FwdIter base = get<0>(part_begin.get_iterator_tuple());
 
                     // MSVC complains if pred or proj is captured by ref below
-                    util::detail::loop_n<std::decay_t<ExPolicy>>(++part_begin,
+                    util::loop_n<std::decay_t<ExPolicy>>(++part_begin,
                         part_size, [base, pred, proj](zip_iterator it) mutable {
                             using hpx::util::invoke;
 
@@ -150,7 +150,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                     if (dest == get<0>(part_begin.get_iterator_tuple()))
                     {
                         // Self-assignment must be detected.
-                        util::detail::loop_n<execution_policy_type>(
+                        util::loop_n<execution_policy_type>(
                             part_begin, part_size, [&dest](zip_iterator it) {
                                 if (!get<1>(*it))
                                 {
@@ -164,7 +164,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                     else
                     {
                         // Self-assignment can't be performed.
-                        util::detail::loop_n<execution_policy_type>(
+                        util::loop_n<execution_policy_type>(
                             part_begin, part_size, [&dest](zip_iterator it) {
                                 if (!get<1>(*it))
                                     *dest++ = std::move(get<0>(*it));
@@ -422,7 +422,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                     std::size_t curr = 0;
 
                     // MSVC complains if pred or proj is captured by ref below
-                    util::detail::loop_n<std::decay_t<ExPolicy>>(++part_begin,
+                    util::loop_n<std::decay_t<ExPolicy>>(++part_begin,
                         part_size,
                         [base, pred, proj, &curr](zip_iterator it) mutable {
                             using hpx::util::invoke;
@@ -449,7 +449,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                     next.get();    // rethrow exceptions
 
                     std::advance(dest, curr.get());
-                    util::detail::loop_n<std::decay_t<ExPolicy>>(++part_begin,
+                    util::loop_n<std::decay_t<ExPolicy>>(++part_begin,
                         part_size, [&dest](zip_iterator it) mutable {
                             if (!get<1>(*it))
                                 *dest++ = get<0>(*it);

--- a/libs/parallelism/algorithms/include/hpx/parallel/datapar/loop.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/datapar/loop.hpp
@@ -475,28 +475,25 @@ namespace hpx { namespace parallel { namespace util {
     }
 
     ///////////////////////////////////////////////////////////////////////////
-    namespace detail {
+    template <typename ExPolicy, typename Iter, typename F>
+    HPX_HOST_DEVICE HPX_FORCEINLINE constexpr typename std::enable_if<
+        hpx::is_vectorpack_execution_policy<ExPolicy>::value, Iter>::type
+    tag_dispatch(hpx::parallel::util::loop_n_t<ExPolicy>, Iter it,
+        std::size_t count, F&& f)
+    {
+        return hpx::parallel::util::detail::datapar_loop_n<Iter>::call(
+            it, count, std::forward<F>(f));
+    }
 
-        template <typename ExPolicy, typename Iter, typename F>
-        HPX_HOST_DEVICE HPX_FORCEINLINE constexpr typename std::enable_if<
-            hpx::is_vectorpack_execution_policy<ExPolicy>::value, Iter>::type
-        tag_dispatch(hpx::parallel::util::detail::loop_n_t<ExPolicy>, Iter it,
-            std::size_t count, F&& f)
-        {
-            return hpx::parallel::util::detail::datapar_loop_n<Iter>::call(
-                it, count, std::forward<F>(f));
-        }
-
-        template <typename ExPolicy, typename Iter, typename F>
-        HPX_HOST_DEVICE HPX_FORCEINLINE constexpr typename std::enable_if<
-            hpx::is_vectorpack_execution_policy<ExPolicy>::value, Iter>::type
-        tag_dispatch(hpx::parallel::util::detail::loop_n_ind_t<ExPolicy>,
-            Iter it, std::size_t count, F&& f)
-        {
-            return hpx::parallel::util::detail::datapar_loop_n_ind<Iter>::call(
-                it, count, std::forward<F>(f));
-        }
-    }    // namespace detail
-}}}      // namespace hpx::parallel::util
+    template <typename ExPolicy, typename Iter, typename F>
+    HPX_HOST_DEVICE HPX_FORCEINLINE constexpr typename std::enable_if<
+        hpx::is_vectorpack_execution_policy<ExPolicy>::value, Iter>::type
+    tag_dispatch(hpx::parallel::util::loop_n_ind_t<ExPolicy>, Iter it,
+        std::size_t count, F&& f)
+    {
+        return hpx::parallel::util::detail::datapar_loop_n_ind<Iter>::call(
+            it, count, std::forward<F>(f));
+    }
+}}}    // namespace hpx::parallel::util
 
 #endif

--- a/libs/parallelism/algorithms/include/hpx/parallel/datapar/transform_loop.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/datapar/transform_loop.hpp
@@ -460,8 +460,11 @@ namespace hpx { namespace parallel { namespace util {
             call(InIter1 first1, InIter1 last1, InIter2 first2, InIter2 last2,
                 OutIter dest, F&& f)
             {
-                std::size_t count = (std::min)(
-                    std::distance(first1, last1), std::distance(first2, last2));
+                // different version of clang-formt do different things
+                // clang-format off
+                std::size_t count = (std::min) (std::distance(first1, last1),
+                    std::distance(first2, last2));
+                // clang-format on
 
                 auto ret = util::transform_binary_loop_n<
                     hpx::execution::simdpar_policy>(

--- a/libs/parallelism/algorithms/include/hpx/parallel/datapar/transform_loop.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/datapar/transform_loop.hpp
@@ -460,7 +460,7 @@ namespace hpx { namespace parallel { namespace util {
             call(InIter1 first1, InIter1 last1, InIter2 first2, InIter2 last2,
                 OutIter dest, F&& f)
             {
-                // different version of clang-formt do different things
+                // different versions of clang-format do different things
                 // clang-format off
                 std::size_t count = (std::min) (std::distance(first1, last1),
                     std::distance(first2, last2));

--- a/libs/parallelism/algorithms/include/hpx/parallel/util/detail/chunk_size.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/util/detail/chunk_size.hpp
@@ -32,14 +32,15 @@ namespace hpx { namespace parallel { namespace util { namespace detail {
     void add_ready_future(
         std::vector<Future>& workitems, F&& f, FwdIter first, std::size_t count)
     {
-        workitems.push_back(hpx::make_ready_future(f(first, count)));
+        workitems.push_back(
+            hpx::make_ready_future(std::forward<F>(f)(first, count)));
     }
 
     template <typename F, typename FwdIter>
     void add_ready_future(std::vector<hpx::future<void>>& workitems, F&& f,
         FwdIter first, std::size_t count)
     {
-        f(first, count);
+        std::forward<F>(f)(first, count);
         workitems.push_back(hpx::make_ready_future());
     }
 
@@ -47,7 +48,7 @@ namespace hpx { namespace parallel { namespace util { namespace detail {
     void add_ready_future(std::vector<hpx::shared_future<void>>& workitems,
         F&& f, FwdIter first, std::size_t count)
     {
-        f(first, count);
+        std::forward<F>(f)(first, count);
         workitems.push_back(hpx::make_ready_future());
     }
 
@@ -63,13 +64,17 @@ namespace hpx { namespace parallel { namespace util { namespace detail {
                 // try to calculate chunk-size and maximum number of chunks
                 chunk_size = (count + 4 * cores - 1) / (4 * cores);    // -V112
 
+                // different version of clang-formt do different things
+                // clang-format off
+
                 // we should not consider more chunks than we have elements
-                max_chunks = (std::min)(4 * cores, count);    // -V112
+                max_chunks = (std::min) (4 * cores, count);    // -V112
 
                 // we should not make chunks smaller than what's determined by
                 // the max chunk size
-                chunk_size = (std::max)(
-                    chunk_size, (count + max_chunks - 1) / max_chunks);
+                chunk_size = (std::max) (chunk_size,
+                    (count + max_chunks - 1) / max_chunks);
+                // clang-format on
             }
             else
             {
@@ -131,9 +136,13 @@ namespace hpx { namespace parallel { namespace util { namespace detail {
 
             if (stride != 1)
             {
+                // different version of clang-formt do different things
+                // clang-format off
+
                 // rounding up
-                test_chunk_size = (std::max)(std::size_t(stride),
+                test_chunk_size = (std::max) (std::size_t(stride),
                     ((test_chunk_size + stride - 1) / stride) * stride);
+                // clang-format on
             }
 
             add_ready_future(workitems, f1, begin, test_chunk_size);
@@ -153,8 +162,11 @@ namespace hpx { namespace parallel { namespace util { namespace detail {
 
         if (stride != 1)
         {
-            chunk_size = (std::max)(std::size_t(stride),
+            // different version of clang-formt do different things
+            // clang-format off
+            chunk_size = (std::max) (std::size_t(stride),
                 ((chunk_size + stride) / stride - 1) * stride);
+            // clang-format on
         }
 
         using iterator = parallel::util::detail::chunk_size_iterator<FwdIter>;
@@ -185,10 +197,13 @@ namespace hpx { namespace parallel { namespace util { namespace detail {
         std::vector<tuple_type> shape;
         Stride stride = parallel::v1::detail::abs(s);
 
+        // different version of clang-formt do different things
+        // clang-format off
+
         // we should not consider more chunks than we have elements
         if (max_chunks != 0)
         {
-            max_chunks = (std::min)(max_chunks, count);
+            max_chunks = (std::min) (max_chunks, count);
         }
 
         while (count != 0)
@@ -203,12 +218,12 @@ namespace hpx { namespace parallel { namespace util { namespace detail {
 
             if (stride != 1)
             {
-                chunk_size = (std::max)(std::size_t(stride),
+                chunk_size = (std::max) (std::size_t(stride),
                     ((chunk_size + stride) / stride - 1) * stride);
             }
 
             // in last chunk, consider only remaining number of elements
-            std::size_t chunk = (std::min)(chunk_size, count);
+            std::size_t chunk = (std::min) (chunk_size, count);
 
             shape.push_back(hpx::make_tuple(first, chunk));
 
@@ -216,6 +231,7 @@ namespace hpx { namespace parallel { namespace util { namespace detail {
             first = parallel::v1::detail::next(first, count, chunk);
             count -= chunk;
         }
+        // clang-format on
 
         return shape;
     }
@@ -226,14 +242,15 @@ namespace hpx { namespace parallel { namespace util { namespace detail {
     void add_ready_future_idx(std::vector<Future>& workitems, F&& f,
         FwdIter first, std::size_t base_idx, std::size_t count)
     {
-        workitems.push_back(hpx::make_ready_future(f(first, count, base_idx)));
+        workitems.push_back(
+            hpx::make_ready_future(std::forward<F>(f)(first, count, base_idx)));
     }
 
     template <typename F, typename FwdIter>
     void add_ready_future_idx(std::vector<hpx::future<void>>& workitems, F&& f,
         FwdIter first, std::size_t base_idx, std::size_t count)
     {
-        f(first, count, base_idx);
+        std::forward<F>(f)(first, count, base_idx);
         workitems.push_back(hpx::make_ready_future());
     }
 
@@ -241,7 +258,7 @@ namespace hpx { namespace parallel { namespace util { namespace detail {
     void add_ready_future_idx(std::vector<hpx::shared_future<void>>& workitems,
         F&& f, std::size_t base_idx, FwdIter first, std::size_t count)
     {
-        f(first, count, base_idx);
+        std::forward<F>(f)(first, count, base_idx);
         workitems.push_back(hpx::make_ready_future());
     }
 
@@ -270,8 +287,11 @@ namespace hpx { namespace parallel { namespace util { namespace detail {
 
             if (stride != 1)
             {
+                // different version of clang-formt do different things
+                // clang-format off
                 test_chunk_size = (std::max)(std::size_t(stride),
                     ((test_chunk_size + stride) / stride - 1) * stride);
+                // clang-format on
             }
 
             add_ready_future_idx(
@@ -294,8 +314,11 @@ namespace hpx { namespace parallel { namespace util { namespace detail {
 
         if (stride != 1)
         {
-            chunk_size = (std::max)(std::size_t(stride),
+            // different version of clang-formt do different things
+            // clang-format off
+            chunk_size = (std::max) (std::size_t(stride),
                 ((chunk_size + stride) / stride - 1) * stride);
+            // clang-format on
         }
 
         using iterator =
@@ -327,10 +350,13 @@ namespace hpx { namespace parallel { namespace util { namespace detail {
         Stride stride = parallel::v1::detail::abs(s);
         std::size_t base_idx = 0;
 
+        // different version of clang-formt do different things
+        // clang-format off
+
         // we should not consider more chunks than we have elements
         if (max_chunks != 0)
         {
-            max_chunks = (std::min)(max_chunks, count);
+            max_chunks = (std::min) (max_chunks, count);
         }
 
         while (count != 0)
@@ -345,12 +371,12 @@ namespace hpx { namespace parallel { namespace util { namespace detail {
 
             if (stride != 1)
             {
-                chunk_size = (std::max)(std::size_t(stride),
+                chunk_size = (std::max) (std::size_t(stride),
                     ((chunk_size + stride) / stride - 1) * stride);
             }
 
             // in last chunk, consider only remaining number of elements
-            std::size_t chunk = (std::min)(chunk_size, count);
+            std::size_t chunk = (std::min) (chunk_size, count);
 
             shape.push_back(hpx::make_tuple(first, chunk, base_idx));
 
@@ -360,6 +386,7 @@ namespace hpx { namespace parallel { namespace util { namespace detail {
             count -= chunk;
             base_idx += chunk;
         }
+        // clang-format on
 
         return shape;
     }

--- a/libs/parallelism/algorithms/include/hpx/parallel/util/detail/chunk_size.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/util/detail/chunk_size.hpp
@@ -64,7 +64,7 @@ namespace hpx { namespace parallel { namespace util { namespace detail {
                 // try to calculate chunk-size and maximum number of chunks
                 chunk_size = (count + 4 * cores - 1) / (4 * cores);    // -V112
 
-                // different version of clang-formt do different things
+                // different versions of clang-format do different things
                 // clang-format off
 
                 // we should not consider more chunks than we have elements
@@ -136,7 +136,7 @@ namespace hpx { namespace parallel { namespace util { namespace detail {
 
             if (stride != 1)
             {
-                // different version of clang-formt do different things
+                // different versions of clang-format do different things
                 // clang-format off
 
                 // rounding up
@@ -162,7 +162,7 @@ namespace hpx { namespace parallel { namespace util { namespace detail {
 
         if (stride != 1)
         {
-            // different version of clang-formt do different things
+            // different versions of clang-format do different things
             // clang-format off
             chunk_size = (std::max) (std::size_t(stride),
                 ((chunk_size + stride) / stride - 1) * stride);
@@ -197,7 +197,7 @@ namespace hpx { namespace parallel { namespace util { namespace detail {
         std::vector<tuple_type> shape;
         Stride stride = parallel::v1::detail::abs(s);
 
-        // different version of clang-formt do different things
+        // different versions of clang-format do different things
         // clang-format off
 
         // we should not consider more chunks than we have elements
@@ -287,7 +287,7 @@ namespace hpx { namespace parallel { namespace util { namespace detail {
 
             if (stride != 1)
             {
-                // different version of clang-formt do different things
+                // different versions of clang-format do different things
                 // clang-format off
                 test_chunk_size = (std::max)(std::size_t(stride),
                     ((test_chunk_size + stride) / stride - 1) * stride);
@@ -314,7 +314,7 @@ namespace hpx { namespace parallel { namespace util { namespace detail {
 
         if (stride != 1)
         {
-            // different version of clang-formt do different things
+            // different versions of clang-format do different things
             // clang-format off
             chunk_size = (std::max) (std::size_t(stride),
                 ((chunk_size + stride) / stride - 1) * stride);
@@ -350,7 +350,7 @@ namespace hpx { namespace parallel { namespace util { namespace detail {
         Stride stride = parallel::v1::detail::abs(s);
         std::size_t base_idx = 0;
 
-        // different version of clang-formt do different things
+        // different versions of clang-format do different things
         // clang-format off
 
         // we should not consider more chunks than we have elements

--- a/libs/parallelism/algorithms/include/hpx/parallel/util/detail/handle_local_exceptions.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/util/detail/handle_local_exceptions.hpp
@@ -84,14 +84,28 @@ namespace hpx { namespace parallel { namespace util { namespace detail {
             HPX_UNUSED(throw_errors);
             HPX_ASSERT(false);
 #else
-            for (hpx::future<T> const& f : workitems)
+            // first extract exception from all futures
+            std::vector<std::exception_ptr> exceptions;
+            exceptions.reserve(workitems.size());
+            for (auto const& f : workitems)
             {
                 if (f.has_exception())
-                    call(f.get_exception_ptr(), errors);
+                {
+                    exceptions.reserve(workitems.size());
+                    exceptions.push_back(f.get_exception_ptr());
+                }
+            }
+
+            // now handle exceptions as needed
+            for (auto& e : exceptions)
+            {
+                call(e, errors);
             }
 
             if (throw_errors && !errors.empty())
+            {
                 throw exception_list(std::move(errors));
+            }
 #endif
         }
 
@@ -106,14 +120,28 @@ namespace hpx { namespace parallel { namespace util { namespace detail {
             HPX_UNUSED(throw_errors);
             HPX_ASSERT(false);
 #else
-            for (hpx::shared_future<T> const& f : workitems)
+            // first extract exception from all futures
+            std::vector<std::exception_ptr> exceptions;
+            exceptions.reserve(workitems.size());
+            for (auto const& f : workitems)
             {
                 if (f.has_exception())
-                    call(f.get_exception_ptr(), errors);
+                {
+                    exceptions.reserve(workitems.size());
+                    exceptions.push_back(f.get_exception_ptr());
+                }
+            }
+
+            // now handle exceptions as needed
+            for (auto& e : exceptions)
+            {
+                call(e, errors);
             }
 
             if (throw_errors && !errors.empty())
+            {
                 throw exception_list(std::move(errors));
+            }
 #endif
         }
 
@@ -131,7 +159,7 @@ namespace hpx { namespace parallel { namespace util { namespace detail {
 #else
             bool has_exception = false;
             std::exception_ptr bad_alloc_exception;
-            for (hpx::future<T>& f : workitems)
+            for (auto& f : workitems)
             {
                 if (f.has_exception())
                 {
@@ -157,18 +185,24 @@ namespace hpx { namespace parallel { namespace util { namespace detail {
             // are assumed to have already run the cleanup).
             if (has_exception)
             {
-                for (hpx::future<T>& f : workitems)
+                for (auto& f : workitems)
                 {
                     if (!f.has_exception())
+                    {
                         cleanup(f.get());
+                    }
                 }
             }
 
             if (bad_alloc_exception)
+            {
                 std::rethrow_exception(bad_alloc_exception);
+            }
 
             if (throw_errors && !errors.empty())
+            {
                 throw exception_list(std::move(errors));
+            }
 #endif
         }
     };
@@ -211,7 +245,7 @@ namespace hpx { namespace parallel { namespace util { namespace detail {
             HPX_UNUSED(workitems);
             HPX_ASSERT(false);
 #else
-            for (hpx::future<T> const& f : workitems)
+            for (auto const& f : workitems)
             {
                 if (f.has_exception())
                 {
@@ -229,7 +263,7 @@ namespace hpx { namespace parallel { namespace util { namespace detail {
             HPX_UNUSED(workitems);
             HPX_ASSERT(false);
 #else
-            for (hpx::shared_future<T> const& f : workitems)
+            for (auto const& f : workitems)
             {
                 if (f.has_exception())
                 {
@@ -248,7 +282,7 @@ namespace hpx { namespace parallel { namespace util { namespace detail {
             HPX_UNUSED(workitems);
             HPX_ASSERT(false);
 #else
-            for (hpx::future<T> const& f : workitems)
+            for (auto const& f : workitems)
             {
                 if (f.has_exception())
                 {
@@ -297,7 +331,7 @@ namespace hpx { namespace parallel { namespace util { namespace detail {
             HPX_UNUSED(workitems);
             HPX_ASSERT(false);
 #else
-            for (hpx::future<T> const& f : workitems)
+            for (auto const& f : workitems)
             {
                 if (f.has_exception())
                 {
@@ -315,7 +349,7 @@ namespace hpx { namespace parallel { namespace util { namespace detail {
             HPX_UNUSED(workitems);
             HPX_ASSERT(false);
 #else
-            for (hpx::shared_future<T> const& f : workitems)
+            for (auto const& f : workitems)
             {
                 if (f.has_exception())
                 {
@@ -334,7 +368,7 @@ namespace hpx { namespace parallel { namespace util { namespace detail {
             HPX_UNUSED(workitems);
             HPX_ASSERT(false);
 #else
-            for (hpx::future<T> const& f : workitems)
+            for (auto const& f : workitems)
             {
                 if (f.has_exception())
                 {

--- a/libs/parallelism/algorithms/include/hpx/parallel/util/foreach_partitioner.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/util/foreach_partitioner.hpp
@@ -210,12 +210,18 @@ namespace hpx { namespace parallel { namespace util {
                 return hpx::future<FwdIter>();
 #else
                 // wait for all tasks to finish
+                // Note: the lambda takes the vectors by value (dataflow
+                //       moves those into the lambda) to ensure that they
+                //       will be destroyed before the lambda exists.
+                //       Otherwise the vectors stay alive in the dataflow's
+                //       shared state and may reference data that has gone
+                //       out of scope.
                 return hpx::dataflow(
                     [last, errors = std::move(errors),
                         scoped_params = std::move(scoped_params),
                         f = std::forward<F>(f)](
-                        std::vector<hpx::future<Result>>&& r1,
-                        std::vector<hpx::future<Result>>&& r2) mutable
+                        std::vector<hpx::future<Result>> r1,
+                        std::vector<hpx::future<Result>> r2) mutable
                     -> FwdIter {
                         HPX_UNUSED(scoped_params);
 

--- a/libs/parallelism/algorithms/include/hpx/parallel/util/loop.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/util/loop.hpp
@@ -433,65 +433,64 @@ namespace hpx { namespace parallel { namespace util {
                 return it + num;
             }
         };
+    }    // namespace detail
 
-        ///////////////////////////////////////////////////////////////////////
-        template <typename ExPolicy>
-        struct loop_n_t final
-          : hpx::functional::tag_fallback<loop_n_t<ExPolicy>>
+    ///////////////////////////////////////////////////////////////////////
+    template <typename ExPolicy>
+    struct loop_n_t final : hpx::functional::tag_fallback<loop_n_t<ExPolicy>>
+    {
+    private:
+        template <typename Iter, typename F>
+        friend HPX_HOST_DEVICE HPX_FORCEINLINE constexpr Iter
+        tag_fallback_dispatch(hpx::parallel::util::loop_n_t<ExPolicy>, Iter it,
+            std::size_t count, F&& f)
         {
-        private:
-            template <typename Iter, typename F>
-            friend HPX_HOST_DEVICE HPX_FORCEINLINE constexpr Iter
-            tag_fallback_dispatch(
-                hpx::parallel::util::detail::loop_n_t<ExPolicy>, Iter it,
-                std::size_t count, F&& f)
-            {
-                using pred = std::integral_constant<bool,
-                    hpx::traits::is_random_access_iterator<Iter>::value ||
-                        std::is_integral<Iter>::value>;
+            using pred = std::integral_constant<bool,
+                hpx::traits::is_random_access_iterator<Iter>::value ||
+                    std::is_integral<Iter>::value>;
 
-                return detail::loop_n_helper::call(
-                    it, count, std::forward<F>(f), pred());
-            }
+            return detail::loop_n_helper::call(
+                it, count, std::forward<F>(f), pred());
+        }
 
-            template <typename Iter, typename CancelToken, typename F>
-            friend HPX_HOST_DEVICE HPX_FORCEINLINE constexpr Iter
-            tag_fallback_dispatch(
-                hpx::parallel::util::detail::loop_n_t<ExPolicy>, Iter it,
-                std::size_t count, CancelToken& tok, F&& f)
-            {
-                using pred = std::integral_constant<bool,
-                    hpx::traits::is_random_access_iterator<Iter>::value ||
-                        std::is_integral<Iter>::value>;
+        template <typename Iter, typename CancelToken, typename F>
+        friend HPX_HOST_DEVICE HPX_FORCEINLINE constexpr Iter
+        tag_fallback_dispatch(hpx::parallel::util::loop_n_t<ExPolicy>, Iter it,
+            std::size_t count, CancelToken& tok, F&& f)
+        {
+            using pred = std::integral_constant<bool,
+                hpx::traits::is_random_access_iterator<Iter>::value ||
+                    std::is_integral<Iter>::value>;
 
-                return detail::loop_n_helper::call(
-                    it, count, tok, std::forward<F>(f), pred());
-            }
-        };
+            return detail::loop_n_helper::call(
+                it, count, tok, std::forward<F>(f), pred());
+        }
+    };
 
 #if !defined(HPX_COMPUTE_DEVICE_CODE)
-        template <typename ExPolicy>
-        HPX_INLINE_CONSTEXPR_VARIABLE loop_n_t<ExPolicy> loop_n =
-            loop_n_t<ExPolicy>{};
+    template <typename ExPolicy>
+    HPX_INLINE_CONSTEXPR_VARIABLE loop_n_t<ExPolicy> loop_n =
+        loop_n_t<ExPolicy>{};
 #else
-        template <typename ExPolicy, typename Iter, typename F>
-        HPX_HOST_DEVICE HPX_FORCEINLINE constexpr Iter loop_n(
-            Iter it, std::size_t count, F&& f)
-        {
-            return hpx::parallel::util::detail::loop_n_t<ExPolicy>{}(
-                it, count, std::forward<F>(f));
-        }
+    template <typename ExPolicy, typename Iter, typename F>
+    HPX_HOST_DEVICE HPX_FORCEINLINE constexpr Iter loop_n(
+        Iter it, std::size_t count, F&& f)
+    {
+        return hpx::parallel::util::loop_n_t<ExPolicy>{}(
+            it, count, std::forward<F>(f));
+    }
 
-        template <typename ExPolicy, typename Iter, typename CancelToken,
-            typename F>
-        HPX_HOST_DEVICE HPX_FORCEINLINE constexpr Iter loop_n(
-            Iter it, std::size_t count, CancelToken& tok, F&& f)
-        {
-            return hpx::parallel::util::detail::loop_n_t<ExPolicy>{}(
-                it, count, tok, std::forward<F>(f));
-        }
+    template <typename ExPolicy, typename Iter, typename CancelToken,
+        typename F>
+    HPX_HOST_DEVICE HPX_FORCEINLINE constexpr Iter loop_n(
+        Iter it, std::size_t count, CancelToken& tok, F&& f)
+    {
+        return hpx::parallel::util::loop_n_t<ExPolicy>{}(
+            it, count, tok, std::forward<F>(f));
+    }
 #endif
 
+    namespace detail {
         ///////////////////////////////////////////////////////////////////////
         template <typename ExPolicy>
         struct extract_value_t
@@ -701,65 +700,65 @@ namespace hpx { namespace parallel { namespace util {
                 return it + num;
             }
         };
+    }    // namespace detail
 
-        ///////////////////////////////////////////////////////////////////////
-        template <typename ExPolicy>
-        struct loop_n_ind_t final
-          : hpx::functional::tag_fallback<loop_n_ind_t<ExPolicy>>
-        {
-        private:
-            template <typename Iter, typename F>
-            friend HPX_HOST_DEVICE HPX_FORCEINLINE constexpr Iter
-            tag_fallback_dispatch(
-                hpx::parallel::util::detail::loop_n_ind_t<ExPolicy>, Iter it,
-                std::size_t count, F&& f)
-            {
-                using pred = std::integral_constant<bool,
-                    hpx::traits::is_random_access_iterator<Iter>::value ||
-                        std::is_integral<Iter>::value>;
-
-                return loop_n_ind_helper::call(
-                    it, count, std::forward<F>(f), pred());
-            }
-
-            template <typename Iter, typename CancelToken, typename F>
-            friend HPX_HOST_DEVICE HPX_FORCEINLINE constexpr Iter
-            tag_fallback_dispatch(
-                hpx::parallel::util::detail::loop_n_ind_t<ExPolicy>, Iter it,
-                std::size_t count, CancelToken& tok, F&& f)
-            {
-                using pred = std::integral_constant<bool,
-                    hpx::traits::is_random_access_iterator<Iter>::value ||
-                        std::is_integral<Iter>::value>;
-
-                return loop_n_ind_helper::call(
-                    it, count, tok, std::forward<F>(f), pred());
-            }
-        };
-
-#if !defined(HPX_COMPUTE_DEVICE_CODE)
-        template <typename ExPolicy>
-        HPX_INLINE_CONSTEXPR_VARIABLE loop_n_ind_t<ExPolicy> loop_n_ind =
-            loop_n_ind_t<ExPolicy>{};
-#else
-        template <typename ExPolicy, typename Iter, typename F>
-        HPX_HOST_DEVICE HPX_FORCEINLINE constexpr Iter loop_n_ind(
+    ///////////////////////////////////////////////////////////////////////
+    template <typename ExPolicy>
+    struct loop_n_ind_t final
+      : hpx::functional::tag_fallback<loop_n_ind_t<ExPolicy>>
+    {
+    private:
+        template <typename Iter, typename F>
+        friend HPX_HOST_DEVICE HPX_FORCEINLINE constexpr Iter
+        tag_fallback_dispatch(hpx::parallel::util::loop_n_ind_t<ExPolicy>,
             Iter it, std::size_t count, F&& f)
         {
-            return hpx::parallel::util::detail::loop_n_ind_t<ExPolicy>{}(
-                it, count, std::forward<F>(f));
+            using pred = std::integral_constant<bool,
+                hpx::traits::is_random_access_iterator<Iter>::value ||
+                    std::is_integral<Iter>::value>;
+
+            return detail::loop_n_ind_helper::call(
+                it, count, std::forward<F>(f), pred());
         }
 
-        template <typename ExPolicy, typename Iter, typename CancelToken,
-            typename F>
-        HPX_HOST_DEVICE HPX_FORCEINLINE constexpr Iter loop_n_ind(
+        template <typename Iter, typename CancelToken, typename F>
+        friend HPX_HOST_DEVICE HPX_FORCEINLINE constexpr Iter
+        tag_fallback_dispatch(hpx::parallel::util::loop_n_ind_t<ExPolicy>,
             Iter it, std::size_t count, CancelToken& tok, F&& f)
         {
-            return hpx::parallel::util::detail::loop_n_ind_t<ExPolicy>{}(
-                it, count, tok, std::forward<F>(f));
+            using pred = std::integral_constant<bool,
+                hpx::traits::is_random_access_iterator<Iter>::value ||
+                    std::is_integral<Iter>::value>;
+
+            return detail::loop_n_ind_helper::call(
+                it, count, tok, std::forward<F>(f), pred());
         }
+    };
+
+#if !defined(HPX_COMPUTE_DEVICE_CODE)
+    template <typename ExPolicy>
+    HPX_INLINE_CONSTEXPR_VARIABLE loop_n_ind_t<ExPolicy> loop_n_ind =
+        loop_n_ind_t<ExPolicy>{};
+#else
+    template <typename ExPolicy, typename Iter, typename F>
+    HPX_HOST_DEVICE HPX_FORCEINLINE constexpr Iter loop_n_ind(
+        Iter it, std::size_t count, F&& f)
+    {
+        return hpx::parallel::util::loop_n_ind_t<ExPolicy>{}(
+            it, count, std::forward<F>(f));
+    }
+
+    template <typename ExPolicy, typename Iter, typename CancelToken,
+        typename F>
+    HPX_HOST_DEVICE HPX_FORCEINLINE constexpr Iter loop_n_ind(
+        Iter it, std::size_t count, CancelToken& tok, F&& f)
+    {
+        return hpx::parallel::util::loop_n_ind_t<ExPolicy>{}(
+            it, count, tok, std::forward<F>(f));
+    }
 #endif
 
+    namespace detail {
         ///////////////////////////////////////////////////////////////////////
         // Helper class to repeatedly call a function a given number of times
         // starting from a given iterator position. If an exception is thrown,
@@ -843,12 +842,21 @@ namespace hpx { namespace parallel { namespace util {
             ///////////////////////////////////////////////////////////////////
             template <typename FwdIter, typename F, typename Cleanup>
             static FwdIter call(
-                FwdIter it, std::size_t count, F&& f, Cleanup&& cleanup)
+                FwdIter it, std::size_t num, F&& f, Cleanup&& cleanup)
             {
                 FwdIter base = it;
                 try
                 {
-                    for (/**/; count != 0; (void) --count, ++it)
+                    std::size_t count(num & std::size_t(-4));    // -V112
+                    for (std::size_t i = 0; i < count;
+                         (void) ++it, i += 4)    // -V112
+                    {
+                        HPX_INVOKE(f, it);
+                        HPX_INVOKE(f, ++it);
+                        HPX_INVOKE(f, ++it);
+                        HPX_INVOKE(f, ++it);
+                    }
+                    for (/**/; count < num; (void) ++count, ++it)
                     {
                         HPX_INVOKE(f, it);
                     }
@@ -866,13 +874,22 @@ namespace hpx { namespace parallel { namespace util {
 
             template <typename Iter, typename FwdIter, typename F,
                 typename Cleanup>
-            static FwdIter call(Iter it, std::size_t count, FwdIter dest, F&& f,
+            static FwdIter call(Iter it, std::size_t num, FwdIter dest, F&& f,
                 Cleanup&& cleanup)
             {
                 FwdIter base = dest;
                 try
                 {
-                    for (/**/; count != 0; (void) --count, ++it, ++dest)
+                    std::size_t count(num & std::size_t(-4));    // -V112
+                    for (std::size_t i = 0; i < count;
+                         (void) ++it, ++dest, i += 4)    // -V112
+                    {
+                        HPX_INVOKE(f, it, dest);
+                        HPX_INVOKE(f, ++it, ++dest);
+                        HPX_INVOKE(f, ++it, ++dest);
+                        HPX_INVOKE(f, ++it, ++dest);
+                    }
+                    for (/**/; count < num; (void) ++count, ++it, ++dest)
                     {
                         HPX_INVOKE(f, it, dest);
                     }
@@ -891,16 +908,29 @@ namespace hpx { namespace parallel { namespace util {
             ///////////////////////////////////////////////////////////////////
             template <typename FwdIter, typename CancelToken, typename F,
                 typename Cleanup>
-            static FwdIter call_with_token(FwdIter it, std::size_t count,
+            static FwdIter call_with_token(FwdIter it, std::size_t num,
                 CancelToken& tok, F&& f, Cleanup&& cleanup)
             {
                 FwdIter base = it;
                 try
                 {
-                    for (/**/; count != 0; (void) --count, ++it)
+                    std::size_t count(num & std::size_t(-4));    // -V112
+                    for (std::size_t i = 0; i < count;
+                         (void) ++it, i += 4)    // -V112
                     {
                         if (tok.was_cancelled())
                             break;
+
+                        HPX_INVOKE(f, it);
+                        HPX_INVOKE(f, ++it);
+                        HPX_INVOKE(f, ++it);
+                        HPX_INVOKE(f, ++it);
+                    }
+                    for (/**/; count < num; (void) ++count, ++it)
+                    {
+                        if (tok.was_cancelled())
+                            break;
+
                         HPX_INVOKE(f, it);
                     }
                     return it;
@@ -918,16 +948,29 @@ namespace hpx { namespace parallel { namespace util {
 
             template <typename Iter, typename FwdIter, typename CancelToken,
                 typename F, typename Cleanup>
-            static FwdIter call_with_token(Iter it, std::size_t count,
+            static FwdIter call_with_token(Iter it, std::size_t num,
                 FwdIter dest, CancelToken& tok, F&& f, Cleanup&& cleanup)
             {
                 FwdIter base = dest;
                 try
                 {
-                    for (/**/; count != 0; (void) --count, ++it, ++dest)
+                    std::size_t count(num & std::size_t(-4));    // -V112
+                    for (std::size_t i = 0; i < count;
+                         (void) ++it, ++dest, i += 4)    // -V112
                     {
                         if (tok.was_cancelled())
                             break;
+
+                        HPX_INVOKE(f, it, dest);
+                        HPX_INVOKE(f, ++it, ++dest);
+                        HPX_INVOKE(f, ++it, ++dest);
+                        HPX_INVOKE(f, ++it, ++dest);
+                    }
+                    for (/**/; count < num; (void) ++count, ++it, ++dest)
+                    {
+                        if (tok.was_cancelled())
+                            break;
+
                         HPX_INVOKE(f, it, dest);
                     }
                     return dest;

--- a/libs/parallelism/algorithms/include/hpx/parallel/util/prefetching.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/util/prefetching.hpp
@@ -59,7 +59,7 @@ namespace hpx { namespace parallel { namespace util {
             std::size_t idx_;
 
         public:
-            // different version of clang-formt do different things
+            // different versions of clang-format do different things
             // clang-format off
             explicit prefetching_iterator(std::size_t idx, base_iterator base,
                 std::size_t chunk_size, std::size_t range_size,
@@ -97,7 +97,7 @@ namespace hpx { namespace parallel { namespace util {
 
             inline prefetching_iterator& operator+=(difference_type rhs)
             {
-                // different version of clang-formt do different things
+                // different versions of clang-format do different things
                 // clang-format off
                 std::size_t last =
                     (std::min) (idx_ + rhs * chunk_size_, range_size_);
@@ -292,7 +292,7 @@ namespace hpx { namespace parallel { namespace util {
                     Itr base = it.base();
                     std::size_t j = it.index();
 
-                    // different version of clang-formt do different things
+                    // different versions of clang-format do different things
                     // clang-format off
                     std::size_t last = (std::min) (it.index() + it.chunk_size(),
                         it.range_size());
@@ -328,7 +328,7 @@ namespace hpx { namespace parallel { namespace util {
                     Itr base = it.base();
                     std::size_t j = it.index();
 
-                    // different version of clang-formt do different things
+                    // different versions of clang-format do different things
                     // clang-format off
                     std::size_t last = (std::min) (it.index() + it.chunk_size(),
                         it.range_size());
@@ -375,7 +375,7 @@ namespace hpx { namespace parallel { namespace util {
                     Itr base = it.base();
                     std::size_t j = it.index();
 
-                    // different version of clang-formt do different things
+                    // different versions of clang-format do different things
                     // clang-format off
                     std::size_t last = (std::min) (it.index() + it.chunk_size(),
                         it.range_size());
@@ -411,7 +411,7 @@ namespace hpx { namespace parallel { namespace util {
                     Itr base = it.base();
                     std::size_t j = it.index();
 
-                    // different version of clang-formt do different things
+                    // different versions of clang-format do different things
                     // clang-format off
                     std::size_t last = (std::min) (it.index() + it.chunk_size(),
                         it.range_size());
@@ -479,7 +479,7 @@ namespace hpx { namespace parallel { namespace util {
                     Itr base = it.base();
                     std::size_t j = it.index();
 
-                    // different version of clang-formt do different things
+                    // different versions of clang-format do different things
                     // clang-format off
                     std::size_t last = (std::min) (it.index() + it.chunk_size(),
                         it.range_size());
@@ -506,7 +506,7 @@ namespace hpx { namespace parallel { namespace util {
                     Itr base = it.base();
                     std::size_t j = it.index();
 
-                    // different version of clang-formt do different things
+                    // different versions of clang-format do different things
                     // clang-format off
                     std::size_t last = (std::min) (it.index() + it.chunk_size(),
                         it.range_size());
@@ -539,7 +539,7 @@ namespace hpx { namespace parallel { namespace util {
                     Itr base = it.base();
                     std::size_t j = it.index();
 
-                    // different version of clang-formt do different things
+                    // different versions of clang-format do different things
                     // clang-format off
                     std::size_t last = (std::min) (it.index() + it.chunk_size(),
                         it.range_size());
@@ -566,7 +566,7 @@ namespace hpx { namespace parallel { namespace util {
                     Itr base = it.base();
                     std::size_t j = it.index();
 
-                    // different version of clang-formt do different things
+                    // different versions of clang-format do different things
                     // clang-format off
                     std::size_t last = (std::min) (it.index() + it.chunk_size(),
                         it.range_size());

--- a/libs/parallelism/algorithms/include/hpx/parallel/util/prefetching.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/util/prefetching.hpp
@@ -59,6 +59,8 @@ namespace hpx { namespace parallel { namespace util {
             std::size_t idx_;
 
         public:
+            // different version of clang-formt do different things
+            // clang-format off
             explicit prefetching_iterator(std::size_t idx, base_iterator base,
                 std::size_t chunk_size, std::size_t range_size,
                 ranges_type const& rngs)
@@ -66,9 +68,10 @@ namespace hpx { namespace parallel { namespace util {
               , base_(base)
               , chunk_size_(chunk_size)
               , range_size_(range_size)
-              , idx_((std::min)(idx, range_size))
+              , idx_((std::min) (idx, range_size))
             {
             }
+            // clang-format on
 
             ranges_type const& ranges() const
             {
@@ -94,8 +97,11 @@ namespace hpx { namespace parallel { namespace util {
 
             inline prefetching_iterator& operator+=(difference_type rhs)
             {
+                // different version of clang-formt do different things
+                // clang-format off
                 std::size_t last =
-                    (std::min)(idx_ + rhs * chunk_size_, range_size_);
+                    (std::min) (idx_ + rhs * chunk_size_, range_size_);
+                // clang-format on
 
                 std::advance(base_, last - idx_);
                 idx_ = last;
@@ -286,8 +292,11 @@ namespace hpx { namespace parallel { namespace util {
                     Itr base = it.base();
                     std::size_t j = it.index();
 
-                    std::size_t last = (std::min)(
-                        it.index() + it.chunk_size(), it.range_size());
+                    // different version of clang-formt do different things
+                    // clang-format off
+                    std::size_t last = (std::min) (it.index() + it.chunk_size(),
+                        it.range_size());
+                    // clang-format on
 
                     for (/**/; j != last; (void) ++j, ++base)
                     {
@@ -319,8 +328,11 @@ namespace hpx { namespace parallel { namespace util {
                     Itr base = it.base();
                     std::size_t j = it.index();
 
-                    std::size_t last = (std::min)(
-                        it.index() + it.chunk_size(), it.range_size());
+                    // different version of clang-formt do different things
+                    // clang-format off
+                    std::size_t last = (std::min) (it.index() + it.chunk_size(),
+                        it.range_size());
+                    // clang-format on
 
                     for (/**/; j != last; (void) ++j, ++base)
                     {
@@ -340,7 +352,7 @@ namespace hpx { namespace parallel { namespace util {
         template <typename ExPolicy, typename Itr, typename... Ts, typename F>
         HPX_HOST_DEVICE
             HPX_FORCEINLINE constexpr prefetching_iterator<Itr, Ts...>
-            tag_dispatch(hpx::parallel::util::detail::loop_n_t<ExPolicy>,
+            tag_dispatch(hpx::parallel::util::loop_n_t<ExPolicy>,
                 prefetching_iterator<Itr, Ts...> it, std::size_t count, F&& f)
         {
             return loop_n_helper::call(
@@ -363,8 +375,11 @@ namespace hpx { namespace parallel { namespace util {
                     Itr base = it.base();
                     std::size_t j = it.index();
 
-                    std::size_t last = (std::min)(
-                        it.index() + it.chunk_size(), it.range_size());
+                    // different version of clang-formt do different things
+                    // clang-format off
+                    std::size_t last = (std::min) (it.index() + it.chunk_size(),
+                        it.range_size());
+                    // clang-format on
 
                     for (/**/; j != last; (void) ++j, ++base)
                     {
@@ -396,8 +411,11 @@ namespace hpx { namespace parallel { namespace util {
                     Itr base = it.base();
                     std::size_t j = it.index();
 
-                    std::size_t last = (std::min)(
-                        it.index() + it.chunk_size(), it.range_size());
+                    // different version of clang-formt do different things
+                    // clang-format off
+                    std::size_t last = (std::min) (it.index() + it.chunk_size(),
+                        it.range_size());
+                    // clang-format on
 
                     for (/**/; j != last; (void) ++j, ++base)
                     {
@@ -417,7 +435,7 @@ namespace hpx { namespace parallel { namespace util {
         template <typename ExPolicy, typename Itr, typename... Ts, typename F>
         HPX_HOST_DEVICE
             HPX_FORCEINLINE constexpr prefetching_iterator<Itr, Ts...>
-            tag_dispatch(hpx::parallel::util::detail::loop_n_ind_t<ExPolicy>,
+            tag_dispatch(hpx::parallel::util::loop_n_ind_t<ExPolicy>,
                 prefetching_iterator<Itr, Ts...> it, std::size_t count, F&& f)
         {
             return loop_n_ind_helper::call(
@@ -461,8 +479,11 @@ namespace hpx { namespace parallel { namespace util {
                     Itr base = it.base();
                     std::size_t j = it.index();
 
-                    std::size_t last = (std::min)(
-                        it.index() + it.chunk_size(), it.range_size());
+                    // different version of clang-formt do different things
+                    // clang-format off
+                    std::size_t last = (std::min) (it.index() + it.chunk_size(),
+                        it.range_size());
+                    // clang-format on
 
                     for (/**/; j != last; (void) ++j, ++base)
                         f(base);
@@ -485,8 +506,11 @@ namespace hpx { namespace parallel { namespace util {
                     Itr base = it.base();
                     std::size_t j = it.index();
 
-                    std::size_t last = (std::min)(
-                        it.index() + it.chunk_size(), it.range_size());
+                    // different version of clang-formt do different things
+                    // clang-format off
+                    std::size_t last = (std::min) (it.index() + it.chunk_size(),
+                        it.range_size());
+                    // clang-format on
 
                     for (/**/; j != last; (void) ++j, ++base)
                         f(base);
@@ -515,8 +539,11 @@ namespace hpx { namespace parallel { namespace util {
                     Itr base = it.base();
                     std::size_t j = it.index();
 
-                    std::size_t last = (std::min)(
-                        it.index() + it.chunk_size(), it.range_size());
+                    // different version of clang-formt do different things
+                    // clang-format off
+                    std::size_t last = (std::min) (it.index() + it.chunk_size(),
+                        it.range_size());
+                    // clang-format on
 
                     for (/**/; j != last; (void) ++j, ++base)
                         f(*base);
@@ -539,8 +566,11 @@ namespace hpx { namespace parallel { namespace util {
                     Itr base = it.base();
                     std::size_t j = it.index();
 
-                    std::size_t last = (std::min)(
-                        it.index() + it.chunk_size(), it.range_size());
+                    // different version of clang-formt do different things
+                    // clang-format off
+                    std::size_t last = (std::min) (it.index() + it.chunk_size(),
+                        it.range_size());
+                    // clang-format on
 
                     for (/**/; j != last; (void) ++j, ++base)
                         f(*base);


### PR DESCRIPTION
- flyby: modernize `transform` algorithms, `annotated_function`
- flyby: various optimizations for transform algorithms
- flyby: move `parallel::util::detail::loop_n` and `parallel::util::detail::loop_n_ind`
  into `namespace parallel::util`
- flyby: enable `datapar` for `for_loop` with stride == 1 and no additional reducers
- flyby: add `transform_binary_loop_ind` and `transform_binary_loop_ind_n` helper facilities (these need datapar counterparts, still)

Fixes #5397

If we decided to add the lifting of annotated function from the algorithm iteration to the chunk (as currently proposed), then other algorithms need to be adapted. If we decided not to add the lifting (but perhaps add a generic implementation for executors to support annotations), then I'll change this PR, leaving only all the flyby changes, which on their own improve things in various ways.
