### PR TITLE
Require CMake 3.18 as it is already a requirement for CUDA

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ working_dir_default: &working_dir_default
 
 docker_default: &docker_default
     docker:
-      - image: stellargroup/build_env:6
+      - image: stellargroup/build_env:7
 
 defaults: &defaults
     <<: *working_dir_default

--- a/.github/workflows/linux_debug.yml
+++ b/.github/workflows/linux_debug.yml
@@ -11,7 +11,7 @@ on: [pull_request]
 jobs:
   build:
     runs-on: ubuntu-latest
-    container: stellargroup/build_env:6
+    container: stellargroup/build_env:7
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/linux_hip.yml
+++ b/.github/workflows/linux_hip.yml
@@ -11,7 +11,7 @@ on: [pull_request]
 jobs:
   build:
     runs-on: ubuntu-latest
-    container: stellargroup/hip_build_env:6
+    container: stellargroup/hip_build_env:7
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/linux_release_fetchcontent.yml
+++ b/.github/workflows/linux_release_fetchcontent.yml
@@ -11,7 +11,7 @@ on: [pull_request]
 jobs:
   build:
     runs-on: ubuntu-latest
-    container: stellargroup/build_env:6
+    container: stellargroup/build_env:7
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/linux_sanitizers.yml
+++ b/.github/workflows/linux_sanitizers.yml
@@ -11,7 +11,7 @@ on: [pull_request]
 jobs:
   build:
     runs-on: ubuntu-latest
-    container: stellargroup/build_env:6
+    container: stellargroup/build_env:7
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/windows_debug.yml
+++ b/.github/workflows/windows_debug.yml
@@ -14,6 +14,9 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+    - uses: jwlawson/actions-setup-cmake@v1.9
+      with:
+        cmake-version: '3.18.x'
     - name: Install dependencies
       run: |
         md C:\projects

--- a/.github/workflows/windows_release.yml
+++ b/.github/workflows/windows_release.yml
@@ -14,6 +14,9 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+    - uses: jwlawson/actions-setup-cmake@v1.9
+      with:
+        cmake-version: '3.18.x'
     - name: Install dependencies
       run: |
         md C:\projects

--- a/.jenkins/cscs-perftests/env-perftests.sh
+++ b/.jenkins/cscs-perftests/env-perftests.sh
@@ -24,5 +24,5 @@ export CPP="${CLANG_ROOT}/bin/clang -E"
 
 module load cray-jemalloc/5.1.0.3
 module load daint-mc
-spack load cmake@3.17.3
+spack load cmake@3.18.6
 spack load ninja@1.10.0

--- a/.jenkins/cscs/env-clang-10.sh
+++ b/.jenkins/cscs/env-clang-10.sh
@@ -20,7 +20,7 @@ export CC="${CLANG_ROOT}/bin/clang"
 export CPP="${CLANG_ROOT}/bin/clang -E"
 
 module load daint-mc
-spack load cmake@3.17.3
+spack load cmake@3.18.6
 spack load ninja@1.10.0
 
 configure_extra_options="-DCMAKE_BUILD_TYPE=Debug"

--- a/.jenkins/cscs/env-clang-8.sh
+++ b/.jenkins/cscs/env-clang-8.sh
@@ -20,7 +20,7 @@ export CC="${CLANG_ROOT}/bin/clang"
 export CPP="${CLANG_ROOT}/bin/clang -E"
 
 module load daint-mc
-spack load cmake@3.17.3
+spack load cmake@3.18.6
 spack load ninja@1.10.0
 
 configure_extra_options="-DCMAKE_BUILD_TYPE=Debug"

--- a/.jenkins/cscs/env-clang-9.sh
+++ b/.jenkins/cscs/env-clang-9.sh
@@ -20,7 +20,7 @@ export CC="${CLANG_ROOT}/bin/clang"
 export CPP="${CLANG_ROOT}/bin/clang -E"
 
 module load daint-mc
-spack load cmake@3.17.3
+spack load cmake@3.18.6
 spack load ninja@1.10.0
 
 configure_extra_options="-DCMAKE_BUILD_TYPE=Debug"

--- a/.jenkins/cscs/env-clang-apex.sh
+++ b/.jenkins/cscs/env-clang-apex.sh
@@ -22,7 +22,7 @@ export CC="${CLANG_ROOT}/bin/clang"
 export CPP="${CLANG_ROOT}/bin/clang -E"
 
 module load daint-mc
-spack load cmake@3.17.3
+spack load cmake@3.18.6
 spack load ninja@1.10.0
 
 configure_extra_options="-DCMAKE_BUILD_TYPE=Debug"

