### PR TITLE
Extend launch policy to carry stack size and scheduling hint in addition to priority

### DIFF
--- a/libs/core/async_base/CMakeLists.txt
+++ b/libs/core/async_base/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 The STE||AR-Group
+# Copyright (c) 2020-2021 The STE||AR-Group
 #
 # SPDX-License-Identifier: BSL-1.0
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -7,9 +7,13 @@
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 
 set(async_base_headers
-    hpx/async_base/apply.hpp hpx/async_base/async.hpp
-    hpx/async_base/dataflow.hpp hpx/async_base/launch_policy.hpp
-    hpx/async_base/sync.hpp hpx/async_base/traits/is_launch_policy.hpp
+    hpx/async_base/apply.hpp
+    hpx/async_base/async.hpp
+    hpx/async_base/dataflow.hpp
+    hpx/async_base/launch_policy.hpp
+    hpx/async_base/sync.hpp
+    hpx/async_base/traits/is_launch_policy.hpp
+    hpx/async_base/scheduling_properties.hpp
 )
 
 set(async_base_sources launch_policy.cpp)
@@ -29,5 +33,6 @@ add_hpx_module(
   COMPAT_HEADERS ${async_base_compat_headers}
   SOURCES ${async_base_sources}
   MODULE_DEPENDENCIES hpx_allocator_support hpx_config hpx_coroutines
+                      hpx_tag_dispatch
   CMAKE_SUBDIRS examples tests
 )

--- a/libs/core/async_base/include/hpx/async_base/scheduling_properties.hpp
+++ b/libs/core/async_base/include/hpx/async_base/scheduling_properties.hpp
@@ -1,0 +1,82 @@
+//  Copyright (c) 2020 ETH Zurich
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include <hpx/config.hpp>
+#include <hpx/functional/tag_fallback_dispatch.hpp>
+
+namespace hpx { namespace execution { namespace experimental {
+
+    namespace detail {
+
+        template <typename Tag, typename... Args>
+        struct property_not_supported
+        {
+            static_assert(sizeof(Tag) == 0,
+                "The given property (Tag) is not supported on the given type "
+                "(first type in Args). Ensure that you are including the "
+                "correct headers if the property is supported. Alternatively, "
+                "implement support for the property by overloading "
+                "tag_dispatch for the given property and type. If the property "
+                "is not required, you can use prefer to fall back to the "
+                "identity transformation when a property is not supported.");
+        };
+
+        template <typename Tag>
+        struct property_base : hpx::functional::tag_fallback<Tag>
+        {
+        private:
+            // attempt to improve error messages if property is not supported
+            template <typename... Args>
+            friend HPX_FORCEINLINE decltype(auto) tag_fallback_dispatch(
+                Tag, Args&&... /*args*/)
+            {
+                return property_not_supported<Tag, Args...>{};
+            }
+        };
+    }    // namespace detail
+
+    HPX_INLINE_CONSTEXPR_VARIABLE struct with_priority_t final
+      : detail::property_base<with_priority_t>
+    {
+    } with_priority{};
+
+    HPX_INLINE_CONSTEXPR_VARIABLE struct get_priority_t final
+      : detail::property_base<get_priority_t>
+    {
+    } get_priority{};
+
+    HPX_INLINE_CONSTEXPR_VARIABLE struct with_stacksize_t final
+      : detail::property_base<with_stacksize_t>
+    {
+    } with_stacksize{};
+
+    HPX_INLINE_CONSTEXPR_VARIABLE struct get_stacksize_t final
+      : detail::property_base<get_stacksize_t>
+    {
+    } get_stacksize{};
+
+    HPX_INLINE_CONSTEXPR_VARIABLE struct with_hint_t final
+      : detail::property_base<with_hint_t>
+    {
+    } with_hint{};
+
+    HPX_INLINE_CONSTEXPR_VARIABLE struct get_hint_t final
+      : detail::property_base<get_hint_t>
+    {
+    } get_hint{};
+
+    HPX_INLINE_CONSTEXPR_VARIABLE struct with_annotation_t final
+      : detail::property_base<with_annotation_t>
+    {
+    } with_annotation{};
+
+    HPX_INLINE_CONSTEXPR_VARIABLE struct get_annotation_t final
+      : detail::property_base<get_annotation_t>
+    {
+    } get_annotation{};
+}}}    // namespace hpx::execution::experimental

