### PR TITLE
Rename simdpar to par_simd

### DIFF
--- a/libs/parallelism/algorithms/tests/unit/datapar_algorithms/fill_datapar.cpp
+++ b/libs/parallelism/algorithms/tests/unit/datapar_algorithms/fill_datapar.cpp
@@ -24,10 +24,10 @@ void test_fill()
     test_fill(IteratorTag());
 
     test_fill(simd, IteratorTag());
-    test_fill(simdpar, IteratorTag());
+    test_fill(par_simd, IteratorTag());
 
     test_fill_async(simd(task), IteratorTag());
-    test_fill_async(simdpar(task), IteratorTag());
+    test_fill_async(par_simd(task), IteratorTag());
 }
 
 void fill_test()
@@ -45,10 +45,10 @@ void test_fill_exception()
     test_fill_exception(IteratorTag());
 
     test_fill_exception(simd, IteratorTag());
-    test_fill_exception(simdpar, IteratorTag());
+    test_fill_exception(par_simd, IteratorTag());
 
     test_fill_exception_async(simd(task), IteratorTag());
-    test_fill_exception_async(simdpar(task), IteratorTag());
+    test_fill_exception_async(par_simd(task), IteratorTag());
 }
 
 void fill_exception_test()
@@ -64,10 +64,10 @@ void test_fill_bad_alloc()
     using namespace hpx::execution;
 
     test_fill_bad_alloc(simd, IteratorTag());
-    test_fill_bad_alloc(simdpar, IteratorTag());
+    test_fill_bad_alloc(par_simd, IteratorTag());
 
     test_fill_bad_alloc_async(simd(task), IteratorTag());
-    test_fill_bad_alloc_async(simdpar(task), IteratorTag());
+    test_fill_bad_alloc_async(par_simd(task), IteratorTag());
 }
 
 void fill_bad_alloc_test()

--- a/libs/parallelism/algorithms/tests/unit/datapar_algorithms/filln_datapar.cpp
+++ b/libs/parallelism/algorithms/tests/unit/datapar_algorithms/filln_datapar.cpp
@@ -24,10 +24,10 @@ void test_fill_n()
     test_fill_n(IteratorTag());
 
     test_fill_n(simd, IteratorTag());
-    test_fill_n(simdpar, IteratorTag());
+    test_fill_n(par_simd, IteratorTag());
 
     test_fill_n_async(simd(task), IteratorTag());
-    test_fill_n_async(simdpar(task), IteratorTag());
+    test_fill_n_async(par_simd(task), IteratorTag());
 }
 
 void fill_n_test()
@@ -45,10 +45,10 @@ void test_fill_n_exception()
     test_fill_n_exception(IteratorTag());
 
     test_fill_n_exception(simd, IteratorTag());
-    test_fill_n_exception(simdpar, IteratorTag());
+    test_fill_n_exception(par_simd, IteratorTag());
 
     test_fill_n_exception_async(simd(task), IteratorTag());
-    test_fill_n_exception_async(simdpar(task), IteratorTag());
+    test_fill_n_exception_async(par_simd(task), IteratorTag());
 }
 
 void fill_n_exception_test()
@@ -64,10 +64,10 @@ void test_fill_n_bad_alloc()
     using namespace hpx::execution;
 
     test_fill_n_bad_alloc(simd, IteratorTag());
-    test_fill_n_bad_alloc(simdpar, IteratorTag());
+    test_fill_n_bad_alloc(par_simd, IteratorTag());
 
     test_fill_n_bad_alloc_async(simd(task), IteratorTag());
-    test_fill_n_bad_alloc_async(simdpar(task), IteratorTag());
+    test_fill_n_bad_alloc_async(par_simd(task), IteratorTag());
 }
 
 void fill_n_bad_alloc_test()


### PR DESCRIPTION
## Proposed Changes
  - Renames simdpar to par_simd in unit tests.

## Any background context you want to provide?
https://cdash.cscs.ch/viewBuildError.php?buildid=178422