### PR TITLE
Adapt inclusive_scan to C++ 20

### DIFF
--- a/docs/sphinx/api/public_api.rst
+++ b/docs/sphinx/api/public_api.rst
@@ -602,11 +602,13 @@ Functions
 
 - :cpp:func:`hpx::parallel::v1::adjacent_difference`
 - :cpp:func:`hpx::parallel::v1::exclusive_scan`
-- :cpp:func:`hpx::parallel::v1::inclusive_scan`
+- :cpp:func:`hpx::inclusive_scan`
 - :cpp:func:`hpx::reduce`
 - :cpp:func:`hpx::parallel::v1::transform_exclusive_scan`
 - :cpp:func:`hpx::parallel::v1::transform_inclusive_scan`
 - :cpp:func:`hpx::transform_reduce`
+
+- :cpp:func:`hpx::ranges::inclusive_scan`
 
 Header ``hpx/optional.hpp``
 ===========================

--- a/docs/sphinx/manual/writing_single_node_hpx_applications.rst
+++ b/docs/sphinx/manual/writing_single_node_hpx_applications.rst
@@ -677,7 +677,7 @@ Parallel algorithms
      * Sums up a range of elements.
      * ``<hpx/numeric.hpp>``
      * :cppreference-algorithm:`reduce`
-   * * :cpp:func:`hpx::parallel::v1::inclusive_scan`
+   * * :cpp:func:`hpx::inclusive_scan`
      * Does an inclusive parallel scan over a range of elements.
      * ``<hpx/algorithm.hpp>``
      * :cppreference-algorithm:`inclusive_scan`

--- a/libs/core/iterator_support/include/hpx/iterator_support/traits/is_range.hpp
+++ b/libs/core/iterator_support/include/hpx/iterator_support/traits/is_range.hpp
@@ -53,4 +53,7 @@ namespace hpx { namespace traits {
         typedef typename util::detail::iterator<R>::type iterator_type;
         typedef typename util::detail::sentinel<R>::type sentinel_type;
     };
+
+    template <typename T>
+    using range_iterator_t = typename range_iterator<T>::type;
 }}    // namespace hpx::traits

