### PR TITLE
Removing superfluous semicolons

### DIFF
--- a/components/component_storage/include/hpx/components/component_storage/server/component_storage.hpp
+++ b/components/component_storage/include/hpx/components/component_storage/server/component_storage.hpp
@@ -39,9 +39,9 @@ namespace hpx { namespace components { namespace server
         std::vector<char> migrate_from_here(naming::gid_type const&);
         std::size_t size() const { return data_.size(); }
 
-        HPX_DEFINE_COMPONENT_ACTION(component_storage, migrate_to_here);
-        HPX_DEFINE_COMPONENT_ACTION(component_storage, migrate_from_here);
-        HPX_DEFINE_COMPONENT_ACTION(component_storage, size);
+        HPX_DEFINE_COMPONENT_ACTION(component_storage, migrate_to_here)
+        HPX_DEFINE_COMPONENT_ACTION(component_storage, migrate_from_here)
+        HPX_DEFINE_COMPONENT_ACTION(component_storage, size)
 
     private:
         hpx::unordered_map<naming::gid_type, std::vector<char> > data_;

--- a/components/containers/partitioned_vector/include/hpx/components/containers/partitioned_vector/partitioned_vector_component_decl.hpp
+++ b/components/containers/partitioned_vector/include/hpx/components/containers/partitioned_vector/partitioned_vector_component_decl.hpp
@@ -249,31 +249,31 @@ namespace hpx { namespace server {
         void clear();
 
         /// Macros to define HPX component actions for all exported functions.
-        HPX_DEFINE_COMPONENT_DIRECT_ACTION(partitioned_vector, size);
+        HPX_DEFINE_COMPONENT_DIRECT_ACTION(partitioned_vector, size)
 
-        // HPX_DEFINE_COMPONENT_DIRECT_ACTION(partitioned_vector_partition, max_size);
+        // HPX_DEFINE_COMPONENT_DIRECT_ACTION(partitioned_vector_partition, max_size)
 
-        HPX_DEFINE_COMPONENT_DIRECT_ACTION(partitioned_vector, resize);
+        HPX_DEFINE_COMPONENT_DIRECT_ACTION(partitioned_vector, resize)
 
-        // HPX_DEFINE_COMPONENT_DIRECT_ACTION(partitioned_vector_partition, capacity);
-        // HPX_DEFINE_COMPONENT_DIRECT_ACTION(partitioned_vector_partition, empty);
-        // HPX_DEFINE_COMPONENT_ACTION(partitioned_vector_partition, reserve);
+        // HPX_DEFINE_COMPONENT_DIRECT_ACTION(partitioned_vector_partition, capacity)
+        // HPX_DEFINE_COMPONENT_DIRECT_ACTION(partitioned_vector_partition, empty)
+        // HPX_DEFINE_COMPONENT_ACTION(partitioned_vector_partition, reserve)
 
-        HPX_DEFINE_COMPONENT_DIRECT_ACTION(partitioned_vector, get_value);
-        HPX_DEFINE_COMPONENT_DIRECT_ACTION(partitioned_vector, get_values);
+        HPX_DEFINE_COMPONENT_DIRECT_ACTION(partitioned_vector, get_value)
+        HPX_DEFINE_COMPONENT_DIRECT_ACTION(partitioned_vector, get_values)
 
-        // HPX_DEFINE_COMPONENT_DIRECT_ACTION(partitioned_vector_partition, front);
-        // HPX_DEFINE_COMPONENT_DIRECT_ACTION(partitioned_vector_partition, back);
-        // HPX_DEFINE_COMPONENT_ACTION(partitioned_vector_partition, assign);
-        // HPX_DEFINE_COMPONENT_DIRECT_ACTION(partitioned_vector_partition, push_back);
-        // HPX_DEFINE_COMPONENT_DIRECT_ACTION(partitioned_vector_partition, pop_back);
+        // HPX_DEFINE_COMPONENT_DIRECT_ACTION(partitioned_vector_partition, front)
+        // HPX_DEFINE_COMPONENT_DIRECT_ACTION(partitioned_vector_partition, back)
+        // HPX_DEFINE_COMPONENT_ACTION(partitioned_vector_partition, assign)
+        // HPX_DEFINE_COMPONENT_DIRECT_ACTION(partitioned_vector_partition, push_back)
+        // HPX_DEFINE_COMPONENT_DIRECT_ACTION(partitioned_vector_partition, pop_back)
 
-        HPX_DEFINE_COMPONENT_DIRECT_ACTION(partitioned_vector, set_value);
-        HPX_DEFINE_COMPONENT_DIRECT_ACTION(partitioned_vector, set_values);
+        HPX_DEFINE_COMPONENT_DIRECT_ACTION(partitioned_vector, set_value)
+        HPX_DEFINE_COMPONENT_DIRECT_ACTION(partitioned_vector, set_values)
 
-        // HPX_DEFINE_COMPONENT_ACTION(partitioned_vector_partition, clear);
-        HPX_DEFINE_COMPONENT_DIRECT_ACTION(partitioned_vector, get_copied_data);
-        HPX_DEFINE_COMPONENT_DIRECT_ACTION(partitioned_vector, set_data);
+        // HPX_DEFINE_COMPONENT_ACTION(partitioned_vector_partition, clear)
+        HPX_DEFINE_COMPONENT_DIRECT_ACTION(partitioned_vector, get_copied_data)
+        HPX_DEFINE_COMPONENT_DIRECT_ACTION(partitioned_vector, set_data)
     };
 }}    // namespace hpx::server
 

--- a/components/containers/unordered/include/hpx/components/containers/unordered/partition_unordered_map_component.hpp
+++ b/components/containers/unordered/include/hpx/components/containers/unordered/partition_unordered_map_component.hpp
@@ -315,20 +315,20 @@ namespace hpx { namespace server {
         }
 
         /// Macros to define HPX component actions for all exported functions.
-        HPX_DEFINE_COMPONENT_DIRECT_ACTION(partition_unordered_map, size);
+        HPX_DEFINE_COMPONENT_DIRECT_ACTION(partition_unordered_map, size)
 
-        HPX_DEFINE_COMPONENT_DIRECT_ACTION(partition_unordered_map, get_value);
-        HPX_DEFINE_COMPONENT_DIRECT_ACTION(partition_unordered_map, get_values);
+        HPX_DEFINE_COMPONENT_DIRECT_ACTION(partition_unordered_map, get_value)
+        HPX_DEFINE_COMPONENT_DIRECT_ACTION(partition_unordered_map, get_values)
 
-        HPX_DEFINE_COMPONENT_DIRECT_ACTION(partition_unordered_map, set_value);
-        HPX_DEFINE_COMPONENT_DIRECT_ACTION(partition_unordered_map, set_values);
+        HPX_DEFINE_COMPONENT_DIRECT_ACTION(partition_unordered_map, set_value)
+        HPX_DEFINE_COMPONENT_DIRECT_ACTION(partition_unordered_map, set_values)
 
-        HPX_DEFINE_COMPONENT_DIRECT_ACTION(partition_unordered_map, erase);
+        HPX_DEFINE_COMPONENT_DIRECT_ACTION(partition_unordered_map, erase)
 
         HPX_DEFINE_COMPONENT_DIRECT_ACTION(
-            partition_unordered_map, get_copied_data);
+            partition_unordered_map, get_copied_data)
         HPX_DEFINE_COMPONENT_DIRECT_ACTION(
-            partition_unordered_map, set_copied_data);
+            partition_unordered_map, set_copied_data)
     };
 }}    // namespace hpx::server
 

--- a/components/iostreams/include/hpx/components/iostreams/server/output_stream.hpp
+++ b/components/iostreams/include/hpx/components/iostreams/server/output_stream.hpp
@@ -71,8 +71,8 @@ namespace hpx { namespace iostreams { namespace server
         void write_sync(std::uint32_t locality_id,
             std::uint64_t count, detail::buffer const& in);
 
-        HPX_DEFINE_COMPONENT_ACTION(output_stream, write_async);
-        HPX_DEFINE_COMPONENT_ACTION(output_stream, write_sync);
+        HPX_DEFINE_COMPONENT_ACTION(output_stream, write_async)
+        HPX_DEFINE_COMPONENT_ACTION(output_stream, write_sync)
     };
 }}}
 

--- a/components/iostreams/tests/regressions/lost_output_2236.cpp
+++ b/components/iostreams/tests/regressions/lost_output_2236.cpp
@@ -102,7 +102,7 @@ namespace gc {
             collector_data* cd;
 
             std::vector<hpx::id_type> outgoing();
-            HPX_DEFINE_COMPONENT_ACTION(collectable, outgoing);
+            HPX_DEFINE_COMPONENT_ACTION(collectable, outgoing)
 
             // Assume a root is pointing to the object
             collectable()
@@ -135,7 +135,7 @@ namespace gc {
                 }
                 return n;
             }
