### PR TITLE
Add stop support to when_all

### DIFF
--- a/libs/core/execution/CMakeLists.txt
+++ b/libs/core/execution/CMakeLists.txt
@@ -47,6 +47,11 @@ set(execution_headers
     hpx/execution/executors/polymorphic_executor.hpp
     hpx/execution/executors/rebind_executor.hpp
     hpx/execution/executors/static_chunk_size.hpp
+    hpx/execution/queries/get_allocator.hpp
+    hpx/execution/queries/get_scheduler.hpp
+    hpx/execution/queries/get_delegatee_scheduler.hpp
+    hpx/execution/queries/get_stop_token.hpp
+    hpx/execution/queries/read.hpp
     hpx/execution/traits/detail/simd/vector_pack_alignment_size.hpp
     hpx/execution/traits/detail/simd/vector_pack_all_any_none.hpp
     hpx/execution/traits/detail/simd/vector_pack_count_bits.hpp

--- a/libs/core/execution/include/hpx/execution/algorithms/let_error.hpp
+++ b/libs/core/execution/include/hpx/execution/algorithms/let_error.hpp
@@ -220,7 +220,8 @@ namespace hpx { namespace execution { namespace experimental {
                         get_env_t, let_error_predecessor_receiver const& r)
                         -> env_of_t<std::decay_t<Receiver>>
                     {
-                        return get_env(r.receiver);
+                        return hpx::execution::experimental::get_env(
+                            r.receiver);
                     }
                 };
 

--- a/libs/core/execution/include/hpx/execution/algorithms/let_value.hpp
+++ b/libs/core/execution/include/hpx/execution/algorithms/let_value.hpp
@@ -13,6 +13,7 @@
 #include <hpx/datastructures/variant.hpp>
 #include <hpx/errors/try_catch_exception_ptr.hpp>
 #include <hpx/execution/algorithms/detail/partial_algorithm.hpp>
+#include <hpx/execution_base/get_env.hpp>
 #include <hpx/execution_base/receiver.hpp>
 #include <hpx/execution_base/sender.hpp>
 #include <hpx/functional/detail/tag_fallback_invoke.hpp>
@@ -267,6 +268,14 @@ namespace hpx { namespace execution { namespace experimental {
                         // inlined here compilation fails with an internal
                         // compiler error.
                         r.set_value(HPX_FORWARD(Ts, ts)...);
+                    }
+
+                    // Pass through the get_env receiver query
+                    friend auto tag_invoke(
+                        get_env_t, let_value_predecessor_receiver const& r)
+                        -> env_of_t<std::decay_t<Receiver>>
+                    {
+                        return get_env(r.receiver);
                     }
                 };
 

--- a/libs/core/execution/include/hpx/execution/algorithms/let_value.hpp
+++ b/libs/core/execution/include/hpx/execution/algorithms/let_value.hpp
@@ -275,7 +275,8 @@ namespace hpx { namespace execution { namespace experimental {
                         get_env_t, let_value_predecessor_receiver const& r)
                         -> env_of_t<std::decay_t<Receiver>>
                     {
-                        return get_env(r.receiver);
+                        return hpx::execution::experimental::get_env(
+                            r.receiver);
                     }
                 };
 

--- a/libs/core/execution/include/hpx/execution/algorithms/schedule_from.hpp
+++ b/libs/core/execution/include/hpx/execution/algorithms/schedule_from.hpp
@@ -177,7 +177,8 @@ namespace hpx { namespace execution { namespace experimental {
                         get_env_t, predecessor_sender_receiver const& r)
                         -> env_of_t<std::decay_t<Receiver>>
                     {
-                        return get_env(r.op_state.receiver);
+                        return hpx::execution::experimental::get_env(
+                            r.op_state.receiver);
                     }
                 };
 

--- a/libs/core/execution/include/hpx/execution/algorithms/schedule_from.hpp
+++ b/libs/core/execution/include/hpx/execution/algorithms/schedule_from.hpp
@@ -12,6 +12,7 @@
 #include <hpx/datastructures/tuple.hpp>
 #include <hpx/datastructures/variant.hpp>
 #include <hpx/execution_base/completion_scheduler.hpp>
+#include <hpx/execution_base/get_env.hpp>
 #include <hpx/execution_base/receiver.hpp>
 #include <hpx/execution_base/sender.hpp>
 #include <hpx/functional/bind_front.hpp>
@@ -170,6 +171,14 @@ namespace hpx { namespace execution { namespace experimental {
                         r.op_state.set_value_predecessor_sender(
                             HPX_FORWARD(Ts, ts)...);
                     }
+
+                    // Pass through the get_env receiver query
+                    friend auto tag_invoke(
+                        get_env_t, predecessor_sender_receiver const& r)
+                        -> env_of_t<std::decay_t<Receiver>>
+                    {
+                        return get_env(r.op_state.receiver);
+                    }
                 };
 
                 template <typename Error>
@@ -237,6 +246,14 @@ namespace hpx { namespace execution { namespace experimental {
                         set_value_t, scheduler_sender_receiver&& r) noexcept
                     {
                         r.op_state.set_value_scheduler_sender();
+                    }
+
+                    // Pass through the get_env receiver query
+                    friend auto tag_invoke(
+                        get_env_t, scheduler_sender_receiver const& r)
+                        -> env_of_t<std::decay_t<Receiver>>
+                    {
+                        return get_env(r.op_state.receiver);
                     }
                 };
 

--- a/libs/core/execution/include/hpx/execution/queries/get_allocator.hpp
+++ b/libs/core/execution/include/hpx/execution/queries/get_allocator.hpp
@@ -7,8 +7,8 @@
 #pragma once
 
 #include <hpx/config.hpp>
+#include <hpx/execution/queries/read.hpp>
 #include <hpx/execution_base/get_env.hpp>
-#include <hpx/execution_base/read.hpp>
 #include <hpx/functional/detail/tag_fallback_invoke.hpp>
 
 namespace hpx::execution::experimental {
@@ -34,6 +34,7 @@ namespace hpx::execution::experimental {
     inline constexpr struct get_allocator_t final
       : hpx::functional::detail::tag_fallback<get_allocator_t>
     {
+    private:
         friend inline constexpr auto tag_fallback_invoke(
             get_allocator_t) noexcept;
 

--- a/libs/core/execution/include/hpx/execution/queries/get_delegatee_scheduler.hpp
+++ b/libs/core/execution/include/hpx/execution/queries/get_delegatee_scheduler.hpp
@@ -7,8 +7,8 @@
 #pragma once
 
 #include <hpx/config.hpp>
+#include <hpx/execution/queries/read.hpp>
 #include <hpx/execution_base/get_env.hpp>
-#include <hpx/execution_base/read.hpp>
 #include <hpx/functional/detail/tag_fallback_invoke.hpp>
 
 namespace hpx::execution::experimental {
@@ -36,6 +36,7 @@ namespace hpx::execution::experimental {
     inline constexpr struct get_delegatee_scheduler_t final
       : hpx::functional::detail::tag_fallback<get_delegatee_scheduler_t>
     {
+    private:
         friend inline constexpr auto tag_fallback_invoke(
             get_delegatee_scheduler_t) noexcept;
 

--- a/libs/core/execution/include/hpx/execution/queries/get_scheduler.hpp
+++ b/libs/core/execution/include/hpx/execution/queries/get_scheduler.hpp
@@ -7,8 +7,8 @@
 #pragma once
 
 #include <hpx/config.hpp>
+#include <hpx/execution/queries/read.hpp>
 #include <hpx/execution_base/get_env.hpp>
-#include <hpx/execution_base/read.hpp>
 #include <hpx/functional/detail/tag_fallback_invoke.hpp>
 
 namespace hpx::execution::experimental {
@@ -36,6 +36,7 @@ namespace hpx::execution::experimental {
     inline constexpr struct get_scheduler_t final
       : hpx::functional::detail::tag_fallback<get_scheduler_t>
     {
+    private:
         friend inline constexpr auto tag_fallback_invoke(
             get_scheduler_t) noexcept;
 

--- a/libs/core/execution/include/hpx/execution/queries/get_stop_token.hpp
+++ b/libs/core/execution/include/hpx/execution/queries/get_stop_token.hpp
@@ -37,7 +37,7 @@ namespace hpx::execution::experimental {
     // 3.  execution::get_stop_token() (with no arguments) is expression-
     //     equivalent to execution::read(execution::get_stop_token).
     //
-    inline constexpr struct get_stop_token_t final
+    HPX_HOST_DEVICE_INLINE_CONSTEXPR_VARIABLE struct get_stop_token_t final
       : hpx::functional::detail::tag_fallback<get_stop_token_t>
     {
     private:

--- a/libs/core/execution/include/hpx/execution/queries/get_stop_token.hpp
+++ b/libs/core/execution/include/hpx/execution/queries/get_stop_token.hpp
@@ -7,9 +7,13 @@
 #pragma once
 
 #include <hpx/config.hpp>
+#include <hpx/execution/queries/read.hpp>
 #include <hpx/execution_base/get_env.hpp>
-#include <hpx/execution_base/read.hpp>
 #include <hpx/functional/detail/tag_fallback_invoke.hpp>
+#include <hpx/synchronization/stop_token.hpp>
+
+#include <type_traits>
+#include <utility>
 
 namespace hpx::execution::experimental {
 
@@ -36,6 +40,14 @@ namespace hpx::execution::experimental {
     inline constexpr struct get_stop_token_t final
       : hpx::functional::detail::tag_fallback<get_stop_token_t>
     {
+    private:
+        template <typename Env>
+        friend inline constexpr auto tag_fallback_invoke(
+            get_stop_token_t, Env&&) noexcept
+        {
+            return hpx::experimental::never_stop_token();
+        }
+
         friend inline constexpr auto tag_fallback_invoke(
             get_stop_token_t) noexcept;
 
@@ -45,4 +57,11 @@ namespace hpx::execution::experimental {
     {
         return hpx::execution::experimental::read(get_stop_token);
     }
+
+    // Helper template allowing to exptract the type of a stop_token
+    // extracted from a receiver environment.
+    template <typename T>
+    using stop_token_of_t = std::remove_cv_t<
+        std::remove_reference_t<decltype(get_stop_token(std::declval<T>()))>>;
+
 }    // namespace hpx::execution::experimental

--- a/libs/core/execution/include/hpx/execution/queries/read.hpp
+++ b/libs/core/execution/include/hpx/execution/queries/read.hpp
@@ -84,6 +84,7 @@ namespace hpx::execution::experimental {
 
     inline constexpr struct read_t final : hpx::functional::tag<read_t>
     {
+    private:
         template <typename Tag>
         friend constexpr auto tag_invoke(read_t, Tag) noexcept
         {

--- a/libs/core/execution/tests/unit/CMakeLists.txt
+++ b/libs/core/execution/tests/unit/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2014-2021 Hartmut Kaiser
+# Copyright (c) 2014-2022 Hartmut Kaiser
 #
 # SPDX-License-Identifier: BSL-1.0
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -17,11 +17,13 @@ set(tests
     algorithm_then
     algorithm_transfer
     algorithm_transfer_just
+    algorithm_transfer_when_all
     algorithm_when_all
     bulk_async
     executor_parameters
     executor_parameters_dispatching
     executor_parameters_timer_hooks
+    forwarding_env_query
     future_then_executor
     minimal_async_executor
     minimal_sync_executor

--- a/libs/core/execution/tests/unit/algorithm_transfer_when_all.cpp
+++ b/libs/core/execution/tests/unit/algorithm_transfer_when_all.cpp
@@ -1,0 +1,136 @@
+//  Copyright (c) 2021 ETH Zurich
+//  Copyright (c) 2022 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+// Our implementation of transfer_when_all relies on when_all and transfer.
+// Those are thoroughly tested independently. We provide fewer test cases
+// here for this reason.
+
+#include <hpx/config.hpp>
+#include <hpx/modules/execution.hpp>
+#include <hpx/modules/testing.hpp>
+
+#include "algorithm_test_utils.hpp"
+
+#include <atomic>
+#include <exception>
+#include <stdexcept>
+#include <string>
+#include <type_traits>
+#include <utility>
+
+namespace ex = hpx::execution::experimental;
+
+int main()
+{
+    // Success path
+    {
+        std::atomic<bool> set_value_called{false};
+        std::atomic<bool> scheduler_schedule_called{false};
+        std::atomic<bool> scheduler_execute_called{false};
+        std::atomic<bool> tag_invoke_overload_called{false};
+
+        auto sched = scheduler{scheduler_schedule_called,
+            scheduler_execute_called, tag_invoke_overload_called};
+        auto s = ex::transfer_when_all(sched, ex::just(42));
+        static_assert(ex::is_sender_v<decltype(s)>,
+            "transfer_when_all must return a sender");
+
+        auto csch = ex::get_completion_scheduler<ex::set_value_t>(s);
+        HPX_TEST(sched == csch);
+
+        auto f = [](int x) { HPX_TEST_EQ(x, 42); };
+        auto r = callback_receiver<decltype(f)>{f, set_value_called};
+        auto os = ex::connect(std::move(s), std::move(r));
+        tag_invoke(ex::start, os);
+        HPX_TEST(set_value_called);
+        HPX_TEST(!tag_invoke_overload_called);
+        HPX_TEST(scheduler_schedule_called);
+        HPX_TEST(!scheduler_execute_called);
+    }
+
+    {
+        std::atomic<bool> set_value_called{false};
+        std::atomic<bool> scheduler_schedule_called{false};
+        std::atomic<bool> scheduler_execute_called{false};
+        std::atomic<bool> tag_invoke_overload_called{false};
+
+        auto sched = scheduler{scheduler_schedule_called,
+            scheduler_execute_called, tag_invoke_overload_called};
+        auto s = ex::transfer_when_all(sched, ex::just(42),
+            ex::just(std::string("hello")), ex::just(3.14));
+        static_assert(ex::is_sender_v<decltype(s)>,
+            "transfer_when_all must return a sender");
+
+        auto csch = ex::get_completion_scheduler<ex::set_value_t>(s);
+        HPX_TEST(sched == csch);
+
+        auto f = [](int x, std::string y, double z) {
+            HPX_TEST_EQ(x, 42);
+            HPX_TEST_EQ(y, std::string("hello"));
+            HPX_TEST_EQ(z, 3.14);
+        };
+        auto r = callback_receiver<decltype(f)>{f, set_value_called};
+        auto os = ex::connect(std::move(s), std::move(r));
+        ex::start(os);
+        HPX_TEST(set_value_called);
+        HPX_TEST(!tag_invoke_overload_called);
+        HPX_TEST(scheduler_schedule_called);
+        HPX_TEST(!scheduler_execute_called);
+    }
+
+    {
+        std::atomic<bool> set_value_called{false};
+        std::atomic<bool> scheduler_schedule_called{false};
+        std::atomic<bool> scheduler_execute_called{false};
+        std::atomic<bool> tag_invoke_overload_called{false};
+
+        auto sched = scheduler{scheduler_schedule_called,
+            scheduler_execute_called, tag_invoke_overload_called};
+        auto s = ex::transfer_when_all(
+            sched, ex::just(), ex::just(std::string("hello")), ex::just(3.14));
+        static_assert(ex::is_sender_v<decltype(s)>,
+            "transfer_when_all must return a sender");
+
+        auto csch = ex::get_completion_scheduler<ex::set_value_t>(s);
+        HPX_TEST(sched == csch);
+
+        auto f = [](std::string y, double z) {
+            HPX_TEST_EQ(y, std::string("hello"));
+            HPX_TEST_EQ(z, 3.14);
+        };
+        auto r = callback_receiver<decltype(f)>{f, set_value_called};
+        auto os = ex::connect(std::move(s), std::move(r));
+        ex::start(os);
+        HPX_TEST(set_value_called);
+        HPX_TEST(!tag_invoke_overload_called);
+        HPX_TEST(scheduler_schedule_called);
+        HPX_TEST(!scheduler_execute_called);
+    }
+
+    // Failure path
+    {
+        std::atomic<bool> set_error_called{false};
+        std::atomic<bool> scheduler_schedule_called{false};
+        std::atomic<bool> scheduler_execute_called{false};
+        std::atomic<bool> tag_invoke_overload_called{false};
+
+        auto sched = scheduler{scheduler_schedule_called,
+            scheduler_execute_called, tag_invoke_overload_called};
+        auto s = ex::transfer_when_all(sched, error_typed_sender<double>{});
+        auto r = error_callback_receiver<decltype(check_exception_ptr)>{
+            check_exception_ptr, set_error_called};
+        auto os = ex::connect(std::move(s), std::move(r));
+        ex::start(os);
+
+        HPX_TEST(set_error_called);
+        HPX_TEST(!tag_invoke_overload_called);
+        HPX_TEST(!scheduler_schedule_called);
+        HPX_TEST(!scheduler_execute_called);
+    }
+
+    return hpx::util::report_errors();
+}

--- a/libs/core/execution/tests/unit/forwarding_env_query.cpp
+++ b/libs/core/execution/tests/unit/forwarding_env_query.cpp
@@ -4,8 +4,8 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+#include <hpx/execution/queries/get_scheduler.hpp>
 #include <hpx/execution_base/get_env.hpp>
-#include <hpx/execution_base/get_scheduler.hpp>
 #include <hpx/functional/tag_invoke.hpp>
 #include <hpx/modules/testing.hpp>
 

--- a/libs/core/execution_base/CMakeLists.txt
+++ b/libs/core/execution_base/CMakeLists.txt
@@ -12,13 +12,8 @@ set(execution_base_headers
     hpx/execution_base/context_base.hpp
     hpx/execution_base/detail/spinlock_deadlock_detection.hpp
     hpx/execution_base/execution.hpp
-    hpx/execution_base/get_allocator.hpp
     hpx/execution_base/get_env.hpp
-    hpx/execution_base/get_scheduler.hpp
-    hpx/execution_base/get_delegatee_scheduler.hpp
-    hpx/execution_base/get_stop_token.hpp
     hpx/execution_base/operation_state.hpp
-    hpx/execution_base/read.hpp
     hpx/execution_base/receiver.hpp
     hpx/execution_base/resource_base.hpp
     hpx/execution_base/sender.hpp

--- a/libs/core/execution_base/include/hpx/execution_base/get_env.hpp
+++ b/libs/core/execution_base/include/hpx/execution_base/get_env.hpp
@@ -130,7 +130,7 @@ namespace hpx::execution::experimental {
     // 1. tag_invoke(execution::get_env, r) if that expression is well-formed.
     // 2. Otherwise, empty_env{}.
     //
-    inline constexpr struct get_env_t final
+    HPX_HOST_DEVICE_INLINE_CONSTEXPR_VARIABLE struct get_env_t final
       : hpx::functional::detail::tag_fallback<get_env_t>
     {
     private:
@@ -145,9 +145,12 @@ namespace hpx::execution::experimental {
     template <typename T>
     using env_of_t = decltype(get_env(std::declval<T>()));
 
+    // different versions of clang-format disagree
+    // clang-format off
     template <typename Tag, typename Value, typename BaseEnv = empty_env>
     using make_env_t = decltype(
         make_env<Tag>(std::declval<Value&&>(), std::declval<BaseEnv&&>()));
+    // clang-format on
 
     // execution::forwarding_env_query is used to ask a customization point
     // object whether it is an environment query that should be forwarded
@@ -165,8 +168,8 @@ namespace hpx::execution::experimental {
     //      is a core constant expression.
     // 2. Otherwise, false.
     //
-    inline constexpr struct forwarding_env_query_t final
-      : hpx::functional::detail::tag_fallback<forwarding_env_query_t>
+    HPX_HOST_DEVICE_INLINE_CONSTEXPR_VARIABLE struct forwarding_env_query_t
+        final : hpx::functional::detail::tag_fallback<forwarding_env_query_t>
     {
     private:
         template <typename T>

--- a/libs/core/execution_base/include/hpx/execution_base/get_env.hpp
+++ b/libs/core/execution_base/include/hpx/execution_base/get_env.hpp
@@ -133,6 +133,7 @@ namespace hpx::execution::experimental {
     inline constexpr struct get_env_t final
       : hpx::functional::detail::tag_fallback<get_env_t>
     {
+    private:
         template <typename EnvProvider>
         friend constexpr HPX_FORCEINLINE auto tag_fallback_invoke(
             get_env_t, EnvProvider&&) noexcept
@@ -167,6 +168,7 @@ namespace hpx::execution::experimental {
     inline constexpr struct forwarding_env_query_t final
       : hpx::functional::detail::tag_fallback<forwarding_env_query_t>
     {
+    private:
         template <typename T>
         friend constexpr HPX_FORCEINLINE auto tag_fallback_invoke(
             forwarding_env_query_t, T&&) noexcept

--- a/libs/core/execution_base/include/hpx/execution_base/sender.hpp
+++ b/libs/core/execution_base/include/hpx/execution_base/sender.hpp
@@ -77,7 +77,7 @@ namespace hpx { namespace execution { namespace experimental {
     ///
     /// A sender's destructor shall not block pending completion of submitted
     /// operations.
-    template <typename Sender>
+    template <typename Sender, typename Env = no_env>
     struct is_sender;
 
     /// \see is_sender
@@ -123,7 +123,7 @@ namespace hpx { namespace execution { namespace experimental {
         }
     }    // namespace detail
 
-    template <typename Sender>
+    template <typename Sender, typename Env>
     struct is_sender
       : std::integral_constant<bool,
             std::is_move_constructible_v<std::decay_t<Sender>> &&
@@ -145,12 +145,15 @@ namespace hpx { namespace execution { namespace experimental {
         {
         };
 
+        // different versions of clang-format disagree
+        // clang-format off
         template <typename S, typename R>
         struct has_member_connect<S, R,
             hpx::util::always_void_t<decltype(
                 std::declval<S>().connect(std::declval<R>()))>> : std::true_type
         {
         };
+        // clang-format on
     }    // namespace detail
 
     HPX_HOST_DEVICE_INLINE_CONSTEXPR_VARIABLE
@@ -248,6 +251,10 @@ namespace hpx { namespace execution { namespace experimental {
             is_sender_v<Sender> && is_receiver_v<Receiver>, Sender, Receiver>
     {
     };
+
+    template <typename Sender, typename Receiver>
+    inline constexpr bool is_sender_to_v =
+        is_sender_to<Sender, Receiver>::value;
 
     namespace detail {
         template <typename... As>
@@ -384,10 +391,9 @@ namespace hpx { namespace execution { namespace experimental {
 
     template <typename Scheduler>
     struct is_scheduler<Scheduler,
-        std::enable_if_t<hpx::is_invocable<schedule_t, Scheduler>::value &&
-            std::is_copy_constructible<Scheduler>::value &&
-            hpx::traits::is_equality_comparable<Scheduler>::value>>
-      : std::true_type
+        std::enable_if_t<hpx::is_invocable_v<schedule_t, Scheduler> &&
+            std::is_copy_constructible_v<Scheduler> &&
+            hpx::traits::is_equality_comparable_v<Scheduler>>> : std::true_type
     {
     };
 

--- a/libs/core/execution_base/tests/unit/CMakeLists.txt
+++ b/libs/core/execution_base/tests/unit/CMakeLists.txt
@@ -12,7 +12,6 @@ set(tests
     basic_sender
     basic_schedule
     execution_context
-    forwarding_env_query
     get_env
 )
 

--- a/libs/core/threading/src/thread.cpp
+++ b/libs/core/threading/src/thread.cpp
@@ -215,8 +215,8 @@ namespace hpx {
         this_thread::interruption_point();
 
         // register callback function to be called when thread exits
-        if (threads::add_thread_exit_callback(
-                id_.noref(), util::bind_front(&resume_thread, this_id)))
+        if (threads::add_thread_exit_callback(id_.noref(),
+                util::bind_front(&resume_thread, HPX_MOVE(this_id))))
         {
             // wait for thread to be terminated
             util::unlock_guard ul(l);

--- a/libs/core/type_support/include/hpx/type_support/equality.hpp
+++ b/libs/core/type_support/include/hpx/type_support/equality.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2020 Hartmut Kaiser
+//  Copyright (c) 2007-2022 Hartmut Kaiser
 //  Copyright (c) 2019 Austin McCartney
 //
 //  SPDX-License-Identifier: BSL-1.0
@@ -22,14 +22,17 @@ namespace hpx { namespace traits {
         {
         };
 
+        // different versions of clang-format disagree
+        // clang-format off
         template <typename T, typename U>
         struct equality_result<T, U,
-            typename util::always_void<decltype(
-                std::declval<const T&>() == std::declval<const U&>())>::type>
+            util::always_void_t<decltype(
+                std::declval<const T&>() == std::declval<const U&>())>>
         {
             using type =
                 decltype(std::declval<const T&>() == std::declval<const U&>());
         };
+        // clang-format on
 
         ///////////////////////////////////////////////////////////////////////
         template <typename T, typename U, typename Enable = void>
@@ -37,14 +40,17 @@ namespace hpx { namespace traits {
         {
         };
 
+        // different versions of clang-format disagree
+        // clang-format off
         template <typename T, typename U>
         struct inequality_result<T, U,
-            typename util::always_void<decltype(
-                std::declval<const T&>() != std::declval<const U&>())>::type>
+            util::always_void_t<decltype(
+                std::declval<const T&>() != std::declval<const U&>())>>
         {
             using type =
                 decltype(std::declval<const T&>() != std::declval<const U&>());
         };
+        // clang-format on
 
         ///////////////////////////////////////////////////////////////////////
         template <typename T, typename U, typename Enable = void>
@@ -62,7 +68,6 @@ namespace hpx { namespace traits {
           : std::true_type
         {
         };
-
     }    // namespace detail
 
     template <typename T, typename U>
@@ -72,6 +77,10 @@ namespace hpx { namespace traits {
     {
     };
 
+    template <typename T, typename U>
+    inline constexpr bool is_weakly_equality_comparable_with_v =
+        is_weakly_equality_comparable_with<T, U>::value;
+
     // for now is_equality_comparable is equivalent to its weak version
     template <typename T, typename U>
     struct is_equality_comparable_with
@@ -80,10 +89,18 @@ namespace hpx { namespace traits {
     {
     };
 
+    template <typename T, typename U>
+    inline constexpr bool is_equality_comparable_with_v =
+        is_equality_comparable_with<T, U>::value;
+
     template <typename T>
     struct is_equality_comparable
       : detail::is_weakly_equality_comparable_with<typename std::decay<T>::type,
             typename std::decay<T>::type>
     {
     };
+
+    template <typename T>
+    inline constexpr bool is_equality_comparable_v =
+        is_equality_comparable<T>::value;
 }}    // namespace hpx::traits

--- a/libs/core/type_support/include/hpx/type_support/pack.hpp
+++ b/libs/core/type_support/include/hpx/type_support/pack.hpp
@@ -101,8 +101,8 @@ namespace hpx { namespace util {
         static std::false_type all_of(...);
 
         template <typename... Ts>
-        static auto all_of(int) -> always_true<
-            typename std::enable_if<is_true<Ts>::value>::type...>;
+        static auto all_of(int)
+            -> always_true<std::enable_if_t<is_true<Ts>::value>...>;
     }    // namespace detail
 
     template <typename... Ts>
@@ -124,8 +124,8 @@ namespace hpx { namespace util {
         static std::true_type any_of(...);
 
         template <typename... Ts>
-        static auto any_of(int) -> always_false<
-            typename std::enable_if<is_false<Ts>::value>::type...>;
+        static auto any_of(int)
+            -> always_false<std::enable_if_t<is_false<Ts>::value>...>;
     }    // namespace detail
 
     template <typename... Ts>


### PR DESCRIPTION
- fixes to environmental query support
- move queries to execution module
- adding transfer_when_all (and test)
- flyby: add concept checks to get_completion_handler<CPO>

This relies on #5748