### PR TITLE
Modernize action modules and related code

### DIFF
--- a/components/component_storage/src/server/component_storage_server.cpp
+++ b/components/component_storage/src/server/component_storage_server.cpp
@@ -26,7 +26,7 @@ namespace hpx { namespace components { namespace server
 
         // rebind the object to this storage locality
         naming::address addr(current_lva);
-        addr.address_ = 0;       // invalidate lva
+        addr.address_ = nullptr;       // invalidate lva
         if (!agas::bind(launch::sync, gid, addr, this->gid_))
         {
             HPX_THROW_EXCEPTION(duplicate_component_address,

--- a/components/containers/partitioned_vector/include/hpx/components/containers/partitioned_vector/partitioned_vector_component_decl.hpp
+++ b/components/containers/partitioned_vector/include/hpx/components/containers/partitioned_vector/partitioned_vector_component_decl.hpp
@@ -84,8 +84,11 @@ namespace hpx { namespace server {
             allocator_type const& alloc);
 
         // support components::copy
-        partitioned_vector(partitioned_vector const& rhs);
-        partitioned_vector(partitioned_vector&& rhs);
+        partitioned_vector(partitioned_vector const& rhs) = default;
+        partitioned_vector(partitioned_vector&& rhs) = default;
+
+        partitioned_vector& operator=(partitioned_vector const& rhs) = default;
+        partitioned_vector& operator=(partitioned_vector&& rhs) = default;
 
         ///////////////////////////////////////////////////////////////////////
         data_type& get_data();

--- a/components/containers/partitioned_vector/include/hpx/components/containers/partitioned_vector/partitioned_vector_component_impl.hpp
+++ b/components/containers/partitioned_vector/include/hpx/components/containers/partitioned_vector/partitioned_vector_component_impl.hpp
@@ -62,24 +62,6 @@ namespace hpx { namespace server {
     {
     }
 
-    template <typename T, typename Data>
-    HPX_PARTITIONED_VECTOR_SPECIALIZATION_EXPORT
-    partitioned_vector<T, Data>::partitioned_vector(
-        partitioned_vector const& rhs)
-      : base_type(rhs)
-      , partitioned_vector_partition_(rhs.partitioned_vector_partition_)
-    {
-    }
-
-    template <typename T, typename Data>
-    HPX_PARTITIONED_VECTOR_SPECIALIZATION_EXPORT
-    partitioned_vector<T, Data>::partitioned_vector(partitioned_vector&& rhs)
-      : base_type(HPX_MOVE(rhs))
-      , partitioned_vector_partition_(
-            HPX_MOVE(rhs.partitioned_vector_partition_))
-    {
-    }
-
     ///////////////////////////////////////////////////////////////////////////
     template <typename T, typename Data>
     HPX_PARTITIONED_VECTOR_SPECIALIZATION_EXPORT

--- a/components/performance_counters/papi/include/hpx/components/performance_counters/papi/server/papi.hpp
+++ b/components/performance_counters/papi/include/hpx/components/performance_counters/papi/server/papi.hpp
@@ -210,6 +210,8 @@ namespace hpx { namespace performance_counters { namespace papi { namespace serv
         // currently cached value
         long long get_value() const {return value_;}
 
+        naming::address get_current_address() const;
+
     private:
         //// methods below operate on shared state and require locking in the caller
 

--- a/components/performance_counters/papi/src/server/papi.cpp
+++ b/components/performance_counters/papi/src/server/papi.cpp
@@ -318,6 +318,14 @@ namespace hpx { namespace performance_counters { namespace papi { namespace serv
         base_type::finalize();
     }
 
+    naming::address papi_counter::get_current_address() const
+    {
+        return naming::address(
+            naming::get_gid_from_locality_id(hpx::get_locality_id()),
+            components::get_component_type<papi_counter>(),
+            const_cast<papi_counter*>(this));
+    }
+
 }}}}
 
 #undef HPX_PAPI_NS_STR

--- a/libs/full/actions/include/hpx/actions/apply_helper.hpp
+++ b/libs/full/actions/include/hpx/actions/apply_helper.hpp
@@ -40,8 +40,7 @@ namespace hpx { namespace applier { namespace detail {
         threads::thread_priority priority)
     {
         return hpx::actions::detail::thread_priority<
-            static_cast<threads::thread_priority>(
-                traits::action_priority<Action>::value)>::call(priority);
+            traits::action_priority_v<Action>>::call(priority);
     }
 
     ///////////////////////////////////////////////////////////////////////////
@@ -51,8 +50,7 @@ namespace hpx { namespace applier { namespace detail {
         naming::address::component_type comptype,
         threads::thread_priority priority, Ts&&... vs)
     {
-        using continuation_type =
-            typename traits::action_continuation<Action>::type;
+        using continuation_type = traits::action_continuation_t<Action>;
 
         continuation_type cont;
         if (traits::action_decorate_continuation<Action>::call(cont))    //-V614

--- a/libs/full/actions/tests/performance/serialization_overhead.cpp
+++ b/libs/full/actions/tests/performance/serialization_overhead.cpp
@@ -51,8 +51,7 @@ double benchmark_serialization(std::size_t data_size, std::size_t iterations,
 {
     hpx::naming::id_type const here = hpx::find_here();
     hpx::naming::address addr(hpx::get_locality(),
-        hpx::components::component_invalid,
-        reinterpret_cast<std::uint64_t>(&test_function));
+        hpx::components::component_invalid, (void*) &test_function);
 
     // compose archive flags
     std::string endian_out = hpx::get_config_entry("hpx.parcel.endian_out",

--- a/libs/full/actions/tests/unit/zero_copy_serialization.cpp
+++ b/libs/full/actions/tests/unit/zero_copy_serialization.cpp
@@ -179,8 +179,7 @@ void test_normal_serialization(T& arg)
 {
     hpx::naming::id_type const here = hpx::find_here();
     hpx::naming::address addr(hpx::get_locality(),
-        hpx::components::component_invalid,
-        reinterpret_cast<std::uint64_t>(&test_function1));
+        hpx::components::component_invalid, (void*) &test_function1);
 
     // compose archive flags
     std::uint32_t out_archive_flags = hpx::serialization::disable_data_chunking;
@@ -210,8 +209,7 @@ void test_normal_serialization(T1& arg1, T2& arg2)
 {
     hpx::naming::id_type const here = hpx::find_here();
     hpx::naming::address addr(hpx::get_locality(),
-        hpx::components::component_invalid,
-        reinterpret_cast<std::uint64_t>(&test_function2));
+        hpx::components::component_invalid, (void*) &test_function2);
 
     // compose archive flags
     std::uint32_t out_archive_flags = hpx::serialization::disable_data_chunking;
@@ -242,8 +240,7 @@ void test_normal_serialization(
 {
     hpx::naming::id_type const here = hpx::find_here();
     hpx::naming::address addr(hpx::get_locality(),
-        hpx::components::component_invalid,
-        reinterpret_cast<std::uint64_t>(&test_function2));
+        hpx::components::component_invalid, (void*) &test_function2);
 
     // compose archive flags
     std::uint32_t out_archive_flags = hpx::serialization::disable_data_chunking;
@@ -274,8 +271,7 @@ void test_zero_copy_serialization(T& arg)
 {
     hpx::naming::id_type const here = hpx::find_here();
     hpx::naming::address addr(hpx::get_locality(),
-        hpx::components::component_invalid,
-        reinterpret_cast<std::uint64_t>(&test_function1));
+        hpx::components::component_invalid, (void*) &test_function1);
 
     // compose archive flags
     std::uint32_t out_archive_flags = 0U;
@@ -305,8 +301,7 @@ void test_zero_copy_serialization(T1& arg1, T2& arg2)
 {
     hpx::naming::id_type const here = hpx::find_here();
     hpx::naming::address addr(hpx::get_locality(),
-        hpx::components::component_invalid,
-        reinterpret_cast<std::uint64_t>(&test_function2));
+        hpx::components::component_invalid, (void*) &test_function2);
 
     // compose archive flags
     std::uint32_t out_archive_flags = 0U;
@@ -337,8 +332,7 @@ void test_zero_copy_serialization(
 {
     hpx::naming::id_type const here = hpx::find_here();
     hpx::naming::address addr(hpx::get_locality(),
-        hpx::components::component_invalid,
-        reinterpret_cast<std::uint64_t>(&test_function2));
+        hpx::components::component_invalid, (void*) &test_function2);
 
     // compose archive flags
     std::uint32_t out_archive_flags = 0U;

--- a/libs/full/actions_base/include/hpx/actions_base/action_priority.hpp
+++ b/libs/full/actions_base/include/hpx/actions_base/action_priority.hpp
@@ -14,16 +14,11 @@
 namespace hpx { namespace actions {
 
     template <typename Action>
-    threads::thread_priority action_priority()
+    constexpr threads::thread_priority action_priority() noexcept
     {
-        typedef typename hpx::traits::extract_action<Action>::type action_type_;
-        threads::thread_priority priority =
-            static_cast<threads::thread_priority>(
-                traits::action_priority<action_type_>::value);
         //  The mapping to 'normal' is now done at the last possible moment in
         //  the scheduler.
-        //  if (priority == threads::thread_priority::default_)
-        //      priority = threads::thread_priority::normal;
-        return priority;
+        using action_type = typename hpx::traits::extract_action<Action>::type;
+        return hpx::traits::action_priority_v<action_type>;
     }
 }}    // namespace hpx::actions

--- a/libs/full/actions_base/include/hpx/actions_base/actions_base_fwd.hpp
+++ b/libs/full/actions_base/include/hpx/actions_base/actions_base_fwd.hpp
@@ -1,4 +1,5 @@
 //  Copyright (c)      2016 Thomas Heller
+//  Copyright (c) 2007-2021 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -7,6 +8,7 @@
 #pragma once
 
 #include <hpx/config.hpp>
+#include <hpx/actions_base/basic_action_fwd.hpp>
 
 #include <cstdint>
 
@@ -15,9 +17,6 @@ namespace hpx { namespace actions {
     /// \cond NOINTERNAL
 
     ///////////////////////////////////////////////////////////////////////////
-    template <typename Component, typename Signature, typename Derived>
-    struct basic_action;
-
     /// The type of an action defines whether this action will be executed
     /// directly or by an HPX-threads
     enum class action_flavor

--- a/libs/full/actions_base/include/hpx/actions_base/actions_base_support.hpp
+++ b/libs/full/actions_base/include/hpx/actions_base/actions_base_support.hpp
@@ -38,10 +38,13 @@ namespace hpx { namespace actions { namespace detail {
     template <threads::thread_priority Priority>
     struct thread_priority
     {
-        static threads::thread_priority call(threads::thread_priority priority)
+        constexpr static threads::thread_priority call(
+            threads::thread_priority priority) noexcept
         {
             if (priority == threads::thread_priority::default_)
+            {
                 return Priority;
+            }
             return priority;
         }
     };
@@ -51,12 +54,11 @@ namespace hpx { namespace actions { namespace detail {
     template <>
     struct thread_priority<threads::thread_priority::default_>
     {
-        static threads::thread_priority call(threads::thread_priority priority)
+        constexpr static threads::thread_priority call(
+            threads::thread_priority priority) noexcept
         {
             // The mapping to 'normal' is now done at the last possible
             // moment in the scheduler.
-            //    if (priority == threads::thread_priority::default_)
-            //        return threads::thread_priority::normal;
             return priority;
         }
     };
@@ -68,11 +70,13 @@ namespace hpx { namespace actions { namespace detail {
     template <threads::thread_stacksize Stacksize>
     struct thread_stacksize
     {
-        static threads::thread_stacksize call(
-            threads::thread_stacksize stacksize)
+        constexpr static threads::thread_stacksize call(
+            threads::thread_stacksize stacksize) noexcept
         {
             if (stacksize == threads::thread_stacksize::default_)
+            {
                 return Stacksize;
+            }
             return stacksize;
         }
     };
@@ -82,11 +86,9 @@ namespace hpx { namespace actions { namespace detail {
     template <>
     struct thread_stacksize<threads::thread_stacksize::default_>
     {
-        static threads::thread_stacksize call(
-            threads::thread_stacksize stacksize)
+        constexpr static threads::thread_stacksize call(
+            threads::thread_stacksize stacksize) noexcept
         {
-            if (stacksize == threads::thread_stacksize::default_)
-                return threads::thread_stacksize::minimal;
             return stacksize;
         }
     };

--- a/libs/full/actions_base/include/hpx/actions_base/basic_action_fwd.hpp
+++ b/libs/full/actions_base/include/hpx/actions_base/basic_action_fwd.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2016 Hartmut Kaiser
+//  Copyright (c) 2007-2021 Hartmut Kaiser
 //  Copyright (c)      2011 Bryce Lelbach
 //  Copyright (c)      2011 Thomas Heller
 //
@@ -8,14 +8,7 @@
 
 #pragma once
 
-#include <hpx/config.hpp>
 #include <hpx/actions_base/preassigned_action_id.hpp>
-#include <hpx/functional/traits/get_action_name.hpp>
-
-#if defined(HPX_HAVE_NETWORKING) &&                                            \
-    (HPX_HAVE_ITTNOTIFY != 0 && !defined(HPX_HAVE_APEX))
-#include <hpx/modules/itt_notify.hpp>
-#endif
 
 namespace hpx { namespace actions {
 

--- a/libs/full/actions_base/include/hpx/actions_base/component_action.hpp
+++ b/libs/full/actions_base/include/hpx/actions_base/component_action.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2016 Hartmut Kaiser
+//  Copyright (c) 2007-2021 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -45,29 +45,30 @@ namespace hpx { namespace actions {
 
         ///////////////////////////////////////////////////////////////////////
         template <typename Component, typename R, typename F, typename... Ts>
-        R component_invoke(std::false_type, naming::address_type lva,
+        R component_invoke(naming::address_type lva,
             naming::component_type /*comptype*/, F Component::*f, Ts&&... vs)
         {
             Component* component = get_lva<Component>::call(lva);
-            return (component->*f)(HPX_FORWARD(Ts, vs)...);
-        }
+            if constexpr (traits::is_future_v<R> || traits::is_client_v<R>)
+            {
+                // additional pinning is required such that the object becomes
+                // unpinned only after the returned future has become ready
+                components::pinned_ptr p =
+                    components::pinned_ptr::create<Component>(lva);
 
-        template <typename Component, typename R, typename F, typename... Ts>
-        R component_invoke(std::true_type, naming::address_type lva,
-            naming::component_type /* comptype */, F Component::*f, Ts&&... vs)
-        {
-            // additional pinning is required such that the object becomes
-            // unpinned only after the returned future has become ready
-            components::pinned_ptr p =
-                components::pinned_ptr::create<Component>(lva);
+                R result = (component->*f)(HPX_FORWARD(Ts, vs)...);
 
-            Component* component = get_lva<Component>::call(lva);
-            R result = (component->*f)(HPX_FORWARD(Ts, vs)...);
-
-            traits::detail::get_shared_state(result)->set_on_completed(
-                [p = HPX_MOVE(p)]() {});
-
-            return result;
+                if (!result.is_ready())
+                {
+                    traits::detail::get_shared_state(result)->set_on_completed(
+                        [p = HPX_MOVE(p)]() {});
+                }
+                return result;
+            }
+            else
+            {
+                return (component->*f)(HPX_FORWARD(Ts, vs)...);
+            }
         }
     }    // namespace detail
 
@@ -79,12 +80,11 @@ namespace hpx { namespace actions {
         R (Component::*F)(Ps...), typename Derived>
     struct action<R (Component::*)(Ps...), F, Derived>
       : public basic_action<Component, R(Ps...),
-            typename detail::action_type<
-                action<R (Component::*)(Ps...), F, Derived>, Derived>::type>
+            detail::action_type_t<action<R (Component::*)(Ps...), F, Derived>,
+                Derived>>
     {
     public:
-        typedef
-            typename detail::action_type<action, Derived>::type derived_type;
+        using derived_type = detail::action_type_t<action, Derived>;
 
         static std::string get_action_name(naming::address_type lva)
         {
@@ -100,9 +100,8 @@ namespace hpx { namespace actions {
             basic_action<Component, R(Ps...),
                 derived_type>::increment_invocation_count();
 
-            using is_future = typename traits::is_future<R>::type;
             return detail::component_invoke<Component, R>(
-                is_future{}, lva, comptype, F, HPX_FORWARD(Ts, vs)...);
+                lva, comptype, F, HPX_FORWARD(Ts, vs)...);
         }
     };
 
@@ -114,13 +113,11 @@ namespace hpx { namespace actions {
         R (Component::*F)(Ps...) const, typename Derived>
     struct action<R (Component::*)(Ps...) const, F, Derived>
       : public basic_action<Component const, R(Ps...),
-            typename detail::action_type<
-                action<R (Component::*)(Ps...) const, F, Derived>,
-                Derived>::type>
+            detail::action_type_t<
+                action<R (Component::*)(Ps...) const, F, Derived>, Derived>>
     {
     public:
-        typedef
-            typename detail::action_type<action, Derived>::type derived_type;
+        using derived_type = detail::action_type_t<action, Derived>;
 
         static std::string get_action_name(naming::address_type lva)
         {
@@ -136,13 +133,8 @@ namespace hpx { namespace actions {
             basic_action<Component const, R(Ps...),
                 derived_type>::increment_invocation_count();
 
-            using is_future_or_client = typename std::integral_constant<bool,
-                traits::is_future<R>::value ||
-                    traits::is_client<R>::value>::type;
-
             return detail::component_invoke<Component const, R>(
-                is_future_or_client{}, lva, comptype, F,
-                HPX_FORWARD(Ts, vs)...);
+                lva, comptype, F, HPX_FORWARD(Ts, vs)...);
         }
     };
 
@@ -154,13 +146,11 @@ namespace hpx { namespace actions {
         R (Component::*F)(Ps...) noexcept, typename Derived>
     struct action<R (Component::*)(Ps...) noexcept, F, Derived>
       : public basic_action<Component, R(Ps...),
-            typename detail::action_type<
-                action<R (Component::*)(Ps...) noexcept, F, Derived>,
-                Derived>::type>
+            detail::action_type_t<
+                action<R (Component::*)(Ps...) noexcept, F, Derived>, Derived>>
     {
     public:
-        typedef
-            typename detail::action_type<action, Derived>::type derived_type;
+        using derived_type = detail::action_type_t<action, Derived>;
 
         static std::string get_action_name(naming::address_type lva)
         {
@@ -176,27 +166,24 @@ namespace hpx { namespace actions {
             basic_action<Component, R(Ps...),
                 derived_type>::increment_invocation_count();
 
-            using is_future = typename traits::is_future<R>::type;
             return detail::component_invoke<Component, R>(
-                is_future{}, lva, comptype, F, HPX_FORWARD(Ts, vs)...);
+                lva, comptype, F, HPX_FORWARD(Ts, vs)...);
         }
     };
 
     ///////////////////////////////////////////////////////////////////////////
     //  Specialized generic const noexcept component action types allowing to
     //  hold a different number of arguments
-    ///////////////////////////////////////////////////////////////////////////
     template <typename Component, typename R, typename... Ps,
         R (Component::*F)(Ps...) const noexcept, typename Derived>
     struct action<R (Component::*)(Ps...) const noexcept, F, Derived>
       : public basic_action<Component const, R(Ps...),
-            typename detail::action_type<
+            detail::action_type_t<
                 action<R (Component::*)(Ps...) const noexcept, F, Derived>,
-                Derived>::type>
+                Derived>>
     {
     public:
-        typedef
-            typename detail::action_type<action, Derived>::type derived_type;
+        using derived_type = detail::action_type_t<action, Derived>;
 
         static std::string get_action_name(naming::address_type lva)
         {
@@ -212,13 +199,8 @@ namespace hpx { namespace actions {
             basic_action<Component const, R(Ps...),
                 derived_type>::increment_invocation_count();
 
-            using is_future_or_client = typename std::integral_constant<bool,
-                traits::is_future<R>::value ||
-                    traits::is_client<R>::value>::type;
-
             return detail::component_invoke<Component const, R>(
-                is_future_or_client{}, lva, comptype, F,
-                HPX_FORWARD(Ts, vs)...);
+                lva, comptype, F, HPX_FORWARD(Ts, vs)...);
         }
     };
 
@@ -295,8 +277,8 @@ namespace hpx { namespace actions {
 
 #define HPX_DEFINE_COMPONENT_ACTION_3(component, func, name)                   \
     struct name                                                                \
-      : hpx::actions::make_action<decltype(&component::func),                  \
-            &component::func, name>::type                                      \
+      : hpx::actions::make_action_t<decltype(&component::func),                \
+            &component::func, name>                                            \
     {                                                                          \
     } /**/
 #define HPX_DEFINE_COMPONENT_ACTION_2(component, func)                         \
@@ -316,8 +298,8 @@ namespace hpx { namespace actions {
 
 #define HPX_DEFINE_COMPONENT_DIRECT_ACTION_3(component, func, name)            \
     struct name                                                                \
-      : hpx::actions::make_direct_action<decltype(&component::func),           \
-            &component::func, name>::type                                      \
+      : hpx::actions::make_direct_action_t<decltype(&component::func),         \
+            &component::func, name>                                            \
     {                                                                          \
     } /**/
 

--- a/libs/full/actions_base/include/hpx/actions_base/lambda_to_action.hpp
+++ b/libs/full/actions_base/include/hpx/actions_base/lambda_to_action.hpp
@@ -29,9 +29,8 @@ namespace hpx { namespace actions {
 
         struct addr_add
         {
-            template <class T>
-            friend typename std::remove_reference<T>::type* operator+(
-                addr_add, T&& t)
+            template <typename T>
+            friend std::remove_reference_t<T>* operator+(addr_add, T&& t)
             {
                 return &t;
             }
@@ -75,31 +74,35 @@ namespace hpx { namespace actions {
             using type = lambda_action<F, ReturnType, Args...>;
         };
 
+        template <typename F, typename T>
+        using extract_lambda_action_t =
+            typename extract_lambda_action<F, T>::type;
+
         template <typename F>
         struct action_from_lambda
         {
-            using type = typename extract_lambda_action<F,
-                decltype(&F::operator())>::type;
+            using type = extract_lambda_action_t<F, decltype(&F::operator())>;
         };
+
+        template <typename F>
+        using action_from_lambda_t = typename action_from_lambda<F>::type;
 
         struct action_maker
         {
             template <typename F>
-            constexpr typename hpx::actions::detail::action_from_lambda<F>::type
-            operator+=(F*) const
+            constexpr action_from_lambda_t<F> operator+=(F*) const noexcept
             {
-                static_assert(std::is_empty<F>::value,
+                static_assert(std::is_empty_v<F>,
                     "lambda_to_action() needs and only needs a lambda with "
                     "empty capture list");
 
-                return typename hpx::actions::detail::action_from_lambda<
-                    F>::type();
+                return action_from_lambda_t<F>();
             }
         };
     }    // namespace detail
 
     template <typename F>
-    auto lambda_to_action(F&& f)
+    constexpr auto lambda_to_action(F&& f) noexcept
         -> decltype(hpx::actions::detail::action_maker() +=
             true ? nullptr : hpx::actions::detail::addr_add() + f)
     {

--- a/libs/full/actions_base/include/hpx/actions_base/plain_action.hpp
+++ b/libs/full/actions_base/include/hpx/actions_base/plain_action.hpp
@@ -42,7 +42,7 @@ namespace hpx { namespace actions {
         struct plain_function
         {
             // Only localities are valid targets for a plain action
-            static bool is_target_valid(naming::id_type const& id)
+            static bool is_target_valid(naming::id_type const& id) noexcept
             {
                 return naming::is_locality(id);
             }
@@ -62,12 +62,10 @@ namespace hpx { namespace actions {
     template <typename R, typename... Ps, R (*F)(Ps...), typename Derived>
     struct action<R (*)(Ps...), F, Derived>
       : public basic_action<detail::plain_function, R(Ps...),
-            typename detail::action_type<action<R (*)(Ps...), F, Derived>,
-                Derived>::type>
+            detail::action_type_t<action<R (*)(Ps...), F, Derived>, Derived>>
     {
     public:
-        typedef
-            typename detail::action_type<action, Derived>::type derived_type;
+        using derived_type = detail::action_type_t<action, Derived>;
 
         static std::string get_action_name(
             naming::address::address_type /*lva*/)
@@ -82,6 +80,7 @@ namespace hpx { namespace actions {
         {
             basic_action<detail::plain_function, R(Ps...),
                 derived_type>::increment_invocation_count();
+
             return F(HPX_FORWARD(Ts, vs)...);
         }
     };
@@ -90,12 +89,11 @@ namespace hpx { namespace actions {
         typename Derived>
     struct action<R (*)(Ps...) noexcept, F, Derived>
       : public basic_action<detail::plain_function, R(Ps...),
-            typename detail::action_type<
-                action<R (*)(Ps...) noexcept, F, Derived>, Derived>::type>
+            detail::action_type_t<action<R (*)(Ps...) noexcept, F, Derived>,
+                Derived>>
     {
     public:
-        typedef
-            typename detail::action_type<action, Derived>::type derived_type;
+        using derived_type = detail::action_type_t<action, Derived>;
 
         static std::string get_action_name(
             naming::address::address_type /*lva*/)
@@ -110,6 +108,7 @@ namespace hpx { namespace actions {
         {
             basic_action<detail::plain_function, R(Ps...),
                 derived_type>::increment_invocation_count();
+
             return F(HPX_FORWARD(Ts, vs)...);
         }
     };
@@ -202,8 +201,7 @@ namespace hpx { namespace traits {
     } /**/
 #else
 #define HPX_DEFINE_PLAIN_ACTION_2(func, name)                                  \
-    struct name                                                                \
-      : hpx::actions::make_action<decltype(&func), &func, name>::type          \
+    struct name : hpx::actions::make_action_t<decltype(&func), &func, name>    \
     {                                                                          \
     } /**/
 #endif
@@ -214,7 +212,7 @@ namespace hpx { namespace traits {
 
 #define HPX_DEFINE_PLAIN_DIRECT_ACTION_2(func, name)                           \
     struct name                                                                \
-      : hpx::actions::make_direct_action<decltype(&func), &func, name>::type   \
+      : hpx::actions::make_direct_action_t<decltype(&func), &func, name>       \
     {                                                                          \
     } /**/
 

--- a/libs/full/actions_base/include/hpx/actions_base/traits/action_continuation.hpp
+++ b/libs/full/actions_base/include/hpx/actions_base/traits/action_continuation.hpp
@@ -23,4 +23,7 @@ namespace hpx { namespace traits {
             hpx::actions::typed_continuation<typename Action::local_result_type,
                 typename Action::remote_result_type>;
     };
+
+    template <typename Action>
+    using action_continuation_t = typename action_continuation<Action>::type;
 }}    // namespace hpx::traits

--- a/libs/full/actions_base/include/hpx/actions_base/traits/action_priority.hpp
+++ b/libs/full/actions_base/include/hpx/actions_base/traits/action_priority.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2020 Hartmut Kaiser
+//  Copyright (c) 2007-2021 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <hpx/config.hpp>
 #include <hpx/coroutines/thread_enums.hpp>
 
 namespace hpx { namespace traits {
@@ -18,4 +19,8 @@ namespace hpx { namespace traits {
         static constexpr threads::thread_priority value =
             threads::thread_priority::default_;
     };
+
+    template <typename Action>
+    inline constexpr threads::thread_priority action_priority_v =
+        action_priority<Action>::value;
 }}    // namespace hpx::traits

--- a/libs/full/actions_base/include/hpx/actions_base/traits/action_remote_result.hpp
+++ b/libs/full/actions_base/include/hpx/actions_base/traits/action_remote_result.hpp
@@ -34,4 +34,7 @@ namespace hpx { namespace traits {
       : detail::action_remote_result_customization_point<Result>
     {
     };
+
+    template <typename Result>
+    using action_remote_result_t = typename action_remote_result<Result>::type;
 }}    // namespace hpx::traits

--- a/libs/full/actions_base/include/hpx/actions_base/traits/action_stacksize.hpp
+++ b/libs/full/actions_base/include/hpx/actions_base/traits/action_stacksize.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2020 Hartmut Kaiser
+//  Copyright (c) 2007-2021 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <hpx/config.hpp>
 #include <hpx/coroutines/thread_enums.hpp>
 
 namespace hpx { namespace traits {
@@ -18,4 +19,8 @@ namespace hpx { namespace traits {
         static constexpr threads::thread_stacksize value =
             threads::thread_stacksize::default_;
     };
+
+    template <typename Action>
+    inline constexpr threads::thread_stacksize action_stacksize_v =
+        action_stacksize<Action>::value;
 }}    // namespace hpx::traits

--- a/libs/full/actions_base/include/hpx/actions_base/traits/is_continuation.hpp
+++ b/libs/full/actions_base/include/hpx/actions_base/traits/is_continuation.hpp
@@ -1,4 +1,5 @@
 //  Copyright (c) 2015 Thomas Heller
+//  Copyright (c) 2021 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -33,4 +34,8 @@ namespace hpx { namespace traits {
       : detail::is_continuation_impl<typename std::decay<Continuation>::type>
     {
     };
+
+    template <typename Continuation>
+    inline constexpr bool is_continuation_v =
+        is_continuation<Continuation>::value;
 }}    // namespace hpx::traits

--- a/libs/full/actions_base/include/hpx/actions_base/traits/is_distribution_policy.hpp
+++ b/libs/full/actions_base/include/hpx/actions_base/traits/is_distribution_policy.hpp
@@ -19,6 +19,10 @@ namespace hpx { namespace traits {
     {
     };
 
+    template <typename T>
+    inline constexpr bool is_distribution_policy_v =
+        is_distribution_policy<T>::value;
+
     // By default the number of partitions is the same as the number of
     // localities represented by the given distribution policy
     template <typename Policy, typename Enable = void>

--- a/libs/full/actions_base/include/hpx/actions_base/traits/is_valid_action.hpp
+++ b/libs/full/actions_base/include/hpx/actions_base/traits/is_valid_action.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2020 Hartmut Kaiser
+//  Copyright (c) 2007-2021 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -14,8 +14,8 @@ namespace hpx { namespace traits {
     // verify that given Action is actually supported by the given Component
     template <typename Action, typename Component, typename Enable = void>
     struct is_valid_action
-      : std::is_same<typename std::decay<typename Action::component_type>::type,
-            typename std::decay<Component>::type>
+      : std::is_same<std::decay_t<typename Action::component_type>,
+            std::decay_t<Component>>
     {
     };
 }}    // namespace hpx::traits

--- a/libs/full/agas/src/addressing_service.cpp
+++ b/libs/full/agas/src/addressing_service.cpp
@@ -796,7 +796,8 @@ namespace hpx { namespace agas {
                 HPX_ASSERT(rts_lva_);
 
                 addr.type_ = components::component_runtime_support;
-                addr.address_ = rts_lva_;
+                addr.address_ =
+                    reinterpret_cast<naming::address::address_type>(rts_lva_);
                 return true;
             }
 
@@ -804,7 +805,8 @@ namespace hpx { namespace agas {
             {
                 // handle (non-migratable) components located on this locality first
                 addr.type_ = naming::detail::get_component_type_from_gid(msb);
-                addr.address_ = lsb;
+                addr.address_ =
+                    reinterpret_cast<naming::address::address_type>(lsb);
                 return true;
             }
         }

--- a/libs/full/agas_base/CMakeLists.txt
+++ b/libs/full/agas_base/CMakeLists.txt
@@ -47,6 +47,7 @@ set(agas_base_sources
     detail/bootstrap_locality_namespace.cpp
     detail/hosted_component_namespace.cpp
     detail/hosted_locality_namespace.cpp
+    gva.cpp
     locality_namespace.cpp
     primary_namespace.cpp
     server/component_namespace_server.cpp

--- a/libs/full/agas_base/include/hpx/agas_base/detail/bootstrap_component_namespace.hpp
+++ b/libs/full/agas_base/include/hpx/agas_base/detail/bootstrap_component_namespace.hpp
@@ -28,7 +28,7 @@ namespace hpx { namespace agas { namespace detail {
 
         naming::address::address_type ptr() const
         {
-            return reinterpret_cast<naming::address::address_type>(&server_);
+            return const_cast<server::component_namespace*>(&server_);
         }
         naming::address addr() const;
         naming::id_type gid() const;
@@ -48,8 +48,6 @@ namespace hpx { namespace agas { namespace detail {
 
         hpx::future<std::uint32_t> get_num_localities(
             components::component_type type);
-
-        void register_counter_types();
 
         void register_server_instance(std::uint32_t locality_id);
 

--- a/libs/full/agas_base/include/hpx/agas_base/detail/bootstrap_locality_namespace.hpp
+++ b/libs/full/agas_base/include/hpx/agas_base/detail/bootstrap_locality_namespace.hpp
@@ -31,7 +31,7 @@ namespace hpx { namespace agas { namespace detail {
 
         naming::address::address_type ptr() const override
         {
-            return reinterpret_cast<naming::address::address_type>(&server_);
+            return const_cast<server::locality_namespace*>(&server_);
         }
         naming::address addr() const override;
         naming::id_type gid() const override;

--- a/libs/full/agas_base/include/hpx/agas_base/gva.hpp
+++ b/libs/full/agas_base/include/hpx/agas_base/gva.hpp
@@ -14,28 +14,23 @@
 #include <hpx/modules/errors.hpp>
 #include <hpx/modules/naming.hpp>
 #include <hpx/naming_base/gid_type.hpp>
-#include <hpx/util/ios_flags_saver.hpp>
 
 #include <cstdint>
+#include <iosfwd>
 
 namespace hpx { namespace agas {
 
     struct gva
     {
         using component_type = std::int32_t;
-        using lva_type = std::uint64_t;
+        using lva_type = void*;
 
-        gva()
-          : type(components::component_invalid)
-          , count(0)
-          , lva_(0)
-          , offset(0)
-        {
-        }
+        constexpr gva() noexcept = default;
 
-        explicit gva(naming::gid_type const& p,
+        constexpr explicit gva(naming::gid_type const& p,
             component_type t = components::component_invalid,
-            std::uint64_t c = 1, lva_type a = 0, std::uint64_t o = 0)
+            std::uint64_t c = 1, lva_type a = nullptr,
+            std::uint64_t o = 0) noexcept
           : prefix(p)
           , type(t)
           , count(c)
@@ -44,29 +39,19 @@ namespace hpx { namespace agas {
         {
         }
 
-        gva(naming::gid_type const& p, component_type t, std::uint64_t c,
-            void* a, std::uint64_t o = 0)
+        explicit gva(naming::gid_type const& p, component_type t,
+            std::uint64_t c, std::uint64_t l, std::uint64_t o = 0) noexcept
           : prefix(p)
           , type(t)
           , count(c)
-          , lva_(reinterpret_cast<lva_type>(a))
+          , lva_(reinterpret_cast<lva_type>(l))
           , offset(o)
         {
         }
 
-        explicit gva(lva_type a)
+        constexpr explicit gva(lva_type a) noexcept
           : type(components::component_invalid)
-          , count(0)
           , lva_(a)
-          , offset(0)
-        {
-        }
-
-        explicit gva(void* a)
-          : type(components::component_invalid)
-          , count(0)
-          , lva_(reinterpret_cast<lva_type>(a))
-          , offset(0)
         {
         }
 
@@ -80,48 +65,32 @@ namespace hpx { namespace agas {
             return *this;
         }
 
-        gva& operator=(void* a)
-        {
-            prefix = naming::gid_type();
-            type = components::component_invalid;
-            count = 0;
-            lva_ = reinterpret_cast<lva_type>(a);
-            offset = 0;
-            return *this;
-        }
-
-        bool operator==(gva const& rhs) const
+        constexpr bool operator==(gva const& rhs) const noexcept
         {
             return type == rhs.type && count == rhs.count && lva_ == rhs.lva_ &&
                 offset == rhs.offset && prefix == rhs.prefix;
         }
 
-        bool operator!=(gva const& rhs) const
+        constexpr bool operator!=(gva const& rhs) const noexcept
         {
             return !(*this == rhs);
         }
 
-        void lva(lva_type a)
+        void lva(lva_type a) noexcept
         {
             lva_ = a;
         }
 
-        void lva(void* a)
-        {
-            lva_ = reinterpret_cast<lva_type>(a);
-        }
-
-        lva_type lva() const
+        constexpr lva_type lva() const noexcept
         {
             return lva_;
         }
 
-        lva_type lva(
-            naming::gid_type const& gid, naming::gid_type const& gidbase) const
+        lva_type lva(naming::gid_type const& gid,
+            naming::gid_type const& gidbase) const noexcept
         {
-            lva_type l = lva_;
-            l += (gid.get_lsb() - gidbase.get_lsb()) * offset;
-            return l;
+            return static_cast<char*>(lva_) +
+                (gid.get_lsb() - gidbase.get_lsb()) * offset;
         }
 
         gva resolve(
@@ -138,46 +107,26 @@ namespace hpx { namespace agas {
         }
 
         naming::gid_type prefix;
-        component_type type;
-        std::uint64_t count;
+        component_type type = components::component_invalid;
+        std::uint64_t count = 0;
 
     private:
-        lva_type lva_;
+        lva_type lva_ = nullptr;
 
     public:
-        std::uint64_t offset;
+        std::uint64_t offset = 0;
 
     private:
         friend class hpx::serialization::access;
 
-        template <class Archive>
-        void save(Archive& ar, const unsigned int /*version*/) const
-        {
-            ar << prefix << type << count << lva_ << offset;
-        }    //-V128
+        template <typename Archive>
+        HPX_EXPORT void save(Archive& ar, const unsigned int /*version*/) const;
 
-        template <class Archive>
-        void load(Archive& ar, const unsigned int version)
-        {
-            if (version > HPX_AGAS_VERSION)
-                HPX_THROW_EXCEPTION(version_too_new, "gva::load",
-                    "trying to load GVA with unknown version");
-            ar >> prefix >> type >> count >> lva_ >> offset;    //-V128
-        }
+        template <typename Archive>
+        HPX_EXPORT void load(Archive& ar, const unsigned int version);
 
         HPX_SERIALIZATION_SPLIT_MEMBER()
     };
 
-    template <typename Char, typename Traits>
-    inline std::basic_ostream<Char, Traits>& operator<<(
-        std::basic_ostream<Char, Traits>& os, gva const& addr)
-    {
-        hpx::util::ios_flags_saver ifs(os);
-        os << "(" << addr.prefix << " "
-           << components::get_component_type_name(addr.type) << " "
-           << addr.count << " " << std::showbase << std::hex << addr.lva()
-           << " " << addr.offset << ")";
-        return os;
-    }
-
+    HPX_EXPORT std::ostream& operator<<(std::ostream& os, gva const& addr);
 }}    // namespace hpx::agas

--- a/libs/full/agas_base/src/gva.cpp
+++ b/libs/full/agas_base/src/gva.cpp
@@ -1,0 +1,57 @@
+//  Copyright (c) 2020-2021 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/config.hpp>
+#include <hpx/agas_base/gva.hpp>
+#include <hpx/serialization/input_archive.hpp>
+#include <hpx/serialization/output_archive.hpp>
+#include <hpx/serialization/serialize.hpp>
+#include <hpx/util/ios_flags_saver.hpp>
+
+#include <cstddef>
+#include <ostream>
+
+namespace hpx::agas {
+
+    ///////////////////////////////////////////////////////////////////////////
+    template <typename Archive>
+    void gva::save(Archive& ar, const unsigned int /*version*/) const
+    {
+        std::size_t lva = reinterpret_cast<std::size_t>(lva_);
+        ar << prefix << type << count << lva << offset;
+    }    //-V128
+
+    template <typename Archive>
+    void gva::load(Archive& ar, const unsigned int version)
+    {
+        if (version > HPX_AGAS_VERSION)
+        {
+            HPX_THROW_EXCEPTION(version_too_new, "gva::load",
+                "trying to load GVA with unknown version");
+        }
+
+        std::size_t lva;
+        ar >> prefix >> type >> count >> lva >> offset;    //-V128
+        lva_ = reinterpret_cast<lva_type>(lva);
+    }
+
+    template void gva::save(
+        hpx::serialization::output_archive& ar, const unsigned int) const;
+
+    template void gva::load(
+        hpx::serialization::input_archive& ar, const unsigned int);
+
+    ///////////////////////////////////////////////////////////////////////////
+    std::ostream& operator<<(std::ostream& os, gva const& addr)
+    {
+        hpx::util::ios_flags_saver ifs(os);
+        os << "(" << addr.prefix << " "
+           << components::get_component_type_name(addr.type) << " "
+           << addr.count << " " << std::showbase << std::hex << addr.lva()
+           << " " << addr.offset << ")";
+        return os;
+    }
+}    // namespace hpx::agas

--- a/libs/full/agas_base/src/server/primary_namespace_server.cpp
+++ b/libs/full/agas_base/src/server/primary_namespace_server.cpp
@@ -631,7 +631,7 @@ namespace hpx { namespace agas { namespace server {
             }
 
             // Otherwise, correct
-            lower = naming::gid_type(upper.get_msb(), 0);
+            lower = naming::gid_type(upper.get_msb(), nullptr);
             upper = lower + real_count;
         }
 

--- a/libs/full/async_colocated/include/hpx/async_colocated/async_colocated_fwd.hpp
+++ b/libs/full/async_colocated/include/hpx/async_colocated/async_colocated_fwd.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2015 Hartmut Kaiser
+//  Copyright (c) 2007-2021 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -20,36 +20,33 @@
 namespace hpx { namespace detail {
     ///////////////////////////////////////////////////////////////////////////
     template <typename Action, typename... Ts>
-    hpx::future<typename traits::promise_local_result<
-        typename hpx::traits::extract_action<Action>::remote_result_type>::type>
+    hpx::future<traits::promise_local_result_t<
+        typename hpx::traits::extract_action<Action>::remote_result_type>>
     async_colocated(naming::id_type const& id, Ts&&... vs);
 
     template <typename Component, typename Signature, typename Derived,
         typename... Ts>
-    hpx::future<typename traits::promise_local_result<typename hpx::traits::
-            extract_action<Derived>::remote_result_type>::type>
-    async_colocated(
-        hpx::actions::basic_action<Component, Signature, Derived> /*act*/
-        ,
+    hpx::future<traits::promise_local_result_t<
+        typename hpx::traits::extract_action<Derived>::remote_result_type>>
+    async_colocated(hpx::actions::basic_action<Component, Signature, Derived>,
         naming::id_type const& id, Ts&&... vs);
 
     ///////////////////////////////////////////////////////////////////////////
     // MSVC complains about ambiguities if it sees this forward declaration
 #if !defined(HPX_MSVC)
     template <typename Action, typename Continuation, typename... Ts>
-    typename std::enable_if<traits::is_continuation<Continuation>::value,
-        hpx::future<typename traits::promise_local_result<typename hpx::traits::
-                extract_action<Action>::remote_result_type>::type>>::type
+    std::enable_if_t<traits::is_continuation_v<Continuation>,
+        hpx::future<traits::promise_local_result_t<
+            typename hpx::traits::extract_action<Action>::remote_result_type>>>
     async_colocated(Continuation&& cont, naming::id_type const& id, Ts&&... vs);
 
     template <typename Continuation, typename Component, typename Signature,
         typename Derived, typename... Ts>
-    typename std::enable_if<traits::is_continuation<Continuation>::value,
-        hpx::future<typename traits::promise_local_result<typename hpx::traits::
-                extract_action<Derived>::remote_result_type>::type>>::type
+    std::enable_if_t<traits::is_continuation_v<Continuation>,
+        hpx::future<traits::promise_local_result_t<
+            typename hpx::traits::extract_action<Derived>::remote_result_type>>>
     async_colocated(Continuation&& cont,
-        hpx::actions::basic_action<Component, Signature, Derived> /*act*/
-        ,
+        hpx::actions::basic_action<Component, Signature, Derived>,
         naming::id_type const& id, Ts&&... vs);
 #endif
 }}    // namespace hpx::detail

--- a/libs/full/async_distributed/include/hpx/async_distributed/base_lco.hpp
+++ b/libs/full/async_distributed/include/hpx/async_distributed/base_lco.hpp
@@ -120,24 +120,26 @@ namespace hpx { namespace lcos {
 
 ///////////////////////////////////////////////////////////////////////////////
 namespace hpx {
+
     template <>
     struct get_lva<lcos::base_lco>
     {
-        static lcos::base_lco* call(naming::address_type lva)
+        constexpr static lcos::base_lco* call(naming::address_type lva) noexcept
         {
-            typedef typename lcos::base_lco::wrapping_type wrapping_type;
-            return reinterpret_cast<wrapping_type*>(lva)->get_checked();
+            using wrapping_type = typename lcos::base_lco::wrapping_type;
+            return static_cast<wrapping_type*>(lva)->get();
         }
     };
 
     template <>
     struct get_lva<lcos::base_lco const>
     {
-        static lcos::base_lco const* call(naming::address_type lva)
+        constexpr static lcos::base_lco const* call(
+            naming::address_type lva) noexcept
         {
-            typedef typename std::add_const<
-                typename lcos::base_lco::wrapping_type>::type wrapping_type;
-            return reinterpret_cast<wrapping_type*>(lva)->get_checked();
+            using wrapping_type =
+                std::add_const_t<typename lcos::base_lco::wrapping_type>;
+            return static_cast<wrapping_type*>(lva)->get();
         }
     };
 }    // namespace hpx

--- a/libs/full/async_distributed/include/hpx/async_distributed/base_lco_with_value.hpp
+++ b/libs/full/async_distributed/include/hpx/async_distributed/base_lco_with_value.hpp
@@ -74,8 +74,8 @@ namespace hpx { namespace lcos {
       , public ComponentTag
     {
     protected:
-        typedef typename std::conditional<std::is_void<Result>::value,
-            util::unused_type, Result>::type result_type;
+        using result_type = std::conditional_t<std::is_void_v<Result>,
+            util::unused_type, Result>;
 
         /// Destructor, needs to be virtual to allow for clean destruction of
         /// derived objects
@@ -91,8 +91,10 @@ namespace hpx { namespace lcos {
             // this shouldn't ever be called
             HPX_THROW_EXCEPTION(invalid_status,
                 "base_lco_with_value::set_event_nonvirt",
-                "attempt to use a non-default-constructible return type with "
-                "an action in a context where default-construction would be "
+                "attempt to use a non-default-constructible return type "
+                "with "
+                "an action in a context where default-construction would "
+                "be "
                 "required");
         }
 

--- a/libs/full/async_distributed/include/hpx/async_distributed/detail/async_implementations.hpp
+++ b/libs/full/async_distributed/include/hpx/async_distributed/detail/async_implementations.hpp
@@ -168,8 +168,8 @@ namespace hpx { namespace detail {
         std::ptrdiff_t requested_stack_size =
             threads::get_stack_size(static_cast<threads::thread_stacksize>(
                 traits::action_stacksize<Action>::value));
-        return !traits::action_decorate_function<Action>::value &&
-            this_thread::get_stack_size() >= requested_stack_size &&
+        constexpr bool df = traits::action_decorate_function<Action>::value;
+        return !df && this_thread::get_stack_size() >= requested_stack_size &&
             this_thread::has_sufficient_stack_space(requested_stack_size);
     }
 

--- a/libs/full/collectives/include/hpx/collectives/detail/latch.hpp
+++ b/libs/full/collectives/include/hpx/collectives/detail/latch.hpp
@@ -50,6 +50,14 @@ namespace hpx { namespace lcos { namespace server {
         }
         static void set_component_type(components::component_type) {}
 
+        naming::address get_current_address() const
+        {
+            return naming::address(
+                naming::get_gid_from_locality_id(agas::get_locality_id()),
+                components::get_component_type<latch>(),
+                const_cast<latch*>(this));
+        }
+
     public:
         // This is the component type id. Every component type needs to have an
         // embedded enumerator 'value' which is used by the generic action

--- a/libs/full/components/include/hpx/components/client_base.hpp
+++ b/libs/full/components/include/hpx/components/client_base.hpp
@@ -255,8 +255,7 @@ namespace hpx { namespace components {
         // derived from a) stub_base.
         template <typename Stub>
         struct make_stub<Stub,
-            typename util::always_void<
-                typename Stub::server_component_type>::type>
+            util::always_void_t<typename Stub::server_component_type>>
         {
             using type = Stub;
             using server_component_type = typename Stub::server_component_type;

--- a/libs/full/components/include/hpx/components/executor_component.hpp
+++ b/libs/full/components/include/hpx/components/executor_component.hpp
@@ -28,9 +28,9 @@ namespace hpx { namespace components {
     struct executor_component : BaseComponent
     {
     private:
-        typedef BaseComponent base_type;
-        typedef Executor executor_type;
-        typedef typename base_type::this_component_type this_component_type;
+        using base_type = BaseComponent;
+        using executor_type = Executor;
+        using this_component_type = typename base_type::this_component_type;
 
     public:
         template <typename... Arg>

--- a/libs/full/components_base/include/hpx/components_base/component_type.hpp
+++ b/libs/full/components_base/include/hpx/components_base/component_type.hpp
@@ -127,18 +127,24 @@ namespace hpx { namespace components {
     {
         // don't compare types if one of them is unknown
         if (component_invalid == rhs || component_invalid == lhs)
+        {
             return true;    // no way of telling, so we assume the best :-P
+        }
 
         // don't compare types if one of them is component_runtime_support
         if (component_runtime_support == rhs ||
             component_runtime_support == lhs)
+        {
             return true;
+        }
 
         component_type lhs_base = get_base_type(lhs);
         component_type rhs_base = get_base_type(rhs);
 
         if (lhs_base == rhs_base)
+        {
             return true;
+        }
 
         // special case for lco's
         if (lhs_base == component_base_lco &&

--- a/libs/full/components_base/include/hpx/components_base/components_base_fwd.hpp
+++ b/libs/full/components_base/include/hpx/components_base/components_base_fwd.hpp
@@ -59,8 +59,10 @@ namespace hpx {
         class abstract_component_base;
 
         template <typename Component>
-        using abstract_simple_component_base =
-            abstract_component_base<Component>;
+        using abstract_simple_component_base HPX_DEPRECATED_V(1, 8,
+            "The type hpx::components::abstract_simple_component_base is "
+            "deprecated. Please use hpx::components::abstract_component_base "
+            "instead.") = abstract_component_base<Component>;
 
         template <typename Component, typename Derived = detail::this_type>
         class abstract_managed_component_base;

--- a/libs/full/components_base/include/hpx/components_base/generate_unique_ids.hpp
+++ b/libs/full/components_base/include/hpx/components_base/generate_unique_ids.hpp
@@ -22,7 +22,7 @@ namespace hpx { namespace util {
     /// unique ids for components, parcels, threads etc.
     class HPX_EXPORT unique_id_ranges
     {
-        typedef hpx::util::spinlock mutex_type;
+        using mutex_type = hpx::util::spinlock;
 
         mutex_type mtx_;
 
@@ -36,8 +36,8 @@ namespace hpx { namespace util {
     public:
         unique_id_ranges()
           : mtx_()
-          , lower_(0)
-          , upper_(0)
+          , lower_(nullptr)
+          , upper_(nullptr)
         {
         }
 
@@ -47,7 +47,7 @@ namespace hpx { namespace util {
         void set_range(
             naming::gid_type const& lower, naming::gid_type const& upper)
         {
-            std::lock_guard<mutex_type> l(mtx_);
+            std::lock_guard l(mtx_);
             lower_ = lower;
             upper_ = upper;
         }

--- a/libs/full/components_base/include/hpx/components_base/server/abstract_component_base.hpp
+++ b/libs/full/components_base/include/hpx/components_base/server/abstract_component_base.hpp
@@ -37,6 +37,14 @@ namespace hpx { namespace components {
         {
             hpx::components::set_component_type<wrapping_type>(t);
         }
+
+        virtual naming::address get_current_address() const
+        {
+            return naming::address(
+                naming::get_gid_from_locality_id(agas::get_locality_id()),
+                components::get_component_type<Component>(),
+                const_cast<Component*>(static_cast<Component const*>(this)));
+        }
     };
 
     ///////////////////////////////////////////////////////////////////////////
@@ -60,6 +68,14 @@ namespace hpx { namespace components {
         {
             hpx::components::set_component_type<wrapping_type>(t);
         }
+
+        virtual naming::address get_current_address() const
+        {
+            return naming::address(
+                naming::get_gid_from_locality_id(agas::get_locality_id()),
+                components::get_component_type<Component>(),
+                const_cast<Component*>(static_cast<Component const*>(this)));
+        }
     };
 
     ///////////////////////////////////////////////////////////////////////////
@@ -82,6 +98,14 @@ namespace hpx { namespace components {
         static constexpr void set_component_type(component_type t)
         {
             hpx::components::set_component_type<wrapping_type>(t);
+        }
+
+        virtual naming::address get_current_address() const
+        {
+            return naming::address(
+                naming::get_gid_from_locality_id(agas::get_locality_id()),
+                components::get_component_type<Component>(),
+                const_cast<Component*>(static_cast<Component const*>(this)));
         }
     };
 }}    // namespace hpx::components

--- a/libs/full/components_base/include/hpx/components_base/server/abstract_migration_support.hpp
+++ b/libs/full/components_base/include/hpx/components_base/server/abstract_migration_support.hpp
@@ -96,9 +96,15 @@ namespace hpx { namespace components {
         using type_holder = Derived;
         using base_type_holder = Base;
 
-        template <typename... Ts>
-        abstract_migration_support(Ts&&... ts)
-          : abstract_base_type(HPX_FORWARD(Ts, ts)...)
+        using base_type::get_current_address;
+
+        abstract_migration_support() = default;
+
+        template <typename T, typename... Ts,
+            typename Enable = std::enable_if_t<
+                !std::is_same_v<std::decay_t<T>, abstract_migration_support>>>
+        abstract_migration_support(T&& t, Ts&&... ts)
+          : abstract_base_type(HPX_FORWARD(T, t), HPX_FORWARD(Ts, ts)...)
         {
         }
 

--- a/libs/full/components_base/include/hpx/components_base/server/component.hpp
+++ b/libs/full/components_base/include/hpx/components_base/server/component.hpp
@@ -17,6 +17,7 @@
 
 #include <cstddef>
 #include <new>
+#include <type_traits>
 #include <utility>
 
 namespace hpx { namespace components { namespace detail {
@@ -65,10 +66,14 @@ namespace hpx { namespace components {
         using derived_type = component_type;
         using heap_type = typename traits::component_heap_type<Component>::type;
 
+        constexpr component() = default;
+
         // Construct a component instance holding a new wrapped instance
-        template <typename... Ts>
-        component(Ts&&... vs)
-          : Component(HPX_FORWARD(Ts, vs)...)
+        template <typename T, typename... Ts,
+            typename Enable =
+                std::enable_if_t<!std::is_same_v<std::decay_t<T>, component>>>
+        explicit component(T&& t, Ts&&... ts)
+          : Component(HPX_FORWARD(T, t), HPX_FORWARD(Ts, ts)...)
         {
         }
     };

--- a/libs/full/components_base/include/hpx/components_base/server/component_base.hpp
+++ b/libs/full/components_base/include/hpx/components_base/server/component_base.hpp
@@ -1,4 +1,5 @@
 //  Copyright (c) 2015 Thomas Heller
+//  Copyright (c) 2007-2021 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -31,30 +32,15 @@ namespace hpx { namespace components {
 
         struct base_component : traits::detail::component_tag
         {
-            base_component() = default;
-
+            constexpr base_component() = default;
             HPX_EXPORT ~base_component();
 
-            // Copy construction and copy assignment should not copy the gid_.
-            base_component(base_component const& /*rhs*/) noexcept {}
-            base_component& operator=(base_component const& /*rhs*/) noexcept
-            {
-                return *this;
-            }
+            base_component(base_component const&) = default;
+            base_component& operator=(base_component const&) = default;
 
             // just move our gid_
-            base_component(base_component&& rhs) noexcept
-              : gid_(HPX_MOVE(rhs.gid_))
-            {
-            }
-            base_component& operator=(base_component&& rhs) noexcept
-            {
-                if (this != &rhs)
-                {
-                    gid_ = HPX_MOVE(rhs.gid_);
-                }
-                return *this;
-            }
+            base_component(base_component&& rhs) noexcept = default;
+            base_component& operator=(base_component&& rhs) noexcept = default;
 
             // finalize() will be called just before the instance gets destructed
             static constexpr void finalize() noexcept {}
@@ -63,7 +49,7 @@ namespace hpx { namespace components {
             HPX_EXPORT naming::id_type get_unmanaged_id(
                 naming::gid_type const& gid) const;
 
-            static void mark_as_migrated()
+            static void mark_as_migrated() noexcept
             {
                 // If this assertion is triggered then this component instance
                 // is being migrated even if the component type has not been
@@ -71,7 +57,7 @@ namespace hpx { namespace components {
                 HPX_ASSERT(false);
             }
 
-            static void on_migrated()
+            static void on_migrated() noexcept
             {
                 // If this assertion is triggered then this component instance
                 // is being migrated even if the component type has not been
@@ -103,9 +89,9 @@ namespace hpx { namespace components {
     class component_base : public detail::base_component
     {
     protected:
-        using this_component_type = typename std::conditional<
-            std::is_same<Component, components::detail::this_type>::value,
-            component_base, Component>::type;
+        using this_component_type = std::conditional_t<
+            std::is_same_v<Component, components::detail::this_type>,
+            component_base, Component>;
 
     public:
         using wrapped_type = this_component_type;
@@ -113,10 +99,16 @@ namespace hpx { namespace components {
         using wrapping_type = component<this_component_type>;
 
         // Construct an empty component
-        component_base() = default;
+        constexpr component_base() = default;
 
         // Destruct a component
         ~component_base() = default;
+
+        component_base(component_base const&) = default;
+        component_base(component_base&& rhs) noexcept = default;
+
+        component_base& operator=(component_base const&) = default;
+        component_base& operator=(component_base&& rhs) noexcept = default;
 
     public:
         naming::address get_current_address() const
@@ -124,7 +116,7 @@ namespace hpx { namespace components {
             return naming::address(
                 naming::get_gid_from_locality_id(agas::get_locality_id()),
                 components::get_component_type<wrapped_type>(),
-                std::uint64_t(static_cast<this_component_type const*>(this)));
+                const_cast<component_base*>(this));
         }
 
         naming::id_type get_id() const

--- a/libs/full/components_base/include/hpx/components_base/server/fixed_component_base.hpp
+++ b/libs/full/components_base/include/hpx/components_base/server/fixed_component_base.hpp
@@ -90,7 +90,8 @@ namespace hpx { namespace components {
                 naming::address addr(
                     naming::get_gid_from_locality_id(agas::get_locality_id()),
                     components::get_component_type<wrapped_type>(),
-                    std::size_t(static_cast<this_component_type const*>(this)));
+                    const_cast<this_component_type*>(
+                        static_cast<this_component_type const*>(this)));
 
                 gid_ = naming::gid_type(msb_, lsb_);
 
@@ -141,7 +142,7 @@ namespace hpx { namespace components {
             }
         }
 
-        static void mark_as_migrated()
+        static void mark_as_migrated() noexcept
         {
             // If this assertion is triggered then this component instance is being
             // migrated even if the component type has not been enabled to support
@@ -149,7 +150,7 @@ namespace hpx { namespace components {
             HPX_ASSERT(false);
         }
 
-        static void on_migrated()
+        static void on_migrated() noexcept
         {
             // If this assertion is triggered then this component instance is being
             // migrated even if the component type has not been enabled to support
@@ -168,12 +169,12 @@ namespace hpx { namespace components {
         ///////////////////////////////////////////////////////////////////////
         struct fixed_heap
         {
-            static void* alloc(std::size_t)
+            static void* alloc(std::size_t) noexcept
             {
                 HPX_ASSERT(false);    // this shouldn't ever be called
                 return nullptr;
             }
-            static void free(void*, std::size_t)
+            static void free(void*, std::size_t) noexcept
             {
                 HPX_ASSERT(false);    // this shouldn't ever be called
             }
@@ -192,7 +193,7 @@ namespace hpx { namespace components {
 
         /// \brief  The function \a create is used for allocation and
         ///         initialization of instances of the derived components.
-        static Component* create(std::size_t /* count */)
+        static Component* create(std::size_t /* count */) noexcept
         {
             HPX_ASSERT(false);    // this shouldn't ever be called
             return nullptr;
@@ -200,7 +201,8 @@ namespace hpx { namespace components {
 
         /// \brief  The function \a destroy is used for destruction and
         ///         de-allocation of instances of the derived components.
-        static void destroy(Component* /* p */, std::size_t /* count */ = 1)
+        static void destroy(
+            Component* /* p */, std::size_t /* count */ = 1) noexcept
         {
             HPX_ASSERT(false);    // this shouldn't ever be called
         }

--- a/libs/full/components_base/include/hpx/components_base/server/managed_component_base.hpp
+++ b/libs/full/components_base/include/hpx/components_base/server/managed_component_base.hpp
@@ -167,7 +167,7 @@ namespace hpx { namespace components {
             // finalize() will be called just before the instance gets destructed
             static constexpr void finalize() noexcept {}
 
-            static void mark_as_migrated()
+            static void mark_as_migrated() noexcept
             {
                 // If this assertion is triggered then this component instance is
                 // being migrated even if the component type has not been enabled
@@ -175,7 +175,7 @@ namespace hpx { namespace components {
                 HPX_ASSERT(false);
             }
 
-            static void on_migrated()
+            static void on_migrated() noexcept
             {
                 // If this assertion is triggered then this component instance is being
                 // migrated even if the component type has not been enabled to support
@@ -205,14 +205,12 @@ namespace hpx { namespace components {
 
         // make sure that we have a back_ptr whenever we need to control the
         // lifetime of the managed_component
-        static_assert((std::is_same<ctor_policy,
-                           traits::construct_without_back_ptr>::value ||
-                          std::is_same<dtor_policy,
-                              traits::managed_object_controls_lifetime>::value),
-            "std::is_same<ctor_policy, "
-            "traits::construct_without_back_ptr>::value || "
-            "std::is_same<dtor_policy, "
-            "traits::managed_object_controls_lifetime>::value");
+        static_assert(
+            (std::is_same_v<ctor_policy, traits::construct_without_back_ptr> ||
+                std::is_same_v<dtor_policy,
+                    traits::managed_object_controls_lifetime>),
+            "std::is_same_v<ctor_policy, construct_without_back_ptr> || "
+            "std::is_same_v<dtor_policy, managed_object_controls_lifetime>");
 
         constexpr managed_component_base() noexcept
           : back_ptr_(nullptr)
@@ -220,7 +218,7 @@ namespace hpx { namespace components {
         }
 
         explicit managed_component_base(
-            managed_component<Component, Wrapper>* back_ptr)
+            managed_component<Component, Wrapper>* back_ptr) noexcept
           : back_ptr_(back_ptr)
         {
             HPX_ASSERT(back_ptr);
@@ -249,7 +247,8 @@ namespace hpx { namespace components {
         template <typename>
         friend struct detail_adl_barrier::init;
 
-        void set_back_ptr(components::managed_component<Component, Wrapper>* bp)
+        void set_back_ptr(
+            components::managed_component<Component, Wrapper>* bp) noexcept
         {
             HPX_ASSERT(nullptr == back_ptr_);
             HPX_ASSERT(bp);
@@ -265,14 +264,14 @@ namespace hpx { namespace components {
     void intrusive_ptr_add_ref(managed_component<Component, Derived>* p)
     {
         detail_adl_barrier::manage_lifetime<
-            typename traits::managed_component_dtor_policy<Component>::type>::
+            traits::managed_component_dtor_policy_t<Component>>::
             addref(p->component_);
     }
     template <typename Component, typename Derived>
     void intrusive_ptr_release(managed_component<Component, Derived>* p)
     {
         detail_adl_barrier::manage_lifetime<
-            typename traits::managed_component_dtor_policy<Component>::type>::
+            traits::managed_component_dtor_policy_t<Component>>::
             release(p->component_);
     }
 
@@ -327,22 +326,31 @@ namespace hpx { namespace components {
         explicit managed_component(Component* comp)
           : component_(comp)
         {
-            detail_adl_barrier::init<
-                typename traits::managed_component_ctor_policy<
-                    Component>::type>::call(component_, this);
+            detail_adl_barrier::
+                init<traits::managed_component_ctor_policy_t<Component>>::call(
+                    component_, this);
             intrusive_ptr_add_ref(this);
         }
 
     public:
         // Construct a managed_component instance holding a new wrapped instance
-        template <typename... Ts>
-        managed_component(Ts&&... vs)
+        managed_component()
           : component_(nullptr)
         {
-            detail_adl_barrier::init<
-                typename traits::managed_component_ctor_policy<
-                    Component>::type>::call_new(component_, this,
-                HPX_FORWARD(Ts, vs)...);
+            detail_adl_barrier::init<traits::managed_component_ctor_policy_t<
+                Component>>::call_new(component_, this);
+            intrusive_ptr_add_ref(this);
+        }
+
+        template <typename T, typename... Ts,
+            typename Enable = std::enable_if_t<
+                !std::is_same_v<std::decay_t<T>, managed_component>>>
+        explicit managed_component(T&& t, Ts&&... ts)
+          : component_(nullptr)
+        {
+            detail_adl_barrier::init<traits::managed_component_ctor_policy_t<
+                Component>>::call_new(component_, this, HPX_FORWARD(T, t),
+                HPX_FORWARD(Ts, ts)...);
             intrusive_ptr_add_ref(this);
         }
 
@@ -352,8 +360,8 @@ namespace hpx { namespace components {
         {
             intrusive_ptr_release(this);
             detail_adl_barrier::manage_lifetime<
-                typename traits::managed_component_dtor_policy<
-                    Component>::type>::call(component_);
+                traits::managed_component_dtor_policy_t<Component>>::
+                call(component_);
         }
 
         //finalize() will be called just before the instance gets destructed

--- a/libs/full/components_base/include/hpx/components_base/server/one_size_heap_list.hpp
+++ b/libs/full/components_base/include/hpx/components_base/server/one_size_heap_list.hpp
@@ -32,8 +32,6 @@ namespace hpx { namespace util {
 
         using mutex_type = lcos::local::spinlock;
 
-        using unique_lock_type = std::unique_lock<mutex_type>;
-
         using heap_parameters = wrapper_heap_base::heap_parameters;
 
     private:

--- a/libs/full/components_base/include/hpx/components_base/server/wrapper_heap.hpp
+++ b/libs/full/components_base/include/hpx/components_base/server/wrapper_heap.hpp
@@ -35,9 +35,6 @@ namespace hpx { namespace components { namespace detail {
     namespace one_size_heap_allocators {
 
         ///////////////////////////////////////////////////////////////////////
-        // TODO: this interface should conform to the Boost.Pool allocator
-        // interface, to maximize code reuse and consistency - wash.
-        //
         // simple allocator which gets the memory from the default malloc,
         // but which does not reallocate the heap (it doesn't grow)
         struct fixed_mallocator
@@ -50,7 +47,7 @@ namespace hpx { namespace components { namespace detail {
             {
                 alloc_.deallocate(static_cast<char*>(p), count);
             }
-            static void* realloc(std::size_t&, void*)
+            static void* realloc(std::size_t&, void*) noexcept
             {
                 // normally this should return ::realloc(p, size), but we are
                 // not interested in growing the allocated heaps, so we just
@@ -71,7 +68,6 @@ namespace hpx { namespace components { namespace detail {
     public:
         using allocator_type = one_size_heap_allocators::fixed_mallocator;
         using mutex_type = hpx::lcos::local::spinlock;
-        using scoped_lock = std::unique_lock<mutex_type>;
         using heap_parameters = wrapper_heap_base::heap_parameters;
 
 #if HPX_DEBUG_WRAPPER_HEAP != 0
@@ -109,7 +105,7 @@ namespace hpx { namespace components { namespace detail {
         void set_gid(naming::gid_type const& g);
 
     protected:
-        bool test_release(scoped_lock& lk);
+        bool test_release(std::unique_lock<mutex_type>& lk);
         bool ensure_pool(std::size_t count);
 
         bool init_pool();
@@ -149,8 +145,8 @@ namespace hpx { namespace components { namespace detail {
 #endif
 
     private:
-        util::itt::heap_function heap_alloc_function_;
-        util::itt::heap_function heap_free_function_;
+        HPX_NO_UNIQUE_ADDRESS util::itt::heap_function heap_alloc_function_;
+        HPX_NO_UNIQUE_ADDRESS util::itt::heap_function heap_free_function_;
     };
 
     ///////////////////////////////////////////////////////////////////////////

--- a/libs/full/components_base/include/hpx/components_base/server/wrapper_heap_list.hpp
+++ b/libs/full/components_base/include/hpx/components_base/server/wrapper_heap_list.hpp
@@ -25,15 +25,15 @@ namespace hpx { namespace components { namespace detail {
         using base_type = util::one_size_heap_list;
         using value_type = typename Heap::value_type;
 
-        using storage_type = typename std::aligned_storage<sizeof(value_type),
-            std::alignment_of<value_type>::value>::type;
+        using storage_type = std::aligned_storage_t<sizeof(value_type),
+            std::alignment_of<value_type>::value>;
 
         enum
         {
             // default initial number of elements
             heap_capacity = 0xFFF,
             // Alignment of one element
-            heap_element_alignment = std::alignment_of<value_type>::value,
+            heap_element_alignment = std::alignment_of_v<value_type>,
             // size of one element in the heap
             heap_element_size = sizeof(storage_type)
         };
@@ -52,7 +52,7 @@ namespace hpx { namespace components { namespace detail {
 
         naming::gid_type get_gid(void* p)
         {
-            typename base_type::unique_lock_type guard(this->mtx_);
+            std::unique_lock guard(this->mtx_);
 
             using iterator = typename base_type::const_iterator;
 
@@ -61,8 +61,7 @@ namespace hpx { namespace components { namespace detail {
             {
                 if ((*it)->did_alloc(p))
                 {
-                    util::unlock_guard<typename base_type::unique_lock_type> ul(
-                        guard);
+                    util::unlock_guard ul(guard);
                     return (*it)->get_gid(id_range_, p, type_);
                 }
             }
@@ -72,7 +71,7 @@ namespace hpx { namespace components { namespace detail {
         void set_range(
             naming::gid_type const& lower, naming::gid_type const& upper)
         {
-            typename base_type::unique_lock_type guard(this->mtx_);
+            std::scoped_lock guard(this->mtx_);
             id_range_.set_range(lower, upper);
         }
 

--- a/libs/full/components_base/include/hpx/components_base/traits/action_decorate_function.hpp
+++ b/libs/full/components_base/include/hpx/components_base/traits/action_decorate_function.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2018 Hartmut Kaiser
+//  Copyright (c) 2007-2021 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -43,10 +43,14 @@ namespace hpx { namespace traits {
     {
     };
 
+    template <typename Action>
+    inline constexpr bool has_decorates_action_v =
+        has_decorates_action<Action>::value;
+
     template <typename Action, typename Enable = void>
     struct action_decorate_function
     {
-        static constexpr bool value = has_decorates_action<Action>::value;
+        static constexpr bool value = has_decorates_action_v<Action>;
 
         template <typename F>
         static threads::thread_function_type call(
@@ -58,10 +62,14 @@ namespace hpx { namespace traits {
         }
     };
 
-    template <typename Action, typename Enable = void>
-    struct component_decorates_action : detail::has_decorates_action<Action>
+    template <typename Component, typename Enable = void>
+    struct component_decorates_action : detail::has_decorates_action<Component>
     {
     };
+
+    template <typename Component>
+    inline constexpr bool component_decorates_action_v =
+        component_decorates_action<Component>::value;
 
     template <typename Component, typename Enable = void>
     struct component_decorate_function

--- a/libs/full/components_base/include/hpx/components_base/traits/component_config_data.hpp
+++ b/libs/full/components_base/include/hpx/components_base/traits/component_config_data.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2013 Hartmut Kaiser
+//  Copyright (c) 2007-2021 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -16,7 +16,7 @@ namespace hpx { namespace traits {
     struct component_config_data
     {
         // by default no additional config data is injected into the factory
-        static char const* call()
+        static char const* call() noexcept
         {
             return nullptr;
         }

--- a/libs/full/components_base/include/hpx/components_base/traits/component_pin_support.hpp
+++ b/libs/full/components_base/include/hpx/components_base/traits/component_pin_support.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2018 Hartmut Kaiser
+//  Copyright (c) 2018-2021 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying

--- a/libs/full/components_base/include/hpx/components_base/traits/component_supports_migration.hpp
+++ b/libs/full/components_base/include/hpx/components_base/traits/component_supports_migration.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2016 Hartmut Kaiser
+//  Copyright (c) 2007-2021 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -22,7 +22,7 @@ namespace hpx { namespace traits {
             // by default we return 'false' (component does not support
             // migration)
             template <typename Component>
-            static constexpr bool call(wrap_int)
+            static constexpr bool call(wrap_int) noexcept
             {
                 return false;
             }

--- a/libs/full/components_base/include/hpx/components_base/traits/component_type_database.hpp
+++ b/libs/full/components_base/include/hpx/components_base/traits/component_type_database.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2012 Hartmut Kaiser
+//  Copyright (c) 2007-2021 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -30,7 +30,7 @@ namespace hpx { namespace traits {
     template <typename Component, typename Enable>
     components::component_type
         component_type_database<Component, Enable>::value =
-            components::component_type(-1);    //components::component_invalid;
+            components::component_type(-1);    // components::component_invalid;
 
     template <typename Component, typename Enable>
     struct component_type_database<Component const, Enable>

--- a/libs/full/components_base/include/hpx/components_base/traits/component_type_is_compatible.hpp
+++ b/libs/full/components_base/include/hpx/components_base/traits/component_type_is_compatible.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2014 Hartmut Kaiser
+//  Copyright (c) 2007-2021 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -16,7 +16,7 @@ namespace hpx { namespace traits {
     template <typename Component, typename Enable = void>
     struct component_type_is_compatible
     {
-        static bool call(naming::address const& addr)
+        static bool call(naming::address const& addr) noexcept
         {
             return components::types_are_compatible(
                 addr.type_, components::get_component_type<Component>());

--- a/libs/full/components_base/include/hpx/components_base/traits/is_component.hpp
+++ b/libs/full/components_base/include/hpx/components_base/traits/is_component.hpp
@@ -46,8 +46,7 @@ namespace hpx { namespace traits {
     // Simple components are components
     template <typename Component>
     struct is_component<Component,
-        typename std::enable_if<
-            std::is_base_of<detail::component_tag, Component>::value>::type>
+        std::enable_if_t<std::is_base_of_v<detail::component_tag, Component>>>
       : std::true_type
     {
     };
@@ -55,18 +54,23 @@ namespace hpx { namespace traits {
     // Fixed components are components
     template <typename Component>
     struct is_component<Component,
-        typename std::enable_if<std::is_base_of<detail::fixed_component_tag,
-            Component>::value>::type> : std::true_type
+        std::enable_if_t<
+            std::is_base_of_v<detail::fixed_component_tag, Component>>>
+      : std::true_type
     {
     };
 
     // Managed components are components
     template <typename Component>
     struct is_component<Component,
-        typename std::enable_if<std::is_base_of<detail::managed_component_tag,
-            Component>::value>::type> : std::true_type
+        std::enable_if_t<
+            std::is_base_of_v<detail::managed_component_tag, Component>>>
+      : std::true_type
     {
     };
+
+    template <typename Component>
+    inline constexpr bool is_component_v = is_component<Component>::value;
 
     ///////////////////////////////////////////////////////////////////////////
     template <typename T, typename Enable = void>
@@ -84,12 +88,14 @@ namespace hpx { namespace traits {
     {
     };
 
+    template <typename Component>
+    inline constexpr bool is_component_or_component_array_v =
+        is_component_or_component_array<Component>::value;
+
     ///////////////////////////////////////////////////////////////////////////
     template <typename Component>
     struct is_fixed_component
-      : std::integral_constant<bool,
-            std::is_base_of<traits::detail::fixed_component_tag,
-                Component>::value>
+      : std::is_base_of<traits::detail::fixed_component_tag, Component>
     {
     };
 
@@ -99,10 +105,13 @@ namespace hpx { namespace traits {
     };
 
     template <typename Component>
+    inline constexpr bool is_fixed_component_v =
+        is_fixed_component<Component>::value;
+
+    ///////////////////////////////////////////////////////////////////////////
+    template <typename Component>
     struct is_managed_component
-      : std::integral_constant<bool,
-            std::is_base_of<traits::detail::managed_component_tag,
-                Component>::value>
+      : std::is_base_of<traits::detail::managed_component_tag, Component>
     {
     };
 
@@ -111,4 +120,9 @@ namespace hpx { namespace traits {
       : is_managed_component<Component>
     {
     };
+
+    template <typename Component>
+    inline constexpr bool is_managed_component_v =
+        is_managed_component<Component>::value;
+
 }}    // namespace hpx::traits

--- a/libs/full/components_base/include/hpx/components_base/traits/managed_component_policies.hpp
+++ b/libs/full/components_base/include/hpx/components_base/traits/managed_component_policies.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2016 Hartmut Kaiser
+//  Copyright (c) 2016-2021 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -30,11 +30,14 @@ namespace hpx { namespace traits {
 
     template <typename Component>
     struct managed_component_ctor_policy<Component,
-        typename util::always_void<
-            typename Component::has_managed_component_base>::type>
+        util::always_void_t<typename Component::has_managed_component_base>>
     {
         using type = typename Component::ctor_policy;
     };
+
+    template <typename T>
+    using managed_component_ctor_policy_t =
+        typename managed_component_ctor_policy<T>::type;
 
     ///////////////////////////////////////////////////////////////////////////
     // control the way managed_components are destructed
@@ -54,9 +57,12 @@ namespace hpx { namespace traits {
 
     template <typename Component>
     struct managed_component_dtor_policy<Component,
-        typename util::always_void<
-            typename Component::has_managed_component_base>::type>
+        util::always_void<typename Component::has_managed_component_base>>
     {
         using type = typename Component::dtor_policy;
     };
+
+    template <typename T>
+    using managed_component_dtor_policy_t =
+        typename managed_component_dtor_policy<T>::type;
 }}    // namespace hpx::traits

--- a/libs/full/components_base/src/component_type.cpp
+++ b/libs/full/components_base/src/component_type.cpp
@@ -71,7 +71,7 @@ namespace hpx { namespace components {
         public:
             static component_entry& get_entry(component_type type)
             {
-                std::lock_guard<mutex_type> l(mtx());
+                std::lock_guard l(mtx());
                 auto& d = data();
 
                 auto it = d.find(type);
@@ -89,7 +89,7 @@ namespace hpx { namespace components {
                 std::vector<component_type> types;
 
                 {
-                    std::lock_guard<mutex_type> l(mtx());
+                    std::lock_guard l(mtx());
                     types.reserve(data().size());
 
                     for (auto const& e : data())
@@ -158,17 +158,27 @@ namespace hpx { namespace components {
         std::string result;
 
         if (type == component_invalid)
+        {
             result = "component_invalid";
+        }
         else if ((type < component_last) && (get_derived_type(type) == 0))
+        {
             result = components::detail::names[type];
+        }
         else if (get_derived_type(type) < component_last &&
             (get_derived_type(type) != 0))
+        {
             result = components::detail::names[get_derived_type(type)];
+        }
         else
+        {
             result = "component";
+        }
 
         if (type == get_base_type(type) || component_invalid == type)
+        {
             result += "[" + std::to_string(type) + "]";
+        }
         else
         {
             result += "[" +

--- a/libs/full/components_base/src/generate_unique_ids.cpp
+++ b/libs/full/components_base/src/generate_unique_ids.cpp
@@ -19,7 +19,7 @@ namespace hpx { namespace util {
     naming::gid_type unique_id_ranges::get_id(std::size_t count)
     {
         // create a new id
-        std::unique_lock<mutex_type> l(mtx_);
+        std::unique_lock l(mtx_);
 
         // ensure next_id doesn't overflow
         while (!lower_ || (lower_ + count) > upper_)
@@ -30,7 +30,7 @@ namespace hpx { namespace util {
             std::size_t count_ = (std::max)(std::size_t(range_delta), count);
 
             {
-                unlock_guard<std::unique_lock<mutex_type>> ul(l);
+                unlock_guard ul(l);
                 lower = hpx::agas::get_next_id(count_);
             }
 

--- a/libs/full/components_base/src/server/component_base.cpp
+++ b/libs/full/components_base/src/server/component_base.cpp
@@ -76,7 +76,7 @@ namespace hpx { namespace components { namespace detail {
             }
         }
 
-        std::unique_lock<naming::gid_type::mutex_type> l(gid_.get_mutex());
+        std::unique_lock l(gid_.get_mutex());
 
         naming::gid_type gid = gid_;
         if (!naming::detail::has_credits(gid_))
@@ -121,7 +121,7 @@ namespace hpx { namespace components { namespace detail {
             // can be directly resolved to the address it contains.
         }
 
-        std::unique_lock<naming::gid_type::mutex_type> l(gid_.get_mutex());
+        std::unique_lock l(gid_.get_mutex());
 
         naming::gid_type gid = gid_;
         if (!naming::detail::has_credits(gid_))

--- a/libs/full/init_runtime/src/hpx_init.cpp
+++ b/libs/full/init_runtime/src/hpx_init.cpp
@@ -1049,7 +1049,7 @@ namespace hpx {
             shutdown_timeout = detail::get_option("hpx.shutdown_timeout", -1.0);
 
         components::server::runtime_support* p =
-            reinterpret_cast<components::server::runtime_support*>(
+            static_cast<components::server::runtime_support*>(
                 get_runtime_distributed().get_runtime_support_lva());
 
         if (nullptr == p)
@@ -1078,7 +1078,7 @@ namespace hpx {
         }
 
         components::server::runtime_support* p =
-            reinterpret_cast<components::server::runtime_support*>(
+            static_cast<components::server::runtime_support*>(
                 get_runtime_distributed().get_runtime_support_lva());
 
         if (nullptr == p)

--- a/libs/full/lcos_distributed/include/hpx/lcos_distributed/server/channel.hpp
+++ b/libs/full/lcos_distributed/include/hpx/lcos_distributed/server/channel.hpp
@@ -67,6 +67,14 @@ namespace hpx { namespace lcos { namespace server {
             components::set_component_type<channel>(type);
         }
 
+        naming::address get_current_address() const
+        {
+            return naming::address(
+                naming::get_gid_from_locality_id(agas::get_locality_id()),
+                components::get_component_type<channel>(),
+                const_cast<channel*>(this));
+        }
+
         // standard LCO action implementations
 
         // Push a value to the channel.

--- a/libs/full/naming_base/include/hpx/naming_base/address.hpp
+++ b/libs/full/naming_base/include/hpx/naming_base/address.hpp
@@ -40,26 +40,19 @@ namespace hpx { namespace naming {
         {
         }
 
-        address(gid_type const& l, component_type t, void* lva) noexcept
-          : locality_(l)
-          , type_(t)
-          , address_(reinterpret_cast<address_type>(lva))
-        {
-        }
-
         constexpr address(
-            gid_type const& l, component_type t, address_type a) noexcept
+            gid_type const& l, component_type t, void* lva) noexcept
           : locality_(l)
           , type_(t)
-          , address_(a)
+          , address_(lva)
         {
         }
 
         // local only addresses
-        explicit address(
+        explicit constexpr address(
             void* lva, component_type t = component_invalid) noexcept
           : type_(t)
-          , address_(reinterpret_cast<address_type>(lva))
+          , address_(lva)
         {
         }
 
@@ -70,7 +63,8 @@ namespace hpx { namespace naming {
 
         explicit constexpr operator bool() const noexcept
         {
-            return !!locality_ && (component_invalid != type_ || 0 != address_);
+            return !!locality_ &&
+                (component_invalid != type_ || nullptr != address_);
         }
 
         friend constexpr bool operator==(
@@ -82,7 +76,7 @@ namespace hpx { namespace naming {
 
         gid_type locality_;
         component_type type_ = component_invalid;
-        address_type address_ = 0;    /// address (local virtual address)
+        address_type address_ = nullptr;    // address (local virtual address)
 
     private:
         // serialization support

--- a/libs/full/naming_base/include/hpx/naming_base/gid_type.hpp
+++ b/libs/full/naming_base/include/hpx/naming_base/gid_type.hpp
@@ -99,8 +99,16 @@ namespace hpx { namespace naming {
         {
         }
 
+        explicit gid_type(void* lsb_id) noexcept
+          : id_msb_(0)
+          , id_lsb_(reinterpret_cast<std::uint64_t>(lsb_id))
+        {
+        }
+
         explicit inline gid_type(
             std::uint64_t msb_id, std::uint64_t lsb_id) noexcept;
+        explicit inline gid_type(std::uint64_t msb_id, void* lsb_id) noexcept;
+
         inline constexpr gid_type(gid_type const& rhs) noexcept;
         inline constexpr gid_type(gid_type&& rhs) noexcept;
 
@@ -357,7 +365,8 @@ namespace hpx { namespace naming {
     inline gid_type get_gid_from_locality_id(std::uint32_t locality_id) noexcept
     {
         return gid_type(
-            (std::uint64_t(locality_id) + 1) << gid_type::locality_id_shift, 0);
+            (std::uint64_t(locality_id) + 1) << gid_type::locality_id_shift,
+            nullptr);
     }
 
     inline std::uint32_t get_locality_id_from_gid(
@@ -674,6 +683,12 @@ namespace hpx { namespace naming {
         std::uint64_t msb_id, std::uint64_t lsb_id) noexcept
       : id_msb_(naming::detail::strip_lock_from_gid(msb_id))
       , id_lsb_(lsb_id)
+    {
+    }
+
+    inline gid_type::gid_type(std::uint64_t msb_id, void* lsb_id) noexcept
+      : id_msb_(naming::detail::strip_lock_from_gid(msb_id))
+      , id_lsb_(reinterpret_cast<std::uint64_t>(lsb_id))
     {
     }
 

--- a/libs/full/naming_base/include/hpx/naming_base/naming_base.hpp
+++ b/libs/full/naming_base/include/hpx/naming_base/naming_base.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2020 Hartmut Kaiser
+//  Copyright (c) 2007-2021 Hartmut Kaiser
 //  Copyright (c) 2011      Bryce Lelbach
 //
 //  SPDX-License-Identifier: BSL-1.0
@@ -20,7 +20,7 @@ namespace hpx {
         }    // namespace detail
 
         using component_type = std::int32_t;
-        using address_type = std::uint64_t;
+        using address_type = void*;
 
         inline constexpr std::uint32_t invalid_locality_id =
             ~static_cast<std::uint32_t>(0);

--- a/libs/full/naming_base/src/address.cpp
+++ b/libs/full/naming_base/src/address.cpp
@@ -1,12 +1,13 @@
-//  Copyright (c) 2007-2020 Hartmut Kaiser
+//  Copyright (c) 2007-2021 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include <hpx/modules/errors.hpp>
 #include <hpx/naming_base/address.hpp>
 #include <hpx/serialization/serialize.hpp>
+
+#include <cstddef>
 
 ///////////////////////////////////////////////////////////////////////////////
 namespace hpx { namespace naming {
@@ -15,7 +16,8 @@ namespace hpx { namespace naming {
     void address::save(Archive& ar, unsigned int /* version */) const
     {
         // clang-format off
-        ar & locality_ & type_ & address_;
+        std::size_t address = reinterpret_cast<std::size_t>(address_);
+        ar & locality_ & type_ & address;
         // clang-format on
     }
 
@@ -23,7 +25,9 @@ namespace hpx { namespace naming {
     void address::load(Archive& ar, unsigned int /* version */)
     {
         // clang-format off
-        ar & locality_ & type_ & address_;
+        std::size_t address;
+        ar & locality_ & type_ & address;
+        address_ = reinterpret_cast<address_type>(address);
         // clang-format on
     }
 

--- a/libs/full/naming_base/tests/unit/gid_type.cpp
+++ b/libs/full/naming_base/tests/unit/gid_type.cpp
@@ -401,12 +401,12 @@ int main()
     }
 
     {    // post-increment tests (post-increment should return a temporary)
-        gid_type gid0(~0x0ULL),        // boundary case
-            gid1(0xabULL),             // < ~0x0ULL case
-            gid2(0xdeULL, 0x0ULL),     // 0 lsb, > ~0x0ULL case
-            gid3(0xdeULL, 0xadULL),    // none-zero lsb, > ~0x0ULL case
+        gid_type gid0(~0x0ULL),                // boundary case
+            gid1(0xabULL),                     // < ~0x0ULL case
+            gid2(0xdeULL, nullptr),            // 0 lsb, > ~0x0ULL case
+            gid3(0xdeULL, (void*) 0xadULL),    // none-zero lsb, > ~0x0ULL case
             // we need these to check the order of operations
-            eq0(~0x0ULL), eq1(0xabULL), eq2(0xdeULL, 0x0ULL),
+            eq0(~0x0ULL), eq1(0xabULL), eq2(0xdeULL, nullptr),
             eq3(0xdeULL, 0xadULL);
 
         // sanity checks
@@ -455,12 +455,12 @@ int main()
     }
 
     {    // pre-increment tests (post-increment should return the original)
-        gid_type gid0(~0x0ULL),        // boundary case
-            gid1(0xabULL),             // < ~0x0ULL case
-            gid2(0xdeULL, 0x0ULL),     // 0 lsb, > ~0x0ULL case
-            gid3(0xdeULL, 0xadULL),    // none-zero lsb, > ~0x0ULL case
+        gid_type gid0(~0x0ULL),                // boundary case
+            gid1(0xabULL),                     // < ~0x0ULL case
+            gid2(0xdeULL, nullptr),            // 0 lsb, > ~0x0ULL case
+            gid3(0xdeULL, (void*) 0xadULL),    // none-zero lsb, > ~0x0ULL case
             // we need these to check the order of operations
-            eq0(~0x0ULL), eq1(0xabULL), eq2(0xdeULL, 0x0ULL),
+            eq0(~0x0ULL), eq1(0xabULL), eq2(0xdeULL, nullptr),
             eq3(0xdeULL, 0xadULL);
 
         // sanity checks
@@ -508,12 +508,12 @@ int main()
         HPX_TEST_EQ(gid3.get_lsb(), 0xaeULL);
     }
 
-    {                                  // arithmetic (operator+) tests
-        gid_type gid0(~0x0ULL),        // boundary case
-            gid1(0xabULL),             // < ~0x0ULL case
-            gid2(0xdeULL, 0x0ULL),     // 0 lsb, > ~0x0ULL case
-            gid3(0xdeULL, 0xadULL),    // none-zero lsb, > ~0x0ULL case
-            gid4(0x1ULL);              // 1 case
+    {                                          // arithmetic (operator+) tests
+        gid_type gid0(~0x0ULL),                // boundary case
+            gid1(0xabULL),                     // < ~0x0ULL case
+            gid2(0xdeULL, nullptr),            // 0 lsb, > ~0x0ULL case
+            gid3(0xdeULL, (void*) 0xadULL),    // none-zero lsb, > ~0x0ULL case
+            gid4(0x1ULL);                      // 1 case
 
         // sanity checks
         HPX_SANITY_EQ(gid0.get_msb(), 0x0ULL);

--- a/libs/full/performance_counters/CMakeLists.txt
+++ b/libs/full/performance_counters/CMakeLists.txt
@@ -68,6 +68,7 @@ set(performance_counters_sources
     server/action_invocation_counter.cpp
     server/arithmetics_counter.cpp
     server/arithmetics_counter_extended.cpp
+    server/base_performance_counter.cpp
     server/component_instance_counter.cpp
     server/elapsed_time_counter.cpp
     server/per_action_data_counters.cpp

--- a/libs/full/performance_counters/include/hpx/performance_counters/base_performance_counter.hpp
+++ b/libs/full/performance_counters/include/hpx/performance_counters/base_performance_counter.hpp
@@ -36,7 +36,7 @@ namespace hpx { namespace performance_counters {
         typedef hpx::performance_counters::server::base_performance_counter
             base_type_holder;
 
-        base_performance_counter() {}
+        base_performance_counter() = default;
 
         base_performance_counter(
             hpx::performance_counters::counter_info const& info)
@@ -49,6 +49,14 @@ namespace hpx { namespace performance_counters {
         {
             base_type_holder::finalize();
             base_type::finalize();
+        }
+
+        hpx::naming::address get_current_address() const
+        {
+            return hpx::naming::address(
+                hpx::naming::get_gid_from_locality_id(hpx::get_locality_id()),
+                hpx::components::get_component_type<Derived>(),
+                const_cast<Derived*>(static_cast<Derived const*>(this)));
         }
     };
 }}    // namespace hpx::performance_counters

--- a/libs/full/performance_counters/include/hpx/performance_counters/performance_counter_base.hpp
+++ b/libs/full/performance_counters/include/hpx/performance_counters/performance_counter_base.hpp
@@ -18,7 +18,7 @@ namespace hpx { namespace performance_counters {
         //<-
         /// Destructor, needs to be virtual to allow for clean destruction of
         /// derived objects
-        virtual ~performance_counter_base() {}
+        virtual ~performance_counter_base() = default;
         //->
         // Retrieve the descriptive information about the Performance Counter.
         virtual counter_info get_counter_info() const = 0;

--- a/libs/full/performance_counters/include/hpx/performance_counters/server/arithmetics_counter.hpp
+++ b/libs/full/performance_counters/include/hpx/performance_counters/server/arithmetics_counter.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2017 Hartmut Kaiser
+//  Copyright (c) 2007-2021 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -32,7 +32,7 @@ namespace hpx { namespace performance_counters { namespace server {
         using type_holder = arithmetics_counter;
         using base_type_holder = base_performance_counter;
 
-        arithmetics_counter() = default;
+        arithmetics_counter();
 
         arithmetics_counter(counter_info const& info,
             std::vector<std::string> const& base_counter_names);
@@ -45,11 +45,9 @@ namespace hpx { namespace performance_counters { namespace server {
         bool stop() override;
         void reset_counter_value() override;
 
-        void finalize()
-        {
-            base_performance_counter::finalize();
-            base_type::finalize();
-        }
+        void finalize();
+
+        naming::address get_current_address() const;
 
     private:
         // base counters to be queried

--- a/libs/full/performance_counters/include/hpx/performance_counters/server/arithmetics_counter_extended.hpp
+++ b/libs/full/performance_counters/include/hpx/performance_counters/server/arithmetics_counter_extended.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2017 Hartmut Kaiser
+//  Copyright (c) 2007-2021 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -35,7 +35,7 @@ namespace hpx { namespace performance_counters { namespace server {
         using type_holder = arithmetics_counter_extended;
         using base_type_holder = base_performance_counter;
 
-        arithmetics_counter_extended() = default;
+        arithmetics_counter_extended();
 
         arithmetics_counter_extended(counter_info const& info,
             std::vector<std::string> const& base_counter_names);
@@ -48,11 +48,9 @@ namespace hpx { namespace performance_counters { namespace server {
         bool stop() override;
         void reset_counter_value() override;
 
-        void finalize()
-        {
-            base_performance_counter::finalize();
-            base_type::finalize();
-        }
+        void finalize();
+
+        naming::address get_current_address() const;
 
     private:
         // base counters to be queried

--- a/libs/full/performance_counters/include/hpx/performance_counters/server/base_performance_counter.hpp
+++ b/libs/full/performance_counters/include/hpx/performance_counters/server/base_performance_counter.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2018 Hartmut Kaiser
+//  Copyright (c) 2007-2021 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -12,8 +12,6 @@
 #include <hpx/async_distributed/base_lco_with_value.hpp>
 #include <hpx/async_distributed/transfer_continuation_action.hpp>
 #include <hpx/components_base/component_type.hpp>
-#include <hpx/components_base/server/component.hpp>
-#include <hpx/modules/errors.hpp>
 #include <hpx/performance_counters/counters.hpp>
 #include <hpx/performance_counters/performance_counter_base.hpp>
 #include <hpx/thread_support/atomic_count.hpp>
@@ -21,67 +19,25 @@
 ///////////////////////////////////////////////////////////////////////////////
 namespace hpx { namespace performance_counters { namespace server {
 
-    class base_performance_counter
+    class HPX_EXPORT base_performance_counter
       : public hpx::performance_counters::performance_counter_base
       , public hpx::traits::detail::component_tag
     {
     protected:
-        /// the following functions are not implemented by default, they will
-        /// just throw
-        void reset_counter_value() override
-        {
-            HPX_THROW_EXCEPTION(invalid_status, "reset_counter_value",
-                "reset_counter_value is not implemented for this counter");
-        }
-
-        void set_counter_value(counter_value const& /*value*/) override
-        {
-            HPX_THROW_EXCEPTION(invalid_status, "set_counter_value",
-                "set_counter_value is not implemented for this counter");
-        }
-
-        counter_value get_counter_value(bool /*reset*/) override
-        {
-            HPX_THROW_EXCEPTION(invalid_status, "get_counter_value",
-                "get_counter_value is not implemented for this counter");
-            return {};
-        }
-
-        counter_values_array get_counter_values_array(bool /*reset*/) override
-        {
-            HPX_THROW_EXCEPTION(invalid_status, "get_counter_values_array",
-                "get_counter_values_array is not implemented for this "
-                "counter");
-            return {};
-        }
-
-        bool start() override
-        {
-            return false;    // nothing to do
-        }
-
-        bool stop() override
-        {
-            return false;    // nothing to do
-        }
-
-        void reinit(bool /*reset*/) override {}
-
-        counter_info get_counter_info() const override
-        {
-            return info_;
-        }
+        // the following functions are not implemented by default, they will
+        // just throw
+        void reset_counter_value() override;
+        void set_counter_value(counter_value const& /*value*/) override;
+        counter_value get_counter_value(bool /*reset*/) override;
+        counter_values_array get_counter_values_array(bool /*reset*/) override;
+        bool start() override;
+        bool stop() override;
+        void reinit(bool /*reset*/) override;
+        counter_info get_counter_info() const override;
 
     public:
-        base_performance_counter()
-          : invocation_count_(0)
-        {
-        }
-        base_performance_counter(counter_info const& info)
-          : info_(info)
-          , invocation_count_(0)
-        {
-        }
+        base_performance_counter();
+        explicit base_performance_counter(counter_info const& info);
 
         // components must contain a typedef for wrapping_type defining the
         // component type used to encapsulate instances of this
@@ -89,8 +45,7 @@ namespace hpx { namespace performance_counters { namespace server {
         using wrapping_type = components::component<base_performance_counter>;
         using base_type_holder = base_performance_counter;
 
-        /// \brief finalize() will be called just before the instance gets
-        ///        destructed
+        // finalize() will be called just before the instance gets destructed
         constexpr void finalize() {}
 
         static components::component_type get_component_type() noexcept
@@ -103,49 +58,18 @@ namespace hpx { namespace performance_counters { namespace server {
         }
 
         ///////////////////////////////////////////////////////////////////////
-        counter_info get_counter_info_nonvirt() const
-        {
-            return this->get_counter_info();
-        }
+        counter_info get_counter_info_nonvirt() const;
+        counter_value get_counter_value_nonvirt(bool reset);
+        counter_values_array get_counter_values_array_nonvirt(bool reset);
+        void set_counter_value_nonvirt(counter_value const& info);
+        void reset_counter_value_nonvirt();
+        bool start_nonvirt();
+        bool stop_nonvirt();
+        void reinit_nonvirt(bool reset);
 
-        counter_value get_counter_value_nonvirt(bool reset)
-        {
-            return this->get_counter_value(reset);
-        }
-
-        counter_values_array get_counter_values_array_nonvirt(bool reset)
-        {
-            return this->get_counter_values_array(reset);
-        }
-
-        void set_counter_value_nonvirt(counter_value const& info)
-        {
-            this->set_counter_value(info);
-        }
-
-        void reset_counter_value_nonvirt()
-        {
-            this->reset_counter_value();
-        }
-
-        bool start_nonvirt()
-        {
-            return this->start();
-        }
-
-        bool stop_nonvirt()
-        {
-            return this->stop();
-        }
-
-        void reinit_nonvirt(bool reset)
-        {
-            reinit(reset);
-        }
-
-        /// Each of the exposed functions needs to be encapsulated into an action
-        /// type, allowing to generate all required boilerplate code for threads,
-        /// serialization, etc.
+        // Each of the exposed functions needs to be encapsulated into an action
+        // type, allowing to generate all required boilerplate code for threads,
+        // serialization, etc.
 
         /// The \a get_counter_info_action retrieves a performance counters
         /// information.

--- a/libs/full/performance_counters/include/hpx/performance_counters/server/elapsed_time_counter.hpp
+++ b/libs/full/performance_counters/include/hpx/performance_counters/server/elapsed_time_counter.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2012 Hartmut Kaiser
+//  Copyright (c) 2007-2021 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -24,27 +24,19 @@ namespace hpx { namespace performance_counters { namespace server {
         using type_holder = elapsed_time_counter;
         using base_type_holder = base_performance_counter;
 
-        elapsed_time_counter() = default;
+        elapsed_time_counter();
         elapsed_time_counter(counter_info const& info);
 
         hpx::performance_counters::counter_value get_counter_value(
             bool reset) override;
         void reset_counter_value() override;
 
-        bool start() override
-        {
-            return false;
-        }
-        bool stop() override
-        {
-            return false;
-        }
+        bool start() override;
+        bool stop() override;
 
         // finalize() will be called just before the instance gets destructed
-        void finalize()
-        {
-            base_performance_counter::finalize();
-            base_type::finalize();
-        }
+        void finalize();
+
+        naming::address get_current_address() const;
     };
 }}}    // namespace hpx::performance_counters::server

--- a/libs/full/performance_counters/include/hpx/performance_counters/server/raw_counter.hpp
+++ b/libs/full/performance_counters/include/hpx/performance_counters/server/raw_counter.hpp
@@ -26,10 +26,7 @@ namespace hpx { namespace performance_counters { namespace server {
         using type_holder = raw_counter;
         using base_type_holder = base_performance_counter;
 
-        raw_counter()
-          : reset_(false)
-        {
-        }
+        raw_counter();
 
         raw_counter(counter_info const& info,
             hpx::util::function_nonser<std::int64_t(bool)> f);
@@ -39,11 +36,9 @@ namespace hpx { namespace performance_counters { namespace server {
         void reset_counter_value() override;
 
         // finalize() will be called just before the instance gets destructed
-        void finalize()
-        {
-            base_performance_counter::finalize();
-            base_type::finalize();
-        }
+        void finalize();
+
+        naming::address get_current_address() const;
 
     private:
         hpx::util::function_nonser<std::int64_t(bool)> f_;

--- a/libs/full/performance_counters/include/hpx/performance_counters/server/raw_values_counter.hpp
+++ b/libs/full/performance_counters/include/hpx/performance_counters/server/raw_values_counter.hpp
@@ -27,10 +27,7 @@ namespace hpx { namespace performance_counters { namespace server {
         using type_holder = raw_values_counter;
         using base_type_holder = base_performance_counter;
 
-        raw_values_counter()
-          : reset_(false)
-        {
-        }
+        raw_values_counter();
 
         raw_values_counter(counter_info const& info,
             hpx::util::function_nonser<std::vector<std::int64_t>(bool)> f);
@@ -41,11 +38,9 @@ namespace hpx { namespace performance_counters { namespace server {
         void reset_counter_value() override;
 
         // finalize() will be called just before the instance gets destructed
-        void finalize()
-        {
-            base_performance_counter::finalize();
-            base_type::finalize();
-        }
+        void finalize();
+
+        naming::address get_current_address() const;
 
     private:
         hpx::util::function_nonser<std::vector<std::int64_t>(bool)> f_;

--- a/libs/full/performance_counters/include/hpx/performance_counters/server/statistics_counter.hpp
+++ b/libs/full/performance_counters/include/hpx/performance_counters/server/statistics_counter.hpp
@@ -46,7 +46,7 @@ namespace hpx { namespace performance_counters { namespace server {
             base_type;
 
         // avoid warnings about using this in member initializer list
-        statistics_counter* this_()
+        constexpr statistics_counter* this_() noexcept
         {
             return this;
         }
@@ -55,13 +55,7 @@ namespace hpx { namespace performance_counters { namespace server {
         typedef statistics_counter type_holder;
         typedef base_performance_counter base_type_holder;
 
-        statistics_counter()
-          : has_prev_value_(false)
-          , parameter1_(0)
-          , parameter2_(0)
-          , reset_base_counter_(false)
-        {
-        }
+        statistics_counter();
 
         statistics_counter(counter_info const& info,
             std::string const& base_counter_name, std::size_t parameter1,
@@ -77,14 +71,12 @@ namespace hpx { namespace performance_counters { namespace server {
 
         void reset_counter_value() override;
 
-        void on_terminate() {}
+        void on_terminate();
 
         // finalize() will be called just before the instance gets destructed
-        void finalize()
-        {
-            base_performance_counter::finalize();
-            base_type::finalize();
-        }
+        void finalize();
+
+        naming::address get_current_address() const;
 
     protected:
         bool evaluate_base_counter(counter_value& value);

--- a/libs/full/performance_counters/src/server/arithmetics_counter.cpp
+++ b/libs/full/performance_counters/src/server/arithmetics_counter.cpp
@@ -70,6 +70,9 @@ namespace hpx { namespace performance_counters { namespace server {
 
     ///////////////////////////////////////////////////////////////////////////
     template <typename Operation>
+    arithmetics_counter<Operation>::arithmetics_counter() = default;
+
+    template <typename Operation>
     arithmetics_counter<Operation>::arithmetics_counter(
         counter_info const& info,
         std::vector<std::string> const& base_counter_names)
@@ -149,6 +152,22 @@ namespace hpx { namespace performance_counters { namespace server {
     void arithmetics_counter<Operation>::reset_counter_value()
     {
         counters_.reset(hpx::launch::sync);
+    }
+
+    template <typename Operation>
+    void arithmetics_counter<Operation>::finalize()
+    {
+        base_performance_counter::finalize();
+        base_type::finalize();
+    }
+
+    template <typename Operation>
+    naming::address arithmetics_counter<Operation>::get_current_address() const
+    {
+        return naming::address(
+            naming::get_gid_from_locality_id(agas::get_locality_id()),
+            components::get_component_type<arithmetics_counter>(),
+            const_cast<arithmetics_counter*>(this));
     }
 }}}    // namespace hpx::performance_counters::server
 

--- a/libs/full/performance_counters/src/server/arithmetics_counter_extended.cpp
+++ b/libs/full/performance_counters/src/server/arithmetics_counter_extended.cpp
@@ -32,7 +32,12 @@
 
 ///////////////////////////////////////////////////////////////////////////////
 namespace hpx { namespace performance_counters { namespace server {
+
     ///////////////////////////////////////////////////////////////////////////
+    template <typename Statistic>
+    arithmetics_counter_extended<Statistic>::arithmetics_counter_extended() =
+        default;
+
     template <typename Statistic>
     arithmetics_counter_extended<Statistic>::arithmetics_counter_extended(
         counter_info const& info,
@@ -168,6 +173,23 @@ namespace hpx { namespace performance_counters { namespace server {
     void arithmetics_counter_extended<Statistic>::reset_counter_value()
     {
         counters_.reset(hpx::launch::sync);
+    }
+
+    template <typename Statistic>
+    void arithmetics_counter_extended<Statistic>::finalize()
+    {
+        base_performance_counter::finalize();
+        base_type::finalize();
+    }
+
+    template <typename Statistic>
+    naming::address
+    arithmetics_counter_extended<Statistic>::get_current_address() const
+    {
+        return naming::address(
+            naming::get_gid_from_locality_id(agas::get_locality_id()),
+            components::get_component_type<arithmetics_counter_extended>(),
+            const_cast<arithmetics_counter_extended*>(this));
     }
 }}}    // namespace hpx::performance_counters::server
 

--- a/libs/full/performance_counters/src/server/base_performance_counter.cpp
+++ b/libs/full/performance_counters/src/server/base_performance_counter.cpp
@@ -1,0 +1,126 @@
+//  Copyright (c) 2007-2021 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/config.hpp>
+#include <hpx/actions/transfer_action.hpp>
+#include <hpx/actions_base/component_action.hpp>
+#include <hpx/async_distributed/base_lco_with_value.hpp>
+#include <hpx/async_distributed/transfer_continuation_action.hpp>
+#include <hpx/components_base/component_type.hpp>
+#include <hpx/components_base/server/component.hpp>
+#include <hpx/modules/errors.hpp>
+#include <hpx/performance_counters/counters.hpp>
+#include <hpx/performance_counters/performance_counter_base.hpp>
+#include <hpx/performance_counters/server/base_performance_counter.hpp>
+#include <hpx/thread_support/atomic_count.hpp>
+
+HPX_DEFINE_GET_COMPONENT_TYPE(hpx::components::component<
+    hpx::performance_counters::server::base_performance_counter>)
+
+///////////////////////////////////////////////////////////////////////////////
+namespace hpx { namespace performance_counters { namespace server {
+
+    void base_performance_counter::reset_counter_value()
+    {
+        HPX_THROW_EXCEPTION(invalid_status, "reset_counter_value",
+            "reset_counter_value is not implemented for this counter");
+    }
+
+    void base_performance_counter::set_counter_value(
+        counter_value const& /*value*/)
+    {
+        HPX_THROW_EXCEPTION(invalid_status, "set_counter_value",
+            "set_counter_value is not implemented for this counter");
+    }
+
+    counter_value base_performance_counter::get_counter_value(bool /*reset*/)
+    {
+        HPX_THROW_EXCEPTION(invalid_status, "get_counter_value",
+            "get_counter_value is not implemented for this counter");
+        return {};
+    }
+
+    counter_values_array base_performance_counter::get_counter_values_array(
+        bool /*reset*/)
+    {
+        HPX_THROW_EXCEPTION(invalid_status, "get_counter_values_array",
+            "get_counter_values_array is not implemented for this "
+            "counter");
+        return {};
+    }
+
+    bool base_performance_counter::start()
+    {
+        return false;    // nothing to do
+    }
+
+    bool base_performance_counter::stop()
+    {
+        return false;    // nothing to do
+    }
+
+    void base_performance_counter::reinit(bool /*reset*/) {}
+
+    counter_info base_performance_counter::get_counter_info() const
+    {
+        return info_;
+    }
+
+    base_performance_counter::base_performance_counter()
+      : invocation_count_(0)
+    {
+    }
+
+    base_performance_counter::base_performance_counter(counter_info const& info)
+      : info_(info)
+      , invocation_count_(0)
+    {
+    }
+
+    ///////////////////////////////////////////////////////////////////////
+    counter_info base_performance_counter::get_counter_info_nonvirt() const
+    {
+        return this->get_counter_info();
+    }
+
+    counter_value base_performance_counter::get_counter_value_nonvirt(
+        bool reset)
+    {
+        return this->get_counter_value(reset);
+    }
+
+    counter_values_array
+    base_performance_counter::get_counter_values_array_nonvirt(bool reset)
+    {
+        return this->get_counter_values_array(reset);
+    }
+
+    void base_performance_counter::set_counter_value_nonvirt(
+        counter_value const& info)
+    {
+        this->set_counter_value(info);
+    }
+
+    void base_performance_counter::reset_counter_value_nonvirt()
+    {
+        this->reset_counter_value();
+    }
+
+    bool base_performance_counter::start_nonvirt()
+    {
+        return this->start();
+    }
+
+    bool base_performance_counter::stop_nonvirt()
+    {
+        return this->stop();
+    }
+
+    void base_performance_counter::reinit_nonvirt(bool reset)
+    {
+        reinit(reset);
+    }
+}}}    // namespace hpx::performance_counters::server

--- a/libs/full/performance_counters/src/server/elapsed_time_counter.cpp
+++ b/libs/full/performance_counters/src/server/elapsed_time_counter.cpp
@@ -30,6 +30,9 @@ HPX_DEFINE_GET_COMPONENT_TYPE(
 
 ///////////////////////////////////////////////////////////////////////////////
 namespace hpx { namespace performance_counters { namespace server {
+
+    elapsed_time_counter::elapsed_time_counter() = default;
+
     elapsed_time_counter::elapsed_time_counter(counter_info const& info)
       : base_type_holder(info)
     {
@@ -68,6 +71,29 @@ namespace hpx { namespace performance_counters { namespace server {
         HPX_THROW_EXCEPTION(bad_parameter,
             "elapsed_time_counter::reset_counter_value",
             "counter /runtime/uptime does no support reset");
+    }
+
+    bool elapsed_time_counter::start()
+    {
+        return false;
+    }
+    bool elapsed_time_counter::stop()
+    {
+        return false;
+    }
+
+    void elapsed_time_counter::finalize()
+    {
+        base_performance_counter::finalize();
+        base_type::finalize();
+    }
+
+    naming::address elapsed_time_counter::get_current_address() const
+    {
+        return naming::address(
+            naming::get_gid_from_locality_id(agas::get_locality_id()),
+            components::get_component_type<elapsed_time_counter>(),
+            const_cast<elapsed_time_counter*>(this));
     }
 }}}    // namespace hpx::performance_counters::server
 

--- a/libs/full/performance_counters/src/server/raw_counter.cpp
+++ b/libs/full/performance_counters/src/server/raw_counter.cpp
@@ -28,6 +28,11 @@ HPX_DEFINE_GET_COMPONENT_TYPE(hpx::performance_counters::server::raw_counter)
 ///////////////////////////////////////////////////////////////////////////////
 namespace hpx { namespace performance_counters { namespace server {
 
+    raw_counter::raw_counter()
+      : reset_(false)
+    {
+    }
+
     raw_counter::raw_counter(counter_info const& info,
         hpx::util::function_nonser<std::int64_t(bool)> f)
       : base_type_holder(info)
@@ -62,5 +67,19 @@ namespace hpx { namespace performance_counters { namespace server {
     void raw_counter::reset_counter_value()
     {
         f_(true);
+    }
+
+    void raw_counter::finalize()
+    {
+        base_performance_counter::finalize();
+        base_type::finalize();
+    }
+
+    naming::address raw_counter::get_current_address() const
+    {
+        return naming::address(
+            naming::get_gid_from_locality_id(agas::get_locality_id()),
+            components::get_component_type<raw_counter>(),
+            const_cast<raw_counter*>(this));
     }
 }}}    // namespace hpx::performance_counters::server

--- a/libs/full/performance_counters/src/server/raw_values_counter.cpp
+++ b/libs/full/performance_counters/src/server/raw_values_counter.cpp
@@ -31,6 +31,11 @@ HPX_DEFINE_GET_COMPONENT_TYPE(
 ///////////////////////////////////////////////////////////////////////////////
 namespace hpx { namespace performance_counters { namespace server {
 
+    raw_values_counter::raw_values_counter()
+      : reset_(false)
+    {
+    }
+
     raw_values_counter::raw_values_counter(counter_info const& info,
         hpx::util::function_nonser<std::vector<std::int64_t>(bool)> f)
       : base_type_holder(info)
@@ -63,5 +68,19 @@ namespace hpx { namespace performance_counters { namespace server {
     void raw_values_counter::reset_counter_value()
     {
         f_(true);
+    }
+
+    void raw_values_counter::finalize()
+    {
+        base_performance_counter::finalize();
+        base_type::finalize();
+    }
+
+    naming::address raw_values_counter::get_current_address() const
+    {
+        return naming::address(
+            naming::get_gid_from_locality_id(agas::get_locality_id()),
+            components::get_component_type<raw_values_counter>(),
+            const_cast<raw_values_counter*>(this));
     }
 }}}    // namespace hpx::performance_counters::server

--- a/libs/full/performance_counters/src/server/statistics_counter.cpp
+++ b/libs/full/performance_counters/src/server/statistics_counter.cpp
@@ -377,6 +377,15 @@ namespace hpx { namespace performance_counters { namespace server {
 
     ///////////////////////////////////////////////////////////////////////////
     template <typename Statistic>
+    statistics_counter<Statistic>::statistics_counter()
+      : has_prev_value_(false)
+      , parameter1_(0)
+      , parameter2_(0)
+      , reset_base_counter_(false)
+    {
+    }
+
+    template <typename Statistic>
     statistics_counter<Statistic>::statistics_counter(counter_info const& info,
         std::string const& base_counter_name, std::size_t parameter1,
         std::size_t parameter2, bool reset_base_counter)
@@ -595,6 +604,27 @@ namespace hpx { namespace performance_counters { namespace server {
 
         // start off with last base value
         value_->add_value(static_cast<double>(prev_value_.value_));
+    }
+
+    template <typename Statistic>
+    void statistics_counter<Statistic>::on_terminate()
+    {
+    }
+
+    template <typename Statistic>
+    void statistics_counter<Statistic>::finalize()
+    {
+        base_performance_counter::finalize();
+        base_type::finalize();
+    }
+
+    template <typename Statistic>
+    naming::address statistics_counter<Statistic>::get_current_address() const
+    {
+        return naming::address(
+            naming::get_gid_from_locality_id(agas::get_locality_id()),
+            components::get_component_type<statistics_counter>(),
+            const_cast<statistics_counter*>(this));
     }
 }}}    // namespace hpx::performance_counters::server
 

--- a/libs/full/runtime_components/tests/unit/agas/local_address_rebind.cpp
+++ b/libs/full/runtime_components/tests/unit/agas/local_address_rebind.cpp
@@ -50,15 +50,16 @@ int hpx_main()
         address addr = hpx::agas::resolve(a_id).get();
 
         ///////////////////////////////////////////////////////////////////////
-        HPX_TEST_EQ(addr.address_, a.get_lva());
-        HPX_SANITY_EQ(hpx::agas::resolve(a_id).get().address_, a.get_lva());
+        HPX_TEST_EQ(addr.address_, reinterpret_cast<void*>(a.get_lva()));
+        HPX_SANITY_EQ(hpx::agas::resolve(a_id).get().address_,
+            reinterpret_cast<void*>(a.get_lva()));
 
         ///////////////////////////////////////////////////////////////////////
         // Change a's GID to point to b.
 
         // Rebind the GID.
-        std::uint64_t a_lva = addr.address_;
-        addr.address_ = b_lva;
+        void* a_lva = addr.address_;
+        addr.address_ = reinterpret_cast<void*>(b_lva);
         HPX_TEST(hpx::agas::bind_gid_local(a_gid, addr));
 
         // Update our AGAS cache.
@@ -66,7 +67,8 @@ int hpx_main()
 
         ///////////////////////////////////////////////////////////////////////
         HPX_TEST_EQ(b_lva, a.get_lva());
-        HPX_SANITY_EQ(hpx::agas::resolve(a_id).get().address_, a.get_lva());
+        HPX_SANITY_EQ(hpx::agas::resolve(a_id).get().address_,
+            reinterpret_cast<void*>(a.get_lva()));
 
         ///////////////////////////////////////////////////////////////////////
         // Now we restore the original bindings to prevent a double free.
@@ -80,7 +82,8 @@ int hpx_main()
 
         ///////////////////////////////////////////////////////////////////////
         HPX_TEST_EQ(hpx::agas::resolve(a_id).get().address_, a_lva);
-        HPX_SANITY_EQ(hpx::agas::resolve(a_id).get().address_, a.get_lva());
+        HPX_SANITY_EQ(hpx::agas::resolve(a_id).get().address_,
+            reinterpret_cast<void*>(a.get_lva()));
     }
 
     finalize();

--- a/libs/full/runtime_components/tests/unit/components/inheritance_2_classes_concrete_simple.cpp
+++ b/libs/full/runtime_components/tests/unit/components/inheritance_2_classes_concrete_simple.cpp
@@ -41,6 +41,13 @@ struct A : hpx::components::component_base<A>
         return test0();
     }
     HPX_DEFINE_COMPONENT_ACTION(A, test0_nonvirt, test0_action);
+
+    hpx::naming::address get_current_address() const
+    {
+        return hpx::naming::address(
+            hpx::naming::get_gid_from_locality_id(hpx::get_locality_id()),
+            hpx::components::get_component_type<A>(), const_cast<A*>(this));
+    }
 };
 
 typedef hpx::components::component<A> serverA_type;
@@ -61,7 +68,13 @@ struct B
 
     using hpx::components::component_base<B>::finalize;
     using hpx::components::component_base<B>::get_base_gid;
-    using hpx::components::component_base<B>::get_current_address;
+
+    hpx::naming::address get_current_address() const
+    {
+        return hpx::naming::address(
+            hpx::naming::get_gid_from_locality_id(hpx::get_locality_id()),
+            hpx::components::get_component_type<B>(), const_cast<B*>(this));
+    }
 
     typedef B type_holder;
     typedef A base_type_holder;

--- a/libs/full/runtime_components/tests/unit/components/inheritance_3_classes_2_concrete.cpp
+++ b/libs/full/runtime_components/tests/unit/components/inheritance_3_classes_2_concrete.cpp
@@ -46,6 +46,13 @@ struct A : hpx::components::component_base<A>
         return test0();
     }
     HPX_DEFINE_COMPONENT_ACTION(A, test0_nonvirt, test0_action);
+
+    hpx::naming::address get_current_address() const
+    {
+        return hpx::naming::address(
+            hpx::naming::get_gid_from_locality_id(hpx::get_locality_id()),
+            hpx::components::get_component_type<A>(), const_cast<A*>(this));
+    }
 };
 
 typedef hpx::components::component<A> serverA_type;
@@ -77,6 +84,13 @@ struct B : hpx::components::component_base<B>
         return test1();
     }
     HPX_DEFINE_COMPONENT_ACTION(B, test1_nonvirt, test1_action);
+
+    hpx::naming::address get_current_address() const
+    {
+        return hpx::naming::address(
+            hpx::naming::get_gid_from_locality_id(hpx::get_locality_id()),
+            hpx::components::get_component_type<B>(), const_cast<B*>(this));
+    }
 };
 
 typedef hpx::components::component<B> serverB_type;
@@ -98,7 +112,6 @@ struct C
 
     using hpx::components::component_base<C>::finalize;
     using hpx::components::component_base<C>::get_base_gid;
-    using hpx::components::component_base<C>::get_current_address;
 
     typedef C type_holder;
     typedef B base_type_holder;
@@ -127,6 +140,13 @@ struct C
         return "C";
     }
     HPX_DEFINE_COMPONENT_ACTION(C, test2, test2_action);
+
+    hpx::naming::address get_current_address() const
+    {
+        return hpx::naming::address(
+            hpx::naming::get_gid_from_locality_id(hpx::get_locality_id()),
+            hpx::components::get_component_type<C>(), const_cast<C*>(this));
+    }
 };
 
 typedef hpx::components::component<C> serverC_type;

--- a/libs/full/runtime_components/tests/unit/components/migrate_polymorphic_component.cpp
+++ b/libs/full/runtime_components/tests/unit/components/migrate_polymorphic_component.cpp
@@ -131,6 +131,14 @@ struct test_server_base
         // clang-format on
     }
 
+    hpx::naming::address get_current_address() const override
+    {
+        return hpx::naming::address(
+            hpx::naming::get_gid_from_locality_id(hpx::get_locality_id()),
+            hpx::components::get_component_type<test_server_base>(),
+            const_cast<test_server_base*>(this));
+    }
+
 private:
     int base_data_;
 };
@@ -224,6 +232,14 @@ struct test_server
         ar & hpx::serialization::base_object<test_server_base>(*this);
         ar & data_;
         // clang-format on
+    }
+
+    hpx::naming::address get_current_address() const override
+    {
+        return hpx::naming::address(
+            hpx::naming::get_gid_from_locality_id(hpx::get_locality_id()),
+            hpx::components::get_component_type<test_server>(),
+            const_cast<test_server*>(this));
     }
 
 private:

--- a/libs/full/runtime_distributed/include/hpx/runtime_distributed.hpp
+++ b/libs/full/runtime_distributed/include/hpx/runtime_distributed.hpp
@@ -263,7 +263,7 @@ namespace hpx {
         /// \brief Returns a string of the locality endpoints (usable in debug output)
         std::string here() const override;
 
-        std::uint64_t get_runtime_support_lva() const;
+        naming::address_type get_runtime_support_lva() const;
 
         naming::gid_type get_next_id(std::size_t count = 1);
 

--- a/libs/full/runtime_distributed/src/runtime_distributed.cpp
+++ b/libs/full/runtime_distributed/src/runtime_distributed.cpp
@@ -181,7 +181,7 @@ namespace hpx {
     ///////////////////////////////////////////////////////////////////////////
     components::server::runtime_support* get_runtime_support_ptr()
     {
-        return reinterpret_cast<components::server::runtime_support*>(
+        return static_cast<components::server::runtime_support*>(
             get_runtime_distributed().get_runtime_support_lva());
     }
 
@@ -914,9 +914,9 @@ namespace hpx {
 #endif
     }
 
-    std::uint64_t runtime_distributed::get_runtime_support_lva() const
+    naming::address_type runtime_distributed::get_runtime_support_lva() const
     {
-        return reinterpret_cast<std::uint64_t>(runtime_support_.get());
+        return runtime_support_.get();
     }
 
     naming::gid_type get_next_id(std::size_t count = 1);

--- a/src/runtime/parcelset/parcel.cpp
+++ b/src/runtime/parcelset/parcel.cpp
@@ -387,16 +387,18 @@ namespace hpx { namespace parcelset {
 
         // decode the local virtual address of the parcel
         naming::address::address_type lva = data_.addr_.address_;
+
         // by convention, a zero address references either the local
         // runtime support component or one of the AGAS components
-        if (0 == lva)
+        if (nullptr == lva)
         {
             switch (comptype)
             {
             case components::component_runtime_support:
-                lva = hpx::applier::get_applier()
-                          .get_runtime_support_raw_gid()
-                          .get_lsb();
+                lva = reinterpret_cast<naming::address::address_type>(
+                    hpx::applier::get_applier()
+                        .get_runtime_support_raw_gid()
+                        .get_lsb());
                 break;
 
             case components::component_agas_primary_namespace:

--- a/tests/regressions/actions/plain_action_move_semantics.cpp
+++ b/tests/regressions/actions/plain_action_move_semantics.cpp
@@ -68,8 +68,8 @@ std::size_t pass_movable_object_value(movable_object obj)
     return obj.get_count();
 }
 
-auto movable_object_value_void_passer =
-    hpx::actions::lambda_to_action([](movable_object) -> void {});
+//auto movable_object_value_void_passer =
+//    hpx::actions::lambda_to_action([](movable_object) -> void {});
 
 auto movable_object_value_passer = hpx::actions::lambda_to_action(
     [](movable_object obj) -> std::size_t { return obj.get_count(); });
@@ -118,8 +118,8 @@ std::size_t pass_non_movable_object_value(non_movable_object obj)
     return obj.get_count();
 }
 
-auto non_movable_object_value_void_passer =
-    hpx::actions::lambda_to_action([](non_movable_object) -> void {});
+//auto non_movable_object_value_void_passer =
+//    hpx::actions::lambda_to_action([](non_movable_object) -> void {});
 
 auto non_movable_object_value_passer = hpx::actions::lambda_to_action(
     [](non_movable_object obj) -> std::size_t { return obj.get_count(); });
@@ -268,6 +268,7 @@ void test_void_actions()
 
         // test void(movable_object const&)
         {
+            (void) movable_object_void_passer;
             HPX_TEST_EQ((pass_object_void<decltype(movable_object_void_passer),
                             movable_object>()),
                 1u);    // bind
@@ -279,6 +280,7 @@ void test_void_actions()
 
         // test void(non_movable_object const&)
         {
+            (void) non_movable_object_void_passer;
             HPX_TEST_EQ(
                 (pass_object_void<decltype(non_movable_object_void_passer),
                     non_movable_object>()),
@@ -292,6 +294,7 @@ void test_void_actions()
 
         // test void(movable_object)
         {
+            (void) movable_object_value_passer;
             HPX_TEST_EQ((pass_object_void<decltype(movable_object_value_passer),
                             movable_object>()),
                 1u);    // call
@@ -304,6 +307,7 @@ void test_void_actions()
 
         // test void(non_movable_object)
         {
+            (void) non_movable_object_value_passer;
             HPX_TEST_EQ(
                 (pass_object_void<decltype(non_movable_object_value_passer),
                     non_movable_object>()),
@@ -532,6 +536,7 @@ void test_object_actions()
             bool is_local = id == find_here();
 
             // test size_t(movable_object const&)
+            (void) movable_object_passer;
             if (is_local)
             {
                 HPX_TEST_EQ((pass_object<decltype(movable_object_passer),
@@ -556,6 +561,7 @@ void test_object_actions()
 #endif
 
             // test size_t(non_movable_object const&)
+            (void) non_movable_object_passer;
             if (is_local)
             {
                 HPX_TEST_EQ((pass_object<decltype(non_movable_object_passer),
@@ -580,6 +586,7 @@ void test_object_actions()
 #endif
 
             // test size_t(movable_object)
+            (void) movable_object_value_passer;
             if (is_local)
             {
                 HPX_TEST_EQ((pass_object<decltype(movable_object_value_passer),
@@ -604,6 +611,7 @@ void test_object_actions()
 #endif
 
             // test size_t(non_movable_object)
+            (void) non_movable_object_value_passer;
             if (is_local)
             {
                 HPX_TEST_EQ(
@@ -632,6 +640,7 @@ void test_object_actions()
 #endif
 
             // test movable_object()
+            (void) movable_object_returner;
             if (is_local)
             {
                 HPX_TEST_EQ((return_object<decltype(movable_object_returner),
@@ -648,6 +657,7 @@ void test_object_actions()
 #endif
 
             // test non_movable_object()
+            (void) non_movable_object_returner;
             if (is_local)
             {
                 //FIXME: bumped number for intel compiler


### PR DESCRIPTION
- change lva type from size_t to void*
- a lot of noexcept and constexpr additions
- removing HPX_NOEXCEPT_WITH_ASSERT (replacing it with noexcept)

No functional changes are proposed.