### PR TITLE
Fix Vc datapar adjacent_difference

### DIFF
--- a/libs/core/algorithms/tests/unit/algorithms/adjacentdifference_tests.hpp
+++ b/libs/core/algorithms/tests/unit/algorithms/adjacentdifference_tests.hpp
@@ -25,9 +25,9 @@ void test_adjacent_difference(ExPolicy policy)
     static_assert(hpx::is_execution_policy<ExPolicy>::value,
         "hpx::is_execution_policy<ExPolicy>::value");
 
-    std::vector<std::size_t> c = test::random_iota(10007);
-    std::vector<std::size_t> d(10007);
-    std::vector<std::size_t> d_ans(10007);
+    std::vector<int> c = test::random_iota<int>(10007);
+    std::vector<int> d(10007);
+    std::vector<int> d_ans(10007);
 
     auto it = hpx::parallel::adjacent_difference(
         policy, std::begin(c), std::end(c), std::begin(d));
@@ -45,9 +45,9 @@ void test_adjacent_difference_async(ExPolicy p)
     static_assert(hpx::is_execution_policy<ExPolicy>::value,
         "hpx::is_execution_policy<ExPolicy>::value");
 
-    std::vector<std::size_t> c = test::random_iota(10007);
-    std::vector<std::size_t> d(10007);
-    std::vector<std::size_t> d_ans(10007);
+    std::vector<int> c = test::random_iota<int>(10007);
+    std::vector<int> d(10007);
+    std::vector<int> d_ans(10007);
 
     auto f_it = hpx::parallel::adjacent_difference(
         p, std::begin(c), std::end(c), std::begin(d));
@@ -67,11 +67,11 @@ void test_adjacent_difference_exception(ExPolicy policy, IteratorTag)
     static_assert(hpx::is_execution_policy<ExPolicy>::value,
         "hpx::is_execution_policy<ExPolicy>::value");
 
-    typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef std::vector<int>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>
         decorated_iterator;
-    std::vector<std::size_t> c(10007);
-    std::vector<std::size_t> d(10007);
+    std::vector<int> c(10007);
+    std::vector<int> d(10007);
 
     bool caught_exception = false;
     try
@@ -100,12 +100,12 @@ void test_adjacent_difference_exception(ExPolicy policy, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_adjacent_difference_exception_async(ExPolicy p, IteratorTag)
 {
-    typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef std::vector<int>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>
         decorated_iterator;
 
-    std::vector<std::size_t> c(10007);
-    std::vector<std::size_t> d(10007);
+    std::vector<int> c(10007);
+    std::vector<int> d(10007);
 
     bool caught_exception = false;
     bool returned_from_algorithm = false;
@@ -146,12 +146,12 @@ void test_adjacent_difference_bad_alloc(ExPolicy policy, IteratorTag)
     static_assert(hpx::is_execution_policy<ExPolicy>::value,
         "hpx::is_execution_policy<ExPolicy>::value");
 
-    typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef std::vector<int>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>
         decorated_iterator;
 
-    std::vector<std::size_t> c(10007);
-    std::vector<std::size_t> d(10007);
+    std::vector<int> c(10007);
+    std::vector<int> d(10007);
 
     bool caught_bad_alloc = false;
     try
@@ -178,12 +178,12 @@ void test_adjacent_difference_bad_alloc(ExPolicy policy, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_adjacent_difference_bad_alloc_async(ExPolicy p, IteratorTag)
 {
-    typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef std::vector<int>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>
         decorated_iterator;
 
-    std::vector<std::size_t> c(10007);
-    std::vector<std::size_t> d(10007);
+    std::vector<int> c(10007);
+    std::vector<int> d(10007);
 
     bool caught_bad_alloc = false;
     bool returned_from_algorithm = false;


### PR DESCRIPTION
Vc fails with `std::size_t `when using `std::minus<>` in adjacent difference algorithm.

Fixes #5580 
## Proposed Changes

  - Replaces `std::size_t` with `int`
 