### PR TITLE
Modernize hpx::future and related facilities

### DIFF
--- a/docs/sphinx/api/public_api.rst
+++ b/docs/sphinx/api/public_api.rst
@@ -461,17 +461,21 @@ compared to the C++ standard library.
 Classes
 -------
 
-- :cpp:class:`hpx::lcos::future`
-- :cpp:class:`hpx::lcos::shared_future`
+- :cpp:class:`hpx::future`
+- :cpp:class:`hpx::shared_future`
 - :cpp:class:`hpx::lcos::local::promise`
 - :cpp:class:`hpx::launch`
 
 Functions
 ---------
 
-- :cpp:func:`hpx::lcos::make_future`
-- :cpp:func:`hpx::lcos::make_shared_future`
-- :cpp:func:`hpx::lcos::make_ready_future`
+- :cpp:func:`hpx::make_future`
+- :cpp:func:`hpx::make_shared_future`
+- :cpp:func:`hpx::make_ready_future`
+- :cpp:func:`hpx::make_ready_future_alloc`
+- :cpp:func:`hpx::make_ready_future_at`
+- :cpp:func:`hpx::make_ready_future_after`
+- :cpp:func:`hpx::make_exceptional_future`
 - :cpp:func:`hpx::async`
 - :cpp:func:`hpx::apply`
 - :cpp:func:`hpx::sync`

--- a/examples/accumulators/accumulator.hpp
+++ b/examples/accumulators/accumulator.hpp
@@ -106,7 +106,7 @@ namespace examples
         ///////////////////////////////////////////////////////////////////////
         /// Asynchronously query the current value of the accumulator.
         ///
-        /// \returns This function returns an \a hpx::lcos::future. When the
+        /// \returns This function returns an \a hpx::future. When the
         ///          value of this computation is needed, the get() method of
         ///          the future should be called. If the value is available,
         ///          get() will return immediately; otherwise, it will block

--- a/examples/accumulators/template_accumulator.hpp
+++ b/examples/accumulators/template_accumulator.hpp
@@ -106,7 +106,7 @@ namespace examples
         ///////////////////////////////////////////////////////////////////////
         /// Asynchronously query the current value of the accumulator.
         ///
-        /// \returns This function returns an \a hpx::lcos::future. When the
+        /// \returns This function returns an \a hpx::future. When the
         ///          value of this computation is needed, the get() method of
         ///          the future should be called. If the value is available,
         ///          get() will return immediately; otherwise, it will block

--- a/examples/accumulators/template_function_accumulator.hpp
+++ b/examples/accumulators/template_function_accumulator.hpp
@@ -107,7 +107,7 @@ namespace examples
         ///////////////////////////////////////////////////////////////////////
         /// Asynchronously query the current value of the accumulator.
         ///
-        /// \returns This function returns an \a hpx::lcos::future. When the
+        /// \returns This function returns an \a hpx::future. When the
         ///          value of this computation is needed, the get() method of
         ///          the future should be called. If the value is available,
         ///          get() will return immediately; otherwise, it will block

--- a/examples/apex/apex_balance.cpp
+++ b/examples/apex/apex_balance.cpp
@@ -9,8 +9,8 @@
 // Naive SMP version implemented with futures.
 
 #include <hpx/hpx_init.hpp>
+#include <hpx/future.hpp>
 #include <hpx/include/actions.hpp>
-#include <hpx/include/lcos.hpp>
 #include <hpx/include/util.hpp>
 
 #include <apex_api.hpp>
@@ -75,7 +75,7 @@ int hpx_main(hpx::program_options::variables_map& vm)
     for(std::uint64_t block = 0; block < blocks; ++block) {
         std::cout << "Block " << block << std::endl;
         std::list<std::uint64_t> work(units, n);
-        std::list<hpx::lcos::future<double> > futures;
+        std::list<hpx::future<double> > futures;
         for(std::uint64_t & item : work) {
             do_work_action act;
             size_t next = next_locality(probabilities);

--- a/examples/async_io/async_io_action.cpp
+++ b/examples/async_io/async_io_action.cpp
@@ -37,7 +37,7 @@ namespace detail
     }
 
     // This function will be executed by an HPX thread
-    hpx::lcos::future<int> async_io_worker(std::string const& string_to_write)
+    hpx::future<int> async_io_worker(std::string const& string_to_write)
     {
         std::shared_ptr<hpx::lcos::local::promise<int> > p =
             std::make_shared<hpx::lcos::local::promise<int> >();
@@ -56,7 +56,7 @@ namespace detail
 // invoked. This allows to remotely execute the async_io.
 int async_io(std::string const& string_to_write)
 {
-    hpx::lcos::future<int> f = detail::async_io_worker(string_to_write);
+    hpx::future<int> f = detail::async_io_worker(string_to_write);
     return f.get();    // simply wait for the IO to finish
 }
 

--- a/examples/async_io/async_io_low_level.cpp
+++ b/examples/async_io/async_io_low_level.cpp
@@ -29,7 +29,7 @@ void do_async_io(char const* string_to_write,
 }
 
 // This function will be executed by an HPX thread
-hpx::lcos::future<int> async_io(char const* string_to_write)
+hpx::future<int> async_io(char const* string_to_write)
 {
     std::shared_ptr<hpx::lcos::local::promise<int> > p =
         std::make_shared<hpx::lcos::local::promise<int> >();
@@ -50,7 +50,7 @@ int hpx_main()
     {
         // Initiate an asynchronous IO operation wait for it to complete without
         // blocking any of the HPX thread-manager threads.
-        hpx::lcos::future<int> f = async_io("Write this string to std::cout");
+        hpx::future<int> f = async_io("Write this string to std::cout");
 
         // This will suspend the current HPX thread until the IO operation is
         // finished.

--- a/examples/cancelable_action/cancelable_action/stubs/cancelable_action.hpp
+++ b/examples/cancelable_action/cancelable_action/stubs/cancelable_action.hpp
@@ -20,7 +20,7 @@ namespace examples { namespace stubs
       : hpx::components::stub_base<server::cancelable_action>
     {
         // Do some lengthy work
-        static hpx::lcos::future<void>
+        static hpx::future<void>
         do_it_async(hpx::naming::id_type const& gid)
         {
             typedef server::cancelable_action::do_it_action action_type;

--- a/examples/interpolate1d/interpolate1d/interpolate1d.hpp
+++ b/examples/interpolate1d/interpolate1d/interpolate1d.hpp
@@ -32,7 +32,7 @@ namespace interpolate1d
         // Return the interpolated  function value for the given argument. This
         // function dispatches to the proper partition for the actual
         // interpolation.
-        hpx::lcos::future<double>
+        hpx::future<double>
         interpolate_async(double value) const
         {
             return get_partition(value).interpolate_async(value);

--- a/examples/interpolate1d/interpolate1d/partition.hpp
+++ b/examples/interpolate1d/interpolate1d/partition.hpp
@@ -45,7 +45,7 @@ namespace interpolate1d
         {}
 
         // initialize this partition
-        hpx::lcos::future<void>
+        hpx::future<void>
         init_async(std::string const& datafilename, dimension const& dim,
             std::size_t num_nodes)
         {
@@ -62,7 +62,7 @@ namespace interpolate1d
 
         // ask this partition to interpolate, note that value must be in the
         // range valid for this partition
-        hpx::lcos::future<double>
+        hpx::future<double>
         interpolate_async(double value) const
         {
             typedef server::partition::interpolate_action interpolate_action;

--- a/examples/jacobi/jacobi_component/grid.cpp
+++ b/examples/jacobi/jacobi_component/grid.cpp
@@ -27,7 +27,7 @@ namespace jacobi
             hpx::default_layout(hpx::find_all_localities()), ny).get();
 
         rows.reserve(ny);
-        std::vector<hpx::lcos::future<void> > init_futures;
+        std::vector<hpx::future<void> > init_futures;
         init_futures.reserve(ny);
         for (hpx::naming::id_type const& id : ids)
         {

--- a/examples/jacobi/jacobi_component/row.hpp
+++ b/examples/jacobi/jacobi_component/row.hpp
@@ -23,14 +23,14 @@ namespace jacobi
     {
         row() {}
 
-        hpx::lcos::future<void> init(std::size_t nx, double value = 0.0)
+        hpx::future<void> init(std::size_t nx, double value = 0.0)
         {
             return hpx::async<server::row::init_action>(id, nx, value);
         }
 
         hpx::naming::id_type id;
 
-        hpx::lcos::future<row_range> get(std::size_t begin, std::size_t end)
+        hpx::future<row_range> get(std::size_t begin, std::size_t end)
         {
             return hpx::async<server::row::get_action>(id, begin, end);
         }

--- a/examples/jacobi/jacobi_component/server/solver.hpp
+++ b/examples/jacobi/jacobi_component/server/solver.hpp
@@ -57,7 +57,7 @@ namespace jacobi { namespace server {
                     hpx::default_layout(hpx::find_all_localities()), ny)
                     .get();
 
-            std::vector<hpx::lcos::shared_future<void>> init_futures;
+            std::vector<hpx::shared_future<void>> init_futures;
             init_futures.reserve(ny);
             std::size_t y = 0;
             for (hpx::naming::id_type const& id : ids)
@@ -72,7 +72,7 @@ namespace jacobi { namespace server {
             }
             HPX_ASSERT(y == ny);
 
-            std::vector<hpx::lcos::shared_future<void>> boundary_futures;
+            std::vector<hpx::shared_future<void>> boundary_futures;
             hpx::lcos::wait(init_futures, [&](std::size_t y) {
                 if (y > 0 && y < ny - 1)
                 {
@@ -111,7 +111,7 @@ namespace jacobi { namespace server {
 
             for (std::size_t iter = 0; iter < max_iterations; ++iter)
             {
-                std::vector<hpx::lcos::shared_future<void>> run_futures;
+                std::vector<hpx::shared_future<void>> run_futures;
                 run_futures.reserve(ny - 2);
                 for (std::size_t y = 1; y < ny - 1; ++y)
                 {

--- a/examples/jacobi/jacobi_component/server/stencil_iterator.cpp
+++ b/examples/jacobi/jacobi_component/server/stencil_iterator.cpp
@@ -34,7 +34,7 @@ namespace jacobi
             HPX_ASSERT(this->get_unmanaged_id() != top.id);
             HPX_ASSERT(this->get_unmanaged_id() != bottom.id);
 
-            std::vector<hpx::lcos::future<void> > fs;
+            std::vector<hpx::future<void> > fs;
             for(std::size_t x = 1; x < nx-1; x += line_block)
             {
                 std::size_t x_end = (std::min)(nx-1, x + line_block);
@@ -54,10 +54,10 @@ namespace jacobi
         }
 
         void stencil_iterator::update(
-            hpx::lcos::future<row_range> dst
-          , hpx::lcos::future<row_range> src
-          , hpx::lcos::future<row_range> top
-          , hpx::lcos::future<row_range> bottom
+            hpx::future<row_range> dst
+          , hpx::future<row_range> src
+          , hpx::future<row_range> top
+          , hpx::future<row_range> bottom
         )
         {
             row_range d = dst.get();

--- a/examples/jacobi/jacobi_component/server/stencil_iterator.hpp
+++ b/examples/jacobi/jacobi_component/server/stencil_iterator.hpp
@@ -76,10 +76,10 @@ namespace jacobi
             jacobi::row get(std::size_t idx);
 
             void update(
-                hpx::lcos::future<row_range> dst
-              , hpx::lcos::future<row_range> src
-              , hpx::lcos::future<row_range> top
-              , hpx::lcos::future<row_range> bottom
+                hpx::future<row_range> dst
+              , hpx::future<row_range> src
+              , hpx::future<row_range> top
+              , hpx::future<row_range> bottom
             );
 
             HPX_DEFINE_COMPONENT_ACTION(stencil_iterator, init, init_action);
@@ -94,9 +94,9 @@ namespace jacobi
             std::size_t line_block;
             std::size_t src;
             std::size_t dst;
-            hpx::lcos::shared_future<jacobi::row> top_future[2];
+            hpx::shared_future<jacobi::row> top_future[2];
             jacobi::row rows[2];
-            hpx::lcos::shared_future<jacobi::row> bottom_future[2];
+            hpx::shared_future<jacobi::row> bottom_future[2];
 
         };
     }

--- a/examples/jacobi/jacobi_component/stencil_iterator.cpp
+++ b/examples/jacobi/jacobi_component/stencil_iterator.cpp
@@ -15,7 +15,7 @@
 
 namespace jacobi
 {
-    hpx::lcos::future<void> stencil_iterator::init(
+    hpx::future<void> stencil_iterator::init(
         jacobi::row const & r
       , std::size_t y
       , std::size_t nx
@@ -27,7 +27,7 @@ namespace jacobi
         return hpx::async<server::stencil_iterator::init_action>(id, r, y, nx, ny, l);
     }
 
-    hpx::lcos::future<void> stencil_iterator::setup_boundary(
+    hpx::future<void> stencil_iterator::setup_boundary(
         stencil_iterator const & top
       , stencil_iterator const & bottom
     )
@@ -43,14 +43,14 @@ namespace jacobi
             );
     }
 
-    hpx::lcos::future<void> stencil_iterator::step()
+    hpx::future<void> stencil_iterator::step()
     {
         HPX_ASSERT(id);
         return
             hpx::async<server::stencil_iterator::step_action>(id);
     }
 
-    hpx::lcos::future<jacobi::row> stencil_iterator::get(std::size_t idx) const
+    hpx::future<jacobi::row> stencil_iterator::get(std::size_t idx) const
     {
         HPX_ASSERT(id);
         return hpx::async<server::stencil_iterator::get_action>(id, idx);

--- a/examples/jacobi/jacobi_component/stencil_iterator.hpp
+++ b/examples/jacobi/jacobi_component/stencil_iterator.hpp
@@ -24,19 +24,19 @@ namespace jacobi
 
         ~stencil_iterator() { /*HPX_ASSERT(id);*/ }
 
-        hpx::lcos::future<void> init(
+        hpx::future<void> init(
             jacobi::row const & r
           , std::size_t y_
           , std::size_t nx_
           , std::size_t ny_
           , std::size_t l
         );
-        hpx::lcos::future<void> setup_boundary(stencil_iterator const & top,
+        hpx::future<void> setup_boundary(stencil_iterator const & top,
             stencil_iterator const & bottom);
 
-        hpx::lcos::future<void> step();
+        hpx::future<void> step();
 
-        hpx::lcos::future<jacobi::row> get(std::size_t idx) const;
+        hpx::future<jacobi::row> get(std::size_t idx) const;
 
         template <typename Archive>
         void serialize(Archive & ar, unsigned)

--- a/examples/nqueen/nqueen.hpp
+++ b/examples/nqueen/nqueen.hpp
@@ -41,7 +41,7 @@ namespace nqueen
             return init_board_async(size).get();
         }
 
-        hpx::lcos::future<void> init_board_async(std::size_t size)
+        hpx::future<void> init_board_async(std::size_t size)
         {
             return hpx::async<server::board::init_action>(this->get_id(), size);
         }
@@ -52,7 +52,7 @@ namespace nqueen
             return access_board_async().get();
         }
 
-        hpx::lcos::future<list_type> access_board_async()
+        hpx::future<list_type> access_board_async()
         {
             typedef server::board::access_action action_type;
             return hpx::async<action_type>(this->get_id());
@@ -71,7 +71,7 @@ namespace nqueen
             return check_board_async(list, level).get();
         }
 
-        hpx::lcos::future<bool> check_board_async(list_type const& list,
+        hpx::future<bool> check_board_async(list_type const& list,
             std::size_t level)
         {
             typedef server::board::check_action action_type;
@@ -85,7 +85,7 @@ namespace nqueen
             return solve_board_async(list, size, level, col).get();
         }
 
-        hpx::lcos::future<std::size_t> solve_board_async(list_type const& list,
+        hpx::future<std::size_t> solve_board_async(list_type const& list,
             std::size_t size, std::size_t level, std::size_t col)
         {
             typedef server::board::solve_action action_type;

--- a/examples/qt/qt.cpp
+++ b/examples/qt/qt.cpp
@@ -28,7 +28,7 @@ HPX_PLAIN_ACTION(runner, runner_action)
 
 void run(widget * w, std::size_t num_threads)
 {
-    std::vector<hpx::lcos::future<double> > futures(num_threads);
+    std::vector<hpx::future<double> > futures(num_threads);
 
     for(std::size_t i = 0; i < num_threads; ++i)
     {

--- a/examples/quickstart/1d_wave_equation.cpp
+++ b/examples/quickstart/1d_wave_equation.cpp
@@ -46,7 +46,7 @@ using hpx::naming::id_type;
 using hpx::naming::invalid_id;
 
 using hpx::async;
-using hpx::lcos::future;
+using hpx::future;
 using hpx::lcos::wait;
 
 using hpx::chrono::high_resolution_timer;

--- a/examples/quickstart/factorial.cpp
+++ b/examples/quickstart/factorial.cpp
@@ -31,7 +31,7 @@ std::uint64_t factorial(std::uint64_t n)
     if (n == 0)
         return 1;
 
-    hpx::lcos::future<std::uint64_t> n1 =
+    hpx::future<std::uint64_t> n1 =
         hpx::async<factorial_action>(hpx::find_here(), n - 1);
     return n * n1.get();
 }

--- a/examples/quickstart/fibonacci_futures_distributed.cpp
+++ b/examples/quickstart/fibonacci_futures_distributed.cpp
@@ -41,11 +41,11 @@ hpx::id_type here;
 struct when_all_wrapper
 {
     typedef hpx::tuple<
-            hpx::lcos::future<std::uint64_t>
-          , hpx::lcos::future<std::uint64_t> > data_type;
+            hpx::future<std::uint64_t>
+          , hpx::future<std::uint64_t> > data_type;
 
     std::uint64_t operator()(
-        hpx::lcos::future<data_type> data
+        hpx::future<data_type> data
     ) const
     {
         data_type v = data.get();

--- a/examples/quickstart/hello_world_distributed.cpp
+++ b/examples/quickstart/hello_world_distributed.cpp
@@ -85,7 +85,7 @@ void hello_world_foreman()
         // Each iteration, we create a task for each element in the set of
         // OS-threads that have not said "Hello world". Each of these tasks
         // is encapsulated in a future.
-        std::vector<hpx::lcos::future<std::size_t>> futures;
+        std::vector<hpx::future<std::size_t>> futures;
         futures.reserve(attendance.size());
 
         for (std::size_t worker : attendance)
@@ -137,7 +137,7 @@ int main()
     std::vector<hpx::naming::id_type> localities = hpx::find_all_localities();
 
     // Reserve storage space for futures, one for each locality.
-    std::vector<hpx::lcos::future<void>> futures;
+    std::vector<hpx::future<void>> futures;
     futures.reserve(localities.size());
 
     for (hpx::naming::id_type const& node : localities)

--- a/examples/quickstart/wait_composition.cpp
+++ b/examples/quickstart/wait_composition.cpp
@@ -15,11 +15,11 @@
 ///////////////////////////////////////////////////////////////////////////////
 struct cout_continuation
 {
-    typedef hpx::tuple<hpx::lcos::future<int>, hpx::lcos::future<int>,
-        hpx::lcos::future<int>>
+    typedef hpx::tuple<hpx::future<int>, hpx::future<int>,
+        hpx::future<int>>
         data_type;
 
-    void operator()(hpx::lcos::future<data_type> data) const
+    void operator()(hpx::future<data_type> data) const
     {
         data_type v = data.get();
         std::cout << hpx::get<0>(v).get() << "\n";
@@ -31,9 +31,9 @@ struct cout_continuation
 int hpx_main()
 {
     {
-        hpx::future<int> a = hpx::lcos::make_ready_future<int>(17);
-        hpx::future<int> b = hpx::lcos::make_ready_future<int>(42);
-        hpx::future<int> c = hpx::lcos::make_ready_future<int>(-1);
+        hpx::future<int> a = hpx::make_ready_future<int>(17);
+        hpx::future<int> b = hpx::make_ready_future<int>(42);
+        hpx::future<int> c = hpx::make_ready_future<int>(-1);
 
         hpx::when_all(a, b, c).then(cout_continuation());
     }

--- a/examples/random_mem_access/random_mem_access/random_mem_access.hpp
+++ b/examples/random_mem_access/random_mem_access/random_mem_access.hpp
@@ -53,7 +53,7 @@ namespace hpx { namespace components
             add_async().get();
         }
 
-        hpx::lcos::future<void> add_async()
+        hpx::future<void> add_async()
         {
             typedef server::random_mem_access::add_action action_type;
             return hpx::async<action_type>(this->get_id());
@@ -65,7 +65,7 @@ namespace hpx { namespace components
             print_async().get();
         }
         /// Asynchronously query the current value of the random_mem_access
-        hpx::lcos::future<void> print_async ()
+        hpx::future<void> print_async ()
         {
             typedef server::random_mem_access::print_action action_type;
             return hpx::async<action_type>(this->get_id());
@@ -78,7 +78,7 @@ namespace hpx { namespace components
         }
 
         /// Asynchronously query the current value of the random_mem_access
-        lcos::future<std::size_t> query_async()
+        hpx::future<std::size_t> query_async()
         {
             typedef server::random_mem_access::query_action action_type;
             return hpx::async<action_type>(this->get_id());

--- a/examples/sheneos/sheneos/interpolator.hpp
+++ b/examples/sheneos/sheneos/interpolator.hpp
@@ -133,7 +133,7 @@ namespace sheneos
         /// temp and rho from the ShenEOS tables. This function dispatches to
         /// the proper partition for the actual interpolation using bulk
         /// operations.
-        hpx::lcos::future<std::vector<std::vector<double> > >
+        hpx::future<std::vector<std::vector<double> > >
         interpolate_bulk_async(std::vector<sheneos_coord> const& coords,
             std::uint32_t eosvalues = server::partition3d::small_api_values) const;
 

--- a/examples/sheneos/sheneos/partition3d.hpp
+++ b/examples/sheneos/sheneos/partition3d.hpp
@@ -147,7 +147,7 @@ namespace sheneos
         ///                  and rest mass densities of the plasma.
         /// \param eosvalue  [in] The EOS value to interpolate. Must be
         ///                  in the range of the given partition.
-        hpx::lcos::future<std::vector<double> >
+        hpx::future<std::vector<double> >
         interpolate_one_bulk_async(std::vector<sheneos_coord> const& coords,
             std::uint32_t eosvalue) const
         {

--- a/examples/sheneos/sheneos_test.cpp
+++ b/examples/sheneos/sheneos_test.cpp
@@ -89,7 +89,7 @@ void test_sheneos(std::size_t num_ye_points, std::size_t num_temp_points,
     std::random_shuffle(sequence_rho.begin(), sequence_rho.end());
 
     // Create the three-dimensional future grid.
-    std::vector<hpx::lcos::future<std::vector<double> > > tests;
+    std::vector<hpx::future<std::vector<double> > > tests;
     for (std::size_t const& ii : sequence_ye)
     {
         for (std::size_t const& jj : sequence_temp)
@@ -177,7 +177,7 @@ void test_sheneos_one_bulk(std::size_t num_ye_points,
     std::vector<sheneos::sheneos_coord> values;
     values.reserve(num_ye_points * num_temp_points * num_rho_points);
 
-    std::vector<hpx::lcos::future<std::vector<double> > > tests;
+    std::vector<hpx::future<std::vector<double> > > tests;
     for (std::size_t const& ii : sequence_ye)
     {
         for (std::size_t const& jj : sequence_temp)
@@ -191,7 +191,7 @@ void test_sheneos_one_bulk(std::size_t num_ye_points,
     }
 
     // Execute bulk operation
-    hpx::lcos::future<std::vector<double> > bulk_one_tests =
+    hpx::future<std::vector<double> > bulk_one_tests =
         shen.interpolate_one_bulk_async(values,
             sheneos::server::partition3d::logpress);
 
@@ -271,7 +271,7 @@ void test_sheneos_bulk(std::size_t num_ye_points,
     std::vector<sheneos::sheneos_coord> values;
     values.reserve(num_ye_points * num_temp_points * num_rho_points);
 
-    std::vector<hpx::lcos::future<std::vector<double> > > tests;
+    std::vector<hpx::future<std::vector<double> > > tests;
     for (std::size_t const& ii : sequence_ye)
     {
         for (std::size_t const& jj : sequence_temp)
@@ -285,7 +285,7 @@ void test_sheneos_bulk(std::size_t num_ye_points,
     }
 
     // Execute bulk operation
-    hpx::lcos::future<std::vector<std::vector<double> > > bulk_tests =
+    hpx::future<std::vector<std::vector<double> > > bulk_tests =
         shen.interpolate_bulk_async(values);
 
     std::vector<std::vector<double>> results = hpx::unwrap(bulk_tests);
@@ -346,7 +346,7 @@ int hpx_main(hpx::program_options::variables_map& vm)
 
 //         // Kick off the computation asynchronously. On each locality,
 //         // num_workers test_actions are created.
-//         std::vector<hpx::lcos::future<void> > tests;
+//         std::vector<hpx::future<void> > tests;
 //         for (hpx::naming::id_type const& id : locality_ids)
 //         {
 //             using hpx::async;
@@ -365,7 +365,7 @@ int hpx_main(hpx::program_options::variables_map& vm)
 //
 //         // Kick off the computation asynchronously. On each locality,
 //         // num_workers test_actions are created.
-//         std::vector<hpx::lcos::future<void> > bulk_one_tests;
+//         std::vector<hpx::future<void> > bulk_one_tests;
 //         for (hpx::naming::id_type const& id : locality_ids)
 //         {
 //             using hpx::async;

--- a/examples/spell_check/spell_check_file.cpp
+++ b/examples/spell_check/spell_check_file.cpp
@@ -201,7 +201,7 @@ int hpx_main()
         fin.close();
         t.restart();
         {
-            using hpx::lcos::future;
+            using hpx::future;
             using hpx::async;
             using hpx::wait_all;
             vector<search_action> sAct;//[sizeX * sizeY];

--- a/examples/spell_check/spell_check_simple.cpp
+++ b/examples/spell_check/spell_check_simple.cpp
@@ -180,7 +180,7 @@ int hpx_main()
         }
         t.restart();
         {
-            using hpx::lcos::future;
+            using hpx::future;
             using hpx::async;
             using hpx::wait_all;
             vector<search_action> sAct;//[sizeX * sizeY];

--- a/examples/throttle/throttle/stubs/throttle.hpp
+++ b/examples/throttle/throttle/stubs/throttle.hpp
@@ -21,7 +21,7 @@ namespace throttle { namespace stubs
     struct throttle : hpx::components::stub_base<server::throttle>
     {
         ///////////////////////////////////////////////////////////////////////
-        static hpx::lcos::future<void>
+        static hpx::future<void>
         suspend_async(hpx::naming::id_type const& gid, std::size_t thread_num)
         {
             // Create a future, execute the required action,
@@ -38,7 +38,7 @@ namespace throttle { namespace stubs
         }
 
         ///////////////////////////////////////////////////////////////////////
-        static hpx::lcos::future<void>
+        static hpx::future<void>
         resume_async(hpx::naming::id_type const& gid, std::size_t thread_num)
         {
             // Create a future, execute the required action,

--- a/examples/tuplespace/central_tuplespace/simple_central_tuplespace.hpp
+++ b/examples/tuplespace/central_tuplespace/simple_central_tuplespace.hpp
@@ -108,7 +108,7 @@ namespace examples
         ///       for the action to be executed. Instead, it will return
         ///       immediately after the action has has been dispatched.
         //[simple_central_tuplespace_client_write_async
-        hpx::lcos::future<int> write_async(tuple_type const& tuple)
+        hpx::future<int> write_async(tuple_type const& tuple)
         {
             HPX_ASSERT(this->get_id());
             return this->base_type::write_async(this->get_id(), tuple);
@@ -130,7 +130,7 @@ namespace examples
         /// \note This function has fire-and-forget semantics. It will not wait
         ///       for the action to be executed. Instead, it will return
         ///       immediately after the action has has been dispatched.
-        hpx::lcos::future<tuple_type>
+        hpx::future<tuple_type>
             read_async(tuple_type const& tp, double const timeout)
         {
             HPX_ASSERT(this->get_id());
@@ -153,13 +153,13 @@ namespace examples
         ///////////////////////////////////////////////////////////////////////
         /// take matching tuple from tuplespace within \p timeout.
         ///
-        /// \returns This function returns an \a hpx::lcos::future. When the
+        /// \returns This function returns an \a hpx::future. When the
         ///          value of this computation is needed, the get() method of
         ///          the future should be called. If the value is available,
         ///          get() will return immediately; otherwise, it will block
         ///          until the value is ready.
         //[simple_central_tuplespace_client_take_async
-        hpx::lcos::future<tuple_type>
+        hpx::future<tuple_type>
             take_async(tuple_type const& tp, double const timeout)
         {
             HPX_ASSERT(this->get_id());

--- a/examples/tuplespace/central_tuplespace/stubs/simple_central_tuplespace.hpp
+++ b/examples/tuplespace/central_tuplespace/stubs/simple_central_tuplespace.hpp
@@ -29,7 +29,7 @@ namespace examples { namespace stubs {
         ///       for the action to be executed. Instead, it will return
         ///       immediately after the action has has been dispatched.
         //[simple_central_tuplespace_stubs_write_async
-        static hpx::lcos::future<int> write_async(
+        static hpx::future<int> write_async(
             hpx::naming::id_type const& gid, tuple_type const& tuple)
         {
             typedef server::simple_central_tuplespace::write_action action_type;
@@ -53,7 +53,7 @@ namespace examples { namespace stubs {
         /// \note This function has fire-and-forget semantics. It will not wait
         ///       for the action to be executed. Instead, it will return
         ///       immediately after the action has has been dispatched.
-        static hpx::lcos::future<tuple_type> read_async(
+        static hpx::future<tuple_type> read_async(
             hpx::naming::id_type const& gid, tuple_type const& tp,
             double const timeout)
         {
@@ -77,13 +77,13 @@ namespace examples { namespace stubs {
         ///////////////////////////////////////////////////////////////////////
         /// take tuple matching \p key from tuplespace within \p timeout.
         ///
-        /// \returns This function returns an \a hpx::lcos::future. When the
+        /// \returns This function returns an \a hpx::future. When the
         ///          value of this computation is needed, the get() method of
         ///          the future should be called. If the value is available,
         ///          get() will return immediately; otherwise, it will block
         ///          until the value is ready.
         //[simple_central_tuplespace_stubs_take_async
-        static hpx::lcos::future<tuple_type> take(hpx::launch::async_policy,
+        static hpx::future<tuple_type> take(hpx::launch::async_policy,
             hpx::naming::id_type const& gid, tuple_type const& tp,
             double const timeout)
         {

--- a/examples/tuplespace/simple_central_tuplespace_client.cpp
+++ b/examples/tuplespace/simple_central_tuplespace_client.cpp
@@ -141,7 +141,7 @@ int hpx_main()
         print_tuple(tuple2);
         hpx::cout << hpx::endl;
 
-        std::vector<hpx::lcos::future<void>> futures;
+        std::vector<hpx::future<void>> futures;
 
         for (hpx::naming::id_type const& node : localities)
         {

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/mismatch.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/mismatch.hpp
@@ -333,7 +333,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
         hpx::future<std::pair<I1, I2>> get_pair(
             hpx::future<util::in_in_result<I1, I2>>&& f)
         {
-            return lcos::make_future<std::pair<I1, I2>>(HPX_MOVE(f),
+            return hpx::make_future<std::pair<I1, I2>>(HPX_MOVE(f),
                 [](util::in_in_result<I1, I2>&& p) -> std::pair<I1, I2> {
                     return {HPX_MOVE(p.in1), HPX_MOVE(p.in2)};
                 });

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/reduce_by_key.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/reduce_by_key.hpp
@@ -185,7 +185,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
         {
             typedef util::in_out_result<iKey, iVal> result_type;
 
-            return lcos::make_future<result_type>(
+            return hpx::make_future<result_type>(
                 HPX_MOVE(ziter), [=](ZIter zipiter) {
                     auto t = zipiter.second.get_iterator_tuple();
                     iKey key_end = hpx::get<0>(t);

--- a/libs/core/algorithms/include/hpx/parallel/util/result_types.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/util/result_types.hpp
@@ -227,7 +227,7 @@ namespace hpx { namespace parallel { namespace util {
     hpx::future<O> get_third_element(
         hpx::future<util::in_in_out_result<I1, I2, O>>&& f)
     {
-        return lcos::make_future<O>(
+        return hpx::make_future<O>(
             HPX_MOVE(f), [](in_in_out_result<I1, I2, O>&& p) { return p.out; });
     }
 
@@ -289,7 +289,7 @@ namespace hpx { namespace parallel { namespace util {
 
         using result_type = in_out_out_result<Ts...>;
 
-        return lcos::make_future<result_type>(
+        return hpx::make_future<result_type>(
             HPX_MOVE(f), [](hpx::tuple<Ts...>&& t) -> result_type {
                 return make_in_out_out_result(HPX_MOVE(t));
             });
@@ -340,7 +340,7 @@ namespace hpx { namespace parallel { namespace util {
     hpx::future<hpx::util::iterator_range<Iterator, Sentinel>> make_subrange(
         hpx::future<Iterator>&& iterator, Sentinel sentinel)
     {
-        return lcos::make_future<hpx::util::iterator_range<Iterator, Sentinel>>(
+        return hpx::make_future<hpx::util::iterator_range<Iterator, Sentinel>>(
             HPX_MOVE(iterator), [sentinel](Iterator&& it) {
                 return hpx::util::iterator_range<Iterator, Sentinel>(
                     it, sentinel);
@@ -380,7 +380,7 @@ namespace hpx { namespace parallel { namespace util {
                 typename hpx::tuple_element<0, iterator_tuple_type>::type,
                 typename hpx::tuple_element<1, iterator_tuple_type>::type>;
 
-            return lcos::make_future<result_type>(
+            return hpx::make_future<result_type>(
                 HPX_MOVE(zipiter), [](ZipIter zipiter) {
                     return get_in_out_result(HPX_MOVE(zipiter));
                 });
@@ -410,7 +410,7 @@ namespace hpx { namespace parallel { namespace util {
             using result_type = min_max_result<
                 typename hpx::tuple_element<0, iterator_tuple_type>::type>;
 
-            return lcos::make_future<result_type>(
+            return hpx::make_future<result_type>(
                 std::move(zipiter), [](ZipIter zipiter) {
                     return get_min_max_result(std::move(zipiter));
                 });
@@ -453,7 +453,7 @@ namespace hpx { namespace parallel { namespace util {
                 typename hpx::tuple_element<1, iterator_tuple_type>::type,
                 typename hpx::tuple_element<2, iterator_tuple_type>::type>;
 
-            return lcos::make_future<result_type>(
+            return hpx::make_future<result_type>(
                 HPX_MOVE(zipiter), [](ZipIter zipiter) {
                     return get_in_in_out_result(HPX_MOVE(zipiter));
                 });

--- a/libs/core/algorithms/include/hpx/parallel/util/zip_iterator.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/util/zip_iterator.hpp
@@ -30,7 +30,7 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
         typedef typename hpx::tuple_element<N,
             typename ZipIter::iterator_tuple_type>::type result_type;
 
-        return lcos::make_future<result_type>(
+        return hpx::make_future<result_type>(
             HPX_MOVE(zipiter), [](ZipIter zipiter) {
                 return get_iter<N, result_type>(HPX_MOVE(zipiter));
             });
@@ -48,7 +48,7 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
         hpx::future<ZipIter>&& zipiter)
     {
         typedef typename ZipIter::iterator_tuple_type result_type;
-        return lcos::make_future<result_type>(HPX_MOVE(zipiter),
+        return hpx::make_future<result_type>(HPX_MOVE(zipiter),
             [](ZipIter zipiter) { return get_iter_tuple(HPX_MOVE(zipiter)); });
     }
 
@@ -80,7 +80,7 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
             typename hpx::tuple_element<1, iterator_tuple_type>::type>
             result_type;
 
-        return lcos::make_future<result_type>(HPX_MOVE(zipiter),
+        return hpx::make_future<result_type>(HPX_MOVE(zipiter),
             [](ZipIter zipiter) { return get_iter_pair(HPX_MOVE(zipiter)); });
     }
 
@@ -116,7 +116,7 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
             typename hpx::tuple_element<0, iterator_tuple_type>::type,
             typename hpx::tuple_element<1, iterator_tuple_type>::type>;
 
-        return lcos::make_future<result_type>(
+        return hpx::make_future<result_type>(
             HPX_MOVE(zipiter), [](ZipIter zipiter) {
                 return get_iter_in_in_result(HPX_MOVE(zipiter));
             });

--- a/libs/core/async_combinators/include/hpx/async_combinators/when_all.hpp
+++ b/libs/core/async_combinators/include/hpx/async_combinators/when_all.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2017 Hartmut Kaiser
+//  Copyright (c) 2007-2021 Hartmut Kaiser
 //  Copyright (c) 2013 Agustin Berge
 //  Copyright (c) 2017 Denis Blank
 //
@@ -41,7 +41,7 @@ namespace hpx {
     template <typename InputIter,
         typename Container = vector<
             future<typename std::iterator_traits<InputIter>::value_type>>>
-    future<Container> when_all(InputIter first, InputIter last);
+    hpx::future<Container> when_all(InputIter first, InputIter last);
 
     /// The function \a when_all is an operator allowing to join on the result
     /// of all given futures. It AND-composes all future objects given and
@@ -67,7 +67,7 @@ namespace hpx {
     ///       The future returned by \a when_all will not throw an exception,
     ///       but the futures held in the output collection may.
     template <typename Range>
-    future<Range> when_all(Range&& values);
+    hpx::future<Range> when_all(Range&& values);
 
     /// The function \a when_all is an operator allowing to join on the result
     /// of all given futures. It AND-composes all future objects given and
@@ -92,7 +92,7 @@ namespace hpx {
     ///       The future returned by \a when_all will not throw an exception,
     ///       but the futures held in the output collection may.
     template <typename... T>
-    future<tuple<future<T>...>> when_all(T&&... futures);
+    hpx::future<hpx::tuple<hpx::future<T>...>> when_all(T&&... futures);
 
     /// The function \a when_all_n is an operator allowing to join on the result
     /// of all given futures. It AND-composes all future objects given and
@@ -127,7 +127,7 @@ namespace hpx {
     template <typename InputIter,
         typename Container = vector<
             future<typename std::iterator_traits<InputIter>::value_type>>>
-    future<Container> when_all_n(InputIter begin, std::size_t count);
+    hpx::future<Container> when_all_n(InputIter begin, std::size_t count);
 }    // namespace hpx
 
 #else    // DOXYGEN
@@ -184,7 +184,7 @@ namespace hpx { namespace lcos {
         {
         public:
             typedef typename when_all_result<Tuple>::type result_type;
-            typedef hpx::lcos::future<result_type> type;
+            typedef hpx::future<result_type> type;
             typedef hpx::lcos::detail::future_data<result_type> base_type;
 
             explicit async_when_all_frame(
@@ -253,24 +253,24 @@ namespace hpx { namespace lcos {
     template <typename Iterator,
         typename Container = std::vector<
             typename detail::future_iterator_traits<Iterator>::type>>
-    future<Container> when_all(Iterator begin, Iterator end)
+    hpx::future<Container> when_all(Iterator begin, Iterator end)
     {
         return detail::when_all_impl(
             detail::acquire_future_iterators<Iterator, Container>(begin, end));
     }
 
-    inline lcos::future<hpx::tuple<>>    //-V524
+    inline hpx::future<hpx::tuple<>>    //-V524
     when_all()
     {
         typedef hpx::tuple<> result_type;
-        return lcos::make_ready_future(result_type());
+        return hpx::make_ready_future(result_type());
     }
 
     ///////////////////////////////////////////////////////////////////////////
     template <typename Iterator,
         typename Container = std::vector<
             typename lcos::detail::future_iterator_traits<Iterator>::type>>
-    lcos::future<Container> when_all_n(Iterator begin, std::size_t count)
+    hpx::future<Container> when_all_n(Iterator begin, std::size_t count)
     {
         return detail::when_all_impl(
             detail::acquire_future_n<Iterator, Container>(begin, count));

--- a/libs/core/async_combinators/include/hpx/async_combinators/when_any.hpp
+++ b/libs/core/async_combinators/include/hpx/async_combinators/when_any.hpp
@@ -372,7 +372,7 @@ namespace hpx { namespace lcos {
     ///////////////////////////////////////////////////////////////////////////
     template <typename Range>
     typename std::enable_if<traits::is_future_range<Range>::value,
-        lcos::future<when_any_result<typename std::decay<Range>::type>>>::type
+        hpx::future<when_any_result<typename std::decay<Range>::type>>>::type
     when_any(Range&& lazy_values)
     {
         typedef typename std::decay<Range>::type result_type;
@@ -396,7 +396,7 @@ namespace hpx { namespace lcos {
     template <typename Iterator,
         typename Container = std::vector<
             typename lcos::detail::future_iterator_traits<Iterator>::type>>
-    lcos::future<when_any_result<Container>> when_any(
+    hpx::future<when_any_result<Container>> when_any(
         Iterator begin, Iterator end)
     {
         Container lazy_values_;
@@ -413,19 +413,19 @@ namespace hpx { namespace lcos {
         return lcos::when_any(HPX_MOVE(lazy_values_));
     }
 
-    inline lcos::future<when_any_result<hpx::tuple<>>>    //-V524
+    inline hpx::future<when_any_result<hpx::tuple<>>>    //-V524
     when_any()
     {
         typedef when_any_result<hpx::tuple<>> result_type;
 
-        return lcos::make_ready_future(result_type());
+        return hpx::make_ready_future(result_type());
     }
 
     ///////////////////////////////////////////////////////////////////////////
     template <typename Iterator,
         typename Container = std::vector<
             typename lcos::detail::future_iterator_traits<Iterator>::type>>
-    lcos::future<when_any_result<Container>> when_any_n(
+    hpx::future<when_any_result<Container>> when_any_n(
         Iterator begin, std::size_t count)
     {
         Container lazy_values_;
@@ -442,7 +442,7 @@ namespace hpx { namespace lcos {
     template <typename T, typename... Ts>
     typename std::enable_if<!(traits::is_future_range<T>::value &&
                                 sizeof...(Ts) == 0),
-        lcos::future<
+        hpx::future<
             when_any_result<hpx::tuple<typename traits::acquire_future<T>::type,
                 typename traits::acquire_future<Ts>::type...>>>>::type
     when_any(T&& t, Ts&&... ts)

--- a/libs/core/async_combinators/include/hpx/async_combinators/when_each.hpp
+++ b/libs/core/async_combinators/include/hpx/async_combinators/when_each.hpp
@@ -176,7 +176,7 @@ namespace hpx { namespace lcos {
         struct when_each_frame    //-V690
           : lcos::detail::future_data<void>
         {
-            typedef lcos::future<void> type;
+            typedef hpx::future<void> type;
 
         private:
             // workaround gcc regression wrongly instantiating constructors
@@ -349,7 +349,7 @@ namespace hpx { namespace lcos {
 
     ///////////////////////////////////////////////////////////////////////////
     template <typename F, typename Future>
-    lcos::future<void> when_each(F&& func, std::vector<Future>& lazy_values)
+    hpx::future<void> when_each(F&& func, std::vector<Future>& lazy_values)
     {
         static_assert(
             traits::is_future<Future>::value, "invalid use of when_each");
@@ -376,7 +376,7 @@ namespace hpx { namespace lcos {
     }
 
     template <typename F, typename Future>
-    lcos::future<void>    //-V659
+    hpx::future<void>    //-V659
     when_each(F&& f, std::vector<Future>&& lazy_values)
     {
         return lcos::when_each(HPX_FORWARD(F, f), lazy_values);
@@ -384,7 +384,7 @@ namespace hpx { namespace lcos {
 
     template <typename F, typename Iterator>
     typename std::enable_if<!traits::is_future<Iterator>::value,
-        lcos::future<Iterator>>::type
+        hpx::future<Iterator>>::type
     when_each(F&& f, Iterator begin, Iterator end)
     {
         typedef typename lcos::detail::future_iterator_traits<Iterator>::type
@@ -396,14 +396,14 @@ namespace hpx { namespace lcos {
 
         return lcos::when_each(HPX_FORWARD(F, f), lazy_values_)
             .then(hpx::launch::sync,
-                [end = HPX_MOVE(end)](lcos::future<void> fut) -> Iterator {
+                [end = HPX_MOVE(end)](hpx::future<void> fut) -> Iterator {
                     fut.get();    // rethrow exceptions, if any
                     return end;
                 });
     }
 
     template <typename F, typename Iterator>
-    lcos::future<Iterator> when_each_n(F&& f, Iterator begin, std::size_t count)
+    hpx::future<Iterator> when_each_n(F&& f, Iterator begin, std::size_t count)
     {
         typedef typename lcos::detail::future_iterator_traits<Iterator>::type
             future_type;
@@ -417,16 +417,16 @@ namespace hpx { namespace lcos {
 
         return lcos::when_each(HPX_FORWARD(F, f), lazy_values_)
             .then(hpx::launch::sync,
-                [begin = HPX_MOVE(begin)](lcos::future<void> fut) -> Iterator {
+                [begin = HPX_MOVE(begin)](hpx::future<void> fut) -> Iterator {
                     fut.get();    // rethrow exceptions, if any
                     return begin;
                 });
     }
 
     template <typename F>
-    inline lcos::future<void> when_each(F&&)
+    inline hpx::future<void> when_each(F&&)
     {
-        return lcos::make_ready_future();
+        return hpx::make_ready_future();
     }
 
     ///////////////////////////////////////////////////////////////////////////
@@ -434,7 +434,7 @@ namespace hpx { namespace lcos {
     typename std::enable_if<
         !traits::is_future<typename std::decay<F>::type>::value &&
             util::all_of<traits::is_future<Ts>...>::value,
-        lcos::future<void>>::type
+        hpx::future<void>>::type
     when_each(F&& f, Ts&&... ts)
     {
         typedef hpx::tuple<typename traits::acquire_future<Ts>::type...>

--- a/libs/core/async_combinators/include/hpx/async_combinators/when_some.hpp
+++ b/libs/core/async_combinators/include/hpx/async_combinators/when_some.hpp
@@ -484,7 +484,7 @@ namespace hpx { namespace lcos {
     ///////////////////////////////////////////////////////////////////////////
     template <typename Range>
     typename std::enable_if<traits::is_future_range<Range>::value,
-        lcos::future<when_some_result<typename std::decay<Range>::type>>>::type
+        hpx::future<when_some_result<typename std::decay<Range>::type>>>::type
     when_some(std::size_t n, Range&& lazy_values, error_code& ec = throws)
     {
         typedef typename std::decay<Range>::type result_type;
@@ -494,7 +494,7 @@ namespace hpx { namespace lcos {
 
         if (n == 0)
         {
-            return lcos::make_ready_future(
+            return hpx::make_ready_future(
                 when_some_result<result_type>(HPX_MOVE(lazy_values_)));
         }
 
@@ -502,7 +502,7 @@ namespace hpx { namespace lcos {
         {
             HPX_THROWS_IF(ec, hpx::bad_parameter, "hpx::lcos::when_some",
                 "number of results to wait for is out of bounds");
-            return lcos::make_ready_future(
+            return hpx::make_ready_future(
                 when_some_result<result_type>(result_type()));
         }
 
@@ -522,7 +522,7 @@ namespace hpx { namespace lcos {
     template <typename Iterator,
         typename Container = std::vector<
             typename lcos::detail::future_iterator_traits<Iterator>::type>>
-    lcos::future<when_some_result<Container>> when_some(
+    hpx::future<when_some_result<Container>> when_some(
         std::size_t n, Iterator begin, Iterator end, error_code& ec = throws)
     {
         Container lazy_values_;
@@ -542,7 +542,7 @@ namespace hpx { namespace lcos {
     template <typename Iterator,
         typename Container = std::vector<
             typename lcos::detail::future_iterator_traits<Iterator>::type>>
-    lcos::future<when_some_result<Container>> when_some_n(std::size_t n,
+    hpx::future<when_some_result<Container>> when_some_n(std::size_t n,
         Iterator begin, std::size_t count, error_code& ec = throws)
     {
         Container lazy_values_;
@@ -555,7 +555,7 @@ namespace hpx { namespace lcos {
         return lcos::when_some(n, lazy_values_, ec);
     }
 
-    inline lcos::future<when_some_result<hpx::tuple<>>> when_some(
+    inline hpx::future<when_some_result<hpx::tuple<>>> when_some(
         std::size_t n, error_code& ec = throws)
     {
         typedef hpx::tuple<> result_type;
@@ -564,20 +564,20 @@ namespace hpx { namespace lcos {
 
         if (n == 0)
         {
-            return lcos::make_ready_future(
+            return hpx::make_ready_future(
                 when_some_result<result_type>(HPX_MOVE(lazy_values)));
         }
 
         HPX_THROWS_IF(ec, hpx::bad_parameter, "hpx::lcos::when_some",
             "number of results to wait for is out of bounds");
-        return lcos::make_ready_future(when_some_result<result_type>());
+        return hpx::make_ready_future(when_some_result<result_type>());
     }
 
     ///////////////////////////////////////////////////////////////////////////
     template <typename T, typename... Ts>
     typename std::enable_if<!(traits::is_future_range<T>::value &&
                                 sizeof...(Ts) == 0),
-        lcos::future<when_some_result<
+        hpx::future<when_some_result<
             hpx::tuple<typename traits::acquire_future<T>::type,
                 typename traits::acquire_future<Ts>::type...>>>>::type
     when_some(std::size_t n, T&& t, Ts&&... ts)
@@ -592,7 +592,7 @@ namespace hpx { namespace lcos {
 
         if (n == 0)
         {
-            return lcos::make_ready_future(
+            return hpx::make_ready_future(
                 when_some_result<result_type>(HPX_MOVE(lazy_values)));
         }
 
@@ -600,7 +600,7 @@ namespace hpx { namespace lcos {
         {
             HPX_THROW_EXCEPTION(hpx::bad_parameter, "hpx::lcos::when_some",
                 "number of results to wait for is out of bounds");
-            return lcos::make_ready_future(when_some_result<result_type>());
+            return hpx::make_ready_future(when_some_result<result_type>());
         }
 
         std::shared_ptr<detail::when_some<result_type>> f =
@@ -619,7 +619,7 @@ namespace hpx { namespace lcos {
     template <typename T, typename... Ts>
     typename std::enable_if<!(traits::is_future_range<T>::value &&
                                 sizeof...(Ts) == 0),
-        lcos::future<when_some_result<
+        hpx::future<when_some_result<
             hpx::tuple<typename traits::acquire_future<T>::type,
                 typename traits::acquire_future<Ts>::type...>>>>::type
     when_some(std::size_t n, error_code& ec, T&& t, Ts&&... ts)
@@ -634,7 +634,7 @@ namespace hpx { namespace lcos {
 
         if (n == 0)
         {
-            return lcos::make_ready_future(
+            return hpx::make_ready_future(
                 when_some_result<result_type>(HPX_MOVE(lazy_values)));
         }
 
@@ -642,7 +642,7 @@ namespace hpx { namespace lcos {
         {
             HPX_THROWS_IF(ec, hpx::bad_parameter, "hpx::lcos::when_some",
                 "number of results to wait for is out of bounds");
-            return lcos::make_ready_future(when_some_result<result_type>());
+            return hpx::make_ready_future(when_some_result<result_type>());
         }
 
         std::shared_ptr<detail::when_some<result_type>> f =

--- a/libs/core/async_combinators/tests/unit/when_all.cpp
+++ b/libs/core/async_combinators/tests/unit/when_all.cpp
@@ -38,7 +38,7 @@ void test_wait_for_all_from_list()
         task.apply();
     }
 
-    hpx::lcos::future<Container> r = hpx::when_all(futures);
+    hpx::future<Container> r = hpx::when_all(futures);
 
     Container result = r.get();
 
@@ -62,7 +62,7 @@ void test_wait_for_all_from_list_iterators()
         task.apply();
     }
 
-    hpx::lcos::future<Container> r =
+    hpx::future<Container> r =
         hpx::when_all<typename Container::iterator, Container>(
             futures.begin(), futures.end());
 
@@ -78,11 +78,11 @@ void test_wait_for_all_from_list_iterators()
 void test_wait_for_all_one_future()
 {
     hpx::lcos::local::futures_factory<int()> pt1(make_int_slowly);
-    hpx::lcos::future<int> f1 = pt1.get_future();
+    hpx::future<int> f1 = pt1.get_future();
     pt1.apply();
 
-    typedef hpx::tuple<hpx::lcos::future<int>> result_type;
-    hpx::lcos::future<result_type> r = hpx::when_all(f1);
+    typedef hpx::tuple<hpx::future<int>> result_type;
+    hpx::future<result_type> r = hpx::when_all(f1);
 
     result_type result = r.get();
 
@@ -94,15 +94,14 @@ void test_wait_for_all_one_future()
 void test_wait_for_all_two_futures()
 {
     hpx::lcos::local::futures_factory<int()> pt1(make_int_slowly);
-    hpx::lcos::future<int> f1 = pt1.get_future();
+    hpx::future<int> f1 = pt1.get_future();
     pt1.apply();
     hpx::lcos::local::futures_factory<int()> pt2(make_int_slowly);
-    hpx::lcos::future<int> f2 = pt2.get_future();
+    hpx::future<int> f2 = pt2.get_future();
     pt2.apply();
 
-    typedef hpx::tuple<hpx::lcos::future<int>, hpx::lcos::future<int>>
-        result_type;
-    hpx::lcos::future<result_type> r = hpx::when_all(f1, f2);
+    typedef hpx::tuple<hpx::future<int>, hpx::future<int>> result_type;
+    hpx::future<result_type> r = hpx::when_all(f1, f2);
 
     result_type result = r.get();
 
@@ -116,19 +115,18 @@ void test_wait_for_all_two_futures()
 void test_wait_for_all_three_futures()
 {
     hpx::lcos::local::futures_factory<int()> pt1(make_int_slowly);
-    hpx::lcos::future<int> f1 = pt1.get_future();
+    hpx::future<int> f1 = pt1.get_future();
     pt1.apply();
     hpx::lcos::local::futures_factory<int()> pt2(make_int_slowly);
-    hpx::lcos::future<int> f2 = pt2.get_future();
+    hpx::future<int> f2 = pt2.get_future();
     pt2.apply();
     hpx::lcos::local::futures_factory<int()> pt3(make_int_slowly);
-    hpx::lcos::future<int> f3 = pt3.get_future();
+    hpx::future<int> f3 = pt3.get_future();
     pt3.apply();
 
-    typedef hpx::tuple<hpx::lcos::future<int>, hpx::lcos::future<int>,
-        hpx::lcos::future<int>>
+    typedef hpx::tuple<hpx::future<int>, hpx::future<int>, hpx::future<int>>
         result_type;
-    hpx::lcos::future<result_type> r = hpx::when_all(f1, f2, f3);
+    hpx::future<result_type> r = hpx::when_all(f1, f2, f3);
 
     result_type result = r.get();
 
@@ -144,22 +142,22 @@ void test_wait_for_all_three_futures()
 void test_wait_for_all_four_futures()
 {
     hpx::lcos::local::futures_factory<int()> pt1(make_int_slowly);
-    hpx::lcos::future<int> f1 = pt1.get_future();
+    hpx::future<int> f1 = pt1.get_future();
     pt1.apply();
     hpx::lcos::local::futures_factory<int()> pt2(make_int_slowly);
-    hpx::lcos::future<int> f2 = pt2.get_future();
+    hpx::future<int> f2 = pt2.get_future();
     pt2.apply();
     hpx::lcos::local::futures_factory<int()> pt3(make_int_slowly);
-    hpx::lcos::future<int> f3 = pt3.get_future();
+    hpx::future<int> f3 = pt3.get_future();
     pt3.apply();
     hpx::lcos::local::futures_factory<int()> pt4(make_int_slowly);
-    hpx::lcos::future<int> f4 = pt4.get_future();
+    hpx::future<int> f4 = pt4.get_future();
     pt4.apply();
 
-    typedef hpx::tuple<hpx::lcos::future<int>, hpx::lcos::future<int>,
-        hpx::lcos::future<int>, hpx::lcos::future<int>>
+    typedef hpx::tuple<hpx::future<int>, hpx::future<int>, hpx::future<int>,
+        hpx::future<int>>
         result_type;
-    hpx::lcos::future<result_type> r = hpx::when_all(f1, f2, f3, f4);
+    hpx::future<result_type> r = hpx::when_all(f1, f2, f3, f4);
 
     result_type result = r.get();
 
@@ -177,25 +175,25 @@ void test_wait_for_all_four_futures()
 void test_wait_for_all_five_futures()
 {
     hpx::lcos::local::futures_factory<int()> pt1(make_int_slowly);
-    hpx::lcos::future<int> f1 = pt1.get_future();
+    hpx::future<int> f1 = pt1.get_future();
     pt1.apply();
     hpx::lcos::local::futures_factory<int()> pt2(make_int_slowly);
-    hpx::lcos::future<int> f2 = pt2.get_future();
+    hpx::future<int> f2 = pt2.get_future();
     pt2.apply();
     hpx::lcos::local::futures_factory<int()> pt3(make_int_slowly);
-    hpx::lcos::future<int> f3 = pt3.get_future();
+    hpx::future<int> f3 = pt3.get_future();
     pt3.apply();
     hpx::lcos::local::futures_factory<int()> pt4(make_int_slowly);
-    hpx::lcos::future<int> f4 = pt4.get_future();
+    hpx::future<int> f4 = pt4.get_future();
     pt4.apply();
     hpx::lcos::local::futures_factory<int()> pt5(make_int_slowly);
-    hpx::lcos::future<int> f5 = pt5.get_future();
+    hpx::future<int> f5 = pt5.get_future();
     pt5.apply();
 
-    typedef hpx::tuple<hpx::lcos::future<int>, hpx::lcos::future<int>,
-        hpx::lcos::future<int>, hpx::lcos::future<int>, hpx::lcos::future<int>>
+    typedef hpx::tuple<hpx::future<int>, hpx::future<int>, hpx::future<int>,
+        hpx::future<int>, hpx::future<int>>
         result_type;
-    hpx::lcos::future<result_type> r = hpx::when_all(f1, f2, f3, f4, f5);
+    hpx::future<result_type> r = hpx::when_all(f1, f2, f3, f4, f5);
 
     result_type result = r.get();
 
@@ -215,14 +213,13 @@ void test_wait_for_all_five_futures()
 void test_wait_for_all_late_futures()
 {
     hpx::lcos::local::futures_factory<int()> pt1(make_int_slowly);
-    hpx::lcos::future<int> f1 = pt1.get_future();
+    hpx::future<int> f1 = pt1.get_future();
     pt1.apply();
     hpx::lcos::local::futures_factory<int()> pt2(make_int_slowly);
-    hpx::lcos::future<int> f2 = pt2.get_future();
+    hpx::future<int> f2 = pt2.get_future();
 
-    typedef hpx::tuple<hpx::lcos::future<int>, hpx::lcos::future<int>>
-        result_type;
-    hpx::lcos::future<result_type> r = hpx::when_all(f1, f2);
+    typedef hpx::tuple<hpx::future<int>, hpx::future<int>> result_type;
+    hpx::future<result_type> r = hpx::when_all(f1, f2);
 
     HPX_TEST(!f1.valid());
     HPX_TEST(!f2.valid());
@@ -237,14 +234,11 @@ void test_wait_for_all_late_futures()
 
 void test_wait_for_all_deferred_futures()
 {
-    hpx::lcos::future<int> f1 =
-        hpx::async(hpx::launch::deferred, &make_int_slowly);
-    hpx::lcos::future<int> f2 =
-        hpx::async(hpx::launch::deferred, &make_int_slowly);
+    hpx::future<int> f1 = hpx::async(hpx::launch::deferred, &make_int_slowly);
+    hpx::future<int> f2 = hpx::async(hpx::launch::deferred, &make_int_slowly);
 
-    typedef hpx::tuple<hpx::lcos::future<int>, hpx::lcos::future<int>>
-        result_type;
-    hpx::lcos::future<result_type> r = hpx::when_all(f1, f2);
+    typedef hpx::tuple<hpx::future<int>, hpx::future<int>> result_type;
+    hpx::future<result_type> r = hpx::when_all(f1, f2);
 
     HPX_TEST(!f1.valid());
     HPX_TEST(!f2.valid());
@@ -259,7 +253,7 @@ void test_wait_for_all_deferred_futures()
 using hpx::program_options::options_description;
 using hpx::program_options::variables_map;
 
-using hpx::lcos::future;
+using hpx::future;
 
 int hpx_main(variables_map&)
 {

--- a/libs/core/async_combinators/tests/unit/when_all_std_array.cpp
+++ b/libs/core/async_combinators/tests/unit/when_all_std_array.cpp
@@ -36,8 +36,7 @@ void test_wait_for_all_from_array()
         task.apply();
     }
 
-    hpx::lcos::future<std::array<hpx::future<int>, 10>> r =
-        hpx::when_all(futures);
+    hpx::future<std::array<hpx::future<int>, 10>> r = hpx::when_all(futures);
 
     std::array<hpx::future<int>, 10> result = r.get();
 
@@ -51,7 +50,7 @@ void test_wait_for_all_from_array()
 using hpx::program_options::options_description;
 using hpx::program_options::variables_map;
 
-using hpx::lcos::future;
+using hpx::future;
 
 int hpx_main(variables_map&)
 {

--- a/libs/core/async_combinators/tests/unit/when_any.cpp
+++ b/libs/core/async_combinators/tests/unit/when_any.cpp
@@ -29,17 +29,16 @@ int make_int_slowly()
 void test_wait_for_either_of_two_futures_1()
 {
     hpx::lcos::local::packaged_task<int()> pt1(make_int_slowly);
-    hpx::lcos::future<int> f1(pt1.get_future());
+    hpx::future<int> f1(pt1.get_future());
     hpx::lcos::local::packaged_task<int()> pt2(make_int_slowly);
-    hpx::lcos::future<int> f2(pt2.get_future());
+    hpx::future<int> f2(pt2.get_future());
 
     pt1();
 
-    hpx::lcos::future<hpx::when_any_result<
-        hpx::tuple<hpx::lcos::future<int>, hpx::lcos::future<int>>>>
+    hpx::future<
+        hpx::when_any_result<hpx::tuple<hpx::future<int>, hpx::future<int>>>>
         r = hpx::when_any(f1, f2);
-    hpx::tuple<hpx::lcos::future<int>, hpx::lcos::future<int>> t =
-        r.get().futures;
+    hpx::tuple<hpx::future<int>, hpx::future<int>> t = r.get().futures;
 
     HPX_TEST(!f1.valid());
     HPX_TEST(!f2.valid());
@@ -51,17 +50,16 @@ void test_wait_for_either_of_two_futures_1()
 void test_wait_for_either_of_two_futures_2()
 {
     hpx::lcos::local::packaged_task<int()> pt(make_int_slowly);
-    hpx::lcos::future<int> f1(pt.get_future());
+    hpx::future<int> f1(pt.get_future());
     hpx::lcos::local::packaged_task<int()> pt2(make_int_slowly);
-    hpx::lcos::future<int> f2(pt2.get_future());
+    hpx::future<int> f2(pt2.get_future());
 
     pt2();
 
-    hpx::lcos::future<hpx::when_any_result<
-        hpx::tuple<hpx::lcos::future<int>, hpx::lcos::future<int>>>>
+    hpx::future<
+        hpx::when_any_result<hpx::tuple<hpx::future<int>, hpx::future<int>>>>
         r = hpx::when_any(f1, f2);
-    hpx::tuple<hpx::lcos::future<int>, hpx::lcos::future<int>> t =
-        r.get().futures;
+    hpx::tuple<hpx::future<int>, hpx::future<int>> t = r.get().futures;
 
     HPX_TEST(!f1.valid());
     HPX_TEST(!f2.valid());
@@ -81,8 +79,7 @@ void test_wait_for_either_of_two_futures_list_1()
 
     pt1();
 
-    hpx::lcos::future<hpx::when_any_result<Container>> r =
-        hpx::when_any(futures);
+    hpx::future<hpx::when_any_result<Container>> r = hpx::when_any(futures);
     hpx::when_any_result<Container> raw = r.get();
 
     HPX_TEST_EQ(raw.index, 0u);
@@ -107,8 +104,7 @@ void test_wait_for_either_of_two_futures_list_2()
 
     pt2();
 
-    hpx::lcos::future<hpx::when_any_result<Container>> r =
-        hpx::when_any(futures);
+    hpx::future<hpx::when_any_result<Container>> r = hpx::when_any(futures);
     hpx::when_any_result<Container> raw = r.get();
 
     HPX_TEST_EQ(raw.index, 1u);
@@ -125,20 +121,19 @@ void test_wait_for_either_of_two_futures_list_2()
 void test_wait_for_either_of_three_futures_1()
 {
     hpx::lcos::local::packaged_task<int()> pt1(make_int_slowly);
-    hpx::lcos::future<int> f1(pt1.get_future());
+    hpx::future<int> f1(pt1.get_future());
     hpx::lcos::local::packaged_task<int()> pt2(make_int_slowly);
-    hpx::lcos::future<int> f2(pt2.get_future());
+    hpx::future<int> f2(pt2.get_future());
     hpx::lcos::local::packaged_task<int()> pt3(make_int_slowly);
-    hpx::lcos::future<int> f3(pt3.get_future());
+    hpx::future<int> f3(pt3.get_future());
 
     pt1();
 
-    hpx::lcos::future<hpx::when_any_result<hpx::tuple<hpx::lcos::future<int>,
-        hpx::lcos::future<int>, hpx::lcos::future<int>>>>
+    hpx::future<hpx::when_any_result<
+        hpx::tuple<hpx::future<int>, hpx::future<int>, hpx::future<int>>>>
         r = hpx::when_any(f1, f2, f3);
-    hpx::tuple<hpx::lcos::future<int>, hpx::lcos::future<int>,
-        hpx::lcos::future<int>>
-        t = r.get().futures;
+    hpx::tuple<hpx::future<int>, hpx::future<int>, hpx::future<int>> t =
+        r.get().futures;
 
     HPX_TEST(!f1.valid());
     HPX_TEST(!f2.valid());
@@ -151,20 +146,19 @@ void test_wait_for_either_of_three_futures_1()
 void test_wait_for_either_of_three_futures_2()
 {
     hpx::lcos::local::packaged_task<int()> pt1(make_int_slowly);
-    hpx::lcos::future<int> f1(pt1.get_future());
+    hpx::future<int> f1(pt1.get_future());
     hpx::lcos::local::packaged_task<int()> pt2(make_int_slowly);
-    hpx::lcos::future<int> f2(pt2.get_future());
+    hpx::future<int> f2(pt2.get_future());
     hpx::lcos::local::packaged_task<int()> pt3(make_int_slowly);
-    hpx::lcos::future<int> f3(pt3.get_future());
+    hpx::future<int> f3(pt3.get_future());
 
     pt2();
 
-    hpx::lcos::future<hpx::when_any_result<hpx::tuple<hpx::lcos::future<int>,
-        hpx::lcos::future<int>, hpx::lcos::future<int>>>>
+    hpx::future<hpx::when_any_result<
+        hpx::tuple<hpx::future<int>, hpx::future<int>, hpx::future<int>>>>
         r = hpx::when_any(f1, f2, f3);
-    hpx::tuple<hpx::lcos::future<int>, hpx::lcos::future<int>,
-        hpx::lcos::future<int>>
-        t = r.get().futures;
+    hpx::tuple<hpx::future<int>, hpx::future<int>, hpx::future<int>> t =
+        r.get().futures;
 
     HPX_TEST(!f1.valid());
     HPX_TEST(!f2.valid());
@@ -177,20 +171,19 @@ void test_wait_for_either_of_three_futures_2()
 void test_wait_for_either_of_three_futures_3()
 {
     hpx::lcos::local::packaged_task<int()> pt1(make_int_slowly);
-    hpx::lcos::future<int> f1(pt1.get_future());
+    hpx::future<int> f1(pt1.get_future());
     hpx::lcos::local::packaged_task<int()> pt2(make_int_slowly);
-    hpx::lcos::future<int> f2(pt2.get_future());
+    hpx::future<int> f2(pt2.get_future());
     hpx::lcos::local::packaged_task<int()> pt3(make_int_slowly);
-    hpx::lcos::future<int> f3(pt3.get_future());
+    hpx::future<int> f3(pt3.get_future());
 
     pt3();
 
-    hpx::lcos::future<hpx::when_any_result<hpx::tuple<hpx::lcos::future<int>,
-        hpx::lcos::future<int>, hpx::lcos::future<int>>>>
+    hpx::future<hpx::when_any_result<
+        hpx::tuple<hpx::future<int>, hpx::future<int>, hpx::future<int>>>>
         r = hpx::when_any(f1, f2, f3);
-    hpx::tuple<hpx::lcos::future<int>, hpx::lcos::future<int>,
-        hpx::lcos::future<int>>
-        t = r.get().futures;
+    hpx::tuple<hpx::future<int>, hpx::future<int>, hpx::future<int>> t =
+        r.get().futures;
 
     HPX_TEST(!f1.valid());
     HPX_TEST(!f2.valid());
@@ -203,22 +196,21 @@ void test_wait_for_either_of_three_futures_3()
 void test_wait_for_either_of_four_futures_1()
 {
     hpx::lcos::local::packaged_task<int()> pt1(make_int_slowly);
-    hpx::lcos::future<int> f1(pt1.get_future());
+    hpx::future<int> f1(pt1.get_future());
     hpx::lcos::local::packaged_task<int()> pt2(make_int_slowly);
-    hpx::lcos::future<int> f2(pt2.get_future());
+    hpx::future<int> f2(pt2.get_future());
     hpx::lcos::local::packaged_task<int()> pt3(make_int_slowly);
-    hpx::lcos::future<int> f3(pt3.get_future());
+    hpx::future<int> f3(pt3.get_future());
     hpx::lcos::local::packaged_task<int()> pt4(make_int_slowly);
-    hpx::lcos::future<int> f4(pt4.get_future());
+    hpx::future<int> f4(pt4.get_future());
 
     pt1();
 
-    hpx::lcos::future<hpx::when_any_result<
-        hpx::tuple<hpx::lcos::future<int>, hpx::lcos::future<int>,
-            hpx::lcos::future<int>, hpx::lcos::future<int>>>>
+    hpx::future<hpx::when_any_result<hpx::tuple<hpx::future<int>,
+        hpx::future<int>, hpx::future<int>, hpx::future<int>>>>
         r = hpx::when_any(f1, f2, f3, f4);
-    hpx::tuple<hpx::lcos::future<int>, hpx::lcos::future<int>,
-        hpx::lcos::future<int>, hpx::lcos::future<int>>
+    hpx::tuple<hpx::future<int>, hpx::future<int>, hpx::future<int>,
+        hpx::future<int>>
         t = r.get().futures;
 
     HPX_TEST(!f1.valid());
@@ -233,22 +225,21 @@ void test_wait_for_either_of_four_futures_1()
 void test_wait_for_either_of_four_futures_2()
 {
     hpx::lcos::local::packaged_task<int()> pt1(make_int_slowly);
-    hpx::lcos::future<int> f1(pt1.get_future());
+    hpx::future<int> f1(pt1.get_future());
     hpx::lcos::local::packaged_task<int()> pt2(make_int_slowly);
-    hpx::lcos::future<int> f2(pt2.get_future());
+    hpx::future<int> f2(pt2.get_future());
     hpx::lcos::local::packaged_task<int()> pt3(make_int_slowly);
-    hpx::lcos::future<int> f3(pt3.get_future());
+    hpx::future<int> f3(pt3.get_future());
     hpx::lcos::local::packaged_task<int()> pt4(make_int_slowly);
-    hpx::lcos::future<int> f4(pt4.get_future());
+    hpx::future<int> f4(pt4.get_future());
 
     pt2();
 
-    hpx::lcos::future<hpx::when_any_result<
-        hpx::tuple<hpx::lcos::future<int>, hpx::lcos::future<int>,
-            hpx::lcos::future<int>, hpx::lcos::future<int>>>>
+    hpx::future<hpx::when_any_result<hpx::tuple<hpx::future<int>,
+        hpx::future<int>, hpx::future<int>, hpx::future<int>>>>
         r = hpx::when_any(f1, f2, f3, f4);
-    hpx::tuple<hpx::lcos::future<int>, hpx::lcos::future<int>,
-        hpx::lcos::future<int>, hpx::lcos::future<int>>
+    hpx::tuple<hpx::future<int>, hpx::future<int>, hpx::future<int>,
+        hpx::future<int>>
         t = r.get().futures;
 
     HPX_TEST(!f1.valid());
@@ -263,22 +254,21 @@ void test_wait_for_either_of_four_futures_2()
 void test_wait_for_either_of_four_futures_3()
 {
     hpx::lcos::local::packaged_task<int()> pt1(make_int_slowly);
-    hpx::lcos::future<int> f1(pt1.get_future());
+    hpx::future<int> f1(pt1.get_future());
     hpx::lcos::local::packaged_task<int()> pt2(make_int_slowly);
-    hpx::lcos::future<int> f2(pt2.get_future());
+    hpx::future<int> f2(pt2.get_future());
     hpx::lcos::local::packaged_task<int()> pt3(make_int_slowly);
-    hpx::lcos::future<int> f3(pt3.get_future());
+    hpx::future<int> f3(pt3.get_future());
     hpx::lcos::local::packaged_task<int()> pt4(make_int_slowly);
-    hpx::lcos::future<int> f4(pt4.get_future());
+    hpx::future<int> f4(pt4.get_future());
 
     pt3();
 
-    hpx::lcos::future<hpx::when_any_result<
-        hpx::tuple<hpx::lcos::future<int>, hpx::lcos::future<int>,
-            hpx::lcos::future<int>, hpx::lcos::future<int>>>>
+    hpx::future<hpx::when_any_result<hpx::tuple<hpx::future<int>,
+        hpx::future<int>, hpx::future<int>, hpx::future<int>>>>
         r = hpx::when_any(f1, f2, f3, f4);
-    hpx::tuple<hpx::lcos::future<int>, hpx::lcos::future<int>,
-        hpx::lcos::future<int>, hpx::lcos::future<int>>
+    hpx::tuple<hpx::future<int>, hpx::future<int>, hpx::future<int>,
+        hpx::future<int>>
         t = r.get().futures;
 
     HPX_TEST(!f1.valid());
@@ -293,22 +283,21 @@ void test_wait_for_either_of_four_futures_3()
 void test_wait_for_either_of_four_futures_4()
 {
     hpx::lcos::local::packaged_task<int()> pt1(make_int_slowly);
-    hpx::lcos::future<int> f1(pt1.get_future());
+    hpx::future<int> f1(pt1.get_future());
     hpx::lcos::local::packaged_task<int()> pt2(make_int_slowly);
-    hpx::lcos::future<int> f2(pt2.get_future());
+    hpx::future<int> f2(pt2.get_future());
     hpx::lcos::local::packaged_task<int()> pt3(make_int_slowly);
-    hpx::lcos::future<int> f3(pt3.get_future());
+    hpx::future<int> f3(pt3.get_future());
     hpx::lcos::local::packaged_task<int()> pt4(make_int_slowly);
-    hpx::lcos::future<int> f4(pt4.get_future());
+    hpx::future<int> f4(pt4.get_future());
 
     pt4();
 
-    hpx::lcos::future<hpx::when_any_result<
-        hpx::tuple<hpx::lcos::future<int>, hpx::lcos::future<int>,
-            hpx::lcos::future<int>, hpx::lcos::future<int>>>>
+    hpx::future<hpx::when_any_result<hpx::tuple<hpx::future<int>,
+        hpx::future<int>, hpx::future<int>, hpx::future<int>>>>
         r = hpx::when_any(f1, f2, f3, f4);
-    hpx::tuple<hpx::lcos::future<int>, hpx::lcos::future<int>,
-        hpx::lcos::future<int>, hpx::lcos::future<int>>
+    hpx::tuple<hpx::future<int>, hpx::future<int>, hpx::future<int>,
+        hpx::future<int>>
         t = r.get().futures;
 
     HPX_TEST(!f1.valid());
@@ -326,25 +315,24 @@ void test_wait_for_either_of_five_futures_1_from_list()
     Container futures;
 
     hpx::lcos::local::packaged_task<int()> pt1(make_int_slowly);
-    hpx::lcos::future<int> f1(pt1.get_future());
+    hpx::future<int> f1(pt1.get_future());
     futures.push_back(std::move(f1));
     hpx::lcos::local::packaged_task<int()> pt2(make_int_slowly);
-    hpx::lcos::future<int> f2(pt2.get_future());
+    hpx::future<int> f2(pt2.get_future());
     futures.push_back(std::move(f2));
     hpx::lcos::local::packaged_task<int()> pt3(make_int_slowly);
-    hpx::lcos::future<int> f3(pt3.get_future());
+    hpx::future<int> f3(pt3.get_future());
     futures.push_back(std::move(f3));
     hpx::lcos::local::packaged_task<int()> pt4(make_int_slowly);
-    hpx::lcos::future<int> f4(pt4.get_future());
+    hpx::future<int> f4(pt4.get_future());
     futures.push_back(std::move(f4));
     hpx::lcos::local::packaged_task<int()> pt5(make_int_slowly);
-    hpx::lcos::future<int> f5(pt5.get_future());
+    hpx::future<int> f5(pt5.get_future());
     futures.push_back(std::move(f5));
 
     pt1();
 
-    hpx::lcos::future<hpx::when_any_result<Container>> r =
-        hpx::when_any(futures);
+    hpx::future<hpx::when_any_result<Container>> r = hpx::when_any(futures);
     hpx::when_any_result<Container> raw = r.get();
 
     HPX_TEST_EQ(raw.index, 0u);
@@ -369,24 +357,24 @@ void test_wait_for_either_of_five_futures_1_from_list_iterators()
     Container futures;
 
     hpx::lcos::local::packaged_task<int()> pt1(make_int_slowly);
-    hpx::lcos::future<int> f1(pt1.get_future());
+    hpx::future<int> f1(pt1.get_future());
     futures.push_back(std::move(f1));
     hpx::lcos::local::packaged_task<int()> pt2(make_int_slowly);
-    hpx::lcos::future<int> f2(pt2.get_future());
+    hpx::future<int> f2(pt2.get_future());
     futures.push_back(std::move(f2));
     hpx::lcos::local::packaged_task<int()> pt3(make_int_slowly);
-    hpx::lcos::future<int> f3(pt3.get_future());
+    hpx::future<int> f3(pt3.get_future());
     futures.push_back(std::move(f3));
     hpx::lcos::local::packaged_task<int()> pt4(make_int_slowly);
-    hpx::lcos::future<int> f4(pt4.get_future());
+    hpx::future<int> f4(pt4.get_future());
     futures.push_back(std::move(f4));
     hpx::lcos::local::packaged_task<int()> pt5(make_int_slowly);
-    hpx::lcos::future<int> f5(pt5.get_future());
+    hpx::future<int> f5(pt5.get_future());
     futures.push_back(std::move(f5));
 
     pt1();
 
-    hpx::lcos::future<hpx::when_any_result<Container>> r =
+    hpx::future<hpx::when_any_result<Container>> r =
         hpx::when_any<iterator, Container>(futures.begin(), futures.end());
     hpx::when_any_result<Container> raw = r.get();
 
@@ -407,24 +395,24 @@ void test_wait_for_either_of_five_futures_1_from_list_iterators()
 void test_wait_for_either_of_five_futures_1()
 {
     hpx::lcos::local::packaged_task<int()> pt1(make_int_slowly);
-    hpx::lcos::future<int> f1(pt1.get_future());
+    hpx::future<int> f1(pt1.get_future());
     hpx::lcos::local::packaged_task<int()> pt2(make_int_slowly);
-    hpx::lcos::future<int> f2(pt2.get_future());
+    hpx::future<int> f2(pt2.get_future());
     hpx::lcos::local::packaged_task<int()> pt3(make_int_slowly);
-    hpx::lcos::future<int> f3(pt3.get_future());
+    hpx::future<int> f3(pt3.get_future());
     hpx::lcos::local::packaged_task<int()> pt4(make_int_slowly);
-    hpx::lcos::future<int> f4(pt4.get_future());
+    hpx::future<int> f4(pt4.get_future());
     hpx::lcos::local::packaged_task<int()> pt5(make_int_slowly);
-    hpx::lcos::future<int> f5(pt5.get_future());
+    hpx::future<int> f5(pt5.get_future());
 
     pt1();
 
-    hpx::lcos::future<hpx::when_any_result<hpx::tuple<hpx::lcos::future<int>,
-        hpx::lcos::future<int>, hpx::lcos::future<int>, hpx::lcos::future<int>,
-        hpx::lcos::future<int>>>>
+    hpx::future<
+        hpx::when_any_result<hpx::tuple<hpx::future<int>, hpx::future<int>,
+            hpx::future<int>, hpx::future<int>, hpx::future<int>>>>
         r = hpx::when_any(f1, f2, f3, f4, f5);
-    hpx::tuple<hpx::lcos::future<int>, hpx::lcos::future<int>,
-        hpx::lcos::future<int>, hpx::lcos::future<int>, hpx::lcos::future<int>>
+    hpx::tuple<hpx::future<int>, hpx::future<int>, hpx::future<int>,
+        hpx::future<int>, hpx::future<int>>
         t = r.get().futures;
 
     HPX_TEST(!f1.valid());
@@ -440,24 +428,24 @@ void test_wait_for_either_of_five_futures_1()
 void test_wait_for_either_of_five_futures_2()
 {
     hpx::lcos::local::packaged_task<int()> pt1(make_int_slowly);
-    hpx::lcos::future<int> f1(pt1.get_future());
+    hpx::future<int> f1(pt1.get_future());
     hpx::lcos::local::packaged_task<int()> pt2(make_int_slowly);
-    hpx::lcos::future<int> f2(pt2.get_future());
+    hpx::future<int> f2(pt2.get_future());
     hpx::lcos::local::packaged_task<int()> pt3(make_int_slowly);
-    hpx::lcos::future<int> f3(pt3.get_future());
+    hpx::future<int> f3(pt3.get_future());
     hpx::lcos::local::packaged_task<int()> pt4(make_int_slowly);
-    hpx::lcos::future<int> f4(pt4.get_future());
+    hpx::future<int> f4(pt4.get_future());
     hpx::lcos::local::packaged_task<int()> pt5(make_int_slowly);
-    hpx::lcos::future<int> f5(pt5.get_future());
+    hpx::future<int> f5(pt5.get_future());
 
     pt2();
 
-    hpx::lcos::future<hpx::when_any_result<hpx::tuple<hpx::lcos::future<int>,
-        hpx::lcos::future<int>, hpx::lcos::future<int>, hpx::lcos::future<int>,
-        hpx::lcos::future<int>>>>
+    hpx::future<
+        hpx::when_any_result<hpx::tuple<hpx::future<int>, hpx::future<int>,
+            hpx::future<int>, hpx::future<int>, hpx::future<int>>>>
         r = hpx::when_any(f1, f2, f3, f4, f5);
-    hpx::tuple<hpx::lcos::future<int>, hpx::lcos::future<int>,
-        hpx::lcos::future<int>, hpx::lcos::future<int>, hpx::lcos::future<int>>
+    hpx::tuple<hpx::future<int>, hpx::future<int>, hpx::future<int>,
+        hpx::future<int>, hpx::future<int>>
         t = r.get().futures;
 
     HPX_TEST(!f1.valid());
@@ -473,24 +461,24 @@ void test_wait_for_either_of_five_futures_2()
 void test_wait_for_either_of_five_futures_3()
 {
     hpx::lcos::local::packaged_task<int()> pt1(make_int_slowly);
-    hpx::lcos::future<int> f1(pt1.get_future());
+    hpx::future<int> f1(pt1.get_future());
     hpx::lcos::local::packaged_task<int()> pt2(make_int_slowly);
-    hpx::lcos::future<int> f2(pt2.get_future());
+    hpx::future<int> f2(pt2.get_future());
     hpx::lcos::local::packaged_task<int()> pt3(make_int_slowly);
-    hpx::lcos::future<int> f3(pt3.get_future());
+    hpx::future<int> f3(pt3.get_future());
     hpx::lcos::local::packaged_task<int()> pt4(make_int_slowly);
-    hpx::lcos::future<int> f4(pt4.get_future());
+    hpx::future<int> f4(pt4.get_future());
     hpx::lcos::local::packaged_task<int()> pt5(make_int_slowly);
-    hpx::lcos::future<int> f5(pt5.get_future());
+    hpx::future<int> f5(pt5.get_future());
 
     pt3();
 
-    hpx::lcos::future<hpx::when_any_result<hpx::tuple<hpx::lcos::future<int>,
-        hpx::lcos::future<int>, hpx::lcos::future<int>, hpx::lcos::future<int>,
-        hpx::lcos::future<int>>>>
+    hpx::future<
+        hpx::when_any_result<hpx::tuple<hpx::future<int>, hpx::future<int>,
+            hpx::future<int>, hpx::future<int>, hpx::future<int>>>>
         r = hpx::when_any(f1, f2, f3, f4, f5);
-    hpx::tuple<hpx::lcos::future<int>, hpx::lcos::future<int>,
-        hpx::lcos::future<int>, hpx::lcos::future<int>, hpx::lcos::future<int>>
+    hpx::tuple<hpx::future<int>, hpx::future<int>, hpx::future<int>,
+        hpx::future<int>, hpx::future<int>>
         t = r.get().futures;
 
     HPX_TEST(!f1.valid());
@@ -506,24 +494,24 @@ void test_wait_for_either_of_five_futures_3()
 void test_wait_for_either_of_five_futures_4()
 {
     hpx::lcos::local::packaged_task<int()> pt1(make_int_slowly);
-    hpx::lcos::future<int> f1(pt1.get_future());
+    hpx::future<int> f1(pt1.get_future());
     hpx::lcos::local::packaged_task<int()> pt2(make_int_slowly);
-    hpx::lcos::future<int> f2(pt2.get_future());
+    hpx::future<int> f2(pt2.get_future());
     hpx::lcos::local::packaged_task<int()> pt3(make_int_slowly);
-    hpx::lcos::future<int> f3(pt3.get_future());
+    hpx::future<int> f3(pt3.get_future());
     hpx::lcos::local::packaged_task<int()> pt4(make_int_slowly);
-    hpx::lcos::future<int> f4(pt4.get_future());
+    hpx::future<int> f4(pt4.get_future());
     hpx::lcos::local::packaged_task<int()> pt5(make_int_slowly);
-    hpx::lcos::future<int> f5(pt5.get_future());
+    hpx::future<int> f5(pt5.get_future());
 
     pt4();
 
-    hpx::lcos::future<hpx::when_any_result<hpx::tuple<hpx::lcos::future<int>,
-        hpx::lcos::future<int>, hpx::lcos::future<int>, hpx::lcos::future<int>,
-        hpx::lcos::future<int>>>>
+    hpx::future<
+        hpx::when_any_result<hpx::tuple<hpx::future<int>, hpx::future<int>,
+            hpx::future<int>, hpx::future<int>, hpx::future<int>>>>
         r = hpx::when_any(f1, f2, f3, f4, f5);
-    hpx::tuple<hpx::lcos::future<int>, hpx::lcos::future<int>,
-        hpx::lcos::future<int>, hpx::lcos::future<int>, hpx::lcos::future<int>>
+    hpx::tuple<hpx::future<int>, hpx::future<int>, hpx::future<int>,
+        hpx::future<int>, hpx::future<int>>
         t = r.get().futures;
 
     HPX_TEST(!f1.valid());
@@ -539,24 +527,24 @@ void test_wait_for_either_of_five_futures_4()
 void test_wait_for_either_of_five_futures_5()
 {
     hpx::lcos::local::packaged_task<int()> pt1(make_int_slowly);
-    hpx::lcos::future<int> f1(pt1.get_future());
+    hpx::future<int> f1(pt1.get_future());
     hpx::lcos::local::packaged_task<int()> pt2(make_int_slowly);
-    hpx::lcos::future<int> f2(pt2.get_future());
+    hpx::future<int> f2(pt2.get_future());
     hpx::lcos::local::packaged_task<int()> pt3(make_int_slowly);
-    hpx::lcos::future<int> f3(pt3.get_future());
+    hpx::future<int> f3(pt3.get_future());
     hpx::lcos::local::packaged_task<int()> pt4(make_int_slowly);
-    hpx::lcos::future<int> f4(pt4.get_future());
+    hpx::future<int> f4(pt4.get_future());
     hpx::lcos::local::packaged_task<int()> pt5(make_int_slowly);
-    hpx::lcos::future<int> f5(pt5.get_future());
+    hpx::future<int> f5(pt5.get_future());
 
     pt5();
 
-    hpx::lcos::future<hpx::when_any_result<hpx::tuple<hpx::lcos::future<int>,
-        hpx::lcos::future<int>, hpx::lcos::future<int>, hpx::lcos::future<int>,
-        hpx::lcos::future<int>>>>
+    hpx::future<
+        hpx::when_any_result<hpx::tuple<hpx::future<int>, hpx::future<int>,
+            hpx::future<int>, hpx::future<int>, hpx::future<int>>>>
         r = hpx::when_any(f1, f2, f3, f4, f5);
-    hpx::tuple<hpx::lcos::future<int>, hpx::lcos::future<int>,
-        hpx::lcos::future<int>, hpx::lcos::future<int>, hpx::lcos::future<int>>
+    hpx::tuple<hpx::future<int>, hpx::future<int>, hpx::future<int>,
+        hpx::future<int>, hpx::future<int>>
         t = r.get().futures;
 
     HPX_TEST(!f1.valid());
@@ -574,9 +562,9 @@ void test_wait_for_either_of_five_futures_5()
 // {
 //     callback_called = 0;
 //     hpx::lcos::local::packaged_task<int()> pt1(make_int_slowly);
-//     hpx::lcos::future<int> fi = pt1.get_future();
+//     hpx::future<int> fi = pt1.get_future();
 //     hpx::lcos::local::packaged_task<int()> pt2(make_int_slowly);
-//     hpx::lcos::future<int> fi2 = pt2.get_future();
+//     hpx::future<int> fi2 = pt2.get_future();
 //     pt1.set_wait_callback(wait_callback_for_task);
 //
 //     hpx::thread t(std::move(pt));
@@ -592,7 +580,7 @@ void test_wait_for_either_of_five_futures_5()
 //     for(unsigned i = 0; i < count; ++i)
 //     {
 //         hpx::lcos::local::packaged_task<int()> tasks[count];
-//         hpx::lcos::future<int> futures[count];
+//         hpx::future<int> futures[count];
 //         for(unsigned j = 0; j < count; ++j)
 //         {
 //             tasks[j] =
@@ -603,7 +591,7 @@ void test_wait_for_either_of_five_futures_5()
 //
 //         hpx::lcos::wait_any(futures, futures);
 //
-//         hpx::lcos::future<int>* const future =
+//         hpx::future<int>* const future =
 //               boost::wait_for_any(futures, futures+count);
 //
 //         HPX_TEST_EQ(future, (futures + i));
@@ -625,12 +613,12 @@ void test_wait_for_either_of_five_futures_5()
 void test_wait_for_either_of_two_late_futures()
 {
     hpx::lcos::local::packaged_task<int()> pt1(make_int_slowly);
-    hpx::lcos::future<int> f1(pt1.get_future());
+    hpx::future<int> f1(pt1.get_future());
     hpx::lcos::local::packaged_task<int()> pt2(make_int_slowly);
-    hpx::lcos::future<int> f2(pt2.get_future());
+    hpx::future<int> f2(pt2.get_future());
 
-    hpx::lcos::future<hpx::when_any_result<
-        hpx::tuple<hpx::lcos::future<int>, hpx::lcos::future<int>>>>
+    hpx::future<
+        hpx::when_any_result<hpx::tuple<hpx::future<int>, hpx::future<int>>>>
         r = hpx::when_any(f1, f2);
 
     HPX_TEST(!f1.valid());
@@ -639,8 +627,7 @@ void test_wait_for_either_of_two_late_futures()
     pt2();
     pt1();
 
-    hpx::tuple<hpx::lcos::future<int>, hpx::lcos::future<int>> t =
-        r.get().futures;
+    hpx::tuple<hpx::future<int>, hpx::future<int>> t = r.get().futures;
 
     HPX_TEST(hpx::get<1>(t).is_ready());
     HPX_TEST_EQ(hpx::get<1>(t).get(), 42);
@@ -648,20 +635,17 @@ void test_wait_for_either_of_two_late_futures()
 
 void test_wait_for_either_of_two_deferred_futures()
 {
-    hpx::lcos::future<int> f1 =
-        hpx::async(hpx::launch::deferred, &make_int_slowly);
-    hpx::lcos::future<int> f2 =
-        hpx::async(hpx::launch::deferred, &make_int_slowly);
+    hpx::future<int> f1 = hpx::async(hpx::launch::deferred, &make_int_slowly);
+    hpx::future<int> f2 = hpx::async(hpx::launch::deferred, &make_int_slowly);
 
-    hpx::lcos::future<hpx::when_any_result<
-        hpx::tuple<hpx::lcos::future<int>, hpx::lcos::future<int>>>>
+    hpx::future<
+        hpx::when_any_result<hpx::tuple<hpx::future<int>, hpx::future<int>>>>
         r = hpx::when_any(f1, f2);
 
     HPX_TEST(!f1.valid());
     HPX_TEST(!f2.valid());
 
-    hpx::tuple<hpx::lcos::future<int>, hpx::lcos::future<int>> t =
-        r.get().futures;
+    hpx::tuple<hpx::future<int>, hpx::future<int>> t = r.get().futures;
 
     HPX_TEST(hpx::get<0>(t).is_ready());
     HPX_TEST_EQ(hpx::get<0>(t).get(), 42);
@@ -671,7 +655,7 @@ void test_wait_for_either_of_two_deferred_futures()
 using hpx::program_options::options_description;
 using hpx::program_options::variables_map;
 
-using hpx::lcos::future;
+using hpx::future;
 
 int hpx_main(variables_map&)
 {

--- a/libs/core/async_combinators/tests/unit/when_any_std_array.cpp
+++ b/libs/core/async_combinators/tests/unit/when_any_std_array.cpp
@@ -35,7 +35,7 @@ void test_wait_for_either_of_two_futures_list()
 
     pt1();
 
-    hpx::lcos::future<hpx::when_any_result<std::array<hpx::future<int>, 2>>> r =
+    hpx::future<hpx::when_any_result<std::array<hpx::future<int>, 2>>> r =
         hpx::when_any(futures);
     hpx::when_any_result<std::array<hpx::future<int>, 2>> raw = r.get();
 
@@ -54,7 +54,7 @@ void test_wait_for_either_of_two_futures_list()
 using hpx::program_options::options_description;
 using hpx::program_options::variables_map;
 
-using hpx::lcos::future;
+using hpx::future;
 
 int hpx_main(variables_map&)
 {

--- a/libs/core/async_combinators/tests/unit/when_each.cpp
+++ b/libs/core/async_combinators/tests/unit/when_each.cpp
@@ -537,14 +537,14 @@ void test_when_each_deferred_futures()
         HPX_TEST_LT(id, count);
     };
 
-    hpx::lcos::future<unsigned> f1 =
+    hpx::future<unsigned> f1 =
         hpx::async(hpx::launch::deferred, &make_unsigned_slowly<0>);
-    hpx::lcos::future<unsigned> f2 =
+    hpx::future<unsigned> f2 =
         hpx::async(hpx::launch::deferred, &make_unsigned_slowly<1>);
 
-    hpx::lcos::future<unsigned> g1 =
+    hpx::future<unsigned> g1 =
         hpx::async(hpx::launch::deferred, &make_unsigned_slowly<0>);
-    hpx::lcos::future<unsigned> g2 =
+    hpx::future<unsigned> g2 =
         hpx::async(hpx::launch::deferred, &make_unsigned_slowly<1>);
 
     hpx::future<void> r =
@@ -570,7 +570,7 @@ void test_when_each_deferred_futures()
 using hpx::program_options::options_description;
 using hpx::program_options::variables_map;
 
-using hpx::lcos::future;
+using hpx::future;
 
 int hpx_main(variables_map&)
 {

--- a/libs/core/async_combinators/tests/unit/when_some.cpp
+++ b/libs/core/async_combinators/tests/unit/when_some.cpp
@@ -30,24 +30,22 @@ void test_wait_for_two_out_of_five_futures()
     unsigned const count = 2;
 
     hpx::lcos::local::packaged_task<int()> pt1(make_int_slowly);
-    hpx::lcos::future<int> f1 = pt1.get_future();
+    hpx::future<int> f1 = pt1.get_future();
     hpx::lcos::local::packaged_task<int()> pt2(make_int_slowly);
-    hpx::lcos::future<int> f2 = pt2.get_future();
+    hpx::future<int> f2 = pt2.get_future();
     pt2();
     hpx::lcos::local::packaged_task<int()> pt3(make_int_slowly);
-    hpx::lcos::future<int> f3 = pt3.get_future();
+    hpx::future<int> f3 = pt3.get_future();
     hpx::lcos::local::packaged_task<int()> pt4(make_int_slowly);
-    hpx::lcos::future<int> f4 = pt4.get_future();
+    hpx::future<int> f4 = pt4.get_future();
     pt4();
     hpx::lcos::local::packaged_task<int()> pt5(make_int_slowly);
-    hpx::lcos::future<int> f5 = pt5.get_future();
+    hpx::future<int> f5 = pt5.get_future();
 
-    typedef hpx::when_some_result<hpx::tuple<hpx::lcos::future<int>,
-        hpx::lcos::future<int>, hpx::lcos::future<int>, hpx::lcos::future<int>,
-        hpx::lcos::future<int>>>
+    typedef hpx::when_some_result<hpx::tuple<hpx::future<int>, hpx::future<int>,
+        hpx::future<int>, hpx::future<int>, hpx::future<int>>>
         result_type;
-    hpx::lcos::future<result_type> r =
-        hpx::when_some(count, f1, f2, f3, f4, f5);
+    hpx::future<result_type> r = hpx::when_some(count, f1, f2, f3, f4, f5);
 
     result_type result = r.get();
 
@@ -70,25 +68,23 @@ void test_wait_for_three_out_of_five_futures()
     unsigned const count = 3;
 
     hpx::lcos::local::packaged_task<int()> pt1(make_int_slowly);
-    hpx::lcos::future<int> f1 = pt1.get_future();
+    hpx::future<int> f1 = pt1.get_future();
     pt1();
     hpx::lcos::local::packaged_task<int()> pt2(make_int_slowly);
-    hpx::lcos::future<int> f2 = pt2.get_future();
+    hpx::future<int> f2 = pt2.get_future();
     hpx::lcos::local::packaged_task<int()> pt3(make_int_slowly);
-    hpx::lcos::future<int> f3 = pt3.get_future();
+    hpx::future<int> f3 = pt3.get_future();
     pt3();
     hpx::lcos::local::packaged_task<int()> pt4(make_int_slowly);
-    hpx::lcos::future<int> f4 = pt4.get_future();
+    hpx::future<int> f4 = pt4.get_future();
     hpx::lcos::local::packaged_task<int()> pt5(make_int_slowly);
-    hpx::lcos::future<int> f5 = pt5.get_future();
+    hpx::future<int> f5 = pt5.get_future();
     pt5();
 
-    typedef hpx::when_some_result<hpx::tuple<hpx::lcos::future<int>,
-        hpx::lcos::future<int>, hpx::lcos::future<int>, hpx::lcos::future<int>,
-        hpx::lcos::future<int>>>
+    typedef hpx::when_some_result<hpx::tuple<hpx::future<int>, hpx::future<int>,
+        hpx::future<int>, hpx::future<int>, hpx::future<int>>>
         result_type;
-    hpx::lcos::future<result_type> r =
-        hpx::when_some(count, f1, f2, f3, f4, f5);
+    hpx::future<result_type> r = hpx::when_some(count, f1, f2, f3, f4, f5);
 
     result_type result = r.get();
 
@@ -111,22 +107,20 @@ void test_wait_for_two_out_of_five_late_futures()
     unsigned const count = 2;
 
     hpx::lcos::local::packaged_task<int()> pt1(make_int_slowly);
-    hpx::lcos::future<int> f1 = pt1.get_future();
+    hpx::future<int> f1 = pt1.get_future();
     hpx::lcos::local::packaged_task<int()> pt2(make_int_slowly);
-    hpx::lcos::future<int> f2 = pt2.get_future();
+    hpx::future<int> f2 = pt2.get_future();
     hpx::lcos::local::packaged_task<int()> pt3(make_int_slowly);
-    hpx::lcos::future<int> f3 = pt3.get_future();
+    hpx::future<int> f3 = pt3.get_future();
     hpx::lcos::local::packaged_task<int()> pt4(make_int_slowly);
-    hpx::lcos::future<int> f4 = pt4.get_future();
+    hpx::future<int> f4 = pt4.get_future();
     hpx::lcos::local::packaged_task<int()> pt5(make_int_slowly);
-    hpx::lcos::future<int> f5 = pt5.get_future();
+    hpx::future<int> f5 = pt5.get_future();
 
-    typedef hpx::when_some_result<hpx::tuple<hpx::lcos::future<int>,
-        hpx::lcos::future<int>, hpx::lcos::future<int>, hpx::lcos::future<int>,
-        hpx::lcos::future<int>>>
+    typedef hpx::when_some_result<hpx::tuple<hpx::future<int>, hpx::future<int>,
+        hpx::future<int>, hpx::future<int>, hpx::future<int>>>
         result_type;
-    hpx::lcos::future<result_type> r =
-        hpx::when_some(count, f1, f2, f3, f4, f5);
+    hpx::future<result_type> r = hpx::when_some(count, f1, f2, f3, f4, f5);
 
     HPX_TEST(!f1.valid());
     HPX_TEST(!f2.valid());
@@ -151,23 +145,16 @@ void test_wait_for_two_out_of_five_deferred_futures()
 {
     unsigned const count = 2;
 
-    hpx::lcos::future<int> f1 =
-        hpx::async(hpx::launch::deferred, &make_int_slowly);
-    hpx::lcos::future<int> f2 =
-        hpx::async(hpx::launch::deferred, &make_int_slowly);
-    hpx::lcos::future<int> f3 =
-        hpx::async(hpx::launch::deferred, &make_int_slowly);
-    hpx::lcos::future<int> f4 =
-        hpx::async(hpx::launch::deferred, &make_int_slowly);
-    hpx::lcos::future<int> f5 =
-        hpx::async(hpx::launch::deferred, &make_int_slowly);
+    hpx::future<int> f1 = hpx::async(hpx::launch::deferred, &make_int_slowly);
+    hpx::future<int> f2 = hpx::async(hpx::launch::deferred, &make_int_slowly);
+    hpx::future<int> f3 = hpx::async(hpx::launch::deferred, &make_int_slowly);
+    hpx::future<int> f4 = hpx::async(hpx::launch::deferred, &make_int_slowly);
+    hpx::future<int> f5 = hpx::async(hpx::launch::deferred, &make_int_slowly);
 
-    typedef hpx::when_some_result<hpx::tuple<hpx::lcos::future<int>,
-        hpx::lcos::future<int>, hpx::lcos::future<int>, hpx::lcos::future<int>,
-        hpx::lcos::future<int>>>
+    typedef hpx::when_some_result<hpx::tuple<hpx::future<int>, hpx::future<int>,
+        hpx::future<int>, hpx::future<int>, hpx::future<int>>>
         result_type;
-    hpx::lcos::future<result_type> r =
-        hpx::when_some(count, f1, f2, f3, f4, f5);
+    hpx::future<result_type> r = hpx::when_some(count, f1, f2, f3, f4, f5);
 
     HPX_TEST(!f1.valid());
     HPX_TEST(!f2.valid());
@@ -196,7 +183,7 @@ void test_wait_for_either_of_two_futures_list_1()
 
     pt1();
 
-    hpx::lcos::future<hpx::when_some_result<Container>> r =
+    hpx::future<hpx::when_some_result<Container>> r =
         hpx::when_some(1u, futures);
     hpx::when_some_result<Container> raw = r.get();
 
@@ -223,7 +210,7 @@ void test_wait_for_either_of_two_futures_list_2()
 
     pt2();
 
-    hpx::lcos::future<hpx::when_some_result<Container>> r =
+    hpx::future<hpx::when_some_result<Container>> r =
         hpx::when_some(1u, futures);
     hpx::when_some_result<Container> raw = r.get();
 
@@ -245,25 +232,25 @@ void test_wait_for_either_of_five_futures_1_from_list()
     Container futures;
 
     hpx::lcos::local::packaged_task<int()> pt1(make_int_slowly);
-    hpx::lcos::future<int> f1(pt1.get_future());
+    hpx::future<int> f1(pt1.get_future());
     futures.push_back(std::move(f1));
     hpx::lcos::local::packaged_task<int()> pt2(make_int_slowly);
-    hpx::lcos::future<int> f2(pt2.get_future());
+    hpx::future<int> f2(pt2.get_future());
     futures.push_back(std::move(f2));
     hpx::lcos::local::packaged_task<int()> pt3(make_int_slowly);
-    hpx::lcos::future<int> f3(pt3.get_future());
+    hpx::future<int> f3(pt3.get_future());
     futures.push_back(std::move(f3));
     hpx::lcos::local::packaged_task<int()> pt4(make_int_slowly);
-    hpx::lcos::future<int> f4(pt4.get_future());
+    hpx::future<int> f4(pt4.get_future());
     futures.push_back(std::move(f4));
     hpx::lcos::local::packaged_task<int()> pt5(make_int_slowly);
-    hpx::lcos::future<int> f5(pt5.get_future());
+    hpx::future<int> f5(pt5.get_future());
     futures.push_back(std::move(f5));
 
     pt1();
     pt5();
 
-    hpx::lcos::future<hpx::when_some_result<Container>> r =
+    hpx::future<hpx::when_some_result<Container>> r =
         hpx::when_some(2u, futures);
     hpx::when_some_result<Container> raw = r.get();
 
@@ -290,26 +277,26 @@ void test_wait_for_either_of_five_futures_1_from_list_iterators()
     Container futures;
 
     hpx::lcos::local::packaged_task<int()> pt1(make_int_slowly);
-    hpx::lcos::future<int> f1(pt1.get_future());
+    hpx::future<int> f1(pt1.get_future());
     futures.push_back(std::move(f1));
     hpx::lcos::local::packaged_task<int()> pt2(make_int_slowly);
-    hpx::lcos::future<int> f2(pt2.get_future());
+    hpx::future<int> f2(pt2.get_future());
     futures.push_back(std::move(f2));
     hpx::lcos::local::packaged_task<int()> pt3(make_int_slowly);
-    hpx::lcos::future<int> f3(pt3.get_future());
+    hpx::future<int> f3(pt3.get_future());
     futures.push_back(std::move(f3));
     hpx::lcos::local::packaged_task<int()> pt4(make_int_slowly);
-    hpx::lcos::future<int> f4(pt4.get_future());
+    hpx::future<int> f4(pt4.get_future());
     futures.push_back(std::move(f4));
     hpx::lcos::local::packaged_task<int()> pt5(make_int_slowly);
-    hpx::lcos::future<int> f5(pt5.get_future());
+    hpx::future<int> f5(pt5.get_future());
     futures.push_back(std::move(f5));
 
     pt1();
     pt3();
     pt5();
 
-    hpx::lcos::future<hpx::when_some_result<Container>> r =
+    hpx::future<hpx::when_some_result<Container>> r =
         hpx::when_some<iterator, Container>(3u, futures.begin(), futures.end());
     hpx::when_some_result<Container> raw = r.get();
 
@@ -333,7 +320,7 @@ void test_wait_for_either_of_five_futures_1_from_list_iterators()
 using hpx::program_options::options_description;
 using hpx::program_options::variables_map;
 
-using hpx::lcos::future;
+using hpx::future;
 
 int hpx_main(variables_map&)
 {

--- a/libs/core/async_combinators/tests/unit/when_some_std_array.cpp
+++ b/libs/core/async_combinators/tests/unit/when_some_std_array.cpp
@@ -35,8 +35,8 @@ void test_wait_for_either_of_two_futures_list()
 
     pt1();
 
-    hpx::lcos::future<hpx::when_some_result<std::array<hpx::future<int>, 2>>>
-        r = hpx::when_some(1u, futures);
+    hpx::future<hpx::when_some_result<std::array<hpx::future<int>, 2>>> r =
+        hpx::when_some(1u, futures);
     hpx::when_some_result<std::array<hpx::future<int>, 2>> raw = r.get();
 
     HPX_TEST_EQ(raw.indices.size(), 1u);
@@ -55,7 +55,7 @@ void test_wait_for_either_of_two_futures_list()
 using hpx::program_options::options_description;
 using hpx::program_options::variables_map;
 
-using hpx::lcos::future;
+using hpx::future;
 
 int hpx_main(variables_map&)
 {

--- a/libs/core/execution/include/hpx/execution/detail/future_exec.hpp
+++ b/libs/core/execution/include/hpx/execution/detail/future_exec.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2019 Hartmut Kaiser
+//  Copyright (c) 2007-2021 Hartmut Kaiser
 //  Copyright (c) 2013 Agustin Berge
 //
 //  SPDX-License-Identifier: BSL-1.0
@@ -34,9 +34,10 @@
 #include <utility>
 
 namespace hpx { namespace lcos { namespace detail {
+
     template <typename Executor, typename Future, typename F>
-    inline typename hpx::traits::future_then_executor_result<Executor,
-        typename std::decay<Future>::type, F>::type
+    inline hpx::traits::future_then_executor_result_t<Executor,
+        std::decay_t<Future>, F>
     then_execute_helper(Executor&& exec, F&& f, Future&& predecessor)
     {
         // simply forward this to executor
@@ -48,42 +49,42 @@ namespace hpx { namespace lcos { namespace detail {
     // launch
     template <typename Future, typename Policy>
     struct future_then_dispatch<Future, Policy,
-        typename std::enable_if<traits::is_launch_policy<Policy>::value>::type>
+        std::enable_if_t<traits::is_launch_policy_v<Policy>>>
     {
         template <typename Policy_, typename F>
-        HPX_FORCEINLINE static
-            typename hpx::traits::future_then_result<Future, F>::type
-            call(Future&& fut, Policy_&& policy, F&& f)
+        HPX_FORCEINLINE static hpx::traits::future_then_result_t<Future, F>
+        call(Future&& fut, Policy_&& policy, F&& f)
         {
             using result_type = typename hpx::traits::future_then_result<Future,
                 F>::result_type;
             using continuation_result_type =
-                typename hpx::util::invoke_result<F, Future>::type;
+                hpx::util::invoke_result_t<F, Future>;
 
-            typename hpx::traits::detail::shared_state_ptr<result_type>::type
-                p = detail::make_continuation_alloc<continuation_result_type>(
+            hpx::traits::detail::shared_state_ptr_t<result_type> p =
+                detail::make_continuation_alloc<continuation_result_type>(
                     hpx::util::internal_allocator<>{}, HPX_MOVE(fut),
                     HPX_FORWARD(Policy_, policy), HPX_FORWARD(F, f));
-            return hpx::traits::future_access<future<result_type>>::create(
+
+            return hpx::traits::future_access<hpx::future<result_type>>::create(
                 HPX_MOVE(p));
         }
 
         template <typename Allocator, typename Policy_, typename F>
-        HPX_FORCEINLINE static
-            typename hpx::traits::future_then_result<Future, F>::type
-            call_alloc(
-                Allocator const& alloc, Future&& fut, Policy_&& policy, F&& f)
+        HPX_FORCEINLINE static hpx::traits::future_then_result_t<Future, F>
+        call_alloc(
+            Allocator const& alloc, Future&& fut, Policy_&& policy, F&& f)
         {
             using result_type = typename hpx::traits::future_then_result<Future,
                 F>::result_type;
             using continuation_result_type =
-                typename hpx::util::invoke_result<F, Future>::type;
+                hpx::util::invoke_result_t<F, Future>;
 
-            typename hpx::traits::detail::shared_state_ptr<result_type>::type
-                p = detail::make_continuation_alloc<continuation_result_type>(
-                    alloc, HPX_MOVE(fut), HPX_FORWARD(Policy_, policy),
+            hpx::traits::detail::shared_state_ptr_t<result_type> p =
+                detail::make_continuation_alloc<continuation_result_type>(alloc,
+                    HPX_MOVE(fut), HPX_FORWARD(Policy_, policy),
                     HPX_FORWARD(F, f));
-            return hpx::traits::future_access<future<result_type>>::create(
+
+            return hpx::traits::future_access<hpx::future<result_type>>::create(
                 HPX_MOVE(p));
         }
     };
@@ -95,14 +96,13 @@ namespace hpx { namespace lcos { namespace detail {
     // threads::executor
     template <typename Future, typename Executor>
     struct future_then_dispatch<Future, Executor,
-        typename std::enable_if<traits::is_one_way_executor<Executor>::value ||
-            traits::is_two_way_executor<Executor>::value>::type>
+        std::enable_if_t<traits::is_one_way_executor_v<Executor> ||
+            traits::is_two_way_executor_v<Executor>>>
     {
         template <typename Executor_, typename F>
-        HPX_FORCEINLINE static
-            typename hpx::traits::future_then_executor_result<Executor_, Future,
-                F>::type
-            call(Future&& fut, Executor_&& exec, F&& f)
+        HPX_FORCEINLINE static hpx::traits::future_then_executor_result_t<
+            Executor_, Future, F>
+        call(Future&& fut, Executor_&& exec, F&& f)
         {
             // simply forward this to executor
             return detail::then_execute_helper(
@@ -110,10 +110,9 @@ namespace hpx { namespace lcos { namespace detail {
         }
 
         template <typename Allocator, typename Executor_, typename F>
-        HPX_FORCEINLINE static
-            typename hpx::traits::future_then_executor_result<Executor_, Future,
-                F>::type
-            call_alloc(Allocator const&, Future&& fut, Executor_&& exec, F&& f)
+        HPX_FORCEINLINE static hpx::traits::future_then_executor_result_t<
+            Executor_, Future, F>
+        call_alloc(Allocator const&, Future&& fut, Executor_&& exec, F&& f)
         {
             return call(HPX_FORWARD(Future, fut), HPX_FORWARD(Executor_, exec),
                 HPX_FORWARD(F, f));
@@ -123,9 +122,9 @@ namespace hpx { namespace lcos { namespace detail {
     // plain function, or function object
     template <typename Future, typename FD>
     struct future_then_dispatch<Future, FD,
-        typename std::enable_if<!traits::is_launch_policy<FD>::value &&
-            !(traits::is_one_way_executor<FD>::value ||
-                traits::is_two_way_executor<FD>::value)>::type>
+        std::enable_if_t<!traits::is_launch_policy_v<FD> &&
+            !(traits::is_one_way_executor_v<FD> ||
+                traits::is_two_way_executor_v<FD>)>>
     {
         template <typename F>
         HPX_FORCEINLINE static auto call(Future&& fut, F&& f)
@@ -173,36 +172,36 @@ namespace hpx { namespace lcos { namespace detail {
 
     ///////////////////////////////////////////////////////////////////////////
     template <typename ContResult, typename Future, typename Policy, typename F>
-    inline typename traits::detail::shared_state_ptr<
-        typename continuation_result<ContResult>::type>::type
+    inline traits::detail::shared_state_ptr_t<continuation_result_t<ContResult>>
     make_continuation(Future const& future, Policy&& policy, F&& f)
     {
-        using result_type = typename continuation_result<ContResult>::type;
+        using result_type = continuation_result_t<ContResult>;
         using shared_state = detail::continuation<Future, F, result_type>;
         using init_no_addref = typename shared_state::init_no_addref;
         using spawner_type = post_policy_spawner;
 
         // create a continuation
-        typename traits::detail::shared_state_ptr<result_type>::type p(
+        traits::detail::shared_state_ptr_t<result_type> p(
             new shared_state(init_no_addref{}, HPX_FORWARD(F, f)), false);
+
         static_cast<shared_state*>(p.get())->template attach<spawner_type>(
             future, spawner_type{}, HPX_FORWARD(Policy, policy));
+
         return p;
     }
 
     // same as above, except with allocator
     template <typename ContResult, typename Allocator, typename Future,
         typename Policy, typename F>
-    inline typename traits::detail::shared_state_ptr<
-        typename continuation_result<ContResult>::type>::type
+    inline traits::detail::shared_state_ptr_t<continuation_result_t<ContResult>>
     make_continuation_alloc(
         Allocator const& a, Future const& future, Policy&& policy, F&& f)
     {
-        using result_type = typename continuation_result<ContResult>::type;
+        using result_type = continuation_result_t<ContResult>;
 
         using base_allocator = Allocator;
-        using shared_state = typename traits::detail::shared_state_allocator<
-            detail::continuation<Future, F, result_type>, base_allocator>::type;
+        using shared_state = traits::shared_state_allocator_t<
+            detail::continuation<Future, F, result_type>, base_allocator>;
 
         using other_allocator = typename std::allocator_traits<
             base_allocator>::template rebind_alloc<shared_state>;
@@ -222,7 +221,7 @@ namespace hpx { namespace lcos { namespace detail {
             alloc, p.get(), init_no_addref{}, alloc, HPX_FORWARD(F, f));
 
         // create a continuation
-        typename hpx::traits::detail::shared_state_ptr<result_type>::type r(
+        hpx::traits::detail::shared_state_ptr_t<result_type> r(
             p.release(), false);
 
         static_cast<shared_state*>(r.get())->template attach<spawner_type>(
@@ -235,15 +234,15 @@ namespace hpx { namespace lcos { namespace detail {
     // futures
     template <typename ContResult, typename Allocator, typename Future,
         typename Policy, typename F>
-    inline typename traits::detail::shared_state_ptr<ContResult>::type
+    inline traits::detail::shared_state_ptr_t<ContResult>
     make_continuation_alloc_nounwrap(
         Allocator const& a, Future const& future, Policy&& policy, F&& f)
     {
         using result_type = ContResult;
 
         using base_allocator = Allocator;
-        using shared_state = typename traits::detail::shared_state_allocator<
-            detail::continuation<Future, F, result_type>, base_allocator>::type;
+        using shared_state = traits::shared_state_allocator_t<
+            detail::continuation<Future, F, result_type>, base_allocator>;
 
         using other_allocator = typename std::allocator_traits<
             base_allocator>::template rebind_alloc<shared_state>;
@@ -275,42 +274,44 @@ namespace hpx { namespace lcos { namespace detail {
 
     template <typename ContResult, typename Future, typename Executor,
         typename F>
-    inline typename traits::detail::shared_state_ptr<ContResult>::type
+    inline traits::detail::shared_state_ptr_t<ContResult>
     make_continuation_exec(Future const& future, Executor&& exec, F&& f)
     {
         using shared_state = detail::continuation<Future, F, ContResult>;
         using init_no_addref = typename shared_state::init_no_addref;
-        using spawner_type =
-            executor_spawner<typename std::decay<Executor>::type>;
+        using spawner_type = executor_spawner<std::decay_t<Executor>>;
 
         // create a continuation
-        typename traits::detail::shared_state_ptr<ContResult>::type p(
+        traits::detail::shared_state_ptr_t<ContResult> p(
             new shared_state(init_no_addref{}, HPX_FORWARD(F, f)), false);
+
         static_cast<shared_state*>(p.get())
             ->template attach_nounwrap<spawner_type>(future,
                 spawner_type{HPX_FORWARD(Executor, exec)},
                 launch::async_policy{});
+
         return p;
     }
 
     template <typename ContResult, typename Future, typename Executor,
         typename Policy, typename F>
-    inline typename traits::detail::shared_state_ptr<ContResult>::type
+    inline traits::detail::shared_state_ptr_t<ContResult>
     make_continuation_exec_policy(
         Future const& future, Executor&& exec, Policy&& policy, F&& f)
     {
         using shared_state = detail::continuation<Future, F, ContResult>;
         using init_no_addref = typename shared_state::init_no_addref;
-        using spawner_type =
-            executor_spawner<typename std::decay<Executor>::type>;
+        using spawner_type = executor_spawner<std::decay_t<Executor>>;
 
         // create a continuation
-        typename traits::detail::shared_state_ptr<ContResult>::type p(
+        traits::detail::shared_state_ptr_t<ContResult> p(
             new shared_state(init_no_addref{}, HPX_FORWARD(F, f)), false);
+
         static_cast<shared_state*>(p.get())
             ->template attach_nounwrap<spawner_type>(future,
                 spawner_type{HPX_FORWARD(Executor, exec)},
                 HPX_FORWARD(Policy, policy));
+
         return p;
     }
 }}}    // namespace hpx::lcos::detail

--- a/libs/core/execution/include/hpx/execution/traits/executor_traits.hpp
+++ b/libs/core/execution/include/hpx/execution/traits/executor_traits.hpp
@@ -17,10 +17,10 @@
 #include <type_traits>
 #include <utility>
 
-namespace hpx { namespace lcos {
+namespace hpx {
     template <typename R>
     class future;
-}}    // namespace hpx::lcos
+}    // namespace hpx
 
 namespace hpx { namespace execution {
     ///////////////////////////////////////////////////////////////////////////
@@ -191,7 +191,7 @@ namespace hpx { namespace parallel { namespace execution {
         struct executor_future<Executor, T, Ts,
             std::enable_if_t<!hpx::traits::is_two_way_executor_v<Executor>>>
         {
-            using type = hpx::lcos::future<T>;
+            using type = hpx::future<T>;
         };
     }    // namespace detail
 

--- a/libs/core/executors/include/hpx/executors/dataflow.hpp
+++ b/libs/core/executors/include/hpx/executors/dataflow.hpp
@@ -112,7 +112,7 @@ namespace hpx { namespace lcos { namespace detail {
         /*IsAction=*/false, Policy, F, Args,
         typename std::enable_if<traits::is_launch_policy<Policy>::value>::type>
     {
-        using type = hpx::lcos::future<
+        using type = hpx::future<
             typename util::detail::invoke_fused_result<F, Args>::type>;
     };
 

--- a/libs/core/executors/include/hpx/executors/guided_pool_executor.hpp
+++ b/libs/core/executors/include/hpx/executors/guided_pool_executor.hpp
@@ -590,7 +590,7 @@ namespace hpx { namespace parallel { namespace execution {
                         HPX_MOVE(func));
 
                 return hpx::traits::future_access<
-                    hpx::lcos::future<result_type>>::create(HPX_MOVE(p));
+                    hpx::future<result_type>>::create(HPX_MOVE(p));
             }
         }
 

--- a/libs/core/executors/include/hpx/executors/restricted_thread_pool_executor.hpp
+++ b/libs/core/executors/include/hpx/executors/restricted_thread_pool_executor.hpp
@@ -131,8 +131,8 @@ namespace hpx { namespace parallel { namespace execution {
                 p = hpx::lcos::detail::make_continuation_exec<result_type>(
                     HPX_FORWARD(Future, predecessor), *this, HPX_MOVE(func));
 
-            return hpx::traits::future_access<
-                hpx::lcos::future<result_type>>::create(HPX_MOVE(p));
+            return hpx::traits::future_access<hpx::future<result_type>>::create(
+                HPX_MOVE(p));
         }
 
         // NonBlockingOneWayExecutor (adapted) interface

--- a/libs/core/executors/include/hpx/executors/service_executors.hpp
+++ b/libs/core/executors/include/hpx/executors/service_executors.hpp
@@ -89,7 +89,7 @@ namespace hpx { namespace parallel { namespace execution { namespace detail {
         }
 
         template <typename F, typename Shape, typename... Ts>
-        std::vector<hpx::lcos::future<
+        std::vector<hpx::future<
             typename detail::bulk_function_result<F, Shape, Ts...>::type>>
         bulk_async_execute(F&& f, Shape const& shape, Ts&&... ts) const
         {
@@ -122,8 +122,7 @@ namespace hpx { namespace parallel { namespace execution { namespace detail {
             using func_result_type =
                 typename parallel::execution::detail::then_bulk_function_result<
                     F, Shape, Future, Ts...>::type;
-            using result_type =
-                std::vector<hpx::lcos::future<func_result_type>>;
+            using result_type = std::vector<hpx::future<func_result_type>>;
 
             auto func = parallel::execution::detail::
                 make_fused_bulk_async_execute_helper<result_type>(*this,

--- a/libs/core/futures/docs/index.rst
+++ b/libs/core/futures/docs/index.rst
@@ -11,10 +11,10 @@
 futures
 =======
 
-This module defines the :cpp:class:`hpx::lcos::future` and
-:cpp:class:`hpx::lcos::shared_future` classes corresponding to the C++ standard
+This module defines the :cpp:class:`hpx::future` and
+:cpp:class:`hpx::shared_future` classes corresponding to the C++ standard
 library classes ``std::future`` and ``std::shared_future``. Note that the
-specializations of :cpp:func:`hpx::lcos::future::then` for executors and
+specializations of :cpp:func:`hpx::future::then` for executors and
 execution policies are defined in the :ref:`modules_execution` module.
 
 See the :ref:`API reference <modules_futures_api>` of this module for more

--- a/libs/core/futures/include/hpx/futures/detail/future_data.hpp
+++ b/libs/core/futures/include/hpx/futures/detail/future_data.hpp
@@ -39,7 +39,7 @@
 #include <hpx/config/warnings_prefix.hpp>
 
 ///////////////////////////////////////////////////////////////////////////////
-namespace hpx { namespace lcos {
+namespace hpx {
     enum class future_status
     {
         ready,
@@ -47,7 +47,19 @@ namespace hpx { namespace lcos {
         deferred,
         uninitialized
     };
-}}    // namespace hpx::lcos
+
+    namespace lcos {
+        enum class HPX_DEPRECATED_V(1, 8,
+            "hpx::lcos::future_status is deprecated. Use "
+            "hpx::future_status instead.") future_status
+        {
+            ready = static_cast<int>(hpx::future_status::ready),
+            timeout = static_cast<int>(hpx::future_status::timeout),
+            deferred = static_cast<int>(hpx::future_status::deferred),
+            uninitialized = static_cast<int>(hpx::future_status::uninitialized)
+        };
+    }    // namespace lcos
+}    // namespace hpx
 
 ///////////////////////////////////////////////////////////////////////////////
 namespace hpx { namespace lcos { namespace detail {
@@ -63,29 +75,36 @@ namespace hpx { namespace lcos { namespace detail {
     ///////////////////////////////////////////////////////////////////////
     struct future_data_refcnt_base;
 
-    void intrusive_ptr_add_ref(future_data_refcnt_base* p);
-    void intrusive_ptr_release(future_data_refcnt_base* p);
+    void intrusive_ptr_add_ref(future_data_refcnt_base* p) noexcept;
+    void intrusive_ptr_release(future_data_refcnt_base* p) noexcept;
 
     ///////////////////////////////////////////////////////////////////////
     struct HPX_CORE_EXPORT future_data_refcnt_base
     {
-    public:
-        typedef util::unique_function_nonser<void()> completed_callback_type;
-        typedef hpx::detail::small_vector<completed_callback_type, 1>
-            completed_callback_vector_type;
+        // future shared states are non-copyable and non-movable
+        future_data_refcnt_base(future_data_refcnt_base const&) = delete;
+        future_data_refcnt_base(future_data_refcnt_base&&) = delete;
+        future_data_refcnt_base& operator=(
+            future_data_refcnt_base const&) = delete;
+        future_data_refcnt_base& operator=(future_data_refcnt_base&&) = delete;
 
-        typedef void has_future_data_refcnt_base;
+    public:
+        using completed_callback_type = util::unique_function_nonser<void()>;
+        using completed_callback_vector_type =
+            hpx::detail::small_vector<completed_callback_type, 1>;
+
+        using has_future_data_refcnt_base = void;
 
         virtual ~future_data_refcnt_base();
 
         virtual void set_on_completed(completed_callback_type) = 0;
 
-        virtual bool requires_delete()
+        virtual bool requires_delete() noexcept
         {
             return 0 == --count_;
         }
 
-        virtual void destroy()
+        virtual void destroy() noexcept
         {
             delete this;
         }
@@ -97,38 +116,40 @@ namespace hpx { namespace lcos { namespace detail {
         };
 
     protected:
-        future_data_refcnt_base()
+        future_data_refcnt_base() noexcept
           : count_(0)
         {
         }
-        future_data_refcnt_base(init_no_addref)
+        future_data_refcnt_base(init_no_addref) noexcept
           : count_(1)
         {
         }
 
         // reference counting
-        friend void intrusive_ptr_add_ref(future_data_refcnt_base* p);
-        friend void intrusive_ptr_release(future_data_refcnt_base* p);
+        friend void intrusive_ptr_add_ref(future_data_refcnt_base* p) noexcept;
+        friend void intrusive_ptr_release(future_data_refcnt_base* p) noexcept;
 
         util::atomic_count count_;
     };
 
     /// support functions for hpx::intrusive_ptr
-    inline void intrusive_ptr_add_ref(future_data_refcnt_base* p)
+    inline void intrusive_ptr_add_ref(future_data_refcnt_base* p) noexcept
     {
         ++p->count_;
     }
-    inline void intrusive_ptr_release(future_data_refcnt_base* p)
+    inline void intrusive_ptr_release(future_data_refcnt_base* p) noexcept
     {
         if (p->requires_delete())
+        {
             p->destroy();
+        }
     }
 
     ///////////////////////////////////////////////////////////////////////////
     template <typename Result>
     struct future_data_result
     {
-        typedef Result type;
+        using type = Result;
 
         template <typename U>
         HPX_FORCEINLINE static U&& set(U&& u)
@@ -140,7 +161,7 @@ namespace hpx { namespace lcos { namespace detail {
     template <typename Result>
     struct future_data_result<Result&>
     {
-        typedef Result* type;
+        using type = Result*;
 
         HPX_FORCEINLINE static Result* set(Result* u)
         {
@@ -156,7 +177,7 @@ namespace hpx { namespace lcos { namespace detail {
     template <>
     struct future_data_result<void>
     {
-        typedef util::unused_type type;
+        using type = util::unused_type;
 
         HPX_FORCEINLINE static util::unused_type set(util::unused_type u)
         {
@@ -164,28 +185,33 @@ namespace hpx { namespace lcos { namespace detail {
         }
     };
 
+    template <typename Result>
+    using future_data_result_t = typename future_data_result<Result>::type;
+
     ///////////////////////////////////////////////////////////////////////////
     template <typename R>
     struct future_data_storage
     {
-        typedef typename future_data_result<R>::type value_type;
-        typedef std::exception_ptr error_type;
+        using value_type = future_data_result_t<R>;
+        using error_type = std::exception_ptr;
 
         // determine the required alignment, define aligned storage of proper
         // size
-        HPX_STATIC_CONSTEXPR std::size_t max_alignment =
-            (std::alignment_of<value_type>::value >
-                std::alignment_of<error_type>::value) ?
-            std::alignment_of<value_type>::value :
-            std::alignment_of<error_type>::value;
+        static constexpr std::size_t max_alignment =
+            (std::alignment_of_v<value_type> >
+                std::alignment_of_v<error_type>) ?
+            std::alignment_of_v<value_type> :
+            std::alignment_of_v<error_type>;
 
-        HPX_STATIC_CONSTEXPR std::size_t max_size =
+        static constexpr std::size_t max_size =
             (sizeof(value_type) > sizeof(error_type)) ? sizeof(value_type) :
                                                         sizeof(error_type);
 
-        typedef
-            typename std::aligned_storage<max_size, max_alignment>::type type;
+        using type = std::aligned_storage_t<max_size, max_alignment>;
     };
+
+    template <typename Result>
+    using future_data_storage_t = typename future_data_storage<Result>::type;
 
     ///////////////////////////////////////////////////////////////////////////
     template <typename Result>
@@ -195,6 +221,8 @@ namespace hpx { namespace lcos { namespace detail {
     struct HPX_CORE_EXPORT future_data_base<traits::detail::future_data_void>
       : future_data_refcnt_base
     {
+        using mutex_type = lcos::local::spinlock;
+
         future_data_base()
           : state_(empty)
         {
@@ -208,9 +236,8 @@ namespace hpx { namespace lcos { namespace detail {
 
         using future_data_refcnt_base::completed_callback_type;
         using future_data_refcnt_base::completed_callback_vector_type;
-        typedef lcos::local::spinlock mutex_type;
-        typedef util::unused_type result_type;
-        typedef future_data_refcnt_base::init_no_addref init_no_addref;
+        using result_type = util::unused_type;
+        using init_no_addref = future_data_refcnt_base::init_no_addref;
 
         virtual ~future_data_base();
 
@@ -224,17 +251,18 @@ namespace hpx { namespace lcos { namespace detail {
 
         /// Return whether or not the data is available for this
         /// \a future.
-        bool is_ready(std::memory_order order = std::memory_order_acquire) const
+        bool is_ready(
+            std::memory_order order = std::memory_order_acquire) const noexcept
         {
             return (state_.load(order) & ready) != 0;
         }
 
-        bool has_value() const
+        bool has_value() const noexcept
         {
             return state_.load(std::memory_order_acquire) == value;
         }
 
-        bool has_exception() const
+        bool has_exception() const noexcept
         {
             return state_.load(std::memory_order_acquire) == exception;
         }
@@ -242,7 +270,7 @@ namespace hpx { namespace lcos { namespace detail {
         virtual void execute_deferred(error_code& /*ec*/ = throws) {}
 
         // cancellation is disabled by default
-        virtual bool cancelable() const
+        virtual bool cancelable() const noexcept
         {
             return false;
         }
@@ -279,7 +307,7 @@ namespace hpx { namespace lcos { namespace detail {
 
         virtual state wait(error_code& ec = throws);
 
-        virtual future_status wait_until(
+        virtual hpx::future_status wait_until(
             std::chrono::steady_clock::time_point const& abs_time,
             error_code& ec = throws);
 
@@ -317,8 +345,6 @@ namespace hpx { namespace lcos { namespace detail {
     template <typename Result>
     struct future_data_base : future_data_base<traits::detail::future_data_void>
     {
-        HPX_NON_COPYABLE(future_data_base);
-
     private:
         static void construct(void* p)
         {
@@ -334,15 +360,18 @@ namespace hpx { namespace lcos { namespace detail {
         }
 
     public:
-        typedef typename future_data_result<Result>::type result_type;
-        typedef future_data_base<traits::detail::future_data_void> base_type;
-        typedef lcos::local::spinlock mutex_type;
-        typedef typename base_type::init_no_addref init_no_addref;
-        typedef
-            typename base_type::completed_callback_type completed_callback_type;
-        typedef typename base_type::completed_callback_vector_type
-            completed_callback_vector_type;
+        using result_type = future_data_result_t<Result>;
+        using base_type = future_data_base<traits::detail::future_data_void>;
+        using init_no_addref = typename base_type::init_no_addref;
+        using completed_callback_type =
+            typename base_type::completed_callback_type;
+        using completed_callback_vector_type =
+            typename base_type::completed_callback_vector_type;
 
+    protected:
+        using mutex_type = typename base_type::mutex_type;
+
+    public:
         future_data_base() = default;
 
         future_data_base(init_no_addref no_addref)
@@ -376,7 +405,7 @@ namespace hpx { namespace lcos { namespace detail {
             state_.store(exception, std::memory_order_relaxed);
         }
 
-        virtual ~future_data_base() noexcept
+        ~future_data_base() noexcept override
         {
             reset();
         }
@@ -400,7 +429,9 @@ namespace hpx { namespace lcos { namespace detail {
         virtual result_type* get_result(error_code& ec = throws)
         {
             if (get_result_void(ec) != nullptr)
+            {
                 return reinterpret_cast<result_type*>(&storage_);
+            }
             return nullptr;
         }
 
@@ -545,14 +576,14 @@ namespace hpx { namespace lcos { namespace detail {
         {
             hpx::detail::try_catch_exception_ptr(
                 [&]() {
-                    typedef typename std::decay<T>::type naked_type;
+                    using naked_type = std::decay_t<T>;
 
-                    typedef traits::get_remote_result<result_type, naked_type>
-                        get_remote_result_type;
+                    using get_remote_result_type =
+                        traits::get_remote_result<result_type, naked_type>;
 
                     // store the value
-                    set_value(std::move(
-                        get_remote_result_type::call(HPX_FORWARD(T, result))));
+                    set_value(
+                        get_remote_result_type::call(HPX_FORWARD(T, result)));
                 },
                 [&](std::exception_ptr ep) { set_exception(HPX_MOVE(ep)); });
         }
@@ -609,7 +640,7 @@ namespace hpx { namespace lcos { namespace detail {
 
     private:
         using base_type::cond_;
-        typename future_data_storage<Result>::type storage_;
+        future_data_storage_t<Result> storage_;
     };
 
     ///////////////////////////////////////////////////////////////////////////
@@ -618,10 +649,8 @@ namespace hpx { namespace lcos { namespace detail {
     template <typename Result>
     struct future_data : future_data_base<Result>
     {
-        HPX_NON_COPYABLE(future_data);
-
-        typedef
-            typename future_data_base<Result>::init_no_addref init_no_addref;
+        using init_no_addref =
+            typename future_data_base<Result>::init_no_addref;
 
         future_data() = default;
 
@@ -653,14 +682,13 @@ namespace hpx { namespace lcos { namespace detail {
     template <typename Result, typename Allocator, typename Derived = void>
     struct future_data_allocator : future_data<Result>
     {
-        typedef typename future_data<Result>::init_no_addref init_no_addref;
+        using init_no_addref = typename future_data<Result>::init_no_addref;
 
-        typedef typename std::conditional<std::is_void<Derived>::value,
-            future_data_allocator, Derived>::type allocated_type;
+        using allocated_type = std::conditional_t<std::is_void_v<Derived>,
+            future_data_allocator, Derived>;
 
-        typedef typename std::allocator_traits<
-            Allocator>::template rebind_alloc<allocated_type>
-            other_allocator;
+        using other_allocator = typename std::allocator_traits<
+            Allocator>::template rebind_alloc<allocated_type>;
 
         future_data_allocator(other_allocator const& alloc)
           : future_data<Result>()
@@ -698,9 +726,9 @@ namespace hpx { namespace lcos { namespace detail {
         }
 
     protected:
-        void destroy() override
+        void destroy() noexcept override
         {
-            typedef std::allocator_traits<other_allocator> traits;
+            using traits = std::allocator_traits<other_allocator>;
 
             other_allocator alloc(alloc_);
             traits::destroy(alloc, static_cast<allocated_type*>(this));
@@ -716,9 +744,8 @@ namespace hpx { namespace lcos { namespace detail {
     struct timed_future_data : future_data<Result>
     {
     public:
-        typedef future_data<Result> base_type;
-        typedef typename base_type::result_type result_type;
-        typedef typename base_type::mutex_type mutex_type;
+        using base_type = future_data<Result>;
+        using result_type = typename base_type::result_type;
 
     public:
         timed_future_data() {}
@@ -769,11 +796,13 @@ namespace hpx { namespace lcos { namespace detail {
     struct task_base : future_data<Result>
     {
     protected:
-        typedef future_data<Result> base_type;
-        typedef typename future_data<Result>::mutex_type mutex_type;
-        typedef hpx::intrusive_ptr<task_base> future_base_type;
-        typedef typename future_data<Result>::result_type result_type;
-        typedef typename base_type::init_no_addref init_no_addref;
+        using base_type = future_data<Result>;
+        using future_base_type = hpx::intrusive_ptr<task_base>;
+        using result_type = typename future_data<Result>::result_type;
+        using init_no_addref = typename base_type::init_no_addref;
+
+        using mutex_type = typename base_type::mutex_type;
+        using base_type::mtx_;
 
     public:
         task_base()
@@ -787,41 +816,49 @@ namespace hpx { namespace lcos { namespace detail {
         {
         }
 
-        virtual void execute_deferred(error_code& /*ec*/ = throws)
+        void execute_deferred(error_code& /*ec*/ = throws) override
         {
             if (!started_test_and_set())
+            {
                 this->do_run();
+            }
         }
 
         // retrieving the value
-        virtual result_type* get_result(error_code& ec = throws)
+        result_type* get_result(error_code& ec = throws) override
         {
             if (!started_test_and_set())
+            {
                 this->do_run();
+            }
             return this->future_data<Result>::get_result(ec);
         }
 
         // wait support
-        virtual typename base_type::state wait(error_code& ec = throws)
+        typename base_type::state wait(error_code& ec = throws) override
         {
             if (!started_test_and_set())
+            {
                 this->do_run();
+            }
             return this->future_data<Result>::wait(ec);
         }
 
-        virtual future_status wait_until(
+        hpx::future_status wait_until(
             std::chrono::steady_clock::time_point const& abs_time,
-            error_code& ec = throws)
+            error_code& ec = throws) override
         {
             if (!started_test())
-                return future_status::deferred;    //-V110
+            {
+                return hpx::future_status::deferred;    //-V110
+            }
             return this->future_data<Result>::wait_until(abs_time, ec);
         }
 
     private:
         bool started_test() const
         {
-            std::lock_guard<mutex_type> l(this->mtx_);
+            std::lock_guard<mutex_type> l(mtx_);
             return started_;
         }
 
@@ -830,8 +867,9 @@ namespace hpx { namespace lcos { namespace detail {
         {
             HPX_ASSERT_OWNS_LOCK(l);
             if (started_)
+            {
                 return true;
-
+            }
             started_ = true;
             return false;
         }
@@ -839,13 +877,13 @@ namespace hpx { namespace lcos { namespace detail {
     protected:
         bool started_test_and_set()
         {
-            std::lock_guard<mutex_type> l(this->mtx_);
+            std::lock_guard<mutex_type> l(mtx_);
             return started_test_and_set_locked(l);
         }
 
         void check_started()
         {
-            std::unique_lock<mutex_type> l(this->mtx_);
+            std::unique_lock<mutex_type> l(mtx_);
             if (started_)
             {
                 l.unlock();
@@ -887,7 +925,7 @@ namespace hpx { namespace lcos { namespace detail {
             this->future_data<Result>::set_data(HPX_FORWARD(T, result));
         }
 
-        void set_exception(std::exception_ptr e)
+        void set_exception(std::exception_ptr e) override
         {
             this->future_data<Result>::set_exception(HPX_MOVE(e));
         }
@@ -906,20 +944,23 @@ namespace hpx { namespace lcos { namespace detail {
     struct cancelable_task_base : task_base<Result>
     {
     protected:
-        typedef typename task_base<Result>::mutex_type mutex_type;
-        typedef hpx::intrusive_ptr<cancelable_task_base> future_base_type;
-        typedef typename future_data<Result>::result_type result_type;
-        typedef typename task_base<Result>::init_no_addref init_no_addref;
+        using base_type = task_base<Result>;
+        using future_base_type = hpx::intrusive_ptr<cancelable_task_base>;
+        using result_type = typename future_data<Result>::result_type;
+        using init_no_addref = typename task_base<Result>::init_no_addref;
+
+        using mutex_type = typename base_type::mutex_type;
+        using base_type::mtx_;
 
     protected:
         threads::thread_id_type get_thread_id() const
         {
-            std::lock_guard<mutex_type> l(this->mtx_);
+            std::lock_guard<mutex_type> l(mtx_);
             return id_;
         }
         void set_thread_id(threads::thread_id_type id)
         {
-            std::lock_guard<mutex_type> l(this->mtx_);
+            std::lock_guard<mutex_type> l(mtx_);
             id_ = id;
         }
 
@@ -959,21 +1000,25 @@ namespace hpx { namespace lcos { namespace detail {
 
     public:
         // cancellation support
-        bool cancelable() const
+        bool cancelable() const noexcept override
         {
             return true;
         }
 
-        void cancel()
+        void cancel() override
         {
-            std::unique_lock<mutex_type> l(this->mtx_);
+            std::unique_lock<mutex_type> l(mtx_);
             hpx::detail::try_catch_exception_ptr(
                 [&]() {
                     if (!this->started_)
+                    {
                         HPX_THROW_THREAD_INTERRUPTED_EXCEPTION();
+                    }
 
                     if (this->is_ready())
+                    {
                         return;    // nothing we can do
+                    }
 
                     if (id_ != threads::invalid_thread_id)
                     {
@@ -1012,7 +1057,7 @@ namespace hpx { namespace traits { namespace detail {
     template <typename R, typename Allocator>
     struct shared_state_allocator<lcos::detail::future_data<R>, Allocator>
     {
-        typedef lcos::detail::future_data_allocator<R, Allocator> type;
+        using type = lcos::detail::future_data_allocator<R, Allocator>;
     };
 }}}    // namespace hpx::traits::detail
 

--- a/libs/core/futures/include/hpx/futures/detail/future_transforms.hpp
+++ b/libs/core/futures/include/hpx/futures/detail/future_transforms.hpp
@@ -25,8 +25,7 @@ namespace hpx { namespace lcos { namespace detail {
     // Returns true when the given future is ready,
     // the future is deferred executed if possible first.
     template <typename T,
-        typename std::enable_if<traits::is_future<
-            typename std::decay<T>::type>::value>::type* = nullptr>
+        std::enable_if_t<traits::is_future_v<std::decay_t<T>>>* = nullptr>
     bool async_visit_future(T&& current)
     {
         // Check for state right away as the element might not be able to
@@ -53,8 +52,7 @@ namespace hpx { namespace lcos { namespace detail {
 
     // Attach the continuation next to the given future
     template <typename T, typename N,
-        typename std::enable_if<traits::is_future<
-            typename std::decay<T>::type>::value>::type* = nullptr>
+        std::enable_if_t<traits::is_future_v<std::decay_t<T>>>* = nullptr>
     void async_detach_future(T&& current, N&& next)
     {
         auto const& state =
@@ -67,28 +65,27 @@ namespace hpx { namespace lcos { namespace detail {
 
     // Acquire a future range from the given begin and end iterator
     template <typename Iterator,
-        typename Container =
-            std::vector<typename future_iterator_traits<Iterator>::type>>
+        typename Container = std::vector<future_iterator_traits_t<Iterator>>>
     Container acquire_future_iterators(Iterator begin, Iterator end)
     {
         Container lazy_values;
 
         auto difference = std::distance(begin, end);
         if (difference > 0)
+        {
             traits::detail::reserve_if_reservable(
                 lazy_values, static_cast<std::size_t>(difference));
+        }
 
         std::transform(begin, end, std::back_inserter(lazy_values),
             traits::acquire_future_disp());
 
-        return lazy_values;    // Should be optimized by RVO
+        return lazy_values;
     }
 
-    // Acquire a future range from the given
-    // begin iterator and count
+    // Acquire a future range from the given begin iterator and count
     template <typename Iterator,
-        typename Container =
-            std::vector<typename future_iterator_traits<Iterator>::type>>
+        typename Container = std::vector<future_iterator_traits_t<Iterator>>>
     Container acquire_future_n(Iterator begin, std::size_t count)
     {
         Container values;
@@ -96,8 +93,10 @@ namespace hpx { namespace lcos { namespace detail {
 
         traits::acquire_future_disp func;
         for (std::size_t i = 0; i != count; ++i)
+        {
             values.push_back(func(*begin++));
+        }
 
-        return values;    // Should be optimized by RVO
+        return values;
     }
 }}}    // namespace hpx::lcos::detail

--- a/libs/core/futures/include/hpx/futures/future_fwd.hpp
+++ b/libs/core/futures/include/hpx/futures/future_fwd.hpp
@@ -12,21 +12,28 @@
 namespace hpx {
 
     /// \namespace lcos
+    namespace lcos { namespace detail {
+        template <typename Result>
+        struct future_data;
+
+        struct future_data_refcnt_base;
+    }}    // namespace lcos::detail
+
+    template <typename R>
+    class future;
+
+    template <typename R>
+    class shared_future;
+
     namespace lcos {
-        namespace detail {
-            template <typename Result>
-            struct future_data;
-
-            struct future_data_refcnt_base;
-        }    // namespace detail
+        template <typename R>
+        using future HPX_DEPRECATED_V(
+            1, 8, "hpx::lcos::future is deprecated. Use hpx::future instead.") =
+            hpx::future<R>;
 
         template <typename R>
-        class future;
-
-        template <typename R>
-        class shared_future;
+        using shared_future HPX_DEPRECATED_V(1, 8,
+            "hpx::lcos::shared_future is deprecated. Use hpx::shared_future "
+            "instead.") = hpx::shared_future<R>;
     }    // namespace lcos
-
-    using lcos::future;
-    using lcos::shared_future;
 }    // namespace hpx

--- a/libs/core/futures/include/hpx/futures/futures_factory.hpp
+++ b/libs/core/futures/include/hpx/futures/futures_factory.hpp
@@ -172,7 +172,7 @@ namespace hpx { namespace lcos { namespace local {
             }
 
         private:
-            void destroy() override
+            void destroy() noexcept override
             {
                 using traits = std::allocator_traits<other_allocator>;
 
@@ -339,7 +339,7 @@ namespace hpx { namespace lcos { namespace local {
             }
 
         private:
-            void destroy() override
+            void destroy() noexcept override
             {
                 using traits = std::allocator_traits<other_allocator>;
 
@@ -772,27 +772,27 @@ namespace hpx { namespace lcos { namespace local {
 
         // This is the same as get_future, except that it moves the
         // shared state into the returned future.
-        lcos::future<Result> get_future(error_code& ec = throws)
+        hpx::future<Result> get_future(error_code& ec = throws)
         {
             if (!task_)
             {
                 HPX_THROWS_IF(ec, task_moved,
                     "futures_factory<Result()>::get_future",
                     "futures_factory invalid (has it been moved?)");
-                return lcos::future<Result>();
+                return hpx::future<Result>();
             }
             if (future_obtained_)
             {
                 HPX_THROWS_IF(ec, future_already_retrieved,
                     "futures_factory<Result()>::get_future",
                     "future already has been retrieved from this factory");
-                return lcos::future<Result>();
+                return hpx::future<Result>();
             }
 
             future_obtained_ = true;
 
             using traits::future_access;
-            return future_access<future<Result>>::create(HPX_MOVE(task_));
+            return future_access<hpx::future<Result>>::create(HPX_MOVE(task_));
         }
 
         bool valid() const noexcept

--- a/libs/core/futures/include/hpx/futures/packaged_task.hpp
+++ b/libs/core/futures/include/hpx/futures/packaged_task.hpp
@@ -97,14 +97,14 @@ namespace hpx { namespace lcos { namespace local {
         }
 
         // result retrieval
-        lcos::future<R> get_future(error_code& ec = throws)
+        hpx::future<R> get_future(error_code& ec = throws)
         {
             if (function_.empty())
             {
                 HPX_THROWS_IF(ec, no_state,
                     "packaged_task<Signature>::get_future",
                     "this packaged_task has no valid shared state");
-                return lcos::future<R>();
+                return hpx::future<R>();
             }
             return promise_.get_future();
         }

--- a/libs/core/futures/include/hpx/futures/promise.hpp
+++ b/libs/core/futures/include/hpx/futures/promise.hpp
@@ -114,7 +114,7 @@ namespace hpx { namespace lcos { namespace local {
                 return shared_state_ != nullptr;
             }
 
-            future<R> get_future(error_code& ec = throws)
+            hpx::future<R> get_future(error_code& ec = throws)
             {
                 if (future_retrieved_ || shared_future_retrieved_)
                 {
@@ -122,7 +122,7 @@ namespace hpx { namespace lcos { namespace local {
                         "local::detail::promise_base<R>::get_future",
                         "future or shared future has already been retrieved "
                         "from this promise");
-                    return future<R>();
+                    return hpx::future<R>();
                 }
 
                 if (shared_state_ == nullptr)
@@ -130,21 +130,22 @@ namespace hpx { namespace lcos { namespace local {
                     HPX_THROWS_IF(ec, no_state,
                         "local::detail::promise_base<R>::get_future",
                         "this promise has no valid shared state");
-                    return future<R>();
+                    return hpx::future<R>();
                 }
 
                 future_retrieved_ = true;
-                return traits::future_access<future<R>>::create(shared_state_);
+                return traits::future_access<hpx::future<R>>::create(
+                    shared_state_);
             }
 
-            shared_future<R> get_shared_future(error_code& ec = throws)
+            hpx::shared_future<R> get_shared_future(error_code& ec = throws)
             {
                 if (future_retrieved_)
                 {
                     HPX_THROWS_IF(ec, future_already_retrieved,
                         "local::detail::promise_base<R>::get_shared_future",
                         "future has already been retrieved from this promise");
-                    return shared_future<R>();
+                    return hpx::shared_future<R>();
                 }
 
                 if (shared_state_ == nullptr)
@@ -152,11 +153,11 @@ namespace hpx { namespace lcos { namespace local {
                     HPX_THROWS_IF(ec, no_state,
                         "local::detail::promise_base<R>::get_shared_future",
                         "this promise has no valid shared state");
-                    return shared_future<R>();
+                    return hpx::shared_future<R>();
                 }
 
                 shared_future_retrieved_ = true;
-                return traits::future_access<shared_future<R>>::create(
+                return traits::future_access<hpx::shared_future<R>>::create(
                     shared_state_);
             }
 

--- a/libs/core/futures/include/hpx/futures/traits/acquire_future.hpp
+++ b/libs/core/futures/include/hpx/futures/traits/acquire_future.hpp
@@ -61,36 +61,36 @@ namespace hpx { namespace traits {
 
         ///////////////////////////////////////////////////////////////////////
         template <typename R>
-        struct acquire_future_impl<hpx::lcos::future<R>>
+        struct acquire_future_impl<hpx::future<R>>
         {
-            typedef hpx::lcos::future<R> type;
+            typedef hpx::future<R> type;
 
-            HPX_FORCEINLINE hpx::lcos::future<R> operator()(
-                hpx::lcos::future<R>& future) const
+            HPX_FORCEINLINE hpx::future<R> operator()(
+                hpx::future<R>& future) const
             {
                 return HPX_MOVE(future);
             }
 
-            HPX_FORCEINLINE hpx::lcos::future<R> operator()(
-                hpx::lcos::future<R>&& future) const
+            HPX_FORCEINLINE hpx::future<R> operator()(
+                hpx::future<R>&& future) const
             {
                 return HPX_MOVE(future);
             }
         };
 
         template <typename R>
-        struct acquire_future_impl<hpx::lcos::shared_future<R>>
+        struct acquire_future_impl<hpx::shared_future<R>>
         {
-            typedef hpx::lcos::shared_future<R> type;
+            typedef hpx::shared_future<R> type;
 
-            HPX_FORCEINLINE hpx::lcos::shared_future<R> operator()(
-                hpx::lcos::shared_future<R> const& future) const
+            HPX_FORCEINLINE hpx::shared_future<R> operator()(
+                hpx::shared_future<R> const& future) const
             {
                 return future;
             }
 
-            HPX_FORCEINLINE hpx::lcos::shared_future<R> operator()(
-                hpx::lcos::shared_future<R>&& future) const
+            HPX_FORCEINLINE hpx::shared_future<R> operator()(
+                hpx::shared_future<R>&& future) const
             {
                 return HPX_MOVE(future);
             }

--- a/libs/core/futures/include/hpx/futures/traits/detail/future_await_traits.hpp
+++ b/libs/core/futures/include/hpx/futures/traits/detail/future_await_traits.hpp
@@ -40,11 +40,11 @@ namespace hpx { namespace lcos { namespace detail {
         {
         }
 
-        constexpr bool await_ready() const noexcept
+        HPX_NODISCARD constexpr bool await_ready() const noexcept
         {
             return is_ready_;
         }
-        void await_suspend(coroutine_handle<>) const noexcept {}
+        constexpr void await_suspend(coroutine_handle<>) const noexcept {}
         constexpr void await_resume() const noexcept {}
     };
 
@@ -52,14 +52,14 @@ namespace hpx { namespace lcos { namespace detail {
     // Allow using co_await with an expression which evaluates to
     // hpx::future<T>.
     template <typename T>
-    HPX_FORCEINLINE bool await_ready(future<T> const& f) noexcept
+    HPX_FORCEINLINE bool await_ready(hpx::future<T> const& f) noexcept
     {
         return f.is_ready();
     }
 
     template <typename T, typename Promise>
     HPX_FORCEINLINE void await_suspend(
-        future<T>& f, coroutine_handle<Promise> rh)
+        hpx::future<T>& f, coroutine_handle<Promise> rh)
     {
         // f.then([=](future<T> result) {});
         auto st = traits::detail::get_shared_state(f);
@@ -73,20 +73,20 @@ namespace hpx { namespace lcos { namespace detail {
     }
 
     template <typename T>
-    HPX_FORCEINLINE T await_resume(future<T>& f)
+    HPX_FORCEINLINE T await_resume(hpx::future<T>& f)
     {
         return f.get();
     }
 
     // Allow wrapped futures to be unwrapped, if possible.
     template <typename T>
-    HPX_FORCEINLINE T await_resume(future<future<T>>& f)
+    HPX_FORCEINLINE T await_resume(hpx::future<hpx::future<T>>& f)
     {
         return f.get().get();
     }
 
     template <typename T>
-    HPX_FORCEINLINE T await_resume(future<shared_future<T>>& f)
+    HPX_FORCEINLINE T await_resume(hpx::future<hpx::shared_future<T>>& f)
     {
         return f.get().get();
     }
@@ -94,14 +94,14 @@ namespace hpx { namespace lcos { namespace detail {
     // Allow using co_await with an expression which evaluates to
     // hpx::shared_future<T>.
     template <typename T>
-    HPX_FORCEINLINE bool await_ready(shared_future<T> const& f) noexcept
+    HPX_FORCEINLINE bool await_ready(hpx::shared_future<T> const& f) noexcept
     {
         return f.is_ready();
     }
 
     template <typename T, typename Promise>
     HPX_FORCEINLINE void await_suspend(
-        shared_future<T>& f, coroutine_handle<Promise> rh)
+        hpx::shared_future<T>& f, coroutine_handle<Promise> rh)
     {
         // f.then([=](shared_future<T> result) {})
         auto st = traits::detail::get_shared_state(f);
@@ -115,7 +115,7 @@ namespace hpx { namespace lcos { namespace detail {
     }
 
     template <typename T>
-    HPX_FORCEINLINE T await_resume(shared_future<T>& f)
+    HPX_FORCEINLINE T await_resume(hpx::shared_future<T>& f)
     {
         return f.get();
     }
@@ -137,11 +137,11 @@ namespace hpx { namespace lcos { namespace detail {
         {
         }
 
-        hpx::lcos::future<T> get_return_object()
+        hpx::future<T> get_return_object()
         {
             hpx::intrusive_ptr<Derived> shared_state(
                 static_cast<Derived*>(this));
-            return hpx::traits::future_access<hpx::lcos::future<T>>::create(
+            return hpx::traits::future_access<hpx::future<T>>::create(
                 HPX_MOVE(shared_state));
         }
 
@@ -158,7 +158,7 @@ namespace hpx { namespace lcos { namespace detail {
             return suspend_if{!this->base_type::requires_delete()};
         }
 
-        void destroy() override
+        void destroy() noexcept override
         {
             coroutine_handle<Derived>::from_promise(
                 *static_cast<Derived*>(this))
@@ -197,7 +197,7 @@ namespace hpx { namespace lcos { namespace detail {
 namespace std {
     // Allow for functions which use co_await to return an hpx::future<T>
     template <typename T, typename... Ts>
-    struct coroutine_traits<hpx::lcos::future<T>, Ts...>
+    struct coroutine_traits<hpx::future<T>, Ts...>
     {
         using allocator_type = hpx::util::internal_allocator<coroutine_traits>;
 
@@ -235,7 +235,7 @@ namespace std {
     };
 
     template <typename... Ts>
-    struct coroutine_traits<hpx::lcos::future<void>, Ts...>
+    struct coroutine_traits<hpx::future<void>, Ts...>
     {
         using allocator_type = hpx::util::internal_allocator<coroutine_traits>;
 
@@ -274,7 +274,7 @@ namespace std {
     // Allow for functions which use co_await to return an
     // hpx::shared_future<T>
     template <typename T, typename... Ts>
-    struct coroutine_traits<hpx::lcos::shared_future<T>, Ts...>
+    struct coroutine_traits<hpx::shared_future<T>, Ts...>
     {
         using allocator_type = hpx::util::internal_allocator<coroutine_traits>;
 
@@ -312,7 +312,7 @@ namespace std {
     };
 
     template <typename... Ts>
-    struct coroutine_traits<hpx::lcos::shared_future<void>, Ts...>
+    struct coroutine_traits<hpx::shared_future<void>, Ts...>
     {
         using allocator_type = hpx::util::internal_allocator<coroutine_traits>;
 

--- a/libs/core/futures/include/hpx/futures/traits/detail/future_traits.hpp
+++ b/libs/core/futures/include/hpx/futures/traits/detail/future_traits.hpp
@@ -22,8 +22,8 @@ namespace hpx { namespace lcos { namespace detail {
 
     template <typename Iterator>
     struct future_iterator_traits<Iterator,
-        typename hpx::util::always_void<
-            typename std::iterator_traits<Iterator>::value_type>::type>
+        hpx::util::always_void_t<
+            typename std::iterator_traits<Iterator>::value_type>>
     {
         using type = typename std::iterator_traits<Iterator>::value_type;
         using traits_type = hpx::traits::future_traits<type>;

--- a/libs/core/futures/include/hpx/futures/traits/future_access.hpp
+++ b/libs/core/futures/include/hpx/futures/traits/future_access.hpp
@@ -15,17 +15,17 @@
 #include <utility>
 #include <vector>
 
-namespace hpx { namespace lcos {
+namespace hpx {
     template <typename R>
     class future;
     template <typename R>
     class shared_future;
 
-    namespace detail {
+    namespace lcos::detail {
         template <typename Result>
         struct future_data_base;
-    }
-}}    // namespace hpx::lcos
+    }    // namespace lcos::detail
+}    // namespace hpx
 
 namespace hpx { namespace traits {
     ///////////////////////////////////////////////////////////////////////////
@@ -131,55 +131,55 @@ namespace hpx { namespace traits {
     };
 
     template <typename R>
-    struct future_access<lcos::future<R>>
+    struct future_access<hpx::future<R>>
     {
         template <typename SharedState>
-        static lcos::future<R> create(
+        static hpx::future<R> create(
             hpx::intrusive_ptr<SharedState> const& shared_state)
         {
-            return lcos::future<R>(shared_state);
+            return hpx::future<R>(shared_state);
         }
 
         template <typename T = void>
-        static lcos::future<R> create(
-            detail::shared_state_ptr_for_t<lcos::future<lcos::future<R>>> const&
+        static hpx::future<R> create(
+            detail::shared_state_ptr_for_t<hpx::future<hpx::future<R>>> const&
                 shared_state)
         {
-            return lcos::future<lcos::future<R>>(shared_state);
+            return hpx::future<hpx::future<R>>(shared_state);
         }
 
         template <typename SharedState>
-        static lcos::future<R> create(
+        static hpx::future<R> create(
             hpx::intrusive_ptr<SharedState>&& shared_state)
         {
-            return lcos::future<R>(HPX_MOVE(shared_state));
+            return hpx::future<R>(HPX_MOVE(shared_state));
         }
 
         template <typename T = void>
-        static lcos::future<R> create(
-            detail::shared_state_ptr_for_t<lcos::future<lcos::future<R>>>&&
+        static hpx::future<R> create(
+            detail::shared_state_ptr_for_t<hpx::future<hpx::future<R>>>&&
                 shared_state)
         {
-            return lcos::future<lcos::future<R>>(HPX_MOVE(shared_state));
+            return hpx::future<hpx::future<R>>(HPX_MOVE(shared_state));
         }
 
         template <typename SharedState>
-        static lcos::future<R> create(
+        static hpx::future<R> create(
             SharedState* shared_state, bool addref = true)
         {
-            return lcos::future<R>(
+            return hpx::future<R>(
                 hpx::intrusive_ptr<SharedState>(shared_state, addref));
         }
 
         HPX_FORCEINLINE static traits::detail::shared_state_ptr_t<R> const&
-        get_shared_state(lcos::future<R> const& f)
+        get_shared_state(hpx::future<R> const& f)
         {
             return f.shared_state_;
         }
 
         HPX_FORCEINLINE static
             typename traits::detail::shared_state_ptr_t<R>::element_type*
-            detach_shared_state(lcos::future<R>&& f)
+            detach_shared_state(hpx::future<R>&& f)
         {
             return f.shared_state_.detach();
         }
@@ -187,14 +187,14 @@ namespace hpx { namespace traits {
     private:
         template <typename Destination>
         HPX_FORCEINLINE static void transfer_result_impl(
-            lcos::future<R>&& src, Destination& dest, std::false_type)
+            hpx::future<R>&& src, Destination& dest, std::false_type)
         {
             dest.set_value(src.get());
         }
 
         template <typename Destination>
         HPX_FORCEINLINE static void transfer_result_impl(
-            lcos::future<R>&& src, Destination& dest, std::true_type)
+            hpx::future<R>&& src, Destination& dest, std::true_type)
         {
             src.get();
             dest.set_value(util::unused);
@@ -203,60 +203,61 @@ namespace hpx { namespace traits {
     public:
         template <typename Destination>
         HPX_FORCEINLINE static void transfer_result(
-            lcos::future<R>&& src, Destination& dest)
+            hpx::future<R>&& src, Destination& dest)
         {
             transfer_result_impl(HPX_MOVE(src), dest, std::is_void<R>{});
         }
     };
 
     template <typename R>
-    struct future_access<lcos::shared_future<R>>
+    struct future_access<hpx::shared_future<R>>
     {
         template <typename SharedState>
-        static lcos::shared_future<R> create(
+        static hpx::shared_future<R> create(
             hpx::intrusive_ptr<SharedState> const& shared_state)
         {
-            return lcos::shared_future<R>(shared_state);
+            return hpx::shared_future<R>(shared_state);
         }
 
         template <typename T = void>
-        static lcos::shared_future<R> create(detail::shared_state_ptr_for_t<
-            lcos::shared_future<lcos::future<R>>> const& shared_state)
+        static hpx::shared_future<R> create(detail::shared_state_ptr_for_t<
+            hpx::shared_future<hpx::future<R>>> const& shared_state)
         {
-            return lcos::shared_future<lcos::future<R>>(shared_state);
+            return hpx::shared_future<hpx::future<R>>(shared_state);
         }
 
         template <typename SharedState>
-        static lcos::shared_future<R> create(
+        static hpx::shared_future<R> create(
             hpx::intrusive_ptr<SharedState>&& shared_state)
         {
-            return lcos::shared_future<R>(HPX_MOVE(shared_state));
+            return hpx::shared_future<R>(HPX_MOVE(shared_state));
         }
 
         template <typename T = void>
-        static lcos::shared_future<R> create(detail::shared_state_ptr_for_t<
-            lcos::shared_future<lcos::future<R>>>&& shared_state)
+        static hpx::shared_future<R> create(
+            detail::shared_state_ptr_for_t<hpx::shared_future<hpx::future<R>>>&&
+                shared_state)
         {
-            return lcos::shared_future<lcos::future<R>>(HPX_MOVE(shared_state));
+            return hpx::shared_future<hpx::future<R>>(HPX_MOVE(shared_state));
         }
 
         template <typename SharedState>
-        static lcos::shared_future<R> create(
+        static hpx::shared_future<R> create(
             SharedState* shared_state, bool addref = true)
         {
-            return lcos::shared_future<R>(
+            return hpx::shared_future<R>(
                 hpx::intrusive_ptr<SharedState>(shared_state, addref));
         }
 
         HPX_FORCEINLINE static traits::detail::shared_state_ptr_t<R> const&
-        get_shared_state(lcos::shared_future<R> const& f)
+        get_shared_state(hpx::shared_future<R> const& f)
         {
             return f.shared_state_;
         }
 
         HPX_FORCEINLINE static
             typename traits::detail::shared_state_ptr_t<R>::element_type*
-            detach_shared_state(lcos::shared_future<R> const& f)
+            detach_shared_state(hpx::shared_future<R> const& f)
         {
             return f.shared_state_.get();
         }
@@ -264,14 +265,14 @@ namespace hpx { namespace traits {
     private:
         template <typename Destination>
         HPX_FORCEINLINE static void transfer_result_impl(
-            lcos::shared_future<R>&& src, Destination& dest, std::false_type)
+            hpx::shared_future<R>&& src, Destination& dest, std::false_type)
         {
             dest.set_value(src.get());
         }
 
         template <typename Destination>
         HPX_FORCEINLINE static void transfer_result_impl(
-            lcos::shared_future<R>&& src, Destination& dest, std::true_type)
+            hpx::shared_future<R>&& src, Destination& dest, std::true_type)
         {
             src.get();
             dest.set_value(util::unused);
@@ -280,7 +281,7 @@ namespace hpx { namespace traits {
     public:
         template <typename Destination>
         HPX_FORCEINLINE static void transfer_result(
-            lcos::shared_future<R>&& src, Destination& dest)
+            hpx::shared_future<R>&& src, Destination& dest)
         {
             transfer_result_impl(HPX_MOVE(src), dest, std::is_void<R>{});
         }
@@ -292,4 +293,8 @@ namespace hpx { namespace traits {
       : detail::shared_state_allocator<SharedState, Allocator>
     {
     };
+
+    template <typename SharedState, typename Allocator>
+    using shared_state_allocator_t =
+        typename shared_state_allocator<SharedState, Allocator>::type;
 }}    // namespace hpx::traits

--- a/libs/core/futures/include/hpx/futures/traits/future_then_result.hpp
+++ b/libs/core/futures/include/hpx/futures/traits/future_then_result.hpp
@@ -60,7 +60,7 @@ namespace hpx { namespace traits {
                 hpx::traits::future_traits<cont_result>,
                 hpx::util::identity<cont_result>>;
 
-            using type = hpx::lcos::future<result_type>;
+            using type = hpx::future<result_type>;
         };
 
     }    // namespace detail

--- a/libs/core/futures/include/hpx/futures/traits/future_traits.hpp
+++ b/libs/core/futures/include/hpx/futures/traits/future_traits.hpp
@@ -11,12 +11,12 @@
 
 #include <type_traits>
 
-namespace hpx { namespace lcos {
+namespace hpx {
     template <typename R>
     class future;
     template <typename R>
     class shared_future;
-}}    // namespace hpx::lcos
+}    // namespace hpx
 
 namespace hpx { namespace traits {
     ///////////////////////////////////////////////////////////////////////////
@@ -48,21 +48,21 @@ namespace hpx { namespace traits {
     };
 
     template <typename R>
-    struct future_traits<lcos::future<R>>
+    struct future_traits<hpx::future<R>>
     {
         using type = R;
         using result_type = R;
     };
 
     template <typename R>
-    struct future_traits<lcos::shared_future<R>>
+    struct future_traits<hpx::shared_future<R>>
     {
         using type = R;
         using result_type = R const&;
     };
 
     template <>
-    struct future_traits<lcos::shared_future<void>>
+    struct future_traits<hpx::shared_future<void>>
     {
         using type = void;
         using result_type = void;

--- a/libs/core/futures/include/hpx/futures/traits/is_future.hpp
+++ b/libs/core/futures/include/hpx/futures/traits/is_future.hpp
@@ -11,12 +11,13 @@
 #include <functional>
 #include <type_traits>
 
-namespace hpx { namespace lcos {
+namespace hpx {
     template <typename R>
     class future;
+
     template <typename R>
     class shared_future;
-}}    // namespace hpx::lcos
+}    // namespace hpx
 
 namespace hpx { namespace traits {
     namespace detail {
@@ -26,9 +27,12 @@ namespace hpx { namespace traits {
         };
 
         template <typename R>
-        struct is_unique_future<lcos::future<R>> : std::true_type
+        struct is_unique_future<hpx::future<R>> : std::true_type
         {
         };
+
+        template <typename R>
+        inline constexpr bool is_unique_future_v = is_unique_future<R>::value;
 
         template <typename Future, typename Enable = void>
         struct is_future_customization_point : std::false_type
@@ -42,12 +46,12 @@ namespace hpx { namespace traits {
     };
 
     template <typename R>
-    struct is_future<lcos::future<R>> : std::true_type
+    struct is_future<hpx::future<R>> : std::true_type
     {
     };
 
     template <typename R>
-    struct is_future<lcos::shared_future<R>> : std::true_type
+    struct is_future<hpx::shared_future<R>> : std::true_type
     {
     };
 

--- a/libs/core/futures/src/future_data.cpp
+++ b/libs/core/futures/src/future_data.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2015 Hartmut Kaiser
+//  Copyright (c) 2015-2021 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -10,6 +10,7 @@
 #include <hpx/config.hpp>
 #include <hpx/assert.hpp>
 #include <hpx/async_base/launch_policy.hpp>
+#include <hpx/errors/try_catch_exception_ptr.hpp>
 #include <hpx/execution_base/this_thread.hpp>
 #include <hpx/functional/deferred_call.hpp>
 #include <hpx/functional/unique_function.hpp>
@@ -25,6 +26,7 @@
 #include <utility>
 
 namespace hpx { namespace lcos { namespace detail {
+
     static run_on_completed_error_handler_type run_on_completed_error_handler;
 
     void set_run_on_completed_error_handler(
@@ -38,7 +40,7 @@ namespace hpx { namespace lcos { namespace detail {
     ///////////////////////////////////////////////////////////////////////////
     struct handle_continuation_recursion_count
     {
-        handle_continuation_recursion_count()
+        handle_continuation_recursion_count() noexcept
           : count_(threads::get_continuation_recursion_count())
         {
             ++count_;
@@ -60,7 +62,9 @@ namespace hpx { namespace lcos { namespace detail {
         bool is_hpx_thread = nullptr != hpx::threads::get_self_ptr();
         hpx::launch policy = launch::fork;
         if (!is_hpx_thread)
+        {
             policy = launch::async;
+        }
 
         policy.set_priority(threads::thread_priority::boost);
         policy.set_stacksize(threads::thread_stacksize::current);
@@ -77,12 +81,14 @@ namespace hpx { namespace lcos { namespace detail {
                 threads::thread_schedule_state::pending, tid.noref());
             return p.get_future().get();
         }
+
         // If we are not on a HPX thread, we need to return immediately, to
         // allow the newly spawned thread to execute.
     }
 
     ///////////////////////////////////////////////////////////////////////////
-    future_data_base<traits::detail::future_data_void>::~future_data_base() {}
+    future_data_base<traits::detail::future_data_void>::~future_data_base() =
+        default;
 
     static util::unused_type unused_;
 
@@ -93,7 +99,9 @@ namespace hpx { namespace lcos { namespace detail {
         // yields control if needed
         state s = wait(ec);
         if (ec)
+        {
             return nullptr;
+        }
 
         // No locking is required. Once a future has been made ready, which
         // is a postcondition of wait, either:
@@ -129,6 +137,7 @@ namespace hpx { namespace lcos { namespace detail {
         {
             std::exception_ptr const* exception_ptr =
                 static_cast<std::exception_ptr const*>(storage);
+
             // an error has been reported in the meantime, throw or set
             // the error code
             if (&ec == &throws)
@@ -149,24 +158,23 @@ namespace hpx { namespace lcos { namespace detail {
     void future_data_base<traits::detail::future_data_void>::run_on_completed(
         completed_callback_type&& on_completed) noexcept
     {
-        try
-        {
-            hpx::util::annotate_function annotate(on_completed);
-            on_completed();
-        }
-        catch (...)
-        {
-            // If the completion handler throws an exception, there's nothing
-            // we can do, report the exception and terminate.
-            if (run_on_completed_error_handler)
-            {
-                run_on_completed_error_handler(std::current_exception());
-            }
-            else
-            {
-                std::terminate();
-            }
-        }
+        hpx::detail::try_catch_exception_ptr(
+            [&]() {
+                hpx::util::annotate_function annotate(on_completed);
+                on_completed();
+            },
+            [&](std::exception_ptr ep) {
+                // If the completion handler throws an exception, there's nothing
+                // we can do, report the exception and terminate.
+                if (run_on_completed_error_handler)
+                {
+                    run_on_completed_error_handler(HPX_MOVE(ep));
+                }
+                else
+                {
+                    std::terminate();
+                }
+            });
     }
 
     void future_data_base<traits::detail::future_data_void>::run_on_completed(
@@ -204,27 +212,27 @@ namespace hpx { namespace lcos { namespace detail {
         else
         {
             // re-spawn continuation on a new thread
-            void (*p)(Callback &&) = &future_data_base::run_on_completed;
 
-            try
-            {
-                run_on_completed_on_new_thread(util::deferred_call(
-                    p, HPX_FORWARD(Callback, on_completed)));
-            }
-            catch (...)
-            {
-                // If an exception while creating the new task or inside the
-                // completion handler is thrown, there is nothing we can do...
-                // ... but terminate and report the error
-                if (run_on_completed_error_handler)
-                {
-                    run_on_completed_error_handler(std::current_exception());
-                }
-                else
-                {
-                    std::rethrow_exception(std::current_exception());
-                }
-            }
+            hpx::detail::try_catch_exception_ptr(
+                [&]() {
+                    constexpr void (*p)(Callback &&) =
+                        &future_data_base::run_on_completed;
+                    run_on_completed_on_new_thread(util::deferred_call(
+                        p, HPX_FORWARD(Callback, on_completed)));
+                },
+                [&](std::exception_ptr ep) {
+                    // If an exception while creating the new task or inside the
+                    // completion handler is thrown, there is nothing we can do...
+                    // ... but terminate and report the error
+                    if (run_on_completed_error_handler)
+                    {
+                        run_on_completed_error_handler(HPX_MOVE(ep));
+                    }
+                    else
+                    {
+                        std::rethrow_exception(HPX_MOVE(ep));
+                    }
+                });
         }
     }
 
@@ -253,7 +261,7 @@ namespace hpx { namespace lcos { namespace detail {
         }
         else
         {
-            std::unique_lock<mutex_type> l(mtx_);
+            std::unique_lock l(mtx_);
             if (is_ready())
             {
                 l.unlock();
@@ -275,44 +283,56 @@ namespace hpx { namespace lcos { namespace detail {
         state s = state_.load(std::memory_order_acquire);
         if (s == empty)
         {
-            std::unique_lock<mutex_type> l(mtx_);
+            std::unique_lock l(mtx_);
             s = state_.load(std::memory_order_relaxed);
             if (s == empty)
             {
                 cond_.wait(l, "future_data_base::wait", ec);
                 if (ec)
+                {
                     return s;
+                }
+
+                // reload the state, it's not empty anymore
+                s = state_.load(std::memory_order_relaxed);
             }
         }
 
         if (&ec != &throws)
+        {
             ec = make_success_code();
+        }
         return s;
     }
 
-    future_status
+    hpx::future_status
     future_data_base<traits::detail::future_data_void>::wait_until(
         std::chrono::steady_clock::time_point const& abs_time, error_code& ec)
     {
         // block if this entry is empty
         if (state_.load(std::memory_order_acquire) == empty)
         {
-            std::unique_lock<mutex_type> l(mtx_);
+            std::unique_lock l(mtx_);
             if (state_.load(std::memory_order_relaxed) == empty)
             {
                 threads::thread_restart_state const reason = cond_.wait_until(
                     l, abs_time, "future_data_base::wait_until", ec);
                 if (ec)
-                    return future_status::uninitialized;
+                {
+                    return hpx::future_status::uninitialized;
+                }
 
                 if (reason == threads::thread_restart_state::timeout)
-                    return future_status::timeout;
+                {
+                    return hpx::future_status::timeout;
+                }
             }
         }
 
         if (&ec != &throws)
+        {
             ec = make_success_code();
-
-        return future_status::ready;    //-V110
+        }
+        return hpx::future_status::ready;    //-V110
     }
 }}}    // namespace hpx::lcos::detail

--- a/libs/core/futures/tests/regressions/future_790.cpp
+++ b/libs/core/futures/tests/regressions/future_790.cpp
@@ -15,7 +15,7 @@
 
 int hpx_main()
 {
-    hpx::lcos::future<int> future = hpx::lcos::make_ready_future(0);
+    hpx::future<int> future = hpx::make_ready_future(0);
     std::chrono::nanoseconds tn(static_cast<long long>(1000000000LL));
     future.wait_for(tn);
 

--- a/libs/core/futures/tests/regressions/wait_for_1751.cpp
+++ b/libs/core/futures/tests/regressions/wait_for_1751.cpp
@@ -30,8 +30,7 @@ int hpx_main()
 
         auto f = hpx::async([]() {});
 
-        if (f.wait_for(std::chrono::seconds(1)) ==
-            hpx::lcos::future_status::timeout)
+        if (f.wait_for(std::chrono::seconds(1)) == hpx::future_status::timeout)
         {
             auto now = std::chrono::high_resolution_clock::now();
             std::chrono::duration<double> dif = now - start_time;

--- a/libs/core/futures/tests/unit/future.cpp
+++ b/libs/core/futures/tests/unit/future.cpp
@@ -66,7 +66,7 @@ void set_promise_exception_thread(hpx::lcos::local::promise<int>* p)
 void test_store_value_from_thread()
 {
     hpx::lcos::local::promise<int> pi2;
-    hpx::lcos::future<int> fi2(pi2.get_future());
+    hpx::future<int> fi2(pi2.get_future());
     hpx::thread t(&set_promise_thread, &pi2);
     fi2.wait();
     HPX_TEST(fi2.is_ready());
@@ -81,7 +81,7 @@ void test_store_value_from_thread()
 void test_store_exception()
 {
     hpx::lcos::local::promise<int> pi3;
-    hpx::lcos::future<int> fi3 = pi3.get_future();
+    hpx::future<int> fi3 = pi3.get_future();
     hpx::thread t(&set_promise_exception_thread, &pi3);
     fi3.wait();
 
@@ -103,7 +103,7 @@ void test_store_exception()
 ///////////////////////////////////////////////////////////////////////////////
 void test_initial_state()
 {
-    hpx::lcos::future<int> fi;
+    hpx::future<int> fi;
     HPX_TEST(!fi.is_ready());
     HPX_TEST(!fi.has_value());
     HPX_TEST(!fi.has_exception());
@@ -126,7 +126,7 @@ void test_initial_state()
 void test_waiting_future()
 {
     hpx::lcos::local::promise<int> pi;
-    hpx::lcos::future<int> fi;
+    hpx::future<int> fi;
     fi = pi.get_future();
 
     HPX_TEST(!fi.is_ready());
@@ -162,7 +162,7 @@ void test_cannot_get_future_twice()
 void test_set_value_updates_future_status()
 {
     hpx::lcos::local::promise<int> pi;
-    hpx::lcos::future<int> fi;
+    hpx::future<int> fi;
     fi = pi.get_future();
 
     pi.set_value(42);
@@ -176,7 +176,7 @@ void test_set_value_updates_future_status()
 void test_set_value_can_be_retrieved()
 {
     hpx::lcos::local::promise<int> pi;
-    hpx::lcos::future<int> fi;
+    hpx::future<int> fi;
     fi = pi.get_future();
 
     pi.set_value(42);
@@ -193,7 +193,7 @@ void test_set_value_can_be_retrieved()
 void test_set_value_can_be_moved()
 {
     hpx::lcos::local::promise<int> pi;
-    hpx::lcos::future<int> fi;
+    hpx::future<int> fi;
     fi = pi.get_future();
 
     pi.set_value(42);
@@ -211,7 +211,7 @@ void test_set_value_can_be_moved()
 void test_future_from_packaged_task_is_waiting()
 {
     hpx::lcos::local::packaged_task<int()> pt(make_int);
-    hpx::lcos::future<int> fi = pt.get_future();
+    hpx::future<int> fi = pt.get_future();
 
     HPX_TEST(!fi.is_ready());
     HPX_TEST(!fi.has_value());
@@ -222,7 +222,7 @@ void test_future_from_packaged_task_is_waiting()
 void test_invoking_a_packaged_task_populates_future()
 {
     hpx::lcos::local::packaged_task<int()> pt(make_int);
-    hpx::lcos::future<int> fi = pt.get_future();
+    hpx::future<int> fi = pt.get_future();
 
     pt();
 
@@ -283,7 +283,7 @@ void test_cannot_get_future_twice_from_task()
 void test_task_stores_exception_if_function_throws()
 {
     hpx::lcos::local::packaged_task<int()> pt(throw_runtime_error);
-    hpx::lcos::future<int> fi = pt.get_future();
+    hpx::future<int> fi = pt.get_future();
 
     pt();
 
@@ -308,7 +308,7 @@ void test_task_stores_exception_if_function_throws()
 void test_void_promise()
 {
     hpx::lcos::local::promise<void> p;
-    hpx::lcos::future<void> f = p.get_future();
+    hpx::future<void> f = p.get_future();
 
     p.set_value();
     HPX_TEST(f.is_ready());
@@ -319,7 +319,7 @@ void test_void_promise()
 void test_reference_promise()
 {
     hpx::lcos::local::promise<int&> p;
-    hpx::lcos::future<int&> f = p.get_future();
+    hpx::future<int&> f = p.get_future();
     int i = 42;
     p.set_value(i);
     HPX_TEST(f.is_ready());
@@ -333,7 +333,7 @@ void do_nothing() {}
 void test_task_returning_void()
 {
     hpx::lcos::local::packaged_task<void()> pt(do_nothing);
-    hpx::lcos::future<void> fi = pt.get_future();
+    hpx::future<void> fi = pt.get_future();
 
     pt();
 
@@ -352,7 +352,7 @@ int& return_ref()
 void test_task_returning_reference()
 {
     hpx::lcos::local::packaged_task<int&()> pt(return_ref);
-    hpx::lcos::future<int&> fi = pt.get_future();
+    hpx::future<int&> fi = pt.get_future();
 
     pt();
 
@@ -366,7 +366,7 @@ void test_task_returning_reference()
 void test_future_for_move_only_udt()
 {
     hpx::lcos::local::promise<X> pt;
-    hpx::lcos::future<X> fi = pt.get_future();
+    hpx::future<X> fi = pt.get_future();
 
     pt.set_value(X());
     X res(fi.get());
@@ -376,7 +376,7 @@ void test_future_for_move_only_udt()
 void test_future_for_string()
 {
     hpx::lcos::local::promise<std::string> pt;
-    hpx::lcos::future<std::string> fi1 = pt.get_future();
+    hpx::future<std::string> fi1 = pt.get_future();
 
     pt.set_value(std::string("hello"));
     std::string res(fi1.get());
@@ -404,7 +404,7 @@ void test_future_for_string()
 hpx::lcos::local::spinlock callback_mutex;
 unsigned callback_called = 0;
 
-void wait_callback(hpx::lcos::future<int>)
+void wait_callback(hpx::future<int>)
 {
     std::lock_guard<hpx::lcos::local::spinlock> lk(callback_mutex);
     ++callback_called;
@@ -425,9 +425,9 @@ void test_wait_callback()
 {
     callback_called = 0;
     hpx::lcos::local::promise<int> pi;
-    hpx::lcos::future<int> fi = pi.get_future();
+    hpx::future<int> fi = pi.get_future();
 
-    hpx::lcos::future<void> ft = fi.then(&wait_callback);
+    hpx::future<void> ft = fi.then(&wait_callback);
     hpx::thread t(&promise_set_value, std::ref(pi));
 
     ft.wait();
@@ -451,25 +451,25 @@ void test_wait_callback_with_timed_wait()
 {
     callback_called = 0;
     hpx::lcos::local::promise<int> pi;
-    hpx::lcos::future<int> fi = pi.get_future();
+    hpx::future<int> fi = pi.get_future();
 
-    hpx::lcos::future<void> fv =
+    hpx::future<void> fv =
         fi.then(hpx::util::bind(&do_nothing_callback, std::ref(pi)));
 
     int state = int(fv.wait_for(std::chrono::milliseconds(100)));
-    HPX_TEST_EQ(state, int(hpx::lcos::future_status::timeout));
+    HPX_TEST_EQ(state, int(hpx::future_status::timeout));
     HPX_TEST_EQ(callback_called, 0U);
 
     state = int(fv.wait_for(std::chrono::milliseconds(100)));
-    HPX_TEST_EQ(state, int(hpx::lcos::future_status::timeout));
+    HPX_TEST_EQ(state, int(hpx::future_status::timeout));
     state = int(fv.wait_for(std::chrono::milliseconds(100)));
-    HPX_TEST_EQ(state, int(hpx::lcos::future_status::timeout));
+    HPX_TEST_EQ(state, int(hpx::future_status::timeout));
     HPX_TEST_EQ(callback_called, 0U);
 
     pi.set_value(42);
 
     state = int(fv.wait_for(std::chrono::milliseconds(100)));
-    HPX_TEST_EQ(state, int(hpx::lcos::future_status::ready));
+    HPX_TEST_EQ(state, int(hpx::future_status::ready));
 
     HPX_TEST_EQ(callback_called, 1U);
 }
@@ -477,7 +477,7 @@ void test_wait_callback_with_timed_wait()
 void test_packaged_task_can_be_moved()
 {
     hpx::lcos::local::packaged_task<int()> pt(make_int);
-    hpx::lcos::future<int> fi = pt.get_future();
+    hpx::future<int> fi = pt.get_future();
     HPX_TEST(!fi.is_ready());
 
     hpx::lcos::local::packaged_task<int()> pt2(std::move(pt));
@@ -506,7 +506,7 @@ void test_packaged_task_can_be_moved()
 
 void test_destroying_a_promise_stores_broken_promise()
 {
-    hpx::lcos::future<int> f;
+    hpx::future<int> f;
 
     {
         hpx::lcos::local::promise<int> p;
@@ -532,7 +532,7 @@ void test_destroying_a_promise_stores_broken_promise()
 
 void test_destroying_a_packaged_task_stores_broken_task()
 {
-    hpx::lcos::future<int> f;
+    hpx::future<int> f;
 
     {
         hpx::lcos::local::packaged_task<int()> p(make_int);
@@ -558,11 +558,10 @@ void test_destroying_a_packaged_task_stores_broken_task()
 
 void test_assign_to_void()
 {
-    hpx::lcos::future<void> f1 = hpx::lcos::make_ready_future(42);
+    hpx::future<void> f1 = hpx::make_ready_future(42);
     f1.get();
 
-    hpx::lcos::shared_future<void> f2 =
-        hpx::lcos::make_ready_future(42).share();
+    hpx::shared_future<void> f2 = hpx::make_ready_future(42).share();
     f2.get();
 }
 

--- a/libs/core/futures/tests/unit/shared_future.cpp
+++ b/libs/core/futures/tests/unit/shared_future.cpp
@@ -48,7 +48,7 @@ void set_promise_exception_thread(hpx::lcos::local::promise<int>* p)
 void test_store_value_from_thread()
 {
     hpx::lcos::local::promise<int> pi2;
-    hpx::lcos::shared_future<int> fi2(pi2.get_future());
+    hpx::shared_future<int> fi2(pi2.get_future());
     hpx::thread t(&set_promise_thread, &pi2);
     int j = fi2.get();
     HPX_TEST_EQ(j, 42);
@@ -62,7 +62,7 @@ void test_store_value_from_thread()
 void test_store_exception()
 {
     hpx::lcos::local::promise<int> pi3;
-    hpx::lcos::shared_future<int> fi3 = pi3.get_future();
+    hpx::shared_future<int> fi3 = pi3.get_future();
     hpx::thread t(&set_promise_exception_thread, &pi3);
     try
     {
@@ -83,7 +83,7 @@ void test_store_exception()
 ///////////////////////////////////////////////////////////////////////////////
 void test_initial_state()
 {
-    hpx::lcos::shared_future<int> fi;
+    hpx::shared_future<int> fi;
     HPX_TEST(!fi.is_ready());
     HPX_TEST(!fi.has_value());
     HPX_TEST(!fi.has_exception());
@@ -106,7 +106,7 @@ void test_initial_state()
 void test_waiting_future()
 {
     hpx::lcos::local::promise<int> pi;
-    hpx::lcos::shared_future<int> fi;
+    hpx::shared_future<int> fi;
     fi = pi.get_future();
 
     HPX_TEST(!fi.is_ready());
@@ -142,7 +142,7 @@ void test_cannot_get_future_twice()
 void test_set_value_updates_future_status()
 {
     hpx::lcos::local::promise<int> pi;
-    hpx::lcos::shared_future<int> fi;
+    hpx::shared_future<int> fi;
     fi = pi.get_future();
 
     pi.set_value(42);
@@ -156,7 +156,7 @@ void test_set_value_updates_future_status()
 void test_set_value_can_be_retrieved()
 {
     hpx::lcos::local::promise<int> pi;
-    hpx::lcos::shared_future<int> fi;
+    hpx::shared_future<int> fi;
     fi = pi.get_future();
 
     pi.set_value(42);
@@ -172,7 +172,7 @@ void test_set_value_can_be_retrieved()
 void test_set_value_can_be_moved()
 {
     hpx::lcos::local::promise<int> pi;
-    hpx::lcos::shared_future<int> fi;
+    hpx::shared_future<int> fi;
     fi = pi.get_future();
 
     pi.set_value(42);
@@ -189,7 +189,7 @@ void test_set_value_can_be_moved()
 void test_future_from_packaged_task_is_waiting()
 {
     hpx::lcos::local::packaged_task<int()> pt(make_int);
-    hpx::lcos::shared_future<int> fi = pt.get_future();
+    hpx::shared_future<int> fi = pt.get_future();
 
     HPX_TEST(!fi.is_ready());
     HPX_TEST(!fi.has_value());
@@ -200,7 +200,7 @@ void test_future_from_packaged_task_is_waiting()
 void test_invoking_a_packaged_task_populates_future()
 {
     hpx::lcos::local::packaged_task<int()> pt(make_int);
-    hpx::lcos::shared_future<int> fi = pt.get_future();
+    hpx::shared_future<int> fi = pt.get_future();
 
     pt();
 
@@ -261,7 +261,7 @@ void test_cannot_get_future_twice_from_task()
 void test_task_stores_exception_if_function_throws()
 {
     hpx::lcos::local::packaged_task<int()> pt(throw_runtime_error);
-    hpx::lcos::shared_future<int> fi = pt.get_future();
+    hpx::shared_future<int> fi = pt.get_future();
 
     pt();
 
@@ -286,7 +286,7 @@ void test_task_stores_exception_if_function_throws()
 void test_void_promise()
 {
     hpx::lcos::local::promise<void> p;
-    hpx::lcos::shared_future<void> f = p.get_future();
+    hpx::shared_future<void> f = p.get_future();
 
     p.set_value();
     HPX_TEST(f.is_ready());
@@ -297,7 +297,7 @@ void test_void_promise()
 void test_reference_promise()
 {
     hpx::lcos::local::promise<int&> p;
-    hpx::lcos::shared_future<int&> f = p.get_future();
+    hpx::shared_future<int&> f = p.get_future();
     int i = 42;
     p.set_value(i);
     HPX_TEST(f.is_ready());
@@ -311,7 +311,7 @@ void do_nothing() {}
 void test_task_returning_void()
 {
     hpx::lcos::local::packaged_task<void()> pt(do_nothing);
-    hpx::lcos::shared_future<void> fi = pt.get_future();
+    hpx::shared_future<void> fi = pt.get_future();
 
     pt();
 
@@ -330,7 +330,7 @@ int& return_ref()
 void test_task_returning_reference()
 {
     hpx::lcos::local::packaged_task<int&()> pt(return_ref);
-    hpx::lcos::shared_future<int&> fi = pt.get_future();
+    hpx::shared_future<int&> fi = pt.get_future();
 
     pt();
 
@@ -344,9 +344,9 @@ void test_task_returning_reference()
 void test_shared_future()
 {
     hpx::lcos::local::packaged_task<int()> pt(make_int);
-    hpx::lcos::shared_future<int> fi = pt.get_future();
+    hpx::shared_future<int> fi = pt.get_future();
 
-    hpx::lcos::shared_future<int> sf(std::move(fi));
+    hpx::shared_future<int> sf(std::move(fi));
 
     pt();
 
@@ -361,11 +361,11 @@ void test_shared_future()
 void test_copies_of_shared_future_become_ready_together()
 {
     hpx::lcos::local::packaged_task<int()> pt(make_int);
-    hpx::lcos::shared_future<int> fi = pt.get_future();
+    hpx::shared_future<int> fi = pt.get_future();
 
-    hpx::lcos::shared_future<int> sf1(std::move(fi));
-    hpx::lcos::shared_future<int> sf2(sf1);
-    hpx::lcos::shared_future<int> sf3;
+    hpx::shared_future<int> sf1(std::move(fi));
+    hpx::shared_future<int> sf2(sf1);
+    hpx::shared_future<int> sf3;
 
     sf3 = sf1;
     HPX_TEST(!sf1.is_ready());
@@ -396,9 +396,9 @@ void test_copies_of_shared_future_become_ready_together()
 void test_shared_future_can_be_move_assigned_from_shared_future()
 {
     hpx::lcos::local::packaged_task<int()> pt(make_int);
-    hpx::lcos::shared_future<int> fi = pt.get_future();
+    hpx::shared_future<int> fi = pt.get_future();
 
-    hpx::lcos::shared_future<int> sf;
+    hpx::shared_future<int> sf;
     sf = std::move(fi);
     HPX_TEST(!fi.valid());    // NOLINT
 
@@ -410,9 +410,9 @@ void test_shared_future_can_be_move_assigned_from_shared_future()
 void test_shared_future_void()
 {
     hpx::lcos::local::packaged_task<void()> pt(do_nothing);
-    hpx::lcos::shared_future<void> fi = pt.get_future();
+    hpx::shared_future<void> fi = pt.get_future();
 
-    hpx::lcos::shared_future<void> sf(std::move(fi));
+    hpx::shared_future<void> sf(std::move(fi));
     HPX_TEST(!fi.valid());    // NOLINT
 
     pt();
@@ -426,7 +426,7 @@ void test_shared_future_void()
 void test_shared_future_ref()
 {
     hpx::lcos::local::promise<int&> p;
-    hpx::lcos::shared_future<int&> f(p.get_future());
+    hpx::shared_future<int&> f(p.get_future());
     int i = 42;
     p.set_value(i);
     HPX_TEST(f.is_ready());
@@ -438,7 +438,7 @@ void test_shared_future_ref()
 void test_shared_future_for_string()
 {
     hpx::lcos::local::promise<std::string> pt;
-    hpx::lcos::shared_future<std::string> fi1 = pt.get_future();
+    hpx::shared_future<std::string> fi1 = pt.get_future();
 
     pt.set_value(std::string("hello"));
     std::string res(fi1.get());
@@ -466,7 +466,7 @@ void test_shared_future_for_string()
 hpx::lcos::local::spinlock callback_mutex;
 unsigned callback_called = 0;
 
-void wait_callback(hpx::lcos::shared_future<int>)
+void wait_callback(hpx::shared_future<int>)
 {
     std::lock_guard<hpx::lcos::local::spinlock> lk(callback_mutex);
     ++callback_called;
@@ -488,7 +488,7 @@ void test_wait_callback()
 {
     callback_called = 0;
     hpx::lcos::local::promise<int> pi;
-    hpx::lcos::shared_future<int> fi = pi.get_future();
+    hpx::shared_future<int> fi = pi.get_future();
 
     hpx::future<void> cbf = fi.then(&wait_callback);
     hpx::thread t(&promise_set_value, std::ref(pi));
@@ -515,25 +515,25 @@ void test_wait_callback_with_timed_wait()
 {
     callback_called = 0;
     hpx::lcos::local::promise<int> pi;
-    hpx::lcos::shared_future<int> fi = pi.get_future();
+    hpx::shared_future<int> fi = pi.get_future();
 
-    hpx::lcos::shared_future<void> fv =
+    hpx::shared_future<void> fv =
         fi.then(hpx::util::bind(&do_nothing_callback, std::ref(pi)));
 
     int state = int(fv.wait_for(std::chrono::milliseconds(100)));
-    HPX_TEST_EQ(state, int(hpx::lcos::future_status::timeout));
+    HPX_TEST_EQ(state, int(hpx::future_status::timeout));
     HPX_TEST_EQ(callback_called, 0U);
 
     state = int(fv.wait_for(std::chrono::milliseconds(100)));
-    HPX_TEST_EQ(state, int(hpx::lcos::future_status::timeout));
+    HPX_TEST_EQ(state, int(hpx::future_status::timeout));
     state = int(fv.wait_for(std::chrono::milliseconds(100)));
-    HPX_TEST_EQ(state, int(hpx::lcos::future_status::timeout));
+    HPX_TEST_EQ(state, int(hpx::future_status::timeout));
     HPX_TEST_EQ(callback_called, 0U);
 
     pi.set_value(42);
 
     state = int(fv.wait_for(std::chrono::milliseconds(100)));
-    HPX_TEST_EQ(state, int(hpx::lcos::future_status::ready));
+    HPX_TEST_EQ(state, int(hpx::future_status::ready));
 
     HPX_TEST_EQ(callback_called, 1U);
 }
@@ -541,7 +541,7 @@ void test_wait_callback_with_timed_wait()
 void test_packaged_task_can_be_moved()
 {
     hpx::lcos::local::packaged_task<int()> pt(make_int);
-    hpx::lcos::shared_future<int> fi = pt.get_future();
+    hpx::shared_future<int> fi = pt.get_future();
     HPX_TEST(!fi.is_ready());
 
     hpx::lcos::local::packaged_task<int()> pt2(std::move(pt));
@@ -570,7 +570,7 @@ void test_packaged_task_can_be_moved()
 
 void test_destroying_a_promise_stores_broken_promise()
 {
-    hpx::lcos::shared_future<int> f;
+    hpx::shared_future<int> f;
 
     {
         hpx::lcos::local::promise<int> p;
@@ -596,7 +596,7 @@ void test_destroying_a_promise_stores_broken_promise()
 
 void test_destroying_a_packaged_task_stores_broken_task()
 {
-    hpx::lcos::shared_future<int> f;
+    hpx::shared_future<int> f;
 
     {
         hpx::lcos::local::packaged_task<int()> p(make_int);
@@ -630,16 +630,16 @@ int make_int_slowly()
 void test_wait_for_either_of_two_futures_1()
 {
     hpx::lcos::local::packaged_task<int()> pt1(make_int_slowly);
-    hpx::lcos::shared_future<int> f1(pt1.get_future());
+    hpx::shared_future<int> f1(pt1.get_future());
     hpx::lcos::local::packaged_task<int()> pt2(make_int_slowly);
-    hpx::lcos::shared_future<int> f2(pt2.get_future());
+    hpx::shared_future<int> f2(pt2.get_future());
 
     pt1();
 
-    hpx::lcos::future<hpx::when_any_result<hpx::tuple<
-        hpx::lcos::shared_future<int>, hpx::lcos::shared_future<int>>>>
+    hpx::future<hpx::when_any_result<
+        hpx::tuple<hpx::shared_future<int>, hpx::shared_future<int>>>>
         r = hpx::when_any(f1, f2);
-    hpx::tuple<hpx::lcos::shared_future<int>, hpx::lcos::shared_future<int>> t =
+    hpx::tuple<hpx::shared_future<int>, hpx::shared_future<int>> t =
         r.get().futures;
 
     HPX_TEST(f1.is_ready());
@@ -653,16 +653,16 @@ void test_wait_for_either_of_two_futures_1()
 void test_wait_for_either_of_two_futures_2()
 {
     hpx::lcos::local::packaged_task<int()> pt(make_int_slowly);
-    hpx::lcos::shared_future<int> f1(pt.get_future());
+    hpx::shared_future<int> f1(pt.get_future());
     hpx::lcos::local::packaged_task<int()> pt2(make_int_slowly);
-    hpx::lcos::shared_future<int> f2(pt2.get_future());
+    hpx::shared_future<int> f2(pt2.get_future());
 
     pt2();
 
-    hpx::lcos::future<hpx::when_any_result<hpx::tuple<
-        hpx::lcos::shared_future<int>, hpx::lcos::shared_future<int>>>>
+    hpx::future<hpx::when_any_result<
+        hpx::tuple<hpx::shared_future<int>, hpx::shared_future<int>>>>
         r = hpx::when_any(f1, f2);
-    hpx::tuple<hpx::lcos::shared_future<int>, hpx::lcos::shared_future<int>> t =
+    hpx::tuple<hpx::shared_future<int>, hpx::shared_future<int>> t =
         r.get().futures;
 
     HPX_TEST(!f1.is_ready());
@@ -675,7 +675,7 @@ void test_wait_for_either_of_two_futures_2()
 
 void test_wait_for_either_of_two_futures_list_1()
 {
-    std::vector<hpx::lcos::shared_future<int>> futures;
+    std::vector<hpx::shared_future<int>> futures;
     hpx::lcos::local::packaged_task<int()> pt1(make_int_slowly);
     futures.push_back(pt1.get_future());
     hpx::lcos::local::packaged_task<int()> pt2(make_int_slowly);
@@ -683,15 +683,13 @@ void test_wait_for_either_of_two_futures_list_1()
 
     pt1();
 
-    hpx::lcos::future<
-        hpx::when_any_result<std::vector<hpx::lcos::shared_future<int>>>>
-        r = hpx::when_any(futures);
-    hpx::when_any_result<std::vector<hpx::lcos::shared_future<int>>> raw =
-        r.get();
+    hpx::future<hpx::when_any_result<std::vector<hpx::shared_future<int>>>> r =
+        hpx::when_any(futures);
+    hpx::when_any_result<std::vector<hpx::shared_future<int>>> raw = r.get();
 
     HPX_TEST_EQ(raw.index, 0u);
 
-    std::vector<hpx::lcos::shared_future<int>> t = std::move(raw.futures);
+    std::vector<hpx::shared_future<int>> t = std::move(raw.futures);
 
     HPX_TEST(futures[0].is_ready());
     HPX_TEST(!futures[1].is_ready());
@@ -703,7 +701,7 @@ void test_wait_for_either_of_two_futures_list_1()
 
 void test_wait_for_either_of_two_futures_list_2()
 {
-    std::vector<hpx::lcos::shared_future<int>> futures;
+    std::vector<hpx::shared_future<int>> futures;
     hpx::lcos::local::packaged_task<int()> pt1(make_int_slowly);
     futures.push_back(pt1.get_future());
     hpx::lcos::local::packaged_task<int()> pt2(make_int_slowly);
@@ -711,15 +709,13 @@ void test_wait_for_either_of_two_futures_list_2()
 
     pt2();
 
-    hpx::lcos::future<
-        hpx::when_any_result<std::vector<hpx::lcos::shared_future<int>>>>
-        r = hpx::when_any(futures);
-    hpx::when_any_result<std::vector<hpx::lcos::shared_future<int>>> raw =
-        r.get();
+    hpx::future<hpx::when_any_result<std::vector<hpx::shared_future<int>>>> r =
+        hpx::when_any(futures);
+    hpx::when_any_result<std::vector<hpx::shared_future<int>>> raw = r.get();
 
     HPX_TEST_EQ(raw.index, 1u);
 
-    std::vector<hpx::lcos::shared_future<int>> t = std::move(raw.futures);
+    std::vector<hpx::shared_future<int>> t = std::move(raw.futures);
 
     HPX_TEST(!futures[0].is_ready());
     HPX_TEST(futures[1].is_ready());
@@ -732,20 +728,19 @@ void test_wait_for_either_of_two_futures_list_2()
 void test_wait_for_either_of_three_futures_1()
 {
     hpx::lcos::local::packaged_task<int()> pt1(make_int_slowly);
-    hpx::lcos::shared_future<int> f1(pt1.get_future());
+    hpx::shared_future<int> f1(pt1.get_future());
     hpx::lcos::local::packaged_task<int()> pt2(make_int_slowly);
-    hpx::lcos::shared_future<int> f2(pt2.get_future());
+    hpx::shared_future<int> f2(pt2.get_future());
     hpx::lcos::local::packaged_task<int()> pt3(make_int_slowly);
-    hpx::lcos::shared_future<int> f3(pt3.get_future());
+    hpx::shared_future<int> f3(pt3.get_future());
 
     pt1();
 
-    hpx::lcos::future<
-        hpx::when_any_result<hpx::tuple<hpx::lcos::shared_future<int>,
-            hpx::lcos::shared_future<int>, hpx::lcos::shared_future<int>>>>
+    hpx::future<hpx::when_any_result<hpx::tuple<hpx::shared_future<int>,
+        hpx::shared_future<int>, hpx::shared_future<int>>>>
         r = hpx::when_any(f1, f2, f3);
-    hpx::tuple<hpx::lcos::shared_future<int>, hpx::lcos::shared_future<int>,
-        hpx::lcos::shared_future<int>>
+    hpx::tuple<hpx::shared_future<int>, hpx::shared_future<int>,
+        hpx::shared_future<int>>
         t = r.get().futures;
 
     HPX_TEST(f1.is_ready());
@@ -760,20 +755,19 @@ void test_wait_for_either_of_three_futures_1()
 void test_wait_for_either_of_three_futures_2()
 {
     hpx::lcos::local::packaged_task<int()> pt1(make_int_slowly);
-    hpx::lcos::shared_future<int> f1(pt1.get_future());
+    hpx::shared_future<int> f1(pt1.get_future());
     hpx::lcos::local::packaged_task<int()> pt2(make_int_slowly);
-    hpx::lcos::shared_future<int> f2(pt2.get_future());
+    hpx::shared_future<int> f2(pt2.get_future());
     hpx::lcos::local::packaged_task<int()> pt3(make_int_slowly);
-    hpx::lcos::shared_future<int> f3(pt3.get_future());
+    hpx::shared_future<int> f3(pt3.get_future());
 
     pt2();
 
-    hpx::lcos::future<
-        hpx::when_any_result<hpx::tuple<hpx::lcos::shared_future<int>,
-            hpx::lcos::shared_future<int>, hpx::lcos::shared_future<int>>>>
+    hpx::future<hpx::when_any_result<hpx::tuple<hpx::shared_future<int>,
+        hpx::shared_future<int>, hpx::shared_future<int>>>>
         r = hpx::when_any(f1, f2, f3);
-    hpx::tuple<hpx::lcos::shared_future<int>, hpx::lcos::shared_future<int>,
-        hpx::lcos::shared_future<int>>
+    hpx::tuple<hpx::shared_future<int>, hpx::shared_future<int>,
+        hpx::shared_future<int>>
         t = r.get().futures;
 
     HPX_TEST(!f1.is_ready());
@@ -788,20 +782,19 @@ void test_wait_for_either_of_three_futures_2()
 void test_wait_for_either_of_three_futures_3()
 {
     hpx::lcos::local::packaged_task<int()> pt1(make_int_slowly);
-    hpx::lcos::shared_future<int> f1(pt1.get_future());
+    hpx::shared_future<int> f1(pt1.get_future());
     hpx::lcos::local::packaged_task<int()> pt2(make_int_slowly);
-    hpx::lcos::shared_future<int> f2(pt2.get_future());
+    hpx::shared_future<int> f2(pt2.get_future());
     hpx::lcos::local::packaged_task<int()> pt3(make_int_slowly);
-    hpx::lcos::shared_future<int> f3(pt3.get_future());
+    hpx::shared_future<int> f3(pt3.get_future());
 
     pt3();
 
-    hpx::lcos::future<
-        hpx::when_any_result<hpx::tuple<hpx::lcos::shared_future<int>,
-            hpx::lcos::shared_future<int>, hpx::lcos::shared_future<int>>>>
+    hpx::future<hpx::when_any_result<hpx::tuple<hpx::shared_future<int>,
+        hpx::shared_future<int>, hpx::shared_future<int>>>>
         r = hpx::when_any(f1, f2, f3);
-    hpx::tuple<hpx::lcos::shared_future<int>, hpx::lcos::shared_future<int>,
-        hpx::lcos::shared_future<int>>
+    hpx::tuple<hpx::shared_future<int>, hpx::shared_future<int>,
+        hpx::shared_future<int>>
         t = r.get().futures;
 
     HPX_TEST(!f1.is_ready());
@@ -816,22 +809,22 @@ void test_wait_for_either_of_three_futures_3()
 void test_wait_for_either_of_four_futures_1()
 {
     hpx::lcos::local::packaged_task<int()> pt1(make_int_slowly);
-    hpx::lcos::shared_future<int> f1(pt1.get_future());
+    hpx::shared_future<int> f1(pt1.get_future());
     hpx::lcos::local::packaged_task<int()> pt2(make_int_slowly);
-    hpx::lcos::shared_future<int> f2(pt2.get_future());
+    hpx::shared_future<int> f2(pt2.get_future());
     hpx::lcos::local::packaged_task<int()> pt3(make_int_slowly);
-    hpx::lcos::shared_future<int> f3(pt3.get_future());
+    hpx::shared_future<int> f3(pt3.get_future());
     hpx::lcos::local::packaged_task<int()> pt4(make_int_slowly);
-    hpx::lcos::shared_future<int> f4(pt4.get_future());
+    hpx::shared_future<int> f4(pt4.get_future());
 
     pt1();
 
-    hpx::lcos::future<hpx::when_any_result<
-        hpx::tuple<hpx::lcos::shared_future<int>, hpx::lcos::shared_future<int>,
-            hpx::lcos::shared_future<int>, hpx::lcos::shared_future<int>>>>
+    hpx::future<hpx::when_any_result<
+        hpx::tuple<hpx::shared_future<int>, hpx::shared_future<int>,
+            hpx::shared_future<int>, hpx::shared_future<int>>>>
         r = hpx::when_any(f1, f2, f3, f4);
-    hpx::tuple<hpx::lcos::shared_future<int>, hpx::lcos::shared_future<int>,
-        hpx::lcos::shared_future<int>, hpx::lcos::shared_future<int>>
+    hpx::tuple<hpx::shared_future<int>, hpx::shared_future<int>,
+        hpx::shared_future<int>, hpx::shared_future<int>>
         t = r.get().futures;
 
     HPX_TEST(f1.is_ready());
@@ -847,22 +840,22 @@ void test_wait_for_either_of_four_futures_1()
 void test_wait_for_either_of_four_futures_2()
 {
     hpx::lcos::local::packaged_task<int()> pt1(make_int_slowly);
-    hpx::lcos::shared_future<int> f1(pt1.get_future());
+    hpx::shared_future<int> f1(pt1.get_future());
     hpx::lcos::local::packaged_task<int()> pt2(make_int_slowly);
-    hpx::lcos::shared_future<int> f2(pt2.get_future());
+    hpx::shared_future<int> f2(pt2.get_future());
     hpx::lcos::local::packaged_task<int()> pt3(make_int_slowly);
-    hpx::lcos::shared_future<int> f3(pt3.get_future());
+    hpx::shared_future<int> f3(pt3.get_future());
     hpx::lcos::local::packaged_task<int()> pt4(make_int_slowly);
-    hpx::lcos::shared_future<int> f4(pt4.get_future());
+    hpx::shared_future<int> f4(pt4.get_future());
 
     pt2();
 
-    hpx::lcos::future<hpx::when_any_result<
-        hpx::tuple<hpx::lcos::shared_future<int>, hpx::lcos::shared_future<int>,
-            hpx::lcos::shared_future<int>, hpx::lcos::shared_future<int>>>>
+    hpx::future<hpx::when_any_result<
+        hpx::tuple<hpx::shared_future<int>, hpx::shared_future<int>,
+            hpx::shared_future<int>, hpx::shared_future<int>>>>
         r = hpx::when_any(f1, f2, f3, f4);
-    hpx::tuple<hpx::lcos::shared_future<int>, hpx::lcos::shared_future<int>,
-        hpx::lcos::shared_future<int>, hpx::lcos::shared_future<int>>
+    hpx::tuple<hpx::shared_future<int>, hpx::shared_future<int>,
+        hpx::shared_future<int>, hpx::shared_future<int>>
         t = r.get().futures;
 
     HPX_TEST(!f1.is_ready());
@@ -878,22 +871,22 @@ void test_wait_for_either_of_four_futures_2()
 void test_wait_for_either_of_four_futures_3()
 {
     hpx::lcos::local::packaged_task<int()> pt1(make_int_slowly);
-    hpx::lcos::shared_future<int> f1(pt1.get_future());
+    hpx::shared_future<int> f1(pt1.get_future());
     hpx::lcos::local::packaged_task<int()> pt2(make_int_slowly);
-    hpx::lcos::shared_future<int> f2(pt2.get_future());
+    hpx::shared_future<int> f2(pt2.get_future());
     hpx::lcos::local::packaged_task<int()> pt3(make_int_slowly);
-    hpx::lcos::shared_future<int> f3(pt3.get_future());
+    hpx::shared_future<int> f3(pt3.get_future());
     hpx::lcos::local::packaged_task<int()> pt4(make_int_slowly);
-    hpx::lcos::shared_future<int> f4(pt4.get_future());
+    hpx::shared_future<int> f4(pt4.get_future());
 
     pt3();
 
-    hpx::lcos::future<hpx::when_any_result<
-        hpx::tuple<hpx::lcos::shared_future<int>, hpx::lcos::shared_future<int>,
-            hpx::lcos::shared_future<int>, hpx::lcos::shared_future<int>>>>
+    hpx::future<hpx::when_any_result<
+        hpx::tuple<hpx::shared_future<int>, hpx::shared_future<int>,
+            hpx::shared_future<int>, hpx::shared_future<int>>>>
         r = hpx::when_any(f1, f2, f3, f4);
-    hpx::tuple<hpx::lcos::shared_future<int>, hpx::lcos::shared_future<int>,
-        hpx::lcos::shared_future<int>, hpx::lcos::shared_future<int>>
+    hpx::tuple<hpx::shared_future<int>, hpx::shared_future<int>,
+        hpx::shared_future<int>, hpx::shared_future<int>>
         t = r.get().futures;
 
     HPX_TEST(!f1.is_ready());
@@ -909,22 +902,22 @@ void test_wait_for_either_of_four_futures_3()
 void test_wait_for_either_of_four_futures_4()
 {
     hpx::lcos::local::packaged_task<int()> pt1(make_int_slowly);
-    hpx::lcos::shared_future<int> f1(pt1.get_future());
+    hpx::shared_future<int> f1(pt1.get_future());
     hpx::lcos::local::packaged_task<int()> pt2(make_int_slowly);
-    hpx::lcos::shared_future<int> f2(pt2.get_future());
+    hpx::shared_future<int> f2(pt2.get_future());
     hpx::lcos::local::packaged_task<int()> pt3(make_int_slowly);
-    hpx::lcos::shared_future<int> f3(pt3.get_future());
+    hpx::shared_future<int> f3(pt3.get_future());
     hpx::lcos::local::packaged_task<int()> pt4(make_int_slowly);
-    hpx::lcos::shared_future<int> f4(pt4.get_future());
+    hpx::shared_future<int> f4(pt4.get_future());
 
     pt4();
 
-    hpx::lcos::future<hpx::when_any_result<
-        hpx::tuple<hpx::lcos::shared_future<int>, hpx::lcos::shared_future<int>,
-            hpx::lcos::shared_future<int>, hpx::lcos::shared_future<int>>>>
+    hpx::future<hpx::when_any_result<
+        hpx::tuple<hpx::shared_future<int>, hpx::shared_future<int>,
+            hpx::shared_future<int>, hpx::shared_future<int>>>>
         r = hpx::when_any(f1, f2, f3, f4);
-    hpx::tuple<hpx::lcos::shared_future<int>, hpx::lcos::shared_future<int>,
-        hpx::lcos::shared_future<int>, hpx::lcos::shared_future<int>>
+    hpx::tuple<hpx::shared_future<int>, hpx::shared_future<int>,
+        hpx::shared_future<int>, hpx::shared_future<int>>
         t = r.get().futures;
 
     HPX_TEST(!f1.is_ready());
@@ -939,35 +932,33 @@ void test_wait_for_either_of_four_futures_4()
 
 void test_wait_for_either_of_five_futures_1_from_list()
 {
-    std::vector<hpx::lcos::shared_future<int>> futures;
+    std::vector<hpx::shared_future<int>> futures;
 
     hpx::lcos::local::packaged_task<int()> pt1(make_int_slowly);
-    hpx::lcos::shared_future<int> f1(pt1.get_future());
+    hpx::shared_future<int> f1(pt1.get_future());
     futures.push_back(f1);
     hpx::lcos::local::packaged_task<int()> pt2(make_int_slowly);
-    hpx::lcos::shared_future<int> f2(pt2.get_future());
+    hpx::shared_future<int> f2(pt2.get_future());
     futures.push_back(f2);
     hpx::lcos::local::packaged_task<int()> pt3(make_int_slowly);
-    hpx::lcos::shared_future<int> f3(pt3.get_future());
+    hpx::shared_future<int> f3(pt3.get_future());
     futures.push_back(f3);
     hpx::lcos::local::packaged_task<int()> pt4(make_int_slowly);
-    hpx::lcos::shared_future<int> f4(pt4.get_future());
+    hpx::shared_future<int> f4(pt4.get_future());
     futures.push_back(f4);
     hpx::lcos::local::packaged_task<int()> pt5(make_int_slowly);
-    hpx::lcos::shared_future<int> f5(pt5.get_future());
+    hpx::shared_future<int> f5(pt5.get_future());
     futures.push_back(f5);
 
     pt1();
 
-    hpx::lcos::future<
-        hpx::when_any_result<std::vector<hpx::lcos::shared_future<int>>>>
-        r = hpx::when_any(futures);
-    hpx::when_any_result<std::vector<hpx::lcos::shared_future<int>>> raw =
-        r.get();
+    hpx::future<hpx::when_any_result<std::vector<hpx::shared_future<int>>>> r =
+        hpx::when_any(futures);
+    hpx::when_any_result<std::vector<hpx::shared_future<int>>> raw = r.get();
 
     HPX_TEST_EQ(raw.index, 0u);
 
-    std::vector<hpx::lcos::shared_future<int>> t = std::move(raw.futures);
+    std::vector<hpx::shared_future<int>> t = std::move(raw.futures);
 
     HPX_TEST(f1.is_ready());
     HPX_TEST(!f2.is_ready());
@@ -982,35 +973,33 @@ void test_wait_for_either_of_five_futures_1_from_list()
 
 void test_wait_for_either_of_five_futures_1_from_list_iterators()
 {
-    std::vector<hpx::lcos::shared_future<int>> futures;
+    std::vector<hpx::shared_future<int>> futures;
 
     hpx::lcos::local::packaged_task<int()> pt1(make_int_slowly);
-    hpx::lcos::shared_future<int> f1(pt1.get_future());
+    hpx::shared_future<int> f1(pt1.get_future());
     futures.push_back(f1);
     hpx::lcos::local::packaged_task<int()> pt2(make_int_slowly);
-    hpx::lcos::shared_future<int> f2(pt2.get_future());
+    hpx::shared_future<int> f2(pt2.get_future());
     futures.push_back(f2);
     hpx::lcos::local::packaged_task<int()> pt3(make_int_slowly);
-    hpx::lcos::shared_future<int> f3(pt3.get_future());
+    hpx::shared_future<int> f3(pt3.get_future());
     futures.push_back(f3);
     hpx::lcos::local::packaged_task<int()> pt4(make_int_slowly);
-    hpx::lcos::shared_future<int> f4(pt4.get_future());
+    hpx::shared_future<int> f4(pt4.get_future());
     futures.push_back(f4);
     hpx::lcos::local::packaged_task<int()> pt5(make_int_slowly);
-    hpx::lcos::shared_future<int> f5(pt5.get_future());
+    hpx::shared_future<int> f5(pt5.get_future());
     futures.push_back(f5);
 
     pt1();
 
-    hpx::lcos::future<
-        hpx::when_any_result<std::vector<hpx::lcos::shared_future<int>>>>
-        r = hpx::when_any(futures.begin(), futures.end());
-    hpx::when_any_result<std::vector<hpx::lcos::shared_future<int>>> raw =
-        r.get();
+    hpx::future<hpx::when_any_result<std::vector<hpx::shared_future<int>>>> r =
+        hpx::when_any(futures.begin(), futures.end());
+    hpx::when_any_result<std::vector<hpx::shared_future<int>>> raw = r.get();
 
     HPX_TEST_EQ(raw.index, 0u);
 
-    std::vector<hpx::lcos::shared_future<int>> t = std::move(raw.futures);
+    std::vector<hpx::shared_future<int>> t = std::move(raw.futures);
 
     HPX_TEST(f1.is_ready());
     HPX_TEST(!f2.is_ready());
@@ -1026,26 +1015,25 @@ void test_wait_for_either_of_five_futures_1_from_list_iterators()
 void test_wait_for_either_of_five_futures_1()
 {
     hpx::lcos::local::packaged_task<int()> pt1(make_int_slowly);
-    hpx::lcos::shared_future<int> f1(pt1.get_future());
+    hpx::shared_future<int> f1(pt1.get_future());
     hpx::lcos::local::packaged_task<int()> pt2(make_int_slowly);
-    hpx::lcos::shared_future<int> f2(pt2.get_future());
+    hpx::shared_future<int> f2(pt2.get_future());
     hpx::lcos::local::packaged_task<int()> pt3(make_int_slowly);
-    hpx::lcos::shared_future<int> f3(pt3.get_future());
+    hpx::shared_future<int> f3(pt3.get_future());
     hpx::lcos::local::packaged_task<int()> pt4(make_int_slowly);
-    hpx::lcos::shared_future<int> f4(pt4.get_future());
+    hpx::shared_future<int> f4(pt4.get_future());
     hpx::lcos::local::packaged_task<int()> pt5(make_int_slowly);
-    hpx::lcos::shared_future<int> f5(pt5.get_future());
+    hpx::shared_future<int> f5(pt5.get_future());
 
     pt1();
 
-    hpx::lcos::future<
-        hpx::when_any_result<hpx::tuple<hpx::lcos::shared_future<int>,
-            hpx::lcos::shared_future<int>, hpx::lcos::shared_future<int>,
-            hpx::lcos::shared_future<int>, hpx::lcos::shared_future<int>>>>
+    hpx::future<hpx::when_any_result<hpx::tuple<hpx::shared_future<int>,
+        hpx::shared_future<int>, hpx::shared_future<int>,
+        hpx::shared_future<int>, hpx::shared_future<int>>>>
         r = hpx::when_any(f1, f2, f3, f4, f5);
-    hpx::tuple<hpx::lcos::shared_future<int>, hpx::lcos::shared_future<int>,
-        hpx::lcos::shared_future<int>, hpx::lcos::shared_future<int>,
-        hpx::lcos::shared_future<int>>
+    hpx::tuple<hpx::shared_future<int>, hpx::shared_future<int>,
+        hpx::shared_future<int>, hpx::shared_future<int>,
+        hpx::shared_future<int>>
         t = r.get().futures;
 
     HPX_TEST(f1.is_ready());
@@ -1062,26 +1050,25 @@ void test_wait_for_either_of_five_futures_1()
 void test_wait_for_either_of_five_futures_2()
 {
     hpx::lcos::local::packaged_task<int()> pt1(make_int_slowly);
-    hpx::lcos::shared_future<int> f1(pt1.get_future());
+    hpx::shared_future<int> f1(pt1.get_future());
     hpx::lcos::local::packaged_task<int()> pt2(make_int_slowly);
-    hpx::lcos::shared_future<int> f2(pt2.get_future());
+    hpx::shared_future<int> f2(pt2.get_future());
     hpx::lcos::local::packaged_task<int()> pt3(make_int_slowly);
-    hpx::lcos::shared_future<int> f3(pt3.get_future());
+    hpx::shared_future<int> f3(pt3.get_future());
     hpx::lcos::local::packaged_task<int()> pt4(make_int_slowly);
-    hpx::lcos::shared_future<int> f4(pt4.get_future());
+    hpx::shared_future<int> f4(pt4.get_future());
     hpx::lcos::local::packaged_task<int()> pt5(make_int_slowly);
-    hpx::lcos::shared_future<int> f5(pt5.get_future());
+    hpx::shared_future<int> f5(pt5.get_future());
 
     pt2();
 
-    hpx::lcos::future<
-        hpx::when_any_result<hpx::tuple<hpx::lcos::shared_future<int>,
-            hpx::lcos::shared_future<int>, hpx::lcos::shared_future<int>,
-            hpx::lcos::shared_future<int>, hpx::lcos::shared_future<int>>>>
+    hpx::future<hpx::when_any_result<hpx::tuple<hpx::shared_future<int>,
+        hpx::shared_future<int>, hpx::shared_future<int>,
+        hpx::shared_future<int>, hpx::shared_future<int>>>>
         r = hpx::when_any(f1, f2, f3, f4, f5);
-    hpx::tuple<hpx::lcos::shared_future<int>, hpx::lcos::shared_future<int>,
-        hpx::lcos::shared_future<int>, hpx::lcos::shared_future<int>,
-        hpx::lcos::shared_future<int>>
+    hpx::tuple<hpx::shared_future<int>, hpx::shared_future<int>,
+        hpx::shared_future<int>, hpx::shared_future<int>,
+        hpx::shared_future<int>>
         t = r.get().futures;
 
     HPX_TEST(!f1.is_ready());
@@ -1098,26 +1085,25 @@ void test_wait_for_either_of_five_futures_2()
 void test_wait_for_either_of_five_futures_3()
 {
     hpx::lcos::local::packaged_task<int()> pt1(make_int_slowly);
-    hpx::lcos::shared_future<int> f1(pt1.get_future());
+    hpx::shared_future<int> f1(pt1.get_future());
     hpx::lcos::local::packaged_task<int()> pt2(make_int_slowly);
-    hpx::lcos::shared_future<int> f2(pt2.get_future());
+    hpx::shared_future<int> f2(pt2.get_future());
     hpx::lcos::local::packaged_task<int()> pt3(make_int_slowly);
-    hpx::lcos::shared_future<int> f3(pt3.get_future());
+    hpx::shared_future<int> f3(pt3.get_future());
     hpx::lcos::local::packaged_task<int()> pt4(make_int_slowly);
-    hpx::lcos::shared_future<int> f4(pt4.get_future());
+    hpx::shared_future<int> f4(pt4.get_future());
     hpx::lcos::local::packaged_task<int()> pt5(make_int_slowly);
-    hpx::lcos::shared_future<int> f5(pt5.get_future());
+    hpx::shared_future<int> f5(pt5.get_future());
 
     pt3();
 
-    hpx::lcos::future<
-        hpx::when_any_result<hpx::tuple<hpx::lcos::shared_future<int>,
-            hpx::lcos::shared_future<int>, hpx::lcos::shared_future<int>,
-            hpx::lcos::shared_future<int>, hpx::lcos::shared_future<int>>>>
+    hpx::future<hpx::when_any_result<hpx::tuple<hpx::shared_future<int>,
+        hpx::shared_future<int>, hpx::shared_future<int>,
+        hpx::shared_future<int>, hpx::shared_future<int>>>>
         r = hpx::when_any(f1, f2, f3, f4, f5);
-    hpx::tuple<hpx::lcos::shared_future<int>, hpx::lcos::shared_future<int>,
-        hpx::lcos::shared_future<int>, hpx::lcos::shared_future<int>,
-        hpx::lcos::shared_future<int>>
+    hpx::tuple<hpx::shared_future<int>, hpx::shared_future<int>,
+        hpx::shared_future<int>, hpx::shared_future<int>,
+        hpx::shared_future<int>>
         t = r.get().futures;
 
     HPX_TEST(!f1.is_ready());
@@ -1134,26 +1120,25 @@ void test_wait_for_either_of_five_futures_3()
 void test_wait_for_either_of_five_futures_4()
 {
     hpx::lcos::local::packaged_task<int()> pt1(make_int_slowly);
-    hpx::lcos::shared_future<int> f1(pt1.get_future());
+    hpx::shared_future<int> f1(pt1.get_future());
     hpx::lcos::local::packaged_task<int()> pt2(make_int_slowly);
-    hpx::lcos::shared_future<int> f2(pt2.get_future());
+    hpx::shared_future<int> f2(pt2.get_future());
     hpx::lcos::local::packaged_task<int()> pt3(make_int_slowly);
-    hpx::lcos::shared_future<int> f3(pt3.get_future());
+    hpx::shared_future<int> f3(pt3.get_future());
     hpx::lcos::local::packaged_task<int()> pt4(make_int_slowly);
-    hpx::lcos::shared_future<int> f4(pt4.get_future());
+    hpx::shared_future<int> f4(pt4.get_future());
     hpx::lcos::local::packaged_task<int()> pt5(make_int_slowly);
-    hpx::lcos::shared_future<int> f5(pt5.get_future());
+    hpx::shared_future<int> f5(pt5.get_future());
 
     pt4();
 
-    hpx::lcos::future<
-        hpx::when_any_result<hpx::tuple<hpx::lcos::shared_future<int>,
-            hpx::lcos::shared_future<int>, hpx::lcos::shared_future<int>,
-            hpx::lcos::shared_future<int>, hpx::lcos::shared_future<int>>>>
+    hpx::future<hpx::when_any_result<hpx::tuple<hpx::shared_future<int>,
+        hpx::shared_future<int>, hpx::shared_future<int>,
+        hpx::shared_future<int>, hpx::shared_future<int>>>>
         r = hpx::when_any(f1, f2, f3, f4, f5);
-    hpx::tuple<hpx::lcos::shared_future<int>, hpx::lcos::shared_future<int>,
-        hpx::lcos::shared_future<int>, hpx::lcos::shared_future<int>,
-        hpx::lcos::shared_future<int>>
+    hpx::tuple<hpx::shared_future<int>, hpx::shared_future<int>,
+        hpx::shared_future<int>, hpx::shared_future<int>,
+        hpx::shared_future<int>>
         t = r.get().futures;
 
     HPX_TEST(!f1.is_ready());
@@ -1170,26 +1155,25 @@ void test_wait_for_either_of_five_futures_4()
 void test_wait_for_either_of_five_futures_5()
 {
     hpx::lcos::local::packaged_task<int()> pt1(make_int_slowly);
-    hpx::lcos::shared_future<int> f1(pt1.get_future());
+    hpx::shared_future<int> f1(pt1.get_future());
     hpx::lcos::local::packaged_task<int()> pt2(make_int_slowly);
-    hpx::lcos::shared_future<int> f2(pt2.get_future());
+    hpx::shared_future<int> f2(pt2.get_future());
     hpx::lcos::local::packaged_task<int()> pt3(make_int_slowly);
-    hpx::lcos::shared_future<int> f3(pt3.get_future());
+    hpx::shared_future<int> f3(pt3.get_future());
     hpx::lcos::local::packaged_task<int()> pt4(make_int_slowly);
-    hpx::lcos::shared_future<int> f4(pt4.get_future());
+    hpx::shared_future<int> f4(pt4.get_future());
     hpx::lcos::local::packaged_task<int()> pt5(make_int_slowly);
-    hpx::lcos::shared_future<int> f5(pt5.get_future());
+    hpx::shared_future<int> f5(pt5.get_future());
 
     pt5();
 
-    hpx::lcos::future<
-        hpx::when_any_result<hpx::tuple<hpx::lcos::shared_future<int>,
-            hpx::lcos::shared_future<int>, hpx::lcos::shared_future<int>,
-            hpx::lcos::shared_future<int>, hpx::lcos::shared_future<int>>>>
+    hpx::future<hpx::when_any_result<hpx::tuple<hpx::shared_future<int>,
+        hpx::shared_future<int>, hpx::shared_future<int>,
+        hpx::shared_future<int>, hpx::shared_future<int>>>>
         r = hpx::when_any(f1, f2, f3, f4, f5);
-    hpx::tuple<hpx::lcos::shared_future<int>, hpx::lcos::shared_future<int>,
-        hpx::lcos::shared_future<int>, hpx::lcos::shared_future<int>,
-        hpx::lcos::shared_future<int>>
+    hpx::tuple<hpx::shared_future<int>, hpx::shared_future<int>,
+        hpx::shared_future<int>, hpx::shared_future<int>,
+        hpx::shared_future<int>>
         t = r.get().futures;
 
     HPX_TEST(!f1.is_ready());
@@ -1208,9 +1192,9 @@ void test_wait_for_either_of_five_futures_5()
 // {
 //     callback_called = 0;
 //     hpx::lcos::local::packaged_task<int()> pt1(make_int_slowly);
-//     hpx::lcos::shared_future<int> fi = pt1.get_future();
+//     hpx::shared_future<int> fi = pt1.get_future();
 //     hpx::lcos::local::packaged_task<int()> pt2(make_int_slowly);
-//     hpx::lcos::shared_future<int> fi2 = pt2.get_future();
+//     hpx::shared_future<int> fi2 = pt2.get_future();
 //     pt1.set_wait_callback(wait_callback_for_task);
 //
 //     hpx::thread t(std::move(pt));
@@ -1226,7 +1210,7 @@ void test_wait_for_either_of_five_futures_5()
 //     for(unsigned i = 0; i < count; ++i)
 //     {
 //         hpx::lcos::local::packaged_task<int()> tasks[count];
-//         hpx::lcos::shared_future<int> futures[count];
+//         hpx::shared_future<int> futures[count];
 //         for(unsigned j = 0; j < count; ++j)
 //         {
 //             tasks[j] =
@@ -1237,7 +1221,7 @@ void test_wait_for_either_of_five_futures_5()
 //
 //         hpx::lcos::wait_any(futures, futures);
 //
-//         hpx::lcos::shared_future<int>* const future =
+//         hpx::shared_future<int>* const future =
 //              boost::wait_for_any(futures, futures+count);
 //
 //         HPX_TEST_EQ(future, (futures + i));
@@ -1259,7 +1243,7 @@ void test_wait_for_either_of_five_futures_5()
 void test_wait_for_all_from_list()
 {
     unsigned const count = 10;
-    std::vector<hpx::lcos::shared_future<int>> futures;
+    std::vector<hpx::shared_future<int>> futures;
     for (unsigned j = 0; j < count; ++j)
     {
         hpx::lcos::local::futures_factory<int()> task(make_int_slowly);
@@ -1267,10 +1251,10 @@ void test_wait_for_all_from_list()
         task.apply();
     }
 
-    hpx::lcos::future<std::vector<hpx::lcos::shared_future<int>>> r =
+    hpx::future<std::vector<hpx::shared_future<int>>> r =
         hpx::when_all(futures);
 
-    std::vector<hpx::lcos::shared_future<int>> result = r.get();
+    std::vector<hpx::shared_future<int>> result = r.get();
 
     HPX_TEST_EQ(futures.size(), result.size());
     for (unsigned j = 0; j < count; ++j)
@@ -1283,7 +1267,7 @@ void test_wait_for_all_from_list()
 void test_wait_for_all_from_list_iterators()
 {
     unsigned const count = 10;
-    std::vector<hpx::lcos::shared_future<int>> futures;
+    std::vector<hpx::shared_future<int>> futures;
     for (unsigned j = 0; j < count; ++j)
     {
         hpx::lcos::local::futures_factory<int()> task(make_int_slowly);
@@ -1291,10 +1275,10 @@ void test_wait_for_all_from_list_iterators()
         task.apply();
     }
 
-    hpx::lcos::future<std::vector<hpx::lcos::shared_future<int>>> r =
+    hpx::future<std::vector<hpx::shared_future<int>>> r =
         hpx::when_all(futures.begin(), futures.end());
 
-    std::vector<hpx::lcos::shared_future<int>> result = r.get();
+    std::vector<hpx::shared_future<int>> result = r.get();
 
     HPX_TEST_EQ(futures.size(), result.size());
     for (unsigned j = 0; j < count; ++j)
@@ -1307,16 +1291,15 @@ void test_wait_for_all_from_list_iterators()
 void test_wait_for_all_two_futures()
 {
     hpx::lcos::local::futures_factory<int()> pt1(make_int_slowly);
-    hpx::lcos::shared_future<int> f1 = pt1.get_future();
+    hpx::shared_future<int> f1 = pt1.get_future();
     pt1.apply();
     hpx::lcos::local::futures_factory<int()> pt2(make_int_slowly);
-    hpx::lcos::shared_future<int> f2 = pt2.get_future();
+    hpx::shared_future<int> f2 = pt2.get_future();
     pt2.apply();
 
-    typedef hpx::tuple<hpx::lcos::shared_future<int>,
-        hpx::lcos::shared_future<int>>
+    typedef hpx::tuple<hpx::shared_future<int>, hpx::shared_future<int>>
         result_type;
-    hpx::lcos::future<result_type> r = hpx::when_all(f1, f2);
+    hpx::future<result_type> r = hpx::when_all(f1, f2);
 
     result_type result = r.get();
 
@@ -1329,19 +1312,19 @@ void test_wait_for_all_two_futures()
 void test_wait_for_all_three_futures()
 {
     hpx::lcos::local::futures_factory<int()> pt1(make_int_slowly);
-    hpx::lcos::shared_future<int> f1 = pt1.get_future();
+    hpx::shared_future<int> f1 = pt1.get_future();
     pt1.apply();
     hpx::lcos::local::futures_factory<int()> pt2(make_int_slowly);
-    hpx::lcos::shared_future<int> f2 = pt2.get_future();
+    hpx::shared_future<int> f2 = pt2.get_future();
     pt2.apply();
     hpx::lcos::local::futures_factory<int()> pt3(make_int_slowly);
-    hpx::lcos::shared_future<int> f3 = pt3.get_future();
+    hpx::shared_future<int> f3 = pt3.get_future();
     pt3.apply();
 
-    typedef hpx::tuple<hpx::lcos::shared_future<int>,
-        hpx::lcos::shared_future<int>, hpx::lcos::shared_future<int>>
+    typedef hpx::tuple<hpx::shared_future<int>, hpx::shared_future<int>,
+        hpx::shared_future<int>>
         result_type;
-    hpx::lcos::future<result_type> r = hpx::when_all(f1, f2, f3);
+    hpx::future<result_type> r = hpx::when_all(f1, f2, f3);
 
     result_type result = r.get();
 
@@ -1356,23 +1339,22 @@ void test_wait_for_all_three_futures()
 void test_wait_for_all_four_futures()
 {
     hpx::lcos::local::futures_factory<int()> pt1(make_int_slowly);
-    hpx::lcos::shared_future<int> f1 = pt1.get_future();
+    hpx::shared_future<int> f1 = pt1.get_future();
     pt1.apply();
     hpx::lcos::local::futures_factory<int()> pt2(make_int_slowly);
-    hpx::lcos::shared_future<int> f2 = pt2.get_future();
+    hpx::shared_future<int> f2 = pt2.get_future();
     pt2.apply();
     hpx::lcos::local::futures_factory<int()> pt3(make_int_slowly);
-    hpx::lcos::shared_future<int> f3 = pt3.get_future();
+    hpx::shared_future<int> f3 = pt3.get_future();
     pt3.apply();
     hpx::lcos::local::futures_factory<int()> pt4(make_int_slowly);
-    hpx::lcos::shared_future<int> f4 = pt4.get_future();
+    hpx::shared_future<int> f4 = pt4.get_future();
     pt4.apply();
 
-    typedef hpx::tuple<hpx::lcos::shared_future<int>,
-        hpx::lcos::shared_future<int>, hpx::lcos::shared_future<int>,
-        hpx::lcos::shared_future<int>>
+    typedef hpx::tuple<hpx::shared_future<int>, hpx::shared_future<int>,
+        hpx::shared_future<int>, hpx::shared_future<int>>
         result_type;
-    hpx::lcos::future<result_type> r = hpx::when_all(f1, f2, f3, f4);
+    hpx::future<result_type> r = hpx::when_all(f1, f2, f3, f4);
 
     result_type result = r.get();
 
@@ -1389,26 +1371,26 @@ void test_wait_for_all_four_futures()
 void test_wait_for_all_five_futures()
 {
     hpx::lcos::local::futures_factory<int()> pt1(make_int_slowly);
-    hpx::lcos::shared_future<int> f1 = pt1.get_future();
+    hpx::shared_future<int> f1 = pt1.get_future();
     pt1.apply();
     hpx::lcos::local::futures_factory<int()> pt2(make_int_slowly);
-    hpx::lcos::shared_future<int> f2 = pt2.get_future();
+    hpx::shared_future<int> f2 = pt2.get_future();
     pt2.apply();
     hpx::lcos::local::futures_factory<int()> pt3(make_int_slowly);
-    hpx::lcos::shared_future<int> f3 = pt3.get_future();
+    hpx::shared_future<int> f3 = pt3.get_future();
     pt3.apply();
     hpx::lcos::local::futures_factory<int()> pt4(make_int_slowly);
-    hpx::lcos::shared_future<int> f4 = pt4.get_future();
+    hpx::shared_future<int> f4 = pt4.get_future();
     pt4.apply();
     hpx::lcos::local::futures_factory<int()> pt5(make_int_slowly);
-    hpx::lcos::shared_future<int> f5 = pt5.get_future();
+    hpx::shared_future<int> f5 = pt5.get_future();
     pt5.apply();
 
-    typedef hpx::tuple<hpx::lcos::shared_future<int>,
-        hpx::lcos::shared_future<int>, hpx::lcos::shared_future<int>,
-        hpx::lcos::shared_future<int>, hpx::lcos::shared_future<int>>
+    typedef hpx::tuple<hpx::shared_future<int>, hpx::shared_future<int>,
+        hpx::shared_future<int>, hpx::shared_future<int>,
+        hpx::shared_future<int>>
         result_type;
-    hpx::lcos::future<result_type> r = hpx::when_all(f1, f2, f3, f4, f5);
+    hpx::future<result_type> r = hpx::when_all(f1, f2, f3, f4, f5);
 
     result_type result = r.get();
 
@@ -1429,24 +1411,23 @@ void test_wait_for_two_out_of_five_futures()
     unsigned const count = 2;
 
     hpx::lcos::local::packaged_task<int()> pt1(make_int_slowly);
-    hpx::lcos::shared_future<int> f1 = pt1.get_future();
+    hpx::shared_future<int> f1 = pt1.get_future();
     hpx::lcos::local::packaged_task<int()> pt2(make_int_slowly);
-    hpx::lcos::shared_future<int> f2 = pt2.get_future();
+    hpx::shared_future<int> f2 = pt2.get_future();
     pt2();
     hpx::lcos::local::packaged_task<int()> pt3(make_int_slowly);
-    hpx::lcos::shared_future<int> f3 = pt3.get_future();
+    hpx::shared_future<int> f3 = pt3.get_future();
     hpx::lcos::local::packaged_task<int()> pt4(make_int_slowly);
-    hpx::lcos::shared_future<int> f4 = pt4.get_future();
+    hpx::shared_future<int> f4 = pt4.get_future();
     pt4();
     hpx::lcos::local::packaged_task<int()> pt5(make_int_slowly);
-    hpx::lcos::shared_future<int> f5 = pt5.get_future();
+    hpx::shared_future<int> f5 = pt5.get_future();
 
-    typedef hpx::when_some_result<hpx::tuple<hpx::lcos::shared_future<int>,
-        hpx::lcos::shared_future<int>, hpx::lcos::shared_future<int>,
-        hpx::lcos::shared_future<int>, hpx::lcos::shared_future<int>>>
+    typedef hpx::when_some_result<hpx::tuple<hpx::shared_future<int>,
+        hpx::shared_future<int>, hpx::shared_future<int>,
+        hpx::shared_future<int>, hpx::shared_future<int>>>
         result_type;
-    hpx::lcos::future<result_type> r =
-        hpx::when_some(count, f1, f2, f3, f4, f5);
+    hpx::future<result_type> r = hpx::when_some(count, f1, f2, f3, f4, f5);
 
     result_type result = r.get();
 
@@ -1469,25 +1450,24 @@ void test_wait_for_three_out_of_five_futures()
     unsigned const count = 3;
 
     hpx::lcos::local::packaged_task<int()> pt1(make_int_slowly);
-    hpx::lcos::shared_future<int> f1 = pt1.get_future();
+    hpx::shared_future<int> f1 = pt1.get_future();
     pt1();
     hpx::lcos::local::packaged_task<int()> pt2(make_int_slowly);
-    hpx::lcos::shared_future<int> f2 = pt2.get_future();
+    hpx::shared_future<int> f2 = pt2.get_future();
     hpx::lcos::local::packaged_task<int()> pt3(make_int_slowly);
-    hpx::lcos::shared_future<int> f3 = pt3.get_future();
+    hpx::shared_future<int> f3 = pt3.get_future();
     pt3();
     hpx::lcos::local::packaged_task<int()> pt4(make_int_slowly);
-    hpx::lcos::shared_future<int> f4 = pt4.get_future();
+    hpx::shared_future<int> f4 = pt4.get_future();
     hpx::lcos::local::packaged_task<int()> pt5(make_int_slowly);
-    hpx::lcos::shared_future<int> f5 = pt5.get_future();
+    hpx::shared_future<int> f5 = pt5.get_future();
     pt5();
 
-    typedef hpx::when_some_result<hpx::tuple<hpx::lcos::shared_future<int>,
-        hpx::lcos::shared_future<int>, hpx::lcos::shared_future<int>,
-        hpx::lcos::shared_future<int>, hpx::lcos::shared_future<int>>>
+    typedef hpx::when_some_result<hpx::tuple<hpx::shared_future<int>,
+        hpx::shared_future<int>, hpx::shared_future<int>,
+        hpx::shared_future<int>, hpx::shared_future<int>>>
         result_type;
-    hpx::lcos::future<result_type> r =
-        hpx::when_some(count, f1, f2, f3, f4, f5);
+    hpx::future<result_type> r = hpx::when_some(count, f1, f2, f3, f4, f5);
 
     result_type result = r.get();
 

--- a/libs/core/lcos_local/include/hpx/lcos_local/and_gate.hpp
+++ b/libs/core/lcos_local/include/hpx/lcos_local/and_gate.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2012 Hartmut Kaiser
+//  Copyright (c) 2007-2021 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -94,7 +94,7 @@ namespace hpx { namespace lcos { namespace local {
     protected:
         /// \brief get a future allowing to wait for the gate to fire
         template <typename OuterLock>
-        future<void> get_future(OuterLock& outer_lock,
+        hpx::future<void> get_future(OuterLock& outer_lock,
             std::size_t count = std::size_t(-1),
             std::size_t* generation_value = nullptr,
             error_code& ec = hpx::throws)
@@ -125,7 +125,7 @@ namespace hpx { namespace lcos { namespace local {
         }
 
     public:
-        future<void> get_future(std::size_t count = std::size_t(-1),
+        hpx::future<void> get_future(std::size_t count = std::size_t(-1),
             std::size_t* generation_value = nullptr,
             error_code& ec = hpx::throws)
         {
@@ -137,7 +137,7 @@ namespace hpx { namespace lcos { namespace local {
     protected:
         /// \brief get a shared future allowing to wait for the gate to fire
         template <typename OuterLock>
-        shared_future<void> get_shared_future(OuterLock& outer_lock,
+        hpx::shared_future<void> get_shared_future(OuterLock& outer_lock,
             std::size_t count = std::size_t(-1),
             std::size_t* generation_value = nullptr,
             error_code& ec = hpx::throws)
@@ -171,7 +171,7 @@ namespace hpx { namespace lcos { namespace local {
         }
 
     public:
-        shared_future<void> get_shared_future(
+        hpx::shared_future<void> get_shared_future(
             std::size_t count = std::size_t(-1),
             std::size_t* generation_value = nullptr,
             error_code& ec = hpx::throws)
@@ -265,7 +265,7 @@ namespace hpx { namespace lcos { namespace local {
             }
 
             template <typename Condition>
-            future<void> get_future(
+            hpx::future<void> get_future(
                 Condition&& func, error_code& ec = hpx::throws)
             {
                 return (*it_)->get_future(HPX_FORWARD(Condition, func), ec);
@@ -308,7 +308,7 @@ namespace hpx { namespace lcos { namespace local {
                 conditional_trigger c;
                 manage_condition cond(*this, c);
 
-                future<void> f = cond.get_future(util::bind(
+                hpx::future<void> f = cond.get_future(util::bind(
                     &base_and_gate::test_condition, this, generation_value));
 
                 {
@@ -398,7 +398,8 @@ namespace hpx { namespace lcos { namespace local {
         }
 
         template <typename Lock>
-        future<void> get_future(Lock& l, std::size_t count = std::size_t(-1),
+        hpx::future<void> get_future(Lock& l,
+            std::size_t count = std::size_t(-1),
             std::size_t* generation_value = nullptr,
             error_code& ec = hpx::throws)
         {
@@ -406,7 +407,7 @@ namespace hpx { namespace lcos { namespace local {
         }
 
         template <typename Lock>
-        shared_future<void> get_shared_future(Lock& l,
+        hpx::shared_future<void> get_shared_future(Lock& l,
             std::size_t count = std::size_t(-1),
             std::size_t* generation_value = nullptr,
             error_code& ec = hpx::throws)

--- a/libs/core/lcos_local/include/hpx/lcos_local/channel.hpp
+++ b/libs/core/lcos_local/include/hpx/lcos_local/channel.hpp
@@ -55,7 +55,7 @@ namespace hpx { namespace lcos { namespace local {
             {
                 return 0 == release();
             }
-            virtual void destroy()
+            virtual void destroy() noexcept
             {
                 delete this;
             }

--- a/libs/core/lcos_local/include/hpx/lcos_local/conditional_trigger.hpp
+++ b/libs/core/lcos_local/include/hpx/lcos_local/conditional_trigger.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2012 Hartmut Kaiser
+//  Copyright (c) 2007-2021 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -28,11 +28,12 @@ namespace hpx { namespace lcos { namespace local {
 
         /// \brief get a future allowing to wait for the trigger to fire
         template <typename Condition>
-        future<void> get_future(Condition&& func, error_code& ec = hpx::throws)
+        hpx::future<void> get_future(
+            Condition&& func, error_code& ec = hpx::throws)
         {
             cond_.assign(HPX_FORWARD(Condition, func));
 
-            future<void> f = promise_.get_future(ec);
+            hpx::future<void> f = promise_.get_future(ec);
 
             set(ec);    // trigger as soon as possible
 

--- a/libs/core/lcos_local/include/hpx/lcos_local/trigger.hpp
+++ b/libs/core/lcos_local/include/hpx/lcos_local/trigger.hpp
@@ -78,7 +78,7 @@ namespace hpx { namespace lcos { namespace local {
 
     public:
         /// \brief get a future allowing to wait for the trigger to fire
-        future<void> get_future(std::size_t* generation_value = nullptr,
+        hpx::future<void> get_future(std::size_t* generation_value = nullptr,
             error_code& ec = hpx::throws)
         {
             std::lock_guard<mutex_type> l(mtx_);
@@ -135,7 +135,7 @@ namespace hpx { namespace lcos { namespace local {
             }
 
             template <typename Condition>
-            future<void> get_future(
+            hpx::future<void> get_future(
                 Condition&& func, error_code& ec = hpx::throws)
             {
                 return (*it_)->get_future(HPX_FORWARD(Condition, func), ec);
@@ -177,7 +177,7 @@ namespace hpx { namespace lcos { namespace local {
                 conditional_trigger c;
                 manage_condition cond(*this, c);
 
-                future<void> f = cond.get_future(util::bind(
+                hpx::future<void> f = cond.get_future(util::bind(
                     &base_trigger::test_condition, this, generation_value));
 
                 {

--- a/libs/core/memory/include/hpx/memory/detail/sp_convertible.hpp
+++ b/libs/core/memory/include/hpx/memory/detail/sp_convertible.hpp
@@ -24,25 +24,29 @@ namespace hpx { namespace memory { namespace detail {
         static yes f(T*);
         static no f(...);
 
-        HPX_STATIC_CONSTEXPR bool value =
+        static constexpr bool value =
             sizeof((f)(static_cast<Y*>(nullptr))) == sizeof(yes);
     };
 
     template <typename Y, typename T>
     struct sp_convertible<Y, T[]>
     {
-        HPX_STATIC_CONSTEXPR bool value = false;
+        static constexpr bool value = false;
     };
 
     template <typename Y, typename T>
     struct sp_convertible<Y[], T[]>
     {
-        HPX_STATIC_CONSTEXPR bool value = sp_convertible<Y[1], T[1]>::value;
+        static constexpr bool value = sp_convertible<Y[1], T[1]>::value;
     };
 
     template <typename Y, std::size_t N, typename T>
     struct sp_convertible<Y[N], T[]>
     {
-        HPX_STATIC_CONSTEXPR bool value = sp_convertible<Y[1], T[1]>::value;
+        static constexpr bool value = sp_convertible<Y[1], T[1]>::value;
     };
+
+    template <typename Y, typename T>
+    inline constexpr bool sp_convertible_v = sp_convertible<Y, T>::value;
+
 }}}    // namespace hpx::memory::detail

--- a/libs/core/memory/include/hpx/memory/intrusive_ptr.hpp
+++ b/libs/core/memory/include/hpx/memory/intrusive_ptr.hpp
@@ -56,8 +56,8 @@ namespace hpx { namespace memory {
         }
 
         template <typename U,
-            typename Enable = typename std::enable_if<
-                memory::detail::sp_convertible<U, T>::value>::type>
+            typename Enable =
+                std::enable_if_t<memory::detail::sp_convertible_v<U, T>>>
         intrusive_ptr(intrusive_ptr<U> const& rhs)
           : px(rhs.get())
         {
@@ -102,9 +102,9 @@ namespace hpx { namespace memory {
         friend class intrusive_ptr;
 
         template <typename U,
-            typename Enable = typename std::enable_if<
-                memory::detail::sp_convertible<U, T>::value>::type>
-        constexpr intrusive_ptr(intrusive_ptr<U>&& rhs)
+            typename Enable =
+                std::enable_if_t<memory::detail::sp_convertible_v<U, T>>>
+        constexpr intrusive_ptr(intrusive_ptr<U>&& rhs) noexcept
           : px(rhs.px)
         {
             rhs.px = nullptr;
@@ -118,29 +118,29 @@ namespace hpx { namespace memory {
         }
 
         // NOLINTNEXTLINE(bugprone-unhandled-self-assignment)
-        intrusive_ptr& operator=(intrusive_ptr const& rhs)
+        intrusive_ptr& operator=(intrusive_ptr const& rhs) noexcept
         {
             this_type(rhs).swap(*this);
             return *this;
         }
 
-        intrusive_ptr& operator=(T* rhs)
+        intrusive_ptr& operator=(T* rhs) noexcept
         {
             this_type(rhs).swap(*this);
             return *this;
         }
 
-        void reset()
+        void reset() noexcept
         {
             this_type().swap(*this);
         }
 
-        void reset(T* rhs)
+        void reset(T* rhs) noexcept
         {
             this_type(rhs).swap(*this);
         }
 
-        void reset(T* rhs, bool add_ref)
+        void reset(T* rhs, bool add_ref) noexcept
         {
             this_type(rhs, add_ref).swap(*this);
         }
@@ -186,69 +186,73 @@ namespace hpx { namespace memory {
     };
 
     template <typename T, typename U>
-    inline bool operator==(
+    inline constexpr bool operator==(
         intrusive_ptr<T> const& a, intrusive_ptr<U> const& b) noexcept
     {
         return a.get() == b.get();
     }
 
     template <typename T, typename U>
-    inline bool operator!=(
+    inline constexpr bool operator!=(
         intrusive_ptr<T> const& a, intrusive_ptr<U> const& b) noexcept
     {
         return a.get() != b.get();
     }
 
     template <typename T, typename U>
-    inline bool operator==(intrusive_ptr<T> const& a, U* b) noexcept
+    inline constexpr bool operator==(intrusive_ptr<T> const& a, U* b) noexcept
     {
         return a.get() == b;
     }
 
     template <typename T, typename U>
-    inline bool operator!=(intrusive_ptr<T> const& a, U* b) noexcept
+    inline constexpr bool operator!=(intrusive_ptr<T> const& a, U* b) noexcept
     {
         return a.get() != b;
     }
 
     template <typename T, typename U>
-    inline bool operator==(T* a, intrusive_ptr<U> const& b) noexcept
+    inline constexpr bool operator==(T* a, intrusive_ptr<U> const& b) noexcept
     {
         return a == b.get();
     }
 
     template <typename T, typename U>
-    inline bool operator!=(T* a, intrusive_ptr<U> const& b) noexcept
+    inline constexpr bool operator!=(T* a, intrusive_ptr<U> const& b) noexcept
     {
         return a != b.get();
     }
 
     template <typename T>
-    inline bool operator==(intrusive_ptr<T> const& p, std::nullptr_t) noexcept
+    inline constexpr bool operator==(
+        intrusive_ptr<T> const& p, std::nullptr_t) noexcept
     {
         return p.get() == nullptr;
     }
 
     template <typename T>
-    inline bool operator==(std::nullptr_t, intrusive_ptr<T> const& p) noexcept
+    inline constexpr bool operator==(
+        std::nullptr_t, intrusive_ptr<T> const& p) noexcept
     {
         return p.get() == nullptr;
     }
 
     template <typename T>
-    inline bool operator!=(intrusive_ptr<T> const& p, std::nullptr_t) noexcept
+    inline constexpr bool operator!=(
+        intrusive_ptr<T> const& p, std::nullptr_t) noexcept
     {
         return p.get() != nullptr;
     }
 
     template <typename T>
-    inline bool operator!=(std::nullptr_t, intrusive_ptr<T> const& p) noexcept
+    inline constexpr bool operator!=(
+        std::nullptr_t, intrusive_ptr<T> const& p) noexcept
     {
         return p.get() != nullptr;
     }
 
     template <typename T>
-    inline bool operator<(
+    inline constexpr bool operator<(
         intrusive_ptr<T> const& a, intrusive_ptr<T> const& b) noexcept
     {
         return std::less<T*>{}(a.get(), b.get());
@@ -262,20 +266,20 @@ namespace hpx { namespace memory {
 
     // mem_fn support
     template <typename T>
-    T* get_pointer(intrusive_ptr<T> const& p) noexcept
+    constexpr T* get_pointer(intrusive_ptr<T> const& p) noexcept
     {
         return p.get();
     }
 
     // pointer casts
     template <typename T, typename U>
-    intrusive_ptr<T> static_pointer_cast(intrusive_ptr<U> const& p)
+    constexpr intrusive_ptr<T> static_pointer_cast(intrusive_ptr<U> const& p)
     {
         return static_cast<T*>(p.get());
     }
 
     template <typename T, typename U>
-    intrusive_ptr<T> const_pointer_cast(intrusive_ptr<U> const& p)
+    constexpr intrusive_ptr<T> const_pointer_cast(intrusive_ptr<U> const& p)
     {
         return const_cast<T*>(p.get());
     }
@@ -287,13 +291,14 @@ namespace hpx { namespace memory {
     }
 
     template <typename T, typename U>
-    intrusive_ptr<T> static_pointer_cast(intrusive_ptr<U>&& p) noexcept
+    constexpr intrusive_ptr<T> static_pointer_cast(
+        intrusive_ptr<U>&& p) noexcept
     {
         return intrusive_ptr<T>(static_cast<T*>(p.detach()), false);
     }
 
     template <typename T, typename U>
-    intrusive_ptr<T> const_pointer_cast(intrusive_ptr<U>&& p) noexcept
+    constexpr intrusive_ptr<T> const_pointer_cast(intrusive_ptr<U>&& p) noexcept
     {
         return intrusive_ptr<T>(const_cast<T*>(p.detach()), false);
     }

--- a/libs/core/pack_traversal/include/hpx/pack_traversal/detail/pack_traversal_async_impl.hpp
+++ b/libs/core/pack_traversal/include/hpx/pack_traversal/detail/pack_traversal_async_impl.hpp
@@ -221,7 +221,7 @@ namespace hpx {
             }
 
         private:
-            void destroy() override
+            void destroy() noexcept override
             {
                 typedef std::allocator_traits<other_allocator> traits;
 

--- a/libs/core/pack_traversal/tests/unit/pack_traversal.cpp
+++ b/libs/core/pack_traversal/tests/unit/pack_traversal.cpp
@@ -19,11 +19,11 @@
 #include <utility>
 #include <vector>
 
+using hpx::future;
 using hpx::get;
+using hpx::make_ready_future;
 using hpx::make_tuple;
 using hpx::tuple;
-using hpx::lcos::future;
-using hpx::lcos::make_ready_future;
 using hpx::traits::future_traits;
 using hpx::traits::is_future;
 using hpx::util::map_pack;

--- a/libs/core/pack_traversal/tests/unit/unwrap.cpp
+++ b/libs/core/pack_traversal/tests/unit/unwrap.cpp
@@ -548,13 +548,13 @@ struct future_factory
 {
     FutureType<void> operator()() const
     {
-        return hpx::lcos::make_ready_future();
+        return hpx::make_ready_future();
     }
 
     template <typename T>
     FutureType<typename std::decay<T>::type> operator()(T&& value) const
     {
-        return hpx::lcos::make_ready_future(std::forward<T>(value));
+        return hpx::make_ready_future(std::forward<T>(value));
     }
 };
 
@@ -579,9 +579,9 @@ void test_all()
 int hpx_main()
 {
     // Test everything using default futures
-    test_all<hpx::lcos::future>();
+    test_all<hpx::future>();
     // Test everything using shared futures
-    test_all<hpx::lcos::shared_future>();
+    test_all<hpx::shared_future>();
 
     return hpx::local::finalize();
 }

--- a/libs/core/runtime_local/include/hpx/runtime_local/get_num_all_localities.hpp
+++ b/libs/core/runtime_local/include/hpx/runtime_local/get_num_all_localities.hpp
@@ -44,7 +44,7 @@ namespace hpx {
     ///           from an HPX-thread. It will return 0 otherwise.
     ///
     /// \see      \a hpx::find_all_localities, \a hpx::get_num_localities
-    HPX_CORE_EXPORT lcos::future<std::uint32_t> get_num_localities();
+    HPX_CORE_EXPORT hpx::future<std::uint32_t> get_num_localities();
 
     ///////////////////////////////////////////////////////////////////////////
     /// \brief Return the number of localities which are currently registered

--- a/libs/core/runtime_local/include/hpx/runtime_local/runtime_local.hpp
+++ b/libs/core/runtime_local/include/hpx/runtime_local/runtime_local.hpp
@@ -378,7 +378,7 @@ namespace hpx {
 
         virtual std::uint32_t get_initial_num_localities() const;
 
-        virtual lcos::future<std::uint32_t> get_num_localities() const;
+        virtual hpx::future<std::uint32_t> get_num_localities() const;
 
         virtual std::string get_locality_name() const;
 

--- a/libs/core/runtime_local/src/runtime_local.cpp
+++ b/libs/core/runtime_local/src/runtime_local.cpp
@@ -611,7 +611,7 @@ namespace hpx {
         return 1;
     }
 
-    lcos::future<std::uint32_t> runtime::get_num_localities() const
+    hpx::future<std::uint32_t> runtime::get_num_localities() const
     {
         return make_ready_future(std::uint32_t(1));
     }
@@ -2024,7 +2024,7 @@ namespace hpx {
         return rt->get_initial_num_localities();
     }
 
-    lcos::future<std::uint32_t> get_num_localities()
+    hpx::future<std::uint32_t> get_num_localities()
     {
         runtime* rt = get_runtime_ptr();
         if (nullptr == rt)

--- a/libs/core/threading/include/hpx/threading/thread.hpp
+++ b/libs/core/threading/include/hpx/threading/thread.hpp
@@ -117,7 +117,7 @@ namespace hpx {
 
         static void interrupt(id, bool flag = true);
 
-        lcos::future<void> get_future(error_code& ec = throws);
+        hpx::future<void> get_future(error_code& ec = throws);
 
         std::size_t get_thread_data() const;
         std::size_t set_thread_data(std::size_t);

--- a/libs/core/threading_base/include/hpx/threading_base/thread_helpers.hpp
+++ b/libs/core/threading_base/include/hpx/threading_base/thread_helpers.hpp
@@ -414,8 +414,8 @@ namespace hpx { namespace threads {
         thread_id_type const& id, std::size_t data, error_code& ec = throws);
 #endif
 
-    HPX_CORE_EXPORT std::size_t& get_continuation_recursion_count();
-    HPX_CORE_EXPORT void reset_continuation_recursion_count();
+    HPX_CORE_EXPORT std::size_t& get_continuation_recursion_count() noexcept;
+    HPX_CORE_EXPORT void reset_continuation_recursion_count() noexcept;
     /// \endcond
 
     /// Returns a pointer to the pool that was used to run the current thread

--- a/libs/core/threading_base/src/thread_helpers.cpp
+++ b/libs/core/threading_base/src/thread_helpers.cpp
@@ -297,16 +297,17 @@ namespace hpx { namespace threads {
     ////////////////////////////////////////////////////////////////////////////
     static thread_local std::size_t continuation_recursion_count(0);
 
-    std::size_t& get_continuation_recursion_count()
+    std::size_t& get_continuation_recursion_count() noexcept
     {
         thread_self* self_ptr = get_self_ptr();
         if (self_ptr)
+        {
             return self_ptr->get_continuation_recursion_count();
-
+        }
         return continuation_recursion_count;
     }
 
-    void reset_continuation_recursion_count()
+    void reset_continuation_recursion_count() noexcept
     {
         continuation_recursion_count = 0;
     }

--- a/libs/core/type_support/include/hpx/type_support/unused.hpp
+++ b/libs/core/type_support/include/hpx/type_support/unused.hpp
@@ -1,6 +1,6 @@
 /*=============================================================================
     Copyright (c) 2001-2011 Joel de Guzman
-    Copyright (c) 2007-2019 Hartmut Kaiser
+    Copyright (c) 2007-2021 Hartmut Kaiser
 
 //  SPDX-License-Identifier: BSL-1.0
     Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -24,13 +24,17 @@ namespace hpx { namespace util {
     ///////////////////////////////////////////////////////////////////////////
     struct unused_type
     {
-        constexpr HPX_HOST_DEVICE HPX_FORCEINLINE unused_type() noexcept {}
+        constexpr HPX_HOST_DEVICE HPX_FORCEINLINE unused_type() noexcept =
+            default;
 
         constexpr HPX_HOST_DEVICE HPX_FORCEINLINE unused_type(
-            unused_type const&)
+            unused_type const&) noexcept
         {
         }
-        constexpr HPX_HOST_DEVICE HPX_FORCEINLINE unused_type(unused_type&&) {}
+        constexpr HPX_HOST_DEVICE HPX_FORCEINLINE unused_type(
+            unused_type&&) noexcept
+        {
+        }
 
         template <typename T>
         constexpr HPX_HOST_DEVICE HPX_FORCEINLINE unused_type(T const&) noexcept
@@ -43,7 +47,6 @@ namespace hpx { namespace util {
         {
             return *this;
         }
-
         template <typename T>
         HPX_HOST_DEVICE HPX_FORCEINLINE unused_type& operator=(
             T const&) noexcept
@@ -56,19 +59,17 @@ namespace hpx { namespace util {
         {
             return *this;
         }
-
-        HPX_HOST_DEVICE HPX_FORCEINLINE unused_type& operator=(
-            unused_type const&) noexcept
-        {
-            return *this;
-        }
-
         constexpr HPX_HOST_DEVICE HPX_FORCEINLINE unused_type const& operator=(
             unused_type&&) const noexcept
         {
             return *this;
         }
 
+        HPX_HOST_DEVICE HPX_FORCEINLINE unused_type& operator=(
+            unused_type const&) noexcept
+        {
+            return *this;
+        }
         HPX_HOST_DEVICE HPX_FORCEINLINE unused_type& operator=(
             unused_type&&) noexcept
         {

--- a/libs/full/actions/tests/unit/set_thread_state.cpp
+++ b/libs/full/actions/tests/unit/set_thread_state.cpp
@@ -28,7 +28,7 @@ using hpx::naming::id_type;
 using hpx::threads::register_thread;
 
 using hpx::async;
-using hpx::lcos::future;
+using hpx::future;
 
 using hpx::this_thread::suspend;
 using hpx::threads::set_thread_state;

--- a/libs/full/actions/tests/unit/thread_affinity.cpp
+++ b/libs/full/actions/tests/unit/thread_affinity.cpp
@@ -117,7 +117,7 @@ void thread_affinity_foreman()
         // Each iteration, we create a task for each element in the set of
         // OS-threads that have not said "Hello world". Each of these tasks
         // is encapsulated in a future.
-        std::vector<hpx::lcos::future<std::size_t>> futures;
+        std::vector<hpx::future<std::size_t>> futures;
         futures.reserve(attendance.size());
 
         for (std::size_t worker : attendance)
@@ -153,7 +153,7 @@ int hpx_main(hpx::program_options::variables_map& /*vm*/)
             hpx::find_all_localities();
 
         // Reserve storage space for futures, one for each locality.
-        std::vector<hpx::lcos::future<void>> futures;
+        std::vector<hpx::future<void>> futures;
         futures.reserve(localities.size());
 
         for (hpx::naming::id_type const& node : localities)

--- a/libs/full/agas/include/hpx/agas/addressing_service.hpp
+++ b/libs/full/agas/include/hpx/agas/addressing_service.hpp
@@ -358,7 +358,7 @@ namespace hpx { namespace agas {
         ///                   throw but returns the result code using the
         ///                   parameter \a ec. Otherwise it throws an instance
         ///                   of hpx#exception.
-        lcos::future<std::uint32_t> get_num_localities_async(
+        hpx::future<std::uint32_t> get_num_localities_async(
             components::component_type type =
                 components::component_invalid) const;
 
@@ -370,11 +370,11 @@ namespace hpx { namespace agas {
             return get_num_localities(components::component_invalid, ec);
         }
 
-        lcos::future<std::uint32_t> get_num_overall_threads_async() const;
+        hpx::future<std::uint32_t> get_num_overall_threads_async() const;
 
         std::uint32_t get_num_overall_threads(error_code& ec = throws) const;
 
-        lcos::future<std::vector<std::uint32_t>> get_num_threads_async() const;
+        hpx::future<std::vector<std::uint32_t>> get_num_threads_async() const;
 
         std::vector<std::uint32_t> get_num_threads(
             error_code& ec = throws) const;
@@ -970,7 +970,7 @@ namespace hpx { namespace agas {
         ///                   throw but returns the result code using the
         ///                   parameter \a ec. Otherwise it throws an instance
         ///                   of hpx#exception.
-        lcos::future<std::int64_t> incref_async(naming::gid_type const& gid,
+        hpx::future<std::int64_t> incref_async(naming::gid_type const& gid,
             std::int64_t credits = 1,
             naming::id_type const& keep_alive = naming::invalid_id);
 
@@ -1045,7 +1045,7 @@ namespace hpx { namespace agas {
         bool register_name(std::string const& name, naming::gid_type const& id,
             error_code& ec = throws);
 
-        lcos::future<bool> register_name_async(
+        hpx::future<bool> register_name_async(
             std::string const& name, naming::id_type const& id);
 
         bool register_name(std::string const& name, naming::id_type const& id,
@@ -1073,7 +1073,7 @@ namespace hpx { namespace agas {
         ///                   throw but returns the result code using the
         ///                   parameter \a ec. Otherwise it throws an instance
         ///                   of hpx#exception.
-        lcos::future<naming::id_type> unregister_name_async(
+        hpx::future<naming::id_type> unregister_name_async(
             std::string const& name);
 
         naming::id_type unregister_name(
@@ -1104,7 +1104,7 @@ namespace hpx { namespace agas {
         ///                   throw but returns the result code using the
         ///                   parameter \a ec. Otherwise it throws an instance
         ///                   of hpx#exception.
-        lcos::future<naming::id_type> resolve_name_async(
+        hpx::future<naming::id_type> resolve_name_async(
             std::string const& name);
 
         naming::id_type resolve_name(

--- a/libs/full/agas/src/addressing_service.cpp
+++ b/libs/full/agas/src/addressing_service.cpp
@@ -487,7 +487,7 @@ namespace hpx { namespace agas {
         return std::uint32_t(-1);
     }    // }}}
 
-    lcos::future<std::uint32_t> addressing_service::get_num_localities_async(
+    hpx::future<std::uint32_t> addressing_service::get_num_localities_async(
         components::component_type type) const
     {    // {{{ get_num_localities implementation
         if (type == components::component_invalid)
@@ -514,7 +514,7 @@ namespace hpx { namespace agas {
         return std::uint32_t(0);
     }    // }}}
 
-    lcos::future<std::uint32_t>
+    hpx::future<std::uint32_t>
     addressing_service::get_num_overall_threads_async() const
     {    // {{{
         return locality_ns_->get_num_overall_threads_async();
@@ -534,7 +534,7 @@ namespace hpx { namespace agas {
         return std::vector<std::uint32_t>();
     }    // }}}
 
-    lcos::future<std::vector<std::uint32_t>>
+    hpx::future<std::vector<std::uint32_t>>
     addressing_service::get_num_threads_async() const
     {    // {{{
         return locality_ns_->get_num_threads_async();
@@ -1256,7 +1256,7 @@ namespace hpx { namespace agas {
         return fut.get() + compensated_credit;
     }
 
-    lcos::future<std::int64_t> addressing_service::incref_async(
+    hpx::future<std::int64_t> addressing_service::incref_async(
         naming::gid_type const& id, std::int64_t credit,
         naming::id_type const& keep_alive)
     {    // {{{ incref implementation
@@ -1265,7 +1265,7 @@ namespace hpx { namespace agas {
         if (HPX_UNLIKELY(nullptr == threads::get_self_ptr()))
         {
             // reschedule this call as an HPX thread
-            lcos::future<std::int64_t> (addressing_service::*incref_async_ptr)(
+            hpx::future<std::int64_t> (addressing_service::*incref_async_ptr)(
                 naming::gid_type const&, std::int64_t, naming::id_type const&) =
                 &addressing_service::incref_async;
 
@@ -1277,7 +1277,7 @@ namespace hpx { namespace agas {
             HPX_THROW_EXCEPTION(bad_parameter,
                 "addressing_service::incref_async",
                 "invalid credit count of {1}", credit);
-            return lcos::future<std::int64_t>();
+            return hpx::future<std::int64_t>();
         }
 
         HPX_ASSERT(keep_alive != naming::invalid_id);
@@ -1350,7 +1350,7 @@ namespace hpx { namespace agas {
 
         naming::gid_type const e_lower = pending_incref.first;
 
-        lcos::future<std::int64_t> f = primary_ns_.increment_credit(
+        hpx::future<std::int64_t> f = primary_ns_.increment_credit(
             pending_incref.second, e_lower, e_lower);
 
         // pass the amount of compensated decrefs to the callback
@@ -1480,7 +1480,7 @@ namespace hpx { namespace agas {
         return false;
     }
 
-    lcos::future<bool> addressing_service::register_name_async(
+    hpx::future<bool> addressing_service::register_name_async(
         std::string const& name, naming::id_type const& id)
     {    // {{{
         // We need to modify the reference count.
@@ -1517,7 +1517,7 @@ namespace hpx { namespace agas {
         }
     }    // }}}
 
-    lcos::future<naming::id_type> addressing_service::unregister_name_async(
+    hpx::future<naming::id_type> addressing_service::unregister_name_async(
         std::string const& name)
     {    // {{{
         return symbol_ns_.unbind_async(name);
@@ -1538,7 +1538,7 @@ namespace hpx { namespace agas {
         }
     }    // }}}
 
-    lcos::future<naming::id_type> addressing_service::resolve_name_async(
+    hpx::future<naming::id_type> addressing_service::resolve_name_async(
         std::string const& name)
     {    // {{{
         return symbol_ns_.resolve_async(name);

--- a/libs/full/agas_base/include/hpx/agas_base/component_namespace.hpp
+++ b/libs/full/agas_base/include/hpx/agas_base/component_namespace.hpp
@@ -44,7 +44,7 @@ namespace hpx { namespace agas {
         virtual std::string get_component_type_name(
             components::component_type type) = 0;
 
-        virtual lcos::future<std::uint32_t> get_num_localities(
+        virtual hpx::future<std::uint32_t> get_num_localities(
             components::component_type type) = 0;
 
         virtual void register_server_instance(std::uint32_t /*locality_id*/) {}

--- a/libs/full/agas_base/include/hpx/agas_base/detail/bootstrap_component_namespace.hpp
+++ b/libs/full/agas_base/include/hpx/agas_base/detail/bootstrap_component_namespace.hpp
@@ -46,7 +46,7 @@ namespace hpx { namespace agas { namespace detail {
 
         std::string get_component_type_name(components::component_type type);
 
-        lcos::future<std::uint32_t> get_num_localities(
+        hpx::future<std::uint32_t> get_num_localities(
             components::component_type type);
 
         void register_counter_types();

--- a/libs/full/agas_base/include/hpx/agas_base/detail/hosted_component_namespace.hpp
+++ b/libs/full/agas_base/include/hpx/agas_base/detail/hosted_component_namespace.hpp
@@ -52,7 +52,7 @@ namespace hpx { namespace agas { namespace detail {
 
         std::string get_component_type_name(components::component_type type);
 
-        lcos::future<std::uint32_t> get_num_localities(
+        hpx::future<std::uint32_t> get_num_localities(
             components::component_type type);
 
     private:

--- a/libs/full/agas_base/src/detail/bootstrap_component_namespace.cpp
+++ b/libs/full/agas_base/src/detail/bootstrap_component_namespace.cpp
@@ -62,7 +62,7 @@ namespace hpx { namespace agas { namespace detail {
         return server_.get_component_type_name(type);
     }
 
-    lcos::future<std::uint32_t>
+    hpx::future<std::uint32_t>
     bootstrap_component_namespace::get_num_localities(
         components::component_type type)
     {

--- a/libs/full/agas_base/src/detail/hosted_component_namespace.cpp
+++ b/libs/full/agas_base/src/detail/hosted_component_namespace.cpp
@@ -104,7 +104,7 @@ namespace hpx { namespace agas { namespace detail {
 #endif
     }
 
-    lcos::future<std::uint32_t> hosted_component_namespace::get_num_localities(
+    hpx::future<std::uint32_t> hosted_component_namespace::get_num_localities(
         components::component_type type)
     {
 #if !defined(HPX_COMPUTE_DEVICE_CODE)

--- a/libs/full/async_colocated/include/hpx/async_colocated/async_colocated.hpp
+++ b/libs/full/async_colocated/include/hpx/async_colocated/async_colocated.hpp
@@ -67,7 +67,7 @@ namespace hpx { namespace detail {
 namespace hpx { namespace detail {
     ///////////////////////////////////////////////////////////////////////////
     template <typename Action, typename... Ts>
-    lcos::future<typename traits::promise_local_result<
+    hpx::future<typename traits::promise_local_result<
         typename hpx::traits::extract_action<Action>::remote_result_type>::type>
     async_colocated(naming::id_type const& gid,
         Ts&&...
@@ -95,14 +95,14 @@ namespace hpx { namespace detail {
             service_target, gid.get_gid());
 #else
         HPX_ASSERT(false);
-        return lcos::future<typename traits::promise_local_result<typename hpx::
+        return hpx::future<typename traits::promise_local_result<typename hpx::
                 traits::extract_action<Action>::remote_result_type>::type>{};
 #endif
     }
 
     template <typename Component, typename Signature, typename Derived,
         typename... Ts>
-    lcos::future<typename traits::promise_local_result<typename hpx::traits::
+    hpx::future<typename traits::promise_local_result<typename hpx::traits::
             extract_action<Derived>::remote_result_type>::type>
     async_colocated(
         hpx::actions::basic_action<Component, Signature, Derived> /*act*/
@@ -115,15 +115,14 @@ namespace hpx { namespace detail {
     ///////////////////////////////////////////////////////////////////////////
     template <typename Action, typename Continuation, typename... Ts>
     typename std::enable_if<traits::is_continuation<Continuation>::value,
-        lcos::future<typename traits::promise_local_result<typename hpx::
-                traits::extract_action<Action>::remote_result_type>::type>>::
-        type
-        async_colocated(Continuation&& cont, naming::id_type const& gid,
-            Ts&&...
+        hpx::future<typename traits::promise_local_result<typename hpx::traits::
+                extract_action<Action>::remote_result_type>::type>>::type
+    async_colocated(Continuation&& cont, naming::id_type const& gid,
+        Ts&&...
 #if !defined(HPX_COMPUTE_DEVICE_CODE)
-            vs
+        vs
 #endif
-        )
+    )
     {
 #if defined(HPX_COMPUTE_DEVICE_CODE)
         HPX_UNUSED(cont);
@@ -154,13 +153,12 @@ namespace hpx { namespace detail {
     template <typename Continuation, typename Component, typename Signature,
         typename Derived, typename... Ts>
     typename std::enable_if<traits::is_continuation<Continuation>::value,
-        lcos::future<typename traits::promise_local_result<typename hpx::
-                traits::extract_action<Derived>::remote_result_type>::type>>::
-        type
-        async_colocated(Continuation&& cont,
-            hpx::actions::basic_action<Component, Signature, Derived> /*act*/
-            ,
-            naming::id_type const& gid, Ts&&... vs)
+        hpx::future<typename traits::promise_local_result<typename hpx::traits::
+                extract_action<Derived>::remote_result_type>::type>>::type
+    async_colocated(Continuation&& cont,
+        hpx::actions::basic_action<Component, Signature, Derived> /*act*/
+        ,
+        naming::id_type const& gid, Ts&&... vs)
     {
         return async_colocated<Derived>(
             HPX_FORWARD(Continuation, cont), gid, HPX_FORWARD(Ts, vs)...);

--- a/libs/full/async_colocated/include/hpx/async_colocated/async_colocated_callback.hpp
+++ b/libs/full/async_colocated/include/hpx/async_colocated/async_colocated_callback.hpp
@@ -20,7 +20,7 @@
 namespace hpx { namespace detail {
     ///////////////////////////////////////////////////////////////////////////
     template <typename Action, typename Callback, typename... Ts>
-    lcos::future<typename traits::promise_local_result<
+    hpx::future<typename traits::promise_local_result<
         typename hpx::traits::extract_action<Action>::remote_result_type>::type>
     async_colocated_cb(naming::id_type const& gid, Callback&& cb,
         Ts&&...
@@ -55,7 +55,7 @@ namespace hpx { namespace detail {
 
     template <typename Component, typename Signature, typename Derived,
         typename Callback, typename... Ts>
-    lcos::future<typename traits::promise_local_result<typename hpx::traits::
+    hpx::future<typename traits::promise_local_result<typename hpx::traits::
             extract_action<Derived>::remote_result_type>::type>
     async_colocated_cb(
         hpx::actions::basic_action<Component, Signature, Derived> /*act*/
@@ -69,7 +69,7 @@ namespace hpx { namespace detail {
     ///////////////////////////////////////////////////////////////////////////
     template <typename Action, typename Continuation, typename Callback,
         typename... Ts>
-    lcos::future<typename traits::promise_local_result<
+    hpx::future<typename traits::promise_local_result<
         typename hpx::traits::extract_action<Action>::remote_result_type>::type>
     async_colocated_cb(
         Continuation&& cont, naming::id_type const& gid, Callback&& cb,
@@ -108,7 +108,7 @@ namespace hpx { namespace detail {
 
     template <typename Continuation, typename Component, typename Signature,
         typename Derived, typename Callback, typename... Ts>
-    lcos::future<typename traits::promise_local_result<typename hpx::traits::
+    hpx::future<typename traits::promise_local_result<typename hpx::traits::
             extract_action<Derived>::remote_result_type>::type>
     async_colocated_cb(Continuation&& cont,
         hpx::actions::basic_action<Component, Signature, Derived> /*act*/

--- a/libs/full/async_colocated/include/hpx/async_colocated/async_colocated_callback_fwd.hpp
+++ b/libs/full/async_colocated/include/hpx/async_colocated/async_colocated_callback_fwd.hpp
@@ -13,13 +13,13 @@
 namespace hpx { namespace detail {
     ///////////////////////////////////////////////////////////////////////////
     template <typename Action, typename Callback, typename... Ts>
-    lcos::future<typename traits::promise_local_result<
+    hpx::future<typename traits::promise_local_result<
         typename hpx::traits::extract_action<Action>::remote_result_type>::type>
     async_colocated_cb(naming::id_type const& gid, Callback&& cb, Ts&&... vs);
 
     template <typename Component, typename Signature, typename Derived,
         typename Callback, typename... Ts>
-    lcos::future<typename traits::promise_local_result<typename hpx::traits::
+    hpx::future<typename traits::promise_local_result<typename hpx::traits::
             extract_action<Derived>::remote_result_type>::type>
     async_colocated_cb(
         hpx::actions::basic_action<Component, Signature, Derived> /*act*/
@@ -29,14 +29,14 @@ namespace hpx { namespace detail {
     ///////////////////////////////////////////////////////////////////////////
     template <typename Action, typename Continuation, typename Callback,
         typename... Ts>
-    lcos::future<typename traits::promise_local_result<
+    hpx::future<typename traits::promise_local_result<
         typename hpx::traits::extract_action<Action>::remote_result_type>::type>
     async_colocated_cb(Continuation&& cont, naming::id_type const& gid,
         Callback&& cb, Ts&&... vs);
 
     template <typename Continuation, typename Component, typename Signature,
         typename Derived, typename Callback, typename... Ts>
-    lcos::future<typename traits::promise_local_result<typename hpx::traits::
+    hpx::future<typename traits::promise_local_result<typename hpx::traits::
             extract_action<Derived>::remote_result_type>::type>
     async_colocated_cb(Continuation&& cont,
         hpx::actions::basic_action<Component, Signature, Derived> /*act*/

--- a/libs/full/async_colocated/include/hpx/async_colocated/async_colocated_fwd.hpp
+++ b/libs/full/async_colocated/include/hpx/async_colocated/async_colocated_fwd.hpp
@@ -20,13 +20,13 @@
 namespace hpx { namespace detail {
     ///////////////////////////////////////////////////////////////////////////
     template <typename Action, typename... Ts>
-    lcos::future<typename traits::promise_local_result<
+    hpx::future<typename traits::promise_local_result<
         typename hpx::traits::extract_action<Action>::remote_result_type>::type>
     async_colocated(naming::id_type const& id, Ts&&... vs);
 
     template <typename Component, typename Signature, typename Derived,
         typename... Ts>
-    lcos::future<typename traits::promise_local_result<typename hpx::traits::
+    hpx::future<typename traits::promise_local_result<typename hpx::traits::
             extract_action<Derived>::remote_result_type>::type>
     async_colocated(
         hpx::actions::basic_action<Component, Signature, Derived> /*act*/
@@ -38,22 +38,19 @@ namespace hpx { namespace detail {
 #if !defined(HPX_MSVC)
     template <typename Action, typename Continuation, typename... Ts>
     typename std::enable_if<traits::is_continuation<Continuation>::value,
-        lcos::future<typename traits::promise_local_result<typename hpx::
-                traits::extract_action<Action>::remote_result_type>::type>>::
-        type
-        async_colocated(
-            Continuation&& cont, naming::id_type const& id, Ts&&... vs);
+        hpx::future<typename traits::promise_local_result<typename hpx::traits::
+                extract_action<Action>::remote_result_type>::type>>::type
+    async_colocated(Continuation&& cont, naming::id_type const& id, Ts&&... vs);
 
     template <typename Continuation, typename Component, typename Signature,
         typename Derived, typename... Ts>
     typename std::enable_if<traits::is_continuation<Continuation>::value,
-        lcos::future<typename traits::promise_local_result<typename hpx::
-                traits::extract_action<Derived>::remote_result_type>::type>>::
-        type
-        async_colocated(Continuation&& cont,
-            hpx::actions::basic_action<Component, Signature, Derived> /*act*/
-            ,
-            naming::id_type const& id, Ts&&... vs);
+        hpx::future<typename traits::promise_local_result<typename hpx::traits::
+                extract_action<Derived>::remote_result_type>::type>>::type
+    async_colocated(Continuation&& cont,
+        hpx::actions::basic_action<Component, Signature, Derived> /*act*/
+        ,
+        naming::id_type const& id, Ts&&... vs);
 #endif
 }}    // namespace hpx::detail
 

--- a/libs/full/async_colocated/include/hpx/async_colocated/get_colocation_id.hpp
+++ b/libs/full/async_colocated/include/hpx/async_colocated/get_colocation_id.hpp
@@ -43,6 +43,6 @@ namespace hpx {
     /// \param id [in] The id of the object to locate.
     ///
     /// \see    \a hpx::get_colocation_id(launch::sync_policy)
-    HPX_EXPORT lcos::future<naming::id_type> get_colocation_id(
+    HPX_EXPORT hpx::future<naming::id_type> get_colocation_id(
         naming::id_type const& id);
 }    // namespace hpx

--- a/libs/full/async_distributed/include/hpx/async_distributed/async.hpp
+++ b/libs/full/async_distributed/include/hpx/async_distributed/async.hpp
@@ -44,7 +44,7 @@ namespace hpx { namespace detail {
             typename... Ts>
         HPX_FORCEINLINE typename std::enable_if<
             traits::is_launch_policy<Policy>::value,
-            lcos::future<typename traits::promise_local_result<typename traits::
+            hpx::future<typename traits::promise_local_result<typename traits::
                     extract_action<Action>::remote_result_type>::type>>::type
         operator()(components::client_base<Client, Stub> const& c,
             Policy const& launch_policy, Ts&&... ts) const
@@ -63,7 +63,7 @@ namespace hpx { namespace detail {
     {
         // id_type
         template <typename Policy_, typename... Ts>
-        HPX_FORCEINLINE static lcos::future<
+        HPX_FORCEINLINE static hpx::future<
             typename traits::promise_local_result<typename hpx::traits::
                     extract_action<Action>::remote_result_type>::type>
         call(Policy_&& launch_policy, naming::id_type const& id, Ts&&... ts)
@@ -75,7 +75,7 @@ namespace hpx { namespace detail {
 
         template <typename Policy_, typename Client, typename Stub,
             typename... Ts>
-        HPX_FORCEINLINE static lcos::future<
+        HPX_FORCEINLINE static hpx::future<
             typename traits::promise_local_result<typename traits::
                     extract_action<Action>::remote_result_type>::type>
         call(Policy_&& launch_policy, components::client_base<Client, Stub> c,
@@ -120,7 +120,7 @@ namespace hpx { namespace detail {
     struct async_action_dispatch<Action, naming::id_type>
     {
         template <typename... Ts>
-        HPX_FORCEINLINE static lcos::future<
+        HPX_FORCEINLINE static hpx::future<
             typename traits::promise_local_result<typename hpx::traits::
                     extract_action<Action>::remote_result_type>::type>
         call(naming::id_type const& id, Ts&&... ts)
@@ -137,7 +137,7 @@ namespace hpx { namespace detail {
         typename std::enable_if<traits::is_client<Client>::value>::type>
     {
         template <typename Client_, typename Stub, typename... Ts>
-        HPX_FORCEINLINE static lcos::future<
+        HPX_FORCEINLINE static hpx::future<
             typename traits::promise_local_result<typename traits::
                     extract_action<Action>::remote_result_type>::type>
         call(components::client_base<Client_, Stub> const& c, Ts&&... ts)
@@ -211,7 +211,7 @@ namespace hpx { namespace detail {
     {
         template <typename Component, typename Signature, typename Derived,
             typename... Ts>
-        HPX_FORCEINLINE static lcos::future<
+        HPX_FORCEINLINE static hpx::future<
             typename traits::promise_local_result<typename hpx::traits::
                     extract_action<Derived>::remote_result_type>::type>
         call(hpx::actions::basic_action<Component, Signature, Derived> const&,
@@ -222,7 +222,7 @@ namespace hpx { namespace detail {
 
         template <typename Component, typename Signature, typename Derived,
             typename Client, typename Stub, typename... Ts>
-        HPX_FORCEINLINE static lcos::future<
+        HPX_FORCEINLINE static hpx::future<
             typename traits::promise_local_result<typename traits::
                     extract_action<Derived>::remote_result_type>::type>
         call(hpx::actions::basic_action<Component, Signature, Derived> const&,
@@ -272,7 +272,7 @@ namespace hpx { namespace detail {
 
         template <typename Policy_, typename Component, typename Signature,
             typename Derived, typename Client, typename Stub, typename... Ts>
-        HPX_FORCEINLINE static lcos::future<
+        HPX_FORCEINLINE static hpx::future<
             typename traits::promise_local_result<typename traits::
                     extract_action<Derived>::remote_result_type>::type>
         call(Policy_&& launch_policy,

--- a/libs/full/async_distributed/include/hpx/async_distributed/async_callback.hpp
+++ b/libs/full/async_distributed/include/hpx/async_distributed/async_callback.hpp
@@ -32,7 +32,7 @@ namespace hpx { namespace detail {
     {
         // id_type
         template <typename Policy_, typename Callback, typename... Ts>
-        HPX_FORCEINLINE static lcos::future<
+        HPX_FORCEINLINE static hpx::future<
             typename traits::promise_local_result<typename traits::
                     extract_action<Action>::remote_result_type>::type>
         call(Policy_&& launch_policy, naming::id_type const& id, Callback&& cb,
@@ -45,7 +45,7 @@ namespace hpx { namespace detail {
 
         template <typename Policy_, typename Client, typename Stub,
             typename Callback, typename... Ts>
-        HPX_FORCEINLINE static lcos::future<
+        HPX_FORCEINLINE static hpx::future<
             typename traits::promise_local_result<typename traits::
                     extract_action<Action>::remote_result_type>::type>
         call(Policy_&& launch_policy,
@@ -69,7 +69,7 @@ namespace hpx { namespace detail {
             typename... Ts>
         HPX_FORCEINLINE static typename std::enable_if<
             traits::is_distribution_policy<DistPolicy>::value,
-            lcos::future<typename traits::promise_local_result<typename traits::
+            hpx::future<typename traits::promise_local_result<typename traits::
                     extract_action<Action>::remote_result_type>::type>>::type
         call(Policy_&& launch_policy, DistPolicy const& policy, Callback&& cb,
             Ts&&... ts)
@@ -85,7 +85,7 @@ namespace hpx { namespace detail {
     struct async_cb_action_dispatch<Action, naming::id_type>
     {
         template <typename Callback, typename... Ts>
-        HPX_FORCEINLINE static lcos::future<
+        HPX_FORCEINLINE static hpx::future<
             typename traits::promise_local_result<typename traits::
                     extract_action<Action>::remote_result_type>::type>
         call(naming::id_type const& id, Callback&& cb, Ts&&... ts)
@@ -103,7 +103,7 @@ namespace hpx { namespace detail {
     {
         template <typename Client_, typename Stub, typename Callback,
             typename... Ts>
-        HPX_FORCEINLINE static lcos::future<
+        HPX_FORCEINLINE static hpx::future<
             typename traits::promise_local_result<typename traits::
                     extract_action<Action>::remote_result_type>::type>
         call(components::client_base<Client_, Stub> const& c, Callback&& cb,
@@ -129,7 +129,7 @@ namespace hpx { namespace detail {
             traits::is_distribution_policy<Policy>::value>::type>
     {
         template <typename DistPolicy, typename Callback, typename... Ts>
-        HPX_FORCEINLINE static lcos::future<
+        HPX_FORCEINLINE static hpx::future<
             typename traits::promise_local_result<typename traits::
                     extract_action<Action>::remote_result_type>::type>
         call(DistPolicy const& policy, Callback&& cb, Ts&&... ts)
@@ -163,7 +163,7 @@ namespace hpx { namespace detail {
     {
         template <typename Component, typename Signature, typename Derived,
             typename Callback, typename... Ts>
-        HPX_FORCEINLINE static lcos::future<
+        HPX_FORCEINLINE static hpx::future<
             typename traits::promise_local_result<typename traits::
                     extract_action<Derived>::remote_result_type>::type>
         call(hpx::actions::basic_action<Component, Signature, Derived> const&,
@@ -175,7 +175,7 @@ namespace hpx { namespace detail {
 
         template <typename Component, typename Signature, typename Derived,
             typename Client, typename Stub, typename Callback, typename... Ts>
-        HPX_FORCEINLINE static lcos::future<
+        HPX_FORCEINLINE static hpx::future<
             typename traits::promise_local_result<typename traits::
                     extract_action<Derived>::remote_result_type>::type>
         call(hpx::actions::basic_action<Component, Signature, Derived> const&,
@@ -195,7 +195,7 @@ namespace hpx { namespace detail {
 
         template <typename Component, typename Signature, typename Derived,
             typename DistPolicy, typename Callback, typename... Ts>
-        HPX_FORCEINLINE static lcos::future<
+        HPX_FORCEINLINE static hpx::future<
             typename traits::promise_local_result<typename traits::
                     extract_action<Derived>::remote_result_type>::type>
         call(hpx::actions::basic_action<Component, Signature, Derived> const&,
@@ -212,7 +212,7 @@ namespace hpx { namespace detail {
     {
         template <typename Policy_, typename Component, typename Signature,
             typename Derived, typename Callback, typename... Ts>
-        HPX_FORCEINLINE static lcos::future<
+        HPX_FORCEINLINE static hpx::future<
             typename traits::promise_local_result<typename traits::
                     extract_action<Derived>::remote_result_type>::type>
         call(Policy_&& launch_policy,
@@ -226,7 +226,7 @@ namespace hpx { namespace detail {
         template <typename Policy_, typename Component, typename Signature,
             typename Derived, typename Client, typename Stub, typename Callback,
             typename... Ts>
-        HPX_FORCEINLINE static lcos::future<
+        HPX_FORCEINLINE static hpx::future<
             typename traits::promise_local_result<typename traits::
                     extract_action<Derived>::remote_result_type>::type>
         call(Policy_&& launch_policy,
@@ -248,7 +248,7 @@ namespace hpx { namespace detail {
         template <typename Policy_, typename Component, typename Signature,
             typename Derived, typename DistPolicy, typename Callback,
             typename... Ts>
-        HPX_FORCEINLINE static lcos::future<
+        HPX_FORCEINLINE static hpx::future<
             typename traits::promise_local_result<typename traits::
                     extract_action<Derived>::remote_result_type>::type>
         call(Policy_&& launch_policy,

--- a/libs/full/async_distributed/include/hpx/async_distributed/async_continue.hpp
+++ b/libs/full/async_distributed/include/hpx/async_distributed/async_continue.hpp
@@ -27,7 +27,7 @@ namespace hpx {
     namespace detail {
         template <typename Action, typename RemoteResult, typename Cont,
             typename Target, typename... Ts>
-        lcos::future<typename traits::promise_local_result<
+        hpx::future<typename traits::promise_local_result<
             typename result_of_async_continue<Action, Cont>::type>::type>
         async_continue_r(Cont&& cont, Target const& target, Ts&&... vs)
         {
@@ -53,7 +53,7 @@ namespace hpx {
 
     ///////////////////////////////////////////////////////////////////////////
     template <typename Action, typename Cont, typename... Ts>
-    lcos::future<typename traits::promise_local_result<
+    hpx::future<typename traits::promise_local_result<
         typename detail::result_of_async_continue<Action, Cont>::type>::type>
     async_continue(Cont&& cont, naming::id_type const& gid, Ts&&... vs)
     {
@@ -67,7 +67,7 @@ namespace hpx {
 
     template <typename Component, typename Signature, typename Derived,
         typename Cont, typename... Ts>
-    lcos::future<typename traits::promise_local_result<
+    hpx::future<typename traits::promise_local_result<
         typename detail::result_of_async_continue<Derived, Cont>::type>::type>
     async_continue(
         hpx::actions::basic_action<Component, Signature, Derived> /*act*/
@@ -82,7 +82,7 @@ namespace hpx {
     template <typename Action, typename Cont, typename DistPolicy,
         typename... Ts>
     typename std::enable_if<traits::is_distribution_policy<DistPolicy>::value,
-        lcos::future<typename traits::promise_local_result<typename detail::
+        hpx::future<typename traits::promise_local_result<typename detail::
                 result_of_async_continue<Action, Cont>::type>::type>>::type
     async_continue(Cont&& cont, DistPolicy const& policy, Ts&&... vs)
     {
@@ -97,7 +97,7 @@ namespace hpx {
     template <typename Component, typename Signature, typename Derived,
         typename Cont, typename DistPolicy, typename... Ts>
     typename std::enable_if<traits::is_distribution_policy<DistPolicy>::value,
-        lcos::future<typename traits::promise_local_result<typename detail::
+        hpx::future<typename traits::promise_local_result<typename detail::
                 result_of_async_continue<Derived, Cont>::type>::type>>::type
     async_continue(
         hpx::actions::basic_action<Component, Signature, Derived> /*act*/

--- a/libs/full/async_distributed/include/hpx/async_distributed/async_continue_callback.hpp
+++ b/libs/full/async_distributed/include/hpx/async_distributed/async_continue_callback.hpp
@@ -24,7 +24,7 @@ namespace hpx {
     namespace detail {
         template <typename Action, typename RemoteResult, typename Cont,
             typename Target, typename Callback, typename... Ts>
-        lcos::future<typename traits::promise_local_result<
+        hpx::future<typename traits::promise_local_result<
             typename result_of_async_continue<Action, Cont>::type>::type>
         async_continue_r_cb(
             Cont&& cont, Target const& target, Callback&& cb, Ts&&... vs)
@@ -51,7 +51,7 @@ namespace hpx {
 
     ///////////////////////////////////////////////////////////////////////////
     template <typename Action, typename Cont, typename Callback, typename... Ts>
-    lcos::future<typename traits::promise_local_result<
+    hpx::future<typename traits::promise_local_result<
         typename detail::result_of_async_continue<Action, Cont>::type>::type>
     async_continue_cb(
         Cont&& cont, naming::id_type const& gid, Callback&& cb, Ts&&... vs)
@@ -67,7 +67,7 @@ namespace hpx {
 
     template <typename Component, typename Signature, typename Derived,
         typename Cont, typename Callback, typename... Ts>
-    lcos::future<typename traits::promise_local_result<
+    hpx::future<typename traits::promise_local_result<
         typename detail::result_of_async_continue<Derived, Cont>::type>::type>
     async_continue_cb(
         hpx::actions::basic_action<Component, Signature, Derived> /*act*/
@@ -82,7 +82,7 @@ namespace hpx {
     template <typename Action, typename Cont, typename DistPolicy,
         typename Callback, typename... Ts>
     typename std::enable_if<traits::is_distribution_policy<DistPolicy>::value,
-        lcos::future<typename traits::promise_local_result<typename detail::
+        hpx::future<typename traits::promise_local_result<typename detail::
                 result_of_async_continue<Action, Cont>::type>::type>>::type
     async_continue_cb(
         Cont&& cont, DistPolicy const& policy, Callback&& cb, Ts&&... vs)
@@ -99,7 +99,7 @@ namespace hpx {
     template <typename Component, typename Signature, typename Derived,
         typename Cont, typename DistPolicy, typename Callback, typename... Ts>
     typename std::enable_if<traits::is_distribution_policy<DistPolicy>::value,
-        lcos::future<typename traits::promise_local_result<typename detail::
+        hpx::future<typename traits::promise_local_result<typename detail::
                 result_of_async_continue<Derived, Cont>::type>::type>>::type
     async_continue_cb(
         hpx::actions::basic_action<Component, Signature, Derived> /*act*/

--- a/libs/full/async_distributed/include/hpx/async_distributed/async_continue_callback_fwd.hpp
+++ b/libs/full/async_distributed/include/hpx/async_distributed/async_continue_callback_fwd.hpp
@@ -19,7 +19,7 @@ namespace hpx {
     namespace detail {
         template <typename Action, typename RemoteResult, typename Cont,
             typename Target, typename Callback, typename... Ts>
-        lcos::future<typename traits::promise_local_result<
+        hpx::future<typename traits::promise_local_result<
             typename result_of_async_continue<Action, Cont>::type>::type>
         async_continue_r_cb(
             Cont&& cont, Target const& target, Callback&& cb, Ts&&... vs);
@@ -27,14 +27,14 @@ namespace hpx {
 
     ///////////////////////////////////////////////////////////////////////////
     template <typename Action, typename Cont, typename Callback, typename... Ts>
-    lcos::future<typename traits::promise_local_result<
+    hpx::future<typename traits::promise_local_result<
         typename detail::result_of_async_continue<Action, Cont>::type>::type>
     async_continue_cb(
         Cont&& cont, naming::id_type const& gid, Callback&& cb, Ts&&... vs);
 
     template <typename Component, typename Signature, typename Derived,
         typename Cont, typename Callback, typename... Ts>
-    lcos::future<typename traits::promise_local_result<
+    hpx::future<typename traits::promise_local_result<
         typename detail::result_of_async_continue<Derived, Cont>::type>::type>
     async_continue_cb(
         hpx::actions::basic_action<Component, Signature, Derived> /*act*/
@@ -47,7 +47,7 @@ namespace hpx {
     template <typename Action, typename Cont, typename DistPolicy,
         typename Callback, typename... Ts>
     typename std::enable_if<traits::is_distribution_policy<DistPolicy>::value,
-        lcos::future<typename traits::promise_local_result<typename detail::
+        hpx::future<typename traits::promise_local_result<typename detail::
                 result_of_async_continue<Action, Cont>::type>::type>>::type
     async_continue_cb(
         Cont&& cont, DistPolicy const& policy, Callback&& cb, Ts&&... vs);
@@ -55,7 +55,7 @@ namespace hpx {
     template <typename Component, typename Signature, typename Derived,
         typename Cont, typename DistPolicy, typename Callback, typename... Ts>
     typename std::enable_if<traits::is_distribution_policy<DistPolicy>::value,
-        lcos::future<typename traits::promise_local_result<typename detail::
+        hpx::future<typename traits::promise_local_result<typename detail::
                 result_of_async_continue<Derived, Cont>::type>::type>>::type
     async_continue_cb(
         hpx::actions::basic_action<Component, Signature, Derived> /*act*/

--- a/libs/full/async_distributed/include/hpx/async_distributed/async_continue_fwd.hpp
+++ b/libs/full/async_distributed/include/hpx/async_distributed/async_continue_fwd.hpp
@@ -34,20 +34,20 @@ namespace hpx {
 
         template <typename Action, typename RemoteResult, typename Cont,
             typename Target, typename... Ts>
-        lcos::future<typename traits::promise_local_result<
+        hpx::future<typename traits::promise_local_result<
             typename result_of_async_continue<Action, Cont>::type>::type>
         async_continue_r(Cont&& cont, Target const& target, Ts&&... vs);
     }    // namespace detail
 
     ///////////////////////////////////////////////////////////////////////////
     template <typename Action, typename Cont, typename... Ts>
-    lcos::future<typename traits::promise_local_result<
+    hpx::future<typename traits::promise_local_result<
         typename detail::result_of_async_continue<Action, Cont>::type>::type>
     async_continue(Cont&& cont, naming::id_type const& gid, Ts&&... vs);
 
     template <typename Component, typename Signature, typename Derived,
         typename Cont, typename... Ts>
-    lcos::future<typename traits::promise_local_result<
+    hpx::future<typename traits::promise_local_result<
         typename detail::result_of_async_continue<Derived, Cont>::type>::type>
     async_continue(
         hpx::actions::basic_action<Component, Signature, Derived> /*act*/
@@ -60,14 +60,14 @@ namespace hpx {
     template <typename Action, typename Cont, typename DistPolicy,
         typename... Ts>
     typename std::enable_if<traits::is_distribution_policy<DistPolicy>::value,
-        lcos::future<typename traits::promise_local_result<typename detail::
+        hpx::future<typename traits::promise_local_result<typename detail::
                 result_of_async_continue<Action, Cont>::type>::type>>::type
     async_continue(Cont&& cont, DistPolicy const& policy, Ts&&... vs);
 
     template <typename Component, typename Signature, typename Derived,
         typename Cont, typename DistPolicy, typename... Ts>
     typename std::enable_if<traits::is_distribution_policy<DistPolicy>::value,
-        lcos::future<typename traits::promise_local_result<typename detail::
+        hpx::future<typename traits::promise_local_result<typename detail::
                 result_of_async_continue<Derived, Cont>::type>::type>>::type
     async_continue(
         hpx::actions::basic_action<Component, Signature, Derived> /*act*/

--- a/libs/full/async_distributed/include/hpx/async_distributed/bind_action.hpp
+++ b/libs/full/async_distributed/include/hpx/async_distributed/bind_action.hpp
@@ -97,8 +97,7 @@ namespace hpx { namespace util {
             }
 
             template <typename... Us>
-            HPX_FORCEINLINE hpx::lcos::future<result_type> async(
-                Us&&... vs) const
+            HPX_FORCEINLINE hpx::future<result_type> async(Us&&... vs) const
             {
                 return hpx::async<Action>(
                     detail::bind_eval<Ts const&, sizeof...(Us)>::call(

--- a/libs/full/async_distributed/include/hpx/async_distributed/dataflow.hpp
+++ b/libs/full/async_distributed/include/hpx/async_distributed/dataflow.hpp
@@ -50,7 +50,7 @@ namespace hpx { namespace lcos { namespace detail {
     template <typename Policy, typename Action, typename Args>
     struct dataflow_return_impl</*IsAction=*/true, Policy, Action, Args>
     {
-        using type = hpx::lcos::future<typename Action::result_type>;
+        using type = hpx::future<typename Action::result_type>;
     };
 
     ///////////////////////////////////////////////////////////////////////////
@@ -95,7 +95,7 @@ namespace hpx { namespace lcos { namespace detail {
     struct dataflow_action_dispatch
     {
         template <typename Allocator, typename... Ts>
-        HPX_FORCEINLINE static lcos::future<
+        HPX_FORCEINLINE static hpx::future<
             typename traits::promise_local_result<typename hpx::traits::
                     extract_action<Action>::remote_result_type>::type>
         call(Allocator const& alloc, naming::id_type const& id, Ts&&... ts)
@@ -111,7 +111,7 @@ namespace hpx { namespace lcos { namespace detail {
             typename std::decay<Policy>::type>::value>::type>
     {
         template <typename Allocator, typename... Ts>
-        HPX_FORCEINLINE static lcos::future<
+        HPX_FORCEINLINE static hpx::future<
             typename traits::promise_local_result<typename hpx::traits::
                     extract_action<Action>::remote_result_type>::type>
         call(Allocator const& alloc, Policy&& policy, naming::id_type const& id,

--- a/libs/full/async_distributed/include/hpx/async_distributed/detail/async_implementations.hpp
+++ b/libs/full/async_distributed/include/hpx/async_distributed/detail/async_implementations.hpp
@@ -140,7 +140,7 @@ namespace hpx { namespace detail {
     struct sync_local_invoke
     {
         template <typename... Ts>
-        static lcos::future<Result> call(
+        static hpx::future<Result> call(
             naming::id_type const& /*id*/, naming::address&& addr, Ts&&... vs)
         {
             try
@@ -177,7 +177,7 @@ namespace hpx { namespace detail {
     struct sync_local_invoke<Action, void>
     {
         template <typename... Ts>
-        static lcos::future<void> call(
+        static hpx::future<void> call(
             naming::id_type const& /*id*/, naming::address&& addr, Ts&&... vs)
         {
             try
@@ -199,7 +199,7 @@ namespace hpx { namespace detail {
     struct sync_local_invoke_cb
     {
         template <typename Callback, typename... Ts>
-        static lcos::future<Result> call(naming::id_type const& id,
+        static hpx::future<Result> call(naming::id_type const& id,
             naming::address&& addr, Callback&& cb, Ts&&... vs)
         {
             future<Result> f;

--- a/libs/full/async_distributed/include/hpx/async_distributed/detail/promise_base.hpp
+++ b/libs/full/async_distributed/include/hpx/async_distributed/detail/promise_base.hpp
@@ -95,7 +95,7 @@ namespace hpx {
             }
 
         private:
-            void destroy()
+            void destroy() noexcept
             {
                 typedef std::allocator_traits<other_allocator> traits;
 

--- a/libs/full/async_distributed/tests/regressions/async_callback_non_deduced_context.cpp
+++ b/libs/full/async_distributed/tests/regressions/async_callback_non_deduced_context.cpp
@@ -23,7 +23,7 @@ int test()
 HPX_PLAIN_ACTION(test, test_action)
 
 ///////////////////////////////////////////////////////////////////////////////
-int future_callback(hpx::lcos::future<int> p)
+int future_callback(hpx::future<int> p)
 {
     HPX_TEST(p.has_value());
     int result = p.get();
@@ -35,7 +35,7 @@ int future_callback(hpx::lcos::future<int> p)
 int hpx_main()
 {
     using hpx::async;
-    using hpx::lcos::future;
+    using hpx::future;
 
     {
         test_action do_test;

--- a/libs/full/async_distributed/tests/regressions/dataflow_791.cpp
+++ b/libs/full/async_distributed/tests/regressions/dataflow_791.cpp
@@ -28,9 +28,9 @@
 
 using hpx::async;
 using hpx::dataflow;
+using hpx::shared_future;
 using hpx::unwrapping;
 using hpx::wait_all;
-using hpx::lcos::shared_future;
 using std::vector;
 
 struct block

--- a/libs/full/async_distributed/tests/regressions/dataflow_const_functor_773.cpp
+++ b/libs/full/async_distributed/tests/regressions/dataflow_const_functor_773.cpp
@@ -14,7 +14,7 @@
 #include <hpx/hpx_main.hpp>
 #include <hpx/pack_traversal/unwrap.hpp>
 
-typedef hpx::lcos::shared_future<double> future_type;
+typedef hpx::shared_future<double> future_type;
 
 template <typename Value>
 struct mul

--- a/libs/full/async_distributed/tests/regressions/dataflow_future_swap.cpp
+++ b/libs/full/async_distributed/tests/regressions/dataflow_future_swap.cpp
@@ -23,7 +23,7 @@
 
 using hpx::unwrapping;
 
-typedef hpx::lcos::shared_future<double> future_type;
+typedef hpx::shared_future<double> future_type;
 
 struct mul
 {

--- a/libs/full/async_distributed/tests/regressions/dataflow_future_swap2.cpp
+++ b/libs/full/async_distributed/tests/regressions/dataflow_future_swap2.cpp
@@ -22,7 +22,7 @@
 
 using hpx::unwrapping;
 
-typedef hpx::lcos::shared_future<double> future_type;
+typedef hpx::shared_future<double> future_type;
 
 struct mul
 {

--- a/libs/full/async_distributed/tests/regressions/dataflow_launch_775.cpp
+++ b/libs/full/async_distributed/tests/regressions/dataflow_launch_775.cpp
@@ -18,7 +18,7 @@
 
 using hpx::dataflow;
 
-typedef hpx::lcos::shared_future<double> future_type;
+typedef hpx::shared_future<double> future_type;
 
 template <typename Value>
 struct mul

--- a/libs/full/async_distributed/tests/regressions/dataflow_using_774.cpp
+++ b/libs/full/async_distributed/tests/regressions/dataflow_using_774.cpp
@@ -19,7 +19,7 @@
 // the following line causes compile errors
 using hpx::dataflow;
 
-typedef hpx::lcos::shared_future<double> future_type;
+typedef hpx::shared_future<double> future_type;
 
 template <typename Value>
 struct mul

--- a/libs/full/async_distributed/tests/regressions/future_timed_wait_1025.cpp
+++ b/libs/full/async_distributed/tests/regressions/future_timed_wait_1025.cpp
@@ -12,7 +12,7 @@
 
 #include <chrono>
 
-void wait_for(hpx::lcos::shared_future<int> f)
+void wait_for(hpx::shared_future<int> f)
 {
     try
     {
@@ -29,7 +29,7 @@ void wait_for(hpx::lcos::shared_future<int> f)
     HPX_TEST(false);
 }
 
-void wait_until(hpx::lcos::shared_future<int> f)
+void wait_until(hpx::shared_future<int> f)
 {
     try
     {
@@ -50,7 +50,7 @@ void wait_until(hpx::lcos::shared_future<int> f)
 void test_wait_for()
 {
     hpx::lcos::local::promise<int> promise;
-    hpx::lcos::shared_future<int> future = promise.get_future();
+    hpx::shared_future<int> future = promise.get_future();
 
     hpx::thread thread(&wait_for, future);
 
@@ -75,7 +75,7 @@ void test_wait_for()
 void test_wait_until()
 {
     hpx::lcos::local::promise<int> promise;
-    hpx::lcos::shared_future<int> future = promise.get_future();
+    hpx::shared_future<int> future = promise.get_future();
 
     hpx::thread thread(&wait_until, future);
 

--- a/libs/full/collectives/include/hpx/collectives/broadcast_direct.hpp
+++ b/libs/full/collectives/include/hpx/collectives/broadcast_direct.hpp
@@ -382,7 +382,7 @@ namespace hpx { namespace lcos {
             std::true_type, Ts const&... vs)
         {
             if (ids.empty())
-                return;    // hpx::lcos::make_ready_future();
+                return;    // hpx::make_ready_future();
 
             std::size_t const local_fanout = HPX_BROADCAST_FANOUT;
             std::size_t local_size = (std::min)(ids.size(), local_fanout);
@@ -439,7 +439,7 @@ namespace hpx { namespace lcos {
                 typename broadcast_result<Action>::action_result action_result;
             typedef typename broadcast_result<Action>::type result_type;
 
-            //if(ids.empty()) return hpx::lcos::make_ready_future(result_type());
+            //if(ids.empty()) return hpx::make_ready_future(result_type());
             if (ids.empty())
                 return result_type();
 

--- a/libs/full/collectives/src/barrier.cpp
+++ b/libs/full/collectives/src/barrier.cpp
@@ -113,7 +113,7 @@ namespace hpx { namespace lcos {
         (*node_)->wait(false).get();
     }
 
-    future<void> barrier::wait(hpx::launch::async_policy)
+    hpx::future<void> barrier::wait(hpx::launch::async_policy)
     {
         return (*node_)->wait(true);
     }

--- a/libs/full/collectives/src/detail/barrier_node.cpp
+++ b/libs/full/collectives/src/detail/barrier_node.cpp
@@ -87,7 +87,7 @@ namespace hpx { namespace lcos { namespace detail {
     hpx::future<void> barrier_node::wait(bool async)
     {
         hpx::intrusive_ptr<barrier_node> this_(this);
-        future<void> result;
+        hpx::future<void> result;
 
         if (num_ < cut_off_)
         {
@@ -266,7 +266,7 @@ namespace hpx { namespace lcos { namespace detail {
         // Once we notified our children, we mark ourself ready.
         hpx::intrusive_ptr<barrier_node> this_(this);
         hpx::when_all(futures).then(
-            hpx::launch::sync, [this_ = HPX_MOVE(this_)](future<void> f) {
+            hpx::launch::sync, [this_ = HPX_MOVE(this_)](hpx::future<void> f) {
                 // Trigger possible errors...
                 f.get();
                 this_->broadcast_promise_.set_value();

--- a/libs/full/collectives/tests/performance/osu/broadcast.hpp
+++ b/libs/full/collectives/tests/performance/osu/broadcast.hpp
@@ -39,14 +39,14 @@ namespace hpx { namespace lcos {
     {
         broadcast()
           : ready_future(ready_promise.get_future())
-          , bcast_future(hpx::lcos::make_ready_future())
+          , bcast_future(hpx::make_ready_future())
         {
         }
 
         explicit broadcast(hpx::id_type id, std::size_t fan_out = 2)
           : this_id(id)
           , ready_future(ready_promise.get_future())
-          , bcast_future(hpx::lcos::make_ready_future())
+          , bcast_future(hpx::make_ready_future())
         {
         }
 
@@ -89,7 +89,7 @@ namespace hpx { namespace lcos {
                         hpx::util::bind(act, hpx::util::placeholders::_1, a0),
                         fan_out);
                 }
-                return hpx::lcos::make_ready_future(a0);
+                return hpx::make_ready_future(a0);
             }
             else
             {

--- a/libs/full/collectives/tests/regressions/broadcast_wait_for_2822.cpp
+++ b/libs/full/collectives/tests/regressions/broadcast_wait_for_2822.cpp
@@ -43,16 +43,16 @@ int hpx_main()
 
         auto f =
             hpx::lcos::broadcast<vector_bcast_action>(localities, bcast_array);
-        hpx::lcos::future_status status = hpx::lcos::future_status::timeout;
+        hpx::future_status status = hpx::future_status::timeout;
 
         // This test should usually test against future_status == ready. However,
         // under some circumstances, the operation might still take a little
         // longer...
-        while (status != hpx::lcos::future_status::ready)
+        while (status != hpx::future_status::ready)
         {
             status = f.wait_for(std::chrono::milliseconds(1000));
-            HPX_TEST(status == hpx::lcos::future_status::ready ||
-                status == hpx::lcos::future_status::timeout);
+            HPX_TEST(status == hpx::future_status::ready ||
+                status == hpx::future_status::timeout);
         }
 
         HPX_TEST_EQ(buffer.size(), N);

--- a/libs/full/components/include/hpx/components/client_base.hpp
+++ b/libs/full/components/include/hpx/components/client_base.hpp
@@ -83,21 +83,21 @@ namespace hpx { namespace traits {
             HPX_FORCEINLINE static Derived create(
                 hpx::intrusive_ptr<SharedState> const& shared_state)
             {
-                return Derived(future<id_type>(shared_state));
+                return Derived(hpx::future<id_type>(shared_state));
             }
 
             template <typename SharedState>
             HPX_FORCEINLINE static Derived create(
                 hpx::intrusive_ptr<SharedState>&& shared_state)
             {
-                return Derived(future<id_type>(HPX_MOVE(shared_state)));
+                return Derived(hpx::future<id_type>(HPX_MOVE(shared_state)));
             }
 
             template <typename SharedState>
             HPX_FORCEINLINE static Derived create(
                 SharedState* shared_state, bool addref = true)
             {
-                return Derived(future<id_type>(
+                return Derived(hpx::future<id_type>(
                     hpx::intrusive_ptr<SharedState>(shared_state, addref)));
             }
 
@@ -156,16 +156,16 @@ namespace hpx { namespace lcos { namespace detail {
     struct future_unwrap_result<Derived,
         std::enable_if_t<traits::is_client_v<Derived>>>
     {
-        using result_type = id_type;
-        using type = Derived;
+        using type = id_type;
+        using wrapped_type = Derived;
     };
 
     template <typename Derived>
-    struct future_unwrap_result<future<Derived>,
+    struct future_unwrap_result<hpx::future<Derived>,
         std::enable_if_t<traits::is_client_v<Derived>>>
     {
-        using result_type = id_type;
-        using type = Derived;
+        using type = id_type;
+        using wrapped_type = Derived;
     };
 
     // Specialization for shared state of id_type, additionally (optionally)
@@ -307,18 +307,18 @@ namespace hpx { namespace components {
             shared_state_->set_value(HPX_MOVE(id));
         }
 
-        explicit client_base(shared_future<id_type> const& f) noexcept
+        explicit client_base(hpx::shared_future<id_type> const& f) noexcept
           : shared_state_(
                 hpx::traits::future_access<future_type>::get_shared_state(f))
         {
         }
-        explicit client_base(shared_future<id_type>&& f) noexcept
+        explicit client_base(hpx::shared_future<id_type>&& f) noexcept
           : shared_state_(
                 hpx::traits::future_access<future_type>::get_shared_state(
                     HPX_MOVE(f)))
         {
         }
-        explicit client_base(future<id_type>&& f) noexcept
+        explicit client_base(hpx::future<id_type>&& f) noexcept
           : shared_state_(
                 hpx::traits::future_access<future_type>::get_shared_state(
                     HPX_MOVE(f)))
@@ -338,7 +338,7 @@ namespace hpx { namespace components {
         // A future to a client_base can be unwrap to represent the
         // client_base directly as a client_base is semantically a future to
         // the id of the referenced object.
-        client_base(future<Derived>&& d)
+        client_base(hpx::future<Derived>&& d)
           : shared_state_(
                 d.valid() ? lcos::detail::unwrap(HPX_MOVE(d)) : nullptr)
         {
@@ -360,20 +360,20 @@ namespace hpx { namespace components {
             return *this;
         }
 
-        client_base& operator=(shared_future<id_type> const& f) noexcept
+        client_base& operator=(hpx::shared_future<id_type> const& f) noexcept
         {
             shared_state_ =
                 hpx::traits::future_access<future_type>::get_shared_state(f);
             return *this;
         }
-        client_base& operator=(shared_future<id_type>&& f) noexcept
+        client_base& operator=(hpx::shared_future<id_type>&& f) noexcept
         {
             shared_state_ =
                 hpx::traits::future_access<future_type>::get_shared_state(
                     HPX_MOVE(f));
             return *this;
         }
-        client_base& operator=(future<id_type>&& f) noexcept
+        client_base& operator=(hpx::future<id_type>&& f) noexcept
         {
             shared_state_ =
                 hpx::traits::future_access<future_type>::get_shared_state(
@@ -421,13 +421,13 @@ namespace hpx { namespace components {
         }
 
         ///////////////////////////////////////////////////////////////////////
-        shared_future<id_type> detach()
+        hpx::shared_future<id_type> detach()
         {
             return hpx::traits::future_access<future_type>::create(
                 HPX_MOVE(shared_state_));
         }
 
-        shared_future<id_type> share() const
+        hpx::shared_future<id_type> share() const
         {
             return hpx::traits::future_access<future_type>::create(
                 shared_state_);
@@ -519,7 +519,7 @@ namespace hpx { namespace components {
     private:
         template <typename F>
         static typename hpx::traits::future_then_result<Derived, F>::cont_result
-        on_ready(shared_future<id_type>&& fut, F f)
+        on_ready(hpx::shared_future<id_type>&& fut, F f)
         {
             return f(Derived(HPX_MOVE(fut)));
         }
@@ -536,7 +536,7 @@ namespace hpx { namespace components {
             {
                 HPX_THROW_EXCEPTION(no_state, "client_base::then",
                     "this client_base has no valid shared state");
-                return future<result_type>();
+                return hpx::future<result_type>();
             }
 
             using continuation_result_type =
@@ -547,7 +547,7 @@ namespace hpx { namespace components {
             shared_state_ptr p =
                 lcos::detail::make_continuation<continuation_result_type>(
                     *static_cast<Derived const*>(this), l, HPX_FORWARD(F, f));
-            return hpx::traits::future_access<future<result_type>>::create(
+            return hpx::traits::future_access<hpx::future<result_type>>::create(
                 HPX_MOVE(p));
         }
 
@@ -568,7 +568,7 @@ namespace hpx { namespace components {
 
     public:
         // Register our id with AGAS using the given name
-        future<bool> register_as(
+        hpx::future<bool> register_as(
             std::string symbolic_name, bool manage_lifetime = true)
         {
             if (!shared_state_)
@@ -585,7 +585,7 @@ namespace hpx { namespace components {
                             f, HPX_MOVE(symbolic_name), manage_lifetime);
                     });
 
-            return hpx::traits::future_access<future<bool>>::create(
+            return hpx::traits::future_access<hpx::future<bool>>::create(
                 HPX_MOVE(p));
         }
 

--- a/libs/full/lcos_distributed/include/hpx/lcos_distributed/object_semaphore.hpp
+++ b/libs/full/lcos_distributed/include/hpx/lcos_distributed/object_semaphore.hpp
@@ -36,7 +36,7 @@ namespace hpx { namespace lcos {
         }
 
         ///////////////////////////////////////////////////////////////////////
-        lcos::future<void> signal(
+        hpx::future<void> signal(
             launch::async_policy, ValueType const& val, std::uint64_t count = 1)
         {
             HPX_ASSERT(this->get_id());
@@ -51,7 +51,7 @@ namespace hpx { namespace lcos {
         }
 
         ///////////////////////////////////////////////////////////////////////
-        lcos::future<ValueType> get(launch::async_policy)
+        hpx::future<ValueType> get(launch::async_policy)
         {
             HPX_ASSERT(this->get_id());
             typedef typename server_type::get_action action_type;

--- a/libs/full/performance_counters/include/hpx/performance_counters/counters.hpp
+++ b/libs/full/performance_counters/include/hpx/performance_counters/counters.hpp
@@ -395,7 +395,7 @@ namespace hpx { namespace performance_counters {
 
     inline naming::id_type get_counter(std::string const& name, error_code& ec)
     {
-        lcos::future<naming::id_type> f = get_counter_async(name, ec);
+        hpx::future<naming::id_type> f = get_counter_async(name, ec);
         if (ec)
             return naming::invalid_id;
 
@@ -404,7 +404,7 @@ namespace hpx { namespace performance_counters {
 
     inline naming::id_type get_counter(counter_info const& info, error_code& ec)
     {
-        lcos::future<naming::id_type> f = get_counter_async(info, ec);
+        hpx::future<naming::id_type> f = get_counter_async(info, ec);
         if (ec)
             return naming::invalid_id;
 

--- a/libs/full/performance_counters/include/hpx/performance_counters/counters_fwd.hpp
+++ b/libs/full/performance_counters/include/hpx/performance_counters/counters_fwd.hpp
@@ -495,7 +495,7 @@ namespace hpx { namespace performance_counters {
     /// \brief Get the global id of an existing performance counter, if the
     ///        counter does not exist yet, the function attempts to create the
     ///        counter based on the given counter name.
-    HPX_EXPORT lcos::future<naming::id_type> get_counter_async(
+    HPX_EXPORT hpx::future<naming::id_type> get_counter_async(
         std::string name, error_code& ec = throws);
 
     inline naming::id_type get_counter(
@@ -504,7 +504,7 @@ namespace hpx { namespace performance_counters {
     /// \brief Get the global id of an existing performance counter, if the
     ///        counter does not exist yet, the function attempts to create the
     ///        counter based on the given counter info.
-    HPX_EXPORT lcos::future<naming::id_type> get_counter_async(
+    HPX_EXPORT hpx::future<naming::id_type> get_counter_async(
         counter_info const& info, error_code& ec = throws);
 
     inline naming::id_type get_counter(

--- a/libs/full/performance_counters/src/counters.cpp
+++ b/libs/full/performance_counters/src/counters.cpp
@@ -1105,7 +1105,7 @@ namespace hpx { namespace performance_counters {
 
     ///////////////////////////////////////////////////////////////////////////
     static naming::id_type register_with_agas(
-        std::string const& fullname, lcos::future<naming::id_type> f)
+        std::string const& fullname, hpx::future<naming::id_type> f)
     {
         // register the canonical name with AGAS
         naming::id_type id = f.get();
@@ -1114,10 +1114,10 @@ namespace hpx { namespace performance_counters {
     }
 
     ///////////////////////////////////////////////////////////////////////////
-    lcos::future<naming::id_type> get_counter_async(
+    hpx::future<naming::id_type> get_counter_async(
         counter_info const& info, error_code& ec)
     {
-        typedef lcos::future<naming::id_type> result_type;
+        typedef hpx::future<naming::id_type> result_type;
 
         // complement counter info data
         counter_info complemented_info = info;
@@ -1163,7 +1163,7 @@ namespace hpx { namespace performance_counters {
 
                 // use the runtime_support component of the target locality to
                 // create the new performance counter
-                lcos::future<naming::id_type> f;
+                hpx::future<naming::id_type> f;
                 if (p.parentinstanceindex_ >= 0)
                 {
                     f = create_performance_counter_async(
@@ -1192,16 +1192,16 @@ namespace hpx { namespace performance_counters {
                 LPCS_(warning).format("failed to create counter {} ({})",
                     remove_counter_prefix(complemented_info.fullname_),
                     e.what());
-                return lcos::future<naming::id_type>();
+                return hpx::future<naming::id_type>();
             }
         }
         if (ec)
             return result_type();
 
-        return lcos::make_ready_future(id);
+        return hpx::make_ready_future(id);
     }
 
-    lcos::future<naming::id_type> get_counter_async(
+    hpx::future<naming::id_type> get_counter_async(
         std::string name, error_code& ec)
     {
         ensure_counter_prefix(name);    // prepend prefix, if necessary

--- a/libs/full/performance_counters/src/performance_counter.cpp
+++ b/libs/full/performance_counters/src/performance_counter.cpp
@@ -45,7 +45,7 @@ namespace hpx { namespace performance_counters {
     }
 
     ///////////////////////////////////////////////////////////////////////////
-    future<counter_info> performance_counter::get_info() const
+    hpx::future<counter_info> performance_counter::get_info() const
     {
 #if !defined(HPX_COMPUTE_DEVICE_CODE)
         using action_type =
@@ -62,7 +62,8 @@ namespace hpx { namespace performance_counters {
         return get_info().get(ec);
     }
 
-    future<counter_value> performance_counter::get_counter_value(bool reset)
+    hpx::future<counter_value> performance_counter::get_counter_value(
+        bool reset)
     {
 #if !defined(HPX_COMPUTE_DEVICE_CODE)
         using action_type =
@@ -80,7 +81,7 @@ namespace hpx { namespace performance_counters {
         return get_counter_value(reset).get(ec);
     }
 
-    future<counter_value> performance_counter::get_counter_value() const
+    hpx::future<counter_value> performance_counter::get_counter_value() const
     {
 #if !defined(HPX_COMPUTE_DEVICE_CODE)
         using action_type =
@@ -97,8 +98,8 @@ namespace hpx { namespace performance_counters {
         return get_counter_value().get(ec);
     }
 
-    future<counter_values_array> performance_counter::get_counter_values_array(
-        bool reset)
+    hpx::future<counter_values_array>
+    performance_counter::get_counter_values_array(bool reset)
     {
 #if !defined(HPX_COMPUTE_DEVICE_CODE)
         using action_type =
@@ -116,8 +117,8 @@ namespace hpx { namespace performance_counters {
         return get_counter_values_array(reset).get(ec);
     }
 
-    future<counter_values_array> performance_counter::get_counter_values_array()
-        const
+    hpx::future<counter_values_array>
+    performance_counter::get_counter_values_array() const
     {
 #if !defined(HPX_COMPUTE_DEVICE_CODE)
         using action_type =
@@ -135,7 +136,7 @@ namespace hpx { namespace performance_counters {
     }
 
     ///////////////////////////////////////////////////////////////////////////
-    future<bool> performance_counter::start()
+    hpx::future<bool> performance_counter::start()
     {
 #if !defined(HPX_COMPUTE_DEVICE_CODE)
         using action_type = server::base_performance_counter::start_action;
@@ -150,7 +151,7 @@ namespace hpx { namespace performance_counters {
         return start().get(ec);
     }
 
-    future<bool> performance_counter::stop()
+    hpx::future<bool> performance_counter::stop()
     {
 #if !defined(HPX_COMPUTE_DEVICE_CODE)
         using action_type = server::base_performance_counter::stop_action;
@@ -165,7 +166,7 @@ namespace hpx { namespace performance_counters {
         return stop().get(ec);
     }
 
-    future<void> performance_counter::reset()
+    hpx::future<void> performance_counter::reset()
     {
 #if !defined(HPX_COMPUTE_DEVICE_CODE)
         using action_type =
@@ -181,7 +182,7 @@ namespace hpx { namespace performance_counters {
         reset().get(ec);
     }
 
-    future<void> performance_counter::reinit(bool reset)
+    hpx::future<void> performance_counter::reinit(bool reset)
     {
 #if !defined(HPX_COMPUTE_DEVICE_CODE)
         using action_type = server::base_performance_counter::reinit_action;
@@ -199,9 +200,9 @@ namespace hpx { namespace performance_counters {
     }
 
     ///
-    future<std::string> performance_counter::get_name() const
+    hpx::future<std::string> performance_counter::get_name() const
     {
-        return lcos::make_future<std::string>(get_info(),
+        return hpx::make_future<std::string>(get_info(),
             [](counter_info&& info) -> std::string { return info.fullname_; });
     }
 

--- a/libs/full/runtime_components/tests/unit/agas/components/managed_refcnt_checker.hpp
+++ b/libs/full/runtime_components/tests/unit/agas/components/managed_refcnt_checker.hpp
@@ -32,7 +32,7 @@ namespace hpx { namespace test {
 
     private:
         lcos::promise<void> flag_promise_;
-        lcos::future<void> flag_;
+        hpx::future<void> flag_;
         naming::id_type const locality_;
 
     public:
@@ -68,7 +68,7 @@ namespace hpx { namespace test {
                     locality_, flag_promise_.get_id());
         }
 
-        lcos::future<void> take_reference_async(naming::id_type const& gid)
+        hpx::future<void> take_reference_async(naming::id_type const& gid)
         {
             return this->base_type::take_reference_async(get_id(), gid);
         }

--- a/libs/full/runtime_components/tests/unit/agas/components/simple_refcnt_checker.hpp
+++ b/libs/full/runtime_components/tests/unit/agas/components/simple_refcnt_checker.hpp
@@ -32,7 +32,7 @@ namespace hpx { namespace test {
 
     private:
         lcos::promise<void> flag_promise_;
-        lcos::future<void> flag_;
+        hpx::future<void> flag_;
         naming::id_type const locality_;
 
     public:
@@ -68,7 +68,7 @@ namespace hpx { namespace test {
                     locality_, flag_promise_.get_id());
         }
 
-        lcos::future<void> take_reference_async(naming::id_type const& gid)
+        hpx::future<void> take_reference_async(naming::id_type const& gid)
         {
             return this->base_type::take_reference_async(get_id(), gid);
         }

--- a/libs/full/runtime_components/tests/unit/agas/components/stubs/managed_refcnt_checker.hpp
+++ b/libs/full/runtime_components/tests/unit/agas/components/stubs/managed_refcnt_checker.hpp
@@ -22,7 +22,7 @@ namespace hpx { namespace test { namespace stubs {
     struct managed_refcnt_checker
       : components::stub_base<server::managed_refcnt_checker>
     {
-        static lcos::future<void> take_reference_async(
+        static hpx::future<void> take_reference_async(
             naming::id_type const& this_, naming::id_type const& gid)
         {
             typedef server::managed_refcnt_checker::take_reference_action

--- a/libs/full/runtime_components/tests/unit/agas/components/stubs/simple_refcnt_checker.hpp
+++ b/libs/full/runtime_components/tests/unit/agas/components/stubs/simple_refcnt_checker.hpp
@@ -22,7 +22,7 @@ namespace hpx { namespace test { namespace stubs {
     struct simple_refcnt_checker
       : components::stub_base<server::simple_refcnt_checker>
     {
-        static lcos::future<void> take_reference_async(
+        static hpx::future<void> take_reference_async(
             naming::id_type const& this_, naming::id_type const& gid)
         {
             typedef server::simple_refcnt_checker::take_reference_action

--- a/libs/full/runtime_distributed/include/hpx/runtime_distributed.hpp
+++ b/libs/full/runtime_distributed/include/hpx/runtime_distributed.hpp
@@ -354,14 +354,14 @@ namespace hpx {
 
         std::uint32_t get_initial_num_localities() const override;
 
-        lcos::future<std::uint32_t> get_num_localities() const override;
+        hpx::future<std::uint32_t> get_num_localities() const override;
 
         std::string get_locality_name() const override;
 
         std::uint32_t get_num_localities(hpx::launch::sync_policy,
             components::component_type type, error_code& ec) const;
 
-        lcos::future<std::uint32_t> get_num_localities(
+        hpx::future<std::uint32_t> get_num_localities(
             components::component_type type) const;
 
         std::uint32_t assign_cores(std::string const& locality_basename,

--- a/libs/full/runtime_distributed/include/hpx/runtime_distributed/get_num_localities.hpp
+++ b/libs/full/runtime_distributed/include/hpx/runtime_distributed/get_num_localities.hpp
@@ -35,7 +35,7 @@ namespace hpx {
     ///           from an HPX-thread. It will return 0 otherwise.
     ///
     /// \see      \a hpx::find_all_localities, \a hpx::get_num_localities
-    HPX_EXPORT lcos::future<std::uint32_t> get_num_localities(
+    HPX_EXPORT hpx::future<std::uint32_t> get_num_localities(
         components::component_type t);
 
     /// \brief Synchronously return the number of localities which are

--- a/libs/full/runtime_distributed/include/hpx/runtime_distributed/runtime_support.hpp
+++ b/libs/full/runtime_distributed/include/hpx/runtime_distributed/runtime_support.hpp
@@ -50,7 +50,7 @@ namespace hpx { namespace components {
 
         /// Asynchronously create a new component using the runtime_support
         template <typename Component, typename... Ts>
-        lcos::future<naming::id_type> create_component_async(Ts&&... vs)
+        hpx::future<naming::id_type> create_component_async(Ts&&... vs)
         {
             return this->base_type::template create_component_async<Component>(
                 gid_, HPX_FORWARD(Ts, vs)...);
@@ -68,7 +68,7 @@ namespace hpx { namespace components {
 
         /// Asynchronously create a new component using the runtime_support
         template <typename Component, typename... Ts>
-        lcos::future<std::vector<naming::id_type>> bulk_create_components_async(
+        hpx::future<std::vector<naming::id_type>> bulk_create_components_async(
             std::size_t /* count */, Ts&&... vs)
         {
             return this->base_type::template bulk_create_component<Component>(
@@ -76,7 +76,7 @@ namespace hpx { namespace components {
         }
 
         ///////////////////////////////////////////////////////////////////////
-        lcos::future<int> load_components_async()
+        hpx::future<int> load_components_async()
         {
             return this->base_type::load_components_async(gid_);
         }
@@ -86,7 +86,7 @@ namespace hpx { namespace components {
             return this->base_type::load_components(gid_);
         }
 
-        lcos::future<void> call_startup_functions_async(bool pre_startup)
+        hpx::future<void> call_startup_functions_async(bool pre_startup)
         {
             return this->base_type::call_startup_functions_async(
                 gid_, pre_startup);
@@ -98,7 +98,7 @@ namespace hpx { namespace components {
         }
 
         /// \brief Shutdown the given runtime system
-        lcos::future<void> shutdown_async(double timeout = -1)
+        hpx::future<void> shutdown_async(double timeout = -1)
         {
             return this->base_type::shutdown_async(gid_, timeout);
         }
@@ -115,7 +115,7 @@ namespace hpx { namespace components {
         }
 
         /// \brief Terminate the given runtime system
-        lcos::future<void> terminate_async()
+        hpx::future<void> terminate_async()
         {
             return this->base_type::terminate_async(gid_);
         }

--- a/libs/full/runtime_distributed/include/hpx/runtime_distributed/stubs/runtime_support.hpp
+++ b/libs/full/runtime_distributed/include/hpx/runtime_distributed/stubs/runtime_support.hpp
@@ -38,7 +38,7 @@ namespace hpx { namespace components { namespace stubs {
         /// to call \a future#get on the result of this function
         /// to obtain the global id of the newly created object.
         template <typename Component, typename... Ts>
-        static lcos::future<naming::id_type> create_component_async(
+        static hpx::future<naming::id_type> create_component_async(
             naming::id_type const& gid, Ts&&... vs)
         {
             if (!naming::is_locality(gid))
@@ -47,7 +47,7 @@ namespace hpx { namespace components { namespace stubs {
                     "stubs::runtime_support::create_component_async",
                     "The id passed as the first argument is not representing"
                     " a locality");
-                return lcos::make_ready_future(naming::invalid_id);
+                return hpx::make_ready_future(naming::invalid_id);
             }
 
             typedef server::create_component_action<Component,
@@ -71,7 +71,7 @@ namespace hpx { namespace components { namespace stubs {
         /// colocated with the with the given \a targetgid. This is a
         /// non-blocking call.
         template <typename Component, typename... Ts>
-        static lcos::future<std::vector<naming::id_type>>
+        static hpx::future<std::vector<naming::id_type>>
         bulk_create_component_colocated_async(
             naming::id_type const& gid, std::size_t count, Ts&&... vs)
         {
@@ -98,7 +98,7 @@ namespace hpx { namespace components { namespace stubs {
         /// Create multiple new components \a type using the runtime_support
         /// on the given locality. This is a  non-blocking call.
         template <typename Component, typename... Ts>
-        static lcos::future<std::vector<naming::id_type>>
+        static hpx::future<std::vector<naming::id_type>>
         bulk_create_component_async(
             naming::id_type const& gid, std::size_t count, Ts&&... vs)
         {
@@ -108,7 +108,7 @@ namespace hpx { namespace components { namespace stubs {
                     "stubs::runtime_support::bulk_create_component_async",
                     "The id passed as the first argument is not representing"
                     " a locality");
-                return lcos::make_ready_future(std::vector<naming::id_type>());
+                return hpx::make_ready_future(std::vector<naming::id_type>());
             }
 
             typedef server::bulk_create_component_action<Component,
@@ -133,7 +133,7 @@ namespace hpx { namespace components { namespace stubs {
         /// to call \a future#get on the result of this function
         /// to obtain the global id of the newly created object.
         template <typename Component, typename... Ts>
-        static lcos::future<naming::id_type> create_component_colocated_async(
+        static hpx::future<naming::id_type> create_component_colocated_async(
             naming::id_type const& gid, Ts&&... vs)
         {
             typedef server::create_component_action<Component,
@@ -157,7 +157,7 @@ namespace hpx { namespace components { namespace stubs {
         ///////////////////////////////////////////////////////////////////////
         // copy construct a component
         template <typename Component>
-        static lcos::future<naming::id_type> copy_create_component_async(
+        static hpx::future<naming::id_type> copy_create_component_async(
             naming::id_type const& gid, std::shared_ptr<Component> const& p,
             bool local_op)
         {
@@ -167,7 +167,7 @@ namespace hpx { namespace components { namespace stubs {
                     "stubs::runtime_support::copy_create_component_async",
                     "The id passed as the first argument is not representing"
                     " a locality");
-                return lcos::make_ready_future(naming::invalid_id);
+                return hpx::make_ready_future(naming::invalid_id);
             }
 
             typedef typename server::copy_create_component_action<Component>
@@ -188,7 +188,7 @@ namespace hpx { namespace components { namespace stubs {
         ///////////////////////////////////////////////////////////////////////
         // copy construct a component
         template <typename Component>
-        static lcos::future<naming::id_type> migrate_component_async(
+        static hpx::future<naming::id_type> migrate_component_async(
             naming::id_type const& target_locality,
             std::shared_ptr<Component> const& p,
             naming::id_type const& to_migrate)
@@ -199,7 +199,7 @@ namespace hpx { namespace components { namespace stubs {
                     "stubs::runtime_support::migrate_component_async",
                     "The id passed as the first argument is not representing"
                     " a locality");
-                return lcos::make_ready_future(naming::invalid_id);
+                return hpx::make_ready_future(naming::invalid_id);
             }
 
             typedef typename server::migrate_component_here_action<Component>
@@ -208,7 +208,7 @@ namespace hpx { namespace components { namespace stubs {
         }
 
         template <typename Component, typename DistPolicy>
-        static lcos::future<naming::id_type> migrate_component_async(
+        static hpx::future<naming::id_type> migrate_component_async(
             DistPolicy const& policy, std::shared_ptr<Component> const& p,
             naming::id_type const& to_migrate)
         {
@@ -229,17 +229,17 @@ namespace hpx { namespace components { namespace stubs {
         }
 
         ///////////////////////////////////////////////////////////////////////
-        static lcos::future<int> load_components_async(
+        static hpx::future<int> load_components_async(
             naming::id_type const& gid);
         static int load_components(naming::id_type const& gid);
 
-        static lcos::future<void> call_startup_functions_async(
+        static hpx::future<void> call_startup_functions_async(
             naming::id_type const& gid, bool pre_startup);
         static void call_startup_functions(
             naming::id_type const& gid, bool pre_startup);
 
         /// \brief Shutdown the given runtime system
-        static lcos::future<void> shutdown_async(
+        static hpx::future<void> shutdown_async(
             naming::id_type const& targetgid, double timeout = -1);
         static void shutdown(
             naming::id_type const& targetgid, double timeout = -1);
@@ -253,7 +253,7 @@ namespace hpx { namespace components { namespace stubs {
         ///////////////////////////////////////////////////////////////////////
         /// \brief Retrieve configuration information
         /// \brief Terminate the given runtime system
-        static lcos::future<void> terminate_async(
+        static hpx::future<void> terminate_async(
             naming::id_type const& targetgid);
 
         static void terminate(naming::id_type const& targetgid);
@@ -267,13 +267,13 @@ namespace hpx { namespace components { namespace stubs {
         static void garbage_collect_non_blocking(
             naming::id_type const& targetgid);
 
-        static lcos::future<void> garbage_collect_async(
+        static hpx::future<void> garbage_collect_async(
             naming::id_type const& targetgid);
 
         static void garbage_collect(naming::id_type const& targetgid);
 
         ///////////////////////////////////////////////////////////////////////
-        static lcos::future<naming::id_type> create_performance_counter_async(
+        static hpx::future<naming::id_type> create_performance_counter_async(
             naming::id_type targetgid,
             performance_counters::counter_info const& info);
         static naming::id_type create_performance_counter(
@@ -283,7 +283,7 @@ namespace hpx { namespace components { namespace stubs {
 
         ///////////////////////////////////////////////////////////////////////
         /// \brief Retrieve configuration information
-        static lcos::future<util::section> get_config_async(
+        static hpx::future<util::section> get_config_async(
             naming::id_type const& targetgid);
         static void get_config(
             naming::id_type const& targetgid, util::section& ini);

--- a/libs/full/runtime_distributed/src/runtime_distributed.cpp
+++ b/libs/full/runtime_distributed/src/runtime_distributed.cpp
@@ -1553,7 +1553,7 @@ namespace hpx {
         return get_config().get_num_localities();
     }
 
-    lcos::future<std::uint32_t> runtime_distributed::get_num_localities() const
+    hpx::future<std::uint32_t> runtime_distributed::get_num_localities() const
     {
         return agas_client_.get_num_localities_async();
     }
@@ -1574,7 +1574,7 @@ namespace hpx {
         return agas_client_.get_num_localities(type, ec);
     }
 
-    lcos::future<std::uint32_t> runtime_distributed::get_num_localities(
+    hpx::future<std::uint32_t> runtime_distributed::get_num_localities(
         components::component_type type) const
     {
         return agas_client_.get_num_localities_async(type);
@@ -1845,7 +1845,7 @@ namespace hpx {
         return rt->get_num_localities(hpx::launch::sync, type, ec);
     }
 
-    lcos::future<std::uint32_t> get_num_localities(
+    hpx::future<std::uint32_t> get_num_localities(
         components::component_type type)
     {
         runtime_distributed* rt = get_runtime_distributed_ptr();

--- a/libs/full/runtime_distributed/src/server/runtime_support_server.cpp
+++ b/libs/full/runtime_distributed/src/server/runtime_support_server.cpp
@@ -465,7 +465,7 @@ namespace hpx { namespace components { namespace server {
         // way.
         std::reverse(locality_ids.begin(), locality_ids.end());
         std::uint32_t locality_id = get_locality_id();
-        std::vector<lcos::future<void>> lazy_actions;
+        std::vector<hpx::future<void>> lazy_actions;
 
         for (naming::id_type const& id : locality_ids)
         {
@@ -501,7 +501,7 @@ namespace hpx { namespace components { namespace server {
         // way.
         {
             std::uint32_t locality_id = get_locality_id();
-            std::vector<lcos::future<void>> lazy_actions;
+            std::vector<hpx::future<void>> lazy_actions;
 
             for (naming::gid_type gid : locality_ids)
             {

--- a/libs/full/runtime_distributed/src/stubs/runtime_support_stubs.cpp
+++ b/libs/full/runtime_distributed/src/stubs/runtime_support_stubs.cpp
@@ -29,7 +29,7 @@
 
 namespace hpx { namespace components { namespace stubs {
 
-    lcos::future<int> runtime_support::load_components_async(
+    hpx::future<int> runtime_support::load_components_async(
         naming::id_type const& gid)
     {
 #if !defined(HPX_COMPUTE_DEVICE_CODE)
@@ -47,7 +47,7 @@ namespace hpx { namespace components { namespace stubs {
         return load_components_async(gid).get();
     }
 
-    lcos::future<void> runtime_support::call_startup_functions_async(
+    hpx::future<void> runtime_support::call_startup_functions_async(
         naming::id_type const& gid, bool pre_startup)
     {
 #if !defined(HPX_COMPUTE_DEVICE_CODE)
@@ -69,7 +69,7 @@ namespace hpx { namespace components { namespace stubs {
     }
 
     /// \brief Shutdown the given runtime system
-    lcos::future<void> runtime_support::shutdown_async(
+    hpx::future<void> runtime_support::shutdown_async(
         naming::id_type const& targetgid, double timeout)
     {
 #if !defined(HPX_COMPUTE_DEVICE_CODE)
@@ -133,7 +133,7 @@ namespace hpx { namespace components { namespace stubs {
     ///////////////////////////////////////////////////////////////////////
     /// \brief Retrieve configuration information
     /// \brief Terminate the given runtime system
-    lcos::future<void> runtime_support::terminate_async(
+    hpx::future<void> runtime_support::terminate_async(
         naming::id_type const& targetgid)
     {
 #if !defined(HPX_COMPUTE_DEVICE_CODE)
@@ -197,7 +197,7 @@ namespace hpx { namespace components { namespace stubs {
 #endif
     }
 
-    lcos::future<void> runtime_support::garbage_collect_async(
+    hpx::future<void> runtime_support::garbage_collect_async(
         naming::id_type const& targetgid)
     {
 #if !defined(HPX_COMPUTE_DEVICE_CODE)
@@ -222,7 +222,7 @@ namespace hpx { namespace components { namespace stubs {
     }
 
     ///////////////////////////////////////////////////////////////////////
-    lcos::future<naming::id_type>
+    hpx::future<naming::id_type>
     runtime_support::create_performance_counter_async(naming::id_type targetgid,
         performance_counters::counter_info const& info)
     {
@@ -256,7 +256,7 @@ namespace hpx { namespace components { namespace stubs {
 
     ///////////////////////////////////////////////////////////////////////
     /// \brief Retrieve configuration information
-    lcos::future<util::section> runtime_support::get_config_async(
+    hpx::future<util::section> runtime_support::get_config_async(
         naming::id_type const& targetgid)
     {
 #if !defined(HPX_COMPUTE_DEVICE_CODE)

--- a/tests/performance/local/spinlock_overhead1.cpp
+++ b/tests/performance/local/spinlock_overhead1.cpp
@@ -33,7 +33,7 @@ using hpx::find_here;
 
 using hpx::naming::id_type;
 
-using hpx::lcos::future;
+using hpx::future;
 using hpx::async;
 using hpx::lcos::wait_each;
 

--- a/tests/performance/local/spinlock_overhead2.cpp
+++ b/tests/performance/local/spinlock_overhead2.cpp
@@ -33,7 +33,7 @@ using hpx::find_here;
 
 using hpx::naming::id_type;
 
-using hpx::lcos::future;
+using hpx::future;
 using hpx::async;
 using hpx::lcos::wait_each;
 

--- a/tests/regressions/agas/pass_by_value_id_type_action.cpp
+++ b/tests/regressions/agas/pass_by_value_id_type_action.cpp
@@ -32,7 +32,7 @@ int hpx_main(hpx::program_options::variables_map&)
             hpx::naming::id_type a = id;
 
             test_action act;
-            hpx::lcos::future<void> f = hpx::async(act, id, a);
+            hpx::future<void> f = hpx::async(act, id, a);
             f.get();
 
             HPX_TEST_EQ(id, a);
@@ -50,7 +50,7 @@ int hpx_main(hpx::program_options::variables_map&)
         {
 
             test_return_action act;
-            hpx::lcos::future<hpx::naming::id_type> f = hpx::async(act, id);
+            hpx::future<hpx::naming::id_type> f = hpx::async(act, id);
 
             HPX_TEST_EQ(id, f.get());
         }

--- a/tests/regressions/lcos/promise_leak_996.cpp
+++ b/tests/regressions/lcos/promise_leak_996.cpp
@@ -34,7 +34,7 @@ int hpx_main()
     {
         HPX_TEST_EQ(test::count, 0);
         hpx::lcos::promise<test> p;
-        hpx::lcos::future<test> f = p.get_future();
+        hpx::future<test> f = p.get_future();
         p.set_value(test());
         HPX_TEST_EQ(test::count, 1);
         f.get();

--- a/tests/regressions/lcos/wait_for_action_2796.cpp
+++ b/tests/regressions/lcos/wait_for_action_2796.cpp
@@ -31,7 +31,7 @@ int main()
     {
         auto fut = hpx::async<f_action>(hpx::find_here());
         auto status = fut.wait_for(std::chrono::seconds(3));
-        HPX_TEST(status != hpx::lcos::future_status::deferred);
+        HPX_TEST(status != hpx::future_status::deferred);
         HPX_TEST(called.load());
     }
 
@@ -39,7 +39,7 @@ int main()
     {
         auto fut = hpx::async<f_direct_action>(hpx::find_here());
         auto status = fut.wait_for(std::chrono::seconds(3));
-        HPX_TEST(status != hpx::lcos::future_status::deferred);
+        HPX_TEST(status != hpx::future_status::deferred);
         HPX_TEST(called.load());
     }
 

--- a/tests/unit/lcos/future_wait.cpp
+++ b/tests/unit/lcos/future_wait.cpp
@@ -34,7 +34,7 @@ using hpx::actions::action;
 
 using hpx::lcos::wait_each;
 using hpx::async;
-using hpx::lcos::future;
+using hpx::future;
 
 using hpx::find_here;
 

--- a/tests/unit/lcos/packaged_action.cpp
+++ b/tests/unit/lcos/packaged_action.cpp
@@ -20,7 +20,7 @@
 using hpx::program_options::variables_map;
 using hpx::program_options::options_description;
 
-using hpx::lcos::future;
+using hpx::future;
 
 ///////////////////////////////////////////////////////////////////////////////
 bool null_thread_executed = false;
@@ -67,7 +67,7 @@ int hpx_main(variables_map&)
         HPX_TEST(null_thread_executed);
 
         //test two successive 'get' from a promise
-        hpx::lcos::shared_future<int> int_promise(async<int_action>(hpx::find_here()));
+        hpx::shared_future<int> int_promise(async<int_action>(hpx::find_here()));
         HPX_TEST_EQ(int_promise.get(), int_promise.get());
     }
 
@@ -91,7 +91,7 @@ int hpx_main(variables_map&)
 
         //test two successive 'get' from a promise
         int_action do_int;
-        hpx::lcos::shared_future<int> int_promise(async(do_int, hpx::find_here()));
+        hpx::shared_future<int> int_promise(async(do_int, hpx::find_here()));
         HPX_TEST_EQ(int_promise.get(), int_promise.get());
     }
 

--- a/tests/unit/lcos/promise.cpp
+++ b/tests/unit/lcos/promise.cpp
@@ -39,7 +39,7 @@ char const* const error_msg = "throwing test exception: HPX(not_implemented)";
 int future_callback(
     bool& data_cb_called
   , bool& error_cb_called
-  , hpx::lcos::shared_future<int> f
+  , hpx::shared_future<int> f
     )
 {
     if (f.has_value()) {
@@ -76,13 +76,13 @@ int future_callback(
 int hpx_main(hpx::program_options::variables_map&)
 {
     {
-        hpx::lcos::future<int> p = hpx::async<test_action>(hpx::find_here());
+        hpx::future<int> p = hpx::async<test_action>(hpx::find_here());
         HPX_TEST_EQ(p.get(), 42);
     }
 
     {
         test_action do_test;
-        hpx::lcos::future<int> p = hpx::async(do_test, hpx::find_here());
+        hpx::future<int> p = hpx::async(do_test, hpx::find_here());
         HPX_TEST_EQ(p.get(), 42);
     }
 
@@ -90,8 +90,8 @@ int hpx_main(hpx::program_options::variables_map&)
         bool data_cb_called = false;
         bool error_cb_called = false;
 
-        hpx::lcos::shared_future<int> f = hpx::async<test_action>(hpx::find_here());
-        hpx::lcos::future<int> p = f.then(hpx::util::bind(future_callback,
+        hpx::shared_future<int> f = hpx::async<test_action>(hpx::find_here());
+        hpx::future<int> p = f.then(hpx::util::bind(future_callback,
             std::ref(data_cb_called), std::ref(error_cb_called),
             hpx::util::placeholders::_1));
 
@@ -105,9 +105,9 @@ int hpx_main(hpx::program_options::variables_map&)
         bool error_cb_called = false;
         test_action do_test;
 
-        hpx::lcos::shared_future<int> f = hpx::async(do_test, hpx::find_here());
+        hpx::shared_future<int> f = hpx::async(do_test, hpx::find_here());
 
-        hpx::lcos::future<int> p = f.then(
+        hpx::future<int> p = f.then(
                 hpx::util::bind(future_callback, std::ref(data_cb_called),
                     std::ref(error_cb_called), hpx::util::placeholders::_1));
 
@@ -117,7 +117,7 @@ int hpx_main(hpx::program_options::variables_map&)
     }
 
     {
-        hpx::lcos::future<int> p =
+        hpx::future<int> p =
             hpx::async<test_error_action>(hpx::find_here());
 
         std::string what_msg;
@@ -141,7 +141,7 @@ int hpx_main(hpx::program_options::variables_map&)
 
     {
         test_error_action do_error;
-        hpx::lcos::future<int> p = hpx::async(do_error, hpx::find_here());
+        hpx::future<int> p = hpx::async(do_error, hpx::find_here());
 
         std::string what_msg;
         bool caught_exception = false;
@@ -163,9 +163,9 @@ int hpx_main(hpx::program_options::variables_map&)
         bool data_cb_called = false;
         bool error_cb_called = false;
 
-        hpx::lcos::shared_future<int> f =
+        hpx::shared_future<int> f =
             hpx::async<test_error_action>(hpx::find_here());
-        hpx::lcos::future<int> p = f.then(hpx::util::bind(future_callback,
+        hpx::future<int> p = f.then(hpx::util::bind(future_callback,
             std::ref(data_cb_called), std::ref(error_cb_called),
             hpx::util::placeholders::_1));
 
@@ -196,9 +196,9 @@ int hpx_main(hpx::program_options::variables_map&)
         bool error_cb_called = false;
         test_error_action do_test_error;
 
-        hpx::lcos::shared_future<int> f = hpx::async(do_test_error, hpx::find_here());
+        hpx::shared_future<int> f = hpx::async(do_test_error, hpx::find_here());
 
-        hpx::lcos::future<int> p = f.then(
+        hpx::future<int> p = f.then(
                 hpx::util::bind(future_callback, std::ref(data_cb_called),
                     std::ref(error_cb_called), hpx::util::placeholders::_1));
 

--- a/tools/VS/future.natvis
+++ b/tools/VS/future.natvis
@@ -8,7 +8,7 @@
 
 <AutoVisualizer xmlns="http://schemas.microsoft.com/vstudio/debugger/natvis/2010">
 
-    <Type Name="hpx::lcos::future&lt;void&gt;" Priority="High">
+    <Type Name="hpx::future&lt;void&gt;" Priority="High">
         <DisplayString Condition="shared_state_.px->state_ == 0">empty</DisplayString>
         <DisplayString Condition="shared_state_.px->state_ == 3">ready(value)</DisplayString>
         <DisplayString Condition="shared_state_.px->state_ == 5">ready(exception)</DisplayString>
@@ -17,7 +17,7 @@
         </Expand>
     </Type>
 
-    <Type Name="hpx::lcos::future&lt;*&gt;">
+    <Type Name="hpx::future&lt;*&gt;">
         <DisplayString Condition="shared_state_.px->state_ == 0">empty</DisplayString>
         <DisplayString Condition="shared_state_.px->state_ == 3">ready(value)</DisplayString>
         <DisplayString Condition="shared_state_.px->state_ == 5">ready(exception)</DisplayString>
@@ -27,7 +27,7 @@
         </Expand>
     </Type>
 
-    <Type Name="hpx::lcos::shared_future&lt;void&gt;" Priority="High">
+    <Type Name="hpx::shared_future&lt;void&gt;" Priority="High">
         <DisplayString Condition="shared_state_.px->state_ == 0">empty</DisplayString>
         <DisplayString Condition="shared_state_.px->state_ == 3">ready(value)</DisplayString>
         <DisplayString Condition="shared_state_.px->state_ == 5">ready(exception)</DisplayString>
@@ -36,7 +36,7 @@
         </Expand>
     </Type>
 
-    <Type Name="hpx::lcos::shared_future&lt;*&gt;">
+    <Type Name="hpx::shared_future&lt;*&gt;">
         <DisplayString Condition="shared_state_.px->state_ == 0">empty</DisplayString>
         <DisplayString Condition="shared_state_.px->state_ == 3">ready(value)</DisplayString>
         <DisplayString Condition="shared_state_.px->state_ == 5">ready(exception)</DisplayString>


### PR DESCRIPTION
- move future (and facilities) to namespace hpx
- deprecate those types/functions in namespace hpx::lcos
