### PR TITLE
Use dynamic bitsets by default for CPU masks

### DIFF
--- a/.jenkins/cscs/env-clang-10.sh
+++ b/.jenkins/cscs/env-clang-10.sh
@@ -23,7 +23,6 @@ module load daint-mc
 spack load cmake@3.18.6
 spack load ninja@1.10.0
 
-configure_extra_options+=" -DHPX_WITH_MAX_CPU_COUNT=128"
 configure_extra_options+=" -DHPX_WITH_MALLOC=system"
 configure_extra_options+=" -DHPX_WITH_FETCH_ASIO=ON"
 configure_extra_options+=" -DHPX_WITH_COMPILER_WARNINGS=ON"

--- a/.jenkins/cscs/env-clang-12.sh
+++ b/.jenkins/cscs/env-clang-12.sh
@@ -23,7 +23,6 @@ module load daint-mc
 spack load cmake@3.18.6
 spack load ninja@1.10.0
 
-configure_extra_options+=" -DHPX_WITH_MAX_CPU_COUNT=128"
 configure_extra_options+=" -DHPX_WITH_MALLOC=system"
 configure_extra_options+=" -DHPX_WITH_FETCH_ASIO=ON"
 configure_extra_options+=" -DHPX_WITH_CXX_STANDARD=${CXX_STD}"

--- a/.jenkins/cscs/env-clang-13.sh
+++ b/.jenkins/cscs/env-clang-13.sh
@@ -23,7 +23,6 @@ module load daint-mc
 spack load cmake@3.18.6
 spack load ninja@1.10.0
 
-configure_extra_options+=" -DHPX_WITH_MAX_CPU_COUNT=128"
 configure_extra_options+=" -DHPX_WITH_MALLOC=system"
 configure_extra_options+=" -DHPX_WITH_FETCH_ASIO=ON"
 configure_extra_options+=" -DHPX_WITH_CXX_STANDARD=${CXX_STD}"

--- a/.jenkins/cscs/env-clang-7.sh
+++ b/.jenkins/cscs/env-clang-7.sh
@@ -23,7 +23,7 @@ module load daint-mc
 spack load cmake@3.18.6
 spack load ninja@1.10.0
 
-configure_extra_options+=" -DHPX_WITH_MAX_CPU_COUNT="
+configure_extra_options+=" -DHPX_WITH_MAX_CPU_COUNT=128"
 configure_extra_options+=" -DHPX_WITH_MALLOC=system"
 configure_extra_options+=" -DHPX_WITH_FETCH_ASIO=ON"
 configure_extra_options+=" -DHPX_WITH_CXX_STANDARD=${CXX_STD}"

--- a/.jenkins/cscs/env-clang-8.sh
+++ b/.jenkins/cscs/env-clang-8.sh
@@ -23,7 +23,6 @@ module load daint-mc
 spack load cmake@3.18.6
 spack load ninja@1.10.0
 
-configure_extra_options+=" -DHPX_WITH_MAX_CPU_COUNT=128"
 configure_extra_options+=" -DHPX_WITH_MALLOC=system"
 configure_extra_options+=" -DHPX_WITH_FETCH_ASIO=ON"
 configure_extra_options+=" -DHPX_WITH_COMPILER_WARNINGS=ON"

--- a/.jenkins/cscs/env-clang-9.sh
+++ b/.jenkins/cscs/env-clang-9.sh
@@ -23,7 +23,6 @@ module load daint-mc
 spack load cmake@3.18.6
 spack load ninja@1.10.0
 
-configure_extra_options+=" -DHPX_WITH_MAX_CPU_COUNT=128"
 configure_extra_options+=" -DHPX_WITH_MALLOC=system"
 configure_extra_options+=" -DHPX_WITH_FETCH_ASIO=ON"
 configure_extra_options+=" -DHPX_WITH_COMPILER_WARNINGS=ON"

--- a/.jenkins/cscs/env-clang-cuda.sh
+++ b/.jenkins/cscs/env-clang-cuda.sh
@@ -18,6 +18,7 @@ spack load ninja@1.10.0
 export CXX=`which CC`
 export CC=`which cc`
 
+configure_extra_options+=" -DHPX_WITH_MAX_CPU_COUNT=64"
 configure_extra_options+=" -DHPX_WITH_CUDA=ON"
 configure_extra_options+=" -DHPX_WITH_MALLOC=system"
 configure_extra_options+=" -DHPX_WITH_FETCH_ASIO=ON"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -650,11 +650,11 @@ endif()
 
 # Thread Manager related build options
 
-set(HPX_MAX_CPU_COUNT_DEFAULT "64")
+set(HPX_MAX_CPU_COUNT_DEFAULT "")
 hpx_option(
   HPX_WITH_MAX_CPU_COUNT
   STRING
-  "HPX applications will not use more that this number of OS-Threads (empty string means dynamic) (default: ${HPX_MAX_CPU_COUNT_DEFAULT})"
+  "HPX applications will not use more that this number of OS-Threads (empty string means dynamic) (default: \"${HPX_MAX_CPU_COUNT_DEFAULT}\")"
   "${HPX_MAX_CPU_COUNT_DEFAULT}"
   CATEGORY "Thread Manager"
   ADVANCED

--- a/tools/perftests_ci/driver.py
+++ b/tools/perftests_ci/driver.py
@@ -55,7 +55,6 @@ def build(build_type, environment, target, source_dir, build_dir, install_dir,
     env.set_cmake_arg('PYUTILS_HPX_WITH_FETCH_ASIO', 'ON')
     env.set_cmake_arg('PYUTILS_HPX_WITH_MALLOC', 'jemalloc')
     env.set_cmake_arg('PYUTILS_HPX_WITH_TESTS_BENCHMARKS', 'ON')
-    env.set_cmake_arg('PYUTILS_HPX_WITH_MAX_CPU_COUNT', '72')
     env.set_cmake_arg('PYUTILS_CMAKE_BUILD_TYPE', 'Release')
     env.set_cmake_arg('-GNinja', '')
     # For possibly more stable/focused results


### PR DESCRIPTION
Maybe fixes #5661.

Opening this as a draft only to see the performance test CI results.