### PR TITLE
Adding execution::experimental::bulk algorithm

### DIFF
--- a/libs/core/type_support/include/hpx/type_support/pack.hpp
+++ b/libs/core/type_support/include/hpx/type_support/pack.hpp
@@ -17,14 +17,14 @@ namespace hpx { namespace util {
     struct pack
     {
         typedef pack type;
-        static const std::size_t size = sizeof...(Ts);
+        static constexpr std::size_t size = sizeof...(Ts);
     };
 
     template <typename T, T... Vs>
     struct pack_c
     {
         typedef pack_c type;
-        static const std::size_t size = sizeof...(Vs);
+        static constexpr std::size_t size = sizeof...(Vs);
     };
 
     template <std::size_t... Is>
@@ -110,6 +110,9 @@ namespace hpx { namespace util {
     {
     };
 
+    template <typename... Ts>
+    HPX_INLINE_CONSTEXPR_VARIABLE bool all_of_v = all_of<Ts...>::value;
+
     namespace detail {
         template <typename... Ts>
         static std::true_type any_of(...);
@@ -131,9 +134,15 @@ namespace hpx { namespace util {
     };
 
     template <typename... Ts>
+    HPX_INLINE_CONSTEXPR_VARIABLE bool any_of_v = any_of<Ts...>::value;
+
+    template <typename... Ts>
     struct none_of : std::integral_constant<bool, !any_of<Ts...>::value>
     {
     };
+
+    template <typename... Ts>
+    HPX_INLINE_CONSTEXPR_VARIABLE bool none_of_v = none_of<Ts...>::value;
 
     template <typename T, typename... Ts>
     struct contains : any_of<std::is_same<T, Ts>...>
@@ -192,6 +201,9 @@ namespace hpx { namespace util {
     struct at_index : detail::at_index_impl<I, pack<Ts...>>
     {
     };
+
+    template <std::size_t I, typename... Ts>
+    using at_index_t = typename at_index<I, Ts...>::type;
 
     namespace detail {
         template <typename Pack, template <typename> class Transformer>

--- a/libs/parallelism/execution/CMakeLists.txt
+++ b/libs/parallelism/execution/CMakeLists.txt
@@ -7,6 +7,7 @@
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 
 set(execution_headers
+    hpx/execution/algorithms/bulk.hpp
     hpx/execution/algorithms/detach.hpp
     hpx/execution/algorithms/detail/is_negative.hpp
     hpx/execution/algorithms/detail/partial_algorithm.hpp

--- a/libs/parallelism/execution/include/hpx/execution/algorithms/bulk.hpp
+++ b/libs/parallelism/execution/include/hpx/execution/algorithms/bulk.hpp
@@ -47,7 +47,7 @@ namespace hpx { namespace execution { namespace experimental {
             }
 
             template <typename E>
-            void set_error(E&& e) && noexcept
+                void set_error(E&& e) && noexcept
             {
                 hpx::execution::experimental::set_error(
                     std::move(r), std::forward<E>(e));

--- a/libs/parallelism/execution/include/hpx/execution/algorithms/bulk.hpp
+++ b/libs/parallelism/execution/include/hpx/execution/algorithms/bulk.hpp
@@ -1,0 +1,256 @@
+//  Copyright (c) 2020 ETH Zurich
+//  Copyright (c) 2021 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include <hpx/config.hpp>
+#include <hpx/concepts/concepts.hpp>
+#include <hpx/errors/try_catch_exception_ptr.hpp>
+#include <hpx/execution/algorithms/detail/partial_algorithm.hpp>
+#include <hpx/execution/algorithms/transform.hpp>
+#include <hpx/execution_base/receiver.hpp>
+#include <hpx/execution_base/sender.hpp>
+#include <hpx/functional/invoke_result.hpp>
+#include <hpx/functional/tag_fallback_dispatch.hpp>
+#include <hpx/iterator_support/counting_iterator.hpp>
+#include <hpx/iterator_support/iterator_range.hpp>
+#include <hpx/iterator_support/range.hpp>
+#include <hpx/iterator_support/traits/is_range.hpp>
+#include <hpx/type_support/pack.hpp>
+
+#include <exception>
+#include <iterator>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+namespace hpx { namespace execution { namespace experimental {
+
+    ///////////////////////////////////////////////////////////////////////////
+    namespace detail {
+        template <typename R, typename Shape, typename F>
+        struct bulk_receiver
+        {
+            std::decay_t<R> r;
+            std::decay_t<Shape> shape;
+            std::decay_t<F> f;
+
+            using shape_iterator = typename hpx::traits::range_traits<
+                std::decay_t<Shape>>::iterator_type;
+            using shape_element =
+                typename std::iterator_traits<shape_iterator>::value_type;
+
+            template <typename R_, typename Shape_, typename F_>
+            bulk_receiver(R_&& r, Shape_&& shape, F_&& f)
+              : r(std::forward<R_>(r))
+              , shape(std::forward<Shape_>(shape))
+              , f(std::forward<F_>(f))
+            {
+            }
+
+            template <typename E>
+            void set_error(E&& e) && noexcept
+            {
+                hpx::execution::experimental::set_error(
+                    std::move(r), std::forward<E>(e));
+            }
+
+            void set_done() && noexcept
+            {
+                hpx::execution::experimental::set_done(std::move(r));
+            }
+
+        private:
+            template <typename... Ts>
+            void set_value_helper(std::true_type, Ts&&... ts) noexcept
+            {
+                hpx::detail::try_catch_exception_ptr(
+                    [&]() {
+                        for (auto const& s : shape)
+                        {
+                            HPX_INVOKE(f, s, ts...);
+                        }
+                        hpx::execution::experimental::set_value(std::move(r));
+                    },
+                    [&](std::exception_ptr ep) {
+                        hpx::execution::experimental::set_error(
+                            std::move(r), std::move(ep));
+                    });
+            }
+
+            template <typename... Ts>
+            void set_value_helper(std::false_type, Ts&&... ts) noexcept
+            {
+                hpx::detail::try_catch_exception_ptr(
+                    [&]() {
+                        using result_type =
+                            hpx::util::invoke_result_t<std::decay_t<F>,
+                                shape_element, std::decay_t<Ts>...>;
+
+                        std::vector<result_type> results;
+                        results.reserve(util::size(shape));
+                        for (auto const& s : shape)
+                        {
+                            results.emplace_back(HPX_INVOKE(f, s, ts...));
+                        }
+
+                        hpx::execution::experimental::set_value(
+                            std::move(r), std::move(results));
+                    },
+                    [&](std::exception_ptr ep) {
+                        hpx::execution::experimental::set_error(
+                            std::move(r), std::move(ep));
+                    });
+            }
+
+        public:
+            template <typename... Ts,
+                typename = std::enable_if_t<
+                    hpx::is_invocable_v<F, shape_element, Ts...>>>
+            void set_value(Ts&&... ts) && noexcept
+            {
+                using is_void_result = std::is_void<
+                    hpx::util::invoke_result_t<F, shape_element, Ts...>>;
+                set_value_helper(is_void_result{}, std::forward<Ts>(ts)...);
+            }
+        };
+
+        template <typename S, typename Shape, typename F>
+        struct bulk_sender
+        {
+            std::decay_t<S> s;
+            std::decay_t<Shape> shape;
+            std::decay_t<F> f;
+
+            using shape_iterator = typename hpx::traits::range_traits<
+                std::decay_t<Shape>>::iterator_type;
+            using shape_element =
+                typename std::iterator_traits<shape_iterator>::value_type;
+
+            template <typename Tuple>
+            struct invoke_result_helper;
+
+            template <template <typename...> class Tuple, typename... Ts>
+            struct invoke_result_helper<Tuple<Ts...>>
+            {
+                using result_type =
+                    hpx::util::invoke_result_t<F, shape_element, Ts...>;
+                using type =
+                    typename std::conditional<std::is_void<result_type>::value,
+                        Tuple<>, Tuple<std::vector<result_type>>>::type;
+            };
+
+            template <template <typename...> class Tuple,
+                template <typename...> class Variant>
+            using value_types =
+                hpx::util::detail::unique_t<hpx::util::detail::transform_t<
+                    typename hpx::execution::experimental::sender_traits<
+                        S>::template value_types<Tuple, Variant>,
+                    invoke_result_helper>>;
+
+            template <template <typename...> class Variant>
+            using error_types =
+                hpx::util::detail::unique_t<hpx::util::detail::prepend_t<
+                    typename hpx::execution::experimental::sender_traits<
+                        S>::template error_types<Variant>,
+                    std::exception_ptr>>;
+
+            static constexpr bool sends_done = false;
+
+            template <typename R>
+            auto connect(R&& r) &&
+            {
+                return hpx::execution::experimental::connect(std::move(s),
+                    bulk_receiver<R, Shape, F>(
+                        std::forward<R>(r), std::move(shape), std::move(f)));
+            }
+
+            template <typename R>
+            auto connect(R&& r) &
+            {
+                return hpx::execution::experimental::connect(s,
+                    bulk_receiver<R, Shape, F>(std::forward<R>(r), shape, f));
+            }
+        };
+
+        ///////////////////////////////////////////////////////////////////////
+        template <typename Incrementable>
+        using counting_shape_type = hpx::util::iterator_range<
+            hpx::util::counting_iterator<Incrementable>>;
+
+        template <typename Incrementable>
+        HPX_HOST_DEVICE inline counting_shape_type<Incrementable>
+        make_counting_shape(Incrementable n)
+        {
+            return hpx::util::make_iterator_range(
+                hpx::util::make_counting_iterator(Incrementable(0)),
+                hpx::util::make_counting_iterator(n));
+        }
+    }    // namespace detail
+
+    ///////////////////////////////////////////////////////////////////////////
+    HPX_INLINE_CONSTEXPR_VARIABLE struct bulk_t final
+      : hpx::functional::tag_fallback<bulk_t>
+    {
+    private:
+        // clang-format off
+        template <typename S, typename Shape, typename F,
+            HPX_CONCEPT_REQUIRES_(
+                is_sender_v<S> &&
+                std::is_integral<Shape>::value
+            )>
+        // clang-format on
+        friend constexpr HPX_FORCEINLINE auto tag_fallback_dispatch(
+            bulk_t, S&& s, Shape const& shape, F&& f)
+        {
+            return detail::bulk_sender<S, detail::counting_shape_type<Shape>,
+                F>{std::forward<S>(s), detail::make_counting_shape(shape),
+                std::forward<F>(f)};
+        }
+
+        // clang-format off
+        template <typename S, typename Shape, typename F,
+            HPX_CONCEPT_REQUIRES_(
+                is_sender_v<S> &&
+                !std::is_integral<std::decay_t<Shape>>::value
+            )>
+        // clang-format on
+        friend constexpr HPX_FORCEINLINE auto tag_fallback_dispatch(
+            bulk_t, S&& s, Shape&& shape, F&& f)
+        {
+            return detail::bulk_sender<S, Shape, F>{std::forward<S>(s),
+                std::forward<Shape>(shape), std::forward<F>(f)};
+        }
+
+        // clang-format off
+        template <typename Shape, typename F,
+            HPX_CONCEPT_REQUIRES_(
+                std::is_integral<Shape>::value
+            )>
+        // clang-format on
+        friend constexpr HPX_FORCEINLINE auto tag_fallback_dispatch(
+            bulk_t, Shape const& shape, F&& f)
+        {
+            return detail::partial_algorithm<bulk_t,
+                detail::counting_shape_type<Shape>, F>{
+                detail::make_counting_shape(shape), std::forward<F>(f)};
+        }
+
+        // clang-format off
+        template <typename Shape, typename F,
+            HPX_CONCEPT_REQUIRES_(
+                !std::is_integral<std::decay_t<Shape>>::value
+            )>
+        // clang-format on
+        friend constexpr HPX_FORCEINLINE auto tag_fallback_dispatch(
+            bulk_t, Shape&& shape, F&& f)
+        {
+            return detail::partial_algorithm<bulk_t, Shape, F>{
+                std::forward<Shape>(shape), std::forward<F>(f)};
+        }
+    } bulk{};
+}}}    // namespace hpx::execution::experimental

--- a/libs/parallelism/execution/include/hpx/execution/algorithms/bulk.hpp
+++ b/libs/parallelism/execution/include/hpx/execution/algorithms/bulk.hpp
@@ -59,7 +59,7 @@ namespace hpx { namespace execution { namespace experimental {
             }
 
             template <typename... Ts>
-            void set_value(Ts&&... ts) noexcept
+                void set_value(Ts&&... ts) && noexcept
             {
                 hpx::detail::try_catch_exception_ptr(
                     [&]() {

--- a/libs/parallelism/execution/include/hpx/execution/algorithms/transform.hpp
+++ b/libs/parallelism/execution/include/hpx/execution/algorithms/transform.hpp
@@ -26,13 +26,6 @@ namespace hpx { namespace execution { namespace experimental {
             std::decay_t<R> r;
             std::decay_t<F> f;
 
-            template <typename R_, typename F_>
-            transform_receiver(R_&& r, F_&& f)
-              : r(std::forward<R_>(r))
-              , f(std::forward<F_>(f))
-            {
-            }
-
             template <typename E>
                 void set_error(E&& e) && noexcept
             {
@@ -125,14 +118,14 @@ namespace hpx { namespace execution { namespace experimental {
             auto connect(R&& r) &&
             {
                 return hpx::execution::experimental::connect(std::move(s),
-                    transform_receiver<R, F>(std::forward<R>(r), std::move(f)));
+                    transform_receiver<R, F>{std::forward<R>(r), std::move(f)});
             }
 
             template <typename R>
             auto connect(R&& r) &
             {
                 return hpx::execution::experimental::connect(
-                    s, transform_receiver<R, F>(std::forward<R>(r), f));
+                    s, transform_receiver<R, F>{std::forward<R>(r), f});
             }
         };
     }    // namespace detail

--- a/libs/parallelism/execution/include/hpx/execution/algorithms/when_all.hpp
+++ b/libs/parallelism/execution/include/hpx/execution/algorithms/when_all.hpp
@@ -125,6 +125,7 @@ namespace hpx { namespace execution { namespace experimental {
             static_assert(num_predecessors > 0,
                 "when_all expects at least one predecessor sender");
 
+            // define operation state for each connected sender
             template <typename R, std::size_t I>
             struct operation_state;
 
@@ -244,12 +245,6 @@ namespace hpx { namespace execution { namespace experimental {
                 return operation_state<R, num_predecessors - 1>(
                     std::forward<R>(r), senders);
             }
-
-            template <typename R>
-            auto connect(R&& r) &
-            {
-                return operation_state<R, num_predecessors - 1>(r, senders);
-            }
         };
     }    // namespace detail
 
@@ -257,7 +252,12 @@ namespace hpx { namespace execution { namespace experimental {
       : hpx::functional::tag_fallback<when_all_t>
     {
     private:
-        template <typename... Ss>
+        // clang-format off
+        template <typename... Ss,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::util::all_of_v<is_sender<Ss>...>
+            )>
+        // clang-format on
         friend constexpr HPX_FORCEINLINE auto tag_fallback_dispatch(
             when_all_t, Ss&&... ss)
         {

--- a/libs/parallelism/execution/include/hpx/execution/algorithms/when_all.hpp
+++ b/libs/parallelism/execution/include/hpx/execution/algorithms/when_all.hpp
@@ -245,6 +245,12 @@ namespace hpx { namespace execution { namespace experimental {
                 return operation_state<R, num_predecessors - 1>(
                     std::forward<R>(r), senders);
             }
+
+            template <typename R>
+            auto connect(R&& r) &
+            {
+                return operation_state<R, num_predecessors - 1>(r, senders);
+            }
         };
     }    // namespace detail
 

--- a/libs/parallelism/execution/tests/unit/CMakeLists.txt
+++ b/libs/parallelism/execution/tests/unit/CMakeLists.txt
@@ -19,6 +19,7 @@ if(HPX_CXX_STANDARD GREATER_EQUAL 17)
   list(
     APPEND
     tests
+    algorithm_bulk
     algorithm_detach
     algorithm_ensure_started
     algorithm_just

--- a/libs/parallelism/execution/tests/unit/algorithm_bulk.cpp
+++ b/libs/parallelism/execution/tests/unit/algorithm_bulk.cpp
@@ -1,0 +1,241 @@
+//  Copyright (c) 2021 ETH Zurich
+//  Copyright (c) 2021 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/modules/execution.hpp>
+#include <hpx/modules/testing.hpp>
+
+#include "algorithm_test_utils.hpp"
+
+#include <atomic>
+#include <exception>
+#include <stdexcept>
+#include <string>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+namespace ex = hpx::execution::experimental;
+
+struct custom_bulk_operation
+{
+    std::atomic<bool>& tag_dispatch_overload_called;
+    std::atomic<bool>& call_operator_called;
+    std::atomic<int>& call_operator_count;
+    bool throws;
+
+    void operator()(int n) const
+    {
+        HPX_TEST_EQ(n, call_operator_count);
+
+        call_operator_called = true;
+        if (n == 3 && throws)
+        {
+            throw std::runtime_error("error");
+        }
+        ++call_operator_count;
+    }
+};
+
+template <typename S>
+auto tag_dispatch(ex::bulk_t, S&& s, int num, custom_bulk_operation t)
+{
+    t.tag_dispatch_overload_called = true;
+    return ex::bulk(
+        std::forward<S>(s), num, [t = std::move(t)](int n) { t(n); });
+}
+
+int main()
+{
+    // Success path
+    {
+        std::atomic<bool> set_value_called{false};
+        std::atomic<int> set_value_count{0};
+        auto s = ex::bulk(ex::just(), 10, [&](int n) {
+            HPX_TEST_EQ(n, set_value_count);
+            ++set_value_count;
+        });
+        auto f = [] {};
+        auto r = callback_receiver<decltype(f)>{f, set_value_called};
+        auto os = ex::connect(std::move(s), std::move(r));
+        ex::start(os);
+        HPX_TEST(set_value_called);
+        HPX_TEST_EQ(set_value_count, 10);
+    }
+
+    {
+        std::atomic<bool> set_value_called{false};
+        std::atomic<int> set_value_count{0};
+        auto s = ex::bulk(ex::just(0), 10, [&](int n, int x) {
+            HPX_TEST_EQ(n, set_value_count);
+            ++set_value_count;
+            return ++x;
+        });
+        auto f = [](std::vector<int>&& v) {
+            for (int x : v)
+            {
+                HPX_TEST_EQ(x, 1);
+            }
+        };
+        auto r = callback_receiver<decltype(f)>{f, set_value_called};
+        auto os = ex::connect(std::move(s), std::move(r));
+        ex::start(os);
+        HPX_TEST(set_value_called);
+        HPX_TEST_EQ(set_value_count, 10);
+    }
+
+    {
+        std::atomic<bool> set_value_called{false};
+        std::atomic<int> set_value_count{0};
+        auto s = ex::bulk(ex::just(custom_type_non_default_constructible{0}),
+            10, [&](int n, auto x) {
+                HPX_TEST_EQ(n, set_value_count);
+                ++set_value_count;
+                ++(x.x);
+                return x;
+            });
+        auto f = [](auto&& v) {
+            for (auto&& x : v)
+            {
+                HPX_TEST_EQ(x.x, 1);
+            }
+        };
+        auto r = callback_receiver<decltype(f)>{f, set_value_called};
+        auto os = ex::connect(std::move(s), std::move(r));
+        ex::start(os);
+        HPX_TEST(set_value_called);
+        HPX_TEST_EQ(set_value_count, 10);
+    }
+
+    {
+        std::atomic<bool> set_value_called{false};
+        auto s1 = ex::bulk(ex::just(0), 10, [](int, int x) { return ++x; });
+        auto f = [](int n, std::vector<int> v) {
+            for (auto& x : v)
+            {
+                ++x;
+            }
+            return v[n];
+        };
+        auto s2 = ex::bulk(std::move(s1), 10, f);
+        auto s3 = ex::bulk(std::move(s2), 10, f);
+        auto s4 = ex::bulk(std::move(s3), 10, f);
+        auto f1 = [](std::vector<int> v) {
+            for (auto x : v)
+            {
+                HPX_TEST_EQ(x, 4);
+            }
+        };
+        auto r = callback_receiver<decltype(f1)>{f1, set_value_called};
+        auto os = ex::connect(std::move(s4), std::move(r));
+        ex::start(os);
+        HPX_TEST(set_value_called);
+    }
+
+    // operator| overload
+    {
+        std::atomic<bool> set_value_called{false};
+        auto s = ex::just() | ex::bulk(10, [](int) { return 3; }) |
+            ex::bulk(10,
+                [](int n, std::vector<int> const& x) { return x[n] / 1.5; }) |
+            ex::bulk(10,
+                [](int n, std::vector<double> const& x) { return x[n] / 2; }) |
+            ex::bulk(10, [](int n, std::vector<double> const& x) {
+                return std::to_string((int) x[n]);
+            });
+        auto f = [](std::vector<std::string> const& v) {
+            for (auto x : v)
+            {
+                HPX_TEST_EQ(x, std::string("1"));
+            }
+        };
+        auto r = callback_receiver<decltype(f)>{f, set_value_called};
+        auto os = ex::connect(std::move(s), r);
+        ex::start(os);
+        HPX_TEST(set_value_called);
+    }
+
+    // tag_dispatch overload
+    {
+        std::atomic<bool> receiver_set_value_called{false};
+        std::atomic<bool> tag_dispatch_overload_called{false};
+        std::atomic<bool> custom_bulk_call_operator_called{false};
+        std::atomic<int> custom_bulk_call_count{0};
+        auto s = ex::bulk(ex::just(), 10,
+            custom_bulk_operation{tag_dispatch_overload_called,
+                custom_bulk_call_operator_called, custom_bulk_call_count,
+                false});
+        auto f = [] {};
+        auto r = callback_receiver<decltype(f)>{f, receiver_set_value_called};
+        auto os = ex::connect(std::move(s), std::move(r));
+        ex::start(os);
+        HPX_TEST(receiver_set_value_called);
+        HPX_TEST(tag_dispatch_overload_called);
+        HPX_TEST(custom_bulk_call_operator_called);
+        HPX_TEST_EQ(custom_bulk_call_count, 10);
+    }
+
+    // Failure path
+    {
+        std::atomic<bool> set_error_called{false};
+        auto s = ex::bulk(ex::just(), 10, [](int n) {
+            if (n == 3)
+                throw std::runtime_error("error");
+        });
+        auto r = error_callback_receiver<decltype(check_exception_ptr)>{
+            check_exception_ptr, set_error_called};
+        auto os = ex::connect(std::move(s), std::move(r));
+        ex::start(os);
+        HPX_TEST(set_error_called);
+    }
+
+    {
+        std::atomic<bool> set_error_called{false};
+        auto s1 = ex::bulk(ex::just(0), 10, [](int, int x) { return ++x; });
+        auto s2 = ex::bulk(
+            std::move(s1), 10, [](int n, std::vector<int> const& x) {
+                if (n == 3)
+                    throw std::runtime_error("error");
+                return x[n] + 1;
+            });
+        auto s3 =
+            ex::bulk(std::move(s2), 10, [](int, std::vector<int> const& x) {
+            HPX_TEST(false);
+            return x[0];
+        });
+        auto s4 =
+            ex::bulk(std::move(s3), 10, [](int, std::vector<int> const& x) {
+            HPX_TEST(false);
+            return x[0];
+        });
+        auto r = error_callback_receiver<decltype(check_exception_ptr)>{
+            check_exception_ptr, set_error_called};
+        auto os = ex::connect(std::move(s4), std::move(r));
+        ex::start(os);
+        HPX_TEST(set_error_called);
+    }
+
+    {
+        std::atomic<bool> receiver_set_error_called{false};
+        std::atomic<bool> tag_dispatch_overload_called{false};
+        std::atomic<bool> custom_bulk_call_operator_called{false};
+        std::atomic<int> custom_bulk_call_count{0};
+        auto s = ex::bulk(ex::just(), 10,
+            custom_bulk_operation{tag_dispatch_overload_called,
+                custom_bulk_call_operator_called,
+                custom_bulk_call_count, true});
+        auto r = error_callback_receiver<decltype(check_exception_ptr)>{
+            check_exception_ptr, receiver_set_error_called};
+        auto os = ex::connect(std::move(s), std::move(r));
+        ex::start(os);
+        HPX_TEST(receiver_set_error_called);
+        HPX_TEST(tag_dispatch_overload_called);
+        HPX_TEST(custom_bulk_call_operator_called);
+        HPX_TEST_EQ(custom_bulk_call_count, 3);
+    }
+
+    return hpx::util::report_errors();
+}

--- a/libs/parallelism/execution/tests/unit/algorithm_test_utils.hpp
+++ b/libs/parallelism/execution/tests/unit/algorithm_test_utils.hpp
@@ -111,6 +111,7 @@ struct error_callback_receiver
 {
     std::decay_t<F> f;
     std::atomic<bool>& set_error_called;
+    bool expect_set_value = false;
 
     template <typename E>
     void set_error(E&& e) noexcept
@@ -127,7 +128,7 @@ struct error_callback_receiver
     template <typename... Ts>
     void set_value(Ts&&...) noexcept
     {
-        HPX_TEST(false);
+        HPX_TEST(expect_set_value);
     }
 };
 


### PR DESCRIPTION
This adds the `bulk()` algorithm for the sender/receiver framework

As a flyby this slightly cleans up the `transform` algorithm ~and also fixes an issue with the `when_all` algorithm~ (see #5423).