### PR TITLE
Downgrade CI on rostam to CUDA 11.2

### DIFF
--- a/.jenkins/lsu/env-gcc-9-cuda-11.sh
+++ b/.jenkins/lsu/env-gcc-9-cuda-11.sh
@@ -9,7 +9,7 @@ module load cmake
 module load gcc/9
 module load boost/1.73.0-${build_type,,}
 module load hwloc
-module load cuda/11
+module load cuda/11.2
 module load openmpi
 
 export CXX_STD="17"


### PR DESCRIPTION
I didn't find yet a workaround for all CI configuration for the second `nvcc` bug introduced in CUDA 11.3, this temporarily downgrade to 11.2 to fix master