-            HPX_DEFINE_COMPONENT_ACTION(collectable, add_ref);
+            HPX_DEFINE_COMPONENT_ACTION(collectable, add_ref)
 
             void set_ref(unsigned int index, hpx::naming::id_type id)
             {
@@ -148,30 +148,30 @@ namespace gc {
                 if (id != hpx::naming::invalid_id)
                     incref_(weight, id);
             }
-            HPX_DEFINE_COMPONENT_ACTION(collectable, set_ref);
+            HPX_DEFINE_COMPONENT_ACTION(collectable, set_ref)
 
             void phantomize_ref(
                 unsigned int weight, hpx::id_type parent, hpx::id_type cid);
-            HPX_DEFINE_COMPONENT_ACTION(collectable, phantomize_ref);
+            HPX_DEFINE_COMPONENT_ACTION(collectable, phantomize_ref)
             void incref(unsigned int weight);
-            HPX_DEFINE_COMPONENT_ACTION(collectable, incref);
+            HPX_DEFINE_COMPONENT_ACTION(collectable, incref)
             void incref_(unsigned int weight, hpx::naming::id_type id);
             void decref(unsigned int weight);
-            HPX_DEFINE_COMPONENT_ACTION(collectable, decref);
+            HPX_DEFINE_COMPONENT_ACTION(collectable, decref)
             void decref_(unsigned int weight, hpx::naming::id_type id);
 
             void phantom_wait_complete();
 
             void done(hpx::id_type child);
-            HPX_DEFINE_COMPONENT_ACTION(collectable, done);
+            HPX_DEFINE_COMPONENT_ACTION(collectable, done)
 
             void recover(hpx::id_type cid);
-            HPX_DEFINE_COMPONENT_ACTION(collectable, recover);
+            HPX_DEFINE_COMPONENT_ACTION(collectable, recover)
 
             void spread(unsigned int weight);
 
             void recover_done();
-            HPX_DEFINE_COMPONENT_ACTION(collectable, recover_done);
+            HPX_DEFINE_COMPONENT_ACTION(collectable, recover_done)
 
             void check_recover_done();
 

--- a/components/process/include/hpx/components/process/server/child.hpp
+++ b/components/process/include/hpx/components/process/server/child.hpp
@@ -34,8 +34,8 @@ namespace hpx { namespace components { namespace process { namespace server {
         void terminate();
         int wait_for_exit();
 
-        HPX_DEFINE_COMPONENT_ACTION(child, terminate);
-        HPX_DEFINE_COMPONENT_ACTION(child, wait_for_exit);
+        HPX_DEFINE_COMPONENT_ACTION(child, terminate)
+        HPX_DEFINE_COMPONENT_ACTION(child, wait_for_exit)
 
     private:
         process::util::child child_;

--- a/examples/1d_stencil/1d_stencil_5.cpp
+++ b/examples/1d_stencil/1d_stencil_5.cpp
@@ -143,7 +143,7 @@ struct partition_server
     // wrapped into a component action. The macro below defines a new type
     // 'get_data_action' which represents the (possibly remote) member function
     // partition::get_data().
-    HPX_DEFINE_COMPONENT_DIRECT_ACTION(partition_server, get_data, get_data_action);
+    HPX_DEFINE_COMPONENT_DIRECT_ACTION(partition_server, get_data, get_data_action)
 
 private:
     partition_data data_;

--- a/examples/1d_stencil/1d_stencil_6.cpp
+++ b/examples/1d_stencil/1d_stencil_6.cpp
@@ -187,7 +187,7 @@ struct partition_server
     // wrapped into a component action. The macro below defines a new type
     // 'get_data_action' which represents the (possibly remote) member function
     // partition::get_data().
-    HPX_DEFINE_COMPONENT_DIRECT_ACTION(partition_server, get_data, get_data_action);
+    HPX_DEFINE_COMPONENT_DIRECT_ACTION(partition_server, get_data, get_data_action)
 
 private:
     partition_data data_;

--- a/examples/1d_stencil/1d_stencil_7.cpp
+++ b/examples/1d_stencil/1d_stencil_7.cpp
@@ -187,7 +187,7 @@ struct partition_server
     // wrapped into a component action. The macro below defines a new type
     // 'get_data_action' which represents the (possibly remote) member function
     // partition::get_data().
-    HPX_DEFINE_COMPONENT_DIRECT_ACTION(partition_server, get_data, get_data_action);
+    HPX_DEFINE_COMPONENT_DIRECT_ACTION(partition_server, get_data, get_data_action)
 
 private:
     partition_data data_;

--- a/examples/1d_stencil/1d_stencil_8.cpp
+++ b/examples/1d_stencil/1d_stencil_8.cpp
@@ -286,7 +286,7 @@ struct partition_server : hpx::components::component_base<partition_server>
     // 'get_data_action' which represents the (possibly remote) member function
     // partition::get_data().
     HPX_DEFINE_COMPONENT_DIRECT_ACTION(
-        partition_server, get_data, get_data_action);
+        partition_server, get_data, get_data_action)
 
 private:
     partition_data data_;
@@ -374,7 +374,7 @@ struct stepper_server : hpx::components::component_base<stepper_server>
     space do_work(
         std::size_t local_np, std::size_t nx, std::size_t nt, std::uint64_t nd);
 
-    HPX_DEFINE_COMPONENT_ACTION(stepper_server, do_work, do_work_action);
+    HPX_DEFINE_COMPONENT_ACTION(stepper_server, do_work, do_work_action)
 
     // receive the left-most partition from the right
     void from_right(std::size_t t, partition p)
@@ -388,8 +388,8 @@ struct stepper_server : hpx::components::component_base<stepper_server>
         left_receive_buffer_.store_received(t, std::move(p));
     }
 
-    HPX_DEFINE_COMPONENT_ACTION(stepper_server, from_right, from_right_action);
-    HPX_DEFINE_COMPONENT_ACTION(stepper_server, from_left, from_left_action);
+    HPX_DEFINE_COMPONENT_ACTION(stepper_server, from_right, from_right_action)
+    HPX_DEFINE_COMPONENT_ACTION(stepper_server, from_left, from_left_action)
 
     // release dependencies
     void release_dependencies()
@@ -399,7 +399,7 @@ struct stepper_server : hpx::components::component_base<stepper_server>
     }
 
     HPX_DEFINE_COMPONENT_ACTION(
-        stepper_server, release_dependencies, release_dependencies_action);
+        stepper_server, release_dependencies, release_dependencies_action)
 
 protected:
     // Our operator

--- a/examples/accumulators/server/accumulator.hpp
+++ b/examples/accumulators/server/accumulator.hpp
@@ -87,9 +87,9 @@ namespace examples { namespace server
         // action type, generating all required boilerplate code for threads,
         // serialization, etc.
         //[accumulator_action_types
-        HPX_DEFINE_COMPONENT_ACTION(accumulator, reset);
-        HPX_DEFINE_COMPONENT_ACTION(accumulator, add);
-        HPX_DEFINE_COMPONENT_ACTION(accumulator, query);
+        HPX_DEFINE_COMPONENT_ACTION(accumulator, reset)
+        HPX_DEFINE_COMPONENT_ACTION(accumulator, add)
+        HPX_DEFINE_COMPONENT_ACTION(accumulator, query)
         //]
 
     private:

--- a/examples/accumulators/server/template_accumulator.hpp
+++ b/examples/accumulators/server/template_accumulator.hpp
@@ -80,9 +80,9 @@ namespace examples { namespace server
         // Each of the exposed functions needs to be encapsulated into an
         // action type, generating all required boilerplate code for threads,
         // serialization, etc.
-        HPX_DEFINE_COMPONENT_ACTION(template_accumulator, reset);
-        HPX_DEFINE_COMPONENT_ACTION(template_accumulator, add);
-        HPX_DEFINE_COMPONENT_ACTION(template_accumulator, query);
+        HPX_DEFINE_COMPONENT_ACTION(template_accumulator, reset)
+        HPX_DEFINE_COMPONENT_ACTION(template_accumulator, add)
+        HPX_DEFINE_COMPONENT_ACTION(template_accumulator, query)
 
     private:
         argument_type value_;

--- a/examples/accumulators/server/template_function_accumulator.hpp
+++ b/examples/accumulators/server/template_function_accumulator.hpp
@@ -79,8 +79,8 @@ namespace examples { namespace server
         // action type, generating all required boilerplate code for threads,
         // serialization, etc.
 
-        HPX_DEFINE_COMPONENT_ACTION(template_function_accumulator, reset);
-        HPX_DEFINE_COMPONENT_ACTION(template_function_accumulator, query);
+        HPX_DEFINE_COMPONENT_ACTION(template_function_accumulator, reset)
+        HPX_DEFINE_COMPONENT_ACTION(template_function_accumulator, query)
 
         // Actions with template arguments (see add<>() above) require special
         // type definitions. The simplest way to define such an action type is

--- a/examples/cancelable_action/cancelable_action/server/cancelable_action.hpp
+++ b/examples/cancelable_action/cancelable_action/server/cancelable_action.hpp
@@ -98,9 +98,9 @@ namespace examples { namespace server {
             hpx::thread::interrupt(id_);
         }
 
-        HPX_DEFINE_COMPONENT_ACTION(cancelable_action, do_it, do_it_action);
+        HPX_DEFINE_COMPONENT_ACTION(cancelable_action, do_it, do_it_action)
         HPX_DEFINE_COMPONENT_ACTION(
-            cancelable_action, cancel_it, cancel_it_action);
+            cancelable_action, cancel_it, cancel_it_action)
 
     private:
         hpx::lcos::local::mutex mtx_;

--- a/examples/hello_world_component/hello_world_component.hpp
+++ b/examples/hello_world_component/hello_world_component.hpp
@@ -23,7 +23,7 @@ namespace examples { namespace server
         : hpx::components::component_base<hello_world>
     {
         void invoke();
-        HPX_DEFINE_COMPONENT_ACTION(hello_world, invoke);
+        HPX_DEFINE_COMPONENT_ACTION(hello_world, invoke)
     };
 }}
 

--- a/examples/interpolate1d/interpolate1d/server/partition.hpp
+++ b/examples/interpolate1d/interpolate1d/server/partition.hpp
@@ -36,8 +36,8 @@ namespace interpolate1d { namespace server
         // Each of the exposed functions needs to be encapsulated into an action
         // type, allowing to generate all required boilerplate code for threads,
         // serialization, etc.
-        HPX_DEFINE_COMPONENT_ACTION(partition, init);
-        HPX_DEFINE_COMPONENT_ACTION(partition, interpolate);
+        HPX_DEFINE_COMPONENT_ACTION(partition, init)
+        HPX_DEFINE_COMPONENT_ACTION(partition, interpolate)
 
     private:
         static mutex_type mtx_;     // one for whole application

--- a/examples/jacobi/jacobi_component/server/row.hpp
+++ b/examples/jacobi/jacobi_component/server/row.hpp
@@ -45,8 +45,8 @@ namespace jacobi {
                 return row_range(values, begin, end);
             }
 
-            HPX_DEFINE_COMPONENT_ACTION(row, get, get_action);
-            HPX_DEFINE_COMPONENT_ACTION(row, init, init_action);
+            HPX_DEFINE_COMPONENT_ACTION(row, get, get_action)
+            HPX_DEFINE_COMPONENT_ACTION(row, init, init_action)
         };
     }
 }

--- a/examples/jacobi/jacobi_component/server/solver.hpp
+++ b/examples/jacobi/jacobi_component/server/solver.hpp
@@ -131,7 +131,7 @@ namespace jacobi { namespace server {
                       << hpx::flush;
         }
 
-        HPX_DEFINE_COMPONENT_ACTION(solver, run, run_action);
+        HPX_DEFINE_COMPONENT_ACTION(solver, run, run_action)
 
         std::size_t ny;
         std::size_t nx;

--- a/examples/jacobi/jacobi_component/server/stencil_iterator.hpp
+++ b/examples/jacobi/jacobi_component/server/stencil_iterator.hpp
@@ -82,11 +82,11 @@ namespace jacobi
               , hpx::future<row_range> bottom
             );
 
-            HPX_DEFINE_COMPONENT_ACTION(stencil_iterator, init, init_action);
+            HPX_DEFINE_COMPONENT_ACTION(stencil_iterator, init, init_action)
             HPX_DEFINE_COMPONENT_ACTION(stencil_iterator,
-                setup_boundary, setup_boundary_action);
-            HPX_DEFINE_COMPONENT_ACTION(stencil_iterator, step, step_action);
-            HPX_DEFINE_COMPONENT_ACTION(stencil_iterator, get, get_action);
+                setup_boundary, setup_boundary_action)
+            HPX_DEFINE_COMPONENT_ACTION(stencil_iterator, step, step_action)
+            HPX_DEFINE_COMPONENT_ACTION(stencil_iterator, get, get_action)
 
             std::size_t y;
             std::size_t ny;

--- a/examples/nqueen/server/nqueen.hpp
+++ b/examples/nqueen/server/nqueen.hpp
@@ -122,12 +122,12 @@ namespace server
             return b.count_;
         }
 
-        HPX_DEFINE_COMPONENT_ACTION(board, init_board, init_action);
-        HPX_DEFINE_COMPONENT_ACTION(board, access_board, access_action);
-        HPX_DEFINE_COMPONENT_ACTION(board, update_board, update_action);
-        HPX_DEFINE_COMPONENT_ACTION(board, check_board, check_action);
-        HPX_DEFINE_COMPONENT_ACTION(board, solve_board, solve_action);
-        HPX_DEFINE_COMPONENT_ACTION(board, clear_board, clear_action);
+        HPX_DEFINE_COMPONENT_ACTION(board, init_board, init_action)
+        HPX_DEFINE_COMPONENT_ACTION(board, access_board, access_action)
+        HPX_DEFINE_COMPONENT_ACTION(board, update_board, update_action)
+        HPX_DEFINE_COMPONENT_ACTION(board, check_board, check_action)
+        HPX_DEFINE_COMPONENT_ACTION(board, solve_board, solve_action)
+        HPX_DEFINE_COMPONENT_ACTION(board, clear_board, clear_action)
     };
 }}
 

--- a/examples/quickstart/component_ctors.cpp
+++ b/examples/quickstart/component_ctors.cpp
@@ -37,7 +37,7 @@ struct message_server : component_base<message_server>
 
     void print() const { cout << msg << flush; }
 
-    HPX_DEFINE_COMPONENT_ACTION(message_server, print, print_action);
+    HPX_DEFINE_COMPONENT_ACTION(message_server, print, print_action)
 };
 
 typedef component<message_server> server_type;

--- a/examples/quickstart/component_in_executable.cpp
+++ b/examples/quickstart/component_in_executable.cpp
@@ -29,7 +29,7 @@ struct hello_world_server : component_base<hello_world_server>
 {
     void print() const { cout << "hello world\n" << flush; }
 
-    HPX_DEFINE_COMPONENT_ACTION(hello_world_server, print, print_action);
+    HPX_DEFINE_COMPONENT_ACTION(hello_world_server, print, print_action)
 };
 
 typedef component<hello_world_server> server_type;

--- a/examples/quickstart/component_inheritance.cpp
+++ b/examples/quickstart/component_inheritance.cpp
@@ -38,7 +38,7 @@ struct A : hpx::components::abstract_component_base<A>
     {
         print();
     }
-    HPX_DEFINE_COMPONENT_ACTION(A, print_nonvirt, print_action);
+    HPX_DEFINE_COMPONENT_ACTION(A, print_nonvirt, print_action)
 
     // Overload this function to allow to extract the proper base address
     // of the component that is used as part of the generated global id.

--- a/examples/quickstart/component_with_custom_heap.cpp
+++ b/examples/quickstart/component_with_custom_heap.cpp
@@ -343,7 +343,7 @@ struct hello_world_server
         }
     }
 
-    HPX_DEFINE_COMPONENT_ACTION(hello_world_server, print, print_action);
+    HPX_DEFINE_COMPONENT_ACTION(hello_world_server, print, print_action)
 
     std::size_t count_;
 };

--- a/examples/quickstart/component_with_executor.cpp
+++ b/examples/quickstart/component_with_executor.cpp
@@ -35,7 +35,7 @@ struct hello_world_server
         hpx::cout << "hello world\n" << hpx::flush;
     }
 
