### PR TITLE
Make default_agent::yield actually yield

### DIFF
--- a/libs/core/execution_base/src/this_thread.cpp
+++ b/libs/core/execution_base/src/this_thread.cpp
@@ -92,14 +92,10 @@ namespace hpx { namespace execution_base {
 
         void default_agent::yield(char const* /* desc */)
         {
-#if defined(HPX_SMT_PAUSE)
-            HPX_SMT_PAUSE;
-#else
 #if defined(HPX_WINDOWS)
             Sleep(0);
 #else
             sched_yield();
-#endif
 #endif
         }
 


### PR DESCRIPTION
When `HPX_SMT_PAUSE` is available, `default_agent::yield` would never actually yield. This changes it to actually yield (`HPX_SMT_PAUSE` is still used in the first iterations of `yield_k`). See discussion at https://github.com/STEllAR-GROUP/hpx/pull/5549#discussion_r707106060 for context.