### PR TITLE
Create generic executor that adds annotations to any other executor

### DIFF
--- a/libs/core/concepts/include/hpx/concepts/has_member_xxx.hpp
+++ b/libs/core/concepts/include/hpx/concepts/has_member_xxx.hpp
@@ -12,16 +12,6 @@
 
 #include <type_traits>
 
-#if defined(HPX_HAVE_CXX17_VARIABLE_TEMPLATES)
-#define HPX_HAS_MEMBER_XXX_TRAIT_DEF_CXX17(MEMBER)                             \
-    template <typename T>                                                      \
-    constexpr bool HPX_PP_CAT(HPX_PP_CAT(has_, MEMBER), _v) =                  \
-        HPX_PP_CAT(has_, MEMBER)::value;                                       \
-    /**/
-#else
-#define HPX_HAS_MEMBER_XXX_TRAIT_DEF_CXX17(MEMBER) /**/
-#endif
-
 /// This macro creates a boolean unary meta-function which result is
 /// true if and only if its parameter type has member function with
 /// MEMBER name (no matter static it is or not). The generated trait
@@ -76,5 +66,7 @@
     using HPX_PP_CAT(HPX_PP_CAT(has_, MEMBER), _t) =                           \
         typename HPX_PP_CAT(has_, MEMBER)<T>::type;                            \
                                                                                \
-    HPX_HAS_MEMBER_XXX_TRAIT_DEF_CXX17(MEMBER)                                 \
+    template <typename T>                                                      \
+    HPX_INLINE_CONSTEXPR_VARIABLE bool HPX_PP_CAT(                             \
+        HPX_PP_CAT(has_, MEMBER), _v) = HPX_PP_CAT(has_, MEMBER)<T>::value;    \
     /**/

--- a/libs/core/concepts/include/hpx/concepts/has_xxx.hpp
+++ b/libs/core/concepts/include/hpx/concepts/has_xxx.hpp
@@ -13,16 +13,6 @@
 
 #include <type_traits>
 
-#if defined(HPX_HAVE_CXX17_VARIABLE_TEMPLATES)
-#define HPX_HAS_XXX_TRAIT_DEF_CXX17(Name)                                      \
-    template <typename T>                                                      \
-    constexpr bool HPX_PP_CAT(HPX_PP_CAT(has_, Name), _v) =                    \
-        HPX_PP_CAT(has_, Name)::value;                                         \
-    /**/
-#else
-#define HPX_HAS_XXX_TRAIT_DEF_CXX17(Name) /**/
-#endif
-
 /// This macro creates a boolean unary meta-function such that for
 /// any type X, has_name<X>::value == true if and only if X is a
 /// class type and has a nested type member x::name. The generated
@@ -46,5 +36,7 @@
     using HPX_PP_CAT(HPX_PP_CAT(has_, Name), _t) =                             \
         typename HPX_PP_CAT(has_, Name)<T>::type;                              \
                                                                                \
-    HPX_HAS_XXX_TRAIT_DEF_CXX17(Name)                                          \
+    template <typename T>                                                      \
+    HPX_INLINE_CONSTEXPR_VARIABLE bool HPX_PP_CAT(                             \
+        HPX_PP_CAT(has_, Name), _v) = HPX_PP_CAT(has_, Name)<T>::value;        \
     /**/

--- a/libs/core/execution_base/include/hpx/execution_base/traits/is_executor.hpp
+++ b/libs/core/execution_base/include/hpx/execution_base/traits/is_executor.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2017 Hartmut Kaiser
+//  Copyright (c) 2017-2021 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -44,87 +44,47 @@ namespace hpx { namespace parallel { namespace execution {
     // Condition: T meets the syntactic requirements for OneWayExecutor
     // Precondition: T is a complete type
     template <typename T, typename Enable = void>
-    struct is_one_way_executor
-      : detail::is_one_way_executor<typename std::decay<T>::type>
+    struct is_one_way_executor : detail::is_one_way_executor<std::decay_t<T>>
     {
     };
-
-    template <typename T>
-    using is_one_way_executor_t = typename is_one_way_executor<T>::type;
 
     // Condition: T meets the syntactic requirements for NonBlockingOneWayExecutor
     // Precondition: T is a complete type
     template <typename T, typename Enable = void>
     struct is_never_blocking_one_way_executor
-      : detail::is_never_blocking_one_way_executor<typename std::decay<T>::type>
+      : detail::is_never_blocking_one_way_executor<std::decay_t<T>>
     {
     };
-
-    template <typename T>
-    using is_never_blocking_one_way_executor_t =
-        typename is_never_blocking_one_way_executor<T>::type;
 
     // Condition: T meets the syntactic requirements for BulkOneWayExecutor
     // Precondition: T is a complete type
     template <typename T, typename Enable = void>
     struct is_bulk_one_way_executor
-      : detail::is_bulk_one_way_executor<typename std::decay<T>::type>
+      : detail::is_bulk_one_way_executor<std::decay_t<T>>
     {
     };
-
-    template <typename T>
-    using is_bulk_one_way_executor_t =
-        typename is_bulk_one_way_executor<T>::type;
 
     // Condition: T meets the syntactic requirements for TwoWayExecutor
     // Precondition: T is a complete type
     template <typename T, typename Enable = void>
-    struct is_two_way_executor
-      : detail::is_two_way_executor<typename std::decay<T>::type>
+    struct is_two_way_executor : detail::is_two_way_executor<std::decay_t<T>>
     {
     };
-
-    template <typename T>
-    using is_two_way_executor_t = typename is_two_way_executor<T>::type;
 
     // Condition: T meets the syntactic requirements for BulkTwoWayExecutor
     // Precondition: T is a complete type
     template <typename T, typename Enable = void>
     struct is_bulk_two_way_executor
-      : detail::is_bulk_two_way_executor<typename std::decay<T>::type>
+      : detail::is_bulk_two_way_executor<std::decay_t<T>>
     {
     };
