### PR TITLE
Support for data-parallelism for adjacent find

### DIFF
--- a/libs/core/algorithms/CMakeLists.txt
+++ b/libs/core/algorithms/CMakeLists.txt
@@ -18,6 +18,7 @@ set(algorithms_headers
     hpx/parallel/algorithms/count.hpp
     hpx/parallel/algorithms/destroy.hpp
     hpx/parallel/algorithms/detail/adjacent_difference.hpp
+    hpx/parallel/algorithms/detail/adjacent_find.hpp
     hpx/parallel/algorithms/detail/accumulate.hpp
     hpx/parallel/algorithms/detail/advance_and_get_distance.hpp
     hpx/parallel/algorithms/detail/advance_to_sentinel.hpp
@@ -153,10 +154,11 @@ set(algorithms_headers
     hpx/parallel/container_memory.hpp
     hpx/parallel/container_numeric.hpp
     hpx/parallel/datapar.hpp
+    hpx/parallel/datapar/adjacent_difference.hpp
+    hpx/parallel/datapar/adjacent_find.hpp
     hpx/parallel/datapar/fill.hpp
     hpx/parallel/datapar/find.hpp
     hpx/parallel/datapar/generate.hpp
-    hpx/parallel/datapar/adjacent_difference.hpp
     hpx/parallel/datapar/iterator_helpers.hpp
     hpx/parallel/datapar/loop.hpp
     hpx/parallel/datapar/transfer.hpp

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/detail/adjacent_find.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/detail/adjacent_find.hpp
@@ -1,0 +1,68 @@
+//  Copyright (c) 2021 Srinivas Yadav
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include <hpx/config.hpp>
+#include <hpx/execution/traits/is_execution_policy.hpp>
+#include <hpx/functional/detail/tag_fallback_invoke.hpp>
+#include <hpx/functional/invoke.hpp>
+#include <hpx/parallel/util/loop.hpp>
+#include <hpx/parallel/util/projection_identity.hpp>
+
+#include <cstddef>
+#include <functional>
+#include <iostream>
+#include <type_traits>
+
+namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
+
+    template <typename ExPolicy>
+    struct sequential_adjacent_find_t
+      : hpx::functional::detail::tag_fallback<
+            sequential_adjacent_find_t<ExPolicy>>
+    {
+    private:
+        template <typename InIter, typename Sent_, typename PredProj>
+        friend inline InIter tag_fallback_invoke(
+            sequential_adjacent_find_t<ExPolicy>, InIter first, Sent_ last,
+            PredProj&& pred_projected)
+        {
+            return std::adjacent_find(
+                first, last, std::forward<PredProj>(pred_projected));
+        }
+
+        template <typename ZipIter, typename Token, typename PredProj>
+        friend inline void tag_fallback_invoke(
+            sequential_adjacent_find_t<ExPolicy>, std::size_t base_idx,
+            ZipIter part_begin, std::size_t part_count, Token& tok,
+            PredProj&& pred_projected)
+        {
+            util::loop_idx_n<ExPolicy>(base_idx, part_begin, part_count, tok,
+                [&pred_projected, &tok](auto t, std::size_t i) {
+                    using hpx::get;
+                    if (pred_projected(get<0>(t), get<1>(t)))
+                        tok.cancel(i);
+                });
+        }
+    };
+
+#if !defined(HPX_COMPUTE_DEVICE_CODE)
+    template <typename ExPolicy>
+    HPX_INLINE_CONSTEXPR_VARIABLE sequential_adjacent_find_t<ExPolicy>
+        sequential_adjacent_find = sequential_adjacent_find_t<ExPolicy>{};
+#else
+    template <typename ExPolicy, typename InIter, typename Sent_,
+        typename PredProj>
+    HPX_HOST_DEVICE HPX_FORCEINLINE InIter sequential_adjacent_find(
+        InIter first, Sent_ last, PredProj&& pred_projected)
+    {
+        return sequential_adjacent_find_t<ExPolicy>{}(
+            first, last, std::forward<PredProj>(pred_projected));
+    }
+#endif
+
+}}}}    // namespace hpx::parallel::v1::detail

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/detail/adjacent_find.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/detail/adjacent_find.hpp
@@ -52,7 +52,7 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
 
 #if !defined(HPX_COMPUTE_DEVICE_CODE)
     template <typename ExPolicy>
-    HPX_INLINE_CONSTEXPR_VARIABLE sequential_adjacent_find_t<ExPolicy>
+    inline constexpr sequential_adjacent_find_t<ExPolicy>
         sequential_adjacent_find = sequential_adjacent_find_t<ExPolicy>{};
 #else
     template <typename ExPolicy, typename InIter, typename Sent_,

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/detail/adjacent_find.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/detail/adjacent_find.hpp
@@ -32,7 +32,7 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
             PredProj&& pred_projected)
         {
             return std::adjacent_find(
-                first, last, std::forward<PredProj>(pred_projected));
+                first, last, HPX_FORWARD(PredProj, pred_projected));
         }
 
         template <typename ZipIter, typename Token, typename PredProj>
@@ -61,7 +61,7 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
         InIter first, Sent_ last, PredProj&& pred_projected)
     {
         return sequential_adjacent_find_t<ExPolicy>{}(
-            first, last, std::forward<PredProj>(pred_projected));
+            first, last, HPX_FORWARD(PredProj, pred_projected));
     }
 #endif
 

