### PR TITLE
Minor bug fix in transform exclusive and inclusive scan tests

### DIFF
--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/exclusive_scan_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/exclusive_scan_range.cpp
@@ -25,7 +25,7 @@
 ////////////////////////////////////////////////////////////////////////////
 unsigned int seed;
 std::mt19937 gen;
-std::uniform_int_distribution<> dis(1, 10007);
+std::uniform_int_distribution<> dis(1, 10006);
 
 template <typename IteratorTag>
 void test_exclusive_scan_sent(IteratorTag)

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/inclusive_scan_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/inclusive_scan_range.cpp
@@ -25,7 +25,7 @@
 ////////////////////////////////////////////////////////////////////////////
 unsigned int seed;
 std::mt19937 gen;
-std::uniform_int_distribution<> dis(1, 10007);
+std::uniform_int_distribution<> dis(1, 10006);
 
 template <typename IteratorTag>
 void test_inclusive_scan_sent(IteratorTag)

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/transform_exclusive_scan_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/transform_exclusive_scan_range.cpp
@@ -25,7 +25,7 @@
 ////////////////////////////////////////////////////////////////////////////
 unsigned int seed;
 std::mt19937 gen;
-std::uniform_int_distribution<> dis(1, 10007);
+std::uniform_int_distribution<> dis(1, 10006);
 
 template <typename IteratorTag>
 void test_transform_exclusive_scan_sent(IteratorTag)

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/transform_inclusive_scan_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/transform_inclusive_scan_range.cpp
@@ -25,7 +25,7 @@
 ////////////////////////////////////////////////////////////////////////////
 unsigned int seed;
 std::mt19937 gen;
-std::uniform_int_distribution<> dis(1, 10007);
+std::uniform_int_distribution<> dis(1, 10006);
 
 template <typename IteratorTag>
 void test_transform_inclusive_scan_sent(IteratorTag)


### PR DESCRIPTION
Will lead to a segmentation fault if end_len happens to be the vector size value.
