### PR TITLE
Use bors for merging pull requests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,7 +43,10 @@ move_debug_log: &move_debug_log
 gh_pages_filter: &gh_pages_filter
     filters:
       branches:
-        ignore: gh-pages
+        ignore:
+          - gh-pages
+          - trying
+          - staging
       tags:
         ignore: stable
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,7 +75,7 @@ configure_local_git: &configure_local_git
         name: Configure local Git
         command: |
             git config --global user.name "StellarBot"
-            git config --global user.email "stellar@cct.lsu.edu"
+            git config --global user.email "contact@stellar-group.org"
 
 
 version: 2

--- a/.github/bors.toml
+++ b/.github/bors.toml
@@ -1,0 +1,14 @@
+# Copyright (c) 2021 ETH Zurich
+#
+# SPDX-License-Identifier: BSL-1.0
+# Distributed under the Boost Software License, Version 1.0. (See accompanying
+# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+status = [ "Bors" ]
+required_approvals = 1
+delete_merged_branches = true
+use_squash_merge = false
+
+[committer]
+name = "StellarBot"
+email = "contact@stellar-group.org"

--- a/.github/workflows/linux_bors.yml
+++ b/.github/workflows/linux_bors.yml
@@ -1,0 +1,49 @@
+# Copyright (c) 2020 ETH Zurich
+#
+# SPDX-License-Identifier: BSL-1.0
+# Distributed under the Boost Software License, Version 1.0. (See accompanying
+# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+name: Linux CI (Debug)
+
+on:
+  push:
+    branches:
+      - staging
+      - trying
+
+jobs:
+  build:
+    name: Bors
+    runs-on: ubuntu-latest
+    container: stellargroup/build_env:10
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Configure
+      shell: bash
+      run: |
+          cmake \
+              . \
+              -Bbuild \
+              -GNinja \
+              -DCMAKE_BUILD_TYPE=Debug \
+              -DHPX_WITH_MALLOC=system \
+              -DHPX_WITH_FETCH_ASIO=ON \
+              -DHPX_WITH_EXAMPLES=ON \
+              -DHPX_WITH_TESTS=ON \
+              -DHPX_WITH_TESTS_MAX_THREADS_PER_LOCALITY=2 \
+              -DHPX_WITH_CHECK_MODULE_DEPENDENCIES=On
+    - name: Build
+      shell: bash
+      run: |
+          cmake --build build --target all
+          cmake --build build --target examples
+    - name: Test
+      shell: bash
+      run: |
+          cd build
+          ctest \
+            --output-on-failure \
+            --tests-regex tests.examples \
+            --exclude-regex tests.examples.transpose.transpose_block_numa


### PR DESCRIPTION
Bors is meant to avoid this problem: https://bors.tech/essay/2017/02/02/pitch/, which happened (again) yesterday.

This will not be very useful until CI actually passes reliably, but I'm starting by setting it up for a subset, i.e. one single GitHub action on Linux that builds and runs the examples (i.e. the current "Linux CI (Debug)" configuration). Eventually all CI should just report to bors, but I'm keeping it separate for now until we get some experience with how well this works.