### PR TITLE
Update CI base image to use clang-format 11

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ working_dir_default: &working_dir_default
 
 docker_default: &docker_default
     docker:
-      - image: stellargroup/build_env:4
+      - image: stellargroup/build_env:6
 
 defaults: &defaults
     <<: *working_dir_default
@@ -159,8 +159,8 @@ jobs:
           name: Check that the modules are well clang-formatted
           command: |
               cd /hpx/source/libs && shopt -s globstar # to activate the ** globbing
-              clang-format-9 --version
-              clang-format-9 -i **/*.{cpp,hpp}
+              clang-format-11 --version
+              clang-format-11 -i **/*.{cpp,hpp}
               git diff --exit-code > /tmp/modified_clang_format_files.txt
       - store_artifacts:
           path: /tmp/modified_clang_format_files.txt

--- a/.clang-format
+++ b/.clang-format
@@ -19,7 +19,7 @@
 #   file while saving edits to disk
 # - Please do _not_ reformat a full source file without dire need.
 
-# PLEASE NOTE: This file requires clang-format V9.0
+# PLEASE NOTE: This file requires clang-format V11.0
 
 ---
 AccessModifierOffset: -4

--- a/.github/workflows/linux_debug.yml
+++ b/.github/workflows/linux_debug.yml
@@ -11,7 +11,7 @@ on: [pull_request]
 jobs:
   build:
     runs-on: ubuntu-latest
-    container: stellargroup/build_env:4
+    container: stellargroup/build_env:6
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/linux_hip.yml
+++ b/.github/workflows/linux_hip.yml
@@ -11,7 +11,7 @@ on: [pull_request]
 jobs:
   build:
     runs-on: ubuntu-latest
-    container: stellargroup/hip_build_env:4
+    container: stellargroup/hip_build_env:6
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/linux_release_fetchcontent.yml
+++ b/.github/workflows/linux_release_fetchcontent.yml
@@ -11,7 +11,7 @@ on: [pull_request]
 jobs:
   build:
     runs-on: ubuntu-latest
-    container: stellargroup/build_env:4
+    container: stellargroup/build_env:6
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/linux_sanitizers.yml
+++ b/.github/workflows/linux_sanitizers.yml
@@ -11,7 +11,7 @@ on: [pull_request]
 jobs:
   build:
     runs-on: ubuntu-latest
-    container: stellargroup/build_env:4
+    container: stellargroup/build_env:6
 
     steps:
     - uses: actions/checkout@v2

