### PR TITLE
Adapt stable_sort to C++ 20

### DIFF
--- a/docs/sphinx/api/public_api.rst
+++ b/docs/sphinx/api/public_api.rst
@@ -101,8 +101,8 @@ Functions
 - :cpp:func:`hpx::parallel::v1::stable_sort`
 - :cpp:func:`hpx::swap_ranges`
 - :cpp:func:`hpx::transform`
-- :cpp:func:`hpx::parallel::v1::unique`
-- :cpp:func:`hpx::parallel::v1::unique_copy`
+- :cpp:func:`hpx::unique`
+- :cpp:func:`hpx::unique_copy`
 - :cpp:func:`hpx::for_loop`
 - :cpp:func:`hpx::for_loop_strided`
 - :cpp:func:`hpx::for_loop_n`
@@ -144,6 +144,8 @@ Functions
 - :cpp:func:`hpx::ranges::set_symmetric_difference`
 - :cpp:func:`hpx::ranges::set_union`
 - :cpp:func:`hpx::ranges::swap_ranges`
+- :cpp:func:`hpx::ranges::unique`
+- :cpp:func:`hpx::ranges::unique_copy`
 - :cpp:func:`hpx::ranges::for_loop`
 - :cpp:func:`hpx::ranges::for_loop_strided`
 

--- a/docs/sphinx/api/public_api.rst
+++ b/docs/sphinx/api/public_api.rst
@@ -98,8 +98,8 @@ Functions
 - :cpp:func:`hpx::set_union`
 - :cpp:func:`hpx::parallel::v1::sort`
 - :cpp:func:`hpx::parallel::v1::stable_partition`
-- :cpp:func:`hpx::parallel::v1::stable_sort`
 - :cpp:func:`hpx::swap_ranges`
+- :cpp:func:`hpx::stable_sort`
 - :cpp:func:`hpx::transform`
 - :cpp:func:`hpx::unique`
 - :cpp:func:`hpx::unique_copy`
@@ -143,9 +143,13 @@ Functions
 - :cpp:func:`hpx::ranges::set_intersection`
 - :cpp:func:`hpx::ranges::set_symmetric_difference`
 - :cpp:func:`hpx::ranges::set_union`
+<<<<<<< HEAD
 - :cpp:func:`hpx::ranges::swap_ranges`
 - :cpp:func:`hpx::ranges::unique`
 - :cpp:func:`hpx::ranges::unique_copy`
+=======
+- :cpp:func:`hpx::ranges::stable_sort`
+>>>>>>> 41acac1b94 (added sphinx api docs made stable_sort work for sentinels)
 - :cpp:func:`hpx::ranges::for_loop`
 - :cpp:func:`hpx::ranges::for_loop_strided`
 

--- a/docs/sphinx/manual/writing_single_node_hpx_applications.rst
+++ b/docs/sphinx/manual/writing_single_node_hpx_applications.rst
@@ -645,7 +645,7 @@ Parallel algorithms
      * Sorts the elements in a range.
      * ``<hpx/algorithm.hpp>``
      * :cppreference-algorithm:`sort`
-   * * :cpp:func:`hpx::parallel::v1::stable_sort`
+   * * :cpp:func:`hpx::stable_sort`
      * Sorts the elements in a range, maintain sequence of equal elements.
      * ``<hpx/algorithm.hpp>``
      * :cppreference-algorithm:`stable_sort`

--- a/docs/sphinx/manual/writing_single_node_hpx_applications.rst
+++ b/docs/sphinx/manual/writing_single_node_hpx_applications.rst
@@ -522,12 +522,12 @@ Parallel algorithms
      * Applies a function to a range of elements.
      * ``<hpx/algorithm.hpp>``
      * :cppreference-algorithm:`transform`
-   * * :cpp:func:`hpx::parallel::v1::unique_copy`
+   * * :cpp:func:`hpx::unique`
      * Eliminates all but the first element from every consecutive group of equivalent elements from a range.
      * ``<hpx/algorithm.hpp>``
      * :cppreference-algorithm:`unique`
-   * * :cpp:func:`hpx::parallel::v1::unique_copy`
-     * Eliminates all but the first element from every consecutive group of equivalent elements from a range.
+   * * :cpp:func:`hpx::unique_copy`
+     * Copies the elements from one range to another in such a way that there are no consecutive equal elements.
      * ``<hpx/algorithm.hpp>``
      * :cppreference-algorithm:`unique_copy`
 

--- a/libs/full/include_local/include/hpx/local/algorithm.hpp
+++ b/libs/full/include_local/include/hpx/local/algorithm.hpp
@@ -18,5 +18,4 @@ namespace hpx {
     using hpx::parallel::partition_copy;
     using hpx::parallel::sort;
     using hpx::parallel::stable_partition;
-    using hpx::parallel::stable_sort;
 }    // namespace hpx