-    HPX_DEFINE_COMPONENT_ACTION(hello_world_server, print, print_action);
+    HPX_DEFINE_COMPONENT_ACTION(hello_world_server, print, print_action)
 };
 
 typedef hpx::components::component<hello_world_server> server_type;

--- a/examples/quickstart/receive_buffer.cpp
+++ b/examples/quickstart/receive_buffer.cpp
@@ -62,7 +62,7 @@ public:
 
     // Do all the work for 'nt' time steps on the local
     hpx::future<void> do_work(std::size_t nt);
-    HPX_DEFINE_COMPONENT_ACTION(partition_server, do_work, do_work_action);
+    HPX_DEFINE_COMPONENT_ACTION(partition_server, do_work, do_work_action)
 
     // Receive the data from the left partition. This will be called by the
     // other partition, sending us its data.
@@ -70,7 +70,7 @@ public:
     {
         right_buffer_.store_received(timestep, std::move(data));
     }
-    HPX_DEFINE_COMPONENT_ACTION(partition_server, from_right, from_right_action);
+    HPX_DEFINE_COMPONENT_ACTION(partition_server, from_right, from_right_action)
 
     // Explicitly release dependencies to avoid circular dependencies in the
     // reference counting chain.
@@ -79,7 +79,7 @@ public:
         left_.free();
     }
     HPX_DEFINE_COMPONENT_ACTION(partition_server, release_dependencies,
-        release_dependencies_action);
+        release_dependencies_action)
 
 public:
     // Other helper functions

--- a/examples/quickstart/zerocopy_rdma.cpp
+++ b/examples/quickstart/zerocopy_rdma.cpp
@@ -132,7 +132,7 @@ public:
             hpx::util::bind(&zerocopy_server::release_lock, this),
             allocator);
     }
-    HPX_DEFINE_COMPONENT_ACTION(zerocopy_server, get_here, get_here_action);
+    HPX_DEFINE_COMPONENT_ACTION(zerocopy_server, get_here, get_here_action)
 
     ///////////////////////////////////////////////////////////////////////////
     // Retrieve an array of doubles
@@ -146,7 +146,7 @@ public:
             general_buffer_type::reference,
             hpx::util::bind(&zerocopy_server::release_lock, this));
     }
-    HPX_DEFINE_COMPONENT_ACTION(zerocopy_server, get, get_action);
+    HPX_DEFINE_COMPONENT_ACTION(zerocopy_server, get, get_action)
 
 private:
     std::vector<double> data_;

--- a/examples/random_mem_access/random_mem_access/server/random_mem_access.hpp
+++ b/examples/random_mem_access/random_mem_access/server/random_mem_access.hpp
@@ -95,10 +95,10 @@ namespace hpx { namespace components { namespace server
         // Each of the exposed functions needs to be encapsulated into an action
         // type, allowing to generate all required boilerplate code for threads,
         // serialization, etc.
-        HPX_DEFINE_COMPONENT_ACTION(random_mem_access, init);
-        HPX_DEFINE_COMPONENT_ACTION(random_mem_access, add);
-        HPX_DEFINE_COMPONENT_ACTION(random_mem_access, query);
-        HPX_DEFINE_COMPONENT_ACTION(random_mem_access, print);
+        HPX_DEFINE_COMPONENT_ACTION(random_mem_access, init)
+        HPX_DEFINE_COMPONENT_ACTION(random_mem_access, add)
+        HPX_DEFINE_COMPONENT_ACTION(random_mem_access, query)
+        HPX_DEFINE_COMPONENT_ACTION(random_mem_access, print)
 
     private:
         std::size_t arg_;

--- a/examples/sheneos/sheneos/server/partition3d.hpp
+++ b/examples/sheneos/sheneos/server/partition3d.hpp
@@ -145,11 +145,11 @@ namespace sheneos { namespace server
         // Each of the exposed functions needs to be encapsulated into an
         // action type, generating all required boilerplate code for threads,
         // serialization, etc.
-        HPX_DEFINE_COMPONENT_ACTION(partition3d, init);
-        HPX_DEFINE_COMPONENT_ACTION(partition3d, interpolate);
-        HPX_DEFINE_COMPONENT_ACTION(partition3d, interpolate_one);
-        HPX_DEFINE_COMPONENT_ACTION(partition3d, interpolate_bulk);
-        HPX_DEFINE_COMPONENT_ACTION(partition3d, interpolate_one_bulk);
+        HPX_DEFINE_COMPONENT_ACTION(partition3d, init)
+        HPX_DEFINE_COMPONENT_ACTION(partition3d, interpolate)
+        HPX_DEFINE_COMPONENT_ACTION(partition3d, interpolate_one)
+        HPX_DEFINE_COMPONENT_ACTION(partition3d, interpolate_bulk)
+        HPX_DEFINE_COMPONENT_ACTION(partition3d, interpolate_one_bulk)
 
     protected:
         double interpolate_one(sheneos_coord const& c,

--- a/examples/startup_shutdown/server/startup_shutdown.hpp
+++ b/examples/startup_shutdown/server/startup_shutdown.hpp
@@ -35,7 +35,7 @@ namespace startup_shutdown { namespace server
         // Each of the exposed functions needs to be encapsulated into an action
         // type, allowing to generate all required boilerplate code for threads,
         // serialization, etc.
-        HPX_DEFINE_COMPONENT_ACTION(startup_shutdown_component, init);
+        HPX_DEFINE_COMPONENT_ACTION(startup_shutdown_component, init)
 
     private:
         std::string arg_;

--- a/examples/throttle/throttle/server/throttle.hpp
+++ b/examples/throttle/throttle/server/throttle.hpp
@@ -50,9 +50,9 @@ namespace throttle { namespace server
         // Each of the exposed functions needs to be encapsulated into an action
         // type, allowing to generate all required boilerplate code for threads,
         // serialization, etc.
-        HPX_DEFINE_COMPONENT_ACTION(throttle, suspend, suspend_action);
-        HPX_DEFINE_COMPONENT_ACTION(throttle, resume, resume_action);
-        HPX_DEFINE_COMPONENT_ACTION(throttle, is_suspended, is_suspended_action);
+        HPX_DEFINE_COMPONENT_ACTION(throttle, suspend, suspend_action)
+        HPX_DEFINE_COMPONENT_ACTION(throttle, resume, resume_action)
+        HPX_DEFINE_COMPONENT_ACTION(throttle, is_suspended, is_suspended_action)
 
     private:
         // this function is periodically scheduled as a worker thread with the

--- a/examples/transpose/transpose_await.cpp
+++ b/examples/transpose/transpose_await.cpp
@@ -142,7 +142,7 @@ struct block_component : hpx::components::component_base<block_component>
         return sub_block(&data_[offset], size);
     }
 
-    HPX_DEFINE_COMPONENT_ACTION(block_component, get_sub_block);
+    HPX_DEFINE_COMPONENT_ACTION(block_component, get_sub_block)
 
     std::vector<double> data_;
 };

--- a/examples/transpose/transpose_block.cpp
+++ b/examples/transpose/transpose_block.cpp
@@ -148,7 +148,7 @@ struct block_component : hpx::components::component_base<block_component>
         return sub_block(&data_[offset], size);
     }
 
-    HPX_DEFINE_COMPONENT_DIRECT_ACTION(block_component, get_sub_block);
+    HPX_DEFINE_COMPONENT_DIRECT_ACTION(block_component, get_sub_block)
 
     std::vector<double> data_;
 };

--- a/examples/tuplespace/central_tuplespace/server/simple_central_tuplespace.hpp
+++ b/examples/tuplespace/central_tuplespace/server/simple_central_tuplespace.hpp
@@ -168,9 +168,9 @@ namespace examples { namespace server {
         // serialization, etc.
 
         //[simple_central_tuplespace_action_types
-        HPX_DEFINE_COMPONENT_ACTION(simple_central_tuplespace, write);
-        HPX_DEFINE_COMPONENT_ACTION(simple_central_tuplespace, read);
-        HPX_DEFINE_COMPONENT_ACTION(simple_central_tuplespace, take);
+        HPX_DEFINE_COMPONENT_ACTION(simple_central_tuplespace, write)
+        HPX_DEFINE_COMPONENT_ACTION(simple_central_tuplespace, read)
+        HPX_DEFINE_COMPONENT_ACTION(simple_central_tuplespace, take)
         //]
 
         //[simple_central_tuplespace_server_data_member

--- a/libs/full/actions_base/include/hpx/actions_base/component_action.hpp
+++ b/libs/full/actions_base/include/hpx/actions_base/component_action.hpp
@@ -280,7 +280,7 @@ namespace hpx { namespace actions {
       : hpx::actions::make_action_t<decltype(&component::func),                \
             &component::func, name>                                            \
     {                                                                          \
-    } /**/
+    }; /**/
 #define HPX_DEFINE_COMPONENT_ACTION_2(component, func)                         \
     HPX_DEFINE_COMPONENT_ACTION_3(component, func, HPX_PP_CAT(func, _action))  \
     /**/
@@ -301,7 +301,7 @@ namespace hpx { namespace actions {
       : hpx::actions::make_direct_action_t<decltype(&component::func),         \
             &component::func, name>                                            \
     {                                                                          \
-    } /**/
+    }; /**/
 
 #define HPX_DEFINE_COMPONENT_DIRECT_ACTION_2(component, func)                  \
     HPX_DEFINE_COMPONENT_DIRECT_ACTION_3(                                      \

--- a/libs/full/agas_base/include/hpx/agas_base/server/component_namespace.hpp
+++ b/libs/full/agas_base/include/hpx/agas_base/server/component_namespace.hpp
@@ -169,14 +169,14 @@ namespace hpx { namespace agas { namespace server {
 
         std::uint32_t get_num_localities(components::component_type type);
 
-        HPX_DEFINE_COMPONENT_ACTION(component_namespace, bind_prefix);
-        HPX_DEFINE_COMPONENT_ACTION(component_namespace, bind_name);
-        HPX_DEFINE_COMPONENT_ACTION(component_namespace, resolve_id);
-        HPX_DEFINE_COMPONENT_ACTION(component_namespace, unbind);
-        HPX_DEFINE_COMPONENT_ACTION(component_namespace, iterate_types);
+        HPX_DEFINE_COMPONENT_ACTION(component_namespace, bind_prefix)
+        HPX_DEFINE_COMPONENT_ACTION(component_namespace, bind_name)
+        HPX_DEFINE_COMPONENT_ACTION(component_namespace, resolve_id)
+        HPX_DEFINE_COMPONENT_ACTION(component_namespace, unbind)
+        HPX_DEFINE_COMPONENT_ACTION(component_namespace, iterate_types)
         HPX_DEFINE_COMPONENT_ACTION(
-            component_namespace, get_component_type_name);
-        HPX_DEFINE_COMPONENT_ACTION(component_namespace, get_num_localities);
+            component_namespace, get_component_type_name)
+        HPX_DEFINE_COMPONENT_ACTION(component_namespace, get_num_localities)
     };
 
 }}}    // namespace hpx::agas::server

--- a/libs/full/agas_base/include/hpx/agas_base/server/locality_namespace.hpp
+++ b/libs/full/agas_base/include/hpx/agas_base/server/locality_namespace.hpp
@@ -168,14 +168,13 @@ namespace hpx { namespace agas { namespace server {
         std::uint32_t get_num_overall_threads();
 
     public:
-        HPX_DEFINE_COMPONENT_ACTION(locality_namespace, allocate);
-        HPX_DEFINE_COMPONENT_ACTION(locality_namespace, free);
-        HPX_DEFINE_COMPONENT_ACTION(locality_namespace, localities);
-        HPX_DEFINE_COMPONENT_ACTION(locality_namespace, resolve_locality);
-        HPX_DEFINE_COMPONENT_ACTION(locality_namespace, get_num_localities);
-        HPX_DEFINE_COMPONENT_ACTION(locality_namespace, get_num_threads);
-        HPX_DEFINE_COMPONENT_ACTION(
-            locality_namespace, get_num_overall_threads);
+        HPX_DEFINE_COMPONENT_ACTION(locality_namespace, allocate)
+        HPX_DEFINE_COMPONENT_ACTION(locality_namespace, free)
+        HPX_DEFINE_COMPONENT_ACTION(locality_namespace, localities)
+        HPX_DEFINE_COMPONENT_ACTION(locality_namespace, resolve_locality)
+        HPX_DEFINE_COMPONENT_ACTION(locality_namespace, get_num_localities)
+        HPX_DEFINE_COMPONENT_ACTION(locality_namespace, get_num_threads)
+        HPX_DEFINE_COMPONENT_ACTION(locality_namespace, get_num_overall_threads)
     };
 
 }}}    // namespace hpx::agas::server

--- a/libs/full/agas_base/include/hpx/agas_base/server/primary_namespace.hpp
+++ b/libs/full/agas_base/include/hpx/agas_base/server/primary_namespace.hpp
@@ -333,17 +333,17 @@ namespace hpx::agas::server {
             error_code& ec);
 
     public:
-        HPX_DEFINE_COMPONENT_ACTION(primary_namespace, allocate);
-        HPX_DEFINE_COMPONENT_ACTION(primary_namespace, bind_gid);
-        HPX_DEFINE_COMPONENT_ACTION(primary_namespace, colocate);
-        HPX_DEFINE_COMPONENT_ACTION(primary_namespace, begin_migration);
-        HPX_DEFINE_COMPONENT_ACTION(primary_namespace, end_migration);
-        HPX_DEFINE_COMPONENT_ACTION(primary_namespace, decrement_credit);
-        HPX_DEFINE_COMPONENT_ACTION(primary_namespace, increment_credit);
-        HPX_DEFINE_COMPONENT_ACTION(primary_namespace, resolve_gid);
-        HPX_DEFINE_COMPONENT_ACTION(primary_namespace, unbind_gid);
+        HPX_DEFINE_COMPONENT_ACTION(primary_namespace, allocate)
+        HPX_DEFINE_COMPONENT_ACTION(primary_namespace, bind_gid)
+        HPX_DEFINE_COMPONENT_ACTION(primary_namespace, colocate)
+        HPX_DEFINE_COMPONENT_ACTION(primary_namespace, begin_migration)
+        HPX_DEFINE_COMPONENT_ACTION(primary_namespace, end_migration)
+        HPX_DEFINE_COMPONENT_ACTION(primary_namespace, decrement_credit)
+        HPX_DEFINE_COMPONENT_ACTION(primary_namespace, increment_credit)
+        HPX_DEFINE_COMPONENT_ACTION(primary_namespace, resolve_gid)
+        HPX_DEFINE_COMPONENT_ACTION(primary_namespace, unbind_gid)
 #if defined(HPX_HAVE_NETWORKING)
-        HPX_DEFINE_COMPONENT_ACTION(primary_namespace, route);
+        HPX_DEFINE_COMPONENT_ACTION(primary_namespace, route)
 #endif
     };
 }    // namespace hpx::agas::server

--- a/libs/full/agas_base/include/hpx/agas_base/server/symbol_namespace.hpp
+++ b/libs/full/agas_base/include/hpx/agas_base/server/symbol_namespace.hpp
@@ -151,11 +151,11 @@ namespace hpx { namespace agas { namespace server {
         bool on_event(std::string const& name, bool call_for_past_events,
             hpx::id_type lco);
 
-        HPX_DEFINE_COMPONENT_ACTION(symbol_namespace, bind);
-        HPX_DEFINE_COMPONENT_ACTION(symbol_namespace, resolve);
-        HPX_DEFINE_COMPONENT_ACTION(symbol_namespace, unbind);
-        HPX_DEFINE_COMPONENT_ACTION(symbol_namespace, iterate);
-        HPX_DEFINE_COMPONENT_ACTION(symbol_namespace, on_event);
+        HPX_DEFINE_COMPONENT_ACTION(symbol_namespace, bind)
+        HPX_DEFINE_COMPONENT_ACTION(symbol_namespace, resolve)
+        HPX_DEFINE_COMPONENT_ACTION(symbol_namespace, unbind)
+        HPX_DEFINE_COMPONENT_ACTION(symbol_namespace, iterate)
+        HPX_DEFINE_COMPONENT_ACTION(symbol_namespace, on_event)
     };
 
 }}}    // namespace hpx::agas::server

--- a/libs/full/async_colocated/tests/unit/apply_colocated.cpp
+++ b/libs/full/async_colocated/tests/unit/apply_colocated.cpp
@@ -56,7 +56,7 @@ struct increment_server
         hpx::apply(receive_result_action(), there, accumulator.load());
     }
 
