### PR TITLE
Randomly delay execution of bash scripts launched by Jenkins

### DIFF
--- a/.jenkins/lsu/entry.sh
+++ b/.jenkins/lsu/entry.sh
@@ -36,6 +36,9 @@ else
     export install_hpx=0
 fi
 
+# delay things for a random amount of time
+sleep $[(RANDOM % 10) + 1]s
+
 # Start the actual build
 set +e
 sbatch \


### PR DESCRIPTION
This is an attempt to overcome the Slurm issues we're seeing on rostam (sporadic failures to launch the builders that do not seem to be reproducible).