### PR TITLE
Fix version check for CUDA noexcept/result_of bug

### DIFF
--- a/libs/parallelism/lcos_local/include/hpx/lcos_local/channel.hpp
+++ b/libs/parallelism/lcos_local/include/hpx/lcos_local/channel.hpp
@@ -253,11 +253,12 @@ namespace hpx { namespace lcos { namespace local {
                 push_active_ = false;
             }
             void set_deferred(T&& val)
-            // CUDA versions less than 11.4 don't compile push_pt correctly if
-            // this is noexcept. hpx::util::result_of (and std::result_of)
-            // inside deferred_call does not detect that the call is valid, and
-            // compilation fails.
-#if !defined(HPX_CUDA_VERSION) || (HPX_CUDA_VERSION >= 0x1104)
+            // NVCC with GCC versions less than 10 don't compile push_pt
+            // correctly if this is noexcept. hpx::util::result_of (and
+            // std::result_of) inside deferred_call does not detect that the
+            // call is valid, and compilation fails.
+#if !(defined(HPX_CUDA_VERSION) && defined(HPX_GCC_VERSION) &&                 \
+    (HPX_GCC_VERSION < 100000))
                 noexcept
 #endif
             {


### PR DESCRIPTION
The version check was not accurate. It turns out that the behaviour is also dependent on the GCC version, and the new check is what I *think* is closer to the truth. I have not exhaustively tested the combinations though. This seems to hold for the versions on rostam and on compiler explorer. What I had missed earlier is that the different nvcc versions on compiler explorer of course implicitly change the GCC version as well, leading me to incorrectly think that the bug was dependent on the CUDA version (and I seem to have had the version wrong even if the GCC version would not have changed implicitly).