### PR TITLE
Fixing a integral conversion warning

### DIFF
--- a/libs/core/runtime_local/src/runtime_local.cpp
+++ b/libs/core/runtime_local/src/runtime_local.cpp
@@ -212,7 +212,7 @@ namespace hpx {
         hpx::threads::coroutines::exception_verbosity = 0;
 #if defined(HPX_HAVE_STACKTRACES) && defined(HPX_HAVE_THREAD_BACKTRACE_DEPTH)
         hpx::threads::coroutines::exception_verbosity =
-            util::from_string<std::size_t>(get_config_entry(
+            util::from_string<int>(get_config_entry(
                 "hpx.trace_depth", HPX_HAVE_THREAD_BACKTRACE_DEPTH));
 #endif
 


### PR DESCRIPTION
Fixes a warning as reported here: https://irclog.cct.lsu.edu/ste~b~~b~ar/2022-02-06#374594;