### PR TITLE
Change scan partitioner implementation

### DIFF
--- a/libs/core/algorithms/include/hpx/parallel/algorithms/copy.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/copy.hpp
@@ -568,14 +568,9 @@ namespace hpx { namespace parallel { inline namespace v1 {
                     return curr;
                 };
                 auto f3 = [dest, flags](zip_iterator part_begin,
-                              std::size_t part_size,
-                              hpx::shared_future<std::size_t> curr,
-                              hpx::shared_future<std::size_t> next) mutable {
+                              std::size_t part_size, std::size_t val) mutable {
                     HPX_UNUSED(flags);
-
-                    next.get();    // rethrow exceptions
-
-                    std::advance(dest, curr.get());
+                    std::advance(dest, val);
                     util::loop_n<std::decay_t<ExPolicy>>(part_begin, part_size,
                         [&dest](zip_iterator it) mutable {
                             if (get<1>(*it))
@@ -610,7 +605,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                     std::move(f1),
                     // step 2 propagates the partition results from left
                     // to right
-                    hpx::unwrapping(std::plus<std::size_t>()),
+                    std::plus<std::size_t>(),
                     // step 3 runs final accumulation on each partition
                     std::move(f3),
                     // step 4 use this return value

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/copy.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/copy.hpp
@@ -578,20 +578,17 @@ namespace hpx { namespace parallel { inline namespace v1 {
                         });
                 };
 
-                auto f4 =
-                    [first, dest, flags](
-                        std::vector<hpx::shared_future<std::size_t>>&& items,
-                        std::vector<hpx::future<void>>&& data) mutable
+                auto f4 = [first, dest, flags](std::vector<std::size_t>&& items,
+                              std::vector<hpx::future<void>>&& data) mutable
                     -> util::in_out_result<FwdIter1, FwdIter3> {
                     HPX_UNUSED(flags);
 
-                    auto dist = items.back().get();
+                    auto dist = items.back();
                     std::advance(first, dist);
                     std::advance(dest, dist);
 
                     // make sure iterators embedded in function object that is
                     // attached to futures are invalidated
-                    items.clear();
                     data.clear();
 
                     return util::in_out_result<FwdIter1, FwdIter3>{

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/exclusive_scan.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/exclusive_scan.hpp
@@ -408,11 +408,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 using hpx::util::make_zip_iterator;
 
                 auto f3 = [op](zip_iterator part_begin, std::size_t part_size,
-                              hpx::shared_future<T> curr,
-                              hpx::shared_future<T> next) {
-                    next.get();    // rethrow exceptions
-
-                    T val = curr.get();
+                              T val) {
                     FwdIter2 dst = get<1>(part_begin.get_iterator_tuple());
                     *dst++ = val;
 
@@ -444,7 +440,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                         },
                         // step 2 propagates the partition results from left
                         // to right
-                        hpx::unwrapping(op),
+                        op,
                         // step 3 runs final accumulation on each partition
                         std::move(f3),
                         // step 4 use this return value

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/exclusive_scan.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/exclusive_scan.hpp
@@ -444,12 +444,10 @@ namespace hpx { namespace parallel { inline namespace v1 {
                         // step 3 runs final accumulation on each partition
                         std::move(f3),
                         // step 4 use this return value
-                        [last_iter, final_dest](
-                            std::vector<hpx::shared_future<T>>&& items,
+                        [last_iter, final_dest](std::vector<T>&&,
                             std::vector<hpx::future<void>>&& data) {
                             // make sure iterators embedded in function object that is
                             // attached to futures are invalidated
-                            items.clear();
                             data.clear();
                             return util::in_out_result<FwdIter1, FwdIter2>{
                                 last_iter, final_dest};

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/inclusive_scan.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/inclusive_scan.hpp
@@ -599,12 +599,10 @@ namespace hpx { namespace parallel { inline namespace v1 {
                         // step 3 runs final accumulation on each partition
                         std::move(f3),
                         // step 4 use this return value
-                        [last_iter, final_dest](
-                            std::vector<hpx::shared_future<T>>&& items,
+                        [last_iter, final_dest](std::vector<T>&&,
                             std::vector<hpx::future<void>>&& data) {
                             // make sure iterators embedded in function object that is
                             // attached to futures are invalidated
-                            items.clear();
                             data.clear();
                             return util::in_out_result<FwdIter1, FwdIter2>{
                                 last_iter, final_dest};

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/inclusive_scan.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/inclusive_scan.hpp
@@ -563,11 +563,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 using hpx::util::make_zip_iterator;
 
                 auto f3 = [op](zip_iterator part_begin, std::size_t part_size,
-                              hpx::shared_future<T> curr,
-                              hpx::shared_future<T> next) {
-                    next.get();    // rethrow exceptions
-
-                    T val = curr.get();
+                              T val) {
                     FwdIter2 dst = get<1>(part_begin.get_iterator_tuple());
 
                     // MSVC 2015 fails if op is captured by reference
@@ -599,7 +595,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                         },
                         // step 2 propagates the partition results from left
                         // to right
-                        hpx::unwrapping(op),
+                        op,
                         // step 3 runs final accumulation on each partition
                         std::move(f3),
                         // step 4 use this return value

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/partition.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/partition.hpp
@@ -1584,25 +1584,18 @@ namespace hpx { namespace parallel { inline namespace v1 {
                         true_count, part_size - true_count);
                 };
 
-                auto f2 =
-                    hpx::unwrapping([](output_iterator_offset const& prev_sum,
-                                        output_iterator_offset const& curr)
-                                        -> output_iterator_offset {
-                        return output_iterator_offset(
-                            get<0>(prev_sum) + get<0>(curr),
-                            get<1>(prev_sum) + get<1>(curr));
-                    });
-                auto f3 =
-                    [dest_true, dest_false, flags](zip_iterator part_begin,
-                        std::size_t part_size,
-                        hpx::shared_future<output_iterator_offset> curr,
-                        hpx::shared_future<output_iterator_offset> next) mutable
-                    -> void {
+                auto f2 = [](output_iterator_offset const& prev_sum,
+                              output_iterator_offset const& curr)
+                    -> output_iterator_offset {
+                    return output_iterator_offset(
+                        get<0>(prev_sum) + get<0>(curr),
+                        get<1>(prev_sum) + get<1>(curr));
+                };
+                auto f3 = [dest_true, dest_false, flags](
+                              zip_iterator part_begin, std::size_t part_size,
+                              output_iterator_offset val) mutable -> void {
                     HPX_UNUSED(flags);
-
-                    next.get();    // rethrow exceptions
-
-                    output_iterator_offset offset = curr.get();
+                    output_iterator_offset offset = val;
                     std::size_t count_true = get<0>(offset);
                     std::size_t count_false = get<1>(offset);
                     std::advance(dest_true, count_true);

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/partition.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/partition.hpp
@@ -1610,15 +1610,13 @@ namespace hpx { namespace parallel { inline namespace v1 {
                         });
                 };
 
-                auto f4 =
-                    [last_iter, dest_true, dest_false, flags](
-                        std::vector<
-                            hpx::shared_future<output_iterator_offset>>&& items,
-                        std::vector<hpx::future<void>>&&) mutable
+                auto f4 = [last_iter, dest_true, dest_false, flags](
+                              std::vector<output_iterator_offset>&& items,
+                              std::vector<hpx::future<void>>&&) mutable
                     -> hpx::tuple<FwdIter1, FwdIter2, FwdIter3> {
                     HPX_UNUSED(flags);
 
-                    output_iterator_offset count_pair = items.back().get();
+                    output_iterator_offset count_pair = items.back();
                     std::size_t count_true = get<0>(count_pair);
                     std::size_t count_false = get<1>(count_pair);
                     std::advance(dest_true, count_true);

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/reduce_by_key.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/reduce_by_key.hpp
@@ -196,56 +196,6 @@ namespace hpx { namespace parallel { inline namespace v1 {
         }
 
         // -------------------------------------------------------------------
-        // when we are being run with an asynchronous policy, we do not want to
-        // pass the policy directly to other algorithms we are using - as we
-        // would have to wait internally on them before proceeding.
-        // Instead create a new policy from the old one which removes the async/future
-        // -------------------------------------------------------------------
-        template <typename ExPolicy>
-        struct remove_asynchronous
-        {
-            typedef ExPolicy type;
-        };
-
-        template <>
-        struct remove_asynchronous<hpx::execution::parallel_unsequenced_policy>
-        {
-            typedef hpx::execution::parallel_policy type;
-        };
-
-        template <>
-        struct remove_asynchronous<hpx::execution::unsequenced_policy>
-        {
-            typedef hpx::execution::sequenced_policy type;
-        };
-
-        template <>
-        struct remove_asynchronous<hpx::execution::sequenced_task_policy>
-        {
-            typedef hpx::execution::sequenced_policy type;
-        };
-
-        template <typename Executor, typename Parameters>
-        struct remove_asynchronous<
-            hpx::execution::sequenced_task_policy_shim<Executor, Parameters>>
-        {
-            typedef hpx::execution::sequenced_policy type;
-        };
-
-        template <>
-        struct remove_asynchronous<hpx::execution::parallel_task_policy>
-        {
-            typedef hpx::execution::parallel_policy type;
-        };
-
-        template <typename Executor, typename Parameters>
-        struct remove_asynchronous<
-            hpx::execution::parallel_task_policy_shim<Executor, Parameters>>
-        {
-            typedef hpx::execution::parallel_policy type;
-        };
-
-        // -------------------------------------------------------------------
         // The main algorithm is implemented here, it replaces any async
         // execution policy with a non async one so that no waits are
         // necessry on the internal algorithms. Async execution is handled
@@ -262,26 +212,18 @@ namespace hpx { namespace parallel { inline namespace v1 {
             using namespace hpx::parallel::v1::detail;
             using namespace hpx::util;
 
-            typedef typename detail::remove_asynchronous<
-                typename std::decay<ExPolicy>::type>::type sync_policy_type;
-
-            auto sync_policy = sync_policy_type()
-                                   .on(policy.executor())
-                                   .with(policy.parameters());
-
             // we need to determine based on the keys what is the keystate for
             // each key. The states are start, middle, end of a series and the special
             // state start and end of the sequence
             std::vector<reduce_key_series_states> key_state;
-            typedef std::vector<reduce_key_series_states>::iterator
-                keystate_iter_type;
-            typedef detail::reduce_stencil_iterator<RanIter,
-                reduce_stencil_transformer>
-                reducebykey_iter;
-            typedef
-                typename std::iterator_traits<RanIter>::reference element_type;
-            typedef typename zip_iterator<reducebykey_iter,
-                keystate_iter_type>::reference zip_ref;
+            using keystate_iter_type =
+                std::vector<reduce_key_series_states>::iterator;
+            using reducebykey_iter = detail::reduce_stencil_iterator<RanIter,
+                reduce_stencil_transformer>;
+            using element_type =
+                typename std::iterator_traits<RanIter>::reference;
+            using zip_ref = typename zip_iterator<reducebykey_iter,
+                keystate_iter_type>::reference;
             //
             const std::uint64_t number_of_keys =
                 std::distance(key_first, key_last);
@@ -320,7 +262,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                     reduce_stencil_generate<reduce_stencil_transformer, RanIter,
                         keystate_iter_type, Compare>
                         kernel;
-                    hpx::for_each(sync_policy,
+                    hpx::for_each(policy(hpx::execution::non_task),
                         make_zip_iterator(
                             reduce_begin + 1, key_state.begin() + 1),
                         make_zip_iterator(reduce_end - 1, key_state.end() - 1),
@@ -335,17 +277,15 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 }
             }
             {
-                typedef zip_iterator<RanIter2,
-                    std::vector<reduce_key_series_states>::iterator>
-                    zip_iterator_in;
-                typedef typename zip_iterator_in::value_type zip_type_in;
+                using zip_iterator_in = zip_iterator<RanIter2,
+                    std::vector<reduce_key_series_states>::iterator>;
+                using zip_type_in = typename zip_iterator_in::value_type;
 
-                typedef zip_iterator<FwdIter2,
-                    std::vector<reduce_key_series_states>::iterator>
-                    zip_iterator_vout;
+                using zip_iterator_vout = zip_iterator<FwdIter2,
+                    std::vector<reduce_key_series_states>::iterator>;
 
-                typedef typename std::iterator_traits<RanIter2>::value_type
-                    value_type;
+                using value_type =
+                    typename std::iterator_traits<RanIter2>::value_type;
 
                 zip_iterator_in states_begin = make_zip_iterator(
                     values_first, hpx::util::begin(key_state));
@@ -357,10 +297,11 @@ namespace hpx { namespace parallel { inline namespace v1 {
 
                 zip_type_in initial;
                 //
-                typedef hpx::tuple<value_type, reduce_key_series_states>
-                    lambda_type;
+                using lambda_type =
+                    hpx::tuple<value_type, reduce_key_series_states>;
                 hpx::inclusive_scan(
-                    sync_policy, states_begin, states_end, states_out_begin,
+                    policy(hpx::execution::non_task), states_begin, states_end,
+                    states_out_begin,
                     // B is the current entry, A is the one passed in from 'previous'
                     [&func](zip_type_in a, zip_type_in b) -> lambda_type {
                         value_type a_val = hpx::get<0>(a);
@@ -395,16 +336,16 @@ namespace hpx { namespace parallel { inline namespace v1 {
 
                 // now copy the values and keys for each element that
                 // is marked by an 'END' state to the final output
-                typedef typename hpx::util::zip_iterator<RanIter, FwdIter2,
-                    std::vector<reduce_key_series_states>::iterator>::reference
-                    zip2_ref;
+                using zip2_ref = typename hpx::util::zip_iterator<RanIter,
+                    FwdIter2,
+                    std::vector<reduce_key_series_states>::iterator>::reference;
 
                 std::vector<value_type> temp(number_of_keys);
-                hpx::copy(sync_policy, values_output,
+                hpx::copy(policy(hpx::execution::non_task), values_output,
                     values_output + number_of_keys, temp.begin());
 
                 return make_pair_result(
-                    hpx::ranges::copy_if(sync_policy,
+                    hpx::ranges::copy_if(policy(hpx::execution::non_task),
                         make_zip_iterator(key_first, temp.begin(),
                             hpx::util::begin(key_state)),
                         make_zip_iterator(key_last,

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/reduce_by_key.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/reduce_by_key.hpp
@@ -399,12 +399,16 @@ namespace hpx { namespace parallel { inline namespace v1 {
                     std::vector<reduce_key_series_states>::iterator>::reference
                     zip2_ref;
 
+                std::vector<value_type> temp(number_of_keys);
+                hpx::copy(sync_policy, values_output,
+                    values_output + number_of_keys, temp.begin());
+
                 return make_pair_result(
                     hpx::ranges::copy_if(sync_policy,
-                        make_zip_iterator(key_first, values_output,
+                        make_zip_iterator(key_first, temp.begin(),
                             hpx::util::begin(key_state)),
                         make_zip_iterator(key_last,
-                            values_output + number_of_keys,
+                            temp.begin() + number_of_keys,
                             hpx::util::end(key_state)),
                         make_zip_iterator(keys_output, values_output,
                             hpx::util::begin(key_state)),

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/transform_exclusive_scan.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/transform_exclusive_scan.hpp
@@ -368,12 +368,10 @@ namespace hpx { namespace parallel { inline namespace v1 {
                     // step 3 runs final accumulation on each partition
                     std::move(f3),
                     // use this return value
-                    [last_iter, final_dest](
-                        std::vector<hpx::shared_future<T>>&& items,
+                    [last_iter, final_dest](std::vector<T>&&,
                         std::vector<hpx::future<void>>&& data) -> result_type {
                         // make sure iterators embedded in function object that is
                         // attached to futures are invalidated
-                        items.clear();
                         data.clear();
 
                         return result_type{last_iter, final_dest};

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/transform_exclusive_scan.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/transform_exclusive_scan.hpp
@@ -338,11 +338,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 using hpx::util::make_zip_iterator;
 
                 auto f3 = [op](zip_iterator part_begin, std::size_t part_size,
-                              hpx::shared_future<T> curr,
-                              hpx::shared_future<T> next) -> void {
-                    next.get();    // rethrow exceptions
-
-                    T val = curr.get();
+                              T val) -> void {
                     FwdIter2 dst = get<1>(part_begin.get_iterator_tuple());
                     *dst++ = val;
 
@@ -368,7 +364,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                     },
                     // step 2 propagates the partition results from left
                     // to right
-                    hpx::unwrapping(op),
+                    op,
                     // step 3 runs final accumulation on each partition
                     std::move(f3),
                     // use this return value

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/transform_inclusive_scan.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/transform_inclusive_scan.hpp
@@ -550,11 +550,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 using hpx::util::make_zip_iterator;
 
                 auto f3 = [op](zip_iterator part_begin, std::size_t part_size,
-                              hpx::shared_future<T> curr,
-                              hpx::shared_future<T> next) -> void {
-                    next.get();    // rethrow exceptions
-
-                    T val = curr.get();
+                              T val) -> void {
                     FwdIter2 dst = get<1>(part_begin.get_iterator_tuple());
 
                     util::loop_n<std::decay_t<ExPolicy>>(
@@ -580,7 +576,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                     },
                     // step 2 propagates the partition results from left
                     // to right
-                    hpx::unwrapping(op),
+                    op,
                     // step 3 runs final accumulation on each partition
                     std::move(f3),
                     // step 4 use this return value

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/transform_inclusive_scan.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/transform_inclusive_scan.hpp
@@ -580,12 +580,10 @@ namespace hpx { namespace parallel { inline namespace v1 {
                     // step 3 runs final accumulation on each partition
                     std::move(f3),
                     // step 4 use this return value
-                    [last_iter, final_dest](
-                        std::vector<hpx::shared_future<T>>&& items,
+                    [last_iter, final_dest](std::vector<T>&&,
                         std::vector<hpx::future<void>>&& data) -> result_type {
                         // make sure iterators embedded in function object that is
                         // attached to futures are invalidated
-                        items.clear();
                         data.clear();
                         return result_type{last_iter, final_dest};
                     });

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/unique.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/unique.hpp
@@ -869,10 +869,8 @@ namespace hpx { namespace parallel { inline namespace v1 {
                     util::loop_n<std::decay_t<ExPolicy>>(++part_begin,
                         part_size,
                         [base, pred, proj, &curr](zip_iterator it) mutable {
-                            using hpx::util::invoke;
-
-                            bool f = invoke(pred, invoke(proj, *base),
-                                invoke(proj, get<0>(*it)));
+                            bool f = HPX_INVOKE(pred, HPX_INVOKE(proj, *base),
+                                HPX_INVOKE(proj, get<0>(*it)));
 
                             if (!(get<1>(*it) = f))
                             {
@@ -895,18 +893,16 @@ namespace hpx { namespace parallel { inline namespace v1 {
                         });
                 };
 
-                auto f4 =
-                    [last_iter, dest, flags](
-                        std::vector<hpx::shared_future<std::size_t>>&& items,
-                        std::vector<hpx::future<void>>&& data) mutable
+                auto f4 = [last_iter, dest, flags](
+                              std::vector<std::size_t>&& items,
+                              std::vector<hpx::future<void>>&& data) mutable
                     -> unique_copy_result<FwdIter1, FwdIter2> {
                     HPX_UNUSED(flags);
 
-                    std::advance(dest, items.back().get());
+                    std::advance(dest, items.back());
 
                     // make sure iterators embedded in function object that is
                     // attached to futures are invalidated
-                    items.clear();
                     data.clear();
 
                     return unique_copy_result<FwdIter1, FwdIter2>{

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/unique.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/unique.hpp
@@ -883,16 +883,11 @@ namespace hpx { namespace parallel { inline namespace v1 {
 
                     return curr;
                 };
-                auto f3 =
-                    [dest, flags](zip_iterator part_begin,
-                        std::size_t part_size,
-                        hpx::shared_future<std::size_t> curr,
-                        hpx::shared_future<std::size_t> next) mutable -> void {
+                auto f3 = [dest, flags](zip_iterator part_begin,
+                              std::size_t part_size,
+                              std::size_t val) mutable -> void {
                     HPX_UNUSED(flags);
-
-                    next.get();    // rethrow exceptions
-
-                    std::advance(dest, curr.get());
+                    std::advance(dest, val);
                     util::loop_n<std::decay_t<ExPolicy>>(++part_begin,
                         part_size, [&dest](zip_iterator it) mutable {
                             if (!get<1>(*it))
@@ -926,7 +921,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                     std::move(f1),
                     // step 2 propagates the partition results from left
                     // to right
-                    hpx::unwrapping(std::plus<std::size_t>()),
+                    std::plus<std::size_t>(),
                     // step 3 runs final accumulation on each partition
                     std::move(f3),
                     // step 4 use this return value

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/unique.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/unique.hpp
@@ -866,9 +866,8 @@ namespace hpx { namespace parallel { inline namespace v1 {
                     std::size_t curr = 0;
 
                     // MSVC complains if pred or proj is captured by ref below
-                    util::loop_n<std::decay_t<ExPolicy>>(++part_begin,
-                        part_size,
-                        [base, pred, proj, &curr](zip_iterator it) mutable {
+                    util::loop_n<std::decay_t<ExPolicy>>(
+                        ++part_begin, part_size, [&](zip_iterator it) mutable {
                             bool f = HPX_INVOKE(pred, HPX_INVOKE(proj, *base),
                                 HPX_INVOKE(proj, get<0>(*it)));
 

--- a/libs/core/algorithms/tests/performance/CMakeLists.txt
+++ b/libs/core/algorithms/tests/performance/CMakeLists.txt
@@ -18,6 +18,7 @@ set(benchmarks
     benchmark_partition_copy
     benchmark_remove
     benchmark_remove_if
+    benchmark_scan_algorithms
     benchmark_unique
     benchmark_unique_copy
     foreach_scaling

--- a/libs/core/algorithms/tests/performance/benchmark_scan_algorithms.cpp
+++ b/libs/core/algorithms/tests/performance/benchmark_scan_algorithms.cpp
@@ -4,11 +4,23 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include <hpx/algorithm.hpp>
-#include <hpx/hpx_init.hpp>
+#include <hpx/local/init.hpp>
+#include <hpx/modules/program_options.hpp>
+#include <hpx/modules/testing.hpp>
+#include <hpx/parallel/algorithms/copy.hpp>
+#include <hpx/parallel/algorithms/exclusive_scan.hpp>
+#include <hpx/parallel/algorithms/inclusive_scan.hpp>
+#include <hpx/parallel/algorithms/transform_exclusive_scan.hpp>
+#include <hpx/parallel/algorithms/transform_inclusive_scan.hpp>
+#include <hpx/parallel/algorithms/unique.hpp>
 
+#include <array>
+#include <cstddef>
 #include <fstream>
 #include <functional>
+#include <iostream>
+#include <map>
+#include <string>
 #include <vector>
 
 //#define OUTPUT_TO_CSV
@@ -177,8 +189,25 @@ void measureScanAlgorithms()
     }
 }
 
-int hpx_main(int, char**)
+int hpx_main(hpx::program_options::variables_map&)
 {
-    measureScanAlgorithms();
-    return hpx::finalize();
+    {
+        measureScanAlgorithms();
+    };
+    // Initiate shutdown of the runtime systems on all localities.
+    return hpx::local::finalize();
+};
+
+int main(int argc, char* argv[])
+{
+    std::vector<std::string> cfg;
+    cfg.push_back("hpx.os_threads=all");
+    hpx::local::init_params init_args;
+    init_args.cfg = cfg;
+
+    // Initialize and run HPX.
+    HPX_TEST_EQ_MSG(hpx::local::init(hpx_main, argc, argv, init_args), 0,
+        "HPX main exited with non-zero status");
+
+    return hpx::util::report_errors();
 }

--- a/libs/core/algorithms/tests/performance/benchmark_scan_algorithms.cpp
+++ b/libs/core/algorithms/tests/performance/benchmark_scan_algorithms.cpp
@@ -1,0 +1,184 @@
+//  Copyright (c) 2021 Akhil J Nair
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/algorithm.hpp>
+#include <hpx/hpx_init.hpp>
+
+#include <fstream>
+#include <functional>
+#include <vector>
+
+//#define OUTPUT_TO_CSV
+
+enum class ALGORITHM
+{
+    EXCLUSIVE_SCAN,
+    INCLUSIVE_SCAN,
+    TRANSFORM_EXCLUSIVE_SCAN,
+    TRANSFORM_INCLUSIVE_SCAN,
+    COPY_IF,
+    UNIQUE_COPY
+};
+
+void measureScanAlgorithms()
+{
+#if defined(OUTPUT_TO_CSV)
+    std::map<ALGORITHM, std::string> filenames = {
+        {ALGORITHM::EXCLUSIVE_SCAN, "exclusiveScanCompare.csv"},
+        {ALGORITHM::INCLUSIVE_SCAN, "inclusiveScanCompare.csv"},
+        {ALGORITHM::TRANSFORM_EXCLUSIVE_SCAN,
+            "transformExclusiveScanCompare.csv"},
+        {ALGORITHM::TRANSFORM_INCLUSIVE_SCAN,
+            "transformInclusiveScanCompare.csv"},
+        {ALGORITHM::COPY_IF, "copyIfCompare.csv"},
+        {ALGORITHM::UNIQUE_COPY, "uniqueCopyCompare.csv"},
+    };
+#endif
+
+    for (int alg = (int) ALGORITHM::EXCLUSIVE_SCAN;
+         alg <= (int) ALGORITHM::UNIQUE_COPY; alg++)
+    {
+        std::size_t start = 32;
+        std::size_t till = 1 << 30;
+
+        const auto NUM_ITERATIONS = 50;
+
+        std::vector<std::array<double, 3>> data;
+
+        for (std::size_t s = start; s <= till; s *= 2)
+        {
+            std::vector<int> arr(s);
+            std::iota(std::begin(arr), std::end(arr), 1);
+
+            double seqTime = 0;
+            double parTime = 0;
+
+            for (int i = 0; i < NUM_ITERATIONS + 5; i++)
+            {
+                std::vector<int> res(s);
+                auto t1 = std::chrono::high_resolution_clock::now();
+
+                switch ((ALGORITHM) alg)
+                {
+                case ALGORITHM::INCLUSIVE_SCAN:
+                    hpx::inclusive_scan(arr.begin(), arr.end(), res.begin(),
+                        std::plus<int>(), 0);
+                    break;
+                case ALGORITHM::EXCLUSIVE_SCAN:
+                    hpx::exclusive_scan(arr.begin(), arr.end(), res.begin(), 10,
+                        std::plus<int>{});
+                    break;
+                case ALGORITHM::TRANSFORM_EXCLUSIVE_SCAN:
+                    hpx::transform_exclusive_scan(arr.begin(), arr.end(),
+                        res.begin(), 10, std::plus<int>{},
+                        [](int x) { return x * 10; });
+                    break;
+                case ALGORITHM::TRANSFORM_INCLUSIVE_SCAN:
+                    hpx::transform_inclusive_scan(
+                        arr.begin(), arr.end(), res.begin(), std::plus<int>{},
+                        [](int x) { return x * 10; }, 10);
+                    break;
+                case ALGORITHM::COPY_IF:
+                    hpx::copy_if(arr.begin(), arr.end(), res.begin(),
+                        [](int x) { return (x % 2) != 0; });
+                    break;
+                case ALGORITHM::UNIQUE_COPY:
+                    hpx::unique_copy(arr.begin(), arr.end(), res.begin(),
+                        std::equal_to<int>{});
+                    break;
+                };
+                auto end1 = std::chrono::high_resolution_clock::now();
+
+                // don't consider first 5 iterations
+                if (NUM_ITERATIONS < 5)
+                {
+                    continue;
+                }
+
+                std::chrono::duration<double> time_span1 =
+                    std::chrono::duration_cast<std::chrono::duration<double>>(
+                        end1 - t1);
+
+                seqTime += time_span1.count();
+            }
+
+            for (int i = 0; i < NUM_ITERATIONS + 5; i++)
+            {
+                std::vector<int> res1(s);
+                auto t2 = std::chrono::high_resolution_clock::now();
+                switch ((ALGORITHM) alg)
+                {
+                case ALGORITHM::INCLUSIVE_SCAN:
+                    hpx::inclusive_scan(hpx::execution::par, arr.begin(),
+                        arr.end(), res1.begin(), std::plus<int>(), 0);
+                    break;
+                case ALGORITHM::EXCLUSIVE_SCAN:
+                    hpx::exclusive_scan(hpx::execution::par, arr.begin(),
+                        arr.end(), res1.begin(), 10, std::plus<int>{});
+                    break;
+                case ALGORITHM::TRANSFORM_EXCLUSIVE_SCAN:
+                    hpx::transform_exclusive_scan(hpx::execution::par,
+                        arr.begin(), arr.end(), res1.begin(), 10,
+                        std::plus<int>{}, [](int x) { return x * 10; });
+                    break;
+                case ALGORITHM::TRANSFORM_INCLUSIVE_SCAN:
+                    hpx::transform_inclusive_scan(
+                        hpx::execution::par, arr.begin(), arr.end(),
+                        res1.begin(), std::plus<int>{},
+                        [](int x) { return x * 10; }, 10);
+                    break;
+                case ALGORITHM::COPY_IF:
+                    hpx::copy_if(hpx::execution::par, arr.begin(), arr.end(),
+                        res1.begin(), [](int x) { return (x % 2) != 0; });
+                    break;
+                case ALGORITHM::UNIQUE_COPY:
+                    hpx::unique_copy(hpx::execution::par, arr.begin(),
+                        arr.end(), res1.begin(), std::equal_to<int>{});
+                    break;
+                };
+                auto end2 = std::chrono::high_resolution_clock::now();
+
+                // don't consider first 5 iterations
+                if (NUM_ITERATIONS < 5)
+                {
+                    continue;
+                }
+
+                std::chrono::duration<double> time_span2 =
+                    std::chrono::duration_cast<std::chrono::duration<double>>(
+                        end2 - t2);
+
+                parTime += time_span2.count();
+            }
+
+            seqTime /= NUM_ITERATIONS;
+            parTime /= NUM_ITERATIONS;
+
+#if defined(OUTPUT_TO_CSV)
+            data.push_back(std::array<double, 3>{(double) s, seqTime, parTime});
+#else
+            std::cout << "N : " << s << '\n';
+            std::cout << "SEQ: " << seqTime << '\n';
+            std::cout << "PAR: " << parTime << "\n\n";
+#endif
+        }
+
+#if defined(OUTPUT_TO_CSV)
+        std::ofstream outputFile(filenames[(ALGORITHM) alg]);
+        for (auto& d : data)
+        {
+            outputFile << d[0] << "," << d[1] << "," << d[2] << ","
+                       << ",\n";
+        }
+#endif
+    }
+}
+
+int hpx_main(int, char**)
+{
+    measureScanAlgorithms();
+    return hpx::finalize();
+}

--- a/libs/core/algorithms/tests/performance/benchmark_scan_algorithms.cpp
+++ b/libs/core/algorithms/tests/performance/benchmark_scan_algorithms.cpp
@@ -54,9 +54,9 @@ void measureScanAlgorithms()
          alg <= (int) ALGORITHM::UNIQUE_COPY; alg++)
     {
         std::size_t start = 32;
-        std::size_t till = 1 << 30;
+        std::size_t till = 1 << 28;
 
-        const auto NUM_ITERATIONS = 50;
+        const auto NUM_ITERATIONS = 5;
 
         std::vector<std::array<double, 3>> data;
 

--- a/libs/core/algorithms/tests/performance/benchmark_scan_algorithms.cpp
+++ b/libs/core/algorithms/tests/performance/benchmark_scan_algorithms.cpp
@@ -54,7 +54,7 @@ void measureScanAlgorithms()
          alg <= (int) ALGORITHM::UNIQUE_COPY; alg++)
     {
         std::size_t start = 32;
-        std::size_t till = 1 << 28;
+        std::size_t till = 1 << 10;
 
         const auto NUM_ITERATIONS = 5;
 

--- a/libs/core/datastructures/include/hpx/datastructures/tuple.hpp
+++ b/libs/core/datastructures/include/hpx/datastructures/tuple.hpp
@@ -153,7 +153,7 @@ namespace hpx {
         struct are_tuples_compatible<tuple<Ts...>, UTuple>
           : are_tuples_compatible_impl<
                 typename util::make_index_pack<sizeof...(Ts)>::type,
-                tuple<Ts...>, UTuple>
+                hpx::tuple<Ts...>, UTuple>
         {
         };
 

--- a/libs/core/execution/tests/regressions/chunk_size_4118.cpp
+++ b/libs/core/execution/tests/regressions/chunk_size_4118.cpp
@@ -18,16 +18,17 @@
 
 struct test_async_executor : hpx::execution::parallel_executor
 {
-    template <typename F, typename T>
-    hpx::future<typename hpx::util::invoke_result<F, T, std::size_t>::type>
-    async_execute(F&& f, T&& t, std::size_t chunk_size)
+    template <typename F, typename T, typename... Ts>
+    hpx::future<
+        typename hpx::util::invoke_result<F, T, std::size_t, Ts...>::type>
+    async_execute(F&& f, T&& t, std::size_t chunk_size, Ts&&... ts)
     {
         // make sure the chunk_size is equal to what was specified below
         HPX_TEST_EQ(chunk_size, std::size_t(50000));
 
         using base_type = hpx::execution::parallel_executor;
-        return this->base_type::async_execute(
-            std::forward<F>(f), std::forward<T>(t), chunk_size);
+        return this->base_type::async_execute(std::forward<F>(f),
+            std::forward<T>(t), chunk_size, std::forward<Ts>(ts)...);
     }
 };
 


### PR DESCRIPTION
Modify scan partitioner implementation to execute f2 sequentially once f1 tasks are done, so that f3 tasks can all be executed in parallel.
Minor changes to algorithms using the scan partitioner.
Added benchmark for comparing sequential and parallel execution times of scan algorithms.

## Any background context you want to provide?
Issue #3733
