### PR TITLE
Eagerly initialize a configurable number of threads on scheduler/thread queue init

### DIFF
--- a/libs/core/config/include/hpx/config.hpp
+++ b/libs/core/config/include/hpx/config.hpp
@@ -444,6 +444,13 @@
 #endif
 
 ///////////////////////////////////////////////////////////////////////////////
+// Number of threads (of the default stack size) to pre-allocate when
+// initializing a thread queue.
+#if !defined(HPX_THREAD_QUEUE_INIT_THREADS_COUNT)
+#  define HPX_THREAD_QUEUE_INIT_THREADS_COUNT 10
+#endif
+
+///////////////////////////////////////////////////////////////////////////////
 // Maximum sleep time for idle backoff in milliseconds (used only if
 // HPX_HAVE_THREAD_MANAGER_IDLE_BACKOFF is defined).
 #if !defined(HPX_IDLE_BACKOFF_TIME_MAX)

--- a/libs/core/coroutines/include/hpx/coroutines/coroutine.hpp
+++ b/libs/core/coroutines/include/hpx/coroutines/coroutine.hpp
@@ -128,6 +128,11 @@ namespace hpx { namespace threads { namespace coroutines {
         }
 #endif
 
+        void init()
+        {
+            impl_.init();
+        }
+
         void rebind(functor_type&& f, thread_id_type id)
         {
             impl_.rebind(std::move(f), id);

--- a/libs/core/coroutines/include/hpx/coroutines/detail/coroutine_impl.hpp
+++ b/libs/core/coroutines/include/hpx/coroutines/detail/coroutine_impl.hpp
@@ -112,6 +112,11 @@ namespace hpx { namespace threads { namespace coroutines { namespace detail {
         }
 #endif
 
+        void init()
+        {
+            this->super_type::init();
+        }
+
         void reset()
         {
             // First reset the function and arguments

--- a/libs/core/runtime_configuration/src/runtime_configuration.cpp
+++ b/libs/core/runtime_configuration/src/runtime_configuration.cpp
@@ -259,6 +259,9 @@ namespace hpx { namespace util {
             "max_terminated_threads = "
             "${HPX_THREAD_QUEUE_MAX_TERMINATED_THREADS:" HPX_PP_STRINGIZE(
                 HPX_PP_EXPAND(HPX_THREAD_QUEUE_MAX_TERMINATED_THREADS)) "}",
+            "init_threads_count = "
+            "${HPX_THREAD_QUEUE_INIT_THREADS_COUNT:" HPX_PP_STRINGIZE(
+                HPX_PP_EXPAND(HPX_THREAD_QUEUE_INIT_THREADS_COUNT)) "}",
 
             "[hpx.commandline]",
             // enable aliasing

--- a/libs/core/schedulers/include/hpx/schedulers/queue_holder_thread.hpp
+++ b/libs/core/schedulers/include/hpx/schedulers/queue_holder_thread.hpp
@@ -527,7 +527,7 @@ namespace hpx { namespace threads { namespace policies {
                     p = threads::thread_data_stackful::create(
                         data, this, stacksize);
                 }
-                tid = thread_id_ref_type(p, thread_id_ref_type::addref::no);
+                tid = thread_id_ref_type(p, thread_id_addref::no);
 
                 tq_deb.debug(debug::str<>("create_thread_object"), "new",
                     queue_data_print(this),

--- a/libs/core/schedulers/include/hpx/schedulers/thread_queue.hpp
+++ b/libs/core/schedulers/include/hpx/schedulers/thread_queue.hpp
@@ -193,7 +193,7 @@ namespace hpx { namespace threads { namespace policies {
                     p = threads::thread_data_stackful::create(
                         data, this, stacksize);
                 }
-                thrd = thread_id_ref_type(p, thread_id_ref_type::addref::no);
+                thrd = thread_id_ref_type(p, thread_id_addref::no);
             }
         }
 

--- a/libs/core/schedulers/include/hpx/schedulers/thread_queue.hpp
+++ b/libs/core/schedulers/include/hpx/schedulers/thread_queue.hpp
@@ -37,7 +37,6 @@
 #include <cstdint>
 #include <exception>
 #include <functional>
-#include <list>
 #include <map>
 #include <memory>
 #include <mutex>
@@ -93,8 +92,8 @@ namespace hpx { namespace threads { namespace policies {
             std::hash<thread_id_type>, std::equal_to<thread_id_type>,
             util::internal_allocator<thread_id_type>>;
 
-        using thread_heap_type =
-            std::list<thread_id_type, util::internal_allocator<thread_id_type>>;
+        using thread_heap_type = std::vector<thread_id_type,
+            util::internal_allocator<thread_id_type>>;
 
         struct task_description
         {
@@ -172,8 +171,8 @@ namespace hpx { namespace threads { namespace policies {
             if (!heap->empty())
             {
                 // Take ownership of the thread object and rebind it.
-                thrd = heap->front();
-                heap->pop_front();
+                thrd = heap->back();
+                heap->pop_back();
                 get_thread_id_data(thrd)->rebind(data);
             }
             else
@@ -330,23 +329,23 @@ namespace hpx { namespace threads { namespace policies {
 
             if (stacksize == parameters_.small_stacksize_)
             {
-                thread_heap_small_.push_front(thrd);
+                thread_heap_small_.push_back(thrd);
             }
             else if (stacksize == parameters_.medium_stacksize_)
             {
-                thread_heap_medium_.push_front(thrd);
+                thread_heap_medium_.push_back(thrd);
             }
             else if (stacksize == parameters_.large_stacksize_)
             {
-                thread_heap_large_.push_front(thrd);
+                thread_heap_large_.push_back(thrd);
             }
             else if (stacksize == parameters_.huge_stacksize_)
             {
-                thread_heap_huge_.push_front(thrd);
+                thread_heap_huge_.push_back(thrd);
             }
             else if (stacksize == parameters_.nostack_stacksize_)
             {
-                thread_heap_nostack_.push_front(thrd);
+                thread_heap_nostack_.push_back(thrd);
             }
             else
             {
@@ -1112,7 +1111,43 @@ namespace hpx { namespace threads { namespace policies {
         }
 
         ///////////////////////////////////////////////////////////////////////
-        void on_start_thread(std::size_t /* num_thread */) {}
+        void on_start_thread(std::size_t /* num_thread */)
+        {
+            thread_heap_small_.reserve(parameters_.init_threads_count_);
+            thread_heap_medium_.reserve(parameters_.init_threads_count_);
+            thread_heap_large_.reserve(parameters_.init_threads_count_);
+            thread_heap_huge_.reserve(parameters_.init_threads_count_);
+
+            // Pre-allocate init_threads_count threads, with accompanying stack,
+            // with the default stack size
+            static_assert(
+                thread_stacksize::default_ == thread_stacksize::small_,
+                "This assumes that the default stacksize is \"small_\". If the "
+                "default changes, so should this code. If this static_assert "
+                "fails you've most likely changed the default without changing "
+                "the code here.");
+
+            std::lock_guard<mutex_type> lk(mtx_);
+            for (std::int64_t i = 0; i < parameters_.init_threads_count_; ++i)
+            {
+                // We don't care about the init parameters since this thread
+                // will be rebound once it is actually used
+                hpx::threads::thread_init_data init_data;
+
+                // We start the reference count at zero since the thread goes
+                // immediately into the list of recycled threads
+                threads::thread_data* p =
+                    threads::thread_data_stackful::create(init_data, this,
+                        parameters_.small_stacksize_, thread_id_addref::no);
+                HPX_ASSERT(p);
+
+                // We initialize the stack eagerly
+                p->init();
+
+                // Finally, store the thread for later use
+                thread_heap_small_.emplace_back(p);
+            }
+        }
         void on_stop_thread(std::size_t /* num_thread */) {}
         void on_error(
             std::size_t /* num_thread */, std::exception_ptr const& /* e */)

--- a/libs/core/threading_base/include/hpx/threading_base/thread_data.hpp
+++ b/libs/core/threading_base/include/hpx/threading_base/thread_data.hpp
@@ -584,6 +584,7 @@ namespace hpx { namespace threads {
             std::size_t data) = 0;
 #endif
 
+        virtual void init() = 0;
         virtual void rebind(thread_init_data& init_data) = 0;
 
 #if defined(HPX_HAVE_APEX)

--- a/libs/core/threading_base/include/hpx/threading_base/thread_data.hpp
+++ b/libs/core/threading_base/include/hpx/threading_base/thread_data.hpp
@@ -74,7 +74,7 @@ namespace hpx { namespace threads {
     /// Generally, \a threads are not created or executed directly. All
     /// functionality related to the management of \a threads is
     /// implemented by the thread-manager.
-    class thread_data : public threads::detail::thread_data_reference_counting
+    class thread_data : public detail::thread_data_reference_counting
     {
     public:
         thread_data(thread_data const&) = delete;
@@ -601,7 +601,8 @@ namespace hpx { namespace threads {
 
         // Construct a new \a thread
         thread_data(thread_init_data& init_data, void* queue,
-            std::ptrdiff_t stacksize, bool is_stackless = false);
+            std::ptrdiff_t stacksize, bool is_stackless = false,
+            thread_id_addref addref = thread_id_addref::yes);
 
         virtual ~thread_data() override;
         virtual void destroy() = 0;

--- a/libs/core/threading_base/include/hpx/threading_base/thread_data_stackful.hpp
+++ b/libs/core/threading_base/include/hpx/threading_base/thread_data_stackful.hpp
@@ -134,9 +134,9 @@ namespace hpx { namespace threads {
             HPX_ASSERT(coroutine_.is_ready());
         }
 
-        thread_data_stackful(
-            thread_init_data& init_data, void* queue, std::ptrdiff_t stacksize)
-          : thread_data(init_data, queue, stacksize)
+        thread_data_stackful(thread_init_data& init_data, void* queue,
+            std::ptrdiff_t stacksize, thread_id_addref addref)
+          : thread_data(init_data, queue, stacksize, false, addref)
           , coroutine_(
                 std::move(init_data.func), thread_id_type(this_()), stacksize)
           , agent_(coroutine_.impl())
@@ -146,8 +146,9 @@ namespace hpx { namespace threads {
 
         ~thread_data_stackful();
 
-        static inline thread_data* create(
-            thread_init_data& init_data, void* queue, std::ptrdiff_t stacksize);
+        static inline thread_data* create(thread_init_data& init_data,
+            void* queue, std::ptrdiff_t stacksize,
+            thread_id_addref addref = thread_id_addref::yes);
 
         void destroy() override
         {
@@ -161,11 +162,11 @@ namespace hpx { namespace threads {
     };
 
     ////////////////////////////////////////////////////////////////////////////
-    inline thread_data* thread_data_stackful::create(
-        thread_init_data& data, void* queue, std::ptrdiff_t stacksize)
+    inline thread_data* thread_data_stackful::create(thread_init_data& data,
+        void* queue, std::ptrdiff_t stacksize, thread_id_addref addref)
     {
         thread_data* p = thread_alloc_.allocate(1);
-        new (p) thread_data_stackful(data, queue, stacksize);
+        new (p) thread_data_stackful(data, queue, stacksize, addref);
         return p;
     }
 }}    // namespace hpx::threads

--- a/libs/core/threading_base/include/hpx/threading_base/thread_data_stackful.hpp
+++ b/libs/core/threading_base/include/hpx/threading_base/thread_data_stackful.hpp
@@ -125,6 +125,11 @@ namespace hpx { namespace threads {
         }
 #endif
 
+        void init() override
+        {
+            coroutine_.init();
+        }
+
         void rebind(thread_init_data& init_data) override
         {
             this->thread_data::rebind_base(init_data);

--- a/libs/core/threading_base/include/hpx/threading_base/thread_data_stackless.hpp
+++ b/libs/core/threading_base/include/hpx/threading_base/thread_data_stackless.hpp
@@ -121,6 +121,8 @@ namespace hpx { namespace threads {
         }
 #endif
 
+        void init() override {}
+
         void rebind(thread_init_data& init_data) override
         {
             this->thread_data::rebind_base(init_data);

--- a/libs/core/threading_base/include/hpx/threading_base/thread_data_stackless.hpp
+++ b/libs/core/threading_base/include/hpx/threading_base/thread_data_stackless.hpp
@@ -130,9 +130,9 @@ namespace hpx { namespace threads {
             HPX_ASSERT(coroutine_.is_ready());
         }
 
-        thread_data_stackless(
-            thread_init_data& init_data, void* queue, std::ptrdiff_t stacksize)
-          : thread_data(init_data, queue, stacksize, true)
+        thread_data_stackless(thread_init_data& init_data, void* queue,
+            std::ptrdiff_t stacksize, thread_id_addref addref)
+          : thread_data(init_data, queue, stacksize, true, addref)
           , coroutine_(std::move(init_data.func), thread_id_type(this_()))
         {
             HPX_ASSERT(coroutine_.is_ready());
@@ -140,8 +140,9 @@ namespace hpx { namespace threads {
 
         ~thread_data_stackless();
 
-        inline static thread_data* create(
-            thread_init_data& init_data, void* queue, std::ptrdiff_t stacksize);
+        inline static thread_data* create(thread_init_data& data, void* queue,
+            std::ptrdiff_t stacksize,
+            thread_id_addref addref = thread_id_addref::yes);
 
         void destroy() override
         {
@@ -154,11 +155,11 @@ namespace hpx { namespace threads {
     };
 
     ////////////////////////////////////////////////////////////////////////////
-    inline thread_data* thread_data_stackless::create(
-        thread_init_data& data, void* queue, std::ptrdiff_t stacksize)
+    inline thread_data* thread_data_stackless::create(thread_init_data& data,
+        void* queue, std::ptrdiff_t stacksize, thread_id_addref addref)
     {
         thread_data* p = thread_alloc_.allocate(1);
-        new (p) thread_data_stackless(data, queue, stacksize);
+        new (p) thread_data_stackless(data, queue, stacksize, addref);
         return p;
     }
 }}    // namespace hpx::threads

--- a/libs/core/threading_base/include/hpx/threading_base/thread_queue_init_parameters.hpp
+++ b/libs/core/threading_base/include/hpx/threading_base/thread_queue_init_parameters.hpp
@@ -33,6 +33,8 @@ namespace hpx { namespace threads { namespace policies {
                 HPX_THREAD_QUEUE_MAX_DELETE_COUNT),
             std::int64_t max_terminated_threads = std::int64_t(
                 HPX_THREAD_QUEUE_MAX_TERMINATED_THREADS),
+            std::int64_t init_threads_count = std::int64_t(
+                HPX_THREAD_QUEUE_INIT_THREADS_COUNT),
             double max_idle_backoff_time = double(HPX_IDLE_BACKOFF_TIME_MAX),
             std::ptrdiff_t small_stacksize = HPX_SMALL_STACK_SIZE,
             std::ptrdiff_t medium_stacksize = HPX_MEDIUM_STACK_SIZE,
@@ -46,6 +48,7 @@ namespace hpx { namespace threads { namespace policies {
           , min_delete_count_(min_delete_count)
           , max_delete_count_(max_delete_count)
           , max_terminated_threads_(max_terminated_threads)
+          , init_threads_count_(init_threads_count)
           , max_idle_backoff_time_(max_idle_backoff_time)
           , small_stacksize_(small_stacksize)
           , medium_stacksize_(medium_stacksize)
@@ -63,6 +66,7 @@ namespace hpx { namespace threads { namespace policies {
         std::int64_t min_delete_count_;
         std::int64_t max_delete_count_;
         std::int64_t max_terminated_threads_;
+        std::int64_t init_threads_count_;
         double max_idle_backoff_time_;
         std::ptrdiff_t const small_stacksize_;
         std::ptrdiff_t const medium_stacksize_;

--- a/libs/core/threading_base/src/thread_data.cpp
+++ b/libs/core/threading_base/src/thread_data.cpp
@@ -223,6 +223,10 @@ namespace hpx { namespace threads {
         scheduler_base_ = init_data.scheduler_base;
         last_worker_thread_num_ = std::size_t(-1);
 
+        // We explicitly set the logical stack size again as it can be different
+        // from what the previous use required. However, the physical stack size
+        // must be the same as before.
+        stacksize_enum_ = init_data.stacksize;
         HPX_ASSERT(stacksize_ == get_stack_size());
         HPX_ASSERT(stacksize_ != 0);
 

--- a/libs/core/threading_base/src/thread_data.cpp
+++ b/libs/core/threading_base/src/thread_data.cpp
@@ -46,8 +46,9 @@ namespace hpx { namespace threads {
     }    // namespace detail
 
     thread_data::thread_data(thread_init_data& init_data, void* queue,
-        std::ptrdiff_t stacksize, bool is_stackless)
-      : current_state_(thread_state(
+        std::ptrdiff_t stacksize, bool is_stackless, thread_id_addref addref)
+      : detail::thread_data_reference_counting(addref)
+      , current_state_(thread_state(
             init_data.initial_state, thread_restart_state::signaled))
 #ifdef HPX_HAVE_THREAD_DESCRIPTION
       , description_(init_data.description)

--- a/libs/core/threadmanager/src/threadmanager.cpp
+++ b/libs/core/threadmanager/src/threadmanager.cpp
@@ -137,6 +137,10 @@ namespace hpx { namespace threads {
             hpx::util::get_entry_as<std::int64_t>(rtcfg_,
                 "hpx.thread_queue.max_terminated_threads",
                 HPX_THREAD_QUEUE_MAX_TERMINATED_THREADS);
+        std::int64_t const init_threads_count =
+            hpx::util::get_entry_as<std::int64_t>(rtcfg_,
+                "hpx.thread_queue.init_threads_count",
+                HPX_THREAD_QUEUE_INIT_THREADS_COUNT);
         double const max_idle_backoff_time = hpx::util::get_entry_as<double>(
             rtcfg_, "hpx.max_idle_backoff_time", HPX_IDLE_BACKOFF_TIME_MAX);
 
@@ -153,8 +157,8 @@ namespace hpx { namespace threads {
             max_thread_count, min_tasks_to_steal_pending,
             min_tasks_to_steal_staged, min_add_new_count, max_add_new_count,
             min_delete_count, max_delete_count, max_terminated_threads,
-            max_idle_backoff_time, small_stacksize, medium_stacksize,
-            large_stacksize, huge_stacksize);
+            init_threads_count, max_idle_backoff_time, small_stacksize,
+            medium_stacksize, large_stacksize, huge_stacksize);
 
         if (!rtcfg_.enable_networking())
         {


### PR DESCRIPTION
This adds a configuration option `hpx.thread_queue.init_threads_count` (default `10`) which controls how many threads to allocate and initialize (including allocating a stack) with the default stack size in each `thread_queue`. The thread queue also first attempts to clean up terminated threads when it runs out of recycled threads to reuse existing threads if possible. Only if it can't reuse an old thread will it actually allocate a new thread. Checking for this is cheap, and we are anyway holding the thread queue lock at that point.

This reduces the need to "warm up" the scheduler and thread queues when benchmarking (see benchmarks below), and I don't see the harm in doing this generally either since threads will need to be allocated sooner or later.

To achieve this, I've added a way to create `thread_data` with a reference count of zero so that it can be added to the "heaps" of recycled threads immediately without having to go through `terminated_threads`. I've also added a way to eagerly initialize a `thread_data`, which in practice means allocating a stack. `on_start_thread` creates the configured number of threads, initializes them, and adds them to the default stack size heap.

Stream benchmark before these changes (note the very irregular lines for all executors except the fork-join executor (which is not affected by these changes since it starts its threads up front and then reuses them)):
![stream_lazy_thread_init](https://user-images.githubusercontent.com/42977/131345555-b8c2746b-d177-4a31-ac12-eba930bed395.png)

Stream after these changes (the dips are mostly missing in these results):
![stream_eager_thread_init](https://user-images.githubusercontent.com/42977/131345748-960e8b7f-1fe9-4a66-85a6-a7588cde2547.png)

The dips also mostly disappear with enough warmup iterations of the stream benchmark, or by increasing the number of iterations. The benchmark defaults to 10 iterations, and the plots show the best result from those 10 iterations. With the changes in this PR the best performance is easily achieved within the default 10 iterations.

An open question is whether 10 is a good default, and if the eager initialization should be more granular (per stacksize/priority), but I figured this was a reasonable number for most systems.