### PR TITLE
Adapt unique and unique_copy to C++ 20

### DIFF
--- a/docs/sphinx/api/public_api.rst
+++ b/docs/sphinx/api/public_api.rst
@@ -101,8 +101,8 @@ Functions
 - :cpp:func:`hpx::parallel::v1::stable_sort`
 - :cpp:func:`hpx::swap_ranges`
 - :cpp:func:`hpx::transform`
-- :cpp:func:`hpx::parallel::v1::unique`
-- :cpp:func:`hpx::parallel::v1::unique_copy`
+- :cpp:func:`hpx::unique`
+- :cpp:func:`hpx::unique_copy`
 - :cpp:func:`hpx::for_loop`
 - :cpp:func:`hpx::for_loop_strided`
 - :cpp:func:`hpx::for_loop_n`
@@ -144,6 +144,8 @@ Functions
 - :cpp:func:`hpx::ranges::set_symmetric_difference`
 - :cpp:func:`hpx::ranges::set_union`
 - :cpp:func:`hpx::ranges::swap_ranges`
+- :cpp:func:`hpx::ranges::unique`
+- :cpp:func:`hpx::ranges::unique_copy`
 - :cpp:func:`hpx::ranges::for_loop`
 - :cpp:func:`hpx::ranges::for_loop_strided`
 

--- a/docs/sphinx/manual/writing_single_node_hpx_applications.rst
+++ b/docs/sphinx/manual/writing_single_node_hpx_applications.rst
@@ -522,12 +522,12 @@ Parallel algorithms
      * Applies a function to a range of elements.
      * ``<hpx/algorithm.hpp>``
      * :cppreference-algorithm:`transform`
-   * * :cpp:func:`hpx::parallel::v1::unique_copy`
+   * * :cpp:func:`hpx::unique`
      * Eliminates all but the first element from every consecutive group of equivalent elements from a range.
      * ``<hpx/algorithm.hpp>``
      * :cppreference-algorithm:`unique`
-   * * :cpp:func:`hpx::parallel::v1::unique_copy`
-     * Eliminates all but the first element from every consecutive group of equivalent elements from a range.
+   * * :cpp:func:`hpx::unique_copy`
+     * Copies the elements from one range to another in such a way that there are no consecutive equal elements.
      * ``<hpx/algorithm.hpp>``
      * :cppreference-algorithm:`unique_copy`
 

