### PR TITLE
Changing the APEX repository to the new location

### DIFF
--- a/cmake/HPX_SetupApex.cmake
+++ b/cmake/HPX_SetupApex.cmake
@@ -32,7 +32,7 @@ if(HPX_WITH_APEX AND NOT TARGET APEX::apex)
       include(FetchContent)
       fetchcontent_declare(
         apex
-        GIT_REPOSITORY https://github.com/khuck/xpress-apex.git
+        GIT_REPOSITORY https://github.com/UO-OACISS/apex.git
         GIT_TAG ${HPX_WITH_APEX_TAG}
       )
 

--- a/cmake/templates/conf.py.in
+++ b/cmake/templates/conf.py.in
@@ -313,9 +313,9 @@ rst_prolog += '''
 .. _macports: https://www.macports.org/
 
 .. |apex| replace:: APEX
-.. _apex: https://khuck.github.io/xpress-apex/
+.. _apex: http://uo-oaciss.github.io/apex
 .. |apex_hpx_doc| replace:: APEX |hpx| documentation
-.. _apex_hpx_doc: https://khuck.github.io/xpress-apex/usage/#hpx-louisiana-state-university
+.. _apex_hpx_doc: https://uo-oaciss.github.io/apex/usage/#hpx-louisiana-state-university
 .. |tau| replace:: TAU
 .. _tau: https://www.cs.uoregon.edu/research/tau/home.php
 .. |cmake| replace:: CMake


### PR DESCRIPTION
at https://github.com/UO-OACISS/apex.git, and updating
the APEX documentation link to https://uo-oaciss.github.io/apex.

## Any background context you want to provide?

Moved the APEX repo from my personal workspace on GitHub to the UO-OACISS organization. 