### PR TITLE
add num_cores facility

### DIFF
--- a/libs/core/execution/CMakeLists.txt
+++ b/libs/core/execution/CMakeLists.txt
@@ -88,7 +88,6 @@ set(execution_compat_headers
     hpx/parallel/executors/execution_parameters.hpp => hpx/execution.hpp
     hpx/parallel/executors/fused_bulk_execute.hpp => hpx/execution.hpp
     hpx/parallel/executors/guided_chunk_size.hpp => hpx/execution.hpp
-    hpx/parallel/executors/num_cores.hpp => hpx/execution.hpp
     hpx/parallel/executors/persistent_auto_chunk_size.hpp => hpx/execution.hpp
     hpx/parallel/executors/post_policy_dispatch.hpp => hpx/execution.hpp
     hpx/parallel/executors/rebind_executor.hpp => hpx/execution.hpp

--- a/libs/core/execution/CMakeLists.txt
+++ b/libs/core/execution/CMakeLists.txt
@@ -42,6 +42,7 @@ set(execution_headers
     hpx/execution/executors/execution_parameters_fwd.hpp
     hpx/execution/executors/fused_bulk_execute.hpp
     hpx/execution/executors/guided_chunk_size.hpp
+    hpx/execution/executors/num_cores.hpp
     hpx/execution/executors/persistent_auto_chunk_size.hpp
     hpx/execution/executors/polymorphic_executor.hpp
     hpx/execution/executors/rebind_executor.hpp
@@ -87,6 +88,7 @@ set(execution_compat_headers
     hpx/parallel/executors/execution_parameters.hpp => hpx/execution.hpp
     hpx/parallel/executors/fused_bulk_execute.hpp => hpx/execution.hpp
     hpx/parallel/executors/guided_chunk_size.hpp => hpx/execution.hpp
+    hpx/parallel/executors/num_cores.hpp => hpx/execution.hpp
     hpx/parallel/executors/persistent_auto_chunk_size.hpp => hpx/execution.hpp
     hpx/parallel/executors/post_policy_dispatch.hpp => hpx/execution.hpp
     hpx/parallel/executors/rebind_executor.hpp => hpx/execution.hpp

--- a/libs/core/execution/include/hpx/execution/executors/num_cores.hpp
+++ b/libs/core/execution/include/hpx/execution/executors/num_cores.hpp
@@ -11,7 +11,7 @@
 
 #include <hpx/execution/executors/execution_parameters_fwd.hpp>
 #include <hpx/execution_base/traits/is_executor_parameters.hpp>
-#include <hpx/executors/is_execution_policy.hpp>
+#include <hpx/executors/execution_policy.hpp>
 
 #include <cstddef>
 #include <type_traits>

--- a/libs/core/execution/include/hpx/execution/executors/num_cores.hpp
+++ b/libs/core/execution/include/hpx/execution/executors/num_cores.hpp
@@ -1,0 +1,55 @@
+//  Copyright (c) 2022 Hartmut Kaiser
+//  Copyright (c) 2022 Chuanqiu He
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+/// \file parallel/executors/static_chunk_size.hpp
+
+#pragma once
+
+#include <hpx/execution/executors/execution_parameters_fwd.hpp>
+#include <hpx/execution_base/traits/is_executor_parameters.hpp>
+#include <hpx/executors/execution_policy.hpp>
+#include <cstddef>
+#include <type_traits>
+
+namespace hpx { namespace execution {
+    ///Control number of cores in executors which need a functionality
+    ///for setting the number of cores to be used by an algorithm directly
+    ///
+    struct num_cores
+    {
+        /// Construct a \a num_cores executor parameters object
+        ///
+        /// \note make sure the minimal number of cores is 1
+        ///
+        constexpr explicit num_cores(std::size_t cores = 1) noexcept
+          : num_cores_(cores == 0 ? 1 : cores)
+        {
+        }
+
+        /// \cond NOINTERNAL
+        // discover the number of cores to use for parallelization
+        template <typename Executor>
+        constexpr std::size_t processing_units_count(Executor&&) const noexcept
+        {
+            return num_cores_;
+        }
+        /// \endcond
+
+        /// \cond NOINTERNAL
+        std::size_t num_cores_;
+        /// \endcond
+    };
+}}    // namespace hpx::execution
+
+namespace hpx { namespace parallel { namespace execution {
+    /// \cond NOINTERNAL
+    template <>
+    struct is_executor_parameters<hpx::execution::num_cores> : std::true_type
+    {
+    };
+    /// \endcond
+}}}    // namespace hpx::parallel::execution

--- a/libs/core/execution/include/hpx/execution/executors/num_cores.hpp
+++ b/libs/core/execution/include/hpx/execution/executors/num_cores.hpp
@@ -5,13 +5,14 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-/// \file parallel/executors/static_chunk_size.hpp
+/// \file parallel/executors/numcores.hpp
 
 #pragma once
 
 #include <hpx/execution/executors/execution_parameters_fwd.hpp>
 #include <hpx/execution_base/traits/is_executor_parameters.hpp>
-#include <hpx/executors/execution_policy.hpp>
+#include <hpx/executors/is_execution_policy.hpp>
+
 #include <cstddef>
 #include <type_traits>
 


### PR DESCRIPTION
- Aim to control the number of cores in executors 
- A functionality setting the number of cores to be used by an algorithm directly

note: under ..hpx/libs/core/execution/include/hpx/execution/executors/..