### PR TITLE
Rename simdpar to par_simd

### DIFF
--- a/libs/parallelism/algorithms/include/hpx/parallel/datapar/transform_loop.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/datapar/transform_loop.hpp
@@ -421,7 +421,7 @@ namespace hpx { namespace parallel { namespace util {
                 F&& f)
             {
                 auto ret = util::transform_binary_loop_n<
-                    hpx::execution::simdpar_policy>(first1,
+                    hpx::execution::par_simd_policy>(first1,
                     std::distance(first1, last1), first2, dest,
                     std::forward<F>(f));
 
@@ -465,7 +465,7 @@ namespace hpx { namespace parallel { namespace util {
                 // clang-format on
 
                 auto ret = util::transform_binary_loop_n<
-                    hpx::execution::simdpar_policy>(
+                    hpx::execution::par_simd_policy>(
                     first1, count, first2, dest, std::forward<F>(f));
 
                 return util::in_in_out_result<InIter1, InIter2, OutIter>{

--- a/libs/parallelism/algorithms/include/hpx/parallel/util/detail/algorithm_result.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/util/detail/algorithm_result.hpp
@@ -218,27 +218,27 @@ namespace hpx { namespace parallel { namespace util { namespace detail {
     };
 
     template <typename T>
-    struct algorithm_result_impl<hpx::execution::simdpar_task_policy, T>
+    struct algorithm_result_impl<hpx::execution::par_simd_task_policy, T>
       : algorithm_result_impl<hpx::execution::parallel_task_policy, T>
     {
     };
 
     template <>
-    struct algorithm_result_impl<hpx::execution::simdpar_task_policy, void>
+    struct algorithm_result_impl<hpx::execution::par_simd_task_policy, void>
       : algorithm_result_impl<hpx::execution::parallel_task_policy, void>
     {
     };
 
     template <typename Executor, typename Parameters, typename T>
     struct algorithm_result_impl<
-        hpx::execution::simdpar_task_policy_shim<Executor, Parameters>, T>
+        hpx::execution::par_simd_task_policy_shim<Executor, Parameters>, T>
       : algorithm_result_impl<hpx::execution::parallel_task_policy, T>
     {
     };
 
     template <typename Executor, typename Parameters>
     struct algorithm_result_impl<
-        hpx::execution::simdpar_task_policy_shim<Executor, Parameters>, void>
+        hpx::execution::par_simd_task_policy_shim<Executor, Parameters>, void>
       : algorithm_result_impl<hpx::execution::parallel_task_policy, void>
     {
     };

--- a/libs/parallelism/algorithms/include/hpx/parallel/util/detail/select_partitioner.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/util/detail/select_partitioner.hpp
@@ -48,12 +48,12 @@ namespace hpx { namespace parallel { namespace util { namespace detail {
 #if defined(HPX_HAVE_DATAPAR)
     template <template <typename...> class Partitioner,
         template <typename...> class TaskPartitioner>
-    struct select_partitioner<hpx::execution::simdpar_task_policy, Partitioner,
+    struct select_partitioner<hpx::execution::par_simd_task_policy, Partitioner,
         TaskPartitioner>
     {
         template <typename... Args>
         using apply =
-            TaskPartitioner<hpx::execution::simdpar_task_policy, Args...>;
+            TaskPartitioner<hpx::execution::par_simd_task_policy, Args...>;
     };
 #endif
 }}}}    // namespace hpx::parallel::util::detail

--- a/libs/parallelism/algorithms/tests/regressions/for_each_datapar.cpp
+++ b/libs/parallelism/algorithms/tests/regressions/for_each_datapar.cpp
@@ -37,7 +37,7 @@ void for_each_test()
 {
     using namespace hpx::execution;
     test_for_each(simd);
-    test_for_each(simdpar);
+    test_for_each(par_simd);
 }
 
 int hpx_main()

--- a/libs/parallelism/algorithms/tests/unit/datapar_algorithms/copy_datapar.cpp
+++ b/libs/parallelism/algorithms/tests/unit/datapar_algorithms/copy_datapar.cpp
@@ -23,10 +23,10 @@ void test_copy()
     test_copy(IteratorTag());
 
     test_copy(simd, IteratorTag());
-    test_copy(simdpar, IteratorTag());
+    test_copy(par_simd, IteratorTag());
 
     test_copy_async(simd(task), IteratorTag());
-    test_copy_async(simdpar(task), IteratorTag());
+    test_copy_async(par_simd(task), IteratorTag());
 }
 
 void copy_test()
@@ -44,10 +44,10 @@ void test_copy_exception()
     test_copy_exception(IteratorTag());
 
     test_copy_exception(simd, IteratorTag());
-    test_copy_exception(simdpar, IteratorTag());
+    test_copy_exception(par_simd, IteratorTag());
 
     test_copy_exception_async(simd(task), IteratorTag());
-    test_copy_exception_async(simdpar(task), IteratorTag());
+    test_copy_exception_async(par_simd(task), IteratorTag());
 }
 
 void copy_exception_test()
@@ -61,12 +61,12 @@ template <typename IteratorTag>
 void test_copy_bad_alloc()
 {
     test_copy_bad_alloc(hpx::execution::simd, IteratorTag());
-    test_copy_bad_alloc(hpx::execution::simdpar, IteratorTag());
+    test_copy_bad_alloc(hpx::execution::par_simd, IteratorTag());
 
     test_copy_bad_alloc_async(
         hpx::execution::simd(hpx::execution::task), IteratorTag());
     test_copy_bad_alloc_async(
-        hpx::execution::simdpar(hpx::execution::task), IteratorTag());
+        hpx::execution::par_simd(hpx::execution::task), IteratorTag());
 }
 
 void copy_bad_alloc_test()

--- a/libs/parallelism/algorithms/tests/unit/datapar_algorithms/copyn_datapar.cpp
+++ b/libs/parallelism/algorithms/tests/unit/datapar_algorithms/copyn_datapar.cpp
@@ -21,12 +21,12 @@ void test_copy_n()
     test_copy_n(IteratorTag());
 
     test_copy_n(hpx::execution::simd, IteratorTag());
-    test_copy_n(hpx::execution::simdpar, IteratorTag());
+    test_copy_n(hpx::execution::par_simd, IteratorTag());
 
     test_copy_n_async(
         hpx::execution::simd(hpx::execution::task), IteratorTag());
     test_copy_n_async(
-        hpx::execution::simdpar(hpx::execution::task), IteratorTag());
+        hpx::execution::par_simd(hpx::execution::task), IteratorTag());
 }
 
 void n_copy_test()
@@ -42,12 +42,12 @@ void test_copy_n_exception()
     test_copy_n_exception(IteratorTag());
 
     test_copy_n_exception(hpx::execution::simd, IteratorTag());
-    test_copy_n_exception(hpx::execution::simdpar, IteratorTag());
+    test_copy_n_exception(hpx::execution::par_simd, IteratorTag());
 
     test_copy_n_exception_async(
         hpx::execution::simd(hpx::execution::task), IteratorTag());
     test_copy_n_exception_async(
-        hpx::execution::simdpar(hpx::execution::task), IteratorTag());
+        hpx::execution::par_simd(hpx::execution::task), IteratorTag());
 }
 
 void copy_n_exception_test()
@@ -61,12 +61,12 @@ template <typename IteratorTag>
 void test_copy_n_bad_alloc()
 {
     test_copy_n_bad_alloc(hpx::execution::simd, IteratorTag());
-    test_copy_n_bad_alloc(hpx::execution::simdpar, IteratorTag());
+    test_copy_n_bad_alloc(hpx::execution::par_simd, IteratorTag());
 
     test_copy_n_bad_alloc_async(
         hpx::execution::simd(hpx::execution::task), IteratorTag());
     test_copy_n_bad_alloc_async(
-        hpx::execution::simdpar(hpx::execution::task), IteratorTag());
+        hpx::execution::par_simd(hpx::execution::task), IteratorTag());
 }
 
 void copy_n_bad_alloc_test()

--- a/libs/parallelism/algorithms/tests/unit/datapar_algorithms/count_datapar.cpp
+++ b/libs/parallelism/algorithms/tests/unit/datapar_algorithms/count_datapar.cpp
@@ -19,10 +19,10 @@ void test_count()
 {
     using namespace hpx::execution;
     test_count(simd, IteratorTag());
-    test_count(simdpar, IteratorTag());
+    test_count(par_simd, IteratorTag());
 
     test_count_async(simd(task), IteratorTag());
-    test_count_async(simdpar(task), IteratorTag());
+    test_count_async(par_simd(task), IteratorTag());
 }
 
 void count_test()
@@ -38,10 +38,10 @@ void test_count_exception()
     using namespace hpx::execution;
 
     test_count_exception(simd, IteratorTag());
-    test_count_exception(simdpar, IteratorTag());
+    test_count_exception(par_simd, IteratorTag());
 
     test_count_exception_async(simd(task), IteratorTag());
-    test_count_exception_async(simdpar(task), IteratorTag());
+    test_count_exception_async(par_simd(task), IteratorTag());
 }
 
 void count_exception_test()
@@ -57,10 +57,10 @@ void test_count_bad_alloc()
     using namespace hpx::execution;
 
     test_count_bad_alloc(simd, IteratorTag());
-    test_count_bad_alloc(simdpar, IteratorTag());
+    test_count_bad_alloc(par_simd, IteratorTag());
 
     test_count_bad_alloc_async(simd(task), IteratorTag());
-    test_count_bad_alloc_async(simdpar(task), IteratorTag());
+    test_count_bad_alloc_async(par_simd(task), IteratorTag());
 }
 
 void count_bad_alloc_test()

--- a/libs/parallelism/algorithms/tests/unit/datapar_algorithms/countif_datapar.cpp
+++ b/libs/parallelism/algorithms/tests/unit/datapar_algorithms/countif_datapar.cpp
@@ -20,10 +20,10 @@ void test_count_if()
     using namespace hpx::execution;
 
     test_count_if(simd, IteratorTag());
-    test_count_if(simdpar, IteratorTag());
+    test_count_if(par_simd, IteratorTag());
 
     test_count_if_async(simd(task), IteratorTag());
-    test_count_if_async(simdpar(task), IteratorTag());
+    test_count_if_async(par_simd(task), IteratorTag());
 }
 
 void count_if_test()
@@ -39,10 +39,10 @@ void test_count_if_exception()
     using namespace hpx::execution;
 
     test_count_if_exception(simd, IteratorTag());
-    test_count_if_exception(simdpar, IteratorTag());
+    test_count_if_exception(par_simd, IteratorTag());
 
     test_count_if_exception_async(simd(task), IteratorTag());
-    test_count_if_exception_async(simdpar(task), IteratorTag());
+    test_count_if_exception_async(par_simd(task), IteratorTag());
 }
 
 void count_if_exception_test()
