### PR TITLE
Adding a sphinx role allowing to link to a file directly in github

### DIFF
--- a/cmake/templates/conf.py.in
+++ b/cmake/templates/conf.py.in
@@ -571,8 +571,8 @@ html_theme_options = {'logo_only': True}
 # of the sidebar.
 html_logo = '_static/images/HPX_STELLAR_blue.png'
 
-#  The name of an image file (relative to this directory) to place at the top
-# of the brower page.
+# The name of an image file (relative to this directory) to place at the top
+# of the browser page.
 html_favicon = '_static/images/favicon.png'
 
 # Add any paths that contain custom static files (such as style sheets) here,

--- a/cmake/templates/conf.py.in
+++ b/cmake/templates/conf.py.in
@@ -123,7 +123,7 @@ api_ref_header = '''
 {0}
 -------------------------------------------------------------------------------
 
-See :ref:`public_api` for a list of names and headers that are part of the public 
+See :ref:`public_api` for a list of names and headers that are part of the public
 |hpx| API.
 '''
 
@@ -589,6 +589,13 @@ html_context = {
 
 if "@HPX_WITH_GIT_COMMIT_SHORT@" != "":
     html_context['commit'] = "@HPX_WITH_GIT_COMMIT_SHORT@"
+else:
+    html_context['commit'] = "unknown"
+
+if "@HPX_WITH_GIT_COMMIT@" != "":
+    html_context['fullcommit'] = "@HPX_WITH_GIT_COMMIT@"
+else:
+    html_context['fullcommit'] = "unknown"
 
 # Add any extra paths that contain custom files (such as robots.txt or
 # .htaccess) here, relative to this directory. These files are copied

--- a/docs/sphinx/extensions/sphinx-hpx.py
+++ b/docs/sphinx/extensions/sphinx-hpx.py
@@ -8,6 +8,7 @@ from docutils import nodes
 
 def setup(app):
     app.add_role('hpx-issue', autolink('https://github.com/STEllAR-GROUP/hpx/issues/%s', "Issue #"))
+    app.add_role('hpx-header', autolink_file('http://github.com/STEllAR-GROUP/hpx/blob/%s/%s/%s'))
     app.add_role('hpx-pr', autolink('https://github.com/STEllAR-GROUP/hpx/pull/%s', "PR #"))
     app.add_role('cppreference-header', autolink('http://en.cppreference.com/w/cpp/header/%s'))
     app.add_role('cppreference-algorithm', autolink('http://en.cppreference.com/w/cpp/algorithm/%s'))
@@ -18,5 +19,16 @@ def autolink(pattern, prefix=''):
     def role(name, rawtext, text, lineno, inliner, options={}, content=[]):
         url = pattern % (text,)
         node = nodes.reference(rawtext, prefix + text, refuri=url, **options)
+        return [node], []
+    return role
+
+# The text in the rst file should be:
+# :hpx-header:`base_path,file_name`
+def autolink_file(pattern):
+    def role(name, rawtext, text, lineno, inliner, options={}, content=[]):
+        test_parts = text.split(',')
+        commit = inliner.document.settings.env.app.config.html_context['fullcommit']
+        url = pattern % (commit, test_parts[0], test_parts[1])
+        node = nodes.reference(rawtext, test_parts[1], refuri=url, **options)
         return [node], []
     return role

--- a/docs/sphinx/extensions/sphinx-hpx.py
+++ b/docs/sphinx/extensions/sphinx-hpx.py
@@ -8,12 +8,13 @@ from docutils import nodes
 
 def setup(app):
     app.add_role('hpx-issue', autolink('https://github.com/STEllAR-GROUP/hpx/issues/%s', "Issue #"))
-    app.add_role('hpx-header', autolink_file('http://github.com/STEllAR-GROUP/hpx/blob/%s/%s/%s'))
+    app.add_role('hpx-header', autolink_hpx_file('http://github.com/STEllAR-GROUP/hpx/blob/%s/%s/%s'))
     app.add_role('hpx-pr', autolink('https://github.com/STEllAR-GROUP/hpx/pull/%s', "PR #"))
     app.add_role('cppreference-header', autolink('http://en.cppreference.com/w/cpp/header/%s'))
     app.add_role('cppreference-algorithm', autolink('http://en.cppreference.com/w/cpp/algorithm/%s'))
     app.add_role('cppreference-memory', autolink('http://en.cppreference.com/w/cpp/memory/%s'))
     app.add_role('cppreference-container', autolink('http://en.cppreference.com/w/cpp/container/%s'))
+    app.add_role('cppreference-generic', autolink_generic('http://en.cppreference.com/w/cpp/%s/%s'))
 
 def autolink(pattern, prefix=''):
     def role(name, rawtext, text, lineno, inliner, options={}, content=[]):
@@ -24,11 +25,27 @@ def autolink(pattern, prefix=''):
 
 # The text in the rst file should be:
 # :hpx-header:`base_path,file_name`
-def autolink_file(pattern):
+def autolink_hpx_file(pattern):
     def role(name, rawtext, text, lineno, inliner, options={}, content=[]):
-        test_parts = text.split(',')
+        text_parts = [p.strip() for p in text.split(',')]
         commit = inliner.document.settings.env.app.config.html_context['fullcommit']
-        url = pattern % (commit, test_parts[0], test_parts[1])
-        node = nodes.reference(rawtext, test_parts[1], refuri=url, **options)
+        if len(text_parts) >= 2:
+            url = pattern % (commit, text_parts[0], text_parts[1])
+        else:
+            url = pattern % (commit, text_parts[0], text_parts[0])
+        node = nodes.reference(rawtext, text_parts[1], refuri=url, **options)
+        return [node], []
+    return role
+
+# The text in the rst file should be:
+# :cppreference-generic:`base_path,typename`, for instance `thread,barrier`
+def autolink_generic(pattern):
+    def role(name, rawtext, text, lineno, inliner, options={}, content=[]):
+        text_parts = [p.strip() for p in text.split(',')]
+        if len(text_parts) >= 2:
+            url = pattern % (text_parts[0], text_parts[1])
+        else:
+            url = pattern % (text_parts[0], text_parts[0])
+        node = nodes.reference(rawtext, "std::" + text_parts[1], refuri=url, **options)
         return [node], []
     return role


### PR DESCRIPTION
@dimitraka: this adds a new role (a first version of it, at least) that enables linking a specific file to it's page on github:
```
:hpx-header:`libs/core/include_local/include,hpx/local/algorithm.hpp`
```
will link for instance to https://github.com/STEllAR-GROUP/hpx/blob/20bcde189e62bd617f6403a8a9c95a0945b2fffa/libs/core/include_local/include/hpx/local/algorithm.hpp (if the git-hash is '20bcde189e62bd617f6403a8a9c95a0945b2fffa') and show `hpx/local/algorithm.hpp` in the generated html (please note the comma in the `base_path,file_name` argument to the new role).
