### PR TITLE
Make use of shell-session to allow non-copyable $

### DIFF
--- a/docs/sphinx/contributing/docker_image.rst
+++ b/docs/sphinx/contributing/docker_image.rst
@@ -22,9 +22,9 @@ directly run the docker image. The image is based on Debian and Clang, and can
 be found on |docker_build_env|_. To start a container using the |hpx| build
 environment, run:
 
-.. code-block:: bash
+.. code-block:: shell-session
 
-   docker run --interactive --tty stellargroup/build_env:latest bash
+   $ docker run --interactive --tty stellargroup/build_env:latest bash
 
 You are now in an environment where all the |hpx| build and runtime dependencies
 are present. You can install additional packages according to your own needs.

--- a/docs/sphinx/contributing/modules.rst
+++ b/docs/sphinx/contributing/modules.rst
@@ -18,9 +18,9 @@ The tool `create_library_skeleton.py
 can be used to generate a basic skeleton. To create a library skeleton, run the
 tool in the ``libs`` subdirectory with the module name as an argument:
 
-.. code-block:: bash
+.. code-block:: shell-session
 
-    ./create_library_skeleton <lib_name>
+    $ ./create_library_skeleton <lib_name>
 
 This creates a skeleton with the necessary files for an |hpx| module. It will not create any actual source files. The structure of this skeleton is as follows:
 
@@ -123,37 +123,37 @@ the docker image.
 To produce the graph produced by CI run the following command (``HPX_SOURCE`` is
 assumed to hold the path to the |hpx| source directory):
 
-.. code-block:: sh
+.. code-block:: shell-session
 
-   cpp-dependencies --dir $HPX_SOURCE/libs --graph-cycles circular_dependencies.dot
+   $ cpp-dependencies --dir $HPX_SOURCE/libs --graph-cycles circular_dependencies.dot
 
 This will produce a ``dot`` file in the current directory. You can inspect this
 manually with a text editor. You can also convert this to an image if you have
 ``graphviz`` installed:
 
-.. code-block:: sh
+.. code-block:: shell-session
 
-   dot circular_dependencies.dot -Tsvg -o circular_dependencies.svg
+   $ dot circular_dependencies.dot -Tsvg -o circular_dependencies.svg
 
 This produces an ``svg`` file in the current directory which shows the circular
 dependencies. Note that if there are no cycles the image will be empty.
 
 You can use ``cpp-dependencies`` to print the include paths between two modules.
 
-.. code-block:: sh
+.. code-block:: shell-session
 
-   cpp-dependencies --dir $HPX_SOURCE/libs --shortest <from> <to>
+   $ cpp-dependencies --dir $HPX_SOURCE/libs --shortest <from> <to>
 
 prints all possible paths from the module ``<from>`` to the module ``<to>``. For
 example, as most modules depend on ``config``, the following should give you a
 long list of paths from ``algorithms`` to ``config``:
 
-.. code-block:: sh
+.. code-block:: shell-session
 
-   cpp-dependencies --dir $HPX_SOURCE/libs --shortest algorithms config
+   $ cpp-dependencies --dir $HPX_SOURCE/libs --shortest algorithms config
 
 The following should report that it can't find a path between the two modules:
 
-.. code-block:: sh
+.. code-block:: shell-session
 
-   cpp-dependencies --dir $HPX_SOURCE/libs --shortest config algorithms
+   $ cpp-dependencies --dir $HPX_SOURCE/libs --shortest config algorithms

--- a/docs/sphinx/examples/accumulator.rst
+++ b/docs/sphinx/examples/accumulator.rst
@@ -52,15 +52,15 @@ To compile this program, go to your |hpx| build directory (see
 :ref:`hpx_build_system` for information on configuring and building |hpx|) and
 enter:
 
-.. code-block:: bash
+.. code-block:: shell-session
 
-   make examples.accumulators.accumulator
+   $ make examples.accumulators.accumulator
 
 To run the program type:
 
-.. code-block:: bash
+.. code-block:: shell-session
 
-   ./bin/accumulator_client
+   $ ./bin/accumulator_client
 
 Once the program starts running, it will print the following prompt and then
 wait for input. An example session is given below:

--- a/docs/sphinx/examples/fibonacci.rst
+++ b/docs/sphinx/examples/fibonacci.rst
@@ -30,15 +30,15 @@ To compile this program, go to your |hpx| build directory (see
 :ref:`hpx_build_system` for information on configuring and building |hpx|) and
 enter:
 
-.. code-block:: bash
+.. code-block:: shell-session
 
-   make examples.quickstart.fibonacci
+   $ make examples.quickstart.fibonacci
 
 To run the program type:
 
-.. code-block:: bash
+.. code-block:: shell-session
 
-   ./bin/fibonacci
+   $ ./bin/fibonacci
 
 This should print (time should be approximate):
 
@@ -53,9 +53,9 @@ the ``--n-value`` option. Additionally you can use the :option:`--hpx:threads`
 option to declare how many OS-threads you wish to use when running the program.
 For instance, running:
 
-.. code-block:: bash
+.. code-block:: shell-session
 
-   ./bin/fibonacci --n-value 20 --hpx:threads 4
+   $ ./bin/fibonacci --n-value 20 --hpx:threads 4
 
 Will yield:
 

--- a/docs/sphinx/examples/fibonacci_local.rst
+++ b/docs/sphinx/examples/fibonacci_local.rst
@@ -55,15 +55,15 @@ To compile this program, go to your |hpx| build directory (see
 :ref:`hpx_build_system` for information on configuring and building |hpx|) and
 enter:
 
-.. code-block:: bash
+.. code-block:: shell-session
 
-   make examples.quickstart.fibonacci_local
+   $ make examples.quickstart.fibonacci_local
 
 To run the program type:
 
-.. code-block:: bash
+.. code-block:: shell-session
 
-   ./bin/fibonacci_local
+   $ ./bin/fibonacci_local
 
 This should print (time should be approximate):
 
@@ -78,9 +78,9 @@ the ``--n-value`` option. Additionally you can use the :option:`--hpx:threads`
 option to declare how many OS-threads you wish to use when running the program.
 For instance, running:
 
-.. code-block:: bash
+.. code-block:: shell-session
 
-   ./bin/fibonacci --n-value 20 --hpx:threads 4
+   $ ./bin/fibonacci --n-value 20 --hpx:threads 4
 
 Will yield:
 

--- a/docs/sphinx/examples/hello_world.rst
+++ b/docs/sphinx/examples/hello_world.rst
@@ -34,15 +34,15 @@ To compile this program, go to your |hpx| build directory (see
 :ref:`hpx_build_system` for information on configuring and building |hpx|) and
 enter:
 
-.. code-block:: bash
+.. code-block:: shell-session
 
-   make examples.quickstart.hello_world_distributed
+   $ make examples.quickstart.hello_world_distributed
 
 To run the program type:
 
-.. code-block:: bash
+.. code-block:: shell-session
 
-   ./bin/hello_world_distributed
+   $ ./bin/hello_world_distributed
 
 This should print:
 
@@ -53,9 +53,9 @@ This should print:
 To use more OS-threads use the command line option :option:`--hpx:threads` and
 type the number of threads that you wish to use. For example, typing:
 
-.. code-block:: bash
+.. code-block:: shell-session
 
-   ./bin/hello_world_distributed --hpx:threads 2
+   $ ./bin/hello_world_distributed --hpx:threads 2
 
 will yield:
 

--- a/docs/sphinx/examples/interest_calculator.rst
+++ b/docs/sphinx/examples/interest_calculator.rst
@@ -62,20 +62,15 @@ To compile this program, go to your |hpx| build directory (see
 :ref:`hpx_build_system` for information on configuring and building |hpx|) and
 enter:
 
-.. code-block:: bash
+.. code-block:: shell-session
 
-   make examples.quickstart.interest_calculator
+   $ make examples.quickstart.interest_calculator
 
 To run the program type:
 
-.. code-block:: bash
+.. code-block:: shell-session
 
-   ./bin/interest_calculator --principal 100 --rate 5 --cp 6 --time 36
-
-This should print:
-
-.. code-block:: text
-
+   $ ./bin/interest_calculator --principal 100 --rate 5 --cp 6 --time 36
    Final amount: 134.01
    Amount made: 34.0096
 

--- a/docs/sphinx/manual/building_hpx.rst
+++ b/docs/sphinx/manual/building_hpx.rst
@@ -121,16 +121,16 @@ Getting |hpx|
 Download a tarball of the latest release from |stellar_hpx_download|_ and
 unpack it or clone the repository directly using ``git``:
 
-.. code-block:: sh
+.. code-block:: shell-session
 
-    git clone https://github.com/STEllAR-GROUP/hpx.git
+    $ git clone https://github.com/STEllAR-GROUP/hpx.git
 
 It is also recommended that you check out the latest stable tag:
 
-.. code-block:: sh
+.. code-block:: shell-session
     
-    cd hpx
-    git checkout 1.7.1 
+    $ cd hpx
+    $ git checkout 1.7.1
 
 .. _building_hpx:
 
@@ -231,17 +231,17 @@ known to |cmake|, the following gets you started:
 
 #. First, set up a separate build directory to configure the project:
 
-   .. code-block:: sh
+   .. code-block:: shell-session
 
-      mkdir build && cd build
+      $ mkdir build && cd build
 
 #. To configure the project you have the following options:
 
    * To build the core |hpx| libraries and examples, and install them to your chosen location (recommended):
 
-    .. code-block:: sh
+    .. code-block:: shell-session
 
-        cmake -DCMAKE_INSTALL_PREFIX=/install/path ..
+        $ cmake -DCMAKE_INSTALL_PREFIX=/install/path ..
 
     .. tip::
 
@@ -252,15 +252,15 @@ known to |cmake|, the following gets you started:
 
    * To install |hpx| to the default system folders, simply leave out the ``CMAKE_INSTALL_PREFIX`` option:
 
-    .. code-block:: sh
+    .. code-block:: shell-session
 
-        cmake ..
+        $ cmake ..
 
    * If your dependencies are in custom locations, you may need to tell |cmake| where to find them by passing one or more options to |cmake| as shown below:
 
-    .. code-block:: sh
+    .. code-block:: shell-session
 
-        cmake -DBOOST_ROOT=/path/to/boost
+        $ cmake -DBOOST_ROOT=/path/to/boost
               -DHWLOC_ROOT=/path/to/hwloc
               -DTCMALLOC_ROOT=/path/to/tcmalloc
               -DJEMALLOC_ROOT=/path/to/jemalloc
@@ -269,15 +269,15 @@ known to |cmake|, the following gets you started:
 
     For instance:
 
-    .. code-block:: bash
+    .. code-block:: shell-session
 
-        cmake -DBOOST_ROOT=~/packages/boost -DHWLOC_ROOT=/packages/hwloc -DCMAKE_INSTALL_PREFIX=~/packages/hpx ~/downloads/hpx_1.5.1
+        $ cmake -DBOOST_ROOT=~/packages/boost -DHWLOC_ROOT=/packages/hwloc -DCMAKE_INSTALL_PREFIX=~/packages/hpx ~/downloads/hpx_1.5.1
 
    * If you want to try |hpx| without using a custom allocator pass ``-DHPX_WITH_MALLOC=system`` to |cmake|:
 
-    .. code-block:: sh 
+    .. code-block:: shell-session
 
-        cmake -DCMAKE_INSTALL_PREFIX=/install/path -DHPX_WITH_MALLOC=system ..
+        $ cmake -DCMAKE_INSTALL_PREFIX=/install/path -DHPX_WITH_MALLOC=system ..
 
     .. note::
        Please pay special attention to the section about :option:`HPX_WITH_MALLOC:STRING` as this is crucial for getting decent performance.
@@ -295,9 +295,9 @@ known to |cmake|, the following gets you started:
 
 #. Once the configuration is complete, to build the project you run:
 
-  .. code-block:: sh
+  .. code-block:: shell-session
 
-      cmake --build . --target install
+      $ cmake --build . --target install
 
 .. _windows_installation:
 
@@ -429,47 +429,47 @@ Running tests
 
 To build the tests:
 
-.. code-block:: sh
+.. code-block:: shell-session
 
-    cmake --build . --target tests
+    $ cmake --build . --target tests
 
 To control which tests to run use ``ctest``:
 
 * To run single tests, for example a test for ``for_loop``:
 
-.. code-block:: sh
+.. code-block:: shell-session
 
-    ctest --output-on-failure -R tests.unit.modules.algorithms.for_loop
+    $ ctest --output-on-failure -R tests.unit.modules.algorithms.for_loop
 
 * To run a whole group of tests:
 
-.. code-block:: sh
+.. code-block:: shell-session
 
-    ctest --output-on-failure -R tests.unit
+    $ ctest --output-on-failure -R tests.unit
 
 Running examples
 ................
 
 * To build (and install) all examples invoke:
 
-.. code-block:: bash
+.. code-block:: shell-session
 
-   cmake -DHPX_WITH_EXAMPLES=On .
-   make examples
-   make install
+   $ cmake -DHPX_WITH_EXAMPLES=On .
+   $ make examples
+   $ make install
 
 * To build the ``hello_world_1`` example run:
 
-.. code-block:: sh
+.. code-block:: shell-session
 
-   make hello_world_1
+   $ make hello_world_1
 
 |hpx| executables end up in the ``bin`` directory in your build directory. You
 can now run ``hello_world_1`` and should see the following output:
 
-.. code-block:: sh
+.. code-block:: shell-session
 
-   ./bin/hello_world_1
+   $ ./bin/hello_world_1
    Hello World!
 
 You've just run an example which prints ``Hello World!`` from the |hpx| runtime.

--- a/docs/sphinx/manual/creating_hpx_projects.rst
+++ b/docs/sphinx/manual/creating_hpx_projects.rst
@@ -37,10 +37,10 @@ Now, in the directory where you put hello_world.cpp, issue the following
 commands (where ``$HPX_LOCATION`` is the build directory or
 ``CMAKE_INSTALL_PREFIX`` you used while building |hpx|):
 
-.. code-block:: bash
+.. code-block:: shell-session
 
-   export PKG_CONFIG_PATH=$PKG_CONFIG_PATH:$HPX_LOCATION/lib/pkgconfig
-   c++ -o hello_world hello_world.cpp \
+   $ export PKG_CONFIG_PATH=$PKG_CONFIG_PATH:$HPX_LOCATION/lib/pkgconfig
+   $ c++ -o hello_world hello_world.cpp \
       `pkg-config --cflags --libs hpx_application`\
        -lhpx_iostreams -DHPX_APPLICATION_NAME=hello_world
 
@@ -67,9 +67,9 @@ commands (where ``$HPX_LOCATION`` is the build directory or
 
 To test the program, type:
 
-.. code-block:: bash
+.. code-block:: shell-session
 
-   ./hello_world
+   $ ./hello_world
 
 which should print ``Hello World!`` and exit.
 
@@ -112,20 +112,20 @@ Now, in the directory where you put the files, run the following command to
 build the component library. (where ``$HPX_LOCATION`` is the build directory or
 ``CMAKE_INSTALL_PREFIX`` you used while building |hpx|):
 
-.. code-block:: bash
+.. code-block:: shell-session
 
-   export PKG_CONFIG_PATH=$PKG_CONFIG_PATH:$HPX_LOCATION/lib/pkgconfig
-   c++ -o libhpx_hello_world.so hello_world_component.cpp \
+   $ export PKG_CONFIG_PATH=$PKG_CONFIG_PATH:$HPX_LOCATION/lib/pkgconfig
+   $ c++ -o libhpx_hello_world.so hello_world_component.cpp \
       `pkg-config --cflags --libs hpx_component` \
        -lhpx_iostreams -DHPX_COMPONENT_NAME=hpx_hello_world
 
 Now pick a directory in which to install your |hpx| component libraries. For
 this example, we'll choose a directory named ``my_hpx_libs``:
 
-.. code-block:: bash
+.. code-block:: shell-session
 
-   mkdir ~/my_hpx_libs
-   mv libhpx_hello_world.so ~/my_hpx_libs
+   $ mkdir ~/my_hpx_libs
+   $ mv libhpx_hello_world.so ~/my_hpx_libs
 
 .. note::
 
@@ -146,10 +146,10 @@ this example, we'll choose a directory named ``my_hpx_libs``:
 Now, to build the application that uses this component (``hello_world_client.cpp``),
 we do:
 
-.. code-block:: bash
+.. code-block:: shell-session
 
-   export PKG_CONFIG_PATH=$PKG_CONFIG_PATH:$HPX_LOCATION/lib/pkgconfig
-   c++ -o hello_world_client hello_world_client.cpp \
+   $ export PKG_CONFIG_PATH=$PKG_CONFIG_PATH:$HPX_LOCATION/lib/pkgconfig
+   $ c++ -o hello_world_client hello_world_client.cpp \
       ``pkg-config --cflags --libs hpx_application``\
        -L${HOME}/my_hpx_libs -lhpx_hello_world -lhpx_iostreams
 
@@ -161,10 +161,10 @@ we do:
 Finally, you'll need to set your LD_LIBRARY_PATH before you can run the program.
 To run the program, type:
 
-.. code-block:: bash
+.. code-block:: shell-session
 
-   export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$HOME/my_hpx_libs"
-   ./hello_world_client
+   $ export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$HOME/my_hpx_libs"
+   $ ./hello_world_client
 
 which should print ``Hello HPX World!`` and exit.
 
@@ -207,9 +207,9 @@ used by ``find_package(HPX)`` to set up all the necessary macros needed to use
 * Set the ``HPX_DIR`` CMake variable to point to the directory containing the
   ``HPXConfig.cmake`` script on the command line when you invoke CMake:
 
-  .. code-block:: bash
+  .. code-block:: shell-session
 
-     cmake -DHPX_DIR=$HPX_LOCATION/lib/cmake/HPX ...
+     $ cmake -DHPX_DIR=$HPX_LOCATION/lib/cmake/HPX ...
 
   where ``$HPX_LOCATION`` is the build directory or ``CMAKE_INSTALL_PREFIX`` you
   used when building/configuring |hpx|.
@@ -217,9 +217,9 @@ used by ``find_package(HPX)`` to set up all the necessary macros needed to use
 * Set the ``CMAKE_PREFIX_PATH`` variable to the root directory of your |hpx|
   build or install location on the command line when you invoke CMake:
 
-  .. code-block:: bash
+  .. code-block:: shell-session
 
-     cmake -DCMAKE_PREFIX_PATH=$HPX_LOCATION ...
+     $ cmake -DCMAKE_PREFIX_PATH=$HPX_LOCATION ...
 
   The difference between ``CMAKE_PREFIX_PATH`` and ``HPX_DIR`` is that CMake
   will add common postfixes, such as ``lib/cmake/<project``, to the
@@ -378,9 +378,9 @@ Using the |hpx| compiler wrapper ``hpxcxx``
 The ``hpxcxx`` compiler wrapper helps to compile a |hpx| component, application,
 or object file, based on the arguments passed to it.
 
-.. code-block:: bash
+.. code-block:: shell-session
 
-   hpxcxx [--exe=<APPLICATION_NAME> | --comp=<COMPONENT_NAME> | -c] FLAGS FILES
+   $ hpxcxx [--exe=<APPLICATION_NAME> | --comp=<COMPONENT_NAME> | -c] FLAGS FILES
 
 The ``hpxcxx`` command **requires** that either an application or a component is
 built or ``-c`` flag is specified. If the build is against a debug build, the
@@ -501,15 +501,15 @@ Add the following code:
 
 To build the program, type:
 
-.. code-block:: bash
+.. code-block:: shell-session
 
-   make
+   $ make
 
 A successful build should result in hello_world binary. To test, type:
 
-.. code-block:: bash
+.. code-block:: shell-session
 
-   ./hello_world
+   $ ./hello_world
 
 How to build |hpx| components with makefile
 -------------------------------------------
@@ -573,15 +573,15 @@ Now, in the directory, create a Makefile. Add the following code:
 
 To build the program, type:
 
-.. code-block:: bash
+.. code-block:: shell-session
 
-   make
+   $ make
 
 A successful build should result in hello_world binary. To test, type:
 
-.. code-block:: bash
+.. code-block:: shell-session
 
-   ./hello_world
+   $ ./hello_world
 
 .. note::
 

--- a/docs/sphinx/manual/debugging_hpx_applications.rst
+++ b/docs/sphinx/manual/debugging_hpx_applications.rst
@@ -84,15 +84,15 @@ stacktrace.
 To debug with core files, the operating system first has to be told to actually
 write them. On most Unix systems this can be done by calling:
 
-.. code-block:: bash
+.. code-block:: shell-session
 
-   ulimit -c unlimited
+   $ ulimit -c unlimited
 
 in the shell. Now the debugger can be started up with:
 
-.. code-block:: bash
+.. code-block:: shell-session
 
-   gdb <application> <core file name>
+   $ gdb <application> <core file name>
 
 The debugger should now display the last state of the application. The default
 file name for core files is ``core``.

--- a/docs/sphinx/manual/launching_and_configuring_hpx_applications.rst
+++ b/docs/sphinx/manual/launching_and_configuring_hpx_applications.rst
@@ -1762,9 +1762,9 @@ ignore the option. For instance, the following PBS script passes the option
    Alternatively, use the option :option:`--hpx:endnodes` to explicitly
    mark the end of the list of node names:
 
-   .. code-block:: bash
+   .. code-block:: shell-session
 
-      pbsdsh -u $APP_PATH --hpx:1:pu-offset=4 --hpx:nodes=`cat $PBS_NODEFILE` --hpx:endnodes $APP_OPTIONS
+      $ pbsdsh -u $APP_PATH --hpx:1:pu-offset=4 --hpx:nodes=`cat $PBS_NODEFILE` --hpx:endnodes $APP_OPTIONS
 
 .. _details:
 
@@ -1852,9 +1852,9 @@ has more than 1 processing unit (hardware threads). Running
 each of those threads is bound to the first processing unit of each of the
 cores, can be achieved by invoking:
 
-.. code-block:: bash
+.. code-block:: shell-session
 
-   hello_world_distributed -t4 --hpx:bind=thread:0-3=core:0-3.pu:0
+   $ hello_world_distributed -t4 --hpx:bind=thread:0-3=core:0-3.pu:0
 
 Here ``thread:0-3`` specifies the OS threads for which to define affinity
 bindings, and ``core:0-3.pu:`` defines that for each of the cores (``core:0-3``)
@@ -1867,9 +1867,9 @@ only their first processing unit ``pu:0`` should be used.
    :option:`--hpx:bind`. For instance, on a system with hyperthreading enabled
    (i.e. 2 processing units per core), the command line:
 
-   .. code-block:: bash
+   .. code-block:: shell-session
 
-      hello_world_distributed -t4 --hpx:bind=thread:0-3=core:0-3.pu:0 --hpx:print-bind
+      $ hello_world_distributed -t4 --hpx:bind=thread:0-3=core:0-3.pu:0 --hpx:print-bind
 
    will cause this output to be printed:
 

--- a/docs/sphinx/manual/optimizing_hpx_applications.rst
+++ b/docs/sphinx/manual/optimizing_hpx_applications.rst
@@ -352,9 +352,9 @@ of the data exposed by this counter.
 Requesting the counter data for one or more performance counters can be achieved
 by invoking ``hello_world_distributed`` with a list of counter names:
 
-.. code-block:: bash
+.. code-block:: shell-session
 
-   hello_world_distributed \
+   $ hello_world_distributed \
        --hpx:print-counter=/threads{locality#0/total}/count/cumulative \
        --hpx:print-counter=/agas{locality#0/total}/count/bind
 
@@ -391,9 +391,9 @@ counters returning an array of values, like for instance a histogram).
 Requesting to query the counter data once after a constant time interval with
 this command line:
 
-.. code-block:: bash
+.. code-block:: shell-session
 
-   hello_world_distributed \
+   $ hello_world_distributed \
        --hpx:print-counter=/threads{locality#0/total}/count/cumulative \
        --hpx:print-counter=/agas{locality#0/total}/count/bind \
        --hpx:print-counter-interval=20
@@ -422,9 +422,9 @@ environment for the executed program. For instance, if your program is utilizing
 four worker threads for the execution of |hpx| threads (see command line option
 :option:`--hpx:threads`) the following command line
 
-.. code-block:: bash
+.. code-block:: shell-session
 
-   hello_world_distributed \
+   $ hello_world_distributed \
        --hpx:threads=4 \
        --hpx:print-counter=/threads{locality#0/worker-thread#*}/count/cumulative
 
@@ -447,9 +447,9 @@ The command ``--hpx:print-counter-format`` takes values ``csv`` and
 
 With format as csv:
 
-.. code-block:: bash
+.. code-block:: shell-session
 
-   hello_world_distributed \
+   $ hello_world_distributed \
        --hpx:threads=2 \
        --hpx:print-counter-format csv \
        --hpx:print-counter /threads{locality#*/total}/count/cumulative \
@@ -467,9 +467,9 @@ countername as a header:
 
 With format csv-short:
 
-.. code-block:: bash
+.. code-block:: shell-session
 
-   hello_world_distributed \
+   $ hello_world_distributed \
        --hpx:threads 2 \
        --hpx:print-counter-format csv-short \
        --hpx:print-counter cumulative,/threads{locality#*/total}/count/cumulative \
@@ -487,9 +487,9 @@ as a header:
 
 With format csv and csv-short when used with ``--hpx:print-counter-interval``:
 
-.. code-block:: bash
+.. code-block:: shell-session
 
-   hello_world_distributed \
+   $ hello_world_distributed \
        --hpx:threads 2 \
        --hpx:print-counter-format csv-short \
        --hpx:print-counter cumulative,/threads{locality#*/total}/count/cumulative \
@@ -510,9 +510,9 @@ The command ``--hpx:no-csv-header`` can be used with
 ``--hpx:print-counter-format`` to print performance counter values in CSV format
 without any header:
 
-.. code-block:: bash
+.. code-block:: shell-session
 
-   hello_world_distributed \
+   $ hello_world_distributed \
    --hpx:threads 2 \
    --hpx:print-counter-format csv-short \
    --hpx:print-counter cumulative,/threads{locality#*/total}/count/cumulative \
@@ -2615,9 +2615,9 @@ system and application performance.
    counters. For this reason those have to be specified as parameters (a comma
    separated list of counters appended after a ``'@'``). For instance:
 
-   .. code-block:: bash
+   .. code-block:: shell-session
 
-      ./bin/hello_world_distributed -t2 \
+      $ ./bin/hello_world_distributed -t2 \
           --hpx:print-counter=/threads{locality#0/worker-thread#*}/count/cumulative \
           --hpx:print-counter=/arithmetics/add@/threads{locality#0/worker-thread#*}/count/cumulative
       hello world from OS-thread 0 on locality 0
@@ -2629,9 +2629,9 @@ system and application performance.
    Since all wildcards in the parameters are expanded, this example is fully
    equivalent to specifying both counters separately to ``/arithmetics/add``:
 
-   .. code-block:: bash
+   .. code-block:: shell-session
 
-      ./bin/hello_world_distributed -t2 \
+      $ ./bin/hello_world_distributed -t2 \
           --hpx:print-counter=/threads{locality#0/worker-thread#*}/count/cumulative \
           --hpx:print-counter=/arithmetics/add@\
               /threads{locality#0/worker-thread#0}/count/cumulative,\

--- a/docs/sphinx/manual/running_on_batch_systems.rst
+++ b/docs/sphinx/manual/running_on_batch_systems.rst
@@ -60,9 +60,9 @@ program, explained in the section :ref:`examples_hello_world`.
    Alternatively, use the option :option:`--hpx:endnodes` to explicitly mark the
    end of the list of node names:
 
-   .. code-block:: bash
+   .. code-block:: shell-session
 
-      pbsdsh -u $APP_PATH --hpx:nodes`cat $PBS_NODEFILE` --hpx:endnodes $APP_OPTIONS
+      $ pbsdsh -u $APP_PATH --hpx:nodes`cat $PBS_NODEFILE` --hpx:endnodes $APP_OPTIONS
 
 The ``#PBS -l nodes=2:ppn=4`` directive will cause two compute nodes to be
 allocated for the application, as specified in the option ``nodes``. Each of the
@@ -139,22 +139,22 @@ All that remains now is submitting the job to the queuing system. Assuming that
 the contents of the PBS script were saved in the file ``pbs_hello_world.sh`` in the
 current directory, this is accomplished by typing:
 
-.. code-block:: bash
+.. code-block:: shell-session
 
-   qsub ./pbs_hello_world_pbs.sh
+   $ qsub ./pbs_hello_world_pbs.sh
 
 If the job is accepted, |qsub| will print out the assigned job ID, which may
 look like:
 
-.. code-block:: bash
+.. code-block:: shell-session
 
    $ 42.supercomputer.some.university.edu
 
 To check the status of your job, issue the following command:
 
-.. code-block:: bash
+.. code-block:: shell-session
 
-   qstat 42.supercomputer.some.university.edu
+   $ qstat 42.supercomputer.some.university.edu
 
 and look for a single-letter job status symbol. The common cases include:
 
@@ -204,9 +204,9 @@ can be done.
 The easiest way to run an |hpx| application using SLURM is to utilize the
 command line tool |srun|, which interacts with the SLURM batch scheduling system:
 
-.. code-block:: bash
+.. code-block:: shell-session
 
-   srun -p <partition> -N <number-of-nodes> hpx-application <application-arguments>
+   $ srun -p <partition> -N <number-of-nodes> hpx-application <application-arguments>
 
 Here, ``<partition>`` is one of the node partitions existing on the target
 machine (consult the machine's documentation to get a list of existing
@@ -241,9 +241,9 @@ Interactive shells
 To get an interactive development shell on one of the nodes, users can issue the
 following command:
 
-.. code-block:: bash
+.. code-block:: shell-session
 
-   srun -p <node-type> -N <number-of-nodes> --pty /bin/bash -l
+   $ srun -p <node-type> -N <number-of-nodes> --pty /bin/bash -l
 
 After the shell has been opened, users can run their |hpx| application. By default,
 it uses all available cores. Note that if you requested one node, you don't need

--- a/docs/sphinx/quickstart.rst
+++ b/docs/sphinx/quickstart.rst
@@ -23,25 +23,25 @@ The easiest way to install |hpx| on your system is by choosing one of the steps 
 
    You can download and install |hpx| using the `vcpkg <https://github.com/Microsoft/vcpkg>`_ dependency manager:
 
