### PR TITLE
Relax constraints on `execution::when_all`

### DIFF
--- a/libs/core/execution/include/hpx/execution/algorithms/detail/single_result.hpp
+++ b/libs/core/execution/include/hpx/execution/algorithms/detail/single_result.hpp
@@ -67,4 +67,20 @@ namespace hpx {
     template <typename Variants>
     using single_result_non_void_t =
         typename single_result_non_void<Variants>::type;
+
+    template <typename Variants>
+    struct single_variant
+    {
+        static_assert(sizeof(Variants) == 0,
+            "expected a single variant sender_traits<>::value_types");
+    };
+
+    template <typename T>
+    struct single_variant<hpx::util::pack<T>>
+    {
+        using type = T;
+    };
+
+    template <typename Variants>
+    using single_variant_t = typename single_variant<Variants>::type;
 }}}}    // namespace hpx::execution::experimental::detail

--- a/libs/core/execution/include/hpx/execution/algorithms/when_all.hpp
+++ b/libs/core/execution/include/hpx/execution/algorithms/when_all.hpp
@@ -195,9 +195,20 @@ namespace hpx { namespace execution { namespace experimental {
                 // The offset at which we start to emplace values sent by the
                 // ith predecessor sender.
                 static constexpr std::size_t i_storage_offset = 0;
+#if !defined(HPX_CUDA_VERSION)
                 // The number of values sent by the ith predecessor sender.
                 static constexpr std::size_t sender_pack_size =
                     sender_pack_size_at_index<i>;
+#else
+                // nvcc does not like using the helper sender_pack_size_at_index
+                // here and complains about incmplete types. Lifting the helper
+                // explicitly in here works.
+                static constexpr std::size_t sender_pack_size =
+                    single_variant_t<
+                        typename sender_traits<hpx::util::at_index_t<i,
+                            Senders...>>::template value_types<hpx::util::pack,
+                            hpx::util::pack>>::size;
+#endif
 
                 // Number of predecessor senders that have not yet called any of
                 // the set signals.

--- a/libs/core/execution/tests/unit/algorithm_when_all.cpp
+++ b/libs/core/execution/tests/unit/algorithm_when_all.cpp
@@ -58,6 +58,101 @@ int main()
 
     {
         std::atomic<bool> set_value_called{false};
+        auto s = ex::when_all(
+            ex::just(), ex::just(std::string("hello")), ex::just(3.14));
+        auto f = [](std::string y, double z) {
+            HPX_TEST_EQ(y, std::string("hello"));
+            HPX_TEST_EQ(z, 3.14);
+        };
+        auto r = callback_receiver<decltype(f)>{f, set_value_called};
+        auto os = ex::connect(std::move(s), std::move(r));
+        ex::start(os);
+        HPX_TEST(set_value_called);
+    }
+
+    {
+        std::atomic<bool> set_value_called{false};
+        auto s = ex::when_all(ex::just(42), ex::just(), ex::just(3.14));
+        auto f = [](int x, double z) {
+            HPX_TEST_EQ(x, 42);
+            HPX_TEST_EQ(z, 3.14);
+        };
+        auto r = callback_receiver<decltype(f)>{f, set_value_called};
+        auto os = ex::connect(std::move(s), std::move(r));
+        ex::start(os);
+        HPX_TEST(set_value_called);
+    }
+
+    {
+        std::atomic<bool> set_value_called{false};
+        auto s = ex::when_all(ex::just(), ex::just(), ex::just());
+        auto f = []() {};
+        auto r = callback_receiver<decltype(f)>{f, set_value_called};
+        auto os = ex::connect(std::move(s), std::move(r));
+        ex::start(os);
+        HPX_TEST(set_value_called);
+    }
+
+    {
+        std::atomic<bool> set_value_called{false};
+        auto s = ex::when_all(
+            ex::just(42), ex::just(std::string("hello")), ex::just());
+        auto f = [](int x, std::string y) {
+            HPX_TEST_EQ(x, 42);
+            HPX_TEST_EQ(y, std::string("hello"));
+        };
+        auto r = callback_receiver<decltype(f)>{f, set_value_called};
+        auto os = ex::connect(std::move(s), std::move(r));
+        ex::start(os);
+        HPX_TEST(set_value_called);
+    }
+
+    {
+        std::atomic<bool> set_value_called{false};
+        auto s = ex::when_all(ex::just(42, std::string("hello"), 3.14));
+        auto f = [](int x, std::string y, double z) {
+            HPX_TEST_EQ(x, 42);
+            HPX_TEST_EQ(y, std::string("hello"));
+            HPX_TEST_EQ(z, 3.14);
+        };
+        auto r = callback_receiver<decltype(f)>{f, set_value_called};
+        auto os = ex::connect(std::move(s), std::move(r));
+        ex::start(os);
+        HPX_TEST(set_value_called);
+    }
+
+    {
+        std::atomic<bool> set_value_called{false};
+        auto s =
+            ex::when_all(ex::just(42, std::string("hello")), ex::just(3.14));
+        auto f = [](int x, std::string y, double z) {
+            HPX_TEST_EQ(x, 42);
+            HPX_TEST_EQ(y, std::string("hello"));
+            HPX_TEST_EQ(z, 3.14);
+        };
+        auto r = callback_receiver<decltype(f)>{f, set_value_called};
+        auto os = ex::connect(std::move(s), std::move(r));
+        ex::start(os);
+        HPX_TEST(set_value_called);
+    }
+
+    {
+        std::atomic<bool> set_value_called{false};
+        auto s = ex::when_all(ex::just(), ex::just(42, std::string("hello")),
+            ex::just(), ex::just(3.14), ex::just());
+        auto f = [](int x, std::string y, double z) {
+            HPX_TEST_EQ(x, 42);
+            HPX_TEST_EQ(y, std::string("hello"));
+            HPX_TEST_EQ(z, 3.14);
+        };
+        auto r = callback_receiver<decltype(f)>{f, set_value_called};
+        auto os = ex::connect(std::move(s), std::move(r));
+        ex::start(os);
+        HPX_TEST(set_value_called);
+    }
+
+    {
+        std::atomic<bool> set_value_called{false};
         auto s =
             ex::when_all(ex::just(custom_type_non_default_constructible(42)));
         auto f = [](auto x) { HPX_TEST_EQ(x.x, 42); };

--- a/libs/core/type_support/include/hpx/type_support/pack.hpp
+++ b/libs/core/type_support/include/hpx/type_support/pack.hpp
@@ -280,6 +280,11 @@ namespace hpx { namespace util {
         template <typename... Packs>
         using concat_t = typename concat<Packs...>::type;
 
+        /// Concatenate the elements in the given packs into a single pack and then
+        /// remove duplicates.
+        template <typename... Packs>
+        using unique_concat_t = unique_t<concat_t<Packs...>>;
+
         template <typename Pack>
         struct concat_pack_of_packs;
 
@@ -289,13 +294,25 @@ namespace hpx { namespace util {
             using type = typename concat<Ts...>::type;
         };
 
-        template <typename... Packs>
-        using unique_concat_t = unique_t<concat_t<Packs...>>;
-
-        /// Concatenate the packs in the given pack into a single pack.
+        /// Concatenate the packs in the given pack into a single pack. The
+        /// outer pack is discarded.
         template <typename Pack>
         using concat_pack_of_packs_t =
             typename concat_pack_of_packs<Pack>::type;
+
+        template <typename Pack>
+        struct concat_inner_packs;
+
+        template <template <typename...> class Pack, typename... Ts>
+        struct concat_inner_packs<Pack<Ts...>>
+        {
+            using type = Pack<typename concat<Ts...>::type>;
+        };
+
+        /// Concatenate the packs in the given pack into a single pack. The
+        /// outer pack is kept.
+        template <typename Pack>
+        using concat_inner_packs_t = typename concat_inner_packs<Pack>::type;
 
         template <typename Pack, typename T>
         struct prepend;
@@ -322,5 +339,19 @@ namespace hpx { namespace util {
         /// Append a given type to the given pack.
         template <typename Pack, typename T>
         using append_t = typename prepend<Pack, T>::type;
+
+        template <template <typename...> class NewPack, typename OldPack>
+        struct change_pack;
+
+        template <template <typename...> class NewPack,
+            template <typename...> class OldPack, typename... Ts>
+        struct change_pack<NewPack, OldPack<Ts...>>
+        {
+            using type = NewPack<Ts...>;
+        };
+
+        /// Change a OldPack<Ts...> to NewPack<Ts...>
+        template <template <typename...> class NewPack, typename OldPack>
+        using change_pack_t = typename change_pack<NewPack, OldPack>::type;
     }    // namespace detail
 }}       // namespace hpx::util


### PR DESCRIPTION
## Proposed Changes

Previously `execution::when_all` required all predecessors to send exactly one variant with exactly one type. This relaxes it to allow exactly one variant with any number of types (including zero). This brings it in line with P2300 and makes it much closer to `dataflow` (and much more useful).

## Checklist

Not all points below apply to all pull requests.

- [x] I have added a new feature and have added tests to go along with it.
- [ ] I have fixed a bug and have added a regression test.
- [ ] I have added a test using random numbers; I have made sure it uses a seed, and that random numbers generated are valid inputs for the tests.