--- a/libs/core/algorithms/include/hpx/parallel/datapar.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/datapar.hpp
@@ -13,6 +13,7 @@
 
 #include <hpx/executors/datapar/execution_policy.hpp>
 #include <hpx/parallel/datapar/adjacent_difference.hpp>
+#include <hpx/parallel/datapar/adjacent_find.hpp>
 #include <hpx/parallel/datapar/fill.hpp>
 #include <hpx/parallel/datapar/find.hpp>
 #include <hpx/parallel/datapar/generate.hpp>

--- a/libs/core/algorithms/include/hpx/parallel/datapar/adjacent_find.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/datapar/adjacent_find.hpp
@@ -13,6 +13,7 @@
 #include <hpx/execution/traits/is_execution_policy.hpp>
 #include <hpx/execution/traits/vector_pack_all_any_none.hpp>
 #include <hpx/execution/traits/vector_pack_find.hpp>
+#include <hpx/executors/datapar/execution_policy.hpp>
 #include <hpx/functional/tag_invoke.hpp>
 #include <hpx/parallel/algorithms/detail/adjacent_find.hpp>
 #include <hpx/parallel/datapar/iterator_helpers.hpp>
@@ -84,6 +85,19 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
             first, last, std::forward<PredProj>(pred_projected));
     }
 
+    template <typename ExPolicy, typename InIter, typename Sent_,
+        typename PredProj,
+        HPX_CONCEPT_REQUIRES_(
+            hpx::is_vectorpack_execution_policy<ExPolicy>::value &&
+            !hpx::parallel::util::detail::iterator_datapar_compatible<
+                InIter>::value)>
+    inline InIter tag_invoke(sequential_adjacent_find_t<ExPolicy>, InIter first,
+        Sent_ last, PredProj&& pred_projected)
+    {
+        return sequential_adjacent_find<typename ExPolicy::base_policy_type>(
+            first, last, std::forward<PredProj>(pred_projected));
+    }
+
     template <typename ExPolicy, typename ZipIter, typename Token,
         typename PredProj,
         HPX_CONCEPT_REQUIRES_(
@@ -98,5 +112,19 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
             part_count, tok, std::forward<PredProj>(pred_projected));
     }
 
+    template <typename ExPolicy, typename ZipIter, typename Token,
+        typename PredProj,
+        HPX_CONCEPT_REQUIRES_(
+            hpx::is_vectorpack_execution_policy<ExPolicy>::value &&
+            !hpx::parallel::util::detail::iterator_datapar_compatible<
+                ZipIter>::value)>
+    inline void tag_invoke(sequential_adjacent_find_t<ExPolicy>,
+        std::size_t base_idx, ZipIter part_begin, std::size_t part_count,
+        Token& tok, PredProj&& pred_projected)
+    {
+        return sequential_adjacent_find<typename ExPolicy::base_policy_type>(
+            base_idx, part_begin, part_count, tok,
+            std::forward<PredProj>(pred_projected));
+    }
 }}}}    // namespace hpx::parallel::v1::detail
 #endif

--- a/libs/core/algorithms/include/hpx/parallel/datapar/adjacent_find.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/datapar/adjacent_find.hpp
@@ -1,0 +1,102 @@
+//  Copyright (c) 2021 Srinivas Yadav
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include <hpx/config.hpp>
+
+#if defined(HPX_HAVE_DATAPAR)
+#include <hpx/concepts/concepts.hpp>
+#include <hpx/execution/traits/is_execution_policy.hpp>
+#include <hpx/execution/traits/vector_pack_all_any_none.hpp>
+#include <hpx/execution/traits/vector_pack_find.hpp>
+#include <hpx/functional/tag_invoke.hpp>
+#include <hpx/parallel/algorithms/detail/adjacent_find.hpp>
+#include <hpx/parallel/datapar/iterator_helpers.hpp>
+#include <hpx/parallel/datapar/loop.hpp>
+#include <hpx/parallel/datapar/zip_iterator.hpp>
+#include <hpx/parallel/util/result_types.hpp>
+
+#include <cstddef>
+#include <type_traits>
+#include <utility>
+
+namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
+
+    ///////////////////////////////////////////////////////////////////////////
+    template <typename ExPolicy>
+    struct datapar_adjacent_find
+    {
+        template <typename InIter, typename Sent_, typename PredProj>
+        static inline InIter call(
+            InIter first, Sent_ last, PredProj&& pred_projected)
+        {
+            if (first == last)
+                return last;
+
+            InIter next = first;
+            ++next;
+
+            auto zip_iter = hpx::util::make_zip_iterator(first, next);
+            std::size_t count = std::distance(first, last);
+            util::cancellation_token<std::size_t> tok(count);
+
+            call(0, zip_iter, count - 1, tok,
+                std::forward<PredProj>(pred_projected));
+
+            std::size_t adj_find_res = tok.get_data();
+            if (adj_find_res != count)
+                std::advance(first, adj_find_res);
+            else
+                first = last;
+
+            return first;
+        }
+
+        template <typename ZipIter, typename Token, typename PredProj>
+        static inline void call(std::size_t base_idx, ZipIter part_begin,
+            std::size_t part_count, Token& tok, PredProj&& pred_projected)
+        {
+            util::loop_idx_n<ExPolicy>(base_idx, part_begin, part_count, tok,
+                [&pred_projected, &tok](auto&& t, std::size_t i) {
+                    using hpx::get;
+                    auto msk = pred_projected(get<0>(t), get<1>(t));
+                    int offset = hpx::parallel::traits::find_first_of(msk);
+                    if (offset != -1)
+                        tok.cancel(i + offset);
+                });
+        }
+    };
+
+    template <typename ExPolicy, typename InIter, typename Sent_,
+        typename PredProj,
+        HPX_CONCEPT_REQUIRES_(
+            hpx::is_vectorpack_execution_policy<ExPolicy>::value&&
+                hpx::parallel::util::detail::iterator_datapar_compatible<
+                    InIter>::value)>
+    inline InIter tag_invoke(sequential_adjacent_find_t<ExPolicy>, InIter first,
+        Sent_ last, PredProj&& pred_projected)
+    {
+        return datapar_adjacent_find<ExPolicy>::call(
+            first, last, std::forward<PredProj>(pred_projected));
+    }
+
+    template <typename ExPolicy, typename ZipIter, typename Token,
+        typename PredProj,
+        HPX_CONCEPT_REQUIRES_(
+            hpx::is_vectorpack_execution_policy<ExPolicy>::value&&
+                hpx::parallel::util::detail::iterator_datapar_compatible<
+                    ZipIter>::value)>
+    inline void tag_invoke(sequential_adjacent_find_t<ExPolicy>,
+        std::size_t base_idx, ZipIter part_begin, std::size_t part_count,
+        Token& tok, PredProj&& pred_projected)
+    {
+        return datapar_adjacent_find<ExPolicy>::call(base_idx, part_begin,
+            part_count, tok, std::forward<PredProj>(pred_projected));
+    }
+
+}}}}    // namespace hpx::parallel::v1::detail
+#endif

