### PR TITLE
Rename the new P0443/P2300 executor to thread_pool_scheduler

### DIFF
--- a/libs/core/synchronization/tests/unit/async_rw_mutex.cpp
+++ b/libs/core/synchronization/tests/unit/async_rw_mutex.cpp
@@ -19,9 +19,9 @@
 #include <vector>
 
 using hpx::execution::experimental::execute;
-using hpx::execution::experimental::executor;
 using hpx::execution::experimental::on;
 using hpx::execution::experimental::sync_wait;
+using hpx::execution::experimental::thread_pool_scheduler;
 using hpx::execution::experimental::transform;
 using hpx::experimental::async_rw_mutex;
 
@@ -196,7 +196,7 @@ template <typename ReadWriteT, typename ReadT = ReadWriteT>
 void test_multiple_accesses(
     async_rw_mutex<ReadWriteT, ReadT> rwm, std::size_t iterations)
 {
-    executor exec{};
+    thread_pool_scheduler exec{};
 
     std::atomic<std::size_t> count{0};
 

--- a/libs/full/compute_cuda/tests/performance/synchronize.cu
+++ b/libs/full/compute_cuda/tests/performance/synchronize.cu
@@ -370,7 +370,7 @@ int hpx_main(hpx::program_options::variables_map& vm)
         for (std::size_t i = 0; i != iterations; ++i)
         {
             cu::transform_stream(ex::just(), f, cuda_stream) |
-                ex::on(ex::executor{}) | ex::sync_wait();
+                ex::on(ex::thread_pool_scheduler{}) | ex::sync_wait();
         }
         double elapsed = timer.elapsed();
         std::cout
@@ -405,14 +405,14 @@ int hpx_main(hpx::program_options::variables_map& vm)
                 cu::transform_stream(f, cuda_stream) |
                 cu::transform_stream(f, cuda_stream) |
                 cu::transform_stream(f, cuda_stream) |
-                cu::transform_stream(f, cuda_stream) | ex::on(ex::executor{}) |
-                ex::sync_wait();
+                cu::transform_stream(f, cuda_stream) |
+                ex::on(ex::thread_pool_scheduler{}) | ex::sync_wait();
         }
         // Do the remainder one-by-one
         for (std::size_t i = 0; i < non_batch_iterations; ++i)
         {
             cu::transform_stream(ex::just(), f, cuda_stream) |
-                ex::on(ex::executor{}) | ex::sync_wait();
+                ex::on(ex::thread_pool_scheduler{}) | ex::sync_wait();
         }
         double elapsed = timer.elapsed();
         std::cout