--- a/libs/core/async_base/include/hpx/async_base/traits/is_launch_policy.hpp
+++ b/libs/core/async_base/include/hpx/async_base/traits/is_launch_policy.hpp
@@ -7,9 +7,14 @@
 #pragma once
 
 #include <hpx/config.hpp>
-#include <hpx/async_base/launch_policy.hpp>
 
 #include <type_traits>
+
+namespace hpx { namespace detail {
+
+    // forward declaration only
+    struct policy_holder_base;
+}}    // namespace hpx::detail
 
 namespace hpx { namespace traits {
 

--- a/libs/core/async_base/src/launch_policy.cpp
+++ b/libs/core/async_base/src/launch_policy.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2017 Hartmut Kaiser
+//  Copyright (c) 2007-2021 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -6,6 +6,7 @@
 
 #include <hpx/config.hpp>
 #include <hpx/async_base/launch_policy.hpp>
+#include <hpx/coroutines/thread_enums.hpp>
 #include <hpx/serialization/input_archive.hpp>
 #include <hpx/serialization/output_archive.hpp>
 #include <hpx/serialization/serialize.hpp>
@@ -39,19 +40,27 @@ namespace hpx {
             // clang-format off
             ar & value;
             policy_ = static_cast<launch_policy>(value);
+
             ar & value;
-            // clang-format on
             priority_ = static_cast<threads::thread_priority>(value);
+
+            ar & hint_.hint & value;
+            hint_.mode = static_cast<threads::thread_schedule_hint_mode>(value);
+            // clang-format on
         }
 
         void policy_holder_base::save(
             serialization::output_archive& ar, unsigned) const
         {
-            int value = static_cast<int>(policy_);
             // clang-format off
+            int value = static_cast<int>(policy_);
             ar & value;
+
             value = static_cast<int>(priority_);
             ar & value;
+
+            value = static_cast<int>(hint_.mode);
+            ar & value & hint_.hint;
             // clang-format on
         }
     }    // namespace detail

--- a/libs/core/async_base/tests/unit/CMakeLists.txt
+++ b/libs/core/async_base/tests/unit/CMakeLists.txt
@@ -1,5 +1,24 @@
-# Copyright (c) 2020 The STE||AR-Group
+# Copyright (c) 2021 Hartmut Kaiser
 #
 # SPDX-License-Identifier: BSL-1.0
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+set(tests launch_policy)
+
+foreach(test ${tests})
+  set(sources ${test}.cpp)
+
+  source_group("Source Files" FILES ${sources})
+
+  set(folder_name "Tests/Unit/Modules/Parallelism/AsyncBase")
+
+  add_hpx_executable(
+    ${test}_test INTERNAL_FLAGS
+    SOURCES ${sources} ${${test}_FLAGS}
+    EXCLUDE_FROM_ALL
+    FOLDER ${folder_name}
+  )
+
+  add_hpx_unit_test("modules.async_base" ${test} ${${test}_PARAMETERS})
+endforeach()

--- a/libs/core/async_base/tests/unit/launch_policy.cpp
+++ b/libs/core/async_base/tests/unit/launch_policy.cpp
@@ -1,0 +1,75 @@
+//  Copyright (c) 2021 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/config.hpp>
+#include <hpx/hpx_main.hpp>
+#include <hpx/modules/async_base.hpp>
+#include <hpx/modules/coroutines.hpp>
+#include <hpx/modules/testing.hpp>
+
+#include <cstdint>
+
+///////////////////////////////////////////////////////////////////////////////
+template <typename Launch>
+void test_policy(Launch policy)
+{
+    HPX_TEST(policy.priority() == hpx::threads::thread_priority::default_);
+    HPX_TEST(policy.stacksize() == hpx::threads::thread_stacksize::default_);
+    HPX_TEST(
+        policy.hint().mode == hpx::threads::thread_schedule_hint_mode::none);
+    HPX_TEST_EQ(policy.hint().hint, std::int16_t(-1));
+
+    policy.set_priority(hpx::threads::thread_priority::normal);
+    HPX_TEST(policy.priority() == hpx::threads::thread_priority::normal);
+
+    auto p = hpx::execution::experimental::with_priority(
+        policy, hpx::threads::thread_priority::high);
+    HPX_TEST(hpx::execution::experimental::get_priority(p) ==
+        hpx::threads::thread_priority::high);
+
+    policy.set_stacksize(hpx::threads::thread_stacksize::medium);
+    HPX_TEST(policy.stacksize() == hpx::threads::thread_stacksize::medium);
+
+    auto p1 = hpx::execution::experimental::with_stacksize(
+        policy, hpx::threads::thread_stacksize::small_);
+    HPX_TEST(hpx::execution::experimental::get_stacksize(p1) ==
+        hpx::threads::thread_stacksize::small_);
+
+    hpx::threads::thread_schedule_hint hint(0);
+    policy.set_hint(hint);
+    HPX_TEST(policy.hint().mode == hint.mode);
+    HPX_TEST_EQ(policy.hint().hint, hint.hint);
+
+    hpx::threads::thread_schedule_hint hint1(1);
+    auto p2 = hpx::execution::experimental::with_hint(policy, hint1);
+    HPX_TEST(hpx::execution::experimental::get_hint(p2).mode == hint1.mode);
+    HPX_TEST(hpx::execution::experimental::get_hint(p2).hint == hint1.hint);
+}
+
+int main()
+{
+    static_assert(sizeof(hpx::launch::async_policy) <= sizeof(std::int64_t));
+    static_assert(sizeof(hpx::launch::sync_policy) <= sizeof(std::int64_t));
+    static_assert(sizeof(hpx::launch::deferred_policy) <= sizeof(std::int64_t));
+    static_assert(sizeof(hpx::launch::fork_policy) <= sizeof(std::int64_t));
+    static_assert(sizeof(hpx::launch::apply_policy) <= sizeof(std::int64_t));
+    static_assert(sizeof(hpx::launch) <= sizeof(std::int64_t));
+
+    test_policy(hpx::launch::async);
+    test_policy(hpx::launch::sync);
+    test_policy(hpx::launch::deferred);
+    test_policy(hpx::launch::fork);
+    test_policy(hpx::launch::apply);
+
+    test_policy(hpx::launch());
+    test_policy(hpx::launch(hpx::launch::async));
+    test_policy(hpx::launch(hpx::launch::sync));
+    test_policy(hpx::launch(hpx::launch::deferred));
+    test_policy(hpx::launch(hpx::launch::fork));
+    test_policy(hpx::launch(hpx::launch::apply));
+
+    return 0;
+}

--- a/libs/core/coroutines/include/hpx/coroutines/thread_enums.hpp
+++ b/libs/core/coroutines/include/hpx/coroutines/thread_enums.hpp
@@ -24,7 +24,7 @@ namespace hpx { namespace threads {
     ///
     /// The \a thread_schedule_state enumerator encodes the current state of a
     /// \a thread instance
-    enum class thread_schedule_state
+    enum class thread_schedule_state : std::int8_t
     {
         unknown = 0,
         active = 1,                   /*!< thread is currently active (running,
@@ -106,7 +106,7 @@ namespace hpx { namespace threads {
 
     /// This enumeration lists all possible thread-priorities for HPX threads.
     ///
-    enum class thread_priority
+    enum class thread_priority : std::int8_t
     {
         unknown = -1,
         default_ = 0, /*!< Will assign the priority of the
@@ -192,7 +192,7 @@ namespace hpx { namespace threads {
     ///
     /// The \a thread_restart_state enumerator encodes the reason why a
     /// thread is being restarted
-    enum class thread_restart_state
+    enum class thread_restart_state : std::int8_t
     {
         unknown = 0,
         signaled = 1,     ///< The thread has been signaled
@@ -247,7 +247,7 @@ namespace hpx { namespace threads {
     ///
     /// A \a thread_stacksize references any of the possible stack-sizes for
     /// HPX threads.
-    enum class thread_stacksize
+    enum class thread_stacksize : std::int8_t
     {
         unknown = -1,
         small_ = 1,     ///< use small stack size (the underscore is to work
@@ -316,7 +316,7 @@ namespace hpx { namespace threads {
     /// \enum thread_schedule_hint_mode
     ///
     /// The type of hint given when creating new tasks.
-    enum class thread_schedule_hint_mode : std::int16_t
+    enum class thread_schedule_hint_mode : std::int8_t
     {
         /// A hint that leaves the choice of scheduling entirely up to the
         /// scheduler.
@@ -365,16 +365,17 @@ namespace hpx { namespace threads {
     {
         /// Construct a default hint with mode thread_schedule_hint_mode::none.
         constexpr thread_schedule_hint() noexcept
-          : mode(thread_schedule_hint_mode::none)
-          , hint(-1)
+          : hint(-1)
+          , mode(thread_schedule_hint_mode::none)
         {
         }
 
         /// Construct a hint with mode thread_schedule_hint_mode::thread and the
         /// given hint as the local thread number.
-        constexpr explicit thread_schedule_hint(std::int16_t thread_hint)
-          : mode(thread_schedule_hint_mode::thread)
-          , hint(thread_hint)
+        constexpr explicit thread_schedule_hint(
+            std::int16_t thread_hint) noexcept
+          : hint(thread_hint)
+          , mode(thread_schedule_hint_mode::thread)
         {
         }
 
@@ -382,8 +383,8 @@ namespace hpx { namespace threads {
         /// unused when the mode is thread_schedule_hint_mode::none.
         constexpr thread_schedule_hint(
             thread_schedule_hint_mode mode, std::int16_t hint) noexcept
-          : mode(mode)
-          , hint(hint)
+          : hint(hint)
+          , mode(mode)
         {
         }
 
@@ -399,10 +400,11 @@ namespace hpx { namespace threads {
         }
         /// \endcond
 
-        /// The mode of the scheduling hint.
-        thread_schedule_hint_mode mode;
         /// The hint associated with the mode. The interepretation of this hint
         /// depends on the given mode.
         std::int16_t hint;
+
+        /// The mode of the scheduling hint.
+        thread_schedule_hint_mode mode;
     };
 }}    // namespace hpx::threads

--- a/libs/core/execution/include/hpx/execution/detail/async_launch_policy_dispatch.hpp
+++ b/libs/core/execution/include/hpx/execution/detail/async_launch_policy_dispatch.hpp
@@ -68,9 +68,7 @@ namespace hpx { namespace detail {
             traits::detail::is_deferred_invocable_v<F, Ts...>,
             hpx::future<util::detail::invoke_deferred_result_t<F, Ts...>>>
         call(launch policy, hpx::util::thread_description const& desc,
-            threads::thread_pool_base* pool, threads::thread_priority priority,
-            threads::thread_stacksize stacksize,
-            threads::thread_schedule_hint hint, F&& f, Ts&&... ts)
+            threads::thread_pool_base* pool, F&& f, Ts&&... ts)
         {
             using result_type =
                 util::detail::invoke_deferred_result_t<F, Ts...>;
@@ -85,8 +83,8 @@ namespace hpx { namespace detail {
                 std::forward<F>(f), std::forward<Ts>(ts)...));
             if (hpx::detail::has_async_policy(policy))
             {
-                threads::thread_id_ref_type tid = p.apply(pool,
-                    desc.get_description(), policy, priority, stacksize, hint);
+                threads::thread_id_ref_type tid =
+                    p.apply(pool, desc.get_description(), policy);
                 if (tid)
                 {
                     if (policy == launch::fork)
@@ -111,14 +109,12 @@ namespace hpx { namespace detail {
         HPX_FORCEINLINE static std::enable_if_t<
             traits::detail::is_deferred_invocable_v<F, Ts...>,
             hpx::future<util::detail::invoke_deferred_result_t<F, Ts...>>>
-        call(launch policy, hpx::util::thread_description const& desc,
-            threads::thread_priority priority,
-            threads::thread_stacksize stacksize,
-            threads::thread_schedule_hint hint, F&& f, Ts&&... ts)
+        call(launch policy, hpx::util::thread_description const& desc, F&& f,
+            Ts&&... ts)
         {
             return call(policy, desc,
-                threads::detail::get_self_or_default_pool(), priority,
-                stacksize, hint, std::forward<F>(f), std::forward<Ts>(ts)...);
+                threads::detail::get_self_or_default_pool(), std::forward<F>(f),
+                std::forward<Ts>(ts)...);
         }
 
         template <typename F, typename... Ts>
@@ -129,9 +125,7 @@ namespace hpx { namespace detail {
         {
             hpx::util::thread_description desc(f);
             return call(policy, desc,
-                threads::detail::get_self_or_default_pool(), policy.priority(),
-                threads::thread_stacksize::default_,
-                threads::thread_schedule_hint{}, std::forward<F>(f),
+                threads::detail::get_self_or_default_pool(), std::forward<F>(f),
                 std::forward<Ts>(ts)...);
         }
 
@@ -151,9 +145,7 @@ namespace hpx { namespace detail {
             hpx::future<util::detail::invoke_deferred_result_t<F, Ts...>>>
         call(hpx::detail::async_policy policy,
             hpx::util::thread_description const& desc,
-            threads::thread_pool_base* pool, threads::thread_priority priority,
-            threads::thread_stacksize stacksize,
-            threads::thread_schedule_hint hint, F&& f, Ts&&... ts)
+            threads::thread_pool_base* pool, F&& f, Ts&&... ts)
         {
             HPX_ASSERT(pool);
 
@@ -163,8 +155,8 @@ namespace hpx { namespace detail {
             lcos::local::futures_factory<result_type()> p(util::deferred_call(
                 std::forward<F>(f), std::forward<Ts>(ts)...));
 
-            threads::thread_id_ref_type tid = p.apply(pool,
-                desc.get_description(), policy, priority, stacksize, hint);
+            threads::thread_id_ref_type tid =
+                p.apply(pool, desc.get_description(), policy);
 
             if (tid)
             {
@@ -185,10 +177,7 @@ namespace hpx { namespace detail {
         {
             hpx::util::thread_description desc(f);
             return call(policy, desc,
-                threads::detail::get_self_or_default_pool(),
-                threads::thread_priority::default_,
-                threads::thread_stacksize::default_,
-                threads::thread_schedule_hint{}, std::forward<F>(f),
+                threads::detail::get_self_or_default_pool(), std::forward<F>(f),
                 std::forward<Ts>(ts)...);
         }
 
@@ -198,9 +187,7 @@ namespace hpx { namespace detail {
             hpx::future<util::detail::invoke_deferred_result_t<F, Ts...>>>
         call(hpx::detail::fork_policy policy,
             hpx::util::thread_description const& desc,
-            threads::thread_pool_base* pool, threads::thread_priority priority,
-            threads::thread_stacksize stacksize,
-            threads::thread_schedule_hint hint, F&& f, Ts&&... ts)
+            threads::thread_pool_base* pool, F&& f, Ts&&... ts)
         {
             HPX_ASSERT(pool);
 
@@ -210,8 +197,8 @@ namespace hpx { namespace detail {
             lcos::local::futures_factory<result_type()> p(util::deferred_call(
                 std::forward<F>(f), std::forward<Ts>(ts)...));
 
-            threads::thread_id_ref_type tid = p.apply(pool,
-                desc.get_description(), policy, priority, stacksize, hint);
+            threads::thread_id_ref_type tid =
+                p.apply(pool, desc.get_description(), policy);
 
             // make sure this thread is executed last
             threads::thread_id_type tid_self = threads::get_self_id();
@@ -241,10 +228,7 @@ namespace hpx { namespace detail {
         {
             hpx::util::thread_description desc(f);
             return call(policy, desc,
-                threads::detail::get_self_or_default_pool(),
-                threads::thread_priority::default_,
-                threads::thread_stacksize::default_,
-                threads::thread_schedule_hint{}, std::forward<F>(f),
+                threads::detail::get_self_or_default_pool(), std::forward<F>(f),
                 std::forward<Ts>(ts)...);
         }
 

--- a/libs/core/execution/include/hpx/execution/executors/execution_parameters.hpp
+++ b/libs/core/execution/include/hpx/execution/executors/execution_parameters.hpp
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <hpx/config.hpp>
+#include <hpx/async_base/scheduling_properties.hpp>
 #include <hpx/async_base/traits/is_launch_policy.hpp>
 #include <hpx/concepts/has_member_xxx.hpp>
 #include <hpx/execution/detail/execution_parameter_callbacks.hpp>
@@ -808,75 +809,3 @@ namespace hpx { namespace parallel { namespace execution {
         return std::forward<Param>(param);
     }
 }}}    // namespace hpx::parallel::execution
-
-namespace hpx { namespace execution { namespace experimental {
-
-    namespace detail {
-
-        template <typename Tag, typename... Args>
-        struct property_not_supported
-        {
-            static_assert(sizeof(Tag) == 0,
-                "The given property (Tag) is not supported on the given type "
-                "(first type in Args). Ensure that you are including the "
-                "correct headers if the property is supported. Alternatively, "
-                "implement support for the property by overloading "
-                "tag_dispatch for the given property and type. If the property "
-                "is not required, you can use prefer to fall back to the "
-                "identity transformation when a property is not supported.");
-        };
-
-        template <typename Tag>
-        struct property_base : hpx::functional::tag_fallback<Tag>
-        {
-        private:
-            // attempt to improve error messages if property is not supported
-            template <typename... Args>
-            friend HPX_FORCEINLINE decltype(auto) tag_fallback_dispatch(
-                Tag, Args&&... /*args*/)
-            {
-                return property_not_supported<Tag, Args...>{};
-            }
-        };
-    }    // namespace detail
-
-    HPX_INLINE_CONSTEXPR_VARIABLE struct with_priority_t final
-      : detail::property_base<with_priority_t>
-    {
-    } with_priority{};
-
-    HPX_INLINE_CONSTEXPR_VARIABLE struct get_priority_t final
-      : detail::property_base<get_priority_t>
-    {
-    } get_priority{};
-
-    HPX_INLINE_CONSTEXPR_VARIABLE struct with_stacksize_t final
-      : detail::property_base<with_stacksize_t>
-    {
-    } with_stacksize{};
-
-    HPX_INLINE_CONSTEXPR_VARIABLE struct get_stacksize_t final
-      : detail::property_base<get_stacksize_t>
-    {
-    } get_stacksize{};
-
-    HPX_INLINE_CONSTEXPR_VARIABLE struct with_hint_t final
-      : detail::property_base<with_hint_t>
-    {
-    } with_hint{};
-
-    HPX_INLINE_CONSTEXPR_VARIABLE struct get_hint_t final
-      : detail::property_base<get_hint_t>
-    {
-    } get_hint{};
-
-    HPX_INLINE_CONSTEXPR_VARIABLE struct with_annotation_t final
-      : detail::property_base<with_annotation_t>
-    {
-    } with_annotation{};
-
-    HPX_INLINE_CONSTEXPR_VARIABLE struct get_annotation_t final
-      : detail::property_base<get_annotation_t>
-    {
-    } get_annotation{};
-}}}    // namespace hpx::execution::experimental

