### PR TITLE
Fix `fork_join_executor` with dynamic schedule

### DIFF
--- a/libs/core/executors/CMakeLists.txt
+++ b/libs/core/executors/CMakeLists.txt
@@ -64,7 +64,9 @@ set(executors_compat_headers
 )
 # cmake-format: on
 
-set(executors_sources current_executor.cpp exception_list_callbacks.cpp)
+set(executors_sources current_executor.cpp exception_list_callbacks.cpp
+                      fork_join_executor.cpp
+)
 
 include(HPX_AddModule)
 add_hpx_module(

--- a/libs/core/executors/include/hpx/executors/fork_join_executor.hpp
+++ b/libs/core/executors/include/hpx/executors/fork_join_executor.hpp
@@ -401,9 +401,10 @@ namespace hpx { namespace execution { namespace experimental {
                                 invoke_helper(index_pack_type{},
                                     element_function, *it, argument_pack);
                             }
-                            set_state(thread_states, thread_index,
-                                thread_state::idle);
                         }
+
+                        set_state(
+                            thread_states, thread_index, thread_state::idle);
                     }
                     catch (...)
                     {

--- a/libs/core/executors/include/hpx/executors/fork_join_executor.hpp
+++ b/libs/core/executors/include/hpx/executors/fork_join_executor.hpp
@@ -27,6 +27,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <exception>
+#include <iosfwd>
 #include <memory>
 #include <type_traits>
 #include <utility>
@@ -534,6 +535,9 @@ namespace hpx { namespace execution { namespace experimental {
         {
         }
     };
+
+    HPX_CORE_EXPORT std::ostream& operator<<(
+        std::ostream& os, fork_join_executor::loop_schedule const& schedule);
 }}}    // namespace hpx::execution::experimental
 
 namespace hpx { namespace parallel { namespace execution {

--- a/libs/core/executors/include/hpx/executors/fork_join_executor.hpp
+++ b/libs/core/executors/include/hpx/executors/fork_join_executor.hpp
@@ -483,7 +483,7 @@ namespace hpx { namespace execution { namespace experimental {
         };
 
     private:
-        std::shared_ptr<shared_data> shared_data_;
+        std::shared_ptr<shared_data> shared_data_ = nullptr;
 
     public:
         template <typename F, typename S, typename... Ts>
@@ -519,7 +519,8 @@ namespace hpx { namespace execution { namespace experimental {
         /// \brief Construct a fork_join_executor.
         ///
         /// \param priority The priority of the worker threads.
-        /// \param stacksize The stacksize of the worker threads.
+        /// \param stacksize The stacksize of the worker threads. Must not be
+        ///                  nostack.
         /// \param schedule The loop schedule of the parallel regions.
         /// \param yield_delay The time after which the executor yields to
         ///        other work if it hasn't received any new work for bulk
@@ -530,9 +531,18 @@ namespace hpx { namespace execution { namespace experimental {
                 threads::thread_stacksize::small_,
             loop_schedule schedule = loop_schedule::static_,
             std::chrono::nanoseconds yield_delay = std::chrono::milliseconds(1))
-          : shared_data_(
-                new shared_data(priority, stacksize, schedule, yield_delay))
         {
+            if (stacksize == threads::thread_stacksize::nostack)
+            {
+                HPX_THROW_EXCEPTION(bad_parameter,
+                    "fork_join_executor::fork_join_executor",
+                    "The fork_join_executor does not support using "
+                    "thread_stacksize::nostack as the stacksize (stackful "
+                    "threads are required to yield correctly when idle)");
+            }
+
+            shared_data_ = std::make_shared<shared_data>(
+                priority, stacksize, schedule, yield_delay);
         }
     };
 

--- a/libs/core/executors/src/fork_join_executor.cpp
+++ b/libs/core/executors/src/fork_join_executor.cpp
@@ -1,0 +1,36 @@
+//  Copyright (c) 2021 ETH Zurich
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/executors/fork_join_executor.hpp>
+
+#include <ostream>
+
+namespace hpx::execution::experimental {
+    std::ostream& operator<<(
+        std::ostream& os, fork_join_executor::loop_schedule const& schedule)
+    {
+        switch (schedule)
+        {
+        case fork_join_executor::loop_schedule::static_:
+            os << "static";
+            break;
+        case fork_join_executor::loop_schedule::dynamic:
+            os << "dynamic";
+            break;
+        default:
+            os << "<unknown>";
+            break;
+        }
+
+        os << " ("
+           << static_cast<
+                  std::underlying_type_t<fork_join_executor::loop_schedule>>(
+                  schedule)
+           << ")";
+
+        return os;
+    }
+}    // namespace hpx::execution::experimental

--- a/libs/core/executors/tests/unit/fork_join_executor.cpp
+++ b/libs/core/executors/tests/unit/fork_join_executor.cpp
@@ -16,10 +16,14 @@
 #include <atomic>
 #include <cstddef>
 #include <cstdlib>
+#include <iostream>
 #include <iterator>
 #include <numeric>
 #include <string>
+#include <utility>
 #include <vector>
+
+using hpx::execution::experimental::fork_join_executor;
 
 static std::atomic<std::size_t> count{0};
 
@@ -30,9 +34,10 @@ void bulk_test(int, int passed_through)    //-V813
     HPX_TEST_EQ(passed_through, 42);
 }
 
-void test_bulk_sync()
+template <typename... ExecutorArgs>
+void test_bulk_sync(ExecutorArgs&&... args)
 {
-    using executor = hpx::execution::experimental::fork_join_executor;
+    std::cerr << "test_bulk_sync\n";
 
     count = 0;
     std::size_t const n = 107;
@@ -42,7 +47,7 @@ void test_bulk_sync()
     using hpx::util::placeholders::_1;
     using hpx::util::placeholders::_2;
 
-    executor exec;
+    fork_join_executor exec{std::forward<ExecutorArgs>(args)...};
     hpx::parallel::execution::bulk_sync_execute(
         exec, hpx::util::bind(&bulk_test, _1, _2), v, 42);
     HPX_TEST_EQ(count.load(), n);
@@ -51,9 +56,10 @@ void test_bulk_sync()
     HPX_TEST_EQ(count.load(), 2 * n);
 }
 
-void test_bulk_async()
+template <typename... ExecutorArgs>
+void test_bulk_async(ExecutorArgs&&... args)
 {
-    using executor = hpx::execution::experimental::fork_join_executor;
+    std::cerr << "test_bulk_async\n";
 
     count = 0;
     std::size_t const n = 107;
@@ -63,7 +69,7 @@ void test_bulk_async()
     using hpx::util::placeholders::_1;
     using hpx::util::placeholders::_2;
 
-    executor exec;
+    fork_join_executor exec{std::forward<ExecutorArgs>(args)...};
     hpx::when_all(hpx::parallel::execution::bulk_async_execute(
                       exec, hpx::util::bind(&bulk_test, _1, _2), v, 42))
         .get();
@@ -82,16 +88,17 @@ void bulk_test_exception(int, int passed_through)    //-V813
     throw std::runtime_error("test");
 }
 
-void test_bulk_sync_exception()
+template <typename... ExecutorArgs>
+void test_bulk_sync_exception(ExecutorArgs&&... args)
 {
-    using executor = hpx::execution::experimental::fork_join_executor;
+    std::cerr << "test_bulk_sync_exception\n";
 
     count = 0;
     std::size_t const n = 107;
     std::vector<int> v(n);
     std::iota(std::begin(v), std::end(v), std::rand());
 
-    executor exec;
+    fork_join_executor exec{std::forward<ExecutorArgs>(args)...};
     bool caught_exception = false;
     try
     {
@@ -112,16 +119,17 @@ void test_bulk_sync_exception()
     HPX_TEST(caught_exception);
 }
 
-void test_bulk_async_exception()
+template <typename... ExecutorArgs>
+void test_bulk_async_exception(ExecutorArgs&&... args)
 {
-    using executor = hpx::execution::experimental::fork_join_executor;
+    std::cerr << "test_bulk_async_exception\n";
 
     count = 0;
     std::size_t const n = 107;
     std::vector<int> v(n);
     std::iota(std::begin(v), std::end(v), std::rand());
 
-    executor exec;
+    fork_join_executor exec{std::forward<ExecutorArgs>(args)...};
     bool caught_exception = false;
     try
     {
@@ -147,22 +155,35 @@ void test_bulk_async_exception()
 void static_check_executor()
 {
     using namespace hpx::traits;
-    using executor = hpx::execution::experimental::fork_join_executor;
 
-    static_assert(!has_sync_execute_member<executor>::value,
-        "!has_sync_execute_member<executor>::value");
-    static_assert(!has_async_execute_member<executor>::value,
-        "!has_async_execute_member<executor>::value");
-    static_assert(!has_then_execute_member<executor>::value,
-        "!has_then_execute_member<executor>::value");
-    static_assert(has_bulk_sync_execute_member<executor>::value,
-        "has_bulk_sync_execute_member<executor>::value");
-    static_assert(has_bulk_async_execute_member<executor>::value,
-        "has_bulk_async_execute_member<executor>::value");
-    static_assert(!has_bulk_then_execute_member<executor>::value,
-        "!has_bulk_then_execute_member<executor>::value");
-    static_assert(
-        !has_post_member<executor>::value, "!has_post_member<executor>::value");
+    static_assert(!has_sync_execute_member<fork_join_executor>::value,
+        "!has_sync_execute_member<fork_join_executor>::value");
+    static_assert(!has_async_execute_member<fork_join_executor>::value,
+        "!has_async_execute_member<fork_join_executor>::value");
+    static_assert(!has_then_execute_member<fork_join_executor>::value,
+        "!has_then_execute_member<fork_join_executor>::value");
+    static_assert(has_bulk_sync_execute_member<fork_join_executor>::value,
+        "has_bulk_sync_execute_member<fork_join_executor>::value");
+    static_assert(has_bulk_async_execute_member<fork_join_executor>::value,
+        "has_bulk_async_execute_member<fork_join_executor>::value");
+    static_assert(!has_bulk_then_execute_member<fork_join_executor>::value,
+        "!has_bulk_then_execute_member<fork_join_executor>::value");
+    static_assert(!has_post_member<fork_join_executor>::value,
+        "!has_post_member<fork_join_executor>::value");
+}
+
+template <typename... ExecutorArgs>
+void test_executor(hpx::threads::thread_priority priority,
+    hpx::threads::thread_stacksize stacksize,
+    fork_join_executor::loop_schedule schedule)
+{
+    std::cerr << "testing fork_join_executor with priority = " << priority
+              << ", stacksize = " << stacksize << ", schedule = " << schedule
+              << "\n";
+    test_bulk_sync(priority, stacksize, schedule);
+    test_bulk_async(priority, stacksize, schedule);
+    test_bulk_sync_exception(priority, stacksize, schedule);
+    test_bulk_async_exception(priority, stacksize, schedule);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -170,10 +191,31 @@ int hpx_main()
 {
     static_check_executor();
 
-    test_bulk_sync();
-    test_bulk_async();
-    test_bulk_sync_exception();
-    test_bulk_async_exception();
+    // thread_stacksize::nostack cannot be used with the fork_join_executor
+    // because it prevents other work from running when yielding. Using
+    // thread_priority::low hangs for unknown reasons.
+    for (auto const priority : {
+             // hpx::threads::thread_priority::low,
+             hpx::threads::thread_priority::normal,
+             hpx::threads::thread_priority::high,
+         })
+    {
+        for (auto const stacksize : {
+                 // hpx::threads::thread_stacksize::nostack,
+                 hpx::threads::thread_stacksize::small_,
+             })
+        {
+            for (auto const schedule : {
+                     fork_join_executor::loop_schedule::static_,
+                     fork_join_executor::loop_schedule::dynamic,
+                 })
+            {
+                {
+                    test_executor(priority, stacksize, schedule);
+                }
+            }
+        }
+    }
 
     return hpx::local::finalize();
 }


### PR DESCRIPTION
I've expanded the `fork_join_executor` to also test the dynamic schedule. I've also added tests for normal and high priority threads.

The constructor now throws an exception if the executor is constructed with `thread_stacksize::nostack` since that would prevent yielding. For an unclear reason `thread_priority::low` does not work with the executor. I'm guessing it has to do with how we decide to steal threads, and low priority threads having a single queue, but I don't have a full explanation. I'm leaving it out of the test at the moment, but I'm not adding a check for it in the constructor without understanding the reason for it.

@gonidelis could you please try this on your test cases as well? 

## Checklist

Not all points below apply to all pull requests.

- [ ] I have added a new feature and have added tests to go along with it.
- [X] I have fixed a bug and have added a regression test.
- [ ] I have added a test using random numbers; I have made sure it uses a seed, and that random numbers generated are valid inputs for the tests.
