### PR TITLE
Attempt to fix thread_pool_scheduler test

### DIFF
--- a/libs/parallelism/executors/tests/unit/thread_pool_scheduler.cpp
+++ b/libs/parallelism/executors/tests/unit/thread_pool_scheduler.cpp
@@ -1223,8 +1223,8 @@ void test_detach()
 
         {
             std::unique_lock<hpx::mutex> l(m);
-            hpx::cv_status st = cv.wait_for(l, std::chrono::seconds(1));
-            HPX_TEST(st == hpx::cv_status::no_timeout);
+            HPX_TEST(cv.wait_for(
+                l, std::chrono::seconds(1), [&]() { return called; }));
         }
         HPX_TEST(called);
     }
@@ -1243,8 +1243,8 @@ void test_detach()
 
         {
             std::unique_lock<hpx::mutex> l(m);
-            hpx::cv_status st = cv.wait_for(l, std::chrono::seconds(1));
-            HPX_TEST(st == hpx::cv_status::no_timeout);
+            HPX_TEST(cv.wait_for(
+                l, std::chrono::seconds(1), [&]() { return called; }));
         }
         HPX_TEST(called);
     }


### PR DESCRIPTION
Added predicates to the `wait_for`s. Without them the waits may fail even if the the tasks were executed (and since https://github.com/STEllAR-GROUP/hpx/blob/0bfa445daefecb5ab4f8a4bb1873c3b92ceed468/libs/parallelism/executors/tests/unit/thread_pool_scheduler.cpp#L1229 seems to not fail, it must be the case here).