@@ -58,10 +58,10 @@ void test_count_if_bad_alloc()
     using namespace hpx::execution;
 
     test_count_if_bad_alloc(simd, IteratorTag());
-    test_count_if_bad_alloc(simdpar, IteratorTag());
+    test_count_if_bad_alloc(par_simd, IteratorTag());
 
     test_count_if_bad_alloc_async(simd(task), IteratorTag());
-    test_count_if_bad_alloc_async(simdpar(task), IteratorTag());
+    test_count_if_bad_alloc_async(par_simd(task), IteratorTag());
 }
 
 void count_if_bad_alloc_test()

--- a/libs/parallelism/algorithms/tests/unit/datapar_algorithms/foreach_datapar.cpp
+++ b/libs/parallelism/algorithms/tests/unit/datapar_algorithms/foreach_datapar.cpp
@@ -20,10 +20,10 @@ void test_for_each()
     using namespace hpx::execution;
 
     test_for_each(simd, IteratorTag());
-    test_for_each(simdpar, IteratorTag());
+    test_for_each(par_simd, IteratorTag());
 
     test_for_each_async(simd(task), IteratorTag());
-    test_for_each_async(simdpar(task), IteratorTag());
+    test_for_each_async(par_simd(task), IteratorTag());
 }
 
 void for_each_test()
