### PR TITLE
Adapt transform_exclusive_scan to C++ 20

### DIFF
--- a/docs/sphinx/api/public_api.rst
+++ b/docs/sphinx/api/public_api.rst
@@ -608,12 +608,13 @@ Functions
 - :cpp:func:`hpx::exclusive_scan`
 - :cpp:func:`hpx::inclusive_scan`
 - :cpp:func:`hpx::reduce`
-- :cpp:func:`hpx::parallel::v1::transform_exclusive_scan`
+- :cpp:func:`hpx::transform_exclusive_scan`
 - :cpp:func:`hpx::parallel::v1::transform_inclusive_scan`
 - :cpp:func:`hpx::transform_reduce`
 
 - :cpp:func:`hpx::ranges::exclusive_scan`
 - :cpp:func:`hpx::ranges::inclusive_scan`
+- :cpp:func:`hpx::ranges::transform_exclusive_scan`
 
 Header ``hpx/optional.hpp``
 ===========================

--- a/libs/full/include_local/include/hpx/local/numeric.hpp
+++ b/libs/full/include_local/include/hpx/local/numeric.hpp
@@ -11,6 +11,5 @@
 
 namespace hpx {
     using hpx::parallel::adjacent_difference;
-    using hpx::parallel::transform_exclusive_scan;
     using hpx::parallel::transform_inclusive_scan;
 }    // namespace hpx

