### PR TITLE
Adapt transform_inclusive_scan to C++ 20

### DIFF
--- a/docs/sphinx/api/public_api.rst
+++ b/docs/sphinx/api/public_api.rst
@@ -609,12 +609,13 @@ Functions
 - :cpp:func:`hpx::inclusive_scan`
 - :cpp:func:`hpx::reduce`
 - :cpp:func:`hpx::transform_exclusive_scan`
-- :cpp:func:`hpx::parallel::v1::transform_inclusive_scan`
+- :cpp:func:`hpx::transform_inclusive_scan`
 - :cpp:func:`hpx::transform_reduce`
 
 - :cpp:func:`hpx::ranges::exclusive_scan`
 - :cpp:func:`hpx::ranges::inclusive_scan`
 - :cpp:func:`hpx::ranges::transform_exclusive_scan`
+- :cpp:func:`hpx::ranges::transform_inclusive_scan`
 
 Header ``hpx/optional.hpp``
 ===========================

--- a/docs/sphinx/manual/writing_single_node_hpx_applications.rst
+++ b/docs/sphinx/manual/writing_single_node_hpx_applications.rst
@@ -693,7 +693,7 @@ Parallel algorithms
      * Sums up a range of elements after applying a function. Also, accumulates the inner products of two input ranges.
      * ``<hpx/numeric.hpp>``
      * :cppreference-algorithm:`transform_reduce`
-   * * :cpp:func:`hpx::parallel::v1::transform_inclusive_scan`
+   * * :cpp:func:`hpx::transform_inclusive_scan`
      * Does an inclusive parallel scan over a range of elements after applying a function.
      * ``<hpx/numeric.hpp>``
      * :cppreference-algorithm:`transform_inclusive_scan`

--- a/libs/full/include_local/include/hpx/local/numeric.hpp
+++ b/libs/full/include_local/include/hpx/local/numeric.hpp
@@ -11,5 +11,4 @@
 
 namespace hpx {
     using hpx::parallel::adjacent_difference;
-    using hpx::parallel::transform_inclusive_scan;
 }    // namespace hpx

--- a/libs/full/segmented_algorithms/include/hpx/parallel/segmented_algorithms/transform_inclusive_scan.hpp
+++ b/libs/full/segmented_algorithms/include/hpx/parallel/segmented_algorithms/transform_inclusive_scan.hpp
@@ -1,4 +1,5 @@
 //  Copyright (c) 2017 Ajai V George
+//  Copyright (c) 2021 Akhil J Nair
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -25,68 +26,127 @@
 #include <utility>
 #include <vector>
 
-namespace hpx { namespace parallel { inline namespace v1 {
-    ///////////////////////////////////////////////////////////////////////////
-    // segmented transform_inclusive_scan
-    namespace detail {
-        ///////////////////////////////////////////////////////////////////////
-        // segmented implementation
-        template <typename ExPolicy, typename InIter, typename OutIter,
-            typename Op, typename Conv, typename T>
-        typename util::detail::algorithm_result<ExPolicy, OutIter>::type
-        transform_inclusive_scan_(ExPolicy&& policy, InIter first, InIter last,
-            OutIter dest, Conv&& conv, T&& init, Op&& op, std::true_type)
-        {
-            if (first == last)
-            {
-                return util::detail::algorithm_result<ExPolicy, OutIter>::get(
-                    std::move(dest));
-            }
+// The segmented iterators we support all live in namespace hpx::segmented
+namespace hpx { namespace segmented {
+    // clang-format off
+    template <typename InIter, typename OutIter, typename Op,
+        typename Conv,
+        HPX_CONCEPT_REQUIRES_(
+            hpx::traits::is_iterator<InIter>::value &&
+            hpx::traits::is_segmented_iterator<InIter>::value &&
+            hpx::traits::is_iterator<OutIter>::value &&
+            hpx::traits::is_segmented_iterator<OutIter>::value
+        )>
+    // clang-format on
+    OutIter tag_dispatch(hpx::transform_inclusive_scan_t, InIter first,
+        InIter last, OutIter dest, Op&& op, Conv&& conv)
+    {
+        static_assert(hpx::traits::is_input_iterator<InIter>::value,
+            "Requires at least input iterator.");
 
-            using is_seq = hpx::is_sequenced_execution_policy<ExPolicy>;
+        static_assert(hpx::traits::is_output_iterator<OutIter>::value,
+            "Requires at least output iterator.");
 
-            return hpx::parallel::v1::detail::segmented_inclusive_scan(
-                std::forward<ExPolicy>(policy), first, last, dest,
-                std::forward<T>(init), std::forward<Op>(op), is_seq(),
-                std::forward<Conv>(conv));
-        }
+        if (first == last)
+            return dest;
 
-        template <typename ExPolicy, typename InIter, typename OutIter,
-            typename Op, typename Conv>
-        typename util::detail::algorithm_result<ExPolicy, OutIter>::type
-        transform_inclusive_scan_(ExPolicy&& policy, InIter first, InIter last,
-            OutIter dest, Conv&& conv, Op&& op, std::true_type)
-        {
-            if (first == last)
-            {
-                return util::detail::algorithm_result<ExPolicy, OutIter>::get(
-                    std::move(dest));
-            }
+        using value_type = typename std::iterator_traits<InIter>::value_type;
 
-            using is_seq = hpx::is_sequenced_execution_policy<ExPolicy>;
-            using value_type =
-                typename std::iterator_traits<InIter>::value_type;
+        return hpx::parallel::v1::detail::segmented_inclusive_scan(
+            hpx::execution::seq, first, last, dest, value_type{},
+            std::forward<Op>(op), std::true_type{}, std::forward<Conv>(conv));
+    }
 
-            return hpx::parallel::v1::detail::segmented_inclusive_scan(
-                std::forward<ExPolicy>(policy), first, last, dest, value_type{},
-                std::forward<Op>(op), is_seq(), std::forward<Conv>(conv));
-        }
+    // clang-format off
+    template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
+        typename Op, typename Conv,
+        HPX_CONCEPT_REQUIRES_(
+            hpx::is_execution_policy<ExPolicy>::value &&
+            hpx::traits::is_iterator<FwdIter1>::value &&
+            hpx::traits::is_segmented_iterator<FwdIter1>::value &&
+            hpx::traits::is_iterator<FwdIter2>::value &&
+            hpx::traits::is_segmented_iterator<FwdIter2>::value
+        )>
+    // clang-format on
+    typename parallel::util::detail::algorithm_result<ExPolicy, FwdIter2>::type
+    tag_dispatch(hpx::transform_inclusive_scan_t, ExPolicy&& policy,
+        FwdIter1 first, FwdIter1 last, FwdIter2 dest, Op&& op, Conv&& conv)
+    {
+        static_assert(hpx::traits::is_forward_iterator<FwdIter1>::value,
+            "Requires at least forward iterator.");
 
-        // forward declare the non-segmented version of this algorithm
-        template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
-            typename Op, typename Conv, typename T>
-        typename util::detail::algorithm_result<ExPolicy, FwdIter2>::type
-        transform_inclusive_scan_(ExPolicy&& policy, FwdIter1 first,
-            FwdIter1 last, FwdIter2 dest, Conv&& conv, T&& init, Op&& op,
-            std::false_type);
+        static_assert(hpx::traits::is_forward_iterator<FwdIter2>::value,
+            "Requires at least forward iterator.");
 
-        template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
-            typename Op, typename Conv>
-        typename util::detail::algorithm_result<ExPolicy, FwdIter2>::type
-        transform_inclusive_scan_(ExPolicy&& policy, FwdIter1 first,
-            FwdIter1 last, FwdIter2 dest, Conv&& conv, Op&& op,
-            std::false_type);
+        if (first == last)
+            return parallel::util::detail::algorithm_result<ExPolicy,
+                FwdIter2>::get(std::move(dest));
 
-        /// \endcond
-    }    // namespace detail
-}}}      // namespace hpx::parallel::v1
+        using is_seq = hpx::is_sequenced_execution_policy<ExPolicy>;
+        using value_type = typename std::iterator_traits<FwdIter1>::value_type;
+
+        return hpx::parallel::v1::detail::segmented_inclusive_scan(
+            std::forward<ExPolicy>(policy), first, last, dest, value_type{},
+            std::forward<Op>(op), is_seq(), std::forward<Conv>(conv));
+    }
+
+    // clang-format off
+    template <typename InIter, typename OutIter,
+        typename T, typename Op, typename Conv,
+        HPX_CONCEPT_REQUIRES_(
+            hpx::traits::is_iterator<InIter>::value &&
+            hpx::traits::is_segmented_iterator<InIter>::value &&
+            hpx::traits::is_iterator<OutIter>::value &&
+            hpx::traits::is_segmented_iterator<OutIter>::value
+        )>
+    // clang-format on
+    OutIter tag_dispatch(hpx::transform_inclusive_scan_t, InIter first,
+        InIter last, OutIter dest, Op&& op, Conv&& conv, T init)
+    {
+        static_assert(hpx::traits::is_input_iterator<InIter>::value,
+            "Requires at least input iterator.");
+
+        static_assert(hpx::traits::is_output_iterator<OutIter>::value,
+            "Requires at least output iterator.");
+
+        if (first == last)
+            return dest;
+
+        return hpx::parallel::v1::detail::segmented_inclusive_scan(
+            hpx::execution::seq, first, last, dest, std::move(init),
+            std::forward<Op>(op), std::true_type{}, std::forward<Conv>(conv));
+    }
+
+    // clang-format off
+    template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
+        typename T, typename Op, typename Conv,
+        HPX_CONCEPT_REQUIRES_(
+            hpx::is_execution_policy<ExPolicy>::value &&
+            hpx::traits::is_iterator<FwdIter1>::value &&
+            hpx::traits::is_segmented_iterator<FwdIter1>::value &&
+            hpx::traits::is_iterator<FwdIter2>::value &&
+            hpx::traits::is_segmented_iterator<FwdIter2>::value
+        )>
+    // clang-format on
+    typename parallel::util::detail::algorithm_result<ExPolicy, FwdIter2>::type
+    tag_dispatch(hpx::transform_inclusive_scan_t, ExPolicy&& policy,
+        FwdIter1 first, FwdIter1 last, FwdIter2 dest, Op&& op, Conv&& conv,
+        T init)
+    {
+        static_assert(hpx::traits::is_forward_iterator<FwdIter1>::value,
+            "Requires at least forward iterator.");
+
+        static_assert(hpx::traits::is_forward_iterator<FwdIter2>::value,
+            "Requires at least forward iterator.");
+
+        if (first == last)
+            return parallel::util::detail::algorithm_result<ExPolicy,
+                FwdIter2>::get(std::move(dest));
+
+        using is_seq = hpx::is_sequenced_execution_policy<ExPolicy>;
+
+        return hpx::parallel::v1::detail::segmented_inclusive_scan(
+            std::forward<ExPolicy>(policy), first, last, dest, std::move(init),
+            std::forward<Op>(op), is_seq(), std::forward<Conv>(conv));
+    }
+}}    // namespace hpx::segmented

--- a/libs/full/segmented_algorithms/tests/unit/partitioned_vector_transform_scan.cpp
+++ b/libs/full/segmented_algorithms/tests/unit/partitioned_vector_transform_scan.cpp
@@ -34,19 +34,43 @@ struct op
     }
 };
 
+template <typename T>
+void test_transform_inclusive_scan(
+    hpx::partitioned_vector<T>& xvalues, hpx::partitioned_vector<T>& out)
+{
+    hpx::transform_inclusive_scan(
+        xvalues.begin(), xvalues.end(), out.begin(), op(), conv(), T(0));
+}
+
+template <typename T>
+void test_transform_inclusive_scan_noinit(
+    hpx::partitioned_vector<T>& xvalues, hpx::partitioned_vector<T>& out)
+{
+    hpx::transform_inclusive_scan(
+        xvalues.begin(), xvalues.end(), out.begin(), op(), conv());
+}
+
+template <typename ExPolicy, typename T>
+void test_transform_inclusive_scan_noinit(ExPolicy&& policy,
+    hpx::partitioned_vector<T>& xvalues, hpx::partitioned_vector<T>& out)
+{
+    hpx::transform_inclusive_scan(
+        policy, xvalues.begin(), xvalues.end(), out.begin(), op(), conv());
+}
+
 template <typename ExPolicy, typename T>
 void test_transform_inclusive_scan(ExPolicy&& policy,
     hpx::partitioned_vector<T>& xvalues, hpx::partitioned_vector<T>& out)
 {
-    hpx::parallel::transform_inclusive_scan(policy, xvalues.begin(),
-        xvalues.end(), out.begin(), op(), conv(), T(0));
+    hpx::transform_inclusive_scan(policy, xvalues.begin(), xvalues.end(),
+        out.begin(), op(), conv(), T(0));
 }
 
 template <typename ExPolicy, typename T>
 void test_transform_inclusive_scan_async(ExPolicy&& policy,
     hpx::partitioned_vector<T>& xvalues, hpx::partitioned_vector<T>& out)
 {
-    hpx::parallel::transform_inclusive_scan(
+    hpx::transform_inclusive_scan(
         policy, xvalues.begin(), xvalues.end(), out.begin(), op(), conv(), T(0))
         .get();
 }
@@ -80,6 +104,12 @@ template <typename T>
 void transform_scan_tests(std::size_t num, hpx::partitioned_vector<T>& xvalues,
     hpx::partitioned_vector<T>& out)
 {
+    test_transform_inclusive_scan_noinit(xvalues, out);
+    HPX_TEST_EQ((out[num - 1]), T(2 * num));
+    test_transform_inclusive_scan_noinit(hpx::execution::seq, xvalues, out);
+    HPX_TEST_EQ((out[num - 1]), T(2 * num));
+    test_transform_inclusive_scan(xvalues, out);
+    HPX_TEST_EQ((out[num - 1]), T(2 * num));
     test_transform_inclusive_scan(hpx::execution::seq, xvalues, out);
     HPX_TEST_EQ((out[num - 1]), T(2 * num));
     test_transform_inclusive_scan(hpx::execution::par, xvalues, out);

--- a/libs/full/segmented_algorithms/tests/unit/partitioned_vector_transform_scan2.cpp
+++ b/libs/full/segmented_algorithms/tests/unit/partitioned_vector_transform_scan2.cpp
@@ -34,19 +34,43 @@ struct op
     }
 };
 
