### PR TITLE
Disable Vc in final docker image created in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -521,6 +521,11 @@ jobs:
           name: Installing
           command: |
               ./bin/hello_world_distributed --hpx:bind=none
+              # Disable Vc here as the target machine of the container image may
+              # not support the same vector intrinsics as this machine. The
+              # "Test Docker Image" below fails with "Illegal instruction" if VC
+              # is enabled, and other machines may fail similarly.
+              cmake -DHPX_WITH_DATAPAR_VC=Off .
               ninja -j2 install
           working_directory: /hpx/build
           when: always


### PR DESCRIPTION
Conjecture, but I think this will fix the failing "install" step on CircleCI. Running the hello world example with the `setup_remote_docker` key fails with exit code 132 which apparently is sigkill 128 + illegal instruction 4. This started appearing when we merged the changes for datapar (https://github.com/STEllAR-GROUP/hpx/pull/5235).