--- a/libs/full/include_local/include/hpx/local/algorithm.hpp
+++ b/libs/full/include_local/include/hpx/local/algorithm.hpp
@@ -19,6 +19,4 @@ namespace hpx {
     using hpx::parallel::sort;
     using hpx::parallel::stable_partition;
     using hpx::parallel::stable_sort;
-    using hpx::parallel::unique;
-    using hpx::parallel::unique_copy;
 }    // namespace hpx

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/stable_sort.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/stable_sort.hpp
@@ -238,6 +238,7 @@ namespace hpx {
 #include <hpx/execution/executors/execution_parameters.hpp>
 #include <hpx/executors/exception_list.hpp>
 #include <hpx/executors/execution_policy.hpp>
+#include <hpx/parallel/algorithms/detail/advance_to_sentinel.hpp>
 #include <hpx/parallel/algorithms/detail/dispatch.hpp>
 #include <hpx/parallel/algorithms/detail/distance.hpp>
 #include <hpx/parallel/algorithms/detail/parallel_stable_sort.hpp>
@@ -282,10 +283,12 @@ namespace hpx { namespace parallel { inline namespace v1 {
                     util::compare_projected<typename std::decay<Compare>::type,
                         typename std::decay<Proj>::type>;
 
-                spin_sort(first, last,
+                auto last_iter = detail::advance_to_sentinel(first, last);
+
+                spin_sort(first, last_iter,
                     compare_type(
                         std::forward<Compare>(comp), std::forward<Proj>(proj)));
-                return last;
+                return last_iter;
             }
 
             template <typename ExPolicy, typename Sentinel, typename Compare,
@@ -303,6 +306,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
 
                 // number of elements to sort
                 std::size_t count = detail::distance(first, last);
+                auto last_iter = detail::advance_to_sentinel(first, last);
 
                 // figure out the chunk size to use
                 std::size_t cores = execution::processing_units_count(
@@ -329,8 +333,8 @@ namespace hpx { namespace parallel { inline namespace v1 {
                         std::forward<Proj>(proj));
 
                     return algorithm_result::get(
-                        parallel_stable_sort(policy.executor(), first, last,
-                            cores, chunk_size, std::move(comp)));
+                        parallel_stable_sort(policy.executor(), first,
+                            last_iter, cores, chunk_size, std::move(comp)));
                 }
                 catch (...)
                 {

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/stable_sort.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/stable_sort.hpp
@@ -239,6 +239,7 @@ namespace hpx {
 #include <hpx/executors/exception_list.hpp>
 #include <hpx/executors/execution_policy.hpp>
 #include <hpx/parallel/algorithms/detail/dispatch.hpp>
+#include <hpx/parallel/algorithms/detail/distance.hpp>
 #include <hpx/parallel/algorithms/detail/parallel_stable_sort.hpp>
 #include <hpx/parallel/algorithms/detail/spin_sort.hpp>
 #include <hpx/parallel/util/compare_projected.hpp>
@@ -301,7 +302,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                         typename std::decay<Proj>::type>;
 
                 // number of elements to sort
-                std::size_t count = last - first;
+                std::size_t count = detail::distance(first, last);
 
                 // figure out the chunk size to use
                 std::size_t cores = execution::processing_units_count(
@@ -444,3 +445,5 @@ namespace hpx {
         }
     } stable_sort{};
 }    // namespace hpx
+
+#endif

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/stable_sort.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/stable_sort.hpp
@@ -1,11 +1,228 @@
 //  Copyright (c) 2015-2017 Francisco Jose Tapia
 //  Copyright (c) 2020 Hartmut Kaiser
+//  Copyright (c) 2021 Akhil J Nair
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #pragma once
+
+#if defined(DOXYGEN)
+
+namespace hpx {
+    // clang-format off
+
+    ///////////////////////////////////////////////////////////////////////////
+    /// Sorts the elements in the range [first, last) in ascending order. The
+    /// relative order of equal elements is preserved. The function
+    /// uses the given comparison function object comp (defaults to using
+    /// operator<()).
+    ///
+    /// \note   Complexity: O(Nlog(N)), where N = std::distance(first, last)
+    ///                     comparisons.
+    ///
+    /// A sequence is sorted with respect to a comparator \a comp and a
+    /// projection \a proj if for every iterator i pointing to the sequence and
+    /// every non-negative integer n such that i + n is a valid iterator
+    /// pointing to an element of the sequence, and
+    /// INVOKE(comp, INVOKE(proj, *(i + n)), INVOKE(proj, *i)) == false.
+    ///
+    /// \tparam RandomIt    The type of the source iterators used (deduced).
+    ///                     This iterator type must meet the requirements of a
+    ///                     random access iterator.
+    ///
+    /// \param first        Refers to the beginning of the sequence of elements
+    ///                     the algorithm will be applied to.
+    /// \param last         Refers to the end of the sequence of elements the
+    ///                     algorithm will be applied to.
+    ///
+    /// The assignments in the parallel \a stable_sort algorithm invoked without
+    /// an execution policy object execute in sequential order in the
+    /// calling thread.
+    ///
+    /// \returns  The \a stable_sort algorithm does not return anything.
+    ///
+    template <typename RandomIt>
+    void stable_sort(RandomIt first, RandomIt last);
+
+    ///////////////////////////////////////////////////////////////////////////
+    /// Sorts the elements in the range [first, last) in ascending order. The
+    /// relative order of equal elements is preserved. The function
+    /// uses the given comparison function object comp (defaults to using
+    /// operator<()).
+    ///
+    /// \note   Complexity: O(Nlog(N)), where N = std::distance(first, last)
+    ///                     comparisons.
+    ///
+    /// A sequence is sorted with respect to a comparator \a comp and a
+    /// projection \a proj if for every iterator i pointing to the sequence and
+    /// every non-negative integer n such that i + n is a valid iterator
+    /// pointing to an element of the sequence, and
+    /// INVOKE(comp, INVOKE(proj, *(i + n)), INVOKE(proj, *i)) == false.
+    ///
+    /// \tparam ExPolicy    The type of the execution policy to use (deduced).
+    ///                     It describes the manner in which the execution
+    ///                     of the algorithm may be parallelized and the manner
+    ///                     in which it applies user-provided function objects.
+    /// \tparam RandomIt    The type of the source iterators used (deduced).
+    ///                     This iterator type must meet the requirements of a
+    ///                     random access iterator.
+    ///
+    /// \param policy       The execution policy to use for the scheduling of
+    ///                     the iterations.
+    /// \param first        Refers to the beginning of the sequence of elements
+    ///                     the algorithm will be applied to.
+    /// \param last         Refers to the end of the sequence of elements the
+    ///                     algorithm will be applied to.
+    ///
+    /// The application of function objects in parallel algorithm
+    /// invoked with an execution policy object of type
+    /// \a sequenced_policy execute in sequential order in the
+    /// calling thread.
+    ///
+    /// The application of function objects in parallel algorithm
+    /// invoked with an execution policy object of type
+    /// \a parallel_policy or \a parallel_task_policy are
+    /// permitted to execute in an unordered fashion in unspecified
+    /// threads, and indeterminately sequenced within each thread.
+    ///
+    /// \returns  The \a stable_sort algorithm returns a
+    ///           \a hpx::future<void> if the execution policy is of
+    ///           type
+    ///           \a sequenced_task_policy or
+    ///           \a parallel_task_policy and returns nothing
+    ///           otherwise.
+    ///
+    template <typename ExPolicy, typename RandomIt>
+    typename util::detail::algorithm_result<ExPolicy>::type
+    stable_sort(ExPolicy&& policy, RandomIt first, RandomIt last);
+
+    ///////////////////////////////////////////////////////////////////////////
+    /// Sorts the elements in the range [first, last) in ascending order. The
+    /// relative order of equal elements is preserved. The function
+    /// uses the given comparison function object comp (defaults to using
+    /// operator<()).
+    ///
+    /// \note   Complexity: O(Nlog(N)), where N = std::distance(first, last)
+    ///                     comparisons.
+    ///
+    /// A sequence is sorted with respect to a comparator \a comp and a
+    /// projection \a proj if for every iterator i pointing to the sequence and
+    /// every non-negative integer n such that i + n is a valid iterator
+    /// pointing to an element of the sequence, and
+    /// INVOKE(comp, INVOKE(proj, *(i + n)), INVOKE(proj, *i)) == false.
+    ///
+    /// \tparam RandomIt    The type of the source iterators used (deduced).
+    ///                     This iterator type must meet the requirements of a
+    ///                     random access iterator.
+    /// \tparam Comp        The type of the function/function object to use
+    ///                     (deduced).
+    /// \tparam Proj        The type of an optional projection function. This
+    ///                     defaults to \a util::projection_identity
+    ///
+    /// \param first        Refers to the beginning of the sequence of elements
+    ///                     the algorithm will be applied to.
+    /// \param last         Refers to the end of the sequence of elements the
+    ///                     algorithm will be applied to.
+    /// \param comp         comp is a callable object. The return value of the
+    ///                     INVOKE operation applied to an object of type Comp,
+    ///                     when contextually converted to bool, yields true if
+    ///                     the first argument of the call is less than the
+    ///                     second, and false otherwise. It is assumed that comp
+    ///                     will not apply any non-constant function through the
+    ///                     dereferenced iterator.
+    /// \param proj         Specifies the function (or function object) which
+    ///                     will be invoked for each pair of elements as a
+    ///                     projection operation before the actual predicate
+    ///                     \a comp is invoked.
+    ///
+    /// \a comp has to induce a strict weak ordering on the values.
+    ///
+    /// The assignments in the parallel \a stable_sort algorithm invoked without
+    /// an execution policy object execute in sequential order in the
+    /// calling thread.
+    ///
+    /// \returns  The \a stable_sort algorithm returns nothing.
+    ///
+    template <typename RandomIt, typename Comp, typename Proj>
+    void stable_sort(RandomIt first, RandomIt last, Comp&& comp, Proj&& proj);
+
+    ///////////////////////////////////////////////////////////////////////////
+    /// Sorts the elements in the range [first, last) in ascending order. The
+    /// relative order of equal elements is preserved. The function
+    /// uses the given comparison function object comp (defaults to using
+    /// operator<()).
+    ///
+    /// \note   Complexity: O(Nlog(N)), where N = std::distance(first, last)
+    ///                     comparisons.
+    ///
+    /// A sequence is sorted with respect to a comparator \a comp and a
+    /// projection \a proj if for every iterator i pointing to the sequence and
+    /// every non-negative integer n such that i + n is a valid iterator
+    /// pointing to an element of the sequence, and
+    /// INVOKE(comp, INVOKE(proj, *(i + n)), INVOKE(proj, *i)) == false.
+    ///
+    /// \tparam ExPolicy    The type of the execution policy to use (deduced).
+    ///                     It describes the manner in which the execution
+    ///                     of the algorithm may be parallelized and the manner
+    ///                     in which it applies user-provided function objects.
+    /// \tparam RandomIt    The type of the source iterators used (deduced).
+    ///                     This iterator type must meet the requirements of a
+    ///                     random access iterator.
+    /// \tparam Comp        The type of the function/function object to use
+    ///                     (deduced).
+    /// \tparam Proj        The type of an optional projection function. This
+    ///                     defaults to \a util::projection_identity.
+    ///
+    /// \param policy       The execution policy to use for the scheduling of
+    ///                     the iterations.
+    /// \param first        Refers to the beginning of the sequence of elements
+    ///                     the algorithm will be applied to.
+    /// \param last         Refers to the end of the sequence of elements the
+    ///                     algorithm will be applied to.
+    /// \param comp         comp is a callable object. The return value of the
+    ///                     INVOKE operation applied to an object of type Comp,
+    ///                     when contextually converted to bool, yields true if
+    ///                     the first argument of the call is less than the
+    ///                     second, and false otherwise. It is assumed that comp
+    ///                     will not apply any non-constant function through the
+    ///                     dereferenced iterator.
+    /// \param proj         Specifies the function (or function object) which
+    ///                     will be invoked for each pair of elements as a
+    ///                     projection operation before the actual predicate
+    ///                     \a comp is invoked.
+    ///
+    /// \a comp has to induce a strict weak ordering on the values.
+    ///
+    /// The application of function objects in parallel algorithm
+    /// invoked with an execution policy object of type
+    /// \a sequenced_policy execute in sequential order in the
+    /// calling thread.
+    ///
+    /// The application of function objects in parallel algorithm
+    /// invoked with an execution policy object of type
+    /// \a parallel_policy or \a parallel_task_policy are
+    /// permitted to execute in an unordered fashion in unspecified
+    /// threads, and indeterminately sequenced within each thread.
+    ///
+    /// \returns  The \a stable_sort algorithm returns a
+    ///           \a hpx::future<void> if the execution policy is of
+    ///           type
+    ///           \a sequenced_task_policy or
+    ///           \a parallel_task_policy and returns nothing
+    ///           otherwise.
+    ///
+    template <typename ExPolicy, typename RandomIt, typename Comp,
+        typename Proj>
+    typename parallel::util::detail::algorithm_result<ExPolicy>::type
+    stable_sort(ExPolicy&& policy, RandomIt first, RandomIt last, Comp&& comp,
+        Proj&& proj);
+
+    // clang-format on
+}    // namespace hpx
+
+#else    // DOXYGEN
 
 #include <hpx/config.hpp>
 #include <hpx/assert.hpp>
@@ -125,84 +342,13 @@ namespace hpx { namespace parallel { inline namespace v1 {
         /// \endcond
     }    // namespace detail
 
-    //-----------------------------------------------------------------------------
-    /// Sorts the elements in the range [first, last) in ascending order. The
-    /// relative order of equal elements is preserved. The function
-    /// uses the given comparison function object comp (defaults to using
-    /// operator<()).
-    ///
-    /// \note   Complexity: O(Nlog(N)), where N = std::distance(first, last)
-    ///                     comparisons.
-    ///
-    /// A sequence is sorted with respect to a comparator \a comp and a
-    /// projection \a proj if for every iterator i pointing to the sequence and
-    /// every non-negative integer n such that i + n is a valid iterator
-    /// pointing to an element of the sequence, and
-    /// INVOKE(comp, INVOKE(proj, *(i + n)), INVOKE(proj, *i)) == false.
-    ///
-    /// \tparam ExPolicy    The type of the execution policy to use (deduced).
-    ///                     It describes the manner in which the execution
-    ///                     of the algorithm may be parallelized and the manner
-    ///                     in which it applies user-provided function objects.
-    /// \tparam RandomIt    The type of the source iterators used (deduced).
-    ///                     This iterator type must meet the requirements of a
-    ///                     random access iterator.
-    /// \tparam Sentinel    The type of the end iterators used (deduced).
-    ///                     This iterator type must meet the requirements of a
-    ///                     random access iterator and must be a valid sentinel
-    ///                     type for RandomIt.
-    /// \tparam Comp        The type of the function/function object to use
-    ///                     (deduced).
-    /// \tparam Proj        The type of an optional projection function. This
-    ///                     defaults to \a util::projection_identity
-    ///
-    /// \param policy       The execution policy to use for the scheduling of
-    ///                     the iterations.
-    /// \param first        Refers to the beginning of the sequence of elements
-    ///                     the algorithm will be applied to.
-    /// \param last         Refers to the end of the sequence of elements the
-    ///                     algorithm will be applied to.
-    /// \param comp         comp is a callable object. The return value of the
-    ///                     INVOKE operation applied to an object of type Comp,
-    ///                     when contextually converted to bool, yields true if
-    ///                     the first argument of the call is less than the
-    ///                     second, and false otherwise. It is assumed that comp
-    ///                     will not apply any non-constant function through the
-    ///                     dereferenced iterator.
-    /// \param proj         Specifies the function (or function object) which
-    ///                     will be invoked for each pair of elements as a
-    ///                     projection operation before the actual predicate
-    ///                     \a comp is invoked.
-    ///
-    /// \a comp has to induce a strict weak ordering on the values.
-    ///
-    /// The application of function objects in parallel algorithm
-    /// invoked with an execution policy object of type
-    /// \a sequenced_policy execute in sequential order in the
-    /// calling thread.
-    ///
-    /// The application of function objects in parallel algorithm
-    /// invoked with an execution policy object of type
-    /// \a parallel_policy or \a parallel_task_policy are
-    /// permitted to execute in an unordered fashion in unspecified
-    /// threads, and indeterminately sequenced within each thread.
-    ///
-    /// \returns  The \a stable_sort algorithm returns a
-    ///           \a hpx::future<RandomIt> if the execution policy is of
-    ///           type
-    ///           \a sequenced_task_policy or
-    ///           \a parallel_task_policy and returns \a RandomIt
-    ///           otherwise.
-    ///           The algorithm returns an iterator pointing to the first
-    ///           element after the last element in the input sequence.
-    //-----------------------------------------------------------------------------
     // clang-format off
     template <typename ExPolicy, typename RandomIt, typename Sentinel,
         typename Proj = util::projection_identity,
         typename Compare = detail::less,
         HPX_CONCEPT_REQUIRES_(
             hpx::is_execution_policy<ExPolicy>::value &&
-            hpx::traits::is_iterator<RandomIt>::value &&
+            hpx::traits::is_iterator_v<RandomIt> &&
             hpx::traits::is_sentinel_for<Sentinel, RandomIt>::value &&
             traits::is_projected<Proj, RandomIt>::value &&
             traits::is_indirect_callable<ExPolicy, Compare,
@@ -211,15 +357,90 @@ namespace hpx { namespace parallel { inline namespace v1 {
             >::value
         )>
     // clang-format on
-    typename util::detail::algorithm_result<ExPolicy, RandomIt>::type
-    stable_sort(ExPolicy&& policy, RandomIt first, Sentinel last,
-        Compare&& comp = Compare(), Proj&& proj = Proj())
+    HPX_DEPRECATED_V(1, 8,
+        "hpx::parallel::stable_sort is deprecated, use hpx::stable_sort "
+        "instead")
+        typename util::detail::algorithm_result<ExPolicy, RandomIt>::type
+        stable_sort(ExPolicy&& policy, RandomIt first, Sentinel last,
+            Compare&& comp = Compare(), Proj&& proj = Proj())
     {
-        static_assert((hpx::traits::is_random_access_iterator<RandomIt>::value),
+        static_assert((hpx::traits::is_random_access_iterator_v<RandomIt>),
             "Requires a random access iterator.");
 
+#if defined(HPX_GCC_VERSION) && HPX_GCC_VERSION >= 100000
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
         return detail::stable_sort<RandomIt>().call(
             std::forward<ExPolicy>(policy), first, last,
             std::forward<Compare>(comp), std::forward<Proj>(proj));
+#if defined(HPX_GCC_VERSION) && HPX_GCC_VERSION >= 100000
+#pragma GCC diagnostic pop
+#endif
     }
 }}}    // namespace hpx::parallel::v1
+
+namespace hpx {
+    ///////////////////////////////////////////////////////////////////////////
+    // DPO for hpx::stable_sort
+    HPX_INLINE_CONSTEXPR_VARIABLE struct stable_sort_t final
+      : hpx::functional::tag_fallback<stable_sort_t>
+    {
+        // clang-format off
+        template <typename RandomIt,
+            typename Comp = hpx::parallel::v1::detail::less,
+            typename Proj = parallel::util::projection_identity,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::traits::is_iterator_v<RandomIt> &&
+                parallel::traits::is_projected<Proj, RandomIt>::value &&
+                parallel::traits::is_indirect_callable<
+                    hpx::execution::sequenced_policy, Comp,
+                    parallel::traits::projected<Proj, RandomIt>,
+                    parallel::traits::projected<Proj, RandomIt>
+                >::value
+            )>
+        // clang-format on
+        friend void tag_fallback_dispatch(hpx::stable_sort_t, RandomIt first,
+            RandomIt last, Comp&& comp = Comp(), Proj&& proj = Proj())
+        {
+            static_assert(hpx::traits::is_random_access_iterator_v<RandomIt>,
+                "Requires a random access iterator.");
+
+            hpx::parallel::v1::detail::stable_sort<RandomIt>().call(
+                hpx::execution::seq, first, last, std::forward<Comp>(comp),
+                std::forward<Proj>(proj));
+        }
+
+        // clang-format off
+        template <typename ExPolicy, typename RandomIt,
+            typename Comp = hpx::parallel::v1::detail::less,
+            typename Proj = parallel::util::projection_identity,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::is_execution_policy<ExPolicy>::value &&
+                hpx::traits::is_iterator_v<RandomIt> &&
+                parallel::traits::is_projected<Proj, RandomIt>::value &&
+                parallel::traits::is_indirect_callable<ExPolicy, Comp,
+                    parallel::traits::projected<Proj, RandomIt>,
+                    parallel::traits::projected<Proj, RandomIt>
+                >::value
+            )>
+        // clang-format on
+        friend typename parallel::util::detail::algorithm_result<ExPolicy>::type
+        tag_fallback_dispatch(hpx::stable_sort_t, ExPolicy&& policy,
+            RandomIt first, RandomIt last, Comp&& comp = Comp(),
+            Proj&& proj = Proj())
+        {
+            static_assert(hpx::traits::is_random_access_iterator_v<RandomIt>,
+                "Requires a random access iterator.");
+
+            using result_type =
+                typename hpx::parallel::util::detail::algorithm_result<
+                    ExPolicy>::type;
+
+            return hpx::util::void_guard<result_type>(),
+                   hpx::parallel::v1::detail::stable_sort<RandomIt>().call(
+                       std::forward<ExPolicy>(policy), first, last,
+                       std::forward<Comp>(comp), std::forward<Proj>(proj));
+        }
+    } stable_sort{};
+}    // namespace hpx

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/unique.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/unique.hpp
@@ -845,8 +845,10 @@ namespace hpx { namespace parallel { inline namespace v1 {
                     util::loop_n<std::decay_t<ExPolicy>>(++part_begin,
                         part_size,
                         [base, pred, proj, &curr](zip_iterator it) mutable {
-                            bool f = HPX_INVOKE(pred, HPX_INVOKE(proj, *base),
-                                HPX_INVOKE(proj, get<0>(*it)));
+                            using hpx::util::invoke;
+
+                            bool f = invoke(pred, invoke(proj, *base),
+                                invoke(proj, get<0>(*it)));
 
                             if (!(get<1>(*it) = f))
                             {

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/unique.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/unique.hpp
@@ -1,4 +1,5 @@
 //  Copyright (c) 2017 Taeguk Kwon
+//  Copyright (c) 2021 Akhil J Nair
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -608,8 +609,8 @@ namespace hpx { namespace parallel { inline namespace v1 {
     typename util::detail::algorithm_result<ExPolicy,
         parallel::util::in_out_result<FwdIter1, FwdIter2>>::type
         HPX_DEPRECATED_V(1, 8,
-            "hpx::parallel::unique is deprecated, use "
-            "hpx::unique instead")
+            "hpx::parallel::unique_copy is deprecated, use "
+            "hpx::unique_copy instead")
             unique_copy(ExPolicy&& policy, FwdIter1 first, FwdIter1 last,
                 FwdIter2 dest, Pred&& pred = Pred(), Proj&& proj = Proj())
     {

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/unique.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/unique.hpp
@@ -586,8 +586,10 @@ namespace hpx { namespace parallel { inline namespace v1 {
                     // MSVC complains if pred or proj is captured by ref below
                     util::loop_n<std::decay_t<ExPolicy>>(++part_begin,
                         part_size, [base, pred, proj](zip_iterator it) mutable {
-                            bool f = HPX_INVOKE(pred, HPX_INVOKE(proj, *base),
-                                HPX_INVOKE(proj, get<0>(*it)));
+                            using hpx::util::invoke;
+
+                            bool f = invoke(pred, invoke(proj, *base),
+                                invoke(proj, get<0>(*it)));
 
                             if (!(get<1>(*it) = f))
                                 base = get<0>(it.get_iterator_tuple());
@@ -680,14 +682,18 @@ namespace hpx { namespace parallel { inline namespace v1 {
         /// \endcond
     }    // namespace detail
 
+    // clang-format off
     template <typename ExPolicy, typename FwdIter,
         typename Pred = detail::equal_to,
         typename Proj = util::projection_identity,
-        HPX_CONCEPT_REQUIRES_(hpx::is_execution_policy<ExPolicy>::value&& hpx::
-                traits::is_iterator<FwdIter>::value&& traits::is_projected<Proj,
-                    FwdIter>::value&& traits::is_indirect_callable<ExPolicy,
-                    Pred, traits::projected<Proj, FwdIter>,
-                    traits::projected<Proj, FwdIter>>::value)>
+        HPX_CONCEPT_REQUIRES_(
+            hpx::is_execution_policy<ExPolicy>::value &&
+            hpx::traits::is_iterator_v<FwdIter> &&
+            traits::is_projected<Proj, FwdIter>::value &&
+            traits::is_indirect_callable<ExPolicy, Pred,
+                    traits::projected<Proj, FwdIter>,
+                    traits::projected<Proj, FwdIter>>::value
+        )>
     // clang-format on
     HPX_DEPRECATED_V(1, 8,
         "hpx::parallel::unique is deprecated, use "
@@ -696,7 +702,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
         unique(ExPolicy&& policy, FwdIter first, FwdIter last,
             Pred&& pred = Pred(), Proj&& proj = Proj())
     {
-        static_assert((hpx::traits::is_forward_iterator<FwdIter>::value),
+        static_assert((hpx::traits::is_forward_iterator_v<FwdIter>),
             "Required at least forward iterator.");
 
 #if defined(HPX_GCC_VERSION) && HPX_GCC_VERSION >= 100000
@@ -906,27 +912,31 @@ namespace hpx { namespace parallel { inline namespace v1 {
         /// \endcond
     }    // namespace detail
 
+    // clang-format off
     template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
         typename Pred = detail::equal_to,
         typename Proj = util::projection_identity,
-        HPX_CONCEPT_REQUIRES_(hpx::is_execution_policy<ExPolicy>::value&&
-                hpx::traits::is_iterator<FwdIter1>::value&&
-                    hpx::traits::is_iterator<FwdIter2>::value&&
-                        traits::is_projected<Proj, FwdIter1>::value&&
-                            traits::is_indirect_callable<ExPolicy, Pred,
-                                traits::projected<Proj, FwdIter1>,
-                                traits::projected<Proj, FwdIter1>>::value)>
+        HPX_CONCEPT_REQUIRES_(
+            hpx::is_execution_policy<ExPolicy>::value &&
+            hpx::traits::is_iterator_v<FwdIter1> &&
+            hpx::traits::is_iterator_v<FwdIter2> &&
+            traits::is_projected<Proj, FwdIter1>::value &&
+            traits::is_indirect_callable<ExPolicy, Pred,
+                traits::projected<Proj, FwdIter1>,
+                traits::projected<Proj, FwdIter1>>::value
+        )>
+    // clang-format on
     HPX_DEPRECATED_V(1, 8,
         "hpx::parallel::unique_copy is deprecated, use "
         "hpx::unique_copy instead")
-    typename util::detail::algorithm_result<ExPolicy,
-        parallel::util::in_out_result<FwdIter1, FwdIter2>>::type
+        typename util::detail::algorithm_result<ExPolicy,
+            parallel::util::in_out_result<FwdIter1, FwdIter2>>::type
         unique_copy(ExPolicy&& policy, FwdIter1 first, FwdIter1 last,
             FwdIter2 dest, Pred&& pred = Pred(), Proj&& proj = Proj())
     {
-        static_assert((hpx::traits::is_forward_iterator<FwdIter1>::value),
+        static_assert((hpx::traits::is_forward_iterator_v<FwdIter1>),
             "Required at least forward iterator.");
-        static_assert((hpx::traits::is_forward_iterator<FwdIter2>::value),
+        static_assert((hpx::traits::is_forward_iterator_v<FwdIter2>),
             "Requires at least forward iterator.");
 
         using result_type = parallel::util::in_out_result<FwdIter1, FwdIter2>;
@@ -955,7 +965,7 @@ namespace hpx {
             typename Pred = hpx::parallel::v1::detail::equal_to,
             typename Proj = parallel::util::projection_identity,
             HPX_CONCEPT_REQUIRES_(
-                hpx::traits::is_iterator<FwdIter>::value &&
+                hpx::traits::is_iterator_v<FwdIter> &&
                 parallel::traits::is_projected<Proj, FwdIter>::value &&
                 parallel::traits::is_indirect_callable<
                     hpx::execution::sequenced_policy, Pred,
@@ -966,7 +976,7 @@ namespace hpx {
         friend FwdIter tag_fallback_dispatch(hpx::unique_t, FwdIter first,
             FwdIter last, Pred&& pred = Pred(), Proj&& proj = Proj())
         {
-            static_assert(hpx::traits::is_forward_iterator<FwdIter>::value,
+            static_assert(hpx::traits::is_forward_iterator_v<FwdIter>,
                 "Requires at least forward iterator.");
 
             return hpx::parallel::v1::detail::unique<FwdIter>().call(
@@ -980,7 +990,7 @@ namespace hpx {
             typename Proj = parallel::util::projection_identity,
             HPX_CONCEPT_REQUIRES_(
                 hpx::is_execution_policy<ExPolicy>::value &&
-                hpx::traits::is_iterator<FwdIter>::value &&
+                hpx::traits::is_iterator_v<FwdIter> &&
                 parallel::traits::is_projected<Proj, FwdIter>::value &&
                 parallel::traits::is_indirect_callable<ExPolicy, Pred,
                     parallel::traits::projected<Proj, FwdIter>,
@@ -992,7 +1002,7 @@ namespace hpx {
         tag_fallback_dispatch(hpx::unique_t, ExPolicy&& policy, FwdIter first,
             FwdIter last, Pred&& pred = Pred(), Proj&& proj = Proj())
         {
-            static_assert(hpx::traits::is_forward_iterator<FwdIter>::value,
+            static_assert(hpx::traits::is_forward_iterator_v<FwdIter>,
                 "Requires at least forward iterator.");
 
             return hpx::parallel::v1::detail::unique<FwdIter>().call(
@@ -1011,8 +1021,8 @@ namespace hpx {
             typename Pred = hpx::parallel::v1::detail::equal_to,
             typename Proj = parallel::util::projection_identity,
             HPX_CONCEPT_REQUIRES_(
-                hpx::traits::is_iterator<InIter>::value &&
-                hpx::traits::is_iterator<OutIter>::value &&
+                hpx::traits::is_iterator_v<InIter> &&
+                hpx::traits::is_iterator_v<OutIter> &&
                 parallel::traits::is_indirect_callable<
                     hpx::execution::sequenced_policy, Pred,
                     parallel::traits::projected<Proj, InIter>,
@@ -1023,7 +1033,7 @@ namespace hpx {
             InIter last, OutIter dest, Pred&& pred = Pred(),
             Proj&& proj = Proj())
         {
-            static_assert(hpx::traits::is_input_iterator<InIter>::value,
+            static_assert(hpx::traits::is_input_iterator_v<InIter>,
                 "Requires at least input iterator.");
 
             using result_type = parallel::util::in_out_result<InIter, OutIter>;
@@ -1040,8 +1050,8 @@ namespace hpx {
             typename Proj = parallel::util::projection_identity,
             HPX_CONCEPT_REQUIRES_(
                 hpx::is_execution_policy<ExPolicy>::value &&
-                hpx::traits::is_iterator<FwdIter1>::value &&
-                hpx::traits::is_iterator<FwdIter2>::value &&
+                hpx::traits::is_iterator_v<FwdIter1> &&
+                hpx::traits::is_iterator_v<FwdIter2> &&
                 parallel::traits::is_indirect_callable<ExPolicy, Pred,
                     parallel::traits::projected<Proj, FwdIter1>,
                     parallel::traits::projected<Proj, FwdIter1>>::value
@@ -1053,7 +1063,7 @@ namespace hpx {
             FwdIter1 first, FwdIter1 last, FwdIter2 dest, Pred&& pred = Pred(),
             Proj&& proj = Proj())
         {
-            static_assert(hpx::traits::is_forward_iterator<FwdIter1>::value,
+            static_assert(hpx::traits::is_forward_iterator_v<FwdIter1>,
                 "Requires at least forward iterator.");
 
             using result_type =

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/unique.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/unique.hpp
@@ -37,7 +37,7 @@ namespace hpx {
     ///           The \a unique algorithm returns the iterator to the new end
     ///           of the range.
     ///
-    template <typename ExPolicy, typename FwdIter>
+    template <typename FwdIter>
     FwdIter unique(FwdIter first, FwdIter last);
 
     ///////////////////////////////////////////////////////////////////////////
@@ -914,13 +914,13 @@ namespace hpx { namespace parallel { inline namespace v1 {
                             traits::is_indirect_callable<ExPolicy, Pred,
                                 traits::projected<Proj, FwdIter1>,
                                 traits::projected<Proj, FwdIter1>>::value)>
+    HPX_DEPRECATED_V(1, 8,
+        "hpx::parallel::unique_copy is deprecated, use "
+        "hpx::unique_copy instead")
     typename util::detail::algorithm_result<ExPolicy,
         parallel::util::in_out_result<FwdIter1, FwdIter2>>::type
-        HPX_DEPRECATED_V(1, 8,
-            "hpx::parallel::unique_copy is deprecated, use "
-            "hpx::unique_copy instead")
-            unique_copy(ExPolicy&& policy, FwdIter1 first, FwdIter1 last,
-                FwdIter2 dest, Pred&& pred = Pred(), Proj&& proj = Proj())
+        unique_copy(ExPolicy&& policy, FwdIter1 first, FwdIter1 last,
+            FwdIter2 dest, Pred&& pred = Pred(), Proj&& proj = Proj())
     {
         static_assert((hpx::traits::is_forward_iterator<FwdIter1>::value),
             "Required at least forward iterator.");

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/unique.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/unique.hpp
@@ -7,6 +7,457 @@
 
 #pragma once
 
+#if defined(DOXYGEN)
+
+namespace hpx {
+    // clang-format off
+
+    ///////////////////////////////////////////////////////////////////////////
+    /// Eliminates all but the first element from every consecutive group of
+    /// equivalent elements from the range [first, last) and returns a
+    /// past-the-end iterator for the new logical end of the range.
+    ///
+    /// \note   Complexity: Performs not more than \a last - \a first
+    ///         assignments.
+    ///
+    /// \tparam FwdIter     The type of the source iterators used (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     forward iterator.
+    ///
+    /// \param first        Refers to the beginning of the sequence of elements
+    ///                     the algorithm will be applied to.
+    /// \param last         Refers to the end of the sequence of elements the
+    ///                     algorithm will be applied to.
+    ///
+    /// The assignments in the parallel \a unique algorithm invoked without
+    /// an execution policy object execute in sequential order in the
+    /// calling thread.
+    ///
+    /// \returns  The \a unique algorithm returns \a FwdIter.
+    ///           The \a unique algorithm returns the iterator to the new end
+    ///           of the range.
+    ///
+    template <typename ExPolicy, typename FwdIter>
+    FwdIter unique(FwdIter first, FwdIter last);
+
+    ///////////////////////////////////////////////////////////////////////////
+    /// Eliminates all but the first element from every consecutive group of
+    /// equivalent elements from the range [first, last) and returns a
+    /// past-the-end iterator for the new logical end of the range.
+    ///
+    /// \note   Complexity: Performs not more than \a last - \a first
+    ///         assignments.
+    ///
+    /// \tparam ExPolicy    The type of the execution policy to use (deduced).
+    ///                     It describes the manner in which the execution
+    ///                     of the algorithm may be parallelized and the manner
+    ///                     in which it executes the assignments.
+    /// \tparam FwdIter     The type of the source iterators used (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     forward iterator.
+    ///
+    /// \param policy       The execution policy to use for the scheduling of
+    ///                     the iterations.
+    /// \param first        Refers to the beginning of the sequence of elements
+    ///                     the algorithm will be applied to.
+    /// \param last         Refers to the end of the sequence of elements the
+    ///                     algorithm will be applied to.
+    ///
+    /// The assignments in the parallel \a unique algorithm invoked with
+    /// an execution policy object of type \a sequenced_policy
+    /// execute in sequential order in the calling thread.
+    ///
+    /// The assignments in the parallel \a unique algorithm invoked with
+    /// an execution policy object of type \a parallel_policy or
+    /// \a parallel_task_policy are permitted to execute in an unordered
+    /// fashion in unspecified threads, and indeterminately sequenced
+    /// within each thread.
+    ///
+    /// \returns  The \a unique algorithm returns a \a hpx::future<FwdIter>
+    ///           if the execution policy is of type
+    ///           \a sequenced_task_policy or \a parallel_task_policy and
+    ///           returns \a FwdIter otherwise.
+    ///           The \a unique algorithm returns the iterator to the new end
+    ///           of the range.
+    ///
+    template <typename ExPolicy, typename FwdIter>
+    typename parallel::util::detail::algorithm_result<ExPolicy,
+        FwdIter>::type
+     unique(ExPolicy&& policy, FwdIter first, FwdIter last);
+
+    ///////////////////////////////////////////////////////////////////////////
+    /// Eliminates all but the first element from every consecutive group of
+    /// equivalent elements from the range [first, last) and returns a
+    /// past-the-end iterator for the new logical end of the range.
+    ///
+    /// \note   Complexity: Performs not more than \a last - \a first
+    ///         assignments, exactly \a last - \a first - 1 applications of
+    ///         the predicate \a pred and no more than twice as many
+    ///         applications of the projection \a proj.
+    ///
+    /// \tparam FwdIter     The type of the source iterators used (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     forward iterator.
+    /// \tparam Pred        The type of the function/function object to use
+    ///                     (deduced). Unlike its sequential form, the parallel
+    ///                     overload of \a unique requires \a Pred to meet the
+    ///                     requirements of \a CopyConstructible. This defaults
+    ///                     to std::equal_to<>
+    /// \tparam Proj        The type of an optional projection function. This
+    ///                     defaults to \a util::projection_identity
+    ///
+    /// \param first        Refers to the beginning of the sequence of elements
+    ///                     the algorithm will be applied to.
+    /// \param last         Refers to the end of the sequence of elements the
+    ///                     algorithm will be applied to.
+    /// \param pred         Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements in the
+    ///                     sequence specified by [first, last). This is an
+    ///                     binary predicate which returns \a true for the
+    ///                     required elements. The signature of this predicate
+    ///                     should be equivalent to:
+    ///                     \code
+    ///                     bool pred(const Type1 &a, const Type2 &b);
+    ///                     \endcode \n
+    ///                     The signature does not need to have const&, but
+    ///                     the function must not modify the objects passed to
+    ///                     it. The types \a Type1 and \a Type2 must be
+    ///                     such that objects of types \a FwdIter can be
+    ///                     dereferenced and then implicitly converted to
+    ///                     both \a Type1 and \a Type2
+    /// \param proj         Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements as a
+    ///                     projection operation before the actual predicate
+    ///                     \a is invoked.
+    ///
+    /// The assignments in the parallel \a unique algorithm invoked without
+    /// an execution policy object execute in sequential order in the
+    /// calling thread.
+    ///
+    /// \returns  The \a unique algorithm returns \a FwdIter.
+    ///           The \a unique algorithm returns the iterator to the new end
+    ///           of the range.
+    ///
+    template <typename ExPolicy, typename FwdIter, typename Pred,
+        typename Proj>
+    FwdIter unique(FwdIter first, FwdIter last, Pred&& pred,
+        Proj&& proj);
+
+    ///////////////////////////////////////////////////////////////////////////
+    /// Eliminates all but the first element from every consecutive group of
+    /// equivalent elements from the range [first, last) and returns a
+    /// past-the-end iterator for the new logical end of the range.
+    ///
+    /// \note   Complexity: Performs not more than \a last - \a first
+    ///         assignments, exactly \a last - \a first - 1 applications of
+    ///         the predicate \a pred and no more than twice as many
+    ///         applications of the projection \a proj.
+    ///
+    /// \tparam ExPolicy    The type of the execution policy to use (deduced).
+    ///                     It describes the manner in which the execution
+    ///                     of the algorithm may be parallelized and the manner
+    ///                     in which it executes the assignments.
+    /// \tparam FwdIter     The type of the source iterators used (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     forward iterator.
+    /// \tparam Pred        The type of the function/function object to use
+    ///                     (deduced). Unlike its sequential form, the parallel
+    ///                     overload of \a unique requires \a Pred to meet the
+    ///                     requirements of \a CopyConstructible. This defaults
+    ///                     to std::equal_to<>
+    /// \tparam Proj        The type of an optional projection function. This
+    ///                     defaults to \a util::projection_identity
+    ///
+    /// \param policy       The execution policy to use for the scheduling of
+    ///                     the iterations.
+    /// \param first        Refers to the beginning of the sequence of elements
+    ///                     the algorithm will be applied to.
+    /// \param last         Refers to the end of the sequence of elements the
+    ///                     algorithm will be applied to.
+    /// \param pred         Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements in the
+    ///                     sequence specified by [first, last). This is an
+    ///                     binary predicate which returns \a true for the
+    ///                     required elements. The signature of this predicate
+    ///                     should be equivalent to:
+    ///                     \code
+    ///                     bool pred(const Type1 &a, const Type2 &b);
+    ///                     \endcode \n
+    ///                     The signature does not need to have const&, but
+    ///                     the function must not modify the objects passed to
+    ///                     it. The types \a Type1 and \a Type2 must be
+    ///                     such that objects of types \a FwdIter can be
+    ///                     dereferenced and then implicitly converted to
+    ///                     both \a Type1 and \a Type2
+    /// \param proj         Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements as a
+    ///                     projection operation before the actual predicate
+    ///                     \a is invoked.
+    ///
+    /// The assignments in the parallel \a unique algorithm invoked with
+    /// an execution policy object of type \a sequenced_policy
+    /// execute in sequential order in the calling thread.
+    ///
+    /// The assignments in the parallel \a unique algorithm invoked with
+    /// an execution policy object of type \a parallel_policy or
+    /// \a parallel_task_policy are permitted to execute in an unordered
+    /// fashion in unspecified threads, and indeterminately sequenced
+    /// within each thread.
+    ///
+    /// \returns  The \a unique algorithm returns a \a hpx::future<FwdIter>
+    ///           if the execution policy is of type
+    ///           \a sequenced_task_policy or \a parallel_task_policy and
+    ///           returns \a FwdIter otherwise.
+    ///           The \a unique algorithm returns the iterator to the new end
+    ///           of the range.
+    ///
+    template <typename ExPolicy, typename FwdIter, typename Pred,
+        typename Proj>
+    typename parallel::util::detail::algorithm_result<ExPolicy,
+        FwdIter>::type
+     unique(ExPolicy&& policy, FwdIter first, FwdIter last, Pred&& pred,
+         Proj&& proj);
+
+    ///////////////////////////////////////////////////////////////////////////
+    /// Copies the elements from the range [first, last),
+    /// to another range beginning at \a dest in such a way that
+    /// there are no consecutive equal elements. Only the first element of
+    /// each group of equal elements is copied.
+    ///
+    /// \note   Complexity: Performs not more than \a last - \a first
+    ///         assignments.
+    ///
+    /// \tparam InIter      The type of the source iterators used (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     input iterator.
+    /// \tparam OutIter     The type of the iterator representing the
+    ///                     destination range (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     output iterator.
+    ///
+    /// \param first        Refers to the beginning of the sequence of elements
+    ///                     the algorithm will be applied to.
+    /// \param last         Refers to the end of the sequence of elements the
+    ///                     algorithm will be applied to.
+    /// \param dest         Refers to the beginning of the destination range.
+    ///
+    /// The assignments in the parallel \a unique_copy algorithm invoked
+    /// without an execution policy object  will execute in sequential
+    /// order in the calling thread.
+    ///
+    /// \returns  The \a unique_copy algorithm returns a
+    ///           returns OutIter.
+    ///           The \a unique_copy algorithm returns the destination
+    ///           iterator to the end of the \a dest range.
+    ///
+    template <typename InIter, typename OutIter>
+    OutIter unique_copy(InIter first, InIter last, OutIter dest);
+
+    ///////////////////////////////////////////////////////////////////////////
+    /// Copies the elements from the range [first, last),
+    /// to another range beginning at \a dest in such a way that
+    /// there are no consecutive equal elements. Only the first element of
+    /// each group of equal elements is copied.
+    ///
+    /// \note   Complexity: Performs not more than \a last - \a first
+    ///         assignments.
+    ///
+    /// \tparam ExPolicy    The type of the execution policy to use (deduced).
+    ///                     It describes the manner in which the execution
+    ///                     of the algorithm may be parallelized and the manner
+    ///                     in which it executes the assignments.
+    /// \tparam FwdIter1    The type of the source iterators used (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     forward iterator.
+    /// \tparam FwdIter2    The type of the iterator representing the
+    ///                     destination range (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     forward iterator.
+    ///
+    /// \param policy       The execution policy to use for the scheduling of
+    ///                     the iterations.
+    /// \param first        Refers to the beginning of the sequence of elements
+    ///                     the algorithm will be applied to.
+    /// \param last         Refers to the end of the sequence of elements the
+    ///                     algorithm will be applied to.
+    /// \param dest         Refers to the beginning of the destination range.
+    ///
+    /// The assignments in the parallel \a unique_copy algorithm invoked with
+    /// an execution policy object of type \a sequenced_policy
+    /// execute in sequential order in the calling thread.
+    ///
+    /// The assignments in the parallel \a unique_copy algorithm invoked with
+    /// an execution policy object of type \a parallel_policy or
+    /// \a parallel_task_policy are permitted to execute in an unordered
+    /// fashion in unspecified threads, and indeterminately sequenced
+    /// within each thread.
+    ///
+    /// \returns  The \a unique_copy algorithm returns a
+    ///           \a hpx::future<FwdIter2> if the execution policy
+    ///           is of type \a sequenced_task_policy or
+    ///           \a parallel_task_policy and
+    ///           returns \a FwdIter2 otherwise.
+    ///           The \a unique_copy algorithm returns the pair of
+    ///           the source iterator to \a last, and
+    ///           the destination iterator to the end of the \a dest range.
+    ///
+    template <typename ExPolicy, typename FwdIter1, typename FwdIter2>
+    typename parallel::util::detail::algorithm_result<ExPolicy,
+        FwdIter2>::type
+     unique_copy(ExPolicy&& policy, FwdIter1 first, FwdIter1 last,
+         FwdIter2 dest);
+
+    ///////////////////////////////////////////////////////////////////////////
+    /// Copies the elements from the range [first, last),
+    /// to another range beginning at \a dest in such a way that
+    /// there are no consecutive equal elements. Only the first element of
+    /// each group of equal elements is copied.
+    ///
+    /// \note   Complexity: Performs not more than \a last - \a first
+    ///         assignments, exactly \a last - \a first - 1 applications of
+    ///         the predicate \a pred and no more than twice as many
+    ///         applications of the projection \a proj
+    ///
+    /// \tparam InIter      The type of the source iterators used (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     input iterator.
+    /// \tparam OutIter     The type of the iterator representing the
+    ///                     destination range (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     output iterator.
+    /// \tparam Pred        The type of the function/function object to use
+    ///                     (deduced). Unlike its sequential form, the parallel
+    ///                     overload of \a unique_copy requires \a Pred to meet the
+    ///                     requirements of \a CopyConstructible. This defaults
+    ///                     to std::equal_to<>
+    /// \tparam Proj        The type of an optional projection function. This
+    ///                     defaults to \a util::projection_identity
+    ///
+    /// \param first        Refers to the beginning of the sequence of elements
+    ///                     the algorithm will be applied to.
+    /// \param last         Refers to the end of the sequence of elements the
+    ///                     algorithm will be applied to.
+    /// \param dest         Refers to the beginning of the destination range.
+    /// \param pred         Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements in the
+    ///                     sequence specified by [first, last). This is an
+    ///                     binary predicate which returns \a true for the
+    ///                     required elements. The signature of this predicate
+    ///                     should be equivalent to:
+    ///                     \code
+    ///                     bool pred(const Type &a, const Type &b);
+    ///                     \endcode \n
+    ///                     The signature does not need to have const&, but
+    ///                     the function must not modify the objects passed to
+    ///                     it. The type \a Type must be such that an object of
+    ///                     type \a FwdIter1 can be dereferenced and then
+    ///                     implicitly converted to \a Type.
+    /// \param proj         Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements as a
+    ///                     projection operation before the actual predicate
+    ///                     \a is invoked.
+    ///
+    /// The assignments in the parallel \a unique_copy algorithm invoked
+    /// without an execution policy object  will execute in sequential
+    /// order in the calling thread.
+    ///
+    /// \returns  The \a unique_copy algorithm returns a
+    ///           returns OutIter.
+    ///           The \a unique_copy algorithm returns the destination
+    ///           iterator to the end of the \a dest range.
+    ///
+    template <typename InIter, typename OutIter, typename Pred,
+        typename Proj>
+    OutIter unique_copy(InIter first, InIter last, OutIter dest,
+        Pred&& pred, Proj&& proj);
+
+    ///////////////////////////////////////////////////////////////////////////
+    /// Copies the elements from the range [first, last),
+    /// to another range beginning at \a dest in such a way that
+    /// there are no consecutive equal elements. Only the first element of
+    /// each group of equal elements is copied.
+    ///
+    /// \note   Complexity: Performs not more than \a last - \a first
+    ///         assignments, exactly \a last - \a first - 1 applications of
+    ///         the predicate \a pred and no more than twice as many
+    ///         applications of the projection \a proj
+    ///
+    /// \tparam ExPolicy    The type of the execution policy to use (deduced).
+    ///                     It describes the manner in which the execution
+    ///                     of the algorithm may be parallelized and the manner
+    ///                     in which it executes the assignments.
+    /// \tparam FwdIter1    The type of the source iterators used (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     forward iterator.
+    /// \tparam FwdIter2    The type of the iterator representing the
+    ///                     destination range (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     forward iterator.
+    /// \tparam Pred        The type of the function/function object to use
+    ///                     (deduced). Unlike its sequential form, the parallel
+    ///                     overload of \a unique_copy requires \a Pred to meet the
+    ///                     requirements of \a CopyConstructible. This defaults
+    ///                     to std::equal_to<>
+    /// \tparam Proj        The type of an optional projection function. This
+    ///                     defaults to \a util::projection_identity
+    ///
+    /// \param policy       The execution policy to use for the scheduling of
+    ///                     the iterations.
+    /// \param first        Refers to the beginning of the sequence of elements
+    ///                     the algorithm will be applied to.
+    /// \param last         Refers to the end of the sequence of elements the
+    ///                     algorithm will be applied to.
+    /// \param dest         Refers to the beginning of the destination range.
+    /// \param pred         Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements in the
+    ///                     sequence specified by [first, last). This is an
+    ///                     binary predicate which returns \a true for the
+    ///                     required elements. The signature of this predicate
+    ///                     should be equivalent to:
+    ///                     \code
+    ///                     bool pred(const Type &a, const Type &b);
+    ///                     \endcode \n
+    ///                     The signature does not need to have const&, but
+    ///                     the function must not modify the objects passed to
+    ///                     it. The type \a Type must be such that an object of
+    ///                     type \a FwdIter1 can be dereferenced and then
+    ///                     implicitly converted to \a Type.
+    /// \param proj         Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements as a
+    ///                     projection operation before the actual predicate
+    ///                     \a is invoked.
+    ///
+    /// The assignments in the parallel \a unique_copy algorithm invoked with
+    /// an execution policy object of type \a sequenced_policy
+    /// execute in sequential order in the calling thread.
+    ///
+    /// The assignments in the parallel \a unique_copy algorithm invoked with
+    /// an execution policy object of type \a parallel_policy or
+    /// \a parallel_task_policy are permitted to execute in an unordered
+    /// fashion in unspecified threads, and indeterminately sequenced
+    /// within each thread.
+    ///
+    /// \returns  The \a unique_copy algorithm returns a
+    ///           \a hpx::future<FwdIter2> if the execution policy
+    ///           is of type \a sequenced_task_policy or
+    ///           \a parallel_task_policy and
+    ///           returns \a FwdIter2 otherwise.
+    ///           The \a unique_copy algorithm returns the pair of
+    ///           the source iterator to \a last, and
+    ///           the destination iterator to the end of the \a dest range.
+    ///
+    template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
+        typename Pred, typename Proj>
+    typename parallel::util::detail::algorithm_result<ExPolicy,
+        FwdIter2>::type
+     unique_copy(ExPolicy&& policy, FwdIter1 first, FwdIter1 last,
+         FwdIter2 dest, Pred&& pred, Proj&& proj);
+
+    // clang-format on
+}    // namespace hpx
+
+#else    // DOXYGEN
+
 #include <hpx/config.hpp>
 #include <hpx/concepts/concepts.hpp>
 #include <hpx/functional/invoke.hpp>
@@ -229,73 +680,6 @@ namespace hpx { namespace parallel { inline namespace v1 {
         /// \endcond
     }    // namespace detail
 
-    /// Eliminates all but the first element from every consecutive group of
-    /// equivalent elements from the range [first, last) and returns a
-    /// past-the-end iterator for the new logical end of the range.
-    ///
-    /// \note   Complexity: Performs not more than \a last - \a first
-    ///         assignments, exactly \a last - \a first - 1 applications of
-    ///         the predicate \a pred and no more than twice as many
-    ///         applications of the projection \a proj.
-    ///
-    /// \tparam ExPolicy    The type of the execution policy to use (deduced).
-    ///                     It describes the manner in which the execution
-    ///                     of the algorithm may be parallelized and the manner
-    ///                     in which it executes the assignments.
-    /// \tparam FwdIter     The type of the source iterators used (deduced).
-    ///                     This iterator type must meet the requirements of an
-    ///                     forward iterator.
-    /// \tparam Pred        The type of the function/function object to use
-    ///                     (deduced). Unlike its sequential form, the parallel
-    ///                     overload of \a unique requires \a Pred to meet the
-    ///                     requirements of \a CopyConstructible. This defaults
-    ///                     to std::equal_to<>
-    /// \tparam Proj        The type of an optional projection function. This
-    ///                     defaults to \a util::projection_identity
-    ///
-    /// \param policy       The execution policy to use for the scheduling of
-    ///                     the iterations.
-    /// \param first        Refers to the beginning of the sequence of elements
-    ///                     the algorithm will be applied to.
-    /// \param last         Refers to the end of the sequence of elements the
-    ///                     algorithm will be applied to.
-    /// \param pred         Specifies the function (or function object) which
-    ///                     will be invoked for each of the elements in the
-    ///                     sequence specified by [first, last). This is an
-    ///                     binary predicate which returns \a true for the
-    ///                     required elements. The signature of this predicate
-    ///                     should be equivalent to:
-    ///                     \code
-    ///                     bool pred(const Type1 &a, const Type2 &b);
-    ///                     \endcode \n
-    ///                     The signature does not need to have const&, but
-    ///                     the function must not modify the objects passed to
-    ///                     it. The types \a Type1 and \a Type2 must be
-    ///                     such that objects of types \a FwdIter can be
-    ///                     dereferenced and then implicitly converted to
-    ///                     both \a Type1 and \a Type2
-    /// \param proj         Specifies the function (or function object) which
-    ///                     will be invoked for each of the elements as a
-    ///                     projection operation before the actual predicate
-    ///                     \a is invoked.
-    ///
-    /// The assignments in the parallel \a unique algorithm invoked with
-    /// an execution policy object of type \a sequenced_policy
-    /// execute in sequential order in the calling thread.
-    ///
-    /// The assignments in the parallel \a unique algorithm invoked with
-    /// an execution policy object of type \a parallel_policy or
-    /// \a parallel_task_policy are permitted to execute in an unordered
-    /// fashion in unspecified threads, and indeterminately sequenced
-    /// within each thread.
-    ///
-    /// \returns  The \a unique algorithm returns a \a hpx::future<FwdIter>
-    ///           if the execution policy is of type
-    ///           \a sequenced_task_policy or \a parallel_task_policy and
-    ///           returns \a FwdIter otherwise.
-    ///           The \a unique algorithm returns the iterator to the new end
-    ///           of the range.
-    ///
     template <typename ExPolicy, typename FwdIter,
         typename Pred = detail::equal_to,
         typename Proj = util::projection_identity,
@@ -520,82 +904,6 @@ namespace hpx { namespace parallel { inline namespace v1 {
         /// \endcond
     }    // namespace detail
 
-    /// Copies the elements from the range [first, last),
-    /// to another range beginning at \a dest in such a way that
-    /// there are no consecutive equal elements. Only the first element of
-    /// each group of equal elements is copied.
-    ///
-    /// \note   Complexity: Performs not more than \a last - \a first
-    ///         assignments, exactly \a last - \a first - 1 applications of
-    ///         the predicate \a pred and no more than twice as many
-    ///         applications of the projection \a proj
-    ///
-    /// \tparam ExPolicy    The type of the execution policy to use (deduced).
-    ///                     It describes the manner in which the execution
-    ///                     of the algorithm may be parallelized and the manner
-    ///                     in which it executes the assignments.
-    /// \tparam FwdIter1    The type of the source iterators used (deduced).
-    ///                     This iterator type must meet the requirements of an
-    ///                     forward iterator.
-    /// \tparam FwdIter2    The type of the iterator representing the
-    ///                     destination range (deduced).
-    ///                     This iterator type must meet the requirements of an
-    ///                     forward iterator.
-    /// \tparam Pred        The type of the function/function object to use
-    ///                     (deduced). Unlike its sequential form, the parallel
-    ///                     overload of \a unique_copy requires \a Pred to meet the
-    ///                     requirements of \a CopyConstructible. This defaults
-    ///                     to std::equal_to<>
-    /// \tparam Proj        The type of an optional projection function. This
-    ///                     defaults to \a util::projection_identity
-    ///
-    /// \param policy       The execution policy to use for the scheduling of
-    ///                     the iterations.
-    /// \param first        Refers to the beginning of the sequence of elements
-    ///                     the algorithm will be applied to.
-    /// \param last         Refers to the end of the sequence of elements the
-    ///                     algorithm will be applied to.
-    /// \param dest         Refers to the beginning of the destination range.
-    /// \param pred         Specifies the function (or function object) which
-    ///                     will be invoked for each of the elements in the
-    ///                     sequence specified by [first, last). This is an
-    ///                     binary predicate which returns \a true for the
-    ///                     required elements. The signature of this predicate
-    ///                     should be equivalent to:
-    ///                     \code
-    ///                     bool pred(const Type &a, const Type &b);
-    ///                     \endcode \n
-    ///                     The signature does not need to have const&, but
-    ///                     the function must not modify the objects passed to
-    ///                     it. The type \a Type must be such that an object of
-    ///                     type \a FwdIter1 can be dereferenced and then
-    ///                     implicitly converted to \a Type.
-    /// \param proj         Specifies the function (or function object) which
-    ///                     will be invoked for each of the elements as a
-    ///                     projection operation before the actual predicate
-    ///                     \a is invoked.
-    ///
-    /// The assignments in the parallel \a unique_copy algorithm invoked with
-    /// an execution policy object of type \a sequenced_policy
-    /// execute in sequential order in the calling thread.
-    ///
-    /// The assignments in the parallel \a unique_copy algorithm invoked with
-    /// an execution policy object of type \a parallel_policy or
-    /// \a parallel_task_policy are permitted to execute in an unordered
-    /// fashion in unspecified threads, and indeterminately sequenced
-    /// within each thread.
-    ///
-    /// \returns  The \a unique_copy algorithm returns a
-    ///           \a hpx::future<tagged_pair<tag::in(FwdIter1), tag::out(FwdIter2)> >
-    ///           if the execution policy is of type
-    ///           \a sequenced_task_policy or
-    ///           \a parallel_task_policy and
-    ///           returns \a tagged_pair<tag::in(FwdIter1), tag::out(FwdIter2)>
-    ///           otherwise.
-    ///           The \a unique_copy algorithm returns the pair of
-    ///           the source iterator to \a last, and
-    ///           the destination iterator to the end of the \a dest range.
-    ///
     template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
         typename Pred = detail::equal_to,
         typename Proj = util::projection_identity,
@@ -756,3 +1064,5 @@ namespace hpx {
         }
     } unique_copy{};
 }    // namespace hpx
+
+#endif    // DOXYGEN

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/stable_sort.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/stable_sort.hpp
@@ -306,14 +306,14 @@ namespace hpx { namespace parallel { inline namespace rangev1 {
     {
         using iterator_type = typename hpx::traits::range_iterator<Rng>::type;
 
-        static_assert(hpx::traits::is_random_access_iterator_v<iterator_type>,
-            "Requires a random access iterator.");
-
 #if defined(HPX_GCC_VERSION) && HPX_GCC_VERSION >= 100000
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #endif
-        return detail::stable_sort<iterator_type>().call(
+        static_assert(hpx::traits::is_random_access_iterator_v<iterator_type>,
+            "Requires a random access iterator.");
+
+        return parallel::v1::detail::stable_sort<iterator_type>().call(
             std::forward<ExPolicy>(policy), hpx::util::begin(rng),
             hpx::util::end(rng), std::forward<Compare>(comp),
             std::forward<Proj>(proj));
@@ -335,7 +335,7 @@ namespace hpx { namespace ranges {
             typename Comp = ranges::less,
             typename Proj = parallel::util::projection_identity,
             HPX_CONCEPT_REQUIRES_(
-                hpx::traits::is_iterator<RandomIt>::value &&
+                hpx::traits::is_iterator_v<RandomIt> &&
                 hpx::traits::is_sentinel_for<Sent, RandomIt>::value &&
                 parallel::traits::is_projected<Proj, RandomIt>::value &&
                 parallel::traits::is_indirect_callable<
@@ -349,8 +349,7 @@ namespace hpx { namespace ranges {
             RandomIt first, Sent last, Comp&& comp = Comp(),
             Proj&& proj = Proj())
         {
-            static_assert(
-                hpx::traits::is_random_access_iterator<RandomIt>::value,
+            static_assert(hpx::traits::is_random_access_iterator_v<RandomIt>,
                 "Requires a random access iterator.");
 
             return hpx::parallel::v1::detail::stable_sort<RandomIt>().call(
@@ -364,7 +363,7 @@ namespace hpx { namespace ranges {
             typename Proj = parallel::util::projection_identity,
             HPX_CONCEPT_REQUIRES_(
                 hpx::is_execution_policy<ExPolicy>::value &&
-                hpx::traits::is_iterator<RandomIt>::value &&
+                hpx::traits::is_iterator_v<RandomIt> &&
                 hpx::traits::is_sentinel_for<Sent, RandomIt>::value &&
                 parallel::traits::is_projected<Proj, RandomIt>::value &&
                 parallel::traits::is_indirect_callable<ExPolicy, Comp,
@@ -379,8 +378,7 @@ namespace hpx { namespace ranges {
             RandomIt first, Sent last, Comp&& comp = Comp(),
             Proj&& proj = Proj())
         {
-            static_assert(
-                hpx::traits::is_random_access_iterator<RandomIt>::value,
+            static_assert(hpx::traits::is_random_access_iterator_v<RandomIt>,
                 "Requires a random access iterator.");
 
             return hpx::parallel::v1::detail::stable_sort<RandomIt>().call(
@@ -410,7 +408,7 @@ namespace hpx { namespace ranges {
                 typename hpx::traits::range_traits<Rng>::iterator_type;
 
             static_assert(
-                hpx::traits::is_random_access_iterator<iterator_type>::value,
+                hpx::traits::is_random_access_iterator_v<iterator_type>,
                 "Requires a random access iterator.");
 
             return hpx::parallel::v1::detail::stable_sort<iterator_type>().call(
@@ -441,7 +439,7 @@ namespace hpx { namespace ranges {
                 typename hpx::traits::range_traits<Rng>::iterator_type;
 
             static_assert(
-                hpx::traits::is_random_access_iterator<iterator_type>::value,
+                hpx::traits::is_random_access_iterator_v<iterator_type>,
                 "Requires a random access iterator.");
 
             return hpx::parallel::v1::detail::stable_sort<iterator_type>().call(

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/stable_sort.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/stable_sort.hpp
@@ -1,4 +1,5 @@
 //  Copyright (c) 2020 Hartmut Kaiser
+//  Copyright (c) 2021 Akhil J Nair
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -8,20 +9,192 @@
 
 #pragma once
 
-#include <hpx/config.hpp>
-#include <hpx/concepts/concepts.hpp>
-#include <hpx/iterator_support/range.hpp>
-#include <hpx/iterator_support/traits/is_range.hpp>
+#if defined(DOXYGEN)
 
-#include <hpx/algorithms/traits/projected_range.hpp>
-#include <hpx/parallel/algorithms/stable_sort.hpp>
-#include <hpx/parallel/util/projection_identity.hpp>
+namespace hpx { namespace ranges {
+    // clang-format off
 
-#include <type_traits>
-#include <utility>
+    ///////////////////////////////////////////////////////////////////////////
+    /// Sorts the elements in the range [first, last) in ascending order. The
+    /// relative order of equal elements is preserved. The function
+    /// uses the given comparison function object comp (defaults to using
+    /// operator<()).
+    ///
+    /// \note   Complexity: O(Nlog(N)), where N = std::distance(first, last)
+    ///                     comparisons.
+    ///
+    /// A sequence is sorted with respect to a comparator \a comp and a
+    /// projection \a proj if for every iterator i pointing to the sequence and
+    /// every non-negative integer n such that i + n is a valid iterator
+    /// pointing to an element of the sequence, and
+    /// INVOKE(comp, INVOKE(proj, *(i + n)), INVOKE(proj, *i)) == false.
+    ///
+    /// \tparam RandomIt    The type of the source iterators used (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     random iterator.
+    /// \tparam Sent        The type of the source sentinel (deduced). This
+    ///                     sentinel type must be a sentinel for RandomIt.
+    /// \tparam Comp        The type of the function/function object to use
+    ///                     (deduced).
+    /// \tparam Proj        The type of an optional projection function. This
+    ///                     defaults to \a util::projection_identity
+    ///
+    /// \param first        Refers to the beginning of the sequence of elements
+    ///                     the algorithm will be applied to.
+    /// \param last         Refers to sentinel value denoting the end of the
+    ///                     sequence of elements the algorithm will be applied.
+    /// \param comp         comp is a callable object. The return value of the
+    ///                     INVOKE operation applied to an object of type Comp,
+    ///                     when contextually converted to bool, yields true if
+    ///                     the first argument of the call is less than the
+    ///                     second, and false otherwise. It is assumed that comp
+    ///                     will not apply any non-constant function through the
+    ///                     dereferenced iterator.
+    /// \param proj         Specifies the function (or function object) which
+    ///                     will be invoked for each pair of elements as a
+    ///                     projection operation before the actual predicate
+    ///                     \a comp is invoked.
+    ///
+    /// \a comp has to induce a strict weak ordering on the values.
+    ///
+    /// The assignments in the parallel \a stable_sort algorithm invoked without
+    /// an execution policy object execute in sequential order in the
+    /// calling thread.
+    ///
+    /// \returns  The \a stable_sort algorithm returns \a RandomIt.
+    ///           The algorithm returns an iterator pointing to the first
+    ///           element after the last element in the input sequence.
+    ///
+    template <typename RandomIt, typename Sent, typename Comp, typename Proj>
+    RandomIt stable_sort(RandomIt first, Sent last, Comp&& comp, Proj&& proj);
 
-namespace hpx { namespace parallel { inline namespace rangev1 {
+    ///////////////////////////////////////////////////////////////////////////
+    /// Sorts the elements in the range [first, last) in ascending order. The
+    /// relative order of equal elements is preserved. The function
+    /// uses the given comparison function object comp (defaults to using
+    /// operator<()).
+    ///
+    /// \note   Complexity: O(Nlog(N)), where N = std::distance(first, last)
+    ///                     comparisons.
+    ///
+    /// A sequence is sorted with respect to a comparator \a comp and a
+    /// projection \a proj if for every iterator i pointing to the sequence and
+    /// every non-negative integer n such that i + n is a valid iterator
+    /// pointing to an element of the sequence, and
+    /// INVOKE(comp, INVOKE(proj, *(i + n)), INVOKE(proj, *i)) == false.
+    ///
+    /// \tparam ExPolicy    The type of the execution policy to use (deduced).
+    ///                     It describes the manner in which the execution
+    ///                     of the algorithm may be parallelized and the manner
+    ///                     in which it executes the assignments.
+    /// \tparam RandomIt    The type of the source iterators used (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     random iterator.
+    /// \tparam Sent        The type of the source sentinel (deduced). This
+    ///                     sentinel type must be a sentinel for RandomIt.
+    /// \tparam Comp        The type of the function/function object to use
+    ///                     (deduced).
+    /// \tparam Proj        The type of an optional projection function. This
+    ///                     defaults to \a util::projection_identity
+    ///
+    /// \param policy       The execution policy to use for the scheduling of
+    ///                     the iterations.
+    /// \param first        Refers to the beginning of the sequence of elements
+    ///                     the algorithm will be applied to.
+    /// \param last         Refers to sentinel value denoting the end of the
+    ///                     sequence of elements the algorithm will be applied.
+    /// \param comp         comp is a callable object. The return value of the
+    ///                     INVOKE operation applied to an object of type Comp,
+    ///                     when contextually converted to bool, yields true if
+    ///                     the first argument of the call is less than the
+    ///                     second, and false otherwise. It is assumed that comp
+    ///                     will not apply any non-constant function through the
+    ///                     dereferenced iterator.
+    /// \param proj         Specifies the function (or function object) which
+    ///                     will be invoked for each pair of elements as a
+    ///                     projection operation before the actual predicate
+    ///                     \a comp is invoked.
+    ///
+    /// \a comp has to induce a strict weak ordering on the values.
+    ///
+    /// The application of function objects in parallel algorithm
+    /// invoked with an execution policy object of type
+    /// \a sequenced_policy execute in sequential order in the
+    /// calling thread.
+    ///
+    /// The application of function objects in parallel algorithm
+    /// invoked with an execution policy object of type
+    /// \a parallel_policy or \a parallel_task_policy are
+    /// permitted to execute in an unordered fashion in unspecified
+    /// threads, and indeterminately sequenced within each thread.
+    ///
+    /// \returns  The \a stable_sort algorithm returns a
+    ///           \a hpx::future<RandomIt> if the execution policy is of
+    ///           type
+    ///           \a sequenced_task_policy or
+    ///           \a parallel_task_policy and returns \a RandomIt
+    ///           otherwise.
+    ///           The algorithm returns an iterator pointing to the first
+    ///           element after the last element in the input sequence.
+    ///
+    template <typename ExPolicy, typename RandomIt, typename Sent,
+        typename Comp, typename Proj>
+    typename parallel::util::detail::algorithm_result<ExPolicy,
+        RandomIt>::type
+    stable_sort(ExPolicy&& policy, RandomIt first, Sent last, Comp&& comp,
+        Proj&& proj);
 
+    ///////////////////////////////////////////////////////////////////////////
+    /// Sorts the elements in the range [first, last) in ascending order. The
+    /// relative order of equal elements is preserved. The function
+    /// uses the given comparison function object comp (defaults to using
+    /// operator<()).
+    ///
+    /// \note   Complexity: O(Nlog(N)), where N = std::distance(first, last)
+    ///                     comparisons.
+    ///
+    /// A sequence is sorted with respect to a comparator \a comp and a
+    /// projection \a proj if for every iterator i pointing to the sequence and
+    /// every non-negative integer n such that i + n is a valid iterator
+    /// pointing to an element of the sequence, and
+    /// INVOKE(comp, INVOKE(proj, *(i + n)), INVOKE(proj, *i)) == false.
+    ///
+    /// \tparam Rng         The type of the source range used (deduced).
+    ///                     The iterators extracted from this range type must
+    ///                     meet the requirements of an input iterator.
+    /// \tparam Comp        The type of the function/function object to use
+    ///                     (deduced).
+    /// \tparam Proj        The type of an optional projection function. This
+    ///                     defaults to \a util::projection_identity
+    ///
+    /// \param rng          Refers to the sequence of elements the algorithm
+    ///                     will be applied to.
+    /// \param comp         comp is a callable object. The return value of the
+    ///                     INVOKE operation applied to an object of type Comp,
+    ///                     when contextually converted to bool, yields true if
+    ///                     the first argument of the call is less than the
+    ///                     second, and false otherwise. It is assumed that comp
+    ///                     will not apply any non-constant function through the
+    ///                     dereferenced iterator.
+    /// \param proj         Specifies the function (or function object) which
+    ///                     will be invoked for each pair of elements as a
+    ///                     projection operation before the actual predicate
+    ///                     \a comp is invoked.
+    ///
+    /// \a comp has to induce a strict weak ordering on the values.
+    ///
+    /// The assignments in the parallel \a stable_sort algorithm invoked without
+    /// an execution policy object execute in sequential order in the
+    /// calling thread.
+    ///
+    /// \returns  The \a stable_sort algorithm returns \a
+    ///           typename hpx::traits::range_iterator<Rng>::type.
+    ///           It returns \a last.
+    template <typename Rng, typename Comp, typename Proj>
+    typename hpx::traits::range_iterator<Rng>::type
+    stable_sort(Rng&& rng, Compare&& comp, Proj&& proj);
+
+    ///////////////////////////////////////////////////////////////////////////
     /// Sorts the elements in the range [first, last) in ascending order. The
     /// relative order of equal elements is preserved. The function
     /// uses the given comparison function object comp (defaults to using
@@ -78,35 +251,205 @@ namespace hpx { namespace parallel { inline namespace rangev1 {
     /// threads, and indeterminately sequenced within each thread.
     ///
     /// \returns  The \a stable_sort algorithm returns a
-    ///           \a hpx::future<RandomIt> if the execution policy is of
-    ///           type
+    ///           \a hpx::future<typename hpx::traits::range_iterator<Rng>
+    ///           ::type> if the execution policy is of type
     ///           \a sequenced_task_policy or
-    ///           \a parallel_task_policy and returns \a RandomIt
+    ///           \a parallel_task_policy and returns \a
+    ///           typename hpx::traits::range_iterator<Rng>::type
     ///           otherwise.
-    ///           The algorithm returns an iterator pointing to the first
-    ///           element after the last element in the input sequence.
-    //-----------------------------------------------------------------------------
+    ///           It returns \a last.
+    ///
+    template <typename ExPolicy, typename Rng, typename Pred, typename Proj>
+    typename util::detail::algorithm_result<ExPolicy,
+        typename hpx::traits::range_iterator<Rng>::type>::type
+    stable_sort(ExPolicy&& policy, Rng&& rng, Comp&& comp, Proj&&);
+
+    // clang-format on
+}}    // namespace hpx::ranges
+
+#else
+
+#include <hpx/config.hpp>
+#include <hpx/concepts/concepts.hpp>
+#include <hpx/iterator_support/range.hpp>
+#include <hpx/iterator_support/traits/is_range.hpp>
+
+#include <hpx/algorithms/traits/projected_range.hpp>
+#include <hpx/parallel/algorithms/stable_sort.hpp>
+#include <hpx/parallel/util/projection_identity.hpp>
+
+#include <type_traits>
+#include <utility>
+
+namespace hpx { namespace parallel { inline namespace rangev1 {
+
     // clang-format off
     template <typename ExPolicy, typename Rng,
         typename Compare = v1::detail::less,
         typename Proj = util::projection_identity,
         HPX_CONCEPT_REQUIRES_(
             hpx::is_execution_policy<ExPolicy>::value &&
-            hpx::traits::is_range<Rng>::value&&
-            traits::is_projected_range<Proj, Rng>::value&&
+            hpx::traits::is_range<Rng>::value &&
+            traits::is_projected_range<Proj, Rng>::value &&
             traits::is_indirect_callable<ExPolicy, Compare,
                 traits::projected_range<Proj, Rng>,
                 traits::projected_range<Proj, Rng>
             >::value
         )>
     // clang-format on
-    typename util::detail::algorithm_result<ExPolicy,
+    HPX_DEPRECATED_V(1, 8,
+        "hpx::parallel::stable_sort is deprecated, use hpx::stable_sort "
+        "instead") typename util::detail::algorithm_result<ExPolicy,
         typename hpx::traits::range_iterator<Rng>::type>::type
-    stable_sort(ExPolicy&& policy, Rng&& rng, Compare&& comp = Compare(),
-        Proj&& proj = Proj())
+        stable_sort(ExPolicy&& policy, Rng&& rng, Compare&& comp = Compare(),
+            Proj&& proj = Proj())
     {
-        return v1::stable_sort(std::forward<ExPolicy>(policy),
-            hpx::util::begin(rng), hpx::util::end(rng),
-            std::forward<Compare>(comp), std::forward<Proj>(proj));
+        using iterator_type = typename hpx::traits::range_iterator<Rng>::type;
+
+        static_assert(hpx::traits::is_random_access_iterator_v<iterator_type>,
+            "Requires a random access iterator.");
+
+#if defined(HPX_GCC_VERSION) && HPX_GCC_VERSION >= 100000
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
+        return detail::stable_sort<iterator_type>().call(
+            std::forward<ExPolicy>(policy), hpx::util::begin(rng),
+            hpx::util::end(rng), std::forward<Compare>(comp),
+            std::forward<Proj>(proj));
+#if defined(HPX_GCC_VERSION) && HPX_GCC_VERSION >= 100000
+#pragma GCC diagnostic pop
+#endif
     }
 }}}    // namespace hpx::parallel::rangev1
+
+namespace hpx { namespace ranges {
+    ///////////////////////////////////////////////////////////////////////////
+    // DPO for hpx::ranges::stable_sort
+    HPX_INLINE_CONSTEXPR_VARIABLE struct stable_sort_t final
+      : hpx::functional::tag_fallback<stable_sort_t>
+    {
+    private:
+        // clang-format off
+        template <typename RandomIt, typename Sent,
+            typename Comp = ranges::less,
+            typename Proj = parallel::util::projection_identity,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::traits::is_iterator<RandomIt>::value &&
+                hpx::traits::is_sentinel_for<Sent, RandomIt>::value &&
+                parallel::traits::is_projected<Proj, RandomIt>::value &&
+                parallel::traits::is_indirect_callable<
+                    hpx::execution::sequenced_policy, Comp,
+                    parallel::traits::projected<Proj, RandomIt>,
+                    parallel::traits::projected<Proj, RandomIt>
+                >::value
+            )>
+        // clang-format on
+        friend RandomIt tag_fallback_dispatch(hpx::ranges::stable_sort_t,
+            RandomIt first, Sent last, Comp&& comp = Comp(),
+            Proj&& proj = Proj())
+        {
+            static_assert(
+                hpx::traits::is_random_access_iterator<RandomIt>::value,
+                "Requires a random access iterator.");
+
+            return hpx::parallel::v1::detail::stable_sort<RandomIt>().call(
+                hpx::execution::seq, first, last, std::forward<Comp>(comp),
+                std::forward<Proj>(proj));
+        }
+
+        // clang-format off
+        template <typename ExPolicy, typename RandomIt, typename Sent,
+            typename Comp = ranges::less,
+            typename Proj = parallel::util::projection_identity,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::is_execution_policy<ExPolicy>::value &&
+                hpx::traits::is_iterator<RandomIt>::value &&
+                hpx::traits::is_sentinel_for<Sent, RandomIt>::value &&
+                parallel::traits::is_projected<Proj, RandomIt>::value &&
+                parallel::traits::is_indirect_callable<ExPolicy, Comp,
+                    parallel::traits::projected<Proj, RandomIt>,
+                    parallel::traits::projected<Proj, RandomIt>
+                >::value
+            )>
+        // clang-format on
+        friend typename parallel::util::detail::algorithm_result<ExPolicy,
+            RandomIt>::type
+        tag_fallback_dispatch(hpx::ranges::stable_sort_t, ExPolicy&& policy,
+            RandomIt first, Sent last, Comp&& comp = Comp(),
+            Proj&& proj = Proj())
+        {
+            static_assert(
+                hpx::traits::is_random_access_iterator<RandomIt>::value,
+                "Requires a random access iterator.");
+
+            return hpx::parallel::v1::detail::stable_sort<RandomIt>().call(
+                std::forward<ExPolicy>(policy), first, last,
+                std::forward<Comp>(comp), std::forward<Proj>(proj));
+        }
+
+        // clang-format off
+        template <typename Rng,
+            typename Compare = ranges::less,
+            typename Proj = parallel::util::projection_identity,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::traits::is_range<Rng>::value &&
+                parallel::traits::is_projected_range<Proj, Rng>::value &&
+                parallel::traits::is_indirect_callable<
+                    hpx::execution::sequenced_policy, Compare,
+                    parallel::traits::projected_range<Proj, Rng>,
+                    parallel::traits::projected_range<Proj, Rng>
+                >::value
+            )>
+        // clang-format on
+        friend typename hpx::traits::range_iterator<Rng>::type
+        tag_fallback_dispatch(hpx::ranges::stable_sort_t, Rng&& rng,
+            Compare&& comp = Compare(), Proj&& proj = Proj())
+        {
+            using iterator_type =
+                typename hpx::traits::range_traits<Rng>::iterator_type;
+
+            static_assert(
+                hpx::traits::is_random_access_iterator<iterator_type>::value,
+                "Requires a random access iterator.");
+
+            return hpx::parallel::v1::detail::stable_sort<iterator_type>().call(
+                hpx::execution::seq, hpx::util::begin(rng), hpx::util::end(rng),
+                std::forward<Compare>(comp), std::forward<Proj>(proj));
+        }
+
+        // clang-format off
+        template <typename ExPolicy, typename Rng,
+            typename Compare = ranges::less,
+            typename Proj = parallel::util::projection_identity,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::is_execution_policy<ExPolicy>::value &&
+                hpx::traits::is_range<Rng>::value &&
+                parallel::traits::is_projected_range<Proj, Rng>::value &&
+                parallel::traits::is_indirect_callable<ExPolicy, Compare,
+                    parallel::traits::projected_range<Proj, Rng>,
+                    parallel::traits::projected_range<Proj, Rng>
+                >::value
+            )>
+        // clang-format on
+        friend typename parallel::util::detail::algorithm_result<ExPolicy,
+            typename hpx::traits::range_iterator<Rng>::type>::type
+        tag_fallback_dispatch(hpx::ranges::stable_sort_t, ExPolicy&& policy,
+            Rng&& rng, Compare&& comp = Compare(), Proj&& proj = Proj())
+        {
+            using iterator_type =
+                typename hpx::traits::range_traits<Rng>::iterator_type;
+
+            static_assert(
+                hpx::traits::is_random_access_iterator<iterator_type>::value,
+                "Requires a random access iterator.");
+
+            return hpx::parallel::v1::detail::stable_sort<iterator_type>().call(
+                std::forward<ExPolicy>(policy), hpx::util::begin(rng),
+                hpx::util::end(rng), std::forward<Compare>(comp),
+                std::forward<Proj>(proj));
+        }
+    } stable_sort{};
+}}    // namespace hpx::ranges
+
+#endif

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/unique.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/unique.hpp
@@ -9,23 +9,204 @@
 
 #pragma once
 
-#include <hpx/config.hpp>
-#include <hpx/concepts/concepts.hpp>
-#include <hpx/execution/algorithms/detail/predicates.hpp>
-#include <hpx/iterator_support/iterator_range.hpp>
-#include <hpx/iterator_support/range.hpp>
-#include <hpx/iterator_support/traits/is_iterator.hpp>
-#include <hpx/iterator_support/traits/is_range.hpp>
-#include <hpx/parallel/util/tagged_pair.hpp>
+#if defined(DOXYGEN)
 
-#include <hpx/algorithms/traits/projected.hpp>
-#include <hpx/algorithms/traits/projected_range.hpp>
-#include <hpx/parallel/algorithms/unique.hpp>
+namespace hpx { namespace ranges {
+    // clang-format off
 
-#include <type_traits>
-#include <utility>
+    ///////////////////////////////////////////////////////////////////////////
+    /// Eliminates all but the first element from every consecutive group of
+    /// equivalent elements from the range [first, last) and returns a
+    /// past-the-end iterator for the new logical end of the range.
+    ///
+    /// \note   Complexity: Performs not more than \a last - \a first
+    ///         assignments, exactly \a last - \a first - 1 applications of
+    ///         the predicate \a pred and no more than twice as many
+    ///         applications of the projection \a proj.
+    ///
+    /// \tparam FwdIter     The type of the source iterators used (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     forward iterator.
+    /// \tparam Sent        The type of the source sentinel (deduced). This
+    ///                     sentinel type must be a sentinel for FwdIter.
+    /// \tparam Pred        The type of the function/function object to use
+    ///                     (deduced). Unlike its sequential form, the parallel
+    ///                     overload of \a unique requires \a Pred to meet the
+    ///                     requirements of \a CopyConstructible. This defaults
+    ///                     to std::equal_to<>
+    /// \tparam Proj        The type of an optional projection function. This
+    ///                     defaults to \a util::projection_identity
+    ///
+    /// \param first        Refers to the beginning of the sequence of elements
+    ///                     the algorithm will be applied to.
+    /// \param last         Refers to sentinel value denoting the end of the
+    ///                     sequence of elements the algorithm will be applied.
+    /// \param pred         Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements in the
+    ///                     sequence specified by [first, last). This is an
+    ///                     binary predicate which returns \a true for the
+    ///                     required elements. The signature of this predicate
+    ///                     should be equivalent to:
+    ///                     \code
+    ///                     bool pred(const Type1 &a, const Type2 &b);
+    ///                     \endcode \n
+    ///                     The signature does not need to have const&, but
+    ///                     the function must not modify the objects passed to
+    ///                     it. The types \a Type1 and \a Type2 must be
+    ///                     such that objects of types \a FwdIter can be
+    ///                     dereferenced and then implicitly converted to
+    ///                     both \a Type1 and \a Type2
+    /// \param proj         Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements as a
+    ///                     projection operation before the actual predicate
+    ///                     \a is invoked.
+    ///
+    /// The assignments in the parallel \a unique algorithm invoked without
+    /// an execution policy object execute in sequential order in the
+    /// calling thread.
+    ///
+    /// \returns  The \a unique algorithm returns \a subrange_t<FwdIter, Sent>.
+    ///           The \a unique algorithm returns an object {ret, last},
+    ///           where ret is a past-the-end iterator for a new
+    ///           subrange.
+    ///
+    template <typename FwdIter, typename Sent, typename Pred, typename Proj>
+    subrange_t<FwdIter, Sent> unique(FwdIter first, Sent last, Pred&& pred,
+        Proj&& proj);
 
-namespace hpx { namespace parallel { inline namespace v1 {
+    ///////////////////////////////////////////////////////////////////////////
+    /// Eliminates all but the first element from every consecutive group of
+    /// equivalent elements from the range [first, last) and returns a
+    /// past-the-end iterator for the new logical end of the range.
+    ///
+    /// \note   Complexity: Performs not more than \a last - \a first
+    ///         assignments, exactly \a last - \a first - 1 applications of
+    ///         the predicate \a pred and no more than twice as many
+    ///         applications of the projection \a proj.
+    ///
+    /// \tparam ExPolicy    The type of the execution policy to use (deduced).
+    ///                     It describes the manner in which the execution
+    ///                     of the algorithm may be parallelized and the manner
+    ///                     in which it executes the assignments.
+    /// \tparam FwdIter     The type of the source iterators used (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     forward iterator.
+    /// \tparam Sent        The type of the source sentinel (deduced). This
+    ///                     sentinel type must be a sentinel for FwdIter.
+    /// \tparam Pred        The type of the function/function object to use
+    ///                     (deduced). Unlike its sequential form, the parallel
+    ///                     overload of \a unique requires \a Pred to meet the
+    ///                     requirements of \a CopyConstructible. This defaults
+    ///                     to std::equal_to<>
+    /// \tparam Proj        The type of an optional projection function. This
+    ///                     defaults to \a util::projection_identity
+    ///
+    /// \param policy       The execution policy to use for the scheduling of
+    ///                     the iterations.
+    /// \param first        Refers to the beginning of the sequence of elements
+    ///                     the algorithm will be applied to.
+    /// \param last         Refers to sentinel value denoting the end of the
+    ///                     sequence of elements the algorithm will be applied.
+    /// \param pred         Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements in the
+    ///                     sequence specified by [first, last). This is an
+    ///                     binary predicate which returns \a true for the
+    ///                     required elements. The signature of this predicate
+    ///                     should be equivalent to:
+    ///                     \code
+    ///                     bool pred(const Type1 &a, const Type2 &b);
+    ///                     \endcode \n
+    ///                     The signature does not need to have const&, but
+    ///                     the function must not modify the objects passed to
+    ///                     it. The types \a Type1 and \a Type2 must be
+    ///                     such that objects of types \a FwdIter can be
+    ///                     dereferenced and then implicitly converted to
+    ///                     both \a Type1 and \a Type2
+    /// \param proj         Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements as a
+    ///                     projection operation before the actual predicate
+    ///                     \a is invoked.
+    ///
+    /// The assignments in the parallel \a unique algorithm invoked with
+    /// an execution policy object of type \a sequenced_policy
+    /// execute in sequential order in the calling thread.
+    ///
+    /// The assignments in the parallel \a unique algorithm invoked with
+    /// an execution policy object of type \a parallel_policy or
+    /// \a parallel_task_policy are permitted to execute in an unordered
+    /// fashion in unspecified threads, and indeterminately sequenced
+    /// within each thread.
+    ///
+    /// \returns  The \a unique algorithm returns \a subrange_t<FwdIter, Sent>.
+    ///           The \a unique algorithm returns an object {ret, last},
+    ///           where ret is a past-the-end iterator for a new
+    ///           subrange.
+    ///
+    template <typename ExPolicy, typename FwdIter, typename Sent, typename Pred,
+        typename Proj>
+    typename parallel::util::detail::algorithm_result<ExPolicy,
+        subrange_t<FwdIter, Sent>>::type
+    unique(ExPolicy&& policy, FwdIter first, Sent last, Pred&& pred,
+        Proj&& proj);
+
+    ///////////////////////////////////////////////////////////////////////////
+    /// Eliminates all but the first element from every consecutive group of
+    /// equivalent elements from the range \a rng and returns a
+    /// past-the-end iterator for the new logical end of the range.
+    ///
+    /// \note   Complexity: Performs not more than N assignments,
+    ///         exactly N - 1 applications of the predicate \a pred and
+    ///         no more than twice as many applications of the projection
+    ///         \a proj, where N = std::distance(begin(rng), end(rng)).
+    ///
+    /// \tparam Rng         The type of the source range used (deduced).
+    ///                     The iterators extracted from this range type must
+    ///                     meet the requirements of an forward iterator.
+    /// \tparam Pred        The type of the function/function object to use
+    ///                     (deduced). Unlike its sequential form, the parallel
+    ///                     overload of \a unique requires \a Pred to meet the
+    ///                     requirements of \a CopyConstructible. This defaults
+    ///                     to std::equal_to<>
+    /// \tparam Proj        The type of an optional projection function. This
+    ///                     defaults to \a util::projection_identity
+    ///
+    /// \param rng          Refers to the sequence of elements the algorithm
+    ///                     will be applied to.
+    /// \param pred         Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements in the
+    ///                     sequence specified by [first, last). This is an
+    ///                     binary predicate which returns \a true for the
+    ///                     required elements. The signature of this predicate
+    ///                     should be equivalent to:
+    ///                     \code
+    ///                     bool pred(const Type &a, const Type &b);
+    ///                     \endcode \n
+    ///                     The signature does not need to have const&, but
+    ///                     the function must not modify the objects passed to
+    ///                     it. The type \a Type must be such that an object of
+    ///                     type \a FwdIter1 can be dereferenced and then
+    ///                     implicitly converted to \a Type.
+    /// \param proj         Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements as a
+    ///                     projection operation before the actual predicate
+    ///                     \a is invoked.
+    ///
+    /// The assignments in the parallel \a unique algorithm invoked without
+    /// an execution policy object execute in sequential order in the
+    /// calling thread.
+    ///
+    /// \returns  The \a unique algorithm returns
+    ///           \a subrange_t<typename hpx::traits::range_iterator<Rng>
+    ///           ::type>.
+    ///           The \a unique algorithm returns an object {ret, last},
+    ///           where ret is a past-the-end iterator for a new
+    ///           subrange.
+    ///
+    template <typename Rng, typename Pred, typename Proj>
+    subrange_t<typename hpx::traits::range_iterator<Rng>::type>
+    unique(Rng&& rng, Pred&& pred, Proj&& proj);
+
+    ///////////////////////////////////////////////////////////////////////////
     /// Eliminates all but the first element from every consecutive group of
     /// equivalent elements from the range \a rng and returns a
     /// past-the-end iterator for the new logical end of the range.
@@ -83,39 +264,238 @@ namespace hpx { namespace parallel { inline namespace v1 {
     /// fashion in unspecified threads, and indeterminately sequenced
     /// within each thread.
     ///
-    /// \returns  The \a unique algorithm returns a \a hpx::future<FwdIter>
-    ///           if the execution policy is of type
-    ///           \a sequenced_task_policy or \a parallel_task_policy and
-    ///           returns \a FwdIter otherwise.
-    ///           The \a unique algorithm returns the iterator to the new end
-    ///           of the range.
+    /// \returns  The \a unique algorithm returns a \a hpx::future
+    ///           <subrange_t<typename hpx::traits::range_iterator<Rng>::type>>
+    ///           if the execution policy is of type \a sequenced_task_policy
+    ///           or \a parallel_task_policy and returns
+    ///           \a subrange_t<typename hpx::traits::range_iterator<Rng>
+    ///           ::type>. otherwise.
+    ///           The \a unique algorithm returns an object {ret, last},
+    ///           where ret is a past-the-end iterator for a new
+    ///           subrange.
     ///
-    template <typename ExPolicy, typename Rng, typename Pred = detail::equal_to,
-        typename Proj = util::projection_identity,
-        HPX_CONCEPT_REQUIRES_(hpx::is_execution_policy<ExPolicy>::value&&
-                hpx::traits::is_range<Rng>::value&& traits::is_projected_range<
-                    Proj, Rng>::value&& traits::is_indirect_callable<ExPolicy,
-                    Pred, traits::projected_range<Proj, Rng>,
-                    traits::projected_range<Proj, Rng>>::value)>
+    template <typename ExPolicy, typename Rng, typename Pred, typename Proj>
     typename util::detail::algorithm_result<ExPolicy,
-        typename hpx::traits::range_iterator<Rng>::type>::type
-        HPX_DEPRECATED_V(1, 8,
-            "hpx::parallel::unique is deprecated, use hpx::unique instead")
-            unique(ExPolicy&& policy, Rng&& rng, Pred&& pred = Pred(),
-                Proj&& proj = Proj())
-    {
-#if defined(HPX_GCC_VERSION) && HPX_GCC_VERSION >= 100000
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-#endif
-        return unique(std::forward<ExPolicy>(policy), hpx::util::begin(rng),
-            hpx::util::end(rng), std::forward<Pred>(pred),
-            std::forward<Proj>(proj));
-#if defined(HPX_GCC_VERSION) && HPX_GCC_VERSION >= 100000
-#pragma GCC diagnostic pop
-#endif
-    }
+    subrange_t<typename hpx::traits::range_iterator<Rng>::type>::type
+    unique(ExPolicy&& policy, Rng&& rng, Pred&& pred, Proj&& proj);
 
+    ///////////////////////////////////////////////////////////////////////////
+    /// Copies the elements from the range [first, last),
+    /// to another range beginning at \a dest in such a way that
+    /// there are no consecutive equal elements. Only the first element of
+    /// each group of equal elements is copied.
+    ///
+    /// \note   Complexity: Performs not more than \a last - \a first
+    ///         assignments, exactly \a last - \a first - 1 applications of
+    ///         the predicate \a pred and no more than twice as many
+    ///         applications of the projection \a proj
+    ///
+    /// \tparam InIter      The type of the source iterators used (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     input iterator.
+    /// \tparam Sent        The type of the source sentinel (deduced). This
+    ///                     sentinel type must be a sentinel for InIter.
+    /// \tparam OutIter     The type of the iterator representing the
+    ///                     destination range (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     output iterator.
+    /// \tparam Pred        The type of the function/function object to use
+    ///                     (deduced). Unlike its sequential form, the parallel
+    ///                     overload of \a unique_copy requires \a Pred to meet the
+    ///                     requirements of \a CopyConstructible. This defaults
+    ///                     to std::equal_to<>
+    /// \tparam Proj        The type of an optional projection function. This
+    ///                     defaults to \a util::projection_identity
+    ///
+    /// \param first        Refers to the beginning of the sequence of elements
+    ///                     the algorithm will be applied to.
+    /// \param last         Refers to sentinel value denoting the end of the
+    ///                     sequence of elements the algorithm will be applied.
+    /// \param dest         Refers to the beginning of the destination range.
+    /// \param pred         Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements in the
+    ///                     sequence specified by [first, last). This is an
+    ///                     binary predicate which returns \a true for the
+    ///                     required elements. The signature of this predicate
+    ///                     should be equivalent to:
+    ///                     \code
+    ///                     bool pred(const Type &a, const Type &b);
+    ///                     \endcode \n
+    ///                     The signature does not need to have const&, but
+    ///                     the function must not modify the objects passed to
+    ///                     it. The type \a Type must be such that an object of
+    ///                     type \a FwdIter1 can be dereferenced and then
+    ///                     implicitly converted to \a Type.
+    /// \param proj         Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements as a
+    ///                     projection operation before the actual predicate
+    ///                     \a is invoked.
+    ///
+    /// The assignments in the parallel \a unique_copy algorithm invoked
+    /// without an execution policy object  will execute in sequential
+    /// order in the calling thread.
+    ///
+    /// \returns  The \a unique_copy algorithm returns a
+    ///           returns parallel::util::in_out_result<FwdIter, OutIter>.
+    ///           The \a unique_copy algorithm returns an in_out_result with
+    ///           the source iterator to one past the last element and out
+    ///           containing the destination iterator to the end of the
+    ///           \a dest range.
+    ///
+    template <typename InIter, typename Sent, typename OutIter,
+        typename Pred, typename Proj>
+    util::in_out_result<FwdIter, OutIter> unique(FwdIter first,
+        Sent last, OutIter dest, Pred&& pred, Proj&& proj);
+
+    ///////////////////////////////////////////////////////////////////////////
+    /// Copies the elements from the range [first, last),
+    /// to another range beginning at \a dest in such a way that
+    /// there are no consecutive equal elements. Only the first element of
+    /// each group of equal elements is copied.
+    ///
+    /// \note   Complexity: Performs not more than \a last - \a first
+    ///         assignments, exactly \a last - \a first - 1 applications of
+    ///         the predicate \a pred and no more than twice as many
+    ///         applications of the projection \a proj
+    ///
+    /// \tparam ExPolicy    The type of the execution policy to use (deduced).
+    ///                     It describes the manner in which the execution
+    ///                     of the algorithm may be parallelized and the manner
+    ///                     in which it executes the assignments.
+    /// \tparam FwdIter1    The type of the source iterators used (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     forward iterator.
+    /// \tparam Sent        The type of the source sentinel (deduced). This
+    ///                     sentinel type must be a sentinel for FwdIter1.
+    /// \tparam FwdIter2    The type of the iterator representing the
+    ///                     destination range (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     forward iterator.
+    /// \tparam Pred        The type of the function/function object to use
+    ///                     (deduced). Unlike its sequential form, the parallel
+    ///                     overload of \a unique_copy requires \a Pred to meet the
+    ///                     requirements of \a CopyConstructible. This defaults
+    ///                     to std::equal_to<>
+    /// \tparam Proj        The type of an optional projection function. This
+    ///                     defaults to \a util::projection_identity
+    ///
+    /// \param policy       The execution policy to use for the scheduling of
+    ///                     the iterations.
+    /// \param first        Refers to the beginning of the sequence of elements
+    ///                     the algorithm will be applied to.
+    /// \param last         Refers to sentinel value denoting the end of the
+    ///                     sequence of elements the algorithm will be applied.
+    /// \param dest         Refers to the beginning of the destination range.
+    /// \param pred         Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements in the
+    ///                     sequence specified by [first, last). This is an
+    ///                     binary predicate which returns \a true for the
+    ///                     required elements. The signature of this predicate
+    ///                     should be equivalent to:
+    ///                     \code
+    ///                     bool pred(const Type &a, const Type &b);
+    ///                     \endcode \n
+    ///                     The signature does not need to have const&, but
+    ///                     the function must not modify the objects passed to
+    ///                     it. The type \a Type must be such that an object of
+    ///                     type \a FwdIter1 can be dereferenced and then
+    ///                     implicitly converted to \a Type.
+    /// \param proj         Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements as a
+    ///                     projection operation before the actual predicate
+    ///                     \a is invoked.
+    ///
+    /// The assignments in the parallel \a unique_copy algorithm invoked with
+    /// an execution policy object of type \a sequenced_policy
+    /// execute in sequential order in the calling thread.
+    ///
+    /// The assignments in the parallel \a unique_copy algorithm invoked with
+    /// an execution policy object of type \a parallel_policy or
+    /// \a parallel_task_policy are permitted to execute in an unordered
+    /// fashion in unspecified threads, and indeterminately sequenced
+    /// within each thread.
+    ///
+    /// \returns  The \a unique_copy algorithm returns areturns hpx::future<
+    ///           parallel::util::in_out_result<FwdIter1, FwdIter2>> if the
+    ///           execution policy is of type \a sequenced_task_policy or
+    ///           \a parallel_task_policy and returns \a 
+    ///           parallel::util::in_out_result<FwdIter1, FwdIter2> otherwise.
+    ///           The \a unique_copy algorithm returns an in_out_result with
+    ///           the source iterator to one past the last element and out
+    ///           containing the destination iterator to the end of the
+    ///           \a dest range.
+    ///
+    template <typename ExPolicy, typename FwdIter1, typename Sent,
+        typename FwdIter2, typename Pred, typename Proj>
+    typename parallel::util::detail::algorithm_result<ExPolicy,
+        util::in_out_result<FwdIter1, FwdIter2>>::type
+    unique_copy(ExPolicy&& policy, FwdIter1 first, Sent last,
+        FwdIter2 dest, Pred&& pred, Proj&& proj);
+
+    ///////////////////////////////////////////////////////////////////////////
+    /// Copies the elements from the range \a rng,
+    /// to another range beginning at \a dest in such a way that
+    /// there are no consecutive equal elements. Only the first element of
+    /// each group of equal elements is copied.
+    ///
+    /// \note   Complexity: Performs not more than N assignments,
+    ///         exactly N - 1 applications of the predicate \a pred,
+    ///         where N = std::distance(begin(rng), end(rng)).
+    ///
+    /// \tparam Rng         The type of the source range used (deduced).
+    ///                     The iterators extracted from this range type must
+    ///                     meet the requirements of an forward iterator.
+    /// \tparam O           The type of the iterator representing the
+    ///                     destination range (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     forward iterator.
+    /// \tparam Pred        The type of the function/function object to use
+    ///                     (deduced). Unlike its sequential form, the parallel
+    ///                     overload of \a unique_copy requires \a Pred to meet the
+    ///                     requirements of \a CopyConstructible. This defaults
+    ///                     to std::equal_to<>
+    /// \tparam Proj        The type of an optional projection function. This
+    ///                     defaults to \a util::projection_identity
+    ///
+    /// \param rng          Refers to the sequence of elements the algorithm
+    ///                     will be applied to.
+    /// \param dest         Refers to the beginning of the destination range.
+    /// \param pred         Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements in the
+    ///                     sequence specified by the range \a rng. This is an
+    ///                     binary predicate which returns \a true for the
+    ///                     required elements. The signature of this predicate
+    ///                     should be equivalent to:
+    ///                     \code
+    ///                     bool pred(const Type &a, const Type &b);
+    ///                     \endcode \n
+    ///                     The signature does not need to have const&, but
+    ///                     the function must not modify the objects passed to
+    ///                     it. The type \a Type must be such that an object of
+    ///                     type \a FwdIter1 can be dereferenced and then
+    ///                     implicitly converted to \a Type.
+    /// \param proj         Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements as a
+    ///                     projection operation before the actual predicate
+    ///                     \a is invoked.
+    ///
+    /// The assignments in the parallel \a unique_copy algorithm invoked
+    /// without an execution policy object  will execute in sequential
+    /// order in the calling thread.
+    ///
+    /// \returns  The \a unique_copy algorithm returns \a
+    ///           parallel::util::in_out_result<
+    ///           typename hpx::traits::range_iterator<Rng>::type, O>.
+    ///           The \a unique_copy algorithm returns the pair of
+    ///           the source iterator to \a last, and
+    ///           the destination iterator to the end of the \a dest range.
+    ///
+    template <typename Rng, typename O, typename Pred, typename Proj>
+    parallel::util::in_out_result<
+        typename hpx::traits::range_iterator<Rng>::type, O>
+    unique_copy(Rng&& rng, O dest, Pred&& pred, Proj&& proj);
+
+    ///////////////////////////////////////////////////////////////////////////
     /// Copies the elements from the range \a rng,
     /// to another range beginning at \a dest in such a way that
     /// there are no consecutive equal elements. Only the first element of
@@ -132,7 +512,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
     /// \tparam Rng         The type of the source range used (deduced).
     ///                     The iterators extracted from this range type must
     ///                     meet the requirements of an forward iterator.
-    /// \tparam FwdIter2    The type of the iterator representing the
+    /// \tparam O           The type of the iterator representing the
     ///                     destination range (deduced).
     ///                     This iterator type must meet the requirements of an
     ///                     forward iterator.
@@ -179,16 +559,74 @@ namespace hpx { namespace parallel { inline namespace v1 {
     /// within each thread.
     ///
     /// \returns  The \a unique_copy algorithm returns a
-    ///           \a hpx::future<tagged_pair<tag::in(FwdIter1), tag::out(FwdIter2)> >
+    ///           \a hpx::future<parallel::util::in_out_result<
+    ///           typename hpx::traits::range_iterator<Rng>::type, O>>
     ///           if the execution policy is of type
     ///           \a sequenced_task_policy or
     ///           \a parallel_task_policy and
-    ///           returns \a tagged_pair<tag::in(FwdIter1), tag::out(FwdIter2)>
+    ///           returns \a parallel::util::in_out_result<
+    ///           typename hpx::traits::range_iterator<Rng>::type, O>
     ///           otherwise.
     ///           The \a unique_copy algorithm returns the pair of
     ///           the source iterator to \a last, and
     ///           the destination iterator to the end of the \a dest range.
     ///
+    template <typename InIter, typename Sent, typename OutIter,
+        typename Pred, typename Proj>
+    typename parallel::util::detail::algorithm_result<ExPolicy,
+        util::in_out_result<typename hpx::traits::range_iterator<Rng>::type,
+        O>>::type
+    unique_copy(ExPolicy&& policy, Rng&& rng, O dest,
+        Pred&& pred, Proj&& proj);
+
+    // clang-format on
+}}    // namespace hpx::ranges
+
+#else
+
+#include <hpx/config.hpp>
+#include <hpx/concepts/concepts.hpp>
+#include <hpx/execution/algorithms/detail/predicates.hpp>
+#include <hpx/iterator_support/iterator_range.hpp>
+#include <hpx/iterator_support/range.hpp>
+#include <hpx/iterator_support/traits/is_iterator.hpp>
+#include <hpx/iterator_support/traits/is_range.hpp>
+#include <hpx/parallel/util/tagged_pair.hpp>
+
+#include <hpx/algorithms/traits/projected.hpp>
+#include <hpx/algorithms/traits/projected_range.hpp>
+#include <hpx/parallel/algorithms/unique.hpp>
+
+#include <type_traits>
+#include <utility>
+
+namespace hpx { namespace parallel { inline namespace v1 {
+    template <typename ExPolicy, typename Rng, typename Pred = detail::equal_to,
+        typename Proj = util::projection_identity,
+        HPX_CONCEPT_REQUIRES_(hpx::is_execution_policy<ExPolicy>::value&&
+                hpx::traits::is_range<Rng>::value&& traits::is_projected_range<
+                    Proj, Rng>::value&& traits::is_indirect_callable<ExPolicy,
+                    Pred, traits::projected_range<Proj, Rng>,
+                    traits::projected_range<Proj, Rng>>::value)>
+    typename util::detail::algorithm_result<ExPolicy,
+        typename hpx::traits::range_iterator<Rng>::type>::type
+        HPX_DEPRECATED_V(1, 8,
+            "hpx::parallel::unique is deprecated, use hpx::unique instead")
+            unique(ExPolicy&& policy, Rng&& rng, Pred&& pred = Pred(),
+                Proj&& proj = Proj())
+    {
+#if defined(HPX_GCC_VERSION) && HPX_GCC_VERSION >= 100000
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
+        return unique(std::forward<ExPolicy>(policy), hpx::util::begin(rng),
+            hpx::util::end(rng), std::forward<Pred>(pred),
+            std::forward<Proj>(proj));
+#if defined(HPX_GCC_VERSION) && HPX_GCC_VERSION >= 100000
+#pragma GCC diagnostic pop
+#endif
+    }
+
     template <typename ExPolicy, typename Rng, typename FwdIter2,
         typename Pred = detail::equal_to,
         typename Proj = util::projection_identity,
@@ -500,3 +938,5 @@ namespace hpx { namespace ranges {
         }
     } unique_copy{};
 }}    // namespace hpx::ranges
+
+#endif

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/unique.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/unique.hpp
@@ -197,14 +197,14 @@ namespace hpx { namespace ranges {
     ///
     /// \returns  The \a unique algorithm returns
     ///           \a subrange_t<typename hpx::traits::range_iterator<Rng>
-    ///           ::type,typename hpx::traits::range_iterator<Rng>::type>.
+    ///           ::type,hpx::traits::range_iterator_t<Rng>>.
     ///           The \a unique algorithm returns an object {ret, last},
     ///           where ret is a past-the-end iterator for a new
     ///           subrange.
     ///
     template <typename Rng, typename Pred, typename Proj>
-    subrange_t<typename hpx::traits::range_iterator<Rng>::type,
-        typename hpx::traits::range_iterator<Rng>::type>
+    subrange_t<hpx::traits::range_iterator_t<Rng>,
+        hpx::traits::range_iterator_t<Rng>>
     unique(Rng&& rng, Pred&& pred, Proj&& proj);
 
     ///////////////////////////////////////////////////////////////////////////
@@ -266,12 +266,12 @@ namespace hpx { namespace ranges {
     /// within each thread.
     ///
     /// \returns  The \a unique algorithm returns a \a hpx::future
-    ///           <subrange_t<typename hpx::traits::range_iterator<Rng>::type,
-    ///           typename hpx::traits::range_iterator<Rng>::type>>
+    ///           <subrange_t<hpx::traits::range_iterator_t<Rng>,
+    ///           hpx::traits::range_iterator_t<Rng>>>
     ///           if the execution policy is of type \a sequenced_task_policy
     ///           or \a parallel_task_policy and returns
     ///           \a subrange_t<typename hpx::traits::range_iterator<Rng>
-    ///           ::type,typename hpx::traits::range_iterator<Rng>::type>.
+    ///           ::type,hpx::traits::range_iterator_t<Rng>>.
     ///           otherwise.
     ///           The \a unique algorithm returns an object {ret, last},
     ///           where ret is a past-the-end iterator for a new
@@ -279,8 +279,8 @@ namespace hpx { namespace ranges {
     ///
     template <typename ExPolicy, typename Rng, typename Pred, typename Proj>
     typename util::detail::algorithm_result<ExPolicy,
-    subrange_t<typename hpx::traits::range_iterator<Rng>::type,
-    typename hpx::traits::range_iterator<Rng>::type>::type
+    subrange_t<hpx::traits::range_iterator_t<Rng>,
+    hpx::traits::range_iterator_t<Rng>>::type
     unique(ExPolicy&& policy, Rng&& rng, Pred&& pred, Proj&& proj);
 
     ///////////////////////////////////////////////////////////////////////////
@@ -489,14 +489,14 @@ namespace hpx { namespace ranges {
     ///
     /// \returns  The \a unique_copy algorithm returns \a
     ///           parallel::util::in_out_result<
-    ///           typename hpx::traits::range_iterator<Rng>::type, O>.
+    ///           hpx::traits::range_iterator_t<Rng>, O>.
     ///           The \a unique_copy algorithm returns the pair of
     ///           the source iterator to \a last, and
     ///           the destination iterator to the end of the \a dest range.
     ///
     template <typename Rng, typename O, typename Pred, typename Proj>
     parallel::util::in_out_result<
-        typename hpx::traits::range_iterator<Rng>::type, O>
+        hpx::traits::range_iterator_t<Rng>, O>
     unique_copy(Rng&& rng, O dest, Pred&& pred, Proj&& proj);
 
     ///////////////////////////////////////////////////////////////////////////
@@ -564,12 +564,12 @@ namespace hpx { namespace ranges {
     ///
     /// \returns  The \a unique_copy algorithm returns a
     ///           \a hpx::future<parallel::util::in_out_result<
-    ///           typename hpx::traits::range_iterator<Rng>::type, O>>
+    ///           hpx::traits::range_iterator_t<Rng>, O>>
     ///           if the execution policy is of type
     ///           \a sequenced_task_policy or
     ///           \a parallel_task_policy and
     ///           returns \a parallel::util::in_out_result<
-    ///           typename hpx::traits::range_iterator<Rng>::type, O>
+    ///           hpx::traits::range_iterator_t<Rng>, O>
     ///           otherwise.
     ///           The \a unique_copy algorithm returns the pair of
     ///           the source iterator to \a last, and
@@ -578,7 +578,7 @@ namespace hpx { namespace ranges {
     template <typename InIter, typename Sent, typename OutIter,
         typename Pred, typename Proj>
     typename parallel::util::detail::algorithm_result<ExPolicy,
-        util::in_out_result<typename hpx::traits::range_iterator<Rng>::type,
+        util::in_out_result<hpx::traits::range_iterator_t<Rng>,
         O>>::type
     unique_copy(ExPolicy&& policy, Rng&& rng, O dest,
         Pred&& pred, Proj&& proj);
@@ -615,9 +615,8 @@ namespace hpx { namespace parallel { inline namespace v1 {
     HPX_DEPRECATED_V(
         1, 8, "hpx::parallel::unique is deprecated, use hpx::unique instead")
     typename util::detail::algorithm_result<ExPolicy,
-        typename hpx::traits::range_iterator<Rng>::type>::type
-        unique(ExPolicy&& policy, Rng&& rng, Pred&& pred = Pred(),
-            Proj&& proj = Proj())
+        hpx::traits::range_iterator_t<Rng>>::type unique(ExPolicy&& policy,
+        Rng&& rng, Pred&& pred = Pred(), Proj&& proj = Proj())
     {
 #if defined(HPX_GCC_VERSION) && HPX_GCC_VERSION >= 100000
 #pragma GCC diagnostic push
@@ -644,9 +643,9 @@ namespace hpx { namespace parallel { inline namespace v1 {
         "hpx::parallel::unique_copy is deprecated, use hpx::unique_copy "
         "instead")
     typename util::detail::algorithm_result<ExPolicy,
-        util::in_out_result<typename hpx::traits::range_iterator<Rng>::type,
-            FwdIter2>>::type unique_copy(ExPolicy&& policy, Rng&& rng,
-        FwdIter2 dest, Pred&& pred = Pred(), Proj&& proj = Proj())
+        util::in_out_result<hpx::traits::range_iterator_t<Rng>, FwdIter2>>::type
+        unique_copy(ExPolicy&& policy, Rng&& rng, FwdIter2 dest,
+            Pred&& pred = Pred(), Proj&& proj = Proj())
     {
 #if defined(HPX_GCC_VERSION) && HPX_GCC_VERSION >= 100000
 #pragma GCC diagnostic push
@@ -745,23 +744,22 @@ namespace hpx { namespace ranges {
                     hpx::parallel::traits::projected_range<Proj, Rng>>::value
             )>
         // clang-format on
-        friend subrange_t<typename hpx::traits::range_iterator<Rng>::type,
-            typename hpx::traits::range_iterator<Rng>::type>
+        friend subrange_t<hpx::traits::range_iterator_t<Rng>,
+            hpx::traits::range_iterator_t<Rng>>
         tag_fallback_dispatch(hpx::ranges::unique_t, Rng&& rng,
             Pred&& pred = Pred(), Proj&& proj = Proj())
         {
-            using iterator_type =
-                typename hpx::traits::range_iterator<Rng>::type;
+            using iterator_type = hpx::traits::range_iterator_t<Rng>;
 
             static_assert(
                 hpx::traits::is_forward_iterator<iterator_type>::value,
                 "Requires at least input iterator.");
 
             return hpx::parallel::util::make_subrange<
-                typename hpx::traits::range_iterator<Rng>::type,
+                hpx::traits::range_iterator_t<Rng>,
                 typename hpx::traits::range_sentinel<Rng>::type>(
                 hpx::parallel::v1::detail::unique<
-                    typename hpx::traits::range_iterator<Rng>::type>()
+                    hpx::traits::range_iterator_t<Rng>>()
                     .call(hpx::execution::seq, hpx::util::begin(rng),
                         hpx::util::end(rng), std::forward<Pred>(pred),
                         std::forward<Proj>(proj)),
@@ -783,23 +781,22 @@ namespace hpx { namespace ranges {
             )>
         // clang-format on
         friend typename parallel::util::detail::algorithm_result<ExPolicy,
-            subrange_t<typename hpx::traits::range_iterator<Rng>::type,
-                typename hpx::traits::range_iterator<Rng>::type>>::type
+            subrange_t<hpx::traits::range_iterator_t<Rng>,
+                hpx::traits::range_iterator_t<Rng>>>::type
         tag_fallback_dispatch(hpx::ranges::unique_t, ExPolicy&& policy,
             Rng&& rng, Pred&& pred = Pred(), Proj&& proj = Proj())
         {
-            using iterator_type =
-                typename hpx::traits::range_iterator<Rng>::type;
+            using iterator_type = hpx::traits::range_iterator_t<Rng>;
 
             static_assert(
                 hpx::traits::is_forward_iterator<iterator_type>::value,
                 "Requires at least forward iterator.");
 
             return hpx::parallel::util::make_subrange<
-                typename hpx::traits::range_iterator<Rng>::type,
+                hpx::traits::range_iterator_t<Rng>,
                 typename hpx::traits::range_sentinel<Rng>::type>(
                 hpx::parallel::v1::detail::unique<
-                    typename hpx::traits::range_iterator<Rng>::type>()
+                    hpx::traits::range_iterator_t<Rng>>()
                     .call(std::forward<ExPolicy>(policy), hpx::util::begin(rng),
                         hpx::util::end(rng), std::forward<Pred>(pred),
                         std::forward<Proj>(proj)),
@@ -889,19 +886,16 @@ namespace hpx { namespace ranges {
                     hpx::parallel::traits::projected_range<Proj, Rng>>::value
             )>
         // clang-format on
-        friend unique_copy_result<
-            typename hpx::traits::range_iterator<Rng>::type, O>
+        friend unique_copy_result<hpx::traits::range_iterator_t<Rng>, O>
         tag_fallback_dispatch(hpx::ranges::unique_copy_t, Rng&& rng, O dest,
             Pred&& pred = Pred(), Proj&& proj = Proj())
         {
-            using iterator_type =
-                typename hpx::traits::range_iterator<Rng>::type;
+            using iterator_type = hpx::traits::range_iterator_t<Rng>;
 
             static_assert(hpx::traits::is_input_iterator<iterator_type>::value,
                 "Requires at least input iterator.");
 
-            using result_type = unique_copy_result<
-                typename hpx::traits::range_iterator<Rng>::type, O>;
+            using result_type = unique_copy_result<iterator_type, O>;
 
             return hpx::parallel::v1::detail::unique_copy<result_type>().call(
                 hpx::execution::seq, hpx::util::begin(rng), hpx::util::end(rng),
@@ -923,20 +917,17 @@ namespace hpx { namespace ranges {
             )>
         // clang-format on
         friend typename parallel::util::detail::algorithm_result<ExPolicy,
-            unique_copy_result<typename hpx::traits::range_iterator<Rng>::type,
-                O>>::type
+            unique_copy_result<hpx::traits::range_iterator_t<Rng>, O>>::type
         tag_fallback_dispatch(hpx::ranges::unique_copy_t, ExPolicy&& policy,
             Rng&& rng, O dest, Pred&& pred = Pred(), Proj&& proj = Proj())
         {
-            using iterator_type =
-                typename hpx::traits::range_iterator<Rng>::type;
+            using iterator_type = hpx::traits::range_iterator_t<Rng>;
 
             static_assert(
                 hpx::traits::is_forward_iterator<iterator_type>::value,
                 "Requires at least input iterator.");
 
-            using result_type = unique_copy_result<
-                typename hpx::traits::range_iterator<Rng>::type, O>;
+            using result_type = unique_copy_result<iterator_type, O>;
 
             return hpx::parallel::v1::detail::unique_copy<result_type>().call(
                 std::forward<ExPolicy>(policy), hpx::util::begin(rng),

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/unique.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/unique.hpp
@@ -340,7 +340,7 @@ namespace hpx { namespace ranges {
     /// order in the calling thread.
     ///
     /// \returns  The \a unique_copy algorithm returns a
-    ///           returns parallel::util::in_out_result<FwdIter, OutIter>.
+    ///           returns unique_copy_result<FwdIter, OutIter>.
     ///           The \a unique_copy algorithm returns an in_out_result with
     ///           the source iterator to one past the last element and out
     ///           containing the destination iterator to the end of the
@@ -348,7 +348,7 @@ namespace hpx { namespace ranges {
     ///
     template <typename InIter, typename Sent, typename OutIter,
         typename Pred, typename Proj>
-    util::in_out_result<FwdIter, OutIter> unique_copy(InIter first,
+    unique_copy_result<FwdIter, OutIter> unique_copy(InIter first,
         Sent last, OutIter dest, Pred&& pred, Proj&& proj);
 
     ///////////////////////////////////////////////////////////////////////////
@@ -420,10 +420,10 @@ namespace hpx { namespace ranges {
     /// within each thread.
     ///
     /// \returns  The \a unique_copy algorithm returns areturns hpx::future<
-    ///           parallel::util::in_out_result<FwdIter1, FwdIter2>> if the
+    ///           unique_copy_result<FwdIter1, FwdIter2>> if the
     ///           execution policy is of type \a sequenced_task_policy or
     ///           \a parallel_task_policy and returns \a
-    ///           parallel::util::in_out_result<FwdIter1, FwdIter2> otherwise.
+    ///           unique_copy_result<FwdIter1, FwdIter2> otherwise.
     ///           The \a unique_copy algorithm returns an in_out_result with
     ///           the source iterator to one past the last element and out
     ///           containing the destination iterator to the end of the
@@ -432,7 +432,7 @@ namespace hpx { namespace ranges {
     template <typename ExPolicy, typename FwdIter1, typename Sent,
         typename FwdIter2, typename Pred, typename Proj>
     typename parallel::util::detail::algorithm_result<ExPolicy,
-        util::in_out_result<FwdIter1, FwdIter2>>::type
+        unique_copy_result<FwdIter1, FwdIter2>>::type
     unique_copy(ExPolicy&& policy, FwdIter1 first, Sent last,
         FwdIter2 dest, Pred&& pred, Proj&& proj);
 
@@ -488,15 +488,14 @@ namespace hpx { namespace ranges {
     /// order in the calling thread.
     ///
     /// \returns  The \a unique_copy algorithm returns \a
-    ///           parallel::util::in_out_result<
+    ///           unique_copy_result<
     ///           hpx::traits::range_iterator_t<Rng>, O>.
     ///           The \a unique_copy algorithm returns the pair of
     ///           the source iterator to \a last, and
     ///           the destination iterator to the end of the \a dest range.
     ///
     template <typename Rng, typename O, typename Pred, typename Proj>
-    parallel::util::in_out_result<
-        hpx::traits::range_iterator_t<Rng>, O>
+    unique_copy_result<hpx::traits::range_iterator_t<Rng>, O>
     unique_copy(Rng&& rng, O dest, Pred&& pred, Proj&& proj);
 
     ///////////////////////////////////////////////////////////////////////////
@@ -563,12 +562,12 @@ namespace hpx { namespace ranges {
     /// within each thread.
     ///
     /// \returns  The \a unique_copy algorithm returns a
-    ///           \a hpx::future<parallel::util::in_out_result<
+    ///           \a hpx::future<unique_copy_result<
     ///           hpx::traits::range_iterator_t<Rng>, O>>
     ///           if the execution policy is of type
     ///           \a sequenced_task_policy or
     ///           \a parallel_task_policy and
-    ///           returns \a parallel::util::in_out_result<
+    ///           returns \a unique_copy_result<
     ///           hpx::traits::range_iterator_t<Rng>, O>
     ///           otherwise.
     ///           The \a unique_copy algorithm returns the pair of
@@ -578,7 +577,7 @@ namespace hpx { namespace ranges {
     template <typename InIter, typename Sent, typename OutIter,
         typename Pred, typename Proj>
     typename parallel::util::detail::algorithm_result<ExPolicy,
-        util::in_out_result<hpx::traits::range_iterator_t<Rng>,
+        unique_copy_result<hpx::traits::range_iterator_t<Rng>,
         O>>::type
     unique_copy(ExPolicy&& policy, Rng&& rng, O dest,
         Pred&& pred, Proj&& proj);
@@ -605,18 +604,24 @@ namespace hpx { namespace ranges {
 #include <utility>
 
 namespace hpx { namespace parallel { inline namespace v1 {
-    template <typename ExPolicy, typename Rng, typename Pred = detail::equal_to,
+    // clang-format off
+    template <typename ExPolicy, typename Rng,
+        typename Pred = detail::equal_to,
         typename Proj = util::projection_identity,
-        HPX_CONCEPT_REQUIRES_(hpx::is_execution_policy<ExPolicy>::value&&
-                hpx::traits::is_range<Rng>::value&& traits::is_projected_range<
-                    Proj, Rng>::value&& traits::is_indirect_callable<ExPolicy,
-                    Pred, traits::projected_range<Proj, Rng>,
-                    traits::projected_range<Proj, Rng>>::value)>
+        HPX_CONCEPT_REQUIRES_(
+            hpx::is_execution_policy<ExPolicy>::value &&
+            hpx::traits::is_range<Rng>::value &&
+            traits::is_projected_range<Proj, Rng>::value &&
+            traits::is_indirect_callable<ExPolicy, Pred,
+                traits::projected_range<Proj, Rng>,
+                traits::projected_range<Proj, Rng>>::value
+        )>
+    // clang-format on
     HPX_DEPRECATED_V(
         1, 8, "hpx::parallel::unique is deprecated, use hpx::unique instead")
-    typename util::detail::algorithm_result<ExPolicy,
-        hpx::traits::range_iterator_t<Rng>>::type unique(ExPolicy&& policy,
-        Rng&& rng, Pred&& pred = Pred(), Proj&& proj = Proj())
+        typename util::detail::algorithm_result<ExPolicy,
+            hpx::traits::range_iterator_t<Rng>>::type unique(ExPolicy&& policy,
+            Rng&& rng, Pred&& pred = Pred(), Proj&& proj = Proj())
     {
 #if defined(HPX_GCC_VERSION) && HPX_GCC_VERSION >= 100000
 #pragma GCC diagnostic push
@@ -630,19 +635,23 @@ namespace hpx { namespace parallel { inline namespace v1 {
 #endif
     }
 
+    // clang-format off
     template <typename ExPolicy, typename Rng, typename FwdIter2,
         typename Pred = detail::equal_to,
         typename Proj = util::projection_identity,
-        HPX_CONCEPT_REQUIRES_(hpx::is_execution_policy<ExPolicy>::value&&
-                hpx::traits::is_range<Rng>::value&& hpx::traits::is_iterator<
-                    FwdIter2>::value&& traits::is_projected_range<Proj,
-                    Rng>::value&& traits::is_indirect_callable<ExPolicy, Pred,
-                    traits::projected_range<Proj, Rng>,
-                    traits::projected_range<Proj, Rng>>::value)>
+        HPX_CONCEPT_REQUIRES_(
+            hpx::is_execution_policy<ExPolicy>::value &&
+            hpx::traits::is_range<Rng>::value &&
+            hpx::traits::is_iterator<FwdIter2>::value &&
+            traits::is_projected_range<Proj, Rng>::value &&
+            traits::is_indirect_callable<ExPolicy, Pred,
+                traits::projected_range<Proj, Rng>,
+                traits::projected_range<Proj, Rng>>::value
+        )>
+    // clang-format on
     HPX_DEPRECATED_V(1, 8,
         "hpx::parallel::unique_copy is deprecated, use hpx::unique_copy "
-        "instead")
-    typename util::detail::algorithm_result<ExPolicy,
+        "instead") typename util::detail::algorithm_result<ExPolicy,
         util::in_out_result<hpx::traits::range_iterator_t<Rng>, FwdIter2>>::type
         unique_copy(ExPolicy&& policy, Rng&& rng, FwdIter2 dest,
             Pred&& pred = Pred(), Proj&& proj = Proj())
@@ -677,7 +686,7 @@ namespace hpx { namespace ranges {
             typename Pred = ranges::equal_to,
             typename Proj = parallel::util::projection_identity,
             HPX_CONCEPT_REQUIRES_(
-                hpx::traits::is_iterator<FwdIter>::value &&
+                hpx::traits::is_iterator_v<FwdIter> &&
                 hpx::traits::is_sentinel_for<Sent, FwdIter>::value &&
                 parallel::traits::is_projected<Proj, FwdIter>::value &&
                 parallel::traits::is_indirect_callable<
@@ -690,7 +699,7 @@ namespace hpx { namespace ranges {
             hpx::ranges::unique_t, FwdIter first, Sent last,
             Pred&& pred = Pred(), Proj&& proj = Proj())
         {
-            static_assert(hpx::traits::is_forward_iterator<FwdIter>::value,
+            static_assert(hpx::traits::is_forward_iterator_v<FwdIter>,
                 "Requires at least forward iterator.");
 
             return hpx::parallel::util::make_subrange<FwdIter, Sent>(
@@ -706,7 +715,7 @@ namespace hpx { namespace ranges {
             typename Proj = parallel::util::projection_identity,
             HPX_CONCEPT_REQUIRES_(
                 hpx::is_execution_policy<ExPolicy>::value &&
-                hpx::traits::is_iterator<FwdIter>::value &&
+                hpx::traits::is_iterator_v<FwdIter> &&
                 hpx::traits::is_sentinel_for<Sent, FwdIter>::value &&
                 parallel::traits::is_projected<Proj, FwdIter>::value &&
                 parallel::traits::is_indirect_callable<
@@ -721,7 +730,7 @@ namespace hpx { namespace ranges {
             FwdIter first, Sent last, Pred&& pred = Pred(),
             Proj&& proj = Proj())
         {
-            static_assert(hpx::traits::is_forward_iterator<FwdIter>::value,
+            static_assert(hpx::traits::is_forward_iterator_v<FwdIter>,
                 "Requires at least forward iterator.");
 
             return hpx::parallel::util::make_subrange<FwdIter, Sent>(
@@ -751,8 +760,7 @@ namespace hpx { namespace ranges {
         {
             using iterator_type = hpx::traits::range_iterator_t<Rng>;
 
-            static_assert(
-                hpx::traits::is_forward_iterator<iterator_type>::value,
+            static_assert(hpx::traits::is_forward_iterator_v<iterator_type>,
                 "Requires at least input iterator.");
 
             return hpx::parallel::util::make_subrange<
@@ -788,8 +796,7 @@ namespace hpx { namespace ranges {
         {
             using iterator_type = hpx::traits::range_iterator_t<Rng>;
 
-            static_assert(
-                hpx::traits::is_forward_iterator<iterator_type>::value,
+            static_assert(hpx::traits::is_forward_iterator_v<iterator_type>,
                 "Requires at least forward iterator.");
 
             return hpx::parallel::util::make_subrange<
@@ -818,7 +825,7 @@ namespace hpx { namespace ranges {
             typename Pred = ranges::equal_to,
             typename Proj = parallel::util::projection_identity,
             HPX_CONCEPT_REQUIRES_(
-                hpx::traits::is_iterator<InIter>::value &&
+                hpx::traits::is_iterator_v<InIter> &&
                 hpx::traits::is_sentinel_for<Sent, InIter>::value &&
                 parallel::traits::is_projected<Proj, InIter>::value &&
                 parallel::traits::is_indirect_callable<
@@ -831,7 +838,7 @@ namespace hpx { namespace ranges {
             hpx::ranges::unique_copy_t, InIter first, Sent last, O dest,
             Pred&& pred = Pred(), Proj&& proj = Proj())
         {
-            static_assert(hpx::traits::is_input_iterator<InIter>::value,
+            static_assert(hpx::traits::is_input_iterator_v<InIter>,
                 "Requires at least input iterator.");
 
             using result_type = unique_copy_result<InIter, O>;
@@ -848,7 +855,7 @@ namespace hpx { namespace ranges {
             typename Proj = parallel::util::projection_identity,
             HPX_CONCEPT_REQUIRES_(
                 hpx::is_execution_policy<ExPolicy>::value &&
-                hpx::traits::is_iterator<FwdIter>::value &&
+                hpx::traits::is_iterator_v<FwdIter> &&
                 hpx::traits::is_sentinel_for<Sent, FwdIter>::value &&
                 parallel::traits::is_projected<Proj, FwdIter>::value &&
                 parallel::traits::is_indirect_callable<
@@ -863,7 +870,7 @@ namespace hpx { namespace ranges {
             FwdIter first, Sent last, O dest, Pred&& pred = Pred(),
             Proj&& proj = Proj())
         {
-            static_assert(hpx::traits::is_forward_iterator<FwdIter>::value,
+            static_assert(hpx::traits::is_forward_iterator_v<FwdIter>,
                 "Requires at least forward iterator.");
 
             using result_type = unique_copy_result<FwdIter, O>;
@@ -892,7 +899,7 @@ namespace hpx { namespace ranges {
         {
             using iterator_type = hpx::traits::range_iterator_t<Rng>;
 
-            static_assert(hpx::traits::is_input_iterator<iterator_type>::value,
+            static_assert(hpx::traits::is_input_iterator_v<iterator_type>,
                 "Requires at least input iterator.");
 
             using result_type = unique_copy_result<iterator_type, O>;
@@ -923,8 +930,7 @@ namespace hpx { namespace ranges {
         {
             using iterator_type = hpx::traits::range_iterator_t<Rng>;
 
-            static_assert(
-                hpx::traits::is_forward_iterator<iterator_type>::value,
+            static_assert(hpx::traits::is_forward_iterator_v<iterator_type>,
                 "Requires at least input iterator.");
 
             using result_type = unique_copy_result<iterator_type, O>;

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/unique.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/unique.hpp
@@ -188,9 +188,8 @@ namespace hpx { namespace parallel { inline namespace v1 {
                     traits::projected_range<Proj, Rng>,
                     traits::projected_range<Proj, Rng>>::value)>
     typename util::detail::algorithm_result<ExPolicy,
-        hpx::util::tagged_pair<
-            tag::in(typename hpx::traits::range_iterator<Rng>::type),
-            tag::out(FwdIter2)>>::type
+        util::in_out_result<typename hpx::traits::range_iterator<Rng>::type,
+            FwdIter2>>::type
     unique_copy(ExPolicy&& policy, Rng&& rng, FwdIter2 dest,
         Pred&& pred = Pred(), Proj&& proj = Proj())
     {

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/unique.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/unique.hpp
@@ -197,13 +197,14 @@ namespace hpx { namespace ranges {
     ///
     /// \returns  The \a unique algorithm returns
     ///           \a subrange_t<typename hpx::traits::range_iterator<Rng>
-    ///           ::type>.
+    ///           ::type,typename hpx::traits::range_iterator<Rng>::type>.
     ///           The \a unique algorithm returns an object {ret, last},
     ///           where ret is a past-the-end iterator for a new
     ///           subrange.
     ///
     template <typename Rng, typename Pred, typename Proj>
-    subrange_t<typename hpx::traits::range_iterator<Rng>::type>
+    subrange_t<typename hpx::traits::range_iterator<Rng>::type,
+        typename hpx::traits::range_iterator<Rng>::type>
     unique(Rng&& rng, Pred&& pred, Proj&& proj);
 
     ///////////////////////////////////////////////////////////////////////////
@@ -265,18 +266,21 @@ namespace hpx { namespace ranges {
     /// within each thread.
     ///
     /// \returns  The \a unique algorithm returns a \a hpx::future
-    ///           <subrange_t<typename hpx::traits::range_iterator<Rng>::type>>
+    ///           <subrange_t<typename hpx::traits::range_iterator<Rng>::type,
+    ///           typename hpx::traits::range_iterator<Rng>::type>>
     ///           if the execution policy is of type \a sequenced_task_policy
     ///           or \a parallel_task_policy and returns
     ///           \a subrange_t<typename hpx::traits::range_iterator<Rng>
-    ///           ::type>. otherwise.
+    ///           ::type,typename hpx::traits::range_iterator<Rng>::type>.
+    ///           otherwise.
     ///           The \a unique algorithm returns an object {ret, last},
     ///           where ret is a past-the-end iterator for a new
     ///           subrange.
     ///
     template <typename ExPolicy, typename Rng, typename Pred, typename Proj>
     typename util::detail::algorithm_result<ExPolicy,
-    subrange_t<typename hpx::traits::range_iterator<Rng>::type>::type
+    subrange_t<typename hpx::traits::range_iterator<Rng>::type,
+    typename hpx::traits::range_iterator<Rng>::type>::type
     unique(ExPolicy&& policy, Rng&& rng, Pred&& pred, Proj&& proj);
 
     ///////////////////////////////////////////////////////////////////////////
@@ -344,7 +348,7 @@ namespace hpx { namespace ranges {
     ///
     template <typename InIter, typename Sent, typename OutIter,
         typename Pred, typename Proj>
-    util::in_out_result<FwdIter, OutIter> unique(FwdIter first,
+    util::in_out_result<FwdIter, OutIter> unique_copy(InIter first,
         Sent last, OutIter dest, Pred&& pred, Proj&& proj);
 
     ///////////////////////////////////////////////////////////////////////////
@@ -418,7 +422,7 @@ namespace hpx { namespace ranges {
     /// \returns  The \a unique_copy algorithm returns areturns hpx::future<
     ///           parallel::util::in_out_result<FwdIter1, FwdIter2>> if the
     ///           execution policy is of type \a sequenced_task_policy or
-    ///           \a parallel_task_policy and returns \a 
+    ///           \a parallel_task_policy and returns \a
     ///           parallel::util::in_out_result<FwdIter1, FwdIter2> otherwise.
     ///           The \a unique_copy algorithm returns an in_out_result with
     ///           the source iterator to one past the last element and out
@@ -608,12 +612,12 @@ namespace hpx { namespace parallel { inline namespace v1 {
                     Proj, Rng>::value&& traits::is_indirect_callable<ExPolicy,
                     Pred, traits::projected_range<Proj, Rng>,
                     traits::projected_range<Proj, Rng>>::value)>
+    HPX_DEPRECATED_V(
+        1, 8, "hpx::parallel::unique is deprecated, use hpx::unique instead")
     typename util::detail::algorithm_result<ExPolicy,
         typename hpx::traits::range_iterator<Rng>::type>::type
-        HPX_DEPRECATED_V(1, 8,
-            "hpx::parallel::unique is deprecated, use hpx::unique instead")
-            unique(ExPolicy&& policy, Rng&& rng, Pred&& pred = Pred(),
-                Proj&& proj = Proj())
+        unique(ExPolicy&& policy, Rng&& rng, Pred&& pred = Pred(),
+            Proj&& proj = Proj())
     {
 #if defined(HPX_GCC_VERSION) && HPX_GCC_VERSION >= 100000
 #pragma GCC diagnostic push
@@ -636,12 +640,13 @@ namespace hpx { namespace parallel { inline namespace v1 {
                     Rng>::value&& traits::is_indirect_callable<ExPolicy, Pred,
                     traits::projected_range<Proj, Rng>,
                     traits::projected_range<Proj, Rng>>::value)>
+    HPX_DEPRECATED_V(1, 8,
+        "hpx::parallel::unique_copy is deprecated, use hpx::unique_copy "
+        "instead")
     typename util::detail::algorithm_result<ExPolicy,
         util::in_out_result<typename hpx::traits::range_iterator<Rng>::type,
-            FwdIter2>>::type HPX_DEPRECATED_V(1, 8,
-        "hpx::parallel::unique_copy is deprecated, use hpx::unique_copy "
-        "instead") unique_copy(ExPolicy&& policy, Rng&& rng, FwdIter2 dest,
-        Pred&& pred = Pred(), Proj&& proj = Proj())
+            FwdIter2>>::type unique_copy(ExPolicy&& policy, Rng&& rng,
+        FwdIter2 dest, Pred&& pred = Pred(), Proj&& proj = Proj())
     {
 #if defined(HPX_GCC_VERSION) && HPX_GCC_VERSION >= 100000
 #pragma GCC diagnostic push
@@ -659,7 +664,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
 namespace hpx { namespace ranges {
 
     ///////////////////////////////////////////////////////////////////////////
-    template <typename I, typename S = I>
+    template <typename I, typename S>
     using subrange_t = hpx::util::iterator_range<I, S>;
 
     ///////////////////////////////////////////////////////////////////////////
@@ -740,7 +745,8 @@ namespace hpx { namespace ranges {
                     hpx::parallel::traits::projected_range<Proj, Rng>>::value
             )>
         // clang-format on
-        friend subrange_t<typename hpx::traits::range_iterator<Rng>::type>
+        friend subrange_t<typename hpx::traits::range_iterator<Rng>::type,
+            typename hpx::traits::range_iterator<Rng>::type>
         tag_fallback_dispatch(hpx::ranges::unique_t, Rng&& rng,
             Pred&& pred = Pred(), Proj&& proj = Proj())
         {
@@ -777,7 +783,8 @@ namespace hpx { namespace ranges {
             )>
         // clang-format on
         friend typename parallel::util::detail::algorithm_result<ExPolicy,
-            subrange_t<typename hpx::traits::range_iterator<Rng>::type>>::type
+            subrange_t<typename hpx::traits::range_iterator<Rng>::type,
+                typename hpx::traits::range_iterator<Rng>::type>>::type
         tag_fallback_dispatch(hpx::ranges::unique_t, ExPolicy&& policy,
             Rng&& rng, Pred&& pred = Pred(), Proj&& proj = Proj())
         {

--- a/libs/parallelism/algorithms/tests/performance/benchmark_unique.cpp
+++ b/libs/parallelism/algorithms/tests/performance/benchmark_unique.cpp
@@ -127,7 +127,7 @@ double run_unique_benchmark_hpx(int test_count, ExPolicy policy,
         hpx::copy(hpx::execution::par, org_first, org_last, first);
 
         std::uint64_t elapsed = hpx::chrono::high_resolution_clock::now();
-        hpx::parallel::unique(policy, first, last);
+        hpx::unique(policy, first, last);
         time += hpx::chrono::high_resolution_clock::now() - elapsed;
     }
 

--- a/libs/parallelism/algorithms/tests/performance/benchmark_unique_copy.cpp
+++ b/libs/parallelism/algorithms/tests/performance/benchmark_unique_copy.cpp
@@ -69,7 +69,7 @@ double run_unique_copy_benchmark_hpx(int test_count, ExPolicy policy,
 
     for (int i = 0; i < test_count; ++i)
     {
-        hpx::parallel::unique_copy(policy, first, last, dest);
+        hpx::unique_copy(policy, first, last, dest);
     }
 
     time = hpx::chrono::high_resolution_clock::now() - time;

--- a/libs/parallelism/algorithms/tests/unit/algorithms/stable_sort.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/stable_sort.cpp
@@ -58,6 +58,7 @@ void test_stable_sort1()
     using namespace hpx::execution;
 
     // default comparison operator (std::less)
+    test_stable_sort1(int());
     test_stable_sort1(seq, int());
     test_stable_sort1(par, int());
     test_stable_sort1(par_unseq, int());
@@ -111,6 +112,7 @@ void test_stable_sort2()
 {
     using namespace hpx::execution;
     // default comparison operator (std::less)
+    test_stable_sort2(int());
     test_stable_sort2(seq, int());
     test_stable_sort2(par, int());
     test_stable_sort2(par_unseq, int());

--- a/libs/parallelism/algorithms/tests/unit/algorithms/stable_sort.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/stable_sort.cpp
@@ -35,7 +35,7 @@ void sort_benchmark()
 
         hpx::chrono::high_resolution_timer t;
         // sort, blocking when seq, par, par_vec
-        hpx::parallel::stable_sort(par, c.begin(), c.end());
+        hpx::stable_sort(par, c.begin(), c.end());
         auto elapsed = static_cast<std::uint64_t>(t.elapsed_nanoseconds());
 
         bool is_sorted = (verify_(c, std::less<double>(), elapsed, true) != 0);

--- a/libs/parallelism/algorithms/tests/unit/algorithms/stable_sort_tests.hpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/stable_sort_tests.hpp
@@ -118,6 +118,25 @@ int verify_(
               << c << std::setw(6) << #d << std::setw(8) << #e << "\t";
 
 ////////////////////////////////////////////////////////////////////////////////
+// call stable_sort with no comparison operator
+template <typename T>
+void test_stable_sort1(T)
+{
+    // Fill vector with random values
+    std::vector<T> c(HPX_SORT_TEST_SIZE);
+    rnd_fill<T>(c, (std::numeric_limits<T>::min)(),
+        (std::numeric_limits<T>::max)(), T(std::rand()));
+
+    std::uint64_t t = hpx::chrono::high_resolution_clock::now();
+    // stable_sort, blocking when seq, par, par_vec
+    hpx::stable_sort(c.begin(), c.end());
+    std::uint64_t elapsed = hpx::chrono::high_resolution_clock::now() - t;
+
+    bool is_sorted = (verify_(c, std::less<T>(), elapsed, true) != 0);
+    HPX_TEST(is_sorted);
+}
+
+////////////////////////////////////////////////////////////////////////////////
 // call sort with no comparison operator
 template <typename ExPolicy, typename T>
 void test_stable_sort1(ExPolicy&& policy, T)
@@ -528,6 +547,24 @@ void test_stable_sort_exception_async(ExPolicy&& policy, T, Compare comp)
         else
             std::cout << "Failed " << std::endl;
     }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// already sorted
+template <typename T>
+void test_stable_sort2(T)
+{
+    // Fill vector with increasing values
+    std::vector<T> c(HPX_SORT_TEST_SIZE);
+    std::iota(std::begin(c), std::end(c), 0);
+
+    std::uint64_t t = hpx::chrono::high_resolution_clock::now();
+    // stable_sort, blocking when seq, par, par_vec
+    hpx::stable_sort(c.begin(), c.end());
+    std::uint64_t elapsed = hpx::chrono::high_resolution_clock::now() - t;
+
+    bool is_sorted = (verify_(c, std::less<T>(), elapsed, true) != 0);
+    HPX_TEST(is_sorted);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/libs/parallelism/algorithms/tests/unit/algorithms/stable_sort_tests.hpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/stable_sort_tests.hpp
@@ -27,11 +27,11 @@
 #include "test_utils.hpp"
 
 #if !defined(HPX_SORT_TEST_SIZE_STRINGS)
-#define HPX_SORT_TEST_SIZE_STRINGS 1000
+#define HPX_SORT_TEST_SIZE_STRINGS 1000000
 #endif
 
 #if !defined(HPX_SORT_TEST_SIZE)
-#define HPX_SORT_TEST_SIZE 5000
+#define HPX_SORT_TEST_SIZE 5000000
 #endif
 
 // --------------------------------------------------------------------

--- a/libs/parallelism/algorithms/tests/unit/algorithms/stable_sort_tests.hpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/stable_sort_tests.hpp
@@ -27,11 +27,11 @@
 #include "test_utils.hpp"
 
 #if !defined(HPX_SORT_TEST_SIZE_STRINGS)
-#define HPX_SORT_TEST_SIZE_STRINGS 1000000
+#define HPX_SORT_TEST_SIZE_STRINGS 1000
 #endif
 
 #if !defined(HPX_SORT_TEST_SIZE)
-#define HPX_SORT_TEST_SIZE 5000000
+#define HPX_SORT_TEST_SIZE 5000
 #endif
 
 // --------------------------------------------------------------------
@@ -133,8 +133,7 @@ void test_stable_sort1(ExPolicy&& policy, T)
 
     std::uint64_t t = hpx::chrono::high_resolution_clock::now();
     // sort, blocking when seq, par, par_vec
-    hpx::parallel::stable_sort(
-        std::forward<ExPolicy>(policy), c.begin(), c.end());
+    hpx::stable_sort(std::forward<ExPolicy>(policy), c.begin(), c.end());
     std::uint64_t elapsed = hpx::chrono::high_resolution_clock::now() - t;
 
     bool is_sorted = (verify_(c, std::less<T>(), elapsed, true) != 0);
@@ -158,8 +157,7 @@ void test_stable_sort1_comp(ExPolicy&& policy, T, Compare comp = Compare())
 
     std::uint64_t t = hpx::chrono::high_resolution_clock::now();
     // sort, blocking when seq, par, par_vec
-    hpx::parallel::stable_sort(
-        std::forward<ExPolicy>(policy), c.begin(), c.end(), comp);
+    hpx::stable_sort(std::forward<ExPolicy>(policy), c.begin(), c.end(), comp);
     std::uint64_t elapsed = hpx::chrono::high_resolution_clock::now() - t;
 
     bool is_sorted = (verify_(c, comp, elapsed, true) != 0);
@@ -183,7 +181,7 @@ void test_stable_sort1_async(ExPolicy&& policy, T, Compare comp = Compare())
 
     std::uint64_t t = hpx::chrono::high_resolution_clock::now();
     // sort, non blocking
-    hpx::future<void> f = hpx::parallel::stable_sort(
+    hpx::future<void> f = hpx::stable_sort(
         std::forward<ExPolicy>(policy), c.begin(), c.end(), comp);
     f.get();
     std::uint64_t elapsed = hpx::chrono::high_resolution_clock::now() - t;
@@ -215,7 +213,7 @@ void test_stable_sort_exception(ExPolicy&& policy, T)
                 std::random_access_iterator_tag>
                 decorated_iterator;
 
-            hpx::parallel::stable_sort(std::forward<ExPolicy>(policy),
+            hpx::stable_sort(std::forward<ExPolicy>(policy),
                 decorated_iterator(
                     c.begin(), []() { throw std::runtime_error("test"); }),
                 decorated_iterator(c.end()));
@@ -248,7 +246,7 @@ void test_stable_sort_exception(ExPolicy&& policy, T)
                 std::random_access_iterator_tag>
                 decorated_iterator;
 
-            hpx::parallel::stable_sort(std::forward<ExPolicy>(policy),
+            hpx::stable_sort(std::forward<ExPolicy>(policy),
                 decorated_iterator(c.begin(), []() { throw std::bad_alloc(); }),
                 decorated_iterator(c.end()));
 
@@ -294,7 +292,7 @@ void test_stable_sort_exception(ExPolicy&& policy, T, Compare comp)
                 std::random_access_iterator_tag>
                 decorated_iterator;
 
-            hpx::parallel::stable_sort(std::forward<ExPolicy>(policy),
+            hpx::stable_sort(std::forward<ExPolicy>(policy),
                 decorated_iterator(
                     c.begin(), []() { throw std::runtime_error("test"); }),
                 decorated_iterator(c.end()), comp);
@@ -327,7 +325,7 @@ void test_stable_sort_exception(ExPolicy&& policy, T, Compare comp)
                 std::random_access_iterator_tag>
                 decorated_iterator;
 
-            hpx::parallel::stable_sort(std::forward<ExPolicy>(policy),
+            hpx::stable_sort(std::forward<ExPolicy>(policy),
                 decorated_iterator(c.begin(), []() { throw std::bad_alloc(); }),
                 decorated_iterator(c.end()), comp);
 
@@ -375,7 +373,7 @@ void test_stable_sort_exception_async(ExPolicy&& policy, T)
                 decorated_iterator;
 
             hpx::future<void> f =
-                hpx::parallel::stable_sort(std::forward<ExPolicy>(policy),
+                hpx::stable_sort(std::forward<ExPolicy>(policy),
                     decorated_iterator(
                         c.begin(), []() { throw std::runtime_error("test"); }),
                     decorated_iterator(c.end()));
@@ -413,7 +411,7 @@ void test_stable_sort_exception_async(ExPolicy&& policy, T)
                 std::random_access_iterator_tag>
                 decorated_iterator;
 
-            hpx::future<void> f = hpx::parallel::stable_sort(
+            hpx::future<void> f = hpx::stable_sort(
                 std::forward<ExPolicy>(policy),
                 decorated_iterator(c.begin(), []() { throw std::bad_alloc(); }),
                 decorated_iterator(c.end()));
@@ -466,7 +464,7 @@ void test_stable_sort_exception_async(ExPolicy&& policy, T, Compare comp)
                 decorated_iterator;
 
             hpx::future<void> f =
-                hpx::parallel::stable_sort(std::forward<ExPolicy>(policy),
+                hpx::stable_sort(std::forward<ExPolicy>(policy),
                     decorated_iterator(
                         c.begin(), []() { throw std::runtime_error("test"); }),
                     decorated_iterator(c.end()), comp);
@@ -504,7 +502,7 @@ void test_stable_sort_exception_async(ExPolicy&& policy, T, Compare comp)
                 std::random_access_iterator_tag>
                 decorated_iterator;
 
-            hpx::future<void> f = hpx::parallel::stable_sort(
+            hpx::future<void> f = hpx::stable_sort(
                 std::forward<ExPolicy>(policy),
                 decorated_iterator(c.begin(), []() { throw std::bad_alloc(); }),
                 decorated_iterator(c.end()), comp);
@@ -547,8 +545,7 @@ void test_stable_sort2(ExPolicy&& policy, T)
 
     std::uint64_t t = hpx::chrono::high_resolution_clock::now();
     // sort, blocking when seq, par, par_vec
-    hpx::parallel::stable_sort(
-        std::forward<ExPolicy>(policy), c.begin(), c.end());
+    hpx::stable_sort(std::forward<ExPolicy>(policy), c.begin(), c.end());
     std::uint64_t elapsed = hpx::chrono::high_resolution_clock::now() - t;
 
     bool is_sorted = (verify_(c, std::less<T>(), elapsed, true) != 0);
@@ -570,8 +567,7 @@ void test_stable_sort2_comp(ExPolicy&& policy, T, Compare comp = Compare())
 
     std::uint64_t t = hpx::chrono::high_resolution_clock::now();
     // sort, blocking when seq, par, par_vec
-    hpx::parallel::stable_sort(
-        std::forward<ExPolicy>(policy), c.begin(), c.end(), comp);
+    hpx::stable_sort(std::forward<ExPolicy>(policy), c.begin(), c.end(), comp);
     std::uint64_t elapsed = hpx::chrono::high_resolution_clock::now() - t;
 
     bool is_sorted = (verify_(c, comp, elapsed, true) != 0);
@@ -593,7 +589,7 @@ void test_stable_sort2_async(ExPolicy&& policy, T, Compare comp = Compare())
 
     std::uint64_t t = hpx::chrono::high_resolution_clock::now();
     // sort, non blocking
-    hpx::future<void> f = hpx::parallel::stable_sort(
+    hpx::future<void> f = hpx::stable_sort(
         std::forward<ExPolicy>(policy), c.begin(), c.end(), comp);
     f.get();
     std::uint64_t elapsed = hpx::chrono::high_resolution_clock::now() - t;
@@ -619,8 +615,7 @@ void test_stable_sort1(ExPolicy&& policy, const std::string&)
 
     std::uint64_t t = hpx::chrono::high_resolution_clock::now();
     // sort, blocking when seq, par, par_vec
-    hpx::parallel::stable_sort(
-        std::forward<ExPolicy>(policy), c.begin(), c.end());
+    hpx::stable_sort(std::forward<ExPolicy>(policy), c.begin(), c.end());
     std::uint64_t elapsed = hpx::chrono::high_resolution_clock::now() - t;
 
     bool is_sorted = (verify_(c, std::less<std::string>(), elapsed, true) != 0);
@@ -645,8 +640,7 @@ void test_stable_sort1_comp(
 
     std::uint64_t t = hpx::chrono::high_resolution_clock::now();
     // sort, blocking when seq, par, par_vec
-    hpx::parallel::stable_sort(
-        std::forward<ExPolicy>(policy), c.begin(), c.end(), comp);
+    hpx::stable_sort(std::forward<ExPolicy>(policy), c.begin(), c.end(), comp);
     std::uint64_t elapsed = hpx::chrono::high_resolution_clock::now() - t;
 
     bool is_sorted = (verify_(c, comp, elapsed, true) != 0);
@@ -670,7 +664,7 @@ void test_stable_sort1_async_str(ExPolicy&& policy, Compare comp = Compare())
 
     std::uint64_t t = hpx::chrono::high_resolution_clock::now();
     // sort, non blocking
-    hpx::future<void> f = hpx::parallel::stable_sort(
+    hpx::future<void> f = hpx::stable_sort(
         std::forward<ExPolicy>(policy), c.begin(), c.end(), comp);
     f.get();
     std::uint64_t elapsed = hpx::chrono::high_resolution_clock::now() - t;

--- a/libs/parallelism/algorithms/tests/unit/algorithms/unique_copy_tests.hpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/unique_copy_tests.hpp
@@ -121,8 +121,8 @@ struct random_fill
 template <typename IteratorTag, typename DataType, typename Pred>
 void test_unique_copy(IteratorTag, DataType, Pred pred, int rand_base)
 {
-    typedef typename std::vector<DataType>::iterator base_iterator;
-    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+    using base_iterator = typename std::vector<DataType>::iterator;
+    using iterator = test::test_iterator<base_iterator, IteratorTag>;
 
     using hpx::get;
 
@@ -149,8 +149,8 @@ void test_unique_copy(
     static_assert(hpx::is_execution_policy<ExPolicy>::value,
         "hpx::is_execution_policy<ExPolicy>::value");
 
-    typedef typename std::vector<DataType>::iterator base_iterator;
-    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+    using base_iterator = typename std::vector<DataType>::iterator;
+    using iterator = test::test_iterator<base_iterator, IteratorTag>;
 
     using hpx::get;
 
@@ -177,8 +177,8 @@ void test_unique_copy_async(
     static_assert(hpx::is_execution_policy<ExPolicy>::value,
         "hpx::is_execution_policy<ExPolicy>::value");
 
-    typedef typename std::vector<DataType>::iterator base_iterator;
-    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+    using base_iterator = typename std::vector<DataType>::iterator;
+    using iterator = test::test_iterator<base_iterator, IteratorTag>;
 
     using hpx::get;
 
@@ -205,8 +205,8 @@ void test_unique_copy_exception(ExPolicy policy, IteratorTag)
     static_assert(hpx::is_execution_policy<ExPolicy>::value,
         "hpx::is_execution_policy<ExPolicy>::value");
 
-    typedef std::vector<int>::iterator base_iterator;
-    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+    using base_iterator = std::vector<int>::iterator;
+    using iterator = test::test_iterator<base_iterator, IteratorTag>;
 
     std::size_t const size = 10007;
     std::vector<int> c(size), dest(size);
@@ -237,8 +237,8 @@ void test_unique_copy_exception(ExPolicy policy, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_unique_copy_exception_async(ExPolicy policy, IteratorTag)
 {
-    typedef std::vector<int>::iterator base_iterator;
-    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+    using base_iterator = std::vector<int>::iterator;
+    using iterator = test::test_iterator<base_iterator, IteratorTag>;
 
     std::size_t const size = 10007;
     std::vector<int> c(size), dest(size);
@@ -276,8 +276,8 @@ void test_unique_copy_bad_alloc(ExPolicy policy, IteratorTag)
     static_assert(hpx::is_execution_policy<ExPolicy>::value,
         "hpx::is_execution_policy<ExPolicy>::value");
 
-    typedef std::vector<int>::iterator base_iterator;
-    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+    using base_iterator = std::vector<int>::iterator;
+    using iterator = test::test_iterator<base_iterator, IteratorTag>;
 
     std::size_t const size = 10007;
     std::vector<int> c(size), dest(size);
@@ -308,8 +308,8 @@ void test_unique_copy_bad_alloc(ExPolicy policy, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_unique_copy_bad_alloc_async(ExPolicy policy, IteratorTag)
 {
-    typedef std::vector<int>::iterator base_iterator;
-    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+    using base_iterator = std::vector<int>::iterator;
+    using iterator = test::test_iterator<base_iterator, IteratorTag>;
 
     std::size_t const size = 10007;
     std::vector<int> c(size), dest(size);
@@ -347,7 +347,7 @@ void test_unique_copy_etc(ExPolicy policy, IteratorTag, DataType, int rand_base)
     static_assert(hpx::is_execution_policy<ExPolicy>::value,
         "hpx::is_execution_policy<ExPolicy>::value");
 
-    typedef typename std::vector<DataType>::iterator base_iterator;
+    using base_iterator = typename std::vector<DataType>::iterator;
 
     using hpx::get;
 
@@ -358,7 +358,7 @@ void test_unique_copy_etc(ExPolicy policy, IteratorTag, DataType, int rand_base)
 
     // Test default predicate.
     {
-        typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+        using iterator = test::test_iterator<base_iterator, IteratorTag>;
 
         auto result = hpx::unique_copy(policy, iterator(std::begin(c)),
             iterator(std::end(c)), iterator(std::begin(dest_res)));
@@ -373,7 +373,7 @@ void test_unique_copy_etc(ExPolicy policy, IteratorTag, DataType, int rand_base)
 
     // Test projection.
     {
-        typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+        using iterator = test::test_iterator<base_iterator, IteratorTag>;
 
         DataType val;
         auto result = hpx::unique_copy(

--- a/libs/parallelism/algorithms/tests/unit/algorithms/unique_tests.hpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/unique_tests.hpp
@@ -121,8 +121,8 @@ struct random_fill
 template <typename IteratorTag, typename DataType, typename Pred>
 void test_unique(IteratorTag, DataType, Pred pred, int rand_base)
 {
-    typedef typename std::vector<DataType>::iterator base_iterator;
-    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+    using base_iterator = typename std::vector<DataType>::iterator;
+    using iterator = test::test_iterator<base_iterator, IteratorTag>;
 
     std::size_t const size = 10007;
     std::vector<DataType> c(size), d;
@@ -147,8 +147,8 @@ void test_unique(
     static_assert(hpx::is_execution_policy<ExPolicy>::value,
         "hpx::is_execution_policy<ExPolicy>::value");
 
-    typedef typename std::vector<DataType>::iterator base_iterator;
-    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+    using base_iterator = typename std::vector<DataType>::iterator;
+    using iterator = test::test_iterator<base_iterator, IteratorTag>;
 
     std::size_t const size = 10007;
     std::vector<DataType> c(size), d;
@@ -173,8 +173,8 @@ void test_unique_async(
     static_assert(hpx::is_execution_policy<ExPolicy>::value,
         "hpx::is_execution_policy<ExPolicy>::value");
 
-    typedef typename std::vector<DataType>::iterator base_iterator;
-    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+    using base_iterator = typename std::vector<DataType>::iterator;
+    using iterator = test::test_iterator<base_iterator, IteratorTag>;
 
     std::size_t const size = 10007;
     std::vector<DataType> c(size), d;
@@ -199,8 +199,8 @@ void test_unique_exception(ExPolicy policy, IteratorTag)
     static_assert(hpx::is_execution_policy<ExPolicy>::value,
         "hpx::is_execution_policy<ExPolicy>::value");
 
-    typedef std::vector<int>::iterator base_iterator;
-    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+    using base_iterator = std::vector<int>::iterator;
+    using iterator = test::test_iterator<base_iterator, IteratorTag>;
 
     std::size_t const size = 10007;
     std::vector<int> c(size);
@@ -231,8 +231,8 @@ void test_unique_exception(ExPolicy policy, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_unique_exception_async(ExPolicy policy, IteratorTag)
 {
-    typedef std::vector<int>::iterator base_iterator;
-    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+    using base_iterator = std::vector<int>::iterator;
+    using iterator = test::test_iterator<base_iterator, IteratorTag>;
 
     std::size_t const size = 10007;
     std::vector<int> c(size);
@@ -270,8 +270,8 @@ void test_unique_bad_alloc(ExPolicy policy, IteratorTag)
     static_assert(hpx::is_execution_policy<ExPolicy>::value,
         "hpx::is_execution_policy<ExPolicy>::value");
 
-    typedef std::vector<int>::iterator base_iterator;
-    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+    using base_iterator = std::vector<int>::iterator;
+    using iterator = test::test_iterator<base_iterator, IteratorTag>;
 
     std::size_t const size = 10007;
     std::vector<int> c(size);
@@ -301,8 +301,8 @@ void test_unique_bad_alloc(ExPolicy policy, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_unique_bad_alloc_async(ExPolicy policy, IteratorTag)
 {
-    typedef std::vector<int>::iterator base_iterator;
-    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+    using base_iterator = std::vector<int>::iterator;
+    using iterator = test::test_iterator<base_iterator, IteratorTag>;
 
     std::size_t const size = 10007;
     std::vector<int> c(size);
@@ -339,7 +339,7 @@ void test_unique_etc(ExPolicy policy, IteratorTag, DataType, int rand_base)
     static_assert(hpx::is_execution_policy<ExPolicy>::value,
         "hpx::is_execution_policy<ExPolicy>::value");
 
-    typedef typename std::vector<DataType>::iterator base_iterator;
+    using base_iterator = typename std::vector<DataType>::iterator;
 
     std::size_t const size = 10007;
     std::vector<DataType> c(size), d, org;
@@ -349,7 +349,7 @@ void test_unique_etc(ExPolicy policy, IteratorTag, DataType, int rand_base)
 
     // Test default predicate.
     {
-        typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+        using iterator = test::test_iterator<base_iterator, IteratorTag>;
 
         auto result =
             hpx::unique(policy, iterator(std::begin(c)), iterator(std::end(c)));
@@ -363,7 +363,7 @@ void test_unique_etc(ExPolicy policy, IteratorTag, DataType, int rand_base)
 
     // Test projection.
     {
-        typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+        using iterator = test::test_iterator<base_iterator, IteratorTag>;
 
         c = org;
 

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/stable_sort_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/stable_sort_range.cpp
@@ -24,7 +24,19 @@ void test_stable_sort1()
 {
     using namespace hpx::execution;
 
+    // default comparison operator (std::less) (sentinel)
+    test_stable_sort1_sent(int());
+    test_stable_sort1_sent(seq, int());
+    test_stable_sort1_sent(par, int());
+    test_stable_sort1_sent(par_unseq, int());
+
+    // user supplied comparison operator (std::less) (sentinel)
+    test_stable_sort1_comp_sent(seq, int(), std::less<int>());
+    test_stable_sort1_comp_sent(par, int(), std::less<int>());
+    test_stable_sort1_comp_sent(par_unseq, int(), std::less<int>());
+
     // default comparison operator (std::less)
+    test_stable_sort1(int());
     test_stable_sort1(seq, int());
     test_stable_sort1(par, int());
     test_stable_sort1(par_unseq, int());

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/stable_sort_range_tests.hpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/stable_sort_range_tests.hpp
@@ -10,9 +10,7 @@
 #include <hpx/iterator_support/iterator_range.hpp>
 #include <hpx/modules/format.hpp>
 #include <hpx/modules/testing.hpp>
-#include <hpx/parallel/algorithms/sort.hpp>
-#include <hpx/parallel/algorithms/stable_sort.hpp>
-#include <hpx/parallel/container_algorithms/sort.hpp>
+#include <hpx/parallel/container_algorithms/stable_sort.hpp>
 
 #include <cstddef>
 #include <cstdint>
@@ -29,11 +27,11 @@
 #include "test_utils.hpp"
 
 #if !defined(HPX_SORT_TEST_SIZE_STRINGS)
-#define HPX_SORT_TEST_SIZE_STRINGS 1000000
+#define HPX_SORT_TEST_SIZE_STRINGS 1000
 #endif
 
 #if !defined(HPX_SORT_TEST_SIZE)
-#define HPX_SORT_TEST_SIZE 5000000
+#define HPX_SORT_TEST_SIZE 5000
 #endif
 
 // --------------------------------------------------------------------
@@ -135,7 +133,7 @@ void test_stable_sort1(ExPolicy&& policy, T)
 
     std::uint64_t t = hpx::chrono::high_resolution_clock::now();
     // sort, blocking when seq, par, par_vec
-    hpx::parallel::sort(std::forward<ExPolicy>(policy), c);
+    hpx::ranges::stable_sort(std::forward<ExPolicy>(policy), c);
     std::uint64_t elapsed = hpx::chrono::high_resolution_clock::now() - t;
 
     bool is_sorted = (verify_(c, std::less<T>(), elapsed, true) != 0);
@@ -159,7 +157,7 @@ void test_stable_sort1_comp(ExPolicy&& policy, T, Compare comp = Compare())
 
     std::uint64_t t = hpx::chrono::high_resolution_clock::now();
     // sort, blocking when seq, par, par_vec
-    hpx::parallel::sort(std::forward<ExPolicy>(policy), c, comp);
+    hpx::ranges::stable_sort(std::forward<ExPolicy>(policy), c, comp);
     std::uint64_t elapsed = hpx::chrono::high_resolution_clock::now() - t;
 
     bool is_sorted = (verify_(c, comp, elapsed, true) != 0);
@@ -183,8 +181,8 @@ void test_stable_sort1_async(ExPolicy&& policy, T, Compare comp = Compare())
 
     std::uint64_t t = hpx::chrono::high_resolution_clock::now();
     // sort, non blocking
-    hpx::future<void> f =
-        hpx::parallel::sort(std::forward<ExPolicy>(policy), c, comp);
+    auto f =
+        hpx::ranges::stable_sort(std::forward<ExPolicy>(policy), c, comp);
     f.get();
     std::uint64_t elapsed = hpx::chrono::high_resolution_clock::now() - t;
 
@@ -215,7 +213,7 @@ void test_stable_sort_exception(ExPolicy&& policy, T)
                 std::random_access_iterator_tag>
                 decorated_iterator;
 
-            hpx::parallel::sort(std::forward<ExPolicy>(policy),
+            hpx::ranges::stable_sort(std::forward<ExPolicy>(policy),
                 hpx::util::make_iterator_range(
                     decorated_iterator(
                         c.begin(), []() { throw std::runtime_error("test"); }),
@@ -249,7 +247,7 @@ void test_stable_sort_exception(ExPolicy&& policy, T)
                 std::random_access_iterator_tag>
                 decorated_iterator;
 
-            hpx::parallel::sort(std::forward<ExPolicy>(policy),
+            hpx::ranges::stable_sort(std::forward<ExPolicy>(policy),
                 hpx::util::make_iterator_range(
                     decorated_iterator(
                         c.begin(), []() { throw std::bad_alloc(); }),
@@ -297,7 +295,7 @@ void test_stable_sort_exception(ExPolicy&& policy, T, Compare comp)
                 std::random_access_iterator_tag>
                 decorated_iterator;
 
-            hpx::parallel::sort(std::forward<ExPolicy>(policy),
+            hpx::ranges::stable_sort(std::forward<ExPolicy>(policy),
                 hpx::util::make_iterator_range(
                     decorated_iterator(
                         c.begin(), []() { throw std::runtime_error("test"); }),
@@ -332,7 +330,7 @@ void test_stable_sort_exception(ExPolicy&& policy, T, Compare comp)
                 std::random_access_iterator_tag>
                 decorated_iterator;
 
-            hpx::parallel::sort(std::forward<ExPolicy>(policy),
+            hpx::ranges::stable_sort(std::forward<ExPolicy>(policy),
                 hpx::util::make_iterator_range(
                     decorated_iterator(
                         c.begin(), []() { throw std::bad_alloc(); }),
@@ -383,7 +381,7 @@ void test_stable_sort_exception_async(ExPolicy&& policy, T)
                 decorated_iterator;
 
             hpx::future<void> f =
-                hpx::parallel::sort(std::forward<ExPolicy>(policy),
+                hpx::ranges::stable_sort(std::forward<ExPolicy>(policy),
                     hpx::util::make_iterator_range(
                         decorated_iterator(c.begin(),
                             []() { throw std::runtime_error("test"); }),
@@ -423,7 +421,7 @@ void test_stable_sort_exception_async(ExPolicy&& policy, T)
                 decorated_iterator;
 
             hpx::future<void> f =
-                hpx::parallel::sort(std::forward<ExPolicy>(policy),
+                hpx::ranges::stable_sort(std::forward<ExPolicy>(policy),
                     hpx::util::make_iterator_range(
                         decorated_iterator(
                             c.begin(), []() { throw std::bad_alloc(); }),
@@ -477,7 +475,7 @@ void test_stable_sort_exception_async(ExPolicy&& policy, T, Compare comp)
                 decorated_iterator;
 
             hpx::future<void> f =
-                hpx::parallel::sort(std::forward<ExPolicy>(policy),
+                hpx::ranges::stable_sort(std::forward<ExPolicy>(policy),
                     hpx::util::make_iterator_range(
                         decorated_iterator(c.begin(),
                             []() { throw std::runtime_error("test"); }),
@@ -518,7 +516,7 @@ void test_stable_sort_exception_async(ExPolicy&& policy, T, Compare comp)
                 decorated_iterator;
 
             hpx::future<void> f =
-                hpx::parallel::sort(std::forward<ExPolicy>(policy),
+                hpx::ranges::stable_sort(std::forward<ExPolicy>(policy),
                     hpx::util::make_iterator_range(
                         decorated_iterator(
                             c.begin(), []() { throw std::bad_alloc(); }),
@@ -563,7 +561,7 @@ void test_stable_sort2(ExPolicy&& policy, T)
 
     std::uint64_t t = hpx::chrono::high_resolution_clock::now();
     // sort, blocking when seq, par, par_vec
-    hpx::parallel::sort(std::forward<ExPolicy>(policy), c.begin(), c.end());
+    hpx::ranges::stable_sort(std::forward<ExPolicy>(policy), c.begin(), c.end());
     std::uint64_t elapsed = hpx::chrono::high_resolution_clock::now() - t;
 
     bool is_sorted = (verify_(c, std::less<T>(), elapsed, true) != 0);
@@ -585,8 +583,7 @@ void test_stable_sort2_comp(ExPolicy&& policy, T, Compare comp = Compare())
 
     std::uint64_t t = hpx::chrono::high_resolution_clock::now();
     // sort, blocking when seq, par, par_vec
-    hpx::parallel::sort(
-        std::forward<ExPolicy>(policy), c.begin(), c.end(), comp);
+    hpx::ranges::stable_sort(std::forward<ExPolicy>(policy), c.begin(), c.end(), comp);
     std::uint64_t elapsed = hpx::chrono::high_resolution_clock::now() - t;
 
     bool is_sorted = (verify_(c, comp, elapsed, true) != 0);
@@ -608,7 +605,7 @@ void test_stable_sort2_async(ExPolicy&& policy, T, Compare comp = Compare())
 
     std::uint64_t t = hpx::chrono::high_resolution_clock::now();
     // sort, non blocking
-    hpx::future<void> f = hpx::parallel::sort(
+    hpx::future<void> f = hpx::ranges::stable_sort(
         std::forward<ExPolicy>(policy), c.begin(), c.end(), comp);
     f.get();
     std::uint64_t elapsed = hpx::chrono::high_resolution_clock::now() - t;
@@ -634,7 +631,7 @@ void test_stable_sort1(ExPolicy&& policy, const std::string&)
 
     std::uint64_t t = hpx::chrono::high_resolution_clock::now();
     // sort, blocking when seq, par, par_vec
-    hpx::parallel::sort(std::forward<ExPolicy>(policy), c.begin(), c.end());
+    hpx::ranges::stable_sort(std::forward<ExPolicy>(policy), c.begin(), c.end());
     std::uint64_t elapsed = hpx::chrono::high_resolution_clock::now() - t;
 
     bool is_sorted = (verify_(c, std::less<std::string>(), elapsed, true) != 0);
@@ -659,8 +656,7 @@ void test_stable_sort1_comp(
 
     std::uint64_t t = hpx::chrono::high_resolution_clock::now();
     // sort, blocking when seq, par, par_vec
-    hpx::parallel::sort(
-        std::forward<ExPolicy>(policy), c.begin(), c.end(), comp);
+    hpx::ranges::stable_sort(std::forward<ExPolicy>(policy), c.begin(), c.end(), comp);
     std::uint64_t elapsed = hpx::chrono::high_resolution_clock::now() - t;
 
     bool is_sorted = (verify_(c, comp, elapsed, true) != 0);
@@ -685,7 +681,7 @@ void test_stable_sort1_async_string(
 
     std::uint64_t t = hpx::chrono::high_resolution_clock::now();
     // sort, non blocking
-    hpx::future<void> f = hpx::parallel::sort(
+    hpx::future<void> f = hpx::ranges::stable_sort(
         std::forward<ExPolicy>(policy), c.begin(), c.end(), comp);
     f.get();
     std::uint64_t elapsed = hpx::chrono::high_resolution_clock::now() - t;

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/stable_sort_range_tests.hpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/stable_sort_range_tests.hpp
@@ -1,5 +1,6 @@
 //  Copyright (c) 2015 Daniel Bourgeois
 //  Copyright (c) 2015 John Biddiscombe
+//  Copyright (c) 2021 Akhil J Nair
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -29,11 +30,11 @@
 #include "test_utils.hpp"
 
 #if !defined(HPX_SORT_TEST_SIZE_STRINGS)
-#define HPX_SORT_TEST_SIZE_STRINGS 1000
+#define HPX_SORT_TEST_SIZE_STRINGS 1000000
 #endif
 
 #if !defined(HPX_SORT_TEST_SIZE)
-#define HPX_SORT_TEST_SIZE 5000
+#define HPX_SORT_TEST_SIZE 5000000
 #endif
 
 // --------------------------------------------------------------------
@@ -125,10 +126,10 @@ template <typename T>
 void test_stable_sort1_sent(T)
 {
     auto rand_max_val = std::rand() + 1;
-    std::size_t N = HPX_SORT_TEST_SIZE;
+    std::size_t N = std::rand() % 10007;
 
     // Fill vector with random values
-    std::vector<T> c(HPX_SORT_TEST_SIZE);
+    std::vector<T> c(N);
     rnd_fill<T>(
         c, (std::numeric_limits<T>::min)(), rand_max_val - 1, T(std::rand()));
 
@@ -150,10 +151,10 @@ void test_stable_sort1_sent(ExPolicy&& policy, T)
     msg(typeid(ExPolicy).name(), typeid(T).name(), "default", sync, random);
 
     auto rand_max_val = std::rand() + 1;
-    std::size_t N = HPX_SORT_TEST_SIZE;
+    std::size_t N = std::rand() % 10007;
 
     // Fill vector with random values
-    std::vector<T> c(HPX_SORT_TEST_SIZE);
+    std::vector<T> c(N);
     rnd_fill<T>(
         c, (std::numeric_limits<T>::min)(), rand_max_val - 1, T(std::rand()));
 
@@ -176,10 +177,10 @@ void test_stable_sort1_comp_sent(ExPolicy&& policy, T, Compare comp = Compare())
         random);
 
     auto rand_max_val = std::rand() + 1;
-    std::size_t N = HPX_SORT_TEST_SIZE;
+    std::size_t N = std::rand() % 10007;
 
     // Fill vector with random values
-    std::vector<T> c(HPX_SORT_TEST_SIZE);
+    std::vector<T> c(N);
     rnd_fill<T>(
         c, (std::numeric_limits<T>::min)(), rand_max_val - 1, T(std::rand()));
 

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/unique_copy_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/unique_copy_range.cpp
@@ -82,10 +82,10 @@ void test_unique_copy(ExPolicy policy, DataType)
     auto solution =
         std::unique_copy(std::begin(c), std::end(c), std::begin(dest_sol));
 
-    HPX_TEST(get<0>(result) == std::end(c));
+    HPX_TEST(result.in == std::end(c));
 
     bool equality = test::equal(
-        std::begin(dest_res), get<1>(result), std::begin(dest_sol), solution);
+        std::begin(dest_res), result.out, std::begin(dest_sol), solution);
 
     HPX_TEST(equality);
 }
@@ -107,10 +107,10 @@ void test_unique_copy_async(ExPolicy policy, DataType)
     auto solution =
         std::unique_copy(std::begin(c), std::end(c), std::begin(dest_sol));
 
-    HPX_TEST(get<0>(result) == std::end(c));
+    HPX_TEST(result.in == std::end(c));
 
     bool equality = test::equal(
-        std::begin(dest_res), get<1>(result), std::begin(dest_sol), solution);
+        std::begin(dest_res), result.out, std::begin(dest_sol), solution);
 
     HPX_TEST(equality);
 }

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/unique_copy_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/unique_copy_range.cpp
@@ -81,8 +81,8 @@ void test_unique_copy_sent()
 
     auto result = hpx::ranges::unique_copy(
         std::begin(c), sentinel<std::size_t>{10}, std::begin(dest_res));
-    auto solution =
-        std::unique_copy(std::begin(c), std::begin(c) + end_len, std::begin(dest_sol));
+    auto solution = std::unique_copy(
+        std::begin(c), std::begin(c) + end_len, std::begin(dest_sol));
 
     HPX_TEST(result.in == std::next(std::begin(c), end_len));
 
@@ -92,7 +92,7 @@ void test_unique_copy_sent()
     HPX_TEST(equality);
 }
 
-template<typename ExPolicy>
+template <typename ExPolicy>
 void test_unique_copy_sent(ExPolicy policy)
 {
     using hpx::get;
@@ -104,8 +104,8 @@ void test_unique_copy_sent(ExPolicy policy)
     auto end_len = std::rand() % 10006 + 1;
     c[end_len] = 10;
 
-    auto result = hpx::ranges::unique_copy(policy,
-        std::begin(c), sentinel<std::size_t>{10}, std::begin(dest_res));
+    auto result = hpx::ranges::unique_copy(
+        policy, std::begin(c), sentinel<std::size_t>{10}, std::begin(dest_res));
     auto solution = std::unique_copy(
         std::begin(c), std::begin(c) + end_len, std::begin(dest_sol));
 

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/unique_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/unique_range.cpp
@@ -48,7 +48,7 @@ struct user_defined_type
 };
 
 const std::vector<std::string> user_defined_type::name_list{
-    "ABB", "ABC", "ACB", "BASE", "CAA", "CAAA", "CAAB", "END"};
+    "ABB", "ABC", "ACB", "BASE", "CAA", "CAAA", "CAAB"};
 
 struct random_fill
 {


### PR DESCRIPTION
Adapted stable_sort to C++ 20 and added container overloads. (range and sentinel). Added sentinel tests.

## Any background context you want to provide?
Issue #4822