### PR TITLE
Fix find_end parallel overload

### DIFF
--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/find.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/find.hpp
@@ -822,8 +822,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                     std::greater<difference_type>>
                     tok(-1);
 
-                auto f1 = [count, diff, tok, first2,
-                              op = std::forward<Pred>(op),
+                auto f1 = [diff, tok, first2, op = std::forward<Pred>(op),
                               proj1 = std::forward<Proj1>(proj1),
                               proj2 = std::forward<Proj2>(proj2)](Iter1 it,
                               std::size_t part_size,

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/find.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/find.hpp
@@ -802,8 +802,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
             {
                 using result_type =
                     util::detail::algorithm_result<ExPolicy, Iter1>;
-                using reference =
-                    typename std::iterator_traits<Iter1>::reference;
+
                 using difference_type =
                     typename std::iterator_traits<Iter1>::difference_type;
 
@@ -829,26 +828,25 @@ namespace hpx { namespace parallel { inline namespace v1 {
                               proj2 = std::forward<Proj2>(proj2)](Iter1 it,
                               std::size_t part_size,
                               std::size_t base_idx) mutable -> void {
-                    Iter1 curr = it;
-
                     util::loop_idx_n(base_idx, it, part_size, tok,
-                        [=, &tok, &curr, &op, &proj1, &proj2](
-                            reference t, std::size_t i) -> void {
-                            ++curr;
+                        [=, &tok, &op, &proj1, &proj2](
+                            auto t, std::size_t i) -> void {
                             if (hpx::util::invoke(op,
                                     hpx::util::invoke(proj1, t),
                                     hpx::util::invoke(proj2, *first2)))
                             {
                                 difference_type local_count = 1;
-                                FwdIter mid = curr;
+                                auto mid = t;
+                                auto mid2 = first2;
+                                ++mid;
+                                ++mid2;
 
-                                for (difference_type len = 0;
-                                     local_count != diff && len != count;
-                                     (void) ++local_count, ++len, ++mid)
+                                for (; local_count != diff;
+                                     ++local_count, ++mid, ++mid2)
                                 {
                                     if (!hpx::util::invoke(op,
-                                            hpx::util::invoke(proj1, t),
-                                            hpx::util::invoke(proj2, *first2)))
+                                            hpx::util::invoke(proj1, mid),
+                                            hpx::util::invoke(proj2, *mid2)))
                                     {
                                         break;
                                     }

--- a/libs/parallelism/algorithms/tests/unit/algorithms/findend.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/findend.cpp
@@ -43,9 +43,10 @@ void test_find_end1(IteratorTag)
     iterator index = hpx::find_end(iterator(std::begin(c)),
         iterator(std::end(c)), std::begin(h), std::end(h));
 
-    base_iterator test_index = std::begin(c) + c.size() / 2;
+    iterator test_index = std::find_end(iterator(std::begin(c)),
+        iterator(std::end(c)), std::begin(h), std::end(h));
 
-    HPX_TEST(index == iterator(test_index));
+    HPX_TEST(index == test_index);
 }
 
 template <typename ExPolicy, typename IteratorTag>
@@ -69,9 +70,10 @@ void test_find_end1(ExPolicy&& policy, IteratorTag)
     iterator index = hpx::find_end(policy, iterator(std::begin(c)),
         iterator(std::end(c)), std::begin(h), std::end(h));
 
-    base_iterator test_index = std::begin(c) + c.size() / 2;
+    iterator test_index = std::find_end(iterator(std::begin(c)),
+        iterator(std::end(c)), std::begin(h), std::end(h));
 
-    HPX_TEST(index == iterator(test_index));
+    HPX_TEST(index == test_index);
 }
 
 template <typename ExPolicy, typename IteratorTag>
@@ -93,10 +95,10 @@ void test_find_end1_async(ExPolicy&& p, IteratorTag)
         iterator(std::end(c)), std::begin(h), std::end(h));
     f.wait();
 
-    // create iterator at position of value to be found
-    base_iterator test_index = std::begin(c) + c.size() / 2;
+    iterator test_index = std::find_end(iterator(std::begin(c)),
+        iterator(std::end(c)), std::begin(h), std::end(h));
 
-    HPX_TEST(f.get() == iterator(test_index));
+    HPX_TEST(f.get() == test_index);
 }
 
 template <typename IteratorTag>
@@ -140,9 +142,10 @@ void test_find_end2(IteratorTag)
     iterator index = hpx::find_end(iterator(std::begin(c)),
         iterator(std::end(c)), std::begin(h), std::end(h));
 
-    base_iterator test_index = std::begin(c) + c.size() - 2;
+    iterator test_index = std::find_end(iterator(std::begin(c)),
+        iterator(std::end(c)), std::begin(h), std::end(h));
 
-    HPX_TEST(index == iterator(test_index));
+    HPX_TEST(index == test_index);
 }
 
 template <typename ExPolicy, typename IteratorTag>
@@ -168,9 +171,10 @@ void test_find_end2(ExPolicy&& policy, IteratorTag)
     iterator index = hpx::find_end(policy, iterator(std::begin(c)),
         iterator(std::end(c)), std::begin(h), std::end(h));
 
-    base_iterator test_index = std::begin(c) + c.size() - 2;
+    iterator test_index = std::find_end(iterator(std::begin(c)),
+        iterator(std::end(c)), std::begin(h), std::end(h));
 
-    HPX_TEST(index == iterator(test_index));
+    HPX_TEST(index == test_index);
 }
 
 template <typename ExPolicy, typename IteratorTag>
@@ -195,10 +199,10 @@ void test_find_end2_async(ExPolicy&& p, IteratorTag)
         iterator(std::end(c)), std::begin(h), std::end(h));
     f.wait();
 
-    // create iterator at position of value to be found
-    base_iterator test_index = std::begin(c) + c.size() - 2;
+    iterator test_index = std::find_end(iterator(std::begin(c)),
+        iterator(std::end(c)), std::begin(h), std::end(h));
 
-    HPX_TEST(f.get() == iterator(test_index));
+    HPX_TEST(f.get() == test_index);
 }
 
 template <typename IteratorTag>
@@ -242,9 +246,10 @@ void test_find_end3(IteratorTag)
     iterator index = hpx::find_end(iterator(std::begin(c)),
         iterator(std::end(c)), std::begin(h), std::end(h));
 
-    base_iterator test_index = std::begin(c);
+    iterator test_index = std::find_end(iterator(std::begin(c)),
+        iterator(std::end(c)), std::begin(h), std::end(h));
 
-    HPX_TEST(index == iterator(test_index));
+    HPX_TEST(index == test_index);
 }
 
 template <typename ExPolicy, typename IteratorTag>
