### PR TITLE
Adapt swap_ranges to C++ 20

### DIFF
--- a/cmake/HPX_AddConfigTest.cmake
+++ b/cmake/HPX_AddConfigTest.cmake
@@ -492,6 +492,15 @@ function(hpx_check_for_cxx20_std_execution_policies)
 endfunction()
 
 # ##############################################################################
+function(hpx_check_for_cxx20_std_ranges_iter_swap)
+  add_hpx_config_test(
+    HPX_WITH_CXX20_STD_RANGES_ITER_SWAP
+    SOURCE cmake/tests/cxx20_std_ranges_iter_swap.cpp
+    FILE ${ARGN}
+  )
+endfunction()
+
+# ##############################################################################
 function(hpx_check_for_builtin_integer_pack)
   add_hpx_config_test(
     HPX_WITH_BUILTIN_INTEGER_PACK

--- a/cmake/HPX_PerformCxxFeatureTests.cmake
+++ b/cmake/HPX_PerformCxxFeatureTests.cmake
@@ -84,6 +84,10 @@ function(hpx_perform_cxx_feature_tests)
     DEFINITIONS HPX_HAVE_CXX20_STD_EXECUTION_POLICES
   )
 
+  hpx_check_for_cxx20_std_ranges_iter_swap(
+    DEFINITIONS HPX_HAVE_CXX20_STD_RANGES_ITER_SWAP
+  )
+
   # Check the availability of certain C++ builtins
   hpx_check_for_builtin_integer_pack(DEFINITIONS HPX_HAVE_BUILTIN_INTEGER_PACK)
 

--- a/cmake/tests/cxx20_std_ranges_iter_swap.cpp
+++ b/cmake/tests/cxx20_std_ranges_iter_swap.cpp
@@ -1,0 +1,20 @@
+//  Copyright (c) 2021 Akhil J Nair
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+
+// test for availability of std::ranges::iter_swap (C++ 20)
+
+#include <iterator>
+#include <vector>
+
+int main()
+{
+    std::vector<int> buff1(1, 0);
+    std::vector<int> buff2(1, 1);
+    std::ranges::iter_swap(buff1.begin(), buff2.begin());
+
+    return 0;
+}

--- a/docs/sphinx/api/public_api.rst
+++ b/docs/sphinx/api/public_api.rst
@@ -99,7 +99,7 @@ Functions
 - :cpp:func:`hpx::parallel::v1::sort`
 - :cpp:func:`hpx::parallel::v1::stable_partition`
 - :cpp:func:`hpx::parallel::v1::stable_sort`
-- :cpp:func:`hpx::parallel::v1::swap_ranges`
+- :cpp:func:`hpx::swap_ranges`
 - :cpp:func:`hpx::transform`
 - :cpp:func:`hpx::parallel::v1::unique`
 - :cpp:func:`hpx::parallel::v1::unique_copy`
@@ -143,6 +143,7 @@ Functions
 - :cpp:func:`hpx::ranges::set_intersection`
 - :cpp:func:`hpx::ranges::set_symmetric_difference`
 - :cpp:func:`hpx::ranges::set_union`
+- :cpp:func:`hpx::ranges::swap_ranges`
 - :cpp:func:`hpx::ranges::for_loop`
 - :cpp:func:`hpx::ranges::for_loop_strided`
 

--- a/docs/sphinx/manual/writing_single_node_hpx_applications.rst
+++ b/docs/sphinx/manual/writing_single_node_hpx_applications.rst
@@ -514,7 +514,7 @@ Parallel algorithms
      * Copies and rotates a range of elements.
      * ``<hpx/algorithm.hpp>``
      * :cppreference-algorithm:`rotate_copy`
-   * * :cpp:func:`hpx::parallel::v1::swap_ranges`
+   * * :cpp:func:`hpx::swap_ranges`
      * Swaps two ranges of elements.
      * ``<hpx/algorithm.hpp>``
      * :cppreference-algorithm:`swap_ranges`

--- a/libs/full/include_local/include/hpx/local/algorithm.hpp
+++ b/libs/full/include_local/include/hpx/local/algorithm.hpp
@@ -21,7 +21,6 @@ namespace hpx {
     using hpx::parallel::sort;
     using hpx::parallel::stable_partition;
     using hpx::parallel::stable_sort;
-    using hpx::parallel::swap_ranges;
     using hpx::parallel::unique;
     using hpx::parallel::unique_copy;
 }    // namespace hpx

