### PR TITLE
Add back explicit -pthread flags when available

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2015,7 +2015,9 @@ else()
      AND NOT WIN32
      AND NOT HPX_WITH_SANITIZERS
   )
-    hpx_add_link_flag_if_available(-Wl,-z,defs TARGETS SHARED EXE)
+    hpx_add_link_flag_if_available(
+      -Wl,-z,defs TARGETS SHARED_LIBRARY EXECUTABLE
+    )
   endif()
   if(WIN32)
     target_link_libraries(hpx_base_libraries INTERFACE psapi WS2_32 mswsock)
@@ -2027,7 +2029,9 @@ else()
 
   if(HPX_WITH_HIDDEN_VISIBILITY)
     hpx_add_compile_flag_if_available(-fvisibility=hidden)
-    hpx_add_link_flag_if_available(-fvisibility=hidden TARGETS SHARED EXE)
+    hpx_add_link_flag_if_available(
+      -fvisibility=hidden TARGETS SHARED_LIBRARY EXECUTABLE
+    )
     hpx_add_config_define(HPX_HAVE_ELF_HIDDEN_VISIBILITY)
     hpx_add_config_define(HPX_HAVE_COROUTINE_GCC_HIDDEN_VISIBILITY)
     hpx_add_config_define(HPX_HAVE_PLUGIN_GCC_HIDDEN_VISIBILITY)

--- a/cmake/HPX_AddCompileFlag.cmake
+++ b/cmake/HPX_AddCompileFlag.cmake
@@ -5,7 +5,6 @@
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 include(CMakeParseArguments)
-include(CheckCCompilerFlag)
 include(CheckCXXCompilerFlag)
 
 function(hpx_add_target_compile_option FLAG)
@@ -179,12 +178,17 @@ function(hpx_add_compile_flag)
 endfunction()
 
 function(hpx_add_compile_flag_if_available FLAG)
+  set(options PUBLIC)
   set(one_value_args NAME)
   set(multi_value_args CONFIGURATIONS LANGUAGES)
   cmake_parse_arguments(
     HPX_ADD_COMPILE_FLAG_IA "${options}" "${one_value_args}"
     "${multi_value_args}" ${ARGN}
   )
+
+  if(HPX_ADD_COMPILE_FLAG_IA_PUBLIC)
+    set(_public PUBLIC)
+  endif()
 
   if(HPX_ADD_COMPILE_FLAG_IA_NAME)
     string(TOUPPER ${HPX_ADD_COMPILE_FLAG_IA_NAME} _name)
@@ -211,7 +215,7 @@ function(hpx_add_compile_flag_if_available FLAG)
     if(HPX_WITH_${_lang}_FLAG_${_name})
       hpx_add_compile_flag(
         ${FLAG} CONFIGURATIONS ${HPX_ADD_COMPILE_FLAG_IA_CONFIGURATIONS}
-        LANGUAGES ${_lang}
+        LANGUAGES ${_lang} ${_public}
       )
     else()
       hpx_info("\"${FLAG}\" not available for language ${_lang}.")

--- a/cmake/HPX_SetupThreads.cmake
+++ b/cmake/HPX_SetupThreads.cmake
@@ -10,4 +10,7 @@ find_package(Threads REQUIRED)
 
 if(NOT HPX_FIND_PACKAGE)
   target_link_libraries(hpx_base_libraries INTERFACE Threads::Threads)
+
+  hpx_add_compile_flag_if_available(-pthread PUBLIC)
+  hpx_add_link_flag_if_available(-pthread PUBLIC)
 endif()


### PR DESCRIPTION
It turns out that we do actually need the `-pthread` flag when using the Cray compiler, so I'm adding it back here for both compilation and linking (#5420 is responsible for the timeouts on the clang-cuda configuration and I missed this before merging). The flag also now gets passed on to consuming projects unlike before #5420.

@kordejong I know you may be tired of rebuilding HPX, but if you have the time I'd be very grateful if you could also test this on your system to ensure that I haven't brought things back to before #5420...