--- a/libs/full/include_local/include/hpx/local/algorithm.hpp
+++ b/libs/full/include_local/include/hpx/local/algorithm.hpp
@@ -19,6 +19,4 @@ namespace hpx {
     using hpx::parallel::sort;
     using hpx::parallel::stable_partition;
     using hpx::parallel::stable_sort;
-    using hpx::parallel::unique;
-    using hpx::parallel::unique_copy;
 }    // namespace hpx

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/unique.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/unique.hpp
@@ -845,8 +845,10 @@ namespace hpx { namespace parallel { inline namespace v1 {
                     util::loop_n<std::decay_t<ExPolicy>>(++part_begin,
                         part_size,
                         [base, pred, proj, &curr](zip_iterator it) mutable {
-                            bool f = HPX_INVOKE(pred, HPX_INVOKE(proj, *base),
-                                HPX_INVOKE(proj, get<0>(*it)));
+                            using hpx::util::invoke;
+
+                            bool f = invoke(pred, invoke(proj, *base),
+                                invoke(proj, get<0>(*it)));
 
                             if (!(get<1>(*it) = f))
                             {

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/unique.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/unique.hpp
@@ -1,4 +1,5 @@
 //  Copyright (c) 2017 Taeguk Kwon
+//  Copyright (c) 2021 Akhil J Nair
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -608,8 +609,8 @@ namespace hpx { namespace parallel { inline namespace v1 {
     typename util::detail::algorithm_result<ExPolicy,
         parallel::util::in_out_result<FwdIter1, FwdIter2>>::type
         HPX_DEPRECATED_V(1, 8,
-            "hpx::parallel::unique is deprecated, use "
-            "hpx::unique instead")
+            "hpx::parallel::unique_copy is deprecated, use "
+            "hpx::unique_copy instead")
             unique_copy(ExPolicy&& policy, FwdIter1 first, FwdIter1 last,
                 FwdIter2 dest, Pred&& pred = Pred(), Proj&& proj = Proj())
     {

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/unique.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/unique.hpp
@@ -586,8 +586,10 @@ namespace hpx { namespace parallel { inline namespace v1 {
                     // MSVC complains if pred or proj is captured by ref below
                     util::loop_n<std::decay_t<ExPolicy>>(++part_begin,
                         part_size, [base, pred, proj](zip_iterator it) mutable {
-                            bool f = HPX_INVOKE(pred, HPX_INVOKE(proj, *base),
-                                HPX_INVOKE(proj, get<0>(*it)));
+                            using hpx::util::invoke;
+
+                            bool f = invoke(pred, invoke(proj, *base),
+                                invoke(proj, get<0>(*it)));
 
                             if (!(get<1>(*it) = f))
                                 base = get<0>(it.get_iterator_tuple());
@@ -680,14 +682,18 @@ namespace hpx { namespace parallel { inline namespace v1 {
         /// \endcond
     }    // namespace detail
 
+    // clang-format off
     template <typename ExPolicy, typename FwdIter,
         typename Pred = detail::equal_to,
         typename Proj = util::projection_identity,
-        HPX_CONCEPT_REQUIRES_(hpx::is_execution_policy<ExPolicy>::value&& hpx::
-                traits::is_iterator<FwdIter>::value&& traits::is_projected<Proj,
-                    FwdIter>::value&& traits::is_indirect_callable<ExPolicy,
-                    Pred, traits::projected<Proj, FwdIter>,
-                    traits::projected<Proj, FwdIter>>::value)>
+        HPX_CONCEPT_REQUIRES_(
+            hpx::is_execution_policy<ExPolicy>::value &&
+            hpx::traits::is_iterator_v<FwdIter> &&
+            traits::is_projected<Proj, FwdIter>::value &&
+            traits::is_indirect_callable<ExPolicy, Pred,
+                    traits::projected<Proj, FwdIter>,
+                    traits::projected<Proj, FwdIter>>::value
+        )>
     // clang-format on
     HPX_DEPRECATED_V(1, 8,
         "hpx::parallel::unique is deprecated, use "
@@ -696,7 +702,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
         unique(ExPolicy&& policy, FwdIter first, FwdIter last,
             Pred&& pred = Pred(), Proj&& proj = Proj())
     {
-        static_assert((hpx::traits::is_forward_iterator<FwdIter>::value),
+        static_assert((hpx::traits::is_forward_iterator_v<FwdIter>),
             "Required at least forward iterator.");
 
 #if defined(HPX_GCC_VERSION) && HPX_GCC_VERSION >= 100000
@@ -906,27 +912,31 @@ namespace hpx { namespace parallel { inline namespace v1 {
         /// \endcond
     }    // namespace detail
 
+    // clang-format off
     template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
         typename Pred = detail::equal_to,
         typename Proj = util::projection_identity,
-        HPX_CONCEPT_REQUIRES_(hpx::is_execution_policy<ExPolicy>::value&&
-                hpx::traits::is_iterator<FwdIter1>::value&&
-                    hpx::traits::is_iterator<FwdIter2>::value&&
-                        traits::is_projected<Proj, FwdIter1>::value&&
-                            traits::is_indirect_callable<ExPolicy, Pred,
-                                traits::projected<Proj, FwdIter1>,
-                                traits::projected<Proj, FwdIter1>>::value)>
+        HPX_CONCEPT_REQUIRES_(
+            hpx::is_execution_policy<ExPolicy>::value &&
+            hpx::traits::is_iterator_v<FwdIter1> &&
+            hpx::traits::is_iterator_v<FwdIter2> &&
+            traits::is_projected<Proj, FwdIter1>::value &&
+            traits::is_indirect_callable<ExPolicy, Pred,
+                traits::projected<Proj, FwdIter1>,
+                traits::projected<Proj, FwdIter1>>::value
+        )>
+    // clang-format on
     HPX_DEPRECATED_V(1, 8,
         "hpx::parallel::unique_copy is deprecated, use "
         "hpx::unique_copy instead")
-    typename util::detail::algorithm_result<ExPolicy,
-        parallel::util::in_out_result<FwdIter1, FwdIter2>>::type
+        typename util::detail::algorithm_result<ExPolicy,
+            parallel::util::in_out_result<FwdIter1, FwdIter2>>::type
         unique_copy(ExPolicy&& policy, FwdIter1 first, FwdIter1 last,
             FwdIter2 dest, Pred&& pred = Pred(), Proj&& proj = Proj())
     {
-        static_assert((hpx::traits::is_forward_iterator<FwdIter1>::value),
+        static_assert((hpx::traits::is_forward_iterator_v<FwdIter1>),
             "Required at least forward iterator.");
-        static_assert((hpx::traits::is_forward_iterator<FwdIter2>::value),
+        static_assert((hpx::traits::is_forward_iterator_v<FwdIter2>),
             "Requires at least forward iterator.");
 
         using result_type = parallel::util::in_out_result<FwdIter1, FwdIter2>;
@@ -955,7 +965,7 @@ namespace hpx {
             typename Pred = hpx::parallel::v1::detail::equal_to,
             typename Proj = parallel::util::projection_identity,
             HPX_CONCEPT_REQUIRES_(
-                hpx::traits::is_iterator<FwdIter>::value &&
+                hpx::traits::is_iterator_v<FwdIter> &&
                 parallel::traits::is_projected<Proj, FwdIter>::value &&
                 parallel::traits::is_indirect_callable<
                     hpx::execution::sequenced_policy, Pred,
@@ -966,7 +976,7 @@ namespace hpx {
         friend FwdIter tag_fallback_dispatch(hpx::unique_t, FwdIter first,
             FwdIter last, Pred&& pred = Pred(), Proj&& proj = Proj())
         {
-            static_assert(hpx::traits::is_forward_iterator<FwdIter>::value,
+            static_assert(hpx::traits::is_forward_iterator_v<FwdIter>,
                 "Requires at least forward iterator.");
 
             return hpx::parallel::v1::detail::unique<FwdIter>().call(
@@ -980,7 +990,7 @@ namespace hpx {
             typename Proj = parallel::util::projection_identity,
             HPX_CONCEPT_REQUIRES_(
                 hpx::is_execution_policy<ExPolicy>::value &&
-                hpx::traits::is_iterator<FwdIter>::value &&
+                hpx::traits::is_iterator_v<FwdIter> &&
                 parallel::traits::is_projected<Proj, FwdIter>::value &&
                 parallel::traits::is_indirect_callable<ExPolicy, Pred,
                     parallel::traits::projected<Proj, FwdIter>,
@@ -992,7 +1002,7 @@ namespace hpx {
         tag_fallback_dispatch(hpx::unique_t, ExPolicy&& policy, FwdIter first,
             FwdIter last, Pred&& pred = Pred(), Proj&& proj = Proj())
         {
-            static_assert(hpx::traits::is_forward_iterator<FwdIter>::value,
+            static_assert(hpx::traits::is_forward_iterator_v<FwdIter>,
                 "Requires at least forward iterator.");
 
             return hpx::parallel::v1::detail::unique<FwdIter>().call(
@@ -1011,8 +1021,8 @@ namespace hpx {
             typename Pred = hpx::parallel::v1::detail::equal_to,
             typename Proj = parallel::util::projection_identity,
             HPX_CONCEPT_REQUIRES_(
-                hpx::traits::is_iterator<InIter>::value &&
-                hpx::traits::is_iterator<OutIter>::value &&
+                hpx::traits::is_iterator_v<InIter> &&
+                hpx::traits::is_iterator_v<OutIter> &&
                 parallel::traits::is_indirect_callable<
                     hpx::execution::sequenced_policy, Pred,
                     parallel::traits::projected<Proj, InIter>,
@@ -1023,7 +1033,7 @@ namespace hpx {
             InIter last, OutIter dest, Pred&& pred = Pred(),
             Proj&& proj = Proj())
         {
-            static_assert(hpx::traits::is_input_iterator<InIter>::value,
+            static_assert(hpx::traits::is_input_iterator_v<InIter>,
                 "Requires at least input iterator.");
 
             using result_type = parallel::util::in_out_result<InIter, OutIter>;
@@ -1040,8 +1050,8 @@ namespace hpx {
             typename Proj = parallel::util::projection_identity,
             HPX_CONCEPT_REQUIRES_(
                 hpx::is_execution_policy<ExPolicy>::value &&
-                hpx::traits::is_iterator<FwdIter1>::value &&
-                hpx::traits::is_iterator<FwdIter2>::value &&
+                hpx::traits::is_iterator_v<FwdIter1> &&
+                hpx::traits::is_iterator_v<FwdIter2> &&
                 parallel::traits::is_indirect_callable<ExPolicy, Pred,
                     parallel::traits::projected<Proj, FwdIter1>,
                     parallel::traits::projected<Proj, FwdIter1>>::value
@@ -1053,7 +1063,7 @@ namespace hpx {
             FwdIter1 first, FwdIter1 last, FwdIter2 dest, Pred&& pred = Pred(),
             Proj&& proj = Proj())
         {
-            static_assert(hpx::traits::is_forward_iterator<FwdIter1>::value,
+            static_assert(hpx::traits::is_forward_iterator_v<FwdIter1>,
                 "Requires at least forward iterator.");
 
             using result_type =

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/unique.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/unique.hpp
@@ -37,7 +37,7 @@ namespace hpx {
     ///           The \a unique algorithm returns the iterator to the new end
     ///           of the range.
     ///
-    template <typename ExPolicy, typename FwdIter>
+    template <typename FwdIter>
     FwdIter unique(FwdIter first, FwdIter last);
 
     ///////////////////////////////////////////////////////////////////////////
@@ -914,13 +914,13 @@ namespace hpx { namespace parallel { inline namespace v1 {
                             traits::is_indirect_callable<ExPolicy, Pred,
                                 traits::projected<Proj, FwdIter1>,
                                 traits::projected<Proj, FwdIter1>>::value)>
+    HPX_DEPRECATED_V(1, 8,
+        "hpx::parallel::unique_copy is deprecated, use "
+        "hpx::unique_copy instead")
     typename util::detail::algorithm_result<ExPolicy,
         parallel::util::in_out_result<FwdIter1, FwdIter2>>::type
-        HPX_DEPRECATED_V(1, 8,
-            "hpx::parallel::unique_copy is deprecated, use "
-            "hpx::unique_copy instead")
-            unique_copy(ExPolicy&& policy, FwdIter1 first, FwdIter1 last,
-                FwdIter2 dest, Pred&& pred = Pred(), Proj&& proj = Proj())
+        unique_copy(ExPolicy&& policy, FwdIter1 first, FwdIter1 last,
+            FwdIter2 dest, Pred&& pred = Pred(), Proj&& proj = Proj())
     {
         static_assert((hpx::traits::is_forward_iterator<FwdIter1>::value),
             "Required at least forward iterator.");

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/unique.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/unique.hpp
@@ -7,6 +7,457 @@
 
 #pragma once
 
+#if defined(DOXYGEN)
+
+namespace hpx {
+    // clang-format off
+
+    ///////////////////////////////////////////////////////////////////////////
+    /// Eliminates all but the first element from every consecutive group of
+    /// equivalent elements from the range [first, last) and returns a
+    /// past-the-end iterator for the new logical end of the range.
+    ///
+    /// \note   Complexity: Performs not more than \a last - \a first
+    ///         assignments.
+    ///
+    /// \tparam FwdIter     The type of the source iterators used (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     forward iterator.
+    ///
+    /// \param first        Refers to the beginning of the sequence of elements
+    ///                     the algorithm will be applied to.
+    /// \param last         Refers to the end of the sequence of elements the
+    ///                     algorithm will be applied to.
+    ///
+    /// The assignments in the parallel \a unique algorithm invoked without
+    /// an execution policy object execute in sequential order in the
+    /// calling thread.
+    ///
+    /// \returns  The \a unique algorithm returns \a FwdIter.
+    ///           The \a unique algorithm returns the iterator to the new end
+    ///           of the range.
+    ///
+    template <typename ExPolicy, typename FwdIter>
+    FwdIter unique(FwdIter first, FwdIter last);
+
+    ///////////////////////////////////////////////////////////////////////////
+    /// Eliminates all but the first element from every consecutive group of
+    /// equivalent elements from the range [first, last) and returns a
+    /// past-the-end iterator for the new logical end of the range.
+    ///
+    /// \note   Complexity: Performs not more than \a last - \a first
+    ///         assignments.
+    ///
+    /// \tparam ExPolicy    The type of the execution policy to use (deduced).
+    ///                     It describes the manner in which the execution
+    ///                     of the algorithm may be parallelized and the manner
+    ///                     in which it executes the assignments.
+    /// \tparam FwdIter     The type of the source iterators used (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     forward iterator.
+    ///
+    /// \param policy       The execution policy to use for the scheduling of
+    ///                     the iterations.
+    /// \param first        Refers to the beginning of the sequence of elements
+    ///                     the algorithm will be applied to.
+    /// \param last         Refers to the end of the sequence of elements the
+    ///                     algorithm will be applied to.
+    ///
+    /// The assignments in the parallel \a unique algorithm invoked with
+    /// an execution policy object of type \a sequenced_policy
+    /// execute in sequential order in the calling thread.
+    ///
+    /// The assignments in the parallel \a unique algorithm invoked with
+    /// an execution policy object of type \a parallel_policy or
+    /// \a parallel_task_policy are permitted to execute in an unordered
+    /// fashion in unspecified threads, and indeterminately sequenced
+    /// within each thread.
+    ///
+    /// \returns  The \a unique algorithm returns a \a hpx::future<FwdIter>
+    ///           if the execution policy is of type
+    ///           \a sequenced_task_policy or \a parallel_task_policy and
+    ///           returns \a FwdIter otherwise.
+    ///           The \a unique algorithm returns the iterator to the new end
+    ///           of the range.
+    ///
+    template <typename ExPolicy, typename FwdIter>
+    typename parallel::util::detail::algorithm_result<ExPolicy,
+        FwdIter>::type
+     unique(ExPolicy&& policy, FwdIter first, FwdIter last);
+
+    ///////////////////////////////////////////////////////////////////////////
+    /// Eliminates all but the first element from every consecutive group of
+    /// equivalent elements from the range [first, last) and returns a
+    /// past-the-end iterator for the new logical end of the range.
+    ///
+    /// \note   Complexity: Performs not more than \a last - \a first
+    ///         assignments, exactly \a last - \a first - 1 applications of
+    ///         the predicate \a pred and no more than twice as many
+    ///         applications of the projection \a proj.
+    ///
+    /// \tparam FwdIter     The type of the source iterators used (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     forward iterator.
+    /// \tparam Pred        The type of the function/function object to use
+    ///                     (deduced). Unlike its sequential form, the parallel
+    ///                     overload of \a unique requires \a Pred to meet the
+    ///                     requirements of \a CopyConstructible. This defaults
+    ///                     to std::equal_to<>
+    /// \tparam Proj        The type of an optional projection function. This
+    ///                     defaults to \a util::projection_identity
+    ///
+    /// \param first        Refers to the beginning of the sequence of elements
+    ///                     the algorithm will be applied to.
+    /// \param last         Refers to the end of the sequence of elements the
+    ///                     algorithm will be applied to.
+    /// \param pred         Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements in the
+    ///                     sequence specified by [first, last). This is an
+    ///                     binary predicate which returns \a true for the
+    ///                     required elements. The signature of this predicate
+    ///                     should be equivalent to:
+    ///                     \code
+    ///                     bool pred(const Type1 &a, const Type2 &b);
+    ///                     \endcode \n
+    ///                     The signature does not need to have const&, but
+    ///                     the function must not modify the objects passed to
+    ///                     it. The types \a Type1 and \a Type2 must be
+    ///                     such that objects of types \a FwdIter can be
+    ///                     dereferenced and then implicitly converted to
+    ///                     both \a Type1 and \a Type2
+    /// \param proj         Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements as a
+    ///                     projection operation before the actual predicate
+    ///                     \a is invoked.
+    ///
+    /// The assignments in the parallel \a unique algorithm invoked without
+    /// an execution policy object execute in sequential order in the
+    /// calling thread.
+    ///
+    /// \returns  The \a unique algorithm returns \a FwdIter.
+    ///           The \a unique algorithm returns the iterator to the new end
+    ///           of the range.
+    ///
+    template <typename ExPolicy, typename FwdIter, typename Pred,
+        typename Proj>
+    FwdIter unique(FwdIter first, FwdIter last, Pred&& pred,
+        Proj&& proj);
+
+    ///////////////////////////////////////////////////////////////////////////
+    /// Eliminates all but the first element from every consecutive group of
+    /// equivalent elements from the range [first, last) and returns a
+    /// past-the-end iterator for the new logical end of the range.
+    ///
+    /// \note   Complexity: Performs not more than \a last - \a first
+    ///         assignments, exactly \a last - \a first - 1 applications of
+    ///         the predicate \a pred and no more than twice as many
+    ///         applications of the projection \a proj.
+    ///
+    /// \tparam ExPolicy    The type of the execution policy to use (deduced).
+    ///                     It describes the manner in which the execution
+    ///                     of the algorithm may be parallelized and the manner
+    ///                     in which it executes the assignments.
+    /// \tparam FwdIter     The type of the source iterators used (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     forward iterator.
+    /// \tparam Pred        The type of the function/function object to use
+    ///                     (deduced). Unlike its sequential form, the parallel
+    ///                     overload of \a unique requires \a Pred to meet the
+    ///                     requirements of \a CopyConstructible. This defaults
+    ///                     to std::equal_to<>
+    /// \tparam Proj        The type of an optional projection function. This
+    ///                     defaults to \a util::projection_identity
+    ///
+    /// \param policy       The execution policy to use for the scheduling of
+    ///                     the iterations.
+    /// \param first        Refers to the beginning of the sequence of elements
+    ///                     the algorithm will be applied to.
+    /// \param last         Refers to the end of the sequence of elements the
+    ///                     algorithm will be applied to.
+    /// \param pred         Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements in the
+    ///                     sequence specified by [first, last). This is an
+    ///                     binary predicate which returns \a true for the
+    ///                     required elements. The signature of this predicate
+    ///                     should be equivalent to:
+    ///                     \code
+    ///                     bool pred(const Type1 &a, const Type2 &b);
+    ///                     \endcode \n
+    ///                     The signature does not need to have const&, but
+    ///                     the function must not modify the objects passed to
+    ///                     it. The types \a Type1 and \a Type2 must be
+    ///                     such that objects of types \a FwdIter can be
+    ///                     dereferenced and then implicitly converted to
+    ///                     both \a Type1 and \a Type2
+    /// \param proj         Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements as a
+    ///                     projection operation before the actual predicate
+    ///                     \a is invoked.
+    ///
+    /// The assignments in the parallel \a unique algorithm invoked with
+    /// an execution policy object of type \a sequenced_policy
+    /// execute in sequential order in the calling thread.
+    ///
+    /// The assignments in the parallel \a unique algorithm invoked with
+    /// an execution policy object of type \a parallel_policy or
+    /// \a parallel_task_policy are permitted to execute in an unordered
+    /// fashion in unspecified threads, and indeterminately sequenced
+    /// within each thread.
+    ///
+    /// \returns  The \a unique algorithm returns a \a hpx::future<FwdIter>
+    ///           if the execution policy is of type
+    ///           \a sequenced_task_policy or \a parallel_task_policy and
+    ///           returns \a FwdIter otherwise.
+    ///           The \a unique algorithm returns the iterator to the new end
+    ///           of the range.
+    ///
+    template <typename ExPolicy, typename FwdIter, typename Pred,
+        typename Proj>
+    typename parallel::util::detail::algorithm_result<ExPolicy,
+        FwdIter>::type
+     unique(ExPolicy&& policy, FwdIter first, FwdIter last, Pred&& pred,
+         Proj&& proj);
+
+    ///////////////////////////////////////////////////////////////////////////
+    /// Copies the elements from the range [first, last),
+    /// to another range beginning at \a dest in such a way that
+    /// there are no consecutive equal elements. Only the first element of
+    /// each group of equal elements is copied.
+    ///
+    /// \note   Complexity: Performs not more than \a last - \a first
+    ///         assignments.
+    ///
+    /// \tparam InIter      The type of the source iterators used (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     input iterator.
+    /// \tparam OutIter     The type of the iterator representing the
+    ///                     destination range (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     output iterator.
+    ///
+    /// \param first        Refers to the beginning of the sequence of elements
+    ///                     the algorithm will be applied to.
+    /// \param last         Refers to the end of the sequence of elements the
+    ///                     algorithm will be applied to.
+    /// \param dest         Refers to the beginning of the destination range.
+    ///
+    /// The assignments in the parallel \a unique_copy algorithm invoked
+    /// without an execution policy object  will execute in sequential
+    /// order in the calling thread.
+    ///
+    /// \returns  The \a unique_copy algorithm returns a
+    ///           returns OutIter.
+    ///           The \a unique_copy algorithm returns the destination
+    ///           iterator to the end of the \a dest range.
+    ///
+    template <typename InIter, typename OutIter>
+    OutIter unique_copy(InIter first, InIter last, OutIter dest);
+
+    ///////////////////////////////////////////////////////////////////////////
+    /// Copies the elements from the range [first, last),
+    /// to another range beginning at \a dest in such a way that
+    /// there are no consecutive equal elements. Only the first element of
+    /// each group of equal elements is copied.
+    ///
+    /// \note   Complexity: Performs not more than \a last - \a first
+    ///         assignments.
+    ///
+    /// \tparam ExPolicy    The type of the execution policy to use (deduced).
+    ///                     It describes the manner in which the execution
+    ///                     of the algorithm may be parallelized and the manner
+    ///                     in which it executes the assignments.
+    /// \tparam FwdIter1    The type of the source iterators used (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     forward iterator.
+    /// \tparam FwdIter2    The type of the iterator representing the
+    ///                     destination range (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     forward iterator.
+    ///
+    /// \param policy       The execution policy to use for the scheduling of
+    ///                     the iterations.
+    /// \param first        Refers to the beginning of the sequence of elements
+    ///                     the algorithm will be applied to.
+    /// \param last         Refers to the end of the sequence of elements the
+    ///                     algorithm will be applied to.
+    /// \param dest         Refers to the beginning of the destination range.
+    ///
+    /// The assignments in the parallel \a unique_copy algorithm invoked with
+    /// an execution policy object of type \a sequenced_policy
+    /// execute in sequential order in the calling thread.
+    ///
+    /// The assignments in the parallel \a unique_copy algorithm invoked with
+    /// an execution policy object of type \a parallel_policy or
+    /// \a parallel_task_policy are permitted to execute in an unordered
+    /// fashion in unspecified threads, and indeterminately sequenced
+    /// within each thread.
+    ///
+    /// \returns  The \a unique_copy algorithm returns a
+    ///           \a hpx::future<FwdIter2> if the execution policy
+    ///           is of type \a sequenced_task_policy or
+    ///           \a parallel_task_policy and
+    ///           returns \a FwdIter2 otherwise.
+    ///           The \a unique_copy algorithm returns the pair of
+    ///           the source iterator to \a last, and
+    ///           the destination iterator to the end of the \a dest range.
+    ///
+    template <typename ExPolicy, typename FwdIter1, typename FwdIter2>
+    typename parallel::util::detail::algorithm_result<ExPolicy,
+        FwdIter2>::type
+     unique_copy(ExPolicy&& policy, FwdIter1 first, FwdIter1 last,
+         FwdIter2 dest);
+
+    ///////////////////////////////////////////////////////////////////////////
+    /// Copies the elements from the range [first, last),
+    /// to another range beginning at \a dest in such a way that
+    /// there are no consecutive equal elements. Only the first element of
+    /// each group of equal elements is copied.
+    ///
+    /// \note   Complexity: Performs not more than \a last - \a first
+    ///         assignments, exactly \a last - \a first - 1 applications of
+    ///         the predicate \a pred and no more than twice as many
+    ///         applications of the projection \a proj
+    ///
+    /// \tparam InIter      The type of the source iterators used (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     input iterator.
+    /// \tparam OutIter     The type of the iterator representing the
+    ///                     destination range (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     output iterator.
+    /// \tparam Pred        The type of the function/function object to use
+    ///                     (deduced). Unlike its sequential form, the parallel
+    ///                     overload of \a unique_copy requires \a Pred to meet the
+    ///                     requirements of \a CopyConstructible. This defaults
+    ///                     to std::equal_to<>
+    /// \tparam Proj        The type of an optional projection function. This
+    ///                     defaults to \a util::projection_identity
+    ///
+    /// \param first        Refers to the beginning of the sequence of elements
+    ///                     the algorithm will be applied to.
+    /// \param last         Refers to the end of the sequence of elements the
+    ///                     algorithm will be applied to.
+    /// \param dest         Refers to the beginning of the destination range.
+    /// \param pred         Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements in the
+    ///                     sequence specified by [first, last). This is an
+    ///                     binary predicate which returns \a true for the
+    ///                     required elements. The signature of this predicate
+    ///                     should be equivalent to:
+    ///                     \code
+    ///                     bool pred(const Type &a, const Type &b);
+    ///                     \endcode \n
+    ///                     The signature does not need to have const&, but
+    ///                     the function must not modify the objects passed to
+    ///                     it. The type \a Type must be such that an object of
+    ///                     type \a FwdIter1 can be dereferenced and then
+    ///                     implicitly converted to \a Type.
+    /// \param proj         Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements as a
+    ///                     projection operation before the actual predicate
+    ///                     \a is invoked.
+    ///
+    /// The assignments in the parallel \a unique_copy algorithm invoked
+    /// without an execution policy object  will execute in sequential
+    /// order in the calling thread.
+    ///
+    /// \returns  The \a unique_copy algorithm returns a
+    ///           returns OutIter.
+    ///           The \a unique_copy algorithm returns the destination
+    ///           iterator to the end of the \a dest range.
+    ///
+    template <typename InIter, typename OutIter, typename Pred,
+        typename Proj>
+    OutIter unique_copy(InIter first, InIter last, OutIter dest,
+        Pred&& pred, Proj&& proj);
+
+    ///////////////////////////////////////////////////////////////////////////
+    /// Copies the elements from the range [first, last),
+    /// to another range beginning at \a dest in such a way that
+    /// there are no consecutive equal elements. Only the first element of
+    /// each group of equal elements is copied.
+    ///
+    /// \note   Complexity: Performs not more than \a last - \a first
+    ///         assignments, exactly \a last - \a first - 1 applications of
+    ///         the predicate \a pred and no more than twice as many
+    ///         applications of the projection \a proj
+    ///
+    /// \tparam ExPolicy    The type of the execution policy to use (deduced).
+    ///                     It describes the manner in which the execution
+    ///                     of the algorithm may be parallelized and the manner
+    ///                     in which it executes the assignments.
+    /// \tparam FwdIter1    The type of the source iterators used (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     forward iterator.
+    /// \tparam FwdIter2    The type of the iterator representing the
+    ///                     destination range (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     forward iterator.
+    /// \tparam Pred        The type of the function/function object to use
+    ///                     (deduced). Unlike its sequential form, the parallel
+    ///                     overload of \a unique_copy requires \a Pred to meet the
+    ///                     requirements of \a CopyConstructible. This defaults
+    ///                     to std::equal_to<>
+    /// \tparam Proj        The type of an optional projection function. This
+    ///                     defaults to \a util::projection_identity
+    ///
+    /// \param policy       The execution policy to use for the scheduling of
+    ///                     the iterations.
+    /// \param first        Refers to the beginning of the sequence of elements
+    ///                     the algorithm will be applied to.
+    /// \param last         Refers to the end of the sequence of elements the
+    ///                     algorithm will be applied to.
+    /// \param dest         Refers to the beginning of the destination range.
+    /// \param pred         Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements in the
+    ///                     sequence specified by [first, last). This is an
+    ///                     binary predicate which returns \a true for the
+    ///                     required elements. The signature of this predicate
+    ///                     should be equivalent to:
+    ///                     \code
+    ///                     bool pred(const Type &a, const Type &b);
+    ///                     \endcode \n
+    ///                     The signature does not need to have const&, but
+    ///                     the function must not modify the objects passed to
+    ///                     it. The type \a Type must be such that an object of
+    ///                     type \a FwdIter1 can be dereferenced and then
+    ///                     implicitly converted to \a Type.
+    /// \param proj         Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements as a
+    ///                     projection operation before the actual predicate
+    ///                     \a is invoked.
+    ///
+    /// The assignments in the parallel \a unique_copy algorithm invoked with
+    /// an execution policy object of type \a sequenced_policy
+    /// execute in sequential order in the calling thread.
+    ///
+    /// The assignments in the parallel \a unique_copy algorithm invoked with
+    /// an execution policy object of type \a parallel_policy or
+    /// \a parallel_task_policy are permitted to execute in an unordered
+    /// fashion in unspecified threads, and indeterminately sequenced
+    /// within each thread.
+    ///
+    /// \returns  The \a unique_copy algorithm returns a
+    ///           \a hpx::future<FwdIter2> if the execution policy
+    ///           is of type \a sequenced_task_policy or
+    ///           \a parallel_task_policy and
+    ///           returns \a FwdIter2 otherwise.
+    ///           The \a unique_copy algorithm returns the pair of
+    ///           the source iterator to \a last, and
+    ///           the destination iterator to the end of the \a dest range.
+    ///
+    template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
+        typename Pred, typename Proj>
+    typename parallel::util::detail::algorithm_result<ExPolicy,
+        FwdIter2>::type
+     unique_copy(ExPolicy&& policy, FwdIter1 first, FwdIter1 last,
+         FwdIter2 dest, Pred&& pred, Proj&& proj);
+
+    // clang-format on
+}    // namespace hpx
+
+#else    // DOXYGEN
+
 #include <hpx/config.hpp>
 #include <hpx/concepts/concepts.hpp>
 #include <hpx/functional/invoke.hpp>
@@ -229,73 +680,6 @@ namespace hpx { namespace parallel { inline namespace v1 {
         /// \endcond
     }    // namespace detail
 
-    /// Eliminates all but the first element from every consecutive group of
-    /// equivalent elements from the range [first, last) and returns a
-    /// past-the-end iterator for the new logical end of the range.
-    ///
-    /// \note   Complexity: Performs not more than \a last - \a first
-    ///         assignments, exactly \a last - \a first - 1 applications of
-    ///         the predicate \a pred and no more than twice as many
-    ///         applications of the projection \a proj.
-    ///
-    /// \tparam ExPolicy    The type of the execution policy to use (deduced).
-    ///                     It describes the manner in which the execution
-    ///                     of the algorithm may be parallelized and the manner
-    ///                     in which it executes the assignments.
-    /// \tparam FwdIter     The type of the source iterators used (deduced).
-    ///                     This iterator type must meet the requirements of an
-    ///                     forward iterator.
-    /// \tparam Pred        The type of the function/function object to use
-    ///                     (deduced). Unlike its sequential form, the parallel
-    ///                     overload of \a unique requires \a Pred to meet the
-    ///                     requirements of \a CopyConstructible. This defaults
-    ///                     to std::equal_to<>
-    /// \tparam Proj        The type of an optional projection function. This
-    ///                     defaults to \a util::projection_identity
-    ///
-    /// \param policy       The execution policy to use for the scheduling of
-    ///                     the iterations.
-    /// \param first        Refers to the beginning of the sequence of elements
-    ///                     the algorithm will be applied to.
-    /// \param last         Refers to the end of the sequence of elements the
-    ///                     algorithm will be applied to.
-    /// \param pred         Specifies the function (or function object) which
-    ///                     will be invoked for each of the elements in the
-    ///                     sequence specified by [first, last). This is an
-    ///                     binary predicate which returns \a true for the
-    ///                     required elements. The signature of this predicate
-    ///                     should be equivalent to:
-    ///                     \code
-    ///                     bool pred(const Type1 &a, const Type2 &b);
-    ///                     \endcode \n
-    ///                     The signature does not need to have const&, but
-    ///                     the function must not modify the objects passed to
-    ///                     it. The types \a Type1 and \a Type2 must be
-    ///                     such that objects of types \a FwdIter can be
-    ///                     dereferenced and then implicitly converted to
-    ///                     both \a Type1 and \a Type2
-    /// \param proj         Specifies the function (or function object) which
-    ///                     will be invoked for each of the elements as a
-    ///                     projection operation before the actual predicate
-    ///                     \a is invoked.
-    ///
-    /// The assignments in the parallel \a unique algorithm invoked with
-    /// an execution policy object of type \a sequenced_policy
-    /// execute in sequential order in the calling thread.
-    ///
-    /// The assignments in the parallel \a unique algorithm invoked with
-    /// an execution policy object of type \a parallel_policy or
-    /// \a parallel_task_policy are permitted to execute in an unordered
-    /// fashion in unspecified threads, and indeterminately sequenced
-    /// within each thread.
-    ///
-    /// \returns  The \a unique algorithm returns a \a hpx::future<FwdIter>
-    ///           if the execution policy is of type
-    ///           \a sequenced_task_policy or \a parallel_task_policy and
-    ///           returns \a FwdIter otherwise.
-    ///           The \a unique algorithm returns the iterator to the new end
-    ///           of the range.
-    ///
     template <typename ExPolicy, typename FwdIter,
         typename Pred = detail::equal_to,
         typename Proj = util::projection_identity,
@@ -520,82 +904,6 @@ namespace hpx { namespace parallel { inline namespace v1 {
         /// \endcond
     }    // namespace detail
 
-    /// Copies the elements from the range [first, last),
-    /// to another range beginning at \a dest in such a way that
-    /// there are no consecutive equal elements. Only the first element of
-    /// each group of equal elements is copied.
-    ///
-    /// \note   Complexity: Performs not more than \a last - \a first
-    ///         assignments, exactly \a last - \a first - 1 applications of
-    ///         the predicate \a pred and no more than twice as many
-    ///         applications of the projection \a proj
-    ///
-    /// \tparam ExPolicy    The type of the execution policy to use (deduced).
-    ///                     It describes the manner in which the execution
-    ///                     of the algorithm may be parallelized and the manner
-    ///                     in which it executes the assignments.
-    /// \tparam FwdIter1    The type of the source iterators used (deduced).
-    ///                     This iterator type must meet the requirements of an
-    ///                     forward iterator.
-    /// \tparam FwdIter2    The type of the iterator representing the
-    ///                     destination range (deduced).
-    ///                     This iterator type must meet the requirements of an
-    ///                     forward iterator.
-    /// \tparam Pred        The type of the function/function object to use
-    ///                     (deduced). Unlike its sequential form, the parallel
-    ///                     overload of \a unique_copy requires \a Pred to meet the
-    ///                     requirements of \a CopyConstructible. This defaults
-    ///                     to std::equal_to<>
-    /// \tparam Proj        The type of an optional projection function. This
-    ///                     defaults to \a util::projection_identity
-    ///
-    /// \param policy       The execution policy to use for the scheduling of
-    ///                     the iterations.
-    /// \param first        Refers to the beginning of the sequence of elements
-    ///                     the algorithm will be applied to.
-    /// \param last         Refers to the end of the sequence of elements the
-    ///                     algorithm will be applied to.
-    /// \param dest         Refers to the beginning of the destination range.
-    /// \param pred         Specifies the function (or function object) which
-    ///                     will be invoked for each of the elements in the
-    ///                     sequence specified by [first, last). This is an
-    ///                     binary predicate which returns \a true for the
-    ///                     required elements. The signature of this predicate
-    ///                     should be equivalent to:
-    ///                     \code
-    ///                     bool pred(const Type &a, const Type &b);
-    ///                     \endcode \n
-    ///                     The signature does not need to have const&, but
-    ///                     the function must not modify the objects passed to
-    ///                     it. The type \a Type must be such that an object of
-    ///                     type \a FwdIter1 can be dereferenced and then
-    ///                     implicitly converted to \a Type.
-    /// \param proj         Specifies the function (or function object) which
-    ///                     will be invoked for each of the elements as a
-    ///                     projection operation before the actual predicate
-    ///                     \a is invoked.
-    ///
-    /// The assignments in the parallel \a unique_copy algorithm invoked with
-    /// an execution policy object of type \a sequenced_policy
-    /// execute in sequential order in the calling thread.
-    ///
-    /// The assignments in the parallel \a unique_copy algorithm invoked with
-    /// an execution policy object of type \a parallel_policy or
-    /// \a parallel_task_policy are permitted to execute in an unordered
-    /// fashion in unspecified threads, and indeterminately sequenced
-    /// within each thread.
-    ///
-    /// \returns  The \a unique_copy algorithm returns a
-    ///           \a hpx::future<tagged_pair<tag::in(FwdIter1), tag::out(FwdIter2)> >
-    ///           if the execution policy is of type
-    ///           \a sequenced_task_policy or
-    ///           \a parallel_task_policy and
-    ///           returns \a tagged_pair<tag::in(FwdIter1), tag::out(FwdIter2)>
-    ///           otherwise.
-    ///           The \a unique_copy algorithm returns the pair of
-    ///           the source iterator to \a last, and
-    ///           the destination iterator to the end of the \a dest range.
-    ///
     template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
         typename Pred = detail::equal_to,
         typename Proj = util::projection_identity,
@@ -756,3 +1064,5 @@ namespace hpx {
         }
     } unique_copy{};
 }    // namespace hpx
+
+#endif    // DOXYGEN

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/unique.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/unique.hpp
@@ -9,23 +9,204 @@
 
 #pragma once
 
-#include <hpx/config.hpp>
-#include <hpx/concepts/concepts.hpp>
-#include <hpx/execution/algorithms/detail/predicates.hpp>
-#include <hpx/iterator_support/iterator_range.hpp>
-#include <hpx/iterator_support/range.hpp>
-#include <hpx/iterator_support/traits/is_iterator.hpp>
-#include <hpx/iterator_support/traits/is_range.hpp>
-#include <hpx/parallel/util/tagged_pair.hpp>
+#if defined(DOXYGEN)
 
-#include <hpx/algorithms/traits/projected.hpp>
-#include <hpx/algorithms/traits/projected_range.hpp>
-#include <hpx/parallel/algorithms/unique.hpp>
+namespace hpx { namespace ranges {
+    // clang-format off
 
-#include <type_traits>
-#include <utility>
+    ///////////////////////////////////////////////////////////////////////////
+    /// Eliminates all but the first element from every consecutive group of
+    /// equivalent elements from the range [first, last) and returns a
+    /// past-the-end iterator for the new logical end of the range.
+    ///
+    /// \note   Complexity: Performs not more than \a last - \a first
+    ///         assignments, exactly \a last - \a first - 1 applications of
+    ///         the predicate \a pred and no more than twice as many
+    ///         applications of the projection \a proj.
+    ///
+    /// \tparam FwdIter     The type of the source iterators used (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     forward iterator.
+    /// \tparam Sent        The type of the source sentinel (deduced). This
+    ///                     sentinel type must be a sentinel for FwdIter.
+    /// \tparam Pred        The type of the function/function object to use
+    ///                     (deduced). Unlike its sequential form, the parallel
+    ///                     overload of \a unique requires \a Pred to meet the
+    ///                     requirements of \a CopyConstructible. This defaults
+    ///                     to std::equal_to<>
+    /// \tparam Proj        The type of an optional projection function. This
+    ///                     defaults to \a util::projection_identity
+    ///
+    /// \param first        Refers to the beginning of the sequence of elements
+    ///                     the algorithm will be applied to.
+    /// \param last         Refers to sentinel value denoting the end of the
+    ///                     sequence of elements the algorithm will be applied.
+    /// \param pred         Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements in the
+    ///                     sequence specified by [first, last). This is an
+    ///                     binary predicate which returns \a true for the
+    ///                     required elements. The signature of this predicate
+    ///                     should be equivalent to:
+    ///                     \code
+    ///                     bool pred(const Type1 &a, const Type2 &b);
+    ///                     \endcode \n
+    ///                     The signature does not need to have const&, but
+    ///                     the function must not modify the objects passed to
+    ///                     it. The types \a Type1 and \a Type2 must be
+    ///                     such that objects of types \a FwdIter can be
+    ///                     dereferenced and then implicitly converted to
+    ///                     both \a Type1 and \a Type2
+    /// \param proj         Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements as a
+    ///                     projection operation before the actual predicate
+    ///                     \a is invoked.
+    ///
+    /// The assignments in the parallel \a unique algorithm invoked without
+    /// an execution policy object execute in sequential order in the
+    /// calling thread.
+    ///
+    /// \returns  The \a unique algorithm returns \a subrange_t<FwdIter, Sent>.
+    ///           The \a unique algorithm returns an object {ret, last},
+    ///           where ret is a past-the-end iterator for a new
+    ///           subrange.
+    ///
+    template <typename FwdIter, typename Sent, typename Pred, typename Proj>
+    subrange_t<FwdIter, Sent> unique(FwdIter first, Sent last, Pred&& pred,
+        Proj&& proj);
 
-namespace hpx { namespace parallel { inline namespace v1 {
+    ///////////////////////////////////////////////////////////////////////////
+    /// Eliminates all but the first element from every consecutive group of
+    /// equivalent elements from the range [first, last) and returns a
+    /// past-the-end iterator for the new logical end of the range.
+    ///
+    /// \note   Complexity: Performs not more than \a last - \a first
+    ///         assignments, exactly \a last - \a first - 1 applications of
+    ///         the predicate \a pred and no more than twice as many
+    ///         applications of the projection \a proj.
+    ///
+    /// \tparam ExPolicy    The type of the execution policy to use (deduced).
+    ///                     It describes the manner in which the execution
+    ///                     of the algorithm may be parallelized and the manner
+    ///                     in which it executes the assignments.
+    /// \tparam FwdIter     The type of the source iterators used (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     forward iterator.
+    /// \tparam Sent        The type of the source sentinel (deduced). This
+    ///                     sentinel type must be a sentinel for FwdIter.
+    /// \tparam Pred        The type of the function/function object to use
+    ///                     (deduced). Unlike its sequential form, the parallel
+    ///                     overload of \a unique requires \a Pred to meet the
+    ///                     requirements of \a CopyConstructible. This defaults
+    ///                     to std::equal_to<>
+    /// \tparam Proj        The type of an optional projection function. This
+    ///                     defaults to \a util::projection_identity
+    ///
+    /// \param policy       The execution policy to use for the scheduling of
+    ///                     the iterations.
+    /// \param first        Refers to the beginning of the sequence of elements
+    ///                     the algorithm will be applied to.
+    /// \param last         Refers to sentinel value denoting the end of the
+    ///                     sequence of elements the algorithm will be applied.
+    /// \param pred         Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements in the
+    ///                     sequence specified by [first, last). This is an
+    ///                     binary predicate which returns \a true for the
+    ///                     required elements. The signature of this predicate
+    ///                     should be equivalent to:
+    ///                     \code
+    ///                     bool pred(const Type1 &a, const Type2 &b);
+    ///                     \endcode \n
+    ///                     The signature does not need to have const&, but
+    ///                     the function must not modify the objects passed to
+    ///                     it. The types \a Type1 and \a Type2 must be
+    ///                     such that objects of types \a FwdIter can be
+    ///                     dereferenced and then implicitly converted to
+    ///                     both \a Type1 and \a Type2
+    /// \param proj         Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements as a
+    ///                     projection operation before the actual predicate
+    ///                     \a is invoked.
+    ///
+    /// The assignments in the parallel \a unique algorithm invoked with
+    /// an execution policy object of type \a sequenced_policy
+    /// execute in sequential order in the calling thread.
+    ///
+    /// The assignments in the parallel \a unique algorithm invoked with
+    /// an execution policy object of type \a parallel_policy or
+    /// \a parallel_task_policy are permitted to execute in an unordered
+    /// fashion in unspecified threads, and indeterminately sequenced
+    /// within each thread.
+    ///
+    /// \returns  The \a unique algorithm returns \a subrange_t<FwdIter, Sent>.
+    ///           The \a unique algorithm returns an object {ret, last},
+    ///           where ret is a past-the-end iterator for a new
+    ///           subrange.
+    ///
+    template <typename ExPolicy, typename FwdIter, typename Sent, typename Pred,
+        typename Proj>
+    typename parallel::util::detail::algorithm_result<ExPolicy,
+        subrange_t<FwdIter, Sent>>::type
+    unique(ExPolicy&& policy, FwdIter first, Sent last, Pred&& pred,
+        Proj&& proj);
+
+    ///////////////////////////////////////////////////////////////////////////
+    /// Eliminates all but the first element from every consecutive group of
+    /// equivalent elements from the range \a rng and returns a
+    /// past-the-end iterator for the new logical end of the range.
+    ///
+    /// \note   Complexity: Performs not more than N assignments,
+    ///         exactly N - 1 applications of the predicate \a pred and
+    ///         no more than twice as many applications of the projection
+    ///         \a proj, where N = std::distance(begin(rng), end(rng)).
+    ///
+    /// \tparam Rng         The type of the source range used (deduced).
+    ///                     The iterators extracted from this range type must
+    ///                     meet the requirements of an forward iterator.
+    /// \tparam Pred        The type of the function/function object to use
+    ///                     (deduced). Unlike its sequential form, the parallel
+    ///                     overload of \a unique requires \a Pred to meet the
+    ///                     requirements of \a CopyConstructible. This defaults
+    ///                     to std::equal_to<>
+    /// \tparam Proj        The type of an optional projection function. This
+    ///                     defaults to \a util::projection_identity
+    ///
+    /// \param rng          Refers to the sequence of elements the algorithm
+    ///                     will be applied to.
+    /// \param pred         Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements in the
+    ///                     sequence specified by [first, last). This is an
+    ///                     binary predicate which returns \a true for the
+    ///                     required elements. The signature of this predicate
+    ///                     should be equivalent to:
+    ///                     \code
+    ///                     bool pred(const Type &a, const Type &b);
+    ///                     \endcode \n
+    ///                     The signature does not need to have const&, but
+    ///                     the function must not modify the objects passed to
+    ///                     it. The type \a Type must be such that an object of
+    ///                     type \a FwdIter1 can be dereferenced and then
+    ///                     implicitly converted to \a Type.
+    /// \param proj         Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements as a
+    ///                     projection operation before the actual predicate
+    ///                     \a is invoked.
+    ///
+    /// The assignments in the parallel \a unique algorithm invoked without
+    /// an execution policy object execute in sequential order in the
+    /// calling thread.
+    ///
+    /// \returns  The \a unique algorithm returns
+    ///           \a subrange_t<typename hpx::traits::range_iterator<Rng>
+    ///           ::type>.
+    ///           The \a unique algorithm returns an object {ret, last},
+    ///           where ret is a past-the-end iterator for a new
+    ///           subrange.
+    ///
+    template <typename Rng, typename Pred, typename Proj>
+    subrange_t<typename hpx::traits::range_iterator<Rng>::type>
+    unique(Rng&& rng, Pred&& pred, Proj&& proj);
+
+    ///////////////////////////////////////////////////////////////////////////
     /// Eliminates all but the first element from every consecutive group of
     /// equivalent elements from the range \a rng and returns a
     /// past-the-end iterator for the new logical end of the range.
@@ -83,39 +264,238 @@ namespace hpx { namespace parallel { inline namespace v1 {
     /// fashion in unspecified threads, and indeterminately sequenced
     /// within each thread.
     ///
-    /// \returns  The \a unique algorithm returns a \a hpx::future<FwdIter>
-    ///           if the execution policy is of type
-    ///           \a sequenced_task_policy or \a parallel_task_policy and
-    ///           returns \a FwdIter otherwise.
-    ///           The \a unique algorithm returns the iterator to the new end
-    ///           of the range.
+    /// \returns  The \a unique algorithm returns a \a hpx::future
+    ///           <subrange_t<typename hpx::traits::range_iterator<Rng>::type>>
+    ///           if the execution policy is of type \a sequenced_task_policy
+    ///           or \a parallel_task_policy and returns
+    ///           \a subrange_t<typename hpx::traits::range_iterator<Rng>
+    ///           ::type>. otherwise.
+    ///           The \a unique algorithm returns an object {ret, last},
+    ///           where ret is a past-the-end iterator for a new
+    ///           subrange.
     ///
-    template <typename ExPolicy, typename Rng, typename Pred = detail::equal_to,
-        typename Proj = util::projection_identity,
-        HPX_CONCEPT_REQUIRES_(hpx::is_execution_policy<ExPolicy>::value&&
-                hpx::traits::is_range<Rng>::value&& traits::is_projected_range<
-                    Proj, Rng>::value&& traits::is_indirect_callable<ExPolicy,
-                    Pred, traits::projected_range<Proj, Rng>,
-                    traits::projected_range<Proj, Rng>>::value)>
+    template <typename ExPolicy, typename Rng, typename Pred, typename Proj>
     typename util::detail::algorithm_result<ExPolicy,
-        typename hpx::traits::range_iterator<Rng>::type>::type
-        HPX_DEPRECATED_V(1, 8,
-            "hpx::parallel::unique is deprecated, use hpx::unique instead")
-            unique(ExPolicy&& policy, Rng&& rng, Pred&& pred = Pred(),
-                Proj&& proj = Proj())
-    {
-#if defined(HPX_GCC_VERSION) && HPX_GCC_VERSION >= 100000
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-#endif
-        return unique(std::forward<ExPolicy>(policy), hpx::util::begin(rng),
-            hpx::util::end(rng), std::forward<Pred>(pred),
-            std::forward<Proj>(proj));
-#if defined(HPX_GCC_VERSION) && HPX_GCC_VERSION >= 100000
-#pragma GCC diagnostic pop
-#endif
-    }
+    subrange_t<typename hpx::traits::range_iterator<Rng>::type>::type
+    unique(ExPolicy&& policy, Rng&& rng, Pred&& pred, Proj&& proj);
 
+    ///////////////////////////////////////////////////////////////////////////
+    /// Copies the elements from the range [first, last),
+    /// to another range beginning at \a dest in such a way that
+    /// there are no consecutive equal elements. Only the first element of
+    /// each group of equal elements is copied.
+    ///
+    /// \note   Complexity: Performs not more than \a last - \a first
+    ///         assignments, exactly \a last - \a first - 1 applications of
+    ///         the predicate \a pred and no more than twice as many
+    ///         applications of the projection \a proj
+    ///
+    /// \tparam InIter      The type of the source iterators used (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     input iterator.
+    /// \tparam Sent        The type of the source sentinel (deduced). This
+    ///                     sentinel type must be a sentinel for InIter.
+    /// \tparam OutIter     The type of the iterator representing the
+    ///                     destination range (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     output iterator.
+    /// \tparam Pred        The type of the function/function object to use
+    ///                     (deduced). Unlike its sequential form, the parallel
+    ///                     overload of \a unique_copy requires \a Pred to meet the
+    ///                     requirements of \a CopyConstructible. This defaults
+    ///                     to std::equal_to<>
+    /// \tparam Proj        The type of an optional projection function. This
+    ///                     defaults to \a util::projection_identity
+    ///
+    /// \param first        Refers to the beginning of the sequence of elements
+    ///                     the algorithm will be applied to.
+    /// \param last         Refers to sentinel value denoting the end of the
+    ///                     sequence of elements the algorithm will be applied.
+    /// \param dest         Refers to the beginning of the destination range.
+    /// \param pred         Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements in the
+    ///                     sequence specified by [first, last). This is an
+    ///                     binary predicate which returns \a true for the
+    ///                     required elements. The signature of this predicate
+    ///                     should be equivalent to:
+    ///                     \code
+    ///                     bool pred(const Type &a, const Type &b);
+    ///                     \endcode \n
+    ///                     The signature does not need to have const&, but
+    ///                     the function must not modify the objects passed to
+    ///                     it. The type \a Type must be such that an object of
+    ///                     type \a FwdIter1 can be dereferenced and then
+    ///                     implicitly converted to \a Type.
+    /// \param proj         Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements as a
+    ///                     projection operation before the actual predicate
+    ///                     \a is invoked.
+    ///
+    /// The assignments in the parallel \a unique_copy algorithm invoked
+    /// without an execution policy object  will execute in sequential
+    /// order in the calling thread.
+    ///
+    /// \returns  The \a unique_copy algorithm returns a
+    ///           returns parallel::util::in_out_result<FwdIter, OutIter>.
+    ///           The \a unique_copy algorithm returns an in_out_result with
+    ///           the source iterator to one past the last element and out
+    ///           containing the destination iterator to the end of the
+    ///           \a dest range.
+    ///
+    template <typename InIter, typename Sent, typename OutIter,
+        typename Pred, typename Proj>
+    util::in_out_result<FwdIter, OutIter> unique(FwdIter first,
+        Sent last, OutIter dest, Pred&& pred, Proj&& proj);
+
+    ///////////////////////////////////////////////////////////////////////////
+    /// Copies the elements from the range [first, last),
+    /// to another range beginning at \a dest in such a way that
+    /// there are no consecutive equal elements. Only the first element of
+    /// each group of equal elements is copied.
+    ///
+    /// \note   Complexity: Performs not more than \a last - \a first
+    ///         assignments, exactly \a last - \a first - 1 applications of
+    ///         the predicate \a pred and no more than twice as many
+    ///         applications of the projection \a proj
+    ///
+    /// \tparam ExPolicy    The type of the execution policy to use (deduced).
+    ///                     It describes the manner in which the execution
+    ///                     of the algorithm may be parallelized and the manner
+    ///                     in which it executes the assignments.
+    /// \tparam FwdIter1    The type of the source iterators used (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     forward iterator.
+    /// \tparam Sent        The type of the source sentinel (deduced). This
+    ///                     sentinel type must be a sentinel for FwdIter1.
+    /// \tparam FwdIter2    The type of the iterator representing the
+    ///                     destination range (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     forward iterator.
+    /// \tparam Pred        The type of the function/function object to use
+    ///                     (deduced). Unlike its sequential form, the parallel
+    ///                     overload of \a unique_copy requires \a Pred to meet the
+    ///                     requirements of \a CopyConstructible. This defaults
+    ///                     to std::equal_to<>
+    /// \tparam Proj        The type of an optional projection function. This
+    ///                     defaults to \a util::projection_identity
+    ///
+    /// \param policy       The execution policy to use for the scheduling of
+    ///                     the iterations.
+    /// \param first        Refers to the beginning of the sequence of elements
+    ///                     the algorithm will be applied to.
+    /// \param last         Refers to sentinel value denoting the end of the
+    ///                     sequence of elements the algorithm will be applied.
+    /// \param dest         Refers to the beginning of the destination range.
+    /// \param pred         Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements in the
+    ///                     sequence specified by [first, last). This is an
+    ///                     binary predicate which returns \a true for the
+    ///                     required elements. The signature of this predicate
+    ///                     should be equivalent to:
+    ///                     \code
+    ///                     bool pred(const Type &a, const Type &b);
+    ///                     \endcode \n
+    ///                     The signature does not need to have const&, but
+    ///                     the function must not modify the objects passed to
+    ///                     it. The type \a Type must be such that an object of
+    ///                     type \a FwdIter1 can be dereferenced and then
+    ///                     implicitly converted to \a Type.
+    /// \param proj         Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements as a
+    ///                     projection operation before the actual predicate
+    ///                     \a is invoked.
+    ///
+    /// The assignments in the parallel \a unique_copy algorithm invoked with
+    /// an execution policy object of type \a sequenced_policy
+    /// execute in sequential order in the calling thread.
+    ///
+    /// The assignments in the parallel \a unique_copy algorithm invoked with
+    /// an execution policy object of type \a parallel_policy or
+    /// \a parallel_task_policy are permitted to execute in an unordered
+    /// fashion in unspecified threads, and indeterminately sequenced
+    /// within each thread.
+    ///
+    /// \returns  The \a unique_copy algorithm returns areturns hpx::future<
+    ///           parallel::util::in_out_result<FwdIter1, FwdIter2>> if the
+    ///           execution policy is of type \a sequenced_task_policy or
+    ///           \a parallel_task_policy and returns \a 
+    ///           parallel::util::in_out_result<FwdIter1, FwdIter2> otherwise.
+    ///           The \a unique_copy algorithm returns an in_out_result with
+    ///           the source iterator to one past the last element and out
+    ///           containing the destination iterator to the end of the
+    ///           \a dest range.
+    ///
+    template <typename ExPolicy, typename FwdIter1, typename Sent,
+        typename FwdIter2, typename Pred, typename Proj>
+    typename parallel::util::detail::algorithm_result<ExPolicy,
+        util::in_out_result<FwdIter1, FwdIter2>>::type
+    unique_copy(ExPolicy&& policy, FwdIter1 first, Sent last,
+        FwdIter2 dest, Pred&& pred, Proj&& proj);
+
+    ///////////////////////////////////////////////////////////////////////////
+    /// Copies the elements from the range \a rng,
+    /// to another range beginning at \a dest in such a way that
+    /// there are no consecutive equal elements. Only the first element of
+    /// each group of equal elements is copied.
+    ///
+    /// \note   Complexity: Performs not more than N assignments,
+    ///         exactly N - 1 applications of the predicate \a pred,
+    ///         where N = std::distance(begin(rng), end(rng)).
+    ///
+    /// \tparam Rng         The type of the source range used (deduced).
+    ///                     The iterators extracted from this range type must
+    ///                     meet the requirements of an forward iterator.
+    /// \tparam O           The type of the iterator representing the
+    ///                     destination range (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     forward iterator.
+    /// \tparam Pred        The type of the function/function object to use
+    ///                     (deduced). Unlike its sequential form, the parallel
+    ///                     overload of \a unique_copy requires \a Pred to meet the
+    ///                     requirements of \a CopyConstructible. This defaults
+    ///                     to std::equal_to<>
+    /// \tparam Proj        The type of an optional projection function. This
+    ///                     defaults to \a util::projection_identity
+    ///
+    /// \param rng          Refers to the sequence of elements the algorithm
+    ///                     will be applied to.
+    /// \param dest         Refers to the beginning of the destination range.
+    /// \param pred         Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements in the
+    ///                     sequence specified by the range \a rng. This is an
+    ///                     binary predicate which returns \a true for the
+    ///                     required elements. The signature of this predicate
+    ///                     should be equivalent to:
+    ///                     \code
+    ///                     bool pred(const Type &a, const Type &b);
+    ///                     \endcode \n
+    ///                     The signature does not need to have const&, but
+    ///                     the function must not modify the objects passed to
+    ///                     it. The type \a Type must be such that an object of
+    ///                     type \a FwdIter1 can be dereferenced and then
+    ///                     implicitly converted to \a Type.
+    /// \param proj         Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements as a
+    ///                     projection operation before the actual predicate
+    ///                     \a is invoked.
+    ///
+    /// The assignments in the parallel \a unique_copy algorithm invoked
+    /// without an execution policy object  will execute in sequential
+    /// order in the calling thread.
+    ///
+    /// \returns  The \a unique_copy algorithm returns \a
+    ///           parallel::util::in_out_result<
+    ///           typename hpx::traits::range_iterator<Rng>::type, O>.
+    ///           The \a unique_copy algorithm returns the pair of
+    ///           the source iterator to \a last, and
+    ///           the destination iterator to the end of the \a dest range.
+    ///
+    template <typename Rng, typename O, typename Pred, typename Proj>
+    parallel::util::in_out_result<
+        typename hpx::traits::range_iterator<Rng>::type, O>
+    unique_copy(Rng&& rng, O dest, Pred&& pred, Proj&& proj);
+
+    ///////////////////////////////////////////////////////////////////////////
     /// Copies the elements from the range \a rng,
     /// to another range beginning at \a dest in such a way that
     /// there are no consecutive equal elements. Only the first element of
@@ -132,7 +512,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
     /// \tparam Rng         The type of the source range used (deduced).
     ///                     The iterators extracted from this range type must
     ///                     meet the requirements of an forward iterator.
-    /// \tparam FwdIter2    The type of the iterator representing the
+    /// \tparam O           The type of the iterator representing the
     ///                     destination range (deduced).
     ///                     This iterator type must meet the requirements of an
     ///                     forward iterator.
@@ -179,16 +559,74 @@ namespace hpx { namespace parallel { inline namespace v1 {
     /// within each thread.
     ///
     /// \returns  The \a unique_copy algorithm returns a
-    ///           \a hpx::future<tagged_pair<tag::in(FwdIter1), tag::out(FwdIter2)> >
+    ///           \a hpx::future<parallel::util::in_out_result<
+    ///           typename hpx::traits::range_iterator<Rng>::type, O>>
     ///           if the execution policy is of type
     ///           \a sequenced_task_policy or
     ///           \a parallel_task_policy and
-    ///           returns \a tagged_pair<tag::in(FwdIter1), tag::out(FwdIter2)>
+    ///           returns \a parallel::util::in_out_result<
+    ///           typename hpx::traits::range_iterator<Rng>::type, O>
     ///           otherwise.
     ///           The \a unique_copy algorithm returns the pair of
     ///           the source iterator to \a last, and
     ///           the destination iterator to the end of the \a dest range.
     ///
+    template <typename InIter, typename Sent, typename OutIter,
+        typename Pred, typename Proj>
+    typename parallel::util::detail::algorithm_result<ExPolicy,
+        util::in_out_result<typename hpx::traits::range_iterator<Rng>::type,
+        O>>::type
+    unique_copy(ExPolicy&& policy, Rng&& rng, O dest,
+        Pred&& pred, Proj&& proj);
+
+    // clang-format on
+}}    // namespace hpx::ranges
+
+#else
+
+#include <hpx/config.hpp>
+#include <hpx/concepts/concepts.hpp>
+#include <hpx/execution/algorithms/detail/predicates.hpp>
+#include <hpx/iterator_support/iterator_range.hpp>
+#include <hpx/iterator_support/range.hpp>
+#include <hpx/iterator_support/traits/is_iterator.hpp>
+#include <hpx/iterator_support/traits/is_range.hpp>
+#include <hpx/parallel/util/tagged_pair.hpp>
+
+#include <hpx/algorithms/traits/projected.hpp>
+#include <hpx/algorithms/traits/projected_range.hpp>
+#include <hpx/parallel/algorithms/unique.hpp>
+
+#include <type_traits>
+#include <utility>
+
+namespace hpx { namespace parallel { inline namespace v1 {
+    template <typename ExPolicy, typename Rng, typename Pred = detail::equal_to,
+        typename Proj = util::projection_identity,
+        HPX_CONCEPT_REQUIRES_(hpx::is_execution_policy<ExPolicy>::value&&
+                hpx::traits::is_range<Rng>::value&& traits::is_projected_range<
+                    Proj, Rng>::value&& traits::is_indirect_callable<ExPolicy,
+                    Pred, traits::projected_range<Proj, Rng>,
+                    traits::projected_range<Proj, Rng>>::value)>
+    typename util::detail::algorithm_result<ExPolicy,
+        typename hpx::traits::range_iterator<Rng>::type>::type
+        HPX_DEPRECATED_V(1, 8,
+            "hpx::parallel::unique is deprecated, use hpx::unique instead")
+            unique(ExPolicy&& policy, Rng&& rng, Pred&& pred = Pred(),
+                Proj&& proj = Proj())
+    {
+#if defined(HPX_GCC_VERSION) && HPX_GCC_VERSION >= 100000
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
+        return unique(std::forward<ExPolicy>(policy), hpx::util::begin(rng),
+            hpx::util::end(rng), std::forward<Pred>(pred),
+            std::forward<Proj>(proj));
+#if defined(HPX_GCC_VERSION) && HPX_GCC_VERSION >= 100000
+#pragma GCC diagnostic pop
+#endif
+    }
+
     template <typename ExPolicy, typename Rng, typename FwdIter2,
         typename Pred = detail::equal_to,
         typename Proj = util::projection_identity,
@@ -500,3 +938,5 @@ namespace hpx { namespace ranges {
         }
     } unique_copy{};
 }}    // namespace hpx::ranges
+
+#endif

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/unique.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/unique.hpp
@@ -197,14 +197,14 @@ namespace hpx { namespace ranges {
     ///
     /// \returns  The \a unique algorithm returns
     ///           \a subrange_t<typename hpx::traits::range_iterator<Rng>
-    ///           ::type,typename hpx::traits::range_iterator<Rng>::type>.
+    ///           ::type,hpx::traits::range_iterator_t<Rng>>.
     ///           The \a unique algorithm returns an object {ret, last},
     ///           where ret is a past-the-end iterator for a new
     ///           subrange.
     ///
     template <typename Rng, typename Pred, typename Proj>
-    subrange_t<typename hpx::traits::range_iterator<Rng>::type,
-        typename hpx::traits::range_iterator<Rng>::type>
+    subrange_t<hpx::traits::range_iterator_t<Rng>,
+        hpx::traits::range_iterator_t<Rng>>
     unique(Rng&& rng, Pred&& pred, Proj&& proj);
 
     ///////////////////////////////////////////////////////////////////////////
@@ -266,12 +266,12 @@ namespace hpx { namespace ranges {
     /// within each thread.
     ///
     /// \returns  The \a unique algorithm returns a \a hpx::future
-    ///           <subrange_t<typename hpx::traits::range_iterator<Rng>::type,
-    ///           typename hpx::traits::range_iterator<Rng>::type>>
+    ///           <subrange_t<hpx::traits::range_iterator_t<Rng>,
+    ///           hpx::traits::range_iterator_t<Rng>>>
     ///           if the execution policy is of type \a sequenced_task_policy
     ///           or \a parallel_task_policy and returns
     ///           \a subrange_t<typename hpx::traits::range_iterator<Rng>
-    ///           ::type,typename hpx::traits::range_iterator<Rng>::type>.
+    ///           ::type,hpx::traits::range_iterator_t<Rng>>.
     ///           otherwise.
     ///           The \a unique algorithm returns an object {ret, last},
     ///           where ret is a past-the-end iterator for a new
@@ -279,8 +279,8 @@ namespace hpx { namespace ranges {
     ///
     template <typename ExPolicy, typename Rng, typename Pred, typename Proj>
     typename util::detail::algorithm_result<ExPolicy,
-    subrange_t<typename hpx::traits::range_iterator<Rng>::type,
-    typename hpx::traits::range_iterator<Rng>::type>::type
+    subrange_t<hpx::traits::range_iterator_t<Rng>,
+    hpx::traits::range_iterator_t<Rng>>::type
     unique(ExPolicy&& policy, Rng&& rng, Pred&& pred, Proj&& proj);
 
     ///////////////////////////////////////////////////////////////////////////
@@ -489,14 +489,14 @@ namespace hpx { namespace ranges {
     ///
     /// \returns  The \a unique_copy algorithm returns \a
     ///           parallel::util::in_out_result<
-    ///           typename hpx::traits::range_iterator<Rng>::type, O>.
+    ///           hpx::traits::range_iterator_t<Rng>, O>.
     ///           The \a unique_copy algorithm returns the pair of
     ///           the source iterator to \a last, and
     ///           the destination iterator to the end of the \a dest range.
     ///
     template <typename Rng, typename O, typename Pred, typename Proj>
     parallel::util::in_out_result<
-        typename hpx::traits::range_iterator<Rng>::type, O>
+        hpx::traits::range_iterator_t<Rng>, O>
     unique_copy(Rng&& rng, O dest, Pred&& pred, Proj&& proj);
 
     ///////////////////////////////////////////////////////////////////////////
@@ -564,12 +564,12 @@ namespace hpx { namespace ranges {
     ///
     /// \returns  The \a unique_copy algorithm returns a
     ///           \a hpx::future<parallel::util::in_out_result<
-    ///           typename hpx::traits::range_iterator<Rng>::type, O>>
+    ///           hpx::traits::range_iterator_t<Rng>, O>>
     ///           if the execution policy is of type
     ///           \a sequenced_task_policy or
     ///           \a parallel_task_policy and
     ///           returns \a parallel::util::in_out_result<
-    ///           typename hpx::traits::range_iterator<Rng>::type, O>
+    ///           hpx::traits::range_iterator_t<Rng>, O>
     ///           otherwise.
     ///           The \a unique_copy algorithm returns the pair of
     ///           the source iterator to \a last, and
@@ -578,7 +578,7 @@ namespace hpx { namespace ranges {
     template <typename InIter, typename Sent, typename OutIter,
         typename Pred, typename Proj>
     typename parallel::util::detail::algorithm_result<ExPolicy,
-        util::in_out_result<typename hpx::traits::range_iterator<Rng>::type,
+        util::in_out_result<hpx::traits::range_iterator_t<Rng>,
         O>>::type
     unique_copy(ExPolicy&& policy, Rng&& rng, O dest,
         Pred&& pred, Proj&& proj);
@@ -615,9 +615,8 @@ namespace hpx { namespace parallel { inline namespace v1 {
     HPX_DEPRECATED_V(
         1, 8, "hpx::parallel::unique is deprecated, use hpx::unique instead")
     typename util::detail::algorithm_result<ExPolicy,
-        typename hpx::traits::range_iterator<Rng>::type>::type
-        unique(ExPolicy&& policy, Rng&& rng, Pred&& pred = Pred(),
-            Proj&& proj = Proj())
+        hpx::traits::range_iterator_t<Rng>>::type unique(ExPolicy&& policy,
+        Rng&& rng, Pred&& pred = Pred(), Proj&& proj = Proj())
     {
 #if defined(HPX_GCC_VERSION) && HPX_GCC_VERSION >= 100000
 #pragma GCC diagnostic push
@@ -644,9 +643,9 @@ namespace hpx { namespace parallel { inline namespace v1 {
         "hpx::parallel::unique_copy is deprecated, use hpx::unique_copy "
         "instead")
     typename util::detail::algorithm_result<ExPolicy,
-        util::in_out_result<typename hpx::traits::range_iterator<Rng>::type,
-            FwdIter2>>::type unique_copy(ExPolicy&& policy, Rng&& rng,
-        FwdIter2 dest, Pred&& pred = Pred(), Proj&& proj = Proj())
+        util::in_out_result<hpx::traits::range_iterator_t<Rng>, FwdIter2>>::type
+        unique_copy(ExPolicy&& policy, Rng&& rng, FwdIter2 dest,
+            Pred&& pred = Pred(), Proj&& proj = Proj())
     {
 #if defined(HPX_GCC_VERSION) && HPX_GCC_VERSION >= 100000
 #pragma GCC diagnostic push
@@ -745,23 +744,22 @@ namespace hpx { namespace ranges {
                     hpx::parallel::traits::projected_range<Proj, Rng>>::value
             )>
         // clang-format on
-        friend subrange_t<typename hpx::traits::range_iterator<Rng>::type,
-            typename hpx::traits::range_iterator<Rng>::type>
+        friend subrange_t<hpx::traits::range_iterator_t<Rng>,
+            hpx::traits::range_iterator_t<Rng>>
         tag_fallback_dispatch(hpx::ranges::unique_t, Rng&& rng,
             Pred&& pred = Pred(), Proj&& proj = Proj())
         {
-            using iterator_type =
-                typename hpx::traits::range_iterator<Rng>::type;
+            using iterator_type = hpx::traits::range_iterator_t<Rng>;
 
             static_assert(
                 hpx::traits::is_forward_iterator<iterator_type>::value,
                 "Requires at least input iterator.");
 
             return hpx::parallel::util::make_subrange<
-                typename hpx::traits::range_iterator<Rng>::type,
+                hpx::traits::range_iterator_t<Rng>,
                 typename hpx::traits::range_sentinel<Rng>::type>(
                 hpx::parallel::v1::detail::unique<
-                    typename hpx::traits::range_iterator<Rng>::type>()
+                    hpx::traits::range_iterator_t<Rng>>()
                     .call(hpx::execution::seq, hpx::util::begin(rng),
                         hpx::util::end(rng), std::forward<Pred>(pred),
                         std::forward<Proj>(proj)),
@@ -783,23 +781,22 @@ namespace hpx { namespace ranges {
             )>
         // clang-format on
         friend typename parallel::util::detail::algorithm_result<ExPolicy,
-            subrange_t<typename hpx::traits::range_iterator<Rng>::type,
-                typename hpx::traits::range_iterator<Rng>::type>>::type
+            subrange_t<hpx::traits::range_iterator_t<Rng>,
+                hpx::traits::range_iterator_t<Rng>>>::type
         tag_fallback_dispatch(hpx::ranges::unique_t, ExPolicy&& policy,
             Rng&& rng, Pred&& pred = Pred(), Proj&& proj = Proj())
         {
-            using iterator_type =
-                typename hpx::traits::range_iterator<Rng>::type;
+            using iterator_type = hpx::traits::range_iterator_t<Rng>;
 
             static_assert(
                 hpx::traits::is_forward_iterator<iterator_type>::value,
                 "Requires at least forward iterator.");
 
             return hpx::parallel::util::make_subrange<
-                typename hpx::traits::range_iterator<Rng>::type,
+                hpx::traits::range_iterator_t<Rng>,
                 typename hpx::traits::range_sentinel<Rng>::type>(
                 hpx::parallel::v1::detail::unique<
-                    typename hpx::traits::range_iterator<Rng>::type>()
+                    hpx::traits::range_iterator_t<Rng>>()
                     .call(std::forward<ExPolicy>(policy), hpx::util::begin(rng),
                         hpx::util::end(rng), std::forward<Pred>(pred),
                         std::forward<Proj>(proj)),
@@ -889,19 +886,16 @@ namespace hpx { namespace ranges {
                     hpx::parallel::traits::projected_range<Proj, Rng>>::value
             )>
         // clang-format on
-        friend unique_copy_result<
-            typename hpx::traits::range_iterator<Rng>::type, O>
+        friend unique_copy_result<hpx::traits::range_iterator_t<Rng>, O>
         tag_fallback_dispatch(hpx::ranges::unique_copy_t, Rng&& rng, O dest,
             Pred&& pred = Pred(), Proj&& proj = Proj())
         {
-            using iterator_type =
-                typename hpx::traits::range_iterator<Rng>::type;
+            using iterator_type = hpx::traits::range_iterator_t<Rng>;
 
             static_assert(hpx::traits::is_input_iterator<iterator_type>::value,
                 "Requires at least input iterator.");
 
-            using result_type = unique_copy_result<
-                typename hpx::traits::range_iterator<Rng>::type, O>;
+            using result_type = unique_copy_result<iterator_type, O>;
 
             return hpx::parallel::v1::detail::unique_copy<result_type>().call(
                 hpx::execution::seq, hpx::util::begin(rng), hpx::util::end(rng),
@@ -923,20 +917,17 @@ namespace hpx { namespace ranges {
             )>
         // clang-format on
         friend typename parallel::util::detail::algorithm_result<ExPolicy,
-            unique_copy_result<typename hpx::traits::range_iterator<Rng>::type,
-                O>>::type
+            unique_copy_result<hpx::traits::range_iterator_t<Rng>, O>>::type
         tag_fallback_dispatch(hpx::ranges::unique_copy_t, ExPolicy&& policy,
             Rng&& rng, O dest, Pred&& pred = Pred(), Proj&& proj = Proj())
         {
-            using iterator_type =
-                typename hpx::traits::range_iterator<Rng>::type;
+            using iterator_type = hpx::traits::range_iterator_t<Rng>;
 
             static_assert(
                 hpx::traits::is_forward_iterator<iterator_type>::value,
                 "Requires at least input iterator.");
 
-            using result_type = unique_copy_result<
-                typename hpx::traits::range_iterator<Rng>::type, O>;
+            using result_type = unique_copy_result<iterator_type, O>;
 
             return hpx::parallel::v1::detail::unique_copy<result_type>().call(
                 std::forward<ExPolicy>(policy), hpx::util::begin(rng),

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/unique.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/unique.hpp
@@ -340,7 +340,7 @@ namespace hpx { namespace ranges {
     /// order in the calling thread.
     ///
     /// \returns  The \a unique_copy algorithm returns a
-    ///           returns parallel::util::in_out_result<FwdIter, OutIter>.
+    ///           returns unique_copy_result<FwdIter, OutIter>.
     ///           The \a unique_copy algorithm returns an in_out_result with
     ///           the source iterator to one past the last element and out
     ///           containing the destination iterator to the end of the
@@ -348,7 +348,7 @@ namespace hpx { namespace ranges {
     ///
     template <typename InIter, typename Sent, typename OutIter,
         typename Pred, typename Proj>
-    util::in_out_result<FwdIter, OutIter> unique_copy(InIter first,
+    unique_copy_result<FwdIter, OutIter> unique_copy(InIter first,
         Sent last, OutIter dest, Pred&& pred, Proj&& proj);
 
     ///////////////////////////////////////////////////////////////////////////
@@ -420,10 +420,10 @@ namespace hpx { namespace ranges {
     /// within each thread.
     ///
     /// \returns  The \a unique_copy algorithm returns areturns hpx::future<
-    ///           parallel::util::in_out_result<FwdIter1, FwdIter2>> if the
+    ///           unique_copy_result<FwdIter1, FwdIter2>> if the
     ///           execution policy is of type \a sequenced_task_policy or
     ///           \a parallel_task_policy and returns \a
-    ///           parallel::util::in_out_result<FwdIter1, FwdIter2> otherwise.
+    ///           unique_copy_result<FwdIter1, FwdIter2> otherwise.
     ///           The \a unique_copy algorithm returns an in_out_result with
     ///           the source iterator to one past the last element and out
     ///           containing the destination iterator to the end of the
@@ -432,7 +432,7 @@ namespace hpx { namespace ranges {
     template <typename ExPolicy, typename FwdIter1, typename Sent,
         typename FwdIter2, typename Pred, typename Proj>
     typename parallel::util::detail::algorithm_result<ExPolicy,
-        util::in_out_result<FwdIter1, FwdIter2>>::type
+        unique_copy_result<FwdIter1, FwdIter2>>::type
     unique_copy(ExPolicy&& policy, FwdIter1 first, Sent last,
         FwdIter2 dest, Pred&& pred, Proj&& proj);
 
@@ -488,15 +488,14 @@ namespace hpx { namespace ranges {
     /// order in the calling thread.
     ///
     /// \returns  The \a unique_copy algorithm returns \a
-    ///           parallel::util::in_out_result<
+    ///           unique_copy_result<
     ///           hpx::traits::range_iterator_t<Rng>, O>.
     ///           The \a unique_copy algorithm returns the pair of
     ///           the source iterator to \a last, and
     ///           the destination iterator to the end of the \a dest range.
     ///
     template <typename Rng, typename O, typename Pred, typename Proj>
-    parallel::util::in_out_result<
-        hpx::traits::range_iterator_t<Rng>, O>
+    unique_copy_result<hpx::traits::range_iterator_t<Rng>, O>
     unique_copy(Rng&& rng, O dest, Pred&& pred, Proj&& proj);
 
     ///////////////////////////////////////////////////////////////////////////
@@ -563,12 +562,12 @@ namespace hpx { namespace ranges {
     /// within each thread.
     ///
     /// \returns  The \a unique_copy algorithm returns a
-    ///           \a hpx::future<parallel::util::in_out_result<
+    ///           \a hpx::future<unique_copy_result<
     ///           hpx::traits::range_iterator_t<Rng>, O>>
     ///           if the execution policy is of type
     ///           \a sequenced_task_policy or
     ///           \a parallel_task_policy and
-    ///           returns \a parallel::util::in_out_result<
+    ///           returns \a unique_copy_result<
     ///           hpx::traits::range_iterator_t<Rng>, O>
     ///           otherwise.
     ///           The \a unique_copy algorithm returns the pair of
@@ -578,7 +577,7 @@ namespace hpx { namespace ranges {
     template <typename InIter, typename Sent, typename OutIter,
         typename Pred, typename Proj>
     typename parallel::util::detail::algorithm_result<ExPolicy,
-        util::in_out_result<hpx::traits::range_iterator_t<Rng>,
+        unique_copy_result<hpx::traits::range_iterator_t<Rng>,
         O>>::type
     unique_copy(ExPolicy&& policy, Rng&& rng, O dest,
         Pred&& pred, Proj&& proj);
@@ -605,18 +604,24 @@ namespace hpx { namespace ranges {
 #include <utility>
 
 namespace hpx { namespace parallel { inline namespace v1 {
-    template <typename ExPolicy, typename Rng, typename Pred = detail::equal_to,
+    // clang-format off
+    template <typename ExPolicy, typename Rng,
+        typename Pred = detail::equal_to,
         typename Proj = util::projection_identity,
-        HPX_CONCEPT_REQUIRES_(hpx::is_execution_policy<ExPolicy>::value&&
-                hpx::traits::is_range<Rng>::value&& traits::is_projected_range<
-                    Proj, Rng>::value&& traits::is_indirect_callable<ExPolicy,
-                    Pred, traits::projected_range<Proj, Rng>,
-                    traits::projected_range<Proj, Rng>>::value)>
+        HPX_CONCEPT_REQUIRES_(
+            hpx::is_execution_policy<ExPolicy>::value &&
+            hpx::traits::is_range<Rng>::value &&
+            traits::is_projected_range<Proj, Rng>::value &&
+            traits::is_indirect_callable<ExPolicy, Pred,
+                traits::projected_range<Proj, Rng>,
+                traits::projected_range<Proj, Rng>>::value
+        )>
+    // clang-format on
     HPX_DEPRECATED_V(
         1, 8, "hpx::parallel::unique is deprecated, use hpx::unique instead")
-    typename util::detail::algorithm_result<ExPolicy,
-        hpx::traits::range_iterator_t<Rng>>::type unique(ExPolicy&& policy,
-        Rng&& rng, Pred&& pred = Pred(), Proj&& proj = Proj())
+        typename util::detail::algorithm_result<ExPolicy,
+            hpx::traits::range_iterator_t<Rng>>::type unique(ExPolicy&& policy,
+            Rng&& rng, Pred&& pred = Pred(), Proj&& proj = Proj())
     {
 #if defined(HPX_GCC_VERSION) && HPX_GCC_VERSION >= 100000
 #pragma GCC diagnostic push
@@ -630,19 +635,23 @@ namespace hpx { namespace parallel { inline namespace v1 {
 #endif
     }
 
+    // clang-format off
     template <typename ExPolicy, typename Rng, typename FwdIter2,
         typename Pred = detail::equal_to,
         typename Proj = util::projection_identity,
-        HPX_CONCEPT_REQUIRES_(hpx::is_execution_policy<ExPolicy>::value&&
-                hpx::traits::is_range<Rng>::value&& hpx::traits::is_iterator<
-                    FwdIter2>::value&& traits::is_projected_range<Proj,
-                    Rng>::value&& traits::is_indirect_callable<ExPolicy, Pred,
-                    traits::projected_range<Proj, Rng>,
-                    traits::projected_range<Proj, Rng>>::value)>
+        HPX_CONCEPT_REQUIRES_(
+            hpx::is_execution_policy<ExPolicy>::value &&
+            hpx::traits::is_range<Rng>::value &&
+            hpx::traits::is_iterator<FwdIter2>::value &&
+            traits::is_projected_range<Proj, Rng>::value &&
+            traits::is_indirect_callable<ExPolicy, Pred,
+                traits::projected_range<Proj, Rng>,
+                traits::projected_range<Proj, Rng>>::value
+        )>
+    // clang-format on
     HPX_DEPRECATED_V(1, 8,
         "hpx::parallel::unique_copy is deprecated, use hpx::unique_copy "
-        "instead")
-    typename util::detail::algorithm_result<ExPolicy,
+        "instead") typename util::detail::algorithm_result<ExPolicy,
         util::in_out_result<hpx::traits::range_iterator_t<Rng>, FwdIter2>>::type
         unique_copy(ExPolicy&& policy, Rng&& rng, FwdIter2 dest,
             Pred&& pred = Pred(), Proj&& proj = Proj())
@@ -677,7 +686,7 @@ namespace hpx { namespace ranges {
             typename Pred = ranges::equal_to,
             typename Proj = parallel::util::projection_identity,
             HPX_CONCEPT_REQUIRES_(
-                hpx::traits::is_iterator<FwdIter>::value &&
+                hpx::traits::is_iterator_v<FwdIter> &&
                 hpx::traits::is_sentinel_for<Sent, FwdIter>::value &&
                 parallel::traits::is_projected<Proj, FwdIter>::value &&
                 parallel::traits::is_indirect_callable<
@@ -690,7 +699,7 @@ namespace hpx { namespace ranges {
             hpx::ranges::unique_t, FwdIter first, Sent last,
             Pred&& pred = Pred(), Proj&& proj = Proj())
         {
-            static_assert(hpx::traits::is_forward_iterator<FwdIter>::value,
+            static_assert(hpx::traits::is_forward_iterator_v<FwdIter>,
                 "Requires at least forward iterator.");
 
             return hpx::parallel::util::make_subrange<FwdIter, Sent>(
@@ -706,7 +715,7 @@ namespace hpx { namespace ranges {
             typename Proj = parallel::util::projection_identity,
             HPX_CONCEPT_REQUIRES_(
                 hpx::is_execution_policy<ExPolicy>::value &&
-                hpx::traits::is_iterator<FwdIter>::value &&
+                hpx::traits::is_iterator_v<FwdIter> &&
                 hpx::traits::is_sentinel_for<Sent, FwdIter>::value &&
                 parallel::traits::is_projected<Proj, FwdIter>::value &&
                 parallel::traits::is_indirect_callable<
@@ -721,7 +730,7 @@ namespace hpx { namespace ranges {
             FwdIter first, Sent last, Pred&& pred = Pred(),
             Proj&& proj = Proj())
         {
-            static_assert(hpx::traits::is_forward_iterator<FwdIter>::value,
+            static_assert(hpx::traits::is_forward_iterator_v<FwdIter>,
                 "Requires at least forward iterator.");
 
             return hpx::parallel::util::make_subrange<FwdIter, Sent>(
@@ -751,8 +760,7 @@ namespace hpx { namespace ranges {
         {
             using iterator_type = hpx::traits::range_iterator_t<Rng>;
 
-            static_assert(
-                hpx::traits::is_forward_iterator<iterator_type>::value,
+            static_assert(hpx::traits::is_forward_iterator_v<iterator_type>,
                 "Requires at least input iterator.");
 
             return hpx::parallel::util::make_subrange<
@@ -788,8 +796,7 @@ namespace hpx { namespace ranges {
         {
             using iterator_type = hpx::traits::range_iterator_t<Rng>;
 
-            static_assert(
-                hpx::traits::is_forward_iterator<iterator_type>::value,
+            static_assert(hpx::traits::is_forward_iterator_v<iterator_type>,
                 "Requires at least forward iterator.");
 
             return hpx::parallel::util::make_subrange<
@@ -818,7 +825,7 @@ namespace hpx { namespace ranges {
             typename Pred = ranges::equal_to,
             typename Proj = parallel::util::projection_identity,
             HPX_CONCEPT_REQUIRES_(
-                hpx::traits::is_iterator<InIter>::value &&
+                hpx::traits::is_iterator_v<InIter> &&
                 hpx::traits::is_sentinel_for<Sent, InIter>::value &&
                 parallel::traits::is_projected<Proj, InIter>::value &&
                 parallel::traits::is_indirect_callable<
@@ -831,7 +838,7 @@ namespace hpx { namespace ranges {
             hpx::ranges::unique_copy_t, InIter first, Sent last, O dest,
             Pred&& pred = Pred(), Proj&& proj = Proj())
         {
-            static_assert(hpx::traits::is_input_iterator<InIter>::value,
+            static_assert(hpx::traits::is_input_iterator_v<InIter>,
                 "Requires at least input iterator.");
 
             using result_type = unique_copy_result<InIter, O>;
@@ -848,7 +855,7 @@ namespace hpx { namespace ranges {
             typename Proj = parallel::util::projection_identity,
             HPX_CONCEPT_REQUIRES_(
                 hpx::is_execution_policy<ExPolicy>::value &&
-                hpx::traits::is_iterator<FwdIter>::value &&
+                hpx::traits::is_iterator_v<FwdIter> &&
                 hpx::traits::is_sentinel_for<Sent, FwdIter>::value &&
                 parallel::traits::is_projected<Proj, FwdIter>::value &&
                 parallel::traits::is_indirect_callable<
@@ -863,7 +870,7 @@ namespace hpx { namespace ranges {
             FwdIter first, Sent last, O dest, Pred&& pred = Pred(),
             Proj&& proj = Proj())
         {
-            static_assert(hpx::traits::is_forward_iterator<FwdIter>::value,
+            static_assert(hpx::traits::is_forward_iterator_v<FwdIter>,
                 "Requires at least forward iterator.");
 
             using result_type = unique_copy_result<FwdIter, O>;
@@ -892,7 +899,7 @@ namespace hpx { namespace ranges {
         {
             using iterator_type = hpx::traits::range_iterator_t<Rng>;
 
-            static_assert(hpx::traits::is_input_iterator<iterator_type>::value,
+            static_assert(hpx::traits::is_input_iterator_v<iterator_type>,
                 "Requires at least input iterator.");
 
             using result_type = unique_copy_result<iterator_type, O>;
@@ -923,8 +930,7 @@ namespace hpx { namespace ranges {
         {
             using iterator_type = hpx::traits::range_iterator_t<Rng>;
 
-            static_assert(
-                hpx::traits::is_forward_iterator<iterator_type>::value,
+            static_assert(hpx::traits::is_forward_iterator_v<iterator_type>,
                 "Requires at least input iterator.");
 
             using result_type = unique_copy_result<iterator_type, O>;

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/unique.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/unique.hpp
@@ -188,9 +188,8 @@ namespace hpx { namespace parallel { inline namespace v1 {
                     traits::projected_range<Proj, Rng>,
                     traits::projected_range<Proj, Rng>>::value)>
     typename util::detail::algorithm_result<ExPolicy,
-        hpx::util::tagged_pair<
-            tag::in(typename hpx::traits::range_iterator<Rng>::type),
-            tag::out(FwdIter2)>>::type
+        util::in_out_result<typename hpx::traits::range_iterator<Rng>::type,
+            FwdIter2>>::type
     unique_copy(ExPolicy&& policy, Rng&& rng, FwdIter2 dest,
         Pred&& pred = Pred(), Proj&& proj = Proj())
     {

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/unique.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/unique.hpp
@@ -197,13 +197,14 @@ namespace hpx { namespace ranges {
     ///
     /// \returns  The \a unique algorithm returns
     ///           \a subrange_t<typename hpx::traits::range_iterator<Rng>
-    ///           ::type>.
+    ///           ::type,typename hpx::traits::range_iterator<Rng>::type>.
     ///           The \a unique algorithm returns an object {ret, last},
     ///           where ret is a past-the-end iterator for a new
     ///           subrange.
     ///
     template <typename Rng, typename Pred, typename Proj>
-    subrange_t<typename hpx::traits::range_iterator<Rng>::type>
+    subrange_t<typename hpx::traits::range_iterator<Rng>::type,
+        typename hpx::traits::range_iterator<Rng>::type>
     unique(Rng&& rng, Pred&& pred, Proj&& proj);
 
     ///////////////////////////////////////////////////////////////////////////
@@ -265,18 +266,21 @@ namespace hpx { namespace ranges {
     /// within each thread.
     ///
     /// \returns  The \a unique algorithm returns a \a hpx::future
-    ///           <subrange_t<typename hpx::traits::range_iterator<Rng>::type>>
+    ///           <subrange_t<typename hpx::traits::range_iterator<Rng>::type,
+    ///           typename hpx::traits::range_iterator<Rng>::type>>
     ///           if the execution policy is of type \a sequenced_task_policy
     ///           or \a parallel_task_policy and returns
     ///           \a subrange_t<typename hpx::traits::range_iterator<Rng>
-    ///           ::type>. otherwise.
+    ///           ::type,typename hpx::traits::range_iterator<Rng>::type>.
+    ///           otherwise.
     ///           The \a unique algorithm returns an object {ret, last},
     ///           where ret is a past-the-end iterator for a new
     ///           subrange.
     ///
     template <typename ExPolicy, typename Rng, typename Pred, typename Proj>
     typename util::detail::algorithm_result<ExPolicy,
-    subrange_t<typename hpx::traits::range_iterator<Rng>::type>::type
+    subrange_t<typename hpx::traits::range_iterator<Rng>::type,
+    typename hpx::traits::range_iterator<Rng>::type>::type
     unique(ExPolicy&& policy, Rng&& rng, Pred&& pred, Proj&& proj);
 
     ///////////////////////////////////////////////////////////////////////////
@@ -344,7 +348,7 @@ namespace hpx { namespace ranges {
     ///
     template <typename InIter, typename Sent, typename OutIter,
         typename Pred, typename Proj>
-    util::in_out_result<FwdIter, OutIter> unique(FwdIter first,
+    util::in_out_result<FwdIter, OutIter> unique_copy(InIter first,
         Sent last, OutIter dest, Pred&& pred, Proj&& proj);
 
     ///////////////////////////////////////////////////////////////////////////
@@ -418,7 +422,7 @@ namespace hpx { namespace ranges {
     /// \returns  The \a unique_copy algorithm returns areturns hpx::future<
     ///           parallel::util::in_out_result<FwdIter1, FwdIter2>> if the
     ///           execution policy is of type \a sequenced_task_policy or
-    ///           \a parallel_task_policy and returns \a 
+    ///           \a parallel_task_policy and returns \a
     ///           parallel::util::in_out_result<FwdIter1, FwdIter2> otherwise.
     ///           The \a unique_copy algorithm returns an in_out_result with
     ///           the source iterator to one past the last element and out
@@ -608,12 +612,12 @@ namespace hpx { namespace parallel { inline namespace v1 {
                     Proj, Rng>::value&& traits::is_indirect_callable<ExPolicy,
                     Pred, traits::projected_range<Proj, Rng>,
                     traits::projected_range<Proj, Rng>>::value)>
+    HPX_DEPRECATED_V(
+        1, 8, "hpx::parallel::unique is deprecated, use hpx::unique instead")
     typename util::detail::algorithm_result<ExPolicy,
         typename hpx::traits::range_iterator<Rng>::type>::type
-        HPX_DEPRECATED_V(1, 8,
-            "hpx::parallel::unique is deprecated, use hpx::unique instead")
-            unique(ExPolicy&& policy, Rng&& rng, Pred&& pred = Pred(),
-                Proj&& proj = Proj())
+        unique(ExPolicy&& policy, Rng&& rng, Pred&& pred = Pred(),
+            Proj&& proj = Proj())
     {
 #if defined(HPX_GCC_VERSION) && HPX_GCC_VERSION >= 100000
 #pragma GCC diagnostic push
@@ -636,12 +640,13 @@ namespace hpx { namespace parallel { inline namespace v1 {
                     Rng>::value&& traits::is_indirect_callable<ExPolicy, Pred,
                     traits::projected_range<Proj, Rng>,
                     traits::projected_range<Proj, Rng>>::value)>
+    HPX_DEPRECATED_V(1, 8,
+        "hpx::parallel::unique_copy is deprecated, use hpx::unique_copy "
+        "instead")
     typename util::detail::algorithm_result<ExPolicy,
         util::in_out_result<typename hpx::traits::range_iterator<Rng>::type,
-            FwdIter2>>::type HPX_DEPRECATED_V(1, 8,
-        "hpx::parallel::unique_copy is deprecated, use hpx::unique_copy "
-        "instead") unique_copy(ExPolicy&& policy, Rng&& rng, FwdIter2 dest,
-        Pred&& pred = Pred(), Proj&& proj = Proj())
+            FwdIter2>>::type unique_copy(ExPolicy&& policy, Rng&& rng,
+        FwdIter2 dest, Pred&& pred = Pred(), Proj&& proj = Proj())
     {
 #if defined(HPX_GCC_VERSION) && HPX_GCC_VERSION >= 100000
 #pragma GCC diagnostic push
@@ -659,7 +664,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
 namespace hpx { namespace ranges {
 
     ///////////////////////////////////////////////////////////////////////////
-    template <typename I, typename S = I>
+    template <typename I, typename S>
     using subrange_t = hpx::util::iterator_range<I, S>;
 
     ///////////////////////////////////////////////////////////////////////////
@@ -740,7 +745,8 @@ namespace hpx { namespace ranges {
                     hpx::parallel::traits::projected_range<Proj, Rng>>::value
             )>
         // clang-format on
-        friend subrange_t<typename hpx::traits::range_iterator<Rng>::type>
+        friend subrange_t<typename hpx::traits::range_iterator<Rng>::type,
+            typename hpx::traits::range_iterator<Rng>::type>
         tag_fallback_dispatch(hpx::ranges::unique_t, Rng&& rng,
             Pred&& pred = Pred(), Proj&& proj = Proj())
         {
@@ -777,7 +783,8 @@ namespace hpx { namespace ranges {
             )>
         // clang-format on
         friend typename parallel::util::detail::algorithm_result<ExPolicy,
-            subrange_t<typename hpx::traits::range_iterator<Rng>::type>>::type
+            subrange_t<typename hpx::traits::range_iterator<Rng>::type,
+                typename hpx::traits::range_iterator<Rng>::type>>::type
         tag_fallback_dispatch(hpx::ranges::unique_t, ExPolicy&& policy,
             Rng&& rng, Pred&& pred = Pred(), Proj&& proj = Proj())
         {

--- a/libs/parallelism/algorithms/tests/performance/benchmark_unique.cpp
+++ b/libs/parallelism/algorithms/tests/performance/benchmark_unique.cpp
@@ -127,7 +127,7 @@ double run_unique_benchmark_hpx(int test_count, ExPolicy policy,
         hpx::copy(hpx::execution::par, org_first, org_last, first);
 
         std::uint64_t elapsed = hpx::chrono::high_resolution_clock::now();
-        hpx::parallel::unique(policy, first, last);
+        hpx::unique(policy, first, last);
         time += hpx::chrono::high_resolution_clock::now() - elapsed;
     }
 

--- a/libs/parallelism/algorithms/tests/performance/benchmark_unique_copy.cpp
+++ b/libs/parallelism/algorithms/tests/performance/benchmark_unique_copy.cpp
@@ -69,7 +69,7 @@ double run_unique_copy_benchmark_hpx(int test_count, ExPolicy policy,
 
     for (int i = 0; i < test_count; ++i)
     {
-        hpx::parallel::unique_copy(policy, first, last, dest);
+        hpx::unique_copy(policy, first, last, dest);
     }
 
     time = hpx::chrono::high_resolution_clock::now() - time;

--- a/libs/parallelism/algorithms/tests/unit/algorithms/unique_copy_tests.hpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/unique_copy_tests.hpp
@@ -121,8 +121,8 @@ struct random_fill
 template <typename IteratorTag, typename DataType, typename Pred>
 void test_unique_copy(IteratorTag, DataType, Pred pred, int rand_base)
 {
-    typedef typename std::vector<DataType>::iterator base_iterator;
-    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+    using base_iterator = typename std::vector<DataType>::iterator;
+    using iterator = test::test_iterator<base_iterator, IteratorTag>;
 
     using hpx::get;
 
@@ -149,8 +149,8 @@ void test_unique_copy(
     static_assert(hpx::is_execution_policy<ExPolicy>::value,
         "hpx::is_execution_policy<ExPolicy>::value");
 
-    typedef typename std::vector<DataType>::iterator base_iterator;
-    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+    using base_iterator = typename std::vector<DataType>::iterator;
+    using iterator = test::test_iterator<base_iterator, IteratorTag>;
 
     using hpx::get;
 
@@ -177,8 +177,8 @@ void test_unique_copy_async(
     static_assert(hpx::is_execution_policy<ExPolicy>::value,
         "hpx::is_execution_policy<ExPolicy>::value");
 
-    typedef typename std::vector<DataType>::iterator base_iterator;
-    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+    using base_iterator = typename std::vector<DataType>::iterator;
+    using iterator = test::test_iterator<base_iterator, IteratorTag>;
 
     using hpx::get;
 
@@ -205,8 +205,8 @@ void test_unique_copy_exception(ExPolicy policy, IteratorTag)
     static_assert(hpx::is_execution_policy<ExPolicy>::value,
         "hpx::is_execution_policy<ExPolicy>::value");
 
-    typedef std::vector<int>::iterator base_iterator;
-    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+    using base_iterator = std::vector<int>::iterator;
+    using iterator = test::test_iterator<base_iterator, IteratorTag>;
 
     std::size_t const size = 10007;
     std::vector<int> c(size), dest(size);
@@ -237,8 +237,8 @@ void test_unique_copy_exception(ExPolicy policy, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_unique_copy_exception_async(ExPolicy policy, IteratorTag)
 {
-    typedef std::vector<int>::iterator base_iterator;
-    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+    using base_iterator = std::vector<int>::iterator;
+    using iterator = test::test_iterator<base_iterator, IteratorTag>;
 
     std::size_t const size = 10007;
     std::vector<int> c(size), dest(size);
@@ -276,8 +276,8 @@ void test_unique_copy_bad_alloc(ExPolicy policy, IteratorTag)
     static_assert(hpx::is_execution_policy<ExPolicy>::value,
         "hpx::is_execution_policy<ExPolicy>::value");
 
-    typedef std::vector<int>::iterator base_iterator;
-    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+    using base_iterator = std::vector<int>::iterator;
+    using iterator = test::test_iterator<base_iterator, IteratorTag>;
 
     std::size_t const size = 10007;
     std::vector<int> c(size), dest(size);
@@ -308,8 +308,8 @@ void test_unique_copy_bad_alloc(ExPolicy policy, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_unique_copy_bad_alloc_async(ExPolicy policy, IteratorTag)
 {
-    typedef std::vector<int>::iterator base_iterator;
-    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+    using base_iterator = std::vector<int>::iterator;
+    using iterator = test::test_iterator<base_iterator, IteratorTag>;
 
     std::size_t const size = 10007;
     std::vector<int> c(size), dest(size);
@@ -347,7 +347,7 @@ void test_unique_copy_etc(ExPolicy policy, IteratorTag, DataType, int rand_base)
     static_assert(hpx::is_execution_policy<ExPolicy>::value,
         "hpx::is_execution_policy<ExPolicy>::value");
 
-    typedef typename std::vector<DataType>::iterator base_iterator;
+    using base_iterator = typename std::vector<DataType>::iterator;
 
     using hpx::get;
 
@@ -358,7 +358,7 @@ void test_unique_copy_etc(ExPolicy policy, IteratorTag, DataType, int rand_base)
 
     // Test default predicate.
     {
-        typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+        using iterator = test::test_iterator<base_iterator, IteratorTag>;
 
         auto result = hpx::unique_copy(policy, iterator(std::begin(c)),
             iterator(std::end(c)), iterator(std::begin(dest_res)));
@@ -373,7 +373,7 @@ void test_unique_copy_etc(ExPolicy policy, IteratorTag, DataType, int rand_base)
 
     // Test projection.
     {
-        typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+        using iterator = test::test_iterator<base_iterator, IteratorTag>;
 
         DataType val;
         auto result = hpx::unique_copy(

--- a/libs/parallelism/algorithms/tests/unit/algorithms/unique_tests.hpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/unique_tests.hpp
@@ -121,8 +121,8 @@ struct random_fill
 template <typename IteratorTag, typename DataType, typename Pred>
 void test_unique(IteratorTag, DataType, Pred pred, int rand_base)
 {
-    typedef typename std::vector<DataType>::iterator base_iterator;
-    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+    using base_iterator = typename std::vector<DataType>::iterator;
+    using iterator = test::test_iterator<base_iterator, IteratorTag>;
 
     std::size_t const size = 10007;
     std::vector<DataType> c(size), d;
@@ -147,8 +147,8 @@ void test_unique(
     static_assert(hpx::is_execution_policy<ExPolicy>::value,
         "hpx::is_execution_policy<ExPolicy>::value");
 
-    typedef typename std::vector<DataType>::iterator base_iterator;
-    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+    using base_iterator = typename std::vector<DataType>::iterator;
+    using iterator = test::test_iterator<base_iterator, IteratorTag>;
 
     std::size_t const size = 10007;
     std::vector<DataType> c(size), d;
@@ -173,8 +173,8 @@ void test_unique_async(
     static_assert(hpx::is_execution_policy<ExPolicy>::value,
         "hpx::is_execution_policy<ExPolicy>::value");
 
-    typedef typename std::vector<DataType>::iterator base_iterator;
-    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+    using base_iterator = typename std::vector<DataType>::iterator;
+    using iterator = test::test_iterator<base_iterator, IteratorTag>;
 
     std::size_t const size = 10007;
     std::vector<DataType> c(size), d;
@@ -199,8 +199,8 @@ void test_unique_exception(ExPolicy policy, IteratorTag)
     static_assert(hpx::is_execution_policy<ExPolicy>::value,
         "hpx::is_execution_policy<ExPolicy>::value");
 
-    typedef std::vector<int>::iterator base_iterator;
-    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+    using base_iterator = std::vector<int>::iterator;
+    using iterator = test::test_iterator<base_iterator, IteratorTag>;
 
     std::size_t const size = 10007;
     std::vector<int> c(size);
@@ -231,8 +231,8 @@ void test_unique_exception(ExPolicy policy, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_unique_exception_async(ExPolicy policy, IteratorTag)
 {
-    typedef std::vector<int>::iterator base_iterator;
-    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+    using base_iterator = std::vector<int>::iterator;
+    using iterator = test::test_iterator<base_iterator, IteratorTag>;
 
     std::size_t const size = 10007;
     std::vector<int> c(size);
@@ -270,8 +270,8 @@ void test_unique_bad_alloc(ExPolicy policy, IteratorTag)
     static_assert(hpx::is_execution_policy<ExPolicy>::value,
         "hpx::is_execution_policy<ExPolicy>::value");
 
-    typedef std::vector<int>::iterator base_iterator;
-    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+    using base_iterator = std::vector<int>::iterator;
+    using iterator = test::test_iterator<base_iterator, IteratorTag>;
 
     std::size_t const size = 10007;
     std::vector<int> c(size);
@@ -301,8 +301,8 @@ void test_unique_bad_alloc(ExPolicy policy, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_unique_bad_alloc_async(ExPolicy policy, IteratorTag)
 {
-    typedef std::vector<int>::iterator base_iterator;
-    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+    using base_iterator = std::vector<int>::iterator;
+    using iterator = test::test_iterator<base_iterator, IteratorTag>;
 
     std::size_t const size = 10007;
     std::vector<int> c(size);
@@ -339,7 +339,7 @@ void test_unique_etc(ExPolicy policy, IteratorTag, DataType, int rand_base)
     static_assert(hpx::is_execution_policy<ExPolicy>::value,
         "hpx::is_execution_policy<ExPolicy>::value");
 
-    typedef typename std::vector<DataType>::iterator base_iterator;
+    using base_iterator = typename std::vector<DataType>::iterator;
 
     std::size_t const size = 10007;
     std::vector<DataType> c(size), d, org;
@@ -349,7 +349,7 @@ void test_unique_etc(ExPolicy policy, IteratorTag, DataType, int rand_base)
 
     // Test default predicate.
     {
-        typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+        using iterator = test::test_iterator<base_iterator, IteratorTag>;
 
         auto result =
             hpx::unique(policy, iterator(std::begin(c)), iterator(std::end(c)));
@@ -363,7 +363,7 @@ void test_unique_etc(ExPolicy policy, IteratorTag, DataType, int rand_base)
 
     // Test projection.
     {
-        typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+        using iterator = test::test_iterator<base_iterator, IteratorTag>;
 
         c = org;
 

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/unique_copy_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/unique_copy_range.cpp
@@ -82,10 +82,10 @@ void test_unique_copy(ExPolicy policy, DataType)
     auto solution =
         std::unique_copy(std::begin(c), std::end(c), std::begin(dest_sol));
 
-    HPX_TEST(get<0>(result) == std::end(c));
+    HPX_TEST(result.in == std::end(c));
 
     bool equality = test::equal(
-        std::begin(dest_res), get<1>(result), std::begin(dest_sol), solution);
+        std::begin(dest_res), result.out, std::begin(dest_sol), solution);
 
     HPX_TEST(equality);
 }
@@ -107,10 +107,10 @@ void test_unique_copy_async(ExPolicy policy, DataType)
     auto solution =
         std::unique_copy(std::begin(c), std::end(c), std::begin(dest_sol));
 
-    HPX_TEST(get<0>(result) == std::end(c));
+    HPX_TEST(result.in == std::end(c));
 
     bool equality = test::equal(
-        std::begin(dest_res), get<1>(result), std::begin(dest_sol), solution);
+        std::begin(dest_res), result.out, std::begin(dest_sol), solution);
 
     HPX_TEST(equality);
 }

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/unique_copy_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/unique_copy_range.cpp
@@ -81,8 +81,8 @@ void test_unique_copy_sent()
 
     auto result = hpx::ranges::unique_copy(
         std::begin(c), sentinel<std::size_t>{10}, std::begin(dest_res));
-    auto solution =
-        std::unique_copy(std::begin(c), std::begin(c) + end_len, std::begin(dest_sol));
+    auto solution = std::unique_copy(
+        std::begin(c), std::begin(c) + end_len, std::begin(dest_sol));
 
     HPX_TEST(result.in == std::next(std::begin(c), end_len));
 
@@ -92,7 +92,7 @@ void test_unique_copy_sent()
     HPX_TEST(equality);
 }
 
-template<typename ExPolicy>
+template <typename ExPolicy>
 void test_unique_copy_sent(ExPolicy policy)
 {
     using hpx::get;
@@ -104,8 +104,8 @@ void test_unique_copy_sent(ExPolicy policy)
     auto end_len = std::rand() % 10006 + 1;
     c[end_len] = 10;
 
-    auto result = hpx::ranges::unique_copy(policy,
-        std::begin(c), sentinel<std::size_t>{10}, std::begin(dest_res));
+    auto result = hpx::ranges::unique_copy(
+        policy, std::begin(c), sentinel<std::size_t>{10}, std::begin(dest_res));
     auto solution = std::unique_copy(
         std::begin(c), std::begin(c) + end_len, std::begin(dest_sol));
 

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/unique_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/unique_range.cpp
@@ -48,7 +48,7 @@ struct user_defined_type
 };
 
 const std::vector<std::string> user_defined_type::name_list{
-    "ABB", "ABC", "ACB", "BASE", "CAA", "CAAA", "CAAB", "END"};
+    "ABB", "ABC", "ACB", "BASE", "CAA", "CAAA", "CAAB"};
 
 struct random_fill
 {


### PR DESCRIPTION
Adapted unique and unique_copy to C++ 20 and added container overloads. (range and sentinel). Added container tests.

## Any background context you want to provide?
Issue #4822
Issue #3646