### PR TITLE
fix coroutine_traits allocate calls, add unhandled_exception() implementation.

### DIFF
--- a/libs/core/futures/include/hpx/futures/traits/detail/future_await_traits.hpp
+++ b/libs/core/futures/include/hpx/futures/traits/detail/future_await_traits.hpp
@@ -258,6 +258,11 @@ namespace std {
                     this->base_type::set_value(std::forward<U>(value));
                 }
 
+                void unhandled_exception() noexcept
+                {
+                    this->base_type::set_exception(std::current_exception());
+                }
+
                 HPX_NODISCARD HPX_FORCEINLINE static void* operator new(
                     std::size_t size)
                 {
@@ -299,10 +304,15 @@ namespace std {
                     this->base_type::set_value();
                 }
 
+                void unhandled_exception() noexcept
+                {
+                    this->base_type::set_exception(std::current_exception());
+                }
+
                 HPX_NODISCARD HPX_FORCEINLINE static void* operator new(
                     std::size_t size)
                 {
-                    return base_type::allocate();
+                    return base_type::allocate(size);
                 }
 
                 HPX_FORCEINLINE static void operator delete(
@@ -341,6 +351,11 @@ namespace std {
                 void return_value(U&& value)
                 {
                     this->base_type::set_value(std::forward<U>(value));
+                }
+
+                void unhandled_exception() noexcept
+                {
+                    this->base_type::set_exception(std::current_exception());
                 }
 
                 HPX_NODISCARD HPX_FORCEINLINE static void* operator new(
@@ -384,10 +399,15 @@ namespace std {
                     this->base_type::set_value();
                 }
 
+                void unhandled_exception() noexcept
+                {
+                    this->base_type::set_exception(std::current_exception());
+                }
+
                 HPX_NODISCARD HPX_FORCEINLINE static void* operator new(
                     std::size_t size)
                 {
-                    return base_type::allocate();
+                    return base_type::allocate(size);
                 }
 
                 HPX_FORCEINLINE static void operator delete(


### PR DESCRIPTION
re: #5502, #5517

these are the changes required to get my coroutine-using application to build with gcc 10.2 & hpx.

it doesn't fix #5502 (I had to force `HPX_HAVE_CXX20_COROUTINES` in my non-cmake build).