### PR TITLE
Set local thread/pool number in local/static_queue_scheduler

### DIFF
--- a/libs/core/schedulers/include/hpx/schedulers/local_queue_scheduler.hpp
+++ b/libs/core/schedulers/include/hpx/schedulers/local_queue_scheduler.hpp
@@ -8,7 +8,6 @@
 #pragma once
 
 #include <hpx/config.hpp>
-
 #include <hpx/affinity/affinity_data.hpp>
 #include <hpx/assert.hpp>
 #include <hpx/functional/function.hpp>
@@ -19,6 +18,7 @@
 #include <hpx/schedulers/thread_queue.hpp>
 #include <hpx/threading_base/scheduler_base.hpp>
 #include <hpx/threading_base/thread_data.hpp>
+#include <hpx/threading_base/thread_num_tss.hpp>
 #include <hpx/threading_base/thread_queue_init_parameters.hpp>
 #include <hpx/topology/topology.hpp>
 
@@ -870,6 +870,10 @@ namespace hpx { namespace threads { namespace policies {
         ///////////////////////////////////////////////////////////////////////
         void on_start_thread(std::size_t num_thread) override
         {
+            hpx::threads::detail::set_local_thread_num_tss(num_thread);
+            hpx::threads::detail::set_thread_pool_num_tss(
+                parent_pool_->get_pool_id().index());
+
             if (nullptr == queues_[num_thread])
             {
                 queues_[num_thread] =


### PR DESCRIPTION
We were setting it in the `local/static_priority_queue_scheduler` and `shared_priority_scheduler`, but not the non-priority schedulers. Allows the use of e.g. the `fork_join_scheduler`.