### PR TITLE
Adapt exclusive_scan to C++20

### DIFF
--- a/docs/sphinx/api/public_api.rst
+++ b/docs/sphinx/api/public_api.rst
@@ -605,13 +605,14 @@ Functions
 ---------
 
 - :cpp:func:`hpx::parallel::v1::adjacent_difference`
-- :cpp:func:`hpx::parallel::v1::exclusive_scan`
+- :cpp:func:`hpx::exclusive_scan`
 - :cpp:func:`hpx::inclusive_scan`
 - :cpp:func:`hpx::reduce`
 - :cpp:func:`hpx::parallel::v1::transform_exclusive_scan`
 - :cpp:func:`hpx::parallel::v1::transform_inclusive_scan`
 - :cpp:func:`hpx::transform_reduce`
 
+- :cpp:func:`hpx::ranges::exclusive_scan`
 - :cpp:func:`hpx::ranges::inclusive_scan`
 
 Header ``hpx/optional.hpp``

--- a/docs/sphinx/manual/writing_single_node_hpx_applications.rst
+++ b/docs/sphinx/manual/writing_single_node_hpx_applications.rst
@@ -669,7 +669,7 @@ Parallel algorithms
      * Calculates the difference between each element in an input range and the preceding element.
      * ``<hpx/numeric.hpp>``
      * :cppreference-algorithm:`adjacent_difference`
-   * * :cpp:func:`hpx::parallel::v1::exclusive_scan`
+   * * :cpp:func:`hpx::exclusive_scan`
      * Does an exclusive parallel scan over a range of elements.
      * ``<hpx/numeric.hpp>``
      * :cppreference-algorithm:`exclusive_scan`

