### PR TITLE
Fix usage of HPX_INVOKE macro

### DIFF
--- a/libs/core/execution_base/include/hpx/execution_base/sender.hpp
+++ b/libs/core/execution_base/include/hpx/execution_base/sender.hpp
@@ -206,9 +206,9 @@ namespace hpx { namespace execution { namespace experimental {
         {
             F f;
 
-            void set_value() noexcept(noexcept(HPX_INVOKE(f)))
+            void set_value() noexcept(noexcept(HPX_INVOKE(f, )))
             {
-                HPX_INVOKE(f);
+                HPX_INVOKE(f, );
             }
 
             template <typename E_>

--- a/libs/core/executors/tests/unit/thread_pool_scheduler.cpp
+++ b/libs/core/executors/tests/unit/thread_pool_scheduler.cpp
@@ -245,7 +245,7 @@ struct callback_receiver
     friend void tag_dispatch(
         ex::set_value_t, callback_receiver&& r, Ts&&...) noexcept
     {
-        HPX_INVOKE(r.f);
+        HPX_INVOKE(r.f, );
         r.executed = true;
         r.cond.notify_one();
     }


### PR DESCRIPTION
`HPX_INVOKE` is a variadic macro and as such requires at least one argument for the '...' part to be strictly standard-compliant, at least pre-C++20.