### PR TITLE
This adds support for systems that assume all types are bitwise serializable by default

### DIFF
--- a/libs/core/serialization/CMakeLists.txt
+++ b/libs/core/serialization/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2020 The STE||AR-Group
+# Copyright (c) 2019-2021 The STE||AR-Group
 #
 # SPDX-License-Identifier: BSL-1.0
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -17,6 +17,22 @@ hpx_option(
 if(HPX_SERIALIZATION_WITH_BOOST_TYPES)
   hpx_add_config_define_namespace(
     DEFINE HPX_SERIALIZATION_HAVE_BOOST_TYPES NAMESPACE SERIALIZATION
+  )
+endif()
+
+# This flag can be used in systems that assume that all types are bitwise
+# serializable by default (like SHAD).
+hpx_option(
+  HPX_SERIALIZATION_WITH_ALL_TYPES_ARE_BITWISE_SERIALIZABLE BOOL
+  "Assume all types are bitwise serializable. (default: OFF)" OFF ADVANCED
+  CATEGORY "Modules"
+  MODULE SERIALIZATION
+)
+
+if(HPX_SERIALIZATION_WITH_ALL_TYPES_ARE_BITWISE_SERIALIZABLE)
+  hpx_add_config_define_namespace(
+    DEFINE HPX_SERIALIZATION_HAVE_ALL_TYPES_ARE_BITWISE_SERIALIZABLE
+    NAMESPACE SERIALIZATION
   )
 endif()
 
@@ -74,6 +90,7 @@ set(serialization_headers
     hpx/serialization/serialize.hpp
     hpx/serialization/traits/brace_initializable_traits.hpp
     hpx/serialization/traits/is_bitwise_serializable.hpp
+    hpx/serialization/traits/is_not_bitwise_serializable.hpp
     hpx/serialization/traits/needs_automatic_registration.hpp
     hpx/serialization/traits/polymorphic_traits.hpp
     hpx/serialization/traits/serialization_access_data.hpp

--- a/libs/core/serialization/include/hpx/serialization/array.hpp
+++ b/libs/core/serialization/include/hpx/serialization/array.hpp
@@ -13,6 +13,7 @@
 #include <hpx/serialization/serialization_fwd.hpp>
 #include <hpx/serialization/serialize.hpp>
 #include <hpx/serialization/traits/is_bitwise_serializable.hpp>
+#include <hpx/serialization/traits/is_not_bitwise_serializable.hpp>
 
 #if defined(HPX_SERIALIZATION_HAVE_BOOST_TYPES)
 #include <boost/array.hpp>
@@ -71,9 +72,10 @@ namespace hpx { namespace serialization {
         template <class Archive>
         void serialize(Archive& ar, unsigned int v)
         {
+            using element_type = typename std::remove_const<T>::type;
             using use_optimized = std::integral_constant<bool,
-                hpx::traits::is_bitwise_serializable<
-                    typename std::remove_const<T>::type>::value>;
+                hpx::traits::is_bitwise_serializable_v<element_type> ||
+                    !hpx::traits::is_not_bitwise_serializable_v<element_type>>;
 
             bool archive_endianess_differs = endian::native == endian::big ?
                 ar.endian_little() :

--- a/libs/core/serialization/include/hpx/serialization/complex.hpp
+++ b/libs/core/serialization/include/hpx/serialization/complex.hpp
@@ -8,6 +8,7 @@
 
 #include <hpx/serialization/serialization_fwd.hpp>
 #include <hpx/serialization/traits/is_bitwise_serializable.hpp>
+#include <hpx/serialization/traits/is_not_bitwise_serializable.hpp>
 
 #include <complex>
 #include <type_traits>
@@ -35,6 +36,13 @@ namespace hpx { namespace traits {
     template <typename T>
     struct is_bitwise_serializable<std::complex<T>>
       : is_bitwise_serializable<typename std::remove_const<T>::type>
+    {
+    };
+
+    template <typename T>
+    struct is_not_bitwise_serializable<std::complex<T>>
+      : std::integral_constant<bool,
+            !is_bitwise_serializable_v<std::complex<T>>>
     {
     };
 }}    // namespace hpx::traits

--- a/libs/core/serialization/include/hpx/serialization/detail/vc.hpp
+++ b/libs/core/serialization/include/hpx/serialization/detail/vc.hpp
@@ -12,6 +12,7 @@
 #include <hpx/serialization/array.hpp>
 #include <hpx/serialization/serialize.hpp>
 #include <hpx/serialization/traits/is_bitwise_serializable.hpp>
+#include <hpx/serialization/traits/is_not_bitwise_serializable.hpp>
 
 #include <cstddef>
 #include <type_traits>
@@ -113,6 +114,27 @@ namespace hpx { namespace traits {
       : is_bitwise_serializable<typename std::remove_const<T>::type>
     {
     };
+
+    template <typename T, typename Abi>
+    struct is_not_bitwise_serializable<Vc::Vector<T, Abi>>
+      : std::integral_constant<bool,
+            !is_bitwise_serializable_v<Vc::Vector<T, Abi>>>
+    {
+    };
+
+    template <typename T>
+    struct is_not_bitwise_serializable<Vc::Scalar::Vector<T>>
+      : std::integral_constant<bool,
+            !is_bitwise_serializable_v<Vc::Scalar::Vector<T>>>
+    {
+    };
+
+    template <typename T, std::size_t N, typename V, std::size_t W>
+    struct is_not_bitwise_serializable<Vc::SimdArray<T, N, V, W>>
+      : std::integral_constant<bool,
+            !is_bitwise_serializable_v<Vc::SimdArray<T, N, V, W>>>
+    {
+    };
 }}    // namespace hpx::traits
 
 #else
@@ -146,6 +168,13 @@ namespace hpx { namespace traits {
     template <typename T, typename Abi>
     struct is_bitwise_serializable<Vc::datapar<T, Abi>>
       : is_bitwise_serializable<typename std::remove_const<T>::type>
+    {
+    };
+
+    template <typename T, typename Abi>
+    struct is_not_bitwise_serializable<Vc::datapar<T, Abi>>
+      : std::integral_constant<bool,
+            !is_bitwise_serializable_v<Vc::datapar<T, Abi>>>
     {
     };
 }}    // namespace hpx::traits

--- a/libs/core/serialization/include/hpx/serialization/input_archive.hpp
+++ b/libs/core/serialization/include/hpx/serialization/input_archive.hpp
@@ -15,6 +15,7 @@
 #include <hpx/serialization/detail/raw_ptr.hpp>
 #include <hpx/serialization/input_container.hpp>
 #include <hpx/serialization/traits/is_bitwise_serializable.hpp>
+#include <hpx/serialization/traits/is_not_bitwise_serializable.hpp>
 
 #include <cstddef>
 #include <cstdint>
@@ -75,7 +76,9 @@ namespace hpx { namespace serialization {
             !std::is_enum<T>::value>::type
         load(T& t)
         {
-            typedef hpx::traits::is_bitwise_serializable<T> use_optimized;
+            using use_optimized = std::integral_constant<bool,
+                hpx::traits::is_bitwise_serializable_v<T> ||
+                    !hpx::traits::is_not_bitwise_serializable_v<T>>;
 
             load_bitwise(t, use_optimized());
         }

--- a/libs/core/serialization/include/hpx/serialization/input_archive.hpp
+++ b/libs/core/serialization/include/hpx/serialization/input_archive.hpp
@@ -141,7 +141,11 @@ namespace hpx { namespace serialization {
         {
             static_assert(!std::is_abstract<T>::value,
                 "Can not bitwise serialize a class that is abstract");
-            if (disable_array_optimization())
+
+            bool archive_endianess_differs =
+                endian::native == endian::big ? endian_little() : endian_big();
+
+            if (disable_array_optimization() || archive_endianess_differs)
             {
                 access::serialize(*this, t, 0);
             }

--- a/libs/core/serialization/include/hpx/serialization/output_archive.hpp
+++ b/libs/core/serialization/include/hpx/serialization/output_archive.hpp
@@ -15,6 +15,7 @@
 #include <hpx/serialization/detail/raw_ptr.hpp>
 #include <hpx/serialization/output_container.hpp>
 #include <hpx/serialization/traits/is_bitwise_serializable.hpp>
+#include <hpx/serialization/traits/is_not_bitwise_serializable.hpp>
 
 #include <cstddef>
 #include <cstdint>
@@ -182,7 +183,9 @@ namespace hpx { namespace serialization {
             !std::is_enum<T>::value>::type
         save(T const& t)
         {
-            using use_optimized = hpx::traits::is_bitwise_serializable<T>;
+            using use_optimized = std::integral_constant<bool,
+                hpx::traits::is_bitwise_serializable_v<T> ||
+                    !hpx::traits::is_not_bitwise_serializable_v<T>>;
 
             save_bitwise(t, use_optimized());
         }

--- a/libs/core/serialization/include/hpx/serialization/output_archive.hpp
+++ b/libs/core/serialization/include/hpx/serialization/output_archive.hpp
@@ -233,7 +233,11 @@ namespace hpx { namespace serialization {
         {
             static_assert(!std::is_abstract<T>::value,
                 "Can not bitwise serialize a class that is abstract");
-            if (disable_array_optimization())
+
+            bool archive_endianess_differs =
+                endian::native == endian::big ? endian_little() : endian_big();
+
+            if (disable_array_optimization() || archive_endianess_differs)
             {
                 access::serialize(*this, t, 0);
             }

--- a/libs/core/serialization/include/hpx/serialization/traits/is_not_bitwise_serializable.hpp
+++ b/libs/core/serialization/include/hpx/serialization/traits/is_not_bitwise_serializable.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2014 Thomas Heller
+//  Copyright (c) 2021 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -12,21 +12,32 @@
 
 namespace hpx { namespace traits {
 
+    // This traits can be used in systems that assume that all types are bitwise
+    // serializable by default (like SHAD), while still enforcing normal
+    // serialization for a given type.
+
+#if defined(HPX_SERIALIZATION_HAVE_ALL_TYPES_ARE_BITWISE_SERIALIZABLE)
     template <typename T>
-    struct is_bitwise_serializable : std::is_arithmetic<T>
+    struct is_not_bitwise_serializable : std::is_abstract<T>
     {
     };
+#else
+    template <typename T>
+    struct is_not_bitwise_serializable : std::true_type
+    {
+    };
+#endif
 
     template <typename T>
-    HPX_INLINE_CONSTEXPR_VARIABLE bool is_bitwise_serializable_v =
-        is_bitwise_serializable<T>::value;
+    HPX_INLINE_CONSTEXPR_VARIABLE bool is_not_bitwise_serializable_v =
+        is_not_bitwise_serializable<T>::value;
 
 }}    // namespace hpx::traits
 
-#define HPX_IS_BITWISE_SERIALIZABLE(T)                                         \
+#define HPX_IS_NOT_BITWISE_SERIALIZABLE(T)                                     \
     namespace hpx { namespace traits {                                         \
             template <>                                                        \
-            struct is_bitwise_serializable<T> : std::true_type                 \
+            struct is_not_bitwise_serializable<T> : std::true_type             \
             {                                                                  \
             };                                                                 \
         }                                                                      \

--- a/libs/core/serialization/include/hpx/serialization/tuple.hpp
+++ b/libs/core/serialization/include/hpx/serialization/tuple.hpp
@@ -13,6 +13,7 @@
 #include <hpx/serialization/detail/non_default_constructible.hpp>
 #include <hpx/serialization/serialization_fwd.hpp>
 #include <hpx/serialization/traits/is_bitwise_serializable.hpp>
+#include <hpx/serialization/traits/is_not_bitwise_serializable.hpp>
 #include <hpx/type_support/pack.hpp>
 
 #include <cstddef>
@@ -24,6 +25,13 @@ namespace hpx { namespace traits {
     struct is_bitwise_serializable<::hpx::tuple<Ts...>>
       : ::hpx::util::all_of<hpx::traits::is_bitwise_serializable<
             typename std::remove_const<Ts>::type>...>
+    {
+    };
+
+    template <typename... Ts>
+    struct is_not_bitwise_serializable<::hpx::tuple<Ts...>>
+      : std::integral_constant<bool,
+            !is_bitwise_serializable_v<::hpx::tuple<Ts...>>>
     {
     };
 }}    // namespace hpx::traits

--- a/libs/core/serialization/tests/unit/CMakeLists.txt
+++ b/libs/core/serialization/tests/unit/CMakeLists.txt
@@ -73,7 +73,8 @@ foreach(test ${full_tests})
   # add example executable
   add_hpx_executable(
     ${test}_test INTERNAL_FLAGS
-    SOURCES ${sources} ${${test}_FLAGS} EXCLUDE_FROM_ALL
+    SOURCES ${sources} ${${test}_FLAGS}
+    EXCLUDE_FROM_ALL
     FOLDER ${folder_name}
   )
 

--- a/libs/core/serialization/tests/unit/CMakeLists.txt
+++ b/libs/core/serialization/tests/unit/CMakeLists.txt
@@ -34,7 +34,9 @@ if(HPX_SERIALIZATION_WITH_BOOST_TYPES)
   set(tests ${tests} serialization_boost_variant)
 endif()
 
-set(full_tests any_serialization serializable_any serializable_boost_any)
+set(full_tests any_serialization not_bitwise_serializable serializable_any
+               serializable_boost_any
+)
 
 add_subdirectory(polymorphic)
 
@@ -71,8 +73,7 @@ foreach(test ${full_tests})
   # add example executable
   add_hpx_executable(
     ${test}_test INTERNAL_FLAGS
-    SOURCES ${sources} ${${test}_FLAGS}
-    EXCLUDE_FROM_ALL
+    SOURCES ${sources} ${${test}_FLAGS} EXCLUDE_FROM_ALL
     FOLDER ${folder_name}
   )
 

--- a/libs/core/serialization/tests/unit/any_serialization.cpp
+++ b/libs/core/serialization/tests/unit/any_serialization.cpp
@@ -105,6 +105,6 @@ int main(int argc, char* argv[])
 
     hpx::local::init(hpx_main, argc, argv, init_args);
 
-    return EXIT_SUCCESS;
+    return hpx::util::report_errors();
 }
 // EOF

--- a/libs/core/serialization/tests/unit/not_bitwise_serializable.cpp
+++ b/libs/core/serialization/tests/unit/not_bitwise_serializable.cpp
@@ -1,0 +1,102 @@
+//  Copyright (c) 2021 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+// enforce that types are bitwise serializable by default
+#define HPX_SERIALIZATION_HAVE_ALL_TYPES_ARE_BITWISE_SERIALIZABLE
+
+#include <hpx/config.hpp>
+#include <hpx/local/init.hpp>
+#include <hpx/modules/testing.hpp>
+#include <hpx/serialization/serialize.hpp>
+#include <hpx/serialization/traits/is_not_bitwise_serializable.hpp>
+
+bool serialize_A = false;
+bool serialize_B = false;
+
+struct A
+{
+    int a;
+    double b;
+
+    template <typename Archive>
+    void serialize(Archive& ar, unsigned)
+    {
+        // clang-format off
+        ar & a & b;
+        // clang-format on
+
+        serialize_A = true;
+    }
+};
+
+struct B
+{
+    int a;
+    double b;
+
+    template <typename Archive>
+    void serialize(Archive& ar, unsigned)
+    {
+        // clang-format off
+        ar & a & b;
+        // clang-format on
+
+        serialize_B = true;
+    }
+};
+
+HPX_IS_NOT_BITWISE_SERIALIZABLE(B);
+
+int hpx_main()
+{
+    {
+        std::vector<char> buffer;
+        hpx::serialization::output_archive oarchive(buffer);
+
+        serialize_A = false;
+        A oa{42, 42.0};
+        oarchive << oa;
+        HPX_TEST(!serialize_A);
+
+        hpx::serialization::input_archive iarchive(buffer);
+        A ia{0, 0.0};
+
+        serialize_A = false;
+        iarchive >> ia;
+        HPX_TEST(!serialize_A);
+
+        HPX_TEST_EQ(ia.a, 42);
+        HPX_TEST_EQ(ia.b, 42.0);
+    }
+
+    {
+        std::vector<char> buffer;
+        hpx::serialization::output_archive oarchive(buffer);
+
+        serialize_B = false;
+        B ob{42, 42.0};
+        oarchive << ob;
+        HPX_TEST(serialize_B);
+
+        hpx::serialization::input_archive iarchive(buffer);
+        B ib{0, 0.0};
+
+        serialize_B = false;
+        iarchive >> ib;
+        HPX_TEST(serialize_B);
+
+        HPX_TEST_EQ(ib.a, 42);
+        HPX_TEST_EQ(ib.b, 42.0);
+    }
+
+    return hpx::local::finalize();
+}
+
+int main(int argc, char* argv[])
+{
+    hpx::local::init(hpx_main, argc, argv);
+    return hpx::util::report_errors();
+}

--- a/libs/core/serialization/tests/unit/not_bitwise_serializable.cpp
+++ b/libs/core/serialization/tests/unit/not_bitwise_serializable.cpp
@@ -13,6 +13,8 @@
 #include <hpx/serialization/serialize.hpp>
 #include <hpx/serialization/traits/is_not_bitwise_serializable.hpp>
 
+#include <vector>
+
 bool serialize_A = false;
 bool serialize_B = false;
 

--- a/libs/full/compute/include/hpx/compute/serialization/vector.hpp
+++ b/libs/full/compute/include/hpx/compute/serialization/vector.hpp
@@ -8,10 +8,12 @@
 #pragma once
 
 #include <hpx/config.hpp>
+#include <hpx/config/endian.hpp>
 
 #if !defined(__CUDA_ARCH__)
 #include <hpx/serialization/serialize.hpp>
 #include <hpx/serialization/traits/is_bitwise_serializable.hpp>
+#include <hpx/serialization/traits/is_not_bitwise_serializable.hpp>
 #else
 #include <hpx/serialization/serialization_fwd.hpp>
 #endif
@@ -52,7 +54,11 @@ namespace hpx { namespace serialization {
         void load_impl(
             input_archive& ar, compute::vector<T, Allocator>& v, std::true_type)
         {
-            if (ar.disable_array_optimization())
+            bool archive_endianess_differs = endian::native == endian::big ?
+                ar.endian_little() :
+                ar.endian_big();
+
+            if (ar.disable_array_optimization() || archive_endianess_differs)
             {
                 load_impl(ar, v, std::false_type());
             }
@@ -79,11 +85,11 @@ namespace hpx { namespace serialization {
     void serialize(
         input_archive& ar, compute::vector<T, Allocator>& v, unsigned)
     {
-        typedef std::integral_constant<bool,
-            hpx::traits::is_bitwise_serializable<
-                typename std::remove_const<typename compute::vector<T,
-                    Allocator>::value_type>::type>::value>
-            use_optimized;
+        using element_type = typename std::remove_const<
+            typename compute::vector<T, Allocator>::value_type>::type;
+        using use_optimized = std::integral_constant<bool,
+            hpx::traits::is_bitwise_serializable_v<element_type> ||
+                !hpx::traits::is_not_bitwise_serializable_v<element_type>>;
 
         v.clear();
         detail::load_impl(ar, v, use_optimized());
@@ -106,7 +112,11 @@ namespace hpx { namespace serialization {
         void save_impl(output_archive& ar,
             compute::vector<T, Allocator> const& v, std::true_type)
         {
-            if (ar.disable_array_optimization())
+            bool archive_endianess_differs = endian::native == endian::big ?
+                ar.endian_little() :
+                ar.endian_big();
+
+            if (ar.disable_array_optimization() || archive_endianess_differs)
             {
                 save_impl(ar, v, std::false_type());
             }
@@ -124,11 +134,11 @@ namespace hpx { namespace serialization {
     void serialize(
         output_archive& ar, compute::vector<T, Allocator> const& v, unsigned)
     {
-        typedef std::integral_constant<bool,
-            hpx::traits::is_bitwise_serializable<
-                typename std::remove_const<typename compute::vector<T,
-                    Allocator>::value_type>::type>::value>
-            use_optimized;
+        using element_type = typename std::remove_const<
+            typename compute::vector<T, Allocator>::value_type>::type;
+        using use_optimized = std::integral_constant<bool,
+            hpx::traits::is_bitwise_serializable_v<element_type> ||
+                !hpx::traits::is_not_bitwise_serializable_v<element_type>>;
 
         ar << v.size();    //-V128
         if (v.empty())

--- a/libs/full/include/include/hpx/include/traits.hpp
+++ b/libs/full/include/include/hpx/include/traits.hpp
@@ -35,6 +35,7 @@
 #include <hpx/plugin/traits/plugin_config_data.hpp>
 #include <hpx/serialization/traits/brace_initializable_traits.hpp>
 #include <hpx/serialization/traits/is_bitwise_serializable.hpp>
+#include <hpx/serialization/traits/is_not_bitwise_serializable.hpp>
 #include <hpx/serialization/traits/needs_automatic_registration.hpp>
 #include <hpx/serialization/traits/polymorphic_traits.hpp>
 #include <hpx/serialization/traits/serialization_access_data.hpp>


### PR DESCRIPTION
- this also allows for certain types to be normally serialized, still

More explanations of the rationale for this:

HPX so far assumes that only types that are specifically marked as such are bitwise serializable. This is fine in normal situations. Certain systems (like [SHAD](https://github.com/pnnl/SHAD)) however assume the opposite: all types are bitwise serializable by default, and only few require proper serialization. This PR adds an option to HPX that allows to support such systems by defining the new configuration option `HPX_SERIALIZATION_WITH_ALL_TYPES_ARE_BITWISE_SERIALIZABLE=On`. This also adds a new helper macro `HPX_IS_NOT_BITWISE_SERIALIZABLE(T)` which marks `T` as not bitwise serializable.

@msimberg I'd appreciate it if this PR could still make it into the release.
