### PR TITLE
Change default `get_function_annotation` implementation

### DIFF
--- a/libs/core/functional/include/hpx/functional/traits/get_function_annotation.hpp
+++ b/libs/core/functional/include/hpx/functional/traits/get_function_annotation.hpp
@@ -19,7 +19,7 @@ namespace hpx { namespace traits {
     {
         static constexpr char const* call(F const& /*f*/) noexcept
         {
-            return nullptr;
+            return typeid(F).name();
         }
     };
 


### PR DESCRIPTION
Note, this is a proposal. There are pros and cons to this change. I'd like to hear some opinions from others about this.

Currently on master `get_function_annotation` returns `nullptr` unless there's a specialization (like when using `annotated_function`). In practice this means that unannotated functions typically inherit the annotation from the spawning thread (like `hpx_main`). This is nice in some situations because you know what spawned the task.

On the other hand it would be nice if the default annotations were actually related to the actual task being spawned. Instead of returning `nullptr` `get_function_annotation` can fall back to returning `typeid(F).name()`. Even if this a mangled name it will usually be more descriptive (in my opinion...). This also means that all the other fallback names that we use will never be taken into account because a function will always have a non-`nullptr` name.

Ideally we'd be able to have both. APEX does keep track of parent task ids which indirectly gives the task name of the parent. However, tooling for viewing this data is still quite bad.

Are there other pros/cons to using `typeid` instead?