### PR TITLE
Update benchmarks and add support for scheduler_executor

### DIFF
--- a/libs/parallelism/executors/include/hpx/executors/scheduler_executor.hpp
+++ b/libs/parallelism/executors/include/hpx/executors/scheduler_executor.hpp
@@ -68,6 +68,8 @@ namespace hpx { namespace execution { namespace experimental {
     template <typename BaseScheduler>
     struct scheduler_executor
     {
+        constexpr scheduler_executor() = default;
+
         template <typename Scheduler,
             typename Enable = std::enable_if_t<
                 hpx::execution::experimental::is_scheduler_v<Scheduler>>>
@@ -75,6 +77,12 @@ namespace hpx { namespace execution { namespace experimental {
           : sched_(std::forward<Scheduler>(sched))
         {
         }
+
+        constexpr scheduler_executor(scheduler_executor&&) = default;
+        constexpr scheduler_executor& operator=(scheduler_executor&&) = default;
+        constexpr scheduler_executor(scheduler_executor const&) = default;
+        constexpr scheduler_executor& operator=(
+            scheduler_executor const&) = default;
 
         /// \cond NOINTERNAL
         constexpr bool operator==(scheduler_executor const& rhs) const noexcept

--- a/libs/parallelism/executors/include/hpx/executors/scheduler_executor.hpp
+++ b/libs/parallelism/executors/include/hpx/executors/scheduler_executor.hpp
@@ -193,8 +193,9 @@ namespace hpx { namespace execution { namespace experimental {
                                     S const& shape, Ts&... ts) {
                     hpx::detail::try_catch_exception_ptr(
                         [&]() mutable {
-                            promises[i].set_value(HPX_INVOKE(
-                                f, hpx::util::begin(shape)[i], ts...));
+                            auto it = hpx::util::begin(shape);
+                            std::advance(it, i);
+                            promises[i].set_value(HPX_INVOKE(f, *it, ts...));
                         },
                         [&](std::exception_ptr&& ep) {
                             promises[i].set_exception(std::move(ep));

--- a/tests/performance/local/future_overhead.cpp
+++ b/tests/performance/local/future_overhead.cpp
@@ -91,6 +91,12 @@ const char* exec_name(
     return "parallel_executor_aggregated";
 }
 
+const char* exec_name(hpx::execution::experimental::scheduler_executor<
+    hpx::execution::experimental::thread_pool_scheduler> const&)
+{
+    return "scheduler_executor<thread_pool_scheduler>";
+}
+
 ///////////////////////////////////////////////////////////////////////////////
 // we use globals here to prevent the delay from being optimized away
 double global_scratch = 0;
@@ -509,6 +515,9 @@ int hpx_main(variables_map& vm)
         hpx::execution::parallel_executor par_nostack(
             hpx::threads::thread_priority::default_,
             hpx::threads::thread_stacksize::nostack);
+        hpx::execution::experimental::scheduler_executor<
+            hpx::execution::experimental::thread_pool_scheduler>
+            sched_exec_tps;
 
         for (int i = 0; i < repetitions; i++)
         {
@@ -526,6 +535,7 @@ int hpx_main(variables_map& vm)
                 measure_function_futures_sliding_semaphore(count, csv, par);
                 measure_function_futures_for_loop(count, csv, par);
                 measure_function_futures_for_loop(count, csv, par_agg);
+                measure_function_futures_for_loop(count, csv, sched_exec_tps);
                 measure_function_futures_for_loop(
                     count, csv, par_nostack, "parallel_executor_nostack");
                 measure_function_futures_register_work(count, csv);

--- a/tests/performance/local/stream.cpp
+++ b/tests/performance/local/stream.cpp
@@ -106,8 +106,6 @@ void check_results(std::size_t iterations, Vector const& a_res,
     aj = 1.0;
     bj = 2.0;
     cj = 0.0;
-    /* a[] is modified during timing check */
-    aj = 2.0E0 * aj;
     /* now execute timing loop */
     scalar = 3.0;
     for (std::size_t k = 0; k < iterations; k++)
@@ -323,8 +321,9 @@ struct triad_step
 
 ///////////////////////////////////////////////////////////////////////////////
 template <typename Allocator, typename Policy>
-std::vector<std::vector<double>> run_benchmark(std::size_t iterations,
-    std::size_t size, Allocator&& alloc, Policy&& policy)
+std::vector<std::vector<double>> run_benchmark(std::size_t warmup_iterations,
+    std::size_t iterations, std::size_t size, Allocator&& alloc,
+    Policy&& policy)
 {
     // Allocate our data
     using vector_type = hpx::compute::vector<STREAM_TYPE, Allocator>;
@@ -387,10 +386,35 @@ std::vector<std::vector<double>> run_benchmark(std::size_t iterations,
     }
 
     ///////////////////////////////////////////////////////////////////////////
-    // Main Loop
-    std::vector<std::vector<double>> timing(4, std::vector<double>(iterations));
-
+    // Warmup loop
     double scalar = 3.0;
+    for (std::size_t iteration = 0; iteration != warmup_iterations; ++iteration)
+    {
+        // Copy
+        hpx::copy(policy, a.begin(), a.end(), c.begin());
+
+        // Scale
+        hpx::transform(policy, c.begin(), c.end(), b.begin(),
+            multiply_step<STREAM_TYPE>(scalar));
+
+        // Add
+        hpx::ranges::transform(policy, a.begin(), a.end(), b.begin(), b.end(),
+            c.begin(), add_step<STREAM_TYPE>());
+
+        // Triad
+        hpx::ranges::transform(policy, b.begin(), b.end(), c.begin(), c.end(),
+            a.begin(), triad_step<STREAM_TYPE>(scalar));
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    // Reinitialize arrays (if needed)
+    hpx::fill(policy, a.begin(), a.end(), 1.0);
+    hpx::fill(policy, b.begin(), b.end(), 2.0);
+    hpx::fill(policy, c.begin(), c.end(), 0.0);
+
+    ///////////////////////////////////////////////////////////////////////////
+    // Main timing loop
+    std::vector<std::vector<double>> timing(4, std::vector<double>(iterations));
     for (std::size_t iteration = 0; iteration != iterations; ++iteration)
     {
         // Copy
@@ -436,6 +460,7 @@ int hpx_main(hpx::program_options::variables_map& vm)
     std::size_t vector_size = vm["vector_size"].as<std::size_t>();
     std::size_t offset = vm["offset"].as<std::size_t>();
     std::size_t iterations = vm["iterations"].as<std::size_t>();
+    std::size_t warmup_iterations = vm["warmup_iterations"].as<std::size_t>();
     std::size_t chunk_size = vm["chunk_size"].as<std::size_t>();
     std::size_t executor = vm["executor"].as<std::size_t>();
     csv = vm.count("csv") > 0;
@@ -444,6 +469,18 @@ int hpx_main(hpx::program_options::variables_map& vm)
     HPX_UNUSED(chunk_size);
 
     std::string chunker = vm["chunker"].as<std::string>();
+
+    if (vector_size < 1)
+    {
+        HPX_THROW_EXCEPTION(hpx::commandline_option_error, "hpx_main",
+            "Invalid vector size, must be at least 1");
+    }
+
+    if (iterations < 1)
+    {
+        HPX_THROW_EXCEPTION(hpx::commandline_option_error, "hpx_main",
+            "Invalid number of iterations given, must be at least 1");
+    }
 
     // clang-format off
     if (!csv)
@@ -500,8 +537,8 @@ int hpx_main(hpx::program_options::variables_map& vm)
         auto policy = hpx::execution::par.on(exec);
 
         // perform benchmark
-        timing = run_benchmark<>(
-            iterations, vector_size, std::move(alloc), std::move(policy));
+        timing = run_benchmark<>(warmup_iterations, iterations, vector_size,
+            std::move(alloc), std::move(policy));
         //iterations, vector_size, std::move(target));
     }
     else
@@ -510,7 +547,7 @@ int hpx_main(hpx::program_options::variables_map& vm)
         if (executor == 0)
         {
             // Default parallel policy with serial allocator.
-            timing = run_benchmark<>(iterations, vector_size,
+            timing = run_benchmark<>(warmup_iterations, iterations, vector_size,
                 std::allocator<STREAM_TYPE>{}, hpx::execution::par);
         }
         else if (executor == 1)
@@ -525,8 +562,8 @@ int hpx_main(hpx::program_options::variables_map& vm)
             executor_type exec(numa_nodes);
             auto policy = hpx::execution::par.on(exec);
 
-            timing = run_benchmark<>(
-                iterations, vector_size, std::move(alloc), std::move(policy));
+            timing = run_benchmark<>(warmup_iterations, iterations, vector_size,
+                std::move(alloc), std::move(policy));
         }
         else if (executor == 2)
         {
@@ -536,8 +573,8 @@ int hpx_main(hpx::program_options::variables_map& vm)
                 decltype(policy)>
                 alloc(policy);
 
-            timing = run_benchmark<>(
-                iterations, vector_size, std::move(alloc), std::move(policy));
+            timing = run_benchmark<>(warmup_iterations, iterations, vector_size,
+                std::move(alloc), std::move(policy));
         }
         else if (executor == 3)
         {
@@ -551,8 +588,8 @@ int hpx_main(hpx::program_options::variables_map& vm)
                 decltype(policy)>
                 alloc(policy);
 
-            timing = run_benchmark<>(
-                iterations, vector_size, std::move(alloc), std::move(policy));
+            timing = run_benchmark<>(warmup_iterations, iterations, vector_size,
+                std::move(alloc), std::move(policy));
         }
         else if (executor == 4)
         {
@@ -567,8 +604,8 @@ int hpx_main(hpx::program_options::variables_map& vm)
                 decltype(policy)>
                 alloc(policy);
 
-            timing = run_benchmark<>(
-                iterations, vector_size, std::move(alloc), std::move(policy));
+            timing = run_benchmark<>(warmup_iterations, iterations, vector_size,
+                std::move(alloc), std::move(policy));
         }
         else
         {
@@ -595,11 +632,18 @@ int hpx_main(hpx::program_options::variables_map& vm)
         3 * sizeof(STREAM_TYPE) * static_cast<double>(vector_size),
         3 * sizeof(STREAM_TYPE) * static_cast<double>(vector_size)};
 
-    // Note: skip first iteration
     std::vector<double> avgtime(num_stream_tests, 0.0);
     std::vector<double> mintime(
         num_stream_tests, (std::numeric_limits<double>::max)());
     std::vector<double> maxtime(num_stream_tests, 0.0);
+
+    for (std::size_t j = 0; j < num_stream_tests; j++)
+    {
+        avgtime[j] = timing[j][0];
+        mintime[j] = timing[j][0];
+        maxtime[j] = timing[j][0];
+    }
+
     for (std::size_t iteration = 1; iteration != iterations; ++iteration)
     {
         for (std::size_t j = 0; j < num_stream_tests; j++)
@@ -634,7 +678,7 @@ int hpx_main(hpx::program_options::variables_map& vm)
 
     for (std::size_t j = 0; j < num_stream_tests; j++)
     {
-        avgtime[j] = avgtime[j] / (double) (iterations - 1);
+        avgtime[j] = avgtime[j] / (double) (iterations);
 
         if (csv)
         {
@@ -686,6 +730,9 @@ int main(int argc, char* argv[])
         (   "iterations",
             hpx::program_options::value<std::size_t>()->default_value(10),
             "number of iterations to repeat each test. (default: 10)")
+        (   "warmup_iterations",
+            hpx::program_options::value<std::size_t>()->default_value(1),
+            "number of warmup iterations to perform before timing. (default: 1)")
         (   "chunker",
             hpx::program_options::value<std::string>()->default_value("default"),
             "Which chunker to use for the parallel algorithms. "


### PR DESCRIPTION
- Add support for `scheduler_executor<thread_pool_scheduler>` to the stream and future overhead benchmarks.
- Add default constructor (and copy/move constructors/assignment operators) to `scheduler_executor`.
- Add support for setting warmup iterations in stream benchmark.
- Allow using `scheduler_executor` with forward iterators.