### PR TITLE
More changes to overcome build problems on Windows after recent module rearrangements

### DIFF
--- a/libs/core/mpi_base/include/hpx/mpi_base/mpi_environment.hpp
+++ b/libs/core/mpi_base/include/hpx/mpi_base/mpi_environment.hpp
@@ -41,7 +41,7 @@ namespace hpx { namespace util {
 
         static std::string get_processor_name();
 
-        struct scoped_lock
+        struct HPX_CORE_EXPORT scoped_lock
         {
             scoped_lock();
             scoped_lock(scoped_lock const&) = delete;
@@ -50,7 +50,7 @@ namespace hpx { namespace util {
             void unlock();
         };
 
-        struct scoped_try_lock
+        struct HPX_CORE_EXPORT scoped_try_lock
         {
             scoped_try_lock();
             scoped_try_lock(scoped_try_lock const&) = delete;

--- a/libs/core/runtime_configuration/CMakeLists.txt
+++ b/libs/core/runtime_configuration/CMakeLists.txt
@@ -21,22 +21,24 @@ set(runtime_configuration_headers
 )
 
 # cmake-format: off
-set(runtime_configuration_compat_headers
-    hpx/util/ini.hpp => hpx/modules/runtime_configuration.hpp
-    hpx/util/init_ini_data.hpp => hpx/modules/runtime_configuration.hpp
-    hpx/util/register_locks_globally.hpp => hpx/modules/runtime_configuration.hpp
-    hpx/util/runtime_configuration.hpp => hpx/modules/runtime_configuration.hpp
-    hpx/plugins/plugin_registry_base.hpp => hpx/modules/runtime_configuration.hpp
-    hpx/runtime/components/component_commandline_base.hpp => hpx/modules/runtime_configuration.hpp
-    hpx/runtime/components/component_factory_base.hpp => hpx/modules/runtime_configuration.hpp
-    hpx/runtime/components/component_registry_base.hpp => hpx/modules/runtime_configuration.hpp
-    hpx/runtime/components/static_factory_data.hpp => hpx/modules/runtime_configuration.hpp
-    hpx/runtime/runtime_mode.hpp => hpx/modules/runtime_configuration.hpp
+set(
+  runtime_configuration_compat_headers
+  hpx/util/ini.hpp => hpx/modules/runtime_configuration.hpp
+  hpx/util/init_ini_data.hpp => hpx/modules/runtime_configuration.hpp
+  hpx/util/register_locks_globally.hpp => hpx/modules/runtime_configuration.hpp
+  hpx/util/runtime_configuration.hpp => hpx/modules/runtime_configuration.hpp
+  hpx/plugins/plugin_registry_base.hpp => hpx/modules/runtime_configuration.hpp
+  hpx/runtime/components/component_commandline_base.hpp => hpx/modules/runtime_configuration.hpp
+  hpx/runtime/components/component_factory_base.hpp => hpx/modules/runtime_configuration.hpp
+  hpx/runtime/components/component_registry_base.hpp => hpx/modules/runtime_configuration.hpp
+  hpx/runtime/components/static_factory_data.hpp => hpx/modules/runtime_configuration.hpp
+  hpx/runtime/runtime_mode.hpp => hpx/modules/runtime_configuration.hpp
 )
 # cmake-format: on
 
-set(runtime_configuration_sources init_ini_data.cpp register_locks_globally.cpp
-                                  runtime_configuration.cpp runtime_mode.cpp
+set(runtime_configuration_sources
+    init_ini_data.cpp register_locks_globally.cpp runtime_configuration.cpp
+    runtime_mode.cpp static_factory_data.cpp
 )
 
 include(HPX_AddModule)

--- a/libs/core/runtime_configuration/include/hpx/runtime_configuration/static_factory_data.hpp
+++ b/libs/core/runtime_configuration/include/hpx/runtime_configuration/static_factory_data.hpp
@@ -25,12 +25,27 @@ namespace hpx { namespace components {
         hpx::util::plugin::get_plugins_list_type get_factory;
     };
 
-    HPX_EXPORT void init_registry_module(static_factory_load_data_type const&);
-    HPX_EXPORT void init_registry_factory(static_factory_load_data_type const&);
-    HPX_EXPORT void init_registry_commandline(
-        static_factory_load_data_type const&);
-    HPX_EXPORT void init_registry_startup_shutdown(
-        static_factory_load_data_type const&);
+    HPX_CORE_EXPORT bool& get_initial_static_loading();
+
+    HPX_CORE_EXPORT std::vector<static_factory_load_data_type>&
+    get_static_module_data();
+    HPX_CORE_EXPORT
+    void init_registry_module(static_factory_load_data_type const&);
+
+    HPX_CORE_EXPORT bool get_static_factory(
+        std::string const& instance, util::plugin::get_plugins_list_type& f);
+    HPX_CORE_EXPORT
+    void init_registry_factory(static_factory_load_data_type const&);
+
+    HPX_CORE_EXPORT bool get_static_commandline(
+        std::string const& instance, util::plugin::get_plugins_list_type& f);
+    HPX_CORE_EXPORT
+    void init_registry_commandline(static_factory_load_data_type const&);
+
+    HPX_CORE_EXPORT bool get_static_startup_shutdown(
+        std::string const& instance, util::plugin::get_plugins_list_type& f);
+    HPX_CORE_EXPORT
+    void init_registry_startup_shutdown(static_factory_load_data_type const&);
 }}    // namespace hpx::components
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/libs/core/runtime_configuration/include/hpx/runtime_configuration/static_factory_data.hpp
+++ b/libs/core/runtime_configuration/include/hpx/runtime_configuration/static_factory_data.hpp
@@ -25,13 +25,11 @@ namespace hpx { namespace components {
         hpx::util::plugin::get_plugins_list_type get_factory;
     };
 
-    HPX_CORE_EXPORT void init_registry_module(
+    HPX_EXPORT void init_registry_module(static_factory_load_data_type const&);
+    HPX_EXPORT void init_registry_factory(static_factory_load_data_type const&);
+    HPX_EXPORT void init_registry_commandline(
         static_factory_load_data_type const&);
-    HPX_CORE_EXPORT void init_registry_factory(
-        static_factory_load_data_type const&);
-    HPX_CORE_EXPORT void init_registry_commandline(
-        static_factory_load_data_type const&);
-    HPX_CORE_EXPORT void init_registry_startup_shutdown(
+    HPX_EXPORT void init_registry_startup_shutdown(
         static_factory_load_data_type const&);
 }}    // namespace hpx::components
 

--- a/libs/core/runtime_configuration/src/static_factory_data.cpp
+++ b/libs/core/runtime_configuration/src/static_factory_data.cpp
@@ -1,0 +1,130 @@
+//  Copyright (c) 2005-2014 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/runtime_configuration/static_factory_data.hpp>
+
+#include <map>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace hpx { namespace components {
+    bool& get_initial_static_loading()
+    {
+        static bool initial_static_loading = true;
+        return initial_static_loading;
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    // There is no need to protect these global from thread concurrent access
+    // as they are access during early startup only.
+    std::vector<static_factory_load_data_type>& get_static_module_data()
+    {
+        static std::vector<static_factory_load_data_type>
+            global_module_init_data;
+        return global_module_init_data;
+    }
+
+    void init_registry_module(static_factory_load_data_type const& data)
+    {
+        if (get_initial_static_loading())
+            get_static_module_data().push_back(data);
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    std::map<std::string, util::plugin::get_plugins_list_type>&
+    get_static_factory_data()
+    {
+        static std::map<std::string, util::plugin::get_plugins_list_type>
+            global_factory_init_data;
+        return global_factory_init_data;
+    }
+
+    void init_registry_factory(static_factory_load_data_type const& data)
+    {
+        if (get_initial_static_loading())
+            get_static_factory_data().insert(
+                std::make_pair(data.name, data.get_factory));
+    }
+
+    bool get_static_factory(
+        std::string const& instance, util::plugin::get_plugins_list_type& f)
+    {
+        typedef std::map<std::string, util::plugin::get_plugins_list_type>
+            map_type;
+
+        map_type const& m = get_static_factory_data();
+        map_type::const_iterator it = m.find(instance);
+        if (it == m.end())
+            return false;
+
+        f = it->second;
+        return true;
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    std::map<std::string, util::plugin::get_plugins_list_type>&
+    get_static_commandline_data()
+    {
+        static std::map<std::string, util::plugin::get_plugins_list_type>
+            global_commandline_init_data;
+        return global_commandline_init_data;
+    }
+
+    void init_registry_commandline(static_factory_load_data_type const& data)
+    {
+        if (get_initial_static_loading())
+            get_static_commandline_data().insert(
+                std::make_pair(data.name, data.get_factory));
+    }
+
+    bool get_static_commandline(
+        std::string const& instance, util::plugin::get_plugins_list_type& f)
+    {
+        typedef std::map<std::string, util::plugin::get_plugins_list_type>
+            map_type;
+
+        map_type const& m = get_static_commandline_data();
+        map_type::const_iterator it = m.find(instance);
+        if (it == m.end())
+            return false;
+
+        f = it->second;
+        return true;
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    std::map<std::string, util::plugin::get_plugins_list_type>&
+    get_static_startup_shutdown_data()
+    {
+        static std::map<std::string, util::plugin::get_plugins_list_type>
+            global_startup_shutdown_init_data;
+        return global_startup_shutdown_init_data;
+    }
+
+    void init_registry_startup_shutdown(
+        static_factory_load_data_type const& data)
+    {
+        if (get_initial_static_loading())
+            get_static_startup_shutdown_data().insert(
+                std::make_pair(data.name, data.get_factory));
+    }
+
+    bool get_static_startup_shutdown(
+        std::string const& instance, util::plugin::get_plugins_list_type& f)
+    {
+        typedef std::map<std::string, util::plugin::get_plugins_list_type>
+            map_type;
+
+        map_type const& m = get_static_startup_shutdown_data();
+        map_type::const_iterator it = m.find(instance);
+        if (it == m.end())
+            return false;
+
+        f = it->second;
+        return true;
+    }
+}}    // namespace hpx::components

--- a/libs/core/runtime_local/src/runtime_local.cpp
+++ b/libs/core/runtime_local/src/runtime_local.cpp
@@ -23,6 +23,7 @@
 #include <hpx/runtime_local/debugging.hpp>
 #include <hpx/runtime_local/os_thread_type.hpp>
 #include <hpx/runtime_local/runtime_local.hpp>
+#include <hpx/runtime_local/runtime_local_fwd.hpp>
 #include <hpx/runtime_local/shutdown_function.hpp>
 #include <hpx/runtime_local/startup_function.hpp>
 #include <hpx/runtime_local/state.hpp>
@@ -969,13 +970,13 @@ namespace hpx {
 #endif
     }
 
-    bool HPX_CORE_EXPORT is_starting()
+    bool is_starting()
     {
         runtime* rt = get_runtime_ptr();
         return nullptr != rt ? rt->get_state() <= state_startup : true;
     }
 
-    bool HPX_CORE_EXPORT is_pre_startup()
+    bool is_pre_startup()
     {
         runtime* rt = get_runtime_ptr();
         return nullptr != rt ? rt->get_state() < state_startup : true;
@@ -1017,22 +1018,22 @@ namespace hpx { namespace threads {
         return get_runtime().get_config().get_stack_size(stacksize);
     }
 
-    HPX_CORE_EXPORT void reset_thread_distribution()
+    void reset_thread_distribution()
     {
         get_runtime().get_thread_manager().reset_thread_distribution();
     }
 
-    HPX_CORE_EXPORT void set_scheduler_mode(threads::policies::scheduler_mode m)
+    void set_scheduler_mode(threads::policies::scheduler_mode m)
     {
         get_runtime().get_thread_manager().set_scheduler_mode(m);
     }
 
-    HPX_CORE_EXPORT void add_scheduler_mode(threads::policies::scheduler_mode m)
+    void add_scheduler_mode(threads::policies::scheduler_mode m)
     {
         get_runtime().get_thread_manager().add_scheduler_mode(m);
     }
 
-    HPX_CORE_EXPORT void add_remove_scheduler_mode(
+    void add_remove_scheduler_mode(
         threads::policies::scheduler_mode to_add_mode,
         threads::policies::scheduler_mode to_remove_mode)
     {
@@ -1040,13 +1041,12 @@ namespace hpx { namespace threads {
             to_add_mode, to_remove_mode);
     }
 
-    HPX_CORE_EXPORT void remove_scheduler_mode(
-        threads::policies::scheduler_mode m)
+    void remove_scheduler_mode(threads::policies::scheduler_mode m)
     {
         get_runtime().get_thread_manager().remove_scheduler_mode(m);
     }
 
-    HPX_CORE_EXPORT topology const& get_topology()
+    topology const& get_topology()
     {
         hpx::runtime* rt = hpx::get_runtime_ptr();
         if (rt == nullptr)

--- a/libs/full/collectives/src/barrier.cpp
+++ b/libs/full/collectives/src/barrier.cpp
@@ -24,10 +24,6 @@
 #include <vector>
 
 ///////////////////////////////////////////////////////////////////////////////
-namespace hpx {
-    HPX_CORE_EXPORT bool is_stopped_or_shutting_down();
-}
-
 namespace hpx { namespace lcos {
     barrier::barrier(std::string const& base_name)
       : node_(new (hpx::components::component_heap<wrapping_type>().alloc())

--- a/libs/full/collectives/src/barrier.cpp
+++ b/libs/full/collectives/src/barrier.cpp
@@ -25,7 +25,7 @@
 
 ///////////////////////////////////////////////////////////////////////////////
 namespace hpx {
-    bool is_stopped_or_shutting_down();
+    HPX_CORE_EXPORT bool is_stopped_or_shutting_down();
 }
 
 namespace hpx { namespace lcos {

--- a/libs/full/command_line_handling/CMakeLists.txt
+++ b/libs/full/command_line_handling/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2019 The STE||AR-Group
+# Copyright (c) 2019-2021 The STE||AR-Group
 #
 # SPDX-License-Identifier: BSL-1.0
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -24,10 +24,6 @@ set(command_line_handling_sources
     parse_command_line.cpp
 )
 
-if((HPX_WITH_NETWORKING AND HPX_WITH_PARCELPORT_MPI) OR HPX_WITH_ASYNC_MPI)
-  set(MPI_DEPS hpx_mpi_base)
-endif()
-
 include(HPX_AddModule)
 add_hpx_module(
   full command_line_handling
@@ -35,6 +31,6 @@ add_hpx_module(
   SOURCES ${command_line_handling_sources}
   HEADERS ${command_line_handling_headers}
   COMPAT_HEADERS ${command_line_handling_compat_headers}
-  DEPENDENCIES hpx_core ${MPI_DEPS}
+  DEPENDENCIES hpx_core
   CMAKE_SUBDIRS tests
 )

--- a/libs/full/init_runtime/include/hpx/hpx_init_impl.hpp
+++ b/libs/full/init_runtime/include/hpx/hpx_init_impl.hpp
@@ -14,6 +14,7 @@
 #include <hpx/hpx_main_winsocket.hpp>
 #include <hpx/hpx_user_main_config.hpp>
 #include <hpx/init_runtime/detail/run_or_start.hpp>
+#include <hpx/init_runtime_local/init_runtime_local.hpp>
 #include <hpx/modules/program_options.hpp>
 #include <hpx/prefix/find_prefix.hpp>
 #include <hpx/runtime_configuration/runtime_mode.hpp>

--- a/libs/full/init_runtime/include/hpx/hpx_start_impl.hpp
+++ b/libs/full/init_runtime/include/hpx/hpx_start_impl.hpp
@@ -14,6 +14,7 @@
 #include <hpx/hpx_start.hpp>
 #include <hpx/hpx_user_main_config.hpp>
 #include <hpx/init_runtime/detail/run_or_start.hpp>
+#include <hpx/init_runtime_local/init_runtime_local.hpp>
 #include <hpx/modules/program_options.hpp>
 #include <hpx/prefix/find_prefix.hpp>
 #include <hpx/runtime_configuration/runtime_mode.hpp>

--- a/libs/full/init_runtime/include/hpx/init_runtime/detail/run_or_start.hpp
+++ b/libs/full/init_runtime/include/hpx/init_runtime/detail/run_or_start.hpp
@@ -17,9 +17,6 @@ namespace hpx {
             util::function_nonser<int(
                 hpx::program_options::variables_map& vm)> const& f,
             int argc, char** argv, init_params const& params, bool blocking);
-
-        HPX_CORE_EXPORT int init_helper(hpx::program_options::variables_map&,
-            util::function_nonser<int(int, char**)> const&);
     }    // namespace detail
     /// \endcond
 }    // namespace hpx

--- a/libs/full/init_runtime/include/hpx/init_runtime/detail/run_or_start.hpp
+++ b/libs/full/init_runtime/include/hpx/init_runtime/detail/run_or_start.hpp
@@ -18,7 +18,7 @@ namespace hpx {
                 hpx::program_options::variables_map& vm)> const& f,
             int argc, char** argv, init_params const& params, bool blocking);
 
-        HPX_EXPORT int init_helper(hpx::program_options::variables_map&,
+        HPX_CORE_EXPORT int init_helper(hpx::program_options::variables_map&,
             util::function_nonser<int(int, char**)> const&);
     }    // namespace detail
     /// \endcond

--- a/libs/full/runtime_distributed/src/server/runtime_support_server.cpp
+++ b/libs/full/runtime_distributed/src/server/runtime_support_server.cpp
@@ -131,120 +131,6 @@ namespace hpx {
     void stop_evaluating_counters(bool terminate = false);
 }    // namespace hpx
 
-namespace hpx { namespace components {
-    bool initial_static_loading = true;
-
-    ///////////////////////////////////////////////////////////////////////////
-    // There is no need to protect these global from thread concurrent access
-    // as they are access during early startup only.
-    std::vector<static_factory_load_data_type>& get_static_module_data()
-    {
-        static std::vector<static_factory_load_data_type>
-            global_module_init_data;
-        return global_module_init_data;
-    }
-
-    void init_registry_module(static_factory_load_data_type const& data)
-    {
-        if (initial_static_loading)
-            get_static_module_data().push_back(data);
-    }
-
-    ///////////////////////////////////////////////////////////////////////////
-    std::map<std::string, util::plugin::get_plugins_list_type>&
-    get_static_factory_data()
-    {
-        static std::map<std::string, util::plugin::get_plugins_list_type>
-            global_factory_init_data;
-        return global_factory_init_data;
-    }
-
-    void init_registry_factory(static_factory_load_data_type const& data)
-    {
-        if (initial_static_loading)
-            get_static_factory_data().insert(
-                std::make_pair(data.name, data.get_factory));
-    }
-
-    bool get_static_factory(
-        std::string const& instance, util::plugin::get_plugins_list_type& f)
-    {
-        typedef std::map<std::string, util::plugin::get_plugins_list_type>
-            map_type;
-
-        map_type const& m = get_static_factory_data();
-        map_type::const_iterator it = m.find(instance);
-        if (it == m.end())
-            return false;
-
-        f = it->second;
-        return true;
-    }
-
-    ///////////////////////////////////////////////////////////////////////////
-    std::map<std::string, util::plugin::get_plugins_list_type>&
-    get_static_commandline_data()
-    {
-        static std::map<std::string, util::plugin::get_plugins_list_type>
-            global_commandline_init_data;
-        return global_commandline_init_data;
-    }
-
-    void init_registry_commandline(static_factory_load_data_type const& data)
-    {
-        if (initial_static_loading)
-            get_static_commandline_data().insert(
-                std::make_pair(data.name, data.get_factory));
-    }
-
-    bool get_static_commandline(
-        std::string const& instance, util::plugin::get_plugins_list_type& f)
-    {
-        typedef std::map<std::string, util::plugin::get_plugins_list_type>
-            map_type;
-
-        map_type const& m = get_static_commandline_data();
-        map_type::const_iterator it = m.find(instance);
-        if (it == m.end())
-            return false;
-
-        f = it->second;
-        return true;
-    }
-
-    ///////////////////////////////////////////////////////////////////////////
-    std::map<std::string, util::plugin::get_plugins_list_type>&
-    get_static_startup_shutdown_data()
-    {
-        static std::map<std::string, util::plugin::get_plugins_list_type>
-            global_startup_shutdown_init_data;
-        return global_startup_shutdown_init_data;
-    }
-
-    void init_registry_startup_shutdown(
-        static_factory_load_data_type const& data)
-    {
-        if (initial_static_loading)
-            get_static_startup_shutdown_data().insert(
-                std::make_pair(data.name, data.get_factory));
-    }
-
-    bool get_static_startup_shutdown(
-        std::string const& instance, util::plugin::get_plugins_list_type& f)
-    {
-        typedef std::map<std::string, util::plugin::get_plugins_list_type>
-            map_type;
-
-        map_type const& m = get_static_startup_shutdown_data();
-        map_type::const_iterator it = m.find(instance);
-        if (it == m.end())
-            return false;
-
-        f = it->second;
-        return true;
-    }
-}}    // namespace hpx::components
-
 ///////////////////////////////////////////////////////////////////////////////
 namespace hpx { namespace components { namespace server {
     ///////////////////////////////////////////////////////////////////////////
@@ -882,7 +768,7 @@ namespace hpx { namespace components { namespace server {
         ini.load_components_static(components::get_static_module_data());
 
         // modules loaded dynamically should not register themselves statically
-        components::initial_static_loading = false;
+        components::get_initial_static_loading() = false;
 
         // make sure every component module gets asked for startup/shutdown
         // functions only once

--- a/plugins/parcelport/mpi/parcelport_mpi.cpp
+++ b/plugins/parcelport/mpi/parcelport_mpi.cpp
@@ -45,7 +45,7 @@
 
 namespace hpx
 {
-    bool is_starting();
+    HPX_CORE_EXPORT bool is_starting();
 }
 
 namespace hpx { namespace parcelset

--- a/plugins/parcelport/mpi/parcelport_mpi.cpp
+++ b/plugins/parcelport/mpi/parcelport_mpi.cpp
@@ -43,11 +43,6 @@
 
 #include <hpx/config/warnings_prefix.hpp>
 
-namespace hpx
-{
-    HPX_CORE_EXPORT bool is_starting();
-}
-
 namespace hpx { namespace parcelset
 {
     namespace policies { namespace mpi

--- a/src/runtime/parcelset/parcelhandler.cpp
+++ b/src/runtime/parcelset/parcelhandler.cpp
@@ -70,10 +70,6 @@
 #endif
 
 ///////////////////////////////////////////////////////////////////////////////
-namespace hpx {
-    HPX_CORE_EXPORT bool is_stopped_or_shutting_down();
-}
-
 namespace hpx { namespace detail {
     void dijkstra_make_black();    // forward declaration only
 }}                                 // namespace hpx::detail

--- a/src/runtime/parcelset/parcelhandler.cpp
+++ b/src/runtime/parcelset/parcelhandler.cpp
@@ -71,7 +71,7 @@
 
 ///////////////////////////////////////////////////////////////////////////////
 namespace hpx {
-    bool is_stopped_or_shutting_down();
+    HPX_CORE_EXPORT bool is_stopped_or_shutting_down();
 }
 
 namespace hpx { namespace detail {


### PR DESCRIPTION
- this is a somewhat hacky solution as it marks functions that are declared in the core module with `HPX_EXPORT` (those are defined in full, currently)
