### PR TITLE
Minor release changes from 1.7.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,7 +52,7 @@ docs_push_filter: &docs_push_filter
       branches:
         only:
           - master
-          - release
+          - /release.*/
       tags:
         ignore: stable
 

--- a/cmake/packaging/rpm/Changelog.txt
+++ b/cmake/packaging/rpm/Changelog.txt
@@ -1,3 +1,6 @@
+* Wed Aug 12 2021 STE||AR Group <contact@stellar-group.org> 1.7.1
+- HPX Release 1.7.1 (https://hpx-docs.stellar-group.org/tags/1.7.1/html/releases/whats_new_1_7_1.html)
+
 * Wed Jul 14 2021 STE||AR Group <contact@stellar-group.org> 1.7.0
 - HPX Release 1.7.0 (https://hpx-docs.stellar-group.org/tags/1.7.0/html/releases/whats_new_1_7_0.html)
 

--- a/docs/sphinx/contributing/release_procedure.rst
+++ b/docs/sphinx/contributing/release_procedure.rst
@@ -1,4 +1,5 @@
 ..
+    Copyright (c)      2021 ETH Zurich
     Copyright (c) 2007-2017 Louisiana State University
 
     SPDX-License-Identifier: BSL-1.0
@@ -20,6 +21,12 @@ One way to use this procedure is to print a copy and check off the lines as they
 are completed to avoid confusion.
 
 #. Notify developers that a release is imminent.
+
+#. For minor and major releases: create and check out a new branch at an
+   appropriate point on ``master`` with the name ``release-major.minor.X``.
+   ``major`` and ``minor`` should be the major and minor versions of the
+   release. For patch releases: check out the corresponding
+   ``release-major.minor.X`` branch.
 
 #. Write release notes in ``docs/sphinx/releases/whats_new_$VERSION.rst``. Keep
    adding merged PRs and closed issues to this until just before the release is
@@ -47,26 +54,6 @@ are completed to avoid confusion.
      release to synchronize with the |hpx| release (`APEX
      <http://github.com/khuck/xpress-apex>`_, `libCDS
      <https://github.com/STEllAR-GROUP/libcds>`_).
-
-#. If there have been any commits to the release branch since the last release,
-   create a tag from the old release branch before deleting the old release
-   branch in the next step.
-
-#. Unprotect the release branch in the github repository settings so that it can
-   be deleted and recreated (tick "Allow force pushes" in the release branch
-   settings of the repository).
-
-#. Reset the release branch to the latest stable state on master and force push
-   to origin/release. If you are creating a patch release, branch from the
-   release tag for which you want to create a patch release.
-
-   * ``git checkout -b release`` (or just ``checkout`` in case the it exists)
-   * ``git reset --hard stable``
-   * ``git push --force origin release``
-
-#. Protect the release branch again to disable force pushes.
-
-#. Check out the release branch.
 
 #. Make sure ``HPX_VERSION_MAJOR/MINOR/SUBMINOR`` in ``CMakeLists.txt`` contain
    the correct values. Change them if needed.

--- a/docs/sphinx/quickstart.rst
+++ b/docs/sphinx/quickstart.rst
@@ -33,7 +33,7 @@ It is also recommended that you check out the latest stable tag:
 
 .. code-block:: sh
 
-    git checkout 1.7.0
+    git checkout 1.7.1
 
 |hpx| dependencies
 ==================

--- a/docs/sphinx/releases.rst
+++ b/docs/sphinx/releases.rst
@@ -14,6 +14,7 @@ Releases
 .. toctree::
    :maxdepth: 1
 
+   releases/whats_new_1_7_1
    releases/whats_new_1_7_0
    releases/whats_new_1_6_0
    releases/whats_new_1_5_1

--- a/docs/sphinx/releases/whats_new_1_7_1.rst
+++ b/docs/sphinx/releases/whats_new_1_7_1.rst
@@ -1,0 +1,61 @@
+..
+    Copyright (C) 2020-2021 ETH Zurich
+    Copyright (C) 2007-2020 Hartmut Kaiser
+
+    SPDX-License-Identifier: BSL-1.0
+    Distributed under the Boost Software License, Version 1.0. (See accompanying
+    file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+.. _hpx_1_7_1:
+
+===========================
+|hpx| V1.7.1 (Aug 11, 2021)
+===========================
+
+This is a bugfix release with a few minor fixes.
+
+General changes
+===============
+
+- Added a CMake option to assume that all types are bitwise serializable by
+  default: ``HPX_SERIALIZATION_WITH_ALL_TYPES_ARE_BITWISE_SERIALIZABLE``. The
+  default value ``OFF`` corresponds to the old behaviour.
+- Added a version check for Asio. The minimum Asio version supported by |hpx| is
+  1.12.0.
+- Fixed a bug affecting usage of actions, where the internals of |hpx| relied on
+  function addresses being unique. This was fixed by relying on variable
+  addresses being unique instead.
+- Made ``hpx::util::bind`` more strict in checking the validity of placeholders.
+- Small performance improvement to spinlocks.
+- Adapted the following parallel algorithms to C++20: ``inclusive_scan``,
+  ``exclusive_scan``, ``transform_inclusive_scan``,
+  ``transform_exclusive_scan``.
+
+Breaking changes
+================
+
+- The experimental ``hpx::execution::simdpar`` execution policy (introduced in
+  1.7.0) was renamed to ``hpx::execution::par_simd`` for consistency with the
+  other parallel policies.
+
+Closed issues
+=============
+
+* :hpx-issue:`5494` - Rename `simdpar` execution policy to `par_simd`
+* :hpx-issue:`5488` - `hpx::util::bind` doesn't bounds-check placeholders
+* :hpx-issue:`5486` - Possible V1.7.1 release
+
+Closed pull requests
+====================
+
+* :hpx-pr:`5500` - Minor bug fix in transform exclusive and inclusive scan tests
+* :hpx-pr:`5499` - Rename simdpar to par_simd
+* :hpx-pr:`5489` - Adding bound-checking for bind placeholders
+* :hpx-pr:`5485` - Add Asio version check
+* :hpx-pr:`5482` - Change extra archive data to rely on uniqueness of a variable address, not a function address
+* :hpx-pr:`5448` - More fixes to enable for all types to be assumed to be bitwise copyable
+* :hpx-pr:`5445` - Improve performance of Spinlocks
+* :hpx-pr:`5444` - Adapt transform_inclusive_scan to C++ 20
+* :hpx-pr:`5440` - Adapt transform_exclusive_scan to C++ 20
+* :hpx-pr:`5439` - Adapt inclusive_scan to C++ 20
+* :hpx-pr:`5436` - Adapt exclusive_scan to C++20

--- a/docs/sphinx/releases/whats_new_1_7_1.rst
+++ b/docs/sphinx/releases/whats_new_1_7_1.rst
@@ -9,7 +9,7 @@
 .. _hpx_1_7_1:
 
 ===========================
-|hpx| V1.7.1 (Aug 11, 2021)
+|hpx| V1.7.1 (Aug 12, 2021)
 ===========================
 
 This is a bugfix release with a few minor fixes.

--- a/tools/roll_release.sh
+++ b/tools/roll_release.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright (c)      2020 ETH Zurich
-# Copyright (c)      2019 Mikael Simberg
+# Copyright (c) 2019-2021 ETH Zurich
 # Copyright (c) 2011-2012 Bryce Adelstein-Lelbach
 #
 # SPDX-License-Identifier: BSL-1.0
@@ -37,6 +36,35 @@ fi
 
 if [ -z "${VERSION_TAG}" ]; then
     echo "You are about to tag and create a final release on GitHub."
+
+    echo ""
+    echo "Sanity checking release"
+
+    sanity_errors=0
+
+    whats_new_file_nosuffix="whats_new_${VERSION_FULL_NOTAG_UNDERSCORE}"
+    whats_new_path="docs/sphinx/releases/${whats_new_file_nosuffix}.rst"
+    printf "Checking that %s exists... " "${whats_new_path}"
+    if [[ -f "${whats_new_path}" ]]; then
+        echo "OK"
+    else
+        echo "Missing"
+        sanity_errors=$((sanity_errors+1))
+    fi
+
+
+    printf "Checking that %s.rst is included in the docs/sphinx/releases.rst table of contents... " "${whats_new_file_nosuffix}"
+    if [[ $(grep "${whats_new_file_nosuffix}" docs/sphinx/releases.rst) ]]; then
+        echo "OK"
+    else
+        echo "Missing"
+        sanity_errors=$((sanity_errors+1))
+    fi
+
+    if [[ ${sanity_errors} -gt 0 ]]; then
+        echo "Found ${sanity_errors} error(s). Fix it/them and try again."
+        exit 1
+    fi
 else
     echo "You are about to tag and create a pre-release on GitHub."
     echo "If you intended to make a final release, remove the tag in the main CMakeLists.txt first."

--- a/tools/roll_release.sh
+++ b/tools/roll_release.sh
@@ -26,12 +26,12 @@ VERSION_DESCRIPTION="[Release notes](${VERSION_RELEASE_NOTES_URL})"
 CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
 
 if ! which hub > /dev/null 2>&1; then
-    echo "Hub not installed on this system. Exiting.."
+    echo "Hub not installed on this system (see https://hub.github.com/). Exiting."
     exit 1
 fi
 
-if [ "${CURRENT_BRANCH}" != "release" ]; then
-    echo "Not on release branch. Not continuing to make release."
+if ! [[ "$CURRENT_BRANCH" =~ ^release-[0-9]+\.[0-9]+\.X$ ]]; then
+    echo "Not on release branch (current branch is \"${CURRENT_BRANCH}\"). Not continuing to make release."
     exit 1
 fi
 


### PR DESCRIPTION
Cherry-picks release notes from 1.7.1 branch, and slightly updates the release procedures. Also adds a basic sanity check to the `roll_release.sh` script (can/should be expanded, feel free to comment with ideas).