@@ -270,9 +275,10 @@ void test_find_end3(ExPolicy&& policy, IteratorTag)
     iterator index = hpx::find_end(policy, iterator(std::begin(c)),
         iterator(std::end(c)), std::begin(h), std::end(h));
 
-    base_iterator test_index = std::begin(c);
+    iterator test_index = std::find_end(iterator(std::begin(c)),
+        iterator(std::end(c)), std::begin(h), std::end(h));
 
-    HPX_TEST(index == iterator(test_index));
+    HPX_TEST(index == test_index);
 }
 
 template <typename ExPolicy, typename IteratorTag>
@@ -298,10 +304,10 @@ void test_find_end3_async(ExPolicy&& p, IteratorTag)
         iterator(std::end(c)), std::begin(h), std::end(h));
     f.wait();
 
-    //create iterator at position of value to be found
-    base_iterator test_index = std::begin(c);
+    iterator test_index = std::find_end(iterator(std::begin(c)),
+        iterator(std::end(c)), std::begin(h), std::end(h));
 
-    HPX_TEST(f.get() == iterator(test_index));
+    HPX_TEST(f.get() == test_index);
 }
 
 template <typename IteratorTag>
@@ -345,9 +351,11 @@ void test_find_end4(IteratorTag)
         iterator(std::end(c)), std::begin(h), std::end(h),
         [](std::size_t v1, std::size_t v2) { return !(v1 != v2); });
 
-    base_iterator test_index = std::begin(c) + c.size() / 2;
+    iterator test_index = std::find_end(iterator(std::begin(c)),
+        iterator(std::end(c)), std::begin(h), std::end(h),
+        [](std::size_t v1, std::size_t v2) { return !(v1 != v2); });
 
-    HPX_TEST(index == iterator(test_index));
+    HPX_TEST(index == test_index);
 }
 
 template <typename ExPolicy, typename IteratorTag>
@@ -372,9 +380,11 @@ void test_find_end4(ExPolicy&& policy, IteratorTag)
         iterator(std::end(c)), std::begin(h), std::end(h),
         [](std::size_t v1, std::size_t v2) { return !(v1 != v2); });
 
-    base_iterator test_index = std::begin(c) + c.size() / 2;
+    iterator test_index = std::find_end(iterator(std::begin(c)),
+        iterator(std::end(c)), std::begin(h), std::end(h),
+        [](std::size_t v1, std::size_t v2) { return !(v1 != v2); });
 
-    HPX_TEST(index == iterator(test_index));
+    HPX_TEST(index == test_index);
 }
 
 template <typename ExPolicy, typename IteratorTag>
@@ -398,10 +408,11 @@ void test_find_end4_async(ExPolicy&& p, IteratorTag)
         [](std::size_t v1, std::size_t v2) { return !(v1 != v2); });
     f.wait();
 
-    //create iterator at position of value to be found
-    base_iterator test_index = std::begin(c) + c.size() / 2;
+    iterator test_index = std::find_end(iterator(std::begin(c)),
+        iterator(std::end(c)), std::begin(h), std::end(h),
+        [](std::size_t v1, std::size_t v2) { return !(v1 != v2); });
 
-    HPX_TEST(f.get() == iterator(test_index));
+    HPX_TEST(f.get() == test_index);
 }
 
 template <typename IteratorTag>


### PR DESCRIPTION

## Fixes find_end parallel overload
The current version just checks the first element in the subsequence and returns the iterator if matches.
It does not check the whole subsequence.

## Proposed Changes
- Replaces typedef reference with auto.
- Removes unused `curr` Iterator variable.
- Uses `mid` and `mid2` to check the whole subsequence.
 
