### PR TITLE
Disambiguate namespace for MSVC

### DIFF
--- a/libs/core/algorithms/include/hpx/parallel/algorithms/detail/dispatch.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/detail/dispatch.hpp
@@ -153,7 +153,7 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
             catch (...)
             {
                 // this does not return
-                return hpx::parallel::detail::handle_exception<ExPolicy,
+                return hpx::parallel::v1::detail::handle_exception<ExPolicy,
                     local_result_type>::call();
             }
 #endif


### PR DESCRIPTION
This slipped into master while the Windows builders were not working