-    HPX_DEFINE_COMPONENT_ACTION(increment_server, call);
+    HPX_DEFINE_COMPONENT_ACTION(increment_server, call)
 };
 
 typedef hpx::components::managed_component<increment_server> server_type;

--- a/libs/full/async_colocated/tests/unit/async_cb_colocated.cpp
+++ b/libs/full/async_colocated/tests/unit/async_cb_colocated.cpp
@@ -44,7 +44,7 @@ struct decrement_server
         return i - 1;
     }
 
-    HPX_DEFINE_COMPONENT_ACTION(decrement_server, call);
+    HPX_DEFINE_COMPONENT_ACTION(decrement_server, call)
 };
 
 typedef hpx::components::managed_component<decrement_server> server_type;

--- a/libs/full/async_colocated/tests/unit/async_colocated.cpp
+++ b/libs/full/async_colocated/tests/unit/async_colocated.cpp
@@ -43,7 +43,7 @@ struct decrement_server
         return i - 1;
     }
 
-    HPX_DEFINE_COMPONENT_ACTION(decrement_server, call);
+    HPX_DEFINE_COMPONENT_ACTION(decrement_server, call)
 };
 
 typedef hpx::components::managed_component<decrement_server> server_type;

--- a/libs/full/async_distributed/include/hpx/async_distributed/base_lco.hpp
+++ b/libs/full/async_distributed/include/hpx/async_distributed/base_lco.hpp
@@ -96,7 +96,7 @@ namespace hpx { namespace lcos {
         /// The \a set_event_action may be used to unconditionally trigger any
         /// LCO instances, it carries no additional parameters.
         HPX_DEFINE_COMPONENT_DIRECT_ACTION(
-            base_lco, set_event_nonvirt, set_event_action);
+            base_lco, set_event_nonvirt, set_event_action)
 
         /// The \a set_exception_action may be used to transfer arbitrary error
         /// information from the remote site to the LCO instance specified as
@@ -106,15 +106,15 @@ namespace hpx { namespace lcos {
         ///               [in] The exception encapsulating the error to report
         ///               to this LCO instance.
         HPX_DEFINE_COMPONENT_DIRECT_ACTION(
-            base_lco, set_exception_nonvirt, set_exception_action);
+            base_lco, set_exception_nonvirt, set_exception_action)
 
         /// The \a connect_action may be used to
         HPX_DEFINE_COMPONENT_DIRECT_ACTION(
-            base_lco, connect_nonvirt, connect_action);
+            base_lco, connect_nonvirt, connect_action)
 
         /// The \a set_exception_action may be used to
         HPX_DEFINE_COMPONENT_DIRECT_ACTION(
-            base_lco, disconnect_nonvirt, disconnect_action);
+            base_lco, disconnect_nonvirt, disconnect_action)
     };
 }}    // namespace hpx::lcos
 

--- a/libs/full/async_distributed/include/hpx/async_distributed/base_lco_with_value.hpp
+++ b/libs/full/async_distributed/include/hpx/async_distributed/base_lco_with_value.hpp
@@ -166,12 +166,12 @@ namespace hpx { namespace lcos {
         /// \param RemoteResult [in] The type of the result to be transferred
         ///               back to this LCO instance.
         HPX_DEFINE_COMPONENT_DIRECT_ACTION(
-            base_lco_with_value, set_value_nonvirt, set_value_action);
+            base_lco_with_value, set_value_nonvirt, set_value_action)
 
         /// The \a get_value_action may be used to query the value this LCO
         /// instance exposes as its 'result' value.
         HPX_DEFINE_COMPONENT_DIRECT_ACTION(
-            base_lco_with_value, get_value_nonvirt, get_value_action);
+            base_lco_with_value, get_value_nonvirt, get_value_action)
     };
 
     /// The base_lco<void> specialization is used whenever the set_event action
@@ -207,7 +207,7 @@ namespace hpx { namespace lcos {
         void get_value() {}
 
         HPX_DEFINE_COMPONENT_DIRECT_ACTION(
-            base_lco_with_value, get_value, get_value_action);
+            base_lco_with_value, get_value, get_value_action)
     };
 }}    // namespace hpx::lcos
 

--- a/libs/full/async_distributed/tests/regressions/async_action_1813.cpp
+++ b/libs/full/async_distributed/tests/regressions/async_action_1813.cpp
@@ -35,7 +35,7 @@ struct get_locality_server
         return hpx::find_here();
     }
 
-    HPX_DEFINE_COMPONENT_ACTION(get_locality_server, call);
+    HPX_DEFINE_COMPONENT_ACTION(get_locality_server, call)
 };
 
 typedef hpx::components::component<get_locality_server> server_type;

--- a/libs/full/async_distributed/tests/unit/apply_remote.cpp
+++ b/libs/full/async_distributed/tests/unit/apply_remote.cpp
@@ -60,7 +60,7 @@ struct increment_server
         hpx::apply(receive_result_action(), there, accumulator.load());
     }
 
-    HPX_DEFINE_COMPONENT_ACTION(increment_server, call);
+    HPX_DEFINE_COMPONENT_ACTION(increment_server, call)
 };
 
 typedef hpx::components::managed_component<increment_server> server_type;

--- a/libs/full/async_distributed/tests/unit/apply_remote_client.cpp
+++ b/libs/full/async_distributed/tests/unit/apply_remote_client.cpp
@@ -45,7 +45,7 @@ struct increment_server
         hpx::apply(receive_result_action(), there, accumulator.load());
     }
 
-    HPX_DEFINE_COMPONENT_ACTION(increment_server, call);
+    HPX_DEFINE_COMPONENT_ACTION(increment_server, call)
 };
 
 typedef hpx::components::managed_component<increment_server> server_type;

--- a/libs/full/async_distributed/tests/unit/async_cb_remote.cpp
+++ b/libs/full/async_distributed/tests/unit/async_cb_remote.cpp
@@ -42,7 +42,7 @@ struct decrement_server
         return i - 1;
     }
 
-    HPX_DEFINE_COMPONENT_ACTION(decrement_server, call);
+    HPX_DEFINE_COMPONENT_ACTION(decrement_server, call)
 };
 
 typedef hpx::components::managed_component<decrement_server> server_type;

--- a/libs/full/async_distributed/tests/unit/async_cb_remote_client.cpp
+++ b/libs/full/async_distributed/tests/unit/async_cb_remote_client.cpp
@@ -29,7 +29,7 @@ struct decrement_server
         return i - 1;
     }
 
-    HPX_DEFINE_COMPONENT_ACTION(decrement_server, call);
+    HPX_DEFINE_COMPONENT_ACTION(decrement_server, call)
 };
 
 typedef hpx::components::managed_component<decrement_server> server_type;

--- a/libs/full/async_distributed/tests/unit/async_remote.cpp
+++ b/libs/full/async_distributed/tests/unit/async_remote.cpp
@@ -40,7 +40,7 @@ struct decrement_server
         return i - 1;
     }
 
-    HPX_DEFINE_COMPONENT_ACTION(decrement_server, call);
+    HPX_DEFINE_COMPONENT_ACTION(decrement_server, call)
 };
 
 typedef hpx::components::managed_component<decrement_server> server_type;

--- a/libs/full/async_distributed/tests/unit/async_remote_client.cpp
+++ b/libs/full/async_distributed/tests/unit/async_remote_client.cpp
@@ -26,7 +26,7 @@ struct decrement_server
         return i - 1;
     }
 
-    HPX_DEFINE_COMPONENT_ACTION(decrement_server, call);
+    HPX_DEFINE_COMPONENT_ACTION(decrement_server, call)
 };
 
 typedef hpx::components::managed_component<decrement_server> server_type;

--- a/libs/full/async_distributed/tests/unit/async_unwrap_result.cpp
+++ b/libs/full/async_distributed/tests/unit/async_unwrap_result.cpp
@@ -29,7 +29,7 @@ struct decrement_server
         return hpx::make_ready_future(i - 1);
     }
 
-    HPX_DEFINE_COMPONENT_ACTION(decrement_server, call);
+    HPX_DEFINE_COMPONENT_ACTION(decrement_server, call)
 };
 
 typedef hpx::components::managed_component<decrement_server> server_type;
@@ -46,14 +46,14 @@ struct test_server : hpx::components::component_base<test_server>
     {
         return hpx::make_ready_future(i + 1);
     }
-    HPX_DEFINE_COMPONENT_ACTION(test_server, increment);
+    HPX_DEFINE_COMPONENT_ACTION(test_server, increment)
 
     hpx::future<std::int32_t> increment_with_future(
         hpx::shared_future<std::int32_t> fi)
     {
         return hpx::make_ready_future(fi.get() + 1);
     }
-    HPX_DEFINE_COMPONENT_ACTION(test_server, increment_with_future);
+    HPX_DEFINE_COMPONENT_ACTION(test_server, increment_with_future)
 };
 
 typedef hpx::components::component<test_server> test_server_type;

