### PR TITLE
Adapt simd adj diff

### DIFF
--- a/libs/core/algorithms/CMakeLists.txt
+++ b/libs/core/algorithms/CMakeLists.txt
@@ -142,6 +142,7 @@ set(algorithms_headers
     hpx/parallel/container_numeric.hpp
     hpx/parallel/datapar.hpp
     hpx/parallel/datapar/fill.hpp
+    hpx/parallel/datapar/adjacent_difference.hpp
     hpx/parallel/datapar/iterator_helpers.hpp
     hpx/parallel/datapar/loop.hpp
     hpx/parallel/datapar/transfer.hpp

--- a/libs/core/algorithms/CMakeLists.txt
+++ b/libs/core/algorithms/CMakeLists.txt
@@ -17,6 +17,7 @@ set(algorithms_headers
     hpx/parallel/algorithms/copy.hpp
     hpx/parallel/algorithms/count.hpp
     hpx/parallel/algorithms/destroy.hpp
+    hpx/parallel/algorithms/detail/adjacent_difference.hpp
     hpx/parallel/algorithms/detail/accumulate.hpp
     hpx/parallel/algorithms/detail/advance_and_get_distance.hpp
     hpx/parallel/algorithms/detail/advance_to_sentinel.hpp

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/adjacent_difference.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/adjacent_difference.hpp
@@ -189,10 +189,10 @@ namespace hpx { namespace parallel { inline namespace v1 {
     adjacent_difference(
         ExPolicy&& policy, FwdIter1 first, FwdIter1 last, FwdIter2 dest)
     {
-        typedef typename std::iterator_traits<FwdIter1>::value_type value_type;
         typedef hpx::traits::is_segmented_iterator<FwdIter1> is_segmented;
-        return detail::adjacent_difference_(std::forward<ExPolicy>(policy),
-            first, last, dest, std::minus<value_type>(), is_segmented());
+        return detail::adjacent_difference_(
+            std::forward<ExPolicy>(policy), first, last, dest,
+            [](const auto& x, const auto& y) { return x - y; }, is_segmented());
     }
 
     ////////////////////////////////////////////////////////////////////////////

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/adjacent_difference.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/adjacent_difference.hpp
@@ -14,6 +14,7 @@
 #include <hpx/iterator_support/zip_iterator.hpp>
 
 #include <hpx/executors/execution_policy.hpp>
+#include <hpx/parallel/algorithms/detail/adjacent_difference.hpp>
 #include <hpx/parallel/algorithms/detail/dispatch.hpp>
 #include <hpx/parallel/util/detail/algorithm_result.hpp>
 #include <hpx/parallel/util/loop.hpp>
@@ -47,7 +48,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
             static OutIter sequential(
                 ExPolicy, InIter first, InIter last, OutIter dest, Op&& op)
             {
-                return std::adjacent_difference(
+                return sequential_adjacent_difference<ExPolicy>(
                     first, last, dest, std::forward<Op>(op));
             }
 
@@ -83,7 +84,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                     // VS2015RC bails out when op is captured by ref
                     using hpx::get;
                     util::loop_n<std::decay_t<ExPolicy>>(
-                        part_begin, part_size, [op](zip_iterator it) {
+                        part_begin, part_size, [op](auto&& it) {
                             get<2>(*it) =
                                 hpx::util::invoke(op, get<0>(*it), get<1>(*it));
                         });

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/detail/adjacent_difference.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/detail/adjacent_difference.hpp
@@ -1,0 +1,53 @@
+//  Copyright (c) 2021 Srinivas Yadav
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include <hpx/config.hpp>
+#include <hpx/execution/traits/is_execution_policy.hpp>
+#include <hpx/functional/invoke.hpp>
+#include <hpx/functional/tag_fallback_dispatch.hpp>
+#include <hpx/parallel/util/loop.hpp>
+#include <hpx/parallel/util/projection_identity.hpp>
+
+#include <functional>
+#include <iostream>
+#include <type_traits>
+
+namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
+
+    template <typename ExPolicy>
+    struct sequential_adjacent_difference_t
+      : hpx::functional::tag_fallback<
+            sequential_adjacent_difference_t<ExPolicy>>
+    {
+    private:
+        template <typename InIter, typename OutIter, typename Op>
+        friend inline OutIter tag_fallback_dispatch(
+            sequential_adjacent_difference_t<ExPolicy>, InIter first,
+            InIter last, OutIter dest, Op&& op)
+        {
+            return std::adjacent_difference(
+                first, last, dest, std::forward<Op>(op));
+        }
+    };
+
+#if !defined(HPX_COMPUTE_DEVICE_CODE)
+    template <typename ExPolicy>
+    HPX_INLINE_CONSTEXPR_VARIABLE sequential_adjacent_difference_t<ExPolicy>
+        sequential_adjacent_difference =
+            sequential_adjacent_difference_t<ExPolicy>{};
+#else
+    template <typename ExPolicy, typename InIter, typename OutIter, typename Op>
+    HPX_HOST_DEVICE HPX_FORCEINLINE OutIter sequential_adjacent_difference(
+        InIter first, InIter last, OutIter dest, Op&& op)
+    {
+        return sequential_adjacent_difference_t<
+            ExPolicy>{}(first, last, dest, std::forward<Op>(op));
+    }
+#endif
+
+}}}}    // namespace hpx::parallel::v1::detail

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/detail/adjacent_difference.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/detail/adjacent_difference.hpp
@@ -16,6 +16,7 @@
 #include <functional>
 #include <iostream>
 #include <type_traits>
+#include <utility>
 
 namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
 
@@ -45,8 +46,8 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
     HPX_HOST_DEVICE HPX_FORCEINLINE OutIter sequential_adjacent_difference(
         InIter first, InIter last, OutIter dest, Op&& op)
     {
-        return sequential_adjacent_difference_t<
-            ExPolicy>{}(first, last, dest, std::forward<Op>(op));
+        return sequential_adjacent_difference_t<ExPolicy>{}(
+            first, last, dest, std::forward<Op>(op));
     }
 #endif
 

--- a/libs/core/algorithms/include/hpx/parallel/datapar.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/datapar.hpp
@@ -12,8 +12,8 @@
 #if defined(HPX_HAVE_DATAPAR)
 
 #include <hpx/executors/datapar/execution_policy.hpp>
-#include <hpx/parallel/datapar/fill.hpp>
 #include <hpx/parallel/datapar/adjacent_difference.hpp>
+#include <hpx/parallel/datapar/fill.hpp>
 #include <hpx/parallel/datapar/iterator_helpers.hpp>
 #include <hpx/parallel/datapar/loop.hpp>
 #include <hpx/parallel/datapar/transfer.hpp>

--- a/libs/core/algorithms/include/hpx/parallel/datapar.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/datapar.hpp
@@ -13,6 +13,7 @@
 
 #include <hpx/executors/datapar/execution_policy.hpp>
 #include <hpx/parallel/datapar/fill.hpp>
+#include <hpx/parallel/datapar/adjacent_difference.hpp>
 #include <hpx/parallel/datapar/iterator_helpers.hpp>
 #include <hpx/parallel/datapar/loop.hpp>
 #include <hpx/parallel/datapar/transfer.hpp>

--- a/libs/core/algorithms/include/hpx/parallel/datapar/adjacent_difference.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/datapar/adjacent_difference.hpp
@@ -1,0 +1,73 @@
+//  Copyright (c) 2021 Srinivas Yadav
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include <hpx/config.hpp>
+
+#if defined(HPX_HAVE_DATAPAR)
+#include <hpx/concepts/concepts.hpp>
+#include <hpx/execution/traits/is_execution_policy.hpp>
+#include <hpx/functional/tag_dispatch.hpp>
+#include <hpx/iterator_support/zip_iterator.hpp>
+#include <hpx/parallel/algorithms/detail/adjacent_difference.hpp>
+#include <hpx/parallel/datapar/iterator_helpers.hpp>
+#include <hpx/parallel/datapar/loop.hpp>
+#include <hpx/parallel/datapar/zip_iterator.hpp>
+#include <hpx/parallel/util/result_types.hpp>
+
+#include <cstddef>
+#include <iostream>
+#include <type_traits>
+#include <utility>
+
+namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
+
+    ///////////////////////////////////////////////////////////////////////////
+    template <typename ExPolicy>
+    struct datapar_adjacent_difference
+    {
+        template <typename InIter, typename OutIter, typename Op>
+        static inline OutIter call(
+            InIter first, InIter last, OutIter dest, Op&& op)
+        {
+            if (first == last)
+                return dest;
+            auto count = std::distance(first, last) - 1;
+
+            InIter prev = first;
+            *dest++ = *first++;
+
+            if (count == 0)
+            {
+                return dest;
+            }
+
+            using hpx::get;
+            using hpx::util::make_zip_iterator;
+            util::loop_n<std::decay_t<ExPolicy>>(
+                make_zip_iterator(first, prev, dest), count, [op](auto&& it) {
+                    get<2>(*it) =
+                        hpx::util::invoke(op, get<0>(*it), get<1>(*it));
+                });
+            std::advance(dest, count);
+            return dest;
+        }
+    };
+
+    template <typename ExPolicy, typename InIter, typename OutIter, typename Op,
+        HPX_CONCEPT_REQUIRES_(
+            hpx::is_vectorpack_execution_policy<ExPolicy>::value&&
+                hpx::parallel::util::detail::iterator_datapar_compatible<
+                    InIter>::value)>
+    inline OutIter tag_dispatch(sequential_adjacent_difference_t<ExPolicy>,
+        InIter first, InIter last, OutIter dest, Op&& op)
+    {
+        return datapar_adjacent_difference<ExPolicy>::call(
+            first, last, dest, std::forward<Op>(op));
+    }
+}}}}    // namespace hpx::parallel::v1::detail
+#endif