--- a/libs/full/segmented_algorithms/include/hpx/parallel/segmented_algorithms/transform_exclusive_scan.hpp
+++ b/libs/full/segmented_algorithms/include/hpx/parallel/segmented_algorithms/transform_exclusive_scan.hpp
@@ -28,7 +28,6 @@
 
 // The segmented iterators we support all live in namespace hpx::segmented
 namespace hpx { namespace segmented {
-
     // clang-format off
     template <typename InIter, typename OutIter,
         typename T, typename Op, typename Conv,
@@ -52,7 +51,7 @@ namespace hpx { namespace segmented {
             return dest;
 
         return hpx::parallel::v1::detail::segmented_exclusive_scan(
-            std::forward<ExPolicy>(policy), first, last, dest, std::move(init),
+            hpx::execution::seq, first, last, dest, std::move(init),
             std::forward<Op>(op), std::true_type{}, std::forward<Conv>(conv));
     }
 

--- a/libs/full/segmented_algorithms/include/hpx/parallel/segmented_algorithms/transform_exclusive_scan.hpp
+++ b/libs/full/segmented_algorithms/include/hpx/parallel/segmented_algorithms/transform_exclusive_scan.hpp
@@ -1,4 +1,5 @@
 //  Copyright (c) 2017 Ajai V George
+//  Copyright (c) 2021 Akhil J Nair
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -25,37 +26,66 @@
 #include <utility>
 #include <vector>
 
-namespace hpx { namespace parallel { inline namespace v1 {
-    ///////////////////////////////////////////////////////////////////////////
-    // segmented transform_exclusive_scan
-    namespace detail {
-        ///////////////////////////////////////////////////////////////////////
-        // segmented implementation
-        template <typename ExPolicy, typename InIter, typename OutIter,
-            typename T, typename Op, typename Conv>
-        typename util::detail::algorithm_result<ExPolicy, OutIter>::type
-        transform_exclusive_scan_(ExPolicy&& policy, InIter first, InIter last,
-            OutIter dest, Conv&& conv, T&& init, Op&& op, std::true_type)
-        {
-            if (first == last)
-                return util::detail::algorithm_result<ExPolicy, OutIter>::get(
-                    std::move(dest));
+// The segmented iterators we support all live in namespace hpx::segmented
+namespace hpx { namespace segmented {
 
-            using is_seq = hpx::is_sequenced_execution_policy<ExPolicy>;
+    // clang-format off
+    template <typename InIter, typename OutIter,
+        typename T, typename Op, typename Conv,
+        HPX_CONCEPT_REQUIRES_(
+            hpx::traits::is_iterator<InIter>::value &&
+            hpx::traits::is_segmented_iterator<InIter>::value &&
+            hpx::traits::is_iterator<OutIter>::value &&
+            hpx::traits::is_segmented_iterator<OutIter>::value
+        )>
+    // clang-format on
+    OutIter tag_dispatch(hpx::transform_exclusive_scan_t, InIter first,
+        InIter last, OutIter dest, T init, Op&& op, Conv&& conv)
+    {
+        static_assert(hpx::traits::is_input_iterator<InIter>::value,
+            "Requires at least input iterator.");
 
-            return hpx::parallel::v1::detail::segmented_exclusive_scan(
-                std::forward<ExPolicy>(policy), first, last, dest,
-                std::forward<T>(init), std::forward<Op>(op), is_seq(),
-                std::forward<Conv>(conv));
-        }
+        static_assert(hpx::traits::is_output_iterator<OutIter>::value,
+            "Requires at least output iterator.");
 
-        // forward declare the non-segmented version of this algorithm
-        template <typename ExPolicy, typename InIter, typename OutIter,
-            typename T, typename Op, typename Conv>
-        typename util::detail::algorithm_result<ExPolicy, OutIter>::type
-        transform_exclusive_scan_(ExPolicy&& policy, InIter first, InIter last,
-            OutIter dest, Conv&& conv, T&& init, Op&& op, std::false_type);
+        if (first == last)
+            return dest;
 
-        /// \endcond
-    }    // namespace detail
-}}}      // namespace hpx::parallel::v1
+        return hpx::parallel::v1::detail::segmented_exclusive_scan(
+            std::forward<ExPolicy>(policy), first, last, dest, std::move(init),
+            std::forward<Op>(op), std::true_type{}, std::forward<Conv>(conv));
+    }
+
+    // clang-format off
+    template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
+        typename T, typename Op, typename Conv,
+        HPX_CONCEPT_REQUIRES_(
+            hpx::is_execution_policy<ExPolicy>::value &&
+            hpx::traits::is_iterator<FwdIter1>::value &&
+            hpx::traits::is_segmented_iterator<FwdIter1>::value &&
+            hpx::traits::is_iterator<FwdIter2>::value &&
+            hpx::traits::is_segmented_iterator<FwdIter2>::value
+        )>
+    // clang-format on
+    typename parallel::util::detail::algorithm_result<ExPolicy, FwdIter2>::type
+    tag_dispatch(hpx::transform_exclusive_scan_t, ExPolicy&& policy,
+        FwdIter1 first, FwdIter1 last, FwdIter2 dest, T init, Op&& op,
+        Conv&& conv)
+    {
+        static_assert(hpx::traits::is_forward_iterator<FwdIter1>::value,
+            "Requires at least forward iterator.");
+
+        static_assert(hpx::traits::is_forward_iterator<FwdIter2>::value,
+            "Requires at least forward iterator.");
+
+        if (first == last)
+            return parallel::util::detail::algorithm_result<ExPolicy,
+                FwdIter2>::get(std::move(dest));
+
+        using is_seq = hpx::is_sequenced_execution_policy<ExPolicy>;
+
+        return hpx::parallel::v1::detail::segmented_exclusive_scan(
+            std::forward<ExPolicy>(policy), first, last, dest, std::move(init),
+            std::forward<Op>(op), is_seq(), std::forward<Conv>(conv));
+    }
+}}    // namespace hpx::segmented

--- a/libs/full/segmented_algorithms/tests/unit/partitioned_vector_transform_scan.cpp
+++ b/libs/full/segmented_algorithms/tests/unit/partitioned_vector_transform_scan.cpp
@@ -51,6 +51,14 @@ void test_transform_inclusive_scan_async(ExPolicy&& policy,
         .get();
 }
 
+template <typename T>
+void test_transform_exclusive_scan(
+    hpx::partitioned_vector<T>& xvalues, hpx::partitioned_vector<T>& out)
+{
+    hpx::transform_exclusive_scan(
+        xvalues.begin(), xvalues.end(), out.begin(), T(0), op(), conv());
+}
+
 template <typename ExPolicy, typename T>
 void test_transform_exclusive_scan(ExPolicy&& policy,
     hpx::partitioned_vector<T>& xvalues, hpx::partitioned_vector<T>& out)
@@ -83,6 +91,8 @@ void transform_scan_tests(std::size_t num, hpx::partitioned_vector<T>& xvalues,
         hpx::execution::par(hpx::execution::task), xvalues, out);
     HPX_TEST_EQ((out[num - 1]), T(2 * num));
 
+    test_transform_exclusive_scan(xvalues, out);
+    HPX_TEST_EQ((out[num - 1]), T(2 * (num - 1)));
     test_transform_exclusive_scan(hpx::execution::seq, xvalues, out);
     HPX_TEST_EQ((out[num - 1]), T(2 * (num - 1)));
     test_transform_exclusive_scan(hpx::execution::par, xvalues, out);

--- a/libs/full/segmented_algorithms/tests/unit/partitioned_vector_transform_scan.cpp
+++ b/libs/full/segmented_algorithms/tests/unit/partitioned_vector_transform_scan.cpp
@@ -55,15 +55,15 @@ template <typename ExPolicy, typename T>
 void test_transform_exclusive_scan(ExPolicy&& policy,
     hpx::partitioned_vector<T>& xvalues, hpx::partitioned_vector<T>& out)
 {
-    hpx::parallel::transform_exclusive_scan(policy, xvalues.begin(),
-        xvalues.end(), out.begin(), T(0), op(), conv());
+    hpx::transform_exclusive_scan(policy, xvalues.begin(), xvalues.end(),
+        out.begin(), T(0), op(), conv());
 }
 
 template <typename ExPolicy, typename T>
 void test_transform_exclusive_scan_async(ExPolicy&& policy,
     hpx::partitioned_vector<T>& xvalues, hpx::partitioned_vector<T>& out)
 {
-    hpx::parallel::transform_exclusive_scan(
+    hpx::transform_exclusive_scan(
         policy, xvalues.begin(), xvalues.end(), out.begin(), T(0), op(), conv())
         .get();
 }

--- a/libs/full/segmented_algorithms/tests/unit/partitioned_vector_transform_scan2.cpp
+++ b/libs/full/segmented_algorithms/tests/unit/partitioned_vector_transform_scan2.cpp
@@ -51,6 +51,14 @@ void test_transform_inclusive_scan_async(ExPolicy&& policy,
         .get();
 }
 
+template <typename T>
+void test_transform_exclusive_scan(
+    hpx::partitioned_vector<T>& xvalues, hpx::partitioned_vector<T>& out)
+{
+    hpx::transform_exclusive_scan(
+        xvalues.begin(), xvalues.end(), out.begin(), T(0), op(), conv());
+}
+
 template <typename ExPolicy, typename T>
 void test_transform_exclusive_scan(ExPolicy&& policy,
     hpx::partitioned_vector<T>& xvalues, hpx::partitioned_vector<T>& out)
@@ -83,6 +91,8 @@ void transform_scan_tests(std::size_t num, hpx::partitioned_vector<T>& xvalues,
         hpx::execution::par(hpx::execution::task), xvalues, out);
     HPX_TEST_EQ((out[num - 1]), T(2 * num));
 
+    test_transform_exclusive_scan(xvalues, out);
+    HPX_TEST_EQ((out[num - 1]), T(2 * (num - 1)));
     test_transform_exclusive_scan(hpx::execution::seq, xvalues, out);
     HPX_TEST_EQ((out[num - 1]), T(2 * (num - 1)));
     test_transform_exclusive_scan(hpx::execution::par, xvalues, out);

--- a/libs/full/segmented_algorithms/tests/unit/partitioned_vector_transform_scan2.cpp
+++ b/libs/full/segmented_algorithms/tests/unit/partitioned_vector_transform_scan2.cpp
@@ -55,15 +55,15 @@ template <typename ExPolicy, typename T>
 void test_transform_exclusive_scan(ExPolicy&& policy,
     hpx::partitioned_vector<T>& xvalues, hpx::partitioned_vector<T>& out)
 {
-    hpx::parallel::transform_exclusive_scan(policy, xvalues.begin(),
-        xvalues.end(), out.begin(), T(0), op(), conv());
+    hpx::transform_exclusive_scan(policy, xvalues.begin(), xvalues.end(),
+        out.begin(), T(0), op(), conv());
 }
 
 template <typename ExPolicy, typename T>
 void test_transform_exclusive_scan_async(ExPolicy&& policy,
     hpx::partitioned_vector<T>& xvalues, hpx::partitioned_vector<T>& out)
 {
-    hpx::parallel::transform_exclusive_scan(
+    hpx::transform_exclusive_scan(
         policy, xvalues.begin(), xvalues.end(), out.begin(), T(0), op(), conv())
         .get();
 }

--- a/libs/parallelism/algorithms/CMakeLists.txt
+++ b/libs/parallelism/algorithms/CMakeLists.txt
@@ -122,6 +122,7 @@ set(algorithms_headers
     hpx/parallel/container_algorithms/sort.hpp
     hpx/parallel/container_algorithms/stable_sort.hpp
     hpx/parallel/container_algorithms/transform.hpp
+    hpx/parallel/container_algorithms/transform_exclusive_scan.hpp
     hpx/parallel/container_algorithms/transform_reduce.hpp
     hpx/parallel/container_algorithms/uninitialized_copy.hpp
     hpx/parallel/container_algorithms/uninitialized_default_construct.hpp

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/transform_exclusive_scan.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/transform_exclusive_scan.hpp
@@ -1,4 +1,5 @@
 //  Copyright (c) 2014-2017 Hartmut Kaiser
+//  Copyright (c) 2021 Akhil J Nair
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -222,6 +223,7 @@ namespace hpx {
 #include <hpx/type_support/unused.hpp>
 
 #include <hpx/executors/execution_policy.hpp>
+#include <hpx/parallel/algorithms/detail/advance_to_sentinel.hpp>
 #include <hpx/parallel/algorithms/detail/dispatch.hpp>
 #include <hpx/parallel/algorithms/detail/distance.hpp>
 #include <hpx/parallel/algorithms/transform_inclusive_scan.hpp>
@@ -248,7 +250,8 @@ namespace hpx { namespace parallel { inline namespace v1 {
         // Our own version of the sequential transform_exclusive_scan.
         template <typename InIter, typename Sent, typename OutIter,
             typename Conv, typename T, typename Op>
-        OutIter sequential_transform_exclusive_scan(
+        static constexpr util::in_out_result<InIter, OutIter>
+        sequential_transform_exclusive_scan(
             InIter first, Sent last, OutIter dest, Conv&& conv, T init, Op&& op)
         {
             T temp = init;
@@ -259,13 +262,13 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 *dest = temp;
                 temp = init;
             }
-            return dest;
+            return util::in_out_result<InIter, OutIter>{first, dest};
         }
 
         template <typename InIter, typename OutIter, typename Conv, typename T,
             typename Op>
-        T sequential_transform_exclusive_scan_n(InIter first, std::size_t count,
-            OutIter dest, Conv&& conv, T init, Op&& op)
+        static constexpr T sequential_transform_exclusive_scan_n(InIter first,
+            std::size_t count, OutIter dest, Conv&& conv, T init, Op&& op)
         {
             T temp = init;
             for (/* */; count-- != 0; (void) ++first, ++dest)
@@ -279,10 +282,10 @@ namespace hpx { namespace parallel { inline namespace v1 {
         }
 
         ///////////////////////////////////////////////////////////////////////
-        template <typename FwdIter2>
+        template <typename IterPair>
         struct transform_exclusive_scan
-          : public detail::algorithm<transform_exclusive_scan<FwdIter2>,
-                FwdIter2>
+          : public detail::algorithm<transform_exclusive_scan<IterPair>,
+                IterPair>
         {
             transform_exclusive_scan()
               : transform_exclusive_scan::algorithm("transform_exclusive_scan")
@@ -291,8 +294,9 @@ namespace hpx { namespace parallel { inline namespace v1 {
 
             template <typename ExPolicy, typename InIter, typename Sent,
                 typename Conv, typename T, typename OutIter, typename Op>
-            static OutIter sequential(ExPolicy, InIter first, Sent last,
-                OutIter dest, Conv&& conv, T&& init, Op&& op)
+            static constexpr util::in_out_result<InIter, OutIter> sequential(
+                ExPolicy, InIter first, Sent last, OutIter dest, Conv&& conv,
+                T&& init, Op&& op)
             {
                 return sequential_transform_exclusive_scan(first, last, dest,
                     std::forward<Conv>(conv), std::forward<T>(init),
@@ -300,23 +304,25 @@ namespace hpx { namespace parallel { inline namespace v1 {
             }
 
             template <typename ExPolicy, typename FwdIter1, typename Sent,
-                typename Conv, typename T, typename Op>
+                typename FwdIter2, typename Conv, typename T, typename Op>
             static typename util::detail::algorithm_result<ExPolicy,
-                FwdIter2>::type
+                util::in_out_result<FwdIter1, FwdIter2>>::type
             parallel(ExPolicy&& policy, FwdIter1 first, Sent last,
                 FwdIter2 dest, Conv&& conv, T&& init, Op&& op)
             {
-                typedef util::detail::algorithm_result<ExPolicy, FwdIter2>
-                    result;
-                typedef hpx::util::zip_iterator<FwdIter1, FwdIter2>
-                    zip_iterator;
-                typedef typename std::iterator_traits<FwdIter1>::difference_type
-                    difference_type;
+                using result_type = util::in_out_result<FwdIter1, FwdIter2>;
+                using result =
+                    util::detail::algorithm_result<ExPolicy, result_type>;
+                using zip_iterator =
+                    hpx::util::zip_iterator<FwdIter1, FwdIter2>;
+                using difference_type =
+                    typename std::iterator_traits<FwdIter1>::difference_type;
 
                 if (first == last)
-                    return result::get(std::move(dest));
+                    return result::get(std::move(result_type{first, dest}));
 
                 difference_type count = detail::distance(first, last);
+                FwdIter1 last_iter = detail::advance_to_sentinel(first, last);
 
                 FwdIter2 final_dest = dest;
                 std::advance(final_dest, count);
@@ -344,7 +350,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                         });
                 };
 
-                return util::scan_partitioner<ExPolicy, FwdIter2, T>::call(
+                return util::scan_partitioner<ExPolicy, result_type, T>::call(
                     std::forward<ExPolicy>(policy),
                     make_zip_iterator(first, dest), count, init,
                     // step 1 performs first part of scan algorithm
@@ -364,127 +370,30 @@ namespace hpx { namespace parallel { inline namespace v1 {
                     // step 3 runs final accumulation on each partition
                     std::move(f3),
                     // use this return value
-                    [final_dest](std::vector<hpx::shared_future<T>>&&,
-                        std::vector<hpx::future<void>>&&) -> FwdIter2 {
-                        return final_dest;
+                    [last_iter, final_dest](
+                        std::vector<hpx::shared_future<T>>&&,
+                        std::vector<hpx::future<void>> &&) -> result_type {
+                        return result_type{last_iter, final_dest};
                     });
             }
         };
         /// \endcond
     }    // namespace detail
 
-    ///////////////////////////////////////////////////////////////////////////
-    /// Assigns through each iterator \a i in [result, result + (last - first))
-    /// the value of
-    /// GENERALIZED_NONCOMMUTATIVE_SUM(binary_op, init, conv(*first), ...,
-    /// conv(*(first + (i - result) - 1))).
-    ///
-    /// \note   Complexity: O(\a last - \a first) applications of the
-    ///         predicates \a op and \a conv.
-    ///
-    /// \tparam ExPolicy    The type of the execution policy to use (deduced).
-    ///                     It describes the manner in which the execution
-    ///                     of the algorithm may be parallelized and the manner
-    ///                     in which it executes the assignments.
-    /// \tparam FwdIter1    The type of the source iterators used (deduced).
-    ///                     This iterator type must meet the requirements of an
-    ///                     forward iterator.
-    /// \tparam FwdIter2    The type of the iterator representing the
-    ///                     destination range (deduced).
-    ///                     This iterator type must meet the requirements of an
-    ///                     forward iterator.
-    /// \tparam Conv        The type of the unary function object used for
-    ///                     the conversion operation.
-    /// \tparam T           The type of the value to be used as initial (and
-    ///                     intermediate) values (deduced).
-    /// \tparam Op          The type of the binary function object used for
-    ///                     the reduction operation.
-    ///
-    /// \param policy       The execution policy to use for the scheduling of
-    ///                     the iterations.
-    /// \param first        Refers to the beginning of the sequence of elements
-    ///                     the algorithm will be applied to.
-    /// \param last         Refers to the end of the sequence of elements the
-    ///                     algorithm will be applied to.
-    /// \param dest         Refers to the beginning of the destination range.
-    /// \param conv         Specifies the function (or function object) which
-    ///                     will be invoked for each of the elements in the
-    ///                     sequence specified by [first, last). This is a
-    ///                     unary predicate. The signature of this predicate
-    ///                     should be equivalent to:
-    ///                     \code
-    ///                     R fun(const Type &a);
-    ///                     \endcode \n
-    ///                     The signature does not need to have const&, but
-    ///                     the function must not modify the objects passed to
-    ///                     it. The type \a Type must be such that an object of
-    ///                     type \a FwdIter1 can be dereferenced and then
-    ///                     implicitly converted to Type.
-    ///                     The type \a R must be such that an object of this
-    ///                     type can be implicitly converted to \a T.
-    /// \param init         The initial value for the generalized sum.
-    /// \param op           Specifies the function (or function object) which
-    ///                     will be invoked for each of the values of the input
-    ///                     sequence. This is a
-    ///                     binary predicate. The signature of this predicate
-    ///                     should be equivalent to:
-    ///                     \code
-    ///                     Ret fun(const Type1 &a, const Type1 &b);
-    ///                     \endcode \n
-    ///                     The signature does not need to have const&, but
-    ///                     the function must not modify the objects passed to
-    ///                     it.
-    ///                     The types \a Type1 and \a Ret must be
-    ///                     such that an object of a type as given by the input
-    ///                     sequence can be implicitly converted to any
-    ///                     of those types.
-    ///
-    /// The reduce operations in the parallel \a transform_exclusive_scan algorithm
-    /// invoked with an execution policy object of type \a sequenced_policy
-    /// execute in sequential order in the calling thread.
-    ///
-    /// The reduce operations in the parallel \a transform_exclusive_scan algorithm
-    /// invoked with an execution policy object of type \a parallel_policy
-    /// or \a parallel_task_policy are permitted to execute in an unordered
-    /// fashion in unspecified threads, and indeterminately sequenced
-    /// within each thread.
-    ///
-    /// \returns  The \a transform_exclusive_scan algorithm returns a
-    ///           \a hpx::future<FwdIter2> if
-    ///           the execution policy is of type
-    ///           \a sequenced_task_policy or
-    ///           \a parallel_task_policy and
-    ///           returns \a FwdIter2 otherwise.
-    ///           The \a transform_exclusive_scan algorithm returns the output
-    ///           iterator to the element in the destination range, one past
-    ///           the last element copied.
-    ///
-    /// \note   GENERALIZED_NONCOMMUTATIVE_SUM(op, a1, ..., aN) is defined as:
-    ///         * a1 when N is 1
-    ///         * op(GENERALIZED_NONCOMMUTATIVE_SUM(op, a1, ..., aK),
-    ///           GENERALIZED_NONCOMMUTATIVE_SUM(op, aM, ..., aN)
-    ///           where 1 < K+1 = M <= N.
-    ///
-    /// Neither \a conv nor \a op shall invalidate iterators or subranges, or
-    /// modify elements in the ranges [first,last) or [result,result + (last - first)).
-    ///
-    /// The behavior of transform_exclusive_scan may be non-deterministic for
-    /// a non-associative predicate.
-    ///
     // clang-format off
     template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
         typename T, typename Op, typename Conv,
         HPX_CONCEPT_REQUIRES_(
             hpx::is_execution_policy<ExPolicy>::value &&
-            hpx::traits::is_iterator<FwdIter1>::value &&
-            hpx::traits::is_iterator<FwdIter2>::value &&
+            hpx::traits::is_iterator_v<FwdIter1> &&
+            hpx::traits::is_iterator_v<FwdIter2> &&
             hpx::is_invocable_v<Conv,
-                typename std::iterator_traits<FwdIter1>::value_type> &&
+                    typename std::iterator_traits<FwdIter1>::value_type> &&
             hpx::is_invocable_v<Op,
-                typename hpx::util::invoke_result<Conv,
-                    typename std::iterator_traits<FwdIter1>::value_type>::type,
-                typename hpx::util::invoke_result<Conv,
-                    typename std::iterator_traits<FwdIter1>::value_type>::type
+                    typename hpx::util::invoke_result_t<Conv,
+                        typename std::iterator_traits<FwdIter1>::value_type>,
+                    typename hpx::util::invoke_result_t<Conv,
+                        typename std::iterator_traits<FwdIter1>::value_type>
             >
         )>
     // clang-format on
@@ -495,18 +404,22 @@ namespace hpx { namespace parallel { inline namespace v1 {
         transform_exclusive_scan(ExPolicy&& policy, FwdIter1 first,
             FwdIter1 last, FwdIter2 dest, T init, Op&& op, Conv&& conv)
     {
-        static_assert(hpx::traits::is_forward_iterator<FwdIter1>::value,
+        static_assert(hpx::traits::is_forward_iterator_v<FwdIter1>,
             "Requires at least forward iterator.");
-        static_assert(hpx::traits::is_forward_iterator<FwdIter2>::value,
+        static_assert(hpx::traits::is_forward_iterator_v<FwdIter2>,
             "Requires at least forward iterator.");
+
+        using result_type = parallel::util::in_out_result<FwdIter1, FwdIter2>;
 
 #if defined(HPX_GCC_VERSION) && HPX_GCC_VERSION >= 100000
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #endif
-        return detail::transform_exclusive_scan<FwdIter2>().call(
-            std::forward<ExPolicy>(policy), first, last, dest,
-            std::forward<Conv>(conv), std::move(init), std::forward<Op>(op));
+        return parallel::util::get_second_element(
+            detail::transform_exclusive_scan<result_type>().call(
+                std::forward<ExPolicy>(policy), first, last, dest,
+                std::forward<Conv>(conv), std::move(init),
+                std::forward<Op>(op)));
 #if defined(HPX_GCC_VERSION) && HPX_GCC_VERSION >= 100000
 #pragma GCC diagnostic pop
 #endif
@@ -523,15 +436,15 @@ namespace hpx {
         template <typename InIter, typename OutIter, typename T,
             typename BinOp, typename UnOp,
             HPX_CONCEPT_REQUIRES_(
-                hpx::traits::is_iterator<InIter>::value &&
-                hpx::traits::is_iterator<OutIter>::value &&
+                hpx::traits::is_iterator_v<InIter> &&
+                hpx::traits::is_iterator_v<OutIter> &&
                 hpx::is_invocable_v<UnOp,
                     typename std::iterator_traits<InIter>::value_type> &&
                 hpx::is_invocable_v<BinOp,
-                    typename hpx::util::invoke_result<UnOp,
-                        typename std::iterator_traits<InIter>::value_type>::type,
-                    typename hpx::util::invoke_result<UnOp,
-                        typename std::iterator_traits<InIter>::value_type>::type
+                    typename hpx::util::invoke_result_t<UnOp,
+                        typename std::iterator_traits<InIter>::value_type>,
+                    typename hpx::util::invoke_result_t<UnOp,
+                        typename std::iterator_traits<InIter>::value_type>
                 >
             )>
         // clang-format on
@@ -539,16 +452,19 @@ namespace hpx {
             InIter first, InIter last, OutIter dest, T init, BinOp&& binary_op,
             UnOp&& unary_op)
         {
-            static_assert((hpx::traits::is_input_iterator<InIter>::value),
+            static_assert((hpx::traits::is_input_iterator_v<InIter>),
                 "Requires at least input iterator.");
-            static_assert((hpx::traits::is_output_iterator<OutIter>::value),
+            static_assert((hpx::traits::is_output_iterator_v<OutIter>),
                 "Requires at least output iterator.");
 
-            return hpx::parallel::v1::detail::transform_exclusive_scan<
-                OutIter>()
-                .call(hpx::execution::seq, first, last, dest,
-                    std::forward<UnOp>(unary_op), std::move(init),
-                    std::forward<BinOp>(binary_op));
+            using result_type = parallel::util::in_out_result<InIter, OutIter>;
+
+            return parallel::util::get_second_element(
+                hpx::parallel::v1::detail::transform_exclusive_scan<
+                    result_type>()
+                    .call(hpx::execution::seq, first, last, dest,
+                        std::forward<UnOp>(unary_op), std::move(init),
+                        std::forward<BinOp>(binary_op)));
         }
 
         // clang-format off
@@ -556,15 +472,15 @@ namespace hpx {
             typename T, typename BinOp, typename UnOp,
             HPX_CONCEPT_REQUIRES_(
                 hpx::is_execution_policy<ExPolicy>::value &&
-                hpx::traits::is_forward_iterator<FwdIter1>::value &&
-                hpx::traits::is_forward_iterator<FwdIter2>::value &&
+                hpx::traits::is_iterator_v<FwdIter1> &&
+                hpx::traits::is_iterator_v<FwdIter2> &&
                 hpx::is_invocable_v<UnOp,
                     typename std::iterator_traits<FwdIter1>::value_type> &&
                 hpx::is_invocable_v<BinOp,
-                    typename hpx::util::invoke_result<UnOp,
-                        typename std::iterator_traits<FwdIter1>::value_type>::type,
-                    typename hpx::util::invoke_result<UnOp,
-                        typename std::iterator_traits<FwdIter1>::value_type>::type
+                    typename hpx::util::invoke_result_t<UnOp,
+                        typename std::iterator_traits<FwdIter1>::value_type>,
+                    typename hpx::util::invoke_result_t<UnOp,
+                        typename std::iterator_traits<FwdIter1>::value_type>
                 >
             )>
         // clang-format on
@@ -574,16 +490,20 @@ namespace hpx {
             ExPolicy&& policy, FwdIter1 first, FwdIter1 last, FwdIter2 dest,
             T init, BinOp&& binary_op, UnOp&& unary_op)
         {
-            static_assert(hpx::traits::is_forward_iterator<FwdIter1>::value,
+            static_assert(hpx::traits::is_forward_iterator_v<FwdIter1>,
                 "Requires at least forward iterator.");
-            static_assert(hpx::traits::is_forward_iterator<FwdIter2>::value,
+            static_assert(hpx::traits::is_forward_iterator_v<FwdIter2>,
                 "Requires at least forward iterator.");
 
-            return hpx::parallel::v1::detail::transform_exclusive_scan<
-                FwdIter2>()
-                .call(std::forward<ExPolicy>(policy), first, last, dest,
-                    std::forward<UnOp>(unary_op), std::move(init),
-                    std::forward<BinOp>(binary_op));
+            using result_type =
+                parallel::util::in_out_result<FwdIter1, FwdIter2>;
+
+            return parallel::util::get_second_element(
+                hpx::parallel::v1::detail::transform_exclusive_scan<
+                    result_type>()
+                    .call(std::forward<ExPolicy>(policy), first, last, dest,
+                        std::forward<UnOp>(unary_op), std::move(init),
+                        std::forward<BinOp>(binary_op)));
         }
     } transform_exclusive_scan{};
 }    // namespace hpx

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/transform_exclusive_scan.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/transform_exclusive_scan.hpp
@@ -442,31 +442,6 @@ namespace hpx { namespace parallel { inline namespace v1 {
                     });
             }
         };
-
-        template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
-            typename T, typename Op, typename Conv>
-        typename util::detail::algorithm_result<ExPolicy, FwdIter2>::type
-        transform_exclusive_scan_(ExPolicy&& policy, FwdIter1 first,
-            FwdIter1 last, FwdIter2 dest, Conv&& conv, T&& init, Op&& op,
-            std::false_type)
-        {
-            static_assert((hpx::traits::is_forward_iterator<FwdIter1>::value),
-                "Requires at least forward iterator.");
-            static_assert((hpx::traits::is_forward_iterator<FwdIter2>::value),
-                "Requires at least forward iterator.");
-
-            return detail::transform_exclusive_scan<FwdIter2>().call(
-                std::forward<ExPolicy>(policy), first, last, dest,
-                std::forward<Conv>(conv), std::forward<T>(init),
-                std::forward<Op>(op));
-        }
-
-        template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
-            typename T, typename Op, typename Conv>
-        typename util::detail::algorithm_result<ExPolicy, FwdIter2>::type
-        transform_exclusive_scan_(ExPolicy&& policy, FwdIter1 first,
-            FwdIter1 last, FwdIter2 dest, Conv&& conv, T&& init, Op&& op,
-            std::true_type);
         /// \endcond
     }    // namespace detail
 

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/transform_exclusive_scan.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/transform_exclusive_scan.hpp
@@ -1,17 +1,17 @@
-//  Copyright (c) 2014-2017 Hartmut Kaiser
+//  Copyright (c) 2020 ETH Zurich
+//  Copyright (c) 2014 Grant Mercer
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-/// \file parallel/algorithms/transform_exclusive_scan.hpp
+/// \file parallel/container_algorithms/transform_exclusive_scan.hpp
 
 #pragma once
 
 #if defined(DOXYGEN)
 
-namespace hpx {
-    // clang-format off
+namespace hpx { namespace ranges {
 
     ///////////////////////////////////////////////////////////////////////////
     /// Assigns through each iterator \a i in [result, result + (last - first))
@@ -25,6 +25,8 @@ namespace hpx {
     /// \tparam InIter      The type of the source iterators used (deduced).
     ///                     This iterator type must meet the requirements of an
     ///                     input iterator.
+    /// \tparam Sent        The type of the source sentinel (deduced). This
+    ///                     sentinel type must be a sentinel for InIter.
     /// \tparam OutIter     The type of the iterator representing the
     ///                     destination range (deduced).
     ///                     This iterator type must meet the requirements of an
@@ -34,8 +36,8 @@ namespace hpx {
     ///
     /// \param first        Refers to the beginning of the sequence of elements
     ///                     the algorithm will be applied to.
-    /// \param last         Refers to the end of the sequence of elements the
-    ///                     algorithm will be applied to.
+    /// \param last         Refers to sentinel value denoting the end of the
+    ///                     sequence of elements the algorithm will be applied.
     /// \param dest         Refers to the beginning of the destination range.
     /// \param init         The initial value for the generalized sum.
     ///
@@ -57,8 +59,8 @@ namespace hpx {
     /// The difference between \a exclusive_scan and \a inclusive_scan is that
     /// \a inclusive_scan includes the ith input element in the ith sum.
     ///
-    template <typename InIter, typename OutIter, typename T>
-    OutIter exclusive_scan(InIter first, InIter last, OutIter dest, T init);
+    template <typename InIter, typename Sent, typename OutIter, typename T>
+    OutIter exclusive_scan(InIter first, Sent last, OutIter dest, T init);
 
     ///////////////////////////////////////////////////////////////////////////
     /// Assigns through each iterator \a i in [result, result + (last - first))
@@ -76,6 +78,8 @@ namespace hpx {
     /// \tparam FwdIter1    The type of the source iterators used (deduced).
     ///                     This iterator type must meet the requirements of an
     ///                     forward iterator.
+    /// \tparam Sent        The type of the source sentinel (deduced). This
+    ///                     sentinel type must be a sentinel for FwdIter.
     /// \tparam FwdIter2    The type of the iterator representing the
     ///                     destination range (deduced).
     ///                     This iterator type must meet the requirements of an
@@ -87,8 +91,8 @@ namespace hpx {
     ///                     the iterations.
     /// \param first        Refers to the beginning of the sequence of elements
     ///                     the algorithm will be applied to.
-    /// \param last         Refers to the end of the sequence of elements the
-    ///                     algorithm will be applied to.
+    /// \param last         Refers to sentinel value denoting the end of the
+    ///                     sequence of elements the algorithm will be applied.
     /// \param dest         Refers to the beginning of the destination range.
     /// \param init         The initial value for the generalized sum.
     ///
@@ -121,11 +125,11 @@ namespace hpx {
     /// The difference between \a exclusive_scan and \a inclusive_scan is that
     /// \a inclusive_scan includes the ith input element in the ith sum.
     ///
-    template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
-        typename T>
+    template <typename ExPolicy, typename FwdIter1, typename Sent,
+        typename FwdIter2, typename T>
     typename util::detail::algorithm_result<ExPolicy, FwdIter2>::type
-    exclusive_scan(ExPolicy&& policy, FwdIter1 first, FwdIter1 last,
-        FwdIter2 dest, T init);
+    exclusive_scan(
+        ExPolicy&& policy, FwdIter1 first, Sent last, FwdIter2 dest, T init);
 
     ///////////////////////////////////////////////////////////////////////////
     /// Assigns through each iterator \a i in [result, result + (last - first))
@@ -139,6 +143,8 @@ namespace hpx {
     /// \tparam InIter      The type of the source iterators used (deduced).
     ///                     This iterator type must meet the requirements of an
     ///                     input iterator.
+    /// \tparam Sent        The type of the source sentinel (deduced). This
+    ///                     sentinel type must be a sentinel for InIter.
     /// \tparam OutIter     The type of the iterator representing the
     ///                     destination range (deduced).
     ///                     This iterator type must meet the requirements of an
@@ -150,8 +156,8 @@ namespace hpx {
     ///
     /// \param first        Refers to the beginning of the sequence of elements
     ///                     the algorithm will be applied to.
-    /// \param last         Refers to the end of the sequence of elements the
-    ///                     algorithm will be applied to.
+    /// \param last         Refers to sentinel value denoting the end of the
+    ///                     sequence of elements the algorithm will be applied.
     /// \param dest         Refers to the beginning of the destination range.
     /// \param init         The initial value for the generalized sum.
     /// \param op           Specifies the function (or function object) which
@@ -190,11 +196,12 @@ namespace hpx {
     /// \a op is not mathematically associative, the behavior of
     /// \a inclusive_scan may be non-deterministic.
     ///
-    template <typename InIter, typename OutIter,typename T, typename Op>
-    OutIter exclusive_scan(InIter first, InIter last, OutIter dest,
-        T init, Op&& op);
+    template <typename InIter, typename Sent, typename OutIter, typename T,
+        typename Op>
+    OutIter exclusive_scan(
+        InIter first, Sent last, OutIter dest, T init, Op&& op);
 
-        ///////////////////////////////////////////////////////////////////////////
+    ///////////////////////////////////////////////////////////////////////////
     /// Assigns through each iterator \a i in [result, result + (last - first))
     /// the value of
     /// GENERALIZED_NONCOMMUTATIVE_SUM(binary_op, init, *first, ...,
@@ -210,6 +217,8 @@ namespace hpx {
     /// \tparam FwdIter1    The type of the source iterators used (deduced).
     ///                     This iterator type must meet the requirements of an
     ///                     forward iterator.
+    /// \tparam Sent        The type of the source sentinel (deduced). This
+    ///                     sentinel type must be a sentinel for FwdIter1.
     /// \tparam FwdIter2    The type of the iterator representing the
     ///                     destination range (deduced).
     ///                     This iterator type must meet the requirements of an
@@ -223,8 +232,8 @@ namespace hpx {
     ///                     the iterations.
     /// \param first        Refers to the beginning of the sequence of elements
     ///                     the algorithm will be applied to.
-    /// \param last         Refers to the end of the sequence of elements the
-    ///                     algorithm will be applied to.
+    /// \param last         Refers to sentinel value denoting the end of the
+    ///                     sequence of elements the algorithm will be applied.
     /// \param dest         Refers to the beginning of the destination range.
     /// \param init         The initial value for the generalized sum.
     /// \param op           Specifies the function (or function object) which
@@ -274,251 +283,144 @@ namespace hpx {
     /// \a op is not mathematically associative, the behavior of
     /// \a inclusive_scan may be non-deterministic.
     ///
-    template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
-        typename T, typename Op>
+    template <typename ExPolicy, typename FwdIter1, typename Sent,
+        typename FwdIter2, typename T, typename Op>
     typename util::detail::algorithm_result<ExPolicy, FwdIter2>::type
-    exclusive_scan(ExPolicy&& policy, FwdIter1 first, FwdIter1 last,
-        FwdIter2 dest, T init, Op&& op);
-    // clang-format on
-}    // namespace hpx
-
-#else    // DOXYGEN
-
-#include <hpx/config.hpp>
-#include <hpx/concepts/concepts.hpp>
-#include <hpx/functional/invoke.hpp>
-#include <hpx/functional/invoke_result.hpp>
-#include <hpx/functional/tag_fallback_dispatch.hpp>
-#include <hpx/functional/traits/is_invocable.hpp>
-#include <hpx/iterator_support/traits/is_iterator.hpp>
-#include <hpx/type_support/unused.hpp>
-
-#include <hpx/executors/execution_policy.hpp>
-#include <hpx/parallel/algorithms/detail/dispatch.hpp>
-#include <hpx/parallel/algorithms/detail/distance.hpp>
-#include <hpx/parallel/algorithms/transform_inclusive_scan.hpp>
-#include <hpx/parallel/util/detail/algorithm_result.hpp>
-#include <hpx/parallel/util/loop.hpp>
-#include <hpx/parallel/util/partitioner.hpp>
-#include <hpx/parallel/util/scan_partitioner.hpp>
-#include <hpx/parallel/util/zip_iterator.hpp>
-
-#include <algorithm>
-#include <cstddef>
-#include <iterator>
-#include <numeric>
-#include <type_traits>
-#include <utility>
-#include <vector>
-
-namespace hpx { namespace parallel { inline namespace v1 {
-    ///////////////////////////////////////////////////////////////////////////
-    // transform_exclusive_scan
-    namespace detail {
-        /// \cond NOINTERNAL
-
-        // Our own version of the sequential transform_exclusive_scan.
-        template <typename InIter, typename Sent, typename OutIter,
-            typename Conv, typename T, typename Op>
-        OutIter sequential_transform_exclusive_scan(
-            InIter first, Sent last, OutIter dest, Conv&& conv, T init, Op&& op)
-        {
-            T temp = init;
-            for (/* */; first != last; (void) ++first, ++dest)
-            {
-                init = hpx::util::invoke(
-                    op, init, hpx::util::invoke(conv, *first));
-                *dest = temp;
-                temp = init;
-            }
-            return dest;
-        }
-
-        template <typename InIter, typename OutIter, typename Conv, typename T,
-            typename Op>
-        T sequential_transform_exclusive_scan_n(InIter first, std::size_t count,
-            OutIter dest, Conv&& conv, T init, Op&& op)
-        {
-            T temp = init;
-            for (/* */; count-- != 0; (void) ++first, ++dest)
-            {
-                init = hpx::util::invoke(
-                    op, init, hpx::util::invoke(conv, *first));
-                *dest = temp;
-                temp = init;
-            }
-            return init;
-        }
-
-        ///////////////////////////////////////////////////////////////////////
-        template <typename FwdIter2>
-        struct transform_exclusive_scan
-          : public detail::algorithm<transform_exclusive_scan<FwdIter2>,
-                FwdIter2>
-        {
-            transform_exclusive_scan()
-              : transform_exclusive_scan::algorithm("transform_exclusive_scan")
-            {
-            }
-
-            template <typename ExPolicy, typename InIter, typename Sent,
-                typename Conv, typename T, typename OutIter, typename Op>
-            static OutIter sequential(ExPolicy, InIter first, Sent last,
-                OutIter dest, Conv&& conv, T&& init, Op&& op)
-            {
-                return sequential_transform_exclusive_scan(first, last, dest,
-                    std::forward<Conv>(conv), std::forward<T>(init),
-                    std::forward<Op>(op));
-            }
-
-            template <typename ExPolicy, typename FwdIter1, typename Sent,
-                typename Conv, typename T, typename Op>
-            static typename util::detail::algorithm_result<ExPolicy,
-                FwdIter2>::type
-            parallel(ExPolicy&& policy, FwdIter1 first, Sent last,
-                FwdIter2 dest, Conv&& conv, T&& init, Op&& op)
-            {
-                typedef util::detail::algorithm_result<ExPolicy, FwdIter2>
-                    result;
-                typedef hpx::util::zip_iterator<FwdIter1, FwdIter2>
-                    zip_iterator;
-                typedef typename std::iterator_traits<FwdIter1>::difference_type
-                    difference_type;
-
-                if (first == last)
-                    return result::get(std::move(dest));
-
-                difference_type count = detail::distance(first, last);
-
-                FwdIter2 final_dest = dest;
-                std::advance(final_dest, count);
-
-                // The overall scan algorithm is performed by executing 2
-                // subsequent parallel steps. The first calculates the scan
-                // results for each partition and the second produces the
-                // overall result
-
-                using hpx::get;
-                using hpx::util::make_zip_iterator;
-
-                auto f3 = [op](zip_iterator part_begin, std::size_t part_size,
-                              hpx::shared_future<T> curr,
-                              hpx::shared_future<T> next) -> void {
-                    next.get();    // rethrow exceptions
-
-                    T val = curr.get();
-                    FwdIter2 dst = get<1>(part_begin.get_iterator_tuple());
-                    *dst++ = val;
-
-                    util::loop_n<std::decay_t<ExPolicy>>(
-                        dst, part_size - 1, [&op, &val](FwdIter2 it) -> void {
-                            *it = hpx::util::invoke(op, val, *it);
-                        });
-                };
-
-                return util::scan_partitioner<ExPolicy, FwdIter2, T>::call(
-                    std::forward<ExPolicy>(policy),
-                    make_zip_iterator(first, dest), count, init,
-                    // step 1 performs first part of scan algorithm
-                    [op, conv](
-                        zip_iterator part_begin, std::size_t part_size) -> T {
-                        T part_init =
-                            hpx::util::invoke(conv, get<0>(*part_begin++));
-
-                        auto iters = part_begin.get_iterator_tuple();
-                        return sequential_transform_exclusive_scan_n(
-                            get<0>(iters), part_size - 1, get<1>(iters), conv,
-                            part_init, op);
-                    },
-                    // step 2 propagates the partition results from left
-                    // to right
-                    hpx::unwrapping(op),
-                    // step 3 runs final accumulation on each partition
-                    std::move(f3),
-                    // use this return value
-                    [final_dest](std::vector<hpx::shared_future<T>>&&,
-                        std::vector<hpx::future<void>>&&) -> FwdIter2 {
-                        return final_dest;
-                    });
-            }
-        };
-
-        template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
-            typename T, typename Op, typename Conv>
-        typename util::detail::algorithm_result<ExPolicy, FwdIter2>::type
-        transform_exclusive_scan_(ExPolicy&& policy, FwdIter1 first,
-            FwdIter1 last, FwdIter2 dest, Conv&& conv, T&& init, Op&& op,
-            std::false_type)
-        {
-            static_assert((hpx::traits::is_forward_iterator<FwdIter1>::value),
-                "Requires at least forward iterator.");
-            static_assert((hpx::traits::is_forward_iterator<FwdIter2>::value),
-                "Requires at least forward iterator.");
-
-            return detail::transform_exclusive_scan<FwdIter2>().call(
-                std::forward<ExPolicy>(policy), first, last, dest,
-                std::forward<Conv>(conv), std::forward<T>(init),
-                std::forward<Op>(op));
-        }
-
-        template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
-            typename T, typename Op, typename Conv>
-        typename util::detail::algorithm_result<ExPolicy, FwdIter2>::type
-        transform_exclusive_scan_(ExPolicy&& policy, FwdIter1 first,
-            FwdIter1 last, FwdIter2 dest, Conv&& conv, T&& init, Op&& op,
-            std::true_type);
-        /// \endcond
-    }    // namespace detail
+    exclusive_scan(ExPolicy&& policy, FwdIter1 first, Sent last, FwdIter2 dest,
+        T init, Op&& op);
 
     ///////////////////////////////////////////////////////////////////////////
     /// Assigns through each iterator \a i in [result, result + (last - first))
     /// the value of
-    /// GENERALIZED_NONCOMMUTATIVE_SUM(binary_op, init, conv(*first), ...,
-    /// conv(*(first + (i - result) - 1))).
+    /// GENERALIZED_NONCOMMUTATIVE_SUM(+, init, *first, ...,
+    /// *(first + (i - result) - 1))
     ///
     /// \note   Complexity: O(\a last - \a first) applications of the
-    ///         predicates \a op and \a conv.
+    ///         predicate \a std::plus<T>.
+    ///
+    /// \tparam Rng         The type of the source range used (deduced).
+    ///                     The iterators extracted from this range type must
+    ///                     meet the requirements of an input iterator.
+    /// \tparam O           The type of the iterator representing the
+    ///                     destination range (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     output iterator.
+    /// \tparam T           The type of the value to be used as initial (and
+    ///                     intermediate) values (deduced).
+    ///
+    /// \param rng          Refers to the sequence of elements the algorithm
+    ///                     will be applied to.
+    /// \param dest         Refers to the beginning of the destination range.
+    /// \param init         The initial value for the generalized sum.
+    ///
+    /// The reduce operations in the parallel \a exclusive_scan algorithm
+    /// invoked without an execution policy object will execute in sequential
+    /// order in the calling thread.
+    ///
+    /// \returns  The \a exclusive_scan algorithm returns \a O.
+    ///           The \a exclusive_scan algorithm returns the output iterator
+    ///           to the element in the destination range, one past the last
+    ///           element copied.
+    ///
+    /// \note   GENERALIZED_NONCOMMUTATIVE_SUM(+, a1, ..., aN) is defined as:
+    ///         * a1 when N is 1
+    ///         * GENERALIZED_NONCOMMUTATIVE_SUM(+, a1, ..., aK)
+    ///           + GENERALIZED_NONCOMMUTATIVE_SUM(+, aM, ..., aN)
+    ///           where 1 < K+1 = M <= N.
+    ///
+    /// The difference between \a exclusive_scan and \a inclusive_scan is that
+    /// \a inclusive_scan includes the ith input element in the ith sum.
+    ///
+    template <typename Rng, typename O, typename T>
+    O exclusive_scan(Rng&& rng, O dest, T init);
+
+    ///////////////////////////////////////////////////////////////////////////
+    /// Assigns through each iterator \a i in [result, result + (last - first))
+    /// the value of
+    /// GENERALIZED_NONCOMMUTATIVE_SUM(+, init, *first, ...,
+    /// *(first + (i - result) - 1))
+    ///
+    /// \note   Complexity: O(\a last - \a first) applications of the
+    ///         predicate \a std::plus<T>.
     ///
     /// \tparam ExPolicy    The type of the execution policy to use (deduced).
     ///                     It describes the manner in which the execution
     ///                     of the algorithm may be parallelized and the manner
     ///                     in which it executes the assignments.
-    /// \tparam FwdIter1    The type of the source iterators used (deduced).
-    ///                     This iterator type must meet the requirements of an
-    ///                     forward iterator.
-    /// \tparam FwdIter2    The type of the iterator representing the
+    /// \tparam Rng         The type of the source range used (deduced).
+    ///                     The iterators extracted from this range type must
+    ///                     meet the requirements of an forward iterator.
+    /// \tparam O           The type of the iterator representing the
     ///                     destination range (deduced).
     ///                     This iterator type must meet the requirements of an
     ///                     forward iterator.
-    /// \tparam Conv        The type of the unary function object used for
-    ///                     the conversion operation.
+    /// \tparam T           The type of the value to be used as initial (and
+    ///                     intermediate) values (deduced).
+    ///
+    /// \param policy       The execution policy to use for the scheduling of
+    ///                     the iterations.
+    /// \param rng          Refers to the sequence of elements the algorithm
+    ///                     will be applied to.
+    /// \param dest         Refers to the beginning of the destination range.
+    /// \param init         The initial value for the generalized sum.
+    ///
+    /// The reduce operations in the parallel \a exclusive_scan algorithm
+    /// invoked with an execution policy object of type \a sequenced_policy
+    /// execute in sequential order in the calling thread.
+    ///
+    /// The reduce operations in the parallel \a exclusive_scan algorithm
+    /// invoked with an execution policy object of type \a parallel_policy
+    /// or \a parallel_task_policy are permitted to execute in an unordered
+    /// fashion in unspecified threads, and indeterminately sequenced
+    /// within each thread.
+    ///
+    /// \returns  The \a exclusive_scan algorithm returns a
+    ///           \a hpx::future<O> if
+    ///           the execution policy is of type
+    ///           \a sequenced_task_policy or
+    ///           \a parallel_task_policy and
+    ///           returns \a O otherwise.
+    ///           The \a exclusive_scan algorithm returns the output iterator
+    ///           to the element in the destination range, one past the last
+    ///           element copied.
+    ///
+    /// \note   GENERALIZED_NONCOMMUTATIVE_SUM(+, a1, ..., aN) is defined as:
+    ///         * a1 when N is 1
+    ///         * GENERALIZED_NONCOMMUTATIVE_SUM(+, a1, ..., aK)
+    ///           + GENERALIZED_NONCOMMUTATIVE_SUM(+, aM, ..., aN)
+    ///           where 1 < K+1 = M <= N.
+    ///
+    /// The difference between \a exclusive_scan and \a inclusive_scan is that
+    /// \a inclusive_scan includes the ith input element in the ith sum.
+    ///
+    template <typename ExPolicy, typename Rng, typename O, typename T>
+    typename util::detail::algorithm_result<ExPolicy, O>::type exclusive_scan(
+        ExPolicy&& policy, Rng&& rng, O dest, T init);
+
+    ///////////////////////////////////////////////////////////////////////////
+    /// Assigns through each iterator \a i in [result, result + (last - first))
+    /// the value of
+    /// GENERALIZED_NONCOMMUTATIVE_SUM(+, init, *first, ...,
+    /// *(first + (i - result) - 1))
+    ///
+    /// \note   Complexity: O(\a last - \a first) applications of the
+    ///         predicate \a std::plus<T>.
+    ///
+    /// \tparam Rng         The type of the source range used (deduced).
+    ///                     The iterators extracted from this range type must
+    ///                     meet the requirements of an input iterator.
+    /// \tparam O           The type of the iterator representing the
+    ///                     destination range (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     output iterator.
     /// \tparam T           The type of the value to be used as initial (and
     ///                     intermediate) values (deduced).
     /// \tparam Op          The type of the binary function object used for
     ///                     the reduction operation.
     ///
-    /// \param policy       The execution policy to use for the scheduling of
-    ///                     the iterations.
-    /// \param first        Refers to the beginning of the sequence of elements
-    ///                     the algorithm will be applied to.
-    /// \param last         Refers to the end of the sequence of elements the
-    ///                     algorithm will be applied to.
+    /// \param rng          Refers to the sequence of elements the algorithm
+    ///                     will be applied to.
     /// \param dest         Refers to the beginning of the destination range.
-    /// \param conv         Specifies the function (or function object) which
-    ///                     will be invoked for each of the elements in the
-    ///                     sequence specified by [first, last). This is a
-    ///                     unary predicate. The signature of this predicate
-    ///                     should be equivalent to:
-    ///                     \code
-    ///                     R fun(const Type &a);
-    ///                     \endcode \n
-    ///                     The signature does not need to have const&, but
-    ///                     the function must not modify the objects passed to
-    ///                     it. The type \a Type must be such that an object of
-    ///                     type \a FwdIter1 can be dereferenced and then
-    ///                     implicitly converted to Type.
-    ///                     The type \a R must be such that an object of this
-    ///                     type can be implicitly converted to \a T.
     /// \param init         The initial value for the generalized sum.
     /// \param op           Specifies the function (or function object) which
     ///                     will be invoked for each of the values of the input
@@ -536,91 +438,137 @@ namespace hpx { namespace parallel { inline namespace v1 {
     ///                     sequence can be implicitly converted to any
     ///                     of those types.
     ///
-    /// The reduce operations in the parallel \a transform_exclusive_scan algorithm
+    /// The reduce operations in the parallel \a exclusive_scan algorithm
+    /// invoked without an execution policy object will execute in sequential
+    /// order in the calling thread.
+    ///
+    /// \returns  The \a exclusive_scan algorithm returns \a O.
+    ///           The \a exclusive_scan algorithm returns the output iterator
+    ///           to the element in the destination range, one past the last
+    ///           element copied.
+    ///
+    /// \note   GENERALIZED_NONCOMMUTATIVE_SUM(+, a1, ..., aN) is defined as:
+    ///         * a1 when N is 1
+    ///         * GENERALIZED_NONCOMMUTATIVE_SUM(+, a1, ..., aK)
+    ///           + GENERALIZED_NONCOMMUTATIVE_SUM(+, aM, ..., aN)
+    ///           where 1 < K+1 = M <= N.
+    ///
+    /// The difference between \a exclusive_scan and \a inclusive_scan is that
+    /// \a inclusive_scan includes the ith input element in the ith sum.
+    ///
+    template <typename Rng, typename O, typename T, typename Op>
+    O exclusive_scan(Rng&& rng, O dest, T init, Op&& op);
+
+    ///////////////////////////////////////////////////////////////////////////
+    /// Assigns through each iterator \a i in [result, result + (last - first))
+    /// the value of
+    /// GENERALIZED_NONCOMMUTATIVE_SUM(+, init, *first, ...,
+    /// *(first + (i - result) - 1))
+    ///
+    /// \note   Complexity: O(\a last - \a first) applications of the
+    ///         predicate \a std::plus<T>.
+    ///
+    /// \tparam ExPolicy    The type of the execution policy to use (deduced).
+    ///                     It describes the manner in which the execution
+    ///                     of the algorithm may be parallelized and the manner
+    ///                     in which it executes the assignments.
+    /// \tparam Rng         The type of the source range used (deduced).
+    ///                     The iterators extracted from this range type must
+    ///                     meet the requirements of an forward iterator.
+    /// \tparam O           The type of the iterator representing the
+    ///                     destination range (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     forward iterator.
+    /// \tparam T           The type of the value to be used as initial (and
+    ///                     intermediate) values (deduced).
+    /// \tparam Op          The type of the binary function object used for
+    ///                     the reduction operation.
+    ///
+    /// \param policy       The execution policy to use for the scheduling of
+    ///                     the iterations.
+    /// \param rng          Refers to the sequence of elements the algorithm
+    ///                     will be applied to.
+    /// \param dest         Refers to the beginning of the destination range.
+    /// \param init         The initial value for the generalized sum.
+    /// \param op           Specifies the function (or function object) which
+    ///                     will be invoked for each of the values of the input
+    ///                     sequence. This is a
+    ///                     binary predicate. The signature of this predicate
+    ///                     should be equivalent to:
+    ///                     \code
+    ///                     Ret fun(const Type1 &a, const Type1 &b);
+    ///                     \endcode \n
+    ///                     The signature does not need to have const&, but
+    ///                     the function must not modify the objects passed to
+    ///                     it.
+    ///                     The types \a Type1 and \a Ret must be
+    ///                     such that an object of a type as given by the input
+    ///                     sequence can be implicitly converted to any
+    ///                     of those types.
+    ///
+    /// The reduce operations in the parallel \a exclusive_scan algorithm
     /// invoked with an execution policy object of type \a sequenced_policy
     /// execute in sequential order in the calling thread.
     ///
-    /// The reduce operations in the parallel \a transform_exclusive_scan algorithm
+    /// The reduce operations in the parallel \a exclusive_scan algorithm
     /// invoked with an execution policy object of type \a parallel_policy
     /// or \a parallel_task_policy are permitted to execute in an unordered
     /// fashion in unspecified threads, and indeterminately sequenced
     /// within each thread.
     ///
-    /// \returns  The \a transform_exclusive_scan algorithm returns a
-    ///           \a hpx::future<FwdIter2> if
+    /// \returns  The \a exclusive_scan algorithm returns a
+    ///           \a hpx::future<O> if
     ///           the execution policy is of type
     ///           \a sequenced_task_policy or
     ///           \a parallel_task_policy and
-    ///           returns \a FwdIter2 otherwise.
-    ///           The \a transform_exclusive_scan algorithm returns the output
-    ///           iterator to the element in the destination range, one past
-    ///           the last element copied.
+    ///           returns \a O otherwise.
+    ///           The \a exclusive_scan algorithm returns the output iterator
+    ///           to the element in the destination range, one past the last
+    ///           element copied.
     ///
-    /// \note   GENERALIZED_NONCOMMUTATIVE_SUM(op, a1, ..., aN) is defined as:
+    /// \note   GENERALIZED_NONCOMMUTATIVE_SUM(+, a1, ..., aN) is defined as:
     ///         * a1 when N is 1
-    ///         * op(GENERALIZED_NONCOMMUTATIVE_SUM(op, a1, ..., aK),
-    ///           GENERALIZED_NONCOMMUTATIVE_SUM(op, aM, ..., aN)
+    ///         * GENERALIZED_NONCOMMUTATIVE_SUM(+, a1, ..., aK)
+    ///           + GENERALIZED_NONCOMMUTATIVE_SUM(+, aM, ..., aN)
     ///           where 1 < K+1 = M <= N.
     ///
-    /// Neither \a conv nor \a op shall invalidate iterators or subranges, or
-    /// modify elements in the ranges [first,last) or [result,result + (last - first)).
+    /// The difference between \a exclusive_scan and \a inclusive_scan is that
+    /// \a inclusive_scan includes the ith input element in the ith sum.
     ///
-    /// The behavior of transform_exclusive_scan may be non-deterministic for
-    /// a non-associative predicate.
-    ///
-    // clang-format off
-    template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
-        typename T, typename Op, typename Conv,
-        HPX_CONCEPT_REQUIRES_(
-            hpx::is_execution_policy<ExPolicy>::value &&
-            hpx::traits::is_iterator<FwdIter1>::value &&
-            hpx::traits::is_iterator<FwdIter2>::value &&
-            hpx::is_invocable_v<Conv,
-                typename std::iterator_traits<FwdIter1>::value_type> &&
-            hpx::is_invocable_v<Op,
-                typename hpx::util::invoke_result<Conv,
-                    typename std::iterator_traits<FwdIter1>::value_type>::type,
-                typename hpx::util::invoke_result<Conv,
-                    typename std::iterator_traits<FwdIter1>::value_type>::type
-            >
-        )>
-    // clang-format on
-    HPX_DEPRECATED_V(1, 8,
-        "hpx::parallel::transform_exclusive_scan is deprecated, use "
-        "hpx::transform_exclusive_scan instead")
-        typename util::detail::algorithm_result<ExPolicy, FwdIter2>::type
-        transform_exclusive_scan(ExPolicy&& policy, FwdIter1 first,
-            FwdIter1 last, FwdIter2 dest, T init, Op&& op, Conv&& conv)
-    {
-        static_assert(hpx::traits::is_forward_iterator<FwdIter1>::value,
-            "Requires at least forward iterator.");
-        static_assert(hpx::traits::is_forward_iterator<FwdIter2>::value,
-            "Requires at least forward iterator.");
+    template <typename ExPolicy, typename Rng, typename O, typename T,
+        typename Op>
+    typename util::detail::algorithm_result<ExPolicy, O>::type exclusive_scan(
+        ExPolicy&& policy, Rng&& rng, O dest, T init, Op&& op);
+}}    // namespace hpx::ranges
+#else
 
-#if defined(HPX_GCC_VERSION) && HPX_GCC_VERSION >= 100000
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-#endif
-        return detail::transform_exclusive_scan<FwdIter2>().call(
-            std::forward<ExPolicy>(policy), first, last, dest,
-            std::forward<Conv>(conv), std::move(init), std::forward<Op>(op));
-#if defined(HPX_GCC_VERSION) && HPX_GCC_VERSION >= 100000
-#pragma GCC diagnostic pop
-#endif
-    }
-}}}    // namespace hpx::parallel::v1
+#include <hpx/config.hpp>
+#include <hpx/execution/algorithms/detail/predicates.hpp>
+#include <hpx/executors/execution_policy.hpp>
+#include <hpx/functional/tag_fallback_dispatch.hpp>
+#include <hpx/iterator_support/traits/is_iterator.hpp>
+#include <hpx/parallel/algorithms/transform_exclusive_scan.hpp>
+#include <hpx/parallel/util/detail/algorithm_result.hpp>
+#include <hpx/parallel/util/projection_identity.hpp>
 
-namespace hpx {
-    ///////////////////////////////////////////////////////////////////////////
-    // DPO for hpx::transform_exclusive_scan
+#include <algorithm>
+#include <cstddef>
+#include <iterator>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+namespace hpx { namespace ranges {
     HPX_INLINE_CONSTEXPR_VARIABLE struct transform_exclusive_scan_t final
       : hpx::functional::tag_fallback<transform_exclusive_scan_t>
     {
+    private:
         // clang-format off
-        template <typename InIter, typename OutIter, typename T,
-            typename BinOp, typename UnOp,
+        template <typename InIter, typename Sent, typename OutIter,
+             typename T, typename BinOp, typename UnOp,
             HPX_CONCEPT_REQUIRES_(
                 hpx::traits::is_iterator<InIter>::value &&
+                hpx::traits::is_sentinel_for<Sent, InIter>::value &&
                 hpx::traits::is_iterator<OutIter>::value &&
                 hpx::is_invocable_v<UnOp,
                     typename std::iterator_traits<InIter>::value_type> &&
@@ -629,16 +577,15 @@ namespace hpx {
                         typename std::iterator_traits<InIter>::value_type>::type,
                     typename hpx::util::invoke_result<UnOp,
                         typename std::iterator_traits<InIter>::value_type>::type
-                >
             )>
         // clang-format on
-        friend OutIter tag_fallback_dispatch(hpx::transform_exclusive_scan_t,
-            InIter first, InIter last, OutIter dest, T init, BinOp&& binary_op,
-            UnOp&& unary_op)
+        friend OutIter tag_fallback_dispatch(
+            hpx::ranges::transform_exclusive_scan_t, InIter first, Sent last,
+            OutIter dest, T init, BinOp&& binary_op, UnOp&& unary_op)
         {
-            static_assert((hpx::traits::is_input_iterator<InIter>::value),
+            static_assert(hpx::traits::is_input_iterator<InIter>::value,
                 "Requires at least input iterator.");
-            static_assert((hpx::traits::is_output_iterator<OutIter>::value),
+            static_assert(hpx::traits::is_output_iterator<OutIter>::value,
                 "Requires at least output iterator.");
 
             return hpx::parallel::v1::detail::transform_exclusive_scan<
@@ -649,12 +596,13 @@ namespace hpx {
         }
 
         // clang-format off
-        template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
-            typename T, typename BinOp, typename UnOp,
+        template <typename ExPolicy, typename FwdIter1, typename Sent,
+            typename FwdIter2, typename T, typename BinOp, typename UnOp,
             HPX_CONCEPT_REQUIRES_(
                 hpx::is_execution_policy<ExPolicy>::value &&
-                hpx::traits::is_forward_iterator<FwdIter1>::value &&
-                hpx::traits::is_forward_iterator<FwdIter2>::value &&
+                hpx::traits::is_iterator<FwdIter1>::value &&
+                hpx::traits::is_sentinel_for<Sent, FwdIter1>::value &&
+                hpx::traits::is_iterator<FwdIter2>::value &&
                 hpx::is_invocable_v<UnOp,
                     typename std::iterator_traits<FwdIter1>::value_type> &&
                 hpx::is_invocable_v<BinOp,
@@ -667,9 +615,9 @@ namespace hpx {
         // clang-format on
         friend typename parallel::util::detail::algorithm_result<ExPolicy,
             FwdIter2>::type
-        tag_fallback_dispatch(hpx::transform_exclusive_scan_t,
-            ExPolicy&& policy, FwdIter1 first, FwdIter1 last, FwdIter2 dest,
-            T init, BinOp&& binary_op, UnOp&& unary_op)
+        tag_fallback_dispatch(hpx::ranges::transform_exclusive_scan_t,
+            ExPolicy&& policy, FwdIter1 first, Sent last, FwdIter2 dest, T init,
+            BinOp&& binary_op, UnOp&& unary_op)
         {
             static_assert(hpx::traits::is_forward_iterator<FwdIter1>::value,
                 "Requires at least forward iterator.");
@@ -682,7 +630,72 @@ namespace hpx {
                     std::forward<UnOp>(unary_op), std::move(init),
                     std::forward<BinOp>(binary_op));
         }
-    } transform_exclusive_scan{};
-}    // namespace hpx
 
-#endif    // DOXYGEN
+        // clang-format off
+        template <typename Rng, typename O, typename T,
+            typename BinOp, typename UnOp,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::traits::is_range<Rng>::value &&
+                hpx::is_invocable_v<UnOp,
+                    typename hpx::traits::range_traits<Rng>::value_type> &&
+                hpx::is_invocable_v<BinOp,
+                    typename hpx::util::invoke_result<UnOp,
+                        typename hpx::traits::range_traits<Rng>::value_type>::type,
+                    typename hpx::util::invoke_result<UnOp,
+                        typename hpx::traits::range_traits<Rng>::value_type>::type
+                >
+            )>
+        // clang-format on
+        friend O tag_fallback_dispatch(hpx::ranges::transform_exclusive_scan_t,
+            Rng&& rng, O dest, T init, BinOp&& binary_op, UnOp&& unary_op)
+        {
+            using iterator_type =
+                typename hpx::traits::range_traits<Rng>::iterator_type;
+
+            static_assert(hpx::traits::is_input_iterator<iterator_type>::value,
+                "Requires at least input iterator.");
+
+            return hpx::parallel::v1::detail::transform_exclusive_scan<O>()
+                .call(hpx::execution::seq, std::begin(rng), std::end(rng), dest,
+                    std::forward<UnOp>(unary_op), std::move(init),
+                    std::forward<BinOp>(binary_op));
+        }
+
+        // clang-format off
+        template <typename ExPolicy, typename Rng,  typename O, typename T,
+            typename BinOp, typename UnOp,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::is_execution_policy<ExPolicy>::value &&
+                hpx::traits::is_range<Rng>::value &&
+                hpx::is_invocable_v<UnOp,
+                    typename hpx::traits::range_traits<Rng>::value_type> &&
+                hpx::is_invocable_v<BinOp,
+                    typename hpx::util::invoke_result<UnOp,
+                        typename hpx::traits::range_traits<Rng>::value_type>::type,
+                    typename hpx::util::invoke_result<UnOp,
+                        typename hpx::traits::range_traits<Rng>::value_type>::type
+                >
+            )>
+        // clang-format on
+        friend
+            typename parallel::util::detail::algorithm_result<ExPolicy, O>::type
+            tag_fallback_dispatch(hpx::ranges::transform_exclusive_scan_t,
+                ExPolicy&& policy, Rng&& rng, O dest, T init, BinOp&& binary_op,
+                UnOp&& unary_op)
+        {
+            using iterator_type =
+                typename hpx::traits::range_traits<Rng>::iterator_type;
+
+            static_assert(
+                hpx::traits::is_forward_iterator<iterator_type>::value,
+                "Requires at least forward iterator.");
+
+            return hpx::parallel::v1::detail::transform_exclusive_scan<O>()
+                .call(std::forward<ExPolicy>(policy), std::begin(rng),
+                    std::end(rng), dest, std::forward<UnOp>(unary_op),
+                    std::move(init), std::forward<BinOp>(binary_op));
+        }
+    } transform_exclusive_scan{};
+}}    // namespace hpx::ranges
+
+#endif

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/transform_exclusive_scan.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/transform_exclusive_scan.hpp
@@ -577,6 +577,7 @@ namespace hpx { namespace ranges {
                         typename std::iterator_traits<InIter>::value_type>::type,
                     typename hpx::util::invoke_result<UnOp,
                         typename std::iterator_traits<InIter>::value_type>::type
+                >
             )>
         // clang-format on
         friend OutIter tag_fallback_dispatch(

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/transform_exclusive_scan.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/transform_exclusive_scan.hpp
@@ -12,15 +12,16 @@
 #if defined(DOXYGEN)
 
 namespace hpx { namespace ranges {
+    // clang-format off
 
     ///////////////////////////////////////////////////////////////////////////
     /// Assigns through each iterator \a i in [result, result + (last - first))
     /// the value of
-    /// GENERALIZED_NONCOMMUTATIVE_SUM(+, init, *first, ...,
-    /// *(first + (i - result) - 1))
+    /// GENERALIZED_NONCOMMUTATIVE_SUM(binary_op, init, conv(*first), ...,
+    /// conv(*(first + (i - result) - 1))).
     ///
     /// \note   Complexity: O(\a last - \a first) applications of the
-    ///         predicate \a std::plus<T>.
+    ///         predicates \a op and \a conv.
     ///
     /// \tparam InIter      The type of the source iterators used (deduced).
     ///                     This iterator type must meet the requirements of an
@@ -31,45 +32,86 @@ namespace hpx { namespace ranges {
     ///                     destination range (deduced).
     ///                     This iterator type must meet the requirements of an
     ///                     output iterator.
+    /// \tparam Conv        The type of the unary function object used for
+    ///                     the conversion operation.
     /// \tparam T           The type of the value to be used as initial (and
     ///                     intermediate) values (deduced).
+    /// \tparam Op          The type of the binary function object used for
+    ///                     the reduction operation.
     ///
     /// \param first        Refers to the beginning of the sequence of elements
     ///                     the algorithm will be applied to.
     /// \param last         Refers to sentinel value denoting the end of the
     ///                     sequence of elements the algorithm will be applied.
     /// \param dest         Refers to the beginning of the destination range.
+    /// \param conv         Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements in the
+    ///                     sequence specified by [first, last). This is a
+    ///                     unary predicate. The signature of this predicate
+    ///                     should be equivalent to:
+    ///                     \code
+    ///                     R fun(const Type &a);
+    ///                     \endcode \n
+    ///                     The signature does not need to have const&, but
+    ///                     the function must not modify the objects passed to
+    ///                     it. The type \a Type must be such that an object of
+    ///                     type \a FwdIter1 can be dereferenced and then
+    ///                     implicitly converted to Type.
+    ///                     The type \a R must be such that an object of this
+    ///                     type can be implicitly converted to \a T.
     /// \param init         The initial value for the generalized sum.
+    /// \param op           Specifies the function (or function object) which
+    ///                     will be invoked for each of the values of the input
+    ///                     sequence. This is a
+    ///                     binary predicate. The signature of this predicate
+    ///                     should be equivalent to:
+    ///                     \code
+    ///                     Ret fun(const Type1 &a, const Type1 &b);
+    ///                     \endcode \n
+    ///                     The signature does not need to have const&, but
+    ///                     the function must not modify the objects passed to
+    ///                     it.
+    ///                     The types \a Type1 and \a Ret must be
+    ///                     such that an object of a type as given by the input
+    ///                     sequence can be implicitly converted to any
+    ///                     of those types.
     ///
-    /// The reduce operations in the parallel \a exclusive_scan algorithm
-    /// invoked without an execution policy object will execute in sequential
-    /// order in the calling thread.
+    /// The reduce operations in the parallel \a transform_exclusive_scan
+    /// algorithm invoked without an execution policy object execute in
+    /// sequential order in the calling thread.
     ///
-    /// \returns  The \a exclusive_scan algorithm returns \a OutIter.
-    ///           The \a exclusive_scan algorithm returns the output iterator
-    ///           to the element in the destination range, one past the last
-    ///           element copied.
+    /// \returns  The \a transform_exclusive_scan algorithm returns a
+    ///           returns \a OutIter.
+    ///           The \a transform_exclusive_scan algorithm returns the output
+    ///           iterator to the element in the destination range, one past
+    ///           the last element copied.
     ///
-    /// \note   GENERALIZED_NONCOMMUTATIVE_SUM(+, a1, ..., aN) is defined as:
+    /// \note   GENERALIZED_NONCOMMUTATIVE_SUM(op, a1, ..., aN) is defined as:
     ///         * a1 when N is 1
-    ///         * GENERALIZED_NONCOMMUTATIVE_SUM(+, a1, ..., aK)
-    ///           + GENERALIZED_NONCOMMUTATIVE_SUM(+, aM, ..., aN)
+    ///         * op(GENERALIZED_NONCOMMUTATIVE_SUM(op, a1, ..., aK),
+    ///           GENERALIZED_NONCOMMUTATIVE_SUM(op, aM, ..., aN)
     ///           where 1 < K+1 = M <= N.
     ///
-    /// The difference between \a exclusive_scan and \a inclusive_scan is that
-    /// \a inclusive_scan includes the ith input element in the ith sum.
+    /// Neither \a conv nor \a op shall invalidate iterators or subranges, or
+    /// modify elements in the ranges [first,last) or [result,result +
+    /// (last - first)).
     ///
-    template <typename InIter, typename Sent, typename OutIter, typename T>
-    OutIter exclusive_scan(InIter first, Sent last, OutIter dest, T init);
+    /// The behavior of transform_exclusive_scan may be non-deterministic for
+    /// a non-associative predicate.
+    ///
+    template <typename InIter, typename Sent, typename OutIter, typename T,
+        typename BinOp, typename UnOp>
+    OutIter transform_exclusive_scan(InIter first, Sent last, OutIter dest,
+        T init, BinOp&& binary_op, UnOp&& unary_op);
 
     ///////////////////////////////////////////////////////////////////////////
     /// Assigns through each iterator \a i in [result, result + (last - first))
     /// the value of
-    /// GENERALIZED_NONCOMMUTATIVE_SUM(+, init, *first, ...,
-    /// *(first + (i - result) - 1))
+    /// GENERALIZED_NONCOMMUTATIVE_SUM(binary_op, init, conv(*first), ...,
+    /// conv(*(first + (i - result) - 1))).
     ///
     /// \note   Complexity: O(\a last - \a first) applications of the
-    ///         predicate \a std::plus<T>.
+    ///         predicates \a op and \a conv.
     ///
     /// \tparam ExPolicy    The type of the execution policy to use (deduced).
     ///                     It describes the manner in which the execution
@@ -84,8 +126,12 @@ namespace hpx { namespace ranges {
     ///                     destination range (deduced).
     ///                     This iterator type must meet the requirements of an
     ///                     forward iterator.
+    /// \tparam Conv        The type of the unary function object used for
+    ///                     the conversion operation.
     /// \tparam T           The type of the value to be used as initial (and
     ///                     intermediate) values (deduced).
+    /// \tparam Op          The type of the binary function object used for
+    ///                     the reduction operation.
     ///
     /// \param policy       The execution policy to use for the scheduling of
     ///                     the iterations.
@@ -94,254 +140,168 @@ namespace hpx { namespace ranges {
     /// \param last         Refers to sentinel value denoting the end of the
     ///                     sequence of elements the algorithm will be applied.
     /// \param dest         Refers to the beginning of the destination range.
+    /// \param conv         Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements in the
+    ///                     sequence specified by [first, last). This is a
+    ///                     unary predicate. The signature of this predicate
+    ///                     should be equivalent to:
+    ///                     \code
+    ///                     R fun(const Type &a);
+    ///                     \endcode \n
+    ///                     The signature does not need to have const&, but
+    ///                     the function must not modify the objects passed to
+    ///                     it. The type \a Type must be such that an object of
+    ///                     type \a FwdIter1 can be dereferenced and then
+    ///                     implicitly converted to Type.
+    ///                     The type \a R must be such that an object of this
+    ///                     type can be implicitly converted to \a T.
     /// \param init         The initial value for the generalized sum.
+    /// \param op           Specifies the function (or function object) which
+    ///                     will be invoked for each of the values of the input
+    ///                     sequence. This is a
+    ///                     binary predicate. The signature of this predicate
+    ///                     should be equivalent to:
+    ///                     \code
+    ///                     Ret fun(const Type1 &a, const Type1 &b);
+    ///                     \endcode \n
+    ///                     The signature does not need to have const&, but
+    ///                     the function must not modify the objects passed to
+    ///                     it.
+    ///                     The types \a Type1 and \a Ret must be
+    ///                     such that an object of a type as given by the input
+    ///                     sequence can be implicitly converted to any
+    ///                     of those types.
     ///
-    /// The reduce operations in the parallel \a exclusive_scan algorithm
-    /// invoked with an execution policy object of type \a sequenced_policy
-    /// execute in sequential order in the calling thread.
+    /// The reduce operations in the parallel \a transform_exclusive_scan
+    /// algorithm invoked with an execution policy object of type \a
+    /// sequenced_policy execute in sequential order in the calling thread.
     ///
-    /// The reduce operations in the parallel \a exclusive_scan algorithm
-    /// invoked with an execution policy object of type \a parallel_policy
-    /// or \a parallel_task_policy are permitted to execute in an unordered
-    /// fashion in unspecified threads, and indeterminately sequenced
-    /// within each thread.
+    /// The reduce operations in the parallel \a transform_exclusive_scan
+    /// algorithm invoked with an execution policy object of type \a
+    /// parallel_policy or \a parallel_task_policy are permitted to execute
+    /// in an unordered fashion in unspecified threads, and indeterminately
+    /// sequenced within each thread.
     ///
-    /// \returns  The \a exclusive_scan algorithm returns a
+    /// \returns  The \a transform_exclusive_scan algorithm returns a
     ///           \a hpx::future<FwdIter2> if
     ///           the execution policy is of type
     ///           \a sequenced_task_policy or
     ///           \a parallel_task_policy and
     ///           returns \a FwdIter2 otherwise.
-    ///           The \a exclusive_scan algorithm returns the output iterator
-    ///           to the element in the destination range, one past the last
-    ///           element copied.
-    ///
-    /// \note   GENERALIZED_NONCOMMUTATIVE_SUM(+, a1, ..., aN) is defined as:
-    ///         * a1 when N is 1
-    ///         * GENERALIZED_NONCOMMUTATIVE_SUM(+, a1, ..., aK)
-    ///           + GENERALIZED_NONCOMMUTATIVE_SUM(+, aM, ..., aN)
-    ///           where 1 < K+1 = M <= N.
-    ///
-    /// The difference between \a exclusive_scan and \a inclusive_scan is that
-    /// \a inclusive_scan includes the ith input element in the ith sum.
-    ///
-    template <typename ExPolicy, typename FwdIter1, typename Sent,
-        typename FwdIter2, typename T>
-    typename util::detail::algorithm_result<ExPolicy, FwdIter2>::type
-    exclusive_scan(
-        ExPolicy&& policy, FwdIter1 first, Sent last, FwdIter2 dest, T init);
-
-    ///////////////////////////////////////////////////////////////////////////
-    /// Assigns through each iterator \a i in [result, result + (last - first))
-    /// the value of
-    /// GENERALIZED_NONCOMMUTATIVE_SUM(binary_op, init, *first, ...,
-    /// *(first + (i - result) - 1)).
-    ///
-    /// \note   Complexity: O(\a last - \a first) applications of the
-    ///         predicate \a op.
-    ///
-    /// \tparam InIter      The type of the source iterators used (deduced).
-    ///                     This iterator type must meet the requirements of an
-    ///                     input iterator.
-    /// \tparam Sent        The type of the source sentinel (deduced). This
-    ///                     sentinel type must be a sentinel for InIter.
-    /// \tparam OutIter     The type of the iterator representing the
-    ///                     destination range (deduced).
-    ///                     This iterator type must meet the requirements of an
-    ///                     output iterator.
-    /// \tparam T           The type of the value to be used as initial (and
-    ///                     intermediate) values (deduced).
-    /// \tparam Op          The type of the binary function object used for
-    ///                     the reduction operation.
-    ///
-    /// \param first        Refers to the beginning of the sequence of elements
-    ///                     the algorithm will be applied to.
-    /// \param last         Refers to sentinel value denoting the end of the
-    ///                     sequence of elements the algorithm will be applied.
-    /// \param dest         Refers to the beginning of the destination range.
-    /// \param init         The initial value for the generalized sum.
-    /// \param op           Specifies the function (or function object) which
-    ///                     will be invoked for each of the values of the input
-    ///                     sequence. This is a
-    ///                     binary predicate. The signature of this predicate
-    ///                     should be equivalent to:
-    ///                     \code
-    ///                     Ret fun(const Type1 &a, const Type1 &b);
-    ///                     \endcode \n
-    ///                     The signature does not need to have const&, but
-    ///                     the function must not modify the objects passed to
-    ///                     it.
-    ///                     The types \a Type1 and \a Ret must be
-    ///                     such that an object of a type as given by the input
-    ///                     sequence can be implicitly converted to any
-    ///                     of those types.
-    ///
-    /// The reduce operations in the parallel \a exclusive_scan algorithm
-    /// invoked without an execution policy object will execute in sequential
-    /// order in the calling thread.
-    ///
-    /// \returns  The \a exclusive_scan algorithm returns \a OutIter.
-    ///           The \a exclusive_scan algorithm returns the output iterator
-    ///           to the element in the destination range, one past the last
-    ///           element copied.
+    ///           The \a transform_exclusive_scan algorithm returns the output
+    ///           iterator to the element in the destination range, one past
+    ///           the last element copied.
     ///
     /// \note   GENERALIZED_NONCOMMUTATIVE_SUM(op, a1, ..., aN) is defined as:
     ///         * a1 when N is 1
     ///         * op(GENERALIZED_NONCOMMUTATIVE_SUM(op, a1, ..., aK),
-    ///           GENERALIZED_NONCOMMUTATIVE_SUM(op, aM, ..., aN))
+    ///           GENERALIZED_NONCOMMUTATIVE_SUM(op, aM, ..., aN)
     ///           where 1 < K+1 = M <= N.
     ///
-    /// The difference between \a exclusive_scan and \a inclusive_scan is that
-    /// \a inclusive_scan includes the ith input element in the ith sum. If
-    /// \a op is not mathematically associative, the behavior of
-    /// \a inclusive_scan may be non-deterministic.
+    /// Neither \a conv nor \a op shall invalidate iterators or subranges, or
+    /// modify elements in the ranges [first,last) or [result,result +
+    /// (last - first)).
     ///
-    template <typename InIter, typename Sent, typename OutIter, typename T,
-        typename Op>
-    OutIter exclusive_scan(
-        InIter first, Sent last, OutIter dest, T init, Op&& op);
-
-    ///////////////////////////////////////////////////////////////////////////
-    /// Assigns through each iterator \a i in [result, result + (last - first))
-    /// the value of
-    /// GENERALIZED_NONCOMMUTATIVE_SUM(binary_op, init, *first, ...,
-    /// *(first + (i - result) - 1)).
-    ///
-    /// \note   Complexity: O(\a last - \a first) applications of the
-    ///         predicate \a op.
-    ///
-    /// \tparam ExPolicy    The type of the execution policy to use (deduced).
-    ///                     It describes the manner in which the execution
-    ///                     of the algorithm may be parallelized and the manner
-    ///                     in which it executes the assignments.
-    /// \tparam FwdIter1    The type of the source iterators used (deduced).
-    ///                     This iterator type must meet the requirements of an
-    ///                     forward iterator.
-    /// \tparam Sent        The type of the source sentinel (deduced). This
-    ///                     sentinel type must be a sentinel for FwdIter1.
-    /// \tparam FwdIter2    The type of the iterator representing the
-    ///                     destination range (deduced).
-    ///                     This iterator type must meet the requirements of an
-    ///                     forward iterator.
-    /// \tparam T           The type of the value to be used as initial (and
-    ///                     intermediate) values (deduced).
-    /// \tparam Op          The type of the binary function object used for
-    ///                     the reduction operation.
-    ///
-    /// \param policy       The execution policy to use for the scheduling of
-    ///                     the iterations.
-    /// \param first        Refers to the beginning of the sequence of elements
-    ///                     the algorithm will be applied to.
-    /// \param last         Refers to sentinel value denoting the end of the
-    ///                     sequence of elements the algorithm will be applied.
-    /// \param dest         Refers to the beginning of the destination range.
-    /// \param init         The initial value for the generalized sum.
-    /// \param op           Specifies the function (or function object) which
-    ///                     will be invoked for each of the values of the input
-    ///                     sequence. This is a
-    ///                     binary predicate. The signature of this predicate
-    ///                     should be equivalent to:
-    ///                     \code
-    ///                     Ret fun(const Type1 &a, const Type1 &b);
-    ///                     \endcode \n
-    ///                     The signature does not need to have const&, but
-    ///                     the function must not modify the objects passed to
-    ///                     it.
-    ///                     The types \a Type1 and \a Ret must be
-    ///                     such that an object of a type as given by the input
-    ///                     sequence can be implicitly converted to any
-    ///                     of those types.
-    ///
-    /// The reduce operations in the parallel \a exclusive_scan algorithm
-    /// invoked with an execution policy object of type \a sequenced_policy
-    /// execute in sequential order in the calling thread.
-    ///
-    /// The reduce operations in the parallel \a exclusive_scan algorithm
-    /// invoked with an execution policy object of type \a parallel_policy
-    /// or \a parallel_task_policy are permitted to execute in an unordered
-    /// fashion in unspecified threads, and indeterminately sequenced
-    /// within each thread.
-    ///
-    /// \returns  The \a exclusive_scan algorithm returns a
-    ///           \a hpx::future<OutIter> if
-    ///           the execution policy is of type
-    ///           \a sequenced_task_policy or
-    ///           \a parallel_task_policy and
-    ///           returns \a OutIter otherwise.
-    ///           The \a exclusive_scan algorithm returns the output iterator
-    ///           to the element in the destination range, one past the last
-    ///           element copied.
-    ///
-    /// \note   GENERALIZED_NONCOMMUTATIVE_SUM(op, a1, ..., aN) is defined as:
-    ///         * a1 when N is 1
-    ///         * op(GENERALIZED_NONCOMMUTATIVE_SUM(op, a1, ..., aK),
-    ///           GENERALIZED_NONCOMMUTATIVE_SUM(op, aM, ..., aN))
-    ///           where 1 < K+1 = M <= N.
-    ///
-    /// The difference between \a exclusive_scan and \a inclusive_scan is that
-    /// \a inclusive_scan includes the ith input element in the ith sum. If
-    /// \a op is not mathematically associative, the behavior of
-    /// \a inclusive_scan may be non-deterministic.
+    /// The behavior of transform_exclusive_scan may be non-deterministic for
+    /// a non-associative predicate.
     ///
     template <typename ExPolicy, typename FwdIter1, typename Sent,
-        typename FwdIter2, typename T, typename Op>
-    typename util::detail::algorithm_result<ExPolicy, FwdIter2>::type
-    exclusive_scan(ExPolicy&& policy, FwdIter1 first, Sent last, FwdIter2 dest,
-        T init, Op&& op);
+        typename FwdIter2, typename T, typename BinOp, typename UnOp>
+    typename parallel::util::detail::algorithm_result<ExPolicy, FwdIter2>::type
+    transform_exclusive_scan(ExPolicy&& policy, FwdIter1 first, Sent last,
+        FwdIter2 dest, T init, BinOp&& binary_op, UnOp&& unary_op);
 
     ///////////////////////////////////////////////////////////////////////////
     /// Assigns through each iterator \a i in [result, result + (last - first))
     /// the value of
-    /// GENERALIZED_NONCOMMUTATIVE_SUM(+, init, *first, ...,
-    /// *(first + (i - result) - 1))
+    /// GENERALIZED_NONCOMMUTATIVE_SUM(binary_op, init, conv(*first), ...,
+    /// conv(*(first + (i - result) - 1))).
     ///
     /// \note   Complexity: O(\a last - \a first) applications of the
-    ///         predicate \a std::plus<T>.
+    ///         predicates \a op and \a conv.
     ///
     /// \tparam Rng         The type of the source range used (deduced).
     ///                     The iterators extracted from this range type must
     ///                     meet the requirements of an input iterator.
     /// \tparam O           The type of the iterator representing the
     ///                     destination range (deduced).
-    ///                     This iterator type must meet the requirements of an
-    ///                     output iterator.
+    /// \tparam Conv        The type of the unary function object used for
+    ///                     the conversion operation.
     /// \tparam T           The type of the value to be used as initial (and
     ///                     intermediate) values (deduced).
+    /// \tparam Op          The type of the binary function object used for
+    ///                     the reduction operation.
     ///
     /// \param rng          Refers to the sequence of elements the algorithm
     ///                     will be applied to.
-    /// \param dest         Refers to the beginning of the destination range.
+    /// \param conv         Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements in the
+    ///                     sequence specified by [first, last). This is a
+    ///                     unary predicate. The signature of this predicate
+    ///                     should be equivalent to:
+    ///                     \code
+    ///                     R fun(const Type &a);
+    ///                     \endcode \n
+    ///                     The signature does not need to have const&, but
+    ///                     the function must not modify the objects passed to
+    ///                     it. The type \a Type must be such that an object of
+    ///                     type \a FwdIter1 can be dereferenced and then
+    ///                     implicitly converted to Type.
+    ///                     The type \a R must be such that an object of this
+    ///                     type can be implicitly converted to \a T.
     /// \param init         The initial value for the generalized sum.
+    /// \param op           Specifies the function (or function object) which
+    ///                     will be invoked for each of the values of the input
+    ///                     sequence. This is a
+    ///                     binary predicate. The signature of this predicate
+    ///                     should be equivalent to:
+    ///                     \code
+    ///                     Ret fun(const Type1 &a, const Type1 &b);
+    ///                     \endcode \n
+    ///                     The signature does not need to have const&, but
+    ///                     the function must not modify the objects passed to
+    ///                     it.
+    ///                     The types \a Type1 and \a Ret must be
+    ///                     such that an object of a type as given by the input
+    ///                     sequence can be implicitly converted to any
+    ///                     of those types.
     ///
-    /// The reduce operations in the parallel \a exclusive_scan algorithm
-    /// invoked without an execution policy object will execute in sequential
-    /// order in the calling thread.
+    /// The reduce operations in the parallel \a transform_exclusive_scan
+    /// algorithm invoked without an execution policy object execute in
+    /// sequential order in the calling thread.
     ///
-    /// \returns  The \a exclusive_scan algorithm returns \a O.
-    ///           The \a exclusive_scan algorithm returns the output iterator
-    ///           to the element in the destination range, one past the last
-    ///           element copied.
+    /// \returns  The \a transform_exclusive_scan algorithm returns a
+    ///           returns \a O.
+    ///           The \a transform_exclusive_scan algorithm returns the output
+    ///           iterator to the element in the destination range, one past
+    ///           the last element copied.
     ///
-    /// \note   GENERALIZED_NONCOMMUTATIVE_SUM(+, a1, ..., aN) is defined as:
+    /// \note   GENERALIZED_NONCOMMUTATIVE_SUM(op, a1, ..., aN) is defined as:
     ///         * a1 when N is 1
-    ///         * GENERALIZED_NONCOMMUTATIVE_SUM(+, a1, ..., aK)
-    ///           + GENERALIZED_NONCOMMUTATIVE_SUM(+, aM, ..., aN)
+    ///         * op(GENERALIZED_NONCOMMUTATIVE_SUM(op, a1, ..., aK),
+    ///           GENERALIZED_NONCOMMUTATIVE_SUM(op, aM, ..., aN)
     ///           where 1 < K+1 = M <= N.
     ///
-    /// The difference between \a exclusive_scan and \a inclusive_scan is that
-    /// \a inclusive_scan includes the ith input element in the ith sum.
+    /// Neither \a conv nor \a op shall invalidate iterators or subranges, or
+    /// modify elements in the ranges [first,last) or [result,result +
+    /// (last - first)).
     ///
-    template <typename Rng, typename O, typename T>
-    O exclusive_scan(Rng&& rng, O dest, T init);
+    /// The behavior of transform_exclusive_scan may be non-deterministic for
+    /// a non-associative predicate.
+    ///
+    template <typename Rng, typename O, typename T, typename BinOp,
+        typename UnOp>
+    O transform_exclusive_scan(Rng&& rng, O dest, T init, BinOp&& binary_op,
+        UnOp&& unary_op);
 
     ///////////////////////////////////////////////////////////////////////////
     /// Assigns through each iterator \a i in [result, result + (last - first))
     /// the value of
-    /// GENERALIZED_NONCOMMUTATIVE_SUM(+, init, *first, ...,
-    /// *(first + (i - result) - 1))
+    /// GENERALIZED_NONCOMMUTATIVE_SUM(binary_op, init, conv(*first), ...,
+    /// conv(*(first + (i - result) - 1))).
     ///
     /// \note   Complexity: O(\a last - \a first) applications of the
-    ///         predicate \a std::plus<T>.
+    ///         predicates \a op and \a conv.
     ///
     /// \tparam ExPolicy    The type of the execution policy to use (deduced).
     ///                     It describes the manner in which the execution
@@ -354,131 +314,10 @@ namespace hpx { namespace ranges {
     ///                     destination range (deduced).
     ///                     This iterator type must meet the requirements of an
     ///                     forward iterator.
-    /// \tparam T           The type of the value to be used as initial (and
-    ///                     intermediate) values (deduced).
-    ///
-    /// \param policy       The execution policy to use for the scheduling of
-    ///                     the iterations.
-    /// \param rng          Refers to the sequence of elements the algorithm
-    ///                     will be applied to.
-    /// \param dest         Refers to the beginning of the destination range.
-    /// \param init         The initial value for the generalized sum.
-    ///
-    /// The reduce operations in the parallel \a exclusive_scan algorithm
-    /// invoked with an execution policy object of type \a sequenced_policy
-    /// execute in sequential order in the calling thread.
-    ///
-    /// The reduce operations in the parallel \a exclusive_scan algorithm
-    /// invoked with an execution policy object of type \a parallel_policy
-    /// or \a parallel_task_policy are permitted to execute in an unordered
-    /// fashion in unspecified threads, and indeterminately sequenced
-    /// within each thread.
-    ///
-    /// \returns  The \a exclusive_scan algorithm returns a
-    ///           \a hpx::future<O> if
-    ///           the execution policy is of type
-    ///           \a sequenced_task_policy or
-    ///           \a parallel_task_policy and
-    ///           returns \a O otherwise.
-    ///           The \a exclusive_scan algorithm returns the output iterator
-    ///           to the element in the destination range, one past the last
-    ///           element copied.
-    ///
-    /// \note   GENERALIZED_NONCOMMUTATIVE_SUM(+, a1, ..., aN) is defined as:
-    ///         * a1 when N is 1
-    ///         * GENERALIZED_NONCOMMUTATIVE_SUM(+, a1, ..., aK)
-    ///           + GENERALIZED_NONCOMMUTATIVE_SUM(+, aM, ..., aN)
-    ///           where 1 < K+1 = M <= N.
-    ///
-    /// The difference between \a exclusive_scan and \a inclusive_scan is that
-    /// \a inclusive_scan includes the ith input element in the ith sum.
-    ///
-    template <typename ExPolicy, typename Rng, typename O, typename T>
-    typename util::detail::algorithm_result<ExPolicy, O>::type exclusive_scan(
-        ExPolicy&& policy, Rng&& rng, O dest, T init);
-
-    ///////////////////////////////////////////////////////////////////////////
-    /// Assigns through each iterator \a i in [result, result + (last - first))
-    /// the value of
-    /// GENERALIZED_NONCOMMUTATIVE_SUM(+, init, *first, ...,
-    /// *(first + (i - result) - 1))
-    ///
-    /// \note   Complexity: O(\a last - \a first) applications of the
-    ///         predicate \a std::plus<T>.
-    ///
-    /// \tparam Rng         The type of the source range used (deduced).
-    ///                     The iterators extracted from this range type must
-    ///                     meet the requirements of an input iterator.
-    /// \tparam O           The type of the iterator representing the
-    ///                     destination range (deduced).
-    ///                     This iterator type must meet the requirements of an
-    ///                     output iterator.
-    /// \tparam T           The type of the value to be used as initial (and
-    ///                     intermediate) values (deduced).
-    /// \tparam Op          The type of the binary function object used for
-    ///                     the reduction operation.
-    ///
-    /// \param rng          Refers to the sequence of elements the algorithm
-    ///                     will be applied to.
-    /// \param dest         Refers to the beginning of the destination range.
-    /// \param init         The initial value for the generalized sum.
-    /// \param op           Specifies the function (or function object) which
-    ///                     will be invoked for each of the values of the input
-    ///                     sequence. This is a
-    ///                     binary predicate. The signature of this predicate
-    ///                     should be equivalent to:
-    ///                     \code
-    ///                     Ret fun(const Type1 &a, const Type1 &b);
-    ///                     \endcode \n
-    ///                     The signature does not need to have const&, but
-    ///                     the function must not modify the objects passed to
-    ///                     it.
-    ///                     The types \a Type1 and \a Ret must be
-    ///                     such that an object of a type as given by the input
-    ///                     sequence can be implicitly converted to any
-    ///                     of those types.
-    ///
-    /// The reduce operations in the parallel \a exclusive_scan algorithm
-    /// invoked without an execution policy object will execute in sequential
-    /// order in the calling thread.
-    ///
-    /// \returns  The \a exclusive_scan algorithm returns \a O.
-    ///           The \a exclusive_scan algorithm returns the output iterator
-    ///           to the element in the destination range, one past the last
-    ///           element copied.
-    ///
-    /// \note   GENERALIZED_NONCOMMUTATIVE_SUM(+, a1, ..., aN) is defined as:
-    ///         * a1 when N is 1
-    ///         * GENERALIZED_NONCOMMUTATIVE_SUM(+, a1, ..., aK)
-    ///           + GENERALIZED_NONCOMMUTATIVE_SUM(+, aM, ..., aN)
-    ///           where 1 < K+1 = M <= N.
-    ///
-    /// The difference between \a exclusive_scan and \a inclusive_scan is that
-    /// \a inclusive_scan includes the ith input element in the ith sum.
-    ///
-    template <typename Rng, typename O, typename T, typename Op>
-    O exclusive_scan(Rng&& rng, O dest, T init, Op&& op);
-
-    ///////////////////////////////////////////////////////////////////////////
-    /// Assigns through each iterator \a i in [result, result + (last - first))
-    /// the value of
-    /// GENERALIZED_NONCOMMUTATIVE_SUM(+, init, *first, ...,
-    /// *(first + (i - result) - 1))
-    ///
-    /// \note   Complexity: O(\a last - \a first) applications of the
-    ///         predicate \a std::plus<T>.
-    ///
-    /// \tparam ExPolicy    The type of the execution policy to use (deduced).
-    ///                     It describes the manner in which the execution
-    ///                     of the algorithm may be parallelized and the manner
-    ///                     in which it executes the assignments.
-    /// \tparam Rng         The type of the source range used (deduced).
-    ///                     The iterators extracted from this range type must
-    ///                     meet the requirements of an forward iterator.
-    /// \tparam O           The type of the iterator representing the
-    ///                     destination range (deduced).
     ///                     This iterator type must meet the requirements of an
     ///                     forward iterator.
+    /// \tparam Conv        The type of the unary function object used for
+    ///                     the conversion operation.
     /// \tparam T           The type of the value to be used as initial (and
     ///                     intermediate) values (deduced).
     /// \tparam Op          The type of the binary function object used for
@@ -489,6 +328,21 @@ namespace hpx { namespace ranges {
     /// \param rng          Refers to the sequence of elements the algorithm
     ///                     will be applied to.
     /// \param dest         Refers to the beginning of the destination range.
+    /// \param conv         Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements in the
+    ///                     sequence specified by [first, last). This is a
+    ///                     unary predicate. The signature of this predicate
+    ///                     should be equivalent to:
+    ///                     \code
+    ///                     R fun(const Type &a);
+    ///                     \endcode \n
+    ///                     The signature does not need to have const&, but
+    ///                     the function must not modify the objects passed to
+    ///                     it. The type \a Type must be such that an object of
+    ///                     type \a FwdIter1 can be dereferenced and then
+    ///                     implicitly converted to Type.
+    ///                     The type \a R must be such that an object of this
+    ///                     type can be implicitly converted to \a T.
     /// \param init         The initial value for the generalized sum.
     /// \param op           Specifies the function (or function object) which
     ///                     will be invoked for each of the values of the input
@@ -506,39 +360,46 @@ namespace hpx { namespace ranges {
     ///                     sequence can be implicitly converted to any
     ///                     of those types.
     ///
-    /// The reduce operations in the parallel \a exclusive_scan algorithm
-    /// invoked with an execution policy object of type \a sequenced_policy
-    /// execute in sequential order in the calling thread.
+    /// The reduce operations in the parallel \a transform_exclusive_scan
+    /// algorithm invoked with an execution policy object of type \a
+    /// sequenced_policy execute in sequential order in the calling thread.
     ///
-    /// The reduce operations in the parallel \a exclusive_scan algorithm
-    /// invoked with an execution policy object of type \a parallel_policy
-    /// or \a parallel_task_policy are permitted to execute in an unordered
-    /// fashion in unspecified threads, and indeterminately sequenced
-    /// within each thread.
+    /// The reduce operations in the parallel \a transform_exclusive_scan
+    /// algorithm invoked with an execution policy object of type \a
+    /// parallel_policy or \a parallel_task_policy are permitted to execute
+    /// in an unordered fashion in unspecified threads, and indeterminately
+    /// sequenced within each thread.
     ///
-    /// \returns  The \a exclusive_scan algorithm returns a
+    /// \returns  The \a transform_exclusive_scan algorithm returns a
     ///           \a hpx::future<O> if
     ///           the execution policy is of type
     ///           \a sequenced_task_policy or
     ///           \a parallel_task_policy and
     ///           returns \a O otherwise.
-    ///           The \a exclusive_scan algorithm returns the output iterator
-    ///           to the element in the destination range, one past the last
-    ///           element copied.
+    ///           The \a transform_exclusive_scan algorithm returns the output
+    ///           iterator to the element in the destination range, one past
+    ///           the last element copied.
     ///
-    /// \note   GENERALIZED_NONCOMMUTATIVE_SUM(+, a1, ..., aN) is defined as:
+    /// \note   GENERALIZED_NONCOMMUTATIVE_SUM(op, a1, ..., aN) is defined as:
     ///         * a1 when N is 1
-    ///         * GENERALIZED_NONCOMMUTATIVE_SUM(+, a1, ..., aK)
-    ///           + GENERALIZED_NONCOMMUTATIVE_SUM(+, aM, ..., aN)
+    ///         * op(GENERALIZED_NONCOMMUTATIVE_SUM(op, a1, ..., aK),
+    ///           GENERALIZED_NONCOMMUTATIVE_SUM(op, aM, ..., aN)
     ///           where 1 < K+1 = M <= N.
     ///
-    /// The difference between \a exclusive_scan and \a inclusive_scan is that
-    /// \a inclusive_scan includes the ith input element in the ith sum.
+    /// Neither \a conv nor \a op shall invalidate iterators or subranges, or
+    /// modify elements in the ranges [first,last) or [result,result +
+    /// (last - first)).
     ///
-    template <typename ExPolicy, typename Rng, typename O, typename T,
-        typename Op>
-    typename util::detail::algorithm_result<ExPolicy, O>::type exclusive_scan(
-        ExPolicy&& policy, Rng&& rng, O dest, T init, Op&& op);
+    /// The behavior of transform_exclusive_scan may be non-deterministic for
+    /// a non-associative predicate.
+    ///
+    template <typename ExPolicy, typename Rng,  typename O, typename T,
+        typename BinOp, typename UnOp>
+    typename parallel::util::detail::algorithm_result<ExPolicy, O>::type
+    transform_exclusive_scan(ExPolicy&& policy, Rng&& rng, O dest, T init,
+        BinOp&& binary_op, UnOp&& unary_op);
+
+    // clang-format on
 }}    // namespace hpx::ranges
 #else
 

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_numeric.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_numeric.hpp
@@ -12,4 +12,5 @@
 #include <hpx/parallel/container_algorithms/exclusive_scan.hpp>
 #include <hpx/parallel/container_algorithms/inclusive_scan.hpp>
 #include <hpx/parallel/container_algorithms/reduce.hpp>
+#include <hpx/parallel/container_algorithms/transform_exclusive_scan.hpp>
 #include <hpx/parallel/container_algorithms/transform_reduce.hpp>

--- a/libs/parallelism/algorithms/tests/regressions/scan_different_inits.cpp
+++ b/libs/parallelism/algorithms/tests/regressions/scan_different_inits.cpp
@@ -41,7 +41,7 @@ void test_zero()
         policy, a.begin(), a.end(), f.begin(),
         [](int bar, int baz) { return 2 * bar + 2 * baz; },
         [](int foo) { return foo - 3; }, 10);
-    Iter i_transform_exc = hpx::parallel::transform_exclusive_scan(
+    Iter i_transform_exc = hpx::transform_exclusive_scan(
         policy, a.begin(), a.end(), g.begin(), 10,
         [](int bar, int baz) { return 2 * bar + 2 * baz; },
         [](int foo) { return foo - 3; });
@@ -75,7 +75,7 @@ void test_async_zero()
         policy, a.begin(), a.end(), f.begin(),
         [](int bar, int baz) { return 2 * bar + 2 * baz; },
         [](int foo) { return foo - 3; }, 10);
-    Fut_Iter f_transform_exc = hpx::parallel::transform_exclusive_scan(
+    Fut_Iter f_transform_exc = hpx::transform_exclusive_scan(
         policy, a.begin(), a.end(), g.begin(), 10,
         [](int bar, int baz) { return 2 * bar + 2 * baz; },
         [](int foo) { return foo - 3; });
@@ -111,7 +111,7 @@ void test_one(std::vector<int> a)
         policy, a.begin(), a.end(), e.begin(), 10, fun_mult);
     Iter f_transform_inc = hpx::parallel::transform_inclusive_scan(
         policy, a.begin(), a.end(), f.begin(), fun_add, fun_conv, 10);
-    Iter f_transform_exc = hpx::parallel::transform_exclusive_scan(
+    Iter f_transform_exc = hpx::transform_exclusive_scan(
         policy, a.begin(), a.end(), g.begin(), 10, fun_add, fun_conv);
 
     HPX_UNUSED(f_inc_add);
@@ -168,7 +168,7 @@ void test_async_one(std::vector<int> a)
         policy, a.begin(), a.end(), e.begin(), 10, fun_mult);
     Fut_Iter f_transform_inc = hpx::parallel::transform_inclusive_scan(
         policy, a.begin(), a.end(), f.begin(), fun_add, fun_conv, 10);
-    Fut_Iter f_transform_exc = hpx::parallel::transform_exclusive_scan(
+    Fut_Iter f_transform_exc = hpx::transform_exclusive_scan(
         policy, a.begin(), a.end(), g.begin(), 10, fun_add, fun_conv);
 
     hpx::parallel::v1::detail::sequential_inclusive_scan(

--- a/libs/parallelism/algorithms/tests/unit/algorithms/transform_exclusive_scan.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/transform_exclusive_scan.cpp
@@ -35,7 +35,7 @@ void test_transform_exclusive_scan(ExPolicy policy, IteratorTag)
     auto op = [](std::size_t v1, std::size_t v2) { return v1 + v2; };
     auto conv = [](std::size_t val) { return 2 * val; };
 
-    hpx::parallel::transform_exclusive_scan(policy, iterator(std::begin(c)),
+    hpx::transform_exclusive_scan(policy, iterator(std::begin(c)),
         iterator(std::end(c)), std::begin(d), val, op, conv);
 
     // verify values
@@ -69,7 +69,7 @@ void test_transform_exclusive_scan_async(ExPolicy p, IteratorTag)
     auto conv = [](std::size_t val) { return 2 * val; };
 
     hpx::future<void> fut =
-        hpx::parallel::transform_exclusive_scan(p, iterator(std::begin(c)),
+        hpx::transform_exclusive_scan(p, iterator(std::begin(c)),
             iterator(std::end(c)), std::begin(d), val, op, conv);
     fut.wait();
 
@@ -125,7 +125,7 @@ void test_transform_exclusive_scan_exception(ExPolicy policy, IteratorTag)
     bool caught_exception = false;
     try
     {
-        hpx::parallel::transform_exclusive_scan(
+        hpx::transform_exclusive_scan(
             policy, iterator(std::begin(c)), iterator(std::end(c)),
             std::begin(d), std::size_t(0),
             [](std::size_t v1, std::size_t v2) {
@@ -162,7 +162,7 @@ void test_transform_exclusive_scan_exception_async(ExPolicy p, IteratorTag)
     bool returned_from_algorithm = false;
     try
     {
-        hpx::future<void> f = hpx::parallel::transform_exclusive_scan(
+        hpx::future<void> f = hpx::transform_exclusive_scan(
             p, iterator(std::begin(c)), iterator(std::end(c)), std::begin(d),
             std::size_t(0),
             [](std::size_t v1, std::size_t v2) {
@@ -227,7 +227,7 @@ void test_transform_exclusive_scan_bad_alloc(ExPolicy policy, IteratorTag)
     bool caught_exception = false;
     try
     {
-        hpx::parallel::transform_exclusive_scan(
+        hpx::transform_exclusive_scan(
             policy, iterator(std::begin(c)), iterator(std::end(c)),
             std::begin(d), std::size_t(0),
             [](std::size_t v1, std::size_t v2) {
@@ -263,7 +263,7 @@ void test_transform_exclusive_scan_bad_alloc_async(ExPolicy p, IteratorTag)
     bool returned_from_algorithm = false;
     try
     {
-        hpx::future<void> f = hpx::parallel::transform_exclusive_scan(
+        hpx::future<void> f = hpx::transform_exclusive_scan(
             p, iterator(std::begin(c)), iterator(std::end(c)), std::begin(d),
             std::size_t(0),
             [](std::size_t v1, std::size_t v2) {

--- a/libs/parallelism/algorithms/tests/unit/algorithms/transform_exclusive_scan.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/transform_exclusive_scan.cpp
@@ -18,6 +18,39 @@
 #include "test_utils.hpp"
 
 ///////////////////////////////////////////////////////////////////////////////
+template <typename IteratorTag>
+void test_transform_exclusive_scan(IteratorTag)
+{
+    typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+
+    std::vector<std::size_t> c(10007);
+    std::vector<std::size_t> d(c.size());
+    std::fill(std::begin(c), std::end(c), std::size_t(1));
+
+    std::size_t const val(0);
+    auto op = [](std::size_t v1, std::size_t v2) { return v1 + v2; };
+    auto conv = [](std::size_t val) { return 2 * val; };
+
+    hpx::transform_exclusive_scan(iterator(std::begin(c)),
+        iterator(std::end(c)), std::begin(d), val, op, conv);
+
+    // verify values
+    std::vector<std::size_t> e(c.size());
+    hpx::parallel::v1::detail::sequential_transform_exclusive_scan(
+        std::begin(c), std::end(c), std::begin(e), conv, val, op);
+
+    HPX_TEST(std::equal(std::begin(d), std::end(d), std::begin(e)));
+
+#if defined(HPX_HAVE_CXX17_STD_TRANSFORM_SCAN_ALGORITHMS_ALGORITHMS)
+    std::vector<std::size_t> f(c.size());
+    std::transform_exclusive_scan(
+        std::begin(c), std::end(c), std::begin(f), val, op, conv);
+
+    HPX_TEST(std::equal(std::begin(d), std::end(d), std::begin(f)));
+#endif
+}
+
 template <typename ExPolicy, typename IteratorTag>
 void test_transform_exclusive_scan(ExPolicy policy, IteratorTag)
 {
@@ -94,6 +127,7 @@ void test_transform_exclusive_scan()
 {
     using namespace hpx::execution;
 
+    test_transform_exclusive_scan(IteratorTag());
     test_transform_exclusive_scan(seq, IteratorTag());
     test_transform_exclusive_scan(par, IteratorTag());
     test_transform_exclusive_scan(par_unseq, IteratorTag());

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/CMakeLists.txt
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/CMakeLists.txt
@@ -92,6 +92,7 @@ set(tests
     transform_range_binary
     transform_range2
     transform_range_binary2
+    transform_exclusive_scan_range
     transform_reduce_binary_bad_alloc_range
     transform_reduce_binary_exception_range
     transform_reduce_binary_range

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/transform_exclusive_scan_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/transform_exclusive_scan_range.cpp
@@ -1,0 +1,448 @@
+//  Copyright (c) 2014-2020 Hartmut Kaiser
+//  Copyright (c) 2020 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/local/init.hpp>
+#include <hpx/modules/testing.hpp>
+#include <hpx/parallel/container_algorithms/transform_reduce.hpp>
+
+#include <algorithm>
+#include <cstddef>
+#include <iostream>
+#include <iterator>
+#include <numeric>
+#include <string>
+#include <vector>
+
+#include "test_utils.hpp"
+
+///////////////////////////////////////////////////////////////////////////////
+template <typename IteratorTag>
+void test_transform_reduce(IteratorTag)
+{
+    typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+
+    std::vector<std::size_t> c(10007);
+    std::iota(std::begin(c), std::end(c), std::rand());
+
+    typedef hpx::tuple<std::size_t, std::size_t> result_type;
+
+    using hpx::get;
+    using hpx::make_tuple;
+
+    auto reduce_op = [](result_type v1, result_type v2) -> result_type {
+        return make_tuple(get<0>(v1) * get<0>(v2), get<1>(v1) * get<1>(v2));
+    };
+
+    auto convert_op = [](std::size_t val) -> result_type {
+        return make_tuple(val, val);
+    };
+
+    result_type const init = make_tuple(std::size_t(1), std::size_t(1));
+
+    result_type r1 = hpx::ranges::transform_reduce(iterator(std::begin(c)),
+        iterator(std::end(c)), init, reduce_op, convert_op);
+
+    // verify values
+    result_type r2 = std::accumulate(std::begin(c), std::end(c), init,
+        [&reduce_op, &convert_op](result_type res, std::size_t val) {
+            return reduce_op(res, convert_op(val));
+        });
+
+    HPX_TEST_EQ(get<0>(r1), get<0>(r2));
+    HPX_TEST_EQ(get<1>(r1), get<1>(r2));
+}
+
+template <typename ExPolicy, typename IteratorTag>
+void test_transform_reduce(ExPolicy&& policy, IteratorTag)
+{
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
+
+    typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+
+    std::vector<std::size_t> c(10007);
+    std::iota(std::begin(c), std::end(c), std::rand());
+
+    typedef hpx::tuple<std::size_t, std::size_t> result_type;
+
+    using hpx::get;
+    using hpx::make_tuple;
+
+    auto reduce_op = [](result_type v1, result_type v2) -> result_type {
+        return make_tuple(get<0>(v1) * get<0>(v2), get<1>(v1) * get<1>(v2));
+    };
+
+    auto convert_op = [](std::size_t val) -> result_type {
+        return make_tuple(val, val);
+    };
+
+    result_type const init = make_tuple(std::size_t(1), std::size_t(1));
+
+    result_type r1 =
+        hpx::ranges::transform_reduce(policy, iterator(std::begin(c)),
+            iterator(std::end(c)), init, reduce_op, convert_op);
+
+    // verify values
+    result_type r2 = std::accumulate(std::begin(c), std::end(c), init,
+        [&reduce_op, &convert_op](result_type res, std::size_t val) {
+            return reduce_op(res, convert_op(val));
+        });
+
+    HPX_TEST_EQ(get<0>(r1), get<0>(r2));
+    HPX_TEST_EQ(get<1>(r1), get<1>(r2));
+}
+
+template <typename ExPolicy, typename IteratorTag>
+void test_transform_reduce_async(ExPolicy&& p, IteratorTag)
+{
+    typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+
+    std::vector<std::size_t> c(10007);
+    std::iota(std::begin(c), std::end(c), std::rand());
+
+    std::size_t val(42);
+    auto op = [val](std::size_t v1, std::size_t v2) { return v1 + v2 + val; };
+
+    hpx::future<std::size_t> f =
+        hpx::ranges::transform_reduce(p, iterator(std::begin(c)),
+            iterator(std::end(c)), val, op, [](std::size_t v) { return v; });
+    f.wait();
+
+    // verify values
+    std::size_t r2 = std::accumulate(std::begin(c), std::end(c), val, op);
+    HPX_TEST_EQ(f.get(), r2);
+}
+
+template <typename IteratorTag>
+void test_transform_reduce()
+{
+    using namespace hpx::execution;
+
+    test_transform_reduce(IteratorTag());
+
+    test_transform_reduce(seq, IteratorTag());
+    test_transform_reduce(par, IteratorTag());
+    test_transform_reduce(par_unseq, IteratorTag());
+
+    test_transform_reduce_async(seq(task), IteratorTag());
+    test_transform_reduce_async(par(task), IteratorTag());
+}
+
+void transform_reduce_test()
+{
+    test_transform_reduce<std::random_access_iterator_tag>();
+    test_transform_reduce<std::forward_iterator_tag>();
+}
+
+///////////////////////////////////////////////////////////////////////////////
+template <typename IteratorTag>
+void test_transform_reduce_exception(IteratorTag)
+{
+    typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+
+    std::vector<std::size_t> c(10007);
+    std::iota(std::begin(c), std::end(c), std::rand());
+
+    bool caught_exception = false;
+    try
+    {
+        hpx::ranges::transform_reduce(
+            iterator(std::begin(c)), iterator(std::end(c)), std::size_t(42),
+            [](std::size_t v1, std::size_t v2) {
+                return throw std::runtime_error("test"), v1 + v2;
+            },
+            [](std::size_t v) { return v; });
+
+        HPX_TEST(false);
+    }
+    catch (hpx::exception_list const& e)
+    {
+        caught_exception = true;
+        test::test_num_exceptions<hpx::execution::sequenced_policy,
+            IteratorTag>::call(hpx::execution::seq, e);
+    }
+    catch (...)
+    {
+        HPX_TEST(false);
+    }
+
+    HPX_TEST(caught_exception);
+}
+
+template <typename ExPolicy, typename IteratorTag>
+void test_transform_reduce_exception(ExPolicy&& policy, IteratorTag)
+{
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
+
+    typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+
+    std::vector<std::size_t> c(10007);
+    std::iota(std::begin(c), std::end(c), std::rand());
+
+    bool caught_exception = false;
+    try
+    {
+        hpx::ranges::transform_reduce(
+            policy, iterator(std::begin(c)), iterator(std::end(c)),
+            std::size_t(42),
+            [](std::size_t v1, std::size_t v2) {
+                return throw std::runtime_error("test"), v1 + v2;
+            },
+            [](std::size_t v) { return v; });
+
+        HPX_TEST(false);
+    }
+    catch (hpx::exception_list const& e)
+    {
+        caught_exception = true;
+        test::test_num_exceptions<ExPolicy, IteratorTag>::call(policy, e);
+    }
+    catch (...)
+    {
+        HPX_TEST(false);
+    }
+
+    HPX_TEST(caught_exception);
+}
+
+template <typename ExPolicy, typename IteratorTag>
+void test_transform_reduce_exception_async(ExPolicy&& p, IteratorTag)
+{
+    typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+
+    std::vector<std::size_t> c(10007);
+    std::iota(std::begin(c), std::end(c), std::rand());
+
+    bool caught_exception = false;
+    bool returned_from_algorithm = false;
+    try
+    {
+        hpx::future<void> f = hpx::ranges::transform_reduce(
+            p, iterator(std::begin(c)), iterator(std::end(c)), std::size_t(42),
+            [](std::size_t v1, std::size_t v2) {
+                return throw std::runtime_error("test"), v1 + v2;
+            },
+            [](std::size_t v) { return v; });
+        returned_from_algorithm = true;
+        f.get();
+
+        HPX_TEST(false);
+    }
+    catch (hpx::exception_list const& e)
+    {
+        caught_exception = true;
+        test::test_num_exceptions<ExPolicy, IteratorTag>::call(p, e);
+    }
+    catch (...)
+    {
+        HPX_TEST(false);
+    }
+
+    HPX_TEST(caught_exception);
+    HPX_TEST(returned_from_algorithm);
+}
+
+template <typename IteratorTag>
+void test_transform_reduce_exception()
+{
+    using namespace hpx::execution;
+
+    test_transform_reduce_exception(IteratorTag());
+
+    // If the execution policy object is of type vector_execution_policy,
+    // std::terminate shall be called. therefore we do not test exceptions
+    // with a vector execution policy
+    test_transform_reduce_exception(seq, IteratorTag());
+    test_transform_reduce_exception(par, IteratorTag());
+
+    test_transform_reduce_exception_async(seq(task), IteratorTag());
+    test_transform_reduce_exception_async(par(task), IteratorTag());
+}
+
+void transform_reduce_exception_test()
+{
+    test_transform_reduce_exception<std::random_access_iterator_tag>();
+    test_transform_reduce_exception<std::forward_iterator_tag>();
+}
+
+///////////////////////////////////////////////////////////////////////////////
+template <typename IteratorTag>
+void test_transform_reduce_bad_alloc(IteratorTag)
+{
+    typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+
+    std::vector<std::size_t> c(10007);
+    std::iota(std::begin(c), std::end(c), std::rand());
+
+    bool caught_exception = false;
+    try
+    {
+        hpx::ranges::transform_reduce(
+            iterator(std::begin(c)), iterator(std::end(c)), std::size_t(42),
+            [](std::size_t v1, std::size_t v2) {
+                return throw std::bad_alloc(), v1 + v2;
+            },
+            [](std::size_t v) { return v; });
+
+        HPX_TEST(false);
+    }
+    catch (std::bad_alloc const&)
+    {
+        caught_exception = true;
+    }
+    catch (...)
+    {
+        HPX_TEST(false);
+    }
+
+    HPX_TEST(caught_exception);
+}
+
+template <typename ExPolicy, typename IteratorTag>
+void test_transform_reduce_bad_alloc(ExPolicy&& policy, IteratorTag)
+{
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
+
+    typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+
+    std::vector<std::size_t> c(10007);
+    std::iota(std::begin(c), std::end(c), std::rand());
+
+    bool caught_exception = false;
+    try
+    {
+        hpx::ranges::transform_reduce(
+            policy, iterator(std::begin(c)), iterator(std::end(c)),
+            std::size_t(42),
+            [](std::size_t v1, std::size_t v2) {
+                return throw std::bad_alloc(), v1 + v2;
+            },
+            [](std::size_t v) { return v; });
+
+        HPX_TEST(false);
+    }
+    catch (std::bad_alloc const&)
+    {
+        caught_exception = true;
+    }
+    catch (...)
+    {
+        HPX_TEST(false);
+    }
+
+    HPX_TEST(caught_exception);
+}
+
+template <typename ExPolicy, typename IteratorTag>
+void test_transform_reduce_bad_alloc_async(ExPolicy&& p, IteratorTag)
+{
+    typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+
+    std::vector<std::size_t> c(10007);
+    std::iota(std::begin(c), std::end(c), std::rand());
+
+    bool caught_exception = false;
+    bool returned_from_algorithm = false;
+    try
+    {
+        hpx::future<void> f = hpx::ranges::transform_reduce(
+            p, iterator(std::begin(c)), iterator(std::end(c)), std::size_t(42),
+            [](std::size_t v1, std::size_t v2) {
+                return throw std::bad_alloc(), v1 + v2;
+            },
+            [](std::size_t v) { return v; });
+        returned_from_algorithm = true;
+        f.get();
+
+        HPX_TEST(false);
+    }
+    catch (std::bad_alloc const&)
+    {
+        caught_exception = true;
+    }
+    catch (...)
+    {
+        HPX_TEST(false);
+    }
+
+    HPX_TEST(caught_exception);
+    HPX_TEST(returned_from_algorithm);
+}
+
+template <typename IteratorTag>
+void test_transform_reduce_bad_alloc()
+{
+    using namespace hpx::execution;
+
+    test_transform_reduce_bad_alloc(IteratorTag());
+
+    // If the execution policy object is of type vector_execution_policy,
+    // std::terminate shall be called. therefore we do not test exceptions
+    // with a vector execution policy
+    test_transform_reduce_bad_alloc(seq, IteratorTag());
+    test_transform_reduce_bad_alloc(par, IteratorTag());
+
+    test_transform_reduce_bad_alloc_async(seq(task), IteratorTag());
+    test_transform_reduce_bad_alloc_async(par(task), IteratorTag());
+}
+
+void transform_reduce_bad_alloc_test()
+{
+    test_transform_reduce_bad_alloc<std::random_access_iterator_tag>();
+    test_transform_reduce_bad_alloc<std::forward_iterator_tag>();
+}
+
+int hpx_main(hpx::program_options::variables_map& vm)
+{
+    unsigned int seed = (unsigned int) std::time(nullptr);
+    if (vm.count("seed"))
+        seed = vm["seed"].as<unsigned int>();
+
+    std::cout << "using seed: " << seed << std::endl;
+    std::srand(seed);
+
+    transform_reduce_test();
+    transform_reduce_bad_alloc_test();
+    transform_reduce_exception_test();
+
+    return hpx::local::finalize();
+}
+
+int main(int argc, char* argv[])
+{
+    // add command line option which controls the random number generator seed
+    using namespace hpx::program_options;
+    options_description desc_commandline(
+        "Usage: " HPX_APPLICATION_STRING " [options]");
+
+    desc_commandline.add_options()("seed,s", value<unsigned int>(),
+        "the random number generator seed to use for this run");
+
+    //By default run on all available cores
+    std::vector<std::string> const cfg = {"hpx.os_threads=all"};
+
+    // Initialize and run HPX
+    hpx::local::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::local::init(hpx_main, argc, argv, init_args), 0,
+        "HPX main exited with non-zero status");
+
+    return hpx::util::report_errors();
+}

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/transform_exclusive_scan_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/transform_exclusive_scan_range.cpp
@@ -1,5 +1,6 @@
 //  Copyright (c) 2018 Christopher Ogle
 //  Copyright (c) 2020 Hartmut Kaiser
+//  Copyright (c) 2021 Akhil J Nair
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -39,8 +40,11 @@ void test_transform_exclusive_scan_sent(IteratorTag)
     auto op = [](std::size_t v1, std::size_t v2) { return v1 + v2; };
     auto conv = [](std::size_t val) { return 2 * val; };
 
-    hpx::ranges::transform_exclusive_scan(
+    auto res = hpx::ranges::transform_exclusive_scan(
         std::begin(c), sentinel<std::size_t>{2}, std::begin(d), val, op, conv);
+
+    HPX_TEST(res.in == std::begin(c) + end_len);
+    HPX_TEST(res.out == std::end(d));
 
     // verify values
     std::vector<std::size_t> e(end_len);
@@ -66,8 +70,11 @@ void test_transform_exclusive_scan_sent(ExPolicy policy, IteratorTag)
     auto op = [](std::size_t v1, std::size_t v2) { return v1 + v2; };
     auto conv = [](std::size_t val) { return 2 * val; };
 
-    hpx::ranges::transform_exclusive_scan(policy, std::begin(c),
+    auto res = hpx::ranges::transform_exclusive_scan(policy, std::begin(c),
         sentinel<std::size_t>{2}, std::begin(d), val, op, conv);
+
+    HPX_TEST(res.in == std::begin(c) + end_len);
+    HPX_TEST(res.out == std::end(d));
 
     // verify values
     std::vector<std::size_t> e(end_len);
@@ -88,7 +95,11 @@ void test_transform_exclusive_scan(IteratorTag)
     auto op = [](std::size_t v1, std::size_t v2) { return v1 + v2; };
     auto conv = [](std::size_t val) { return 2 * val; };
 
-    hpx::ranges::transform_exclusive_scan(c, std::begin(d), val, op, conv);
+    auto res =
+        hpx::ranges::transform_exclusive_scan(c, std::begin(d), val, op, conv);
+
+    HPX_TEST(res.in == std::end(c));
+    HPX_TEST(res.out == std::end(d));
 
     // verify values
     std::vector<std::size_t> e(c.size());
@@ -112,8 +123,11 @@ void test_transform_exclusive_scan(ExPolicy policy, IteratorTag)
     auto op = [](std::size_t v1, std::size_t v2) { return v1 + v2; };
     auto conv = [](std::size_t val) { return 2 * val; };
 
-    hpx::ranges::transform_exclusive_scan(
+    auto res = hpx::ranges::transform_exclusive_scan(
         policy, c, std::begin(d), val, op, conv);
+
+    HPX_TEST(res.in == std::end(c));
+    HPX_TEST(res.out == std::end(d));
 
     // verify values
     std::vector<std::size_t> e(c.size());

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/transform_exclusive_scan_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/transform_exclusive_scan_range.cpp
@@ -1,425 +1,193 @@
-//  Copyright (c) 2014-2020 Hartmut Kaiser
+//  Copyright (c) 2018 Christopher Ogle
 //  Copyright (c) 2020 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+#include <hpx/iterator_support/tests/iter_sent.hpp>
 #include <hpx/local/init.hpp>
 #include <hpx/modules/testing.hpp>
-#include <hpx/parallel/container_algorithms/transform_reduce.hpp>
+#include <hpx/parallel/container_algorithms/transform_exclusive_scan.hpp>
 
 #include <algorithm>
 #include <cstddef>
 #include <iostream>
 #include <iterator>
-#include <numeric>
+#include <random>
 #include <string>
+#include <unordered_set>
 #include <vector>
 
 #include "test_utils.hpp"
 
-///////////////////////////////////////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////
+unsigned int seed;
+std::mt19937 gen;
+std::uniform_int_distribution<> dis(1, 10007);
+
 template <typename IteratorTag>
-void test_transform_reduce(IteratorTag)
+void test_transform_exclusive_scan_sent(IteratorTag)
 {
-    typedef std::vector<std::size_t>::iterator base_iterator;
-    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
-
+    auto end_len = dis(gen);
     std::vector<std::size_t> c(10007);
-    std::iota(std::begin(c), std::end(c), std::rand());
+    std::vector<std::size_t> d(end_len);
+    std::fill(std::begin(c), std::begin(c) + end_len, std::size_t(1));
+    c[end_len] = 2;
 
-    typedef hpx::tuple<std::size_t, std::size_t> result_type;
+    std::size_t const val(0);
+    auto op = [](std::size_t v1, std::size_t v2) { return v1 + v2; };
+    auto conv = [](std::size_t val) { return 2 * val; };
 
-    using hpx::get;
-    using hpx::make_tuple;
-
-    auto reduce_op = [](result_type v1, result_type v2) -> result_type {
-        return make_tuple(get<0>(v1) * get<0>(v2), get<1>(v1) * get<1>(v2));
-    };
-
-    auto convert_op = [](std::size_t val) -> result_type {
-        return make_tuple(val, val);
-    };
-
-    result_type const init = make_tuple(std::size_t(1), std::size_t(1));
-
-    result_type r1 = hpx::ranges::transform_reduce(iterator(std::begin(c)),
-        iterator(std::end(c)), init, reduce_op, convert_op);
+    hpx::ranges::transform_exclusive_scan(
+        std::begin(c), sentinel<std::size_t>{2}, std::begin(d), val, op, conv);
 
     // verify values
-    result_type r2 = std::accumulate(std::begin(c), std::end(c), init,
-        [&reduce_op, &convert_op](result_type res, std::size_t val) {
-            return reduce_op(res, convert_op(val));
-        });
+    std::vector<std::size_t> e(end_len);
+    hpx::parallel::v1::detail::sequential_transform_exclusive_scan(
+        std::begin(c), std::begin(c) + end_len, std::begin(e), conv, val, op);
 
-    HPX_TEST_EQ(get<0>(r1), get<0>(r2));
-    HPX_TEST_EQ(get<1>(r1), get<1>(r2));
+    HPX_TEST(std::equal(std::begin(d), std::end(d), std::begin(e)));
 }
 
 template <typename ExPolicy, typename IteratorTag>
-void test_transform_reduce(ExPolicy&& policy, IteratorTag)
+void test_transform_exclusive_scan_sent(ExPolicy policy, IteratorTag)
 {
     static_assert(hpx::is_execution_policy<ExPolicy>::value,
         "hpx::is_execution_policy<ExPolicy>::value");
 
-    typedef std::vector<std::size_t>::iterator base_iterator;
-    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
-
+    auto end_len = dis(gen);
     std::vector<std::size_t> c(10007);
-    std::iota(std::begin(c), std::end(c), std::rand());
+    std::vector<std::size_t> d(end_len);
+    std::fill(std::begin(c), std::begin(c) + end_len, std::size_t(1));
+    c[end_len] = 2;
 
-    typedef hpx::tuple<std::size_t, std::size_t> result_type;
+    std::size_t const val(0);
+    auto op = [](std::size_t v1, std::size_t v2) { return v1 + v2; };
+    auto conv = [](std::size_t val) { return 2 * val; };
 
-    using hpx::get;
-    using hpx::make_tuple;
-
-    auto reduce_op = [](result_type v1, result_type v2) -> result_type {
-        return make_tuple(get<0>(v1) * get<0>(v2), get<1>(v1) * get<1>(v2));
-    };
-
-    auto convert_op = [](std::size_t val) -> result_type {
-        return make_tuple(val, val);
-    };
-
-    result_type const init = make_tuple(std::size_t(1), std::size_t(1));
-
-    result_type r1 =
-        hpx::ranges::transform_reduce(policy, iterator(std::begin(c)),
-            iterator(std::end(c)), init, reduce_op, convert_op);
+    hpx::ranges::transform_exclusive_scan(policy, std::begin(c),
+        sentinel<std::size_t>{2}, std::begin(d), val, op, conv);
 
     // verify values
-    result_type r2 = std::accumulate(std::begin(c), std::end(c), init,
-        [&reduce_op, &convert_op](result_type res, std::size_t val) {
-            return reduce_op(res, convert_op(val));
-        });
+    std::vector<std::size_t> e(end_len);
+    hpx::parallel::v1::detail::sequential_transform_exclusive_scan(
+        std::begin(c), std::begin(c) + end_len, std::begin(e), conv, val, op);
 
-    HPX_TEST_EQ(get<0>(r1), get<0>(r2));
-    HPX_TEST_EQ(get<1>(r1), get<1>(r2));
-}
-
-template <typename ExPolicy, typename IteratorTag>
-void test_transform_reduce_async(ExPolicy&& p, IteratorTag)
-{
-    typedef std::vector<std::size_t>::iterator base_iterator;
-    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
-
-    std::vector<std::size_t> c(10007);
-    std::iota(std::begin(c), std::end(c), std::rand());
-
-    std::size_t val(42);
-    auto op = [val](std::size_t v1, std::size_t v2) { return v1 + v2 + val; };
-
-    hpx::future<std::size_t> f =
-        hpx::ranges::transform_reduce(p, iterator(std::begin(c)),
-            iterator(std::end(c)), val, op, [](std::size_t v) { return v; });
-    f.wait();
-
-    // verify values
-    std::size_t r2 = std::accumulate(std::begin(c), std::end(c), val, op);
-    HPX_TEST_EQ(f.get(), r2);
+    HPX_TEST(std::equal(std::begin(d), std::end(d), std::begin(e)));
 }
 
 template <typename IteratorTag>
-void test_transform_reduce()
+void test_transform_exclusive_scan(IteratorTag)
 {
-    using namespace hpx::execution;
-
-    test_transform_reduce(IteratorTag());
-
-    test_transform_reduce(seq, IteratorTag());
-    test_transform_reduce(par, IteratorTag());
-    test_transform_reduce(par_unseq, IteratorTag());
-
-    test_transform_reduce_async(seq(task), IteratorTag());
-    test_transform_reduce_async(par(task), IteratorTag());
-}
-
-void transform_reduce_test()
-{
-    test_transform_reduce<std::random_access_iterator_tag>();
-    test_transform_reduce<std::forward_iterator_tag>();
-}
-
-///////////////////////////////////////////////////////////////////////////////
-template <typename IteratorTag>
-void test_transform_reduce_exception(IteratorTag)
-{
-    typedef std::vector<std::size_t>::iterator base_iterator;
-    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
-
     std::vector<std::size_t> c(10007);
-    std::iota(std::begin(c), std::end(c), std::rand());
+    std::vector<std::size_t> d(c.size());
+    std::fill(std::begin(c), std::end(c), std::size_t(1));
 
-    bool caught_exception = false;
-    try
-    {
-        hpx::ranges::transform_reduce(
-            iterator(std::begin(c)), iterator(std::end(c)), std::size_t(42),
-            [](std::size_t v1, std::size_t v2) {
-                return throw std::runtime_error("test"), v1 + v2;
-            },
-            [](std::size_t v) { return v; });
+    std::size_t const val(0);
+    auto op = [](std::size_t v1, std::size_t v2) { return v1 + v2; };
+    auto conv = [](std::size_t val) { return 2 * val; };
 
-        HPX_TEST(false);
-    }
-    catch (hpx::exception_list const& e)
-    {
-        caught_exception = true;
-        test::test_num_exceptions<hpx::execution::sequenced_policy,
-            IteratorTag>::call(hpx::execution::seq, e);
-    }
-    catch (...)
-    {
-        HPX_TEST(false);
-    }
+    hpx::ranges::transform_exclusive_scan(c, std::begin(d), val, op, conv);
 
-    HPX_TEST(caught_exception);
+    // verify values
+    std::vector<std::size_t> e(c.size());
+    hpx::parallel::v1::detail::sequential_transform_exclusive_scan(
+        std::begin(c), std::end(c), std::begin(e), conv, val, op);
+
+    HPX_TEST(std::equal(std::begin(d), std::end(d), std::begin(e)));
 }
 
 template <typename ExPolicy, typename IteratorTag>
-void test_transform_reduce_exception(ExPolicy&& policy, IteratorTag)
+void test_transform_exclusive_scan(ExPolicy policy, IteratorTag)
 {
     static_assert(hpx::is_execution_policy<ExPolicy>::value,
         "hpx::is_execution_policy<ExPolicy>::value");
 
-    typedef std::vector<std::size_t>::iterator base_iterator;
-    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
-
     std::vector<std::size_t> c(10007);
-    std::iota(std::begin(c), std::end(c), std::rand());
+    std::vector<std::size_t> d(c.size());
+    std::fill(std::begin(c), std::end(c), std::size_t(1));
 
-    bool caught_exception = false;
-    try
-    {
-        hpx::ranges::transform_reduce(
-            policy, iterator(std::begin(c)), iterator(std::end(c)),
-            std::size_t(42),
-            [](std::size_t v1, std::size_t v2) {
-                return throw std::runtime_error("test"), v1 + v2;
-            },
-            [](std::size_t v) { return v; });
+    std::size_t const val(0);
+    auto op = [](std::size_t v1, std::size_t v2) { return v1 + v2; };
+    auto conv = [](std::size_t val) { return 2 * val; };
 
-        HPX_TEST(false);
-    }
-    catch (hpx::exception_list const& e)
-    {
-        caught_exception = true;
-        test::test_num_exceptions<ExPolicy, IteratorTag>::call(policy, e);
-    }
-    catch (...)
-    {
-        HPX_TEST(false);
-    }
+    hpx::ranges::transform_exclusive_scan(
+        policy, c, std::begin(d), val, op, conv);
 
-    HPX_TEST(caught_exception);
+    // verify values
+    std::vector<std::size_t> e(c.size());
+    hpx::parallel::v1::detail::sequential_transform_exclusive_scan(
+        std::begin(c), std::end(c), std::begin(e), conv, val, op);
+
+    HPX_TEST(std::equal(std::begin(d), std::end(d), std::begin(e)));
 }
 
 template <typename ExPolicy, typename IteratorTag>
-void test_transform_reduce_exception_async(ExPolicy&& p, IteratorTag)
-{
-    typedef std::vector<std::size_t>::iterator base_iterator;
-    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
-
-    std::vector<std::size_t> c(10007);
-    std::iota(std::begin(c), std::end(c), std::rand());
-
-    bool caught_exception = false;
-    bool returned_from_algorithm = false;
-    try
-    {
-        hpx::future<void> f = hpx::ranges::transform_reduce(
-            p, iterator(std::begin(c)), iterator(std::end(c)), std::size_t(42),
-            [](std::size_t v1, std::size_t v2) {
-                return throw std::runtime_error("test"), v1 + v2;
-            },
-            [](std::size_t v) { return v; });
-        returned_from_algorithm = true;
-        f.get();
-
-        HPX_TEST(false);
-    }
-    catch (hpx::exception_list const& e)
-    {
-        caught_exception = true;
-        test::test_num_exceptions<ExPolicy, IteratorTag>::call(p, e);
-    }
-    catch (...)
-    {
-        HPX_TEST(false);
-    }
-
-    HPX_TEST(caught_exception);
-    HPX_TEST(returned_from_algorithm);
-}
-
-template <typename IteratorTag>
-void test_transform_reduce_exception()
-{
-    using namespace hpx::execution;
-
-    test_transform_reduce_exception(IteratorTag());
-
-    // If the execution policy object is of type vector_execution_policy,
-    // std::terminate shall be called. therefore we do not test exceptions
-    // with a vector execution policy
-    test_transform_reduce_exception(seq, IteratorTag());
-    test_transform_reduce_exception(par, IteratorTag());
-
-    test_transform_reduce_exception_async(seq(task), IteratorTag());
-    test_transform_reduce_exception_async(par(task), IteratorTag());
-}
-
-void transform_reduce_exception_test()
-{
-    test_transform_reduce_exception<std::random_access_iterator_tag>();
-    test_transform_reduce_exception<std::forward_iterator_tag>();
-}
-
-///////////////////////////////////////////////////////////////////////////////
-template <typename IteratorTag>
-void test_transform_reduce_bad_alloc(IteratorTag)
-{
-    typedef std::vector<std::size_t>::iterator base_iterator;
-    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
-
-    std::vector<std::size_t> c(10007);
-    std::iota(std::begin(c), std::end(c), std::rand());
-
-    bool caught_exception = false;
-    try
-    {
-        hpx::ranges::transform_reduce(
-            iterator(std::begin(c)), iterator(std::end(c)), std::size_t(42),
-            [](std::size_t v1, std::size_t v2) {
-                return throw std::bad_alloc(), v1 + v2;
-            },
-            [](std::size_t v) { return v; });
-
-        HPX_TEST(false);
-    }
-    catch (std::bad_alloc const&)
-    {
-        caught_exception = true;
-    }
-    catch (...)
-    {
-        HPX_TEST(false);
-    }
-
-    HPX_TEST(caught_exception);
-}
-
-template <typename ExPolicy, typename IteratorTag>
-void test_transform_reduce_bad_alloc(ExPolicy&& policy, IteratorTag)
+void test_transform_exclusive_scan_async(ExPolicy policy, IteratorTag)
 {
     static_assert(hpx::is_execution_policy<ExPolicy>::value,
         "hpx::is_execution_policy<ExPolicy>::value");
 
-    typedef std::vector<std::size_t>::iterator base_iterator;
-    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
-
     std::vector<std::size_t> c(10007);
-    std::iota(std::begin(c), std::end(c), std::rand());
+    std::vector<std::size_t> d(c.size());
+    std::fill(std::begin(c), std::end(c), std::size_t(1));
 
-    bool caught_exception = false;
-    try
-    {
-        hpx::ranges::transform_reduce(
-            policy, iterator(std::begin(c)), iterator(std::end(c)),
-            std::size_t(42),
-            [](std::size_t v1, std::size_t v2) {
-                return throw std::bad_alloc(), v1 + v2;
-            },
-            [](std::size_t v) { return v; });
+    std::size_t const val(0);
+    auto op = [](std::size_t v1, std::size_t v2) { return v1 + v2; };
+    auto conv = [](std::size_t val) { return 2 * val; };
 
-        HPX_TEST(false);
-    }
-    catch (std::bad_alloc const&)
-    {
-        caught_exception = true;
-    }
-    catch (...)
-    {
-        HPX_TEST(false);
-    }
+    hpx::future<void> fut = hpx::ranges::transform_exclusive_scan(
+        policy, c, std::begin(d), val, op, conv);
+    fut.wait();
 
-    HPX_TEST(caught_exception);
-}
+    // verify values
+    std::vector<std::size_t> e(c.size());
+    hpx::parallel::v1::detail::sequential_transform_exclusive_scan(
+        std::begin(c), std::end(c), std::begin(e), conv, val, op);
 
-template <typename ExPolicy, typename IteratorTag>
-void test_transform_reduce_bad_alloc_async(ExPolicy&& p, IteratorTag)
-{
-    typedef std::vector<std::size_t>::iterator base_iterator;
-    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
-
-    std::vector<std::size_t> c(10007);
-    std::iota(std::begin(c), std::end(c), std::rand());
-
-    bool caught_exception = false;
-    bool returned_from_algorithm = false;
-    try
-    {
-        hpx::future<void> f = hpx::ranges::transform_reduce(
-            p, iterator(std::begin(c)), iterator(std::end(c)), std::size_t(42),
-            [](std::size_t v1, std::size_t v2) {
-                return throw std::bad_alloc(), v1 + v2;
-            },
-            [](std::size_t v) { return v; });
-        returned_from_algorithm = true;
-        f.get();
-
-        HPX_TEST(false);
-    }
-    catch (std::bad_alloc const&)
-    {
-        caught_exception = true;
-    }
-    catch (...)
-    {
-        HPX_TEST(false);
-    }
-
-    HPX_TEST(caught_exception);
-    HPX_TEST(returned_from_algorithm);
+    HPX_TEST(std::equal(std::begin(d), std::end(d), std::begin(e)));
 }
 
 template <typename IteratorTag>
-void test_transform_reduce_bad_alloc()
+void test_transform_exclusive_scan()
 {
     using namespace hpx::execution;
 
-    test_transform_reduce_bad_alloc(IteratorTag());
+    test_transform_exclusive_scan(IteratorTag());
+    test_transform_exclusive_scan(seq, IteratorTag());
+    test_transform_exclusive_scan(par, IteratorTag());
+    test_transform_exclusive_scan(par_unseq, IteratorTag());
 
-    // If the execution policy object is of type vector_execution_policy,
-    // std::terminate shall be called. therefore we do not test exceptions
-    // with a vector execution policy
-    test_transform_reduce_bad_alloc(seq, IteratorTag());
-    test_transform_reduce_bad_alloc(par, IteratorTag());
+    test_transform_exclusive_scan_async(seq(task), IteratorTag());
+    test_transform_exclusive_scan_async(par(task), IteratorTag());
 
-    test_transform_reduce_bad_alloc_async(seq(task), IteratorTag());
-    test_transform_reduce_bad_alloc_async(par(task), IteratorTag());
+    test_transform_exclusive_scan_sent(IteratorTag());
+    test_transform_exclusive_scan_sent(seq, IteratorTag());
+    test_transform_exclusive_scan_sent(par, IteratorTag());
+    test_transform_exclusive_scan_sent(par_unseq, IteratorTag());
 }
 
-void transform_reduce_bad_alloc_test()
+void transform_exclusive_scan_test()
 {
-    test_transform_reduce_bad_alloc<std::random_access_iterator_tag>();
-    test_transform_reduce_bad_alloc<std::forward_iterator_tag>();
+    test_transform_exclusive_scan<std::random_access_iterator_tag>();
+    test_transform_exclusive_scan<std::forward_iterator_tag>();
 }
 
+////////////////////////////////////////////////////////////////////////////
 int hpx_main(hpx::program_options::variables_map& vm)
 {
-    unsigned int seed = (unsigned int) std::time(nullptr);
+    unsigned int seed1 = (unsigned int) std::time(nullptr);
     if (vm.count("seed"))
-        seed = vm["seed"].as<unsigned int>();
+        seed1 = vm["seed"].as<unsigned int>();
 
-    std::cout << "using seed: " << seed << std::endl;
-    std::srand(seed);
+    std::cout << "using seed: " << seed1 << std::endl;
+    std::srand(seed1);
 
-    transform_reduce_test();
-    transform_reduce_bad_alloc_test();
-    transform_reduce_exception_test();
+    seed = seed1;
+    gen = std::mt19937(seed);
 
+    transform_exclusive_scan_test();
     return hpx::local::finalize();
 }
 
@@ -433,7 +201,7 @@ int main(int argc, char* argv[])
     desc_commandline.add_options()("seed,s", value<unsigned int>(),
         "the random number generator seed to use for this run");
 
-    //By default run on all available cores
+    // By default this test should run on all available cores
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX


### PR DESCRIPTION
Adapted transform_exclusive_scan to C++ 20 and added container overloads. (range and sentinel). Added container tests. Seperated segmented overloads.

## Any background context you want to provide?
Issue #4822
Issue #3646
Issue #1668
Issue #5156