--- a/libs/full/async_distributed/tests/unit/sync_remote.cpp
+++ b/libs/full/async_distributed/tests/unit/sync_remote.cpp
@@ -40,7 +40,7 @@ struct decrement_server
         return i - 1;
     }
 
-    HPX_DEFINE_COMPONENT_ACTION(decrement_server, call);
+    HPX_DEFINE_COMPONENT_ACTION(decrement_server, call)
 };
 
 typedef hpx::components::managed_component<decrement_server> server_type;

--- a/libs/full/checkpoint/tests/unit/checkpoint_component.cpp
+++ b/libs/full/checkpoint/tests/unit/checkpoint_component.cpp
@@ -42,7 +42,7 @@ struct data_server : hpx::components::component_base<data_server>
     {
         return data_;
     }
-    HPX_DEFINE_COMPONENT_ACTION(data_server, get_data, get_data_action);
+    HPX_DEFINE_COMPONENT_ACTION(data_server, get_data, get_data_action)
 
     void print()
     {
@@ -56,7 +56,7 @@ struct data_server : hpx::components::component_base<data_server>
         }
         std::cout << std::endl;
     }
-    HPX_DEFINE_COMPONENT_ACTION(data_server, print, print_action);
+    HPX_DEFINE_COMPONENT_ACTION(data_server, print, print_action)
 
     std::vector<int> data_;
 

--- a/libs/full/collectives/examples/channel_communicator.cpp
+++ b/libs/full/collectives/examples/channel_communicator.cpp
@@ -84,6 +84,8 @@ int main(int argc, char* argv[])
     params.cfg = {"--hpx:run-hpx-main"};
     return hpx::init(argc, argv, params);
 #else
+    (void) argc;
+    (void) argv;
     return 0;
 #endif
 }

--- a/libs/full/collectives/include/hpx/collectives/detail/barrier_node.hpp
+++ b/libs/full/collectives/include/hpx/collectives/detail/barrier_node.hpp
@@ -56,7 +56,7 @@ namespace hpx { namespace lcos { namespace detail {
 
         hpx::future<void> wait(bool async);
 
-        HPX_DEFINE_COMPONENT_DIRECT_ACTION(barrier_node, gather);
+        HPX_DEFINE_COMPONENT_DIRECT_ACTION(barrier_node, gather)
 
     private:
         hpx::util::atomic_count count_;

--- a/libs/full/collectives/include/hpx/collectives/detail/latch.hpp
+++ b/libs/full/collectives/include/hpx/collectives/detail/latch.hpp
@@ -137,7 +137,7 @@ namespace hpx { namespace lcos { namespace server {
         {
             latch_.wait();
         }
-        HPX_DEFINE_COMPONENT_ACTION(latch, wait, wait_action);
+        HPX_DEFINE_COMPONENT_ACTION(latch, wait, wait_action)
 
     private:
         lcos::local::latch latch_;

--- a/libs/full/collectives/tests/performance/osu/broadcast.hpp
+++ b/libs/full/collectives/tests/performance/osu/broadcast.hpp
@@ -21,7 +21,7 @@
     {                                                                          \
         NAME.set(hpx::any(value));                                             \
     }                                                                          \
-    HPX_DEFINE_COMPONENT_ACTION(broadcast_component, HPX_PP_CAT(NAME, _));     \
+    HPX_DEFINE_COMPONENT_ACTION(broadcast_component, HPX_PP_CAT(NAME, _))      \
                                                                                \
     ::hpx::lcos::broadcast<HPX_PP_CAT(HPX_PP_CAT(NAME, _), _action)> NAME;     \
     /**/

--- a/libs/full/collectives/tests/performance/osu/osu_bcast.cpp
+++ b/libs/full/collectives/tests/performance/osu/osu_bcast.cpp
@@ -42,7 +42,7 @@ struct broadcast_component
         send_buffer = std::vector<char>(max_msg_size);
     }
 
-    HPX_DEFINE_COMPONENT_ACTION(broadcast_component, init);
+    HPX_DEFINE_COMPONENT_ACTION(broadcast_component, init)
 
     typedef hpx::serialization::serialize_buffer<char> buffer_type;
 
@@ -69,7 +69,7 @@ struct broadcast_component
         return latency;
     }
 
-    HPX_DEFINE_COMPONENT_ACTION(broadcast_component, run);
+    HPX_DEFINE_COMPONENT_ACTION(broadcast_component, run)
 
     HPX_DEFINE_COMPONENT_BROADCAST(bcast, buffer_type);
     std::vector<hpx::id_type> ids;

--- a/libs/full/collectives/tests/unit/broadcast_component.cpp
+++ b/libs/full/collectives/tests/unit/broadcast_component.cpp
@@ -24,7 +24,7 @@ struct test_component1 : hpx::components::component_base<test_component1>
     {
         return hpx::get_locality_id();
     }
-    HPX_DEFINE_COMPONENT_ACTION(test_component1, f1);
+    HPX_DEFINE_COMPONENT_ACTION(test_component1, f1)
 };
 
 using test_component1_type = hpx::components::component<test_component1>;

--- a/libs/full/lcos_distributed/include/hpx/lcos_distributed/server/channel.hpp
+++ b/libs/full/lcos_distributed/include/hpx/lcos_distributed/server/channel.hpp
@@ -104,19 +104,19 @@ namespace hpx { namespace lcos { namespace server {
         {
             return channel_.get(generation);
         }
-        HPX_DEFINE_COMPONENT_DIRECT_ACTION(channel, get_generation);
+        HPX_DEFINE_COMPONENT_DIRECT_ACTION(channel, get_generation)
 
         void set_generation(RemoteType&& value, std::size_t generation)
         {
             channel_.set(HPX_MOVE(value), generation);
         }
-        HPX_DEFINE_COMPONENT_DIRECT_ACTION(channel, set_generation);
+        HPX_DEFINE_COMPONENT_DIRECT_ACTION(channel, set_generation)
 
         std::size_t close(bool force_delete_entries)
         {
             return channel_.close(force_delete_entries);
         }
-        HPX_DEFINE_COMPONENT_ACTION(channel, close);
+        HPX_DEFINE_COMPONENT_ACTION(channel, close)
 
     private:
         lcos::local::channel<result_type> channel_;

--- a/libs/full/lcos_distributed/include/hpx/lcos_distributed/server/object_semaphore.hpp
+++ b/libs/full/lcos_distributed/include/hpx/lcos_distributed/server/object_semaphore.hpp
@@ -212,11 +212,11 @@ namespace hpx { namespace lcos { namespace server {
             }
         }
 
-        HPX_DEFINE_COMPONENT_ACTION(object_semaphore, signal, signal_action);
-        HPX_DEFINE_COMPONENT_ACTION(object_semaphore, get, get_action);
+        HPX_DEFINE_COMPONENT_ACTION(object_semaphore, signal, signal_action)
+        HPX_DEFINE_COMPONENT_ACTION(object_semaphore, get, get_action)
         HPX_DEFINE_COMPONENT_ACTION(
-            object_semaphore, abort_pending, abort_pending_action);
-        HPX_DEFINE_COMPONENT_ACTION(object_semaphore, wait, wait_action);
+            object_semaphore, abort_pending, abort_pending_action)
+        HPX_DEFINE_COMPONENT_ACTION(object_semaphore, wait, wait_action)
 
     private:
         value_queue_type value_queue_;

--- a/libs/full/parcelset/tests/unit/put_parcels_with_coalescing.cpp
+++ b/libs/full/parcelset/tests/unit/put_parcels_with_coalescing.cpp
@@ -55,7 +55,7 @@ struct test_server : hpx::components::component_base<test_server>
         return hpx::find_here();
     }
 
-    HPX_DEFINE_COMPONENT_ACTION(test_server, test1, test1_action);
+    HPX_DEFINE_COMPONENT_ACTION(test_server, test1, test1_action)
 };
 
 typedef hpx::components::component<test_server> server_type;

--- a/libs/full/parcelset/tests/unit/put_parcels_with_compression.cpp
+++ b/libs/full/parcelset/tests/unit/put_parcels_with_compression.cpp
@@ -56,7 +56,7 @@ struct test_server : hpx::components::component_base<test_server>
         return hpx::find_here();
     }
 
-    HPX_DEFINE_COMPONENT_ACTION(test_server, test1, test1_action);
+    HPX_DEFINE_COMPONENT_ACTION(test_server, test1, test1_action)
 };
 
 typedef hpx::components::component<test_server> server_type;

--- a/libs/full/performance_counters/include/hpx/performance_counters/server/base_performance_counter.hpp
+++ b/libs/full/performance_counters/include/hpx/performance_counters/server/base_performance_counter.hpp
@@ -74,37 +74,37 @@ namespace hpx { namespace performance_counters { namespace server {
         /// The \a get_counter_info_action retrieves a performance counters
         /// information.
         HPX_DEFINE_COMPONENT_ACTION(base_performance_counter,
-            get_counter_info_nonvirt, get_counter_info_action);
+            get_counter_info_nonvirt, get_counter_info_action)
 
         /// The \a get_counter_value_action queries the value of a performance
         /// counter.
         HPX_DEFINE_COMPONENT_ACTION(base_performance_counter,
-            get_counter_value_nonvirt, get_counter_value_action);
+            get_counter_value_nonvirt, get_counter_value_action)
 
         /// The \a get_counter_value_action queries the value of a performance
         /// counter.
         HPX_DEFINE_COMPONENT_ACTION(base_performance_counter,
-            get_counter_values_array_nonvirt, get_counter_values_array_action);
+            get_counter_values_array_nonvirt, get_counter_values_array_action)
 
         /// The \a set_counter_value_action
         HPX_DEFINE_COMPONENT_ACTION(base_performance_counter,
-            set_counter_value_nonvirt, set_counter_value_action);
+            set_counter_value_nonvirt, set_counter_value_action)
 
         /// The \a reset_counter_value_action
         HPX_DEFINE_COMPONENT_ACTION(base_performance_counter,
-            reset_counter_value_nonvirt, reset_counter_value_action);
+            reset_counter_value_nonvirt, reset_counter_value_action)
 
         /// The \a start_action
         HPX_DEFINE_COMPONENT_ACTION(
-            base_performance_counter, start_nonvirt, start_action);
+            base_performance_counter, start_nonvirt, start_action)
 
         /// The \a stop_action
         HPX_DEFINE_COMPONENT_ACTION(
-            base_performance_counter, stop_nonvirt, stop_action);
+            base_performance_counter, stop_nonvirt, stop_action)
 
         /// The \a reinit_action
         HPX_DEFINE_COMPONENT_ACTION(
-            base_performance_counter, reinit_nonvirt, reinit_action);
+            base_performance_counter, reinit_nonvirt, reinit_action)
 
     protected:
         hpx::performance_counters::counter_info info_;

--- a/libs/full/runtime_components/include/hpx/runtime_components/distributed_metadata_base.hpp
+++ b/libs/full/runtime_components/include/hpx/runtime_components/distributed_metadata_base.hpp
@@ -55,7 +55,7 @@ namespace hpx { namespace components { namespace server {
             return data_;
         }
 
-        HPX_DEFINE_COMPONENT_DIRECT_ACTION(distributed_metadata_base, get);
+        HPX_DEFINE_COMPONENT_DIRECT_ACTION(distributed_metadata_base, get)
 
     private:
         ConfigData data_;

--- a/libs/full/runtime_components/tests/unit/agas/components/server/managed_refcnt_checker.hpp
+++ b/libs/full/runtime_components/tests/unit/agas/components/server/managed_refcnt_checker.hpp
@@ -45,7 +45,7 @@ namespace hpx { namespace test { namespace server {
             references_.push_back(gid);
         }
 
-        HPX_DEFINE_COMPONENT_ACTION(managed_refcnt_checker, take_reference);
+        HPX_DEFINE_COMPONENT_ACTION(managed_refcnt_checker, take_reference)
     };
 
 }}}    // namespace hpx::test::server

--- a/libs/full/runtime_components/tests/unit/agas/components/server/simple_mobile_object.hpp
+++ b/libs/full/runtime_components/tests/unit/agas/components/server/simple_mobile_object.hpp
@@ -31,7 +31,7 @@ namespace hpx { namespace test { namespace server {
         }
 
         HPX_DEFINE_COMPONENT_ACTION(
-            simple_mobile_object, get_lva, get_lva_action);
+            simple_mobile_object, get_lva, get_lva_action)
 
         // the tests using this object rely on rebind-able gids
         naming::gid_type get_base_gid(

--- a/libs/full/runtime_components/tests/unit/agas/components/server/simple_refcnt_checker.hpp
+++ b/libs/full/runtime_components/tests/unit/agas/components/server/simple_refcnt_checker.hpp
@@ -46,7 +46,7 @@ namespace hpx { namespace test { namespace server {
             references_.push_back(gid);
         }
 
-        HPX_DEFINE_COMPONENT_ACTION(simple_refcnt_checker, take_reference);
+        HPX_DEFINE_COMPONENT_ACTION(simple_refcnt_checker, take_reference)
     };
 
 }}}    // namespace hpx::test::server

