### PR TITLE
build: remove unused import from conf.py.in

### DIFF
--- a/cmake/templates/conf.py.in
+++ b/cmake/templates/conf.py.in
@@ -19,7 +19,6 @@
 # serve to show the default.
 
 import os
-import subprocess
 import sys
 import re
 


### PR DESCRIPTION
## Proposed Changes

`conf.py.in` (template used for generating Sphinx config file -- `conf.py`) file had an unused import called `subprocess`. This PR removes it.
