### PR TITLE
Simplify dispatching to annotation handlers

### DIFF
--- a/libs/core/properties/include/hpx/properties/property.hpp
+++ b/libs/core/properties/include/hpx/properties/property.hpp
@@ -22,10 +22,8 @@ namespace hpx { namespace experimental {
         template <typename Tag, typename... Tn>
         friend constexpr HPX_FORCEINLINE auto tag_fallback_dispatch(
                 prefer_t, Tag const& tag, Tn&&... tn)
-            noexcept(noexcept(
-                tag(std::forward<Tn>(tn)...)))
-            -> decltype(
-                tag(std::forward<Tn>(tn)...))
+            noexcept(noexcept(tag(std::forward<Tn>(tn)...)))
+            -> decltype(tag(std::forward<Tn>(tn)...))
         // clang-format on
         {
             return tag(std::forward<Tn>(tn)...);
@@ -36,10 +34,11 @@ namespace hpx { namespace experimental {
         friend constexpr HPX_FORCEINLINE auto tag_fallback_dispatch(
                 prefer_t, Tag, T0&& t0, Tn&&...)
             noexcept(noexcept(std::forward<T0>(t0)))
-            -> typename std::enable_if<
-                    !hpx::functional::is_tag_dispatchable<prefer_t, Tag, T0, Tn...>::value &&
-                    !hpx::is_invocable<Tag, T0, Tn...>::value,
-                    decltype(std::forward<T0>(t0))>::type
+            -> std::enable_if_t<
+                    !hpx::functional::is_tag_dispatchable_v<
+                        prefer_t, Tag, T0, Tn...> &&
+                    !hpx::is_invocable_v<Tag, T0, Tn...>,
+                    decltype(std::forward<T0>(t0))>
         // clang-format on
         {
             return std::forward<T0>(t0);

--- a/libs/core/properties/include/hpx/properties/property.hpp
+++ b/libs/core/properties/include/hpx/properties/property.hpp
@@ -21,15 +21,14 @@ namespace hpx { namespace experimental {
         // clang-format off
         template <typename Tag, typename... Tn>
         friend constexpr HPX_FORCEINLINE auto tag_fallback_dispatch(
-                prefer_t, Tag tag, Tn&&... tn)
+                prefer_t, Tag const& tag, Tn&&... tn)
             noexcept(noexcept(
-                hpx::functional::tag_dispatch(tag, std::forward<Tn>(tn)...)))
+                tag(std::forward<Tn>(tn)...)))
             -> decltype(
-                hpx::functional::tag_dispatch(tag, std::forward<Tn>(tn)...))
+                tag(std::forward<Tn>(tn)...))
         // clang-format on
         {
-            return hpx::functional::tag_dispatch(
-                std::forward<Tag>(tag), std::forward<Tn>(tn)...);
+            return tag(std::forward<Tn>(tn)...);
         }
 
         // clang-format off
@@ -38,9 +37,8 @@ namespace hpx { namespace experimental {
                 prefer_t, Tag, T0&& t0, Tn&&...)
             noexcept(noexcept(std::forward<T0>(t0)))
             -> typename std::enable_if<
-                    !hpx::functional::is_tag_dispatchable<
-                        prefer_t, Tag, T0, Tn...>::value &&
-                    !hpx::functional::is_tag_dispatchable<Tag, T0, Tn...>::value,
+                    !hpx::functional::is_tag_dispatchable<prefer_t, Tag, T0, Tn...>::value &&
+                    !hpx::is_invocable<Tag, T0, Tn...>::value,
                     decltype(std::forward<T0>(t0))>::type
         // clang-format on
         {

--- a/libs/parallelism/executors/include/hpx/executors/annotating_executor.hpp
+++ b/libs/parallelism/executors/include/hpx/executors/annotating_executor.hpp
@@ -139,8 +139,6 @@ namespace hpx { namespace execution { namespace experimental {
         }
 
         // support with_annotation property
-        using supports_annotations = void;
-
         friend constexpr annotating_executor tag_dispatch(
             hpx::execution::experimental::with_annotation_t,
             annotating_executor const& exec, char const* annotation)
@@ -188,59 +186,32 @@ namespace hpx { namespace execution { namespace experimental {
     ///////////////////////////////////////////////////////////////////////////
     // if the given executor does not support annotations, wrap it into
     // a annotating_executor
-    namespace detail {
-
-        template <typename Executor, typename Enable = void>
-        struct supports_annotations : std::false_type
-        {
-        };
-
-        template <typename Executor>
-        struct supports_annotations<Executor,
-            hpx::util::always_void_t<typename Executor::supports_annotations>>
-          : std::true_type
-        {
-        };
-
-        template <typename Executor>
-        HPX_INLINE_CONSTEXPR_VARIABLE bool supports_annotations_v =
-            supports_annotations<Executor>::value;
-    };    // namespace detail
-
-    ///////////////////////////////////////////////////////////////////////////
+    //
     // The functions below are used for executors that do not directly support
     // annotations. Those are wrapped into an annotating_executor if passed
     // to `with_annotation`.
-
+    //
     // clang-format off
-    template <typename Executor>
+    template <typename Executor,
+        HPX_CONCEPT_REQUIRES_(
+            hpx::traits::is_executor_any_v<Executor>
+        )>
+    // clang-format on
     constexpr auto tag_dispatch(
         with_annotation_t, Executor&& exec, char const* annotation)
-        -> decltype(
-            std::enable_if_t<
-                hpx::traits::is_executor_any_v<Executor> &&
-               !detail::supports_annotations_v<std::decay_t<Executor>>
-            >(),
-            annotating_executor<std::decay_t<Executor>>(
-                std::forward<Executor>(exec), annotation))
-    // clang-format on
     {
         return annotating_executor<std::decay_t<Executor>>(
             std::forward<Executor>(exec), annotation);
     }
 
     // clang-format off
-    template <typename Executor>
+    template <typename Executor,
+        HPX_CONCEPT_REQUIRES_(
+            hpx::traits::is_executor_any_v<Executor>
+         )>
+    // clang-format on
     auto tag_dispatch(
         with_annotation_t, Executor&& exec, std::string annotation)
-        -> decltype(
-            std::enable_if_t<
-                hpx::traits::is_executor_any_v<Executor> &&
-               !detail::supports_annotations_v<std::decay_t<Executor>>
-            >(),
-            annotating_executor<std::decay_t<Executor>>(
-                std::forward<Executor>(exec), std::move(annotation)))
-    // clang-format on
     {
         return annotating_executor<std::decay_t<Executor>>(
             std::forward<Executor>(exec), std::move(annotation));

--- a/libs/parallelism/executors/include/hpx/executors/annotating_executor.hpp
+++ b/libs/parallelism/executors/include/hpx/executors/annotating_executor.hpp
@@ -197,7 +197,7 @@ namespace hpx { namespace execution { namespace experimental {
             hpx::traits::is_executor_any_v<Executor>
         )>
     // clang-format on
-    constexpr auto tag_dispatch(
+    constexpr auto tag_fallback_dispatch(
         with_annotation_t, Executor&& exec, char const* annotation)
     {
         return annotating_executor<std::decay_t<Executor>>(
@@ -210,7 +210,7 @@ namespace hpx { namespace execution { namespace experimental {
             hpx::traits::is_executor_any_v<Executor>
          )>
     // clang-format on
-    auto tag_dispatch(
+    auto tag_fallback_dispatch(
         with_annotation_t, Executor&& exec, std::string annotation)
     {
         return annotating_executor<std::decay_t<Executor>>(

--- a/libs/parallelism/executors/include/hpx/executors/execution_policy_annotation.hpp
+++ b/libs/parallelism/executors/include/hpx/executors/execution_policy_annotation.hpp
@@ -26,11 +26,7 @@ namespace hpx { namespace execution { namespace experimental {
     // clang-format off
     template <typename ExPolicy,
         HPX_CONCEPT_REQUIRES_(
-            hpx::is_execution_policy_v<ExPolicy> &&
-            hpx::functional::is_tag_dispatchable_v<
-                hpx::execution::experimental::with_annotation_t,
-                typename std::decay_t<ExPolicy>::executor_type,
-                char const*>
+            hpx::is_execution_policy_v<ExPolicy>
         )>
     // clang-format on
     constexpr decltype(auto) tag_dispatch(
@@ -47,11 +43,7 @@ namespace hpx { namespace execution { namespace experimental {
     // clang-format off
     template <typename ExPolicy,
         HPX_CONCEPT_REQUIRES_(
-            hpx::is_execution_policy_v<ExPolicy> &&
-            hpx::functional::is_tag_dispatchable_v<
-                hpx::execution::experimental::with_annotation_t,
-                typename std::decay_t<ExPolicy>::executor_type,
-                std::string>
+            hpx::is_execution_policy_v<ExPolicy>
         )>
     // clang-format on
     decltype(auto) tag_dispatch(hpx::execution::experimental::with_annotation_t,

--- a/libs/parallelism/executors/include/hpx/executors/parallel_executor.hpp
+++ b/libs/parallelism/executors/include/hpx/executors/parallel_executor.hpp
@@ -185,8 +185,6 @@ namespace hpx { namespace execution {
             return exec.schedulehint_;
         }
 
-        using supports_annotations = void;
-
         friend constexpr parallel_policy_executor tag_dispatch(
             hpx::execution::experimental::with_annotation_t,
             parallel_policy_executor const& exec, char const* annotation)

--- a/libs/parallelism/executors/tests/unit/annotating_executor.cpp
+++ b/libs/parallelism/executors/tests/unit/annotating_executor.cpp
@@ -403,21 +403,71 @@ void test_with_annotation(ExPolicy&& policy)
 void test_seq_policy()
 {
     // make sure execution::seq is not used directly
-    auto policy = hpx::execution::experimental::with_annotation(
-        hpx::execution::seq, "seq");
+    {
+        auto policy = hpx::execution::experimental::with_annotation(
+            hpx::execution::seq, "seq");
 
-    HPX_TEST(typeid(policy.executor()).name() !=
-        typeid(hpx::execution::seq.executor()).name());
+        static_assert(
+            !std::is_same<std::decay_t<decltype(policy.executor())>,
+                std::decay_t<decltype(hpx::execution::seq.executor())>>::value,
+            "sequenced_executor should be wrapped in annotating_executor");
+
+        static_assert(
+            !std::is_same_v<std::decay_t<decltype(policy.executor())>,
+                std::decay_t<decltype(hpx::execution::seq.executor())>>,
+            "sequenced_executor should be wrapped in annotating_executor");
+    }
+
+    {
+        auto original_policy = hpx::execution::seq;
+        auto policy = hpx::execution::experimental::with_annotation(
+            std::move(original_policy), "seq");
+
+        static_assert(
+            !std::is_same<std::decay_t<decltype(policy.executor())>,
+                std::decay_t<decltype(hpx::execution::seq.executor())>>::value,
+            "sequenced_executor should be wrapped in annotating_executor");
+
+        static_assert(
+            !std::is_same_v<std::decay_t<decltype(policy.executor())>,
+                std::decay_t<decltype(hpx::execution::seq.executor())>>,
+            "sequenced_executor should be wrapped in annotating_executor");
+    }
 }
 
 void test_par_policy()
 {
     // make sure execution::par is used directly
-    auto policy = hpx::execution::experimental::with_annotation(
-        hpx::execution::par, "par");
+    {
+        auto policy = hpx::execution::experimental::with_annotation(
+            hpx::execution::par, "par");
 
-    HPX_TEST(typeid(policy.executor()).name() ==
-        typeid(hpx::execution::par.executor()).name());
+        static_assert(
+            std::is_same<std::decay_t<decltype(policy.executor())>,
+                std::decay_t<decltype(hpx::execution::par.executor())>>::value,
+            "parallel_executor should not be wrapped in annotating_executor");
+
+        static_assert(
+            std::is_same_v<std::decay_t<decltype(policy.executor())>,
+                std::decay_t<decltype(hpx::execution::par.executor())>>,
+            "parallel_executor should not be wrapped in annotating_executor");
+    }
+
+    {
+        auto original_policy = hpx::execution::par;
+        auto policy = hpx::execution::experimental::with_annotation(
+            std::move(original_policy), "par");
+
+        static_assert(
+            std::is_same<std::decay_t<decltype(policy.executor())>,
+                std::decay_t<decltype(hpx::execution::par.executor())>>::value,
+            "parallel_executor should not be wrapped in annotating_executor");
+
+        static_assert(
+            std::is_same_v<std::decay_t<decltype(policy.executor())>,
+                std::decay_t<decltype(hpx::execution::par.executor())>>,
+            "parallel_executor should not be wrapped in annotating_executor");
+    }
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/libs/parallelism/executors/tests/unit/annotating_executor.cpp
+++ b/libs/parallelism/executors/tests/unit/annotating_executor.cpp
@@ -411,11 +411,6 @@ void test_seq_policy()
             !std::is_same<std::decay_t<decltype(policy.executor())>,
                 std::decay_t<decltype(hpx::execution::seq.executor())>>::value,
             "sequenced_executor should be wrapped in annotating_executor");
-
-        static_assert(
-            !std::is_same_v<std::decay_t<decltype(policy.executor())>,
-                std::decay_t<decltype(hpx::execution::seq.executor())>>,
-            "sequenced_executor should be wrapped in annotating_executor");
     }
 
     {
@@ -426,11 +421,6 @@ void test_seq_policy()
         static_assert(
             !std::is_same<std::decay_t<decltype(policy.executor())>,
                 std::decay_t<decltype(hpx::execution::seq.executor())>>::value,
-            "sequenced_executor should be wrapped in annotating_executor");
-
-        static_assert(
-            !std::is_same_v<std::decay_t<decltype(policy.executor())>,
-                std::decay_t<decltype(hpx::execution::seq.executor())>>,
             "sequenced_executor should be wrapped in annotating_executor");
     }
 }
@@ -446,11 +436,6 @@ void test_par_policy()
             std::is_same<std::decay_t<decltype(policy.executor())>,
                 std::decay_t<decltype(hpx::execution::par.executor())>>::value,
             "parallel_executor should not be wrapped in annotating_executor");
-
-        static_assert(
-            std::is_same_v<std::decay_t<decltype(policy.executor())>,
-                std::decay_t<decltype(hpx::execution::par.executor())>>,
-            "parallel_executor should not be wrapped in annotating_executor");
     }
 
     {
@@ -461,11 +446,6 @@ void test_par_policy()
         static_assert(
             std::is_same<std::decay_t<decltype(policy.executor())>,
                 std::decay_t<decltype(hpx::execution::par.executor())>>::value,
-            "parallel_executor should not be wrapped in annotating_executor");
-
-        static_assert(
-            std::is_same_v<std::decay_t<decltype(policy.executor())>,
-                std::decay_t<decltype(hpx::execution::par.executor())>>,
             "parallel_executor should not be wrapped in annotating_executor");
     }
 }


### PR DESCRIPTION
This is mostly a cleanup PR for #5403 simplifying the selection conditions for the various `with_annotation` tag_dispatch overloads.
