### PR TITLE
Adding environmental query CPOs

### DIFF
--- a/libs/core/config/include/hpx/config/compiler_specific.hpp
+++ b/libs/core/config/include/hpx/config/compiler_specific.hpp
@@ -166,4 +166,5 @@
 #  endif
 #endif
 // clang-format on
-#endif
+
+#endif    // defined(DOXYGEN)

--- a/libs/core/execution/CMakeLists.txt
+++ b/libs/core/execution/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2021 The STE||AR-Group
+# Copyright (c) 2019-2022 The STE||AR-Group
 #
 # SPDX-License-Identifier: BSL-1.0
 # Distributed under the Boost Software License, Version 1.0. (See accompanying

--- a/libs/core/execution/include/hpx/execution/algorithms/let_value.hpp
+++ b/libs/core/execution/include/hpx/execution/algorithms/let_value.hpp
@@ -73,14 +73,7 @@ namespace hpx { namespace execution { namespace experimental {
             using value_types = hpx::util::detail::unique_t<
                 hpx::util::detail::concat_pack_of_packs_t<hpx::util::detail::
                         transform_t<successor_sender_types<Tuple, Variant>,
-                            value_types<Tuple, Variant>::template apply
-#if defined(HPX_CLANG_VERSION) && HPX_CLANG_VERSION < 110000
-                            >
-                    //
-                    >>;
-#else
-                            >>>;
-#endif
+                            value_types<Tuple, Variant>::template apply> /**/>>;
 
             // hpx::util::pack acts as a concrete type in place of Tuple. It is
             // required for computing successor_sender_types, but disappears

--- a/libs/core/execution_base/CMakeLists.txt
+++ b/libs/core/execution_base/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2020 The STE||AR-Group
+# Copyright (c) 2019-2022 The STE||AR-Group
 #
 # SPDX-License-Identifier: BSL-1.0
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -8,11 +8,17 @@ set(execution_base_headers
     hpx/execution_base/agent_base.hpp
     hpx/execution_base/agent_ref.hpp
     hpx/execution_base/any_sender.hpp
+    hpx/execution_base/completion_scheduler.hpp
     hpx/execution_base/context_base.hpp
     hpx/execution_base/detail/spinlock_deadlock_detection.hpp
     hpx/execution_base/execution.hpp
-    hpx/execution_base/completion_scheduler.hpp
+    hpx/execution_base/get_allocator.hpp
+    hpx/execution_base/get_env.hpp
+    hpx/execution_base/get_scheduler.hpp
+    hpx/execution_base/get_delegatee_scheduler.hpp
+    hpx/execution_base/get_stop_token.hpp
     hpx/execution_base/operation_state.hpp
+    hpx/execution_base/read.hpp
     hpx/execution_base/receiver.hpp
     hpx/execution_base/resource_base.hpp
     hpx/execution_base/sender.hpp

--- a/libs/core/execution_base/include/hpx/execution_base/get_allocator.hpp
+++ b/libs/core/execution_base/include/hpx/execution_base/get_allocator.hpp
@@ -1,0 +1,46 @@
+//  Copyright (c) 2022 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include <hpx/config.hpp>
+#include <hpx/execution_base/get_env.hpp>
+#include <hpx/execution_base/read.hpp>
+#include <hpx/functional/detail/tag_fallback_invoke.hpp>
+
+namespace hpx::execution::experimental {
+
+    // 1. execution::get_allocator is used to ask an object for its associated
+    //    allocator.
+    //
+    // 2. The name execution::get_allocator denotes a customization point object.
+    //     For some subexpression r, if the type of r is (possibly cv-qualified)
+    //     no_env, then execution::get_allocator(r) is ill-formed.
+    //     Otherwise, it is expression equivalent to:
+    //
+    //    1. tag_invoke(execution::get_allocator, as_const(r)), if this expression
+    //       is well formed.
+    //          Mandates: The tag_invoke expression above is not potentially-
+    //          throwing and its type satisfies Allocator.
+    //
+    //    2. Otherwise, execution::get_allocator(r) is ill-formed.
+    //
+    // 3. execution::get_allocator() (with no arguments) is expression-equivalent
+    //    to execution::read(execution::get_allocator).
+    //
+    inline constexpr struct get_allocator_t final
+      : hpx::functional::detail::tag_fallback<get_allocator_t>
+    {
+        friend inline constexpr auto tag_fallback_invoke(
+            get_allocator_t) noexcept;
+
+    } get_allocator{};
+
+    constexpr auto tag_fallback_invoke(get_allocator_t) noexcept
+    {
+        return hpx::execution::experimental::read(get_allocator);
+    }
+}    // namespace hpx::execution::experimental

--- a/libs/core/execution_base/include/hpx/execution_base/get_delegatee_scheduler.hpp
+++ b/libs/core/execution_base/include/hpx/execution_base/get_delegatee_scheduler.hpp
@@ -1,0 +1,48 @@
+//  Copyright (c) 2022 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include <hpx/config.hpp>
+#include <hpx/execution_base/get_env.hpp>
+#include <hpx/execution_base/read.hpp>
+#include <hpx/functional/detail/tag_fallback_invoke.hpp>
+
+namespace hpx::execution::experimental {
+
+    // 1. execution::get_delegatee_scheduler is used to ask an object for a
+    //    scheduler that may be used to delegate work to for the purpose of
+    //    forward progress delegation.
+    //
+    // 2. The name execution::get_scheduler denotes a customization point
+    //    object.
+    //    For some subexpression r, if the type of r is (possibly cv-qualified)
+    //    no_env, then execution::get_delegatee_scheduler(r) is ill-formed.
+    //    Otherwise, it is expression equivalent to:
+    //
+    //    1. tag_invoke(execution::get_delegatee_scheduler, as_const(r)), if
+    //       this expression is well formed.
+    //          Mandates: The tag_invoke expression above is not potentially-
+    //          throwing and its type satisfies execution::scheduler.
+    //
+    //    2. Otherwise, execution::get_delegatee_scheduler(r) is ill-formed.
+    //
+    // 3. execution::get_delegatee_scheduler() (with no arguments) is expression-
+    //    equivalent to execution::read(execution::get_delegatee_scheduler).
+    //
+    inline constexpr struct get_delegatee_scheduler_t final
+      : hpx::functional::detail::tag_fallback<get_delegatee_scheduler_t>
+    {
+        friend inline constexpr auto tag_fallback_invoke(
+            get_delegatee_scheduler_t) noexcept;
+
+    } get_delegatee_scheduler{};
+
+    constexpr auto tag_fallback_invoke(get_delegatee_scheduler_t) noexcept
+    {
+        return hpx::execution::experimental::read(get_delegatee_scheduler);
+    }
+}    // namespace hpx::execution::experimental

--- a/libs/core/execution_base/include/hpx/execution_base/get_env.hpp
+++ b/libs/core/execution_base/include/hpx/execution_base/get_env.hpp
@@ -1,0 +1,179 @@
+//  Copyright (c) 2022 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include <hpx/config.hpp>
+#include <hpx/functional/detail/tag_fallback_invoke.hpp>
+#include <hpx/type_support/hide_from_adl.hpp>
+#include <hpx/type_support/unwrap_ref.hpp>
+
+#include <type_traits>
+#include <utility>
+
+namespace hpx::execution::experimental {
+
+    // 1. An execution environment contains state associated with the
+    //    completion of an asynchronous operation. Every receiver has an
+    //    associated execution environment, accessible with the get_env
+    //    receiver query. The state of an execution environment is accessed
+    //    with customization point objects. An execution environment may
+    //    respond to any number of these environment queries.
+    //
+    // 2. An environment query is a customization point object that accepts
+    //    as its first argument an execution environment. For an environment
+    //    query EQ and an object e of type no_env, the expression EQ(e) shall
+    //    be ill-formed.
+    //
+    namespace exec_envs {
+
+        // no_env is a special environment used by the sender concept and by
+        // the get_completion_signatures customization point when the user
+        // has specified no environment argument.
+        //
+        //  [Note: A user may choose to not specify an environment in order
+        //         to see if a sender knows its completion signatures
+        //         independent of any particular execution environment.
+        //  -- end note]
+        struct no_env
+        {
+            template <typename Tag, typename Env>
+            friend std::enable_if_t<std::is_same_v<no_env, std::decay_t<Env>>>
+                tag_invoke(Tag, Env) = delete;
+        };
+
+        struct empty_env
+        {
+        };
+
+        template <typename Tag, typename Value,
+            typename BaseEnvId = util::hide_from_adl<empty_env>>
+        struct env
+        {
+            using BaseEnv = util::hidden_from_adl_t<BaseEnvId>;
+
+            HPX_NO_UNIQUE_ADDRESS util::unwrap_reference_t<Value> value_;
+            HPX_NO_UNIQUE_ADDRESS BaseEnv base_env_{};
+
+            // Forward only the receiver queries
+            template <typename Tag2, typename... Args,
+                typename = std::enable_if_t<functional::is_tag_invocable_v<Tag2,
+                    BaseEnv const&, Args...>>>
+            friend constexpr auto tag_invoke(
+                Tag2 tag, env const& self, Args&&... args) noexcept
+                -> functional::tag_invoke_result_t<Tag2, BaseEnv const&,
+                    Args...>
+            {
+                return HPX_FORWARD(Tag2, tag)(
+                    self.base_env_, HPX_FORWARD(Args, args)...);
+            }
+
+            template <typename... Args>
+            friend constexpr auto
+            tag_invoke(Tag, env const& self, Args&&...) noexcept(
+                std::is_nothrow_copy_constructible_v<
+                    util::unwrap_reference_t<Value>>)
+                -> util::unwrap_reference_t<Value>
+            {
+                return self.value_;
+            }
+        };
+
+        template <typename Tag>
+        struct make_env_t
+        {
+            template <typename Value>
+            constexpr auto operator()(Value&& value) const
+                noexcept(std::is_nothrow_copy_constructible_v<
+                    util::unwrap_reference_t<std::decay_t<Value>>>)
+                    -> env<Tag, std::decay_t<Value>>
+            {
+                return {HPX_FORWARD(Value, value)};
+            }
+
+            template <typename Value, typename BaseEnv>
+            constexpr auto operator()(Value&& value, BaseEnv&& base_env) const
+                -> env<Tag, std::decay_t<Value>,
+                    util::hide_from_adl<std::decay_t<BaseEnv>>>
+            {
+                return {
+                    HPX_FORWARD(Value, value), HPX_FORWARD(BaseEnv, base_env)};
+            }
+        };
+
+        // For making an evaluation environment from a key/value pair, and
+        // optionally another environment.
+        template <typename Tag>
+        inline constexpr exec_envs::make_env_t<Tag> make_env{};
+
+    }    // namespace exec_envs
+
+    using exec_envs::empty_env;
+    using exec_envs::env;
+    using exec_envs::make_env;
+    using exec_envs::no_env;
+
+    template <typename Env>
+    struct is_no_env : std::is_same<std::decay_t<Env>, no_env>
+    {
+    };
+
+    template <typename Env>
+    inline constexpr bool is_no_env_v = is_no_env<Env>::value;
+
+    // get_env is a customization point object. For some subexpression r,
+    // get_env(r) is expression-equivalent to:
+    //
+    // 1. tag_invoke(execution::get_env, r) if that expression is well-formed.
+    // 2. Otherwise, empty_env{}.
+    //
+    inline constexpr struct get_env_t final
+      : hpx::functional::detail::tag_fallback<get_env_t>
+    {
+        template <typename EnvProvider>
+        friend constexpr HPX_FORCEINLINE auto tag_fallback_invoke(
+            get_env_t, EnvProvider&&) noexcept
+        {
+            return empty_env{};
+        }
+    } get_env{};
+
+    template <typename T>
+    using env_of_t = decltype(get_env(std::declval<T>()));
+
+    template <typename Tag, typename Value, typename BaseEnv = empty_env>
+    using make_env_t =
+        decltype(make_env<Tag>(std::declval<Value>(), std::declval<BaseEnv>()));
+
+    // execution::forwarding_env_query is used to ask a customization point
+    // object whether it is an environment query that should be forwarded
+    // through environment adaptors.
+    //
+    // The name execution::forwarding_env_query denotes a customization point
+    // object. For some subexpression t, execution::forwarding_env_query(t)
+    // is expression equivalent to:
+    //
+    // 1. tag_invoke(execution::forwarding_env_query, t), contextually
+    //    converted to bool, if the tag_invoke expression is well formed.
+    //      Mandates: The tag_invoke expression is indeed contextually
+    //      convertible to bool, that expression and the contextual conversion
+    //      are not potentially-throwing and are core constant expressions if t
+    //      is a core constant expression.
+    // 2. Otherwise, false.
+    //
+    inline constexpr struct forwarding_env_query_t final
+      : hpx::functional::detail::tag_fallback<forwarding_env_query_t>
+    {
+        template <typename T>
+        friend constexpr HPX_FORCEINLINE auto tag_fallback_invoke(
+            forwarding_env_query_t, T&&) noexcept
+        {
+            return true;
+        }
+
+    } forwarding_env_query{};
+
+}    // namespace hpx::execution::experimental

--- a/libs/core/execution_base/include/hpx/execution_base/get_scheduler.hpp
+++ b/libs/core/execution_base/include/hpx/execution_base/get_scheduler.hpp
@@ -1,0 +1,48 @@
+//  Copyright (c) 2022 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include <hpx/config.hpp>
+#include <hpx/execution_base/get_env.hpp>
+#include <hpx/execution_base/read.hpp>
+#include <hpx/functional/detail/tag_fallback_invoke.hpp>
+
+namespace hpx::execution::experimental {
+
+    // 1. execution::get_scheduler is used to ask an object for its associated
+    //    scheduler.
+    //
+    // 2. The name execution::get_scheduler denotes a customization point object.
+    //    For some subexpression r, if the type of r is (possibly cv-qualified)
+    //    no_env, then execution::get_scheduler(r) is ill-formed.
+    //
+    //    Otherwise, it is expression equivalent to:
+    //
+    //    1. tag_invoke(execution::get_scheduler, as_const(r)), if this expression
+    //       is well formed.
+    //
+    //       Mandates: The tag_invoke expression above is not potentially-
+    //                 throwing and its type satisfies execution::scheduler.
+    //
+    //    2. Otherwise, execution::get_scheduler(r) is ill-formed.
+    //
+    // 3. execution::get_scheduler() (with no arguments) is expression-equivalent
+    //    to execution::read(execution::get_scheduler).
+    //
+    inline constexpr struct get_scheduler_t final
+      : hpx::functional::detail::tag_fallback<get_scheduler_t>
+    {
+        friend inline constexpr auto tag_fallback_invoke(
+            get_scheduler_t) noexcept;
+
+    } get_scheduler{};
+
+    constexpr auto tag_fallback_invoke(get_scheduler_t) noexcept
+    {
+        return hpx::execution::experimental::read(get_scheduler);
+    }
+}    // namespace hpx::execution::experimental

--- a/libs/core/execution_base/include/hpx/execution_base/get_stop_token.hpp
+++ b/libs/core/execution_base/include/hpx/execution_base/get_stop_token.hpp
@@ -1,0 +1,48 @@
+//  Copyright (c) 2022 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include <hpx/config.hpp>
+#include <hpx/execution_base/get_env.hpp>
+#include <hpx/execution_base/read.hpp>
+#include <hpx/functional/detail/tag_fallback_invoke.hpp>
+
+namespace hpx::execution::experimental {
+
+    // 1. execution::get_stop_token is used to ask an object for an
+    //    associated stop token.
+    //
+    // 2. The name execution::get_stop_token denotes a customization
+    //    point object. For some subexpression r, if the type of r is
+    //    (possibly cv-qualified) no_env, then execution::get_stop_token(r)
+    //    is ill-formed.
+    //    Otherwise, it is expression equivalent to:
+    //
+    //    1. tag_invoke(execution::get_stop_token, as_const(r)), if this
+    //       expression is well formed.
+    //
+    //          Mandates: The tag_invoke expression above is not potentially
+    //          -throwing and its type satisfies stoppable_token.
+    //
+    //    2. Otherwise, never_stop_token{}.
+    //
+    // 3.  execution::get_stop_token() (with no arguments) is expression-
+    //     equivalent to execution::read(execution::get_stop_token).
+    //
+    inline constexpr struct get_stop_token_t final
+      : hpx::functional::detail::tag_fallback<get_stop_token_t>
+    {
+        friend inline constexpr auto tag_fallback_invoke(
+            get_stop_token_t) noexcept;
+
+    } get_stop_token{};
+
+    constexpr auto tag_fallback_invoke(get_stop_token_t) noexcept
+    {
+        return hpx::execution::experimental::read(get_stop_token);
+    }
+}    // namespace hpx::execution::experimental

--- a/libs/core/execution_base/include/hpx/execution_base/read.hpp
+++ b/libs/core/execution_base/include/hpx/execution_base/read.hpp
@@ -1,0 +1,94 @@
+//  Copyright (c) 2022 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include <hpx/config.hpp>
+#include <hpx/errors/try_catch_exception_ptr.hpp>
+#include <hpx/execution_base/get_env.hpp>
+#include <hpx/execution_base/receiver.hpp>
+#include <hpx/execution_base/sender.hpp>
+#include <hpx/functional/tag_invoke.hpp>
+#include <hpx/type_support/pack.hpp>
+
+#include <cstddef>
+#include <exception>
+#include <stdexcept>
+#include <utility>
+
+namespace hpx::execution::experimental {
+
+    namespace detail {
+
+        template <typename Tag>
+        struct read_sender
+        {
+            constexpr read_sender() = default;
+
+            read_sender(read_sender&&) = default;
+            read_sender(read_sender const&) = default;
+            read_sender& operator=(read_sender&&) = default;
+            read_sender& operator=(read_sender const&) = default;
+
+            template <typename Receiver>
+            struct operation_state
+            {
+                HPX_NO_UNIQUE_ADDRESS std::decay_t<Receiver> receiver;
+
+                template <typename Receiver_>
+                operation_state(Receiver_&& receiver) noexcept
+                  : receiver(HPX_FORWARD(Receiver_, receiver))
+                {
+                }
+
+                operation_state(operation_state&&) = delete;
+                operation_state& operator=(operation_state&&) = delete;
+                operation_state(operation_state const&) = delete;
+                operation_state& operator=(operation_state const&) = delete;
+
+                friend void tag_invoke(start_t, operation_state& os) noexcept
+                {
+                    hpx::detail::try_catch_exception_ptr(
+                        [&]() {
+                            auto env = hpx::execution::experimental::get_env(
+                                os.receiver);
+                            hpx::execution::experimental::set_value(
+                                HPX_MOVE(os.receiver), Tag()(HPX_MOVE(env)));
+                        },
+                        [&](std::exception_ptr ep) {
+                            hpx::execution::experimental::set_error(
+                                HPX_MOVE(os.receiver), HPX_MOVE(ep));
+                        });
+                }
+            };
+
+            template <typename Receiver>
+            friend auto tag_invoke(
+                connect_t, read_sender&&, Receiver&& receiver)
+            {
+                return operation_state<Receiver>{
+                    HPX_FORWARD(Receiver, receiver)};
+            }
+
+            template <typename Receiver>
+            friend auto tag_invoke(connect_t, read_sender&, Receiver&& receiver)
+            {
+                return operation_state<Receiver>{
+                    HPX_FORWARD(Receiver, receiver)};
+            }
+        };
+    }    // namespace detail
+
+    inline constexpr struct read_t final : hpx::functional::tag<read_t>
+    {
+        template <typename Tag>
+        friend constexpr auto tag_invoke(read_t, Tag) noexcept
+        {
+            return detail::read_sender<Tag>{};
+        }
+    } read{};
+
+}    // namespace hpx::execution::experimental

--- a/libs/core/execution_base/tests/unit/CMakeLists.txt
+++ b/libs/core/execution_base/tests/unit/CMakeLists.txt
@@ -1,12 +1,20 @@
 # Copyright (c) 2019 Thomas Heller
-# Copyright (c) 2020 Hartmut Kaiser
+# Copyright (c) 2020-2022 Hartmut Kaiser
 #
 # SPDX-License-Identifier: BSL-1.0
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-set(tests any_sender basic_operation_state basic_receiver basic_sender
-          basic_schedule execution_context
+set(tests
+    any_sender
+    basic_operation_state
+    basic_receiver
+    basic_sender
+    basic_schedule
+    environment_queries
+    execution_context
+    forwarding_env_query
+    get_env
 )
 
 foreach(test ${tests})

--- a/libs/core/execution_base/tests/unit/environment_queries.cpp
+++ b/libs/core/execution_base/tests/unit/environment_queries.cpp
@@ -1,0 +1,182 @@
+//  Copyright (c) 2022 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/execution_base/get_allocator.hpp>
+#include <hpx/execution_base/get_delegatee_scheduler.hpp>
+#include <hpx/execution_base/get_env.hpp>
+#include <hpx/execution_base/get_scheduler.hpp>
+#include <hpx/execution_base/get_stop_token.hpp>
+#include <hpx/execution_base/operation_state.hpp>
+#include <hpx/execution_base/receiver.hpp>
+#include <hpx/execution_base/sender.hpp>
+#include <hpx/modules/testing.hpp>
+
+#include <exception>
+#include <type_traits>
+
+bool set_value_sched_called = false;
+bool set_value_delegatee_sched_called = false;
+bool set_value_allocator_called = false;
+bool set_value_stop_token_called = false;
+
+namespace mylib {
+
+    struct sched
+    {
+    };
+
+    using sched_env_t = hpx::execution::experimental::make_env_t<
+        hpx::execution::experimental::get_scheduler_t, sched>;
+
+    struct delegatee_sched
+    {
+    };
+
+    using delegatee_sched_env_t = hpx::execution::experimental::make_env_t<
+        hpx::execution::experimental::get_delegatee_scheduler_t,
+        delegatee_sched, sched_env_t>;
+
+    struct allocator
+    {
+    };
+
+    using allocator_env_t = hpx::execution::experimental::make_env_t<
+        hpx::execution::experimental::get_allocator_t, allocator,
+        delegatee_sched_env_t>;
+
+    struct stop_token
+    {
+    };
+
+    using stop_token_env_t = hpx::execution::experimental::make_env_t<
+        hpx::execution::experimental::get_stop_token_t, stop_token,
+        allocator_env_t>;
+
+    struct receiver_1
+    {
+        friend void tag_invoke(
+            hpx::execution::experimental::set_stopped_t, receiver_1&&) noexcept
+        {
+        }
+
+        friend void tag_invoke(hpx::execution::experimental::set_error_t,
+            receiver_1&&, std::exception_ptr) noexcept
+        {
+        }
+
+        friend void tag_invoke(
+            hpx::execution::experimental::set_value_t, receiver_1&&, sched)
+        {
+            set_value_sched_called = true;
+        }
+
+        friend void tag_invoke(hpx::execution::experimental::set_value_t,
+            receiver_1&&, delegatee_sched)
+        {
+            set_value_delegatee_sched_called = true;
+        }
+
+        friend void tag_invoke(
+            hpx::execution::experimental::set_value_t, receiver_1&&, allocator)
+        {
+            set_value_allocator_called = true;
+        }
+
+        friend void tag_invoke(
+            hpx::execution::experimental::set_value_t, receiver_1&&, stop_token)
+        {
+            set_value_stop_token_called = true;
+        }
+
+        friend constexpr auto tag_invoke(
+            hpx::execution::experimental::get_env_t, receiver_1) noexcept
+        {
+            auto sched_env = hpx::execution::experimental::make_env<
+                hpx::execution::experimental::get_scheduler_t>(sched());
+            static_assert(std::is_same_v<decltype(sched_env), sched_env_t>,
+                "must return sched_env");
+
+            auto delegatee_sched_env = hpx::execution::experimental::make_env<
+                hpx::execution::experimental::get_delegatee_scheduler_t>(
+                delegatee_sched(), sched_env);
+            static_assert(std::is_same_v<decltype(delegatee_sched_env),
+                              delegatee_sched_env_t>,
+                "must return delegatee_sched_env");
+
+            auto allocator_env = hpx::execution::experimental::make_env<
+                hpx::execution::experimental::get_allocator_t>(
+                allocator(), delegatee_sched_env);
+            static_assert(
+                std::is_same_v<decltype(allocator_env), allocator_env_t>,
+                "must return allocator_env");
+
+            auto stop_token_env = hpx::execution::experimental::make_env<
+                hpx::execution::experimental::get_stop_token_t>(
+                stop_token(), allocator_env);
+            static_assert(
+                std::is_same_v<decltype(stop_token_env), stop_token_env_t>,
+                "must return stop_token_env");
+
+            return stop_token_env;
+        }
+    };
+}    // namespace mylib
+
+int main()
+{
+    {
+        mylib::receiver_1 rcv;
+        auto env = hpx::execution::experimental::get_env(rcv);
+
+        auto sched = hpx::execution::experimental::get_scheduler(env);
+        static_assert(std::is_same_v<decltype(sched), mylib::sched>,
+            "must return mylib::sched");
+
+        auto delegatee_sched =
+            hpx::execution::experimental::get_delegatee_scheduler(env);
+        static_assert(
+            std::is_same_v<decltype(delegatee_sched), mylib::delegatee_sched>,
+            "must return mylib::delegatee_sched");
+
+        auto allocator = hpx::execution::experimental::get_allocator(env);
+        static_assert(std::is_same_v<decltype(allocator), mylib::allocator>,
+            "must return mylib::allocator");
+
+        auto stop_token = hpx::execution::experimental::get_stop_token(env);
+        static_assert(std::is_same_v<decltype(stop_token), mylib::stop_token>,
+            "must return mylib::stop_token");
+    }
+    {
+        mylib::receiver_1 rcv;
+        auto os = hpx::execution::experimental::connect(
+            hpx::execution::experimental::get_scheduler(), rcv);
+        hpx::execution::experimental::start(os);
+        HPX_TEST(set_value_sched_called);
+    }
+    {
+        mylib::receiver_1 rcv;
+        auto os = hpx::execution::experimental::connect(
+            hpx::execution::experimental::get_delegatee_scheduler(), rcv);
+        hpx::execution::experimental::start(os);
+        HPX_TEST(set_value_delegatee_sched_called);
+    }
+    {
+        mylib::receiver_1 rcv;
+        auto os = hpx::execution::experimental::connect(
+            hpx::execution::experimental::get_allocator(), rcv);
+        hpx::execution::experimental::start(os);
+        HPX_TEST(set_value_allocator_called);
+    }
+    {
+        mylib::receiver_1 rcv;
+        auto os = hpx::execution::experimental::connect(
+            hpx::execution::experimental::get_stop_token(), rcv);
+        hpx::execution::experimental::start(os);
+        HPX_TEST(set_value_stop_token_called);
+    }
+
+    return hpx::util::report_errors();
+}

--- a/libs/core/execution_base/tests/unit/forwarding_env_query.cpp
+++ b/libs/core/execution_base/tests/unit/forwarding_env_query.cpp
@@ -1,0 +1,43 @@
+//  Copyright (c) 2022 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/execution_base/get_env.hpp>
+#include <hpx/execution_base/get_scheduler.hpp>
+#include <hpx/functional/tag_invoke.hpp>
+#include <hpx/modules/testing.hpp>
+
+#include <exception>
+#include <string>
+#include <type_traits>
+#include <utility>
+
+namespace mylib {
+
+    inline constexpr struct non_query_t final
+      : hpx::functional::tag<non_query_t>
+    {
+        friend constexpr auto tag_invoke(
+            hpx::execution::experimental::forwarding_env_query_t,
+            non_query_t) noexcept
+        {
+            return false;
+        }
+    } non_query{};
+
+}    // namespace mylib
+
+int main()
+{
+    static_assert(
+        !hpx::execution::experimental::forwarding_env_query(mylib::non_query),
+        "non_query is not an environmental query");
+
+    static_assert(hpx::execution::experimental::forwarding_env_query(
+                      hpx::execution::experimental::get_scheduler),
+        "get_scheduler is an environmental query");
+
+    return hpx::util::report_errors();
+}

--- a/libs/core/execution_base/tests/unit/get_env.cpp
+++ b/libs/core/execution_base/tests/unit/get_env.cpp
@@ -1,0 +1,130 @@
+//  Copyright (c) 2022 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/execution_base/get_env.hpp>
+#include <hpx/execution_base/receiver.hpp>
+#include <hpx/modules/testing.hpp>
+
+#include <exception>
+#include <string>
+#include <type_traits>
+#include <utility>
+
+struct some_env
+{
+};
+
+namespace mylib {
+    struct receiver_1
+    {
+    };
+
+    struct receiver_2
+    {
+        friend some_env tag_invoke(
+            hpx::execution::experimental::get_env_t, receiver_2&&)
+        {
+            return some_env{};
+        }
+    };
+
+    inline constexpr struct receiver_env_t final
+      : hpx::functional::tag<receiver_env_t>
+    {
+    } receiver_env{};
+
+    using env3_t =
+        hpx::execution::experimental::make_env_t<receiver_env_t, int>;
+
+    struct receiver_3
+    {
+        friend constexpr auto tag_invoke(
+            hpx::execution::experimental::get_env_t, receiver_3&&) noexcept
+        {
+            return hpx::execution::experimental::make_env<receiver_env_t>(42);
+        }
+    };
+
+    using env4_t = hpx::execution::experimental::make_env_t<receiver_env_t,
+        std::string, env3_t>;
+
+    struct receiver_4
+    {
+        friend auto tag_invoke(
+            hpx::execution::experimental::get_env_t, receiver_4&&) noexcept
+        {
+            receiver_3 rcv;
+            return hpx::execution::experimental::make_env<receiver_env_t>(
+                std::string("42"),
+                hpx::execution::experimental::get_env(std::move(rcv)));
+        }
+    };
+
+    inline constexpr struct receiver_env1_t final
+      : hpx::functional::tag<receiver_env1_t>
+    {
+    } receiver_env1{};
+
+    using env5_t = hpx::execution::experimental::make_env_t<receiver_env1_t,
+        std::string, env3_t>;
+
+    struct receiver_5
+    {
+        friend auto tag_invoke(
+            hpx::execution::experimental::get_env_t, receiver_5&&) noexcept
+        {
+            receiver_3 rcv;
+            return hpx::execution::experimental::make_env<receiver_env1_t>(
+                std::string("42"),
+                hpx::execution::experimental::get_env(std::move(rcv)));
+        }
+    };
+}    // namespace mylib
+
+int main()
+{
+    using hpx::execution::experimental::empty_env;
+    using hpx::execution::experimental::is_no_env_v;
+    using hpx::execution::experimental::no_env;
+
+    static_assert(
+        is_no_env_v<no_env>, "no_env is a (possibly cv-qualified) no_env");
+    static_assert(is_no_env_v<no_env const&>,
+        "no_env is a (possibly cv-qualified) no_env");
+    static_assert(!is_no_env_v<some_env>,
+        "some_env is not a (possibly cv-qualified) no_env");
+
+    {
+        mylib::receiver_1 rcv;
+        auto env = hpx::execution::experimental::get_env(std::move(rcv));
+        static_assert(
+            std::is_same_v<decltype(env), empty_env>, "must return empty_env");
+    }
+    {
+        mylib::receiver_2 rcv;
+        auto env = hpx::execution::experimental::get_env(std::move(rcv));
+        static_assert(
+            std::is_same_v<decltype(env), some_env>, "must return some_env");
+    }
+    {
+        mylib::receiver_3 rcv;
+        auto env = hpx::execution::experimental::get_env(std::move(rcv));
+        HPX_TEST_EQ(mylib::receiver_env(env), 42);
+    }
+    {
+        mylib::receiver_4 rcv;
+        auto env = hpx::execution::experimental::get_env(std::move(rcv));
+        HPX_TEST_EQ(mylib::receiver_env(env), std::string("42"));
+    }
+    {
+        mylib::receiver_5 rcv;
+        auto env = hpx::execution::experimental::get_env(std::move(rcv));
+        HPX_TEST_EQ(mylib::receiver_env(env), 42);
+        HPX_TEST_EQ(mylib::receiver_env1(env), std::string("42"));
+    }
+
+    return hpx::util::report_errors();
+}

--- a/libs/core/tag_invoke/include/hpx/functional/detail/tag_fallback_invoke.hpp
+++ b/libs/core/tag_invoke/include/hpx/functional/detail/tag_fallback_invoke.hpp
@@ -223,6 +223,7 @@ namespace hpx::functional::detail {
         struct not_tag_fallback_noexcept_dispatchable;
 
         // poison pill
+        void tag_invoke();
         void tag_fallback_invoke();
 
         ///////////////////////////////////////////////////////////////////////////

--- a/libs/core/testing/include/hpx/modules/testing.hpp
+++ b/libs/core/testing/include/hpx/modules/testing.hpp
@@ -173,7 +173,7 @@ namespace hpx { namespace util {
             }
         };
 
-        HPX_CORE_EXPORT extern fixture global_fixture;
+        HPX_CORE_EXPORT fixture& global_fixture();
 
     }    // namespace detail
 
@@ -196,7 +196,7 @@ namespace hpx { namespace util {
         HPX_PP_CAT(HPX_TEST_, HPX_PP_NARGS(__VA_ARGS__))(__VA_ARGS__))         \
     /**/
 #define HPX_TEST_1(expr)                                                       \
-    HPX_TEST_IMPL(::hpx::util::detail::global_fixture, expr)
+    HPX_TEST_IMPL(::hpx::util::detail::global_fixture(), expr)
 #define HPX_TEST_2(strm, expr)                                                 \
     HPX_TEST_IMPL(::hpx::util::detail::fixture{strm}, expr)
 
@@ -214,7 +214,7 @@ namespace hpx { namespace util {
         HPX_PP_CAT(HPX_TEST_MSG_, HPX_PP_NARGS(__VA_ARGS__))(__VA_ARGS__))     \
     /**/
 #define HPX_TEST_MSG_2(expr, msg)                                              \
-    HPX_TEST_MSG_IMPL(::hpx::util::detail::global_fixture, expr, msg)
+    HPX_TEST_MSG_IMPL(::hpx::util::detail::global_fixture(), expr, msg)
 #define HPX_TEST_MSG_3(strm, expr, msg)                                        \
     HPX_TEST_MSG_IMPL(::hpx::util::detail::fixture{strm}, expr, msg)
 
@@ -232,7 +232,7 @@ namespace hpx { namespace util {
         HPX_PP_CAT(HPX_TEST_EQ_, HPX_PP_NARGS(__VA_ARGS__))(__VA_ARGS__))      \
     /**/
 #define HPX_TEST_EQ_2(expr1, expr2)                                            \
-    HPX_TEST_EQ_IMPL(::hpx::util::detail::global_fixture, expr1, expr2)
+    HPX_TEST_EQ_IMPL(::hpx::util::detail::global_fixture(), expr1, expr2)
 #define HPX_TEST_EQ_3(strm, expr1, expr2)                                      \
     HPX_TEST_EQ_IMPL(::hpx::util::detail::fixture{strm}, expr1, expr2)
 
@@ -251,7 +251,7 @@ namespace hpx { namespace util {
         HPX_PP_CAT(HPX_TEST_NEQ_, HPX_PP_NARGS(__VA_ARGS__))(__VA_ARGS__))     \
     /**/
 #define HPX_TEST_NEQ_2(expr1, expr2)                                           \
-    HPX_TEST_NEQ_IMPL(::hpx::util::detail::global_fixture, expr1, expr2)
+    HPX_TEST_NEQ_IMPL(::hpx::util::detail::global_fixture(), expr1, expr2)
 #define HPX_TEST_NEQ_3(strm, expr1, expr2)                                     \
     HPX_TEST_NEQ_IMPL(::hpx::util::detail::fixture{strm}, expr1, expr2)
 
@@ -270,7 +270,7 @@ namespace hpx { namespace util {
         HPX_PP_CAT(HPX_TEST_LT_, HPX_PP_NARGS(__VA_ARGS__))(__VA_ARGS__))      \
     /**/
 #define HPX_TEST_LT_2(expr1, expr2)                                            \
-    HPX_TEST_LT_IMPL(::hpx::util::detail::global_fixture, expr1, expr2)
+    HPX_TEST_LT_IMPL(::hpx::util::detail::global_fixture(), expr1, expr2)
 #define HPX_TEST_LT_3(strm, expr1, expr2)                                      \
     HPX_TEST_LT_IMPL(::hpx::util::detail::fixture{strm}, expr1, expr2)
 
@@ -289,7 +289,7 @@ namespace hpx { namespace util {
         HPX_PP_CAT(HPX_TEST_LTE_, HPX_PP_NARGS(__VA_ARGS__))(__VA_ARGS__))     \
     /**/
 #define HPX_TEST_LTE_2(expr1, expr2)                                           \
-    HPX_TEST_LTE_IMPL(::hpx::util::detail::global_fixture, expr1, expr2)
+    HPX_TEST_LTE_IMPL(::hpx::util::detail::global_fixture(), expr1, expr2)
 #define HPX_TEST_LTE_3(strm, expr1, expr2)                                     \
     HPX_TEST_LTE_IMPL(::hpx::util::detail::fixture{strm}, expr1, expr2)
 
@@ -309,7 +309,7 @@ namespace hpx { namespace util {
     /**/
 #define HPX_TEST_RANGE_3(expr1, expr2, expr3)                                  \
     HPX_TEST_RANGE_IMPL(                                                       \
-        ::hpx::util::detail::global_fixture, expr1, expr2, expr3)
+        ::hpx::util::detail::global_fixture(), expr1, expr2, expr3)
 #define HPX_TEST_RANGE_4(strm, expr1, expr2, expr3)                            \
     HPX_TEST_RANGE_IMPL(::hpx::util::detail::fixture{strm}, expr1, expr2, expr3)
 
@@ -329,7 +329,8 @@ namespace hpx { namespace util {
         HPX_PP_CAT(HPX_TEST_EQ_MSG_, HPX_PP_NARGS(__VA_ARGS__))(__VA_ARGS__))  \
     /**/
 #define HPX_TEST_EQ_MSG_3(expr1, expr2, msg)                                   \
-    HPX_TEST_EQ_MSG_IMPL(::hpx::util::detail::global_fixture, expr1, expr2, msg)
+    HPX_TEST_EQ_MSG_IMPL(                                                      \
+        ::hpx::util::detail::global_fixture(), expr1, expr2, msg)
 #define HPX_TEST_EQ_MSG_4(strm, expr1, expr2, msg)                             \
     HPX_TEST_EQ_MSG_IMPL(::hpx::util::detail::fixture{strm}, expr1, expr2, msg)
 
@@ -348,7 +349,7 @@ namespace hpx { namespace util {
     /**/
 #define HPX_TEST_NEQ_MSG_3(expr1, expr2, msg)                                  \
     HPX_TEST_NEQ_MSG_IMPL(                                                     \
-        ::hpx::util::detail::global_fixture, expr1, expr2, msg)
+        ::hpx::util::detail::global_fixture(), expr1, expr2, msg)
 #define HPX_TEST_NEQ_MSG_4(strm, expr1, expr2, msg)                            \
     HPX_TEST_NEQ_MSG_IMPL(::hpx::util::detail::fixture{strm}, expr1, expr2, msg)
 
@@ -366,7 +367,8 @@ namespace hpx { namespace util {
         HPX_PP_CAT(HPX_TEST_LT_MSG_, HPX_PP_NARGS(__VA_ARGS__))(__VA_ARGS__))  \
     /**/
 #define HPX_TEST_LT_MSG_3(expr1, expr2, msg)                                   \
-    HPX_TEST_LT_MSG_IMPL(::hpx::util::detail::global_fixture, expr1, expr2, msg)
+    HPX_TEST_LT_MSG_IMPL(                                                      \
+        ::hpx::util::detail::global_fixture(), expr1, expr2, msg)
 #define HPX_TEST_LT_MSG_4(strm, expr1, expr2, msg)                             \
     HPX_TEST_LT_MSG_IMPL(::hpx::util::detail::fixture{strm}, expr1, expr2, msg)
 
@@ -385,7 +387,7 @@ namespace hpx { namespace util {
     /**/
 #define HPX_TEST_LTE_MSG_3(expr1, expr2, msg)                                  \
     HPX_TEST_LTE_MSG_IMPL(                                                     \
-        ::hpx::util::detail::global_fixture, expr1, expr2, msg)
+        ::hpx::util::detail::global_fixture(), expr1, expr2, msg)
 #define HPX_TEST_LTE_MSG_4(strm, expr1, expr2, msg)                            \
     HPX_TEST_LTE_MSG_IMPL(::hpx::util::detail::fixture{strm}, expr1, expr2, msg)
 
@@ -404,7 +406,7 @@ namespace hpx { namespace util {
     /**/
 #define HPX_TEST_RANGE_MSG_4(expr1, expr2, expr3, msg)                         \
     HPX_TEST_RANGE_MSG_IMPL(                                                   \
-        ::hpx::util::detail::global_fixture, expr1, expr2, expr3, msg)
+        ::hpx::util::detail::global_fixture(), expr1, expr2, expr3, msg)
 #define HPX_TEST_RANGE_MSG_5(strm, expr1, expr2, expr3, msg)                   \
     HPX_TEST_RANGE_MSG_IMPL(                                                   \
         ::hpx::util::detail::fixture{strm}, expr1, expr2, expr3, msg)
@@ -423,7 +425,7 @@ namespace hpx { namespace util {
         HPX_PP_CAT(HPX_SANITY_, HPX_PP_NARGS(__VA_ARGS__))(__VA_ARGS__))       \
     /**/
 #define HPX_SANITY_1(expr)                                                     \
-    HPX_TEST_IMPL(::hpx::util::detail::global_fixture, expr)
+    HPX_TEST_IMPL(::hpx::util::detail::global_fixture(), expr)
 #define HPX_SANITY_2(strm, expr)                                               \
     HPX_SANITY_IMPL(::hpx::util::detail::fixture{strm}, expr)
 
@@ -442,7 +444,7 @@ namespace hpx { namespace util {
         HPX_PP_CAT(HPX_SANITY_MSG_, HPX_PP_NARGS(__VA_ARGS__))(__VA_ARGS__))   \
     /**/
 #define HPX_SANITY_MSG_2(expr, msg)                                            \
-    HPX_SANITY_MSG_IMPL(::hpx::util::detail::global_fixture, expr, msg)
+    HPX_SANITY_MSG_IMPL(::hpx::util::detail::global_fixture(), expr, msg)
 #define HPX_SANITY_MSG_3(strm, expr, msg)                                      \
     HPX_SANITY_MSG_IMPL(::hpx::util::detail::fixture{strm}, expr, msg)
 
@@ -460,7 +462,7 @@ namespace hpx { namespace util {
         HPX_PP_CAT(HPX_SANITY_EQ_, HPX_PP_NARGS(__VA_ARGS__))(__VA_ARGS__))    \
     /**/
 #define HPX_SANITY_EQ_2(expr1, expr2)                                          \
-    HPX_SANITY_EQ_IMPL(::hpx::util::detail::global_fixture, expr1, expr2)
+    HPX_SANITY_EQ_IMPL(::hpx::util::detail::global_fixture(), expr1, expr2)
 #define HPX_SANITY_EQ_3(strm, expr1, expr2)                                    \
     HPX_SANITY_EQ_IMPL(::hpx::util::detail::fixture{strm}, expr1, expr2)
 
@@ -480,7 +482,7 @@ namespace hpx { namespace util {
         HPX_PP_CAT(HPX_SANITY_NEQ_, HPX_PP_NARGS(__VA_ARGS__))(__VA_ARGS__))   \
     /**/
 #define HPX_SANITY_NEQ_2(expr1, expr2)                                         \
-    HPX_SANITY_NEQ_IMPL(::hpx::util::detail::global_fixture, expr1, expr2)
+    HPX_SANITY_NEQ_IMPL(::hpx::util::detail::global_fixture(), expr1, expr2)
 #define HPX_SANITY_NEQ_3(strm, expr1, expr2)                                   \
     HPX_SANITY_NEQ_IMPL(::hpx::util::detail::fixture{strm}, expr1, expr2)
 
@@ -500,7 +502,7 @@ namespace hpx { namespace util {
         HPX_PP_CAT(HPX_SANITY_LT_, HPX_PP_NARGS(__VA_ARGS__))(__VA_ARGS__))    \
     /**/
 #define HPX_SANITY_LT_2(expr1, expr2)                                          \
-    HPX_SANITY_LT_IMPL(::hpx::util::detail::global_fixture, expr1, expr2)
+    HPX_SANITY_LT_IMPL(::hpx::util::detail::global_fixture(), expr1, expr2)
 #define HPX_SANITY_LT_3(strm, expr1, expr2)                                    \
     HPX_SANITY_LT_IMPL(::hpx::util::detail::fixture{strm}, expr1, expr2)
 
@@ -520,7 +522,7 @@ namespace hpx { namespace util {
         HPX_PP_CAT(HPX_SANITY_LTE_, HPX_PP_NARGS(__VA_ARGS__))(__VA_ARGS__))   \
     /**/
 #define HPX_SANITY_LTE_2(expr1, expr2)                                         \
-    HPX_SANITY_LTE_IMPL(::hpx::util::detail::global_fixture, expr1, expr2)
+    HPX_SANITY_LTE_IMPL(::hpx::util::detail::global_fixture(), expr1, expr2)
 #define HPX_SANITY_LTE_3(strm, expr1, expr2)                                   \
     HPX_SANITY_LTE_IMPL(::hpx::util::detail::fixture{strm}, expr1, expr2)
 
@@ -541,7 +543,7 @@ namespace hpx { namespace util {
     /**/
 #define HPX_SANITY_RANGE_3(expr1, expr2, expr3)                                \
     HPX_SANITY_RANGE_IMPL(                                                     \
-        ::hpx::util::detail::global_fixture, expr1, expr2, expr3)
+        ::hpx::util::detail::global_fixture(), expr1, expr2, expr3)
 #define HPX_SANITY_RANGE_4(strm, expr1, expr2, expr3)                          \
     HPX_SANITY_RANGE_IMPL(                                                     \
         ::hpx::util::detail::fixture{strm}, expr1, expr2, expr3)
@@ -563,7 +565,7 @@ namespace hpx { namespace util {
     /**/
 #define HPX_SANITY_EQ_MSG_3(expr1, expr2, msg)                                 \
     HPX_SANITY_EQ_MSG_IMPL(                                                    \
-        ::hpx::util::detail::global_fixture, expr1, expr2, msg)
+        ::hpx::util::detail::global_fixture(), expr1, expr2, msg)
 #define HPX_SANITY_EQ_MSG_4(strm, expr1, expr2, msg)                           \
     HPX_SANITY_EQ_MSG_IMPL(                                                    \
         ::hpx::util::detail::fixture{strm}, expr1, expr2, msg)
@@ -583,7 +585,7 @@ namespace hpx { namespace util {
     /**/
 #define HPX_TEST_THROW_2(expression, exception)                                \
     HPX_TEST_THROW_IMPL(                                                       \
-        ::hpx::util::detail::global_fixture, expression, exception)
+        ::hpx::util::detail::global_fixture(), expression, exception)
 #define HPX_TEST_THROW_3(strm, expression, exception)                          \
     HPX_TEST_THROW_IMPL(                                                       \
         ::hpx::util::detail::fixture{strm}, expression, exception)

--- a/libs/core/testing/src/testing.cpp
+++ b/libs/core/testing/src/testing.cpp
@@ -25,7 +25,7 @@ namespace hpx { namespace util {
 
     void set_test_failure_handler(test_failure_handler_type f)
     {
-        test_failure_handler = f;
+        test_failure_handler = HPX_MOVE(f);
     }
 
     namespace detail {
@@ -69,8 +69,11 @@ namespace hpx { namespace util {
             return std::size_t(-1);
         }
 
-        fixture global_fixture{std::cerr};
-
+        fixture& global_fixture()
+        {
+            static fixture fixture_(std::cerr);
+            return fixture_;
+        }
     }    // namespace detail
 
     ////////////////////////////////////////////////////////////////////////////
@@ -81,8 +84,8 @@ namespace hpx { namespace util {
 
     int report_errors(std::ostream& stream)
     {
-        std::size_t sanity = detail::global_fixture.get(counter_sanity),
-                    test = detail::global_fixture.get(counter_test);
+        std::size_t sanity = detail::global_fixture().get(counter_sanity),
+                    test = detail::global_fixture().get(counter_test);
         if (sanity == 0 && test == 0)
             return 0;
 

--- a/libs/core/type_support/CMakeLists.txt
+++ b/libs/core/type_support/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2019 The STE||AR-Group
+# Copyright (c) 2019-2022 The STE||AR-Group
 #
 # SPDX-License-Identifier: BSL-1.0
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -12,6 +12,7 @@ set(type_support_headers
     hpx/type_support/detected.hpp
     hpx/type_support/empty_function.hpp
     hpx/type_support/equality.hpp
+    hpx/type_support/hide_from_adl.hpp
     hpx/type_support/identity.hpp
     hpx/type_support/lazy_conditional.hpp
     hpx/type_support/lazy_enable_if.hpp

--- a/libs/core/type_support/include/hpx/type_support/hide_from_adl.hpp
+++ b/libs/core/type_support/include/hpx/type_support/hide_from_adl.hpp
@@ -1,0 +1,28 @@
+//  Copyright (c) 2022 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+namespace hpx { namespace util {
+
+    namespace detail {
+
+        template <typename T>
+        struct hide_from_adl
+        {
+            struct inner
+            {
+                using type = T;
+            };
+        };
+    }    // namespace detail
+
+    template <typename T>
+    using hide_from_adl = typename detail::hide_from_adl<T>::inner;
+
+    template <typename T>
+    using hidden_from_adl_t = typename T::type;
+}}    // namespace hpx::util

--- a/libs/core/type_support/include/hpx/type_support/unwrap_ref.hpp
+++ b/libs/core/type_support/include/hpx/type_support/unwrap_ref.hpp
@@ -11,26 +11,30 @@
 #include <functional>
 
 namespace hpx { namespace util {
+
     template <typename T>
     struct unwrap_reference
     {
-        typedef T type;
+        using type = T;
     };
 
     template <typename T>
     struct unwrap_reference<std::reference_wrapper<T>>
     {
-        typedef T type;
+        using type = T;
     };
 
     template <typename T>
     struct unwrap_reference<std::reference_wrapper<T> const>
     {
-        typedef T type;
+        using type = T;
     };
 
     template <typename T>
-    HPX_FORCEINLINE typename unwrap_reference<T>::type& unwrap_ref(T& t)
+    using unwrap_reference_t = typename unwrap_reference<T>::type;
+
+    template <typename T>
+    HPX_FORCEINLINE unwrap_reference_t<T>& unwrap_ref(T& t)
     {
         return t;
     }


### PR DESCRIPTION
- flyby: fixing global_fixture linking problems with MSVC
