### PR TITLE
Fix leftover std::holds_alternative usage

### DIFF
--- a/libs/core/datastructures/include/hpx/datastructures/variant.hpp
+++ b/libs/core/datastructures/include/hpx/datastructures/variant.hpp
@@ -14,6 +14,7 @@
 namespace hpx {
 
     using std::get;
+    using std::holds_alternative;
     using std::monostate;
     using std::variant;
     using std::visit;
@@ -26,6 +27,7 @@ namespace hpx {
 namespace hpx {
 
     using hpx::variant_ns::get;
+    using hpx::variant_ns::holds_alternative;
     using hpx::variant_ns::monostate;
     using hpx::variant_ns::variant;
     using hpx::variant_ns::visit;

--- a/libs/core/execution/include/hpx/execution/algorithms/sync_wait.hpp
+++ b/libs/core/execution/include/hpx/execution/algorithms/sync_wait.hpp
@@ -105,7 +105,7 @@ namespace hpx { namespace execution { namespace experimental {
 
                 auto get_value()
                 {
-                    if (std::holds_alternative<value_type>(value))
+                    if (hpx::holds_alternative<value_type>(value))
                     {
                         if constexpr (is_void_result)
                         {
@@ -116,7 +116,7 @@ namespace hpx { namespace execution { namespace experimental {
                             return std::move(hpx::get<value_type>(value));
                         }
                     }
-                    else if (std::holds_alternative<error_type>(value))
+                    else if (hpx::holds_alternative<error_type>(value))
                     {
                         hpx::visit(sync_wait_error_visitor{},
                             hpx::get<error_type>(value));


### PR DESCRIPTION
Use `hpx::holds_alternative` instead.