### PR TITLE
Update cdash build url

### DIFF
--- a/.jenkins/common/set_github_status.sh
+++ b/.jenkins/common/set_github_status.sh
@@ -21,4 +21,4 @@ curl --verbose \
     --url "https://api.github.com/repos/${commit_repo}/statuses/${commit_sha}" \
     --header 'Content-Type: application/json' \
     --header "authorization: Bearer ${github_token}" \
-    --data "{ \"state\": \"${commit_status}\", \"target_url\": \"https://cdash.cscs.ch/buildSummary.php?buildid=${build_id}\", \"description\": \"Jenkins\", \"context\": \"${context}/${configuration_name}\" }"
+    --data "{ \"state\": \"${commit_status}\", \"target_url\": \"https://cdash.cscs.ch/build/${build_id}\", \"description\": \"Jenkins\", \"context\": \"${context}/${configuration_name}\" }"


### PR DESCRIPTION
The url has changed from `/buildSummary.php?buildid=<buildid>` to just `/build/<buildid>`. The old urls still work and get forwarded to the new ones.