@@ -39,10 +39,10 @@ void test_for_each_exception()
     using namespace hpx::execution;
 
     test_for_each_exception(simd, IteratorTag());
-    test_for_each_exception(simdpar, IteratorTag());
+    test_for_each_exception(par_simd, IteratorTag());
 
     test_for_each_exception_async(simd(task), IteratorTag());
-    test_for_each_exception_async(simdpar(task), IteratorTag());
+    test_for_each_exception_async(par_simd(task), IteratorTag());
 }
 
 void for_each_exception_test()
@@ -58,10 +58,10 @@ void test_for_each_bad_alloc()
     using namespace hpx::execution;
 
     test_for_each_bad_alloc(simd, IteratorTag());
-    test_for_each_bad_alloc(simdpar, IteratorTag());
+    test_for_each_bad_alloc(par_simd, IteratorTag());
 
     test_for_each_bad_alloc_async(simd(task), IteratorTag());
-    test_for_each_bad_alloc_async(simdpar(task), IteratorTag());
+    test_for_each_bad_alloc_async(par_simd(task), IteratorTag());
 }
 
 void for_each_bad_alloc_test()

--- a/libs/parallelism/algorithms/tests/unit/datapar_algorithms/foreach_datapar_zipiter.cpp
+++ b/libs/parallelism/algorithms/tests/unit/datapar_algorithms/foreach_datapar_zipiter.cpp
@@ -89,8 +89,8 @@ void for_each_zipiter_test()
 {
     using namespace hpx::execution;
 
-    for_each_zipiter_test(simdpar, IteratorTag());
-    //     test_for_each_async(simdpar(task), IteratorTag());
+    for_each_zipiter_test(par_simd, IteratorTag());
+    //     test_for_each_async(par_simd(task), IteratorTag());
 }
 
 void for_each_zipiter_test()

--- a/libs/parallelism/algorithms/tests/unit/datapar_algorithms/foreachn_datapar.cpp
+++ b/libs/parallelism/algorithms/tests/unit/datapar_algorithms/foreachn_datapar.cpp
@@ -21,10 +21,10 @@ void test_for_each_n()
     using namespace hpx::execution;
 
     test_for_each_n(simd, IteratorTag());
-    test_for_each_n(simdpar, IteratorTag());
+    test_for_each_n(par_simd, IteratorTag());
 
     test_for_each_n_async(simd(task), IteratorTag());
-    test_for_each_n_async(simdpar(task), IteratorTag());
+    test_for_each_n_async(par_simd(task), IteratorTag());
 }
 
 void for_each_n_test()

--- a/libs/parallelism/algorithms/tests/unit/datapar_algorithms/transform_binary2_datapar.cpp
+++ b/libs/parallelism/algorithms/tests/unit/datapar_algorithms/transform_binary2_datapar.cpp
@@ -20,10 +20,10 @@ void test_transform_binary2()
     using namespace hpx::execution;
 
     test_transform_binary2(simd, IteratorTag());
-    test_transform_binary2(simdpar, IteratorTag());
+    test_transform_binary2(par_simd, IteratorTag());
 
     test_transform_binary2_async(simd(task), IteratorTag());
-    test_transform_binary2_async(simdpar(task), IteratorTag());
+    test_transform_binary2_async(par_simd(task), IteratorTag());
 }
 
 void transform_binary2_test()
@@ -39,10 +39,10 @@ void test_transform_binary2_exception()
     using namespace hpx::execution;
 
     test_transform_binary2_exception(simd, IteratorTag());
-    test_transform_binary2_exception(simdpar, IteratorTag());
+    test_transform_binary2_exception(par_simd, IteratorTag());
 
     test_transform_binary2_exception_async(simd(task), IteratorTag());
-    test_transform_binary2_exception_async(simdpar(task), IteratorTag());
+    test_transform_binary2_exception_async(par_simd(task), IteratorTag());
 }
 
 void transform_binary2_exception_test()
@@ -58,10 +58,10 @@ void test_transform_binary2_bad_alloc()
     using namespace hpx::execution;
 
     test_transform_binary2_bad_alloc(simd, IteratorTag());
-    test_transform_binary2_bad_alloc(simdpar, IteratorTag());
+    test_transform_binary2_bad_alloc(par_simd, IteratorTag());
 
     test_transform_binary2_bad_alloc_async(simd(task), IteratorTag());
-    test_transform_binary2_bad_alloc_async(simdpar(task), IteratorTag());
+    test_transform_binary2_bad_alloc_async(par_simd(task), IteratorTag());
 }
 
 void transform_binary2_bad_alloc_test()

