### PR TITLE
Workaround for CMake/Ninja generator OOM problem

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -207,7 +207,6 @@ jobs:
                 /hpx/source \
                 -G "Ninja" \
                 -DCMAKE_BUILD_TYPE=Debug \
-                -DHPX_WITH_MODULES_AS_STATIC_LIBRARIES=On \
                 -DHPX_WITH_MALLOC=system \
                 -DHPX_WITH_FETCH_ASIO=Off \
                 -DHPX_WITH_DATAPAR_VC=On \
@@ -247,7 +246,6 @@ jobs:
             cmake \
                 /hpx/source \
                 -G "Ninja" \
-                -DHPX_WITH_MODULES_AS_STATIC_LIBRARIES=On \
                 -DHPX_WITH_MALLOC=system \
                 -DHPX_WITH_FETCH_ASIO=Off \
                 -DHPX_WITH_TESTS=On \
@@ -259,7 +257,6 @@ jobs:
             cmake \
                 /hpx/source \
                 -G "Ninja" \
-                -DHPX_WITH_MODULES_AS_STATIC_LIBRARIES=On \
                 -DHPX_WITH_MALLOC=system \
                 -DHPX_WITH_FETCH_ASIO=Off \
                 -DHPX_WITH_TESTS=Off \
@@ -271,7 +268,6 @@ jobs:
             cmake \
                 /hpx/source \
                 -G "Ninja" \
-                -DHPX_WITH_MODULES_AS_STATIC_LIBRARIES=On \
                 -DHPX_WITH_MALLOC=system \
                 -DHPX_WITH_FETCH_ASIO=Off \
                 -DHPX_WITH_APEX=On \
@@ -682,7 +678,6 @@ jobs:
               # "Test Docker Image" below fails with "Illegal instruction" if VC
               # is enabled, and other machines may fail similarly.
               cmake \
-                -DHPX_WITH_MODULES_AS_STATIC_LIBRARIES=On \
                 -DHPX_WITH_DATAPAR_VC=Off .
               ninja -j2 install
           working_directory: /hpx/build

--- a/.github/workflows/linux_bors.yml
+++ b/.github/workflows/linux_bors.yml
@@ -28,7 +28,6 @@ jobs:
               -Bbuild \
               -GNinja \
               -DCMAKE_BUILD_TYPE=Debug \
-              -DHPX_WITH_MODULES_AS_STATIC_LIBRARIES=ON \
               -DHPX_WITH_MALLOC=system \
               -DHPX_WITH_FETCH_ASIO=ON \
               -DHPX_WITH_EXAMPLES=ON \

--- a/.github/workflows/linux_debug.yml
+++ b/.github/workflows/linux_debug.yml
@@ -23,7 +23,6 @@ jobs:
               -Bbuild \
               -GNinja \
               -DCMAKE_BUILD_TYPE=Debug \
-              -DHPX_WITH_MODULES_AS_STATIC_LIBRARIES=ON \
               -DHPX_WITH_MALLOC=system \
               -DHPX_WITH_FETCH_ASIO=ON \
               -DHPX_WITH_EXAMPLES=ON \

--- a/.github/workflows/linux_hip.yml
+++ b/.github/workflows/linux_hip.yml
@@ -23,7 +23,6 @@ jobs:
               -Bbuild \
               -GNinja \
               -DCMAKE_BUILD_TYPE=Debug \
-              -DHPX_WITH_MODULES_AS_STATIC_LIBRARIES=ON \
               -DHPX_WITH_MALLOC=system \
               -DHPX_WITH_FETCH_ASIO=ON \
               -DHPX_WITH_EXAMPLES=ON \

--- a/.github/workflows/linux_release_fetchcontent.yml
+++ b/.github/workflows/linux_release_fetchcontent.yml
@@ -23,7 +23,6 @@ jobs:
               -Bbuild \
               -GNinja \
               -DCMAKE_BUILD_TYPE=Release \
-              -DHPX_WITH_MODULES_AS_STATIC_LIBRARIES=ON \
               -DHPX_WITH_MALLOC=system \
               -DHPX_WITH_FETCH_ASIO=ON \
               -DHPX_WITH_APEX=ON \

--- a/.github/workflows/linux_sanitizers.yml
+++ b/.github/workflows/linux_sanitizers.yml
@@ -23,7 +23,6 @@ jobs:
               -Bbuild \
               -GNinja \
               -DCMAKE_BUILD_TYPE=Debug \
