### PR TITLE
Make hpx::wait_all etc. throw exceptions when waited futures hold exceptions and deprecate hpx::lcos::wait_all[_n] in favor of hpx::wait_all[_n]

### DIFF
--- a/components/containers/partitioned_vector/include/hpx/components/containers/partitioned_vector/partitioned_vector_impl.hpp
+++ b/components/containers/partitioned_vector/include/hpx/components/containers/partitioned_vector/partitioned_vector_impl.hpp
@@ -87,7 +87,7 @@ namespace hpx {
                         .then(get_ptr_helper{l, partitions_}));
             }
         }
-        wait_all(ptrs);
+        hpx::wait_all(ptrs);
 
         partition_size_ = get_partition_size();
         this->base_type::reset(HPX_MOVE(id));
@@ -436,7 +436,7 @@ namespace hpx {
             objs.push_back(
                 hpx::components::copy<component_type>(it->partition_));
         }
-        wait_all(objs);
+        hpx::wait_all(objs);
 
         std::uint32_t this_locality = get_locality_id();
         std::vector<future<void>> ptrs;

--- a/components/containers/unordered/include/hpx/components/containers/unordered/unordered_map.hpp
+++ b/components/containers/unordered/include/hpx/components/containers/unordered/unordered_map.hpp
@@ -420,7 +420,7 @@ namespace hpx {
                 }
             }
 
-            wait_all(ptrs);
+            hpx::wait_all(ptrs);
         }
 
         ///////////////////////////////////////////////////////////////////////
@@ -475,7 +475,7 @@ namespace hpx {
                 objs.push_back(hpx::components::copy<component_type>(
                     it->partition_.get()));
             }
-            wait_all(objs);
+            hpx::wait_all(objs);
 
             std::uint32_t this_locality = get_locality_id();
             std::vector<future<void>> ptrs;
@@ -496,7 +496,7 @@ namespace hpx {
                 }
             }
 
-            wait_all(ptrs);
+            hpx::wait_all(ptrs);
 
             std::swap(partitions_, partitions);
         }

--- a/docs/sphinx/examples/hello_world.rst
+++ b/docs/sphinx/examples/hello_world.rst
@@ -116,14 +116,14 @@ wrapped in the action above:
 
 Now, before we discuss ``hello_world_foreman()``, let's talk about the
 :cpp:func:`hpx::wait_each()` function.
-The version of :cpp:func:`hpx::lcos::wait_each` invokes a callback function
+The version of :cpp:func:`hpx::wait_each` invokes a callback function
 provided by the user, supplying the callback function with the result of the
 future.
 
 In ``hello_world_foreman()``, an ``std::set<>`` called ``attendance`` keeps
 track of which OS-threads have printed out the hello world message. When the
 OS-thread prints out the statement, the future is marked as ready, and
-:cpp:func:`hpx::lcos::wait_each` in ``hello_world_foreman()``. If it is not
+:cpp:func:`hpx::wait_each` in ``hello_world_foreman()``. If it is not
 executing on the correct OS-thread, it returns a value of -1, which causes
 ``hello_world_foreman()`` to leave the OS-thread id in ``attendance``.
 

--- a/examples/apex/apex_balance.cpp
+++ b/examples/apex/apex_balance.cpp
@@ -83,7 +83,7 @@ int hpx_main(hpx::program_options::variables_map& vm)
             futures.push_back(hpx::async(act, localities[next], item));
         }
         std::cout << "Issued work for block " << block << std::endl;
-        hpx::lcos::wait_all(futures.begin(), futures.end());
+        hpx::wait_all(futures.begin(), futures.end());
         std::cout << "Work done for block " << block << std::endl;
     }
 

--- a/examples/qt/qt.cpp
+++ b/examples/qt/qt.cpp
@@ -26,26 +26,26 @@ double runner(double now)
 
 HPX_PLAIN_ACTION(runner, runner_action)
 
-void run(widget * w, std::size_t num_threads)
+void run(widget* w, std::size_t num_threads)
 {
-    std::vector<hpx::future<double> > futures(num_threads);
+    std::vector<hpx::future<double>> futures(num_threads);
 
-    for(std::size_t i = 0; i < num_threads; ++i)
+    for (std::size_t i = 0; i < num_threads; ++i)
     {
         runner_action a;
-        futures[i] = hpx::async(a,
-                                hpx::find_here(),
-                                high_resolution_timer::now());
+        futures[i] =
+            hpx::async(a, hpx::find_here(), high_resolution_timer::now());
     }
 
-    hpx::lcos::wait(
-                futures,
-                [w](std::size_t i, double t){ w->threadsafe_add_label(i, t); }
-    );
+    hpx::wait_each(
+        [w](std::size_t i, auto&& f) {
+            w->threadsafe_add_label(i, f.get());
+        },
+        futures);
     w->threadsafe_run_finished();
 }
 
-void qt_main(int argc, char ** argv)
+void qt_main(int argc, char** argv)
 {
     QApplication app(argc, argv);
 
@@ -57,14 +57,14 @@ void qt_main(int argc, char ** argv)
     app.exec();
 }
 
-int hpx_main(int argc, char ** argv)
+int hpx_main(int argc, char** argv)
 {
     {
         // Get a reference to one of the main thread
         hpx::parallel::execution::main_pool_executor scheduler;
         // run an async function on the main thread to start the Qt application
-        hpx::future<void> qt_application
-            = hpx::async(scheduler, qt_main, argc, argv);
+        hpx::future<void> qt_application =
+            hpx::async(scheduler, qt_main, argc, argv);
 
         // do something else while qt is executing in the background ...
 
@@ -73,7 +73,7 @@ int hpx_main(int argc, char ** argv)
     return hpx::finalize();
 }
 
-int main(int argc, char **argv)
+int main(int argc, char** argv)
 {
     return hpx::init(argc, argv);
 }

--- a/examples/quickstart/1d_wave_equation.cpp
+++ b/examples/quickstart/1d_wave_equation.cpp
@@ -47,7 +47,7 @@ using hpx::naming::invalid_id;
 
 using hpx::async;
 using hpx::future;
-using hpx::lcos::wait;
+
 
 using hpx::chrono::high_resolution_timer;
 
@@ -234,11 +234,11 @@ int hpx_main(variables_map& vm)
         std::ofstream outfile;
         outfile.open("output.dat");
 
-        auto f = [&](std::size_t i, double n) {
+        auto f = [&](std::size_t i, hpx::future<double>&& f) {
             double x_here = i * dx;
-            hpx::util::format_to(outfile, "{1} {2}\n", x_here, n) << flush;
+            hpx::util::format_to(outfile, "{1} {2}\n", x_here, f.get()) << flush;
         };
-        wait(futures, f);
+        hpx::wait_each(f, futures);
 
         outfile.close();
 

--- a/examples/quickstart/hello_world_distributed.cpp
+++ b/examples/quickstart/hello_world_distributed.cpp
@@ -149,7 +149,7 @@ int main()
         futures.push_back(hpx::async<action_type>(node));
     }
 
-    // The non-callback version of hpx::lcos::wait_all takes a single parameter,
+    // The non-callback version of hpx::wait_all takes a single parameter,
     // a vector of futures to wait on. hpx::wait_all only returns when
     // all of the futures have finished.
     hpx::wait_all(futures);

--- a/examples/quickstart/hello_world_distributed.cpp
+++ b/examples/quickstart/hello_world_distributed.cpp
@@ -103,13 +103,13 @@ void hello_world_foreman()
         }
 
         // Wait for all of the futures to finish. The callback version of the
-        // hpx::lcos::wait_each function takes two arguments: a vector of futures,
+        // hpx::wait_each function takes two arguments: a vector of futures,
         // and a binary callback.  The callback takes two arguments; the first
         // is the index of the future in the vector, and the second is the
-        // return value of the future. hpx::lcos::wait_each doesn't return until
+        // return value of the future. hpx::wait_each doesn't return until
         // all the futures in the vector have returned.
         hpx::lcos::local::spinlock mtx;
-        hpx::lcos::wait_each(hpx::unwrapping([&](std::size_t t) {
+        hpx::wait_each(hpx::unwrapping([&](std::size_t t) {
             if (std::size_t(-1) != t)
             {
                 std::lock_guard<hpx::lcos::local::spinlock> lk(mtx);

--- a/examples/quickstart/pipeline1.cpp
+++ b/examples/quickstart/pipeline1.cpp
@@ -41,7 +41,7 @@ struct pipeline
             tasks.push_back(hpx::async(grep, "Error.*", std::move(s)));
         }
 
-        wait_all(tasks);
+        hpx::wait_all(tasks);
     }
 };
 

--- a/examples/sheneos/sheneos/interpolator.cpp
+++ b/examples/sheneos/sheneos/interpolator.cpp
@@ -386,7 +386,7 @@ namespace sheneos
             }
 
             // wait for all asynchronous operations to complete
-            wait_all(lazy_results);
+            hpx::wait_all(lazy_results);
 
             return overall_result;
         }
@@ -495,7 +495,7 @@ namespace sheneos
             }
 
             // wait for all asynchronous operations to complete
-            wait_all(lazy_results);
+            hpx::wait_all(lazy_results);
 
             return overall_results;
         }

--- a/examples/sheneos/sheneos_test.cpp
+++ b/examples/sheneos/sheneos_test.cpp
@@ -344,45 +344,6 @@ int hpx_main(hpx::program_options::variables_map& vm)
 
         t.restart();
 
-//         // Kick off the computation asynchronously. On each locality,
-//         // num_workers test_actions are created.
-//         std::vector<hpx::future<void> > tests;
-//         for (hpx::naming::id_type const& id : locality_ids)
-//         {
-//             using hpx::async;
-//             for (std::size_t i = 0; i < num_workers; ++i)
-//                 tests.push_back(async<test_action>(id, num_ye_points,
-//                     num_temp_points, num_rho_points, seed));
-//         }
-//
-//         using hpx::util::placeholders::_1;
-//         hpx::lcos::wait(tests,
-//             hpx::util::bind(wait_for_task, _1, std::ref(t)));
-//
-//         std::cout << "Completed tests: " << t.elapsed() << " [s]" << std::endl;
-//
-//         t.restart();
-//
-//         // Kick off the computation asynchronously. On each locality,
-//         // num_workers test_actions are created.
-//         std::vector<hpx::future<void> > bulk_one_tests;
-//         for (hpx::naming::id_type const& id : locality_ids)
-//         {
-//             using hpx::async;
-//             for (std::size_t i = 0; i < num_workers; ++i)
-//                 bulk_one_tests.push_back(async<test_one_bulk_action>(id,
-//                     num_ye_points, num_temp_points, num_rho_points, seed));
-//         }
-//
-//         using hpx::util::placeholders::_1;
-//         hpx::lcos::wait(bulk_one_tests,
-//             hpx::util::bind(wait_for_bulk_one_task, _1, std::ref(t)));
-//
-//         std::cout << "Completed bulk-one tests: " << t.elapsed() << " [s]"
-//             << std::endl;
-//
-//         t.restart();
-
         // Kick off the computation asynchronously. On each locality,
         // num_workers test_actions are created.
         std::vector<hpx::future<void> > bulk_tests;

--- a/examples/spell_check/spell_check_file.cpp
+++ b/examples/spell_check/spell_check_file.cpp
@@ -217,7 +217,7 @@ int hpx_main()
                 sAct.push_back(temp);
                 //cout << search(0, wordcount, single) << endl;
             }
-            wait_all(wordRun);
+            hpx::wait_all(wordRun);
             cout << "Search completed in " << t.elapsed() << "s.\n";
             for (string::size_type i = 0; i < strs.size(); i++)
             {

--- a/examples/spell_check/spell_check_simple.cpp
+++ b/examples/spell_check/spell_check_simple.cpp
@@ -182,7 +182,6 @@ int hpx_main()
         {
             using hpx::future;
             using hpx::async;
-            using hpx::wait_all;
             vector<search_action> sAct;//[sizeX * sizeY];
             vector<future<string> > wordRun;
             wordRun.reserve(strs.size());
@@ -196,7 +195,7 @@ int hpx_main()
                 sAct.push_back(temp);
                 //cout << search(0, wordcount, single) << endl;
             }
-            wait_all(wordRun);
+            hpx::wait_all(wordRun);
             cout << "Search completed in " << t.elapsed() << "s.\n";
             for (string::size_type i = 0; i < strs.size(); i++)
             {

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/make_heap.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/make_heap.hpp
@@ -345,7 +345,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                                 policy.executor(), op, shapes);
 
                             // Required synchronization per level
-                            hpx::wait_all(workitems);
+                            hpx::wait_all_nothrow(workitems);
 
                             // collect exceptions
                             util::detail::handle_local_exceptions<

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/partition.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/partition.hpp
@@ -1344,11 +1344,11 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 }
 
                 // Wait sub-partitioning to be all finished.
-                hpx::wait_all(remaining_block_futures);
+                hpx::wait_all_nothrow(remaining_block_futures);
 
                 // Handle exceptions in parallel phrase.
                 std::list<std::exception_ptr> errors;
-                // TODO: Is it okay to use thing in util::detail:: ?
+
                 util::detail::handle_local_exceptions<ExPolicy>::call(
                     remaining_block_futures, errors);
 

