### PR TITLE
Fixing the output formatting for id_types

### DIFF
--- a/libs/full/actions/tests/regressions/CMakeLists.txt
+++ b/libs/full/actions/tests/regressions/CMakeLists.txt
@@ -42,7 +42,6 @@ foreach(test ${tests})
     SOURCES ${sources} ${${test}_FLAGS}
     EXCLUDE_FROM_ALL
     FOLDER ${folder_name}
-    FOLDER "Tests/Regressions/Modules/Full/Actions"
   )
 
   add_hpx_regression_test("modules.actions" ${test} ${${test}_PARAMETERS})

--- a/libs/full/naming_base/src/gid_type.cpp
+++ b/libs/full/naming_base/src/gid_type.cpp
@@ -109,7 +109,7 @@ namespace hpx { namespace naming {
 
     std::string gid_type::to_string() const
     {
-        return hpx::util::format("{:016x}{:016x}", id_msb_, id_lsb_);
+        return hpx::util::format("{:016llx}{:016llx}", id_msb_, id_lsb_);
     }
 
     std::ostream& operator<<(std::ostream& os, gid_type const& id)
@@ -118,7 +118,7 @@ namespace hpx { namespace naming {
         if (id != naming::invalid_gid)
         {
             hpx::util::format_to(
-                os, "{{{:016x}, {:016x}}}", id.id_msb_, id.id_lsb_);
+                os, "{{{:016llx}, {:016llx}}}", id.id_msb_, id.id_lsb_);
         }
         else
         {

--- a/libs/full/naming_base/tests/regressions/CMakeLists.txt
+++ b/libs/full/naming_base/tests/regressions/CMakeLists.txt
@@ -1,5 +1,25 @@
-# Copyright (c) 2019 The STE||AR-Group
+# Copyright (c) 2021 The STE||AR-Group
 #
 # SPDX-License-Identifier: BSL-1.0
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+set(tests format_id_type)
+
+foreach(test ${tests})
+  set(sources ${test}.cpp)
+
+  source_group("Source Files" FILES ${sources})
+
+  set(folder_name "Tests/Regressions/Modules/Full/NamingBase")
+
+  # add example executable
+  add_hpx_executable(
+    ${test}_test INTERNAL_FLAGS
+    SOURCES ${sources} ${${test}_FLAGS}
+    EXCLUDE_FROM_ALL
+    FOLDER ${folder_name}
+  )
+
+  add_hpx_regression_test("modules.naming_base" ${test} ${${test}_PARAMETERS})
+endforeach()

--- a/libs/full/naming_base/tests/regressions/format_id_type.cpp
+++ b/libs/full/naming_base/tests/regressions/format_id_type.cpp
@@ -1,0 +1,30 @@
+//  Copyright (c) 2021 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/hpx_init.hpp>
+#include <hpx/modules/naming_base.hpp>
+#include <hpx/modules/runtime_distributed.hpp>
+#include <hpx/modules/testing.hpp>
+
+#include <sstream>
+#include <string>
+
+///////////////////////////////////////////////////////////////////////////////
+int hpx_main()
+{
+    std::stringstream strm;
+    strm << hpx::find_here();
+
+    HPX_TEST_EQ(
+        strm.str(), std::string("{0000000100000000, 0000000000000000}"));
+    return hpx::finalize();
+}
+
+int main(int argc, char** argv)
+{
+    HPX_TEST_EQ(hpx::init(argc, argv), 0);
+    return hpx::util::report_errors();
+}


### PR DESCRIPTION
This fixes the wrong output reported here: https://gist.github.com/severinstrobl/bfba712aa4a03454e5fbab65bd70046e