### PR TITLE
Make sure command line aliasing is properly handled

### DIFF
--- a/libs/core/command_line_handling_local/include/hpx/command_line_handling_local/parse_command_line_local.hpp
+++ b/libs/core/command_line_handling_local/include/hpx/command_line_handling_local/parse_command_line_local.hpp
@@ -22,6 +22,7 @@ namespace hpx {
             return_on_error,
             rethrow_on_error,
             allow_unregistered,
+            ignore_aliases = 0x40,
             report_missing_config_file = 0x80
         };
 

--- a/libs/core/command_line_handling_local/tests/regressions/CMakeLists.txt
+++ b/libs/core/command_line_handling_local/tests/regressions/CMakeLists.txt
@@ -1,5 +1,29 @@
-# Copyright (c) 2020 The STE||AR-Group
+# Copyright (c) 2021 The STE||AR-Group
 #
 # SPDX-License-Identifier: BSL-1.0
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+set(tests ignore_aliases_local)
+
+set(ignore_aliases_local_PARAMETERS "-wobble=1")
+
+foreach(test ${tests})
+  set(sources ${test}.cpp)
+
+  set(${test}_PARAMETERS ${${test}_PARAMETERS} THREADS_PER_LOCALITY 4)
+
+  source_group("Source Files" FILES ${sources})
+
+  add_hpx_executable(
+    ${test}_test INTERNAL_FLAGS
+    SOURCES ${sources} ${${test}_FLAGS}
+    EXCLUDE_FROM_ALL
+    HPX_PREFIX ${HPX_BUILD_PREFIX}
+    FOLDER "Tests/Regressions/Modules/Full/CommandLineHandlingLocal"
+  )
+
+  add_hpx_regression_test(
+    "modules.command_line_handling_local" ${test} ${${test}_PARAMETERS}
+  )
+endforeach()

--- a/libs/core/command_line_handling_local/tests/regressions/ignore_aliases_local.cpp
+++ b/libs/core/command_line_handling_local/tests/regressions/ignore_aliases_local.cpp
@@ -1,0 +1,37 @@
+//  Copyright (c) 2021 Nanmiao Wu
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/config.hpp>
+#include <hpx/local/init.hpp>
+#include <hpx/modules/testing.hpp>
+
+#include <string>
+#include <vector>
+
+///////////////////////////////////////////////////////////////////////////////
+int hpx_main(int argc, char* argv[])
+{
+    HPX_TEST_EQ(argc, 2);
+    HPX_TEST_EQ(std::string(argv[1]), std::string("-wobble=1"));
+
+    return hpx::local::finalize();
+}
+///////////////////////////////////////////////////////////////////////////////
+int main(int argc, char* argv[])
+{
+    // pass unknown command line option that would conflict with predefined
+    // alias (-w)
+    std::vector<std::string> const cfg = {
+        "--hpx:ini=hpx.commandline.allow_unknown!=1",
+        "--hpx:ini=hpx.commandline.aliasing!=0"};
+
+    hpx::local::init_params init_args;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ(hpx::local::init(hpx_main, argc, argv, init_args), 0);
+
+    return hpx::util::report_errors();
+}

--- a/libs/full/command_line_handling/src/command_line_handling.cpp
+++ b/libs/full/command_line_handling/src/command_line_handling.cpp
@@ -1567,7 +1567,8 @@ namespace hpx { namespace util {
             // command line handling.
             hpx::program_options::variables_map prevm;
             if (!util::parse_commandline(rtcfg_, desc_cmdline, argv[0], args,
-                    prevm, std::size_t(-1), error_mode, rtcfg_.mode_))
+                    prevm, std::size_t(-1), error_mode | util::ignore_aliases,
+                    rtcfg_.mode_))
             {
                 return -1;
             }

--- a/libs/full/command_line_handling/tests/regressions/CMakeLists.txt
+++ b/libs/full/command_line_handling/tests/regressions/CMakeLists.txt
@@ -4,16 +4,18 @@
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-set(tests late_commandline_options_5257 options_as_config_3339
+set(tests ignore_aliases late_commandline_options_5257 options_as_config_3339
           use_all_cores_2262
 )
 
 set(tests ${tests} configuration_1572)
 
+set(ignore_aliases_PARAMETERS "-wobble=1")
+
 foreach(test ${tests})
   set(sources ${test}.cpp)
 
-  set(${test}_PARAMETERS THREADS_PER_LOCALITY 4)
+  set(${test}_PARAMETERS ${${test}_PARAMETERS} THREADS_PER_LOCALITY 4)
 
   source_group("Source Files" FILES ${sources})
 

--- a/libs/full/command_line_handling/tests/regressions/ignore_aliases.cpp
+++ b/libs/full/command_line_handling/tests/regressions/ignore_aliases.cpp
@@ -1,0 +1,37 @@
+//  Copyright (c) 2021 Nanmiao Wu
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/config.hpp>
+#include <hpx/hpx_init.hpp>
+#include <hpx/modules/testing.hpp>
+
+#include <string>
+#include <vector>
+
+///////////////////////////////////////////////////////////////////////////////
+int hpx_main(int argc, char* argv[])
+{
+    HPX_TEST_EQ(argc, 2);
+    HPX_TEST_EQ(std::string(argv[1]), std::string("-wobble=1"));
+
+    return hpx::finalize();
+}
+///////////////////////////////////////////////////////////////////////////////
+int main(int argc, char* argv[])
+{
+    // pass unknown command line option that would conflict with predefined
+    // alias (-w)
+    std::vector<std::string> const cfg = {
+        "--hpx:ini=hpx.commandline.allow_unknown!=1",
+        "--hpx:ini=hpx.commandline.aliasing!=0"};
+
+    hpx::init_params init_args;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ(hpx::init(argc, argv, init_args), 0);
+
+    return hpx::util::report_errors();
+}


### PR DESCRIPTION
If `--hpx:ini=hpx.commandline.aliasing!=0` and `--hpx:ini=hpx.commandline.allow_unknown!=1` were given on the command line, HPX still tried to apply aliases while interpreting non-HPX options. This patch fixes the issue by ignoring aliases during the first attempt to parse the command line arguments.
