### PR TITLE
Add any_sender and unique_any_sender

### DIFF
--- a/libs/core/execution/include/hpx/execution/algorithms/just.hpp
+++ b/libs/core/execution/include/hpx/execution/algorithms/just.hpp
@@ -29,11 +29,27 @@ namespace hpx { namespace execution { namespace experimental {
         {
             hpx::util::member_pack_for<std::decay_t<Ts>...> ts;
 
-            template <typename... Ts_>
-            explicit constexpr just_sender(Ts_&&... ts)
-              : ts(std::piecewise_construct, std::forward<Ts_>(ts)...)
+            constexpr just_sender() = default;
+
+            template <typename T,
+                typename = std::enable_if_t<
+                    !std::is_same_v<std::decay_t<T>, just_sender>>>
+            explicit constexpr just_sender(T&& t)
+              : ts(std::piecewise_construct, std::forward<T>(t))
             {
             }
+
+            template <typename T0, typename T1, typename... Ts_>
+            explicit constexpr just_sender(T0&& t0, T1&& t1, Ts_&&... ts)
+              : ts(std::piecewise_construct, std::forward<T0>(t0),
+                    std::forward<T1>(t1), std::forward<Ts_>(ts)...)
+            {
+            }
+
+            just_sender(just_sender&&) = default;
+            just_sender(just_sender const&) = default;
+            just_sender& operator=(just_sender&&) = default;
+            just_sender& operator=(just_sender const&) = default;
 
             template <template <typename...> class Tuple,
                 template <typename...> class Variant>

--- a/libs/core/execution_base/CMakeLists.txt
+++ b/libs/core/execution_base/CMakeLists.txt
@@ -7,6 +7,7 @@
 set(execution_base_headers
     hpx/execution_base/agent_base.hpp
     hpx/execution_base/agent_ref.hpp
+    hpx/execution_base/any_sender.hpp
     hpx/execution_base/context_base.hpp
     hpx/execution_base/detail/spinlock_deadlock_detection.hpp
     hpx/execution_base/execution.hpp
@@ -39,7 +40,7 @@ set(execution_base_compat_headers
 )
 # cmake-format: on
 
-set(execution_base_sources agent_ref.cpp register_locks.cpp
+set(execution_base_sources agent_ref.cpp any_sender.cpp register_locks.cpp
                            spinlock_deadlock_detection.cpp this_thread.cpp
 )
 

--- a/libs/core/execution_base/include/hpx/execution_base/any_sender.hpp
+++ b/libs/core/execution_base/include/hpx/execution_base/any_sender.hpp
@@ -1,0 +1,811 @@
+//  Copyright (c) 2021 ETH Zurich
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include <hpx/assert.hpp>
+#include <hpx/errors/error.hpp>
+#include <hpx/errors/throw_exception.hpp>
+#include <hpx/execution_base/sender.hpp>
+
+#include <cstddef>
+#include <cstring>
+#include <exception>
+#include <memory>
+#include <type_traits>
+#include <utility>
+
+namespace hpx::detail {
+    template <typename T>
+    struct empty_vtable
+    {
+        static_assert(
+            sizeof(T) == 0, "No empty vtable type defined for given type T");
+    };
+
+    template <typename T>
+    struct get_empty_vtable
+    {
+        using empty_vtable_type = typename empty_vtable<T>::type;
+        static_assert(std::is_base_of_v<T, empty_vtable_type>,
+            "Given empty vtable type should be a base of T");
+
+        static T* call()
+        {
+            static empty_vtable_type empty;
+            return &empty;
+        }
+    };
+
+    template <typename Base, std::size_t EmbeddedStorageSize,
+        std::size_t AlignmentSize = sizeof(void*)>
+    class movable_sbo_storage
+    {
+    protected:
+        using base_type = Base;
+        static constexpr std::size_t embedded_storage_size =
+            EmbeddedStorageSize;
+        static constexpr std::size_t alignment_size = AlignmentSize;
+
+        // The union has two members:
+        // - embedded_storage: Embedded storage size array used for types that
+        //   are at most embedded_storage_size bytes large, and require at most
+        //   alignment_size alignment.
+        // - heap_storage: A pointer to base_type that is used when objects
+        //   don't fit in the embedded storage.
+        union
+        {
+            std::aligned_storage_t<embedded_storage_size, alignment_size>
+                embedded_storage;
+            base_type* heap_storage;
+        };
+        base_type* object;
+
+        // Returns true when it's safe to use the embedded storage, i.e.
+        // when the size and alignment of Impl are small enough.
+        template <typename Impl>
+        static constexpr bool can_use_embedded_storage()
+        {
+            constexpr bool fits_storage =
+                sizeof(std::decay_t<Impl>) <= embedded_storage_size;
+            constexpr bool sufficiently_aligned =
+                alignof(std::decay_t<Impl>) <= alignment_size;
+            return fits_storage && sufficiently_aligned;
+        }
+
+        bool using_embedded_storage() const noexcept
+        {
+            return object ==
+                reinterpret_cast<base_type const*>(&embedded_storage);
+        }
+
+        bool empty() const noexcept
+        {
+            return get().empty();
+        }
+
+        void release()
+        {
+            HPX_ASSERT(!empty());
+
+            if (using_embedded_storage())
+            {
+                get().~base_type();
+            }
+            else
+            {
+                delete heap_storage;
+                heap_storage = nullptr;
+            }
+
+            object = get_empty_vtable<base_type>::call();
+        }
+
+        void move_assign(movable_sbo_storage&& other) &
+
+        {
+            HPX_ASSERT(&other != this);
+            HPX_ASSERT(empty());
+
+            if (!other.empty())
+            {
+                if (other.using_embedded_storage())
+                {
+                    auto p = reinterpret_cast<base_type*>(&embedded_storage);
+                    other.get().move_into(p);
+                    object = p;
+                }
+                else
+                {
+                    heap_storage = other.heap_storage;
+                    other.heap_storage = nullptr;
+                    object = heap_storage;
+                }
+
+                other.object = get_empty_vtable<base_type>::call();
+            }
+        }
+
+    public:
+        movable_sbo_storage()
+          : heap_storage(nullptr)
+          , object(get_empty_vtable<base_type>::call())
+        {
+        }
+
+        ~movable_sbo_storage()
+        {
+            if (!empty())
+            {
+                release();
+            }
+        }
+
+        movable_sbo_storage(movable_sbo_storage&& other)
+          : heap_storage(nullptr)
+          , object(get_empty_vtable<base_type>::call())
+        {
+            move_assign(std::move(other));
+        }
+
+        movable_sbo_storage& operator=(movable_sbo_storage&& other)
+        {
+            if (&other != this)
+            {
+                if (!empty())
+                {
+                    release();
+                }
+
+                move_assign(std::move(other));
+            }
+            return *this;
+        }
+
+        movable_sbo_storage(movable_sbo_storage const&) = delete;
+        movable_sbo_storage& operator=(movable_sbo_storage const&) = delete;
+
+        base_type const& get() const noexcept
+        {
+            return *object;
+        }
+
+        base_type& get() noexcept
+        {
+            return *object;
+        }
+
+        template <typename Impl, typename... Ts>
+        void store(Ts&&... ts)
+        {
+            if (!empty())
+            {
+                release();
+            }
+
+            if constexpr (can_use_embedded_storage<Impl>())
+            {
+                Impl* p = reinterpret_cast<Impl*>(&embedded_storage);
+                new (p) Impl(std::forward<Ts>(ts)...);
+                object = p;
+            }
+            else
+            {
+                heap_storage = new Impl(std::forward<Ts>(ts)...);
+                object = heap_storage;
+            }
+        }
+    };
+
+    template <typename Base, std::size_t EmbeddedStorageSize,
+        std::size_t AlignmentSize = sizeof(void*)>
+    class copyable_sbo_storage
+      : public movable_sbo_storage<Base, EmbeddedStorageSize, AlignmentSize>
+    {
+        using storage_base_type =
+            movable_sbo_storage<Base, EmbeddedStorageSize, AlignmentSize>;
+
+        using typename storage_base_type::base_type;
+
+        using storage_base_type::embedded_storage;
+        using storage_base_type::empty;
+        using storage_base_type::heap_storage;
+        using storage_base_type::object;
+        using storage_base_type::release;
+        using storage_base_type::using_embedded_storage;
+
+        void copy_assign(copyable_sbo_storage const& other) &
+        {
+            HPX_ASSERT(&other != this);
+            HPX_ASSERT(empty());
+
+            if (!other.empty())
+            {
+                if (other.using_embedded_storage())
+                {
+                    base_type* p =
+                        reinterpret_cast<base_type*>(&embedded_storage);
+                    other.get().clone_into(p);
+                    object = p;
+                }
+                else
+                {
+                    heap_storage = other.get().clone();
+                    object = heap_storage;
+                }
+            }
+        }
+
+    public:
+        using storage_base_type::get;
+        using storage_base_type::store;
+
+        copyable_sbo_storage() = default;
+        copyable_sbo_storage(copyable_sbo_storage&&) = default;
+        copyable_sbo_storage& operator=(copyable_sbo_storage&&) = default;
+
+        copyable_sbo_storage(copyable_sbo_storage const& other)
+          : storage_base_type()
+        {
+            copy_assign(other);
+        }
+
+        copyable_sbo_storage& operator=(copyable_sbo_storage const& other)
+        {
+            if (&other != this)
+            {
+                if (!empty())
+                {
+                    release();
+                }
+                copy_assign(other);
+            }
+            return *this;
+        }
+    };
+}    // namespace hpx::detail
+
+namespace hpx::execution::experimental {
+    namespace detail {
+        struct any_operation_state_base
+        {
+            virtual ~any_operation_state_base() = default;
+            virtual bool empty() const noexcept
+            {
+                return false;
+            }
+            virtual void start() & noexcept = 0;
+        };
+
+        struct HPX_CORE_EXPORT empty_any_operation_state final
+          : any_operation_state_base
+        {
+            bool empty() const noexcept override;
+            void start() & noexcept override;
+        };
+
+        template <typename Sender, typename Receiver>
+        struct any_operation_state_impl final : any_operation_state_base
+        {
+            std::decay_t<
+                connect_result_t<std::decay_t<Sender>, std::decay_t<Receiver>>>
+                operation_state;
+
+            template <typename Sender_, typename Receiver_>
+            any_operation_state_impl(Sender_&& sender, Receiver_&& receiver)
+              : operation_state(hpx::execution::experimental::connect(
+                    std::forward<Sender_>(sender),
+                    std::forward<Receiver_>(receiver)))
+            {
+            }
+
+            void start() & noexcept override
+            {
+                hpx::execution::experimental::start(operation_state);
+            }
+        };
+
+        class HPX_CORE_EXPORT any_operation_state
+        {
+            using base_type = detail::any_operation_state_base;
+            template <typename Sender, typename Receiver>
+            using impl_type =
+                detail::any_operation_state_impl<Sender, Receiver>;
+            using storage_type =
+                hpx::detail::movable_sbo_storage<base_type, 8 * sizeof(void*)>;
+
+            storage_type storage{};
+
+        public:
+            template <typename Sender, typename Receiver>
+            any_operation_state(Sender&& sender, Receiver&& receiver)
+            {
+                storage.template store<impl_type<Sender, Receiver>>(
+                    std::forward<Sender>(sender),
+                    std::forward<Receiver>(receiver));
+            }
+
+            ~any_operation_state() = default;
+            any_operation_state(any_operation_state&&) = delete;
+            any_operation_state(any_operation_state const&) = delete;
+            any_operation_state& operator=(any_operation_state&&) = delete;
+            any_operation_state& operator=(any_operation_state const&) = delete;
+
+            void start() & noexcept;
+        };
+
+        template <typename... Ts>
+        struct any_receiver_base
+        {
+            virtual ~any_receiver_base() = default;
+            virtual void move_into(void* p) = 0;
+            virtual void set_value(Ts... ts) && = 0;
+            virtual void set_error(std::exception_ptr ep) && noexcept = 0;
+            virtual void set_done() && noexcept = 0;
+            virtual bool empty() const noexcept
+            {
+                return false;
+            }
+        };
+
+        HPX_NORETURN HPX_CORE_EXPORT void throw_bad_any_call(
+            char const* class_name, char const* function_name);
+
+        template <typename... Ts>
+        struct empty_any_receiver final : any_receiver_base<Ts...>
+        {
+            void move_into(void*) override
+            {
+                HPX_UNREACHABLE;
+            }
+
+            bool empty() const noexcept override
+            {
+                return true;
+            }
+
+            HPX_NORETURN void set_value(Ts...) && override
+            {
+                throw_bad_any_call("any_receiver", "set_value");
+            }
+
+            HPX_NORETURN void set_error(std::exception_ptr) && noexcept override
+            {
+                throw_bad_any_call("any_receiver", "set_error");
+            }
+
+            HPX_NORETURN void set_done() && noexcept override
+            {
+                throw_bad_any_call("any_receiver", "set_done");
+            }
+        };
+
+        template <typename Receiver, typename... Ts>
+        struct any_receiver_impl final : any_receiver_base<Ts...>
+        {
+            std::decay_t<Receiver> receiver;
+
+            template <typename Receiver_,
+                typename = std::enable_if_t<!std::is_same_v<
+                    std::decay_t<Receiver_>, any_receiver_impl>>>
+            explicit any_receiver_impl(Receiver_&& receiver)
+              : receiver(std::forward<Receiver_>(receiver))
+            {
+            }
+
+            void move_into(void* p) override
+            {
+                new (p) any_receiver_impl(std::move(receiver));
+            }
+
+            void set_value(Ts... ts) && override
+            {
+                hpx::execution::experimental::set_value(
+                    std::move(receiver), std::move(ts)...);
+            }
+
+            void set_error(std::exception_ptr ep) && noexcept override
+            {
+                hpx::execution::experimental::set_error(
+                    std::move(receiver), std::move(ep));
+            }
+
+            void set_done() && noexcept override
+            {
+                hpx::execution::experimental::set_done(std::move(receiver));
+            }
+        };
+
+        template <typename... Ts>
+        class any_receiver
+        {
+            using base_type = detail::any_receiver_base<Ts...>;
+            template <typename Receiver>
+            using impl_type = detail::any_receiver_impl<Receiver, Ts...>;
+            using storage_type =
+                hpx::detail::movable_sbo_storage<base_type, 4 * sizeof(void*)>;
+
+            storage_type storage{};
+
+        public:
+            template <typename Receiver,
+                typename = std::enable_if_t<
+                    !std::is_same_v<std::decay_t<Receiver>, any_receiver>>>
+            explicit any_receiver(Receiver&& receiver)
+            {
+                storage.template store<impl_type<Receiver>>(
+                    std::forward<Receiver>(receiver));
+            }
+
+            template <typename Receiver,
+                typename = std::enable_if_t<
+                    !std::is_same_v<std::decay_t<Receiver>, any_receiver>>>
+            any_receiver& operator=(Receiver&& receiver)
+            {
+                storage.template store<impl_type<Receiver>>(
+                    std::forward<Receiver>(receiver));
+                return *this;
+            }
+
+            ~any_receiver() = default;
+            any_receiver(any_receiver&&) = default;
+            any_receiver(any_receiver const&) = delete;
+            any_receiver& operator=(any_receiver&&) = default;
+            any_receiver& operator=(any_receiver const&) = delete;
+
+            void set_value(Ts... ts) &&
+            {
+                // We first move the storage to a temporary variable so that
+                // this any_receiver is empty after this set_value. Doing
+                // std::move(storage.get()).set_value(...) would leave us with a
+                // non-empty any_receiver holding a moved-from receiver.
+                auto moved_storage = std::move(storage);
+                std::move(moved_storage.get()).set_value(std::move(ts)...);
+            }
+
+            void set_error(std::exception_ptr ep) && noexcept
+            {
+                // We first move the storage to a temporary variable so that
+                // this any_receiver is empty after this set_error. Doing
+                // std::move(storage.get()).set_error(...) would leave us with a
+                // non-empty any_receiver holding a moved-from receiver.
+                auto moved_storage = std::move(storage);
+                std::move(moved_storage.get()).set_error(std::move(ep));
+            }
+
+            void set_done() && noexcept
+            {
+                // We first move the storage to a temporary variable so that
+                // this any_receiver is empty after this set_done. Doing
+                // std::move(storage.get()).set_done(...) would leave us with a
+                // non-empty any_receiver holding a moved-from receiver.
+                auto moved_storage = std::move(storage);
+                std::move(moved_storage.get()).set_done();
+            }
+        };
+
+        template <typename... Ts>
+        struct unique_any_sender_base
+        {
+            virtual ~unique_any_sender_base() = default;
+            virtual void move_into(void* p) = 0;
+            virtual any_operation_state connect(
+                any_receiver<Ts...>&& receiver) && = 0;
+            virtual bool empty() const noexcept
+            {
+                return false;
+            }
+        };
+
+        template <typename... Ts>
+        struct any_sender_base : public unique_any_sender_base<Ts...>
+        {
+            virtual any_sender_base* clone() const = 0;
+            virtual void clone_into(void* p) const = 0;
+            using unique_any_sender_base<Ts...>::connect;
+            virtual any_operation_state connect(
+                any_receiver<Ts...>&& receiver) & = 0;
+        };
+
+        template <typename... Ts>
+        struct empty_unique_any_sender final : unique_any_sender_base<Ts...>
+        {
+            void move_into(void*) override
+            {
+                HPX_UNREACHABLE;
+            }
+
+            bool empty() const noexcept override
+            {
+                return true;
+            }
+
+            HPX_NORETURN any_operation_state connect(any_receiver<Ts...>&&) &&
+                override
+            {
+                throw_bad_any_call("unique_any_sender", "connect");
+            }
+        };
+
+        template <typename... Ts>
+        struct empty_any_sender final : any_sender_base<Ts...>
+        {
+            void move_into(void*) override
+            {
+                HPX_UNREACHABLE;
+            }
+
+            any_sender_base<Ts...>* clone() const override
+            {
+                HPX_UNREACHABLE;
+            }
+
+            void clone_into(void*) const override
+            {
+                HPX_UNREACHABLE;
+            }
+
+            bool empty() const noexcept override
+            {
+                return true;
+            }
+
+            HPX_NORETURN any_operation_state connect(any_receiver<Ts...>&&) &
+                override
+            {
+                throw_bad_any_call("any_sender", "connect");
+            }
+
+            HPX_NORETURN any_operation_state connect(any_receiver<Ts...>&&) &&
+                override
+            {
+                throw_bad_any_call("any_sender", "connect");
+            }
+        };
+
+        template <typename Sender, typename... Ts>
+        struct unique_any_sender_impl final : unique_any_sender_base<Ts...>
+        {
+            std::decay_t<Sender> sender;
+
+            template <typename Sender_,
+                typename = std::enable_if_t<!std::is_same_v<
+                    std::decay_t<Sender_>, unique_any_sender_impl>>>
+            explicit unique_any_sender_impl(Sender_&& sender)
+              : sender(std::forward<Sender_>(sender))
+            {
+            }
+
+            void move_into(void* p) override
+            {
+                new (p) unique_any_sender_impl(std::move(sender));
+            }
+
+            any_operation_state connect(any_receiver<Ts...>&& receiver) &&
+                override
+            {
+                return any_operation_state{
+                    std::move(sender), std::move(receiver)};
+            }
+        };
+
+        template <typename Sender, typename... Ts>
+        struct any_sender_impl final : any_sender_base<Ts...>
+        {
+            std::decay_t<Sender> sender;
+
+            template <typename Sender_,
+                typename = std::enable_if_t<
+                    !std::is_same_v<std::decay_t<Sender_>, any_sender_impl>>>
+            explicit any_sender_impl(Sender_&& sender)
+              : sender(std::forward<Sender_>(sender))
+            {
+            }
+
+            void move_into(void* p) override
+            {
+                new (p) any_sender_impl(std::move(sender));
+            }
+
+            any_sender_base<Ts...>* clone() const override
+            {
+                return new any_sender_impl(sender);
+            }
+
+            void clone_into(void* p) const override
+            {
+                new (p) any_sender_impl(sender);
+            }
+
+            any_operation_state connect(any_receiver<Ts...>&& receiver) &
+                override
+            {
+                return any_operation_state{sender, std::move(receiver)};
+            }
+
+            any_operation_state connect(any_receiver<Ts...>&& receiver) &&
+                override
+            {
+                return any_operation_state{
+                    std::move(sender), std::move(receiver)};
+            }
+        };
+    }    // namespace detail
+
+    template <typename... Ts>
+    class unique_any_sender
+    {
+        using base_type = detail::unique_any_sender_base<Ts...>;
+        template <typename Sender>
+        using impl_type = detail::unique_any_sender_impl<Sender, Ts...>;
+        using storage_type =
+            hpx::detail::movable_sbo_storage<base_type, 4 * sizeof(void*)>;
+
+        storage_type storage{};
+
+    public:
+        unique_any_sender() = default;
+
+        template <typename Sender,
+            typename = std::enable_if_t<
+                !std::is_same_v<std::decay_t<Sender>, unique_any_sender>>>
+        explicit unique_any_sender(Sender&& sender)
+        {
+            storage.template store<impl_type<Sender>>(
+                std::forward<Sender>(sender));
+        }
+
+        template <typename Sender,
+            typename = std::enable_if_t<
+                !std::is_same_v<std::decay_t<Sender>, unique_any_sender>>>
+        unique_any_sender& operator=(Sender&& sender)
+        {
+            storage.template store<impl_type<Sender>>(
+                std::forward<Sender>(sender));
+            return *this;
+        }
+
+        ~unique_any_sender() = default;
+        unique_any_sender(unique_any_sender&&) = default;
+        unique_any_sender(unique_any_sender const&) = delete;
+        unique_any_sender& operator=(unique_any_sender&&) = default;
+        unique_any_sender& operator=(unique_any_sender const&) = delete;
+
+        template <template <typename...> class Tuple,
+            template <typename...> class Variant>
+        using value_types = Variant<Tuple<Ts...>>;
+
+        template <template <typename...> class Variant>
+        using error_types = Variant<std::exception_ptr>;
+
+        static constexpr bool sends_done = false;
+
+        template <typename R>
+        detail::any_operation_state connect(R&& r) &&
+        {
+            // We first move the storage to a temporary variable so that this
+            // any_sender is empty after this connect. Doing
+            // std::move(storage.get()).connect(...) would leave us with a
+            // non-empty any_sender holding a moved-from sender.
+            auto moved_storage = std::move(storage);
+            return std::move(moved_storage.get())
+                .connect(detail::any_receiver<Ts...>{std::forward<R>(r)});
+        }
+    };
+
+    template <typename... Ts>
+    class any_sender
+    {
+        using base_type = detail::any_sender_base<Ts...>;
+        template <typename Sender>
+        using impl_type = detail::any_sender_impl<Sender, Ts...>;
+        using storage_type =
+            hpx::detail::copyable_sbo_storage<base_type, 4 * sizeof(void*)>;
+
+        storage_type storage{};
+
+    public:
+        any_sender() = default;
+
+        template <typename Sender,
+            typename = std::enable_if_t<
+                !std::is_same_v<std::decay_t<Sender>, any_sender>>>
+        explicit any_sender(Sender&& sender)
+        {
+            static_assert(std::is_copy_constructible_v<std::decay_t<Sender>>,
+                "any_sender requires the given sender to be copy "
+                "constructible. Ensure the used sender type is copy "
+                "constructible or use unique_any_sender if you do not require "
+                "copyability.");
+            storage.template store<impl_type<Sender>>(
+                std::forward<Sender>(sender));
+        }
+
+        template <typename Sender,
+            typename = std::enable_if_t<
+                !std::is_same_v<std::decay_t<Sender>, any_sender>>>
+        any_sender& operator=(Sender&& sender)
+        {
+            static_assert(std::is_copy_constructible_v<std::decay_t<Sender>>,
+                "any_sender requires the given sender to be copy "
+                "constructible. Ensure the used sender type is copy "
+                "constructible or use unique_any_sender if you do not require "
+                "copyability.");
+            storage.template store<impl_type<Sender>>(
+                std::forward<Sender>(sender));
+            return *this;
+        }
+
+        ~any_sender() = default;
+        any_sender(any_sender&&) = default;
+        any_sender(any_sender const&) = default;
+        any_sender& operator=(any_sender&&) = default;
+        any_sender& operator=(any_sender const&) = default;
+
+        template <template <typename...> class Tuple,
+            template <typename...> class Variant>
+        using value_types = Variant<Tuple<Ts...>>;
+
+        template <template <typename...> class Variant>
+        using error_types = Variant<std::exception_ptr>;
+
+        static constexpr bool sends_done = false;
+
+        template <typename R>
+        detail::any_operation_state connect(R&& r) &
+        {
+            return storage.get().connect(
+                detail::any_receiver<Ts...>{std::forward<R>(r)});
+        }
+
+        template <typename R>
+        detail::any_operation_state connect(R&& r) &&
+        {
+            // We first move the storage to a temporary variable so that this
+            // any_sender is empty after this connect. Doing
+            // std::move(storage.get()).connect(...) would leave us with a
+            // non-empty any_sender holding a moved-from sender.
+            auto moved_storage = std::move(storage);
+            return std::move(moved_storage.get())
+                .connect(detail::any_receiver<Ts...>{std::forward<R>(r)});
+        }
+    };
+}    // namespace hpx::execution::experimental
+
+namespace hpx::detail {
+    template <>
+    struct empty_vtable<
+        hpx::execution::experimental::detail::any_operation_state_base>
+    {
+        using type =
+            hpx::execution::experimental::detail::empty_any_operation_state;
+    };
+
+    template <typename... Ts>
+    struct empty_vtable<
+        hpx::execution::experimental::detail::any_receiver_base<Ts...>>
+    {
+        using type =
+            hpx::execution::experimental::detail::empty_any_receiver<Ts...>;
+    };
+
+    template <typename... Ts>
+    struct empty_vtable<
+        hpx::execution::experimental::detail::unique_any_sender_base<Ts...>>
+    {
+        using type =
+            hpx::execution::experimental::detail::empty_unique_any_sender<
+                Ts...>;
+    };
+
+    template <typename... Ts>
+    struct empty_vtable<
+        hpx::execution::experimental::detail::any_sender_base<Ts...>>
+    {
+        using type =
+            hpx::execution::experimental::detail::empty_any_sender<Ts...>;
+    };
+}    // namespace hpx::detail

--- a/libs/core/execution_base/src/any_sender.cpp
+++ b/libs/core/execution_base/src/any_sender.cpp
@@ -1,0 +1,42 @@
+//  Copyright (c) 2021 ETH Zurich
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/errors/error.hpp>
+#include <hpx/errors/throw_exception.hpp>
+#include <hpx/execution_base/any_sender.hpp>
+#include <hpx/modules/format.hpp>
+
+#include <atomic>
+#include <exception>
+#include <string>
+#include <utility>
+
+namespace hpx::execution::experimental::detail {
+    void empty_any_operation_state::start() & noexcept
+    {
+        HPX_THROW_EXCEPTION(hpx::bad_function_call,
+            "attempted to call start on empty any_operation_state",
+            "any_operation_state::start");
+    }
+
+    bool empty_any_operation_state::empty() const noexcept
+    {
+        return true;
+    }
+
+    void any_operation_state::start() & noexcept
+    {
+        storage.get().start();
+    }
+
+    void throw_bad_any_call(char const* class_name, char const* function_name)
+    {
+        HPX_THROW_EXCEPTION(hpx::bad_function_call,
+            hpx::util::format(
+                "attempted to call {} on empty {}", function_name, class_name),
+            hpx::util::format("{}::{}", class_name, function_name));
+    }
+}    // namespace hpx::execution::experimental::detail

--- a/libs/core/execution_base/tests/unit/CMakeLists.txt
+++ b/libs/core/execution_base/tests/unit/CMakeLists.txt
@@ -5,8 +5,8 @@
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-set(tests basic_operation_state basic_receiver basic_sender basic_schedule
-          execution_context
+set(tests any_sender basic_operation_state basic_receiver basic_sender
+          basic_schedule execution_context
 )
 
 foreach(test ${tests})

--- a/libs/core/execution_base/tests/unit/any_sender.cpp
+++ b/libs/core/execution_base/tests/unit/any_sender.cpp
@@ -1,0 +1,634 @@
+//  Copyright (c) 2021 ETH Zurich
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/execution_base/any_sender.hpp>
+#include <hpx/execution_base/sender.hpp>
+#include <hpx/functional/bind_front.hpp>
+#include <hpx/functional/invoke_fused.hpp>
+#include <hpx/modules/errors.hpp>
+#include <hpx/modules/testing.hpp>
+
+#include <atomic>
+#include <exception>
+#include <string>
+#include <utility>
+
+struct custom_type_non_copyable
+{
+    int x;
+
+    custom_type_non_copyable(int x)
+      : x(x)
+    {
+    }
+    custom_type_non_copyable() = default;
+    custom_type_non_copyable(custom_type_non_copyable&&) = default;
+    custom_type_non_copyable& operator=(custom_type_non_copyable&&) = default;
+    custom_type_non_copyable(custom_type_non_copyable const&) = delete;
+    custom_type_non_copyable& operator=(
+        custom_type_non_copyable const&) = delete;
+};
+
+template <typename... Ts>
+struct non_copyable_sender
+{
+    std::tuple<std::decay_t<Ts>...> ts;
+
+    template <template <class...> class Tuple,
+        template <class...> class Variant>
+    using value_types = Variant<Tuple<>>;
+
+    template <template <class...> class Variant>
+    using error_types = Variant<std::exception_ptr>;
+
+    static constexpr bool sends_done = false;
+
+    non_copyable_sender() = default;
+    template <typename T,
+        typename = std::enable_if_t<
+            !std::is_same_v<std::decay_t<T>, non_copyable_sender>>>
+    non_copyable_sender(T&& t)
+      : ts(std::forward<T>(t))
+    {
+    }
+    template <typename T1, typename T2, typename... Ts_>
+    non_copyable_sender(T1&& t1, T2&& t2, Ts_&&... ts)
+      : ts(std::forward<T1>(t1), std::forward<T2>(t2), std::forward<Ts_>(ts)...)
+    {
+    }
+    non_copyable_sender(non_copyable_sender&&) = default;
+    non_copyable_sender(non_copyable_sender const&) = delete;
+    non_copyable_sender& operator=(non_copyable_sender&&) = default;
+    non_copyable_sender& operator=(non_copyable_sender const&) = delete;
+
+    template <typename R>
+    struct operation_state
+    {
+        std::decay_t<R> r;
+        std::tuple<std::decay_t<Ts>...> ts;
+
+        void start() & noexcept
+        {
+            hpx::util::invoke_fused(
+                hpx::util::bind_front(
+                    hpx::execution::experimental::set_value, std::move(r)),
+                std::move(ts));
+        };
+    };
+
+    template <typename R>
+    operation_state<R> connect(R&& r) && noexcept
+    {
+        return {std::forward<R>(r), std::move(ts)};
+    }
+};
+
+template <typename... Ts>
+struct sender
+{
+    std::tuple<std::decay_t<Ts>...> ts;
+
+    template <template <class...> class Tuple,
+        template <class...> class Variant>
+    using value_types = Variant<Tuple<>>;
+
+    template <template <class...> class Variant>
+    using error_types = Variant<std::exception_ptr>;
+
+    static constexpr bool sends_done = false;
+
+    sender() = default;
+    template <typename T,
+        typename = std::enable_if_t<!std::is_same_v<std::decay_t<T>, sender>>>
+    sender(T&& t)
+      : ts(std::forward<T>(t))
+    {
+    }
+    template <typename T1, typename T2, typename... Ts_>
+    sender(T1&& t1, T2&& t2, Ts_&&... ts)
+      : ts(std::forward<T1>(t1), std::forward<T2>(t2), std::forward<Ts_>(ts)...)
+    {
+    }
+    sender(sender&&) = default;
+    sender(sender const&) = default;
+    sender& operator=(sender&&) = default;
+    sender& operator=(sender const&) = default;
+
+    template <typename R>
+    struct operation_state
+    {
+        std::decay_t<R> r;
+        std::tuple<std::decay_t<Ts>...> ts;
+
+        void start() & noexcept
+        {
+            hpx::util::invoke_fused(
+                hpx::util::bind_front(
+                    hpx::execution::experimental::set_value, std::move(r)),
+                std::move(ts));
+        };
+    };
+
+    template <typename R>
+    operation_state<R> connect(R&& r) && noexcept
+    {
+        return {std::forward<R>(r), std::move(ts)};
+    }
+
+    template <typename R>
+    operation_state<R> connect(R&& r) & noexcept
+    {
+        return {std::forward<R>(r), ts};
+    }
+};
+
+template <typename... Ts>
+struct large_non_copyable_sender : non_copyable_sender<Ts...>
+{
+    // This padding only needs to be larger than the embedded storage in
+    // any_sender. Adjust if needed.
+    unsigned char padding[128] = {0};
+
+    large_non_copyable_sender() = default;
+    template <typename T,
+        typename = std::enable_if_t<
+            !std::is_same_v<std::decay_t<T>, large_non_copyable_sender>>>
+    large_non_copyable_sender(T&& t)
+      : non_copyable_sender<Ts...>(std::forward<T>(t))
+    {
+    }
+    template <typename T1, typename T2, typename... Ts_>
+    large_non_copyable_sender(T1&& t1, T2&& t2, Ts_&&... ts)
+      : non_copyable_sender<Ts...>(std::forward<T1>(t1), std::forward<T2>(t2),
+            std::forward<Ts_>(ts)...)
+    {
+    }
+    large_non_copyable_sender(large_non_copyable_sender&&) = default;
+    large_non_copyable_sender(large_non_copyable_sender const&) = delete;
+    large_non_copyable_sender& operator=(large_non_copyable_sender&&) = default;
+    large_non_copyable_sender& operator=(
+        large_non_copyable_sender const&) = delete;
+};
+
+template <typename... Ts>
+struct large_sender : sender<Ts...>
+{
+    // This padding only needs to be larger than the embedded storage in
+    // any_sender. Adjust if needed.
+    unsigned char padding[128] = {0};
+
+    large_sender() = default;
+    template <typename T,
+        typename =
+            std::enable_if_t<!std::is_same_v<std::decay_t<T>, large_sender>>>
+    large_sender(T&& t)
+      : sender<Ts...>(std::forward<T>(t))
+    {
+    }
+    template <typename T1, typename T2, typename... Ts_>
+    large_sender(T1&& t1, T2&& t2, Ts_&&... ts)
+      : sender<Ts...>(std::forward<T1>(t1), std::forward<T2>(t2),
+            std::forward<Ts_>(ts)...)
+    {
+    }
+    large_sender(large_sender&&) = default;
+    large_sender(large_sender const&) = default;
+    large_sender& operator=(large_sender&&) = default;
+    large_sender& operator=(large_sender const&) = default;
+};
+
+struct error_sender
+{
+    template <template <typename...> class Tuple,
+        template <typename...> class Variant>
+    using value_types = Variant<Tuple<>>;
+
+    template <template <typename...> class Variant>
+    using error_types = Variant<std::exception_ptr>;
+
+    static constexpr bool sends_done = false;
+
+    template <typename R>
+    struct operation_state
+    {
+        std::decay_t<R> r;
+        void start() noexcept
+        {
+            try
+            {
+                throw std::runtime_error("error");
+            }
+            catch (...)
+            {
+                hpx::execution::experimental::set_error(
+                    std::move(r), std::current_exception());
+            }
+        }
+    };
+
+    template <typename R>
+    operation_state<R> connect(R&& r)
+    {
+        return {std::forward<R>(r)};
+    }
+};
+
+template <typename F>
+struct callback_receiver
+{
+    std::decay_t<F> f;
+    std::atomic<bool>& set_value_called;
+
+    template <typename E>
+    void set_error(E&&) && noexcept
+    {
+        HPX_TEST(false);
+    }
+
+    void set_done() && noexcept
+    {
+        HPX_TEST(false);
+    };
+
+    template <typename... Ts>
+    auto set_value(Ts&&... ts) && noexcept
+        -> decltype(HPX_INVOKE(f, std::forward<Ts>(ts)...), void())
+    {
+        HPX_INVOKE(f, std::forward<Ts>(ts)...);
+        set_value_called = true;
+    }
+};
+
+struct error_receiver
+{
+    std::atomic<bool>& set_error_called;
+
+    void set_error(std::exception_ptr&& e) noexcept
+    {
+        try
+        {
+            std::rethrow_exception(std::move(e));
+        }
+        catch (std::runtime_error const& e)
+        {
+            HPX_TEST_EQ(std::string(e.what()), std::string("error"));
+        }
+        catch (...)
+        {
+            HPX_TEST(false);
+        }
+        set_error_called = true;
+    }
+
+    void set_done() noexcept
+    {
+        HPX_TEST(false);
+    };
+
+    template <typename... Ts>
+    void set_value(Ts&&...) noexcept
+    {
+        HPX_TEST(false);
+    }
+};
+
+template <template <typename...> typename Sender, typename... Ts, typename F>
+void test_any_sender(F&& f, Ts&&... ts)
+{
+    namespace ex = hpx::execution::experimental;
+
+    static_assert(std::is_copy_constructible_v<Sender<Ts...>>,
+        "This test requires the sender to be copy constructible.");
+
+    Sender<std::decay_t<Ts>...> s{std::forward<Ts>(ts)...};
+
+    ex::any_sender<std::decay_t<Ts>...> as1{s};
+    auto as2 = as1;
+
+    // We should be able to connect both as1 and as2 multiple times; set_value
+    // should always be called
+    {
+        std::atomic<bool> set_value_called{false};
+        auto os = ex::connect(as1, callback_receiver<F>{f, set_value_called});
+        ex::start(os);
+        HPX_TEST(set_value_called);
+    }
+
+    {
+        std::atomic<bool> set_value_called{false};
+        auto os = ex::connect(
+            std::move(as1), callback_receiver<F>{f, set_value_called});
+        ex::start(os);
+        HPX_TEST(set_value_called);
+    }
+
+    {
+        std::atomic<bool> set_value_called{false};
+        auto os = ex::connect(as2, callback_receiver<F>{f, set_value_called});
+        ex::start(os);
+        HPX_TEST(set_value_called);
+    }
+
+    {
+        std::atomic<bool> set_value_called{false};
+        auto os = ex::connect(
+            std::move(as2), callback_receiver<F>{f, set_value_called});
+        ex::start(os);
+        HPX_TEST(set_value_called);
+    }
+
+    // as1 and as2 have been moved so we always expect an exception here
+    {
+        std::atomic<bool> set_value_called{false};
+        try
+        {
+            auto os = ex::connect(
+                // NOLINTNEXTLINE(bugprone-use-after-move)
+                std::move(as1), callback_receiver<F>{f, set_value_called});
+            HPX_TEST(false);
+            ex::start(os);
+        }
+        catch (hpx::exception const& e)
+        {
+            HPX_TEST_EQ(e.get_error(), hpx::bad_function_call);
+        }
+        catch (...)
+        {
+            HPX_TEST(false);
+        }
+        HPX_TEST(!set_value_called);
+    }
+
+    {
+        std::atomic<bool> set_value_called{false};
+        try
+        {
+            auto os = ex::connect(
+                // NOLINTNEXTLINE(bugprone-use-after-move)
+                std::move(as2), callback_receiver<F>{f, set_value_called});
+            HPX_TEST(false);
+            ex::start(os);
+        }
+        catch (hpx::exception const& e)
+        {
+            HPX_TEST_EQ(e.get_error(), hpx::bad_function_call);
+        }
+        catch (...)
+        {
+            HPX_TEST(false);
+        }
+        HPX_TEST(!set_value_called);
+    }
+}
+
+template <template <typename...> typename Sender, typename... Ts, typename F>
+void test_unique_any_sender(F&& f, Ts&&... ts)
+{
+    namespace ex = hpx::execution::experimental;
+
+    Sender<std::decay_t<Ts>...> s{std::forward<Ts>(ts)...};
+
+    ex::unique_any_sender<std::decay_t<Ts>...> as1{std::move(s)};
+    auto as2 = std::move(as1);
+
+    // We expect set_value to be called here
+    {
+        std::atomic<bool> set_value_called = false;
+        auto os = ex::connect(
+            std::move(as2), callback_receiver<F>{f, set_value_called});
+        ex::start(os);
+        HPX_TEST(set_value_called);
+    }
+
+    // as1 has been moved so we always expect an exception here
+    {
+        std::atomic<bool> set_value_called{false};
+        try
+        {
+            auto os = ex::connect(
+                // NOLINTNEXTLINE(bugprone-use-after-move)
+                std::move(as1), callback_receiver<F>{f, set_value_called});
+            HPX_TEST(false);
+            ex::start(os);
+        }
+        catch (hpx::exception const& e)
+        {
+            HPX_TEST_EQ(e.get_error(), hpx::bad_function_call);
+        }
+        catch (...)
+        {
+            HPX_TEST(false);
+        }
+        HPX_TEST(!set_value_called);
+    }
+}
+
+void test_any_sender_set_error()
+{
+    namespace ex = hpx::execution::experimental;
+
+    error_sender s;
+
+    ex::any_sender<> as1{std::move(s)};
+    auto as2 = as1;
+
+    // We should be able to connect the sender multiple times; set_error should
+    // always be called
+    {
+        std::atomic<bool> set_error_called{false};
+        auto os = ex::connect(as1, error_receiver{set_error_called});
+        ex::start(os);
+        HPX_TEST(set_error_called);
+    }
+
+    {
+        std::atomic<bool> set_error_called{false};
+        auto os = ex::connect(std::move(as1), error_receiver{set_error_called});
+        ex::start(os);
+        HPX_TEST(set_error_called);
+    }
+
+    {
+        std::atomic<bool> set_error_called{false};
+        auto os = ex::connect(as2, error_receiver{set_error_called});
+        ex::start(os);
+        HPX_TEST(set_error_called);
+    }
+
+    {
+        std::atomic<bool> set_error_called{false};
+        auto os = ex::connect(std::move(as2), error_receiver{set_error_called});
+        ex::start(os);
+        HPX_TEST(set_error_called);
+    }
+
+    // as1 and as2 have been moved so we always expect an exception here
+    {
+        std::atomic<bool> set_error_called{false};
+        try
+        {
+            auto os =
+                // NOLINTNEXTLINE(bugprone-use-after-move)
+                ex::connect(std::move(as1), error_receiver{set_error_called});
+            HPX_TEST(false);
+            ex::start(os);
+        }
+        catch (hpx::exception const& e)
+        {
+            HPX_TEST_EQ(e.get_error(), hpx::bad_function_call);
+        }
+        catch (...)
+        {
+            HPX_TEST(false);
+        }
+        HPX_TEST(!set_error_called);
+    }
+
+    {
+        std::atomic<bool> set_error_called{false};
+        try
+        {
+            auto os =
+                // NOLINTNEXTLINE(bugprone-use-after-move)
+                ex::connect(std::move(as2), error_receiver{set_error_called});
+            HPX_TEST(false);
+            ex::start(os);
+        }
+        catch (hpx::exception const& e)
+        {
+            HPX_TEST_EQ(e.get_error(), hpx::bad_function_call);
+        }
+        catch (...)
+        {
+            HPX_TEST(false);
+        }
+        HPX_TEST(!set_error_called);
+    }
+}
+
+void test_unique_any_sender_set_error()
+{
+    namespace ex = hpx::execution::experimental;
+
+    error_sender s;
+
+    ex::unique_any_sender<> as1{std::move(s)};
+    auto as2 = std::move(as1);
+
+    // We expect set_error to be called here
+    {
+        std::atomic<bool> set_error_called{false};
+        auto os = ex::connect(std::move(as2), error_receiver{set_error_called});
+        ex::start(os);
+        HPX_TEST(set_error_called);
+    }
+
+    // as1 has been moved so we always expect an exception here
+    {
+        std::atomic<bool> set_error_called{false};
+        try
+        {
+            auto os =
+                // NOLINTNEXTLINE(bugprone-use-after-move)
+                ex::connect(std::move(as1), error_receiver{set_error_called});
+            HPX_TEST(false);
+            ex::start(os);
+        }
+        catch (hpx::exception const& e)
+        {
+            HPX_TEST_EQ(e.get_error(), hpx::bad_function_call);
+        }
+        catch (...)
+        {
+            HPX_TEST(false);
+        }
+        HPX_TEST(!set_error_called);
+    }
+}
+
+int main()
+{
+    // We can only wrap copyable senders in any_sender
+    test_any_sender<sender>([] {});
+    test_any_sender<sender, int>([](int x) { HPX_TEST_EQ(x, 42); }, 42);
+    test_any_sender<sender, int, double>(
+        [](int x, double y) {
+            HPX_TEST_EQ(x, 42);
+            HPX_TEST_EQ(y, 3.14);
+        },
+        42, 3.14);
+
+    test_any_sender<large_sender>([] {});
+    test_any_sender<large_sender, int>([](int x) { HPX_TEST_EQ(x, 42); }, 42);
+    test_any_sender<large_sender, int, double>(
+        [](int x, double y) {
+            HPX_TEST_EQ(x, 42);
+            HPX_TEST_EQ(y, 3.14);
+        },
+        42, 3.14);
+
+    // We can wrap both copyable and non-copyable senders in unique_any_sender
+    test_unique_any_sender<sender>([] {});
+    test_unique_any_sender<sender, int>([](int x) { HPX_TEST_EQ(x, 42); }, 42);
+    test_unique_any_sender<sender, int, double>(
+        [](int x, double y) {
+            HPX_TEST_EQ(x, 42);
+            HPX_TEST_EQ(y, 3.14);
+        },
+        42, 3.14);
+
+    test_unique_any_sender<large_sender>([] {});
+    test_unique_any_sender<large_sender, int>(
+        [](int x) { HPX_TEST_EQ(x, 42); }, 42);
+    test_unique_any_sender<large_sender, int, double>(
+        [](int x, double y) {
+            HPX_TEST_EQ(x, 42);
+            HPX_TEST_EQ(y, 3.14);
+        },
+        42, 3.14);
+
+    test_unique_any_sender<non_copyable_sender>([] {});
+    test_unique_any_sender<non_copyable_sender, int>(
+        [](int x) { HPX_TEST_EQ(x, 42); }, 42);
+    test_unique_any_sender<non_copyable_sender, int, double>(
+        [](int x, double y) {
+            HPX_TEST_EQ(x, 42);
+            HPX_TEST_EQ(y, 3.14);
+        },
+        42, 3.14);
+    test_unique_any_sender<non_copyable_sender, int, double,
+        custom_type_non_copyable>(
+        [](int x, double y, custom_type_non_copyable z) {
+            HPX_TEST_EQ(x, 42);
+            HPX_TEST_EQ(y, 3.14);
+            HPX_TEST_EQ(z.x, 43);
+        },
+        42, 3.14, custom_type_non_copyable(43));
+
+    test_unique_any_sender<large_non_copyable_sender>([] {});
+    test_unique_any_sender<large_non_copyable_sender, int>(
+        [](int x) { HPX_TEST_EQ(x, 42); }, 42);
+    test_unique_any_sender<large_non_copyable_sender, int, double>(
+        [](int x, double y) {
+            HPX_TEST_EQ(x, 42);
+            HPX_TEST_EQ(y, 3.14);
+        },
+        42, 3.14);
+    test_unique_any_sender<large_non_copyable_sender, int, double,
+        custom_type_non_copyable>(
+        [](int x, double y, custom_type_non_copyable z) {
+            HPX_TEST_EQ(x, 42);
+            HPX_TEST_EQ(y, 3.14);
+            HPX_TEST_EQ(z.x, 43);
+        },
+        42, 3.14, custom_type_non_copyable(43));
+
+    // Failure paths
+    test_any_sender_set_error();
+    test_unique_any_sender_set_error();
+
+    return hpx::util::report_errors();
+}


### PR DESCRIPTION
Adds type-erased senders, `any_sender` and `unique_any_sender` (of which the latter is move-only). I'd appreciate feedback on this as it's the first time I do any serious type-erasing. The type-erasure mechanisms don't have to stay this way if the techniques used elsewhere are preferable.

The senders are currently templated on the value types that the wrapped senders send, and only on that. The wrapped senders must send only one set of values (i.e. no multiple variants in `value_types`). The senders are currently not templated on the error type at all, and assume `std::exception_ptr`. This could easily be changed if needed.

The buffers used for SBO are quite big right now and may be self-defeating. I guess experience will show what are good sizes for the buffers. It can of course also become a template parameter but I'd prefer not putting it there unless there's a strong need for it.

There are still a few TODOs in the code, but the overall structure is there, and the tests pass.