### PR TITLE
Fix generate datapar tests for Vc

### DIFF
--- a/libs/core/algorithms/tests/unit/datapar_algorithms/generate_tests.hpp
+++ b/libs/core/algorithms/tests/unit/datapar_algorithms/generate_tests.hpp
@@ -38,10 +38,10 @@ void test_generate(ExPolicy&& policy, IteratorTag)
     static_assert(hpx::is_execution_policy<ExPolicy>::value,
         "hpx::is_execution_policy<ExPolicy>::value");
 
-    typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef std::vector<int>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
 
-    std::vector<std::size_t> c(10007);
+    std::vector<int> c(10007);
 
     foo gen;
 
@@ -49,8 +49,8 @@ void test_generate(ExPolicy&& policy, IteratorTag)
 
     // verify values
     std::size_t count = 0;
-    std::for_each(std::begin(c), std::end(c), [&count](std::size_t v) -> void {
-        HPX_TEST_EQ(v, std::size_t(10));
+    std::for_each(std::begin(c), std::end(c), [&count](int v) -> void {
+        HPX_TEST_EQ(v, int(10));
         ++count;
     });
     HPX_TEST_EQ(count, c.size());
@@ -59,10 +59,10 @@ void test_generate(ExPolicy&& policy, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_generate_async(ExPolicy&& p, IteratorTag)
 {
-    typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef std::vector<int>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
 
-    std::vector<std::size_t> c(10007);
+    std::vector<int> c(10007);
 
     foo gen;
 
@@ -71,8 +71,8 @@ void test_generate_async(ExPolicy&& p, IteratorTag)
     f.wait();
 
     std::size_t count = 0;
-    std::for_each(std::begin(c), std::end(c), [&count](std::size_t v) -> void {
-        HPX_TEST_EQ(v, std::size_t(10));
+    std::for_each(std::begin(c), std::end(c), [&count](int v) -> void {
+        HPX_TEST_EQ(v, int(10));
         ++count;
     });
     HPX_TEST_EQ(count, c.size());
@@ -85,10 +85,10 @@ void test_generate_exception(ExPolicy&& policy, IteratorTag)
     static_assert(hpx::is_execution_policy<ExPolicy>::value,
         "hpx::is_execution_policy<ExPolicy>::value");
 
-    typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef std::vector<int>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>
         decorated_iterator;
-    std::vector<std::size_t> c(10007);
+    std::vector<int> c(10007);
 
     foo gen;
 
@@ -117,11 +117,11 @@ void test_generate_exception(ExPolicy&& policy, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_generate_exception_async(ExPolicy&& p, IteratorTag)
 {
-    typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef std::vector<int>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>
         decorated_iterator;
 
-    std::vector<std::size_t> c(10007);
+    std::vector<int> c(10007);
 
     foo gen;
 
@@ -159,11 +159,11 @@ void test_generate_bad_alloc(ExPolicy&& policy, IteratorTag)
     static_assert(hpx::is_execution_policy<ExPolicy>::value,
         "hpx::is_execution_policy<ExPolicy>::value");
 
-    typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef std::vector<int>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>
         decorated_iterator;
 
-    std::vector<std::size_t> c(10007);
+    std::vector<int> c(10007);
 
     foo gen;
 
@@ -190,11 +190,11 @@ void test_generate_bad_alloc(ExPolicy&& policy, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_generate_bad_alloc_async(ExPolicy&& p, IteratorTag)
 {
-    typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef std::vector<int>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>
         decorated_iterator;
 
-    std::vector<std::size_t> c(10007);
+    std::vector<int> c(10007);
 
     foo gen;
 

--- a/libs/core/algorithms/tests/unit/datapar_algorithms/generaten_tests.hpp
+++ b/libs/core/algorithms/tests/unit/datapar_algorithms/generaten_tests.hpp
@@ -37,11 +37,10 @@ void test_generate_n(ExPolicy&& policy, IteratorTag)
     static_assert(hpx::is_execution_policy<ExPolicy>::value,
         "hpx::is_execution_policy<ExPolicy>::value");
 
-    typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef std::vector<int>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
 
-    using V = hpx::parallel::traits::vector_pack_type<std::size_t, 1>::type;
-    std::vector<std::size_t> c(10007);
+    std::vector<int> c(10007);
 
     foo gen;
 
@@ -49,8 +48,8 @@ void test_generate_n(ExPolicy&& policy, IteratorTag)
 
     // verify values
     std::size_t count = 0;
-    std::for_each(std::begin(c), std::end(c), [&count](std::size_t v) -> void {
-        HPX_TEST_EQ(v, std::size_t(10));
+    std::for_each(std::begin(c), std::end(c), [&count](int v) -> void {
+        HPX_TEST_EQ(v, int(10));
         ++count;
     });
     HPX_TEST_EQ(count, c.size());
@@ -59,11 +58,10 @@ void test_generate_n(ExPolicy&& policy, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_generate_n_async(ExPolicy&& p, IteratorTag)
 {
-    typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef std::vector<int>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
 
-    using V = hpx::parallel::traits::vector_pack_type<std::size_t, 1>::type;
-    std::vector<std::size_t> c(10007);
+    std::vector<int> c(10007);
 
     foo gen;
 
@@ -72,8 +70,8 @@ void test_generate_n_async(ExPolicy&& p, IteratorTag)
     f.wait();
 
     std::size_t count = 0;
-    std::for_each(std::begin(c), std::end(c), [&count](std::size_t v) -> void {
-        HPX_TEST_EQ(v, std::size_t(10));
+    std::for_each(std::begin(c), std::end(c), [&count](int v) -> void {
+        HPX_TEST_EQ(v, int(10));
         ++count;
     });
     HPX_TEST_EQ(count, c.size());
@@ -86,11 +84,10 @@ void test_generate_n_exception(ExPolicy&& policy, IteratorTag)
     static_assert(hpx::is_execution_policy<ExPolicy>::value,
         "hpx::is_execution_policy<ExPolicy>::value");
 
-    typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef std::vector<int>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>
         decorated_iterator;
-    using V = hpx::parallel::traits::vector_pack_type<std::size_t, 1>::type;
-    std::vector<std::size_t> c(10007);
+    std::vector<int> c(10007);
 
     foo gen;
 
@@ -119,12 +116,11 @@ void test_generate_n_exception(ExPolicy&& policy, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_generate_n_exception_async(ExPolicy&& p, IteratorTag)
 {
-    typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef std::vector<int>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>
         decorated_iterator;
 
-    using V = hpx::parallel::traits::vector_pack_type<std::size_t, 1>::type;
-    std::vector<std::size_t> c(10007);
+    std::vector<int> c(10007);
 
     foo gen;
 
@@ -162,12 +158,11 @@ void test_generate_n_bad_alloc(ExPolicy&& policy, IteratorTag)
     static_assert(hpx::is_execution_policy<ExPolicy>::value,
         "hpx::is_execution_policy<ExPolicy>::value");
 
-    typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef std::vector<int>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>
         decorated_iterator;
 
-    using V = hpx::parallel::traits::vector_pack_type<std::size_t, 1>::type;
-    std::vector<std::size_t> c(10007);
+    std::vector<int> c(10007);
 
     foo gen;
 
@@ -194,12 +189,11 @@ void test_generate_n_bad_alloc(ExPolicy&& policy, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_generate_n_bad_alloc_async(ExPolicy&& p, IteratorTag)
 {
-    typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef std::vector<int>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>
         decorated_iterator;
 
-    using V = hpx::parallel::traits::vector_pack_type<std::size_t, 1>::type;
-    std::vector<std::size_t> c(10007);
+    std::vector<int> c(10007);
 
     foo gen;
 


### PR DESCRIPTION
Same problem as https://github.com/STEllAR-GROUP/hpx/pull/5613.

This was again not caught because @srinivasyadav18's PRs don't run on circleci (at least not under STEllAR-GROUP). However, I just noticed that @srinivasyadav18 has CircleCI enabled on his own fork, and the PRs do actually build there. This may be the reason why it doesn't run under STEllAR-GROUP. @srinivasyadav18 could you try if disabling builds on your fork would get the builds over to the main repo again. There should be a "stop building" button on this page for you: https://app.circleci.com/settings/project/github/srinivasyadav18/hpx.