### PR TITLE
Improve performance of Spinlocks

### DIFF
--- a/libs/core/synchronization/include/hpx/synchronization/spinlock.hpp
+++ b/libs/core/synchronization/include/hpx/synchronization/spinlock.hpp
@@ -72,11 +72,11 @@ namespace hpx { namespace lcos { namespace local {
             //      The above order can be changed arbitrarily but
             //      the nature of execution will still remain the
             //      same.
-            while (is_locked() || !acquire_lock())
+            do
             {
                 util::yield_while([this] { return is_locked(); },
                     "hpx::lcos::local::spinlock::lock");
-            }
+            } while (!acquire_lock());
 
             HPX_ITT_SYNC_ACQUIRED(this);
             util::register_lock(this);

--- a/libs/core/synchronization/include/hpx/synchronization/spinlock.hpp
+++ b/libs/core/synchronization/include/hpx/synchronization/spinlock.hpp
@@ -4,6 +4,7 @@
 //  Copyright (c) 2014 Thomas Heller
 //  Copyright (c) 2008 Peter Dimov
 //  Copyright (c) 2018 Patrick Diehl
+//  Copyright (c) 2021 Nikunj Gupta
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying

--- a/libs/core/thread_support/include/hpx/thread_support/spinlock.hpp
+++ b/libs/core/thread_support/include/hpx/thread_support/spinlock.hpp
@@ -45,17 +45,17 @@ namespace hpx { namespace util { namespace detail {
 
         void lock() noexcept
         {
+            // Optimistically assume the lock is free on the first try
+            if (try_lock())
+                return;
+
+            // Wait for lock to be released without generating cache misses
+            // Similar implementation to hpx::lcos::local::spinlock
             unsigned k = 0;
             do
             {
-                // Wait for lock to be released without generating cache misses
-                // Similar implementation to hpx::lcos::local::spinlock
-                if (try_lock())
-                    return;
-
                 yield_k(k++);
-
-            } while (true);
+            } while (!try_lock());
         }
 
         HPX_FORCEINLINE void unlock() noexcept

--- a/libs/core/thread_support/include/hpx/thread_support/spinlock.hpp
+++ b/libs/core/thread_support/include/hpx/thread_support/spinlock.hpp
@@ -45,17 +45,13 @@ namespace hpx { namespace util { namespace detail {
 
         void lock() noexcept
         {
-            // Optimistically assume the lock is free on the first try
-            if (try_lock())
-                return;
-
             // Wait for lock to be released without generating cache misses
             // Similar implementation to hpx::lcos::local::spinlock
             unsigned k = 0;
-            do
+            while (!try_lock())
             {
                 yield_k(k++);
-            } while (!try_lock());
+            }
         }
 
         HPX_FORCEINLINE void unlock() noexcept


### PR DESCRIPTION
The current implementation of spinlocks uses atomic exchanges on every loop iteration that can cause excess contention due to cache coherence policies within the CPU. This will lead to overwhelming traffic on the bus reducing the performance of the locks. The backoff through yield does reduce contention but we can still do better in performance.

I have mitigated this by first checking if the lock can be acquired by loading the value to cache and then spinning on it every iteration. This reduces the contention from every iteration to iterations where the lock has been released by another thread. The improvements will be insignificant for low contention situations (probably an improvement of a couple of nanoseconds) but should be observable for very high contention situations.