--- a/libs/full/runtime_components/tests/unit/agas/find_clients_from_prefix.cpp
+++ b/libs/full/runtime_components/tests/unit/agas/find_clients_from_prefix.cpp
@@ -28,7 +28,7 @@ struct test_server : hpx::components::component_base<test_server>
     {
         return hpx::find_here();
     }
-    HPX_DEFINE_COMPONENT_ACTION(test_server, call, call_action);
+    HPX_DEFINE_COMPONENT_ACTION(test_server, call, call_action)
 };
 
 typedef hpx::components::component<test_server> server_type;

--- a/libs/full/runtime_components/tests/unit/agas/find_ids_from_prefix.cpp
+++ b/libs/full/runtime_components/tests/unit/agas/find_ids_from_prefix.cpp
@@ -28,7 +28,7 @@ struct test_server : hpx::components::component_base<test_server>
     {
         return hpx::find_here();
     }
-    HPX_DEFINE_COMPONENT_ACTION(test_server, call, call_action);
+    HPX_DEFINE_COMPONENT_ACTION(test_server, call, call_action)
 };
 
 typedef hpx::components::component<test_server> server_type;

--- a/libs/full/runtime_components/tests/unit/agas/get_colocation_id.cpp
+++ b/libs/full/runtime_components/tests/unit/agas/get_colocation_id.cpp
@@ -30,7 +30,7 @@ struct test_server : hpx::components::managed_component_base<test_server>
     {
         return hpx::find_here();
     }
-    HPX_DEFINE_COMPONENT_ACTION(test_server, call, call_action);
+    HPX_DEFINE_COMPONENT_ACTION(test_server, call, call_action)
 };
 
 typedef hpx::components::managed_component<test_server> server_type;

--- a/libs/full/runtime_components/tests/unit/components/action_invoke_no_more_than.cpp
+++ b/libs/full/runtime_components/tests/unit/components/action_invoke_no_more_than.cpp
@@ -57,9 +57,9 @@ struct test_server : hpx::components::component_base<test_server>
         return hpx::make_ready_future();
     }
 
-    HPX_DEFINE_COMPONENT_ACTION(test_server, call_void, call_void_action);
+    HPX_DEFINE_COMPONENT_ACTION(test_server, call_void, call_void_action)
     HPX_DEFINE_COMPONENT_ACTION(
-        test_server, call_future_void, call_future_void_action);
+        test_server, call_future_void, call_future_void_action)
 };
 
 typedef hpx::components::component<test_server> server_type;

--- a/libs/full/runtime_components/tests/unit/components/components/launch_process_test_server.hpp
+++ b/libs/full/runtime_components/tests/unit/components/components/launch_process_test_server.hpp
@@ -28,14 +28,14 @@ namespace launch_process {
             return msg_;
         }
         HPX_DEFINE_COMPONENT_ACTION(
-            test_server, get_message, get_message_action);
+            test_server, get_message, get_message_action)
 
         void set_message(std::string const& msg)
         {
             msg_ = msg;
         }
         HPX_DEFINE_COMPONENT_ACTION(
-            test_server, set_message, set_message_action);
+            test_server, set_message, set_message_action)
 
         std::string msg_;
     };

--- a/libs/full/runtime_components/tests/unit/components/copy_component.cpp
+++ b/libs/full/runtime_components/tests/unit/components/copy_component.cpp
@@ -45,7 +45,7 @@ struct test_server : hpx::components::component_base<test_server>
         return *this;
     }
 
-    HPX_DEFINE_COMPONENT_ACTION(test_server, call, call_action);
+    HPX_DEFINE_COMPONENT_ACTION(test_server, call, call_action)
 
     template <typename Archive>
     void serialize(Archive&, unsigned)

--- a/libs/full/runtime_components/tests/unit/components/get_gid.cpp
+++ b/libs/full/runtime_components/tests/unit/components/get_gid.cpp
@@ -32,7 +32,7 @@ struct test_server : managed_component_base<test_server>
         HPX_TEST_NEQ(hpx::invalid_id, id);
     }
 
-    HPX_DEFINE_COMPONENT_ACTION(test_server, check_gid, check_gid_action);
+    HPX_DEFINE_COMPONENT_ACTION(test_server, check_gid, check_gid_action)
 };
 
 using server_type = managed_component<test_server>;

--- a/libs/full/runtime_components/tests/unit/components/get_ptr.cpp
+++ b/libs/full/runtime_components/tests/unit/components/get_ptr.cpp
@@ -26,7 +26,7 @@ struct test_server : hpx::components::component_base<test_server>
         return reinterpret_cast<std::size_t>(this);
     }
 
-    HPX_DEFINE_COMPONENT_ACTION(test_server, check_ptr, check_ptr_action);
+    HPX_DEFINE_COMPONENT_ACTION(test_server, check_ptr, check_ptr_action)
 };
 
 typedef hpx::components::component<test_server> server_type;

--- a/libs/full/runtime_components/tests/unit/components/inheritance_2_classes_abstract.cpp
+++ b/libs/full/runtime_components/tests/unit/components/inheritance_2_classes_abstract.cpp
@@ -40,7 +40,7 @@ struct A : hpx::components::abstract_managed_component_base<A>
     {
         return test0();
     }
-    HPX_DEFINE_COMPONENT_ACTION(A, test0_nonvirt, test0_action);
+    HPX_DEFINE_COMPONENT_ACTION(A, test0_nonvirt, test0_action)
 };
 
 HPX_REGISTER_COMPONENT_HEAP(hpx::components::managed_component<A>)
@@ -80,7 +80,7 @@ struct B
     {
         return "B";
     }
-    HPX_DEFINE_COMPONENT_ACTION(B, test1, test1_action);
+    HPX_DEFINE_COMPONENT_ACTION(B, test1, test1_action)
 };
 
 typedef hpx::components::managed_component<B> serverB_type;

--- a/libs/full/runtime_components/tests/unit/components/inheritance_2_classes_concrete.cpp
+++ b/libs/full/runtime_components/tests/unit/components/inheritance_2_classes_concrete.cpp
@@ -43,7 +43,7 @@ struct A : hpx::components::managed_component_base<A>
     {
         return test0();
     }
-    HPX_DEFINE_COMPONENT_ACTION(A, test0_nonvirt, test0_action);
+    HPX_DEFINE_COMPONENT_ACTION(A, test0_nonvirt, test0_action)
 };
 
 typedef hpx::components::managed_component<A> serverA_type;
@@ -87,7 +87,7 @@ struct B
     {
         return "B";
     }
-    HPX_DEFINE_COMPONENT_ACTION(B, test1, test1_action);
+    HPX_DEFINE_COMPONENT_ACTION(B, test1, test1_action)
 };
 
 typedef hpx::components::managed_component<B> serverB_type;

--- a/libs/full/runtime_components/tests/unit/components/inheritance_2_classes_concrete_simple.cpp
+++ b/libs/full/runtime_components/tests/unit/components/inheritance_2_classes_concrete_simple.cpp
@@ -40,7 +40,7 @@ struct A : hpx::components::component_base<A>
     {
         return test0();
     }
-    HPX_DEFINE_COMPONENT_ACTION(A, test0_nonvirt, test0_action);
+    HPX_DEFINE_COMPONENT_ACTION(A, test0_nonvirt, test0_action)
 
     hpx::naming::address get_current_address() const
     {
@@ -97,7 +97,7 @@ struct B
     {
         return "B";
     }
-    HPX_DEFINE_COMPONENT_ACTION(B, test1, test1_action);
+    HPX_DEFINE_COMPONENT_ACTION(B, test1, test1_action)
 };
 
 typedef hpx::components::component<B> serverB_type;

--- a/libs/full/runtime_components/tests/unit/components/inheritance_3_classes_1_abstract.cpp
+++ b/libs/full/runtime_components/tests/unit/components/inheritance_3_classes_1_abstract.cpp
@@ -42,7 +42,7 @@ struct A : hpx::components::abstract_managed_component_base<A>
     {
         return test0();
     }
-    HPX_DEFINE_COMPONENT_ACTION(A, test0_nonvirt, test0_action);
+    HPX_DEFINE_COMPONENT_ACTION(A, test0_nonvirt, test0_action)
 };
 
 HPX_REGISTER_COMPONENT_HEAP(hpx::components::managed_component<A>)
@@ -86,7 +86,7 @@ struct B
     {
         return test1();
     }
-    HPX_DEFINE_COMPONENT_ACTION(B, test1_nonvirt, test1_action);
+    HPX_DEFINE_COMPONENT_ACTION(B, test1_nonvirt, test1_action)
 };
 
 typedef hpx::components::managed_component<B> serverB_type;
@@ -135,7 +135,7 @@ struct C
     {
         return "C";
     }
-    HPX_DEFINE_COMPONENT_ACTION(C, test2, test2_action);
+    HPX_DEFINE_COMPONENT_ACTION(C, test2, test2_action)
 };
 
 typedef hpx::components::managed_component<C> serverC_type;

--- a/libs/full/runtime_components/tests/unit/components/inheritance_3_classes_2_abstract.cpp
+++ b/libs/full/runtime_components/tests/unit/components/inheritance_3_classes_2_abstract.cpp
@@ -42,7 +42,7 @@ struct A : hpx::components::abstract_managed_component_base<A>
     {
         return test0();
     }
-    HPX_DEFINE_COMPONENT_ACTION(A, test0_nonvirt, test0_action);
+    HPX_DEFINE_COMPONENT_ACTION(A, test0_nonvirt, test0_action)
 };
 
 HPX_REGISTER_COMPONENT_HEAP(hpx::components::managed_component<A>)
@@ -83,7 +83,7 @@ struct B
     {
         return test1();
     }
-    HPX_DEFINE_COMPONENT_ACTION(B, test1_nonvirt, test1_action);
+    HPX_DEFINE_COMPONENT_ACTION(B, test1_nonvirt, test1_action)
 };
 
 HPX_REGISTER_COMPONENT_HEAP(hpx::components::managed_component<B>)
@@ -128,7 +128,7 @@ struct C
     {
         return "C";
     }
-    HPX_DEFINE_COMPONENT_ACTION(C, test2, test2_action);
+    HPX_DEFINE_COMPONENT_ACTION(C, test2, test2_action)
 };
 
 typedef hpx::components::managed_component<C> serverC_type;

--- a/libs/full/runtime_components/tests/unit/components/inheritance_3_classes_2_concrete.cpp
+++ b/libs/full/runtime_components/tests/unit/components/inheritance_3_classes_2_concrete.cpp
@@ -45,7 +45,7 @@ struct A : hpx::components::component_base<A>
     {
         return test0();
     }
-    HPX_DEFINE_COMPONENT_ACTION(A, test0_nonvirt, test0_action);
+    HPX_DEFINE_COMPONENT_ACTION(A, test0_nonvirt, test0_action)
 
     hpx::naming::address get_current_address() const
     {
@@ -83,7 +83,7 @@ struct B : hpx::components::component_base<B>
     {
         return test1();
     }
-    HPX_DEFINE_COMPONENT_ACTION(B, test1_nonvirt, test1_action);
+    HPX_DEFINE_COMPONENT_ACTION(B, test1_nonvirt, test1_action)
 
     hpx::naming::address get_current_address() const
     {
@@ -139,7 +139,7 @@ struct C
     {
         return "C";
     }
-    HPX_DEFINE_COMPONENT_ACTION(C, test2, test2_action);
+    HPX_DEFINE_COMPONENT_ACTION(C, test2, test2_action)
 
     hpx::naming::address get_current_address() const
     {

--- a/libs/full/runtime_components/tests/unit/components/inheritance_3_classes_concrete.cpp
+++ b/libs/full/runtime_components/tests/unit/components/inheritance_3_classes_concrete.cpp
@@ -45,7 +45,7 @@ struct A : hpx::components::managed_component_base<A>
     {
         return test0();
     }
-    HPX_DEFINE_COMPONENT_ACTION(A, test0_nonvirt, test0_action);
+    HPX_DEFINE_COMPONENT_ACTION(A, test0_nonvirt, test0_action)
 };
 
 typedef hpx::components::managed_component<A> serverA_type;
@@ -93,7 +93,7 @@ struct B
     {
         return test1();
     }
-    HPX_DEFINE_COMPONENT_ACTION(B, test1_nonvirt, test1_action);
+    HPX_DEFINE_COMPONENT_ACTION(B, test1_nonvirt, test1_action)
 };
 
 typedef hpx::components::managed_component<B> serverB_type;
@@ -142,7 +142,7 @@ struct C
     {
         return "C";
     }
-    HPX_DEFINE_COMPONENT_ACTION(C, test2, test2_action);
+    HPX_DEFINE_COMPONENT_ACTION(C, test2, test2_action)
 };
 
 typedef hpx::components::managed_component<C> serverC_type;

