### PR TITLE
This fixes referencing stale iterators during the execution of binary mismatch

### DIFF
--- a/libs/core/iterator_support/include/hpx/iterator_support/traits/is_sentinel_for.hpp
+++ b/libs/core/iterator_support/include/hpx/iterator_support/traits/is_sentinel_for.hpp
@@ -60,4 +60,8 @@ namespace hpx { namespace traits {
     {
     };
 
+    template <typename Sent, typename Iter>
+    HPX_INLINE_CONSTEXPR_VARIABLE bool is_sized_sentinel_for_v =
+        is_sized_sentinel_for<Sent, Iter>::value;
+
 }}    // namespace hpx::traits

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/adjacent_difference.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/adjacent_difference.hpp
@@ -89,9 +89,12 @@ namespace hpx { namespace parallel { inline namespace v1 {
                         });
                 };
 
-                auto f2 =
-                    [dest, count](
-                        std::vector<hpx::future<void>>&&) mutable -> FwdIter2 {
+                auto f2 = [dest, count](
+                              std::vector<hpx::future<void>>&& data) mutable
+                    -> FwdIter2 {
+                    // make sure iterators embedded in function object that is
+                    // attached to futures are invalidated
+                    data.clear();
                     std::advance(dest, count);
                     return dest;
                 };

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/adjacent_find.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/adjacent_find.hpp
@@ -201,9 +201,12 @@ namespace hpx { namespace parallel { inline namespace v1 {
                         });
                 };
 
-                auto f2 =
-                    [tok, count, first, last](
-                        std::vector<hpx::future<void>>&&) mutable -> FwdIter {
+                auto f2 = [tok, count, first, last](
+                              std::vector<hpx::future<void>>&& data) mutable
+                    -> FwdIter {
+                    // make sure iterators embedded in function object that is
+                    // attached to futures are invalidated
+                    data.clear();
                     difference_type adj_find_res = tok.get_data();
                     if (adj_find_res != count)
                         std::advance(first, adj_find_res);

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/copy.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/copy.hpp
@@ -204,8 +204,8 @@ namespace hpx {
 #include <hpx/assert.hpp>
 #include <hpx/concepts/concepts.hpp>
 #include <hpx/functional/invoke.hpp>
-#include <hpx/parallel/util/detail/sender_util.hpp>
 #include <hpx/iterator_support/traits/is_iterator.hpp>
+#include <hpx/parallel/util/detail/sender_util.hpp>
 
 #include <hpx/algorithms/traits/projected.hpp>
 #include <hpx/execution/algorithms/detail/is_negative.hpp>
@@ -586,12 +586,19 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 auto f4 =
                     [first, dest, flags](
                         std::vector<hpx::shared_future<std::size_t>>&& items,
-                        std::vector<hpx::future<void>>&&) mutable
+                        std::vector<hpx::future<void>>&& data) mutable
                     -> util::in_out_result<FwdIter1, FwdIter3> {
                     HPX_UNUSED(flags);
 
-                    std::advance(dest, items.back().get());
-                    std::advance(first, items.back().get());
+                    auto dist = items.back().get();
+                    std::advance(first, dist);
+                    std::advance(dest, dist);
+
+                    // make sure iterators embedded in function object that is
+                    // attached to futures are invalidated
+                    items.clear();
+                    data.clear();
+
                     return util::in_out_result<FwdIter1, FwdIter3>{
                         std::move(first), std::move(dest)};
                 };

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/detail/advance_to_sentinel.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/detail/advance_to_sentinel.hpp
@@ -8,6 +8,7 @@
 
 #include <hpx/config.hpp>
 #include <hpx/iterator_support/traits/is_sentinel_for.hpp>
+#include <hpx/parallel/algorithms/detail/distance.hpp>
 
 #include <iterator>
 #include <type_traits>
@@ -16,34 +17,25 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
 
     // Generic implementation for advancing a given iterator to its sentinel
     template <typename Iter, typename Sent>
-    constexpr inline Iter advance_to_sentinel(
-        Iter first, Sent last, std::false_type)
-    {
-        for (/**/; first != last; ++first)
-        {
-            /**/;
-        }
-        return first;
-    }
-
-    template <typename Iter, typename Sent>
-    constexpr inline Iter advance_to_sentinel(
-        Iter first, Sent last, std::true_type)
-    {
-        return first + (last - first);
-    }
-
-    template <typename Iter, typename Sent>
     constexpr inline Iter advance_to_sentinel(Iter first, Sent last)
     {
-        return advance_to_sentinel(first, last,
-            typename hpx::traits::is_sized_sentinel_for<Sent, Iter>::type{});
-    }
-
-    template <typename Iter>
-    constexpr inline Iter advance_to_sentinel(Iter, Iter last)
-    {
-        return last;
+        if constexpr (std::is_same<Iter, Sent>::value)
+        {
+            return last;
+        }
+        else if constexpr (hpx::traits::is_sized_sentinel_for_v<Sent, Iter>)
+        {
+            std::advance(first, last - first);
+            return first;
+        }
+        else
+        {
+            for (/**/; first != last; ++first)
+            {
+                /**/;
+            }
+            return first;
+        }
     }
 
 }}}}    // namespace hpx::parallel::v1::detail

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/detail/search.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/detail/search.hpp
@@ -137,7 +137,11 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
                     });
             };
 
