### PR TITLE
Modernize when_all and friends (when_any, when_some, when_each)

### DIFF
--- a/components/containers/partitioned_vector/include/hpx/components/containers/partitioned_vector/partitioned_vector_decl.hpp
+++ b/components/containers/partitioned_vector/include/hpx/components/containers/partitioned_vector/partitioned_vector_decl.hpp
@@ -1036,7 +1036,7 @@ namespace hpx {
                     std::vector<size_type>(pos_block_begin, pos.end())),
                 std::vector<T>(val_block_begin, val.end())));
 
-            return when_all(part_futures);
+            return hpx::when_all(part_futures);
         }
 
         void set_values(launch::sync_policy, std::vector<size_type> const& pos,

--- a/components/containers/partitioned_vector/include/hpx/components/containers/partitioned_vector/partitioned_vector_impl.hpp
+++ b/components/containers/partitioned_vector/include/hpx/components/containers/partitioned_vector/partitioned_vector_impl.hpp
@@ -397,7 +397,7 @@ namespace hpx {
         }
         HPX_ASSERT(l == num_parts);
 
-        when_all(ptrs).get();
+        hpx::when_all(ptrs).get();
 
         // cache our partition size
         partition_size_ = get_partition_size();
@@ -461,7 +461,7 @@ namespace hpx {
             }
         }
 
-        when_all(ptrs).get();
+        hpx::when_all(ptrs).get();
 
         size_ = rhs.size_;
         partition_size_ = rhs.partition_size_;

--- a/libs/core/async_combinators/include/hpx/async_combinators/wait_all.hpp
+++ b/libs/core/async_combinators/include/hpx/async_combinators/wait_all.hpp
@@ -5,7 +5,7 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-/// \file lcos/wait_all.hpp
+/// \file wait_all.hpp
 
 #pragma once
 
