### PR TITLE
Propagate MPI dependencies to command line handling

### DIFF
--- a/libs/full/command_line_handling/CMakeLists.txt
+++ b/libs/full/command_line_handling/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2021 The STE||AR-Group
+# Copyright (c) 2019-2022 The STE||AR-Group
 #
 # SPDX-License-Identifier: BSL-1.0
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -24,6 +24,13 @@ set(command_line_handling_sources
     parse_command_line.cpp
 )
 
+if((HPX_WITH_NETWORKING AND HPX_WITH_PARCELPORT_MPI) OR HPX_WITH_ASYNC_MPI)
+  # setup MPI, if necessary
+  include(HPX_SetupMPI)
+  hpx_setup_mpi()
+  set(additional_dependencies Mpi::mpi)
+endif()
+
 include(HPX_AddModule)
 add_hpx_module(
   full command_line_handling
@@ -31,6 +38,6 @@ add_hpx_module(
   SOURCES ${command_line_handling_sources}
   HEADERS ${command_line_handling_headers}
   COMPAT_HEADERS ${command_line_handling_compat_headers}
-  DEPENDENCIES hpx_core
+  DEPENDENCIES hpx_core ${additional_dependencies}
   CMAKE_SUBDIRS tests
 )


### PR DESCRIPTION
This allows to compile the command_line_handling odule in case MPI is not installed in system directories.