-            auto f2 = [=](std::vector<hpx::future<void>>&&) mutable -> FwdIter {
+            auto f2 =
+                [=](std::vector<hpx::future<void>>&& data) mutable -> FwdIter {
+                // make sure iterators embedded in function object that is
+                // attached to futures are invalidated
+                data.clear();
                 difference_type search_res = tok.get_data();
                 if (search_res != count)
                     std::advance(first, search_res);
@@ -233,7 +237,11 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
                     });
             };
 
-            auto f2 = [=](std::vector<hpx::future<void>>&&) mutable -> FwdIter {
+            auto f2 =
+                [=](std::vector<hpx::future<void>>&& data) mutable -> FwdIter {
+                // make sure iterators embedded in function object that is
+                // attached to futures are invalidated
+                data.clear();
                 difference_type search_res = tok.get_data();
                 if (search_res != s_difference_type(count))
                     std::advance(first, search_res);

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/detail/set_operation.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/detail/set_operation.hpp
@@ -217,8 +217,12 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
         // different versions of clang-format produce different formatting
         // clang-format off
         auto f2 = [buffer, chunks, cores, first1, first2, dest](
-                      std::vector<future<void>>&&) -> result_type {
+                      std::vector<future<void>>&& data) -> result_type {
             // clang-format on
+
+            // make sure iterators embedded in function object that is
+            // attached to futures are invalidated
+            data.clear();
 
             // accumulate real length and rightmost positions in input sequences
             std::size_t first1_pos = 0;

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/exclusive_scan.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/exclusive_scan.hpp
@@ -449,8 +449,12 @@ namespace hpx { namespace parallel { inline namespace v1 {
                         std::move(f3),
                         // step 4 use this return value
                         [last_iter, final_dest](
-                            std::vector<hpx::shared_future<T>>&&,
-                            std::vector<hpx::future<void>>&&) {
+                            std::vector<hpx::shared_future<T>>&& items,
+                            std::vector<hpx::future<void>>&& data) {
+                            // make sure iterators embedded in function object that is
+                            // attached to futures are invalidated
+                            items.clear();
+                            data.clear();
                             return util::in_out_result<FwdIter1, FwdIter2>{
                                 last_iter, final_dest};
                         });

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/find.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/find.hpp
@@ -376,16 +376,16 @@ namespace hpx {
 #include <hpx/config.hpp>
 #include <hpx/concepts/concepts.hpp>
 #include <hpx/functional/invoke.hpp>
-#include <hpx/parallel/util/detail/sender_util.hpp>
 #include <hpx/iterator_support/traits/is_iterator.hpp>
+#include <hpx/parallel/util/detail/sender_util.hpp>
 
 #include <hpx/algorithms/traits/projected.hpp>
 #include <hpx/execution/algorithms/detail/predicates.hpp>
 #include <hpx/executors/execution_policy.hpp>
 #include <hpx/parallel/algorithms/detail/advance_to_sentinel.hpp>
-#include <hpx/parallel/algorithms/detail/find.hpp>
 #include <hpx/parallel/algorithms/detail/dispatch.hpp>
 #include <hpx/parallel/algorithms/detail/distance.hpp>
+#include <hpx/parallel/algorithms/detail/find.hpp>
 #include <hpx/parallel/util/compare_projected.hpp>
 #include <hpx/parallel/util/detail/algorithm_result.hpp>
 #include <hpx/parallel/util/invoke_projected.hpp>
@@ -454,7 +454,11 @@ namespace hpx { namespace parallel { inline namespace v1 {
 
                 auto f2 =
                     [tok, count, first, last](
-                        std::vector<hpx::future<void>>&&) mutable -> Iter {
+                        std::vector<hpx::future<void>>&& data) mutable -> Iter {
+                    // make sure iterators embedded in function object that is
+                    // attached to futures are invalidated
+                    data.clear();
+
                     difference_type find_res =
                         static_cast<difference_type>(tok.get_data());
 
@@ -553,7 +557,11 @@ namespace hpx { namespace parallel { inline namespace v1 {
 
                 auto f2 =
                     [tok, count, first, last](
-                        std::vector<hpx::future<void>>&&) mutable -> Iter {
+                        std::vector<hpx::future<void>>&& data) mutable -> Iter {
+                    // make sure iterators embedded in function object that is
+                    // attached to futures are invalidated
+                    data.clear();
+
                     difference_type find_res =
                         static_cast<difference_type>(tok.get_data());
 
@@ -658,7 +666,11 @@ namespace hpx { namespace parallel { inline namespace v1 {
 
                 auto f2 =
                     [tok, count, first, last](
-                        std::vector<hpx::future<void>>&&) mutable -> Iter {
+                        std::vector<hpx::future<void>>&& data) mutable -> Iter {
+                    // make sure iterators embedded in function object that is
+                    // attached to futures are invalidated
+                    data.clear();
+
                     difference_type find_res =
                         static_cast<difference_type>(tok.get_data());
 
@@ -859,9 +871,13 @@ namespace hpx { namespace parallel { inline namespace v1 {
                         });
                 };
 
-                auto f2 =
-                    [tok, count, first1, last1](
-                        std::vector<hpx::future<void>>&&) mutable -> Iter1 {
+                auto f2 = [tok, count, first1, last1](
+                              std::vector<hpx::future<void>>&& data) mutable
+                    -> Iter1 {
+                    // make sure iterators embedded in function object that is
+                    // attached to futures are invalidated
+                    data.clear();
+
                     difference_type find_end_res = tok.get_data();
 
                     if (find_end_res >= 0 && find_end_res != count)
@@ -1006,9 +1022,13 @@ namespace hpx { namespace parallel { inline namespace v1 {
                         });
                 };
 
-                auto f2 =
-                    [tok, count, first, last](
-                        std::vector<hpx::future<void>>&&) mutable -> FwdIter {
+                auto f2 = [tok, count, first, last](
+                              std::vector<hpx::future<void>>&& data) mutable
+                    -> FwdIter {
+                    // make sure iterators embedded in function object that is
+                    // attached to futures are invalidated
+                    data.clear();
+
                     difference_type find_first_of_res = tok.get_data();
 
                     if (find_first_of_res != count)

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/inclusive_scan.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/inclusive_scan.hpp
@@ -603,8 +603,12 @@ namespace hpx { namespace parallel { inline namespace v1 {
                         std::move(f3),
                         // step 4 use this return value
                         [last_iter, final_dest](
-                            std::vector<hpx::shared_future<T>>&&,
-                            std::vector<hpx::future<void>>&&) {
+                            std::vector<hpx::shared_future<T>>&& items,
+                            std::vector<hpx::future<void>>&& data) {
+                            // make sure iterators embedded in function object that is
+                            // attached to futures are invalidated
+                            items.clear();
+                            data.clear();
                             return util::in_out_result<FwdIter1, FwdIter2>{
                                 last_iter, final_dest};
                         });

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/is_heap.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/is_heap.hpp
@@ -137,10 +137,10 @@ namespace hpx {
 #include <hpx/config.hpp>
 #include <hpx/concepts/concepts.hpp>
 #include <hpx/functional/invoke.hpp>
-#include <hpx/parallel/util/detail/sender_util.hpp>
 #include <hpx/functional/traits/is_invocable.hpp>
 #include <hpx/futures/future.hpp>
 #include <hpx/iterator_support/traits/is_iterator.hpp>
+#include <hpx/parallel/util/detail/sender_util.hpp>
 
 #include <hpx/algorithms/traits/projected.hpp>
 #include <hpx/execution/executors/execution.hpp>
@@ -224,7 +224,12 @@ namespace hpx { namespace parallel { inline namespace v1 {
                         });
                 };
                 auto f2 =
-                    [tok](std::vector<hpx::future<void>>&&) mutable -> bool {
+                    [tok](
+                        std::vector<hpx::future<void>>&& data) mutable -> bool {
+                    // make sure iterators embedded in function object that is
+                    // attached to futures are invalidated
+                    data.clear();
+
                     difference_type find_res =
                         static_cast<difference_type>(tok.get_data());
 
@@ -364,7 +369,11 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 };
                 auto f2 =
                     [tok, second](
-                        std::vector<hpx::future<void>>&&) mutable -> Iter {
+                        std::vector<hpx::future<void>>&& data) mutable -> Iter {
+                    // make sure iterators embedded in function object that is
+                    // attached to futures are invalidated
+                    data.clear();
+
                     difference_type find_res =
                         static_cast<difference_type>(tok.get_data());
 

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/is_sorted.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/is_sorted.hpp
@@ -413,9 +413,13 @@ namespace hpx { namespace parallel { inline namespace v1 {
                         }
                     }
                 };
-                auto f2 =
-                    [first, tok](
-                        std::vector<hpx::future<void>>&&) mutable -> FwdIter {
+                auto f2 = [first, tok](
+                              std::vector<hpx::future<void>>&& data) mutable
+                    -> FwdIter {
+                    // make sure iterators embedded in function object that is
+                    // attached to futures are invalidated
+                    data.clear();
+
                     difference_type loc = tok.get_data();
                     std::advance(first, loc);
                     return std::move(first);

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/lexicographical_compare.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/lexicographical_compare.hpp
@@ -266,7 +266,11 @@ namespace hpx { namespace parallel { inline namespace v1 {
 
                 auto f2 =
                     [tok, first1, first2, last1, last2, pred, proj1, proj2](
-                        std::vector<hpx::future<void>>&&) mutable -> bool {
+                        std::vector<hpx::future<void>>&& data) mutable -> bool {
+                    // make sure iterators embedded in function object that is
+                    // attached to futures are invalidated
+                    data.clear();
+
                     std::size_t mismatched = tok.get_data();
 
                     std::advance(first1, mismatched);

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/mismatch.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/mismatch.hpp
@@ -283,7 +283,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                               zip_iterator it, std::size_t part_count,
                               std::size_t base_idx) mutable -> void {
                     util::loop_idx_n(base_idx, it, part_count, tok,
-                        [&f, &proj1, &proj2, &tok](reference t, std::size_t i) {
+                        [&](reference t, std::size_t i) {
                             if (!HPX_INVOKE(f,
                                     HPX_INVOKE(proj1, hpx::get<0>(t)),
                                     HPX_INVOKE(proj2, hpx::get<1>(t))))
@@ -423,7 +423,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                               std::size_t part_count,
                               std::size_t base_idx) mutable -> void {
                     util::loop_idx_n(base_idx, it, part_count, tok,
-                        [&f, &tok](reference t, std::size_t i) {
+                        [&](reference t, std::size_t i) {
                             if (!HPX_INVOKE(f, hpx::get<0>(t), hpx::get<1>(t)))
                             {
                                 tok.cancel(i);

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/remove.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/remove.hpp
@@ -383,9 +383,15 @@ namespace hpx { namespace parallel { inline namespace v1 {
 
                 auto f4 =
                     [dest_ptr, flags](
-                        std::vector<hpx::shared_future<std::size_t>>&&,
-                        std::vector<hpx::future<void>>&&) mutable -> Iter {
+                        std::vector<hpx::shared_future<std::size_t>>&& items,
+                        std::vector<hpx::future<void>>&& data) mutable -> Iter {
                     HPX_UNUSED(flags);
+
+                    // make sure iterators embedded in function object that is
+                    // attached to futures are invalidated
+                    items.clear();
+                    data.clear();
+
                     return *dest_ptr;
                 };
 

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/transform_exclusive_scan.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/transform_exclusive_scan.hpp
@@ -372,8 +372,13 @@ namespace hpx { namespace parallel { inline namespace v1 {
                     std::move(f3),
                     // use this return value
                     [last_iter, final_dest](
-                        std::vector<hpx::shared_future<T>>&&,
-                        std::vector<hpx::future<void>>&&) -> result_type {
+                        std::vector<hpx::shared_future<T>>&& items,
+                        std::vector<hpx::future<void>>&& data) -> result_type {
+                        // make sure iterators embedded in function object that is
+                        // attached to futures are invalidated
+                        items.clear();
+                        data.clear();
+
                         return result_type{last_iter, final_dest};
                     });
             }

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/transform_inclusive_scan.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/transform_inclusive_scan.hpp
@@ -584,8 +584,12 @@ namespace hpx { namespace parallel { inline namespace v1 {
                     std::move(f3),
                     // step 4 use this return value
                     [last_iter, final_dest](
-                        std::vector<hpx::shared_future<T>>&&,
-                        std::vector<hpx::future<void>>&&) -> result_type {
+                        std::vector<hpx::shared_future<T>>&& items,
+                        std::vector<hpx::future<void>>&& data) -> result_type {
+                        // make sure iterators embedded in function object that is
+                        // attached to futures are invalidated
+                        items.clear();
+                        data.clear();
                         return result_type{last_iter, final_dest};
                     });
             }

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/uninitialized_copy.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/uninitialized_copy.hpp
@@ -302,9 +302,14 @@ namespace hpx { namespace parallel { inline namespace v1 {
                                     get<0>(iters), part_size, dest, tok)));
                     },
                     // finalize, called once if no error occurred
-                    [dest, first, count](std::vector<
-                        hpx::future<partition_result_type>>&&) mutable
+                    [dest, first, count](
+                        std::vector<hpx::future<partition_result_type>>&&
+                            data) mutable
                     -> util::in_out_result<Iter, FwdIter2> {
+                        // make sure iterators embedded in function object that is
+                        // attached to futures are invalidated
+                        data.clear();
+
                         std::advance(first, count);
                         std::advance(dest, count);
                         return util::in_out_result<Iter, FwdIter2>{first, dest};

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/uninitialized_default_construct.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/uninitialized_default_construct.hpp
@@ -265,9 +265,13 @@ namespace hpx { namespace parallel { inline namespace v1 {
                                 it, part_size, tok));
                     },
                     // finalize, called once if no error occurred
-                    [first, count](std::vector<
-                        hpx::future<partition_result_type>>&&) mutable
-                    -> FwdIter {
+                    [first, count](
+                        std::vector<hpx::future<partition_result_type>>&&
+                            data) mutable -> FwdIter {
+                        // make sure iterators embedded in function object that is
+                        // attached to futures are invalidated
+                        data.clear();
+
                         std::advance(first, count);
                         return first;
                     },

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/uninitialized_fill.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/uninitialized_fill.hpp
@@ -267,8 +267,13 @@ namespace hpx { namespace parallel { inline namespace v1 {
                                 it, part_size, value, tok));
                     },
                     // finalize, called once if no error occurred
-                    [first, count](std::vector<
-                        hpx::future<partition_result_type>>&&) mutable -> Iter {
+                    [first, count](
+                        std::vector<hpx::future<partition_result_type>>&&
+                            data) mutable -> Iter {
+                        // make sure iterators embedded in function object that is
+                        // attached to futures are invalidated
+                        data.clear();
+
                         std::advance(first, count);
                         return first;
                     },

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/uninitialized_move.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/uninitialized_move.hpp
@@ -311,9 +311,14 @@ namespace hpx { namespace parallel { inline namespace v1 {
                                     get<0>(iters), part_size, dest, tok)));
                     },
                     // finalize, called once if no error occurred
-                    [first, dest, count](std::vector<
-                        hpx::future<partition_result_type>>&&) mutable
+                    [first, dest, count](
+                        std::vector<hpx::future<partition_result_type>>&&
+                            data) mutable
                     -> util::in_out_result<Iter, FwdIter2> {
+                        // make sure iterators embedded in function object that is
+                        // attached to futures are invalidated
+                        data.clear();
+
                         std::advance(first, count);
                         std::advance(dest, count);
                         return util::in_out_result<Iter, FwdIter2>{first, dest};

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/uninitialized_value_construct.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/uninitialized_value_construct.hpp
@@ -175,9 +175,9 @@ namespace hpx {
 #include <hpx/execution/algorithms/detail/is_negative.hpp>
 #include <hpx/executors/execution_policy.hpp>
 #include <hpx/parallel/algorithms/detail/dispatch.hpp>
-#include <hpx/parallel/util/detail/sender_util.hpp>
 #include <hpx/parallel/algorithms/detail/distance.hpp>
 #include <hpx/parallel/util/detail/algorithm_result.hpp>
+#include <hpx/parallel/util/detail/sender_util.hpp>
 #include <hpx/parallel/util/loop.hpp>
 #include <hpx/parallel/util/partitioner_with_cleanup.hpp>
 #include <hpx/parallel/util/zip_iterator.hpp>
@@ -267,9 +267,13 @@ namespace hpx { namespace parallel { inline namespace v1 {
                                 it, part_size, tok));
                     },
                     // finalize, called once if no error occurred
-                    [first, count](std::vector<
-                        hpx::future<partition_result_type>>&&) mutable
-                    -> FwdIter {
+                    [first, count](
+                        std::vector<hpx::future<partition_result_type>>&&
+                            data) mutable -> FwdIter {
+                        // make sure iterators embedded in function object that is
+                        // attached to futures are invalidated
+                        data.clear();
+
                         std::advance(first, count);
                         return first;
                     },

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/unique.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/unique.hpp
@@ -649,8 +649,14 @@ namespace hpx { namespace parallel { inline namespace v1 {
 
                 auto f4 =
                     [dest_ptr = std::move(dest_ptr), first, count, flags](
-                        std::vector<hpx::shared_future<std::size_t>>&&,
-                        std::vector<hpx::future<void>>&&) mutable -> FwdIter {
+                        std::vector<hpx::shared_future<std::size_t>>&& items,
+                        std::vector<hpx::future<void>>&& data) mutable
+                    -> FwdIter {
+                    // make sure iterators embedded in function object that is
+                    // attached to futures are invalidated
+                    items.clear();
+                    data.clear();
+
                     if (!flags[count - 1])
                     {
                         std::advance(first, count - 1);
@@ -896,11 +902,17 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 auto f4 =
                     [last_iter, dest, flags](
                         std::vector<hpx::shared_future<std::size_t>>&& items,
-                        std::vector<hpx::future<void>>&&) mutable
+                        std::vector<hpx::future<void>>&& data) mutable
                     -> unique_copy_result<FwdIter1, FwdIter2> {
                     HPX_UNUSED(flags);
 
                     std::advance(dest, items.back().get());
+
+                    // make sure iterators embedded in function object that is
+                    // attached to futures are invalidated
+                    items.clear();
+                    data.clear();
+
                     return unique_copy_result<FwdIter1, FwdIter2>{
                         std::move(last_iter), std::move(dest)};
                 };

--- a/libs/parallelism/algorithms/include/hpx/parallel/util/detail/algorithm_result.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/util/detail/algorithm_result.hpp
@@ -22,7 +22,7 @@ namespace hpx { namespace parallel { namespace util { namespace detail {
     struct algorithm_result_impl
     {
         // The return type of the initiating function.
-        typedef T type;
+        using type = T;
 
         // Obtain initiating function's return type.
         static constexpr type get()
@@ -47,12 +47,12 @@ namespace hpx { namespace parallel { namespace util { namespace detail {
     struct algorithm_result_impl<ExPolicy, void>
     {
         // The return type of the initiating function.
-        typedef void type;
+        using type = void;
 
         // Obtain initiating function's return type.
-        static constexpr void get() {}
+        static constexpr void get() noexcept {}
 
-        static constexpr void get(hpx::util::unused_type) {}
+        static constexpr void get(hpx::util::unused_type) noexcept {}
 
         static void get(hpx::future<void>&& t)
         {
@@ -70,7 +70,7 @@ namespace hpx { namespace parallel { namespace util { namespace detail {
     struct algorithm_result_impl<hpx::execution::sequenced_task_policy, T>
     {
         // The return type of the initiating function.
-        typedef hpx::future<T> type;
+        using type = hpx::future<T>;
 
         // Obtain initiating function's return type.
         static type get(T&& t)
@@ -88,7 +88,7 @@ namespace hpx { namespace parallel { namespace util { namespace detail {
     struct algorithm_result_impl<hpx::execution::sequenced_task_policy, void>
     {
         // The return type of the initiating function.
-        typedef hpx::future<void> type;
+        using type = hpx::future<void>;
 
         // Obtain initiating function's return type.
         static type get()
@@ -117,7 +117,7 @@ namespace hpx { namespace parallel { namespace util { namespace detail {
     struct algorithm_result_impl<hpx::execution::parallel_task_policy, T>
     {
         // The return type of the initiating function.
-        typedef hpx::future<T> type;
+        using type = hpx::future<T>;
 
         // Obtain initiating function's return type.
         static type get(T&& t)
@@ -135,7 +135,7 @@ namespace hpx { namespace parallel { namespace util { namespace detail {
     struct algorithm_result_impl<hpx::execution::parallel_task_policy, void>
     {
         // The return type of the initiating function.
-        typedef hpx::future<void> type;
+        using type = hpx::future<void>;
 
         // Obtain initiating function's return type.
         static type get()
@@ -252,6 +252,9 @@ namespace hpx { namespace parallel { namespace util { namespace detail {
         static_assert(!std::is_lvalue_reference<T>::value,
             "T shouldn't be a lvalue reference");
     };
+
+    template <typename ExPolicy, typename T = void>
+    using algorithm_result_t = typename algorithm_result<ExPolicy, T>::type;
 
     ///////////////////////////////////////////////////////////////////////////
     template <typename U, typename Conv,


### PR DESCRIPTION
- flyby: modernize the implementation of mismatch
- flyby: modernize `advance_to_sentinel`, `algorithm_result`

for more details, see https://github.com/STEllAR-GROUP/hpx/pull/5410#issuecomment-911790179

@Jedi18 please verify whether this fixes the issues you were seeing.