-              -DHPX_WITH_MODULES_AS_STATIC_LIBRARIES=ON \
               -DHPX_WITH_MALLOC=system \
               -DHPX_WITH_FETCH_ASIO=ON \
               -DHPX_WITH_EXAMPLES=ON \

--- a/.jenkins/cscs/env-common.sh
+++ b/.jenkins/cscs/env-common.sh
@@ -18,4 +18,3 @@ export CCACHE_MAXFILES=50000
 
 configure_extra_options+=" -DCMAKE_BUILD_TYPE=${build_type}"
 configure_extra_options+=" -DHPX_WITH_CHECK_MODULE_DEPENDENCIES=ON"
-configure_extra_options+=" -DHPX_WITH_MODULES_AS_STATIC_LIBRARIES=ON"

--- a/.jenkins/lsu/env-common.sh
+++ b/.jenkins/lsu/env-common.sh
@@ -6,4 +6,3 @@
 
 configure_extra_options+=" -DCMAKE_BUILD_TYPE=${build_type}"
 configure_extra_options+=" -DHPX_WITH_CHECK_MODULE_DEPENDENCIES=ON"
-configure_extra_options+=" -DHPX_WITH_MODULES_AS_STATIC_LIBRARIES=ON"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -368,16 +368,28 @@ else()
 endif()
 
 # ##############################################################################
-# In some some restricted environments (e.g. CircleCI, Github builders) cmake
-# runs out of memory when the modules are being built as OBJECT libraries. Set
-# this option to ON to fall back to building the modules as static libraries.
+# The cmake Ninja generator runs out of memory if the modules are being built as
+# OBJECT libraries. In this case the fallback is to build whole-archive STATIC
+# libraries.
+set(HPX_WITH_MODULES_AS_STATIC_LIBRARIES_DEFAULT ON)
+if("${CMAKE_MAKE_PROGRAM}" STREQUAL "ninja")
+  set(HPX_WITH_MODULES_AS_STATIC_LIBRARIES_DEFAULT OFF)
+endif()
+
 hpx_option(
   HPX_WITH_MODULES_AS_STATIC_LIBRARIES
   BOOL
-  "Compile HPX modules as static (whole-archive) libraries instead of OBJECT libraries (Default: OFF)"
-  OFF
+  "Compile HPX modules as STATIC (whole-archive) libraries instead of OBJECT\
+  libraries (Default: ${HPX_WITH_MODULES_AS_STATIC_LIBRARIES_DEFAULT})"
+  ${HPX_WITH_MODULES_AS_STATIC_LIBRARIES_DEFAULT}
   ADVANCED
 )
+
+if(HPX_WITH_MODULES_AS_STATIC_LIBRARIES)
+  hpx_info("Building modules as STATIC (whole-archive) libraries")
+else()
+  hpx_info("Building modules as OBJECT libraries")
+endif()
 
 # ##############################################################################
 hpx_option(

--- a/cmake/HPX_AddModule.cmake
+++ b/cmake/HPX_AddModule.cmake
@@ -193,7 +193,7 @@ function(add_hpx_module libname modulename)
     hpx_debug(${header_file})
   endforeach(header_file)
 
-  # NOTE: We optionally keep the modules as static libraries as otherwise docker
+  # NOTE: We optionally keep the modules as static libraries as otherwise cmake
   # may run out of memory.
   if(HPX_WITH_MODULES_AS_STATIC_LIBRARIES)
     set(module_library_type STATIC)
@@ -390,7 +390,6 @@ function(add_hpx_module libname modulename)
 
   # Link modules to their higher-level libraries
   if(HPX_WITH_MODULES_AS_STATIC_LIBRARIES)
-    set(_module_target hpx_${modulename})
     if(UNIX)
       if(APPLE)
         set(_module_target "-Wl,-all_load" "hpx_${modulename}")
@@ -400,12 +399,13 @@ function(add_hpx_module libname modulename)
                            "-Wl,--no-whole-archive"
         )
       endif()
-      target_link_libraries(hpx_${libname} PRIVATE ${_module_target})
     elseif(MSVC)
+      set(_module_target hpx_${modulename})
       target_link_libraries(
         hpx_${libname} PRIVATE -WHOLEARCHIVE:$<TARGET_FILE:hpx_${modulename}>
       )
     endif()
+    target_link_libraries(hpx_${libname} PRIVATE ${_module_target})
 
     get_target_property(
       _module_interface_include_directories hpx_${modulename}


### PR DESCRIPTION
CMake runs out of memory when using the Ninja generator if the modules are being built as OBJECT libraries. In this case the fallback is to build STATIC (whole-archive) libraries instead.
