### PR TITLE
Add sender overloads for remaining algorithms

### DIFF
--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/exclusive_scan.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/exclusive_scan.hpp
@@ -299,6 +299,7 @@ namespace hpx {
 #include <hpx/parallel/algorithms/detail/distance.hpp>
 #include <hpx/parallel/algorithms/inclusive_scan.hpp>
 #include <hpx/parallel/util/detail/algorithm_result.hpp>
+#include <hpx/parallel/util/detail/sender_util.hpp>
 #include <hpx/parallel/util/loop.hpp>
 #include <hpx/parallel/util/partitioner.hpp>
 #include <hpx/parallel/util/projection_identity.hpp>
@@ -539,7 +540,7 @@ namespace hpx {
     ///////////////////////////////////////////////////////////////////////////
     // DPO for hpx::exclusive_scan
     HPX_INLINE_CONSTEXPR_VARIABLE struct exclusive_scan_t final
-      : hpx::functional::tag_fallback<exclusive_scan_t>
+      : hpx::detail::tag_parallel_algorithm<exclusive_scan_t>
     {
         // clang-format off
         template <typename InIter, typename OutIter, typename T,

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/inclusive_scan.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/inclusive_scan.hpp
@@ -433,6 +433,7 @@ namespace hpx {
 #include <hpx/parallel/algorithms/detail/dispatch.hpp>
 #include <hpx/parallel/algorithms/detail/distance.hpp>
 #include <hpx/parallel/util/detail/algorithm_result.hpp>
+#include <hpx/parallel/util/detail/sender_util.hpp>
 #include <hpx/parallel/util/loop.hpp>
 #include <hpx/parallel/util/partitioner.hpp>
 #include <hpx/parallel/util/projection_identity.hpp>
@@ -754,7 +755,7 @@ namespace hpx {
     ///////////////////////////////////////////////////////////////////////////
     // DPO for hpx::inclusive_scan
     HPX_INLINE_CONSTEXPR_VARIABLE struct inclusive_scan_t final
-      : hpx::functional::tag_fallback<inclusive_scan_t>
+      : hpx::detail::tag_parallel_algorithm<inclusive_scan_t>
     {
         // clang-format off
         template <typename InIter, typename OutIter,

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/sort.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/sort.hpp
@@ -245,6 +245,7 @@ namespace hpx {
 #include <hpx/parallel/algorithms/detail/is_sorted.hpp>
 #include <hpx/parallel/util/compare_projected.hpp>
 #include <hpx/parallel/util/detail/algorithm_result.hpp>
+#include <hpx/parallel/util/detail/sender_util.hpp>
 #include <hpx/parallel/util/detail/chunk_size.hpp>
 #include <hpx/parallel/util/projection_identity.hpp>
 
@@ -570,7 +571,7 @@ namespace hpx {
     ///////////////////////////////////////////////////////////////////////////
     // DPO for hpx::sort
     HPX_INLINE_CONSTEXPR_VARIABLE struct sort_t final
-      : hpx::functional::tag_fallback<sort_t>
+      : hpx::detail::tag_parallel_algorithm<sort_t>
     {
         // clang-format off
         template <typename RandomIt,

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/stable_sort.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/stable_sort.hpp
@@ -245,6 +245,7 @@ namespace hpx {
 #include <hpx/parallel/algorithms/detail/spin_sort.hpp>
 #include <hpx/parallel/util/compare_projected.hpp>
 #include <hpx/parallel/util/detail/algorithm_result.hpp>
+#include <hpx/parallel/util/detail/sender_util.hpp>
 #include <hpx/parallel/util/detail/chunk_size.hpp>
 #include <hpx/parallel/util/projection_identity.hpp>
 
@@ -389,7 +390,7 @@ namespace hpx {
     ///////////////////////////////////////////////////////////////////////////
     // DPO for hpx::stable_sort
     HPX_INLINE_CONSTEXPR_VARIABLE struct stable_sort_t final
-      : hpx::functional::tag_fallback<stable_sort_t>
+      : hpx::detail::tag_parallel_algorithm<stable_sort_t>
     {
         // clang-format off
         template <typename RandomIt,

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/swap_ranges.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/swap_ranges.hpp
@@ -114,6 +114,7 @@ namespace hpx {
 #include <hpx/parallel/algorithms/detail/distance.hpp>
 #include <hpx/parallel/algorithms/for_each.hpp>
 #include <hpx/parallel/util/detail/algorithm_result.hpp>
+#include <hpx/parallel/util/detail/sender_util.hpp>
 #include <hpx/parallel/util/projection_identity.hpp>
 #include <hpx/parallel/util/result_types.hpp>
 #include <hpx/parallel/util/zip_iterator.hpp>
@@ -250,7 +251,7 @@ namespace hpx {
     ///////////////////////////////////////////////////////////////////////////
     // DPO for hpx::swap_ranges
     HPX_INLINE_CONSTEXPR_VARIABLE struct swap_ranges_t final
-      : hpx::functional::tag_fallback<swap_ranges_t>
+      : hpx::detail::tag_parallel_algorithm<swap_ranges_t>
     {
         // clang-format off
         template <typename FwdIter1, typename FwdIter2,

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/transform_exclusive_scan.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/transform_exclusive_scan.hpp
@@ -228,6 +228,7 @@ namespace hpx {
 #include <hpx/parallel/algorithms/detail/distance.hpp>
 #include <hpx/parallel/algorithms/transform_inclusive_scan.hpp>
 #include <hpx/parallel/util/detail/algorithm_result.hpp>
+#include <hpx/parallel/util/detail/sender_util.hpp>
 #include <hpx/parallel/util/loop.hpp>
 #include <hpx/parallel/util/partitioner.hpp>
 #include <hpx/parallel/util/scan_partitioner.hpp>
@@ -430,7 +431,7 @@ namespace hpx {
     ///////////////////////////////////////////////////////////////////////////
     // DPO for hpx::transform_exclusive_scan
     HPX_INLINE_CONSTEXPR_VARIABLE struct transform_exclusive_scan_t final
-      : hpx::functional::tag_fallback<transform_exclusive_scan_t>
+      : hpx::detail::tag_parallel_algorithm<transform_exclusive_scan_t>
     {
         // clang-format off
         template <typename InIter, typename OutIter, typename T,

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/transform_inclusive_scan.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/transform_inclusive_scan.hpp
@@ -414,6 +414,7 @@ namespace hpx {
 #include <hpx/parallel/algorithms/detail/distance.hpp>
 #include <hpx/parallel/algorithms/inclusive_scan.hpp>
 #include <hpx/parallel/util/detail/algorithm_result.hpp>
+#include <hpx/parallel/util/detail/sender_util.hpp>
 #include <hpx/parallel/util/loop.hpp>
 #include <hpx/parallel/util/partitioner.hpp>
 #include <hpx/parallel/util/scan_partitioner.hpp>
@@ -709,7 +710,7 @@ namespace hpx {
     ///////////////////////////////////////////////////////////////////////////
     // DPO for hpx::transform_inclusive_scan
     HPX_INLINE_CONSTEXPR_VARIABLE struct transform_inclusive_scan_t final
-      : hpx::functional::tag_fallback<transform_inclusive_scan_t>
+      : hpx::detail::tag_parallel_algorithm<transform_inclusive_scan_t>
     {
         // clang-format off
         template <typename InIter, typename OutIter, typename BinOp,

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/unique.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/unique.hpp
@@ -475,6 +475,7 @@ namespace hpx {
 #include <hpx/parallel/tagspec.hpp>
 #include <hpx/parallel/util/compare_projected.hpp>
 #include <hpx/parallel/util/detail/algorithm_result.hpp>
+#include <hpx/parallel/util/detail/sender_util.hpp>
 #include <hpx/parallel/util/foreach_partitioner.hpp>
 #include <hpx/parallel/util/loop.hpp>
 #include <hpx/parallel/util/projection_identity.hpp>
@@ -968,7 +969,7 @@ namespace hpx {
     ///////////////////////////////////////////////////////////////////////////
     // DPO for hpx::unique
     HPX_INLINE_CONSTEXPR_VARIABLE struct unique_t final
-      : hpx::functional::tag_fallback<unique_t>
+      : hpx::detail::tag_parallel_algorithm<unique_t>
     {
         // clang-format off
         template <typename FwdIter,
@@ -1024,7 +1025,7 @@ namespace hpx {
     ///////////////////////////////////////////////////////////////////////////
     // DPO for hpx::unique_copy
     HPX_INLINE_CONSTEXPR_VARIABLE struct unique_copy_t final
-      : hpx::functional::tag_fallback<unique_copy_t>
+      : hpx::detail::tag_parallel_algorithm<unique_copy_t>
     {
         // clang-format off
         template <typename InIter, typename OutIter,

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/exclusive_scan.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/exclusive_scan.hpp
@@ -577,6 +577,7 @@ namespace hpx { namespace ranges {
 #include <hpx/iterator_support/traits/is_range.hpp>
 #include <hpx/parallel/algorithms/exclusive_scan.hpp>
 #include <hpx/parallel/util/detail/algorithm_result.hpp>
+#include <hpx/parallel/util/detail/sender_util.hpp>
 #include <hpx/parallel/util/projection_identity.hpp>
 
 #include <algorithm>
@@ -592,7 +593,7 @@ namespace hpx { namespace ranges {
     using exclusive_scan_result = parallel::util::in_out_result<I, O>;
 
     HPX_INLINE_CONSTEXPR_VARIABLE struct exclusive_scan_t final
-      : hpx::functional::tag_fallback<exclusive_scan_t>
+      : hpx::detail::tag_parallel_algorithm<exclusive_scan_t>
     {
     private:
         // clang-format off

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/inclusive_scan.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/inclusive_scan.hpp
@@ -863,6 +863,7 @@ namespace hpx { namespace ranges {
 #include <hpx/iterator_support/traits/is_range.hpp>
 #include <hpx/parallel/algorithms/inclusive_scan.hpp>
 #include <hpx/parallel/util/detail/algorithm_result.hpp>
+#include <hpx/parallel/util/detail/sender_util.hpp>
 #include <hpx/parallel/util/projection_identity.hpp>
 
 #include <algorithm>
@@ -878,7 +879,7 @@ namespace hpx { namespace ranges {
     using inclusive_scan_result = parallel::util::in_out_result<I, O>;
 
     HPX_INLINE_CONSTEXPR_VARIABLE struct inclusive_scan_t final
-      : hpx::functional::tag_fallback<inclusive_scan_t>
+      : hpx::detail::tag_parallel_algorithm<inclusive_scan_t>
     {
     private:
         // clang-format off

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/sort.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/sort.hpp
@@ -277,6 +277,7 @@ namespace hpx { namespace ranges {
 #include <hpx/algorithms/traits/projected_range.hpp>
 #include <hpx/parallel/algorithms/sort.hpp>
 #include <hpx/parallel/util/projection_identity.hpp>
+#include <hpx/parallel/util/detail/sender_util.hpp>
 
 #include <type_traits>
 #include <utility>
@@ -320,7 +321,7 @@ namespace hpx { namespace ranges {
     ///////////////////////////////////////////////////////////////////////////
     // DPO for hpx::ranges::sort
     HPX_INLINE_CONSTEXPR_VARIABLE struct sort_t final
-      : hpx::functional::tag_fallback<sort_t>
+      : hpx::detail::tag_parallel_algorithm<sort_t>
     {
     private:
         // clang-format off

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/stable_sort.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/stable_sort.hpp
@@ -277,6 +277,7 @@ namespace hpx { namespace ranges {
 #include <hpx/algorithms/traits/projected_range.hpp>
 #include <hpx/parallel/algorithms/stable_sort.hpp>
 #include <hpx/parallel/util/projection_identity.hpp>
+#include <hpx/parallel/util/detail/sender_util.hpp>
 
 #include <type_traits>
 #include <utility>
@@ -327,7 +328,7 @@ namespace hpx { namespace ranges {
     ///////////////////////////////////////////////////////////////////////////
     // DPO for hpx::ranges::stable_sort
     HPX_INLINE_CONSTEXPR_VARIABLE struct stable_sort_t final
-      : hpx::functional::tag_fallback<stable_sort_t>
+      : hpx::detail::tag_parallel_algorithm<stable_sort_t>
     {
     private:
         // clang-format off

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/swap_ranges.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/swap_ranges.hpp
@@ -220,6 +220,7 @@ namespace hpx { namespace ranges {
 #include <hpx/algorithms/traits/projected_range.hpp>
 #include <hpx/parallel/algorithms/swap_ranges.hpp>
 #include <hpx/parallel/util/projection_identity.hpp>
+#include <hpx/parallel/util/detail/sender_util.hpp>
 
 #include <type_traits>
 #include <utility>
@@ -233,7 +234,7 @@ namespace hpx { namespace ranges {
     ///////////////////////////////////////////////////////////////////////////
     // DPO for hpx::ranges::swap_ranges
     HPX_INLINE_CONSTEXPR_VARIABLE struct swap_ranges_t final
-      : hpx::functional::tag_fallback<swap_ranges_t>
+      : hpx::detail::tag_parallel_algorithm<swap_ranges_t>
     {
     private:
         // clang-format off

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/transform_exclusive_scan.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/transform_exclusive_scan.hpp
@@ -424,6 +424,7 @@ namespace hpx { namespace ranges {
 #include <hpx/iterator_support/traits/is_iterator.hpp>
 #include <hpx/parallel/algorithms/transform_exclusive_scan.hpp>
 #include <hpx/parallel/util/detail/algorithm_result.hpp>
+#include <hpx/parallel/util/detail/sender_util.hpp>
 #include <hpx/parallel/util/projection_identity.hpp>
 
 #include <algorithm>
@@ -439,7 +440,7 @@ namespace hpx { namespace ranges {
     using transform_exclusive_scan_result = parallel::util::in_out_result<I, O>;
 
     HPX_INLINE_CONSTEXPR_VARIABLE struct transform_exclusive_scan_t final
-      : hpx::functional::tag_fallback<transform_exclusive_scan_t>
+      : hpx::detail::tag_parallel_algorithm<transform_exclusive_scan_t>
     {
     private:
         // clang-format off

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/transform_inclusive_scan.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/transform_inclusive_scan.hpp
@@ -810,6 +810,7 @@ namespace hpx { namespace ranges {
 #include <hpx/iterator_support/traits/is_iterator.hpp>
 #include <hpx/parallel/algorithms/transform_inclusive_scan.hpp>
 #include <hpx/parallel/util/detail/algorithm_result.hpp>
+#include <hpx/parallel/util/detail/sender_util.hpp>
 #include <hpx/parallel/util/projection_identity.hpp>
 
 #include <algorithm>
@@ -825,7 +826,7 @@ namespace hpx { namespace ranges {
     using transform_inclusive_scan_result = parallel::util::in_out_result<I, O>;
 
     HPX_INLINE_CONSTEXPR_VARIABLE struct transform_inclusive_scan_t final
-      : hpx::functional::tag_fallback<transform_inclusive_scan_t>
+      : hpx::detail::tag_parallel_algorithm<transform_inclusive_scan_t>
     {
     private:
         // clang-format off

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/uninitialized_copy.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/uninitialized_copy.hpp
@@ -315,6 +315,7 @@ namespace hpx { namespace ranges {
 #include <hpx/iterator_support/traits/is_iterator.hpp>
 #include <hpx/parallel/algorithms/uninitialized_copy.hpp>
 #include <hpx/parallel/util/detail/algorithm_result.hpp>
+#include <hpx/parallel/util/detail/sender_util.hpp>
 #include <hpx/parallel/util/projection_identity.hpp>
 
 #include <algorithm>
@@ -326,7 +327,7 @@ namespace hpx { namespace ranges {
 
 namespace hpx { namespace ranges {
     HPX_INLINE_CONSTEXPR_VARIABLE struct uninitialized_copy_t final
-      : hpx::functional::tag_fallback<uninitialized_copy_t>
+      : hpx::detail::tag_parallel_algorithm<uninitialized_copy_t>
     {
     private:
         // clang-format off
@@ -447,7 +448,7 @@ namespace hpx { namespace ranges {
     } uninitialized_copy{};
 
     HPX_INLINE_CONSTEXPR_VARIABLE struct uninitialized_copy_n_t final
-      : hpx::functional::tag_fallback<uninitialized_copy_n_t>
+      : hpx::detail::tag_parallel_algorithm<uninitialized_copy_n_t>
     {
     private:
         // clang-format off

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/uninitialized_default_construct.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/uninitialized_default_construct.hpp
@@ -263,6 +263,7 @@ namespace hpx { namespace ranges {
 #include <hpx/iterator_support/traits/is_iterator.hpp>
 #include <hpx/parallel/algorithms/uninitialized_default_construct.hpp>
 #include <hpx/parallel/util/detail/algorithm_result.hpp>
+#include <hpx/parallel/util/detail/sender_util.hpp>
 #include <hpx/parallel/util/projection_identity.hpp>
 
 #include <algorithm>
@@ -274,7 +275,7 @@ namespace hpx { namespace ranges {
 
 namespace hpx { namespace ranges {
     HPX_INLINE_CONSTEXPR_VARIABLE struct uninitialized_default_construct_t final
-      : hpx::functional::tag_fallback<uninitialized_default_construct_t>
+      : hpx::detail::tag_parallel_algorithm<uninitialized_default_construct_t>
     {
     private:
         // clang-format off
@@ -367,7 +368,7 @@ namespace hpx { namespace ranges {
 
     HPX_INLINE_CONSTEXPR_VARIABLE struct uninitialized_default_construct_n_t
         final
-      : hpx::functional::tag_fallback<uninitialized_default_construct_n_t>
+      : hpx::detail::tag_parallel_algorithm<uninitialized_default_construct_n_t>
     {
     private:
         // clang-format off

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/uninitialized_fill.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/uninitialized_fill.hpp
@@ -262,6 +262,7 @@ namespace hpx { namespace ranges {
 #include <hpx/iterator_support/traits/is_iterator.hpp>
 #include <hpx/parallel/algorithms/uninitialized_fill.hpp>
 #include <hpx/parallel/util/detail/algorithm_result.hpp>
+#include <hpx/parallel/util/detail/sender_util.hpp>
 #include <hpx/parallel/util/projection_identity.hpp>
 
 #include <algorithm>
@@ -273,7 +274,7 @@ namespace hpx { namespace ranges {
 
 namespace hpx { namespace ranges {
     HPX_INLINE_CONSTEXPR_VARIABLE struct uninitialized_fill_t final
-      : hpx::functional::tag_fallback<uninitialized_fill_t>
+      : hpx::detail::tag_parallel_algorithm<uninitialized_fill_t>
     {
     private:
         // clang-format off
@@ -364,7 +365,7 @@ namespace hpx { namespace ranges {
     } uninitialized_fill{};
 
     HPX_INLINE_CONSTEXPR_VARIABLE struct uninitialized_fill_n_t final
-      : hpx::functional::tag_fallback<uninitialized_fill_n_t>
+      : hpx::detail::tag_parallel_algorithm<uninitialized_fill_n_t>
     {
     private:
         // clang-format off

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/uninitialized_move.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/uninitialized_move.hpp
@@ -323,6 +323,7 @@ namespace hpx { namespace ranges {
 #include <hpx/iterator_support/traits/is_iterator.hpp>
 #include <hpx/parallel/algorithms/uninitialized_move.hpp>
 #include <hpx/parallel/util/detail/algorithm_result.hpp>
+#include <hpx/parallel/util/detail/sender_util.hpp>
 #include <hpx/parallel/util/projection_identity.hpp>
 
 #include <algorithm>
@@ -334,7 +335,7 @@ namespace hpx { namespace ranges {
 
 namespace hpx { namespace ranges {
     HPX_INLINE_CONSTEXPR_VARIABLE struct uninitialized_move_t final
-      : hpx::functional::tag_fallback<uninitialized_move_t>
+      : hpx::detail::tag_parallel_algorithm<uninitialized_move_t>
     {
     private:
         // clang-format off
@@ -455,7 +456,7 @@ namespace hpx { namespace ranges {
     } uninitialized_move{};
 
     HPX_INLINE_CONSTEXPR_VARIABLE struct uninitialized_move_n_t final
-      : hpx::functional::tag_fallback<uninitialized_move_n_t>
+      : hpx::detail::tag_parallel_algorithm<uninitialized_move_n_t>
     {
     private:
         // clang-format off

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/uninitialized_value_construct.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/uninitialized_value_construct.hpp
@@ -263,6 +263,7 @@ namespace hpx { namespace ranges {
 #include <hpx/iterator_support/traits/is_iterator.hpp>
 #include <hpx/parallel/algorithms/uninitialized_value_construct.hpp>
 #include <hpx/parallel/util/detail/algorithm_result.hpp>
+#include <hpx/parallel/util/detail/sender_util.hpp>
 #include <hpx/parallel/util/projection_identity.hpp>
 
 #include <algorithm>
@@ -274,7 +275,7 @@ namespace hpx { namespace ranges {
 
 namespace hpx { namespace ranges {
     HPX_INLINE_CONSTEXPR_VARIABLE struct uninitialized_value_construct_t final
-      : hpx::functional::tag_fallback<uninitialized_value_construct_t>
+      : hpx::detail::tag_parallel_algorithm<uninitialized_value_construct_t>
     {
     private:
         // clang-format off
@@ -366,7 +367,7 @@ namespace hpx { namespace ranges {
     } uninitialized_value_construct{};
 
     HPX_INLINE_CONSTEXPR_VARIABLE struct uninitialized_value_construct_n_t final
-      : hpx::functional::tag_fallback<uninitialized_value_construct_n_t>
+      : hpx::detail::tag_parallel_algorithm<uninitialized_value_construct_n_t>
     {
     private:
         // clang-format off

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/unique.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/unique.hpp
@@ -599,6 +599,7 @@ namespace hpx { namespace ranges {
 #include <hpx/algorithms/traits/projected.hpp>
 #include <hpx/algorithms/traits/projected_range.hpp>
 #include <hpx/parallel/algorithms/unique.hpp>
+#include <hpx/parallel/util/detail/sender_util.hpp>
 
 #include <type_traits>
 #include <utility>
@@ -678,7 +679,7 @@ namespace hpx { namespace ranges {
     ///////////////////////////////////////////////////////////////////////////
     // DPO for hpx::ranges::unique
     HPX_INLINE_CONSTEXPR_VARIABLE struct unique_t final
-      : hpx::functional::tag_fallback<unique_t>
+      : hpx::detail::tag_parallel_algorithm<unique_t>
     {
     private:
         // clang-format off
@@ -817,7 +818,7 @@ namespace hpx { namespace ranges {
     ///////////////////////////////////////////////////////////////////////////
     // DPO for hpx::ranges::unique_copy
     HPX_INLINE_CONSTEXPR_VARIABLE struct unique_copy_t final
-      : hpx::functional::tag_fallback<unique_copy_t>
+      : hpx::detail::tag_parallel_algorithm<unique_copy_t>
     {
     private:
         // clang-format off


### PR DESCRIPTION
Update the remaining algorithms to change the tag_fallback base classes to tag_parallel_algorithm. [PR #5329](https://github.com/STEllAR-GROUP/hpx/pull/5329#issuecomment-900733077).