--- a/libs/core/executors/include/hpx/executors/fork_join_executor.hpp
+++ b/libs/core/executors/include/hpx/executors/fork_join_executor.hpp
@@ -234,11 +234,13 @@ namespace hpx { namespace execution { namespace experimental {
 
                     thread_states_[t].data_ = thread_state::starting;
                     hpx::util::thread_description desc("fork_join_executor");
-                    threads::thread_schedule_hint hint{
-                        static_cast<std::int16_t>(t)};
+
+                    auto policy = launch::async_policy(priority_, stacksize_,
+                        threads::thread_schedule_hint{
+                            static_cast<std::int16_t>(t)});
+
                     hpx::detail::async_launch_policy_dispatch<
-                        launch::async_policy>::call(launch::async, desc, pool_,
-                        priority_, stacksize_, hint,
+                        launch::async_policy>::call(policy, desc, pool_,
                         thread_function{num_threads_, t, schedule_,
                             thread_states_[t].data_, exception_mutex_,
                             exception_, yield_delay_, thread_function_helper_,

--- a/libs/core/executors/include/hpx/executors/guided_pool_executor.hpp
+++ b/libs/core/executors/include/hpx/executors/guided_pool_executor.hpp
@@ -130,19 +130,22 @@ namespace hpx { namespace parallel { namespace execution {
                 if (hp_sync_ &&
                     executor_.priority_ == hpx::threads::thread_priority::high)
                 {
-                    p.apply(executor_.pool_, "guided async", hpx::launch::sync,
-                        executor_.priority_, executor_.stacksize_,
-                        hpx::threads::thread_schedule_hint(
-                            hpx::threads::thread_schedule_hint_mode::numa,
-                            domain));
+                    p.apply(executor_.pool_, "guided sync",
+                        hpx::launch::sync_policy(
+                            hpx::threads::thread_priority::high,
+                            executor_.stacksize_,
+                            hpx::threads::thread_schedule_hint(
+                                hpx::threads::thread_schedule_hint_mode::numa,
+                                domain)));
                 }
                 else
                 {
-                    p.apply(executor_.pool_, "guided async", hpx::launch::async,
-                        executor_.priority_, executor_.stacksize_,
-                        hpx::threads::thread_schedule_hint(
-                            hpx::threads::thread_schedule_hint_mode::numa,
-                            domain));
+                    p.apply(executor_.pool_, "guided async",
+                        hpx::launch::async_policy(executor_.priority_,
+                            executor_.stacksize_,
+                            hpx::threads::thread_schedule_hint(
+                                hpx::threads::thread_schedule_hint_mode::numa,
+                                domain)));
                 }
 
                 return p.get_future();
@@ -188,19 +191,22 @@ namespace hpx { namespace parallel { namespace execution {
                 if (hp_sync_ &&
                     executor_.priority_ == hpx::threads::thread_priority::high)
                 {
-                    p.apply(executor_.pool_, "guided then", hpx::launch::sync,
-                        executor_.priority_, executor_.stacksize_,
-                        hpx::threads::thread_schedule_hint(
-                            hpx::threads::thread_schedule_hint_mode::numa,
-                            domain));
+                    p.apply(executor_.pool_, "guided then",
+                        hpx::launch::sync_policy(
+                            hpx::threads::thread_priority::high,
+                            executor_.stacksize_,
+                            hpx::threads::thread_schedule_hint(
+                                hpx::threads::thread_schedule_hint_mode::numa,
+                                domain)));
                 }
                 else
                 {
-                    p.apply(executor_.pool_, "guided then", hpx::launch::async,
-                        executor_.priority_, executor_.stacksize_,
-                        hpx::threads::thread_schedule_hint(
-                            hpx::threads::thread_schedule_hint_mode::numa,
-                            domain));
+                    p.apply(executor_.pool_, "guided then",
+                        hpx::launch::async_policy(executor_.priority_,
+                            executor_.stacksize_,
+                            hpx::threads::thread_schedule_hint(
+                                hpx::threads::thread_schedule_hint_mode::numa,
+                                domain)));
                 }
 
                 return p.get_future();
@@ -476,17 +482,20 @@ namespace hpx { namespace parallel { namespace execution {
 
             if (hp_sync_ && priority_ == hpx::threads::thread_priority::high)
             {
-                p.apply(pool_, "guided async", hpx::launch::sync, priority_,
-                    stacksize_,
-                    hpx::threads::thread_schedule_hint(
-                        hpx::threads::thread_schedule_hint_mode::numa, domain));
+                p.apply(pool_, "guided async",
+                    hpx::launch::sync_policy(
+                        hpx::threads::thread_priority::high, stacksize_,
+                        hpx::threads::thread_schedule_hint(
+                            hpx::threads::thread_schedule_hint_mode::numa,
+                            domain)));
             }
             else
             {
-                p.apply(pool_, "guided async", hpx::launch::async, priority_,
-                    stacksize_,
-                    hpx::threads::thread_schedule_hint(
-                        hpx::threads::thread_schedule_hint_mode::numa, domain));
+                p.apply(pool_, "guided async",
+                    hpx::launch::async_policy(priority_, stacksize_,
+                        hpx::threads::thread_schedule_hint(
+                            hpx::threads::thread_schedule_hint_mode::numa,
+                            domain)));
             }
             return p.get_future();
         }
@@ -550,9 +559,10 @@ namespace hpx { namespace parallel { namespace execution {
                 lcos::local::futures_factory<result_type()> p(
                     hpx::util::deferred_call(
                         std::forward<F>(f), std::forward<Ts>(ts)...));
-                p.apply(guided_exec_.pool_, "guided async", hpx::launch::async,
-                    guided_exec_.priority_, guided_exec_.stacksize_,
-                    hpx::threads::thread_schedule_hint());
+
+                p.apply(guided_exec_.pool_, "guided async",
+                    hpx::launch::async_policy(
+                        guided_exec_.priority_, guided_exec_.stacksize_));
                 return p.get_future();
             }
         }

--- a/libs/core/futures/include/hpx/futures/detail/future_data.hpp
+++ b/libs/core/futures/include/hpx/futures/detail/future_data.hpp
@@ -869,9 +869,7 @@ namespace hpx { namespace lcos { namespace detail {
         // run in a separate thread
         virtual threads::thread_id_ref_type apply(
             threads::thread_pool_base* /*pool*/, const char* /*annotation*/,
-            launch /*policy*/, threads::thread_priority /*priority*/,
-            threads::thread_stacksize /*stacksize*/,
-            threads::thread_schedule_hint /*schedulehint*/, error_code& /*ec*/)
+            launch /*policy*/, error_code& /*ec*/)
         {
             HPX_ASSERT(false);    // shouldn't ever be called
             return threads::invalid_thread_id;

--- a/libs/core/futures/src/future_data.cpp
+++ b/libs/core/futures/src/future_data.cpp
@@ -62,11 +62,12 @@ namespace hpx { namespace lcos { namespace detail {
         if (!is_hpx_thread)
             policy = launch::async;
 
+        policy.set_priority(threads::thread_priority::boost);
+        policy.set_stacksize(threads::thread_stacksize::current);
+
         // launch a new thread executing the given function
-        threads::thread_id_ref_type tid = p.apply(
-            "run_on_completed_on_new_thread", policy,
-            threads::thread_priority::boost, threads::thread_stacksize::current,
-            threads::thread_schedule_hint());
+        threads::thread_id_ref_type tid =
+            p.apply("run_on_completed_on_new_thread", policy);
 
         // wait for the task to run
         if (is_hpx_thread)

--- a/libs/core/properties/CMakeLists.txt
+++ b/libs/core/properties/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2020 The STE||AR-Group
+# Copyright (c) 2019-2021 The STE||AR-Group
 #
 # SPDX-License-Identifier: BSL-1.0
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -13,6 +13,6 @@ add_hpx_module(
   core properties
   GLOBAL_HEADER_GEN ON
   HEADERS ${properties_headers}
-  DEPENDENCIES hpx_functional
+  DEPENDENCIES hpx_tag_dispatch
   CMAKE_SUBDIRS examples tests
 )

--- a/libs/core/runtime_local/src/custom_exception_info.cpp
+++ b/libs/core/runtime_local/src/custom_exception_info.cpp
@@ -190,10 +190,10 @@ namespace hpx { namespace util {
 
         error_code ec(lightweight);
         threads::thread_id_ref_type tid =
-            p.apply("hpx::util::trace_on_new_stack", launch::fork,
-                threads::thread_priority::default_,
-                threads::thread_stacksize::medium,
-                threads::thread_schedule_hint(), ec);
+            p.apply("hpx::util::trace_on_new_stack",
+                launch::fork_policy(threads::thread_priority::default_,
+                    threads::thread_stacksize::medium),
+                ec);
         if (ec)
             return "<couldn't retrieve stack backtrace>";
 


### PR DESCRIPTION
This PR extends `hpx::launch` and related types (i.e. `hpx::launch::async`, etc.) such that they contain the scheduling hint and the stack size in addition to the thread priority.

This will be needed for the direct scoped execution to be able to control whether threads should be executed directly or not. This also simplifies a couple of internal interfaces.

As a flyby, this PR changes all thread enums to be of size `std::int8_t`, which allows for the launch policy to fit into a 64 bit register.