+template <typename T>
+void test_transform_inclusive_scan_noinit(
+    hpx::partitioned_vector<T>& xvalues, hpx::partitioned_vector<T>& out)
+{
+    hpx::transform_inclusive_scan(
+        xvalues.begin(), xvalues.end(), out.begin(), op(), conv());
+}
+
+template <typename ExPolicy, typename T>
+void test_transform_inclusive_scan_noinit(ExPolicy&& policy,
+    hpx::partitioned_vector<T>& xvalues, hpx::partitioned_vector<T>& out)
+{
+    hpx::transform_inclusive_scan(
+        policy, xvalues.begin(), xvalues.end(), out.begin(), op(), conv());
+}
+
+template <typename T>
+void test_transform_inclusive_scan(
+    hpx::partitioned_vector<T>& xvalues, hpx::partitioned_vector<T>& out)
+{
+    hpx::transform_inclusive_scan(
+        xvalues.begin(), xvalues.end(), out.begin(), op(), conv(), T(0));
+}
+
 template <typename ExPolicy, typename T>
 void test_transform_inclusive_scan(ExPolicy&& policy,
     hpx::partitioned_vector<T>& xvalues, hpx::partitioned_vector<T>& out)
 {
-    hpx::parallel::transform_inclusive_scan(policy, xvalues.begin(),
-        xvalues.end(), out.begin(), op(), conv(), T(0));
+    hpx::transform_inclusive_scan(policy, xvalues.begin(), xvalues.end(),
+        out.begin(), op(), conv(), T(0));
 }
 
 template <typename ExPolicy, typename T>
 void test_transform_inclusive_scan_async(ExPolicy&& policy,
     hpx::partitioned_vector<T>& xvalues, hpx::partitioned_vector<T>& out)
 {
-    hpx::parallel::transform_inclusive_scan(
+    hpx::transform_inclusive_scan(
         policy, xvalues.begin(), xvalues.end(), out.begin(), op(), conv(), T(0))
         .get();
 }
@@ -80,6 +104,12 @@ template <typename T>
 void transform_scan_tests(std::size_t num, hpx::partitioned_vector<T>& xvalues,
     hpx::partitioned_vector<T>& out)
 {
+    test_transform_inclusive_scan_noinit(xvalues, out);
+    HPX_TEST_EQ((out[num - 1]), T(2 * num));
+    test_transform_inclusive_scan_noinit(hpx::execution::seq, xvalues, out);
+    HPX_TEST_EQ((out[num - 1]), T(2 * num));
+    test_transform_inclusive_scan(xvalues, out);
+    HPX_TEST_EQ((out[num - 1]), T(2 * num));
     test_transform_inclusive_scan(hpx::execution::seq, xvalues, out);
     HPX_TEST_EQ((out[num - 1]), T(2 * num));
     test_transform_inclusive_scan(hpx::execution::par, xvalues, out);

--- a/libs/parallelism/algorithms/CMakeLists.txt
+++ b/libs/parallelism/algorithms/CMakeLists.txt
@@ -123,6 +123,7 @@ set(algorithms_headers
     hpx/parallel/container_algorithms/stable_sort.hpp
     hpx/parallel/container_algorithms/transform.hpp
     hpx/parallel/container_algorithms/transform_exclusive_scan.hpp
+    hpx/parallel/container_algorithms/transform_inclusive_scan.hpp
     hpx/parallel/container_algorithms/transform_reduce.hpp
     hpx/parallel/container_algorithms/uninitialized_copy.hpp
     hpx/parallel/container_algorithms/uninitialized_default_construct.hpp

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/transform_inclusive_scan.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/transform_inclusive_scan.hpp
@@ -12,11 +12,13 @@
 #include <hpx/concepts/concepts.hpp>
 #include <hpx/functional/invoke.hpp>
 #include <hpx/functional/invoke_result.hpp>
+#include <hpx/functional/tag_fallback_dispatch.hpp>
 #include <hpx/functional/traits/is_invocable.hpp>
 #include <hpx/iterator_support/traits/is_iterator.hpp>
 
 #include <hpx/executors/execution_policy.hpp>
 #include <hpx/parallel/algorithms/detail/dispatch.hpp>
+#include <hpx/parallel/algorithms/detail/distance.hpp>
 #include <hpx/parallel/algorithms/inclusive_scan.hpp>
 #include <hpx/parallel/util/detail/algorithm_result.hpp>
 #include <hpx/parallel/util/loop.hpp>
@@ -41,27 +43,27 @@ namespace hpx { namespace parallel { inline namespace v1 {
 
         ///////////////////////////////////////////////////////////////////////
         // Our own version of the sequential transform_inclusive_scan.
-        template <typename InIter, typename OutIter, typename Conv, typename T,
-            typename Op>
-        OutIter sequential_transform_inclusive_scan(InIter first, InIter last,
-            OutIter dest, Conv&& conv, T init, Op&& op)
+        template <typename InIter, typename Sent, typename OutIter,
+            typename Conv, typename T, typename Op>
+        OutIter sequential_transform_inclusive_scan(
+            InIter first, Sent last, OutIter dest, Conv&& conv, T init, Op&& op)
         {
             for (/**/; first != last; (void) ++first, ++dest)
             {
-                init = hpx::util::invoke(
-                    op, init, hpx::util::invoke(conv, *first));
+                init = HPX_INVOKE(op, init, HPX_INVOKE(conv, *first));
                 *dest = init;
             }
             return dest;
         }
 
-        template <typename InIter, typename OutIter, typename Conv, typename Op>
+        template <typename InIter, typename Sent, typename OutIter,
+            typename Conv, typename Op>
         OutIter sequential_transform_inclusive_scan_noinit(
-            InIter first, InIter last, OutIter dest, Conv&& conv, Op&& op)
+            InIter first, Sent last, OutIter dest, Conv&& conv, Op&& op)
         {
             if (first != last)
             {
-                auto init = hpx::util::invoke(conv, *first);
+                auto init = HPX_INVOKE(conv, *first);
 
                 *dest++ = init;
                 return sequential_transform_inclusive_scan(++first, last, dest,
@@ -78,8 +80,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
         {
             for (/**/; count-- != 0; (void) ++first, ++dest)
             {
-                init = hpx::util::invoke(
-                    op, init, hpx::util::invoke(conv, *first));
+                init = HPX_INVOKE(op, init, HPX_INVOKE(conv, *first));
                 *dest = init;
             }
             return init;
@@ -96,9 +97,9 @@ namespace hpx { namespace parallel { inline namespace v1 {
             {
             }
 
-            template <typename ExPolicy, typename InIter, typename OutIter,
-                typename Conv, typename T, typename Op>
-            static OutIter sequential(ExPolicy, InIter first, InIter last,
+            template <typename ExPolicy, typename InIter, typename Sent,
+                typename OutIter, typename Conv, typename T, typename Op>
+            static OutIter sequential(ExPolicy, InIter first, Sent last,
                 OutIter dest, Conv&& conv, T&& init, Op&& op)
             {
                 return sequential_transform_inclusive_scan(first, last, dest,
@@ -106,33 +107,33 @@ namespace hpx { namespace parallel { inline namespace v1 {
                     std::forward<Op>(op));
             }
 
-            template <typename ExPolicy, typename InIter, typename OutIter,
-                typename Conv, typename Op>
-            static OutIter sequential(ExPolicy&&, InIter first, InIter last,
+            template <typename ExPolicy, typename InIter, typename Sent,
+                typename OutIter, typename Conv, typename Op>
+            static OutIter sequential(ExPolicy&&, InIter first, Sent last,
                 OutIter dest, Conv&& conv, Op&& op)
             {
                 return sequential_transform_inclusive_scan_noinit(first, last,
                     dest, std::forward<Conv>(conv), std::forward<Op>(op));
             }
 
-            template <typename ExPolicy, typename FwdIter1, typename Conv,
-                typename T, typename Op>
+            template <typename ExPolicy, typename FwdIter1, typename Sent,
+                typename Conv, typename T, typename Op>
             static typename util::detail::algorithm_result<ExPolicy,
                 FwdIter2>::type
-            parallel(ExPolicy&& policy, FwdIter1 first, FwdIter1 last,
+            parallel(ExPolicy&& policy, FwdIter1 first, Sent last,
                 FwdIter2 dest, Conv&& conv, T init, Op&& op)
             {
-                typedef util::detail::algorithm_result<ExPolicy, FwdIter2>
-                    result;
-                typedef hpx::util::zip_iterator<FwdIter1, FwdIter2>
-                    zip_iterator;
-                typedef typename std::iterator_traits<FwdIter1>::difference_type
-                    difference_type;
+                using result =
+                    util::detail::algorithm_result<ExPolicy, FwdIter2>;
+                using zip_iterator =
+                    hpx::util::zip_iterator<FwdIter1, FwdIter2>;
+                using difference_type =
+                    typename std::iterator_traits<FwdIter1>::difference_type;
 
                 if (first == last)
                     return result::get(std::move(dest));
 
-                difference_type count = std::distance(first, last);
+                difference_type count = detail::distance(first, last);
 
                 FwdIter2 final_dest = dest;
                 std::advance(final_dest, count);
@@ -155,7 +156,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
 
                     util::loop_n<std::decay_t<ExPolicy>>(
                         dst, part_size, [&op, &val](FwdIter2 it) -> void {
-                            *it = hpx::util::invoke(op, val, *it);
+                            *it = HPX_INVOKE(op, val, *it);
                         });
                 };
 
@@ -165,8 +166,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                     // step 1 performs first part of scan algorithm
                     [op, conv](
                         zip_iterator part_begin, std::size_t part_size) -> T {
-                        T part_init =
-                            hpx::util::invoke(conv, get<0>(*part_begin));
+                        T part_init = HPX_INVOKE(conv, get<0>(*part_begin));
                         get<1>(*part_begin++) = part_init;
 
                         auto iters = part_begin.get_iterator_tuple();
@@ -195,7 +195,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
             {
                 if (first != last)
                 {
-                    auto init = hpx::util::invoke(conv, *first);
+                    auto init = HPX_INVOKE(conv, *first);
 
                     *dest++ = init;
                     return parallel(std::forward<ExPolicy>(policy), ++first,
@@ -203,58 +203,11 @@ namespace hpx { namespace parallel { inline namespace v1 {
                         std::forward<Op>(op));
                 }
 
-                typedef util::detail::algorithm_result<ExPolicy, FwdIter2>
-                    result;
+                using result =
+                    util::detail::algorithm_result<ExPolicy, FwdIter2>;
                 return result::get(std::move(dest));
             }
         };
-
-        template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
-            typename Op, typename Conv, typename T>
-        typename util::detail::algorithm_result<ExPolicy, FwdIter2>::type
-        transform_inclusive_scan_(ExPolicy&& policy, FwdIter1 first,
-            FwdIter1 last, FwdIter2 dest, Conv&& conv, T&& init, Op&& op,
-            std::false_type)
-        {
-            static_assert((hpx::traits::is_forward_iterator<FwdIter1>::value),
-                "Requires at least forward iterator.");
-            static_assert((hpx::traits::is_forward_iterator<FwdIter2>::value),
-                "Requires at least forward iterator.");
-
-            return detail::transform_inclusive_scan<FwdIter2>().call(
-                std::forward<ExPolicy>(policy), first, last, dest,
-                std::forward<Conv>(conv), std::forward<T>(init),
-                std::forward<Op>(op));
-        }
-
-        template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
-            typename Op, typename Conv>
-        typename util::detail::algorithm_result<ExPolicy, FwdIter2>::type
-        transform_inclusive_scan_(ExPolicy&& policy, FwdIter1 first,
-            FwdIter1 last, FwdIter2 dest, Conv&& conv, Op&& op, std::false_type)
-        {
-            static_assert((hpx::traits::is_forward_iterator<FwdIter1>::value),
-                "Requires at least forward iterator.");
-            static_assert((hpx::traits::is_forward_iterator<FwdIter2>::value),
-                "Requires at least forward iterator.");
-
-            return detail::transform_inclusive_scan<FwdIter2>().call(
-                std::forward<ExPolicy>(policy), first, last, dest,
-                std::forward<Conv>(conv), std::forward<Op>(op));
-        }
-
-        template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
-            typename Op, typename Conv, typename T>
-        typename util::detail::algorithm_result<ExPolicy, FwdIter2>::type
-        transform_inclusive_scan_(ExPolicy&& policy, FwdIter1 first,
-            FwdIter1 last, FwdIter2 dest, Conv&& conv, T&& init, Op&& op,
-            std::true_type);
-
-        template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
-            typename Op, typename Conv>
-        typename util::detail::algorithm_result<ExPolicy, FwdIter2>::type
-        transform_inclusive_scan_(ExPolicy&& policy, FwdIter1 first,
-            FwdIter1 last, FwdIter2 dest, Conv&& conv, Op&& op, std::true_type);
         /// \endcond
     }    // namespace detail
 
@@ -377,14 +330,29 @@ namespace hpx { namespace parallel { inline namespace v1 {
             >
         )>
     // clang-format on
-    typename util::detail::algorithm_result<ExPolicy, FwdIter2>::type
-    transform_inclusive_scan(ExPolicy&& policy, FwdIter1 first, FwdIter1 last,
-        FwdIter2 dest, Op&& op, Conv&& conv, T init)
+    HPX_DEPRECATED_V(1, 8,
+        "hpx::parallel::transform_inclusive_scan is deprecated, use "
+        "hpx::transform_inclusive_scan instead")
+        typename util::detail::algorithm_result<ExPolicy, FwdIter2>::type
+        transform_inclusive_scan(ExPolicy&& policy, FwdIter1 first,
+            FwdIter1 last, FwdIter2 dest, Op&& op, Conv&& conv, T init)
     {
-        typedef hpx::traits::is_segmented_iterator<FwdIter1> is_segmented;
-        return detail::transform_inclusive_scan_(std::forward<ExPolicy>(policy),
-            first, last, dest, std::forward<Conv>(conv), std::move(init),
-            std::forward<Op>(op), is_segmented());
+        static_assert(hpx::traits::is_forward_iterator<FwdIter1>::value,
+            "Requires at least forward iterator.");
+        static_assert(hpx::traits::is_forward_iterator<FwdIter2>::value,
+            "Requires at least forward iterator.");
+
+#if defined(HPX_GCC_VERSION) && HPX_GCC_VERSION >= 100000
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
+        return hpx::parallel::v1::detail::transform_inclusive_scan<FwdIter2>()
+            .call(std::forward<ExPolicy>(policy), first, last, dest,
+                std::forward<Conv>(conv), std::move(init),
+                std::forward<Op>(op));
+#if defined(HPX_GCC_VERSION) && HPX_GCC_VERSION >= 100000
+#pragma GCC diagnostic pop
+#endif
     }
 
     ///////////////////////////////////////////////////////////////////////////
@@ -503,13 +471,169 @@ namespace hpx { namespace parallel { inline namespace v1 {
             >
         )>
     // clang-format on
-    typename util::detail::algorithm_result<ExPolicy, FwdIter2>::type
-    transform_inclusive_scan(ExPolicy&& policy, FwdIter1 first, FwdIter1 last,
-        FwdIter2 dest, Op&& op, Conv&& conv)
+    HPX_DEPRECATED_V(1, 8,
+        "hpx::parallel::transform_inclusive_scan is deprecated, use "
+        "hpx::transform_inclusive_scan instead")
+        typename util::detail::algorithm_result<ExPolicy, FwdIter2>::type
+        transform_inclusive_scan(ExPolicy&& policy, FwdIter1 first,
+            FwdIter1 last, FwdIter2 dest, Op&& op, Conv&& conv)
     {
-        typedef hpx::traits::is_segmented_iterator<FwdIter1> is_segmented;
-        return detail::transform_inclusive_scan_(std::forward<ExPolicy>(policy),
-            first, last, dest, std::forward<Conv>(conv), std::forward<Op>(op),
-            is_segmented());
+        static_assert(hpx::traits::is_forward_iterator<FwdIter1>::value,
+            "Requires at least forward iterator.");
+        static_assert(hpx::traits::is_forward_iterator<FwdIter2>::value,
+            "Requires at least forward iterator.");
+
+#if defined(HPX_GCC_VERSION) && HPX_GCC_VERSION >= 100000
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
+        return hpx::parallel::v1::detail::transform_inclusive_scan<FwdIter2>()
+            .call(std::forward<ExPolicy>(policy), first, last, dest,
+                std::forward<Conv>(conv), std::forward<Op>(op));
+#if defined(HPX_GCC_VERSION) && HPX_GCC_VERSION >= 100000
+#pragma GCC diagnostic pop
+#endif
     }
 }}}    // namespace hpx::parallel::v1
+
+namespace hpx {
+    ///////////////////////////////////////////////////////////////////////////
+    // DPO for hpx::transform_inclusive_scan
+    HPX_INLINE_CONSTEXPR_VARIABLE struct transform_inclusive_scan_t final
+      : hpx::functional::tag_fallback<transform_inclusive_scan_t>
+    {
+        // clang-format off
+        template <typename InIter, typename OutIter, typename BinOp,
+            typename UnOp,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::traits::is_iterator<InIter>::value &&
+                hpx::traits::is_iterator<OutIter>::value &&
+                hpx::is_invocable_v<UnOp,
+                    typename std::iterator_traits<InIter>::value_type> &&
+                hpx::is_invocable_v<BinOp,
+                    typename hpx::util::invoke_result<UnOp,
+                        typename std::iterator_traits<InIter>::value_type>::type,
+                    typename hpx::util::invoke_result<UnOp,
+                        typename std::iterator_traits<InIter>::value_type>::type
+                >
+            )>
+        // clang-format on
+        friend OutIter tag_fallback_dispatch(hpx::transform_inclusive_scan_t,
+            InIter first, InIter last, OutIter dest, BinOp&& binary_op,
+            UnOp&& unary_op)
+        {
+            static_assert(hpx::traits::is_input_iterator<InIter>::value,
+                "Requires at least input iterator.");
+            static_assert(hpx::traits::is_output_iterator<OutIter>::value,
+                "Requires at least output iterator.");
+
+            return hpx::parallel::v1::detail::transform_inclusive_scan<
+                OutIter>()
+                .call(hpx::execution::seq, first, last, dest,
+                    std::forward<UnOp>(unary_op),
+                    std::forward<BinOp>(binary_op));
+        }
+
+        // clang-format off
+        template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
+            typename BinOp, typename UnOp,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::is_execution_policy<ExPolicy>::value &&
+                hpx::traits::is_forward_iterator<FwdIter1>::value &&
+                hpx::traits::is_forward_iterator<FwdIter2>::value &&
+                hpx::is_invocable_v<UnOp,
+                    typename std::iterator_traits<FwdIter1>::value_type> &&
+                hpx::is_invocable_v<BinOp,
+                    typename hpx::util::invoke_result<UnOp,
+                        typename std::iterator_traits<FwdIter1>::value_type>::type,
+                    typename hpx::util::invoke_result<UnOp,
+                        typename std::iterator_traits<FwdIter1>::value_type>::type
+                >
+            )>
+        // clang-format on
+        friend typename parallel::util::detail::algorithm_result<ExPolicy,
+            FwdIter2>::type
+        tag_fallback_dispatch(hpx::transform_inclusive_scan_t,
+            ExPolicy&& policy, FwdIter1 first, FwdIter1 last, FwdIter2 dest,
+            BinOp&& binary_op, UnOp&& unary_op)
+        {
+            static_assert(hpx::traits::is_forward_iterator<FwdIter1>::value,
+                "Requires at least forward iterator.");
+            static_assert(hpx::traits::is_forward_iterator<FwdIter2>::value,
+                "Requires at least forward iterator.");
+
+            return hpx::parallel::v1::detail::transform_inclusive_scan<
+                FwdIter2>()
+                .call(std::forward<ExPolicy>(policy), first, last, dest,
+                    std::forward<UnOp>(unary_op),
+                    std::forward<BinOp>(binary_op));
+        }
+
+        // clang-format off
+        template <typename InIter, typename OutIter, typename BinOp,
+            typename UnOp, typename T,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::traits::is_iterator<InIter>::value &&
+                hpx::traits::is_iterator<OutIter>::value &&
+                hpx::is_invocable_v<UnOp,
+                    typename std::iterator_traits<InIter>::value_type> &&
+                hpx::is_invocable_v<BinOp,
+                    typename hpx::util::invoke_result<UnOp,
+                        typename std::iterator_traits<InIter>::value_type>::type,
+                    typename hpx::util::invoke_result<UnOp,
+                        typename std::iterator_traits<InIter>::value_type>::type
+                >
+            )>
+        // clang-format on
+        friend OutIter tag_fallback_dispatch(hpx::transform_inclusive_scan_t,
+            InIter first, InIter last, OutIter dest, BinOp&& binary_op,
+            UnOp&& unary_op, T init)
+        {
+            static_assert(hpx::traits::is_input_iterator<InIter>::value,
+                "Requires at least input iterator.");
+            static_assert(hpx::traits::is_output_iterator<OutIter>::value,
+                "Requires at least output iterator.");
+
+            return hpx::parallel::v1::detail::transform_inclusive_scan<
+                OutIter>()
+                .call(hpx::execution::seq, first, last, dest,
+                    std::forward<UnOp>(unary_op), std::move(init),
+                    std::forward<BinOp>(binary_op));
+        }
+
+        // clang-format off
+        template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
+            typename BinOp, typename UnOp, typename T,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::is_execution_policy<ExPolicy>::value &&
+                hpx::traits::is_forward_iterator<FwdIter1>::value &&
+                hpx::traits::is_forward_iterator<FwdIter2>::value &&
+                hpx::is_invocable_v<UnOp,
+                    typename std::iterator_traits<FwdIter1>::value_type> &&
+                hpx::is_invocable_v<BinOp,
+                    typename hpx::util::invoke_result<UnOp,
+                        typename std::iterator_traits<FwdIter1>::value_type>::type,
+                    typename hpx::util::invoke_result<UnOp,
+                        typename std::iterator_traits<FwdIter1>::value_type>::type
+                >
+            )>
+        // clang-format on
+        friend typename parallel::util::detail::algorithm_result<ExPolicy,
+            FwdIter2>::type
+        tag_fallback_dispatch(hpx::transform_inclusive_scan_t,
+            ExPolicy&& policy, FwdIter1 first, FwdIter1 last, FwdIter2 dest,
+            BinOp&& binary_op, UnOp&& unary_op, T init)
+        {
+            static_assert(hpx::traits::is_forward_iterator<FwdIter1>::value,
+                "Requires at least forward iterator.");
+            static_assert(hpx::traits::is_forward_iterator<FwdIter2>::value,
+                "Requires at least forward iterator.");
+
+            return hpx::parallel::v1::detail::transform_inclusive_scan<
+                FwdIter2>()
+                .call(std::forward<ExPolicy>(policy), first, last, dest,
+                    std::forward<UnOp>(unary_op), std::move(init),
+                    std::forward<BinOp>(binary_op));
+        }
+    } transform_inclusive_scan{};
+}    // namespace hpx

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/transform_inclusive_scan.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/transform_inclusive_scan.hpp
@@ -1,4 +1,5 @@
 //  Copyright (c) 2014-2020 Hartmut Kaiser
+//  Copyright (c) 2021 Akhil J Nair
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -512,7 +513,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
             static typename util::detail::algorithm_result<ExPolicy,
                 FwdIter2>::type
             parallel(ExPolicy&& policy, FwdIter1 first, Sent last,
-                FwdIter2 dest, Conv&& conv, T init, Op&& op)
+                FwdIter2 dest, Conv&& conv, T&& init, Op&& op)
             {
                 using result =
                     util::detail::algorithm_result<ExPolicy, FwdIter2>;

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/transform_inclusive_scan.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/transform_inclusive_scan.hpp
@@ -186,11 +186,11 @@ namespace hpx { namespace parallel { inline namespace v1 {
                     });
             }
 
-            template <typename ExPolicy, typename FwdIter1, typename Conv,
-                typename Op>
+            template <typename ExPolicy, typename FwdIter1, typename Sent,
+                typename Conv, typename Op>
             static typename util::detail::algorithm_result<ExPolicy,
                 FwdIter2>::type
-            parallel(ExPolicy&& policy, FwdIter1 first, FwdIter1 last,
+            parallel(ExPolicy&& policy, FwdIter1 first, Sent last,
                 FwdIter2 dest, Conv&& conv, Op&& op)
             {
                 if (first != last)

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/transform_inclusive_scan.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/transform_inclusive_scan.hpp
@@ -8,6 +8,397 @@
 
 #pragma once
 
+#if defined(DOXYGEN)
+namespace hpx {
+    // clang-format off
+
+    ///////////////////////////////////////////////////////////////////////////
+    /// Assigns through each iterator \a i in [result, result + (last - first))
+    /// the value of
+    /// GENERALIZED_NONCOMMUTATIVE_SUM(op, conv(*first), ...,
+    /// conv(*(first + (i - result)))).
+    ///
+    /// \note   Complexity: O(\a last - \a first) applications of the
+    ///         predicate \a op.
+    ///
+    /// \tparam InIter      The type of the source iterators used (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     input iterator.
+    /// \tparam OutIter     The type of the iterator representing the
+    ///                     destination range (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     output iterator.
+    /// \tparam Conv        The type of the unary function object used for
+    ///                     the conversion operation.
+    /// \tparam Op          The type of the binary function object used for
+    ///                     the reduction operation.
+    ///
+    /// \param first        Refers to the beginning of the sequence of elements
+    ///                     the algorithm will be applied to.
+    /// \param last         Refers to the end of the sequence of elements the
+    ///                     algorithm will be applied to.
+    /// \param dest         Refers to the beginning of the destination range.
+    /// \param op           Specifies the function (or function object) which
+    ///                     will be invoked for each of the values of the input
+    ///                     sequence. This is a
+    ///                     binary predicate. The signature of this predicate
+    ///                     should be equivalent to:
+    ///                     \code
+    ///                     Ret fun(const Type1 &a, const Type1 &b);
+    ///                     \endcode \n
+    ///                     The signature does not need to have const&, but
+    ///                     the function must not modify the objects passed to
+    ///                     it.
+    ///                     The types \a Type1 and \a Ret must be
+    ///                     such that an object of a type as given by the input
+    ///                     sequence can be implicitly converted to any
+    ///                     of those types.
+    /// \param conv         Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements in the
+    ///                     sequence specified by [first, last). This is a
+    ///                     unary predicate. The signature of this predicate
+    ///                     should be equivalent to:
+    ///                     \code
+    ///                     R fun(const Type &a);
+    ///                     \endcode \n
+    ///                     The signature does not need to have const&, but
+    ///                     the function must not modify the objects passed to
+    ///                     it. The type \a Type must be such that an object of
+    ///                     type \a FwdIter1 can be dereferenced and then
+    ///                     implicitly converted to Type.
+    ///                     The type \a R must be such that an object of this
+    ///                     type can be implicitly converted to \a T.
+    ///
+    /// The reduce operations in the parallel \a transform_inclusive_scan
+    /// algorithm invoked without an execution policy object execute in
+    /// sequential order in the calling thread.
+    ///
+    /// \returns  The \a transform_inclusive_scan algorithm returns a
+    ///           returns \a OutIter.
+    ///           The \a transform_inclusive_scan algorithm returns the output
+    ///           iterator to the element in the destination range, one past
+    ///           the last element copied.
+    ///
+    /// \note   GENERALIZED_NONCOMMUTATIVE_SUM(op, a1, ..., aN) is defined as:
+    ///         * a1 when N is 1
+    ///         * op(GENERALIZED_NONCOMMUTATIVE_SUM(op, a1, ..., aK),
+    ///           GENERALIZED_NONCOMMUTATIVE_SUM(op, aM, ..., aN))
+    ///           where 1 < K+1 = M <= N.
+    ///
+    /// Neither \a conv nor \a op shall invalidate iterators or subranges, or
+    /// modify elements in the ranges [first,last) or [result,result + (last - first)).
+    ///
+    /// The difference between \a inclusive_scan and \a transform_inclusive_scan is that
+    /// \a transform_inclusive_scan includes the ith input element in the ith sum.
+    ///
+    template <typename InIter, typename OutIter, typename BinOp,
+        typename UnOp>
+    OutIter transform_inclusive_scan(InIter first, InIter last, OutIter dest,
+        BinOp&& binary_op, UnOp&& unary_op);
+
+    ///////////////////////////////////////////////////////////////////////////
+    /// Assigns through each iterator \a i in [result, result + (last - first))
+    /// the value of
+    /// GENERALIZED_NONCOMMUTATIVE_SUM(op, conv(*first), ...,
+    /// conv(*(first + (i - result)))).
+    ///
+    /// \note   Complexity: O(\a last - \a first) applications of the
+    ///         predicate \a op.
+    ///
+    /// \tparam ExPolicy    The type of the execution policy to use (deduced).
+    ///                     It describes the manner in which the execution
+    ///                     of the algorithm may be parallelized and the manner
+    ///                     in which it executes the assignments.
+    /// \tparam FwdIter1    The type of the source iterators used (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     forward iterator.
+    /// \tparam FwdIter2    The type of the iterator representing the
+    ///                     destination range (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     forward iterator.
+    /// \tparam Conv        The type of the unary function object used for
+    ///                     the conversion operation.
+    /// \tparam Op          The type of the binary function object used for
+    ///                     the reduction operation.
+    ///
+    /// \param policy       The execution policy to use for the scheduling of
+    ///                     the iterations.
+    /// \param first        Refers to the beginning of the sequence of elements
+    ///                     the algorithm will be applied to.
+    /// \param last         Refers to the end of the sequence of elements the
+    ///                     algorithm will be applied to.
+    /// \param dest         Refers to the beginning of the destination range.
+    /// \param op           Specifies the function (or function object) which
+    ///                     will be invoked for each of the values of the input
+    ///                     sequence. This is a
+    ///                     binary predicate. The signature of this predicate
+    ///                     should be equivalent to:
+    ///                     \code
+    ///                     Ret fun(const Type1 &a, const Type1 &b);
+    ///                     \endcode \n
+    ///                     The signature does not need to have const&, but
+    ///                     the function must not modify the objects passed to
+    ///                     it.
+    ///                     The types \a Type1 and \a Ret must be
+    ///                     such that an object of a type as given by the input
+    ///                     sequence can be implicitly converted to any
+    ///                     of those types.
+    /// \param conv         Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements in the
+    ///                     sequence specified by [first, last). This is a
+    ///                     unary predicate. The signature of this predicate
+    ///                     should be equivalent to:
+    ///                     \code
+    ///                     R fun(const Type &a);
+    ///                     \endcode \n
+    ///                     The signature does not need to have const&, but
+    ///                     the function must not modify the objects passed to
+    ///                     it. The type \a Type must be such that an object of
+    ///                     type \a FwdIter1 can be dereferenced and then
+    ///                     implicitly converted to Type.
+    ///                     The type \a R must be such that an object of this
+    ///                     type can be implicitly converted to \a T.
+    ///
+    /// The reduce operations in the parallel \a transform_inclusive_scan
+    /// algorithm invoked with an execution policy object of type \a
+    /// sequenced_policy execute in sequential order in the calling thread.
+    ///
+    /// The reduce operations in the parallel \a transform_inclusive_scan
+    /// algorithm invoked with an execution policy object of type \a
+    /// parallel_policy or \a parallel_task_policy are permitted to execute
+    /// in an unordered fashion in unspecified threads, and indeterminately
+    /// sequenced within each thread.
+    ///
+    /// \returns  The \a transform_inclusive_scan algorithm returns a
+    ///           \a hpx::future<FwdIter2> if
+    ///           the execution policy is of type
+    ///           \a sequenced_task_policy or
+    ///           \a parallel_task_policy and
+    ///           returns \a FwdIter2 otherwise.
+    ///           The \a transform_inclusive_scan algorithm returns the output
+    ///           iterator to the element in the destination range, one past
+    ///           the last element copied.
+    ///
+    /// \note   GENERALIZED_NONCOMMUTATIVE_SUM(op, a1, ..., aN) is defined as:
+    ///         * a1 when N is 1
+    ///         * op(GENERALIZED_NONCOMMUTATIVE_SUM(op, a1, ..., aK),
+    ///           GENERALIZED_NONCOMMUTATIVE_SUM(op, aM, ..., aN))
+    ///           where 1 < K+1 = M <= N.
+    ///
+    /// Neither \a conv nor \a op shall invalidate iterators or subranges, or
+    /// modify elements in the ranges [first,last) or [result,result + (last - first)).
+    ///
+    /// The difference between \a inclusive_scan and \a transform_inclusive_scan is that
+    /// \a transform_inclusive_scan includes the ith input element in the ith sum.
+    ///
+    template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
+        typename BinOp, typename UnOp>
+    typename parallel::util::detail::algorithm_result<ExPolicy,
+        FwdIter2>::type
+     transform_inclusive_scan(ExPolicy&& policy, FwdIter1 first,
+         FwdIter1 last, FwdIter2 dest, BinOp&& binary_op, UnOp&& unary_op);
+
+    ///////////////////////////////////////////////////////////////////////////
+    /// Assigns through each iterator \a i in [result, result + (last - first))
+    /// the value of
+    /// GENERALIZED_NONCOMMUTATIVE_SUM(op, init, conv(*first), ...,
+    /// conv(*(first + (i - result)))).
+    ///
+    /// \note   Complexity: O(\a last - \a first) applications of the
+    ///         predicate \a op.
+    ///
+    /// \tparam InIter      The type of the source iterators used (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     input iterator.
+    /// \tparam OutIter     The type of the iterator representing the
+    ///                     destination range (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     output iterator.
+    /// \tparam Conv        The type of the unary function object used for
+    ///                     the conversion operation.
+    /// \tparam Op          The type of the binary function object used for
+    ///                     the reduction operation.
+    /// \tparam T           The type of the value to be used as initial (and
+    ///                     intermediate) values (deduced).
+    ///
+    /// \param first        Refers to the beginning of the sequence of elements
+    ///                     the algorithm will be applied to.
+    /// \param last         Refers to the end of the sequence of elements the
+    ///                     algorithm will be applied to.
+    /// \param dest         Refers to the beginning of the destination range.
+    /// \param op           Specifies the function (or function object) which
+    ///                     will be invoked for each of the values of the input
+    ///                     sequence. This is a
+    ///                     binary predicate. The signature of this predicate
+    ///                     should be equivalent to:
+    ///                     \code
+    ///                     Ret fun(const Type1 &a, const Type1 &b);
+    ///                     \endcode \n
+    ///                     The signature does not need to have const&, but
+    ///                     the function must not modify the objects passed to
+    ///                     it.
+    ///                     The types \a Type1 and \a Ret must be
+    ///                     such that an object of a type as given by the input
+    ///                     sequence can be implicitly converted to any
+    ///                     of those types.
+    /// \param conv         Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements in the
+    ///                     sequence specified by [first, last). This is a
+    ///                     unary predicate. The signature of this predicate
+    ///                     should be equivalent to:
+    ///                     \code
+    ///                     R fun(const Type &a);
+    ///                     \endcode \n
+    ///                     The signature does not need to have const&, but
+    ///                     the function must not modify the objects passed to
+    ///                     it. The type \a Type must be such that an object of
+    ///                     type \a FwdIter1 can be dereferenced and then
+    ///                     implicitly converted to Type.
+    ///                     The type \a R must be such that an object of this
+    ///                     type can be implicitly converted to \a T.
+    /// \param init         The initial value for the generalized sum.
+    ///
+    /// The reduce operations in the parallel \a transform_inclusive_scan
+    /// algorithm invoked without an execution policy object execute in
+    /// sequential order in the calling thread.
+    ///
+    /// \returns  The \a transform_inclusive_scan algorithm returns a
+    ///           returns \a OutIter.
+    ///           The \a transform_inclusive_scan algorithm returns the output
+    ///           iterator to the element in the destination range, one past
+    ///           the last element copied.
+    ///
+    /// \note   GENERALIZED_NONCOMMUTATIVE_SUM(op, a1, ..., aN) is defined as:
+    ///         * a1 when N is 1
+    ///         * op(GENERALIZED_NONCOMMUTATIVE_SUM(op, a1, ..., aK),
+    ///           GENERALIZED_NONCOMMUTATIVE_SUM(op, aM, ..., aN))
+    ///           where 1 < K+1 = M <= N.
+    ///
+    /// Neither \a conv nor \a op shall invalidate iterators or subranges, or
+    /// modify elements in the ranges [first,last) or [result,result + (last - first)).
+    ///
+    /// The difference between \a inclusive_scan and \a transform_inclusive_scan is that
+    /// \a transform_inclusive_scan includes the ith input element in the ith sum.
+    /// \a op is not mathematically associative, the behavior of
+    /// \a transform_inclusive_scan may be non-deterministic.
+    ///
+    template <typename InIter, typename OutIter, typename BinOp,
+        typename UnOp, typename T>
+    OutIter transform_inclusive_scan(InIter first, InIter last, OutIter dest,
+        BinOp&& binary_op, UnOp&& unary_op, T init);
+
+    ///////////////////////////////////////////////////////////////////////////
+    /// Assigns through each iterator \a i in [result, result + (last - first))
+    /// the value of
+    /// GENERALIZED_NONCOMMUTATIVE_SUM(op, init, conv(*first), ...,
+    /// conv(*(first + (i - result)))).
+    ///
+    /// \note   Complexity: O(\a last - \a first) applications of the
+    ///         predicate \a op.
+    ///
+    /// \tparam ExPolicy    The type of the execution policy to use (deduced).
+    ///                     It describes the manner in which the execution
+    ///                     of the algorithm may be parallelized and the manner
+    ///                     in which it executes the assignments.
+    /// \tparam FwdIter1    The type of the source iterators used (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     forward iterator.
+    /// \tparam FwdIter2    The type of the iterator representing the
+    ///                     destination range (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     forward iterator.
+    /// \tparam Conv        The type of the unary function object used for
+    ///                     the conversion operation.
+    /// \tparam Op          The type of the binary function object used for
+    ///                     the reduction operation.
+    /// \tparam T           The type of the value to be used as initial (and
+    ///                     intermediate) values (deduced).
+    ///
+    /// \param policy       The execution policy to use for the scheduling of
+    ///                     the iterations.
+    /// \param first        Refers to the beginning of the sequence of elements
+    ///                     the algorithm will be applied to.
+    /// \param last         Refers to the end of the sequence of elements the
+    ///                     algorithm will be applied to.
+    /// \param dest         Refers to the beginning of the destination range.
+    /// \param op           Specifies the function (or function object) which
+    ///                     will be invoked for each of the values of the input
+    ///                     sequence. This is a
+    ///                     binary predicate. The signature of this predicate
+    ///                     should be equivalent to:
+    ///                     \code
+    ///                     Ret fun(const Type1 &a, const Type1 &b);
+    ///                     \endcode \n
+    ///                     The signature does not need to have const&, but
+    ///                     the function must not modify the objects passed to
+    ///                     it.
+    ///                     The types \a Type1 and \a Ret must be
+    ///                     such that an object of a type as given by the input
+    ///                     sequence can be implicitly converted to any
+    ///                     of those types.
+    /// \param conv         Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements in the
+    ///                     sequence specified by [first, last). This is a
+    ///                     unary predicate. The signature of this predicate
+    ///                     should be equivalent to:
+    ///                     \code
+    ///                     R fun(const Type &a);
+    ///                     \endcode \n
+    ///                     The signature does not need to have const&, but
+    ///                     the function must not modify the objects passed to
+    ///                     it. The type \a Type must be such that an object of
+    ///                     type \a FwdIter1 can be dereferenced and then
+    ///                     implicitly converted to Type.
+    ///                     The type \a R must be such that an object of this
+    ///                     type can be implicitly converted to \a T.
+    /// \param init         The initial value for the generalized sum.
+    ///
+    /// The reduce operations in the parallel \a transform_inclusive_scan
+    /// algorithm invoked with an execution policy object of type \a
+    /// sequenced_policy execute in sequential order in the calling thread.
+    ///
+    /// The reduce operations in the parallel \a transform_inclusive_scan
+    /// algorithm invoked with an execution policy object of type \a
+    /// parallel_policy or \a parallel_task_policy are permitted to execute
+    /// in an unordered fashion in unspecified threads, and indeterminately
+    /// sequenced within each thread.
+    ///
+    /// \returns  The \a transform_inclusive_scan algorithm returns a
+    ///           \a hpx::future<FwdIter2> if
+    ///           the execution policy is of type
+    ///           \a sequenced_task_policy or
+    ///           \a parallel_task_policy and
+    ///           returns \a FwdIter2 otherwise.
+    ///           The \a transform_inclusive_scan algorithm returns the output
+    ///           iterator to the element in the destination range, one past
+    ///           the last element copied.
+    ///
+    /// \note   GENERALIZED_NONCOMMUTATIVE_SUM(op, a1, ..., aN) is defined as:
+    ///         * a1 when N is 1
+    ///         * op(GENERALIZED_NONCOMMUTATIVE_SUM(op, a1, ..., aK),
+    ///           GENERALIZED_NONCOMMUTATIVE_SUM(op, aM, ..., aN))
+    ///           where 1 < K+1 = M <= N.
+    ///
+    /// Neither \a conv nor \a op shall invalidate iterators or subranges, or
+    /// modify elements in the ranges [first,last) or [result,result + (last - first)).
+    ///
+    /// The difference between \a inclusive_scan and \a transform_inclusive_scan is that
+    /// \a transform_inclusive_scan includes the ith input element in the ith sum.
+    /// \a op is not mathematically associative, the behavior of
+    /// \a transform_inclusive_scan may be non-deterministic.
+    ///
+    template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
+        typename BinOp, typename UnOp, typename T,>
+    typename parallel::util::detail::algorithm_result<ExPolicy,
+        FwdIter2>::type
+     transform_inclusive_scan(ExPolicy&& policy, FwdIter1 first,
+         FwdIter1 last, FwdIter2 dest, BinOp&& binary_op, UnOp&& unary_op,
+         T init);
+    // clang-format on
+}    // namespace hpx
+
+#else    // DOXYGEN
+
 #include <hpx/config.hpp>
 #include <hpx/concepts/concepts.hpp>
 #include <hpx/functional/invoke.hpp>
@@ -211,124 +602,19 @@ namespace hpx { namespace parallel { inline namespace v1 {
         /// \endcond
     }    // namespace detail
 
-    ///////////////////////////////////////////////////////////////////////////
-    /// Assigns through each iterator \a i in [result, result + (last - first))
-    /// the value of
-    /// GENERALIZED_NONCOMMUTATIVE_SUM(op, init, conv(*first), ...,
-    /// conv(*(first + (i - result)))).
-    ///
-    /// \note   Complexity: O(\a last - \a first) applications of the
-    ///         predicate \a op.
-    ///
-    /// \tparam ExPolicy    The type of the execution policy to use (deduced).
-    ///                     It describes the manner in which the execution
-    ///                     of the algorithm may be parallelized and the manner
-    ///                     in which it executes the assignments.
-    /// \tparam FwdIter1    The type of the source iterators used (deduced).
-    ///                     This iterator type must meet the requirements of an
-    ///                     forward iterator.
-    /// \tparam FwdIter2    The type of the iterator representing the
-    ///                     destination range (deduced).
-    ///                     This iterator type must meet the requirements of an
-    ///                     forward iterator.
-    /// \tparam Conv        The type of the unary function object used for
-    ///                     the conversion operation.
-    /// \tparam T           The type of the value to be used as initial (and
-    ///                     intermediate) values (deduced).
-    /// \tparam Op          The type of the binary function object used for
-    ///                     the reduction operation.
-    ///
-    /// \param policy       The execution policy to use for the scheduling of
-    ///                     the iterations.
-    /// \param first        Refers to the beginning of the sequence of elements
-    ///                     the algorithm will be applied to.
-    /// \param last         Refers to the end of the sequence of elements the
-    ///                     algorithm will be applied to.
-    /// \param dest         Refers to the beginning of the destination range.
-    /// \param conv         Specifies the function (or function object) which
-    ///                     will be invoked for each of the elements in the
-    ///                     sequence specified by [first, last). This is a
-    ///                     unary predicate. The signature of this predicate
-    ///                     should be equivalent to:
-    ///                     \code
-    ///                     R fun(const Type &a);
-    ///                     \endcode \n
-    ///                     The signature does not need to have const&, but
-    ///                     the function must not modify the objects passed to
-    ///                     it. The type \a Type must be such that an object of
-    ///                     type \a FwdIter1 can be dereferenced and then
-    ///                     implicitly converted to Type.
-    ///                     The type \a R must be such that an object of this
-    ///                     type can be implicitly converted to \a T.
-    /// \param init         The initial value for the generalized sum.
-    /// \param op           Specifies the function (or function object) which
-    ///                     will be invoked for each of the values of the input
-    ///                     sequence. This is a
-    ///                     binary predicate. The signature of this predicate
-    ///                     should be equivalent to:
-    ///                     \code
-    ///                     Ret fun(const Type1 &a, const Type1 &b);
-    ///                     \endcode \n
-    ///                     The signature does not need to have const&, but
-    ///                     the function must not modify the objects passed to
-    ///                     it.
-    ///                     The types \a Type1 and \a Ret must be
-    ///                     such that an object of a type as given by the input
-    ///                     sequence can be implicitly converted to any
-    ///                     of those types.
-    ///
-    /// The reduce operations in the parallel \a transform_inclusive_scan algorithm
-    /// invoked
-    /// with an execution policy object of type \a sequenced_policy
-    /// execute in sequential order in the calling thread.
-    ///
-    /// The reduce operations in the parallel \a transform_inclusive_scan algorithm
-    /// invoked
-    /// with an execution policy object of type \a parallel_policy
-    /// or \a parallel_task_policy are permitted to execute in an unordered
-    /// fashion in unspecified threads, and indeterminately sequenced
-    /// within each thread.
-    ///
-    /// \returns  The \a transform_inclusive_scan algorithm returns a
-    ///           \a hpx::future<FwdIter2> if
-    ///           the execution policy is of type
-    ///           \a sequenced_task_policy or
-    ///           \a parallel_task_policy and
-    ///           returns \a FwdIter2 otherwise.
-    ///           The \a transform_inclusive_scan algorithm returns the output iterator
-    ///           to the element in the destination range, one past the last
-    ///           element copied.
-    ///
-    /// \note   GENERALIZED_NONCOMMUTATIVE_SUM(op, a1, ..., aN) is defined as:
-    ///         * a1 when N is 1
-    ///         * op(GENERALIZED_NONCOMMUTATIVE_SUM(op, a1, ..., aK),
-    ///           GENERALIZED_NONCOMMUTATIVE_SUM(op, aM, ..., aN))
-    ///           where 1 < K+1 = M <= N.
-    ///
-    /// Neither \a conv nor \a op shall invalidate iterators or subranges, or
-    /// modify elements in the ranges [first,last) or [result,result + (last - first)).
-    ///
-    /// The difference between \a exclusive_scan and \a transform_inclusive_scan is that
-    /// \a transform_inclusive_scan includes the ith input element in the ith sum. If
-    /// \a op is not mathematically associative, the behavior of
-    /// \a transform_inclusive_scan may be non-deterministic.
-    ///
-    // clang-format off
     template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
         typename Op, typename Conv, typename T,
-        HPX_CONCEPT_REQUIRES_(
-            hpx::is_execution_policy<ExPolicy>::value &&
-            hpx::traits::is_iterator<FwdIter1>::value &&
-            hpx::traits::is_iterator<FwdIter2>::value &&
-            hpx::is_invocable_v<Conv,
-                typename std::iterator_traits<FwdIter1>::value_type> &&
-            hpx::is_invocable_v<Op,
-                typename hpx::util::invoke_result<Conv,
-                    typename std::iterator_traits<FwdIter1>::value_type>::type,
-                typename hpx::util::invoke_result<Conv,
-                    typename std::iterator_traits<FwdIter1>::value_type>::type
-            >
-        )>
+        HPX_CONCEPT_REQUIRES_(hpx::is_execution_policy<
+            ExPolicy>::value&& hpx::traits::is_iterator<FwdIter1>::value&&
+                hpx::traits::is_iterator<FwdIter2>::value&& hpx::is_invocable_v<
+                    Conv, typename std::iterator_traits<FwdIter1>::value_type>&&
+                    hpx::is_invocable_v<Op,
+                        typename hpx::util::invoke_result<Conv,
+                            typename std::iterator_traits<
+                                FwdIter1>::value_type>::type,
+                        typename hpx::util::invoke_result<Conv,
+                            typename std::iterator_traits<
+                                FwdIter1>::value_type>::type>)>
     // clang-format on
     HPX_DEPRECATED_V(1, 8,
         "hpx::parallel::transform_inclusive_scan is deprecated, use "
@@ -355,121 +641,19 @@ namespace hpx { namespace parallel { inline namespace v1 {
 #endif
     }
 
-    ///////////////////////////////////////////////////////////////////////////
-    /// Assigns through each iterator \a i in [result, result + (last - first))
-    /// the value of
-    /// GENERALIZED_NONCOMMUTATIVE_SUM(op, conv(*first), ...,
-    /// conv(*(first + (i - result)))).
-    ///
-    /// \note   Complexity: O(\a last - \a first) applications of the
-    ///         predicate \a op.
-    ///
-    /// \tparam ExPolicy    The type of the execution policy to use (deduced).
-    ///                     It describes the manner in which the execution
-    ///                     of the algorithm may be parallelized and the manner
-    ///                     in which it executes the assignments.
-    /// \tparam FwdIter1    The type of the source iterators used (deduced).
-    ///                     This iterator type must meet the requirements of an
-    ///                     forward iterator.
-    /// \tparam FwdIter2    The type of the iterator representing the
-    ///                     destination range (deduced).
-    ///                     This iterator type must meet the requirements of an
-    ///                     forward iterator.
-    /// \tparam Conv        The type of the unary function object used for
-    ///                     the conversion operation.
-    /// \tparam T           The type of the value to be used as initial (and
-    ///                     intermediate) values (deduced).
-    /// \tparam Op          The type of the binary function object used for
-    ///                     the reduction operation.
-    ///
-    /// \param policy       The execution policy to use for the scheduling of
-    ///                     the iterations.
-    /// \param first        Refers to the beginning of the sequence of elements
-    ///                     the algorithm will be applied to.
-    /// \param last         Refers to the end of the sequence of elements the
-    ///                     algorithm will be applied to.
-    /// \param dest         Refers to the beginning of the destination range.
-    /// \param conv         Specifies the function (or function object) which
-    ///                     will be invoked for each of the elements in the
-    ///                     sequence specified by [first, last). This is a
-    ///                     unary predicate. The signature of this predicate
-    ///                     should be equivalent to:
-    ///                     \code
-    ///                     R fun(const Type &a);
-    ///                     \endcode \n
-    ///                     The signature does not need to have const&, but
-    ///                     the function must not modify the objects passed to
-    ///                     it. The type \a Type must be such that an object of
-    ///                     type \a FwdIter1 can be dereferenced and then
-    ///                     implicitly converted to Type.
-    ///                     The type \a R must be such that an object of this
-    ///                     type can be implicitly converted to \a T.
-    /// \param op           Specifies the function (or function object) which
-    ///                     will be invoked for each of the values of the input
-    ///                     sequence. This is a
-    ///                     binary predicate. The signature of this predicate
-    ///                     should be equivalent to:
-    ///                     \code
-    ///                     Ret fun(const Type1 &a, const Type1 &b);
-    ///                     \endcode \n
-    ///                     The signature does not need to have const&, but
-    ///                     the function must not modify the objects passed to
-    ///                     it.
-    ///                     The types \a Type1 and \a Ret must be
-    ///                     such that an object of a type as given by the input
-    ///                     sequence can be implicitly converted to any
-    ///                     of those types.
-    ///
-    /// The reduce operations in the parallel \a transform_inclusive_scan algorithm
-    /// invoked
-    /// with an execution policy object of type \a sequenced_policy
-    /// execute in sequential order in the calling thread.
-    ///
-    /// The reduce operations in the parallel \a transform_inclusive_scan algorithm
-    /// invoked
-    /// with an execution policy object of type \a parallel_policy
-    /// or \a parallel_task_policy are permitted to execute in an unordered
-    /// fashion in unspecified threads, and indeterminately sequenced
-    /// within each thread.
-    ///
-    /// \returns  The \a transform_inclusive_scan algorithm returns a
-    ///           \a hpx::future<FwdIter2> if
-    ///           the execution policy is of type
-    ///           \a sequenced_task_policy or
-    ///           \a parallel_task_policy and
-    ///           returns \a FwdIter2 otherwise.
-    ///           The \a transform_inclusive_scan algorithm returns the output iterator
-    ///           to the element in the destination range, one past the last
-    ///           element copied.
-    ///
-    /// \note   GENERALIZED_NONCOMMUTATIVE_SUM(op, a1, ..., aN) is defined as:
-    ///         * a1 when N is 1
-    ///         * op(GENERALIZED_NONCOMMUTATIVE_SUM(op, a1, ..., aK),
-    ///           GENERALIZED_NONCOMMUTATIVE_SUM(op, aM, ..., aN))
-    ///           where 1 < K+1 = M <= N.
-    ///
-    /// Neither \a conv nor \a op shall invalidate iterators or subranges, or
-    /// modify elements in the ranges [first,last) or [result,result + (last - first)).
-    ///
-    /// The difference between \a exclusive_scan and \a transform_inclusive_scan is that
-    /// \a transform_inclusive_scan includes the ith input element in the ith sum.
-    ///
-    // clang-format off
     template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
         typename Conv, typename Op,
-        HPX_CONCEPT_REQUIRES_(
-            hpx::is_execution_policy<ExPolicy>::value &&
-            hpx::traits::is_iterator<FwdIter1>::value &&
-            hpx::traits::is_iterator<FwdIter2>::value &&
-            hpx::is_invocable_v<Conv,
-                typename std::iterator_traits<FwdIter1>::value_type> &&
-            hpx::is_invocable_v<Op,
-                typename hpx::util::invoke_result<Conv,
-                    typename std::iterator_traits<FwdIter1>::value_type>::type,
-                typename hpx::util::invoke_result<Conv,
-                    typename std::iterator_traits<FwdIter1>::value_type>::type
-            >
-        )>
+        HPX_CONCEPT_REQUIRES_(hpx::is_execution_policy<
+            ExPolicy>::value&& hpx::traits::is_iterator<FwdIter1>::value&&
+                hpx::traits::is_iterator<FwdIter2>::value&& hpx::is_invocable_v<
+                    Conv, typename std::iterator_traits<FwdIter1>::value_type>&&
+                    hpx::is_invocable_v<Op,
+                        typename hpx::util::invoke_result<Conv,
+                            typename std::iterator_traits<
+                                FwdIter1>::value_type>::type,
+                        typename hpx::util::invoke_result<Conv,
+                            typename std::iterator_traits<
+                                FwdIter1>::value_type>::type>)>
     // clang-format on
     HPX_DEPRECATED_V(1, 8,
         "hpx::parallel::transform_inclusive_scan is deprecated, use "
@@ -637,3 +821,5 @@ namespace hpx {
         }
     } transform_inclusive_scan{};
 }    // namespace hpx
+
+#endif    // DOXYGEN

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/transform_inclusive_scan.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/transform_inclusive_scan.hpp
@@ -17,8 +17,8 @@ namespace hpx { namespace ranges {
     ///////////////////////////////////////////////////////////////////////////
     /// Assigns through each iterator \a i in [result, result + (last - first))
     /// the value of
-    /// GENERALIZED_NONCOMMUTATIVE_SUM(binary_op, init, conv(*first), ...,
-    /// conv(*(first + (i - result) - 1))).
+    /// GENERALIZED_NONCOMMUTATIVE_SUM(op, conv(*first), ...,
+    /// conv(*(first + (i - result)))).
     ///
     /// \note   Complexity: O(\a last - \a first) applications of the
     ///         predicates \a op and \a conv.
@@ -32,34 +32,16 @@ namespace hpx { namespace ranges {
     ///                     destination range (deduced).
     ///                     This iterator type must meet the requirements of an
     ///                     output iterator.
-    /// \tparam Conv        The type of the unary function object used for
-    ///                     the conversion operation.
-    /// \tparam T           The type of the value to be used as initial (and
-    ///                     intermediate) values (deduced).
     /// \tparam Op          The type of the binary function object used for
     ///                     the reduction operation.
+    /// \tparam Conv        The type of the unary function object used for
+    ///                     the conversion operation.
     ///
     /// \param first        Refers to the beginning of the sequence of elements
     ///                     the algorithm will be applied to.
     /// \param last         Refers to sentinel value denoting the end of the
     ///                     sequence of elements the algorithm will be applied.
     /// \param dest         Refers to the beginning of the destination range.
-    /// \param conv         Specifies the function (or function object) which
-    ///                     will be invoked for each of the elements in the
-    ///                     sequence specified by [first, last). This is a
-    ///                     unary predicate. The signature of this predicate
-    ///                     should be equivalent to:
-    ///                     \code
-    ///                     R fun(const Type &a);
-    ///                     \endcode \n
-    ///                     The signature does not need to have const&, but
-    ///                     the function must not modify the objects passed to
-    ///                     it. The type \a Type must be such that an object of
-    ///                     type \a FwdIter1 can be dereferenced and then
-    ///                     implicitly converted to Type.
-    ///                     The type \a R must be such that an object of this
-    ///                     type can be implicitly converted to \a T.
-    /// \param init         The initial value for the generalized sum.
     /// \param op           Specifies the function (or function object) which
     ///                     will be invoked for each of the values of the input
     ///                     sequence. This is a
@@ -75,6 +57,21 @@ namespace hpx { namespace ranges {
     ///                     such that an object of a type as given by the input
     ///                     sequence can be implicitly converted to any
     ///                     of those types.
+    /// \param conv         Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements in the
+    ///                     sequence specified by [first, last). This is a
+    ///                     unary predicate. The signature of this predicate
+    ///                     should be equivalent to:
+    ///                     \code
+    ///                     R fun(const Type &a);
+    ///                     \endcode \n
+    ///                     The signature does not need to have const&, but
+    ///                     the function must not modify the objects passed to
+    ///                     it. The type \a Type must be such that an object of
+    ///                     type \a FwdIter1 can be dereferenced and then
+    ///                     implicitly converted to Type.
+    ///                     The type \a R must be such that an object of this
+    ///                     type can be implicitly converted to \a T.
     ///
     /// The reduce operations in the parallel \a transform_inclusive_scan
     /// algorithm invoked without an execution policy object execute in
@@ -99,16 +96,16 @@ namespace hpx { namespace ranges {
     /// The behavior of transform_inclusive_scan may be non-deterministic for
     /// a non-associative predicate.
     ///
-    template <typename InIter, typename Sent, typename OutIter, typename T,
+    template <typename InIter, typename Sent, typename OutIter,
         typename BinOp, typename UnOp>
     OutIter transform_inclusive_scan(InIter first, Sent last, OutIter dest,
-        T init, BinOp&& binary_op, UnOp&& unary_op);
+        BinOp&& binary_op, UnOp&& unary_op);
 
     ///////////////////////////////////////////////////////////////////////////
     /// Assigns through each iterator \a i in [result, result + (last - first))
     /// the value of
-    /// GENERALIZED_NONCOMMUTATIVE_SUM(binary_op, init, conv(*first), ...,
-    /// conv(*(first + (i - result) - 1))).
+    /// GENERALIZED_NONCOMMUTATIVE_SUM(op, conv(*first), ...,
+    /// conv(*(first + (i - result)))).
     ///
     /// \note   Complexity: O(\a last - \a first) applications of the
     ///         predicates \a op and \a conv.
@@ -126,12 +123,10 @@ namespace hpx { namespace ranges {
     ///                     destination range (deduced).
     ///                     This iterator type must meet the requirements of an
     ///                     forward iterator.
-    /// \tparam Conv        The type of the unary function object used for
-    ///                     the conversion operation.
-    /// \tparam T           The type of the value to be used as initial (and
-    ///                     intermediate) values (deduced).
     /// \tparam Op          The type of the binary function object used for
     ///                     the reduction operation.
+    /// \tparam Conv        The type of the unary function object used for
+    ///                     the conversion operation.
     ///
     /// \param policy       The execution policy to use for the scheduling of
     ///                     the iterations.
@@ -140,22 +135,6 @@ namespace hpx { namespace ranges {
     /// \param last         Refers to sentinel value denoting the end of the
     ///                     sequence of elements the algorithm will be applied.
     /// \param dest         Refers to the beginning of the destination range.
-    /// \param conv         Specifies the function (or function object) which
-    ///                     will be invoked for each of the elements in the
-    ///                     sequence specified by [first, last). This is a
-    ///                     unary predicate. The signature of this predicate
-    ///                     should be equivalent to:
-    ///                     \code
-    ///                     R fun(const Type &a);
-    ///                     \endcode \n
-    ///                     The signature does not need to have const&, but
-    ///                     the function must not modify the objects passed to
-    ///                     it. The type \a Type must be such that an object of
-    ///                     type \a FwdIter1 can be dereferenced and then
-    ///                     implicitly converted to Type.
-    ///                     The type \a R must be such that an object of this
-    ///                     type can be implicitly converted to \a T.
-    /// \param init         The initial value for the generalized sum.
     /// \param op           Specifies the function (or function object) which
     ///                     will be invoked for each of the values of the input
     ///                     sequence. This is a
@@ -171,6 +150,21 @@ namespace hpx { namespace ranges {
     ///                     such that an object of a type as given by the input
     ///                     sequence can be implicitly converted to any
     ///                     of those types.
+    /// \param conv         Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements in the
+    ///                     sequence specified by [first, last). This is a
+    ///                     unary predicate. The signature of this predicate
+    ///                     should be equivalent to:
+    ///                     \code
+    ///                     R fun(const Type &a);
+    ///                     \endcode \n
+    ///                     The signature does not need to have const&, but
+    ///                     the function must not modify the objects passed to
+    ///                     it. The type \a Type must be such that an object of
+    ///                     type \a FwdIter1 can be dereferenced and then
+    ///                     implicitly converted to Type.
+    ///                     The type \a R must be such that an object of this
+    ///                     type can be implicitly converted to \a T.
     ///
     /// The reduce operations in the parallel \a transform_inclusive_scan
     /// algorithm invoked with an execution policy object of type \a
@@ -206,16 +200,16 @@ namespace hpx { namespace ranges {
     /// a non-associative predicate.
     ///
     template <typename ExPolicy, typename FwdIter1, typename Sent,
-        typename FwdIter2, typename T, typename BinOp, typename UnOp>
+        typename FwdIter2, typename BinOp, typename UnOp>
     typename parallel::util::detail::algorithm_result<ExPolicy, FwdIter2>::type
     transform_inclusive_scan(ExPolicy&& policy, FwdIter1 first, Sent last,
-        FwdIter2 dest, T init, BinOp&& binary_op, UnOp&& unary_op);
+        FwdIter2 dest, BinOp&& binary_op, UnOp&& unary_op);
 
     ///////////////////////////////////////////////////////////////////////////
     /// Assigns through each iterator \a i in [result, result + (last - first))
     /// the value of
-    /// GENERALIZED_NONCOMMUTATIVE_SUM(binary_op, init, conv(*first), ...,
-    /// conv(*(first + (i - result) - 1))).
+    /// GENERALIZED_NONCOMMUTATIVE_SUM(op, conv(*first), ...,
+    /// conv(*(first + (i - result)))).
     ///
     /// \note   Complexity: O(\a last - \a first) applications of the
     ///         predicates \a op and \a conv.
@@ -225,31 +219,13 @@ namespace hpx { namespace ranges {
     ///                     meet the requirements of an input iterator.
     /// \tparam O           The type of the iterator representing the
     ///                     destination range (deduced).
-    /// \tparam Conv        The type of the unary function object used for
-    ///                     the conversion operation.
-    /// \tparam T           The type of the value to be used as initial (and
-    ///                     intermediate) values (deduced).
     /// \tparam Op          The type of the binary function object used for
     ///                     the reduction operation.
+    /// \tparam Conv        The type of the unary function object used for
+    ///                     the conversion operation.
     ///
     /// \param rng          Refers to the sequence of elements the algorithm
     ///                     will be applied to.
-    /// \param conv         Specifies the function (or function object) which
-    ///                     will be invoked for each of the elements in the
-    ///                     sequence specified by [first, last). This is a
-    ///                     unary predicate. The signature of this predicate
-    ///                     should be equivalent to:
-    ///                     \code
-    ///                     R fun(const Type &a);
-    ///                     \endcode \n
-    ///                     The signature does not need to have const&, but
-    ///                     the function must not modify the objects passed to
-    ///                     it. The type \a Type must be such that an object of
-    ///                     type \a FwdIter1 can be dereferenced and then
-    ///                     implicitly converted to Type.
-    ///                     The type \a R must be such that an object of this
-    ///                     type can be implicitly converted to \a T.
-    /// \param init         The initial value for the generalized sum.
     /// \param op           Specifies the function (or function object) which
     ///                     will be invoked for each of the values of the input
     ///                     sequence. This is a
@@ -265,6 +241,21 @@ namespace hpx { namespace ranges {
     ///                     such that an object of a type as given by the input
     ///                     sequence can be implicitly converted to any
     ///                     of those types.
+    /// \param conv         Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements in the
+    ///                     sequence specified by [first, last). This is a
+    ///                     unary predicate. The signature of this predicate
+    ///                     should be equivalent to:
+    ///                     \code
+    ///                     R fun(const Type &a);
+    ///                     \endcode \n
+    ///                     The signature does not need to have const&, but
+    ///                     the function must not modify the objects passed to
+    ///                     it. The type \a Type must be such that an object of
+    ///                     type \a FwdIter1 can be dereferenced and then
+    ///                     implicitly converted to Type.
+    ///                     The type \a R must be such that an object of this
+    ///                     type can be implicitly converted to \a T.
     ///
     /// The reduce operations in the parallel \a transform_inclusive_scan
     /// algorithm invoked without an execution policy object execute in
@@ -289,16 +280,16 @@ namespace hpx { namespace ranges {
     /// The behavior of transform_inclusive_scan may be non-deterministic for
     /// a non-associative predicate.
     ///
-    template <typename Rng, typename O, typename T, typename BinOp,
+    template <typename Rng, typename O, typename BinOp,
         typename UnOp>
-    O transform_inclusive_scan(Rng&& rng, O dest, T init, BinOp&& binary_op,
+    O transform_inclusive_scan(Rng&& rng, O dest, BinOp&& binary_op,
         UnOp&& unary_op);
 
     ///////////////////////////////////////////////////////////////////////////
     /// Assigns through each iterator \a i in [result, result + (last - first))
     /// the value of
-    /// GENERALIZED_NONCOMMUTATIVE_SUM(binary_op, init, conv(*first), ...,
-    /// conv(*(first + (i - result) - 1))).
+    /// GENERALIZED_NONCOMMUTATIVE_SUM(op, conv(*first), ...,
+    /// conv(*(first + (i - result)))).
     ///
     /// \note   Complexity: O(\a last - \a first) applications of the
     ///         predicates \a op and \a conv.
@@ -318,8 +309,6 @@ namespace hpx { namespace ranges {
     ///                     forward iterator.
     /// \tparam Conv        The type of the unary function object used for
     ///                     the conversion operation.
-    /// \tparam T           The type of the value to be used as initial (and
-    ///                     intermediate) values (deduced).
     /// \tparam Op          The type of the binary function object used for
     ///                     the reduction operation.
     ///
@@ -328,22 +317,6 @@ namespace hpx { namespace ranges {
     /// \param rng          Refers to the sequence of elements the algorithm
     ///                     will be applied to.
     /// \param dest         Refers to the beginning of the destination range.
-    /// \param conv         Specifies the function (or function object) which
-    ///                     will be invoked for each of the elements in the
-    ///                     sequence specified by [first, last). This is a
-    ///                     unary predicate. The signature of this predicate
-    ///                     should be equivalent to:
-    ///                     \code
-    ///                     R fun(const Type &a);
-    ///                     \endcode \n
-    ///                     The signature does not need to have const&, but
-    ///                     the function must not modify the objects passed to
-    ///                     it. The type \a Type must be such that an object of
-    ///                     type \a FwdIter1 can be dereferenced and then
-    ///                     implicitly converted to Type.
-    ///                     The type \a R must be such that an object of this
-    ///                     type can be implicitly converted to \a T.
-    /// \param init         The initial value for the generalized sum.
     /// \param op           Specifies the function (or function object) which
     ///                     will be invoked for each of the values of the input
     ///                     sequence. This is a
@@ -359,6 +332,21 @@ namespace hpx { namespace ranges {
     ///                     such that an object of a type as given by the input
     ///                     sequence can be implicitly converted to any
     ///                     of those types.
+    /// \param conv         Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements in the
+    ///                     sequence specified by [first, last). This is a
+    ///                     unary predicate. The signature of this predicate
+    ///                     should be equivalent to:
+    ///                     \code
+    ///                     R fun(const Type &a);
+    ///                     \endcode \n
+    ///                     The signature does not need to have const&, but
+    ///                     the function must not modify the objects passed to
+    ///                     it. The type \a Type must be such that an object of
+    ///                     type \a FwdIter1 can be dereferenced and then
+    ///                     implicitly converted to Type.
+    ///                     The type \a R must be such that an object of this
+    ///                     type can be implicitly converted to \a T.
     ///
     /// The reduce operations in the parallel \a transform_inclusive_scan
     /// algorithm invoked with an execution policy object of type \a
@@ -393,11 +381,396 @@ namespace hpx { namespace ranges {
     /// The behavior of transform_inclusive_scan may be non-deterministic for
     /// a non-associative predicate.
     ///
-    template <typename ExPolicy, typename Rng,  typename O, typename T,
+    template <typename ExPolicy, typename Rng,  typename O,
         typename BinOp, typename UnOp>
     typename parallel::util::detail::algorithm_result<ExPolicy, O>::type
-    transform_inclusive_scan(ExPolicy&& policy, Rng&& rng, O dest, T init,
+    transform_inclusive_scan(ExPolicy&& policy, Rng&& rng, O dest,
         BinOp&& binary_op, UnOp&& unary_op);
+
+    ///////////////////////////////////////////////////////////////////////////
+    /// Assigns through each iterator \a i in [result, result + (last - first))
+    /// the value of
+    /// GENERALIZED_NONCOMMUTATIVE_SUM(binary_op, init, conv(*first), ...,
+    /// conv(*(first + (i - result)))).
+    ///
+    /// \note   Complexity: O(\a last - \a first) applications of the
+    ///         predicates \a op and \a conv.
+    ///
+    /// \tparam InIter      The type of the source iterators used (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     input iterator.
+    /// \tparam Sent        The type of the source sentinel (deduced). This
+    ///                     sentinel type must be a sentinel for InIter.
+    /// \tparam OutIter     The type of the iterator representing the
+    ///                     destination range (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     output iterator.
+    /// \tparam Conv        The type of the unary function object used for
+    ///                     the conversion operation.
+    /// \tparam Op          The type of the binary function object used for
+    ///                     the reduction operation.
+    /// \tparam T           The type of the value to be used as initial (and
+    ///                     intermediate) values (deduced).
+    ///
+    /// \param first        Refers to the beginning of the sequence of elements
+    ///                     the algorithm will be applied to.
+    /// \param last         Refers to sentinel value denoting the end of the
+    ///                     sequence of elements the algorithm will be applied.
+    /// \param dest         Refers to the beginning of the destination range.
+    /// \param conv         Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements in the
+    ///                     sequence specified by [first, last). This is a
+    ///                     unary predicate. The signature of this predicate
+    ///                     should be equivalent to:
+    ///                     \code
+    ///                     R fun(const Type &a);
+    ///                     \endcode \n
+    ///                     The signature does not need to have const&, but
+    ///                     the function must not modify the objects passed to
+    ///                     it. The type \a Type must be such that an object of
+    ///                     type \a FwdIter1 can be dereferenced and then
+    ///                     implicitly converted to Type.
+    ///                     The type \a R must be such that an object of this
+    ///                     type can be implicitly converted to \a T.
+    /// \param op           Specifies the function (or function object) which
+    ///                     will be invoked for each of the values of the input
+    ///                     sequence. This is a
+    ///                     binary predicate. The signature of this predicate
+    ///                     should be equivalent to:
+    ///                     \code
+    ///                     Ret fun(const Type1 &a, const Type1 &b);
+    ///                     \endcode \n
+    ///                     The signature does not need to have const&, but
+    ///                     the function must not modify the objects passed to
+    ///                     it.
+    ///                     The types \a Type1 and \a Ret must be
+    ///                     such that an object of a type as given by the input
+    ///                     sequence can be implicitly converted to any
+    ///                     of those types.
+    /// \param init         The initial value for the generalized sum.
+    ///
+    /// The reduce operations in the parallel \a transform_inclusive_scan
+    /// algorithm invoked without an execution policy object execute in
+    /// sequential order in the calling thread.
+    ///
+    /// \returns  The \a transform_inclusive_scan algorithm returns a
+    ///           returns \a OutIter.
+    ///           The \a transform_inclusive_scan algorithm returns the output
+    ///           iterator to the element in the destination range, one past
+    ///           the last element copied.
+    ///
+    /// \note   GENERALIZED_NONCOMMUTATIVE_SUM(op, a1, ..., aN) is defined as:
+    ///         * a1 when N is 1
+    ///         * op(GENERALIZED_NONCOMMUTATIVE_SUM(op, a1, ..., aK),
+    ///           GENERALIZED_NONCOMMUTATIVE_SUM(op, aM, ..., aN)
+    ///           where 1 < K+1 = M <= N.
+    ///
+    /// Neither \a conv nor \a op shall invalidate iterators or subranges, or
+    /// modify elements in the ranges [first,last) or [result,result +
+    /// (last - first)).
+    ///
+    /// The behavior of transform_inclusive_scan may be non-deterministic for
+    /// a non-associative predicate.
+    ///
+    template <typename InIter, typename Sent, typename OutIter,
+        typename BinOp, typename UnOp, typename T>
+    OutIter transform_inclusive_scan(InIter first, Sent last, OutIter dest,
+        BinOp&& binary_op, UnOp&& unary_op, T init);
+
+    ///////////////////////////////////////////////////////////////////////////
+    /// Assigns through each iterator \a i in [result, result + (last - first))
+    /// the value of
+    /// GENERALIZED_NONCOMMUTATIVE_SUM(binary_op, init, conv(*first), ...,
+    /// conv(*(first + (i - result)))).
+    ///
+    /// \note   Complexity: O(\a last - \a first) applications of the
+    ///         predicates \a op and \a conv.
+    ///
+    /// \tparam ExPolicy    The type of the execution policy to use (deduced).
+    ///                     It describes the manner in which the execution
+    ///                     of the algorithm may be parallelized and the manner
+    ///                     in which it executes the assignments.
+    /// \tparam FwdIter1    The type of the source iterators used (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     forward iterator.
+    /// \tparam Sent        The type of the source sentinel (deduced). This
+    ///                     sentinel type must be a sentinel for FwdIter.
+    /// \tparam FwdIter2    The type of the iterator representing the
+    ///                     destination range (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     forward iterator.
+    /// \tparam Conv        The type of the unary function object used for
+    ///                     the conversion operation.
+    /// \tparam Op          The type of the binary function object used for
+    ///                     the reduction operation.
+    /// \tparam T           The type of the value to be used as initial (and
+    ///                     intermediate) values (deduced).
+    ///
+    /// \param policy       The execution policy to use for the scheduling of
+    ///                     the iterations.
+    /// \param first        Refers to the beginning of the sequence of elements
+    ///                     the algorithm will be applied to.
+    /// \param last         Refers to sentinel value denoting the end of the
+    ///                     sequence of elements the algorithm will be applied.
+    /// \param dest         Refers to the beginning of the destination range.
+    /// \param conv         Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements in the
+    ///                     sequence specified by [first, last). This is a
+    ///                     unary predicate. The signature of this predicate
+    ///                     should be equivalent to:
+    ///                     \code
+    ///                     R fun(const Type &a);
+    ///                     \endcode \n
+    ///                     The signature does not need to have const&, but
+    ///                     the function must not modify the objects passed to
+    ///                     it. The type \a Type must be such that an object of
+    ///                     type \a FwdIter1 can be dereferenced and then
+    ///                     implicitly converted to Type.
+    ///                     The type \a R must be such that an object of this
+    ///                     type can be implicitly converted to \a T.
+    /// \param op           Specifies the function (or function object) which
+    ///                     will be invoked for each of the values of the input
+    ///                     sequence. This is a
+    ///                     binary predicate. The signature of this predicate
+    ///                     should be equivalent to:
+    ///                     \code
+    ///                     Ret fun(const Type1 &a, const Type1 &b);
+    ///                     \endcode \n
+    ///                     The signature does not need to have const&, but
+    ///                     the function must not modify the objects passed to
+    ///                     it.
+    ///                     The types \a Type1 and \a Ret must be
+    ///                     such that an object of a type as given by the input
+    ///                     sequence can be implicitly converted to any
+    ///                     of those types.
+    /// \param init         The initial value for the generalized sum.
+    ///
+    /// The reduce operations in the parallel \a transform_inclusive_scan
+    /// algorithm invoked with an execution policy object of type \a
+    /// sequenced_policy execute in sequential order in the calling thread.
+    ///
+    /// The reduce operations in the parallel \a transform_inclusive_scan
+    /// algorithm invoked with an execution policy object of type \a
+    /// parallel_policy or \a parallel_task_policy are permitted to execute
+    /// in an unordered fashion in unspecified threads, and indeterminately
+    /// sequenced within each thread.
+    ///
+    /// \returns  The \a transform_inclusive_scan algorithm returns a
+    ///           \a hpx::future<FwdIter2> if
+    ///           the execution policy is of type
+    ///           \a sequenced_task_policy or
+    ///           \a parallel_task_policy and
+    ///           returns \a FwdIter2 otherwise.
+    ///           The \a transform_inclusive_scan algorithm returns the output
+    ///           iterator to the element in the destination range, one past
+    ///           the last element copied.
+    ///
+    /// \note   GENERALIZED_NONCOMMUTATIVE_SUM(op, a1, ..., aN) is defined as:
+    ///         * a1 when N is 1
+    ///         * op(GENERALIZED_NONCOMMUTATIVE_SUM(op, a1, ..., aK),
+    ///           GENERALIZED_NONCOMMUTATIVE_SUM(op, aM, ..., aN)
+    ///           where 1 < K+1 = M <= N.
+    ///
+    /// Neither \a conv nor \a op shall invalidate iterators or subranges, or
+    /// modify elements in the ranges [first,last) or [result,result +
+    /// (last - first)).
+    ///
+    /// The behavior of transform_inclusive_scan may be non-deterministic for
+    /// a non-associative predicate.
+    ///
+    template <typename ExPolicy, typename FwdIter1, typename Sent,
+        typename FwdIter2, typename BinOp, typename UnOp, typename T>
+    typename parallel::util::detail::algorithm_result<ExPolicy, FwdIter2>::type
+    transform_inclusive_scan(ExPolicy&& policy, FwdIter1 first, Sent last,
+        FwdIter2 dest, BinOp&& binary_op, UnOp&& unary_op, T init);
+
+    ///////////////////////////////////////////////////////////////////////////
+    /// Assigns through each iterator \a i in [result, result + (last - first))
+    /// the value of
+    /// GENERALIZED_NONCOMMUTATIVE_SUM(binary_op, init, conv(*first), ...,
+    /// conv(*(first + (i - result)))).
+    ///
+    /// \note   Complexity: O(\a last - \a first) applications of the
+    ///         predicates \a op and \a conv.
+    ///
+    /// \tparam Rng         The type of the source range used (deduced).
+    ///                     The iterators extracted from this range type must
+    ///                     meet the requirements of an input iterator.
+    /// \tparam O           The type of the iterator representing the
+    ///                     destination range (deduced).
+    /// \tparam Conv        The type of the unary function object used for
+    ///                     the conversion operation.
+    /// \tparam Op          The type of the binary function object used for
+    ///                     the reduction operation.
+    /// \tparam T           The type of the value to be used as initial (and
+    ///                     intermediate) values (deduced).
+    ///
+    /// \param rng          Refers to the sequence of elements the algorithm
+    ///                     will be applied to.
+    /// \param conv         Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements in the
+    ///                     sequence specified by [first, last). This is a
+    ///                     unary predicate. The signature of this predicate
+    ///                     should be equivalent to:
+    ///                     \code
+    ///                     R fun(const Type &a);
+    ///                     \endcode \n
+    ///                     The signature does not need to have const&, but
+    ///                     the function must not modify the objects passed to
+    ///                     it. The type \a Type must be such that an object of
+    ///                     type \a FwdIter1 can be dereferenced and then
+    ///                     implicitly converted to Type.
+    ///                     The type \a R must be such that an object of this
+    ///                     type can be implicitly converted to \a T.
+    /// \param op           Specifies the function (or function object) which
+    ///                     will be invoked for each of the values of the input
+    ///                     sequence. This is a
+    ///                     binary predicate. The signature of this predicate
+    ///                     should be equivalent to:
+    ///                     \code
+    ///                     Ret fun(const Type1 &a, const Type1 &b);
+    ///                     \endcode \n
+    ///                     The signature does not need to have const&, but
+    ///                     the function must not modify the objects passed to
+    ///                     it.
+    ///                     The types \a Type1 and \a Ret must be
+    ///                     such that an object of a type as given by the input
+    ///                     sequence can be implicitly converted to any
+    ///                     of those types.
+    /// \param init         The initial value for the generalized sum.
+    ///
+    /// The reduce operations in the parallel \a transform_inclusive_scan
+    /// algorithm invoked without an execution policy object execute in
+    /// sequential order in the calling thread.
+    ///
+    /// \returns  The \a transform_inclusive_scan algorithm returns a
+    ///           returns \a O.
+    ///           The \a transform_inclusive_scan algorithm returns the output
+    ///           iterator to the element in the destination range, one past
+    ///           the last element copied.
+    ///
+    /// \note   GENERALIZED_NONCOMMUTATIVE_SUM(op, a1, ..., aN) is defined as:
+    ///         * a1 when N is 1
+    ///         * op(GENERALIZED_NONCOMMUTATIVE_SUM(op, a1, ..., aK),
+    ///           GENERALIZED_NONCOMMUTATIVE_SUM(op, aM, ..., aN)
+    ///           where 1 < K+1 = M <= N.
+    ///
+    /// Neither \a conv nor \a op shall invalidate iterators or subranges, or
+    /// modify elements in the ranges [first,last) or [result,result +
+    /// (last - first)).
+    ///
+    /// The behavior of transform_inclusive_scan may be non-deterministic for
+    /// a non-associative predicate.
+    ///
+    template <typename Rng, typename O, typename BinOp,
+        typename UnOp, typename T>
+    O transform_inclusive_scan(Rng&& rng, O dest, BinOp&& binary_op,
+        UnOp&& unary_op, T init);
+
+    ///////////////////////////////////////////////////////////////////////////
+    /// Assigns through each iterator \a i in [result, result + (last - first))
+    /// the value of
+    /// GENERALIZED_NONCOMMUTATIVE_SUM(binary_op, init, conv(*first), ...,
+    /// conv(*(first + (i - result)))).
+    ///
+    /// \note   Complexity: O(\a last - \a first) applications of the
+    ///         predicates \a op and \a conv.
+    ///
+    /// \tparam ExPolicy    The type of the execution policy to use (deduced).
+    ///                     It describes the manner in which the execution
+    ///                     of the algorithm may be parallelized and the manner
+    ///                     in which it executes the assignments.
+    /// \tparam Rng         The type of the source range used (deduced).
+    ///                     The iterators extracted from this range type must
+    ///                     meet the requirements of an forward iterator.
+    /// \tparam O           The type of the iterator representing the
+    ///                     destination range (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     forward iterator.
+    ///                     This iterator type must meet the requirements of an
+    ///                     forward iterator.
+    /// \tparam Conv        The type of the unary function object used for
+    ///                     the conversion operation.
+    /// \tparam Op          The type of the binary function object used for
+    ///                     the reduction operation.
+    /// \tparam T           The type of the value to be used as initial (and
+    ///                     intermediate) values (deduced).
+    ///
+    /// \param policy       The execution policy to use for the scheduling of
+    ///                     the iterations.
+    /// \param rng          Refers to the sequence of elements the algorithm
+    ///                     will be applied to.
+    /// \param dest         Refers to the beginning of the destination range.
+    /// \param conv         Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements in the
+    ///                     sequence specified by [first, last). This is a
+    ///                     unary predicate. The signature of this predicate
+    ///                     should be equivalent to:
+    ///                     \code
+    ///                     R fun(const Type &a);
+    ///                     \endcode \n
+    ///                     The signature does not need to have const&, but
+    ///                     the function must not modify the objects passed to
+    ///                     it. The type \a Type must be such that an object of
+    ///                     type \a FwdIter1 can be dereferenced and then
+    ///                     implicitly converted to Type.
+    ///                     The type \a R must be such that an object of this
+    ///                     type can be implicitly converted to \a T.
+    /// \param op           Specifies the function (or function object) which
+    ///                     will be invoked for each of the values of the input
+    ///                     sequence. This is a
+    ///                     binary predicate. The signature of this predicate
+    ///                     should be equivalent to:
+    ///                     \code
+    ///                     Ret fun(const Type1 &a, const Type1 &b);
+    ///                     \endcode \n
+    ///                     The signature does not need to have const&, but
+    ///                     the function must not modify the objects passed to
+    ///                     it.
+    ///                     The types \a Type1 and \a Ret must be
+    ///                     such that an object of a type as given by the input
+    ///                     sequence can be implicitly converted to any
+    ///                     of those types.
+    /// \param init         The initial value for the generalized sum.
+    ///
+    /// The reduce operations in the parallel \a transform_inclusive_scan
+    /// algorithm invoked with an execution policy object of type \a
+    /// sequenced_policy execute in sequential order in the calling thread.
+    ///
+    /// The reduce operations in the parallel \a transform_inclusive_scan
+    /// algorithm invoked with an execution policy object of type \a
+    /// parallel_policy or \a parallel_task_policy are permitted to execute
+    /// in an unordered fashion in unspecified threads, and indeterminately
+    /// sequenced within each thread.
+    ///
+    /// \returns  The \a transform_inclusive_scan algorithm returns a
+    ///           \a hpx::future<O> if
+    ///           the execution policy is of type
+    ///           \a sequenced_task_policy or
+    ///           \a parallel_task_policy and
+    ///           returns \a O otherwise.
+    ///           The \a transform_inclusive_scan algorithm returns the output
+    ///           iterator to the element in the destination range, one past
+    ///           the last element copied.
+    ///
+    /// \note   GENERALIZED_NONCOMMUTATIVE_SUM(op, a1, ..., aN) is defined as:
+    ///         * a1 when N is 1
+    ///         * op(GENERALIZED_NONCOMMUTATIVE_SUM(op, a1, ..., aK),
+    ///           GENERALIZED_NONCOMMUTATIVE_SUM(op, aM, ..., aN)
+    ///           where 1 < K+1 = M <= N.
+    ///
+    /// Neither \a conv nor \a op shall invalidate iterators or subranges, or
+    /// modify elements in the ranges [first,last) or [result,result +
+    /// (last - first)).
+    ///
+    /// The behavior of transform_inclusive_scan may be non-deterministic for
+    /// a non-associative predicate.
+    ///
+    template <typename ExPolicy, typename Rng,  typename O,
+        typename BinOp, typename UnOp, typename T>
+    typename parallel::util::detail::algorithm_result<ExPolicy, O>::type
+    transform_inclusive_scan(ExPolicy&& policy, Rng&& rng, O dest,
+        BinOp&& binary_op, UnOp&& unary_op, T init);
 
     // clang-format on
 }}    // namespace hpx::ranges

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/transform_inclusive_scan.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/transform_inclusive_scan.hpp
@@ -1,0 +1,695 @@
+//  Copyright (c) 2020 ETH Zurich
+//  Copyright (c) 2014 Grant Mercer
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+/// \file parallel/container_algorithms/transform_inclusive_scan.hpp
+
+#pragma once
+
+#if defined(DOXYGEN)
+
+namespace hpx { namespace ranges {
+    // clang-format off
+
+    ///////////////////////////////////////////////////////////////////////////
+    /// Assigns through each iterator \a i in [result, result + (last - first))
+    /// the value of
+    /// GENERALIZED_NONCOMMUTATIVE_SUM(binary_op, init, conv(*first), ...,
+    /// conv(*(first + (i - result) - 1))).
+    ///
+    /// \note   Complexity: O(\a last - \a first) applications of the
+    ///         predicates \a op and \a conv.
+    ///
+    /// \tparam InIter      The type of the source iterators used (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     input iterator.
+    /// \tparam Sent        The type of the source sentinel (deduced). This
+    ///                     sentinel type must be a sentinel for InIter.
+    /// \tparam OutIter     The type of the iterator representing the
+    ///                     destination range (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     output iterator.
+    /// \tparam Conv        The type of the unary function object used for
+    ///                     the conversion operation.
+    /// \tparam T           The type of the value to be used as initial (and
+    ///                     intermediate) values (deduced).
+    /// \tparam Op          The type of the binary function object used for
+    ///                     the reduction operation.
+    ///
+    /// \param first        Refers to the beginning of the sequence of elements
+    ///                     the algorithm will be applied to.
+    /// \param last         Refers to sentinel value denoting the end of the
+    ///                     sequence of elements the algorithm will be applied.
+    /// \param dest         Refers to the beginning of the destination range.
+    /// \param conv         Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements in the
+    ///                     sequence specified by [first, last). This is a
+    ///                     unary predicate. The signature of this predicate
+    ///                     should be equivalent to:
+    ///                     \code
+    ///                     R fun(const Type &a);
+    ///                     \endcode \n
+    ///                     The signature does not need to have const&, but
+    ///                     the function must not modify the objects passed to
+    ///                     it. The type \a Type must be such that an object of
+    ///                     type \a FwdIter1 can be dereferenced and then
+    ///                     implicitly converted to Type.
+    ///                     The type \a R must be such that an object of this
+    ///                     type can be implicitly converted to \a T.
+    /// \param init         The initial value for the generalized sum.
+    /// \param op           Specifies the function (or function object) which
+    ///                     will be invoked for each of the values of the input
+    ///                     sequence. This is a
+    ///                     binary predicate. The signature of this predicate
+    ///                     should be equivalent to:
+    ///                     \code
+    ///                     Ret fun(const Type1 &a, const Type1 &b);
+    ///                     \endcode \n
+    ///                     The signature does not need to have const&, but
+    ///                     the function must not modify the objects passed to
+    ///                     it.
+    ///                     The types \a Type1 and \a Ret must be
+    ///                     such that an object of a type as given by the input
+    ///                     sequence can be implicitly converted to any
+    ///                     of those types.
+    ///
+    /// The reduce operations in the parallel \a transform_inclusive_scan
+    /// algorithm invoked without an execution policy object execute in
+    /// sequential order in the calling thread.
+    ///
+    /// \returns  The \a transform_inclusive_scan algorithm returns a
+    ///           returns \a OutIter.
+    ///           The \a transform_inclusive_scan algorithm returns the output
+    ///           iterator to the element in the destination range, one past
+    ///           the last element copied.
+    ///
+    /// \note   GENERALIZED_NONCOMMUTATIVE_SUM(op, a1, ..., aN) is defined as:
+    ///         * a1 when N is 1
+    ///         * op(GENERALIZED_NONCOMMUTATIVE_SUM(op, a1, ..., aK),
+    ///           GENERALIZED_NONCOMMUTATIVE_SUM(op, aM, ..., aN)
+    ///           where 1 < K+1 = M <= N.
+    ///
+    /// Neither \a conv nor \a op shall invalidate iterators or subranges, or
+    /// modify elements in the ranges [first,last) or [result,result +
+    /// (last - first)).
+    ///
+    /// The behavior of transform_inclusive_scan may be non-deterministic for
+    /// a non-associative predicate.
+    ///
+    template <typename InIter, typename Sent, typename OutIter, typename T,
+        typename BinOp, typename UnOp>
+    OutIter transform_inclusive_scan(InIter first, Sent last, OutIter dest,
+        T init, BinOp&& binary_op, UnOp&& unary_op);
+
+    ///////////////////////////////////////////////////////////////////////////
+    /// Assigns through each iterator \a i in [result, result + (last - first))
+    /// the value of
+    /// GENERALIZED_NONCOMMUTATIVE_SUM(binary_op, init, conv(*first), ...,
+    /// conv(*(first + (i - result) - 1))).
+    ///
+    /// \note   Complexity: O(\a last - \a first) applications of the
+    ///         predicates \a op and \a conv.
+    ///
+    /// \tparam ExPolicy    The type of the execution policy to use (deduced).
+    ///                     It describes the manner in which the execution
+    ///                     of the algorithm may be parallelized and the manner
+    ///                     in which it executes the assignments.
+    /// \tparam FwdIter1    The type of the source iterators used (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     forward iterator.
+    /// \tparam Sent        The type of the source sentinel (deduced). This
+    ///                     sentinel type must be a sentinel for FwdIter.
+    /// \tparam FwdIter2    The type of the iterator representing the
+    ///                     destination range (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     forward iterator.
+    /// \tparam Conv        The type of the unary function object used for
+    ///                     the conversion operation.
+    /// \tparam T           The type of the value to be used as initial (and
+    ///                     intermediate) values (deduced).
+    /// \tparam Op          The type of the binary function object used for
+    ///                     the reduction operation.
+    ///
+    /// \param policy       The execution policy to use for the scheduling of
+    ///                     the iterations.
+    /// \param first        Refers to the beginning of the sequence of elements
+    ///                     the algorithm will be applied to.
+    /// \param last         Refers to sentinel value denoting the end of the
+    ///                     sequence of elements the algorithm will be applied.
+    /// \param dest         Refers to the beginning of the destination range.
+    /// \param conv         Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements in the
+    ///                     sequence specified by [first, last). This is a
+    ///                     unary predicate. The signature of this predicate
+    ///                     should be equivalent to:
+    ///                     \code
+    ///                     R fun(const Type &a);
+    ///                     \endcode \n
+    ///                     The signature does not need to have const&, but
+    ///                     the function must not modify the objects passed to
+    ///                     it. The type \a Type must be such that an object of
+    ///                     type \a FwdIter1 can be dereferenced and then
+    ///                     implicitly converted to Type.
+    ///                     The type \a R must be such that an object of this
+    ///                     type can be implicitly converted to \a T.
+    /// \param init         The initial value for the generalized sum.
+    /// \param op           Specifies the function (or function object) which
+    ///                     will be invoked for each of the values of the input
+    ///                     sequence. This is a
+    ///                     binary predicate. The signature of this predicate
+    ///                     should be equivalent to:
+    ///                     \code
+    ///                     Ret fun(const Type1 &a, const Type1 &b);
+    ///                     \endcode \n
+    ///                     The signature does not need to have const&, but
+    ///                     the function must not modify the objects passed to
+    ///                     it.
+    ///                     The types \a Type1 and \a Ret must be
+    ///                     such that an object of a type as given by the input
+    ///                     sequence can be implicitly converted to any
+    ///                     of those types.
+    ///
+    /// The reduce operations in the parallel \a transform_inclusive_scan
+    /// algorithm invoked with an execution policy object of type \a
+    /// sequenced_policy execute in sequential order in the calling thread.
+    ///
+    /// The reduce operations in the parallel \a transform_inclusive_scan
+    /// algorithm invoked with an execution policy object of type \a
+    /// parallel_policy or \a parallel_task_policy are permitted to execute
+    /// in an unordered fashion in unspecified threads, and indeterminately
+    /// sequenced within each thread.
+    ///
+    /// \returns  The \a transform_inclusive_scan algorithm returns a
+    ///           \a hpx::future<FwdIter2> if
+    ///           the execution policy is of type
+    ///           \a sequenced_task_policy or
+    ///           \a parallel_task_policy and
+    ///           returns \a FwdIter2 otherwise.
+    ///           The \a transform_inclusive_scan algorithm returns the output
+    ///           iterator to the element in the destination range, one past
+    ///           the last element copied.
+    ///
+    /// \note   GENERALIZED_NONCOMMUTATIVE_SUM(op, a1, ..., aN) is defined as:
+    ///         * a1 when N is 1
+    ///         * op(GENERALIZED_NONCOMMUTATIVE_SUM(op, a1, ..., aK),
+    ///           GENERALIZED_NONCOMMUTATIVE_SUM(op, aM, ..., aN)
+    ///           where 1 < K+1 = M <= N.
+    ///
+    /// Neither \a conv nor \a op shall invalidate iterators or subranges, or
+    /// modify elements in the ranges [first,last) or [result,result +
+    /// (last - first)).
+    ///
+    /// The behavior of transform_inclusive_scan may be non-deterministic for
+    /// a non-associative predicate.
+    ///
+    template <typename ExPolicy, typename FwdIter1, typename Sent,
+        typename FwdIter2, typename T, typename BinOp, typename UnOp>
+    typename parallel::util::detail::algorithm_result<ExPolicy, FwdIter2>::type
+    transform_inclusive_scan(ExPolicy&& policy, FwdIter1 first, Sent last,
+        FwdIter2 dest, T init, BinOp&& binary_op, UnOp&& unary_op);
+
+    ///////////////////////////////////////////////////////////////////////////
+    /// Assigns through each iterator \a i in [result, result + (last - first))
+    /// the value of
+    /// GENERALIZED_NONCOMMUTATIVE_SUM(binary_op, init, conv(*first), ...,
+    /// conv(*(first + (i - result) - 1))).
+    ///
+    /// \note   Complexity: O(\a last - \a first) applications of the
+    ///         predicates \a op and \a conv.
+    ///
+    /// \tparam Rng         The type of the source range used (deduced).
+    ///                     The iterators extracted from this range type must
+    ///                     meet the requirements of an input iterator.
+    /// \tparam O           The type of the iterator representing the
+    ///                     destination range (deduced).
+    /// \tparam Conv        The type of the unary function object used for
+    ///                     the conversion operation.
+    /// \tparam T           The type of the value to be used as initial (and
+    ///                     intermediate) values (deduced).
+    /// \tparam Op          The type of the binary function object used for
+    ///                     the reduction operation.
+    ///
+    /// \param rng          Refers to the sequence of elements the algorithm
+    ///                     will be applied to.
+    /// \param conv         Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements in the
+    ///                     sequence specified by [first, last). This is a
+    ///                     unary predicate. The signature of this predicate
+    ///                     should be equivalent to:
+    ///                     \code
+    ///                     R fun(const Type &a);
+    ///                     \endcode \n
+    ///                     The signature does not need to have const&, but
+    ///                     the function must not modify the objects passed to
+    ///                     it. The type \a Type must be such that an object of
+    ///                     type \a FwdIter1 can be dereferenced and then
+    ///                     implicitly converted to Type.
+    ///                     The type \a R must be such that an object of this
+    ///                     type can be implicitly converted to \a T.
+    /// \param init         The initial value for the generalized sum.
+    /// \param op           Specifies the function (or function object) which
+    ///                     will be invoked for each of the values of the input
+    ///                     sequence. This is a
+    ///                     binary predicate. The signature of this predicate
+    ///                     should be equivalent to:
+    ///                     \code
+    ///                     Ret fun(const Type1 &a, const Type1 &b);
+    ///                     \endcode \n
+    ///                     The signature does not need to have const&, but
+    ///                     the function must not modify the objects passed to
+    ///                     it.
+    ///                     The types \a Type1 and \a Ret must be
+    ///                     such that an object of a type as given by the input
+    ///                     sequence can be implicitly converted to any
+    ///                     of those types.
+    ///
+    /// The reduce operations in the parallel \a transform_inclusive_scan
+    /// algorithm invoked without an execution policy object execute in
+    /// sequential order in the calling thread.
+    ///
+    /// \returns  The \a transform_inclusive_scan algorithm returns a
+    ///           returns \a O.
+    ///           The \a transform_inclusive_scan algorithm returns the output
+    ///           iterator to the element in the destination range, one past
+    ///           the last element copied.
+    ///
+    /// \note   GENERALIZED_NONCOMMUTATIVE_SUM(op, a1, ..., aN) is defined as:
+    ///         * a1 when N is 1
+    ///         * op(GENERALIZED_NONCOMMUTATIVE_SUM(op, a1, ..., aK),
+    ///           GENERALIZED_NONCOMMUTATIVE_SUM(op, aM, ..., aN)
+    ///           where 1 < K+1 = M <= N.
+    ///
+    /// Neither \a conv nor \a op shall invalidate iterators or subranges, or
+    /// modify elements in the ranges [first,last) or [result,result +
+    /// (last - first)).
+    ///
+    /// The behavior of transform_inclusive_scan may be non-deterministic for
+    /// a non-associative predicate.
+    ///
+    template <typename Rng, typename O, typename T, typename BinOp,
+        typename UnOp>
+    O transform_inclusive_scan(Rng&& rng, O dest, T init, BinOp&& binary_op,
+        UnOp&& unary_op);
+
+    ///////////////////////////////////////////////////////////////////////////
+    /// Assigns through each iterator \a i in [result, result + (last - first))
+    /// the value of
+    /// GENERALIZED_NONCOMMUTATIVE_SUM(binary_op, init, conv(*first), ...,
+    /// conv(*(first + (i - result) - 1))).
+    ///
+    /// \note   Complexity: O(\a last - \a first) applications of the
+    ///         predicates \a op and \a conv.
+    ///
+    /// \tparam ExPolicy    The type of the execution policy to use (deduced).
+    ///                     It describes the manner in which the execution
+    ///                     of the algorithm may be parallelized and the manner
+    ///                     in which it executes the assignments.
+    /// \tparam Rng         The type of the source range used (deduced).
+    ///                     The iterators extracted from this range type must
+    ///                     meet the requirements of an forward iterator.
+    /// \tparam O           The type of the iterator representing the
+    ///                     destination range (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     forward iterator.
+    ///                     This iterator type must meet the requirements of an
+    ///                     forward iterator.
+    /// \tparam Conv        The type of the unary function object used for
+    ///                     the conversion operation.
+    /// \tparam T           The type of the value to be used as initial (and
+    ///                     intermediate) values (deduced).
+    /// \tparam Op          The type of the binary function object used for
+    ///                     the reduction operation.
+    ///
+    /// \param policy       The execution policy to use for the scheduling of
+    ///                     the iterations.
+    /// \param rng          Refers to the sequence of elements the algorithm
+    ///                     will be applied to.
+    /// \param dest         Refers to the beginning of the destination range.
+    /// \param conv         Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements in the
+    ///                     sequence specified by [first, last). This is a
+    ///                     unary predicate. The signature of this predicate
+    ///                     should be equivalent to:
+    ///                     \code
+    ///                     R fun(const Type &a);
+    ///                     \endcode \n
+    ///                     The signature does not need to have const&, but
+    ///                     the function must not modify the objects passed to
+    ///                     it. The type \a Type must be such that an object of
+    ///                     type \a FwdIter1 can be dereferenced and then
+    ///                     implicitly converted to Type.
+    ///                     The type \a R must be such that an object of this
+    ///                     type can be implicitly converted to \a T.
+    /// \param init         The initial value for the generalized sum.
+    /// \param op           Specifies the function (or function object) which
+    ///                     will be invoked for each of the values of the input
+    ///                     sequence. This is a
+    ///                     binary predicate. The signature of this predicate
+    ///                     should be equivalent to:
+    ///                     \code
+    ///                     Ret fun(const Type1 &a, const Type1 &b);
+    ///                     \endcode \n
+    ///                     The signature does not need to have const&, but
+    ///                     the function must not modify the objects passed to
+    ///                     it.
+    ///                     The types \a Type1 and \a Ret must be
+    ///                     such that an object of a type as given by the input
+    ///                     sequence can be implicitly converted to any
+    ///                     of those types.
+    ///
+    /// The reduce operations in the parallel \a transform_inclusive_scan
+    /// algorithm invoked with an execution policy object of type \a
+    /// sequenced_policy execute in sequential order in the calling thread.
+    ///
+    /// The reduce operations in the parallel \a transform_inclusive_scan
+    /// algorithm invoked with an execution policy object of type \a
+    /// parallel_policy or \a parallel_task_policy are permitted to execute
+    /// in an unordered fashion in unspecified threads, and indeterminately
+    /// sequenced within each thread.
+    ///
+    /// \returns  The \a transform_inclusive_scan algorithm returns a
+    ///           \a hpx::future<O> if
+    ///           the execution policy is of type
+    ///           \a sequenced_task_policy or
+    ///           \a parallel_task_policy and
+    ///           returns \a O otherwise.
+    ///           The \a transform_inclusive_scan algorithm returns the output
+    ///           iterator to the element in the destination range, one past
+    ///           the last element copied.
+    ///
+    /// \note   GENERALIZED_NONCOMMUTATIVE_SUM(op, a1, ..., aN) is defined as:
+    ///         * a1 when N is 1
+    ///         * op(GENERALIZED_NONCOMMUTATIVE_SUM(op, a1, ..., aK),
+    ///           GENERALIZED_NONCOMMUTATIVE_SUM(op, aM, ..., aN)
+    ///           where 1 < K+1 = M <= N.
+    ///
+    /// Neither \a conv nor \a op shall invalidate iterators or subranges, or
+    /// modify elements in the ranges [first,last) or [result,result +
+    /// (last - first)).
+    ///
+    /// The behavior of transform_inclusive_scan may be non-deterministic for
+    /// a non-associative predicate.
+    ///
+    template <typename ExPolicy, typename Rng,  typename O, typename T,
+        typename BinOp, typename UnOp>
+    typename parallel::util::detail::algorithm_result<ExPolicy, O>::type
+    transform_inclusive_scan(ExPolicy&& policy, Rng&& rng, O dest, T init,
+        BinOp&& binary_op, UnOp&& unary_op);
+
+    // clang-format on
+}}    // namespace hpx::ranges
+#else
+
+#include <hpx/config.hpp>
+#include <hpx/execution/algorithms/detail/predicates.hpp>
+#include <hpx/executors/execution_policy.hpp>
+#include <hpx/functional/tag_fallback_dispatch.hpp>
+#include <hpx/iterator_support/traits/is_iterator.hpp>
+#include <hpx/parallel/algorithms/transform_inclusive_scan.hpp>
+#include <hpx/parallel/util/detail/algorithm_result.hpp>
+#include <hpx/parallel/util/projection_identity.hpp>
+
+#include <algorithm>
+#include <cstddef>
+#include <iterator>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+namespace hpx { namespace ranges {
+    HPX_INLINE_CONSTEXPR_VARIABLE struct transform_inclusive_scan_t final
+      : hpx::functional::tag_fallback<transform_inclusive_scan_t>
+    {
+    private:
+        // clang-format off
+        template <typename InIter, typename Sent, typename OutIter,
+             typename BinOp, typename UnOp,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::traits::is_iterator<InIter>::value &&
+                hpx::traits::is_sentinel_for<Sent, InIter>::value &&
+                hpx::traits::is_iterator<OutIter>::value &&
+                hpx::is_invocable_v<UnOp,
+                    typename std::iterator_traits<InIter>::value_type> &&
+                hpx::is_invocable_v<BinOp,
+                    typename hpx::util::invoke_result<UnOp,
+                        typename std::iterator_traits<InIter>::value_type>::type,
+                    typename hpx::util::invoke_result<UnOp,
+                        typename std::iterator_traits<InIter>::value_type>::type
+                >
+            )>
+        // clang-format on
+        friend OutIter tag_fallback_dispatch(
+            hpx::ranges::transform_inclusive_scan_t, InIter first, Sent last,
+            OutIter dest, BinOp&& binary_op, UnOp&& unary_op)
+        {
+            static_assert(hpx::traits::is_input_iterator<InIter>::value,
+                "Requires at least input iterator.");
+            static_assert(hpx::traits::is_output_iterator<OutIter>::value,
+                "Requires at least output iterator.");
+
+            return hpx::parallel::v1::detail::transform_inclusive_scan<
+                OutIter>()
+                .call(hpx::execution::seq, first, last, dest,
+                    std::forward<UnOp>(unary_op),
+                    std::forward<BinOp>(binary_op));
+        }
+
+        // clang-format off
+        template <typename ExPolicy, typename FwdIter1, typename Sent,
+            typename FwdIter2, typename BinOp, typename UnOp,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::is_execution_policy<ExPolicy>::value &&
+                hpx::traits::is_iterator<FwdIter1>::value &&
+                hpx::traits::is_sentinel_for<Sent, FwdIter1>::value &&
+                hpx::traits::is_iterator<FwdIter2>::value &&
+                hpx::is_invocable_v<UnOp,
+                    typename std::iterator_traits<FwdIter1>::value_type> &&
+                hpx::is_invocable_v<BinOp,
+                    typename hpx::util::invoke_result<UnOp,
+                        typename std::iterator_traits<FwdIter1>::value_type>::type,
+                    typename hpx::util::invoke_result<UnOp,
+                        typename std::iterator_traits<FwdIter1>::value_type>::type
+                >
+            )>
+        // clang-format on
+        friend typename parallel::util::detail::algorithm_result<ExPolicy,
+            FwdIter2>::type
+        tag_fallback_dispatch(hpx::ranges::transform_inclusive_scan_t,
+            ExPolicy&& policy, FwdIter1 first, Sent last, FwdIter2 dest,
+            BinOp&& binary_op, UnOp&& unary_op)
+        {
+            static_assert(hpx::traits::is_forward_iterator<FwdIter1>::value,
+                "Requires at least forward iterator.");
+            static_assert(hpx::traits::is_forward_iterator<FwdIter2>::value,
+                "Requires at least forward iterator.");
+
+            return hpx::parallel::v1::detail::transform_inclusive_scan<
+                FwdIter2>()
+                .call(std::forward<ExPolicy>(policy), first, last, dest,
+                    std::forward<UnOp>(unary_op),
+                    std::forward<BinOp>(binary_op));
+        }
+
+        // clang-format off
+        template <typename Rng, typename O,
+            typename BinOp, typename UnOp,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::traits::is_range<Rng>::value &&
+                hpx::is_invocable_v<UnOp,
+                    typename hpx::traits::range_traits<Rng>::value_type> &&
+                hpx::is_invocable_v<BinOp,
+                    typename hpx::util::invoke_result<UnOp,
+                        typename hpx::traits::range_traits<Rng>::value_type>::type,
+                    typename hpx::util::invoke_result<UnOp,
+                        typename hpx::traits::range_traits<Rng>::value_type>::type
+                >
+            )>
+        // clang-format on
+        friend O tag_fallback_dispatch(hpx::ranges::transform_inclusive_scan_t,
+            Rng&& rng, O dest, BinOp&& binary_op, UnOp&& unary_op)
+        {
+            using iterator_type =
+                typename hpx::traits::range_traits<Rng>::iterator_type;
+
+            static_assert(hpx::traits::is_input_iterator<iterator_type>::value,
+                "Requires at least input iterator.");
+
+            return hpx::parallel::v1::detail::transform_inclusive_scan<O>()
+                .call(hpx::execution::seq, std::begin(rng), std::end(rng), dest,
+                    std::forward<UnOp>(unary_op),
+                    std::forward<BinOp>(binary_op));
+        }
+
+        // clang-format off
+        template <typename ExPolicy, typename Rng,  typename O,
+            typename BinOp, typename UnOp,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::is_execution_policy<ExPolicy>::value &&
+                hpx::traits::is_range<Rng>::value &&
+                hpx::is_invocable_v<UnOp,
+                    typename hpx::traits::range_traits<Rng>::value_type> &&
+                hpx::is_invocable_v<BinOp,
+                    typename hpx::util::invoke_result<UnOp,
+                        typename hpx::traits::range_traits<Rng>::value_type>::type,
+                    typename hpx::util::invoke_result<UnOp,
+                        typename hpx::traits::range_traits<Rng>::value_type>::type
+                >
+            )>
+        // clang-format on
+        friend
+            typename parallel::util::detail::algorithm_result<ExPolicy, O>::type
+            tag_fallback_dispatch(hpx::ranges::transform_inclusive_scan_t,
+                ExPolicy&& policy, Rng&& rng, O dest, BinOp&& binary_op,
+                UnOp&& unary_op)
+        {
+            using iterator_type =
+                typename hpx::traits::range_traits<Rng>::iterator_type;
+
+            static_assert(
+                hpx::traits::is_forward_iterator<iterator_type>::value,
+                "Requires at least forward iterator.");
+
+            return hpx::parallel::v1::detail::transform_inclusive_scan<O>()
+                .call(std::forward<ExPolicy>(policy), std::begin(rng),
+                    std::end(rng), dest, std::forward<UnOp>(unary_op),
+                    std::forward<BinOp>(binary_op));
+        }
+
+        template <typename InIter, typename Sent, typename OutIter,
+            typename BinOp, typename UnOp, typename T,
+            HPX_CONCEPT_REQUIRES_(hpx::traits::is_iterator<InIter>::value&&
+                    hpx::traits::is_sentinel_for<Sent, InIter>::value&&
+                        hpx::traits::is_iterator<
+                            OutIter>::value&& hpx::is_invocable_v<UnOp,
+                            typename std::iterator_traits<InIter>::value_type>&&
+                            hpx::is_invocable_v<BinOp,
+                                typename hpx::util::invoke_result<UnOp,
+                                    typename std::iterator_traits<
+                                        InIter>::value_type>::type,
+                                typename hpx::util::invoke_result<UnOp,
+                                    typename std::iterator_traits<
+                                        InIter>::value_type>::type>)>
+        // clang-format on
+        friend OutIter tag_fallback_dispatch(
+            hpx::ranges::transform_inclusive_scan_t, InIter first, Sent last,
+            OutIter dest, BinOp&& binary_op, UnOp&& unary_op, T init)
+        {
+            static_assert(hpx::traits::is_input_iterator<InIter>::value,
+                "Requires at least input iterator.");
+            static_assert(hpx::traits::is_output_iterator<OutIter>::value,
+                "Requires at least output iterator.");
+
+            return hpx::parallel::v1::detail::transform_inclusive_scan<
+                OutIter>()
+                .call(hpx::execution::seq, first, last, dest,
+                    std::forward<UnOp>(unary_op), std::move(init),
+                    std::forward<BinOp>(binary_op));
+        }
+
+        // clang-format off
+        template <typename ExPolicy, typename FwdIter1, typename Sent,
+            typename FwdIter2, typename BinOp, typename UnOp, typename T,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::is_execution_policy<ExPolicy>::value &&
+                hpx::traits::is_iterator<FwdIter1>::value &&
+                hpx::traits::is_sentinel_for<Sent, FwdIter1>::value &&
+                hpx::traits::is_iterator<FwdIter2>::value &&
+                hpx::is_invocable_v<UnOp,
+                    typename std::iterator_traits<FwdIter1>::value_type> &&
+                hpx::is_invocable_v<BinOp,
+                    typename hpx::util::invoke_result<UnOp,
+                        typename std::iterator_traits<FwdIter1>::value_type>::type,
+                    typename hpx::util::invoke_result<UnOp,
+                        typename std::iterator_traits<FwdIter1>::value_type>::type
+                >
+            )>
+        // clang-format on
+        friend typename parallel::util::detail::algorithm_result<ExPolicy,
+            FwdIter2>::type
+        tag_fallback_dispatch(hpx::ranges::transform_inclusive_scan_t,
+            ExPolicy&& policy, FwdIter1 first, Sent last, FwdIter2 dest,
+            BinOp&& binary_op, UnOp&& unary_op, T init)
+        {
+            static_assert(hpx::traits::is_forward_iterator<FwdIter1>::value,
+                "Requires at least forward iterator.");
+            static_assert(hpx::traits::is_forward_iterator<FwdIter2>::value,
+                "Requires at least forward iterator.");
+
+            return hpx::parallel::v1::detail::transform_inclusive_scan<
+                FwdIter2>()
+                .call(std::forward<ExPolicy>(policy), first, last, dest,
+                    std::forward<UnOp>(unary_op), std::move(init),
+                    std::forward<BinOp>(binary_op));
+        }
+
+        // clang-format off
+        template <typename Rng, typename O, typename BinOp,
+            typename UnOp, typename T,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::traits::is_range<Rng>::value &&
+                hpx::is_invocable_v<UnOp,
+                    typename hpx::traits::range_traits<Rng>::value_type> &&
+                hpx::is_invocable_v<BinOp,
+                    typename hpx::util::invoke_result<UnOp,
+                        typename hpx::traits::range_traits<Rng>::value_type>::type,
+                    typename hpx::util::invoke_result<UnOp,
+                        typename hpx::traits::range_traits<Rng>::value_type>::type
+                >
+            )>
+        // clang-format on
+        friend O tag_fallback_dispatch(hpx::ranges::transform_inclusive_scan_t,
+            Rng&& rng, O dest, BinOp&& binary_op, UnOp&& unary_op, T init)
+        {
+            using iterator_type =
+                typename hpx::traits::range_traits<Rng>::iterator_type;
+
+            static_assert(hpx::traits::is_input_iterator<iterator_type>::value,
+                "Requires at least input iterator.");
+
+            return hpx::parallel::v1::detail::transform_inclusive_scan<O>()
+                .call(hpx::execution::seq, std::begin(rng), std::end(rng), dest,
+                    std::forward<UnOp>(unary_op), std::move(init),
+                    std::forward<BinOp>(binary_op));
+        }
+
+        // clang-format off
+        template <typename ExPolicy, typename Rng,  typename O,
+            typename BinOp, typename UnOp, typename T,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::is_execution_policy<ExPolicy>::value &&
+                hpx::traits::is_range<Rng>::value &&
+                hpx::is_invocable_v<UnOp,
+                    typename hpx::traits::range_traits<Rng>::value_type> &&
+                hpx::is_invocable_v<BinOp,
+                    typename hpx::util::invoke_result<UnOp,
+                        typename hpx::traits::range_traits<Rng>::value_type>::type,
+                    typename hpx::util::invoke_result<UnOp,
+                        typename hpx::traits::range_traits<Rng>::value_type>::type
+                >
+            )>
+        // clang-format on
+        friend
+            typename parallel::util::detail::algorithm_result<ExPolicy, O>::type
+            tag_fallback_dispatch(hpx::ranges::transform_inclusive_scan_t,
+                ExPolicy&& policy, Rng&& rng, O dest, BinOp&& binary_op,
+                UnOp&& unary_op, T init)
+        {
+            using iterator_type =
+                typename hpx::traits::range_traits<Rng>::iterator_type;
+
+            static_assert(
+                hpx::traits::is_forward_iterator<iterator_type>::value,
+                "Requires at least forward iterator.");
+
+            return hpx::parallel::v1::detail::transform_inclusive_scan<O>()
+                .call(std::forward<ExPolicy>(policy), std::begin(rng),
+                    std::end(rng), dest, std::forward<UnOp>(unary_op),
+                    std::move(init), std::forward<BinOp>(binary_op));
+        }
+    } transform_inclusive_scan{};
+}}    // namespace hpx::ranges
+
+#endif

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/transform_inclusive_scan.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/transform_inclusive_scan.hpp
@@ -78,9 +78,10 @@ namespace hpx { namespace ranges {
     /// algorithm invoked without an execution policy object execute in
     /// sequential order in the calling thread.
     ///
-    /// \returns  The \a transform_inclusive_scan algorithm returns a
-    ///           returns \a OutIter.
-    ///           The \a transform_inclusive_scan algorithm returns the output
+    /// \returns  The \a transform_inclusive_scan algorithm returns \a
+    ///           transform_inclusive_scan_result<InIter, OutIter>.
+    ///           The \a transform_inclusive_scan algorithm returns an input
+    ///           iterator to the point denoted by the sentinel and an output
     ///           iterator to the element in the destination range, one past
     ///           the last element copied.
     ///
@@ -99,8 +100,9 @@ namespace hpx { namespace ranges {
     ///
     template <typename InIter, typename Sent, typename OutIter,
         typename BinOp, typename UnOp>
-    OutIter transform_inclusive_scan(InIter first, Sent last, OutIter dest,
-        BinOp&& binary_op, UnOp&& unary_op);
+    transform_inclusive_scan_result<InIter, OutIter> transform_inclusive_scan(
+        InIter first, Sent last, OutIter dest, BinOp&& binary_op,
+        UnOp&& unary_op);
 
     ///////////////////////////////////////////////////////////////////////////
     /// Assigns through each iterator \a i in [result, result + (last - first))
@@ -178,12 +180,15 @@ namespace hpx { namespace ranges {
     /// sequenced within each thread.
     ///
     /// \returns  The \a transform_inclusive_scan algorithm returns a
-    ///           \a hpx::future<FwdIter2> if
+    ///           \a hpx::future<transform_inclusive_result<FwdIter1,
+    ///           FwdIter2>> if
     ///           the execution policy is of type
     ///           \a sequenced_task_policy or
     ///           \a parallel_task_policy and
-    ///           returns \a FwdIter2 otherwise.
-    ///           The \a transform_inclusive_scan algorithm returns the output
+    ///           returns \a transform_inclusive_result<FwdIter1,
+    ///           FwdIter2> otherwise.
+    ///           The \a transform_inclusive_scan algorithm returns an input
+    ///           iterator to the point denoted by the sentinel and an output
     ///           iterator to the element in the destination range, one past
     ///           the last element copied.
     ///
@@ -202,7 +207,8 @@ namespace hpx { namespace ranges {
     ///
     template <typename ExPolicy, typename FwdIter1, typename Sent,
         typename FwdIter2, typename BinOp, typename UnOp>
-    typename parallel::util::detail::algorithm_result<ExPolicy, FwdIter2>::type
+    typename parallel::util::detail::algorithm_result<ExPolicy,
+        transform_inclusive_result<FwdIter1, FwdIter2>>::type
     transform_inclusive_scan(ExPolicy&& policy, FwdIter1 first, Sent last,
         FwdIter2 dest, BinOp&& binary_op, UnOp&& unary_op);
 
@@ -263,8 +269,10 @@ namespace hpx { namespace ranges {
     /// sequential order in the calling thread.
     ///
     /// \returns  The \a transform_inclusive_scan algorithm returns a
-    ///           returns \a O.
-    ///           The \a transform_inclusive_scan algorithm returns the output
+    ///           returns \a transform_inclusive_scan_result<
+    ///           traits::range_iterator_t<Rng>, O>.
+    ///           The \a transform_inclusive_scan algorithm returns an input
+    ///           iterator to one past the end of the range and an output
     ///           iterator to the element in the destination range, one past
     ///           the last element copied.
     ///
@@ -283,7 +291,8 @@ namespace hpx { namespace ranges {
     ///
     template <typename Rng, typename O, typename BinOp,
         typename UnOp>
-    O transform_inclusive_scan(Rng&& rng, O dest, BinOp&& binary_op,
+    transform_inclusive_scan_result<traits::range_iterator_t<Rng>, O>
+    transform_inclusive_scan(Rng&& rng, O dest, BinOp&& binary_op,
         UnOp&& unary_op);
 
     ///////////////////////////////////////////////////////////////////////////
@@ -360,12 +369,15 @@ namespace hpx { namespace ranges {
     /// sequenced within each thread.
     ///
     /// \returns  The \a transform_inclusive_scan algorithm returns a
-    ///           \a hpx::future<O> if
+    ///           \a hpx::future<transform_inclusive_scan_result<
+    ///           traits::range_iterator_t<Rng>, O>> if
     ///           the execution policy is of type
     ///           \a sequenced_task_policy or
     ///           \a parallel_task_policy and
-    ///           returns \a O otherwise.
-    ///           The \a transform_inclusive_scan algorithm returns the output
+    ///           returns \a transform_inclusive_scan_result<
+    ///           traits::range_iterator_t<Rng>, O> otherwise.
+    ///           The \a transform_inclusive_scan algorithm returns an input
+    ///           iterator to one past the end of the range and an output
     ///           iterator to the element in the destination range, one past
     ///           the last element copied.
     ///
@@ -384,7 +396,8 @@ namespace hpx { namespace ranges {
     ///
     template <typename ExPolicy, typename Rng,  typename O,
         typename BinOp, typename UnOp>
-    typename parallel::util::detail::algorithm_result<ExPolicy, O>::type
+    typename parallel::util::detail::algorithm_result<ExPolicy,
+        transform_inclusive_scan_result<traits::range_iterator_t<Rng>, O>>::type
     transform_inclusive_scan(ExPolicy&& policy, Rng&& rng, O dest,
         BinOp&& binary_op, UnOp&& unary_op);
 
@@ -454,9 +467,10 @@ namespace hpx { namespace ranges {
     /// algorithm invoked without an execution policy object execute in
     /// sequential order in the calling thread.
     ///
-    /// \returns  The \a transform_inclusive_scan algorithm returns a
-    ///           returns \a OutIter.
-    ///           The \a transform_inclusive_scan algorithm returns the output
+    /// \returns  The \a transform_inclusive_scan algorithm returns \a
+    ///           transform_inclusive_scan_result<InIter, OutIter>.
+    ///           The \a transform_inclusive_scan algorithm returns an input
+    ///           iterator to the point denoted by the sentinel and an output
     ///           iterator to the element in the destination range, one past
     ///           the last element copied.
     ///
@@ -475,8 +489,9 @@ namespace hpx { namespace ranges {
     ///
     template <typename InIter, typename Sent, typename OutIter,
         typename BinOp, typename UnOp, typename T>
-    OutIter transform_inclusive_scan(InIter first, Sent last, OutIter dest,
-        BinOp&& binary_op, UnOp&& unary_op, T init);
+    transform_inclusive_scan_result<InIter, OutIter> transform_inclusive_scan(
+        InIter first, Sent last, OutIter dest, BinOp&& binary_op,
+        UnOp&& unary_op, T init);
 
     ///////////////////////////////////////////////////////////////////////////
     /// Assigns through each iterator \a i in [result, result + (last - first))
@@ -557,12 +572,15 @@ namespace hpx { namespace ranges {
     /// sequenced within each thread.
     ///
     /// \returns  The \a transform_inclusive_scan algorithm returns a
-    ///           \a hpx::future<FwdIter2> if
+    ///           \a hpx::future<transform_inclusive_result<FwdIter1,
+    ///           FwdIter2>> if
     ///           the execution policy is of type
     ///           \a sequenced_task_policy or
     ///           \a parallel_task_policy and
-    ///           returns \a FwdIter2 otherwise.
-    ///           The \a transform_inclusive_scan algorithm returns the output
+    ///           returns \a transform_inclusive_result<FwdIter1,
+    ///           FwdIter2> otherwise.
+    ///           The \a transform_inclusive_scan algorithm returns an input
+    ///           iterator to the point denoted by the sentinel and an output
     ///           iterator to the element in the destination range, one past
     ///           the last element copied.
     ///
@@ -581,7 +599,8 @@ namespace hpx { namespace ranges {
     ///
     template <typename ExPolicy, typename FwdIter1, typename Sent,
         typename FwdIter2, typename BinOp, typename UnOp, typename T>
-    typename parallel::util::detail::algorithm_result<ExPolicy, FwdIter2>::type
+    typename parallel::util::detail::algorithm_result<ExPolicy,
+        transform_inclusive_result<FwdIter1, FwdIter2>>::type
     transform_inclusive_scan(ExPolicy&& policy, FwdIter1 first, Sent last,
         FwdIter2 dest, BinOp&& binary_op, UnOp&& unary_op, T init);
 
@@ -645,8 +664,10 @@ namespace hpx { namespace ranges {
     /// sequential order in the calling thread.
     ///
     /// \returns  The \a transform_inclusive_scan algorithm returns a
-    ///           returns \a O.
-    ///           The \a transform_inclusive_scan algorithm returns the output
+    ///           returns \a transform_inclusive_scan_result<
+    ///           traits::range_iterator_t<Rng>, O>.
+    ///           The \a transform_inclusive_scan algorithm returns an input
+    ///           iterator to one past the end of the range and an output
     ///           iterator to the element in the destination range, one past
     ///           the last element copied.
     ///
@@ -665,7 +686,8 @@ namespace hpx { namespace ranges {
     ///
     template <typename Rng, typename O, typename BinOp,
         typename UnOp, typename T>
-    O transform_inclusive_scan(Rng&& rng, O dest, BinOp&& binary_op,
+    transform_inclusive_scan_result<traits::range_iterator_t<Rng>, O>
+    transform_inclusive_scan(Rng&& rng, O dest, BinOp&& binary_op,
         UnOp&& unary_op, T init);
 
     ///////////////////////////////////////////////////////////////////////////
@@ -745,12 +767,15 @@ namespace hpx { namespace ranges {
     /// sequenced within each thread.
     ///
     /// \returns  The \a transform_inclusive_scan algorithm returns a
-    ///           \a hpx::future<O> if
+    ///           \a hpx::future<transform_inclusive_scan_result<
+    ///           traits::range_iterator_t<Rng>, O>> if
     ///           the execution policy is of type
     ///           \a sequenced_task_policy or
     ///           \a parallel_task_policy and
-    ///           returns \a O otherwise.
-    ///           The \a transform_inclusive_scan algorithm returns the output
+    ///           returns \a transform_inclusive_scan_result<
+    ///           traits::range_iterator_t<Rng>, O> otherwise.
+    ///           The \a transform_inclusive_scan algorithm returns an input
+    ///           iterator to one past the end of the range and an output
     ///           iterator to the element in the destination range, one past
     ///           the last element copied.
     ///
@@ -769,7 +794,8 @@ namespace hpx { namespace ranges {
     ///
     template <typename ExPolicy, typename Rng,  typename O,
         typename BinOp, typename UnOp, typename T>
-    typename parallel::util::detail::algorithm_result<ExPolicy, O>::type
+    typename parallel::util::detail::algorithm_result<ExPolicy,
+        transform_inclusive_scan_result<traits::range_iterator_t<Rng>, O>>::type
     transform_inclusive_scan(ExPolicy&& policy, Rng&& rng, O dest,
         BinOp&& binary_op, UnOp&& unary_op, T init);
 
@@ -794,6 +820,10 @@ namespace hpx { namespace ranges {
 #include <vector>
 
 namespace hpx { namespace ranges {
+
+    template <typename I, typename O>
+    using transform_inclusive_scan_result = parallel::util::in_out_result<I, O>;
+
     HPX_INLINE_CONSTEXPR_VARIABLE struct transform_inclusive_scan_t final
       : hpx::functional::tag_fallback<transform_inclusive_scan_t>
     {
@@ -802,30 +832,34 @@ namespace hpx { namespace ranges {
         template <typename InIter, typename Sent, typename OutIter,
              typename BinOp, typename UnOp,
             HPX_CONCEPT_REQUIRES_(
-                hpx::traits::is_iterator<InIter>::value &&
+                hpx::traits::is_iterator_v<InIter> &&
                 hpx::traits::is_sentinel_for<Sent, InIter>::value &&
-                hpx::traits::is_iterator<OutIter>::value &&
+                hpx::traits::is_iterator_v<OutIter> &&
                 hpx::is_invocable_v<UnOp,
                     typename std::iterator_traits<InIter>::value_type> &&
                 hpx::is_invocable_v<BinOp,
-                    typename hpx::util::invoke_result<UnOp,
-                        typename std::iterator_traits<InIter>::value_type>::type,
-                    typename hpx::util::invoke_result<UnOp,
-                        typename std::iterator_traits<InIter>::value_type>::type
+                    typename hpx::util::invoke_result_t<UnOp,
+                        typename std::iterator_traits<InIter>::value_type>,
+                    typename hpx::util::invoke_result_t<UnOp,
+                        typename std::iterator_traits<InIter>::value_type>
                 >
             )>
         // clang-format on
-        friend OutIter tag_fallback_dispatch(
-            hpx::ranges::transform_inclusive_scan_t, InIter first, Sent last,
-            OutIter dest, BinOp&& binary_op, UnOp&& unary_op)
+        friend transform_inclusive_scan_result<InIter, OutIter>
+        tag_fallback_dispatch(hpx::ranges::transform_inclusive_scan_t,
+            InIter first, Sent last, OutIter dest, BinOp&& binary_op,
+            UnOp&& unary_op)
         {
-            static_assert(hpx::traits::is_input_iterator<InIter>::value,
+            static_assert(hpx::traits::is_input_iterator_v<InIter>,
                 "Requires at least input iterator.");
-            static_assert(hpx::traits::is_output_iterator<OutIter>::value,
+            static_assert(hpx::traits::is_output_iterator_v<OutIter>,
                 "Requires at least output iterator.");
 
+            using result_type =
+                transform_inclusive_scan_result<InIter, OutIter>;
+
             return hpx::parallel::v1::detail::transform_inclusive_scan<
-                OutIter>()
+                result_type>()
                 .call(hpx::execution::seq, first, last, dest,
                     std::forward<UnOp>(unary_op),
                     std::forward<BinOp>(binary_op));
@@ -836,32 +870,35 @@ namespace hpx { namespace ranges {
             typename FwdIter2, typename BinOp, typename UnOp,
             HPX_CONCEPT_REQUIRES_(
                 hpx::is_execution_policy<ExPolicy>::value &&
-                hpx::traits::is_iterator<FwdIter1>::value &&
+                hpx::traits::is_iterator_v<FwdIter1> &&
                 hpx::traits::is_sentinel_for<Sent, FwdIter1>::value &&
-                hpx::traits::is_iterator<FwdIter2>::value &&
+                hpx::traits::is_iterator_v<FwdIter2> &&
                 hpx::is_invocable_v<UnOp,
                     typename std::iterator_traits<FwdIter1>::value_type> &&
                 hpx::is_invocable_v<BinOp,
-                    typename hpx::util::invoke_result<UnOp,
-                        typename std::iterator_traits<FwdIter1>::value_type>::type,
-                    typename hpx::util::invoke_result<UnOp,
-                        typename std::iterator_traits<FwdIter1>::value_type>::type
+                    typename hpx::util::invoke_result_t<UnOp,
+                        typename std::iterator_traits<FwdIter1>::value_type>,
+                    typename hpx::util::invoke_result_t<UnOp,
+                        typename std::iterator_traits<FwdIter1>::value_type>
                 >
             )>
         // clang-format on
         friend typename parallel::util::detail::algorithm_result<ExPolicy,
-            FwdIter2>::type
+            transform_inclusive_scan_result<FwdIter1, FwdIter2>>::type
         tag_fallback_dispatch(hpx::ranges::transform_inclusive_scan_t,
             ExPolicy&& policy, FwdIter1 first, Sent last, FwdIter2 dest,
             BinOp&& binary_op, UnOp&& unary_op)
         {
-            static_assert(hpx::traits::is_forward_iterator<FwdIter1>::value,
+            static_assert(hpx::traits::is_forward_iterator_v<FwdIter1>,
                 "Requires at least forward iterator.");
-            static_assert(hpx::traits::is_forward_iterator<FwdIter2>::value,
+            static_assert(hpx::traits::is_forward_iterator_v<FwdIter2>,
                 "Requires at least forward iterator.");
 
+            using result_type =
+                transform_inclusive_scan_result<FwdIter1, FwdIter2>;
+
             return hpx::parallel::v1::detail::transform_inclusive_scan<
-                FwdIter2>()
+                result_type>()
                 .call(std::forward<ExPolicy>(policy), first, last, dest,
                     std::forward<UnOp>(unary_op),
                     std::forward<BinOp>(binary_op));
@@ -875,23 +912,29 @@ namespace hpx { namespace ranges {
                 hpx::is_invocable_v<UnOp,
                     typename hpx::traits::range_traits<Rng>::value_type> &&
                 hpx::is_invocable_v<BinOp,
-                    typename hpx::util::invoke_result<UnOp,
-                        typename hpx::traits::range_traits<Rng>::value_type>::type,
-                    typename hpx::util::invoke_result<UnOp,
-                        typename hpx::traits::range_traits<Rng>::value_type>::type
+                    typename hpx::util::invoke_result_t<UnOp,
+                        typename hpx::traits::range_traits<Rng>::value_type>,
+                    typename hpx::util::invoke_result_t<UnOp,
+                        typename hpx::traits::range_traits<Rng>::value_type>
                 >
             )>
         // clang-format on
-        friend O tag_fallback_dispatch(hpx::ranges::transform_inclusive_scan_t,
+        friend transform_inclusive_scan_result<
+            hpx::traits::range_iterator_t<Rng>, O>
+        tag_fallback_dispatch(hpx::ranges::transform_inclusive_scan_t,
             Rng&& rng, O dest, BinOp&& binary_op, UnOp&& unary_op)
         {
             using iterator_type =
                 typename hpx::traits::range_traits<Rng>::iterator_type;
 
-            static_assert(hpx::traits::is_input_iterator<iterator_type>::value,
+            static_assert(hpx::traits::is_input_iterator_v<iterator_type>,
                 "Requires at least input iterator.");
 
-            return hpx::parallel::v1::detail::transform_inclusive_scan<O>()
+            using result_type =
+                transform_inclusive_scan_result<iterator_type, O>;
+
+            return hpx::parallel::v1::detail::transform_inclusive_scan<
+                result_type>()
                 .call(hpx::execution::seq, std::begin(rng), std::end(rng), dest,
                     std::forward<UnOp>(unary_op),
                     std::forward<BinOp>(binary_op));
@@ -906,58 +949,68 @@ namespace hpx { namespace ranges {
                 hpx::is_invocable_v<UnOp,
                     typename hpx::traits::range_traits<Rng>::value_type> &&
                 hpx::is_invocable_v<BinOp,
-                    typename hpx::util::invoke_result<UnOp,
-                        typename hpx::traits::range_traits<Rng>::value_type>::type,
-                    typename hpx::util::invoke_result<UnOp,
-                        typename hpx::traits::range_traits<Rng>::value_type>::type
+                    typename hpx::util::invoke_result_t<UnOp,
+                        typename hpx::traits::range_traits<Rng>::value_type>,
+                    typename hpx::util::invoke_result_t<UnOp,
+                        typename hpx::traits::range_traits<Rng>::value_type>
                 >
             )>
         // clang-format on
-        friend
-            typename parallel::util::detail::algorithm_result<ExPolicy, O>::type
-            tag_fallback_dispatch(hpx::ranges::transform_inclusive_scan_t,
-                ExPolicy&& policy, Rng&& rng, O dest, BinOp&& binary_op,
-                UnOp&& unary_op)
+        friend typename parallel::util::detail::algorithm_result<ExPolicy,
+            transform_inclusive_scan_result<hpx::traits::range_iterator_t<Rng>,
+                O>>::type
+        tag_fallback_dispatch(hpx::ranges::transform_inclusive_scan_t,
+            ExPolicy&& policy, Rng&& rng, O dest, BinOp&& binary_op,
+            UnOp&& unary_op)
         {
             using iterator_type =
                 typename hpx::traits::range_traits<Rng>::iterator_type;
 
-            static_assert(
-                hpx::traits::is_forward_iterator<iterator_type>::value,
+            static_assert(hpx::traits::is_forward_iterator_v<iterator_type>,
                 "Requires at least forward iterator.");
 
-            return hpx::parallel::v1::detail::transform_inclusive_scan<O>()
+            using result_type =
+                transform_inclusive_scan_result<iterator_type, O>;
+
+            return hpx::parallel::v1::detail::transform_inclusive_scan<
+                result_type>()
                 .call(std::forward<ExPolicy>(policy), std::begin(rng),
                     std::end(rng), dest, std::forward<UnOp>(unary_op),
                     std::forward<BinOp>(binary_op));
         }
 
+        // clang-format off
         template <typename InIter, typename Sent, typename OutIter,
             typename BinOp, typename UnOp, typename T,
-            HPX_CONCEPT_REQUIRES_(hpx::traits::is_iterator<InIter>::value&&
-                    hpx::traits::is_sentinel_for<Sent, InIter>::value&&
-                        hpx::traits::is_iterator<
-                            OutIter>::value&& hpx::is_invocable_v<UnOp,
-                            typename std::iterator_traits<InIter>::value_type>&&
-                            hpx::is_invocable_v<BinOp,
-                                typename hpx::util::invoke_result<UnOp,
-                                    typename std::iterator_traits<
-                                        InIter>::value_type>::type,
-                                typename hpx::util::invoke_result<UnOp,
-                                    typename std::iterator_traits<
-                                        InIter>::value_type>::type>)>
+            HPX_CONCEPT_REQUIRES_(
+                hpx::traits::is_iterator_v<InIter> &&
+                hpx::traits::is_sentinel_for<Sent, InIter>::value &&
+                hpx::traits::is_iterator_v<OutIter> &&
+                hpx::is_invocable_v<UnOp,
+                    typename std::iterator_traits<InIter>::value_type> &&
+                hpx::is_invocable_v<BinOp,
+                    typename hpx::util::invoke_result_t<UnOp,
+                        typename std::iterator_traits<InIter>::value_type>,
+                    typename hpx::util::invoke_result_t<UnOp,
+                        typename std::iterator_traits<InIter>::value_type>
+                >
+            )>
         // clang-format on
-        friend OutIter tag_fallback_dispatch(
-            hpx::ranges::transform_inclusive_scan_t, InIter first, Sent last,
-            OutIter dest, BinOp&& binary_op, UnOp&& unary_op, T init)
+        friend transform_inclusive_scan_result<InIter, OutIter>
+        tag_fallback_dispatch(hpx::ranges::transform_inclusive_scan_t,
+            InIter first, Sent last, OutIter dest, BinOp&& binary_op,
+            UnOp&& unary_op, T init)
         {
-            static_assert(hpx::traits::is_input_iterator<InIter>::value,
+            static_assert(hpx::traits::is_input_iterator_v<InIter>,
                 "Requires at least input iterator.");
-            static_assert(hpx::traits::is_output_iterator<OutIter>::value,
+            static_assert(hpx::traits::is_output_iterator_v<OutIter>,
                 "Requires at least output iterator.");
 
+            using result_type =
+                transform_inclusive_scan_result<InIter, OutIter>;
+
             return hpx::parallel::v1::detail::transform_inclusive_scan<
-                OutIter>()
+                result_type>()
                 .call(hpx::execution::seq, first, last, dest,
                     std::forward<UnOp>(unary_op), std::move(init),
                     std::forward<BinOp>(binary_op));
@@ -968,32 +1021,35 @@ namespace hpx { namespace ranges {
             typename FwdIter2, typename BinOp, typename UnOp, typename T,
             HPX_CONCEPT_REQUIRES_(
                 hpx::is_execution_policy<ExPolicy>::value &&
-                hpx::traits::is_iterator<FwdIter1>::value &&
+                hpx::traits::is_iterator_v<FwdIter1> &&
                 hpx::traits::is_sentinel_for<Sent, FwdIter1>::value &&
-                hpx::traits::is_iterator<FwdIter2>::value &&
+                hpx::traits::is_iterator_v<FwdIter2> &&
                 hpx::is_invocable_v<UnOp,
                     typename std::iterator_traits<FwdIter1>::value_type> &&
                 hpx::is_invocable_v<BinOp,
-                    typename hpx::util::invoke_result<UnOp,
-                        typename std::iterator_traits<FwdIter1>::value_type>::type,
-                    typename hpx::util::invoke_result<UnOp,
-                        typename std::iterator_traits<FwdIter1>::value_type>::type
+                    typename hpx::util::invoke_result_t<UnOp,
+                        typename std::iterator_traits<FwdIter1>::value_type>,
+                    typename hpx::util::invoke_result_t<UnOp,
+                        typename std::iterator_traits<FwdIter1>::value_type>
                 >
             )>
         // clang-format on
         friend typename parallel::util::detail::algorithm_result<ExPolicy,
-            FwdIter2>::type
+            transform_inclusive_scan_result<FwdIter1, FwdIter2>>::type
         tag_fallback_dispatch(hpx::ranges::transform_inclusive_scan_t,
             ExPolicy&& policy, FwdIter1 first, Sent last, FwdIter2 dest,
             BinOp&& binary_op, UnOp&& unary_op, T init)
         {
-            static_assert(hpx::traits::is_forward_iterator<FwdIter1>::value,
+            static_assert(hpx::traits::is_forward_iterator_v<FwdIter1>,
                 "Requires at least forward iterator.");
-            static_assert(hpx::traits::is_forward_iterator<FwdIter2>::value,
+            static_assert(hpx::traits::is_forward_iterator_v<FwdIter2>,
                 "Requires at least forward iterator.");
 
+            using result_type =
+                transform_inclusive_scan_result<FwdIter1, FwdIter2>;
+
             return hpx::parallel::v1::detail::transform_inclusive_scan<
-                FwdIter2>()
+                result_type>()
                 .call(std::forward<ExPolicy>(policy), first, last, dest,
                     std::forward<UnOp>(unary_op), std::move(init),
                     std::forward<BinOp>(binary_op));
@@ -1007,23 +1063,29 @@ namespace hpx { namespace ranges {
                 hpx::is_invocable_v<UnOp,
                     typename hpx::traits::range_traits<Rng>::value_type> &&
                 hpx::is_invocable_v<BinOp,
-                    typename hpx::util::invoke_result<UnOp,
-                        typename hpx::traits::range_traits<Rng>::value_type>::type,
-                    typename hpx::util::invoke_result<UnOp,
-                        typename hpx::traits::range_traits<Rng>::value_type>::type
+                    typename hpx::util::invoke_result_t<UnOp,
+                        typename hpx::traits::range_traits<Rng>::value_type>,
+                    typename hpx::util::invoke_result_t<UnOp,
+                        typename hpx::traits::range_traits<Rng>::value_type>
                 >
             )>
         // clang-format on
-        friend O tag_fallback_dispatch(hpx::ranges::transform_inclusive_scan_t,
+        friend transform_inclusive_scan_result<
+            hpx::traits::range_iterator_t<Rng>, O>
+        tag_fallback_dispatch(hpx::ranges::transform_inclusive_scan_t,
             Rng&& rng, O dest, BinOp&& binary_op, UnOp&& unary_op, T init)
         {
             using iterator_type =
                 typename hpx::traits::range_traits<Rng>::iterator_type;
 
-            static_assert(hpx::traits::is_input_iterator<iterator_type>::value,
+            static_assert(hpx::traits::is_input_iterator_v<iterator_type>,
                 "Requires at least input iterator.");
 
-            return hpx::parallel::v1::detail::transform_inclusive_scan<O>()
+            using result_type =
+                transform_inclusive_scan_result<iterator_type, O>;
+
+            return hpx::parallel::v1::detail::transform_inclusive_scan<
+                result_type>()
                 .call(hpx::execution::seq, std::begin(rng), std::end(rng), dest,
                     std::forward<UnOp>(unary_op), std::move(init),
                     std::forward<BinOp>(binary_op));
@@ -1038,27 +1100,31 @@ namespace hpx { namespace ranges {
                 hpx::is_invocable_v<UnOp,
                     typename hpx::traits::range_traits<Rng>::value_type> &&
                 hpx::is_invocable_v<BinOp,
-                    typename hpx::util::invoke_result<UnOp,
-                        typename hpx::traits::range_traits<Rng>::value_type>::type,
-                    typename hpx::util::invoke_result<UnOp,
-                        typename hpx::traits::range_traits<Rng>::value_type>::type
+                    typename hpx::util::invoke_result_t<UnOp,
+                        typename hpx::traits::range_traits<Rng>::value_type>,
+                    typename hpx::util::invoke_result_t<UnOp,
+                        typename hpx::traits::range_traits<Rng>::value_type>
                 >
             )>
         // clang-format on
-        friend
-            typename parallel::util::detail::algorithm_result<ExPolicy, O>::type
-            tag_fallback_dispatch(hpx::ranges::transform_inclusive_scan_t,
-                ExPolicy&& policy, Rng&& rng, O dest, BinOp&& binary_op,
-                UnOp&& unary_op, T init)
+        friend typename parallel::util::detail::algorithm_result<ExPolicy,
+            transform_inclusive_scan_result<hpx::traits::range_iterator_t<Rng>,
+                O>>::type
+        tag_fallback_dispatch(hpx::ranges::transform_inclusive_scan_t,
+            ExPolicy&& policy, Rng&& rng, O dest, BinOp&& binary_op,
+            UnOp&& unary_op, T init)
         {
             using iterator_type =
                 typename hpx::traits::range_traits<Rng>::iterator_type;
 
-            static_assert(
-                hpx::traits::is_forward_iterator<iterator_type>::value,
+            static_assert(hpx::traits::is_forward_iterator_v<iterator_type>,
                 "Requires at least forward iterator.");
 
-            return hpx::parallel::v1::detail::transform_inclusive_scan<O>()
+            using result_type =
+                transform_inclusive_scan_result<iterator_type, O>;
+
+            return hpx::parallel::v1::detail::transform_inclusive_scan<
+                result_type>()
                 .call(std::forward<ExPolicy>(policy), std::begin(rng),
                     std::end(rng), dest, std::forward<UnOp>(unary_op),
                     std::move(init), std::forward<BinOp>(binary_op));

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/transform_inclusive_scan.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/transform_inclusive_scan.hpp
@@ -1,5 +1,6 @@
 //  Copyright (c) 2020 ETH Zurich
 //  Copyright (c) 2014 Grant Mercer
+//  Copyright (c) 2021 Akhil J Nair
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying

--- a/libs/parallelism/algorithms/tests/regressions/scan_different_inits.cpp
+++ b/libs/parallelism/algorithms/tests/regressions/scan_different_inits.cpp
@@ -37,7 +37,7 @@ void test_zero()
         100, [](int bar, int baz) { return bar + baz; });
     Iter i_exc_mult = hpx::exclusive_scan(policy, a.begin(), a.end(), e.begin(),
         10, [](int bar, int baz) { return bar * baz; });
-    Iter i_transform_inc = hpx::parallel::transform_inclusive_scan(
+    Iter i_transform_inc = hpx::transform_inclusive_scan(
         policy, a.begin(), a.end(), f.begin(),
         [](int bar, int baz) { return 2 * bar + 2 * baz; },
         [](int foo) { return foo - 3; }, 10);
@@ -71,7 +71,7 @@ void test_async_zero()
         d.begin(), 100, [](int bar, int baz) { return bar + baz; });
     Fut_Iter f_exc_mult = hpx::exclusive_scan(policy, a.begin(), a.end(),
         e.begin(), 10, [](int bar, int baz) { return bar * baz; });
-    Fut_Iter f_transform_inc = hpx::parallel::transform_inclusive_scan(
+    Fut_Iter f_transform_inc = hpx::transform_inclusive_scan(
         policy, a.begin(), a.end(), f.begin(),
         [](int bar, int baz) { return 2 * bar + 2 * baz; },
         [](int foo) { return foo - 3; }, 10);
@@ -109,7 +109,7 @@ void test_one(std::vector<int> a)
         hpx::exclusive_scan(policy, a.begin(), a.end(), d.begin(), 10, fun_add);
     Iter f_exc_mult = hpx::exclusive_scan(
         policy, a.begin(), a.end(), e.begin(), 10, fun_mult);
-    Iter f_transform_inc = hpx::parallel::transform_inclusive_scan(
+    Iter f_transform_inc = hpx::transform_inclusive_scan(
         policy, a.begin(), a.end(), f.begin(), fun_add, fun_conv, 10);
     Iter f_transform_exc = hpx::transform_exclusive_scan(
         policy, a.begin(), a.end(), g.begin(), 10, fun_add, fun_conv);
@@ -166,7 +166,7 @@ void test_async_one(std::vector<int> a)
         hpx::exclusive_scan(policy, a.begin(), a.end(), d.begin(), 10, fun_add);
     Fut_Iter f_exc_mult = hpx::exclusive_scan(
         policy, a.begin(), a.end(), e.begin(), 10, fun_mult);
-    Fut_Iter f_transform_inc = hpx::parallel::transform_inclusive_scan(
+    Fut_Iter f_transform_inc = hpx::transform_inclusive_scan(
         policy, a.begin(), a.end(), f.begin(), fun_add, fun_conv, 10);
     Fut_Iter f_transform_exc = hpx::transform_exclusive_scan(
         policy, a.begin(), a.end(), g.begin(), 10, fun_add, fun_conv);

--- a/libs/parallelism/algorithms/tests/regressions/transform_inclusive_scan_4786.cpp
+++ b/libs/parallelism/algorithms/tests/regressions/transform_inclusive_scan_4786.cpp
@@ -36,7 +36,7 @@ int hpx_main()
     std::vector<int> test{1, 10, 100, 1000};
     std::vector<Integer> output(test.size());
 
-    hpx::parallel::transform_inclusive_scan(
+    hpx::transform_inclusive_scan(
         hpx::execution::par, test.cbegin(), test.cend(), output.begin(),
         [](Integer acc, Integer xs) -> Integer {
             return Integer{acc.integer + xs.integer};

--- a/libs/parallelism/algorithms/tests/regressions/transform_inclusive_scan_4787.cpp
+++ b/libs/parallelism/algorithms/tests/regressions/transform_inclusive_scan_4787.cpp
@@ -30,7 +30,7 @@ int hpx_main()
         Elem{1, true}, Elem{3, false}, Elem{2, true}, Elem{4, false}};
     std::vector<Elem> output(test.size());
 
-    hpx::parallel::transform_inclusive_scan(
+    hpx::transform_inclusive_scan(
         hpx::execution::par, test.cbegin(), test.cend(), output.begin(),
         [](Elem left, Elem right) -> Elem {
             if (right.begin)

--- a/libs/parallelism/algorithms/tests/unit/algorithms/transform_inclusive_scan.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/transform_inclusive_scan.cpp
@@ -18,6 +18,31 @@
 #include "test_utils.hpp"
 
 ///////////////////////////////////////////////////////////////////////////////
+template <typename IteratorTag>
+void test_transform_inclusive_scan1(IteratorTag)
+{
+    typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+
+    std::vector<std::size_t> c(10007);
+    std::vector<std::size_t> d(c.size());
+    std::fill(std::begin(c), std::end(c), std::size_t(1));
+
+    std::size_t const val(0);
+    auto op = [](std::size_t v1, std::size_t v2) { return v1 + v2; };
+    auto conv = [](std::size_t val) { return 2 * val; };
+
+    hpx::transform_inclusive_scan(iterator(std::begin(c)),
+        iterator(std::end(c)), std::begin(d), op, conv, val);
+
+    // verify values
+    std::vector<std::size_t> e(c.size());
+    hpx::parallel::v1::detail::sequential_transform_inclusive_scan(
+        std::begin(c), std::end(c), std::begin(e), conv, val, op);
+
+    HPX_TEST(std::equal(std::begin(d), std::end(d), std::begin(e)));
+}
+
 template <typename ExPolicy, typename IteratorTag>
 void test_transform_inclusive_scan1(ExPolicy policy, IteratorTag)
 {
@@ -35,7 +60,7 @@ void test_transform_inclusive_scan1(ExPolicy policy, IteratorTag)
     auto op = [](std::size_t v1, std::size_t v2) { return v1 + v2; };
     auto conv = [](std::size_t val) { return 2 * val; };
 
-    hpx::parallel::transform_inclusive_scan(policy, iterator(std::begin(c)),
+    hpx::transform_inclusive_scan(policy, iterator(std::begin(c)),
         iterator(std::end(c)), std::begin(d), op, conv, val);
 
     // verify values
@@ -69,7 +94,7 @@ void test_transform_inclusive_scan1_async(ExPolicy p, IteratorTag)
     auto conv = [](std::size_t val) { return 2 * val; };
 
     hpx::future<void> fut =
-        hpx::parallel::transform_inclusive_scan(p, iterator(std::begin(c)),
+        hpx::transform_inclusive_scan(p, iterator(std::begin(c)),
             iterator(std::end(c)), std::begin(d), op, conv, val);
     fut.wait();
 
@@ -94,6 +119,7 @@ void test_transform_inclusive_scan1()
 {
     using namespace hpx::execution;
 
+    test_transform_inclusive_scan1(IteratorTag());
     test_transform_inclusive_scan1(seq, IteratorTag());
     test_transform_inclusive_scan1(par, IteratorTag());
     test_transform_inclusive_scan1(par_unseq, IteratorTag());
@@ -109,6 +135,30 @@ void transform_inclusive_scan_test1()
 }
 
 ///////////////////////////////////////////////////////////////////////////////
+template <typename IteratorTag>
+void test_transform_inclusive_scan2(IteratorTag)
+{
+    typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+
+    std::vector<std::size_t> c(10007);
+    std::vector<std::size_t> d(c.size());
+    std::fill(std::begin(c), std::end(c), std::size_t(1));
+
+    auto op = [](std::size_t v1, std::size_t v2) { return v1 + v2; };
+    auto conv = [](std::size_t val) { return 2 * val; };
+
+    hpx::transform_inclusive_scan(iterator(std::begin(c)),
+        iterator(std::end(c)), std::begin(d), op, conv);
+
+    // verify values
+    std::vector<std::size_t> e(c.size());
+    hpx::parallel::v1::detail::sequential_transform_inclusive_scan_noinit(
+        std::begin(c), std::end(c), std::begin(e), conv, op);
+
+    HPX_TEST(std::equal(std::begin(d), std::end(d), std::begin(e)));
+}
+
 template <typename ExPolicy, typename IteratorTag>
 void test_transform_inclusive_scan2(ExPolicy policy, IteratorTag)
 {
@@ -125,7 +175,7 @@ void test_transform_inclusive_scan2(ExPolicy policy, IteratorTag)
     auto op = [](std::size_t v1, std::size_t v2) { return v1 + v2; };
     auto conv = [](std::size_t val) { return 2 * val; };
 
-    hpx::parallel::transform_inclusive_scan(policy, iterator(std::begin(c)),
+    hpx::transform_inclusive_scan(policy, iterator(std::begin(c)),
         iterator(std::end(c)), std::begin(d), op, conv);
 
     // verify values
@@ -158,7 +208,7 @@ void test_transform_inclusive_scan2_async(ExPolicy p, IteratorTag)
     auto conv = [](std::size_t val) { return 2 * val; };
 
     hpx::future<void> fut =
-        hpx::parallel::transform_inclusive_scan(p, iterator(std::begin(c)),
+        hpx::transform_inclusive_scan(p, iterator(std::begin(c)),
             iterator(std::end(c)), std::begin(d), op, conv);
     fut.wait();
 
@@ -183,6 +233,7 @@ void test_transform_inclusive_scan2()
 {
     using namespace hpx::execution;
 
+    test_transform_inclusive_scan2(IteratorTag());
     test_transform_inclusive_scan2(seq, IteratorTag());
     test_transform_inclusive_scan2(par, IteratorTag());
     test_transform_inclusive_scan2(par_unseq, IteratorTag());
@@ -214,7 +265,7 @@ void test_transform_inclusive_scan_exception(ExPolicy policy, IteratorTag)
     bool caught_exception = false;
     try
     {
-        hpx::parallel::transform_inclusive_scan(
+        hpx::transform_inclusive_scan(
             policy, iterator(std::begin(c)), iterator(std::end(c)),
             std::begin(d),
             [](std::size_t v1, std::size_t v2) {
@@ -251,7 +302,7 @@ void test_transform_inclusive_scan_exception_async(ExPolicy p, IteratorTag)
     bool returned_from_algorithm = false;
     try
     {
-        hpx::future<void> f = hpx::parallel::transform_inclusive_scan(
+        hpx::future<void> f = hpx::transform_inclusive_scan(
             p, iterator(std::begin(c)), iterator(std::end(c)), std::begin(d),
             [](std::size_t v1, std::size_t v2) {
                 return throw std::runtime_error("test"), v1 + v2;
@@ -315,7 +366,7 @@ void test_transform_inclusive_scan_bad_alloc(ExPolicy policy, IteratorTag)
     bool caught_exception = false;
     try
     {
-        hpx::parallel::transform_inclusive_scan(
+        hpx::transform_inclusive_scan(
             policy, iterator(std::begin(c)), iterator(std::end(c)),
             std::begin(d),
             [](std::size_t v1, std::size_t v2) {
@@ -351,7 +402,7 @@ void test_transform_inclusive_scan_bad_alloc_async(ExPolicy p, IteratorTag)
     bool returned_from_algorithm = false;
     try
     {
-        hpx::future<void> f = hpx::parallel::transform_inclusive_scan(
+        hpx::future<void> f = hpx::transform_inclusive_scan(
             p, iterator(std::begin(c)), iterator(std::end(c)), std::begin(d),
             [](std::size_t v1, std::size_t v2) {
                 return throw std::bad_alloc(), v1 + v2;

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/CMakeLists.txt
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/CMakeLists.txt
@@ -93,6 +93,7 @@ set(tests
     transform_range2
     transform_range_binary2
     transform_exclusive_scan_range
+    transform_inclusive_scan_range
     transform_reduce_binary_bad_alloc_range
     transform_reduce_binary_exception_range
     transform_reduce_binary_range

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/transform_inclusive_scan_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/transform_inclusive_scan_range.cpp
@@ -1,5 +1,6 @@
 //  Copyright (c) 2018 Christopher Ogle
 //  Copyright (c) 2020 Hartmut Kaiser
+//  Copyright (c) 2021 Akhil J Nair
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/transform_inclusive_scan_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/transform_inclusive_scan_range.cpp
@@ -1,0 +1,236 @@
+//  Copyright (c) 2018 Christopher Ogle
+//  Copyright (c) 2020 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/iterator_support/tests/iter_sent.hpp>
+#include <hpx/local/init.hpp>
+#include <hpx/modules/testing.hpp>
+#include <hpx/parallel/container_algorithms/transform_inclusive_scan.hpp>
+
+#include <algorithm>
+#include <cstddef>
+#include <iostream>
+#include <iterator>
+#include <random>
+#include <string>
+#include <unordered_set>
+#include <vector>
+
+#include "test_utils.hpp"
+
+////////////////////////////////////////////////////////////////////////////
+unsigned int seed;
+std::mt19937 gen;
+std::uniform_int_distribution<> dis(1, 10007);
+
+template <typename IteratorTag>
+void test_transform_inclusive_scan_sent(IteratorTag)
+{
+    auto end_len = dis(gen);
+    std::vector<std::size_t> c(10007);
+    std::vector<std::size_t> d(end_len);
+    std::vector<std::size_t> e(end_len);
+    std::fill(std::begin(c), std::begin(c) + end_len, std::size_t(1));
+    c[end_len] = 2;
+
+    std::size_t const val(0);
+    auto op = [](std::size_t v1, std::size_t v2) { return v1 + v2; };
+    auto conv = [](std::size_t val) { return 2 * val; };
+
+    hpx::ranges::transform_inclusive_scan(
+        std::begin(c), sentinel<std::size_t>{2}, std::begin(d), op, conv, val);
+    hpx::ranges::transform_inclusive_scan(
+        std::begin(c), sentinel<std::size_t>{2}, std::begin(e), op, conv);
+
+    // verify values
+    std::vector<std::size_t> f(end_len);
+    hpx::parallel::v1::detail::sequential_transform_inclusive_scan(
+        std::begin(c), std::begin(c) + end_len, std::begin(f), conv, val, op);
+
+    HPX_TEST(std::equal(std::begin(d), std::end(d), std::begin(f)));
+    HPX_TEST(std::equal(std::begin(e), std::end(e), std::begin(f)));
+}
+
+template <typename ExPolicy, typename IteratorTag>
+void test_transform_inclusive_scan_sent(ExPolicy policy, IteratorTag)
+{
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
+
+    auto end_len = dis(gen);
+    std::vector<std::size_t> c(10007);
+    std::vector<std::size_t> d(end_len);
+    std::vector<std::size_t> e(end_len);
+    std::fill(std::begin(c), std::begin(c) + end_len, std::size_t(1));
+    c[end_len] = 2;
+
+    std::size_t const val(0);
+    auto op = [](std::size_t v1, std::size_t v2) { return v1 + v2; };
+    auto conv = [](std::size_t val) { return 2 * val; };
+
+    hpx::ranges::transform_inclusive_scan(policy, std::begin(c),
+        sentinel<std::size_t>{2}, std::begin(d), op, conv, val);
+    hpx::ranges::transform_inclusive_scan(policy, std::begin(c),
+        sentinel<std::size_t>{2}, std::begin(e), op, conv);
+
+    // verify values
+    std::vector<std::size_t> f(end_len);
+    hpx::parallel::v1::detail::sequential_transform_inclusive_scan(
+        std::begin(c), std::begin(c) + end_len, std::begin(f), conv, val, op);
+
+    HPX_TEST(std::equal(std::begin(d), std::end(d), std::begin(f)));
+    HPX_TEST(std::equal(std::begin(e), std::end(e), std::begin(f)));
+}
+
+template <typename IteratorTag>
+void test_transform_inclusive_scan(IteratorTag)
+{
+    std::vector<std::size_t> c(10007);
+    std::vector<std::size_t> d(c.size());
+    std::vector<std::size_t> e(c.size());
+    std::fill(std::begin(c), std::end(c), std::size_t(1));
+
+    std::size_t const val(0);
+    auto op = [](std::size_t v1, std::size_t v2) { return v1 + v2; };
+    auto conv = [](std::size_t val) { return 2 * val; };
+
+    hpx::ranges::transform_inclusive_scan(c, std::begin(d), op, conv, val);
+    hpx::ranges::transform_inclusive_scan(c, std::begin(e), op, conv);
+
+    // verify values
+    std::vector<std::size_t> f(c.size());
+    hpx::parallel::v1::detail::sequential_transform_inclusive_scan(
+        std::begin(c), std::end(c), std::begin(f), conv, val, op);
+
+    HPX_TEST(std::equal(std::begin(d), std::end(d), std::begin(f)));
+    HPX_TEST(std::equal(std::begin(e), std::end(e), std::begin(f)));
+}
+
+template <typename ExPolicy, typename IteratorTag>
+void test_transform_inclusive_scan(ExPolicy policy, IteratorTag)
+{
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
+
+    std::vector<std::size_t> c(10007);
+    std::vector<std::size_t> d(c.size());
+    std::vector<std::size_t> e(c.size());
+    std::fill(std::begin(c), std::end(c), std::size_t(1));
+
+    std::size_t const val(0);
+    auto op = [](std::size_t v1, std::size_t v2) { return v1 + v2; };
+    auto conv = [](std::size_t val) { return 2 * val; };
+
+    hpx::ranges::transform_inclusive_scan(
+        policy, c, std::begin(d), op, conv, val);
+    hpx::ranges::transform_inclusive_scan(policy, c, std::begin(e), op, conv);
+
+    // verify values
+    std::vector<std::size_t> f(c.size());
+    hpx::parallel::v1::detail::sequential_transform_inclusive_scan(
+        std::begin(c), std::end(c), std::begin(f), conv, val, op);
+
+    HPX_TEST(std::equal(std::begin(d), std::end(d), std::begin(f)));
+    HPX_TEST(std::equal(std::begin(e), std::end(e), std::begin(f)));
+}
+
+template <typename ExPolicy, typename IteratorTag>
+void test_transform_inclusive_scan_async(ExPolicy policy, IteratorTag)
+{
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
+
+    std::vector<std::size_t> c(10007);
+    std::vector<std::size_t> d(c.size());
+    std::vector<std::size_t> e(c.size());
+    std::fill(std::begin(c), std::end(c), std::size_t(1));
+
+    std::size_t const val(0);
+    auto op = [](std::size_t v1, std::size_t v2) { return v1 + v2; };
+    auto conv = [](std::size_t val) { return 2 * val; };
+
+    hpx::future<void> fut = hpx::ranges::transform_inclusive_scan(
+        policy, c, std::begin(d), op, conv, val);
+    fut.wait();
+
+    hpx::future<void> fut1 = hpx::ranges::transform_inclusive_scan(
+        policy, c, std::begin(e), op, conv);
+    fut1.wait();
+
+    // verify values
+    std::vector<std::size_t> f(c.size());
+    hpx::parallel::v1::detail::sequential_transform_inclusive_scan(
+        std::begin(c), std::end(c), std::begin(f), conv, val, op);
+
+    HPX_TEST(std::equal(std::begin(d), std::end(d), std::begin(f)));
+    HPX_TEST(std::equal(std::begin(e), std::end(e), std::begin(f)));
+}
+
+template <typename IteratorTag>
+void test_transform_inclusive_scan()
+{
+    using namespace hpx::execution;
+
+    test_transform_inclusive_scan(IteratorTag());
+    test_transform_inclusive_scan(seq, IteratorTag());
+    test_transform_inclusive_scan(par, IteratorTag());
+    test_transform_inclusive_scan(par_unseq, IteratorTag());
+
+    test_transform_inclusive_scan_async(seq(task), IteratorTag());
+    test_transform_inclusive_scan_async(par(task), IteratorTag());
+
+    test_transform_inclusive_scan_sent(IteratorTag());
+    test_transform_inclusive_scan_sent(seq, IteratorTag());
+    test_transform_inclusive_scan_sent(par, IteratorTag());
+    test_transform_inclusive_scan_sent(par_unseq, IteratorTag());
+}
+
+void transform_inclusive_scan_test()
+{
+    test_transform_inclusive_scan<std::random_access_iterator_tag>();
+    test_transform_inclusive_scan<std::forward_iterator_tag>();
+}
+
+////////////////////////////////////////////////////////////////////////////
+int hpx_main(hpx::program_options::variables_map& vm)
+{
+    unsigned int seed1 = (unsigned int) std::time(nullptr);
+    if (vm.count("seed"))
+        seed1 = vm["seed"].as<unsigned int>();
+
+    std::cout << "using seed: " << seed1 << std::endl;
+    std::srand(seed1);
+
+    seed = seed1;
+    gen = std::mt19937(seed);
+
+    transform_inclusive_scan_test();
+    return hpx::local::finalize();
+}
+
+int main(int argc, char* argv[])
+{
+    // add command line option which controls the random number generator seed
+    using namespace hpx::program_options;
+    options_description desc_commandline(
+        "Usage: " HPX_APPLICATION_STRING " [options]");
+
+    desc_commandline.add_options()("seed,s", value<unsigned int>(),
+        "the random number generator seed to use for this run");
+
+    // By default this test should run on all available cores
+    std::vector<std::string> const cfg = {"hpx.os_threads=all"};
+
+    // Initialize and run HPX
+    hpx::local::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::local::init(hpx_main, argc, argv, init_args), 0,
+        "HPX main exited with non-zero status");
+
+    return hpx::util::report_errors();
+}

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/transform_inclusive_scan_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/transform_inclusive_scan_range.cpp
@@ -41,10 +41,16 @@ void test_transform_inclusive_scan_sent(IteratorTag)
     auto op = [](std::size_t v1, std::size_t v2) { return v1 + v2; };
     auto conv = [](std::size_t val) { return 2 * val; };
 
-    hpx::ranges::transform_inclusive_scan(
+    auto res1 = hpx::ranges::transform_inclusive_scan(
         std::begin(c), sentinel<std::size_t>{2}, std::begin(d), op, conv, val);
-    hpx::ranges::transform_inclusive_scan(
+    auto res2 = hpx::ranges::transform_inclusive_scan(
         std::begin(c), sentinel<std::size_t>{2}, std::begin(e), op, conv);
+
+    HPX_TEST(res1.in == std::begin(c) + end_len);
+    HPX_TEST(res1.out == std::end(d));
+
+    HPX_TEST(res2.in == std::begin(c) + end_len);
+    HPX_TEST(res2.out == std::end(e));
 
     // verify values
     std::vector<std::size_t> f(end_len);
@@ -72,10 +78,16 @@ void test_transform_inclusive_scan_sent(ExPolicy policy, IteratorTag)
     auto op = [](std::size_t v1, std::size_t v2) { return v1 + v2; };
     auto conv = [](std::size_t val) { return 2 * val; };
 
-    hpx::ranges::transform_inclusive_scan(policy, std::begin(c),
+    auto res1 = hpx::ranges::transform_inclusive_scan(policy, std::begin(c),
         sentinel<std::size_t>{2}, std::begin(d), op, conv, val);
-    hpx::ranges::transform_inclusive_scan(policy, std::begin(c),
+    auto res2 = hpx::ranges::transform_inclusive_scan(policy, std::begin(c),
         sentinel<std::size_t>{2}, std::begin(e), op, conv);
+
+    HPX_TEST(res1.in == std::begin(c) + end_len);
+    HPX_TEST(res1.out == std::end(d));
+
+    HPX_TEST(res2.in == std::begin(c) + end_len);
+    HPX_TEST(res2.out == std::end(e));
 
     // verify values
     std::vector<std::size_t> f(end_len);
@@ -98,8 +110,16 @@ void test_transform_inclusive_scan(IteratorTag)
     auto op = [](std::size_t v1, std::size_t v2) { return v1 + v2; };
     auto conv = [](std::size_t val) { return 2 * val; };
 
-    hpx::ranges::transform_inclusive_scan(c, std::begin(d), op, conv, val);
-    hpx::ranges::transform_inclusive_scan(c, std::begin(e), op, conv);
+    auto res1 =
+        hpx::ranges::transform_inclusive_scan(c, std::begin(d), op, conv, val);
+    auto res2 =
+        hpx::ranges::transform_inclusive_scan(c, std::begin(e), op, conv);
+
+    HPX_TEST(res1.in == std::end(c));
+    HPX_TEST(res1.out == std::end(d));
+
+    HPX_TEST(res2.in == std::end(c));
+    HPX_TEST(res2.out == std::end(e));
 
     // verify values
     std::vector<std::size_t> f(c.size());
@@ -125,9 +145,16 @@ void test_transform_inclusive_scan(ExPolicy policy, IteratorTag)
     auto op = [](std::size_t v1, std::size_t v2) { return v1 + v2; };
     auto conv = [](std::size_t val) { return 2 * val; };
 
-    hpx::ranges::transform_inclusive_scan(
+    auto res1 = hpx::ranges::transform_inclusive_scan(
         policy, c, std::begin(d), op, conv, val);
-    hpx::ranges::transform_inclusive_scan(policy, c, std::begin(e), op, conv);
+    auto res2 = hpx::ranges::transform_inclusive_scan(
+        policy, c, std::begin(e), op, conv);
+
+    HPX_TEST(res1.in == std::end(c));
+    HPX_TEST(res1.out == std::end(d));
+
+    HPX_TEST(res2.in == std::end(c));
+    HPX_TEST(res2.out == std::end(e));
 
     // verify values
     std::vector<std::size_t> f(c.size());


### PR DESCRIPTION
Adapted transform_inclusive_scan to C++ 20 and added container overloads. (range and sentinel). Added container tests. Seperated segmented overloads.

## Any background context you want to provide?
Issue #4822
Issue #3646
Issue #1668
Issue #5156