--- a/libs/full/runtime_components/tests/unit/components/local_new.cpp
+++ b/libs/full/runtime_components/tests/unit/components/local_new.cpp
@@ -35,7 +35,7 @@ struct test_server : hpx::components::component_base<test_server>
         return hpx::find_here();
     }
 
-    HPX_DEFINE_COMPONENT_ACTION(test_server, call);
+    HPX_DEFINE_COMPONENT_ACTION(test_server, call)
 };
 
 typedef hpx::components::component<test_server> server_type;

--- a/libs/full/runtime_components/tests/unit/components/migrate_component.cpp
+++ b/libs/full/runtime_components/tests/unit/components/migrate_component.cpp
@@ -32,7 +32,7 @@ struct dummy_server : hpx::components::component_base<dummy_server>
         return hpx::find_here();
     }
 
-    HPX_DEFINE_COMPONENT_ACTION(dummy_server, call);
+    HPX_DEFINE_COMPONENT_ACTION(dummy_server, call)
 };
 
 typedef hpx::components::component<dummy_server> dummy_server_type;
@@ -164,16 +164,16 @@ struct test_server
         return *this;
     }
 
-    HPX_DEFINE_COMPONENT_ACTION(test_server, call, call_action);
-    HPX_DEFINE_COMPONENT_ACTION(test_server, busy_work, busy_work_action);
+    HPX_DEFINE_COMPONENT_ACTION(test_server, call, call_action)
+    HPX_DEFINE_COMPONENT_ACTION(test_server, busy_work, busy_work_action)
     HPX_DEFINE_COMPONENT_ACTION(
-        test_server, lazy_busy_work, lazy_busy_work_action);
+        test_server, lazy_busy_work, lazy_busy_work_action)
 
-    HPX_DEFINE_COMPONENT_ACTION(test_server, get_data, get_data_action);
+    HPX_DEFINE_COMPONENT_ACTION(test_server, get_data, get_data_action)
     HPX_DEFINE_COMPONENT_ACTION(
-        test_server, lazy_get_data, lazy_get_data_action);
+        test_server, lazy_get_data, lazy_get_data_action)
     HPX_DEFINE_COMPONENT_ACTION(
-        test_server, lazy_get_client, lazy_get_client_action);
+        test_server, lazy_get_client, lazy_get_client_action)
 
     template <typename Archive>
     void serialize(Archive& ar, unsigned)

--- a/libs/full/runtime_components/tests/unit/components/migrate_polymorphic_component.cpp
+++ b/libs/full/runtime_components/tests/unit/components/migrate_polymorphic_component.cpp
@@ -37,7 +37,7 @@ struct test_server_base
     {
         return hpx::find_here();
     }
-    HPX_DEFINE_COMPONENT_ACTION(test_server_base, call, call_action);
+    HPX_DEFINE_COMPONENT_ACTION(test_server_base, call, call_action)
 
     void busy_work() const
     {
@@ -45,7 +45,7 @@ struct test_server_base
         hpx::this_thread::sleep_for(std::chrono::seconds(1));
         HPX_TEST_NEQ(pin_count(), std::uint32_t(0));
     }
-    HPX_DEFINE_COMPONENT_ACTION(test_server_base, busy_work, busy_work_action);
+    HPX_DEFINE_COMPONENT_ACTION(test_server_base, busy_work, busy_work_action)
 
     hpx::future<void> lazy_busy_work() const
     {
@@ -60,7 +60,7 @@ struct test_server_base
         });
     }
     HPX_DEFINE_COMPONENT_ACTION(
-        test_server_base, lazy_busy_work, lazy_busy_work_action);
+        test_server_base, lazy_busy_work, lazy_busy_work_action)
 
     int get_base_data() const
     {
@@ -68,7 +68,7 @@ struct test_server_base
         return base_data_;
     }
     HPX_DEFINE_COMPONENT_ACTION(
-        test_server_base, get_base_data, get_base_data_action);
+        test_server_base, get_base_data, get_base_data_action)
 
     hpx::future<int> lazy_get_base_data() const
     {
@@ -84,7 +84,7 @@ struct test_server_base
         });
     }
     HPX_DEFINE_COMPONENT_ACTION(
-        test_server_base, lazy_get_base_data, lazy_get_base_data_action);
+        test_server_base, lazy_get_base_data, lazy_get_base_data_action)
 
     virtual int get_data() const
     {
@@ -95,7 +95,7 @@ struct test_server_base
         return get_data();
     }
     HPX_DEFINE_COMPONENT_ACTION(
-        test_server_base, get_data_nonvirt, get_data_action);
+        test_server_base, get_data_nonvirt, get_data_action)
 
     virtual hpx::future<int> lazy_get_data() const
     {
@@ -106,7 +106,7 @@ struct test_server_base
         return lazy_get_data();
     }
     HPX_DEFINE_COMPONENT_ACTION(
-        test_server_base, lazy_get_data_nonvirt, lazy_get_data_action);
+        test_server_base, lazy_get_data_nonvirt, lazy_get_data_action)
 
     // Components which should be migrated using hpx::migrate<> need to
     // be Serializable and CopyConstructable. Components can be

--- a/libs/full/runtime_components/tests/unit/components/new_.cpp
+++ b/libs/full/runtime_components/tests/unit/components/new_.cpp
@@ -24,7 +24,7 @@ struct test_server : hpx::components::component_base<test_server>
         return hpx::find_here();
     }
 
-    HPX_DEFINE_COMPONENT_ACTION(test_server, call);
+    HPX_DEFINE_COMPONENT_ACTION(test_server, call)
 };
 
 typedef hpx::components::component<test_server> server_type;

--- a/libs/full/runtime_distributed/include/hpx/runtime_distributed/server/runtime_support.hpp
+++ b/libs/full/runtime_distributed/include/hpx/runtime_distributed/server/runtime_support.hpp
@@ -192,30 +192,29 @@ namespace hpx { namespace components { namespace server {
         // Each of the exposed functions needs to be encapsulated into a action
         // type, allowing to generate all require boilerplate code for threads,
         // serialization, etc.
-        HPX_DEFINE_COMPONENT_ACTION(runtime_support, load_components);
-        HPX_DEFINE_COMPONENT_ACTION(runtime_support, call_startup_functions);
-        HPX_DEFINE_COMPONENT_ACTION(runtime_support, call_shutdown_functions);
-        HPX_DEFINE_COMPONENT_ACTION(runtime_support, shutdown);
-        HPX_DEFINE_COMPONENT_ACTION(runtime_support, shutdown_all);
+        HPX_DEFINE_COMPONENT_ACTION(runtime_support, load_components)
+        HPX_DEFINE_COMPONENT_ACTION(runtime_support, call_startup_functions)
+        HPX_DEFINE_COMPONENT_ACTION(runtime_support, call_shutdown_functions)
+        HPX_DEFINE_COMPONENT_ACTION(runtime_support, shutdown)
+        HPX_DEFINE_COMPONENT_ACTION(runtime_support, shutdown_all)
         HPX_DEFINE_COMPONENT_ACTION(
-            runtime_support, terminate_act, terminate_action);
+            runtime_support, terminate_act, terminate_action)
         HPX_DEFINE_COMPONENT_ACTION(
-            runtime_support, terminate_all_act, terminate_all_action);
+            runtime_support, terminate_all_act, terminate_all_action)
 
         // even if this is not a short/minimal action, we still execute it
         // directly to avoid a deadlock condition inside the thread manager
         // waiting for this thread to finish, which waits for the thread
         // manager to exit
-        HPX_DEFINE_COMPONENT_DIRECT_ACTION(runtime_support, get_config);
+        HPX_DEFINE_COMPONENT_DIRECT_ACTION(runtime_support, get_config)
 
-        HPX_DEFINE_COMPONENT_ACTION(runtime_support, garbage_collect);
+        HPX_DEFINE_COMPONENT_ACTION(runtime_support, garbage_collect)
+        HPX_DEFINE_COMPONENT_ACTION(runtime_support, create_performance_counter)
         HPX_DEFINE_COMPONENT_ACTION(
-            runtime_support, create_performance_counter);
-        HPX_DEFINE_COMPONENT_ACTION(
-            runtime_support, remove_from_connection_cache);
+            runtime_support, remove_from_connection_cache)
 
 #if defined(HPX_HAVE_NETWORKING)
-        HPX_DEFINE_COMPONENT_ACTION(runtime_support, dijkstra_termination);
+        HPX_DEFINE_COMPONENT_ACTION(runtime_support, dijkstra_termination)
 #endif
 
         ///////////////////////////////////////////////////////////////////////

--- a/tests/regressions/actions/components/server/action_move_semantics.hpp
+++ b/tests/regressions/actions/components/server/action_move_semantics.hpp
@@ -44,22 +44,22 @@ namespace hpx { namespace test { namespace server
 
         ///////////////////////////////////////////////////////////////////////
         HPX_DEFINE_COMPONENT_ACTION(action_move_semantics,
-            test_movable, test_movable_action);
+            test_movable, test_movable_action)
         HPX_DEFINE_COMPONENT_ACTION(action_move_semantics,
-            test_non_movable, test_non_movable_action);
+            test_non_movable, test_non_movable_action)
         HPX_DEFINE_COMPONENT_DIRECT_ACTION(action_move_semantics,
-            test_movable, test_movable_direct_action);
+            test_movable, test_movable_direct_action)
         HPX_DEFINE_COMPONENT_DIRECT_ACTION(action_move_semantics,
-            test_non_movable, test_non_movable_direct_action);
+            test_non_movable, test_non_movable_direct_action)
 
         HPX_DEFINE_COMPONENT_ACTION(action_move_semantics,
-            return_test_movable, return_test_movable_action);
+            return_test_movable, return_test_movable_action)
         HPX_DEFINE_COMPONENT_ACTION(action_move_semantics,
-            return_test_non_movable, return_test_non_movable_action);
+            return_test_non_movable, return_test_non_movable_action)
         HPX_DEFINE_COMPONENT_DIRECT_ACTION(action_move_semantics,
-            return_test_movable, return_test_movable_direct_action);
+            return_test_movable, return_test_movable_direct_action)
         HPX_DEFINE_COMPONENT_DIRECT_ACTION(action_move_semantics,
-            return_test_non_movable, return_test_non_movable_direct_action);
+            return_test_non_movable, return_test_non_movable_direct_action)
     };
 }}}
 

--- a/tests/regressions/agas/duplicate_id_registration_1596.cpp
+++ b/tests/regressions/agas/duplicate_id_registration_1596.cpp
@@ -44,7 +44,7 @@ struct ViewRegistrationListener
         hpx::util::format_to(cout, "register view at listener {1} ({2})",
             name, this) << endl;
     }
-    HPX_DEFINE_COMPONENT_ACTION(ViewRegistrationListener, register_view);
+    HPX_DEFINE_COMPONENT_ACTION(ViewRegistrationListener, register_view)
 
     string name;
 };

--- a/tests/regressions/agas/register_with_basename_1804.cpp
+++ b/tests/regressions/agas/register_with_basename_1804.cpp
@@ -36,7 +36,7 @@ struct test_server
     {
         return hpx::find_here();
     }
-    HPX_DEFINE_COMPONENT_ACTION(test_server, call, call_action);
+    HPX_DEFINE_COMPONENT_ACTION(test_server, call, call_action)
 };
 
 typedef hpx::components::component<test_server> server_type;

--- a/tests/regressions/agas/send_gid_keep_component_1624.cpp
+++ b/tests/regressions/agas/send_gid_keep_component_1624.cpp
@@ -31,8 +31,8 @@ namespace server
 
         void update();
 
-        HPX_DEFINE_COMPONENT_ACTION(view_registry, register_view);
-        HPX_DEFINE_COMPONENT_ACTION(view_registry, update);
+        HPX_DEFINE_COMPONENT_ACTION(view_registry, register_view)
+        HPX_DEFINE_COMPONENT_ACTION(view_registry, update)
 
         std::vector<hpx::naming::id_type> registered_regions_;
     };
