### PR TITLE
Update container image tag in GitHub actions HIP configuration

### DIFF
--- a/.github/workflows/linux_hip.yml
+++ b/.github/workflows/linux_hip.yml
@@ -11,7 +11,7 @@ on: [pull_request]
 jobs:
   build:
     runs-on: ubuntu-latest
-    container: stellargroup/hip_build_env:7
+    container: stellargroup/hip_build_env:10
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
This one seems to have been left behind at some point (maybe even intentionally, hmm... @aurianer do you remember anything about this?). Bumping it up to the latest. #5626 bumps the others from `9` to `10`.