--- a/libs/full/collectives/include/hpx/collectives/exclusive_scan.hpp
+++ b/libs/full/collectives/include/hpx/collectives/exclusive_scan.hpp
@@ -147,8 +147,8 @@ namespace hpx { namespace traits {
                     dest.resize(data.size());
 
                     auto it = data.begin();
-                    hpx::exclusive_scan(hpx::execution::seq, it,
-                        data.end(), dest.begin(), *it, std::forward<F>(op));
+                    hpx::exclusive_scan(hpx::execution::seq, it, data.end(),
+                        dest.begin(), *it, std::forward<F>(op));
 
                     std::swap(data, dest);
                     communicator.data_available_ = true;

--- a/libs/full/collectives/include/hpx/collectives/exclusive_scan.hpp
+++ b/libs/full/collectives/include/hpx/collectives/exclusive_scan.hpp
@@ -147,7 +147,7 @@ namespace hpx { namespace traits {
                     dest.resize(data.size());
 
                     auto it = data.begin();
-                    hpx::parallel::exclusive_scan(hpx::execution::seq, it,
+                    hpx::exclusive_scan(hpx::execution::seq, it,
                         data.end(), dest.begin(), *it, std::forward<F>(op));
 
                     std::swap(data, dest);

--- a/libs/full/include_local/include/hpx/local/numeric.hpp
+++ b/libs/full/include_local/include/hpx/local/numeric.hpp
@@ -11,7 +11,6 @@
 
 namespace hpx {
     using hpx::parallel::adjacent_difference;
-    using hpx::parallel::exclusive_scan;
     using hpx::parallel::transform_exclusive_scan;
     using hpx::parallel::transform_inclusive_scan;
 }    // namespace hpx

--- a/libs/full/segmented_algorithms/include/hpx/parallel/segmented_algorithms/exclusive_scan.hpp
+++ b/libs/full/segmented_algorithms/include/hpx/parallel/segmented_algorithms/exclusive_scan.hpp
@@ -259,7 +259,7 @@ namespace hpx { namespace segmented {
 
     // clang-format off
     template <typename InIter, typename OutIter,
-        typename T, typename Op,
+        typename T, typename Op = std::plus<T>,
         HPX_CONCEPT_REQUIRES_(
             hpx::traits::is_iterator<InIter>::value &&
             hpx::traits::is_segmented_iterator<InIter>::value &&
@@ -268,7 +268,7 @@ namespace hpx { namespace segmented {
         )>
     // clang-format on
     OutIter tag_dispatch(hpx::exclusive_scan_t, InIter first, InIter last,
-        OutIter dest, T init, Op&& op)
+        OutIter dest, T init, Op&& op = Op())
     {
         static_assert(hpx::traits::is_input_iterator<InIter>::value,
             "Requires at least input iterator.");
@@ -287,7 +287,7 @@ namespace hpx { namespace segmented {
 
     // clang-format off
     template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
-        typename T, typename Op,
+        typename T, typename Op = std::plus<T>,
         HPX_CONCEPT_REQUIRES_(
             hpx::is_execution_policy<ExPolicy>::value &&
             hpx::traits::is_iterator<FwdIter1>::value &&
@@ -298,7 +298,7 @@ namespace hpx { namespace segmented {
     // clang-format on
     typename parallel::util::detail::algorithm_result<ExPolicy, FwdIter2>::type
     tag_dispatch(hpx::exclusive_scan_t, ExPolicy&& policy, FwdIter1 first,
-        FwdIter1 last, FwdIter2 dest, T init, Op&& op)
+        FwdIter1 last, FwdIter2 dest, T init, Op&& op = Op())
     {
         static_assert(hpx::traits::is_forward_iterator<FwdIter1>::value,
             "Requires at least forward iterator.");

--- a/libs/full/segmented_algorithms/include/hpx/parallel/segmented_algorithms/exclusive_scan.hpp
+++ b/libs/full/segmented_algorithms/include/hpx/parallel/segmented_algorithms/exclusive_scan.hpp
@@ -250,34 +250,70 @@ namespace hpx { namespace parallel { inline namespace v1 {
                     std::forward<Conv>(conv));
             }
         }
-
-        ///////////////////////////////////////////////////////////////////////
-        // segmented implementation
-        template <typename ExPolicy, typename InIter, typename OutIter,
-            typename T, typename Op, typename Conv>
-        static typename util::detail::algorithm_result<ExPolicy, OutIter>::type
-        exclusive_scan_(ExPolicy&& policy, InIter first, InIter last,
-            OutIter dest, T&& init, Op&& op, std::true_type, Conv&& conv)
-        {
-            typedef hpx::is_sequenced_execution_policy<ExPolicy> is_seq;
-
-            if (first == last)
-                return util::detail::algorithm_result<ExPolicy, OutIter>::get(
-                    std::move(dest));
-
-            return segmented_exclusive_scan(std::forward<ExPolicy>(policy),
-                first, last, dest, std::forward<T>(init), std::forward<Op>(op),
-                is_seq(), std::forward<Conv>(conv));
-        }
-
-        ///////////////////////////////////////////////////////////////////////
-        // forward declare the non-segmented version of this algorithm
-        template <typename ExPolicy, typename InIter, typename OutIter,
-            typename T, typename Op, typename Conv>
-        static typename util::detail::algorithm_result<ExPolicy, OutIter>::type
-        exclusive_scan_(ExPolicy&& policy, InIter first, InIter last,
-            OutIter dest, T&& init, Op&& op, std::false_type, Conv&& conv);
-
         /// \endcond
     }    // namespace detail
 }}}      // namespace hpx::parallel::v1
+
+// The segmented iterators we support all live in namespace hpx::segmented
+namespace hpx { namespace segmented {
+
+    // clang-format off
+    template <typename InIter, typename OutIter,
+            typename T, typename Op, typename Conv,
+        HPX_CONCEPT_REQUIRES_(
+            hpx::traits::is_iterator<InIter>::value &&
+            hpx::traits::is_segmented_iterator<InIter>::value &&
+            hpx::traits::is_iterator<OutIter>::value &&
+            hpx::traits::is_segmented_iterator<OutIter>::value
+        )>
+    // clang-format on
+    OutIter tag_dispatch(hpx::exclusive_scan_t, InIter first, InIter last,
+        OutIter dest, T&& init, Op&& op, Conv&& conv)
+    {
+        static_assert(hpx::traits::is_input_iterator<InIter>::value,
+            "Requires at least input iterator.");
+
+        static_assert(hpx::traits::is_output_iterator<OutIter>::value,
+            "Requires at least output iterator.");
+
+        if (first == last)
+            return dest;
+
+        return hpx::parallel::v1::detail::segmented_exclusive_scan(
+            hpx::execution::seq, first, last, dest, std::forward<T>(init),
+            std::forward<Op>(op), std::true_type{}, std::forward<Conv>(conv));
+    }
+
+    // clang-format off
+    template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
+        typename T, typename Op, typename Conv,
+        HPX_CONCEPT_REQUIRES_(
+            hpx::is_execution_policy<ExPolicy>::value &&
+            hpx::traits::is_iterator<FwdIter1>::value &&
+            hpx::traits::is_segmented_iterator<FwdIter1>::value &&
+            hpx::traits::is_iterator<FwdIter2>::value &&
+            hpx::traits::is_segmented_iterator<FwdIter2>::value
+        )>
+    // clang-format on
+    typename parallel::util::detail::algorithm_result<ExPolicy, FwdIter2>::type
+    tag_dispatch(hpx::exclusive_scan_t, ExPolicy&& policy, FwdIter1 first,
+        FwdIter1 last, FwdIter2 dest, T&& init, Op&& op, Conv&& conv)
+    {
+        static_assert(hpx::traits::is_forward_iterator<FwdIter1>::value,
+            "Requires at least forward iterator.");
+
+        static_assert(hpx::traits::is_forward_iterator<FwdIter2>::value,
+            "Requires at least forward iterator.");
+
+        if (first == last)
+            return util::detail::algorithm_result<ExPolicy, FwdIter2>::get(
+                std::move(dest));
+
+        using is_seq = hpx::is_sequenced_execution_policy<ExPolicy>;
+
+        return hpx::parallel::v1::detail::segmented_exclusive_scan(
+            std::forward<ExPolicy>(policy), first, last, dest,
+            std::forward<T>(init), std::forward<Op>(op), is_seq(),
+            std::forward<Conv>(conv));
+    }
+}}    // namespace hpx::segmented

--- a/libs/full/segmented_algorithms/include/hpx/parallel/segmented_algorithms/exclusive_scan.hpp
+++ b/libs/full/segmented_algorithms/include/hpx/parallel/segmented_algorithms/exclusive_scan.hpp
@@ -260,7 +260,6 @@ namespace hpx { namespace segmented {
     // clang-format off
     template <typename InIter, typename OutIter,
         typename T, typename Op,
-        typename Proj = parallel::util::projection_identity,
         HPX_CONCEPT_REQUIRES_(
             hpx::traits::is_iterator<InIter>::value &&
             hpx::traits::is_segmented_iterator<InIter>::value &&
@@ -269,7 +268,7 @@ namespace hpx { namespace segmented {
         )>
     // clang-format on
     OutIter tag_dispatch(hpx::exclusive_scan_t, InIter first, InIter last,
-        OutIter dest, T&& init, Op&& op, Proj&& proj = Proj())
+        OutIter dest, T init, Op&& op)
     {
         static_assert(hpx::traits::is_input_iterator<InIter>::value,
             "Requires at least input iterator.");
@@ -281,14 +280,14 @@ namespace hpx { namespace segmented {
             return dest;
 
         return hpx::parallel::v1::detail::segmented_exclusive_scan(
-            hpx::execution::seq, first, last, dest, std::forward<T>(init),
-            std::forward<Op>(op), std::true_type{}, std::forward<Proj>(proj));
+            hpx::execution::seq, first, last, dest, std::move(init),
+            std::forward<Op>(op), std::true_type{},
+            parallel::util::projection_identity{});
     }
 
     // clang-format off
     template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
         typename T, typename Op,
-        typename Proj = parallel::util::projection_identity,
         HPX_CONCEPT_REQUIRES_(
             hpx::is_execution_policy<ExPolicy>::value &&
             hpx::traits::is_iterator<FwdIter1>::value &&
@@ -299,7 +298,7 @@ namespace hpx { namespace segmented {
     // clang-format on
     typename parallel::util::detail::algorithm_result<ExPolicy, FwdIter2>::type
     tag_dispatch(hpx::exclusive_scan_t, ExPolicy&& policy, FwdIter1 first,
-        FwdIter1 last, FwdIter2 dest, T&& init, Op&& op, Proj&& proj = Proj())
+        FwdIter1 last, FwdIter2 dest, T init, Op&& op)
     {
         static_assert(hpx::traits::is_forward_iterator<FwdIter1>::value,
             "Requires at least forward iterator.");
@@ -314,8 +313,8 @@ namespace hpx { namespace segmented {
         using is_seq = hpx::is_sequenced_execution_policy<ExPolicy>;
 
         return hpx::parallel::v1::detail::segmented_exclusive_scan(
-            std::forward<ExPolicy>(policy), first, last, dest,
-            std::forward<T>(init), std::forward<Op>(op), is_seq(),
-            std::forward<Proj>(proj));
+            std::forward<ExPolicy>(policy), first, last, dest, std::move(init),
+            std::forward<Op>(op), is_seq(),
+            parallel::util::projection_identity{});
     }
 }}    // namespace hpx::segmented

--- a/libs/full/segmented_algorithms/include/hpx/parallel/segmented_algorithms/transform_exclusive_scan.hpp
+++ b/libs/full/segmented_algorithms/include/hpx/parallel/segmented_algorithms/transform_exclusive_scan.hpp
@@ -41,9 +41,11 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 return util::detail::algorithm_result<ExPolicy, OutIter>::get(
                     std::move(dest));
 
+            using is_seq = hpx::is_sequenced_execution_policy<ExPolicy>;
+
             return hpx::parallel::v1::detail::segmented_exclusive_scan(
                 std::forward<ExPolicy>(policy), first, last, dest,
-                std::forward<T>(init), std::forward<Op>(op), std::true_type(),
+                std::forward<T>(init), std::forward<Op>(op), is_seq(),
                 std::forward<Conv>(conv));
         }
 

--- a/libs/full/segmented_algorithms/include/hpx/parallel/segmented_algorithms/transform_exclusive_scan.hpp
+++ b/libs/full/segmented_algorithms/include/hpx/parallel/segmented_algorithms/transform_exclusive_scan.hpp
@@ -41,9 +41,10 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 return util::detail::algorithm_result<ExPolicy, OutIter>::get(
                     std::move(dest));
 
-            return exclusive_scan_(std::forward<ExPolicy>(policy), first, last,
-                dest, std::forward<T>(init), std::forward<Op>(op),
-                std::true_type(), std::forward<Conv>(conv));
+            return hpx::parallel::v1::detail::segmented_exclusive_scan(
+                std::forward<ExPolicy>(policy), first, last, dest,
+                std::forward<T>(init), std::forward<Op>(op), std::true_type(),
+                std::forward<Conv>(conv));
         }
 
         // forward declare the non-segmented version of this algorithm

--- a/libs/full/segmented_algorithms/tests/unit/partitioned_vector_exclusive_scan.cpp
+++ b/libs/full/segmented_algorithms/tests/unit/partitioned_vector_exclusive_scan.cpp
@@ -50,7 +50,7 @@ struct opt
 template <typename T, typename DistPolicy, typename ExPolicy>
 void exclusive_scan_algo_tests_with_policy(std::size_t size,
     DistPolicy const& dist_policy, hpx::partitioned_vector<T>& in,
-    std::vector<T> ver, ExPolicy const& policy)
+    std::vector<T> const& ver, ExPolicy const& policy)
 {
     msg7(typeid(ExPolicy).name(), typeid(DistPolicy).name(), typeid(T).name(),
         regular, size, dist_policy.get_num_partitions(),
@@ -63,7 +63,7 @@ void exclusive_scan_algo_tests_with_policy(std::size_t size,
     double e1 = t1.elapsed();
     t1.restart();
 
-    hpx::parallel::exclusive_scan(
+    hpx::exclusive_scan(
         policy, in.begin(), in.end(), out.begin(), val, opt<T>());
 
     double e2 = t1.elapsed();
@@ -76,11 +76,41 @@ void exclusive_scan_algo_tests_with_policy(std::size_t size,
               << "\n";
 }
 
+template <typename T, typename DistPolicy>
+void exclusive_scan_algo_tests_segmented_out_with_policy_seq(std::size_t size,
+    DistPolicy const& in_dist_policy, DistPolicy const& out_dist_policy,
+    hpx::partitioned_vector<T>& in, hpx::partitioned_vector<T> out,
+    std::vector<T> const& ver)
+{
+    msg9(typeid(hpx::execution::seq).name(), typeid(DistPolicy).name(),
+        typeid(T).name(), segmented, size, in_dist_policy.get_num_partitions(),
+        in_dist_policy.get_localities().size(),
+        out_dist_policy.get_num_partitions(),
+        out_dist_policy.get_localities().size());
+    hpx::chrono::high_resolution_timer t1;
+
+    T val(0);
+
+    double e1 = t1.elapsed();
+    t1.restart();
+
+    hpx::exclusive_scan(in.begin(), in.end(), out.begin(), val, opt<T>());
+
+    double e2 = t1.elapsed();
+    t1.restart();
+
+    verify_values(out, ver);
+
+    double e3 = t1.elapsed();
+    std::cout << std::setprecision(4) << "\t" << e1 << " " << e2 << " " << e3
+              << "\n";
+}
+
 template <typename T, typename DistPolicy, typename ExPolicy>
 void exclusive_scan_algo_tests_segmented_out_with_policy(std::size_t size,
     DistPolicy const& in_dist_policy, DistPolicy const& out_dist_policy,
     hpx::partitioned_vector<T>& in, hpx::partitioned_vector<T> out,
-    std::vector<T> ver, ExPolicy const& policy)
+    std::vector<T> const& ver, ExPolicy const& policy)
 {
     msg9(typeid(ExPolicy).name(), typeid(DistPolicy).name(), typeid(T).name(),
         segmented, size, in_dist_policy.get_num_partitions(),
@@ -94,7 +124,7 @@ void exclusive_scan_algo_tests_segmented_out_with_policy(std::size_t size,
     double e1 = t1.elapsed();
     t1.restart();
 
-    hpx::parallel::exclusive_scan(
+    hpx::exclusive_scan(
         policy, in.begin(), in.end(), out.begin(), val, opt<T>());
 
     double e2 = t1.elapsed();
@@ -109,7 +139,8 @@ void exclusive_scan_algo_tests_segmented_out_with_policy(std::size_t size,
 
 template <typename T, typename DistPolicy, typename ExPolicy>
 void exclusive_scan_algo_tests_inplace_with_policy(std::size_t size,
-    DistPolicy const& dist_policy, std::vector<T> ver, ExPolicy const& policy)
+    DistPolicy const& dist_policy, std::vector<T> const& ver,
+    ExPolicy const& policy)
 {
     msg7(typeid(ExPolicy).name(), typeid(DistPolicy).name(), typeid(T).name(),
         inplace, size, dist_policy.get_num_partitions(),
@@ -124,7 +155,7 @@ void exclusive_scan_algo_tests_inplace_with_policy(std::size_t size,
     double e1 = t1.elapsed();
     t1.restart();
 
-    hpx::parallel::exclusive_scan(
+    hpx::exclusive_scan(
         policy, in.begin(), in.end(), in.begin(), val, opt<T>());
 
     double e2 = t1.elapsed();
@@ -142,7 +173,7 @@ void exclusive_scan_algo_tests_inplace_with_policy(std::size_t size,
 template <typename T, typename DistPolicy, typename ExPolicy>
 void exclusive_scan_algo_tests_with_policy_async(std::size_t size,
     DistPolicy const& dist_policy, hpx::partitioned_vector<T>& in,
-    std::vector<T> ver, ExPolicy const& policy)
+    std::vector<T> const& ver, ExPolicy const& policy)
 {
     msg7(typeid(ExPolicy).name(), typeid(DistPolicy).name(), typeid(T).name(),
         async, size, dist_policy.get_num_partitions(),
@@ -155,7 +186,7 @@ void exclusive_scan_algo_tests_with_policy_async(std::size_t size,
     double e1 = t1.elapsed();
     t1.restart();
 
-    auto res = hpx::parallel::exclusive_scan(
+    auto res = hpx::exclusive_scan(
         policy, in.begin(), in.end(), out.begin(), val, opt<T>());
     res.get();
 
@@ -173,7 +204,7 @@ template <typename T, typename DistPolicy, typename ExPolicy>
 void exclusive_scan_algo_tests_segmented_out_with_policy_async(std::size_t size,
     DistPolicy const& in_dist_policy, DistPolicy const& out_dist_policy,
     hpx::partitioned_vector<T>& in, hpx::partitioned_vector<T> out,
-    std::vector<T> ver, ExPolicy const& policy)
+    std::vector<T> const& ver, ExPolicy const& policy)
 {
     msg9(typeid(ExPolicy).name(), typeid(DistPolicy).name(), typeid(T).name(),
         async_segmented, size, in_dist_policy.get_num_partitions(),
@@ -188,7 +219,7 @@ void exclusive_scan_algo_tests_segmented_out_with_policy_async(std::size_t size,
     double e1 = t1.elapsed();
     t1.restart();
 
-    auto res = hpx::parallel::exclusive_scan(
+    auto res = hpx::exclusive_scan(
         policy, in.begin(), in.end(), out.begin(), val, opt<T>());
     res.get();
 
@@ -204,7 +235,8 @@ void exclusive_scan_algo_tests_segmented_out_with_policy_async(std::size_t size,
 
 template <typename T, typename DistPolicy, typename ExPolicy>
 void exclusive_scan_algo_tests_inplace_with_policy_async(std::size_t size,
-    DistPolicy const& dist_policy, std::vector<T> ver, ExPolicy const& policy)
+    DistPolicy const& dist_policy, std::vector<T> const& ver,
+    ExPolicy const& policy)
 {
     msg7(typeid(ExPolicy).name(), typeid(DistPolicy).name(), typeid(T).name(),
         async_inplace, size, dist_policy.get_num_partitions(),
@@ -219,7 +251,7 @@ void exclusive_scan_algo_tests_inplace_with_policy_async(std::size_t size,
     double e1 = t1.elapsed();
     t1.restart();
 
-    auto res = hpx::parallel::exclusive_scan(
+    auto res = hpx::exclusive_scan(
         policy, in.begin(), in.end(), in.begin(), val, opt<T>());
     res.get();
 
@@ -281,6 +313,9 @@ void exclusive_scan_tests_segmented_out_with_policy(
 
     hpx::parallel::v1::detail::sequential_exclusive_scan(
         ver.begin(), ver.end(), ver.begin(), val, opt<T>());
+
+    exclusive_scan_algo_tests_segmented_out_with_policy_seq<T>(
+        size, in_policy, out_policy, in, out, ver);
 
     //sync
     exclusive_scan_algo_tests_segmented_out_with_policy<T>(

--- a/libs/full/segmented_algorithms/tests/unit/partitioned_vector_exclusive_scan2.cpp
+++ b/libs/full/segmented_algorithms/tests/unit/partitioned_vector_exclusive_scan2.cpp
@@ -50,7 +50,7 @@ struct opt
 template <typename T, typename DistPolicy, typename ExPolicy>
 void exclusive_scan_algo_tests_with_policy(std::size_t size,
     DistPolicy const& dist_policy, hpx::partitioned_vector<T>& in,
-    std::vector<T> ver, ExPolicy const& policy)
+    std::vector<T> const& ver, ExPolicy const& policy)
 {
     msg7(typeid(ExPolicy).name(), typeid(DistPolicy).name(), typeid(T).name(),
         regular, size, dist_policy.get_num_partitions(),
@@ -63,7 +63,7 @@ void exclusive_scan_algo_tests_with_policy(std::size_t size,
     double e1 = t1.elapsed();
     t1.restart();
 
-    hpx::parallel::exclusive_scan(
+    hpx::exclusive_scan(
         policy, in.begin(), in.end(), out.begin(), val, opt<T>());
 
     double e2 = t1.elapsed();
@@ -80,7 +80,7 @@ template <typename T, typename DistPolicy, typename ExPolicy>
 void exclusive_scan_algo_tests_segmented_out_with_policy(std::size_t size,
     DistPolicy const& in_dist_policy, DistPolicy const& out_dist_policy,
     hpx::partitioned_vector<T>& in, hpx::partitioned_vector<T> out,
-    std::vector<T> ver, ExPolicy const& policy)
+    std::vector<T> const& ver, ExPolicy const& policy)
 {
     msg9(typeid(ExPolicy).name(), typeid(DistPolicy).name(), typeid(T).name(),
         segmented, size, in_dist_policy.get_num_partitions(),
@@ -94,7 +94,7 @@ void exclusive_scan_algo_tests_segmented_out_with_policy(std::size_t size,
     double e1 = t1.elapsed();
     t1.restart();
 
-    hpx::parallel::exclusive_scan(
+    hpx::exclusive_scan(
         policy, in.begin(), in.end(), out.begin(), val, opt<T>());
 
     double e2 = t1.elapsed();
@@ -109,7 +109,8 @@ void exclusive_scan_algo_tests_segmented_out_with_policy(std::size_t size,
 
 template <typename T, typename DistPolicy, typename ExPolicy>
 void exclusive_scan_algo_tests_inplace_with_policy(std::size_t size,
-    DistPolicy const& dist_policy, std::vector<T> ver, ExPolicy const& policy)
+    DistPolicy const& dist_policy, std::vector<T> const& ver,
+    ExPolicy const& policy)
 {
     msg7(typeid(ExPolicy).name(), typeid(DistPolicy).name(), typeid(T).name(),
         inplace, size, dist_policy.get_num_partitions(),
@@ -124,7 +125,7 @@ void exclusive_scan_algo_tests_inplace_with_policy(std::size_t size,
     double e1 = t1.elapsed();
     t1.restart();
 
-    hpx::parallel::exclusive_scan(
+    hpx::exclusive_scan(
         policy, in.begin(), in.end(), in.begin(), val, opt<T>());
 
     double e2 = t1.elapsed();
@@ -142,7 +143,7 @@ void exclusive_scan_algo_tests_inplace_with_policy(std::size_t size,
 template <typename T, typename DistPolicy, typename ExPolicy>
 void exclusive_scan_algo_tests_with_policy_async(std::size_t size,
     DistPolicy const& dist_policy, hpx::partitioned_vector<T>& in,
-    std::vector<T> ver, ExPolicy const& policy)
+    std::vector<T> const& ver, ExPolicy const& policy)
 {
     msg7(typeid(ExPolicy).name(), typeid(DistPolicy).name(), typeid(T).name(),
         async, size, dist_policy.get_num_partitions(),
@@ -155,7 +156,7 @@ void exclusive_scan_algo_tests_with_policy_async(std::size_t size,
     double e1 = t1.elapsed();
     t1.restart();
 
-    auto res = hpx::parallel::exclusive_scan(
+    auto res = hpx::exclusive_scan(
         policy, in.begin(), in.end(), out.begin(), val, opt<T>());
     res.get();
 
@@ -173,7 +174,7 @@ template <typename T, typename DistPolicy, typename ExPolicy>
 void exclusive_scan_algo_tests_segmented_out_with_policy_async(std::size_t size,
     DistPolicy const& in_dist_policy, DistPolicy const& out_dist_policy,
     hpx::partitioned_vector<T>& in, hpx::partitioned_vector<T> out,
-    std::vector<T> ver, ExPolicy const& policy)
+    std::vector<T> const& ver, ExPolicy const& policy)
 {
     msg9(typeid(ExPolicy).name(), typeid(DistPolicy).name(), typeid(T).name(),
         async_segmented, size, in_dist_policy.get_num_partitions(),
@@ -188,7 +189,7 @@ void exclusive_scan_algo_tests_segmented_out_with_policy_async(std::size_t size,
     double e1 = t1.elapsed();
     t1.restart();
 
-    auto res = hpx::parallel::exclusive_scan(
+    auto res = hpx::exclusive_scan(
         policy, in.begin(), in.end(), out.begin(), val, opt<T>());
     res.get();
 
@@ -204,7 +205,8 @@ void exclusive_scan_algo_tests_segmented_out_with_policy_async(std::size_t size,
 
 template <typename T, typename DistPolicy, typename ExPolicy>
 void exclusive_scan_algo_tests_inplace_with_policy_async(std::size_t size,
-    DistPolicy const& dist_policy, std::vector<T> ver, ExPolicy const& policy)
+    DistPolicy const& dist_policy, std::vector<T> const& ver,
+    ExPolicy const& policy)
 {
     msg7(typeid(ExPolicy).name(), typeid(DistPolicy).name(), typeid(T).name(),
         async_inplace, size, dist_policy.get_num_partitions(),
@@ -219,7 +221,7 @@ void exclusive_scan_algo_tests_inplace_with_policy_async(std::size_t size,
     double e1 = t1.elapsed();
     t1.restart();
 
-    auto res = hpx::parallel::exclusive_scan(
+    auto res = hpx::exclusive_scan(
         policy, in.begin(), in.end(), in.begin(), val, opt<T>());
     res.get();
 

--- a/libs/parallelism/algorithms/CMakeLists.txt
+++ b/libs/parallelism/algorithms/CMakeLists.txt
@@ -89,6 +89,7 @@ set(algorithms_headers
     hpx/parallel/container_algorithms/count.hpp
     hpx/parallel/container_algorithms/destroy.hpp
     hpx/parallel/container_algorithms/equal.hpp
+    hpx/parallel/container_algorithms/exclusive_scan.hpp
     hpx/parallel/container_algorithms/fill.hpp
     hpx/parallel/container_algorithms/find.hpp
     hpx/parallel/container_algorithms/for_each.hpp

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/exclusive_scan.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/exclusive_scan.hpp
@@ -455,7 +455,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 hpx::traits::is_iterator<FwdIter2>::value
             )>
     // clang-format on
-    HPX_DEPRECATED_V(1, 7,
+    HPX_DEPRECATED_V(1, 8,
         "hpx::parallel::exclusive_scan is deprecated, use hpx::exclusive_scan "
         "instead")
         typename util::detail::algorithm_result<ExPolicy, FwdIter2>::type
@@ -488,7 +488,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 hpx::traits::is_iterator<FwdIter2>::value
             )>
     // clang-format on
-    HPX_DEPRECATED_V(1, 7,
+    HPX_DEPRECATED_V(1, 8,
         "hpx::parallel::exclusive_scan is deprecated, use hpx::exclusive_scan "
         "instead")
         typename util::detail::algorithm_result<ExPolicy, FwdIter2>::type

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/exclusive_scan.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/exclusive_scan.hpp
@@ -9,6 +9,281 @@
 
 #pragma once
 
+#if defined(DOXYGEN)
+namespace hpx {
+    // clang-format off
+
+    ///////////////////////////////////////////////////////////////////////////
+    /// Assigns through each iterator \a i in [result, result + (last - first))
+    /// the value of
+    /// GENERALIZED_NONCOMMUTATIVE_SUM(+, init, *first, ...,
+    /// *(first + (i - result) - 1))
+    ///
+    /// \note   Complexity: O(\a last - \a first) applications of the
+    ///         predicate \a std::plus<T>.
+    ///
+    /// \tparam InIter      The type of the source iterators used (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     input iterator.
+    /// \tparam OutIter     The type of the iterator representing the
+    ///                     destination range (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     output iterator.
+    /// \tparam T           The type of the value to be used as initial (and
+    ///                     intermediate) values (deduced).
+    ///
+    /// \param first        Refers to the beginning of the sequence of elements
+    ///                     the algorithm will be applied to.
+    /// \param last         Refers to the end of the sequence of elements the
+    ///                     algorithm will be applied to.
+    /// \param dest         Refers to the beginning of the destination range.
+    /// \param init         The initial value for the generalized sum.
+    ///
+    /// The reduce operations in the parallel \a exclusive_scan algorithm
+    /// invoked without an execution policy object will execute in sequential
+    /// order in the calling thread.
+    ///
+    /// \returns  The \a exclusive_scan algorithm returns \a OutIter.
+    ///           The \a exclusive_scan algorithm returns the output iterator
+    ///           to the element in the destination range, one past the last
+    ///           element copied.
+    ///
+    /// \note   GENERALIZED_NONCOMMUTATIVE_SUM(+, a1, ..., aN) is defined as:
+    ///         * a1 when N is 1
+    ///         * GENERALIZED_NONCOMMUTATIVE_SUM(+, a1, ..., aK)
+    ///           + GENERALIZED_NONCOMMUTATIVE_SUM(+, aM, ..., aN)
+    ///           where 1 < K+1 = M <= N.
+    ///
+    /// The difference between \a exclusive_scan and \a inclusive_scan is that
+    /// \a inclusive_scan includes the ith input element in the ith sum.
+    ///
+    template <typename InIter, typename OutIter, typename T>
+    OutIter exclusive_scan(InIter first, InIter last, OutIter dest, T init);
+
+    ///////////////////////////////////////////////////////////////////////////
+    /// Assigns through each iterator \a i in [result, result + (last - first))
+    /// the value of
+    /// GENERALIZED_NONCOMMUTATIVE_SUM(+, init, *first, ...,
+    /// *(first + (i - result) - 1))
+    ///
+    /// \note   Complexity: O(\a last - \a first) applications of the
+    ///         predicate \a std::plus<T>.
+    ///
+    /// \tparam ExPolicy    The type of the execution policy to use (deduced).
+    ///                     It describes the manner in which the execution
+    ///                     of the algorithm may be parallelized and the manner
+    ///                     in which it executes the assignments.
+    /// \tparam FwdIter1    The type of the source iterators used (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     forward iterator.
+    /// \tparam FwdIter2    The type of the iterator representing the
+    ///                     destination range (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     forward iterator.
+    /// \tparam T           The type of the value to be used as initial (and
+    ///                     intermediate) values (deduced).
+    ///
+    /// \param policy       The execution policy to use for the scheduling of
+    ///                     the iterations.
+    /// \param first        Refers to the beginning of the sequence of elements
+    ///                     the algorithm will be applied to.
+    /// \param last         Refers to the end of the sequence of elements the
+    ///                     algorithm will be applied to.
+    /// \param dest         Refers to the beginning of the destination range.
+    /// \param init         The initial value for the generalized sum.
+    ///
+    /// The reduce operations in the parallel \a exclusive_scan algorithm
+    /// invoked with an execution policy object of type \a sequenced_policy
+    /// execute in sequential order in the calling thread.
+    ///
+    /// The reduce operations in the parallel \a exclusive_scan algorithm
+    /// invoked with an execution policy object of type \a parallel_policy
+    /// or \a parallel_task_policy are permitted to execute in an unordered
+    /// fashion in unspecified threads, and indeterminately sequenced
+    /// within each thread.
+    ///
+    /// \returns  The \a exclusive_scan algorithm returns a
+    ///           \a hpx::future<FwdIter2> if
+    ///           the execution policy is of type
+    ///           \a sequenced_task_policy or
+    ///           \a parallel_task_policy and
+    ///           returns \a FwdIter2 otherwise.
+    ///           The \a exclusive_scan algorithm returns the output iterator
+    ///           to the element in the destination range, one past the last
+    ///           element copied.
+    ///
+    /// \note   GENERALIZED_NONCOMMUTATIVE_SUM(+, a1, ..., aN) is defined as:
+    ///         * a1 when N is 1
+    ///         * GENERALIZED_NONCOMMUTATIVE_SUM(+, a1, ..., aK)
+    ///           + GENERALIZED_NONCOMMUTATIVE_SUM(+, aM, ..., aN)
+    ///           where 1 < K+1 = M <= N.
+    ///
+    /// The difference between \a exclusive_scan and \a inclusive_scan is that
+    /// \a inclusive_scan includes the ith input element in the ith sum.
+    ///
+    template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
+        typename T>
+    typename util::detail::algorithm_result<ExPolicy, FwdIter2>::type
+    exclusive_scan(ExPolicy&& policy, FwdIter1 first, FwdIter1 last,
+        FwdIter2 dest, T init);
+
+    ///////////////////////////////////////////////////////////////////////////
+    /// Assigns through each iterator \a i in [result, result + (last - first))
+    /// the value of
+    /// GENERALIZED_NONCOMMUTATIVE_SUM(binary_op, init, *first, ...,
+    /// *(first + (i - result) - 1)).
+    ///
+    /// \note   Complexity: O(\a last - \a first) applications of the
+    ///         predicate \a op.
+    ///
+    /// \tparam InIter      The type of the source iterators used (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     input iterator.
+    /// \tparam OutIter     The type of the iterator representing the
+    ///                     destination range (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     output iterator.
+    /// \tparam T           The type of the value to be used as initial (and
+    ///                     intermediate) values (deduced).
+    /// \tparam Op          The type of the binary function object used for
+    ///                     the reduction operation.
+    ///
+    /// \param first        Refers to the beginning of the sequence of elements
+    ///                     the algorithm will be applied to.
+    /// \param last         Refers to the end of the sequence of elements the
+    ///                     algorithm will be applied to.
+    /// \param dest         Refers to the beginning of the destination range.
+    /// \param init         The initial value for the generalized sum.
+    /// \param op           Specifies the function (or function object) which
+    ///                     will be invoked for each of the values of the input
+    ///                     sequence. This is a
+    ///                     binary predicate. The signature of this predicate
+    ///                     should be equivalent to:
+    ///                     \code
+    ///                     Ret fun(const Type1 &a, const Type1 &b);
+    ///                     \endcode \n
+    ///                     The signature does not need to have const&, but
+    ///                     the function must not modify the objects passed to
+    ///                     it.
+    ///                     The types \a Type1 and \a Ret must be
+    ///                     such that an object of a type as given by the input
+    ///                     sequence can be implicitly converted to any
+    ///                     of those types.
+    ///
+    /// The reduce operations in the parallel \a exclusive_scan algorithm
+    /// invoked without an execution policy object will execute in sequential
+    /// order in the calling thread.
+    ///
+    /// \returns  The \a exclusive_scan algorithm returns \a OutIter.
+    ///           The \a exclusive_scan algorithm returns the output iterator
+    ///           to the element in the destination range, one past the last
+    ///           element copied.
+    ///
+    /// \note   GENERALIZED_NONCOMMUTATIVE_SUM(op, a1, ..., aN) is defined as:
+    ///         * a1 when N is 1
+    ///         * op(GENERALIZED_NONCOMMUTATIVE_SUM(op, a1, ..., aK),
+    ///           GENERALIZED_NONCOMMUTATIVE_SUM(op, aM, ..., aN))
+    ///           where 1 < K+1 = M <= N.
+    ///
+    /// The difference between \a exclusive_scan and \a inclusive_scan is that
+    /// \a inclusive_scan includes the ith input element in the ith sum. If
+    /// \a op is not mathematically associative, the behavior of
+    /// \a inclusive_scan may be non-deterministic.
+    ///
+    template <typename InIter, typename OutIter,typename T, typename Op>
+    FwdIter2 exclusive_scan(ExPolicy&& policy, FwdIter1 first, FwdIter1 last,
+        FwdIter2 dest, T init, Op&& op);
+
+        ///////////////////////////////////////////////////////////////////////////
+    /// Assigns through each iterator \a i in [result, result + (last - first))
+    /// the value of
+    /// GENERALIZED_NONCOMMUTATIVE_SUM(binary_op, init, *first, ...,
+    /// *(first + (i - result) - 1)).
+    ///
+    /// \note   Complexity: O(\a last - \a first) applications of the
+    ///         predicate \a op.
+    ///
+    /// \tparam ExPolicy    The type of the execution policy to use (deduced).
+    ///                     It describes the manner in which the execution
+    ///                     of the algorithm may be parallelized and the manner
+    ///                     in which it executes the assignments.
+    /// \tparam InIter      The type of the source iterators used (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     forward iterator.
+    /// \tparam OutIter     The type of the iterator representing the
+    ///                     destination range (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     forward iterator.
+    /// \tparam T           The type of the value to be used as initial (and
+    ///                     intermediate) values (deduced).
+    /// \tparam Op          The type of the binary function object used for
+    ///                     the reduction operation.
+    ///
+    /// \param policy       The execution policy to use for the scheduling of
+    ///                     the iterations.
+    /// \param first        Refers to the beginning of the sequence of elements
+    ///                     the algorithm will be applied to.
+    /// \param last         Refers to the end of the sequence of elements the
+    ///                     algorithm will be applied to.
+    /// \param dest         Refers to the beginning of the destination range.
+    /// \param init         The initial value for the generalized sum.
+    /// \param op           Specifies the function (or function object) which
+    ///                     will be invoked for each of the values of the input
+    ///                     sequence. This is a
+    ///                     binary predicate. The signature of this predicate
+    ///                     should be equivalent to:
+    ///                     \code
+    ///                     Ret fun(const Type1 &a, const Type1 &b);
+    ///                     \endcode \n
+    ///                     The signature does not need to have const&, but
+    ///                     the function must not modify the objects passed to
+    ///                     it.
+    ///                     The types \a Type1 and \a Ret must be
+    ///                     such that an object of a type as given by the input
+    ///                     sequence can be implicitly converted to any
+    ///                     of those types.
+    ///
+    /// The reduce operations in the parallel \a exclusive_scan algorithm
+    /// invoked with an execution policy object of type \a sequenced_policy
+    /// execute in sequential order in the calling thread.
+    ///
+    /// The reduce operations in the parallel \a exclusive_scan algorithm
+    /// invoked with an execution policy object of type \a parallel_policy
+    /// or \a parallel_task_policy are permitted to execute in an unordered
+    /// fashion in unspecified threads, and indeterminately sequenced
+    /// within each thread.
+    ///
+    /// \returns  The \a exclusive_scan algorithm returns a
+    ///           \a hpx::future<OutIter> if
+    ///           the execution policy is of type
+    ///           \a sequenced_task_policy or
+    ///           \a parallel_task_policy and
+    ///           returns \a OutIter otherwise.
+    ///           The \a exclusive_scan algorithm returns the output iterator
+    ///           to the element in the destination range, one past the last
+    ///           element copied.
+    ///
+    /// \note   GENERALIZED_NONCOMMUTATIVE_SUM(op, a1, ..., aN) is defined as:
+    ///         * a1 when N is 1
+    ///         * op(GENERALIZED_NONCOMMUTATIVE_SUM(op, a1, ..., aK),
+    ///           GENERALIZED_NONCOMMUTATIVE_SUM(op, aM, ..., aN))
+    ///           where 1 < K+1 = M <= N.
+    ///
+    /// The difference between \a exclusive_scan and \a inclusive_scan is that
+    /// \a inclusive_scan includes the ith input element in the ith sum. If
+    /// \a op is not mathematically associative, the behavior of
+    /// \a inclusive_scan may be non-deterministic.
+    ///
+    template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
+        typename T, typename Op>
+    typename util::detail::algorithm_result<ExPolicy, FwdIter2>::type
+    exclusive_scan(ExPolicy&& policy, FwdIter1 first, FwdIter1 last,
+        FwdIter2 dest, T init, Op&& op);
+    // clang-format on
+}    // namespace hpx
+
+#else    // DOXYGEN
+
 #include <hpx/config.hpp>
 #include <hpx/concepts/concepts.hpp>
 #include <hpx/functional/invoke.hpp>
@@ -171,87 +446,6 @@ namespace hpx { namespace parallel { inline namespace v1 {
         /// \endcond
     }    // namespace detail
 
-    ///////////////////////////////////////////////////////////////////////////
-    /// Assigns through each iterator \a i in [result, result + (last - first))
-    /// the value of
-    /// GENERALIZED_NONCOMMUTATIVE_SUM(binary_op, init, *first, ...,
-    /// *(first + (i - result) - 1)).
-    ///
-    /// \note   Complexity: O(\a last - \a first) applications of the
-    ///         predicate \a op.
-    ///
-    /// \tparam ExPolicy    The type of the execution policy to use (deduced).
-    ///                     It describes the manner in which the execution
-    ///                     of the algorithm may be parallelized and the manner
-    ///                     in which it executes the assignments.
-    /// \tparam FwdIter1    The type of the source iterators used (deduced).
-    ///                     This iterator type must meet the requirements of an
-    ///                     forward iterator.
-    /// \tparam FwdIter2    The type of the iterator representing the
-    ///                     destination range (deduced).
-    ///                     This iterator type must meet the requirements of an
-    ///                     forward iterator.
-    /// \tparam T           The type of the value to be used as initial (and
-    ///                     intermediate) values (deduced).
-    /// \tparam Op          The type of the binary function object used for
-    ///                     the reduction operation.
-    ///
-    /// \param policy       The execution policy to use for the scheduling of
-    ///                     the iterations.
-    /// \param first        Refers to the beginning of the sequence of elements
-    ///                     the algorithm will be applied to.
-    /// \param last         Refers to the end of the sequence of elements the
-    ///                     algorithm will be applied to.
-    /// \param dest         Refers to the beginning of the destination range.
-    /// \param init         The initial value for the generalized sum.
-    /// \param op           Specifies the function (or function object) which
-    ///                     will be invoked for each of the values of the input
-    ///                     sequence. This is a
-    ///                     binary predicate. The signature of this predicate
-    ///                     should be equivalent to:
-    ///                     \code
-    ///                     Ret fun(const Type1 &a, const Type1 &b);
-    ///                     \endcode \n
-    ///                     The signature does not need to have const&, but
-    ///                     the function must not modify the objects passed to
-    ///                     it.
-    ///                     The types \a Type1 and \a Ret must be
-    ///                     such that an object of a type as given by the input
-    ///                     sequence can be implicitly converted to any
-    ///                     of those types.
-    ///
-    /// The reduce operations in the parallel \a exclusive_scan algorithm invoked
-    /// with an execution policy object of type \a sequenced_policy
-    /// execute in sequential order in the calling thread.
-    ///
-    /// The reduce operations in the parallel \a exclusive_scan algorithm invoked
-    /// with an execution policy object of type \a parallel_policy
-    /// or \a parallel_task_policy are permitted to execute in an unordered
-    /// fashion in unspecified threads, and indeterminately sequenced
-    /// within each thread.
-    ///
-    /// \returns  The \a exclusive_scan algorithm returns a
-    ///           \a hpx::future<FwdIter2> if
-    ///           the execution policy is of type
-    ///           \a sequenced_task_policy or
-    ///           \a parallel_task_policy and
-    ///           returns \a FwdIter2 otherwise.
-    ///           The \a exclusive_scan algorithm returns the output iterator
-    ///           to the element in the destination range, one past the last
-    ///           element copied.
-    ///
-    /// \note   GENERALIZED_NONCOMMUTATIVE_SUM(op, a1, ..., aN) is defined as:
-    ///         * a1 when N is 1
-    ///         * op(GENERALIZED_NONCOMMUTATIVE_SUM(op, a1, ..., aK),
-    ///           GENERALIZED_NONCOMMUTATIVE_SUM(op, aM, ..., aN))
-    ///           where 1 < K+1 = M <= N.
-    ///
-    /// The difference between \a exclusive_scan and \a inclusive_scan is that
-    /// \a inclusive_scan includes the ith input element in the ith sum. If
-    /// \a op is not mathematically associative, the behavior of
-    /// \a inclusive_scan may be non-deterministic.
-    ///
-
     // clang-format off
     template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
         typename T, typename Op,
@@ -261,12 +455,12 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 hpx::traits::is_iterator<FwdIter2>::value
             )>
     // clang-format on
-    //HPX_DEPRECATED_V(1, 8,
-    //    "hpx::parallel::exclusive_scan is deprecated, use hpx::exclusive_scan "
-    //    "instead")
-    typename util::detail::algorithm_result<ExPolicy, FwdIter2>::type
-    exclusive_scan(ExPolicy&& policy, FwdIter1 first, FwdIter1 last,
-        FwdIter2 dest, T init, Op&& op)
+    HPX_DEPRECATED_V(1, 8,
+        "hpx::parallel::exclusive_scan is deprecated, use hpx::exclusive_scan "
+        "instead")
+        typename util::detail::algorithm_result<ExPolicy, FwdIter2>::type
+        exclusive_scan(ExPolicy&& policy, FwdIter1 first, FwdIter1 last,
+            FwdIter2 dest, T init, Op&& op)
     {
         static_assert((hpx::traits::is_forward_iterator<FwdIter1>::value),
             "Requires at least forward iterator.");
@@ -285,67 +479,6 @@ namespace hpx { namespace parallel { inline namespace v1 {
 #endif
     }
 
-    ///////////////////////////////////////////////////////////////////////////
-    /// Assigns through each iterator \a i in [result, result + (last - first))
-    /// the value of
-    /// GENERALIZED_NONCOMMUTATIVE_SUM(+, init, *first, ..., *(first + (i - result) - 1))
-    ///
-    /// \note   Complexity: O(\a last - \a first) applications of the
-    ///         predicate \a std::plus<T>.
-    ///
-    /// \tparam ExPolicy    The type of the execution policy to use (deduced).
-    ///                     It describes the manner in which the execution
-    ///                     of the algorithm may be parallelized and the manner
-    ///                     in which it executes the assignments.
-    /// \tparam FwdIter1    The type of the source iterators used (deduced).
-    ///                     This iterator type must meet the requirements of an
-    ///                     forward iterator.
-    /// \tparam FwdIter2    The type of the iterator representing the
-    ///                     destination range (deduced).
-    ///                     This iterator type must meet the requirements of an
-    ///                     forward iterator.
-    /// \tparam T           The type of the value to be used as initial (and
-    ///                     intermediate) values (deduced).
-    ///
-    /// \param policy       The execution policy to use for the scheduling of
-    ///                     the iterations.
-    /// \param first        Refers to the beginning of the sequence of elements
-    ///                     the algorithm will be applied to.
-    /// \param last         Refers to the end of the sequence of elements the
-    ///                     algorithm will be applied to.
-    /// \param dest         Refers to the beginning of the destination range.
-    /// \param init         The initial value for the generalized sum.
-    ///
-    /// The reduce operations in the parallel \a exclusive_scan algorithm invoked
-    /// with an execution policy object of type \a sequenced_policy
-    /// execute in sequential order in the calling thread.
-    ///
-    /// The reduce operations in the parallel \a exclusive_scan algorithm invoked
-    /// with an execution policy object of type \a parallel_policy
-    /// or \a parallel_task_policy are permitted to execute in an unordered
-    /// fashion in unspecified threads, and indeterminately sequenced
-    /// within each thread.
-    ///
-    /// \returns  The \a exclusive_scan algorithm returns a
-    ///           \a hpx::future<FwdIter2> if
-    ///           the execution policy is of type
-    ///           \a sequenced_task_policy or
-    ///           \a parallel_task_policy and
-    ///           returns \a FwdIter2 otherwise.
-    ///           The \a exclusive_scan algorithm returns the output iterator
-    ///           to the element in the destination range, one past the last
-    ///           element copied.
-    ///
-    /// \note   GENERALIZED_NONCOMMUTATIVE_SUM(+, a1, ..., aN) is defined as:
-    ///         * a1 when N is 1
-    ///         * GENERALIZED_NONCOMMUTATIVE_SUM(+, a1, ..., aK)
-    ///           + GENERALIZED_NONCOMMUTATIVE_SUM(+, aM, ..., aN)
-    ///           where 1 < K+1 = M <= N.
-    ///
-    /// The difference between \a exclusive_scan and \a inclusive_scan is that
-    /// \a inclusive_scan includes the ith input element in the ith sum.
-    ///
-
     // clang-format off
     template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
         typename T,
@@ -355,12 +488,12 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 hpx::traits::is_iterator<FwdIter2>::value
             )>
     // clang-format on
-    //HPX_DEPRECATED_V(1, 8,
-    //    "hpx::parallel::exclusive_scan is deprecated, use hpx::exclusive_scan "
-    //    "instead")
-    typename util::detail::algorithm_result<ExPolicy, FwdIter2>::type
-    exclusive_scan(
-        ExPolicy&& policy, FwdIter1 first, FwdIter1 last, FwdIter2 dest, T init)
+    HPX_DEPRECATED_V(1, 8,
+        "hpx::parallel::exclusive_scan is deprecated, use hpx::exclusive_scan "
+        "instead")
+        typename util::detail::algorithm_result<ExPolicy, FwdIter2>::type
+        exclusive_scan(ExPolicy&& policy, FwdIter1 first, FwdIter1 last,
+            FwdIter2 dest, T init)
     {
         static_assert((hpx::traits::is_forward_iterator<FwdIter1>::value),
             "Requires at least forward iterator.");
@@ -477,3 +610,5 @@ namespace hpx {
 
     } exclusive_scan{};
 }    // namespace hpx
+
+#endif    // DOXYGEN

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/exclusive_scan.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/exclusive_scan.hpp
@@ -325,7 +325,8 @@ namespace hpx { namespace parallel { inline namespace v1 {
         // Our own version of the sequential exclusive_scan.
         template <typename InIter, typename Sent, typename OutIter, typename T,
             typename Op>
-        util::in_out_result<InIter, OutIter> sequential_exclusive_scan(
+        static constexpr util::in_out_result<InIter, OutIter>
+        sequential_exclusive_scan(
             InIter first, Sent last, OutIter dest, T init, Op&& op)
         {
             T temp = init;
@@ -339,7 +340,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
         }
 
         template <typename InIter, typename OutIter, typename T, typename Op>
-        T sequential_exclusive_scan_n(
+        static constexpr T sequential_exclusive_scan_n(
             InIter first, std::size_t count, OutIter dest, T init, Op&& op)
         {
             T temp = init;
@@ -364,8 +365,9 @@ namespace hpx { namespace parallel { inline namespace v1 {
 
             template <typename ExPolicy, typename InIter, typename Sent,
                 typename OutIter, typename T, typename Op>
-            static util::in_out_result<InIter, OutIter> sequential(ExPolicy,
-                InIter first, Sent last, OutIter dest, T const& init, Op&& op)
+            static constexpr util::in_out_result<InIter, OutIter> sequential(
+                ExPolicy, InIter first, Sent last, OutIter dest, T const& init,
+                Op&& op)
             {
                 return sequential_exclusive_scan(
                     first, last, dest, init, std::forward<Op>(op));
@@ -462,7 +464,11 @@ namespace hpx { namespace parallel { inline namespace v1 {
         HPX_CONCEPT_REQUIRES_(
                 hpx::is_execution_policy<ExPolicy>::value &&
                 hpx::traits::is_iterator_v<FwdIter1> &&
-                hpx::traits::is_iterator_v<FwdIter2>
+                hpx::traits::is_iterator_v<FwdIter2> &&
+                hpx::is_invocable_v<Op,
+                    typename std::iterator_traits<FwdIter1>::value_type,
+                    typename std::iterator_traits<FwdIter1>::value_type
+                >
             )>
     // clang-format on
     HPX_DEPRECATED_V(1, 8,
@@ -563,8 +569,8 @@ namespace hpx {
             typename T,
             HPX_CONCEPT_REQUIRES_(
                 hpx::is_execution_policy<ExPolicy>::value &&
-                hpx::traits::is_forward_iterator_v<FwdIter1> &&
-                hpx::traits::is_forward_iterator_v<FwdIter2>
+                hpx::traits::is_iterator_v<FwdIter1> &&
+                hpx::traits::is_iterator_v<FwdIter2>
             )>
         // clang-format on
         friend typename parallel::util::detail::algorithm_result<ExPolicy,
@@ -591,7 +597,11 @@ namespace hpx {
             typename Op,
             HPX_CONCEPT_REQUIRES_(
                 hpx::traits::is_iterator_v<InIter> &&
-                hpx::traits::is_iterator_v<OutIter>
+                hpx::traits::is_iterator_v<OutIter> &&
+                hpx::is_invocable_v<Op,
+                    typename std::iterator_traits<InIter>::value_type,
+                    typename std::iterator_traits<InIter>::value_type
+                >
             )>
         // clang-format on
         friend OutIter tag_fallback_dispatch(hpx::exclusive_scan_t,
@@ -615,8 +625,12 @@ namespace hpx {
             typename T, typename Op,
             HPX_CONCEPT_REQUIRES_(
                 hpx::is_execution_policy<ExPolicy>::value &&
-                hpx::traits::is_forward_iterator_v<FwdIter1> &&
-                hpx::traits::is_forward_iterator_v<FwdIter2>
+                hpx::traits::is_iterator_v<FwdIter1> &&
+                hpx::traits::is_iterator_v<FwdIter2> &&
+                hpx::is_invocable_v<Op,
+                    typename std::iterator_traits<FwdIter1>::value_type,
+                    typename std::iterator_traits<FwdIter1>::value_type
+                >
             )>
         // clang-format on
         friend typename parallel::util::detail::algorithm_result<ExPolicy,

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/exclusive_scan.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/exclusive_scan.hpp
@@ -191,8 +191,8 @@ namespace hpx {
     /// \a inclusive_scan may be non-deterministic.
     ///
     template <typename InIter, typename OutIter,typename T, typename Op>
-    FwdIter2 exclusive_scan(ExPolicy&& policy, FwdIter1 first, FwdIter1 last,
-        FwdIter2 dest, T init, Op&& op);
+    OutIter exclusive_scan(InIter first, InIter last, OutIter dest,
+        T init, Op&& op);
 
         ///////////////////////////////////////////////////////////////////////////
     /// Assigns through each iterator \a i in [result, result + (last - first))
@@ -207,10 +207,10 @@ namespace hpx {
     ///                     It describes the manner in which the execution
     ///                     of the algorithm may be parallelized and the manner
     ///                     in which it executes the assignments.
-    /// \tparam InIter      The type of the source iterators used (deduced).
+    /// \tparam FwdIter1    The type of the source iterators used (deduced).
     ///                     This iterator type must meet the requirements of an
     ///                     forward iterator.
-    /// \tparam OutIter     The type of the iterator representing the
+    /// \tparam FwdIter2    The type of the iterator representing the
     ///                     destination range (deduced).
     ///                     This iterator type must meet the requirements of an
     ///                     forward iterator.
@@ -455,7 +455,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 hpx::traits::is_iterator<FwdIter2>::value
             )>
     // clang-format on
-    HPX_DEPRECATED_V(1, 8,
+    HPX_DEPRECATED_V(1, 7,
         "hpx::parallel::exclusive_scan is deprecated, use hpx::exclusive_scan "
         "instead")
         typename util::detail::algorithm_result<ExPolicy, FwdIter2>::type
@@ -488,7 +488,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 hpx::traits::is_iterator<FwdIter2>::value
             )>
     // clang-format on
-    HPX_DEPRECATED_V(1, 8,
+    HPX_DEPRECATED_V(1, 7,
         "hpx::parallel::exclusive_scan is deprecated, use hpx::exclusive_scan "
         "instead")
         typename util::detail::algorithm_result<ExPolicy, FwdIter2>::type

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/exclusive_scan.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/exclusive_scan.hpp
@@ -13,357 +13,532 @@
 
 namespace hpx { namespace ranges {
 
-    /// Checks if the first range [first1, last1) is lexicographically less than
-    /// the second range [first2, last2). uses a provided predicate to compare
-    /// elements.
+    ///////////////////////////////////////////////////////////////////////////
+    /// Assigns through each iterator \a i in [result, result + (last - first))
+    /// the value of
+    /// GENERALIZED_NONCOMMUTATIVE_SUM(+, init, *first, ...,
+    /// *(first + (i - result) - 1))
     ///
-    /// \note   Complexity: At most 2 * min(N1, N2) applications of the comparison
-    ///         operation, where N1 = std::distance(first1, last)
-    ///         and N2 = std::distance(first2, last2).
+    /// \note   Complexity: O(\a last - \a first) applications of the
+    ///         predicate \a std::plus<T>.
     ///
-    /// \tparam InIter1     The type of the source iterators used for the
-    ///                     first range (deduced).
+    /// \tparam InIter      The type of the source iterators used (deduced).
     ///                     This iterator type must meet the requirements of an
     ///                     input iterator.
-    /// \tparam Sent1       The type of the source sentinel (deduced). This
-    ///                     sentinel type must be a sentinel for InIter1.
-    /// \tparam InIter2     The type of the source iterators used for the
-    ///                     second range (deduced).
+    /// \tparam Sent        The type of the source sentinel (deduced). This
+    ///                     sentinel type must be a sentinel for InIter.
+    /// \tparam OutIter     The type of the iterator representing the
+    ///                     destination range (deduced).
     ///                     This iterator type must meet the requirements of an
-    ///                     input iterator.
-    /// \tparam Sent2       The type of the source sentinel (deduced). This
-    ///                     sentinel type must be a sentinel for InIter2.
-    /// \tparam Pred        The type of an optional function/function object to use.
-    ///                     Unlike its sequential form, the parallel
-    ///                     overload of \a exclusive_scan requires \a Pred to
-    ///                     meet the requirements of \a CopyConstructible. This defaults
-    ///                     to std::less<>
-    /// \tparam Proj1       The type of an optional projection function for FwdIter1. This
-    ///                     defaults to \a util::projection_identity
-    /// \tparam Proj2       The type of an optional projection function for FwdIter2. This
-    ///                     defaults to \a util::projection_identity
+    ///                     output iterator.
+    /// \tparam T           The type of the value to be used as initial (and
+    ///                     intermediate) values (deduced).
     ///
-    /// \param first1       Refers to the beginning of the sequence of elements
-    ///                     of the first range the algorithm will be applied to.
-    /// \param last1        Refers to the end of the sequence of elements of
-    ///                     the first range the algorithm will be applied to.
-    /// \param first2       Refers to the beginning of the sequence of elements
-    ///                     of the second range the algorithm will be applied to.
-    /// \param last2        Refers to the end of the sequence of elements of
-    ///                     the second range the algorithm will be applied to.
-    /// \param pred         Refers to the comparison function that the first
-    ///                     and second ranges will be applied to
-    /// \param proj1        Specifies the function (or function object) which
-    ///                     will be invoked for each of the elements of the first range
-    ///                     as a projection operation before the actual predicate
-    ///                     \a is invoked.
-    /// \param proj2        Specifies the function (or function object) which
-    ///                     will be invoked for each of the elements of the second range
-    ///                     as a projection operation before the actual predicate
-    ///                     \a is invoked.
+    /// \param first        Refers to the beginning of the sequence of elements
+    ///                     the algorithm will be applied to.
+    /// \param last         Refers to sentinel value denoting the end of the
+    ///                     sequence of elements the algorithm will be applied.
+    /// \param dest         Refers to the beginning of the destination range.
+    /// \param init         The initial value for the generalized sum.
     ///
-    /// The comparison operations in the parallel \a exclusive_scan
-    /// algorithm invoked with an execution policy object of type
-    /// \a sequenced_policy execute in sequential order in the
-    /// calling thread.
-    ///
-    /// The comparison operations in the parallel \a exclusive_scan
-    /// algorithm invoked with an execution policy object of type
-    /// \a parallel_policy
-    /// or \a parallel_task_policy are permitted to execute in an unordered
-    /// fashion in unspecified threads, and indeterminately sequenced
-    /// within each thread.
-    ///
-    /// \note     Lexicographical comparison is an operation with the
-    ///           following properties
-    ///             - Two ranges are compared element by element
-    ///             - The first mismatching element defines which range
-    ///               is lexicographically
-    ///               \a less or \a greater than the other
-    ///             - If one range is a prefix of another, the shorter range is
-    ///               lexicographically \a less than the other
-    ///             - If two ranges have equivalent elements and are of the same length,
-    ///               then the ranges are lexicographically \a equal
-    ///             - An empty range is lexicographically \a less than any non-empty
-    ///               range
-    ///             - Two empty ranges are lexicographically \a equal
-    ///
-    /// \returns  The \a lexicographically_compare algorithm returns a
-    ///           \a hpx::future<bool> if the execution policy is of type
-    ///           \a sequenced_task_policy or
-    ///           \a parallel_task_policy and
-    ///           returns \a bool otherwise.
-    ///           The \a lexicographically_compare algorithm returns true
-    ///           if the first range is lexicographically less, otherwise
-    ///           it returns false.
-    ///           range [first2, last2), it returns false.
-    template <typename InIter1, typename Sent1, typename InIter2,
-        typename Sent2,
-        typename Proj1 = hpx::parallel::util::projection_identity,
-        typename Proj2 = hpx::parallel::util::projection_identity,
-        typename Pred = detail::less>
-    bool exclusive_scan(InIter1 first1, Sent1 last1, InIter2 first2,
-        Sent2 last2, Pred&& pred = Pred(), Proj1&& proj1 = Proj1(),
-        Proj2&& proj2 = Proj2());
-
-    /// Checks if the first range [first1, last1) is lexicographically less than
-    /// the second range [first2, last2). uses a provided predicate to compare
-    /// elements.
-    ///
-    /// \note   Complexity: At most 2 * min(N1, N2) applications of the comparison
-    ///         operation, where N1 = std::distance(first1, last)
-    ///         and N2 = std::distance(first2, last2).
-    ///
-    /// \tparam ExPolicy    The type of the execution policy to use (deduced).
-    ///                     It describes the manner in which the execution
-    ///                     of the algorithm may be parallelized and the manner
-    ///                     in which it executes the assignments.
-    /// \tparam FwdIter1    The type of the source iterators used for the
-    ///                     first range (deduced).
-    ///                     This iterator type must meet the requirements of an
-    ///                     forward iterator.
-    /// \tparam Sent1       The type of the source sentinel (deduced). This
-    ///                     sentinel type must be a sentinel for FwdIter1.
-    /// \tparam FwdIter2    The type of the source iterators used for the
-    ///                     second range (deduced).
-    ///                     This iterator type must meet the requirements of an
-    ///                     forward iterator.
-    /// \tparam Sent2       The type of the source sentinel (deduced). This
-    ///                     sentinel type must be a sentinel for FwdIter2.
-    /// \tparam Pred        The type of an optional function/function object to use.
-    ///                     Unlike its sequential form, the parallel
-    ///                     overload of \a exclusive_scan requires \a Pred to
-    ///                     meet the requirements of \a CopyConstructible. This defaults
-    ///                     to std::less<>
-    /// \tparam Proj1       The type of an optional projection function for FwdIter1. This
-    ///                     defaults to \a util::projection_identity
-    /// \tparam Proj2       The type of an optional projection function for FwdIter2. This
-    ///                     defaults to \a util::projection_identity
-    ///
-    /// \param policy       The execution policy to use for the scheduling of
-    ///                     the iterations.
-    /// \param first1       Refers to the beginning of the sequence of elements
-    ///                     of the first range the algorithm will be applied to.
-    /// \param last1        Refers to the end of the sequence of elements of
-    ///                     the first range the algorithm will be applied to.
-    /// \param first2       Refers to the beginning of the sequence of elements
-    ///                     of the second range the algorithm will be applied to.
-    /// \param last2        Refers to the end of the sequence of elements of
-    ///                     the second range the algorithm will be applied to.
-    /// \param pred         Refers to the comparison function that the first
-    ///                     and second ranges will be applied to
-    /// \param proj1        Specifies the function (or function object) which
-    ///                     will be invoked for each of the elements of the first range
-    ///                     as a projection operation before the actual predicate
-    ///                     \a is invoked.
-    /// \param proj2        Specifies the function (or function object) which
-    ///                     will be invoked for each of the elements of the second range
-    ///                     as a projection operation before the actual predicate
-    ///                     \a is invoked.
-    ///
-    /// The comparison operations in the parallel \a exclusive_scan
-    /// algorithm invoked with an execution policy object of type
-    /// \a sequenced_policy execute in sequential order in the
-    /// calling thread.
-    ///
-    /// The comparison operations in the parallel \a exclusive_scan
-    /// algorithm invoked with an execution policy object of type
-    /// \a parallel_policy
-    /// or \a parallel_task_policy are permitted to execute in an unordered
-    /// fashion in unspecified threads, and indeterminately sequenced
-    /// within each thread.
-    ///
-    /// \note     Lexicographical comparison is an operation with the
-    ///           following properties
-    ///             - Two ranges are compared element by element
-    ///             - The first mismatching element defines which range
-    ///               is lexicographically
-    ///               \a less or \a greater than the other
-    ///             - If one range is a prefix of another, the shorter range is
-    ///               lexicographically \a less than the other
-    ///             - If two ranges have equivalent elements and are of the same length,
-    ///               then the ranges are lexicographically \a equal
-    ///             - An empty range is lexicographically \a less than any non-empty
-    ///               range
-    ///             - Two empty ranges are lexicographically \a equal
-    ///
-    /// \returns  The \a lexicographically_compare algorithm returns a
-    ///           \a hpx::future<bool> if the execution policy is of type
-    ///           \a sequenced_task_policy or
-    ///           \a parallel_task_policy and
-    ///           returns \a bool otherwise.
-    ///           The \a lexicographically_compare algorithm returns true
-    ///           if the first range is lexicographically less, otherwise
-    ///           it returns false.
-    ///           range [first2, last2), it returns false.
-
-    template <typename ExPolicy, typename FwdIter1, typename Sent1,
-        typename FwdIter2, typename Sent2,
-        typename Proj1 = hpx::parallel::util::projection_identity,
-        typename Proj2 = hpx::parallel::util::projection_identity,
-        typename Pred = detail::less>
-    typename parallel::util::detail::algorithm_result<ExPolicy, bool>::type
-    exclusive_scan(ExPolicy&& policy, FwdIter1 first1, Sent1 last1,
-        FwdIter2 first2, Sent2 last2, Pred&& pred = Pred(),
-        Proj1&& proj1 = Proj1(), Proj2&& proj2 = Proj2());
-
-    /// Checks if the first range rng1 is lexicographically less than
-    /// the second range rng2. uses a provided predicate to compare
-    /// elements.
-    ///
-    /// \note   Complexity: At most 2 * min(N1, N2) applications of the comparison
-    ///         operation, where N1 = std::distance(std::begin(rng1), std::end(rng1))
-    ///         and N2 = std::distance(std::begin(rng2), std::end(rng2)).
-    ///
-    /// \tparam Rng1        The type of the source range used (deduced).
-    ///                     The iterators extracted from this range type must
-    ///                     meet the requirements of an input iterator.
-    /// \tparam Rng2        The type of the source range used (deduced).
-    ///                     The iterators extracted from this range type must
-    ///                     meet the requirements of an input iterator.
-    /// \tparam Pred        The type of an optional function/function object to use.
-    ///                     Unlike its sequential form, the parallel
-    ///                     overload of \a exclusive_scan requires \a Pred to
-    ///                     meet the requirements of \a CopyConstructible. This defaults
-    ///                     to std::less<>
-    /// \tparam Proj1       The type of an optional projection function for elements of the first range.
-    ///                     This defaults to \a util::projection_identity
-    /// \tparam Proj2       The type of an optional projection function for elements of the second range.
-    ///                     This defaults to \a util::projection_identity
-    ///
-    /// \param rng1         Refers to the sequence of elements the algorithm
-    ///                     will be applied to.
-    /// \param rng2         Refers to the sequence of elements the algorithm
-    ///                     will be applied to.
-    /// \param pred         Refers to the comparison function that the first
-    ///                     and second ranges will be applied to
-    /// \param proj1        Specifies the function (or function object) which
-    ///                     will be invoked for each of the elements of the first range
-    ///                     as a projection operation before the actual predicate
-    ///                     \a is invoked.
-    /// \param proj2        Specifies the function (or function object) which
-    ///                     will be invoked for each of the elements of the second range
-    ///                     as a projection operation before the actual predicate
-    ///                     \a is invoked.
-    ///
-    /// The comparison operations in the parallel \a exclusive_scan
-    /// algorithm invoked without an execution policy object  execute in sequential
+    /// The reduce operations in the parallel \a exclusive_scan algorithm
+    /// invoked without an execution policy object will execute in sequential
     /// order in the calling thread.
     ///
-    /// \note     Lexicographical comparison is an operation with the
-    ///           following properties
-    ///             - Two ranges are compared element by element
-    ///             - The first mismatching element defines which range
-    ///               is lexicographically
-    ///               \a less or \a greater than the other
-    ///             - If one range is a prefix of another, the shorter range is
-    ///               lexicographically \a less than the other
-    ///             - If two ranges have equivalent elements and are of the same length,
-    ///               then the ranges are lexicographically \a equal
-    ///             - An empty range is lexicographically \a less than any non-empty
-    ///               range
-    ///             - Two empty ranges are lexicographically \a equal
+    /// \returns  The \a exclusive_scan algorithm returns \a OutIter.
+    ///           The \a exclusive_scan algorithm returns the output iterator
+    ///           to the element in the destination range, one past the last
+    ///           element copied.
     ///
-    /// \returns  The \a lexicographically_compare algorithm returns \a bool.
-    ///           The \a lexicographically_compare algorithm returns true
-    ///           if the first range is lexicographically less, otherwise
-    ///           it returns false.
-    ///           range [first2, last2), it returns false.
-    template <typename Rng1, typename Rng2,
-        typename Proj1 = hpx::parallel::util::projection_identity,
-        typename Proj2 = hpx::parallel::util::projection_identity,
-        typename Pred = detail::less>
-    bool exclusive_scan(Rng1&& rng1, Rng2&& rng2, Pred&& pred = Pred(),
-        Proj1&& proj1 = Proj1(), Proj2&& proj2 = Proj2());
+    /// \note   GENERALIZED_NONCOMMUTATIVE_SUM(+, a1, ..., aN) is defined as:
+    ///         * a1 when N is 1
+    ///         * GENERALIZED_NONCOMMUTATIVE_SUM(+, a1, ..., aK)
+    ///           + GENERALIZED_NONCOMMUTATIVE_SUM(+, aM, ..., aN)
+    ///           where 1 < K+1 = M <= N.
+    ///
+    /// The difference between \a exclusive_scan and \a inclusive_scan is that
+    /// \a inclusive_scan includes the ith input element in the ith sum.
+    ///
+    template <typename InIter, typename Sent, typename OutIter, typename T>
+    OutIter exclusive_scan(InIter first, Sent last, OutIter dest, T init);
 
-    /// Checks if the first range rng1 is lexicographically less than
-    /// the second range rng2. uses a provided predicate to compare
-    /// elements.
+    ///////////////////////////////////////////////////////////////////////////
+    /// Assigns through each iterator \a i in [result, result + (last - first))
+    /// the value of
+    /// GENERALIZED_NONCOMMUTATIVE_SUM(+, init, *first, ...,
+    /// *(first + (i - result) - 1))
     ///
-    /// \note   Complexity: At most 2 * min(N1, N2) applications of the comparison
-    ///         operation, where N1 = std::distance(std::begin(rng1), std::end(rng1))
-    ///         and N2 = std::distance(std::begin(rng2), std::end(rng2)).
+    /// \note   Complexity: O(\a last - \a first) applications of the
+    ///         predicate \a std::plus<T>.
     ///
     /// \tparam ExPolicy    The type of the execution policy to use (deduced).
     ///                     It describes the manner in which the execution
     ///                     of the algorithm may be parallelized and the manner
     ///                     in which it executes the assignments.
-    /// \tparam Rng1        The type of the source range used (deduced).
-    ///                     The iterators extracted from this range type must
-    ///                     meet the requirements of an input iterator.
-    /// \tparam Rng2        The type of the source range used (deduced).
-    ///                     The iterators extracted from this range type must
-    ///                     meet the requirements of an input iterator.
-    /// \tparam Pred        The type of an optional function/function object to use.
-    ///                     Unlike its sequential form, the parallel
-    ///                     overload of \a exclusive_scan requires \a Pred to
-    ///                     meet the requirements of \a CopyConstructible. This defaults
-    ///                     to std::less<>
-    /// \tparam Proj1       The type of an optional projection function for elements of the first range.
-    ///                     This defaults to \a util::projection_identity
-    /// \tparam Proj2       The type of an optional projection function for elements of the second range.
-    ///                     This defaults to \a util::projection_identity
+    /// \tparam FwdIter1    The type of the source iterators used (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     forward iterator.
+    /// \tparam Sent        The type of the source sentinel (deduced). This
+    ///                     sentinel type must be a sentinel for FwdIter.
+    /// \tparam FwdIter2    The type of the iterator representing the
+    ///                     destination range (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     forward iterator.
+    /// \tparam T           The type of the value to be used as initial (and
+    ///                     intermediate) values (deduced).
     ///
     /// \param policy       The execution policy to use for the scheduling of
     ///                     the iterations.
-    /// \param rng1         Refers to the sequence of elements the algorithm
-    ///                     will be applied to.
-    /// \param rng2         Refers to the sequence of elements the algorithm
-    ///                     will be applied to.
-    /// \param pred         Refers to the comparison function that the first
-    ///                     and second ranges will be applied to
-    /// \param proj1        Specifies the function (or function object) which
-    ///                     will be invoked for each of the elements of the first range
-    ///                     as a projection operation before the actual predicate
-    ///                     \a is invoked.
-    /// \param proj2        Specifies the function (or function object) which
-    ///                     will be invoked for each of the elements of the second range
-    ///                     as a projection operation before the actual predicate
-    ///                     \a is invoked.
+    /// \param first        Refers to the beginning of the sequence of elements
+    ///                     the algorithm will be applied to.
+    /// \param last         Refers to sentinel value denoting the end of the
+    ///                     sequence of elements the algorithm will be applied.
+    /// \param dest         Refers to the beginning of the destination range.
+    /// \param init         The initial value for the generalized sum.
     ///
-    /// The comparison operations in the parallel \a exclusive_scan
-    /// algorithm invoked with an execution policy object of type
-    /// \a sequenced_policy execute in sequential order in the
-    /// calling thread.
+    /// The reduce operations in the parallel \a exclusive_scan algorithm
+    /// invoked with an execution policy object of type \a sequenced_policy
+    /// execute in sequential order in the calling thread.
     ///
-    /// The comparison operations in the parallel \a exclusive_scan
-    /// algorithm invoked with an execution policy object of type
-    /// \a parallel_policy
+    /// The reduce operations in the parallel \a exclusive_scan algorithm
+    /// invoked with an execution policy object of type \a parallel_policy
     /// or \a parallel_task_policy are permitted to execute in an unordered
     /// fashion in unspecified threads, and indeterminately sequenced
     /// within each thread.
     ///
-    /// \note     Lexicographical comparison is an operation with the
-    ///           following properties
-    ///             - Two ranges are compared element by element
-    ///             - The first mismatching element defines which range
-    ///               is lexicographically
-    ///               \a less or \a greater than the other
-    ///             - If one range is a prefix of another, the shorter range is
-    ///               lexicographically \a less than the other
-    ///             - If two ranges have equivalent elements and are of the same length,
-    ///               then the ranges are lexicographically \a equal
-    ///             - An empty range is lexicographically \a less than any non-empty
-    ///               range
-    ///             - Two empty ranges are lexicographically \a equal
-    ///
-    /// \returns  The \a lexicographically_compare algorithm returns a
-    ///           \a hpx::future<bool> if the execution policy is of type
+    /// \returns  The \a exclusive_scan algorithm returns a
+    ///           \a hpx::future<FwdIter2> if
+    ///           the execution policy is of type
     ///           \a sequenced_task_policy or
     ///           \a parallel_task_policy and
-    ///           returns \a bool otherwise.
-    ///           The \a lexicographically_compare algorithm returns true
-    ///           if the first range is lexicographically less, otherwise
-    ///           it returns false.
-    ///           range [first2, last2), it returns false.
+    ///           returns \a FwdIter2 otherwise.
+    ///           The \a exclusive_scan algorithm returns the output iterator
+    ///           to the element in the destination range, one past the last
+    ///           element copied.
+    ///
+    /// \note   GENERALIZED_NONCOMMUTATIVE_SUM(+, a1, ..., aN) is defined as:
+    ///         * a1 when N is 1
+    ///         * GENERALIZED_NONCOMMUTATIVE_SUM(+, a1, ..., aK)
+    ///           + GENERALIZED_NONCOMMUTATIVE_SUM(+, aM, ..., aN)
+    ///           where 1 < K+1 = M <= N.
+    ///
+    /// The difference between \a exclusive_scan and \a inclusive_scan is that
+    /// \a inclusive_scan includes the ith input element in the ith sum.
+    ///
+    template <typename ExPolicy, typename FwdIter1, typename Sent,
+        typename FwdIter2, typename T>
+    typename util::detail::algorithm_result<ExPolicy, FwdIter2>::type
+    exclusive_scan(
+        ExPolicy&& policy, FwdIter1 first, Sent last, FwdIter2 dest, T init);
 
-    template <typename ExPolicy, typename Rng1, typename Rng2,
-        typename Proj1 = hpx::parallel::util::projection_identity,
-        typename Proj2 = hpx::parallel::util::projection_identity,
-        typename Pred = detail::less>
-    typename parallel::util::detail::algorithm_result<ExPolicy, bool>::type
-    exclusive_scan(ExPolicy&& policy, Rng1&& rng1, Rng2&& rng2,
-        Pred&& pred = Pred(), Proj1&& proj1 = Proj1(), Proj2&& proj2 = Proj2());
+    ///////////////////////////////////////////////////////////////////////////
+    /// Assigns through each iterator \a i in [result, result + (last - first))
+    /// the value of
+    /// GENERALIZED_NONCOMMUTATIVE_SUM(binary_op, init, *first, ...,
+    /// *(first + (i - result) - 1)).
+    ///
+    /// \note   Complexity: O(\a last - \a first) applications of the
+    ///         predicate \a op.
+    ///
+    /// \tparam InIter      The type of the source iterators used (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     input iterator.
+    /// \tparam Sent        The type of the source sentinel (deduced). This
+    ///                     sentinel type must be a sentinel for InIter.
+    /// \tparam OutIter     The type of the iterator representing the
+    ///                     destination range (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     output iterator.
+    /// \tparam T           The type of the value to be used as initial (and
+    ///                     intermediate) values (deduced).
+    /// \tparam Op          The type of the binary function object used for
+    ///                     the reduction operation.
+    ///
+    /// \param first        Refers to the beginning of the sequence of elements
+    ///                     the algorithm will be applied to.
+    /// \param last         Refers to sentinel value denoting the end of the
+    ///                     sequence of elements the algorithm will be applied.
+    /// \param dest         Refers to the beginning of the destination range.
+    /// \param init         The initial value for the generalized sum.
+    /// \param op           Specifies the function (or function object) which
+    ///                     will be invoked for each of the values of the input
+    ///                     sequence. This is a
+    ///                     binary predicate. The signature of this predicate
+    ///                     should be equivalent to:
+    ///                     \code
+    ///                     Ret fun(const Type1 &a, const Type1 &b);
+    ///                     \endcode \n
+    ///                     The signature does not need to have const&, but
+    ///                     the function must not modify the objects passed to
+    ///                     it.
+    ///                     The types \a Type1 and \a Ret must be
+    ///                     such that an object of a type as given by the input
+    ///                     sequence can be implicitly converted to any
+    ///                     of those types.
+    ///
+    /// The reduce operations in the parallel \a exclusive_scan algorithm
+    /// invoked without an execution policy object will execute in sequential
+    /// order in the calling thread.
+    ///
+    /// \returns  The \a exclusive_scan algorithm returns \a OutIter.
+    ///           The \a exclusive_scan algorithm returns the output iterator
+    ///           to the element in the destination range, one past the last
+    ///           element copied.
+    ///
+    /// \note   GENERALIZED_NONCOMMUTATIVE_SUM(op, a1, ..., aN) is defined as:
+    ///         * a1 when N is 1
+    ///         * op(GENERALIZED_NONCOMMUTATIVE_SUM(op, a1, ..., aK),
+    ///           GENERALIZED_NONCOMMUTATIVE_SUM(op, aM, ..., aN))
+    ///           where 1 < K+1 = M <= N.
+    ///
+    /// The difference between \a exclusive_scan and \a inclusive_scan is that
+    /// \a inclusive_scan includes the ith input element in the ith sum. If
+    /// \a op is not mathematically associative, the behavior of
+    /// \a inclusive_scan may be non-deterministic.
+    ///
+    template <typename InIter, typename Sent, typename OutIter, typename T,
+        typename Op>
+    OutIter exclusive_scan(
+        InIter first, Sent last, OutIter dest, T init, Op&& op);
+
+    ///////////////////////////////////////////////////////////////////////////
+    /// Assigns through each iterator \a i in [result, result + (last - first))
+    /// the value of
+    /// GENERALIZED_NONCOMMUTATIVE_SUM(binary_op, init, *first, ...,
+    /// *(first + (i - result) - 1)).
+    ///
+    /// \note   Complexity: O(\a last - \a first) applications of the
+    ///         predicate \a op.
+    ///
+    /// \tparam ExPolicy    The type of the execution policy to use (deduced).
+    ///                     It describes the manner in which the execution
+    ///                     of the algorithm may be parallelized and the manner
+    ///                     in which it executes the assignments.
+    /// \tparam FwdIter1    The type of the source iterators used (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     forward iterator.
+    /// \tparam Sent        The type of the source sentinel (deduced). This
+    ///                     sentinel type must be a sentinel for FwdIter1.
+    /// \tparam FwdIter2    The type of the iterator representing the
+    ///                     destination range (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     forward iterator.
+    /// \tparam T           The type of the value to be used as initial (and
+    ///                     intermediate) values (deduced).
+    /// \tparam Op          The type of the binary function object used for
+    ///                     the reduction operation.
+    ///
+    /// \param policy       The execution policy to use for the scheduling of
+    ///                     the iterations.
+    /// \param first        Refers to the beginning of the sequence of elements
+    ///                     the algorithm will be applied to.
+    /// \param last         Refers to sentinel value denoting the end of the
+    ///                     sequence of elements the algorithm will be applied.
+    /// \param dest         Refers to the beginning of the destination range.
+    /// \param init         The initial value for the generalized sum.
+    /// \param op           Specifies the function (or function object) which
+    ///                     will be invoked for each of the values of the input
+    ///                     sequence. This is a
+    ///                     binary predicate. The signature of this predicate
+    ///                     should be equivalent to:
+    ///                     \code
+    ///                     Ret fun(const Type1 &a, const Type1 &b);
+    ///                     \endcode \n
+    ///                     The signature does not need to have const&, but
+    ///                     the function must not modify the objects passed to
+    ///                     it.
+    ///                     The types \a Type1 and \a Ret must be
+    ///                     such that an object of a type as given by the input
+    ///                     sequence can be implicitly converted to any
+    ///                     of those types.
+    ///
+    /// The reduce operations in the parallel \a exclusive_scan algorithm
+    /// invoked with an execution policy object of type \a sequenced_policy
+    /// execute in sequential order in the calling thread.
+    ///
+    /// The reduce operations in the parallel \a exclusive_scan algorithm
+    /// invoked with an execution policy object of type \a parallel_policy
+    /// or \a parallel_task_policy are permitted to execute in an unordered
+    /// fashion in unspecified threads, and indeterminately sequenced
+    /// within each thread.
+    ///
+    /// \returns  The \a exclusive_scan algorithm returns a
+    ///           \a hpx::future<OutIter> if
+    ///           the execution policy is of type
+    ///           \a sequenced_task_policy or
+    ///           \a parallel_task_policy and
+    ///           returns \a OutIter otherwise.
+    ///           The \a exclusive_scan algorithm returns the output iterator
+    ///           to the element in the destination range, one past the last
+    ///           element copied.
+    ///
+    /// \note   GENERALIZED_NONCOMMUTATIVE_SUM(op, a1, ..., aN) is defined as:
+    ///         * a1 when N is 1
+    ///         * op(GENERALIZED_NONCOMMUTATIVE_SUM(op, a1, ..., aK),
+    ///           GENERALIZED_NONCOMMUTATIVE_SUM(op, aM, ..., aN))
+    ///           where 1 < K+1 = M <= N.
+    ///
+    /// The difference between \a exclusive_scan and \a inclusive_scan is that
+    /// \a inclusive_scan includes the ith input element in the ith sum. If
+    /// \a op is not mathematically associative, the behavior of
+    /// \a inclusive_scan may be non-deterministic.
+    ///
+    template <typename ExPolicy, typename FwdIter1, typename Sent,
+        typename FwdIter2, typename T, typename Op>
+    typename util::detail::algorithm_result<ExPolicy, FwdIter2>::type
+    exclusive_scan(ExPolicy&& policy, FwdIter1 first, Sent last, FwdIter2 dest,
+        T init, Op&& op);
+
+    ///////////////////////////////////////////////////////////////////////////
+    /// Assigns through each iterator \a i in [result, result + (last - first))
+    /// the value of
+    /// GENERALIZED_NONCOMMUTATIVE_SUM(+, init, *first, ...,
+    /// *(first + (i - result) - 1))
+    ///
+    /// \note   Complexity: O(\a last - \a first) applications of the
+    ///         predicate \a std::plus<T>.
+    ///
+    /// \tparam Rng         The type of the source range used (deduced).
+    ///                     The iterators extracted from this range type must
+    ///                     meet the requirements of an input iterator.
+    /// \tparam O           The type of the iterator representing the
+    ///                     destination range (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     output iterator.
+    /// \tparam T           The type of the value to be used as initial (and
+    ///                     intermediate) values (deduced).
+    ///
+    /// \param rng          Refers to the sequence of elements the algorithm
+    ///                     will be applied to.
+    /// \param dest         Refers to the beginning of the destination range.
+    /// \param init         The initial value for the generalized sum.
+    ///
+    /// The reduce operations in the parallel \a exclusive_scan algorithm
+    /// invoked without an execution policy object will execute in sequential
+    /// order in the calling thread.
+    ///
+    /// \returns  The \a exclusive_scan algorithm returns \a O.
+    ///           The \a exclusive_scan algorithm returns the output iterator
+    ///           to the element in the destination range, one past the last
+    ///           element copied.
+    ///
+    /// \note   GENERALIZED_NONCOMMUTATIVE_SUM(+, a1, ..., aN) is defined as:
+    ///         * a1 when N is 1
+    ///         * GENERALIZED_NONCOMMUTATIVE_SUM(+, a1, ..., aK)
+    ///           + GENERALIZED_NONCOMMUTATIVE_SUM(+, aM, ..., aN)
+    ///           where 1 < K+1 = M <= N.
+    ///
+    /// The difference between \a exclusive_scan and \a inclusive_scan is that
+    /// \a inclusive_scan includes the ith input element in the ith sum.
+    ///
+    template <typename Rng, typename O, typename T>
+    O exclusive_scan(Rng&& rng, O dest, T init);
+
+    ///////////////////////////////////////////////////////////////////////////
+    /// Assigns through each iterator \a i in [result, result + (last - first))
+    /// the value of
+    /// GENERALIZED_NONCOMMUTATIVE_SUM(+, init, *first, ...,
+    /// *(first + (i - result) - 1))
+    ///
+    /// \note   Complexity: O(\a last - \a first) applications of the
+    ///         predicate \a std::plus<T>.
+    ///
+    /// \tparam ExPolicy    The type of the execution policy to use (deduced).
+    ///                     It describes the manner in which the execution
+    ///                     of the algorithm may be parallelized and the manner
+    ///                     in which it executes the assignments.
+    /// \tparam Rng         The type of the source range used (deduced).
+    ///                     The iterators extracted from this range type must
+    ///                     meet the requirements of an forward iterator.
+    /// \tparam O           The type of the iterator representing the
+    ///                     destination range (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     forward iterator.
+    /// \tparam T           The type of the value to be used as initial (and
+    ///                     intermediate) values (deduced).
+    ///
+    /// \param policy       The execution policy to use for the scheduling of
+    ///                     the iterations.
+    /// \param rng          Refers to the sequence of elements the algorithm
+    ///                     will be applied to.
+    /// \param dest         Refers to the beginning of the destination range.
+    /// \param init         The initial value for the generalized sum.
+    ///
+    /// The reduce operations in the parallel \a exclusive_scan algorithm
+    /// invoked with an execution policy object of type \a sequenced_policy
+    /// execute in sequential order in the calling thread.
+    ///
+    /// The reduce operations in the parallel \a exclusive_scan algorithm
+    /// invoked with an execution policy object of type \a parallel_policy
+    /// or \a parallel_task_policy are permitted to execute in an unordered
+    /// fashion in unspecified threads, and indeterminately sequenced
+    /// within each thread.
+    ///
+    /// \returns  The \a exclusive_scan algorithm returns a
+    ///           \a hpx::future<O> if
+    ///           the execution policy is of type
+    ///           \a sequenced_task_policy or
+    ///           \a parallel_task_policy and
+    ///           returns \a O otherwise.
+    ///           The \a exclusive_scan algorithm returns the output iterator
+    ///           to the element in the destination range, one past the last
+    ///           element copied.
+    ///
+    /// \note   GENERALIZED_NONCOMMUTATIVE_SUM(+, a1, ..., aN) is defined as:
+    ///         * a1 when N is 1
+    ///         * GENERALIZED_NONCOMMUTATIVE_SUM(+, a1, ..., aK)
+    ///           + GENERALIZED_NONCOMMUTATIVE_SUM(+, aM, ..., aN)
+    ///           where 1 < K+1 = M <= N.
+    ///
+    /// The difference between \a exclusive_scan and \a inclusive_scan is that
+    /// \a inclusive_scan includes the ith input element in the ith sum.
+    ///
+    template <typename ExPolicy, typename Rng, typename O, typename T>
+    typename util::detail::algorithm_result<ExPolicy, O>::type exclusive_scan(
+        ExPolicy&& policy, Rng&& rng, O dest, T init);
+
+    ///////////////////////////////////////////////////////////////////////////
+    /// Assigns through each iterator \a i in [result, result + (last - first))
+    /// the value of
+    /// GENERALIZED_NONCOMMUTATIVE_SUM(+, init, *first, ...,
+    /// *(first + (i - result) - 1))
+    ///
+    /// \note   Complexity: O(\a last - \a first) applications of the
+    ///         predicate \a std::plus<T>.
+    ///
+    /// \tparam Rng         The type of the source range used (deduced).
+    ///                     The iterators extracted from this range type must
+    ///                     meet the requirements of an input iterator.
+    /// \tparam O           The type of the iterator representing the
+    ///                     destination range (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     output iterator.
+    /// \tparam T           The type of the value to be used as initial (and
+    ///                     intermediate) values (deduced).
+    /// \tparam Op          The type of the binary function object used for
+    ///                     the reduction operation.
+    ///
+    /// \param rng          Refers to the sequence of elements the algorithm
+    ///                     will be applied to.
+    /// \param dest         Refers to the beginning of the destination range.
+    /// \param init         The initial value for the generalized sum.
+    /// \param op           Specifies the function (or function object) which
+    ///                     will be invoked for each of the values of the input
+    ///                     sequence. This is a
+    ///                     binary predicate. The signature of this predicate
+    ///                     should be equivalent to:
+    ///                     \code
+    ///                     Ret fun(const Type1 &a, const Type1 &b);
+    ///                     \endcode \n
+    ///                     The signature does not need to have const&, but
+    ///                     the function must not modify the objects passed to
+    ///                     it.
+    ///                     The types \a Type1 and \a Ret must be
+    ///                     such that an object of a type as given by the input
+    ///                     sequence can be implicitly converted to any
+    ///                     of those types.
+    ///
+    /// The reduce operations in the parallel \a exclusive_scan algorithm
+    /// invoked without an execution policy object will execute in sequential
+    /// order in the calling thread.
+    ///
+    /// \returns  The \a exclusive_scan algorithm returns \a O.
+    ///           The \a exclusive_scan algorithm returns the output iterator
+    ///           to the element in the destination range, one past the last
+    ///           element copied.
+    ///
+    /// \note   GENERALIZED_NONCOMMUTATIVE_SUM(+, a1, ..., aN) is defined as:
+    ///         * a1 when N is 1
+    ///         * GENERALIZED_NONCOMMUTATIVE_SUM(+, a1, ..., aK)
+    ///           + GENERALIZED_NONCOMMUTATIVE_SUM(+, aM, ..., aN)
+    ///           where 1 < K+1 = M <= N.
+    ///
+    /// The difference between \a exclusive_scan and \a inclusive_scan is that
+    /// \a inclusive_scan includes the ith input element in the ith sum.
+    ///
+    template <typename Rng, typename O, typename T, typename Op>
+    O exclusive_scan(Rng&& rng, O dest, T init, Op&& op);
+
+    ///////////////////////////////////////////////////////////////////////////
+    /// Assigns through each iterator \a i in [result, result + (last - first))
+    /// the value of
+    /// GENERALIZED_NONCOMMUTATIVE_SUM(+, init, *first, ...,
+    /// *(first + (i - result) - 1))
+    ///
+    /// \note   Complexity: O(\a last - \a first) applications of the
+    ///         predicate \a std::plus<T>.
+    ///
+    /// \tparam ExPolicy    The type of the execution policy to use (deduced).
+    ///                     It describes the manner in which the execution
+    ///                     of the algorithm may be parallelized and the manner
+    ///                     in which it executes the assignments.
+    /// \tparam Rng         The type of the source range used (deduced).
+    ///                     The iterators extracted from this range type must
+    ///                     meet the requirements of an forward iterator.
+    /// \tparam O           The type of the iterator representing the
+    ///                     destination range (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     forward iterator.
+    /// \tparam T           The type of the value to be used as initial (and
+    ///                     intermediate) values (deduced).
+    /// \tparam Op          The type of the binary function object used for
+    ///                     the reduction operation.
+    ///
+    /// \param policy       The execution policy to use for the scheduling of
+    ///                     the iterations.
+    /// \param rng          Refers to the sequence of elements the algorithm
+    ///                     will be applied to.
+    /// \param dest         Refers to the beginning of the destination range.
+    /// \param init         The initial value for the generalized sum.
+    /// \param op           Specifies the function (or function object) which
+    ///                     will be invoked for each of the values of the input
+    ///                     sequence. This is a
+    ///                     binary predicate. The signature of this predicate
+    ///                     should be equivalent to:
+    ///                     \code
+    ///                     Ret fun(const Type1 &a, const Type1 &b);
+    ///                     \endcode \n
+    ///                     The signature does not need to have const&, but
+    ///                     the function must not modify the objects passed to
+    ///                     it.
+    ///                     The types \a Type1 and \a Ret must be
+    ///                     such that an object of a type as given by the input
+    ///                     sequence can be implicitly converted to any
+    ///                     of those types.
+    ///
+    /// The reduce operations in the parallel \a exclusive_scan algorithm
+    /// invoked with an execution policy object of type \a sequenced_policy
+    /// execute in sequential order in the calling thread.
+    ///
+    /// The reduce operations in the parallel \a exclusive_scan algorithm
+    /// invoked with an execution policy object of type \a parallel_policy
+    /// or \a parallel_task_policy are permitted to execute in an unordered
+    /// fashion in unspecified threads, and indeterminately sequenced
+    /// within each thread.
+    ///
+    /// \returns  The \a exclusive_scan algorithm returns a
+    ///           \a hpx::future<O> if
+    ///           the execution policy is of type
+    ///           \a sequenced_task_policy or
+    ///           \a parallel_task_policy and
+    ///           returns \a O otherwise.
+    ///           The \a exclusive_scan algorithm returns the output iterator
+    ///           to the element in the destination range, one past the last
+    ///           element copied.
+    ///
+    /// \note   GENERALIZED_NONCOMMUTATIVE_SUM(+, a1, ..., aN) is defined as:
+    ///         * a1 when N is 1
+    ///         * GENERALIZED_NONCOMMUTATIVE_SUM(+, a1, ..., aK)
+    ///           + GENERALIZED_NONCOMMUTATIVE_SUM(+, aM, ..., aN)
+    ///           where 1 < K+1 = M <= N.
+    ///
+    /// The difference between \a exclusive_scan and \a inclusive_scan is that
+    /// \a inclusive_scan includes the ith input element in the ith sum.
+    ///
+    template <typename ExPolicy, typename Rng, typename O, typename T,
+        typename Op>
+    typename util::detail::algorithm_result<ExPolicy, O>::type exclusive_scan(
+        ExPolicy&& policy, Rng&& rng, O dest, T init, Op&& op);
 }}    // namespace hpx::ranges
 #else
 

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/exclusive_scan.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/exclusive_scan.hpp
@@ -63,7 +63,7 @@ namespace hpx { namespace ranges {
     /// \a inclusive_scan includes the ith input element in the ith sum.
     ///
     template <typename InIter, typename Sent, typename OutIter, typename T>
-    parallel::util::in_out_result<InIter, OutIter> exclusive_scan(
+    exclusive_scan_result<InIter, OutIter> exclusive_scan(
         InIter first, Sent last, OutIter dest, T init);
 
     ///////////////////////////////////////////////////////////////////////////
@@ -133,7 +133,7 @@ namespace hpx { namespace ranges {
     template <typename ExPolicy, typename FwdIter1, typename Sent,
         typename FwdIter2, typename T>
     typename util::detail::algorithm_result<ExPolicy,
-        parallel::util::in_out_result<FwdIter1, FwdIter2>>::type
+        exclusive_scan_result<FwdIter1, FwdIter2>>::type
     exclusive_scan(
         ExPolicy&& policy, FwdIter1 first, Sent last, FwdIter2 dest, T init);
 
@@ -206,7 +206,7 @@ namespace hpx { namespace ranges {
     ///
     template <typename InIter, typename Sent, typename OutIter, typename T,
         typename Op>
-    parallel::util::in_out_result<InIter, OutIter> exclusive_scan(
+    exclusive_scan_result<InIter, OutIter> exclusive_scan(
         InIter first, Sent last, OutIter dest, T init, Op&& op);
 
     ///////////////////////////////////////////////////////////////////////////
@@ -295,7 +295,7 @@ namespace hpx { namespace ranges {
     template <typename ExPolicy, typename FwdIter1, typename Sent,
         typename FwdIter2, typename T, typename Op>
     typename util::detail::algorithm_result<ExPolicy,
-        parallel::util::in_out_result<FwdIter1, FwdIter2>>::type
+        exclusive_scan_result<FwdIter1, FwdIter2>>::type
     exclusive_scan(ExPolicy&& policy, FwdIter1 first, Sent last, FwdIter2 dest,
         T init, Op&& op);
 
@@ -327,8 +327,8 @@ namespace hpx { namespace ranges {
     /// invoked without an execution policy object will execute in sequential
     /// order in the calling thread.
     ///
-    /// \returns  The \a exclusive_scan algorithm returns \a util::in_out_result
-    ///           <typename hpx::traits::range_traits<Rng>::iterator_type, O>
+    /// \returns  The \a exclusive_scan algorithm returns
+    ///           \a util::in_out_result<traits::range_iterator_t<Rng>, O>
     ///           The \a exclusive_scan algorithm returns an input iterator to
     ///           the point denoted by the sentinel and an output iterator
     ///           to the element in the destination range, one past the last
@@ -344,9 +344,8 @@ namespace hpx { namespace ranges {
     /// \a inclusive_scan includes the ith input element in the ith sum.
     ///
     template <typename Rng, typename O, typename T>
-    parallel::util::in_out_result<
-        typename hpx::traits::range_traits<Rng>::iterator_type, O>
-    exclusive_scan(Rng&& rng, O dest, T init);
+    exclusive_scan_result<traits::range_iterator_t<Rng>, O> exclusive_scan(
+        Rng&& rng, O dest, T init);
 
     ///////////////////////////////////////////////////////////////////////////
     /// Assigns through each iterator \a i in [result, result + (last - first))
@@ -390,12 +389,12 @@ namespace hpx { namespace ranges {
     ///
     /// \returns  The \a exclusive_scan algorithm returns a
     ///           \a hpx::future<util::in_out_result
-    ///           <typename hpx::traits::range_traits<Rng>::iterator_type, O>>
+    ///           <traits::range_iterator_t<Rng>, O>>
     ///           if the execution policy is of type
     ///           \a sequenced_task_policy or
     ///           \a parallel_task_policy and
     ///           returns \a util::in_out_result
-    ///           <typename hpx::traits::range_traits<Rng>::iterator_type, O>
+    ///           <traits::range_iterator_t<Rng>, O>
     ///           otherwise.
     ///           The \a exclusive_scan algorithm returns an input iterator to
     ///           the point denoted by the sentinel and an output iterator
@@ -413,8 +412,7 @@ namespace hpx { namespace ranges {
     ///
     template <typename ExPolicy, typename Rng, typename O, typename T>
     typename util::detail::algorithm_result<ExPolicy,
-        parallel::util::in_out_result<
-            typename hpx::traits::range_traits<Rng>::iterator_type, O>>::type
+        exclusive_scan_result<traits::range_iterator_t<Rng>, O>>::type
     exclusive_scan(ExPolicy&& policy, Rng&& rng, O dest, T init);
 
     ///////////////////////////////////////////////////////////////////////////
@@ -462,8 +460,8 @@ namespace hpx { namespace ranges {
     /// invoked without an execution policy object will execute in sequential
     /// order in the calling thread.
     ///
-    /// \returns  The \a exclusive_scan algorithm returns \a util::in_out_result
-    ///           <typename hpx::traits::range_traits<Rng>::iterator_type, O>
+    /// \returns  The \a exclusive_scan algorithm returns
+    ///           \a util::in_out_result<traits::range_iterator_t<Rng>, O>
     ///           The \a exclusive_scan algorithm returns an input iterator to
     ///           the point denoted by the sentinel and an output iterator
     ///           to the element in the destination range, one past the last
@@ -479,9 +477,8 @@ namespace hpx { namespace ranges {
     /// \a inclusive_scan includes the ith input element in the ith sum.
     ///
     template <typename Rng, typename O, typename T, typename Op>
-    parallel::util::in_out_result<
-        typename hpx::traits::range_traits<Rng>::iterator_type, O>
-    exclusive_scan(Rng&& rng, O dest, T init, Op&& op);
+    exclusive_scan_result<traits::range_iterator_t<Rng>, O> exclusive_scan(
+        Rng&& rng, O dest, T init, Op&& op);
 
     ///////////////////////////////////////////////////////////////////////////
     /// Assigns through each iterator \a i in [result, result + (last - first))
@@ -542,12 +539,12 @@ namespace hpx { namespace ranges {
     ///
     /// \returns  The \a exclusive_scan algorithm returns a
     ///           \a hpx::future<util::in_out_result
-    ///           <typename hpx::traits::range_traits<Rng>::iterator_type, O>>
+    ///           <traits::range_iterator_t<Rng>, O>>
     ///           if the execution policy is of type
     ///           \a sequenced_task_policy or
     ///           \a parallel_task_policy and
     ///           returns \a util::in_out_result
-    ///           <typename hpx::traits::range_traits<Rng>::iterator_type, O>
+    ///           <traits::range_iterator_t<Rng>, O>
     ///           otherwise.
     ///           The \a exclusive_scan algorithm returns an input iterator to
     ///           the point denoted by the sentinel and an output iterator
@@ -566,8 +563,7 @@ namespace hpx { namespace ranges {
     template <typename ExPolicy, typename Rng, typename O, typename T,
         typename Op>
     typename util::detail::algorithm_result<ExPolicy,
-        parallel::util::in_out_result<
-            typename hpx::traits::range_traits<Rng>::iterator_type, O>>::type
+        exclusive_scan_result<traits::range_iterator_t<Rng>, O>>::type
     exclusive_scan(ExPolicy&& policy, Rng&& rng, O dest, T init, Op&& op);
 }}    // namespace hpx::ranges
 #else
@@ -578,6 +574,7 @@ namespace hpx { namespace ranges {
 #include <hpx/executors/execution_policy.hpp>
 #include <hpx/functional/tag_fallback_dispatch.hpp>
 #include <hpx/iterator_support/traits/is_iterator.hpp>
+#include <hpx/iterator_support/traits/is_range.hpp>
 #include <hpx/parallel/algorithms/exclusive_scan.hpp>
 #include <hpx/parallel/util/detail/algorithm_result.hpp>
 #include <hpx/parallel/util/projection_identity.hpp>
@@ -590,6 +587,10 @@ namespace hpx { namespace ranges {
 #include <vector>
 
 namespace hpx { namespace ranges {
+
+    template <typename I, typename O>
+    using exclusive_scan_result = parallel::util::in_out_result<I, O>;
+
     HPX_INLINE_CONSTEXPR_VARIABLE struct exclusive_scan_t final
       : hpx::functional::tag_fallback<exclusive_scan_t>
     {
@@ -600,19 +601,23 @@ namespace hpx { namespace ranges {
             HPX_CONCEPT_REQUIRES_(
                 hpx::traits::is_iterator_v<InIter> &&
                 hpx::traits::is_sentinel_for<Sent, InIter>::value &&
-                hpx::traits::is_iterator_v<OutIter>
+                hpx::traits::is_iterator_v<OutIter> &&
+                hpx::is_invocable_v<Op,
+                    typename std::iterator_traits<InIter>::value_type,
+                    typename std::iterator_traits<InIter>::value_type
+                >
             )>
         // clang-format on
-        friend parallel::util::in_out_result<InIter, OutIter>
-        tag_fallback_dispatch(hpx::ranges::exclusive_scan_t, InIter first,
-            Sent last, OutIter dest, T init, Op&& op = Op())
+        friend exclusive_scan_result<InIter, OutIter> tag_fallback_dispatch(
+            hpx::ranges::exclusive_scan_t, InIter first, Sent last,
+            OutIter dest, T init, Op&& op = Op())
         {
             static_assert(hpx::traits::is_input_iterator_v<InIter>,
                 "Requires at least input iterator.");
             static_assert(hpx::traits::is_output_iterator_v<OutIter>,
                 "Requires at least output iterator.");
 
-            using result_type = parallel::util::in_out_result<InIter, OutIter>;
+            using result_type = exclusive_scan_result<InIter, OutIter>;
 
             return hpx::parallel::v1::detail::exclusive_scan<result_type>()
                 .call(hpx::execution::seq, first, last, dest, std::move(init),
@@ -626,11 +631,15 @@ namespace hpx { namespace ranges {
                 hpx::is_execution_policy<ExPolicy>::value &&
                 hpx::traits::is_iterator_v<FwdIter1> &&
                 hpx::traits::is_sentinel_for<Sent, FwdIter1>::value &&
-                hpx::traits::is_iterator_v<FwdIter2>
+                hpx::traits::is_iterator_v<FwdIter2> &&
+                hpx::is_invocable_v<Op,
+                    typename std::iterator_traits<FwdIter1>::value_type,
+                    typename std::iterator_traits<FwdIter1>::value_type
+                >
             )>
         // clang-format on
         friend typename parallel::util::detail::algorithm_result<ExPolicy,
-            parallel::util::in_out_result<FwdIter1, FwdIter2>>::type
+            exclusive_scan_result<FwdIter1, FwdIter2>>::type
         tag_fallback_dispatch(hpx::ranges::exclusive_scan_t, ExPolicy&& policy,
             FwdIter1 first, Sent last, FwdIter2 dest, T init, Op&& op = Op())
         {
@@ -639,8 +648,7 @@ namespace hpx { namespace ranges {
             static_assert(hpx::traits::is_forward_iterator_v<FwdIter2>,
                 "Requires at least forward iterator.");
 
-            using result_type =
-                parallel::util::in_out_result<FwdIter1, FwdIter2>;
+            using result_type = exclusive_scan_result<FwdIter1, FwdIter2>;
 
             return hpx::parallel::v1::detail::exclusive_scan<result_type>()
                 .call(std::forward<ExPolicy>(policy), first, last, dest,
@@ -651,21 +659,23 @@ namespace hpx { namespace ranges {
         template <typename Rng, typename O, typename T,
             typename Op = std::plus<T>,
             HPX_CONCEPT_REQUIRES_(
-                hpx::traits::is_range<Rng>::value
+                hpx::traits::is_range<Rng>::value &&
+                hpx::is_invocable_v<Op,
+                    typename hpx::traits::range_traits<Rng>::value_type,
+                    typename hpx::traits::range_traits<Rng>::value_type
+                >
             )>
         // clang-format on
-        friend parallel::util::in_out_result<
-            typename hpx::traits::range_traits<Rng>::iterator_type, O>
+        friend exclusive_scan_result<traits::range_iterator_t<Rng>, O>
         tag_fallback_dispatch(hpx::ranges::exclusive_scan_t, Rng&& rng, O dest,
             T init, Op&& op = Op())
         {
-            using iterator_type =
-                typename hpx::traits::range_traits<Rng>::iterator_type;
-
-            static_assert(hpx::traits::is_input_iterator<iterator_type>::value,
+            static_assert(hpx::traits::is_input_iterator<
+                              traits::range_iterator_t<Rng>>::value,
                 "Requires at least input iterator.");
 
-            using result_type = parallel::util::in_out_result<iterator_type, O>;
+            using result_type =
+                exclusive_scan_result<traits::range_iterator_t<Rng>, O>;
 
             return hpx::parallel::v1::detail::exclusive_scan<result_type>()
                 .call(hpx::execution::seq, std::begin(rng), std::end(rng), dest,
@@ -677,24 +687,24 @@ namespace hpx { namespace ranges {
             typename Op = std::plus<T>,
             HPX_CONCEPT_REQUIRES_(
                 hpx::is_execution_policy<ExPolicy>::value &&
-                hpx::traits::is_range<Rng>::value
+                hpx::traits::is_range<Rng>::value &&
+                hpx::is_invocable_v<Op,
+                    typename hpx::traits::range_traits<Rng>::value_type,
+                    typename hpx::traits::range_traits<Rng>::value_type
+                >
             )>
         // clang-format on
         friend typename parallel::util::detail::algorithm_result<ExPolicy,
-            parallel::util::in_out_result<
-                typename hpx::traits::range_traits<Rng>::iterator_type,
-                O>>::type
+            exclusive_scan_result<traits::range_iterator_t<Rng>, O>>::type
         tag_fallback_dispatch(hpx::ranges::exclusive_scan_t, ExPolicy&& policy,
             Rng&& rng, O dest, T init, Op&& op = Op())
         {
-            using iterator_type =
-                typename hpx::traits::range_traits<Rng>::iterator_type;
-
-            static_assert(
-                hpx::traits::is_forward_iterator<iterator_type>::value,
+            static_assert(hpx::traits::is_forward_iterator<
+                              traits::range_iterator_t<Rng>>::value,
                 "Requires at least forward iterator.");
 
-            using result_type = parallel::util::in_out_result<iterator_type, O>;
+            using result_type =
+                exclusive_scan_result<traits::range_iterator_t<Rng>, O>;
 
             return hpx::parallel::v1::detail::exclusive_scan<result_type>()
                 .call(std::forward<ExPolicy>(policy), std::begin(rng),

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/exclusive_scan.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/exclusive_scan.hpp
@@ -1,0 +1,487 @@
+//  Copyright (c) 2020 ETH Zurich
+//  Copyright (c) 2014 Grant Mercer
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+/// \file parallel/container_algorithms/exclusive_scan.hpp
+
+#pragma once
+
+#if defined(DOXYGEN)
+
+namespace hpx { namespace ranges {
+
+    /// Checks if the first range [first1, last1) is lexicographically less than
+    /// the second range [first2, last2). uses a provided predicate to compare
+    /// elements.
+    ///
+    /// \note   Complexity: At most 2 * min(N1, N2) applications of the comparison
+    ///         operation, where N1 = std::distance(first1, last)
+    ///         and N2 = std::distance(first2, last2).
+    ///
+    /// \tparam InIter1     The type of the source iterators used for the
+    ///                     first range (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     input iterator.
+    /// \tparam Sent1       The type of the source sentinel (deduced). This
+    ///                     sentinel type must be a sentinel for InIter1.
+    /// \tparam InIter2     The type of the source iterators used for the
+    ///                     second range (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     input iterator.
+    /// \tparam Sent2       The type of the source sentinel (deduced). This
+    ///                     sentinel type must be a sentinel for InIter2.
+    /// \tparam Pred        The type of an optional function/function object to use.
+    ///                     Unlike its sequential form, the parallel
+    ///                     overload of \a exclusive_scan requires \a Pred to
+    ///                     meet the requirements of \a CopyConstructible. This defaults
+    ///                     to std::less<>
+    /// \tparam Proj1       The type of an optional projection function for FwdIter1. This
+    ///                     defaults to \a util::projection_identity
+    /// \tparam Proj2       The type of an optional projection function for FwdIter2. This
+    ///                     defaults to \a util::projection_identity
+    ///
+    /// \param first1       Refers to the beginning of the sequence of elements
+    ///                     of the first range the algorithm will be applied to.
+    /// \param last1        Refers to the end of the sequence of elements of
+    ///                     the first range the algorithm will be applied to.
+    /// \param first2       Refers to the beginning of the sequence of elements
+    ///                     of the second range the algorithm will be applied to.
+    /// \param last2        Refers to the end of the sequence of elements of
+    ///                     the second range the algorithm will be applied to.
+    /// \param pred         Refers to the comparison function that the first
+    ///                     and second ranges will be applied to
+    /// \param proj1        Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements of the first range
+    ///                     as a projection operation before the actual predicate
+    ///                     \a is invoked.
+    /// \param proj2        Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements of the second range
+    ///                     as a projection operation before the actual predicate
+    ///                     \a is invoked.
+    ///
+    /// The comparison operations in the parallel \a exclusive_scan
+    /// algorithm invoked with an execution policy object of type
+    /// \a sequenced_policy execute in sequential order in the
+    /// calling thread.
+    ///
+    /// The comparison operations in the parallel \a exclusive_scan
+    /// algorithm invoked with an execution policy object of type
+    /// \a parallel_policy
+    /// or \a parallel_task_policy are permitted to execute in an unordered
+    /// fashion in unspecified threads, and indeterminately sequenced
+    /// within each thread.
+    ///
+    /// \note     Lexicographical comparison is an operation with the
+    ///           following properties
+    ///             - Two ranges are compared element by element
+    ///             - The first mismatching element defines which range
+    ///               is lexicographically
+    ///               \a less or \a greater than the other
+    ///             - If one range is a prefix of another, the shorter range is
+    ///               lexicographically \a less than the other
+    ///             - If two ranges have equivalent elements and are of the same length,
+    ///               then the ranges are lexicographically \a equal
+    ///             - An empty range is lexicographically \a less than any non-empty
+    ///               range
+    ///             - Two empty ranges are lexicographically \a equal
+    ///
+    /// \returns  The \a lexicographically_compare algorithm returns a
+    ///           \a hpx::future<bool> if the execution policy is of type
+    ///           \a sequenced_task_policy or
+    ///           \a parallel_task_policy and
+    ///           returns \a bool otherwise.
+    ///           The \a lexicographically_compare algorithm returns true
+    ///           if the first range is lexicographically less, otherwise
+    ///           it returns false.
+    ///           range [first2, last2), it returns false.
+    template <typename InIter1, typename Sent1, typename InIter2,
+        typename Sent2,
+        typename Proj1 = hpx::parallel::util::projection_identity,
+        typename Proj2 = hpx::parallel::util::projection_identity,
+        typename Pred = detail::less>
+    bool exclusive_scan(InIter1 first1, Sent1 last1, InIter2 first2,
+        Sent2 last2, Pred&& pred = Pred(), Proj1&& proj1 = Proj1(),
+        Proj2&& proj2 = Proj2());
+
+    /// Checks if the first range [first1, last1) is lexicographically less than
+    /// the second range [first2, last2). uses a provided predicate to compare
+    /// elements.
+    ///
+    /// \note   Complexity: At most 2 * min(N1, N2) applications of the comparison
+    ///         operation, where N1 = std::distance(first1, last)
+    ///         and N2 = std::distance(first2, last2).
+    ///
+    /// \tparam ExPolicy    The type of the execution policy to use (deduced).
+    ///                     It describes the manner in which the execution
+    ///                     of the algorithm may be parallelized and the manner
+    ///                     in which it executes the assignments.
+    /// \tparam FwdIter1    The type of the source iterators used for the
+    ///                     first range (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     forward iterator.
+    /// \tparam Sent1       The type of the source sentinel (deduced). This
+    ///                     sentinel type must be a sentinel for FwdIter1.
+    /// \tparam FwdIter2    The type of the source iterators used for the
+    ///                     second range (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     forward iterator.
+    /// \tparam Sent2       The type of the source sentinel (deduced). This
+    ///                     sentinel type must be a sentinel for FwdIter2.
+    /// \tparam Pred        The type of an optional function/function object to use.
+    ///                     Unlike its sequential form, the parallel
+    ///                     overload of \a exclusive_scan requires \a Pred to
+    ///                     meet the requirements of \a CopyConstructible. This defaults
+    ///                     to std::less<>
+    /// \tparam Proj1       The type of an optional projection function for FwdIter1. This
+    ///                     defaults to \a util::projection_identity
+    /// \tparam Proj2       The type of an optional projection function for FwdIter2. This
+    ///                     defaults to \a util::projection_identity
+    ///
+    /// \param policy       The execution policy to use for the scheduling of
+    ///                     the iterations.
+    /// \param first1       Refers to the beginning of the sequence of elements
+    ///                     of the first range the algorithm will be applied to.
+    /// \param last1        Refers to the end of the sequence of elements of
+    ///                     the first range the algorithm will be applied to.
+    /// \param first2       Refers to the beginning of the sequence of elements
+    ///                     of the second range the algorithm will be applied to.
+    /// \param last2        Refers to the end of the sequence of elements of
+    ///                     the second range the algorithm will be applied to.
+    /// \param pred         Refers to the comparison function that the first
+    ///                     and second ranges will be applied to
+    /// \param proj1        Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements of the first range
+    ///                     as a projection operation before the actual predicate
+    ///                     \a is invoked.
+    /// \param proj2        Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements of the second range
+    ///                     as a projection operation before the actual predicate
+    ///                     \a is invoked.
+    ///
+    /// The comparison operations in the parallel \a exclusive_scan
+    /// algorithm invoked with an execution policy object of type
+    /// \a sequenced_policy execute in sequential order in the
+    /// calling thread.
+    ///
+    /// The comparison operations in the parallel \a exclusive_scan
+    /// algorithm invoked with an execution policy object of type
+    /// \a parallel_policy
+    /// or \a parallel_task_policy are permitted to execute in an unordered
+    /// fashion in unspecified threads, and indeterminately sequenced
+    /// within each thread.
+    ///
+    /// \note     Lexicographical comparison is an operation with the
+    ///           following properties
+    ///             - Two ranges are compared element by element
+    ///             - The first mismatching element defines which range
+    ///               is lexicographically
+    ///               \a less or \a greater than the other
+    ///             - If one range is a prefix of another, the shorter range is
+    ///               lexicographically \a less than the other
+    ///             - If two ranges have equivalent elements and are of the same length,
+    ///               then the ranges are lexicographically \a equal
+    ///             - An empty range is lexicographically \a less than any non-empty
+    ///               range
+    ///             - Two empty ranges are lexicographically \a equal
+    ///
+    /// \returns  The \a lexicographically_compare algorithm returns a
+    ///           \a hpx::future<bool> if the execution policy is of type
+    ///           \a sequenced_task_policy or
+    ///           \a parallel_task_policy and
+    ///           returns \a bool otherwise.
+    ///           The \a lexicographically_compare algorithm returns true
+    ///           if the first range is lexicographically less, otherwise
+    ///           it returns false.
+    ///           range [first2, last2), it returns false.
+
+    template <typename ExPolicy, typename FwdIter1, typename Sent1,
+        typename FwdIter2, typename Sent2,
+        typename Proj1 = hpx::parallel::util::projection_identity,
+        typename Proj2 = hpx::parallel::util::projection_identity,
+        typename Pred = detail::less>
+    typename parallel::util::detail::algorithm_result<ExPolicy, bool>::type
+    exclusive_scan(ExPolicy&& policy, FwdIter1 first1, Sent1 last1,
+        FwdIter2 first2, Sent2 last2, Pred&& pred = Pred(),
+        Proj1&& proj1 = Proj1(), Proj2&& proj2 = Proj2());
+
+    /// Checks if the first range rng1 is lexicographically less than
+    /// the second range rng2. uses a provided predicate to compare
+    /// elements.
+    ///
+    /// \note   Complexity: At most 2 * min(N1, N2) applications of the comparison
+    ///         operation, where N1 = std::distance(std::begin(rng1), std::end(rng1))
+    ///         and N2 = std::distance(std::begin(rng2), std::end(rng2)).
+    ///
+    /// \tparam Rng1        The type of the source range used (deduced).
+    ///                     The iterators extracted from this range type must
+    ///                     meet the requirements of an input iterator.
+    /// \tparam Rng2        The type of the source range used (deduced).
+    ///                     The iterators extracted from this range type must
+    ///                     meet the requirements of an input iterator.
+    /// \tparam Pred        The type of an optional function/function object to use.
+    ///                     Unlike its sequential form, the parallel
+    ///                     overload of \a exclusive_scan requires \a Pred to
+    ///                     meet the requirements of \a CopyConstructible. This defaults
+    ///                     to std::less<>
+    /// \tparam Proj1       The type of an optional projection function for elements of the first range.
+    ///                     This defaults to \a util::projection_identity
+    /// \tparam Proj2       The type of an optional projection function for elements of the second range.
+    ///                     This defaults to \a util::projection_identity
+    ///
+    /// \param rng1         Refers to the sequence of elements the algorithm
+    ///                     will be applied to.
+    /// \param rng2         Refers to the sequence of elements the algorithm
+    ///                     will be applied to.
+    /// \param pred         Refers to the comparison function that the first
+    ///                     and second ranges will be applied to
+    /// \param proj1        Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements of the first range
+    ///                     as a projection operation before the actual predicate
+    ///                     \a is invoked.
+    /// \param proj2        Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements of the second range
+    ///                     as a projection operation before the actual predicate
+    ///                     \a is invoked.
+    ///
+    /// The comparison operations in the parallel \a exclusive_scan
+    /// algorithm invoked without an execution policy object  execute in sequential
+    /// order in the calling thread.
+    ///
+    /// \note     Lexicographical comparison is an operation with the
+    ///           following properties
+    ///             - Two ranges are compared element by element
+    ///             - The first mismatching element defines which range
+    ///               is lexicographically
+    ///               \a less or \a greater than the other
+    ///             - If one range is a prefix of another, the shorter range is
+    ///               lexicographically \a less than the other
+    ///             - If two ranges have equivalent elements and are of the same length,
+    ///               then the ranges are lexicographically \a equal
+    ///             - An empty range is lexicographically \a less than any non-empty
+    ///               range
+    ///             - Two empty ranges are lexicographically \a equal
+    ///
+    /// \returns  The \a lexicographically_compare algorithm returns \a bool.
+    ///           The \a lexicographically_compare algorithm returns true
+    ///           if the first range is lexicographically less, otherwise
+    ///           it returns false.
+    ///           range [first2, last2), it returns false.
+    template <typename Rng1, typename Rng2,
+        typename Proj1 = hpx::parallel::util::projection_identity,
+        typename Proj2 = hpx::parallel::util::projection_identity,
+        typename Pred = detail::less>
+    bool exclusive_scan(Rng1&& rng1, Rng2&& rng2, Pred&& pred = Pred(),
+        Proj1&& proj1 = Proj1(), Proj2&& proj2 = Proj2());
+
+    /// Checks if the first range rng1 is lexicographically less than
+    /// the second range rng2. uses a provided predicate to compare
+    /// elements.
+    ///
+    /// \note   Complexity: At most 2 * min(N1, N2) applications of the comparison
+    ///         operation, where N1 = std::distance(std::begin(rng1), std::end(rng1))
+    ///         and N2 = std::distance(std::begin(rng2), std::end(rng2)).
+    ///
+    /// \tparam ExPolicy    The type of the execution policy to use (deduced).
+    ///                     It describes the manner in which the execution
+    ///                     of the algorithm may be parallelized and the manner
+    ///                     in which it executes the assignments.
+    /// \tparam Rng1        The type of the source range used (deduced).
+    ///                     The iterators extracted from this range type must
+    ///                     meet the requirements of an input iterator.
+    /// \tparam Rng2        The type of the source range used (deduced).
+    ///                     The iterators extracted from this range type must
+    ///                     meet the requirements of an input iterator.
+    /// \tparam Pred        The type of an optional function/function object to use.
+    ///                     Unlike its sequential form, the parallel
+    ///                     overload of \a exclusive_scan requires \a Pred to
+    ///                     meet the requirements of \a CopyConstructible. This defaults
+    ///                     to std::less<>
+    /// \tparam Proj1       The type of an optional projection function for elements of the first range.
+    ///                     This defaults to \a util::projection_identity
+    /// \tparam Proj2       The type of an optional projection function for elements of the second range.
+    ///                     This defaults to \a util::projection_identity
+    ///
+    /// \param policy       The execution policy to use for the scheduling of
+    ///                     the iterations.
+    /// \param rng1         Refers to the sequence of elements the algorithm
+    ///                     will be applied to.
+    /// \param rng2         Refers to the sequence of elements the algorithm
+    ///                     will be applied to.
+    /// \param pred         Refers to the comparison function that the first
+    ///                     and second ranges will be applied to
+    /// \param proj1        Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements of the first range
+    ///                     as a projection operation before the actual predicate
+    ///                     \a is invoked.
+    /// \param proj2        Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements of the second range
+    ///                     as a projection operation before the actual predicate
+    ///                     \a is invoked.
+    ///
+    /// The comparison operations in the parallel \a exclusive_scan
+    /// algorithm invoked with an execution policy object of type
+    /// \a sequenced_policy execute in sequential order in the
+    /// calling thread.
+    ///
+    /// The comparison operations in the parallel \a exclusive_scan
+    /// algorithm invoked with an execution policy object of type
+    /// \a parallel_policy
+    /// or \a parallel_task_policy are permitted to execute in an unordered
+    /// fashion in unspecified threads, and indeterminately sequenced
+    /// within each thread.
+    ///
+    /// \note     Lexicographical comparison is an operation with the
+    ///           following properties
+    ///             - Two ranges are compared element by element
+    ///             - The first mismatching element defines which range
+    ///               is lexicographically
+    ///               \a less or \a greater than the other
+    ///             - If one range is a prefix of another, the shorter range is
+    ///               lexicographically \a less than the other
+    ///             - If two ranges have equivalent elements and are of the same length,
+    ///               then the ranges are lexicographically \a equal
+    ///             - An empty range is lexicographically \a less than any non-empty
+    ///               range
+    ///             - Two empty ranges are lexicographically \a equal
+    ///
+    /// \returns  The \a lexicographically_compare algorithm returns a
+    ///           \a hpx::future<bool> if the execution policy is of type
+    ///           \a sequenced_task_policy or
+    ///           \a parallel_task_policy and
+    ///           returns \a bool otherwise.
+    ///           The \a lexicographically_compare algorithm returns true
+    ///           if the first range is lexicographically less, otherwise
+    ///           it returns false.
+    ///           range [first2, last2), it returns false.
+
+    template <typename ExPolicy, typename Rng1, typename Rng2,
+        typename Proj1 = hpx::parallel::util::projection_identity,
+        typename Proj2 = hpx::parallel::util::projection_identity,
+        typename Pred = detail::less>
+    typename parallel::util::detail::algorithm_result<ExPolicy, bool>::type
+    exclusive_scan(ExPolicy&& policy, Rng1&& rng1, Rng2&& rng2,
+        Pred&& pred = Pred(), Proj1&& proj1 = Proj1(), Proj2&& proj2 = Proj2());
+}}    // namespace hpx::ranges
+#else
+
+#include <hpx/config.hpp>
+#include <hpx/algorithms/traits/projected_range.hpp>
+#include <hpx/execution/algorithms/detail/predicates.hpp>
+#include <hpx/executors/execution_policy.hpp>
+#include <hpx/functional/tag_fallback_dispatch.hpp>
+#include <hpx/iterator_support/traits/is_iterator.hpp>
+#include <hpx/parallel/algorithms/exclusive_scan.hpp>
+#include <hpx/parallel/util/detail/algorithm_result.hpp>
+#include <hpx/parallel/util/projection_identity.hpp>
+
+#include <algorithm>
+#include <cstddef>
+#include <iterator>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+namespace hpx { namespace ranges {
+    HPX_INLINE_CONSTEXPR_VARIABLE struct exclusive_scan_t final
+      : hpx::functional::tag_fallback<exclusive_scan_t>
+    {
+    private:
+        // clang-format off
+        template <typename InIter, typename Sent, typename OutIter,
+             typename T, typename Op = std::plus<T>,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::traits::is_iterator<InIter>::value &&
+                hpx::traits::is_sentinel_for<Sent, InIter>::value &&
+                hpx::traits::is_iterator<OutIter>::value
+            )>
+        // clang-format on
+        friend OutIter tag_fallback_dispatch(hpx::ranges::exclusive_scan_t,
+            InIter first, Sent last, OutIter dest, T init, Op&& op = Op())
+        {
+            static_assert(hpx::traits::is_input_iterator<InIter>::value,
+                "Requires at least input iterator.");
+            static_assert(hpx::traits::is_output_iterator<OutIter>::value,
+                "Requires at least output iterator.");
+
+            return hpx::parallel::v1::detail::exclusive_scan<OutIter>().call(
+                hpx::execution::seq, first, last, dest, std::move(init),
+                std::forward<Op>(op));
+        }
+
+        // clang-format off
+        template <typename ExPolicy, typename FwdIter1, typename Sent,
+            typename FwdIter2, typename T, typename Op = std::plus<T>,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::is_execution_policy<ExPolicy>::value &&
+                hpx::traits::is_iterator<FwdIter1>::value &&
+                hpx::traits::is_sentinel_for<Sent, FwdIter1>::value &&
+                hpx::traits::is_iterator<FwdIter2>::value
+            )>
+        // clang-format on
+        friend typename parallel::util::detail::algorithm_result<ExPolicy,
+            FwdIter2>::type
+        tag_fallback_dispatch(hpx::ranges::exclusive_scan_t, ExPolicy&& policy,
+            FwdIter1 first, Sent last, FwdIter2 dest, T init, Op&& op = Op())
+        {
+            static_assert(hpx::traits::is_forward_iterator<FwdIter1>::value,
+                "Requires at least forward iterator.");
+            static_assert(hpx::traits::is_forward_iterator<FwdIter2>::value,
+                "Requires at least forward iterator.");
+
+            return hpx::parallel::v1::detail::exclusive_scan<FwdIter2>().call(
+                std::forward<ExPolicy>(policy), first, last, dest,
+                std::move(init), std::forward<Op>(op));
+        }
+
+        // clang-format off
+        template <typename Rng, typename O, typename T,
+            typename Op = std::plus<T>,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::traits::is_range<Rng>::value
+            )>
+        // clang-format on
+        friend O tag_fallback_dispatch(hpx::ranges::exclusive_scan_t, Rng&& rng,
+            O dest, T init, Op&& op = Op())
+        {
+            using iterator_type =
+                typename hpx::traits::range_traits<Rng>::iterator_type;
+
+            static_assert(hpx::traits::is_input_iterator<iterator_type>::value,
+                "Requires at least input iterator.");
+
+            return hpx::parallel::v1::detail::exclusive_scan<O>().call(
+                hpx::execution::seq, std::begin(rng), std::end(rng), dest,
+                std::move(init), std::forward<Op>(op));
+        }
+
+        // clang-format off
+        template <typename ExPolicy, typename Rng,  typename O, typename T,
+            typename Op = std::plus<T>,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::is_execution_policy<ExPolicy>::value &&
+                hpx::traits::is_range<Rng>::value
+            )>
+        // clang-format on
+        friend
+            typename parallel::util::detail::algorithm_result<ExPolicy, O>::type
+            tag_fallback_dispatch(hpx::ranges::exclusive_scan_t,
+                ExPolicy&& policy, Rng&& rng, O dest, T init, Op&& op = Op())
+        {
+            using iterator_type =
+                typename hpx::traits::range_traits<Rng>::iterator_type;
+
+            static_assert(
+                hpx::traits::is_forward_iterator<iterator_type>::value,
+                "Requires at least forward iterator.");
+
+            return hpx::parallel::v1::detail::exclusive_scan<O>().call(
+                std::forward<ExPolicy>(policy), std::begin(rng), std::end(rng),
+                dest, std::move(init), std::forward<Op>(op));
+        }
+    } exclusive_scan{};
+}}    // namespace hpx::ranges
+
+#endif

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/exclusive_scan.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/exclusive_scan.hpp
@@ -1,5 +1,6 @@
 //  Copyright (c) 2020 ETH Zurich
 //  Copyright (c) 2014 Grant Mercer
+//  Copyright (c) 2021 Akhil J Nair
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -45,8 +46,10 @@ namespace hpx { namespace ranges {
     /// invoked without an execution policy object will execute in sequential
     /// order in the calling thread.
     ///
-    /// \returns  The \a exclusive_scan algorithm returns \a OutIter.
-    ///           The \a exclusive_scan algorithm returns the output iterator
+    /// \returns  The \a exclusive_scan algorithm returns \a
+    ///           util::in_out_result<InIter, OutIter>.
+    ///           The \a exclusive_scan algorithm returns an input iterator to
+    ///           the point denoted by the sentinel and an output iterator
     ///           to the element in the destination range, one past the last
     ///           element copied.
     ///
@@ -60,7 +63,8 @@ namespace hpx { namespace ranges {
     /// \a inclusive_scan includes the ith input element in the ith sum.
     ///
     template <typename InIter, typename Sent, typename OutIter, typename T>
-    OutIter exclusive_scan(InIter first, Sent last, OutIter dest, T init);
+    parallel::util::in_out_result<InIter, OutIter> exclusive_scan(
+        InIter first, Sent last, OutIter dest, T init);
 
     ///////////////////////////////////////////////////////////////////////////
     /// Assigns through each iterator \a i in [result, result + (last - first))
@@ -107,12 +111,13 @@ namespace hpx { namespace ranges {
     /// within each thread.
     ///
     /// \returns  The \a exclusive_scan algorithm returns a
-    ///           \a hpx::future<FwdIter2> if
+    ///           \a hpx::future<util::in_out_result<FwdIter1, FwdIter2>> if
     ///           the execution policy is of type
     ///           \a sequenced_task_policy or
     ///           \a parallel_task_policy and
-    ///           returns \a FwdIter2 otherwise.
-    ///           The \a exclusive_scan algorithm returns the output iterator
+    ///           returns \a util::in_out_result<FwdIter1, FwdIter2> otherwise.
+    ///           The \a exclusive_scan algorithm returns an input iterator to
+    ///           the point denoted by the sentinel and an output iterator
     ///           to the element in the destination range, one past the last
     ///           element copied.
     ///
@@ -127,7 +132,8 @@ namespace hpx { namespace ranges {
     ///
     template <typename ExPolicy, typename FwdIter1, typename Sent,
         typename FwdIter2, typename T>
-    typename util::detail::algorithm_result<ExPolicy, FwdIter2>::type
+    typename util::detail::algorithm_result<ExPolicy,
+        parallel::util::in_out_result<FwdIter1, FwdIter2>>::type
     exclusive_scan(
         ExPolicy&& policy, FwdIter1 first, Sent last, FwdIter2 dest, T init);
 
@@ -180,8 +186,10 @@ namespace hpx { namespace ranges {
     /// invoked without an execution policy object will execute in sequential
     /// order in the calling thread.
     ///
-    /// \returns  The \a exclusive_scan algorithm returns \a OutIter.
-    ///           The \a exclusive_scan algorithm returns the output iterator
+    /// \returns  The \a exclusive_scan algorithm returns \a
+    ///           util::in_out_result<InIter, OutIter>.
+    ///           The \a exclusive_scan algorithm returns an input iterator to
+    ///           the point denoted by the sentinel and an output iterator
     ///           to the element in the destination range, one past the last
     ///           element copied.
     ///
@@ -198,7 +206,7 @@ namespace hpx { namespace ranges {
     ///
     template <typename InIter, typename Sent, typename OutIter, typename T,
         typename Op>
-    OutIter exclusive_scan(
+    parallel::util::in_out_result<InIter, OutIter> exclusive_scan(
         InIter first, Sent last, OutIter dest, T init, Op&& op);
 
     ///////////////////////////////////////////////////////////////////////////
@@ -263,12 +271,13 @@ namespace hpx { namespace ranges {
     /// within each thread.
     ///
     /// \returns  The \a exclusive_scan algorithm returns a
-    ///           \a hpx::future<OutIter> if
+    ///           \a hpx::future<util::in_out_result<FwdIter1, FwdIter2>> if
     ///           the execution policy is of type
     ///           \a sequenced_task_policy or
     ///           \a parallel_task_policy and
-    ///           returns \a OutIter otherwise.
-    ///           The \a exclusive_scan algorithm returns the output iterator
+    ///           returns \a util::in_out_result<FwdIter1, FwdIter2> otherwise.
+    ///           The \a exclusive_scan algorithm returns an input iterator to
+    ///           the point denoted by the sentinel and an output iterator
     ///           to the element in the destination range, one past the last
     ///           element copied.
     ///
@@ -285,7 +294,8 @@ namespace hpx { namespace ranges {
     ///
     template <typename ExPolicy, typename FwdIter1, typename Sent,
         typename FwdIter2, typename T, typename Op>
-    typename util::detail::algorithm_result<ExPolicy, FwdIter2>::type
+    typename util::detail::algorithm_result<ExPolicy,
+        parallel::util::in_out_result<FwdIter1, FwdIter2>>::type
     exclusive_scan(ExPolicy&& policy, FwdIter1 first, Sent last, FwdIter2 dest,
         T init, Op&& op);
 
@@ -317,8 +327,10 @@ namespace hpx { namespace ranges {
     /// invoked without an execution policy object will execute in sequential
     /// order in the calling thread.
     ///
-    /// \returns  The \a exclusive_scan algorithm returns \a O.
-    ///           The \a exclusive_scan algorithm returns the output iterator
+    /// \returns  The \a exclusive_scan algorithm returns \a util::in_out_result
+    ///           <typename hpx::traits::range_traits<Rng>::iterator_type, O>
+    ///           The \a exclusive_scan algorithm returns an input iterator to
+    ///           the point denoted by the sentinel and an output iterator
     ///           to the element in the destination range, one past the last
     ///           element copied.
     ///
@@ -332,7 +344,9 @@ namespace hpx { namespace ranges {
     /// \a inclusive_scan includes the ith input element in the ith sum.
     ///
     template <typename Rng, typename O, typename T>
-    O exclusive_scan(Rng&& rng, O dest, T init);
+    parallel::util::in_out_result<
+        typename hpx::traits::range_traits<Rng>::iterator_type, O>
+    exclusive_scan(Rng&& rng, O dest, T init);
 
     ///////////////////////////////////////////////////////////////////////////
     /// Assigns through each iterator \a i in [result, result + (last - first))
@@ -375,12 +389,16 @@ namespace hpx { namespace ranges {
     /// within each thread.
     ///
     /// \returns  The \a exclusive_scan algorithm returns a
-    ///           \a hpx::future<O> if
-    ///           the execution policy is of type
+    ///           \a hpx::future<util::in_out_result
+    ///           <typename hpx::traits::range_traits<Rng>::iterator_type, O>>
+    ///           if the execution policy is of type
     ///           \a sequenced_task_policy or
     ///           \a parallel_task_policy and
-    ///           returns \a O otherwise.
-    ///           The \a exclusive_scan algorithm returns the output iterator
+    ///           returns \a util::in_out_result
+    ///           <typename hpx::traits::range_traits<Rng>::iterator_type, O>
+    ///           otherwise.
+    ///           The \a exclusive_scan algorithm returns an input iterator to
+    ///           the point denoted by the sentinel and an output iterator
     ///           to the element in the destination range, one past the last
     ///           element copied.
     ///
@@ -394,8 +412,10 @@ namespace hpx { namespace ranges {
     /// \a inclusive_scan includes the ith input element in the ith sum.
     ///
     template <typename ExPolicy, typename Rng, typename O, typename T>
-    typename util::detail::algorithm_result<ExPolicy, O>::type exclusive_scan(
-        ExPolicy&& policy, Rng&& rng, O dest, T init);
+    typename util::detail::algorithm_result<ExPolicy,
+        parallel::util::in_out_result<
+            typename hpx::traits::range_traits<Rng>::iterator_type, O>>::type
+    exclusive_scan(ExPolicy&& policy, Rng&& rng, O dest, T init);
 
     ///////////////////////////////////////////////////////////////////////////
     /// Assigns through each iterator \a i in [result, result + (last - first))
@@ -442,8 +462,10 @@ namespace hpx { namespace ranges {
     /// invoked without an execution policy object will execute in sequential
     /// order in the calling thread.
     ///
-    /// \returns  The \a exclusive_scan algorithm returns \a O.
-    ///           The \a exclusive_scan algorithm returns the output iterator
+    /// \returns  The \a exclusive_scan algorithm returns \a util::in_out_result
+    ///           <typename hpx::traits::range_traits<Rng>::iterator_type, O>
+    ///           The \a exclusive_scan algorithm returns an input iterator to
+    ///           the point denoted by the sentinel and an output iterator
     ///           to the element in the destination range, one past the last
     ///           element copied.
     ///
@@ -457,7 +479,9 @@ namespace hpx { namespace ranges {
     /// \a inclusive_scan includes the ith input element in the ith sum.
     ///
     template <typename Rng, typename O, typename T, typename Op>
-    O exclusive_scan(Rng&& rng, O dest, T init, Op&& op);
+    parallel::util::in_out_result<
+        typename hpx::traits::range_traits<Rng>::iterator_type, O>
+    exclusive_scan(Rng&& rng, O dest, T init, Op&& op);
 
     ///////////////////////////////////////////////////////////////////////////
     /// Assigns through each iterator \a i in [result, result + (last - first))
@@ -517,12 +541,16 @@ namespace hpx { namespace ranges {
     /// within each thread.
     ///
     /// \returns  The \a exclusive_scan algorithm returns a
-    ///           \a hpx::future<O> if
-    ///           the execution policy is of type
+    ///           \a hpx::future<util::in_out_result
+    ///           <typename hpx::traits::range_traits<Rng>::iterator_type, O>>
+    ///           if the execution policy is of type
     ///           \a sequenced_task_policy or
     ///           \a parallel_task_policy and
-    ///           returns \a O otherwise.
-    ///           The \a exclusive_scan algorithm returns the output iterator
+    ///           returns \a util::in_out_result
+    ///           <typename hpx::traits::range_traits<Rng>::iterator_type, O>
+    ///           otherwise.
+    ///           The \a exclusive_scan algorithm returns an input iterator to
+    ///           the point denoted by the sentinel and an output iterator
     ///           to the element in the destination range, one past the last
     ///           element copied.
     ///
@@ -537,8 +565,10 @@ namespace hpx { namespace ranges {
     ///
     template <typename ExPolicy, typename Rng, typename O, typename T,
         typename Op>
-    typename util::detail::algorithm_result<ExPolicy, O>::type exclusive_scan(
-        ExPolicy&& policy, Rng&& rng, O dest, T init, Op&& op);
+    typename util::detail::algorithm_result<ExPolicy,
+        parallel::util::in_out_result<
+            typename hpx::traits::range_traits<Rng>::iterator_type, O>>::type
+    exclusive_scan(ExPolicy&& policy, Rng&& rng, O dest, T init, Op&& op);
 }}    // namespace hpx::ranges
 #else
 
@@ -568,22 +598,25 @@ namespace hpx { namespace ranges {
         template <typename InIter, typename Sent, typename OutIter,
              typename T, typename Op = std::plus<T>,
             HPX_CONCEPT_REQUIRES_(
-                hpx::traits::is_iterator<InIter>::value &&
+                hpx::traits::is_iterator_v<InIter> &&
                 hpx::traits::is_sentinel_for<Sent, InIter>::value &&
-                hpx::traits::is_iterator<OutIter>::value
+                hpx::traits::is_iterator_v<OutIter>
             )>
         // clang-format on
-        friend OutIter tag_fallback_dispatch(hpx::ranges::exclusive_scan_t,
-            InIter first, Sent last, OutIter dest, T init, Op&& op = Op())
+        friend parallel::util::in_out_result<InIter, OutIter>
+        tag_fallback_dispatch(hpx::ranges::exclusive_scan_t, InIter first,
+            Sent last, OutIter dest, T init, Op&& op = Op())
         {
-            static_assert(hpx::traits::is_input_iterator<InIter>::value,
+            static_assert(hpx::traits::is_input_iterator_v<InIter>,
                 "Requires at least input iterator.");
-            static_assert(hpx::traits::is_output_iterator<OutIter>::value,
+            static_assert(hpx::traits::is_output_iterator_v<OutIter>,
                 "Requires at least output iterator.");
 
-            return hpx::parallel::v1::detail::exclusive_scan<OutIter>().call(
-                hpx::execution::seq, first, last, dest, std::move(init),
-                std::forward<Op>(op));
+            using result_type = parallel::util::in_out_result<InIter, OutIter>;
+
+            return hpx::parallel::v1::detail::exclusive_scan<result_type>()
+                .call(hpx::execution::seq, first, last, dest, std::move(init),
+                    std::forward<Op>(op));
         }
 
         // clang-format off
@@ -591,24 +624,27 @@ namespace hpx { namespace ranges {
             typename FwdIter2, typename T, typename Op = std::plus<T>,
             HPX_CONCEPT_REQUIRES_(
                 hpx::is_execution_policy<ExPolicy>::value &&
-                hpx::traits::is_iterator<FwdIter1>::value &&
+                hpx::traits::is_iterator_v<FwdIter1> &&
                 hpx::traits::is_sentinel_for<Sent, FwdIter1>::value &&
-                hpx::traits::is_iterator<FwdIter2>::value
+                hpx::traits::is_iterator_v<FwdIter2>
             )>
         // clang-format on
         friend typename parallel::util::detail::algorithm_result<ExPolicy,
-            FwdIter2>::type
+            parallel::util::in_out_result<FwdIter1, FwdIter2>>::type
         tag_fallback_dispatch(hpx::ranges::exclusive_scan_t, ExPolicy&& policy,
             FwdIter1 first, Sent last, FwdIter2 dest, T init, Op&& op = Op())
         {
-            static_assert(hpx::traits::is_forward_iterator<FwdIter1>::value,
+            static_assert(hpx::traits::is_forward_iterator_v<FwdIter1>,
                 "Requires at least forward iterator.");
-            static_assert(hpx::traits::is_forward_iterator<FwdIter2>::value,
+            static_assert(hpx::traits::is_forward_iterator_v<FwdIter2>,
                 "Requires at least forward iterator.");
 
-            return hpx::parallel::v1::detail::exclusive_scan<FwdIter2>().call(
-                std::forward<ExPolicy>(policy), first, last, dest,
-                std::move(init), std::forward<Op>(op));
+            using result_type =
+                parallel::util::in_out_result<FwdIter1, FwdIter2>;
+
+            return hpx::parallel::v1::detail::exclusive_scan<result_type>()
+                .call(std::forward<ExPolicy>(policy), first, last, dest,
+                    std::move(init), std::forward<Op>(op));
         }
 
         // clang-format off
@@ -618,8 +654,10 @@ namespace hpx { namespace ranges {
                 hpx::traits::is_range<Rng>::value
             )>
         // clang-format on
-        friend O tag_fallback_dispatch(hpx::ranges::exclusive_scan_t, Rng&& rng,
-            O dest, T init, Op&& op = Op())
+        friend parallel::util::in_out_result<
+            typename hpx::traits::range_traits<Rng>::iterator_type, O>
+        tag_fallback_dispatch(hpx::ranges::exclusive_scan_t, Rng&& rng, O dest,
+            T init, Op&& op = Op())
         {
             using iterator_type =
                 typename hpx::traits::range_traits<Rng>::iterator_type;
@@ -627,9 +665,11 @@ namespace hpx { namespace ranges {
             static_assert(hpx::traits::is_input_iterator<iterator_type>::value,
                 "Requires at least input iterator.");
 
-            return hpx::parallel::v1::detail::exclusive_scan<O>().call(
-                hpx::execution::seq, std::begin(rng), std::end(rng), dest,
-                std::move(init), std::forward<Op>(op));
+            using result_type = parallel::util::in_out_result<iterator_type, O>;
+
+            return hpx::parallel::v1::detail::exclusive_scan<result_type>()
+                .call(hpx::execution::seq, std::begin(rng), std::end(rng), dest,
+                    std::move(init), std::forward<Op>(op));
         }
 
         // clang-format off
@@ -640,10 +680,12 @@ namespace hpx { namespace ranges {
                 hpx::traits::is_range<Rng>::value
             )>
         // clang-format on
-        friend
-            typename parallel::util::detail::algorithm_result<ExPolicy, O>::type
-            tag_fallback_dispatch(hpx::ranges::exclusive_scan_t,
-                ExPolicy&& policy, Rng&& rng, O dest, T init, Op&& op = Op())
+        friend typename parallel::util::detail::algorithm_result<ExPolicy,
+            parallel::util::in_out_result<
+                typename hpx::traits::range_traits<Rng>::iterator_type,
+                O>>::type
+        tag_fallback_dispatch(hpx::ranges::exclusive_scan_t, ExPolicy&& policy,
+            Rng&& rng, O dest, T init, Op&& op = Op())
         {
             using iterator_type =
                 typename hpx::traits::range_traits<Rng>::iterator_type;
@@ -652,9 +694,11 @@ namespace hpx { namespace ranges {
                 hpx::traits::is_forward_iterator<iterator_type>::value,
                 "Requires at least forward iterator.");
 
-            return hpx::parallel::v1::detail::exclusive_scan<O>().call(
-                std::forward<ExPolicy>(policy), std::begin(rng), std::end(rng),
-                dest, std::move(init), std::forward<Op>(op));
+            using result_type = parallel::util::in_out_result<iterator_type, O>;
+
+            return hpx::parallel::v1::detail::exclusive_scan<result_type>()
+                .call(std::forward<ExPolicy>(policy), std::begin(rng),
+                    std::end(rng), dest, std::move(init), std::forward<Op>(op));
         }
     } exclusive_scan{};
 }}    // namespace hpx::ranges

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_numeric.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_numeric.hpp
@@ -9,6 +9,7 @@
 
 #include <hpx/parallel/numeric.hpp>
 
+#include <hpx/parallel/container_algorithms/exclusive_scan.hpp>
 #include <hpx/parallel/container_algorithms/inclusive_scan.hpp>
 #include <hpx/parallel/container_algorithms/reduce.hpp>
 #include <hpx/parallel/container_algorithms/transform_reduce.hpp>

--- a/libs/parallelism/algorithms/tests/regressions/scan_different_inits.cpp
+++ b/libs/parallelism/algorithms/tests/regressions/scan_different_inits.cpp
@@ -33,10 +33,10 @@ void test_zero()
     Iter i_inc_mult = hpx::inclusive_scan(
         policy, a.begin(), a.end(), c.begin(),
         [](int bar, int baz) { return bar * baz; }, 10);
-    Iter i_exc_add = hpx::parallel::exclusive_scan(policy, a.begin(), a.end(),
-        d.begin(), 100, [](int bar, int baz) { return bar + baz; });
-    Iter i_exc_mult = hpx::parallel::exclusive_scan(policy, a.begin(), a.end(),
-        e.begin(), 10, [](int bar, int baz) { return bar * baz; });
+    Iter i_exc_add = hpx::exclusive_scan(policy, a.begin(), a.end(), d.begin(),
+        100, [](int bar, int baz) { return bar + baz; });
+    Iter i_exc_mult = hpx::exclusive_scan(policy, a.begin(), a.end(), e.begin(),
+        10, [](int bar, int baz) { return bar * baz; });
     Iter i_transform_inc = hpx::parallel::transform_inclusive_scan(
         policy, a.begin(), a.end(), f.begin(),
         [](int bar, int baz) { return 2 * bar + 2 * baz; },
@@ -67,10 +67,10 @@ void test_async_zero()
     Fut_Iter f_inc_mult = hpx::inclusive_scan(
         policy, a.begin(), a.end(), c.begin(),
         [](int bar, int baz) { return bar * baz; }, 10);
-    Fut_Iter f_exc_add = hpx::parallel::exclusive_scan(policy, a.begin(),
-        a.end(), d.begin(), 100, [](int bar, int baz) { return bar + baz; });
-    Fut_Iter f_exc_mult = hpx::parallel::exclusive_scan(policy, a.begin(),
-        a.end(), e.begin(), 10, [](int bar, int baz) { return bar * baz; });
+    Fut_Iter f_exc_add = hpx::exclusive_scan(policy, a.begin(), a.end(),
+        d.begin(), 100, [](int bar, int baz) { return bar + baz; });
+    Fut_Iter f_exc_mult = hpx::exclusive_scan(policy, a.begin(), a.end(),
+        e.begin(), 10, [](int bar, int baz) { return bar * baz; });
     Fut_Iter f_transform_inc = hpx::parallel::transform_inclusive_scan(
         policy, a.begin(), a.end(), f.begin(),
         [](int bar, int baz) { return 2 * bar + 2 * baz; },
@@ -105,9 +105,9 @@ void test_one(std::vector<int> a)
         hpx::inclusive_scan(policy, a.begin(), a.end(), b.begin(), fun_add, 10);
     Iter f_inc_mult = hpx::inclusive_scan(
         policy, a.begin(), a.end(), c.begin(), fun_mult, 10);
-    Iter f_exc_add = hpx::parallel::exclusive_scan(
-        policy, a.begin(), a.end(), d.begin(), 10, fun_add);
-    Iter f_exc_mult = hpx::parallel::exclusive_scan(
+    Iter f_exc_add =
+        hpx::exclusive_scan(policy, a.begin(), a.end(), d.begin(), 10, fun_add);
+    Iter f_exc_mult = hpx::exclusive_scan(
         policy, a.begin(), a.end(), e.begin(), 10, fun_mult);
     Iter f_transform_inc = hpx::parallel::transform_inclusive_scan(
         policy, a.begin(), a.end(), f.begin(), fun_add, fun_conv, 10);
@@ -162,9 +162,9 @@ void test_async_one(std::vector<int> a)
         hpx::inclusive_scan(policy, a.begin(), a.end(), b.begin(), fun_add, 10);
     Fut_Iter f_inc_mult = hpx::inclusive_scan(
         policy, a.begin(), a.end(), c.begin(), fun_mult, 10);
-    Fut_Iter f_exc_add = hpx::parallel::exclusive_scan(
-        policy, a.begin(), a.end(), d.begin(), 10, fun_add);
-    Fut_Iter f_exc_mult = hpx::parallel::exclusive_scan(
+    Fut_Iter f_exc_add =
+        hpx::exclusive_scan(policy, a.begin(), a.end(), d.begin(), 10, fun_add);
+    Fut_Iter f_exc_mult = hpx::exclusive_scan(
         policy, a.begin(), a.end(), e.begin(), 10, fun_mult);
     Fut_Iter f_transform_inc = hpx::parallel::transform_inclusive_scan(
         policy, a.begin(), a.end(), f.begin(), fun_add, fun_conv, 10);

--- a/libs/parallelism/algorithms/tests/regressions/scan_non_commutative.cpp
+++ b/libs/parallelism/algorithms/tests/regressions/scan_non_commutative.cpp
@@ -36,7 +36,7 @@ void test_scan_non_commutative()
     for (unsigned int i = 0; i < vs.size(); ++i)
     {
         std::vector<std::string> rs(vs.size());
-        hpx::parallel::exclusive_scan(
+        hpx::exclusive_scan(
             hpx::execution::par.with(hpx::execution::static_chunk_size(i)),
             vs.cbegin(), vs.cend(), rs.begin(), std::string("0"));
         std::cout << rs.back() << "\n";

--- a/libs/parallelism/algorithms/tests/unit/algorithms/exclusive_scan.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/exclusive_scan.cpp
@@ -34,8 +34,8 @@ void exclusive_scan_benchmark()
         auto op = [](double v1, double v2) { return v1 + v2; };
 
         hpx::chrono::high_resolution_timer t;
-        hpx::exclusive_scan(hpx::execution::par, std::begin(c),
-            std::end(c), std::begin(d), val, op);
+        hpx::exclusive_scan(hpx::execution::par, std::begin(c), std::end(c),
+            std::begin(d), val, op);
         double elapsed = t.elapsed();
 
         // verify values
@@ -58,6 +58,36 @@ void exclusive_scan_benchmark()
 }
 
 ///////////////////////////////////////////////////////////////////////////////
+template <typename IteratorTag>
+void test_exclusive_scan1(IteratorTag)
+{
+    typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+
+    std::vector<std::size_t> c(10007);
+    std::vector<std::size_t> d(c.size());
+    std::fill(std::begin(c), std::end(c), std::size_t(1));
+
+    std::size_t const val(0);
+    auto op = [](std::size_t v1, std::size_t v2) { return v1 + v2; };
+
+    hpx::exclusive_scan(
+        iterator(std::begin(c)), iterator(std::end(c)), std::begin(d), val, op);
+
+    // verify values
+    std::vector<std::size_t> e(c.size());
+    hpx::parallel::v1::detail::sequential_exclusive_scan(
+        std::begin(c), std::end(c), std::begin(e), val, op);
+
+    HPX_TEST(std::equal(std::begin(d), std::end(d), std::begin(e)));
+
+#if defined(HPX_HAVE_CXX17_STD_SCAN_ALGORITHMS)
+    std::vector<std::size_t> f(c.size());
+    std::exclusive_scan(std::begin(c), std::end(c), std::begin(f), val, op);
+    HPX_TEST(std::equal(std::begin(d), std::end(d), std::begin(f)));
+#endif
+}
+
 template <typename ExPolicy, typename IteratorTag>
 void test_exclusive_scan1(ExPolicy policy, IteratorTag)
 {
@@ -74,8 +104,8 @@ void test_exclusive_scan1(ExPolicy policy, IteratorTag)
     std::size_t const val(0);
     auto op = [](std::size_t v1, std::size_t v2) { return v1 + v2; };
 
-    hpx::exclusive_scan(policy, iterator(std::begin(c)),
-        iterator(std::end(c)), std::begin(d), val, op);
+    hpx::exclusive_scan(policy, iterator(std::begin(c)), iterator(std::end(c)),
+        std::begin(d), val, op);
 
     // verify values
     std::vector<std::size_t> e(c.size());
@@ -104,8 +134,8 @@ void test_exclusive_scan1_async(ExPolicy p, IteratorTag)
     std::size_t const val(0);
     auto op = [](std::size_t v1, std::size_t v2) { return v1 + v2; };
 
-    hpx::future<void> fut = hpx::exclusive_scan(p,
-        iterator(std::begin(c)), iterator(std::end(c)), std::begin(d), val, op);
+    hpx::future<void> fut = hpx::exclusive_scan(p, iterator(std::begin(c)),
+        iterator(std::end(c)), std::begin(d), val, op);
     fut.wait();
 
     // verify values
@@ -127,6 +157,7 @@ void test_exclusive_scan1()
 {
     using namespace hpx::execution;
 
+    test_exclusive_scan1(IteratorTag());
     test_exclusive_scan1(seq, IteratorTag());
     test_exclusive_scan1(par, IteratorTag());
     test_exclusive_scan1(par_unseq, IteratorTag());

--- a/libs/parallelism/algorithms/tests/unit/algorithms/exclusive_scan.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/exclusive_scan.cpp
@@ -34,7 +34,7 @@ void exclusive_scan_benchmark()
         auto op = [](double v1, double v2) { return v1 + v2; };
 
         hpx::chrono::high_resolution_timer t;
-        hpx::parallel::exclusive_scan(hpx::execution::par, std::begin(c),
+        hpx::exclusive_scan(hpx::execution::par, std::begin(c),
             std::end(c), std::begin(d), val, op);
         double elapsed = t.elapsed();
 
@@ -74,7 +74,7 @@ void test_exclusive_scan1(ExPolicy policy, IteratorTag)
     std::size_t const val(0);
     auto op = [](std::size_t v1, std::size_t v2) { return v1 + v2; };
 
-    hpx::parallel::exclusive_scan(policy, iterator(std::begin(c)),
+    hpx::exclusive_scan(policy, iterator(std::begin(c)),
         iterator(std::end(c)), std::begin(d), val, op);
 
     // verify values
@@ -104,7 +104,7 @@ void test_exclusive_scan1_async(ExPolicy p, IteratorTag)
     std::size_t const val(0);
     auto op = [](std::size_t v1, std::size_t v2) { return v1 + v2; };
 
-    hpx::future<void> fut = hpx::parallel::exclusive_scan(p,
+    hpx::future<void> fut = hpx::exclusive_scan(p,
         iterator(std::begin(c)), iterator(std::end(c)), std::begin(d), val, op);
     fut.wait();
 

--- a/libs/parallelism/algorithms/tests/unit/algorithms/exclusive_scan2.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/exclusive_scan2.cpp
@@ -31,7 +31,7 @@ void test_exclusive_scan2(ExPolicy policy, IteratorTag)
     std::fill(std::begin(c), std::end(c), std::size_t(1));
 
     std::size_t const val(0);
-    hpx::parallel::exclusive_scan(policy, iterator(std::begin(c)),
+    hpx::exclusive_scan(policy, iterator(std::begin(c)),
         iterator(std::end(c)), std::begin(d), val);
 
     // verify values
@@ -53,7 +53,7 @@ void test_exclusive_scan2_async(ExPolicy p, IteratorTag)
     std::fill(std::begin(c), std::end(c), std::size_t(1));
 
     std::size_t const val(0);
-    hpx::future<void> f = hpx::parallel::exclusive_scan(
+    hpx::future<void> f = hpx::exclusive_scan(
         p, iterator(std::begin(c)), iterator(std::end(c)), std::begin(d), val);
     f.wait();
 

--- a/libs/parallelism/algorithms/tests/unit/algorithms/exclusive_scan2.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/exclusive_scan2.cpp
@@ -17,6 +17,28 @@
 #include "test_utils.hpp"
 
 ///////////////////////////////////////////////////////////////////////////////
+template <typename IteratorTag>
+void test_exclusive_scan2(IteratorTag)
+{
+    typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+
+    std::vector<std::size_t> c(10007);
+    std::vector<std::size_t> d(c.size());
+    std::fill(std::begin(c), std::end(c), std::size_t(1));
+
+    std::size_t const val(0);
+    hpx::exclusive_scan(
+        iterator(std::begin(c)), iterator(std::end(c)), std::begin(d), val);
+
+    // verify values
+    std::vector<std::size_t> e(c.size());
+    hpx::parallel::v1::detail::sequential_exclusive_scan(std::begin(c),
+        std::end(c), std::begin(e), val, std::plus<std::size_t>());
+
+    HPX_TEST(std::equal(std::begin(d), std::end(d), std::begin(e)));
+}
+
 template <typename ExPolicy, typename IteratorTag>
 void test_exclusive_scan2(ExPolicy policy, IteratorTag)
 {
@@ -31,8 +53,8 @@ void test_exclusive_scan2(ExPolicy policy, IteratorTag)
     std::fill(std::begin(c), std::end(c), std::size_t(1));
 
     std::size_t const val(0);
-    hpx::exclusive_scan(policy, iterator(std::begin(c)),
-        iterator(std::end(c)), std::begin(d), val);
+    hpx::exclusive_scan(policy, iterator(std::begin(c)), iterator(std::end(c)),
+        std::begin(d), val);
 
     // verify values
     std::vector<std::size_t> e(c.size());
@@ -70,6 +92,7 @@ void test_exclusive_scan2()
 {
     using namespace hpx::execution;
 
+    test_exclusive_scan2(IteratorTag());
     test_exclusive_scan2(seq, IteratorTag());
     test_exclusive_scan2(par, IteratorTag());
     test_exclusive_scan2(par_unseq, IteratorTag());

--- a/libs/parallelism/algorithms/tests/unit/algorithms/exclusive_scan_bad_alloc.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/exclusive_scan_bad_alloc.cpp
@@ -33,7 +33,7 @@ void test_exclusive_scan_bad_alloc(ExPolicy policy, IteratorTag)
     bool caught_exception = false;
     try
     {
-        hpx::parallel::exclusive_scan(policy, iterator(std::begin(c)),
+        hpx::exclusive_scan(policy, iterator(std::begin(c)),
             iterator(std::end(c)), std::begin(d), std::size_t(0),
             [](std::size_t v1, std::size_t v2) {
                 return throw std::bad_alloc(), v1 + v2;
@@ -67,7 +67,7 @@ void test_exclusive_scan_bad_alloc_async(ExPolicy p, IteratorTag)
     bool returned_from_algorithm = false;
     try
     {
-        hpx::future<void> f = hpx::parallel::exclusive_scan(p,
+        hpx::future<void> f = hpx::exclusive_scan(p,
             iterator(std::begin(c)), iterator(std::end(c)), std::begin(d),
             std::size_t(0), [](std::size_t v1, std::size_t v2) {
                 return throw std::bad_alloc(), v1 + v2;

--- a/libs/parallelism/algorithms/tests/unit/algorithms/exclusive_scan_bad_alloc.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/exclusive_scan_bad_alloc.cpp
@@ -67,9 +67,9 @@ void test_exclusive_scan_bad_alloc_async(ExPolicy p, IteratorTag)
     bool returned_from_algorithm = false;
     try
     {
-        hpx::future<void> f = hpx::exclusive_scan(p,
-            iterator(std::begin(c)), iterator(std::end(c)), std::begin(d),
-            std::size_t(0), [](std::size_t v1, std::size_t v2) {
+        hpx::future<void> f = hpx::exclusive_scan(p, iterator(std::begin(c)),
+            iterator(std::end(c)), std::begin(d), std::size_t(0),
+            [](std::size_t v1, std::size_t v2) {
                 return throw std::bad_alloc(), v1 + v2;
             });
 

--- a/libs/parallelism/algorithms/tests/unit/algorithms/exclusive_scan_exception.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/exclusive_scan_exception.cpp
@@ -33,7 +33,7 @@ void test_exclusive_scan_exception(ExPolicy policy, IteratorTag)
     bool caught_exception = false;
     try
     {
-        hpx::parallel::exclusive_scan(policy, iterator(std::begin(c)),
+        hpx::exclusive_scan(policy, iterator(std::begin(c)),
             iterator(std::end(c)), std::begin(d), std::size_t(0),
             [](std::size_t v1, std::size_t v2) {
                 return throw std::runtime_error("test"), v1 + v2;
@@ -68,7 +68,7 @@ void test_exclusive_scan_exception_async(ExPolicy p, IteratorTag)
     bool returned_from_algorithm = false;
     try
     {
-        hpx::future<void> f = hpx::parallel::exclusive_scan(p,
+        hpx::future<void> f = hpx::exclusive_scan(p,
             iterator(std::begin(c)), iterator(std::end(c)), std::begin(d),
             std::size_t(0), [](std::size_t v1, std::size_t v2) {
                 return throw std::runtime_error("test"), v1 + v2;

--- a/libs/parallelism/algorithms/tests/unit/algorithms/exclusive_scan_exception.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/exclusive_scan_exception.cpp
@@ -68,9 +68,9 @@ void test_exclusive_scan_exception_async(ExPolicy p, IteratorTag)
     bool returned_from_algorithm = false;
     try
     {
-        hpx::future<void> f = hpx::exclusive_scan(p,
-            iterator(std::begin(c)), iterator(std::end(c)), std::begin(d),
-            std::size_t(0), [](std::size_t v1, std::size_t v2) {
+        hpx::future<void> f = hpx::exclusive_scan(p, iterator(std::begin(c)),
+            iterator(std::end(c)), std::begin(d), std::size_t(0),
+            [](std::size_t v1, std::size_t v2) {
                 return throw std::runtime_error("test"), v1 + v2;
             });
 

--- a/libs/parallelism/algorithms/tests/unit/algorithms/exclusive_scan_validate.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/exclusive_scan_validate.cpp
@@ -63,7 +63,7 @@ void test_exclusive_scan_validate(
         std::ostream_iterator<int>(std::cout, ", "));
 #endif
     b.resize(a.size());
-    hpx::parallel::exclusive_scan(p, a.begin(), a.end(), b.begin(), INITIAL_VAL,
+    hpx::exclusive_scan(p, a.begin(), a.end(), b.begin(), INITIAL_VAL,
         [](int bar, int baz) { return bar + baz; });
 #ifdef DUMP_VALUES
     std::cout << "\nOutput : ";
@@ -97,7 +97,7 @@ void test_exclusive_scan_validate(
         std::ostream_iterator<int>(std::cout, ", "));
 #endif
     b.resize(a.size());
-    hpx::parallel::exclusive_scan(p, a.begin(), a.end(), b.begin(), INITIAL_VAL,
+    hpx::exclusive_scan(p, a.begin(), a.end(), b.begin(), INITIAL_VAL,
         [](int bar, int baz) { return bar + baz; });
 #ifdef DUMP_VALUES
     std::cout << "\nOutput : ";
@@ -130,7 +130,7 @@ void test_exclusive_scan_validate(
         std::ostream_iterator<int>(std::cout, ", "));
 #endif
     b.resize(a.size());
-    hpx::parallel::exclusive_scan(p, a.begin(), a.end(), b.begin(), INITIAL_VAL,
+    hpx::exclusive_scan(p, a.begin(), a.end(), b.begin(), INITIAL_VAL,
         [](int bar, int baz) { return bar + baz; });
 #ifdef DUMP_VALUES
     std::cout << "\nOutput : ";

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/CMakeLists.txt
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/CMakeLists.txt
@@ -24,6 +24,7 @@ set(tests
     distance
     equal_range
     equal_binary_range
+    exclusive_scan_range
     fill_range
     filln_range
     find_range

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/exclusive_scan_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/exclusive_scan_range.cpp
@@ -1,5 +1,6 @@
 //  Copyright (c) 2018 Christopher Ogle
 //  Copyright (c) 2020 Hartmut Kaiser
+//  Copyright (c) 2021 Akhil J Nair
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -38,8 +39,11 @@ void test_exclusive_scan_sent(IteratorTag)
     std::size_t const val(0);
     auto op = [](std::size_t v1, std::size_t v2) { return v1 + v2; };
 
-    hpx::ranges::exclusive_scan(
+    auto res = hpx::ranges::exclusive_scan(
         std::begin(c), sentinel<std::size_t>{2}, std::begin(d), val, op);
+
+    HPX_TEST(res.in == std::begin(c) + end_len);
+    HPX_TEST(res.out == std::begin(d) + end_len);
 
     // verify values
     std::vector<std::size_t> e(end_len);
@@ -64,8 +68,11 @@ void test_exclusive_scan_sent(ExPolicy policy, IteratorTag)
     std::size_t const val(0);
     auto op = [](std::size_t v1, std::size_t v2) { return v1 + v2; };
 
-    hpx::ranges::exclusive_scan(policy, std::begin(c), sentinel<std::size_t>{2},
-        std::begin(d), val, op);
+    auto res = hpx::ranges::exclusive_scan(policy, std::begin(c),
+        sentinel<std::size_t>{2}, std::begin(d), val, op);
+
+    HPX_TEST(res.in == std::begin(c) + end_len);
+    HPX_TEST(res.out == std::begin(d) + end_len);
 
     // verify values
     std::vector<std::size_t> e(end_len);
@@ -85,7 +92,10 @@ void test_exclusive_scan(IteratorTag)
     std::size_t const val(0);
     auto op = [](std::size_t v1, std::size_t v2) { return v1 + v2; };
 
-    hpx::ranges::exclusive_scan(c, std::begin(d), val, op);
+    auto res = hpx::ranges::exclusive_scan(c, std::begin(d), val, op);
+
+    HPX_TEST(res.in == std::end(c));
+    HPX_TEST(res.out == std::end(d));
 
     // verify values
     std::vector<std::size_t> e(c.size());
@@ -108,7 +118,10 @@ void test_exclusive_scan(ExPolicy policy, IteratorTag)
     std::size_t const val(0);
     auto op = [](std::size_t v1, std::size_t v2) { return v1 + v2; };
 
-    hpx::ranges::exclusive_scan(policy, c, std::begin(d), val, op);
+    auto res = hpx::ranges::exclusive_scan(policy, c, std::begin(d), val, op);
+
+    HPX_TEST(res.in == std::end(c));
+    HPX_TEST(res.out == std::end(d));
 
     // verify values
     std::vector<std::size_t> e(c.size());

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/exclusive_scan_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/exclusive_scan_range.cpp
@@ -11,6 +11,7 @@
 #include <hpx/parallel/container_algorithms/exclusive_scan.hpp>
 
 #include <algorithm>
+#include <cstddef>
 #include <iostream>
 #include <iterator>
 #include <random>


### PR DESCRIPTION
Adapted exclusive_scan to C++ 20 and added container overloads. (range and sentinel). Added container tests. Seperated segmented overloads.

## Any background context you want to provide?
Issue #4822
Issue #3646
Issue #1668
Issue #5156