### PR TITLE
Fix `counting_iterator` container tests

### DIFF
--- a/libs/core/iterator_support/tests/unit/counting_iterator.cpp
+++ b/libs/core/iterator_support/tests/unit/counting_iterator.cpp
@@ -19,11 +19,15 @@
 #include <iostream>
 #include <iterator>
 #include <list>
+#include <random>
 #include <type_traits>
 #include <utility>
 #include <vector>
 
 #include "iterator_tests.hpp"
+
+int seed = std::random_device{}();
+std::mt19937 gen(seed);
 
 template <typename T>
 struct signed_assert_nonnegative
@@ -58,7 +62,8 @@ void category_test(CountingIterator start, CountingIterator finish, Value,
     difference_type distance = std::distance(start, finish);
 
     // Pick a random position internal to the range
-    difference_type offset = (unsigned) rand() % distance;
+    std::uniform_int_distribution<difference_type> dist(0, distance - 1);
+    difference_type offset = dist(gen);
 
     HPX_TEST(offset >= 0);
 
@@ -183,7 +188,8 @@ template <typename Container>
 void test_container(
     Container* = nullptr)    // default arg works around MSVC bug
 {
-    Container c(2 + (unsigned) rand() % 1673);
+    std::uniform_int_distribution<unsigned> dis(3, 1673);
+    Container c(dis(gen));
 
     typename Container::iterator const start = c.begin();
 
@@ -307,12 +313,12 @@ private:
 
 int hpx_main(hpx::program_options::variables_map& vm)
 {
-    unsigned int seed = (unsigned int) std::time(nullptr);
     if (vm.count("seed"))
+    {
         seed = vm["seed"].as<unsigned int>();
-
+        gen.seed(seed);
+    }
     std::cout << "using seed: " << seed << std::endl;
-    std::srand(seed);
 
     // Test the built-in integer types.
     test_integer<char>();

--- a/libs/core/iterator_support/tests/unit/iterator_tests.hpp
+++ b/libs/core/iterator_support/tests/unit/iterator_tests.hpp
@@ -11,6 +11,7 @@
 #pragma once
 
 #include <hpx/config.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/iterator_support/traits/is_iterator.hpp>
 #include <hpx/modules/testing.hpp>
 #include <hpx/type_support/always_void.hpp>
@@ -297,10 +298,11 @@ namespace tests {
         }
     }    // namespace detail
 
-    // Preconditions: [i,i+N) is a valid range
+    // Preconditions: [i,i+N) is a valid range, N >= 2
     template <typename Iterator, typename TrueVals>
     void random_access_iterator_test(Iterator i, int N, TrueVals vals)
     {
+        HPX_ASSERT(N >= 2);
         bidirectional_iterator_test(i, vals[0], vals[1]);
         Iterator const j = i;
         int c;


### PR DESCRIPTION
The random_access_iterator test requires at least two elements in the container. I've added an assertion to the test to make the precondition slightly more obvious. Fixes these types of failures: https://cdash.cscs.ch/testDetails.php?test=60179258&build=205784, i.e.
```
using seed: 1639331791
/dev/shm/hpx/src/libs/core/iterator_support/tests/unit/iterator_tests.hpp(106): test '*i1 == v2' failed in function 'void tests::input_iterator_test(Iterator, T, T) [Iterator = hpx::util::counting_iterator<std::__wrap_iter<int *>>, T = std::__wrap_iter<int *>]'
/dev/shm/hpx/src/libs/core/iterator_support/tests/unit/iterator_tests.hpp(107): test '*i == v2' failed in function 'void tests::input_iterator_test(Iterator, T, T) [Iterator = hpx::util::counting_iterator<std::__wrap_iter<int *>>, T = std::__wrap_iter<int *>]'
/dev/shm/hpx/src/libs/core/iterator_support/tests/unit/iterator_tests.hpp(66): test 'v == val' failed in function 'void tests::trivial_iterator_test(const Iterator, const Iterator, T) [Iterator = hpx::util::counting_iterator<std::__wrap_iter<int *>>, T = std::__wrap_iter<int *>]'
/dev/shm/hpx/src/libs/core/iterator_support/tests/unit/iterator_tests.hpp(72): test '*k == val' failed in function 'void tests::trivial_iterator_test(const Iterator, const Iterator, T) [Iterator = hpx::util::counting_iterator<std::__wrap_iter<int *>>, T = std::__wrap_iter<int *>]'
/dev/shm/hpx/src/libs/core/iterator_support/tests/unit/iterator_tests.hpp(66): test 'v == val' failed in function 'void tests::trivial_iterator_test(const Iterator, const Iterator, T) [Iterator = hpx::util::counting_iterator<std::__wrap_iter<int *>>, T = std::__wrap_iter<int *>]'
/dev/shm/hpx/src/libs/core/iterator_support/tests/unit/iterator_tests.hpp(72): test '*k == val' failed in function 'void tests::trivial_iterator_test(const Iterator, const Iterator, T) [Iterator = hpx::util::counting_iterator<std::__wrap_iter<int *>>, T = std::__wrap_iter<int *>]'
/dev/shm/hpx/src/libs/core/iterator_support/tests/unit/iterator_tests.hpp(66): test 'v == val' failed in function 'void tests::trivial_iterator_test(const Iterator, const Iterator, T) [Iterator = hpx::util::counting_iterator<std::__wrap_iter<int *>>, T = std::__wrap_iter<int *>]'
/dev/shm/hpx/src/libs/core/iterator_support/tests/unit/iterator_tests.hpp(72): test '*k == val' failed in function 'void tests::trivial_iterator_test(const Iterator, const Iterator, T) [Iterator = hpx::util::counting_iterator<std::__wrap_iter<int *>>, T = std::__wrap_iter<int *>]'
/dev/shm/hpx/src/libs/core/iterator_support/tests/unit/iterator_tests.hpp(66): test 'v == val' failed in function 'void tests::trivial_iterator_test(const Iterator, const Iterator, T) [Iterator = hpx::util::counting_iterator<std::__wrap_iter<int *>>, T = std::__wrap_iter<int *>]'
/dev/shm/hpx/src/libs/core/iterator_support/tests/unit/iterator_tests.hpp(72): test '*k == val' failed in function 'void tests::trivial_iterator_test(const Iterator, const Iterator, T) [Iterator = hpx::util::counting_iterator<std::__wrap_iter<int *>>, T = std::__wrap_iter<int *>]'
/dev/shm/hpx/src/libs/core/iterator_support/tests/unit/iterator_tests.hpp(106): test '*i1 == v2' failed in function 'void tests::input_iterator_test(Iterator, T, T) [Iterator = hpx::util::counting_iterator<std::__wrap_iter<const int *>>, T = std::__wrap_iter<const int *>]'
/dev/shm/hpx/src/libs/core/iterator_support/tests/unit/iterator_tests.hpp(107): test '*i == v2' failed in function 'void tests::input_iterator_test(Iterator, T, T) [Iterator = hpx::util::counting_iterator<std::__wrap_iter<const int *>>, T = std::__wrap_iter<const int *>]'
/dev/shm/hpx/src/libs/core/iterator_support/tests/unit/iterator_tests.hpp(66): test 'v == val' failed in function 'void tests::trivial_iterator_test(const Iterator, const Iterator, T) [Iterator = hpx::util::counting_iterator<std::__wrap_iter<const int *>>, T = std::__wrap_iter<const int *>]'
/dev/shm/hpx/src/libs/core/iterator_support/tests/unit/iterator_tests.hpp(72): test '*k == val' failed in function 'void tests::trivial_iterator_test(const Iterator, const Iterator, T) [Iterator = hpx::util::counting_iterator<std::__wrap_iter<const int *>>, T = std::__wrap_iter<const int *>]'
/dev/shm/hpx/src/libs/core/iterator_support/tests/unit/iterator_tests.hpp(66): test 'v == val' failed in function 'void tests::trivial_iterator_test(const Iterator, const Iterator, T) [Iterator = hpx::util::counting_iterator<std::__wrap_iter<const int *>>, T = std::__wrap_iter<const int *>]'
/dev/shm/hpx/src/libs/core/iterator_support/tests/unit/iterator_tests.hpp(72): test '*k == val' failed in function 'void tests::trivial_iterator_test(const Iterator, const Iterator, T) [Iterator = hpx::util::counting_iterator<std::__wrap_iter<const int *>>, T = std::__wrap_iter<const int *>]'
/dev/shm/hpx/src/libs/core/iterator_support/tests/unit/iterator_tests.hpp(66): test 'v == val' failed in function 'void tests::trivial_iterator_test(const Iterator, const Iterator, T) [Iterator = hpx::util::counting_iterator<std::__wrap_iter<const int *>>, T = std::__wrap_iter<const int *>]'
/dev/shm/hpx/src/libs/core/iterator_support/tests/unit/iterator_tests.hpp(72): test '*k == val' failed in function 'void tests::trivial_iterator_test(const Iterator, const Iterator, T) [Iterator = hpx::util::counting_iterator<std::__wrap_iter<const int *>>, T = std::__wrap_iter<const int *>]'
/dev/shm/hpx/src/libs/core/iterator_support/tests/unit/iterator_tests.hpp(66): test 'v == val' failed in function 'void tests::trivial_iterator_test(const Iterator, const Iterator, T) [Iterator = hpx::util::counting_iterator<std::__wrap_iter<const int *>>, T = std::__wrap_iter<const int *>]'
/dev/shm/hpx/src/libs/core/iterator_support/tests/unit/iterator_tests.hpp(72): test '*k == val' failed in function 'void tests::trivial_iterator_test(const Iterator, const Iterator, T) [Iterator = hpx::util::counting_iterator<std::__wrap_iter<const int *>>, T = std::__wrap_iter<const int *>]'
0 sanity checks and 20 tests failed.
Base command is "/dev/shm/hpx/build/bin/counting_iterator_test --hpx:bind=none --hpx:threads=1"
Executing command: /dev/shm/hpx/build/bin/counting_iterator_test --hpx:bind=none --hpx:threads=1
```