### PR TITLE
Fixed links to sources in Sphinx documentation

### DIFF
--- a/docs/sphinx/manual/optimizing_hpx_applications.rst
+++ b/docs/sphinx/manual/optimizing_hpx_applications.rst
@@ -715,8 +715,7 @@ a component for you. The remainder of this section will explain the process of c
 performance counter based on the Sine example, which you can find in the
 directory ``examples/performance_counters/sine/``.
 
-The base class is defined in the header file [hpx_link
-hpx/performance_counters/base_performance_counter.hpp..hpx/performance_counters/base_performance_counter.hpp]
+The base class is defined in the header file :download:`base_performance_counter.cpp <../../libs/full/performance_counters/include/hpx/performance_counters/base_performance_counter.hpp>`
 as:
 
 .. literalinclude:: ../../libs/full/performance_counters/include/hpx/performance_counters/base_performance_counter.hpp

--- a/docs/sphinx/manual/writing_distributed_hpx_applications.rst
+++ b/docs/sphinx/manual/writing_distributed_hpx_applications.rst
@@ -206,8 +206,7 @@ functions, however we believe they are still manageable.
 
 The most important macro invocation is the :c:macro:`HPX_DEFINE_COMPONENT_ACTION` in the header file
 as this defines the action type we need to invoke the member function. For a
-complete example of a simple component action see [hpx_link
-examples/quickstart/component_in_executable.cpp..component_in_executable.cpp]
+complete example of a simple component action see :download:`component_in_executable.cpp <../../examples/quickstart/component_in_executable.cpp>`.
 
 .. _action_invocation:
 


### PR DESCRIPTION
The documentation contained two dead links to source code examples, hopefully I got the syntax right for the new scheme.
