### PR TITLE
Update logic to find threading library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1730,8 +1730,6 @@ if(NOT WIN32)
   # System libraries
   # ############################################################################
   if(NOT MSVC)
-    hpx_add_compile_flag_if_available(-pthread)
-    hpx_add_link_flag_if_available(-pthread TARGETS EXE SHARED)
     if(HPX_CXX11_STD_ATOMIC_LIBRARIES)
       target_link_libraries(
         hpx_base_libraries INTERFACE ${HPX_CXX11_STD_ATOMIC_LIBRARIES}
@@ -2146,6 +2144,8 @@ endif()
 # Find Our dependencies: These are all dependencies needed to build the core
 # library. Dependencies that are only needed by plugins, examples or tests
 # should be found separately in the appropriate subdirectory.
+
+include(HPX_SetupThreads)
 
 # Setup our required Boost libraries.
 include(HPX_SetupBoost)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -323,7 +323,10 @@ if(HPX_WITH_PRECOMPILED_HEADERS)
   set(HPX_WITH_PRECOMPILED_HEADERS_INTERNAL ON)
 
   add_library(hpx_precompiled_headers OBJECT libs/src/dummy.cpp)
-  target_link_libraries(hpx_precompiled_headers PRIVATE hpx_private_flags)
+  target_link_libraries(
+    hpx_precompiled_headers PRIVATE hpx_public_flags hpx_private_flags
+                                    hpx_base_libraries
+  )
   target_precompile_headers(
     hpx_precompiled_headers
     PRIVATE

--- a/cmake/FindAsio.cmake
+++ b/cmake/FindAsio.cmake
@@ -7,7 +7,6 @@
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-hpx_warn("finding asio")
 if(NOT TARGET Asio::asio)
   find_path(
     ASIO_INCLUDE_DIR asio.hpp

--- a/cmake/HPX_GeneratePackage.cmake
+++ b/cmake/HPX_GeneratePackage.cmake
@@ -141,19 +141,21 @@ if(HPX_WITH_PKGCONFIG)
     hpx_pkgconfig_component INTERFACE "-std=c++${HPX_CXX_STANDARD}"
   )
 
+  set(exclude_targets hpx_interface Threads::Threads)
+
   # Generate the pkconfig files for HPX_APPLICATION (both for build and install)
   hpx_generate_pkgconfig_from_target(
-    hpx_pkgconfig_application hpx_application TRUE EXCLUDE hpx_interface
+    hpx_pkgconfig_application hpx_application TRUE EXCLUDE ${exclude_targets}
   )
   hpx_generate_pkgconfig_from_target(
-    hpx_pkgconfig_application hpx_application FALSE EXCLUDE hpx_interface
+    hpx_pkgconfig_application hpx_application FALSE EXCLUDE ${exclude_targets}
   )
   # Generate the pkconfig files for HPX_COMPONENT (both for build and install)
   hpx_generate_pkgconfig_from_target(
-    hpx_pkgconfig_component hpx_component TRUE EXCLUDE hpx_interface
+    hpx_pkgconfig_component hpx_component TRUE EXCLUDE ${exclude_targets}
   )
   hpx_generate_pkgconfig_from_target(
-    hpx_pkgconfig_component hpx_component FALSE EXCLUDE hpx_interface
+    hpx_pkgconfig_component hpx_component FALSE EXCLUDE ${exclude_targets}
   )
 
   string(TOLOWER ${CMAKE_BUILD_TYPE} build_type)

--- a/cmake/HPX_SetupBoost.cmake
+++ b/cmake/HPX_SetupBoost.cmake
@@ -84,9 +84,6 @@ if(NOT TARGET hpx_dependencies_boost)
 
   include(HPX_AddDefinitions)
 
-  find_package(Threads QUIET REQUIRED)
-  target_link_libraries(hpx_dependencies_boost INTERFACE Threads::Threads)
-
   # Boost preprocessor definitions
   if(NOT Boost_USE_STATIC_LIBS)
     hpx_add_config_cond_define(BOOST_ALL_DYN_LINK)

--- a/cmake/HPX_SetupThreads.cmake
+++ b/cmake/HPX_SetupThreads.cmake
@@ -1,0 +1,13 @@
+# Copyright (c) 2018 Christopher Hinz
+# Copyright (c) 2014 Thomas Heller
+#
+# SPDX-License-Identifier: BSL-1.0
+# Distributed under the Boost Software License, Version 1.0. (See accompanying
+# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+set(THREADS_PREFER_PTHREAD_FLAG ON)
+find_package(Threads REQUIRED)
+
+if(NOT HPX_FIND_PACKAGE)
+  target_link_libraries(hpx_base_libraries INTERFACE Threads::Threads)
+endif()

--- a/cmake/templates/HPXConfig.cmake.in
+++ b/cmake/templates/HPXConfig.cmake.in
@@ -81,6 +81,8 @@ if(NOT MIMALLOC_ROOT AND NOT "$ENV{MIMALLOC_ROOT}")
 endif()
 include(HPX_SetupAllocator)
 
+include(HPX_SetupThreads)
+
 # Boost Separate boost targets to be unarily linked to some modules
 set(HPX_BOOST_ROOT "@BOOST_ROOT@")
 # By default BOOST_ROOT is set to HPX_BOOST_ROOT (not necessary for PAPI or


### PR DESCRIPTION
Fixes #5412 and #4942.

Removes the custom logic for adding pthread flags and uses `FindThreads` exclusively. The manually added pthread flags were interfering with CMake's detection for if `-pthread` should be added. However, the manually added flags were also not in the public interface, leading to linker errors in certain configurations.

Removing the manually added flags also lead to a different path in `FindThreads.cmake` which was triggering #4942. I've added a workaround for that, which is to filter out the `Threads::Threads` target from the pkgconfig file generation. *This may mean that pkgconfig file users have to add `-pthread` manually*. @stevenrbrandt is this an acceptable workaround for you?

@kordejong this is mostly the same changes that you tested earlier, but since I did reshuffle things a bit I'd be grateful if you could give these changes a try as well.