--- a/libs/parallelism/algorithms/tests/unit/datapar_algorithms/transform_binary_datapar.cpp
+++ b/libs/parallelism/algorithms/tests/unit/datapar_algorithms/transform_binary_datapar.cpp
@@ -20,10 +20,10 @@ void test_transform_binary()
     using namespace hpx::execution;
 
     test_transform_binary(simd, IteratorTag());
-    test_transform_binary(simdpar, IteratorTag());
+    test_transform_binary(par_simd, IteratorTag());
 
     test_transform_binary_async(simd(task), IteratorTag());
-    test_transform_binary_async(simdpar(task), IteratorTag());
+    test_transform_binary_async(par_simd(task), IteratorTag());
 }
 
 void transform_binary_test()
@@ -39,10 +39,10 @@ void test_transform_binary_exception()
     using namespace hpx::execution;
 
     test_transform_binary_exception(simd, IteratorTag());
-    test_transform_binary_exception(simdpar, IteratorTag());
+    test_transform_binary_exception(par_simd, IteratorTag());
 
     test_transform_binary_exception_async(simd(task), IteratorTag());
-    test_transform_binary_exception_async(simdpar(task), IteratorTag());
+    test_transform_binary_exception_async(par_simd(task), IteratorTag());
 }
 
 void transform_binary_exception_test()
@@ -58,10 +58,10 @@ void test_transform_binary_bad_alloc()
     using namespace hpx::execution;
 
     test_transform_binary_bad_alloc(simd, IteratorTag());
-    test_transform_binary_bad_alloc(simdpar, IteratorTag());
+    test_transform_binary_bad_alloc(par_simd, IteratorTag());
 
     test_transform_binary_bad_alloc_async(simd(task), IteratorTag());
-    test_transform_binary_bad_alloc_async(simdpar(task), IteratorTag());
+    test_transform_binary_bad_alloc_async(par_simd(task), IteratorTag());
 }
 
 void transform_binary_bad_alloc_test()

--- a/libs/parallelism/algorithms/tests/unit/datapar_algorithms/transform_datapar.cpp
+++ b/libs/parallelism/algorithms/tests/unit/datapar_algorithms/transform_datapar.cpp
@@ -20,10 +20,10 @@ void test_transform()
     using namespace hpx::execution;
 
     test_transform(simd, IteratorTag());
-    test_transform(simdpar, IteratorTag());
+    test_transform(par_simd, IteratorTag());
 
     test_transform_async(simd(task), IteratorTag());
-    test_transform_async(simdpar(task), IteratorTag());
+    test_transform_async(par_simd(task), IteratorTag());
 }
 
 void transform_test()
@@ -38,10 +38,10 @@ void test_transform_exception()
     using namespace hpx::execution;
 
     test_transform_exception(simd, IteratorTag());
-    test_transform_exception(simdpar, IteratorTag());
+    test_transform_exception(par_simd, IteratorTag());
 
     test_transform_exception_async(simd(task), IteratorTag());
-    test_transform_exception_async(simdpar(task), IteratorTag());
+    test_transform_exception_async(par_simd(task), IteratorTag());
 }
 
 void transform_exception_test()
@@ -57,10 +57,10 @@ void test_transform_bad_alloc()
     using namespace hpx::execution;
 
     test_transform_bad_alloc(simd, IteratorTag());
-    test_transform_bad_alloc(simdpar, IteratorTag());
+    test_transform_bad_alloc(par_simd, IteratorTag());
 
     test_transform_bad_alloc_async(simd(task), IteratorTag());
-    test_transform_bad_alloc_async(simdpar(task), IteratorTag());
+    test_transform_bad_alloc_async(par_simd(task), IteratorTag());
 }
 
 void transform_bad_alloc_test()

--- a/libs/parallelism/algorithms/tests/unit/datapar_algorithms/transform_reduce_binary_datapar.cpp
+++ b/libs/parallelism/algorithms/tests/unit/datapar_algorithms/transform_reduce_binary_datapar.cpp
@@ -20,10 +20,10 @@ void test_transform_reduce_binary()
     using namespace hpx::execution;
 
     test_transform_reduce_binary(simd, IteratorTag());
-    test_transform_reduce_binary(simdpar, IteratorTag());
+    test_transform_reduce_binary(par_simd, IteratorTag());
 
     test_transform_reduce_binary_async(simd(task), IteratorTag());
-    test_transform_reduce_binary_async(simdpar(task), IteratorTag());
+    test_transform_reduce_binary_async(par_simd(task), IteratorTag());
 }
 
 void transform_reduce_binary_test()

--- a/libs/parallelism/execution/tests/regressions/lambda_arguments_2403.cpp
+++ b/libs/parallelism/execution/tests/regressions/lambda_arguments_2403.cpp
@@ -20,7 +20,7 @@ int hpx_main()
     auto zip_it_begin = hpx::util::make_zip_iterator(large.begin());
     auto zip_it_end = hpx::util::make_zip_iterator(large.end());
 
