### PR TITLE
Add option enabling serializing raw pointers

### DIFF
--- a/libs/core/serialization/CMakeLists.txt
+++ b/libs/core/serialization/CMakeLists.txt
@@ -36,6 +36,23 @@ if(HPX_SERIALIZATION_WITH_ALL_TYPES_ARE_BITWISE_SERIALIZABLE)
   )
 endif()
 
+# This flag can be used in systems that rely on sending raw pointers to other
+# localities (assuming those are being sent back to the originating locality
+# before they are dereferenced (like SHAD).
+hpx_option(
+  HPX_SERIALIZATION_WITH_ALLOW_RAW_POINTER_SERIALIZATION BOOL
+  "Enable serializing raw pointers. (default: OFF)" OFF ADVANCED
+  CATEGORY "Modules"
+  MODULE SERIALIZATION
+)
+
+if(HPX_SERIALIZATION_WITH_ALLOW_RAW_POINTER_SERIALIZATION)
+  hpx_add_config_define_namespace(
+    DEFINE HPX_SERIALIZATION_HAVE_ALLOW_RAW_POINTER_SERIALIZATION
+    NAMESPACE SERIALIZATION
+  )
+endif()
+
 # Default location is $HPX_ROOT/libs/serialization/include
 set(serialization_headers
     hpx/serialization.hpp

--- a/libs/core/serialization/CMakeLists.txt
+++ b/libs/core/serialization/CMakeLists.txt
@@ -6,7 +6,7 @@
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 
-# Compatibility with using Boost.FileSystem, introduced in V1.4.0
+# Compatibility with various Boost types, introduced in V1.4.0
 hpx_option(
   HPX_SERIALIZATION_WITH_BOOST_TYPES BOOL
   "Enable serialization of certain Boost types. (default: ON)" ON ADVANCED
@@ -19,6 +19,21 @@ if(HPX_SERIALIZATION_WITH_BOOST_TYPES)
     DEFINE HPX_SERIALIZATION_HAVE_BOOST_TYPES NAMESPACE SERIALIZATION
   )
 endif()
+
+# cmake-format: off
+#
+# Important note: The following flags are specific for using HPX as a
+# backend for SHAD (https://github.com/pnnl/SHAD):
+#
+# - HPX_SERIALIZATION_WITH_ALL_TYPES_ARE_BITWISE_SERIALIZABLE
+# - HPX_SERIALIZATION_WITH_ALLOW_RAW_POINTER_SERIALIZATION
+# - HPX_SERIALIZATION_WITH_ALLOW_CONST_TUPLE_MEMBERS
+#
+# They all enable questionable functionalities, partially they even enable
+# undefined behavior. Please only use any of them if you know what you're
+# doing.
+#
+# cmake-format: on
 
 # This flag can be used in systems that assume that all types are bitwise
 # serializable by default (like SHAD).
@@ -49,6 +64,23 @@ hpx_option(
 if(HPX_SERIALIZATION_WITH_ALLOW_RAW_POINTER_SERIALIZATION)
   hpx_add_config_define_namespace(
     DEFINE HPX_SERIALIZATION_HAVE_ALLOW_RAW_POINTER_SERIALIZATION
+    NAMESPACE SERIALIZATION
+  )
+endif()
+
+# This flag can be used in systems that rely on sending constant values as part
+# of std::tuple. This option essentially casts away constness for tuple members.
+hpx_option(
+  HPX_SERIALIZATION_WITH_ALLOW_CONST_TUPLE_MEMBERS BOOL
+  "Enable serializing std::tuple with const members. (default: OFF)" OFF
+  ADVANCED
+  CATEGORY "Modules"
+  MODULE SERIALIZATION
+)
+
+if(HPX_SERIALIZATION_WITH_ALLOW_CONST_TUPLE_MEMBERS)
+  hpx_add_config_define_namespace(
+    DEFINE HPX_SERIALIZATION_HAVE_ALLOW_CONST_TUPLE_MEMBERS
     NAMESPACE SERIALIZATION
   )
 endif()

--- a/libs/core/serialization/include/hpx/serialization/basic_archive.hpp
+++ b/libs/core/serialization/include/hpx/serialization/basic_archive.hpp
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <hpx/config.hpp>
+#include <hpx/serialization/config/defines.hpp>
 #include <hpx/assert.hpp>
 #include <hpx/serialization/detail/extra_archive_data.hpp>
 
@@ -67,10 +68,11 @@ namespace hpx { namespace serialization {
         template <typename T>
         void invoke(T& t)
         {
+#if !defined(HPX_SERIALIZATION_HAVE_ALLOW_RAW_POINTER_SERIALIZATION)
             static_assert(!std::is_pointer<T>::value,
                 "HPX does not support serialization of raw pointers. "
                 "Please use smart pointers.");
-
+#endif
             static_cast<Archive*>(this)->invoke_impl(t);
         }
 

--- a/libs/core/serialization/include/hpx/serialization/input_archive.hpp
+++ b/libs/core/serialization/include/hpx/serialization/input_archive.hpp
@@ -9,6 +9,7 @@
 
 #include <hpx/config.hpp>
 #include <hpx/config/endian.hpp>
+#include <hpx/serialization/config/defines.hpp>
 #include <hpx/assert.hpp>
 #include <hpx/serialization/basic_archive.hpp>
 #include <hpx/serialization/detail/polymorphic_nonintrusive_factory.hpp>
@@ -109,6 +110,14 @@ namespace hpx { namespace serialization {
             load_binary(&b, sizeof(bool));
             HPX_ASSERT(0 == static_cast<int>(b) || 1 == static_cast<int>(b));
         }
+
+#if defined(HPX_SERIALIZATION_HAVE_ALLOW_RAW_POINTER_SERIALIZATION)
+        template <typename T>
+        void load(T*& p)
+        {
+            load_binary(&p, sizeof(std::size_t));
+        }
+#endif
 
         std::size_t bytes_read() const
         {

--- a/libs/core/serialization/include/hpx/serialization/output_archive.hpp
+++ b/libs/core/serialization/include/hpx/serialization/output_archive.hpp
@@ -9,6 +9,7 @@
 
 #include <hpx/config.hpp>
 #include <hpx/config/endian.hpp>
+#include <hpx/serialization/config/defines.hpp>
 #include <hpx/assert.hpp>
 #include <hpx/serialization/basic_archive.hpp>
 #include <hpx/serialization/detail/polymorphic_nonintrusive_factory.hpp>
@@ -216,6 +217,14 @@ namespace hpx { namespace serialization {
             HPX_ASSERT(0 == static_cast<int>(b) || 1 == static_cast<int>(b));
             save_binary(&b, sizeof(bool));
         }
+
+#if defined(HPX_SERIALIZATION_HAVE_ALLOW_RAW_POINTER_SERIALIZATION)
+        template <typename T>
+        void save(T* p)
+        {
+            save_binary(&p, sizeof(std::size_t));
+        }
+#endif
 
         template <typename T>
         void save_bitwise(T const& t, std::false_type)

--- a/libs/core/serialization/include/hpx/serialization/serialization_fwd.hpp
+++ b/libs/core/serialization/include/hpx/serialization/serialization_fwd.hpp
@@ -56,7 +56,7 @@ namespace hpx { namespace serialization {
     HPX_FORCEINLINE void serialize(                                            \
         hpx::serialization::output_archive& ar, T& t, unsigned)                \
     {                                                                          \
-        save(ar, const_cast<std::add_const<T>::type&>(t), 0);                  \
+        save(ar, const_cast<std::add_const_t<T>&>(t), 0);                      \
     }                                                                          \
     /**/
 
@@ -71,9 +71,7 @@ namespace hpx { namespace serialization {
     HPX_FORCEINLINE void serialize(hpx::serialization::output_archive& ar,     \
         HPX_PP_STRIP_PARENS(ARGS) & t, unsigned)                               \
     {                                                                          \
-        save(ar,                                                               \
-            const_cast<                                                        \
-                typename std::add_const<HPX_PP_STRIP_PARENS(ARGS)>::type&>(t), \
+        save(ar, const_cast<std::add_const_t<HPX_PP_STRIP_PARENS(ARGS)>&>(t),  \
             0);                                                                \
     }                                                                          \
     /**/

--- a/libs/core/serialization/include/hpx/serialization/std_tuple.hpp
+++ b/libs/core/serialization/include/hpx/serialization/std_tuple.hpp
@@ -49,7 +49,14 @@ namespace hpx { namespace serialization {
         {
             static void call(Archive& ar, std::tuple<Ts...>& t, unsigned int)
             {
+#if !defined(HPX_SERIALIZATION_HAVE_ALLOW_CONST_TUPLE_MEMBERS)
                 int const _sequencer[] = {((ar & std::get<Is>(t)), 0)...};
+#else
+                int const _sequencer[] = {
+                    ((ar &
+                         const_cast<std::remove_const_t<Ts>&>(std::get<Is>(t))),
+                        0)...};
+#endif
                 (void) _sequencer;
             }
         };

--- a/libs/core/serialization/include/hpx/serialization/traits/is_bitwise_serializable.hpp
+++ b/libs/core/serialization/include/hpx/serialization/traits/is_bitwise_serializable.hpp
@@ -12,10 +12,19 @@
 
 namespace hpx { namespace traits {
 
+#if !defined(HPX_SERIALIZATION_HAVE_ALLOW_RAW_POINTER_SERIALIZATION)
     template <typename T>
     struct is_bitwise_serializable : std::is_arithmetic<T>
     {
     };
+#else
+    template <typename T>
+    struct is_bitwise_serializable
+      : std::integral_constant<bool,
+            std::is_arithmetic<T>::value || std::is_pointer<T>::value>
+    {
+    };
+#endif
 
     template <typename T>
     HPX_INLINE_CONSTEXPR_VARIABLE bool is_bitwise_serializable_v =

--- a/libs/core/serialization/include/hpx/serialization/tuple.hpp
+++ b/libs/core/serialization/include/hpx/serialization/tuple.hpp
@@ -58,7 +58,13 @@ namespace hpx { namespace util { namespace detail {
         template <typename T>
         static void call(Archive& ar, T& t, unsigned int)
         {
-            int const _sequencer[] = {((ar & hpx::get<Is>(t)), 0)...};
+#if !defined(HPX_SERIALIZATION_HAVE_ALLOW_CONST_TUPLE_MEMBERS)
+            int const _sequencer[] = {((ar & std::get<Is>(t)), 0)...};
+#else
+            int const _sequencer[] = {
+                ((ar & const_cast<std::remove_const_t<Ts>&>(std::get<Is>(t))),
+                    0)...};
+#endif
             (void) _sequencer;
         }
     };
@@ -89,8 +95,16 @@ namespace hpx { namespace util { namespace detail {
 
         static void call(Archive& ar, hpx::tuple<Ts...>& t, unsigned int)
         {
+#if !defined(HPX_SERIALIZATION_HAVE_ALLOW_CONST_TUPLE_MEMBERS)
             int const _sequencer[] = {
                 (load_element(ar, hpx::get<Is>(t)), 0)...};
+#else
+            int const _sequencer[] = {
+                (load_element(
+                     ar, const_cast<std::remove_const_t<Ts>&>(hpx::get<Is>(t))),
+                    0)...};
+#endif
+
             (void) _sequencer;
         }
     };

--- a/libs/core/serialization/tests/unit/CMakeLists.txt
+++ b/libs/core/serialization/tests/unit/CMakeLists.txt
@@ -31,7 +31,7 @@ if(HPX_SERIALIZATION_WITH_BOOST_TYPES)
 endif()
 
 set(full_tests any_serialization not_bitwise_serializable serializable_any
-               serializable_boost_any
+               serializable_boost_any serialization_raw_pointer
 )
 
 add_subdirectory(polymorphic)

--- a/libs/core/serialization/tests/unit/serialization_raw_pointer.cpp
+++ b/libs/core/serialization/tests/unit/serialization_raw_pointer.cpp
@@ -1,0 +1,113 @@
+//  Copyright (c) 2021 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+// enforce pointers being serializable
+#define HPX_SERIALIZATION_HAVE_ALLOW_RAW_POINTER_SERIALIZATION
+
+#include <hpx/config.hpp>
+#include <hpx/datastructures/tuple.hpp>
+#include <hpx/local/init.hpp>
+#include <hpx/serialization/input_archive.hpp>
+#include <hpx/serialization/output_archive.hpp>
+#include <hpx/serialization/serialize.hpp>
+#include <hpx/serialization/std_tuple.hpp>
+#include <hpx/serialization/tuple.hpp>
+
+#include <hpx/modules/testing.hpp>
+
+#include <cstddef>
+#include <string>
+#include <tuple>
+#include <vector>
+
+int hpx_main()
+{
+    // serialize raw pointer
+    {
+        static_assert(hpx::traits::is_bitwise_serializable_v<int*>);
+
+        int value = 42;
+        int* outp = &value;
+
+        std::vector<char> buffer;
+        std::vector<hpx::serialization::serialization_chunk> chunks;
+        hpx::serialization::output_archive oarchive(buffer, 0, &chunks);
+        oarchive << outp;
+        std::size_t size = oarchive.bytes_written();
+
+        hpx::serialization::input_archive iarchive(buffer, size, &chunks);
+        int* inp = nullptr;
+        iarchive >> inp;
+        HPX_TEST(outp == inp);
+    }
+
+    // serialize raw pointer
+    {
+        static_assert(hpx::traits::is_bitwise_serializable_v<int const*>);
+
+        int value = 42;
+        int const* outp = &value;
+
+        std::vector<char> buffer;
+        std::vector<hpx::serialization::serialization_chunk> chunks;
+        hpx::serialization::output_archive oarchive(buffer, 0, &chunks);
+        oarchive << outp;
+        std::size_t size = oarchive.bytes_written();
+
+        hpx::serialization::input_archive iarchive(buffer, size, &chunks);
+        int const* inp = nullptr;
+        iarchive >> inp;
+        HPX_TEST(outp == inp);
+    }
+
+    // serialize raw pointer as part of tuple
+    {
+        static_assert(hpx::traits::is_bitwise_serializable_v<
+            hpx::tuple<int*, int const>>);
+
+        int value = 42;
+        hpx::tuple<int*, int const> ot{&value, value};
+
+        std::vector<char> buffer;
+        std::vector<hpx::serialization::serialization_chunk> chunks;
+        hpx::serialization::output_archive oarchive(buffer, 0, &chunks);
+        oarchive << ot;
+        std::size_t size = oarchive.bytes_written();
+
+        hpx::serialization::input_archive iarchive(buffer, size, &chunks);
+        hpx::tuple<int*, int const> it{nullptr, 0};
+        iarchive >> it;
+        HPX_TEST(ot == it);
+    }
+
+    // serialize raw pointer as part of std::tuple
+    {
+        static_assert(hpx::traits::is_bitwise_serializable_v<
+            hpx::tuple<int*, int const>>);
+
+        int value = 42;
+        std::tuple<int*, int const> ot{&value, value};
+
+        std::vector<char> buffer;
+        std::vector<hpx::serialization::serialization_chunk> chunks;
+        hpx::serialization::output_archive oarchive(buffer, 0, &chunks);
+        oarchive << ot;
+        std::size_t size = oarchive.bytes_written();
+
+        hpx::serialization::input_archive iarchive(buffer, size, &chunks);
+        std::tuple<int*, int const> it{nullptr, 0};
+        iarchive >> it;
+        HPX_TEST(ot == it);
+    }
+
+    return hpx::local::finalize();
+}
+
+int main(int argc, char* argv[])
+{
+    hpx::local::init(hpx_main, argc, argv);
+    return hpx::util::report_errors();
+}

--- a/libs/full/actions_base/include/hpx/actions_base/basic_action.hpp
+++ b/libs/full/actions_base/include/hpx/actions_base/basic_action.hpp
@@ -218,9 +218,11 @@ namespace hpx { namespace actions {
         typename Derived>
     struct basic_action<Component, R(Args...), Derived>
     {
+#if !defined(HPX_SERIALIZATION_HAVE_ALLOW_RAW_POINTER_SERIALIZATION)
         // Flag the use of raw pointer types as action arguments
         static_assert(!util::any_of<std::is_pointer<Args>...>::value,
             "Using raw pointers as arguments for actions is not supported.");
+#endif
 
         // Flag the use of array types as action arguments
         static_assert(


### PR DESCRIPTION
- This functionality is needed for systems that rely on sending pointers to other localities just to send them back before they are being dereferenced.

@NanmiaoWu Could you please try adding the `-DHPX_SERIALIZATION_WITH_ALLOW_RAW_POINTER_SERIALIZATION=On` to your setup and see whether this solves the SHAD compilation problems?