### PR TITLE
Add workaround for libstc++ in string_util trim

### DIFF
--- a/libs/core/string_util/include/hpx/string_util/trim.hpp
+++ b/libs/core/string_util/include/hpx/string_util/trim.hpp
@@ -14,11 +14,21 @@ namespace hpx { namespace string_util {
     template <typename CharT, class Traits, class Alloc>
     void trim(std::basic_string<CharT, Traits, Alloc>& s)
     {
+        // When using the pre-C++11 ABI in libstdc++, basic_string::erase
+        // does not have an overload taking different begin and end iterators.
+#if defined(_GLIBCXX_USE_CXX11_ABI) && _GLIBCXX_USE_CXX11_ABI == 0
+        auto first = std::find_if_not(std::begin(s), std::end(s),
+#else
         auto first = std::find_if_not(std::cbegin(s), std::cend(s),
+#endif
             [](int c) { return std::isspace(c); });
         s.erase(std::begin(s), first);
 
+#if defined(_GLIBCXX_USE_CXX11_ABI) && _GLIBCXX_USE_CXX11_ABI == 0
+        auto last = std::find_if_not(std::rbegin(s), std::rend(s),
+#else
         auto last = std::find_if_not(std::crbegin(s), std::crend(s),
+#endif
             [](int c) { return std::isspace(c); });
         s.erase(last.base(), std::end(s));
     }


### PR DESCRIPTION
I've applied the workaround only for the required case to avoid someone coming along later thinking that the `begin`/`end` calls can be changed to `cbegin`/`cend`.

Fixes #5565.

@Spongman would you mind trying this in your setup as well?