-
-    template <typename T>
-    using is_bulk_two_way_executor_t =
-        typename is_bulk_two_way_executor<T>::type;
-
-#if defined(HPX_HAVE_CXX17_VARIABLE_TEMPLATES)
-    template <typename T>
-    constexpr bool is_one_way_executor_v = is_one_way_executor<T>::value;
-
-    template <typename T>
-    constexpr bool is_never_blocking_one_way_executor_v =
-        is_never_blocking_one_way_executor<T>::value;
-
-    template <typename T>
-    constexpr bool is_bulk_one_way_executor_v =
-        is_bulk_one_way_executor<T>::value;
-
-    template <typename T>
-    constexpr bool is_two_way_executor_v = is_two_way_executor<T>::value;
-
-    template <typename T>
-    constexpr bool is_bulk_two_way_executor_v =
-        is_bulk_two_way_executor<T>::value;
-#endif
 }}}    // namespace hpx::parallel::execution
 
 namespace hpx { namespace traits {
     // Concurrency TS V2: executor framework
     template <typename T, typename Enable = void>
     struct is_one_way_executor
-      : parallel::execution::is_one_way_executor<typename std::decay<T>::type>
+      : parallel::execution::is_one_way_executor<std::decay_t<T>>
     {
     };
 
@@ -133,8 +93,7 @@ namespace hpx { namespace traits {
 
     template <typename T, typename Enable = void>
     struct is_never_blocking_one_way_executor
-      : parallel::execution::is_never_blocking_one_way_executor<
-            typename std::decay<T>::type>
+      : parallel::execution::is_never_blocking_one_way_executor<std::decay_t<T>>
     {
     };
 
@@ -144,8 +103,7 @@ namespace hpx { namespace traits {
 
     template <typename T, typename Enable = void>
     struct is_bulk_one_way_executor
-      : parallel::execution::is_bulk_one_way_executor<
-            typename std::decay<T>::type>
+      : parallel::execution::is_bulk_one_way_executor<std::decay_t<T>>
     {
     };
 
@@ -155,7 +113,7 @@ namespace hpx { namespace traits {
 
     template <typename T, typename Enable = void>
     struct is_two_way_executor
-      : parallel::execution::is_two_way_executor<typename std::decay<T>::type>
+      : parallel::execution::is_two_way_executor<std::decay_t<T>>
     {
     };
 
@@ -164,8 +122,7 @@ namespace hpx { namespace traits {
 
     template <typename T, typename Enable = void>
     struct is_bulk_two_way_executor
-      : parallel::execution::is_bulk_two_way_executor<
-            typename std::decay<T>::type>
+      : parallel::execution::is_bulk_two_way_executor<std::decay_t<T>>
     {
     };
 
@@ -185,26 +142,27 @@ namespace hpx { namespace traits {
     template <typename T>
     using is_executor_any_t = typename is_executor_any<T>::type;
 
-#if defined(HPX_HAVE_CXX17_VARIABLE_TEMPLATES)
     template <typename T>
-    constexpr bool is_one_way_executor_v = is_one_way_executor<T>::value;
+    HPX_INLINE_CONSTEXPR_VARIABLE bool is_one_way_executor_v =
+        is_one_way_executor<T>::value;
 
     template <typename T>
-    constexpr bool is_never_blocking_one_way_executor_v =
+    HPX_INLINE_CONSTEXPR_VARIABLE bool is_never_blocking_one_way_executor_v =
         is_never_blocking_one_way_executor<T>::value;
 
     template <typename T>
-    constexpr bool is_bulk_one_way_executor_v =
+    HPX_INLINE_CONSTEXPR_VARIABLE bool is_bulk_one_way_executor_v =
         is_bulk_one_way_executor<T>::value;
 
     template <typename T>
-    constexpr bool is_two_way_executor_v = is_two_way_executor<T>::value;
+    HPX_INLINE_CONSTEXPR_VARIABLE bool is_two_way_executor_v =
+        is_two_way_executor<T>::value;
 
     template <typename T>
-    constexpr bool is_bulk_two_way_executor_v =
+    HPX_INLINE_CONSTEXPR_VARIABLE bool is_bulk_two_way_executor_v =
         is_bulk_two_way_executor<T>::value;
 
     template <typename T>
-    constexpr bool is_executor_any_v = is_executor_any<T>::value;
-#endif
+    HPX_INLINE_CONSTEXPR_VARIABLE bool is_executor_any_v =
+        is_executor_any<T>::value;
 }}    // namespace hpx::traits

--- a/libs/core/execution_base/include/hpx/execution_base/traits/is_executor_parameters.hpp
+++ b/libs/core/execution_base/include/hpx/execution_base/traits/is_executor_parameters.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2014-2017 Hartmut Kaiser
+//  Copyright (c) 2014-2021 Hartmut Kaiser
 //  Copyright (c) 2016 Marcin Copik
 //
 //  SPDX-License-Identifier: BSL-1.0
@@ -94,10 +94,9 @@ namespace hpx { namespace parallel { namespace execution {
     template <typename T>
     using is_executor_parameters_t = typename is_executor_parameters<T>::type;
 
-#if defined(HPX_HAVE_CXX17_VARIABLE_TEMPLATES)
     template <typename T>
-    constexpr bool is_executor_parameters_v = is_executor_parameters<T>::value;
-#endif
+    HPX_INLINE_CONSTEXPR_VARIABLE bool is_executor_parameters_v =
+        is_executor_parameters<T>::value;
 }}}    // namespace hpx::parallel::execution
 
 namespace hpx { namespace traits {
@@ -111,8 +110,7 @@ namespace hpx { namespace traits {
     template <typename T>
     using is_executor_parameters_t = typename is_executor_parameters<T>::type;
 
-#if defined(HPX_HAVE_CXX17_VARIABLE_TEMPLATES)
     template <typename T>
-    constexpr bool is_executor_parameters_v = is_executor_parameters<T>::value;
-#endif
+    HPX_INLINE_CONSTEXPR_VARIABLE bool is_executor_parameters_v =
+        is_executor_parameters<T>::value;
 }}    // namespace hpx::traits

--- a/libs/core/functional/include/hpx/functional/deferred_call.hpp
+++ b/libs/core/functional/include/hpx/functional/deferred_call.hpp
@@ -43,6 +43,10 @@ namespace hpx { namespace util {
         {
         };
 
+        template <typename F, typename... Ts>
+        using invoke_deferred_result_t =
+            typename invoke_deferred_result<F, Ts...>::type;
+
         ///////////////////////////////////////////////////////////////////////
         template <typename F, typename Is, typename... Ts>
         class deferred;

--- a/libs/core/functional/include/hpx/functional/tag_dispatch.hpp
+++ b/libs/core/functional/include/hpx/functional/tag_dispatch.hpp
@@ -162,7 +162,7 @@ namespace hpx { namespace functional {
             Args...>;
 
     template <typename Tag, typename... Args>
-    constexpr bool is_tag_dispatchable_v =
+    HPX_INLINE_CONSTEXPR_VARIABLE bool is_tag_dispatchable_v =
         is_tag_dispatchable<Tag, Args...>::value;
 
     namespace detail {
@@ -193,7 +193,7 @@ namespace hpx { namespace functional {
     };
 
     template <typename Tag, typename... Args>
-    constexpr bool is_nothrow_tag_dispatchable_v =
+    HPX_INLINE_CONSTEXPR_VARIABLE bool is_nothrow_tag_dispatchable_v =
         is_nothrow_tag_dispatchable<Tag, Args...>::value;
 
     template <typename Tag, typename... Args>
@@ -231,8 +231,8 @@ namespace hpx { namespace functional {
         struct tag_noexcept
         {
             template <typename... Args,
-                typename Enable = typename std::enable_if<
-                    is_nothrow_tag_dispatchable_v<Tag, Args...>>::type>
+                typename Enable = std::enable_if_t<
+                    is_nothrow_tag_dispatchable_v<Tag, Args...>>>
             HPX_HOST_DEVICE HPX_FORCEINLINE constexpr auto operator()(
                 Args&&... args) const noexcept
                 -> tag_dispatch_result_t<Tag, decltype(args)...>

--- a/libs/core/functional/include/hpx/functional/tag_fallback_dispatch.hpp
+++ b/libs/core/functional/include/hpx/functional/tag_fallback_dispatch.hpp
@@ -165,7 +165,7 @@ namespace hpx { namespace functional {
             Tag, Args...>;
 
     template <typename Tag, typename... Args>
-    constexpr bool is_tag_fallback_dispatchable_v =
+    HPX_INLINE_CONSTEXPR_VARIABLE bool is_tag_fallback_dispatchable_v =
         is_tag_fallback_dispatchable<Tag, Args...>::value;
 
     namespace detail {
@@ -200,7 +200,7 @@ namespace hpx { namespace functional {
     };
 
     template <typename Tag, typename... Args>
-    constexpr bool is_nothrow_tag_fallback_dispatchable_v =
+    HPX_INLINE_CONSTEXPR_VARIABLE bool is_nothrow_tag_fallback_dispatchable_v =
         is_nothrow_tag_fallback_dispatchable<Tag, Args...>::value;
 
     template <typename Tag, typename... Args>
@@ -256,8 +256,8 @@ namespace hpx { namespace functional {
         {
             // is tag-dispatchable
             template <typename... Args,
-                typename Enable = typename std::enable_if<
-                    is_tag_dispatchable_v<Tag, Args&&...>>::type>
+                typename Enable =
+                    std::enable_if_t<is_tag_dispatchable_v<Tag, Args&&...>>>
             HPX_HOST_DEVICE HPX_FORCEINLINE constexpr auto operator()(
                 Args&&... args) const
                 noexcept(is_nothrow_tag_dispatchable_v<Tag, Args...>)
@@ -269,8 +269,8 @@ namespace hpx { namespace functional {
 
             // is not tag-dispatchable
             template <typename... Args,
-                typename Enable = typename std::enable_if<
-                    !is_tag_dispatchable_v<Tag, Args&&...>>::type>
+                typename Enable =
+                    std::enable_if_t<!is_tag_dispatchable_v<Tag, Args&&...>>>
             HPX_HOST_DEVICE HPX_FORCEINLINE constexpr auto operator()(
                 Args&&... args) const
                 noexcept(is_nothrow_tag_fallback_dispatchable_v<Tag, Args...>)
@@ -309,8 +309,8 @@ namespace hpx { namespace functional {
         public:
             // is nothrow tag-dispatchable
             template <typename... Args,
-                typename Enable = typename std::enable_if<
-                    is_nothrow_tag_dispatchable_v<Tag, Args&&...>>::type>
+                typename Enable = std::enable_if_t<
+                    is_nothrow_tag_dispatchable_v<Tag, Args&&...>>>
             HPX_HOST_DEVICE HPX_FORCEINLINE constexpr auto operator()(
                 Args&&... args) const noexcept
                 -> tag_dispatch_result_t<Tag, Args&&...>
@@ -323,8 +323,8 @@ namespace hpx { namespace functional {
             template <typename... Args,
                 typename IsFallbackDispatchable =
                     is_nothrow_tag_fallback_dispatchable<Tag, Args&&...>,
-                typename Enable = typename std::enable_if<
-                    !is_nothrow_tag_dispatchable_v<Tag, Args&&...>>::type>
+                typename Enable = std::enable_if_t<
+                    !is_nothrow_tag_dispatchable_v<Tag, Args&&...>>>
             HPX_HOST_DEVICE HPX_FORCEINLINE constexpr auto operator()(
                 Args&&... args) const noexcept
                 -> decltype(tag_fallback_dispatch_impl(

--- a/libs/core/functional/include/hpx/functional/tag_priority_dispatch.hpp
+++ b/libs/core/functional/include/hpx/functional/tag_priority_dispatch.hpp
@@ -167,7 +167,7 @@ namespace hpx { namespace functional {
             Tag, Args...>;
 
     template <typename Tag, typename... Args>
-    constexpr bool is_tag_override_dispatchable_v =
+    HPX_INLINE_CONSTEXPR_VARIABLE bool is_tag_override_dispatchable_v =
         is_tag_override_dispatchable<Tag, Args...>::value;
 
     namespace detail {
@@ -202,7 +202,7 @@ namespace hpx { namespace functional {
     };
 
     template <typename Tag, typename... Args>
-    constexpr bool is_nothrow_tag_override_dispatchable_v =
+    HPX_INLINE_CONSTEXPR_VARIABLE bool is_nothrow_tag_override_dispatchable_v =
         is_nothrow_tag_override_dispatchable<Tag, Args...>::value;
 
     template <typename Tag, typename... Args>
@@ -238,8 +238,8 @@ namespace hpx { namespace functional {
         {
             // Is tag-override-dispatchable
             template <typename... Args,
-                typename Enable = typename std::enable_if<
-                    is_tag_override_dispatchable_v<Tag, Args&&...>>::type>
+                typename Enable = std::enable_if_t<
+                    is_tag_override_dispatchable_v<Tag, Args&&...>>>
             HPX_HOST_DEVICE HPX_FORCEINLINE constexpr auto operator()(
                 Args&&... args) const
                 noexcept(is_nothrow_tag_override_dispatchable_v<Tag, Args...>)
@@ -251,9 +251,9 @@ namespace hpx { namespace functional {
 
             // Is not tag-override-dispatchable, but tag-dispatchable
             template <typename... Args,
-                typename Enable = typename std::enable_if<
+                typename Enable = std::enable_if_t<
                     !is_tag_override_dispatchable_v<Tag, Args&&...> &&
-                    is_tag_dispatchable_v<Tag, Args&&...>>::type>
+                    is_tag_dispatchable_v<Tag, Args&&...>>>
             HPX_HOST_DEVICE HPX_FORCEINLINE constexpr auto operator()(
                 Args&&... args) const
                 noexcept(is_nothrow_tag_dispatchable_v<Tag, Args...>)
@@ -266,10 +266,10 @@ namespace hpx { namespace functional {
             // Is not tag-override-dispatchable, not tag-dispatchable, but
             // tag-fallback-dispatchable
             template <typename... Args,
-                typename Enable = typename std::enable_if<
+                typename Enable = std::enable_if_t<
                     !is_tag_override_dispatchable_v<Tag, Args&&...> &&
                     !is_tag_dispatchable_v<Tag, Args&&...> &&
-                    is_tag_fallback_dispatchable_v<Tag, Args&&...>>::type>
+                    is_tag_fallback_dispatchable_v<Tag, Args&&...>>>
             HPX_HOST_DEVICE HPX_FORCEINLINE constexpr auto operator()(
                 Args&&... args) const
                 noexcept(is_nothrow_tag_fallback_dispatchable_v<Tag, Args...>)
@@ -290,9 +290,8 @@ namespace hpx { namespace functional {
         {
             // Is nothrow tag-override-dispatchable
             template <typename... Args,
-                typename Enable = typename std::enable_if<
-                    is_nothrow_tag_override_dispatchable_v<Tag,
-                        Args&&...>>::type>
+                typename Enable = std::enable_if_t<
+                    is_nothrow_tag_override_dispatchable_v<Tag, Args&&...>>>
             HPX_HOST_DEVICE HPX_FORCEINLINE constexpr auto operator()(
                 Args&&... args) const noexcept
                 -> tag_override_dispatch_result_t<Tag, Args&&...>
@@ -304,9 +303,9 @@ namespace hpx { namespace functional {
             // Is not nothrow tag-override-dispatchable, but nothrow
             // tag-dispatchable
             template <typename... Args,
-                typename Enable = typename std::enable_if<
+                typename Enable = std::enable_if_t<
                     !is_nothrow_tag_override_dispatchable_v<Tag, Args&&...> &&
-                    is_nothrow_tag_dispatchable_v<Tag, Args&&...>>::type>
+                    is_nothrow_tag_dispatchable_v<Tag, Args&&...>>>
             HPX_HOST_DEVICE HPX_FORCEINLINE constexpr auto operator()(
                 Args&&... args) const noexcept
                 -> tag_dispatch_result_t<Tag, Args&&...>
@@ -318,11 +317,10 @@ namespace hpx { namespace functional {
             // Is not nothrow tag-override-dispatchable, not nothrow
             // tag-dispatchable, but nothrow tag-fallback-dispatchable
             template <typename... Args,
-                typename Enable = typename std::enable_if<
+                typename Enable = std::enable_if_t<
                     !is_nothrow_tag_override_dispatchable_v<Tag, Args&&...> &&
                     !is_nothrow_tag_dispatchable_v<Tag, Args&&...> &&
-                    is_nothrow_tag_fallback_dispatchable_v<Tag,
-                        Args&&...>>::type>
+                    is_nothrow_tag_fallback_dispatchable_v<Tag, Args&&...>>>
             HPX_HOST_DEVICE HPX_FORCEINLINE constexpr auto operator()(
                 Args&&... args) const noexcept
                 -> tag_fallback_dispatch_result_t<Tag, Args&&...>

--- a/libs/core/type_support/include/hpx/type_support/always_void.hpp
+++ b/libs/core/type_support/include/hpx/type_support/always_void.hpp
@@ -12,4 +12,7 @@ namespace hpx { namespace util {
     {
         using type = void;
     };
+
+    template <typename... T>
+    using always_void_t = typename always_void<T...>::type;
 }}    // namespace hpx::util

--- a/libs/parallelism/execution/include/hpx/execution/executors/fused_bulk_execute.hpp
+++ b/libs/parallelism/execution/include/hpx/execution/executors/fused_bulk_execute.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2017-2019 Hartmut Kaiser
+//  Copyright (c) 2017-2021 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -20,16 +20,22 @@
 #include <vector>
 
 namespace hpx { namespace parallel { namespace execution { namespace detail {
+
     ///////////////////////////////////////////////////////////////////////////
     template <typename F, typename Shape, typename Future, typename... Ts>
     struct then_bulk_function_result
     {
-        typedef
-            typename hpx::traits::range_traits<Shape>::value_type value_type;
-        typedef typename hpx::util::detail::invoke_deferred_result<F,
-            value_type, Future, Ts...>::type type;
+        using value_type =
+            typename hpx::traits::range_traits<Shape>::value_type;
+        using type = hpx::util::detail::invoke_deferred_result_t<F, value_type,
+            Future, Ts...>;
     };
 
+    template <typename F, typename Shape, typename Future, typename... Ts>
+    using then_bulk_function_result_t =
+        typename then_bulk_function_result<F, Shape, Future, Ts...>::type;
+
+    ///////////////////////////////////////////////////////////////////////////
     template <typename F, typename Shape, typename Future, bool IsVoid,
         typename... Ts>
     struct bulk_then_execute_result_impl;
@@ -37,25 +43,28 @@ namespace hpx { namespace parallel { namespace execution { namespace detail {
     template <typename F, typename Shape, typename Future, typename... Ts>
     struct bulk_then_execute_result_impl<F, Shape, Future, false, Ts...>
     {
-        typedef std::vector<
-            typename then_bulk_function_result<F, Shape, Future, Ts...>::type>
-            type;
+        using type =
+            std::vector<then_bulk_function_result_t<F, Shape, Future, Ts...>>;
     };
 
     template <typename F, typename Shape, typename Future, typename... Ts>
     struct bulk_then_execute_result_impl<F, Shape, Future, true, Ts...>
     {
-        typedef void type;
+        using type = void;
     };
 
     template <typename F, typename Shape, typename Future, typename... Ts>
     struct bulk_then_execute_result
       : bulk_then_execute_result_impl<F, Shape, Future,
-            std::is_void<typename then_bulk_function_result<F, Shape, Future,
-                Ts...>::type>::value,
+            std::is_void<
+                then_bulk_function_result_t<F, Shape, Future, Ts...>>::value,
             Ts...>
     {
     };
+
+    template <typename F, typename Shape, typename Future, typename... Ts>
+    using bulk_then_execute_result_t =
+        typename bulk_then_execute_result<F, Shape, Future, Ts...>::type;
 
     ///////////////////////////////////////////////////////////////////////////
     template <typename Executor, typename F, typename Shape, typename Future,
@@ -98,14 +107,13 @@ namespace hpx { namespace parallel { namespace execution { namespace detail {
 
     template <typename Result, typename Executor, typename F, typename Shape,
         typename Args>
-    fused_bulk_sync_execute_helper<Result, typename std::decay<Executor>::type,
-        typename std::decay<F>::type, Shape, typename std::decay<Args>::type>
+    fused_bulk_sync_execute_helper<Result, std::decay_t<Executor>,
+        std::decay_t<F>, Shape, std::decay_t<Args>>
     make_fused_bulk_sync_execute_helper(
         Executor&& exec, F&& f, Shape const& shape, Args&& args)
     {
-        return fused_bulk_sync_execute_helper<Result,
-            typename std::decay<Executor>::type, typename std::decay<F>::type,
-            Shape, typename std::decay<Args>::type>{
+        return fused_bulk_sync_execute_helper<Result, std::decay_t<Executor>,
+            std::decay_t<F>, Shape, std::decay_t<Args>>{
             std::forward<Executor>(exec), std::forward<F>(f), shape,
             std::forward<Args>(args)};
     }
@@ -151,15 +159,13 @@ namespace hpx { namespace parallel { namespace execution { namespace detail {
 
     template <typename Result, typename Executor, typename F, typename Shape,
         typename Args>
-    fused_bulk_async_execute_helper<Result, typename std::decay<Executor>::type,
-        typename std::decay<F>::type, typename std::decay<Shape>::type,
-        typename std::decay<Args>::type>
+    fused_bulk_async_execute_helper<Result, std::decay_t<Executor>,
+        std::decay_t<F>, std::decay_t<Shape>, std::decay_t<Args>>
     make_fused_bulk_async_execute_helper(
         Executor&& exec, F&& f, Shape&& shape, Args&& args)
     {
-        return fused_bulk_async_execute_helper<Result,
-            typename std::decay<Executor>::type, typename std::decay<F>::type,
-            typename std::decay<Shape>::type, typename std::decay<Args>::type>{
+        return fused_bulk_async_execute_helper<Result, std::decay_t<Executor>,
+            std::decay_t<F>, std::decay_t<Shape>, std::decay_t<Args>>{
             std::forward<Executor>(exec), std::forward<F>(f),
             std::forward<Shape>(shape), std::forward<Args>(args)};
     }

--- a/libs/parallelism/execution/include/hpx/execution/traits/executor_traits.hpp
+++ b/libs/parallelism/execution/include/hpx/execution/traits/executor_traits.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2017 Hartmut Kaiser
+//  Copyright (c) 2017-2021 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -44,85 +44,53 @@ namespace hpx { namespace parallel { namespace execution {
     }    // namespace detail
 
     template <typename T, typename Enable = void>
-    struct has_post_member : detail::has_post<typename std::decay<T>::type>
+    struct has_post_member : detail::has_post<std::decay_t<T>>
     {
     };
 
     template <typename T, typename Enable = void>
-    struct has_sync_execute_member
-      : detail::has_sync_execute<typename std::decay<T>::type>
+    struct has_sync_execute_member : detail::has_sync_execute<std::decay_t<T>>
     {
     };
 
     template <typename T, typename Enable = void>
-    struct has_async_execute_member
-      : detail::has_async_execute<typename std::decay<T>::type>
+    struct has_async_execute_member : detail::has_async_execute<std::decay_t<T>>
     {
     };
 
     template <typename T, typename Enable = void>
-    struct has_then_execute_member
-      : detail::has_then_execute<typename std::decay<T>::type>
+    struct has_then_execute_member : detail::has_then_execute<std::decay_t<T>>
     {
     };
 
     template <typename T, typename Enable = void>
     struct has_bulk_sync_execute_member
-      : detail::has_bulk_sync_execute<typename std::decay<T>::type>
+      : detail::has_bulk_sync_execute<std::decay_t<T>>
     {
     };
 
     template <typename T, typename Enable = void>
     struct has_bulk_async_execute_member
-      : detail::has_bulk_async_execute<typename std::decay<T>::type>
+      : detail::has_bulk_async_execute<std::decay_t<T>>
     {
     };
 
     template <typename T, typename Enable = void>
     struct has_bulk_then_execute_member
-      : detail::has_bulk_then_execute<typename std::decay<T>::type>
+      : detail::has_bulk_then_execute<std::decay_t<T>>
     {
     };
-
-#if defined(HPX_HAVE_CXX17_VARIABLE_TEMPLATES)
-    template <typename T>
-    constexpr bool has_post_member_v = has_post_member<T>::value;
-
-    template <typename T>
-    constexpr bool has_sync_execute_member_v =
-        has_sync_execute_member<T>::value;
-
-    template <typename T>
-    constexpr bool has_async_execute_member_v =
-        has_async_execute_member<T>::value;
-
-    template <typename T>
-    constexpr bool has_then_execute_member_v =
-        has_then_execute_member<T>::value;
-
-    template <typename T>
-    constexpr bool has_bulk_sync_execute_member_v =
-        has_bulk_sync_execute_member<T>::value;
-
-    template <typename T>
-    constexpr bool has_bulk_async_execute_member_v =
-        has_bulk_async_execute_member<T>::value;
-
-    template <typename T>
-    constexpr bool has_bulk_then_execute_member_v =
-        has_bulk_then_execute_member<T>::value;
-#endif
 
     ///////////////////////////////////////////////////////////////////////////
     template <typename Executor>
     struct executor_context
     {
-        using type = typename std::decay<decltype(
-            std::declval<Executor const&>().context())>::type;
+        using type =
+            std::decay_t<decltype(std::declval<Executor const&>().context())>;
     };
 
     ///////////////////////////////////////////////////////////////////////////
-    // Components which create groups of execution agents may use execution
+    // Components that create groups of execution agents may use execution
     // categories to communicate the forward progress and ordering guarantees
     // of these execution agents with respect to other agents within the same
     // group.
@@ -203,18 +171,16 @@ namespace hpx { namespace parallel { namespace execution {
 
         template <typename Executor, typename T, typename... Ts>
         struct executor_future<Executor, T, hpx::util::pack<Ts...>,
-            typename std::enable_if<
-                hpx::traits::is_two_way_executor<Executor>::value &&
-                exposes_future_type<Executor, T>::value>::type>
+            std::enable_if_t<hpx::traits::is_two_way_executor_v<Executor> &&
+                exposes_future_type<Executor, T>::value>>
         {
             using type = typename Executor::template future_type<T>;
         };
 
         template <typename Executor, typename T, typename... Ts>
         struct executor_future<Executor, T, hpx::util::pack<Ts...>,
-            typename std::enable_if<
-                hpx::traits::is_two_way_executor<Executor>::value &&
-                !exposes_future_type<Executor, T>::value>::type>
+            std::enable_if_t<hpx::traits::is_two_way_executor_v<Executor> &&
+                !exposes_future_type<Executor, T>::value>>
         {
             using type = decltype(std::declval<Executor&&>().async_execute(
                 std::declval<T (*)(Ts...)>(), std::declval<Ts>()...));
@@ -222,8 +188,7 @@ namespace hpx { namespace parallel { namespace execution {
 
         template <typename Executor, typename T, typename Ts>
         struct executor_future<Executor, T, Ts,
-            typename std::enable_if<
-                !hpx::traits::is_two_way_executor<Executor>::value>::type>
+            std::enable_if_t<!hpx::traits::is_two_way_executor_v<Executor>>>
         {
             using type = hpx::lcos::future<T>;
         };
@@ -231,8 +196,8 @@ namespace hpx { namespace parallel { namespace execution {
 
     template <typename Executor, typename T, typename... Ts>
     struct executor_future
-      : detail::executor_future<typename std::decay<Executor>::type, T,
-            hpx::util::pack<typename std::decay<Ts>::type...>>
+      : detail::executor_future<std::decay_t<Executor>, T,
+            hpx::util::pack<std::decay_t<Ts>...>>
     {
     };
 
@@ -246,57 +211,78 @@ namespace hpx { namespace traits {
     ///////////////////////////////////////////////////////////////////////////
     template <typename T, typename Enable = void>
     struct has_post_member
-      : parallel::execution::has_post_member<typename std::decay<T>::type>
+      : parallel::execution::has_post_member<std::decay_t<T>>
     {
     };
 
     template <typename T, typename Enable = void>
     struct has_sync_execute_member
-      : parallel::execution::has_sync_execute_member<
-            typename std::decay<T>::type>
+      : parallel::execution::has_sync_execute_member<std::decay_t<T>>
     {
     };
 
     template <typename T, typename Enable = void>
     struct has_async_execute_member
-      : parallel::execution::has_async_execute_member<
-            typename std::decay<T>::type>
+      : parallel::execution::has_async_execute_member<std::decay_t<T>>
     {
     };
 
     template <typename T, typename Enable = void>
     struct has_then_execute_member
-      : parallel::execution::has_then_execute_member<
-            typename std::decay<T>::type>
+      : parallel::execution::has_then_execute_member<std::decay_t<T>>
     {
     };
 
     template <typename T, typename Enable = void>
     struct has_bulk_sync_execute_member
-      : parallel::execution::has_bulk_sync_execute_member<
-            typename std::decay<T>::type>
+      : parallel::execution::has_bulk_sync_execute_member<std::decay_t<T>>
     {
     };
 
     template <typename T, typename Enable = void>
     struct has_bulk_async_execute_member
-      : parallel::execution::has_bulk_async_execute_member<
-            typename std::decay<T>::type>
+      : parallel::execution::has_bulk_async_execute_member<std::decay_t<T>>
     {
     };
 
     template <typename T, typename Enable = void>
     struct has_bulk_then_execute_member
-      : parallel::execution::has_bulk_then_execute_member<
-            typename std::decay<T>::type>
+      : parallel::execution::has_bulk_then_execute_member<std::decay_t<T>>
     {
     };
+
+    template <typename T>
+    HPX_INLINE_CONSTEXPR_VARIABLE bool has_post_member_v =
+        has_post_member<T>::value;
+
+    template <typename T>
+    HPX_INLINE_CONSTEXPR_VARIABLE bool has_sync_execute_member_v =
+        has_sync_execute_member<T>::value;
+
+    template <typename T>
+    HPX_INLINE_CONSTEXPR_VARIABLE bool has_async_execute_member_v =
+        has_async_execute_member<T>::value;
+
+    template <typename T>
+    HPX_INLINE_CONSTEXPR_VARIABLE bool has_then_execute_member_v =
+        has_then_execute_member<T>::value;
+
+    template <typename T>
+    HPX_INLINE_CONSTEXPR_VARIABLE bool has_bulk_sync_execute_member_v =
+        has_bulk_sync_execute_member<T>::value;
+
+    template <typename T>
+    HPX_INLINE_CONSTEXPR_VARIABLE bool has_bulk_async_execute_member_v =
+        has_bulk_async_execute_member<T>::value;
+
+    template <typename T>
+    HPX_INLINE_CONSTEXPR_VARIABLE bool has_bulk_then_execute_member_v =
+        has_bulk_then_execute_member<T>::value;
 
     ///////////////////////////////////////////////////////////////////////////
     template <typename Executor, typename Enable = void>
     struct executor_context
-      : parallel::execution::executor_context<
-            typename std::decay<Executor>::type>
+      : parallel::execution::executor_context<std::decay_t<Executor>>
     {
     };
 
@@ -305,8 +291,7 @@ namespace hpx { namespace traits {
 
     template <typename Executor, typename Enable = void>
     struct executor_execution_category
-      : parallel::execution::executor_execution_category<
-            typename std::decay<Executor>::type>
+      : parallel::execution::executor_execution_category<std::decay_t<Executor>>
     {
     };
 
@@ -316,7 +301,7 @@ namespace hpx { namespace traits {
 
     template <typename Executor, typename Enable = void>
     struct executor_shape
-      : parallel::execution::executor_shape<typename std::decay<Executor>::type>
+      : parallel::execution::executor_shape<std::decay_t<Executor>>
     {
     };
 
@@ -325,7 +310,7 @@ namespace hpx { namespace traits {
 
     template <typename Executor, typename Enable = void>
     struct executor_index
-      : parallel::execution::executor_index<typename std::decay<Executor>::type>
+      : parallel::execution::executor_index<std::decay_t<Executor>>
     {
     };
 
@@ -334,9 +319,8 @@ namespace hpx { namespace traits {
 
     template <typename Executor, typename T, typename... Ts>
     struct executor_future
-      : parallel::execution::executor_future<
-            typename std::decay<Executor>::type, T,
-            typename std::decay<Ts>::type...>
+      : parallel::execution::executor_future<std::decay_t<Executor>, T,
+            std::decay_t<Ts>...>
     {
     };
 
@@ -348,8 +332,7 @@ namespace hpx { namespace traits {
     // extension
     template <typename Executor, typename Enable = void>
     struct executor_parameters_type
-      : parallel::execution::executor_parameters_type<
-            typename std::decay<Executor>::type>
+      : parallel::execution::executor_parameters_type<std::decay_t<Executor>>
     {
     };
 

--- a/libs/parallelism/executors/CMakeLists.txt
+++ b/libs/parallelism/executors/CMakeLists.txt
@@ -8,6 +8,7 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 
 # Default location is $HPX_ROOT/libs/executors/include
 set(executors_headers
+    hpx/executors/annotating_executor.hpp
     hpx/executors/current_executor.hpp
     hpx/executors/datapar/execution_policy_fwd.hpp
     hpx/executors/datapar/execution_policy.hpp

--- a/libs/parallelism/executors/include/hpx/executors/annotating_executor.hpp
+++ b/libs/parallelism/executors/include/hpx/executors/annotating_executor.hpp
@@ -1,0 +1,291 @@
+//  Copyright (c) 2021 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+/// \file parallel/executors/annotating_executor.hpp
+
+#pragma once
+
+#include <hpx/config.hpp>
+#include <hpx/execution/executors/execution.hpp>
+#include <hpx/execution/executors/execution_parameters.hpp>
+#include <hpx/execution_base/execution.hpp>
+#include <hpx/execution_base/traits/is_executor.hpp>
+#include <hpx/threading_base/annotated_function.hpp>
+#include <hpx/type_support/always_void.hpp>
+
+#include <string>
+#include <type_traits>
+#include <utility>
+
+namespace hpx { namespace execution { namespace experimental {
+
+    ///////////////////////////////////////////////////////////////////////////
+    /// A \a annotating_executor wraps any other executor and adds the
+    /// capability to add annotations to the launched threads.
+    template <typename BaseExecutor>
+    struct annotating_executor
+    {
+        template <typename Executor,
+            typename Enable =
+                std::enable_if_t<hpx::traits::is_executor_any_v<Executor>>>
+        constexpr explicit annotating_executor(
+            Executor&& exec, char const* annotation = nullptr)
+          : exec_(std::forward<Executor>(exec))
+          , annotation_(annotation)
+        {
+        }
+
+        template <typename Executor,
+            typename Enable =
+                std::enable_if_t<hpx::traits::is_executor_any_v<Executor>>>
+        explicit annotating_executor(Executor&& exec, std::string annotation)
+          : exec_(std::forward<Executor>(exec))
+          , annotation_(hpx::util::detail::store_function_annotation(
+                std::move(annotation)))
+        {
+        }
+
+        /// \cond NOINTERNAL
+        constexpr bool operator==(annotating_executor const& rhs) const noexcept
+        {
+            return exec_ == rhs.exec_;
+        }
+
+        constexpr bool operator!=(annotating_executor const& rhs) const noexcept
+        {
+            return exec_ != rhs.exec_;
+        }
+
+        constexpr auto const& context() const noexcept
+        {
+            return exec_.context();
+        }
+        /// \endcond
+
+        /// \cond NOINTERNAL
+        using execution_category =
+            hpx::traits::executor_execution_category_t<BaseExecutor>;
+
+        using parameters_type =
+            hpx::traits::executor_parameters_type_t<BaseExecutor>;
+
+        template <typename T, typename... Ts>
+        using future_type =
+            hpx::traits::executor_future_t<BaseExecutor, T, Ts...>;
+
+        // NonBlockingOneWayExecutor interface
+        template <typename F, typename... Ts>
+        decltype(auto) post(F&& f, Ts&&... ts)
+        {
+            return parallel::execution::post(exec_,
+                hpx::util::annotated_function(std::forward<F>(f), annotation_),
+                std::forward<Ts>(ts)...);
+        }
+
+        // OneWayExecutor interface
+        template <typename F, typename... Ts>
+        decltype(auto) sync_execute(F&& f, Ts&&... ts)
+        {
+            return parallel::execution::sync_execute(exec_,
+                hpx::util::annotated_function(std::forward<F>(f), annotation_),
+                std::forward<Ts>(ts)...);
+        }
+
+        // TwoWayExecutor interface
+        template <typename F, typename... Ts>
+        decltype(auto) async_execute(F&& f, Ts&&... ts)
+        {
+            return parallel::execution::async_execute(exec_,
+                hpx::util::annotated_function(std::forward<F>(f), annotation_),
+                std::forward<Ts>(ts)...);
+        }
+
+        template <typename F, typename Future, typename... Ts>
+        decltype(auto) then_execute(F&& f, Future&& predecessor, Ts&&... ts)
+        {
+            return parallel::execution::then_execute(exec_,
+                hpx::util::annotated_function(std::forward<F>(f), annotation_),
+                std::forward<Future>(predecessor), std::forward<Ts>(ts)...);
+        }
+
+        // BulkTwoWayExecutor interface
+        template <typename F, typename S, typename... Ts>
+        decltype(auto) bulk_async_execute(F&& f, S const& shape, Ts&&... ts)
+        {
+            return parallel::execution::bulk_async_execute(exec_,
+                hpx::util::annotated_function(std::forward<F>(f), annotation_),
+                shape, std::forward<Ts>(ts)...);
+        }
+
+        template <typename F, typename S, typename... Ts>
+        decltype(auto) bulk_sync_execute(F&& f, S const& shape, Ts&&... ts)
+        {
+            return parallel::execution::bulk_sync_execute(exec_,
+                hpx::util::annotated_function(std::forward<F>(f), annotation_),
+                shape, std::forward<Ts>(ts)...);
+        }
+
+        template <typename F, typename S, typename Future, typename... Ts>
+        decltype(auto) bulk_then_execute(
+            F&& f, S const& shape, Future&& predecessor, Ts&&... ts)
+        {
+            return parallel::execution::bulk_then_execute(exec_,
+                hpx::util::annotated_function(std::forward<F>(f), annotation_),
+                shape, std::forward<Future>(predecessor),
+                std::forward<Ts>(ts)...);
+        }
+
+        // support with_annotation property
+        using supports_annotations = void;
+
+        friend constexpr annotating_executor tag_dispatch(
+            hpx::execution::experimental::with_annotation_t,
+            annotating_executor const& exec, char const* annotation)
+        {
+            auto exec_with_annotation = exec;
+            exec_with_annotation.annotation_ = annotation;
+            return exec_with_annotation;
+        }
+
+        friend annotating_executor tag_dispatch(
+            hpx::execution::experimental::with_annotation_t,
+            annotating_executor const& exec, std::string annotation)
+        {
+            auto exec_with_annotation = exec;
+            exec_with_annotation.annotation_ =
+                hpx::util::detail::store_function_annotation(
+                    std::move(annotation));
+            return exec_with_annotation;
+        }
+
+        // support get_annotation property
+        friend constexpr char const* tag_dispatch(
+            hpx::execution::experimental::get_annotation_t,
+            annotating_executor const& exec) noexcept
+        {
+            return exec.annotation_;
+        }
+
+    private:
+        friend class hpx::serialization::access;
+
+        template <typename Archive>
+        void serialize(Archive& ar, const unsigned int /* version */)
+        {
+            // clang-format off
+            ar & exec_;
+            // clang-format on
+        }
+
+        BaseExecutor exec_;
+        char const* const annotation_ = nullptr;
+        /// \endcond
+    };
+
+    ///////////////////////////////////////////////////////////////////////////
+    // if the given executor does not support annotations, wrap it into
+    // a annotating_executor
+    namespace detail {
+
+        template <typename Executor, typename Enable = void>
+        struct supports_annotations : std::false_type
+        {
+        };
+
+        template <typename Executor>
+        struct supports_annotations<Executor,
+            hpx::util::always_void_t<typename Executor::supports_annotations>>
+          : std::true_type
+        {
+        };
+
+        template <typename Executor>
+        HPX_INLINE_CONSTEXPR_VARIABLE bool supports_annotations_v =
+            supports_annotations<Executor>::value;
+    };    // namespace detail
+
+    ///////////////////////////////////////////////////////////////////////////
+    // The functions below are used for executors that do not directly support
+    // annotations. Those are wrapped into an annotating_executor if passed
+    // to `with_annotation`.
+
+    // clang-format off
+    template <typename Executor>
+    constexpr auto tag_dispatch(
+        with_annotation_t, Executor&& exec, char const* annotation)
+        -> decltype(
+            std::enable_if_t<
+                hpx::traits::is_executor_any_v<Executor> &&
+               !detail::supports_annotations_v<std::decay_t<Executor>>
+            >(),
+            annotating_executor<std::decay_t<Executor>>(
+                std::forward<Executor>(exec), annotation))
+    // clang-format on
+    {
+        return annotating_executor<std::decay_t<Executor>>(
+            std::forward<Executor>(exec), annotation);
+    }
+
+    // clang-format off
+    template <typename Executor>
+    auto tag_dispatch(
+        with_annotation_t, Executor&& exec, std::string annotation)
+        -> decltype(
+            std::enable_if_t<
+                hpx::traits::is_executor_any_v<Executor> &&
+               !detail::supports_annotations_v<std::decay_t<Executor>>
+            >(),
+            annotating_executor<std::decay_t<Executor>>(
+                std::forward<Executor>(exec), std::move(annotation)))
+    // clang-format on
+    {
+        return annotating_executor<std::decay_t<Executor>>(
+            std::forward<Executor>(exec), std::move(annotation));
+    }
+}}}    // namespace hpx::execution::experimental
+
+namespace hpx { namespace parallel { namespace execution {
+
+    // The annotating executor exposes the same executor categories as its
+    // underlying (wrapped) executor.
+
+    /// \cond NOINTERNAL
+    template <typename BaseExecutor>
+    struct is_one_way_executor<
+        hpx::execution::experimental::annotating_executor<BaseExecutor>>
+      : is_one_way_executor<BaseExecutor>
+    {
+    };
+
+    template <typename BaseExecutor>
+    struct is_never_blocking_one_way_executor<
+        hpx::execution::experimental::annotating_executor<BaseExecutor>>
+      : is_never_blocking_one_way_executor<BaseExecutor>
+    {
+    };
+
+    template <typename BaseExecutor>
+    struct is_bulk_one_way_executor<
+        hpx::execution::experimental::annotating_executor<BaseExecutor>>
+      : is_bulk_one_way_executor<BaseExecutor>
+    {
+    };
+
+    template <typename BaseExecutor>
+    struct is_two_way_executor<
+        hpx::execution::experimental::annotating_executor<BaseExecutor>>
+      : is_two_way_executor<BaseExecutor>
+    {
+    };
+
+    template <typename BaseExecutor>
+    struct is_bulk_two_way_executor<
+        hpx::execution::experimental::annotating_executor<BaseExecutor>>
+      : is_bulk_two_way_executor<BaseExecutor>
+    {
+    };
+    /// \endcond
+}}}    // namespace hpx::parallel::execution

--- a/libs/parallelism/executors/include/hpx/executors/execution_policy_annotation.hpp
+++ b/libs/parallelism/executors/include/hpx/executors/execution_policy_annotation.hpp
@@ -12,6 +12,7 @@
 #include <hpx/execution/executors/execution_parameters.hpp>
 #include <hpx/execution/executors/rebind_executor.hpp>
 #include <hpx/execution/traits/is_execution_policy.hpp>
+#include <hpx/executors/annotating_executor.hpp>
 #include <hpx/properties/property.hpp>
 
 #include <string>
@@ -22,13 +23,16 @@ namespace hpx { namespace execution { namespace experimental {
 
     // with_annotation property implementation for execution policies
     // that simply forwards to the embedded executor
+    // clang-format off
     template <typename ExPolicy,
-        typename Enable =
-            std::enable_if_t<hpx::is_execution_policy<ExPolicy>::value &&
-                hpx::functional::is_tag_dispatchable<
-                    hpx::execution::experimental::with_annotation_t,
-                    typename std::decay_t<ExPolicy>::executor_type,
-                    char const*>::value>>
+        HPX_CONCEPT_REQUIRES_(
+            hpx::is_execution_policy_v<ExPolicy> &&
+            hpx::functional::is_tag_dispatchable_v<
+                hpx::execution::experimental::with_annotation_t,
+                typename std::decay_t<ExPolicy>::executor_type,
+                char const*>
+        )>
+    // clang-format on
     constexpr decltype(auto) tag_dispatch(
         hpx::execution::experimental::with_annotation_t, ExPolicy&& policy,
         char const* annotation)
@@ -40,13 +44,16 @@ namespace hpx { namespace execution { namespace experimental {
             policy, std::move(exec), policy.parameters());
     }
 
+    // clang-format off
     template <typename ExPolicy,
-        typename Enable =
-            std::enable_if_t<hpx::is_execution_policy<ExPolicy>::value &&
-                hpx::functional::is_tag_dispatchable<
-                    hpx::execution::experimental::with_annotation_t,
-                    typename std::decay_t<ExPolicy>::executor_type,
-                    std::string>::value>>
+        HPX_CONCEPT_REQUIRES_(
+            hpx::is_execution_policy_v<ExPolicy> &&
+            hpx::functional::is_tag_dispatchable_v<
+                hpx::execution::experimental::with_annotation_t,
+                typename std::decay_t<ExPolicy>::executor_type,
+                std::string>
+        )>
+    // clang-format on
     decltype(auto) tag_dispatch(hpx::execution::experimental::with_annotation_t,
         ExPolicy&& policy, std::string annotation)
     {
@@ -59,9 +66,15 @@ namespace hpx { namespace execution { namespace experimental {
 
     // get_annotation property implementation for execution policies
     // that simply forwards to the embedded executor
+    // clang-format off
     template <typename ExPolicy,
-        typename Enable =
-            std::enable_if_t<hpx::is_execution_policy<ExPolicy>::value>>
+        HPX_CONCEPT_REQUIRES_(
+            hpx::is_execution_policy_v<ExPolicy> &&
+            hpx::functional::is_tag_dispatchable_v<
+                hpx::execution::experimental::get_annotation_t,
+                typename std::decay_t<ExPolicy>::executor_type>
+        )>
+    // clang-format on
     constexpr decltype(auto) tag_dispatch(
         hpx::execution::experimental::get_annotation_t, ExPolicy&& policy)
     {

--- a/libs/parallelism/executors/include/hpx/executors/parallel_executor.hpp
+++ b/libs/parallelism/executors/include/hpx/executors/parallel_executor.hpp
@@ -185,6 +185,8 @@ namespace hpx { namespace execution {
             return exec.schedulehint_;
         }
 
+        using supports_annotations = void;
+
         friend constexpr parallel_policy_executor tag_dispatch(
             hpx::execution::experimental::with_annotation_t,
             parallel_policy_executor const& exec, char const* annotation)

--- a/libs/parallelism/executors/tests/unit/CMakeLists.txt
+++ b/libs/parallelism/executors/tests/unit/CMakeLists.txt
@@ -5,6 +5,7 @@
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 set(tests
+    annotating_executor
     annotation_property
     created_executor
     fork_join_executor

--- a/libs/parallelism/executors/tests/unit/annotating_executor.cpp
+++ b/libs/parallelism/executors/tests/unit/annotating_executor.cpp
@@ -1,0 +1,476 @@
+//  Copyright (c) 2007-2021 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/config.hpp>
+
+#if defined(HPX_HAVE_THREAD_DESCRIPTION)
+#include <hpx/local/execution.hpp>
+#include <hpx/local/future.hpp>
+#include <hpx/local/init.hpp>
+#include <hpx/local/latch.hpp>
+#include <hpx/local/thread.hpp>
+#include <hpx/modules/properties.hpp>
+#include <hpx/modules/testing.hpp>
+
+#include <cstdlib>
+#include <functional>
+#include <string>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+///////////////////////////////////////////////////////////////////////////////
+std::string annotation;
+
+void test_post_f(int passed_through, hpx::lcos::local::latch& l)
+{
+    HPX_TEST_EQ(passed_through, 42);
+
+    annotation =
+        hpx::threads::get_thread_description(hpx::threads::get_self_id())
+            .get_description();
+
+    l.count_down(1);
+}
+
+template <typename Executor>
+void test_post(Executor&& executor)
+{
+    std::string desc("test_post");
+    {
+        auto exec = hpx::experimental::prefer(
+            hpx::execution::experimental::with_annotation, executor, desc);
+
+        hpx::lcos::local::latch l(2);
+        hpx::parallel::execution::post(exec, &test_post_f, 42, std::ref(l));
+        l.arrive_and_wait();
+
+        HPX_TEST_EQ(annotation, desc);
+        HPX_TEST_EQ(annotation,
+            std::string(hpx::execution::experimental::get_annotation(exec)));
+    }
+
+    {
+        annotation.clear();
+        auto exec =
+            hpx::execution::experimental::with_annotation(executor, desc);
+
+        hpx::lcos::local::latch l(2);
+        hpx::parallel::execution::post(exec, &test_post_f, 42, std::ref(l));
+        l.arrive_and_wait();
+
+        HPX_TEST_EQ(annotation, desc);
+        HPX_TEST_EQ(annotation,
+            std::string(hpx::execution::experimental::get_annotation(exec)));
+    }
+}
+
+///////////////////////////////////////////////////////////////////////////////
+void test(int passed_through)
+{
+    HPX_TEST_EQ(passed_through, 42);
+
+    annotation =
+        hpx::threads::get_thread_description(hpx::threads::get_self_id())
+            .get_description();
+}
+
+template <typename Executor>
+void test_sync(Executor&& executor)
+{
+    std::string desc("test_sync");
+    {
+        auto exec = hpx::experimental::prefer(
+            hpx::execution::experimental::with_annotation, executor, desc);
+
+        hpx::parallel::execution::sync_execute(exec, &test, 42);
+
+        HPX_TEST_EQ(annotation, desc);
+        HPX_TEST_EQ(annotation,
+            std::string(hpx::execution::experimental::get_annotation(exec)));
+    }
+
+    {
+        annotation.clear();
+        auto exec =
+            hpx::execution::experimental::with_annotation(executor, desc);
+
+        hpx::parallel::execution::sync_execute(exec, &test, 42);
+
+        HPX_TEST_EQ(annotation, desc);
+        HPX_TEST_EQ(annotation,
+            std::string(hpx::execution::experimental::get_annotation(exec)));
+    }
+}
+
+template <typename Executor>
+void test_async(Executor&& executor)
+{
+    std::string desc("test_async");
+    {
+        auto exec = hpx::experimental::prefer(
+            hpx::execution::experimental::with_annotation, executor, desc);
+
+        hpx::parallel::execution::async_execute(exec, &test, 42).get();
+
+        HPX_TEST_EQ(annotation, desc);
+        HPX_TEST_EQ(annotation,
+            std::string(hpx::execution::experimental::get_annotation(exec)));
+    }
+
+    {
+        annotation.clear();
+        auto exec =
+            hpx::execution::experimental::with_annotation(executor, desc);
+
+        hpx::parallel::execution::async_execute(exec, &test, 42).get();
+
+        HPX_TEST_EQ(annotation, desc);
+        HPX_TEST_EQ(annotation,
+            std::string(hpx::execution::experimental::get_annotation(exec)));
+    }
+}
+
+///////////////////////////////////////////////////////////////////////////////
+void test_f(hpx::future<void> f, int passed_through)
+{
+    HPX_TEST(f.is_ready());    // make sure, future is ready
+
+    f.get();    // propagate exceptions
+
+    HPX_TEST_EQ(passed_through, 42);
+
+    annotation =
+        hpx::threads::get_thread_description(hpx::threads::get_self_id())
+            .get_description();
+}
+
+template <typename Executor>
+void test_then(Executor&& executor)
+{
+    hpx::future<void> f = hpx::make_ready_future();
+
+    std::string desc("test_then");
+    {
+        auto exec = hpx::experimental::prefer(
+            hpx::execution::experimental::with_annotation, executor, desc);
+
+        hpx::parallel::execution::then_execute(exec, &test_f, f, 42).get();
+
+        HPX_TEST_EQ(annotation, desc);
+        HPX_TEST_EQ(annotation,
+            std::string(hpx::execution::experimental::get_annotation(exec)));
+    }
+
+    {
+        annotation.clear();
+        auto exec =
+            hpx::execution::experimental::with_annotation(executor, desc);
+
+        hpx::parallel::execution::then_execute(exec, &test_f, f, 42).get();
+
+        HPX_TEST_EQ(annotation, desc);
+        HPX_TEST_EQ(annotation,
+            std::string(hpx::execution::experimental::get_annotation(exec)));
+    }
+}
+
+///////////////////////////////////////////////////////////////////////////////
+void bulk_test(int seq, int passed_through)    //-V813
+{
+    HPX_TEST_EQ(passed_through, 42);
+
+    if (seq == 0)
+    {
+        annotation =
+            hpx::threads::get_thread_description(hpx::threads::get_self_id())
+                .get_description();
+    }
+}
+
+template <typename Executor>
+void test_bulk_sync(Executor&& executor)
+{
+    using hpx::util::placeholders::_1;
+    using hpx::util::placeholders::_2;
+
+    std::string desc("test_bulk_sync");
+    {
+        auto exec = hpx::experimental::prefer(
+            hpx::execution::experimental::with_annotation, executor, desc);
+
+        hpx::parallel::execution::bulk_sync_execute(
+            exec, hpx::util::bind(&bulk_test, _1, _2), 107, 42);
+
+        HPX_TEST_EQ(annotation, desc);
+        HPX_TEST_EQ(annotation,
+            std::string(hpx::execution::experimental::get_annotation(exec)));
+
+        annotation.clear();
+        hpx::parallel::execution::bulk_sync_execute(exec, &bulk_test, 107, 42);
+
+        HPX_TEST_EQ(annotation, desc);
+        HPX_TEST_EQ(annotation,
+            std::string(hpx::execution::experimental::get_annotation(exec)));
+    }
+
+    {
+        auto exec =
+            hpx::execution::experimental::with_annotation(executor, desc);
+
+        annotation.clear();
+        hpx::parallel::execution::bulk_sync_execute(
+            exec, hpx::util::bind(&bulk_test, _1, _2), 107, 42);
+
+        HPX_TEST_EQ(annotation, desc);
+        HPX_TEST_EQ(annotation,
+            std::string(hpx::execution::experimental::get_annotation(exec)));
+
+        annotation.clear();
+        hpx::parallel::execution::bulk_sync_execute(exec, &bulk_test, 107, 42);
+
+        HPX_TEST_EQ(annotation, desc);
+        HPX_TEST_EQ(annotation,
+            std::string(hpx::execution::experimental::get_annotation(exec)));
+    }
+}
+
+///////////////////////////////////////////////////////////////////////////////
+template <typename Executor>
+void test_bulk_async(Executor&& executor)
+{
+    using hpx::util::placeholders::_1;
+    using hpx::util::placeholders::_2;
+
+    std::string desc("test_bulk_async");
+    {
+        auto exec = hpx::experimental::prefer(
+            hpx::execution::experimental::with_annotation, executor, desc);
+
+        hpx::when_all(hpx::parallel::execution::bulk_async_execute(
+                          exec, hpx::util::bind(&bulk_test, _1, _2), 107, 42))
+            .get();
+
+        HPX_TEST_EQ(annotation, desc);
+        HPX_TEST_EQ(annotation,
+            std::string(hpx::execution::experimental::get_annotation(exec)));
+
+        annotation.clear();
+        hpx::when_all(hpx::parallel::execution::bulk_async_execute(
+                          exec, &bulk_test, 107, 42))
+            .get();
+
+        HPX_TEST_EQ(annotation, desc);
+        HPX_TEST_EQ(annotation,
+            std::string(hpx::execution::experimental::get_annotation(exec)));
+    }
+
+    {
+        auto exec =
+            hpx::execution::experimental::with_annotation(executor, desc);
+
+        annotation.clear();
+        hpx::when_all(hpx::parallel::execution::bulk_async_execute(
+                          exec, hpx::util::bind(&bulk_test, _1, _2), 107, 42))
+            .get();
+
+        HPX_TEST_EQ(annotation, desc);
+        HPX_TEST_EQ(annotation,
+            std::string(hpx::execution::experimental::get_annotation(exec)));
+
+        annotation.clear();
+        hpx::when_all(hpx::parallel::execution::bulk_async_execute(
+                          exec, &bulk_test, 107, 42))
+            .get();
+
+        HPX_TEST_EQ(annotation, desc);
+        HPX_TEST_EQ(annotation,
+            std::string(hpx::execution::experimental::get_annotation(exec)));
+    }
+}
+
+///////////////////////////////////////////////////////////////////////////////
+void bulk_test_f(int seq, hpx::shared_future<void> f,
+    int passed_through)    //-V813
+{
+    HPX_TEST(f.is_ready());    // make sure, future is ready
+
+    f.get();    // propagate exceptions
+
+    HPX_TEST_EQ(passed_through, 42);
+
+    if (seq == 0)
+    {
+        annotation =
+            hpx::threads::get_thread_description(hpx::threads::get_self_id())
+                .get_description();
+    }
+}
+
+template <typename Executor>
+void test_bulk_then(Executor&& executor)
+{
+    using hpx::util::placeholders::_1;
+    using hpx::util::placeholders::_2;
+    using hpx::util::placeholders::_3;
+
+    hpx::shared_future<void> f = hpx::make_ready_future();
+
+    std::string desc("test_bulk_then");
+    {
+        auto exec = hpx::experimental::prefer(
+            hpx::execution::experimental::with_annotation, executor, desc);
+
+        hpx::parallel::execution::bulk_then_execute(
+            exec, hpx::util::bind(&bulk_test_f, _1, _2, _3), 107, f, 42)
+            .get();
+
+        HPX_TEST_EQ(annotation, desc);
+        HPX_TEST_EQ(annotation,
+            std::string(hpx::execution::experimental::get_annotation(exec)));
+
+        annotation.clear();
+        hpx::parallel::execution::bulk_then_execute(
+            exec, &bulk_test_f, 107, f, 42)
+            .get();
+
+        HPX_TEST_EQ(annotation, desc);
+        HPX_TEST_EQ(annotation,
+            std::string(hpx::execution::experimental::get_annotation(exec)));
+    }
+
+    {
+        auto exec =
+            hpx::execution::experimental::with_annotation(executor, desc);
+
+        annotation.clear();
+        hpx::parallel::execution::bulk_then_execute(
+            exec, hpx::util::bind(&bulk_test_f, _1, _2, _3), 107, f, 42)
+            .get();
+
+        HPX_TEST_EQ(annotation, desc);
+        HPX_TEST_EQ(annotation,
+            std::string(hpx::execution::experimental::get_annotation(exec)));
+
+        annotation.clear();
+        hpx::parallel::execution::bulk_then_execute(
+            exec, &bulk_test_f, 107, f, 42)
+            .get();
+
+        HPX_TEST_EQ(annotation, desc);
+        HPX_TEST_EQ(annotation,
+            std::string(hpx::execution::experimental::get_annotation(exec)));
+    }
+}
+
+///////////////////////////////////////////////////////////////////////////////
+template <typename ExPolicy>
+void test_post_policy(ExPolicy&& policy)
+{
+    std::string desc("test_post_policy");
+    auto p = hpx::execution::experimental::with_annotation(policy, desc);
+
+    hpx::lcos::local::latch l(2);
+    hpx::parallel::execution::post(p.executor(), &test_post_f, 42, std::ref(l));
+    l.arrive_and_wait();
+
+    HPX_TEST_EQ(annotation, desc);
+    HPX_TEST_EQ(annotation,
+        std::string(hpx::execution::experimental::get_annotation(p)));
+}
+
+///////////////////////////////////////////////////////////////////////////////
+template <typename ExPolicy>
+void test_with_annotation(ExPolicy&& policy)
+{
+    test_post(policy.executor());
+
+    test_sync(policy.executor());
+    test_async(policy.executor());
+    test_then(policy.executor());
+
+    test_bulk_sync(policy.executor());
+    test_bulk_async(policy.executor());
+    test_bulk_then(policy.executor());
+
+    test_post_policy(policy);
+}
+
+///////////////////////////////////////////////////////////////////////////////
+void test_seq_policy()
+{
+    // make sure execution::seq is not used directly
+    auto policy = hpx::execution::experimental::with_annotation(
+        hpx::execution::seq, "seq");
+
+    HPX_TEST(typeid(policy.executor()).name() !=
+        typeid(hpx::execution::seq.executor()).name());
+}
+
+void test_par_policy()
+{
+    // make sure execution::par is used directly
+    auto policy = hpx::execution::experimental::with_annotation(
+        hpx::execution::par, "par");
+
+    HPX_TEST(typeid(policy.executor()).name() ==
+        typeid(hpx::execution::par.executor()).name());
+}
+
+///////////////////////////////////////////////////////////////////////////////
+struct test_async_executor
+{
+    using execution_category = hpx::execution::parallel_execution_tag;
+
+    template <typename F, typename... Ts>
+    static auto async_execute(F&& f, Ts&&... ts)
+    {
+        return hpx::async(std::forward<F>(f), std::forward<Ts>(ts)...);
+    }
+};
+
+namespace hpx { namespace parallel { namespace execution {
+    template <>
+    struct is_two_way_executor<test_async_executor> : std::true_type
+    {
+    };
+}}}    // namespace hpx::parallel::execution
+
+int hpx_main()
+{
+    // supports annotations
+    test_with_annotation(hpx::execution::par);
+
+    // don't support them
+    test_with_annotation(hpx::execution::seq);
+    test_with_annotation(hpx::execution::par.on(test_async_executor()));
+
+    test_seq_policy();
+    test_par_policy();
+
+    return hpx::local::finalize();
+}
+
+int main(int argc, char* argv[])
+{
+    // By default this test should run on all available cores
+    std::vector<std::string> const cfg = {"hpx.os_threads=all"};
+
+    // Initialize and run HPX
+    hpx::local::init_params init_args;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::local::init(hpx_main, argc, argv, init_args), 0,
+        "HPX main exited with non-zero status");
+
+    return hpx::util::report_errors();
+}
+#else
+int main()
+{
+    return 0;
+}
+#endif

--- a/libs/parallelism/executors/tests/unit/annotation_property.cpp
+++ b/libs/parallelism/executors/tests/unit/annotation_property.cpp
@@ -366,17 +366,6 @@ void test_post_policy()
     HPX_TEST_EQ(annotation, desc);
 }
 
-void test_post_seq_policy()
-{
-    // just make sure things compile even if the used executor does not
-    // support with_annotation
-    auto policy =
-        hpx::experimental::prefer(hpx::execution::experimental::with_annotation,
-            hpx::execution::seq, "seq");
-
-    HPX_TEST(typeid(policy).name() == typeid(hpx::execution::seq).name());
-}
-
 ///////////////////////////////////////////////////////////////////////////////
 int hpx_main()
 {
@@ -392,8 +381,6 @@ int hpx_main()
 
     test_post_policy_prefer();
     test_post_policy();
-
-    test_post_seq_policy();
 
     return hpx::local::finalize();
 }

--- a/libs/parallelism/timed_execution/include/hpx/timed_execution/traits/is_timed_executor.hpp
+++ b/libs/parallelism/timed_execution/include/hpx/timed_execution/traits/is_timed_executor.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2014-2017 Hartmut Kaiser
+//  Copyright (c) 2014-2021 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -27,18 +27,16 @@ namespace hpx { namespace parallel { namespace execution {
     // Condition: T meets the syntactic requirements for OneWayExecutor
     // Precondition: T is a complete type
     template <typename T>
-    struct is_timed_executor
-      : detail::is_timed_executor<typename std::decay<T>::type>
+    struct is_timed_executor : detail::is_timed_executor<std::decay_t<T>>
     {
     };
 
     template <typename T>
     using is_timed_executor_t = typename is_timed_executor<T>::type;
 
-#if defined(HPX_HAVE_CXX17_VARIABLE_TEMPLATES)
     template <typename T>
-    constexpr bool is_timed_executor_v = is_timed_executor<T>::value;
-#endif
+    HPX_INLINE_CONSTEXPR_VARIABLE bool is_timed_executor_v =
+        is_timed_executor<T>::value;
 }}}    // namespace hpx::parallel::execution
 
 namespace hpx { namespace traits {


### PR DESCRIPTION
- flyby: removed obsolete #if defined(HPX_HAVE_CXX17_VARIABLE_TEMPLATES)
- flyby: constexpr variables can be inline
- flyby: modernize execution traits