@@ -557,64 +557,6 @@ namespace hpx {
 }    // namespace hpx
 
 namespace hpx::lcos {
-
-    template <typename Future>
-    HPX_DEPRECATED_V(
-        1, 8, "hpx::lcos::wait_all is deprecated. Use hpx::wait_all instead.")
-    void wait_all(std::vector<Future> const& values)
-    {
-        hpx::wait_all(values);
-    }
-
-    template <typename Future>
-    HPX_DEPRECATED_V(
-        1, 8, "hpx::lcos::wait_all is deprecated. Use hpx::wait_all instead.")
-    void wait_all(std::vector<Future>& values)
-    {
-        hpx::wait_all(values);
-    }
-
-    template <typename Future>
-    HPX_DEPRECATED_V(
-        1, 8, "hpx::lcos::wait_all is deprecated. Use hpx::wait_all instead.")
-    void wait_all(std::vector<Future>&& values)
-    {
-        hpx::wait_all(HPX_MOVE(values));
-    }
-
-    template <typename Iterator,
-        typename Enable =
-            std::enable_if_t<hpx::traits::is_iterator_v<Iterator>>>
-    HPX_DEPRECATED_V(
-        1, 8, "hpx::lcos::wait_all is deprecated. Use hpx::wait_all instead.")
-    void wait_all(Iterator begin, Iterator end)
-    {
-        hpx::wait_all(begin, end);
-    }
-
-    template <typename Future, std::size_t N>
-    HPX_DEPRECATED_V(
-        1, 8, "hpx::lcos::wait_all is deprecated. Use hpx::wait_all instead.")
-    void wait_all(std::array<Future, N> const& values)
-    {
-        hpx::wait_all(values);
-    }
-
-    template <typename Future, std::size_t N>
-    HPX_DEPRECATED_V(
-        1, 8, "hpx::lcos::wait_all is deprecated. Use hpx::wait_all instead.")
-    void wait_all(std::array<Future, N>& values)
-    {
-        hpx::wait_all(const_cast<std::array<Future, N> const&>(values));
-    }
-
-    template <typename Future, std::size_t N>
-    HPX_DEPRECATED_V(
-        1, 8, "hpx::lcos::wait_all is deprecated. Use hpx::wait_all instead.")
-    void wait_all(std::array<Future, N>&& values)
-    {
-        hpx::wait_all(HPX_MOVE(values));
-    }
 
     template <typename... Ts>
     HPX_DEPRECATED_V(

--- a/libs/core/async_combinators/include/hpx/async_combinators/wait_any.hpp
+++ b/libs/core/async_combinators/include/hpx/async_combinators/wait_any.hpp
@@ -5,7 +5,7 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-/// \file lcos/wait_any.hpp
+/// \file wait_any.hpp
 
 #pragma once
 

--- a/libs/core/async_combinators/include/hpx/async_combinators/wait_some.hpp
+++ b/libs/core/async_combinators/include/hpx/async_combinators/wait_some.hpp
@@ -5,7 +5,7 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-/// \file lcos/wait_some.hpp
+/// \file wait_some.hpp
 
 #pragma once
 

--- a/libs/core/async_combinators/include/hpx/async_combinators/when_all.hpp
+++ b/libs/core/async_combinators/include/hpx/async_combinators/when_all.hpp
@@ -6,7 +6,7 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-/// \file lcos/when_all.hpp
+/// \file when_all.hpp
 
 #pragma once
 
@@ -139,6 +139,7 @@ namespace hpx {
 #include <hpx/futures/detail/future_transforms.hpp>
 #include <hpx/futures/future.hpp>
 #include <hpx/futures/traits/acquire_future.hpp>
+#include <hpx/futures/traits/acquire_shared_state.hpp>
 #include <hpx/futures/traits/future_access.hpp>
 #include <hpx/futures/traits/future_traits.hpp>
 #include <hpx/futures/traits/is_future.hpp>
@@ -152,15 +153,16 @@ namespace hpx {
 #include <vector>
 
 ///////////////////////////////////////////////////////////////////////////////
-namespace hpx { namespace lcos {
-    namespace detail {
+namespace hpx {
+
+    namespace lcos { namespace detail {
         ///////////////////////////////////////////////////////////////////////
         template <typename T, typename Enable = void>
         struct when_all_result
         {
-            typedef T type;
+            using type = T;
 
-            static type call(T&& t)
+            static type call(T&& t) noexcept
             {
                 return HPX_MOVE(t);
             }
@@ -168,33 +170,36 @@ namespace hpx { namespace lcos {
 
         template <typename T>
         struct when_all_result<hpx::tuple<T>,
-            typename std::enable_if<traits::is_future_range<T>::value>::type>
+            std::enable_if_t<hpx::traits::is_future_range_v<T>>>
         {
-            typedef T type;
+            using type = T;
 
-            static type call(hpx::tuple<T>&& t)
+            static type call(hpx::tuple<T>&& t) noexcept
             {
                 return HPX_MOVE(hpx::get<0>(t));
             }
         };
 
+        template <typename T>
+        using when_all_result_t = typename when_all_result<T>::type;
+
         template <typename Tuple>
         class async_when_all_frame
-          : public future_data<typename when_all_result<Tuple>::type>
+          : public future_data<when_all_result_t<Tuple>>
         {
         public:
-            typedef typename when_all_result<Tuple>::type result_type;
-            typedef hpx::future<result_type> type;
-            typedef hpx::lcos::detail::future_data<result_type> base_type;
+            using result_type = when_all_result_t<Tuple>;
+            using type = hpx::future<result_type>;
+            using base_type = hpx::lcos::detail::future_data<result_type>;
 
             explicit async_when_all_frame(
                 typename base_type::init_no_addref no_addref)
-              : future_data<typename when_all_result<Tuple>::type>(no_addref)
+              : base_type(no_addref)
             {
             }
 
             template <typename T>
-            auto operator()(util::async_traverse_visit_tag, T&& current)
+            auto operator()(hpx::util::async_traverse_visit_tag, T&& current)
                 -> decltype(async_visit_future(HPX_FORWARD(T, current)))
             {
                 return async_visit_future(HPX_FORWARD(T, current));
@@ -202,7 +207,7 @@ namespace hpx { namespace lcos {
 
             template <typename T, typename N>
             auto operator()(
-                util::async_traverse_detach_tag, T&& current, N&& next)
+                hpx::util::async_traverse_detach_tag, T&& current, N&& next)
                 -> decltype(async_detach_future(
                     HPX_FORWARD(T, current), HPX_FORWARD(N, next)))
             {
@@ -211,7 +216,7 @@ namespace hpx { namespace lcos {
             }
 
             template <typename T>
-            void operator()(util::async_traverse_complete_tag, T&& pack)
+            void operator()(hpx::util::async_traverse_complete_tag, T&& pack)
             {
                 this->set_value(
                     when_all_result<Tuple>::call(HPX_FORWARD(T, pack)));
@@ -219,77 +224,83 @@ namespace hpx { namespace lcos {
         };
 
         template <typename... T>
-        typename detail::async_when_all_frame<
-            hpx::tuple<typename traits::acquire_future<T>::type...>>::type
+        typename async_when_all_frame<
+            hpx::tuple<hpx::traits::acquire_future_t<T>...>>::type
         when_all_impl(T&&... args)
         {
-            typedef hpx::tuple<typename traits::acquire_future<T>::type...>
-                result_type;
-            typedef detail::async_when_all_frame<result_type> frame_type;
+            using result_type = hpx::tuple<hpx::traits::acquire_future_t<T>...>;
+            using frame_type = async_when_all_frame<result_type>;
+            using no_addref = typename frame_type::base_type::init_no_addref;
 
-            traits::acquire_future_disp func;
+            auto frame = hpx::util::traverse_pack_async_allocator(
+                hpx::util::internal_allocator<>{},
+                hpx::util::async_traverse_in_place_tag<frame_type>{},
+                no_addref{},
+                hpx::traits::acquire_future_disp()(HPX_FORWARD(T, args))...);
 
-            typename frame_type::base_type::init_no_addref no_addref;
-
-            auto frame = util::traverse_pack_async_allocator(
-                util::internal_allocator<>{},
-                util::async_traverse_in_place_tag<frame_type>{}, no_addref,
-                func(HPX_FORWARD(T, args))...);
-
-            using traits::future_access;
-            return future_access<typename frame_type::type>::create(
-                HPX_MOVE(frame));
+            return hpx::traits::future_access<
+                typename frame_type::type>::create(HPX_MOVE(frame));
         }
-    }    // namespace detail
+    }}    // namespace lcos::detail
 
-    template <typename First, typename Second>
-    auto when_all(First&& first, Second&& second)
-        -> decltype(detail::when_all_impl(
-            HPX_FORWARD(First, first), HPX_FORWARD(Second, second)))
+    ///////////////////////////////////////////////////////////////////////////
+    template <typename... Args>
+    auto when_all(Args&&... args) -> decltype(
+        hpx::lcos::detail::when_all_impl(HPX_FORWARD(Args, args)...))
     {
-        return detail::when_all_impl(
-            HPX_FORWARD(First, first), HPX_FORWARD(Second, second));
+        return hpx::lcos::detail::when_all_impl(HPX_FORWARD(Args, args)...);
     }
+
     template <typename Iterator,
-        typename Container = std::vector<
-            typename detail::future_iterator_traits<Iterator>::type>>
-    hpx::future<Container> when_all(Iterator begin, Iterator end)
+        typename Container =
+            std::vector<hpx::lcos::detail::future_iterator_traits_t<Iterator>>,
+        typename Enable =
+            std::enable_if_t<hpx::traits::is_iterator_v<Iterator>>>
+    decltype(auto) when_all(Iterator begin, Iterator end)
     {
-        return detail::when_all_impl(
-            detail::acquire_future_iterators<Iterator, Container>(begin, end));
+        return hpx::lcos::detail::when_all_impl(
+            hpx::lcos::detail::acquire_future_iterators<Iterator, Container>(
+                begin, end));
+    }
+
+    template <typename Iterator,
+        typename Container =
+            std::vector<hpx::lcos::detail::future_iterator_traits_t<Iterator>>,
+        typename Enable =
+            std::enable_if_t<hpx::traits::is_iterator_v<Iterator>>>
+    decltype(auto) when_all_n(Iterator begin, std::size_t count)
+    {
+        return hpx::lcos::detail::when_all_impl(
+            hpx::lcos::detail::acquire_future_n<Iterator, Container>(
+                begin, count));
     }
 
     inline hpx::future<hpx::tuple<>>    //-V524
     when_all()
     {
-        typedef hpx::tuple<> result_type;
-        return hpx::make_ready_future(result_type());
+        return hpx::make_ready_future(hpx::tuple<>());
     }
-
-    ///////////////////////////////////////////////////////////////////////////
-    template <typename Iterator,
-        typename Container = std::vector<
-            typename lcos::detail::future_iterator_traits<Iterator>::type>>
-    hpx::future<Container> when_all_n(Iterator begin, std::size_t count)
-    {
-        return detail::when_all_impl(
-            detail::acquire_future_n<Iterator, Container>(begin, count));
-    }
-
-    ///////////////////////////////////////////////////////////////////////////
-    template <typename... Args,
-        typename std::enable_if<(sizeof...(Args) == 1U) ||
-            (sizeof...(Args) > 2U)>::type* = nullptr>
-    auto when_all(Args&&... args)
-        -> decltype(detail::when_all_impl(HPX_FORWARD(Args, args)...))
-    {
-        return detail::when_all_impl(HPX_FORWARD(Args, args)...);
-    }
-}}    // namespace hpx::lcos
-
-namespace hpx {
-    using lcos::when_all;
-    using lcos::when_all_n;
 }    // namespace hpx
+
+namespace hpx::lcos {
+
+    template <typename... Args>
+    HPX_DEPRECATED_V(
+        1, 8, "hpx::lcos::when_all is deprecated. Use hpx::when_all instead.")
+    auto when_all(Args&&... args)
+    {
+        return hpx::when_all(HPX_FORWARD(Args, args)...);
+    }
+
+    template <typename Iterator,
+        typename Enable =
+            std::enable_if_t<hpx::traits::is_iterator_v<Iterator>>>
+    HPX_DEPRECATED_V(1, 8,
+        "hpx::lcos::when_all_n is deprecated. Use hpx::when_all_n instead.")
+    auto when_all_n(Iterator begin, std::size_t count)
+    {
+        return hpx::when_all(begin, count);
+    }
+}    // namespace hpx::lcos
 
 #endif    // DOXYGEN

--- a/libs/core/async_combinators/include/hpx/async_combinators/when_any.hpp
+++ b/libs/core/async_combinators/include/hpx/async_combinators/when_any.hpp
@@ -1,11 +1,11 @@
-//  Copyright (c) 2007-2015 Hartmut Kaiser
+//  Copyright (c) 2007-2021 Hartmut Kaiser
 //  Copyright (c) 2013 Agustin Berge
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-/// \file lcos/when_any.hpp
+/// \file when_any.hpp
 
 #pragma once
 
@@ -18,8 +18,8 @@ namespace hpx {
     struct when_any_result
     {
         std::size_t index;    ///< The index of a future which has become ready
-        Sequence
-            futures;    ///< The sequence of futures as passed to \a hpx::when_any
+        Sequence futures;     ///< The sequence of futures as passed to
+                              ///< \a hpx::when_any
     };
 
     /// The function \a when_any is a non-deterministic choice operator. It
@@ -146,22 +146,23 @@ namespace hpx {
 #include <vector>
 
 ///////////////////////////////////////////////////////////////////////////////
-namespace hpx { namespace lcos {
+namespace hpx {
+
     template <typename Sequence>
     struct when_any_result
     {
-        static std::size_t index_error()
+        static constexpr std::size_t index_error() noexcept
         {
             return static_cast<std::size_t>(-1);
         }
 
-        when_any_result()
-          : index(static_cast<size_t>(index_error()))
+        when_any_result() noexcept
+          : index(index_error())
           , futures()
         {
         }
 
-        explicit when_any_result(Sequence&& futures)
+        explicit when_any_result(Sequence&& futures) noexcept
           : index(index_error())
           , futures(HPX_MOVE(futures))
         {
@@ -173,7 +174,7 @@ namespace hpx { namespace lcos {
         {
         }
 
-        when_any_result(when_any_result&& rhs)
+        when_any_result(when_any_result&& rhs) noexcept
           : index(rhs.index)
           , futures(HPX_MOVE(rhs.futures))
         {
@@ -190,7 +191,7 @@ namespace hpx { namespace lcos {
             return *this;
         }
 
-        when_any_result& operator=(when_any_result&& rhs)
+        when_any_result& operator=(when_any_result&& rhs) noexcept
         {
             if (this != &rhs)
             {
@@ -205,7 +206,8 @@ namespace hpx { namespace lcos {
         Sequence futures;
     };
 
-    namespace detail {
+    namespace lcos { namespace detail {
+
         ///////////////////////////////////////////////////////////////////////
         template <typename Sequence>
         struct when_any;
@@ -213,40 +215,39 @@ namespace hpx { namespace lcos {
         template <typename Sequence>
         struct set_when_any_callback_impl
         {
-            explicit set_when_any_callback_impl(when_any<Sequence>& when)
+            explicit set_when_any_callback_impl(
+                when_any<Sequence>& when) noexcept
               : when_(when)
               , idx_(0)
             {
             }
 
             template <typename Future>
-            void operator()(Future& future,
-                typename std::enable_if<
-                    traits::is_future<Future>::value>::type* = nullptr) const
+            std::enable_if_t<hpx::traits::is_future_v<Future>> operator()(
+                Future& future) const
             {
                 std::size_t index =
                     when_.index_.load(std::memory_order_seq_cst);
+
                 if (index == when_any_result<Sequence>::index_error())
                 {
-                    typedef typename traits::detail::shared_state_ptr_for<
-                        Future>::type shared_state_ptr;
+                    using shared_state_ptr =
+                        hpx::traits::detail::shared_state_ptr_for_t<Future>;
                     shared_state_ptr const& shared_state =
                         traits::detail::get_shared_state(future);
 
-                    if (shared_state.get() != nullptr &&
-                        !shared_state->is_ready())
+                    if (shared_state && !shared_state->is_ready())
                     {
                         // handle future only if not enough futures are ready
                         // yet also, do not touch any futures which are already
                         // ready
-
                         shared_state->execute_deferred();
 
                         // execute_deferred might have made the future ready
                         if (!shared_state->is_ready())
                         {
                             shared_state->set_on_completed(util::deferred_call(
-                                &when_any<Sequence>::on_future_ready,
+                                &detail::when_any<Sequence>::on_future_ready,
                                 when_.shared_from_this(), idx_,
                                 hpx::execution_base::this_thread::agent()));
                             ++idx_;
@@ -263,17 +264,16 @@ namespace hpx { namespace lcos {
             }
 
             template <typename Sequence_>
-            HPX_FORCEINLINE void operator()(Sequence_& sequence,
-                typename std::enable_if<
-                    traits::is_future_range<Sequence_>::value>::type* =
-                    nullptr) const
+            HPX_FORCEINLINE
+                std::enable_if_t<hpx::traits::is_future_range_v<Sequence_>>
+                operator()(Sequence_& sequence) const
             {
                 apply(sequence);
             }
 
             template <typename Tuple, std::size_t... Is>
             HPX_FORCEINLINE void apply(
-                Tuple& tuple, util::index_pack<Is...>) const
+                Tuple& tuple, hpx::util::index_pack<Is...>) const
             {
                 int const _sequencer[] = {
                     (((*this)(hpx::get<Is>(tuple))), 0)...};
@@ -283,8 +283,7 @@ namespace hpx { namespace lcos {
             template <typename... Ts>
             HPX_FORCEINLINE void apply(hpx::tuple<Ts...>& sequence) const
             {
-                apply(sequence,
-                    typename util::make_index_pack<sizeof...(Ts)>::type());
+                apply(sequence, hpx::util::make_index_pack_t<sizeof...(Ts)>());
             }
 
             template <typename Sequence_>
@@ -293,12 +292,13 @@ namespace hpx { namespace lcos {
                 std::for_each(sequence.begin(), sequence.end(), *this);
             }
 
-            when_any<Sequence>& when_;
+            detail::when_any<Sequence>& when_;
             mutable std::size_t idx_;
         };
 
         template <typename Sequence>
-        HPX_FORCEINLINE void set_on_completed_callback(when_any<Sequence>& when)
+        HPX_FORCEINLINE void set_on_completed_callback(
+            detail::when_any<Sequence>& when)
         {
             set_when_any_callback_impl<Sequence> callback(when);
             callback.apply(when.lazy_values_.futures);
@@ -319,21 +319,27 @@ namespace hpx { namespace lcos {
                 {
                     // reactivate waiting thread only if it's not us
                     if (ctx != hpx::execution_base::this_thread::agent())
+                    {
                         ctx.resume();
+                    }
                     else
+                    {
                         goal_reached_on_calling_thread_ = true;
+                    }
                 }
             }
 
         private:
-            // workaround gcc regression wrongly instantiating constructors
-            when_any();
-            when_any(when_any const&);
+            when_any(when_any const&) = delete;
+            when_any(when_any&) = delete;
+
+            when_any& operator=(when_any const&) = delete;
+            when_any& operator=(when_any&&) = delete;
 
         public:
-            typedef Sequence argument_type;
+            using argument_type = Sequence;
 
-            when_any(argument_type&& lazy_values)
+            when_any(argument_type&& lazy_values) noexcept
               : lazy_values_(HPX_MOVE(lazy_values))
               , index_(when_any_result<Sequence>::index_error())
               , goal_reached_on_calling_thread_(false)
@@ -367,112 +373,125 @@ namespace hpx { namespace lcos {
             std::atomic<std::size_t> index_;
             bool goal_reached_on_calling_thread_;
         };
-    }    // namespace detail
+    }}    // namespace lcos::detail
 
     ///////////////////////////////////////////////////////////////////////////
     template <typename Range>
-    typename std::enable_if<traits::is_future_range<Range>::value,
-        hpx::future<when_any_result<typename std::decay<Range>::type>>>::type
-    when_any(Range&& lazy_values)
+    std::enable_if_t<hpx::traits::is_future_range_v<Range>,
+        hpx::future<hpx::when_any_result<std::decay_t<Range>>>>
+    when_any(Range&& values)
     {
-        typedef typename std::decay<Range>::type result_type;
+        using result_type = std::decay_t<Range>;
 
-        result_type lazy_values_ =
-            traits::acquire_future<result_type>()(lazy_values);
+        auto f = std::make_shared<lcos::detail::when_any<result_type>>(
+            hpx::traits::acquire_future<result_type>()(values));
 
-        std::shared_ptr<detail::when_any<result_type>> f =
-            std::make_shared<detail::when_any<result_type>>(
-                HPX_MOVE(lazy_values_));
-
-        lcos::local::futures_factory<when_any_result<result_type>()> p(
-            [f = HPX_MOVE(f)]() -> when_any_result<result_type> {
+        lcos::local::futures_factory<hpx::when_any_result<result_type>()> p(
+            [f = HPX_MOVE(f)]() -> hpx::when_any_result<result_type> {
                 return (*f)();
             });
 
+        auto result = p.get_future();
         p.apply();
-        return p.get_future();
+
+        return result;
     }
 
     template <typename Iterator,
-        typename Container = std::vector<
-            typename lcos::detail::future_iterator_traits<Iterator>::type>>
-    hpx::future<when_any_result<Container>> when_any(
+        typename Container =
+            std::vector<hpx::lcos::detail::future_iterator_traits_t<Iterator>>,
+        typename Enable =
+            std::enable_if_t<hpx::traits::is_iterator_v<Iterator>>>
+    hpx::future<hpx::when_any_result<Container>> when_any(
         Iterator begin, Iterator end)
     {
-        Container lazy_values_;
+        Container values;
+        traits::detail::reserve_if_random_access_by_range(values, begin, end);
 
-        typename std::iterator_traits<Iterator>::difference_type difference =
-            std::distance(begin, end);
-        if (difference > 0)
-            traits::detail::reserve_if_reservable(
-                lazy_values_, static_cast<std::size_t>(difference));
-
-        std::transform(begin, end, std::back_inserter(lazy_values_),
-            traits::acquire_future_disp());
-
-        return lcos::when_any(HPX_MOVE(lazy_values_));
+        std::move(begin, end, std::back_inserter(values));
+        return hpx::when_any(HPX_MOVE(values));
     }
 
-    inline hpx::future<when_any_result<hpx::tuple<>>>    //-V524
-    when_any()
+    inline auto when_any()
     {
-        typedef when_any_result<hpx::tuple<>> result_type;
-
-        return hpx::make_ready_future(result_type());
+        return hpx::make_ready_future(hpx::when_any_result<hpx::tuple<>>());
     }
 
     ///////////////////////////////////////////////////////////////////////////
     template <typename Iterator,
-        typename Container = std::vector<
-            typename lcos::detail::future_iterator_traits<Iterator>::type>>
-    hpx::future<when_any_result<Container>> when_any_n(
+        typename Container =
+            std::vector<hpx::lcos::detail::future_iterator_traits_t<Iterator>>,
+        typename Enable =
+            std::enable_if_t<hpx::traits::is_iterator_v<Iterator>>>
+    hpx::future<hpx::when_any_result<Container>> when_any_n(
         Iterator begin, std::size_t count)
     {
-        Container lazy_values_;
-        traits::detail::reserve_if_reservable(lazy_values_, count);
+        Container values;
+        traits::detail::reserve_if_reservable(values, count);
 
-        traits::acquire_future_disp func;
-        for (std::size_t i = 0; i != count; ++i)
-            lazy_values_.push_back(func(*begin++));
-
-        return lcos::when_any(lazy_values_);
+        while (count-- != 0)
+        {
+            // NOLINTNEXTLINE(bugprone-macro-repeated-side-effects)
+            values.push_back(HPX_MOVE(*begin++));
+        }
+        return hpx::when_any(HPX_MOVE(values));
     }
 
     ///////////////////////////////////////////////////////////////////////////
-    template <typename T, typename... Ts>
-    typename std::enable_if<!(traits::is_future_range<T>::value &&
-                                sizeof...(Ts) == 0),
-        hpx::future<
-            when_any_result<hpx::tuple<typename traits::acquire_future<T>::type,
-                typename traits::acquire_future<Ts>::type...>>>>::type
+    template <typename T, typename... Ts,
+        typename Enable = std::enable_if_t<!(
+            hpx::traits::is_future_range_v<T> && sizeof...(Ts) == 0)>>
+    hpx::future<
+        hpx::when_any_result<hpx::tuple<hpx::traits::acquire_future_t<T>,
+            hpx::traits::acquire_future_t<Ts>...>>>
     when_any(T&& t, Ts&&... ts)
     {
-        typedef hpx::tuple<typename traits::acquire_future<T>::type,
-            typename traits::acquire_future<Ts>::type...>
-            result_type;
+        using result_type = hpx::tuple<hpx::traits::acquire_future_t<T>,
+            hpx::traits::acquire_future_t<Ts>...>;
 
-        traits::acquire_future_disp func;
-        result_type lazy_values(
+        hpx::traits::acquire_future_disp func;
+        result_type values(
             func(HPX_FORWARD(T, t)), func(HPX_FORWARD(Ts, ts))...);
 
-        std::shared_ptr<detail::when_any<result_type>> f =
-            std::make_shared<detail::when_any<result_type>>(
-                HPX_MOVE(lazy_values));
+        auto f = std::make_shared<lcos::detail::when_any<result_type>>(
+            HPX_MOVE(values));
 
-        lcos::local::futures_factory<when_any_result<result_type>()> p(
-            [f = HPX_MOVE(f)]() -> when_any_result<result_type> {
+        lcos::local::futures_factory<hpx::when_any_result<result_type>()> p(
+            [f = HPX_MOVE(f)]() -> hpx::when_any_result<result_type> {
                 return (*f)();
             });
 
+        auto result = p.get_future();
         p.apply();
-        return p.get_future();
-    }
-}}    // namespace hpx::lcos
 
-namespace hpx {
-    using lcos::when_any;
-    using lcos::when_any_n;
-    using lcos::when_any_result;
+        return result;
+    }
 }    // namespace hpx
+
+namespace hpx::lcos {
+
+    template <typename... Ts>
+    HPX_DEPRECATED_V(
+        1, 8, "hpx::lcos::when_any is deprecated. Use hpx::when_any instead.")
+    auto when_any(Ts&&... ts)
+    {
+        return hpx::when_any(HPX_FORWARD(Ts, ts)...);
+    }
+
+    template <typename Iterator,
+        typename Enable =
+            std::enable_if_t<hpx::traits::is_iterator_v<Iterator>>>
+    HPX_DEPRECATED_V(1, 8,
+        "hpx::lcos::when_any_n is deprecated. Use hpx::when_any_n instead.")
+    auto when_any_n(Iterator begin, std::size_t count)
+    {
+        return hpx::when_any_n(begin, count);
+    }
+
+    template <typename Container>
+    using when_any_result HPX_DEPRECATED_V(1, 8,
+        "hpx::lcos::when_all_result is deprecated. Use hpx::when_all_result "
+        "instead.") = hpx::when_any_result<Container>;
+}    // namespace hpx::lcos
 
 #endif    // DOXYGEN

--- a/libs/core/async_combinators/include/hpx/async_combinators/when_each.hpp
+++ b/libs/core/async_combinators/include/hpx/async_combinators/when_each.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2017 Hartmut Kaiser
+//  Copyright (c) 2007-2021 Hartmut Kaiser
 //  Copyright (c) 2013 Agustin Berge
 //  Copyright (c) 2016 Lukas Troska
 //
@@ -6,7 +6,7 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-/// \file lcos/when_each.hpp
+/// \file when_each.hpp
 
 #pragma once
 
@@ -127,12 +127,9 @@ namespace hpx {
 
 #include <hpx/config.hpp>
 #include <hpx/async_base/launch_policy.hpp>
-#include <hpx/async_combinators/when_some.hpp>
 #include <hpx/datastructures/tuple.hpp>
-#include <hpx/functional/bind_back.hpp>
-#include <hpx/futures/detail/future_data.hpp>
+#include <hpx/futures/future.hpp>
 #include <hpx/futures/traits/acquire_future.hpp>
-#include <hpx/futures/traits/acquire_shared_state.hpp>
 #include <hpx/futures/traits/detail/future_traits.hpp>
 #include <hpx/futures/traits/future_access.hpp>
 #include <hpx/futures/traits/future_traits.hpp>
@@ -141,7 +138,6 @@ namespace hpx {
 #include <hpx/iterator_support/range.hpp>
 #include <hpx/modules/memory.hpp>
 #include <hpx/type_support/decay.hpp>
-#include <hpx/type_support/pack.hpp>
 #include <hpx/type_support/unwrap_ref.hpp>
 
 #include <algorithm>
@@ -152,42 +148,31 @@ namespace hpx {
 #include <vector>
 
 ///////////////////////////////////////////////////////////////////////////////
-namespace hpx { namespace lcos {
-    namespace detail {
-        // call supplied callback with or without index
-        struct dispatch
-        {
-            template <typename F, typename IndexType, typename FutureType>
-            inline static void call(
-                F&& f, IndexType index, FutureType&& future, std::true_type)
-            {
-                f(index, HPX_FORWARD(FutureType, future));
-            }
+namespace hpx {
 
-            template <typename F, typename IndexType, typename FutureType>
-            inline static void call(
-                F&& f, IndexType, FutureType&& future, std::false_type)
-            {
-                f(HPX_FORWARD(FutureType, future));
-            }
-        };
+    namespace lcos { namespace detail {
 
         template <typename Tuple, typename F>
         struct when_each_frame    //-V690
           : lcos::detail::future_data<void>
         {
-            typedef hpx::future<void> type;
+            using type = hpx::future<void>;
 
         private:
-            // workaround gcc regression wrongly instantiating constructors
-            when_each_frame();
-            when_each_frame(when_each_frame const&);
+            when_each_frame(when_each_frame const&) = delete;
+            when_each_frame(when_each_frame&&) = delete;
+
+            when_each_frame& operator=(when_each_frame const&) = delete;
+            when_each_frame& operator=(when_each_frame&&) = delete;
 
             template <std::size_t I>
             struct is_end
               : std::integral_constant<bool, hpx::tuple_size<Tuple>::value == I>
             {
             };
+
+            template <std::size_t I>
+            static constexpr bool is_end_v = is_end<I>::value;
 
         public:
             template <typename Tuple_, typename F_>
@@ -199,30 +184,54 @@ namespace hpx { namespace lcos {
             {
             }
 
-        protected:
+        public:
             template <std::size_t I>
-            HPX_FORCEINLINE void do_await(std::true_type)
+            HPX_FORCEINLINE void do_await()
             {
-                this->set_value(util::unused);
+                if constexpr (is_end_v<I>)
+                {
+                    this->set_value(util::unused);
+                }
+                else
+                {
+                    using future_type = hpx::util::decay_unwrap_t<
+                        typename hpx::tuple_element<I, Tuple>::type>;
+
+                    if constexpr (hpx::traits::is_future_v<future_type> ||
+                        hpx::traits::is_ref_wrapped_future_v<future_type>)
+                    {
+                        await_future<I>();
+                    }
+                    else
+                    {
+                        static_assert(
+                            hpx::traits::is_future_range_v<future_type> ||
+                                hpx::traits::is_ref_wrapped_future_range_v<
+                                    future_type>,
+                            "element must be future or range of futures");
+
+                        auto&& curr = hpx::util::unwrap_ref(hpx::get<I>(t_));
+                        await_range<I>(
+                            hpx::util::begin(curr), hpx::util::end(curr));
+                    }
+                }
             }
 
+        protected:
             // Current element is a range (vector) of futures
             template <std::size_t I, typename Iter>
-            void await_range(Iter next, Iter end)
+            void await_range(Iter&& next, Iter&& end)
             {
-                typedef
-                    typename std::iterator_traits<Iter>::value_type future_type;
-                typedef typename traits::future_traits<future_type>::type
-                    future_result_type;
+                using future_type =
+                    typename std::iterator_traits<Iter>::value_type;
 
+                hpx::intrusive_ptr<when_each_frame> this_(this);
                 for (/**/; next != end; ++next)
                 {
-                    typename traits::detail::shared_state_ptr<
-                        future_result_type>::type next_future_data =
+                    auto next_future_data =
                         traits::detail::get_shared_state(*next);
 
-                    if (next_future_data.get() != nullptr &&
-                        !next_future_data->is_ready())
+                    if (next_future_data && !next_future_data->is_ready())
                     {
                         next_future_data->execute_deferred();
 
@@ -232,58 +241,59 @@ namespace hpx { namespace lcos {
                             // Attach a continuation to this future which will
                             // re-evaluate it and continue to the next argument
                             // (if any).
-                            hpx::intrusive_ptr<when_each_frame> this_(this);
                             next_future_data->set_on_completed(
                                 [this_ = HPX_MOVE(this_), next = HPX_MOVE(next),
                                     end = HPX_MOVE(end)]() mutable -> void {
-                                    return this_->template await_range<I>(
+                                    this_->template await_range<I>(
                                         HPX_MOVE(next), HPX_MOVE(end));
                                 });
+
+                            // explicitly destruct iterators as those might
+                            // become dangling after we make ourselves ready
+                            next = std::decay_t<Iter>{};
+                            end = std::decay_t<Iter>{};
                             return;
                         }
                     }
 
-                    dispatch::call(HPX_FORWARD(F, f_), count_++,
-                        HPX_MOVE(*next),
-                        typename is_invocable<F, std::size_t,
-                            future_type>::type());
-
-                    if (count_ == needed_count_)
+                    // call supplied callback with or without index
+                    if constexpr (hpx::is_invocable_v<F, std::size_t,
+                                      future_type>)
                     {
-                        do_await<I + 1>(std::true_type());
+                        f_(count_, HPX_MOVE(*next));
+                    }
+                    else
+                    {
+                        f_(HPX_MOVE(*next));
+                    }
+
+                    if (++count_ == needed_count_)
+                    {
+                        this->set_value(util::unused);
+
+                        // explicitly destruct iterators as those might
+                        // become dangling after we make ourselves ready
+                        next = std::decay_t<Iter>{};
+                        end = std::decay_t<Iter>{};
                         return;
                     }
                 }
 
-                do_await<I + 1>(is_end<I + 1>());
-            }
-
-            template <std::size_t I>
-            HPX_FORCEINLINE void await_next(std::false_type, std::true_type)
-            {
-                await_range<I>(util::begin(util::unwrap_ref(hpx::get<I>(t_))),
-                    util::end(util::unwrap_ref(hpx::get<I>(t_))));
+                do_await<I + 1>();
             }
 
             // Current element is a simple future
             template <std::size_t I>
-            HPX_FORCEINLINE void await_next(std::true_type, std::false_type)
+            HPX_FORCEINLINE void await_future()
             {
-                typedef
-                    typename util::decay_unwrap<typename hpx::tuple_element<I,
-                        Tuple>::type>::type future_type;
+                using future_type = hpx::util::decay_unwrap_t<
+                    typename hpx::tuple_element<I, Tuple>::type>;
 
-                typedef typename traits::future_traits<future_type>::type
-                    future_result_type;
+                hpx::intrusive_ptr<when_each_frame> this_(this);
 
                 future_type& fut = hpx::get<I>(t_);
-
-                typename traits::detail::shared_state_ptr<
-                    future_result_type>::type next_future_data =
-                    traits::detail::get_shared_state(fut);
-
-                if (next_future_data.get() != nullptr &&
-                    !next_future_data->is_ready())
+                auto next_future_data = traits::detail::get_shared_state(fut);
+                if (next_future_data && !next_future_data->is_ready())
                 {
                     next_future_data->execute_deferred();
 
@@ -293,50 +303,32 @@ namespace hpx { namespace lcos {
                         // Attach a continuation to this future which will
                         // re-evaluate it and continue to the next argument
                         // (if any).
-                        hpx::intrusive_ptr<when_each_frame> this_(this);
                         next_future_data->set_on_completed(
                             [this_ = HPX_MOVE(this_)]() -> void {
-                                return this_->template await_next<I>(
-                                    std::true_type(), std::false_type());
+                                this_->template await_future<I>();
                             });
+
                         return;
                     }
                 }
 
-                dispatch::call(HPX_FORWARD(F, f_), count_++, HPX_MOVE(fut),
-                    typename is_invocable<F, std::size_t, future_type>::type());
-
-                if (count_ == needed_count_)
+                // call supplied callback with or without index
+                if constexpr (hpx::is_invocable_v<F, std::size_t, future_type>)
                 {
-                    do_await<I + 1>(std::true_type());
+                    f_(count_, HPX_MOVE(fut));
+                }
+                else
+                {
+                    f_(HPX_MOVE(fut));
+                }
+
+                if (++count_ == needed_count_)
+                {
+                    this->set_value(util::unused);
                     return;
                 }
 
-                do_await<I + 1>(is_end<I + 1>());
-            }
-
-            template <std::size_t I>
-            HPX_FORCEINLINE void do_await(std::false_type)
-            {
-                typedef
-                    typename util::decay_unwrap<typename hpx::tuple_element<I,
-                        Tuple>::type>::type future_type;
-
-                typedef util::any_of<traits::is_future<future_type>,
-                    traits::is_ref_wrapped_future<future_type>>
-                    is_future;
-
-                typedef util::any_of<traits::is_future_range<future_type>,
-                    traits::is_ref_wrapped_future_range<future_type>>
-                    is_range;
-
-                await_next<I>(is_future(), is_range());
-            }
-
-        public:
-            HPX_FORCEINLINE void do_await()
-            {
-                do_await<0>(is_end<0>());
+                do_await<I + 1>();
             }
 
         private:
@@ -345,56 +337,55 @@ namespace hpx { namespace lcos {
             std::size_t count_;
             std::size_t needed_count_;
         };
-    }    // namespace detail
+    }}    // namespace lcos::detail
 
     ///////////////////////////////////////////////////////////////////////////
-    template <typename F, typename Future>
+    template <typename F, typename Future,
+        typename Enable = std::enable_if_t<hpx::traits::is_future_v<Future>>>
     hpx::future<void> when_each(F&& func, std::vector<Future>& lazy_values)
     {
-        static_assert(
-            traits::is_future<Future>::value, "invalid use of when_each");
+        using argument_type = hpx::tuple<std::vector<Future>>;
+        using frame_type =
+            lcos::detail::when_each_frame<argument_type, std::decay_t<F>>;
 
-        typedef hpx::tuple<std::vector<Future>> argument_type;
-        typedef typename std::decay<F>::type func_type;
-        typedef detail::when_each_frame<argument_type, func_type> frame_type;
-
-        std::vector<Future> lazy_values_;
-        lazy_values_.reserve(lazy_values.size());
+        std::vector<Future> values;
+        values.reserve(lazy_values.size());
 
         std::transform(lazy_values.begin(), lazy_values.end(),
-            std::back_inserter(lazy_values_), traits::acquire_future_disp());
+            std::back_inserter(values), traits::acquire_future_disp());
 
-        std::size_t lazy_values_size = lazy_values_.size();
         hpx::intrusive_ptr<frame_type> p(
-            new frame_type(hpx::forward_as_tuple(HPX_MOVE(lazy_values_)),
-                HPX_FORWARD(F, func), lazy_values_size));
+            new frame_type(hpx::forward_as_tuple(HPX_MOVE(values)),
+                HPX_FORWARD(F, func), values.size()));
 
-        p->do_await();
+        p->template do_await<0>();
 
-        using traits::future_access;
-        return future_access<typename frame_type::type>::create(HPX_MOVE(p));
+        return hpx::traits::future_access<typename frame_type::type>::create(
+            HPX_MOVE(p));
     }
 
     template <typename F, typename Future>
     hpx::future<void>    //-V659
-    when_each(F&& f, std::vector<Future>&& lazy_values)
+    when_each(F&& f, std::vector<Future>&& values)
     {
-        return lcos::when_each(HPX_FORWARD(F, f), lazy_values);
+        return hpx::when_each(HPX_FORWARD(F, f), values);
     }
 
-    template <typename F, typename Iterator>
-    typename std::enable_if<!traits::is_future<Iterator>::value,
-        hpx::future<Iterator>>::type
-    when_each(F&& f, Iterator begin, Iterator end)
+    template <typename F, typename Iterator,
+        typename Enable =
+            std::enable_if_t<hpx::traits::is_iterator_v<Iterator>>>
+    hpx::future<Iterator> when_each(F&& f, Iterator begin, Iterator end)
     {
-        typedef typename lcos::detail::future_iterator_traits<Iterator>::type
-            future_type;
+        using future_type =
+            typename lcos::detail::future_iterator_traits<Iterator>::type;
 
-        std::vector<future_type> lazy_values_;
-        std::transform(begin, end, std::back_inserter(lazy_values_),
+        std::vector<future_type> values;
+        traits::detail::reserve_if_random_access_by_range(values, begin, end);
+
+        std::transform(begin, end, std::back_inserter(values),
             traits::acquire_future_disp());
 
-        return lcos::when_each(HPX_FORWARD(F, f), lazy_values_)
+        return hpx::when_each(HPX_FORWARD(F, f), values)
             .then(hpx::launch::sync,
                 [end = HPX_MOVE(end)](hpx::future<void> fut) -> Iterator {
                     fut.get();    // rethrow exceptions, if any
@@ -402,22 +393,26 @@ namespace hpx { namespace lcos {
                 });
     }
 
-    template <typename F, typename Iterator>
+    template <typename F, typename Iterator,
+        typename Enable =
+            std::enable_if_t<hpx::traits::is_iterator_v<Iterator>>>
     hpx::future<Iterator> when_each_n(F&& f, Iterator begin, std::size_t count)
     {
-        typedef typename lcos::detail::future_iterator_traits<Iterator>::type
-            future_type;
+        using future_type =
+            typename lcos::detail::future_iterator_traits<Iterator>::type;
 
-        std::vector<future_type> lazy_values_;
-        lazy_values_.reserve(count);
+        std::vector<future_type> values;
+        values.reserve(count);
 
         traits::acquire_future_disp func;
-        for (std::size_t i = 0; i != count; ++i)
-            lazy_values_.push_back(func(*begin++));
+        while (count-- != 0)
+        {
+            values.push_back(func(*begin++));
+        }
 
-        return lcos::when_each(HPX_FORWARD(F, f), lazy_values_)
+        return hpx::when_each(HPX_FORWARD(F, f), values)
             .then(hpx::launch::sync,
-                [begin = HPX_MOVE(begin)](hpx::future<void> fut) -> Iterator {
+                [begin = HPX_MOVE(begin)](hpx::future<void>&& fut) -> Iterator {
                     fut.get();    // rethrow exceptions, if any
                     return begin;
                 });
@@ -431,34 +426,47 @@ namespace hpx { namespace lcos {
 
     ///////////////////////////////////////////////////////////////////////////
     template <typename F, typename... Ts>
-    typename std::enable_if<
-        !traits::is_future<typename std::decay<F>::type>::value &&
-            util::all_of<traits::is_future<Ts>...>::value,
-        hpx::future<void>>::type
+    std::enable_if_t<!hpx::traits::is_future_v<std::decay_t<F>> &&
+            hpx::util::all_of_v<hpx::traits::is_future<Ts>...>,
+        hpx::future<void>>
     when_each(F&& f, Ts&&... ts)
     {
-        typedef hpx::tuple<typename traits::acquire_future<Ts>::type...>
-            argument_type;
-
-        typedef typename std::decay<F>::type func_type;
-        typedef detail::when_each_frame<argument_type, func_type> frame_type;
+        using argument_type = hpx::tuple<traits::acquire_future_t<Ts>...>;
+        using frame_type =
+            lcos::detail::when_each_frame<argument_type, std::decay_t<F>>;
 
         traits::acquire_future_disp func;
-        argument_type lazy_values(func(HPX_FORWARD(Ts, ts))...);
+        argument_type values(func(HPX_FORWARD(Ts, ts))...);
 
-        hpx::intrusive_ptr<frame_type> p(new frame_type(
-            HPX_MOVE(lazy_values), HPX_FORWARD(F, f), sizeof...(Ts)));
+        hpx::intrusive_ptr<frame_type> p(
+            new frame_type(HPX_MOVE(values), HPX_FORWARD(F, f), sizeof...(Ts)));
 
-        p->do_await();
+        p->template do_await<0>();
 
-        using traits::future_access;
-        return future_access<typename frame_type::type>::create(HPX_MOVE(p));
+        return hpx::traits::future_access<typename frame_type::type>::create(
+            HPX_MOVE(p));
     }
-}}    // namespace hpx::lcos
-
-namespace hpx {
-    using lcos::when_each;
-    using lcos::when_each_n;
 }    // namespace hpx
+
+namespace hpx::lcos {
+
+    template <typename F, typename... Ts>
+    HPX_DEPRECATED_V(
+        1, 8, "hpx::lcos::when_each is deprecated. Use hpx::when_each instead.")
+    auto when_each(F&& f, Ts&&... ts)
+    {
+        return hpx::when_each(HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...);
+    }
+
+    template <typename F, typename Iterator,
+        typename Enable =
+            std::enable_if_t<hpx::traits::is_iterator_v<Iterator>>>
+    HPX_DEPRECATED_V(1, 8,
+        "hpx::lcos::when_each_n is deprecated. Use hpx::when_each_n instead.")
+    hpx::future<Iterator> when_each_n(F&& f, Iterator begin, std::size_t count)
+    {
+        return hpx::when_each_n(HPX_FORWARD(F, f), begin, count);
+    }
+}    // namespace hpx::lcos
 
 #endif    // DOXYGEN

--- a/libs/core/async_combinators/include/hpx/async_combinators/when_some.hpp
+++ b/libs/core/async_combinators/include/hpx/async_combinators/when_some.hpp
@@ -1,23 +1,24 @@
-//  Copyright (c) 2007-2015 Hartmut Kaiser
+//  Copyright (c) 2007-2021 Hartmut Kaiser
 //  Copyright (c) 2013 Agustin Berge
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-/// \file lcos/when_some.hpp
+/// \file when_some.hpp
 
 #pragma once
 
 #if defined(DOXYGEN)
 namespace hpx {
+
     ///////////////////////////////////////////////////////////////////////////
     /// Result type for \a when_some, contains a sequence of futures and
     /// indices pointing to ready futures.
     template <typename Sequence>
     struct when_some_result
     {
-        /// List of indices of futures which became ready
+        /// List of indices of futures that have become ready
         std::vector<std::size_t> indices;
 
         /// The sequence of futures as passed to \a hpx::when_some
@@ -38,9 +39,6 @@ namespace hpx {
     /// \param last     [in] The iterator pointing to the last element of a
     ///                 sequence of \a future or \a shared_future objects for
     ///                 which \a when_all should wait.
-    /// \param ec       [in,out] this represents the error status on exit, if
-    ///                 this is pre-initialized to \a hpx#throws the function
-    ///                 will throw on error instead.
     ///
     /// \note The future returned by the function \a when_some becomes ready
     ///       when at least \a n argument futures have become ready.
@@ -61,11 +59,12 @@ namespace hpx {
     ///       order of the futures in the input collection.
     ///       The future returned by \a when_some will not throw an exception,
     ///       but the futures held in the output collection may.
+    ///
     template <typename InputIter,
         typename Container = vector<
             future<typename std::iterator_traits<InputIter>::value_type>>>
     future<when_some_result<Container>> when_some(
-        std::size_t n, Iterator first, Iterator last, error_code& ec = throws);
+        std::size_t n, Iterator first, Iterator last);
 
     /// The function \a when_some is an operator allowing to join on the result
     /// of all given futures. It AND-composes all future objects given and
@@ -78,9 +77,6 @@ namespace hpx {
     /// \param futures  [in] A container holding an arbitrary amount of \a future
     ///                 or \a shared_future objects for which \a when_some
     ///                 should wait.
-    /// \param ec       [in,out] this represents the error status on exit, if
-    ///                 this is pre-initialized to \a hpx#throws the function
-    ///                 will throw on error instead.
     ///
     /// \note The future returned by the function \a when_some becomes ready
     ///       when at least \a n argument futures have become ready.
@@ -99,47 +95,9 @@ namespace hpx {
     ///       order of the futures in the input collection.
     ///       The future returned by \a when_some will not throw an exception,
     ///       but the futures held in the output collection may.
+    ///
     template <typename Range>
-    future<when_some_result<Range>> when_some(
-        std::size_t n, Range&& futures, error_code& ec = throws);
-
-    /// The function \a when_some is an operator allowing to join on the result
-    /// of all given futures. It AND-composes all future objects given and
-    /// returns a new future object representing the same list of futures
-    /// after n of them finished executing.
-    ///
-    /// \param n        [in] The number of futures out of the arguments which
-    ///                 have to become ready in order for the returned future
-    ///                 to get ready.
-    /// \param ec       [in,out] this represents the error status on exit, if
-    ///                 this is pre-initialized to \a hpx#throws the function
-    ///                 will throw on error instead.
-    /// \param futures  [in] An arbitrary number of \a future or \a shared_future
-    ///                 objects, possibly holding different types for which
-    ///                 \a when_some should wait.
-    ///
-    /// \note The future returned by the function \a when_some becomes ready
-    ///       when at least \a n argument futures have become ready.
-    ///
-    /// \return   Returns a when_some_result holding the same list of futures
-    ///           as has been passed to when_some and an index pointing to a
-    ///           ready future..
-    ///           - future<when_some_result<tuple<future<T0>, future<T1>...>>>:
-    ///             If inputs are fixed in number and are of heterogeneous
-    ///             types. The inputs can be any arbitrary number of future
-    ///             objects.
-    ///           - future<when_some_result<tuple<>>> if \a when_some is
-    ///             called with zero arguments.
-    ///             The returned future will be initially ready.
-    ///
-    /// \note Each future and shared_future is waited upon and then copied into
-    ///       the collection of the output (returned) future, maintaining the
-    ///       order of the futures in the input collection.
-    ///       The future returned by \a when_some will not throw an exception,
-    ///       but the futures held in the output collection may.
-    template <typename... T>
-    future<when_some_result<tuple<future<T>...>>> when_some(
-        std::size_t n, error_code& ec, T&&... futures);
+    future<when_some_result<Range>> when_some(std::size_t n, Range&& futures);
 
     /// The function \a when_some is an operator allowing to join on the result
     /// of all given futures. It AND-composes all future objects given and
@@ -172,9 +130,10 @@ namespace hpx {
     ///       order of the futures in the input collection.
     ///       The future returned by \a when_some will not throw an exception,
     ///       but the futures held in the output collection may.
-    template <typename... T>
+    ///
+    template <typename... Ts>
     future<when_some_result<tuple<future<T>...>>> when_some(
-        std::size_t n, T&&... futures);
+        std::size_t n, Ts&&... futures);
 
     /// The function \a when_some_n is an operator allowing to join on the result
     /// of all given futures. It AND-composes all future objects given and
@@ -189,9 +148,6 @@ namespace hpx {
     ///                 which \a when_all should wait.
     /// \param count    [in] The number of elements in the sequence starting at
     ///                 \a first.
-    /// \param ec       [in,out] this represents the error status on exit, if
-    ///                 this is pre-initialized to \a hpx#throws the function
-    ///                 will throw on error instead.
     ///
     /// \note The future returned by the function \a when_some_n becomes ready
     ///       when at least \a n argument futures have become ready.
@@ -214,11 +170,12 @@ namespace hpx {
     ///       order of the futures in the input collection.
     ///       The future returned by \a when_some_n will not throw an exception,
     ///       but the futures held in the output collection may.
+    ///
     template <typename InputIter,
         typename Container = vector<
             future<typename std::iterator_traits<InputIter>::value_type>>>
-    future<when_some_result<Container>> when_some_n(std::size_t n,
-        Iterator first, std::size_t count, error_code& ec = throws);
+    future<when_some_result<Container>> when_some_n(
+        std::size_t n, Iterator first, std::size_t count);
 }    // namespace hpx
 
 #else    // DOXYGEN
@@ -250,59 +207,25 @@ namespace hpx {
 #include <vector>
 
 ///////////////////////////////////////////////////////////////////////////////
-namespace hpx { namespace lcos {
+namespace hpx {
+
     template <typename Sequence>
     struct when_some_result
     {
-        when_some_result()
-          : indices()
-          , futures()
-        {
-        }
+        when_some_result() = default;
 
-        explicit when_some_result(Sequence&& futures)
+        explicit when_some_result(Sequence&& futures) noexcept
           : indices()
           , futures(HPX_MOVE(futures))
         {
-        }
-
-        when_some_result(when_some_result const& rhs)
-          : indices(rhs.indices)
-          , futures(rhs.futures)
-        {
-        }
-
-        when_some_result(when_some_result&& rhs)
-          : indices(HPX_MOVE(rhs.indices))
-          , futures(HPX_MOVE(rhs.futures))
-        {
-        }
-
-        when_some_result& operator=(when_some_result const& rhs)
-        {
-            if (this != &rhs)
-            {
-                indices = rhs.indices;
-                futures = rhs.futures;
-            }
-            return *this;
-        }
-
-        when_some_result& operator=(when_some_result&& rhs)
-        {
-            if (this != &rhs)
-            {
-                indices = HPX_MOVE(rhs.indices);
-                futures = HPX_MOVE(rhs.futures);
-            }
-            return *this;
         }
 
         std::vector<std::size_t> indices;
         Sequence futures;
     };
 
-    namespace detail {
+    namespace lcos { namespace detail {
+
         ///////////////////////////////////////////////////////////////////////
         template <typename Sequence>
         struct when_some;
@@ -310,16 +233,16 @@ namespace hpx { namespace lcos {
         template <typename Sequence>
         struct set_when_some_callback_impl
         {
-            explicit set_when_some_callback_impl(when_some<Sequence>& when)
+            explicit set_when_some_callback_impl(
+                when_some<Sequence>& when) noexcept
               : when_(when)
               , idx_(0)
             {
             }
 
             template <typename Future>
-            void operator()(Future& future,
-                typename std::enable_if<
-                    traits::is_future<Future>::value>::type* = nullptr) const
+            std::enable_if_t<traits::is_future_v<Future>> operator()(
+                Future& future) const
             {
                 std::size_t counter =
                     when_.count_.load(std::memory_order_seq_cst);
@@ -329,14 +252,10 @@ namespace hpx { namespace lcos {
                     // yet also, do not touch any futures which are already
                     // ready
 
-                    typedef typename traits::detail::shared_state_ptr_for<
-                        Future>::type shared_state_ptr;
-
-                    shared_state_ptr const& shared_state =
+                    auto shared_state =
                         traits::detail::get_shared_state(future);
 
-                    if (shared_state.get() != nullptr &&
-                        !shared_state->is_ready())
+                    if (shared_state && !shared_state->is_ready())
                     {
                         shared_state->execute_deferred();
 
@@ -344,28 +263,35 @@ namespace hpx { namespace lcos {
                         if (!shared_state->is_ready())
                         {
                             shared_state->set_on_completed(util::deferred_call(
-                                &when_some<Sequence>::on_future_ready,
+                                &detail::when_some<Sequence>::on_future_ready,
                                 when_.shared_from_this(), idx_,
                                 hpx::execution_base::this_thread::agent()));
                             ++idx_;
+
                             return;
                         }
                     }
 
-                    when_.lazy_values_.indices.push_back(idx_);
+                    {
+                        using mutex_type =
+                            typename detail::when_some<Sequence>::mutex_type;
+                        std::lock_guard<mutex_type> l(when_.mtx_);
+                        when_.values_.indices.push_back(idx_);
+                    }
+
                     if (when_.count_.fetch_add(1) + 1 == when_.needed_count_)
                     {
-                        when_.goal_reached_on_calling_thread_ = true;
+                        when_.goal_reached_on_calling_thread_.store(
+                            true, std::memory_order_release);
                     }
                 }
                 ++idx_;
             }
 
             template <typename Sequence_>
-            HPX_FORCEINLINE void operator()(Sequence_& sequence,
-                typename std::enable_if<
-                    traits::is_future_range<Sequence_>::value>::type* =
-                    nullptr) const
+            HPX_FORCEINLINE
+                std::enable_if_t<traits::is_future_range_v<Sequence_>>
+                operator()(Sequence_& sequence) const
             {
                 apply(sequence);
             }
@@ -382,8 +308,7 @@ namespace hpx { namespace lcos {
             template <typename... Ts>
             HPX_FORCEINLINE void apply(hpx::tuple<Ts...>& sequence) const
             {
-                apply(sequence,
-                    typename util::make_index_pack<sizeof...(Ts)>::type());
+                apply(sequence, util::make_index_pack_t<sizeof...(Ts)>());
             }
 
             template <typename Sequence_>
@@ -392,23 +317,23 @@ namespace hpx { namespace lcos {
                 std::for_each(sequence.begin(), sequence.end(), *this);
             }
 
-            when_some<Sequence>& when_;
+            detail::when_some<Sequence>& when_;
             mutable std::size_t idx_;
         };
 
         template <typename Sequence>
         HPX_FORCEINLINE void set_on_completed_callback(
-            when_some<Sequence>& when)
+            detail::when_some<Sequence>& when)
         {
             set_when_some_callback_impl<Sequence> callback(when);
-            callback.apply(when.lazy_values_.futures);
+            callback.apply(when.values_.futures);
         }
 
         template <typename Sequence>
         struct when_some
           : std::enable_shared_from_this<when_some<Sequence>>    //-V690
         {
-            typedef lcos::local::spinlock mutex_type;
+            using mutex_type = lcos::local::spinlock;
 
         public:
             void on_future_ready(
@@ -419,8 +344,9 @@ namespace hpx { namespace lcos {
                 {
                     {
                         std::lock_guard<mutex_type> l(this->mtx_);
-                        lazy_values_.indices.push_back(idx);
+                        values_.indices.push_back(idx);
                     }
+
                     if (new_count == needed_count_)
                     {
                         if (ctx != hpx::execution_base::this_thread::agent())
@@ -429,22 +355,25 @@ namespace hpx { namespace lcos {
                         }
                         else
                         {
-                            goal_reached_on_calling_thread_ = true;
+                            goal_reached_on_calling_thread_.store(
+                                true, std::memory_order_release);
                         }
                     }
                 }
             }
 
         private:
-            // workaround gcc regression wrongly instantiating constructors
-            when_some();
-            when_some(when_some const&);
+            when_some(when_some const&) = delete;
+            when_some(when_some&&) = delete;
+
+            when_some& operator=(when_some const&) = delete;
+            when_some& operator=(when_some&&) = delete;
 
         public:
-            typedef Sequence argument_type;
+            using argument_type = Sequence;
 
-            when_some(argument_type&& lazy_values, std::size_t n)
-              : lazy_values_(HPX_MOVE(lazy_values))
+            when_some(argument_type&& values, std::size_t n)
+              : values_(HPX_MOVE(values))
               , count_(0)
               , needed_count_(n)
               , goal_reached_on_calling_thread_(false)
@@ -459,7 +388,8 @@ namespace hpx { namespace lcos {
                 // if all of the requested futures are already set, our
                 // callback above has already been called often enough, otherwise
                 // we suspend ourselves
-                if (!goal_reached_on_calling_thread_)
+                if (!goal_reached_on_calling_thread_.load(
+                        std::memory_order_acquire))
                 {
                     // wait for any of the futures to return to become ready
                     hpx::execution_base::this_thread::suspend(
@@ -468,109 +398,104 @@ namespace hpx { namespace lcos {
 
                 // at least N futures should be ready
                 HPX_ASSERT(
-                    count_.load(std::memory_order_seq_cst) >= needed_count_);
+                    count_.load(std::memory_order_acquire) >= needed_count_);
 
-                return HPX_MOVE(lazy_values_);
+                return HPX_MOVE(values_);
             }
 
             mutable mutex_type mtx_;
-            when_some_result<Sequence> lazy_values_;
+            when_some_result<Sequence> values_;
             std::atomic<std::size_t> count_;
             std::size_t needed_count_;
-            bool goal_reached_on_calling_thread_;
+            std::atomic<bool> goal_reached_on_calling_thread_;
         };
-    }    // namespace detail
+    }}    // namespace lcos::detail
 
     ///////////////////////////////////////////////////////////////////////////
     template <typename Range>
-    typename std::enable_if<traits::is_future_range<Range>::value,
-        hpx::future<when_some_result<typename std::decay<Range>::type>>>::type
-    when_some(std::size_t n, Range&& lazy_values, error_code& ec = throws)
+    std::enable_if_t<traits::is_future_range_v<Range>,
+        hpx::future<when_some_result<std::decay_t<Range>>>>
+    when_some(std::size_t n, Range&& lazy_values)
     {
-        typedef typename std::decay<Range>::type result_type;
-
-        result_type lazy_values_ =
-            traits::acquire_future<result_type>()(lazy_values);
+        using result_type = std::decay_t<Range>;
 
         if (n == 0)
         {
-            return hpx::make_ready_future(
-                when_some_result<result_type>(HPX_MOVE(lazy_values_)));
+            return hpx::make_ready_future(when_some_result<result_type>());
         }
 
-        if (n > lazy_values_.size())
+        result_type values = traits::acquire_future<result_type>()(lazy_values);
+
+        if (n > values.size())
         {
-            HPX_THROWS_IF(ec, hpx::bad_parameter, "hpx::lcos::when_some",
-                "number of results to wait for is out of bounds");
-            return hpx::make_ready_future(
-                when_some_result<result_type>(result_type()));
+            return hpx::make_exceptional_future<when_some_result<result_type>>(
+                HPX_GET_EXCEPTION(hpx::bad_parameter, "hpx::when_some",
+                    "number of results to wait for is out of bounds"));
         }
 
-        std::shared_ptr<detail::when_some<result_type>> f =
-            std::make_shared<detail::when_some<result_type>>(
-                HPX_MOVE(lazy_values_), n);
+        auto f = std::make_shared<lcos::detail::when_some<result_type>>(
+            HPX_MOVE(values), n);
 
         lcos::local::futures_factory<when_some_result<result_type>()> p(
             [f = HPX_MOVE(f)]() -> when_some_result<result_type> {
                 return (*f)();
             });
 
+        auto result = p.get_future();
         p.apply();
-        return p.get_future();
+
+        return result;
     }
 
     template <typename Iterator,
         typename Container = std::vector<
-            typename lcos::detail::future_iterator_traits<Iterator>::type>>
+            typename lcos::detail::future_iterator_traits<Iterator>::type>,
+        typename Enable =
+            std::enable_if_t<hpx::traits::is_iterator_v<Iterator>>>
     hpx::future<when_some_result<Container>> when_some(
-        std::size_t n, Iterator begin, Iterator end, error_code& ec = throws)
+        std::size_t n, Iterator begin, Iterator end)
     {
-        Container lazy_values_;
+        Container values;
+        traits::detail::reserve_if_random_access_by_range(values, begin, end);
 
-        typename std::iterator_traits<Iterator>::difference_type difference =
-            std::distance(begin, end);
-        if (difference > 0)
-            traits::detail::reserve_if_reservable(
-                lazy_values_, static_cast<std::size_t>(difference));
-
-        std::transform(begin, end, std::back_inserter(lazy_values_),
+        std::transform(begin, end, std::back_inserter(values),
             traits::acquire_future_disp());
 
-        return lcos::when_some(n, lazy_values_, ec);
+        return hpx::when_some(n, HPX_MOVE(values));
     }
 
     template <typename Iterator,
         typename Container = std::vector<
-            typename lcos::detail::future_iterator_traits<Iterator>::type>>
-    hpx::future<when_some_result<Container>> when_some_n(std::size_t n,
-        Iterator begin, std::size_t count, error_code& ec = throws)
+            typename lcos::detail::future_iterator_traits<Iterator>::type>,
+        typename Enable =
+            std::enable_if_t<hpx::traits::is_iterator_v<Iterator>>>
+    hpx::future<when_some_result<Container>> when_some_n(
+        std::size_t n, Iterator begin, std::size_t count)
     {
-        Container lazy_values_;
-        traits::detail::reserve_if_reservable(lazy_values_, count);
+        Container values;
+        traits::detail::reserve_if_reservable(values, count);
 
         traits::acquire_future_disp func;
         for (std::size_t i = 0; i != count; ++i)
-            lazy_values_.push_back(func(*begin++));
+        {
+            values.push_back(func(*begin++));
+        }
 
-        return lcos::when_some(n, lazy_values_, ec);
+        return hpx::when_some(n, HPX_MOVE(values));
     }
 
-    inline hpx::future<when_some_result<hpx::tuple<>>> when_some(
-        std::size_t n, error_code& ec = throws)
+    inline hpx::future<when_some_result<hpx::tuple<>>> when_some(std::size_t n)
     {
-        typedef hpx::tuple<> result_type;
-
-        result_type lazy_values;
+        using result_type = hpx::tuple<>;
 
         if (n == 0)
         {
-            return hpx::make_ready_future(
-                when_some_result<result_type>(HPX_MOVE(lazy_values)));
+            return hpx::make_ready_future(when_some_result<result_type>());
         }
 
-        HPX_THROWS_IF(ec, hpx::bad_parameter, "hpx::lcos::when_some",
-            "number of results to wait for is out of bounds");
-        return hpx::make_ready_future(when_some_result<result_type>());
+        return hpx::make_exceptional_future<when_some_result<result_type>>(
+            HPX_GET_EXCEPTION(hpx::bad_parameter, "hpx::when_some",
+                "number of results to wait for is out of bounds"));
     }
 
     ///////////////////////////////////////////////////////////////////////////
@@ -582,87 +507,113 @@ namespace hpx { namespace lcos {
                 typename traits::acquire_future<Ts>::type...>>>>::type
     when_some(std::size_t n, T&& t, Ts&&... ts)
     {
-        typedef hpx::tuple<typename traits::acquire_future<T>::type,
-            typename traits::acquire_future<Ts>::type...>
-            result_type;
-
-        traits::acquire_future_disp func;
-        result_type lazy_values(
-            func(HPX_FORWARD(T, t)), func(HPX_FORWARD(Ts, ts))...);
+        using result_type = hpx::tuple<traits::acquire_future_t<T>,
+            traits::acquire_future_t<Ts>...>;
 
         if (n == 0)
         {
-            return hpx::make_ready_future(
-                when_some_result<result_type>(HPX_MOVE(lazy_values)));
+            return hpx::make_ready_future(when_some_result<result_type>());
         }
 
         if (n > 1 + sizeof...(Ts))
         {
-            HPX_THROW_EXCEPTION(hpx::bad_parameter, "hpx::lcos::when_some",
-                "number of results to wait for is out of bounds");
-            return hpx::make_ready_future(when_some_result<result_type>());
+            return hpx::make_exceptional_future<when_some_result<result_type>>(
+                HPX_GET_EXCEPTION(hpx::bad_parameter, "hpx::when_some",
+                    "number of results to wait for is out of bounds"));
         }
 
-        std::shared_ptr<detail::when_some<result_type>> f =
-            std::make_shared<detail::when_some<result_type>>(
-                HPX_MOVE(lazy_values), n);
+        traits::acquire_future_disp func;
+        result_type values(
+            func(HPX_FORWARD(T, t)), func(HPX_FORWARD(Ts, ts))...);
+
+        auto f = std::make_shared<lcos::detail::when_some<result_type>>(
+            HPX_MOVE(values), n);
 
         lcos::local::futures_factory<when_some_result<result_type>()> p(
             [f = HPX_MOVE(f)]() -> when_some_result<result_type> {
                 return (*f)();
             });
 
+        auto result = p.get_future();
         p.apply();
-        return p.get_future();
+
+        return result;
+    }
+}    // namespace hpx
+
+namespace hpx::lcos {
+
+    template <typename Range>
+    HPX_DEPRECATED_V(
+        1, 8, "hpx::lcos::when_some is deprecated. Use hpx::when_some instead.")
+    std::enable_if_t<traits::is_future_range_v<Range>,
+        hpx::future<
+            when_some_result<std::decay_t<Range>>>> when_some(std::size_t n,
+        Range&& values, error_code& = throws)
+    {
+        return hpx::when_some(n, HPX_FORWARD(Range, values));
+    }
+
+    template <typename Iterator,
+        typename Container = std::vector<
+            typename lcos::detail::future_iterator_traits<Iterator>::type>,
+        typename Enable =
+            std::enable_if_t<hpx::traits::is_iterator_v<Iterator>>>
+    HPX_DEPRECATED_V(
+        1, 8, "hpx::lcos::when_some is deprecated. Use hpx::when_some instead.")
+    hpx::future<when_some_result<Container>> when_some(
+        std::size_t n, Iterator begin, Iterator end, error_code& = throws)
+    {
+        return hpx::when_some(n, begin, end);
+    }
+
+    template <typename Iterator,
+        typename Container = std::vector<
+            typename lcos::detail::future_iterator_traits<Iterator>::type>,
+        typename Enable =
+            std::enable_if_t<hpx::traits::is_iterator_v<Iterator>>>
+    HPX_DEPRECATED_V(1, 8,
+        "hpx::lcos::when_some_n is deprecated. Use hpx::when_some_n instead.")
+    hpx::future<when_some_result<Container>> when_some_n(
+        std::size_t n, Iterator begin, std::size_t count, error_code& = throws)
+    {
+        return hpx::when_some(n, begin, count);
+    }
+
+    HPX_DEPRECATED_V(
+        1, 8, "hpx::lcos::when_some is deprecated. Use hpx::when_some instead.")
+    inline hpx::future<when_some_result<hpx::tuple<>>> when_some(
+        std::size_t n, error_code& = throws)
+    {
+        return hpx::when_some(n);
     }
 
     template <typename T, typename... Ts>
-    typename std::enable_if<!(traits::is_future_range<T>::value &&
-                                sizeof...(Ts) == 0),
-        hpx::future<when_some_result<
-            hpx::tuple<typename traits::acquire_future<T>::type,
-                typename traits::acquire_future<Ts>::type...>>>>::type
-    when_some(std::size_t n, error_code& ec, T&& t, Ts&&... ts)
+    HPX_DEPRECATED_V(
+        1, 8, "hpx::lcos::when_some is deprecated. Use hpx::when_some instead.")
+    std::enable_if_t<!(traits::is_future_range_v<T> && sizeof...(Ts) == 0),
+        hpx::future<when_some_result<hpx::tuple<traits::acquire_future_t<T>,
+            traits::acquire_future_t<Ts>...>>>> when_some(std::size_t n, T&& t,
+        Ts&&... ts)
     {
-        typedef hpx::tuple<typename traits::acquire_future<T>::type,
-            typename traits::acquire_future<Ts>::type...>
-            result_type;
-
-        traits::acquire_future_disp func;
-        result_type lazy_values(
-            func(HPX_FORWARD(T, t)), func(HPX_FORWARD(Ts, ts))...);
-
-        if (n == 0)
-        {
-            return hpx::make_ready_future(
-                when_some_result<result_type>(HPX_MOVE(lazy_values)));
-        }
-
-        if (n > 1 + sizeof...(Ts))
-        {
-            HPX_THROWS_IF(ec, hpx::bad_parameter, "hpx::lcos::when_some",
-                "number of results to wait for is out of bounds");
-            return hpx::make_ready_future(when_some_result<result_type>());
-        }
-
-        std::shared_ptr<detail::when_some<result_type>> f =
-            std::make_shared<detail::when_some<result_type>>(
-                HPX_MOVE(lazy_values), n);
-
-        lcos::local::futures_factory<when_some_result<result_type>()> p(
-            [f = HPX_MOVE(f)]() -> when_some_result<result_type> {
-                return (*f)();
-            });
-
-        p.apply();
-        return p.get_future();
+        return hpx::when_some(n, HPX_FORWARD(T, t), HPX_FORWARD(Ts, ts)...);
     }
-}}    // namespace hpx::lcos
 
-namespace hpx {
-    using lcos::when_some;
-    using lcos::when_some_n;
-    using lcos::when_some_result;
-}    // namespace hpx
+    template <typename T, typename... Ts>
+    HPX_DEPRECATED_V(
+        1, 8, "hpx::lcos::when_some is deprecated. Use hpx::when_some instead.")
+    std::enable_if_t<!(traits::is_future_range_v<T> && sizeof...(Ts) == 0),
+        hpx::future<when_some_result<hpx::tuple<traits::acquire_future_t<T>,
+            traits::acquire_future_t<Ts>...>>>> when_some(std::size_t n,
+        error_code&, T&& t, Ts&&... ts)
+    {
+        return hpx::when_some(n, HPX_FORWARD(T, t), HPX_FORWARD(Ts, ts)...);
+    }
+
+    template <typename Container>
+    using when_some_result HPX_DEPRECATED_V(1, 8,
+        "hpx::lcos::when_some_result is deprecated. Use hpx::when_some_result "
+        "instead.") = hpx::when_some_result<Container>;
+}    // namespace hpx::lcos
 
 #endif    // DOXYGEN

--- a/libs/core/resource_partitioner/examples/async_customization.cpp
+++ b/libs/core/resource_partitioner/examples/async_customization.cpp
@@ -321,7 +321,7 @@ int test(const std::string& message, Executor& exec)
     auto fw1 = hpx::async(&dummy_task<decltype(testval2)>, testval2);
     auto fw2 = hpx::async(&dummy_task<decltype(testval3)>, testval3);
     //
-    auto fw = when_all(fw1, fw2).then(exec,
+    auto fw = hpx::when_all(fw1, fw2).then(exec,
         [testval2, testval3](
             future<hpx::tuple<future<int>, future<double>>>&& f) {
             std::cout << "Inside when_all : " << std::endl;
@@ -347,7 +347,7 @@ int test(const std::string& message, Executor& exec)
     auto fws2 = hpx::async(&dummy_task<decltype(testval5)>, testval5).share();
     //
     auto fws =
-        when_all(fws1, fws2)
+        hpx::when_all(fws1, fws2)
             .then(exec,
                 [testval4, testval5](future<hpx::tuple<future<std::uint64_t>,
                         shared_future<float>>>&& f) {

--- a/libs/core/resource_partitioner/tests/unit/named_pool_executor.cpp
+++ b/libs/core/resource_partitioner/tests/unit/named_pool_executor.cpp
@@ -108,7 +108,7 @@ int hpx_main()
         large_stack_executor, &dummy_task, 3, "true default + large stack"));
 
     // just wait until everything is done
-    when_all(lotsa_futures).get();
+    hpx::when_all(lotsa_futures).get();
 
     return hpx::local::finalize();
 }

--- a/libs/full/agas/src/addressing_service.cpp
+++ b/libs/full/agas/src/addressing_service.cpp
@@ -2119,7 +2119,7 @@ namespace hpx { namespace agas {
             send_refcnt_requests_async(l);
 
         // re throw possible errors
-        when_all(lazy_results).get();
+        hpx::when_all(lazy_results).get();
 
         if (&ec != &throws)
             ec = make_success_code();

--- a/tests/performance/network/network_storage/network_storage.cpp
+++ b/tests/performance/network/network_storage/network_storage.cpp
@@ -655,7 +655,8 @@ void test_write(
         DEBUG_ONLY(int numwait = static_cast<int>(final_list.size());)
 
         DEBUG_OUTPUT(1, "Waiting for when_all future on rank " << rank);
-        hpx::future<int> result = when_all(final_list).then(hpx::launch::sync, reduce);
+        hpx::future<int> result =
+            hpx::when_all(final_list).then(hpx::launch::sync, reduce);
         result.get();
 #ifdef USE_CLEANING_THREAD
         int total = numwait+removed;
@@ -869,7 +870,8 @@ void test_read(
         hpx::chrono::high_resolution_timer futuretimer;
 
         DEBUG_OUTPUT(1, "Waiting for whena_all future on rank " << rank);
-        hpx::future<int> result = when_all(final_list).then(hpx::launch::sync, reduce);
+        hpx::future<int> result =
+            hpx::when_all(final_list).then(hpx::launch::sync, reduce);
         result.get();
 #ifdef USE_CLEANING_THREAD
         int total = numwait+removed;


### PR DESCRIPTION
This also moves those facilities into `namespace hpx` and deprecates the same in `namespace hpx::lcos`