-   .. code-block:: sh
+   .. code-block:: shell-session
 
-      vcpkg install hpx
+      $ vcpkg install hpx
 
 #. **Spack**
 
    Another way to install |hpx| is using `Spack <https://spack.readthedocs.io/en/latest/>`_:
 
-   .. code-block:: sh
+   .. code-block:: shell-session
 
-      spack install hpx
+      $ spack install hpx
 
 #. **Fedora**
 
    Installation can be done with `Fedora <https://fedoraproject.org/wiki/DNF>`_ as well:
 
-   .. code-block:: sh
+   .. code-block:: shell-session
 
-      dnf install hpx*
+      $ dnf install hpx*
 
 #. **Arch Linux**
 
@@ -90,12 +90,12 @@ Also create a ``main.cpp`` with the contents below.
 
 Then, in your project directory run the following:
 
-.. code-block:: sh
+.. code-block:: shell-session
 
-   mkdir build && cd build
-   cmake -DCMAKE_PREFIX_PATH=/path/to/hpx/installation ..
-   make all
-   ./my_hpx_program
+   $ mkdir build && cd build
+   $ cmake -DCMAKE_PREFIX_PATH=/path/to/hpx/installation ..
+   $ make all
+   $ ./my_hpx_program
 
 The program looks almost like a regular C++ hello world with the exception of
 the two includes and ``hpx::cout``. When you include ``hpx_main.hpp`` some
@@ -107,9 +107,9 @@ runtime with lightweight threads. ``hpx::cout`` is a replacement for
 read more about ``hpx::cout`` in :ref:`iostreams`. If you rebuild and run your
 program now, you should see the familiar ``Hello World!``:
 
-.. code-block:: sh
+.. code-block:: shell-session
 
-    ./my_hpx_program
+    $ ./my_hpx_program
     Hello World!
 
 .. note::


### PR DESCRIPTION
Add "$" to shell commands to differentiate them from the output displayed in the terminal.

Note: the $ is not copied if the user wants to copy the code block

@dimitraka what do you think?

![docs](https://user-images.githubusercontent.com/48684432/136807056-dc3798db-5ae9-4b14-a2b8-941d6daaa73e.png)