--- a/libs/core/algorithms/tests/unit/algorithms/CMakeLists.txt
+++ b/libs/core/algorithms/tests/unit/algorithms/CMakeLists.txt
@@ -18,8 +18,6 @@ endforeach()
 # add tests
 set(tests
     adjacentdifference
-    adjacentdifference_exception
-    adjacentdifference_bad_alloc
     adjacentfind
     adjacentfind_exception
     adjacentfind_bad_alloc
@@ -52,7 +50,7 @@ set(tests
     findfirstof
     findfirstof_binary
     findif
-    findifnot
+    findifnot    
     findifnot_exception
     findifnot_bad_alloc
     foreach

--- a/libs/core/algorithms/tests/unit/algorithms/CMakeLists.txt
+++ b/libs/core/algorithms/tests/unit/algorithms/CMakeLists.txt
@@ -50,7 +50,7 @@ set(tests
     findfirstof
     findfirstof_binary
     findif
-    findifnot    
+    findifnot
     findifnot_exception
     findifnot_bad_alloc
     foreach

--- a/libs/core/algorithms/tests/unit/algorithms/adjacentdifference.cpp
+++ b/libs/core/algorithms/tests/unit/algorithms/adjacentdifference.cpp
@@ -1,3 +1,4 @@
+//  Copyright (c) 2021 Srinivas Yadav
 //  Copyright (c) 2015 Daniel Bourgeois
 //
 //  SPDX-License-Identifier: BSL-1.0
@@ -5,59 +6,12 @@
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <hpx/local/init.hpp>
-#include <hpx/modules/testing.hpp>
-#include <hpx/parallel/algorithms/adjacent_difference.hpp>
 
-#include <cstddef>
 #include <iostream>
-#include <iterator>
-#include <numeric>
 #include <string>
 #include <vector>
 
-#include "test_utils.hpp"
-
-////////////////////////////////////////////////////////////////////////////
-template <typename ExPolicy>
-void test_adjacent_difference(ExPolicy policy)
-{
-    static_assert(hpx::is_execution_policy<ExPolicy>::value,
-        "hpx::is_execution_policy<ExPolicy>::value");
-
-    std::vector<std::size_t> c = test::random_iota(10007);
-    std::vector<std::size_t> d(10007);
-    std::vector<std::size_t> d_ans(10007);
-
-    auto it = hpx::parallel::adjacent_difference(
-        policy, std::begin(c), std::end(c), std::begin(d));
-    std::adjacent_difference(std::begin(c), std::end(c), std::begin(d_ans));
-
-    HPX_TEST(std::equal(std::begin(d), std::end(d), std::begin(d_ans),
-        [](std::size_t lhs, std::size_t rhs) -> bool { return lhs == rhs; }));
-
-    HPX_TEST(std::end(d) == it);
-}
-
-template <typename ExPolicy>
-void test_adjacent_difference_async(ExPolicy p)
-{
-    static_assert(hpx::is_execution_policy<ExPolicy>::value,
-        "hpx::is_execution_policy<ExPolicy>::value");
-
-    std::vector<std::size_t> c = test::random_iota(10007);
-    std::vector<std::size_t> d(10007);
-    std::vector<std::size_t> d_ans(10007);
-
-    auto f_it = hpx::parallel::adjacent_difference(
-        p, std::begin(c), std::end(c), std::begin(d));
-    std::adjacent_difference(std::begin(c), std::end(c), std::begin(d_ans));
-
-    f_it.wait();
-    HPX_TEST(std::equal(std::begin(d), std::end(d), std::begin(d_ans),
-        [](std::size_t lhs, std::size_t rhs) -> bool { return lhs == rhs; }));
-
-    HPX_TEST(std::end(d) == f_it.get());
-}
+#include "adjacentdifference_tests.hpp"
 
 void adjacent_difference_test()
 {
@@ -68,6 +22,48 @@ void adjacent_difference_test()
 
     test_adjacent_difference_async(seq(task));
     test_adjacent_difference_async(par(task));
+}
+
+template <typename IteratorTag>
+void test_adjacent_difference_exception()
+{
+    using namespace hpx::execution;
+
+    // If the execution policy object is of type vector_execution_policy,
+    // std::terminate shall be called. therefore we do not test exceptions
+    // with a vector execution policy
+    test_adjacent_difference_exception(seq, IteratorTag());
+    test_adjacent_difference_exception(par, IteratorTag());
+
+    test_adjacent_difference_exception_async(seq(task), IteratorTag());
+    test_adjacent_difference_exception_async(par(task), IteratorTag());
+}
+
+void adjacent_difference_exception_test()
+{
+    test_adjacent_difference_exception<std::random_access_iterator_tag>();
+    test_adjacent_difference_exception<std::forward_iterator_tag>();
+}
+
+template <typename IteratorTag>
+void test_adjacent_difference_bad_alloc()
+{
+    using namespace hpx::execution;
+
+    // If the execution policy object is of type vector_execution_policy,
+    // std::terminate shall be called. therefore we do not test exceptions
+    // with a vector execution policy
+    test_adjacent_difference_bad_alloc(seq, IteratorTag());
+    test_adjacent_difference_bad_alloc(par, IteratorTag());
+
+    test_adjacent_difference_bad_alloc_async(seq(task), IteratorTag());
+    test_adjacent_difference_bad_alloc_async(par(task), IteratorTag());
+}
+
+void adjacent_difference_bad_alloc_test()
+{
+    test_adjacent_difference_bad_alloc<std::random_access_iterator_tag>();
+    test_adjacent_difference_bad_alloc<std::forward_iterator_tag>();
 }
 
 int hpx_main(hpx::program_options::variables_map& vm)

--- a/libs/core/algorithms/tests/unit/algorithms/adjacentdifference_tests.hpp
+++ b/libs/core/algorithms/tests/unit/algorithms/adjacentdifference_tests.hpp
@@ -1,0 +1,216 @@
+//  Copyright (c) 2015 Daniel Bourgeois
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include <hpx/modules/testing.hpp>
+#include <hpx/parallel/algorithms/adjacent_difference.hpp>
+
+#include <cstddef>
+#include <iostream>
+#include <iterator>
+#include <numeric>
+#include <string>
+#include <vector>
+
+#include "test_utils.hpp"
+
+////////////////////////////////////////////////////////////////////////////
+template <typename ExPolicy>
+void test_adjacent_difference(ExPolicy policy)
+{
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
+
+    std::vector<std::size_t> c = test::random_iota(10007);
+    std::vector<std::size_t> d(10007);
+    std::vector<std::size_t> d_ans(10007);
+
+    auto it = hpx::parallel::adjacent_difference(
+        policy, std::begin(c), std::end(c), std::begin(d));
+    std::adjacent_difference(std::begin(c), std::end(c), std::begin(d_ans));
+
+    HPX_TEST(std::equal(std::begin(d), std::end(d), std::begin(d_ans),
+        [](auto lhs, auto rhs) { return lhs == rhs; }));
+
+    HPX_TEST(std::end(d) == it);
+}
+
+template <typename ExPolicy>
+void test_adjacent_difference_async(ExPolicy p)
+{
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
+
+    std::vector<std::size_t> c = test::random_iota(10007);
+    std::vector<std::size_t> d(10007);
+    std::vector<std::size_t> d_ans(10007);
+
+    auto f_it = hpx::parallel::adjacent_difference(
+        p, std::begin(c), std::end(c), std::begin(d));
+    std::adjacent_difference(std::begin(c), std::end(c), std::begin(d_ans));
+
+    f_it.wait();
+    HPX_TEST(std::equal(std::begin(d), std::end(d), std::begin(d_ans),
+        [](auto lhs, auto rhs) { return lhs == rhs; }));
+
+    HPX_TEST(std::end(d) == f_it.get());
+}
+
+///////////////////////////////////////////////////////////////////////////////
+template <typename ExPolicy, typename IteratorTag>
+void test_adjacent_difference_exception(ExPolicy policy, IteratorTag)
+{
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
+
+    typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef test::decorated_iterator<base_iterator, IteratorTag>
+        decorated_iterator;
+    std::vector<std::size_t> c(10007);
+    std::vector<std::size_t> d(10007);
+
+    bool caught_exception = false;
+    try
+    {
+        hpx::parallel::adjacent_difference(policy,
+            decorated_iterator(std::begin(c)), decorated_iterator(std::end(c)),
+            std::begin(d), [](auto lhs, auto rhs) {
+                throw std::runtime_error("test");
+                return lhs - rhs;
+            });
+        HPX_TEST(false);
+    }
+    catch (hpx::exception_list const& e)
+    {
+        caught_exception = true;
+        test::test_num_exceptions<ExPolicy, IteratorTag>::call(policy, e);
+    }
+    catch (...)
+    {
+        HPX_TEST(false);
+    }
+
+    HPX_TEST(caught_exception);
+}
+
+template <typename ExPolicy, typename IteratorTag>
+void test_adjacent_difference_exception_async(ExPolicy p, IteratorTag)
+{
+    typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef test::decorated_iterator<base_iterator, IteratorTag>
+        decorated_iterator;
+
+    std::vector<std::size_t> c(10007);
+    std::vector<std::size_t> d(10007);
+
+    bool caught_exception = false;
+    bool returned_from_algorithm = false;
+
+    try
+    {
+        hpx::future<base_iterator> f = hpx::parallel::adjacent_difference(p,
+            decorated_iterator(std::begin(c)), decorated_iterator(std::end(c)),
+            std::begin(d), [](auto lhs, auto rhs) {
+                throw std::runtime_error("test");
+                return lhs - rhs;
+            });
+
+        returned_from_algorithm = true;
+
+        f.get();
+
+        HPX_TEST(false);
+    }
+    catch (hpx::exception_list const& e)
+    {
+        caught_exception = true;
+        test::test_num_exceptions<ExPolicy, IteratorTag>::call(p, e);
+    }
+    catch (...)
+    {
+        HPX_TEST(false);
+    }
+
+    HPX_TEST(caught_exception);
+    HPX_TEST(returned_from_algorithm);
+}
+
+//////////////////////////////////////////////////////////////////////////////
+template <typename ExPolicy, typename IteratorTag>
+void test_adjacent_difference_bad_alloc(ExPolicy policy, IteratorTag)
+{
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
+
+    typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef test::decorated_iterator<base_iterator, IteratorTag>
+        decorated_iterator;
+
+    std::vector<std::size_t> c(10007);
+    std::vector<std::size_t> d(10007);
+
+    bool caught_bad_alloc = false;
+    try
+    {
+        hpx::parallel::adjacent_difference(policy,
+            decorated_iterator(std::begin(c)), decorated_iterator(std::end(c)),
+            std::begin(d), [](auto lhs, auto rhs) {
+                throw std::bad_alloc();
+                return lhs - rhs;
+            });
+    }
+    catch (std::bad_alloc const&)
+    {
+        caught_bad_alloc = true;
+    }
+    catch (...)
+    {
+        HPX_TEST(false);
+    }
+
+    HPX_TEST(caught_bad_alloc);
+}
+
+template <typename ExPolicy, typename IteratorTag>
+void test_adjacent_difference_bad_alloc_async(ExPolicy p, IteratorTag)
+{
+    typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef test::decorated_iterator<base_iterator, IteratorTag>
+        decorated_iterator;
+
+    std::vector<std::size_t> c(10007);
+    std::vector<std::size_t> d(10007);
+
+    bool caught_bad_alloc = false;
+    bool returned_from_algorithm = false;
+
+    try
+    {
+        hpx::future<base_iterator> f = hpx::parallel::adjacent_difference(p,
+            decorated_iterator(std::begin(c)), decorated_iterator(std::end(c)),
+            std::begin(d), [](auto lhs, auto rhs) {
+                throw std::bad_alloc();
+                return lhs - rhs;
+            });
+        returned_from_algorithm = true;
+
+        f.get();
+
+        HPX_TEST(false);
+    }
+    catch (std::bad_alloc const&)
+    {
+        caught_bad_alloc = true;
+    }
+    catch (...)
+    {
+        HPX_TEST(false);
+    }
+
+    HPX_TEST(caught_bad_alloc);
+    HPX_TEST(returned_from_algorithm);
+}

--- a/libs/core/algorithms/tests/unit/datapar_algorithms/CMakeLists.txt
+++ b/libs/core/algorithms/tests/unit/datapar_algorithms/CMakeLists.txt
@@ -11,6 +11,7 @@ if(HPX_WITH_DATAPAR_VC OR HPX_WITH_CXX20_EXPERIMENTAL_SIMD)
       ${tests}
       copy_datapar
       copyn_datapar
+      adjacentdifference_datapar
       count_datapar
       countif_datapar
       fill_datapar

--- a/libs/core/algorithms/tests/unit/datapar_algorithms/adjacentdifference_datapar.cpp
+++ b/libs/core/algorithms/tests/unit/datapar_algorithms/adjacentdifference_datapar.cpp
@@ -1,0 +1,96 @@
+//  Copyright (c) 2021 Srinivas Yadav
+//  Copyright (c) 2015 Daniel Bourgeois
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/include/datapar.hpp>
+#include <hpx/local/init.hpp>
+
+#include <iostream>
+#include <string>
+#include <vector>
+
+#include "../algorithms/adjacentdifference_tests.hpp"
+
+void adjacent_difference_test()
+{
+    using namespace hpx::execution;
+    test_adjacent_difference(simd);
+    test_adjacent_difference(par_simd);
+
+    test_adjacent_difference_async(simd(task));
+    test_adjacent_difference_async(par_simd(task));
+}
+
+template <typename IteratorTag>
+void test_adjacent_difference_exception()
+{
+    using namespace hpx::execution;
+    test_adjacent_difference_exception(simd, IteratorTag());
+    test_adjacent_difference_exception(par_simd, IteratorTag());
+
+    test_adjacent_difference_exception_async(simd(task), IteratorTag());
+    test_adjacent_difference_exception_async(par_simd(task), IteratorTag());
+}
+
+void adjacent_difference_exception_test()
+{
+    test_adjacent_difference_exception<std::random_access_iterator_tag>();
+    // test_adjacent_difference_exception<std::forward_iterator_tag>();
+}
+
+template <typename IteratorTag>
+void test_adjacent_difference_bad_alloc()
+{
+    using namespace hpx::execution;
+    test_adjacent_difference_bad_alloc(simd, IteratorTag());
+    test_adjacent_difference_bad_alloc(par_simd, IteratorTag());
+
+    test_adjacent_difference_bad_alloc_async(simd(task), IteratorTag());
+    test_adjacent_difference_bad_alloc_async(par_simd(task), IteratorTag());
+}
+
+void adjacent_difference_bad_alloc_test()
+{
+    test_adjacent_difference_bad_alloc<std::random_access_iterator_tag>();
+    // test_adjacent_difference_bad_alloc<std::forward_iterator_tag>();
+}
+
+int hpx_main(hpx::program_options::variables_map& vm)
+{
+    unsigned int seed = (unsigned int) std::time(nullptr);
+    if (vm.count("seed"))
+        seed = vm["seed"].as<unsigned int>();
+
+    std::cout << "using seed: " << seed << std::endl;
+    std::srand(seed);
+
+    adjacent_difference_test();
+    return hpx::local::finalize();
+}
+
+int main(int argc, char* argv[])
+{
+    // add command line option which controls the random number generator seed
+    using namespace hpx::program_options;
+    options_description desc_commandline(
+        "Usage: " HPX_APPLICATION_STRING " [options]");
+
+    desc_commandline.add_options()("seed,s", value<unsigned int>(),
+        "the random number generator seed to use for this run");
+
+    // By default this test should run on all available cores
+    std::vector<std::string> const cfg = {"hpx.os_threads=all"};
+
+    // Initialize and run HPX
+    hpx::local::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::local::init(hpx_main, argc, argv, init_args), 0,
+        "HPX main exited with non-zero status");
+
+    return hpx::util::report_errors();
+}


### PR DESCRIPTION
Fixes #2333 

## Proposed Changes

  - Moves sequential implementation of adjacent_difference to detail which enables overload for simd policy.
  - Adds new header in datapar for adjacent difference algorithm.
  - Splits the existing adjacent_difference into header and source files and merges exception and bad alloc tests into one.
  - Adds adjacent difference datapar unit test.