--- a/libs/full/collectives/include/hpx/collectives/inclusive_scan.hpp
+++ b/libs/full/collectives/include/hpx/collectives/inclusive_scan.hpp
@@ -137,7 +137,7 @@ namespace hpx { namespace traits {
                     std::vector<arg_type> dest;
                     dest.resize(data.size());
 
-                    hpx::parallel::inclusive_scan(hpx::execution::seq,
+                    hpx::inclusive_scan(hpx::execution::seq,
                         data.begin(), data.end(), dest.begin(),
                         std::forward<F>(op));
 

--- a/libs/full/collectives/include/hpx/collectives/inclusive_scan.hpp
+++ b/libs/full/collectives/include/hpx/collectives/inclusive_scan.hpp
@@ -137,9 +137,8 @@ namespace hpx { namespace traits {
                     std::vector<arg_type> dest;
                     dest.resize(data.size());
 
-                    hpx::inclusive_scan(hpx::execution::seq,
-                        data.begin(), data.end(), dest.begin(),
-                        std::forward<F>(op));
+                    hpx::inclusive_scan(hpx::execution::seq, data.begin(),
+                        data.end(), dest.begin(), std::forward<F>(op));
 
                     std::swap(data, dest);
                     communicator.data_available_ = true;

--- a/libs/full/include_local/include/hpx/local/numeric.hpp
+++ b/libs/full/include_local/include/hpx/local/numeric.hpp
@@ -12,7 +12,6 @@
 namespace hpx {
     using hpx::parallel::adjacent_difference;
     using hpx::parallel::exclusive_scan;
-    using hpx::parallel::inclusive_scan;
     using hpx::parallel::transform_exclusive_scan;
     using hpx::parallel::transform_inclusive_scan;
 }    // namespace hpx

--- a/libs/full/segmented_algorithms/include/hpx/parallel/segmented_algorithms/inclusive_scan.hpp
+++ b/libs/full/segmented_algorithms/include/hpx/parallel/segmented_algorithms/inclusive_scan.hpp
@@ -260,8 +260,7 @@ namespace hpx { namespace segmented {
 
     // clang-format off
     template <typename InIter, typename OutIter,
-        typename Op,
-        typename Proj = parallel::util::projection_identity,
+        typename Op = std::plus<typename std::iterator_traits<InIter>::value_type>,
         HPX_CONCEPT_REQUIRES_(
             hpx::traits::is_iterator<InIter>::value &&
             hpx::traits::is_segmented_iterator<InIter>::value &&
@@ -269,8 +268,8 @@ namespace hpx { namespace segmented {
             hpx::traits::is_segmented_iterator<OutIter>::value
         )>
     // clang-format on
-    OutIter tag_dispatch(
-        hpx::inclusive_scan_t, InIter first, InIter last, OutIter dest, Op&& op)
+    OutIter tag_dispatch(hpx::inclusive_scan_t, InIter first, InIter last,
+        OutIter dest, Op&& op = Op())
     {
         static_assert(hpx::traits::is_input_iterator<InIter>::value,
             "Requires at least input iterator.");
@@ -291,7 +290,7 @@ namespace hpx { namespace segmented {
 
     // clang-format off
     template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
-        typename Op,
+        typename Op = std::plus<typename std::iterator_traits<FwdIter1>::value_type>,
         HPX_CONCEPT_REQUIRES_(
             hpx::is_execution_policy<ExPolicy>::value &&
             hpx::traits::is_iterator<FwdIter1>::value &&
@@ -302,7 +301,7 @@ namespace hpx { namespace segmented {
     // clang-format on
     typename parallel::util::detail::algorithm_result<ExPolicy, FwdIter2>::type
     tag_dispatch(hpx::inclusive_scan_t, ExPolicy&& policy, FwdIter1 first,
-        FwdIter1 last, FwdIter2 dest, Op&& op)
+        FwdIter1 last, FwdIter2 dest, Op&& op = Op())
     {
         static_assert(hpx::traits::is_forward_iterator<FwdIter1>::value,
             "Requires at least forward iterator.");

--- a/libs/full/segmented_algorithms/include/hpx/parallel/segmented_algorithms/inclusive_scan.hpp
+++ b/libs/full/segmented_algorithms/include/hpx/parallel/segmented_algorithms/inclusive_scan.hpp
@@ -260,7 +260,8 @@ namespace hpx { namespace segmented {
 
     // clang-format off
     template <typename InIter, typename OutIter,
-            typename Op, typename Conv,
+        typename Op,
+        typename Proj = parallel::util::projection_identity,
         HPX_CONCEPT_REQUIRES_(
             hpx::traits::is_iterator<InIter>::value &&
             hpx::traits::is_segmented_iterator<InIter>::value &&
@@ -268,8 +269,8 @@ namespace hpx { namespace segmented {
             hpx::traits::is_segmented_iterator<OutIter>::value
         )>
     // clang-format on
-    OutIter tag_dispatch(hpx::inclusive_scan_t, InIter first, InIter last,
-        OutIter dest, Op&& op, Conv&& conv)
+    OutIter tag_dispatch(
+        hpx::inclusive_scan_t, InIter first, InIter last, OutIter dest, Op&& op)
     {
         static_assert(hpx::traits::is_input_iterator<InIter>::value,
             "Requires at least input iterator.");
@@ -284,12 +285,13 @@ namespace hpx { namespace segmented {
 
         return hpx::parallel::v1::detail::segmented_inclusive_scan(
             hpx::execution::seq, first, last, dest, value_type{},
-            std::forward<Op>(op), std::true_type{}, std::forward<Conv>(conv));
+            std::forward<Op>(op), std::true_type{},
+            parallel::util::projection_identity{});
     }
 
     // clang-format off
     template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
-        typename Op, typename Conv,
+        typename Op,
         HPX_CONCEPT_REQUIRES_(
             hpx::is_execution_policy<ExPolicy>::value &&
             hpx::traits::is_iterator<FwdIter1>::value &&
@@ -300,7 +302,7 @@ namespace hpx { namespace segmented {
     // clang-format on
     typename parallel::util::detail::algorithm_result<ExPolicy, FwdIter2>::type
     tag_dispatch(hpx::inclusive_scan_t, ExPolicy&& policy, FwdIter1 first,
-        FwdIter1 last, FwdIter2 dest, Op&& op, Conv&& conv)
+        FwdIter1 last, FwdIter2 dest, Op&& op)
     {
         static_assert(hpx::traits::is_forward_iterator<FwdIter1>::value,
             "Requires at least forward iterator.");
@@ -309,20 +311,21 @@ namespace hpx { namespace segmented {
             "Requires at least forward iterator.");
 
         if (first == last)
-            return util::detail::algorithm_result<ExPolicy, FwdIter2>::get(
-                std::move(dest));
+            return parallel::util::detail::algorithm_result<ExPolicy,
+                FwdIter2>::get(std::move(dest));
 
-        using value_type = typename std::iterator_traits<InIter>::value_type;
+        using value_type = typename std::iterator_traits<FwdIter1>::value_type;
         using is_seq = hpx::is_sequenced_execution_policy<ExPolicy>;
 
         return hpx::parallel::v1::detail::segmented_inclusive_scan(
             std::forward<ExPolicy>(policy), first, last, dest, value_type{},
-            std::forward<Op>(op), is_seq(), std::forward<Conv>(conv));
+            std::forward<Op>(op), is_seq(),
+            parallel::util::projection_identity{});
     }
 
     // clang-format off
     template <typename InIter, typename OutIter,
-            typename T, typename Op, typename Conv,
+        typename Op, typename T,
         HPX_CONCEPT_REQUIRES_(
             hpx::traits::is_iterator<InIter>::value &&
             hpx::traits::is_segmented_iterator<InIter>::value &&
@@ -331,7 +334,7 @@ namespace hpx { namespace segmented {
         )>
     // clang-format on
     OutIter tag_dispatch(hpx::inclusive_scan_t, InIter first, InIter last,
-        OutIter dest, T&& init, Op&& op, Conv&& conv)
+        OutIter dest, Op&& op, T&& init)
     {
         static_assert(hpx::traits::is_input_iterator<InIter>::value,
             "Requires at least input iterator.");
@@ -344,12 +347,13 @@ namespace hpx { namespace segmented {
 
         return hpx::parallel::v1::detail::segmented_inclusive_scan(
             hpx::execution::seq, first, last, dest, std::forward<T>(init),
-            std::forward<Op>(op), std::true_type{}, std::forward<Conv>(conv));
+            std::forward<Op>(op), std::true_type{},
+            parallel::util::projection_identity{});
     }
 
     // clang-format off
     template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
-        typename T, typename Op, typename Conv,
+        typename Op, typename T,
         HPX_CONCEPT_REQUIRES_(
             hpx::is_execution_policy<ExPolicy>::value &&
             hpx::traits::is_iterator<FwdIter1>::value &&
@@ -360,7 +364,7 @@ namespace hpx { namespace segmented {
     // clang-format on
     typename parallel::util::detail::algorithm_result<ExPolicy, FwdIter2>::type
     tag_dispatch(hpx::inclusive_scan_t, ExPolicy&& policy, FwdIter1 first,
-        FwdIter1 last, FwdIter2 dest, T&& init, Op&& op, Conv&& conv)
+        FwdIter1 last, FwdIter2 dest, Op&& op, T&& init)
     {
         static_assert(hpx::traits::is_forward_iterator<FwdIter1>::value,
             "Requires at least forward iterator.");
@@ -369,14 +373,14 @@ namespace hpx { namespace segmented {
             "Requires at least forward iterator.");
 
         if (first == last)
-            return util::detail::algorithm_result<ExPolicy, FwdIter2>::get(
-                std::move(dest));
+            return parallel::util::detail::algorithm_result<ExPolicy,
+                FwdIter2>::get(std::move(dest));
 
         using is_seq = hpx::is_sequenced_execution_policy<ExPolicy>;
 
         return hpx::parallel::v1::detail::segmented_inclusive_scan(
             std::forward<ExPolicy>(policy), first, last, dest,
             std::forward<T>(init), std::forward<Op>(op), is_seq(),
-            std::forward<Conv>(conv));
+            parallel::util::projection_identity{});
     }
 }}    // namespace hpx::segmented

--- a/libs/full/segmented_algorithms/include/hpx/parallel/segmented_algorithms/inclusive_scan.hpp
+++ b/libs/full/segmented_algorithms/include/hpx/parallel/segmented_algorithms/inclusive_scan.hpp
@@ -1,5 +1,6 @@
 //  Copyright (c) 2016 Minh-Khanh Do
 //  Copyright (c) 2020 Hartmut Kaiser
+//  Copyright (c) 2021 Akhil J Nair
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -56,7 +57,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
           : public detail::algorithm<segmented_inclusive_scan_vector<Value>,
                 Value>
         {
-            typedef Value vector_type;
+            using vector_type = Value;
 
             segmented_inclusive_scan_vector()
               : segmented_inclusive_scan_vector::algorithm(
@@ -68,8 +69,8 @@ namespace hpx { namespace parallel { inline namespace v1 {
             static vector_type sequential(
                 ExPolicy&& policy, InIter first, InIter last, Op&& op)
             {
-                typedef typename std::iterator_traits<InIter>::value_type
-                    value_type;
+                using value_type =
+                    typename std::iterator_traits<InIter>::value_type;
 
                 vector_type result(std::distance(first, last));
 
@@ -91,11 +92,10 @@ namespace hpx { namespace parallel { inline namespace v1 {
             parallel(
                 ExPolicy&& /* policy */, FwdIter first, FwdIter last, Op&& op)
             {
-                typedef typename std::iterator_traits<FwdIter>::value_type
-                    value_type;
-
-                typedef util::detail::algorithm_result<ExPolicy, vector_type>
-                    result;
+                using value_type =
+                    typename std::iterator_traits<FwdIter>::value_type;
+                using result =
+                    util::detail::algorithm_result<ExPolicy, vector_type>;
 
                 vector_type res(std::distance(first, last));
 
@@ -128,7 +128,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
             SegIter last, OutIter dest, T const& init, Op&& op, std::true_type,
             Conv&& conv)
         {
-            typedef hpx::traits::segmented_iterator_traits<OutIter> traits_out;
+            using traits_out = hpx::traits::segmented_iterator_traits<OutIter>;
 
             return segmented_scan_seq<transform_inclusive_scan<
                 typename traits_out::local_raw_iterator>>(
@@ -145,7 +145,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
             SegIter last, OutIter dest, T const& init, Op&& op, std::false_type,
             Conv&& /* conv */)
         {
-            typedef std::vector<T> vector_type;
+            using vector_type = std::vector<T>;
 
             return segmented_scan_seq_non<
                 segmented_inclusive_scan_vector<vector_type>>(
@@ -167,7 +167,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
             SegIter last, OutIter dest, T const& init, Op&& op, std::true_type,
             Conv&& conv)
         {
-            typedef hpx::traits::segmented_iterator_traits<OutIter> traits_out;
+            using traits_out = hpx::traits::segmented_iterator_traits<OutIter>;
 
             return segmented_scan_par<transform_inclusive_scan<
                 typename traits_out::local_raw_iterator>>(
@@ -184,7 +184,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
             SegIter last, OutIter dest, T const& init, Op&& op, std::false_type,
             Conv&&)
         {
-            typedef std::vector<T> vector_type;
+            using vector_type = std::vector<T>;
 
             return segmented_scan_par_non<
                 segmented_inclusive_scan_vector<vector_type>>(
@@ -202,8 +202,8 @@ namespace hpx { namespace parallel { inline namespace v1 {
         segmented_inclusive_scan(ExPolicy&& policy, SegIter first, SegIter last,
             OutIter dest, T const& init, Op&& op, std::true_type, Conv&& conv)
         {
-            typedef typename hpx::traits::segmented_iterator_traits<
-                OutIter>::is_segmented_iterator is_out_seg;
+            using is_out_seg = typename hpx::traits::segmented_iterator_traits<
+                OutIter>::is_segmented_iterator;
 
             // check if OutIter is segmented in the same way as SegIter
             // NOLINTNEXTLINE(bugprone-branch-clone)
@@ -231,8 +231,8 @@ namespace hpx { namespace parallel { inline namespace v1 {
         segmented_inclusive_scan(ExPolicy&& policy, SegIter first, SegIter last,
             OutIter dest, T const& init, Op&& op, std::false_type, Conv&& conv)
         {
-            typedef typename hpx::traits::segmented_iterator_traits<
-                OutIter>::is_segmented_iterator is_out_seg;
+            using is_out_seg = typename hpx::traits::segmented_iterator_traits<
+                OutIter>::is_segmented_iterator;
 
             // check if OutIter is segmented in the same way as SegIter
             // NOLINTNEXTLINE(bugprone-branch-clone)
@@ -262,19 +262,19 @@ namespace hpx { namespace segmented {
     template <typename InIter, typename OutIter,
         typename Op = std::plus<typename std::iterator_traits<InIter>::value_type>,
         HPX_CONCEPT_REQUIRES_(
-            hpx::traits::is_iterator<InIter>::value &&
-            hpx::traits::is_segmented_iterator<InIter>::value &&
-            hpx::traits::is_iterator<OutIter>::value &&
-            hpx::traits::is_segmented_iterator<OutIter>::value
+            hpx::traits::is_iterator_v<InIter> &&
+            hpx::traits::is_segmented_iterator_v<InIter> &&
+            hpx::traits::is_iterator_v<OutIter> &&
+            hpx::traits::is_segmented_iterator_v<OutIter>
         )>
     // clang-format on
     OutIter tag_dispatch(hpx::inclusive_scan_t, InIter first, InIter last,
         OutIter dest, Op&& op = Op())
     {
-        static_assert(hpx::traits::is_input_iterator<InIter>::value,
+        static_assert(hpx::traits::is_input_iterator_v<InIter>,
             "Requires at least input iterator.");
 
-        static_assert(hpx::traits::is_output_iterator<OutIter>::value,
+        static_assert(hpx::traits::is_output_iterator_v<OutIter>,
             "Requires at least output iterator.");
 
         if (first == last)
@@ -293,20 +293,20 @@ namespace hpx { namespace segmented {
         typename Op = std::plus<typename std::iterator_traits<FwdIter1>::value_type>,
         HPX_CONCEPT_REQUIRES_(
             hpx::is_execution_policy<ExPolicy>::value &&
-            hpx::traits::is_iterator<FwdIter1>::value &&
-            hpx::traits::is_segmented_iterator<FwdIter1>::value &&
-            hpx::traits::is_iterator<FwdIter2>::value &&
-            hpx::traits::is_segmented_iterator<FwdIter2>::value
+            hpx::traits::is_iterator_v<FwdIter1> &&
+            hpx::traits::is_segmented_iterator_v<FwdIter1> &&
+            hpx::traits::is_iterator_v<FwdIter2> &&
+            hpx::traits::is_segmented_iterator_v<FwdIter2>
         )>
     // clang-format on
     typename parallel::util::detail::algorithm_result<ExPolicy, FwdIter2>::type
     tag_dispatch(hpx::inclusive_scan_t, ExPolicy&& policy, FwdIter1 first,
         FwdIter1 last, FwdIter2 dest, Op&& op = Op())
     {
-        static_assert(hpx::traits::is_forward_iterator<FwdIter1>::value,
+        static_assert(hpx::traits::is_forward_iterator_v<FwdIter1>,
             "Requires at least forward iterator.");
 
-        static_assert(hpx::traits::is_forward_iterator<FwdIter2>::value,
+        static_assert(hpx::traits::is_forward_iterator_v<FwdIter2>,
             "Requires at least forward iterator.");
 
         if (first == last)
@@ -326,19 +326,19 @@ namespace hpx { namespace segmented {
     template <typename InIter, typename OutIter,
         typename Op, typename T,
         HPX_CONCEPT_REQUIRES_(
-            hpx::traits::is_iterator<InIter>::value &&
-            hpx::traits::is_segmented_iterator<InIter>::value &&
-            hpx::traits::is_iterator<OutIter>::value &&
-            hpx::traits::is_segmented_iterator<OutIter>::value
+            hpx::traits::is_iterator_v<InIter> &&
+            hpx::traits::is_segmented_iterator_v<InIter> &&
+            hpx::traits::is_iterator_v<OutIter> &&
+            hpx::traits::is_segmented_iterator_v<OutIter>
         )>
     // clang-format on
     OutIter tag_dispatch(hpx::inclusive_scan_t, InIter first, InIter last,
         OutIter dest, Op&& op, T&& init)
     {
-        static_assert(hpx::traits::is_input_iterator<InIter>::value,
+        static_assert(hpx::traits::is_input_iterator_v<InIter>,
             "Requires at least input iterator.");
 
-        static_assert(hpx::traits::is_output_iterator<OutIter>::value,
+        static_assert(hpx::traits::is_output_iterator_v<OutIter>,
             "Requires at least output iterator.");
 
         if (first == last)
@@ -355,20 +355,20 @@ namespace hpx { namespace segmented {
         typename Op, typename T,
         HPX_CONCEPT_REQUIRES_(
             hpx::is_execution_policy<ExPolicy>::value &&
-            hpx::traits::is_iterator<FwdIter1>::value &&
-            hpx::traits::is_segmented_iterator<FwdIter1>::value &&
-            hpx::traits::is_iterator<FwdIter2>::value &&
-            hpx::traits::is_segmented_iterator<FwdIter2>::value
+            hpx::traits::is_iterator_v<FwdIter1> &&
+            hpx::traits::is_segmented_iterator_v<FwdIter1> &&
+            hpx::traits::is_iterator_v<FwdIter2> &&
+            hpx::traits::is_segmented_iterator_v<FwdIter2>
         )>
     // clang-format on
     typename parallel::util::detail::algorithm_result<ExPolicy, FwdIter2>::type
     tag_dispatch(hpx::inclusive_scan_t, ExPolicy&& policy, FwdIter1 first,
         FwdIter1 last, FwdIter2 dest, Op&& op, T&& init)
     {
-        static_assert(hpx::traits::is_forward_iterator<FwdIter1>::value,
+        static_assert(hpx::traits::is_forward_iterator_v<FwdIter1>,
             "Requires at least forward iterator.");
 
-        static_assert(hpx::traits::is_forward_iterator<FwdIter2>::value,
+        static_assert(hpx::traits::is_forward_iterator_v<FwdIter2>,
             "Requires at least forward iterator.");
 
         if (first == last)

--- a/libs/full/segmented_algorithms/include/hpx/parallel/segmented_algorithms/transform_inclusive_scan.hpp
+++ b/libs/full/segmented_algorithms/include/hpx/parallel/segmented_algorithms/transform_inclusive_scan.hpp
@@ -42,9 +42,13 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 return util::detail::algorithm_result<ExPolicy, OutIter>::get(
                     std::move(dest));
             }
-            return inclusive_scan_(std::forward<ExPolicy>(policy), first, last,
-                dest, std::forward<T>(init), std::forward<Op>(op),
-                std::true_type(), std::forward<Conv>(conv));
+
+            using is_seq = hpx::is_sequenced_execution_policy<ExPolicy>;
+
+            return hpx::parallel::v1::detail::segmented_inclusive_scan(
+                std::forward<ExPolicy>(policy), first, last, dest,
+                std::forward<T>(init), std::forward<Op>(op), is_seq(),
+                std::forward<Conv>(conv));
         }
 
         template <typename ExPolicy, typename InIter, typename OutIter,
@@ -58,9 +62,14 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 return util::detail::algorithm_result<ExPolicy, OutIter>::get(
                     std::move(dest));
             }
-            return inclusive_scan_(std::forward<ExPolicy>(policy), first, last,
-                dest, std::forward<Op>(op), std::true_type(),
-                std::forward<Conv>(conv));
+
+            using is_seq = hpx::is_sequenced_execution_policy<ExPolicy>;
+            using value_type =
+                typename std::iterator_traits<InIter>::value_type;
+
+            return hpx::parallel::v1::detail::segmented_inclusive_scan(
+                std::forward<ExPolicy>(policy), first, last, dest, value_type{},
+                std::forward<Op>(op), is_seq(), std::forward<Conv>(conv));
         }
 
         // forward declare the non-segmented version of this algorithm

--- a/libs/full/segmented_algorithms/tests/unit/partitioned_vector_adjacent_difference1.cpp
+++ b/libs/full/segmented_algorithms/tests/unit/partitioned_vector_adjacent_difference1.cpp
@@ -78,8 +78,7 @@ void adjacent_difference_tests(std::vector<hpx::id_type>& localities)
 
     hpx::partitioned_vector<T> v(
         length, T(1), hpx::container_layout(localities));
-    hpx::parallel::inclusive_scan(
-        hpx::execution::seq, v.begin(), v.end(), v.begin());
+    hpx::inclusive_scan(hpx::execution::seq, v.begin(), v.end(), v.begin());
     hpx::partitioned_vector<T> w(length, hpx::container_layout(localities));
     test_adjacent_difference(hpx::execution::seq, v, w, T(1));
     test_adjacent_difference(hpx::execution::par, v, w, T(1));

--- a/libs/full/segmented_algorithms/tests/unit/partitioned_vector_adjacent_difference2.cpp
+++ b/libs/full/segmented_algorithms/tests/unit/partitioned_vector_adjacent_difference2.cpp
@@ -78,8 +78,7 @@ void adjacent_difference_tests(std::vector<hpx::id_type>& localities)
 
     hpx::partitioned_vector<T> v(
         length, T(1), hpx::container_layout(localities));
-    hpx::parallel::inclusive_scan(
-        hpx::execution::seq, v.begin(), v.end(), v.begin());
+    hpx::inclusive_scan(hpx::execution::seq, v.begin(), v.end(), v.begin());
     hpx::partitioned_vector<T> w(length, hpx::container_layout(localities));
     test_adjacent_difference(hpx::execution::seq, v, w, T(1));
     test_adjacent_difference(hpx::execution::par, v, w, T(1));

--- a/libs/full/segmented_algorithms/tests/unit/partitioned_vector_find.cpp
+++ b/libs/full/segmented_algorithms/tests/unit/partitioned_vector_find.cpp
@@ -114,8 +114,8 @@ void find_tests(std::vector<hpx::id_type>& localities)
     std::size_t const num = 1000;
     hpx::partitioned_vector<T> xvalues(
         num, T(1), hpx::container_layout(localities));
-    hpx::parallel::inclusive_scan(hpx::execution::seq, xvalues.begin(),
-        xvalues.end(), xvalues.begin(), std::plus<T>(), T(0));
+    hpx::inclusive_scan(hpx::execution::seq, xvalues.begin(), xvalues.end(),
+        xvalues.begin(), std::plus<T>(), T(0));
 
     test_find(xvalues, T(512));
     test_find(hpx::execution::seq, xvalues, T(512));

--- a/libs/full/segmented_algorithms/tests/unit/partitioned_vector_find2.cpp
+++ b/libs/full/segmented_algorithms/tests/unit/partitioned_vector_find2.cpp
@@ -114,8 +114,8 @@ void find_tests(std::vector<hpx::id_type>& localities)
     std::size_t const num = 1000;
     hpx::partitioned_vector<T> xvalues(
         num, T(1), hpx::container_layout(localities));
-    hpx::parallel::inclusive_scan(hpx::execution::seq, xvalues.begin(),
-        xvalues.end(), xvalues.begin(), std::plus<T>(), T(0));
+    hpx::inclusive_scan(hpx::execution::seq, xvalues.begin(), xvalues.end(),
+        xvalues.begin(), std::plus<T>(), T(0));
 
     test_find(xvalues, T(512));
     test_find(hpx::execution::seq, xvalues, T(512));

--- a/libs/full/segmented_algorithms/tests/unit/partitioned_vector_inclusive_scan.cpp
+++ b/libs/full/segmented_algorithms/tests/unit/partitioned_vector_inclusive_scan.cpp
@@ -59,7 +59,7 @@ void inclusive_scan_algo_tests_with_policy(std::size_t size,
     double e1 = t1.elapsed();
     t1.restart();
 
-    hpx::parallel::inclusive_scan(
+    hpx::inclusive_scan(
         policy, in.begin(), in.end(), out.begin(), opt<T>(), val);
 
     double e2 = t1.elapsed();
@@ -90,7 +90,7 @@ void inclusive_scan_algo_tests_segmented_out_with_policy(std::size_t size,
     double e1 = t1.elapsed();
     t1.restart();
 
-    hpx::parallel::inclusive_scan(
+    hpx::inclusive_scan(
         policy, in.begin(), in.end(), out.begin(), opt<T>(), val);
 
     double e2 = t1.elapsed();
@@ -120,7 +120,7 @@ void inclusive_scan_algo_tests_inplace_with_policy(std::size_t size,
     double e1 = t1.elapsed();
     t1.restart();
 
-    hpx::parallel::inclusive_scan(
+    hpx::inclusive_scan(
         policy, in.begin(), in.end(), in.begin(), opt<T>(), val);
 
     double e2 = t1.elapsed();
@@ -151,7 +151,7 @@ void inclusive_scan_algo_tests_with_policy_async(std::size_t size,
     double e1 = t1.elapsed();
     t1.restart();
 
-    auto res = hpx::parallel::inclusive_scan(
+    auto res = hpx::inclusive_scan(
         policy, in.begin(), in.end(), out.begin(), opt<T>(), val);
     res.get();
 
@@ -183,7 +183,7 @@ void inclusive_scan_algo_tests_segmented_out_with_policy_async(std::size_t size,
     double e1 = t1.elapsed();
     t1.restart();
 
-    auto res = hpx::parallel::inclusive_scan(
+    auto res = hpx::inclusive_scan(
         policy, in.begin(), in.end(), out.begin(), opt<T>(), val);
     res.get();
 
@@ -214,7 +214,7 @@ void inclusive_scan_algo_tests_inplace_with_policy_async(std::size_t size,
     double e1 = t1.elapsed();
     t1.restart();
 
-    auto res = hpx::parallel::inclusive_scan(
+    auto res = hpx::inclusive_scan(
         policy, in.begin(), in.end(), in.begin(), opt<T>(), val);
     res.get();
 

--- a/libs/full/segmented_algorithms/tests/unit/partitioned_vector_inclusive_scan2.cpp
+++ b/libs/full/segmented_algorithms/tests/unit/partitioned_vector_inclusive_scan2.cpp
@@ -59,7 +59,7 @@ void inclusive_scan_algo_tests_with_policy(std::size_t size,
     double e1 = t1.elapsed();
     t1.restart();
 
-    hpx::parallel::inclusive_scan(
+    hpx::inclusive_scan(
         policy, in.begin(), in.end(), out.begin(), opt<T>(), val);
 
     double e2 = t1.elapsed();
@@ -90,7 +90,7 @@ void inclusive_scan_algo_tests_segmented_out_with_policy(std::size_t size,
     double e1 = t1.elapsed();
     t1.restart();
 
-    hpx::parallel::inclusive_scan(
+    hpx::inclusive_scan(
         policy, in.begin(), in.end(), out.begin(), opt<T>(), val);
 
     double e2 = t1.elapsed();
@@ -120,7 +120,7 @@ void inclusive_scan_algo_tests_inplace_with_policy(std::size_t size,
     double e1 = t1.elapsed();
     t1.restart();
 
-    hpx::parallel::inclusive_scan(
+    hpx::inclusive_scan(
         policy, in.begin(), in.end(), in.begin(), opt<T>(), val);
 
     double e2 = t1.elapsed();
@@ -151,7 +151,7 @@ void inclusive_scan_algo_tests_with_policy_async(std::size_t size,
     double e1 = t1.elapsed();
     t1.restart();
 
-    auto res = hpx::parallel::inclusive_scan(
+    auto res = hpx::inclusive_scan(
         policy, in.begin(), in.end(), out.begin(), opt<T>(), val);
     res.get();
 
@@ -183,7 +183,7 @@ void inclusive_scan_algo_tests_segmented_out_with_policy_async(std::size_t size,
     double e1 = t1.elapsed();
     t1.restart();
 
-    auto res = hpx::parallel::inclusive_scan(
+    auto res = hpx::inclusive_scan(
         policy, in.begin(), in.end(), out.begin(), opt<T>(), val);
     res.get();
 
@@ -214,7 +214,7 @@ void inclusive_scan_algo_tests_inplace_with_policy_async(std::size_t size,
     double e1 = t1.elapsed();
     t1.restart();
 
-    auto res = hpx::parallel::inclusive_scan(
+    auto res = hpx::inclusive_scan(
         policy, in.begin(), in.end(), in.begin(), opt<T>(), val);
     res.get();
 

--- a/libs/parallelism/algorithms/CMakeLists.txt
+++ b/libs/parallelism/algorithms/CMakeLists.txt
@@ -96,6 +96,7 @@ set(algorithms_headers
     hpx/parallel/container_algorithms/generate.hpp
     hpx/parallel/container_algorithms.hpp
     hpx/parallel/container_algorithms/includes.hpp
+    hpx/parallel/container_algorithms/inclusive_scan.hpp
     hpx/parallel/container_algorithms/is_heap.hpp
     hpx/parallel/container_algorithms/is_partitioned.hpp
     hpx/parallel/container_algorithms/is_sorted.hpp

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/inclusive_scan.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/inclusive_scan.hpp
@@ -9,6 +9,416 @@
 
 #pragma once
 
+#if defined(DOXYGEN)
+namespace hpx {
+    // clang-format off
+
+    ///////////////////////////////////////////////////////////////////////////
+    /// Assigns through each iterator \a i in [result, result + (last - first))
+    /// the value of
+    /// GENERALIZED_NONCOMMUTATIVE_SUM(+, *first, ...,
+    /// *(first + (i - result))).
+    ///
+    /// \note   Complexity: O(\a last - \a first) applications of the
+    ///         predicate \a op.
+    ///
+    /// \tparam InIter      The type of the source iterators used (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     input iterator.
+    /// \tparam OutIter     The type of the iterator representing the
+    ///                     destination range (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     output iterator.
+    ///
+    /// \param first        Refers to the beginning of the sequence of elements
+    ///                     the algorithm will be applied to.
+    /// \param last         Refers to the end of the sequence of elements the
+    ///                     algorithm will be applied to.
+    /// \param dest         Refers to the beginning of the destination range.
+    ///
+    /// The reduce operations in the parallel \a inclusive_scan algorithm
+    /// invoked without an execution policy object will execute in sequential
+    /// order in the calling thread.
+    ///
+    /// \returns  The \a inclusive_scan algorithm returns \a OutIter.
+    ///           The \a inclusive_scan algorithm returns the output iterator
+    ///           to the element in the destination range, one past the last
+    ///           element copied.
+    ///
+    /// \note   GENERALIZED_NONCOMMUTATIVE_SUM(+, a1, ..., aN) is defined as:
+    ///         * a1 when N is 1
+    ///         * GENERALIZED_NONCOMMUTATIVE_SUM(+, a1, ..., aK)
+    ///           + GENERALIZED_NONCOMMUTATIVE_SUM(+, aM, ..., aN)
+    ///           where 1 < K+1 = M <= N.
+    ///
+    /// The difference between \a exclusive_scan and \a inclusive_scan is that
+    /// \a inclusive_scan includes the ith input element in the ith sum.
+    ///
+    template <typename InIter, typename OutIter>
+    OutIter inclusive_scan(InIter first, InIter last, OutIter dest);
+
+    ///////////////////////////////////////////////////////////////////////////
+    /// Assigns through each iterator \a i in [result, result + (last - first))
+    /// the value of
+    /// GENERALIZED_NONCOMMUTATIVE_SUM(+, *first, ...,
+    /// *(first + (i - result))).
+    ///
+    /// \note   Complexity: O(\a last - \a first) applications of the
+    ///         predicate \a op.
+    ///
+    /// \tparam ExPolicy    The type of the execution policy to use (deduced).
+    ///                     It describes the manner in which the execution
+    ///                     of the algorithm may be parallelized and the manner
+    ///                     in which it executes the assignments.
+    /// \tparam FwdIter1    The type of the source iterators used (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     forward iterator.
+    /// \tparam FwdIter2    The type of the iterator representing the
+    ///                     destination range (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     forward iterator.
+    ///
+    /// \param policy       The execution policy to use for the scheduling of
+    ///                     the iterations.
+    /// \param first        Refers to the beginning of the sequence of elements
+    ///                     the algorithm will be applied to.
+    /// \param last         Refers to the end of the sequence of elements the
+    ///                     algorithm will be applied to.
+    /// \param dest         Refers to the beginning of the destination range.
+    ///
+    /// The reduce operations in the parallel \a inclusive_scan algorithm invoked
+    /// with an execution policy object of type \a sequenced_policy
+    /// execute in sequential order in the calling thread.
+    ///
+    /// The reduce operations in the parallel \a inclusive_scan algorithm invoked
+    /// with an execution policy object of type \a parallel_policy
+    /// or \a parallel_task_policy are permitted to execute in an unordered
+    /// fashion in unspecified threads, and indeterminately sequenced
+    /// within each thread.
+    ///
+    /// \returns  The \a inclusive_scan algorithm returns a
+    ///           \a hpx::future<FwdIter2> if
+    ///           the execution policy is of type
+    ///           \a sequenced_task_policy or
+    ///           \a parallel_task_policy and
+    ///           returns \a FwdIter2 otherwise.
+    ///           The \a inclusive_scan algorithm returns the output iterator
+    ///           to the element in the destination range, one past the last
+    ///           element copied.
+    ///
+    /// \note   GENERALIZED_NONCOMMUTATIVE_SUM(+, a1, ..., aN) is defined as:
+    ///         * a1 when N is 1
+    ///         * GENERALIZED_NONCOMMUTATIVE_SUM(+, a1, ..., aK)
+    ///           + GENERALIZED_NONCOMMUTATIVE_SUM(+, aM, ..., aN)
+    ///           where 1 < K+1 = M <= N.
+    ///
+    /// The difference between \a exclusive_scan and \a inclusive_scan is that
+    /// \a inclusive_scan includes the ith input element in the ith sum.
+    ///
+    template <typename ExPolicy, typename FwdIter1, typename FwdIter2>
+    typename util::detail::algorithm_result<ExPolicy, FwdIter2>::type
+    inclusive_scan(ExPolicy&& policy, FwdIter1 first, FwdIter1 last,
+        FwdIter2 dest);
+
+    ///////////////////////////////////////////////////////////////////////////
+    /// Assigns through each iterator \a i in [result, result + (last - first))
+    /// the value of
+    /// GENERALIZED_NONCOMMUTATIVE_SUM(op, *first, ...,
+    ///  *(first + (i - result))).
+    ///
+    /// \note   Complexity: O(\a last - \a first) applications of the
+    ///         predicate \a op.
+    ///
+    /// \tparam InIter      The type of the source iterators used (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     input iterator.
+    /// \tparam OutIter     The type of the iterator representing the
+    ///                     destination range (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     output iterator.
+    /// \tparam Op          The type of the binary function object used for
+    ///                     the reduction operation.
+    ///
+    /// \param first        Refers to the beginning of the sequence of elements
+    ///                     the algorithm will be applied to.
+    /// \param last         Refers to the end of the sequence of elements the
+    ///                     algorithm will be applied to.
+    /// \param dest         Refers to the beginning of the destination range.
+    /// \param op           Specifies the function (or function object) which
+    ///                     will be invoked for each of the values of the input
+    ///                     sequence. This is a
+    ///                     binary predicate. The signature of this predicate
+    ///                     should be equivalent to:
+    ///                     \code
+    ///                     Ret fun(const Type1 &a, const Type1 &b);
+    ///                     \endcode \n
+    ///                     The signature does not need to have const&, but
+    ///                     the function must not modify the objects passed to
+    ///                     it.
+    ///                     The types \a Type1 and \a Ret must be
+    ///                     such that an object of a type as given by the input
+    ///                     sequence can be implicitly converted to any
+    ///                     of those types.
+    ///
+    /// The reduce operations in the parallel \a inclusive_scan algorithm
+    /// invoked without an execution policy object will execute in sequential
+    /// order in the calling thread.
+    ///
+    /// \returns  The \a inclusive_scan algorithm returns \a OutIter.
+    ///           The \a inclusive_scan algorithm returns the output iterator
+    ///           to the element in the destination range, one past the last
+    ///           element copied.
+    ///
+    /// \note   GENERALIZED_NONCOMMUTATIVE_SUM(+, a1, ..., aN) is defined as:
+    ///         * a1 when N is 1
+    ///         * GENERALIZED_NONCOMMUTATIVE_SUM(+, a1, ..., aK)
+    ///           + GENERALIZED_NONCOMMUTATIVE_SUM(+, aM, ..., aN)
+    ///           where 1 < K+1 = M <= N.
+    ///
+    /// The difference between \a exclusive_scan and \a inclusive_scan is that
+    /// \a inclusive_scan includes the ith input element in the ith sum.
+    ///
+    template <typename InIter, typename OutIter, typename Op>
+    OutIter inclusive_scan(InIter first, InIter last, OutIter dest, Op&& op);
+
+    ///////////////////////////////////////////////////////////////////////////
+    /// Assigns through each iterator \a i in [result, result + (last - first))
+    /// the value of
+    /// GENERALIZED_NONCOMMUTATIVE_SUM(op, *first, ...,
+    /// *(first + (i - result))).
+    ///
+    /// \note   Complexity: O(\a last - \a first) applications of the
+    ///         predicate \a op.
+    ///
+    /// \tparam ExPolicy    The type of the execution policy to use (deduced).
+    ///                     It describes the manner in which the execution
+    ///                     of the algorithm may be parallelized and the manner
+    ///                     in which it executes the assignments.
+    /// \tparam FwdIter1    The type of the source iterators used (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     forward iterator.
+    /// \tparam FwdIter2    The type of the iterator representing the
+    ///                     destination range (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     forward iterator.
+    /// \tparam Op          The type of the binary function object used for
+    ///                     the reduction operation.
+    ///
+    /// \param policy       The execution policy to use for the scheduling of
+    ///                     the iterations.
+    /// \param first        Refers to the beginning of the sequence of elements
+    ///                     the algorithm will be applied to.
+    /// \param last         Refers to the end of the sequence of elements the
+    ///                     algorithm will be applied to.
+    /// \param dest         Refers to the beginning of the destination range.
+    /// \param op           Specifies the function (or function object) which
+    ///                     will be invoked for each of the values of the input
+    ///                     sequence. This is a
+    ///                     binary predicate. The signature of this predicate
+    ///                     should be equivalent to:
+    ///                     \code
+    ///                     Ret fun(const Type1 &a, const Type1 &b);
+    ///                     \endcode \n
+    ///                     The signature does not need to have const&, but
+    ///                     the function must not modify the objects passed to
+    ///                     it.
+    ///                     The types \a Type1 and \a Ret must be
+    ///                     such that an object of a type as given by the input
+    ///                     sequence can be implicitly converted to any
+    ///                     of those types.
+    ///
+    /// The reduce operations in the parallel \a inclusive_scan algorithm invoked
+    /// with an execution policy object of type \a sequenced_policy
+    /// execute in sequential order in the calling thread.
+    ///
+    /// The reduce operations in the parallel \a inclusive_scan algorithm invoked
+    /// with an execution policy object of type \a parallel_policy
+    /// or \a parallel_task_policy are permitted to execute in an unordered
+    /// fashion in unspecified threads, and indeterminately sequenced
+    /// within each thread.
+    ///
+    /// \returns  The \a inclusive_scan algorithm returns a
+    ///           \a hpx::future<FwdIter2> if
+    ///           the execution policy is of type
+    ///           \a sequenced_task_policy or
+    ///           \a parallel_task_policy and
+    ///           returns \a FwdIter2 otherwise.
+    ///           The \a inclusive_scan algorithm returns the output iterator
+    ///           to the element in the destination range, one past the last
+    ///           element copied.
+    ///
+    /// \note   GENERALIZED_NONCOMMUTATIVE_SUM(+, a1, ..., aN) is defined as:
+    ///         * a1 when N is 1
+    ///         * GENERALIZED_NONCOMMUTATIVE_SUM(op, a1, ..., aK)
+    ///           + GENERALIZED_NONCOMMUTATIVE_SUM(+, aM, ..., aN)
+    ///           where 1 < K+1 = M <= N.
+    ///
+    /// The difference between \a exclusive_scan and \a inclusive_scan is that
+    /// \a inclusive_scan includes the ith input element in the ith sum.
+    ///
+    template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
+        typename Op>
+    typename util::detail::algorithm_result<ExPolicy, FwdIter2>::type
+    inclusive_scan(ExPolicy&& policy, FwdIter1 first, FwdIter1 last,
+        FwdIter2 dest, Op&& op);
+
+    ///////////////////////////////////////////////////////////////////////////
+    /// Assigns through each iterator \a i in [result, result + (last - first))
+    /// the value of
+    /// GENERALIZED_NONCOMMUTATIVE_SUM(op, init, *first, ...,
+    /// *(first + (i - result))).
+    ///
+    /// \note   Complexity: O(\a last - \a first) applications of the
+    ///         predicate \a op.
+    ///
+    /// \tparam InIter      The type of the source iterators used (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     input iterator.
+    /// \tparam OutIter     The type of the iterator representing the
+    ///                     destination range (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     output iterator.
+    /// \tparam Op          The type of the binary function object used for
+    ///                     the reduction operation.
+    /// \tparam T           The type of the value to be used as initial (and
+    ///                     intermediate) values (deduced).
+    ///
+    /// \param first        Refers to the beginning of the sequence of elements
+    ///                     the algorithm will be applied to.
+    /// \param last         Refers to the end of the sequence of elements the
+    ///                     algorithm will be applied to.
+    /// \param dest         Refers to the beginning of the destination range.
+    /// \param op           Specifies the function (or function object) which
+    ///                     will be invoked for each of the values of the input
+    ///                     sequence. This is a
+    ///                     binary predicate. The signature of this predicate
+    ///                     should be equivalent to:
+    ///                     \code
+    ///                     Ret fun(const Type1 &a, const Type1 &b);
+    ///                     \endcode \n
+    ///                     The signature does not need to have const&, but
+    ///                     the function must not modify the objects passed to
+    ///                     it.
+    ///                     The types \a Type1 and \a Ret must be
+    ///                     such that an object of a type as given by the input
+    ///                     sequence can be implicitly converted to any
+    ///                     of those types.
+    /// \param init         The initial value for the generalized sum.
+    ///
+    /// The reduce operations in the parallel \a inclusive_scan algorithm
+    /// invoked without an execution policy object will execute in sequential
+    /// order in the calling thread.
+    ///
+    /// \returns  The \a inclusive_scan algorithm returns \a OutIter.
+    ///           The \a inclusive_scan algorithm returns the output iterator
+    ///           to the element in the destination range, one past the last
+    ///           element copied.
+    ///
+    /// \note   GENERALIZED_NONCOMMUTATIVE_SUM(op, a1, ..., aN) is defined as:
+    ///         * a1 when N is 1
+    ///         * op(GENERALIZED_NONCOMMUTATIVE_SUM(op, a1, ..., aK),
+    ///           GENERALIZED_NONCOMMUTATIVE_SUM(op, aM, ..., aN))
+    ///           where 1 < K+1 = M <= N.
+    ///
+    /// The difference between \a exclusive_scan and \a inclusive_scan is that
+    /// \a inclusive_scan includes the ith input element in the ith sum. If
+    /// \a op is not mathematically associative, the behavior of
+    /// \a inclusive_scan may be non-deterministic.
+    ///
+    template <typename InIter, typename OutIter,typename T, typename Op>
+    OutIter inclusive_scan(InIter first, InIter last, OutIter dest,
+        Op&& op, T init);
+
+    ///////////////////////////////////////////////////////////////////////////
+    /// Assigns through each iterator \a i in [result, result + (last - first))
+    /// the value of
+    /// GENERALIZED_NONCOMMUTATIVE_SUM(op, init, *first, ...,
+    /// *(first + (i - result))).
+    ///
+    /// \note   Complexity: O(\a last - \a first) applications of the
+    ///         predicate \a op.
+    ///
+    /// \tparam ExPolicy    The type of the execution policy to use (deduced).
+    ///                     It describes the manner in which the execution
+    ///                     of the algorithm may be parallelized and the manner
+    ///                     in which it executes the assignments.
+    /// \tparam FwdIter1    The type of the source iterators used (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     forward iterator.
+    /// \tparam FwdIter2    The type of the iterator representing the
+    ///                     destination range (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     forward iterator.
+    /// \tparam T           The type of the value to be used as initial (and
+    ///                     intermediate) values (deduced).
+    /// \tparam Op          The type of the binary function object used for
+    ///                     the reduction operation.
+    ///
+    /// \param policy       The execution policy to use for the scheduling of
+    ///                     the iterations.
+    /// \param first        Refers to the beginning of the sequence of elements
+    ///                     the algorithm will be applied to.
+    /// \param last         Refers to the end of the sequence of elements the
+    ///                     algorithm will be applied to.
+    /// \param dest         Refers to the beginning of the destination range.
+    /// \param init         The initial value for the generalized sum.
+    /// \param op           Specifies the function (or function object) which
+    ///                     will be invoked for each of the values of the input
+    ///                     sequence. This is a
+    ///                     binary predicate. The signature of this predicate
+    ///                     should be equivalent to:
+    ///                     \code
+    ///                     Ret fun(const Type1 &a, const Type1 &b);
+    ///                     \endcode \n
+    ///                     The signature does not need to have const&, but
+    ///                     the function must not modify the objects passed to
+    ///                     it.
+    ///                     The types \a Type1 and \a Ret must be
+    ///                     such that an object of a type as given by the input
+    ///                     sequence can be implicitly converted to any
+    ///                     of those types.
+    ///
+    /// The reduce operations in the parallel \a inclusive_scan algorithm invoked
+    /// with an execution policy object of type \a sequenced_policy
+    /// execute in sequential order in the calling thread.
+    ///
+    /// The reduce operations in the parallel \a inclusive_scan algorithm invoked
+    /// with an execution policy object of type \a parallel_policy
+    /// or \a parallel_task_policy are permitted to execute in an unordered
+    /// fashion in unspecified threads, and indeterminately sequenced
+    /// within each thread.
+    ///
+    /// \returns  The \a inclusive_scan algorithm returns a
+    ///           \a hpx::future<FwdIter2> if
+    ///           the execution policy is of type
+    ///           \a sequenced_task_policy or
+    ///           \a parallel_task_policy and
+    ///           returns \a FwdIter2 otherwise.
+    ///           The \a inclusive_scan algorithm returns the output iterator
+    ///           to the element in the destination range, one past the last
+    ///           element copied.
+    ///
+    /// \note   GENERALIZED_NONCOMMUTATIVE_SUM(op, a1, ..., aN) is defined as:
+    ///         * a1 when N is 1
+    ///         * op(GENERALIZED_NONCOMMUTATIVE_SUM(op, a1, ..., aK),
+    ///           GENERALIZED_NONCOMMUTATIVE_SUM(op, aM, ..., aN))
+    ///           where 1 < K+1 = M <= N.
+    ///
+    /// The difference between \a exclusive_scan and \a inclusive_scan is that
+    /// \a inclusive_scan includes the ith input element in the ith sum. If
+    /// \a op is not mathematically associative, the behavior of
+    /// \a inclusive_scan may be non-deterministic.
+    ///
+    template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
+        typename T, typename Op>
+    typename util::detail::algorithm_result<ExPolicy, FwdIter2>::type
+    inclusive_scan(ExPolicy&& policy, FwdIter1 first, FwdIter1 last,
+        FwdIter2 dest, T init, Op&& op);
+    // clang-format on
+}    // namespace hpx
+
+#else    // DOXYGEN
+
 #include <hpx/config.hpp>
 #include <hpx/concepts/concepts.hpp>
 #include <hpx/functional/invoke.hpp>
@@ -209,85 +619,6 @@ namespace hpx { namespace parallel { inline namespace v1 {
         /// \endcond
     }    // namespace detail
 
-    ///////////////////////////////////////////////////////////////////////////
-    /// Assigns through each iterator \a i in [result, result + (last - first))
-    /// the value of
-    /// GENERALIZED_NONCOMMUTATIVE_SUM(op, init, *first, ..., *(first + (i - result))).
-    ///
-    /// \note   Complexity: O(\a last - \a first) applications of the
-    ///         predicate \a op.
-    ///
-    /// \tparam ExPolicy    The type of the execution policy to use (deduced).
-    ///                     It describes the manner in which the execution
-    ///                     of the algorithm may be parallelized and the manner
-    ///                     in which it executes the assignments.
-    /// \tparam FwdIter1    The type of the source iterators used (deduced).
-    ///                     This iterator type must meet the requirements of an
-    ///                     forward iterator.
-    /// \tparam FwdIter2    The type of the iterator representing the
-    ///                     destination range (deduced).
-    ///                     This iterator type must meet the requirements of an
-    ///                     forward iterator.
-    /// \tparam T           The type of the value to be used as initial (and
-    ///                     intermediate) values (deduced).
-    /// \tparam Op          The type of the binary function object used for
-    ///                     the reduction operation.
-    ///
-    /// \param policy       The execution policy to use for the scheduling of
-    ///                     the iterations.
-    /// \param first        Refers to the beginning of the sequence of elements
-    ///                     the algorithm will be applied to.
-    /// \param last         Refers to the end of the sequence of elements the
-    ///                     algorithm will be applied to.
-    /// \param dest         Refers to the beginning of the destination range.
-    /// \param init         The initial value for the generalized sum.
-    /// \param op           Specifies the function (or function object) which
-    ///                     will be invoked for each of the values of the input
-    ///                     sequence. This is a
-    ///                     binary predicate. The signature of this predicate
-    ///                     should be equivalent to:
-    ///                     \code
-    ///                     Ret fun(const Type1 &a, const Type1 &b);
-    ///                     \endcode \n
-    ///                     The signature does not need to have const&, but
-    ///                     the function must not modify the objects passed to
-    ///                     it.
-    ///                     The types \a Type1 and \a Ret must be
-    ///                     such that an object of a type as given by the input
-    ///                     sequence can be implicitly converted to any
-    ///                     of those types.
-    ///
-    /// The reduce operations in the parallel \a inclusive_scan algorithm invoked
-    /// with an execution policy object of type \a sequenced_policy
-    /// execute in sequential order in the calling thread.
-    ///
-    /// The reduce operations in the parallel \a inclusive_scan algorithm invoked
-    /// with an execution policy object of type \a parallel_policy
-    /// or \a parallel_task_policy are permitted to execute in an unordered
-    /// fashion in unspecified threads, and indeterminately sequenced
-    /// within each thread.
-    ///
-    /// \returns  The \a inclusive_scan algorithm returns a
-    ///           \a hpx::future<FwdIter2> if
-    ///           the execution policy is of type
-    ///           \a sequenced_task_policy or
-    ///           \a parallel_task_policy and
-    ///           returns \a FwdIter2 otherwise.
-    ///           The \a inclusive_scan algorithm returns the output iterator
-    ///           to the element in the destination range, one past the last
-    ///           element copied.
-    ///
-    /// \note   GENERALIZED_NONCOMMUTATIVE_SUM(op, a1, ..., aN) is defined as:
-    ///         * a1 when N is 1
-    ///         * op(GENERALIZED_NONCOMMUTATIVE_SUM(op, a1, ..., aK),
-    ///           GENERALIZED_NONCOMMUTATIVE_SUM(op, aM, ..., aN))
-    ///           where 1 < K+1 = M <= N.
-    ///
-    /// The difference between \a exclusive_scan and \a inclusive_scan is that
-    /// \a inclusive_scan includes the ith input element in the ith sum. If
-    /// \a op is not mathematically associative, the behavior of
-    /// \a inclusive_scan may be non-deterministic.
-    ///
     // clang-format off
     template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
         typename Op, typename T,
@@ -301,6 +632,9 @@ namespace hpx { namespace parallel { inline namespace v1 {
             >
         )>
     // clang-format on
+    HPX_DEPRECATED_V(1, 8,
+        "hpx::parallel::inclusive_scan is deprecated, use hpx::inclusive_scan "
+        "instead")
     typename util::detail::algorithm_result<ExPolicy, FwdIter2>::type
     inclusive_scan(ExPolicy&& policy, FwdIter1 first, FwdIter1 last,
         FwdIter2 dest, Op&& op, T init)
@@ -310,85 +644,18 @@ namespace hpx { namespace parallel { inline namespace v1 {
         static_assert((hpx::traits::is_forward_iterator<FwdIter2>::value),
             "Requires at least forward iterator.");
 
+#if defined(HPX_GCC_VERSION) && HPX_GCC_VERSION >= 100000
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
         return hpx::parallel::v1::detail::inclusive_scan<FwdIter2>().call(
             std::forward<ExPolicy>(policy), first, last, dest, std::move(init),
             std::forward<Op>(op));
+#if defined(HPX_GCC_VERSION) && HPX_GCC_VERSION >= 100000
+#pragma GCC diagnostic pop
+#endif
     }
 
-    ///////////////////////////////////////////////////////////////////////////
-    /// Assigns through each iterator \a i in [result, result + (last - first))
-    /// the value of
-    /// GENERALIZED_NONCOMMUTATIVE_SUM(op, *first, ..., *(first + (i - result))).
-    ///
-    /// \note   Complexity: O(\a last - \a first) applications of the
-    ///         predicate \a op.
-    ///
-    /// \tparam ExPolicy    The type of the execution policy to use (deduced).
-    ///                     It describes the manner in which the execution
-    ///                     of the algorithm may be parallelized and the manner
-    ///                     in which it executes the assignments.
-    /// \tparam FwdIter1    The type of the source iterators used (deduced).
-    ///                     This iterator type must meet the requirements of an
-    ///                     forward iterator.
-    /// \tparam FwdIter2    The type of the iterator representing the
-    ///                     destination range (deduced).
-    ///                     This iterator type must meet the requirements of an
-    ///                     forward iterator.
-    /// \tparam Op          The type of the binary function object used for
-    ///                     the reduction operation.
-    ///
-    /// \param policy       The execution policy to use for the scheduling of
-    ///                     the iterations.
-    /// \param first        Refers to the beginning of the sequence of elements
-    ///                     the algorithm will be applied to.
-    /// \param last         Refers to the end of the sequence of elements the
-    ///                     algorithm will be applied to.
-    /// \param dest         Refers to the beginning of the destination range.
-    /// \param op           Specifies the function (or function object) which
-    ///                     will be invoked for each of the values of the input
-    ///                     sequence. This is a
-    ///                     binary predicate. The signature of this predicate
-    ///                     should be equivalent to:
-    ///                     \code
-    ///                     Ret fun(const Type1 &a, const Type1 &b);
-    ///                     \endcode \n
-    ///                     The signature does not need to have const&, but
-    ///                     the function must not modify the objects passed to
-    ///                     it.
-    ///                     The types \a Type1 and \a Ret must be
-    ///                     such that an object of a type as given by the input
-    ///                     sequence can be implicitly converted to any
-    ///                     of those types.
-    ///
-    /// The reduce operations in the parallel \a inclusive_scan algorithm invoked
-    /// with an execution policy object of type \a sequenced_policy
-    /// execute in sequential order in the calling thread.
-    ///
-    /// The reduce operations in the parallel \a inclusive_scan algorithm invoked
-    /// with an execution policy object of type \a parallel_policy
-    /// or \a parallel_task_policy are permitted to execute in an unordered
-    /// fashion in unspecified threads, and indeterminately sequenced
-    /// within each thread.
-    ///
-    /// \returns  The \a inclusive_scan algorithm returns a
-    ///           \a hpx::future<FwdIter2> if
-    ///           the execution policy is of type
-    ///           \a sequenced_task_policy or
-    ///           \a parallel_task_policy and
-    ///           returns \a FwdIter2 otherwise.
-    ///           The \a inclusive_scan algorithm returns the output iterator
-    ///           to the element in the destination range, one past the last
-    ///           element copied.
-    ///
-    /// \note   GENERALIZED_NONCOMMUTATIVE_SUM(+, a1, ..., aN) is defined as:
-    ///         * a1 when N is 1
-    ///         * GENERALIZED_NONCOMMUTATIVE_SUM(op, a1, ..., aK)
-    ///           + GENERALIZED_NONCOMMUTATIVE_SUM(+, aM, ..., aN)
-    ///           where 1 < K+1 = M <= N.
-    ///
-    /// The difference between \a exclusive_scan and \a inclusive_scan is that
-    /// \a inclusive_scan includes the ith input element in the ith sum.
-    ///
     // clang-format off
     template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
         typename Op,
@@ -402,6 +669,9 @@ namespace hpx { namespace parallel { inline namespace v1 {
             >
         )>
     // clang-format on
+    HPX_DEPRECATED_V(1, 8,
+        "hpx::parallel::inclusive_scan is deprecated, use hpx::inclusive_scan "
+        "instead")
     typename util::detail::algorithm_result<ExPolicy, FwdIter2>::type
     inclusive_scan(ExPolicy&& policy, FwdIter1 first, FwdIter1 last,
         FwdIter2 dest, Op&& op)
@@ -411,71 +681,30 @@ namespace hpx { namespace parallel { inline namespace v1 {
         static_assert((hpx::traits::is_forward_iterator<FwdIter2>::value),
             "Requires at least forward iterator.");
 
+#if defined(HPX_GCC_VERSION) && HPX_GCC_VERSION >= 100000
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
         return hpx::parallel::v1::detail::inclusive_scan<FwdIter2>().call(
             std::forward<ExPolicy>(policy), first, last, dest,
             std::forward<Op>(op));
+#if defined(HPX_GCC_VERSION) && HPX_GCC_VERSION >= 100000
+#pragma GCC diagnostic pop
+#endif
     }
 
-    ///////////////////////////////////////////////////////////////////////////
-    /// Assigns through each iterator \a i in [result, result + (last - first))
-    /// the value of
-    /// gENERALIZED_NONCOMMUTATIVE_SUM(+, *first, ..., *(first + (i - result))).
-    ///
-    /// \note   Complexity: O(\a last - \a first) applications of the
-    ///         predicate \a op.
-    ///
-    /// \tparam ExPolicy    The type of the execution policy to use (deduced).
-    ///                     It describes the manner in which the execution
-    ///                     of the algorithm may be parallelized and the manner
-    ///                     in which it executes the assignments.
-    /// \tparam FwdIter1    The type of the source iterators used (deduced).
-    ///                     This iterator type must meet the requirements of an
-    ///                     forward iterator.
-    /// \tparam FwdIter2    The type of the iterator representing the
-    ///                     destination range (deduced).
-    ///                     This iterator type must meet the requirements of an
-    ///                     forward iterator.
-    ///
-    /// \param policy       The execution policy to use for the scheduling of
-    ///                     the iterations.
-    /// \param first        Refers to the beginning of the sequence of elements
-    ///                     the algorithm will be applied to.
-    /// \param last         Refers to the end of the sequence of elements the
-    ///                     algorithm will be applied to.
-    /// \param dest         Refers to the beginning of the destination range.
-    ///
-    /// The reduce operations in the parallel \a inclusive_scan algorithm invoked
-    /// with an execution policy object of type \a sequenced_policy
-    /// execute in sequential order in the calling thread.
-    ///
-    /// The reduce operations in the parallel \a inclusive_scan algorithm invoked
-    /// with an execution policy object of type \a parallel_policy
-    /// or \a parallel_task_policy are permitted to execute in an unordered
-    /// fashion in unspecified threads, and indeterminately sequenced
-    /// within each thread.
-    ///
-    /// \returns  The \a inclusive_scan algorithm returns a
-    ///           \a hpx::future<FwdIter2> if
-    ///           the execution policy is of type
-    ///           \a sequenced_task_policy or
-    ///           \a parallel_task_policy and
-    ///           returns \a FwdIter2 otherwise.
-    ///           The \a inclusive_scan algorithm returns the output iterator
-    ///           to the element in the destination range, one past the last
-    ///           element copied.
-    ///
-    /// \note   GENERALIZED_NONCOMMUTATIVE_SUM(+, a1, ..., aN) is defined as:
-    ///         * a1 when N is 1
-    ///         * GENERALIZED_NONCOMMUTATIVE_SUM(+, a1, ..., aK)
-    ///           + GENERALIZED_NONCOMMUTATIVE_SUM(+, aM, ..., aN)
-    ///           where 1 < K+1 = M <= N.
-    ///
-    /// The difference between \a exclusive_scan and \a inclusive_scan is that
-    /// \a inclusive_scan includes the ith input element in the ith sum.
-    ///
-    template <typename ExPolicy, typename FwdIter1, typename FwdIter2>
-    inline typename std::enable_if<hpx::is_execution_policy<ExPolicy>::value,
-        typename util::detail::algorithm_result<ExPolicy, FwdIter2>::type>::type
+    // clang-format off
+    template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
+        HPX_CONCEPT_REQUIRES_(
+            hpx::is_execution_policy<ExPolicy>::value &&
+            hpx::traits::is_iterator<FwdIter1>::value &&
+            hpx::traits::is_iterator<FwdIter2>::value
+        )>
+    // clang-format on
+    HPX_DEPRECATED_V(1, 8,
+        "hpx::parallel::inclusive_scan is deprecated, use hpx::inclusive_scan "
+        "instead")
+    typename util::detail::algorithm_result<ExPolicy, FwdIter2>::type
     inclusive_scan(
         ExPolicy&& policy, FwdIter1 first, FwdIter1 last, FwdIter2 dest)
     {
@@ -486,9 +715,16 @@ namespace hpx { namespace parallel { inline namespace v1 {
 
         using value_type = typename std::iterator_traits<FwdIter1>::value_type;
 
+#if defined(HPX_GCC_VERSION) && HPX_GCC_VERSION >= 100000
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
         return hpx::parallel::v1::detail::inclusive_scan<FwdIter2>().call(
             std::forward<ExPolicy>(policy), first, last, dest,
             std::plus<value_type>());
+#if defined(HPX_GCC_VERSION) && HPX_GCC_VERSION >= 100000
+#pragma GCC diagnostic pop
+#endif
     }
 }}}    // namespace hpx::parallel::v1
 
@@ -653,3 +889,5 @@ namespace hpx {
 
     } inclusive_scan{};
 }    // namespace hpx
+
+#endif    // DOXYGEN

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/inclusive_scan.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/inclusive_scan.hpp
@@ -206,42 +206,6 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 return result::get(std::move(dest));
             }
         };
-
-        template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
-            typename T, typename Op, typename Conv>
-        static typename util::detail::algorithm_result<ExPolicy, FwdIter2>::type
-        inclusive_scan_(ExPolicy&& policy, FwdIter1 first, FwdIter1 last,
-            FwdIter2 dest, T&& init, Op&& op, std::false_type, Conv&&)
-        {
-            return inclusive_scan<FwdIter2>().call(
-                std::forward<ExPolicy>(policy), first, last, dest,
-                std::forward<T>(init), std::forward<Op>(op));
-        }
-
-        template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
-            typename Op, typename Conv>
-        static typename util::detail::algorithm_result<ExPolicy, FwdIter2>::type
-        inclusive_scan_(ExPolicy&& policy, FwdIter1 first, FwdIter1 last,
-            FwdIter2 dest, Op&& op, std::false_type, Conv&&)
-        {
-            return inclusive_scan<FwdIter2>().call(
-                std::forward<ExPolicy>(policy), first, last, dest,
-                std::forward<Op>(op));
-        }
-
-        // forward declare the segmented version of this algorithm
-        template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
-            typename T, typename Op, typename Conv>
-        static typename util::detail::algorithm_result<ExPolicy, FwdIter2>::type
-        inclusive_scan_(ExPolicy&& policy, FwdIter1 first, FwdIter1 last,
-            FwdIter2 dest, T&& init, Op&& op, std::true_type, Conv&& conv);
-
-        // forward declare the segmented version of this algorithm
-        template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
-            typename Op, typename Conv>
-        static typename util::detail::algorithm_result<ExPolicy, FwdIter2>::type
-        inclusive_scan_(ExPolicy&& policy, FwdIter1 first, FwdIter1 last,
-            FwdIter2 dest, Op&& op, std::true_type, Conv&& conv);
         /// \endcond
     }    // namespace detail
 
@@ -346,11 +310,9 @@ namespace hpx { namespace parallel { inline namespace v1 {
         static_assert((hpx::traits::is_forward_iterator<FwdIter2>::value),
             "Requires at least forward iterator.");
 
-        typedef hpx::traits::is_segmented_iterator<FwdIter1> is_segmented;
-
-        return detail::inclusive_scan_(std::forward<ExPolicy>(policy), first,
-            last, dest, std::move(init), std::forward<Op>(op), is_segmented(),
-            util::projection_identity{});
+        return hpx::parallel::v1::detail::inclusive_scan<FwdIter2>().call(
+            std::forward<ExPolicy>(policy), first, last, dest, std::move(init),
+            std::forward<Op>(op));
     }
 
     ///////////////////////////////////////////////////////////////////////////
@@ -449,11 +411,9 @@ namespace hpx { namespace parallel { inline namespace v1 {
         static_assert((hpx::traits::is_forward_iterator<FwdIter2>::value),
             "Requires at least forward iterator.");
 
-        typedef hpx::traits::is_segmented_iterator<FwdIter1> is_segmented;
-
-        return detail::inclusive_scan_(std::forward<ExPolicy>(policy), first,
-            last, dest, std::forward<Op>(op), is_segmented(),
-            util::projection_identity{});
+        return hpx::parallel::v1::detail::inclusive_scan<FwdIter2>().call(
+            std::forward<ExPolicy>(policy), first, last, dest,
+            std::forward<Op>(op));
     }
 
     ///////////////////////////////////////////////////////////////////////////
@@ -524,13 +484,11 @@ namespace hpx { namespace parallel { inline namespace v1 {
         static_assert((hpx::traits::is_forward_iterator<FwdIter2>::value),
             "Requires at least forward iterator.");
 
-        typedef typename std::iterator_traits<FwdIter1>::value_type value_type;
+        using value_type = typename std::iterator_traits<FwdIter1>::value_type;
 
-        typedef hpx::traits::is_segmented_iterator<FwdIter1> is_segmented;
-
-        return detail::inclusive_scan_(std::forward<ExPolicy>(policy), first,
-            last, dest, std::plus<value_type>(), is_segmented(),
-            util::projection_identity{});
+        return hpx::parallel::v1::detail::inclusive_scan<FwdIter2>().call(
+            std::forward<ExPolicy>(policy), first, last, dest,
+            std::plus<value_type>());
     }
 }}}    // namespace hpx::parallel::v1
 
@@ -555,10 +513,12 @@ namespace hpx {
             static_assert((hpx::traits::is_output_iterator<OutIter>::value),
                 "Requires at least output iterator.");
 
-            using value_type = typename std::iterator_traits<InIter>::value_type;
+            using value_type =
+                typename std::iterator_traits<InIter>::value_type;
 
             return hpx::parallel::v1::detail::inclusive_scan<OutIter>().call(
-                hpx::execution::seq, first, last, dest, std::plus<value_type>());
+                hpx::execution::seq, first, last, dest,
+                std::plus<value_type>());
         }
 
         // clang-format off
@@ -579,7 +539,8 @@ namespace hpx {
             static_assert(hpx::traits::is_forward_iterator<FwdIter2>::value,
                 "Requires at least forward iterator.");
 
-            using value_type = typename std::iterator_traits<FwdIter1>::value_type;
+            using value_type =
+                typename std::iterator_traits<FwdIter1>::value_type;
 
             return hpx::parallel::v1::detail::inclusive_scan<FwdIter2>().call(
                 std::forward<ExPolicy>(policy), first, last, dest,

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/inclusive_scan.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/inclusive_scan.hpp
@@ -635,9 +635,9 @@ namespace hpx { namespace parallel { inline namespace v1 {
     HPX_DEPRECATED_V(1, 8,
         "hpx::parallel::inclusive_scan is deprecated, use hpx::inclusive_scan "
         "instead")
-    typename util::detail::algorithm_result<ExPolicy, FwdIter2>::type
-    inclusive_scan(ExPolicy&& policy, FwdIter1 first, FwdIter1 last,
-        FwdIter2 dest, Op&& op, T init)
+        typename util::detail::algorithm_result<ExPolicy, FwdIter2>::type
+        inclusive_scan(ExPolicy&& policy, FwdIter1 first, FwdIter1 last,
+            FwdIter2 dest, Op&& op, T init)
     {
         static_assert((hpx::traits::is_forward_iterator<FwdIter1>::value),
             "Requires at least forward iterator.");
@@ -672,9 +672,9 @@ namespace hpx { namespace parallel { inline namespace v1 {
     HPX_DEPRECATED_V(1, 8,
         "hpx::parallel::inclusive_scan is deprecated, use hpx::inclusive_scan "
         "instead")
-    typename util::detail::algorithm_result<ExPolicy, FwdIter2>::type
-    inclusive_scan(ExPolicy&& policy, FwdIter1 first, FwdIter1 last,
-        FwdIter2 dest, Op&& op)
+        typename util::detail::algorithm_result<ExPolicy, FwdIter2>::type
+        inclusive_scan(ExPolicy&& policy, FwdIter1 first, FwdIter1 last,
+            FwdIter2 dest, Op&& op)
     {
         static_assert((hpx::traits::is_forward_iterator<FwdIter1>::value),
             "Requires at least forward iterator.");
@@ -704,9 +704,9 @@ namespace hpx { namespace parallel { inline namespace v1 {
     HPX_DEPRECATED_V(1, 8,
         "hpx::parallel::inclusive_scan is deprecated, use hpx::inclusive_scan "
         "instead")
-    typename util::detail::algorithm_result<ExPolicy, FwdIter2>::type
-    inclusive_scan(
-        ExPolicy&& policy, FwdIter1 first, FwdIter1 last, FwdIter2 dest)
+        typename util::detail::algorithm_result<ExPolicy, FwdIter2>::type
+        inclusive_scan(
+            ExPolicy&& policy, FwdIter1 first, FwdIter1 last, FwdIter2 dest)
     {
         static_assert((hpx::traits::is_forward_iterator<FwdIter1>::value),
             "Requires at least forward iterator.");

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/reduce_by_key.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/reduce_by_key.hpp
@@ -359,7 +359,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 //
                 typedef hpx::tuple<value_type, reduce_key_series_states>
                     lambda_type;
-                hpx::parallel::inclusive_scan(
+                hpx::inclusive_scan(
                     sync_policy, states_begin, states_end, states_out_begin,
                     // B is the current entry, A is the one passed in from 'previous'
                     [&func](zip_type_in a, zip_type_in b) -> lambda_type {

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/inclusive_scan.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/inclusive_scan.hpp
@@ -1,5 +1,6 @@
 //  Copyright (c) 2020 ETH Zurich
 //  Copyright (c) 2014 Grant Mercer
+//  Copyright (c) 2021 Akhil J Nair
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -43,8 +44,10 @@ namespace hpx { namespace ranges {
     /// invoked without an execution policy object will execute in sequential
     /// order in the calling thread.
     ///
-    /// \returns  The \a inclusive_scan algorithm returns \a OutIter.
-    ///           The \a inclusive_scan algorithm returns the output iterator
+    /// \returns  The \a inclusive_scan algorithm returns \a
+    ///           util::in_out_result<InIter, OutIter>.
+    ///           The \a inclusive_scan algorithm returns an input iterator to
+    ///           the point denoted by the sentinel and an output iterator
     ///           to the element in the destination range, one past the last
     ///           element copied.
     ///
@@ -58,7 +61,8 @@ namespace hpx { namespace ranges {
     /// \a inclusive_scan includes the ith input element in the ith sum.
     ///
     template <typename InIter, typename Sent, typename OutIter>
-    OutIter inclusive_scan(InIter first, Sent last, OutIter dest);
+    inclusive_scan_result<InIter, OutIter> inclusive_scan(
+        InIter first, Sent last, OutIter dest);
 
     ///////////////////////////////////////////////////////////////////////////
     /// Assigns through each iterator \a i in [result, result + (last - first))
@@ -102,12 +106,13 @@ namespace hpx { namespace ranges {
     /// within each thread.
     ///
     /// \returns  The \a inclusive_scan algorithm returns a
-    ///           \a hpx::future<FwdIter2> if
+    ///           \a hpx::future<util::in_out_result<FwdIter1, FwdIter2>> if
     ///           the execution policy is of type
     ///           \a sequenced_task_policy or
     ///           \a parallel_task_policy and
-    ///           returns \a FwdIter2 otherwise.
-    ///           The \a inclusive_scan algorithm returns the output iterator
+    ///           returns \a util::in_out_result<FwdIter1, FwdIter2> otherwise.
+    ///           The \a inclusive_scan algorithm returns an input iterator to
+    ///           the point denoted by the sentinel and an output iterator
     ///           to the element in the destination range, one past the last
     ///           element copied.
     ///
@@ -121,7 +126,8 @@ namespace hpx { namespace ranges {
     /// \a inclusive_scan includes the ith input element in the ith sum.
     ///
     template <typename ExPolicy, typename FwdIter1, typename Sent, typename FwdIter2>
-    typename util::detail::algorithm_result<ExPolicy, FwdIter2>::type
+    typename util::detail::algorithm_result<ExPolicy,
+        inclusive_scan_result<FwdIter1, FwdIter2>>::type
     inclusive_scan(ExPolicy&& policy, FwdIter1 first, Sent last,
         FwdIter2 dest);
 
@@ -148,8 +154,10 @@ namespace hpx { namespace ranges {
     /// invoked without an execution policy object will execute in sequential
     /// order in the calling thread.
     ///
-    /// \returns  The \a inclusive_scan algorithm returns \a O.
-    ///           The \a inclusive_scan algorithm returns the output iterator
+    /// \returns  The \a inclusive_scan algorithm returns
+    ///           \a util::in_out_result<traits::range_iterator_t<Rng>, O>
+    ///           The \a inclusive_scan algorithm returns an input iterator to
+    ///           the point denoted by the sentinel and an output iterator
     ///           to the element in the destination range, one past the last
     ///           element copied.
     ///
@@ -163,7 +171,8 @@ namespace hpx { namespace ranges {
     /// \a inclusive_scan includes the ith input element in the ith sum.
     ///
     template <typename Rng, typename O>
-    O inclusive_scan(Rng&& rng, O dest);
+    inclusive_scan_result<traits::range_iterator_t<Rng>, O> inclusive_scan(
+        Rng&& rng, O dest);
 
     ///////////////////////////////////////////////////////////////////////////
     /// Assigns through each iterator \a i in [result, result + (last - first))
@@ -203,14 +212,18 @@ namespace hpx { namespace ranges {
     /// within each thread.
     ///
     /// \returns  The \a inclusive_scan algorithm returns a
-    ///           \a hpx::future<O> if
-    ///           the execution policy is of type
+    ///           \a hpx::future<util::in_out_result
+    ///           <traits::range_iterator_t<Rng>, O>>
+    ///           if the execution policy is of type
     ///           \a sequenced_task_policy or
     ///           \a parallel_task_policy and
-    ///           returns \a O otherwise.
-    ///           The \a inclusive_scan algorithm returns the output iterator
+    ///           returns \a util::in_out_result
+    ///           <traits::range_iterator_t<Rng>, O>
+    ///           otherwise.
+    ///           The \a inclusive_scan algorithm returns an input iterator to
+    ///           the point denoted by the sentinel and an output iterator
     ///           to the element in the destination range, one past the last
-    ///           element copied.
+    ///           element copied
     ///
     /// \note   GENERALIZED_NONCOMMUTATIVE_SUM(+, a1, ..., aN) is defined as:
     ///         * a1 when N is 1
@@ -222,7 +235,8 @@ namespace hpx { namespace ranges {
     /// \a inclusive_scan includes the ith input element in the ith sum.
     ///
     template <typename ExPolicy, typename Rng, typename O>
-    typename util::detail::algorithm_result<ExPolicy, O>::type
+    typename util::detail::algorithm_result<ExPolicy,
+        inclusive_scan_result<traits::range_iterator_t<Rng>, O>>::type
     inclusive_scan(ExPolicy&& policy, Rng&& rng, O dest);
 
     ///////////////////////////////////////////////////////////////////////////
@@ -271,8 +285,10 @@ namespace hpx { namespace ranges {
     /// invoked without an execution policy object will execute in sequential
     /// order in the calling thread.
     ///
-    /// \returns  The \a inclusive_scan algorithm returns \a OutIter.
-    ///           The \a inclusive_scan algorithm returns the output iterator
+    /// \returns  The \a inclusive_scan algorithm returns \a
+    ///           util::in_out_result<InIter, OutIter>.
+    ///           The \a inclusive_scan algorithm returns an input iterator to
+    ///           the point denoted by the sentinel and an output iterator
     ///           to the element in the destination range, one past the last
     ///           element copied.
     ///
@@ -286,7 +302,8 @@ namespace hpx { namespace ranges {
     /// \a inclusive_scan includes the ith input element in the ith sum.
     ///
     template <typename InIter, typename Sent, typename OutIter, typename Op>
-    OutIter inclusive_scan(InIter first, Sent last, OutIter dest, Op&& op);
+    inclusive_scan_result<InIter, OutIter> inclusive_scan(
+        InIter first, Sent last, OutIter dest, Op&& op);
 
     ///////////////////////////////////////////////////////////////////////////
     /// Assigns through each iterator \a i in [result, result + (last - first))
@@ -347,12 +364,13 @@ namespace hpx { namespace ranges {
     /// within each thread.
     ///
     /// \returns  The \a inclusive_scan algorithm returns a
-    ///           \a hpx::future<FwdIter2> if
+    ///           \a hpx::future<util::in_out_result<FwdIter1, FwdIter2>> if
     ///           the execution policy is of type
     ///           \a sequenced_task_policy or
     ///           \a parallel_task_policy and
-    ///           returns \a FwdIter2 otherwise.
-    ///           The \a inclusive_scan algorithm returns the output iterator
+    ///           returns \a util::in_out_result<FwdIter1, FwdIter2> otherwise.
+    ///           The \a inclusive_scan algorithm returns an input iterator to
+    ///           the point denoted by the sentinel and an output iterator
     ///           to the element in the destination range, one past the last
     ///           element copied.
     ///
@@ -367,7 +385,8 @@ namespace hpx { namespace ranges {
     ///
     template <typename ExPolicy, typename FwdIter1, typename Sent,
         typename FwdIter2, typename Op>
-    typename util::detail::algorithm_result<ExPolicy, FwdIter2>::type
+    typename util::detail::algorithm_result<ExPolicy,
+        inclusive_scan_result<FwdIter1, FwdIter2>>::type
     inclusive_scan(ExPolicy&& policy, FwdIter1 first, Sent last,
         FwdIter2 dest, Op&& op);
 
@@ -413,8 +432,10 @@ namespace hpx { namespace ranges {
     /// invoked without an execution policy object will execute in sequential
     /// order in the calling thread.
     ///
-    /// \returns  The \a inclusive_scan algorithm returns \a O.
-    ///           The \a inclusive_scan algorithm returns the output iterator
+    /// \returns  The \a inclusive_scan algorithm returns
+    ///           \a util::in_out_result<traits::range_iterator_t<Rng>, O>
+    ///           The \a inclusive_scan algorithm returns an input iterator to
+    ///           the point denoted by the sentinel and an output iterator
     ///           to the element in the destination range, one past the last
     ///           element copied.
     ///
@@ -428,7 +449,8 @@ namespace hpx { namespace ranges {
     /// \a inclusive_scan includes the ith input element in the ith sum.
     ///
     template <typename Rng, typename O, typename Op>
-    O inclusive_scan(Rng&& rng, O dest, Op&& op);
+    inclusive_scan_result<traits::range_iterator_t<Rng>, O> inclusive_scan(
+        Rng&& rng, O dest, Op&& op);
 
     ///////////////////////////////////////////////////////////////////////////
     /// Assigns through each iterator \a i in [result, result + (last - first))
@@ -485,14 +507,18 @@ namespace hpx { namespace ranges {
     /// within each thread.
     ///
     /// \returns  The \a inclusive_scan algorithm returns a
-    ///           \a hpx::future<O> if
-    ///           the execution policy is of type
+    ///           \a hpx::future<util::in_out_result
+    ///           <traits::range_iterator_t<Rng>, O>>
+    ///           if the execution policy is of type
     ///           \a sequenced_task_policy or
     ///           \a parallel_task_policy and
-    ///           returns \a O otherwise.
-    ///           The \a inclusive_scan algorithm returns the output iterator
+    ///           returns \a util::in_out_result
+    ///           <traits::range_iterator_t<Rng>, O>
+    ///           otherwise.
+    ///           The \a inclusive_scan algorithm returns an input iterator to
+    ///           the point denoted by the sentinel and an output iterator
     ///           to the element in the destination range, one past the last
-    ///           element copied.
+    ///           element copied
     ///
     /// \note   GENERALIZED_NONCOMMUTATIVE_SUM(+, a1, ..., aN) is defined as:
     ///         * a1 when N is 1
@@ -504,7 +530,8 @@ namespace hpx { namespace ranges {
     /// \a inclusive_scan includes the ith input element in the ith sum.
     ///
     template <typename ExPolicy, typename Rng, typename O, typename Op>
-    typename util::detail::algorithm_result<ExPolicy, O>::type
+    typename util::detail::algorithm_result<ExPolicy,
+        inclusive_scan_result<traits::range_iterator_t<Rng>, O>>::type
     inclusive_scan(ExPolicy&& policy, Rng&& rng, O dest, Op&& op);
 
     ///////////////////////////////////////////////////////////////////////////
@@ -556,8 +583,10 @@ namespace hpx { namespace ranges {
     /// invoked without an execution policy object will execute in sequential
     /// order in the calling thread.
     ///
-    /// \returns  The \a inclusive_scan algorithm returns \a OutIter.
-    ///           The \a inclusive_scan algorithm returns the output iterator
+    /// \returns  The \a inclusive_scan algorithm returns \a
+    ///           util::in_out_result<InIter, OutIter>.
+    ///           The \a inclusive_scan algorithm returns an input iterator to
+    ///           the point denoted by the sentinel and an output iterator
     ///           to the element in the destination range, one past the last
     ///           element copied.
     ///
@@ -574,8 +603,8 @@ namespace hpx { namespace ranges {
     ///
     template <typename InIter, typename Sent, typename OutIter,typename T,
         typename Op>
-    OutIter inclusive_scan(InIter first, Sent last, OutIter dest,
-        Op&& op, T init);
+    inclusive_scan_result<InIter, OutIter> inclusive_scan(
+        InIter first, Sent last, OutIter dest, Op&& op, T init);
 
     ///////////////////////////////////////////////////////////////////////////
     /// Assigns through each iterator \a i in [result, result + (last - first))
@@ -639,12 +668,13 @@ namespace hpx { namespace ranges {
     /// within each thread.
     ///
     /// \returns  The \a inclusive_scan algorithm returns a
-    ///           \a hpx::future<FwdIter2> if
+    ///           \a hpx::future<util::in_out_result<FwdIter1, FwdIter2>> if
     ///           the execution policy is of type
     ///           \a sequenced_task_policy or
     ///           \a parallel_task_policy and
-    ///           returns \a FwdIter2 otherwise.
-    ///           The \a inclusive_scan algorithm returns the output iterator
+    ///           returns \a util::in_out_result<FwdIter1, FwdIter2> otherwise.
+    ///           The \a inclusive_scan algorithm returns an input iterator to
+    ///           the point denoted by the sentinel and an output iterator
     ///           to the element in the destination range, one past the last
     ///           element copied.
     ///
@@ -661,7 +691,8 @@ namespace hpx { namespace ranges {
     ///
     template <typename ExPolicy, typename FwdIter1, typename Sent,
         typename FwdIter2, typename T, typename Op>
-    typename util::detail::algorithm_result<ExPolicy, FwdIter2>::type
+    typename util::detail::algorithm_result<ExPolicy,
+        inclusive_scan_result<FwdIter1, FwdIter2>>::type
     inclusive_scan(ExPolicy&& policy, FwdIter1 first, Sent last,
         FwdIter2 dest, T init, Op&& op);
 
@@ -710,8 +741,10 @@ namespace hpx { namespace ranges {
     /// invoked without an execution policy object will execute in sequential
     /// order in the calling thread.
     ///
-    /// \returns  The \a inclusive_scan algorithm returns \a O.
-    ///           The \a inclusive_scan algorithm returns the output iterator
+    /// \returns  The \a inclusive_scan algorithm returns
+    ///           \a util::in_out_result<traits::range_iterator_t<Rng>, O>
+    ///           The \a inclusive_scan algorithm returns an input iterator to
+    ///           the point denoted by the sentinel and an output iterator
     ///           to the element in the destination range, one past the last
     ///           element copied.
     ///
@@ -727,7 +760,8 @@ namespace hpx { namespace ranges {
     /// \a inclusive_scan may be non-deterministic.
     ///
     template <typename Rng, typename O, typename Op, typename T>
-    O inclusive_scan(Rng&& rng, O dest, Op&& op, T init);
+    inclusive_scan_result<traits::range_iterator_t<Rng>, O> inclusive_scan(
+        Rng&& rng, O dest, Op&& op, T init);
 
     ///////////////////////////////////////////////////////////////////////////
     /// Assigns through each iterator \a i in [result, result + (last - first))
@@ -787,14 +821,18 @@ namespace hpx { namespace ranges {
     /// within each thread.
     ///
     /// \returns  The \a inclusive_scan algorithm returns a
-    ///           \a hpx::future<O> if
-    ///           the execution policy is of type
+    ///           \a hpx::future<util::in_out_result
+    ///           <traits::range_iterator_t<Rng>, O>>
+    ///           if the execution policy is of type
     ///           \a sequenced_task_policy or
     ///           \a parallel_task_policy and
-    ///           returns \a O otherwise.
-    ///           The \a inclusive_scan algorithm returns the output iterator
+    ///           returns \a util::in_out_result
+    ///           <traits::range_iterator_t<Rng>, O>
+    ///           otherwise.
+    ///           The \a inclusive_scan algorithm returns an input iterator to
+    ///           the point denoted by the sentinel and an output iterator
     ///           to the element in the destination range, one past the last
-    ///           element copied.
+    ///           element copied
     ///
     /// \note   GENERALIZED_NONCOMMUTATIVE_SUM(op, a1, ..., aN) is defined as:
     ///         * a1 when N is 1
@@ -809,8 +847,9 @@ namespace hpx { namespace ranges {
     ///
     template <typename ExPolicy, typename Rng, typename O, typename Op,
         typename T>
-    typename util::detail::algorithm_result<ExPolicy, O>::type inclusive_scan(
-        ExPolicy&& policy, Rng&& rng, O dest, Op&& op, T init);
+    typename util::detail::algorithm_result<ExPolicy,
+        inclusive_scan_result<traits::range_iterator_t<Rng>, O>>::type
+    inclusive_scan(ExPolicy&& policy, Rng&& rng, O dest, Op&& op, T init);
     // clang-format on
 }}    // namespace hpx::ranges
 #else
@@ -821,6 +860,7 @@ namespace hpx { namespace ranges {
 #include <hpx/executors/execution_policy.hpp>
 #include <hpx/functional/tag_fallback_dispatch.hpp>
 #include <hpx/iterator_support/traits/is_iterator.hpp>
+#include <hpx/iterator_support/traits/is_range.hpp>
 #include <hpx/parallel/algorithms/inclusive_scan.hpp>
 #include <hpx/parallel/util/detail/algorithm_result.hpp>
 #include <hpx/parallel/util/projection_identity.hpp>
@@ -833,6 +873,10 @@ namespace hpx { namespace ranges {
 #include <vector>
 
 namespace hpx { namespace ranges {
+
+    template <typename I, typename O>
+    using inclusive_scan_result = parallel::util::in_out_result<I, O>;
+
     HPX_INLINE_CONSTEXPR_VARIABLE struct inclusive_scan_t final
       : hpx::functional::tag_fallback<inclusive_scan_t>
     {
@@ -842,25 +886,29 @@ namespace hpx { namespace ranges {
             typename Op = std::plus<typename
             std::iterator_traits<InIter>::value_type>,
             HPX_CONCEPT_REQUIRES_(
-                hpx::traits::is_iterator<InIter>::value &&
+                hpx::traits::is_iterator_v<InIter> &&
                 hpx::traits::is_sentinel_for<Sent, InIter>::value &&
-                hpx::traits::is_iterator<OutIter>::value &&
+                hpx::traits::is_iterator_v<OutIter> &&
                 hpx::is_invocable_v<Op,
                     typename std::iterator_traits<InIter>::value_type,
                     typename std::iterator_traits<InIter>::value_type
                 >
             )>
         // clang-format on
-        friend OutIter tag_fallback_dispatch(hpx::ranges::inclusive_scan_t,
-            InIter first, Sent last, OutIter dest, Op&& op = Op())
+        friend inclusive_scan_result<InIter, OutIter> tag_fallback_dispatch(
+            hpx::ranges::inclusive_scan_t, InIter first, Sent last,
+            OutIter dest, Op&& op = Op())
         {
-            static_assert(hpx::traits::is_input_iterator<InIter>::value,
+            static_assert(hpx::traits::is_input_iterator_v<InIter>,
                 "Requires at least input iterator.");
-            static_assert(hpx::traits::is_output_iterator<OutIter>::value,
+            static_assert(hpx::traits::is_output_iterator_v<OutIter>,
                 "Requires at least output iterator.");
 
-            return hpx::parallel::v1::detail::inclusive_scan<OutIter>().call(
-                hpx::execution::seq, first, last, dest, std::forward<Op>(op));
+            using result_type = inclusive_scan_result<InIter, OutIter>;
+
+            return hpx::parallel::v1::detail::inclusive_scan<result_type>()
+                .call(hpx::execution::seq, first, last, dest,
+                    std::forward<Op>(op));
         }
 
         // clang-format off
@@ -869,9 +917,9 @@ namespace hpx { namespace ranges {
             std::iterator_traits<FwdIter1>::value_type>,
             HPX_CONCEPT_REQUIRES_(
                 hpx::is_execution_policy<ExPolicy>::value &&
-                hpx::traits::is_iterator<FwdIter1>::value &&
+                hpx::traits::is_iterator_v<FwdIter1> &&
                 hpx::traits::is_sentinel_for<Sent, FwdIter1>::value &&
-                hpx::traits::is_iterator<FwdIter2>::value &&
+                hpx::traits::is_iterator_v<FwdIter2> &&
                 hpx::is_invocable_v<Op,
                     typename std::iterator_traits<FwdIter1>::value_type,
                     typename std::iterator_traits<FwdIter1>::value_type
@@ -879,18 +927,20 @@ namespace hpx { namespace ranges {
             )>
         // clang-format on
         friend typename parallel::util::detail::algorithm_result<ExPolicy,
-            FwdIter2>::type
+            inclusive_scan_result<FwdIter1, FwdIter2>>::type
         tag_fallback_dispatch(hpx::ranges::inclusive_scan_t, ExPolicy&& policy,
             FwdIter1 first, Sent last, FwdIter2 dest, Op&& op = Op())
         {
-            static_assert(hpx::traits::is_forward_iterator<FwdIter1>::value,
+            static_assert(hpx::traits::is_forward_iterator_v<FwdIter1>,
                 "Requires at least forward iterator.");
-            static_assert(hpx::traits::is_forward_iterator<FwdIter2>::value,
+            static_assert(hpx::traits::is_forward_iterator_v<FwdIter2>,
                 "Requires at least forward iterator.");
 
-            return hpx::parallel::v1::detail::inclusive_scan<FwdIter2>().call(
-                std::forward<ExPolicy>(policy), first, last, dest,
-                std::forward<Op>(op));
+            using result_type = inclusive_scan_result<FwdIter1, FwdIter2>;
+
+            return hpx::parallel::v1::detail::inclusive_scan<result_type>()
+                .call(std::forward<ExPolicy>(policy), first, last, dest,
+                    std::forward<Op>(op));
         }
 
         // clang-format off
@@ -904,18 +954,22 @@ namespace hpx { namespace ranges {
                 >
             )>
         // clang-format on
-        friend O tag_fallback_dispatch(
+        friend inclusive_scan_result<hpx::traits::range_iterator_t<Rng>, O>
+        tag_fallback_dispatch(
             hpx::ranges::inclusive_scan_t, Rng&& rng, O dest, Op&& op = Op())
         {
             using iterator_type =
                 typename hpx::traits::range_traits<Rng>::iterator_type;
 
-            static_assert(hpx::traits::is_input_iterator<iterator_type>::value,
+            static_assert(hpx::traits::is_input_iterator_v<iterator_type>,
                 "Requires at least input iterator.");
 
-            return hpx::parallel::v1::detail::inclusive_scan<O>().call(
-                hpx::execution::seq, std::begin(rng), std::end(rng), dest,
-                std::forward<Op>(op));
+            using result_type =
+                inclusive_scan_result<traits::range_iterator_t<Rng>, O>;
+
+            return hpx::parallel::v1::detail::inclusive_scan<result_type>()
+                .call(hpx::execution::seq, std::begin(rng), std::end(rng), dest,
+                    std::forward<Op>(op));
         }
 
         // clang-format off
@@ -930,47 +984,52 @@ namespace hpx { namespace ranges {
                 >
             )>
         // clang-format on
-        friend
-            typename parallel::util::detail::algorithm_result<ExPolicy, O>::type
-            tag_fallback_dispatch(hpx::ranges::inclusive_scan_t,
-                ExPolicy&& policy, Rng&& rng, O dest, Op&& op = Op())
+        friend typename parallel::util::detail::algorithm_result<ExPolicy,
+            inclusive_scan_result<hpx::traits::range_iterator_t<Rng>, O>>::type
+        tag_fallback_dispatch(hpx::ranges::inclusive_scan_t, ExPolicy&& policy,
+            Rng&& rng, O dest, Op&& op = Op())
         {
             using iterator_type =
                 typename hpx::traits::range_traits<Rng>::iterator_type;
 
-            static_assert(
-                hpx::traits::is_forward_iterator<iterator_type>::value,
+            static_assert(hpx::traits::is_forward_iterator_v<iterator_type>,
                 "Requires at least forward iterator.");
 
-            return hpx::parallel::v1::detail::inclusive_scan<O>().call(
-                std::forward<ExPolicy>(policy), std::begin(rng), std::end(rng),
-                dest, std::forward<Op>(op));
+            using result_type =
+                inclusive_scan_result<traits::range_iterator_t<Rng>, O>;
+
+            return hpx::parallel::v1::detail::inclusive_scan<result_type>()
+                .call(std::forward<ExPolicy>(policy), std::begin(rng),
+                    std::end(rng), dest, std::forward<Op>(op));
         }
 
         // clang-format off
         template <typename InIter, typename Sent, typename OutIter,
             typename Op, typename T,
             HPX_CONCEPT_REQUIRES_(
-                hpx::traits::is_iterator<InIter>::value &&
+                hpx::traits::is_iterator_v<InIter> &&
                 hpx::traits::is_sentinel_for<Sent, InIter>::value &&
-                hpx::traits::is_iterator<OutIter>::value &&
+                hpx::traits::is_iterator_v<OutIter> &&
                 hpx::is_invocable_v<Op,
                     typename std::iterator_traits<InIter>::value_type,
                     typename std::iterator_traits<InIter>::value_type
                 >
             )>
         // clang-format on
-        friend OutIter tag_fallback_dispatch(hpx::ranges::inclusive_scan_t,
-            InIter first, Sent last, OutIter dest, Op&& op, T init)
+        friend inclusive_scan_result<InIter, OutIter> tag_fallback_dispatch(
+            hpx::ranges::inclusive_scan_t, InIter first, Sent last,
+            OutIter dest, Op&& op, T init)
         {
-            static_assert(hpx::traits::is_input_iterator<InIter>::value,
+            static_assert(hpx::traits::is_input_iterator_v<InIter>,
                 "Requires at least input iterator.");
-            static_assert(hpx::traits::is_output_iterator<OutIter>::value,
+            static_assert(hpx::traits::is_output_iterator_v<OutIter>,
                 "Requires at least output iterator.");
 
-            return hpx::parallel::v1::detail::inclusive_scan<OutIter>().call(
-                hpx::execution::seq, first, last, dest, std::move(init),
-                std::forward<Op>(op));
+            using result_type = inclusive_scan_result<InIter, OutIter>;
+
+            return hpx::parallel::v1::detail::inclusive_scan<result_type>()
+                .call(hpx::execution::seq, first, last, dest, std::move(init),
+                    std::forward<Op>(op));
         }
 
         // clang-format off
@@ -978,9 +1037,9 @@ namespace hpx { namespace ranges {
             typename FwdIter2, typename Op, typename T,
             HPX_CONCEPT_REQUIRES_(
                 hpx::is_execution_policy<ExPolicy>::value &&
-                hpx::traits::is_iterator<FwdIter1>::value &&
+                hpx::traits::is_iterator_v<FwdIter1> &&
                 hpx::traits::is_sentinel_for<Sent, FwdIter1>::value &&
-                hpx::traits::is_iterator<FwdIter2>::value &&
+                hpx::traits::is_iterator_v<FwdIter2> &&
                 hpx::is_invocable_v<Op,
                     typename std::iterator_traits<FwdIter1>::value_type,
                     typename std::iterator_traits<FwdIter1>::value_type
@@ -988,18 +1047,20 @@ namespace hpx { namespace ranges {
             )>
         // clang-format on
         friend typename parallel::util::detail::algorithm_result<ExPolicy,
-            FwdIter2>::type
+            inclusive_scan_result<FwdIter1, FwdIter2>>::type
         tag_fallback_dispatch(hpx::ranges::inclusive_scan_t, ExPolicy&& policy,
             FwdIter1 first, Sent last, FwdIter2 dest, Op&& op, T init)
         {
-            static_assert(hpx::traits::is_forward_iterator<FwdIter1>::value,
+            static_assert(hpx::traits::is_forward_iterator_v<FwdIter1>,
                 "Requires at least forward iterator.");
-            static_assert(hpx::traits::is_forward_iterator<FwdIter2>::value,
+            static_assert(hpx::traits::is_forward_iterator_v<FwdIter2>,
                 "Requires at least forward iterator.");
 
-            return hpx::parallel::v1::detail::inclusive_scan<FwdIter2>().call(
-                std::forward<ExPolicy>(policy), first, last, dest,
-                std::move(init), std::forward<Op>(op));
+            using result_type = inclusive_scan_result<FwdIter1, FwdIter2>;
+
+            return hpx::parallel::v1::detail::inclusive_scan<result_type>()
+                .call(std::forward<ExPolicy>(policy), first, last, dest,
+                    std::move(init), std::forward<Op>(op));
         }
 
         // clang-format off
@@ -1013,18 +1074,22 @@ namespace hpx { namespace ranges {
                 >
             )>
         // clang-format on
-        friend O tag_fallback_dispatch(
+        friend inclusive_scan_result<hpx::traits::range_iterator_t<Rng>, O>
+        tag_fallback_dispatch(
             hpx::ranges::inclusive_scan_t, Rng&& rng, O dest, Op&& op, T init)
         {
             using iterator_type =
                 typename hpx::traits::range_traits<Rng>::iterator_type;
 
-            static_assert(hpx::traits::is_input_iterator<iterator_type>::value,
+            static_assert(hpx::traits::is_input_iterator_v<iterator_type>,
                 "Requires at least input iterator.");
 
-            return hpx::parallel::v1::detail::inclusive_scan<O>().call(
-                hpx::execution::seq, std::begin(rng), std::end(rng), dest,
-                std::move(init), std::forward<Op>(op));
+            using result_type =
+                inclusive_scan_result<traits::range_iterator_t<Rng>, O>;
+
+            return hpx::parallel::v1::detail::inclusive_scan<result_type>()
+                .call(hpx::execution::seq, std::begin(rng), std::end(rng), dest,
+                    std::move(init), std::forward<Op>(op));
         }
 
         // clang-format off
@@ -1039,21 +1104,23 @@ namespace hpx { namespace ranges {
                 >
             )>
         // clang-format on
-        friend
-            typename parallel::util::detail::algorithm_result<ExPolicy, O>::type
-            tag_fallback_dispatch(hpx::ranges::inclusive_scan_t,
-                ExPolicy&& policy, Rng&& rng, O dest, Op&& op, T init)
+        friend typename parallel::util::detail::algorithm_result<ExPolicy,
+            inclusive_scan_result<hpx::traits::range_iterator_t<Rng>, O>>::type
+        tag_fallback_dispatch(hpx::ranges::inclusive_scan_t, ExPolicy&& policy,
+            Rng&& rng, O dest, Op&& op, T init)
         {
             using iterator_type =
                 typename hpx::traits::range_traits<Rng>::iterator_type;
 
-            static_assert(
-                hpx::traits::is_forward_iterator<iterator_type>::value,
+            static_assert(hpx::traits::is_forward_iterator_v<iterator_type>,
                 "Requires at least forward iterator.");
 
-            return hpx::parallel::v1::detail::inclusive_scan<O>().call(
-                std::forward<ExPolicy>(policy), std::begin(rng), std::end(rng),
-                dest, std::move(init), std::forward<Op>(op));
+            using result_type =
+                inclusive_scan_result<traits::range_iterator_t<Rng>, O>;
+
+            return hpx::parallel::v1::detail::inclusive_scan<result_type>()
+                .call(std::forward<ExPolicy>(policy), std::begin(rng),
+                    std::end(rng), dest, std::move(init), std::forward<Op>(op));
         }
     } inclusive_scan{};
 }}    // namespace hpx::ranges

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/inclusive_scan.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/inclusive_scan.hpp
@@ -1,0 +1,613 @@
+//  Copyright (c) 2020 ETH Zurich
+//  Copyright (c) 2014 Grant Mercer
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+/// \file parallel/container_algorithms/inclusive_scan.hpp
+
+#pragma once
+
+#if defined(DOXYGEN)
+
+namespace hpx { namespace ranges {
+
+    /// Checks if the first range [first1, last1) is lexicographically less than
+    /// the second range [first2, last2). uses a provided predicate to compare
+    /// elements.
+    ///
+    /// \note   Complexity: At most 2 * min(N1, N2) applications of the comparison
+    ///         operation, where N1 = std::distance(first1, last)
+    ///         and N2 = std::distance(first2, last2).
+    ///
+    /// \tparam InIter1     The type of the source iterators used for the
+    ///                     first range (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     input iterator.
+    /// \tparam Sent1       The type of the source sentinel (deduced). This
+    ///                     sentinel type must be a sentinel for InIter1.
+    /// \tparam InIter2     The type of the source iterators used for the
+    ///                     second range (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     input iterator.
+    /// \tparam Sent2       The type of the source sentinel (deduced). This
+    ///                     sentinel type must be a sentinel for InIter2.
+    /// \tparam Pred        The type of an optional function/function object to use.
+    ///                     Unlike its sequential form, the parallel
+    ///                     overload of \a inclusive_scan requires \a Pred to
+    ///                     meet the requirements of \a CopyConstructible. This defaults
+    ///                     to std::less<>
+    /// \tparam Proj1       The type of an optional projection function for FwdIter1. This
+    ///                     defaults to \a util::projection_identity
+    /// \tparam Proj2       The type of an optional projection function for FwdIter2. This
+    ///                     defaults to \a util::projection_identity
+    ///
+    /// \param first1       Refers to the beginning of the sequence of elements
+    ///                     of the first range the algorithm will be applied to.
+    /// \param last1        Refers to the end of the sequence of elements of
+    ///                     the first range the algorithm will be applied to.
+    /// \param first2       Refers to the beginning of the sequence of elements
+    ///                     of the second range the algorithm will be applied to.
+    /// \param last2        Refers to the end of the sequence of elements of
+    ///                     the second range the algorithm will be applied to.
+    /// \param pred         Refers to the comparison function that the first
+    ///                     and second ranges will be applied to
+    /// \param proj1        Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements of the first range
+    ///                     as a projection operation before the actual predicate
+    ///                     \a is invoked.
+    /// \param proj2        Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements of the second range
+    ///                     as a projection operation before the actual predicate
+    ///                     \a is invoked.
+    ///
+    /// The comparison operations in the parallel \a inclusive_scan
+    /// algorithm invoked with an execution policy object of type
+    /// \a sequenced_policy execute in sequential order in the
+    /// calling thread.
+    ///
+    /// The comparison operations in the parallel \a inclusive_scan
+    /// algorithm invoked with an execution policy object of type
+    /// \a parallel_policy
+    /// or \a parallel_task_policy are permitted to execute in an unordered
+    /// fashion in unspecified threads, and indeterminately sequenced
+    /// within each thread.
+    ///
+    /// \note     Lexicographical comparison is an operation with the
+    ///           following properties
+    ///             - Two ranges are compared element by element
+    ///             - The first mismatching element defines which range
+    ///               is lexicographically
+    ///               \a less or \a greater than the other
+    ///             - If one range is a prefix of another, the shorter range is
+    ///               lexicographically \a less than the other
+    ///             - If two ranges have equivalent elements and are of the same length,
+    ///               then the ranges are lexicographically \a equal
+    ///             - An empty range is lexicographically \a less than any non-empty
+    ///               range
+    ///             - Two empty ranges are lexicographically \a equal
+    ///
+    /// \returns  The \a lexicographically_compare algorithm returns a
+    ///           \a hpx::future<bool> if the execution policy is of type
+    ///           \a sequenced_task_policy or
+    ///           \a parallel_task_policy and
+    ///           returns \a bool otherwise.
+    ///           The \a lexicographically_compare algorithm returns true
+    ///           if the first range is lexicographically less, otherwise
+    ///           it returns false.
+    ///           range [first2, last2), it returns false.
+    template <typename InIter1, typename Sent1, typename InIter2,
+        typename Sent2,
+        typename Proj1 = hpx::parallel::util::projection_identity,
+        typename Proj2 = hpx::parallel::util::projection_identity,
+        typename Pred = detail::less>
+    bool inclusive_scan(InIter1 first1, Sent1 last1, InIter2 first2,
+        Sent2 last2, Pred&& pred = Pred(), Proj1&& proj1 = Proj1(),
+        Proj2&& proj2 = Proj2());
+
+    /// Checks if the first range [first1, last1) is lexicographically less than
+    /// the second range [first2, last2). uses a provided predicate to compare
+    /// elements.
+    ///
+    /// \note   Complexity: At most 2 * min(N1, N2) applications of the comparison
+    ///         operation, where N1 = std::distance(first1, last)
+    ///         and N2 = std::distance(first2, last2).
+    ///
+    /// \tparam ExPolicy    The type of the execution policy to use (deduced).
+    ///                     It describes the manner in which the execution
+    ///                     of the algorithm may be parallelized and the manner
+    ///                     in which it executes the assignments.
+    /// \tparam FwdIter1    The type of the source iterators used for the
+    ///                     first range (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     forward iterator.
+    /// \tparam Sent1       The type of the source sentinel (deduced). This
+    ///                     sentinel type must be a sentinel for FwdIter1.
+    /// \tparam FwdIter2    The type of the source iterators used for the
+    ///                     second range (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     forward iterator.
+    /// \tparam Sent2       The type of the source sentinel (deduced). This
+    ///                     sentinel type must be a sentinel for FwdIter2.
+    /// \tparam Pred        The type of an optional function/function object to use.
+    ///                     Unlike its sequential form, the parallel
+    ///                     overload of \a inclusive_scan requires \a Pred to
+    ///                     meet the requirements of \a CopyConstructible. This defaults
+    ///                     to std::less<>
+    /// \tparam Proj1       The type of an optional projection function for FwdIter1. This
+    ///                     defaults to \a util::projection_identity
+    /// \tparam Proj2       The type of an optional projection function for FwdIter2. This
+    ///                     defaults to \a util::projection_identity
+    ///
+    /// \param policy       The execution policy to use for the scheduling of
+    ///                     the iterations.
+    /// \param first1       Refers to the beginning of the sequence of elements
+    ///                     of the first range the algorithm will be applied to.
+    /// \param last1        Refers to the end of the sequence of elements of
+    ///                     the first range the algorithm will be applied to.
+    /// \param first2       Refers to the beginning of the sequence of elements
+    ///                     of the second range the algorithm will be applied to.
+    /// \param last2        Refers to the end of the sequence of elements of
+    ///                     the second range the algorithm will be applied to.
+    /// \param pred         Refers to the comparison function that the first
+    ///                     and second ranges will be applied to
+    /// \param proj1        Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements of the first range
+    ///                     as a projection operation before the actual predicate
+    ///                     \a is invoked.
+    /// \param proj2        Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements of the second range
+    ///                     as a projection operation before the actual predicate
+    ///                     \a is invoked.
+    ///
+    /// The comparison operations in the parallel \a inclusive_scan
+    /// algorithm invoked with an execution policy object of type
+    /// \a sequenced_policy execute in sequential order in the
+    /// calling thread.
+    ///
+    /// The comparison operations in the parallel \a inclusive_scan
+    /// algorithm invoked with an execution policy object of type
+    /// \a parallel_policy
+    /// or \a parallel_task_policy are permitted to execute in an unordered
+    /// fashion in unspecified threads, and indeterminately sequenced
+    /// within each thread.
+    ///
+    /// \note     Lexicographical comparison is an operation with the
+    ///           following properties
+    ///             - Two ranges are compared element by element
+    ///             - The first mismatching element defines which range
+    ///               is lexicographically
+    ///               \a less or \a greater than the other
+    ///             - If one range is a prefix of another, the shorter range is
+    ///               lexicographically \a less than the other
+    ///             - If two ranges have equivalent elements and are of the same length,
+    ///               then the ranges are lexicographically \a equal
+    ///             - An empty range is lexicographically \a less than any non-empty
+    ///               range
+    ///             - Two empty ranges are lexicographically \a equal
+    ///
+    /// \returns  The \a lexicographically_compare algorithm returns a
+    ///           \a hpx::future<bool> if the execution policy is of type
+    ///           \a sequenced_task_policy or
+    ///           \a parallel_task_policy and
+    ///           returns \a bool otherwise.
+    ///           The \a lexicographically_compare algorithm returns true
+    ///           if the first range is lexicographically less, otherwise
+    ///           it returns false.
+    ///           range [first2, last2), it returns false.
+
+    template <typename ExPolicy, typename FwdIter1, typename Sent1,
+        typename FwdIter2, typename Sent2,
+        typename Proj1 = hpx::parallel::util::projection_identity,
+        typename Proj2 = hpx::parallel::util::projection_identity,
+        typename Pred = detail::less>
+    typename parallel::util::detail::algorithm_result<ExPolicy, bool>::type
+    inclusive_scan(ExPolicy&& policy, FwdIter1 first1, Sent1 last1,
+        FwdIter2 first2, Sent2 last2, Pred&& pred = Pred(),
+        Proj1&& proj1 = Proj1(), Proj2&& proj2 = Proj2());
+
+    /// Checks if the first range rng1 is lexicographically less than
+    /// the second range rng2. uses a provided predicate to compare
+    /// elements.
+    ///
+    /// \note   Complexity: At most 2 * min(N1, N2) applications of the comparison
+    ///         operation, where N1 = std::distance(std::begin(rng1), std::end(rng1))
+    ///         and N2 = std::distance(std::begin(rng2), std::end(rng2)).
+    ///
+    /// \tparam Rng1        The type of the source range used (deduced).
+    ///                     The iterators extracted from this range type must
+    ///                     meet the requirements of an input iterator.
+    /// \tparam Rng2        The type of the source range used (deduced).
+    ///                     The iterators extracted from this range type must
+    ///                     meet the requirements of an input iterator.
+    /// \tparam Pred        The type of an optional function/function object to use.
+    ///                     Unlike its sequential form, the parallel
+    ///                     overload of \a inclusive_scan requires \a Pred to
+    ///                     meet the requirements of \a CopyConstructible. This defaults
+    ///                     to std::less<>
+    /// \tparam Proj1       The type of an optional projection function for elements of the first range.
+    ///                     This defaults to \a util::projection_identity
+    /// \tparam Proj2       The type of an optional projection function for elements of the second range.
+    ///                     This defaults to \a util::projection_identity
+    ///
+    /// \param rng1         Refers to the sequence of elements the algorithm
+    ///                     will be applied to.
+    /// \param rng2         Refers to the sequence of elements the algorithm
+    ///                     will be applied to.
+    /// \param pred         Refers to the comparison function that the first
+    ///                     and second ranges will be applied to
+    /// \param proj1        Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements of the first range
+    ///                     as a projection operation before the actual predicate
+    ///                     \a is invoked.
+    /// \param proj2        Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements of the second range
+    ///                     as a projection operation before the actual predicate
+    ///                     \a is invoked.
+    ///
+    /// The comparison operations in the parallel \a inclusive_scan
+    /// algorithm invoked without an execution policy object  execute in sequential
+    /// order in the calling thread.
+    ///
+    /// \note     Lexicographical comparison is an operation with the
+    ///           following properties
+    ///             - Two ranges are compared element by element
+    ///             - The first mismatching element defines which range
+    ///               is lexicographically
+    ///               \a less or \a greater than the other
+    ///             - If one range is a prefix of another, the shorter range is
+    ///               lexicographically \a less than the other
+    ///             - If two ranges have equivalent elements and are of the same length,
+    ///               then the ranges are lexicographically \a equal
+    ///             - An empty range is lexicographically \a less than any non-empty
+    ///               range
+    ///             - Two empty ranges are lexicographically \a equal
+    ///
+    /// \returns  The \a lexicographically_compare algorithm returns \a bool.
+    ///           The \a lexicographically_compare algorithm returns true
+    ///           if the first range is lexicographically less, otherwise
+    ///           it returns false.
+    ///           range [first2, last2), it returns false.
+    template <typename Rng1, typename Rng2,
+        typename Proj1 = hpx::parallel::util::projection_identity,
+        typename Proj2 = hpx::parallel::util::projection_identity,
+        typename Pred = detail::less>
+    bool inclusive_scan(Rng1&& rng1, Rng2&& rng2, Pred&& pred = Pred(),
+        Proj1&& proj1 = Proj1(), Proj2&& proj2 = Proj2());
+
+    /// Checks if the first range rng1 is lexicographically less than
+    /// the second range rng2. uses a provided predicate to compare
+    /// elements.
+    ///
+    /// \note   Complexity: At most 2 * min(N1, N2) applications of the comparison
+    ///         operation, where N1 = std::distance(std::begin(rng1), std::end(rng1))
+    ///         and N2 = std::distance(std::begin(rng2), std::end(rng2)).
+    ///
+    /// \tparam ExPolicy    The type of the execution policy to use (deduced).
+    ///                     It describes the manner in which the execution
+    ///                     of the algorithm may be parallelized and the manner
+    ///                     in which it executes the assignments.
+    /// \tparam Rng1        The type of the source range used (deduced).
+    ///                     The iterators extracted from this range type must
+    ///                     meet the requirements of an input iterator.
+    /// \tparam Rng2        The type of the source range used (deduced).
+    ///                     The iterators extracted from this range type must
+    ///                     meet the requirements of an input iterator.
+    /// \tparam Pred        The type of an optional function/function object to use.
+    ///                     Unlike its sequential form, the parallel
+    ///                     overload of \a inclusive_scan requires \a Pred to
+    ///                     meet the requirements of \a CopyConstructible. This defaults
+    ///                     to std::less<>
+    /// \tparam Proj1       The type of an optional projection function for elements of the first range.
+    ///                     This defaults to \a util::projection_identity
+    /// \tparam Proj2       The type of an optional projection function for elements of the second range.
+    ///                     This defaults to \a util::projection_identity
+    ///
+    /// \param policy       The execution policy to use for the scheduling of
+    ///                     the iterations.
+    /// \param rng1         Refers to the sequence of elements the algorithm
+    ///                     will be applied to.
+    /// \param rng2         Refers to the sequence of elements the algorithm
+    ///                     will be applied to.
+    /// \param pred         Refers to the comparison function that the first
+    ///                     and second ranges will be applied to
+    /// \param proj1        Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements of the first range
+    ///                     as a projection operation before the actual predicate
+    ///                     \a is invoked.
+    /// \param proj2        Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements of the second range
+    ///                     as a projection operation before the actual predicate
+    ///                     \a is invoked.
+    ///
+    /// The comparison operations in the parallel \a inclusive_scan
+    /// algorithm invoked with an execution policy object of type
+    /// \a sequenced_policy execute in sequential order in the
+    /// calling thread.
+    ///
+    /// The comparison operations in the parallel \a inclusive_scan
+    /// algorithm invoked with an execution policy object of type
+    /// \a parallel_policy
+    /// or \a parallel_task_policy are permitted to execute in an unordered
+    /// fashion in unspecified threads, and indeterminately sequenced
+    /// within each thread.
+    ///
+    /// \note     Lexicographical comparison is an operation with the
+    ///           following properties
+    ///             - Two ranges are compared element by element
+    ///             - The first mismatching element defines which range
+    ///               is lexicographically
+    ///               \a less or \a greater than the other
+    ///             - If one range is a prefix of another, the shorter range is
+    ///               lexicographically \a less than the other
+    ///             - If two ranges have equivalent elements and are of the same length,
+    ///               then the ranges are lexicographically \a equal
+    ///             - An empty range is lexicographically \a less than any non-empty
+    ///               range
+    ///             - Two empty ranges are lexicographically \a equal
+    ///
+    /// \returns  The \a lexicographically_compare algorithm returns a
+    ///           \a hpx::future<bool> if the execution policy is of type
+    ///           \a sequenced_task_policy or
+    ///           \a parallel_task_policy and
+    ///           returns \a bool otherwise.
+    ///           The \a lexicographically_compare algorithm returns true
+    ///           if the first range is lexicographically less, otherwise
+    ///           it returns false.
+    ///           range [first2, last2), it returns false.
+
+    template <typename ExPolicy, typename Rng1, typename Rng2,
+        typename Proj1 = hpx::parallel::util::projection_identity,
+        typename Proj2 = hpx::parallel::util::projection_identity,
+        typename Pred = detail::less>
+    typename parallel::util::detail::algorithm_result<ExPolicy, bool>::type
+    inclusive_scan(ExPolicy&& policy, Rng1&& rng1, Rng2&& rng2,
+        Pred&& pred = Pred(), Proj1&& proj1 = Proj1(), Proj2&& proj2 = Proj2());
+}}    // namespace hpx::ranges
+#else
+
+#include <hpx/config.hpp>
+#include <hpx/algorithms/traits/projected_range.hpp>
+#include <hpx/execution/algorithms/detail/predicates.hpp>
+#include <hpx/executors/execution_policy.hpp>
+#include <hpx/functional/tag_fallback_dispatch.hpp>
+#include <hpx/iterator_support/traits/is_iterator.hpp>
+#include <hpx/parallel/algorithms/inclusive_scan.hpp>
+#include <hpx/parallel/util/detail/algorithm_result.hpp>
+#include <hpx/parallel/util/projection_identity.hpp>
+
+#include <algorithm>
+#include <cstddef>
+#include <iterator>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+namespace hpx { namespace ranges {
+    HPX_INLINE_CONSTEXPR_VARIABLE struct inclusive_scan_t final
+      : hpx::functional::tag_fallback<inclusive_scan_t>
+    {
+    private:
+        // clang-format off
+        template <typename InIter, typename Sent, typename OutIter,
+            typename Op = std::plus<typename
+            std::iterator_traits<InIter>::value_type>,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::traits::is_iterator<InIter>::value &&
+                hpx::traits::is_sentinel_for<Sent, InIter>::value &&
+                hpx::traits::is_iterator<OutIter>::value &&
+                hpx::is_invocable_v<Op,
+                    typename std::iterator_traits<InIter>::value_type,
+                    typename std::iterator_traits<InIter>::value_type
+                >
+            )>
+        // clang-format on
+        friend OutIter tag_fallback_dispatch(hpx::ranges::inclusive_scan_t,
+            InIter first, Sent last, OutIter dest, Op&& op = Op())
+        {
+            static_assert(hpx::traits::is_input_iterator<InIter>::value,
+                "Requires at least input iterator.");
+            static_assert(hpx::traits::is_output_iterator<OutIter>::value,
+                "Requires at least output iterator.");
+
+            return hpx::parallel::v1::detail::inclusive_scan<OutIter>().call(
+                hpx::execution::seq, first, last, dest, std::forward<Op>(op));
+        }
+
+        // clang-format off
+        template <typename ExPolicy, typename FwdIter1, typename Sent,
+            typename FwdIter2, typename Op = std::plus<typename
+            std::iterator_traits<FwdIter1>::value_type>,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::is_execution_policy<ExPolicy>::value &&
+                hpx::traits::is_iterator<FwdIter1>::value &&
+                hpx::traits::is_sentinel_for<Sent, FwdIter1>::value &&
+                hpx::traits::is_iterator<FwdIter2>::value &&
+                hpx::is_invocable_v<Op,
+                    typename std::iterator_traits<FwdIter1>::value_type,
+                    typename std::iterator_traits<FwdIter1>::value_type
+                >
+            )>
+        // clang-format on
+        friend typename parallel::util::detail::algorithm_result<ExPolicy,
+            FwdIter2>::type
+        tag_fallback_dispatch(hpx::ranges::inclusive_scan_t, ExPolicy&& policy,
+            FwdIter1 first, Sent last, FwdIter2 dest, Op&& op = Op())
+        {
+            static_assert(hpx::traits::is_forward_iterator<FwdIter1>::value,
+                "Requires at least forward iterator.");
+            static_assert(hpx::traits::is_forward_iterator<FwdIter2>::value,
+                "Requires at least forward iterator.");
+
+            return hpx::parallel::v1::detail::inclusive_scan<FwdIter2>().call(
+                std::forward<ExPolicy>(policy), first, last, dest,
+                std::forward<Op>(op));
+        }
+
+        // clang-format off
+        template <typename Rng, typename O,
+            typename Op = std::plus<typename hpx::traits::range_traits<Rng>::value_type>,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::traits::is_range<Rng>::value &&
+                hpx::is_invocable_v<Op,
+                    typename hpx::traits::range_traits<Rng>::value_type,
+                    typename hpx::traits::range_traits<Rng>::value_type
+                >
+            )>
+        // clang-format on
+        friend O tag_fallback_dispatch(
+            hpx::ranges::inclusive_scan_t, Rng&& rng, O dest, Op&& op = Op())
+        {
+            using iterator_type =
+                typename hpx::traits::range_traits<Rng>::iterator_type;
+
+            static_assert(hpx::traits::is_input_iterator<iterator_type>::value,
+                "Requires at least input iterator.");
+
+            return hpx::parallel::v1::detail::inclusive_scan<O>().call(
+                hpx::execution::seq, std::begin(rng), std::end(rng), dest,
+                std::forward<Op>(op));
+        }
+
+        // clang-format off
+        template <typename ExPolicy, typename Rng,  typename O,
+            typename Op = std::plus<typename hpx::traits::range_traits<Rng>::value_type>,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::is_execution_policy<ExPolicy>::value &&
+                hpx::traits::is_range<Rng>::value &&
+                hpx::is_invocable_v<Op,
+                    typename hpx::traits::range_traits<Rng>::value_type,
+                    typename hpx::traits::range_traits<Rng>::value_type
+                >
+            )>
+        // clang-format on
+        friend
+            typename parallel::util::detail::algorithm_result<ExPolicy, O>::type
+            tag_fallback_dispatch(hpx::ranges::inclusive_scan_t,
+                ExPolicy&& policy, Rng&& rng, O dest, Op&& op = Op())
+        {
+            using iterator_type =
+                typename hpx::traits::range_traits<Rng>::iterator_type;
+
+            static_assert(
+                hpx::traits::is_forward_iterator<iterator_type>::value,
+                "Requires at least forward iterator.");
+
+            return hpx::parallel::v1::detail::inclusive_scan<O>().call(
+                std::forward<ExPolicy>(policy), std::begin(rng), std::end(rng),
+                dest, std::forward<Op>(op));
+        }
+
+        // clang-format off
+        template <typename InIter, typename Sent, typename OutIter,
+            typename Op, typename T,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::traits::is_iterator<InIter>::value &&
+                hpx::traits::is_sentinel_for<Sent, InIter>::value &&
+                hpx::traits::is_iterator<OutIter>::value &&
+                hpx::is_invocable_v<Op,
+                    typename std::iterator_traits<InIter>::value_type,
+                    typename std::iterator_traits<InIter>::value_type
+                >
+            )>
+        // clang-format on
+        friend OutIter tag_fallback_dispatch(hpx::ranges::inclusive_scan_t,
+            InIter first, Sent last, OutIter dest, Op&& op, T init)
+        {
+            static_assert(hpx::traits::is_input_iterator<InIter>::value,
+                "Requires at least input iterator.");
+            static_assert(hpx::traits::is_output_iterator<OutIter>::value,
+                "Requires at least output iterator.");
+
+            return hpx::parallel::v1::detail::inclusive_scan<OutIter>().call(
+                hpx::execution::seq, first, last, dest, std::move(init),
+                std::forward<Op>(op));
+        }
+
+        // clang-format off
+        template <typename ExPolicy, typename FwdIter1, typename Sent,
+            typename FwdIter2, typename Op, typename T,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::is_execution_policy<ExPolicy>::value &&
+                hpx::traits::is_iterator<FwdIter1>::value &&
+                hpx::traits::is_sentinel_for<Sent, FwdIter1>::value &&
+                hpx::traits::is_iterator<FwdIter2>::value &&
+                hpx::is_invocable_v<Op,
+                    typename std::iterator_traits<FwdIter1>::value_type,
+                    typename std::iterator_traits<FwdIter1>::value_type
+                >
+            )>
+        // clang-format on
+        friend typename parallel::util::detail::algorithm_result<ExPolicy,
+            FwdIter2>::type
+        tag_fallback_dispatch(hpx::ranges::inclusive_scan_t, ExPolicy&& policy,
+            FwdIter1 first, Sent last, FwdIter2 dest, Op&& op, T init)
+        {
+            static_assert(hpx::traits::is_forward_iterator<FwdIter1>::value,
+                "Requires at least forward iterator.");
+            static_assert(hpx::traits::is_forward_iterator<FwdIter2>::value,
+                "Requires at least forward iterator.");
+
+            return hpx::parallel::v1::detail::inclusive_scan<FwdIter2>().call(
+                std::forward<ExPolicy>(policy), first, last, dest,
+                std::move(init), std::forward<Op>(op));
+        }
+
+        // clang-format off
+        template <typename Rng, typename O,
+            typename Op, typename T,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::traits::is_range<Rng>::value &&
+                hpx::is_invocable_v<Op,
+                    typename hpx::traits::range_traits<Rng>::value_type,
+                    typename hpx::traits::range_traits<Rng>::value_type
+                >
+            )>
+        // clang-format on
+        friend O tag_fallback_dispatch(
+            hpx::ranges::inclusive_scan_t, Rng&& rng, O dest, Op&& op, T init)
+        {
+            using iterator_type =
+                typename hpx::traits::range_traits<Rng>::iterator_type;
+
+            static_assert(hpx::traits::is_input_iterator<iterator_type>::value,
+                "Requires at least input iterator.");
+
+            return hpx::parallel::v1::detail::inclusive_scan<O>().call(
+                hpx::execution::seq, std::begin(rng), std::end(rng), dest,
+                std::move(init), std::forward<Op>(op));
+        }
+
+        // clang-format off
+        template <typename ExPolicy, typename Rng,  typename O,
+            typename Op, typename T,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::is_execution_policy<ExPolicy>::value &&
+                hpx::traits::is_range<Rng>::value &&
+                hpx::is_invocable_v<Op,
+                    typename hpx::traits::range_traits<Rng>::value_type,
+                    typename hpx::traits::range_traits<Rng>::value_type
+                >
+            )>
+        // clang-format on
+        friend
+            typename parallel::util::detail::algorithm_result<ExPolicy, O>::type
+            tag_fallback_dispatch(hpx::ranges::inclusive_scan_t,
+                ExPolicy&& policy, Rng&& rng, O dest, Op&& op, T init)
+        {
+            using iterator_type =
+                typename hpx::traits::range_traits<Rng>::iterator_type;
+
+            static_assert(
+                hpx::traits::is_forward_iterator<iterator_type>::value,
+                "Requires at least forward iterator.");
+
+            return hpx::parallel::v1::detail::inclusive_scan<O>().call(
+                std::forward<ExPolicy>(policy), std::begin(rng), std::end(rng),
+                dest, std::move(init), std::forward<Op>(op));
+        }
+    } inclusive_scan{};
+}}    // namespace hpx::ranges
+
+#endif

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/inclusive_scan.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/inclusive_scan.hpp
@@ -12,358 +12,806 @@
 #if defined(DOXYGEN)
 
 namespace hpx { namespace ranges {
+    // clang-format off
 
-    /// Checks if the first range [first1, last1) is lexicographically less than
-    /// the second range [first2, last2). uses a provided predicate to compare
-    /// elements.
+    ///////////////////////////////////////////////////////////////////////////
+    /// Assigns through each iterator \a i in [result, result + (last - first))
+    /// the value of
+    /// GENERALIZED_NONCOMMUTATIVE_SUM(+, *first, ...,
+    /// *(first + (i - result))).
     ///
-    /// \note   Complexity: At most 2 * min(N1, N2) applications of the comparison
-    ///         operation, where N1 = std::distance(first1, last)
-    ///         and N2 = std::distance(first2, last2).
+    /// \note   Complexity: O(\a last - \a first) applications of the
+    ///         predicate \a op.
     ///
-    /// \tparam InIter1     The type of the source iterators used for the
-    ///                     first range (deduced).
+    /// \tparam InIter      The type of the source iterators used (deduced).
     ///                     This iterator type must meet the requirements of an
     ///                     input iterator.
-    /// \tparam Sent1       The type of the source sentinel (deduced). This
-    ///                     sentinel type must be a sentinel for InIter1.
-    /// \tparam InIter2     The type of the source iterators used for the
-    ///                     second range (deduced).
+    /// \tparam Sent        The type of the source sentinel (deduced). This
+    ///                     sentinel type must be a sentinel for InIter.
+    /// \tparam OutIter     The type of the iterator representing the
+    ///                     destination range (deduced).
     ///                     This iterator type must meet the requirements of an
-    ///                     input iterator.
-    /// \tparam Sent2       The type of the source sentinel (deduced). This
-    ///                     sentinel type must be a sentinel for InIter2.
-    /// \tparam Pred        The type of an optional function/function object to use.
-    ///                     Unlike its sequential form, the parallel
-    ///                     overload of \a inclusive_scan requires \a Pred to
-    ///                     meet the requirements of \a CopyConstructible. This defaults
-    ///                     to std::less<>
-    /// \tparam Proj1       The type of an optional projection function for FwdIter1. This
-    ///                     defaults to \a util::projection_identity
-    /// \tparam Proj2       The type of an optional projection function for FwdIter2. This
-    ///                     defaults to \a util::projection_identity
+    ///                     output iterator.
     ///
-    /// \param first1       Refers to the beginning of the sequence of elements
-    ///                     of the first range the algorithm will be applied to.
-    /// \param last1        Refers to the end of the sequence of elements of
-    ///                     the first range the algorithm will be applied to.
-    /// \param first2       Refers to the beginning of the sequence of elements
-    ///                     of the second range the algorithm will be applied to.
-    /// \param last2        Refers to the end of the sequence of elements of
-    ///                     the second range the algorithm will be applied to.
-    /// \param pred         Refers to the comparison function that the first
-    ///                     and second ranges will be applied to
-    /// \param proj1        Specifies the function (or function object) which
-    ///                     will be invoked for each of the elements of the first range
-    ///                     as a projection operation before the actual predicate
-    ///                     \a is invoked.
-    /// \param proj2        Specifies the function (or function object) which
-    ///                     will be invoked for each of the elements of the second range
-    ///                     as a projection operation before the actual predicate
-    ///                     \a is invoked.
+    /// \param first        Refers to the beginning of the sequence of elements
+    ///                     the algorithm will be applied to.
+    /// \param last         Refers to sentinel value denoting the end of the
+    ///                     sequence of elements the algorithm will be applied.
+    /// \param dest         Refers to the beginning of the destination range.
     ///
-    /// The comparison operations in the parallel \a inclusive_scan
-    /// algorithm invoked with an execution policy object of type
-    /// \a sequenced_policy execute in sequential order in the
-    /// calling thread.
-    ///
-    /// The comparison operations in the parallel \a inclusive_scan
-    /// algorithm invoked with an execution policy object of type
-    /// \a parallel_policy
-    /// or \a parallel_task_policy are permitted to execute in an unordered
-    /// fashion in unspecified threads, and indeterminately sequenced
-    /// within each thread.
-    ///
-    /// \note     Lexicographical comparison is an operation with the
-    ///           following properties
-    ///             - Two ranges are compared element by element
-    ///             - The first mismatching element defines which range
-    ///               is lexicographically
-    ///               \a less or \a greater than the other
-    ///             - If one range is a prefix of another, the shorter range is
-    ///               lexicographically \a less than the other
-    ///             - If two ranges have equivalent elements and are of the same length,
-    ///               then the ranges are lexicographically \a equal
-    ///             - An empty range is lexicographically \a less than any non-empty
-    ///               range
-    ///             - Two empty ranges are lexicographically \a equal
-    ///
-    /// \returns  The \a lexicographically_compare algorithm returns a
-    ///           \a hpx::future<bool> if the execution policy is of type
-    ///           \a sequenced_task_policy or
-    ///           \a parallel_task_policy and
-    ///           returns \a bool otherwise.
-    ///           The \a lexicographically_compare algorithm returns true
-    ///           if the first range is lexicographically less, otherwise
-    ///           it returns false.
-    ///           range [first2, last2), it returns false.
-    template <typename InIter1, typename Sent1, typename InIter2,
-        typename Sent2,
-        typename Proj1 = hpx::parallel::util::projection_identity,
-        typename Proj2 = hpx::parallel::util::projection_identity,
-        typename Pred = detail::less>
-    bool inclusive_scan(InIter1 first1, Sent1 last1, InIter2 first2,
-        Sent2 last2, Pred&& pred = Pred(), Proj1&& proj1 = Proj1(),
-        Proj2&& proj2 = Proj2());
-
-    /// Checks if the first range [first1, last1) is lexicographically less than
-    /// the second range [first2, last2). uses a provided predicate to compare
-    /// elements.
-    ///
-    /// \note   Complexity: At most 2 * min(N1, N2) applications of the comparison
-    ///         operation, where N1 = std::distance(first1, last)
-    ///         and N2 = std::distance(first2, last2).
-    ///
-    /// \tparam ExPolicy    The type of the execution policy to use (deduced).
-    ///                     It describes the manner in which the execution
-    ///                     of the algorithm may be parallelized and the manner
-    ///                     in which it executes the assignments.
-    /// \tparam FwdIter1    The type of the source iterators used for the
-    ///                     first range (deduced).
-    ///                     This iterator type must meet the requirements of an
-    ///                     forward iterator.
-    /// \tparam Sent1       The type of the source sentinel (deduced). This
-    ///                     sentinel type must be a sentinel for FwdIter1.
-    /// \tparam FwdIter2    The type of the source iterators used for the
-    ///                     second range (deduced).
-    ///                     This iterator type must meet the requirements of an
-    ///                     forward iterator.
-    /// \tparam Sent2       The type of the source sentinel (deduced). This
-    ///                     sentinel type must be a sentinel for FwdIter2.
-    /// \tparam Pred        The type of an optional function/function object to use.
-    ///                     Unlike its sequential form, the parallel
-    ///                     overload of \a inclusive_scan requires \a Pred to
-    ///                     meet the requirements of \a CopyConstructible. This defaults
-    ///                     to std::less<>
-    /// \tparam Proj1       The type of an optional projection function for FwdIter1. This
-    ///                     defaults to \a util::projection_identity
-    /// \tparam Proj2       The type of an optional projection function for FwdIter2. This
-    ///                     defaults to \a util::projection_identity
-    ///
-    /// \param policy       The execution policy to use for the scheduling of
-    ///                     the iterations.
-    /// \param first1       Refers to the beginning of the sequence of elements
-    ///                     of the first range the algorithm will be applied to.
-    /// \param last1        Refers to the end of the sequence of elements of
-    ///                     the first range the algorithm will be applied to.
-    /// \param first2       Refers to the beginning of the sequence of elements
-    ///                     of the second range the algorithm will be applied to.
-    /// \param last2        Refers to the end of the sequence of elements of
-    ///                     the second range the algorithm will be applied to.
-    /// \param pred         Refers to the comparison function that the first
-    ///                     and second ranges will be applied to
-    /// \param proj1        Specifies the function (or function object) which
-    ///                     will be invoked for each of the elements of the first range
-    ///                     as a projection operation before the actual predicate
-    ///                     \a is invoked.
-    /// \param proj2        Specifies the function (or function object) which
-    ///                     will be invoked for each of the elements of the second range
-    ///                     as a projection operation before the actual predicate
-    ///                     \a is invoked.
-    ///
-    /// The comparison operations in the parallel \a inclusive_scan
-    /// algorithm invoked with an execution policy object of type
-    /// \a sequenced_policy execute in sequential order in the
-    /// calling thread.
-    ///
-    /// The comparison operations in the parallel \a inclusive_scan
-    /// algorithm invoked with an execution policy object of type
-    /// \a parallel_policy
-    /// or \a parallel_task_policy are permitted to execute in an unordered
-    /// fashion in unspecified threads, and indeterminately sequenced
-    /// within each thread.
-    ///
-    /// \note     Lexicographical comparison is an operation with the
-    ///           following properties
-    ///             - Two ranges are compared element by element
-    ///             - The first mismatching element defines which range
-    ///               is lexicographically
-    ///               \a less or \a greater than the other
-    ///             - If one range is a prefix of another, the shorter range is
-    ///               lexicographically \a less than the other
-    ///             - If two ranges have equivalent elements and are of the same length,
-    ///               then the ranges are lexicographically \a equal
-    ///             - An empty range is lexicographically \a less than any non-empty
-    ///               range
-    ///             - Two empty ranges are lexicographically \a equal
-    ///
-    /// \returns  The \a lexicographically_compare algorithm returns a
-    ///           \a hpx::future<bool> if the execution policy is of type
-    ///           \a sequenced_task_policy or
-    ///           \a parallel_task_policy and
-    ///           returns \a bool otherwise.
-    ///           The \a lexicographically_compare algorithm returns true
-    ///           if the first range is lexicographically less, otherwise
-    ///           it returns false.
-    ///           range [first2, last2), it returns false.
-
-    template <typename ExPolicy, typename FwdIter1, typename Sent1,
-        typename FwdIter2, typename Sent2,
-        typename Proj1 = hpx::parallel::util::projection_identity,
-        typename Proj2 = hpx::parallel::util::projection_identity,
-        typename Pred = detail::less>
-    typename parallel::util::detail::algorithm_result<ExPolicy, bool>::type
-    inclusive_scan(ExPolicy&& policy, FwdIter1 first1, Sent1 last1,
-        FwdIter2 first2, Sent2 last2, Pred&& pred = Pred(),
-        Proj1&& proj1 = Proj1(), Proj2&& proj2 = Proj2());
-
-    /// Checks if the first range rng1 is lexicographically less than
-    /// the second range rng2. uses a provided predicate to compare
-    /// elements.
-    ///
-    /// \note   Complexity: At most 2 * min(N1, N2) applications of the comparison
-    ///         operation, where N1 = std::distance(std::begin(rng1), std::end(rng1))
-    ///         and N2 = std::distance(std::begin(rng2), std::end(rng2)).
-    ///
-    /// \tparam Rng1        The type of the source range used (deduced).
-    ///                     The iterators extracted from this range type must
-    ///                     meet the requirements of an input iterator.
-    /// \tparam Rng2        The type of the source range used (deduced).
-    ///                     The iterators extracted from this range type must
-    ///                     meet the requirements of an input iterator.
-    /// \tparam Pred        The type of an optional function/function object to use.
-    ///                     Unlike its sequential form, the parallel
-    ///                     overload of \a inclusive_scan requires \a Pred to
-    ///                     meet the requirements of \a CopyConstructible. This defaults
-    ///                     to std::less<>
-    /// \tparam Proj1       The type of an optional projection function for elements of the first range.
-    ///                     This defaults to \a util::projection_identity
-    /// \tparam Proj2       The type of an optional projection function for elements of the second range.
-    ///                     This defaults to \a util::projection_identity
-    ///
-    /// \param rng1         Refers to the sequence of elements the algorithm
-    ///                     will be applied to.
-    /// \param rng2         Refers to the sequence of elements the algorithm
-    ///                     will be applied to.
-    /// \param pred         Refers to the comparison function that the first
-    ///                     and second ranges will be applied to
-    /// \param proj1        Specifies the function (or function object) which
-    ///                     will be invoked for each of the elements of the first range
-    ///                     as a projection operation before the actual predicate
-    ///                     \a is invoked.
-    /// \param proj2        Specifies the function (or function object) which
-    ///                     will be invoked for each of the elements of the second range
-    ///                     as a projection operation before the actual predicate
-    ///                     \a is invoked.
-    ///
-    /// The comparison operations in the parallel \a inclusive_scan
-    /// algorithm invoked without an execution policy object  execute in sequential
+    /// The reduce operations in the parallel \a inclusive_scan algorithm
+    /// invoked without an execution policy object will execute in sequential
     /// order in the calling thread.
     ///
-    /// \note     Lexicographical comparison is an operation with the
-    ///           following properties
-    ///             - Two ranges are compared element by element
-    ///             - The first mismatching element defines which range
-    ///               is lexicographically
-    ///               \a less or \a greater than the other
-    ///             - If one range is a prefix of another, the shorter range is
-    ///               lexicographically \a less than the other
-    ///             - If two ranges have equivalent elements and are of the same length,
-    ///               then the ranges are lexicographically \a equal
-    ///             - An empty range is lexicographically \a less than any non-empty
-    ///               range
-    ///             - Two empty ranges are lexicographically \a equal
+    /// \returns  The \a inclusive_scan algorithm returns \a OutIter.
+    ///           The \a inclusive_scan algorithm returns the output iterator
+    ///           to the element in the destination range, one past the last
+    ///           element copied.
     ///
-    /// \returns  The \a lexicographically_compare algorithm returns \a bool.
-    ///           The \a lexicographically_compare algorithm returns true
-    ///           if the first range is lexicographically less, otherwise
-    ///           it returns false.
-    ///           range [first2, last2), it returns false.
-    template <typename Rng1, typename Rng2,
-        typename Proj1 = hpx::parallel::util::projection_identity,
-        typename Proj2 = hpx::parallel::util::projection_identity,
-        typename Pred = detail::less>
-    bool inclusive_scan(Rng1&& rng1, Rng2&& rng2, Pred&& pred = Pred(),
-        Proj1&& proj1 = Proj1(), Proj2&& proj2 = Proj2());
+    /// \note   GENERALIZED_NONCOMMUTATIVE_SUM(+, a1, ..., aN) is defined as:
+    ///         * a1 when N is 1
+    ///         * GENERALIZED_NONCOMMUTATIVE_SUM(+, a1, ..., aK)
+    ///           + GENERALIZED_NONCOMMUTATIVE_SUM(+, aM, ..., aN)
+    ///           where 1 < K+1 = M <= N.
+    ///
+    /// The difference between \a exclusive_scan and \a inclusive_scan is that
+    /// \a inclusive_scan includes the ith input element in the ith sum.
+    ///
+    template <typename InIter, typename Sent, typename OutIter>
+    OutIter inclusive_scan(InIter first, Sent last, OutIter dest);
 
-    /// Checks if the first range rng1 is lexicographically less than
-    /// the second range rng2. uses a provided predicate to compare
-    /// elements.
+    ///////////////////////////////////////////////////////////////////////////
+    /// Assigns through each iterator \a i in [result, result + (last - first))
+    /// the value of
+    /// GENERALIZED_NONCOMMUTATIVE_SUM(+, *first, ...,
+    /// *(first + (i - result))).
     ///
-    /// \note   Complexity: At most 2 * min(N1, N2) applications of the comparison
-    ///         operation, where N1 = std::distance(std::begin(rng1), std::end(rng1))
-    ///         and N2 = std::distance(std::begin(rng2), std::end(rng2)).
+    /// \note   Complexity: O(\a last - \a first) applications of the
+    ///         predicate \a op.
     ///
     /// \tparam ExPolicy    The type of the execution policy to use (deduced).
     ///                     It describes the manner in which the execution
     ///                     of the algorithm may be parallelized and the manner
     ///                     in which it executes the assignments.
-    /// \tparam Rng1        The type of the source range used (deduced).
-    ///                     The iterators extracted from this range type must
-    ///                     meet the requirements of an input iterator.
-    /// \tparam Rng2        The type of the source range used (deduced).
-    ///                     The iterators extracted from this range type must
-    ///                     meet the requirements of an input iterator.
-    /// \tparam Pred        The type of an optional function/function object to use.
-    ///                     Unlike its sequential form, the parallel
-    ///                     overload of \a inclusive_scan requires \a Pred to
-    ///                     meet the requirements of \a CopyConstructible. This defaults
-    ///                     to std::less<>
-    /// \tparam Proj1       The type of an optional projection function for elements of the first range.
-    ///                     This defaults to \a util::projection_identity
-    /// \tparam Proj2       The type of an optional projection function for elements of the second range.
-    ///                     This defaults to \a util::projection_identity
+    /// \tparam FwdIter1    The type of the source iterators used (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     forward iterator.
+    /// \tparam Sent        The type of the source sentinel (deduced). This
+    ///                     sentinel type must be a sentinel for FwdIter.
+    /// \tparam FwdIter2    The type of the iterator representing the
+    ///                     destination range (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     forward iterator.
     ///
     /// \param policy       The execution policy to use for the scheduling of
     ///                     the iterations.
-    /// \param rng1         Refers to the sequence of elements the algorithm
-    ///                     will be applied to.
-    /// \param rng2         Refers to the sequence of elements the algorithm
-    ///                     will be applied to.
-    /// \param pred         Refers to the comparison function that the first
-    ///                     and second ranges will be applied to
-    /// \param proj1        Specifies the function (or function object) which
-    ///                     will be invoked for each of the elements of the first range
-    ///                     as a projection operation before the actual predicate
-    ///                     \a is invoked.
-    /// \param proj2        Specifies the function (or function object) which
-    ///                     will be invoked for each of the elements of the second range
-    ///                     as a projection operation before the actual predicate
-    ///                     \a is invoked.
+    /// \param first        Refers to the beginning of the sequence of elements
+    ///                     the algorithm will be applied to.
+    /// \param last         Refers to sentinel value denoting the end of the
+    ///                     sequence of elements the algorithm will be applied.
+    /// \param dest         Refers to the beginning of the destination range.
     ///
-    /// The comparison operations in the parallel \a inclusive_scan
-    /// algorithm invoked with an execution policy object of type
-    /// \a sequenced_policy execute in sequential order in the
-    /// calling thread.
+    /// The reduce operations in the parallel \a inclusive_scan algorithm invoked
+    /// with an execution policy object of type \a sequenced_policy
+    /// execute in sequential order in the calling thread.
     ///
-    /// The comparison operations in the parallel \a inclusive_scan
-    /// algorithm invoked with an execution policy object of type
-    /// \a parallel_policy
+    /// The reduce operations in the parallel \a inclusive_scan algorithm invoked
+    /// with an execution policy object of type \a parallel_policy
     /// or \a parallel_task_policy are permitted to execute in an unordered
     /// fashion in unspecified threads, and indeterminately sequenced
     /// within each thread.
     ///
-    /// \note     Lexicographical comparison is an operation with the
-    ///           following properties
-    ///             - Two ranges are compared element by element
-    ///             - The first mismatching element defines which range
-    ///               is lexicographically
-    ///               \a less or \a greater than the other
-    ///             - If one range is a prefix of another, the shorter range is
-    ///               lexicographically \a less than the other
-    ///             - If two ranges have equivalent elements and are of the same length,
-    ///               then the ranges are lexicographically \a equal
-    ///             - An empty range is lexicographically \a less than any non-empty
-    ///               range
-    ///             - Two empty ranges are lexicographically \a equal
-    ///
-    /// \returns  The \a lexicographically_compare algorithm returns a
-    ///           \a hpx::future<bool> if the execution policy is of type
+    /// \returns  The \a inclusive_scan algorithm returns a
+    ///           \a hpx::future<FwdIter2> if
+    ///           the execution policy is of type
     ///           \a sequenced_task_policy or
     ///           \a parallel_task_policy and
-    ///           returns \a bool otherwise.
-    ///           The \a lexicographically_compare algorithm returns true
-    ///           if the first range is lexicographically less, otherwise
-    ///           it returns false.
-    ///           range [first2, last2), it returns false.
+    ///           returns \a FwdIter2 otherwise.
+    ///           The \a inclusive_scan algorithm returns the output iterator
+    ///           to the element in the destination range, one past the last
+    ///           element copied.
+    ///
+    /// \note   GENERALIZED_NONCOMMUTATIVE_SUM(+, a1, ..., aN) is defined as:
+    ///         * a1 when N is 1
+    ///         * GENERALIZED_NONCOMMUTATIVE_SUM(+, a1, ..., aK)
+    ///           + GENERALIZED_NONCOMMUTATIVE_SUM(+, aM, ..., aN)
+    ///           where 1 < K+1 = M <= N.
+    ///
+    /// The difference between \a exclusive_scan and \a inclusive_scan is that
+    /// \a inclusive_scan includes the ith input element in the ith sum.
+    ///
+    template <typename ExPolicy, typename FwdIter1, typename Sent, typename FwdIter2>
+    typename util::detail::algorithm_result<ExPolicy, FwdIter2>::type
+    inclusive_scan(ExPolicy&& policy, FwdIter1 first, Sent last,
+        FwdIter2 dest);
 
-    template <typename ExPolicy, typename Rng1, typename Rng2,
-        typename Proj1 = hpx::parallel::util::projection_identity,
-        typename Proj2 = hpx::parallel::util::projection_identity,
-        typename Pred = detail::less>
-    typename parallel::util::detail::algorithm_result<ExPolicy, bool>::type
-    inclusive_scan(ExPolicy&& policy, Rng1&& rng1, Rng2&& rng2,
-        Pred&& pred = Pred(), Proj1&& proj1 = Proj1(), Proj2&& proj2 = Proj2());
+    ///////////////////////////////////////////////////////////////////////////
+    /// Assigns through each iterator \a i in [result, result + (last - first))
+    /// the value of
+    /// GENERALIZED_NONCOMMUTATIVE_SUM(+, *first, ...,
+    /// *(first + (i - result))).
+    ///
+    /// \note   Complexity: O(\a last - \a first) applications of the
+    ///         predicate \a op.
+    ///
+    /// \tparam Rng         The type of the source range used (deduced).
+    ///                     The iterators extracted from this range type must
+    ///                     meet the requirements of an input iterator.
+    /// \tparam O           The type of the iterator representing the
+    ///                     destination range (deduced).
+    ///
+    /// \param rng          Refers to the sequence of elements the algorithm
+    ///                     will be applied to.
+    /// \param dest         Refers to the beginning of the destination range.
+    ///
+    /// The reduce operations in the parallel \a inclusive_scan algorithm
+    /// invoked without an execution policy object will execute in sequential
+    /// order in the calling thread.
+    ///
+    /// \returns  The \a inclusive_scan algorithm returns \a O.
+    ///           The \a inclusive_scan algorithm returns the output iterator
+    ///           to the element in the destination range, one past the last
+    ///           element copied.
+    ///
+    /// \note   GENERALIZED_NONCOMMUTATIVE_SUM(+, a1, ..., aN) is defined as:
+    ///         * a1 when N is 1
+    ///         * GENERALIZED_NONCOMMUTATIVE_SUM(+, a1, ..., aK)
+    ///           + GENERALIZED_NONCOMMUTATIVE_SUM(+, aM, ..., aN)
+    ///           where 1 < K+1 = M <= N.
+    ///
+    /// The difference between \a exclusive_scan and \a inclusive_scan is that
+    /// \a inclusive_scan includes the ith input element in the ith sum.
+    ///
+    template <typename Rng, typename O>
+    O inclusive_scan(Rng&& rng, O dest);
+
+    ///////////////////////////////////////////////////////////////////////////
+    /// Assigns through each iterator \a i in [result, result + (last - first))
+    /// the value of
+    /// GENERALIZED_NONCOMMUTATIVE_SUM(+, *first, ...,
+    /// *(first + (i - result))).
+    ///
+    /// \note   Complexity: O(\a last - \a first) applications of the
+    ///         predicate \a op.
+    ///
+    /// \tparam ExPolicy    The type of the execution policy to use (deduced).
+    ///                     It describes the manner in which the execution
+    ///                     of the algorithm may be parallelized and the manner
+    ///                     in which it executes the assignments.
+    /// \tparam Rng         The type of the source range used (deduced).
+    ///                     The iterators extracted from this range type must
+    ///                     meet the requirements of an forward iterator.
+    /// \tparam O           The type of the iterator representing the
+    ///                     destination range (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     forward iterator.
+    ///
+    /// \param policy       The execution policy to use for the scheduling of
+    ///                     the iterations.
+    /// \param rng          Refers to the sequence of elements the algorithm
+    ///                     will be applied to.
+    /// \param dest         Refers to the beginning of the destination range.
+    ///
+    /// The reduce operations in the parallel \a inclusive_scan algorithm invoked
+    /// with an execution policy object of type \a sequenced_policy
+    /// execute in sequential order in the calling thread.
+    ///
+    /// The reduce operations in the parallel \a inclusive_scan algorithm invoked
+    /// with an execution policy object of type \a parallel_policy
+    /// or \a parallel_task_policy are permitted to execute in an unordered
+    /// fashion in unspecified threads, and indeterminately sequenced
+    /// within each thread.
+    ///
+    /// \returns  The \a inclusive_scan algorithm returns a
+    ///           \a hpx::future<O> if
+    ///           the execution policy is of type
+    ///           \a sequenced_task_policy or
+    ///           \a parallel_task_policy and
+    ///           returns \a O otherwise.
+    ///           The \a inclusive_scan algorithm returns the output iterator
+    ///           to the element in the destination range, one past the last
+    ///           element copied.
+    ///
+    /// \note   GENERALIZED_NONCOMMUTATIVE_SUM(+, a1, ..., aN) is defined as:
+    ///         * a1 when N is 1
+    ///         * GENERALIZED_NONCOMMUTATIVE_SUM(+, a1, ..., aK)
+    ///           + GENERALIZED_NONCOMMUTATIVE_SUM(+, aM, ..., aN)
+    ///           where 1 < K+1 = M <= N.
+    ///
+    /// The difference between \a exclusive_scan and \a inclusive_scan is that
+    /// \a inclusive_scan includes the ith input element in the ith sum.
+    ///
+    template <typename ExPolicy, typename Rng, typename O>
+    typename util::detail::algorithm_result<ExPolicy, O>::type
+    inclusive_scan(ExPolicy&& policy, Rng&& rng, O dest);
+
+    ///////////////////////////////////////////////////////////////////////////
+    /// Assigns through each iterator \a i in [result, result + (last - first))
+    /// the value of
+    /// GENERALIZED_NONCOMMUTATIVE_SUM(op, *first, ...,
+    ///  *(first + (i - result))).
+    ///
+    /// \note   Complexity: O(\a last - \a first) applications of the
+    ///         predicate \a op.
+    ///
+    /// \tparam InIter      The type of the source iterators used (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     input iterator.
+    /// \tparam Sent        The type of the source sentinel (deduced). This
+    ///                     sentinel type must be a sentinel for InIter.
+    /// \tparam OutIter     The type of the iterator representing the
+    ///                     destination range (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     output iterator.
+    /// \tparam Op          The type of the binary function object used for
+    ///                     the reduction operation.
+    ///
+    /// \param first        Refers to the beginning of the sequence of elements
+    ///                     the algorithm will be applied to.
+    /// \param last         Refers to sentinel value denoting the end of the
+    ///                     sequence of elements the algorithm will be applied.
+    /// \param dest         Refers to the beginning of the destination range.
+    /// \param op           Specifies the function (or function object) which
+    ///                     will be invoked for each of the values of the input
+    ///                     sequence. This is a
+    ///                     binary predicate. The signature of this predicate
+    ///                     should be equivalent to:
+    ///                     \code
+    ///                     Ret fun(const Type1 &a, const Type1 &b);
+    ///                     \endcode \n
+    ///                     The signature does not need to have const&, but
+    ///                     the function must not modify the objects passed to
+    ///                     it.
+    ///                     The types \a Type1 and \a Ret must be
+    ///                     such that an object of a type as given by the input
+    ///                     sequence can be implicitly converted to any
+    ///                     of those types.
+    ///
+    /// The reduce operations in the parallel \a inclusive_scan algorithm
+    /// invoked without an execution policy object will execute in sequential
+    /// order in the calling thread.
+    ///
+    /// \returns  The \a inclusive_scan algorithm returns \a OutIter.
+    ///           The \a inclusive_scan algorithm returns the output iterator
+    ///           to the element in the destination range, one past the last
+    ///           element copied.
+    ///
+    /// \note   GENERALIZED_NONCOMMUTATIVE_SUM(+, a1, ..., aN) is defined as:
+    ///         * a1 when N is 1
+    ///         * GENERALIZED_NONCOMMUTATIVE_SUM(+, a1, ..., aK)
+    ///           + GENERALIZED_NONCOMMUTATIVE_SUM(+, aM, ..., aN)
+    ///           where 1 < K+1 = M <= N.
+    ///
+    /// The difference between \a exclusive_scan and \a inclusive_scan is that
+    /// \a inclusive_scan includes the ith input element in the ith sum.
+    ///
+    template <typename InIter, typename Sent, typename OutIter, typename Op>
+    OutIter inclusive_scan(InIter first, Sent last, OutIter dest, Op&& op);
+
+    ///////////////////////////////////////////////////////////////////////////
+    /// Assigns through each iterator \a i in [result, result + (last - first))
+    /// the value of
+    /// GENERALIZED_NONCOMMUTATIVE_SUM(op, *first, ...,
+    /// *(first + (i - result))).
+    ///
+    /// \note   Complexity: O(\a last - \a first) applications of the
+    ///         predicate \a op.
+    ///
+    /// \tparam ExPolicy    The type of the execution policy to use (deduced).
+    ///                     It describes the manner in which the execution
+    ///                     of the algorithm may be parallelized and the manner
+    ///                     in which it executes the assignments.
+    /// \tparam FwdIter1    The type of the source iterators used (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     forward iterator.
+    /// \tparam Sent        The type of the source sentinel (deduced). This
+    ///                     sentinel type must be a sentinel for InIter.
+    /// \tparam FwdIter2    The type of the iterator representing the
+    ///                     destination range (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     forward iterator.
+    /// \tparam Op          The type of the binary function object used for
+    ///                     the reduction operation.
+    ///
+    /// \param policy       The execution policy to use for the scheduling of
+    ///                     the iterations.
+    /// \param first        Refers to the beginning of the sequence of elements
+    ///                     the algorithm will be applied to.
+    /// \param last         Refers to sentinel value denoting the end of the
+    ///                     sequence of elements the algorithm will be applied.
+    /// \param dest         Refers to the beginning of the destination range.
+    /// \param op           Specifies the function (or function object) which
+    ///                     will be invoked for each of the values of the input
+    ///                     sequence. This is a
+    ///                     binary predicate. The signature of this predicate
+    ///                     should be equivalent to:
+    ///                     \code
+    ///                     Ret fun(const Type1 &a, const Type1 &b);
+    ///                     \endcode \n
+    ///                     The signature does not need to have const&, but
+    ///                     the function must not modify the objects passed to
+    ///                     it.
+    ///                     The types \a Type1 and \a Ret must be
+    ///                     such that an object of a type as given by the input
+    ///                     sequence can be implicitly converted to any
+    ///                     of those types.
+    ///
+    /// The reduce operations in the parallel \a inclusive_scan algorithm invoked
+    /// with an execution policy object of type \a sequenced_policy
+    /// execute in sequential order in the calling thread.
+    ///
+    /// The reduce operations in the parallel \a inclusive_scan algorithm invoked
+    /// with an execution policy object of type \a parallel_policy
+    /// or \a parallel_task_policy are permitted to execute in an unordered
+    /// fashion in unspecified threads, and indeterminately sequenced
+    /// within each thread.
+    ///
+    /// \returns  The \a inclusive_scan algorithm returns a
+    ///           \a hpx::future<FwdIter2> if
+    ///           the execution policy is of type
+    ///           \a sequenced_task_policy or
+    ///           \a parallel_task_policy and
+    ///           returns \a FwdIter2 otherwise.
+    ///           The \a inclusive_scan algorithm returns the output iterator
+    ///           to the element in the destination range, one past the last
+    ///           element copied.
+    ///
+    /// \note   GENERALIZED_NONCOMMUTATIVE_SUM(+, a1, ..., aN) is defined as:
+    ///         * a1 when N is 1
+    ///         * GENERALIZED_NONCOMMUTATIVE_SUM(op, a1, ..., aK)
+    ///           + GENERALIZED_NONCOMMUTATIVE_SUM(+, aM, ..., aN)
+    ///           where 1 < K+1 = M <= N.
+    ///
+    /// The difference between \a exclusive_scan and \a inclusive_scan is that
+    /// \a inclusive_scan includes the ith input element in the ith sum.
+    ///
+    template <typename ExPolicy, typename FwdIter1, typename Sent,
+        typename FwdIter2, typename Op>
+    typename util::detail::algorithm_result<ExPolicy, FwdIter2>::type
+    inclusive_scan(ExPolicy&& policy, FwdIter1 first, Sent last,
+        FwdIter2 dest, Op&& op);
+
+    ///////////////////////////////////////////////////////////////////////////
+    /// Assigns through each iterator \a i in [result, result + (last - first))
+    /// the value of
+    /// GENERALIZED_NONCOMMUTATIVE_SUM(op, *first, ...,
+    ///  *(first + (i - result))).
+    ///
+    /// \note   Complexity: O(\a last - \a first) applications of the
+    ///         predicate \a op.
+    ///
+    /// \tparam Rng         The type of the source range used (deduced).
+    ///                     The iterators extracted from this range type must
+    ///                     meet the requirements of an input iterator.
+    /// \tparam O           The type of the iterator representing the
+    ///                     destination range (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     output iterator.
+    /// \tparam Op          The type of the binary function object used for
+    ///                     the reduction operation.
+    ///
+    /// \param rng          Refers to the sequence of elements the algorithm
+    ///                     will be applied to.
+    /// \param dest         Refers to the beginning of the destination range.
+    /// \param op           Specifies the function (or function object) which
+    ///                     will be invoked for each of the values of the input
+    ///                     sequence. This is a
+    ///                     binary predicate. The signature of this predicate
+    ///                     should be equivalent to:
+    ///                     \code
+    ///                     Ret fun(const Type1 &a, const Type1 &b);
+    ///                     \endcode \n
+    ///                     The signature does not need to have const&, but
+    ///                     the function must not modify the objects passed to
+    ///                     it.
+    ///                     The types \a Type1 and \a Ret must be
+    ///                     such that an object of a type as given by the input
+    ///                     sequence can be implicitly converted to any
+    ///                     of those types.
+    ///
+    /// The reduce operations in the parallel \a inclusive_scan algorithm
+    /// invoked without an execution policy object will execute in sequential
+    /// order in the calling thread.
+    ///
+    /// \returns  The \a inclusive_scan algorithm returns \a O.
+    ///           The \a inclusive_scan algorithm returns the output iterator
+    ///           to the element in the destination range, one past the last
+    ///           element copied.
+    ///
+    /// \note   GENERALIZED_NONCOMMUTATIVE_SUM(+, a1, ..., aN) is defined as:
+    ///         * a1 when N is 1
+    ///         * GENERALIZED_NONCOMMUTATIVE_SUM(+, a1, ..., aK)
+    ///           + GENERALIZED_NONCOMMUTATIVE_SUM(+, aM, ..., aN)
+    ///           where 1 < K+1 = M <= N.
+    ///
+    /// The difference between \a exclusive_scan and \a inclusive_scan is that
+    /// \a inclusive_scan includes the ith input element in the ith sum.
+    ///
+    template <typename Rng, typename O, typename Op>
+    O inclusive_scan(Rng&& rng, O dest, Op&& op);
+
+    ///////////////////////////////////////////////////////////////////////////
+    /// Assigns through each iterator \a i in [result, result + (last - first))
+    /// the value of
+    /// GENERALIZED_NONCOMMUTATIVE_SUM(op, *first, ...,
+    /// *(first + (i - result))).
+    ///
+    /// \note   Complexity: O(\a last - \a first) applications of the
+    ///         predicate \a op.
+    ///
+    /// \tparam ExPolicy    The type of the execution policy to use (deduced).
+    ///                     It describes the manner in which the execution
+    ///                     of the algorithm may be parallelized and the manner
+    ///                     in which it executes the assignments.
+    /// \tparam Rng         The type of the source range used (deduced).
+    ///                     The iterators extracted from this range type must
+    ///                     meet the requirements of an forward iterator.
+    /// \tparam O           The type of the iterator representing the
+    ///                     destination range (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     forward iterator.
+    /// \tparam Op          The type of the binary function object used for
+    ///                     the reduction operation.
+    ///
+    /// \param policy       The execution policy to use for the scheduling of
+    ///                     the iterations.
+    /// \param rng          Refers to the sequence of elements the algorithm
+    ///                     will be applied to.
+    /// \param dest         Refers to the beginning of the destination range.
+    /// \param op           Specifies the function (or function object) which
+    ///                     will be invoked for each of the values of the input
+    ///                     sequence. This is a
+    ///                     binary predicate. The signature of this predicate
+    ///                     should be equivalent to:
+    ///                     \code
+    ///                     Ret fun(const Type1 &a, const Type1 &b);
+    ///                     \endcode \n
+    ///                     The signature does not need to have const&, but
+    ///                     the function must not modify the objects passed to
+    ///                     it.
+    ///                     The types \a Type1 and \a Ret must be
+    ///                     such that an object of a type as given by the input
+    ///                     sequence can be implicitly converted to any
+    ///                     of those types.
+    ///
+    /// The reduce operations in the parallel \a inclusive_scan algorithm invoked
+    /// with an execution policy object of type \a sequenced_policy
+    /// execute in sequential order in the calling thread.
+    ///
+    /// The reduce operations in the parallel \a inclusive_scan algorithm invoked
+    /// with an execution policy object of type \a parallel_policy
+    /// or \a parallel_task_policy are permitted to execute in an unordered
+    /// fashion in unspecified threads, and indeterminately sequenced
+    /// within each thread.
+    ///
+    /// \returns  The \a inclusive_scan algorithm returns a
+    ///           \a hpx::future<O> if
+    ///           the execution policy is of type
+    ///           \a sequenced_task_policy or
+    ///           \a parallel_task_policy and
+    ///           returns \a O otherwise.
+    ///           The \a inclusive_scan algorithm returns the output iterator
+    ///           to the element in the destination range, one past the last
+    ///           element copied.
+    ///
+    /// \note   GENERALIZED_NONCOMMUTATIVE_SUM(+, a1, ..., aN) is defined as:
+    ///         * a1 when N is 1
+    ///         * GENERALIZED_NONCOMMUTATIVE_SUM(op, a1, ..., aK)
+    ///           + GENERALIZED_NONCOMMUTATIVE_SUM(+, aM, ..., aN)
+    ///           where 1 < K+1 = M <= N.
+    ///
+    /// The difference between \a exclusive_scan and \a inclusive_scan is that
+    /// \a inclusive_scan includes the ith input element in the ith sum.
+    ///
+    template <typename ExPolicy, typename Rng, typename O, typename Op>
+    typename util::detail::algorithm_result<ExPolicy, O>::type
+    inclusive_scan(ExPolicy&& policy, Rng&& rng, O dest, Op&& op);
+
+    ///////////////////////////////////////////////////////////////////////////
+    /// Assigns through each iterator \a i in [result, result + (last - first))
+    /// the value of
+    /// GENERALIZED_NONCOMMUTATIVE_SUM(op, init, *first, ...,
+    /// *(first + (i - result))).
+    ///
+    /// \note   Complexity: O(\a last - \a first) applications of the
+    ///         predicate \a op.
+    ///
+    /// \tparam InIter      The type of the source iterators used (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     input iterator.
+    /// \tparam Sent        The type of the source sentinel (deduced). This
+    ///                     sentinel type must be a sentinel for InIter.
+    /// \tparam OutIter     The type of the iterator representing the
+    ///                     destination range (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     output iterator.
+    /// \tparam Op          The type of the binary function object used for
+    ///                     the reduction operation.
+    /// \tparam T           The type of the value to be used as initial (and
+    ///                     intermediate) values (deduced).
+    ///
+    /// \param first        Refers to the beginning of the sequence of elements
+    ///                     the algorithm will be applied to.
+    /// \param last         Refers to sentinel value denoting the end of the
+    ///                     sequence of elements the algorithm will be applied.
+    /// \param dest         Refers to the beginning of the destination range.
+    /// \param op           Specifies the function (or function object) which
+    ///                     will be invoked for each of the values of the input
+    ///                     sequence. This is a
+    ///                     binary predicate. The signature of this predicate
+    ///                     should be equivalent to:
+    ///                     \code
+    ///                     Ret fun(const Type1 &a, const Type1 &b);
+    ///                     \endcode \n
+    ///                     The signature does not need to have const&, but
+    ///                     the function must not modify the objects passed to
+    ///                     it.
+    ///                     The types \a Type1 and \a Ret must be
+    ///                     such that an object of a type as given by the input
+    ///                     sequence can be implicitly converted to any
+    ///                     of those types.
+    /// \param init         The initial value for the generalized sum.
+    ///
+    /// The reduce operations in the parallel \a inclusive_scan algorithm
+    /// invoked without an execution policy object will execute in sequential
+    /// order in the calling thread.
+    ///
+    /// \returns  The \a inclusive_scan algorithm returns \a OutIter.
+    ///           The \a inclusive_scan algorithm returns the output iterator
+    ///           to the element in the destination range, one past the last
+    ///           element copied.
+    ///
+    /// \note   GENERALIZED_NONCOMMUTATIVE_SUM(op, a1, ..., aN) is defined as:
+    ///         * a1 when N is 1
+    ///         * op(GENERALIZED_NONCOMMUTATIVE_SUM(op, a1, ..., aK),
+    ///           GENERALIZED_NONCOMMUTATIVE_SUM(op, aM, ..., aN))
+    ///           where 1 < K+1 = M <= N.
+    ///
+    /// The difference between \a exclusive_scan and \a inclusive_scan is that
+    /// \a inclusive_scan includes the ith input element in the ith sum. If
+    /// \a op is not mathematically associative, the behavior of
+    /// \a inclusive_scan may be non-deterministic.
+    ///
+    template <typename InIter, typename Sent, typename OutIter,typename T,
+        typename Op>
+    OutIter inclusive_scan(InIter first, Sent last, OutIter dest,
+        Op&& op, T init);
+
+    ///////////////////////////////////////////////////////////////////////////
+    /// Assigns through each iterator \a i in [result, result + (last - first))
+    /// the value of
+    /// GENERALIZED_NONCOMMUTATIVE_SUM(op, init, *first, ...,
+    /// *(first + (i - result))).
+    ///
+    /// \note   Complexity: O(\a last - \a first) applications of the
+    ///         predicate \a op.
+    ///
+    /// \tparam ExPolicy    The type of the execution policy to use (deduced).
+    ///                     It describes the manner in which the execution
+    ///                     of the algorithm may be parallelized and the manner
+    ///                     in which it executes the assignments.
+    /// \tparam FwdIter1    The type of the source iterators used (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     forward iterator.
+    /// \tparam Sent        The type of the source sentinel (deduced). This
+    ///                     sentinel type must be a sentinel for InIter.
+    /// \tparam FwdIter2    The type of the iterator representing the
+    ///                     destination range (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     forward iterator.
+    /// \tparam T           The type of the value to be used as initial (and
+    ///                     intermediate) values (deduced).
+    /// \tparam Op          The type of the binary function object used for
+    ///                     the reduction operation.
+    ///
+    /// \param policy       The execution policy to use for the scheduling of
+    ///                     the iterations.
+    /// \param first        Refers to the beginning of the sequence of elements
+    ///                     the algorithm will be applied to.
+    /// \param last         Refers to sentinel value denoting the end of the
+    ///                     sequence of elements the algorithm will be applied.
+    /// \param dest         Refers to the beginning of the destination range.
+    /// \param init         The initial value for the generalized sum.
+    /// \param op           Specifies the function (or function object) which
+    ///                     will be invoked for each of the values of the input
+    ///                     sequence. This is a
+    ///                     binary predicate. The signature of this predicate
+    ///                     should be equivalent to:
+    ///                     \code
+    ///                     Ret fun(const Type1 &a, const Type1 &b);
+    ///                     \endcode \n
+    ///                     The signature does not need to have const&, but
+    ///                     the function must not modify the objects passed to
+    ///                     it.
+    ///                     The types \a Type1 and \a Ret must be
+    ///                     such that an object of a type as given by the input
+    ///                     sequence can be implicitly converted to any
+    ///                     of those types.
+    ///
+    /// The reduce operations in the parallel \a inclusive_scan algorithm invoked
+    /// with an execution policy object of type \a sequenced_policy
+    /// execute in sequential order in the calling thread.
+    ///
+    /// The reduce operations in the parallel \a inclusive_scan algorithm invoked
+    /// with an execution policy object of type \a parallel_policy
+    /// or \a parallel_task_policy are permitted to execute in an unordered
+    /// fashion in unspecified threads, and indeterminately sequenced
+    /// within each thread.
+    ///
+    /// \returns  The \a inclusive_scan algorithm returns a
+    ///           \a hpx::future<FwdIter2> if
+    ///           the execution policy is of type
+    ///           \a sequenced_task_policy or
+    ///           \a parallel_task_policy and
+    ///           returns \a FwdIter2 otherwise.
+    ///           The \a inclusive_scan algorithm returns the output iterator
+    ///           to the element in the destination range, one past the last
+    ///           element copied.
+    ///
+    /// \note   GENERALIZED_NONCOMMUTATIVE_SUM(op, a1, ..., aN) is defined as:
+    ///         * a1 when N is 1
+    ///         * op(GENERALIZED_NONCOMMUTATIVE_SUM(op, a1, ..., aK),
+    ///           GENERALIZED_NONCOMMUTATIVE_SUM(op, aM, ..., aN))
+    ///           where 1 < K+1 = M <= N.
+    ///
+    /// The difference between \a exclusive_scan and \a inclusive_scan is that
+    /// \a inclusive_scan includes the ith input element in the ith sum. If
+    /// \a op is not mathematically associative, the behavior of
+    /// \a inclusive_scan may be non-deterministic.
+    ///
+    template <typename ExPolicy, typename FwdIter1, typename Sent,
+        typename FwdIter2, typename T, typename Op>
+    typename util::detail::algorithm_result<ExPolicy, FwdIter2>::type
+    inclusive_scan(ExPolicy&& policy, FwdIter1 first, Sent last,
+        FwdIter2 dest, T init, Op&& op);
+
+    ///////////////////////////////////////////////////////////////////////////
+    /// Assigns through each iterator \a i in [result, result + (last - first))
+    /// the value of
+    /// GENERALIZED_NONCOMMUTATIVE_SUM(op, init, *first, ...,
+    /// *(first + (i - result))).
+    ///
+    /// \note   Complexity: O(\a last - \a first) applications of the
+    ///         predicate \a op.
+    ///
+    /// \tparam Rng         The type of the source range used (deduced).
+    ///                     The iterators extracted from this range type must
+    ///                     meet the requirements of an input iterator.
+    /// \tparam O           The type of the iterator representing the
+    ///                     destination range (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     output iterator.
+    /// \tparam Op          The type of the binary function object used for
+    ///                     the reduction operation.
+    /// \tparam T           The type of the value to be used as initial (and
+    ///                     intermediate) values (deduced).
+    ///
+    /// \param rng          Refers to the sequence of elements the algorithm
+    ///                     will be applied to.
+    /// \param dest         Refers to the beginning of the destination range.
+    /// \param op           Specifies the function (or function object) which
+    ///                     will be invoked for each of the values of the input
+    ///                     sequence. This is a
+    ///                     binary predicate. The signature of this predicate
+    ///                     should be equivalent to:
+    ///                     \code
+    ///                     Ret fun(const Type1 &a, const Type1 &b);
+    ///                     \endcode \n
+    ///                     The signature does not need to have const&, but
+    ///                     the function must not modify the objects passed to
+    ///                     it.
+    ///                     The types \a Type1 and \a Ret must be
+    ///                     such that an object of a type as given by the input
+    ///                     sequence can be implicitly converted to any
+    ///                     of those types.
+    /// \param init         The initial value for the generalized sum.
+    ///
+    /// The reduce operations in the parallel \a inclusive_scan algorithm
+    /// invoked without an execution policy object will execute in sequential
+    /// order in the calling thread.
+    ///
+    /// \returns  The \a inclusive_scan algorithm returns \a O.
+    ///           The \a inclusive_scan algorithm returns the output iterator
+    ///           to the element in the destination range, one past the last
+    ///           element copied.
+    ///
+    /// \note   GENERALIZED_NONCOMMUTATIVE_SUM(op, a1, ..., aN) is defined as:
+    ///         * a1 when N is 1
+    ///         * op(GENERALIZED_NONCOMMUTATIVE_SUM(op, a1, ..., aK),
+    ///           GENERALIZED_NONCOMMUTATIVE_SUM(op, aM, ..., aN))
+    ///           where 1 < K+1 = M <= N.
+    ///
+    /// The difference between \a exclusive_scan and \a inclusive_scan is that
+    /// \a inclusive_scan includes the ith input element in the ith sum. If
+    /// \a op is not mathematically associative, the behavior of
+    /// \a inclusive_scan may be non-deterministic.
+    ///
+    template <typename Rng, typename O, typename Op, typename T>
+    O inclusive_scan(Rng&& rng, O dest, Op&& op, T init);
+
+    ///////////////////////////////////////////////////////////////////////////
+    /// Assigns through each iterator \a i in [result, result + (last - first))
+    /// the value of
+    /// GENERALIZED_NONCOMMUTATIVE_SUM(op, init, *first, ...,
+    /// *(first + (i - result))).
+    ///
+    /// \note   Complexity: O(\a last - \a first) applications of the
+    ///         predicate \a op.
+    ///
+    /// \tparam ExPolicy    The type of the execution policy to use (deduced).
+    ///                     It describes the manner in which the execution
+    ///                     of the algorithm may be parallelized and the manner
+    ///                     in which it executes the assignments.
+    /// \tparam Rng         The type of the source range used (deduced).
+    ///                     The iterators extracted from this range type must
+    ///                     meet the requirements of an forward iterator.
+    /// \tparam O           The type of the iterator representing the
+    ///                     destination range (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     forward iterator.
+    /// \tparam T           The type of the value to be used as initial (and
+    ///                     intermediate) values (deduced).
+    /// \tparam Op          The type of the binary function object used for
+    ///                     the reduction operation.
+    ///
+    /// \param policy       The execution policy to use for the scheduling of
+    ///                     the iterations.
+    /// \param rng          Refers to the sequence of elements the algorithm
+    ///                     will be applied to.
+    /// \param dest         Refers to the beginning of the destination range.
+    /// \param init         The initial value for the generalized sum.
+    /// \param op           Specifies the function (or function object) which
+    ///                     will be invoked for each of the values of the input
+    ///                     sequence. This is a
+    ///                     binary predicate. The signature of this predicate
+    ///                     should be equivalent to:
+    ///                     \code
+    ///                     Ret fun(const Type1 &a, const Type1 &b);
+    ///                     \endcode \n
+    ///                     The signature does not need to have const&, but
+    ///                     the function must not modify the objects passed to
+    ///                     it.
+    ///                     The types \a Type1 and \a Ret must be
+    ///                     such that an object of a type as given by the input
+    ///                     sequence can be implicitly converted to any
+    ///                     of those types.
+    ///
+    /// The reduce operations in the parallel \a inclusive_scan algorithm invoked
+    /// with an execution policy object of type \a sequenced_policy
+    /// execute in sequential order in the calling thread.
+    ///
+    /// The reduce operations in the parallel \a inclusive_scan algorithm invoked
+    /// with an execution policy object of type \a parallel_policy
+    /// or \a parallel_task_policy are permitted to execute in an unordered
+    /// fashion in unspecified threads, and indeterminately sequenced
+    /// within each thread.
+    ///
+    /// \returns  The \a inclusive_scan algorithm returns a
+    ///           \a hpx::future<O> if
+    ///           the execution policy is of type
+    ///           \a sequenced_task_policy or
+    ///           \a parallel_task_policy and
+    ///           returns \a O otherwise.
+    ///           The \a inclusive_scan algorithm returns the output iterator
+    ///           to the element in the destination range, one past the last
+    ///           element copied.
+    ///
+    /// \note   GENERALIZED_NONCOMMUTATIVE_SUM(op, a1, ..., aN) is defined as:
+    ///         * a1 when N is 1
+    ///         * op(GENERALIZED_NONCOMMUTATIVE_SUM(op, a1, ..., aK),
+    ///           GENERALIZED_NONCOMMUTATIVE_SUM(op, aM, ..., aN))
+    ///           where 1 < K+1 = M <= N.
+    ///
+    /// The difference between \a exclusive_scan and \a inclusive_scan is that
+    /// \a inclusive_scan includes the ith input element in the ith sum. If
+    /// \a op is not mathematically associative, the behavior of
+    /// \a inclusive_scan may be non-deterministic.
+    ///
+    template <typename ExPolicy, typename Rng, typename O, typename Op,
+        typename T>
+    typename util::detail::algorithm_result<ExPolicy, O>::type inclusive_scan(
+        ExPolicy&& policy, Rng&& rng, O dest, Op&& op, T init);
+    // clang-format on
 }}    // namespace hpx::ranges
 #else
 

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_numeric.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_numeric.hpp
@@ -9,5 +9,6 @@
 
 #include <hpx/parallel/numeric.hpp>
 
+#include <hpx/parallel/container_algorithms/inclusive_scan.hpp>
 #include <hpx/parallel/container_algorithms/reduce.hpp>
 #include <hpx/parallel/container_algorithms/transform_reduce.hpp>

--- a/libs/parallelism/algorithms/tests/regressions/scan_different_inits.cpp
+++ b/libs/parallelism/algorithms/tests/regressions/scan_different_inits.cpp
@@ -27,10 +27,10 @@ void test_zero()
     std::vector<int> b, c, d, e, f, g;
     auto policy = hpx::execution::par;
 
-    Iter i_inc_add = hpx::parallel::inclusive_scan(
+    Iter i_inc_add = hpx::inclusive_scan(
         policy, a.begin(), a.end(), b.begin(),
         [](int bar, int baz) { return bar + baz; }, 100);
-    Iter i_inc_mult = hpx::parallel::inclusive_scan(
+    Iter i_inc_mult = hpx::inclusive_scan(
         policy, a.begin(), a.end(), c.begin(),
         [](int bar, int baz) { return bar * baz; }, 10);
     Iter i_exc_add = hpx::parallel::exclusive_scan(policy, a.begin(), a.end(),
@@ -61,10 +61,10 @@ void test_async_zero()
     std::vector<int> b, c, d, e, f, g;
     auto policy = hpx::execution::par(hpx::execution::task);
 
-    Fut_Iter f_inc_add = hpx::parallel::inclusive_scan(
+    Fut_Iter f_inc_add = hpx::inclusive_scan(
         policy, a.begin(), a.end(), b.begin(),
         [](int bar, int baz) { return bar + baz; }, 100);
-    Fut_Iter f_inc_mult = hpx::parallel::inclusive_scan(
+    Fut_Iter f_inc_mult = hpx::inclusive_scan(
         policy, a.begin(), a.end(), c.begin(),
         [](int bar, int baz) { return bar * baz; }, 10);
     Fut_Iter f_exc_add = hpx::parallel::exclusive_scan(policy, a.begin(),
@@ -101,9 +101,9 @@ void test_one(std::vector<int> a)
     auto fun_conv = [](int foo) { return foo - 3; };
     auto policy = hpx::execution::par;
 
-    Iter f_inc_add = hpx::parallel::inclusive_scan(
-        policy, a.begin(), a.end(), b.begin(), fun_add, 10);
-    Iter f_inc_mult = hpx::parallel::inclusive_scan(
+    Iter f_inc_add =
+        hpx::inclusive_scan(policy, a.begin(), a.end(), b.begin(), fun_add, 10);
+    Iter f_inc_mult = hpx::inclusive_scan(
         policy, a.begin(), a.end(), c.begin(), fun_mult, 10);
     Iter f_exc_add = hpx::parallel::exclusive_scan(
         policy, a.begin(), a.end(), d.begin(), 10, fun_add);
@@ -158,9 +158,9 @@ void test_async_one(std::vector<int> a)
     auto fun_conv = [](int foo) { return foo - 3; };
     auto policy = hpx::execution::par(hpx::execution::task);
 
-    Fut_Iter f_inc_add = hpx::parallel::inclusive_scan(
-        policy, a.begin(), a.end(), b.begin(), fun_add, 10);
-    Fut_Iter f_inc_mult = hpx::parallel::inclusive_scan(
+    Fut_Iter f_inc_add =
+        hpx::inclusive_scan(policy, a.begin(), a.end(), b.begin(), fun_add, 10);
+    Fut_Iter f_inc_mult = hpx::inclusive_scan(
         policy, a.begin(), a.end(), c.begin(), fun_mult, 10);
     Fut_Iter f_exc_add = hpx::parallel::exclusive_scan(
         policy, a.begin(), a.end(), d.begin(), 10, fun_add);

--- a/libs/parallelism/algorithms/tests/regressions/scan_non_commutative.cpp
+++ b/libs/parallelism/algorithms/tests/regressions/scan_non_commutative.cpp
@@ -24,7 +24,7 @@ void test_scan_non_commutative()
     for (unsigned int i = 0; i < vs.size(); ++i)
     {
         std::vector<std::string> rs(vs.size());
-        hpx::parallel::inclusive_scan(
+        hpx::inclusive_scan(
             hpx::execution::par.with(hpx::execution::static_chunk_size(i)),
             vs.cbegin(), vs.cend(), rs.begin());
         std::cout << rs.back() << "\n";

--- a/libs/parallelism/algorithms/tests/unit/algorithms/inclusive_scan.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/inclusive_scan.cpp
@@ -18,6 +18,7 @@ void test_inclusive_scan1()
 {
     using namespace hpx::execution;
 
+    test_inclusive_scan1(IteratorTag());
     test_inclusive_scan1(seq, IteratorTag());
     test_inclusive_scan1(par, IteratorTag());
     test_inclusive_scan1(par_unseq, IteratorTag());
@@ -38,6 +39,7 @@ void test_inclusive_scan2()
 {
     using namespace hpx::execution;
 
+    test_inclusive_scan2(IteratorTag());
     test_inclusive_scan2(seq, IteratorTag());
     test_inclusive_scan2(par, IteratorTag());
     test_inclusive_scan2(par_unseq, IteratorTag());
@@ -58,6 +60,7 @@ void test_inclusive_scan3()
 {
     using namespace hpx::execution;
 
+    test_inclusive_scan3(IteratorTag());
     test_inclusive_scan3(seq, IteratorTag());
     test_inclusive_scan3(par, IteratorTag());
     test_inclusive_scan3(par_unseq, IteratorTag());

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/CMakeLists.txt
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/CMakeLists.txt
@@ -46,6 +46,7 @@ set(tests
     foreach_range_projection
     generate_range
     includes_range
+    inclusive_scan_range
     inplace_merge_range
     is_heap_range
     is_heap_until_range

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/inclusive_scan_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/inclusive_scan_range.cpp
@@ -1,0 +1,253 @@
+//  Copyright (c) 2018 Christopher Ogle
+//  Copyright (c) 2020 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/iterator_support/tests/iter_sent.hpp>
+#include <hpx/local/init.hpp>
+#include <hpx/modules/testing.hpp>
+#include <hpx/parallel/container_algorithms/inclusive_scan.hpp>
+
+#include <algorithm>
+#include <iostream>
+#include <iterator>
+#include <random>
+#include <string>
+#include <unordered_set>
+#include <vector>
+
+#include "test_utils.hpp"
+
+////////////////////////////////////////////////////////////////////////////
+unsigned int seed;
+std::mt19937 gen;
+std::uniform_int_distribution<> dis(1, 10007);
+
+template <typename IteratorTag>
+void test_inclusive_scan_sent(IteratorTag)
+{
+    auto end_len = dis(gen);
+    std::vector<std::size_t> c(10007);
+    std::vector<std::size_t> d(end_len);
+    std::vector<std::size_t> d1(end_len);
+    std::vector<std::size_t> d2(end_len);
+    std::fill(std::begin(c), std::begin(c) + end_len, std::size_t(1));
+    c[end_len] = 2;
+
+    std::size_t const val(0);
+    auto op = [](std::size_t v1, std::size_t v2) { return v1 + v2; };
+
+    hpx::ranges::inclusive_scan(
+        std::begin(c), sentinel<std::size_t>{2}, std::begin(d), op, val);
+
+    hpx::ranges::inclusive_scan(
+        std::begin(c), sentinel<std::size_t>{2}, std::begin(d1), op);
+
+    hpx::ranges::inclusive_scan(
+        std::begin(c), sentinel<std::size_t>{2}, std::begin(d2));
+
+    // verify values
+    std::vector<std::size_t> e(end_len);
+    hpx::parallel::v1::detail::sequential_inclusive_scan(
+        std::begin(c), std::begin(c) + end_len, std::begin(e), val, op);
+
+    HPX_TEST(std::equal(std::begin(d), std::end(d), std::begin(e)));
+    HPX_TEST(std::equal(std::begin(d1), std::end(d1), std::begin(e)));
+    HPX_TEST(std::equal(std::begin(d2), std::end(d2), std::begin(e)));
+}
+
+template <typename ExPolicy, typename IteratorTag>
+void test_inclusive_scan_sent(ExPolicy policy, IteratorTag)
+{
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
+
+    auto end_len = dis(gen);
+    std::vector<std::size_t> c(10007);
+    std::vector<std::size_t> d(end_len);
+    std::vector<std::size_t> d1(end_len);
+    std::vector<std::size_t> d2(end_len);
+    std::fill(std::begin(c), std::begin(c) + end_len, std::size_t(1));
+    c[end_len] = 2;
+
+    std::size_t const val(0);
+    auto op = [](std::size_t v1, std::size_t v2) { return v1 + v2; };
+
+    hpx::ranges::inclusive_scan(policy, std::begin(c), sentinel<std::size_t>{2},
+        std::begin(d), op, val);
+
+    hpx::ranges::inclusive_scan(
+        policy, std::begin(c), sentinel<std::size_t>{2}, std::begin(d1), op);
+
+    hpx::ranges::inclusive_scan(
+        policy, std::begin(c), sentinel<std::size_t>{2}, std::begin(d2));
+
+    // verify values
+    std::vector<std::size_t> e(end_len);
+    hpx::parallel::v1::detail::sequential_inclusive_scan(
+        std::begin(c), std::begin(c) + end_len, std::begin(e), val, op);
+
+    HPX_TEST(std::equal(std::begin(d), std::end(d), std::begin(e)));
+    HPX_TEST(std::equal(std::begin(d1), std::end(d1), std::begin(e)));
+    HPX_TEST(std::equal(std::begin(d2), std::end(d2), std::begin(e)));
+}
+
+template <typename IteratorTag>
+void test_inclusive_scan(IteratorTag)
+{
+    std::vector<std::size_t> c(10007);
+    std::vector<std::size_t> d(c.size());
+    std::vector<std::size_t> d1(c.size());
+    std::vector<std::size_t> d2(c.size());
+    std::fill(std::begin(c), std::end(c), std::size_t(1));
+
+    std::size_t const val(0);
+    auto op = [](std::size_t v1, std::size_t v2) { return v1 + v2; };
+
+    hpx::ranges::inclusive_scan(c, std::begin(d), op, val);
+    hpx::ranges::inclusive_scan(c, std::begin(d1), op);
+    hpx::ranges::inclusive_scan(c, std::begin(d2));
+
+    // verify values
+    std::vector<std::size_t> e(c.size());
+    hpx::parallel::v1::detail::sequential_inclusive_scan(
+        std::begin(c), std::end(c), std::begin(e), val, op);
+
+    HPX_TEST(std::equal(std::begin(d), std::end(d), std::begin(e)));
+    HPX_TEST(std::equal(std::begin(d1), std::end(d1), std::begin(e)));
+    HPX_TEST(std::equal(std::begin(d2), std::end(d2), std::begin(e)));
+}
+
+template <typename ExPolicy, typename IteratorTag>
+void test_inclusive_scan(ExPolicy policy, IteratorTag)
+{
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
+
+    std::vector<std::size_t> c(10007);
+    std::vector<std::size_t> d(c.size());
+    std::vector<std::size_t> d1(c.size());
+    std::vector<std::size_t> d2(c.size());
+    std::fill(std::begin(c), std::end(c), std::size_t(1));
+
+    std::size_t const val(0);
+    auto op = [](std::size_t v1, std::size_t v2) { return v1 + v2; };
+
+    hpx::ranges::inclusive_scan(policy, c, std::begin(d), op, val);
+    hpx::ranges::inclusive_scan(policy, c, std::begin(d1), op);
+    hpx::ranges::inclusive_scan(policy, c, std::begin(d2));
+
+    // verify values
+    std::vector<std::size_t> e(c.size());
+    hpx::parallel::v1::detail::sequential_inclusive_scan(
+        std::begin(c), std::end(c), std::begin(e), val, op);
+
+    HPX_TEST(std::equal(std::begin(d), std::end(d), std::begin(e)));
+    HPX_TEST(std::equal(std::begin(d1), std::end(d1), std::begin(e)));
+    HPX_TEST(std::equal(std::begin(d2), std::end(d2), std::begin(e)));
+}
+
+template <typename ExPolicy, typename IteratorTag>
+void test_inclusive_scan_async(ExPolicy policy, IteratorTag)
+{
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
+
+    std::vector<std::size_t> c(10007);
+    std::vector<std::size_t> d(c.size());
+    std::vector<std::size_t> d1(c.size());
+    std::vector<std::size_t> d2(c.size());
+    std::fill(std::begin(c), std::end(c), std::size_t(1));
+
+    std::size_t const val(0);
+    auto op = [](std::size_t v1, std::size_t v2) { return v1 + v2; };
+
+    hpx::future<void> fut =
+        hpx::ranges::inclusive_scan(policy, c, std::begin(d), op, val);
+    fut.wait();
+
+    hpx::future<void> fut1 =
+        hpx::ranges::inclusive_scan(policy, c, std::begin(d1), op);
+    fut1.wait();
+
+    hpx::future<void> fut2 =
+        hpx::ranges::inclusive_scan(policy, c, std::begin(d2));
+    fut2.wait();
+
+    // verify values
+    std::vector<std::size_t> e(c.size());
+    hpx::parallel::v1::detail::sequential_inclusive_scan(
+        std::begin(c), std::end(c), std::begin(e), val, op);
+
+    HPX_TEST(std::equal(std::begin(d), std::end(d), std::begin(e)));
+    HPX_TEST(std::equal(std::begin(d1), std::end(d1), std::begin(e)));
+    HPX_TEST(std::equal(std::begin(d2), std::end(d2), std::begin(e)));
+}
+
+template <typename IteratorTag>
+void test_inclusive_scan()
+{
+    using namespace hpx::execution;
+
+    test_inclusive_scan(IteratorTag());
+    test_inclusive_scan(seq, IteratorTag());
+    test_inclusive_scan(par, IteratorTag());
+    test_inclusive_scan(par_unseq, IteratorTag());
+
+    test_inclusive_scan_async(seq(task), IteratorTag());
+    test_inclusive_scan_async(par(task), IteratorTag());
+
+    test_inclusive_scan_sent(IteratorTag());
+    test_inclusive_scan_sent(seq, IteratorTag());
+    test_inclusive_scan_sent(par, IteratorTag());
+    test_inclusive_scan_sent(par_unseq, IteratorTag());
+}
+
+void inclusive_scan_test()
+{
+    test_inclusive_scan<std::random_access_iterator_tag>();
+    test_inclusive_scan<std::forward_iterator_tag>();
+}
+
+////////////////////////////////////////////////////////////////////////////
+int hpx_main(hpx::program_options::variables_map& vm)
+{
+    unsigned int seed1 = (unsigned int) std::time(nullptr);
+    if (vm.count("seed"))
+        seed1 = vm["seed"].as<unsigned int>();
+
+    std::cout << "using seed: " << seed1 << std::endl;
+    std::srand(seed1);
+
+    seed = seed1;
+    gen = std::mt19937(seed);
+
+    inclusive_scan_test();
+    return hpx::local::finalize();
+}
+
+int main(int argc, char* argv[])
+{
+    // add command line option which controls the random number generator seed
+    using namespace hpx::program_options;
+    options_description desc_commandline(
+        "Usage: " HPX_APPLICATION_STRING " [options]");
+
+    desc_commandline.add_options()("seed,s", value<unsigned int>(),
+        "the random number generator seed to use for this run");
+
+    // By default this test should run on all available cores
+    std::vector<std::string> const cfg = {"hpx.os_threads=all"};
+
+    // Initialize and run HPX
+    hpx::local::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::local::init(hpx_main, argc, argv, init_args), 0,
+        "HPX main exited with non-zero status");
+
+    return hpx::util::report_errors();
+}

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/inclusive_scan_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/inclusive_scan_range.cpp
@@ -11,6 +11,7 @@
 #include <hpx/parallel/container_algorithms/inclusive_scan.hpp>
 
 #include <algorithm>
+#include <cstddef>
 #include <iostream>
 #include <iterator>
 #include <random>

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/inclusive_scan_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/inclusive_scan_range.cpp
@@ -1,5 +1,6 @@
 //  Copyright (c) 2018 Christopher Ogle
 //  Copyright (c) 2020 Hartmut Kaiser
+//  Copyright (c) 2021 Akhil J Nair
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -40,14 +41,23 @@ void test_inclusive_scan_sent(IteratorTag)
     std::size_t const val(0);
     auto op = [](std::size_t v1, std::size_t v2) { return v1 + v2; };
 
-    hpx::ranges::inclusive_scan(
+    auto res1 = hpx::ranges::inclusive_scan(
         std::begin(c), sentinel<std::size_t>{2}, std::begin(d), op, val);
 
-    hpx::ranges::inclusive_scan(
+    auto res2 = hpx::ranges::inclusive_scan(
         std::begin(c), sentinel<std::size_t>{2}, std::begin(d1), op);
 
-    hpx::ranges::inclusive_scan(
+    auto res3 = hpx::ranges::inclusive_scan(
         std::begin(c), sentinel<std::size_t>{2}, std::begin(d2));
+
+    HPX_TEST(res1.in == std::begin(c) + end_len);
+    HPX_TEST(res1.out == std::begin(d) + end_len);
+
+    HPX_TEST(res2.in == std::begin(c) + end_len);
+    HPX_TEST(res2.out == std::begin(d1) + end_len);
+
+    HPX_TEST(res3.in == std::begin(c) + end_len);
+    HPX_TEST(res3.out == std::begin(d2) + end_len);
 
     // verify values
     std::vector<std::size_t> e(end_len);
@@ -76,14 +86,23 @@ void test_inclusive_scan_sent(ExPolicy policy, IteratorTag)
     std::size_t const val(0);
     auto op = [](std::size_t v1, std::size_t v2) { return v1 + v2; };
 
-    hpx::ranges::inclusive_scan(policy, std::begin(c), sentinel<std::size_t>{2},
-        std::begin(d), op, val);
+    auto res1 = hpx::ranges::inclusive_scan(policy, std::begin(c),
+        sentinel<std::size_t>{2}, std::begin(d), op, val);
 
-    hpx::ranges::inclusive_scan(
+    auto res2 = hpx::ranges::inclusive_scan(
         policy, std::begin(c), sentinel<std::size_t>{2}, std::begin(d1), op);
 
-    hpx::ranges::inclusive_scan(
+    auto res3 = hpx::ranges::inclusive_scan(
         policy, std::begin(c), sentinel<std::size_t>{2}, std::begin(d2));
+
+    HPX_TEST(res1.in == std::begin(c) + end_len);
+    HPX_TEST(res1.out == std::begin(d) + end_len);
+
+    HPX_TEST(res2.in == std::begin(c) + end_len);
+    HPX_TEST(res2.out == std::begin(d1) + end_len);
+
+    HPX_TEST(res3.in == std::begin(c) + end_len);
+    HPX_TEST(res3.out == std::begin(d2) + end_len);
 
     // verify values
     std::vector<std::size_t> e(end_len);
@@ -107,9 +126,18 @@ void test_inclusive_scan(IteratorTag)
     std::size_t const val(0);
     auto op = [](std::size_t v1, std::size_t v2) { return v1 + v2; };
 
-    hpx::ranges::inclusive_scan(c, std::begin(d), op, val);
-    hpx::ranges::inclusive_scan(c, std::begin(d1), op);
-    hpx::ranges::inclusive_scan(c, std::begin(d2));
+    auto res1 = hpx::ranges::inclusive_scan(c, std::begin(d), op, val);
+    auto res2 = hpx::ranges::inclusive_scan(c, std::begin(d1), op);
+    auto res3 = hpx::ranges::inclusive_scan(c, std::begin(d2));
+
+    HPX_TEST(res1.in == std::end(c));
+    HPX_TEST(res1.out == std::end(d));
+
+    HPX_TEST(res2.in == std::end(c));
+    HPX_TEST(res2.out == std::end(d1));
+
+    HPX_TEST(res3.in == std::end(c));
+    HPX_TEST(res3.out == std::end(d2));
 
     // verify values
     std::vector<std::size_t> e(c.size());
@@ -136,9 +164,18 @@ void test_inclusive_scan(ExPolicy policy, IteratorTag)
     std::size_t const val(0);
     auto op = [](std::size_t v1, std::size_t v2) { return v1 + v2; };
 
-    hpx::ranges::inclusive_scan(policy, c, std::begin(d), op, val);
-    hpx::ranges::inclusive_scan(policy, c, std::begin(d1), op);
-    hpx::ranges::inclusive_scan(policy, c, std::begin(d2));
+    auto res1 = hpx::ranges::inclusive_scan(policy, c, std::begin(d), op, val);
+    auto res2 = hpx::ranges::inclusive_scan(policy, c, std::begin(d1), op);
+    auto res3 = hpx::ranges::inclusive_scan(policy, c, std::begin(d2));
+
+    HPX_TEST(res1.in == std::end(c));
+    HPX_TEST(res1.out == std::end(d));
+
+    HPX_TEST(res2.in == std::end(c));
+    HPX_TEST(res2.out == std::end(d1));
+
+    HPX_TEST(res3.in == std::end(c));
+    HPX_TEST(res3.out == std::end(d2));
 
     // verify values
     std::vector<std::size_t> e(c.size());


### PR DESCRIPTION
Adapted inclusive_scan to C++ 20 and added container overloads. (range and sentinel). Added container tests. Seperated segmented overloads.

## Any background context you want to provide?
Issue #4822
Issue #3646
Issue #1668
Issue #5156