### PR TITLE
Replacing boost::container::small_vector

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ packages
 .ccls-cache
 .clangd
 /out
+.vs

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2315,7 +2315,6 @@ if(HPX_WITH_PRECOMPILED_HEADERS)
       <asio/io_context.hpp>
       <asio/ip/tcp.hpp>
       <boost/config.hpp>
-      <boost/container/small_vector.hpp>
       <boost/fusion/include/vector.hpp>
       <boost/intrusive/slist.hpp>
       <boost/lockfree/queue.hpp>

--- a/cmake/HPX_AddConfigTest.cmake
+++ b/cmake/HPX_AddConfigTest.cmake
@@ -4,6 +4,7 @@
 # Copyright (c) 2017 Google
 # Copyright (c) 2017 Taeguk Kwon
 # Copyright (c) 2020 Giannis Gonidelis
+# Copyright (c) 2021 Hartmut Kaiser
 #
 # SPDX-License-Identifier: BSL-1.0
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -415,6 +416,15 @@ function(hpx_check_for_cxx17_copy_elision)
   add_hpx_config_test(
     HPX_WITH_CXX17_COPY_ELISION
     SOURCE cmake/tests/cxx17_copy_elision.cpp
+    FILE ${ARGN}
+  )
+endfunction()
+
+# ##############################################################################
+function(hpx_check_for_cxx17_memory_resource)
+  add_hpx_config_test(
+    HPX_WITH_CXX17_MEMORY_RESOURCE
+    SOURCE cmake/tests/cxx17_memory_resource.cpp
     FILE ${ARGN}
   )
 endfunction()

--- a/cmake/HPX_PerformCxxFeatureTests.cmake
+++ b/cmake/HPX_PerformCxxFeatureTests.cmake
@@ -1,4 +1,4 @@
-# Copyright (c) 2007-2017 Hartmut Kaiser
+# Copyright (c) 2007-2021 Hartmut Kaiser
 # Copyright (c) 2011-2014 Thomas Heller
 # Copyright (c) 2013-2016 Agustin Berge
 # Copyright (c)      2017 Taeguk Kwon
@@ -56,6 +56,10 @@ function(hpx_perform_cxx_feature_tests)
   hpx_check_for_cxx17_std_scan(DEFINITIONS HPX_HAVE_CXX17_STD_SCAN_ALGORITHMS)
 
   hpx_check_for_cxx17_copy_elision(DEFINITIONS HPX_HAVE_CXX17_COPY_ELISION)
+
+  hpx_check_for_cxx17_memory_resource(
+    DEFINITIONS HPX_HAVE_CXX17_MEMORY_RESOURCE
+  )
 
   # C++20 feature tests
   hpx_check_for_cxx20_coroutines(DEFINITIONS HPX_HAVE_CXX20_COROUTINES)

--- a/cmake/tests/cxx17_memory_resource.cpp
+++ b/cmake/tests/cxx17_memory_resource.cpp
@@ -1,0 +1,18 @@
+//  Copyright (c) 2021 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <memory_resource>
+
+int main()
+{
+    int memory[10];
+    std::pmr::monotonic_buffer_resource pool(memory, 10);
+    std::pmr::polymorphic_allocator<int> allocator(&pool);
+
+    (void) allocator;
+
+    return 0;
+}

