### PR TITLE
More fixes to enable for all types to be assumed to be bitwise copyable

### DIFF
--- a/libs/core/serialization/CMakeLists.txt
+++ b/libs/core/serialization/CMakeLists.txt
@@ -39,6 +39,7 @@ endif()
 # Default location is $HPX_ROOT/libs/serialization/include
 set(serialization_headers
     hpx/serialization.hpp
+    hpx/serialization/detail/constructor_selector.hpp
     hpx/serialization/detail/extra_archive_data.hpp
     hpx/serialization/detail/non_default_constructible.hpp
     hpx/serialization/detail/pointer.hpp

--- a/libs/core/serialization/include/hpx/serialization/access.hpp
+++ b/libs/core/serialization/include/hpx/serialization/access.hpp
@@ -47,9 +47,9 @@ namespace hpx { namespace serialization {
         static std::false_type test(...);
 
         template <typename T1,
-            typename = decltype(serialize(
-                std::declval<hpx::serialization::output_archive&>(),
-                std::declval<typename std::remove_const<T1>::type&>(), 0u))>
+            typename = decltype(
+                serialize(std::declval<hpx::serialization::output_archive&>(),
+                    std::declval<typename std::remove_const<T1>::type&>(), 0u))>
         static std::true_type test(int);
 
     public:
@@ -155,13 +155,11 @@ namespace hpx { namespace serialization {
             // to implement if there hadn't been an issue with gcc:
             // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=82478
             template <typename T1,
-                typename =
-                    decltype(std::declval<
-                             typename std::remove_const<T1>::type&>()
-                                 .serialize(
-                                     std::declval<
-                                         hpx::serialization::output_archive&>(),
-                                     0u))>
+                typename = decltype(
+                    std::declval<typename std::remove_const<T1>::type&>()
+                        .serialize(
+                            std::declval<hpx::serialization::output_archive&>(),
+                            0u))>
             static std::true_type test(int);
 
         public:

--- a/libs/core/serialization/include/hpx/serialization/access.hpp
+++ b/libs/core/serialization/include/hpx/serialization/access.hpp
@@ -47,9 +47,9 @@ namespace hpx { namespace serialization {
         static std::false_type test(...);
 
         template <typename T1,
-            typename = decltype(
-                serialize(std::declval<hpx::serialization::output_archive&>(),
-                    std::declval<typename std::remove_const<T1>::type&>(), 0u))>
+            typename = decltype(serialize(
+                std::declval<hpx::serialization::output_archive&>(),
+                std::declval<typename std::remove_const<T1>::type&>(), 0u))>
         static std::true_type test(int);
 
     public:
@@ -71,7 +71,7 @@ namespace hpx { namespace serialization {
 
     template <typename T>
     struct serialize_non_intrusive<T,
-        typename std::enable_if<has_serialize_adl<T>::value>::type>
+        std::enable_if_t<has_serialize_adl<T>::value>>
     {
         template <typename Archive>
         static void call(Archive& ar, T& t, unsigned)
@@ -118,7 +118,7 @@ namespace hpx { namespace serialization {
 
     template <typename T>
     struct serialize_brace_initialized<T,
-        typename std::enable_if<has_struct_serialization<T>::value>::type>
+        std::enable_if_t<has_struct_serialization<T>::value>>
     {
         template <typename Archive>
         static void call(Archive& ar, T& t, unsigned)
@@ -133,7 +133,7 @@ namespace hpx { namespace serialization {
 
     template <typename T>
     struct serialize_non_intrusive<T,
-        typename std::enable_if<!has_serialize_adl<T>::value>::type>
+        std::enable_if_t<!has_serialize_adl<T>::value>>
       : serialize_brace_initialized<T>
     {
     };
@@ -141,10 +141,11 @@ namespace hpx { namespace serialization {
     ///////////////////////////////////////////////////////////////////////////
     class access
     {
-        template <class T>
+    public:
+        template <typename T>
         class has_serialize
         {
-            template <class T1>
+            template <typename T1>
             static std::false_type test(...);
 
             // the following expression sfinae trick
@@ -153,17 +154,22 @@ namespace hpx { namespace serialization {
             // note that this detection would have been much easier
             // to implement if there hadn't been an issue with gcc:
             // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=82478
-            template <class T1,
-                class = decltype(
-                    std::declval<typename std::remove_const<T1>::type&>()
-                        .serialize(std::declval<output_archive&>(), 0u))>
+            template <typename T1,
+                typename =
+                    decltype(std::declval<
+                             typename std::remove_const<T1>::type&>()
+                                 .serialize(
+                                     std::declval<
+                                         hpx::serialization::output_archive&>(),
+                                     0u))>
             static std::true_type test(int);
 
         public:
             static constexpr bool value = decltype(test<T>(0))::value;
         };
 
-        template <class T>
+    private:
+        template <typename T>
         class serialize_dispatcher
         {
             struct intrusive_polymorphic
@@ -208,23 +214,21 @@ namespace hpx { namespace serialization {
                 {
                     // cast it to let it be run for templated
                     // member functions
-                    const_cast<typename std::decay<T>::type&>(t).serialize(
-                        ar, 0);
+                    const_cast<std::decay_t<T>&>(t).serialize(ar, 0);
                 }
             };
 
         public:
-            using type = typename std::conditional<
-                hpx::traits::is_intrusive_polymorphic<T>::value,
-                intrusive_polymorphic,
-                typename std::conditional<has_serialize<T>::value,
-                    intrusive_usual,
-                    typename std::conditional<std::is_empty<T>::value, empty,
-                        non_intrusive>::type>::type>::type;
+            using type =
+                std::conditional_t<hpx::traits::is_intrusive_polymorphic_v<T>,
+                    intrusive_polymorphic,
+                    std::conditional_t<has_serialize<T>::value, intrusive_usual,
+                        std::conditional_t<std::is_empty<T>::value, empty,
+                            non_intrusive>>>;
         };
 
     public:
-        template <class Archive, class T>
+        template <typename Archive, typename T>
         static void serialize(Archive& ar, T& t, unsigned)
         {
             serialize_dispatcher<T>::type::call(ar, t, 0);

--- a/libs/core/serialization/include/hpx/serialization/detail/constructor_selector.hpp
+++ b/libs/core/serialization/include/hpx/serialization/detail/constructor_selector.hpp
@@ -1,0 +1,56 @@
+//  Copyright (c) 2021 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0.
+//  See accompanying file LICENSE_1_0.txt or copy at
+//  http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include <hpx/config.hpp>
+#include <hpx/serialization/detail/non_default_constructible.hpp>
+#include <hpx/serialization/serialization_fwd.hpp>
+
+#include <memory>
+#include <type_traits>
+#include <utility>
+
+#include <hpx/config/warnings_prefix.hpp>
+
+namespace hpx { namespace serialization { namespace detail {
+
+    template <typename T>
+    class constructor_selector
+    {
+    public:
+        static T create(input_archive& ar)
+        {
+            return create(ar, std::is_default_constructible<T>());
+        }
+
+        // is default-constructible
+        static T create(input_archive& ar, std::true_type)
+        {
+            T t;
+            ar >> t;
+            return t;
+        }
+
+        // is non-default-constructible
+        static T create(input_archive& ar, std::false_type)
+        {
+            using storage_type =
+                typename std::aligned_storage<sizeof(T), alignof(T)>::type;
+
+            storage_type storage;
+            T* t = reinterpret_cast<T*>(&storage);
+            load_construct_data(ar, t, 0);
+
+            ar >> *t;
+
+            return std::move(*t);
+        }
+    };
+}}}    // namespace hpx::serialization::detail
+
+#include <hpx/config/warnings_suffix.hpp>

--- a/libs/core/serialization/include/hpx/serialization/detail/non_default_constructible.hpp
+++ b/libs/core/serialization/include/hpx/serialization/detail/non_default_constructible.hpp
@@ -8,21 +8,42 @@
 #pragma once
 
 #include <hpx/config.hpp>
+#include <hpx/serialization/traits/is_not_bitwise_serializable.hpp>
 
 #include <memory>
+#include <type_traits>
 
 namespace hpx { namespace serialization { namespace detail {
     ///////////////////////////////////////////////////////////////////////////
     // default fall-backs for serializing non-default-constructible types
-    template <typename Archive, typename T>
+    template <typename Archive, typename T,
+        std::enable_if_t<traits::is_not_bitwise_serializable_v<T>, int> = 0>
     void save_construct_data(Archive&, T const*, unsigned)
     {
     }
 
     // by default fall back to in-place default construction
-    template <typename Archive, typename T>
+    template <typename Archive, typename T,
+        std::enable_if_t<traits::is_not_bitwise_serializable_v<T>, int> = 0>
     void load_construct_data(Archive&, T* t, unsigned)
     {
         ::new (t) T;
     }
+
+#if defined(HPX_SERIALIZATION_HAVE_ALL_TYPES_ARE_BITWISE_SERIALIZABLE)
+    template <typename Archive, typename T,
+        std::enable_if_t<!traits::is_not_bitwise_serializable_v<T>, int> = 0>
+    void save_construct_data(Archive&, T const*, unsigned)
+    {
+    }
+
+    // by default fall back to in-place default construction
+    template <typename Archive, typename T,
+        std::enable_if_t<!traits::is_not_bitwise_serializable_v<T>, int> = 0>
+    void load_construct_data(Archive&, T* t, unsigned)
+    {
+        ::new (t) T;
+    }
+#endif
+
 }}}    // namespace hpx::serialization::detail

--- a/libs/core/serialization/include/hpx/serialization/detail/pointer.hpp
+++ b/libs/core/serialization/include/hpx/serialization/detail/pointer.hpp
@@ -144,7 +144,8 @@ namespace hpx { namespace serialization {
             {
                 static Pointer call(input_archive& ar)
                 {
-                    Pointer t(constructor_selector<referred_type>::create(ar));
+                    Pointer t(
+                        constructor_selector_ptr<referred_type>::create(ar));
                     return t;
                 }
             };

--- a/libs/core/serialization/include/hpx/serialization/detail/polymorphic_nonintrusive_factory.hpp
+++ b/libs/core/serialization/include/hpx/serialization/detail/polymorphic_nonintrusive_factory.hpp
@@ -64,7 +64,7 @@ namespace hpx { namespace serialization { namespace detail {
     };
 
     template <typename T>
-    class constructor_selector
+    class constructor_selector_ptr
     {
     public:
         static T* create(input_archive& ar)
@@ -198,7 +198,7 @@ namespace hpx { namespace serialization { namespace detail {
         // this function is needed for pointer type serialization
         static void* create(input_archive& ar)
         {
-            return constructor_selector<Derived>::create(ar);
+            return constructor_selector_ptr<Derived>::create(ar);
         }
 
         register_class()
@@ -296,7 +296,7 @@ namespace hpx { namespace serialization { namespace detail {
 #define HPX_SERIALIZATION_WITH_CUSTOM_CONSTRUCTOR(Class, Func)                 \
     namespace hpx { namespace serialization { namespace detail {               \
                 template <>                                                    \
-                class constructor_selector<HPX_PP_STRIP_PARENS(Class)>         \
+                class constructor_selector_ptr<HPX_PP_STRIP_PARENS(Class)>     \
                 {                                                              \
                 public:                                                        \
                     static Class* create(input_archive& ar)                    \
@@ -312,7 +312,7 @@ namespace hpx { namespace serialization { namespace detail {
     Parameters, Template, Func)                                                \
     namespace hpx { namespace serialization { namespace detail {               \
                 HPX_PP_STRIP_PARENS(Parameters)                                \
-                class constructor_selector<HPX_PP_STRIP_PARENS(Template)>      \
+                class constructor_selector_ptr<HPX_PP_STRIP_PARENS(Template)>  \
                 {                                                              \
                 public:                                                        \
                     static HPX_PP_STRIP_PARENS(Template) *                     \

--- a/libs/core/serialization/include/hpx/serialization/input_archive.hpp
+++ b/libs/core/serialization/include/hpx/serialization/input_archive.hpp
@@ -145,6 +145,7 @@ namespace hpx { namespace serialization {
             bool archive_endianess_differs =
                 endian::native == endian::big ? endian_little() : endian_big();
 
+#if !defined(HPX_SERIALIZATION_HAVE_ALL_TYPES_ARE_BITWISE_SERIALIZABLE)
             if (disable_array_optimization() || archive_endianess_differs)
             {
                 access::serialize(*this, t, 0);
@@ -153,6 +154,11 @@ namespace hpx { namespace serialization {
             {
                 load_binary(&t, sizeof(t));
             }
+#else
+            HPX_ASSERT(
+                !(disable_array_optimization() || archive_endianess_differs));
+            load_binary(&t, sizeof(t));
+#endif
         }
 
         template <class T>

--- a/libs/core/serialization/include/hpx/serialization/input_archive.hpp
+++ b/libs/core/serialization/include/hpx/serialization/input_archive.hpp
@@ -72,9 +72,8 @@ namespace hpx { namespace serialization {
         }
 
         template <typename T>
-        typename std::enable_if<!std::is_integral<T>::value &&
-            !std::is_enum<T>::value>::type
-        load(T& t)
+        std::enable_if_t<!std::is_integral_v<T> && !std::is_enum_v<T>> load(
+            T& t)
         {
             using use_optimized = std::integral_constant<bool,
                 hpx::traits::is_bitwise_serializable_v<T> ||
@@ -84,9 +83,8 @@ namespace hpx { namespace serialization {
         }
 
         template <typename T>
-        typename std::enable_if<std::is_integral<T>::value ||
-            std::is_enum<T>::value>::type
-        load(T& t)    //-V659
+        std::enable_if_t<std::is_integral_v<T> || std::is_enum_v<T>> load(
+            T& t)    //-V659
         {
             load_integral(t, std::is_unsigned<T>());
         }
@@ -155,6 +153,7 @@ namespace hpx { namespace serialization {
                 load_binary(&t, sizeof(t));
             }
 #else
+            (void) archive_endianess_differs;
             HPX_ASSERT(
                 !(disable_array_optimization() || archive_endianess_differs));
             load_binary(&t, sizeof(t));

--- a/libs/core/serialization/include/hpx/serialization/map.hpp
+++ b/libs/core/serialization/include/hpx/serialization/map.hpp
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <hpx/config/endian.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/serialization/serialization_fwd.hpp>
 #include <hpx/serialization/serialize.hpp>
 #include <hpx/serialization/traits/is_bitwise_serializable.hpp>
@@ -62,11 +63,22 @@ namespace hpx {
                     ar.endian_little() :
                     ar.endian_big();
 
+#if !defined(HPX_SERIALIZATION_HAVE_ALL_TYPES_ARE_BITWISE_SERIALIZABLE)
                 if (ar.disable_array_optimization() ||
                     archive_endianess_differs)
+                {
                     load_pair_impl(ar, t, std::false_type());
+                }
                 else
+                {
                     load_binary(ar, &t, sizeof(std::pair<Key, Value>));
+                }
+#else
+                (void) archive_endianess_differs;
+                HPX_ASSERT(!(ar.disable_array_optimization() ||
+                    archive_endianess_differs));
+                load_binary(ar, &t, sizeof(std::pair<Key, Value>));
+#endif
             }
 
             template <typename Key, typename Value>
@@ -85,11 +97,22 @@ namespace hpx {
                     ar.endian_little() :
                     ar.endian_big();
 
+#if !defined(HPX_SERIALIZATION_HAVE_ALL_TYPES_ARE_BITWISE_SERIALIZABLE)
                 if (ar.disable_array_optimization() ||
                     archive_endianess_differs)
+                {
                     save_pair_impl(ar, t, std::false_type());
+                }
                 else
+                {
                     save_binary(ar, &t, sizeof(std::pair<Key, Value>));
+                }
+#else
+                (void) archive_endianess_differs;
+                HPX_ASSERT(!(ar.disable_array_optimization() ||
+                    archive_endianess_differs));
+                save_binary(ar, &t, sizeof(std::pair<Key, Value>));
+#endif
             }
 
         }    // namespace detail

--- a/libs/core/serialization/include/hpx/serialization/output_archive.hpp
+++ b/libs/core/serialization/include/hpx/serialization/output_archive.hpp
@@ -237,6 +237,7 @@ namespace hpx { namespace serialization {
             bool archive_endianess_differs =
                 endian::native == endian::big ? endian_little() : endian_big();
 
+#if !defined(HPX_SERIALIZATION_HAVE_ALL_TYPES_ARE_BITWISE_SERIALIZABLE)
             if (disable_array_optimization() || archive_endianess_differs)
             {
                 access::serialize(*this, t, 0);
@@ -245,6 +246,11 @@ namespace hpx { namespace serialization {
             {
                 save_binary(&t, sizeof(t));
             }
+#else
+            HPX_ASSERT(
+                !(disable_array_optimization() || archive_endianess_differs));
+            save_binary(&t, sizeof(t));
+#endif
         }
 
         template <typename T>

--- a/libs/core/serialization/include/hpx/serialization/output_archive.hpp
+++ b/libs/core/serialization/include/hpx/serialization/output_archive.hpp
@@ -179,9 +179,8 @@ namespace hpx { namespace serialization {
         }
 
         template <typename T>
-        typename std::enable_if<!std::is_integral<T>::value &&
-            !std::is_enum<T>::value>::type
-        save(T const& t)
+        std::enable_if_t<!std::is_integral_v<T> && !std::is_enum_v<T>> save(
+            T const& t)
         {
             using use_optimized = std::integral_constant<bool,
                 hpx::traits::is_bitwise_serializable_v<T> ||
@@ -191,9 +190,8 @@ namespace hpx { namespace serialization {
         }
 
         template <typename T>
-        typename std::enable_if<std::is_integral<T>::value ||
-            std::is_enum<T>::value>::type
-        save(T t)    //-V659
+        std::enable_if_t<std::is_integral_v<T> || std::is_enum_v<T>> save(
+            T t)    //-V659
         {
             save_integral(t, std::is_unsigned<T>());
         }
@@ -226,8 +224,6 @@ namespace hpx { namespace serialization {
                 t, hpx::traits::is_nonintrusive_polymorphic<T>());
         }
 
-        // FIXME: think about removing this commented stuff below
-        // and adding new free function save_bitwise
         template <typename T>
         void save_bitwise(T const& t, std::true_type)
         {
@@ -247,6 +243,7 @@ namespace hpx { namespace serialization {
                 save_binary(&t, sizeof(t));
             }
 #else
+            (void) archive_endianess_differs;
             HPX_ASSERT(
                 !(disable_array_optimization() || archive_endianess_differs));
             save_binary(&t, sizeof(t));

--- a/libs/core/serialization/include/hpx/serialization/std_tuple.hpp
+++ b/libs/core/serialization/include/hpx/serialization/std_tuple.hpp
@@ -2,7 +2,7 @@
 //  Copyright (c) 2011-2020 Hartmut Kaiser
 //  Copyright (c) 2013-2015 Agustin Berge
 //  Copyright (c) 2019 Mikael Simberg
-//  Copyright (c) 2020 Hartmut Kaiser
+//  Copyright (c) 2020-2021 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -11,11 +11,30 @@
 #pragma once
 
 #include <hpx/serialization/serialization_fwd.hpp>
+#include <hpx/serialization/traits/is_bitwise_serializable.hpp>
+#include <hpx/serialization/traits/is_not_bitwise_serializable.hpp>
 #include <hpx/type_support/pack.hpp>
 
 #include <cstddef>
 #include <tuple>
 #include <type_traits>
+
+namespace hpx { namespace traits {
+
+    template <typename... Ts>
+    struct is_bitwise_serializable<std::tuple<Ts...>>
+      : ::hpx::util::all_of<hpx::traits::is_bitwise_serializable<
+            typename std::remove_const<Ts>::type>...>
+    {
+    };
+
+    template <typename... Ts>
+    struct is_not_bitwise_serializable<std::tuple<Ts...>>
+      : std::integral_constant<bool,
+            !is_bitwise_serializable_v<std::tuple<Ts...>>>
+    {
+    };
+}}    // namespace hpx::traits
 
 namespace hpx { namespace serialization {
 

--- a/libs/core/serialization/include/hpx/serialization/traits/is_not_bitwise_serializable.hpp
+++ b/libs/core/serialization/include/hpx/serialization/traits/is_not_bitwise_serializable.hpp
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <hpx/config.hpp>
+#include <hpx/serialization/access.hpp>
 
 #include <type_traits>
 
@@ -17,20 +18,29 @@ namespace hpx { namespace traits {
     // serialization for a given type.
 
 #if defined(HPX_SERIALIZATION_HAVE_ALL_TYPES_ARE_BITWISE_SERIALIZABLE)
+    // By default, any abstract type or type that exposes serialization will be
+    // treated as non-bitwise copyable.
     template <typename T>
-    struct is_not_bitwise_serializable : std::is_abstract<T>
+    struct is_not_bitwise_serializable
+      : std::integral_constant<bool,
+            std::is_abstract<T>::value ||
+                hpx::serialization::access::has_serialize<T>::value ||
+                hpx::serialization::has_serialize_adl<T>::value>
     {
     };
+
+    template <typename T>
+    HPX_INLINE_CONSTEXPR_VARIABLE bool is_not_bitwise_serializable_v =
+        is_not_bitwise_serializable<T>::value;
 #else
     template <typename T>
     struct is_not_bitwise_serializable : std::true_type
     {
     };
-#endif
 
     template <typename T>
-    HPX_INLINE_CONSTEXPR_VARIABLE bool is_not_bitwise_serializable_v =
-        is_not_bitwise_serializable<T>::value;
+    HPX_INLINE_CONSTEXPR_VARIABLE bool is_not_bitwise_serializable_v = true;
+#endif
 
 }}    // namespace hpx::traits
 

--- a/libs/core/serialization/include/hpx/serialization/traits/polymorphic_traits.hpp
+++ b/libs/core/serialization/include/hpx/serialization/traits/polymorphic_traits.hpp
@@ -27,14 +27,26 @@ namespace hpx { namespace traits {
     };
 
     template <typename T>
+    HPX_INLINE_CONSTEXPR_VARIABLE bool is_intrusive_polymorphic_v =
+        is_intrusive_polymorphic<T>::value;
+
+    template <typename T>
     struct is_nonintrusive_polymorphic : std::false_type
     {
     };
 
     template <typename T>
+    HPX_INLINE_CONSTEXPR_VARIABLE bool is_nonintrusive_polymorphic_v =
+        is_nonintrusive_polymorphic<T>::value;
+
+    template <typename T>
     struct is_serialized_with_id : detail::has_serialized_with_id<T>
     {
     };
+
+    template <typename T>
+    HPX_INLINE_CONSTEXPR_VARIABLE bool is_serialized_with_id_v =
+        is_serialized_with_id<T>::value;
 }}    // namespace hpx::traits
 
 #define HPX_TRAITS_NONINTRUSIVE_POLYMORPHIC(Class)                             \

--- a/libs/core/serialization/tests/unit/not_bitwise_serializable.cpp
+++ b/libs/core/serialization/tests/unit/not_bitwise_serializable.cpp
@@ -34,6 +34,12 @@ struct A
     }
 };
 
+struct A_nonser
+{
+    int a;
+    double b;
+};
+
 struct B
 {
     int a;
@@ -61,14 +67,30 @@ int hpx_main()
         serialize_A = false;
         A oa{42, 42.0};
         oarchive << oa;
-        HPX_TEST(!serialize_A);
+        HPX_TEST(serialize_A);
 
         hpx::serialization::input_archive iarchive(buffer);
         A ia{0, 0.0};
 
         serialize_A = false;
         iarchive >> ia;
-        HPX_TEST(!serialize_A);
+        HPX_TEST(serialize_A);
+
+        HPX_TEST_EQ(ia.a, 42);
+        HPX_TEST_EQ(ia.b, 42.0);
+    }
+
+    {
+        std::vector<char> buffer;
+        hpx::serialization::output_archive oarchive(buffer);
+
+        A_nonser oa{42, 42.0};
+        oarchive << oa;
+
+        hpx::serialization::input_archive iarchive(buffer);
+        A_nonser ia{0, 0.0};
+
+        iarchive >> ia;
 
         HPX_TEST_EQ(ia.a, 42);
         HPX_TEST_EQ(ia.b, 42.0);

--- a/libs/full/include/include/hpx/hpx.hpp
+++ b/libs/full/include/include/hpx/hpx.hpp
@@ -17,6 +17,7 @@
 #include <hpx/numeric.hpp>
 #include <hpx/optional.hpp>
 #include <hpx/runtime.hpp>
+#include <hpx/serialization.hpp>
 #include <hpx/task_block.hpp>
 #include <hpx/tuple.hpp>
 #include <hpx/type_traits.hpp>

--- a/libs/full/performance_counters/src/counters.cpp
+++ b/libs/full/performance_counters/src/counters.cpp
@@ -30,6 +30,7 @@
 #include <hpx/runtime_local/thread_pool_helpers.hpp>
 #include <hpx/serialization/base_object.hpp>
 #include <hpx/serialization/serialize.hpp>
+#include <hpx/serialization/string.hpp>
 #include <hpx/serialization/vector.hpp>
 #include <hpx/threading_base/thread_helpers.hpp>
 #include <hpx/util/from_string.hpp>

--- a/libs/parallelism/futures/include/hpx/futures/future.hpp
+++ b/libs/parallelism/futures/include/hpx/futures/future.hpp
@@ -26,6 +26,7 @@
 #include <hpx/futures/traits/is_future.hpp>
 #include <hpx/modules/errors.hpp>
 #include <hpx/modules/memory.hpp>
+#include <hpx/serialization/detail/constructor_selector.hpp>
 #include <hpx/serialization/detail/non_default_constructible.hpp>
 #include <hpx/serialization/detail/polymorphic_nonintrusive_factory.hpp>
 #include <hpx/serialization/exception_ptr.hpp>
@@ -72,12 +73,11 @@ namespace hpx { namespace lcos { namespace detail {
         typedef lcos::detail::future_data<value_type> shared_state;
         typedef typename shared_state::init_no_addref init_no_addref;
 
-        std::unique_ptr<value_type> value(
-            serialization::detail::constructor_selector<value_type>::create(
-                ar));
+        value_type&& value =
+            serialization::detail::constructor_selector<value_type>::create(ar);
 
         hpx::intrusive_ptr<shared_state> p(
-            new shared_state(init_no_addref{}, in_place{}, std::move(*value)),
+            new shared_state(init_no_addref{}, in_place{}, std::move(value)),
             false);
 
         f = hpx::traits::future_access<Future>::create(std::move(p));


### PR DESCRIPTION
These changes are needed to make the changes from #5435 actually work.

@msimberg I hate to ask, but would it be possible for this to still get into V1.7? We discovered this issue just now. Nan will test it on her side today and report back asap. I think this would be a very low risk change as it doesn't touch on code that is used for normal operation.