--- a/libs/parallelism/executors/CMakeLists.txt
+++ b/libs/parallelism/executors/CMakeLists.txt
@@ -23,7 +23,6 @@ set(executors_headers
     hpx/executors/execution_policy.hpp
     hpx/executors/fork_join_executor.hpp
     hpx/executors/limiting_executor.hpp
-    hpx/executors/p0443_executor.hpp
     hpx/executors/parallel_executor_aggregated.hpp
     hpx/executors/parallel_executor.hpp
     hpx/executors/restricted_thread_pool_executor.hpp
@@ -32,6 +31,7 @@ set(executors_headers
     hpx/executors/std_execution_policy.hpp
     hpx/executors/sync.hpp
     hpx/executors/thread_pool_executor.hpp
+    hpx/executors/thread_pool_scheduler.hpp
 )
 
 # Default location is $HPX_ROOT/libs/executors/include_compatibility

--- a/libs/parallelism/executors/include/hpx/executors/thread_pool_scheduler.hpp
+++ b/libs/parallelism/executors/include/hpx/executors/thread_pool_scheduler.hpp
@@ -22,26 +22,31 @@
 #include <utility>
 
 namespace hpx { namespace execution { namespace experimental {
-    struct executor
+    struct thread_pool_scheduler
     {
-        constexpr executor() = default;
+        constexpr thread_pool_scheduler() = default;
+        explicit thread_pool_scheduler(hpx::threads::thread_pool_base* pool)
+          : pool_(pool)
+        {
+        }
 
         /// \cond NOINTERNAL
-        bool operator==(executor const& rhs) const noexcept
+        bool operator==(thread_pool_scheduler const& rhs) const noexcept
         {
             return pool_ == rhs.pool_ && priority_ == rhs.priority_ &&
                 stacksize_ == rhs.stacksize_ &&
                 schedulehint_ == rhs.schedulehint_;
         }
 
-        bool operator!=(executor const& rhs) const noexcept
+        bool operator!=(thread_pool_scheduler const& rhs) const noexcept
         {
             return !(*this == rhs);
         }
 
         // support with_priority property
-        friend executor tag_dispatch(
-            hpx::execution::experimental::with_priority_t, executor const& exec,
+        friend thread_pool_scheduler tag_dispatch(
+            hpx::execution::experimental::with_priority_t,
+            thread_pool_scheduler const& exec,
             hpx::threads::thread_priority priority)
         {
             auto exec_with_priority = exec;
@@ -50,15 +55,17 @@ namespace hpx { namespace execution { namespace experimental {
         }
 
         friend hpx::threads::thread_priority tag_dispatch(
-            hpx::execution::experimental::get_priority_t, executor const& exec)
+            hpx::execution::experimental::get_priority_t,
+            thread_pool_scheduler const& exec)
         {
             return exec.priority_;
         }
 
         // support with_stacksize property
-        friend executor tag_dispatch(
+        friend thread_pool_scheduler tag_dispatch(
             hpx::execution::experimental::with_stacksize_t,
-            executor const& exec, hpx::threads::thread_stacksize stacksize)
+            thread_pool_scheduler const& exec,
+            hpx::threads::thread_stacksize stacksize)
         {
             auto exec_with_stacksize = exec;
             exec_with_stacksize.stacksize_ = stacksize;
@@ -66,14 +73,17 @@ namespace hpx { namespace execution { namespace experimental {
         }
 
         friend hpx::threads::thread_stacksize tag_dispatch(
-            hpx::execution::experimental::get_stacksize_t, executor const& exec)
+            hpx::execution::experimental::get_stacksize_t,
+            thread_pool_scheduler const& exec)
         {
             return exec.stacksize_;
         }
 
         // support with_hint property
-        friend executor tag_dispatch(hpx::execution::experimental::with_hint_t,
-            executor const& exec, hpx::threads::thread_schedule_hint hint)
+        friend thread_pool_scheduler tag_dispatch(
+            hpx::execution::experimental::with_hint_t,
+            thread_pool_scheduler const& exec,
+            hpx::threads::thread_schedule_hint hint)
         {
             auto exec_with_hint = exec;
             exec_with_hint.schedulehint_ = hint;
@@ -81,24 +91,25 @@ namespace hpx { namespace execution { namespace experimental {
         }
 
         friend hpx::threads::thread_schedule_hint tag_dispatch(
-            hpx::execution::experimental::get_hint_t, executor const& exec)
+            hpx::execution::experimental::get_hint_t,
+            thread_pool_scheduler const& exec)
         {
             return exec.schedulehint_;
         }
 
         // support with_annotation property
-        friend constexpr executor tag_dispatch(
+        friend constexpr thread_pool_scheduler tag_dispatch(
             hpx::execution::experimental::with_annotation_t,
-            executor const& exec, char const* annotation)
+            thread_pool_scheduler const& exec, char const* annotation)
         {
             auto exec_with_annotation = exec;
             exec_with_annotation.annotation_ = annotation;
             return exec_with_annotation;
         }
 
-        friend executor tag_dispatch(
+        friend thread_pool_scheduler tag_dispatch(
             hpx::execution::experimental::with_annotation_t,
-            executor const& exec, std::string annotation)
+            thread_pool_scheduler const& exec, std::string annotation)
         {
             auto exec_with_annotation = exec;
             exec_with_annotation.annotation_ =
@@ -110,7 +121,7 @@ namespace hpx { namespace execution { namespace experimental {
         // support get_annotation property
         friend constexpr char const* tag_dispatch(
             hpx::execution::experimental::get_annotation_t,
-            executor const& exec) noexcept
+            thread_pool_scheduler const& exec) noexcept
         {
             return exec.annotation_;
         }
@@ -128,15 +139,15 @@ namespace hpx { namespace execution { namespace experimental {
                 std::forward<F>(f));
         }
 
-        template <typename Executor, typename R>
+        template <typename Scheduler, typename R>
         struct operation_state
         {
-            std::decay_t<Executor> exec;
+            std::decay_t<Scheduler> exec;
             std::decay_t<R> r;
 
-            template <typename Executor_, typename R_>
-            operation_state(Executor_&& exec, R_&& r)
-              : exec(std::forward<Executor_>(exec))
+            template <typename Scheduler_, typename R_>
+            operation_state(Scheduler_&& exec, R_&& r)
+              : exec(std::forward<Scheduler_>(exec))
               , r(std::forward<R_>(r))
             {
             }
@@ -163,10 +174,10 @@ namespace hpx { namespace execution { namespace experimental {
             }
         };
 
-        template <typename Executor>
+        template <typename Scheduler>
         struct sender
         {
-            std::decay_t<Executor> exec;
+            std::decay_t<Scheduler> exec;
 
             template <template <typename...> class Tuple,
                 template <typename...> class Variant>
@@ -178,13 +189,13 @@ namespace hpx { namespace execution { namespace experimental {
             static constexpr bool sends_done = false;
 
             template <typename R>
-            operation_state<Executor, R> connect(R&& r) &&
+            operation_state<Scheduler, R> connect(R&& r) &&
             {
                 return {std::move(exec), std::forward<R>(r)};
             }
 
             template <typename R>
-            operation_state<Executor, R> connect(R&& r) &
+            operation_state<Scheduler, R> connect(R&& r) &
             {
                 return {exec, std::forward<R>(r)};
             }
@@ -200,12 +211,12 @@ namespace hpx { namespace execution { namespace experimental {
         static constexpr bool sends_done = false;
 
         template <typename R>
-        operation_state<executor, R> connect(R&& r) &&
+        operation_state<thread_pool_scheduler, R> connect(R&& r) &&
         {
             return {*this, std::forward<R>(r)};
         }
 
-        constexpr sender<executor> schedule() const
+        constexpr sender<thread_pool_scheduler> schedule() const
         {
             return {*this};
         }

--- a/libs/parallelism/executors/tests/unit/CMakeLists.txt
+++ b/libs/parallelism/executors/tests/unit/CMakeLists.txt
@@ -21,7 +21,7 @@ set(tests
 )
 
 if(HPX_CXX_STANDARD GREATER_EQUAL 17)
-  list(APPEND tests p0443_executor)
+  list(APPEND tests thread_pool_scheduler)
 endif()
 
 if(HPX_WITH_CXX17_STD_EXECUTION_POLICES)


### PR DESCRIPTION
I suggest `thread_pool_scheduler` to mirror `thread_pool_executor`, both of which allow scheduling/executing tasks on a given HPX `thread_pool_base`. Other suggestions are welcome.

I'm leaving the "executor" functionality for now in `thread_pool_scheduler` but it's likely that the change to make `execute` a plain algorithm in P2300 will likely be supported. I'll remove it separately (there's a meeting today on P2300, and unless the feedback is very negative I think we can start applying changes from it more widely).

Edit: I also wanted to add that I'm not sure if the thread pool attached to the scheduler should be a "property" or not, so it's currently not one (it's also not a property at the moment for `thread_pool_executor`/`parallel_executor`). If someone has a good argument for either case I'd love to hear it.