### PR TITLE
Fix condition for checking if we should use our own variant

### DIFF
--- a/libs/core/datastructures/include/hpx/datastructures/variant.hpp
+++ b/libs/core/datastructures/include/hpx/datastructures/variant.hpp
@@ -13,6 +13,7 @@
 
 namespace hpx {
 
+    using std::get;
     using std::monostate;
     using std::variant;
     using std::visit;
@@ -24,6 +25,7 @@ namespace hpx {
 
 namespace hpx {
 
+    using hpx::variant_ns::get;
     using hpx::variant_ns::monostate;
     using hpx::variant_ns::variant;
     using hpx::variant_ns::visit;

--- a/libs/core/datastructures/include/hpx/datastructures/variant.hpp
+++ b/libs/core/datastructures/include/hpx/datastructures/variant.hpp
@@ -8,7 +8,7 @@
 
 #include <hpx/config.hpp>
 
-#if defined(HPX_HAVE_CXX17_STD_VARIANT) && defined(HPX_HAVE_CXX17_COPY_ELISION)
+#if defined(HPX_HAVE_CXX17_COPY_ELISION)
 #include <variant>
 
 namespace hpx {

--- a/libs/parallelism/execution/include/hpx/execution/algorithms/bulk.hpp
+++ b/libs/parallelism/execution/include/hpx/execution/algorithms/bulk.hpp
@@ -96,17 +96,10 @@ namespace hpx { namespace execution { namespace experimental {
                     hpx::execution::experimental::set_done(std::move(receiver));
                 }
 
-                // The typedef is duplicated from parent struct as the parent one is
-                // not instantiated early enough to use it here.
-                using value_type =
-                    typename hpx::execution::experimental::sender_traits<
-                        Sender>::template value_types<hpx::tuple, hpx::variant>;
-
                 template <typename... Ts>
                 auto set_value(Ts&&... ts) && noexcept -> decltype(
-                    std::declval<hpx::variant<hpx::monostate, value_type>>()
-                        .template emplace<value_type>(
-                            hpx::make_tuple<>(std::forward<Ts>(ts)...)),
+                    hpx::execution::experimental::set_value(
+                        std::move(receiver), std::forward<Ts>(ts)...),
                     void())
                 {
                     hpx::detail::try_catch_exception_ptr(

--- a/libs/parallelism/execution/include/hpx/execution/algorithms/detach.hpp
+++ b/libs/parallelism/execution/include/hpx/execution/algorithms/detach.hpp
@@ -25,7 +25,6 @@
 #include <cstddef>
 #include <exception>
 #include <memory>
-#include <tuple>
 #include <type_traits>
 #include <utility>
 

--- a/libs/parallelism/execution/include/hpx/execution/algorithms/ensure_started.hpp
+++ b/libs/parallelism/execution/include/hpx/execution/algorithms/ensure_started.hpp
@@ -13,6 +13,7 @@
 #include <hpx/assert.hpp>
 #include <hpx/concepts/concepts.hpp>
 #include <hpx/datastructures/tuple.hpp>
+#include <hpx/datastructures/variant.hpp>
 #include <hpx/execution/algorithms/detail/partial_algorithm.hpp>
 #include <hpx/execution/algorithms/detail/single_result.hpp>
 #include <hpx/execution_base/operation_state.hpp>
@@ -36,7 +37,6 @@
 #include <mutex>
 #include <type_traits>
 #include <utility>
-#include <variant>
 
 namespace hpx { namespace execution { namespace experimental {
     namespace detail {
@@ -120,11 +120,11 @@ namespace hpx { namespace execution { namespace experimental {
                 };
                 using value_type =
                     typename hpx::execution::experimental::sender_traits<
-                        Sender>::template value_types<hpx::tuple, std::variant>;
+                        Sender>::template value_types<hpx::tuple, hpx::variant>;
                 using error_type =
                     hpx::util::detail::unique_t<hpx::util::detail::prepend_t<
-                        error_types<std::variant>, std::exception_ptr>>;
-                std::variant<std::monostate, done_type, error_type, value_type>
+                        error_types<hpx::variant>, std::exception_ptr>>;
+                hpx::variant<hpx::monostate, done_type, error_type, value_type>
                     v;
 
                 using continuation_type =
@@ -157,11 +157,11 @@ namespace hpx { namespace execution { namespace experimental {
                     using value_type =
                         typename hpx::execution::experimental::sender_traits<
                             Sender>::template value_types<hpx::tuple,
-                            std::variant>;
+                            hpx::variant>;
 
                     template <typename... Ts>
                     auto set_value(Ts&&... ts) && noexcept -> decltype(
-                        std::declval<std::variant<std::monostate, value_type>>()
+                        std::declval<hpx::variant<hpx::monostate, value_type>>()
                             .template emplace<value_type>(
                                 hpx::make_tuple<>(std::forward<Ts>(ts)...)),
                         void())
@@ -200,7 +200,7 @@ namespace hpx { namespace execution { namespace experimental {
                 {
                     std::decay_t<Receiver> receiver;
 
-                    HPX_NORETURN void operator()(std::monostate) const
+                    HPX_NORETURN void operator()(hpx::monostate) const
                     {
                         HPX_UNREACHABLE;
                     }
@@ -213,7 +213,7 @@ namespace hpx { namespace execution { namespace experimental {
 
                     void operator()(error_type const& error)
                     {
-                        std::visit(
+                        hpx::visit(
                             error_visitor<Receiver>{
                                 std::forward<Receiver>(receiver)},
                             error);
@@ -221,7 +221,7 @@ namespace hpx { namespace execution { namespace experimental {
 
                     void operator()(value_type const& ts)
                     {
-                        std::visit(
+                        hpx::visit(
                             value_visitor<Receiver>{
                                 std::forward<Receiver>(receiver)},
                             ts);
@@ -292,7 +292,7 @@ namespace hpx { namespace execution { namespace experimental {
                         // set_error/set_done/set_value has been called and
                         // values/errors have been stored into the shared state.
                         // We can trigger the continuation directly.
-                        std::visit(
+                        hpx::visit(
                             done_error_value_visitor<Receiver>{
                                 std::forward<Receiver>(receiver)},
                             v);
@@ -311,7 +311,7 @@ namespace hpx { namespace execution { namespace experimental {
                             // release the lock early and call the continuation
                             // directly again.
                             l.unlock();
-                            std::visit(
+                            hpx::visit(
                                 done_error_value_visitor<Receiver>{
                                     std::forward<Receiver>(receiver)},
                                 v);
@@ -329,7 +329,7 @@ namespace hpx { namespace execution { namespace experimental {
                                 [this,
                                     receiver =
                                         std::forward<Receiver>(receiver)]() {
-                                    std::visit(
+                                    hpx::visit(
                                         done_error_value_visitor<Receiver>{
                                             std::move(receiver)},
                                         v);

--- a/libs/parallelism/execution/include/hpx/execution/algorithms/let_error.hpp
+++ b/libs/parallelism/execution/include/hpx/execution/algorithms/let_error.hpp
@@ -21,7 +21,6 @@
 #include <hpx/type_support/pack.hpp>
 
 #include <exception>
-#include <tuple>
 #include <type_traits>
 #include <utility>
 

--- a/libs/parallelism/execution/include/hpx/execution/algorithms/when_all.hpp
+++ b/libs/parallelism/execution/include/hpx/execution/algorithms/when_all.hpp
@@ -8,6 +8,8 @@
 
 #include <hpx/config.hpp>
 #include <hpx/concepts/concepts.hpp>
+#include <hpx/datastructures/optional.hpp>
+#include <hpx/datastructures/variant.hpp>
 #include <hpx/execution/algorithms/detail/single_result.hpp>
 #include <hpx/execution_base/operation_state.hpp>
 #include <hpx/execution_base/receiver.hpp>
@@ -21,10 +23,8 @@
 #include <exception>
 #include <functional>
 #include <memory>
-#include <optional>
 #include <type_traits>
 #include <utility>
-#include <variant>
 
 namespace hpx { namespace execution { namespace experimental {
     namespace detail {
@@ -141,10 +141,10 @@ namespace hpx { namespace execution { namespace experimental {
                 static constexpr std::size_t I = 0;
                 std::atomic<std::size_t> predecessors_remaining =
                     num_predecessors;
-                hpx::util::member_pack_for<std::optional<
+                hpx::util::member_pack_for<hpx::optional<
                     std::decay_t<value_types_helper_t<Senders>>>...>
                     ts;
-                std::optional<error_types<std::variant>> error;
+                hpx::optional<error_types<hpx::variant>> error;
                 std::atomic<bool> set_done_error_called{false};
                 std::decay_t<Receiver> receiver;
 
@@ -193,7 +193,7 @@ namespace hpx { namespace execution { namespace experimental {
                         }
                         else if (error)
                         {
-                            std::visit(
+                            hpx::visit(
                                 [this](auto&& error) {
                                     hpx::execution::experimental::set_error(
                                         std::move(receiver),


### PR DESCRIPTION
There's no longer a feature check for `std::variant`. We assume it is always available.