### PR TITLE
Add get_completion_scheduler CPO and customize bulk for thread_pool_scheduler

### DIFF
--- a/libs/core/execution_base/CMakeLists.txt
+++ b/libs/core/execution_base/CMakeLists.txt
@@ -10,6 +10,7 @@ set(execution_base_headers
     hpx/execution_base/context_base.hpp
     hpx/execution_base/detail/spinlock_deadlock_detection.hpp
     hpx/execution_base/execution.hpp
+    hpx/execution_base/completion_scheduler.hpp
     hpx/execution_base/operation_state.hpp
     hpx/execution_base/receiver.hpp
     hpx/execution_base/register_locks.hpp

--- a/libs/core/execution_base/include/hpx/execution_base/completion_scheduler.hpp
+++ b/libs/core/execution_base/include/hpx/execution_base/completion_scheduler.hpp
@@ -1,0 +1,92 @@
+//  Copyright (c) 2021 ETH Zurich
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include <hpx/config.hpp>
+#include <hpx/execution_base/sender.hpp>
+#include <hpx/functional/tag_dispatch.hpp>
+
+#include <type_traits>
+
+namespace hpx::execution::experimental {
+    template <typename Scheduler>
+    struct get_completion_scheduler_t final
+      : hpx::functional::tag<get_completion_scheduler_t<Scheduler>>
+    {
+    };
+
+    template <typename Scheduler>
+    HPX_INLINE_CONSTEXPR_VARIABLE get_completion_scheduler_t<Scheduler>
+        get_completion_scheduler{};
+
+    namespace detail {
+        template <bool TagDispatchable, typename CPO, typename Sender>
+        struct has_completion_scheduler_impl : std::false_type
+        {
+        };
+
+        template <typename CPO, typename Sender>
+        struct has_completion_scheduler_impl<true, CPO, Sender>
+          : hpx::execution::experimental::is_scheduler<hpx::functional::
+                    tag_dispatch_result_t<get_completion_scheduler_t<CPO>,
+                        std::decay_t<Sender> const&>>
+        {
+        };
+
+        template <typename CPO, typename Sender>
+        struct has_completion_scheduler
+          : has_completion_scheduler_impl<
+                hpx::functional::is_tag_dispatchable_v<
+                    get_completion_scheduler_t<CPO>,
+                    std::decay_t<Sender> const&>,
+                CPO, Sender>
+        {
+        };
+
+        template <typename CPO, typename Sender>
+        HPX_INLINE_CONSTEXPR_VARIABLE bool has_completion_scheduler_v =
+            has_completion_scheduler<CPO, Sender>::value;
+
+        template <bool HasCompletionScheduler, typename ReceiverCPO,
+            typename Sender, typename AlgorithmCPO, typename... Ts>
+        struct is_completion_scheduler_tag_dispatchable_impl : std::false_type
+        {
+        };
+
+        template <typename ReceiverCPO, typename Sender, typename AlgorithmCPO,
+            typename... Ts>
+        struct is_completion_scheduler_tag_dispatchable_impl<true, ReceiverCPO,
+            Sender, AlgorithmCPO, Ts...>
+          : std::integral_constant<bool,
+                hpx::functional::is_tag_dispatchable_v<AlgorithmCPO,
+                    hpx::functional::tag_dispatch_result_t<
+                        hpx::execution::experimental::
+                            get_completion_scheduler_t<ReceiverCPO>,
+                        Sender>,
+                    Sender, Ts...>>
+        {
+        };
+
+        template <typename ReceiverCPO, typename Sender, typename AlgorithmCPO,
+            typename... Ts>
+        struct is_completion_scheduler_tag_dispatchable
+          : is_completion_scheduler_tag_dispatchable_impl<
+                hpx::execution::experimental::detail::
+                    has_completion_scheduler_v<ReceiverCPO, Sender>,
+                ReceiverCPO, Sender, AlgorithmCPO, Ts...>
+        {
+        };
+
+        template <typename ReceiverCPO, typename Sender, typename AlgorithmCPO,
+            typename... Ts>
+        HPX_INLINE_CONSTEXPR_VARIABLE bool
+            is_completion_scheduler_tag_dispatchable_v =
+                is_completion_scheduler_tag_dispatchable<ReceiverCPO, Sender,
+                    AlgorithmCPO, Ts...>::value;
+
+    }    // namespace detail
+}    // namespace hpx::execution::experimental

--- a/libs/core/execution_base/include/hpx/execution_base/execution.hpp
+++ b/libs/core/execution_base/include/hpx/execution_base/execution.hpp
@@ -342,7 +342,8 @@ namespace hpx { namespace parallel { namespace execution {
         {
             return detail::bulk_sync_execute_fn_helper<
                 std::decay_t<Executor>>::call(std::forward<Executor>(exec),
-                std::forward<F>(f), hpx::util::make_counting_shape(shape),
+                std::forward<F>(f),
+                hpx::util::detail::make_counting_shape(shape),
                 std::forward<Ts>(ts)...);
         }
     } bulk_sync_execute{};
@@ -413,7 +414,8 @@ namespace hpx { namespace parallel { namespace execution {
         {
             return detail::bulk_async_execute_fn_helper<
                 std::decay_t<Executor>>::call(std::forward<Executor>(exec),
-                std::forward<F>(f), hpx::util::make_counting_shape(shape),
+                std::forward<F>(f),
+                hpx::util::detail::make_counting_shape(shape),
                 std::forward<Ts>(ts)...);
         }
     } bulk_async_execute{};
@@ -491,7 +493,8 @@ namespace hpx { namespace parallel { namespace execution {
         {
             return detail::bulk_then_execute_fn_helper<
                 std::decay_t<Executor>>::call(std::forward<Executor>(exec),
-                std::forward<F>(f), hpx::util::make_counting_shape(shape),
+                std::forward<F>(f),
+                hpx::util::detail::make_counting_shape(shape),
                 std::forward<Future>(predecessor), std::forward<Ts>(ts)...);
         }
     } bulk_then_execute{};

--- a/libs/core/execution_base/include/hpx/execution_base/receiver.hpp
+++ b/libs/core/execution_base/include/hpx/execution_base/receiver.hpp
@@ -230,4 +230,30 @@ namespace hpx { namespace execution { namespace experimental {
     template <typename T, typename... As>
     HPX_INLINE_CONSTEXPR_VARIABLE bool is_nothrow_receiver_of_v =
         is_nothrow_receiver_of<T, As...>::value;
-}}}    // namespace hpx::execution::experimental
+
+    namespace detail {
+        template <typename CPO>
+        struct is_receiver_cpo : std::false_type
+        {
+        };
+
+        template <>
+        struct is_receiver_cpo<set_value_t> : std::true_type
+        {
+        };
+
+        template <>
+        struct is_receiver_cpo<set_error_t> : std::true_type
+        {
+        };
+
+        template <>
+        struct is_receiver_cpo<set_done_t> : std::true_type
+        {
+        };
+
+        template <typename CPO>
+        HPX_INLINE_CONSTEXPR_VARIABLE bool is_receiver_cpo_v =
+            is_receiver_cpo<CPO>::value;
+    }    // namespace detail
+}}}      // namespace hpx::execution::experimental

--- a/libs/core/iterator_support/include/hpx/iterator_support/counting_iterator.hpp
+++ b/libs/core/iterator_support/include/hpx/iterator_support/counting_iterator.hpp
@@ -11,6 +11,9 @@
 
 #include <hpx/config.hpp>
 #include <hpx/iterator_support/iterator_adaptor.hpp>
+#include <hpx/iterator_support/iterator_range.hpp>
+#include <hpx/iterator_support/range.hpp>
+#include <hpx/iterator_support/traits/is_range.hpp>
 #include <hpx/type_support/identity.hpp>
 #include <hpx/type_support/lazy_conditional.hpp>
 

--- a/libs/core/iterator_support/include/hpx/iterator_support/counting_shape.hpp
+++ b/libs/core/iterator_support/include/hpx/iterator_support/counting_shape.hpp
@@ -12,7 +12,7 @@
 #include <hpx/iterator_support/range.hpp>
 #include <hpx/iterator_support/traits/is_range.hpp>
 
-namespace hpx { namespace util {
+namespace hpx { namespace util { namespace detail {
 
     ///////////////////////////////////////////////////////////////////////////
     template <typename Incrementable>
@@ -27,4 +27,4 @@ namespace hpx { namespace util {
             hpx::util::make_counting_iterator(Incrementable(0)),
             hpx::util::make_counting_iterator(n));
     }
-}}    // namespace hpx::util
+}}}    // namespace hpx::util::detail

--- a/libs/core/iterator_support/include/hpx/iterator_support/traits/is_range.hpp
+++ b/libs/core/iterator_support/include/hpx/iterator_support/traits/is_range.hpp
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <hpx/config.hpp>
 #include <hpx/iterator_support/range.hpp>
 #include <hpx/iterator_support/traits/is_sentinel_for.hpp>
 
@@ -29,16 +30,25 @@ namespace hpx { namespace traits {
     {
     };
 
+    template <typename T>
+    HPX_INLINE_CONSTEXPR_VARIABLE bool is_range_v = is_range<T>::value;
+
     ///////////////////////////////////////////////////////////////////////////
     template <typename T, typename Enable = void>
     struct range_iterator : util::detail::iterator<T>
     {
     };
 
+    template <typename T>
+    using range_iterator_t = typename range_iterator<T>::type;
+
     template <typename T, typename Enable = void>
     struct range_sentinel : util::detail::sentinel<T>
     {
     };
+
+    template <typename T>
+    using range_sentinel_t = typename range_sentinel<T>::type;
 
     ///////////////////////////////////////////////////////////////////////////
     template <typename R, bool IsRange = is_range<R>::value>

--- a/libs/core/tag_dispatch/include/hpx/functional/tag_dispatch.hpp
+++ b/libs/core/tag_dispatch/include/hpx/functional/tag_dispatch.hpp
@@ -76,7 +76,7 @@ namespace hpx { namespace functional {
         is_nothrow_tag_dispatchable<Tag, Args...>::value;
 
     /// `hpx::functional::tag_dispatch_result<Tag, Args...>` is the trait
-    /// returning the result type of the call hpx::functioanl::tag_dispatch. This
+    /// returning the result type of the call hpx::functional::tag_dispatch. This
     /// can be used in a SFINAE context.
     template <typename Tag, typename... Args>
     using tag_dispatch_result =

--- a/libs/core/tag_dispatch/include/hpx/functional/tag_fallback_dispatch.hpp
+++ b/libs/core/tag_dispatch/include/hpx/functional/tag_fallback_dispatch.hpp
@@ -78,7 +78,7 @@ namespace hpx { namespace functional {
         is_nothrow_tag_fallback_dispatchable<Tag, Args...>::value;
 
     /// `hpx::functional::tag_fallback_dispatch_result<Tag, Args...>` is the trait
-    /// returning the result type of the call hpx::functioanl::tag_fallback_dispatch. This
+    /// returning the result type of the call hpx::functional::tag_fallback_dispatch. This
     /// can be used in a SFINAE context.
     template <typename Tag, typename... Args>
     using tag_fallback_dispatch_result =

--- a/libs/core/tag_dispatch/include/hpx/functional/tag_priority_dispatch.hpp
+++ b/libs/core/tag_dispatch/include/hpx/functional/tag_priority_dispatch.hpp
@@ -79,7 +79,7 @@ namespace hpx { namespace functional {
         is_nothrow_tag_override_dispatchable<Tag, Args...>::value;
 
     /// `hpx::functional::tag_override_dispatch_result<Tag, Args...>` is the trait
-    /// returning the result type of the call hpx::functioanl::tag_override_dispatch. This
+    /// returning the result type of the call hpx::functional::tag_override_dispatch. This
     /// can be used in a SFINAE context.
     template <typename Tag, typename... Args>
     using tag_override_dispatch_result =

--- a/libs/parallelism/execution/include/hpx/execution/algorithms/bulk.hpp
+++ b/libs/parallelism/execution/include/hpx/execution/algorithms/bulk.hpp
@@ -14,6 +14,7 @@
 #include <hpx/errors/try_catch_exception_ptr.hpp>
 #include <hpx/execution/algorithms/detail/partial_algorithm.hpp>
 #include <hpx/execution/algorithms/transform.hpp>
+#include <hpx/execution_base/completion_scheduler.hpp>
 #include <hpx/execution_base/receiver.hpp>
 #include <hpx/execution_base/sender.hpp>
 #include <hpx/functional/invoke_result.hpp>

--- a/libs/parallelism/execution/include/hpx/execution/algorithms/bulk.hpp
+++ b/libs/parallelism/execution/include/hpx/execution/algorithms/bulk.hpp
@@ -18,7 +18,7 @@
 #include <hpx/execution_base/receiver.hpp>
 #include <hpx/execution_base/sender.hpp>
 #include <hpx/functional/invoke_result.hpp>
-#include <hpx/functional/tag_fallback_dispatch.hpp>
+#include <hpx/functional/tag_priority_dispatch.hpp>
 #include <hpx/iterator_support/counting_shape.hpp>
 #include <hpx/type_support/pack.hpp>
 
@@ -53,43 +53,42 @@ namespace hpx { namespace execution { namespace experimental {
 
             static constexpr bool sends_done = false;
 
-            template <typename Receiver>
-            auto connect(Receiver&& receiver) &&
+            template <typename CPO,
+                // clang-format off
+                HPX_CONCEPT_REQUIRES_(
+                    hpx::execution::experimental::detail::is_receiver_cpo_v<CPO> &&
+                    hpx::execution::experimental::detail::has_completion_scheduler_v<
+                        CPO, std::decay_t<Sender>>)
+                // clang-format on
+                >
+            friend constexpr auto tag_dispatch(
+                hpx::execution::experimental::get_completion_scheduler_t<CPO>,
+                bulk_sender const& sender)
             {
-                return hpx::execution::experimental::connect(std::move(sender),
-                    bulk_receiver<Receiver, Shape, F>(
-                        std::forward<Receiver>(receiver), std::move(shape),
-                        std::move(f)));
+                return hpx::execution::experimental::get_completion_scheduler<
+                    CPO>(sender.sender);
             }
 
             template <typename Receiver>
-            auto connect(Receiver&& receiver) &
-            {
-                return hpx::execution::experimental::connect(sender,
-                    bulk_receiver<Receiver, Shape, F>(
-                        std::forward<Receiver>(receiver), shape, f));
-            }
-
-            template <typename Receiver, typename Shape_, typename F_>
             struct bulk_receiver
             {
                 std::decay_t<Receiver> receiver;
-                std::decay_t<Shape_> shape;
-                std::decay_t<F_> f;
+                std::decay_t<Shape> shape;
+                std::decay_t<F> f;
 
-                template <typename Receiver_, typename Shape__, typename F__>
-                bulk_receiver(Receiver_&& receiver, Shape__&& shape, F__&& f)
+                template <typename Receiver_, typename Shape_, typename F_>
+                bulk_receiver(Receiver_&& receiver, Shape_&& shape, F_&& f)
                   : receiver(std::forward<Receiver_>(receiver))
-                  , shape(std::forward<Shape__>(shape))
-                  , f(std::forward<F__>(f))
+                  , shape(std::forward<Shape_>(shape))
+                  , f(std::forward<F_>(f))
                 {
                 }
 
-                template <typename E>
-                void set_error(E&& e) && noexcept
+                template <typename Error>
+                void set_error(Error&& error) && noexcept
                 {
                     hpx::execution::experimental::set_error(
-                        std::move(receiver), std::forward<E>(e));
+                        std::move(receiver), std::forward<Error>(error));
                 }
 
                 void set_done() && noexcept
@@ -125,14 +124,49 @@ namespace hpx { namespace execution { namespace experimental {
                         });
                 }
             };
+
+            template <typename Receiver>
+            auto connect(Receiver&& receiver) &&
+            {
+                return hpx::execution::experimental::connect(std::move(sender),
+                    bulk_receiver<Receiver>(std::forward<Receiver>(receiver),
+                        std::move(shape), std::move(f)));
+            }
+
+            template <typename Receiver>
+            auto connect(Receiver&& receiver) &
+            {
+                return hpx::execution::experimental::connect(sender,
+                    bulk_receiver<Receiver>(
+                        std::forward<Receiver>(receiver), shape, f));
+            }
         };
     }    // namespace detail
 
     ///////////////////////////////////////////////////////////////////////////
     HPX_INLINE_CONSTEXPR_VARIABLE struct bulk_t final
-      : hpx::functional::tag_fallback<bulk_t>
+      : hpx::functional::tag_priority<bulk_t>
     {
     private:
+        // clang-format off
+        template <typename Sender, typename Shape, typename F,
+            HPX_CONCEPT_REQUIRES_(
+                is_sender_v<Sender> &&
+                hpx::execution::experimental::detail::
+                    is_completion_scheduler_tag_dispatchable_v<
+                        hpx::execution::experimental::set_value_t, Sender,
+                        bulk_t, Shape, F>)>
+        // clang-format on
+        friend constexpr HPX_FORCEINLINE auto tag_override_dispatch(
+            bulk_t, Sender&& sender, Shape const& shape, F&& f)
+        {
+            auto scheduler =
+                hpx::execution::experimental::get_completion_scheduler<
+                    hpx::execution::experimental::set_value_t>(sender);
+            return hpx::functional::tag_dispatch(bulk_t{}, std::move(scheduler),
+                std::forward<Sender>(sender), shape, std::forward<F>(f));
+        }
+
         // clang-format off
         template <typename Sender, typename Shape, typename F,
             HPX_CONCEPT_REQUIRES_(
@@ -144,9 +178,10 @@ namespace hpx { namespace execution { namespace experimental {
             bulk_t, Sender&& sender, Shape const& shape, F&& f)
         {
             return detail::bulk_sender<Sender,
-                hpx::util::counting_shape_type<Shape>, F>{
+                hpx::util::detail::counting_shape_type<Shape>, F>{
                 std::forward<Sender>(sender),
-                hpx::util::make_counting_shape(shape), std::forward<F>(f)};
+                hpx::util::detail::make_counting_shape(shape),
+                std::forward<F>(f)};
         }
 
         // clang-format off

--- a/libs/parallelism/execution/include/hpx/execution/algorithms/transform.hpp
+++ b/libs/parallelism/execution/include/hpx/execution/algorithms/transform.hpp
@@ -10,6 +10,7 @@
 #include <hpx/concepts/concepts.hpp>
 #include <hpx/errors/try_catch_exception_ptr.hpp>
 #include <hpx/execution/algorithms/detail/partial_algorithm.hpp>
+#include <hpx/execution_base/completion_scheduler.hpp>
 #include <hpx/execution_base/receiver.hpp>
 #include <hpx/execution_base/sender.hpp>
 #include <hpx/functional/tag_fallback_dispatch.hpp>
@@ -115,6 +116,22 @@ namespace hpx { namespace execution { namespace experimental {
                     std::exception_ptr>>;
 
             static constexpr bool sends_done = false;
+
+            template <typename CPO,
+                // clang-format off
+                HPX_CONCEPT_REQUIRES_(
+                    hpx::execution::experimental::detail::is_receiver_cpo_v<CPO> &&
+                    hpx::execution::experimental::detail::has_completion_scheduler_v<
+                        CPO, std::decay_t<Sender>>)
+                // clang-format on
+                >
+            friend constexpr auto tag_dispatch(
+                hpx::execution::experimental::get_completion_scheduler_t<CPO>,
+                transform_sender const& sender)
+            {
+                return hpx::execution::experimental::get_completion_scheduler<
+                    CPO>(sender.sender);
+            }
 
             template <typename Receiver>
             auto connect(Receiver&& receiver) &&

--- a/libs/parallelism/executors/CMakeLists.txt
+++ b/libs/parallelism/executors/CMakeLists.txt
@@ -33,6 +33,7 @@ set(executors_headers
     hpx/executors/sync.hpp
     hpx/executors/thread_pool_executor.hpp
     hpx/executors/thread_pool_scheduler.hpp
+    hpx/executors/thread_pool_scheduler_bulk.hpp
 )
 
 # Default location is $HPX_ROOT/libs/executors/include_compatibility

--- a/libs/parallelism/executors/include/hpx/executors/scheduler_executor.hpp
+++ b/libs/parallelism/executors/include/hpx/executors/scheduler_executor.hpp
@@ -164,9 +164,9 @@ namespace hpx { namespace execution { namespace experimental {
         }
 
         template <typename F, typename S, typename... Ts>
-        decltype(auto) bulk_sync_execute(F&& f, S const& shape, Ts&&... ts)
+        void bulk_sync_execute(F&& f, S const& shape, Ts&&... ts)
         {
-            return sync_wait(bulk(schedule(sched_), shape,
+            sync_wait(bulk(schedule(sched_), shape,
                 hpx::util::bind_back(
                     std::forward<F>(f), std::forward<Ts>(ts)...)));
         }

--- a/libs/parallelism/executors/include/hpx/executors/thread_pool_scheduler.hpp
+++ b/libs/parallelism/executors/include/hpx/executors/thread_pool_scheduler.hpp
@@ -46,84 +46,84 @@ namespace hpx { namespace execution { namespace experimental {
         // support with_priority property
         friend thread_pool_scheduler tag_dispatch(
             hpx::execution::experimental::with_priority_t,
-            thread_pool_scheduler const& sched,
+            thread_pool_scheduler const& scheduler,
             hpx::threads::thread_priority priority)
         {
-            auto exec_with_priority = sched;
-            exec_with_priority.priority_ = priority;
-            return exec_with_priority;
+            auto sched_with_priority = scheduler;
+            sched_with_priority.priority_ = priority;
+            return sched_with_priority;
         }
 
         friend hpx::threads::thread_priority tag_dispatch(
             hpx::execution::experimental::get_priority_t,
-            thread_pool_scheduler const& sched)
+            thread_pool_scheduler const& scheduler)
         {
-            return sched.priority_;
+            return scheduler.priority_;
         }
 
         // support with_stacksize property
         friend thread_pool_scheduler tag_dispatch(
             hpx::execution::experimental::with_stacksize_t,
-            thread_pool_scheduler const& sched,
+            thread_pool_scheduler const& scheduler,
             hpx::threads::thread_stacksize stacksize)
         {
-            auto exec_with_stacksize = sched;
-            exec_with_stacksize.stacksize_ = stacksize;
-            return exec_with_stacksize;
+            auto sched_with_stacksize = scheduler;
+            sched_with_stacksize.stacksize_ = stacksize;
+            return sched_with_stacksize;
         }
 
         friend hpx::threads::thread_stacksize tag_dispatch(
             hpx::execution::experimental::get_stacksize_t,
-            thread_pool_scheduler const& sched)
+            thread_pool_scheduler const& scheduler)
         {
-            return sched.stacksize_;
+            return scheduler.stacksize_;
         }
 
         // support with_hint property
         friend thread_pool_scheduler tag_dispatch(
             hpx::execution::experimental::with_hint_t,
-            thread_pool_scheduler const& sched,
+            thread_pool_scheduler const& scheduler,
             hpx::threads::thread_schedule_hint hint)
         {
-            auto exec_with_hint = sched;
-            exec_with_hint.schedulehint_ = hint;
-            return exec_with_hint;
+            auto sched_with_hint = scheduler;
+            sched_with_hint.schedulehint_ = hint;
+            return sched_with_hint;
         }
 
         friend hpx::threads::thread_schedule_hint tag_dispatch(
             hpx::execution::experimental::get_hint_t,
-            thread_pool_scheduler const& sched)
+            thread_pool_scheduler const& scheduler)
         {
-            return sched.schedulehint_;
+            return scheduler.schedulehint_;
         }
 
         // support with_annotation property
         friend constexpr thread_pool_scheduler tag_dispatch(
             hpx::execution::experimental::with_annotation_t,
-            thread_pool_scheduler const& sched, char const* annotation)
+            thread_pool_scheduler const& scheduler, char const* annotation)
         {
-            auto exec_with_annotation = sched;
-            exec_with_annotation.annotation_ = annotation;
-            return exec_with_annotation;
+            auto sched_with_annotation = scheduler;
+            sched_with_annotation.annotation_ = annotation;
+            return sched_with_annotation;
         }
 
         friend thread_pool_scheduler tag_dispatch(
             hpx::execution::experimental::with_annotation_t,
-            thread_pool_scheduler const& sched, std::string annotation)
+            thread_pool_scheduler const& scheduler, std::string annotation)
         {
-            auto exec_with_annotation = sched;
-            exec_with_annotation.annotation_ =
+            auto sched_with_annotation = scheduler;
+            sched_with_annotation.annotation_ =
                 hpx::util::detail::store_function_annotation(
                     std::move(annotation));
-            return exec_with_annotation;
+            return sched_with_annotation;
         }
 
         // support get_annotation property
         friend constexpr char const* tag_dispatch(
             hpx::execution::experimental::get_annotation_t,
-            thread_pool_scheduler const& sched) noexcept
+            thread_pool_scheduler const& scheduler) noexcept
         {
-            return sched.annotation_;
+            return scheduler.annotation_;
         }
 
         template <typename F>
@@ -142,12 +142,12 @@ namespace hpx { namespace execution { namespace experimental {
         template <typename Scheduler, typename R>
         struct operation_state
         {
-            std::decay_t<Scheduler> sched;
+            std::decay_t<Scheduler> scheduler;
             std::decay_t<R> r;
 
             template <typename Scheduler_, typename R_>
-            operation_state(Scheduler_&& sched, R_&& r)
-              : sched(std::forward<Scheduler_>(sched))
+            operation_state(Scheduler_&& scheduler, R_&& r)
+              : scheduler(std::forward<Scheduler_>(scheduler))
               , r(std::forward<R_>(r))
             {
             }
@@ -161,7 +161,7 @@ namespace hpx { namespace execution { namespace experimental {
             {
                 hpx::detail::try_catch_exception_ptr(
                     [&]() {
-                        sched.execute([r = std::move(r)]() mutable {
+                        scheduler.execute([r = std::move(r)]() mutable {
                             hpx::execution::experimental::set_value(
                                 std::move(r));
                         });
@@ -176,7 +176,7 @@ namespace hpx { namespace execution { namespace experimental {
         template <typename Scheduler>
         struct sender
         {
-            std::decay_t<Scheduler> sched;
+            std::decay_t<Scheduler> scheduler;
 
             template <template <typename...> class Tuple,
                 template <typename...> class Variant>
@@ -190,13 +190,13 @@ namespace hpx { namespace execution { namespace experimental {
             template <typename R>
             operation_state<Scheduler, R> connect(R&& r) &&
             {
-                return {std::move(sched), std::forward<R>(r)};
+                return {std::move(scheduler), std::forward<R>(r)};
             }
 
             template <typename R>
             operation_state<Scheduler, R> connect(R&& r) &
             {
-                return {sched, std::forward<R>(r)};
+                return {scheduler, std::forward<R>(r)};
             }
         };
 

--- a/libs/parallelism/executors/include/hpx/executors/thread_pool_scheduler_bulk.hpp
+++ b/libs/parallelism/executors/include/hpx/executors/thread_pool_scheduler_bulk.hpp
@@ -1,0 +1,309 @@
+//  Copyright (c) 2021 ETH Zurich
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include <hpx/config.hpp>
+#include <hpx/assert.hpp>
+#include <hpx/coroutines/thread_enums.hpp>
+#include <hpx/datastructures/tuple.hpp>
+#include <hpx/datastructures/variant.hpp>
+#include <hpx/execution/algorithms/bulk.hpp>
+#include <hpx/execution/executors/execution_parameters.hpp>
+#include <hpx/execution_base/completion_scheduler.hpp>
+#include <hpx/execution_base/receiver.hpp>
+#include <hpx/execution_base/sender.hpp>
+#include <hpx/executors/thread_pool_scheduler.hpp>
+#include <hpx/functional/bind_front.hpp>
+#include <hpx/functional/tag_dispatch.hpp>
+#include <hpx/iterator_support/counting_iterator.hpp>
+#include <hpx/iterator_support/traits/is_iterator.hpp>
+#include <hpx/iterator_support/traits/is_range.hpp>
+#include <hpx/threading_base/register_thread.hpp>
+
+#include <atomic>
+#include <cstddef>
+#include <exception>
+#include <optional>
+#include <string>
+#include <type_traits>
+#include <utility>
+
+namespace hpx { namespace execution { namespace experimental {
+    namespace detail {
+        template <typename Sender, typename Shape, typename F>
+        struct thread_pool_bulk_sender
+        {
+            thread_pool_scheduler scheduler;
+            std::decay_t<Sender> sender;
+            std::decay_t<Shape> shape;
+            std::decay_t<F> f;
+
+            template <template <typename...> class Tuple,
+                template <typename...> class Variant>
+            using value_types =
+                typename hpx::execution::experimental::sender_traits<
+                    Sender>::template value_types<Tuple, Variant>;
+
+            template <template <typename...> class Variant>
+            using error_types =
+                hpx::util::detail::unique_t<hpx::util::detail::prepend_t<
+                    typename hpx::execution::experimental::sender_traits<
+                        Sender>::template error_types<Variant>,
+                    std::exception_ptr>>;
+
+            static constexpr bool sends_done = false;
+
+            template <typename CPO,
+                // clang-format off
+                HPX_CONCEPT_REQUIRES_(
+                    hpx::execution::experimental::detail::is_receiver_cpo_v<CPO> &&
+                    (std::is_same_v<CPO, hpx::execution::experimental::set_value_t> ||
+                        hpx::execution::experimental::detail::has_completion_scheduler_v<
+                                hpx::execution::experimental::set_error_t,
+                                std::decay_t<Sender>> ||
+                        hpx::execution::experimental::detail::has_completion_scheduler_v<
+                                hpx::execution::experimental::set_done_t,
+                                std::decay_t<Sender>>))
+                // clang-format on
+                >
+            friend constexpr auto tag_dispatch(
+                hpx::execution::experimental::get_completion_scheduler_t<CPO>,
+                thread_pool_bulk_sender const& s)
+            {
+                if constexpr (std::is_same_v<std::decay_t<CPO>,
+                                  hpx::execution::experimental::set_value_t>)
+                {
+                    return s.scheduler;
+                }
+                else
+                {
+                    return hpx::execution::experimental::
+                        get_completion_scheduler<CPO>(s);
+                }
+            }
+
+            template <typename Receiver>
+            struct operation_state
+            {
+                struct bulk_receiver
+                {
+                    operation_state* op_state;
+
+                    template <typename E>
+                    void set_error(E&& e) && noexcept
+                    {
+                        hpx::execution::experimental::set_error(
+                            std::move(op_state->receiver), std::forward<E>(e));
+                    }
+
+                    void set_done() && noexcept
+                    {
+                        hpx::execution::experimental::set_done(
+                            std::move(op_state->receiver));
+                    };
+
+                    template <typename Iterator>
+                    struct set_value_loop_visitor
+                    {
+                        std::decay_t<Iterator> it;
+                        operation_state* op_state;
+
+                        void operator()(hpx::monostate const&) const
+                        {
+                            HPX_UNREACHABLE;
+                        }
+
+                        template <typename Ts,
+                            typename = std::enable_if_t<!std::is_same_v<
+                                std::decay_t<Ts>, hpx::monostate>>>
+                        void operator()(Ts& ts)
+                        {
+                            hpx::util::invoke_fused(
+                                hpx::util::bind_front(
+                                    op_state->f, *std::move(it)),
+                                ts);
+                        }
+                    };
+
+                    struct set_value_end_loop_visitor
+                    {
+                        operation_state* op_state;
+
+                        void operator()(hpx::monostate&&) const
+                        {
+                            std::terminate();
+                        }
+
+                        template <typename Ts,
+                            typename = std::enable_if_t<!std::is_same_v<
+                                std::decay_t<Ts>, hpx::monostate>>>
+                        void operator()(Ts&& ts) const
+                        {
+                            hpx::util::invoke_fused(
+                                hpx::util::bind_front(
+                                    hpx::execution::experimental::set_value,
+                                    std::move(op_state->receiver)),
+                                std::forward<Ts>(ts));
+                        }
+                    };
+
+                    using range_value_type = hpx::traits::iter_value_t<
+                        hpx::traits::range_iterator_t<Shape>>;
+
+                    template <typename... Ts,
+                        typename = std::enable_if_t<
+                            hpx::is_invocable_v<F, range_value_type,
+                                std::add_lvalue_reference_t<Ts>...>>>
+                    void set_value(Ts&&... ts) && noexcept
+                    {
+                        auto const n = hpx::util::size(op_state->shape);
+
+                        if (n == 0)
+                        {
+                            hpx::execution::experimental::set_value(
+                                std::move(op_state->receiver),
+                                std::forward<Ts>(ts)...);
+                            return;
+                        }
+
+                        op_state->ts.template emplace<hpx::tuple<Ts...>>(
+                            std::forward<Ts>(ts)...);
+
+                        // TODO: chunking and hierarchical spawning?
+                        using iterator_type =
+                            hpx::traits::range_iterator_t<Shape>;
+                        for (iterator_type it = std::begin(op_state->shape);
+                             it != std::end(op_state->shape); ++it)
+                        {
+                            auto task_f = [op_state = this->op_state,
+                                              it = std::move(it)]() mutable {
+                                try
+                                {
+                                    hpx::visit(
+                                        set_value_loop_visitor<iterator_type>{
+                                            std::move(it), op_state},
+                                        op_state->ts);
+                                }
+                                catch (...)
+                                {
+                                    if (!op_state->exception_thrown.exchange(
+                                            true))
+                                    {
+                                        op_state->exception =
+                                            std::current_exception();
+                                    }
+                                }
+
+                                if (--(op_state->tasks_remaining) == 0)
+                                {
+                                    if (op_state->exception_thrown)
+                                    {
+                                        HPX_ASSERT(
+                                            op_state->exception.has_value());
+                                        hpx::execution::experimental::set_error(
+                                            std::move(op_state->receiver),
+                                            std::move(
+                                                op_state->exception.value()));
+                                    }
+                                    else
+                                    {
+                                        hpx::visit(
+                                            set_value_end_loop_visitor{
+                                                op_state},
+                                            std::move(op_state->ts));
+                                    }
+                                }
+                            };
+
+                            threads::thread_init_data data(
+                                threads::make_thread_function_nullary(task_f),
+                                "thread_pool_bulk_sender task",
+                                get_priority(op_state->scheduler),
+                                get_hint(op_state->scheduler),
+                                get_stacksize(op_state->scheduler));
+                            threads::register_work(
+                                data, op_state->scheduler.get_thread_pool());
+                        }
+                    }
+                };
+
+                using operation_state_type =
+                    hpx::execution::experimental::connect_result_t<Sender,
+                        bulk_receiver>;
+
+                thread_pool_scheduler scheduler;
+                operation_state_type op_state;
+                std::decay_t<Shape> shape;
+                std::decay_t<F> f;
+                std::decay_t<Receiver> receiver;
+                std::atomic<decltype(hpx::util::size(shape))> tasks_remaining{
+                    hpx::util::size(shape)};
+                hpx::util::detail::prepend_t<
+                    value_types<hpx::tuple, hpx::variant>, hpx::monostate>
+                    ts;
+                std::atomic<bool> exception_thrown{false};
+                std::optional<std::exception_ptr> exception;
+
+                template <typename Sender_, typename Shape_, typename F_,
+                    typename Receiver_>
+                operation_state(thread_pool_scheduler&& scheduler,
+                    Sender_&& sender, Shape_&& shape, F_&& f,
+                    Receiver_&& receiver)
+                  : scheduler(std::move(scheduler))
+                  , op_state(hpx::execution::experimental::connect(
+                        std::forward<Sender_>(sender), bulk_receiver{this}))
+                  , shape(std::forward<Shape_>(shape))
+                  , f(std::forward<F_>(f))
+                  , receiver(std::forward<Receiver_>(receiver))
+                {
+                }
+
+                void start() noexcept
+                {
+                    op_state.start();
+                }
+            };
+
+            template <typename Receiver>
+            auto connect(Receiver&& receiver) &&
+            {
+                return operation_state<std::decay_t<Receiver>>{
+                    std::move(scheduler), std::move(sender), std::move(shape),
+                    std::move(f), std::forward<Receiver>(receiver)};
+            }
+
+            template <typename Receiver>
+            auto connect(Receiver&& receiver) &
+            {
+                return operation_state<std::decay_t<Receiver>>{scheduler,
+                    sender, shape, f, std::forward<Receiver>(receiver)};
+            }
+        };
+    }    // namespace detail
+
+    template <typename Sender, typename Shape, typename F,
+        HPX_CONCEPT_REQUIRES_(std::is_integral_v<std::decay_t<Shape>>)>
+    constexpr auto tag_dispatch(bulk_t, thread_pool_scheduler scheduler,
+        Sender&& sender, Shape&& shape, F&& f)
+    {
+        return detail::thread_pool_bulk_sender<std::decay_t<Sender>,
+            hpx::util::detail::counting_shape_type<std::decay_t<Shape>>,
+            std::decay_t<F>>{std::move(scheduler), std::forward<Sender>(sender),
+            hpx::util::detail::make_counting_shape(shape), std::forward<F>(f)};
+    }
+
+    template <typename Sender, typename Shape, typename F,
+        HPX_CONCEPT_REQUIRES_(!std::is_integral_v<std::decay_t<Shape>>)>
+    constexpr auto tag_dispatch(bulk_t, thread_pool_scheduler scheduler,
+        Sender&& sender, Shape&& shape, F&& f)
+    {
+        return detail::thread_pool_bulk_sender<std::decay_t<Sender>,
+            std::decay_t<Shape>, std::decay_t<F>>{std::move(scheduler),
+            std::forward<Sender>(sender), std::forward<Shape>(shape),
+            std::forward<F>(f)};
+    }
+}}}    // namespace hpx::execution::experimental

--- a/libs/parallelism/executors/tests/unit/thread_pool_scheduler.cpp
+++ b/libs/parallelism/executors/tests/unit/thread_pool_scheduler.cpp
@@ -1524,6 +1524,7 @@ void test_bulk()
     {
         std::unordered_set<std::string> string_map;
         std::vector<std::string> v = {"hello", "brave", "new", "world"};
+        std::vector<std::string> v_ref = v;
 
         hpx::mutex mtx;
 
@@ -1535,7 +1536,7 @@ void test_bulk()
                 }) |
             ex::sync_wait();
 
-        for (auto const& s : v)
+        for (auto const& s : v_ref)
         {
             HPX_TEST(string_map.find(s) != string_map.end());
         }


### PR DESCRIPTION
Customizes `bulk` for `thread_pool_scheduler`. The customization currently does *not* do any chunking or hierarchical spawning like the `parallel_executor` does. Hierarchical spawning will be a must that I will do separately. I also think the chunking should be the responsibility of the scheduler, rather than the algorithms, but there may be trade-offs I'm missing (and things like this should not be necessary: https://github.com/STEllAR-GROUP/hpx/blob/master/libs/full/compute_cuda/include/hpx/compute/cuda/default_executor_parameters.hpp).

The `get_completion_scheduler` customizations are somewhat verbose, but as far as I can tell it's all mostly necessary. If there are ideas on simplifying them I'd be happy to hear them. Also, all senders don't have a customization since I'm not yet sure it makes sense in those cases. E.g. `when_all` can complete on many different schedulers. `let_value` can also in principle use different senders and thus different schedulers. `just` doesn't have one inherently.

Flybys: leftover renaming from `exec` to `scheduler`. Some utility type traits and constexpr variables (i.e. `_t` and `_v` versions of existing facilities). Moved `make_counting_shape` to `iterator_support` module and `detail` namespace. Fix some typos.