### PR TITLE
Test case for any_sender should use hpx::tuple

### DIFF
--- a/libs/core/datastructures/tests/unit/tuple.cpp
+++ b/libs/core/datastructures/tests/unit/tuple.cpp
@@ -568,10 +568,12 @@ void tuple_std_test()
 
 void tuple_structured_binding_test()
 {
+#ifdef HPX_DATASTRUCTURES_HAVE_ADAPT_STD_TUPLE
     auto [a1, a2] = hpx::make_tuple(1, '2');
 
     HPX_TEST_EQ(a1, 1);
     HPX_TEST_EQ(a2, '2');
+#endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/libs/core/execution_base/tests/unit/any_sender.cpp
+++ b/libs/core/execution_base/tests/unit/any_sender.cpp
@@ -35,7 +35,7 @@ struct custom_type_non_copyable
 template <typename... Ts>
 struct non_copyable_sender
 {
-    std::tuple<std::decay_t<Ts>...> ts;
+    hpx::tuple<std::decay_t<Ts>...> ts;
 
     template <template <class...> class Tuple,
         template <class...> class Variant>
@@ -68,7 +68,7 @@ struct non_copyable_sender
     struct operation_state
     {
         std::decay_t<R> r;
-        std::tuple<std::decay_t<Ts>...> ts;
+        hpx::tuple<std::decay_t<Ts>...> ts;
 
         friend void tag_dispatch(
             hpx::execution::experimental::start_t, operation_state& os) noexcept
@@ -92,7 +92,7 @@ struct non_copyable_sender
 template <typename... Ts>
 struct sender
 {
-    std::tuple<std::decay_t<Ts>...> ts;
+    hpx::tuple<std::decay_t<Ts>...> ts;
 
     template <template <class...> class Tuple,
         template <class...> class Variant>
@@ -124,7 +124,7 @@ struct sender
     struct operation_state
     {
         std::decay_t<R> r;
-        std::tuple<std::decay_t<Ts>...> ts;
+        hpx::tuple<std::decay_t<Ts>...> ts;
 
         friend void tag_dispatch(
             hpx::execution::experimental::start_t, operation_state& os) noexcept

--- a/libs/core/functional/include/hpx/functional/invoke_fused.hpp
+++ b/libs/core/functional/include/hpx/functional/invoke_fused.hpp
@@ -69,8 +69,8 @@ namespace hpx { namespace util {
     ///          the first argument in the sequenced type will be treated as
     ///          the callee (this object).
     ///
-    /// \param t A type which is content accessible through a call
-    ///          to hpx#util#get.
+    /// \param t A type whose contents are accessible through a call
+    ///          to hpx#get.
     ///
     /// \returns The result of the callable object when it's called with
     ///          the content of the given sequenced type.


### PR DESCRIPTION
According to the documentation, the tuple type passed to `hpx::util::invoke_fused` must be compatible to `hpx::get`.
Also disabled unit test for structured binding in case compatibility between `hpx::tuple` and `std::tuple` is disabled.