### PR TITLE
Fix compilation of service executors with nvcc

### DIFF
--- a/libs/core/executors/include/hpx/executors/service_executors.hpp
+++ b/libs/core/executors/include/hpx/executors/service_executors.hpp
@@ -61,9 +61,14 @@ namespace hpx { namespace parallel { namespace execution { namespace detail {
                     HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...);
             auto t = std::make_shared<post_wrapper_helper<decltype(f_wrapper)>>(
                 HPX_MOVE(f_wrapper));
+#if defined(HPX_COMPUTE_HOST_CODE)
             pool_->get_io_service().post(hpx::util::bind_front(
                 &post_wrapper_helper<decltype(f_wrapper)>::invoke,
                 HPX_MOVE(t)));
+#else
+            HPX_ASSERT_MSG(
+                false, "Attempting to use io_service_pool in device code");
+#endif
         }
 
         template <typename F, typename... Ts>
@@ -80,10 +85,15 @@ namespace hpx { namespace parallel { namespace execution { namespace detail {
             auto t = std::make_shared<
                 async_execute_wrapper_helper<decltype(f_wrapper), result_type>>(
                 HPX_MOVE(f_wrapper));
+#if defined(HPX_COMPUTE_HOST_CODE)
             pool_->get_io_service().post(hpx::util::bind_front(
                 &async_execute_wrapper_helper<decltype(f_wrapper),
                     result_type>::invoke,
                 t));
+#else
+            HPX_ASSERT_MSG(
+                false, "Attempting to use io_service_pool in device code");
+#endif
 
             return t->p_.get_future();
         }

--- a/libs/core/executors/tests/regressions/CMakeLists.txt
+++ b/libs/core/executors/tests/regressions/CMakeLists.txt
@@ -1,5 +1,29 @@
-# Copyright (c) 2020 The STE||AR-Group
+# Copyright (c) 2021 ETH Zurich
 #
 # SPDX-License-Identifier: BSL-1.0
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+if(HPX_WITH_COMPILE_ONLY_TESTS)
+  set(compile_tests)
+  if(HPX_WITH_CUDA OR HPX_WITH_HIP)
+    list(APPEND compile_tests service_executor_cuda)
+    set(service_executor_cuda_CUDA ON)
+  endif()
+
+  foreach(compile_test ${compile_tests})
+    if(${${compile_test}_CUDA})
+      set(sources ${compile_test}.cu)
+    else()
+      set(sources ${compile_test}.cpp)
+    endif()
+
+    source_group("Source Files" FILES ${sources})
+
+    add_hpx_regression_compile_test(
+      "modules.executors" ${compile_test}
+      SOURCES ${sources} ${${compile_test}_FLAGS}
+      FOLDER "Tests/Regressions/Modules/Core/Executors/CompileOnly"
+    )
+  endforeach()
+endif()

--- a/libs/core/executors/tests/regressions/service_executor_cuda.cu
+++ b/libs/core/executors/tests/regressions/service_executor_cuda.cu
@@ -1,0 +1,13 @@
+//  Copyright (c) 2021 Gregor Daiss
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/executors/service_executors.hpp>
+
+int main()
+{
+    hpx::parallel::execution::detail::service_executor exec{nullptr};
+    exec.async_execute([]{}).get();
+}


### PR DESCRIPTION
Despite the service executors not being marked as device code, nvcc manages to fail to compile the service executors. Since the service executors can't be used on the device I've simply disabled the piece of code that triggers the error.

An example of the failure (thanks @G-071!) is the following:

```
/data/scratch/daissgr/ModernTiger/build/hpx/include/asio/detail/handler_work.hpp(482): error: more than one partial specialization matches the template argument list of class "asio::detail::handler_work_base<asio::io_context::executor_type, void, asio::io_context, asio::executor, void>"            "asio::detail::handler_work_base<Executor, CandidateExecutor, IoContext, PolymorphicExecutor, std::enable_if<<expression>, void>::type>"            "asio::detail::handler_work_base<Executor, void, IoContext, PolymorphicExecutor, std::enable_if<std::is_same<Executor, IoContext::executor_type>::value, void>::type>"          detected during:            instantiation of class "asio::detail::handler_work<Handler, IoExecutor, std::enable_if<std::is_same<asio::associated_executor<Handler, IoExecutor>::asio_associated_executor_is_unspecialised, void>::value, void>::type> [with Handler=hpx::util::detail::bound_front<void (hpx::parallel::execution::detail::service_executor::async_execute_wrapper_helper<hpx::util::unique_function_nonser<void ()>, void>::*)(), hpx::util::pack_c<std::size_t, 0UL>, std::shared_ptr<hpx::parallel::execution::detail::service_executor::async_execute_wrapper_helper<hpx::util::unique_function_nonser<void ()>, void>>>, IoExecutor=asio::io_context::executor_type]"/data/scratch/daissgr/ModernTiger/build/hpx/include/asio/detail/completion_handler.hpp(80): here
            instantiation of class "asio::detail::completion_handler<Handler, IoExecutor> [with Handler=hpx::util::detail::bound_front<void (hpx::parallel::execution::detail::service_executor::async_execute_wrapper_helper<hpx::util::unique_function_nonser<void ()>, void>::*)(), hpx::util::pack_c<std::size_t, 0UL>, std::shared_ptr<hpx::parallel::execution::detail::service_executor::async_execute_wrapper_helper<hpx::util::unique_function_nonser<void ()>, void>>>, IoExecutor=asio::io_context::executor_type]"/data/scratch/daissgr/ModernTiger/build/hpx/include/asio/impl/io_context.hpp(183): here
            instantiation of "void asio::io_context::initiate_post::operator()(LegacyCompletionHandler &&, asio::io_context *) const [with LegacyCompletionHandler=hpx::util::detail::bound_front<void (hpx::parallel::execution::detail::service_executor::async_execute_wrapper_helper<hpx::util::unique_function_nonser<void ()>, void>::*)(), hpx::util::pack_c<std::size_t, 0UL>, std::shared_ptr<hpx::parallel::execution::detail::service_executor::async_execute_wrapper_helper<hpx::util::unique_function_nonser<void ()>, void>>>]"/data/scratch/daissgr/ModernTiger/build/hpx/include/asio/async_result.hpp(153): here
            instantiation of "asio::async_result<CompletionToken, Signature>::return_type asio::async_result<CompletionToken, Signature>::initiate(Initiation &&, RawCompletionToken &&, Args &&...) [with CompletionToken=hpx::util::detail::bound_front<void (hpx::parallel::execution::detail::service_executor::async_execute_wrapper_helper<hpx::util::unique_function_nonser<void ()>, void>::*)(), hpx::util::pack_c<std::size_t, 0UL>, std::shared_ptr<hpx::parallel::execution::detail::service_executor::async_execute_wrapper_helper<hpx::util::unique_function_nonser<void ()>, void>>>, Signature=void (), Initiation=asio::io_context::initiate_post, RawCompletionToken=hpx::util::detail::bound_front<void (hpx::parallel::execution::detail::service_executor::async_execute_wrapper_helper<hpx::util::unique_function_nonser<void ()>, void>::*)(), hpx::util::pack_c<std::size_t, 0UL>, std::shared_ptr<hpx::parallel::execution::detail::service_executor::async_execute_wrapper_helper<hpx::util::unique_function_nonser<void ()>, void>>>, Args=<asio::io_context *>]"/data/scratch/daissgr/ModernTiger/build/hpx/include/asio/async_result.hpp(366): here
            instantiation of "asio::constraint<asio::detail::async_result_has_initiate_memfn<CompletionToken, Signature>::value, decltype((<expression>))>::type asio::async_initiate<CompletionToken,Signature,Initiation,Args...>(Initiation &&, CompletionToken &, Args &&...)[with CompletionToken=hpx::util::detail::bound_front<void (hpx::parallel::execution::detail::service_executor::async_execute_wrapper_helper<hpx::util::unique_function_nonser<void ()>, void>::*)(), hpx::util::pack_c<std::size_t, 0UL>, std::shared_ptr<hpx::parallel::execution::detail::service_executor::async_execute_wrapper_helper<hpx::util::unique_function_nonser<void ()>, void>>>, Signature=void (), Initiation=asio::io_context::initiate_post, Args=<asio::io_context *>]"/data/scratch/daissgr/ModernTiger/build/hpx/include/hpx/runtime_local/run_as_os_thread.hpp(29): here
            instantiation of "hpx::lcos::future<hpx::util::invoke_result<F, Ts...>::type> hpx::threads::run_as_os_thread(F &&, Ts &&...) [with F=lambda [](integer)->void, Ts=<int &>]"/data/scratch/daissgr/ModernTiger/src/octotiger/src/io/silo_out.cpp(168): here
```

The ambiguity that nvcc complains about seems to me like bogus. This fails with both nvcc 11.0 and nvcc 11.2.

## Checklist

Not all points below apply to all pull requests.

- [ ] I have added a new feature and have added tests to go along with it.
- [X] I have fixed a bug and have added a regression test.
- [ ] I have added a test using random numbers; I have made sure it uses a seed, and that random numbers generated are valid inputs for the tests.
