### PR TITLE
Fixing shutdown problems caused by missing ref-counting

### DIFF
--- a/components/iostreams/include/hpx/components/iostreams/server/output_stream.hpp
+++ b/components/iostreams/include/hpx/components/iostreams/server/output_stream.hpp
@@ -44,7 +44,7 @@ namespace hpx { namespace iostreams { namespace server
         void call_write_async(std::uint32_t locality_id, std::uint64_t count,
             detail::buffer const& in, hpx::id_type /*this_id*/);
         void call_write_sync(std::uint32_t locality_id, std::uint64_t count,
-            detail::buffer const& in, threads::thread_id_type caller);
+            detail::buffer const& in, threads::thread_id_ref_type caller);
 
     public:
         explicit output_stream(write_function_type write_f_ = write_function_type())

--- a/components/iostreams/src/standard_streams.cpp
+++ b/components/iostreams/src/standard_streams.cpp
@@ -1,5 +1,5 @@
 //  Copyright (c) 2011 Bryce Lelbach
-//  Copyright (c) 2011-2016 Hartmut Kaiser
+//  Copyright (c) 2011-2021 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -7,6 +7,7 @@
 
 #include <hpx/config.hpp>
 #include <hpx/actions_base/plain_action.hpp>
+#include <hpx/async_base/launch_policy.hpp>
 #include <hpx/async_distributed/base_lco_with_value.hpp>
 #include <hpx/components_base/agas_interface.hpp>
 #include <hpx/components_base/server/component.hpp>
@@ -66,7 +67,7 @@ namespace hpx { namespace iostreams { namespace detail
                 naming::id_type::managed);
 
             return agas::register_name(cout_name, cout_id).then(
-                util::bind_back(&return_id_type, cout_id));
+                hpx::launch::sync, util::bind_back(&return_id_type, cout_id));
         }
 
         // the console locality will create the ostream during startup

--- a/libs/core/thread_pools/include/hpx/thread_pools/scheduled_thread_pool_impl.hpp
+++ b/libs/core/thread_pools/include/hpx/thread_pools/scheduled_thread_pool_impl.hpp
@@ -194,6 +194,7 @@ namespace hpx { namespace threads { namespace detail {
                 hpx_thread_offset;
         bool have_polling_work =
             sched_->Scheduler::get_polling_work_count() > 0;
+
         return have_hpx_threads || have_polling_work;
     }
 

--- a/libs/core/threading_base/src/set_thread_state.cpp
+++ b/libs/core/threading_base/src/set_thread_state.cpp
@@ -25,7 +25,7 @@
 namespace hpx { namespace threads { namespace detail {
 
     ///////////////////////////////////////////////////////////////////////////
-    thread_result_type set_active_state(thread_id_type const& thrd,
+    thread_result_type set_active_state(thread_id_ref_type thrd,
         thread_schedule_state newstate, thread_restart_state newstate_ex,
         thread_priority priority, thread_state previous_state)
     {
@@ -59,7 +59,7 @@ namespace hpx { namespace threads { namespace detail {
 
         // just retry, set_state will create new thread if target is still active
         error_code ec(lightweight);    // do not throw
-        detail::set_thread_state(thrd, newstate, newstate_ex, priority,
+        detail::set_thread_state(thrd.noref(), newstate, newstate_ex, priority,
             thread_schedule_hint(), true, ec);
 
         return thread_result_type(
@@ -134,8 +134,8 @@ namespace hpx { namespace threads { namespace detail {
                         get_thread_state_name(new_state));
 
                     thread_init_data data(
-                        util::bind(&set_active_state, thrd, new_state,
-                            new_state_ex, priority, previous_state),
+                        util::bind(&set_active_state, thread_id_ref_type(thrd),
+                            new_state, new_state_ex, priority, previous_state),
                         "set state for active thread", priority);
 
                     create_work(get_thread_id_data(thrd)->get_scheduler_base(),

--- a/libs/full/runtime_distributed/src/server/runtime_support_server.cpp
+++ b/libs/full/runtime_distributed/src/server/runtime_support_server.cpp
@@ -633,7 +633,7 @@ namespace hpx { namespace components { namespace server {
                     },
                     shutdown_check_count,
                     std::chrono::duration<double>(timeout),
-                    "runtime_support::stop", false);
+                    "runtime_support::stop");
 
                 // If it took longer than expected, kill all suspended threads as
                 // well.
@@ -648,7 +648,7 @@ namespace hpx { namespace components { namespace server {
                         },
                         shutdown_check_count,
                         std::chrono::duration<double>(timeout),
-                        "runtime_support::dijkstra_termination", false);
+                        "runtime_support::stop");
                     HPX_UNUSED(success);
                 }
 


### PR DESCRIPTION
- flyby: handle terminate threads while waiting for activities to cease
