### PR TITLE
Modernize serialization module

### DIFF
--- a/components/containers/partitioned_vector/tests/unit/serialization_partitioned_vector.cpp
+++ b/components/containers/partitioned_vector/tests/unit/serialization_partitioned_vector.cpp
@@ -34,22 +34,20 @@ void test(T minval, T maxval)
         std::vector<char> buffer;
 
         hpx::serialization::output_archive oarchive(
-            buffer, hpx::serialization::disable_data_chunking);
+            buffer, hpx::serialization::archive_flags::disable_data_chunking);
 
         std::size_t sz = static_cast<std::size_t>(maxval - minval);
 
         hpx::partitioned_vector<T> os(sz);
         os.register_as("test_vector");
-        hpx::fill(
-            hpx::execution::par, std::begin(os), std::end(os), 42);
+        hpx::fill(hpx::execution::par, std::begin(os), std::end(os), 42);
 
         oarchive << os;
 
         hpx::serialization::input_archive iarchive(buffer);
 
         hpx::partitioned_vector<T> is(os.size());
-        hpx::fill(
-            hpx::execution::par, std::begin(is), std::end(is), 0);
+        hpx::fill(hpx::execution::par, std::begin(is), std::end(is), 0);
 
         iarchive >> is;
 

--- a/libs/core/debugging/include/hpx/debugging/demangle_helper.hpp
+++ b/libs/core/debugging/include/hpx/debugging/demangle_helper.hpp
@@ -20,7 +20,7 @@ namespace hpx { namespace util { namespace debug {
     template <typename T>
     struct demangle_helper
     {
-        char const* type_id() const
+        char const* type_id() const noexcept
         {
             return typeid(T).name();
         }
@@ -48,7 +48,7 @@ namespace hpx { namespace util { namespace debug {
         {
         }
 
-        char const* type_id() const
+        char const* type_id() const noexcept
         {
             return demangled_ ? demangled_.get() : typeid(T).name();
         }

--- a/libs/core/runtime_configuration/src/runtime_configuration.cpp
+++ b/libs/core/runtime_configuration/src/runtime_configuration.cpp
@@ -695,6 +695,8 @@ namespace hpx { namespace util {
       , argv0(argv0_)
 #endif
     {
+        (void) argv0_;
+
         pre_initialize_ini();
 
         // set global config options

--- a/libs/core/serialization/CMakeLists.txt
+++ b/libs/core/serialization/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2021 The STE||AR-Group
+# Copyright (c) 2019-2022 The STE||AR-Group
 #
 # SPDX-License-Identifier: BSL-1.0
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -9,7 +9,7 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 # Compatibility with various Boost types, introduced in V1.4.0
 hpx_option(
   HPX_SERIALIZATION_WITH_BOOST_TYPES BOOL
-  "Enable serialization of certain Boost types. (default: ON)" ON ADVANCED
+  "Enable serialization of certain Boost types. (default: OFF)" OFF ADVANCED
   CATEGORY "Modules"
   MODULE SERIALIZATION
 )
@@ -17,6 +17,21 @@ hpx_option(
 if(HPX_SERIALIZATION_WITH_BOOST_TYPES)
   hpx_add_config_define_namespace(
     DEFINE HPX_SERIALIZATION_HAVE_BOOST_TYPES NAMESPACE SERIALIZATION
+  )
+endif()
+
+# Support endian conversion on inout and output archives
+hpx_option(
+  HPX_SERIALIZATION_WITH_SUPPORTS_ENDIANESS BOOL
+  "Support endian conversion on inout and output archives. (default: OFF)" OFF
+  ADVANCED
+  CATEGORY "Modules"
+  MODULE SERIALIZATION
+)
+
+if(HPX_SERIALIZATION_WITH_SUPPORTS_ENDIANESS)
+  hpx_add_config_define_namespace(
+    DEFINE HPX_SERIALIZATION_HAVE_SUPPORTS_ENDIANESS NAMESPACE SERIALIZATION
   )
 endif()
 
@@ -69,7 +84,8 @@ if(HPX_SERIALIZATION_WITH_ALLOW_RAW_POINTER_SERIALIZATION)
 endif()
 
 # This flag can be used in systems that rely on sending constant values as part
-# of std::tuple. This option essentially casts away constness for tuple members.
+# of std::tuple. This option essentially casts away constness for tuple members
+# during de-serialization.
 hpx_option(
   HPX_SERIALIZATION_WITH_ALLOW_CONST_TUPLE_MEMBERS BOOL
   "Enable serializing std::tuple with const members. (default: OFF)" OFF

--- a/libs/core/serialization/include/hpx/serialization/basic_archive.hpp
+++ b/libs/core/serialization/include/hpx/serialization/basic_archive.hpp
@@ -1,5 +1,6 @@
 //  Copyright (c) 2014 Thomas Heller
 //  Copyright (c) 2015 Anton Bikineev
+//  Copyright (c) 2022 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -8,6 +9,7 @@
 #pragma once
 
 #include <hpx/config.hpp>
+#include <hpx/config/endian.hpp>
 #include <hpx/serialization/config/defines.hpp>
 #include <hpx/assert.hpp>
 #include <hpx/serialization/detail/extra_archive_data.hpp>
@@ -31,7 +33,7 @@ namespace hpx { namespace serialization {
         };
     }    // namespace detail
 
-    enum archive_flags
+    enum class archive_flags
     {
         no_archive_flags = 0x00000000,
         enable_compression = 0x00002000,
@@ -39,21 +41,25 @@ namespace hpx { namespace serialization {
         endian_little = 0x00008000,
         disable_array_optimization = 0x00010000,
         disable_data_chunking = 0x00020000,
-        all_archive_flags = 0x0003e000    // all of the above
+        archive_is_saving = 0x00040000,
+        archive_is_preprocessing = 0x00080000,
+        all_archive_flags = 0x000fe000    // all of the above
     };
 
-    void HPX_FORCEINLINE reverse_bytes(std::size_t size, char* address)
+#if defined(HPX_SERIALIZATION_HAVE_SUPPORTS_ENDIANESS)
+    HPX_FORCEINLINE void reverse_bytes(std::size_t size, char* address)
     {
         std::reverse(address, address + size);
     }
+#endif
 
     template <typename Archive>
     struct basic_archive
     {
-        static const std::uint64_t npos = std::uint64_t(-1);
+        static constexpr std::uint64_t npos = std::uint64_t(-1);
 
     protected:
-        basic_archive(std::uint32_t flags)
+        explicit constexpr basic_archive(std::uint32_t flags) noexcept
           : flags_(flags)
           , size_(0)
         {
@@ -68,44 +74,57 @@ namespace hpx { namespace serialization {
         template <typename T>
         void invoke(T& t)
         {
-#if !defined(HPX_SERIALIZATION_HAVE_ALLOW_RAW_POINTER_SERIALIZATION)
-            static_assert(!std::is_pointer_v<T>,
-                "HPX does not support serialization of raw pointers. "
-                "Please use smart pointers.");
-#endif
             static_cast<Archive*>(this)->invoke_impl(t);
         }
 
-        bool enable_compression() const
+        constexpr bool archive_is_saving() const noexcept
         {
-            return (flags_ & hpx::serialization::enable_compression) ? true :
-                                                                       false;
+            return bool(
+                flags_ & std::uint32_t(archive_flags::archive_is_saving));
         }
 
-        bool endian_big() const
+        constexpr bool enable_compression() const noexcept
         {
-            return (flags_ & hpx::serialization::endian_big) ? true : false;
+            return bool(
+                flags_ & std::uint32_t(archive_flags::enable_compression));
         }
 
-        bool endian_little() const
+        constexpr bool endian_big() const noexcept
         {
-            return (flags_ & hpx::serialization::endian_little) ? true : false;
+            return bool(flags_ & std::uint32_t(archive_flags::endian_big));
         }
 
-        bool disable_array_optimization() const
+        constexpr bool endian_little() const noexcept
         {
-            return (flags_ & hpx::serialization::disable_array_optimization) ?
-                true :
-                false;
+            return bool(flags_ & std::uint32_t(archive_flags::endian_little));
         }
 
-        bool disable_data_chunking() const
+#if defined(HPX_SERIALIZATION_HAVE_SUPPORTS_ENDIANESS)
+        constexpr bool endianess_differs() const noexcept
         {
-            return (flags_ & hpx::serialization::disable_data_chunking) ? true :
-                                                                          false;
+            return endian::native == endian::big ? endian_little() :
+                                                   endian_big();
+        }
+#else
+        static constexpr bool endianess_differs() noexcept
+        {
+            return false;
+        }
+#endif
+
+        constexpr bool disable_array_optimization() const noexcept
+        {
+            return bool(flags_ &
+                std::uint32_t(archive_flags::disable_array_optimization));
         }
 
-        std::uint32_t flags() const
+        constexpr bool disable_data_chunking() const noexcept
+        {
+            return bool(
+                flags_ & std::uint32_t(archive_flags::disable_data_chunking));
+        }
+
+        constexpr std::uint32_t flags() const noexcept
         {
             return flags_;
         }
@@ -113,12 +132,13 @@ namespace hpx { namespace serialization {
         // Archives can be used to do 'fake' serialization, in which case no
         // data is being stored/restored and no side effects should be
         // performed during serialization/de-serialization.
-        bool is_preprocessing() const
+        constexpr bool is_preprocessing() const noexcept
         {
-            return false;
+            return bool(flags_ &
+                std::uint32_t(archive_flags::archive_is_preprocessing));
         }
 
-        std::size_t current_pos() const
+        constexpr std::size_t current_pos() const noexcept
         {
             return size_;
         }
@@ -148,7 +168,7 @@ namespace hpx { namespace serialization {
 
         // try accessing extra data stored, might return nullptr
         template <typename T>
-        T* try_get_extra_data()
+        T* try_get_extra_data() const noexcept
         {
             return extra_data_.try_get<T>();
         }
@@ -162,17 +182,17 @@ namespace hpx { namespace serialization {
     template <typename Archive>
     inline void save_binary(Archive& ar, void const* address, std::size_t count)
     {
-        return ar.basic_archive<Archive>::save_binary(address, count);
+        ar.save_binary(address, count);
     }
 
     template <typename Archive>
     inline void load_binary(Archive& ar, void* address, std::size_t count)
     {
-        return ar.basic_archive<Archive>::load_binary(address, count);
+        ar.load_binary(address, count);
     }
 
     template <typename Archive>
-    inline std::size_t current_pos(const Archive& ar)
+    inline std::size_t current_pos(Archive const& ar) noexcept
     {
         return ar.current_pos();
     }

--- a/libs/core/serialization/include/hpx/serialization/binary_filter.hpp
+++ b/libs/core/serialization/include/hpx/serialization/binary_filter.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2007-2013 Hartmut Kaiser
+// Copyright (c) 2007-2022 Hartmut Kaiser
 // Copyright (c) 2015 Anton Bikineev
 //
 // SPDX-License-Identifier: BSL-1.0
@@ -13,11 +13,14 @@
 
 #include <cstddef>
 
-namespace hpx { namespace serialization {
+namespace hpx::serialization {
+
     ///////////////////////////////////////////////////////////////////////////
     // Base class for all serialization filters.
     struct binary_filter
     {
+        virtual ~binary_filter() = default;
+
         // compression API
         virtual void set_max_length(std::size_t size) = 0;
         virtual void save(void const* src, std::size_t src_count) = 0;
@@ -29,12 +32,10 @@ namespace hpx { namespace serialization {
             char const* buffer, std::size_t size, std::size_t buffer_size) = 0;
         virtual void load(void* dst, std::size_t dst_count) = 0;
 
-        template <class T>
+        template <typename T>
         void serialize(T& /*ar*/, unsigned)
         {
         }
         HPX_SERIALIZATION_POLYMORPHIC_ABSTRACT(binary_filter);
-
-        virtual ~binary_filter() {}
     };
-}}    // namespace hpx::serialization
+}    // namespace hpx::serialization

--- a/libs/core/serialization/include/hpx/serialization/bitset.hpp
+++ b/libs/core/serialization/include/hpx/serialization/bitset.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2016 Hartmut Kaiser
+//  Copyright (c) 2016-2022 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -9,23 +9,42 @@
 #include <hpx/serialization/serialization_fwd.hpp>
 
 #include <bitset>
+#include <climits>
 #include <cstddef>
+#include <cstdint>
 #include <string>
 
-namespace hpx { namespace serialization {
+namespace hpx::serialization {
 
     template <std::size_t N>
     void serialize(input_archive& ar, std::bitset<N>& d, unsigned)
     {
-        std::string bits;
-        ar >> bits;
-        d = std::bitset<N>(bits);
+        if constexpr (N <= CHAR_BIT * sizeof(std::uint64_t))
+        {
+            std::uint64_t bits;
+            ar >> bits;
+            d = std::bitset<N>(bits);
+        }
+        else
+        {
+            std::string bits;
+            ar >> bits;
+            d = std::bitset<N>(bits);
+        }
     }
 
     template <std::size_t N>
     void serialize(output_archive& ar, std::bitset<N> const& bs, unsigned)
     {
-        std::string const bits = bs.to_string();
-        ar << bits;
+        if constexpr (N <= CHAR_BIT * sizeof(std::uint64_t))
+        {
+            std::uint64_t const bits = bs.to_ullong();
+            ar << bits;
+        }
+        else
+        {
+            std::string const bits = bs.to_string();
+            ar << bits;
+        }
     }
-}}    // namespace hpx::serialization
+}    // namespace hpx::serialization

--- a/libs/core/serialization/include/hpx/serialization/brace_initializable.hpp
+++ b/libs/core/serialization/include/hpx/serialization/brace_initializable.hpp
@@ -1,4 +1,5 @@
 //  Copyright (c) 2019 Jan Melech
+//  Copyright (c) 2022 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -14,7 +15,7 @@
 #include <hpx/serialization/traits/brace_initializable_traits.hpp>
 #include <hpx/serialization/tuple.hpp>
 
-namespace hpx { namespace serialization {
+namespace hpx::serialization {
 
     template <typename Archive, typename T>
     void serialize_struct(Archive& archive, T& t, const unsigned int version,
@@ -170,4 +171,4 @@ namespace hpx { namespace serialization {
     {
         serialize_struct(ar, t, version, hpx::traits::detail::arity<T>());
     }
-}}    // namespace hpx::serialization
+}    // namespace hpx::serialization

--- a/libs/core/serialization/include/hpx/serialization/brace_initializable_fwd.hpp
+++ b/libs/core/serialization/include/hpx/serialization/brace_initializable_fwd.hpp
@@ -1,4 +1,5 @@
 //  Copyright (c) 2019 Jan Melech
+//  Copyright (c) 2022 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -8,8 +9,8 @@
 
 #include <hpx/config.hpp>
 
-namespace hpx { namespace serialization {
+namespace hpx::serialization {
 
     template <typename Archive, typename T>
     void serialize_struct(Archive& ar, T& t, const unsigned int);
-}}    // namespace hpx::serialization
+}    // namespace hpx::serialization

--- a/libs/core/serialization/include/hpx/serialization/complex.hpp
+++ b/libs/core/serialization/include/hpx/serialization/complex.hpp
@@ -1,4 +1,5 @@
 //  Copyright (c) 2015 Agustin Berge
+//  Copyright (c) 2021-2022 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -13,7 +14,7 @@
 #include <complex>
 #include <type_traits>
 
-namespace hpx { namespace serialization {
+namespace hpx::serialization {
 
     template <typename T>
     void serialize(input_archive& ar, std::complex<T>& c, unsigned)
@@ -29,13 +30,13 @@ namespace hpx { namespace serialization {
     {
         ar << c.real() << c.imag();
     }
-}}    // namespace hpx::serialization
+}    // namespace hpx::serialization
 
-namespace hpx { namespace traits {
+namespace hpx::traits {
 
     template <typename T>
     struct is_bitwise_serializable<std::complex<T>>
-      : is_bitwise_serializable<typename std::remove_const<T>::type>
+      : is_bitwise_serializable<std::remove_const_t<T>>
     {
     };
 
@@ -45,4 +46,4 @@ namespace hpx { namespace traits {
             !is_bitwise_serializable_v<std::complex<T>>>
     {
     };
-}}    // namespace hpx::traits
+}    // namespace hpx::traits

--- a/libs/core/serialization/include/hpx/serialization/container.hpp
+++ b/libs/core/serialization/include/hpx/serialization/container.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2019 Hartmut Kaiser
+//  Copyright (c) 2007-2022 Hartmut Kaiser
 //  Copyright (c)      2014 Thomas Heller
 //
 //  SPDX-License-Identifier: BSL-1.0
@@ -13,13 +13,13 @@
 
 #include <cstddef>
 
-namespace hpx { namespace serialization {
+namespace hpx::serialization {
 
     struct erased_output_container
     {
         virtual ~erased_output_container() = default;
 
-        virtual bool is_preprocessing() const
+        virtual bool is_preprocessing() const noexcept
         {
             return false;
         }
@@ -28,15 +28,15 @@ namespace hpx { namespace serialization {
         virtual std::size_t save_binary_chunk(
             void const* address, std::size_t count) = 0;
         virtual void reset() = 0;
-        virtual std::size_t get_num_chunks() const = 0;
+        virtual std::size_t get_num_chunks() const noexcept = 0;
         virtual void flush() = 0;
     };
 
     struct erased_input_container
     {
-        virtual ~erased_input_container() {}
+        virtual ~erased_input_container() = default;
 
-        virtual bool is_preprocessing() const
+        virtual bool is_preprocessing() const noexcept
         {
             return false;
         }
@@ -44,4 +44,4 @@ namespace hpx { namespace serialization {
         virtual void load_binary(void* address, std::size_t count) = 0;
         virtual void load_binary_chunk(void* address, std::size_t count) = 0;
     };
-}}    // namespace hpx::serialization
+}    // namespace hpx::serialization

--- a/libs/core/serialization/include/hpx/serialization/detail/constructor_selector.hpp
+++ b/libs/core/serialization/include/hpx/serialization/detail/constructor_selector.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2021 Hartmut Kaiser
+//  Copyright (c) 2021-2022 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0.
@@ -10,6 +10,7 @@
 #include <hpx/config.hpp>
 #include <hpx/serialization/detail/non_default_constructible.hpp>
 #include <hpx/serialization/serialization_fwd.hpp>
+#include <hpx/serialization/serialize.hpp>
 
 #include <memory>
 #include <type_traits>
@@ -17,7 +18,7 @@
 
 #include <hpx/config/warnings_prefix.hpp>
 
-namespace hpx { namespace serialization { namespace detail {
+namespace hpx::serialization::detail {
 
     template <typename T>
     class constructor_selector
@@ -25,32 +26,27 @@ namespace hpx { namespace serialization { namespace detail {
     public:
         static T create(input_archive& ar)
         {
-            return create(ar, std::is_default_constructible<T>());
-        }
+            if constexpr (std::is_default_constructible_v<T>)
+            {
+                T t;
+                ar.load(t);
+                return t;
+            }
+            else
+            {
+                using storage_type =
+                    std::aligned_storage_t<sizeof(T), alignof(T)>;
 
-        // is default-constructible
-        static T create(input_archive& ar, std::true_type)
-        {
-            T t;
-            ar >> t;
-            return t;
-        }
+                storage_type storage;
+                T* t = reinterpret_cast<T*>(&storage);
+                load_construct_data(ar, t, 0);
 
-        // is non-default-constructible
-        static T create(input_archive& ar, std::false_type)
-        {
-            using storage_type =
-                typename std::aligned_storage<sizeof(T), alignof(T)>::type;
+                ar.load(*t);
 
-            storage_type storage;
-            T* t = reinterpret_cast<T*>(&storage);
-            load_construct_data(ar, t, 0);
-
-            ar >> *t;
-
-            return HPX_MOVE(*t);
+                return HPX_MOVE(*t);
+            }
         }
     };
-}}}    // namespace hpx::serialization::detail
+}    // namespace hpx::serialization::detail
 
 #include <hpx/config/warnings_suffix.hpp>

--- a/libs/core/serialization/include/hpx/serialization/detail/extra_archive_data.hpp
+++ b/libs/core/serialization/include/hpx/serialization/detail/extra_archive_data.hpp
@@ -1,4 +1,5 @@
 //  Copyright (c) 2019 Thomas Heller
+//  Copyright (c) 2019-2022 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -12,7 +13,7 @@
 #include <type_traits>
 #include <utility>
 
-namespace hpx { namespace serialization { namespace detail {
+namespace hpx::serialization::detail {
 
     using extra_archive_data_id_type = void*;
 
@@ -47,7 +48,7 @@ namespace hpx { namespace serialization { namespace detail {
 
     struct extra_archive_data_node
     {
-        extra_archive_data_node() noexcept
+        constexpr extra_archive_data_node() noexcept
           : ptr_()
           , id_(nullptr)
         {
@@ -61,7 +62,7 @@ namespace hpx { namespace serialization { namespace detail {
             extra_archive_data_node&&) noexcept = default;
 
         template <typename T>
-        inline T* get() noexcept;
+        inline T* get() const noexcept;
 
         std::unique_ptr<extra_archive_data_member_base> ptr_;
         extra_archive_data_id_type id_;
@@ -69,7 +70,8 @@ namespace hpx { namespace serialization { namespace detail {
 
     struct extra_archive_data_member_base
     {
-        extra_archive_data_member_base(extra_archive_data_node&& next) noexcept
+        explicit extra_archive_data_member_base(
+            extra_archive_data_node&& next) noexcept
           : next_(HPX_MOVE(next))
         {
         }
@@ -83,24 +85,24 @@ namespace hpx { namespace serialization { namespace detail {
     template <typename T>
     struct extra_archive_data_member : extra_archive_data_member_base
     {
-        extra_archive_data_member(extra_archive_data_node&& next)
+        explicit constexpr extra_archive_data_member(
+            extra_archive_data_node&& next) noexcept
           : extra_archive_data_member_base(HPX_MOVE(next))
         {
         }
 
-        extra_archive_data_member(
-            extra_archive_data_member const&) noexcept = delete;
+        extra_archive_data_member(extra_archive_data_member const&) = delete;
         extra_archive_data_member& operator=(
-            extra_archive_data_member const&) noexcept = delete;
+            extra_archive_data_member const&) = delete;
 
-        T* value() noexcept
+        constexpr T* value() const noexcept
         {
-            return std::addressof(t_);
+            return std::addressof(const_cast<T&>(t_));
         }
 
         void reset() override
         {
-            reset_extra_archive_data(&t_);
+            reset_extra_archive_data(value());
         }
 
         T t_;
@@ -115,7 +117,7 @@ namespace hpx { namespace serialization { namespace detail {
     }
 
     template <typename T>
-    T* extra_archive_data_node::get() noexcept
+    T* extra_archive_data_node::get() const noexcept
     {
         auto id = extra_archive_data_id<T>();
         if (id_ == nullptr)
@@ -125,7 +127,6 @@ namespace hpx { namespace serialization { namespace detail {
         }
 
         HPX_ASSERT(ptr_);
-
         if (id_ == id)
         {
             return static_cast<extra_archive_data_member<T>*>(ptr_.get())
@@ -140,7 +141,7 @@ namespace hpx { namespace serialization { namespace detail {
         extra_archive_data() noexcept = default;
 
         template <typename T>
-        T& get() noexcept
+        T& get()
         {
             if (T* t = try_get<T>())
             {
@@ -153,7 +154,7 @@ namespace hpx { namespace serialization { namespace detail {
         }
 
         template <typename T>
-        T* try_get() noexcept
+        T* try_get() const noexcept
         {
             return head_.get<T>();
         }
@@ -171,5 +172,4 @@ namespace hpx { namespace serialization { namespace detail {
 
         extra_archive_data_node head_;
     };
-
-}}}    // namespace hpx::serialization::detail
+}    // namespace hpx::serialization::detail

--- a/libs/core/serialization/include/hpx/serialization/detail/pointer.hpp
+++ b/libs/core/serialization/include/hpx/serialization/detail/pointer.hpp
@@ -1,5 +1,6 @@
 //  Copyright (c) 2014 Thomas Heller
 //  Copyright (c) 2015 Anton Bikineev
+//  Copyright (c) 2022 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -28,7 +29,7 @@
 #include <type_traits>
 #include <utility>
 
-namespace hpx { namespace serialization {
+namespace hpx::serialization {
 
     ////////////////////////////////////////////////////////////////////////////
     namespace detail {
@@ -77,7 +78,7 @@ namespace hpx { namespace serialization {
         {
             using referred_type = typename Pointer::element_type;
 
-            erase_ptr_helper(Pointer&& t, Pointer& ptr)
+            erase_ptr_helper(Pointer&& t, Pointer& ptr) noexcept
               : t_(HPX_MOVE(t))
             {
                 ptr = t_;
@@ -151,16 +152,16 @@ namespace hpx { namespace serialization {
             };
 
         public:
-            using type = typename util::lazy_conditional<
-                hpx::traits::is_serialized_with_id<referred_type>::value,
+            using type = util::lazy_conditional_t<
+                hpx::traits::is_serialized_with_id_v<referred_type>,
                 hpx::util::identity<polymorphic_with_id>,
                 std::conditional<
-                    hpx::traits::is_intrusive_polymorphic<referred_type>::value,
+                    hpx::traits::is_intrusive_polymorphic_v<referred_type>,
                     intrusive_polymorphic,
-                    typename std::conditional<
-                        hpx::traits::is_nonintrusive_polymorphic<
-                            referred_type>::value,
-                        nonintrusive_polymorphic, usual>::type>>::type;
+                    std::conditional_t<
+                        hpx::traits::is_nonintrusive_polymorphic_v<
+                            referred_type>,
+                        nonintrusive_polymorphic, usual>>>;
         };
 
         template <typename Pointer>
@@ -172,7 +173,7 @@ namespace hpx { namespace serialization {
             {
                 static void call(output_archive& ar, Pointer const& ptr)
                 {
-                    const std::string name = access::get_name(ptr.get());
+                    std::string const name = access::get_name(ptr.get());
                     ar << name;
                     ar << *ptr;
                 }
@@ -183,13 +184,13 @@ namespace hpx { namespace serialization {
                 static void call(output_archive& ar, Pointer const& ptr)
                 {
 #if !defined(HPX_DEBUG)
-                    const std::uint32_t id = polymorphic_id_factory::get_id(
+                    std::uint32_t const id = polymorphic_id_factory::get_id(
                         access::get_name(ptr.get()));
                     ar << id;
                     ar << *ptr;
 #else
                     std::string const name(access::get_name(ptr.get()));
-                    const std::uint32_t id =
+                    std::uint32_t const id =
                         polymorphic_id_factory::get_id(name);
                     ar << name;
                     ar << id;
@@ -202,34 +203,26 @@ namespace hpx { namespace serialization {
             {
                 static void call(output_archive& ar, Pointer const& ptr)
                 {
-                    call(ar, *ptr);
-                }
-
-                template <typename T>
-                static typename std::enable_if<
-                    !std::is_constructible<T>::value>::type
-                call(output_archive& ar, T const& val)
-                {
-                    save_construct_data(ar, &val, 0);
-                    ar << val;
-                }
-
-                template <typename T>
-                static typename std::enable_if<
-                    std::is_constructible<T>::value>::type
-                call(output_archive& ar, T const& val)
-                {
-                    ar << val;
+                    using element_type = typename Pointer::element_type;
+                    if constexpr (std::is_constructible_v<element_type>)
+                    {
+                        ar << *ptr;
+                    }
+                    else
+                    {
+                        save_construct_data(ar, ptr.get(), 0);
+                        ar << *ptr;
+                    }
                 }
             };
 
         public:
-            using type = typename std::conditional<
-                hpx::traits::is_serialized_with_id<referred_type>::value,
+            using type = std::conditional_t<
+                hpx::traits::is_serialized_with_id_v<referred_type>,
                 polymorphic_with_id,
-                typename std::conditional<
-                    hpx::traits::is_intrusive_polymorphic<referred_type>::value,
-                    intrusive_polymorphic, usual>::type>::type;
+                std::conditional_t<
+                    hpx::traits::is_intrusive_polymorphic_v<referred_type>,
+                    intrusive_polymorphic, usual>>;
         };
 
         // forwarded serialize pointer functions
@@ -309,4 +302,4 @@ namespace hpx { namespace serialization {
         }
 
     }    // namespace detail
-}}       // namespace hpx::serialization
+}    // namespace hpx::serialization

--- a/libs/core/serialization/include/hpx/serialization/detail/polymorphic_id_factory.hpp
+++ b/libs/core/serialization/include/hpx/serialization/detail/polymorphic_id_factory.hpp
@@ -1,5 +1,6 @@
 //  Copyright (c) 2015 Anton Bikineev
 //  Copyright (c) 2014 Thomas Heller
+//  Copyright (c) 2022 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0.
@@ -26,7 +27,8 @@
 
 #include <hpx/config/warnings_prefix.hpp>
 
-namespace hpx { namespace serialization { namespace detail {
+namespace hpx::serialization::detail {
+
     class id_registry
     {
     public:
@@ -62,7 +64,7 @@ namespace hpx { namespace serialization { namespace detail {
         HPX_CORE_EXPORT static id_registry& instance();
 
     private:
-        id_registry()
+        id_registry() noexcept
           : max_id(0u)
         {
         }
@@ -121,7 +123,7 @@ namespace hpx { namespace serialization { namespace detail {
             const std::string& type_name);
 
     private:
-        polymorphic_id_factory() {}
+        polymorphic_id_factory() = default;
 
         HPX_CORE_EXPORT static polymorphic_id_factory& instance();
         HPX_CORE_EXPORT static std::string collect_registered_typenames();
@@ -154,10 +156,10 @@ namespace hpx { namespace serialization { namespace detail {
 
     template <class T>
     register_class_name<T,
-        typename std::enable_if<traits::is_serialized_with_id<T>::value>::type>
+        std::enable_if_t<traits::is_serialized_with_id<T>::value>>
         register_class_name<T,
-            typename std::enable_if<
-                traits::is_serialized_with_id<T>::value>::type>::instance;
+            std::enable_if_t<traits::is_serialized_with_id<T>::value>>::
+            instance;
 
     template <std::uint32_t desc>
     std::string get_constant_entry_name();
@@ -177,20 +179,17 @@ namespace hpx { namespace serialization { namespace detail {
     template <std::uint32_t Id>
     add_constant_entry<Id> add_constant_entry<Id>::instance;
 
-}}}    // namespace hpx::serialization::detail
+}    // namespace hpx::serialization::detail
 
 #include <hpx/config/warnings_suffix.hpp>
 
 #define HPX_SERIALIZATION_ADD_CONSTANT_ENTRY(String, Id)                       \
-    namespace hpx { namespace serialization { namespace detail {               \
-                template <>                                                    \
-                std::string get_constant_entry_name<Id>()                      \
-                {                                                              \
-                    return HPX_PP_STRINGIZE(String);                           \
-                }                                                              \
-                template add_constant_entry<Id>                                \
-                    add_constant_entry<Id>::instance;                          \
-            }                                                                  \
+    namespace hpx::serialization::detail {                                     \
+        template <>                                                            \
+        std::string get_constant_entry_name</**/ Id>()                         \
+        {                                                                      \
+            return HPX_PP_STRINGIZE(String);                                   \
         }                                                                      \
+        template add_constant_entry<Id> add_constant_entry</**/ Id>::instance; \
     }                                                                          \
     /**/

--- a/libs/core/serialization/include/hpx/serialization/detail/polymorphic_intrusive_factory.hpp
+++ b/libs/core/serialization/include/hpx/serialization/detail/polymorphic_intrusive_factory.hpp
@@ -30,7 +30,7 @@ namespace hpx { namespace serialization { namespace detail {
             std::unordered_map<std::string, ctor_type, hpx::util::jenkins_hash>;
 
     public:
-        polymorphic_intrusive_factory() {}
+        polymorphic_intrusive_factory() = default;
 
         HPX_CORE_EXPORT static polymorphic_intrusive_factory& instance();
 

--- a/libs/core/serialization/include/hpx/serialization/detail/polymorphic_nonintrusive_factory.hpp
+++ b/libs/core/serialization/include/hpx/serialization/detail/polymorphic_nonintrusive_factory.hpp
@@ -1,6 +1,7 @@
 //  Copyright (c) 2014 Thomas Heller
 //  Copyright (c) 2015 Anton Bikineev
 //  Copyright (c) 2015 Andreas Schaefer
+//  Copyright (c) 2022 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0.
@@ -30,7 +31,7 @@
 
 #include <hpx/config/warnings_prefix.hpp>
 
-namespace hpx { namespace serialization { namespace detail {
+namespace hpx::serialization::detail {
 
     ///////////////////////////////////////////////////////////////////////////
     template <typename T>
@@ -39,13 +40,13 @@ namespace hpx { namespace serialization { namespace detail {
         ;
 #else
     {
-        const char* operator()()
+        const char* operator()() const noexcept
         {
             /// If you encounter this assert while compiling code, that means that
             /// you have a HPX_REGISTER_ACTION macro somewhere in a source file,
             /// but the header in which the action is defined misses a
             /// HPX_REGISTER_ACTION_DECLARATION
-            static_assert(traits::needs_automatic_registration<T>::value,
+            static_assert(traits::needs_automatic_registration_v<T>,
                 "HPX_REGISTER_ACTION_DECLARATION missing");
             return util::debug::type_id<T>::typeid_.type_id();
         }
@@ -69,58 +70,33 @@ namespace hpx { namespace serialization { namespace detail {
     public:
         static T* create(input_archive& ar)
         {
-            return create(ar, std::is_default_constructible<T>());
-        }
+            std::unique_ptr<T> t;
 
-        // is default-constructible
-        static T* create(input_archive& ar, std::true_type)
-        {
-            T* t = new T;
-            try
+            // create new object
+            if constexpr (std::is_default_constructible_v<T>)
             {
-                load_polymorphic(
-                    t, ar, hpx::traits::is_nonintrusive_polymorphic<T>());
+                t.reset(new T);
             }
-            catch (...)
+            else
             {
-                delete t;
-                throw;
+                using storage_type =
+                    std::aligned_storage_t<sizeof(T), alignof(T)>;
+
+                t.reset(reinterpret_cast<T*>(new storage_type));
+                load_construct_data(ar, t.get(), 0);
             }
-            return t;
-        }
 
-        // is non-default-constructible
-        static T* create(input_archive& ar, std::false_type)
-        {
-            using storage_type =
-                typename std::aligned_storage<sizeof(T), alignof(T)>::type;
-
-            storage_type* storage = new storage_type;
-            T* t = reinterpret_cast<T*>(storage);
-            load_construct_data(ar, t, 0);
-
-            try
+            // de-serialize new object
+            if constexpr (hpx::traits::is_nonintrusive_polymorphic_v<T>)
             {
-                load_polymorphic(
-                    t, ar, hpx::traits::is_nonintrusive_polymorphic<T>());
+                serialize(ar, *t, 0);
             }
-            catch (...)
+            else
             {
-                delete t;
-                throw;
+                ar >> *t;
             }
-            return t;
-        }
 
-    private:
-        static void load_polymorphic(T* t, input_archive& ar, std::true_type)
-        {
-            serialize(ar, *t, 0);
-        }
-
-        static void load_polymorphic(T* t, input_archive& ar, std::false_type)
-        {
-            ar >> *t;
+            return t.release();
         }
     };
 
@@ -220,55 +196,49 @@ namespace hpx { namespace serialization { namespace detail {
     template <class T>
     register_class<T> register_class<T>::instance;
 
-}}}    // namespace hpx::serialization::detail
+}    // namespace hpx::serialization::detail
 
 #include <hpx/config/warnings_suffix.hpp>
 
 #define HPX_SERIALIZATION_REGISTER_CLASS_DECLARATION(Class)                    \
-    namespace hpx { namespace serialization { namespace detail {               \
-                template <>                                                    \
-                struct HPX_ALWAYS_EXPORT get_serialization_name<Class>;        \
-            }                                                                  \
-        }                                                                      \
+    namespace hpx::serialization::detail {                                     \
+        template <>                                                            \
+        struct HPX_ALWAYS_EXPORT get_serialization_name</**/ Class>;           \
     }                                                                          \
-    namespace hpx { namespace traits {                                         \
-            template <>                                                        \
-            struct needs_automatic_registration<action> : std::false_type      \
-            {                                                                  \
-            };                                                                 \
-        }                                                                      \
+    namespace hpx::traits {                                                    \
+        template <>                                                            \
+        struct needs_automatic_registration</**/ action> : std::false_type     \
+        {                                                                      \
+        };                                                                     \
     }                                                                          \
     HPX_TRAITS_NONINTRUSIVE_POLYMORPHIC(Class)                                 \
 /**/
 #define HPX_SERIALIZATION_REGISTER_CLASS_NAME(Class, Name)                     \
-    namespace hpx { namespace serialization { namespace detail {               \
-                template <>                                                    \
-                struct HPX_ALWAYS_EXPORT get_serialization_name<Class>         \
-                {                                                              \
-                    char const* operator()()                                   \
-                    {                                                          \
-                        return Name;                                           \
-                    }                                                          \
-                };                                                             \
-        }}                                                                     \
+    namespace hpx::serialization::detail {                                     \
+        template <>                                                            \
+        struct HPX_ALWAYS_EXPORT get_serialization_name</**/ Class>            \
+        {                                                                      \
+            constexpr char const* operator()() const noexcept                  \
+            {                                                                  \
+                return Name;                                                   \
+            }                                                                  \
+        };                                                                     \
     }                                                                          \
-    template hpx::serialization::detail::register_class<Class>                 \
-        hpx::serialization::detail::register_class<Class>::instance;           \
+    template hpx::serialization::detail::register_class</**/ Class>            \
+        hpx::serialization::detail::register_class</**/ Class>::instance;      \
 /**/
 #define HPX_SERIALIZATION_REGISTER_CLASS_NAME_TEMPLATE(                        \
     Parameters, Template, Name)                                                \
-    namespace hpx { namespace serialization { namespace detail {               \
-                HPX_PP_STRIP_PARENS(Parameters)                                \
-                struct HPX_ALWAYS_EXPORT                                       \
-                    get_serialization_name<HPX_PP_STRIP_PARENS(Template)>      \
-                {                                                              \
-                    char const* operator()()                                   \
-                    {                                                          \
-                        return Name;                                           \
-                    }                                                          \
-                };                                                             \
+    namespace hpx::serialization::detail {                                     \
+        HPX_PP_STRIP_PARENS(Parameters)                                        \
+        struct HPX_ALWAYS_EXPORT                                               \
+            get_serialization_name<HPX_PP_STRIP_PARENS(Template)>              \
+        {                                                                      \
+            constexpr char const* operator()() const noexcept                  \
+            {                                                                  \
+                return Name;                                                   \
             }                                                                  \
-        }                                                                      \
+        };                                                                     \
     }                                                                          \
 /**/
 #define HPX_SERIALIZATION_REGISTER_CLASS(Class)                                \
@@ -286,43 +256,38 @@ namespace hpx { namespace serialization { namespace detail {
     static hpx::serialization::detail::register_class<Template>                \
         hpx_register_class_instance;                                           \
                                                                                \
-    virtual hpx::serialization::detail::register_class<Template>&              \
+    virtual hpx::serialization::detail::register_class</**/ Template>&         \
     hpx_get_register_class_instance(                                           \
-        hpx::serialization::detail::register_class<Template>*) const           \
+        hpx::serialization::detail::register_class</**/ Template>*) const      \
     {                                                                          \
         return hpx_register_class_instance;                                    \
     }                                                                          \
 /**/
 #define HPX_SERIALIZATION_WITH_CUSTOM_CONSTRUCTOR(Class, Func)                 \
-    namespace hpx { namespace serialization { namespace detail {               \
-                template <>                                                    \
-                class constructor_selector_ptr<HPX_PP_STRIP_PARENS(Class)>     \
-                {                                                              \
-                public:                                                        \
-                    static Class* create(input_archive& ar)                    \
-                    {                                                          \
-                        return Func(ar);                                       \
-                    }                                                          \
-                };                                                             \
+    namespace hpx::serialization::detail {                                     \
+        template <>                                                            \
+        class constructor_selector_ptr<HPX_PP_STRIP_PARENS(Class)>             \
+        {                                                                      \
+        public:                                                                \
+            static Class* create(input_archive& ar)                            \
+            {                                                                  \
+                return Func(ar);                                               \
             }                                                                  \
-        }                                                                      \
+        };                                                                     \
     }                                                                          \
 /**/
 #define HPX_SERIALIZATION_WITH_CUSTOM_CONSTRUCTOR_TEMPLATE(                    \
     Parameters, Template, Func)                                                \
-    namespace hpx { namespace serialization { namespace detail {               \
-                HPX_PP_STRIP_PARENS(Parameters)                                \
-                class constructor_selector_ptr<HPX_PP_STRIP_PARENS(Template)>  \
-                {                                                              \
-                public:                                                        \
-                    static HPX_PP_STRIP_PARENS(Template) *                     \
-                        create(input_archive& ar)                              \
-                    {                                                          \
-                        return Func(ar,                                        \
-                            static_cast<HPX_PP_STRIP_PARENS(Template)*>(0));   \
-                    }                                                          \
-                };                                                             \
+    namespace hpx::serialization::detail {                                     \
+        HPX_PP_STRIP_PARENS(Parameters)                                        \
+        class constructor_selector_ptr<HPX_PP_STRIP_PARENS(Template)>          \
+        {                                                                      \
+        public:                                                                \
+            static HPX_PP_STRIP_PARENS(Template) * create(input_archive& ar)   \
+            {                                                                  \
+                return Func(                                                   \
+                    ar, static_cast<HPX_PP_STRIP_PARENS(Template)*>(0));       \
             }                                                                  \
-        }                                                                      \
+        };                                                                     \
     }                                                                          \
 /**/

--- a/libs/core/serialization/include/hpx/serialization/detail/preprocess_container.hpp
+++ b/libs/core/serialization/include/hpx/serialization/detail/preprocess_container.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2015-2019 Hartmut Kaiser
+//  Copyright (c) 2015-2022 Hartmut Kaiser
 //  Copyright (c) 2015-2016 Thomas Heller
 //
 //  SPDX-License-Identifier: BSL-1.0
@@ -13,33 +13,33 @@
 #include <type_traits>
 
 ////////////////////////////////////////////////////////////////////////////////
-namespace hpx { namespace serialization { namespace detail {
+namespace hpx::serialization::detail {
 
     // This 'container' is used to gather the required archive size for a given
     // type before it is serialized.
     class preprocess_container
     {
     public:
-        constexpr preprocess_container()
+        constexpr preprocess_container() noexcept
           : size_(0)
         {
         }
 
-        std::size_t size() const
+        constexpr std::size_t size() const noexcept
         {
             return size_;
         }
-        void resize(std::size_t size)
+        void resize(std::size_t size) noexcept
         {
             size_ = size;
         }
 
-        void reset()
+        void reset() noexcept
         {
             size_ = 0;
         }
 
-        static constexpr bool is_preprocessing()
+        static constexpr bool is_preprocessing() noexcept
         {
             return true;
         }
@@ -47,9 +47,9 @@ namespace hpx { namespace serialization { namespace detail {
     private:
         std::size_t size_;
     };
-}}}    // namespace hpx::serialization::detail
+}    // namespace hpx::serialization::detail
 
-namespace hpx { namespace traits {
+namespace hpx::traits {
 
     template <>
     struct serialization_access_data<
@@ -59,26 +59,27 @@ namespace hpx { namespace traits {
     {
         using preprocessing_only = std::true_type;
 
-        static constexpr bool is_preprocessing()
+        static constexpr bool is_preprocessing() noexcept
         {
             return true;
         }
 
-        static std::size_t size(
-            serialization::detail::preprocess_container const& cont)
+        static constexpr std::size_t size(
+            serialization::detail::preprocess_container const& cont) noexcept
         {
             return cont.size();
         }
 
         static void resize(serialization::detail::preprocess_container& cont,
-            std::size_t count)
+            std::size_t count) noexcept
         {
             return cont.resize(cont.size() + count);
         }
 
-        static void reset(serialization::detail::preprocess_container& cont)
+        static void reset(
+            serialization::detail::preprocess_container& cont) noexcept
         {
             cont.reset();
         }
     };
-}}    // namespace hpx::traits
+}    // namespace hpx::traits

--- a/libs/core/serialization/include/hpx/serialization/detail/raw_ptr.hpp
+++ b/libs/core/serialization/include/hpx/serialization/detail/raw_ptr.hpp
@@ -1,4 +1,5 @@
 //  Copyright (c) 2015 Anton Bikineev
+//  Copyright (c) 2022 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -9,29 +10,29 @@
 #include <hpx/serialization/detail/pointer.hpp>
 #include <hpx/serialization/serialization_fwd.hpp>
 
-namespace hpx { namespace serialization { namespace detail {
+namespace hpx::serialization::detail {
 
     template <typename T>
     struct raw_ptr_type
     {
         using element_type = T;
 
-        raw_ptr_type(T* t)
+        constexpr raw_ptr_type(T* t) noexcept
           : t(t)
         {
         }
 
-        T* get() const
+        constexpr T* get() const noexcept
         {
             return t;
         }
 
-        T& operator*() const
+        constexpr T& operator*() const noexcept
         {
             return *t;
         }
 
-        operator bool() const
+        explicit constexpr operator bool() const noexcept
         {
             return t != nullptr;
         }
@@ -43,12 +44,12 @@ namespace hpx { namespace serialization { namespace detail {
     template <typename T>
     struct raw_ptr_proxy
     {
-        raw_ptr_proxy(T*& t)
+        constexpr raw_ptr_proxy(T*& t) noexcept
           : t(t)
         {
         }
 
-        raw_ptr_proxy(T* const& t)
+        constexpr raw_ptr_proxy(T* const& t) noexcept
           : t(const_cast<T*&>(t))
         {
         }
@@ -69,13 +70,13 @@ namespace hpx { namespace serialization { namespace detail {
     };
 
     template <typename T>
-    HPX_FORCEINLINE raw_ptr_proxy<T> raw_ptr(T*& t)
+    HPX_FORCEINLINE constexpr raw_ptr_proxy<T> raw_ptr(T*& t) noexcept
     {
         return raw_ptr_proxy<T>(t);
     }
 
     template <typename T>
-    HPX_FORCEINLINE raw_ptr_proxy<T> raw_ptr(T* const& t)
+    HPX_FORCEINLINE constexpr raw_ptr_proxy<T> raw_ptr(T* const& t) noexcept
     {
         return raw_ptr_proxy<T>(t);
     }
@@ -112,4 +113,4 @@ namespace hpx { namespace serialization { namespace detail {
         t.serialize(ar);
         return ar;
     }
-}}}    // namespace hpx::serialization::detail
+}    // namespace hpx::serialization::detail

--- a/libs/core/serialization/include/hpx/serialization/detail/serialize_collection.hpp
+++ b/libs/core/serialization/include/hpx/serialization/detail/serialize_collection.hpp
@@ -17,152 +17,40 @@
 #include <type_traits>
 #include <utility>
 
-namespace hpx { namespace serialization { namespace detail {
+namespace hpx::serialization::detail {
 
     ////////////////////////////////////////////////////////////////////////////
     // not every random access sequence is reservable, so we need an explicit
     // trait to determine this
     HPX_HAS_MEMBER_XXX_TRAIT_DEF(reserve)
 
-    template <typename Collection>
-    using is_reservable = std::integral_constant<bool,
-        has_reserve<typename std::decay<Collection>::type>::value>;
-
-    ////////////////////////////////////////////////////////////////////////////
     template <typename Container>
-    HPX_FORCEINLINE
-        typename std::enable_if<!is_reservable<Container>::value>::type
-        reserve_if_container(Container&, std::size_t) noexcept
+    HPX_FORCEINLINE void reserve_if_container(Container& v,
+        std::size_t n) noexcept(!has_reserve_v<std::decay_t<Container>>)
     {
-    }
-
-    template <typename Container>
-    HPX_FORCEINLINE
-        typename std::enable_if<is_reservable<Container>::value>::type
-        reserve_if_container(Container& v, std::size_t n)
-    {
-        v.reserve(n);
+        if constexpr (has_reserve_v<std::decay_t<Container>>)
+        {
+            v.reserve(n);
+        }
     }
 
     ////////////////////////////////////////////////////////////////////////////
-    template <typename Value>
-    class save_collection_impl
-    {
-        struct default_
-        {
-            template <typename Archive, typename Collection>
-            static void call(Archive& ar, const Collection& collection)
-            {
-                for (const auto& i : collection)
-                    ar << i;
-            }
-        };
-
-        struct non_default_
-        {
-            template <typename Archive, typename Collection>
-            static void call(Archive& ar, const Collection& collection)
-            {
-                // for non-default constructible types we also provide
-                // a customization point to save any external data
-                // (in the same way as Boost.Serialization does)
-                for (const auto& i : collection)
-                {
-                    save_construct_data(ar, &i, 0);
-                    ar << i;
-                }
-            }
-        };
-
-    public:
-        using type =
-            std::conditional_t<std::is_default_constructible<Value>::value,
-                default_, non_default_>;
-    };
-
-    template <typename Value>
-    class load_collection_impl
-    {
-        struct default_
-        {
-            template <typename Archive, typename Collection>
-            static void call(Archive& ar, Collection& collection,
-                typename Collection::size_type size)
-            {
-                using value_type = typename Collection::value_type;
-
-                collection.clear();
-                reserve_if_container(collection, size);
-
-                while (size-- != 0)
-                {
-                    value_type elem;
-                    ar >> elem;
-                    collection.emplace_back(HPX_MOVE(elem));
-                }
-            }
-        };
-
-        struct non_default_
-        {
-            template <typename Archive, typename Collection>
-            static void call(Archive& ar, Collection& collection,
-                typename Collection::size_type size)
-            {
-                using value_type = typename Collection::value_type;
-
-                using is_polymorphic = std::integral_constant<bool,
-                    hpx::traits::is_intrusive_polymorphic_v<value_type> ||
-                        hpx::traits::is_nonintrusive_polymorphic_v<value_type>>;
-
-                call(ar, collection, size, is_polymorphic());
-            }
-
-            template <typename Archive, typename Collection>
-            static void call(Archive& ar, Collection& collection,
-                typename Collection::size_type size, std::false_type)
-            {
-                using value_type = typename Collection::value_type;
-
-                collection.clear();
-                reserve_if_container(collection, size);
-
-                while (size-- > 0)
-                {
-                    collection.emplace_back(
-                        constructor_selector<value_type>::create(ar));
-                }
-            }
-
-            template <typename Archive, typename Collection>
-            static void call(Archive& ar, Collection& collection,
-                typename Collection::size_type size, std::true_type)
-            {
-                using value_type = typename Collection::value_type;
-
-                collection.clear();
-                reserve_if_container(collection, size);
-
-                while (size-- > 0)
-                {
-                    std::unique_ptr<value_type> data(
-                        constructor_selector_ptr<value_type>::create(ar));
-                    collection.emplace_back(HPX_MOVE(*data));
-                }
-            }
-        };
-
-    public:
-        using type =
-            std::conditional_t<std::is_default_constructible<Value>::value,
-                default_, non_default_>;
-    };
-
     template <typename Archive, typename Collection>
     void save_collection(Archive& ar, const Collection& collection)
     {
         using value_type = typename Collection::value_type;
-        save_collection_impl<value_type>::type::call(ar, collection);
+
+        for (const auto& i : collection)
+        {
+            if constexpr (!std::is_default_constructible_v<value_type>)
+            {
+                // for non-default constructible types we also provide
+                // a customization point to save any external data
+                // (in the same way as Boost.Serialization does)
+                save_construct_data(ar, &i, 0);
+            }
+            ar << i;
+        }
     }
 
     template <typename Archive, typename Collection>
@@ -170,7 +58,39 @@ namespace hpx { namespace serialization { namespace detail {
         typename Collection::size_type size)
     {
         using value_type = typename Collection::value_type;
-        load_collection_impl<value_type>::type::call(ar, collection, size);
-    }
 
-}}}    // namespace hpx::serialization::detail
+        collection.clear();
+        reserve_if_container(collection, size);
+
+        if constexpr (std::is_default_constructible_v<value_type>)
+        {
+            while (size-- != 0)
+            {
+                value_type elem;
+                ar >> elem;
+                collection.emplace_back(HPX_MOVE(elem));
+            }
+        }
+        else
+        {
+            constexpr bool is_polymorphic =
+                hpx::traits::is_intrusive_polymorphic_v<value_type> ||
+                hpx::traits::is_nonintrusive_polymorphic_v<value_type>;
+
+            while (size-- != 0)
+            {
+                if constexpr (is_polymorphic)
+                {
+                    std::unique_ptr<value_type> data(
+                        constructor_selector_ptr<value_type>::create(ar));
+                    collection.emplace_back(HPX_MOVE(*data));
+                }
+                else
+                {
+                    collection.emplace_back(
+                        constructor_selector<value_type>::create(ar));
+                }
+            }
+        }
+    }
+}    // namespace hpx::serialization::detail

--- a/libs/core/serialization/include/hpx/serialization/dynamic_bitset.hpp
+++ b/libs/core/serialization/include/hpx/serialization/dynamic_bitset.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2016 Hartmut Kaiser
+//  Copyright (c) 2016-2022 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -6,9 +6,14 @@
 
 #pragma once
 
-#include <hpx/serialization/serialization_fwd.hpp>
+#include <hpx/config.hpp>
 
-#if defined(HPX_SERIALIZATION_HAVE_BOOST_TYPES)
+// We unconditionally support serializing boost::dynamic_bitset
+// whenever it is being used in HPX.
+// see: libs/core/topology/include/hpx/topology/cpu_mask.hpp
+#if !defined(HPX_HAVE_MAX_CPU_COUNT)
+
+#include <hpx/serialization/serialization_fwd.hpp>
 #include <hpx/serialization/vector.hpp>
 
 #include <cstddef>
@@ -16,7 +21,7 @@
 
 #include <boost/dynamic_bitset.hpp>
 
-namespace hpx { namespace serialization {
+namespace hpx::serialization {
 
     template <typename Block, typename Alloc>
     void serialize(output_archive& ar,
@@ -43,6 +48,6 @@ namespace hpx { namespace serialization {
         boost::from_block_range(blocks.begin(), blocks.end(), bs);
         bs.resize(num_bits);
     }
-}}    // namespace hpx::serialization
+}    // namespace hpx::serialization
 
 #endif

--- a/libs/core/serialization/include/hpx/serialization/exception_ptr.hpp
+++ b/libs/core/serialization/include/hpx/serialization/exception_ptr.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2020 Hartmut Kaiser
+//  Copyright (c) 2007-2022 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -12,7 +12,8 @@
 #include <exception>
 #include <functional>
 
-namespace hpx { namespace util {
+namespace hpx::util {
+
     enum exception_type
     {
         // unknown exception
@@ -43,7 +44,7 @@ namespace hpx { namespace util {
 
         std_system_error = 14
     };
-}}    // namespace hpx::util
+}    // namespace hpx::util
 
 ///////////////////////////////////////////////////////////////////////////////
 namespace hpx { namespace serialization {

--- a/libs/core/serialization/include/hpx/serialization/input_archive.hpp
+++ b/libs/core/serialization/include/hpx/serialization/input_archive.hpp
@@ -1,5 +1,6 @@
 //  Copyright (c) 2014 Thomas Heller
 //  Copyright (c) 2015 Anton Bikineev
+//  Copyright (c) 2022 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -11,6 +12,7 @@
 #include <hpx/config/endian.hpp>
 #include <hpx/serialization/config/defines.hpp>
 #include <hpx/assert.hpp>
+#include <hpx/modules/errors.hpp>
 #include <hpx/serialization/basic_archive.hpp>
 #include <hpx/serialization/detail/polymorphic_nonintrusive_factory.hpp>
 #include <hpx/serialization/detail/raw_ptr.hpp>
@@ -27,33 +29,49 @@
 
 #include <hpx/config/warnings_prefix.hpp>
 
-namespace hpx { namespace serialization {
+namespace hpx::serialization {
 
     struct input_archive : basic_archive<input_archive>
     {
         using base_type = basic_archive<input_archive>;
 
         template <typename Container>
-        input_archive(Container& buffer, std::size_t inbound_data_size = 0,
-            const std::vector<serialization_chunk>* chunks = nullptr)
+        explicit input_archive(Container& buffer,
+            std::size_t inbound_data_size = 0,
+            std::vector<serialization_chunk> const* chunks = nullptr)
           : base_type(0U)
           , buffer_(new input_container<Container>(
                 buffer, chunks, inbound_data_size))
         {
-            // endianness needs to be saves separately as it is needed to
+            // endianness needs to be saved separately as it is needed to
             // properly interpret the flags
 
             // FIXME: make bool once integer compression is implemented
             std::uint64_t endianness = 0ul;
             load(endianness);
             if (endianness)
-                this->base_type::flags_ = hpx::serialization::endian_big;
+            {
+                flags_ = std::uint32_t(
+                    hpx::serialization::archive_flags::endian_big);
+            }
 
-            // load flags sent by the other end to make sure both ends have
-            // the same assumptions about the archive format
+#if !defined(HPX_SERIALIZATION_HAVE_SUPPORTS_ENDIANESS)
+            if ((endianness && (endian::native == endian::little)) ||
+                (!endianness && (endian::native == endian::big)))
+            {
+                HPX_THROW_EXCEPTION(hpx::bad_request,
+                    "hpx::serialization::input_archive::input_archive",
+                    "Converting endianness is not supported by the "
+                    "serialization library, please reconfigure HPX with "
+                    "-DHPX_SERIALIZATION_WITH_SUPPORTS_ENDIANESS=On");
+            }
+#endif
+            // Load flags sent by the other end to make sure both ends have
+            // the same assumptions about the archive format. It is safe to
+            // overwrite the flags_ now.
             std::uint32_t flags = 0;
             load(flags);
-            this->base_type::flags_ = flags;
+            flags_ = flags;
 
             bool has_filter = false;
             load(has_filter);
@@ -67,27 +85,85 @@ namespace hpx { namespace serialization {
         }
 
         template <typename T>
-        void invoke_impl(T& t)
+        HPX_FORCEINLINE void invoke(T& t)
         {
             load(t);
         }
 
         template <typename T>
-        std::enable_if_t<!std::is_integral_v<T> && !std::is_enum_v<T>> load(
-            T& t)
+        HPX_FORCEINLINE void invoke_impl(T& t)
         {
-            using use_optimized = std::integral_constant<bool,
-                hpx::traits::is_bitwise_serializable_v<T> ||
-                    !hpx::traits::is_not_bitwise_serializable_v<T>>;
-
-            load_bitwise(t, use_optimized());
+            load(t);
         }
 
         template <typename T>
-        std::enable_if_t<std::is_integral_v<T> || std::is_enum_v<T>> load(
-            T& t)    //-V659
+        void load(T& t)
         {
-            load_integral(t, std::is_unsigned<T>());
+#if !defined(HPX_SERIALIZATION_HAVE_ALLOW_RAW_POINTER_SERIALIZATION)
+            static_assert(!std::is_pointer_v<T>,
+                "HPX does not support serialization of raw pointers. "
+                "Please use smart pointers instead.");
+#endif
+            if constexpr (!std::is_integral_v<T> && !std::is_enum_v<T>)
+            {
+                if constexpr (hpx::traits::is_bitwise_serializable_v<T> ||
+                    !hpx::traits::is_not_bitwise_serializable_v<T>)
+                {
+                    // bitwise serialization
+                    static_assert(!std::is_abstract_v<T>,
+                        "Can not bitwise serialize a class that is abstract");
+
+#if !defined(HPX_SERIALIZATION_HAVE_ALL_TYPES_ARE_BITWISE_SERIALIZABLE)
+                    if (disable_array_optimization() || endianess_differs())
+                    {
+                        access::serialize(*this, t, 0);
+                        return;
+                    }
+#else
+                    HPX_ASSERT(
+                        !(disable_array_optimization() || endianess_differs()));
+#endif
+                    load_binary(&t, sizeof(t));
+                }
+                else if constexpr (traits::is_nonintrusive_polymorphic_v<T>)
+                {
+                    // non-bitwise polymorphic serialization
+                    detail::polymorphic_nonintrusive_factory::instance().load(
+                        *this, t);
+                }
+                else
+                {
+                    // non-bitwise normal serialization
+                    access::serialize(*this, t, 0);
+                }
+            }
+#if defined(HPX_SERIALIZATION_HAVE_SUPPORTS_ENDIANESS)
+            else if constexpr (std::is_unsigned_v<T>)
+            {
+                std::uint64_t ul;
+                load_integral(ul);
+                t = static_cast<T>(ul);
+            }
+            else
+            {
+                std::int64_t l;
+                load_integral(l);
+                t = static_cast<T>(l);
+            }
+#else
+            else if constexpr (std::is_unsigned_v<T>)
+            {
+                std::uint64_t ul;
+                load_binary(&ul, sizeof(std::uint64_t));
+                t = static_cast<T>(ul);
+            }
+            else
+            {
+                std::int64_t ul;
+                load_binary(&ul, sizeof(std::int64_t));
+                t = static_cast<T>(ul);
+            }
+#endif
         }
 
         void load(float& f)
@@ -105,6 +181,16 @@ namespace hpx { namespace serialization {
             load_binary(&c, sizeof(char));
         }
 
+        void load(signed char& c)
+        {
+            load_binary(&c, sizeof(signed char));
+        }
+
+        void load(unsigned char& c)
+        {
+            load_binary(&c, sizeof(unsigned char));
+        }
+
         void load(bool& b)
         {
             load_binary(&b, sizeof(bool));
@@ -119,96 +205,33 @@ namespace hpx { namespace serialization {
         }
 #endif
 
-        std::size_t bytes_read() const
+        constexpr std::size_t bytes_read() const noexcept
         {
-            return size_;
+            return current_pos();
         }
 
         // this function is needed to avoid a MSVC linker error
-        std::size_t current_pos() const
+        constexpr std::size_t current_pos() const noexcept
         {
-            return basic_archive<input_archive>::current_pos();
+            return base_type::current_pos();
         }
 
     private:
         friend struct basic_archive<input_archive>;
 
-        template <typename T>
-        friend class array;
-
-        template <typename T>
-        void load_bitwise(T& t, std::false_type)
+#if defined(HPX_SERIALIZATION_HAVE_SUPPORTS_ENDIANESS)
+        template <typename Promoted>
+        void load_integral(Promoted& l)
         {
-            load_nonintrusively_polymorphic(
-                t, hpx::traits::is_nonintrusive_polymorphic<T>());
+            load_binary(&l, sizeof(Promoted));
+            if (endianess_differs())
+            {
+                reverse_bytes(sizeof(Promoted), reinterpret_cast<char*>(&l));
+            }
         }
-
-        template <typename T>
-        void load_bitwise(T& t, std::true_type)
-        {
-            static_assert(!std::is_abstract<T>::value,
-                "Can not bitwise serialize a class that is abstract");
-
-            bool archive_endianess_differs =
-                endian::native == endian::big ? endian_little() : endian_big();
-
-#if !defined(HPX_SERIALIZATION_HAVE_ALL_TYPES_ARE_BITWISE_SERIALIZABLE)
-            if (disable_array_optimization() || archive_endianess_differs)
-            {
-                access::serialize(*this, t, 0);
-            }
-            else
-            {
-                load_binary(&t, sizeof(t));
-            }
-#else
-            (void) archive_endianess_differs;
-            HPX_ASSERT(
-                !(disable_array_optimization() || archive_endianess_differs));
-            load_binary(&t, sizeof(t));
 #endif
-        }
 
-        template <class T>
-        void load_nonintrusively_polymorphic(T& t, std::false_type)
-        {
-            access::serialize(*this, t, 0);
-        }
-
-        template <class T>
-        void load_nonintrusively_polymorphic(T& t, std::true_type)
-        {
-            detail::polymorphic_nonintrusive_factory::instance().load(*this, t);
-        }
-
-        template <typename T>
-        void load_integral(T& val, std::false_type)
-        {
-            std::int64_t l;
-            load_integral_impl(l);
-            val = static_cast<T>(l);
-        }
-
-        template <typename T>
-        void load_integral(T& val, std::true_type)
-        {
-            std::uint64_t ul;
-            load_integral_impl(ul);
-            val = static_cast<T>(ul);
-        }
-        template <class Promoted>
-        void load_integral_impl(Promoted& l)
-        {
-            const std::size_t size = sizeof(Promoted);
-            char* cptr = reinterpret_cast<char*>(&l);    //-V206
-            load_binary(cptr, static_cast<std::size_t>(size));
-
-            const bool endianess_differs =
-                endian::native == endian::big ? endian_little() : endian_big();
-            if (endianess_differs)
-                reverse_bytes(size, cptr);
-        }
-
+    public:
         void load_binary(void* address, std::size_t count)
         {
             if (0 == count)
@@ -232,10 +255,9 @@ namespace hpx { namespace serialization {
             size_ += count;
         }
 
+    private:
         std::unique_ptr<erased_input_container> buffer_;
     };
-
-    //
-}}    // namespace hpx::serialization
+}    // namespace hpx::serialization
 
 #include <hpx/config/warnings_suffix.hpp>

--- a/libs/core/serialization/include/hpx/serialization/input_container.hpp
+++ b/libs/core/serialization/include/hpx/serialization/input_container.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2013 Hartmut Kaiser
+//  Copyright (c) 2007-2022 Hartmut Kaiser
 //  Copyright (c)      2014 Thomas Heller
 //
 //  SPDX-License-Identifier: BSL-1.0
@@ -21,7 +21,7 @@
 #include <memory>
 #include <vector>
 
-namespace hpx { namespace serialization {
+namespace hpx::serialization {
 
     template <typename Container>
     struct input_container : erased_input_container
@@ -29,28 +29,29 @@ namespace hpx { namespace serialization {
     private:
         using access_traits = traits::serialization_access_data<Container>;
 
-        std::size_t get_chunk_size(std::size_t chunk) const
+        std::size_t get_chunk_size(std::size_t chunk) const noexcept
         {
             return (*chunks_)[chunk].size_;
         }
 
-        std::uint8_t get_chunk_type(std::size_t chunk) const
+        chunk_type get_chunk_type(std::size_t chunk) const noexcept
         {
             return (*chunks_)[chunk].type_;
         }
 
-        chunk_data get_chunk_data(std::size_t chunk) const
+        chunk_data get_chunk_data(std::size_t chunk) const noexcept
         {
             return (*chunks_)[chunk].data_;
         }
 
-        std::size_t get_num_chunks() const
+        std::size_t get_num_chunks() const noexcept
         {
             return chunks_->size();
         }
 
     public:
-        input_container(Container const& cont, std::size_t inbound_data_size)
+        input_container(
+            Container const& cont, std::size_t inbound_data_size) noexcept
           : cont_(cont)
           , current_(0)
           , filter_()
@@ -63,7 +64,7 @@ namespace hpx { namespace serialization {
 
         input_container(Container const& cont,
             std::vector<serialization_chunk> const* chunks,
-            std::size_t inbound_data_size)
+            std::size_t inbound_data_size) noexcept
           : cont_(cont)
           , current_(0)
           , filter_()
@@ -79,7 +80,7 @@ namespace hpx { namespace serialization {
             }
         }
 
-        void set_filter(binary_filter* filter)    // override
+        void set_filter(binary_filter* filter) override
         {
             filter_.reset(filter);
             if (filter)
@@ -97,9 +98,9 @@ namespace hpx { namespace serialization {
             }
         }
 
-        void load_binary(void* address, std::size_t count)
+        void load_binary(void* address, std::size_t count) override
         {
-            if (filter_)
+            if (filter_ != nullptr)
             {
                 filter_->load(address, count);
             }
@@ -118,7 +119,7 @@ namespace hpx { namespace serialization {
 
                 current_ = new_current;
 
-                if (chunks_)
+                if (chunks_ != nullptr)
                 {
                     current_chunk_size_ += count;
 
@@ -144,12 +145,13 @@ namespace hpx { namespace serialization {
             }
         }
 
-        void load_binary_chunk(void* address, std::size_t count)    // override
+        void load_binary_chunk(void* address, std::size_t count) override
         {
             HPX_ASSERT((std::int64_t) count >= 0);
 
             if (chunks_ == nullptr ||
-                count < HPX_ZERO_COPY_SERIALIZATION_THRESHOLD || filter_)
+                count < HPX_ZERO_COPY_SERIALIZATION_THRESHOLD ||
+                filter_ != nullptr)
             {
                 // fall back to serialization_chunk-less archive
                 this->input_container::load_binary(address, count);
@@ -157,8 +159,8 @@ namespace hpx { namespace serialization {
             else
             {
                 HPX_ASSERT(current_chunk_ != std::size_t(-1));
-                HPX_ASSERT(
-                    get_chunk_type(current_chunk_) == chunk_type_pointer);
+                HPX_ASSERT(get_chunk_type(current_chunk_) ==
+                    chunk_type::chunk_type_pointer);
 
                 if (get_chunk_size(current_chunk_) != count)
                 {
@@ -186,4 +188,4 @@ namespace hpx { namespace serialization {
         std::size_t current_chunk_;
         std::size_t current_chunk_size_;
     };
-}}    // namespace hpx::serialization
+}    // namespace hpx::serialization

--- a/libs/core/serialization/include/hpx/serialization/intrusive_ptr.hpp
+++ b/libs/core/serialization/include/hpx/serialization/intrusive_ptr.hpp
@@ -1,5 +1,6 @@
 //  Copyright (c) 2014 Thomas Heller
 //  Copyright (c) 2014-2015 Anton Bikineev
+//  Copyright (c) 2022 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -11,14 +12,14 @@
 #pragma once
 
 #include <hpx/config.hpp>
-#include <hpx/serialization/serialization_fwd.hpp>
 
 #if defined(HPX_SERIALIZATION_HAVE_BOOST_TYPES)
 #include <hpx/serialization/detail/pointer.hpp>
+#include <hpx/serialization/serialization_fwd.hpp>
 
 #include <boost/intrusive_ptr.hpp>
 
-namespace hpx { namespace serialization {
+namespace hpx::serialization {
 
     template <typename T>
     void load(input_archive& ar, boost::intrusive_ptr<T>& ptr, unsigned)
@@ -34,6 +35,6 @@ namespace hpx { namespace serialization {
 
     HPX_SERIALIZATION_SPLIT_FREE_TEMPLATE(
         (template <typename T>), (boost::intrusive_ptr<T>) )
-}}    // namespace hpx::serialization
+}    // namespace hpx::serialization
 
 #endif

--- a/libs/core/serialization/include/hpx/serialization/list.hpp
+++ b/libs/core/serialization/include/hpx/serialization/list.hpp
@@ -1,4 +1,5 @@
 //  Copyright (c) 2015 Thomas Heller
+//  Copyright (c) 2022 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -12,7 +13,7 @@
 #include <cstdint>
 #include <list>
 
-namespace hpx { namespace serialization {
+namespace hpx::serialization {
 
     template <typename T, typename Allocator>
     void serialize(input_archive& ar, std::list<T, Allocator>& ls, unsigned)
@@ -28,7 +29,7 @@ namespace hpx { namespace serialization {
 
     template <typename T, typename Allocator>
     void serialize(
-        output_archive& ar, const std::list<T, Allocator>& ls, unsigned)
+        output_archive& ar, std::list<T, Allocator> const& ls, unsigned)
     {
         // normal save ...
         std::uint64_t size = ls.size();
@@ -38,4 +39,4 @@ namespace hpx { namespace serialization {
 
         detail::save_collection(ar, ls);
     }
-}}    // namespace hpx::serialization
+}    // namespace hpx::serialization

--- a/libs/core/serialization/include/hpx/serialization/map.hpp
+++ b/libs/core/serialization/include/hpx/serialization/map.hpp
@@ -1,4 +1,5 @@
 //  Copyright (c) 2015 Anton Bikineev
+//  Copyright (c) 2022 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -19,159 +20,124 @@
 #include <type_traits>
 #include <utility>
 
-namespace hpx {
+namespace hpx::traits {
 
-    namespace traits {
+    template <typename Key, typename Value>
+    struct is_bitwise_serializable<std::pair<Key, Value>>
+      : std::integral_constant<bool,
+            is_bitwise_serializable_v<std::remove_const_t<Key>> &&
+                is_bitwise_serializable_v<std::remove_const_t<Value>>>
+    {
+    };
 
-        template <typename Key, typename Value>
-        struct is_bitwise_serializable<std::pair<Key, Value>>
-          : std::integral_constant<bool,
-                is_bitwise_serializable_v<
-                    typename std::remove_const<Key>::type> &&
-                    is_bitwise_serializable_v<
-                        typename std::remove_const<Value>::type>>
+    template <typename Key, typename Value>
+    struct is_not_bitwise_serializable<std::pair<Key, Value>>
+      : std::integral_constant<bool,
+            !is_bitwise_serializable_v<std::pair<Key, Value>>>
+    {
+    };
+}    // namespace hpx::traits
+
+namespace hpx::serialization {
+
+    template <typename Key, typename Value>
+    void serialize(input_archive& ar, std::pair<Key, Value>& t, unsigned)
+    {
+        using pair_type = std::pair<Key, Value>;
+
+        constexpr bool optimized =
+            hpx::traits::is_bitwise_serializable_v<pair_type> ||
+            !hpx::traits::is_not_bitwise_serializable_v<pair_type>;
+
+        if constexpr (optimized)
         {
-        };
-
-        template <typename Key, typename Value>
-        struct is_not_bitwise_serializable<std::pair<Key, Value>>
-          : std::integral_constant<bool,
-                !is_bitwise_serializable_v<std::pair<Key, Value>>>
-        {
-        };
-    }    // namespace traits
-
-    namespace serialization {
-
-        namespace detail {
-
-            template <typename Key, typename Value>
-            void load_pair_impl(
-                input_archive& ar, std::pair<Key, Value>& t, std::false_type)
+#if !defined(HPX_SERIALIZATION_HAVE_ALL_TYPES_ARE_BITWISE_SERIALIZABLE)
+            if (ar.disable_array_optimization() || ar.endianess_differs())
             {
                 ar >>
-                    const_cast<typename std::add_lvalue_reference<
-                        typename std::remove_const<Key>::type>::type>(t.first);
+                    const_cast<
+                        std::add_lvalue_reference_t<std::remove_const_t<Key>>>(
+                        t.first);
                 ar >> t.second;
+                return;
             }
-
-            template <typename Key, typename Value>
-            void load_pair_impl(
-                input_archive& ar, std::pair<Key, Value>& t, std::true_type)
-            {
-                bool archive_endianess_differs = endian::native == endian::big ?
-                    ar.endian_little() :
-                    ar.endian_big();
-
-#if !defined(HPX_SERIALIZATION_HAVE_ALL_TYPES_ARE_BITWISE_SERIALIZABLE)
-                if (ar.disable_array_optimization() ||
-                    archive_endianess_differs)
-                {
-                    load_pair_impl(ar, t, std::false_type());
-                }
-                else
-                {
-                    load_binary(ar, &t, sizeof(std::pair<Key, Value>));
-                }
 #else
-                (void) archive_endianess_differs;
-                HPX_ASSERT(!(ar.disable_array_optimization() ||
-                    archive_endianess_differs));
-                load_binary(ar, &t, sizeof(std::pair<Key, Value>));
+            HPX_ASSERT(
+                !(ar.disable_array_optimization() || ar.endianess_differs()));
 #endif
-            }
+            load_binary(ar, &t, sizeof(std::pair<Key, Value>));
+        }
+        else
+        {
+            ar >> const_cast<
+                      std::add_lvalue_reference_t<std::remove_const_t<Key>>>(
+                      t.first);
+            ar >> t.second;
+        }
+    }
 
-            template <typename Key, typename Value>
-            void save_pair_impl(output_archive& ar,
-                const std::pair<Key, Value>& t, std::false_type)
+    template <typename Key, typename Value>
+    void serialize(output_archive& ar, std::pair<Key, Value> const& t, unsigned)
+    {
+        using pair_type = std::pair<Key, Value>;
+
+        constexpr bool optimized =
+            hpx::traits::is_bitwise_serializable_v<pair_type> ||
+            !hpx::traits::is_not_bitwise_serializable_v<pair_type>;
+
+        if constexpr (optimized)
+        {
+#if !defined(HPX_SERIALIZATION_HAVE_ALL_TYPES_ARE_BITWISE_SERIALIZABLE)
+            if (ar.disable_array_optimization() || ar.endianess_differs())
             {
                 ar << t.first;
                 ar << t.second;
+                return;
             }
-
-            template <typename Key, typename Value>
-            void save_pair_impl(output_archive& ar,
-                const std::pair<Key, Value>& t, std::true_type)
-            {
-                bool archive_endianess_differs = endian::native == endian::big ?
-                    ar.endian_little() :
-                    ar.endian_big();
-
-#if !defined(HPX_SERIALIZATION_HAVE_ALL_TYPES_ARE_BITWISE_SERIALIZABLE)
-                if (ar.disable_array_optimization() ||
-                    archive_endianess_differs)
-                {
-                    save_pair_impl(ar, t, std::false_type());
-                }
-                else
-                {
-                    save_binary(ar, &t, sizeof(std::pair<Key, Value>));
-                }
 #else
-                (void) archive_endianess_differs;
-                HPX_ASSERT(!(ar.disable_array_optimization() ||
-                    archive_endianess_differs));
-                save_binary(ar, &t, sizeof(std::pair<Key, Value>));
+            HPX_ASSERT(
+                !(ar.disable_array_optimization() || ar.endianess_differs()));
 #endif
-            }
-
-        }    // namespace detail
-
-        template <typename Key, typename Value>
-        void serialize(input_archive& ar, std::pair<Key, Value>& t, unsigned)
-        {
-            using pair_type = std::pair<Key, Value>;
-            using optimized = std::integral_constant<bool,
-                hpx::traits::is_bitwise_serializable_v<pair_type> ||
-                    !hpx::traits::is_not_bitwise_serializable_v<pair_type>>;
-
-            detail::load_pair_impl(ar, t, optimized());
+            save_binary(ar, &t, sizeof(std::pair<Key, Value>));
         }
-
-        template <typename Key, typename Value>
-        void serialize(
-            output_archive& ar, const std::pair<Key, Value>& t, unsigned)
+        else
         {
-            using pair_type = std::pair<Key, Value>;
-            using optimized = std::integral_constant<bool,
-                hpx::traits::is_bitwise_serializable_v<pair_type> ||
-                    !hpx::traits::is_not_bitwise_serializable_v<pair_type>>;
-
-            detail::save_pair_impl(ar, t, optimized());
+            ar << t.first;
+            ar << t.second;
         }
+    }
 
-        template <typename Key, typename Value, typename Comp, typename Alloc>
-        void serialize(
-            input_archive& ar, std::map<Key, Value, Comp, Alloc>& t, unsigned)
+    template <typename Key, typename Value, typename Comp, typename Alloc>
+    void serialize(
+        input_archive& ar, std::map<Key, Value, Comp, Alloc>& t, unsigned)
+    {
+        using value_type =
+            typename std::map<Key, Value, Comp, Alloc>::value_type;
+
+        std::uint64_t size;
+        ar >> size;    //-V128
+
+        t.clear();
+        for (std::size_t i = 0; i < size; ++i)
         {
-            using value_type =
-                typename std::map<Key, Value, Comp, Alloc>::value_type;
-
-            std::uint64_t size;
-            ar >> size;    //-V128
-
-            t.clear();
-            for (std::size_t i = 0; i < size; ++i)
-            {
-                value_type v;
-                ar >> v;
-                t.insert(t.end(), HPX_MOVE(v));
-            }
+            value_type v;
+            ar >> v;
+            t.insert(t.end(), HPX_MOVE(v));
         }
+    }
 
-        template <typename Key, typename Value, typename Comp, typename Alloc>
-        void serialize(output_archive& ar,
-            std::map<Key, Value, Comp, Alloc> const& t, unsigned)
+    template <typename Key, typename Value, typename Comp, typename Alloc>
+    void serialize(output_archive& ar,
+        std::map<Key, Value, Comp, Alloc> const& t, unsigned)
+    {
+        using value_type =
+            typename std::map<Key, Value, Comp, Alloc>::value_type;
+
+        std::uint64_t size = t.size();
+        ar << size;
+        for (value_type const& val : t)
         {
-            using value_type =
-                typename std::map<Key, Value, Comp, Alloc>::value_type;
-
-            std::uint64_t size = t.size();
-            ar << size;
-            for (value_type const& val : t)
-            {
-                ar << val;
-            }
+            ar << val;
         }
-    }    // namespace serialization
-}    // namespace hpx
+    }
+}    // namespace hpx::serialization

--- a/libs/core/serialization/include/hpx/serialization/multi_array.hpp
+++ b/libs/core/serialization/include/hpx/serialization/multi_array.hpp
@@ -6,39 +6,46 @@
 
 #pragma once
 
-#include <hpx/serialization/serialization_fwd.hpp>
+#include <hpx/config.hpp>
 
 #if defined(HPX_SERIALIZATION_HAVE_BOOST_TYPES)
 #include <hpx/serialization/array.hpp>
+#include <hpx/serialization/serialization_fwd.hpp>
 
 #include <boost/multi_array.hpp>
 
 #include <cstddef>
 
-namespace hpx { namespace serialization {
+namespace hpx::serialization {
 
     template <typename T, std::size_t N, typename Allocator>
     void load(input_archive& ar, boost::multi_array<T, N, Allocator>& marray,
         unsigned)
     {
         boost::array<std::size_t, N> shape;
-        ar& shape;
+        // clang-format off
+        ar & shape;
+        // clang-format on
 
         marray.resize(shape);
-        ar& make_array(marray.data(), marray.num_elements());
+        // clang-format off
+        ar & make_array(marray.data(), marray.num_elements());
+        // clang-format on
     }
 
     template <typename T, std::size_t N, typename Allocator>
     void save(output_archive& ar,
         const boost::multi_array<T, N, Allocator>& marray, unsigned)
     {
-        ar& make_array(marray.shape(), marray.num_dimensions());
-        ar& make_array(marray.data(), marray.num_elements());
+        // clang-format off
+        ar & make_array(marray.shape(), marray.num_dimensions());
+        ar & make_array(marray.data(), marray.num_elements());
+        // clang-format on
     }
 
     HPX_SERIALIZATION_SPLIT_FREE_TEMPLATE(
         (template <typename T, std::size_t N, typename Allocator>),
         (boost::multi_array<T, N, Allocator>) )
-}}    // namespace hpx::serialization
+}    // namespace hpx::serialization
 
 #endif

--- a/libs/core/serialization/include/hpx/serialization/optional.hpp
+++ b/libs/core/serialization/include/hpx/serialization/optional.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2017 Hartmut Kaiser
+//  Copyright (c) 2017-2022 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -12,7 +12,7 @@
 
 #include <utility>
 
-namespace hpx { namespace serialization {
+namespace hpx::serialization {
 
     template <typename T>
     void save(output_archive& ar, hpx::util::optional<T> const& o, unsigned)
@@ -43,4 +43,4 @@ namespace hpx { namespace serialization {
 
     HPX_SERIALIZATION_SPLIT_FREE_TEMPLATE(
         (template <typename T>), (hpx::util::optional<T>) )
-}}    // namespace hpx::serialization
+}    // namespace hpx::serialization

--- a/libs/core/serialization/include/hpx/serialization/output_archive.hpp
+++ b/libs/core/serialization/include/hpx/serialization/output_archive.hpp
@@ -1,5 +1,6 @@
 //  Copyright (c) 2014 Thomas Heller
 //  Copyright (c) 2015 Anton Bikineev
+//  Copyright (c) 2022 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -28,7 +29,7 @@
 
 #include <hpx/config/warnings_prefix.hpp>
 
-namespace hpx { namespace serialization {
+namespace hpx::serialization {
 
     namespace detail {
 
@@ -93,12 +94,13 @@ namespace hpx { namespace serialization {
     struct output_archive : basic_archive<output_archive>
     {
     private:
-        static std::uint32_t make_flags(
-            std::uint32_t flags, std::vector<serialization_chunk>* chunks)
+        static constexpr std::uint32_t make_flags(std::uint32_t flags,
+            std::vector<serialization_chunk>* chunks) noexcept
         {
-            return flags |
-                (chunks == nullptr ? archive_flags::disable_data_chunking :
-                                     archive_flags::no_archive_flags);
+            return flags | std::uint32_t(archive_flags::archive_is_saving) |
+                std::uint32_t(chunks == nullptr ?
+                        archive_flags::disable_data_chunking :
+                        archive_flags::no_archive_flags);
         }
 
     public:
@@ -113,17 +115,23 @@ namespace hpx { namespace serialization {
                 typename traits::serialization_access_data<
                     Container>::preprocessing_only()))
         {
+            // cache the preprocessing flag in the base class to avoid
+            // asking the buffer repeatedly
+            if (buffer_->is_preprocessing())
+            {
+                flags_ = flags_ |
+                    std::uint32_t(archive_flags::archive_is_preprocessing);
+            }
+
             // endianness needs to be saved separately as it is needed to
             // properly interpret the flags
-
             // FIXME: make bool once integer compression is implemented
-            std::uint64_t endianness =
-                this->base_type::endian_big() ? ~0ul : 0ul;
+            std::uint64_t const endianness = endian_big() ? ~0ul : 0ul;
             save(endianness);
 
             // send flags sent by the other end to make sure both ends have
             // the same assumptions about the archive format
-            save(this->flags_);
+            save(flags_);
 
             bool has_filter = filter != nullptr;
             save(has_filter);
@@ -135,26 +143,34 @@ namespace hpx { namespace serialization {
             }
         }
 
-        std::size_t bytes_written() const
+        template <typename Container>
+        output_archive(Container& buffer, archive_flags flags,
+            std::vector<serialization_chunk>* chunks = nullptr,
+            binary_filter* filter = nullptr)
+          : output_archive(buffer, std::uint32_t(flags), chunks, filter)
+        {
+        }
+
+        constexpr std::size_t bytes_written() const noexcept
         {
             return size_;
         }
 
-        std::size_t get_num_chunks() const
+        std::size_t get_num_chunks() const noexcept
         {
             return buffer_->get_num_chunks();
         }
 
         // this function is needed to avoid a MSVC linker error
-        std::size_t current_pos() const
+        constexpr std::size_t current_pos() const noexcept
         {
-            return basic_archive<output_archive>::current_pos();
+            return base_type::current_pos();
         }
 
         void reset()
         {
             buffer_->reset();
-            basic_archive<output_archive>::reset();
+            base_type::reset();
         }
 
         void flush()
@@ -162,39 +178,80 @@ namespace hpx { namespace serialization {
             buffer_->flush();
         }
 
-        bool is_preprocessing() const
-        {
-            return buffer_->is_preprocessing();
-        }
-
-    protected:
-        friend struct basic_archive<output_archive>;
-
-        template <class T>
-        friend class array;
-
         template <typename T>
-        void invoke_impl(T const& t)
+        HPX_FORCEINLINE void invoke(T const& t)
         {
             save(t);
         }
 
         template <typename T>
-        std::enable_if_t<!std::is_integral_v<T> && !std::is_enum_v<T>> save(
-            T const& t)
+        HPX_FORCEINLINE void invoke_impl(T const& t)
         {
-            using use_optimized = std::integral_constant<bool,
-                hpx::traits::is_bitwise_serializable_v<T> ||
-                    !hpx::traits::is_not_bitwise_serializable_v<T>>;
-
-            save_bitwise(t, use_optimized());
+            save(t);
         }
 
         template <typename T>
-        std::enable_if_t<std::is_integral_v<T> || std::is_enum_v<T>> save(
-            T t)    //-V659
+        void save(T const& t)
         {
-            save_integral(t, std::is_unsigned<T>());
+#if !defined(HPX_SERIALIZATION_HAVE_ALLOW_RAW_POINTER_SERIALIZATION)
+            static_assert(!std::is_pointer_v<T>,
+                "HPX does not support serialization of raw pointers. "
+                "Please use smart pointers instead.");
+#endif
+            if constexpr (!std::is_integral_v<T> && !std::is_enum_v<T>)
+            {
+                if constexpr (hpx::traits::is_bitwise_serializable_v<T> ||
+                    !hpx::traits::is_not_bitwise_serializable_v<T>)
+                {
+                    // bitwise serialization
+                    static_assert(!std::is_abstract_v<T>,
+                        "Can not bitwise serialize a class that is abstract");
+
+#if !defined(HPX_SERIALIZATION_HAVE_ALL_TYPES_ARE_BITWISE_SERIALIZABLE)
+                    if (disable_array_optimization() || endianess_differs())
+                    {
+                        access::serialize(*this, t, 0);
+                        return;
+                    }
+#else
+                    HPX_ASSERT(
+                        !(disable_array_optimization() || endianess_differs()));
+#endif
+                    save_binary(&t, sizeof(t));
+                }
+                else if constexpr (traits::is_nonintrusive_polymorphic_v<T>)
+                {
+                    // non-bitwise polymorphic serialization
+                    detail::polymorphic_nonintrusive_factory::instance().save(
+                        *this, t);
+                }
+                else
+                {
+                    // non-bitwise normal serialization
+                    access::serialize(*this, t, 0);
+                }
+            }
+#if defined(HPX_SERIALIZATION_HAVE_SUPPORTS_ENDIANESS)
+            else if constexpr (std::is_unsigned_v<T>)
+            {
+                save_integral(static_cast<std::uint64_t>(t));
+            }
+            else
+            {
+                save_integral(static_cast<std::int64_t>(t));
+            }
+#else
+            else if constexpr (std::is_unsigned_v<T>)
+            {
+                auto val = static_cast<std::uint64_t>(t);
+                save_binary(&val, sizeof(std::uint64_t));
+            }
+            else
+            {
+                auto val = static_cast<std::int64_t>(t);
+                save_binary(&val, sizeof(std::int64_t));
+            }
+#endif
         }
 
         void save(float f)
@@ -212,6 +269,16 @@ namespace hpx { namespace serialization {
             save_binary(&c, sizeof(char));
         }
 
+        void save(signed char c)
+        {
+            save_binary(&c, sizeof(signed char));
+        }
+
+        void save(unsigned char c)
+        {
+            save_binary(&c, sizeof(unsigned char));
+        }
+
         void save(bool b)
         {
             HPX_ASSERT(0 == static_cast<int>(b) || 1 == static_cast<int>(b));
@@ -226,81 +293,27 @@ namespace hpx { namespace serialization {
         }
 #endif
 
-        template <typename T>
-        void save_bitwise(T const& t, std::false_type)
+    private:
+        friend struct basic_archive<output_archive>;
+
+#if defined(HPX_SERIALIZATION_HAVE_SUPPORTS_ENDIANESS)
+        template <typename Promoted>
+        void save_integral(Promoted l)
         {
-            save_nonintrusively_polymorphic(
-                t, hpx::traits::is_nonintrusive_polymorphic<T>());
+            if (endianess_differs())
+            {
+                reverse_bytes(sizeof(Promoted), reinterpret_cast<char*>(&l));
+            }
+            save_binary(&l, sizeof(Promoted));
         }
-
-        template <typename T>
-        void save_bitwise(T const& t, std::true_type)
-        {
-            static_assert(!std::is_abstract<T>::value,
-                "Can not bitwise serialize a class that is abstract");
-
-            bool archive_endianess_differs =
-                endian::native == endian::big ? endian_little() : endian_big();
-
-#if !defined(HPX_SERIALIZATION_HAVE_ALL_TYPES_ARE_BITWISE_SERIALIZABLE)
-            if (disable_array_optimization() || archive_endianess_differs)
-            {
-                access::serialize(*this, t, 0);
-            }
-            else
-            {
-                save_binary(&t, sizeof(t));
-            }
-#else
-            (void) archive_endianess_differs;
-            HPX_ASSERT(
-                !(disable_array_optimization() || archive_endianess_differs));
-            save_binary(&t, sizeof(t));
 #endif
-        }
 
-        template <typename T>
-        void save_nonintrusively_polymorphic(T const& t, std::false_type)
-        {
-            access::serialize(*this, t, 0);
-        }
-
-        template <typename T>
-        void save_nonintrusively_polymorphic(T const& t, std::true_type)
-        {
-            detail::polymorphic_nonintrusive_factory::instance().save(*this, t);
-        }
-
-        template <typename T>
-        void save_integral(T val, std::false_type)
-        {
-            save_integral_impl(static_cast<std::int64_t>(val));
-        }
-
-        template <typename T>
-        void save_integral(T val, std::true_type)
-        {
-            save_integral_impl(static_cast<std::uint64_t>(val));
-        }
-
-        template <class Promoted>
-        void save_integral_impl(Promoted l)
-        {
-            const std::size_t size = sizeof(Promoted);
-            char* cptr = reinterpret_cast<char*>(&l);    //-V206
-
-            const bool endianess_differs =
-                endian::native == endian::big ? endian_little() : endian_big();
-            if (endianess_differs)
-                reverse_bytes(size, cptr);
-
-            save_binary(cptr, size);
-        }
-
+    public:
         void save_binary(void const* address, std::size_t count)
         {
             if (count == 0)
                 return;
+
             size_ += count;
             buffer_->save_binary(address, count);
         }
@@ -309,6 +322,7 @@ namespace hpx { namespace serialization {
         {
             if (count == 0)
                 return;
+
             if (disable_data_chunking())
             {
                 size_ += count;
@@ -321,8 +335,9 @@ namespace hpx { namespace serialization {
             }
         }
 
+    private:
         std::unique_ptr<erased_output_container> buffer_;
     };
-}}    // namespace hpx::serialization
+}    // namespace hpx::serialization
 
 #include <hpx/config/warnings_suffix.hpp>

--- a/libs/core/serialization/include/hpx/serialization/output_container.hpp
+++ b/libs/core/serialization/include/hpx/serialization/output_container.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2015 Hartmut Kaiser
+//  Copyright (c) 2007-2022 Hartmut Kaiser
 //  Copyright (c)      2014 Thomas Heller
 //  Copyright (c)      2015 Anton Bikineev
 //
@@ -17,76 +17,82 @@
 
 #include <cstddef>    // for size_t
 #include <cstdint>
-#include <cstring>    // for memcpy
 #include <memory>
 #include <type_traits>
 #include <utility>
 #include <vector>
 
-namespace hpx { namespace serialization {
+namespace hpx::serialization {
 
     namespace detail {
 
         ///////////////////////////////////////////////////////////////////////
         struct basic_chunker
         {
-            constexpr basic_chunker(std::vector<serialization_chunk>*) {}
+            explicit constexpr basic_chunker(
+                std::vector<serialization_chunk>*) noexcept
+            {
+            }
 
-            static constexpr std::size_t get_chunk_size()
+            static constexpr std::size_t get_chunk_size() noexcept
             {
                 return 0;
             }
 
-            static void set_chunk_size(std::size_t) {}
+            static constexpr void set_chunk_size(std::size_t) noexcept {}
 
-            static constexpr std::uint8_t get_chunk_type()
+            static constexpr chunk_type get_chunk_type() noexcept
             {
-                return chunk_type_index;
+                return chunk_type::chunk_type_index;
             }
 
-            static constexpr std::size_t get_chunk_data_index()
+            static constexpr std::size_t get_chunk_data_index() noexcept
             {
                 return 0;
             }
 
-            static constexpr std::size_t get_num_chunks()
+            static constexpr std::size_t get_num_chunks() noexcept
             {
                 return 1;
             }
 
-            static void push_back(serialization_chunk&& /*chunk*/) {}
+            static constexpr void push_back(
+                serialization_chunk&& /*chunk*/) noexcept
+            {
+            }
 
-            static void reset() {}
+            static constexpr void reset() noexcept {}
         };
 
         struct vector_chunker
         {
-            vector_chunker(std::vector<serialization_chunk>* chunks)
+            explicit constexpr vector_chunker(
+                std::vector<serialization_chunk>* chunks) noexcept
               : chunks_(chunks)
             {
             }
 
-            std::size_t get_chunk_size() const
+            std::size_t get_chunk_size() const noexcept
             {
                 return chunks_->back().size_;
             }
 
-            void set_chunk_size(std::size_t size)
+            void set_chunk_size(std::size_t size) noexcept
             {
                 chunks_->back().size_ = size;
             }
 
-            std::uint8_t get_chunk_type() const
+            chunk_type get_chunk_type() const noexcept
             {
                 return chunks_->back().type_;
             }
 
-            std::size_t get_chunk_data_index() const
+            std::size_t get_chunk_data_index() const noexcept
             {
                 return chunks_->back().data_.index_;
             }
 
-            std::size_t get_num_chunks() const
+            std::size_t get_num_chunks() const noexcept
             {
                 return chunks_->size();
             }
@@ -107,44 +113,45 @@ namespace hpx { namespace serialization {
 
         struct counting_chunker
         {
-            counting_chunker(std::vector<serialization_chunk>*)
+            explicit constexpr counting_chunker(
+                std::vector<serialization_chunk>*) noexcept
               : chunk_()
               , num_chunks_(0)
             {
             }
 
-            std::size_t get_chunk_size() const
+            constexpr std::size_t get_chunk_size() const noexcept
             {
                 return chunk_.size_;
             }
 
-            void set_chunk_size(std::size_t size)
+            void set_chunk_size(std::size_t size) noexcept
             {
                 chunk_.size_ = size;
             }
 
-            std::uint8_t get_chunk_type() const
+            constexpr chunk_type get_chunk_type() const noexcept
             {
                 return chunk_.type_;
             }
 
-            std::size_t get_chunk_data_index() const
+            constexpr std::size_t get_chunk_data_index() const noexcept
             {
                 return chunk_.data_.index_;
             }
 
-            std::size_t get_num_chunks() const
+            constexpr std::size_t get_num_chunks() const noexcept
             {
                 return num_chunks_;
             }
 
-            void push_back(serialization_chunk&& chunk)
+            void push_back(serialization_chunk&& chunk) noexcept
             {
                 chunk_ = HPX_MOVE(chunk);
                 ++num_chunks_;
             }
 
-            void reset()
+            void reset() noexcept
             {
                 chunk_ = create_index_chunk(0, 0);
                 num_chunks_ = 1;
@@ -161,8 +168,8 @@ namespace hpx { namespace serialization {
     {
         using access_traits = traits::serialization_access_data<Container>;
 
-        output_container(
-            Container& cont, std::vector<serialization_chunk>* chunks = nullptr)
+        explicit output_container(Container& cont,
+            std::vector<serialization_chunk>* chunks = nullptr) noexcept
           : cont_(cont)
           , current_(0)
           , chunker_(chunks)
@@ -174,11 +181,12 @@ namespace hpx { namespace serialization {
 
         void flush() override
         {
-            HPX_ASSERT(chunker_.get_chunk_type() == chunk_type_index ||
+            HPX_ASSERT(
+                chunker_.get_chunk_type() == chunk_type::chunk_type_index ||
                 chunker_.get_chunk_size() != 0);
 
             // complement current serialization_chunk by setting its length
-            if (chunker_.get_chunk_type() == chunk_type_index)
+            if (chunker_.get_chunk_type() == chunk_type::chunk_type_index)
             {
                 HPX_ASSERT(chunker_.get_chunk_size() == 0);
 
@@ -187,7 +195,7 @@ namespace hpx { namespace serialization {
             }
         }
 
-        std::size_t get_num_chunks() const override
+        std::size_t get_num_chunks() const noexcept override
         {
             return chunker_.get_num_chunks();
         }
@@ -211,7 +219,7 @@ namespace hpx { namespace serialization {
 
             // make sure there is a current serialization_chunk descriptor
             // available
-            if (chunker_.get_chunk_type() == chunk_type_pointer ||
+            if (chunker_.get_chunk_type() == chunk_type::chunk_type_pointer ||
                 chunker_.get_chunk_size() != 0)
             {
                 // add a new serialization_chunk,
@@ -241,11 +249,12 @@ namespace hpx { namespace serialization {
             }
             else
             {
-                HPX_ASSERT(chunker_.get_chunk_type() == chunk_type_index ||
+                HPX_ASSERT(
+                    chunker_.get_chunk_type() == chunk_type::chunk_type_index ||
                     chunker_.get_chunk_size() != 0);
 
                 // complement current serialization_chunk by setting its length
-                if (chunker_.get_chunk_type() == chunk_type_index)
+                if (chunker_.get_chunk_type() == chunk_type::chunk_type_index)
                 {
                     HPX_ASSERT(chunker_.get_chunk_size() == 0);
 
@@ -256,12 +265,13 @@ namespace hpx { namespace serialization {
                 // add a new serialization_chunk referring to the external
                 // buffer
                 chunker_.push_back(create_pointer_chunk(address, count));
+
                 // the container did not grow
                 return 0;
             }
         }
 
-        bool is_preprocessing() const override
+        bool is_preprocessing() const noexcept override
         {
             return access_traits::is_preprocessing();
         }
@@ -279,8 +289,8 @@ namespace hpx { namespace serialization {
         using access_traits = traits::serialization_access_data<Container>;
         using base_type = output_container<Container, Chunker>;
 
-        filtered_output_container(
-            Container& cont, std::vector<serialization_chunk>* chunks = nullptr)
+        explicit filtered_output_container(Container& cont,
+            std::vector<serialization_chunk>* chunks = nullptr) noexcept
           : base_type(cont, chunks)
           , start_compressing_at_(0)
           , filter_(nullptr)
@@ -289,7 +299,7 @@ namespace hpx { namespace serialization {
 
         ~filtered_output_container() = default;
 
-        void flush()
+        void flush() override
         {
             std::size_t written = 0;
 
@@ -318,7 +328,7 @@ namespace hpx { namespace serialization {
             access_traits::resize(this->cont_, this->current_);
         }
 
-        void set_filter(binary_filter* filter)    // override
+        void set_filter(binary_filter* filter) override
         {
             HPX_ASSERT(nullptr == filter_ && filter != nullptr);
             filter_ = filter;
@@ -327,7 +337,7 @@ namespace hpx { namespace serialization {
             this->base_type::set_filter(nullptr);
         }
 
-        void save_binary(void const* address, std::size_t count)    // override
+        void save_binary(void const* address, std::size_t count) override
         {
             HPX_ASSERT(count != 0);
 
@@ -338,7 +348,7 @@ namespace hpx { namespace serialization {
         }
 
         std::size_t save_binary_chunk(
-            void const* address, std::size_t count)    // override
+            void const* address, std::size_t count) override
         {
             if (count < HPX_ZERO_COPY_SERIALIZATION_THRESHOLD)
             {
@@ -358,4 +368,4 @@ namespace hpx { namespace serialization {
         std::size_t start_compressing_at_;
         binary_filter* filter_;
     };
-}}    // namespace hpx::serialization
+}    // namespace hpx::serialization

--- a/libs/core/serialization/include/hpx/serialization/serialization_chunk.hpp
+++ b/libs/core/serialization/include/hpx/serialization/serialization_chunk.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2013 Hartmut Kaiser
+//  Copyright (c) 2007-2022 Hartmut Kaiser
 //  Copyright (c)      2014 Thomas Heller
 //
 //  SPDX-License-Identifier: BSL-1.0
@@ -18,7 +18,7 @@
 #error This code assumes an eight-bit byte.
 #endif
 
-namespace hpx { namespace serialization {
+namespace hpx::serialization {
 
     ////////////////////////////////////////////////////////////////////////////
     union chunk_data
@@ -28,7 +28,7 @@ namespace hpx { namespace serialization {
         void* pos_;            // pointer to external data buffer //-V117
     };
 
-    enum chunk_type
+    enum class chunk_type : std::uint8_t
     {
         chunk_type_index = 0,
         chunk_type_pointer = 1
@@ -40,25 +40,25 @@ namespace hpx { namespace serialization {
         std::size_t size_;      // size of serialization_chunk starting pos_
         std::uint64_t rkey_;    // optional RDMA remote key for parcelport
                                 // operations
-        std::uint8_t type_;     // chunk_type
+        chunk_type type_;       // chunk_type
     };
 
     ///////////////////////////////////////////////////////////////////////
     inline serialization_chunk create_index_chunk(
-        std::size_t index, std::size_t size)
+        std::size_t index, std::size_t size) noexcept
     {
         serialization_chunk retval = {
-            {0}, size, 0, static_cast<std::uint8_t>(chunk_type_index)};
+            {0}, size, 0, chunk_type::chunk_type_index};
         retval.data_.index_ = index;
         return retval;
     }
 
     inline serialization_chunk create_pointer_chunk(
-        void const* pos, std::size_t size, std::uint64_t rkey = 0)
+        void const* pos, std::size_t size, std::uint64_t rkey = 0) noexcept
     {
         serialization_chunk retval = {
-            {0}, size, rkey, static_cast<std::uint8_t>(chunk_type_pointer)};
+            {0}, size, rkey, chunk_type::chunk_type_pointer};
         retval.data_.cpos_ = pos;
         return retval;
     }
-}}    // namespace hpx::serialization
+}    // namespace hpx::serialization

--- a/libs/core/serialization/include/hpx/serialization/serialize.hpp
+++ b/libs/core/serialization/include/hpx/serialization/serialize.hpp
@@ -1,5 +1,6 @@
 //  Copyright (c) 2014 Thomas Heller
 //  Copyright (c) 2014-2015 Anton Bikineev
+//  Copyright (c) 2022 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -12,35 +13,36 @@
 #include <hpx/serialization/input_archive.hpp>
 #include <hpx/serialization/output_archive.hpp>
 
-namespace hpx { namespace serialization {
+namespace hpx::serialization {
 
     template <typename T>
-    output_archive& operator<<(output_archive& ar, T const& t)
+    HPX_FORCEINLINE output_archive& operator<<(output_archive& ar, T const& t)
     {
-        ar.invoke(t);
+        ar.save(t);
         return ar;
     }
 
     template <typename T>
-    input_archive& operator>>(input_archive& ar, T& t)
+    HPX_FORCEINLINE input_archive& operator>>(input_archive& ar, T& t)
     {
-        ar.invoke(t);
+        ar.load(t);
         return ar;
     }
 
     template <typename T>
-    output_archive& operator&(output_archive& ar, T const& t)    //-V524
+    HPX_FORCEINLINE output_archive& operator&(
+        output_archive& ar, T const& t)    //-V524
     {
-        ar.invoke(t);
+        ar.save(t);
         return ar;
     }
 
     template <typename T>
-    input_archive& operator&(input_archive& ar, T& t)    //-V524
+    HPX_FORCEINLINE input_archive& operator&(input_archive& ar, T& t)    //-V524
     {
-        ar.invoke(t);
+        ar.load(t);
         return ar;
     }
-}}    // namespace hpx::serialization
+}    // namespace hpx::serialization
 
 #include <hpx/serialization/detail/polymorphic_nonintrusive_factory_impl.hpp>

--- a/libs/core/serialization/include/hpx/serialization/traits/is_bitwise_serializable.hpp
+++ b/libs/core/serialization/include/hpx/serialization/traits/is_bitwise_serializable.hpp
@@ -1,4 +1,5 @@
 //  Copyright (c) 2014 Thomas Heller
+//  Copyright (c) 2022 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -10,7 +11,7 @@
 
 #include <type_traits>
 
-namespace hpx { namespace traits {
+namespace hpx::traits {
 
 #if !defined(HPX_SERIALIZATION_HAVE_ALLOW_RAW_POINTER_SERIALIZATION)
     template <typename T>
@@ -30,14 +31,13 @@ namespace hpx { namespace traits {
     inline constexpr bool is_bitwise_serializable_v =
         is_bitwise_serializable<T>::value;
 
-}}    // namespace hpx::traits
+}    // namespace hpx::traits
 
 #define HPX_IS_BITWISE_SERIALIZABLE(T)                                         \
-    namespace hpx { namespace traits {                                         \
-            template <>                                                        \
-            struct is_bitwise_serializable<T> : std::true_type                 \
-            {                                                                  \
-            };                                                                 \
-        }                                                                      \
+    namespace hpx::traits {                                                    \
+        template <>                                                            \
+        struct is_bitwise_serializable<T> : std::true_type                     \
+        {                                                                      \
+        };                                                                     \
     }                                                                          \
     /**/

--- a/libs/core/serialization/include/hpx/serialization/traits/is_not_bitwise_serializable.hpp
+++ b/libs/core/serialization/include/hpx/serialization/traits/is_not_bitwise_serializable.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2021 Hartmut Kaiser
+//  Copyright (c) 2021-2022 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -11,7 +11,7 @@
 
 #include <type_traits>
 
-namespace hpx { namespace traits {
+namespace hpx::traits {
 
     // This traits can be used in systems that assume that all types are bitwise
     // serializable by default (like SHAD), while still enforcing normal
@@ -42,14 +42,13 @@ namespace hpx { namespace traits {
     inline constexpr bool is_not_bitwise_serializable_v = true;
 #endif
 
-}}    // namespace hpx::traits
+}    // namespace hpx::traits
 
 #define HPX_IS_NOT_BITWISE_SERIALIZABLE(T)                                     \
-    namespace hpx { namespace traits {                                         \
-            template <>                                                        \
-            struct is_not_bitwise_serializable<T> : std::true_type             \
-            {                                                                  \
-            };                                                                 \
-        }                                                                      \
+    namespace hpx::traits {                                                    \
+        template <>                                                            \
+        struct is_not_bitwise_serializable<T> : std::true_type                 \
+        {                                                                      \
+        };                                                                     \
     }                                                                          \
     /**/

--- a/libs/core/serialization/include/hpx/serialization/traits/needs_automatic_registration.hpp
+++ b/libs/core/serialization/include/hpx/serialization/traits/needs_automatic_registration.hpp
@@ -1,5 +1,5 @@
 //  Copyright (c) 2013-2014 Thomas Heller
-//  Copyright (c) 2013 Hartmut Kaiser
+//  Copyright (c) 2013-2022 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -9,7 +9,7 @@
 
 #include <type_traits>
 
-namespace hpx { namespace traits {
+namespace hpx::traits {
 
     // This trait is used to decide whether a class (or specialization) is
     // required to automatically register to the action factory
@@ -17,4 +17,8 @@ namespace hpx { namespace traits {
     struct needs_automatic_registration : std::true_type
     {
     };
-}}    // namespace hpx::traits
+
+    template <typename T>
+    inline constexpr bool needs_automatic_registration_v =
+        needs_automatic_registration<T>::value;
+}    // namespace hpx::traits

--- a/libs/core/serialization/include/hpx/serialization/traits/polymorphic_traits.hpp
+++ b/libs/core/serialization/include/hpx/serialization/traits/polymorphic_traits.hpp
@@ -1,4 +1,5 @@
 //  Copyright (c) 2015 Anton Bikineev
+//  Copyright (c) 2022 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0.
@@ -13,7 +14,7 @@
 
 #include <type_traits>
 
-namespace hpx { namespace traits {
+namespace hpx::traits {
 
     namespace detail {
 
@@ -47,46 +48,42 @@ namespace hpx { namespace traits {
     template <typename T>
     inline constexpr bool is_serialized_with_id_v =
         is_serialized_with_id<T>::value;
-}}    // namespace hpx::traits
+}    // namespace hpx::traits
 
 #define HPX_TRAITS_NONINTRUSIVE_POLYMORPHIC(Class)                             \
-    namespace hpx { namespace traits {                                         \
-            template <>                                                        \
-            struct is_nonintrusive_polymorphic<Class> : std::true_type         \
-            {                                                                  \
-            };                                                                 \
-        }                                                                      \
+    namespace hpx::traits {                                                    \
+        template <>                                                            \
+        struct is_nonintrusive_polymorphic<Class> : std::true_type             \
+        {                                                                      \
+        };                                                                     \
     }                                                                          \
     /**/
 
 #define HPX_TRAITS_NONINTRUSIVE_POLYMORPHIC_TEMPLATE(TEMPLATE, ARG_LIST)       \
-    namespace hpx { namespace traits {                                         \
-            HPX_PP_STRIP_PARENS(TEMPLATE)                                      \
-            struct is_nonintrusive_polymorphic<HPX_PP_STRIP_PARENS(ARG_LIST)>  \
-              : std::true_type                                                 \
-            {                                                                  \
-            };                                                                 \
-        }                                                                      \
+    namespace hpx::traits {                                                    \
+        HPX_PP_STRIP_PARENS(TEMPLATE)                                          \
+        struct is_nonintrusive_polymorphic<HPX_PP_STRIP_PARENS(ARG_LIST)>      \
+          : std::true_type                                                     \
+        {                                                                      \
+        };                                                                     \
     }                                                                          \
     /**/
 
 #define HPX_TRAITS_SERIALIZED_WITH_ID(Class)                                   \
-    namespace hpx { namespace traits {                                         \
-            template <>                                                        \
-            struct is_serialized_with_id<Class> : std::true_type               \
-            {                                                                  \
-            };                                                                 \
-        }                                                                      \
+    namespace hpx::traits {                                                    \
+        template <>                                                            \
+        struct is_serialized_with_id<Class> : std::true_type                   \
+        {                                                                      \
+        };                                                                     \
     }                                                                          \
     /**/
 
 #define HPX_TRAITS_SERIALIZED_WITH_ID_TEMPLATE(TEMPLATE, ARG_LIST)             \
-    namespace hpx { namespace traits {                                         \
-            HPX_PP_STRIP_PARENS(TEMPLATE)                                      \
-            struct is_serialized_with_id<HPX_PP_STRIP_PARENS(ARG_LIST)>        \
-              : std::true_type                                                 \
-            {                                                                  \
-            };                                                                 \
-        }                                                                      \
+    namespace hpx::traits {                                                    \
+        HPX_PP_STRIP_PARENS(TEMPLATE)                                          \
+        struct is_serialized_with_id<HPX_PP_STRIP_PARENS(ARG_LIST)>            \
+          : std::true_type                                                     \
+        {                                                                      \
+        };                                                                     \
     }                                                                          \
     /**/

--- a/libs/core/serialization/include/hpx/serialization/traits/serialization_access_data.hpp
+++ b/libs/core/serialization/include/hpx/serialization/traits/serialization_access_data.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2017 Hartmut Kaiser
+//  Copyright (c) 2017-2022 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -15,7 +15,7 @@
 #include <cstring>
 #include <type_traits>
 
-namespace hpx { namespace traits {
+namespace hpx::traits {
 
     ////////////////////////////////////////////////////////////////////////////
     template <typename Container>
@@ -23,7 +23,7 @@ namespace hpx { namespace traits {
     {
         using preprocessing_only = std::false_type;
 
-        static constexpr bool is_preprocessing()
+        static constexpr bool is_preprocessing() noexcept
         {
             return false;
         }
@@ -31,13 +31,13 @@ namespace hpx { namespace traits {
         // functions related to output operations
         static constexpr void write(Container& /* cont */,
             std::size_t /* count */, std::size_t /* current */,
-            void const* /* address */)
+            void const* /* address */) noexcept
         {
         }
 
         static bool flush(serialization::binary_filter* /* filter */,
             Container& /* cont */, std::size_t /* current */, std::size_t size,
-            std::size_t& written)
+            std::size_t& written) noexcept
         {
             written = size;
             return true;
@@ -46,18 +46,18 @@ namespace hpx { namespace traits {
         // functions related to input operations
         static constexpr void read(Container const& /* cont */,
             std::size_t /* count */, std::size_t /* current */,
-            void* /* address */)
+            void* /* address */) noexcept
         {
         }
 
         static constexpr std::size_t init_data(Container const& /* cont */,
             serialization::binary_filter* /* filter */,
-            std::size_t /* current */, std::size_t decompressed_size)
+            std::size_t /* current */, std::size_t decompressed_size) noexcept
         {
             return decompressed_size;
         }
 
-        static constexpr void reset(Container& /* cont */) {}
+        static constexpr void reset(Container& /* cont */) noexcept {}
     };
 
     ///////////////////////////////////////////////////////////////////////
@@ -65,7 +65,7 @@ namespace hpx { namespace traits {
     struct serialization_access_data
       : default_serialization_access_data<Container>
     {
-        static std::size_t size(Container const& cont)
+        static std::size_t size(Container const& cont) noexcept
         {
             return cont.size();
         }
@@ -76,7 +76,7 @@ namespace hpx { namespace traits {
         }
 
         static void write(Container& cont, std::size_t count,
-            std::size_t current, void const* address)
+            std::size_t current, void const* address) noexcept
         {
             void* dest = &cont[current];
             switch (count)
@@ -116,7 +116,7 @@ namespace hpx { namespace traits {
 
         // functions related to input operations
         static void read(Container const& cont, std::size_t count,
-            std::size_t current, void* address)
+            std::size_t current, void* address) noexcept
         {
             void const* src = &cont[current];
             switch (count)
@@ -162,4 +162,4 @@ namespace hpx { namespace traits {
       : serialization_access_data<Container>
     {
     };
-}}    // namespace hpx::traits
+}    // namespace hpx::traits

--- a/libs/core/serialization/include/hpx/serialization/tuple.hpp
+++ b/libs/core/serialization/include/hpx/serialization/tuple.hpp
@@ -1,5 +1,5 @@
 //  Copyright (c) 2011-2013 Thomas Heller
-//  Copyright (c) 2011-2021 Hartmut Kaiser
+//  Copyright (c) 2011-2022 Hartmut Kaiser
 //  Copyright (c) 2013-2015 Agustin Berge
 //  Copyright (c)      2019 Mikael Simberg
 //
@@ -23,7 +23,7 @@
 #include <type_traits>
 #include <utility>
 
-namespace hpx { namespace traits {
+namespace hpx::traits {
 
     template <typename... Ts>
     struct is_bitwise_serializable<::hpx::tuple<Ts...>>
@@ -38,9 +38,9 @@ namespace hpx { namespace traits {
             !is_bitwise_serializable_v<::hpx::tuple<Ts...>>>
     {
     };
-}}    // namespace hpx::traits
+}    // namespace hpx::traits
 
-namespace hpx { namespace util { namespace detail {
+namespace hpx::util::detail {
 
     template <typename Archive, typename Is, typename... Ts>
     struct serialize_with_index_pack;
@@ -76,11 +76,11 @@ namespace hpx { namespace util { namespace detail {
         template <typename T>
         static void load_element(Archive& ar, T& t)
         {
-            using is_polymorphic = std::integral_constant<bool,
+            constexpr bool is_polymorphic =
                 hpx::traits::is_intrusive_polymorphic_v<T> ||
-                    hpx::traits::is_nonintrusive_polymorphic_v<T>>;
+                hpx::traits::is_nonintrusive_polymorphic_v<T>;
 
-            if constexpr (is_polymorphic::value)
+            if constexpr (is_polymorphic)
             {
                 std::unique_ptr<T> data(
                     serialization::detail::constructor_selector_ptr<T>::create(
@@ -104,7 +104,6 @@ namespace hpx { namespace util { namespace detail {
                      ar, const_cast<std::remove_const_t<Ts>&>(hpx::get<Is>(t))),
                     0)...};
 #endif
-
             (void) _sequencer;
         }
     };
@@ -116,7 +115,7 @@ namespace hpx { namespace util { namespace detail {
         template <typename T>
         static void save_element(Archive& ar, T& t)
         {
-            if constexpr (!std::is_default_constructible<T>::value)
+            if constexpr (!std::is_default_constructible_v<T>)
             {
                 using serialization::detail::save_construct_data;
                 save_construct_data(ar, &t, 0);
@@ -131,9 +130,9 @@ namespace hpx { namespace util { namespace detail {
             (void) _sequencer;
         }
     };
-}}}    // namespace hpx::util::detail
+}    // namespace hpx::util::detail
 
-namespace hpx { namespace serialization {
+namespace hpx::serialization {
 
     template <typename Archive, typename... Ts>
     void serialize(Archive& ar, hpx::tuple<Ts...>& t, unsigned int version)
@@ -165,4 +164,4 @@ namespace hpx { namespace serialization {
         hpx::util::detail::save_construct_data_with_index_pack<Archive, Is,
             Ts...>::call(ar, *t, version);
     }
-}}    // namespace hpx::serialization
+}    // namespace hpx::serialization

--- a/libs/core/serialization/include/hpx/serialization/unique_ptr.hpp
+++ b/libs/core/serialization/include/hpx/serialization/unique_ptr.hpp
@@ -14,7 +14,7 @@
 
 #include <memory>
 
-namespace hpx { namespace serialization {
+namespace hpx::serialization {
 
     template <typename T>
     void load(input_archive& ar, std::unique_ptr<T>& ptr, unsigned)
@@ -23,11 +23,11 @@ namespace hpx { namespace serialization {
     }
 
     template <typename T>
-    void save(output_archive& ar, const std::unique_ptr<T>& ptr, unsigned)
+    void save(output_archive& ar, std::unique_ptr<T> const& ptr, unsigned)
     {
         detail::serialize_pointer_untracked(ar, ptr);
     }
 
     HPX_SERIALIZATION_SPLIT_FREE_TEMPLATE(
         (template <typename T>), (std::unique_ptr<T>) )
-}}    // namespace hpx::serialization
+}    // namespace hpx::serialization

--- a/libs/core/serialization/include/hpx/serialization/unordered_map.hpp
+++ b/libs/core/serialization/include/hpx/serialization/unordered_map.hpp
@@ -52,7 +52,7 @@ namespace hpx { namespace serialization {
         using value_type = typename container_type::value_type;
 
         ar << t.size();    //-V128
-        for (const value_type& val : t)
+        for (value_type const& val : t)
         {
             ar << val;
         }

--- a/libs/core/serialization/include/hpx/serialization/valarray.hpp
+++ b/libs/core/serialization/include/hpx/serialization/valarray.hpp
@@ -13,16 +13,16 @@
 #include <cstddef>
 #include <valarray>
 
-namespace hpx { namespace serialization {
+namespace hpx::serialization {
 
     template <typename T>
     void serialize(input_archive& ar, std::valarray<T>& arr, int /* version */)
     {
         std::size_t sz = 0;
-        ar& sz;
+        ar >> sz;
         arr.resize(sz);
 
-        if (sz < 1)
+        if (sz == 0)
             return;
 
         for (std::size_t i = 0; i < sz; ++i)
@@ -33,9 +33,9 @@ namespace hpx { namespace serialization {
     void serialize(
         output_archive& ar, std::valarray<T> const& arr, int /* version */)
     {
-        const std::size_t sz = arr.size();
-        ar& sz;
-        for (auto v : arr)
+        std::size_t const sz = arr.size();
+        ar << sz;
+        for (auto const& v : arr)
             ar << v;
     }
-}}    // namespace hpx::serialization
+}    // namespace hpx::serialization

--- a/libs/core/serialization/include/hpx/serialization/variant.hpp
+++ b/libs/core/serialization/include/hpx/serialization/variant.hpp
@@ -21,7 +21,7 @@
 #include <utility>
 #include <variant>
 
-namespace hpx { namespace serialization {
+namespace hpx::serialization {
 
     namespace detail {
 
@@ -102,4 +102,4 @@ namespace hpx { namespace serialization {
 
     HPX_SERIALIZATION_SPLIT_FREE_TEMPLATE(
         (template <typename... Ts>), (std::variant<Ts...>) )
-}}    // namespace hpx::serialization
+}    // namespace hpx::serialization

--- a/libs/core/serialization/tests/performance/serialization_performance.cpp
+++ b/libs/core/serialization/tests/performance/serialization_performance.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2017 Hartmut Kaiser
+//  Copyright (c) 2017-2022 Hartmut Kaiser
 //  Copyright (c) 2015-2016 Anton Bikineev
 //
 //  SPDX-License-Identifier: BSL-1.0
@@ -144,8 +144,10 @@ namespace hpx_test {
         template <typename Archive>
         void serialize(Archive& ar, unsigned int)
         {
-            ar& ids;
-            ar& strings;
+            // clang-format off
+            ar & ids;
+            ar & strings;
+            // clang-format on
         }
     };
 

--- a/libs/core/serialization/tests/regressions/CMakeLists.txt
+++ b/libs/core/serialization/tests/regressions/CMakeLists.txt
@@ -1,10 +1,10 @@
-# Copyright (c) 2019 The STE||AR-Group
+# Copyright (c) 2019-2022 The STE||AR-Group
 #
 # SPDX-License-Identifier: BSL-1.0
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-set(tests buffer_overrun_2839)
+set(tests buffer_overrun_2839 not_bitwise_shared_ptr_serialization)
 
 foreach(test ${tests})
   set(sources ${test}.cpp)

--- a/libs/core/serialization/tests/regressions/not_bitwise_shared_ptr_serialization.cpp
+++ b/libs/core/serialization/tests/regressions/not_bitwise_shared_ptr_serialization.cpp
@@ -1,0 +1,102 @@
+//  Copyright (c) 2021-2022 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+// enforce that types are bitwise serializable by default
+#define HPX_SERIALIZATION_HAVE_ALL_TYPES_ARE_BITWISE_SERIALIZABLE
+
+// enforce pointers being serializable
+#define HPX_SERIALIZATION_HAVE_ALLOW_RAW_POINTER_SERIALIZATION
+
+#include <hpx/config.hpp>
+#include <hpx/local/init.hpp>
+#include <hpx/modules/serialization.hpp>
+#include <hpx/modules/testing.hpp>
+
+#include <cstddef>
+#include <memory>
+#include <vector>
+
+struct A
+{
+    A() = default;
+
+    A(int a, double b)
+      : a(a)
+      , b(b)
+    {
+    }
+
+    int a = 0;
+    double b = 0.0;
+    bool serialized = false;
+
+    template <typename Archive>
+    void serialize(Archive& ar, unsigned)
+    {
+        // clang-format off
+        ar & a & b;
+        // clang-format on
+
+        serialized = true;
+    }
+};
+
+int hpx_main()
+{
+    {
+        std::vector<char> buffer;
+        hpx::serialization::output_archive oarchive(buffer);
+
+        std::shared_ptr<A> oa(new A(42, 42.0));
+        std::shared_ptr<A> ob(oa);
+
+        oarchive << oa << ob;
+        HPX_TEST(oa->serialized);
+
+        hpx::serialization::input_archive iarchive(buffer);
+        std::shared_ptr<A> ia;
+        std::shared_ptr<A> ib;
+
+        iarchive >> ia >> ib;
+        HPX_TEST(ia->serialized);
+
+        HPX_TEST(ia.get() == ib.get());
+
+        HPX_TEST_EQ(ia->a, 42);
+        HPX_TEST_EQ(ia->b, 42.0);
+    }
+
+    {
+        std::vector<char> buffer;
+        hpx::serialization::output_archive oarchive(buffer);
+
+        std::shared_ptr<A> oa = std::make_shared<A>(42, 42.0);
+        std::shared_ptr<A> ob(oa);
+
+        oarchive << oa << ob;
+        HPX_TEST(oa->serialized);
+
+        hpx::serialization::input_archive iarchive(buffer);
+        std::shared_ptr<A> ia;
+        std::shared_ptr<A> ib;
+
+        iarchive >> ia >> ib;
+        HPX_TEST(ia->serialized);
+
+        HPX_TEST(ia.get() == ib.get());
+
+        HPX_TEST_EQ(ia->a, 42);
+        HPX_TEST_EQ(ia->b, 42.0);
+    }
+
+    return hpx::local::finalize();
+}
+
+int main(int argc, char* argv[])
+{
+    hpx::local::init(hpx_main, argc, argv);
+    return hpx::util::report_errors();
+}

--- a/libs/core/serialization/tests/unit/CMakeLists.txt
+++ b/libs/core/serialization/tests/unit/CMakeLists.txt
@@ -5,6 +5,7 @@
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 set(tests
+    not_bitwise_serializable
     serialization_array
     serialization_brace_initializable
     serialization_valarray
@@ -26,13 +27,12 @@ set(tests
     serialization_std_variant
 )
 
+set(full_tests any_serialization serializable_any serialization_raw_pointer)
+
 if(HPX_SERIALIZATION_WITH_BOOST_TYPES)
   set(tests ${tests} serialization_boost_variant)
+  set(full_tests ${full_tests} serializable_boost_any)
 endif()
-
-set(full_tests any_serialization not_bitwise_serializable serializable_any
-               serializable_boost_any serialization_raw_pointer
-)
 
 add_subdirectory(polymorphic)
 

--- a/libs/core/serialization/tests/unit/serialization_array.cpp
+++ b/libs/core/serialization/tests/unit/serialization_array.cpp
@@ -51,7 +51,7 @@ void test(T minval, T maxval)
     {
         std::vector<char> buffer;
         hpx::serialization::output_archive oarchive(
-            buffer, hpx::serialization::disable_data_chunking);
+            buffer, hpx::serialization::archive_flags::disable_data_chunking);
         std::vector<T> os;
         for (T c = minval; c < maxval; ++c)
         {
@@ -72,7 +72,7 @@ void test(T minval, T maxval)
     {
         std::vector<char> buffer;
         hpx::serialization::output_archive oarchive(
-            buffer, hpx::serialization::disable_data_chunking);
+            buffer, hpx::serialization::archive_flags::disable_data_chunking);
         std::vector<A<T>> os;
         for (T c = minval; c < maxval; ++c)
         {
@@ -98,7 +98,7 @@ void test_fp(T minval, T maxval)
     {
         std::vector<char> buffer;
         hpx::serialization::output_archive oarchive(
-            buffer, hpx::serialization::disable_data_chunking);
+            buffer, hpx::serialization::archive_flags::disable_data_chunking);
         std::vector<T> os;
         for (T c = minval; c < maxval; c += static_cast<T>(0.5))
         {
@@ -119,7 +119,7 @@ void test_fp(T minval, T maxval)
     {
         std::vector<char> buffer;
         hpx::serialization::output_archive oarchive(
-            buffer, hpx::serialization::disable_data_chunking);
+            buffer, hpx::serialization::archive_flags::disable_data_chunking);
         std::vector<A<T>> os;
         for (T c = minval; c < maxval; c += static_cast<T>(0.5))
         {
@@ -139,13 +139,14 @@ void test_fp(T minval, T maxval)
     }
 }
 
+#if defined(HPX_SERIALIZATION_HAVE_BOOST_TYPES)
 template <class T, std::size_t N>
 void test_boost_array(T first)
 {
     {
         std::vector<char> buffer;
         hpx::serialization::output_archive oarchive(
-            buffer, hpx::serialization::disable_data_chunking);
+            buffer, hpx::serialization::archive_flags::disable_data_chunking);
         boost::array<T, N> oarray;
         std::iota(oarray.begin(), oarray.end(), first);
         oarchive << oarray;
@@ -161,7 +162,7 @@ void test_boost_array(T first)
     {
         std::vector<char> buffer;
         hpx::serialization::output_archive oarchive(
-            buffer, hpx::serialization::disable_data_chunking);
+            buffer, hpx::serialization::archive_flags::disable_data_chunking);
         boost::array<A<T>, N> oarray;
         std::iota(oarray.begin(), oarray.end(), first);
         oarchive << oarray;
@@ -175,6 +176,7 @@ void test_boost_array(T first)
         }
     }
 }
+#endif
 
 template <class T, std::size_t N>
 void test_std_array(T first)
@@ -182,7 +184,7 @@ void test_std_array(T first)
     {
         std::vector<char> buffer;
         hpx::serialization::output_archive oarchive(
-            buffer, hpx::serialization::disable_data_chunking);
+            buffer, hpx::serialization::archive_flags::disable_data_chunking);
         std::array<T, N> oarray;
         std::iota(oarray.begin(), oarray.end(), first);
         oarchive << oarray;
@@ -198,7 +200,7 @@ void test_std_array(T first)
     {
         std::vector<char> buffer;
         hpx::serialization::output_archive oarchive(
-            buffer, hpx::serialization::disable_data_chunking);
+            buffer, hpx::serialization::archive_flags::disable_data_chunking);
         std::array<A<T>, N> oarray;
         std::iota(oarray.begin(), oarray.end(), first);
         oarchive << oarray;
@@ -213,12 +215,13 @@ void test_std_array(T first)
     }
 }
 
+#if defined(HPX_SERIALIZATION_HAVE_BOOST_TYPES)
 template <class T>
 void test_multi_array(T first)
 {
     std::vector<char> buffer;
     hpx::serialization::output_archive oarchive(
-        buffer, hpx::serialization::disable_data_chunking);
+        buffer, hpx::serialization::archive_flags::disable_data_chunking);
     boost::multi_array<T, 3u> oarray(boost::extents[3][4][2]);
 
     for (std::size_t i = 0; i < 3; ++i)
@@ -235,6 +238,7 @@ void test_multi_array(T first)
             for (std::size_t k = 0; k < 2; ++k)
                 HPX_TEST_EQ(oarray[i][j][k], iarray[i][j][k]);
 }
+#endif
 
 template <typename T, std::size_t N>
 void test_plain_array()
@@ -250,7 +254,7 @@ void test_plain_array()
     }
 
     hpx::serialization::output_archive oarchive(
-        buffer, hpx::serialization::disable_data_chunking);
+        buffer, hpx::serialization::archive_flags::disable_data_chunking);
     oarchive << iarray;
 
     hpx::serialization::input_archive iarchive(buffer);
@@ -278,7 +282,7 @@ void test_array_of_vectors()
     }
 
     hpx::serialization::output_archive oarchive(
-        buffer, hpx::serialization::disable_data_chunking);
+        buffer, hpx::serialization::archive_flags::disable_data_chunking);
     oarchive << iarray;
 
     hpx::serialization::input_archive iarchive(buffer);
@@ -324,16 +328,20 @@ int main()
         (std::numeric_limits<double>::min)() + 100);
     test<double>(-100, 100);
 
+#if defined(HPX_SERIALIZATION_HAVE_BOOST_TYPES)
     test_boost_array<char, 100U>('\0');
     test_boost_array<double, 40U>((std::numeric_limits<double>::min)());
     test_boost_array<float, 100U>(0.f);
+#endif
 
     test_std_array<char, 100U>('\0');
     test_std_array<double, 40U>((std::numeric_limits<double>::min)());
     test_std_array<float, 100U>(0.f);
 
+#if defined(HPX_SERIALIZATION_HAVE_BOOST_TYPES)
     test_multi_array(0);
     test_multi_array(0.);
+#endif
 
     test_plain_array<double, 20>();
     test_plain_array<int, 200>();

--- a/libs/core/serialization/tests/unit/serialization_valarray.cpp
+++ b/libs/core/serialization/tests/unit/serialization_valarray.cpp
@@ -50,7 +50,7 @@ void test(T minval, T maxval)
     {
         std::vector<char> buffer;
         hpx::serialization::output_archive oarchive(
-            buffer, hpx::serialization::disable_data_chunking);
+            buffer, hpx::serialization::archive_flags::disable_data_chunking);
         std::vector<T> os;
         for (T c = minval; c < maxval; ++c)
         {
@@ -71,7 +71,7 @@ void test(T minval, T maxval)
     {
         std::vector<char> buffer;
         hpx::serialization::output_archive oarchive(
-            buffer, hpx::serialization::disable_data_chunking);
+            buffer, hpx::serialization::archive_flags::disable_data_chunking);
         std::vector<A<T>> os;
         for (T c = minval; c < maxval; ++c)
         {
@@ -97,7 +97,7 @@ void test_fp(T minval, T maxval)
     {
         std::vector<char> buffer;
         hpx::serialization::output_archive oarchive(
-            buffer, hpx::serialization::disable_data_chunking);
+            buffer, hpx::serialization::archive_flags::disable_data_chunking);
         std::vector<T> os;
         for (T c = minval; c < maxval; c += static_cast<T>(0.5))
         {
@@ -118,7 +118,7 @@ void test_fp(T minval, T maxval)
     {
         std::vector<char> buffer;
         hpx::serialization::output_archive oarchive(
-            buffer, hpx::serialization::disable_data_chunking);
+            buffer, hpx::serialization::archive_flags::disable_data_chunking);
         std::vector<A<T>> os;
         for (T c = minval; c < maxval; c += static_cast<T>(0.5))
         {
@@ -144,7 +144,7 @@ void test_std_valarray(T first)
     {
         std::vector<char> buffer;
         hpx::serialization::output_archive oarchive(
-            buffer, hpx::serialization::disable_data_chunking);
+            buffer, hpx::serialization::archive_flags::disable_data_chunking);
         std::valarray<T> oarray(N);
         std::iota(std::begin(oarray), std::end(oarray), first);
         oarchive << oarray;
@@ -160,7 +160,7 @@ void test_std_valarray(T first)
     {
         std::vector<char> buffer;
         hpx::serialization::output_archive oarchive(
-            buffer, hpx::serialization::disable_data_chunking);
+            buffer, hpx::serialization::archive_flags::disable_data_chunking);
         std::valarray<A<T>> oarray(N);
         std::iota(std::begin(oarray), std::end(oarray), first);
         oarchive << oarray;

--- a/libs/core/topology/include/hpx/topology/cpu_mask.hpp
+++ b/libs/core/topology/include/hpx/topology/cpu_mask.hpp
@@ -132,8 +132,8 @@ namespace hpx { namespace threads {
         mask = 0ull;
     }
 
-// clang-format off
 #else
+    // clang-format off
 #  if defined(HPX_HAVE_MAX_CPU_COUNT)
     typedef std::bitset<HPX_HAVE_MAX_CPU_COUNT> mask_type;
     typedef std::bitset<HPX_HAVE_MAX_CPU_COUNT> const& mask_cref_type;
@@ -233,6 +233,6 @@ namespace hpx { namespace threads {
 
 #endif
 
-        HPX_CORE_EXPORT std::string to_string(mask_cref_type);
-        /// \endcond
+    HPX_CORE_EXPORT std::string to_string(mask_cref_type);
+    /// \endcond
 }}    // namespace hpx::threads

--- a/libs/core/topology/src/topology.cpp
+++ b/libs/core/topology/src/topology.cpp
@@ -525,6 +525,8 @@ namespace hpx { namespace threads {
         sleep(0);    // Allow the OS to pick up the change.
 #endif
         hwloc_bitmap_free(cpuset);
+#else
+        (void) mask;
 #endif    // __APPLE__
 
         if (&ec != &throws)
@@ -1332,11 +1334,11 @@ namespace hpx { namespace threads {
         return
 #if HWLOC_API_VERSION >= 0x00010b06
             hwloc_alloc_membind(topo, len, bitmap->get_bmp(),
-                (hwloc_membind_policy_t)(policy),
+                hwloc_membind_policy_t(policy),
                 flags | HWLOC_MEMBIND_BYNODESET);
 #else
             hwloc_alloc_membind_nodeset(topo, len, bitmap->get_bmp(),
-                (hwloc_membind_policy_t)(policy), flags);
+                hwloc_membind_policy_t(policy), flags);
 #endif
     }
 
@@ -1367,6 +1369,10 @@ namespace hpx { namespace threads {
                 "hwloc_set_area_membind_nodeset failed : {}", msg);
             return false;
         }
+#else
+        (void) addr;
+        (void) len;
+        (void) nodeset;
 #endif
         return true;
     }

--- a/libs/full/actions/include/hpx/actions/base_action.hpp
+++ b/libs/full/actions/include/hpx/actions/base_action.hpp
@@ -203,14 +203,11 @@ namespace hpx { namespace serialization {
 
 #define HPX_DEFINE_GET_ACTION_NAME_(action, actionname)                        \
     HPX_DEFINE_GET_ACTION_NAME_ITT(action, actionname)                         \
-    namespace hpx { namespace actions { namespace detail {                     \
-                template <>                                                    \
-                HPX_ALWAYS_EXPORT char const*                                  \
-                get_action_name<action>() noexcept                             \
-                {                                                              \
-                    return HPX_PP_STRINGIZE(actionname);                       \
-                }                                                              \
-            }                                                                  \
+    namespace hpx::actions::detail {                                           \
+        template <>                                                            \
+        HPX_ALWAYS_EXPORT char const* get_action_name</**/ action>() noexcept  \
+        {                                                                      \
+            return HPX_PP_STRINGIZE(actionname);                               \
         }                                                                      \
     }                                                                          \
     /**/
@@ -219,27 +216,22 @@ namespace hpx { namespace serialization {
 ///////////////////////////////////////////////////////////////////////////////
 #if HPX_HAVE_ITTNOTIFY != 0 && !defined(HPX_HAVE_APEX)
 #define HPX_DEFINE_GET_ACTION_NAME_ITT(action, actionname)                     \
-    namespace hpx { namespace actions { namespace detail {                     \
-                template <>                                                    \
-                HPX_ALWAYS_EXPORT util::itt::string_handle const&              \
-                get_action_name_itt<action>() noexcept                         \
-                {                                                              \
-                    static util::itt::string_handle sh(                        \
-                        HPX_PP_STRINGIZE(actionname));                         \
-                    return sh;                                                 \
-                }                                                              \
-            }                                                                  \
+    namespace hpx::actions::detail {                                           \
+        template <>                                                            \
+        HPX_ALWAYS_EXPORT util::itt::string_handle const&                      \
+        get_action_name_itt</**/ action>() noexcept                            \
+        {                                                                      \
+            static util::itt::string_handle sh(HPX_PP_STRINGIZE(actionname));  \
+            return sh;                                                         \
         }                                                                      \
     }                                                                          \
     /**/
 
 #define HPX_REGISTER_ACTION_DECLARATION_NO_DEFAULT_GUID_ITT(action)            \
-    namespace hpx { namespace actions { namespace detail {                     \
-                template <>                                                    \
-                HPX_ALWAYS_EXPORT util::itt::string_handle const&              \
-                get_action_name_itt<action>() noexcept;                        \
-            }                                                                  \
-        }                                                                      \
+    namespace hpx::actions::detail {                                           \
+        template <>                                                            \
+        HPX_ALWAYS_EXPORT util::itt::string_handle const&                      \
+        get_action_name_itt</**/ action>() noexcept;                           \
     }                                                                          \
 /**/
 #else    // HPX_HAVE_ITTNOTIFY != 0 && !defined(HPX_HAVE_APEX)
@@ -249,25 +241,21 @@ namespace hpx { namespace serialization {
 
 #define HPX_REGISTER_ACTION_DECLARATION_NO_DEFAULT_GUID(action)                \
     HPX_REGISTER_ACTION_DECLARATION_NO_DEFAULT_GUID_ITT(action)                \
-    namespace hpx { namespace actions { namespace detail {                     \
-                template <>                                                    \
-                HPX_ALWAYS_EXPORT char const*                                  \
-                get_action_name<action>() noexcept;                            \
-            }                                                                  \
-        }                                                                      \
+    namespace hpx::actions::detail {                                           \
+        template <>                                                            \
+        HPX_ALWAYS_EXPORT char const* get_action_name<action>() noexcept;      \
     }                                                                          \
     HPX_REGISTER_ACTION_EXTERN_DECLARATION(action)                             \
                                                                                \
-    namespace hpx { namespace traits {                                         \
-            template <>                                                        \
-            struct is_action<action> : std::true_type                          \
-            {                                                                  \
-            };                                                                 \
-            template <>                                                        \
-            struct needs_automatic_registration<action> : std::false_type      \
-            {                                                                  \
-            };                                                                 \
-        }                                                                      \
+    namespace hpx::traits {                                                    \
+        template <>                                                            \
+        struct is_action</**/ action> : std::true_type                         \
+        {                                                                      \
+        };                                                                     \
+        template <>                                                            \
+        struct needs_automatic_registration</**/ action> : std::false_type     \
+        {                                                                      \
+        };                                                                     \
     }                                                                          \
     /**/
 
@@ -280,11 +268,10 @@ namespace hpx { namespace serialization {
     HPX_DEFINE_GET_ACTION_NAME_(action, actionname)                            \
     HPX_REGISTER_ACTION_INVOCATION_COUNT(action)                               \
     HPX_REGISTER_PER_ACTION_DATA_COUNTER_TYPES(action)                         \
-    namespace hpx { namespace actions {                                        \
-            template struct HPX_ALWAYS_EXPORT transfer_action<action>;         \
-            template struct HPX_ALWAYS_EXPORT                                  \
-                transfer_continuation_action<action>;                          \
-        }                                                                      \
+    namespace hpx::actions {                                                   \
+        template struct HPX_ALWAYS_EXPORT transfer_action</**/ action>;        \
+        template struct HPX_ALWAYS_EXPORT                                      \
+            transfer_continuation_action</**/ action>;                         \
     }                                                                          \
 /**/
 #define HPX_REGISTER_ACTION_EXTERN_DECLARATION(action) /**/
@@ -295,18 +282,16 @@ namespace hpx { namespace serialization {
     HPX_DEFINE_GET_ACTION_NAME_(action, actionname)                            \
     HPX_REGISTER_ACTION_INVOCATION_COUNT(action)                               \
     HPX_REGISTER_PER_ACTION_DATA_COUNTER_TYPES(action)                         \
-    namespace hpx { namespace actions {                                        \
-            template struct transfer_action<action>;                           \
-            template struct transfer_continuation_action<action>;              \
-        }                                                                      \
+    namespace hpx::actions {                                                   \
+        template struct transfer_action</**/ action>;                          \
+        template struct transfer_continuation_action</**/ action>;             \
     }                                                                          \
 /**/
 #define HPX_REGISTER_ACTION_EXTERN_DECLARATION(action)                         \
-    namespace hpx { namespace actions {                                        \
-            extern template struct HPX_ALWAYS_IMPORT transfer_action<action>;  \
-            extern template struct HPX_ALWAYS_IMPORT                           \
-                transfer_continuation_action<action>;                          \
-        }                                                                      \
+    namespace hpx::actions {                                                   \
+        extern template struct HPX_ALWAYS_IMPORT transfer_action</**/ action>; \
+        extern template struct HPX_ALWAYS_IMPORT                               \
+            transfer_continuation_action</**/ action>;                         \
     }                                                                          \
     /**/
 

--- a/libs/full/actions/include/hpx/actions/transfer_action.hpp
+++ b/libs/full/actions/include/hpx/actions/transfer_action.hpp
@@ -252,7 +252,7 @@ namespace hpx { namespace actions {
     }
 }}    // namespace hpx::actions
 
-namespace hpx { namespace traits {
+namespace hpx::traits {
     /// \cond NOINTERNAL
     template <typename Action>
     struct needs_automatic_registration<hpx::actions::transfer_action<Action>>
@@ -260,7 +260,7 @@ namespace hpx { namespace traits {
     {
     };
     /// \endcond
-}}    // namespace hpx::traits
+}    // namespace hpx::traits
 
 #include <hpx/config/warnings_suffix.hpp>
 

--- a/libs/full/actions/tests/performance/serialization_overhead.cpp
+++ b/libs/full/actions/tests/performance/serialization_overhead.cpp
@@ -59,9 +59,11 @@ double benchmark_serialization(std::size_t data_size, std::size_t iterations,
 
     unsigned int out_archive_flags = 0U;
     if (endian_out == "little")
-        out_archive_flags |= hpx::serialization::endian_little;
+        out_archive_flags = out_archive_flags |
+            int(hpx::serialization::archive_flags::endian_little);
     else if (endian_out == "big")
-        out_archive_flags |= hpx::serialization::endian_big;
+        out_archive_flags = out_archive_flags |
+            int(hpx::serialization::archive_flags::endian_big);
     else
     {
         HPX_TEST(endian_out == "little" || endian_out == "big");
@@ -72,8 +74,10 @@ double benchmark_serialization(std::size_t data_size, std::size_t iterations,
 
     if (hpx::util::from_string<int>(array_optimization) == 0)
     {
-        out_archive_flags |= hpx::serialization::disable_array_optimization;
-        out_archive_flags |= hpx::serialization::disable_data_chunking;
+        out_archive_flags = out_archive_flags |
+            int(hpx::serialization::archive_flags::disable_array_optimization);
+        out_archive_flags = out_archive_flags |
+            int(hpx::serialization::archive_flags::disable_data_chunking);
     }
     else
     {
@@ -82,7 +86,8 @@ double benchmark_serialization(std::size_t data_size, std::size_t iterations,
         if (!zerocopy ||
             hpx::util::from_string<int>(zero_copy_optimization) == 0)
         {
-            out_archive_flags |= hpx::serialization::disable_data_chunking;
+            out_archive_flags = out_archive_flags |
+                int(hpx::serialization::archive_flags::disable_data_chunking);
         }
     }
 

--- a/libs/full/actions/tests/unit/zero_copy_serialization.cpp
+++ b/libs/full/actions/tests/unit/zero_copy_serialization.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2013 Hartmut Kaiser
+//  Copyright (c) 2007-2022 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -51,19 +51,23 @@ struct data_buffer
     void save(Archive& ar, unsigned) const
     {
         std::uint64_t size = data_.size();
-        ar& size;
-        ar& hpx::serialization::make_array(data_.data(), size);
-        ar& flag_;
+        // clang-format off
+        ar & size;
+        ar & hpx::serialization::make_array(data_.data(), size);
+        ar & flag_;
+        // clang-format on
     }
 
     template <typename Archive>
     void load(Archive& ar, unsigned)
     {
         std::uint64_t size = 0;
-        ar& size;
+        // clang-format off
+        ar & size;
         data_.resize(size);
-        ar& hpx::serialization::make_array(data_.data(), size);
-        ar& flag_;
+        ar & hpx::serialization::make_array(data_.data(), size);
+        ar & flag_;
+        // clang-format on
     }
 
     HPX_SERIALIZATION_SPLIT_MEMBER()
@@ -176,14 +180,17 @@ void test_normal_serialization(T& arg)
         hpx::components::component_invalid, (void*) &test_function1);
 
     // compose archive flags
-    std::uint32_t out_archive_flags = hpx::serialization::disable_data_chunking;
+    auto out_archive_flags =
+        std::uint32_t(hpx::serialization::archive_flags::disable_data_chunking);
     if (hpx::endian::native == hpx::endian::big)
     {
-        out_archive_flags |= hpx::serialization::endian_big;
+        out_archive_flags = out_archive_flags |
+            int(hpx::serialization::archive_flags::endian_big);
     }
     else
     {
-        out_archive_flags |= hpx::serialization::endian_little;
+        out_archive_flags = out_archive_flags |
+            int(hpx::serialization::archive_flags::endian_little);
     }
 
     // create a parcel with/without continuation
@@ -206,14 +213,17 @@ void test_normal_serialization(T1& arg1, T2& arg2)
         hpx::components::component_invalid, (void*) &test_function2);
 
     // compose archive flags
-    std::uint32_t out_archive_flags = hpx::serialization::disable_data_chunking;
+    auto out_archive_flags =
+        std::uint32_t(hpx::serialization::archive_flags::disable_data_chunking);
     if (hpx::endian::native == hpx::endian::big)
     {
-        out_archive_flags |= hpx::serialization::endian_big;
+        out_archive_flags = out_archive_flags |
+            int(hpx::serialization::archive_flags::endian_big);
     }
     else
     {
-        out_archive_flags |= hpx::serialization::endian_little;
+        out_archive_flags = out_archive_flags |
+            int(hpx::serialization::archive_flags::endian_little);
     }
 
     // create a parcel with/without continuation
@@ -237,14 +247,17 @@ void test_normal_serialization(
         hpx::components::component_invalid, (void*) &test_function2);
 
     // compose archive flags
-    std::uint32_t out_archive_flags = hpx::serialization::disable_data_chunking;
+    auto out_archive_flags =
+        std::uint32_t(hpx::serialization::archive_flags::disable_data_chunking);
     if (hpx::endian::native == hpx::endian::big)
     {
-        out_archive_flags |= hpx::serialization::endian_big;
+        out_archive_flags = out_archive_flags |
+            int(hpx::serialization::archive_flags::endian_big);
     }
     else
     {
-        out_archive_flags |= hpx::serialization::endian_little;
+        out_archive_flags = out_archive_flags |
+            int(hpx::serialization::archive_flags::endian_little);
     }
 
     // create a parcel with/without continuation
@@ -271,11 +284,13 @@ void test_zero_copy_serialization(T& arg)
     std::uint32_t out_archive_flags = 0U;
     if (hpx::endian::native == hpx::endian::big)
     {
-        out_archive_flags |= hpx::serialization::endian_big;
+        out_archive_flags = out_archive_flags |
+            int(hpx::serialization::archive_flags::endian_big);
     }
     else
     {
-        out_archive_flags |= hpx::serialization::endian_little;
+        out_archive_flags = out_archive_flags |
+            int(hpx::serialization::archive_flags::endian_little);
     }
 
     // create a parcel with/without continuation
@@ -301,11 +316,13 @@ void test_zero_copy_serialization(T1& arg1, T2& arg2)
     std::uint32_t out_archive_flags = 0U;
     if (hpx::endian::native == hpx::endian::big)
     {
-        out_archive_flags |= hpx::serialization::endian_big;
+        out_archive_flags = out_archive_flags |
+            int(hpx::serialization::archive_flags::endian_big);
     }
     else
     {
-        out_archive_flags |= hpx::serialization::endian_little;
+        out_archive_flags = out_archive_flags |
+            int(hpx::serialization::archive_flags::endian_little);
     }
 
     // create a parcel with/without continuation
@@ -332,11 +349,13 @@ void test_zero_copy_serialization(
     std::uint32_t out_archive_flags = 0U;
     if (hpx::endian::native == hpx::endian::big)
     {
-        out_archive_flags |= hpx::serialization::endian_big;
+        out_archive_flags = out_archive_flags |
+            int(hpx::serialization::archive_flags::endian_big);
     }
     else
     {
-        out_archive_flags |= hpx::serialization::endian_little;
+        out_archive_flags = out_archive_flags |
+            int(hpx::serialization::archive_flags::endian_little);
     }
 
     // create a parcel with/without continuation

--- a/libs/full/actions_base/include/hpx/actions_base/actions_base_support.hpp
+++ b/libs/full/actions_base/include/hpx/actions_base/actions_base_support.hpp
@@ -105,7 +105,7 @@ namespace hpx { namespace actions { namespace detail {
         /// you have a HPX_REGISTER_ACTION macro somewhere in a source file,
         /// but the header in which the action is defined misses a
         /// HPX_REGISTER_ACTION_DECLARATION
-        static_assert(traits::needs_automatic_registration<Action>::value,
+        static_assert(traits::needs_automatic_registration_v<Action>,
             "HPX_REGISTER_ACTION_DECLARATION missing");
         return util::debug::type_id<Action>::typeid_.type_id();
     }

--- a/libs/full/compute/include/hpx/compute/host/numa_binding_allocator.hpp
+++ b/libs/full/compute/include/hpx/compute/host/numa_binding_allocator.hpp
@@ -419,6 +419,9 @@ namespace hpx { namespace compute { namespace host {
                     temp << "-";
             }
             return temp.str();
+#else
+            (void) addr;
+            (void) len;
 #endif
             return "";
         }

--- a/libs/full/compute/include/hpx/compute/serialization/vector.hpp
+++ b/libs/full/compute/include/hpx/compute/serialization/vector.hpp
@@ -55,20 +55,15 @@ namespace hpx { namespace serialization {
         void load_impl(
             input_archive& ar, compute::vector<T, Allocator>& v, std::true_type)
         {
-            bool archive_endianess_differs = endian::native == endian::big ?
-                ar.endian_little() :
-                ar.endian_big();
-
 #if !defined(HPX_SERIALIZATION_HAVE_ALL_TYPES_ARE_BITWISE_SERIALIZABLE)
-            if (ar.disable_array_optimization() || archive_endianess_differs)
+            if (ar.disable_array_optimization() || ar.endianess_differs())
             {
                 load_impl(ar, v, std::false_type());
                 return;
             }
 #else
-            (void) archive_endianess_differs;
-            HPX_ASSERT(!(
-                ar.disable_array_optimization() || archive_endianess_differs));
+            HPX_ASSERT(
+                !(ar.disable_array_optimization() || ar.endianess_differs()));
 #endif
             // bitwise load ...
             using value_type =
@@ -120,20 +115,15 @@ namespace hpx { namespace serialization {
         void save_impl(output_archive& ar,
             compute::vector<T, Allocator> const& v, std::true_type)
         {
-            bool archive_endianess_differs = endian::native == endian::big ?
-                ar.endian_little() :
-                ar.endian_big();
-
 #if !defined(HPX_SERIALIZATION_HAVE_ALL_TYPES_ARE_BITWISE_SERIALIZABLE)
-            if (ar.disable_array_optimization() || archive_endianess_differs)
+            if (ar.disable_array_optimization() || ar.endianess_differs())
             {
                 save_impl(ar, v, std::false_type());
                 return;
             }
 #else
-            (void) archive_endianess_differs;
-            HPX_ASSERT(!(
-                ar.disable_array_optimization() || archive_endianess_differs));
+            HPX_ASSERT(
+                !(ar.disable_array_optimization() || ar.endianess_differs()));
 #endif
             // bitwise save ...
             using value_type =

--- a/libs/full/parcelport_libfabric/src/rma_receiver.cpp
+++ b/libs/full/parcelport_libfabric/src/rma_receiver.cpp
@@ -132,7 +132,7 @@ namespace hpx::parcelset::policies::libfabric {
 
         int zc_chunks =
             std::count_if(chunks_.begin(), chunks_.end(), [](chunk_struct& c) {
-                return c.type_ == serialization::chunk_type_pointer;
+                return c.type_ == serialization::chunk_type::chunk_type_pointer;
             });
         int oo_chunks = chunks_.size() - zc_chunks;
 
@@ -253,7 +253,7 @@ namespace hpx::parcelset::policies::libfabric {
         // for each zerocopy chunk, schedule a read operation
         uint64_t zc_count =
             std::count_if(chunks_.begin(), chunks_.end(), [](chunk_struct& c) {
-                return c.type_ == serialization::chunk_type_pointer;
+                return c.type_ == serialization::chunk_type::chunk_type_pointer;
             });
         LOG_DEBUG_MSG("receiver " << hexpointer(this)
                                   << "Restarting RMA reads with "
@@ -271,7 +271,7 @@ namespace hpx::parcelset::policies::libfabric {
     {
         for (chunk_struct& c : chunks_)
         {
-            if (c.type_ == serialization::chunk_type_pointer)
+            if (c.type_ == serialization::chunk_type::chunk_type_pointer)
             {
                 region_type* get_region =
                     memory_pool_->allocate_region(c.size_);
@@ -466,7 +466,7 @@ namespace hpx::parcelset::policies::libfabric {
 
         int zc_chunks =
             std::count_if(chunks_.begin(), chunks_.end(), [](chunk_struct& c) {
-                return c.type_ == serialization::chunk_type_pointer;
+                return c.type_ == serialization::chunk_type::chunk_type_pointer;
             });
         int oo_chunks = chunks_.size() - zc_chunks;
 

--- a/libs/full/parcelport_libfabric/src/sender.cpp
+++ b/libs/full/parcelport_libfabric/src/sender.cpp
@@ -47,7 +47,7 @@ namespace hpx::parcelset::policies::libfabric {
                 << decnumber((uint64_t) c.type_) << " rkey "
                 << hexpointer(c.rkey_) << " cpos " << hexpointer(c.data_.cpos_)
                 << " index " << decnumber(c.data_.index_));
-            if (c.type_ == serialization::chunk_type_pointer)
+            if (c.type_ == serialization::chunk_type::chunk_type_pointer)
             {
                 LOG_EXCLUSIVE(chrono::high_resolution_timer regtimer);
 

--- a/libs/full/parcelport_mpi/include/hpx/parcelport_mpi/sender_connection.hpp
+++ b/libs/full/parcelport_mpi/include/hpx/parcelport_mpi/sender_connection.hpp
@@ -217,7 +217,7 @@ namespace hpx::parcelset::policies::mpi {
             {
                 serialization::serialization_chunk& c =
                     buffer_.chunks_[chunks_idx_];
-                if (c.type_ == serialization::chunk_type_pointer)
+                if (c.type_ == serialization::chunk_type::chunk_type_pointer)
                 {
                     if (!request_done())
                     {

--- a/libs/full/parcelport_tcp/include/hpx/parcelport_tcp/sender.hpp
+++ b/libs/full/parcelport_tcp/include/hpx/parcelport_tcp/sender.hpp
@@ -163,7 +163,8 @@ namespace hpx::parcelset::policies::tcp {
                 // now add chunks themselves, those hold zero-copy serialized chunks
                 for (serialization::serialization_chunk& c : buffer_.chunks_)
                 {
-                    if (c.type_ == serialization::chunk_type_pointer)
+                    if (c.type_ ==
+                        serialization::chunk_type::chunk_type_pointer)
                         buffers.push_back(asio::buffer(c.data_.cpos_, c.size_));
                 }
             }

--- a/libs/full/parcelset/include/hpx/parcelset/encode_parcels.hpp
+++ b/libs/full/parcelset/include/hpx/parcelset/encode_parcels.hpp
@@ -110,7 +110,7 @@ namespace hpx::parcelset {
             std::size_t index = 0;
             for (serialization::serialization_chunk& c : buffer.chunks_)
             {
-                if (c.type_ == serialization::chunk_type_pointer)
+                if (c.type_ == serialization::chunk_type::chunk_type_pointer)
                     chunks.push_back(transmission_chunk_type(index, c.size_));
                 ++index;
             }
@@ -125,7 +125,7 @@ namespace hpx::parcelset {
                 // the remaining number of chunks are non-zero-copy
                 for (serialization::serialization_chunk& c : buffer.chunks_)
                 {
-                    if (c.type_ == serialization::chunk_type_index)
+                    if (c.type_ == serialization::chunk_type::chunk_type_index)
                     {
                         chunks.push_back(
                             transmission_chunk_type(c.data_.index_, c.size_));
@@ -164,7 +164,8 @@ namespace hpx::parcelset {
                 int archive_flags = archive_flags_;
                 if (filter.get() != nullptr)
                 {
-                    archive_flags |= serialization::enable_compression;
+                    archive_flags = archive_flags |
+                        int(serialization::archive_flags::enable_compression);
                 }
 
                 // preallocate data

--- a/libs/full/parcelset/include/hpx/parcelset/parcelport_impl.hpp
+++ b/libs/full/parcelset/include/hpx/parcelset/parcelport_impl.hpp
@@ -128,11 +128,13 @@ namespace hpx::parcelset {
                 endian::native == endian::big ? "big" : "little");
             if (endian_out == "little")
             {
-                archive_flags_ |= serialization::endian_little;
+                archive_flags_ = archive_flags_ |
+                    int(serialization::archive_flags::endian_little);
             }
             else if (endian_out == "big")
             {
-                archive_flags_ |= serialization::endian_big;
+                archive_flags_ = archive_flags_ |
+                    int(serialization::archive_flags::endian_big);
             }
             else
             {
@@ -141,14 +143,19 @@ namespace hpx::parcelset {
 
             if (!this->allow_array_optimizations())
             {
-                archive_flags_ |= serialization::disable_array_optimization;
-                archive_flags_ |= serialization::disable_data_chunking;
+                archive_flags_ = archive_flags_ |
+                    int(serialization::archive_flags::
+                            disable_array_optimization);
+                archive_flags_ = archive_flags_ |
+                    int(serialization::archive_flags::disable_data_chunking);
             }
             else
             {
                 if (!this->allow_zero_copy_optimizations())
                 {
-                    archive_flags_ |= serialization::disable_data_chunking;
+                    archive_flags_ = archive_flags_ |
+                        int(serialization::archive_flags::
+                                disable_data_chunking);
                 }
             }
         }

--- a/tests/performance/local/spinlock_overhead1.cpp
+++ b/tests/performance/local/spinlock_overhead1.cpp
@@ -19,22 +19,23 @@
 #include <hpx/modules/testing.hpp>
 #include <hpx/modules/timing.hpp>
 
+#include <atomic>
 #include <cstddef>
 #include <cstdint>
 #include <mutex>
 #include <stdexcept>
 #include <vector>
 
-using hpx::program_options::variables_map;
 using hpx::program_options::options_description;
 using hpx::program_options::value;
+using hpx::program_options::variables_map;
 
 using hpx::find_here;
 
 using hpx::naming::id_type;
 
-using hpx::future;
 using hpx::async;
+using hpx::future;
 
 using hpx::chrono::high_resolution_timer;
 
@@ -52,12 +53,11 @@ std::uint64_t num_iterations = 0;
 std::size_t k1 = 0;
 std::size_t k2 = 0;
 
-namespace test
-{
+namespace test {
     struct local_spinlock
     {
     private:
-        std::uint64_t v_;
+        std::atomic<bool> v_;
 
         ///////////////////////////////////////////////////////////////////////////
         static void yield(std::size_t k)
@@ -65,11 +65,9 @@ namespace test
             if (k < k1)
             {
             }
-            if(k < k2)
+            if (k < k2)
             {
-#if defined(BOOST_SMT_PAUSE)
-                BOOST_SMT_PAUSE
-#endif
+                HPX_SMT_PAUSE;
             }
             else if (hpx::threads::get_self_ptr())
             {
@@ -81,7 +79,7 @@ namespace test
                 Sleep(0);
 #else
                 // g++ -Wextra warns on {} or {0}
-                struct timespec rqtp = { 0, 0 };
+                struct timespec rqtp = {0, 0};
 
                 // POSIX says that timespec has tv_sec and tv_nsec
                 // But it doesn't guarantee order or placement
@@ -89,13 +87,14 @@ namespace test
                 rqtp.tv_sec = 0;
                 rqtp.tv_nsec = 1000;
 
-                nanosleep( &rqtp, nullptr );
+                nanosleep(&rqtp, nullptr);
 #endif
             }
         }
 
     public:
-        local_spinlock() : v_(0)
+        local_spinlock()
+          : v_(0)
         {
             HPX_ITT_SYNC_CREATE(this, "test::local_spinlock", "");
         }
@@ -112,10 +111,12 @@ namespace test
         {
             HPX_ITT_SYNC_PREPARE(this);
 
-            for (std::size_t k = 0; !try_lock(); ++k)
+            do
             {
-                local_spinlock::yield(k);
-            }
+                hpx::util::yield_while(
+                    [this]() noexcept { return is_locked(); },
+                    "test::local_spinlock::lock");
+            } while (!acquire_lock());
 
             HPX_ITT_SYNC_ACQUIRED(this);
             hpx::util::register_lock(this);
@@ -125,14 +126,10 @@ namespace test
         {
             HPX_ITT_SYNC_PREPARE(this);
 
-#if defined(BOOST_SP_HAS_SYNC_INTRINSICS) || defined(BOOST_SP_HAS_SYNC)
-            std::uint64_t r = __sync_lock_test_and_set(&v_, 1);
-#else
-            std::uint64_t r = BOOST_INTERLOCKED_EXCHANGE(&v_, 1);
-            HPX_COMPILER_FENCE;
-#endif
+            bool r = acquire_lock();    //-V707
 
-            if (r == 0) {
+            if (r)
+            {
                 HPX_ITT_SYNC_ACQUIRED(this);
                 hpx::util::register_lock(this);
                 return true;
@@ -146,18 +143,31 @@ namespace test
         {
             HPX_ITT_SYNC_RELEASING(this);
 
-#if defined(BOOST_SP_HAS_SYNC_INTRINSICS) || defined(BOOST_SP_HAS_SYNC)
-            __sync_lock_release(&v_);
-#else
-            HPX_COMPILER_FENCE;
-            *const_cast<std::uint64_t volatile*>(&v_) = 0;
-#endif
+            relinquish_lock();
 
             HPX_ITT_SYNC_RELEASED(this);
             hpx::util::unregister_lock(this);
         }
+
+    private:
+        // returns whether the mutex has been acquired
+        HPX_FORCEINLINE bool acquire_lock()
+        {
+            return !v_.exchange(true, std::memory_order_acquire);
+        }
+
+        // relinquish lock
+        HPX_FORCEINLINE void relinquish_lock()
+        {
+            v_.store(false, std::memory_order_release);
+        }
+
+        HPX_FORCEINLINE bool is_locked() const
+        {
+            return v_.load(std::memory_order_relaxed);
+        }
     };
-}
+}    // namespace test
 
 test::local_spinlock mtx[N];
 
@@ -184,9 +194,7 @@ double null_function(std::size_t i)
 HPX_PLAIN_ACTION(null_function, null_action)
 
 ///////////////////////////////////////////////////////////////////////////////
-int hpx_main(
-    variables_map& vm
-    )
+int hpx_main(variables_map& vm)
 {
     {
         num_iterations = vm["delay-iterations"].as<std::uint64_t>();
@@ -201,7 +209,7 @@ int hpx_main(
         if (HPX_UNLIKELY(0 == count))
             throw std::logic_error("error: count of 0 futures specified\n");
 
-        std::vector<future<double> > futures;
+        std::vector<future<double>> futures;
 
         futures.reserve(count);
 
@@ -226,22 +234,15 @@ int hpx_main(
                 const double duration = walltime.elapsed();
 
                 if (vm.count("csv"))
-                    hpx::util::format_to(cout,
-                        "{3},{4},{2}\n",
-                        count,
-                        duration,
-                        k1,
-                        k2
-                    ) << flush;
+                    hpx::util::format_to(
+                        cout, "{3},{4},{2}\n", count, duration, k1, k2)
+                        << flush;
                 else
                     hpx::util::format_to(cout,
                         "invoked {1} futures in {2} seconds "
                         "(k1 = {3}, k2 = {4})\n",
-                        count,
-                        duration,
-                        k1,
-                        k2
-                    ) << flush;
+                        count, duration, k1, k2)
+                        << flush;
                 hpx::util::print_cdash_timing("Spinlock1", duration);
             }
         }
@@ -252,34 +253,23 @@ int hpx_main(
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-int main(
-    int argc
-  , char* argv[]
-    )
+int main(int argc, char* argv[])
 {
     // Configure application-specific options.
     options_description cmdline("usage: " HPX_APPLICATION_STRING " [options]");
 
-    cmdline.add_options()
-        ( "futures"
-        , value<std::uint64_t>()->default_value(500000)
-        , "number of futures to invoke")
+    cmdline.add_options()("futures",
+        value<std::uint64_t>()->default_value(500000),
+        "number of futures to invoke")
 
-        ( "delay-iterations"
-        , value<std::uint64_t>()->default_value(0)
-        , "number of iterations in the delay loop")
+        ("delay-iterations", value<std::uint64_t>()->default_value(0),
+            "number of iterations in the delay loop")
 
-        ( "k1"
-        , value<std::size_t>()->default_value(32)
-        , "")
+            ("k1", value<std::size_t>()->default_value(32), "")
 
-        ( "k2"
-        , value<std::size_t>()->default_value(256)
-        , "")
+                ("k2", value<std::size_t>()->default_value(256), "")
 
-        ( "csv"
-        , "output results as csv (format: count,duration)")
-        ;
+                    ("csv", "output results as csv (format: count,duration)");
 
     // Initialize and run HPX.
     hpx::init_params init_args;


### PR DESCRIPTION
- adding a test combining serialization of all-types-assumed-to-be-bitwise-serializable, with
  pointer-serialization and shared_ptr serialization with pointer tracking
