### PR TITLE
Remove more guards for the distributed runtime

### DIFF
--- a/libs/core/runtime_configuration/include/hpx/runtime_configuration/register_locks_globally.hpp
+++ b/libs/core/runtime_configuration/include/hpx/runtime_configuration/register_locks_globally.hpp
@@ -8,7 +8,6 @@
 
 #include <hpx/config.hpp>
 
-#if defined(HPX_HAVE_DISTRIBUTED_RUNTIME)
 namespace hpx { namespace util {
 
     // Always provide function exports, which guarantees ABI compatibility of
@@ -33,5 +32,3 @@ namespace hpx { namespace util {
 #endif
 
 }}    // namespace hpx::util
-
-#endif

--- a/libs/core/runtime_configuration/src/register_locks_globally.cpp
+++ b/libs/core/runtime_configuration/src/register_locks_globally.cpp
@@ -5,8 +5,6 @@
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <hpx/config.hpp>
-
-#if defined(HPX_HAVE_DISTRIBUTED_RUNTIME)
 #include <hpx/modules/errors.hpp>
 #include <hpx/modules/logging.hpp>
 #include <hpx/runtime_configuration/register_locks_globally.hpp>
@@ -157,5 +155,3 @@ namespace hpx { namespace util {
 
 #endif
 }}    // namespace hpx::util
-
-#endif

--- a/libs/full/async_distributed/include/hpx/async_distributed/bind_action.hpp
+++ b/libs/full/async_distributed/include/hpx/async_distributed/bind_action.hpp
@@ -9,8 +9,6 @@
 #pragma once
 
 #include <hpx/config.hpp>
-
-#if defined(HPX_HAVE_DISTRIBUTED_RUNTIME)
 #include <hpx/actions_base/traits/extract_action.hpp>
 #include <hpx/actions_base/traits/is_continuation.hpp>
 #include <hpx/async_distributed/applier/apply.hpp>
@@ -189,5 +187,3 @@ namespace hpx { namespace serialization {
         bound.serialize(ar, version);
     }
 }}    // namespace hpx::serialization
-
-#endif

--- a/libs/full/async_distributed/include/hpx/async_distributed/lcos_fwd.hpp
+++ b/libs/full/async_distributed/include/hpx/async_distributed/lcos_fwd.hpp
@@ -19,7 +19,6 @@ namespace hpx {
 
     /// \namespace lcos
     namespace lcos {
-#if defined(HPX_HAVE_DISTRIBUTED_RUNTIME)
         class HPX_EXPORT base_lco;
 
         template <typename Result,
@@ -49,7 +48,6 @@ namespace hpx {
             template <typename ValueType>
             struct object_semaphore;
         }
-#endif
 
         namespace local {
             class barrier;

--- a/libs/full/async_distributed/include/hpx/async_distributed/promise.hpp
+++ b/libs/full/async_distributed/include/hpx/async_distributed/promise.hpp
@@ -9,8 +9,6 @@
 #pragma once
 
 #include <hpx/config.hpp>
-
-#if defined(HPX_HAVE_DISTRIBUTED_RUNTIME)
 #include <hpx/async_distributed/detail/promise_base.hpp>
 
 #include <exception>
@@ -253,4 +251,3 @@ namespace std {
     {
     };
 }    // namespace std
-#endif

--- a/libs/full/executors_distributed/include/hpx/executors_distributed/distribution_policy_executor.hpp
+++ b/libs/full/executors_distributed/include/hpx/executors_distributed/distribution_policy_executor.hpp
@@ -9,8 +9,6 @@
 #pragma once
 
 #include <hpx/config.hpp>
-
-#if defined(HPX_HAVE_DISTRIBUTED_RUNTIME)
 #include <hpx/actions/invoke_function.hpp>
 #include <hpx/actions_base/traits/is_distribution_policy.hpp>
 #include <hpx/execution_base/traits/is_executor.hpp>
@@ -201,5 +199,3 @@ namespace hpx { namespace parallel { namespace execution {
     };
     /// \endcond
 }}}    // namespace hpx::parallel::execution
-
-#endif

--- a/libs/full/include/include/hpx/hpx.hpp
+++ b/libs/full/include/include/hpx/hpx.hpp
@@ -28,8 +28,6 @@
 #include <hpx/modules/async_local.hpp>
 #include <hpx/modules/errors.hpp>
 
-#if defined(HPX_HAVE_DISTRIBUTED_RUNTIME)
 #include <hpx/include/components.hpp>
 #include <hpx/include/performance_counters.hpp>
 #include <hpx/modules/async_distributed.hpp>
-#endif

--- a/libs/full/include/include/hpx/include/actions.hpp
+++ b/libs/full/include/include/hpx/include/actions.hpp
@@ -8,8 +8,6 @@
 #pragma once
 
 #include <hpx/config.hpp>
-
-#if defined(HPX_HAVE_DISTRIBUTED_RUNTIME)
 #include <hpx/actions/transfer_action.hpp>
 #include <hpx/actions_base/component_action.hpp>
 #include <hpx/actions_base/lambda_to_action.hpp>
@@ -18,4 +16,3 @@
 #include <hpx/async_distributed/continuation.hpp>
 #include <hpx/async_distributed/make_continuation.hpp>
 #include <hpx/async_distributed/transfer_continuation_action.hpp>
-#endif

--- a/libs/full/include/include/hpx/include/agas.hpp
+++ b/libs/full/include/include/hpx/include/agas.hpp
@@ -8,6 +8,4 @@
 
 #include <hpx/config.hpp>
 
-#if defined(HPX_HAVE_DISTRIBUTED_RUNTIME)
 #include <hpx/components_base/agas_interface.hpp>
-#endif

--- a/libs/full/include/include/hpx/include/applier.hpp
+++ b/libs/full/include/include/hpx/include/applier.hpp
@@ -8,11 +8,8 @@
 #pragma once
 
 #include <hpx/config.hpp>
-
-#if defined(HPX_HAVE_DISTRIBUTED_RUNTIME)
 #include <hpx/async_colocated/apply_colocated.hpp>
 #include <hpx/async_colocated/apply_colocated_callback.hpp>
 #include <hpx/async_distributed/applier/apply.hpp>
 #include <hpx/async_distributed/applier/trigger.hpp>
 #include <hpx/runtime_distributed/applier.hpp>
-#endif

--- a/libs/full/include/include/hpx/include/apply.hpp
+++ b/libs/full/include/include/hpx/include/apply.hpp
@@ -9,8 +9,6 @@
 #include <hpx/config.hpp>
 #include <hpx/async_local/apply.hpp>
 
-#if defined(HPX_HAVE_DISTRIBUTED_RUNTIME)
 #include <hpx/async_colocated/apply_colocated.hpp>
 #include <hpx/async_colocated/apply_colocated_callback.hpp>
 #include <hpx/async_distributed/apply.hpp>
-#endif

--- a/libs/full/include/include/hpx/include/async.hpp
+++ b/libs/full/include/include/hpx/include/async.hpp
@@ -9,10 +9,8 @@
 #include <hpx/config.hpp>
 #include <hpx/async_local/async.hpp>
 
-#if defined(HPX_HAVE_DISTRIBUTED_RUNTIME)
 #include <hpx/async_colocated/async_colocated.hpp>
 #include <hpx/async_colocated/async_colocated_callback.hpp>
 #include <hpx/async_distributed/async.hpp>
 #include <hpx/async_distributed/async_callback.hpp>
 #include <hpx/async_distributed/async_continue_callback.hpp>
-#endif

--- a/libs/full/include/include/hpx/include/bind.hpp
+++ b/libs/full/include/include/hpx/include/bind.hpp
@@ -9,6 +9,4 @@
 #include <hpx/config.hpp>
 #include <hpx/functional/bind.hpp>
 
-#if defined(HPX_HAVE_DISTRIBUTED_RUNTIME)
 #include <hpx/async_distributed/bind_action.hpp>
-#endif

--- a/libs/full/include/include/hpx/include/client.hpp
+++ b/libs/full/include/include/hpx/include/client.hpp
@@ -8,8 +8,6 @@
 
 #include <hpx/config.hpp>
 
-#if defined(HPX_HAVE_DISTRIBUTED_RUNTIME)
 #include <hpx/components/client_base.hpp>
 #include <hpx/runtime_configuration/component_factory_base.hpp>
 #include <hpx/runtime_distributed/stubs/runtime_support.hpp>
-#endif

--- a/libs/full/include/include/hpx/include/components.hpp
+++ b/libs/full/include/include/hpx/include/components.hpp
@@ -8,8 +8,6 @@
 #pragma once
 
 #include <hpx/config.hpp>
-
-#if defined(HPX_HAVE_DISTRIBUTED_RUNTIME)
 #include <hpx/include/actions.hpp>
 
 #include <hpx/runtime_components/component_factory.hpp>
@@ -50,5 +48,3 @@
 #include <hpx/distribution_policies/colocating_distribution_policy.hpp>
 #include <hpx/distribution_policies/target_distribution_policy.hpp>
 #include <hpx/distribution_policies/unwrapping_result_policy.hpp>
-
-#endif

--- a/libs/full/include/include/hpx/include/compression.hpp
+++ b/libs/full/include/include/hpx/include/compression.hpp
@@ -8,11 +8,9 @@
 
 #include <hpx/config.hpp>
 
-#if defined(HPX_HAVE_DISTRIBUTED_RUNTIME)
 #include <hpx/plugins/binary_filter/bzip2_serialization_filter.hpp>
 #include <hpx/plugins/binary_filter/snappy_serialization_filter.hpp>
 #include <hpx/plugins/binary_filter/zlib_serialization_filter.hpp>
-#endif
 
 #if HPX_HAVE_DEPRECATION_WARNINGS
 #if defined(HPX_MSVC)

--- a/libs/full/include/include/hpx/include/compression_registration.hpp
+++ b/libs/full/include/include/hpx/include/compression_registration.hpp
@@ -8,11 +8,9 @@
 
 #include <hpx/config.hpp>
 
-#if defined(HPX_HAVE_DISTRIBUTED_RUNTIME)
 #include <hpx/plugins/binary_filter/bzip2_serialization_filter_registration.hpp>
 #include <hpx/plugins/binary_filter/snappy_serialization_filter_registration.hpp>
 #include <hpx/plugins/binary_filter/zlib_serialization_filter_registration.hpp>
-#endif
 
 #if HPX_HAVE_DEPRECATION_WARNINGS
 #if defined(HPX_MSVC)

--- a/libs/full/include/include/hpx/include/dataflow.hpp
+++ b/libs/full/include/include/hpx/include/dataflow.hpp
@@ -9,6 +9,4 @@
 #include <hpx/config.hpp>
 #include <hpx/async_local/dataflow.hpp>
 
-#if defined(HPX_HAVE_DISTRIBUTED_RUNTIME)
 #include <hpx/async_distributed/dataflow.hpp>
-#endif

--- a/libs/full/include/include/hpx/include/lcos.hpp
+++ b/libs/full/include/include/hpx/include/lcos.hpp
@@ -13,7 +13,6 @@
 #include <hpx/include/lcos_local.hpp>
 #include <hpx/modules/async_combinators.hpp>
 
-#if defined(HPX_HAVE_DISTRIBUTED_RUNTIME)
 #include <hpx/async_distributed/base_lco.hpp>
 #include <hpx/async_distributed/base_lco_with_value.hpp>
 #include <hpx/async_distributed/packaged_action.hpp>
@@ -23,4 +22,3 @@
 #include <hpx/collectives/reduce.hpp>
 #include <hpx/include/actions.hpp>
 #include <hpx/lcos_distributed/channel.hpp>
-#endif

--- a/libs/full/include/include/hpx/include/naming.hpp
+++ b/libs/full/include/include/hpx/include/naming.hpp
@@ -8,10 +8,7 @@
 #pragma once
 
 #include <hpx/config.hpp>
-
-#if defined(HPX_HAVE_DISTRIBUTED_RUNTIME)
 #include <hpx/agas/addressing_service.hpp>
 #include <hpx/naming_base/address.hpp>
 #include <hpx/naming_base/id_type.hpp>
 #include <hpx/naming_base/unmanaged.hpp>
-#endif

--- a/libs/full/include/include/hpx/include/parallel_adjacent_difference.hpp
+++ b/libs/full/include/include/hpx/include/parallel_adjacent_difference.hpp
@@ -9,6 +9,4 @@
 #include <hpx/config.hpp>
 #include <hpx/parallel/algorithms/adjacent_difference.hpp>
 
-#if defined(HPX_HAVE_DISTRIBUTED_RUNTIME)
 #include <hpx/parallel/segmented_algorithms/adjacent_difference.hpp>
-#endif

--- a/libs/full/include/include/hpx/include/parallel_adjacent_find.hpp
+++ b/libs/full/include/include/hpx/include/parallel_adjacent_find.hpp
@@ -10,6 +10,4 @@
 #include <hpx/config.hpp>
 #include <hpx/parallel/algorithms/adjacent_find.hpp>
 
-#if defined(HPX_HAVE_DISTRIBUTED_RUNTIME)
 #include <hpx/parallel/segmented_algorithms/adjacent_find.hpp>
-#endif

--- a/libs/full/include/include/hpx/include/parallel_all_any_none_of.hpp
+++ b/libs/full/include/include/hpx/include/parallel_all_any_none_of.hpp
@@ -11,6 +11,4 @@
 #include <hpx/parallel/algorithms/all_any_none.hpp>
 #include <hpx/parallel/container_algorithms/all_any_none.hpp>
 
-#if defined(HPX_HAVE_DISTRIBUTED_RUNTIME)
 #include <hpx/parallel/segmented_algorithms/all_any_none.hpp>
-#endif

--- a/libs/full/include/include/hpx/include/parallel_count.hpp
+++ b/libs/full/include/include/hpx/include/parallel_count.hpp
@@ -11,6 +11,4 @@
 #include <hpx/parallel/algorithms/count.hpp>
 #include <hpx/parallel/container_algorithms/count.hpp>
 
-#if defined(HPX_HAVE_DISTRIBUTED_RUNTIME)
 #include <hpx/parallel/segmented_algorithms/count.hpp>
-#endif

--- a/libs/full/include/include/hpx/include/parallel_fill.hpp
+++ b/libs/full/include/include/hpx/include/parallel_fill.hpp
@@ -11,6 +11,4 @@
 #include <hpx/parallel/algorithms/fill.hpp>
 #include <hpx/parallel/container_algorithms/fill.hpp>
 
-#if defined(HPX_HAVE_DISTRIBUTED_RUNTIME)
 #include <hpx/parallel/segmented_algorithms/fill.hpp>
-#endif

--- a/libs/full/include/include/hpx/include/parallel_find.hpp
+++ b/libs/full/include/include/hpx/include/parallel_find.hpp
@@ -11,6 +11,4 @@
 #include <hpx/parallel/algorithms/find.hpp>
 #include <hpx/parallel/container_algorithms/find.hpp>
 
-#if defined(HPX_HAVE_DISTRIBUTED_RUNTIME)
 #include <hpx/parallel/segmented_algorithms/find.hpp>
-#endif

--- a/libs/full/include/include/hpx/include/parallel_for_each.hpp
+++ b/libs/full/include/include/hpx/include/parallel_for_each.hpp
@@ -10,6 +10,4 @@
 #include <hpx/parallel/algorithms/for_each.hpp>
 #include <hpx/parallel/container_algorithms/for_each.hpp>
 
-#if defined(HPX_HAVE_DISTRIBUTED_RUNTIME)
 #include <hpx/parallel/segmented_algorithms/for_each.hpp>
-#endif

--- a/libs/full/include/include/hpx/include/parallel_generate.hpp
+++ b/libs/full/include/include/hpx/include/parallel_generate.hpp
@@ -11,6 +11,4 @@
 #include <hpx/parallel/algorithms/generate.hpp>
 #include <hpx/parallel/container_algorithms/generate.hpp>
 
-#if defined(HPX_HAVE_DISTRIBUTED_RUNTIME)
 #include <hpx/parallel/segmented_algorithms/generate.hpp>
-#endif

--- a/libs/full/include/include/hpx/include/parallel_minmax.hpp
+++ b/libs/full/include/include/hpx/include/parallel_minmax.hpp
@@ -11,6 +11,4 @@
 #include <hpx/parallel/algorithms/minmax.hpp>
 #include <hpx/parallel/container_algorithms/minmax.hpp>
 
-#if defined(HPX_HAVE_DISTRIBUTED_RUNTIME)
 #include <hpx/parallel/segmented_algorithms/minmax.hpp>
-#endif

--- a/libs/full/include/include/hpx/include/parallel_reduce.hpp
+++ b/libs/full/include/include/hpx/include/parallel_reduce.hpp
@@ -12,6 +12,4 @@
 #include <hpx/parallel/algorithms/reduce_by_key.hpp>
 #include <hpx/parallel/container_algorithms/reduce.hpp>
 
-#if defined(HPX_HAVE_DISTRIBUTED_RUNTIME)
 #include <hpx/parallel/segmented_algorithms/reduce.hpp>
-#endif

--- a/libs/full/include/include/hpx/include/parallel_scan.hpp
+++ b/libs/full/include/include/hpx/include/parallel_scan.hpp
@@ -10,7 +10,5 @@
 #include <hpx/parallel/algorithms/exclusive_scan.hpp>
 #include <hpx/parallel/algorithms/inclusive_scan.hpp>
 
-#if defined(HPX_HAVE_DISTRIBUTED_RUNTIME)
 #include <hpx/parallel/segmented_algorithms/exclusive_scan.hpp>
 #include <hpx/parallel/segmented_algorithms/inclusive_scan.hpp>
-#endif

--- a/libs/full/include/include/hpx/include/parallel_transform.hpp
+++ b/libs/full/include/include/hpx/include/parallel_transform.hpp
@@ -11,6 +11,4 @@
 #include <hpx/parallel/algorithms/transform.hpp>
 #include <hpx/parallel/container_algorithms/transform.hpp>
 
-#if defined(HPX_HAVE_DISTRIBUTED_RUNTIME)
 #include <hpx/parallel/segmented_algorithms/transform.hpp>
-#endif

--- a/libs/full/include/include/hpx/include/parallel_transform_reduce.hpp
+++ b/libs/full/include/include/hpx/include/parallel_transform_reduce.hpp
@@ -11,6 +11,4 @@
 #include <hpx/parallel/algorithms/transform_reduce.hpp>
 #include <hpx/parallel/container_algorithms/transform_reduce.hpp>
 
-#if defined(HPX_HAVE_DISTRIBUTED_RUNTIME)
 #include <hpx/parallel/segmented_algorithms/transform_reduce.hpp>
-#endif

--- a/libs/full/include/include/hpx/include/parallel_transform_scan.hpp
+++ b/libs/full/include/include/hpx/include/parallel_transform_scan.hpp
@@ -10,7 +10,5 @@
 #include <hpx/parallel/algorithms/transform_exclusive_scan.hpp>
 #include <hpx/parallel/algorithms/transform_inclusive_scan.hpp>
 
-#if defined(HPX_HAVE_DISTRIBUTED_RUNTIME)
 #include <hpx/parallel/segmented_algorithms/transform_exclusive_scan.hpp>
 #include <hpx/parallel/segmented_algorithms/transform_inclusive_scan.hpp>
-#endif

--- a/libs/full/include/include/hpx/include/performance_counters.hpp
+++ b/libs/full/include/include/hpx/include/performance_counters.hpp
@@ -10,7 +10,6 @@
 #include <hpx/config.hpp>
 #include <hpx/util/get_and_reset_value.hpp>
 
-#if defined(HPX_HAVE_DISTRIBUTED_RUNTIME)
 #include <hpx/performance_counters/base_performance_counter.hpp>
 #include <hpx/performance_counters/counter_creators.hpp>
 #include <hpx/performance_counters/counters.hpp>
@@ -18,4 +17,3 @@
 #include <hpx/performance_counters/manage_counter_type.hpp>
 #include <hpx/performance_counters/performance_counter.hpp>
 #include <hpx/performance_counters/performance_counter_set.hpp>
-#endif

--- a/libs/full/include/include/hpx/include/plain_actions.hpp
+++ b/libs/full/include/include/hpx/include/plain_actions.hpp
@@ -7,8 +7,5 @@
 #pragma once
 
 #include <hpx/config.hpp>
-
-#if defined(HPX_HAVE_DISTRIBUTED_RUNTIME)
 #include <hpx/actions_base/plain_action.hpp>
 #include <hpx/async_distributed/continuation.hpp>
-#endif

--- a/libs/full/include/include/hpx/include/runtime.hpp
+++ b/libs/full/include/include/hpx/include/runtime.hpp
@@ -12,7 +12,6 @@
 #include <hpx/include/threadmanager.hpp>
 #include <hpx/runtime_local/runtime_local.hpp>
 
-#if defined(HPX_HAVE_DISTRIBUTED_RUNTIME)
 #include <hpx/include/actions.hpp>
 #include <hpx/include/applier.hpp>
 #include <hpx/include/components.hpp>
@@ -20,4 +19,3 @@
 #include <hpx/include/parcelset.hpp>
 #include <hpx/modules/runtime_distributed.hpp>
 #include <hpx/runtime_distributed.hpp>
-#endif

--- a/libs/full/include/include/hpx/include/sync.hpp
+++ b/libs/full/include/include/hpx/include/sync.hpp
@@ -9,6 +9,4 @@
 #include <hpx/config.hpp>
 #include <hpx/async_local/sync.hpp>
 
-#if defined(HPX_HAVE_DISTRIBUTED_RUNTIME)
 #include <hpx/async_distributed/sync.hpp>
-#endif

--- a/libs/full/include/include/hpx/include/traits.hpp
+++ b/libs/full/include/include/hpx/include/traits.hpp
@@ -42,7 +42,6 @@
 #include <hpx/timed_execution/traits/is_timed_executor.hpp>
 #include <hpx/type_support/detail/wrap_int.hpp>
 
-#if defined(HPX_HAVE_DISTRIBUTED_RUNTIME)
 #include <hpx/actions_base/traits/action_continuation.hpp>
 #include <hpx/actions_base/traits/action_decorate_continuation.hpp>
 #include <hpx/actions_base/traits/action_does_termination_detection.hpp>
@@ -73,4 +72,3 @@
 #include <hpx/futures/traits/promise_remote_result.hpp>
 #include <hpx/traits/action_message_handler.hpp>
 #include <hpx/traits/action_serialization_filter.hpp>
-#endif

--- a/libs/full/include/include/hpx/include/util.hpp
+++ b/libs/full/include/include/hpx/include/util.hpp
@@ -19,6 +19,7 @@
 #include <hpx/iterator_support/iterator_adaptor.hpp>
 #include <hpx/iterator_support/iterator_facade.hpp>
 #include <hpx/modules/format.hpp>
+#include <hpx/modules/string_util.hpp>
 #include <hpx/preprocessor/cat.hpp>
 #include <hpx/preprocessor/expand.hpp>
 #include <hpx/preprocessor/nargs.hpp>
@@ -35,10 +36,4 @@
 #include <hpx/util/get_and_reset_value.hpp>
 #include <hpx/util/to_string.hpp>
 
-#if defined(HPX_HAVE_DISTRIBUTED_RUNTIME)
 #include <hpx/parallel/segmented_algorithms/traits/zip_iterator.hpp>
-#endif
-
-#if defined(HPX_HAVE_MODULE_STRING_UTIL)
-#include <hpx/modules/string_util.hpp>
-#endif

--- a/libs/full/runtime_distributed/include/hpx/runtime_distributed/applier.hpp
+++ b/libs/full/runtime_distributed/include/hpx/runtime_distributed/applier.hpp
@@ -9,8 +9,6 @@
 #pragma once
 
 #include <hpx/config.hpp>
-
-#if defined(HPX_HAVE_DISTRIBUTED_RUNTIME)
 #include <hpx/runtime_distributed/applier_fwd.hpp>    // this needs to go first
 
 #include <hpx/assert.hpp>
@@ -158,5 +156,3 @@ namespace hpx { namespace applier {
 }}    // namespace hpx::applier
 
 #include <hpx/config/warnings_suffix.hpp>
-
-#endif

--- a/libs/full/runtime_distributed/include/hpx/runtime_distributed/runtime_fwd.hpp
+++ b/libs/full/runtime_distributed/include/hpx/runtime_distributed/runtime_fwd.hpp
@@ -10,9 +10,6 @@
 #pragma once
 
 #include <hpx/config.hpp>
-#include <hpx/runtime_local/runtime_local_fwd.hpp>
-
-#if defined(HPX_HAVE_DISTRIBUTED_RUNTIME)
 #include <hpx/components/basename_registration_fwd.hpp>
 #include <hpx/modules/naming_base.hpp>
 #include <hpx/runtime/set_parcel_write_handler.hpp>
@@ -22,6 +19,7 @@
 #include <hpx/runtime_distributed/get_locality_name.hpp>
 #include <hpx/runtime_local/get_locality_id.hpp>
 #include <hpx/runtime_local/get_num_all_localities.hpp>
+#include <hpx/runtime_local/runtime_local_fwd.hpp>
 
 #include <cstddef>
 #include <cstdint>
@@ -157,4 +155,3 @@ namespace hpx {
         serialization::binary_filter* next_filter = nullptr,
         error_code& ec = throws);
 }    // namespace hpx
-#endif

--- a/libs/full/segmented_algorithms/include/hpx/parallel/segmented_algorithms/traits/zip_iterator.hpp
+++ b/libs/full/segmented_algorithms/include/hpx/parallel/segmented_algorithms/traits/zip_iterator.hpp
@@ -8,8 +8,6 @@
 #pragma once
 
 #include <hpx/config.hpp>
-
-#if defined(HPX_HAVE_DISTRIBUTED_RUNTIME)
 #include <hpx/algorithms/traits/segmented_iterator_traits.hpp>
 #include <hpx/datastructures/tuple.hpp>
 #include <hpx/iterator_support/zip_iterator.hpp>
@@ -180,5 +178,3 @@ namespace hpx { namespace traits {
         }
     };
 }}    // namespace hpx::traits
-
-#endif


### PR DESCRIPTION
These guards are no longer necessary since the modules themselves are not built/installed unless the distributed runtime is enabled. There are some more ifdefs that I'll remove when splitting things up. After that the `HPX_WITH_DISTRIBUTED_RUNTIME` option won't be necessary anymore.