--- a/libs/core/algorithms/tests/unit/algorithms/CMakeLists.txt
+++ b/libs/core/algorithms/tests/unit/algorithms/CMakeLists.txt
@@ -19,11 +19,7 @@ endforeach()
 set(tests
     adjacentdifference
     adjacentfind
-    adjacentfind_exception
-    adjacentfind_bad_alloc
     adjacentfind_binary
-    adjacentfind_binary_exception
-    adjacentfind_binary_bad_alloc
     all_of
     any_of
     copy

--- a/libs/core/algorithms/tests/unit/algorithms/adjacentfind.cpp
+++ b/libs/core/algorithms/tests/unit/algorithms/adjacentfind.cpp
@@ -1,80 +1,19 @@
+//  Copyright (c) 2021 Srinivas Yadav
 //  Copyright (c) 2014 Grant Mercer
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include <hpx/local/algorithm.hpp>
 #include <hpx/local/init.hpp>
-#include <hpx/modules/testing.hpp>
 
-#include <cstddef>
 #include <iostream>
-#include <iterator>
-#include <numeric>
-#include <random>
 #include <string>
 #include <vector>
 
-#include "test_utils.hpp"
+#include "adjacentfind_tests.hpp"
 
 ////////////////////////////////////////////////////////////////////////////
-unsigned int seed = std::random_device{}();
-std::mt19937 gen(seed);
-std::uniform_int_distribution<> dis(2, 101);
-std::uniform_int_distribution<> dist(2, 10005);
-
-template <typename ExPolicy, typename IteratorTag>
-void test_adjacent_find(ExPolicy policy, IteratorTag)
-{
-    static_assert(hpx::is_execution_policy<ExPolicy>::value,
-        "hpx::is_execution_policy<ExPolicy>::value");
-
-    typedef std::vector<std::size_t>::iterator base_iterator;
-    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
-
-    // fill vector with random values about 1
-    std::vector<std::size_t> c(10007);
-    std::iota(std::begin(c), std::end(c), dis(gen));
-
-    std::size_t random_pos = dist(gen);    //-V101
-
-    c[random_pos] = 1;
-    c[random_pos + 1] = 1;
-
-    iterator index = hpx::adjacent_find(
-        policy, iterator(std::begin(c)), iterator(std::end(c)));
-
-    base_iterator test_index = std::begin(c) + random_pos;
-
-    HPX_TEST(index == iterator(test_index));
-}
-
-template <typename ExPolicy, typename IteratorTag>
-void test_adjacent_find_async(ExPolicy p, IteratorTag)
-{
-    typedef std::vector<std::size_t>::iterator base_iterator;
-    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
-
-    // fill vector with random values above 1
-    std::vector<std::size_t> c(10007);
-    std::iota(std::begin(c), std::end(c), dis(gen));
-
-    std::size_t random_pos = dist(gen);    //-V101
-
-    c[random_pos] = 1;
-    c[random_pos + 1] = 1;
-
-    hpx::future<iterator> f =
-        hpx::adjacent_find(p, iterator(std::begin(c)), iterator(std::end(c)));
-    f.wait();
-
-    // create iterator at position of value to be found
-    base_iterator test_index = std::begin(c) + random_pos;
-
-    HPX_TEST(f.get() == iterator(test_index));
-}
-
 template <typename IteratorTag>
 void test_adjacent_find()
 {
@@ -93,6 +32,50 @@ void adjacent_find_test()
     test_adjacent_find<std::forward_iterator_tag>();
 }
 
+////////////////////////////////////////////////////////////////////////////
+template <typename IteratorTag>
+void test_adjacent_find_exception()
+{
+    using namespace hpx::execution;
+
+    // If the execution policy object is of type vector_execution_policy,
+    // std::terminate shall be called. therefore we do not test exceptions
+    // with a vector execution policy
+    test_adjacent_find_exception(seq, IteratorTag());
+    test_adjacent_find_exception(par, IteratorTag());
+
+    test_adjacent_find_exception_async(seq(task), IteratorTag());
+    test_adjacent_find_exception_async(par(task), IteratorTag());
+}
+
+void adjacent_find_exception_test()
+{
+    test_adjacent_find_exception<std::random_access_iterator_tag>();
+    test_adjacent_find_exception<std::forward_iterator_tag>();
+}
+
+////////////////////////////////////////////////////////////////////////////
+template <typename IteratorTag>
+void test_adjacent_find_bad_alloc()
+{
+    using namespace hpx::execution;
+
+    // If the execution policy object is of type vector_execution_policy,
+    // std::terminate shall be called. therefore we do not test exceptions
+    // with a vector execution policy
+    test_adjacent_find_bad_alloc(seq, IteratorTag());
+    test_adjacent_find_bad_alloc(par, IteratorTag());
+
+    test_adjacent_find_bad_alloc_async(seq(task), IteratorTag());
+    test_adjacent_find_bad_alloc_async(par(task), IteratorTag());
+}
+
+void adjacent_find_bad_alloc_test()
+{
+    test_adjacent_find_bad_alloc<std::random_access_iterator_tag>();
+    test_adjacent_find_bad_alloc<std::forward_iterator_tag>();
+}
+
 int hpx_main(hpx::program_options::variables_map& vm)
 {
     if (vm.count("seed"))
@@ -102,6 +85,8 @@ int hpx_main(hpx::program_options::variables_map& vm)
     gen.seed(seed);
 
     adjacent_find_test();
+    adjacent_find_exception_test();
+    adjacent_find_bad_alloc_test();
     return hpx::local::finalize();
 }
 

--- a/libs/core/algorithms/tests/unit/algorithms/adjacentfind_binary.cpp
+++ b/libs/core/algorithms/tests/unit/algorithms/adjacentfind_binary.cpp
@@ -1,79 +1,19 @@
+//  Copyright (c) 2021 Srinivas Yadav
 //  Copyright (c) 2014 Grant Mercer
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include <hpx/local/algorithm.hpp>
 #include <hpx/local/init.hpp>
-#include <hpx/modules/testing.hpp>
 
-#include <cstddef>
 #include <iostream>
-#include <iterator>
-#include <numeric>
-#include <random>
 #include <string>
 #include <vector>
 
-#include "test_utils.hpp"
+#include "adjacentfind_binary_tests.hpp"
 
 ////////////////////////////////////////////////////////////////////////////
-unsigned int seed = std::random_device{}();
-std::mt19937 gen(seed);
-std::uniform_int_distribution<> dis(2, 101);
-std::uniform_int_distribution<> dist(2, 10005);
-
-template <typename ExPolicy, typename IteratorTag>
-void test_adjacent_find(ExPolicy policy, IteratorTag)
-{
-    static_assert(hpx::is_execution_policy<ExPolicy>::value,
-        "hpx::is_execution_policy<ExPolicy>::value");
-
-    typedef std::vector<std::size_t>::iterator base_iterator;
-    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
-
-    std::vector<std::size_t> c(10007);
-    //fill vector with random values about 1
-    std::iota(std::begin(c), std::end(c), dis(gen));
-
-    std::size_t random_pos = dist(gen);    //-V101
-
-    c[random_pos] = 100000;
-    c[random_pos + 1] = 1;
-
-    iterator index = hpx::adjacent_find(policy, iterator(std::begin(c)),
-        iterator(std::end(c)), std::greater<std::size_t>());
-
-    base_iterator test_index = std::begin(c) + random_pos;
-
-    HPX_TEST(index == iterator(test_index));
-}
-
-template <typename ExPolicy, typename IteratorTag>
-void test_adjacent_find_async(ExPolicy p, IteratorTag)
-{
-    typedef std::vector<std::size_t>::iterator base_iterator;
-    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
-
-    // fill vector with random values above 1
-    std::vector<std::size_t> c(10007);
-    std::iota(std::begin(c), std::end(c), dis(gen));
-
-    std::size_t random_pos = dist(gen);    //-V101
-
-    c[random_pos] = 100000;
-    c[random_pos + 1] = 1;
-
-    hpx::future<iterator> f = hpx::adjacent_find(p, iterator(std::begin(c)),
-        iterator(std::end(c)), std::greater<std::size_t>());
-    f.wait();
-
-    // create iterator at position of value to be found
-    base_iterator test_index = std::begin(c) + random_pos;
-    HPX_TEST(f.get() == iterator(test_index));
-}
-
 template <typename IteratorTag>
 void test_adjacent_find()
 {
@@ -92,6 +32,50 @@ void adjacent_find_test()
     test_adjacent_find<std::forward_iterator_tag>();
 }
 
+////////////////////////////////////////////////////////////////////////////
+template <typename IteratorTag>
+void test_adjacent_find_exception()
+{
+    using namespace hpx::execution;
+
+    // If the execution policy object is of type vector_execution_policy,
+    // std::terminate shall be called. therefore we do not test exceptions
+    // with a vector execution policy
+    test_adjacent_find_exception(seq, IteratorTag());
+    test_adjacent_find_exception(par, IteratorTag());
+
+    test_adjacent_find_exception_async(seq(task), IteratorTag());
+    test_adjacent_find_exception_async(par(task), IteratorTag());
+}
+
+void adjacent_find_exception_test()
+{
+    test_adjacent_find_exception<std::random_access_iterator_tag>();
+    test_adjacent_find_exception<std::forward_iterator_tag>();
+}
+
+////////////////////////////////////////////////////////////////////////////
+template <typename IteratorTag>
+void test_adjacent_find_bad_alloc()
+{
+    using namespace hpx::execution;
+
+    // If the execution policy object is of type vector_execution_policy,
+    // std::terminate shall be called. therefore we do not test exceptions
+    // with a vector execution policy
+    test_adjacent_find_bad_alloc(seq, IteratorTag());
+    test_adjacent_find_bad_alloc(par, IteratorTag());
+
+    test_adjacent_find_bad_alloc_async(seq(task), IteratorTag());
+    test_adjacent_find_bad_alloc_async(par(task), IteratorTag());
+}
+
+void adjacent_find_bad_alloc_test()
+{
+    test_adjacent_find_bad_alloc<std::random_access_iterator_tag>();
+    test_adjacent_find_bad_alloc<std::forward_iterator_tag>();
+}
+
 int hpx_main(hpx::program_options::variables_map& vm)
 {
     if (vm.count("seed"))
@@ -101,6 +85,8 @@ int hpx_main(hpx::program_options::variables_map& vm)
     gen.seed(seed);
 
     adjacent_find_test();
+    adjacent_find_exception_test();
+    adjacent_find_bad_alloc_test();
     return hpx::local::finalize();
 }
 

--- a/libs/core/algorithms/tests/unit/algorithms/adjacentfind_binary_tests.hpp
+++ b/libs/core/algorithms/tests/unit/algorithms/adjacentfind_binary_tests.hpp
@@ -1,0 +1,224 @@
+//  Copyright (c) 2014 Grant Mercer
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include <hpx/local/init.hpp>
+#include <hpx/modules/testing.hpp>
+#include <hpx/parallel/algorithms/adjacent_find.hpp>
+
+#include <cstddef>
+#include <iostream>
+#include <iterator>
+#include <numeric>
+#include <random>
+#include <string>
+#include <vector>
+
+#include "test_utils.hpp"
+
+////////////////////////////////////////////////////////////////////////////
+unsigned int seed = std::random_device{}();
+std::mt19937 gen(seed);
+std::uniform_int_distribution<> dis(2, 101);
+std::uniform_int_distribution<> dist(2, 10005);
+
+template <typename ExPolicy, typename IteratorTag>
+void test_adjacent_find(ExPolicy policy, IteratorTag)
+{
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
+
+    typedef std::vector<int>::iterator base_iterator;
+    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+
+    std::vector<int> c(10007);
+    //fill vector with random values about 1
+    std::iota(std::begin(c), std::end(c), dis(gen));
+
+    std::size_t random_pos = dist(gen);    //-V101
+
+    c[random_pos] = 100000;
+    c[random_pos + 1] = 1;
+
+    iterator index = hpx::adjacent_find(policy, iterator(std::begin(c)),
+        iterator(std::end(c)), std::greater<int>());
+
+    base_iterator test_index = std::begin(c) + random_pos;
+
+    HPX_TEST(index == iterator(test_index));
+}
+
+template <typename ExPolicy, typename IteratorTag>
+void test_adjacent_find_async(ExPolicy p, IteratorTag)
+{
+    typedef std::vector<int>::iterator base_iterator;
+    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+
+    // fill vector with random values above 1
+    std::vector<int> c(10007);
+    std::iota(std::begin(c), std::end(c), dis(gen));
+
+    std::size_t random_pos = dist(gen);    //-V101
+
+    c[random_pos] = 100000;
+    c[random_pos + 1] = 1;
+
+    hpx::future<iterator> f = hpx::adjacent_find(
+        p, iterator(std::begin(c)), iterator(std::end(c)), std::greater<int>());
+    f.wait();
+
+    // create iterator at position of value to be found
+    base_iterator test_index = std::begin(c) + random_pos;
+    HPX_TEST(f.get() == iterator(test_index));
+}
+
+////////////////////////////////////////////////////////////////////////////
+template <typename ExPolicy, typename IteratorTag>
+void test_adjacent_find_exception(ExPolicy policy, IteratorTag)
+{
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
+
+    typedef std::vector<int>::iterator base_iterator;
+    typedef test::decorated_iterator<base_iterator, IteratorTag>
+        decorated_iterator;
+    std::vector<int> c(10007);
+    std::iota(std::begin(c), std::end(c), gen() + 1);
+
+    bool caught_exception = false;
+    try
+    {
+        hpx::adjacent_find(policy,
+            decorated_iterator(
+                std::begin(c), []() { throw std::runtime_error("test"); }),
+            decorated_iterator(std::end(c)), std::greater<int>());
+        HPX_TEST(false);
+    }
+    catch (hpx::exception_list const& e)
+    {
+        caught_exception = true;
+        test::test_num_exceptions<ExPolicy, IteratorTag>::call(policy, e);
+    }
+    catch (...)
+    {
+        HPX_TEST(false);
+    }
+
+    HPX_TEST(caught_exception);
+}
+
+template <typename ExPolicy, typename IteratorTag>
+void test_adjacent_find_exception_async(ExPolicy p, IteratorTag)
+{
+    typedef std::vector<int>::iterator base_iterator;
+    typedef test::decorated_iterator<base_iterator, IteratorTag>
+        decorated_iterator;
+
+    std::vector<int> c(10007);
+    std::iota(std::begin(c), std::end(c), gen() + 1);
+
+    bool caught_exception = false;
+    bool returned_from_algorithm = false;
+
+    try
+    {
+        hpx::future<decorated_iterator> f = hpx::adjacent_find(p,
+            decorated_iterator(
+                std::begin(c), []() { throw std::runtime_error("test"); }),
+            decorated_iterator(std::end(c)), std::greater<int>());
+
+        returned_from_algorithm = true;
+
+        f.get();
+
+        HPX_TEST(false);
+    }
+    catch (hpx::exception_list const& e)
+    {
+        caught_exception = true;
+        test::test_num_exceptions<ExPolicy, IteratorTag>::call(p, e);
+    }
+    catch (...)
+    {
+        HPX_TEST(false);
+    }
+
+    HPX_TEST(returned_from_algorithm);
+    HPX_TEST(caught_exception);
+}
+
+////////////////////////////////////////////////////////////////////////////
+template <typename ExPolicy, typename IteratorTag>
+void test_adjacent_find_bad_alloc(ExPolicy policy, IteratorTag)
+{
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
+
+    typedef std::vector<int>::iterator base_iterator;
+    typedef test::decorated_iterator<base_iterator, IteratorTag>
+        decorated_iterator;
+
+    std::vector<int> c(10007);
+    std::iota(std::begin(c), std::end(c), gen() + 1);
+
+    bool caught_bad_alloc = false;
+    try
+    {
+        hpx::adjacent_find(policy,
+            decorated_iterator(std::begin(c), []() { throw std::bad_alloc(); }),
+            decorated_iterator(std::end(c)), std::greater<int>());
+        HPX_TEST(false);
+    }
+    catch (std::bad_alloc const&)
+    {
+        caught_bad_alloc = true;
+    }
+    catch (...)
+    {
+        HPX_TEST(false);
+    }
+
+    HPX_TEST(caught_bad_alloc);
+}
+
+template <typename ExPolicy, typename IteratorTag>
+void test_adjacent_find_bad_alloc_async(ExPolicy p, IteratorTag)
+{
+    typedef std::vector<int>::iterator base_iterator;
+    typedef test::decorated_iterator<base_iterator, IteratorTag>
+        decorated_iterator;
+
+    std::vector<int> c(10007);
+    std::iota(std::begin(c), std::end(c), gen() + 1);
+
+    bool returned_from_algorithm = false;
+    bool caught_bad_alloc = false;
+
+    try
+    {
+        hpx::future<decorated_iterator> f = hpx::adjacent_find(p,
+            decorated_iterator(std::begin(c), []() { throw std::bad_alloc(); }),
+            decorated_iterator(std::end(c)), std::greater<int>());
+
+        returned_from_algorithm = true;
+
+        f.get();
+
+        HPX_TEST(false);
+    }
+    catch (std::bad_alloc const&)
+    {
+        caught_bad_alloc = true;
+    }
+    catch (...)
+    {
+        HPX_TEST(false);
+    }
+
+    HPX_TEST(caught_bad_alloc);
+    HPX_TEST(returned_from_algorithm);
+}

--- a/libs/core/algorithms/tests/unit/algorithms/adjacentfind_tests.hpp
+++ b/libs/core/algorithms/tests/unit/algorithms/adjacentfind_tests.hpp
@@ -1,0 +1,225 @@
+//  Copyright (c) 2014 Grant Mercer
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include <hpx/local/init.hpp>
+#include <hpx/modules/testing.hpp>
+#include <hpx/parallel/algorithms/adjacent_find.hpp>
+
+#include <cstddef>
+#include <iostream>
+#include <iterator>
+#include <numeric>
+#include <random>
+#include <string>
+#include <vector>
+
+#include "test_utils.hpp"
+
+////////////////////////////////////////////////////////////////////////////
+unsigned int seed = std::random_device{}();
+std::mt19937 gen(seed);
+std::uniform_int_distribution<> dis(2, 101);
+std::uniform_int_distribution<> dist(2, 10005);
+
+template <typename ExPolicy, typename IteratorTag>
+void test_adjacent_find(ExPolicy policy, IteratorTag)
+{
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
+
+    typedef std::vector<int>::iterator base_iterator;
+    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+
+    // fill vector with random values about 1
+    std::vector<int> c(10007);
+    std::iota(std::begin(c), std::end(c), dis(gen));
+
+    std::size_t random_pos = dist(gen);    //-V101
+
+    c[random_pos] = 1;
+    c[random_pos + 1] = 1;
+
+    iterator index = hpx::adjacent_find(
+        policy, iterator(std::begin(c)), iterator(std::end(c)));
+
+    base_iterator test_index = std::begin(c) + random_pos;
+
+    HPX_TEST(index == iterator(test_index));
+}
+
+template <typename ExPolicy, typename IteratorTag>
+void test_adjacent_find_async(ExPolicy p, IteratorTag)
+{
+    typedef std::vector<int>::iterator base_iterator;
+    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+
+    // fill vector with random values above 1
+    std::vector<int> c(10007);
+    std::iota(std::begin(c), std::end(c), dis(gen));
+
+    std::size_t random_pos = dist(gen);    //-V101
+
+    c[random_pos] = 1;
+    c[random_pos + 1] = 1;
+
+    hpx::future<iterator> f =
+        hpx::adjacent_find(p, iterator(std::begin(c)), iterator(std::end(c)));
+    f.wait();
+
+    // create iterator at position of value to be found
+    base_iterator test_index = std::begin(c) + random_pos;
+
+    HPX_TEST(f.get() == iterator(test_index));
+}
+
+////////////////////////////////////////////////////////////////////////////
+template <typename ExPolicy, typename IteratorTag>
+void test_adjacent_find_exception(ExPolicy policy, IteratorTag)
+{
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
+
+    typedef std::vector<int>::iterator base_iterator;
+    typedef test::decorated_iterator<base_iterator, IteratorTag>
+        decorated_iterator;
+    std::vector<int> c(10007);
+    std::iota(std::begin(c), std::end(c), gen() + 1);
+
+    bool caught_exception = false;
+    try
+    {
+        hpx::adjacent_find(policy,
+            decorated_iterator(
+                std::begin(c), []() { throw std::runtime_error("test"); }),
+            decorated_iterator(std::end(c)));
+        HPX_TEST(false);
+    }
+    catch (hpx::exception_list const& e)
+    {
+        caught_exception = true;
+        test::test_num_exceptions<ExPolicy, IteratorTag>::call(policy, e);
+    }
+    catch (...)
+    {
+        HPX_TEST(false);
+    }
+
+    HPX_TEST(caught_exception);
+}
+
+template <typename ExPolicy, typename IteratorTag>
+void test_adjacent_find_exception_async(ExPolicy p, IteratorTag)
+{
+    typedef std::vector<int>::iterator base_iterator;
+    typedef test::decorated_iterator<base_iterator, IteratorTag>
+        decorated_iterator;
+
+    std::vector<int> c(10007);
+    std::iota(std::begin(c), std::end(c), gen() + 1);
+
+    bool caught_exception = false;
+    bool returned_from_algorithm = false;
+
+    try
+    {
+        hpx::future<decorated_iterator> f = hpx::adjacent_find(p,
+            decorated_iterator(
+                std::begin(c), []() { throw std::runtime_error("test"); }),
+            decorated_iterator(std::end(c)));
+
+        returned_from_algorithm = true;
+
+        f.get();
+
+        HPX_TEST(false);
+    }
+    catch (hpx::exception_list const& e)
+    {
+        caught_exception = true;
+        test::test_num_exceptions<ExPolicy, IteratorTag>::call(p, e);
+    }
+    catch (...)
+    {
+        HPX_TEST(false);
+    }
+
+    HPX_TEST(caught_exception);
+    HPX_TEST(returned_from_algorithm);
+}
+
+////////////////////////////////////////////////////////////////////////////
+template <typename ExPolicy, typename IteratorTag>
+void test_adjacent_find_bad_alloc(ExPolicy policy, IteratorTag)
+{
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
+
+    typedef std::vector<int>::iterator base_iterator;
+    typedef test::decorated_iterator<base_iterator, IteratorTag>
+        decorated_iterator;
+
+    std::vector<int> c(10007);
+    std::iota(std::begin(c), std::end(c), gen() + 1);
+
+    bool caught_bad_alloc = false;
+    try
+    {
+        hpx::adjacent_find(policy,
+            decorated_iterator(std::begin(c), []() { throw std::bad_alloc(); }),
+            decorated_iterator(std::end(c)));
+        HPX_TEST(false);
+    }
+    catch (std::bad_alloc const&)
+    {
+        caught_bad_alloc = true;
+    }
+    catch (...)
+    {
+        HPX_TEST(false);
+    }
+
+    HPX_TEST(caught_bad_alloc);
+}
+
+template <typename ExPolicy, typename IteratorTag>
+void test_adjacent_find_bad_alloc_async(ExPolicy p, IteratorTag)
+{
+    typedef std::vector<int>::iterator base_iterator;
+    typedef test::decorated_iterator<base_iterator, IteratorTag>
+        decorated_iterator;
+
+    std::vector<int> c(10007);
+    std::iota(std::begin(c), std::end(c), gen() + 1);
+
+    bool caught_bad_alloc = false;
+    bool returned_from_algorithm = false;
+
+    try
+    {
+        hpx::future<decorated_iterator> f = hpx::adjacent_find(p,
+            decorated_iterator(std::begin(c), []() { throw std::bad_alloc(); }),
+            decorated_iterator(std::end(c)));
+
+        returned_from_algorithm = true;
+
+        f.get();
+
+        HPX_TEST(false);
+    }
+    catch (std::bad_alloc const&)
+    {
+        caught_bad_alloc = true;
+    }
+    catch (...)
+    {
+        HPX_TEST(false);
+    }
+
+    HPX_TEST(caught_bad_alloc);
+    HPX_TEST(returned_from_algorithm);
+}

--- a/libs/core/algorithms/tests/unit/datapar_algorithms/CMakeLists.txt
+++ b/libs/core/algorithms/tests/unit/datapar_algorithms/CMakeLists.txt
@@ -9,6 +9,7 @@ set(tests)
 if(HPX_WITH_DATAPAR_VC OR HPX_WITH_CXX20_EXPERIMENTAL_SIMD)
   set(tests
       ${tests}
+      adjacentfind_datapar
       adjacentdifference_datapar
       all_of_datapar
       any_of_datapar
@@ -26,6 +27,7 @@ if(HPX_WITH_DATAPAR_VC OR HPX_WITH_CXX20_EXPERIMENTAL_SIMD)
       none_of_datapar
       transform_binary_datapar
       transform_binary2_datapar
+      transform_datapar
       transform_reduce_binary_datapar
   )
 endif()

--- a/libs/core/algorithms/tests/unit/datapar_algorithms/adjacentfind_datapar.cpp
+++ b/libs/core/algorithms/tests/unit/datapar_algorithms/adjacentfind_datapar.cpp
@@ -1,0 +1,107 @@
+//  Copyright (c) 2021 Srinivas Yadav
+//  Copyright (c) 2014-2020 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/include/datapar.hpp>
+#include <hpx/local/init.hpp>
+
+#include <iostream>
+#include <string>
+#include <vector>
+
+#include "../algorithms/adjacentfind_tests.hpp"
+
+////////////////////////////////////////////////////////////////////////////
+template <typename IteratorTag>
+void test_adjacent_find()
+{
+    using namespace hpx::execution;
+    test_adjacent_find(simd, IteratorTag());
+    test_adjacent_find(par_simd, IteratorTag());
+
+    test_adjacent_find_async(simd(task), IteratorTag());
+    test_adjacent_find_async(par_simd(task), IteratorTag());
+}
+
+void adjacent_find_test()
+{
+    test_adjacent_find<std::random_access_iterator_tag>();
+    // test_adjacent_find<std::forward_iterator_tag>();
+}
+
+//////////////////////////////////////////////////////////////////////////
+template <typename IteratorTag>
+void test_adjacent_find_exception()
+{
+    using namespace hpx::execution;
+    test_adjacent_find_exception(simd, IteratorTag());
+    test_adjacent_find_exception(par_simd, IteratorTag());
+
+    test_adjacent_find_exception_async(simd(task), IteratorTag());
+    test_adjacent_find_exception_async(par_simd(task), IteratorTag());
+}
+
+void adjacent_find_exception_test()
+{
+    test_adjacent_find_exception<std::random_access_iterator_tag>();
+    // test_adjacent_find_exception<std::forward_iterator_tag>();
+}
+
+//////////////////////////////////////////////////////////////////////////
+template <typename IteratorTag>
+void test_adjacent_find_bad_alloc()
+{
+    using namespace hpx::execution;
+    test_adjacent_find_bad_alloc(simd, IteratorTag());
+    test_adjacent_find_bad_alloc(par_simd, IteratorTag());
+
+    test_adjacent_find_bad_alloc_async(simd(task), IteratorTag());
+    test_adjacent_find_bad_alloc_async(par_simd(task), IteratorTag());
+}
+
+void adjacent_find_bad_alloc_test()
+{
+    test_adjacent_find_bad_alloc<std::random_access_iterator_tag>();
+    // test_adjacent_find_bad_alloc<std::forward_iterator_tag>();
+}
+
+int hpx_main(hpx::program_options::variables_map& vm)
+{
+    if (vm.count("seed"))
+        seed = vm["seed"].as<unsigned int>();
+
+    std::cout << "using seed: " << seed << std::endl;
+    gen.seed(seed);
+
+    adjacent_find_test();
+    adjacent_find_exception_test();
+    adjacent_find_bad_alloc_test();
+    return hpx::local::finalize();
+}
+
+int main(int argc, char* argv[])
+{
+    // add command line option which controls the random number generator seed
+    using namespace hpx::program_options;
+    options_description desc_commandline(
+        "Usage: " HPX_APPLICATION_STRING " [options]");
+
+    desc_commandline.add_options()("seed,s", value<unsigned int>(),
+        "the random number generator seed to use for this run");
+
+    // By default this test should run on all available cores
+    std::vector<std::string> const cfg = {"hpx.os_threads=all"};
+
+    // Initialize and run HPX
+    hpx::local::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::local::init(hpx_main, argc, argv, init_args), 0,
+        "HPX main exited with non-zero status");
+
+    return hpx::util::report_errors();
+}

