### PR TITLE
Fix `annotate_function` for `std::string`

### DIFF
--- a/libs/core/threading_base/src/annotated_function.cpp
+++ b/libs/core/threading_base/src/annotated_function.cpp
@@ -14,7 +14,7 @@
 #include <utility>
 
 namespace hpx { namespace util { namespace detail {
-    char const* store_function_annotation(std::string&& name)
+    char const* store_function_annotation(std::string name)
     {
         static thread_local std::unordered_set<std::string> names;
         auto r = names.emplace(std::move(name));
@@ -27,7 +27,7 @@ namespace hpx { namespace util { namespace detail {
 #include <string>
 
 namespace hpx { namespace util { namespace detail {
-    char const* store_function_annotation(std::string&&)
+    char const* store_function_annotation(std::string)
     {
         return "<unknown>";
     }

--- a/tests/unit/apex/CMakeLists.txt
+++ b/tests/unit/apex/CMakeLists.txt
@@ -24,24 +24,38 @@ foreach(test ${tests})
 
 endforeach()
 
-# dataflow support works for the following (add sync - if it ever works)
-foreach(
-  launch
-  "" "Executor non-threaded "
-  # "Executor threaded "
-  "apply " "async " "deferred " "fork "
+set(launch_types_
+    ""
+    "Executor "
+    "apply "
+    "async "
+    "deferred "
+    "fork "
+    "sync "
 )
+
+# dataflow
+foreach(launch ${launch_types_})
   set(REGEX_MATCH_D_ "${REGEX_MATCH_D_}.*1-${launch}Dataflow")
 endforeach()
 
-# continuation support works for the following
-foreach(launch "" "Executor non-threaded " # Executor threaded "
-               "async " "fork "
-)
+# continuations
+foreach(launch ${launch_types_})
   set(REGEX_MATCH_C_ "${REGEX_MATCH_C_}.*2-${launch}Continuation")
+endforeach()
+
+# continuations with unwrapping
+foreach(launch ${launch_types_})
+  set(REGEX_MATCH_C_ "${REGEX_MATCH_C_}.*3-${launch}Unwrapping Continuation")
+endforeach()
+
+# annotate_function with std::string and char*
+foreach(type "char" "string")
+  set(REGEX_MATCH_ANN_ "${REGEX_MATCH_ANN_}.*4-${type} annotate_function")
 endforeach()
 
 set_tests_properties(
   tests.unit.apex.annotation_check
-  PROPERTIES PASS_REGULAR_EXPRESSION "${REGEX_MATCH_D_}${REGEX_MATCH_C_}"
+  PROPERTIES PASS_REGULAR_EXPRESSION
+             "${REGEX_MATCH_D_}${REGEX_MATCH_C_}${REGEX_MATCH_ANN_}"
 )


### PR DESCRIPTION
`annotate_function` did not have a constructor taking `std::string`s which means that passing a `std::string` to it would try to use `get_function_annotation` for getting an annotation from a `std::string`. Since there's no specialization, this returns `<unknown>`. This adds an explicit constructor taking a `std::string`.

This also updates the `annotation_check` test and adds a test for `annotate_function`.

Flyby: restore the thread description correctly in the `annotate_function` destructor. @hkaiser after https://github.com/STEllAR-GROUP/hpx/pull/5401/commits/21f87b24ba8ecef89ac89807b1ecb99ca7fb36e1#diff-9d331166da570e7469e476d468b684dfd42590305a752f337fd6f9aa3f3bff86 there was no description stored in the `annotate_function` constructors, meaning that it was always restored to a default constructed thread description. Was this an oversight or intentional?

@albestro would you mind trying this?