--- a/libs/core/algorithms/include/hpx/parallel/util/foreach_partitioner.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/util/foreach_partitioner.hpp
@@ -117,7 +117,7 @@ namespace hpx { namespace parallel { namespace util {
                 std::list<std::exception_ptr>&& errors, F&& f, FwdIter last)
             {
                 // wait for all tasks to finish
-                hpx::wait_all(workitems);
+                hpx::wait_all_nothrow(workitems);
 
                 // always rethrow if 'errors' is not empty or workitems has
                 // exceptional future

--- a/libs/core/algorithms/include/hpx/parallel/util/partitioner.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/util/partitioner.hpp
@@ -255,7 +255,7 @@ namespace hpx { namespace parallel { namespace util {
                 std::list<std::exception_ptr>&& errors, F&& f)
             {
                 // wait for all tasks to finish
-                hpx::wait_all(workitems);
+                hpx::wait_all_nothrow(workitems);
 
                 // always rethrow if 'errors' is not empty or workitems has
                 // exceptional future

--- a/libs/core/algorithms/include/hpx/parallel/util/partitioner_with_cleanup.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/util/partitioner_with_cleanup.hpp
@@ -91,7 +91,7 @@ namespace hpx { namespace parallel { namespace util {
                 Cleanup&& cleanup)
             {
                 // wait for all tasks to finish
-                hpx::wait_all(workitems);
+                hpx::wait_all_nothrow(workitems);
 
                 // always rethrow if 'errors' is not empty or workitems has
                 // exceptional future

--- a/libs/core/algorithms/include/hpx/parallel/util/scan_partitioner.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/util/scan_partitioner.hpp
@@ -148,7 +148,7 @@ namespace hpx { namespace parallel { namespace util {
                     }
 
                     // Wait for all f1 tasks to finish
-                    hpx::wait_all(workitems);
+                    hpx::wait_all_nothrow(workitems);
 
                     // perform f2 sequentially in one go
                     f2results.resize(workitems.size());
@@ -343,7 +343,7 @@ namespace hpx { namespace parallel { namespace util {
                 return R();
 #else
                 // wait for all tasks to finish
-                hpx::wait_all(workitems, finalitems);
+                hpx::wait_all_nothrow(workitems, finalitems);
 
                 // always rethrow if 'errors' is not empty or 'workitems' or
                 // 'finalitems' have an exceptional future
@@ -376,7 +376,7 @@ namespace hpx { namespace parallel { namespace util {
                 return R();
 #else
                 // wait for all tasks to finish
-                hpx::wait_all(finalitems);
+                hpx::wait_all_nothrow(finalitems);
 
                 // always rethrow if 'errors' is not empty or
                 // 'finalitems' have an exceptional future

--- a/libs/core/async_combinators/CMakeLists.txt
+++ b/libs/core/async_combinators/CMakeLists.txt
@@ -8,7 +8,6 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 
 set(async_combinators_headers
     hpx/async_combinators/detail/throw_if_exceptional.hpp
-    hpx/async_combinators/future_wait.hpp
     hpx/async_combinators/split_future.hpp
     hpx/async_combinators/wait_all.hpp
     hpx/async_combinators/wait_any.hpp
@@ -41,6 +40,7 @@ add_hpx_module(
   GLOBAL_HEADER_GEN ON
   HEADERS ${async_combinators_headers}
   COMPAT_HEADERS ${async_combinators_compat_headers}
+  EXCLUDE_FROM_GLOBAL_HEADER "hpx/async_combinators/future_wait.hpp"
   MODULE_DEPENDENCIES hpx_async_base hpx_config hpx_errors hpx_futures
                       hpx_memory hpx_pack_traversal
   CMAKE_SUBDIRS examples tests

--- a/libs/core/async_combinators/CMakeLists.txt
+++ b/libs/core/async_combinators/CMakeLists.txt
@@ -7,6 +7,7 @@
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 
 set(async_combinators_headers
+    hpx/async_combinators/detail/throw_if_exceptional.hpp
     hpx/async_combinators/future_wait.hpp
     hpx/async_combinators/split_future.hpp
     hpx/async_combinators/wait_all.hpp

--- a/libs/core/async_combinators/include/hpx/async_combinators/detail/throw_if_exceptional.hpp
+++ b/libs/core/async_combinators/include/hpx/async_combinators/detail/throw_if_exceptional.hpp
@@ -1,0 +1,54 @@
+//  Copyright (c) 2021 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include <hpx/futures/detail/future_data.hpp>
+#include <hpx/futures/traits/acquire_shared_state.hpp>
+
+#include <array>
+#include <cstddef>
+#include <vector>
+
+// This defines facilities that check a set of futures whether any of those are
+// exceptional, rethrowing the exception if needed.
+namespace hpx::detail {
+
+    template <typename Future>
+    void rethrow_if_needed(Future const& f)
+    {
+        auto shared_state = hpx::traits::detail::get_shared_state(f);
+        if (shared_state->has_exception())
+        {
+            shared_state->get_result_void();    // throws stored exception
+        }
+    }
+
+    template <typename Future>
+    void throw_if_exceptional(std::vector<Future> const& values)
+    {
+        for (auto const& f : values)
+        {
+            rethrow_if_needed(f);
+        }
+    }
+
+    template <typename Future, std::size_t N>
+    void throw_if_exceptional(std::array<Future, N> const& values)
+    {
+        for (auto const& f : values)
+        {
+            rethrow_if_needed(f);
+        }
+    }
+
+    template <typename... Ts>
+    void throw_if_exceptional(Ts const&... ts)
+    {
+        int const _sequencer[] = {0, (rethrow_if_needed(ts), 0)...};
+        (void) _sequencer;
+    }
+}    // namespace hpx::detail

--- a/libs/core/async_combinators/include/hpx/async_combinators/detail/throw_if_exceptional.hpp
+++ b/libs/core/async_combinators/include/hpx/async_combinators/detail/throw_if_exceptional.hpp
@@ -8,6 +8,8 @@
 
 #include <hpx/futures/detail/future_data.hpp>
 #include <hpx/futures/traits/acquire_shared_state.hpp>
+#include <hpx/futures/traits/future_access.hpp>
+#include <hpx/futures/traits/is_future.hpp>
 
 #include <array>
 #include <cstddef>
@@ -25,6 +27,14 @@ namespace hpx::detail {
         {
             shared_state->get_result_void();    // throws stored exception
         }
+    }
+
+    template <typename Future,
+        typename Enable = std::enable_if_t<hpx::traits::is_future_v<Future> ||
+            hpx::traits::is_shared_state_v<Future>>>
+    void throw_if_exceptional(Future const& f)
+    {
+        rethrow_if_needed(f);
     }
 
     template <typename Future>
@@ -48,7 +58,7 @@ namespace hpx::detail {
     template <typename... Ts>
     void throw_if_exceptional(Ts const&... ts)
     {
-        int const _sequencer[] = {0, (rethrow_if_needed(ts), 0)...};
+        int const _sequencer[] = {0, (throw_if_exceptional(ts), 0)...};
         (void) _sequencer;
     }
 }    // namespace hpx::detail

--- a/libs/core/async_combinators/include/hpx/async_combinators/future_wait.hpp
+++ b/libs/core/async_combinators/include/hpx/async_combinators/future_wait.hpp
@@ -205,20 +205,22 @@ namespace hpx { namespace lcos {
     /// The one argument version is special in the sense that it returns the
     /// expected value directly (without wrapping it into a tuple).
     template <typename Future, typename F>
-    inline typename std::enable_if<
-        !std::is_void<typename traits::future_traits<Future>::type>::value,
-        std::size_t>::type
-    wait(Future&& f1, F&& f)
+    HPX_DEPRECATED_V(1, 8,
+        "hpx::lcos::wait is deprecated and will be removed. Use hpx::wait_each "
+        "instead.")
+    std::enable_if_t<!std::is_void_v<traits::future_traits_t<Future>>,
+        std::size_t> wait(Future&& f1, F&& f)
     {
         f(0, f1.get());
         return 1;
     }
 
     template <typename Future, typename F>
-    inline typename std::enable_if<    //-V659
-        std::is_void<typename traits::future_traits<Future>::type>::value,
-        std::size_t>::type
-    wait(Future&& f1, F&& f)
+    HPX_DEPRECATED_V(1, 8,
+        "hpx::lcos::wait is deprecated and will be removed. Use hpx::wait_each "
+        "instead.")
+    std::enable_if_t<std::is_void_v<traits::future_traits_t<Future>>,
+        std::size_t> wait(Future&& f1, F&& f)
     {
         f1.get();
         f(0);
@@ -230,6 +232,9 @@ namespace hpx { namespace lcos {
     // invoked as soon as a value becomes available, it will not wait for all
     // results to be there.
     template <typename Future, typename F>
+    HPX_DEPRECATED_V(1, 8,
+        "hpx::lcos::wait is deprecated and will be removed. Use hpx::wait_each "
+        "instead.")
     inline std::size_t wait(std::vector<Future>& lazy_values, F&& f,
         std::int32_t /* suspend_for */ = 10)
     {
@@ -256,6 +261,9 @@ namespace hpx { namespace lcos {
     }
 
     template <typename Future, typename F>
+    HPX_DEPRECATED_V(1, 8,
+        "hpx::lcos::wait is deprecated and will be removed. Use hpx::wait_each "
+        "instead.")
     inline std::size_t wait(
         std::vector<Future>&& lazy_values, F&& f, std::int32_t suspend_for = 10)
     {
@@ -263,6 +271,9 @@ namespace hpx { namespace lcos {
     }
 
     template <typename Future, typename F>
+    HPX_DEPRECATED_V(1, 8,
+        "hpx::lcos::wait is deprecated and will be removed. Use hpx::wait_each "
+        "instead.")
     inline std::size_t wait(std::vector<Future> const& lazy_values, F&& f,
         std::int32_t /* suspend_for */ = 10)
     {

--- a/libs/core/async_combinators/include/hpx/async_combinators/wait_all.hpp
+++ b/libs/core/async_combinators/include/hpx/async_combinators/wait_all.hpp
@@ -28,7 +28,7 @@ namespace hpx {
     ///
     /// \note           The function wait_all will rethrow any exceptions
     ///                 captured by the futures while becoming ready. If this
-    ///                 behavior is undesireable, use \a wait_all_nothrow
+    ///                 behavior is undesirable, use \a wait_all_nothrow
     ///                 instead.
     ///
     template <typename InputIter>
@@ -48,7 +48,7 @@ namespace hpx {
     ///
     /// \note           The function wait_all will rethrow any exceptions
     ///                 captured by the futures while becoming ready. If this
-    ///                 behavior is undesireable, use \a wait_all_nothrow
+    ///                 behavior is undesirable, use \a wait_all_nothrow
     ///                 instead.
     ///
     template <typename R>
@@ -68,7 +68,7 @@ namespace hpx {
     ///
     /// \note           The function wait_all will rethrow any exceptions
     ///                 captured by the futures while becoming ready. If this
-    ///                 behavior is undesireable, use \a wait_all_nothrow
+    ///                 behavior is undesirable, use \a wait_all_nothrow
     ///                 instead.
     ///
     template <typename R, std::size_t N>
@@ -88,7 +88,7 @@ namespace hpx {
     ///
     /// \note           The function wait_all will rethrow any exceptions
     ///                 captured by the futures while becoming ready. If this
-    ///                 behavior is undesireable, use \a wait_all_nothrow
+    ///                 behavior is undesirable, use \a wait_all_nothrow
     ///                 instead.
     ///
     template <typename... T>
@@ -114,7 +114,7 @@ namespace hpx {
     ///
     /// \note           The function wait_all_n will rethrow any exceptions
     ///                 captured by the futures while becoming ready. If this
-    ///                 behavior is undesireable, use \a wait_all_n_nothrow
+    ///                 behavior is undesirable, use \a wait_all_n_nothrow
     ///                 instead.
     ///
     template <typename InputIter>

--- a/libs/core/async_combinators/include/hpx/async_combinators/wait_all.hpp
+++ b/libs/core/async_combinators/include/hpx/async_combinators/wait_all.hpp
@@ -24,8 +24,12 @@ namespace hpx {
     ///
     /// \note The function \a wait_all returns after all futures have become
     ///       ready. All input futures are still valid after \a wait_all
-    ///       returns. Exceptional futures will not cause wait_all to throw an
-    ///       exception.
+    ///       returns.
+    ///
+    /// \note           The function wait_all will rethrow any exceptions
+    ///                 captured by the futures while becoming ready. If this
+    ///                 behavior is undesireable, use \a wait_all_nothrow
+    ///                 instead.
     ///
     template <typename InputIter>
     void wait_all(InputIter first, InputIter last);
@@ -40,8 +44,12 @@ namespace hpx {
     ///
     /// \note The function \a wait_all returns after all futures have become
     ///       ready. All input futures are still valid after \a wait_all
-    ///       returns. Exceptional futures will not cause wait_all to throw an
-    ///       exception.
+    ///       returns.
+    ///
+    /// \note           The function wait_all will rethrow any exceptions
+    ///                 captured by the futures while becoming ready. If this
+    ///                 behavior is undesireable, use \a wait_all_nothrow
+    ///                 instead.
     ///
     template <typename R>
     void wait_all(std::vector<future<R>>&& futures);
@@ -56,8 +64,12 @@ namespace hpx {
     ///
     /// \note The function \a wait_all returns after all futures have become
     ///       ready. All input futures are still valid after \a wait_all
-    ///       returns. Exceptional futures will not cause wait_all to throw an
-    ///       exception.
+    ///       returns.
+    ///
+    /// \note           The function wait_all will rethrow any exceptions
+    ///                 captured by the futures while becoming ready. If this
+    ///                 behavior is undesireable, use \a wait_all_nothrow
+    ///                 instead.
     ///
     template <typename R, std::size_t N>
     void wait_all(std::array<future<R>, N>&& futures);
@@ -72,8 +84,12 @@ namespace hpx {
     ///
     /// \note The function \a wait_all returns after all futures have become
     ///       ready. All input futures are still valid after \a wait_all
-    ///       returns. Exceptional futures will not cause wait_all to throw an
-    ///       exception.
+    ///       returns.
+    ///
+    /// \note           The function wait_all will rethrow any exceptions
+    ///                 captured by the futures while becoming ready. If this
+    ///                 behavior is undesireable, use \a wait_all_nothrow
+    ///                 instead.
     ///
     template <typename... T>
     void wait_all(T&&... futures);
@@ -94,16 +110,21 @@ namespace hpx {
     ///
     /// \note The function \a wait_all_n returns after all futures have become
     ///       ready. All input futures are still valid after \a wait_all_n
-    ///       returns. Exceptional futures will not cause wait_all to throw an
-    ///       exception.
+    ///       returns.
+    ///
+    /// \note           The function wait_all_n will rethrow any exceptions
+    ///                 captured by the futures while becoming ready. If this
+    ///                 behavior is undesireable, use \a wait_all_n_nothrow
+    ///                 instead.
     ///
     template <typename InputIter>
-    InputIter wait_all_n(InputIter begin, std::size_t count);
+    void wait_all_n(InputIter begin, std::size_t count);
 }    // namespace hpx
 
 #else    // DOXYGEN
 
 #include <hpx/config.hpp>
+#include <hpx/async_combinators/detail/throw_if_exceptional.hpp>
 #include <hpx/datastructures/tuple.hpp>
 #include <hpx/futures/detail/future_data.hpp>
 #include <hpx/futures/traits/acquire_shared_state.hpp>
@@ -111,6 +132,7 @@ namespace hpx {
 #include <hpx/futures/traits/future_access.hpp>
 #include <hpx/futures/traits/is_future.hpp>
 #include <hpx/iterator_support/range.hpp>
+#include <hpx/iterator_support/traits/is_iterator.hpp>
 #include <hpx/modules/memory.hpp>
 #include <hpx/type_support/always_void.hpp>
 #include <hpx/type_support/decay.hpp>
@@ -126,7 +148,7 @@ namespace hpx {
 #include <vector>
 
 ///////////////////////////////////////////////////////////////////////////////
-namespace hpx { namespace lcos {
+namespace hpx {
 
     // forward declare wait_all()
     template <typename Future>
@@ -141,7 +163,8 @@ namespace hpx { namespace lcos {
 
         template <typename R>
         struct is_future_or_shared_state<
-            hpx::intrusive_ptr<future_data_base<R>>> : std::true_type
+            hpx::intrusive_ptr<hpx::lcos::detail::future_data_base<R>>>
+          : std::true_type
         {
         };
 
@@ -152,8 +175,8 @@ namespace hpx { namespace lcos {
         };
 
         template <typename R>
-        using is_future_or_shared_state_t =
-            typename is_future_or_shared_state<R>::type;
+        inline constexpr bool is_future_or_shared_state_v =
+            is_future_or_shared_state<R>::value;
 
         ///////////////////////////////////////////////////////////////////////
         template <typename Range, typename Enable = void>
@@ -174,8 +197,8 @@ namespace hpx { namespace lcos {
         };
 
         template <typename R>
-        using is_future_or_shared_state_range_t =
-            typename is_future_or_shared_state_range<R>::type;
+        inline constexpr bool is_future_or_shared_state_range_v =
+            is_future_or_shared_state_range<R>::value;
 
         ///////////////////////////////////////////////////////////////////////
         template <typename Future, typename Enable = void>
@@ -183,14 +206,14 @@ namespace hpx { namespace lcos {
 
         template <typename Future>
         struct future_or_shared_state_result<Future,
-            std::enable_if_t<traits::is_future_v<Future>>>
-          : traits::future_traits<Future>
+            std::enable_if_t<hpx::traits::is_future_v<Future>>>
+          : hpx::traits::future_traits<Future>
         {
         };
 
         template <typename R>
         struct future_or_shared_state_result<
-            hpx::intrusive_ptr<future_data_base<R>>>
+            hpx::intrusive_ptr<hpx::lcos::detail::future_data_base<R>>>
         {
             using type = R;
         };
@@ -206,10 +229,13 @@ namespace hpx { namespace lcos {
         {
         private:
             using base_type = hpx::lcos::detail::future_data<void>;
+            using init_no_addref = typename base_type::init_no_addref;
 
-            // workaround gcc regression wrongly instantiating constructors
-            wait_all_frame();
-            wait_all_frame(wait_all_frame const&);
+            wait_all_frame(wait_all_frame const&) = delete;
+            wait_all_frame(wait_all_frame&&) = delete;
+
+            wait_all_frame& operator=(wait_all_frame const&) = delete;
+            wait_all_frame& operator=(wait_all_frame&&) = delete;
 
             template <std::size_t I>
             struct is_end
@@ -217,47 +243,28 @@ namespace hpx { namespace lcos {
             {
             };
 
+            template <std::size_t I>
+            static constexpr bool is_end_v = is_end<I>::value;
+
         public:
-            using init_no_addref = typename base_type::init_no_addref;
-
             wait_all_frame(Tuple const& t)
-              : t_(t)
-            {
-            }
-
-            wait_all_frame(init_no_addref no_addref, Tuple const& t)
-              : base_type(no_addref)
+              : base_type(init_no_addref{})
               , t_(t)
             {
             }
 
         protected:
-            // End of the tuple is reached
-            template <std::size_t I>
-            HPX_FORCEINLINE void do_await(std::true_type)
-            {
-                this->set_value(util::unused);    // simply make ourself ready
-            }
-
             // Current element is a range (vector or array) of futures
             template <std::size_t I, typename Iter>
             void await_range(Iter&& next, Iter&& end)
             {
-                using future_type =
-                    typename std::iterator_traits<Iter>::value_type;
-                using future_result_type =
-                    detail::future_or_shared_state_result_t<future_type>;
-
                 hpx::intrusive_ptr<wait_all_frame> this_(this);
-
                 for (/**/; next != end; ++next)
                 {
-                    traits::detail::shared_state_ptr_t<future_result_type>
-                        next_future_data =
-                            traits::detail::get_shared_state(*next);
+                    auto next_future_data =
+                        hpx::traits::detail::get_shared_state(*next);
 
-                    if (next_future_data.get() != nullptr &&
-                        !next_future_data->is_ready())
+                    if (next_future_data && !next_future_data->is_ready())
                     {
                         next_future_data->execute_deferred();
 
@@ -270,9 +277,9 @@ namespace hpx { namespace lcos {
                             next_future_data->set_on_completed(
                                 [this_ = HPX_MOVE(this_),
                                     next = HPX_FORWARD(Iter, next),
-                                    end = std::forward<Iter>(
-                                        end)]() mutable -> void {
-                                    return this_->template await_range<I>(
+                                    end = HPX_FORWARD(
+                                        Iter, end)]() mutable -> void {
+                                    this_->template await_range<I>(
                                         HPX_MOVE(next), HPX_MOVE(end));
                                 });
 
@@ -292,32 +299,26 @@ namespace hpx { namespace lcos {
 
                 // All elements of the sequence are ready now, proceed to the
                 // next argument.
-                do_await<I + 1>(is_end<I + 1>());
+                do_await<I + 1>();
             }
 
             template <std::size_t I>
-            HPX_FORCEINLINE void await_next(std::false_type, std::true_type)
+            HPX_FORCEINLINE void await_range()
             {
-                await_range<I>(util::begin(util::unwrap_ref(hpx::get<I>(t_))),
-                    util::end(util::unwrap_ref(hpx::get<I>(t_))));
+                await_range<I>(
+                    hpx::util::begin(hpx::util::unwrap_ref(hpx::get<I>(t_))),
+                    hpx::util::end(hpx::util::unwrap_ref(hpx::get<I>(t_))));
             }
 
             // Current element is a simple future
             template <std::size_t I>
-            HPX_FORCEINLINE void await_next(std::true_type, std::false_type)
+            HPX_FORCEINLINE void await_future()
             {
-                using future_type = util::decay_unwrap_t<
-                    typename hpx::tuple_element<I, Tuple>::type>;
-                using future_result_type =
-                    detail::future_or_shared_state_result_t<future_type>;
-
                 hpx::intrusive_ptr<wait_all_frame> this_(this);
-                traits::detail::shared_state_ptr_t<future_result_type>
-                    next_future_data =
-                        traits::detail::get_shared_state(hpx::get<I>(t_));
+                auto next_future_data =
+                    hpx::traits::detail::get_shared_state(hpx::get<I>(t_));
 
-                if (next_future_data.get() != nullptr &&
-                    !next_future_data->is_ready())
+                if (next_future_data && !next_future_data->is_ready())
                 {
                     next_future_data->execute_deferred();
 
@@ -329,38 +330,51 @@ namespace hpx { namespace lcos {
                         // (if any).
                         next_future_data->set_on_completed(
                             [this_ = HPX_MOVE(this_)]() -> void {
-                                return this_->template await_next<I>(
-                                    std::true_type(), std::false_type());
+                                this_->template await_future<I>();
                             });
 
                         return;
                     }
                 }
 
-                do_await<I + 1>(is_end<I + 1>());
+                do_await<I + 1>();
             }
 
             template <std::size_t I>
-            HPX_FORCEINLINE void do_await(std::false_type)
+            HPX_FORCEINLINE void do_await()
             {
-                using future_type = util::decay_unwrap_t<
-                    typename hpx::tuple_element<I, Tuple>::type>;
+                // Check if end of the tuple is reached
+                if constexpr (is_end_v<I>)
+                {
+                    // simply make ourself ready
+                    this->set_value(util::unused);
+                }
+                else
+                {
+                    using future_type = hpx::util::decay_unwrap_t<
+                        typename hpx::tuple_element<I, Tuple>::type>;
 
-                using is_future =
-                    detail::is_future_or_shared_state_t<future_type>;
-                using is_range =
-                    detail::is_future_or_shared_state_range_t<future_type>;
-
-                await_next<I>(is_future(), is_range());
+                    if constexpr (is_future_or_shared_state_v<future_type>)
+                    {
+                        await_future<I>();
+                    }
+                    else
+                    {
+                        static_assert(
+                            is_future_or_shared_state_range_v<future_type>,
+                            "element must be future or range of futures");
+                        await_range<I>();
+                    }
+                }
             }
 
         public:
             void wait_all()
             {
-                do_await<0>(is_end<0>());
+                do_await<0>();
 
-                // If there are still futures which are not ready, suspend and
-                // wait.
+                // If there are still futures which are not ready, suspend
+                // and wait.
                 if (!this->is_ready())
                 {
                     this->wait();
@@ -374,22 +388,46 @@ namespace hpx { namespace lcos {
 
     ///////////////////////////////////////////////////////////////////////////
     template <typename Future>
-    void wait_all(std::vector<Future> const& values)
+    void wait_all_nothrow(std::vector<Future> const& values)
     {
         using result_type = hpx::tuple<std::vector<Future> const&>;
-        using frame_type = detail::wait_all_frame<result_type>;
-        using init_no_addref = typename frame_type::init_no_addref;
+        using frame_type = hpx::detail::wait_all_frame<result_type>;
 
         result_type data(values);
-        hpx::intrusive_ptr<frame_type> frame(
-            new frame_type(init_no_addref{}, data), false);
+
+        // frame is initialized with initial reference count
+        hpx::intrusive_ptr<frame_type> frame(new frame_type(data), false);
         frame->wait_all();
+    }
+
+    template <typename Future>
+    void wait_all(std::vector<Future> const& values)
+    {
+        hpx::wait_all_nothrow(values);
+        hpx::detail::throw_if_exceptional(values);
+    }
+
+    template <typename Future>
+    HPX_FORCEINLINE void wait_all_nothrow(std::vector<Future>& values)
+    {
+        hpx::wait_all_nothrow(const_cast<std::vector<Future> const&>(values));
     }
 
     template <typename Future>
     HPX_FORCEINLINE void wait_all(std::vector<Future>& values)
     {
-        lcos::wait_all(const_cast<std::vector<Future> const&>(values));
+        hpx::wait_all_nothrow(const_cast<std::vector<Future> const&>(values));
+        hpx::detail::throw_if_exceptional(values);
+    }
+
+    template <typename Future>
+#if !defined(HPX_INTEL_VERSION)
+    HPX_FORCEINLINE
+#endif
+        void
+        wait_all_nothrow(std::vector<Future>&& values)
+    {
+        hpx::wait_all_nothrow(const_cast<std::vector<Future> const&>(values));
     }
 
     template <typename Future>
@@ -399,98 +437,202 @@ namespace hpx { namespace lcos {
         void
         wait_all(std::vector<Future>&& values)
     {
-        lcos::wait_all(const_cast<std::vector<Future> const&>(values));
+        hpx::wait_all_nothrow(const_cast<std::vector<Future> const&>(values));
+        hpx::detail::throw_if_exceptional(values);
     }
 
     ///////////////////////////////////////////////////////////////////////////
     template <typename Future, std::size_t N>
-    void wait_all(std::array<Future, N> const& values)
+    void wait_all_nothrow(std::array<Future, N> const& values)
     {
         using result_type = hpx::tuple<std::array<Future, N> const&>;
-        using frame_type = detail::wait_all_frame<result_type>;
-        using init_no_addref = typename frame_type::init_no_addref;
+        using frame_type = hpx::detail::wait_all_frame<result_type>;
 
         result_type data(values);
-        hpx::intrusive_ptr<frame_type> frame(
-            new frame_type(init_no_addref{}, data), false);
+
+        // frame is initialized with initial reference count
+        hpx::intrusive_ptr<frame_type> frame(new frame_type(data), false);
         frame->wait_all();
+    }
+
+    template <typename Future, std::size_t N>
+    void wait_all(std::array<Future, N> const& values)
+    {
+        hpx::wait_all_nothrow(values);
+        hpx::detail::throw_if_exceptional(values);
+    }
+
+    template <typename Future, std::size_t N>
+    HPX_FORCEINLINE void wait_all_nothrow(std::array<Future, N>& values)
+    {
+        hpx::wait_all_nothrow(const_cast<std::array<Future, N> const&>(values));
     }
 
     template <typename Future, std::size_t N>
     HPX_FORCEINLINE void wait_all(std::array<Future, N>& values)
     {
-        lcos::wait_all(const_cast<std::array<Future, N> const&>(values));
+        hpx::wait_all_nothrow(const_cast<std::array<Future, N> const&>(values));
+        hpx::detail::throw_if_exceptional(values);
+    }
+
+    template <typename Future, std::size_t N>
+    HPX_FORCEINLINE void wait_all_nothrow(std::array<Future, N>&& values)
+    {
+        hpx::wait_all_nothrow(const_cast<std::array<Future, N> const&>(values));
     }
 
     template <typename Future, std::size_t N>
     HPX_FORCEINLINE void wait_all(std::array<Future, N>&& values)
     {
-        lcos::wait_all(const_cast<std::array<Future, N> const&>(values));
+        hpx::wait_all_nothrow(const_cast<std::array<Future, N> const&>(values));
+        hpx::detail::throw_if_exceptional(values);
     }
 
     ///////////////////////////////////////////////////////////////////////////
-    template <typename Iterator>
-    typename util::always_void<
-        lcos::detail::future_iterator_traits_t<Iterator>>::type
-    wait_all(Iterator begin, Iterator end)
+    template <typename Iterator,
+        typename Enable =
+            std::enable_if_t<hpx::traits::is_iterator_v<Iterator>>>
+    void wait_all_nothrow(Iterator begin, Iterator end)
     {
-        using future_type = lcos::detail::future_iterator_traits_t<Iterator>;
-        using shared_state_ptr =
-            traits::detail::shared_state_ptr_for_t<future_type>;
-        using result_type = std::vector<shared_state_ptr>;
-
-        result_type values;
-        std::transform(begin, end, std::back_inserter(values),
-            traits::detail::wait_get_shared_state<future_type>());
-
-        lcos::wait_all(values);
+        auto values = traits::acquire_shared_state<Iterator>()(begin, end);
+        hpx::wait_all_nothrow(values);
     }
 
-    template <typename Iterator>
-    Iterator wait_all_n(Iterator begin, std::size_t count)
+    template <typename Iterator,
+        typename Enable =
+            std::enable_if_t<hpx::traits::is_iterator_v<Iterator>>>
+    void wait_all(Iterator begin, Iterator end)
     {
-        using future_type = lcos::detail::future_iterator_traits_t<Iterator>;
-        using shared_state_ptr =
-            traits::detail::shared_state_ptr_for_t<future_type>;
-        using result_type = std::vector<shared_state_ptr>;
-
-        result_type values;
-        values.reserve(count);
-
-        traits::detail::wait_get_shared_state<future_type> func;
-        for (std::size_t i = 0; i != count; ++i)
-        {
-            values.push_back(func(*begin++));
-        }
-
-        lcos::wait_all(values);
-
-        return begin;
+        auto values = traits::acquire_shared_state<Iterator>()(begin, end);
+        hpx::wait_all_nothrow(values);
+        hpx::detail::throw_if_exceptional(values);
     }
 
-    inline void wait_all() {}
+    ///////////////////////////////////////////////////////////////////////////
+    template <typename Iterator,
+        typename Enable =
+            std::enable_if_t<hpx::traits::is_iterator_v<Iterator>>>
+    void wait_all_n_nothrow(Iterator begin, std::size_t count)
+    {
+        auto values = traits::acquire_shared_state<Iterator>()(begin, count);
+        hpx::wait_all_nothrow(values);
+    }
+
+    template <typename Iterator,
+        typename Enable =
+            std::enable_if_t<hpx::traits::is_iterator_v<Iterator>>>
+    void wait_all_n(Iterator begin, std::size_t count)
+    {
+        auto values = traits::acquire_shared_state<Iterator>()(begin, count);
+        hpx::wait_all_nothrow(values);
+        hpx::detail::throw_if_exceptional(values);
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    constexpr inline void wait_all_nothrow() noexcept {}
+    constexpr inline void wait_all() noexcept {}
 
     ///////////////////////////////////////////////////////////////////////////
     template <typename... Ts>
-    void wait_all(Ts&&... ts)
+    void wait_all_nothrow(Ts&&... ts)
     {
         using result_type =
             hpx::tuple<traits::detail::shared_state_ptr_for_t<Ts>...>;
         using frame_type = detail::wait_all_frame<result_type>;
-        using init_no_addref = typename frame_type::init_no_addref;
 
         result_type values =
-            result_type(traits::detail::get_shared_state(ts)...);
+            result_type(hpx::traits::detail::get_shared_state(ts)...);
 
-        hpx::intrusive_ptr<frame_type> frame(
-            new frame_type(init_no_addref{}, values), false);
+        // frame is initialized with initial reference count
+        hpx::intrusive_ptr<frame_type> frame(new frame_type(values), false);
         frame->wait_all();
     }
-}}    // namespace hpx::lcos
 
-namespace hpx {
-    using lcos::wait_all;
-    using lcos::wait_all_n;
+    template <typename... Ts>
+    void wait_all(Ts&&... ts)
+    {
+        hpx::wait_all_nothrow(ts...);
+        hpx::detail::throw_if_exceptional(HPX_FORWARD(Ts, ts)...);
+    }
 }    // namespace hpx
+
+namespace hpx::lcos {
+
+    template <typename Future>
+    HPX_DEPRECATED_V(
+        1, 8, "hpx::lcos::wait_all is deprecated. Use hpx::wait_all instead.")
+    void wait_all(std::vector<Future> const& values)
+    {
+        hpx::wait_all(values);
+    }
+
+    template <typename Future>
+    HPX_DEPRECATED_V(
+        1, 8, "hpx::lcos::wait_all is deprecated. Use hpx::wait_all instead.")
+    void wait_all(std::vector<Future>& values)
+    {
+        hpx::wait_all(values);
+    }
+
+    template <typename Future>
+    HPX_DEPRECATED_V(
+        1, 8, "hpx::lcos::wait_all is deprecated. Use hpx::wait_all instead.")
+    void wait_all(std::vector<Future>&& values)
+    {
+        hpx::wait_all(HPX_MOVE(values));
+    }
+
+    template <typename Iterator,
+        typename Enable =
+            std::enable_if_t<hpx::traits::is_iterator_v<Iterator>>>
+    HPX_DEPRECATED_V(
+        1, 8, "hpx::lcos::wait_all is deprecated. Use hpx::wait_all instead.")
+    void wait_all(Iterator begin, Iterator end)
+    {
+        hpx::wait_all(begin, end);
+    }
+
+    template <typename Future, std::size_t N>
+    HPX_DEPRECATED_V(
+        1, 8, "hpx::lcos::wait_all is deprecated. Use hpx::wait_all instead.")
+    void wait_all(std::array<Future, N> const& values)
+    {
+        hpx::wait_all(values);
+    }
+
+    template <typename Future, std::size_t N>
+    HPX_DEPRECATED_V(
+        1, 8, "hpx::lcos::wait_all is deprecated. Use hpx::wait_all instead.")
+    void wait_all(std::array<Future, N>& values)
+    {
+        hpx::wait_all(const_cast<std::array<Future, N> const&>(values));
+    }
+
+    template <typename Future, std::size_t N>
+    HPX_DEPRECATED_V(
+        1, 8, "hpx::lcos::wait_all is deprecated. Use hpx::wait_all instead.")
+    void wait_all(std::array<Future, N>&& values)
+    {
+        hpx::wait_all(HPX_MOVE(values));
+    }
+
+    template <typename... Ts>
+    HPX_DEPRECATED_V(
+        1, 8, "hpx::lcos::wait_all is deprecated. Use hpx::wait_all instead.")
+    void wait_all(Ts&&... ts)
+    {
+        hpx::wait_all(HPX_FORWARD(Ts, ts)...);
+    }
+
+    template <typename Iterator,
+        typename Enable =
+            std::enable_if_t<hpx::traits::is_iterator_v<Iterator>>>
+    HPX_DEPRECATED_V(1, 8,
+        "hpx::lcos::wait_all_n is deprecated. Use hpx::wait_all_n instead.")
+    void wait_all_n(Iterator begin, std::size_t count)
+    {
+        hpx::wait_all_n(begin, count);
+    }
+}    // namespace hpx::lcos
 
 #endif    // DOXYGEN

--- a/libs/core/async_combinators/include/hpx/async_combinators/wait_any.hpp
+++ b/libs/core/async_combinators/include/hpx/async_combinators/wait_any.hpp
@@ -28,7 +28,7 @@ namespace hpx {
     ///
     /// \note           The function wait_any will rethrow any exceptions
     ///                 captured by the futures while becoming ready. If this
-    ///                 behavior is undesireable, use \a wait_any_nothrow
+    ///                 behavior is undesirable, use \a wait_any_nothrow
     ///                 instead.
     ///
     template <typename InputIter>
@@ -48,7 +48,7 @@ namespace hpx {
     ///
     /// \note           The function wait_any will rethrow any exceptions
     ///                 captured by the futures while becoming ready. If this
-    ///                 behavior is undesireable, use \a wait_any_nothrow
+    ///                 behavior is undesirable, use \a wait_any_nothrow
     ///                 instead.
     ///
     template <typename R>
@@ -68,7 +68,7 @@ namespace hpx {
     ///
     /// \note           The function wait_any will rethrow any exceptions
     ///                 captured by the futures while becoming ready. If this
-    ///                 behavior is undesireable, use \a wait_any_nothrow
+    ///                 behavior is undesirable, use \a wait_any_nothrow
     ///                 instead.
     ///
     template <typename R, std::size_t N>
@@ -88,7 +88,7 @@ namespace hpx {
     ///
     /// \note           The function wait_any will rethrow any exceptions
     ///                 captured by the futures while becoming ready. If this
-    ///                 behavior is undesireable, use \a wait_any_nothrow
+    ///                 behavior is undesirable, use \a wait_any_nothrow
     ///                 instead.
     ///
     template <typename... T>
@@ -110,7 +110,7 @@ namespace hpx {
     ///
     /// \note           The function wait_any_n will rethrow any exceptions
     ///                 captured by the futures while becoming ready. If this
-    ///                 behavior is undesireable, use \a wait_any_n_nothrow
+    ///                 behavior is undesirable, use \a wait_any_n_nothrow
     ///                 instead.
     ///
     template <typename InputIter>
@@ -123,6 +123,7 @@ namespace hpx {
 #include <hpx/async_combinators/wait_some.hpp>
 #include <hpx/datastructures/tuple.hpp>
 #include <hpx/futures/future.hpp>
+#include <hpx/iterator_support/traits/is_iterator.hpp>
 #include <hpx/preprocessor/strip_parens.hpp>
 #include <hpx/type_support/always_void.hpp>
 
@@ -276,7 +277,7 @@ namespace hpx::lcos {
     template <typename Future>
     HPX_DEPRECATED_V(
         1, 8, "hpx::lcos::wait_any is deprecated. Use hpx::wait_any instead.")
-    void wait_any(std::vector<Future> const& futures, error_code& ec = throws)
+    void wait_any(std::vector<Future> const& futures, error_code& = throws)
     {
         hpx::wait_some(1, futures);
     }
@@ -284,7 +285,7 @@ namespace hpx::lcos {
     template <typename Future>
     HPX_DEPRECATED_V(
         1, 8, "hpx::lcos::wait_any is deprecated. Use hpx::wait_any instead.")
-    void wait_any(std::vector<Future>& lazy_values, error_code& ec = throws)
+    void wait_any(std::vector<Future>& lazy_values, error_code& = throws)
     {
         hpx::wait_any(const_cast<std::vector<Future> const&>(lazy_values));
     }
@@ -292,7 +293,7 @@ namespace hpx::lcos {
     template <typename Future>
     HPX_DEPRECATED_V(
         1, 8, "hpx::lcos::wait_any is deprecated. Use hpx::wait_any instead.")
-    void wait_any(std::vector<Future>&& lazy_values, error_code& ec = throws)
+    void wait_any(std::vector<Future>&& lazy_values, error_code& = throws)
     {
         hpx::wait_any(const_cast<std::vector<Future> const&>(lazy_values));
     }
@@ -301,7 +302,7 @@ namespace hpx::lcos {
     template <typename Future, std::size_t N>
     HPX_DEPRECATED_V(
         1, 8, "hpx::lcos::wait_any is deprecated. Use hpx::wait_any instead.")
-    void wait_any(std::array<Future, N> const& futures, error_code& ec = throws)
+    void wait_any(std::array<Future, N> const& futures, error_code& = throws)
     {
         hpx::wait_some(1, futures);
     }
@@ -309,7 +310,7 @@ namespace hpx::lcos {
     template <typename Future, std::size_t N>
     HPX_DEPRECATED_V(
         1, 8, "hpx::lcos::wait_any is deprecated. Use hpx::wait_any instead.")
-    void wait_any(std::array<Future, N>& lazy_values, error_code& ec = throws)
+    void wait_any(std::array<Future, N>& lazy_values, error_code& = throws)
     {
         hpx::wait_any(const_cast<std::array<Future, N> const&>(lazy_values));
     }
@@ -317,7 +318,7 @@ namespace hpx::lcos {
     template <typename Future, std::size_t N>
     HPX_DEPRECATED_V(
         1, 8, "hpx::lcos::wait_any is deprecated. Use hpx::wait_any instead.")
-    void wait_any(std::array<Future, N>&& lazy_values, error_code& ec = throws)
+    void wait_any(std::array<Future, N>&& lazy_values, error_code& = throws)
     {
         hpx::wait_any(const_cast<std::array<Future, N> const&>(lazy_values));
     }
@@ -328,14 +329,14 @@ namespace hpx::lcos {
             std::enable_if_t<hpx::traits::is_iterator_v<Iterator>>>
     HPX_DEPRECATED_V(
         1, 8, "hpx::lcos::wait_any is deprecated. Use hpx::wait_any instead.")
-    void wait_any(Iterator begin, Iterator end, error_code& ec = throws)
+    void wait_any(Iterator begin, Iterator end, error_code& = throws)
     {
         hpx::wait_some(1, begin, end);
     }
 
     HPX_DEPRECATED_V(
         1, 8, "hpx::lcos::wait_any is deprecated. Use hpx::wait_any instead.")
-    inline void wait_any(error_code& ec = throws)
+    inline void wait_any(error_code& = throws)
     {
         hpx::wait_some(1);
     }
@@ -346,7 +347,7 @@ namespace hpx::lcos {
             std::enable_if_t<hpx::traits::is_iterator_v<Iterator>>>
     HPX_DEPRECATED_V(
         1, 8, "hpx::lcos::wait_any is deprecated. Use hpx::wait_any instead.")
-    void wait_any_n(Iterator begin, std::size_t count, error_code& ec = throws)
+    void wait_any_n(Iterator begin, std::size_t count, error_code& = throws)
     {
         hpx::wait_some_n(1, begin, count);
     }

--- a/libs/core/async_combinators/include/hpx/async_combinators/wait_any.hpp
+++ b/libs/core/async_combinators/include/hpx/async_combinators/wait_any.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2015 Hartmut Kaiser
+//  Copyright (c) 2007-2021 Hartmut Kaiser
 //  Copyright (c) 2013 Agustin Berge
 //
 //  SPDX-License-Identifier: BSL-1.0
@@ -21,22 +21,18 @@ namespace hpx {
     /// \param last     [in] The iterator pointing to the last element of a
     ///                 sequence of \a future or \a shared_future objects for
     ///                 which \a wait_any should wait.
-    /// \param ec       [in,out] this represents the error status on exit, if
-    ///                 this is pre-initialized to \a hpx#throws the function
-    ///                 will throw on error instead.
     ///
     /// \note The function \a wait_any returns after at least one future has
     ///       become ready. All input futures are still valid after \a wait_any
     ///       returns.
     ///
-    /// \note     As long as \a ec is not pre-initialized to \a hpx::throws this
-    ///           function doesn't throw but returns the result code using the
-    ///           parameter \a ec. Otherwise it throws an instance of
-    ///           \a hpx::exception.
+    /// \note           The function wait_any will rethrow any exceptions
+    ///                 captured by the futures while becoming ready. If this
+    ///                 behavior is undesireable, use \a wait_any_nothrow
+    ///                 instead.
     ///
-    /// \note     None of the futures in the input sequence are invalidated.
     template <typename InputIter>
-    void wait_any(InputIter first, InputIter last, error_code& ec = throws);
+    void wait_any(InputIter first, InputIter last);
 
     /// The function \a wait_any is a non-deterministic choice operator. It
     /// OR-composes all future objects given and returns after one future of
@@ -45,22 +41,18 @@ namespace hpx {
     /// \param futures  [in] A vector holding an arbitrary amount of \a future or
     ///                 \a shared_future objects for which \a wait_any should
     ///                 wait.
-    /// \param ec       [in,out] this represents the error status on exit, if
-    ///                 this is pre-initialized to \a hpx#throws the function
-    ///                 will throw on error instead.
     ///
     /// \note The function \a wait_any returns after at least one future has
     ///       become ready. All input futures are still valid after \a wait_any
     ///       returns.
     ///
-    /// \note     As long as \a ec is not pre-initialized to \a hpx::throws this
-    ///           function doesn't throw but returns the result code using the
-    ///           parameter \a ec. Otherwise it throws an instance of
-    ///           \a hpx::exception.
+    /// \note           The function wait_any will rethrow any exceptions
+    ///                 captured by the futures while becoming ready. If this
+    ///                 behavior is undesireable, use \a wait_any_nothrow
+    ///                 instead.
     ///
-    /// \note     None of the futures in the input sequence are invalidated.
     template <typename R>
-    void wait_any(std::vector<future<R>>& futures, error_code& ec = throws);
+    void wait_any(std::vector<future<R>>& futures);
 
     /// The function \a wait_any is a non-deterministic choice operator. It
     /// OR-composes all future objects given and returns after one future of
@@ -69,47 +61,18 @@ namespace hpx {
     /// \param futures  [in] Amn array holding an arbitrary amount of \a future or
     ///                 \a shared_future objects for which \a wait_any should
     ///                 wait.
-    /// \param ec       [in,out] this represents the error status on exit, if
-    ///                 this is pre-initialized to \a hpx#throws the function
-    ///                 will throw on error instead.
     ///
     /// \note The function \a wait_any returns after at least one future has
     ///       become ready. All input futures are still valid after \a wait_any
     ///       returns.
     ///
-    /// \note     As long as \a ec is not pre-initialized to \a hpx::throws this
-    ///           function doesn't throw but returns the result code using the
-    ///           parameter \a ec. Otherwise it throws an instance of
-    ///           \a hpx::exception.
+    /// \note           The function wait_any will rethrow any exceptions
+    ///                 captured by the futures while becoming ready. If this
+    ///                 behavior is undesireable, use \a wait_any_nothrow
+    ///                 instead.
     ///
-    /// \note     None of the futures in the input sequence are invalidated.
-    template <typename R, std:;
-    size_t N > void wait_any(
-                   std::array<future<R>, N>& futures, error_code& ec = throws);
-
-    /// The function \a wait_any is a non-deterministic choice operator. It
-    /// OR-composes all future objects given and returns after one future of
-    /// that list finishes execution.
-    ///
-    /// \param futures  [in] An arbitrary number of \a future or \a shared_future
-    ///                 objects, possibly holding different types for which
-    ///                 \a wait_any should wait.
-    /// \param ec       [in,out] this represents the error status on exit, if
-    ///                 this is pre-initialized to \a hpx#throws the function
-    ///                 will throw on error instead.
-    ///
-    /// \note The function \a wait_any returns after at least one future has
-    ///       become ready. All input futures are still valid after \a wait_any
-    ///       returns.
-    ///
-    /// \note     As long as \a ec is not pre-initialized to \a hpx::throws this
-    ///           function doesn't throw but returns the result code using the
-    ///           parameter \a ec. Otherwise it throws an instance of
-    ///           \a hpx::exception.
-    ///
-    /// \note     None of the futures in the input sequence are invalidated.
-    template <typename... T>
-    void wait_any(error_code& ec, T&&... futures);
+    template <typename R, std::size_t N>
+    void wait_any(std::array<future<R>, N>& futures);
 
     /// The function \a wait_any is a non-deterministic choice operator. It
     /// OR-composes all future objects given and returns after one future of
@@ -123,7 +86,11 @@ namespace hpx {
     ///       become ready. All input futures are still valid after \a wait_any
     ///       returns.
     ///
-    /// \note     None of the futures in the input sequence are invalidated.
+    /// \note           The function wait_any will rethrow any exceptions
+    ///                 captured by the futures while becoming ready. If this
+    ///                 behavior is undesireable, use \a wait_any_nothrow
+    ///                 instead.
+    ///
     template <typename... T>
     void wait_any(T&&... futures);
 
@@ -136,27 +103,18 @@ namespace hpx {
     ///                 which \a wait_any_n should wait.
     /// \param count    [in] The number of elements in the sequence starting at
     ///                 \a first.
-    /// \param ec       [in,out] this represents the error status on exit, if
-    ///                 this is pre-initialized to \a hpx#throws the function
-    ///                 will throw on error instead.
     ///
     /// \note The function \a wait_any_n returns after at least one future has
     ///       become ready. All input futures are still valid after \a wait_any_n
     ///       returns.
     ///
-    /// \return         The function \a wait_all_n will return an iterator
-    ///                 referring to the first element in the input sequence
-    ///                 after the last processed element.
+    /// \note           The function wait_any_n will rethrow any exceptions
+    ///                 captured by the futures while becoming ready. If this
+    ///                 behavior is undesireable, use \a wait_any_n_nothrow
+    ///                 instead.
     ///
-    /// \note     As long as \a ec is not pre-initialized to \a hpx::throws this
-    ///           function doesn't throw but returns the result code using the
-    ///           parameter \a ec. Otherwise it throws an instance of
-    ///           \a hpx::exception.
-    ///
-    /// \note     None of the futures in the input sequence are invalidated.
     template <typename InputIter>
-    InputIter wait_any_n(
-        InputIter first, std::size_t count, error_code& ec = throws);
+    void wait_any_n(InputIter first, std::size_t count);
 }    // namespace hpx
 
 #else    // DOXYGEN
@@ -174,88 +132,233 @@ namespace hpx {
 #include <vector>
 
 ///////////////////////////////////////////////////////////////////////////////
-namespace hpx { namespace lcos {
+namespace hpx {
+
     ///////////////////////////////////////////////////////////////////////////
     template <typename Future>
-    void wait_any(std::vector<Future> const& futures, error_code& ec = throws)
+    void wait_any_nothrow(std::vector<Future> const& futures)
     {
-        return lcos::wait_some(1, futures, ec);
+        hpx::wait_some_nothrow(1, futures);
     }
 
     template <typename Future>
-    void wait_any(std::vector<Future>& lazy_values, error_code& ec = throws)
+    void wait_any(std::vector<Future> const& futures)
     {
-        return lcos::wait_any(
-            const_cast<std::vector<Future> const&>(lazy_values), ec);
+        hpx::wait_some(1, futures);
     }
 
     template <typename Future>
-    void wait_any(std::vector<Future>&& lazy_values, error_code& ec = throws)
+    void wait_any_nothrow(std::vector<Future>& lazy_values)
     {
-        return lcos::wait_any(
-            const_cast<std::vector<Future> const&>(lazy_values), ec);
+        hpx::wait_any_nothrow(
+            const_cast<std::vector<Future> const&>(lazy_values));
+    }
+
+    template <typename Future>
+    void wait_any(std::vector<Future>& lazy_values)
+    {
+        hpx::wait_any(const_cast<std::vector<Future> const&>(lazy_values));
+    }
+
+    template <typename Future>
+    void wait_any_nothrow(std::vector<Future>&& lazy_values)
+    {
+        hpx::wait_any_nothrow(
+            const_cast<std::vector<Future> const&>(lazy_values));
+    }
+
+    template <typename Future>
+    void wait_any(std::vector<Future>&& lazy_values)
+    {
+        hpx::wait_any(const_cast<std::vector<Future> const&>(lazy_values));
     }
 
     ///////////////////////////////////////////////////////////////////////////
     template <typename Future, std::size_t N>
-    void wait_any(std::array<Future, N> const& futures, error_code& ec = throws)
+    void wait_any_nothrow(std::array<Future, N> const& futures)
     {
-        return lcos::wait_some(1, futures, ec);
+        hpx::wait_some_nothrow(1, futures);
     }
 
     template <typename Future, std::size_t N>
-    void wait_any(std::array<Future, N>& lazy_values, error_code& ec = throws)
+    void wait_any(std::array<Future, N> const& futures)
     {
-        return lcos::wait_any(
-            const_cast<std::array<Future, N> const&>(lazy_values), ec);
+        hpx::wait_some(1, futures);
     }
 
     template <typename Future, std::size_t N>
-    void wait_any(std::array<Future, N>&& lazy_values, error_code& ec = throws)
+    void wait_any_nothrow(std::array<Future, N>& lazy_values)
     {
-        return lcos::wait_any(
-            const_cast<std::array<Future, N> const&>(lazy_values), ec);
+        hpx::wait_any_nothrow(
+            const_cast<std::array<Future, N> const&>(lazy_values));
+    }
+
+    template <typename Future, std::size_t N>
+    void wait_any(std::array<Future, N>& lazy_values)
+    {
+        hpx::wait_any(const_cast<std::array<Future, N> const&>(lazy_values));
+    }
+
+    template <typename Future, std::size_t N>
+    void wait_any_nothrow(std::array<Future, N>&& lazy_values)
+    {
+        hpx::wait_any_nothrow(
+            const_cast<std::array<Future, N> const&>(lazy_values));
+    }
+
+    template <typename Future, std::size_t N>
+    void wait_any(std::array<Future, N>&& lazy_values)
+    {
+        hpx::wait_any(const_cast<std::array<Future, N> const&>(lazy_values));
     }
 
     ///////////////////////////////////////////////////////////////////////////
-    template <typename Iterator>
-    typename util::always_void<
-        typename lcos::detail::future_iterator_traits<Iterator>::type>::type
-    wait_any(Iterator begin, Iterator end, error_code& ec = throws)
+    template <typename Iterator,
+        typename Enable =
+            std::enable_if_t<hpx::traits::is_iterator_v<Iterator>>>
+    void wait_any_nothrow(Iterator begin, Iterator end)
     {
-        return lcos::wait_some(1, begin, end, ec);
+        hpx::wait_some_nothrow(1, begin, end);
     }
 
-    inline void wait_any(error_code& ec = throws)
+    template <typename Iterator,
+        typename Enable =
+            std::enable_if_t<hpx::traits::is_iterator_v<Iterator>>>
+    void wait_any(Iterator begin, Iterator end)
     {
-        return lcos::wait_some(1, ec);
+        hpx::wait_some(1, begin, end);
+    }
+
+    inline void wait_any_nothrow()
+    {
+        hpx::wait_some_nothrow(1);
+    }
+
+    inline void wait_any()
+    {
+        hpx::wait_some(1);
     }
 
     ///////////////////////////////////////////////////////////////////////////
-    template <typename Iterator>
-    Iterator wait_any_n(
-        Iterator begin, std::size_t count, error_code& ec = throws)
+    template <typename Iterator,
+        typename Enable =
+            std::enable_if_t<hpx::traits::is_iterator_v<Iterator>>>
+    void wait_any_n_nothrow(Iterator begin, std::size_t count)
     {
-        return wait_some_n(1, begin, count, ec);
+        hpx::wait_some_n_nothrow(1, begin, count);
+    }
+
+    template <typename Iterator,
+        typename Enable =
+            std::enable_if_t<hpx::traits::is_iterator_v<Iterator>>>
+    void wait_any_n(Iterator begin, std::size_t count)
+    {
+        hpx::wait_some_n(1, begin, count);
     }
 
     ///////////////////////////////////////////////////////////////////////////
     template <typename... Ts>
-    void wait_any(error_code& ec, Ts&&... ts)
+    void wait_any_nothrow(Ts&&... ts)
     {
-        return lcos::wait_some(1, ec, HPX_FORWARD(Ts, ts)...);
+        hpx::wait_some_nothrow(1, HPX_FORWARD(Ts, ts)...);
     }
 
     template <typename... Ts>
     void wait_any(Ts&&... ts)
     {
-        return lcos::wait_some(1, HPX_FORWARD(Ts, ts)...);
+        hpx::wait_some(1, HPX_FORWARD(Ts, ts)...);
     }
-}}    // namespace hpx::lcos
-
-namespace hpx {
-    using lcos::wait_any;
-    using lcos::wait_any_n;
 }    // namespace hpx
+
+namespace hpx::lcos {
+
+    ///////////////////////////////////////////////////////////////////////////
+    template <typename Future>
+    HPX_DEPRECATED_V(
+        1, 8, "hpx::lcos::wait_any is deprecated. Use hpx::wait_any instead.")
+    void wait_any(std::vector<Future> const& futures, error_code& ec = throws)
+    {
+        hpx::wait_some(1, futures);
+    }
+
+    template <typename Future>
+    HPX_DEPRECATED_V(
+        1, 8, "hpx::lcos::wait_any is deprecated. Use hpx::wait_any instead.")
+    void wait_any(std::vector<Future>& lazy_values, error_code& ec = throws)
+    {
+        hpx::wait_any(const_cast<std::vector<Future> const&>(lazy_values));
+    }
+
+    template <typename Future>
+    HPX_DEPRECATED_V(
+        1, 8, "hpx::lcos::wait_any is deprecated. Use hpx::wait_any instead.")
+    void wait_any(std::vector<Future>&& lazy_values, error_code& ec = throws)
+    {
+        hpx::wait_any(const_cast<std::vector<Future> const&>(lazy_values));
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    template <typename Future, std::size_t N>
+    HPX_DEPRECATED_V(
+        1, 8, "hpx::lcos::wait_any is deprecated. Use hpx::wait_any instead.")
+    void wait_any(std::array<Future, N> const& futures, error_code& ec = throws)
+    {
+        hpx::wait_some(1, futures);
+    }
+
+    template <typename Future, std::size_t N>
+    HPX_DEPRECATED_V(
+        1, 8, "hpx::lcos::wait_any is deprecated. Use hpx::wait_any instead.")
+    void wait_any(std::array<Future, N>& lazy_values, error_code& ec = throws)
+    {
+        hpx::wait_any(const_cast<std::array<Future, N> const&>(lazy_values));
+    }
+
+    template <typename Future, std::size_t N>
+    HPX_DEPRECATED_V(
+        1, 8, "hpx::lcos::wait_any is deprecated. Use hpx::wait_any instead.")
+    void wait_any(std::array<Future, N>&& lazy_values, error_code& ec = throws)
+    {
+        hpx::wait_any(const_cast<std::array<Future, N> const&>(lazy_values));
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    template <typename Iterator,
+        typename Enable =
+            std::enable_if_t<hpx::traits::is_iterator_v<Iterator>>>
+    HPX_DEPRECATED_V(
+        1, 8, "hpx::lcos::wait_any is deprecated. Use hpx::wait_any instead.")
+    void wait_any(Iterator begin, Iterator end, error_code& ec = throws)
+    {
+        hpx::wait_some(1, begin, end);
+    }
+
+    HPX_DEPRECATED_V(
+        1, 8, "hpx::lcos::wait_any is deprecated. Use hpx::wait_any instead.")
+    inline void wait_any(error_code& ec = throws)
+    {
+        hpx::wait_some(1);
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    template <typename Iterator,
+        typename Enable =
+            std::enable_if_t<hpx::traits::is_iterator_v<Iterator>>>
+    HPX_DEPRECATED_V(
+        1, 8, "hpx::lcos::wait_any is deprecated. Use hpx::wait_any instead.")
+    void wait_any_n(Iterator begin, std::size_t count, error_code& ec = throws)
+    {
+        hpx::wait_some_n(1, begin, count);
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    template <typename... Ts>
+    HPX_DEPRECATED_V(
+        1, 8, "hpx::lcos::wait_any is deprecated. Use hpx::wait_any instead.")
+    void wait_any(Ts&&... ts)
+    {
+        hpx::wait_some(1, HPX_FORWARD(Ts, ts)...);
+    }
+}    // namespace hpx::lcos
 
 #endif    // DOXYGEN

--- a/libs/core/async_combinators/include/hpx/async_combinators/wait_each.hpp
+++ b/libs/core/async_combinators/include/hpx/async_combinators/wait_each.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2015 Hartmut Kaiser
+//  Copyright (c) 2007-2021 Hartmut Kaiser
 //  Copyright (c) 2013 Agustin Berge
 //  Copyright (c) 2016 Lukas Troska
 //
@@ -118,6 +118,7 @@ namespace hpx {
 #include <hpx/config.hpp>
 #include <hpx/async_combinators/when_each.hpp>
 #include <hpx/futures/traits/is_future.hpp>
+#include <hpx/iterator_support/traits/is_iterator.hpp>
 #include <hpx/type_support/pack.hpp>
 
 #include <cstddef>
@@ -126,26 +127,31 @@ namespace hpx {
 #include <vector>
 
 ///////////////////////////////////////////////////////////////////////////////
-namespace hpx { namespace lcos {
+namespace hpx {
+
     template <typename F, typename Future>
-    void wait_each(F&& f, std::vector<Future>& lazy_values)
+    void wait_each(F&& f, std::vector<Future>& values)
     {
-        lcos::when_each(HPX_FORWARD(F, f), lazy_values).wait();
+        lcos::when_each(HPX_FORWARD(F, f), values).wait();
     }
 
     template <typename F, typename Future>
-    void wait_each(F&& f, std::vector<Future>&& lazy_values)
+    void wait_each(F&& f, std::vector<Future>&& values)
     {
-        lcos::when_each(HPX_FORWARD(F, f), lazy_values).wait();
+        lcos::when_each(HPX_FORWARD(F, f), HPX_MOVE(values)).wait();
     }
 
-    template <typename F, typename Iterator>
+    template <typename F, typename Iterator,
+        typename Enable =
+            std::enable_if_t<hpx::traits::is_iterator_v<Iterator>>>
     void wait_each(F&& f, Iterator begin, Iterator end)
     {
         lcos::when_each(HPX_FORWARD(F, f), begin, end).wait();
     }
 
-    template <typename F, typename Iterator>
+    template <typename F, typename Iterator,
+        typename Enable =
+            std::enable_if_t<hpx::traits::is_iterator_v<Iterator>>>
     void wait_each_n(F&& f, Iterator begin, std::size_t count)
     {
         when_each_n(HPX_FORWARD(F, f), begin, count).wait();
@@ -158,19 +164,73 @@ namespace hpx { namespace lcos {
     }
 
     ///////////////////////////////////////////////////////////////////////////
-    template <typename F, typename... Ts>
-    typename std::enable_if<
-        !traits::is_future<typename std::decay<F>::type>::value &&
-        util::all_of<traits::is_future<Ts>...>::value>::type
-    wait_each(F&& f, Ts&&... ts)
+    template <typename F, typename... Ts,
+        typename Enable =
+            std::enable_if_t<!traits::is_future_v<std::decay_t<F>> &&
+                util::all_of_v<traits::is_future<Ts>...>>>
+    void wait_each(F&& f, Ts&&... ts)
     {
         lcos::when_each(HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...).wait();
     }
-}}    // namespace hpx::lcos
-
-namespace hpx {
-    using lcos::wait_each;
-    using lcos::wait_each_n;
 }    // namespace hpx
+
+namespace hpx::lcos {
+
+    template <typename F, typename Future>
+    HPX_DEPRECATED_V(
+        1, 8, "hpx::lcos::wait_each is deprecated. Use hpx::wait_each instead.")
+    void wait_each(F&& f, std::vector<Future>& values)
+    {
+        hpx::wait_each(HPX_FORWARD(F, f), values);
+    }
+
+    template <typename F, typename Future>
+    HPX_DEPRECATED_V(
+        1, 8, "hpx::lcos::wait_each is deprecated. Use hpx::wait_each instead.")
+    void wait_each(F&& f, std::vector<Future>&& values)
+    {
+        hpx::wait_each(HPX_FORWARD(F, f), HPX_MOVE(values));
+    }
+
+    template <typename F, typename Iterator,
+        typename Enable =
+            std::enable_if_t<hpx::traits::is_iterator_v<Iterator>>>
+    HPX_DEPRECATED_V(
+        1, 8, "hpx::lcos::wait_each is deprecated. Use hpx::wait_each instead.")
+    void wait_each(F&& f, Iterator begin, Iterator end)
+    {
+        hpx::wait_each(HPX_FORWARD(F, f), begin, end);
+    }
+
+    template <typename F, typename Iterator,
+        typename Enable =
+            std::enable_if_t<hpx::traits::is_iterator_v<Iterator>>>
+    HPX_DEPRECATED_V(
+        1, 8, "hpx::lcos::wait_each is deprecated. Use hpx::wait_each instead.")
+    void wait_each_n(F&& f, Iterator begin, std::size_t count)
+    {
+        hpx::wait_each_n(HPX_FORWARD(F, f), begin, count);
+    }
+
+    template <typename F>
+    HPX_DEPRECATED_V(
+        1, 8, "hpx::lcos::wait_each is deprecated. Use hpx::wait_each instead.")
+    void wait_each(F&& f)
+    {
+        hpx::wait_each(HPX_FORWARD(F, f));
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    template <typename F, typename... Ts,
+        typename Enable =
+            std::enable_if_t<!traits::is_future_v<std::decay_t<F>> &&
+                util::all_of_v<traits::is_future<Ts>...>>>
+    HPX_DEPRECATED_V(
+        1, 8, "hpx::lcos::wait_each is deprecated. Use hpx::wait_each instead.")
+    void wait_each(F&& f, Ts&&... ts)
+    {
+        hpx::wait_each(HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...);
+    }
+}    // namespace hpx::lcos
 
 #endif    // DOXYGEN

--- a/libs/core/async_combinators/include/hpx/async_combinators/wait_some.hpp
+++ b/libs/core/async_combinators/include/hpx/async_combinators/wait_some.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2017 Hartmut Kaiser
+//  Copyright (c) 2007-2021 Hartmut Kaiser
 //  Copyright (c) 2013 Agustin Berge
 //
 //  SPDX-License-Identifier: BSL-1.0
@@ -17,38 +17,25 @@ namespace hpx {
     /// after n of them finished executing.
     ///
     /// \param n        [in] The number of futures out of the arguments which
-    ///                 have to become ready in order for the returned future
-    ///                 to get ready.
+    ///                 have to become ready in order for the function to return.
     /// \param first    [in] The iterator pointing to the first element of a
     ///                 sequence of \a future or \a shared_future objects for
     ///                 which \a when_all should wait.
     /// \param last     [in] The iterator pointing to the last element of a
     ///                 sequence of \a future or \a shared_future objects for
     ///                 which \a when_all should wait.
-    /// \param ec       [in,out] this represents the error status on exit, if
-    ///                 this is pre-initialized to \a hpx#throws the function
-    ///                 will throw on error instead.
     ///
-    /// \note The future returned by the function \a wait_some becomes ready
-    ///       when at least \a n argument futures have become ready.
+    /// \note The function \a wait_some returns after \a n futures have become
+    ///       ready. All input futures are still valid after \a wait_some
+    ///       returns.
     ///
-    /// \return   Returns a future holding the same list of futures as has
-    ///           been passed to wait_some.
-    ///           - future<vector<future<R>>>: If the input cardinality is
-    ///             unknown at compile time and the futures are all of the
-    ///             same type.
+    /// \note           The function wait_some will rethrow any exceptions
+    ///                 captured by the futures while becoming ready. If this
+    ///                 behavior is undesireable, use \a wait_some_nothrow
+    ///                 instead.
     ///
-    /// \note Calling this version of \a wait_some where first == last, returns
-    ///       a future with an empty vector that is immediately ready.
-    ///       Each future and shared_future is waited upon and then copied into
-    ///       the collection of the output (returned) future, maintaining the
-    ///       order of the futures in the input collection.
-    ///       The future returned by \a wait_some will not throw an exception,
-    ///       but the futures held in the output collection may.
     template <typename InputIter>
-    future<vector<future<typename std::iterator_traits<InputIter>::value_type>>>
-    wait_some(
-        std::size_t n, Iterator first, Iterator last, error_code& ec = throws);
+    void wait_some(std::size_t n, InputIter first, InputIter last);
 
     /// The function \a wait_some is an operator allowing to join on the result
     /// of all given futures. It AND-composes all future objects given and
@@ -61,22 +48,18 @@ namespace hpx {
     /// \param futures  [in] A vector holding an arbitrary amount of \a future
     ///                 or \a shared_future objects for which \a wait_some
     ///                 should wait.
-    /// \param ec       [in,out] this represents the error status on exit, if
-    ///                 this is pre-initialized to \a hpx#throws the function
-    ///                 will throw on error instead.
     ///
-    /// \note The function \a wait_all returns after \a n futures have become
-    ///       ready. All input futures are still valid after \a wait_all
+    /// \note The function \a wait_some returns after \a n futures have become
+    ///       ready. All input futures are still valid after \a wait_some
     ///       returns.
     ///
-    /// \note Each future and shared_future is waited upon and then copied into
-    ///       the collection of the output (returned) future, maintaining the
-    ///       order of the futures in the input collection.
-    ///       The future returned by \a wait_some will not throw an exception,
-    ///       but the futures held in the output collection may.
+    /// \note           The function wait_some will rethrow any exceptions
+    ///                 captured by the futures while becoming ready. If this
+    ///                 behavior is undesireable, use \a wait_some_nothrow
+    ///                 instead.
+    ///
     template <typename R>
-    void wait_some(std::size_t n, std::vector<future<R>>&& futures,
-        error_code& ec = throws);
+    void wait_some(std::size_t n, std::vector<future<R>>&& futures);
 
     /// The function \a wait_some is an operator allowing to join on the result
     /// of all given futures. It AND-composes all future objects given and
@@ -89,22 +72,18 @@ namespace hpx {
     /// \param futures  [in] An array holding an arbitrary amount of \a future
     ///                 or \a shared_future objects for which \a wait_some
     ///                 should wait.
-    /// \param ec       [in,out] this represents the error status on exit, if
-    ///                 this is pre-initialized to \a hpx#throws the function
-    ///                 will throw on error instead.
     ///
-    /// \note The function \a wait_all returns after \a n futures have become
-    ///       ready. All input futures are still valid after \a wait_all
+    /// \note The function \a wait_some returns after \a n futures have become
+    ///       ready. All input futures are still valid after \a wait_some
     ///       returns.
     ///
-    /// \note Each future and shared_future is waited upon and then copied into
-    ///       the collection of the output (returned) future, maintaining the
-    ///       order of the futures in the input collection.
-    ///       The future returned by \a wait_some will not throw an exception,
-    ///       but the futures held in the output collection may.
+    /// \note           The function wait_some will rethrow any exceptions
+    ///                 captured by the futures while becoming ready. If this
+    ///                 behavior is undesireable, use \a wait_some_nothrow
+    ///                 instead.
+    ///
     template <typename R, std::size_t N>
-    void wait_some(std::size_t n, std::array<future<R>, N>&& futures,
-        error_code& ec = throws);
+    void wait_some(std::size_t n, std::array<future<R>, N>&& futures);
 
     /// The function \a wait_some is an operator allowing to join on the result
     /// of all given futures. It AND-composes all future objects given and
@@ -122,18 +101,16 @@ namespace hpx {
     ///                 will throw on error instead.
     ///
     /// \note The function \a wait_all returns after \a n futures have become
-    ///       ready. All input futures are still valid after \a wait_all
+    ///       ready. All input futures are still valid after \a wait_some
     ///       returns.
     ///
-    /// \note Calling this version of \a wait_some where first == last, returns
-    ///       a future with an empty vector that is immediately ready.
-    ///       Each future and shared_future is waited upon and then copied into
-    ///       the collection of the output (returned) future, maintaining the
-    ///       order of the futures in the input collection.
-    ///       The future returned by \a wait_some will not throw an exception,
-    ///       but the futures held in the output collection may.
+    /// \note           The function wait_some will rethrow any exceptions
+    ///                 captured by the futures while becoming ready. If this
+    ///                 behavior is undesireable, use \a wait_some_nothrow
+    ///                 instead.
+    ///
     template <typename... T>
-    void wait_some(std::size_t n, T&&... futures, error_code& ec = throws);
+    void wait_some(std::size_t n, T&&... futures);
 
     /// The function \a wait_some_n is an operator allowing to join on the result
     /// of all given futures. It AND-composes all future objects given and
@@ -148,34 +125,24 @@ namespace hpx {
     ///                 which \a when_all should wait.
     /// \param count    [in] The number of elements in the sequence starting at
     ///                 \a first.
-    /// \param ec       [in,out] this represents the error status on exit, if
-    ///                 this is pre-initialized to \a hpx#throws the function
-    ///                 will throw on error instead.
     ///
-    /// \note The function \a wait_all returns after \a n futures have become
-    ///       ready. All input futures are still valid after \a wait_all
+    /// \note The function \a wait_some_n returns after \a n futures have become
+    ///       ready. All input futures are still valid after \a wait_some_n
     ///       returns.
     ///
-    /// \return This function returns an Iterator referring to the first
-    ///         element after the last processed input element.
+    /// \note           The function wait_some_n will rethrow any exceptions
+    ///                 captured by the futures while becoming ready. If this
+    ///                 behavior is undesireable, use \a wait_some_n_nothrow
+    ///                 instead.
     ///
-    /// \note Calling this version of \a wait_some_n where count == 0, returns
-    ///       a future with the same elements as the arguments that is
-    ///       immediately ready. Possibly none of the futures in that vector
-    ///       are ready.
-    ///       Each future and shared_future is waited upon and then copied into
-    ///       the collection of the output (returned) future, maintaining the
-    ///       order of the futures in the input collection.
-    ///       The future returned by \a wait_some_n will not throw an exception,
-    ///       but the futures held in the output collection may.
     template <typename InputIter>
-    InputIter wait_some_n(std::size_t n, Iterator first, std::size_t count,
-        error_code& ec = throws);
+    void wait_some_n(std::size_t n, InputIter first, std::size_t count);
 }    // namespace hpx
 #else
 
 #include <hpx/config.hpp>
 #include <hpx/assert.hpp>
+#include <hpx/async_combinators/detail/throw_if_exceptional.hpp>
 #include <hpx/datastructures/tuple.hpp>
 #include <hpx/functional/deferred_call.hpp>
 #include <hpx/futures/future.hpp>
@@ -183,6 +150,7 @@ namespace hpx {
 #include <hpx/futures/traits/detail/future_traits.hpp>
 #include <hpx/futures/traits/future_access.hpp>
 #include <hpx/futures/traits/is_future.hpp>
+#include <hpx/iterator_support/traits/is_iterator.hpp>
 #include <hpx/modules/errors.hpp>
 #include <hpx/preprocessor/strip_parens.hpp>
 #include <hpx/type_support/always_void.hpp>
@@ -199,7 +167,7 @@ namespace hpx {
 #include <vector>
 
 ///////////////////////////////////////////////////////////////////////////////
-namespace hpx { namespace lcos {
+namespace hpx {
     namespace detail {
         ///////////////////////////////////////////////////////////////////////
         template <typename Sequence>
@@ -214,64 +182,59 @@ namespace hpx { namespace lcos {
             }
 
             template <typename SharedState>
-            void operator()(SharedState& shared_state,
-                typename std::enable_if<
-                    traits::is_shared_state<SharedState>::value>::type* =
-                    nullptr) const
+            void operator()(SharedState const& shared_state) const
             {
-                std::size_t counter =
-                    wait_.count_.load(std::memory_order_seq_cst);
-                if (counter < wait_.needed_count_ &&
-                    shared_state.get() != nullptr && !shared_state->is_ready())
+                if constexpr (!traits::is_shared_state_v<SharedState>)
                 {
-                    // handle future only if not enough futures are ready yet
-                    // also, do not touch any futures which are already ready
+                    apply(shared_state);
+                }
+                else
+                {
+                    std::size_t counter =
+                        wait_.count_.load(std::memory_order_acquire);
 
-                    shared_state->execute_deferred();
-
-                    // execute_deferred might have made the future ready
-                    if (!shared_state->is_ready())
+                    if (counter < wait_.needed_count_ && shared_state &&
+                        !shared_state->is_ready())
                     {
-                        shared_state->set_on_completed(util::deferred_call(
-                            &wait_some<Sequence>::on_future_ready,
-                            wait_.shared_from_this(),
-                            hpx::execution_base::this_thread::agent()));
-                        return;
+                        // handle future only if not enough futures are ready yet
+                        // also, do not touch any futures which are already ready
+                        shared_state->execute_deferred();
+
+                        // execute_deferred might have made the future ready
+                        if (!shared_state->is_ready())
+                        {
+                            shared_state->set_on_completed(util::deferred_call(
+                                &wait_some<Sequence>::on_future_ready,
+                                wait_.shared_from_this(),
+                                hpx::execution_base::this_thread::agent()));
+                            return;
+                        }
+                    }
+
+                    if (wait_.count_.fetch_add(1) + 1 == wait_.needed_count_)
+                    {
+                        wait_.goal_reached_on_calling_thread_ = true;
                     }
                 }
-                if (wait_.count_.fetch_add(1) + 1 == wait_.needed_count_)
-                {
-                    wait_.goal_reached_on_calling_thread_ = true;
-                }
-            }
-
-            template <typename Sequence_>
-            HPX_FORCEINLINE void operator()(Sequence_& sequence,
-                typename std::enable_if<
-                    !traits::is_shared_state<Sequence_>::value>::type* =
-                    nullptr) const
-            {
-                apply(sequence);
             }
 
             template <typename Tuple, std::size_t... Is>
             HPX_FORCEINLINE void apply(
-                Tuple& tuple, util::index_pack<Is...>) const
+                Tuple const& tuple, hpx::util::index_pack<Is...>) const
             {
                 int const _sequencer[] = {
-                    (((*this)(hpx::get<Is>(tuple))), 0)...};
+                    0, (((*this)(hpx::get<Is>(tuple))), 0)...};
                 (void) _sequencer;
             }
 
             template <typename... Ts>
-            HPX_FORCEINLINE void apply(hpx::tuple<Ts...>& sequence) const
+            HPX_FORCEINLINE void apply(hpx::tuple<Ts...> const& sequence) const
             {
-                apply(sequence,
-                    typename util::make_index_pack<sizeof...(Ts)>::type());
+                apply(sequence, hpx::util::make_index_pack_t<sizeof...(Ts)>());
             }
 
             template <typename Sequence_>
-            HPX_FORCEINLINE void apply(Sequence_& sequence) const
+            HPX_FORCEINLINE void apply(Sequence_ const& sequence) const
             {
                 std::for_each(sequence.begin(), sequence.end(), *this);
             }
@@ -283,7 +246,7 @@ namespace hpx { namespace lcos {
         void set_on_completed_callback(wait_some<Sequence>& wait)
         {
             set_wait_some_callback_impl<Sequence> callback(wait);
-            callback.apply(wait.lazy_values_);
+            callback.apply(wait.values_);
         }
 
         template <typename Sequence>
@@ -297,22 +260,28 @@ namespace hpx { namespace lcos {
                 {
                     // reactivate waiting thread only if it's not us
                     if (ctx != hpx::execution_base::this_thread::agent())
+                    {
                         ctx.resume();
+                    }
                     else
+                    {
                         goal_reached_on_calling_thread_ = true;
+                    }
                 }
             }
 
         private:
-            // workaround gcc regression wrongly instantiating constructors
-            wait_some();
-            wait_some(wait_some const&);
+            wait_some(wait_some const&) = delete;
+            wait_some(wait_some&&) = delete;
+
+            wait_some& operator=(wait_some const&) = delete;
+            wait_some& operator=(wait_some&&) = delete;
 
         public:
-            typedef Sequence argument_type;
+            using argument_type = Sequence;
 
-            wait_some(argument_type&& lazy_values, std::size_t n)
-              : lazy_values_(HPX_MOVE(lazy_values))
+            wait_some(argument_type const& values, std::size_t n)
+              : values_(values)
               , count_(0)
               , needed_count_(n)
               , goal_reached_on_calling_thread_(false)
@@ -336,186 +305,208 @@ namespace hpx { namespace lcos {
 
                 // at least N futures should be ready
                 HPX_ASSERT(
-                    count_.load(std::memory_order_seq_cst) >= needed_count_);
+                    count_.load(std::memory_order_acquire) >= needed_count_);
             }
 
-            argument_type lazy_values_;
+            argument_type const& values_;
             std::atomic<std::size_t> count_;
             std::size_t const needed_count_;
             bool goal_reached_on_calling_thread_;
         };
+
+        template <typename T>
+        auto get_wait_some_frame(T const& values, std::size_t n)
+        {
+            return std::make_shared<hpx::detail::wait_some<T>>(values, n);
+        }
     }    // namespace detail
 
     ///////////////////////////////////////////////////////////////////////////
     template <typename Future>
-    void wait_some(std::size_t n, std::vector<Future> const& lazy_values,
-        error_code& ec = throws)
+    void wait_some_nothrow(std::size_t n, std::vector<Future> const& values)
     {
         static_assert(
-            traits::is_future<Future>::value, "invalid use of wait_some");
-
-        typedef typename traits::detail::shared_state_ptr_for<Future>::type
-            shared_state_ptr;
-        typedef std::vector<shared_state_ptr> result_type;
+            hpx::traits::is_future_v<Future>, "invalid use of hpx::wait_some");
 
         if (n == 0)
         {
             return;
         }
 
-        if (n > lazy_values.size())
+        if (n > values.size())
         {
-            HPX_THROWS_IF(ec, hpx::bad_parameter, "hpx::lcos::wait_some",
+            HPX_THROW_EXCEPTION(hpx::bad_parameter, "hpx::wait_some",
                 "number of results to wait for is out of bounds");
             return;
         }
 
-        result_type lazy_values_;
-        std::transform(lazy_values.begin(), lazy_values.end(),
-            std::back_inserter(lazy_values_),
-            traits::detail::wait_get_shared_state<Future>());
-
-        std::shared_ptr<detail::wait_some<result_type>> f =
-            std::make_shared<detail::wait_some<result_type>>(
-                HPX_MOVE(lazy_values_), n);
-
-        return (*f.get())();
+        auto lazy_values = traits::acquire_shared_state_disp()(values);
+        auto f = detail::get_wait_some_frame(lazy_values, n);
+        (*f)();
     }
 
     template <typename Future>
-    void wait_some(std::size_t n, std::vector<Future>& lazy_values,
-        error_code& ec = throws)
+    void wait_some(std::size_t n, std::vector<Future> const& values)
     {
-        return lcos::wait_some(
-            n, const_cast<std::vector<Future> const&>(lazy_values), ec);
+        hpx::wait_some_nothrow(n, values);
+        hpx::detail::throw_if_exceptional(values);
     }
 
     template <typename Future>
-    void wait_some(std::size_t n, std::vector<Future>&& lazy_values,
-        error_code& ec = throws)
+    void wait_some_nothrow(std::size_t n, std::vector<Future>& values)
     {
-        return lcos::wait_some(
-            n, const_cast<std::vector<Future> const&>(lazy_values), ec);
+        return hpx::wait_some_nothrow(
+            n, const_cast<std::vector<Future> const&>(values));
+    }
+
+    template <typename Future>
+    void wait_some(std::size_t n, std::vector<Future>& values)
+    {
+        hpx::wait_some_nothrow(
+            n, const_cast<std::vector<Future> const&>(values));
+        hpx::detail::throw_if_exceptional(values);
+    }
+
+    template <typename Future>
+    void wait_some_nothrow(std::size_t n, std::vector<Future>&& values)
+    {
+        return hpx::wait_some_nothrow(
+            n, const_cast<std::vector<Future> const&>(values));
+    }
+
+    template <typename Future>
+    void wait_some(std::size_t n, std::vector<Future>&& values)
+    {
+        hpx::wait_some_nothrow(
+            n, const_cast<std::vector<Future> const&>(values));
+        hpx::detail::throw_if_exceptional(values);
     }
 
     ///////////////////////////////////////////////////////////////////////////
     template <typename Future, std::size_t N>
-    void wait_some(std::size_t n, std::array<Future, N> const& lazy_values,
-        error_code& ec = throws)
+    void wait_some_nothrow(std::size_t n, std::array<Future, N> const& values)
     {
         static_assert(
-            traits::is_future<Future>::value, "invalid use of wait_some");
-
-        typedef typename traits::detail::shared_state_ptr_for<Future>::type
-            shared_state_ptr;
-        typedef std::array<shared_state_ptr, N> result_type;
+            hpx::traits::is_future_v<Future>, "invalid use of wait_some");
 
         if (n == 0)
         {
             return;
         }
 
-        if (n > lazy_values.size())
+        if (n > values.size())
         {
-            HPX_THROWS_IF(ec, hpx::bad_parameter, "hpx::lcos::wait_some",
+            HPX_THROW_EXCEPTION(hpx::bad_parameter, "hpx::wait_some",
                 "number of results to wait for is out of bounds");
             return;
         }
 
-        result_type lazy_values_;
-        std::transform(lazy_values.begin(), lazy_values.end(),
-            lazy_values_.begin(),
-            traits::detail::wait_get_shared_state<Future>());
-
-        std::shared_ptr<detail::wait_some<result_type>> f =
-            std::make_shared<detail::wait_some<result_type>>(
-                HPX_MOVE(lazy_values_), n);
-
-        return (*f.get())();
+        auto lazy_values = traits::acquire_shared_state_disp()(values);
+        auto f = detail::get_wait_some_frame(lazy_values, n);
+        (*f)();
     }
 
     template <typename Future, std::size_t N>
-    void wait_some(std::size_t n, std::array<Future, N>& lazy_values,
-        error_code& ec = throws)
+    void wait_some(std::size_t n, std::array<Future, N> const& lazy_values)
     {
-        return lcos::wait_some(
-            n, const_cast<std::array<Future, N> const&>(lazy_values), ec);
+        hpx::wait_some_nothrow(n, lazy_values);
+        hpx::detail::throw_if_exceptional(lazy_values);
     }
 
     template <typename Future, std::size_t N>
-    void wait_some(std::size_t n, std::array<Future, N>&& lazy_values,
-        error_code& ec = throws)
+    void wait_some_nothrow(std::size_t n, std::array<Future, N>& lazy_values)
     {
-        return lcos::wait_some(
-            n, const_cast<std::array<Future, N> const&>(lazy_values), ec);
+        hpx::wait_some_nothrow(
+            n, const_cast<std::array<Future, N> const&>(lazy_values));
+    }
+
+    template <typename Future, std::size_t N>
+    void wait_some(std::size_t n, std::array<Future, N>& lazy_values)
+    {
+        hpx::wait_some_nothrow(
+            n, const_cast<std::array<Future, N> const&>(lazy_values));
+        hpx::detail::throw_if_exceptional(lazy_values);
+    }
+
+    template <typename Future, std::size_t N>
+    void wait_some_nothrow(std::size_t n, std::array<Future, N>&& lazy_values)
+    {
+        hpx::wait_some_nothrow(
+            n, const_cast<std::array<Future, N> const&>(lazy_values));
+    }
+
+    template <typename Future, std::size_t N>
+    void wait_some(std::size_t n, std::array<Future, N>&& lazy_values)
+    {
+        hpx::wait_some_nothrow(
+            n, const_cast<std::array<Future, N> const&>(lazy_values));
+        hpx::detail::throw_if_exceptional(lazy_values);
     }
 
     ///////////////////////////////////////////////////////////////////////////
-    template <typename Iterator>
-    typename util::always_void<
-        typename lcos::detail::future_iterator_traits<Iterator>::type>::type
-    wait_some(std::size_t n, Iterator begin, Iterator end, error_code& = throws)
+    template <typename Iterator,
+        typename Enable =
+            std::enable_if_t<hpx::traits::is_iterator_v<Iterator>>>
+    void wait_some_nothrow(std::size_t n, Iterator begin, Iterator end)
     {
-        typedef typename lcos::detail::future_iterator_traits<Iterator>::type
-            future_type;
-        typedef typename traits::detail::shared_state_ptr_for<future_type>::type
-            shared_state_ptr;
-        typedef std::vector<shared_state_ptr> result_type;
-
-        result_type lazy_values_;
-        std::transform(begin, end, std::back_inserter(lazy_values_),
-            traits::detail::wait_get_shared_state<future_type>());
-
-        std::shared_ptr<detail::wait_some<result_type>> f =
-            std::make_shared<detail::wait_some<result_type>>(
-                HPX_MOVE(lazy_values_), n);
-
-        return (*f.get())();
+        auto values = traits::acquire_shared_state<Iterator>()(begin, end);
+        auto f = detail::get_wait_some_frame(values, n);
+        (*f)();
     }
 
-    template <typename Iterator>
-    Iterator wait_some_n(
-        std::size_t n, Iterator begin, std::size_t count, error_code& = throws)
+    template <typename Iterator,
+        typename Enable =
+            std::enable_if_t<hpx::traits::is_iterator_v<Iterator>>>
+    void wait_some(std::size_t n, Iterator begin, Iterator end)
     {
-        typedef typename lcos::detail::future_iterator_traits<Iterator>::type
-            future_type;
-        typedef typename traits::detail::shared_state_ptr_for<future_type>::type
-            shared_state_ptr;
-        typedef std::vector<shared_state_ptr> result_type;
-
-        result_type lazy_values_;
-        lazy_values_.resize(count);
-        traits::detail::wait_get_shared_state<future_type> func;
-        for (std::size_t i = 0; i != count; ++i)
-            lazy_values_.push_back(func(*begin++));
-
-        std::shared_ptr<detail::wait_some<result_type>> f =
-            std::make_shared<detail::wait_some<result_type>>(
-                HPX_MOVE(lazy_values_), n);
-
-        (*f.get())();
-
-        return begin;
+        auto values = traits::acquire_shared_state<Iterator>()(begin, end);
+        auto f = detail::get_wait_some_frame(values, n);
+        (*f)();
+        hpx::detail::throw_if_exceptional(values);
     }
 
-    inline void wait_some(std::size_t n, error_code& ec = throws)
+    template <typename Iterator,
+        typename Enable =
+            std::enable_if_t<hpx::traits::is_iterator_v<Iterator>>>
+    void wait_some_n_nothrow(std::size_t n, Iterator begin, std::size_t count)
     {
-        if (n == 0)
+        auto values = traits::acquire_shared_state<Iterator>()(begin, count);
+        auto f = detail::get_wait_some_frame(values, n);
+        (*f)();
+    }
+
+    template <typename Iterator,
+        typename Enable =
+            std::enable_if_t<hpx::traits::is_iterator_v<Iterator>>>
+    void wait_some_n(std::size_t n, Iterator begin, std::size_t count)
+    {
+        auto values = traits::acquire_shared_state<Iterator>()(begin, count);
+        auto f = detail::get_wait_some_frame(values, n);
+        (*f)();
+        hpx::detail::throw_if_exceptional(values);
+    }
+
+    inline void wait_some_nothrow(std::size_t n)
+    {
+        if (n != 0)
         {
-            return;
+            HPX_THROW_EXCEPTION(hpx::bad_parameter, "hpx::wait_some",
+                "number of results to wait for is out of bounds");
         }
+    }
 
-        HPX_THROWS_IF(ec, hpx::bad_parameter, "hpx::lcos::wait_some",
-            "number of results to wait for is out of bounds");
+    inline void wait_some(std::size_t n)
+    {
+        wait_some_nothrow(n);
     }
 
     ///////////////////////////////////////////////////////////////////////////
     template <typename T>
-    void wait_some(std::size_t n, hpx::future<T>&& f, error_code& ec = throws)
+    void wait_some_nothrow(std::size_t n, hpx::future<T>&& f)
     {
         if (n != 1)
         {
-            HPX_THROWS_IF(ec, hpx::bad_parameter, "hpx::lcos::wait_some",
+            HPX_THROW_EXCEPTION(hpx::bad_parameter, "hpx::wait_some",
                 "number of results to wait for is out of bounds");
             return;
         }
@@ -524,12 +515,18 @@ namespace hpx { namespace lcos {
     }
 
     template <typename T>
-    void wait_some(
-        std::size_t n, hpx::shared_future<T>&& f, error_code& ec = throws)
+    void wait_some(std::size_t n, hpx::future<T>&& f)
+    {
+        hpx::wait_some_nothrow(n, HPX_MOVE(f));
+        hpx::detail::throw_if_exceptional(f);
+    }
+
+    template <typename T>
+    void wait_some_nothrow(std::size_t n, hpx::shared_future<T>&& f)
     {
         if (n != 1)
         {
-            HPX_THROWS_IF(ec, hpx::bad_parameter, "hpx::lcos::wait_some",
+            HPX_THROW_EXCEPTION(hpx::bad_parameter, "hpx::wait_some",
                 "number of results to wait for is out of bounds");
             return;
         }
@@ -537,46 +534,17 @@ namespace hpx { namespace lcos {
         f.wait();
     }
 
-    ///////////////////////////////////////////////////////////////////////////
-    template <typename... Ts>
-    void wait_some(std::size_t n, error_code& ec, Ts&&... ts)
+    template <typename T>
+    void wait_some(std::size_t n, hpx::shared_future<T>&& f)
     {
-        typedef hpx::tuple<
-            typename traits::detail::shared_state_ptr_for<Ts>::type...>
-            result_type;
-
-        result_type lazy_values_ =
-            result_type(traits::detail::get_shared_state(ts)...);
-
-        if (n == 0)
-        {
-            return;
-        }
-
-        if (n > sizeof...(Ts))
-        {
-            HPX_THROWS_IF(ec, hpx::bad_parameter, "hpx::lcos::wait_some",
-                "number of results to wait for is out of bounds");
-            return;
-        }
-
-        std::shared_ptr<detail::wait_some<result_type>> f =
-            std::make_shared<detail::wait_some<result_type>>(
-                HPX_MOVE(lazy_values_), n);
-
-        return (*f.get())();
+        hpx::wait_some_nothrow(n, HPX_MOVE(f));
+        hpx::detail::throw_if_exceptional(f);
     }
 
+    ///////////////////////////////////////////////////////////////////////////
     template <typename... Ts>
-    void wait_some(std::size_t n, Ts&&... ts)
+    void wait_some_nothrow(std::size_t n, Ts&&... ts)
     {
-        typedef hpx::tuple<
-            typename traits::detail::shared_state_ptr_for<Ts>::type...>
-            result_type;
-
-        result_type lazy_values_ =
-            result_type(traits::detail::get_shared_state(ts)...);
-
         if (n == 0)
         {
             return;
@@ -589,17 +557,141 @@ namespace hpx { namespace lcos {
             return;
         }
 
-        std::shared_ptr<detail::wait_some<result_type>> f =
-            std::make_shared<detail::wait_some<result_type>>(
-                HPX_MOVE(lazy_values_), n);
+        using result_type =
+            hpx::tuple<traits::detail::shared_state_ptr_for_t<Ts>...>;
 
-        return (*f.get())();
+        result_type values(traits::detail::get_shared_state(ts)...);
+        auto f = detail::get_wait_some_frame(values, n);
+        (*f)();
     }
-}}    // namespace hpx::lcos
 
-namespace hpx {
-    using lcos::wait_some;
-    using lcos::wait_some_n;
+    template <typename... Ts>
+    void wait_some(std::size_t n, Ts&&... ts)
+    {
+        hpx::wait_some_nothrow(n, ts...);
+        hpx::detail::throw_if_exceptional(HPX_FORWARD(Ts, ts)...);
+    }
 }    // namespace hpx
+
+namespace hpx::lcos {
+
+    template <typename Future>
+    HPX_DEPRECATED_V(
+        1, 8, "hpx::lcos::wait_some is deprecated. Use hpx::wait_some instead.")
+    void wait_some(std::size_t n, std::vector<Future> const& lazy_values,
+        error_code& ec = throws)
+    {
+        hpx::wait_some(n, lazy_values);
+    }
+
+    template <typename Future>
+    HPX_DEPRECATED_V(
+        1, 8, "hpx::lcos::wait_some is deprecated. Use hpx::wait_some instead.")
+    void wait_some(std::size_t n, std::vector<Future>& lazy_values,
+        error_code& ec = throws)
+    {
+        hpx::wait_some(n, const_cast<std::vector<Future> const&>(lazy_values));
+    }
+
+    template <typename Future>
+    HPX_DEPRECATED_V(
+        1, 8, "hpx::lcos::wait_some is deprecated. Use hpx::wait_some instead.")
+    void wait_some(std::size_t n, std::vector<Future>&& lazy_values,
+        error_code& ec = throws)
+    {
+        hpx::wait_some(n, const_cast<std::vector<Future> const&>(lazy_values));
+    }
+
+    template <typename Future, std::size_t N>
+    HPX_DEPRECATED_V(
+        1, 8, "hpx::lcos::wait_some is deprecated. Use hpx::wait_some instead.")
+    void wait_some(std::size_t n, std::array<Future, N> const& lazy_values,
+        error_code& ec = throws)
+    {
+        hpx::wait_some(n, lazy_values);
+    }
+
+    template <typename Future, std::size_t N>
+    HPX_DEPRECATED_V(
+        1, 8, "hpx::lcos::wait_some is deprecated. Use hpx::wait_some instead.")
+    void wait_some(std::size_t n, std::array<Future, N>& lazy_values,
+        error_code& ec = throws)
+    {
+        hpx::wait_some(
+            n, const_cast<std::array<Future, N> const&>(lazy_values));
+    }
+
+    template <typename Future, std::size_t N>
+    HPX_DEPRECATED_V(
+        1, 8, "hpx::lcos::wait_some is deprecated. Use hpx::wait_some instead.")
+    void wait_some(std::size_t n, std::array<Future, N>&& lazy_values,
+        error_code& ec = throws)
+    {
+        hpx::wait_some(
+            n, const_cast<std::array<Future, N> const&>(lazy_values));
+    }
+
+    template <typename Iterator,
+        typename Enable =
+            std::enable_if_t<hpx::traits::is_iterator_v<Iterator>>>
+    HPX_DEPRECATED_V(
+        1, 8, "hpx::lcos::wait_some is deprecated. Use hpx::wait_some instead.")
+    void wait_some(
+        std::size_t n, Iterator begin, Iterator end, error_code& = throws)
+    {
+        hpx::wait_some(n, begin, end);
+    }
+
+    template <typename Iterator,
+        typename Enable =
+            std::enable_if_t<hpx::traits::is_iterator_v<Iterator>>>
+    HPX_DEPRECATED_V(
+        1, 8, "hpx::lcos::wait_some is deprecated. Use hpx::wait_some instead.")
+    Iterator wait_some_n(
+        std::size_t n, Iterator begin, std::size_t count, error_code& = throws)
+    {
+        hpx::wait_some(n, begin, count);
+    }
+
+    HPX_DEPRECATED_V(
+        1, 8, "hpx::lcos::wait_some is deprecated. Use hpx::wait_some instead.")
+    inline void wait_some(std::size_t n, error_code& ec = throws)
+    {
+        hpx::wait_some(n);
+    }
+
+    template <typename T>
+    HPX_DEPRECATED_V(
+        1, 8, "hpx::lcos::wait_some is deprecated. Use hpx::wait_some instead.")
+    void wait_some(std::size_t n, hpx::future<T>&& f, error_code& ec = throws)
+    {
+        hpx::wait_some(n, HPX_MOVE(f));
+    }
+
+    template <typename T>
+    HPX_DEPRECATED_V(
+        1, 8, "hpx::lcos::wait_some is deprecated. Use hpx::wait_some instead.")
+    void wait_some(
+        std::size_t n, hpx::shared_future<T>&& f, error_code& ec = throws)
+    {
+        hpx::wait_some(n, HPX_MOVE(f));
+    }
+
+    template <typename... Ts>
+    HPX_DEPRECATED_V(
+        1, 8, "hpx::lcos::wait_some is deprecated. Use hpx::wait_some instead.")
+    void wait_some(std::size_t n, error_code& ec, Ts&&... ts)
+    {
+        hpx::wait_some(n, HPX_FORWARD(Ts, ts)...);
+    }
+
+    template <typename... Ts>
+    HPX_DEPRECATED_V(
+        1, 8, "hpx::lcos::wait_some is deprecated. Use hpx::wait_some instead.")
+    void wait_some(std::size_t n, Ts&&... ts)
+    {
+        hpx::wait_some(n, HPX_FORWARD(Ts, ts)...);
+    }
+}    // namespace hpx::lcos
 
 #endif    // DOXYGEN

--- a/libs/core/async_combinators/include/hpx/async_combinators/wait_some.hpp
+++ b/libs/core/async_combinators/include/hpx/async_combinators/wait_some.hpp
@@ -31,7 +31,7 @@ namespace hpx {
     ///
     /// \note           The function wait_some will rethrow any exceptions
     ///                 captured by the futures while becoming ready. If this
-    ///                 behavior is undesireable, use \a wait_some_nothrow
+    ///                 behavior is undesirable, use \a wait_some_nothrow
     ///                 instead.
     ///
     template <typename InputIter>
@@ -55,7 +55,7 @@ namespace hpx {
     ///
     /// \note           The function wait_some will rethrow any exceptions
     ///                 captured by the futures while becoming ready. If this
-    ///                 behavior is undesireable, use \a wait_some_nothrow
+    ///                 behavior is undesirable, use \a wait_some_nothrow
     ///                 instead.
     ///
     template <typename R>
@@ -79,7 +79,7 @@ namespace hpx {
     ///
     /// \note           The function wait_some will rethrow any exceptions
     ///                 captured by the futures while becoming ready. If this
-    ///                 behavior is undesireable, use \a wait_some_nothrow
+    ///                 behavior is undesirable, use \a wait_some_nothrow
     ///                 instead.
     ///
     template <typename R, std::size_t N>
@@ -106,7 +106,7 @@ namespace hpx {
     ///
     /// \note           The function wait_some will rethrow any exceptions
     ///                 captured by the futures while becoming ready. If this
-    ///                 behavior is undesireable, use \a wait_some_nothrow
+    ///                 behavior is undesirable, use \a wait_some_nothrow
     ///                 instead.
     ///
     template <typename... T>
@@ -132,7 +132,7 @@ namespace hpx {
     ///
     /// \note           The function wait_some_n will rethrow any exceptions
     ///                 captured by the futures while becoming ready. If this
-    ///                 behavior is undesireable, use \a wait_some_n_nothrow
+    ///                 behavior is undesirable, use \a wait_some_n_nothrow
     ///                 instead.
     ///
     template <typename InputIter>
@@ -579,7 +579,7 @@ namespace hpx::lcos {
     HPX_DEPRECATED_V(
         1, 8, "hpx::lcos::wait_some is deprecated. Use hpx::wait_some instead.")
     void wait_some(std::size_t n, std::vector<Future> const& lazy_values,
-        error_code& ec = throws)
+        error_code& = throws)
     {
         hpx::wait_some(n, lazy_values);
     }
@@ -587,8 +587,8 @@ namespace hpx::lcos {
     template <typename Future>
     HPX_DEPRECATED_V(
         1, 8, "hpx::lcos::wait_some is deprecated. Use hpx::wait_some instead.")
-    void wait_some(std::size_t n, std::vector<Future>& lazy_values,
-        error_code& ec = throws)
+    void wait_some(
+        std::size_t n, std::vector<Future>& lazy_values, error_code& = throws)
     {
         hpx::wait_some(n, const_cast<std::vector<Future> const&>(lazy_values));
     }
@@ -596,8 +596,8 @@ namespace hpx::lcos {
     template <typename Future>
     HPX_DEPRECATED_V(
         1, 8, "hpx::lcos::wait_some is deprecated. Use hpx::wait_some instead.")
-    void wait_some(std::size_t n, std::vector<Future>&& lazy_values,
-        error_code& ec = throws)
+    void wait_some(
+        std::size_t n, std::vector<Future>&& lazy_values, error_code& = throws)
     {
         hpx::wait_some(n, const_cast<std::vector<Future> const&>(lazy_values));
     }
@@ -606,7 +606,7 @@ namespace hpx::lcos {
     HPX_DEPRECATED_V(
         1, 8, "hpx::lcos::wait_some is deprecated. Use hpx::wait_some instead.")
     void wait_some(std::size_t n, std::array<Future, N> const& lazy_values,
-        error_code& ec = throws)
+        error_code& = throws)
     {
         hpx::wait_some(n, lazy_values);
     }
@@ -614,8 +614,8 @@ namespace hpx::lcos {
     template <typename Future, std::size_t N>
     HPX_DEPRECATED_V(
         1, 8, "hpx::lcos::wait_some is deprecated. Use hpx::wait_some instead.")
-    void wait_some(std::size_t n, std::array<Future, N>& lazy_values,
-        error_code& ec = throws)
+    void wait_some(
+        std::size_t n, std::array<Future, N>& lazy_values, error_code& = throws)
     {
         hpx::wait_some(
             n, const_cast<std::array<Future, N> const&>(lazy_values));
@@ -625,7 +625,7 @@ namespace hpx::lcos {
     HPX_DEPRECATED_V(
         1, 8, "hpx::lcos::wait_some is deprecated. Use hpx::wait_some instead.")
     void wait_some(std::size_t n, std::array<Future, N>&& lazy_values,
-        error_code& ec = throws)
+        error_code& = throws)
     {
         hpx::wait_some(
             n, const_cast<std::array<Future, N> const&>(lazy_values));
@@ -655,7 +655,7 @@ namespace hpx::lcos {
 
     HPX_DEPRECATED_V(
         1, 8, "hpx::lcos::wait_some is deprecated. Use hpx::wait_some instead.")
-    inline void wait_some(std::size_t n, error_code& ec = throws)
+    inline void wait_some(std::size_t n, error_code& = throws)
     {
         hpx::wait_some(n);
     }
@@ -663,7 +663,7 @@ namespace hpx::lcos {
     template <typename T>
     HPX_DEPRECATED_V(
         1, 8, "hpx::lcos::wait_some is deprecated. Use hpx::wait_some instead.")
-    void wait_some(std::size_t n, hpx::future<T>&& f, error_code& ec = throws)
+    void wait_some(std::size_t n, hpx::future<T>&& f, error_code& = throws)
     {
         hpx::wait_some(n, HPX_MOVE(f));
     }
@@ -672,7 +672,7 @@ namespace hpx::lcos {
     HPX_DEPRECATED_V(
         1, 8, "hpx::lcos::wait_some is deprecated. Use hpx::wait_some instead.")
     void wait_some(
-        std::size_t n, hpx::shared_future<T>&& f, error_code& ec = throws)
+        std::size_t n, hpx::shared_future<T>&& f, error_code& = throws)
     {
         hpx::wait_some(n, HPX_MOVE(f));
     }
@@ -680,7 +680,7 @@ namespace hpx::lcos {
     template <typename... Ts>
     HPX_DEPRECATED_V(
         1, 8, "hpx::lcos::wait_some is deprecated. Use hpx::wait_some instead.")
-    void wait_some(std::size_t n, error_code& ec, Ts&&... ts)
+    void wait_some(std::size_t n, error_code&, Ts&&... ts)
     {
         hpx::wait_some(n, HPX_FORWARD(Ts, ts)...);
     }

--- a/libs/core/async_combinators/tests/unit/CMakeLists.txt
+++ b/libs/core/async_combinators/tests/unit/CMakeLists.txt
@@ -7,8 +7,12 @@
 
 set(tests
     split_shared_future
+    wait_all
     wait_all_std_array
+    wait_any
     wait_any_std_array
+    wait_some
+    wait_some_std_array
     when_all
     when_all_std_array
     when_any

--- a/libs/core/async_combinators/tests/unit/CMakeLists.txt
+++ b/libs/core/async_combinators/tests/unit/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2007-2017 Hartmut Kaiser
+# Copyright (c) 2007-2021 Hartmut Kaiser
 # Copyright (c) 2011-2012 Bryce Adelstein-Lelbach
 #
 # SPDX-License-Identifier: BSL-1.0
@@ -11,6 +11,7 @@ set(tests
     wait_all_std_array
     wait_any
     wait_any_std_array
+    wait_each
     wait_some
     wait_some_std_array
     when_all

--- a/libs/core/async_combinators/tests/unit/wait_all.cpp
+++ b/libs/core/async_combinators/tests/unit/wait_all.cpp
@@ -9,9 +9,9 @@
 #include <hpx/local/thread.hpp>
 #include <hpx/modules/testing.hpp>
 
-#include <array>
 #include <chrono>
 #include <stdexcept>
+#include <vector>
 
 int make_int_slowly()
 {
@@ -28,8 +28,9 @@ hpx::future<int> make_future()
 void test_wait_all()
 {
     {
-        std::array<hpx::future<int>, 2> future_array = {
-            make_future(), make_future()};
+        std::vector<hpx::future<int>> future_array;
+        future_array.push_back(make_future());
+        future_array.push_back(make_future());
 
         hpx::wait_all_nothrow(future_array);
 
@@ -39,8 +40,19 @@ void test_wait_all()
         }
     }
     {
-        std::array<hpx::future<int>, 2> future_array = {make_future(),
-            hpx::make_exceptional_future<int>(std::runtime_error(""))};
+        auto f1 = make_future();
+        auto f2 = make_future();
+
+        hpx::wait_all_nothrow(f1, f2);
+
+        HPX_TEST(f1.is_ready());
+        HPX_TEST(f2.is_ready());
+    }
+    {
+        std::vector<hpx::future<int>> future_array;
+        future_array.push_back(make_future());
+        future_array.push_back(
+            hpx::make_exceptional_future<int>(std::runtime_error("")));
 
         bool caught_exception = false;
         try
@@ -54,6 +66,7 @@ void test_wait_all()
         }
         catch (std::runtime_error const&)
         {
+            HPX_TEST(false);
             caught_exception = true;
         }
         catch (...)
@@ -63,8 +76,10 @@ void test_wait_all()
         HPX_TEST(!caught_exception);
     }
     {
-        std::array<hpx::future<int>, 2> future_array = {make_future(),
-            hpx::make_exceptional_future<int>(std::runtime_error(""))};
+        std::vector<hpx::future<int>> future_array;
+        future_array.push_back(make_future());
+        future_array.push_back(
+            hpx::make_exceptional_future<int>(std::runtime_error("")));
 
         bool caught_exception = false;
         try
@@ -82,15 +97,36 @@ void test_wait_all()
         }
         HPX_TEST(caught_exception);
     }
+    {
+        auto f1 = make_future();
+        auto f2 = hpx::make_exceptional_future<int>(std::runtime_error(""));
+
+        bool caught_exception = false;
+        try
+        {
+            hpx::wait_all(f1, f2);
+            HPX_TEST(false);
+        }
+        catch (std::runtime_error const&)
+        {
+            caught_exception = true;
+        }
+        catch (...)
+        {
+            HPX_TEST(false);
+        }
+        HPX_TEST(caught_exception);
+    }
 }
 
 void test_wait_all_n()
 {
     {
-        std::array<hpx::future<int>, 2> future_array = {
-            make_future(), make_future()};
+        std::vector<hpx::future<int>> future_array;
+        future_array.push_back(make_future());
+        future_array.push_back(make_future());
 
-        hpx::wait_all_n_nothrow(future_array.begin(), 2);
+        hpx::wait_all_n_nothrow(future_array.begin(), future_array.size());
 
         for (auto& f : future_array)
         {
@@ -98,13 +134,15 @@ void test_wait_all_n()
         }
     }
     {
-        std::array<hpx::future<int>, 2> future_array = {make_future(),
-            hpx::make_exceptional_future<int>(std::runtime_error(""))};
+        std::vector<hpx::future<int>> future_array;
+        future_array.push_back(make_future());
+        future_array.push_back(
+            hpx::make_exceptional_future<int>(std::runtime_error("")));
 
         bool caught_exception = false;
         try
         {
-            hpx::wait_all_n_nothrow(future_array.begin(), 2);
+            hpx::wait_all_n_nothrow(future_array.begin(), future_array.size());
 
             for (auto& f : future_array)
             {
@@ -122,13 +160,15 @@ void test_wait_all_n()
         HPX_TEST(!caught_exception);
     }
     {
-        std::array<hpx::future<int>, 2> future_array = {make_future(),
-            hpx::make_exceptional_future<int>(std::runtime_error(""))};
+        std::vector<hpx::future<int>> future_array;
+        future_array.push_back(make_future());
+        future_array.push_back(
+            hpx::make_exceptional_future<int>(std::runtime_error("")));
 
         bool caught_exception = false;
         try
         {
-            hpx::wait_all_n(future_array.begin(), 2);
+            hpx::wait_all_n(future_array.begin(), future_array.size());
             HPX_TEST(false);
         }
         catch (std::runtime_error const&)

--- a/libs/core/async_combinators/tests/unit/wait_all_std_array.cpp
+++ b/libs/core/async_combinators/tests/unit/wait_all_std_array.cpp
@@ -28,8 +28,9 @@ hpx::future<int> make_future()
 void test_wait_all()
 {
     {
-        std::array<hpx::future<int>, 2> future_array = {
-            make_future(), make_future()};
+        std::array<hpx::future<int>, 2> future_array;
+        future_array[0] = make_future();
+        future_array[1] = make_future();
 
         hpx::wait_all_nothrow(future_array);
 
@@ -39,8 +40,10 @@ void test_wait_all()
         }
     }
     {
-        std::array<hpx::future<int>, 2> future_array = {make_future(),
-            hpx::make_exceptional_future<int>(std::runtime_error(""))};
+        std::array<hpx::future<int>, 2> future_array;
+        future_array[0] = make_future();
+        future_array[1] =
+            hpx::make_exceptional_future<int>(std::runtime_error(""));
 
         bool caught_exception = false;
         try
@@ -63,8 +66,10 @@ void test_wait_all()
         HPX_TEST(!caught_exception);
     }
     {
-        std::array<hpx::future<int>, 2> future_array = {make_future(),
-            hpx::make_exceptional_future<int>(std::runtime_error(""))};
+        std::array<hpx::future<int>, 2> future_array;
+        future_array[0] = make_future();
+        future_array[1] =
+            hpx::make_exceptional_future<int>(std::runtime_error(""));
 
         bool caught_exception = false;
         try
@@ -87,8 +92,9 @@ void test_wait_all()
 void test_wait_all_n()
 {
     {
-        std::array<hpx::future<int>, 2> future_array = {
-            make_future(), make_future()};
+        std::array<hpx::future<int>, 2> future_array;
+        future_array[0] = make_future();
+        future_array[1] = make_future();
 
         hpx::wait_all_n_nothrow(future_array.begin(), 2);
 
@@ -98,8 +104,10 @@ void test_wait_all_n()
         }
     }
     {
-        std::array<hpx::future<int>, 2> future_array = {make_future(),
-            hpx::make_exceptional_future<int>(std::runtime_error(""))};
+        std::array<hpx::future<int>, 2> future_array;
+        future_array[0] = make_future();
+        future_array[1] =
+            hpx::make_exceptional_future<int>(std::runtime_error(""));
 
         bool caught_exception = false;
         try
@@ -122,8 +130,10 @@ void test_wait_all_n()
         HPX_TEST(!caught_exception);
     }
     {
-        std::array<hpx::future<int>, 2> future_array = {make_future(),
-            hpx::make_exceptional_future<int>(std::runtime_error(""))};
+        std::array<hpx::future<int>, 2> future_array;
+        future_array[0] = make_future();
+        future_array[1] =
+            hpx::make_exceptional_future<int>(std::runtime_error(""));
 
         bool caught_exception = false;
         try

--- a/libs/core/async_combinators/tests/unit/wait_any.cpp
+++ b/libs/core/async_combinators/tests/unit/wait_any.cpp
@@ -25,28 +25,32 @@ hpx::future<int> make_future()
     return task.get_future();
 }
 
-void test_wait_all()
+void test_wait_any()
 {
     {
         std::vector<hpx::future<int>> future_array;
         future_array.push_back(make_future());
         future_array.push_back(make_future());
 
-        hpx::wait_all_nothrow(future_array);
+        hpx::wait_any_nothrow(future_array);
 
+        int count = 0;
         for (auto& f : future_array)
         {
-            HPX_TEST(f.is_ready());
+            if (f.is_ready())
+            {
+                ++count;
+            }
         }
+        HPX_TEST_NEQ(count, 0);
     }
     {
         auto f1 = make_future();
         auto f2 = make_future();
 
-        hpx::wait_all_nothrow(f1, f2);
+        hpx::wait_any_nothrow(f1, f2);
 
-        HPX_TEST(f1.is_ready());
-        HPX_TEST(f2.is_ready());
+        HPX_TEST(f1.is_ready() || f2.is_ready());
     }
     {
         std::vector<hpx::future<int>> future_array;
@@ -57,12 +61,17 @@ void test_wait_all()
         bool caught_exception = false;
         try
         {
-            hpx::wait_all_nothrow(future_array);
+            hpx::wait_any_nothrow(future_array);
 
+            int count = 0;
             for (auto& f : future_array)
             {
-                HPX_TEST(f.is_ready());
+                if (f.is_ready())
+                {
+                    ++count;
+                }
             }
+            HPX_TEST_NEQ(count, 0);
         }
         catch (std::runtime_error const&)
         {
@@ -84,47 +93,7 @@ void test_wait_all()
         bool caught_exception = false;
         try
         {
-            hpx::wait_all(future_array);
-            HPX_TEST(false);
-        }
-        catch (std::runtime_error const&)
-        {
-            caught_exception = true;
-        }
-        catch (...)
-        {
-            HPX_TEST(false);
-        }
-        HPX_TEST(caught_exception);
-    }
-    {
-        auto f1 = make_future();
-        auto f2 = hpx::make_exceptional_future<int>(std::runtime_error(""));
-
-        bool caught_exception = false;
-        try
-        {
-            hpx::wait_all(f1, f2);
-            HPX_TEST(false);
-        }
-        catch (std::runtime_error const&)
-        {
-            caught_exception = true;
-        }
-        catch (...)
-        {
-            HPX_TEST(false);
-        }
-        HPX_TEST(caught_exception);
-    }
-    {
-        auto f1 = make_future();
-        auto f2 = hpx::make_exceptional_future<int>(std::runtime_error(""));
-
-        bool caught_exception = false;
-        try
-        {
-            hpx::wait_any(f1, f2);
+            hpx::wait_any(future_array);
             HPX_TEST(false);
         }
         catch (std::runtime_error const&)
@@ -139,19 +108,24 @@ void test_wait_all()
     }
 }
 
-void test_wait_all_n()
+void test_wait_any_n()
 {
     {
         std::vector<hpx::future<int>> future_array;
         future_array.push_back(make_future());
         future_array.push_back(make_future());
 
-        hpx::wait_all_n_nothrow(future_array.begin(), future_array.size());
+        hpx::wait_any_n_nothrow(future_array.begin(), future_array.size());
 
+        int count = 0;
         for (auto& f : future_array)
         {
-            HPX_TEST(f.is_ready());
+            if (f.is_ready())
+            {
+                ++count;
+            }
         }
+        HPX_TEST_NEQ(count, 0);
     }
     {
         std::vector<hpx::future<int>> future_array;
@@ -162,12 +136,17 @@ void test_wait_all_n()
         bool caught_exception = false;
         try
         {
-            hpx::wait_all_n_nothrow(future_array.begin(), future_array.size());
+            hpx::wait_any_n_nothrow(future_array.begin(), future_array.size());
 
+            int count = 0;
             for (auto& f : future_array)
             {
-                HPX_TEST(f.is_ready());
+                if (f.is_ready())
+                {
+                    ++count;
+                }
             }
+            HPX_TEST_NEQ(count, 0);
         }
         catch (std::runtime_error const&)
         {
@@ -188,7 +167,7 @@ void test_wait_all_n()
         bool caught_exception = false;
         try
         {
-            hpx::wait_all_n(future_array.begin(), future_array.size());
+            hpx::wait_any_n(future_array.begin(), future_array.size());
             HPX_TEST(false);
         }
         catch (std::runtime_error const&)
@@ -205,8 +184,8 @@ void test_wait_all_n()
 
 int hpx_main()
 {
-    test_wait_all();
-    test_wait_all_n();
+    test_wait_any();
+    test_wait_any_n();
     return hpx::local::finalize();
 }
 

--- a/libs/core/async_combinators/tests/unit/wait_any_std_array.cpp
+++ b/libs/core/async_combinators/tests/unit/wait_any_std_array.cpp
@@ -28,8 +28,9 @@ hpx::future<int> make_future()
 void test_wait_any()
 {
     {
-        std::array<hpx::future<int>, 2> future_array = {
-            make_future(), make_future()};
+        std::array<hpx::future<int>, 2> future_array;
+        future_array[0] = make_future();
+        future_array[1] = make_future();
 
         hpx::wait_any_nothrow(future_array);
 
@@ -44,8 +45,10 @@ void test_wait_any()
         HPX_TEST_NEQ(count, 0);
     }
     {
-        std::array<hpx::future<int>, 2> future_array = {make_future(),
-            hpx::make_exceptional_future<int>(std::runtime_error(""))};
+        std::array<hpx::future<int>, 2> future_array;
+        future_array[0] = make_future();
+        future_array[1] =
+            hpx::make_exceptional_future<int>(std::runtime_error(""));
 
         bool caught_exception = false;
         try
@@ -73,8 +76,10 @@ void test_wait_any()
         HPX_TEST(!caught_exception);
     }
     {
-        std::array<hpx::future<int>, 2> future_array = {make_future(),
-            hpx::make_exceptional_future<int>(std::runtime_error(""))};
+        std::array<hpx::future<int>, 2> future_array;
+        future_array[0] = make_future();
+        future_array[1] =
+            hpx::make_exceptional_future<int>(std::runtime_error(""));
 
         bool caught_exception = false;
         try
@@ -97,8 +102,9 @@ void test_wait_any()
 void test_wait_any_n()
 {
     {
-        std::array<hpx::future<int>, 2> future_array = {
-            make_future(), make_future()};
+        std::array<hpx::future<int>, 2> future_array;
+        future_array[0] = make_future();
+        future_array[1] = make_future();
 
         hpx::wait_any_n_nothrow(future_array.begin(), 2);
 
@@ -113,8 +119,10 @@ void test_wait_any_n()
         HPX_TEST_NEQ(count, 0);
     }
     {
-        std::array<hpx::future<int>, 2> future_array = {make_future(),
-            hpx::make_exceptional_future<int>(std::runtime_error(""))};
+        std::array<hpx::future<int>, 2> future_array;
+        future_array[0] = make_future();
+        future_array[1] =
+            hpx::make_exceptional_future<int>(std::runtime_error(""));
 
         bool caught_exception = false;
         try
@@ -142,8 +150,10 @@ void test_wait_any_n()
         HPX_TEST(!caught_exception);
     }
     {
-        std::array<hpx::future<int>, 2> future_array = {make_future(),
-            hpx::make_exceptional_future<int>(std::runtime_error(""))};
+        std::array<hpx::future<int>, 2> future_array;
+        future_array[0] = make_future();
+        future_array[1] =
+            hpx::make_exceptional_future<int>(std::runtime_error(""));
 
         bool caught_exception = false;
         try

--- a/libs/core/async_combinators/tests/unit/wait_each.cpp
+++ b/libs/core/async_combinators/tests/unit/wait_each.cpp
@@ -1,0 +1,579 @@
+//  Copyright (c) 2016 Lukas Troska
+//  Copyright (c) 2021 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See
+//  accompanying file LICENSE_1_0.txt or copy at
+//  http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/local/future.hpp>
+#include <hpx/local/init.hpp>
+#include <hpx/local/thread.hpp>
+#include <hpx/modules/testing.hpp>
+
+#include <chrono>
+#include <cstddef>
+#include <deque>
+#include <list>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+///////////////////////////////////////////////////////////////////////////////
+template <unsigned id>
+unsigned make_unsigned_slowly()
+{
+    hpx::this_thread::sleep_for(std::chrono::milliseconds(100));
+    return id;
+}
+
+template <class Container>
+void test_wait_each_from_list()
+{
+    unsigned count = 10;
+    unsigned call_count = 0;
+    unsigned call_with_index_count = 0;
+
+    auto callback = [count, &call_count](hpx::future<unsigned> fut) {
+        ++call_count;
+
+        unsigned id = fut.get();
+
+        HPX_TEST_LT(id, count);
+    };
+
+    auto callback_with_index = [count, &call_with_index_count](
+                                   std::size_t idx, hpx::future<unsigned> fut) {
+        ++call_with_index_count;
+
+        unsigned id = fut.get();
+
+        HPX_TEST_EQ(idx, id);
+        HPX_TEST_LT(id, count);
+    };
+
+    Container futures1;
+    Container futures2;
+
+    for (unsigned j = 0; j < count; ++j)
+    {
+        futures1.push_back(
+            hpx::make_ready_future_after(std::chrono::milliseconds(100), j));
+
+        futures2.push_back(
+            hpx::make_ready_future_after(std::chrono::milliseconds(100), j));
+    }
+
+    hpx::wait_each(callback, futures1);
+    hpx::wait_each(callback_with_index, futures2);
+
+    HPX_TEST_EQ(call_count, count);
+    HPX_TEST_EQ(call_with_index_count, count);
+
+    for (const auto& f : futures1)
+    {
+        HPX_TEST(!f.valid());
+    }
+
+    for (const auto& f : futures2)
+    {
+        HPX_TEST(!f.valid());
+    }
+}
+
+template <class Container>
+void test_wait_each_from_list_iterators()
+{
+    unsigned count = 10;
+    unsigned call_count = 0;
+    unsigned call_with_index_count = 0;
+
+    auto callback = [count, &call_count](hpx::future<unsigned> fut) {
+        ++call_count;
+
+        unsigned id = fut.get();
+
+        HPX_TEST_LT(id, count);
+    };
+
+    auto callback_with_index = [count, &call_with_index_count](
+                                   std::size_t idx, hpx::future<unsigned> fut) {
+        ++call_with_index_count;
+
+        unsigned id = fut.get();
+
+        HPX_TEST_EQ(idx, id);
+        HPX_TEST_LT(id, count);
+    };
+
+    Container futures1;
+    Container futures2;
+
+    for (unsigned j = 0; j < count; ++j)
+    {
+        futures1.push_back(
+            hpx::make_ready_future_after(std::chrono::milliseconds(100), j));
+
+        futures2.push_back(
+            hpx::make_ready_future_after(std::chrono::milliseconds(100), j));
+    }
+
+    hpx::wait_each(callback, futures1.begin(), futures1.end());
+    hpx::wait_each(callback_with_index, futures2.begin(), futures2.end());
+
+    HPX_TEST_EQ(call_count, count);
+    HPX_TEST_EQ(call_with_index_count, count);
+
+    for (const auto& f : futures1)
+    {
+        HPX_TEST(!f.valid());
+    }
+
+    for (const auto& f : futures2)
+    {
+        HPX_TEST(!f.valid());
+    }
+}
+
+template <class Container>
+void test_wait_each_n_from_list_iterators()
+{
+    unsigned count = 10;
+    unsigned n = 5;
+
+    unsigned call_count = 0;
+    unsigned call_with_index_count = 0;
+
+    auto callback_n = [n, &call_count](hpx::future<unsigned> fut) {
+        ++call_count;
+
+        unsigned id = fut.get();
+
+        HPX_TEST_LT(id, n);
+    };
+
+    auto callback_with_index_n = [n, &call_with_index_count](std::size_t idx,
+                                     hpx::future<unsigned> fut) {
+        ++call_with_index_count;
+
+        unsigned id = fut.get();
+
+        HPX_TEST_EQ(idx, id);
+        HPX_TEST_LT(id, n);
+    };
+
+    Container futures1;
+    Container futures2;
+
+    for (unsigned j = 0; j < count; ++j)
+    {
+        futures1.push_back(
+            hpx::make_ready_future_after(std::chrono::milliseconds(100), j));
+
+        futures2.push_back(
+            hpx::make_ready_future_after(std::chrono::milliseconds(100), j));
+    }
+
+    hpx::wait_each_n(callback_n, futures1.begin(), n);
+    hpx::wait_each_n(callback_with_index_n, futures2.begin(), n);
+
+    HPX_TEST_EQ(call_count, n);
+    HPX_TEST_EQ(call_with_index_count, n);
+
+    unsigned num = 0;
+    for (auto it = futures1.begin(); num < n; ++num, ++it)
+    {
+        HPX_TEST(!it->valid());
+    }
+
+    num = 0;
+    for (auto it = futures2.begin(); num < n; ++num, ++it)
+    {
+        HPX_TEST(!it->valid());
+    }
+}
+
+void test_wait_each_one_future()
+{
+    unsigned count = 1;
+    unsigned call_count = 0;
+    unsigned call_with_index_count = 0;
+
+    auto callback = [count, &call_count](hpx::future<unsigned> fut) {
+        ++call_count;
+
+        unsigned id = fut.get();
+
+        HPX_TEST_LT(id, count);
+    };
+
+    auto callback_with_index = [count, &call_with_index_count](
+                                   std::size_t idx, hpx::future<unsigned> fut) {
+        ++call_with_index_count;
+
+        unsigned id = fut.get();
+
+        HPX_TEST_EQ(idx, id);
+        HPX_TEST_LT(id, count);
+    };
+
+    hpx::future<unsigned> f = hpx::make_ready_future(static_cast<unsigned>(0));
+    hpx::future<unsigned> g = hpx::make_ready_future(static_cast<unsigned>(0));
+
+    hpx::wait_each(callback, std::move(f));
+    hpx::wait_each(callback_with_index, std::move(g));
+
+    HPX_TEST_EQ(call_count, count);
+    HPX_TEST_EQ(call_with_index_count, count);
+
+    HPX_TEST(!f.valid());    // NOLINT
+    HPX_TEST(!g.valid());    // NOLINT
+}
+
+void test_wait_each_two_futures()
+{
+    unsigned count = 2;
+    unsigned call_count = 0;
+    unsigned call_with_index_count = 0;
+
+    auto callback = [count, &call_count](hpx::future<unsigned> fut) {
+        ++call_count;
+
+        unsigned id = fut.get();
+
+        HPX_TEST_LT(id, count);
+    };
+
+    auto callback_with_index = [count, &call_with_index_count](
+                                   std::size_t idx, hpx::future<unsigned> fut) {
+        ++call_with_index_count;
+
+        unsigned id = fut.get();
+
+        HPX_TEST_EQ(idx, id);
+        HPX_TEST_LT(id, count);
+    };
+
+    hpx::future<unsigned> f1 = hpx::make_ready_future(static_cast<unsigned>(0));
+    hpx::future<unsigned> f2 = hpx::make_ready_future(static_cast<unsigned>(1));
+    hpx::future<unsigned> g1 = hpx::make_ready_future(static_cast<unsigned>(0));
+    hpx::future<unsigned> g2 = hpx::make_ready_future(static_cast<unsigned>(1));
+
+    hpx::wait_each(callback, std::move(f1), std::move(f2));
+    hpx::wait_each(callback_with_index, std::move(g1), std::move(g2));
+
+    HPX_TEST_EQ(call_count, count);
+    HPX_TEST_EQ(call_with_index_count, count);
+
+    HPX_TEST(!f1.valid());    // NOLINT
+    HPX_TEST(!f2.valid());    // NOLINT
+    HPX_TEST(!g1.valid());    // NOLINT
+    HPX_TEST(!g2.valid());    // NOLINT
+}
+
+void test_wait_each_three_futures()
+{
+    unsigned count = 3;
+    unsigned call_count = 0;
+    unsigned call_with_index_count = 0;
+
+    auto callback = [count, &call_count](hpx::future<unsigned> fut) {
+        ++call_count;
+
+        unsigned id = fut.get();
+
+        HPX_TEST_LT(id, count);
+    };
+
+    auto callback_with_index = [count, &call_with_index_count](
+                                   std::size_t idx, hpx::future<unsigned> fut) {
+        ++call_with_index_count;
+
+        unsigned id = fut.get();
+
+        HPX_TEST_EQ(idx, id);
+        HPX_TEST_LT(id, count);
+    };
+
+    hpx::future<unsigned> f1 = hpx::make_ready_future(static_cast<unsigned>(0));
+    hpx::future<unsigned> f2 = hpx::make_ready_future(static_cast<unsigned>(1));
+    hpx::future<unsigned> f3 = hpx::make_ready_future(static_cast<unsigned>(2));
+    hpx::future<unsigned> g1 = hpx::make_ready_future(static_cast<unsigned>(0));
+    hpx::future<unsigned> g2 = hpx::make_ready_future(static_cast<unsigned>(1));
+    hpx::future<unsigned> g3 = hpx::make_ready_future(static_cast<unsigned>(2));
+
+    hpx::wait_each(callback, std::move(f1), std::move(f2), std::move(f3));
+    hpx::wait_each(
+        callback_with_index, std::move(g1), std::move(g2), std::move(g3));
+
+    HPX_TEST_EQ(call_count, count);
+    HPX_TEST_EQ(call_with_index_count, count);
+
+    HPX_TEST(!f1.valid());    // NOLINT
+    HPX_TEST(!f2.valid());    // NOLINT
+    HPX_TEST(!f3.valid());    // NOLINT
+    HPX_TEST(!g1.valid());    // NOLINT
+    HPX_TEST(!g2.valid());    // NOLINT
+    HPX_TEST(!g3.valid());    // NOLINT
+}
+
+void test_wait_each_four_futures()
+{
+    unsigned count = 4;
+    unsigned call_count = 0;
+    unsigned call_with_index_count = 0;
+
+    auto callback = [count, &call_count](hpx::future<unsigned> fut) {
+        ++call_count;
+
+        unsigned id = fut.get();
+
+        HPX_TEST_LT(id, count);
+    };
+
+    auto callback_with_index = [count, &call_with_index_count](
+                                   std::size_t idx, hpx::future<unsigned> fut) {
+        ++call_with_index_count;
+
+        unsigned id = fut.get();
+
+        HPX_TEST_EQ(idx, id);
+        HPX_TEST_LT(id, count);
+    };
+
+    hpx::future<unsigned> f1 = hpx::make_ready_future(static_cast<unsigned>(0));
+    hpx::future<unsigned> f2 = hpx::make_ready_future(static_cast<unsigned>(1));
+    hpx::future<unsigned> f3 = hpx::make_ready_future(static_cast<unsigned>(2));
+    hpx::future<unsigned> f4 = hpx::make_ready_future(static_cast<unsigned>(3));
+    hpx::future<unsigned> g1 = hpx::make_ready_future(static_cast<unsigned>(0));
+    hpx::future<unsigned> g2 = hpx::make_ready_future(static_cast<unsigned>(1));
+    hpx::future<unsigned> g3 = hpx::make_ready_future(static_cast<unsigned>(2));
+    hpx::future<unsigned> g4 = hpx::make_ready_future(static_cast<unsigned>(3));
+
+    hpx::wait_each(
+        callback, std::move(f1), std::move(f2), std::move(f3), std::move(f4));
+    hpx::wait_each(callback_with_index, std::move(g1), std::move(g2),
+        std::move(g3), std::move(g4));
+
+    HPX_TEST_EQ(call_count, count);
+    HPX_TEST_EQ(call_with_index_count, count);
+
+    HPX_TEST(!f1.valid());    // NOLINT
+    HPX_TEST(!f2.valid());    // NOLINT
+    HPX_TEST(!f3.valid());    // NOLINT
+    HPX_TEST(!f4.valid());    // NOLINT
+    HPX_TEST(!g1.valid());    // NOLINT
+    HPX_TEST(!g2.valid());    // NOLINT
+    HPX_TEST(!g3.valid());    // NOLINT
+    HPX_TEST(!g4.valid());    // NOLINT
+}
+
+void test_wait_each_five_futures()
+{
+    unsigned count = 5;
+    unsigned call_count = 0;
+    unsigned call_with_index_count = 0;
+
+    auto callback = [count, &call_count](hpx::future<unsigned> fut) {
+        ++call_count;
+
+        unsigned id = fut.get();
+
+        HPX_TEST_LT(id, count);
+    };
+
+    auto callback_with_index = [count, &call_with_index_count](
+                                   std::size_t idx, hpx::future<unsigned> fut) {
+        ++call_with_index_count;
+
+        unsigned id = fut.get();
+
+        HPX_TEST_EQ(idx, id);
+        HPX_TEST_LT(id, count);
+    };
+
+    hpx::future<unsigned> f1 = hpx::make_ready_future(static_cast<unsigned>(0));
+    hpx::future<unsigned> f2 = hpx::make_ready_future(static_cast<unsigned>(1));
+    hpx::future<unsigned> f3 = hpx::make_ready_future(static_cast<unsigned>(2));
+    hpx::future<unsigned> f4 = hpx::make_ready_future(static_cast<unsigned>(3));
+    hpx::future<unsigned> f5 = hpx::make_ready_future(static_cast<unsigned>(4));
+    hpx::future<unsigned> g1 = hpx::make_ready_future(static_cast<unsigned>(0));
+    hpx::future<unsigned> g2 = hpx::make_ready_future(static_cast<unsigned>(1));
+    hpx::future<unsigned> g3 = hpx::make_ready_future(static_cast<unsigned>(2));
+    hpx::future<unsigned> g4 = hpx::make_ready_future(static_cast<unsigned>(3));
+    hpx::future<unsigned> g5 = hpx::make_ready_future(static_cast<unsigned>(4));
+
+    hpx::wait_each(callback, std::move(f1), std::move(f2), std::move(f3),
+        std::move(f4), std::move(f5));
+
+    hpx::wait_each(callback_with_index, std::move(g1), std::move(g2),
+        std::move(g3), std::move(g4), std::move(g5));
+
+    HPX_TEST_EQ(call_count, count);
+    HPX_TEST_EQ(call_with_index_count, count);
+
+    HPX_TEST(!f1.valid());    // NOLINT
+    HPX_TEST(!f2.valid());    // NOLINT
+    HPX_TEST(!f3.valid());    // NOLINT
+    HPX_TEST(!f4.valid());    // NOLINT
+    HPX_TEST(!f5.valid());    // NOLINT
+    HPX_TEST(!g1.valid());    // NOLINT
+    HPX_TEST(!g2.valid());    // NOLINT
+    HPX_TEST(!g3.valid());    // NOLINT
+    HPX_TEST(!g4.valid());    // NOLINT
+    HPX_TEST(!g5.valid());    // NOLINT
+}
+
+void test_wait_each_late_future()
+{
+    unsigned count = 2;
+    unsigned call_count = 0;
+    unsigned call_with_index_count = 0;
+
+    auto callback = [count, &call_count](hpx::future<unsigned> fut) {
+        ++call_count;
+
+        unsigned id = fut.get();
+
+        HPX_TEST_LT(id, count);
+    };
+
+    auto callback_with_index = [count, &call_with_index_count](
+                                   std::size_t idx, hpx::future<unsigned> fut) {
+        ++call_with_index_count;
+
+        unsigned id = fut.get();
+
+        HPX_TEST_EQ(idx, id);
+        HPX_TEST_LT(id, count);
+    };
+
+    hpx::lcos::local::futures_factory<unsigned()> pt0(make_unsigned_slowly<0>);
+    hpx::lcos::local::futures_factory<unsigned()> pt1(make_unsigned_slowly<1>);
+    hpx::lcos::local::futures_factory<unsigned()> pt2(make_unsigned_slowly<0>);
+    hpx::lcos::local::futures_factory<unsigned()> pt3(make_unsigned_slowly<1>);
+
+    hpx::future<unsigned> f1 = pt0.get_future();
+    hpx::future<unsigned> f2 = pt1.get_future();
+
+    hpx::async([pt0 = std::move(pt0)]() { pt0.apply(); });
+    hpx::async([pt1 = std::move(pt1)]() { pt1.apply(); });
+
+    hpx::wait_each(callback, std::move(f1), std::move(f2));
+
+    HPX_TEST(!f1.valid());    // NOLINT
+    HPX_TEST(!f2.valid());    // NOLINT
+
+    hpx::future<unsigned> g1 = pt2.get_future();
+    hpx::future<unsigned> g2 = pt3.get_future();
+
+    hpx::async([pt2 = std::move(pt2)]() { pt2.apply(); });
+    hpx::async([pt3 = std::move(pt3)]() { pt3.apply(); });
+
+    hpx::wait_each(callback_with_index, std::move(g1), std::move(g2));
+
+    HPX_TEST_EQ(call_count, count);
+    HPX_TEST_EQ(call_with_index_count, count);
+
+    HPX_TEST(!g1.valid());    // NOLINT
+    HPX_TEST(!g2.valid());    // NOLINT
+}
+
+void test_wait_each_deferred_futures()
+{
+    unsigned count = 2;
+    unsigned call_count = 0;
+    unsigned call_with_index_count = 0;
+
+    auto callback = [count, &call_count](hpx::future<unsigned> fut) {
+        ++call_count;
+
+        unsigned id = fut.get();
+
+        HPX_TEST_LT(id, count);
+    };
+
+    auto callback_with_index = [count, &call_with_index_count](
+                                   std::size_t idx, hpx::future<unsigned> fut) {
+        ++call_with_index_count;
+
+        unsigned id = fut.get();
+
+        HPX_TEST_EQ(idx, id);
+        HPX_TEST_LT(id, count);
+    };
+
+    hpx::future<unsigned> f1 =
+        hpx::async(hpx::launch::deferred, &make_unsigned_slowly<0>);
+    hpx::future<unsigned> f2 =
+        hpx::async(hpx::launch::deferred, &make_unsigned_slowly<1>);
+
+    hpx::future<unsigned> g1 =
+        hpx::async(hpx::launch::deferred, &make_unsigned_slowly<0>);
+    hpx::future<unsigned> g2 =
+        hpx::async(hpx::launch::deferred, &make_unsigned_slowly<1>);
+
+    hpx::wait_each(callback, std::move(f1), std::move(f2));
+    hpx::wait_each(callback_with_index, std::move(g1), std::move(g2));
+
+    HPX_TEST_EQ(call_count, count);
+    HPX_TEST_EQ(call_with_index_count, count);
+
+    HPX_TEST(!f1.valid());    // NOLINT
+    HPX_TEST(!f2.valid());    // NOLINT
+
+    HPX_TEST(!g1.valid());    // NOLINT
+    HPX_TEST(!g2.valid());    // NOLINT
+}
+
+///////////////////////////////////////////////////////////////////////////////
+using hpx::program_options::options_description;
+using hpx::program_options::variables_map;
+
+using hpx::future;
+
+int hpx_main(variables_map&)
+{
+    {
+        test_wait_each_from_list<std::vector<future<unsigned>>>();
+
+        test_wait_each_from_list_iterators<std::vector<future<unsigned>>>();
+        test_wait_each_from_list_iterators<std::list<future<unsigned>>>();
+        test_wait_each_from_list_iterators<std::deque<future<unsigned>>>();
+
+        test_wait_each_n_from_list_iterators<std::vector<future<unsigned>>>();
+        test_wait_each_n_from_list_iterators<std::list<future<unsigned>>>();
+        test_wait_each_n_from_list_iterators<std::deque<future<unsigned>>>();
+
+        test_wait_each_one_future();
+        test_wait_each_two_futures();
+        test_wait_each_three_futures();
+        test_wait_each_four_futures();
+        test_wait_each_five_futures();
+
+        test_wait_each_late_future();
+
+        test_wait_each_deferred_futures();
+    }
+
+    hpx::local::finalize();
+    return hpx::util::report_errors();
+}
+
+///////////////////////////////////////////////////////////////////////////////
+int main(int argc, char* argv[])
+{
+    // Configure application-specific options
+    options_description cmdline("Usage: " HPX_APPLICATION_STRING " [options]");
+
+    // We force this test to use several threads by default.
+    std::vector<std::string> const cfg = {"hpx.os_threads=all"};
+
+    // Initialize and run HPX
+    hpx::local::init_params init_args;
+    init_args.desc_cmdline = cmdline;
+    init_args.cfg = cfg;
+
+    return hpx::local::init(hpx_main, argc, argv, init_args);
+}

--- a/libs/core/async_combinators/tests/unit/wait_some.cpp
+++ b/libs/core/async_combinators/tests/unit/wait_some.cpp
@@ -156,7 +156,8 @@ void test_wait_some_n()
         bool caught_exception = false;
         try
         {
-            hpx::wait_some_n_nothrow(1, future_array.begin(), future_array.size());
+            hpx::wait_some_n_nothrow(
+                1, future_array.begin(), future_array.size());
 
             int count = 0;
             for (auto& f : future_array)

--- a/libs/core/async_combinators/tests/unit/wait_some.cpp
+++ b/libs/core/async_combinators/tests/unit/wait_some.cpp
@@ -25,28 +25,32 @@ hpx::future<int> make_future()
     return task.get_future();
 }
 
-void test_wait_all()
+void test_wait_some()
 {
     {
         std::vector<hpx::future<int>> future_array;
         future_array.push_back(make_future());
         future_array.push_back(make_future());
 
-        hpx::wait_all_nothrow(future_array);
+        hpx::wait_some_nothrow(1, future_array);
 
+        int count = 0;
         for (auto& f : future_array)
         {
-            HPX_TEST(f.is_ready());
+            if (f.is_ready())
+            {
+                ++count;
+            }
         }
+        HPX_TEST_NEQ(count, 0);
     }
     {
         auto f1 = make_future();
         auto f2 = make_future();
 
-        hpx::wait_all_nothrow(f1, f2);
+        hpx::wait_some_nothrow(1, f1, f2);
 
-        HPX_TEST(f1.is_ready());
-        HPX_TEST(f2.is_ready());
+        HPX_TEST(f1.is_ready() || f2.is_ready());
     }
     {
         std::vector<hpx::future<int>> future_array;
@@ -57,12 +61,17 @@ void test_wait_all()
         bool caught_exception = false;
         try
         {
-            hpx::wait_all_nothrow(future_array);
+            hpx::wait_some_nothrow(1, future_array);
 
+            int count = 0;
             for (auto& f : future_array)
             {
-                HPX_TEST(f.is_ready());
+                if (f.is_ready())
+                {
+                    ++count;
+                }
             }
+            HPX_TEST_NEQ(count, 0);
         }
         catch (std::runtime_error const&)
         {
@@ -84,7 +93,7 @@ void test_wait_all()
         bool caught_exception = false;
         try
         {
-            hpx::wait_all(future_array);
+            hpx::wait_some(1, future_array);
             HPX_TEST(false);
         }
         catch (std::runtime_error const&)
@@ -104,27 +113,7 @@ void test_wait_all()
         bool caught_exception = false;
         try
         {
-            hpx::wait_all(f1, f2);
-            HPX_TEST(false);
-        }
-        catch (std::runtime_error const&)
-        {
-            caught_exception = true;
-        }
-        catch (...)
-        {
-            HPX_TEST(false);
-        }
-        HPX_TEST(caught_exception);
-    }
-    {
-        auto f1 = make_future();
-        auto f2 = hpx::make_exceptional_future<int>(std::runtime_error(""));
-
-        bool caught_exception = false;
-        try
-        {
-            hpx::wait_any(f1, f2);
+            hpx::wait_some(1, f1, f2);
             HPX_TEST(false);
         }
         catch (std::runtime_error const&)
@@ -139,19 +128,24 @@ void test_wait_all()
     }
 }
 
-void test_wait_all_n()
+void test_wait_some_n()
 {
     {
         std::vector<hpx::future<int>> future_array;
         future_array.push_back(make_future());
         future_array.push_back(make_future());
 
-        hpx::wait_all_n_nothrow(future_array.begin(), future_array.size());
+        hpx::wait_some_n_nothrow(1, future_array.begin(), future_array.size());
 
+        int count = 0;
         for (auto& f : future_array)
         {
-            HPX_TEST(f.is_ready());
+            if (f.is_ready())
+            {
+                ++count;
+            }
         }
+        HPX_TEST_NEQ(count, 0);
     }
     {
         std::vector<hpx::future<int>> future_array;
@@ -162,12 +156,17 @@ void test_wait_all_n()
         bool caught_exception = false;
         try
         {
-            hpx::wait_all_n_nothrow(future_array.begin(), future_array.size());
+            hpx::wait_some_n_nothrow(1, future_array.begin(), future_array.size());
 
+            int count = 0;
             for (auto& f : future_array)
             {
-                HPX_TEST(f.is_ready());
+                if (f.is_ready())
+                {
+                    ++count;
+                }
             }
+            HPX_TEST_NEQ(count, 0);
         }
         catch (std::runtime_error const&)
         {
@@ -188,7 +187,7 @@ void test_wait_all_n()
         bool caught_exception = false;
         try
         {
-            hpx::wait_all_n(future_array.begin(), future_array.size());
+            hpx::wait_some_n(1, future_array.begin(), future_array.size());
             HPX_TEST(false);
         }
         catch (std::runtime_error const&)
@@ -205,8 +204,8 @@ void test_wait_all_n()
 
 int hpx_main()
 {
-    test_wait_all();
-    test_wait_all_n();
+    test_wait_some();
+    test_wait_some_n();
     return hpx::local::finalize();
 }
 

--- a/libs/core/async_combinators/tests/unit/wait_some_std_array.cpp
+++ b/libs/core/async_combinators/tests/unit/wait_some_std_array.cpp
@@ -28,8 +28,9 @@ hpx::future<int> make_future()
 void test_wait_some()
 {
     {
-        std::array<hpx::future<int>, 2> future_array = {
-            make_future(), make_future()};
+        std::array<hpx::future<int>, 2> future_array;
+        future_array[0] = make_future();
+        future_array[1] = make_future();
 
         hpx::wait_some_nothrow(1, future_array);
 
@@ -44,8 +45,10 @@ void test_wait_some()
         HPX_TEST_NEQ(count, 0);
     }
     {
-        std::array<hpx::future<int>, 2> future_array = {make_future(),
-            hpx::make_exceptional_future<int>(std::runtime_error(""))};
+        std::array<hpx::future<int>, 2> future_array;
+        future_array[0] = make_future();
+        future_array[1] =
+            hpx::make_exceptional_future<int>(std::runtime_error(""));
 
         bool caught_exception = false;
         try
@@ -73,8 +76,10 @@ void test_wait_some()
         HPX_TEST(!caught_exception);
     }
     {
-        std::array<hpx::future<int>, 2> future_array = {make_future(),
-            hpx::make_exceptional_future<int>(std::runtime_error(""))};
+        std::array<hpx::future<int>, 2> future_array;
+        future_array[0] = make_future();
+        future_array[1] =
+            hpx::make_exceptional_future<int>(std::runtime_error(""));
 
         bool caught_exception = false;
         try
@@ -97,8 +102,9 @@ void test_wait_some()
 void test_wait_some_n()
 {
     {
-        std::array<hpx::future<int>, 2> future_array = {
-            make_future(), make_future()};
+        std::array<hpx::future<int>, 2> future_array;
+        future_array[0] = make_future();
+        future_array[1] = make_future();
 
         hpx::wait_some_n_nothrow(1, future_array.begin(), 2);
 
@@ -113,8 +119,10 @@ void test_wait_some_n()
         HPX_TEST_NEQ(count, 0);
     }
     {
-        std::array<hpx::future<int>, 2> future_array = {make_future(),
-            hpx::make_exceptional_future<int>(std::runtime_error(""))};
+        std::array<hpx::future<int>, 2> future_array;
+        future_array[0] = make_future();
+        future_array[1] =
+            hpx::make_exceptional_future<int>(std::runtime_error(""));
 
         bool caught_exception = false;
         try
@@ -142,8 +150,10 @@ void test_wait_some_n()
         HPX_TEST(!caught_exception);
     }
     {
-        std::array<hpx::future<int>, 2> future_array = {make_future(),
-            hpx::make_exceptional_future<int>(std::runtime_error(""))};
+        std::array<hpx::future<int>, 2> future_array;
+        future_array[0] = make_future();
+        future_array[1] =
+            hpx::make_exceptional_future<int>(std::runtime_error(""));
 
         bool caught_exception = false;
         try

--- a/libs/core/async_combinators/tests/unit/wait_some_std_array.cpp
+++ b/libs/core/async_combinators/tests/unit/wait_some_std_array.cpp
@@ -25,13 +25,13 @@ hpx::future<int> make_future()
     return task.get_future();
 }
 
-void test_wait_any()
+void test_wait_some()
 {
     {
         std::array<hpx::future<int>, 2> future_array = {
             make_future(), make_future()};
 
-        hpx::wait_any_nothrow(future_array);
+        hpx::wait_some_nothrow(1, future_array);
 
         int count = 0;
         for (auto& f : future_array)
@@ -50,7 +50,7 @@ void test_wait_any()
         bool caught_exception = false;
         try
         {
-            hpx::wait_any_nothrow(future_array);
+            hpx::wait_some_nothrow(1, future_array);
 
             int count = 0;
             for (auto& f : future_array)
@@ -79,7 +79,7 @@ void test_wait_any()
         bool caught_exception = false;
         try
         {
-            hpx::wait_any(future_array);
+            hpx::wait_some(1, future_array);
             HPX_TEST(false);
         }
         catch (std::runtime_error const&)
@@ -94,13 +94,13 @@ void test_wait_any()
     }
 }
 
-void test_wait_any_n()
+void test_wait_some_n()
 {
     {
         std::array<hpx::future<int>, 2> future_array = {
             make_future(), make_future()};
 
-        hpx::wait_any_n_nothrow(future_array.begin(), 2);
+        hpx::wait_some_n_nothrow(1, future_array.begin(), 2);
 
         int count = 0;
         for (auto& f : future_array)
@@ -119,7 +119,7 @@ void test_wait_any_n()
         bool caught_exception = false;
         try
         {
-            hpx::wait_any_n_nothrow(future_array.begin(), 2);
+            hpx::wait_some_n_nothrow(1, future_array.begin(), 2);
 
             int count = 0;
             for (auto& f : future_array)
@@ -148,7 +148,7 @@ void test_wait_any_n()
         bool caught_exception = false;
         try
         {
-            hpx::wait_any_n(future_array.begin(), 2);
+            hpx::wait_some_n(1, future_array.begin(), 2);
             HPX_TEST(false);
         }
         catch (std::runtime_error const&)
@@ -165,8 +165,8 @@ void test_wait_any_n()
 
 int hpx_main()
 {
-    test_wait_any();
-    test_wait_any_n();
+    test_wait_some();
+    test_wait_some_n();
     return hpx::local::finalize();
 }
 

--- a/libs/core/async_combinators/tests/unit/when_any.cpp
+++ b/libs/core/async_combinators/tests/unit/when_any.cpp
@@ -589,7 +589,7 @@ void test_wait_for_either_of_five_futures_5()
 //         }
 //         hpx::thread t(std::move(tasks[i]));
 //
-//         hpx::lcos::wait_any(futures, futures);
+//         hpx::wait_any(futures, futures);
 //
 //         hpx::future<int>* const future =
 //               boost::wait_for_any(futures, futures+count);

--- a/libs/core/execution/include/hpx/execution/executors/execution.hpp
+++ b/libs/core/execution/include/hpx/execution/executors/execution.hpp
@@ -882,7 +882,7 @@ namespace hpx { namespace parallel { namespace execution {
                             execution::async_execute(exec, f, elem, ts...));
                     }
 
-                    hpx::wait_all(results);
+                    hpx::wait_all_nothrow(results);
                 }
                 catch (std::bad_alloc const& ba)
                 {

--- a/libs/core/futures/include/hpx/futures/traits/acquire_shared_state.hpp
+++ b/libs/core/futures/include/hpx/futures/traits/acquire_shared_state.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2016 Hartmut Kaiser
+//  Copyright (c) 2007-2021 Hartmut Kaiser
 //  Copyright (c) 2016 Agustin Berge
 //
 //  SPDX-License-Identifier: BSL-1.0
@@ -13,6 +13,7 @@
 #include <hpx/futures/traits/is_future.hpp>
 #include <hpx/futures/traits/is_future_range.hpp>
 #include <hpx/iterator_support/range.hpp>
+#include <hpx/iterator_support/traits/is_iterator.hpp>
 #include <hpx/iterator_support/traits/is_range.hpp>
 #include <hpx/modules/memory.hpp>
 #include <hpx/util/detail/reserve.hpp>
@@ -25,35 +26,41 @@
 #include <vector>
 
 namespace hpx { namespace traits {
+
     namespace detail {
+
         template <typename T, typename Enable = void>
         struct acquire_shared_state_impl;
     }
 
     template <typename T, typename Enable = void>
     struct acquire_shared_state
-      : detail::acquire_shared_state_impl<typename std::decay<T>::type>
+      : detail::acquire_shared_state_impl<std::decay_t<T>>
     {
     };
+
+    template <typename T>
+    using acquire_shared_state_t = typename acquire_shared_state<T>::type;
 
     struct acquire_shared_state_disp
     {
         template <typename T>
-        HPX_FORCEINLINE typename acquire_shared_state<T>::type operator()(
-            T&& t) const
+        HPX_FORCEINLINE acquire_shared_state_t<T> operator()(T&& t) const
         {
             return acquire_shared_state<T>()(HPX_FORWARD(T, t));
         }
     };
 
     namespace detail {
+
         ///////////////////////////////////////////////////////////////////////
         template <typename T, typename Enable>
         struct acquire_shared_state_impl
         {
-            static_assert(!is_future_or_future_range<T>::value, "");
+            static_assert(!traits::detail::is_future_or_future_range_v<T>,
+                "!is_future_or_future_range_v<T>");
 
-            typedef T type;
+            using type = T;
 
             template <typename T_>
             HPX_FORCEINLINE T operator()(T_&& value) const
@@ -65,10 +72,10 @@ namespace hpx { namespace traits {
         ///////////////////////////////////////////////////////////////////////
         template <typename Future>
         struct acquire_shared_state_impl<Future,
-            typename std::enable_if<is_future<Future>::value>::type>
+            std::enable_if_t<is_future_v<Future>>>
         {
-            typedef typename traits::detail::shared_state_ptr<
-                typename traits::future_traits<Future>::type>::type const& type;
+            using type = traits::detail::shared_state_ptr_t<
+                traits::future_traits_t<Future>> const&;
 
             HPX_FORCEINLINE type operator()(Future const& f) const
             {
@@ -79,22 +86,18 @@ namespace hpx { namespace traits {
         ///////////////////////////////////////////////////////////////////////
         template <typename Range>
         struct acquire_shared_state_impl<Range,
-            typename std::enable_if<
-                traits::is_future_range<Range>::value>::type>
+            std::enable_if_t<traits::is_future_range_v<Range>>>
         {
-            typedef typename traits::future_range_traits<Range>::future_type
-                future_type;
-
-            typedef
-                typename traits::detail::shared_state_ptr_for<future_type>::type
-                    shared_state_ptr;
-            typedef std::vector<shared_state_ptr> type;
+            using future_type =
+                typename traits::future_range_traits<Range>::future_type;
+            using shared_state_ptr =
+                traits::detail::shared_state_ptr_for_t<future_type>;
+            using type = std::vector<shared_state_ptr>;
 
             template <typename Range_>
-            HPX_FORCEINLINE std::vector<shared_state_ptr> operator()(
-                Range_&& futures) const
+            HPX_FORCEINLINE type operator()(Range_&& futures) const
             {
-                std::vector<shared_state_ptr> values;
+                type values;
                 detail::reserve_if_random_access_by_range(values, futures);
 
                 std::transform(util::begin(futures), util::end(futures),
@@ -103,13 +106,50 @@ namespace hpx { namespace traits {
                 return values;
             }
         };
+
+        template <typename Iterator>
+        struct acquire_shared_state_impl<Iterator,
+            std::enable_if_t<traits::is_iterator_v<Iterator>>>
+        {
+            using future_type =
+                typename std::iterator_traits<Iterator>::value_type;
+            using shared_state_ptr =
+                traits::detail::shared_state_ptr_for_t<future_type>;
+            using type = std::vector<shared_state_ptr>;
+
+            template <typename Iter>
+            HPX_FORCEINLINE type operator()(Iter begin, Iter end) const
+            {
+                type values;
+                detail::reserve_if_random_access_by_range(values, begin, end);
+
+                std::transform(begin, end, std::back_inserter(values),
+                    acquire_shared_state_disp());
+
+                return values;
+            }
+
+            template <typename Iter>
+            HPX_FORCEINLINE type operator()(Iter begin, std::size_t count) const
+            {
+                type values;
+                values.reserve(count);
+
+                for (std::size_t i = 0; i != count; ++i)
+                {
+                    values.push_back(acquire_shared_state_disp()(*begin++));
+                }
+
+                return values;
+            }
+        };
     }    // namespace detail
 
     ///////////////////////////////////////////////////////////////////////////
     namespace detail {
+
         template <typename T>
-        HPX_FORCEINLINE typename acquire_shared_state<T>::type get_shared_state(
-            T&& t)
+        HPX_FORCEINLINE acquire_shared_state_t<T> get_shared_state(T&& t)
         {
             return acquire_shared_state<T>()(HPX_FORWARD(T, t));
         }
@@ -128,8 +168,8 @@ namespace hpx { namespace traits {
         struct wait_get_shared_state
         {
             HPX_FORCEINLINE
-            typename traits::detail::shared_state_ptr_for<Future>::type const&
-            operator()(Future const& f) const
+            traits::detail::shared_state_ptr_for_t<Future> const& operator()(
+                Future const& f) const
             {
                 return traits::detail::get_shared_state(f);
             }

--- a/libs/core/futures/include/hpx/futures/traits/future_access.hpp
+++ b/libs/core/futures/include/hpx/futures/traits/future_access.hpp
@@ -119,6 +119,9 @@ namespace hpx { namespace traits {
     {
     };
 
+    template <typename R>
+    inline constexpr bool is_shared_state_v = is_shared_state<R>::value;
+
     ///////////////////////////////////////////////////////////////////////////
     namespace detail {
         template <typename T, typename Enable = void>

--- a/libs/core/futures/include/hpx/futures/traits/is_future_range.hpp
+++ b/libs/core/futures/include/hpx/futures/traits/is_future_range.hpp
@@ -14,6 +14,7 @@
 #include <type_traits>
 
 namespace hpx { namespace traits {
+
     ///////////////////////////////////////////////////////////////////////////
     template <typename R, typename Enable = void>
     struct is_future_range : std::false_type
@@ -21,10 +22,16 @@ namespace hpx { namespace traits {
     };
 
     template <typename R>
-    struct is_future_range<R, typename std::enable_if<is_range<R>::value>::type>
+    struct is_future_range<R, std::enable_if_t<is_range_v<R>>>
       : is_future<typename range_traits<R>::value_type>
     {
     };
+
+    template <typename R>
+    using is_future_range_t = typename is_future_range<R>::type;
+
+    template <typename R>
+    inline constexpr bool is_future_range_v = is_future_range<R>::value;
 
     template <typename R, typename Enable = void>
     struct is_ref_wrapped_future_range : std::false_type
@@ -37,6 +44,14 @@ namespace hpx { namespace traits {
     {
     };
 
+    template <typename R>
+    using is_ref_wrapped_future_range_t =
+        typename is_ref_wrapped_future_range<R>::type;
+
+    template <typename R>
+    inline constexpr bool is_ref_wrapped_future_range_v =
+        is_ref_wrapped_future_range<R>::value;
+
     ///////////////////////////////////////////////////////////////////////////
     template <typename R, bool IsFutureRange = is_future_range<R>::value>
     struct future_range_traits
@@ -46,16 +61,19 @@ namespace hpx { namespace traits {
     template <typename R>
     struct future_range_traits<R, true>
     {
-        typedef typename range_traits<R>::value_type future_type;
+        using future_type = typename range_traits<R>::value_type;
     };
 
     ///////////////////////////////////////////////////////////////////////////
     namespace detail {
         template <typename T>
         struct is_future_or_future_range
-          : std::integral_constant<bool,
-                is_future<T>::value || is_future_range<T>::value>
+          : std::integral_constant<bool, is_future_v<T> || is_future_range_v<T>>
         {
         };
+
+        template <typename R>
+        inline constexpr bool is_future_or_future_range_v =
+            is_future_or_future_range<R>::value;
     }    // namespace detail
 }}       // namespace hpx::traits

--- a/libs/core/futures/tests/regressions/exception_from_continuation_1613.cpp
+++ b/libs/core/futures/tests/regressions/exception_from_continuation_1613.cpp
@@ -61,7 +61,7 @@ void test_exception_from_continuation2()
 
     // make futures ready in backwards sequence
     hpx::apply([&p]() { p.set_value(); });
-    hpx::wait_all(results);
+    hpx::wait_all_nothrow(results);
 
     HPX_TEST_EQ(recursion_level.load(), NUM_FUTURES);
     HPX_TEST_EQ(exceptions_thrown.load(), std::size_t(1));

--- a/libs/core/util/include/hpx/util/detail/reserve.hpp
+++ b/libs/core/util/include/hpx/util/detail/reserve.hpp
@@ -11,14 +11,17 @@
 #include <hpx/config.hpp>
 #include <hpx/concepts/has_member_xxx.hpp>
 #include <hpx/iterator_support/range.hpp>
+#include <hpx/iterator_support/traits/is_iterator.hpp>
 #include <hpx/iterator_support/traits/is_range.hpp>
 
+#include <algorithm>
 #include <cstddef>
 #include <iterator>
 #include <type_traits>
 #include <vector>
 
 namespace hpx { namespace traits { namespace detail {
+
     ///////////////////////////////////////////////////////////////////////
     // not every random access sequence is reservable
     // so we need an explicit trait to determine this
@@ -26,58 +29,44 @@ namespace hpx { namespace traits { namespace detail {
 
     template <typename Range>
     using is_reservable = std::integral_constant<bool,
-        is_range<typename std::decay<Range>::type>::value &&
-            has_reserve<typename std::decay<Range>::type>::value>;
+        is_range_v<std::decay_t<Range>> && has_reserve_v<std::decay_t<Range>>>;
+
+    template <typename Range>
+    inline constexpr bool is_reservable_v = is_reservable<Range>::value;
 
     ///////////////////////////////////////////////////////////////////////
     template <typename Container>
-    HPX_FORCEINLINE
-        typename std::enable_if<!is_reservable<Container>::value>::type
-        reserve_if_reservable(Container&, std::size_t) noexcept
+    HPX_FORCEINLINE void reserve_if_reservable(Container& v, std::size_t n)
     {
-    }
-
-    template <typename Container>
-    HPX_FORCEINLINE
-        typename std::enable_if<is_reservable<Container>::value>::type
-        reserve_if_reservable(Container& v, std::size_t n)
-    {
-        v.reserve(n);
+        if constexpr (is_reservable_v<Container>)
+        {
+            v.reserve(n);
+        }
     }
 
     ///////////////////////////////////////////////////////////////////////
     // Reserve sufficient space in the given vector if the underlying
-    // iterator type of the given range allow calculating the size on O(1).
-    template <typename Future, typename Range>
-    HPX_FORCEINLINE void reserve_if_random_access_by_range(
-        std::vector<Future>&, Range const&, std::false_type) noexcept
-    {
-    }
-
-    template <typename Future, typename Range>
-    HPX_FORCEINLINE void reserve_if_random_access_by_range(
-        std::vector<Future>& v, Range const& r, std::true_type)
-    {
-        v.reserve(util::size(r));
-    }
-
-    template <typename Future, typename Range>
-    HPX_FORCEINLINE void reserve_if_random_access_by_range(
-        std::vector<Future>& v, Range const& r)
-    {
-        typedef
-            typename range_traits<Range>::iterator_category iterator_category;
-
-        typedef typename std::is_base_of<std::random_access_iterator_tag,
-            iterator_category>::type is_random_access;
-
-        reserve_if_random_access_by_range(v, r, is_random_access());
-    }
-
+    // iterator type of the given range allow calculating the size in O(1).
     template <typename Container, typename Range>
     HPX_FORCEINLINE void reserve_if_random_access_by_range(
-        Container&, Range const&)
+        Container& v, Range const& r)
     {
-        // do nothing if it's not a vector
+        using iterator_type = typename range_traits<Range>::iterator_type;
+        if constexpr (is_random_access_iterator_v<iterator_type> &&
+            is_reservable_v<Container>)
+        {
+            v.reserve(hpx::util::size(r));
+        }
+    }
+
+    template <typename Container, typename Iterator>
+    HPX_FORCEINLINE void reserve_if_random_access_by_range(
+        Container& v, Iterator begin, Iterator end)
+    {
+        if constexpr (is_random_access_iterator_v<Iterator> &&
+            is_reservable_v<Container>)
+        {
+            v.reserve(std::distance(begin, end));
+        }
     }
 }}}    // namespace hpx::traits::detail

--- a/libs/full/actions/tests/regressions/wait_all_hang_1946.cpp
+++ b/libs/full/actions/tests/regressions/wait_all_hang_1946.cpp
@@ -56,7 +56,7 @@ int hpx_main()
             fut1.push_back(hpx::async<out_act>(locs.at(i), vec));
             hpx::cout << "Scheduled out to " << i + 1 << std::endl;
         }
-        wait_all(fut1);
+        hpx::wait_all(fut1);
         hpx::cout << j + 1 << ". round finished " << std::endl;
     }
     hpx::cout << "program finished!!!" << std::endl;

--- a/libs/full/actions/tests/unit/thread_affinity.cpp
+++ b/libs/full/actions/tests/unit/thread_affinity.cpp
@@ -130,14 +130,14 @@ void thread_affinity_foreman()
         }
 
         // Wait for all of the futures to finish. The callback version of the
-        // hpx::lcos::wait function takes two arguments: a vector of futures,
+        // hpx::wait_each function takes two arguments: a vector of futures,
         // and a binary callback.  The callback takes two arguments; the first
         // is the index of the future in the vector, and the second is the
-        // return value of the future. hpx::lcos::wait doesn't return until
+        // return value of the future. hpx::wait_each doesn't return until
         // all the futures in the vector have returned.
         using hpx::util::placeholders::_1;
-        hpx::lcos::wait_each(hpx::unwrapping(hpx::util::bind(
-                                 &check_in, std::ref(attendance), _1)),
+        hpx::wait_each(hpx::unwrapping(hpx::util::bind(
+                           &check_in, std::ref(attendance), _1)),
             futures);
     }
 }

--- a/libs/full/agas/src/addressing_service.cpp
+++ b/libs/full/agas/src/addressing_service.cpp
@@ -15,7 +15,6 @@
 #include <hpx/agas_base/detail/bootstrap_locality_namespace.hpp>
 #include <hpx/assert.hpp>
 #include <hpx/async_base/launch_policy.hpp>
-#include <hpx/async_combinators/wait_all.hpp>
 #include <hpx/async_combinators/when_all.hpp>
 #include <hpx/components_base/traits/component_supports_migration.hpp>
 #include <hpx/execution_base/register_locks.hpp>

--- a/libs/full/agas_base/src/server/primary_namespace_server.cpp
+++ b/libs/full/agas_base/src/server/primary_namespace_server.cpp
@@ -9,7 +9,6 @@
 #include <hpx/config.hpp>
 #include <hpx/agas_base/server/primary_namespace.hpp>
 #include <hpx/assert.hpp>
-#include <hpx/async_combinators/wait_all.hpp>
 #include <hpx/async_distributed/applier/apply.hpp>
 #include <hpx/async_distributed/continuation.hpp>
 #include <hpx/components_base/agas_interface.hpp>

--- a/libs/full/async_distributed/tests/regressions/dataflow_791.cpp
+++ b/libs/full/async_distributed/tests/regressions/dataflow_791.cpp
@@ -30,7 +30,6 @@ using hpx::async;
 using hpx::dataflow;
 using hpx::shared_future;
 using hpx::unwrapping;
-using hpx::wait_all;
 using std::vector;
 
 struct block
@@ -188,7 +187,7 @@ void LU(int numBlocks)
             }
         }
     }
-    wait_all(dfArray[numBlocks - 1][numBlocks - 1][numBlocks - 1]);
+    hpx::wait_all(dfArray[numBlocks - 1][numBlocks - 1][numBlocks - 1]);
 }
 
 void getBlockList(vector<vector<block>>& blockList, int numBlocks)
@@ -349,7 +348,7 @@ void InitMatrix3()
     {
         futures.push_back(async(initLoop, i));
     }
-    wait_all(futures);
+    hpx::wait_all(futures);
 }
 
 void initLoop(int i)

--- a/libs/full/async_distributed/tests/regressions/future_hang_on_wait_with_callback_629.cpp
+++ b/libs/full/async_distributed/tests/regressions/future_hang_on_wait_with_callback_629.cpp
@@ -113,7 +113,7 @@ double null_tree(std::uint64_t seed, std::uint64_t children,
 
     null_function(seed, delay_iterations);
 
-    hpx::lcos::wait_each(hpx::unwrapping([&](double r) { d += r; }), futures);
+    hpx::wait_each(hpx::unwrapping([&](double r) { d += r; }), futures);
 
     return d;
 }

--- a/libs/full/compute/include/hpx/compute/host/numa_allocator.hpp
+++ b/libs/full/compute/include/hpx/compute/host/numa_allocator.hpp
@@ -130,7 +130,7 @@ namespace hpx { namespace parallel { namespace util {
 #endif
                     }));
             }
-            hpx::wait_all(first_touch);
+            hpx::wait_all_nothrow(first_touch);
 
             for (auto&& f : first_touch)
             {

--- a/libs/full/compute/include/hpx/compute/host/numa_binding_allocator.hpp
+++ b/libs/full/compute/include/hpx/compute/host/numa_binding_allocator.hpp
@@ -467,7 +467,7 @@ namespace hpx { namespace compute { namespace host {
                     debug::dec<2>(domain), " ", nodesets[i]);
                 tasks.push_back(HPX_MOVE(f1));
             }
-            wait_all(tasks);
+            hpx::wait_all(tasks);
             nba_deb.debug(debug::str<>("First-Touch"), "Done tasks");
         }
 

--- a/libs/full/resiliency_distributed/tests/performance/replay/async_replay_distributed.cpp
+++ b/libs/full/resiliency_distributed/tests/performance/replay/async_replay_distributed.cpp
@@ -131,7 +131,7 @@ int hpx_main(hpx::program_options::variables_map& vm)
             std::rotate(locales.begin(), locales.begin() + 1, locales.end());
         }
 
-        hpx::wait_all(tasks);
+        hpx::wait_all_nothrow(tasks);
 
         double elapsed = t.elapsed();
 

--- a/libs/full/resiliency_distributed/tests/performance/replay/async_replay_distributed_validate.cpp
+++ b/libs/full/resiliency_distributed/tests/performance/replay/async_replay_distributed_validate.cpp
@@ -124,7 +124,7 @@ int hpx_main(hpx::program_options::variables_map& vm)
             std::rotate(locales.begin(), locales.begin() + 1, locales.end());
         }
 
-        hpx::wait_all(tasks);
+        hpx::wait_all_nothrow(tasks);
 
         double elapsed = t.elapsed();
         std::cout << "Replay Validate: " << elapsed << std::endl;

--- a/libs/full/runtime_distributed/src/server/runtime_support_server.cpp
+++ b/libs/full/runtime_distributed/src/server/runtime_support_server.cpp
@@ -478,7 +478,7 @@ namespace hpx { namespace components { namespace server {
         }
 
         // wait for all localities to be stopped
-        wait_all(lazy_actions);
+        hpx::wait_all(lazy_actions);
 
         LRT_(info).format("runtime_support::shutdown_all: all localities have "
                           "been shut down");
@@ -515,7 +515,7 @@ namespace hpx { namespace components { namespace server {
             }
 
             // wait for all localities to be stopped
-            wait_all(lazy_actions);
+            hpx::wait_all(lazy_actions);
         }
 
         // now make sure this local locality gets terminated as well.
@@ -911,7 +911,7 @@ namespace hpx { namespace components { namespace server {
                 act, id, HPX_MOVE(ipt), agas::get_locality(), rtd->endpoints());
         }
 
-        wait_all(callbacks);
+        hpx::wait_all(callbacks);
 #endif
 #else
         HPX_ASSERT(false);

--- a/tests/performance/local/activate_counters.cpp
+++ b/tests/performance/local/activate_counters.cpp
@@ -112,7 +112,7 @@ namespace hpx { namespace util {
         }
 
         // wait for all counters to be started
-        wait_all(started);
+        hpx::wait_all(started);
 
         for (future<bool>& f : started)
         {
@@ -154,7 +154,7 @@ namespace hpx { namespace util {
         }
 
         // wait for all counters to be started
-        wait_all(stopped);
+        hpx::wait_all(stopped);
 
         ids_.clear();    // give up control over all performance counters
 
@@ -198,7 +198,7 @@ namespace hpx { namespace util {
         }
 
         // wait for all counters to be started
-        wait_all(reset);
+        hpx::wait_all(reset);
 
         for (future<void>& f : reset)
         {

--- a/tests/performance/local/future_overhead.cpp
+++ b/tests/performance/local/future_overhead.cpp
@@ -43,7 +43,6 @@ using hpx::program_options::variables_map;
 using hpx::apply;
 using hpx::async;
 using hpx::future;
-using hpx::lcos::wait_each;
 
 using hpx::chrono::high_resolution_timer;
 
@@ -143,7 +142,7 @@ void measure_action_futures_wait_each(std::uint64_t count, bool csv)
     high_resolution_timer walltime;
     for (std::uint64_t i = 0; i < count; ++i)
         futures.push_back(async<null_action>(here));
-    wait_each(scratcher(), futures);
+    hpx::wait_each(scratcher(), futures);
 
     // stop the clock
     const double duration = walltime.elapsed();
@@ -181,7 +180,7 @@ void measure_function_futures_wait_each(
     high_resolution_timer walltime;
     for (std::uint64_t i = 0; i < count; ++i)
         futures.push_back(async(exec, &null_function));
-    wait_each(scratcher(), futures);
+    hpx::wait_each(scratcher(), futures);
 
     // stop the clock
     const double duration = walltime.elapsed();

--- a/tests/performance/local/future_overhead.cpp
+++ b/tests/performance/local/future_overhead.cpp
@@ -161,7 +161,7 @@ void measure_action_futures_wait_all(std::uint64_t count, bool csv)
     high_resolution_timer walltime;
     for (std::uint64_t i = 0; i < count; ++i)
         futures.push_back(async<null_action>(here));
-    wait_all(futures);
+    hpx::wait_all(futures);
 
     // stop the clock
     const double duration = walltime.elapsed();
@@ -199,7 +199,7 @@ void measure_function_futures_wait_all(
     high_resolution_timer walltime;
     for (std::uint64_t i = 0; i < count; ++i)
         futures.push_back(async(exec, &null_function));
-    wait_all(futures);
+    hpx::wait_all(futures);
 
     const double duration = walltime.elapsed();
     print_stats("async", "WaitAll", exec_name(exec), count, duration, csv);

--- a/tests/performance/local/future_overhead_report.cpp
+++ b/tests/performance/local/future_overhead_report.cpp
@@ -26,7 +26,6 @@ using hpx::program_options::variables_map;
 using hpx::apply;
 using hpx::async;
 using hpx::future;
-using hpx::lcos::wait_each;
 
 using hpx::chrono::high_resolution_timer;
 

--- a/tests/performance/local/libcds_hazard_pointer_overhead.cpp
+++ b/tests/performance/local/libcds_hazard_pointer_overhead.cpp
@@ -6,7 +6,6 @@
 //  (See accompanying file LICENSE_1_0.txt or copy at
 //  http://www.boost.org/LICENSE_1_0.txt)
 
-#include <hpx/async_combinators/wait_each.hpp>
 #include <hpx/hpx_init.hpp>
 #include <hpx/include/apply.hpp>
 #include <hpx/include/async.hpp>
@@ -46,7 +45,6 @@ using hpx::naming::id_type;
 using hpx::apply;
 using hpx::async;
 using hpx::future;
-using hpx::lcos::wait_each;
 
 using hpx::chrono::high_resolution_timer;
 

--- a/tests/performance/local/spinlock_overhead1.cpp
+++ b/tests/performance/local/spinlock_overhead1.cpp
@@ -35,7 +35,6 @@ using hpx::naming::id_type;
 
 using hpx::future;
 using hpx::async;
-using hpx::lcos::wait_each;
 
 using hpx::chrono::high_resolution_timer;
 
@@ -219,7 +218,7 @@ int hpx_main(
                 for (std::uint64_t i = 0; i < count; ++i)
                     futures.push_back(async<null_action>(here, i));
 
-                wait_each(
+                hpx::wait_each(
                     hpx::unwrapping([](double r) { global_scratch += r; }),
                     futures);
 

--- a/tests/performance/local/spinlock_overhead2.cpp
+++ b/tests/performance/local/spinlock_overhead2.cpp
@@ -35,7 +35,6 @@ using hpx::naming::id_type;
 
 using hpx::future;
 using hpx::async;
-using hpx::lcos::wait_each;
 
 using hpx::chrono::high_resolution_timer;
 
@@ -245,7 +244,7 @@ int hpx_main(
                 for (std::uint64_t i = 0; i < count; ++i)
                     futures.push_back(async<null_action>(here, i));
 
-                wait_each(
+                hpx::wait_each(
                     hpx::unwrapping([](double r) { global_scratch += r; }),
                     futures);
 

--- a/tests/performance/local/transform_reduce_binary_scaling.cpp
+++ b/tests/performance/local/transform_reduce_binary_scaling.cpp
@@ -4,7 +4,9 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+#include <hpx/local/algorithm.hpp>
 #include <hpx/local/chrono.hpp>
+#include <hpx/local/execution.hpp>
 #include <hpx/local/init.hpp>
 #include <hpx/local/numeric.hpp>
 

--- a/tests/unit/lcos/future_wait.cpp
+++ b/tests/unit/lcos/future_wait.cpp
@@ -32,7 +32,6 @@ using hpx::util::report_errors;
 
 using hpx::actions::action;
 
-using hpx::lcos::wait_each;
 using hpx::async;
 using hpx::future;
 
@@ -115,7 +114,7 @@ int hpx_main()
         ///////////////////////////////////////////////////////////////////////
         // Async wait, single future, void return.
         {
-            wait_each(cb, async<null_action>(here_));
+            hpx::wait_each(cb, async<null_action>(here_));
 
             HPX_TEST_EQ(1U, cb.count());
             HPX_TEST_EQ(1U, void_counter.load());
@@ -127,7 +126,7 @@ int hpx_main()
         ///////////////////////////////////////////////////////////////////////
         // Async wait, single future, non-void return.
         {
-            wait_each(cb, async<null_result_action>(here_));
+            hpx::wait_each(cb, async<null_result_action>(here_));
 
             HPX_TEST_EQ(1U, cb.count());
             HPX_TEST_EQ(1U, result_counter.load());
@@ -145,7 +144,7 @@ int hpx_main()
             for (std::size_t i = 0; i < 64; ++i)
                 futures.push_back(async<null_action>(here_));
 
-            wait_each(cb, futures);
+            hpx::wait_each(cb, futures);
 
             HPX_TEST_EQ(64U, cb.count());
             HPX_TEST_EQ(64U, void_counter.load());
@@ -163,7 +162,7 @@ int hpx_main()
             for (std::size_t i = 0; i < 64; ++i)
                 futures.push_back(async<null_result_action>(here_));
 
-            wait_each(cb, futures);
+            hpx::wait_each(cb, futures);
 
             HPX_TEST_EQ(64U, cb.count());
             HPX_TEST_EQ(64U, result_counter.load());
@@ -175,7 +174,7 @@ int hpx_main()
         ///////////////////////////////////////////////////////////////////////
         // Async wait, single future, deferred.
         {
-            wait_each(cb, async(hpx::launch::deferred, &null_thread));
+            hpx::wait_each(cb, async(hpx::launch::deferred, &null_thread));
 
             HPX_TEST_EQ(1U, cb.count());
             HPX_TEST_EQ(1U, void_counter.load());
@@ -201,7 +200,7 @@ int hpx_main()
                     futures.push_back(async(hpx::launch::deferred, &null_thread));
                 }
             }
-            wait_each(cb, futures);
+            hpx::wait_each(cb, futures);
 
             HPX_TEST_EQ(64U, cb.count());
             HPX_TEST_EQ(64U, void_counter.load());


### PR DESCRIPTION
- Attention: hpx::wait_all[_n] now throws if one of the futures is exceptional
  this is a change in semantics.
- Introduce hpx::wait_all[_n]_nothrow that exhibits the (non-throwing) old
  semantics of wait_all[_n]
- Extending existing tests, add new for nothrow variants

The change in semantics proposed overcome a problem of the long-standing practice that users most of the time didn't realize the old versions of `wait_all` wouldn't throw if one of the futures was exceptional. This was prone to exceptions being dropped on the floor, leading to obscure runtime issues.

Similar changes have been applied for `hpx::wait_any[_n]`, `hpx::wait_some[_n]`, and `hpx::wait_each[_n]`.

This also deprecates `hpx::lcos::wait` and friends. This should be removed completely in the future. Its functionality is fully subsumed by `hpx::wait_each`.