--- a/libs/core/algorithms/tests/unit/datapar_algorithms/adjacentfind_datapar.cpp
+++ b/libs/core/algorithms/tests/unit/datapar_algorithms/adjacentfind_datapar.cpp
@@ -29,7 +29,7 @@ void test_adjacent_find()
 void adjacent_find_test()
 {
     test_adjacent_find<std::random_access_iterator_tag>();
-    // test_adjacent_find<std::forward_iterator_tag>();
+    test_adjacent_find<std::forward_iterator_tag>();
 }
 
 //////////////////////////////////////////////////////////////////////////
@@ -47,7 +47,7 @@ void test_adjacent_find_exception()
 void adjacent_find_exception_test()
 {
     test_adjacent_find_exception<std::random_access_iterator_tag>();
-    // test_adjacent_find_exception<std::forward_iterator_tag>();
+    test_adjacent_find_exception<std::forward_iterator_tag>();
 }
 
 //////////////////////////////////////////////////////////////////////////
@@ -65,7 +65,7 @@ void test_adjacent_find_bad_alloc()
 void adjacent_find_bad_alloc_test()
 {
     test_adjacent_find_bad_alloc<std::random_access_iterator_tag>();
-    // test_adjacent_find_bad_alloc<std::forward_iterator_tag>();
+    test_adjacent_find_bad_alloc<std::forward_iterator_tag>();
 }
 
 int hpx_main(hpx::program_options::variables_map& vm)


### PR DESCRIPTION
Contributes to fixing #2333 

## Proposed Changes

  - Adds CPO to adjacent find
  - Adapts datapar adjacent find
  - Adds unit tests for datapar adjacent_find

## Any background context you want to provide?

Not all points below apply to all pull requests.

- [x] I have added a new feature and have added tests to go along with it.
- [ ] I have fixed a bug and have added a regression test.
- [x] I have added a test using random numbers; I have made sure it uses a seed, and that random numbers generated are valid inputs for the tests.
