### PR TITLE
Reduce max size and number of files in ccache cache

### DIFF
--- a/.jenkins/cscs/env-common.sh
+++ b/.jenkins/cscs/env-common.sh
@@ -13,4 +13,5 @@ spack load ninja@1.10.0
 export CMAKE_CXX_COMPILER_LAUNCHER=ccache
 export CMAKE_GENERATOR=Ninja
 export CCACHE_DIR=/scratch/snx3000/simbergm/ccache-jenkins-hpx
-export CCACHE_MAXSIZE=500G
+export CCACHE_MAXSIZE=100G
+export CCACHE_MAXFILES=50000


### PR DESCRIPTION
Reducing the cache size since the files count towards a shared quota. Hoping that it won't affect build speeds too dramatically.