-    hpx::for_each(hpx::execution::simdpar, zip_it_begin, zip_it_end,
+    hpx::for_each(hpx::execution::par_simd, zip_it_begin, zip_it_end,
         [](auto& t) -> void { hpx::get<0>(t) = 10.0; });
 
     HPX_TEST_EQ(std::count(large.begin(), large.end(), 10.0),

--- a/libs/parallelism/execution/tests/regressions/lambda_return_type_2402.cpp
+++ b/libs/parallelism/execution/tests/regressions/lambda_return_type_2402.cpp
@@ -22,7 +22,7 @@ int hpx_main()
     auto zip_it_end = hpx::util::make_zip_iterator(large.end());
 
     hpx::for_each(
-        hpx::execution::simdpar, zip_it_begin, zip_it_end, [](auto t) {
+        hpx::execution::par_simd, zip_it_begin, zip_it_end, [](auto t) {
             using comp_type = typename hpx::tuple_element<0, decltype(t)>::type;
             using var_type = typename std::decay<comp_type>::type;
 

--- a/libs/parallelism/executors/include/hpx/executors/datapar/execution_policy.hpp
+++ b/libs/parallelism/executors/include/hpx/executors/datapar/execution_policy.hpp
@@ -610,14 +610,14 @@ namespace hpx { namespace execution { inline namespace v1 {
     };
 
     ///////////////////////////////////////////////////////////////////////////
-    /// Extension: The class simdpar_task_policy is an execution
+    /// Extension: The class par_simd_task_policy is an execution
     /// policy type used as a unique type to disambiguate parallel algorithm
     /// overloading and indicate that a parallel algorithm's execution may be
     /// parallelized.
     ///
     /// The algorithm returns a future representing the result of the
     /// corresponding algorithm when invoked with the parallel_policy.
-    struct simdpar_task_policy
+    struct par_simd_task_policy
     {
         /// The type of the executor associated with this execution policy
         typedef parallel_executor executor_type;
@@ -638,26 +638,26 @@ namespace hpx { namespace execution { inline namespace v1 {
         struct rebind
         {
             /// The type of the rebound execution policy
-            typedef simdpar_task_policy_shim<Executor_, Parameters_> type;
+            typedef par_simd_task_policy_shim<Executor_, Parameters_> type;
         };
 
         /// \cond NOINTERNAL
-        constexpr simdpar_task_policy() = default;
+        constexpr par_simd_task_policy() = default;
         /// \endcond
 
-        /// Create a new simdpar_task_policy from itself
+        /// Create a new par_simd_task_policy from itself
         ///
         /// \param tag          [in] Specify that the corresponding asynchronous
         ///                     execution policy should be used
         ///
-        /// \returns The new simdpar_task_policy
+        /// \returns The new par_simd_task_policy
         ///
-        constexpr simdpar_task_policy operator()(task_policy_tag) const
+        constexpr par_simd_task_policy operator()(task_policy_tag) const
         {
             return *this;
         }
 
-        /// Create a new simdpar_task_policy from given executor
+        /// Create a new par_simd_task_policy from given executor
         ///
         /// \tparam Executor    The type of the executor to associate with this
         ///                     execution policy.
@@ -668,10 +668,10 @@ namespace hpx { namespace execution { inline namespace v1 {
         ///
         /// \note Requires: is_executor<Executor>::value is true
         ///
-        /// \returns The new simdpar_task_policy
+        /// \returns The new par_simd_task_policy
         ///
         template <typename Executor>
-        typename parallel::execution::rebind_executor<simdpar_task_policy,
+        typename parallel::execution::rebind_executor<par_simd_task_policy,
             Executor, executor_parameters_type>::type
         on(Executor&& exec) const
         {
@@ -679,12 +679,12 @@ namespace hpx { namespace execution { inline namespace v1 {
                 "hpx::traits::is_executor_any<Executor>::value");
 
             typedef typename parallel::execution::rebind_executor<
-                simdpar_task_policy, Executor, executor_parameters_type>::type
+                par_simd_task_policy, Executor, executor_parameters_type>::type
                 rebound_type;
             return rebound_type(std::forward<Executor>(exec), parameters());
         }
 
-        /// Create a new simdpar_task_policy_shim from the given
+        /// Create a new par_simd_task_policy_shim from the given
         /// execution parameters
         ///
         /// \tparam Parameters  The type of the executor parameters to
@@ -697,17 +697,17 @@ namespace hpx { namespace execution { inline namespace v1 {
         /// \note Requires: all parameters are executor_parameters,
         ///                 different parameter types can't be duplicated
         ///
-        /// \returns The new simdpar_policy_shim
+        /// \returns The new par_simd_policy_shim
         ///
         template <typename... Parameters,
             typename ParametersType = typename parallel::execution::
                 executor_parameters_join<Parameters...>::type>
-        typename parallel::execution::rebind_executor<simdpar_task_policy,
+        typename parallel::execution::rebind_executor<par_simd_task_policy,
             executor_type, ParametersType>::type
         with(Parameters&&... params) const
         {
             typedef typename parallel::execution::rebind_executor<
-                simdpar_task_policy, executor_type, ParametersType>::type
+                par_simd_task_policy, executor_type, ParametersType>::type
                 rebound_type;
             return rebound_type(executor(),
                 parallel::execution::join_executor_parameters(
@@ -751,10 +751,10 @@ namespace hpx { namespace execution { inline namespace v1 {
     };
 
     ///////////////////////////////////////////////////////////////////////////
-    /// The class simdpar_policy is an execution policy type used
+    /// The class par_simd_policy is an execution policy type used
     /// as a unique type to disambiguate parallel algorithm overloading and
     /// indicate that a parallel algorithm's execution may be parallelized.
-    struct simdpar_policy
+    struct par_simd_policy
     {
         /// The type of the executor associated with this execution policy
         typedef parallel_executor executor_type;
@@ -775,36 +775,36 @@ namespace hpx { namespace execution { inline namespace v1 {
         struct rebind
         {
             /// The type of the rebound execution policy
-            typedef simdpar_policy_shim<Executor_, Parameters_> type;
+            typedef par_simd_policy_shim<Executor_, Parameters_> type;
         };
 
         /// \cond NOINTERNAL
-        constexpr simdpar_policy() = default;
+        constexpr par_simd_policy() = default;
         /// \endcond
 
-        /// Create a new simdpar_policy referencing a chunk size.
+        /// Create a new par_simd_policy referencing a chunk size.
         ///
         /// \param tag          [in] Specify that the corresponding asynchronous
         ///                     execution policy should be used
         ///
-        /// \returns The new simdpar_task_policy
+        /// \returns The new par_simd_task_policy
         ///
-        constexpr simdpar_task_policy operator()(task_policy_tag) const
+        constexpr par_simd_task_policy operator()(task_policy_tag) const
         {
-            return simdpar_task_policy();
+            return par_simd_task_policy();
         }
 
-        /// Create a new simdpar_policy referencing an executor and
+        /// Create a new par_simd_policy referencing an executor and
         /// a chunk size.
         ///
         /// \param exec         [in] The executor to use for the execution of
         ///                     the parallel algorithm the returned execution
         ///                     policy is used with
         ///
-        /// \returns The new simdpar_policy
+        /// \returns The new par_simd_policy
         ///
         template <typename Executor>
-        typename parallel::execution::rebind_executor<simdpar_policy, Executor,
+        typename parallel::execution::rebind_executor<par_simd_policy, Executor,
             executor_parameters_type>::type
         on(Executor&& exec) const
         {
@@ -812,12 +812,12 @@ namespace hpx { namespace execution { inline namespace v1 {
                 "hpx::traits::is_executor_any<Executor>::value");
 
             typedef
-                typename parallel::execution::rebind_executor<simdpar_policy,
+                typename parallel::execution::rebind_executor<par_simd_policy,
                     Executor, executor_parameters_type>::type rebound_type;
             return rebound_type(std::forward<Executor>(exec), parameters());
         }
 
-        /// Create a new simdpar_policy from the given
+        /// Create a new par_simd_policy from the given
         /// execution parameters
         ///
         /// \tparam Parameters  The type of the executor parameters to
@@ -829,17 +829,17 @@ namespace hpx { namespace execution { inline namespace v1 {
         ///
         /// \note Requires: is_executor_parameters<Parameters>::value is true
         ///
-        /// \returns The new simdpar_policy
+        /// \returns The new par_simd_policy
         ///
         template <typename... Parameters,
             typename ParametersType = typename parallel::execution::
                 executor_parameters_join<Parameters...>::type>
-        typename parallel::execution::rebind_executor<simdpar_policy,
+        typename parallel::execution::rebind_executor<par_simd_policy,
             executor_type, ParametersType>::type
         with(Parameters&&... params) const
         {
             typedef
-                typename parallel::execution::rebind_executor<simdpar_policy,
+                typename parallel::execution::rebind_executor<par_simd_policy,
                     executor_type, ParametersType>::type rebound_type;
             return rebound_type(executor(),
                 parallel::execution::join_executor_parameters(
@@ -883,13 +883,13 @@ namespace hpx { namespace execution { inline namespace v1 {
     };
 
     /// Default data-parallel execution policy object.
-    static constexpr simdpar_policy simdpar{};
+    static constexpr par_simd_policy par_simd{};
 
-    /// The class simdpar_policy_shim is an execution policy type
+    /// The class par_simd_policy_shim is an execution policy type
     /// used as a unique type to disambiguate parallel algorithm overloading
     /// and indicate that a parallel algorithm's execution may be parallelized.
     template <typename Executor, typename Parameters>
-    struct simdpar_policy_shim : simdpar_policy
+    struct par_simd_policy_shim : par_simd_policy
     {
         /// The type of the executor associated with this execution policy
         typedef Executor executor_type;
@@ -910,24 +910,24 @@ namespace hpx { namespace execution { inline namespace v1 {
         struct rebind
         {
             /// The type of the rebound execution policy
-            typedef simdpar_policy_shim<Executor_, Parameters_> type;
+            typedef par_simd_policy_shim<Executor_, Parameters_> type;
         };
 
-        /// Create a new simdpar_task_policy_shim
+        /// Create a new par_simd_task_policy_shim
         ///
         /// \param tag          [in] Specify that the corresponding asynchronous
         ///                     execution policy should be used
         ///
-        /// \returns The new simdpar_task_policy_shim
+        /// \returns The new par_simd_task_policy_shim
         ///
-        constexpr simdpar_task_policy_shim<Executor, Parameters> operator()(
+        constexpr par_simd_task_policy_shim<Executor, Parameters> operator()(
             task_policy_tag) const
         {
-            return simdpar_task_policy_shim<Executor, Parameters>(
+            return par_simd_task_policy_shim<Executor, Parameters>(
                 exec_, params_);
         }
 
-        /// Create a new simdpar_task_policy_shim from the given
+        /// Create a new par_simd_task_policy_shim from the given
         /// executor
         ///
         /// \tparam Executor    The type of the executor to associate with this
@@ -942,7 +942,7 @@ namespace hpx { namespace execution { inline namespace v1 {
         /// \returns The new parallel_policy
         ///
         template <typename Executor_>
-        typename parallel::execution::rebind_executor<simdpar_policy_shim,
+        typename parallel::execution::rebind_executor<par_simd_policy_shim,
             Executor_, executor_parameters_type>::type
         on(Executor_&& exec) const
         {
@@ -950,12 +950,12 @@ namespace hpx { namespace execution { inline namespace v1 {
                 "hpx::traits::is_executor_any<Executor_>::value");
 
             typedef typename parallel::execution::rebind_executor<
-                simdpar_policy_shim, Executor_, executor_parameters_type>::type
+                par_simd_policy_shim, Executor_, executor_parameters_type>::type
                 rebound_type;
             return rebound_type(std::forward<Executor_>(exec), params_);
         }
 
-        /// Create a new simdpar_policy_shim from the given
+        /// Create a new par_simd_policy_shim from the given
         /// execution parameters
         ///
         /// \tparam Parameters  The type of the executor parameters to
@@ -967,17 +967,17 @@ namespace hpx { namespace execution { inline namespace v1 {
         ///
         /// \note Requires: is_executor_parameters<Parameters>::value is true
         ///
-        /// \returns The new simdpar_policy_shim
+        /// \returns The new par_simd_policy_shim
         ///
         template <typename... Parameters_,
             typename ParametersType = typename parallel::execution::
                 executor_parameters_join<Parameters_...>::type>
-        typename parallel::execution::rebind_executor<simdpar_policy_shim,
+        typename parallel::execution::rebind_executor<par_simd_policy_shim,
             executor_type, ParametersType>::type
         with(Parameters_&&... params) const
         {
             typedef typename parallel::execution::rebind_executor<
-                simdpar_policy_shim, executor_type, ParametersType>::type
+                par_simd_policy_shim, executor_type, ParametersType>::type
                 rebound_type;
             return rebound_type(exec_,
                 parallel::execution::join_executor_parameters(
@@ -1007,10 +1007,10 @@ namespace hpx { namespace execution { inline namespace v1 {
         }
 
         /// \cond NOINTERNAL
-        constexpr simdpar_policy_shim() = default;
+        constexpr par_simd_policy_shim() = default;
 
         template <typename Executor_, typename Parameters_>
-        constexpr simdpar_policy_shim(Executor_&& exec, Parameters_&& params)
+        constexpr par_simd_policy_shim(Executor_&& exec, Parameters_&& params)
           : exec_(std::forward<Executor_>(exec))
           , params_(std::forward<Parameters_>(params))
         {
@@ -1033,13 +1033,13 @@ namespace hpx { namespace execution { inline namespace v1 {
         /// \endcond
     };
 
-    /// The class simdpar_task_policy_shim is an
+    /// The class par_simd_task_policy_shim is an
     /// execution policy type used as a unique type to disambiguate parallel
     /// algorithm overloading based on combining a underlying
-    /// \a simdpar_task_policy and an executor and indicate that
+    /// \a par_simd_task_policy and an executor and indicate that
     /// a parallel algorithm's execution may be parallelized and vectorized.
     template <typename Executor, typename Parameters>
-    struct simdpar_task_policy_shim : simdpar_task_policy
+    struct par_simd_task_policy_shim : par_simd_task_policy
     {
         /// The type of the executor associated with this execution policy
         typedef Executor executor_type;
@@ -1060,17 +1060,17 @@ namespace hpx { namespace execution { inline namespace v1 {
         struct rebind
         {
             /// The type of the rebound execution policy
-            typedef simdpar_task_policy_shim<Executor_, Parameters_> type;
+            typedef par_simd_task_policy_shim<Executor_, Parameters_> type;
         };
 
-        /// Create a new simdpar_task_policy_shim from itself
+        /// Create a new par_simd_task_policy_shim from itself
         ///
         /// \param tag          [in] Specify that the corresponding asynchronous
         ///                     execution policy should be used
         ///
         /// \returns The new sequenced_task_policy
         ///
-        constexpr simdpar_task_policy_shim operator()(task_policy_tag) const
+        constexpr par_simd_task_policy_shim operator()(task_policy_tag) const
         {
             return *this;
         }
@@ -1090,7 +1090,7 @@ namespace hpx { namespace execution { inline namespace v1 {
         /// \returns The new parallel_task_policy
         ///
         template <typename Executor_>
-        typename parallel::execution::rebind_executor<simdpar_task_policy_shim,
+        typename parallel::execution::rebind_executor<par_simd_task_policy_shim,
             Executor_, executor_parameters_type>::type
         on(Executor_&& exec) const
         {
@@ -1098,7 +1098,7 @@ namespace hpx { namespace execution { inline namespace v1 {
                 "hpx::traits::is_executor_any<Executor_>::value");
 
             typedef typename parallel::execution::rebind_executor<
-                simdpar_task_policy_shim, Executor_,
+                par_simd_task_policy_shim, Executor_,
                 executor_parameters_type>::type rebound_type;
             return rebound_type(std::forward<Executor_>(exec), params_);
         }
@@ -1121,12 +1121,12 @@ namespace hpx { namespace execution { inline namespace v1 {
         template <typename... Parameters_,
             typename ParametersType = typename parallel::execution::
                 executor_parameters_join<Parameters_...>::type>
-        typename parallel::execution::rebind_executor<simdpar_task_policy_shim,
+        typename parallel::execution::rebind_executor<par_simd_task_policy_shim,
             executor_type, ParametersType>::type
         with(Parameters_&&... params) const
         {
             typedef typename parallel::execution::rebind_executor<
-                simdpar_task_policy_shim, executor_type, ParametersType>::type
+                par_simd_task_policy_shim, executor_type, ParametersType>::type
                 rebound_type;
             return rebound_type(exec_,
                 parallel::execution::join_executor_parameters(
@@ -1156,10 +1156,10 @@ namespace hpx { namespace execution { inline namespace v1 {
         }
 
         /// \cond NOINTERNAL
-        constexpr simdpar_task_policy_shim() = default;
+        constexpr par_simd_task_policy_shim() = default;
 
         template <typename Executor_, typename Parameters_>
-        constexpr simdpar_task_policy_shim(
+        constexpr par_simd_task_policy_shim(
             Executor_&& exec, Parameters_&& params)
           : exec_(std::forward<Executor_>(exec))
           , params_(std::forward<Parameters_>(params))
@@ -1214,26 +1214,26 @@ namespace hpx { namespace detail {
     };
 
     template <>
-    struct is_execution_policy<hpx::execution::simdpar_policy> : std::true_type
+    struct is_execution_policy<hpx::execution::par_simd_policy> : std::true_type
     {
     };
 
     template <typename Executor, typename Parameters>
     struct is_execution_policy<
-        hpx::execution::simdpar_policy_shim<Executor, Parameters>>
+        hpx::execution::par_simd_policy_shim<Executor, Parameters>>
       : std::true_type
     {
     };
 
     template <>
-    struct is_execution_policy<hpx::execution::simdpar_task_policy>
+    struct is_execution_policy<hpx::execution::par_simd_task_policy>
       : std::true_type
     {
     };
 
     template <typename Executor, typename Parameters>
     struct is_execution_policy<
-        hpx::execution::simdpar_task_policy_shim<Executor, Parameters>>
+        hpx::execution::par_simd_task_policy_shim<Executor, Parameters>>
       : std::true_type
     {
     };
@@ -1283,14 +1283,14 @@ namespace hpx { namespace detail {
     };
 
     template <>
-    struct is_async_execution_policy<hpx::execution::simdpar_task_policy>
+    struct is_async_execution_policy<hpx::execution::par_simd_task_policy>
       : std::true_type
     {
     };
 
     template <typename Executor, typename Parameters>
     struct is_async_execution_policy<
-        hpx::execution::simdpar_task_policy_shim<Executor, Parameters>>
+        hpx::execution::par_simd_task_policy_shim<Executor, Parameters>>
       : std::true_type
     {
     };
@@ -1299,27 +1299,27 @@ namespace hpx { namespace detail {
     ///////////////////////////////////////////////////////////////////////////
     /// \cond NOINTERNAL
     template <>
-    struct is_parallel_execution_policy<hpx::execution::simdpar_policy>
+    struct is_parallel_execution_policy<hpx::execution::par_simd_policy>
       : std::true_type
     {
     };
 
     template <>
-    struct is_parallel_execution_policy<hpx::execution::simdpar_task_policy>
+    struct is_parallel_execution_policy<hpx::execution::par_simd_task_policy>
       : std::true_type
     {
     };
 
     template <typename Executor, typename Parameters>
     struct is_parallel_execution_policy<
-        hpx::execution::simdpar_policy_shim<Executor, Parameters>>
+        hpx::execution::par_simd_policy_shim<Executor, Parameters>>
       : std::true_type
     {
     };
 
     template <typename Executor, typename Parameters>
     struct is_parallel_execution_policy<
-        hpx::execution::simdpar_task_policy_shim<Executor, Parameters>>
+        hpx::execution::par_simd_task_policy_shim<Executor, Parameters>>
       : std::true_type
     {
     };
@@ -1353,27 +1353,27 @@ namespace hpx { namespace detail {
     };
 
     template <>
-    struct is_vectorpack_execution_policy<hpx::execution::simdpar_policy>
+    struct is_vectorpack_execution_policy<hpx::execution::par_simd_policy>
       : std::true_type
     {
     };
 
     template <>
-    struct is_vectorpack_execution_policy<hpx::execution::simdpar_task_policy>
+    struct is_vectorpack_execution_policy<hpx::execution::par_simd_task_policy>
       : std::true_type
     {
     };
 
     template <typename Executor, typename Parameters>
     struct is_vectorpack_execution_policy<
-        hpx::execution::simdpar_policy_shim<Executor, Parameters>>
+        hpx::execution::par_simd_policy_shim<Executor, Parameters>>
       : std::true_type
     {
     };
 
     template <typename Executor, typename Parameters>
     struct is_vectorpack_execution_policy<
-        hpx::execution::simdpar_task_policy_shim<Executor, Parameters>>
+        hpx::execution::par_simd_task_policy_shim<Executor, Parameters>>
       : std::true_type
     {
     };

--- a/libs/parallelism/executors/include/hpx/executors/datapar/execution_policy_fwd.hpp
+++ b/libs/parallelism/executors/include/hpx/executors/datapar/execution_policy_fwd.hpp
@@ -23,15 +23,15 @@ namespace hpx { namespace execution { inline namespace v1 {
     struct simd_task_policy_shim;
 
     ///////////////////////////////////////////////////////////////////////////
-    struct simdpar_policy;
+    struct par_simd_policy;
 
     template <typename Executor, typename Parameters>
-    struct simdpar_policy_shim;
+    struct par_simd_policy_shim;
 
-    struct simdpar_task_policy;
+    struct par_simd_task_policy;
 
     template <typename Executor, typename Parameters>
-    struct simdpar_task_policy_shim;
+    struct par_simd_task_policy_shim;
 }}}    // namespace hpx::execution::v1
 
 #endif

--- a/libs/parallelism/executors/include/hpx/executors/exception_list.hpp
+++ b/libs/parallelism/executors/include/hpx/executors/exception_list.hpp
@@ -172,7 +172,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
         };
 
         template <typename Result>
-        struct handle_exception_impl<hpx::execution::simdpar_task_policy,
+        struct handle_exception_impl<hpx::execution::par_simd_task_policy,
             Result> : handle_exception_task_impl<Result>
         {
         };

--- a/tests/performance/local/transform_reduce_binary_scaling.cpp
+++ b/tests/performance/local/transform_reduce_binary_scaling.cpp
@@ -96,7 +96,7 @@ int hpx_main(hpx::program_options::variables_map& vm)
 
         // do measurements
         std::uint64_t tr_time_datapar = measure_inner_product(
-            test_count, hpx::execution::simdpar, data1, data2);
+            test_count, hpx::execution::par_simd, data1, data2);
         std::uint64_t tr_time_par = measure_inner_product(
             test_count, hpx::execution::par, data1, data2);
 


### PR DESCRIPTION
Fixes #5494. I just did a find-and-replace, hoping there are no surprises.