### PR TITLE
Use more verbose names in sender algorithms

### DIFF
--- a/libs/parallelism/execution/include/hpx/execution/algorithms/detach.hpp
+++ b/libs/parallelism/execution/include/hpx/execution/algorithms/detach.hpp
@@ -30,15 +30,15 @@
 
 namespace hpx { namespace execution { namespace experimental {
     namespace detail {
-        template <typename S, typename Allocator>
+        template <typename Sender, typename Allocator>
         struct operation_state_holder
         {
             struct detach_receiver
             {
-                hpx::intrusive_ptr<operation_state_holder> os;
+                hpx::intrusive_ptr<operation_state_holder> op_state;
 
-                template <typename E>
-                    HPX_NORETURN void set_error(E&&) && noexcept
+                template <typename Error>
+                    HPX_NORETURN void set_error(Error&&) && noexcept
                 {
                     HPX_ASSERT_MSG(false,
                         "set_error was called on the receiver of detach, "
@@ -50,13 +50,13 @@ namespace hpx { namespace execution { namespace experimental {
 
                 void set_done() && noexcept
                 {
-                    os.reset();
+                    op_state.reset();
                 };
 
                 template <typename... Ts>
                     void set_value(Ts&&...) && noexcept
                 {
-                    os.reset();
+                    op_state.reset();
                 }
             };
 
@@ -66,18 +66,21 @@ namespace hpx { namespace execution { namespace experimental {
             allocator_type alloc;
             hpx::util::atomic_count count{0};
 
-            using operation_state_type = connect_result_t<S, detach_receiver>;
-            std::decay_t<operation_state_type> os;
+            using operation_state_type =
+                connect_result_t<Sender, detach_receiver>;
+            std::decay_t<operation_state_type> op_state;
 
         public:
-            template <typename S_,
-                typename = std::enable_if_t<!std::is_same<std::decay_t<S_>,
+            template <typename Sender_,
+                typename = std::enable_if_t<!std::is_same<std::decay_t<Sender_>,
                     operation_state_holder>::value>>
-            explicit operation_state_holder(S_&& s, allocator_type const& alloc)
+            explicit operation_state_holder(
+                Sender_&& sender, allocator_type const& alloc)
               : alloc(alloc)
-              , os(connect(std::forward<S_>(s), detach_receiver{this}))
+              , op_state(connect(
+                    std::forward<Sender_>(sender), detach_receiver{this}))
             {
-                start(os);
+                start(op_state);
             }
 
         private:
@@ -105,31 +108,32 @@ namespace hpx { namespace execution { namespace experimental {
     {
     private:
         // clang-format off
-        template <typename S,
+        template <typename Sender,
             typename Allocator = hpx::util::internal_allocator<>,
             HPX_CONCEPT_REQUIRES_(
-                is_sender_v<S> &&
+                is_sender_v<Sender> &&
                 hpx::traits::is_allocator_v<Allocator>
             )>
         // clang-format on
         friend constexpr HPX_FORCEINLINE void tag_fallback_dispatch(
-            detach_t, S&& s, Allocator const& a = Allocator{})
+            detach_t, Sender&& sender, Allocator const& allocator = Allocator{})
         {
             using allocator_type = Allocator;
             using operation_state_type =
-                detail::operation_state_holder<S, Allocator>;
+                detail::operation_state_holder<Sender, Allocator>;
             using other_allocator = typename std::allocator_traits<
                 allocator_type>::template rebind_alloc<operation_state_type>;
             using allocator_traits = std::allocator_traits<other_allocator>;
             using unique_ptr = std::unique_ptr<operation_state_type,
                 util::allocator_deleter<other_allocator>>;
 
-            other_allocator alloc(a);
+            other_allocator alloc(allocator);
             unique_ptr p(allocator_traits::allocate(alloc, 1),
                 hpx::util::allocator_deleter<other_allocator>{alloc});
 
-            new (p.get()) operation_state_type{std::forward<S>(s), alloc};
-            p.release();
+            new (p.get())
+                operation_state_type{std::forward<Sender>(sender), alloc};
+            HPX_UNUSED(p.release());
         }
 
         // clang-format off
@@ -139,9 +143,9 @@ namespace hpx { namespace execution { namespace experimental {
             )>
         // clang-format on
         friend constexpr HPX_FORCEINLINE auto tag_fallback_dispatch(
-            detach_t, Allocator const& a = Allocator{})
+            detach_t, Allocator const& allocator = Allocator{})
         {
-            return detail::partial_algorithm<detach_t, Allocator>{a};
+            return detail::partial_algorithm<detach_t, Allocator>{allocator};
         }
     } detach{};
 }}}    // namespace hpx::execution::experimental

--- a/libs/parallelism/execution/include/hpx/execution/algorithms/just.hpp
+++ b/libs/parallelism/execution/include/hpx/execution/algorithms/just.hpp
@@ -44,16 +44,16 @@ namespace hpx { namespace execution { namespace experimental {
 
             static constexpr bool sends_done = false;
 
-            template <typename R>
+            template <typename Receiver>
             struct operation_state
             {
-                std::decay_t<R> r;
+                std::decay_t<Receiver> receiver;
                 hpx::util::member_pack_for<std::decay_t<Ts>...> ts;
 
-                template <typename R_>
-                operation_state(
-                    R_&& r, hpx::util::member_pack_for<std::decay_t<Ts>...> ts)
-                  : r(std::forward<R_>(r))
+                template <typename Receiver_>
+                operation_state(Receiver_&& receiver,
+                    hpx::util::member_pack_for<std::decay_t<Ts>...> ts)
+                  : receiver(std::forward<Receiver_>(receiver))
                   , ts(std::move(ts))
                 {
                 }
@@ -68,26 +68,28 @@ namespace hpx { namespace execution { namespace experimental {
                     hpx::detail::try_catch_exception_ptr(
                         [&]() {
                             hpx::execution::experimental::set_value(
-                                std::move(r),
+                                std::move(receiver),
                                 std::move(ts).template get<Is>()...);
                         },
                         [&](std::exception_ptr ep) {
                             hpx::execution::experimental::set_error(
-                                std::move(r), std::move(ep));
+                                std::move(receiver), std::move(ep));
                         });
                 }
             };
 
-            template <typename R>
-            auto connect(R&& r) &&
+            template <typename Receiver>
+            auto connect(Receiver&& receiver) &&
             {
-                return operation_state<R>{std::forward<R>(r), std::move(ts)};
+                return operation_state<Receiver>{
+                    std::forward<Receiver>(receiver), std::move(ts)};
             }
 
-            template <typename R>
-            auto connect(R&& r) &
+            template <typename Receiver>
+            auto connect(Receiver&& receiver) &
             {
-                return operation_state<R>{std::forward<R>(r), ts};
+                return operation_state<Receiver>{
+                    std::forward<Receiver>(receiver), ts};
             }
         };
     }    // namespace detail

--- a/libs/parallelism/execution/include/hpx/execution/algorithms/let_value.hpp
+++ b/libs/parallelism/execution/include/hpx/execution/algorithms/let_value.hpp
@@ -29,10 +29,10 @@
 
 namespace hpx { namespace execution { namespace experimental {
     namespace detail {
-        template <typename PS, typename F>
+        template <typename PredecessorSender, typename F>
         struct let_value_sender
         {
-            typename std::decay_t<PS> ps;
+            typename std::decay_t<PredecessorSender> predecessor_sender;
             typename std::decay_t<F> f;
 
             // Type of the potential values returned from the predecessor sender
@@ -40,7 +40,8 @@ namespace hpx { namespace execution { namespace experimental {
                 template <typename...> class Variant>
             using predecessor_value_types =
                 typename hpx::execution::experimental::sender_traits<
-                    std::decay_t<PS>>::template value_types<Tuple, Variant>;
+                    std::decay_t<PredecessorSender>>::
+                    template value_types<Tuple, Variant>;
 
             template <typename Tuple>
             struct successor_sender_types_helper;
@@ -95,34 +96,35 @@ namespace hpx { namespace execution { namespace experimental {
 
             static constexpr bool sends_done = false;
 
-            template <typename R>
+            template <typename Receiver>
             struct operation_state
             {
                 struct let_value_predecessor_receiver
                 {
-                    std::decay_t<R> r;
+                    std::decay_t<Receiver> receiver;
                     std::decay_t<F> f;
-                    operation_state& os;
+                    operation_state& op_state;
 
-                    template <typename R_, typename F_>
+                    template <typename Receiver_, typename F_>
                     let_value_predecessor_receiver(
-                        R_&& r, F_&& f, operation_state& os)
-                      : r(std::forward<R_>(r))
+                        Receiver_&& receiver, F_&& f, operation_state& op_state)
+                      : receiver(std::forward<Receiver_>(receiver))
                       , f(std::forward<F_>(f))
-                      , os(os)
+                      , op_state(op_state)
                     {
                     }
 
-                    template <typename E>
-                        void set_error(E&& e) && noexcept
+                    template <typename Error>
+                        void set_error(Error&& error) && noexcept
                     {
                         hpx::execution::experimental::set_error(
-                            std::move(r), std::forward<E>(e));
+                            std::move(receiver), std::forward<Error>(error));
                     }
 
                     void set_done() && noexcept
                     {
-                        hpx::execution::experimental::set_done(std::move(r));
+                        hpx::execution::experimental::set_done(
+                            std::move(receiver));
                     };
 
                     struct start_visitor
@@ -132,20 +134,20 @@ namespace hpx { namespace execution { namespace experimental {
                             HPX_UNREACHABLE;
                         }
 
-                        template <typename OS_,
+                        template <typename OperationState_,
                             typename = std::enable_if_t<!std::is_same_v<
-                                std::decay_t<OS_>, hpx::monostate>>>
-                        void operator()(OS_& os) const
+                                std::decay_t<OperationState_>, hpx::monostate>>>
+                        void operator()(OperationState_& op_state) const
                         {
-                            hpx::execution::experimental::start(os);
+                            hpx::execution::experimental::start(op_state);
                         }
                     };
 
                     struct set_value_visitor
                     {
-                        std::decay_t<R> r;
+                        std::decay_t<Receiver> receiver;
                         std::decay_t<F> f;
-                        operation_state& os;
+                        operation_state& op_state;
 
                         HPX_NORETURN void operator()(hpx::monostate) const
                         {
@@ -160,31 +162,32 @@ namespace hpx { namespace execution { namespace experimental {
                             using operation_state_type =
                                 decltype(hpx::execution::experimental::connect(
                                     hpx::util::invoke_fused(std::move(f), t),
-                                    std::declval<R>()));
+                                    std::declval<Receiver>()));
 
 #if defined(HPX_HAVE_CXX17_COPY_ELISION)
                             // with_result_of is used to emplace the operation state
                             // returned from connect without any intermediate copy
                             // construction (the operation state is not required to be
                             // copyable nor movable).
-                            os.successor_os
+                            op_state.successor_op_state
                                 .template emplace<operation_state_type>(
                                     hpx::util::detail::with_result_of([&]() {
                                         return hpx::execution::experimental::
                                             connect(hpx::util::invoke_fused(
                                                         std::move(f), t),
-                                                std::move(r));
+                                                std::move(receiver));
                                     }));
 #else
                             // MSVC doesn't get copy elision quite right, the operation
                             // state must be constructed explicitly directly in place
-                            os.successor_os
+                            op_state.successor_op_state
                                 .template emplace_f<operation_state_type>(
                                     hpx::execution::experimental::connect,
                                     hpx::util::invoke_fused(std::move(f), t),
-                                    std::move(r));
+                                    std::move(receiver));
 #endif
-                            hpx::visit(start_visitor{}, os.successor_os);
+                            hpx::visit(
+                                start_visitor{}, op_state.successor_op_state);
                         }
                     };
 
@@ -193,24 +196,26 @@ namespace hpx { namespace execution { namespace experimental {
                     {
                         hpx::detail::try_catch_exception_ptr(
                             [&]() {
-                                os.predecessor_ts
+                                op_state.predecessor_ts
                                     .template emplace<hpx::tuple<Ts...>>(
                                         std::forward<Ts>(ts)...);
-                                hpx::visit(set_value_visitor{std::move(r),
-                                               std::move(f), os},
-                                    os.predecessor_ts);
+                                hpx::visit(
+                                    set_value_visitor{std::move(receiver),
+                                        std::move(f), op_state},
+                                    op_state.predecessor_ts);
                             },
                             [&](std::exception_ptr ep) {
                                 hpx::execution::experimental::set_error(
-                                    std::move(r), std::move(ep));
+                                    std::move(receiver), std::move(ep));
                             });
                     }
                 };
 
                 // Type of the operation state returned when connecting the
                 // predecessor sender to the let_value_predecessor_receiver
-                using predecessor_operation_state_type = std::decay_t<
-                    connect_result_t<PS&&, let_value_predecessor_receiver>>;
+                using predecessor_operation_state_type =
+                    std::decay_t<connect_result_t<PredecessorSender&&,
+                        let_value_predecessor_receiver>>;
 
                 // Type of the potential operation states returned when
                 // connecting a sender in successor_sender_types to the receiver
@@ -218,7 +223,7 @@ namespace hpx { namespace execution { namespace experimental {
                 template <typename Sender>
                 struct successor_operation_state_types_helper
                 {
-                    using type = connect_result_t<Sender, R>;
+                    using type = connect_result_t<Sender, Receiver>;
                 };
                 template <template <typename...> class Tuple,
                     template <typename...> class Variant>
@@ -229,7 +234,7 @@ namespace hpx { namespace execution { namespace experimental {
 
                 // Operation state from connecting predecessor sender to
                 // let_value_predecessor_receiver
-                predecessor_operation_state_type predecessor_os;
+                predecessor_operation_state_type predecessor_op_state;
 
                 // Potential values returned from the predecessor sender
                 hpx::util::detail::prepend_t<
@@ -243,14 +248,17 @@ namespace hpx { namespace execution { namespace experimental {
                 hpx::util::detail::prepend_t<
                     successor_operation_state_types<hpx::tuple, hpx::variant>,
                     hpx::monostate>
-                    successor_os;
+                    successor_op_state;
 
-                template <typename PS_, typename R_, typename F_>
-                operation_state(PS_&& ps, R_&& r, F_&& f)
-                  : predecessor_os{hpx::execution::experimental::connect(
-                        std::forward<PS_>(ps),
+                template <typename PredecessorSender_, typename Receiver_,
+                    typename F_>
+                operation_state(PredecessorSender_&& predecessor_sender,
+                    Receiver_&& receiver, F_&& f)
+                  : predecessor_op_state{hpx::execution::experimental::connect(
+                        std::forward<PredecessorSender_>(predecessor_sender),
                         let_value_predecessor_receiver(
-                            std::forward<R_>(r), std::forward<F_>(f), *this))}
+                            std::forward<Receiver_>(receiver),
+                            std::forward<F_>(f), *this))}
                 {
                 }
 
@@ -261,15 +269,15 @@ namespace hpx { namespace execution { namespace experimental {
 
                 void start() & noexcept
                 {
-                    hpx::execution::experimental::start(predecessor_os);
+                    hpx::execution::experimental::start(predecessor_op_state);
                 }
             };
 
-            template <typename R>
-            auto connect(R&& r) &&
+            template <typename Receiver>
+            auto connect(Receiver&& receiver) &&
             {
-                return operation_state<R>(
-                    std::move(ps), std::forward<R>(r), std::move(f));
+                return operation_state<Receiver>(std::move(predecessor_sender),
+                    std::forward<Receiver>(receiver), std::move(f));
             }
         };
     }    // namespace detail
@@ -279,16 +287,17 @@ namespace hpx { namespace execution { namespace experimental {
     {
     private:
         // clang-format off
-        template <typename PS, typename F,
+        template <typename PredecessorSender, typename F,
             HPX_CONCEPT_REQUIRES_(
-                is_sender_v<PS>
+                is_sender_v<PredecessorSender>
             )>
         // clang-format on
         friend constexpr HPX_FORCEINLINE auto tag_fallback_dispatch(
-            let_value_t, PS&& ps, F&& f)
+            let_value_t, PredecessorSender&& predecessor_sender, F&& f)
         {
-            return detail::let_value_sender<PS, F>{
-                std::forward<PS>(ps), std::forward<F>(f)};
+            return detail::let_value_sender<PredecessorSender, F>{
+                std::forward<PredecessorSender>(predecessor_sender),
+                std::forward<F>(f)};
         }
 
         template <typename F>

--- a/libs/parallelism/execution/include/hpx/execution/algorithms/transform.hpp
+++ b/libs/parallelism/execution/include/hpx/execution/algorithms/transform.hpp
@@ -21,22 +21,22 @@
 
 namespace hpx { namespace execution { namespace experimental {
     namespace detail {
-        template <typename R, typename F>
+        template <typename Receiver, typename F>
         struct transform_receiver
         {
-            std::decay_t<R> r;
+            std::decay_t<Receiver> receiver;
             std::decay_t<F> f;
 
-            template <typename E>
-                void set_error(E&& e) && noexcept
+            template <typename Error>
+                void set_error(Error&& error) && noexcept
             {
                 hpx::execution::experimental::set_error(
-                    std::move(r), std::forward<E>(e));
+                    std::move(receiver), std::forward<Error>(error));
             }
 
             void set_done() && noexcept
             {
-                hpx::execution::experimental::set_done(std::move(r));
+                hpx::execution::experimental::set_done(std::move(receiver));
             }
 
         private:
@@ -46,11 +46,12 @@ namespace hpx { namespace execution { namespace experimental {
                 hpx::detail::try_catch_exception_ptr(
                     [&]() {
                         HPX_INVOKE(f, std::forward<Ts>(ts)...);
-                        hpx::execution::experimental::set_value(std::move(r));
+                        hpx::execution::experimental::set_value(
+                            std::move(receiver));
                     },
                     [&](std::exception_ptr ep) {
                         hpx::execution::experimental::set_error(
-                            std::move(r), std::move(ep));
+                            std::move(receiver), std::move(ep));
                     });
             }
 
@@ -61,11 +62,11 @@ namespace hpx { namespace execution { namespace experimental {
                     [&]() {
                         auto&& result = HPX_INVOKE(f, std::forward<Ts>(ts)...);
                         hpx::execution::experimental::set_value(
-                            std::move(r), std::move(result));
+                            std::move(receiver), std::move(result));
                     },
                     [&](std::exception_ptr ep) {
                         hpx::execution::experimental::set_error(
-                            std::move(r), std::move(ep));
+                            std::move(receiver), std::move(ep));
                     });
             }
 
@@ -80,10 +81,10 @@ namespace hpx { namespace execution { namespace experimental {
             }
         };
 
-        template <typename S, typename F>
+        template <typename Sender, typename F>
         struct transform_sender
         {
-            std::decay_t<S> s;
+            std::decay_t<Sender> sender;
             std::decay_t<F> f;
 
             template <typename Tuple>
@@ -103,30 +104,32 @@ namespace hpx { namespace execution { namespace experimental {
             using value_types =
                 hpx::util::detail::unique_t<hpx::util::detail::transform_t<
                     typename hpx::execution::experimental::sender_traits<
-                        S>::template value_types<Tuple, Variant>,
+                        Sender>::template value_types<Tuple, Variant>,
                     invoke_result_helper>>;
 
             template <template <typename...> class Variant>
             using error_types =
                 hpx::util::detail::unique_t<hpx::util::detail::prepend_t<
                     typename hpx::execution::experimental::sender_traits<
-                        S>::template error_types<Variant>,
+                        Sender>::template error_types<Variant>,
                     std::exception_ptr>>;
 
             static constexpr bool sends_done = false;
 
-            template <typename R>
-            auto connect(R&& r) &&
+            template <typename Receiver>
+            auto connect(Receiver&& receiver) &&
             {
-                return hpx::execution::experimental::connect(std::move(s),
-                    transform_receiver<R, F>{std::forward<R>(r), std::move(f)});
+                return hpx::execution::experimental::connect(std::move(sender),
+                    transform_receiver<Receiver, F>{
+                        std::forward<Receiver>(receiver), std::move(f)});
             }
 
-            template <typename R>
-            auto connect(R&& r) &
+            template <typename Receiver>
+            auto connect(Receiver&& receiver) &
             {
-                return hpx::execution::experimental::connect(
-                    s, transform_receiver<R, F>{std::forward<R>(r), f});
+                return hpx::execution::experimental::connect(sender,
+                    transform_receiver<Receiver, F>{
+                        std::forward<Receiver>(receiver), f});
             }
         };
     }    // namespace detail
@@ -136,16 +139,16 @@ namespace hpx { namespace execution { namespace experimental {
     {
     private:
         // clang-format off
-        template <typename S, typename F,
+        template <typename Sender, typename F,
             HPX_CONCEPT_REQUIRES_(
-                is_sender_v<S>
+                is_sender_v<Sender>
             )>
         // clang-format on
         friend constexpr HPX_FORCEINLINE auto tag_fallback_dispatch(
-            transform_t, S&& s, F&& f)
+            transform_t, Sender&& sender, F&& f)
         {
-            return detail::transform_sender<S, F>{
-                std::forward<S>(s), std::forward<F>(f)};
+            return detail::transform_sender<Sender, F>{
+                std::forward<Sender>(sender), std::forward<F>(f)};
         }
 
         template <typename F>

--- a/libs/parallelism/execution/include/hpx/execution/algorithms/when_all.hpp
+++ b/libs/parallelism/execution/include/hpx/execution/algorithms/when_all.hpp
@@ -28,72 +28,76 @@
 
 namespace hpx { namespace execution { namespace experimental {
     namespace detail {
-        template <std::size_t I, typename OS>
+        template <std::size_t I, typename OperationState>
         struct when_all_receiver
         {
-            std::decay_t<OS>& os;
+            std::decay_t<OperationState>& op_state;
 
-            when_all_receiver(std::decay_t<OS>& os)
-              : os(os)
+            when_all_receiver(std::decay_t<OperationState>& op_state)
+              : op_state(op_state)
             {
             }
 
-            template <typename E>
-                void set_error(E&& e) && noexcept
+            template <typename Error>
+                void set_error(Error&& error) && noexcept
             {
-                if (!os.set_done_error_called.exchange(true))
+                if (!op_state.set_done_error_called.exchange(true))
                 {
                     try
                     {
-                        os.e = std::forward<E>(e);
+                        op_state.error = std::forward<Error>(error);
                     }
                     catch (...)
                     {
-                        os.e = std::current_exception();
+                        // NOLINTNEXTLINE(bugprone-throw-keyword-missing)
+                        op_state.error = std::current_exception();
                     }
                 }
 
-                os.finish();
+                op_state.finish();
             }
 
             void set_done() && noexcept
             {
-                os.set_done_error_called = true;
-                os.finish();
+                op_state.set_done_error_called = true;
+                op_state.finish();
             };
 
             template <typename T>
                 void set_value(T&& t) && noexcept
             {
-                if (!os.set_done_error_called)
+                if (!op_state.set_done_error_called)
                 {
                     try
                     {
-                        os.ts.template get<I>().emplace(std::forward<T>(t));
+                        op_state.ts.template get<I>().emplace(
+                            std::forward<T>(t));
                     }
                     catch (...)
                     {
-                        if (!os.set_done_error_called.exchange(true))
+                        if (!op_state.set_done_error_called.exchange(true))
                         {
-                            os.e = std::current_exception();
+                            // NOLINTNEXTLINE(bugprone-throw-keyword-missing)
+                            op_state.error = std::current_exception();
                         }
                     }
                 }
 
-                os.finish();
+                op_state.finish();
             }
         };
 
-        template <typename... Ss>
+        template <typename... Senders>
         struct when_all_sender
         {
             using senders_type =
-                hpx::util::member_pack_for<std::decay_t<Ss>...>;
+                hpx::util::member_pack_for<std::decay_t<Senders>...>;
             senders_type senders;
 
-            template <typename... Ss_>
-            explicit constexpr when_all_sender(Ss_&&... ss)
-              : senders(std::piecewise_construct, std::forward<Ss_>(ss)...)
+            template <typename... Senders_>
+            explicit constexpr when_all_sender(Senders_&&... senders)
+              : senders(std::piecewise_construct,
+                    std::forward<Senders_>(senders)...)
             {
             }
 
@@ -113,47 +117,48 @@ namespace hpx { namespace execution { namespace experimental {
 
             template <template <typename...> class Tuple,
                 template <typename...> class Variant>
-            using value_types = Variant<Tuple<value_types_helper_t<Ss>...>>;
+            using value_types =
+                Variant<Tuple<value_types_helper_t<Senders>...>>;
 
             template <template <typename...> class Variant>
             using error_types = hpx::util::detail::unique_concat_t<
                 typename hpx::execution::experimental::sender_traits<
-                    Ss>::template error_types<Variant>...,
+                    Senders>::template error_types<Variant>...,
                 Variant<std::exception_ptr>>;
 
             static constexpr bool sends_done = false;
 
-            static constexpr std::size_t num_predecessors = sizeof...(Ss);
+            static constexpr std::size_t num_predecessors = sizeof...(Senders);
             static_assert(num_predecessors > 0,
                 "when_all expects at least one predecessor sender");
 
-            template <typename R, typename Senders, std::size_t I>
+            template <typename Receiver, typename SendersPack, std::size_t I>
             struct operation_state;
 
-            template <typename R, typename Senders>
-            struct operation_state<R, Senders, 0>
+            template <typename Receiver, typename SendersPack>
+            struct operation_state<Receiver, SendersPack, 0>
             {
                 static constexpr std::size_t I = 0;
                 std::atomic<std::size_t> predecessors_remaining =
                     num_predecessors;
-                hpx::util::member_pack_for<
-                    std::optional<std::decay_t<value_types_helper_t<Ss>>>...>
+                hpx::util::member_pack_for<std::optional<
+                    std::decay_t<value_types_helper_t<Senders>>>...>
                     ts;
-                std::optional<error_types<std::variant>> e;
+                std::optional<error_types<std::variant>> error;
                 std::atomic<bool> set_done_error_called{false};
-                std::decay_t<R> r;
+                std::decay_t<Receiver> receiver;
 
                 using operation_state_type =
                     std::decay_t<decltype(hpx::execution::experimental::connect(
-                        std::declval<Senders>().template get<I>(),
+                        std::declval<SendersPack>().template get<I>(),
                         when_all_receiver<I, operation_state>(
                             std::declval<std::decay_t<operation_state>&>())))>;
-                operation_state_type os;
+                operation_state_type op_state;
 
-                template <typename R_, typename Senders_>
-                operation_state(R_&& r, Senders_&& senders)
-                  : r(std::forward<R_>(r))
-                  , os(hpx::execution::experimental::connect(
+                template <typename Receiver_, typename Senders_>
+                operation_state(Receiver_&& receiver, Senders_&& senders)
+                  : receiver(std::forward<Receiver_>(receiver))
+                  , op_state(hpx::execution::experimental::connect(
                         std::forward<Senders_>(senders).template get<I>(),
                         when_all_receiver<I, operation_state>(*this)))
                 {
@@ -166,7 +171,7 @@ namespace hpx { namespace execution { namespace experimental {
 
                 void start() & noexcept
                 {
-                    hpx::execution::experimental::start(os);
+                    hpx::execution::experimental::start(op_state);
                 }
 
                 template <std::size_t... Is, typename... Ts>
@@ -174,8 +179,8 @@ namespace hpx { namespace execution { namespace experimental {
                     hpx::util::member_pack<hpx::util::index_pack<Is...>, Ts...>&
                         ts)
                 {
-                    hpx::execution::experimental::set_value(
-                        std::move(r), std::move(*(ts.template get<Is>()))...);
+                    hpx::execution::experimental::set_value(std::move(receiver),
+                        std::move(*(ts.template get<Is>()))...);
                 }
 
                 void finish() noexcept
@@ -186,43 +191,44 @@ namespace hpx { namespace execution { namespace experimental {
                         {
                             set_value_helper(ts);
                         }
-                        else if (e)
+                        else if (error)
                         {
                             std::visit(
-                                [this](auto&& e) {
+                                [this](auto&& error) {
                                     hpx::execution::experimental::set_error(
-                                        std::move(r),
-                                        std::forward<decltype(e)>(e));
+                                        std::move(receiver),
+                                        std::forward<decltype(error)>(error));
                                 },
-                                std::move(e.value()));
+                                std::move(error.value()));
                         }
                         else
                         {
                             hpx::execution::experimental::set_done(
-                                std::move(r));
+                                std::move(receiver));
                         }
                     }
                 }
             };
 
-            template <typename R, typename Senders, std::size_t I>
-            struct operation_state : operation_state<R, Senders, I - 1>
+            template <typename Receiver, typename SendersPack, std::size_t I>
+            struct operation_state
+              : operation_state<Receiver, SendersPack, I - 1>
             {
-                using base_type = operation_state<R, Senders, I - 1>;
+                using base_type = operation_state<Receiver, SendersPack, I - 1>;
 
                 using operation_state_type =
                     std::decay_t<decltype(hpx::execution::experimental::connect(
-                        std::forward<Senders>(senders).template get<I>(),
+                        std::forward<SendersPack>(senders).template get<I>(),
                         when_all_receiver<I, operation_state>(
                             std::declval<std::decay_t<operation_state>&>())))>;
-                operation_state_type os;
+                operation_state_type op_state;
 
-                template <typename R_, typename Senders_>
-                operation_state(R_&& r, Senders_&& senders)
-                  : base_type(
-                        std::forward<R_>(r), std::forward<Senders>(senders))
-                  , os(hpx::execution::experimental::connect(
-                        std::forward<Senders_>(senders).template get<I>(),
+                template <typename Receiver_, typename SendersPack_>
+                operation_state(Receiver_&& receiver, SendersPack_&& senders)
+                  : base_type(std::forward<Receiver_>(receiver),
+                        std::forward<SendersPack>(senders))
+                  , op_state(hpx::execution::experimental::connect(
+                        std::forward<SendersPack_>(senders).template get<I>(),
                         when_all_receiver<I, operation_state>(*this)))
                 {
                 }
@@ -235,22 +241,23 @@ namespace hpx { namespace execution { namespace experimental {
                 void start() & noexcept
                 {
                     base_type::start();
-                    hpx::execution::experimental::start(os);
+                    hpx::execution::experimental::start(op_state);
                 }
             };
 
-            template <typename R>
-            auto connect(R&& r) &&
+            template <typename Receiver>
+            auto connect(Receiver&& receiver) &&
             {
-                return operation_state<R, senders_type&&, num_predecessors - 1>(
-                    std::forward<R>(r), std::move(senders));
+                return operation_state<Receiver, senders_type&&,
+                    num_predecessors - 1>(
+                    std::forward<Receiver>(receiver), std::move(senders));
             }
 
-            template <typename R>
-            auto connect(R&& r) &
+            template <typename Receiver>
+            auto connect(Receiver&& receiver) &
             {
-                return operation_state<R, senders_type&, num_predecessors - 1>(
-                    r, senders);
+                return operation_state<Receiver, senders_type&,
+                    num_predecessors - 1>(receiver, senders);
             }
         };
     }    // namespace detail
@@ -260,15 +267,16 @@ namespace hpx { namespace execution { namespace experimental {
     {
     private:
         // clang-format off
-        template <typename... Ss,
+        template <typename... Senders,
             HPX_CONCEPT_REQUIRES_(
-                hpx::util::all_of_v<is_sender<Ss>...>
+                hpx::util::all_of_v<is_sender<Senders>...>
             )>
         // clang-format on
         friend constexpr HPX_FORCEINLINE auto tag_fallback_dispatch(
-            when_all_t, Ss&&... ss)
+            when_all_t, Senders&&... senders)
         {
-            return detail::when_all_sender<Ss...>{std::forward<Ss>(ss)...};
+            return detail::when_all_sender<Senders...>{
+                std::forward<Senders>(senders)...};
         }
     } when_all{};
 }}}    // namespace hpx::execution::experimental

--- a/libs/parallelism/execution/tests/unit/algorithm_ensure_started.cpp
+++ b/libs/parallelism/execution/tests/unit/algorithm_ensure_started.cpp
@@ -128,9 +128,9 @@ int main()
         std::atomic<bool> receiver_set_value_called{false};
         auto s1 = ex::just() | ex::ensure_started();
         auto s2 = ex::ensure_started(s1);
-        HPX_TEST_EQ(s1.st, s2.st);
+        HPX_TEST_EQ(s1.state, s2.state);
         auto s3 = ex::ensure_started(std::move(s2));
-        HPX_TEST_EQ(s1.st, s3.st);
+        HPX_TEST_EQ(s1.state, s3.state);
         auto f = [] {};
         auto r = callback_receiver<decltype(f)>{f, receiver_set_value_called};
         auto os = ex::connect(std::move(s3), std::move(r));
@@ -142,9 +142,9 @@ int main()
         std::atomic<bool> receiver_set_value_called{false};
         auto s1 = ex::just(42) | ex::ensure_started();
         auto s2 = ex::ensure_started(s1);
-        HPX_TEST_EQ(s1.st, s2.st);
+        HPX_TEST_EQ(s1.state, s2.state);
         auto s3 = ex::ensure_started(std::move(s2));
-        HPX_TEST_EQ(s1.st, s3.st);
+        HPX_TEST_EQ(s1.state, s3.state);
         auto f = [](int x) { HPX_TEST_EQ(x, 42); };
         auto r = callback_receiver<decltype(f)>{f, receiver_set_value_called};
         auto os = ex::connect(std::move(s3), std::move(r));


### PR DESCRIPTION
I've been a bit unnecessarily frugal when naming template parameters and members in the sender algorithms. This expands them a bit. Suggestions for other/better names are also welcome, or if someone prefers the shorter names please speak up as well.