--- a/.jenkins/cscs/env-clang-newest.sh
+++ b/.jenkins/cscs/env-clang-newest.sh
@@ -20,7 +20,7 @@ export CC="${CLANG_ROOT}/bin/clang"
 export CPP="${CLANG_ROOT}/bin/clang -E"
 
 module load daint-mc
-spack load cmake@3.17.3
+spack load cmake@3.18.6
 spack load ninja@1.10.0
 
 configure_extra_options="-DCMAKE_BUILD_TYPE=Release"

--- a/.jenkins/cscs/env-clang-oldest.sh
+++ b/.jenkins/cscs/env-clang-oldest.sh
@@ -20,7 +20,7 @@ export CC="${CLANG_ROOT}/bin/clang"
 export CPP="${CLANG_ROOT}/bin/clang -E"
 
 module load daint-mc
-spack load cmake@3.17.3
+spack load cmake@3.18.6
 spack load ninja@1.10.0
 
 configure_extra_options="-DCMAKE_BUILD_TYPE=Debug"

--- a/.jenkins/cscs/env-common.sh
+++ b/.jenkins/cscs/env-common.sh
@@ -7,7 +7,7 @@
 source $SPACK_ROOT/share/spack/setup-env.sh
 
 spack load ccache@3.7.9
-spack load cmake@3.17.3
+spack load cmake@3.18.6
 spack load ninja@1.10.0
 
 export CMAKE_CXX_COMPILER_LAUNCHER=ccache

--- a/.jenkins/cscs/env-gcc-10.sh
+++ b/.jenkins/cscs/env-gcc-10.sh
@@ -19,7 +19,7 @@ export CXX=${GCC_ROOT}/bin/g++
 export CC=${GCC_ROOT}/bin/gcc
 
 module load daint-mc
-spack load cmake@3.17.3
+spack load cmake@3.18.6
 spack load ninja@1.10.0
 
 configure_extra_options="-DCMAKE_BUILD_TYPE=Debug"

--- a/.jenkins/cscs/env-gcc-cuda.sh
+++ b/.jenkins/cscs/env-gcc-cuda.sh
@@ -12,7 +12,7 @@ module switch PrgEnv-cray PrgEnv-gnu
 module load cudatoolkit
 module load Boost/1.75.0-CrayGNU-20.11
 module load hwloc/.2.0.3
-spack load cmake@3.18.6 # Necessary to handle cuda_std_17 compiler feature
+spack load cmake@3.18.6
 spack load ninja@1.10.0
 
 export CXX=`which CC`

--- a/.jenkins/cscs/env-gcc-newest.sh
+++ b/.jenkins/cscs/env-gcc-newest.sh
@@ -19,7 +19,7 @@ export CXX=${GCC_ROOT}/bin/g++
 export CC=${GCC_ROOT}/bin/gcc
 
 module load daint-mc
-spack load cmake@3.17.3
+spack load cmake@3.18.6
 spack load ninja@1.10.0
 
 configure_extra_options="-DCMAKE_BUILD_TYPE=Debug"

--- a/.jenkins/cscs/env-gcc-oldest.sh
+++ b/.jenkins/cscs/env-gcc-oldest.sh
@@ -20,7 +20,7 @@ export CXX=${GCC_ROOT}/bin/g++
 export CC=${GCC_ROOT}/bin/gcc
 
 module load daint-mc
-spack load cmake@3.17.3
+spack load cmake@3.18.6
 spack load ninja@1.10.0
 
 configure_extra_options="-DCMAKE_BUILD_TYPE=Debug"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-cmake_minimum_required(VERSION 3.17 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.18 FATAL_ERROR)
 
 # Overrides must go before the project() statement, otherwise they are ignored.
 
@@ -82,7 +82,7 @@ include(GNUInstallDirs)
 include(HPX_Utils)
 
 # explicitly set certain policies
-cmake_policy(VERSION 3.17)
+cmake_policy(VERSION 3.18)
 hpx_set_cmake_policy(CMP0042 NEW)
 hpx_set_cmake_policy(CMP0060 NEW)
 hpx_set_cmake_policy(CMP0074 NEW)

--- a/cmake/HPX_UpdateGitDocs.cmake
+++ b/cmake/HPX_UpdateGitDocs.cmake
@@ -5,7 +5,7 @@
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-cmake_minimum_required(VERSION 3.17 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.18 FATAL_ERROR)
 
 find_package(Git)
 

