### PR TITLE
Replacing remaining std::forward and std::move with HPX_FORWARD and HPX_MOVE

### DIFF
--- a/libs/core/algorithms/include/hpx/parallel/algorithms/all_any_none.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/all_any_none.hpp
@@ -293,8 +293,8 @@ namespace hpx { namespace parallel { inline namespace v1 {
                               FwdIter part_begin,
                               std::size_t part_count) mutable -> bool {
                     detail::sequential_find_if<std::decay_t<ExPolicy>>(
-                        part_begin, part_count, tok, std::forward<F>(op),
-                        std::forward<Proj>(proj));
+                        part_begin, part_count, tok, HPX_FORWARD(F, op),
+                        HPX_FORWARD(Proj, proj));
 
                     return !tok.was_cancelled();
                 };
@@ -388,8 +388,8 @@ namespace hpx { namespace parallel { inline namespace v1 {
                               FwdIter part_begin,
                               std::size_t part_count) mutable -> bool {
                     detail::sequential_find_if<std::decay_t<ExPolicy>>(
-                        part_begin, part_count, tok, std::forward<F>(op),
-                        std::forward<Proj>(proj));
+                        part_begin, part_count, tok, HPX_FORWARD(F, op),
+                        HPX_FORWARD(Proj, proj));
 
                     return tok.was_cancelled();
                 };
@@ -482,8 +482,8 @@ namespace hpx { namespace parallel { inline namespace v1 {
                               FwdIter part_begin,
                               std::size_t part_count) mutable -> bool {
                     detail::sequential_find_if_not<std::decay_t<ExPolicy>>(
-                        part_begin, part_count, tok, std::forward<F>(op),
-                        std::forward<Proj>(proj));
+                        part_begin, part_count, tok, HPX_FORWARD(F, op),
+                        HPX_FORWARD(Proj, proj));
 
                     return !tok.was_cancelled();
                 };

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/copy.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/copy.hpp
@@ -486,7 +486,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
         {
             while (first != last)
             {
-                if (hpx::util::invoke(pred, hpx::util::invoke(proj, *first)))
+                if (HPX_INVOKE(pred, HPX_INVOKE(proj, *first)))
                     *dest++ = *first;
                 first++;
             }
@@ -555,9 +555,12 @@ namespace hpx { namespace parallel { inline namespace v1 {
                               std::size_t part_size) -> std::size_t {
                     std::size_t curr = 0;
 
+                    // Note: replacing the invoke() with HPX_INVOKE()
+                    // below makes gcc generate errors
+
                     // MSVC complains if proj is captured by ref below
                     util::loop_n<std::decay_t<ExPolicy>>(part_begin, part_size,
-                        [&pred, proj, &curr](zip_iterator it) mutable {
+                        [&pred, proj, &curr](zip_iterator it) mutable -> void {
                             bool f = hpx::util::invoke(
                                 pred, hpx::util::invoke(proj, get<0>(*it)));
 

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/count.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/count.hpp
@@ -242,7 +242,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 typename std::iterator_traits<Iter>::difference_type& ret)
             {
                 ret += traits::count_bits(
-                    hpx::util::invoke(op_, hpx::util::invoke(proj_, *curr)));
+                    HPX_INVOKE(op_, HPX_INVOKE(proj_, *curr)));
             }
         };
 

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/detail/accumulate.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/detail/accumulate.hpp
@@ -19,7 +19,7 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
     {
         for (/**/; first != last; ++first)
         {
-            value = hpx::util::invoke(reduce_op, value, *first);
+            value = HPX_INVOKE(reduce_op, value, *first);
         }
         return value;
     }

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/detail/find.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/detail/find.hpp
@@ -13,7 +13,6 @@
 #include <hpx/functional/detail/tag_fallback_invoke.hpp>
 #include <hpx/functional/invoke.hpp>
 #include <hpx/parallel/algorithms/detail/advance_to_sentinel.hpp>
-#include <hpx/parallel/util/compare_projected.hpp>
 #include <hpx/parallel/util/loop.hpp>
 #include <hpx/parallel/util/projection_identity.hpp>
 
@@ -38,7 +37,7 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
         {
             for (; first != last; ++first)
             {
-                if (hpx::util::invoke(proj, *first) == value)
+                if (HPX_INVOKE(proj, *first) == value)
                 {
                     return first;
                 }
@@ -54,7 +53,7 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
         {
             util::loop_idx_n<ExPolicy>(base_idx, part_begin, part_count, tok,
                 [&val, &proj, &tok](auto& v, std::size_t i) -> void {
-                    if (hpx::util::invoke(proj, v) == val)
+                    if (HPX_INVOKE(proj, v) == val)
                     {
                         tok.cancel(i);
                     }
@@ -100,7 +99,7 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
         {
             for (; first != last; ++first)
             {
-                if (hpx::util::invoke(pred, hpx::util::invoke(proj, *first)))
+                if (HPX_INVOKE(pred, HPX_INVOKE(proj, *first)))
                 {
                     return first;
                 }
@@ -115,7 +114,7 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
         {
             util::loop_n<std::decay_t<ExPolicy>>(part_begin, part_count, tok,
                 [&op, &tok, &proj](auto const& curr) {
-                    if (hpx::util::invoke(op, hpx::util::invoke(proj, *curr)))
+                    if (HPX_INVOKE(op, HPX_INVOKE(proj, *curr)))
                     {
                         tok.cancel();
                     }
@@ -130,7 +129,7 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
         {
             util::loop_idx_n<ExPolicy>(base_idx, part_begin, part_count, tok,
                 [&f, &proj, &tok](auto& v, std::size_t i) -> void {
-                    if (hpx::util::invoke(f, hpx::util::invoke(proj, v)))
+                    if (HPX_INVOKE(f, HPX_INVOKE(proj, v)))
                     {
                         tok.cancel(i);
                     }
@@ -186,7 +185,7 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
         {
             for (; first != last; ++first)
             {
-                if (!hpx::util::invoke(pred, hpx::util::invoke(proj, *first)))
+                if (!HPX_INVOKE(pred, HPX_INVOKE(proj, *first)))
                 {
                     return first;
                 }
@@ -201,7 +200,7 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
         {
             util::loop_n<std::decay_t<ExPolicy>>(part_begin, part_count, tok,
                 [&op, &tok, &proj](auto const& curr) {
-                    if (!hpx::util::invoke(op, hpx::util::invoke(proj, *curr)))
+                    if (!HPX_INVOKE(op, HPX_INVOKE(proj, *curr)))
                     {
                         tok.cancel();
                     }
@@ -216,7 +215,7 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
         {
             util::loop_idx_n<ExPolicy>(base_idx, part_begin, part_count, tok,
                 [&f, &proj, &tok](auto& v, std::size_t i) -> void {
-                    if (!hpx::util::invoke(f, hpx::util::invoke(proj, v)))
+                    if (!HPX_INVOKE(f, HPX_INVOKE(proj, v)))
                     {
                         tok.cancel(i);
                     }

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/detail/find.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/detail/find.hpp
@@ -82,7 +82,7 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
         Proj&& proj)
     {
         return sequential_find_t<ExPolicy>{}(base_idx, part_begin, part_count,
-            tok, val, std::forward<Proj>(proj));
+            tok, val, HPX_FORWARD(Proj, proj));
     }
 #endif
 
@@ -157,7 +157,7 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
         std::size_t part_count, Token& tok, F&& op, Proj&& proj)
     {
         return sequential_find_if_t<ExPolicy>{}(part_begin, part_count, tok,
-            std::forward<F>(op), std::forward<Proj>(proj));
+            HPX_FORWARD(F, op), HPX_FORWARD(Proj, proj));
     }
 
     template <typename ExPolicy, typename FwdIter, typename Token, typename F,
@@ -167,7 +167,7 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
         Proj&& proj)
     {
         return sequential_find_if_t<ExPolicy>{}(base_idx, part_begin,
-            part_count, tok, std::forward<F>(f), std::forward<Proj>(proj));
+            part_count, tok, HPX_FORWARD(F, f), HPX_FORWARD(Proj, proj));
     }
 #endif
 
@@ -243,7 +243,7 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
         std::size_t part_count, Token& tok, F&& op, Proj&& proj)
     {
         return sequential_find_if_not_t<ExPolicy>{}(part_begin, part_count, tok,
-            std::forward<F>(op), std::forward<Proj>(proj));
+            HPX_FORWARD(F, op), HPX_FORWARD(Proj, proj));
     }
 
     template <typename ExPolicy, typename FwdIter, typename Token, typename F,
@@ -253,7 +253,7 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
         Proj&& proj)
     {
         return sequential_find_if_not_t<ExPolicy>{}(base_idx, part_begin,
-            part_count, tok, std::forward<F>(f), std::forward<Proj>(proj));
+            part_count, tok, HPX_FORWARD(F, f), HPX_FORWARD(Proj, proj));
     }
 #endif
 }}}}    // namespace hpx::parallel::v1::detail

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/detail/generate.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/detail/generate.hpp
@@ -22,7 +22,7 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
     constexpr Iter sequential_generate_helper(Iter first, Sent last, F&& f)
     {
         return util::loop_ind(hpx::execution::seq, first, last,
-            [f = std::forward<F>(f)](auto& v) mutable { v = f(); });
+            [f = HPX_FORWARD(F, f)](auto& v) mutable { v = f(); });
     }
 
     struct sequential_generate_t
@@ -33,7 +33,7 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
         friend constexpr Iter tag_fallback_invoke(
             sequential_generate_t, ExPolicy&&, Iter first, Sent last, F&& f)
         {
-            return sequential_generate_helper(first, last, std::forward<F>(f));
+            return sequential_generate_helper(first, last, HPX_FORWARD(F, f));
         }
     };
 
@@ -46,7 +46,7 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
         ExPolicy&& policy, Iter first, Sent last, F&& f)
     {
         return sequential_generate_t{}(
-            std::forward<ExPolicy>(policy), first, last, std::forward<F>(f));
+            HPX_FORWARD(ExPolicy, policy), first, last, HPX_FORWARD(F, f));
     }
 #endif
 
@@ -67,7 +67,7 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
             ExPolicy&&, Iter first, std::size_t count, F&& f)
         {
             return sequential_generate_n_helper(
-                first, count, std::forward<F>(f));
+                first, count, HPX_FORWARD(F, f));
         }
     };
 
@@ -80,7 +80,7 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
         ExPolicy&& policy, Iter first, std::size_t count, F&& f)
     {
         return sequential_generate_n_t{}(
-            std::forward<ExPolicy>(policy), first, count, std::forward<F>(f));
+            HPX_FORWARD(ExPolicy, policy), first, count, HPX_FORWARD(F, f));
     }
 #endif
 

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/detail/search.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/detail/search.hpp
@@ -174,7 +174,8 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
             Proj2&& proj2)
         {
             return std::search(first, std::next(first, count), s_first, s_last,
-                util::compare_projected<Pred, Proj1, Proj2>(op, proj1, proj2));
+                util::compare_projected<Pred&, Proj1&, Proj2&>(
+                    op, proj1, proj2));
         }
 
         template <typename ExPolicy, typename FwdIter2, typename Pred,

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/detail/set_operation.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/detail/set_operation.hpp
@@ -124,7 +124,7 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
 
         // first step, is applied to all partitions
         auto f1 = [=](set_chunk_data* curr_chunk,
-                      std::size_t part_size) -> void {
+                      std::size_t part_size) mutable -> void {
             HPX_ASSERT(part_size == 1);
             HPX_UNUSED(part_size);
 
@@ -140,15 +140,15 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
             bool first_partition = (start1 == 0);
             bool last_partition = (end1 == std::size_t(len1));
 
-            auto start_value = hpx::util::invoke(proj1, first1[start1]);
-            auto end_value = hpx::util::invoke(proj1, first1[end1]);
+            auto start_value = HPX_INVOKE(proj1, first1[start1]);
+            auto end_value = HPX_INVOKE(proj1, first1[end1]);
 
             // all but the last chunk require special handling
             if (!last_partition)
             {
                 // this chunk will be handled by the next one if all
                 // elements of this partition are equal
-                if (!hpx::util::invoke(f, start_value, end_value))
+                if (!HPX_INVOKE(f, start_value, end_value))
                 {
                     return;
                 }
@@ -157,14 +157,12 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
                 // the last element of the current chunk
                 if (end1 != 0)
                 {
-                    auto end_value1 =
-                        hpx::util::invoke(proj1, first1[end1 - 1]);
+                    auto end_value1 = HPX_INVOKE(proj1, first1[end1 - 1]);
 
-                    while (!hpx::util::invoke(f, end_value1, end_value) &&
-                        --end1 != 0)
+                    while (!HPX_INVOKE(f, end_value1, end_value) && --end1 != 0)
                     {
                         end_value = HPX_MOVE(end_value1);
-                        end_value1 = hpx::util::invoke(proj1, first1[end1 - 1]);
+                        end_value1 = HPX_INVOKE(proj1, first1[end1 - 1]);
                     }
                 }
             }
@@ -173,14 +171,13 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
             // the first element of the current chunk
             if (start1 != 0)
             {
-                auto start_value1 =
-                    hpx::util::invoke(proj1, first1[start1 - 1]);
+                auto start_value1 = HPX_INVOKE(proj1, first1[start1 - 1]);
 
-                while (!hpx::util::invoke(f, start_value1, start_value) &&
-                    --start1 != 0)
+                while (
+                    !HPX_INVOKE(f, start_value1, start_value) && --start1 != 0)
                 {
                     start_value = HPX_MOVE(start_value1);
-                    start_value1 = hpx::util::invoke(proj1, first1[start1 - 1]);
+                    start_value1 = HPX_INVOKE(proj1, first1[start1 - 1]);
                 }
             }
 

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/detail/upper_lower_bound.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/detail/upper_lower_bound.hpp
@@ -35,7 +35,7 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
             difference_type step = count / 2;
             Iter it = std::next(first, step);
 
-            if (hpx::util::invoke(f, hpx::util::invoke(proj, *it), value))
+            if (HPX_INVOKE(f, HPX_INVOKE(proj, *it), value))
             {
                 first = ++it;
                 count -= step + 1;
@@ -62,7 +62,7 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
             difference_type step = count / 2;
             Iter it = std::next(first, step);
 
-            if (hpx::util::invoke(f, hpx::util::invoke(proj, *it), value))
+            if (HPX_INVOKE(f, HPX_INVOKE(proj, *it), value))
             {
                 first = ++it;
                 count -= step + 1;
@@ -93,7 +93,7 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
             difference_type step = count / 2;
             Iter it = std::next(first, step);
 
-            if (!hpx::util::invoke(f, value, hpx::util::invoke(proj, *it)))
+            if (!HPX_INVOKE(f, value, HPX_INVOKE(proj, *it)))
             {
                 first = ++it;
                 count -= step + 1;
@@ -120,7 +120,7 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
             difference_type step = count / 2;
             Iter it = std::next(first, step);
 
-            if (!hpx::util::invoke(f, value, hpx::util::invoke(proj, *it)))
+            if (!HPX_INVOKE(f, value, HPX_INVOKE(proj, *it)))
             {
                 first = ++it;
                 count -= step + 1;

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/equal.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/equal.hpp
@@ -211,8 +211,8 @@ namespace hpx { namespace parallel { inline namespace v1 {
             for (/* */; first1 != last1 && first2 != last2;
                  (void) ++first1, ++first2)
             {
-                if (!hpx::util::invoke(f, hpx::util::invoke(proj1, *first1),
-                        hpx::util::invoke(proj2, *first2)))
+                if (!HPX_INVOKE(f, HPX_INVOKE(proj1, *first1),
+                        HPX_INVOKE(proj2, *first2)))
                     return false;
             }
             return first1 == last1 && first2 == last2;
@@ -281,6 +281,9 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 typedef typename zip_iterator::reference reference;
 
                 util::cancellation_token<> tok;
+
+                // Note: replacing the invoke() with HPX_INVOKE()
+                // below makes gcc generate errors
                 auto f1 = [tok, f = HPX_FORWARD(F, f),
                               proj1 = HPX_FORWARD(Proj1, proj1),
                               proj2 = HPX_FORWARD(Proj2, proj2)](
@@ -392,10 +395,9 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 auto f1 = [f, tok](zip_iterator it,
                               std::size_t part_count) mutable -> bool {
                     util::loop_n<std::decay_t<ExPolicy>>(it, part_count, tok,
-                        [&f, &tok](zip_iterator const& curr) {
+                        [&f, &tok](zip_iterator const& curr) mutable -> void {
                             reference t = *curr;
-                            if (!hpx::util::invoke(
-                                    f, hpx::get<0>(t), hpx::get<1>(t)))
+                            if (!HPX_INVOKE(f, hpx::get<0>(t), hpx::get<1>(t)))
                             {
                                 tok.cancel();
                             }

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/exclusive_scan.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/exclusive_scan.hpp
@@ -333,7 +333,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
             T temp = init;
             for (/* */; first != last; (void) ++first, ++dest)
             {
-                init = hpx::util::invoke(op, init, *first);
+                init = HPX_INVOKE(op, init, *first);
                 *dest = temp;
                 temp = init;
             }
@@ -347,7 +347,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
             T temp = init;
             for (/* */; count-- != 0; (void) ++first, ++dest)
             {
-                init = hpx::util::invoke(op, init, *first);
+                init = HPX_INVOKE(op, init, *first);
                 *dest = temp;
                 temp = init;
             }
@@ -408,14 +408,14 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 using hpx::util::make_zip_iterator;
 
                 auto f3 = [op](zip_iterator part_begin, std::size_t part_size,
-                              T val) {
+                              T val) mutable -> void {
                     FwdIter2 dst = get<1>(part_begin.get_iterator_tuple());
                     *dst++ = val;
 
                     // MSVC 2015 fails if op is captured by reference
-                    util::loop_n<std::decay_t<ExPolicy>>(
-                        dst, part_size - 1, [=, &val](FwdIter2 it) {
-                            *it = hpx::util::invoke(op, val, *it);
+                    util::loop_n<std::decay_t<ExPolicy>>(dst, part_size - 1,
+                        [=, &val](FwdIter2 it) mutable -> void {
+                            *it = HPX_INVOKE(op, val, *it);
                         });
                 };
 

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/generate.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/generate.hpp
@@ -179,7 +179,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
             static typename util::detail::algorithm_result<ExPolicy, Iter>::type
             parallel(ExPolicy&& policy, Iter first, Sent last, F&& f)
             {
-                auto f1 = [policy, f = std::forward<F>(f)](
+                auto f1 = [policy, f = HPX_FORWARD(F, f)](
                               Iter part_begin, std::size_t part_size) mutable {
                     auto part_end = part_begin;
                     std::advance(part_end, part_size);
@@ -187,8 +187,8 @@ namespace hpx { namespace parallel { inline namespace v1 {
                         HPX_MOVE(policy), part_begin, part_end, HPX_MOVE(f));
                 };
                 return util::partitioner<ExPolicy, Iter>::call(
-                    std::forward<ExPolicy>(policy), first,
-                    detail::distance(first, last), std::move(f1),
+                    HPX_FORWARD(ExPolicy, policy), first,
+                    detail::distance(first, last), HPX_MOVE(f1),
                     [first, last](std::vector<hpx::future<Iter>>&&) {
                         return detail::advance_to_sentinel(first, last);
                     });
@@ -240,7 +240,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 ExPolicy&& policy, InIter first, std::size_t count, F&& f)
             {
                 return sequential_generate_n(
-                    std::forward<ExPolicy>(policy), first, count, f);
+                    HPX_FORWARD(ExPolicy, policy), first, count, f);
             }
 
             template <typename ExPolicy, typename F>
@@ -255,7 +255,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                         HPX_MOVE(policy), part_begin, part_size, HPX_MOVE(f));
                 };
                 return util::partitioner<ExPolicy, FwdIter>::call(
-                    HPX_FORWARD(ExPolicy, policy), first, count, std::move(f1),
+                    HPX_FORWARD(ExPolicy, policy), first, count, HPX_MOVE(f1),
                     [first, count](
                         std::vector<hpx::future<FwdIter>>&&) mutable {
                         std::advance(first, count);

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/includes.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/includes.hpp
@@ -139,15 +139,15 @@ namespace hpx { namespace parallel { inline namespace v1 {
                     return false;
                 }
 
-                auto&& value1 = hpx::util::invoke(proj1, *first1);
-                auto&& value2 = hpx::util::invoke(proj2, *first2);
+                auto&& value1 = HPX_INVOKE(proj1, *first1);
+                auto&& value2 = HPX_INVOKE(proj2, *first2);
 
-                if (hpx::util::invoke(f, value2, value1))
+                if (HPX_INVOKE(f, value2, value1))
                 {
                     return false;
                 }
 
-                if (!hpx::util::invoke(f, value1, value2))
+                if (!HPX_INVOKE(f, value1, value2))
                 {
                     ++first2;
                 }
@@ -169,15 +169,15 @@ namespace hpx { namespace parallel { inline namespace v1 {
                     return false;
                 }
 
-                auto&& value1 = hpx::util::invoke(proj1, *first1);
-                auto&& value2 = hpx::util::invoke(proj2, *first2);
+                auto&& value1 = HPX_INVOKE(proj1, *first1);
+                auto&& value2 = HPX_INVOKE(proj2, *first2);
 
-                if (hpx::util::invoke(f, value2, value1))
+                if (HPX_INVOKE(f, value2, value1))
                 {
                     return false;
                 }
 
-                if (!hpx::util::invoke(f, value1, value2))
+                if (!HPX_INVOKE(f, value1, value2))
                 {
                     ++first2;
                 }
@@ -233,7 +233,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                         std::size_t part_count) mutable -> bool {
                     Iter2 part_end = detail::next(part_begin, part_count);
 
-                    auto value = hpx::util::invoke(proj2, *part_begin);
+                    auto value = HPX_INVOKE(proj2, *part_begin);
                     if (first2 != part_begin && part_count > 1)
                     {
                         part_begin = detail::upper_bound(
@@ -246,7 +246,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                         {
                             return true;
                         }
-                        value = hpx::util::invoke(proj2, *part_begin);
+                        value = HPX_INVOKE(proj2, *part_begin);
                     }
 
                     Iter1 low = detail::lower_bound(
@@ -257,8 +257,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                     }
 
                     if (low == last1 ||
-                        hpx::util::invoke(
-                            f, value, hpx::util::invoke(proj1, *low)))
+                        HPX_INVOKE(f, value, HPX_INVOKE(proj1, *low)))
                     {
                         tok.cancel();
                         return false;
@@ -267,7 +266,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                     Iter1 high = last1;
                     if (part_end != last2)
                     {
-                        auto&& value1 = hpx::util::invoke(proj2, *part_end);
+                        auto&& value1 = HPX_INVOKE(proj2, *part_end);
 
                         high = detail::upper_bound(
                             low, last1, value1, f, proj1, tok);

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/inclusive_scan.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/inclusive_scan.hpp
@@ -466,7 +466,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
         {
             for (/* */; first != last; (void) ++first, ++dest)
             {
-                init = hpx::util::invoke(op, init, *first);
+                init = HPX_INVOKE(op, init, *first);
                 *dest = init;
             }
             return util::in_out_result<InIter, OutIter>{first, dest};
@@ -493,7 +493,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
         {
             for (/* */; count-- != 0; (void) ++first, ++dest)
             {
-                init = hpx::util::invoke(op, init, *first);
+                init = HPX_INVOKE(op, init, *first);
                 *dest = init;
             }
             return init;
@@ -563,13 +563,13 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 using hpx::util::make_zip_iterator;
 
                 auto f3 = [op](zip_iterator part_begin, std::size_t part_size,
-                              T val) {
+                              T val) mutable -> void {
                     FwdIter2 dst = get<1>(part_begin.get_iterator_tuple());
 
                     // MSVC 2015 fails if op is captured by reference
                     util::loop_n<std::decay_t<ExPolicy>>(
-                        dst, part_size, [=, &val](FwdIter2 it) {
-                            *it = hpx::util::invoke(op, val, *it);
+                        dst, part_size, [=, &val](FwdIter2 it) mutable -> void {
+                            *it = HPX_INVOKE(op, val, *it);
                         });
                 };
 

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/is_heap.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/is_heap.hpp
@@ -176,9 +176,8 @@ namespace hpx { namespace parallel { inline namespace v1 {
 
             for (difference_type i = 1; i < count; ++i)
             {
-                if (hpx::util::invoke(comp,
-                        hpx::util::invoke(proj, *(first + (i - 1) / 2)),
-                        hpx::util::invoke(proj, *(first + i))))
+                if (HPX_INVOKE(comp, HPX_INVOKE(proj, *(first + (i - 1) / 2)),
+                        HPX_INVOKE(proj, *(first + i))))
                     return false;
             }
             return true;
@@ -208,6 +207,8 @@ namespace hpx { namespace parallel { inline namespace v1 {
 
                 util::cancellation_token<std::size_t> tok(count);
 
+                // Note: replacing the invoke() with HPX_INVOKE()
+                // below makes gcc generate errors
                 auto f1 = [tok, first, comp = HPX_FORWARD(Comp, comp),
                               proj = HPX_FORWARD(Proj, proj)](Iter it,
                               std::size_t part_size,
@@ -215,7 +216,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                     util::loop_idx_n<std::decay_t<ExPolicy>>(base_idx, it,
                         part_size, tok,
                         [&tok, first, &comp, &proj](
-                            type const& v, std::size_t i) -> void {
+                            type const& v, std::size_t i) mutable -> void {
                             if (hpx::util::invoke(comp,
                                     hpx::util::invoke(proj, *(first + i / 2)),
                                     hpx::util::invoke(proj, v)))
@@ -321,9 +322,8 @@ namespace hpx { namespace parallel { inline namespace v1 {
 
             for (difference_type i = 1; i < count; ++i)
             {
-                if (hpx::util::invoke(comp,
-                        hpx::util::invoke(proj, *(first + (i - 1) / 2)),
-                        hpx::util::invoke(proj, *(first + i))))
+                if (HPX_INVOKE(comp, HPX_INVOKE(proj, *(first + (i - 1) / 2)),
+                        HPX_INVOKE(proj, *(first + i))))
                     return first + i;
             }
             return last;
@@ -353,6 +353,8 @@ namespace hpx { namespace parallel { inline namespace v1 {
 
                 util::cancellation_token<std::size_t> tok(count);
 
+                // Note: replacing the invoke() with HPX_INVOKE()
+                // below makes gcc generate errors
                 auto f1 = [tok, first, comp = HPX_FORWARD(Comp, comp),
                               proj = HPX_FORWARD(Proj, proj)](Iter it,
                               std::size_t part_size,

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/is_partitioned.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/is_partitioned.hpp
@@ -190,18 +190,20 @@ namespace hpx { namespace parallel { inline namespace v1 {
                     HPX_FORWARD(Pred, pred), HPX_FORWARD(Proj, proj));
 
                 util::cancellation_token<> tok;
+
+                // Note: replacing the invoke() with HPX_INVOKE()
+                // below makes gcc generate errors
                 auto f1 = [tok, pred_projected = HPX_MOVE(pred_projected)](
                               Iter part_begin,
                               std::size_t part_count) mutable -> bool {
-                    bool fst_bool =
-                        hpx::util::invoke(pred_projected, *part_begin);
+                    bool fst_bool = HPX_INVOKE(pred_projected, *part_begin);
                     if (part_count == 1)
                         return fst_bool;
 
                     util::loop_n<std::decay_t<ExPolicy>>(++part_begin,
                         --part_count, tok,
                         [&fst_bool, &pred_projected, &tok](
-                            Iter const& a) -> void {
+                            Iter const& a) mutable -> void {
                             if (fst_bool !=
                                 hpx::util::invoke(pred_projected, *a))
                             {

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/is_sorted.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/is_sorted.hpp
@@ -285,6 +285,9 @@ namespace hpx { namespace parallel { inline namespace v1 {
                     HPX_FORWARD(Pred, pred), HPX_FORWARD(Proj, proj)};
 
                 util::cancellation_token<> tok;
+
+                // Note: replacing the invoke() with HPX_INVOKE()
+                // below makes gcc generate errors
                 auto f1 = [tok, last,
                               pred_projected = HPX_MOVE(pred_projected)](
                               FwdIter part_begin,
@@ -292,7 +295,8 @@ namespace hpx { namespace parallel { inline namespace v1 {
                     FwdIter trail = part_begin++;
                     util::loop_n<std::decay_t<ExPolicy>>(part_begin,
                         part_size - 1,
-                        [&trail, &tok, &pred_projected](FwdIter it) -> void {
+                        [&trail, &tok, &pred_projected](
+                            FwdIter it) mutable -> void {
                             if (hpx::util::invoke(
                                     pred_projected, *it, *trail++))
                             {
@@ -386,6 +390,9 @@ namespace hpx { namespace parallel { inline namespace v1 {
                     HPX_FORWARD(Pred, pred), HPX_FORWARD(Proj, proj)};
 
                 util::cancellation_token<difference_type> tok(count);
+
+                // Note: replacing the invoke() with HPX_INVOKE()
+                // below makes gcc generate errors
                 auto f1 = [tok, last,
                               pred_projected = HPX_MOVE(pred_projected)](
                               FwdIter part_begin, std::size_t part_size,
@@ -408,7 +415,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                     if (!tok.was_cancelled(base_idx + part_size) &&
                         trail != last)
                     {
-                        if (hpx::util::invoke(pred_projected, *trail, *i))
+                        if (HPX_INVOKE(pred_projected, *trail, *i))
                         {
                             tok.cancel(base_idx + part_size);
                         }

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/lexicographical_compare.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/lexicographical_compare.hpp
@@ -202,13 +202,11 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 for (; (first1 != last1) && (first2 != last2);
                      ++first1, (void) ++first2)
                 {
-                    if (hpx::util::invoke(pred,
-                            hpx::util::invoke(proj1, *first1),
-                            hpx::util::invoke(proj2, *first2)))
+                    if (HPX_INVOKE(pred, HPX_INVOKE(proj1, *first1),
+                            HPX_INVOKE(proj2, *first2)))
                         return true;
-                    if (hpx::util::invoke(pred,
-                            hpx::util::invoke(proj2, *first2),
-                            hpx::util::invoke(proj1, *first1)))
+                    if (HPX_INVOKE(pred, HPX_INVOKE(proj2, *first2),
+                            HPX_INVOKE(proj1, *first1)))
                         return false;
                 }
                 return (first1 == last1) && (first2 != last2);
@@ -252,13 +250,12 @@ namespace hpx { namespace parallel { inline namespace v1 {
                     util::loop_idx_n<std::decay_t<ExPolicy>>(base_idx, it,
                         part_count, tok,
                         [&pred, &tok, &proj1, &proj2](
-                            reference t, std::size_t i) -> void {
+                            reference t, std::size_t i) mutable -> void {
                             using hpx::get;
-                            using hpx::util::invoke;
-                            if (invoke(pred, invoke(proj1, get<0>(t)),
-                                    invoke(proj2, get<1>(t))) ||
-                                invoke(pred, invoke(proj2, get<1>(t)),
-                                    invoke(proj1, get<0>(t))))
+                            if (HPX_INVOKE(pred, HPX_INVOKE(proj1, get<0>(t)),
+                                    HPX_INVOKE(proj2, get<1>(t))) ||
+                                HPX_INVOKE(pred, HPX_INVOKE(proj2, get<1>(t)),
+                                    HPX_INVOKE(proj1, get<0>(t))))
                             {
                                 tok.cancel(i);
                             }
@@ -278,9 +275,8 @@ namespace hpx { namespace parallel { inline namespace v1 {
                     std::advance(first2, mismatched);
 
                     if (first1 != last1 && first2 != last2)
-                        return hpx::util::invoke(pred,
-                            hpx::util::invoke(proj1, *first1),
-                            hpx::util::invoke(proj2, *first2));
+                        return HPX_INVOKE(pred, HPX_INVOKE(proj1, *first1),
+                            HPX_INVOKE(proj2, *first2));
 
                     return first2 != last2;
                 };

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/make_heap.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/make_heap.hpp
@@ -158,15 +158,15 @@ namespace hpx { namespace parallel { inline namespace v1 {
             RndIter child_i = first + child;
 
             if ((child + 1) < len &&
-                hpx::util::invoke(comp, hpx::util::invoke(proj, *child_i),
-                    hpx::util::invoke(proj, *(child_i + 1))))
+                HPX_INVOKE(comp, HPX_INVOKE(proj, *child_i),
+                    HPX_INVOKE(proj, *(child_i + 1))))
             {
                 ++child_i;
                 ++child;
             }
 
-            if (hpx::util::invoke(comp, hpx::util::invoke(proj, *child_i),
-                    hpx::util::invoke(proj, *start)))
+            if (HPX_INVOKE(
+                    comp, HPX_INVOKE(proj, *child_i), HPX_INVOKE(proj, *start)))
                 return;
 
             typename std::iterator_traits<RndIter>::value_type top = *start;
@@ -183,15 +183,15 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 child_i = first + child;
 
                 if ((child + 1) < len &&
-                    hpx::util::invoke(comp, hpx::util::invoke(proj, *child_i),
-                        hpx::util::invoke(proj, *(child_i + 1))))
+                    HPX_INVOKE(comp, HPX_INVOKE(proj, *child_i),
+                        HPX_INVOKE(proj, *(child_i + 1))))
                 {
                     ++child_i;
                     ++child;
                 }
 
-            } while (!hpx::util::invoke(comp, hpx::util::invoke(proj, *child_i),
-                hpx::util::invoke(proj, top)));
+            } while (!HPX_INVOKE(
+                comp, HPX_INVOKE(proj, *child_i), HPX_INVOKE(proj, top)));
 
             *start = top;
         }

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/merge.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/merge.hpp
@@ -216,9 +216,8 @@ namespace hpx { namespace parallel { inline namespace v1 {
             {
                 while (true)
                 {
-                    if (hpx::util::invoke(comp,
-                            hpx::util::invoke(proj2, *first2),
-                            hpx::util::invoke(proj1, *first1)))
+                    if (HPX_INVOKE(comp, HPX_INVOKE(proj2, *first2),
+                            HPX_INVOKE(proj1, *first1)))
                     {
                         *dest++ = *first2++;
                         if (first2 == last2)
@@ -324,7 +323,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
 
             Iter1 mid1 = first1 + size1 / 2;
             Iter2 boundary2 = BinarySearchHelper::call(
-                first2, last2, hpx::util::invoke(proj1, *mid1), comp, proj2);
+                first2, last2, HPX_INVOKE(proj1, *mid1), comp, proj2);
             Iter3 target = dest + (mid1 - first1) + (boundary2 - first2);
 
             *target = *mid1;
@@ -530,9 +529,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
         {
             std::inplace_merge(first, middle,
                 detail::advance_to_sentinel(middle, last),
-                util::compare_projected<typename std::decay<Comp>::type,
-                    typename std::decay<Proj>::type>(
-                    HPX_FORWARD(Comp, comp), HPX_FORWARD(Proj, proj)));
+                util::compare_projected<Comp&, Proj&>(comp, proj));
             return last;
         }
 
@@ -564,7 +561,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 // Select pivot in left-side range.
                 Iter pivot = first + left_size / 2;
                 Iter boundary = lower_bound_helper::call(
-                    middle, last, hpx::util::invoke(proj, *pivot), comp, proj);
+                    middle, last, HPX_INVOKE(proj, *pivot), comp, proj);
                 Iter target = pivot + (boundary - middle);
 
                 // Swap two blocks, [pivot, middle) and [middle, boundary).
@@ -620,7 +617,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 // Select pivot in right-side range.
                 Iter pivot = middle + right_size / 2;
                 Iter boundary = upper_bound_helper::call(
-                    first, middle, hpx::util::invoke(proj, *pivot), comp, proj);
+                    first, middle, HPX_INVOKE(proj, *pivot), comp, proj);
                 Iter target = boundary + (pivot - middle);
 
                 // Swap two blocks, [boundary, middle) and [middle, pivot+1).

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/minmax.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/minmax.hpp
@@ -504,7 +504,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 if (first == last)
                 {
                     return util::detail::algorithm_result<ExPolicy,
-                        FwdIter>::get(std::move(first));
+                        FwdIter>::get(HPX_MOVE(first));
                 }
 
                 auto f1 = [f, proj, policy](
@@ -512,17 +512,17 @@ namespace hpx { namespace parallel { inline namespace v1 {
                     return sequential_min_element(
                         policy, it, part_count, f, proj);
                 };
-                auto f2 = [policy, f = std::forward<F>(f),
-                              proj = std::forward<Proj>(proj)](
+                auto f2 = [policy, f = HPX_FORWARD(F, f),
+                              proj = HPX_FORWARD(Proj, proj)](
                               std::vector<FwdIter>&& positions) -> FwdIter {
                     return min_element::sequential_minmax_element_ind(
                         policy, positions.begin(), positions.size(), f, proj);
                 };
 
                 return util::partitioner<ExPolicy, FwdIter, FwdIter>::call(
-                    std::forward<ExPolicy>(policy), first,
-                    detail::distance(first, last), std::move(f1),
-                    hpx::unwrapping(std::move(f2)));
+                    HPX_FORWARD(ExPolicy, policy), first,
+                    detail::distance(first, last), HPX_MOVE(f1),
+                    hpx::unwrapping(HPX_MOVE(f2)));
             }
         };
 
@@ -644,7 +644,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 auto largest = first;
 
                 element_type value = HPX_INVOKE(proj, *largest);
-                util::loop(std::forward<ExPolicy>(policy), ++first, last,
+                util::loop(HPX_FORWARD(ExPolicy, policy), ++first, last,
                     [&](FwdIter const& curr) -> void {
                         element_type curr_value = HPX_INVOKE(proj, *curr);
                         if (!HPX_INVOKE(f, curr_value, value))
@@ -878,7 +878,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 return util::partitioner<ExPolicy, result_type,
                     result_type>::call(HPX_FORWARD(ExPolicy, policy),
                     result.min, detail::distance(result.min, last),
-                    HPX_MOVE(f1), hpx::unwrapping(std::move(f2)));
+                    HPX_MOVE(f1), hpx::unwrapping(HPX_MOVE(f2)));
             }
         };
 
@@ -909,8 +909,8 @@ namespace hpx { namespace parallel { inline namespace v1 {
             "Requires at least forward iterator.");
 
         return detail::minmax_element<FwdIter>().call(
-            std::forward<ExPolicy>(policy), first, last, std::forward<F>(f),
-            std::forward<Proj>(proj));
+            HPX_FORWARD(ExPolicy, policy), first, last, HPX_FORWARD(F, f),
+            HPX_FORWARD(Proj, proj));
     }
 }}}    // namespace hpx::parallel::v1
 
@@ -938,7 +938,7 @@ namespace hpx {
                 "Required at least forward iterator.");
 
             return hpx::parallel::v1::detail::min_element<FwdIter>().call(
-                hpx::execution::seq, first, last, std::forward<F>(f),
+                hpx::execution::seq, first, last, HPX_FORWARD(F, f),
                 hpx::parallel::util::projection_identity{});
         }
 
@@ -983,7 +983,7 @@ namespace hpx {
                 "Required at least forward iterator.");
 
             return hpx::parallel::v1::detail::max_element<FwdIter>().call(
-                hpx::execution::seq, first, last, std::forward<F>(f),
+                hpx::execution::seq, first, last, HPX_FORWARD(F, f),
                 hpx::parallel::util::projection_identity{});
         }
 
@@ -1004,7 +1004,7 @@ namespace hpx {
                 "Required at least forward iterator.");
 
             return hpx::parallel::v1::detail::max_element<FwdIter>().call(
-                std::forward<ExPolicy>(policy), first, last, std::forward<F>(f),
+                HPX_FORWARD(ExPolicy, policy), first, last, HPX_FORWARD(F, f),
                 hpx::parallel::util::projection_identity());
         }
     } max_element{};
@@ -1028,7 +1028,7 @@ namespace hpx {
                 "Required at least forward iterator.");
 
             return hpx::parallel::v1::detail::minmax_element<FwdIter>().call(
-                hpx::execution::seq, first, last, std::forward<F>(f),
+                hpx::execution::seq, first, last, HPX_FORWARD(F, f),
                 hpx::parallel::util::projection_identity{});
         }
 
@@ -1049,7 +1049,7 @@ namespace hpx {
                 "Required at least forward iterator.");
 
             return hpx::parallel::v1::detail::minmax_element<FwdIter>().call(
-                std::forward<ExPolicy>(policy), first, last, std::forward<F>(f),
+                HPX_FORWARD(ExPolicy, policy), first, last, HPX_FORWARD(F, f),
                 hpx::parallel::util::projection_identity());
         }
     } minmax_element{};

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/minmax.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/minmax.hpp
@@ -376,7 +376,6 @@ namespace hpx {
 #include <hpx/executors/execution_policy.hpp>
 #include <hpx/parallel/algorithms/detail/dispatch.hpp>
 #include <hpx/parallel/algorithms/detail/distance.hpp>
-#include <hpx/parallel/util/compare_projected.hpp>
 #include <hpx/parallel/util/detail/algorithm_result.hpp>
 #include <hpx/parallel/util/loop.hpp>
 #include <hpx/parallel/util/partitioner.hpp>

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/mismatch.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/mismatch.hpp
@@ -277,6 +277,8 @@ namespace hpx { namespace parallel { inline namespace v1 {
 
                 util::cancellation_token<std::size_t> tok(count1);
 
+                // Note: replacing the invoke() with HPX_INVOKE()
+                // below makes gcc generate errors
                 auto f1 = [tok, f = HPX_FORWARD(F, f),
                               proj1 = HPX_FORWARD(Proj1, proj1),
                               proj2 = HPX_FORWARD(Proj2, proj2)](
@@ -284,7 +286,8 @@ namespace hpx { namespace parallel { inline namespace v1 {
                               std::size_t base_idx) mutable -> void {
                     util::loop_idx_n<std::decay_t<ExPolicy>>(base_idx, it,
                         part_count, tok,
-                        [&f, &proj1, &proj2, &tok](reference t, std::size_t i) {
+                        [&f, &proj1, &proj2, &tok](
+                            reference t, std::size_t i) mutable -> void {
                             if (!hpx::util::invoke(f,
                                     hpx::util::invoke(proj1, hpx::get<0>(t)),
                                     hpx::util::invoke(proj2, hpx::get<1>(t))))
@@ -424,12 +427,14 @@ namespace hpx { namespace parallel { inline namespace v1 {
 
                 util::cancellation_token<std::size_t> tok(count);
 
+                // Note: replacing the invoke() with HPX_INVOKE()
+                // below makes gcc generate errors
                 auto f1 = [tok, f = HPX_FORWARD(F, f)](zip_iterator it,
                               std::size_t part_count,
                               std::size_t base_idx) mutable -> void {
                     util::loop_idx_n<std::decay_t<ExPolicy>>(base_idx, it,
                         part_count, tok,
-                        [&f, &tok](reference t, std::size_t i) {
+                        [&f, &tok](reference t, std::size_t i) mutable -> void {
                             if (!hpx::util::invoke(
                                     f, hpx::get<0>(t), hpx::get<1>(t)))
                             {

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/partial_sort.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/partial_sort.hpp
@@ -528,8 +528,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
             Comp&& comp, Proj&& proj)
         {
             return sequential_partial_sort(first, middle, last,
-                util::compare_projected<Comp, Proj>(
-                    HPX_FORWARD(Comp, comp), HPX_FORWARD(Proj, proj)));
+                util::compare_projected<Comp&, Proj&>(comp, proj));
         }
 
         template <typename ExPolicy, typename Iter, typename Sent,
@@ -547,8 +546,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 // depending on execution policy
                 return algorithm_result::get(parallel_partial_sort(
                     HPX_FORWARD(ExPolicy, policy), first, middle, last,
-                    util::compare_projected<Comp, Proj>(
-                        HPX_FORWARD(Comp, comp), HPX_FORWARD(Proj, proj))));
+                    util::compare_projected<Comp&, Proj&>(comp, proj)));
             }
             catch (...)
             {

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/partial_sort.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/partial_sort.hpp
@@ -356,7 +356,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
             template <typename... Ts>
             decltype(auto) operator()(Ts&&... ts) const
             {
-                return sort_thread(std::forward<Ts>(ts)...);
+                return sort_thread(HPX_FORWARD(Ts, ts)...);
             }
         };
 
@@ -369,7 +369,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
             template <typename... Ts>
             decltype(auto) operator()(Ts&&... ts) const
             {
-                return parallel_partial_sort(std::forward<Ts>(ts)...);
+                return parallel_partial_sort(HPX_FORWARD(Ts, ts)...);
             }
         };
 

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/partial_sort_copy.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/partial_sort_copy.hpp
@@ -230,9 +230,8 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
 
             HPX_ASSERT(ninput >= 0 || noutput >= 0);
 
-            util::compare_projected<Compare, Proj1, Proj2> proj_comp{
-                HPX_FORWARD(Compare, comp), HPX_FORWARD(Proj1, proj1),
-                HPX_FORWARD(Proj2, proj2)};
+            util::compare_projected<Compare&, Proj1&, Proj2&> proj_comp{
+                comp, proj1, proj2};
 
             auto nmin = ninput < noutput ? ninput : noutput;
             if (noutput >= ninput)
@@ -307,9 +306,8 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
                 std::int64_t noutput = d_last_iter - d_first;
                 HPX_ASSERT(ninput >= 0 and noutput >= 0);
 
-                util::compare_projected<Compare, Proj1, Proj2> proj_comp{
-                    HPX_FORWARD(Compare, comp), HPX_FORWARD(Proj1, proj1),
-                    HPX_FORWARD(Proj2, proj2)};
+                util::compare_projected<Compare&, Proj1&, Proj2&> proj_comp{
+                    comp, proj1, proj2};
 
                 auto nmin = ninput < noutput ? ninput : noutput;
                 if (noutput >= ninput)
@@ -414,8 +412,8 @@ namespace hpx {
 
             return parallel::util::get_second_element(
                 parallel::v1::detail::partial_sort_copy<result_type>().call(
-                    HPX_FORWARD(ExPolicy, policy), first, last, d_first,
-                    d_last, HPX_FORWARD(Comp, comp),
+                    HPX_FORWARD(ExPolicy, policy), first, last, d_first, d_last,
+                    HPX_FORWARD(Comp, comp),
                     parallel::util::projection_identity{},
                     parallel::util::projection_identity{}));
         }

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/partial_sort_copy.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/partial_sort_copy.hpp
@@ -231,21 +231,21 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
             HPX_ASSERT(ninput >= 0 || noutput >= 0);
 
             util::compare_projected<Compare, Proj1, Proj2> proj_comp{
-                std::forward<Compare>(comp), std::forward<Proj1>(proj1),
-                std::forward<Proj2>(proj2)};
+                HPX_FORWARD(Compare, comp), HPX_FORWARD(Proj1, proj1),
+                HPX_FORWARD(Proj2, proj2)};
 
             auto nmin = ninput < noutput ? ninput : noutput;
             if (noutput >= ninput)
             {
                 detail::sort<vec_iter_t>().call(hpx::execution::seq,
-                    aux.begin(), aux.end(), std::move(proj_comp),
+                    aux.begin(), aux.end(), HPX_MOVE(proj_comp),
                     util::projection_identity{});
             }
             else
             {
                 parallel::v1::partial_sort<vec_iter_t>().call(
                     hpx::execution::seq, aux.begin(), aux.begin() + nmin,
-                    aux.end(), std::move(proj_comp),
+                    aux.end(), HPX_MOVE(proj_comp),
                     util::projection_identity{});
             }
 
@@ -308,15 +308,15 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
                 HPX_ASSERT(ninput >= 0 and noutput >= 0);
 
                 util::compare_projected<Compare, Proj1, Proj2> proj_comp{
-                    std::forward<Compare>(comp), std::forward<Proj1>(proj1),
-                    std::forward<Proj2>(proj2)};
+                    HPX_FORWARD(Compare, comp), HPX_FORWARD(Proj1, proj1),
+                    HPX_FORWARD(Proj2, proj2)};
 
                 auto nmin = ninput < noutput ? ninput : noutput;
                 if (noutput >= ninput)
                 {
                     detail::sort<vec_iter_t>().call(
                         policy(hpx::execution::non_task), aux.begin(),
-                        aux.end(), std::move(proj_comp),
+                        aux.end(), HPX_MOVE(proj_comp),
                         util::projection_identity{});
                 }
                 else
@@ -324,7 +324,7 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
                     //
                     hpx::parallel::v1::partial_sort<vec_iter_t>().call(
                         policy(hpx::execution::non_task), aux.begin(),
-                        aux.begin() + nmin, aux.end(), std::move(proj_comp),
+                        aux.begin() + nmin, aux.end(), HPX_MOVE(proj_comp),
                         util::projection_identity{});
                 };
 
@@ -379,7 +379,7 @@ namespace hpx {
             return parallel::util::get_second_element(
                 parallel::v1::detail::partial_sort_copy<result_type>().call(
                     hpx::execution::seq, first, last, d_first, d_last,
-                    std::forward<Comp>(comp),
+                    HPX_FORWARD(Comp, comp),
                     parallel::util::projection_identity{},
                     parallel::util::projection_identity{}));
         }
@@ -414,8 +414,8 @@ namespace hpx {
 
             return parallel::util::get_second_element(
                 parallel::v1::detail::partial_sort_copy<result_type>().call(
-                    std::forward<ExPolicy>(policy), first, last, d_first,
-                    d_last, std::forward<Comp>(comp),
+                    HPX_FORWARD(ExPolicy, policy), first, last, d_first,
+                    d_last, HPX_FORWARD(Comp, comp),
                     parallel::util::projection_identity{},
                     parallel::util::projection_identity{}));
         }

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/remove.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/remove.hpp
@@ -258,7 +258,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
 
             if (first != last)
                 for (Iter i = first; ++i != last;)
-                    if (!hpx::util::invoke(pred, hpx::util::invoke(proj, *i)))
+                    if (!HPX_INVOKE(pred, HPX_INVOKE(proj, *i)))
                     {
                         *first++ = HPX_MOVE(*i);
                     }
@@ -312,6 +312,8 @@ namespace hpx { namespace parallel { inline namespace v1 {
                     void, util::scan_partitioner_sequential_f3_tag>
                     scan_partitioner_type;
 
+                // Note: replacing the invoke() with HPX_INVOKE()
+                // below makes gcc generate errors
                 auto f1 = [pred = HPX_FORWARD(Pred, pred),
                               proj = HPX_FORWARD(Proj, proj)](
                               zip_iterator part_begin,

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/remove_copy.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/remove_copy.hpp
@@ -285,7 +285,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
         {
             for (/* */; first != last; ++first)
             {
-                if (!(hpx::util::invoke(proj, *first) == value))
+                if (!(HPX_INVOKE(proj, *first) == value))
                 {
                     *dest++ = *first;
                 }
@@ -371,8 +371,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
         {
             for (/* */; first != last; ++first)
             {
-                using hpx::util::invoke;
-                if (!invoke(p, invoke(proj, *first)))
+                if (!HPX_INVOKE(p, HPX_INVOKE(proj, *first)))
                 {
                     *dest++ = *first;
                 }
@@ -411,7 +410,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 return copy_if<IterPair>().call(
                     HPX_FORWARD(ExPolicy, policy), first, last, dest,
                     [f = HPX_FORWARD(F, f)](value_type const& a) -> bool {
-                        return !hpx::util::invoke(f, a);
+                        return !HPX_INVOKE(f, a);
                     },
                     HPX_FORWARD(Proj, proj));
             }

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/replace.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/replace.hpp
@@ -502,7 +502,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
         {
             for (/* */; first != last; ++first)
             {
-                if (hpx::util::invoke(proj, *first) == old_value)
+                if (HPX_INVOKE(proj, *first) == old_value)
                 {
                     *first = new_value;
                 }
@@ -541,7 +541,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                     std::distance(first, last),
                     [old_value, new_value, proj = HPX_FORWARD(Proj, proj)](
                         type& t) -> void {
-                        if (hpx::util::invoke(proj, t) == old_value)
+                        if (HPX_INVOKE(proj, t) == old_value)
                         {
                             t = new_value;
                         }
@@ -591,8 +591,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
         {
             for (/* */; first != sent; ++first)
             {
-                using hpx::util::invoke;
-                if (invoke(f, invoke(proj, *first)))
+                if (HPX_INVOKE(f, HPX_INVOKE(proj, *first)))
                 {
                     *first = new_value;
                 }
@@ -630,10 +629,12 @@ namespace hpx { namespace parallel { inline namespace v1 {
                     HPX_FORWARD(ExPolicy, policy), first,
                     detail::distance(first, last),
                     [new_value, f = HPX_FORWARD(F, f),
-                        proj = HPX_FORWARD(Proj, proj)](type& t) -> void {
-                        using hpx::util::invoke;
-                        if (invoke(f, invoke(proj, t)))
+                        proj = HPX_FORWARD(Proj, proj)](
+                        type& t) mutable -> void {
+                        if (HPX_INVOKE(f, HPX_INVOKE(proj, t)))
+                        {
                             t = new_value;
+                        }
                     },
                     util::projection_identity());
             }
@@ -679,7 +680,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
         {
             for (/* */; first != sent; ++first)
             {
-                if (hpx::util::invoke(proj, *first) == old_value)
+                if (HPX_INVOKE(proj, *first) == old_value)
                     *dest++ = new_value;
                 else
                     *dest++ = *first;
@@ -726,7 +727,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                         [old_value, new_value, proj = HPX_FORWARD(Proj, proj)](
                             reference t) -> void {
                             using hpx::get;
-                            if (hpx::util::invoke(proj, get<0>(t)) == old_value)
+                            if (HPX_INVOKE(proj, get<0>(t)) == old_value)
                                 get<1>(t) = new_value;
                             else
                                 get<1>(t) = get<0>(t);    //-V573
@@ -783,11 +784,14 @@ namespace hpx { namespace parallel { inline namespace v1 {
         {
             for (/* */; first != sent; ++first)
             {
-                using hpx::util::invoke;
-                if (invoke(f, invoke(proj, *first)))
+                if (HPX_INVOKE(f, HPX_INVOKE(proj, *first)))
+                {
                     *dest++ = new_value;
+                }
                 else
+                {
                     *dest++ = *first;
+                }
             }
             return util::in_out_result<InIter, OutIter>{first, dest};
         }
@@ -829,13 +833,16 @@ namespace hpx { namespace parallel { inline namespace v1 {
                         detail::distance(first, sent),
                         [new_value, f = HPX_FORWARD(F, f),
                             proj = HPX_FORWARD(Proj, proj)](
-                            reference t) -> void {
+                            reference t) mutable -> void {
                             using hpx::get;
-                            using hpx::util::invoke;
-                            if (invoke(f, invoke(proj, get<0>(t))))
+                            if (HPX_INVOKE(f, HPX_INVOKE(proj, get<0>(t))))
+                            {
                                 get<1>(t) = new_value;
+                            }
                             else
+                            {
                                 get<1>(t) = get<0>(t);    //-V573
+                            }
                         },
                         util::projection_identity()));
             }

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/set_difference.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/set_difference.hpp
@@ -147,16 +147,16 @@ namespace hpx { namespace parallel { inline namespace v1 {
                     return util::copy(first1, last1, dest);
                 }
 
-                auto&& value1 = hpx::util::invoke(proj1, *first1);
-                auto&& value2 = hpx::util::invoke(proj2, *first2);
+                auto&& value1 = HPX_INVOKE(proj1, *first1);
+                auto&& value2 = HPX_INVOKE(proj2, *first2);
 
-                if (hpx::util::invoke(comp, value1, value2))
+                if (HPX_INVOKE(comp, value1, value2))
                 {
                     *dest++ = *first1++;
                 }
                 else
                 {
-                    if (!hpx::util::invoke(comp, value2, value1))
+                    if (!HPX_INVOKE(comp, value2, value1))
                     {
                         ++first1;
                     }

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/set_intersection.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/set_intersection.hpp
@@ -141,16 +141,16 @@ namespace hpx { namespace parallel { inline namespace v1 {
         {
             while (first1 != last1 && first2 != last2)
             {
-                auto&& value1 = hpx::util::invoke(proj1, *first1);
-                auto&& value2 = hpx::util::invoke(proj2, *first2);
+                auto&& value1 = HPX_INVOKE(proj1, *first1);
+                auto&& value2 = HPX_INVOKE(proj2, *first2);
 
-                if (hpx::util::invoke(comp, value1, value2))
+                if (HPX_INVOKE(comp, value1, value2))
                 {
                     ++first1;
                 }
                 else
                 {
-                    if (!hpx::util::invoke(comp, value2, value1))
+                    if (!HPX_INVOKE(comp, value2, value1))
                     {
                         *dest++ = *first1++;
                     }

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/set_symmetric_difference.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/set_symmetric_difference.hpp
@@ -154,16 +154,16 @@ namespace hpx { namespace parallel { inline namespace v1 {
                     return {result.in, first2, result.out};
                 }
 
-                auto&& value1 = hpx::util::invoke(proj1, *first1);
-                auto&& value2 = hpx::util::invoke(proj2, *first2);
+                auto&& value1 = HPX_INVOKE(proj1, *first1);
+                auto&& value2 = HPX_INVOKE(proj2, *first2);
 
-                if (hpx::util::invoke(comp, value1, value2))
+                if (HPX_INVOKE(comp, value1, value2))
                 {
                     *dest++ = *first1++;
                 }
                 else
                 {
-                    if (hpx::util::invoke(comp, value2, value1))
+                    if (HPX_INVOKE(comp, value2, value1))
                     {
                         *dest++ = *first2;
                     }

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/set_union.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/set_union.hpp
@@ -148,17 +148,17 @@ namespace hpx { namespace parallel { inline namespace v1 {
                     return {result.in, first2, result.out};
                 }
 
-                auto&& value1 = hpx::util::invoke(proj1, *first1);
-                auto&& value2 = hpx::util::invoke(proj2, *first2);
+                auto&& value1 = HPX_INVOKE(proj1, *first1);
+                auto&& value2 = HPX_INVOKE(proj2, *first2);
 
-                if (hpx::util::invoke(comp, value2, value1))
+                if (HPX_INVOKE(comp, value2, value1))
                 {
                     *dest = *first2++;
                 }
                 else
                 {
                     *dest = *first1;
-                    if (!hpx::util::invoke(comp, value1, value2))
+                    if (!HPX_INVOKE(comp, value1, value2))
                     {
                         ++first2;
                     }

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/sort.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/sort.hpp
@@ -429,8 +429,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
             {
                 auto last_iter = detail::advance_to_sentinel(first, last);
                 std::sort(first, last_iter,
-                    util::compare_projected<Comp, Proj>(
-                        HPX_FORWARD(Comp, comp), HPX_FORWARD(Proj, proj)));
+                    util::compare_projected<Comp&, Proj&>(comp, proj));
                 return last_iter;
             }
 
@@ -451,8 +450,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                     // depending on execution policy
                     return algorithm_result::get(parallel_sort_async(
                         HPX_FORWARD(ExPolicy, policy), first, last,
-                        util::compare_projected<Comp, Proj>(
-                            HPX_FORWARD(Comp, comp), HPX_FORWARD(Proj, proj))));
+                        util::compare_projected<Comp&, Proj&>(comp, proj)));
                 }
                 catch (...)
                 {

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/stable_sort.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/stable_sort.hpp
@@ -281,15 +281,11 @@ namespace hpx { namespace parallel { inline namespace v1 {
             static RandomIt sequential(ExPolicy, RandomIt first, Sentinel last,
                 Compare&& comp, Proj&& proj)
             {
-                using compare_type =
-                    util::compare_projected<typename std::decay<Compare>::type,
-                        typename std::decay<Proj>::type>;
+                using compare_type = util::compare_projected<Compare&, Proj&>;
 
                 auto last_iter = detail::advance_to_sentinel(first, last);
 
-                spin_sort(first, last_iter,
-                    compare_type(
-                        HPX_FORWARD(Compare, comp), HPX_FORWARD(Proj, proj)));
+                spin_sort(first, last_iter, compare_type(comp, proj));
                 return last_iter;
             }
 
@@ -302,9 +298,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
             {
                 using algorithm_result =
                     util::detail::algorithm_result<ExPolicy, RandomIt>;
-                using compare_type =
-                    util::compare_projected<typename std::decay<Compare>::type,
-                        typename std::decay<Proj>::type>;
+                using compare_type = util::compare_projected<Compare&, Proj&>;
 
                 // number of elements to sort
                 auto last_iter = first;
@@ -332,8 +326,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 {
                     // call the sort routine and return the right type,
                     // depending on execution policy
-                    compare_type comp(
-                        HPX_FORWARD(Compare, compare), HPX_FORWARD(Proj, proj));
+                    compare_type comp(compare, proj);
 
                     return algorithm_result::get(
                         parallel_stable_sort(policy.executor(), first,

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/transform_exclusive_scan.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/transform_exclusive_scan.hpp
@@ -258,8 +258,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
             T temp = init;
             for (/* */; first != last; (void) ++first, ++dest)
             {
-                init = hpx::util::invoke(
-                    op, init, hpx::util::invoke(conv, *first));
+                init = HPX_INVOKE(op, init, HPX_INVOKE(conv, *first));
                 *dest = temp;
                 temp = init;
             }
@@ -274,8 +273,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
             T temp = init;
             for (/* */; count-- != 0; (void) ++first, ++dest)
             {
-                init = hpx::util::invoke(
-                    op, init, hpx::util::invoke(conv, *first));
+                init = HPX_INVOKE(op, init, HPX_INVOKE(conv, *first));
                 *dest = temp;
                 temp = init;
             }
@@ -338,13 +336,13 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 using hpx::util::make_zip_iterator;
 
                 auto f3 = [op](zip_iterator part_begin, std::size_t part_size,
-                              T val) -> void {
+                              T val) mutable -> void {
                     FwdIter2 dst = get<1>(part_begin.get_iterator_tuple());
                     *dst++ = val;
 
                     util::loop_n<std::decay_t<ExPolicy>>(
                         dst, part_size - 1, [&op, &val](FwdIter2 it) -> void {
-                            *it = hpx::util::invoke(op, val, *it);
+                            *it = HPX_INVOKE(op, val, *it);
                         });
                 };
 
@@ -352,10 +350,9 @@ namespace hpx { namespace parallel { inline namespace v1 {
                     HPX_FORWARD(ExPolicy, policy),
                     make_zip_iterator(first, dest), count, init,
                     // step 1 performs first part of scan algorithm
-                    [op, conv](
-                        zip_iterator part_begin, std::size_t part_size) -> T {
-                        T part_init =
-                            hpx::util::invoke(conv, get<0>(*part_begin++));
+                    [op, conv](zip_iterator part_begin,
+                        std::size_t part_size) mutable -> T {
+                        T part_init = HPX_INVOKE(conv, get<0>(*part_begin++));
 
                         auto iters = part_begin.get_iterator_tuple();
                         return sequential_transform_exclusive_scan_n(

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/transform_inclusive_scan.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/transform_inclusive_scan.hpp
@@ -445,8 +445,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
         {
             for (/**/; first != last; (void) ++first, ++dest)
             {
-                init = hpx::util::invoke(
-                    op, init, hpx::util::invoke(conv, *first));
+                init = HPX_INVOKE(op, init, HPX_INVOKE(conv, *first));
                 *dest = init;
             }
             return util::in_out_result<InIter, OutIter>{first, dest};
@@ -460,7 +459,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
         {
             if (first != last)
             {
-                auto init = hpx::util::invoke(conv, *first);
+                auto init = HPX_INVOKE(conv, *first);
 
                 *dest++ = init;
                 return sequential_transform_inclusive_scan(++first, last, dest,
@@ -477,8 +476,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
         {
             for (/**/; count-- != 0; (void) ++first, ++dest)
             {
-                init = hpx::util::invoke(
-                    op, init, hpx::util::invoke(conv, *first));
+                init = HPX_INVOKE(op, init, HPX_INVOKE(conv, *first));
                 *dest = init;
             }
             return init;
@@ -550,12 +548,12 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 using hpx::util::make_zip_iterator;
 
                 auto f3 = [op](zip_iterator part_begin, std::size_t part_size,
-                              T val) -> void {
+                              T val) mutable -> void {
                     FwdIter2 dst = get<1>(part_begin.get_iterator_tuple());
 
                     util::loop_n<std::decay_t<ExPolicy>>(
                         dst, part_size, [&op, &val](FwdIter2 it) -> void {
-                            *it = hpx::util::invoke(op, val, *it);
+                            *it = HPX_INVOKE(op, val, *it);
                         });
                 };
 
@@ -563,10 +561,9 @@ namespace hpx { namespace parallel { inline namespace v1 {
                     HPX_FORWARD(ExPolicy, policy),
                     make_zip_iterator(first, dest), count, init,
                     // step 1 performs first part of scan algorithm
-                    [op, conv](
-                        zip_iterator part_begin, std::size_t part_size) -> T {
-                        T part_init =
-                            hpx::util::invoke(conv, get<0>(*part_begin));
+                    [op, conv](zip_iterator part_begin,
+                        std::size_t part_size) mutable -> T {
+                        T part_init = HPX_INVOKE(conv, get<0>(*part_begin));
                         get<1>(*part_begin++) = part_init;
 
                         auto iters = part_begin.get_iterator_tuple();
@@ -598,7 +595,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
             {
                 if (first != last)
                 {
-                    auto init = hpx::util::invoke(conv, *first);
+                    auto init = HPX_INVOKE(conv, *first);
 
                     *dest++ = init;
                     return parallel(HPX_FORWARD(ExPolicy, policy), ++first,

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/transform_reduce.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/transform_reduce.hpp
@@ -338,13 +338,13 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 using reference =
                     typename std::iterator_traits<Iter>::reference;
 
-                T val = hpx::util::invoke(convert_, *part_begin);
+                T val = HPX_INVOKE(convert_, *part_begin);
                 return util::accumulate_n(++part_begin, --part_size,
                     HPX_MOVE(val),
                     [HPX_CXX20_CAPTURE_THIS(=)](
                         T const& res, reference next) mutable -> T {
-                        return hpx::util::invoke(
-                            reduce_, res, hpx::util::invoke(convert_, next));
+                        return HPX_INVOKE(
+                            reduce_, res, HPX_INVOKE(convert_, next));
                     });
             }
         };
@@ -368,8 +368,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
 
                 return detail::accumulate(first, last, HPX_FORWARD(T_, init),
                     [&r, &conv](T const& res, value_type const& next) -> T {
-                        return hpx::util::invoke(
-                            r, res, hpx::util::invoke(conv, next));
+                        return HPX_INVOKE(r, res, HPX_INVOKE(conv, next));
                     });
             }
 
@@ -453,10 +452,10 @@ namespace hpx { namespace parallel { inline namespace v1 {
             F f_;
 
             template <typename Iter1, typename Iter2>
-            HPX_HOST_DEVICE HPX_FORCEINLINE constexpr auto operator()(Iter1 it1,
-                Iter2 it2) -> decltype(hpx::util::invoke(f_, *it1, *it2))
+            HPX_HOST_DEVICE HPX_FORCEINLINE constexpr auto operator()(
+                Iter1 it1, Iter2 it2) -> decltype(HPX_INVOKE(f_, *it1, *it2))
             {
-                return hpx::util::invoke(f_, *it1, *it2);
+                return HPX_INVOKE(f_, *it1, *it2);
             }
         };
 
@@ -473,8 +472,8 @@ namespace hpx { namespace parallel { inline namespace v1 {
             HPX_HOST_DEVICE HPX_FORCEINLINE constexpr void operator()(
                 Iter1 it1, Iter2 it2)
             {
-                part_sum_ = hpx::util::invoke(
-                    op1_, part_sum_, hpx::util::invoke(op2_, *it1, *it2));
+                part_sum_ =
+                    HPX_INVOKE(op1_, part_sum_, HPX_INVOKE(op2_, *it1, *it2));
             }
         };
 
@@ -521,7 +520,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 // of the elements of a value-pack
                 auto result = util::detail::accumulate_values<ExPolicy>(
                     [&op1](T const& sum, T&& val) -> T {
-                        return hpx::util::invoke(op1, sum, val);
+                        return HPX_INVOKE(op1, sum, val);
                     },
                     HPX_MOVE(part_sum), HPX_MOVE(init));
 
@@ -597,7 +596,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                     // for each of the elements of a value-pack
                     auto result = util::detail::accumulate_values<ExPolicy>(
                         [&op1](T const& sum, T&& val) -> T {
-                            return hpx::util::invoke(op1, sum, val);
+                            return HPX_INVOKE(op1, sum, val);
                         },
                         part_sum);
 
@@ -625,8 +624,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                         T ret = HPX_MOVE(init);
                         for (auto&& fut : results)
                         {
-                            ret = hpx::util::invoke(
-                                op1, HPX_MOVE(ret), fut.get());
+                            ret = HPX_INVOKE(op1, HPX_MOVE(ret), fut.get());
                         }
                         return ret;
                     });

--- a/libs/core/algorithms/include/hpx/parallel/container_algorithms/adjacent_difference.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/container_algorithms/adjacent_difference.hpp
@@ -336,7 +336,7 @@ namespace hpx { namespace ranges {
                 "Required at least forward iterator.");
 
             return hpx::parallel::v1::detail::adjacent_difference<FwdIter2>()
-                .call(std::forward<ExPolicy>(policy), first, last, dest,
+                .call(HPX_FORWARD(ExPolicy, policy), first, last, dest,
                     std::minus<>());
         }
 
@@ -360,7 +360,7 @@ namespace hpx { namespace ranges {
                 "Required at least forward iterator.");
 
             return hpx::parallel::v1::detail::adjacent_difference<FwdIter2>()
-                .call(std::forward<ExPolicy>(policy), hpx::util::begin(rng),
+                .call(HPX_FORWARD(ExPolicy, policy), hpx::util::begin(rng),
                     hpx::util::end(rng), dest, std::minus<>());
         }
 
@@ -383,7 +383,7 @@ namespace hpx { namespace ranges {
 
             return hpx::parallel::v1::detail::adjacent_difference<FwdIter2>()
                 .call(hpx::execution::sequenced_policy{}, first, last, dest,
-                    std::forward<Op>(op));
+                    HPX_FORWARD(Op, op));
         }
 
         // clang-format off
@@ -404,7 +404,7 @@ namespace hpx { namespace ranges {
 
             return hpx::parallel::v1::detail::adjacent_difference<FwdIter2>()
                 .call(hpx::execution::seq, hpx::util::begin(rng),
-                    hpx::util::end(rng), dest, std::forward<Op>(op));
+                    hpx::util::end(rng), dest, HPX_FORWARD(Op, op));
         }
 
         // clang-format off
@@ -429,8 +429,8 @@ namespace hpx { namespace ranges {
                 "Required at least forward iterator.");
 
             return hpx::parallel::v1::detail::adjacent_difference<FwdIter2>()
-                .call(std::forward<ExPolicy>(policy), first, last, dest,
-                    std::forward<Op>(op));
+                .call(HPX_FORWARD(ExPolicy, policy), first, last, dest,
+                    HPX_FORWARD(Op, op));
         }
 
         // clang-format off
@@ -454,8 +454,8 @@ namespace hpx { namespace ranges {
                 "Required at least forward iterator.");
 
             return hpx::parallel::v1::detail::adjacent_difference<FwdIter2>()
-                .call(std::forward<ExPolicy>(policy), hpx::util::begin(rng),
-                    hpx::util::end(rng), dest, std::forward<Op>(op));
+                .call(HPX_FORWARD(ExPolicy, policy), hpx::util::begin(rng),
+                    hpx::util::end(rng), dest, HPX_FORWARD(Op, op));
         }
     } adjacent_difference{};
 }}    // namespace hpx::ranges

--- a/libs/core/algorithms/include/hpx/parallel/container_algorithms/minmax.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/container_algorithms/minmax.hpp
@@ -826,9 +826,9 @@ namespace hpx { namespace parallel { inline namespace v1 {
     {
         return hpx::parallel::v1::detail::min_element<
             hpx::traits::range_iterator_t<Rng>>()
-            .call(std::forward<ExPolicy>(policy), hpx::util::begin(rng),
-                hpx::util::end(rng), std::forward<F>(f),
-                std::forward<Proj>(proj));
+            .call(HPX_FORWARD(ExPolicy, policy), hpx::util::begin(rng),
+                hpx::util::end(rng), HPX_FORWARD(F, f),
+                HPX_FORWARD(Proj, proj));
     }
 
     // clang-format off
@@ -855,9 +855,9 @@ namespace hpx { namespace parallel { inline namespace v1 {
     {
         return hpx::parallel::v1::detail::max_element<
             hpx::traits::range_iterator_t<Rng>>()
-            .call(std::forward<ExPolicy>(policy), hpx::util::begin(rng),
-                hpx::util::end(rng), std::forward<F>(f),
-                std::forward<Proj>(proj));
+            .call(HPX_FORWARD(ExPolicy, policy), hpx::util::begin(rng),
+                hpx::util::end(rng), HPX_FORWARD(F, f),
+                HPX_FORWARD(Proj, proj));
     }
 
 #if defined(HPX_MSVC)
@@ -891,9 +891,9 @@ namespace hpx { namespace parallel { inline namespace v1 {
     {
         return hpx::parallel::v1::detail::minmax_element<
             hpx::traits::range_iterator_t<Rng>>()
-            .call(std::forward<ExPolicy>(policy), hpx::util::begin(rng),
-                hpx::util::end(rng), std::forward<F>(f),
-                std::forward<Proj>(proj));
+            .call(HPX_FORWARD(ExPolicy, policy), hpx::util::begin(rng),
+                hpx::util::end(rng), HPX_FORWARD(F, f),
+                HPX_FORWARD(Proj, proj));
     }
 
 #if defined(HPX_MSVC)
@@ -1211,8 +1211,8 @@ namespace hpx { namespace ranges {
             return hpx::parallel::v1::detail::minmax_element<
                 hpx::traits::range_iterator_t<Rng>>()
                 .call(hpx::execution::seq, hpx::util::begin(rng),
-                    hpx::util::end(rng), std::forward<F>(f),
-                    std::forward<Proj>(proj));
+                    hpx::util::end(rng), HPX_FORWARD(F, f),
+                    HPX_FORWARD(Proj, proj));
         }
 
         // clang-format off
@@ -1240,8 +1240,8 @@ namespace hpx { namespace ranges {
                 "Required at least forward iterator.");
 
             return hpx::parallel::v1::detail::minmax_element<FwdIter>().call(
-                std::forward<ExPolicy>(policy), first, last, std::forward<F>(f),
-                std::forward<Proj>(proj));
+                HPX_FORWARD(ExPolicy, policy), first, last, HPX_FORWARD(F, f),
+                HPX_FORWARD(Proj, proj));
         }
 
         // clang-format off
@@ -1270,9 +1270,9 @@ namespace hpx { namespace ranges {
 
             return hpx::parallel::v1::detail::minmax_element<
                 hpx::traits::range_iterator_t<Rng>>()
-                .call(std::forward<ExPolicy>(policy), hpx::util::begin(rng),
-                    hpx::util::end(rng), std::forward<F>(f),
-                    std::forward<Proj>(proj));
+                .call(HPX_FORWARD(ExPolicy, policy), hpx::util::begin(rng),
+                    hpx::util::end(rng), HPX_FORWARD(F, f),
+                    HPX_FORWARD(Proj, proj));
         }
     } minmax_element{};
 }}    // namespace hpx::ranges

--- a/libs/core/algorithms/include/hpx/parallel/container_algorithms/partial_sort.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/container_algorithms/partial_sort.hpp
@@ -303,7 +303,7 @@ namespace hpx { namespace ranges {
 
             return hpx::parallel::v1::partial_sort<RandomIt>().call(
                 hpx::execution::seq, first, middle, last,
-                std::forward<Comp>(comp), std::forward<Proj>(proj));
+                HPX_FORWARD(Comp, comp), HPX_FORWARD(Proj, proj));
         }
 
         // clang-format off
@@ -331,8 +331,8 @@ namespace hpx { namespace ranges {
                 "Requires a random access iterator.");
 
             return hpx::parallel::v1::partial_sort<RandomIt>().call(
-                std::forward<ExPolicy>(policy), first, middle, last,
-                std::forward<Comp>(comp), std::forward<Proj>(proj));
+                HPX_FORWARD(ExPolicy, policy), first, middle, last,
+                HPX_FORWARD(Comp, comp), HPX_FORWARD(Proj, proj));
         }
 
         // clang-format off
@@ -362,8 +362,8 @@ namespace hpx { namespace ranges {
 
             return hpx::parallel::v1::partial_sort<iterator_type>().call(
                 hpx::execution::seq, hpx::util::begin(rng), middle,
-                hpx::util::end(rng), std::forward<Compare>(comp),
-                std::forward<Proj>(proj));
+                hpx::util::end(rng), HPX_FORWARD(Compare, comp),
+                HPX_FORWARD(Proj, proj));
         }
 
         // clang-format off
@@ -393,9 +393,9 @@ namespace hpx { namespace ranges {
                 "Requires a random access iterator.");
 
             return hpx::parallel::v1::partial_sort<iterator_type>().call(
-                std::forward<ExPolicy>(policy), hpx::util::begin(rng), middle,
-                hpx::util::end(rng), std::forward<Compare>(comp),
-                std::forward<Proj>(proj));
+                HPX_FORWARD(ExPolicy, policy), hpx::util::begin(rng), middle,
+                hpx::util::end(rng), HPX_FORWARD(Compare, comp),
+                HPX_FORWARD(Proj, proj));
         }
     } partial_sort{};
 }}    // namespace hpx::ranges

--- a/libs/core/algorithms/include/hpx/parallel/container_algorithms/partial_sort_copy.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/container_algorithms/partial_sort_copy.hpp
@@ -380,8 +380,8 @@ namespace hpx { namespace ranges {
 
             return hpx::parallel::v1::detail::partial_sort_copy<result_type>()
                 .call(hpx::execution::seq, first, last, r_first, r_last,
-                    std::forward<Comp>(comp), std::forward<Proj1>(proj1),
-                    std::forward<Proj2>(proj2));
+                    HPX_FORWARD(Comp, comp), HPX_FORWARD(Proj1, proj1),
+                    HPX_FORWARD(Proj2, proj2));
         }
 
         // clang-format off
@@ -421,9 +421,9 @@ namespace hpx { namespace ranges {
             using result_type = partial_sort_copy_result<FwdIter, RandIter>;
 
             return hpx::parallel::v1::detail::partial_sort_copy<result_type>()
-                .call(std::forward<ExPolicy>(policy), first, last, r_first,
-                    r_last, std::forward<Comp>(comp),
-                    std::forward<Proj1>(proj1), std::forward<Proj2>(proj2));
+                .call(HPX_FORWARD(ExPolicy, policy), first, last, r_first,
+                    r_last, HPX_FORWARD(Comp, comp),
+                    HPX_FORWARD(Proj1, proj1), HPX_FORWARD(Proj2, proj2));
         }
 
         // clang-format off
@@ -464,8 +464,8 @@ namespace hpx { namespace ranges {
             return hpx::parallel::v1::detail::partial_sort_copy<result_type>()
                 .call(hpx::execution::seq, hpx::util::begin(rng1),
                     hpx::util::end(rng1), hpx::util::begin(rng2),
-                    hpx::util::end(rng2), std::forward<Compare>(comp),
-                    std::forward<Proj1>(proj1), std::forward<Proj2>(proj2));
+                    hpx::util::end(rng2), HPX_FORWARD(Compare, comp),
+                    HPX_FORWARD(Proj1, proj1), HPX_FORWARD(Proj2, proj2));
         }
 
         // clang-format off
@@ -506,10 +506,10 @@ namespace hpx { namespace ranges {
                 "Requires a random access iterator.");
 
             return hpx::parallel::v1::detail::partial_sort_copy<result_type>()
-                .call(std::forward<ExPolicy>(policy), hpx::util::begin(rng1),
+                .call(HPX_FORWARD(ExPolicy, policy), hpx::util::begin(rng1),
                     hpx::util::end(rng1), hpx::util::begin(rng2),
-                    hpx::util::end(rng2), std::forward<Compare>(comp),
-                    std::forward<Proj1>(proj1), std::forward<Proj2>(proj2));
+                    hpx::util::end(rng2), HPX_FORWARD(Compare, comp),
+                    HPX_FORWARD(Proj1, proj1), HPX_FORWARD(Proj2, proj2));
         }
     } partial_sort_copy{};
 }}    // namespace hpx::ranges

--- a/libs/core/algorithms/include/hpx/parallel/container_algorithms/partial_sort_copy.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/container_algorithms/partial_sort_copy.hpp
@@ -422,8 +422,8 @@ namespace hpx { namespace ranges {
 
             return hpx::parallel::v1::detail::partial_sort_copy<result_type>()
                 .call(HPX_FORWARD(ExPolicy, policy), first, last, r_first,
-                    r_last, HPX_FORWARD(Comp, comp),
-                    HPX_FORWARD(Proj1, proj1), HPX_FORWARD(Proj2, proj2));
+                    r_last, HPX_FORWARD(Comp, comp), HPX_FORWARD(Proj1, proj1),
+                    HPX_FORWARD(Proj2, proj2));
         }
 
         // clang-format off

--- a/libs/core/algorithms/include/hpx/parallel/datapar/find.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/datapar/find.hpp
@@ -38,7 +38,7 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
 
             auto ret = util::loop_n<ExPolicy>(first, std::distance(first, last),
                 tok, [&offset, &val, &tok, &proj](auto const& curr) {
-                    auto msk = hpx::util::invoke(proj, *curr) == val;
+                    auto msk = HPX_INVOKE(proj, *curr) == val;
                     offset = hpx::parallel::traits::find_first_of(msk);
                     if (offset != -1)
                     {
@@ -58,7 +58,7 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
         {
             util::loop_idx_n<ExPolicy>(base_idx, part_begin, part_count, tok,
                 [&val, &proj, &tok](auto& v, std::size_t i) -> void {
-                    auto msk = hpx::util::invoke(proj, v) == val;
+                    auto msk = HPX_INVOKE(proj, v) == val;
                     int offset = hpx::parallel::traits::find_first_of(msk);
                     if (offset != -1)
                         tok.cancel(i + offset);
@@ -102,8 +102,7 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
 
             auto ret = util::loop_n<ExPolicy>(first, std::distance(first, last),
                 tok, [&offset, &pred, &tok, &proj](auto const& curr) {
-                    auto msk =
-                        hpx::util::invoke(pred, hpx::util::invoke(proj, *curr));
+                    auto msk = HPX_INVOKE(pred, HPX_INVOKE(proj, *curr));
                     offset = hpx::parallel::traits::find_first_of(msk);
                     if (offset != -1)
                     {
@@ -122,8 +121,7 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
         {
             util::loop_n<std::decay_t<ExPolicy>>(part_begin, part_count, tok,
                 [&op, &tok, &proj](auto const& curr) {
-                    auto msk =
-                        hpx::util::invoke(op, hpx::util::invoke(proj, *curr));
+                    auto msk = HPX_INVOKE(op, HPX_INVOKE(proj, *curr));
                     if (hpx::parallel::traits::any_of(msk))
                     {
                         tok.cancel();
@@ -138,7 +136,7 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
         {
             util::loop_idx_n<ExPolicy>(base_idx, part_begin, part_count, tok,
                 [&f, &proj, &tok](auto& v, std::size_t i) -> void {
-                    auto msk = hpx::util::invoke(f, hpx::util::invoke(proj, v));
+                    auto msk = HPX_INVOKE(f, HPX_INVOKE(proj, v));
                     int offset = hpx::parallel::traits::find_first_of(msk);
                     if (offset != -1)
                         tok.cancel(i + offset);
@@ -190,16 +188,17 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
             int offset = 0;
             util::cancellation_token<> tok;
 
-            auto ret = util::loop_n<ExPolicy>(first, std::distance(first, last),
-                tok, [&offset, &pred, &tok, &proj](auto const& curr) {
-                    auto msk = !hpx::util::invoke(
-                        pred, hpx::util::invoke(proj, *curr));
-                    offset = hpx::parallel::traits::find_first_of(msk);
-                    if (offset != -1)
-                    {
-                        tok.cancel();
-                    }
-                });
+            auto ret =
+                util::loop_n<ExPolicy>(first, std::distance(first, last), tok,
+                    [&offset, &pred, &tok, &proj](
+                        auto const& curr) mutable -> void {
+                        auto msk = !HPX_INVOKE(pred, HPX_INVOKE(proj, *curr));
+                        offset = hpx::parallel::traits::find_first_of(msk);
+                        if (offset != -1)
+                        {
+                            tok.cancel();
+                        }
+                    });
 
             if (tok.was_cancelled())
                 std::advance(ret, offset);
@@ -212,8 +211,7 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
         {
             util::loop_n<std::decay_t<ExPolicy>>(part_begin, part_count, tok,
                 [&op, &tok, &proj](auto const& curr) {
-                    auto msk =
-                        !hpx::util::invoke(op, hpx::util::invoke(proj, *curr));
+                    auto msk = !HPX_INVOKE(op, HPX_INVOKE(proj, *curr));
                     if (hpx::parallel::traits::any_of(msk))
                     {
                         tok.cancel();
@@ -228,8 +226,7 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
         {
             util::loop_idx_n<ExPolicy>(base_idx, part_begin, part_count, tok,
                 [&f, &proj, &tok](auto& v, std::size_t i) -> void {
-                    auto msk =
-                        !hpx::util::invoke(f, hpx::util::invoke(proj, v));
+                    auto msk = !HPX_INVOKE(f, HPX_INVOKE(proj, v));
                     int offset = hpx::parallel::traits::find_first_of(msk);
                     if (offset != -1)
                         tok.cancel(i + offset);

--- a/libs/core/algorithms/include/hpx/parallel/datapar/find.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/datapar/find.hpp
@@ -85,7 +85,7 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
         Proj&& proj)
     {
         return datapar_find<ExPolicy>::call(base_idx, part_begin, part_count,
-            tok, val, std::forward<Proj>(proj));
+            tok, val, HPX_FORWARD(Proj, proj));
     }
 
     ///////////////////////////////////////////////////////////////////////////
@@ -164,7 +164,7 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
         std::size_t part_count, Token& tok, F&& op, Proj&& proj)
     {
         return datapar_find_if<ExPolicy>::call(part_begin, part_count, tok,
-            std::forward<F>(op), std::forward<Proj>(proj));
+            HPX_FORWARD(F, op), HPX_FORWARD(Proj, proj));
     }
 
     template <typename ExPolicy, typename FwdIter, typename Token, typename F,
@@ -176,7 +176,7 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
         Proj&& proj)
     {
         return datapar_find_if<ExPolicy>::call(base_idx, part_begin, part_count,
-            tok, std::forward<F>(op), std::forward<Proj>(proj));
+            tok, HPX_FORWARD(F, op), HPX_FORWARD(Proj, proj));
     }
     ///////////////////////////////////////////////////////////////////////////
     template <typename ExPolicy>
@@ -255,7 +255,7 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
         std::size_t part_count, Token& tok, F&& op, Proj&& proj)
     {
         return datapar_find_if_not<ExPolicy>::call(part_begin, part_count, tok,
-            std::forward<F>(op), std::forward<Proj>(proj));
+            HPX_FORWARD(F, op), HPX_FORWARD(Proj, proj));
     }
 
     template <typename ExPolicy, typename FwdIter, typename Token, typename F,
@@ -267,7 +267,7 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
         Proj&& proj)
     {
         return datapar_find_if_not<ExPolicy>::call(base_idx, part_begin,
-            part_count, tok, std::forward<F>(op), std::forward<Proj>(proj));
+            part_count, tok, HPX_FORWARD(F, op), HPX_FORWARD(Proj, proj));
     }
 }}}}    // namespace hpx::parallel::v1::detail
 #endif

--- a/libs/core/algorithms/include/hpx/parallel/datapar/generate.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/datapar/generate.hpp
@@ -90,7 +90,7 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
         {
             std::size_t count = std::distance(first, last);
             return datapar_generate_helper<Iter>::call(
-                first, count, std::forward<F>(f));
+                first, count, HPX_FORWARD(F, f));
         }
     };
 
@@ -101,7 +101,7 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
         sequential_generate_t, ExPolicy&& policy, Iter first, Sent last, F&& f)
     {
         return datapar_generate::call(
-            std::forward<ExPolicy>(policy), first, last, std::forward<F>(f));
+            HPX_FORWARD(ExPolicy, policy), first, last, HPX_FORWARD(F, f));
     }
 
     ///////////////////////////////////////////////////////////////////////////
@@ -112,7 +112,7 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
             ExPolicy&&, Iter first, std::size_t count, F&& f)
         {
             return datapar_generate_helper<Iter>::call(
-                first, count, std::forward<F>(f));
+                first, count, HPX_FORWARD(F, f));
         }
     };
 
@@ -123,7 +123,7 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
         std::size_t count, F&& f)
     {
         return datapar_generate_n::call(
-            std::forward<ExPolicy>(policy), first, count, std::forward<F>(f));
+            HPX_FORWARD(ExPolicy, policy), first, count, HPX_FORWARD(F, f));
     }
 }}}}    // namespace hpx::parallel::v1::detail
 #endif

--- a/libs/core/algorithms/include/hpx/parallel/datapar/iterator_helpers.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/datapar/iterator_helpers.hpp
@@ -683,7 +683,7 @@ namespace hpx { namespace parallel { namespace util { namespace detail {
             typedef typename traits::vector_pack_type<value_type2, 1>::type V2;
 
             invoke_vectorized_inout2_ind<V1, V2>::call_unaligned(
-                std::forward<F>(f), it1, it2, dest);
+                HPX_FORWARD(F, f), it1, it2, dest);
         }
 
         ///////////////////////////////////////////////////////////////////
@@ -717,7 +717,7 @@ namespace hpx { namespace parallel { namespace util { namespace detail {
             HPX_ASSERT(is_data_aligned(it1) && is_data_aligned(it2) &&
                 is_data_aligned(dest));
             invoke_vectorized_inout2_ind<V1, V2>::call_aligned(
-                std::forward<F>(f), it1, it2, dest);
+                HPX_FORWARD(F, f), it1, it2, dest);
         }
     };
 }}}}    // namespace hpx::parallel::util::detail

--- a/libs/core/algorithms/include/hpx/parallel/datapar/loop.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/datapar/loop.hpp
@@ -640,7 +640,7 @@ namespace hpx { namespace parallel { namespace util {
         End end, CancelToken& tok, F&& f)
     {
         return detail::datapar_loop<Begin>::call(
-            begin, end, tok, std::forward<F>(f));
+            begin, end, tok, HPX_FORWARD(F, f));
     }
 
     template <typename Begin, typename End, typename CancelToken, typename F>
@@ -649,7 +649,7 @@ namespace hpx { namespace parallel { namespace util {
         Begin begin, End end, CancelToken& tok, F&& f)
     {
         return detail::datapar_loop<Begin>::call(
-            begin, end, tok, std::forward<F>(f));
+            begin, end, tok, HPX_FORWARD(F, f));
     }
 
     ///////////////////////////////////////////////////////////////////////////
@@ -703,7 +703,7 @@ namespace hpx { namespace parallel { namespace util {
         std::size_t count, CancelToken& tok, F&& f)
     {
         return hpx::parallel::util::detail::datapar_loop_n<Iter>::call(
-            it, count, tok, std::forward<F>(f));
+            it, count, tok, HPX_FORWARD(F, f));
     }
 
     ///////////////////////////////////////////////////////////////////////////
@@ -725,7 +725,7 @@ namespace hpx { namespace parallel { namespace util {
         std::size_t base_idx, Iter it, std::size_t count, F&& f)
     {
         return hpx::parallel::util::detail::datapar_loop_idx_n<Iter>::call(
-            base_idx, it, count, std::forward<F>(f));
+            base_idx, it, count, HPX_FORWARD(F, f));
     }
 
     template <typename ExPolicy, typename Iter, typename CancelToken,
@@ -737,7 +737,7 @@ namespace hpx { namespace parallel { namespace util {
         F&& f)
     {
         return hpx::parallel::util::detail::datapar_loop_idx_n<Iter>::call(
-            base_idx, it, count, tok, std::forward<F>(f));
+            base_idx, it, count, tok, HPX_FORWARD(F, f));
     }
 }}}    // namespace hpx::parallel::util
 

--- a/libs/core/algorithms/include/hpx/parallel/datapar/transform_loop.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/datapar/transform_loop.hpp
@@ -567,7 +567,7 @@ namespace hpx { namespace parallel { namespace util {
                 }
 
                 return hpx::make_tuple(
-                    std::move(first1), std::move(first2), std::move(dest));
+                    HPX_MOVE(first1), HPX_MOVE(first2), HPX_MOVE(dest));
             }
 
             template <typename InIter1, typename InIter2, typename OutIter,
@@ -584,7 +584,7 @@ namespace hpx { namespace parallel { namespace util {
             {
                 return util::transform_binary_loop_ind_n<
                     hpx::execution::sequenced_policy>(
-                    first1, count, first2, dest, std::forward<F>(f));
+                    first1, count, first2, dest, HPX_FORWARD(F, f));
             }
         };
     }    // namespace detail
@@ -598,7 +598,7 @@ namespace hpx { namespace parallel { namespace util {
         InIter1 first1, std::size_t count, InIter2 first2, OutIter dest, F&& f)
     {
         return detail::datapar_transform_binary_loop_ind_n<InIter1,
-            InIter2>::call(first1, count, first2, dest, std::forward<F>(f));
+            InIter2>::call(first1, count, first2, dest, HPX_FORWARD(F, f));
     }
 
     namespace detail {
@@ -635,7 +635,7 @@ namespace hpx { namespace parallel { namespace util {
                 auto ret = util::transform_binary_loop_ind_n<
                     hpx::execution::par_simd_policy>(first1,
                     std::distance(first1, last1), first2, dest,
-                    std::forward<F>(f));
+                    HPX_FORWARD(F, f));
 
                 return util::in_in_out_result<InIter1, InIter2, OutIter>{
                     hpx::get<0>(ret), hpx::get<1>(ret), hpx::get<2>(ret)};
@@ -655,7 +655,7 @@ namespace hpx { namespace parallel { namespace util {
             {
                 return util::transform_binary_loop_ind<
                     hpx::execution::sequenced_policy>(
-                    first1, last1, first2, dest, std::forward<F>(f));
+                    first1, last1, first2, dest, HPX_FORWARD(F, f));
             }
 
             template <typename InIter1, typename InIter2, typename OutIter,
@@ -675,7 +675,7 @@ namespace hpx { namespace parallel { namespace util {
 
                 auto ret = util::transform_binary_loop_ind_n<
                     hpx::execution::par_simd_policy>(
-                    first1, count, first2, dest, std::forward<F>(f));
+                    first1, count, first2, dest, HPX_FORWARD(F, f));
 
                 return util::in_in_out_result<InIter1, InIter2, OutIter>{
                     hpx::get<0>(ret), hpx::get<1>(ret), hpx::get<2>(ret)};
@@ -695,7 +695,7 @@ namespace hpx { namespace parallel { namespace util {
             {
                 return util::transform_binary_loop_ind<
                     hpx::execution::sequenced_policy>(
-                    first1, last1, first2, last2, dest, std::forward<F>(f));
+                    first1, last1, first2, last2, dest, HPX_FORWARD(F, f));
             }
         };
     }    // namespace detail
@@ -709,7 +709,7 @@ namespace hpx { namespace parallel { namespace util {
         InIter1 first1, InIter1 last1, InIter2 first2, OutIter dest, F&& f)
     {
         return detail::datapar_transform_binary_loop_ind<InIter1,
-            InIter2>::call(first1, last1, first2, dest, std::forward<F>(f));
+            InIter2>::call(first1, last1, first2, dest, HPX_FORWARD(F, f));
     }
 
     template <typename ExPolicy, typename InIter1, typename InIter2,
@@ -723,7 +723,7 @@ namespace hpx { namespace parallel { namespace util {
     {
         return detail::datapar_transform_binary_loop_ind<InIter1,
             InIter2>::call(first1, last1, first2, last2, dest,
-            std::forward<F>(f));
+            HPX_FORWARD(F, f));
     }
 }}}    // namespace hpx::parallel::util
 #endif

--- a/libs/core/algorithms/include/hpx/parallel/spmd_block.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/spmd_block.hpp
@@ -163,7 +163,7 @@ namespace hpx { namespace lcos { namespace local {
             {
                 spmd_block block(
                     num_images_, image_id, *barrier_, *barriers_, *mtx_);
-                hpx::util::invoke(f_, HPX_MOVE(block), HPX_FORWARD(Ts, ts)...);
+                HPX_INVOKE(f_, HPX_MOVE(block), HPX_FORWARD(Ts, ts)...);
             }
         };
     }    // namespace detail

--- a/libs/core/algorithms/include/hpx/parallel/util/loop.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/util/loop.hpp
@@ -1176,7 +1176,7 @@ namespace hpx { namespace parallel { namespace util {
         {
             using cat = typename std::iterator_traits<Iter>::iterator_category;
             return detail::loop_idx_n<cat>::call(
-                base_idx, it, count, std::forward<F>(f));
+                base_idx, it, count, HPX_FORWARD(F, f));
         }
 
         template <typename Iter, typename CancelToken, typename F>
@@ -1187,7 +1187,7 @@ namespace hpx { namespace parallel { namespace util {
         {
             using cat = typename std::iterator_traits<Iter>::iterator_category;
             return detail::loop_idx_n<cat>::call(
-                base_idx, it, count, tok, std::forward<F>(f));
+                base_idx, it, count, tok, HPX_FORWARD(F, f));
         }
     };
 

--- a/libs/core/algorithms/include/hpx/parallel/util/result_types.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/util/result_types.hpp
@@ -168,7 +168,7 @@ namespace hpx { namespace parallel { namespace util {
             typename Enable = std::enable_if_t<std::is_convertible_v<T, T2>>>
         constexpr operator min_max_result<T2>() &&
         {
-            return {std::move(min), std::move(max)};
+            return {HPX_MOVE(min), HPX_MOVE(max)};
         }
 
         template <typename Archive>
@@ -411,8 +411,8 @@ namespace hpx { namespace parallel { namespace util {
                 typename hpx::tuple_element<0, iterator_tuple_type>::type>;
 
             return hpx::make_future<result_type>(
-                std::move(zipiter), [](ZipIter zipiter) {
-                    return get_min_max_result(std::move(zipiter));
+                HPX_MOVE(zipiter), [](ZipIter zipiter) {
+                    return get_min_max_result(HPX_MOVE(zipiter));
                 });
         }
 

--- a/libs/core/algorithms/include/hpx/parallel/util/scan_partitioner.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/util/scan_partitioner.hpp
@@ -384,7 +384,7 @@ namespace hpx { namespace parallel { namespace util {
 
                 try
                 {
-                    return f(std::move(workitems), std::move(finalitems));
+                    return f(HPX_MOVE(workitems), HPX_MOVE(finalitems));
                 }
                 catch (...)
                 {

--- a/libs/core/datastructures/include/hpx/datastructures/detail/small_vector.hpp
+++ b/libs/core/datastructures/include/hpx/datastructures/detail/small_vector.hpp
@@ -94,7 +94,7 @@ namespace hpx::detail {
         }
         memory_storage(memory_storage&& rhs) noexcept
           : memory_()    // data will be provided by small_vector ctor
-          , resource_(std::move(rhs.resource_))
+          , resource_(HPX_MOVE(rhs.resource_))
           , pool_(
                 std::data(memory_), std::size(memory_) * sizeof(T), &resource_)
           , allocator_(&pool_)
@@ -132,7 +132,7 @@ namespace hpx::detail {
             // be provided by the small_vector::operator= below
 
             // move allocator
-            resource_ = std::move(rhs.resource_);
+            resource_ = HPX_MOVE(rhs.resource_);
 
             // reconstruct the memory management infrastructure
             new (&pool_) buffer_resource_type(
@@ -229,7 +229,7 @@ namespace hpx::detail {
 
         small_vector(small_vector&& rhs) noexcept
           : storage_(rhs.storage_)
-          , data_(std::move(rhs.data_), storage_.allocator_)
+          , data_(HPX_MOVE(rhs.data_), storage_.allocator_)
         {
         }
 
@@ -258,11 +258,11 @@ namespace hpx::detail {
 
                 // reconstruct the memory management infrastructure for
                 // the new instance
-                storage_ = std::move(rhs.storage_);
+                storage_ = HPX_MOVE(rhs.storage_);
 
                 // fill the new instance with the moved rhs data
                 new (&data_)
-                    data_type(std::move(rhs.data_), storage_.allocator_);
+                    data_type(HPX_MOVE(rhs.data_), storage_.allocator_);
             }
             return *this;
         }
@@ -433,7 +433,7 @@ namespace hpx::detail {
         }
         iterator insert(const_iterator pos, value_type&& value)
         {
-            return data_.insert(pos, std::move(value));
+            return data_.insert(pos, HPX_MOVE(value));
         }
         iterator insert(
             const_iterator pos, size_type count, value_type const& value)
@@ -458,7 +458,7 @@ namespace hpx::detail {
         template <typename... Ts>
         iterator emplace(const_iterator pos, Ts&&... ts)
         {
-            return data_.emplace(pos, std::forward<Ts>(ts)...);
+            return data_.emplace(pos, HPX_FORWARD(Ts, ts)...);
         }
 
         iterator erase(const_iterator pos)
@@ -472,13 +472,13 @@ namespace hpx::detail {
         }
         void push_back(value_type&& value)
         {
-            data_.push_back(std::move(value));
+            data_.push_back(HPX_MOVE(value));
         }
 
         template <typename... Ts>
         reference emplace_back(Ts&&... ts)
         {
-            return data_.emplace_back(std::forward<Ts>(ts)...);
+            return data_.emplace_back(HPX_FORWARD(Ts, ts)...);
         }
 
         void pop_back()
@@ -500,9 +500,9 @@ namespace hpx::detail {
             // data.swap(other.data_);
             // explicitly move the objects as the MSVC standard library has a
             // bug preventing to swap two std::pmr::vectors
-            small_vector tmp = std::move(*this);
-            *this = std::move(other);
-            other = std::move(tmp);
+            small_vector tmp = HPX_MOVE(*this);
+            *this = HPX_MOVE(other);
+            other = HPX_MOVE(tmp);
         }
 
         friend bool operator==(small_vector const& lhs, small_vector const& rhs)

--- a/libs/core/futures/include/hpx/futures/future.hpp
+++ b/libs/core/futures/include/hpx/futures/future.hpp
@@ -1107,7 +1107,7 @@ namespace hpx {
         else
         {
             return f.then(hpx::launch::sync,
-                [conv = std::forward<Conv>(conv)](hpx::future<U>&& f) -> R {
+                [conv = HPX_FORWARD(Conv, conv)](hpx::future<U>&& f) -> R {
                     return HPX_INVOKE(conv, f.get());
                 });
         }
@@ -1402,7 +1402,7 @@ namespace hpx {
         else
         {
             return f.then(hpx::launch::sync,
-                [conv = std::forward<Conv>(conv)](
+                [conv = HPX_FORWARD(Conv, conv)](
                     hpx::shared_future<U> const& f) -> R {
                     return HPX_INVOKE(conv, f.get());
                 });

--- a/libs/core/futures/include/hpx/futures/future.hpp
+++ b/libs/core/futures/include/hpx/futures/future.hpp
@@ -1402,10 +1402,8 @@ namespace hpx {
         else
         {
             return f.then(hpx::launch::sync,
-                [conv = HPX_FORWARD(Conv, conv)](
-                    hpx::shared_future<U> const& f) -> R {
-                    return HPX_INVOKE(conv, f.get());
-                });
+                [conv = HPX_FORWARD(Conv, conv)](hpx::shared_future<U> const& f)
+                    -> R { return HPX_INVOKE(conv, f.get()); });
         }
     }
 

--- a/libs/core/synchronization/tests/unit/shared_mutex/thread_group.hpp
+++ b/libs/core/synchronization/tests/unit/shared_mutex/thread_group.hpp
@@ -78,7 +78,7 @@ namespace test {
         {
             std::lock_guard<mutex_type> guard(mtx_);
             std::unique_ptr<hpx::thread> new_thread(
-                new hpx::thread(std::forward<F>(f)));
+                new hpx::thread(HPX_FORWARD(F, f)));
             threads.push_back(new_thread.get());
             return new_thread.release();
         }

--- a/libs/full/resiliency_distributed/include/hpx/resiliency_distributed/async_replay_distributed.hpp
+++ b/libs/full/resiliency_distributed/include/hpx/resiliency_distributed/async_replay_distributed.hpp
@@ -87,7 +87,7 @@ namespace hpx { namespace resiliency { namespace experimental {
 
                         auto&& result = f.get();
 
-                        if (!hpx::util::invoke(this_->pred_, result))
+                        if (!HPX_INVOKE(this_->pred_, result))
                         {
                             // execute the task again if an error occurred and
                             // this was not the last attempt

--- a/libs/full/resiliency_distributed/include/hpx/resiliency_distributed/async_replicate_distributed.hpp
+++ b/libs/full/resiliency_distributed/include/hpx/resiliency_distributed/async_replicate_distributed.hpp
@@ -78,7 +78,7 @@ namespace hpx { namespace resiliency { namespace experimental {
                         else
                         {
                             auto&& result = f.get();
-                            if (hpx::util::invoke(pred, result))
+                            if (HPX_INVOKE(pred, result))
                             {
                                 valid_results.emplace_back(HPX_MOVE(result));
                             }
@@ -87,7 +87,7 @@ namespace hpx { namespace resiliency { namespace experimental {
 
                     if (!valid_results.empty())
                     {
-                        return hpx::util::invoke(
+                        return HPX_INVOKE(
                             HPX_FORWARD(Vote, vote), HPX_MOVE(valid_results));
                     }
 

--- a/libs/full/resiliency_distributed/tests/performance/replay/communicator.hpp
+++ b/libs/full/resiliency_distributed/tests/performance/replay/communicator.hpp
@@ -139,7 +139,7 @@ struct communicator
     {
         // Send our data to the neighbor n using fire and forget semantics
         // Synchronization happens when receiving values.
-        send[n].set(std::move(t), step);
+        send[n].set(HPX_MOVE(t), step);
     }
 
     hpx::future<T> get(neighbor n, std::size_t step)

--- a/libs/full/runtime_components/tests/unit/components/action_invoke_no_more_than.hpp
+++ b/libs/full/runtime_components/tests/unit/components/action_invoke_no_more_than.hpp
@@ -104,7 +104,7 @@ namespace hpx { namespace actions { namespace detail {
             return util::one_shot(
                 util::bind_back(&action_decorate_function::thread_function,
                     traits::action_decorate_function<action_wrapper>::call(
-                        lva, std::forward<F>(f))));
+                        lva, HPX_FORWARD(F, f))));
         }
 
         // If the action returns a future we wait on the semaphore as well,
@@ -124,7 +124,7 @@ namespace hpx { namespace actions { namespace detail {
             return util::one_shot(util::bind_back(
                 &action_decorate_function::thread_function_future,
                 traits::action_decorate_function<action_wrapper>::call(
-                    lva, std::forward<F>(f))));
+                    lva, HPX_FORWARD(F, f))));
         }
 
         ///////////////////////////////////////////////////////////////////////
@@ -134,7 +134,7 @@ namespace hpx { namespace actions { namespace detail {
         {
             typedef typename Action::result_type result_type;
             typedef traits::is_future<result_type> is_future;
-            return call(lva, std::forward<F>(f), is_future());
+            return call(lva, HPX_FORWARD(F, f), is_future());
         }
     };
 
@@ -152,7 +152,7 @@ namespace hpx { namespace actions { namespace detail {
         {
             if (id)
             {
-                hpx::set_lco_value(id, std::move(addr_), std::forward<T>(t));
+                hpx::set_lco_value(id, std::move(addr_), HPX_FORWARD(T, t));
             }
             construct_semaphore_type::get_sem().signal();
         }

--- a/libs/full/segmented_algorithms/include/hpx/parallel/segmented_algorithms/adjacent_find.hpp
+++ b/libs/full/segmented_algorithms/include/hpx/parallel/segmented_algorithms/adjacent_find.hpp
@@ -87,8 +87,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 }
                 FwdIter ending = traits::compose(sit, std::prev(end));
                 if (!found &&
-                    hpx::util::invoke(
-                        pred_projected, *ending, *std::next(ending)))
+                    HPX_INVOKE(pred_projected, *ending, *std::next(ending)))
                 {
                     found = true;
                     output = traits::compose(sit, std::prev(end));
@@ -113,7 +112,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                             }
                         }
                         ending = traits::compose(sit, std::prev(end));
-                        if (hpx::util::invoke(
+                        if (HPX_INVOKE(
                                 pred_projected, *ending, *std::next(ending)) &&
                             !found)
                         {
@@ -263,10 +262,12 @@ namespace hpx { namespace parallel { inline namespace v1 {
                     {
                         if (*it != last)
                             return *it;
-                        if (hpx::util::invoke(pred_projected,
+                        if (HPX_INVOKE(pred_projected,
                                 *std::prev(between_segments[i]),
                                 *(between_segments[i])))
+                        {
                             return std::prev(between_segments[i]);
+                        }
                         ++it;
                         i += 1;
                     }

--- a/libs/full/segmented_algorithms/include/hpx/parallel/segmented_algorithms/detail/reduce.hpp
+++ b/libs/full/segmented_algorithms/include/hpx/parallel/segmented_algorithms/detail/reduce.hpp
@@ -79,9 +79,8 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
             typedef typename std::iterator_traits<FwdIter>::reference reference;
             return util::accumulate<T>(
                 first, last,
-                [=](T const& res, reference next) -> T {
-                    return hpx::util::invoke(
-                        r, res, hpx::util::invoke(conv, next));
+                [=](T const& res, reference next) mutable -> T {
+                    return HPX_INVOKE(r, res, HPX_INVOKE(conv, next));
                 },
                 HPX_FORWARD(Convert, conv));
         }
@@ -97,15 +96,15 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
             return util::partitioner<ExPolicy, T>::call(
                 HPX_FORWARD(ExPolicy, policy), first,
                 std::distance(first, last),
-                [r, conv](FwdIter part_begin, std::size_t part_size) -> T {
-                    T val = hpx::util::invoke(conv, *part_begin);
+                [r, conv](
+                    FwdIter part_begin, std::size_t part_size) mutable -> T {
+                    T val = HPX_INVOKE(conv, *part_begin);
                     return util::accumulate_n(++part_begin, --part_size,
                         HPX_MOVE(val),
                         // MSVC14 bails out if r and conv are captured by
                         // reference
-                        [=](T const& res, reference next) -> T {
-                            return hpx::util::invoke(
-                                r, res, hpx::util::invoke(conv, next));
+                        [=](T const& res, reference next) mutable -> T {
+                            return HPX_INVOKE(r, res, HPX_INVOKE(conv, next));
                         });
                 },
                 hpx::unwrapping([r](std::vector<T>&& results) -> T {

--- a/libs/full/segmented_algorithms/include/hpx/parallel/segmented_algorithms/reduce.hpp
+++ b/libs/full/segmented_algorithms/include/hpx/parallel/segmented_algorithms/reduce.hpp
@@ -60,7 +60,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 local_iterator_type end = traits::local(last);
                 if (beg != end)
                 {
-                    overall_result = hpx::util::invoke(red_op, overall_result,
+                    overall_result = HPX_INVOKE(red_op, overall_result,
                         dispatch(traits::get_id(sit), algo, policy,
                             std::true_type(), beg, end, red_op));
                 }
@@ -72,7 +72,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 local_iterator_type end = traits::end(sit);
                 if (beg != end)
                 {
-                    overall_result = hpx::util::invoke(red_op, overall_result,
+                    overall_result = HPX_INVOKE(red_op, overall_result,
                         dispatch(traits::get_id(sit), algo, policy,
                             std::true_type(), beg, end, red_op));
                 }
@@ -84,10 +84,9 @@ namespace hpx { namespace parallel { inline namespace v1 {
                     end = traits::end(sit);
                     if (beg != end)
                     {
-                        overall_result =
-                            hpx::util::invoke(red_op, overall_result,
-                                dispatch(traits::get_id(sit), algo, policy,
-                                    std::true_type(), beg, end, red_op));
+                        overall_result = HPX_INVOKE(red_op, overall_result,
+                            dispatch(traits::get_id(sit), algo, policy,
+                                std::true_type(), beg, end, red_op));
                     }
                 }
 
@@ -96,7 +95,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 end = traits::local(last);
                 if (beg != end)
                 {
-                    overall_result = hpx::util::invoke(red_op, overall_result,
+                    overall_result = HPX_INVOKE(red_op, overall_result,
                         dispatch(traits::get_id(sit), algo, policy,
                             std::true_type(), beg, end, red_op));
                 }
@@ -172,7 +171,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
             }
 
             return result::get(dataflow(
-                [=](std::vector<shared_future<T>>&& r) -> T {
+                [=](std::vector<shared_future<T>>&& r) mutable -> T {
                     // handle any remote exceptions, will throw on error
                     std::list<std::exception_ptr> errors;
                     parallel::util::detail::handle_remote_exceptions<
@@ -180,8 +179,8 @@ namespace hpx { namespace parallel { inline namespace v1 {
 
                     // VS2015RC bails out if red_op is capture by ref
                     return detail::accumulate(r.begin(), r.end(), init,
-                        [=](T const& val, shared_future<T>& curr) {
-                            return hpx::util::invoke(red_op, val, curr.get());
+                        [=](T const& val, shared_future<T>& curr) mutable {
+                            return HPX_INVOKE(red_op, val, curr.get());
                         });
                 },
                 HPX_MOVE(segments)));

--- a/libs/full/segmented_algorithms/include/hpx/parallel/segmented_algorithms/transform_reduce.hpp
+++ b/libs/full/segmented_algorithms/include/hpx/parallel/segmented_algorithms/transform_reduce.hpp
@@ -61,7 +61,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 local_iterator_type end = traits::local(last);
                 if (beg != end)
                 {
-                    overall_result = hpx::util::invoke(red_op, overall_result,
+                    overall_result = HPX_INVOKE(red_op, overall_result,
                         dispatch(traits::get_id(sit), algo, policy,
                             std::true_type(), beg, end, red_op, conv_op));
                 }
@@ -73,7 +73,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 local_iterator_type end = traits::end(sit);
                 if (beg != end)
                 {
-                    overall_result = hpx::util::invoke(red_op, overall_result,
+                    overall_result = HPX_INVOKE(red_op, overall_result,
                         dispatch(traits::get_id(sit), algo, policy,
                             std::true_type(), beg, end, red_op, conv_op));
                 }
@@ -85,8 +85,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                     end = traits::end(sit);
                     if (beg != end)
                     {
-                        overall_result = hpx::util::invoke(red_op,
-                            overall_result,
+                        overall_result = HPX_INVOKE(red_op, overall_result,
                             dispatch(traits::get_id(sit), algo, policy,
                                 std::true_type(), beg, end, red_op, conv_op));
                     }
@@ -97,7 +96,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 end = traits::local(last);
                 if (beg != end)
                 {
-                    overall_result = hpx::util::invoke(red_op, overall_result,
+                    overall_result = HPX_INVOKE(red_op, overall_result,
                         dispatch(traits::get_id(sit), algo, policy,
                             std::true_type(), beg, end, red_op, conv_op));
                 }
@@ -223,7 +222,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 local_iterator_type1 end1 = traits1::local(last1);
                 if (beg1 != end1)
                 {
-                    overall_result = hpx::util::invoke(red_op, overall_result,
+                    overall_result = HPX_INVOKE(red_op, overall_result,
                         dispatch(traits1::get_id(sit1), algo, policy,
                             std::true_type(), beg1, end1, beg2, red_op,
                             conv_op));
@@ -237,7 +236,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 local_iterator_type1 end1 = traits1::end(sit1);
                 if (beg1 != end1)
                 {
-                    overall_result = hpx::util::invoke(red_op, overall_result,
+                    overall_result = HPX_INVOKE(red_op, overall_result,
                         dispatch(traits1::get_id(sit1), algo, policy,
                             std::true_type(), beg1, end1, beg2, red_op,
                             conv_op));
@@ -251,11 +250,10 @@ namespace hpx { namespace parallel { inline namespace v1 {
                     end1 = traits1::end(sit1);
                     if (beg1 != end1)
                     {
-                        overall_result =
-                            hpx::util::invoke(red_op, overall_result,
-                                dispatch(traits1::get_id(sit1), algo, policy,
-                                    std::true_type(), beg1, end1, beg2, red_op,
-                                    conv_op));
+                        overall_result = HPX_INVOKE(red_op, overall_result,
+                            dispatch(traits1::get_id(sit1), algo, policy,
+                                std::true_type(), beg1, end1, beg2, red_op,
+                                conv_op));
                     }
                 }
 
@@ -265,7 +263,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 end1 = traits1::local(last1);
                 if (beg1 != end1)
                 {
-                    overall_result = hpx::util::invoke(red_op, overall_result,
+                    overall_result = HPX_INVOKE(red_op, overall_result,
                         dispatch(traits1::get_id(sit1), algo, policy,
                             std::true_type(), beg1, end1, beg2, red_op,
                             conv_op));

--- a/tests/performance/local/CMakeLists.txt
+++ b/tests/performance/local/CMakeLists.txt
@@ -43,7 +43,7 @@ if(HPX_WITH_LIBCDS)
   set(libcds_hazard_pointer_overhead_FLAGS DEPENDENCIES iostreams_component)
 endif()
 
-if(HPX_WITH_DATAPAR_VC)
+if(HPX_WITH_CXX20_EXPERIMENTAL_SIMD OR HPX_WITH_DATAPAR_VC)
   list(APPEND benchmarks transform_reduce_binary_scaling)
   set(transform_reduce_binary_scaling_FLAGS DEPENDENCIES iostreams_component)
 endif()


### PR DESCRIPTION
- Also replace remaining `hpx::util::invoke` with `HPX_INVOKE`, where appropriate