### PR TITLE
build: replace usage of Python's reserved words and functions as variable names

### DIFF
--- a/cmake/templates/conf.py.in
+++ b/cmake/templates/conf.py.in
@@ -517,7 +517,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'HPX'
-copyright = u'2008-2020, The STE||AR Group'
+Copyright = u'2008-2020, The STE||AR Group'
 author = u'The STE||AR Group'
 
 # The version info for the project you're documenting, acts as replacement for
@@ -691,4 +691,4 @@ texinfo_documents = [
 epub_title = project
 epub_author = author
 epub_publisher = author
-epub_copyright = copyright
+epub_copyright = Copyright

--- a/cmake/templates/conf.py.in
+++ b/cmake/templates/conf.py.in
@@ -517,7 +517,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'HPX'
-Copyright = u'2008-2020, The STE||AR Group'
+Copyright = u'2008-2021, The STE||AR Group'
 author = u'The STE||AR Group'
 
 # The version info for the project you're documenting, acts as replacement for

--- a/cmake/templates/conf.py.in
+++ b/cmake/templates/conf.py.in
@@ -77,9 +77,9 @@ for lib_dir in os.listdir(hpx_libs_dir):
         # If we are in the root of the library dir, we add all
         # subdirectories as a new breathe project
         if len(subdir) == 0:
-            for dir in dirs:
-                breathe_projects_source[dir] = (subdir_full + '/' + dir, [])
-                hpx_libs[lib_dir].append(dir)
+            for Dir in dirs:
+                breathe_projects_source[Dir] = (subdir_full + '/' + Dir, [])
+                hpx_libs[lib_dir].append(Dir)
         # We are inside a module and need to add the files
         # to the breathe project
         else:

--- a/cmake/templates/conf.py.in
+++ b/cmake/templates/conf.py.in
@@ -77,9 +77,9 @@ for lib_dir in os.listdir(hpx_libs_dir):
         # If we are in the root of the library dir, we add all
         # subdirectories as a new breathe project
         if len(subdir) == 0:
-            for Dir in dirs:
-                breathe_projects_source[Dir] = (subdir_full + '/' + Dir, [])
-                hpx_libs[lib_dir].append(Dir)
+            for directory in dirs:
+                breathe_projects_source[directory] = (subdir_full + '/' + directory, [])
+                hpx_libs[lib_dir].append(directory)
         # We are inside a module and need to add the files
         # to the breathe project
         else:
@@ -517,7 +517,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'HPX'
-Copyright = u'2008-2021, The STE||AR Group'
+project_copyright = u'2008-2021, The STE||AR Group'
 author = u'The STE||AR Group'
 
 # The version info for the project you're documenting, acts as replacement for
@@ -691,4 +691,4 @@ texinfo_documents = [
 epub_title = project
 epub_author = author
 epub_publisher = author
-epub_copyright = Copyright
+epub_copyright = project_copyright


### PR DESCRIPTION
## Proposed Changes

Sphinx configuration file uses the following words as variable names:

### `dir`

- Python already has a built-in function called `dir`. Redefining this can cause subtle and hard-to-find bugs.
- Renamed to `Dir`

### `copyright`

- `copyright` is a built-in constant in Python. From [Python documentation](https://docs.python.org/3/library/constants.html#constants-added-by-the-site-module) -- ` They [built-in constants like copyright] are useful for the interactive interpreter shell and should not be used in programs.`
- Renamed to `Copyright`


  