@@ -113,8 +113,8 @@ namespace server
                 << this->get_unmanaged_id() << std::endl;
         }
 
-        HPX_DEFINE_COMPONENT_ACTION(viewer, register_region);
-        HPX_DEFINE_COMPONENT_ACTION(viewer, update);
+        HPX_DEFINE_COMPONENT_ACTION(viewer, register_region)
+        HPX_DEFINE_COMPONENT_ACTION(viewer, update)
     };
 }
 

--- a/tests/regressions/block_matrix/matrix_hpx.hpp
+++ b/tests/regressions/block_matrix/matrix_hpx.hpp
@@ -41,25 +41,25 @@ struct vector_t_server:
   vector_t_server() { HPX_ASSERT(0); }
 
   std::shared_ptr<vector_t> get_data() { return data; }
-  HPX_DEFINE_COMPONENT_ACTION(vector_t_server, get_data);
+  HPX_DEFINE_COMPONENT_ACTION(vector_t_server, get_data)
 
   double get_elt(std::ptrdiff_t i) const { return (*data)(i); }
-  HPX_DEFINE_COMPONENT_ACTION(vector_t_server, get_elt);
+  HPX_DEFINE_COMPONENT_ACTION(vector_t_server, get_elt)
   void set_elt(std::ptrdiff_t i, double x) { (*data)(i) = x; }
-  HPX_DEFINE_COMPONENT_ACTION(vector_t_server, set_elt);
+  HPX_DEFINE_COMPONENT_ACTION(vector_t_server, set_elt)
 
   void axpy(double alpha, const hpx::id_type& x);
-  HPX_DEFINE_COMPONENT_ACTION(vector_t_server, axpy);
+  HPX_DEFINE_COMPONENT_ACTION(vector_t_server, axpy)
   void copy(const hpx::id_type& x);
-  HPX_DEFINE_COMPONENT_ACTION(vector_t_server, copy);
+  HPX_DEFINE_COMPONENT_ACTION(vector_t_server, copy)
   void gemv(bool trans, double alpha, const hpx::id_type& a,
             const hpx::id_type& x,
             double beta);
-  HPX_DEFINE_COMPONENT_ACTION(vector_t_server, gemv);
+  HPX_DEFINE_COMPONENT_ACTION(vector_t_server, gemv)
   double nrm2_process() const;
-  HPX_DEFINE_COMPONENT_ACTION(vector_t_server, nrm2_process);
+  HPX_DEFINE_COMPONENT_ACTION(vector_t_server, nrm2_process)
   void scal(double alpha);
-  HPX_DEFINE_COMPONENT_ACTION(vector_t_server, scal);
+  HPX_DEFINE_COMPONENT_ACTION(vector_t_server, scal)
 };
 
 struct vector_t_client:
@@ -130,33 +130,33 @@ struct matrix_t_server:
   matrix_t_server() { HPX_ASSERT(0); }
 
   std::shared_ptr<matrix_t> get_data() { return data; }
-  HPX_DEFINE_COMPONENT_ACTION(matrix_t_server, get_data);
+  HPX_DEFINE_COMPONENT_ACTION(matrix_t_server, get_data)
 
   double get_elt(std::ptrdiff_t i, std::ptrdiff_t j) const
   {
     return (*data)(i,j);
   }
-  HPX_DEFINE_COMPONENT_ACTION(matrix_t_server, get_elt);
+  HPX_DEFINE_COMPONENT_ACTION(matrix_t_server, get_elt)
   void set_elt(std::ptrdiff_t i, std::ptrdiff_t j, double x)
   {
     (*data)(i,j) = x;
   }
-  HPX_DEFINE_COMPONENT_ACTION(matrix_t_server, set_elt);
+  HPX_DEFINE_COMPONENT_ACTION(matrix_t_server, set_elt)
 
   void axpy(bool trans, double alpha, const hpx::id_type& a);
-  HPX_DEFINE_COMPONENT_ACTION(matrix_t_server, axpy);
+  HPX_DEFINE_COMPONENT_ACTION(matrix_t_server, axpy)
   void copy(bool transa, const hpx::id_type& a);
-  HPX_DEFINE_COMPONENT_ACTION(matrix_t_server, copy);
+  HPX_DEFINE_COMPONENT_ACTION(matrix_t_server, copy)
   void gemm(bool transa, bool transb, double alpha, const hpx::id_type& a,
             const hpx::id_type& b, double beta);
-  HPX_DEFINE_COMPONENT_ACTION(matrix_t_server, gemm);
+  HPX_DEFINE_COMPONENT_ACTION(matrix_t_server, gemm)
   hpx::id_type gemv_process(bool trans, double alpha, const hpx::id_type& x)
     const;
-  HPX_DEFINE_COMPONENT_ACTION(matrix_t_server, gemv_process);
+  HPX_DEFINE_COMPONENT_ACTION(matrix_t_server, gemv_process)
   double nrm2_process() const;
-  HPX_DEFINE_COMPONENT_ACTION(matrix_t_server, nrm2_process);
+  HPX_DEFINE_COMPONENT_ACTION(matrix_t_server, nrm2_process)
   void scal(double alpha);
-  HPX_DEFINE_COMPONENT_ACTION(matrix_t_server, scal);
+  HPX_DEFINE_COMPONENT_ACTION(matrix_t_server, scal)
 };
 
 struct matrix_t_client:

--- a/tests/regressions/component/client_base_registration.cpp
+++ b/tests/regressions/component/client_base_registration.cpp
@@ -29,7 +29,7 @@ struct test_server : hpx::components::component_base<test_server>
 
     int call() const { return i_; }
 
-    HPX_DEFINE_COMPONENT_ACTION(test_server, call);
+    HPX_DEFINE_COMPONENT_ACTION(test_server, call)
 
     int i_;
 };

--- a/tests/regressions/component/new_2848.cpp
+++ b/tests/regressions/component/new_2848.cpp
@@ -25,7 +25,7 @@ struct test_server : hpx::components::component_base<test_server>
 
     hpx::id_type call() const { return hpx::find_here(); }
 
-    HPX_DEFINE_COMPONENT_ACTION(test_server, call);
+    HPX_DEFINE_COMPONENT_ACTION(test_server, call)
 
     int i_;
 };

--- a/tests/regressions/id_type_ref_counting_1032.cpp
+++ b/tests/regressions/id_type_ref_counting_1032.cpp
@@ -56,7 +56,7 @@ struct test_server1
 
     void test();
 
-    HPX_DEFINE_COMPONENT_ACTION(test_server1, test, test_action);
+    HPX_DEFINE_COMPONENT_ACTION(test_server1, test, test_action)
 
     hpx::id_type other;
     static bool alive;
@@ -84,7 +84,7 @@ struct test_server2
     }
 
     HPX_DEFINE_COMPONENT_ACTION(test_server2, create_test_server1,
-        create_test_server1_action);
+        create_test_server1_action)
 
     static bool alive;
 };

--- a/tests/regressions/lcos/after_588.cpp
+++ b/tests/regressions/lcos/after_588.cpp
@@ -29,7 +29,7 @@ struct test
     void pong()
     {}
 
-    HPX_DEFINE_COMPONENT_ACTION(test, pong);
+    HPX_DEFINE_COMPONENT_ACTION(test, pong)
 
     void ping(hpx::id_type id, std::size_t iterations)
     {
@@ -48,7 +48,7 @@ struct test
         finished = true;
     }
 
-    HPX_DEFINE_COMPONENT_ACTION(test, ping);
+    HPX_DEFINE_COMPONENT_ACTION(test, ping)
 
     std::atomic<bool> finished;
 };

--- a/tests/regressions/lcos/lifetime_588.cpp
+++ b/tests/regressions/lcos/lifetime_588.cpp
@@ -27,7 +27,7 @@ struct test_server
 
     hpx::id_type create_new(hpx::id_type const& id) const;
 
-    HPX_DEFINE_COMPONENT_ACTION(test_server, create_new, create_new_action);
+    HPX_DEFINE_COMPONENT_ACTION(test_server, create_new, create_new_action)
 };
 
 typedef hpx::components::component<test_server> server_type;

--- a/tests/regressions/lcos/lifetime_588_1.cpp
+++ b/tests/regressions/lcos/lifetime_588_1.cpp
@@ -37,7 +37,7 @@ struct foo
 
     int bar() { return 42; }
 
-    HPX_DEFINE_COMPONENT_ACTION(foo, bar, bar_action);
+    HPX_DEFINE_COMPONENT_ACTION(foo, bar, bar_action)
 };
 
 HPX_REGISTER_ACTION(foo::bar_action, foo_bar_action)

--- a/tests/regressions/lcos/receive_buffer_1733.cpp
+++ b/tests/regressions/lcos/receive_buffer_1733.cpp
@@ -52,8 +52,8 @@ public:
 
     void do_work();
 
-    HPX_DEFINE_COMPONENT_ACTION(test_receive_buffer_server, from, from_action);
-    HPX_DEFINE_COMPONENT_ACTION(test_receive_buffer_server, do_work, do_work_action);
+    HPX_DEFINE_COMPONENT_ACTION(test_receive_buffer_server, from, from_action)
+    HPX_DEFINE_COMPONENT_ACTION(test_receive_buffer_server, do_work, do_work_action)
 
 protected:
     hpx::future<std::size_t> receive(std::size_t t)

--- a/tests/regressions/lcos/shared_stated_leaked_1211.cpp
+++ b/tests/regressions/lcos/shared_stated_leaked_1211.cpp
@@ -34,7 +34,7 @@ struct test_server : hpx::components::component_base<test_server>
         return 42;
     }
 
-    HPX_DEFINE_COMPONENT_DIRECT_ACTION(test_server, test, test_action);
+    HPX_DEFINE_COMPONENT_DIRECT_ACTION(test_server, test, test_action)
 };
 
 bool test_server::destructor_called = false;

--- a/tests/unit/actions/return_future.cpp
+++ b/tests/unit/actions/return_future.cpp
@@ -30,8 +30,8 @@ struct test_server
         return hpx::make_ready_future(42);
     }
 
-    HPX_DEFINE_COMPONENT_ACTION(test_server, call_future_void, call_future_void_action);
-    HPX_DEFINE_COMPONENT_ACTION(test_server, call_future_int, call_future_int_action);
+    HPX_DEFINE_COMPONENT_ACTION(test_server, call_future_void, call_future_void_action)
+    HPX_DEFINE_COMPONENT_ACTION(test_server, call_future_int, call_future_int_action)
 };
 
 typedef hpx::components::component<test_server> server_type;

--- a/tests/unit/component/migrate_component_to_storage.cpp
+++ b/tests/unit/component/migrate_component_to_storage.cpp
@@ -43,7 +43,7 @@ struct test_server
         return hpx::find_here();
     }
 
-    HPX_DEFINE_COMPONENT_ACTION(test_server, call, call_action);
+    HPX_DEFINE_COMPONENT_ACTION(test_server, call, call_action)
 
     template <typename Archive>
     void serialize(Archive&, unsigned)

--- a/tests/unit/component/new_binpacking.cpp
+++ b/tests/unit/component/new_binpacking.cpp
@@ -23,7 +23,7 @@ struct test_server : hpx::components::component_base<test_server>
 {
     hpx::id_type call() const { return hpx::find_here(); }
 
-    HPX_DEFINE_COMPONENT_ACTION(test_server, call);
+    HPX_DEFINE_COMPONENT_ACTION(test_server, call)
 };
 
 typedef hpx::components::component<test_server> server_type;

--- a/tests/unit/component/new_colocated.cpp
+++ b/tests/unit/component/new_colocated.cpp
@@ -19,7 +19,7 @@ struct test_server : hpx::components::component_base<test_server>
 {
     hpx::id_type call() const { return hpx::find_here(); }
 
-    HPX_DEFINE_COMPONENT_ACTION(test_server, call);
+    HPX_DEFINE_COMPONENT_ACTION(test_server, call)
 };
 
 typedef hpx::components::component<test_server> server_type;

--- a/tests/unit/lcos/client_then.cpp
+++ b/tests/unit/lcos/client_then.cpp
@@ -20,7 +20,7 @@ struct test_server : hpx::components::component_base<test_server>
 {
     hpx::id_type call() const { return hpx::find_here(); }
 
-    HPX_DEFINE_COMPONENT_ACTION(test_server, call, call_action);
+    HPX_DEFINE_COMPONENT_ACTION(test_server, call, call_action)
 };
 
 typedef hpx::components::component<test_server> server_type;


### PR DESCRIPTION
This fixes compilation errors in HIP mode as there the macros are defined empty.