### PR TITLE
Fix ends_with test

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,3 +7,11 @@ Fixes #
   -
 
 ## Any background context you want to provide?
+
+## Checklist
+
+Not all points below apply to all pull requests.
+
+- [ ] I have added a new feature and have added tests to go along with it.
+- [ ] I have fixed a bug and have added a regression test.
+- [ ] I have added a test using random numbers; I have made sure it uses a seed, and that random numbers generated are valid inputs for the tests.

--- a/libs/core/algorithms/tests/unit/algorithms/ends_with.cpp
+++ b/libs/core/algorithms/tests/unit/algorithms/ends_with.cpp
@@ -14,17 +14,23 @@
 #include <iostream>
 #include <iterator>
 #include <numeric>
+#include <random>
 #include <string>
 #include <vector>
 
 #include "test_utils.hpp"
 
+unsigned int seed = std::random_device{}();
+std::mt19937 gen(seed);
+
 ////////////////////////////////////////////////////////////////////////////
 template <typename IteratorTag>
 void test_ends_with(IteratorTag)
 {
-    auto end1 = std::rand() % 10007 + 1;
-    auto end2 = std::rand() % (end1 - 1) + 1;
+    std::uniform_int_distribution<int> dis1(2, 10007);
+    auto end1 = dis1(gen);
+    std::uniform_int_distribution<int> dis2(1, end1 - 1);
+    auto end2 = dis2(gen);
     auto some_ints = std::vector<int>(end1);
     std::iota(some_ints.begin(), some_ints.end(), 1);
 
@@ -50,8 +56,10 @@ void test_ends_with(ExPolicy policy, IteratorTag)
     static_assert(hpx::is_execution_policy<ExPolicy>::value,
         "hpx::is_execution_policy<ExPolicy>::value");
 
-    auto end1 = std::rand() % 10007 + 1;
-    auto end2 = std::rand() % (end1 - 1) + 1;
+    std::uniform_int_distribution<int> dis1(2, 10007);
+    auto end1 = dis1(gen);
+    std::uniform_int_distribution<int> dis2(1, end1 - 1);
+    auto end2 = dis2(gen);
     auto some_ints = std::vector<int>(end1);
     std::iota(some_ints.begin(), some_ints.end(), 1);
     auto some_more_ints = std::vector<int>(end1 - end2 + 1);
@@ -74,8 +82,10 @@ void test_ends_with(ExPolicy policy, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_ends_with_async(ExPolicy p, IteratorTag)
 {
-    auto end1 = std::rand() % 10007 + 1;
-    auto end2 = std::rand() % (end1 - 1) + 1;
+    std::uniform_int_distribution<int> dis1(2, 10007);
+    auto end1 = dis1(gen);
+    std::uniform_int_distribution<int> dis2(1, end1 - 1);
+    auto end2 = dis2(gen);
     auto some_ints = std::vector<int>(end1);
     std::iota(some_ints.begin(), some_ints.end(), 1);
     auto some_more_ints = std::vector<int>(end1 - end2 + 1);
@@ -124,7 +134,7 @@ int hpx_main(hpx::program_options::variables_map& vm)
         seed = vm["seed"].as<unsigned int>();
 
     std::cout << "using seed: " << seed << std::endl;
-    std::srand(seed);
+    gen.seed(seed);
 
     ends_with_test();
     return hpx::local::finalize();

--- a/libs/core/algorithms/tests/unit/algorithms/starts_with.cpp
+++ b/libs/core/algorithms/tests/unit/algorithms/starts_with.cpp
@@ -14,17 +14,23 @@
 #include <iostream>
 #include <iterator>
 #include <numeric>
+#include <random>
 #include <string>
 #include <vector>
 
 #include "test_utils.hpp"
 
+unsigned int seed = std::random_device{}();
+std::mt19937 gen(seed);
+
 ////////////////////////////////////////////////////////////////////////////
 template <typename IteratorTag>
 void test_starts_with(IteratorTag)
 {
-    auto end1 = std::rand() % 10007 + 1;
-    auto end2 = std::rand() % end1 + 1;
+    std::uniform_int_distribution<int> dis1(1, 10007);
+    auto end1 = dis1(gen);
+    std::uniform_int_distribution<int> dis2(1, end1);
+    auto end2 = dis2(gen);
     auto some_ints = std::vector<int>(end1);
     std::iota(some_ints.begin(), some_ints.end(), 1);
     auto some_more_ints = std::vector<int>(end2);
@@ -48,8 +54,10 @@ void test_starts_with(ExPolicy policy, IteratorTag)
     static_assert(hpx::is_execution_policy<ExPolicy>::value,
         "hpx::is_execution_policy<ExPolicy>::value");
 
-    auto end1 = std::rand() % 10007 + 1;
-    auto end2 = std::rand() % end1 + 1;
+    std::uniform_int_distribution<int> dis1(1, 10007);
+    auto end1 = dis1(gen);
+    std::uniform_int_distribution<int> dis2(1, end1);
+    auto end2 = dis2(gen);
     auto some_ints = std::vector<int>(end1);
     std::iota(some_ints.begin(), some_ints.end(), 1);
     auto some_more_ints = std::vector<int>(end2);
@@ -72,8 +80,10 @@ void test_starts_with(ExPolicy policy, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_starts_with_async(ExPolicy p, IteratorTag)
 {
-    auto end1 = std::rand() % 10007 + 1;
-    auto end2 = std::rand() % end1 + 1;
+    std::uniform_int_distribution<int> dis1(1, 10007);
+    auto end1 = dis1(gen);
+    std::uniform_int_distribution<int> dis2(1, end1);
+    auto end2 = dis2(gen);
     auto some_ints = std::vector<int>(end1);
     std::iota(some_ints.begin(), some_ints.end(), 1);
     auto some_more_ints = std::vector<int>(end2);
@@ -123,7 +133,7 @@ int hpx_main(hpx::program_options::variables_map& vm)
         seed = vm["seed"].as<unsigned int>();
 
     std::cout << "using seed: " << seed << std::endl;
-    std::srand(seed);
+    gen.seed(seed);
 
     starts_with_test();
     return hpx::local::finalize();


### PR DESCRIPTION
With certain seeds/random numbers it would fail with a floating point exception because of `x % 0` (like this: https://cdash.cscs.ch/testDetails.php?test=57251016&build=196753). I've updated it to use `uniform_int_distribution` to avoid the modulo in the first place. `starts_with` was not buggy in the same way, but I've still updated it to use `uniform_int_distribution` as I find it much easier to see what range of values can be generated.

Finally, I've added a "Checklist" section to the pull request template. Anything that can be checked in CI should be checked there, but some things are hard or impossible to check automatically. For those cases it's sometimes enough to have a gentle reminder to check things manually. Please feel free to expand the list in the future (or remove things; needs change), or suggest additions already now.