--- a/libs/core/datastructures/CMakeLists.txt
+++ b/libs/core/datastructures/CMakeLists.txt
@@ -21,6 +21,7 @@ endif()
 
 set(datastructures_headers
     hpx/datastructures/any.hpp
+    hpx/datastructures/detail/small_vector.hpp
     hpx/datastructures/detail/variant.hpp
     hpx/datastructures/member_pack.hpp
     hpx/datastructures/optional.hpp

--- a/libs/core/datastructures/include/hpx/datastructures/detail/small_vector.hpp
+++ b/libs/core/datastructures/include/hpx/datastructures/detail/small_vector.hpp
@@ -1,0 +1,546 @@
+//  Copyright (c) 2021 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include <hpx/config.hpp>
+
+#include <cstddef>
+#include <memory>
+
+#if !defined(HPX_HAVE_CXX17_MEMORY_RESOURCE)
+
+// fall back to Boost if memory_resource is not supported
+#include <boost/container/small_vector.hpp>
+
+namespace hpx::detail {
+
+    template <typename T, std::size_t Size,
+        typename Allocator = std::allocator<T>>
+    using small_vector = boost::container::small_vector<T, Size, Allocator>;
+}
+
+#else
+
+#include <initializer_list>
+#include <memory_resource>
+#include <utility>
+#include <vector>
+
+namespace hpx::detail {
+
+    ///////////////////////////////////////////////////////////////////////////
+    template <typename Allocator>
+    class allocator_memory_resource final : public std::pmr::memory_resource
+    {
+    public:
+        explicit allocator_memory_resource(Allocator const& alloc) noexcept
+          : allocator_(alloc)
+        {
+        }
+
+    private:
+        bool do_is_equal(memory_resource const& rhs) const noexcept override
+        {
+            return this == &rhs;
+        }
+
+        void* do_allocate(std::size_t count, std::size_t) override
+        {
+            return allocator_.allocate(count);
+        }
+
+        void do_deallocate(
+            void* ptr, std::size_t count, std::size_t) noexcept override
+        {
+            using value_type =
+                typename std::allocator_traits<Allocator>::value_type;
+
+            return allocator_.deallocate(static_cast<value_type*>(ptr), count);
+        }
+
+    public:
+        HPX_NO_UNIQUE_ADDRESS Allocator allocator_;
+    };
+
+    template <typename T, std::size_t Size, typename Allocator>
+    struct memory_storage final
+    {
+        static_assert(Size > 0, "memory_storage::Size must be non-zero");
+
+        using buffer_resource_type = std::pmr::monotonic_buffer_resource;
+        using allocator_type = std::pmr::polymorphic_allocator<T>;
+
+        explicit memory_storage(Allocator const& alloc = Allocator()) noexcept(
+            noexcept(Allocator()))
+          : memory_()
+          , resource_(alloc)
+          , pool_(std::data(memory_), std::size(memory_), &resource_)
+          , allocator_(&pool_)
+        {
+        }
+
+        memory_storage(memory_storage const& rhs)
+          : memory_()    // data will be provided by small_vector ctor
+          , resource_(rhs.resource_)
+          , pool_(std::data(memory_), std::size(memory_), &resource_)
+          , allocator_(&pool_)
+        {
+        }
+        memory_storage(memory_storage&& rhs) noexcept
+          : memory_()    // data will be provided by small_vector ctor
+          , resource_(std::move(rhs.resource_))
+          , pool_(std::data(memory_), std::size(memory_), &resource_)
+          , allocator_(&pool_)
+        {
+        }
+
+        // NOLINTNEXTLINE(bugprone-unhandled-self-assignment)
+        memory_storage& operator=(memory_storage const& rhs)
+        {
+            // release all memory owned by the old instance
+            allocator_.allocator_type::~allocator_type();
+            pool_.buffer_resource_type::~buffer_resource_type();
+
+            // no need to invoke: memory_ = rhs.memory_; as the data will
+            // be provided by the small_vector::operator= below
+
+            // copy allocator
+            resource_ = rhs.resource_;
+
+            // reconstruct the memory management infrastructure
+            new (&pool_) buffer_resource_type(
+                std::data(memory_), std::size(memory_), &resource_);
+            new (&allocator_) allocator_type(&pool_);
+
+            return *this;
+        }
+        // NOLINTNEXTLINE(bugprone-unhandled-self-assignment)
+        memory_storage& operator=(memory_storage&& rhs) noexcept
+        {
+            // release all memory owned by the old instance
+            allocator_.allocator_type::~allocator_type();
+            pool_.buffer_resource_type::~buffer_resource_type();
+
+            // no need to invoke: memory_ = rhs.memory_; as the data will
+            // be provided by the small_vector::operator= below
+
+            // move allocator
+            resource_ = std::move(rhs.resource_);
+
+            // reconstruct the memory management infrastructure
+            new (&pool_) buffer_resource_type(
+                std::data(memory_), std::size(memory_), &resource_);
+            new (&allocator_) allocator_type(&pool_);
+
+            return *this;
+        }
+
+        std::aligned_storage_t<sizeof(T), alignof(T)> memory_[Size];
+        allocator_memory_resource<Allocator> resource_;
+        buffer_resource_type pool_;
+        allocator_type allocator_;
+    };
+
+    ///////////////////////////////////////////////////////////////////////////
+    template <typename T, std::size_t Size,
+        typename Allocator = std::allocator<T>>
+    class small_vector
+    {
+    private:
+        using other_allocator =
+            typename std::allocator_traits<Allocator>::template rebind_alloc<T>;
+
+        using storage_type = memory_storage<T, Size, other_allocator>;
+        using data_type = std::pmr::vector<T>;
+
+    public:
+        using value_type = typename data_type::value_type;
+        using allocator_type = other_allocator;
+        using size_type = typename data_type::size_type;
+        using difference_type = typename data_type::difference_type;
+        using reference = typename data_type::reference;
+        using const_reference = typename data_type::const_reference;
+        using pointer = typename data_type::pointer;
+        using const_pointer = typename data_type::const_pointer;
+        using iterator = typename data_type::iterator;
+        using const_iterator = typename data_type::const_iterator;
+        using reverse_iterator = typename data_type::reverse_iterator;
+        using const_reverse_iterator =
+            typename data_type::const_reverse_iterator;
+
+        static constexpr std::size_t static_capacity = Size;
+
+        small_vector() noexcept(noexcept(allocator_type()))
+          : storage_()
+          , data_(storage_.allocator_)
+        {
+            data_.reserve(Size);
+        }
+
+        explicit small_vector(allocator_type const& alloc) noexcept
+          : storage_(alloc)
+          , data_(storage_.allocator_)
+        {
+            data_.reserve(Size);
+        }
+
+        explicit small_vector(
+            size_type count, allocator_type const& alloc = allocator_type())
+          : storage_(alloc)
+          , data_(count, storage_.allocator_)
+        {
+        }
+
+        small_vector(size_type count, value_type const& value,
+            allocator_type const& alloc = allocator_type())
+          : storage_(alloc)
+          , data_(count, value, storage_.allocator_)
+        {
+        }
+
+        small_vector(std::initializer_list<T> init_list,
+            allocator_type const& alloc = allocator_type())
+          : storage_(alloc)
+          , data_(std::cbegin(init_list), std::cend(init_list),
+                storage_.allocator_)
+        {
+        }
+
+        template <typename Iterator>
+        small_vector(Iterator first, Iterator last,
+            allocator_type const& alloc = allocator_type())
+          : storage_(alloc)
+          , data_(first, last, storage_.allocator_)
+        {
+        }
+
+        small_vector(small_vector const& rhs)
+          : storage_(rhs.storage_)
+          , data_(rhs.data_, storage_.allocator_)
+        {
+        }
+
+        small_vector(small_vector&& rhs) noexcept
+          : storage_(rhs.storage_)
+          , data_(std::move(rhs.data_), storage_.allocator_)
+        {
+        }
+
+        small_vector& operator=(small_vector const& rhs)
+        {
+            if (this != &rhs)
+            {
+                // free all data owned by the old instance
+                data_.data_type::~data_type();
+
+                // reconstruct the memory management infrastructure for
+                // the new instance
+                storage_ = rhs.storage_;
+
+                // fill the new instance with a copy of the rhs data
+                new (&data_) data_type(rhs.data_, storage_.allocator_);
+            }
+            return *this;
+        }
+        small_vector& operator=(small_vector&& rhs) noexcept
+        {
+            if (this != &rhs)
+            {
+                // free all data owned by the old instance
+                data_.data_type::~data_type();
+
+                // reconstruct the memory management infrastructure for
+                // the new instance
+                storage_ = std::move(rhs.storage_);
+
+                // fill the new instance with the moved rhs data
+                new (&data_)
+                    data_type(std::move(rhs.data_), storage_.allocator_);
+            }
+            return *this;
+        }
+        small_vector& operator=(std::initializer_list<T> init_list)
+        {
+            data_ = init_list;
+            return *this;
+        }
+
+        allocator_type get_allocator() const noexcept
+        {
+            return storage_.resource_.allocator_;
+        }
+
+        void assign(size_type count, value_type const& value)
+        {
+            data_.assign(count, value);
+        }
+        template <typename Iterator>
+        void assign(Iterator first, Iterator last)
+        {
+            data_.assign(first, last);
+        }
+        void assign(std::initializer_list<T> init_list)
+        {
+            data_.assign(init_list);
+        }
+
+        reference operator[](size_type pos)
+        {
+            return data_[pos];
+        }
+        const_reference operator[](size_type pos) const
+        {
+            return data_[pos];
+        }
+
+        reference at(size_type pos)
+        {
+            return data_.at(pos);
+        }
+        const_reference at(size_type pos) const
+        {
+            return data_.at(pos);
+        }
+
+        reference front()
+        {
+            return data_.front();
+        }
+        const_reference front() const
+        {
+            return data_.front();
+        }
+
+        reference back()
+        {
+            return data_.back();
+        }
+        const_reference back() const
+        {
+            return data_.back();
+        }
+
+        T* data() noexcept
+        {
+            return data_.data();
+        }
+        T const* data() const noexcept
+        {
+            return data_.data();
+        }
+
+        iterator begin()
+        {
+            return data_.begin();
+        }
+        const_iterator begin() const
+        {
+            return data_.begin();
+        }
+
+        const_iterator cbegin() const
+        {
+            return data_.cbegin();
+        }
+
+        reverse_iterator rbegin()
+        {
+            return data_.rbegin();
+        }
+        const_reverse_iterator rbegin() const
+        {
+            return data_.rbegin();
+        }
+
+        const_reverse_iterator crbegin() const
+        {
+            return data_.crbegin();
+        }
+
+        iterator end()
+        {
+            return data_.end();
+        }
+        const_iterator end() const
+        {
+            return data_.end();
+        }
+
+        const_iterator cend() const
+        {
+            return data_.cend();
+        }
+
+        reverse_iterator rend()
+        {
+            return data_.rend();
+        }
+        const_reverse_iterator rend() const
+        {
+            return data_.rend();
+        }
+
+        const_reverse_iterator crend() const
+        {
+            return data_.crend();
+        }
+
+        bool empty() const
+        {
+            return data_.empty();
+        }
+
+        size_type size() const
+        {
+            return data_.size();
+        }
+
+        size_type max_size() const
+        {
+            return data_.max_size();
+        }
+
+        void reserve(std::size_t count)
+        {
+            data_.reserve(count);
+        }
+
+        size_type capacity() const
+        {
+            return data_.capacity();
+        }
+
+        void shrink_to_fit()
+        {
+            data_.shrink_to_fit();
+        }
+
+        void clear() noexcept
+        {
+            data_.clear();
+        }
+
+        iterator insert(const_iterator pos, value_type const& value)
+        {
+            return data_.insert(pos, value);
+        }
+        iterator insert(const_iterator pos, value_type&& value)
+        {
+            return data_.insert(pos, std::move(value));
+        }
+        iterator insert(
+            const_iterator pos, size_type count, value_type const& value)
+        {
+            return data_.insert(pos, count, value);
+        }
+        template <typename Iterator>
+        iterator insert(Iterator first, Iterator last)
+        {
+            return data_.insert(first, last);
+        }
+        template <typename Iterator>
+        iterator insert(const_iterator pos, Iterator first, Iterator last)
+        {
+            return data_.insert(pos, first, last);
+        }
+        iterator insert(const_iterator pos, std::initializer_list<T> init_list)
+        {
+            return data_.insert(pos, init_list);
+        }
+
+        template <typename... Ts>
+        iterator emplace(const_iterator pos, Ts&&... ts)
+        {
+            return data_.emplace(pos, std::forward<Ts>(ts)...);
+        }
+
+        iterator erase(const_iterator pos)
+        {
+            return data_.erase(pos);
+        }
+
+        void push_back(value_type const& value)
+        {
+            data_.push_back(value);
+        }
+        void push_back(value_type&& value)
+        {
+            data_.push_back(std::move(value));
+        }
+
+        template <typename... Ts>
+        reference emplace_back(Ts&&... ts)
+        {
+            return data_.emplace_back(std::forward<Ts>(ts)...);
+        }
+
+        void pop_back()
+        {
+            data_.pop_back();
+        }
+
+        void resize(size_type count)
+        {
+            data_.resize(count);
+        }
+        void resize(size_type count, value_type const& value)
+        {
+            data_.resize(count, value);
+        }
+
+        void swap(small_vector& other) noexcept
+        {
+            // data.swap(other.data_);
+            // explicitly move the objects as the MSVC standard library has a
+            // bug preventing to swap two std::pmr::vectors
+            small_vector tmp = std::move(*this);
+            *this = std::move(other);
+            other = std::move(tmp);
+        }
+
+        friend bool operator==(small_vector const& lhs, small_vector const& rhs)
+        {
+            return lhs.data_ == rhs.data_;
+        }
+        friend bool operator<(small_vector const& lhs, small_vector const& rhs)
+        {
+            return lhs.data_ < rhs.data_;
+        }
+        friend bool operator>(small_vector const& lhs, small_vector const& rhs)
+        {
+            return lhs.data_ > rhs.data_;
+        }
+        friend bool operator<=(small_vector const& lhs, small_vector const& rhs)
+        {
+            return lhs.data_ <= rhs.data_;
+        }
+        friend bool operator>=(small_vector const& lhs, small_vector const& rhs)
+        {
+            return lhs.data_ >= rhs.data_;
+        }
+        friend bool operator!=(small_vector const& lhs, small_vector const& rhs)
+        {
+            return lhs.data_ != rhs.data_;
+        }
+
+    private:
+        storage_type storage_;
+        data_type data_;
+    };
+}    // namespace hpx::detail
+
+namespace std {
+
+    template <typename T, std::size_t Size, typename Allocator>
+    void swap(hpx::detail::small_vector<T, Size, Allocator>& lhs,
+        hpx::detail::small_vector<T, Size, Allocator>& rhs)
+    {
+        lhs.swap(rhs);
+    }
+}    // namespace std
+
+#endif

--- a/libs/core/datastructures/tests/unit/CMakeLists.txt
+++ b/libs/core/datastructures/tests/unit/CMakeLists.txt
@@ -1,10 +1,14 @@
-# Copyright (c) 2019 The STE||AR-Group
+# Copyright (c) 2019-2021 The STE||AR-Group
 #
 # SPDX-License-Identifier: BSL-1.0
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 set(tests any boost_any is_tuple_like unique_any tagged tuple)
+
+if(HPX_WITH_CXX17_MEMORY_RESOURCE)
+  set(tests ${tests} small_vector)
+endif()
 
 foreach(test ${tests})
   set(sources ${test}.cpp)

--- a/libs/core/datastructures/tests/unit/small_vector.cpp
+++ b/libs/core/datastructures/tests/unit/small_vector.cpp
@@ -1,0 +1,941 @@
+//  Copyright (c) 2021 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+// (C) Copyright Ion Gaztanaga 2004-2014. Distributed under the Boost
+// Copyright (C) 2013 Cromwell D. Enage
+//
+// See http://www.boost.org/libs/container for documentation.
+
+#include <hpx/config.hpp>
+
+#include <hpx/datastructures/detail/small_vector.hpp>
+#include <hpx/modules/testing.hpp>
+
+#include <algorithm>
+#include <climits>
+#include <cstddef>
+#include <deque>
+#include <forward_list>
+#include <list>
+#include <utility>
+#include <vector>
+
+namespace test {
+
+    // Very simple allocator
+    template <typename T>
+    class simple_allocator
+    {
+    public:
+        using value_type = T;
+
+        simple_allocator() noexcept = default;
+
+        template <typename U>
+        simple_allocator(simple_allocator<U> const&) noexcept
+        {
+        }
+
+        T* allocate(std::size_t n)
+        {
+            return reinterpret_cast<T*>(::new char[sizeof(T) * n]);
+        }
+
+        void deallocate(T* p, std::size_t)
+        {
+            delete[](reinterpret_cast<char*>(p));
+        }
+
+        friend bool operator==(
+            simple_allocator const&, simple_allocator const&) noexcept
+        {
+            return true;
+        }
+
+        friend bool operator!=(
+            simple_allocator const&, simple_allocator const&) noexcept
+        {
+            return false;
+        }
+    };
+
+    class movable_and_copyable_int
+    {
+    public:
+        static inline unsigned int count = 0;
+
+        movable_and_copyable_int() noexcept
+          : int_(0)
+        {
+            ++count;
+        }
+
+        explicit movable_and_copyable_int(int a) noexcept
+          : int_(a)
+        {
+            // Disallow INT_MIN
+            HPX_TEST(this->int_ != INT_MIN);
+            ++count;
+        }
+
+        movable_and_copyable_int(movable_and_copyable_int const& mmi) noexcept
+          : int_(mmi.int_)
+        {
+            ++count;
+        }
+
+        movable_and_copyable_int(movable_and_copyable_int&& mmi) noexcept
+          : int_(mmi.int_)
+        {
+            mmi.int_ = 0;
+            ++count;
+        }
+
+        ~movable_and_copyable_int()
+        {
+            HPX_TEST(this->int_ != INT_MIN);
+            this->int_ = INT_MIN;
+            --count;
+        }
+
+        movable_and_copyable_int& operator=(
+            movable_and_copyable_int const& mi) noexcept
+        {
+            this->int_ = mi.int_;
+            return *this;
+        }
+
+        movable_and_copyable_int& operator=(
+            movable_and_copyable_int&& mmi) noexcept
+        {
+            this->int_ = mmi.int_;
+            mmi.int_ = 0;
+            return *this;
+        }
+
+        movable_and_copyable_int& operator=(int i) noexcept
+        {
+            this->int_ = i;
+            HPX_TEST(this->int_ != INT_MIN);
+            return *this;
+        }
+
+        friend bool operator==(const movable_and_copyable_int& l,
+            const movable_and_copyable_int& r) noexcept
+        {
+            return l.int_ == r.int_;
+        }
+
+        friend bool operator!=(const movable_and_copyable_int& l,
+            const movable_and_copyable_int& r) noexcept
+        {
+            return l.int_ != r.int_;
+        }
+
+        friend bool operator<(const movable_and_copyable_int& l,
+            const movable_and_copyable_int& r) noexcept
+        {
+            return l.int_ < r.int_;
+        }
+
+        friend bool operator<=(const movable_and_copyable_int& l,
+            const movable_and_copyable_int& r) noexcept
+        {
+            return l.int_ <= r.int_;
+        }
+
+        friend bool operator>=(const movable_and_copyable_int& l,
+            const movable_and_copyable_int& r) noexcept
+        {
+            return l.int_ >= r.int_;
+        }
+
+        friend bool operator>(const movable_and_copyable_int& l,
+            const movable_and_copyable_int& r) noexcept
+        {
+            return l.int_ > r.int_;
+        }
+
+        int get_int() const noexcept
+        {
+            return int_;
+        }
+
+        friend bool operator==(
+            const movable_and_copyable_int& l, int r) noexcept
+        {
+            return l.get_int() == r;
+        }
+
+        friend bool operator==(
+            int l, const movable_and_copyable_int& r) noexcept
+        {
+            return l == r.get_int();
+        }
+
+    private:
+        int int_;
+    };
+}    // namespace test
+
+#if defined(HPX_HAVE_CXX17_MEMORY_RESOURCE)
+namespace hpx {
+
+    // Explicit instantiation to detect compilation errors
+    template class hpx::detail::small_vector<char, 1>;
+    template class hpx::detail::small_vector<char, 2>;
+    template class hpx::detail::small_vector<char, 10>;
+
+    template class hpx::detail::small_vector<int, 1>;
+    template class hpx::detail::small_vector<int, 2>;
+    template class hpx::detail::small_vector<int, 10>;
+
+    template class hpx::detail::small_vector<test::movable_and_copyable_int, 10,
+        test::simple_allocator<test::movable_and_copyable_int>>;
+
+    template class hpx::detail::small_vector<test::movable_and_copyable_int, 10,
+        std::allocator<test::movable_and_copyable_int>>;
+}    // namespace hpx
+#endif
+
+namespace test {
+
+    void small_vector_test()
+    {
+        // basic test with less elements than static size
+        {
+            using sm5_t = hpx::detail::small_vector<int, 5>;
+            static_assert(
+                sm5_t::static_capacity == 5, "sm5_t::static_capacity == 5");
+
+            sm5_t sm5;
+            sm5.push_back(1);
+            HPX_TEST_EQ(sm5[0], 1);
+
+            sm5_t sm5_copy(sm5);
+            HPX_TEST(sm5 == sm5_copy);
+        }
+        {
+            using sm7_t = hpx::detail::small_vector<int, 7>;
+            static_assert(
+                sm7_t::static_capacity == 7, "sm7_t::static_capacity == 7");
+
+            sm7_t sm7;
+            sm7.push_back(1);
+            HPX_TEST_EQ(sm7[0], 1);
+
+            sm7_t sm7_copy(sm7);
+            HPX_TEST(sm7 == sm7_copy);
+        }
+        {
+            using sm5_t = hpx::detail::small_vector<int, 5>;
+            sm5_t sm5;
+            sm5.push_back(1);
+            HPX_TEST_EQ(sm5[0], 1);
+
+            sm5_t sm5_copy(sm5);
+            HPX_TEST(sm5 == sm5_copy);
+
+            sm5.push_back(2);
+            HPX_TEST_EQ(sm5[1], 2);
+            HPX_TEST_EQ(sm5.size(), std::size_t(2));
+
+            sm5_copy = sm5;
+            HPX_TEST(sm5 == sm5_copy);
+
+            sm5[0] = 3;
+            HPX_TEST_EQ(sm5[0], 3);
+            HPX_TEST_EQ(sm5_copy[0], 1);
+
+            sm5_copy = sm5;
+            sm5_t sm5_move(std::move(sm5));
+            sm5 = sm5_t();
+            HPX_TEST(sm5_move == sm5_copy);
+
+            sm5 = sm5_copy;
+            sm5_move = std::move(sm5);
+            sm5 = sm5_t();
+            HPX_TEST(sm5_move == sm5_copy);
+        }
+
+        // basic test with more elements than static size
+        {
+            using sm2_t = hpx::detail::small_vector<int, 2>;
+            sm2_t sm2;
+            sm2.push_back(1);
+            HPX_TEST_EQ(sm2[0], 1);
+
+            sm2_t sm2_copy(sm2);
+            HPX_TEST(sm2 == sm2_copy);
+
+            sm2.push_back(2);
+            sm2.push_back(3);
+            HPX_TEST_EQ(sm2[1], 2);
+            HPX_TEST_EQ(sm2[2], 3);
+            HPX_TEST_EQ(sm2.size(), std::size_t(3));
+
+            sm2_copy = sm2;
+            HPX_TEST(sm2 == sm2_copy);
+
+            sm2[2] = 4;
+            HPX_TEST_EQ(sm2[2], 4);
+            HPX_TEST_EQ(sm2_copy[2], 3);
+
+            sm2_copy = sm2;
+            sm2_t sm2_move(std::move(sm2));
+            sm2 = sm2_t();
+            HPX_TEST(sm2_move == sm2_copy);
+
+            sm2 = sm2_copy;
+            sm2_move = std::move(sm2);
+            sm2 = sm2_t();
+            HPX_TEST(sm2_move == sm2_copy);
+        }
+    }
+
+    // small vector has internal storage so some special swap cases must be tested
+    void test_swap()
+    {
+        using vec = hpx::detail::small_vector<int, 10>;
+
+        {
+            // v bigger than static capacity, w empty
+            vec v;
+            HPX_TEST_EQ(v.capacity(), vec::static_capacity);
+
+            for (std::size_t i = 0, max = v.capacity() + 1; i != max; ++i)
+            {
+                v.push_back(int(i));
+            }
+
+            vec w;
+
+            vec v_copy(v);
+            vec w_copy(w);
+
+            v.swap(w);
+            HPX_TEST(v == w_copy);
+            HPX_TEST(w == v_copy);
+        }
+        {
+            // v smaller than static capacity, w empty
+            vec v;
+            for (std::size_t i = 0, max = v.capacity() - 1; i != max; ++i)
+            {
+                v.push_back(int(i));
+            }
+
+            vec w;
+
+            vec v_copy(v);
+            vec w_copy(w);
+
+            v.swap(w);
+            HPX_TEST(v == w_copy);
+            HPX_TEST(w == v_copy);
+        }
+        {
+            // v & w smaller than static capacity
+            vec v;
+            for (std::size_t i = 0, max = v.capacity() - 1; i != max; ++i)
+            {
+                v.push_back(int(i));
+            }
+
+            vec w;
+            for (std::size_t i = 0, max = v.capacity() / 2; i != max; ++i)
+            {
+                w.push_back(int(i));
+            }
+
+            vec v_copy(v);
+            vec w_copy(w);
+
+            v.swap(w);
+            HPX_TEST(v == w_copy);
+            HPX_TEST(w == v_copy);
+        }
+        {
+            // v & w bigger than static capacity
+            vec v;
+            for (std::size_t i = 0, max = v.capacity() + 1; i != max; ++i)
+            {
+                v.push_back(int(i));
+            }
+
+            vec w;
+            for (std::size_t i = 0, max = v.capacity() * 2; i != max; ++i)
+            {
+                w.push_back(int(i));
+            }
+
+            vec v_copy(v);
+            vec w_copy(w);
+
+            v.swap(w);
+            HPX_TEST(v == w_copy);
+            HPX_TEST(w == v_copy);
+        }
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    template <typename ContA, typename ContB>
+    void check_equal_containers(ContA const& cont_a, ContB const& cont_b)
+    {
+        HPX_TEST_EQ(cont_a.size(), cont_b.size());
+
+        auto itcont_a(cont_a.begin());
+        auto itcont_a_end(cont_a.end());
+        std::size_t dist = std::distance(itcont_a, itcont_a_end);
+        HPX_TEST_EQ(dist, cont_a.size());
+
+        auto itcont_b(cont_b.begin());
+        auto itcont_b_end(cont_b.end());
+        std::size_t dist2 = std::distance(itcont_b, itcont_b_end);
+        HPX_TEST_EQ(dist2, cont_b.size());
+
+        for (std::size_t i = 0; itcont_a != itcont_a_end;
+             ++itcont_a, ++itcont_b, ++i)
+        {
+            HPX_TEST_EQ(*itcont_a, *itcont_b);
+        }
+    }
+
+    template <typename SeqContainer>
+    void test_insert_range(std::deque<int>& std_deque,
+        SeqContainer& seq_container, std::deque<int> const& input_deque,
+        std::size_t index)
+    {
+        check_equal_containers(std_deque, seq_container);
+
+        std_deque.insert(
+            std_deque.begin() + index, input_deque.begin(), input_deque.end());
+        seq_container.insert(seq_container.begin() + index, input_deque.begin(),
+            input_deque.end());
+
+        check_equal_containers(std_deque, seq_container);
+    }
+
+    template <typename SeqContainer>
+    void test_range_insertion()
+    {
+        using value_type = typename SeqContainer::value_type;
+
+        std::deque<int> input_deque;
+        for (int element = -10; element < 10; ++element)
+        {
+            input_deque.push_back(element + 20);
+        }
+
+        for (std::size_t i = 0; i <= input_deque.size(); ++i)
+        {
+            std::deque<int> std_deque;
+            SeqContainer seq_container;
+
+            for (int element = -10; element < 10; ++element)
+            {
+                std_deque.push_back(element);
+                seq_container.push_back(value_type(element));
+            }
+
+            test_insert_range(std_deque, seq_container, input_deque, i);
+        }
+    }
+
+    template <typename Vector>
+    void vector_test()
+    {
+        using value_type = typename Vector::value_type;
+        constexpr int max = 100;
+
+        test_range_insertion<Vector>();
+
+        {
+            // Vector(n)
+            Vector const vector(100);
+            std::vector<int> const v(100);
+            test::check_equal_containers(vector, v);
+        }
+        {
+            // Vector(n, alloc)
+            Vector const vector(100, typename Vector::allocator_type());
+            std::vector<int> const v(100);
+            test::check_equal_containers(vector, v);
+        }
+        {
+            // Vector(Vector &&)
+            Vector const vector(100);
+            Vector const vector2(std::move(vector));
+            std::vector<int> const v(100);
+            test::check_equal_containers(vector2, v);
+        }
+        {
+            // Vector operator=(Vector &&)
+            Vector const vector(100);
+            Vector vector2;
+            vector2 = std::move(vector);
+            std::vector<int> const v(100);
+            test::check_equal_containers(vector2, v);
+        }
+        {
+            Vector vector;
+            std::vector<int> v;
+
+            vector.resize(100);
+            v.resize(100);
+            test::check_equal_containers(vector, v);
+
+            vector.resize(200);
+            v.resize(200);
+            test::check_equal_containers(vector, v);
+
+            vector.resize(0);
+            v.resize(0);
+            test::check_equal_containers(vector, v);
+
+            for (int i = 0; i < max; ++i)
+            {
+                value_type new_int(i);
+                vector.insert(vector.end(), std::move(new_int));
+                v.insert(v.end(), i);
+                test::check_equal_containers(vector, v);
+            }
+
+            auto it = vector.begin();
+            auto stdit = v.begin();
+            typename Vector::const_iterator cit = it;
+            (void) cit;
+            ++it;
+            ++stdit;
+            vector.erase(it);
+            v.erase(stdit);
+            test::check_equal_containers(vector, v);
+
+            vector.erase(vector.begin());
+            v.erase(v.begin());
+            test::check_equal_containers(vector, v);
+
+            {
+                // Initialize values
+                value_type aux_vect[50];
+                for (int i = 0; i < 50; ++i)
+                {
+                    value_type new_int(-1);
+                    aux_vect[i] = std::move(new_int);
+                }
+
+                int aux_vect2[50];
+                for (int i = 0; i < 50; ++i)
+                {
+                    aux_vect2[i] = -1;
+                }
+
+                auto insert_it =
+                    vector.insert(vector.end(), &aux_vect[0], aux_vect + 50);
+                HPX_TEST_EQ(std::size_t(std::distance(insert_it, vector.end())),
+                    std::size_t(50));
+
+                v.insert(v.end(), aux_vect2, aux_vect2 + 50);
+                test::check_equal_containers(vector, v);
+
+                for (int i = 0, j = static_cast<int>(vector.size()); i < j; ++i)
+                {
+                    vector.erase(vector.begin());
+                    v.erase(v.begin());
+                }
+                test::check_equal_containers(vector, v);
+            }
+            {
+                vector.resize(100);
+                v.resize(100);
+                test::check_equal_containers(vector, v);
+
+                value_type aux_vect[50];
+                for (int i = 0; i < 50; ++i)
+                {
+                    value_type new_int(-i);
+                    aux_vect[i] = std::move(new_int);
+                }
+
+                int aux_vect2[50];
+                for (int i = 0; i < 50; ++i)
+                {
+                    aux_vect2[i] = -i;
+                }
+
+                auto old_size = vector.size();
+                auto insert_it = vector.insert(
+                    vector.begin() + old_size / 2, &aux_vect[0], aux_vect + 50);
+                HPX_TEST(vector.begin() + old_size / 2 == insert_it);
+
+                v.insert(v.begin() + old_size / 2, aux_vect2, aux_vect2 + 50);
+                test::check_equal_containers(vector, v);
+            }
+
+            vector.shrink_to_fit();
+            v.shrink_to_fit();
+            test::check_equal_containers(vector, v);
+
+            {    //push_back with not enough capacity
+                value_type push_back_this(1);
+                vector.push_back(std::move(push_back_this));
+                v.push_back(int(1));
+                vector.push_back(value_type(1));
+                v.push_back(int(1));
+                test::check_equal_containers(vector, v);
+            }
+
+            {
+                // test back()
+                value_type const test_this(1);
+                HPX_TEST_EQ(test_this, vector.back());
+            }
+            {
+                // pop_back with enough capacity
+                vector.pop_back();
+                vector.pop_back();
+                v.pop_back();
+                v.pop_back();
+
+                value_type push_back_this(1);
+                vector.push_back(std::move(push_back_this));
+                v.push_back(int(1));
+                vector.push_back(value_type(1));
+                v.push_back(int(1));
+                test::check_equal_containers(vector, v);
+            }
+
+            vector.erase(vector.begin());
+            v.erase(v.begin());
+            test::check_equal_containers(vector, v);
+
+            for (int i = 0; i < max; ++i)
+            {
+                value_type insert_this(i);
+                vector.insert(vector.begin(), std::move(insert_this));
+                v.insert(v.begin(), i);
+                vector.insert(vector.begin(), value_type(i));
+                v.insert(v.begin(), int(i));
+            }
+            test::check_equal_containers(vector, v);
+
+            // some comparison operators
+            HPX_TEST(vector == vector);
+            HPX_TEST(!(vector != vector));
+            HPX_TEST(!(vector < vector));
+            HPX_TEST(!(vector > vector));
+            HPX_TEST(vector <= vector);
+            HPX_TEST(vector >= vector);
+
+            // Test insertion from list
+            {
+                std::list<int> l(50, int(1));
+                auto it_insert =
+                    vector.insert(vector.begin(), l.begin(), l.end());
+                HPX_TEST(vector.begin() == it_insert);
+
+                v.insert(v.begin(), l.begin(), l.end());
+                test::check_equal_containers(vector, v);
+
+                vector.assign(l.begin(), l.end());
+                v.assign(l.begin(), l.end());
+                test::check_equal_containers(vector, v);
+
+                std::forward_list<int> fl(50, int(1));
+                vector.clear();
+                v.clear();
+                vector.assign(fl.begin(), fl.end());
+                v.assign(fl.begin(), fl.end());
+                test::check_equal_containers(vector, v);
+            }
+
+            vector.clear();
+            vector.shrink_to_fit();
+            v.clear();
+            v.shrink_to_fit();
+            test::check_equal_containers(vector, v);
+        }
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    class emplace_int
+    {
+    public:
+        emplace_int(
+            int a = 0, int b = 0, int c = 0, int d = 0, int e = 0) noexcept
+          : a_(a)
+          , b_(b)
+          , c_(c)
+          , d_(d)
+          , e_(e)
+        {
+        }
+
+        emplace_int(emplace_int const& o) = delete;
+        emplace_int(emplace_int&& o) noexcept
+          : a_(o.a_)
+          , b_(o.b_)
+          , c_(o.c_)
+          , d_(o.d_)
+          , e_(o.e_)
+        {
+        }
+
+        emplace_int& operator=(emplace_int const& o) = delete;
+        emplace_int& operator=(emplace_int&& o) noexcept
+        {
+            a_ = o.a_;
+            b_ = o.b_;
+            c_ = o.c_;
+            d_ = o.d_;
+            e_ = o.e_;
+            return *this;
+        }
+
+        friend bool operator==(emplace_int const& l, emplace_int const& r)
+        {
+            return l.a_ == r.a_ && l.b_ == r.b_ && l.c_ == r.c_ &&
+                l.d_ == r.d_ && l.e_ == r.e_;
+        }
+
+        friend bool operator<(emplace_int const& l, emplace_int const& r)
+        {
+            return l.sum() < r.sum();
+        }
+
+        friend bool operator>(emplace_int const& l, emplace_int const& r)
+        {
+            return l.sum() > r.sum();
+        }
+
+        friend bool operator!=(emplace_int const& l, emplace_int const& r)
+        {
+            return !(l == r);
+        }
+
+        ~emplace_int()
+        {
+            a_ = b_ = c_ = d_ = e_ = 0;
+        }
+
+        int sum() const
+        {
+            return a_ + b_ + c_ + d_ + e_;
+        }
+
+        int a_, b_, c_, d_, e_;
+        int padding[6];
+    };
+
+    static emplace_int expected[10];
+
+    template <typename Container>
+    void test_expected_container(Container const& ec,
+        emplace_int const* expected, unsigned int only_first_n,
+        unsigned int cont_offset = 0)
+    {
+        HPX_TEST(cont_offset <= ec.size());
+        HPX_TEST(only_first_n <= (ec.size() - cont_offset));
+
+        using const_iterator = typename Container::const_iterator;
+
+        const_iterator itb(ec.begin()), ite(ec.end());
+        unsigned int cur = 0;
+        while (cont_offset--)
+        {
+            ++itb;
+        }
+
+        for (; itb != ite && only_first_n--; ++itb, ++cur)
+        {
+            emplace_int const& cr = *itb;
+            HPX_TEST(cr == expected[cur]);
+        }
+    }
+
+    template <typename Container>
+    void test_emplace_back()
+    {
+        {
+            new (&expected[0]) emplace_int();
+            new (&expected[1]) emplace_int(1);
+            new (&expected[2]) emplace_int(1, 2);
+            new (&expected[3]) emplace_int(1, 2, 3);
+            new (&expected[4]) emplace_int(1, 2, 3, 4);
+            new (&expected[5]) emplace_int(1, 2, 3, 4, 5);
+
+            Container c;
+            using reference = typename Container::reference;
+
+            {
+                reference r = c.emplace_back();
+                HPX_TEST(&r == &c.back());
+                test_expected_container(c, &expected[0], 1);
+            }
+            {
+                reference r = c.emplace_back(1);
+                HPX_TEST(&r == &c.back());
+                test_expected_container(c, &expected[0], 2);
+            }
+
+            c.emplace_back(1, 2);
+            test_expected_container(c, &expected[0], 3);
+
+            c.emplace_back(1, 2, 3);
+            test_expected_container(c, &expected[0], 4);
+
+            c.emplace_back(1, 2, 3, 4);
+            test_expected_container(c, &expected[0], 5);
+
+            c.emplace_back(1, 2, 3, 4, 5);
+            test_expected_container(c, &expected[0], 6);
+        }
+    }
+
+    template <typename Container>
+    void test_emplace_before()
+    {
+        {
+            new (&expected[0]) emplace_int();
+            new (&expected[1]) emplace_int(1);
+            new (&expected[2]) emplace_int();
+
+            Container c;
+            c.emplace(c.cend(), 1);
+            c.emplace(c.cbegin());
+            test_expected_container(c, &expected[0], 2);
+
+            c.emplace(c.cend());
+            test_expected_container(c, &expected[0], 3);
+        }
+        {
+            new (&expected[0]) emplace_int();
+            new (&expected[1]) emplace_int(1);
+            new (&expected[2]) emplace_int(1, 2);
+            new (&expected[3]) emplace_int(1, 2, 3);
+            new (&expected[4]) emplace_int(1, 2, 3, 4);
+            new (&expected[5]) emplace_int(1, 2, 3, 4, 5);
+
+            // emplace_front-like
+            Container c;
+            c.emplace(c.cbegin(), 1, 2, 3, 4, 5);
+            c.emplace(c.cbegin(), 1, 2, 3, 4);
+            c.emplace(c.cbegin(), 1, 2, 3);
+            c.emplace(c.cbegin(), 1, 2);
+            c.emplace(c.cbegin(), 1);
+            c.emplace(c.cbegin());
+            test_expected_container(c, &expected[0], 6);
+            c.clear();
+
+            // emplace_back-like
+            auto i = c.emplace(c.cend());
+            test_expected_container(c, &expected[0], 1);
+
+            i = c.emplace(++i, 1);
+            test_expected_container(c, &expected[0], 2);
+
+            i = c.emplace(++i, 1, 2);
+            test_expected_container(c, &expected[0], 3);
+
+            i = c.emplace(++i, 1, 2, 3);
+            test_expected_container(c, &expected[0], 4);
+
+            i = c.emplace(++i, 1, 2, 3, 4);
+            test_expected_container(c, &expected[0], 5);
+
+            i = c.emplace(++i, 1, 2, 3, 4, 5);
+            test_expected_container(c, &expected[0], 6);
+            c.clear();
+
+            // emplace in the middle
+            c.emplace(c.cbegin());
+            test_expected_container(c, &expected[0], 1);
+
+            i = c.emplace(c.cend(), 1, 2, 3, 4, 5);
+            test_expected_container(c, &expected[0], 1);
+
+            test_expected_container(c, &expected[5], 1, 1);
+
+            i = c.emplace(i, 1, 2, 3, 4);
+            test_expected_container(c, &expected[0], 1);
+
+            test_expected_container(c, &expected[4], 2, 1);
+
+            i = c.emplace(i, 1, 2, 3);
+            test_expected_container(c, &expected[0], 1);
+            test_expected_container(c, &expected[3], 3, 1);
+
+            i = c.emplace(i, 1, 2);
+            test_expected_container(c, &expected[0], 1);
+            test_expected_container(c, &expected[2], 4, 1);
+
+            i = c.emplace(i, 1);
+            test_expected_container(c, &expected[0], 6);
+        }
+    }
+
+    template <typename VectorContainerType>
+    void test_vector_methods_with_initializer_list_as_argument_for()
+    {
+        using allocator_type = typename VectorContainerType::allocator_type;
+
+        {
+            VectorContainerType const tested_vector = {1, 2, 3};
+            std::vector<int> const expected_vector = {1, 2, 3};
+            check_equal_containers(tested_vector, expected_vector);
+        }
+        {
+            VectorContainerType const tested_vector(
+                {1, 2, 3}, allocator_type());
+            std::vector<int> const expected_vector = {1, 2, 3};
+            check_equal_containers(tested_vector, expected_vector);
+        }
+        {
+            VectorContainerType tested_vector = {1, 2, 3};
+            tested_vector = {11, 12, 13};
+
+            std::vector<int> const expected_vector = {11, 12, 13};
+            check_equal_containers(tested_vector, expected_vector);
+        }
+
+        {
+            VectorContainerType tested_vector = {1, 2, 3};
+            tested_vector.assign({5, 6, 7});
+
+            std::vector<int> const expected_vector = {5, 6, 7};
+            check_equal_containers(tested_vector, expected_vector);
+        }
+
+        {
+            VectorContainerType tested_vector = {1, 2, 3};
+            tested_vector.insert(tested_vector.cend(), {5, 6, 7});
+
+            std::vector<int> const expected_vector = {1, 2, 3, 5, 6, 7};
+            check_equal_containers(tested_vector, expected_vector);
+        }
+    }
+
+}    // namespace test
+
+int main()
+{
+    test::small_vector_test();
+    test::test_swap();
+
+    test::vector_test<hpx::detail::small_vector<int, 1>>();
+    test::vector_test<hpx::detail::small_vector<int, 500>>();
+
+    // Emplace testing
+    test::test_emplace_back<hpx::detail::small_vector<test::emplace_int, 5>>();
+    test::test_emplace_before<
+        hpx::detail::small_vector<test::emplace_int, 5>>();
+
+    // Initializer lists testing
+    test::test_vector_methods_with_initializer_list_as_argument_for<
+        hpx::detail::small_vector<int, 5>>();
+
+    return hpx::util::report_errors();
+}

--- a/libs/core/execution/include/hpx/execution/algorithms/split.hpp
+++ b/libs/core/execution/include/hpx/execution/algorithms/split.hpp
@@ -12,6 +12,7 @@
 #include <hpx/allocator_support/traits/is_allocator.hpp>
 #include <hpx/assert.hpp>
 #include <hpx/concepts/concepts.hpp>
+#include <hpx/datastructures/detail/small_vector.hpp>
 #include <hpx/datastructures/tuple.hpp>
 #include <hpx/datastructures/variant.hpp>
 #include <hpx/execution/algorithms/detail/partial_algorithm.hpp>
@@ -27,8 +28,6 @@
 #include <hpx/synchronization/spinlock.hpp>
 #include <hpx/thread_support/atomic_count.hpp>
 #include <hpx/type_support/pack.hpp>
-
-#include <boost/container/small_vector.hpp>
 
 #include <atomic>
 #include <cstddef>
@@ -134,8 +133,7 @@ namespace hpx { namespace execution { namespace experimental {
 
                 using continuation_type =
                     hpx::util::unique_function_nonser<void()>;
-                boost::container::small_vector<continuation_type, 1>
-                    continuations;
+                hpx::detail::small_vector<continuation_type, 1> continuations;
 
                 struct split_receiver
                 {

--- a/libs/core/futures/include/hpx/futures/detail/future_data.hpp
+++ b/libs/core/futures/include/hpx/futures/detail/future_data.hpp
@@ -10,6 +10,7 @@
 #include <hpx/assert.hpp>
 #include <hpx/async_base/launch_policy.hpp>
 #include <hpx/coroutines/detail/get_stack_pointer.hpp>
+#include <hpx/datastructures/detail/small_vector.hpp>
 #include <hpx/errors/try_catch_exception_ptr.hpp>
 #include <hpx/functional/function.hpp>
 #include <hpx/futures/future_fwd.hpp>
@@ -24,8 +25,6 @@
 #include <hpx/threading_base/annotated_function.hpp>
 #include <hpx/threading_base/thread_helpers.hpp>
 #include <hpx/type_support/unused.hpp>
-
-#include <boost/container/small_vector.hpp>
 
 #include <atomic>
 #include <chrono>
@@ -72,7 +71,7 @@ namespace hpx { namespace lcos { namespace detail {
     {
     public:
         typedef util::unique_function_nonser<void()> completed_callback_type;
-        typedef boost::container::small_vector<completed_callback_type, 1>
+        typedef hpx::detail::small_vector<completed_callback_type, 1>
             completed_callback_vector_type;
 
         typedef void has_future_data_refcnt_base;

--- a/libs/core/lcos_local/tests/unit/CMakeLists.txt
+++ b/libs/core/lcos_local/tests/unit/CMakeLists.txt
@@ -7,7 +7,7 @@
 set(tests
     channel_local
     local_dataflow
-    local_dataflow_boost_small_vector
+    local_dataflow_small_vector
     local_dataflow_executor
     local_dataflow_external_future
     local_dataflow_executor_additional_arguments

--- a/libs/core/lcos_local/tests/unit/local_dataflow_small_vector.cpp
+++ b/libs/core/lcos_local/tests/unit/local_dataflow_small_vector.cpp
@@ -1,10 +1,11 @@
 //  Copyright (c) 2013 Thomas Heller
-//  Copyright (c) 2018 Hartmut Kaiser
+//  Copyright (c) 2018-2021 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+#include <hpx/datastructures/detail/small_vector.hpp>
 #include <hpx/local/future.hpp>
 #include <hpx/local/init.hpp>
 #include <hpx/local/thread.hpp>
@@ -21,33 +22,30 @@
 #include <vector>
 
 ///////////////////////////////////////////////////////////////////////////////
-#include <boost/container/small_vector.hpp>
-
 namespace hpx { namespace traits {
-    // support unwrapping of boost::container::small_vector
-    // Note: small_vector's allocator support is not 100% conforming
+
+    // support unwrapping of hpx::detail::small_vector
     template <typename NewType, typename OldType, std::size_t Size,
         typename OldAllocator>
     struct pack_traversal_rebind_container<NewType,
-        boost::container::small_vector<OldType, Size, OldAllocator>>
+        hpx::detail::small_vector<OldType, Size, OldAllocator>>
     {
         using NewAllocator = typename std::allocator_traits<
             OldAllocator>::template rebind_alloc<NewType>;
 
-        static boost::container::small_vector<NewType, Size, NewAllocator> call(
-            boost::container::small_vector<OldType, Size, OldAllocator> const&)
+        static hpx::detail::small_vector<NewType, Size, NewAllocator> call(
+            hpx::detail::small_vector<OldType, Size, OldAllocator> const&)
         {
             // Create a new version of the container with a new allocator
             // instance
-            return boost::container::small_vector<NewType, Size,
-                NewAllocator>();
+            return hpx::detail::small_vector<NewType, Size, NewAllocator>();
         }
     };
 }}    // namespace hpx::traits
 
 template <typename T>
 using small_vector =
-    boost::container::small_vector<T, 3, boost::container::new_allocator<T>>;
+    hpx::detail::small_vector<T, 3, hpx::util::internal_allocator<T>>;
 
 ///////////////////////////////////////////////////////////////////////////////
 std::atomic<std::uint32_t> void_f_count;

--- a/libs/core/synchronization/include/hpx/synchronization/async_rw_mutex.hpp
+++ b/libs/core/synchronization/include/hpx/synchronization/async_rw_mutex.hpp
@@ -8,14 +8,13 @@
 
 #include <hpx/allocator_support/internal_allocator.hpp>
 #include <hpx/assert.hpp>
+#include <hpx/datastructures/detail/small_vector.hpp>
 #include <hpx/datastructures/optional.hpp>
 #include <hpx/execution_base/operation_state.hpp>
 #include <hpx/execution_base/receiver.hpp>
 #include <hpx/execution_base/sender.hpp>
 #include <hpx/functional/unique_function.hpp>
 #include <hpx/synchronization/mutex.hpp>
-
-#include <boost/container/small_vector.hpp>
 
 #include <exception>
 #include <memory>
@@ -39,7 +38,7 @@ namespace hpx { namespace experimental {
             hpx::util::optional<T> value;
             shared_state_ptr_type next_state;
             hpx::lcos::local::mutex mtx;
-            boost::container::small_vector<
+            hpx::detail::small_vector<
                 hpx::util::unique_function_nonser<void(shared_state_ptr_type)>,
                 1>
                 continuations;
@@ -108,7 +107,7 @@ namespace hpx { namespace experimental {
                 std::shared_ptr<async_rw_mutex_shared_state>;
             shared_state_ptr_type next_state;
             hpx::lcos::local::mutex mtx;
-            boost::container::small_vector<
+            hpx::detail::small_vector<
                 hpx::util::unique_function_nonser<void(shared_state_ptr_type)>,
                 1>
                 continuations;

--- a/plugins/parcelport/libfabric/parcelport_libfabric.cpp
+++ b/plugins/parcelport/libfabric/parcelport_libfabric.cpp
@@ -42,7 +42,7 @@
 #define HPX_PARCELPORT_LIBFABRIC_SUSPEND_WAKE  (HPX_PARCELPORT_LIBFABRIC_THROTTLE_SENDS/2)
 
 // --------------------------------------------------------------------
-// Enable the use of boost small_vector for certain short lived storage
+// Enable the use of hpx small_vector for certain short lived storage
 // elements within the parcelport. This can reduce some memory allocations
 #define HPX_PARCELPORT_LIBFABRIC_USE_SMALL_VECTOR    true
 
@@ -61,7 +61,7 @@
 
 //
 #if HPX_PARCELPORT_LIBFABRIC_USE_SMALL_VECTOR
-# include <boost/container/small_vector.hpp>
+#include <hpx/datastructures/detail/small_vector.hpp>
 #endif
 //
 #include <unordered_map>

--- a/plugins/parcelport/libfabric/parcelport_libfabric.hpp
+++ b/plugins/parcelport/libfabric/parcelport_libfabric.hpp
@@ -36,7 +36,7 @@
 
 
 // --------------------------------------------------------------------
-// Enable the use of boost small_vector for certain short lived storage
+// Enable the use of hpx small_vector for certain short lived storage
 // elements within the parcelport. This can reduce some memory allocations
 #define HPX_PARCELPORT_LIBFABRIC_USE_SMALL_VECTOR    true
 
@@ -58,7 +58,7 @@
 
 //
 #if HPX_PARCELPORT_LIBFABRIC_USE_SMALL_VECTOR
-# include <boost/container/small_vector.hpp>
+#include <hpx/datastructures/detail/small_vector.hpp>
 #endif
 //
 #include <atomic>

--- a/plugins/parcelport/libfabric/receiver.hpp
+++ b/plugins/parcelport/libfabric/receiver.hpp
@@ -15,7 +15,7 @@
 //
 #include <hpx/thread_support/atomic_count.hpp>
 //
-#include <boost/container/small_vector.hpp>
+#include <hpx/datastructures/detail/small_vector.hpp>
 //
 #include <cstdint>
 
@@ -37,7 +37,7 @@ namespace libfabric
     {
         typedef libfabric_region_provider                      region_provider;
         typedef rma_memory_region<region_provider>             region_type;
-        typedef boost::container::small_vector<region_type*,8> zero_copy_vector;
+        typedef hpx::detail::small_vector<region_type*, 8>     zero_copy_vector;
 
         // --------------------------------------------------------------------
         // construct receive object

--- a/plugins/parcelport/libfabric/rma_receiver.hpp
+++ b/plugins/parcelport/libfabric/rma_receiver.hpp
@@ -15,7 +15,7 @@
 //
 #include <hpx/thread_support/atomic_count.hpp>
 //
-#include <boost/container/small_vector.hpp>
+#include <hpx/datastructures/detail/small_vector.hpp>
 //
 #include <vector>
 
@@ -36,7 +36,7 @@ namespace libfabric
         typedef libfabric_region_provider                      region_provider;
         typedef rma_memory_region<region_provider>             region_type;
         typedef rma_memory_pool<region_provider>               memory_pool_type;
-        typedef boost::container::small_vector<region_type*,8> zero_copy_vector;
+        typedef hpx::detail::small_vector<region_type*, 8>     zero_copy_vector;
 
         typedef header<HPX_PARCELPORT_LIBFABRIC_MESSAGE_HEADER_SIZE> header_type;
         static constexpr unsigned int header_size = header_type::header_block_size;

--- a/plugins/parcelport/libfabric/sender.hpp
+++ b/plugins/parcelport/libfabric/sender.hpp
@@ -20,7 +20,7 @@
 #include <hpx/functional/unique_function.hpp>
 #include <hpx/thread_support/atomic_count.hpp>
 
-#include <boost/container/small_vector.hpp>
+#include <hpx/datastructures/detail/small_vector.hpp>
 #include <memory>
 
 // include for iovec
@@ -47,7 +47,7 @@ namespace libfabric
         typedef parcel_buffer<snd_data_type, serialization::serialization_chunk>
             snd_buffer_type;
 
-        typedef boost::container::small_vector<region_type*,8> zero_copy_vector;
+        typedef hpx::detail::small_vector<region_type*, 8> zero_copy_vector;
 
         // --------------------------------------------------------------------
         sender(parcelport* pp, fid_ep* endpoint, fid_domain* domain,


### PR DESCRIPTION
This removes the dependency on `boost::container::small_vector`

Working towards #3440