### PR TITLE
Simplify execution CPOs

### DIFF
--- a/libs/core/async_cuda/include/hpx/async_cuda/transform_stream.hpp
+++ b/libs/core/async_cuda/include/hpx/async_cuda/transform_stream.hpp
@@ -137,8 +137,8 @@ namespace hpx { namespace cuda { namespace experimental {
 
             template <typename R_, typename F_>
             transform_stream_receiver(R_&& r, F_&& f, cudaStream_t stream)
-              : r(std::forward<R>(r))
-              , f(std::forward<F>(f))
+              : r(std::forward<R_>(r))
+              , f(std::forward<F_>(f))
               , stream(stream)
             {
             }

--- a/libs/core/execution/include/hpx/execution/algorithms/detach.hpp
+++ b/libs/core/execution/include/hpx/execution/algorithms/detach.hpp
@@ -38,7 +38,8 @@ namespace hpx { namespace execution { namespace experimental {
                 hpx::intrusive_ptr<operation_state_holder> op_state;
 
                 template <typename Error>
-                HPX_NORETURN void set_error(Error&&) && noexcept
+                HPX_NORETURN friend void tag_dispatch(
+                    set_error_t, detach_receiver&&, Error&&) noexcept
                 {
                     HPX_ASSERT_MSG(false,
                         "set_error was called on the receiver of detach, "
@@ -48,15 +49,17 @@ namespace hpx { namespace execution { namespace experimental {
                     std::terminate();
                 }
 
-                void set_done() && noexcept
+                friend void tag_dispatch(
+                    set_done_t, detach_receiver&& r) noexcept
                 {
-                    op_state.reset();
+                    r.op_state.reset();
                 };
 
                 template <typename... Ts>
-                void set_value(Ts&&...) && noexcept
+                friend void tag_dispatch(
+                    set_value_t, detach_receiver&& r, Ts&&...) noexcept
                 {
-                    op_state.reset();
+                    r.op_state.reset();
                 }
             };
 

--- a/libs/core/execution/include/hpx/execution/algorithms/let_error.hpp
+++ b/libs/core/execution/include/hpx/execution/algorithms/let_error.hpp
@@ -180,40 +180,44 @@ namespace hpx { namespace execution { namespace experimental {
                     };
 
                     template <typename Error>
-                    void set_error(Error&& error) && noexcept
+                    friend void tag_dispatch(set_error_t,
+                        let_error_predecessor_receiver&& r,
+                        Error&& error) noexcept
                     {
                         hpx::detail::try_catch_exception_ptr(
                             [&]() {
                                 // TODO: receiver is moved before the visit, but
                                 // the invoke inside the visit may throw.
-                                op_state.predecessor_error
+                                r.op_state.predecessor_error
                                     .template emplace<Error>(
                                         std::forward<Error>(error));
                                 hpx::visit(
-                                    set_error_visitor{std::move(receiver),
-                                        std::move(f), op_state},
-                                    op_state.predecessor_error);
+                                    set_error_visitor{std::move(r.receiver),
+                                        std::move(r.f), r.op_state},
+                                    r.op_state.predecessor_error);
                             },
                             [&](std::exception_ptr ep) {
                                 hpx::execution::experimental::set_error(
-                                    std::move(receiver), std::move(ep));
+                                    std::move(r.receiver), std::move(ep));
                             });
                     }
 
-                    void set_done() && noexcept
+                    friend void tag_dispatch(
+                        set_done_t, let_error_predecessor_receiver&& r) noexcept
                     {
                         hpx::execution::experimental::set_done(
-                            std::move(receiver));
+                            std::move(r.receiver));
                     };
 
                     template <typename... Ts,
                         typename = std::enable_if_t<hpx::is_invocable_v<
                             hpx::execution::experimental::set_value_t,
                             Receiver&&, Ts...>>>
-                    void set_value(Ts&&... ts) && noexcept
+                    friend void tag_dispatch(set_value_t,
+                        let_error_predecessor_receiver&& r, Ts&&... ts) noexcept
                     {
                         hpx::execution::experimental::set_value(
-                            std::move(receiver), std::forward<Ts>(ts)...);
+                            std::move(r.receiver), std::forward<Ts>(ts)...);
                     }
                 };
 
@@ -273,18 +277,20 @@ namespace hpx { namespace execution { namespace experimental {
                 operation_state(operation_state const&) = delete;
                 operation_state& operator=(operation_state const&) = delete;
 
-                void start() & noexcept
+                friend void tag_dispatch(start_t, operation_state& os) noexcept
                 {
                     hpx::execution::experimental::start(
-                        predecessor_operation_state);
+                        os.predecessor_operation_state);
                 }
             };
 
             template <typename Receiver>
-            auto connect(Receiver&& receiver) &&
+            friend auto tag_dispatch(
+                connect_t, let_error_sender&& s, Receiver&& receiver)
             {
-                return operation_state<Receiver>(std::move(predecessor_sender),
-                    std::forward<Receiver>(receiver), std::move(f));
+                return operation_state<Receiver>(
+                    std::move(s.predecessor_sender),
+                    std::forward<Receiver>(receiver), std::move(s.f));
             }
         };
     }    // namespace detail

--- a/libs/core/execution/include/hpx/execution/algorithms/let_value.hpp
+++ b/libs/core/execution/include/hpx/execution/algorithms/let_value.hpp
@@ -156,16 +156,19 @@ namespace hpx { namespace execution { namespace experimental {
                     }
 
                     template <typename Error>
-                    void set_error(Error&& error) && noexcept
+                    friend void tag_dispatch(set_error_t,
+                        let_value_predecessor_receiver&& r,
+                        Error&& error) noexcept
                     {
                         hpx::execution::experimental::set_error(
-                            std::move(receiver), std::forward<Error>(error));
+                            std::move(r.receiver), std::forward<Error>(error));
                     }
 
-                    void set_done() && noexcept
+                    friend void tag_dispatch(
+                        set_done_t, let_value_predecessor_receiver&& r) noexcept
                     {
                         hpx::execution::experimental::set_done(
-                            std::move(receiver));
+                            std::move(r.receiver));
                     };
 
                     struct start_visitor
@@ -240,11 +243,7 @@ namespace hpx { namespace execution { namespace experimental {
                         hpx::monostate>;
 
                     template <typename... Ts>
-                    auto set_value(Ts&&... ts) && noexcept
-                        -> decltype(std::declval<predecessor_ts_type>()
-                                        .template emplace<hpx::tuple<Ts...>>(
-                                            std::forward<Ts>(ts)...),
-                            void())
+                    void set_value(Ts&&... ts)
                     {
                         hpx::detail::try_catch_exception_ptr(
                             [&]() {
@@ -260,6 +259,21 @@ namespace hpx { namespace execution { namespace experimental {
                                 hpx::execution::experimental::set_error(
                                     std::move(receiver), std::move(ep));
                             });
+                    }
+
+                    template <typename... Ts>
+                    friend auto tag_dispatch(set_value_t,
+                        let_value_predecessor_receiver&& r, Ts&&... ts) noexcept
+                        -> decltype(std::declval<predecessor_ts_type>()
+                                        .template emplace<hpx::tuple<Ts...>>(
+                                            std::forward<Ts>(ts)...),
+                            void())
+                    {
+                        // set_value is in a member function only because of a
+                        // compiler bug in GCC 7. When the body of set_value is
+                        // inlined here compilation fails with an internal
+                        // compiler error.
+                        r.set_value(std::forward<Ts>(ts)...);
                     }
                 };
 
@@ -280,17 +294,20 @@ namespace hpx { namespace execution { namespace experimental {
                 operation_state(operation_state const&) = delete;
                 operation_state& operator=(operation_state const&) = delete;
 
-                void start() & noexcept
+                friend void tag_dispatch(start_t, operation_state& os) noexcept
                 {
-                    hpx::execution::experimental::start(predecessor_op_state);
+                    hpx::execution::experimental::start(
+                        os.predecessor_op_state);
                 }
             };
 
             template <typename Receiver>
-            auto connect(Receiver&& receiver) &&
+            friend auto tag_dispatch(
+                connect_t, let_value_sender&& s, Receiver&& receiver)
             {
-                return operation_state<Receiver>(std::move(predecessor_sender),
-                    std::forward<Receiver>(receiver), std::move(f));
+                return operation_state<Receiver>(
+                    std::move(s.predecessor_sender),
+                    std::forward<Receiver>(receiver), std::move(s.f));
             }
         };
     }    // namespace detail

--- a/libs/core/execution/include/hpx/execution/algorithms/make_future.hpp
+++ b/libs/core/execution/include/hpx/execution/algorithms/make_future.hpp
@@ -34,26 +34,29 @@ namespace hpx { namespace execution { namespace experimental {
                 hpx::lcos::detail::future_data_allocator<T, Allocator>>
                 data;
 
-            void set_error(std::exception_ptr ep) && noexcept
+            friend void tag_dispatch(set_error_t, make_future_receiver&& r,
+                std::exception_ptr ep) noexcept
             {
-                data->set_exception(std::move(ep));
-                data.reset();
+                r.data->set_exception(std::move(ep));
+                r.data.reset();
             }
 
-            void set_done() && noexcept
+            friend void tag_dispatch(
+                set_done_t, make_future_receiver&&) noexcept
             {
                 std::terminate();
             }
 
             template <typename U>
-            void set_value(U&& u) && noexcept
+            friend void tag_dispatch(
+                set_value_t, make_future_receiver&& r, U&& u) noexcept
             {
                 hpx::detail::try_catch_exception_ptr(
-                    [&]() { data->set_value(std::forward<U>(u)); },
+                    [&]() { r.data->set_value(std::forward<U>(u)); },
                     [&](std::exception_ptr ep) {
-                        data->set_exception(std::move(ep));
+                        r.data->set_exception(std::move(ep));
                     });
-                data.reset();
+                r.data.reset();
             }
         };
 
@@ -64,25 +67,28 @@ namespace hpx { namespace execution { namespace experimental {
                 hpx::lcos::detail::future_data_allocator<void, Allocator>>
                 data;
 
-            void set_error(std::exception_ptr ep) && noexcept
+            friend void tag_dispatch(set_error_t, make_future_receiver&& r,
+                std::exception_ptr ep) noexcept
             {
-                data->set_exception(std::move(ep));
-                data.reset();
+                r.data->set_exception(std::move(ep));
+                r.data.reset();
             }
 
-            void set_done() && noexcept
+            friend void tag_dispatch(
+                set_done_t, make_future_receiver&&) noexcept
             {
                 std::terminate();
             }
 
-            void set_value() && noexcept
+            friend void tag_dispatch(
+                set_value_t, make_future_receiver&& r) noexcept
             {
                 hpx::detail::try_catch_exception_ptr(
-                    [&]() { data->set_value(hpx::util::unused); },
+                    [&]() { r.data->set_value(hpx::util::unused); },
                     [&](std::exception_ptr ep) {
-                        data->set_exception(std::move(ep));
+                        r.data->set_exception(std::move(ep));
                     });
-                data.reset();
+                r.data.reset();
             }
         };
 

--- a/libs/core/execution/include/hpx/execution/algorithms/sync_wait.hpp
+++ b/libs/core/execution/include/hpx/execution/algorithms/sync_wait.hpp
@@ -139,27 +139,30 @@ namespace hpx { namespace execution { namespace experimental {
             }
 
             template <typename Error>
-            void set_error(Error&& error) && noexcept
+            friend void tag_dispatch(
+                set_error_t, sync_wait_receiver&& r, Error&& error) noexcept
             {
-                state.value.template emplace<error_type>(
+                r.state.value.template emplace<error_type>(
                     std::forward<Error>(error));
-                signal_set_called();
+                r.signal_set_called();
             }
 
-            void set_done() && noexcept
+            friend void tag_dispatch(
+                set_done_t, sync_wait_receiver&& r) noexcept
             {
-                signal_set_called();
+                r.signal_set_called();
             }
 
             template <typename... Us,
                 typename =
                     std::enable_if_t<(is_void_result && sizeof...(Us) == 0) ||
                         (!is_void_result && sizeof...(Us) == 1)>>
-            void set_value(Us&&... us) && noexcept
+            friend void tag_dispatch(
+                set_value_t, sync_wait_receiver&& r, Us&&... us) noexcept
             {
-                state.value.template emplace<value_type>(
+                r.state.value.template emplace<value_type>(
                     std::forward<Us>(us)...);
-                signal_set_called();
+                r.signal_set_called();
             }
         };
     }    // namespace detail

--- a/libs/core/execution/tests/unit/algorithm_just.cpp
+++ b/libs/core/execution/tests/unit/algorithm_just.cpp
@@ -16,15 +16,6 @@
 
 namespace ex = hpx::execution::experimental;
 
-// This overload is only used to check dispatching. It is not a useful
-// implementation.
-template <typename T>
-auto tag_dispatch(ex::just_t, custom_type<T> c)
-{
-    c.tag_dispatch_overload_called = true;
-    return ex::just(c.x);
-}
-
 int main()
 {
     {
@@ -127,31 +118,6 @@ int main()
         auto os = ex::connect(std::move(s), std::move(r));
         ex::start(os);
         HPX_TEST(set_value_called);
-    }
-
-    {
-        std::atomic<bool> set_value_called{false};
-        std::atomic<bool> tag_dispatch_overload_called{false};
-        auto s = ex::just(custom_type<int>{tag_dispatch_overload_called, 3});
-        auto f = [](int x) { HPX_TEST_EQ(x, 3); };
-        auto r = callback_receiver<decltype(f)>{f, set_value_called};
-        auto os = ex::connect(std::move(s), std::move(r));
-        ex::start(os);
-        HPX_TEST(set_value_called);
-        HPX_TEST(tag_dispatch_overload_called);
-    }
-
-    {
-        std::atomic<bool> set_value_called{false};
-        std::atomic<bool> tag_dispatch_overload_called{false};
-        custom_type<int> c{tag_dispatch_overload_called, 3};
-        auto s = ex::just(c);
-        auto f = [](int x) { HPX_TEST_EQ(x, 3); };
-        auto r = callback_receiver<decltype(f)>{f, set_value_called};
-        auto os = ex::connect(std::move(s), std::move(r));
-        ex::start(os);
-        HPX_TEST(set_value_called);
-        HPX_TEST(tag_dispatch_overload_called);
     }
 
     return hpx::util::report_errors();

--- a/libs/core/execution/tests/unit/algorithm_transform.cpp
+++ b/libs/core/execution/tests/unit/algorithm_transform.cpp
@@ -66,11 +66,12 @@ int main()
 
     {
         std::atomic<bool> set_value_called{false};
-        auto s = ex::transform(
-            ex::just(custom_type_non_default_constructible{0}), [](auto x) {
-                ++(x.x);
-                return x;
-            });
+        auto s =
+            ex::transform(ex::just(custom_type_non_default_constructible{0}),
+                [](custom_type_non_default_constructible x) {
+                    ++(x.x);
+                    return x;
+                });
         auto f = [](auto x) { HPX_TEST_EQ(x.x, 1); };
         auto r = callback_receiver<decltype(f)>{f, set_value_called};
         auto os = ex::connect(std::move(s), std::move(r));
@@ -82,9 +83,9 @@ int main()
         std::atomic<bool> set_value_called{false};
         auto s = ex::transform(
             ex::just(custom_type_non_default_constructible_non_copyable{0}),
-            [](auto x) {
+            [](custom_type_non_default_constructible_non_copyable&& x) {
                 ++(x.x);
-                return x;
+                return std::move(x);
             });
         auto f = [](auto x) { HPX_TEST_EQ(x.x, 1); };
         auto r = callback_receiver<decltype(f)>{f, set_value_called};

--- a/libs/core/execution/tests/unit/algorithm_when_all.cpp
+++ b/libs/core/execution/tests/unit/algorithm_when_all.cpp
@@ -37,7 +37,7 @@ int main()
         auto f = [](int x) { HPX_TEST_EQ(x, 42); };
         auto r = callback_receiver<decltype(f)>{f, set_value_called};
         auto os = ex::connect(std::move(s), std::move(r));
-        ex::start(os);
+        tag_dispatch(ex::start, os);
         HPX_TEST(set_value_called);
     }
 

--- a/libs/core/execution_base/include/hpx/execution_base/operation_state.hpp
+++ b/libs/core/execution_base/include/hpx/execution_base/operation_state.hpp
@@ -7,7 +7,7 @@
 #pragma once
 
 #include <hpx/config/constexpr.hpp>
-#include <hpx/functional/tag_priority_dispatch.hpp>
+#include <hpx/functional/tag_dispatch.hpp>
 #include <hpx/functional/traits/is_invocable.hpp>
 
 #include <type_traits>
@@ -46,16 +46,8 @@ namespace hpx { namespace execution { namespace experimental {
     struct is_operation_state;
 
     HPX_HOST_DEVICE_INLINE_CONSTEXPR_VARIABLE
-    struct start_t : hpx::functional::tag_priority_noexcept<start_t>
+    struct start_t : hpx::functional::tag_noexcept<start_t>
     {
-    private:
-        template <typename OperationState>
-        friend constexpr HPX_FORCEINLINE auto tag_override_dispatch(
-            start_t, OperationState& o) noexcept(noexcept(o.start()))
-            -> decltype(o.start())
-        {
-            return o.start();
-        }
     } start{};
 
     namespace detail {

--- a/libs/core/execution_base/include/hpx/execution_base/receiver.hpp
+++ b/libs/core/execution_base/include/hpx/execution_base/receiver.hpp
@@ -8,7 +8,7 @@
 #pragma once
 
 #include <hpx/config/constexpr.hpp>
-#include <hpx/functional/tag_priority_dispatch.hpp>
+#include <hpx/functional/tag_dispatch.hpp>
 #include <hpx/functional/traits/is_invocable.hpp>
 
 #include <exception>
@@ -102,50 +102,18 @@ namespace hpx { namespace execution { namespace experimental {
     struct is_receiver_of;
 
     HPX_HOST_DEVICE_INLINE_CONSTEXPR_VARIABLE
-    struct set_value_t : hpx::functional::tag_priority<set_value_t>
+    struct set_value_t : hpx::functional::tag<set_value_t>
     {
-    private:
-        template <typename R, typename... Args>
-        friend constexpr HPX_FORCEINLINE auto tag_override_dispatch(
-            set_value_t, R&& r, Args&&... args)
-        // This does not compile with CUDA 11.4 (most recent at the moment)
-        // Removing the variadic ... makes it compile
-#if !defined(HPX_COMPUTE_DEVICE_CODE) || (HPX_CUDA_VERSION < 1104)
-            noexcept(noexcept(
-                std::forward<R>(r).set_value(std::forward<Args>(args)...)))
-#endif
-                -> decltype(
-                    std::forward<R>(r).set_value(std::forward<Args>(args)...))
-        {
-            return std::forward<R>(r).set_value(std::forward<Args>(args)...);
-        }
     } set_value{};
 
     HPX_HOST_DEVICE_INLINE_CONSTEXPR_VARIABLE
-    struct set_error_t : hpx::functional::tag_priority_noexcept<set_error_t>
+    struct set_error_t : hpx::functional::tag_noexcept<set_error_t>
     {
-    private:
-        template <typename R, typename E>
-        friend constexpr HPX_FORCEINLINE auto
-        tag_override_dispatch(set_error_t, R&& r, E&& e) noexcept(
-            noexcept(std::declval<R&&>().set_error(std::forward<E>(e))))
-            -> decltype(std::declval<R&&>().set_error(std::forward<E>(e)))
-        {
-            return std::forward<R>(r).set_error(std::forward<E>(e));
-        }
     } set_error{};
 
     HPX_HOST_DEVICE_INLINE_CONSTEXPR_VARIABLE
-    struct set_done_t : hpx::functional::tag_priority_noexcept<set_done_t>
+    struct set_done_t : hpx::functional::tag_noexcept<set_done_t>
     {
-    private:
-        template <typename R>
-        friend constexpr HPX_FORCEINLINE auto tag_override_dispatch(set_done_t,
-            R&& r) noexcept(noexcept(std::declval<R&&>().set_done()))
-            -> decltype(std::declval<R&&>().set_done())
-        {
-            return std::forward<R>(r).set_done();
-        }
     } set_done{};
 
     ///////////////////////////////////////////////////////////////////////

--- a/libs/core/execution_base/include/hpx/execution_base/sender.hpp
+++ b/libs/core/execution_base/include/hpx/execution_base/sender.hpp
@@ -10,7 +10,7 @@
 #include <hpx/execution_base/operation_state.hpp>
 #include <hpx/execution_base/receiver.hpp>
 #include <hpx/functional/invoke_result.hpp>
-#include <hpx/functional/tag_priority_dispatch.hpp>
+#include <hpx/functional/tag_dispatch.hpp>
 #include <hpx/functional/traits/is_invocable.hpp>
 #include <hpx/type_support/equality.hpp>
 
@@ -178,22 +178,8 @@ namespace hpx { namespace execution { namespace experimental {
     }    // namespace detail
 
     HPX_HOST_DEVICE_INLINE_CONSTEXPR_VARIABLE
-    struct connect_t : hpx::functional::tag_priority<connect_t>
+    struct connect_t : hpx::functional::tag<connect_t>
     {
-        template <typename S, typename R,
-            typename = std::enable_if_t<is_sender_v<S> && is_receiver_v<R>>>
-        friend constexpr HPX_FORCEINLINE auto
-        tag_override_dispatch(connect_t, S&& s, R&& r) noexcept(
-            noexcept(std::forward<S>(s).connect(std::forward<R>(r))))
-            -> decltype(std::forward<S>(s).connect(std::forward<R>(r)))
-        {
-            static_assert(is_operation_state_v<decltype(
-                              std::forward<S>(s).connect(std::forward<R>(r)))>,
-                "hpx::execution::experimental::connect needs to return a "
-                "type satisfying the operation_state concept");
-
-            return std::forward<S>(s).connect(std::forward<R>(r));
-        }
     } connect{};
 
     namespace detail {
@@ -250,17 +236,8 @@ namespace hpx { namespace execution { namespace experimental {
     }    // namespace detail
 
     HPX_HOST_DEVICE_INLINE_CONSTEXPR_VARIABLE
-    struct schedule_t : hpx::functional::tag_priority<schedule_t>
+    struct schedule_t : hpx::functional::tag<schedule_t>
     {
-        template <typename S,
-            typename = std::enable_if_t<is_sender_v<
-                std::decay_t<decltype(std::declval<S>().schedule())>>>>
-        friend constexpr HPX_FORCEINLINE auto tag_override_dispatch(
-            schedule_t, S&& s) noexcept(noexcept(std::forward<S>(s).schedule()))
-            -> decltype(std::forward<S>(s).schedule())
-        {
-            return std::forward<S>(s).schedule();
-        }
     } schedule{};
 
     namespace detail {

--- a/libs/core/execution_base/tests/unit/basic_operation_state.cpp
+++ b/libs/core/execution_base/tests/unit/basic_operation_state.cpp
@@ -21,12 +21,16 @@ namespace mylib {
 
     struct state_2
     {
-        void start();
+        friend void tag_dispatch(
+            hpx::execution::experimental::start_t, state_2&)
+        {
+        }
     };
 
     struct state_3
     {
-        void start() noexcept
+        friend void tag_dispatch(
+            hpx::execution::experimental::start_t, state_3&) noexcept
         {
             start_called = true;
         }
@@ -36,13 +40,13 @@ namespace mylib {
     {
     };
 
-    void tag_dispatch(hpx::execution::experimental::start_t, state_4) {}
+    void tag_dispatch(hpx::execution::experimental::start_t, state_4&) {}
 
     struct state_5
     {
     };
 
-    void tag_dispatch(hpx::execution::experimental::start_t, state_5) noexcept
+    void tag_dispatch(hpx::execution::experimental::start_t, state_5&) noexcept
     {
         start_called = true;
     }

--- a/libs/core/execution_base/tests/unit/basic_receiver.cpp
+++ b/libs/core/execution_base/tests/unit/basic_receiver.cpp
@@ -19,17 +19,20 @@ bool value_called = false;
 namespace mylib {
     struct receiver_1
     {
-        void set_done() noexcept
+        friend void tag_dispatch(
+            hpx::execution::experimental::set_done_t, receiver_1&&) noexcept
         {
             done_called = true;
         }
 
-        void set_error(std::exception_ptr) noexcept
+        friend void tag_dispatch(hpx::execution::experimental::set_error_t,
+            receiver_1&&, std::exception_ptr) noexcept
         {
             error_called = true;
         }
 
-        void set_value(int)
+        friend void tag_dispatch(
+            hpx::execution::experimental::set_value_t, receiver_1&&, int)
         {
             value_called = true;
         }
@@ -37,12 +40,14 @@ namespace mylib {
 
     struct receiver_2
     {
-        void set_done() noexcept
+        friend void tag_dispatch(
+            hpx::execution::experimental::set_done_t, receiver_2&&) noexcept
         {
             done_called = true;
         }
 
-        void set_error(int) noexcept
+        friend void tag_dispatch(hpx::execution::experimental::set_error_t,
+            receiver_2&&, int) noexcept
         {
             error_called = true;
         }
@@ -50,17 +55,20 @@ namespace mylib {
 
     struct receiver_3
     {
-        void set_done() noexcept
+        friend void tag_dispatch(
+            hpx::execution::experimental::set_done_t, receiver_3&&) noexcept
         {
             done_called = true;
         }
 
-        void set_error(std::exception_ptr) noexcept
+        friend void tag_dispatch(hpx::execution::experimental::set_error_t,
+            receiver_3&&, std::exception_ptr) noexcept
         {
             error_called = true;
         }
 
-        void set_value(int) noexcept
+        friend void tag_dispatch(
+            hpx::execution::experimental::set_value_t, receiver_3, int) noexcept
         {
             value_called = true;
         }
@@ -68,17 +76,20 @@ namespace mylib {
 
     struct non_receiver_1
     {
-        void set_done() & noexcept
+        friend void tag_dispatch(
+            hpx::execution::experimental::set_done_t, non_receiver_1&) noexcept
         {
             done_called = true;
         }
 
-        void set_error(std::exception_ptr) noexcept
+        friend void tag_dispatch(hpx::execution::experimental::set_error_t,
+            non_receiver_1&&, std::exception_ptr) noexcept
         {
             error_called = true;
         }
 
-        void set_value(int)
+        friend void tag_dispatch(hpx::execution::experimental::set_value_t,
+            non_receiver_1, int) noexcept
         {
             value_called = true;
         }
@@ -86,17 +97,20 @@ namespace mylib {
 
     struct non_receiver_2
     {
-        void set_done() noexcept
+        friend void tag_dispatch(
+            hpx::execution::experimental::set_done_t, non_receiver_2&&) noexcept
         {
             done_called = true;
         }
 
-        void set_error(std::exception_ptr) & noexcept
+        friend void tag_dispatch(hpx::execution::experimental::set_error_t,
+            non_receiver_2&, std::exception_ptr) noexcept
         {
             error_called = true;
         }
 
-        void set_value(int)
+        friend void tag_dispatch(hpx::execution::experimental::set_value_t,
+            non_receiver_2, int) noexcept
         {
             value_called = true;
         }
@@ -104,17 +118,20 @@ namespace mylib {
 
     struct non_receiver_3
     {
-        void set_done() & noexcept
+        friend void tag_dispatch(
+            hpx::execution::experimental::set_done_t, non_receiver_3&) noexcept
         {
             done_called = true;
         }
 
-        void set_error(std::exception_ptr) & noexcept
+        friend void tag_dispatch(hpx::execution::experimental::set_error_t,
+            non_receiver_3&, std::exception_ptr) noexcept
         {
             error_called = true;
         }
 
-        void set_value(int)
+        friend void tag_dispatch(hpx::execution::experimental::set_value_t,
+            non_receiver_3, int) noexcept
         {
             value_called = true;
         }
@@ -122,17 +139,20 @@ namespace mylib {
 
     struct non_receiver_4
     {
-        void set_done() noexcept
+        friend void tag_dispatch(
+            hpx::execution::experimental::set_done_t, non_receiver_4&&) noexcept
         {
             done_called = true;
         }
 
-        void set_error(std::exception_ptr) noexcept
+        friend void tag_dispatch(hpx::execution::experimental::set_error_t,
+            non_receiver_4&&, std::exception_ptr) noexcept
         {
             error_called = true;
         }
 
-        void set_value(int) &
+        friend void tag_dispatch(hpx::execution::experimental::set_value_t,
+            non_receiver_4&, int) noexcept
         {
             value_called = true;
         }
@@ -140,12 +160,14 @@ namespace mylib {
 
     struct non_receiver_5
     {
-        void set_done()
+        friend void tag_dispatch(
+            hpx::execution::experimental::set_done_t, non_receiver_5&&)
         {
             done_called = true;
         }
 
-        void set_error(std::exception_ptr) noexcept
+        friend void tag_dispatch(hpx::execution::experimental::set_error_t,
+            non_receiver_5&&, std::exception_ptr) noexcept
         {
             error_called = true;
         }
@@ -153,12 +175,14 @@ namespace mylib {
 
     struct non_receiver_6
     {
-        void set_done() noexcept
+        friend void tag_dispatch(
+            hpx::execution::experimental::set_done_t, non_receiver_6&&) noexcept
         {
             done_called = true;
         }
 
-        void set_error(std::exception_ptr)
+        friend void tag_dispatch(hpx::execution::experimental::set_error_t,
+            non_receiver_6&&, std::exception_ptr)
         {
             error_called = true;
         }
@@ -166,12 +190,14 @@ namespace mylib {
 
     struct non_receiver_7
     {
-        void set_done()
+        friend void tag_dispatch(
+            hpx::execution::experimental::set_done_t, non_receiver_7&&)
         {
             done_called = true;
         }
 
-        void set_error(std::exception_ptr)
+        friend void tag_dispatch(hpx::execution::experimental::set_error_t,
+            non_receiver_7&&, std::exception_ptr)
         {
             error_called = true;
         }

--- a/libs/core/executors/include/hpx/executors/thread_pool_scheduler.hpp
+++ b/libs/core/executors/include/hpx/executors/thread_pool_scheduler.hpp
@@ -218,22 +218,6 @@ namespace hpx { namespace execution { namespace experimental {
             }
         };
 
-        template <template <class...> class Tuple,
-            template <class...> class Variant>
-        using value_types = Variant<Tuple<>>;
-
-        template <template <class...> class Variant>
-        using error_types = Variant<std::exception_ptr>;
-
-        static constexpr bool sends_done = false;
-
-        template <typename Receiver>
-        operation_state<thread_pool_scheduler, Receiver> connect(
-            Receiver&& receiver) &&
-        {
-            return {*this, std::forward<Receiver>(receiver)};
-        }
-
         constexpr sender<thread_pool_scheduler> schedule() const
         {
             return {*this};

--- a/libs/core/executors/tests/unit/thread_pool_scheduler.cpp
+++ b/libs/core/executors/tests/unit/thread_pool_scheduler.cpp
@@ -103,25 +103,6 @@ void test_sender_receiver_basic()
     HPX_TEST(executed);
 }
 
-void test_sender_receiver_basic2()
-{
-    hpx::thread::id parent_id = hpx::this_thread::get_id();
-    hpx::lcos::local::mutex mtx;
-    hpx::lcos::local::condition_variable cond;
-    std::atomic<bool> executed{false};
-
-    auto os = ex::connect(ex::thread_pool_scheduler{},
-        check_context_receiver{parent_id, cond, executed});
-    ex::start(os);
-
-    {
-        std::unique_lock<hpx::lcos::local::mutex> l{mtx};
-        cond.wait(l, [&]() { return executed.load(); });
-    }
-
-    HPX_TEST(executed);
-}
-
 hpx::thread::id sender_receiver_transform_thread_id;
 
 void test_sender_receiver_transform()
@@ -1796,7 +1777,6 @@ int hpx_main()
 {
     test_execute();
     test_sender_receiver_basic();
-    test_sender_receiver_basic2();
     test_sender_receiver_transform();
     test_sender_receiver_transform_wait();
     test_sender_receiver_transform_sync_wait();


### PR DESCRIPTION
In P0443 member functions were given priority over free functions in the various CPOs. In P2300 tag_dispatch is the only way to implement various CPOs, i.e. member functions are not taken into account. This updates our execution CPOs to behave like P2300. This means that `schedule`, `set_value`, `set_error`, `set_done`, `start`, `connect` inherit `hpx::functional::tag`, not `hpx::functional::tag_priority`. This is slightly more verbose (`friend void tag_dispatch(start_t, ...)` instead of `void start(...)`) but is simpler to reason about. Additionally, the `thread_pool_scheduler` test compiles 10-15% faster with this change.

As a flyby I've:
- Removed the leftover scheduler is a sender functionality (i.e. one has to use `schedule(scheduler)` to get a sender; `thread_pool_scheduler` was previously a sender in itself)
- `just` is no longer a CPO (customization makes very little sense, this is aligned with P2300)
- `keep_future` is no longer a CPO (it only makes sense for futures)

Algorithms that have a reasonable default implementation still use `tag_fallback_dispatch` as before.

I think we should also revisit the `tag_dispatch`/`tag_invoke` question. The way we are now using `tag_dispatch` for the execution CPOs is really what `tag_invoke` is supposed to be. For the case of the segmented algorithms I believe we could put the dispatching one level down into the algorithm implementations as an internal implementation detail, but it should not use the "public" customization point.