### PR TITLE
Remove wrong move in thread_pool_scheduler_bulk.hpp

### DIFF
--- a/libs/parallelism/executors/include/hpx/executors/thread_pool_scheduler_bulk.hpp
+++ b/libs/parallelism/executors/include/hpx/executors/thread_pool_scheduler_bulk.hpp
@@ -180,7 +180,7 @@ namespace hpx { namespace execution { namespace experimental {
                              it != std::end(op_state->shape); ++it)
                         {
                             auto task_f = [op_state = this->op_state,
-                                              it = std::move(it)]() mutable {
+                                              it]() mutable {
                                 try
                                 {
                                     hpx::visit(


### PR DESCRIPTION
The iterator should be copied, not moved. libstdc++ reported this with `_GLIBCXX_DEBUG` defined. I've opened https://github.com/STEllAR-GROUP/hpx/issues/5544 to remind us to get back to enabling it in CI.