### PR TITLE
Use `/dev/shm` for Jenkins checkout on Piz Daint

### DIFF
--- a/.jenkins/cscs/Jenkinsfile
+++ b/.jenkins/cscs/Jenkinsfile
@@ -23,13 +23,14 @@ pipeline {
         )
     }
     environment {
+        CHECKOUT_DIR = "/dev/shm/${env.BUILD_TAG}/hpx"
         SPACK_ROOT = '/apps/daint/SSL/HPX/spack'
         GITHUB_TOKEN = credentials('STELLARBOT_GITHUB_TOKEN')
     }
     stages {
         stage('checkout') {
             steps {
-                dir('hpx') {
+                dir("${CHECKOUT_DIR}") {
                     checkout scm
                     echo "Running ${env.BUILD_ID} on ${env.JENKINS_URL}"
                 }
@@ -40,17 +41,17 @@ pipeline {
                 axes {
                     axis {
                         name 'configuration_name'
-                        values 'gcc-11', 'gcc-10', 'gcc-7', 'gcc-cuda', 'clang-13', 'clang-12', 'clang-10', 'clang-9', 'clang-8', 'clang-7', 'clang-cuda', 'clang-apex'
+                        values 'gcc-11', 'gcc-10' //, 'gcc-7', 'gcc-cuda', 'clang-13', 'clang-12', 'clang-10', 'clang-9', 'clang-8', 'clang-7', 'clang-cuda', 'clang-apex'
                     }
                     axis {
                          name 'build_type'
-                         values 'Release', 'Debug'
+                         values 'Release' //, 'Debug'
                     }
                 }
                 stages {
                     stage('build') {
                         steps {
-                            dir('hpx') {
+                            dir("${CHECKOUT_DIR}") {
                                 sh '''
                                 #!/bin/bash -l
                                 .jenkins/cscs/entry.sh
@@ -65,8 +66,12 @@ pipeline {
 
     post {
         always {
-            archiveArtifacts artifacts: 'hpx/jenkins-hpx-*', fingerprint: true
-            archiveArtifacts artifacts: 'hpx/*-Testing/**', fingerprint: true
+            archiveArtifacts artifacts: '${CHECKOUT_DIR}/jenkins-hpx-*', fingerprint: true
+            archiveArtifacts artifacts: '${CHECKOUT_DIR}/*-Testing/**', fingerprint: true
+            sh '''
+            #!/bin/sh
+            rm -rfv ${CHECKOUT_DIR}
+            '''
         }
     }
 }

--- a/.jenkins/cscs/Jenkinsfile
+++ b/.jenkins/cscs/Jenkinsfile
@@ -54,6 +54,8 @@ pipeline {
                             dir("${CHECKOUT_DIR}") {
                                 sh '''
                                 #!/bin/bash -l
+                                echo ${CHECKOUT_DIR}
+                                pwd
                                 .jenkins/cscs/entry.sh
                                 '''
                             }

--- a/.jenkins/cscs/batch.sh
+++ b/.jenkins/cscs/batch.sh
@@ -20,42 +20,42 @@ cp -r "${orig_src_dir}" "${src_dir}"
 source ${src_dir}/.jenkins/cscs/env-common.sh
 source ${src_dir}/.jenkins/cscs/env-${configuration_name}.sh
 
-set +e
-ctest \
-    --verbose \
-    -S ${src_dir}/.jenkins/cscs/ctest.cmake \
-    -DCTEST_CONFIGURE_EXTRA_OPTIONS="${configure_extra_options} -DCMAKE_INSTALL_PREFIX=${install_dir}" \
-    -DCTEST_BUILD_CONFIGURATION_NAME="${configuration_name_with_build_type}" \
-    -DCTEST_SOURCE_DIRECTORY="${src_dir}" \
-    -DCTEST_BINARY_DIRECTORY="${build_dir}"
-set -e
+# set +e
+# ctest \
+#     --verbose \
+#     -S ${src_dir}/.jenkins/cscs/ctest.cmake \
+#     -DCTEST_CONFIGURE_EXTRA_OPTIONS="${configure_extra_options} -DCMAKE_INSTALL_PREFIX=${install_dir}" \
+#     -DCTEST_BUILD_CONFIGURATION_NAME="${configuration_name_with_build_type}" \
+#     -DCTEST_SOURCE_DIRECTORY="${src_dir}" \
+#     -DCTEST_BINARY_DIRECTORY="${build_dir}"
+# set -e
 
-# Copy the testing directory for saving as an artifact
-cp -r ${build_dir}/Testing ${orig_src_dir}/${configuration_name_with_build_type}-Testing
+# # Copy the testing directory for saving as an artifact
+# cp -r ${build_dir}/Testing ${orig_src_dir}/${configuration_name_with_build_type}-Testing
 
-# Things went wrong by default
-ctest_exit_code=$?
-file_errors=1
-configure_errors=1
-build_errors=1
-test_errors=1
-if [[ -f ${build_dir}/Testing/TAG ]]; then
-    file_errors=0
-    tag="$(head -n 1 ${build_dir}/Testing/TAG)"
+# # Things went wrong by default
+# ctest_exit_code=$?
+# file_errors=1
+# configure_errors=1
+# build_errors=1
+# test_errors=1
+# if [[ -f ${build_dir}/Testing/TAG ]]; then
+#     file_errors=0
+#     tag="$(head -n 1 ${build_dir}/Testing/TAG)"
 
-    if [[ -f "${build_dir}/Testing/${tag}/Configure.xml" ]]; then
-        configure_errors=$(grep '<Error>' "${build_dir}/Testing/${tag}/Configure.xml" | wc -l)
-    fi
+#     if [[ -f "${build_dir}/Testing/${tag}/Configure.xml" ]]; then
+#         configure_errors=$(grep '<Error>' "${build_dir}/Testing/${tag}/Configure.xml" | wc -l)
+#     fi
 
-    if [[ -f "${build_dir}/Testing/${tag}/Build.xml" ]]; then
-        build_errors=$(grep '<Error>' "${build_dir}/Testing/${tag}/Build.xml" | wc -l)
-    fi
+#     if [[ -f "${build_dir}/Testing/${tag}/Build.xml" ]]; then
+#         build_errors=$(grep '<Error>' "${build_dir}/Testing/${tag}/Build.xml" | wc -l)
+#     fi
 
-    if [[ -f "${build_dir}/Testing/${tag}/Test.xml" ]]; then
-        test_errors=$(grep '<Test Status=\"failed\">' "${build_dir}/Testing/${tag}/Test.xml" | wc -l)
-    fi
-fi
-ctest_status=$(( ctest_exit_code + file_errors + configure_errors + build_errors + test_errors ))
+#     if [[ -f "${build_dir}/Testing/${tag}/Test.xml" ]]; then
+#         test_errors=$(grep '<Test Status=\"failed\">' "${build_dir}/Testing/${tag}/Test.xml" | wc -l)
+#     fi
+# fi
+# ctest_status=$(( ctest_exit_code + file_errors + configure_errors + build_errors + test_errors ))
 
-echo "${ctest_status}" > "jenkins-hpx-${configuration_name_with_build_type}-ctest-status.txt"
-exit $ctest_status
+# echo "${ctest_status}" > "jenkins-hpx-${configuration_name_with_build_type}-ctest-status.txt"
+# exit $ctest_status

--- a/.jenkins/cscs/entry.sh
+++ b/.jenkins/cscs/entry.sh
@@ -31,6 +31,7 @@ fi
 # Start the actual build
 set +e
 sbatch \
+    -vvv \
     --job-name="${job_name}" \
     --nodes="1" \
     --constraint="${configuration_slurm_constraint}" \
@@ -40,6 +41,7 @@ sbatch \
     --output="jenkins-hpx-${configuration_name_with_build_type}.out" \
     --error="jenkins-hpx-${configuration_name_with_build_type}.err" \
     --wait .jenkins/cscs/batch.sh
+echo $?
 
 # Print slurm logs
 echo "= stdout =================================================="


### PR DESCRIPTION
Apparently we're taxing the filesystem too heavily. I will try some workarounds here. This might need a few iterations...