### PR TITLE
Remove separately building segmented algorithms on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -414,7 +414,6 @@ jobs:
           name: Building Unit Tests
           command: |
               ninja -j2 -k 0 tests.unit
-              ninja -j1 -k 0 tests.unit.modules.segmented_algorithms
       - run:
           name: Running Unit Tests
           when: always


### PR DESCRIPTION
They were being built as part of the tests.unit target already, so it's unnecessary. They were originally separated to reduce memory requirements, but that seems to no longer be a problem.
