### PR TITLE
Rename `annotate_function` to `scoped_annotation`

### DIFF
--- a/docs/sphinx/api/public_api.rst
+++ b/docs/sphinx/api/public_api.rst
@@ -402,10 +402,12 @@ Classes
 - :cpp:class:`hpx::util::unique_function_nonser`
 - :cpp:struct:`hpx::traits::is_bind_expression`
 - :cpp:struct:`hpx::traits::is_placeholder`
+- :cpp:struct:`hpx::scoped_annotation`
 
 Functions
 ---------
 
+- :cpp:func:`hpx::annotated_function`
 - :cpp:func:`hpx::util::bind`
 - :cpp:func:`hpx::util::bind_back`
 - :cpp:func:`hpx::util::bind_front`

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/for_each.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/for_each.hpp
@@ -444,7 +444,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 using pred = hpx::traits::is_value_proxy<std::decay_t<
                     typename std::iterator_traits<Iter>::reference>>;
 
-                hpx::annotate_function annotate(f_);
+                hpx::scoped_annotation annotate(f_);
                 execute(part_begin, part_size, pred());
             }
         };

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/for_each.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/for_each.hpp
@@ -444,7 +444,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 using pred = hpx::traits::is_value_proxy<std::decay_t<
                     typename std::iterator_traits<Iter>::reference>>;
 
-                hpx::util::annotate_function annotate(f_);
+                hpx::annotate_function annotate(f_);
                 execute(part_begin, part_size, pred());
             }
         };

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/for_loop.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/for_loop.hpp
@@ -888,7 +888,7 @@ namespace hpx {
                 HPX_HOST_DEVICE HPX_FORCEINLINE void operator()(B part_begin,
                     std::size_t part_steps, std::size_t part_index)
                 {
-                    hpx::annotate_function annotate(f_);
+                    hpx::scoped_annotation annotate(f_);
                     execute(part_begin, part_steps, part_index);
                 }
             };
@@ -955,7 +955,7 @@ namespace hpx {
                 HPX_HOST_DEVICE HPX_FORCEINLINE void operator()(
                     B part_begin, std::size_t part_steps, std::size_t)
                 {
-                    hpx::annotate_function annotate(f_);
+                    hpx::scoped_annotation annotate(f_);
                     execute(part_begin, part_steps);
                 }
             };

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/for_loop.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/for_loop.hpp
@@ -888,7 +888,7 @@ namespace hpx {
                 HPX_HOST_DEVICE HPX_FORCEINLINE void operator()(B part_begin,
                     std::size_t part_steps, std::size_t part_index)
                 {
-                    hpx::util::annotate_function annotate(f_);
+                    hpx::annotate_function annotate(f_);
                     execute(part_begin, part_steps, part_index);
                 }
             };
@@ -955,7 +955,7 @@ namespace hpx {
                 HPX_HOST_DEVICE HPX_FORCEINLINE void operator()(
                     B part_begin, std::size_t part_steps, std::size_t)
                 {
-                    hpx::util::annotate_function annotate(f_);
+                    hpx::annotate_function annotate(f_);
                     execute(part_begin, part_steps);
                 }
             };

