### PR TITLE
Change logging errors to warnings in schedulers

### DIFF
--- a/libs/core/schedulers/include/hpx/schedulers/local_queue_scheduler.hpp
+++ b/libs/core/schedulers/include/hpx/schedulers/local_queue_scheduler.hpp
@@ -845,17 +845,17 @@ namespace hpx { namespace threads { namespace policies {
                 {
                     if (running)
                     {
-                        LTM_(error).format("pool({}), scheduler({}), "
-                                           "queue({}): no new work available, "
-                                           "are we deadlocked?",
+                        LTM_(warning).format(
+                            "pool({}), scheduler({}), queue({}): no new work "
+                            "available, are we deadlocked?",
                             *this->get_parent_pool(), *this, num_thread);
                     }
                     else
                     {
-                        LHPX_CONSOLE_(hpx::util::logging::level::error)
-                            .format("  [TM] pool({}), scheduler({}), "
-                                    "queue({}): no new work available, are we "
-                                    "deadlocked?\n",
+                        LHPX_CONSOLE_(hpx::util::logging::level::warning)
+                            .format(
+                                "  [TM] pool({}), scheduler({}), queue({}): no "
+                                "new work available, are we deadlocked?\n",
                                 *this->get_parent_pool(), *this, num_thread);
                     }
                 }

--- a/libs/core/schedulers/include/hpx/schedulers/queue_helpers.hpp
+++ b/libs/core/schedulers/include/hpx/schedulers/queue_helpers.hpp
@@ -73,13 +73,13 @@ namespace hpx { namespace threads { namespace policies {
                     {
                         if (running)
                         {
-                            LTM_(error).format("Listing suspended threads "
-                                               "while queue ({}) is empty:",
+                            LTM_(warning).format("Listing suspended threads "
+                                                 "while queue ({}) is empty:",
                                 num_thread);
                         }
                         else
                         {
-                            LHPX_CONSOLE_(hpx::util::logging::level::error)
+                            LHPX_CONSOLE_(hpx::util::logging::level::warning)
                                 .format("  [TM] Listing suspended threads "
                                         "while queue ({}) is empty:\n",
                                     num_thread);
@@ -89,7 +89,7 @@ namespace hpx { namespace threads { namespace policies {
 
                     if (running)
                     {
-                        LTM_(error)
+                        LTM_(warning)
                             .format("queue({}): {}({:08x}.{:02x}/{:08x})",
                                 num_thread, get_thread_state_name(state), *it,
                                 thrd->get_thread_phase(),
@@ -102,7 +102,7 @@ namespace hpx { namespace threads { namespace policies {
                     }
                     else
                     {
-                        LHPX_CONSOLE_(hpx::util::logging::level::error)
+                        LHPX_CONSOLE_(hpx::util::logging::level::warning)
                             .format("queue({}): {}({:08x}.{:02x}/{:08x})",
                                 num_thread, get_thread_state_name(state), *it,
                                 thrd->get_thread_phase(),

--- a/libs/core/schedulers/include/hpx/schedulers/static_queue_scheduler.hpp
+++ b/libs/core/schedulers/include/hpx/schedulers/static_queue_scheduler.hpp
@@ -141,7 +141,7 @@ namespace hpx { namespace threads { namespace policies {
 
                 if (HPX_UNLIKELY(suspended_only))
                 {
-                    LTM_(error).format(
+                    LTM_(warning).format(
                         "queue({}): no new work available, are we deadlocked?",
                         num_thread);
                 }

--- a/libs/core/threading_base/src/set_thread_state.cpp
+++ b/libs/core/threading_base/src/set_thread_state.cpp
@@ -242,9 +242,10 @@ namespace hpx { namespace threads { namespace detail {
 
             // state has changed since we fetched it from the thread, retry
             // NOLINTNEXTLINE(bugprone-branch-clone)
-            LTM_(error).format("set_thread_state: state has been changed since "
-                               "it was fetched, retrying, thread({}), "
-                               "description({}), new state({}), old state({})",
+            LTM_(warning).format(
+                "set_thread_state: state has been changed since it was "
+                "fetched, retrying, thread({}), description({}), new "
+                "state({}), old state({})",
                 get_thread_id_data(thrd),
                 get_thread_id_data(thrd)->get_description(),
                 get_thread_state_name(new_state),


### PR DESCRIPTION
None of the changed messages are errors. They may indicate a problem, but are not errors in themselves.