--- a/libs/parallelism/algorithms/CMakeLists.txt
+++ b/libs/parallelism/algorithms/CMakeLists.txt
@@ -121,6 +121,7 @@ set(algorithms_headers
     hpx/parallel/container_algorithms/set_union.hpp
     hpx/parallel/container_algorithms/sort.hpp
     hpx/parallel/container_algorithms/stable_sort.hpp
+    hpx/parallel/container_algorithms/swap_ranges.hpp
     hpx/parallel/container_algorithms/transform.hpp
     hpx/parallel/container_algorithms/transform_exclusive_scan.hpp
     hpx/parallel/container_algorithms/transform_inclusive_scan.hpp

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/detail/rotate.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/detail/rotate.hpp
@@ -14,6 +14,7 @@
 
 #include <algorithm>
 #include <functional>
+#include <iterator>
 
 namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
 
@@ -25,7 +26,11 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
         Iter next = new_first;
         while (first != next)
         {
+#if defined(HPX_HAVE_CXX20_STD_RANGES_ITER_SWAP)
+            std::ranges::iter_swap(first++, next++);
+#else
             std::iter_swap(first++, next++);
+#endif
             if (next == last)
             {
                 next = new_first;

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/partial_sort.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/partial_sort.hpp
@@ -153,7 +153,11 @@ namespace hpx { namespace parallel { inline namespace v1 {
             auto N2 = (last - first) >> 1;
             Iter it_val =
                 mid3(first + 1, first + N2, last - 1, std::forward<Comp>(comp));
+#if defined(HPX_HAVE_CXX20_STD_RANGES_ITER_SWAP)
+            std::ranges::iter_swap(first, it_val);
+#else
             std::iter_swap(first, it_val);
+#endif
         }
 
         ///////////////////////////////////////////////////////////////////////
@@ -195,7 +199,11 @@ namespace hpx { namespace parallel { inline namespace v1 {
 
             while (c_first < c_last)
             {
+#if defined(HPX_HAVE_CXX20_STD_RANGES_ITER_SWAP)
+                std::ranges::iter_swap(c_first++, c_last--);
+#else
                 std::iter_swap(c_first++, c_last--);
+#endif
                 while (HPX_INVOKE(comp, *c_first, pivot))
                 {
                     ++c_first;
@@ -206,7 +214,11 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 }
             }
 
+#if defined(HPX_HAVE_CXX20_STD_RANGES_ITER_SWAP)
+            std::ranges::iter_swap(first, c_last);
+#else
             std::iter_swap(first, c_last);
+#endif
             return c_last;
         }
 
@@ -244,7 +256,11 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 {
                     if (HPX_INVOKE(comp, *it, *first))
                     {
+#if defined(HPX_HAVE_CXX20_STD_RANGES_ITER_SWAP)
+                        std::ranges::iter_swap(it, first);
+#else
                         std::iter_swap(it, first);
+#endif
                     }
                 }
                 return;

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/partition.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/partition.hpp
@@ -329,7 +329,11 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 if (first == last)
                     break;
 
+#if defined(HPX_HAVE_CXX20_STD_RANGES_ITER_SWAP)
+                std::ranges::iter_swap(first++, last);
+#else
                 std::iter_swap(first++, last);
+#endif
             }
 
             return first;
@@ -354,7 +358,13 @@ namespace hpx { namespace parallel { inline namespace v1 {
             for (FwdIter it = std::next(first); it != last; ++it)
             {
                 if (invoke(pred, invoke(proj, *it)))
+                {
+#if defined(HPX_HAVE_CXX20_STD_RANGES_ITER_SWAP)
+                    std::ranges::iter_swap(first++, it);
+#else
                     std::iter_swap(first++, it);
+#endif
+                }
             }
 
             return first;
@@ -580,7 +590,13 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 FwdIter1 first, FwdIter1 last, FwdIter2 dest)
             {
                 while (first != last)
+                {
+#if defined(HPX_HAVE_CXX20_STD_RANGES_ITER_SWAP)
+                    std::ranges::iter_swap(first++, dest++);
+#else
                     std::iter_swap(first++, dest++);
+#endif
+                }
 
                 return dest;
             }
@@ -620,7 +636,12 @@ namespace hpx { namespace parallel { inline namespace v1 {
                     if (right_block.empty())
                         return left_block;
 
+#if defined(HPX_HAVE_CXX20_STD_RANGES_ITER_SWAP)
+                    std::ranges::iter_swap(
+                        left_block.first++, right_block.first++);
+#else
                     std::iter_swap(left_block.first++, right_block.first++);
+#endif
                 }
             }
 
@@ -678,7 +699,12 @@ namespace hpx { namespace parallel { inline namespace v1 {
                     if (right_iter->empty() || right_iter->block_no < 0)
                         break;
 
+#if defined(HPX_HAVE_CXX20_STD_RANGES_ITER_SWAP)
+                    std::ranges::iter_swap(
+                        left_iter->first++, right_iter->first++);
+#else
                     std::iter_swap(left_iter->first++, right_iter->first++);
+#endif
                 }
 
                 if (left_iter < right_iter ||

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/reverse.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/reverse.hpp
@@ -222,7 +222,11 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 for (auto tail{last2}; !(first == tail or first == --tail);
                      ++first)
                 {
+#if defined(HPX_HAVE_CXX20_STD_RANGES_ITER_SWAP)
+                    std::ranges::iter_swap(first, tail);
+#else
                     std::iter_swap(first, tail);
+#endif
                 }
                 return last2;
             }

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/sort.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/sort.hpp
@@ -108,7 +108,11 @@ namespace hpx { namespace parallel { inline namespace v1 {
             Iter itaux = mid9(first + 1, first + chunk, first + 2 * chunk,
                 first + 3 * chunk, first + 4 * chunk, first + 5 * chunk,
                 first + 6 * chunk, first + 7 * chunk, last - 1, comp);
+#if defined(HPX_HAVE_CXX20_STD_RANGES_ITER_SWAP)
+            std::ranges::iter_swap(first, itaux);
+#else
             std::iter_swap(first, itaux);
+#endif
         }
 
         /// \brief this function is the work assigned to each thread in the
@@ -155,7 +159,11 @@ namespace hpx { namespace parallel { inline namespace v1 {
             }
             while (c_first < c_last)
             {
+#if defined(HPX_HAVE_CXX20_STD_RANGES_ITER_SWAP)
+                std::ranges::iter_swap(c_first++, c_last--);
+#else
                 std::iter_swap(c_first++, c_last--);
+#endif
                 while (comp(*c_first, val))
                 {
                     ++c_first;
@@ -166,7 +174,11 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 }
             }
 
+#if defined(HPX_HAVE_CXX20_STD_RANGES_ITER_SWAP)
+            std::ranges::iter_swap(first, c_last);
+#else
             std::iter_swap(first, c_last);
+#endif
 
             // spawn tasks for each sub section
             hpx::future<RandomIt> left = execution::async_execute(

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/swap_ranges.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/swap_ranges.hpp
@@ -6,6 +6,103 @@
 
 /// \file parallel/algorithms/swap_ranges.hpp
 
+#if defined(DOXYGEN)
+
+namespace hpx {
+    // clang-format off
+
+    ///////////////////////////////////////////////////////////////////////////
+    /// Exchanges elements between range [first1, last1) and another range
+    /// starting at \a first2.
+    ///
+    /// \note   Complexity: Linear in the distance between \a first1 and \a
+    ///  last1
+    ///
+    /// \tparam FwdIter1    The type of the first range of iterators to swap
+    ///                     (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     forward iterator.
+    /// \tparam FwdIter2    The type of the second range of iterators to swap
+    ///                     (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     forward iterator.
+    ///
+    /// \param first1       Refers to the beginning of the first sequence of
+    ///                     elements the algorithm will be applied to.
+    /// \param last1        Refers to the end of the first sequence of elements
+    ///                     the algorithm will be applied to.
+    /// \param first2       Refers to the beginning of the second  sequence of
+    ///                     elements the algorithm will be applied to.
+    ///
+    /// The swap operations in the parallel \a swap_ranges algorithm
+    /// invoked without an execution policy object  execute in sequential
+    /// order in the calling thread.
+    ///
+    /// \returns  The \a swap_ranges algorithm returns \a FwdIter2.
+    ///           The \a swap_ranges algorithm returns iterator to the element
+    ///           past the last element exchanged in the range beginning with
+    ///           \a first2.
+    ///
+    template <typename FwdIter1, typename FwdIter2>
+    FwdIter2 swap_ranges(FwdIter1 first1, FwdIter1 last1, FwdIter2 first2);
+
+    ///////////////////////////////////////////////////////////////////////////
+    /// Exchanges elements between range [first1, last1) and another range
+    /// starting at \a first2.
+    ///
+    /// \note   Complexity: Linear in the distance between \a first1 and \a last1
+    ///
+    /// \tparam ExPolicy    The type of the execution policy to use (deduced).
+    ///                     It describes the manner in which the execution
+    ///                     of the algorithm may be parallelized and the manner
+    ///                     in which it executes the swap operations.
+    /// \tparam FwdIter1    The type of the first range of iterators to swap
+    ///                     (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     forward iterator.
+    /// \tparam FwdIter2    The type of the second range of iterators to swap
+    ///                     (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     forward iterator.
+    ///
+    /// \param policy       The execution policy to use for the scheduling of
+    ///                     the iterations.
+    /// \param first1       Refers to the beginning of the first sequence of
+    ///                     elements the algorithm will be applied to.
+    /// \param last1        Refers to the end of the first sequence of elements
+    ///                     the algorithm will be applied to.
+    /// \param first2       Refers to the beginning of the second  sequence of
+    ///                     elements the algorithm will be applied to.
+    ///
+    /// The swap operations in the parallel \a swap_ranges algorithm
+    /// invoked with an execution policy object of type
+    /// \a sequenced_policy execute in sequential order in
+    /// the calling thread.
+    ///
+    /// The swap operations in the parallel \a swap_ranges algorithm
+    /// invoked with an execution policy object of type
+    /// \a parallel_policy or \a parallel_task_policy are
+    /// permitted to execute in an unordered fashion in unspecified
+    /// threads, and indeterminately sequenced within each thread.
+    ///
+    /// \returns  The \a swap_ranges algorithm returns a
+    ///           \a hpx::future<FwdIter2>  if the execution policy is of
+    ///           type \a parallel_task_policy and returns \a FwdIter2
+    ///           otherwise.
+    ///           The \a swap_ranges algorithm returns iterator to the element
+    ///           past the last element exchanged in the range beginning with
+    ///           \a first2.
+    ///
+    template <typename ExPolicy, typename FwdIter1, typename FwdIter2>
+    typename parallel::util::detail::algorithm_result<ExPolicy, FwdIter2>::type
+    swap_ranges(ExPolicy&& policy, FwdIter1 first1, FwdIter1 last1,
+        FwdIter2 first2);
+
+    // clang-format on
+}    // namespace hpx
+
+#else    // DOXYGEN
+
 #pragma once
 
 #include <hpx/config.hpp>
@@ -117,52 +214,6 @@ namespace hpx { namespace parallel { inline namespace v1 {
         /// \endcond
     }    // namespace detail
 
-    /// Exchanges elements between range [first1, last1) and another range
-    /// starting at \a first2.
-    ///
-    /// \note   Complexity: Linear in the distance between \a first1 and \a last1
-    ///
-    /// \tparam ExPolicy    The type of the execution policy to use (deduced).
-    ///                     It describes the manner in which the execution
-    ///                     of the algorithm may be parallelized and the manner
-    ///                     in which it executes the swap operations.
-    /// \tparam FwdIter1    The type of the first range of iterators to swap
-    ///                     (deduced).
-    ///                     This iterator type must meet the requirements of an
-    ///                     forward iterator.
-    /// \tparam FwdIter2    The type of the second range of iterators to swap
-    ///                     (deduced).
-    ///                     This iterator type must meet the requirements of an
-    ///                     forward iterator.
-    ///
-    /// \param policy       The execution policy to use for the scheduling of
-    ///                     the iterations.
-    /// \param first1       Refers to the beginning of the first sequence of
-    ///                     elements the algorithm will be applied to.
-    /// \param last1        Refers to the end of the first sequence of elements
-    ///                     the algorithm will be applied to.
-    /// \param first2       Refers to the beginning of the second  sequence of
-    ///                     elements the algorithm will be applied to.
-    ///
-    /// The swap operations in the parallel \a swap_ranges algorithm
-    /// invoked with an execution policy object of type
-    /// \a sequenced_policy execute in sequential order in
-    /// the calling thread.
-    ///
-    /// The swap operations in the parallel \a swap_ranges algorithm
-    /// invoked with an execution policy object of type
-    /// \a parallel_policy or \a parallel_task_policy are
-    /// permitted to execute in an unordered fashion in unspecified
-    /// threads, and indeterminately sequenced within each thread.
-    ///
-    /// \returns  The \a swap_ranges algorithm returns a
-    ///           \a hpx::future<FwdIter2>  if the execution policy is of
-    ///           type \a parallel_task_policy and returns \a FwdIter2
-    ///           otherwise.
-    ///           The \a swap_ranges algorithm returns iterator to the element
-    ///           past the last element exchanged in the range beginning with
-    ///           \a first2.
-    ///
     template <typename ExPolicy, typename FwdIter1, typename FwdIter2>
     HPX_DEPRECATED_V(1, 8,
         "hpx::parallel::transform_exclusive_scan is deprecated, use "
@@ -237,3 +288,5 @@ namespace hpx {
         }
     } swap_ranges{};
 }    // namespace hpx
+
+#endif    // DOXYGEN

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/swap_ranges.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/swap_ranges.hpp
@@ -165,9 +165,11 @@ namespace hpx { namespace parallel { inline namespace v1 {
             {
                 while (first1 != last1)
                 {
-                    std::swap(*first1, *first2);
-                    first1++;
-                    first2++;
+#if defined(HPX_HAVE_CXX20_STD_RANGES_ITER_SWAP)
+                    std::ranges::iter_swap(first1++, first2++);
+#else
+                    std::iter_swap(first1++, first2++);
+#endif
                 }
                 return first2;
             }

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/transform_exclusive_scan.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/transform_exclusive_scan.hpp
@@ -372,7 +372,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                     // use this return value
                     [last_iter, final_dest](
                         std::vector<hpx::shared_future<T>>&&,
-                        std::vector<hpx::future<void>> &&) -> result_type {
+                        std::vector<hpx::future<void>>&&) -> result_type {
                         return result_type{last_iter, final_dest};
                     });
             }

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/transform_inclusive_scan.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/transform_inclusive_scan.hpp
@@ -584,7 +584,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                     // step 4 use this return value
                     [last_iter, final_dest](
                         std::vector<hpx::shared_future<T>>&&,
-                        std::vector<hpx::future<void>> &&) -> result_type {
+                        std::vector<hpx::future<void>>&&) -> result_type {
                         return result_type{last_iter, final_dest};
                     });
             }

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms.hpp
@@ -43,5 +43,6 @@
 #include <hpx/parallel/container_algorithms/set_union.hpp>
 #include <hpx/parallel/container_algorithms/sort.hpp>
 #include <hpx/parallel/container_algorithms/stable_sort.hpp>
+#include <hpx/parallel/container_algorithms/swap_ranges.hpp>
 #include <hpx/parallel/container_algorithms/transform.hpp>
 #include <hpx/parallel/container_algorithms/unique.hpp>

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/swap_ranges.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/swap_ranges.hpp
@@ -4,9 +4,214 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-/// \file parallel/container_algorithms/sort.hpp
+/// \file parallel/container_algorithms/swap_ranges.hpp
 
 #pragma once
+
+#if defined(DOXYGEN)
+
+namespace hpx { namespace ranges {
+    // clang-format off
+
+    ///////////////////////////////////////////////////////////////////////////
+    /// Exchanges elements between range [first1, last1) and another range
+    /// starting at \a first2.
+    ///
+    /// \note   Complexity: Linear in the distance between \a first1 and \a last1
+    ///
+    /// \tparam InIter1     The type of the first range of iterators to swap
+    ///                     (deduced).
+    /// \tparam Sent1       The type of the first sentinel (deduced). This
+    ///                     sentinel type must be a sentinel for InIter1.
+    /// \tparam InIter2     The type of the second range of iterators to swap
+    ///                     (deduced).
+    /// \tparam Sent2       The type of the second sentinel (deduced). This
+    ///                     sentinel type must be a sentinel for InIter2.
+    ///
+    /// \param first1       Refers to the beginning of the sequence of elements
+    ///                     for the first range.
+    /// \param last1        Refers to sentinel value denoting the end of the
+    ///                     sequence of elements for the first range.
+    /// \param first2       Refers to the beginning of the sequence of elements
+    ///                     for the second range.
+    /// \param last2        Refers to sentinel value denoting the end of the
+    ///                     sequence of elements for the second range.
+    ///
+    /// The swap operations in the parallel \a swap_ranges algorithm
+    /// invoked without an execution policy object  execute in sequential
+    /// order in the calling thread.
+    ///
+    /// \returns  The \a swap_ranges algorithm returns
+    ///           \a util::in_in_result<InIter1, InIter2>.
+    ///           The \a swap_ranges algorithm returns in_in_result with the
+    ///           first element as the iterator to the element past the last
+    ///           element exchanged in range beginning with \a first1 and the
+    ///           second element as the iterator to the element past the last
+    ///           element exchanged in the range beginning with \a first2.
+    ///
+    template <typename InIter1, typename Sent1, typename InIter2,
+        typename Sent2>
+    parallel::util::in_in_result<InIter1, InIter2>
+    swap_ranges(InIter1 first1, Sent1 last1,InIter2 first2, Sent2 last2);
+
+    ///////////////////////////////////////////////////////////////////////////
+    /// Exchanges elements between range [first1, last1) and another range
+    /// starting at \a first2.
+    ///
+    /// \note   Complexity: Linear in the distance between \a first1 and \a last1
+    ///
+    /// \tparam ExPolicy    The type of the execution policy to use (deduced).
+    ///                     It describes the manner in which the execution
+    ///                     of the algorithm may be parallelized and the manner
+    ///                     in which it executes the assignments.
+    /// \tparam FwdIter1    The type of the first range of iterators to swap
+    ///                     (deduced).
+    /// \tparam Sent1       The type of the first sentinel (deduced). This
+    ///                     sentinel type must be a sentinel for FwdIter1.
+    /// \tparam FwdIter2    The type of the second range of iterators to swap
+    ///                     (deduced).
+    /// \tparam Sent2       The type of the second sentinel (deduced). This
+    ///                     sentinel type must be a sentinel for FwdIter2.
+    ///
+    /// \param policy       The execution policy to use for the scheduling of
+    ///                     the iterations.
+    /// \param first1       Refers to the beginning of the sequence of elements
+    ///                     for the first range.
+    /// \param last1        Refers to sentinel value denoting the end of the
+    ///                     sequence of elements for the first range.
+    /// \param first2       Refers to the beginning of the sequence of elements
+    ///                     for the second range.
+    /// \param last2        Refers to sentinel value denoting the end of the
+    ///                     sequence of elements for the second range.
+    ///
+    /// The swap operations in the parallel \a swap_ranges algorithm
+    /// invoked with an execution policy object of type
+    /// \a sequenced_policy execute in sequential order in
+    /// the calling thread.
+    ///
+    /// The swap operations in the parallel \a swap_ranges algorithm
+    /// invoked with an execution policy object of type
+    /// \a parallel_policy or \a parallel_task_policy are
+    /// permitted to execute in an unordered fashion in unspecified
+    /// threads, and indeterminately sequenced within each thread.
+    ///
+    /// \returns  The \a swap_ranges algorithm returns a
+    ///           \a hpx::future<util::in_in_result<FwdIter1, FwdIter2>>
+    ///           if the execution policy is of type \a parallel_task_policy
+    ///           and returns \a FwdIter2 otherwise.
+    ///           The \a swap_ranges algorithm returns in_in_result with the
+    ///           first element as the iterator to the element past the last
+    ///           element exchanged in range beginning with \a first1 and the
+    ///           second element as the iterator to the element past the last
+    ///           element exchanged in the range beginning with \a first2.
+    ///
+    template <typename ExPolicy, typename FwdIter1, typename Sent1,
+            typename FwdIter2, typename Sent2>
+    typename parallel::util::detail::algorithm_result<ExPolicy,
+        util::in_in_result<FwdIter1, FwdIter2> >::type
+    swap_ranges(ExPolicy&& policy, FwdIter1 first1, Sent1 last1,
+        FwdIter2 first2, Sent2 last2);
+
+    ///////////////////////////////////////////////////////////////////////////
+    /// Exchanges elements between range [first1, last1) and another range
+    /// starting at \a first2.
+    ///
+    /// \note   Complexity: Linear in the distance between \a first1 and \a last1
+    ///
+    /// \tparam Rng1        The type of the source range used (deduced).
+    ///                     The iterators extracted from this range type must
+    ///                     meet the requirements of an input iterator.
+    /// \tparam Rng2        The type of the destination range used (deduced).
+    ///                     The iterators extracted from this range type must
+    ///                     meet the requirements of an input iterator.
+    ///
+    /// \param rng1         Refers to the sequence of elements of the first
+    ///                     range.
+    /// \param rng2         Refers to the sequence of elements of the second
+    ///                     range.
+    ///
+    /// The swap operations in the parallel \a swap_ranges algorithm
+    /// invoked without an execution policy object  execute in sequential
+    /// order in the calling thread.
+    ///
+    /// \returns  The \a swap_ranges algorithm returns
+    ///           \a util::in_in_result<
+    ///           typename hpx::traits::range_traits<Rng1>::iterator_type,
+    ///           typename hpx::traits::range_traits<Rng1>::iterator_type>.
+    ///           The \a swap_ranges algorithm returns in_in_result with the
+    ///           first element as the iterator to the element past the last
+    ///           element exchanged in range beginning with \a first1 and the
+    ///           second element as the iterator to the element past the last
+    ///           element exchanged in the range beginning with \a first2.
+    ///
+    template <typename Rng1, typename Rng2>
+    parallel::util::in_in_result<
+            typename hpx::traits::range_traits<Rng1>::iterator_type,
+            typename hpx::traits::range_traits<Rng2>::iterator_type>
+    swap_ranges(Rng1&& rng1, Rng2&& rng2);
+
+    ///////////////////////////////////////////////////////////////////////////
+    /// Exchanges elements between range [first1, last1) and another range
+    /// starting at \a first2.
+    ///
+    /// \note   Complexity: Linear in the distance between \a first1 and \a last1
+    ///
+    /// \tparam ExPolicy    The type of the execution policy to use (deduced).
+    ///                     It describes the manner in which the execution
+    ///                     of the algorithm may be parallelized and the manner
+    ///                     in which it executes the assignments.
+    /// \tparam Rng1        The type of the source range used (deduced).
+    ///                     The iterators extracted from this range type must
+    ///                     meet the requirements of an input iterator.
+    /// \tparam Rng2        The type of the destination range used (deduced).
+    ///                     The iterators extracted from this range type must
+    ///                     meet the requirements of an input iterator.
+    ///
+    /// \param policy       The execution policy to use for the scheduling of
+    ///                     the iterations.
+    /// \param rng1         Refers to the sequence of elements of the first
+    ///                     range.
+    /// \param rng2         Refers to the sequence of elements of the second
+    ///                     range.
+    ///
+    /// The swap operations in the parallel \a swap_ranges algorithm
+    /// invoked with an execution policy object of type
+    /// \a sequenced_policy execute in sequential order in
+    /// the calling thread.
+    ///
+    /// The swap operations in the parallel \a swap_ranges algorithm
+    /// invoked with an execution policy object of type
+    /// \a parallel_policy or \a parallel_task_policy are
+    /// permitted to execute in an unordered fashion in unspecified
+    /// threads, and indeterminately sequenced within each thread.
+    ///
+    /// \returns  The \a swap_ranges algorithm returns a
+    ///           \a hpx::future<util::in_in_result<
+    ///           typename hpx::traits::range_traits<Rng1>::iterator_type,
+    ///           typename hpx::traits::range_traits<Rng1>::iterator_type>>
+    ///           if the execution policy is of type \a parallel_task_policy
+    ///           and returns \a util::in_in_result<
+    ///           typename hpx::traits::range_traits<Rng1>::iterator_type,
+    ///           typename hpx::traits::range_traits<Rng1>::iterator_type>.
+    ///           otherwise.
+    ///           The \a swap_ranges algorithm returns in_in_result with the
+    ///           first element as the iterator to the element past the last
+    ///           element exchanged in range beginning with \a first1 and the
+    ///           second element as the iterator to the element past the last
+    ///           element exchanged in the range beginning with \a first2.
+    ///
+    template <typename ExPolicy, typename Rng1, typename Rng2>
+    typename parallel::util::detail::algorithm_result<ExPolicy,
+        parallel::util::in_in_result<
+                typename hpx::traits::range_traits<Rng1>::iterator_type,
+                typename hpx::traits::range_traits<Rng2>::iterator_type>>::type
+    swap_ranges(ExPolicy&& policy, ExPolicy&& policy, Rng1&& rng1,
+        Rng2&& rng2);
+
+    // clang-format on
+}}    // namespace hpx::ranges
+
+#else
 
 #include <hpx/config.hpp>
 #include <hpx/concepts/concepts.hpp>
@@ -33,26 +238,26 @@ namespace hpx { namespace ranges {
     {
     private:
         // clang-format off
-        template <typename FwdIter1, typename Sent1, typename FwdIter2,
+        template <typename InIter1, typename Sent1, typename InIter2,
             typename Sent2,
             HPX_CONCEPT_REQUIRES_(
-                hpx::traits::is_iterator<FwdIter1>::value &&
-                hpx::traits::is_sentinel_for<Sent1, FwdIter1>::value &&
-                hpx::traits::is_iterator<FwdIter2>::value &&
-                hpx::traits::is_sentinel_for<Sent2, FwdIter2>::value
+                hpx::traits::is_iterator<InIter1>::value &&
+                hpx::traits::is_sentinel_for<Sent1, InIter1>::value &&
+                hpx::traits::is_iterator<InIter2>::value &&
+                hpx::traits::is_sentinel_for<Sent2, InIter2>::value
             )>
         // clang-format on
-        friend swap_ranges_result<FwdIter1, FwdIter2> tag_fallback_dispatch(
-            hpx::ranges::swap_ranges_t, FwdIter1 first1, Sent1 last1,
-            FwdIter2 first2, Sent2 last2)
+        friend swap_ranges_result<InIter1, InIter2> tag_fallback_dispatch(
+            hpx::ranges::swap_ranges_t, InIter1 first1, Sent1 last1,
+            InIter2 first2, Sent2 last2)
         {
-            static_assert(hpx::traits::is_input_iterator<FwdIter1>::value,
+            static_assert(hpx::traits::is_input_iterator<InIter1>::value,
                 "Requires at least input iterator.");
-            static_assert(hpx::traits::is_input_iterator<FwdIter2>::value,
+            static_assert(hpx::traits::is_input_iterator<InIter2>::value,
                 "Requires at least input iterator.");
 
             return hpx::parallel::v1::detail::swap_ranges<
-                swap_ranges_result<FwdIter1, FwdIter2>>()
+                swap_ranges_result<InIter1, InIter2>>()
                 .call(hpx::execution::seq, first1, last1, first2, last2);
         }
 
@@ -72,10 +277,10 @@ namespace hpx { namespace ranges {
         tag_fallback_dispatch(hpx::ranges::swap_ranges_t, ExPolicy&& policy,
             FwdIter1 first1, Sent1 last1, FwdIter2 first2, Sent2 last2)
         {
-            static_assert(hpx::traits::is_input_iterator<FwdIter1>::value,
-                "Requires at least input iterator.");
-            static_assert(hpx::traits::is_input_iterator<FwdIter2>::value,
-                "Requires at least input iterator.");
+            static_assert(hpx::traits::is_forward_iterator<FwdIter1>::value,
+                "Requires at least forward iterator.");
+            static_assert(hpx::traits::is_forward_iterator<FwdIter2>::value,
+                "Requires at least forward iterator.");
 
             return hpx::parallel::v1::detail::swap_ranges<
                 swap_ranges_result<FwdIter1, FwdIter2>>()
@@ -132,10 +337,12 @@ namespace hpx { namespace ranges {
             using iterator_type2 =
                 typename hpx::traits::range_traits<Rng2>::iterator_type;
 
-            static_assert(hpx::traits::is_input_iterator<iterator_type1>::value,
-                "Requires at least input iterator.");
-            static_assert(hpx::traits::is_input_iterator<iterator_type2>::value,
-                "Requires at least input iterator.");
+            static_assert(
+                hpx::traits::is_forward_iterator<iterator_type1>::value,
+                "Requires at least forward iterator.");
+            static_assert(
+                hpx::traits::is_forward_iterator<iterator_type2>::value,
+                "Requires at least forward iterator.");
 
             return hpx::parallel::v1::detail::swap_ranges<
                 swap_ranges_result<iterator_type1, iterator_type2>>()
@@ -144,3 +351,5 @@ namespace hpx { namespace ranges {
         }
     } swap_ranges{};
 }}    // namespace hpx::ranges
+
+#endif

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/swap_ranges.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/swap_ranges.hpp
@@ -1,4 +1,5 @@
 //  Copyright (c) 2015-2020 Hartmut Kaiser
+//  Copyright (c) 2021 Akhli J Nair
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -42,7 +43,7 @@ namespace hpx { namespace ranges {
     /// order in the calling thread.
     ///
     /// \returns  The \a swap_ranges algorithm returns
-    ///           \a util::in_in_result<InIter1, InIter2>.
+    ///           \a swap_ranges_result<InIter1, InIter2>.
     ///           The \a swap_ranges algorithm returns in_in_result with the
     ///           first element as the iterator to the element past the last
     ///           element exchanged in range beginning with \a first1 and the
@@ -51,7 +52,7 @@ namespace hpx { namespace ranges {
     ///
     template <typename InIter1, typename Sent1, typename InIter2,
         typename Sent2>
-    parallel::util::in_in_result<InIter1, InIter2>
+    swap_ranges_result<InIter1, InIter2>
     swap_ranges(InIter1 first1, Sent1 last1,InIter2 first2, Sent2 last2);
 
     ///////////////////////////////////////////////////////////////////////////
@@ -96,7 +97,7 @@ namespace hpx { namespace ranges {
     /// threads, and indeterminately sequenced within each thread.
     ///
     /// \returns  The \a swap_ranges algorithm returns a
-    ///           \a hpx::future<util::in_in_result<FwdIter1, FwdIter2>>
+    ///           \a hpx::future<swap_ranges_result<FwdIter1, FwdIter2>>
     ///           if the execution policy is of type \a parallel_task_policy
     ///           and returns \a FwdIter2 otherwise.
     ///           The \a swap_ranges algorithm returns in_in_result with the
@@ -108,7 +109,7 @@ namespace hpx { namespace ranges {
     template <typename ExPolicy, typename FwdIter1, typename Sent1,
             typename FwdIter2, typename Sent2>
     typename parallel::util::detail::algorithm_result<ExPolicy,
-        util::in_in_result<FwdIter1, FwdIter2> >::type
+        swap_ranges_result<FwdIter1, FwdIter2> >::type
     swap_ranges(ExPolicy&& policy, FwdIter1 first1, Sent1 last1,
         FwdIter2 first2, Sent2 last2);
 
@@ -135,9 +136,9 @@ namespace hpx { namespace ranges {
     /// order in the calling thread.
     ///
     /// \returns  The \a swap_ranges algorithm returns
-    ///           \a util::in_in_result<
-    ///           typename hpx::traits::range_traits<Rng1>::iterator_type,
-    ///           typename hpx::traits::range_traits<Rng1>::iterator_type>.
+    ///           \a swap_ranges_result<
+    ///           hpx::traits::range_iterator_t<Rng1>,
+    ///           hpx::traits::range_iterator_t<Rng1>>.
     ///           The \a swap_ranges algorithm returns in_in_result with the
     ///           first element as the iterator to the element past the last
     ///           element exchanged in range beginning with \a first1 and the
@@ -145,9 +146,8 @@ namespace hpx { namespace ranges {
     ///           element exchanged in the range beginning with \a first2.
     ///
     template <typename Rng1, typename Rng2>
-    parallel::util::in_in_result<
-            typename hpx::traits::range_traits<Rng1>::iterator_type,
-            typename hpx::traits::range_traits<Rng2>::iterator_type>
+    swap_ranges_result<hpx::traits::range_iterator_t<Rng1>,
+            hpx::traits::range_iterator_t<Rng2>>
     swap_ranges(Rng1&& rng1, Rng2&& rng2);
 
     ///////////////////////////////////////////////////////////////////////////
@@ -186,13 +186,13 @@ namespace hpx { namespace ranges {
     /// threads, and indeterminately sequenced within each thread.
     ///
     /// \returns  The \a swap_ranges algorithm returns a
-    ///           \a hpx::future<util::in_in_result<
-    ///           typename hpx::traits::range_traits<Rng1>::iterator_type,
-    ///           typename hpx::traits::range_traits<Rng1>::iterator_type>>
+    ///           \a hpx::future<swap_ranges_result<
+    ///           hpx::traits::range_iterator_t<Rng1>,
+    ///           hpx::traits::range_iterator_t<Rng1>>>
     ///           if the execution policy is of type \a parallel_task_policy
-    ///           and returns \a util::in_in_result<
-    ///           typename hpx::traits::range_traits<Rng1>::iterator_type,
-    ///           typename hpx::traits::range_traits<Rng1>::iterator_type>.
+    ///           and returns \a swap_ranges_result<
+    ///           hpx::traits::range_iterator_t<Rng1>,
+    ///           hpx::traits::range_iterator_t<Rng1>>.
     ///           otherwise.
     ///           The \a swap_ranges algorithm returns in_in_result with the
     ///           first element as the iterator to the element past the last
@@ -202,9 +202,8 @@ namespace hpx { namespace ranges {
     ///
     template <typename ExPolicy, typename Rng1, typename Rng2>
     typename parallel::util::detail::algorithm_result<ExPolicy,
-        parallel::util::in_in_result<
-                typename hpx::traits::range_traits<Rng1>::iterator_type,
-                typename hpx::traits::range_traits<Rng2>::iterator_type>>::type
+    swap_ranges_result<hpx::traits::range_iterator_t<Rng1>,
+                hpx::traits::range_iterator_t<Rng2>>>::type
     swap_ranges(ExPolicy&& policy, ExPolicy&& policy, Rng1&& rng1,
         Rng2&& rng2);
 
@@ -251,9 +250,9 @@ namespace hpx { namespace ranges {
             hpx::ranges::swap_ranges_t, InIter1 first1, Sent1 last1,
             InIter2 first2, Sent2 last2)
         {
-            static_assert(hpx::traits::is_input_iterator<InIter1>::value,
+            static_assert(hpx::traits::is_input_iterator_v<InIter1>,
                 "Requires at least input iterator.");
-            static_assert(hpx::traits::is_input_iterator<InIter2>::value,
+            static_assert(hpx::traits::is_input_iterator_v<InIter2>,
                 "Requires at least input iterator.");
 
             return hpx::parallel::v1::detail::swap_ranges<
@@ -277,9 +276,9 @@ namespace hpx { namespace ranges {
         tag_fallback_dispatch(hpx::ranges::swap_ranges_t, ExPolicy&& policy,
             FwdIter1 first1, Sent1 last1, FwdIter2 first2, Sent2 last2)
         {
-            static_assert(hpx::traits::is_forward_iterator<FwdIter1>::value,
+            static_assert(hpx::traits::is_forward_iterator_v<FwdIter1>,
                 "Requires at least forward iterator.");
-            static_assert(hpx::traits::is_forward_iterator<FwdIter2>::value,
+            static_assert(hpx::traits::is_forward_iterator_v<FwdIter2>,
                 "Requires at least forward iterator.");
 
             return hpx::parallel::v1::detail::swap_ranges<
@@ -295,20 +294,17 @@ namespace hpx { namespace ranges {
                 hpx::traits::is_range<Rng2>::value
             )>
         // clang-format on
-        friend swap_ranges_result<
-            typename hpx::traits::range_traits<Rng1>::iterator_type,
-            typename hpx::traits::range_traits<Rng2>::iterator_type>
+        friend swap_ranges_result<typename hpx::traits::range_iterator_t<Rng1>,
+            typename hpx::traits::range_iterator_t<Rng2>>
         tag_fallback_dispatch(
             hpx::ranges::swap_ranges_t, Rng1&& rng1, Rng2&& rng2)
         {
-            using iterator_type1 =
-                typename hpx::traits::range_traits<Rng1>::iterator_type;
-            using iterator_type2 =
-                typename hpx::traits::range_traits<Rng2>::iterator_type;
+            using iterator_type1 = typename hpx::traits::range_iterator_t<Rng1>;
+            using iterator_type2 = typename hpx::traits::range_iterator_t<Rng2>;
 
-            static_assert(hpx::traits::is_input_iterator<iterator_type1>::value,
+            static_assert(hpx::traits::is_input_iterator_v<iterator_type1>,
                 "Requires at least input iterator.");
-            static_assert(hpx::traits::is_input_iterator<iterator_type2>::value,
+            static_assert(hpx::traits::is_input_iterator_v<iterator_type2>,
                 "Requires at least input iterator.");
 
             return hpx::parallel::v1::detail::swap_ranges<
@@ -326,22 +322,17 @@ namespace hpx { namespace ranges {
             )>
         // clang-format on
         friend typename parallel::util::detail::algorithm_result<ExPolicy,
-            swap_ranges_result<
-                typename hpx::traits::range_traits<Rng1>::iterator_type,
-                typename hpx::traits::range_traits<Rng2>::iterator_type>>::type
+            swap_ranges_result<typename hpx::traits::range_iterator_t<Rng1>,
+                typename hpx::traits::range_iterator_t<Rng2>>>::type
         tag_fallback_dispatch(hpx::ranges::swap_ranges_t, ExPolicy&& policy,
             Rng1&& rng1, Rng2&& rng2)
         {
-            using iterator_type1 =
-                typename hpx::traits::range_traits<Rng1>::iterator_type;
-            using iterator_type2 =
-                typename hpx::traits::range_traits<Rng2>::iterator_type;
+            using iterator_type1 = typename hpx::traits::range_iterator_t<Rng1>;
+            using iterator_type2 = typename hpx::traits::range_iterator_t<Rng2>;
 
-            static_assert(
-                hpx::traits::is_forward_iterator<iterator_type1>::value,
+            static_assert(hpx::traits::is_forward_iterator_v<iterator_type1>,
                 "Requires at least forward iterator.");
-            static_assert(
-                hpx::traits::is_forward_iterator<iterator_type2>::value,
+            static_assert(hpx::traits::is_forward_iterator_v<iterator_type2>,
                 "Requires at least forward iterator.");
 
             return hpx::parallel::v1::detail::swap_ranges<

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/swap_ranges.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/swap_ranges.hpp
@@ -1,0 +1,131 @@
+//  Copyright (c) 2015-2020 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+/// \file parallel/container_algorithms/sort.hpp
+
+#pragma once
+
+#include <hpx/config.hpp>
+#include <hpx/concepts/concepts.hpp>
+#include <hpx/iterator_support/range.hpp>
+#include <hpx/iterator_support/traits/is_range.hpp>
+
+#include <hpx/algorithms/traits/projected_range.hpp>
+#include <hpx/parallel/algorithms/swap_ranges.hpp>
+#include <hpx/parallel/util/projection_identity.hpp>
+
+#include <type_traits>
+#include <utility>
+
+namespace hpx { namespace ranges {
+    HPX_INLINE_CONSTEXPR_VARIABLE struct swap_ranges_t final
+      : hpx::functional::tag_fallback<swap_ranges_t>
+    {
+    private:
+        // clang-format off
+        template <typename FwdIter1, typename Sent1, typename FwdIter2,
+            typename Sent2,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::traits::is_forward_iterator<FwdIter1>::value &&
+                hpx::traits::is_sentinel_for<Sent1, FwdIter1>::value &&
+                hpx::traits::is_forward_iterator<FwdIter2>::value &&
+                hpx::traits::is_sentinel_for<Sent2, FwdIter2>::value
+            )>
+        // clang-format on
+        friend FwdIter2 tag_fallback_dispatch(hpx::ranges::swap_ranges_t,
+            FwdIter1 first1, Sent1 last1, FwdIter2 first2, Sent2 last2)
+        {
+            static_assert(hpx::traits::is_input_iterator<FwdIter1>::value,
+                "Requires at least forward iterator.");
+            static_assert(hpx::traits::is_output_iterator<FwdIter2>::value,
+                "Requires at least forward iterator.");
+
+            return hpx::parallel::v1::detail::swap_ranges<FwdIter2>().call(
+                hpx::execution::seq, first1, last1, first2, last2);
+        }
+
+        // clang-format off
+        template <typename ExPolicy, typename FwdIter1, typename Sent1,
+            typename FwdIter2, typename Sent2,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::is_execution_policy<ExPolicy>::value &&
+                hpx::traits::is_forward_iterator<FwdIter1>::value &&
+                hpx::traits::is_sentinel_for<Sent1, FwdIter1>::value &&
+                hpx::traits::is_forward_iterator<FwdIter2>::value &&
+                hpx::traits::is_sentinel_for<Sent2, FwdIter2>::value
+            )>
+        // clang-format on
+        friend typename parallel::util::detail::algorithm_result<ExPolicy,
+            FwdIter2>::type
+        tag_fallback_dispatch(hpx::ranges::swap_ranges_t, ExPolicy&& policy,
+            FwdIter1 first1, Sent1 last1, FwdIter2 first2, Sent2 last2)
+        {
+            static_assert(hpx::traits::is_input_iterator<FwdIter1>::value,
+                "Requires at least forward iterator.");
+            static_assert(hpx::traits::is_output_iterator<FwdIter2>::value,
+                "Requires at least forward iterator.");
+
+            return hpx::parallel::v1::detail::swap_ranges<FwdIter2>().call(
+                std::forward<ExPolicy>(policy), first1, last1, first2, last2);
+        }
+
+        // clang-format off
+        template <typename Rng1, typename Rng2,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::traits::is_range<Rng1>::value &&
+                hpx::traits::is_range<Rng2>::value
+            )>
+        // clang-format on
+        friend typename hpx::traits::range_traits<Rng2>::iterator_type
+        tag_fallback_dispatch(
+            hpx::ranges::swap_ranges_t, Rng1&& rng1, Rng2&& rng2)
+        {
+            using iterator_type1 =
+                typename hpx::traits::range_traits<Rng1>::iterator_type;
+            using iterator_type2 =
+                typename hpx::traits::range_traits<Rng2>::iterator_type;
+
+            static_assert(hpx::traits::is_input_iterator<iterator_type1>::value,
+                "Requires at least forward iterator.");
+            static_assert(
+                hpx::traits::is_forward_iterator<iterator_type2>::value,
+                "Requires at least forward iterator.");
+
+            return hpx::parallel::v1::detail::swap_ranges<iterator_type2>()
+                .call(hpx::execution::seq, std::begin(rng1), std::end(rng1),
+                    std::begin(rng2), std::end(rng2));
+        }
+
+        // clang-format off
+        template <typename ExPolicy, typename Rng1, typename Rng2,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::is_execution_policy<ExPolicy>::value &&
+                hpx::traits::is_range<Rng1>::value &&
+                hpx::traits::is_range<Rng2>::value
+            )>
+        // clang-format on
+        friend typename parallel::util::detail::algorithm_result<ExPolicy,
+            typename hpx::traits::range_traits<Rng2>::iterator_type>::type
+        tag_fallback_dispatch(hpx::ranges::swap_ranges_t, ExPolicy&& policy,
+            Rng1&& rng1, Rng2&& rng2)
+        {
+            using iterator_type1 =
+                typename hpx::traits::range_traits<Rng1>::iterator_type;
+            using iterator_type2 =
+                typename hpx::traits::range_traits<Rng2>::iterator_type;
+
+            static_assert(hpx::traits::is_input_iterator<iterator_type1>::value,
+                "Requires at least forward iterator.");
+            static_assert(
+                hpx::traits::is_forward_iterator<iterator_type2>::value,
+                "Requires at least forward iterator.");
+
+            return hpx::parallel::v1::detail::swap_ranges<iterator_type2>()
+                .call(std::forward<ExPolicy>(policy), std::begin(rng1),
+                    std::end(rng1), std::begin(rng2), std::end(rng2));
+        }
+    } swap_ranges{};
+}}    // namespace hpx::ranges

--- a/libs/parallelism/algorithms/include/hpx/parallel/util/result_types.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/util/result_types.hpp
@@ -52,6 +52,19 @@ namespace hpx { namespace parallel { namespace util {
         }
     };
 
+    template <typename I1, typename I2>
+    I2 get_in2_element(util::in_in_result<I1, I2>&& p)
+    {
+        return p.in2;
+    }
+
+    template <typename I1, typename I2>
+    hpx::future<I2> get_in2_element(hpx::future<util::in_in_result<I1, I2>>&& f)
+    {
+        return hpx::make_future<I2>(
+            std::move(f), [](util::in_in_result<I1, I2>&& p) { return p.in2; });
+    }
+
     ///////////////////////////////////////////////////////////////////////////
     template <typename I, typename O>
     struct in_out_result

--- a/libs/parallelism/algorithms/include/hpx/parallel/util/zip_iterator.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/util/zip_iterator.hpp
@@ -12,8 +12,8 @@
 #include <hpx/futures/future.hpp>
 #include <hpx/iterator_support/zip_iterator.hpp>
 #include <hpx/modules/execution.hpp>
-#include <hpx/parallel/util/tagged_pair.hpp>
 #include <hpx/parallel/util/result_types.hpp>
+#include <hpx/parallel/util/tagged_pair.hpp>
 
 #include <utility>
 

--- a/libs/parallelism/algorithms/include/hpx/parallel/util/zip_iterator.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/util/zip_iterator.hpp
@@ -13,6 +13,7 @@
 #include <hpx/iterator_support/zip_iterator.hpp>
 #include <hpx/modules/execution.hpp>
 #include <hpx/parallel/util/tagged_pair.hpp>
+#include <hpx/parallel/util/result_types.hpp>
 
 #include <utility>
 
@@ -114,6 +115,44 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
         return lcos::make_future<result_type>(
             std::move(zipiter), [](ZipIter&& zipiter) {
                 return get_iter_tagged_pair<Tag1, Tag2>(std::move(zipiter));
+            });
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    template <typename ZipIter>
+    util::in_in_result<typename hpx::tuple_element<0,
+                           typename ZipIter::iterator_tuple_type>::type,
+        typename hpx::tuple_element<1,
+            typename ZipIter::iterator_tuple_type>::type>
+    get_iter_in_in_result(ZipIter&& zipiter)
+    {
+        using iterator_tuple_type = typename ZipIter::iterator_tuple_type;
+
+        using result_type = util::in_in_result<
+            typename hpx::tuple_element<0, iterator_tuple_type>::type,
+            typename hpx::tuple_element<1, iterator_tuple_type>::type>;
+
+        iterator_tuple_type t = zipiter.get_iterator_tuple();
+        return result_type{hpx::get<0>(t), hpx::get<1>(t)};
+    }
+
+    template <typename ZipIter>
+    hpx::future<
+        util::in_in_result<typename hpx::tuple_element<0,
+                               typename ZipIter::iterator_tuple_type>::type,
+            typename hpx::tuple_element<1,
+                typename ZipIter::iterator_tuple_type>::type>>
+    get_iter_in_in_result(hpx::future<ZipIter>&& zipiter)
+    {
+        using iterator_tuple_type = typename ZipIter::iterator_tuple_type;
+
+        using result_type = util::in_in_result<
+            typename hpx::tuple_element<0, iterator_tuple_type>::type,
+            typename hpx::tuple_element<1, iterator_tuple_type>::type>;
+
+        return lcos::make_future<result_type>(
+            std::move(zipiter), [](ZipIter zipiter) {
+                return get_iter_in_in_result(std::move(zipiter));
             });
     }
 }}}}    // namespace hpx::parallel::v1::detail

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/CMakeLists.txt
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/CMakeLists.txt
@@ -88,6 +88,7 @@ set(tests
     set_union_range
     sort_range
     stable_sort_range
+    swap_ranges_range
     transform_range
     transform_range_binary
     transform_range2

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/swap_ranges_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/swap_ranges_range.cpp
@@ -1,0 +1,254 @@
+//  Copyright (c) 2018 Christopher Ogle
+//  Copyright (c) 2020 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/iterator_support/tests/iter_sent.hpp>
+#include <hpx/local/init.hpp>
+#include <hpx/modules/testing.hpp>
+#include <hpx/parallel/container_algorithms/swap_ranges.hpp>
+
+#include <algorithm>
+#include <cstddef>
+#include <iostream>
+#include <iterator>
+#include <random>
+#include <string>
+#include <unordered_set>
+#include <vector>
+
+#include "test_utils.hpp"
+
+////////////////////////////////////////////////////////////////////////////
+unsigned int seed;
+std::mt19937 gen;
+std::uniform_int_distribution<> dis(1, 10007);
+
+template <typename IteratorTag>
+void test_swap_ranges_sent(IteratorTag)
+{
+    std::vector<std::size_t> c(10007);
+    std::vector<std::size_t> d(c.size());
+
+    std::size_t len = std::rand() % 10007 + 1;
+    std::size_t begin_num = std::rand();
+
+    std::iota(std::begin(c), std::begin(c) + len, begin_num);
+    d = c;
+    std::reverse(std::begin(d), std::begin(d) + len);
+
+    std::fill(std::begin(c) + len, std::end(c), 100);
+    std::fill(std::begin(d) + len, std::end(d), 200);
+
+    hpx::ranges::swap_ranges(std::begin(c), sentinel<std::size_t>{100},
+        std::begin(d), sentinel<std::size_t>{200});
+
+    std::size_t count = 0;
+    std::for_each(
+        std::begin(d), std::end(d), [&count, len, begin_num](std::size_t v) {
+            if (count < len)
+            {
+                HPX_TEST_EQ(v, count + begin_num);
+                count++;
+            }
+            else
+            {
+                HPX_TEST_EQ(v, 200);
+            }
+        });
+
+    std::for_each(
+        std::begin(c), std::end(c), [&count, len, begin_num](std::size_t v) {
+            if (count >= 1)
+            {
+                HPX_TEST_EQ(v, count + begin_num - 1);
+                count--;
+            }
+            else
+            {
+                HPX_TEST_EQ(v, 100);
+            }
+        });
+}
+
+template <typename ExPolicy, typename IteratorTag>
+void test_swap_ranges_sent(ExPolicy policy, IteratorTag)
+{
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
+
+    std::vector<std::size_t> c(10007);
+    std::vector<std::size_t> d(c.size());
+
+    std::size_t len = std::rand() % 10007 + 1;
+    std::size_t begin_num = std::rand();
+
+    std::iota(std::begin(c), std::begin(c) + len, begin_num);
+    d = c;
+    std::reverse(std::begin(d), std::begin(d) + len);
+
+    std::fill(std::begin(c) + len, std::end(c), 100);
+    std::fill(std::begin(d) + len, std::end(d), 200);
+
+    hpx::ranges::swap_ranges(policy, std::begin(c), sentinel<std::size_t>{100},
+        std::begin(d), sentinel<std::size_t>{200});
+
+    std::size_t count = 0;
+    std::for_each(
+        std::begin(d), std::end(d), [&count, len, begin_num](std::size_t v) {
+            if (count < len)
+            {
+                HPX_TEST_EQ(v, count + begin_num);
+                count++;
+            }
+            else
+            {
+                HPX_TEST_EQ(v, 200);
+            }
+        });
+
+    std::for_each(
+        std::begin(c), std::end(c), [&count, len, begin_num](std::size_t v) {
+            if (count >= 1)
+            {
+                HPX_TEST_EQ(v, count + begin_num - 1);
+                count--;
+            }
+            else
+            {
+                HPX_TEST_EQ(v, 100);
+            }
+        });
+}
+
+template <typename IteratorTag>
+void test_swap_ranges(IteratorTag)
+{
+    std::vector<std::size_t> c(10007);
+    std::vector<std::size_t> d(c.size());
+    std::vector<std::size_t> e(c.size());
+
+    std::iota(std::begin(c), std::end(c), std::rand());
+    d = c;
+    e = c;
+    std::reverse(std::begin(d), std::end(d));
+
+    hpx::ranges::swap_ranges(c, d);
+
+    std::size_t count = 0;
+    HPX_TEST(std::equal(std::begin(c), std::end(c), e.rbegin()));
+    HPX_TEST(std::equal(std::begin(d), std::end(d), e.begin()));
+}
+
+template <typename ExPolicy, typename IteratorTag>
+void test_swap_ranges(ExPolicy policy, IteratorTag)
+{
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
+
+    std::vector<std::size_t> c(10007);
+    std::vector<std::size_t> d(c.size());
+    std::vector<std::size_t> e(c.size());
+
+    std::iota(std::begin(c), std::end(c), std::rand());
+    d = c;
+    e = c;
+    std::reverse(std::begin(d), std::end(d));
+
+    hpx::ranges::swap_ranges(policy, c, d);
+
+    std::size_t count = 0;
+    HPX_TEST(std::equal(std::begin(c), std::end(c), e.rbegin()));
+    HPX_TEST(std::equal(std::begin(d), std::end(d), e.begin()));
+}
+
+template <typename ExPolicy, typename IteratorTag>
+void test_swap_ranges_async(ExPolicy policy, IteratorTag)
+{
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
+
+    std::vector<std::size_t> c(10007);
+    std::vector<std::size_t> d(c.size());
+    std::vector<std::size_t> e(c.size());
+
+    std::iota(std::begin(c), std::end(c), std::rand());
+    d = c;
+    e = c;
+    std::reverse(std::begin(d), std::end(d));
+
+    auto fut = hpx::ranges::swap_ranges(policy, c, d);
+    fut.wait();
+
+    std::size_t count = 0;
+    HPX_TEST(std::equal(std::begin(c), std::end(c), e.rbegin()));
+    HPX_TEST(std::equal(std::begin(d), std::end(d), e.begin()));
+}
+
+template <typename IteratorTag>
+void test_swap_ranges()
+{
+    using namespace hpx::execution;
+
+    test_swap_ranges(IteratorTag());
+    test_swap_ranges(seq, IteratorTag());
+    test_swap_ranges(par, IteratorTag());
+    test_swap_ranges(par_unseq, IteratorTag());
+
+    test_swap_ranges_async(seq(task), IteratorTag());
+    test_swap_ranges_async(par(task), IteratorTag());
+
+    test_swap_ranges_sent(IteratorTag());
+    test_swap_ranges_sent(seq, IteratorTag());
+    test_swap_ranges_sent(par, IteratorTag());
+    test_swap_ranges_sent(par_unseq, IteratorTag());
+}
+
+void swap_ranges_test()
+{
+    test_swap_ranges<std::random_access_iterator_tag>();
+    test_swap_ranges<std::forward_iterator_tag>();
+}
+
+////////////////////////////////////////////////////////////////////////////
+int hpx_main(hpx::program_options::variables_map& vm)
+{
+    unsigned int seed1 = (unsigned int) std::time(nullptr);
+    if (vm.count("seed"))
+        seed1 = vm["seed"].as<unsigned int>();
+
+    std::cout << "using seed: " << seed1 << std::endl;
+    std::srand(seed1);
+
+    seed = seed1;
+    gen = std::mt19937(seed);
+
+    swap_ranges_test();
+    return hpx::local::finalize();
+}
+
+int main(int argc, char* argv[])
+{
+    // add command line option which controls the random number generator seed
+    using namespace hpx::program_options;
+    options_description desc_commandline(
+        "Usage: " HPX_APPLICATION_STRING " [options]");
+
+    desc_commandline.add_options()("seed,s", value<unsigned int>(),
+        "the random number generator seed to use for this run");
+
+    // By default this test should run on all available cores
+    std::vector<std::string> const cfg = {"hpx.os_threads=all"};
+
+    // Initialize and run HPX
+    hpx::local::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::local::init(hpx_main, argc, argv, init_args), 0,
+        "HPX main exited with non-zero status");
+
+    return hpx::util::report_errors();
+}

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/swap_ranges_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/swap_ranges_range.cpp
@@ -1,5 +1,6 @@
 //  Copyright (c) 2018 Christopher Ogle
 //  Copyright (c) 2020 Hartmut Kaiser
+//  Copyright (c) 2021 Akhil J Nair
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -32,7 +33,7 @@ void test_swap_ranges_sent(IteratorTag)
     std::vector<std::size_t> c(10007);
     std::vector<std::size_t> d(c.size());
 
-    std::size_t len = std::rand() % 10007 + 1;
+    std::size_t len = std::rand() % 10005 + 1;
     std::size_t begin_num = std::rand();
 
     std::iota(std::begin(c), std::begin(c) + len, begin_num);
@@ -82,7 +83,7 @@ void test_swap_ranges_sent(ExPolicy policy, IteratorTag)
     std::vector<std::size_t> c(10007);
     std::vector<std::size_t> d(c.size());
 
-    std::size_t len = std::rand() % 10007 + 1;
+    std::size_t len = std::rand() % 10005 + 1;
     std::size_t begin_num = std::rand();
 
     std::iota(std::begin(c), std::begin(c) + len, begin_num);

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/swap_ranges_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/swap_ranges_range.cpp
@@ -55,12 +55,12 @@ void test_swap_ranges_sent(IteratorTag)
             }
             else
             {
-                HPX_TEST_EQ(v, 200);
+                HPX_TEST_EQ(v, static_cast<std::size_t>(200));
             }
         });
 
     std::for_each(
-        std::begin(c), std::end(c), [&count, len, begin_num](std::size_t v) {
+        std::begin(c), std::end(c), [&count, begin_num](std::size_t v) {
             if (count >= 1)
             {
                 HPX_TEST_EQ(v, count + begin_num - 1);
@@ -68,7 +68,7 @@ void test_swap_ranges_sent(IteratorTag)
             }
             else
             {
-                HPX_TEST_EQ(v, 100);
+                HPX_TEST_EQ(v, static_cast<std::size_t>(100));
             }
         });
 }
@@ -105,12 +105,12 @@ void test_swap_ranges_sent(ExPolicy policy, IteratorTag)
             }
             else
             {
-                HPX_TEST_EQ(v, 200);
+                HPX_TEST_EQ(v, static_cast<std::size_t>(200));
             }
         });
 
     std::for_each(
-        std::begin(c), std::end(c), [&count, len, begin_num](std::size_t v) {
+        std::begin(c), std::end(c), [&count, begin_num](std::size_t v) {
             if (count >= 1)
             {
                 HPX_TEST_EQ(v, count + begin_num - 1);
@@ -118,7 +118,7 @@ void test_swap_ranges_sent(ExPolicy policy, IteratorTag)
             }
             else
             {
-                HPX_TEST_EQ(v, 100);
+                HPX_TEST_EQ(v, static_cast<std::size_t>(100));
             }
         });
 }
@@ -137,7 +137,6 @@ void test_swap_ranges(IteratorTag)
 
     hpx::ranges::swap_ranges(c, d);
 
-    std::size_t count = 0;
     HPX_TEST(std::equal(std::begin(c), std::end(c), e.rbegin()));
     HPX_TEST(std::equal(std::begin(d), std::end(d), e.begin()));
 }
@@ -159,7 +158,6 @@ void test_swap_ranges(ExPolicy policy, IteratorTag)
 
     hpx::ranges::swap_ranges(policy, c, d);
 
-    std::size_t count = 0;
     HPX_TEST(std::equal(std::begin(c), std::end(c), e.rbegin()));
     HPX_TEST(std::equal(std::begin(d), std::end(d), e.begin()));
 }
@@ -182,7 +180,6 @@ void test_swap_ranges_async(ExPolicy policy, IteratorTag)
     auto fut = hpx::ranges::swap_ranges(policy, c, d);
     fut.wait();
 
-    std::size_t count = 0;
     HPX_TEST(std::equal(std::begin(c), std::end(c), e.rbegin()));
     HPX_TEST(std::equal(std::begin(d), std::end(d), e.begin()));
 }


### PR DESCRIPTION
Adapted swap_ranges to C++ 20 and added container overloads. (range and sentinel). Added container tests.

## Any background context you want to provide?
Issue #4822
Issue #3646
Issue #1668