--- a/cmake/templates/HPXConfig.cmake.in
+++ b/cmake/templates/HPXConfig.cmake.in
@@ -6,7 +6,7 @@
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 set(HPX_FIND_PACKAGE ON)
-cmake_policy(VERSION 3.17)
+cmake_policy(VERSION 3.18)
 
 # Forward HPX_* cache variables
 include("${CMAKE_CURRENT_LIST_DIR}/HPXCacheVariables.cmake")

--- a/components/create_component_skeleton.py
+++ b/components/create_component_skeleton.py
@@ -21,7 +21,7 @@ component_name_upper = component_name.upper()
 header_str = '=' * len(component_name)
 
 # CMake minimum version
-cmake_version = '3.17'
+cmake_version = '3.18'
 
 cmake_header = f'''# Copyright (c) 2019 The STE||AR-Group
 #

--- a/docs/sphinx/manual/building_hpx.rst
+++ b/docs/sphinx/manual/building_hpx.rst
@@ -71,7 +71,7 @@ Quick start
 
 Here, you will use the command-line, non-interactive CMake interface.
 
-#. Download and install CMake here: |cmake_download|_. Version 3.17 is the
+#. Download and install CMake here: |cmake_download|_. Version 3.18 is the
    minimum required version for |hpx|.
 
 #. Open a shell. Your development tools must be reachable from this shell
@@ -211,8 +211,7 @@ favorite compiler with |hpx| visit |hpx_buildbot|_.
      *
      *
    * * |cmake|_
-     * 3.17
-     * Cuda support 3.9
+     * 3.18
    * * **Required Libraries**
      *
      *
@@ -243,7 +242,7 @@ favorite compiler with |hpx| visit |hpx_buildbot|_.
      *
      *
    * * |cmake|_
-     * 3.17
+     * 3.18
      *
    * * **Required Libraries**
      *

--- a/docs/sphinx/manual/creating_hpx_projects.rst
+++ b/docs/sphinx/manual/creating_hpx_projects.rst
@@ -191,7 +191,7 @@ The basic structure to include |hpx| into your CMakeLists.txt is shown here:
 .. code-block:: cmake
 
    # Require a recent version of cmake
-   cmake_minimum_required(VERSION 3.17 FATAL_ERROR)
+   cmake_minimum_required(VERSION 3.18 FATAL_ERROR)
 
    # This project is C++ based.
    project(your_app CXX)

--- a/docs/sphinx/quickstart.rst
+++ b/docs/sphinx/quickstart.rst
@@ -175,7 +175,7 @@ build an executable using |cmake| and |hpx|:
 
 .. code-block:: cmake
 
-   cmake_minimum_required(VERSION 3.17)
+   cmake_minimum_required(VERSION 3.18)
    project(my_hpx_project CXX)
    find_package(HPX REQUIRED)
    add_executable(my_hpx_program main.cpp)

--- a/examples/gtest_emulation/CMakeLists.txt
+++ b/examples/gtest_emulation/CMakeLists.txt
@@ -4,7 +4,7 @@
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-cmake_minimum_required(VERSION 3.17)
+cmake_minimum_required(VERSION 3.18)
 
 project(gtest CXX)
 

--- a/examples/hello_world_component/CMakeLists.txt
+++ b/examples/hello_world_component/CMakeLists.txt
@@ -4,7 +4,7 @@
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-cmake_minimum_required(VERSION 3.17)
+cmake_minimum_required(VERSION 3.18)
 
 project(hello_world_client CXX)
 

--- a/tests/unit/build/fetchcontent/CMakeLists.txt
+++ b/tests/unit/build/fetchcontent/CMakeLists.txt
@@ -8,7 +8,7 @@
 # This project tests that HPX can be built using FetchContent. It is built by
 # the .github/workflows/linux_fetchcontent.yml GitHub actions workflow.
 
-cmake_minimum_required(VERSION 3.17)
+cmake_minimum_required(VERSION 3.18)
 project(HPXFetchContent LANGUAGES CXX)
 
 # Test that HPX correctly handles having Boost Filesystem and ProgramOptions

--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -3,7 +3,7 @@
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-FROM stellargroup/build_env:6
+FROM stellargroup/build_env:7
 
 # docker build needs to be run in /usr/local
 COPY . /usr/local


### PR DESCRIPTION
In accordance to [this comment](https://github.com/STEllAR-GROUP/hpx/pull/5283/files#r625587954)
CMake 3.18 is necessary to handle the cuda_std_17 compiler feature

TODO
- [x] Install cmake 3.18 in the github actions, default is 3.17
- [x] Wait the update of the docker image for circleci