### PR TITLE
Remove unnecessary checks for C++17 for tests

### DIFF
--- a/libs/core/async_cuda/tests/unit/CMakeLists.txt
+++ b/libs/core/async_cuda/tests/unit/CMakeLists.txt
@@ -8,12 +8,9 @@ if(NOT HPX_WITH_ASYNC_CUDA)
   return()
 endif()
 
-set(tests cuda_future)
+set(tests cuda_future transform_stream)
 if(HPX_WITH_GPUBLAS)
   set(benchmarks ${benchmarks} cublas_matmul)
-endif()
-if(HPX_CXX_STANDARD GREATER_EQUAL 17)
-  list(APPEND tests transform_stream)
 endif()
 
 set(cublas_matmul_PARAMETERS THREADS_PER_LOCALITY 4)

--- a/libs/core/execution/tests/unit/CMakeLists.txt
+++ b/libs/core/execution/tests/unit/CMakeLists.txt
@@ -5,20 +5,6 @@
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 set(tests
-    bulk_async
-    executor_parameters
-    executor_parameters_dispatching
-    executor_parameters_timer_hooks
-    future_then_executor
-    minimal_async_executor
-    minimal_sync_executor
-    persistent_executor_parameters
-)
-
-if(HPX_CXX_STANDARD GREATER_EQUAL 17)
-  list(
-    APPEND
-    tests
     algorithm_bulk
     algorithm_detach
     algorithm_ensure_started
@@ -32,8 +18,15 @@ if(HPX_CXX_STANDARD GREATER_EQUAL 17)
     algorithm_sync_wait
     algorithm_transform
     algorithm_when_all
-  )
-endif()
+    bulk_async
+    executor_parameters
+    executor_parameters_dispatching
+    executor_parameters_timer_hooks
+    future_then_executor
+    minimal_async_executor
+    minimal_sync_executor
+    persistent_executor_parameters
+)
 
 set(future_then_executor_PARAMETERS THREADS_PER_LOCALITY 4)
 

--- a/libs/core/executors/tests/unit/CMakeLists.txt
+++ b/libs/core/executors/tests/unit/CMakeLists.txt
@@ -14,15 +14,13 @@ set(tests
     parallel_fork_executor
     parallel_policy_executor
     polymorphic_executor
+    scheduler_executor
     sequenced_executor
     service_executors
     shared_parallel_executor
     standalone_thread_pool_executor
+    thread_pool_scheduler
 )
-
-if(HPX_CXX_STANDARD GREATER_EQUAL 17)
-  list(APPEND tests thread_pool_scheduler scheduler_executor)
-endif()
 
 if(HPX_WITH_CXX17_STD_EXECUTION_POLICES)
   set(tests ${tests} std_execution_policies)

--- a/libs/core/synchronization/tests/unit/CMakeLists.txt
+++ b/libs/core/synchronization/tests/unit/CMakeLists.txt
@@ -5,6 +5,7 @@
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 set(tests
+    async_rw_mutex
     barrier_cpp20
     binary_semaphore_cpp20
     channel_mpmc_fib
@@ -27,10 +28,6 @@ set(tests
     stop_token
     stop_token_cb2
 )
-
-if(HPX_CXX_STANDARD GREATER_EQUAL 17)
-  list(APPEND tests async_rw_mutex)
-endif()
 
 set(async_rw_mutex_PARAMETERS THREADS_PER_LOCALITY 4)
 set(barrier_cpp20_PARAMETERS THREADS_PER_LOCALITY 4)

--- a/libs/full/compute_cuda/tests/performance/CMakeLists.txt
+++ b/libs/full/compute_cuda/tests/performance/CMakeLists.txt
@@ -5,11 +5,7 @@
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-set(benchmarks)
-
-if(HPX_CXX_STANDARD GREATER_EQUAL 17)
-  list(APPEND benchmarks synchronize)
-endif()
+set(benchmarks synchronize)
 
 set(synchronize_CUDA ON)
 


### PR DESCRIPTION
Not needed anymore since we require C++17.