### PR TITLE
docs: add support for BibTeX references in Sphinx docs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ working_dir_default: &working_dir_default
 
 docker_default: &docker_default
     docker:
-      - image: stellargroup/build_env:9
+      - image: stellargroup/build_env:10
 
 defaults: &defaults
     <<: *working_dir_default

--- a/.github/workflows/linux_debug.yml
+++ b/.github/workflows/linux_debug.yml
@@ -11,7 +11,7 @@ on: [pull_request]
 jobs:
   build:
     runs-on: ubuntu-latest
-    container: stellargroup/build_env:9
+    container: stellargroup/build_env:10
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/linux_release_fetchcontent.yml
+++ b/.github/workflows/linux_release_fetchcontent.yml
@@ -11,7 +11,7 @@ on: [pull_request]
 jobs:
   build:
     runs-on: ubuntu-latest
-    container: stellargroup/build_env:9
+    container: stellargroup/build_env:10
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/linux_sanitizers.yml
+++ b/.github/workflows/linux_sanitizers.yml
@@ -11,7 +11,7 @@ on: [pull_request]
 jobs:
   build:
     runs-on: ubuntu-latest
-    container: stellargroup/build_env:9
+    container: stellargroup/build_env:10
 
     steps:
     - uses: actions/checkout@v2

--- a/cmake/templates/conf.py.in
+++ b/cmake/templates/conf.py.in
@@ -634,6 +634,10 @@ html_search_language = 'en'
 # Output file base name for HTML help builder.
 htmlhelp_basename = 'HPXdoc'
 
+# Files mentioned in this list are used by sphinxcontrib.bibtex extension to generate
+# references/citations
+bibtex_bibfiles = ['references.bib']
+
 # -- Options for LaTeX output ---------------------------------------------
 
 latex_elements = {
@@ -689,6 +693,3 @@ epub_title = project
 epub_author = author
 epub_publisher = author
 epub_copyright = copyright
-
-# -- 
-bibtex_bibfiles = ['references.bib']

--- a/cmake/templates/conf.py.in
+++ b/cmake/templates/conf.py.in
@@ -40,6 +40,7 @@ sys.path.insert(0, os.path.abspath('.') + '/extensions')
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
+    'sphinxcontrib.bibtex',
     'sphinx.ext.autodoc',
     'sphinx.ext.doctest',
     'sphinx.ext.intersphinx',
@@ -688,3 +689,6 @@ epub_title = project
 epub_author = author
 epub_publisher = author
 epub_copyright = copyright
+
+# -- 
+bibtex_bibfiles = ['references.bib']

--- a/docs/sphinx/manual/optimizing_hpx_applications.rst
+++ b/docs/sphinx/manual/optimizing_hpx_applications.rst
@@ -3193,3 +3193,8 @@ optionally, ``TAU_ROOT=$PATH_TO_TAU`` to your |cmake| configuration. In
 addition, you can override the tag used for |apex| with the
 :option:`HPX_WITH_APEX_TAG` option. Please see the |apex_hpx_doc|_ for detailed
 instructions on using |apex| with |hpx|.
+
+See :cite:t:`1999:examplecitation` for an example citation number 1.
+See :cite:t:`1999:examplecitation` for an example citation number 2.
+
+.. bibliography::

--- a/docs/sphinx/manual/optimizing_hpx_applications.rst
+++ b/docs/sphinx/manual/optimizing_hpx_applications.rst
@@ -3194,7 +3194,4 @@ addition, you can override the tag used for |apex| with the
 :option:`HPX_WITH_APEX_TAG` option. Please see the |apex_hpx_doc|_ for detailed
 instructions on using |apex| with |hpx|.
 
-See :cite:t:`1999:examplecitation` for an example citation number 1.
-See :cite:t:`1999:examplecitation` for an example citation number 2.
-
 .. bibliography::

--- a/docs/sphinx/manual/optimizing_hpx_applications.rst
+++ b/docs/sphinx/manual/optimizing_hpx_applications.rst
@@ -3184,9 +3184,9 @@ APEX integration
 ================
 
 |hpx| provides integration with |apex|_, which is a framework for application
-profiling using task timers and various performance counters. It can be added as
-a ``git`` submodule by turning on the option :option:`HPX_WITH_APEX:BOOL` during
-|cmake| configuration. |tau|_ is an optional dependency when using |apex|.
+profiling using task timers and various performance counters :footcite:t:`2015:apex`.
+It can be added as a ``git`` submodule by turning on the option :option:`HPX_WITH_APEX:BOOL`
+during |cmake| configuration. |tau|_ is an optional dependency when using |apex|.
 
 To build |hpx| with |apex|, add :option:`HPX_WITH_APEX`\ ``=ON``, and,
 optionally, ``TAU_ROOT=$PATH_TO_TAU`` to your |cmake| configuration. In
@@ -3194,4 +3194,7 @@ addition, you can override the tag used for |apex| with the
 :option:`HPX_WITH_APEX_TAG` option. Please see the |apex_hpx_doc|_ for detailed
 instructions on using |apex| with |hpx|.
 
-.. bibliography::
+References
+==========
+
+.. footbibliography::

--- a/docs/sphinx/references.bib
+++ b/docs/sphinx/references.bib
@@ -1,0 +1,13 @@
+@Book{2015:apex,
+  author = {K. A. Huck and 
+            A. Porterfield and
+            N Chaimov and
+            H. Kaiser and
+            A. D. Malony and 
+            T. Sterling and
+            R. Fowler},
+  title = {An autonomic performance environment for exascale},
+  publisher = {Supercomputing Frontiers and Innovations },
+  pages={49--66},
+  year = {2015}
+}

--- a/docs/sphinx/references.bib
+++ b/docs/sphinx/references.bib
@@ -1,0 +1,6 @@
+@Book{1999:examplecitation,
+  author = {John Doe},
+  title = {Example Citation},
+  publisher = {Foo Bar Press},
+  year = {1999}
+}

--- a/docs/sphinx/references.bib
+++ b/docs/sphinx/references.bib
@@ -1,6 +1,0 @@
-@Book{1999:examplecitation,
-  author = {John Doe},
-  title = {Example Citation},
-  publisher = {Foo Bar Press},
-  year = {1999}
-}

--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -3,7 +3,7 @@
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-FROM stellargroup/build_env:9
+FROM stellargroup/build_env:10
 
 # docker build needs to be run in /usr/local
 COPY . /usr/local


### PR DESCRIPTION
Fixes #4698 

## Proposed Changes

- Adds support for BibTeX references in Sphinx docs
- Added an example citation (this will have to be removed before merging)

## Any other context you'd like to provide?

This is how the references/citations will look with this change:

<img width="776" alt="image" src="https://user-images.githubusercontent.com/61645613/139540432-cf4606da-82a3-4713-aca8-f6a4143900ce.png">

EDIT:
Changed the style of references because earlier style would have meant there would me a single, unified bibliography section. New style should look like this:

<img width="833" alt="image" src="https://user-images.githubusercontent.com/61645613/139789850-768a9e39-7a50-4d11-8e9b-a6c70a9eb7b8.png">