--- a/libs/core/algorithms/tests/regressions/for_each_annotated_function.cpp
+++ b/libs/core/algorithms/tests/regressions/for_each_annotated_function.cpp
@@ -23,7 +23,7 @@ int hpx_main()
     std::iota(std::begin(c), std::end(c), std::random_device{}());
 
     hpx::ranges::for_each(hpx::execution::par, c,
-        hpx::util::annotated_function(
+        hpx::annotated_function(
             [](int) -> void {
                 hpx::util::thread_description desc(
                     hpx::threads::get_thread_description(

--- a/libs/core/execution/tests/regressions/annotated_minmax_2593.cpp
+++ b/libs/core/execution/tests/regressions/annotated_minmax_2593.cpp
@@ -28,7 +28,7 @@ int hpx_main()
     double extent;
 
     hpx::async(hpx::launch::sync,
-        hpx::util::annotated_function(
+        hpx::annotated_function(
             [&]() { extent = compute_minmax(vec); }, "compute_minmax"));
     HPX_TEST_EQ(extent, 76.6);
 

--- a/libs/core/executors/include/hpx/executors/annotating_executor.hpp
+++ b/libs/core/executors/include/hpx/executors/annotating_executor.hpp
@@ -43,8 +43,8 @@ namespace hpx { namespace execution { namespace experimental {
                 std::enable_if_t<hpx::traits::is_executor_any_v<Executor>>>
         explicit annotating_executor(Executor&& exec, std::string annotation)
           : exec_(HPX_FORWARD(Executor, exec))
-          , annotation_(hpx::util::detail::store_function_annotation(
-                HPX_MOVE(annotation)))
+          , annotation_(
+                hpx::detail::store_function_annotation(HPX_MOVE(annotation)))
         {
         }
 
@@ -81,7 +81,7 @@ namespace hpx { namespace execution { namespace experimental {
         decltype(auto) post(F&& f, Ts&&... ts)
         {
             return parallel::execution::post(exec_,
-                hpx::util::annotated_function(HPX_FORWARD(F, f), annotation_),
+                hpx::annotated_function(HPX_FORWARD(F, f), annotation_),
                 HPX_FORWARD(Ts, ts)...);
         }
 
@@ -90,7 +90,7 @@ namespace hpx { namespace execution { namespace experimental {
         decltype(auto) sync_execute(F&& f, Ts&&... ts)
         {
             return parallel::execution::sync_execute(exec_,
-                hpx::util::annotated_function(HPX_FORWARD(F, f), annotation_),
+                hpx::annotated_function(HPX_FORWARD(F, f), annotation_),
                 HPX_FORWARD(Ts, ts)...);
         }
 
@@ -99,7 +99,7 @@ namespace hpx { namespace execution { namespace experimental {
         decltype(auto) async_execute(F&& f, Ts&&... ts)
         {
             return parallel::execution::async_execute(exec_,
-                hpx::util::annotated_function(HPX_FORWARD(F, f), annotation_),
+                hpx::annotated_function(HPX_FORWARD(F, f), annotation_),
                 HPX_FORWARD(Ts, ts)...);
         }
 
@@ -107,7 +107,7 @@ namespace hpx { namespace execution { namespace experimental {
         decltype(auto) then_execute(F&& f, Future&& predecessor, Ts&&... ts)
         {
             return parallel::execution::then_execute(exec_,
-                hpx::util::annotated_function(HPX_FORWARD(F, f), annotation_),
+                hpx::annotated_function(HPX_FORWARD(F, f), annotation_),
                 HPX_FORWARD(Future, predecessor), HPX_FORWARD(Ts, ts)...);
         }
 
@@ -116,16 +116,16 @@ namespace hpx { namespace execution { namespace experimental {
         decltype(auto) bulk_async_execute(F&& f, S const& shape, Ts&&... ts)
         {
             return parallel::execution::bulk_async_execute(exec_,
-                hpx::util::annotated_function(HPX_FORWARD(F, f), annotation_),
-                shape, HPX_FORWARD(Ts, ts)...);
+                hpx::annotated_function(HPX_FORWARD(F, f), annotation_), shape,
+                HPX_FORWARD(Ts, ts)...);
         }
 
         template <typename F, typename S, typename... Ts>
         decltype(auto) bulk_sync_execute(F&& f, S const& shape, Ts&&... ts)
         {
             return parallel::execution::bulk_sync_execute(exec_,
-                hpx::util::annotated_function(HPX_FORWARD(F, f), annotation_),
-                shape, HPX_FORWARD(Ts, ts)...);
+                hpx::annotated_function(HPX_FORWARD(F, f), annotation_), shape,
+                HPX_FORWARD(Ts, ts)...);
         }
 
         template <typename F, typename S, typename Future, typename... Ts>
@@ -133,9 +133,8 @@ namespace hpx { namespace execution { namespace experimental {
             F&& f, S const& shape, Future&& predecessor, Ts&&... ts)
         {
             return parallel::execution::bulk_then_execute(exec_,
-                hpx::util::annotated_function(HPX_FORWARD(F, f), annotation_),
-                shape, HPX_FORWARD(Future, predecessor),
-                HPX_FORWARD(Ts, ts)...);
+                hpx::annotated_function(HPX_FORWARD(F, f), annotation_), shape,
+                HPX_FORWARD(Future, predecessor), HPX_FORWARD(Ts, ts)...);
         }
 
         // support with_annotation property
@@ -154,8 +153,7 @@ namespace hpx { namespace execution { namespace experimental {
         {
             auto exec_with_annotation = exec;
             exec_with_annotation.annotation_ =
-                hpx::util::detail::store_function_annotation(
-                    HPX_MOVE(annotation));
+                hpx::detail::store_function_annotation(HPX_MOVE(annotation));
             return exec_with_annotation;
         }
 

--- a/libs/core/executors/include/hpx/executors/dataflow.hpp
+++ b/libs/core/executors/include/hpx/executors/dataflow.hpp
@@ -296,7 +296,7 @@ namespace hpx { namespace lcos { namespace detail {
 #endif
             if (!recurse_asynchronously)
             {
-                hpx::util::annotate_function annotate(func_);
+                hpx::annotate_function annotate(func_);
                 execute(is_void{}, HPX_FORWARD(Futures_, futures));
             }
             else

--- a/libs/core/executors/include/hpx/executors/dataflow.hpp
+++ b/libs/core/executors/include/hpx/executors/dataflow.hpp
@@ -296,7 +296,7 @@ namespace hpx { namespace lcos { namespace detail {
 #endif
             if (!recurse_asynchronously)
             {
-                hpx::annotate_function annotate(func_);
+                hpx::scoped_annotation annotate(func_);
                 execute(is_void{}, HPX_FORWARD(Futures_, futures));
             }
             else

--- a/libs/core/executors/include/hpx/executors/parallel_executor.hpp
+++ b/libs/core/executors/include/hpx/executors/parallel_executor.hpp
@@ -243,7 +243,7 @@ namespace hpx { namespace execution {
         typename hpx::util::detail::invoke_deferred_result<F, Ts...>::type
         sync_execute(F&& f, Ts&&... ts) const
         {
-            hpx::annotate_function annotate(annotation_ ?
+            hpx::scoped_annotation annotate(annotation_ ?
                     annotation_ :
                     "parallel_policy_executor::sync_execute");
             return hpx::detail::sync_launch_policy_dispatch<Policy>::call(

--- a/libs/core/executors/include/hpx/executors/parallel_executor.hpp
+++ b/libs/core/executors/include/hpx/executors/parallel_executor.hpp
@@ -205,7 +205,7 @@ namespace hpx { namespace execution {
         {
             auto exec_with_annotation = exec;
             exec_with_annotation.annotation_ =
-                util::detail::store_function_annotation(HPX_MOVE(annotation));
+                detail::store_function_annotation(HPX_MOVE(annotation));
             return exec_with_annotation;
         }
 
@@ -243,7 +243,7 @@ namespace hpx { namespace execution {
         typename hpx::util::detail::invoke_deferred_result<F, Ts...>::type
         sync_execute(F&& f, Ts&&... ts) const
         {
-            hpx::util::annotate_function annotate(annotation_ ?
+            hpx::annotate_function annotate(annotation_ ?
                     annotation_ :
                     "parallel_policy_executor::sync_execute");
             return hpx::detail::sync_launch_policy_dispatch<Policy>::call(
@@ -275,7 +275,7 @@ namespace hpx { namespace execution {
                     Ts...>::type;
 
             auto&& func = hpx::util::one_shot(hpx::util::bind_back(
-                hpx::util::annotated_function(HPX_FORWARD(F, f), annotation_),
+                hpx::annotated_function(HPX_FORWARD(F, f), annotation_),
                 HPX_FORWARD(Ts, ts)...));
 
             typename hpx::traits::detail::shared_state_ptr<result_type>::type
@@ -321,8 +321,7 @@ namespace hpx { namespace execution {
         {
             return parallel::execution::detail::
                 hierarchical_bulk_then_execute_helper(*this, policy_,
-                    hpx::util::annotated_function(
-                        HPX_FORWARD(F, f), annotation_),
+                    hpx::annotated_function(HPX_FORWARD(F, f), annotation_),
                     shape, HPX_FORWARD(Future, predecessor),
                     HPX_FORWARD(Ts, ts)...);
         }

--- a/libs/core/executors/include/hpx/executors/thread_pool_scheduler.hpp
+++ b/libs/core/executors/include/hpx/executors/thread_pool_scheduler.hpp
@@ -120,8 +120,7 @@ namespace hpx { namespace execution { namespace experimental {
         {
             auto sched_with_annotation = scheduler;
             sched_with_annotation.annotation_ =
-                hpx::util::detail::store_function_annotation(
-                    HPX_MOVE(annotation));
+                hpx::detail::store_function_annotation(HPX_MOVE(annotation));
             return sched_with_annotation;
         }
 

--- a/libs/core/executors/include/hpx/executors/thread_pool_scheduler_bulk.hpp
+++ b/libs/core/executors/include/hpx/executors/thread_pool_scheduler_bulk.hpp
@@ -404,8 +404,8 @@ namespace hpx { namespace execution { namespace experimental {
                         char const* scheduler_annotation =
                             get_annotation(op_state->scheduler);
                         auto af = scheduler_annotation ?
-                            hpx::util::annotate_function(scheduler_annotation) :
-                            hpx::util::annotate_function(op_state->f);
+                            hpx::annotate_function(scheduler_annotation) :
+                            hpx::annotate_function(op_state->f);
                         task_function{
                             this->op_state, n, chunk_size, worker_thread}();
                     }

--- a/libs/core/executors/include/hpx/executors/thread_pool_scheduler_bulk.hpp
+++ b/libs/core/executors/include/hpx/executors/thread_pool_scheduler_bulk.hpp
@@ -404,8 +404,8 @@ namespace hpx { namespace execution { namespace experimental {
                         char const* scheduler_annotation =
                             get_annotation(op_state->scheduler);
                         auto af = scheduler_annotation ?
-                            hpx::annotate_function(scheduler_annotation) :
-                            hpx::annotate_function(op_state->f);
+                            hpx::scoped_annotation(scheduler_annotation) :
+                            hpx::scoped_annotation(op_state->f);
                         task_function{
                             this->op_state, n, chunk_size, worker_thread}();
                     }

--- a/libs/core/futures/include/hpx/futures/packaged_continuation.hpp
+++ b/libs/core/futures/include/hpx/futures/packaged_continuation.hpp
@@ -77,7 +77,7 @@ namespace hpx { namespace lcos { namespace detail {
     {
         using is_void = std::is_void<util::invoke_result_t<Func, Future>>;
 
-        hpx::util::annotate_function annotate(func);
+        hpx::annotate_function annotate(func);
         invoke_continuation_nounwrap(
             func, HPX_FORWARD(Future, future), cont, is_void());
     }

--- a/libs/core/futures/include/hpx/futures/packaged_continuation.hpp
+++ b/libs/core/futures/include/hpx/futures/packaged_continuation.hpp
@@ -77,7 +77,7 @@ namespace hpx { namespace lcos { namespace detail {
     {
         using is_void = std::is_void<util::invoke_result_t<Func, Future>>;
 
-        hpx::annotate_function annotate(func);
+        hpx::scoped_annotation annotate(func);
         invoke_continuation_nounwrap(
             func, HPX_FORWARD(Future, future), cont, is_void());
     }

--- a/libs/core/futures/include/hpx/futures/packaged_task.hpp
+++ b/libs/core/futures/include/hpx/futures/packaged_task.hpp
@@ -80,7 +80,7 @@ namespace hpx { namespace lcos { namespace local {
             // synchronous execution of the embedded function (object)
             hpx::detail::try_catch_exception_ptr(
                 [&]() {
-                    hpx::annotate_function annotate(function_);
+                    hpx::scoped_annotation annotate(function_);
                     if constexpr (std::is_void_v<R>)
                     {
                         function_(HPX_FORWARD(Ts, ts)...);

--- a/libs/core/futures/include/hpx/futures/packaged_task.hpp
+++ b/libs/core/futures/include/hpx/futures/packaged_task.hpp
@@ -80,7 +80,7 @@ namespace hpx { namespace lcos { namespace local {
             // synchronous execution of the embedded function (object)
             hpx::detail::try_catch_exception_ptr(
                 [&]() {
-                    hpx::util::annotate_function annotate(function_);
+                    hpx::annotate_function annotate(function_);
                     if constexpr (std::is_void_v<R>)
                     {
                         function_(HPX_FORWARD(Ts, ts)...);

--- a/libs/core/futures/src/future_data.cpp
+++ b/libs/core/futures/src/future_data.cpp
@@ -160,7 +160,7 @@ namespace hpx { namespace lcos { namespace detail {
     {
         hpx::detail::try_catch_exception_ptr(
             [&]() {
-                hpx::annotate_function annotate(on_completed);
+                hpx::scoped_annotation annotate(on_completed);
                 on_completed();
             },
             [&](std::exception_ptr ep) {

--- a/libs/core/futures/src/future_data.cpp
+++ b/libs/core/futures/src/future_data.cpp
@@ -160,7 +160,7 @@ namespace hpx { namespace lcos { namespace detail {
     {
         hpx::detail::try_catch_exception_ptr(
             [&]() {
-                hpx::util::annotate_function annotate(on_completed);
+                hpx::annotate_function annotate(on_completed);
                 on_completed();
             },
             [&](std::exception_ptr ep) {

--- a/libs/core/include_local/include/hpx/local/functional.hpp
+++ b/libs/core/include_local/include/hpx/local/functional.hpp
@@ -16,6 +16,8 @@
 #include <hpx/functional/traits/is_bind_expression.hpp>
 #include <hpx/functional/traits/is_placeholder.hpp>
 #include <hpx/functional/unique_function.hpp>
+#include <hpx/threading_base/annotated_function.hpp>
+#include <hpx/threading_base/scoped_annotation.hpp>
 
 namespace hpx {
     using hpx::traits::is_bind_expression;

--- a/libs/core/resource_partitioner/examples/async_customization.cpp
+++ b/libs/core/resource_partitioner/examples/async_customization.cpp
@@ -102,7 +102,7 @@ struct test_async_executor
 
         // forward the task execution on to the real internal executor
         return hpx::parallel::execution::async_execute(executor_,
-            util::annotated_function(std::forward<F>(f), "custom"),
+            hpx::annotated_function(std::forward<F>(f), "custom"),
             std::forward<Ts>(ts)...);
     }
 
@@ -187,7 +187,7 @@ struct test_async_executor
 
         // forward the task execution on to the real internal executor
         return hpx::parallel::execution::then_execute(executor_,
-            util::annotated_function(std::forward<F>(f), "custom then"),
+            hpx::annotated_function(std::forward<F>(f), "custom then"),
             std::forward<OuterFuture<hpx::tuple<InnerFutures...>>>(predecessor),
             std::forward<Ts>(ts)...);
     }
@@ -230,7 +230,7 @@ struct test_async_executor
 
         // forward the task execution on to the real internal executor
         return hpx::parallel::execution::async_execute(executor_,
-            util::annotated_function(std::forward<F>(f), "custom async"),
+            hpx::annotated_function(std::forward<F>(f), "custom async"),
             std::forward<hpx::tuple<InnerFutures...>>(predecessor));
     }
 

--- a/libs/core/resource_partitioner/tests/unit/scheduler_priority_check.cpp
+++ b/libs/core/resource_partitioner/tests/unit/scheduler_priority_check.cpp
@@ -118,14 +118,14 @@ int hpx_main(variables_map& vm)
     std::atomic<int> count_down((np_loop + hp_loop) * cycles);
     std::atomic<int> counter(0);
     auto f3 = hpx::async(NP_executor,
-        hpx::util::annotated_function(
+        hpx::annotated_function(
             [&]() {
                 ++launch_count;
                 for (int i = 0; i < np_total; ++i)
                 {
                     // normal priority
                     auto f3 = hpx::async(NP_executor,
-                        hpx::util::annotated_function(
+                        hpx::annotated_function(
                             [&, np_m]() {
                                 np_task_count++;
                                 dec_counter dec(count_down);
@@ -141,13 +141,13 @@ int hpx_main(variables_map& vm)
 
                         // Launch HP tasks using an HP task to do it
                         hpx::async(HP_executor,
-                            hpx::util::annotated_function(
+                            hpx::annotated_function(
                                 [&]() {
                                     ++hp_launch_count;
                                     for (int j = 0; j < hp_loop; ++j)
                                     {
                                         hpx::async(HP_executor,
-                                            hpx::util::annotated_function(
+                                            hpx::annotated_function(
                                                 [&]() {
                                                     ++hp_task_count;
                                                     dec_counter dec(count_down);

--- a/libs/core/threading_base/CMakeLists.txt
+++ b/libs/core/threading_base/CMakeLists.txt
@@ -23,6 +23,7 @@ set(threading_base_headers
     hpx/threading_base/scheduler_base.hpp
     hpx/threading_base/scheduler_mode.hpp
     hpx/threading_base/scheduler_state.hpp
+    hpx/threading_base/scoped_annotation.hpp
     hpx/threading_base/set_thread_state.hpp
     hpx/threading_base/set_thread_state_timed.hpp
     hpx/threading_base/thread_data.hpp

--- a/libs/core/threading_base/include/hpx/threading_base/annotated_function.hpp
+++ b/libs/core/threading_base/include/hpx/threading_base/annotated_function.hpp
@@ -29,7 +29,7 @@
 #include <type_traits>
 #include <utility>
 
-namespace hpx { namespace util {
+namespace hpx {
     namespace detail {
         HPX_CORE_EXPORT char const* store_function_annotation(std::string name);
     }    // namespace detail
@@ -237,7 +237,7 @@ namespace hpx { namespace util {
         // Store string in a set to ensure it lives for the entire duration of
         // the task.
         char const* name_c_str =
-            detail::store_function_annotation(HPX_MOVE(name));
+            hpx::detail::store_function_annotation(HPX_MOVE(name));
         return result_type(HPX_FORWARD(F, f), name_c_str);
     }
 
@@ -276,30 +276,52 @@ namespace hpx { namespace util {
         return HPX_FORWARD(F, f);
     }
 #endif
-}}    // namespace hpx::util
+}    // namespace hpx
 
-namespace hpx { namespace traits {
+namespace hpx::traits {
 
 #if defined(HPX_HAVE_THREAD_DESCRIPTION)
     ///////////////////////////////////////////////////////////////////////////
     template <typename F>
-    struct get_function_address<util::detail::annotated_function<F>>
+    struct get_function_address<hpx::detail::annotated_function<F>>
     {
         static constexpr std::size_t call(
-            util::detail::annotated_function<F> const& f) noexcept
+            hpx::detail::annotated_function<F> const& f) noexcept
         {
             return f.get_function_address();
         }
     };
 
     template <typename F>
-    struct get_function_annotation<util::detail::annotated_function<F>>
+    struct get_function_annotation<hpx::detail::annotated_function<F>>
     {
         static constexpr char const* call(
-            util::detail::annotated_function<F> const& f) noexcept
+            hpx::detail::annotated_function<F> const& f) noexcept
         {
             return f.get_function_annotation();
         }
     };
 #endif
-}}    // namespace hpx::traits
+}    // namespace hpx::traits
+
+namespace hpx::util {
+    template <typename F>
+    HPX_DEPRECATED_V(1, 8, "Please use hpx::annotated_function instead.")
+    constexpr decltype(auto)
+        annotated_function(F&& f, char const* name = nullptr) noexcept
+    {
+        return hpx::annotated_function(HPX_FORWARD(F, f), name);
+    }
+
+    template <typename F>
+    HPX_DEPRECATED_V(1, 8, "Please use hpx::annotated_function instead.")
+    constexpr decltype(auto)
+        annotated_function(F&& f, std::string const& name) noexcept
+    {
+        return hpx::annotated_function(HPX_FORWARD(F, f), name);
+    }
+
+    using annotate_function HPX_DEPRECATED_V(1, 8,
+        "Please use hpx::annotate_function instead.") = hpx::annotate_function;
+
+}    // namespace hpx::util

--- a/libs/core/threading_base/include/hpx/threading_base/annotated_function.hpp
+++ b/libs/core/threading_base/include/hpx/threading_base/annotated_function.hpp
@@ -37,31 +37,31 @@ namespace hpx {
 #if defined(HPX_HAVE_THREAD_DESCRIPTION)
     ///////////////////////////////////////////////////////////////////////////
 #if defined(HPX_COMPUTE_DEVICE_CODE)
-    struct HPX_NODISCARD annotate_function
+    struct HPX_NODISCARD scoped_annotation
     {
-        HPX_NON_COPYABLE(annotate_function);
+        HPX_NON_COPYABLE(scoped_annotation);
 
-        explicit constexpr annotate_function(char const*) noexcept {}
+        explicit constexpr scoped_annotation(char const*) noexcept {}
 
         template <typename F>
-        explicit HPX_HOST_DEVICE constexpr annotate_function(F&&) noexcept
+        explicit HPX_HOST_DEVICE constexpr scoped_annotation(F&&) noexcept
         {
         }
 
         // add empty (but non-trivial) destructor to silence warnings
-        HPX_HOST_DEVICE ~annotate_function() {}
+        HPX_HOST_DEVICE ~scoped_annotation() {}
     };
 #elif HPX_HAVE_ITTNOTIFY != 0
-    struct HPX_NODISCARD annotate_function
+    struct HPX_NODISCARD scoped_annotation
     {
-        HPX_NON_COPYABLE(annotate_function);
+        HPX_NON_COPYABLE(scoped_annotation);
 
-        explicit annotate_function(char const* name)
+        explicit scoped_annotation(char const* name)
           : task_(thread_domain_, hpx::util::itt::string_handle(name))
         {
         }
         template <typename F>
-        explicit annotate_function(F&& f)
+        explicit scoped_annotation(F&& f)
           : task_(thread_domain_,
                 hpx::traits::get_function_annotation_itt<std::decay_t<F>>::call(
                     f))
@@ -73,11 +73,11 @@ namespace hpx {
         hpx::util::itt::task task_;
     };
 #else
-    struct HPX_NODISCARD annotate_function
+    struct HPX_NODISCARD scoped_annotation
     {
-        HPX_NON_COPYABLE(annotate_function);
+        HPX_NON_COPYABLE(scoped_annotation);
 
-        explicit annotate_function(char const* name)
+        explicit scoped_annotation(char const* name)
         {
             auto* self = hpx::threads::get_self_ptr();
             if (self != nullptr)
@@ -93,7 +93,7 @@ namespace hpx {
 #endif
         }
 
-        explicit annotate_function(std::string name)
+        explicit scoped_annotation(std::string name)
         {
             auto* self = hpx::threads::get_self_ptr();
             if (self != nullptr)
@@ -118,7 +118,7 @@ namespace hpx {
         template <typename F,
             typename =
                 std::enable_if_t<!std::is_same_v<std::decay_t<F>, std::string>>>
-        explicit annotate_function(F&& f)
+        explicit scoped_annotation(F&& f)
         {
             auto* self = hpx::threads::get_self_ptr();
             if (self != nullptr)
@@ -133,7 +133,7 @@ namespace hpx {
 #endif
         }
 
-        ~annotate_function()
+        ~scoped_annotation()
         {
             auto* self = hpx::threads::get_self_ptr();
             if (self != nullptr)
@@ -173,7 +173,7 @@ namespace hpx {
             template <typename... Ts>
             invoke_result_t<fun_type, Ts...> operator()(Ts&&... ts)
             {
-                annotate_function annotate(get_function_annotation());
+                scoped_annotation annotate(get_function_annotation());
                 return HPX_INVOKE(f_, HPX_FORWARD(Ts, ts)...);
             }
 
@@ -243,23 +243,23 @@ namespace hpx {
 
 #else
     ///////////////////////////////////////////////////////////////////////////
-    struct HPX_NODISCARD annotate_function
+    struct HPX_NODISCARD scoped_annotation
     {
-        HPX_NON_COPYABLE(annotate_function);
+        HPX_NON_COPYABLE(scoped_annotation);
 
-        explicit constexpr annotate_function(char const* /*name*/) noexcept {}
+        explicit constexpr scoped_annotation(char const* /*name*/) noexcept {}
 
         template <typename F>
-        explicit HPX_HOST_DEVICE constexpr annotate_function(F&& /*f*/) noexcept
+        explicit HPX_HOST_DEVICE constexpr scoped_annotation(F&& /*f*/) noexcept
         {
         }
 
         // add empty (but non-trivial) destructor to silence warnings
-        HPX_HOST_DEVICE ~annotate_function() {}
+        HPX_HOST_DEVICE ~scoped_annotation() {}
     };
 
     ///////////////////////////////////////////////////////////////////////////
-    /// \brief Given a function as an argument, the user can annotate_function
+    /// \brief Given a function as an argument, the user can scoped_annotation
     /// as well.
     /// Annotating includes setting the thread description per thread id.
     ///
@@ -322,6 +322,6 @@ namespace hpx::util {
     }
 
     using annotate_function HPX_DEPRECATED_V(1, 8,
-        "Please use hpx::annotate_function instead.") = hpx::annotate_function;
+        "Please use hpx::scoped_annotation instead.") = hpx::scoped_annotation;
 
 }    // namespace hpx::util

--- a/libs/core/threading_base/include/hpx/threading_base/scoped_annotation.hpp
+++ b/libs/core/threading_base/include/hpx/threading_base/scoped_annotation.hpp
@@ -1,0 +1,166 @@
+//  Copyright (c) 2017-2021 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include <hpx/config.hpp>
+
+#if defined(HPX_HAVE_THREAD_DESCRIPTION)
+#include <hpx/threading_base/thread_description.hpp>
+#include <hpx/threading_base/thread_helpers.hpp>
+
+#if HPX_HAVE_ITTNOTIFY != 0
+#include <hpx/modules/itt_notify.hpp>
+#elif defined(HPX_HAVE_APEX)
+#include <hpx/threading_base/external_timer.hpp>
+#endif
+#endif
+
+#include <string>
+#include <type_traits>
+
+namespace hpx {
+    namespace detail {
+        HPX_CORE_EXPORT char const* store_function_annotation(std::string name);
+    }    // namespace detail
+
+#if defined(HPX_HAVE_THREAD_DESCRIPTION)
+    ///////////////////////////////////////////////////////////////////////////
+#if defined(HPX_COMPUTE_DEVICE_CODE)
+    struct HPX_NODISCARD scoped_annotation
+    {
+        HPX_NON_COPYABLE(scoped_annotation);
+
+        explicit constexpr scoped_annotation(char const*) noexcept {}
+
+        template <typename F>
+        explicit HPX_HOST_DEVICE constexpr scoped_annotation(F&&) noexcept
+        {
+        }
+
+        // add empty (but non-trivial) destructor to silence warnings
+        HPX_HOST_DEVICE ~scoped_annotation() {}
+    };
+#elif HPX_HAVE_ITTNOTIFY != 0
+    struct HPX_NODISCARD scoped_annotation
+    {
+        HPX_NON_COPYABLE(scoped_annotation);
+
+        explicit scoped_annotation(char const* name)
+          : task_(thread_domain_, hpx::util::itt::string_handle(name))
+        {
+        }
+        template <typename F>
+        explicit scoped_annotation(F&& f)
+          : task_(thread_domain_,
+                hpx::traits::get_function_annotation_itt<std::decay_t<F>>::call(
+                    f))
+        {
+        }
+
+    private:
+        hpx::util::itt::thread_domain thread_domain_;
+        hpx::util::itt::task task_;
+    };
+#else
+    struct HPX_NODISCARD scoped_annotation
+    {
+        HPX_NON_COPYABLE(scoped_annotation);
+
+        explicit scoped_annotation(char const* name)
+        {
+            auto* self = hpx::threads::get_self_ptr();
+            if (self != nullptr)
+            {
+                desc_ = threads::get_thread_id_data(self->get_thread_id())
+                            ->set_description(name);
+            }
+
+#if defined(HPX_HAVE_APEX)
+            /* update the task wrapper in APEX to use the specified name */
+            threads::set_self_timer_data(hpx::util::external_timer::update_task(
+                threads::get_self_timer_data(), std::string(name)));
+#endif
+        }
+
+        explicit scoped_annotation(std::string name)
+        {
+            auto* self = hpx::threads::get_self_ptr();
+            if (self != nullptr)
+            {
+                char const* name_c_str =
+#if defined(HPX_HAVE_APEX)
+                    detail::store_function_annotation(name);
+#else
+                    detail::store_function_annotation(HPX_MOVE(name));
+#endif
+                desc_ = threads::get_thread_id_data(self->get_thread_id())
+                            ->set_description(name_c_str);
+            }
+
+#if defined(HPX_HAVE_APEX)
+            /* update the task wrapper in APEX to use the specified name */
+            threads::set_self_timer_data(hpx::util::external_timer::update_task(
+                threads::get_self_timer_data(), HPX_MOVE(name)));
+#endif
+        }
+
+        template <typename F,
+            typename =
+                std::enable_if_t<!std::is_same_v<std::decay_t<F>, std::string>>>
+        explicit scoped_annotation(F&& f)
+        {
+            auto* self = hpx::threads::get_self_ptr();
+            if (self != nullptr)
+            {
+                desc_ = threads::get_thread_id_data(self->get_thread_id())
+                            ->set_description(hpx::util::thread_description(f));
+            }
+
+#if defined(HPX_HAVE_APEX)
+            /* no need to update the task description in APEX, because
+             * this same description was used when the task was created. */
+#endif
+        }
+
+        ~scoped_annotation()
+        {
+            auto* self = hpx::threads::get_self_ptr();
+            if (self != nullptr)
+            {
+                threads::get_thread_id_data(self->get_thread_id())
+                    ->set_description(desc_);
+            }
+        }
+
+        hpx::util::thread_description desc_;
+    };
+#endif
+
+#else
+    ///////////////////////////////////////////////////////////////////////////
+    struct HPX_NODISCARD scoped_annotation
+    {
+        HPX_NON_COPYABLE(scoped_annotation);
+
+        explicit constexpr scoped_annotation(char const* /*name*/) noexcept {}
+
+        template <typename F>
+        explicit HPX_HOST_DEVICE constexpr scoped_annotation(F&& /*f*/) noexcept
+        {
+        }
+
+        // add empty (but non-trivial) destructor to silence warnings
+        HPX_HOST_DEVICE ~scoped_annotation() {}
+    };
+#endif
+}    // namespace hpx
+
+namespace hpx::util {
+    using annotate_function HPX_DEPRECATED_V(1, 8,
+        "Please use hpx::scoped_annotation instead.") = hpx::scoped_annotation;
+
+}    // namespace hpx::util

--- a/libs/core/threading_base/src/annotated_function.cpp
+++ b/libs/core/threading_base/src/annotated_function.cpp
@@ -13,24 +13,24 @@
 #include <unordered_set>
 #include <utility>
 
-namespace hpx { namespace util { namespace detail {
+namespace hpx::detail {
     char const* store_function_annotation(std::string name)
     {
         static thread_local std::unordered_set<std::string> names;
         auto r = names.emplace(HPX_MOVE(name));
         return (*std::get<0>(r)).c_str();
     }
-}}}    // namespace hpx::util::detail
+}    // namespace hpx::detail
 
 #else
 
 #include <string>
 
-namespace hpx { namespace util { namespace detail {
+namespace hpx::detail {
     char const* store_function_annotation(std::string)
     {
         return "<unknown>";
     }
-}}}    // namespace hpx::util::detail
+}    // namespace hpx::detail
 
 #endif

--- a/libs/full/components/include/hpx/components/executor_component.hpp
+++ b/libs/full/components/include/hpx/components/executor_component.hpp
@@ -63,7 +63,7 @@ namespace hpx { namespace components {
             hpx::parallel::execution::async_execute(
                 hpx::get_lva<executor_component>::call(lva)->exec_,
                 hpx::util::deferred_call(
-                    hpx::util::annotated_function(
+                    hpx::annotated_function(
                         &executor_component::execute, desc.get_description()),
                     HPX_MOVE(data.func)));
         }

--- a/tests/unit/apex/CMakeLists.txt
+++ b/tests/unit/apex/CMakeLists.txt
@@ -49,9 +49,9 @@ foreach(launch ${launch_types_})
   set(REGEX_MATCH_C_ "${REGEX_MATCH_C_}.*3-${launch}Unwrapping Continuation")
 endforeach()
 
-# annotate_function with std::string and char*
+# scoped_annotation with std::string and char*
 foreach(type "char" "string")
-  set(REGEX_MATCH_ANN_ "${REGEX_MATCH_ANN_}.*4-${type} annotate_function")
+  set(REGEX_MATCH_ANN_ "${REGEX_MATCH_ANN_}.*4-${type} scoped_annotation")
 endforeach()
 
 set_tests_properties(

--- a/tests/unit/apex/annotation_check.cpp
+++ b/tests/unit/apex/annotation_check.cpp
@@ -114,16 +114,16 @@ execution_string(const Policy& policy)
 }
 
 // --------------------------------------------------------------------------
-// use annotate_function
-void test_annotate_function()
+// use scoped_annotation
+void test_scoped_annotation()
 {
     hpx::async([]() {
-        hpx::annotate_function annotate("4-char annotate_function");
+        hpx::scoped_annotation annotate("4-char scoped_annotation");
     }).get();
 
     hpx::async([]() {
-        std::string s("4-string annotate_function");
-        hpx::annotate_function annotate(std::move(s));
+        std::string s("4-string scoped_annotation");
+        hpx::scoped_annotation annotate(std::move(s));
     }).get();
 }
 
@@ -204,7 +204,7 @@ int hpx_main()
     // setup executors
     hpx::execution::parallel_executor par_exec{};
 
-    test_annotate_function();
+    test_scoped_annotation();
     //
     test_none().get();
     //

--- a/tests/unit/apex/annotation_check.cpp
+++ b/tests/unit/apex/annotation_check.cpp
@@ -118,12 +118,12 @@ execution_string(const Policy& policy)
 void test_annotate_function()
 {
     hpx::async([]() {
-        hpx::util::annotate_function annotate("4-char annotate_function");
+        hpx::annotate_function annotate("4-char annotate_function");
     }).get();
 
     hpx::async([]() {
         std::string s("4-string annotate_function");
-        hpx::util::annotate_function annotate(std::move(s));
+        hpx::annotate_function annotate(std::move(s));
     }).get();
 }
 
@@ -140,22 +140,21 @@ hpx::future<void> test_none()
         hpx::future<int> f1 = hpx::async([]() { return 5; });
         hpx::future<int> f2 = hpx::make_ready_future(5);
         results.emplace_back(hpx::dataflow(
-            hpx::util::annotated_function(
+            hpx::annotated_function(
                 [](auto&&, auto&&) { dummy_task(std::size_t(1000)); }, dfs),
             f1, f2));
     }
 
     {
         hpx::future<int> f1 = hpx::async([]() { return 5; });
-        results.emplace_back(f1.then(hpx::util::annotated_function(
+        results.emplace_back(f1.then(hpx::annotated_function(
             [](auto&&) { dummy_task(std::size_t(1000)); }, pcs)));
     }
 
     {
         hpx::future<int> f1 = hpx::async([]() { return 5; });
-        results.emplace_back(
-            f1.then(hpx::unwrapping(hpx::util::annotated_function(
-                [](auto&&) { dummy_task(std::size_t(1000)); }, pcsu))));
+        results.emplace_back(f1.then(hpx::unwrapping(hpx::annotated_function(
+            [](auto&&) { dummy_task(std::size_t(1000)); }, pcsu))));
     }
 
     // wait for completion
@@ -180,20 +179,20 @@ hpx::future<void> test_execution(Execution& exec)
         hpx::future<int> f1 = hpx::async([]() { return 5; });
         hpx::future<int> f2 = hpx::make_ready_future(5);
         results.emplace_back(hpx::dataflow(exec,
-            hpx::util::annotated_function(
+            hpx::annotated_function(
                 [](auto&&, auto&&) { dummy_task(std::size_t(1000)); }, dfs),
             f1, f2));
     }
     {
         hpx::future<int> f1 = hpx::async([]() { return 5; });
         results.emplace_back(f1.then(exec,
-            hpx::util::annotated_function(
+            hpx::annotated_function(
                 [](auto&&) { dummy_task(std::size_t(1000)); }, pcs)));
     }
     {
         hpx::future<int> f1 = hpx::async([]() { return 5; });
         results.emplace_back(f1.then(exec,
-            hpx::unwrapping(hpx::util::annotated_function(
+            hpx::unwrapping(hpx::annotated_function(
                 [](auto&&) { dummy_task(std::size_t(1000)); }, pcsu))));
     }
     // wait for completion


### PR DESCRIPTION
Fixes #5686. Also moves the utilities to the top-level `hpx` namespace. Adds them to the public API list.

Open question: which header should provide these? I've now added both to `hpx/local/functional.hpp` (and by extension `hpx/functional.hpp`). `scoped_annotation` could also fit in `hpx/local/execution.hpp` in my opinion (`annotated_function` could sort of also fit there). 

Some (in my opinion worse) alternative names:

- `annotation`
- `annotate_scope`
- `annotation_scoped`
- `raii_annotation`