### PR TITLE
Add check for MPICH and set the correct env to suport multi-threaded

### DIFF
--- a/libs/core/mpi_base/src/mpi_environment.cpp
+++ b/libs/core/mpi_base/src/mpi_environment.cpp
@@ -174,7 +174,7 @@ namespace hpx { namespace util {
 #if defined(MPICH) && defined(_POSIX_SOURCE)
         // This enables multi threading support in MVAPICH if requested.
         if (required == MPI_THREAD_MULTIPLE)
-            setenv("MPICH_MAX_THREAD_SAFETY", "MPICH_MAX_THREAD_SAFETY", 1);
+            setenv("MPICH_MAX_THREAD_SAFETY", "multiple", 1);
 #endif
 
 #endif

--- a/libs/core/mpi_base/src/mpi_environment.cpp
+++ b/libs/core/mpi_base/src/mpi_environment.cpp
@@ -169,6 +169,13 @@ namespace hpx { namespace util {
         if (required == MPI_THREAD_MULTIPLE)
             setenv("MV2_ENABLE_AFFINITY", "0", 1);
 #endif
+
+#if defined(MPICH) && defined(_POSIX_SOURCE)
+        // This enables multi threading support in MVAPICH if requested.
+        if (required == MPI_THREAD_MULTIPLE)
+            setenv("MPICH_MAX_THREAD_SAFETY", "MPICH_MAX_THREAD_SAFETY", 1);
+#endif
+
 #endif
 
         int retval =

--- a/libs/core/mpi_base/src/mpi_environment.cpp
+++ b/libs/core/mpi_base/src/mpi_environment.cpp
@@ -1,5 +1,6 @@
 //  Copyright (c) 2013-2015 Thomas Heller
 //  Copyright (c)      2020 Google
+//  Copyright (c)      2022 Patrick Diehl
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying


### PR DESCRIPTION
## Proposed Changes

  - If MPICH is used we set `export MPICH_MAX_THREAD_SAFETY=multiple` to activate multithreaded MPI.

## Any background context you want to provide?

This might solve some hanging, we experienced with MPI recently.

Note, this has to happen before `MPI_Init` is being called.