--- a/libs/core/datastructures/include/hpx/datastructures/member_pack.hpp
+++ b/libs/core/datastructures/include/hpx/datastructures/member_pack.hpp
@@ -119,7 +119,7 @@ namespace hpx { namespace util {
         }
 
         template <std::size_t I>
-            constexpr decltype(auto) get() & noexcept
+        constexpr decltype(auto) get() & noexcept
         {
             return detail::member_get<I>(*this);
         }
@@ -129,7 +129,7 @@ namespace hpx { namespace util {
             return detail::member_get<I>(*this);
         }
         template <std::size_t I>
-            constexpr decltype(auto) get() && noexcept
+        constexpr decltype(auto) get() && noexcept
         {
             using T = decltype(detail::member_type<I>(*this));
             return std::forward<T>(detail::member_get<I>(*this));

--- a/libs/core/datastructures/include/hpx/datastructures/optional.hpp
+++ b/libs/core/datastructures/include/hpx/datastructures/optional.hpp
@@ -327,9 +327,9 @@ namespace hpx { namespace util {
     template <typename T>
     constexpr bool operator==(optional<T> const& lhs, optional<T> const& rhs)
     {
-        return (bool(lhs) != bool(rhs)) ?
-            false :
-            (!bool(lhs) && !bool(rhs)) ? true : (*lhs == *rhs);
+        return (bool(lhs) != bool(rhs)) ? false :
+            (!bool(lhs) && !bool(rhs))  ? true :
+                                          (*lhs == *rhs);
     }
 
     template <typename T>

--- a/libs/core/errors/include/hpx/errors/exception_info.hpp
+++ b/libs/core/errors/include/hpx/errors/exception_info.hpp
@@ -64,8 +64,8 @@ namespace hpx {
         {
         public:
             virtual ~exception_info_node_base() = default;
-            virtual void const* lookup(std::type_info const& tag) const
-                noexcept = 0;
+            virtual void const* lookup(
+                std::type_info const& tag) const noexcept = 0;
 
             std::shared_ptr<exception_info_node_base> next;
         };
@@ -82,8 +82,8 @@ namespace hpx {
             {
             }
 
-            void const* lookup(std::type_info const& tag) const
-                noexcept override
+            void const* lookup(
+                std::type_info const& tag) const noexcept override
             {
                 using entry_type =
                     std::pair<std::type_info const&, void const*>;

--- a/libs/core/execution_base/include/hpx/execution_base/sender.hpp
+++ b/libs/core/execution_base/include/hpx/execution_base/sender.hpp
@@ -500,8 +500,8 @@ namespace hpx { namespace execution { namespace experimental {
 
                 template <typename... Ts,
                     typename = std::enable_if_t<is_receiver_of_v<R, Ts...>>>
-                    void set_value(Ts&&... ts) &&
-                    noexcept(is_nothrow_receiver_of_v<R, Ts...>)
+                void set_value(Ts&&... ts) && noexcept(
+                    is_nothrow_receiver_of_v<R, Ts...>)
                 {
                     hpx::execution::experimental::set_value(
                         std::move(p->r), std::forward<Ts>(ts)...);
@@ -510,7 +510,7 @@ namespace hpx { namespace execution { namespace experimental {
 
                 template <typename E,
                     typename = std::enable_if_t<is_receiver_v<R, E>>>
-                    void set_error(E&& e) && noexcept
+                void set_error(E&& e) && noexcept
                 {
                     hpx::execution::experimental::set_error(
                         std::move(p->r), std::forward<E>(e));

--- a/libs/core/execution_base/tests/unit/basic_schedule.cpp
+++ b/libs/core/execution_base/tests/unit/basic_schedule.cpp
@@ -32,7 +32,7 @@ struct sender
     };
 
     template <typename R>
-        operation_state connect(R&&) && noexcept
+    operation_state connect(R&&) && noexcept
     {
         return {};
     }

--- a/libs/core/execution_base/tests/unit/basic_submit.cpp
+++ b/libs/core/execution_base/tests/unit/basic_submit.cpp
@@ -165,7 +165,7 @@ struct sender_4
     };
 
     template <typename R>
-        operation_state<R> connect(R&& r) && noexcept
+    operation_state<R> connect(R&& r) && noexcept
     {
         ++connect_calls;
         return {r};

--- a/libs/core/iterator_support/include/hpx/iterator_support/iterator_facade.hpp
+++ b/libs/core/iterator_support/include/hpx/iterator_support/iterator_facade.hpp
@@ -437,7 +437,7 @@ namespace hpx { namespace util {
             }
 
             // Provides X(r++)
-            HPX_HOST_DEVICE operator Iterator const&() const
+            HPX_HOST_DEVICE operator Iterator const &() const
             {
                 return stored_iterator;
             }

--- a/libs/core/iterator_support/tests/unit/iterator_facade.cpp
+++ b/libs/core/iterator_support/tests/unit/iterator_facade.cpp
@@ -62,7 +62,7 @@ struct proxy
     {
     }
 
-    operator int const&() const
+    operator int const &() const
     {
         return state;
     }

--- a/libs/core/logging/include/hpx/modules/logging.hpp
+++ b/libs/core/logging/include/hpx/modules/logging.hpp
@@ -199,8 +199,8 @@ namespace hpx { namespace util {
             }
 
             template <typename... Args>
-            dummy_log_impl const& format(char const*, Args const&...) const
-                noexcept
+            dummy_log_impl const& format(
+                char const*, Args const&...) const noexcept
             {
                 return *this;
             }

--- a/libs/core/memory/include/hpx/memory/intrusive_ptr.hpp
+++ b/libs/core/memory/include/hpx/memory/intrusive_ptr.hpp
@@ -340,8 +340,8 @@ namespace std {
     {
         using result_type = std::size_t;
 
-        result_type operator()(hpx::memory::intrusive_ptr<T> const& p) const
-            noexcept
+        result_type operator()(
+            hpx::memory::intrusive_ptr<T> const& p) const noexcept
         {
             return hash<T*>{}(p.get());
         }

--- a/libs/core/serialization/include/hpx/serialization/traits/brace_initializable_traits.hpp
+++ b/libs/core/serialization/include/hpx/serialization/traits/brace_initializable_traits.hpp
@@ -28,7 +28,7 @@ namespace hpx { namespace traits {
                     !std::is_lvalue_reference<T>::value &&
                     !std::is_same<typename std::decay<T>::type,
                         hpx::util::unused_type>::value>::type>
-            operator T &&() const;
+            operator T&&() const;
 
             template <typename T,
                 typename Enable = typename std::enable_if<

--- a/libs/core/tag_dispatch/include/hpx/functional/tag_fallback_dispatch.hpp
+++ b/libs/core/tag_dispatch/include/hpx/functional/tag_fallback_dispatch.hpp
@@ -311,8 +311,9 @@ namespace hpx { namespace functional {
 
             template <typename... Args>
             HPX_HOST_DEVICE HPX_FORCEINLINE constexpr auto
-            tag_fallback_dispatch_impl(std::true_type, Args&&... args) const
-                noexcept -> tag_fallback_dispatch_result_t<Tag, Args&&...>
+            tag_fallback_dispatch_impl(
+                std::true_type, Args&&... args) const noexcept
+                -> tag_fallback_dispatch_result_t<Tag, Args&&...>
             {
                 return tag_fallback_dispatch(static_cast<Tag const&>(*this),
                     std::forward<Args>(args)...);

--- a/libs/core/threading_base/include/hpx/threading_base/thread_description.hpp
+++ b/libs/core/threading_base/include/hpx/threading_base/thread_description.hpp
@@ -147,8 +147,8 @@ namespace hpx { namespace util {
                                util::itt::string_handle(get_description());
         }
 
-        util::itt::task get_task_itt(util::itt::domain const& domain) const
-            noexcept
+        util::itt::task get_task_itt(
+            util::itt::domain const& domain) const noexcept
         {
             switch (kind())
             {
@@ -241,8 +241,8 @@ namespace hpx { namespace util {
             return util::itt::string_handle(get_description());
         }
 
-        util::itt::task get_task_itt(util::itt::domain const& domain) const
-            noexcept
+        util::itt::task get_task_itt(
+            util::itt::domain const& domain) const noexcept
         {
             switch (kind())
             {

--- a/libs/core/threading_base/include/hpx/threading_base/threading_base_fwd.hpp
+++ b/libs/core/threading_base/include/hpx/threading_base/threading_base_fwd.hpp
@@ -75,8 +75,8 @@ namespace std {
     template <>
     struct hash<::hpx::threads::thread_id>
     {
-        std::size_t operator()(::hpx::threads::thread_id const& v) const
-            noexcept
+        std::size_t operator()(
+            ::hpx::threads::thread_id const& v) const noexcept
         {
             std::hash<::hpx::threads::thread_data const*> hasher_;
             return hasher_(static_cast<::hpx::threads::thread_data*>(v.get()));

--- a/libs/full/async_cuda/tests/unit/saxpy.cu
+++ b/libs/full/async_cuda/tests/unit/saxpy.cu
@@ -19,7 +19,7 @@ __global__ void saxpy(int n, float a, float* x, float* y)
 }
 
 void launch_saxpy_kernel(hpx::cuda::experimental::cuda_executor& cudaexec,
-        unsigned int& blocks, unsigned int& threads, void** args)
+    unsigned int& blocks, unsigned int& threads, void** args)
 {
     // Invoking hpx::apply with cudaLaunchKernel<void> directly result in an
     // error for NVCC with gcc configuration

--- a/libs/full/naming_base/include/hpx/naming_base/id_type.hpp
+++ b/libs/full/naming_base/include/hpx/naming_base/id_type.hpp
@@ -223,8 +223,8 @@ namespace hpx { namespace naming {
             {
             }
 
-            constexpr id_type::management_type get_management_type() const
-                noexcept
+            constexpr id_type::management_type get_management_type()
+                const noexcept
             {
                 return type_;
             }

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/transform_exclusive_scan.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/transform_exclusive_scan.hpp
@@ -159,7 +159,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                     std::move(f3),
                     // use this return value
                     [final_dest](std::vector<hpx::shared_future<T>>&&,
-                        std::vector<hpx::future<void>> &&) -> FwdIter2 {
+                        std::vector<hpx::future<void>>&&) -> FwdIter2 {
                         return final_dest;
                     });
             }

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/transform_inclusive_scan.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/transform_inclusive_scan.hpp
@@ -181,7 +181,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                     std::move(f3),
                     // step 4 use this return value
                     [final_dest](std::vector<hpx::shared_future<T>>&&,
-                        std::vector<hpx::future<void>> &&) -> FwdIter2 {
+                        std::vector<hpx::future<void>>&&) -> FwdIter2 {
                         return final_dest;
                     });
             }

--- a/libs/parallelism/algorithms/include/hpx/parallel/util/projection_identity.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/util/projection_identity.hpp
@@ -18,8 +18,8 @@ namespace hpx { namespace parallel { namespace util {
         using is_transparent = std::true_type;
 
         template <typename T>
-        HPX_HOST_DEVICE HPX_FORCEINLINE constexpr T&& operator()(T&& val) const
-            noexcept
+        HPX_HOST_DEVICE HPX_FORCEINLINE constexpr T&& operator()(
+            T&& val) const noexcept
         {
             return std::forward<T>(val);
         }

--- a/libs/parallelism/execution/include/hpx/execution/algorithms/bulk.hpp
+++ b/libs/parallelism/execution/include/hpx/execution/algorithms/bulk.hpp
@@ -88,7 +88,7 @@ namespace hpx { namespace execution { namespace experimental {
                 }
 
                 template <typename E>
-                    void set_error(E&& e) && noexcept
+                void set_error(E&& e) && noexcept
                 {
                     hpx::execution::experimental::set_error(
                         std::move(receiver), std::forward<E>(e));
@@ -106,12 +106,11 @@ namespace hpx { namespace execution { namespace experimental {
                         Sender>::template value_types<hpx::tuple, hpx::variant>;
 
                 template <typename... Ts>
-                    auto set_value(Ts&&... ts) &&
-                    noexcept -> decltype(
-                        std::declval<hpx::variant<hpx::monostate, value_type>>()
-                            .template emplace<value_type>(
-                                hpx::make_tuple<>(std::forward<Ts>(ts)...)),
-                        void())
+                auto set_value(Ts&&... ts) && noexcept -> decltype(
+                    std::declval<hpx::variant<hpx::monostate, value_type>>()
+                        .template emplace<value_type>(
+                            hpx::make_tuple<>(std::forward<Ts>(ts)...)),
+                    void())
                 {
                     hpx::detail::try_catch_exception_ptr(
                         [&]() {

--- a/libs/parallelism/execution/include/hpx/execution/algorithms/detach.hpp
+++ b/libs/parallelism/execution/include/hpx/execution/algorithms/detach.hpp
@@ -38,7 +38,7 @@ namespace hpx { namespace execution { namespace experimental {
                 hpx::intrusive_ptr<operation_state_holder> op_state;
 
                 template <typename Error>
-                    HPX_NORETURN void set_error(Error&&) && noexcept
+                HPX_NORETURN void set_error(Error&&) && noexcept
                 {
                     HPX_ASSERT_MSG(false,
                         "set_error was called on the receiver of detach, "
@@ -54,7 +54,7 @@ namespace hpx { namespace execution { namespace experimental {
                 };
 
                 template <typename... Ts>
-                    void set_value(Ts&&...) && noexcept
+                void set_value(Ts&&...) && noexcept
                 {
                     op_state.reset();
                 }

--- a/libs/parallelism/execution/include/hpx/execution/algorithms/ensure_started.hpp
+++ b/libs/parallelism/execution/include/hpx/execution/algorithms/ensure_started.hpp
@@ -135,7 +135,7 @@ namespace hpx { namespace execution { namespace experimental {
                     hpx::intrusive_ptr<shared_state> state;
 
                     template <typename Error>
-                        void set_error(Error&& error) && noexcept
+                    void set_error(Error&& error) && noexcept
                     {
                         state->v.template emplace<error_type>(
                             error_type(std::forward<Error>(error)));
@@ -158,13 +158,11 @@ namespace hpx { namespace execution { namespace experimental {
                             std::variant>;
 
                     template <typename... Ts>
-                        auto set_value(Ts&&... ts) &&
-                        noexcept -> decltype(
-                            std::declval<
-                                std::variant<std::monostate, value_type>>()
-                                .template emplace<value_type>(
-                                    hpx::make_tuple<>(std::forward<Ts>(ts)...)),
-                            void())
+                    auto set_value(Ts&&... ts) && noexcept -> decltype(
+                        std::declval<std::variant<std::monostate, value_type>>()
+                            .template emplace<value_type>(
+                                hpx::make_tuple<>(std::forward<Ts>(ts)...)),
+                        void())
                     {
                         state->v.template emplace<value_type>(
                             hpx::make_tuple<>(std::forward<Ts>(ts)...));

--- a/libs/parallelism/execution/include/hpx/execution/algorithms/let_error.hpp
+++ b/libs/parallelism/execution/include/hpx/execution/algorithms/let_error.hpp
@@ -181,7 +181,7 @@ namespace hpx { namespace execution { namespace experimental {
                     };
 
                     template <typename Error>
-                        void set_error(Error&& error) && noexcept
+                    void set_error(Error&& error) && noexcept
                     {
                         hpx::detail::try_catch_exception_ptr(
                             [&]() {
@@ -211,7 +211,7 @@ namespace hpx { namespace execution { namespace experimental {
                         typename = std::enable_if_t<hpx::is_invocable_v<
                             hpx::execution::experimental::set_value_t,
                             Receiver&&, Ts...>>>
-                        void set_value(Ts&&... ts) && noexcept
+                    void set_value(Ts&&... ts) && noexcept
                     {
                         hpx::execution::experimental::set_value(
                             std::move(receiver), std::forward<Ts>(ts)...);

--- a/libs/parallelism/execution/include/hpx/execution/algorithms/let_value.hpp
+++ b/libs/parallelism/execution/include/hpx/execution/algorithms/let_value.hpp
@@ -156,7 +156,7 @@ namespace hpx { namespace execution { namespace experimental {
                     }
 
                     template <typename Error>
-                        void set_error(Error&& error) && noexcept
+                    void set_error(Error&& error) && noexcept
                     {
                         hpx::execution::experimental::set_error(
                             std::move(receiver), std::forward<Error>(error));
@@ -240,8 +240,7 @@ namespace hpx { namespace execution { namespace experimental {
                         hpx::monostate>;
 
                     template <typename... Ts>
-                        auto set_value(Ts&&... ts) &&
-                        noexcept
+                    auto set_value(Ts&&... ts) && noexcept
                         -> decltype(std::declval<predecessor_ts_type>()
                                         .template emplace<hpx::tuple<Ts...>>(
                                             std::forward<Ts>(ts)...),

--- a/libs/parallelism/execution/include/hpx/execution/algorithms/make_future.hpp
+++ b/libs/parallelism/execution/include/hpx/execution/algorithms/make_future.hpp
@@ -46,7 +46,7 @@ namespace hpx { namespace execution { namespace experimental {
             }
 
             template <typename U>
-                void set_value(U&& u) && noexcept
+            void set_value(U&& u) && noexcept
             {
                 hpx::detail::try_catch_exception_ptr(
                     [&]() { data->set_value(std::forward<U>(u)); },

--- a/libs/parallelism/execution/include/hpx/execution/algorithms/on.hpp
+++ b/libs/parallelism/execution/include/hpx/execution/algorithms/on.hpp
@@ -107,7 +107,7 @@ namespace hpx { namespace execution { namespace experimental {
                     operation_state& op_state;
 
                     template <typename Error>
-                        void set_error(Error&& error) && noexcept
+                    void set_error(Error&& error) && noexcept
                     {
                         op_state.set_error_predecessor_sender(
                             std::forward<Error>(error));
@@ -128,8 +128,7 @@ namespace hpx { namespace execution { namespace experimental {
                         hpx::monostate>;
 
                     template <typename... Ts>
-                        auto set_value(Ts&&... ts) &&
-                        noexcept
+                    auto set_value(Ts&&... ts) && noexcept
                         -> decltype(std::declval<value_type>()
                                         .template emplace<hpx::tuple<Ts...>>(
                                             std::forward<Ts>(ts)...),
@@ -187,7 +186,7 @@ namespace hpx { namespace execution { namespace experimental {
                     operation_state& op_state;
 
                     template <typename Error>
-                        void set_error(Error&& error) && noexcept
+                    void set_error(Error&& error) && noexcept
                     {
                         op_state.set_error_scheduler_sender(
                             std::forward<Error>(error));

--- a/libs/parallelism/execution/include/hpx/execution/algorithms/sync_wait.hpp
+++ b/libs/parallelism/execution/include/hpx/execution/algorithms/sync_wait.hpp
@@ -140,7 +140,7 @@ namespace hpx { namespace execution { namespace experimental {
             }
 
             template <typename Error>
-                void set_error(Error&& error) && noexcept
+            void set_error(Error&& error) && noexcept
             {
                 state.value.template emplace<error_type>(
                     std::forward<Error>(error));
@@ -156,7 +156,7 @@ namespace hpx { namespace execution { namespace experimental {
                 typename =
                     std::enable_if_t<(is_void_result && sizeof...(Us) == 0) ||
                         (!is_void_result && sizeof...(Us) == 1)>>
-                void set_value(Us&&... us) && noexcept
+            void set_value(Us&&... us) && noexcept
             {
                 state.value.template emplace<value_type>(
                     std::forward<Us>(us)...);

--- a/libs/parallelism/execution/include/hpx/execution/algorithms/transform.hpp
+++ b/libs/parallelism/execution/include/hpx/execution/algorithms/transform.hpp
@@ -28,7 +28,7 @@ namespace hpx { namespace execution { namespace experimental {
             std::decay_t<F> f;
 
             template <typename Error>
-                void set_error(Error&& error) && noexcept
+            void set_error(Error&& error) && noexcept
             {
                 hpx::execution::experimental::set_error(
                     std::move(receiver), std::forward<Error>(error));
@@ -73,7 +73,7 @@ namespace hpx { namespace execution { namespace experimental {
         public:
             template <typename... Ts,
                 typename = std::enable_if_t<hpx::is_invocable_v<F, Ts...>>>
-                void set_value(Ts&&... ts) && noexcept
+            void set_value(Ts&&... ts) && noexcept
             {
                 using is_void_result =
                     std::is_void<hpx::util::invoke_result_t<F, Ts...>>;

--- a/libs/parallelism/execution/include/hpx/execution/algorithms/when_all.hpp
+++ b/libs/parallelism/execution/include/hpx/execution/algorithms/when_all.hpp
@@ -39,7 +39,7 @@ namespace hpx { namespace execution { namespace experimental {
             }
 
             template <typename Error>
-                void set_error(Error&& error) && noexcept
+            void set_error(Error&& error) && noexcept
             {
                 if (!op_state.set_done_error_called.exchange(true))
                 {
@@ -64,7 +64,7 @@ namespace hpx { namespace execution { namespace experimental {
             };
 
             template <typename T>
-                void set_value(T&& t) && noexcept
+            void set_value(T&& t) && noexcept
             {
                 if (!op_state.set_done_error_called)
                 {

--- a/libs/parallelism/executors/include/hpx/executors/parallel_executor.hpp
+++ b/libs/parallelism/executors/include/hpx/executors/parallel_executor.hpp
@@ -212,8 +212,8 @@ namespace hpx { namespace execution {
         }
 
         /// \cond NOINTERNAL
-        constexpr bool operator==(parallel_policy_executor const& rhs) const
-            noexcept
+        constexpr bool operator==(
+            parallel_policy_executor const& rhs) const noexcept
         {
             return policy_ == rhs.policy_ && pool_ == rhs.pool_ &&
                 priority_ == rhs.priority_ && stacksize_ == rhs.stacksize_ &&
@@ -221,8 +221,8 @@ namespace hpx { namespace execution {
                 hierarchical_threshold_ == rhs.hierarchical_threshold_;
         }
 
-        constexpr bool operator!=(parallel_policy_executor const& rhs) const
-            noexcept
+        constexpr bool operator!=(
+            parallel_policy_executor const& rhs) const noexcept
         {
             return !(*this == rhs);
         }

--- a/libs/parallelism/executors/include/hpx/executors/restricted_thread_pool_executor.hpp
+++ b/libs/parallelism/executors/include/hpx/executors/restricted_thread_pool_executor.hpp
@@ -71,8 +71,8 @@ namespace hpx { namespace parallel { namespace execution {
         }
 
         /// \cond NOINTERNAL
-        bool operator==(restricted_thread_pool_executor const& rhs) const
-            noexcept
+        bool operator==(
+            restricted_thread_pool_executor const& rhs) const noexcept
         {
             return pool_ == rhs.pool_ && priority_ == rhs.priority_ &&
                 stacksize_ == rhs.stacksize_ &&
@@ -81,8 +81,8 @@ namespace hpx { namespace parallel { namespace execution {
                 num_threads_ == rhs.num_threads_;
         }
 
-        bool operator!=(restricted_thread_pool_executor const& rhs) const
-            noexcept
+        bool operator!=(
+            restricted_thread_pool_executor const& rhs) const noexcept
         {
             return !(*this == rhs);
         }

--- a/libs/parallelism/pack_traversal/include/hpx/pack_traversal/detail/pack_traversal_async_impl.hpp
+++ b/libs/parallelism/pack_traversal/include/hpx/pack_traversal/detail/pack_traversal_async_impl.hpp
@@ -282,14 +282,14 @@ namespace hpx {
             }
 
             template <std::size_t Position>
-            constexpr static_async_range<Target, Position, End> relocate() const
-                noexcept
+            constexpr static_async_range<Target, Position, End> relocate()
+                const noexcept
             {
                 return static_async_range<Target, Position, End>{target_};
             }
 
-            constexpr static_async_range<Target, Begin + 1, End> next() const
-                noexcept
+            constexpr static_async_range<Target, Begin + 1, End> next()
+                const noexcept
             {
                 return static_async_range<Target, Begin + 1, End>{target_};
             }

--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -3,7 +3,7 @@
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-FROM stellargroup/build_env:4
+FROM stellargroup/build_env:6
 
 # docker build needs to be run in /usr/local
 COPY . /usr/local


### PR DESCRIPTION
Partially fixes #5364 (the clang-format part, not the Ubuntu version).

[skip ci]