### PR TITLE
Avoid duplicate definition error

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -598,15 +598,6 @@ if(HPX_WITH_NETWORKING)
   endif()
 endif(HPX_WITH_NETWORKING)
 
-if((HPX_WITH_NETWORKING AND HPX_WITH_PARCELPORT_MPI) OR HPXLocal_WITH_ASYNC_MPI)
-  if(MSVC)
-    # FIXME: add OpenMPI specific flag here for now as the
-    # hpx_add_compile_flag() below does not add the extra options to the top
-    # level directory
-    hpx_add_config_define(OMPI_IMPORTS)
-  endif()
-endif()
-
 # External libraries/frameworks used by sme of the examples and benchmarks
 hpx_option(
   HPX_WITH_EXAMPLES_HDF5 BOOL

--- a/cmake/HPX_SetupHPXLocal.cmake
+++ b/cmake/HPX_SetupHPXLocal.cmake
@@ -188,7 +188,10 @@ elseif(NOT TARGET HPX::hpx_local AND NOT HPX_FIND_PACKAGE)
   if(MSVC AND NOT DEFINED HPXLocal_WITH_BINARY_DIR)
     set(HPXLocal_WITH_BINARY_DIR
         "${PROJECT_BINARY_DIR}"
-        CACHE STRING "Binary directory for local should be the same as for full library" FORCE
+        CACHE
+          STRING
+          "Binary directory for local should be the same as for full library"
+          FORCE
     )
   endif()
 


### PR DESCRIPTION
`OMPI_IMPORTS` is already defined in hpx-local if ASYNC_MPI is enabled