### PR TITLE
Make the cuda parameters of try_compile optional

### DIFF
--- a/cmake/HPX_AddConfigTest.cmake
+++ b/cmake/HPX_AddConfigTest.cmake
@@ -153,6 +153,9 @@ function(add_hpx_config_test variable)
         set(${variable}_RESULT FALSE)
       endif()
     else()
+      if (HPX_WITH_CUDA)
+        set(cuda_parameters CUDA_STANDARD ${CMAKE_CUDA_STANDARD})
+      endif()
       set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${additional_cmake_flags}")
       set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} ${additional_cmake_flags}")
       # cmake-format: off
@@ -169,7 +172,7 @@ function(add_hpx_config_test variable)
         CXX_STANDARD ${HPX_CXX_STANDARD}
         CXX_STANDARD_REQUIRED ON
         CXX_EXTENSIONS FALSE
-        CUDA_STANDARD ${CMAKE_CUDA_STANDARD}
+        ${cuda_parameters}
         COPY_FILE ${test_binary}
       )
       # cmake-format: on


### PR DESCRIPTION
Fixup for the C+17 PR #5283
A warning for unrecognized parameters in try_compile is issued when CUDA is disabled, this PR makes the parameter optional