### PR TITLE
Moving for_loop into namespace hpx::experimental

### DIFF
--- a/docs/sphinx/api/public_api.rst
+++ b/docs/sphinx/api/public_api.rst
@@ -11,8 +11,8 @@
 Public API
 ==========
 
-Our API is semantically conforming; hence, the reader is highly encouraged to refer to the 
-corresponding facility in the `C++ Standard <https://en.cppreference.com/w/cpp/header>`_ if 
+Our API is semantically conforming; hence, the reader is highly encouraged to refer to the
+corresponding facility in the `C++ Standard <https://en.cppreference.com/w/cpp/header>`_ if
 needed. All names below are also available in the top-level ``hpx`` namespace unless
 otherwise noted. The names in ``hpx`` should be preferred. The names in
 sub-namespaces will eventually be removed.
@@ -21,8 +21,8 @@ Header ``hpx/algorithm.hpp``
 ============================
 
 This header includes :ref:`public_api_header_hpx_local_algorithm` and contains
-overloads of the algorithms for segmented iterators. For more information you can refer to the 
-`C++ Standard algorithms library <https://en.cppreference.com/w/cpp/algorithm>`_. 
+overloads of the algorithms for segmented iterators. For more information you can refer to the
+`C++ Standard algorithms library <https://en.cppreference.com/w/cpp/algorithm>`_.
 
 .. _public_api_header_hpx_local_algorithm:
 
@@ -36,8 +36,8 @@ algorithms.
 Classes
 -------
 
-- :cpp:class:`hpx::parallel::v2::reduction`
-- :cpp:class:`hpx::parallel::v2::induction`
+- :cpp:class:`hpx::experimental::reduction`
+- :cpp:class:`hpx::experimental::induction`
 
 Functions
 ---------
@@ -112,10 +112,10 @@ Functions
 - :cpp:func:`hpx::transform`
 - :cpp:func:`hpx::unique`
 - :cpp:func:`hpx::unique_copy`
-- :cpp:func:`hpx::for_loop`
-- :cpp:func:`hpx::for_loop_strided`
-- :cpp:func:`hpx::for_loop_n`
-- :cpp:func:`hpx::for_loop_n_strided`
+- :cpp:func:`hpx::experimental::for_loop`
+- :cpp:func:`hpx::experimental::for_loop_strided`
+- :cpp:func:`hpx::experimental::for_loop_n`
+- :cpp:func:`hpx::experimental::for_loop_n_strided`
 
 - :cpp:func:`hpx::ranges::adjacent_find`
 - :cpp:func:`hpx::ranges::all_of`
@@ -167,8 +167,8 @@ Functions
 - :cpp:func:`hpx::ranges::swap_ranges`
 - :cpp:func:`hpx::ranges::unique`
 - :cpp:func:`hpx::ranges::unique_copy`
-- :cpp:func:`hpx::ranges::for_loop`
-- :cpp:func:`hpx::ranges::for_loop_strided`
+- :cpp:func:`hpx::ranges::experimental::for_loop`
+- :cpp:func:`hpx::ranges::experimental::for_loop_strided`
 
 Header ``hpx/any.hpp``
 ======================

--- a/docs/sphinx/examples/matrix_multiplication.rst
+++ b/docs/sphinx/examples/matrix_multiplication.rst
@@ -15,18 +15,18 @@ This program will perform a matrix multiplication in parallel. The output will l
 
 .. code-block:: text
 
-   Matrix A is : 
-   4 9 6 
-   1 9 8 
+   Matrix A is :
+   4 9 6
+   1 9 8
 
-   Matrix B is : 
-   4 9 
-   6 1 
-   9 8 
+   Matrix B is :
+   4 9
+   6 1
+   9 8
 
-   Resultant Matrix is : 
-   124 93 
-   111 127 
+   Resultant Matrix is :
+   124 93
+   111 127
 
 Setup
 =====
@@ -53,27 +53,27 @@ or:
 
 .. code-block:: shell-session
 
-   $ ./bin/matrix_multiplication --n 2 --m 3 --k 2 --s 100 --l 0 --u 10 
+   $ ./bin/matrix_multiplication --n 2 --m 3 --k 2 --s 100 --l 0 --u 10
 
-where the first matrix is `n` x `m` and the second `m` x `k`, s is the seed for creating the random values of 
-the matrices and the range of these values is [l,u] 
+where the first matrix is `n` x `m` and the second `m` x `k`, s is the seed for creating the random values of
+the matrices and the range of these values is [l,u]
 
 This should print:
 
 .. code-block:: text
 
-   Matrix A is : 
-   4 9 6 
-   1 9 8 
+   Matrix A is :
+   4 9 6
+   1 9 8
 
-   Matrix B is : 
-   4 9 
-   6 1 
-   9 8 
-   
-   Resultant Matrix is : 
-   124 93 
-   111 127 
+   Matrix B is :
+   4 9
+   6 1
+   9 8
+
+   Resultant Matrix is :
+   124 93
+   111 127
 
 Notice that the numbers may be different because of the random initialization of the matrices.
 
@@ -82,7 +82,7 @@ Walkthrough
 
 Now that you have compiled and run the code, let's look at how the code works.
 
-First, ``main()`` is used to initialize the runtime system and pass the command line arguments to the program. 
+First, ``main()`` is used to initialize the runtime system and pass the command line arguments to the program.
 ``hpx::init`` calls ``hpx_main()`` after setting up HPX, which is where our program is implemented.
 
 .. literalinclude:: ../../examples/quickstart/matrix_multiplication.cpp
@@ -90,25 +90,25 @@ First, ``main()`` is used to initialize the runtime system and pass the command 
    :start-after: //[mul_main
    :end-before: //]
 
-Proceeding to the ``hpx_main()`` function, we can see that matrix multiplication can be done very easily. 
+Proceeding to the ``hpx_main()`` function, we can see that matrix multiplication can be done very easily.
 
 .. literalinclude:: ../../examples/quickstart/matrix_multiplication.cpp
    :language: c++
    :start-after: //[mul_hpx_main
    :end-before: //]
 
-First, the dimensions of the matrices are defined. If they were not given as command-line arguments, their default 
-values are `2` x `3` for the first matrix and `3` x `2` for the second. We use standard vectors to define the matrices 
-to be multiplied as well as the resultant matrix. 
+First, the dimensions of the matrices are defined. If they were not given as command-line arguments, their default
+values are `2` x `3` for the first matrix and `3` x `2` for the second. We use standard vectors to define the matrices
+to be multiplied as well as the resultant matrix.
 
 To give some random initial values to our matrices, we use `std::uniform_int_distribution
 <https://en.cppreference.com/w/cpp/numeric/random/uniform_int_distribution>`_. Then, ``std::bind()`` is used
 along with ``hpx::ranges::generate()`` to yield two matrices A and B, which contain values in the range of [0, 10] or in
 the range defined by the user at the command-line arguments. The seed to generate the values can also be defined by the user.
 
-The next step is to perform the matrix multiplication in parallel. This can be done by just using an :cpp:func:`\hpx::for_loop` 
-combined with a parallel execution policy ``hpx::execution::par`` as the outer loop of the multiplication. Note that the execution 
-of :cpp:func:`\hpx::for_loop` without specifying an execution policy is equivalent to specifying ``hpx::execution::seq`` 
+The next step is to perform the matrix multiplication in parallel. This can be done by just using an :cpp:func:`\hpx::experimental::for_loop`
+combined with a parallel execution policy ``hpx::execution::par`` as the outer loop of the multiplication. Note that the execution
+of :cpp:func:`\hpx::experimental::for_loop` without specifying an execution policy is equivalent to specifying ``hpx::execution::seq``
 as the execution policy.
 
 Finally, the matrices A, B that are multiplied as well as the resultant matrix R are printed using the following function.

--- a/docs/sphinx/manual/writing_single_node_hpx_applications.rst
+++ b/docs/sphinx/manual/writing_single_node_hpx_applications.rst
@@ -778,16 +778,16 @@ Parallel algorithms
    * * Name
      * Description
      * In header
-   * * :cpp:func:`hpx::for_loop`
+   * * :cpp:func:`hpx::experimental::for_loop`
      * Implements loop functionality over a range specified by integral or iterator bounds.
      * ``<hpx/algorithm.hpp>``
-   * * :cpp:func:`hpx::for_loop_strided`
+   * * :cpp:func:`hpx::experimental::for_loop_strided`
      * Implements loop functionality over a range specified by integral or iterator bounds.
      * ``<hpx/algorithm.hpp>``
-   * * :cpp:func:`hpx::for_loop_n`
+   * * :cpp:func:`hpx::experimental::for_loop_n`
      * Implements loop functionality over a range specified by integral or iterator bounds.
      * ``<hpx/algorithm.hpp>``
-   * * :cpp:func:`hpx::for_loop_n_strided`
+   * * :cpp:func:`hpx::experimental::for_loop_n_strided`
      * Implements loop functionality over a range specified by integral or iterator bounds.
      * ``<hpx/algorithm.hpp>``
 

--- a/examples/quickstart/disable_thread_stealing_executor.cpp
+++ b/examples/quickstart/disable_thread_stealing_executor.cpp
@@ -121,7 +121,7 @@ int hpx_main()
     auto exec = executor_example::make_disable_thread_stealing_executor(
         hpx::execution::par.executor());
 
-    hpx::for_loop(
+    hpx::experimental::for_loop(
         hpx::execution::par.on(exec), 0, v.size(), [](std::size_t) {});
 
     return hpx::local::finalize();

--- a/examples/quickstart/executor_with_thread_hooks.cpp
+++ b/examples/quickstart/executor_with_thread_hooks.cpp
@@ -225,7 +225,7 @@ int hpx_main()
     auto exec = executor_example::make_executor_with_thread_hooks(
         hpx::execution::par.executor(), on_start, on_stop);
 
-    hpx::for_loop(
+    hpx::experimental::for_loop(
         hpx::execution::par.on(exec), 0, v.size(), [](std::size_t) {});
 
     std::cout << "Executed " << starts.load() << " starts and " << stops.load()

--- a/examples/quickstart/matrix_multiplication.cpp
+++ b/examples/quickstart/matrix_multiplication.cpp
@@ -72,10 +72,10 @@ int hpx_main(hpx::program_options::variables_map& vm)
     hpx::ranges::generate(B, generator);
 
     // Perform matrix multiplication
-    hpx::for_loop(hpx::execution::par, 0, rowsA, [&](auto i) {
-        hpx::for_loop(0, colsB, [&](auto j) {
+    hpx::experimental::for_loop(hpx::execution::par, 0, rowsA, [&](auto i) {
+        hpx::experimental::for_loop(0, colsB, [&](auto j) {
             R[i * colsR + j] = 0;
-            hpx::for_loop(0, rowsB, [&](auto k) {
+            hpx::experimental::for_loop(0, rowsB, [&](auto k) {
                 R[i * colsR + j] += A[i * colsA + k] * B[k * colsB + j];
             });
         });

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/for_loop.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/for_loop.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2021 Hartmut Kaiser
+//  Copyright (c) 2007-2022 Hartmut Kaiser
 //  Copyright (c) 2016 Thomas Heller
 //
 //  SPDX-License-Identifier: BSL-1.0
@@ -10,7 +10,7 @@
 #pragma once
 
 #if defined(DOXYGEN)
-namespace hpx {
+namespace hpx { namespace experimental {
     /// The for_loop implements loop functionality over a range specified by
     /// integral or iterator bounds. For the iterator case, these algorithms
     /// resemble for_each from the Parallelism TS, but leave to the programmer
@@ -725,7 +725,7 @@ namespace hpx {
         typename... Args>
     typename util::detail::algorithm_result<ExPolicy>::type for_loop_n_strided(
         ExPolicy&& policy, I first, Size size, S stride, Args&&... args);
-}    // namespace hpx
+}}    // namespace hpx::experimental
 
 #else
 
@@ -758,592 +758,574 @@ namespace hpx {
 #include <utility>
 #include <vector>
 
-namespace hpx {
-    namespace parallel { inline namespace v2 {
-        // for_loop
-        namespace detail {
-            /// \cond NOINTERNAL
+namespace hpx::parallel { inline namespace v2 {
 
-            ///////////////////////////////////////////////////////////////////////
-            template <typename... Ts, std::size_t... Is>
-            HPX_HOST_DEVICE HPX_FORCEINLINE constexpr void init_iteration(
-                hpx::tuple<Ts...>& args, hpx::util::index_pack<Is...>,
-                std::size_t part_index) noexcept
+    // for_loop
+    namespace detail {
+        /// \cond NOINTERNAL
+
+        ///////////////////////////////////////////////////////////////////////
+        template <typename... Ts, std::size_t... Is>
+        HPX_HOST_DEVICE HPX_FORCEINLINE constexpr void init_iteration(
+            hpx::tuple<Ts...>& args, hpx::util::index_pack<Is...>,
+            std::size_t part_index) noexcept
+        {
+            int const _sequencer[] = {
+                0, (hpx::get<Is>(args).init_iteration(part_index), 0)...};
+            (void) _sequencer;
+        }
+
+        template <typename... Ts, std::size_t... Is, typename F, typename B>
+        HPX_HOST_DEVICE HPX_FORCEINLINE constexpr void invoke_iteration(
+            hpx::tuple<Ts...>& args, hpx::util::index_pack<Is...>, F&& f,
+            B part_begin)
+        {
+            HPX_INVOKE(HPX_FORWARD(F, f), part_begin,
+                hpx::get<Is>(args).iteration_value()...);
+        }
+
+        template <typename... Ts, std::size_t... Is>
+        HPX_HOST_DEVICE HPX_FORCEINLINE constexpr void next_iteration(
+            hpx::tuple<Ts...>& args, hpx::util::index_pack<Is...>) noexcept
+        {
+            int const _sequencer[] = {
+                0, (hpx::get<Is>(args).next_iteration(), 0)...};
+            (void) _sequencer;
+        }
+
+        template <typename... Ts, std::size_t... Is>
+        HPX_HOST_DEVICE HPX_FORCEINLINE constexpr void exit_iteration(
+            hpx::tuple<Ts...>& args, hpx::util::index_pack<Is...>,
+            std::size_t size) noexcept
+        {
+            int const _sequencer[] = {
+                0, (hpx::get<Is>(args).exit_iteration(size), 0)...};
+            (void) _sequencer;
+        }
+
+        ///////////////////////////////////////////////////////////////////////
+        template <typename ExPolicy, typename F, typename S,
+            typename Tuple = hpx::tuple<>>
+        struct part_iterations;
+
+        template <typename ExPolicy, typename F, typename S, typename... Ts>
+        struct part_iterations<ExPolicy, F, S, hpx::tuple<Ts...>>
+        {
+            using fun_type = std::decay_t<F>;
+
+            fun_type f_;
+            S stride_;
+            hpx::tuple<Ts...> args_;
+
+            template <typename F_, typename S_, typename Args>
+            part_iterations(F_&& f, S_&& stride, Args&& args)
+              : f_(HPX_FORWARD(F_, f))
+              , stride_(HPX_FORWARD(S_, stride))
+              , args_(HPX_FORWARD(Args, args))
             {
-                int const _sequencer[] = {
-                    0, (hpx::get<Is>(args).init_iteration(part_index), 0)...};
-                (void) _sequencer;
             }
 
-            template <typename... Ts, std::size_t... Is, typename F, typename B>
-            HPX_HOST_DEVICE HPX_FORCEINLINE constexpr void invoke_iteration(
-                hpx::tuple<Ts...>& args, hpx::util::index_pack<Is...>, F&& f,
-                B part_begin)
+            template <typename B>
+            HPX_HOST_DEVICE HPX_FORCEINLINE constexpr void operator()(
+                B part_begin, std::size_t part_steps, std::size_t part_index)
             {
-                HPX_INVOKE(HPX_FORWARD(F, f), part_begin,
-                    hpx::get<Is>(args).iteration_value()...);
-            }
+                auto pack =
+                    typename hpx::util::make_index_pack<sizeof...(Ts)>::type();
+                detail::init_iteration(args_, pack, part_index);
 
-            template <typename... Ts, std::size_t... Is>
-            HPX_HOST_DEVICE HPX_FORCEINLINE constexpr void next_iteration(
-                hpx::tuple<Ts...>& args, hpx::util::index_pack<Is...>) noexcept
-            {
-                int const _sequencer[] = {
-                    0, (hpx::get<Is>(args).next_iteration(), 0)...};
-                (void) _sequencer;
-            }
-
-            template <typename... Ts, std::size_t... Is>
-            HPX_HOST_DEVICE HPX_FORCEINLINE constexpr void exit_iteration(
-                hpx::tuple<Ts...>& args, hpx::util::index_pack<Is...>,
-                std::size_t size) noexcept
-            {
-                int const _sequencer[] = {
-                    0, (hpx::get<Is>(args).exit_iteration(size), 0)...};
-                (void) _sequencer;
-            }
-
-            ///////////////////////////////////////////////////////////////////////
-            template <typename ExPolicy, typename F, typename S,
-                typename Tuple = hpx::tuple<>>
-            struct part_iterations;
-
-            template <typename ExPolicy, typename F, typename S, typename... Ts>
-            struct part_iterations<ExPolicy, F, S, hpx::tuple<Ts...>>
-            {
-                using fun_type = std::decay_t<F>;
-
-                fun_type f_;
-                S stride_;
-                hpx::tuple<Ts...> args_;
-
-                template <typename F_, typename S_, typename Args>
-                part_iterations(F_&& f, S_&& stride, Args&& args)
-                  : f_(HPX_FORWARD(F_, f))
-                  , stride_(HPX_FORWARD(S_, stride))
-                  , args_(HPX_FORWARD(Args, args))
+                if (stride_ == 1)
                 {
-                }
-
-                template <typename B>
-                HPX_HOST_DEVICE HPX_FORCEINLINE constexpr void operator()(
-                    B part_begin, std::size_t part_steps,
-                    std::size_t part_index)
-                {
-                    auto pack = typename hpx::util::make_index_pack<sizeof...(
-                        Ts)>::type();
-                    detail::init_iteration(args_, pack, part_index);
-
-                    if (stride_ == 1)
+                    while (part_steps-- != 0)
                     {
-                        while (part_steps-- != 0)
-                        {
-                            detail::invoke_iteration(
-                                args_, pack, f_, part_begin++);
-                            detail::next_iteration(args_, pack);
-                        }
-                    }
-                    else if (stride_ > 0)
-                    {
-                        while (part_steps >= std::size_t(stride_))
-                        {
-                            detail::invoke_iteration(
-                                args_, pack, f_, part_begin);
-
-                            part_begin =
-                                parallel::v1::detail::next(part_begin, stride_);
-                            part_steps -= stride_;
-
-                            detail::next_iteration(args_, pack);
-                        }
-
-                        if (part_steps != 0)
-                        {
-                            detail::invoke_iteration(
-                                args_, pack, f_, part_begin);
-                            detail::next_iteration(args_, pack);
-                        }
-                    }
-                    else
-                    {
-                        while (part_steps >= std::size_t(-stride_))
-                        {
-                            detail::invoke_iteration(
-                                args_, pack, f_, part_begin);
-
-                            part_begin =
-                                parallel::v1::detail::next(part_begin, stride_);
-                            part_steps += stride_;
-
-                            detail::next_iteration(args_, pack);
-                        }
-
-                        if (part_steps != 0)
-                        {
-                            detail::invoke_iteration(
-                                args_, pack, f_, part_begin);
-                            detail::next_iteration(args_, pack);
-                        }
+                        detail::invoke_iteration(args_, pack, f_, part_begin++);
+                        detail::next_iteration(args_, pack);
                     }
                 }
-            };
+                else if (stride_ > 0)
+                {
+                    while (part_steps >= std::size_t(stride_))
+                    {
+                        detail::invoke_iteration(args_, pack, f_, part_begin);
 
-            template <typename ExPolicy, typename F, typename S>
-            struct part_iterations<ExPolicy, F, S, hpx::tuple<>>
+                        part_begin =
+                            parallel::v1::detail::next(part_begin, stride_);
+                        part_steps -= stride_;
+
+                        detail::next_iteration(args_, pack);
+                    }
+
+                    if (part_steps != 0)
+                    {
+                        detail::invoke_iteration(args_, pack, f_, part_begin);
+                        detail::next_iteration(args_, pack);
+                    }
+                }
+                else
+                {
+                    while (part_steps >= std::size_t(-stride_))
+                    {
+                        detail::invoke_iteration(args_, pack, f_, part_begin);
+
+                        part_begin =
+                            parallel::v1::detail::next(part_begin, stride_);
+                        part_steps += stride_;
+
+                        detail::next_iteration(args_, pack);
+                    }
+
+                    if (part_steps != 0)
+                    {
+                        detail::invoke_iteration(args_, pack, f_, part_begin);
+                        detail::next_iteration(args_, pack);
+                    }
+                }
+            }
+        };
+
+        template <typename ExPolicy, typename F, typename S>
+        struct part_iterations<ExPolicy, F, S, hpx::tuple<>>
+        {
+            using fun_type = std::decay_t<F>;
+
+            fun_type f_;
+            S stride_;
+
+            template <typename F_,
+                typename Enable = std::enable_if_t<
+                    !std::is_same_v<std::decay_t<F_>, part_iterations>>>
+            explicit part_iterations(F_&& f)
+              : f_(HPX_FORWARD(F_, f))
+              , stride_(1)
             {
-                using fun_type = std::decay_t<F>;
+            }
 
-                fun_type f_;
-                S stride_;
+            template <typename F_, typename S_>
+            part_iterations(F_&& f, S_&& stride)
+              : f_(HPX_FORWARD(F_, f))
+              , stride_(HPX_FORWARD(S_, stride))
+            {
+            }
 
-                template <typename F_,
-                    typename Enable = std::enable_if_t<
-                        !std::is_same_v<std::decay_t<F_>, part_iterations>>>
-                explicit part_iterations(F_&& f)
-                  : f_(HPX_FORWARD(F_, f))
-                  , stride_(1)
+            template <typename F_, typename S_, typename Args>
+            part_iterations(F_&& f, S_&& stride, Args&&)
+              : f_(HPX_FORWARD(F_, f))
+              , stride_(HPX_FORWARD(S_, stride))
+            {
+            }
+
+            template <typename B>
+            HPX_HOST_DEVICE HPX_FORCEINLINE constexpr void operator()(
+                B part_begin, std::size_t part_steps)
+            {
+                HPX_ASSERT(stride_ == 1);
+                parallel::util::loop_n<std::decay_t<ExPolicy>>(
+                    part_begin, part_steps, f_);
+            }
+
+            template <typename B>
+            HPX_HOST_DEVICE HPX_FORCEINLINE constexpr void operator()(
+                B part_begin, std::size_t part_steps, std::size_t)
+            {
+                if (stride_ == 1)
                 {
-                }
-
-                template <typename F_, typename S_>
-                part_iterations(F_&& f, S_&& stride)
-                  : f_(HPX_FORWARD(F_, f))
-                  , stride_(HPX_FORWARD(S_, stride))
-                {
-                }
-
-                template <typename F_, typename S_, typename Args>
-                part_iterations(F_&& f, S_&& stride, Args&&)
-                  : f_(HPX_FORWARD(F_, f))
-                  , stride_(HPX_FORWARD(S_, stride))
-                {
-                }
-
-                template <typename B>
-                HPX_HOST_DEVICE HPX_FORCEINLINE constexpr void operator()(
-                    B part_begin, std::size_t part_steps)
-                {
-                    HPX_ASSERT(stride_ == 1);
                     parallel::util::loop_n<std::decay_t<ExPolicy>>(
                         part_begin, part_steps, f_);
                 }
-
-                template <typename B>
-                HPX_HOST_DEVICE HPX_FORCEINLINE constexpr void operator()(
-                    B part_begin, std::size_t part_steps, std::size_t)
+                else if (stride_ > 0)
                 {
-                    if (stride_ == 1)
+                    while (part_steps >= std::size_t(stride_))
                     {
-                        parallel::util::loop_n<std::decay_t<ExPolicy>>(
-                            part_begin, part_steps, f_);
+                        HPX_INVOKE(f_, part_begin);
+
+                        part_begin =
+                            parallel::v1::detail::next(part_begin, stride_);
+                        part_steps -= stride_;
                     }
-                    else if (stride_ > 0)
+
+                    if (part_steps != 0)
                     {
-                        while (part_steps >= std::size_t(stride_))
-                        {
-                            HPX_INVOKE(f_, part_begin);
-
-                            part_begin =
-                                parallel::v1::detail::next(part_begin, stride_);
-                            part_steps -= stride_;
-                        }
-
-                        if (part_steps != 0)
-                        {
-                            HPX_INVOKE(f_, part_begin);
-                        }
-                    }
-                    else
-                    {
-                        while (part_steps >= std::size_t(-stride_))
-                        {
-                            HPX_INVOKE(f_, part_begin);
-
-                            part_begin =
-                                parallel::v1::detail::next(part_begin, stride_);
-                            part_steps += stride_;
-                        }
-
-                        if (part_steps != 0)
-                        {
-                            HPX_INVOKE(f_, part_begin);
-                        }
+                        HPX_INVOKE(f_, part_begin);
                     }
                 }
-            };
+                else
+                {
+                    while (part_steps >= std::size_t(-stride_))
+                    {
+                        HPX_INVOKE(f_, part_begin);
 
-            ///////////////////////////////////////////////////////////////////////
-            struct for_loop_algo : public v1::detail::algorithm<for_loop_algo>
+                        part_begin =
+                            parallel::v1::detail::next(part_begin, stride_);
+                        part_steps += stride_;
+                    }
+
+                    if (part_steps != 0)
+                    {
+                        HPX_INVOKE(f_, part_begin);
+                    }
+                }
+            }
+        };
+
+        ///////////////////////////////////////////////////////////////////////
+        struct for_loop_algo : public v1::detail::algorithm<for_loop_algo>
+        {
+            constexpr for_loop_algo() noexcept
+              : for_loop_algo::algorithm("for_loop_algo")
             {
-                constexpr for_loop_algo() noexcept
-                  : for_loop_algo::algorithm("for_loop_algo")
+            }
+
+            template <typename ExPolicy, typename InIter, typename S,
+                typename F>
+            HPX_HOST_DEVICE static constexpr hpx::util::unused_type sequential(
+                ExPolicy&&, InIter first, std::size_t count, S stride, F&& f)
+            {
+                if (stride == 1)
                 {
+                    parallel::util::loop_n<std::decay_t<ExPolicy>>(
+                        first, count, HPX_FORWARD(F, f));
                 }
-
-                template <typename ExPolicy, typename InIter, typename S,
-                    typename F>
-                HPX_HOST_DEVICE static constexpr hpx::util::unused_type
-                sequential(ExPolicy&&, InIter first, std::size_t count,
-                    S stride, F&& f)
+                else if (stride > 0)
                 {
-                    if (stride == 1)
+                    while (count >= std::size_t(stride))
                     {
-                        parallel::util::loop_n<std::decay_t<ExPolicy>>(
-                            first, count, HPX_FORWARD(F, f));
-                    }
-                    else if (stride > 0)
-                    {
-                        while (count >= std::size_t(stride))
-                        {
-                            HPX_INVOKE(f, first);
+                        HPX_INVOKE(f, first);
 
-                            first = parallel::v1::detail::next(first, stride);
-                            count -= stride;
-                        }
-
-                        if (count != 0)
-                        {
-                            HPX_INVOKE(f, first);
-                        }
-                    }
-                    else
-                    {
-                        while (count >= std::size_t(-stride))
-                        {
-                            HPX_INVOKE(f, first);
-
-                            first = parallel::v1::detail::next(first, stride);
-                            count += stride;
-                        }
-
-                        if (count != 0)
-                        {
-                            HPX_INVOKE(f, first);
-                        }
-                    }
-
-                    return hpx::util::unused_type();
-                }
-
-                template <typename ExPolicy, typename InIter, typename Size,
-                    typename S, typename F, typename Arg, typename... Args>
-                HPX_HOST_DEVICE static constexpr hpx::util::unused_type
-                sequential(ExPolicy&&, InIter first, Size size, S stride, F&& f,
-                    Arg&& arg, Args&&... args)
-                {
-                    int const init_sequencer[] = {(arg.init_iteration(0), 0),
-                        (args.init_iteration(0), 0)...};
-                    (void) init_sequencer;
-
-                    std::size_t count = size;
-                    if (stride > 0)
-                    {
-                        while (count >= std::size_t(stride))
-                        {
-                            HPX_INVOKE(f, first, arg.iteration_value(),
-                                args.iteration_value()...);
-
-                            first = parallel::v1::detail::next(first, stride);
-                            count -= stride;
-
-                            int const next_sequencer[] = {
-                                (arg.next_iteration(), 0),
-                                (args.next_iteration(), 0)...};
-                            (void) next_sequencer;
-                        }
-                    }
-                    else
-                    {
-                        while (count >= std::size_t(-stride))
-                        {
-                            HPX_INVOKE(f, first, arg.iteration_value(),
-                                args.iteration_value()...);
-
-                            first = parallel::v1::detail::next(first, stride);
-                            count += stride;
-
-                            int const next_sequencer[] = {
-                                (arg.next_iteration(), 0),
-                                (args.next_iteration(), 0)...};
-                            (void) next_sequencer;
-                        }
+                        first = parallel::v1::detail::next(first, stride);
+                        count -= stride;
                     }
 
                     if (count != 0)
                     {
+                        HPX_INVOKE(f, first);
+                    }
+                }
+                else
+                {
+                    while (count >= std::size_t(-stride))
+                    {
+                        HPX_INVOKE(f, first);
+
+                        first = parallel::v1::detail::next(first, stride);
+                        count += stride;
+                    }
+
+                    if (count != 0)
+                    {
+                        HPX_INVOKE(f, first);
+                    }
+                }
+
+                return hpx::util::unused_type();
+            }
+
+            template <typename ExPolicy, typename InIter, typename Size,
+                typename S, typename F, typename Arg, typename... Args>
+            HPX_HOST_DEVICE static constexpr hpx::util::unused_type sequential(
+                ExPolicy&&, InIter first, Size size, S stride, F&& f, Arg&& arg,
+                Args&&... args)
+            {
+                int const init_sequencer[] = {
+                    (arg.init_iteration(0), 0), (args.init_iteration(0), 0)...};
+                (void) init_sequencer;
+
+                std::size_t count = size;
+                if (stride > 0)
+                {
+                    while (count >= std::size_t(stride))
+                    {
                         HPX_INVOKE(f, first, arg.iteration_value(),
                             args.iteration_value()...);
+
+                        first = parallel::v1::detail::next(first, stride);
+                        count -= stride;
+
+                        int const next_sequencer[] = {(arg.next_iteration(), 0),
+                            (args.next_iteration(), 0)...};
+                        (void) next_sequencer;
                     }
+                }
+                else
+                {
+                    while (count >= std::size_t(-stride))
+                    {
+                        HPX_INVOKE(f, first, arg.iteration_value(),
+                            args.iteration_value()...);
 
-                    // make sure live-out variables are properly set on return
-                    int const exit_sequencer[] = {(arg.exit_iteration(size), 0),
-                        (args.exit_iteration(size), 0)...};
-                    (void) exit_sequencer;
+                        first = parallel::v1::detail::next(first, stride);
+                        count += stride;
 
-                    return hpx::util::unused_type();
+                        int const next_sequencer[] = {(arg.next_iteration(), 0),
+                            (args.next_iteration(), 0)...};
+                        (void) next_sequencer;
+                    }
                 }
 
-                template <typename ExPolicy, typename B, typename Size,
-                    typename S, typename F, typename... Ts>
-                static typename util::detail::algorithm_result<ExPolicy>::type
-                parallel(ExPolicy&& policy, B first, Size size, S stride, F&& f,
-                    Ts&&... ts)
+                if (count != 0)
                 {
-                    if (size == 0)
-                    {
-                        return util::detail::algorithm_result<ExPolicy>::get();
-                    }
+                    HPX_INVOKE(f, first, arg.iteration_value(),
+                        args.iteration_value()...);
+                }
 
-                    if constexpr (sizeof...(Ts) == 0)
-                    {
-                        if (stride == 1)
-                        {
-                            return util::partitioner<ExPolicy>::call(
-                                HPX_FORWARD(ExPolicy, policy), first, size,
-                                part_iterations<ExPolicy, F, S>{
-                                    HPX_FORWARD(F, f)},
-                                hpx::util::empty_function{});
-                        }
+                // make sure live-out variables are properly set on return
+                int const exit_sequencer[] = {(arg.exit_iteration(size), 0),
+                    (args.exit_iteration(size), 0)...};
+                (void) exit_sequencer;
 
-                        return util::partitioner<ExPolicy>::call_with_index(
-                            HPX_FORWARD(ExPolicy, policy), first, size, stride,
-                            part_iterations<ExPolicy, F, S>{
-                                HPX_FORWARD(F, f), stride},
+                return hpx::util::unused_type();
+            }
+
+            template <typename ExPolicy, typename B, typename Size, typename S,
+                typename F, typename... Ts>
+            static typename util::detail::algorithm_result<ExPolicy>::type
+            parallel(ExPolicy&& policy, B first, Size size, S stride, F&& f,
+                Ts&&... ts)
+            {
+                if (size == 0)
+                {
+                    return util::detail::algorithm_result<ExPolicy>::get();
+                }
+
+                if constexpr (sizeof...(Ts) == 0)
+                {
+                    if (stride == 1)
+                    {
+                        return util::partitioner<ExPolicy>::call(
+                            HPX_FORWARD(ExPolicy, policy), first, size,
+                            part_iterations<ExPolicy, F, S>{HPX_FORWARD(F, f)},
                             hpx::util::empty_function{});
                     }
-                    else
-                    {
-                        // we need to decay copy here to properly transport
-                        // everything to a GPU device
-                        using args_type = hpx::tuple<std::decay_t<Ts>...>;
 
-                        args_type args =
-                            hpx::forward_as_tuple(HPX_FORWARD(Ts, ts)...);
-
-                        return util::partitioner<ExPolicy>::call_with_index(
-                            policy, first, size, stride,
-                            part_iterations<ExPolicy, F, S, args_type>{
-                                HPX_FORWARD(F, f), stride, args},
-                            [=](std::vector<hpx::future<void>>&&) mutable
-                            -> void {
-                                auto pack = typename hpx::util::make_index_pack<
-                                    sizeof...(Ts)>::type();
-                                // make sure live-out variables are properly set on
-                                // return
-                                detail::exit_iteration(args, pack, size);
-                            });
-                    }
+                    return util::partitioner<ExPolicy>::call_with_index(
+                        HPX_FORWARD(ExPolicy, policy), first, size, stride,
+                        part_iterations<ExPolicy, F, S>{
+                            HPX_FORWARD(F, f), stride},
+                        hpx::util::empty_function{});
                 }
-            };
-
-            // reshuffle arguments, last argument is function object, will go first
-            template <typename ExPolicy, typename B, typename E, typename S,
-                std::size_t... Is, typename... Args>
-            typename util::detail::algorithm_result<ExPolicy>::type for_loop(
-                ExPolicy&& policy, B first, E last, S stride,
-                hpx::util::index_pack<Is...>, Args&&... args)
-            {
-                // stride shall not be zero
-                HPX_ASSERT(stride != 0);
-
-                // stride should be negative only if E is an integral type or at
-                // least a bidirectional iterator
-                if (stride < 0)
+                else
                 {
-                    HPX_ASSERT(std::is_integral<E>::value ||
-                        hpx::traits::is_bidirectional_iterator<E>::value);
+                    // we need to decay copy here to properly transport
+                    // everything to a GPU device
+                    using args_type = hpx::tuple<std::decay_t<Ts>...>;
+
+                    args_type args =
+                        hpx::forward_as_tuple(HPX_FORWARD(Ts, ts)...);
+
+                    return util::partitioner<ExPolicy>::call_with_index(policy,
+                        first, size, stride,
+                        part_iterations<ExPolicy, F, S, args_type>{
+                            HPX_FORWARD(F, f), stride, args},
+                        [=](std::vector<hpx::future<void>>&&) mutable -> void {
+                            auto pack =
+                                typename hpx::util::make_index_pack<sizeof...(
+                                    Ts)>::type();
+                            // make sure live-out variables are properly set on
+                            // return
+                            detail::exit_iteration(args, pack, size);
+                        });
                 }
-
-                static_assert((std::is_integral<B>::value ||
-                                  hpx::traits::is_forward_iterator<B>::value),
-                    "Requires at least forward iterator or integral loop "
-                    "boundaries.");
-
-                std::size_t size = parallel::v1::detail::distance(first, last);
-                auto&& t = hpx::forward_as_tuple(HPX_FORWARD(Args, args)...);
-
-                return for_loop_algo().call(HPX_FORWARD(ExPolicy, policy),
-                    first, size, stride, hpx::get<sizeof...(Args) - 1>(t),
-                    hpx::get<Is>(t)...);
             }
+        };
 
-            // reshuffle arguments, last argument is function object, will go first
-            template <typename ExPolicy, typename B, typename Size, typename S,
-                std::size_t... Is, typename... Args>
-            typename util::detail::algorithm_result<ExPolicy>::type for_loop_n(
-                ExPolicy&& policy, B first, Size size, S stride,
-                hpx::util::index_pack<Is...>, Args&&... args)
-            {
-                // stride shall not be zero
-                HPX_ASSERT(stride != 0);
-
-                // stride should be negative only if E is an integral type or at
-                // least a bidirectional iterator
-                if (stride < 0)
-                {
-                    HPX_ASSERT(std::is_integral<B>::value ||
-                        hpx::traits::is_bidirectional_iterator<B>::value);
-                }
-
-                static_assert((std::is_integral<B>::value ||
-                                  hpx::traits::is_forward_iterator<B>::value),
-                    "Requires at least forward iterator or integral loop "
-                    "boundaries.");
-
-                auto&& t = hpx::forward_as_tuple(HPX_FORWARD(Args, args)...);
-
-                return for_loop_algo().call(HPX_FORWARD(ExPolicy, policy),
-                    first, size, stride, hpx::get<sizeof...(Args) - 1>(t),
-                    hpx::get<Is>(t)...);
-            }
-            /// \endcond
-        }    // namespace detail
-
-        template <typename ExPolicy, typename I, typename... Args,
-            HPX_CONCEPT_REQUIRES_(hpx::is_execution_policy<ExPolicy>::value &&
-                (hpx::traits::is_iterator<I>::value ||
-                    std::is_integral<I>::value))>
-        HPX_DEPRECATED_V(1, 6,
-            "hpx::parallel::for_loop is deprecated, use hpx::for_loop instead")
+        // reshuffle arguments, last argument is function object, will go first
+        template <typename ExPolicy, typename B, typename E, typename S,
+            std::size_t... Is, typename... Args>
         typename util::detail::algorithm_result<ExPolicy>::type for_loop(
-            ExPolicy&& policy, std::decay_t<I> first, I last, Args&&... args)
+            ExPolicy&& policy, B first, E last, S stride,
+            hpx::util::index_pack<Is...>, Args&&... args)
         {
-            static_assert(sizeof...(Args) >= 1,
-                "for_loop must be called with at least a function object");
+            // stride shall not be zero
+            HPX_ASSERT(stride != 0);
 
-            using hpx::util::make_index_pack;
-            return detail::for_loop(HPX_FORWARD(ExPolicy, policy), first, last,
-                1, typename make_index_pack<sizeof...(Args) - 1>::type(),
-                HPX_FORWARD(Args, args)...);
+            // stride should be negative only if E is an integral type or at
+            // least a bidirectional iterator
+            if (stride < 0)
+            {
+                HPX_ASSERT(std::is_integral<E>::value ||
+                    hpx::traits::is_bidirectional_iterator<E>::value);
+            }
+
+            static_assert((std::is_integral<B>::value ||
+                              hpx::traits::is_forward_iterator<B>::value),
+                "Requires at least forward iterator or integral loop "
+                "boundaries.");
+
+            std::size_t size = parallel::v1::detail::distance(first, last);
+            auto&& t = hpx::forward_as_tuple(HPX_FORWARD(Args, args)...);
+
+            return for_loop_algo().call(HPX_FORWARD(ExPolicy, policy), first,
+                size, stride, hpx::get<sizeof...(Args) - 1>(t),
+                hpx::get<Is>(t)...);
         }
 
-        template <typename I, typename... Args,
-            HPX_CONCEPT_REQUIRES_(hpx::traits::is_iterator<I>::value ||
-                std::is_integral<I>::value)>
-        HPX_DEPRECATED_V(1, 6,
-            "hpx::parallel::for_loop is deprecated, use hpx::for_loop instead")
-        void for_loop(std::decay_t<I> first, I last, Args&&... args)
+        // reshuffle arguments, last argument is function object, will go first
+        template <typename ExPolicy, typename B, typename Size, typename S,
+            std::size_t... Is, typename... Args>
+        typename util::detail::algorithm_result<ExPolicy>::type for_loop_n(
+            ExPolicy&& policy, B first, Size size, S stride,
+            hpx::util::index_pack<Is...>, Args&&... args)
         {
-            static_assert(sizeof...(Args) >= 1,
-                "for_loop must be called with at least a function object");
+            // stride shall not be zero
+            HPX_ASSERT(stride != 0);
 
-            return for_loop(
-                hpx::execution::seq, first, last, HPX_FORWARD(Args, args)...);
+            // stride should be negative only if E is an integral type or at
+            // least a bidirectional iterator
+            if (stride < 0)
+            {
+                HPX_ASSERT(std::is_integral<B>::value ||
+                    hpx::traits::is_bidirectional_iterator<B>::value);
+            }
+
+            static_assert((std::is_integral<B>::value ||
+                              hpx::traits::is_forward_iterator<B>::value),
+                "Requires at least forward iterator or integral loop "
+                "boundaries.");
+
+            auto&& t = hpx::forward_as_tuple(HPX_FORWARD(Args, args)...);
+
+            return for_loop_algo().call(HPX_FORWARD(ExPolicy, policy), first,
+                size, stride, hpx::get<sizeof...(Args) - 1>(t),
+                hpx::get<Is>(t)...);
         }
+        /// \endcond
+    }    // namespace detail
 
-        template <typename ExPolicy, typename I, typename S, typename... Args,
-            HPX_CONCEPT_REQUIRES_(hpx::is_execution_policy<ExPolicy>::value&&
-                                      std::is_integral<S>::value &&
-                (hpx::traits::is_iterator<I>::value ||
-                    std::is_integral<I>::value))>
-        HPX_DEPRECATED_V(1, 6,
-            "hpx::parallel::for_loop is deprecated, use hpx::for_loop instead")
-        typename util::detail::algorithm_result<ExPolicy>::type
-            for_loop_strided(ExPolicy&& policy, std::decay_t<I> first, I last,
-                S stride, Args&&... args)
-        {
-            static_assert(sizeof...(Args) >= 1,
-                "for_loop_strided must be called with at least a function "
-                "object");
+    template <typename ExPolicy, typename I, typename... Args,
+        HPX_CONCEPT_REQUIRES_(hpx::is_execution_policy<ExPolicy>::value &&
+            (hpx::traits::is_iterator<I>::value || std::is_integral<I>::value))>
+    HPX_DEPRECATED_V(1, 6,
+        "hpx::parallel::for_loop is deprecated, use hpx::for_loop instead")
+    typename util::detail::algorithm_result<ExPolicy>::type for_loop(
+        ExPolicy&& policy, std::decay_t<I> first, I last, Args&&... args)
+    {
+        static_assert(sizeof...(Args) >= 1,
+            "for_loop must be called with at least a function object");
 
-            using hpx::util::make_index_pack;
-            return detail::for_loop(HPX_FORWARD(ExPolicy, policy), first, last,
-                stride, typename make_index_pack<sizeof...(Args) - 1>::type(),
-                HPX_FORWARD(Args, args)...);
-        }
+        using hpx::util::make_index_pack;
+        return detail::for_loop(HPX_FORWARD(ExPolicy, policy), first, last, 1,
+            typename make_index_pack<sizeof...(Args) - 1>::type(),
+            HPX_FORWARD(Args, args)...);
+    }
 
-        template <typename I, typename S, typename... Args,
-            HPX_CONCEPT_REQUIRES_(std::is_integral<S>::value &&
-                (hpx::traits::is_iterator<I>::value ||
-                    std::is_integral<I>::value))>
-        HPX_DEPRECATED_V(1, 6,
-            "hpx::parallel::for_loop is deprecated, use hpx::for_loop instead")
-        void for_loop_strided(
-            std::decay_t<I> first, I last, S stride, Args&&... args)
-        {
-            static_assert(sizeof...(Args) >= 1,
-                "for_loop_strided must be called with at least a function "
-                "object");
+    template <typename I, typename... Args,
+        HPX_CONCEPT_REQUIRES_(
+            hpx::traits::is_iterator<I>::value || std::is_integral<I>::value)>
+    HPX_DEPRECATED_V(1, 6,
+        "hpx::parallel::for_loop is deprecated, use hpx::for_loop instead")
+    void for_loop(std::decay_t<I> first, I last, Args&&... args)
+    {
+        static_assert(sizeof...(Args) >= 1,
+            "for_loop must be called with at least a function object");
 
-            return for_loop_strided(hpx::execution::seq, first, last, stride,
-                HPX_FORWARD(Args, args)...);
-        }
+        return for_loop(
+            hpx::execution::seq, first, last, HPX_FORWARD(Args, args)...);
+    }
 
-        template <typename ExPolicy, typename I, typename Size,
-            typename... Args,
-            HPX_CONCEPT_REQUIRES_(hpx::is_execution_policy<ExPolicy>::value&&
-                                      std::is_integral<Size>::value &&
-                (hpx::traits::is_iterator<I>::value ||
-                    std::is_integral<I>::value))>
-        HPX_DEPRECATED_V(1, 6,
-            "hpx::parallel::for_loop is deprecated, use hpx::for_loop instead")
-        typename util::detail::algorithm_result<ExPolicy>::type
-            for_loop_n(ExPolicy&& policy, I first, Size size, Args&&... args)
-        {
-            static_assert(sizeof...(Args) >= 1,
-                "for_loop_n must be called with at least a function object");
+    template <typename ExPolicy, typename I, typename S, typename... Args,
+        HPX_CONCEPT_REQUIRES_(hpx::is_execution_policy<ExPolicy>::value&&
+                                  std::is_integral<S>::value &&
+            (hpx::traits::is_iterator<I>::value || std::is_integral<I>::value))>
+    HPX_DEPRECATED_V(1, 6,
+        "hpx::parallel::for_loop is deprecated, use hpx::for_loop instead")
+    typename util::detail::algorithm_result<ExPolicy>::type
+        for_loop_strided(ExPolicy&& policy, std::decay_t<I> first, I last,
+            S stride, Args&&... args)
+    {
+        static_assert(sizeof...(Args) >= 1,
+            "for_loop_strided must be called with at least a function "
+            "object");
 
-            using hpx::util::make_index_pack;
-            return detail::for_loop_n(HPX_FORWARD(ExPolicy, policy), first,
-                size, 1, typename make_index_pack<sizeof...(Args) - 1>::type(),
-                HPX_FORWARD(Args, args)...);
-        }
+        using hpx::util::make_index_pack;
+        return detail::for_loop(HPX_FORWARD(ExPolicy, policy), first, last,
+            stride, typename make_index_pack<sizeof...(Args) - 1>::type(),
+            HPX_FORWARD(Args, args)...);
+    }
 
-        template <typename I, typename Size, typename... Args,
-            HPX_CONCEPT_REQUIRES_(std::is_integral<Size>::value &&
-                (hpx::traits::is_iterator<I>::value ||
-                    std::is_integral<I>::value))>
-        HPX_DEPRECATED_V(1, 6,
-            "hpx::parallel::for_loop is deprecated, use hpx::for_loop instead")
-        void for_loop_n(I first, Size size, Args&&... args)
-        {
-            static_assert(sizeof...(Args) >= 1,
-                "for_loop_n must be called with at least a function object");
+    template <typename I, typename S, typename... Args,
+        HPX_CONCEPT_REQUIRES_(std::is_integral<S>::value &&
+            (hpx::traits::is_iterator<I>::value || std::is_integral<I>::value))>
+    HPX_DEPRECATED_V(1, 6,
+        "hpx::parallel::for_loop is deprecated, use hpx::for_loop instead")
+    void for_loop_strided(
+        std::decay_t<I> first, I last, S stride, Args&&... args)
+    {
+        static_assert(sizeof...(Args) >= 1,
+            "for_loop_strided must be called with at least a function "
+            "object");
 
-            return for_loop_n(
-                hpx::execution::seq, first, size, HPX_FORWARD(Args, args)...);
-        }
+        return for_loop_strided(hpx::execution::seq, first, last, stride,
+            HPX_FORWARD(Args, args)...);
+    }
 
-        template <typename ExPolicy, typename I, typename Size, typename S,
-            typename... Args,
-            HPX_CONCEPT_REQUIRES_(
-                hpx::is_execution_policy<ExPolicy>::value&& std::is_integral<
-                    Size>::value&& std::is_integral<S>::value &&
-                (hpx::traits::is_iterator<I>::value ||
-                    std::is_integral<I>::value))>
-        HPX_DEPRECATED_V(1, 6,
-            "hpx::parallel::for_loop is deprecated, use hpx::for_loop instead")
-        typename util::detail::algorithm_result<ExPolicy>::type
-            for_loop_n_strided(
-                ExPolicy&& policy, I first, Size size, S stride, Args&&... args)
-        {
-            static_assert(sizeof...(Args) >= 1,
-                "for_loop_n_strided must be called with at least a function "
-                "object");
+    template <typename ExPolicy, typename I, typename Size, typename... Args,
+        HPX_CONCEPT_REQUIRES_(hpx::is_execution_policy<ExPolicy>::value&&
+                                  std::is_integral<Size>::value &&
+            (hpx::traits::is_iterator<I>::value || std::is_integral<I>::value))>
+    HPX_DEPRECATED_V(1, 6,
+        "hpx::parallel::for_loop is deprecated, use hpx::for_loop instead")
+    typename util::detail::algorithm_result<ExPolicy>::type
+        for_loop_n(ExPolicy&& policy, I first, Size size, Args&&... args)
+    {
+        static_assert(sizeof...(Args) >= 1,
+            "for_loop_n must be called with at least a function object");
 
-            using hpx::util::make_index_pack;
-            return detail::for_loop_n(HPX_FORWARD(ExPolicy, policy), first,
-                size, stride,
-                typename make_index_pack<sizeof...(Args) - 1>::type(),
-                HPX_FORWARD(Args, args)...);
-        }
+        using hpx::util::make_index_pack;
+        return detail::for_loop_n(HPX_FORWARD(ExPolicy, policy), first, size, 1,
+            typename make_index_pack<sizeof...(Args) - 1>::type(),
+            HPX_FORWARD(Args, args)...);
+    }
 
-        template <typename I, typename Size, typename S, typename... Args,
-            HPX_CONCEPT_REQUIRES_(
+    template <typename I, typename Size, typename... Args,
+        HPX_CONCEPT_REQUIRES_(std::is_integral<Size>::value &&
+            (hpx::traits::is_iterator<I>::value || std::is_integral<I>::value))>
+    HPX_DEPRECATED_V(1, 6,
+        "hpx::parallel::for_loop is deprecated, use hpx::for_loop instead")
+    void for_loop_n(I first, Size size, Args&&... args)
+    {
+        static_assert(sizeof...(Args) >= 1,
+            "for_loop_n must be called with at least a function object");
+
+        return for_loop_n(
+            hpx::execution::seq, first, size, HPX_FORWARD(Args, args)...);
+    }
+
+    template <typename ExPolicy, typename I, typename Size, typename S,
+        typename... Args,
+        HPX_CONCEPT_REQUIRES_(
+            hpx::is_execution_policy<ExPolicy>::value&&
                 std::is_integral<Size>::value&& std::is_integral<S>::value &&
-                (hpx::traits::is_iterator<I>::value ||
-                    std::is_integral<I>::value))>
-        HPX_DEPRECATED_V(1, 6,
-            "hpx::parallel::for_loop is deprecated, use hpx::for_loop instead")
-        void for_loop_n_strided(I first, Size size, S stride, Args&&... args)
-        {
-            static_assert(sizeof...(Args) >= 1,
-                "for_loop_n_strided must be called with at least a function "
-                "object");
-            return for_loop_strided_n(hpx::execution::seq, first, size, stride,
-                HPX_FORWARD(Args, args)...);
-        }
-    }}    // namespace parallel::v2
+            (hpx::traits::is_iterator<I>::value || std::is_integral<I>::value))>
+    HPX_DEPRECATED_V(1, 6,
+        "hpx::parallel::for_loop is deprecated, use hpx::for_loop instead")
+    typename util::detail::algorithm_result<ExPolicy>::type for_loop_n_strided(
+        ExPolicy&& policy, I first, Size size, S stride, Args&&... args)
+    {
+        static_assert(sizeof...(Args) >= 1,
+            "for_loop_n_strided must be called with at least a function "
+            "object");
+
+        using hpx::util::make_index_pack;
+        return detail::for_loop_n(HPX_FORWARD(ExPolicy, policy), first, size,
+            stride, typename make_index_pack<sizeof...(Args) - 1>::type(),
+            HPX_FORWARD(Args, args)...);
+    }
+
+    template <typename I, typename Size, typename S, typename... Args,
+        HPX_CONCEPT_REQUIRES_(
+            std::is_integral<Size>::value&& std::is_integral<S>::value &&
+            (hpx::traits::is_iterator<I>::value || std::is_integral<I>::value))>
+    HPX_DEPRECATED_V(1, 6,
+        "hpx::parallel::for_loop is deprecated, use hpx::for_loop instead")
+    void for_loop_n_strided(I first, Size size, S stride, Args&&... args)
+    {
+        static_assert(sizeof...(Args) >= 1,
+            "for_loop_n_strided must be called with at least a function "
+            "object");
+        return for_loop_strided_n(hpx::execution::seq, first, size, stride,
+            HPX_FORWARD(Args, args)...);
+    }
+}}    // namespace hpx::parallel::v2
+
+namespace hpx::experimental {
 
     ///////////////////////////////////////////////////////////////////////////
     inline constexpr struct for_loop_t final
@@ -1358,16 +1340,17 @@ namespace hpx {
                  std::is_integral<I>::value)
             )>
         // clang-format on
-        friend typename parallel::util::detail::algorithm_result<ExPolicy>::type
-        tag_fallback_invoke(hpx::for_loop_t, ExPolicy&& policy,
+        friend typename hpx::parallel::util::detail::algorithm_result<
+            ExPolicy>::type
+        tag_fallback_invoke(hpx::experimental::for_loop_t, ExPolicy&& policy,
             std::decay_t<I> first, I last, Args&&... args)
         {
             static_assert(sizeof...(Args) >= 1,
                 "for_loop must be called with at least a function object");
 
             using hpx::util::make_index_pack;
-            return parallel::v2::detail::for_loop(HPX_FORWARD(ExPolicy, policy),
-                first, last, 1,
+            return hpx::parallel::v2::detail::for_loop(
+                HPX_FORWARD(ExPolicy, policy), first, last, 1,
                 typename make_index_pack<sizeof...(Args) - 1>::type(),
                 HPX_FORWARD(Args, args)...);
         }
@@ -1379,15 +1362,16 @@ namespace hpx {
                 std::is_integral<I>::value
             )>
         // clang-format on
-        friend void tag_fallback_invoke(
-            hpx::for_loop_t, std::decay_t<I> first, I last, Args&&... args)
+        friend void tag_fallback_invoke(hpx::experimental::for_loop_t,
+            std::decay_t<I> first, I last, Args&&... args)
         {
             static_assert(sizeof...(Args) >= 1,
                 "for_loop must be called with at least a function object");
 
             using hpx::util::make_index_pack;
-            return parallel::v2::detail::for_loop(hpx::execution::seq, first,
-                last, 1, typename make_index_pack<sizeof...(Args) - 1>::type(),
+            return hpx::parallel::v2::detail::for_loop(hpx::execution::seq,
+                first, last, 1,
+                typename make_index_pack<sizeof...(Args) - 1>::type(),
                 HPX_FORWARD(Args, args)...);
         }
     } for_loop{};
@@ -1406,17 +1390,19 @@ namespace hpx {
                  std::is_integral<I>::value)
             )>
         // clang-format on
-        friend typename parallel::util::detail::algorithm_result<ExPolicy>::type
-        tag_fallback_invoke(hpx::for_loop_strided_t, ExPolicy&& policy,
-            std::decay_t<I> first, I last, S stride, Args&&... args)
+        friend typename hpx::parallel::util::detail::algorithm_result<
+            ExPolicy>::type
+        tag_fallback_invoke(hpx::experimental::for_loop_strided_t,
+            ExPolicy&& policy, std::decay_t<I> first, I last, S stride,
+            Args&&... args)
         {
             static_assert(sizeof...(Args) >= 1,
                 "for_loop_strided must be called with at least a function "
                 "object");
 
             using hpx::util::make_index_pack;
-            return parallel::v2::detail::for_loop(HPX_FORWARD(ExPolicy, policy),
-                first, last, stride,
+            return hpx::parallel::v2::detail::for_loop(
+                HPX_FORWARD(ExPolicy, policy), first, last, stride,
                 typename make_index_pack<sizeof...(Args) - 1>::type(),
                 HPX_FORWARD(Args, args)...);
         }
@@ -1429,7 +1415,7 @@ namespace hpx {
                  std::is_integral<I>::value)
             )>
         // clang-format on
-        friend void tag_fallback_invoke(hpx::for_loop_strided_t,
+        friend void tag_fallback_invoke(hpx::experimental::for_loop_strided_t,
             std::decay_t<I> first, I last, S stride, Args&&... args)
         {
             static_assert(sizeof...(Args) >= 1,
@@ -1437,8 +1423,8 @@ namespace hpx {
                 "object");
 
             using hpx::util::make_index_pack;
-            return parallel::v2::detail::for_loop(hpx::execution::seq, first,
-                last, stride,
+            return hpx::parallel::v2::detail::for_loop(hpx::execution::seq,
+                first, last, stride,
                 typename make_index_pack<sizeof...(Args) - 1>::type(),
                 HPX_FORWARD(Args, args)...);
         }
@@ -1459,15 +1445,16 @@ namespace hpx {
                  std::is_integral<I>::value)
             )>
         // clang-format on
-        friend typename parallel::util::detail::algorithm_result<ExPolicy>::type
-        tag_fallback_invoke(hpx::for_loop_n_t, ExPolicy&& policy, I first,
-            Size size, Args&&... args)
+        friend typename hpx::parallel::util::detail::algorithm_result<
+            ExPolicy>::type
+        tag_fallback_invoke(hpx::experimental::for_loop_n_t, ExPolicy&& policy,
+            I first, Size size, Args&&... args)
         {
             static_assert(sizeof...(Args) >= 1,
                 "for_loop_n must be called with at least a function object");
 
             using hpx::util::make_index_pack;
-            return parallel::v2::detail::for_loop_n(
+            return hpx::parallel::v2::detail::for_loop_n(
                 HPX_FORWARD(ExPolicy, policy), first, size, 1,
                 typename make_index_pack<sizeof...(Args) - 1>::type(),
                 HPX_FORWARD(Args, args)...);
@@ -1482,14 +1469,15 @@ namespace hpx {
             )>
         // clang-format on
         friend void tag_fallback_invoke(
-            hpx::for_loop_n_t, I first, Size size, Args&&... args)
+            hpx::experimental::for_loop_n_t, I first, Size size, Args&&... args)
         {
             static_assert(sizeof...(Args) >= 1,
                 "for_loop_n must be called with at least a function object");
 
             using hpx::util::make_index_pack;
-            return parallel::v2::detail::for_loop_n(hpx::execution::seq, first,
-                size, 1, typename make_index_pack<sizeof...(Args) - 1>::type(),
+            return hpx::parallel::v2::detail::for_loop_n(hpx::execution::seq,
+                first, size, 1,
+                typename make_index_pack<sizeof...(Args) - 1>::type(),
                 HPX_FORWARD(Args, args)...);
         }
     } for_loop_n{};
@@ -1510,16 +1498,17 @@ namespace hpx {
                  std::is_integral<I>::value)
             )>
         // clang-format on
-        friend typename parallel::util::detail::algorithm_result<ExPolicy>::type
-        tag_fallback_invoke(hpx::for_loop_n_strided_t, ExPolicy&& policy,
-            I first, Size size, S stride, Args&&... args)
+        friend typename hpx::parallel::util::detail::algorithm_result<
+            ExPolicy>::type
+        tag_fallback_invoke(hpx::experimental::for_loop_n_strided_t,
+            ExPolicy&& policy, I first, Size size, S stride, Args&&... args)
         {
             static_assert(sizeof...(Args) >= 1,
                 "for_loop_n_strided must be called with at least a function "
                 "object");
 
             using hpx::util::make_index_pack;
-            return parallel::v2::detail::for_loop_n(
+            return hpx::parallel::v2::detail::for_loop_n(
                 HPX_FORWARD(ExPolicy, policy), first, size, stride,
                 typename make_index_pack<sizeof...(Args) - 1>::type(),
                 HPX_FORWARD(Args, args)...);
@@ -1534,31 +1523,55 @@ namespace hpx {
                  std::is_integral<I>::value)
             )>
         // clang-format on
-        friend void tag_fallback_invoke(hpx::for_loop_n_strided_t, I first,
-            Size size, S stride, Args&&... args)
+        friend void tag_fallback_invoke(hpx::experimental::for_loop_n_strided_t,
+            I first, Size size, S stride, Args&&... args)
         {
             static_assert(sizeof...(Args) >= 1,
                 "for_loop_n_strided must be called with at least a function "
                 "object");
 
             using hpx::util::make_index_pack;
-            return parallel::v2::detail::for_loop_n(hpx::execution::seq, first,
-                size, stride,
+            return hpx::parallel::v2::detail::for_loop_n(hpx::execution::seq,
+                first, size, stride,
                 typename make_index_pack<sizeof...(Args) - 1>::type(),
                 HPX_FORWARD(Args, args)...);
         }
     } for_loop_n_strided{};
+}    // namespace hpx::experimental
+
+namespace hpx {
+
+    HPX_DEPRECATED_V(1, 8,
+        "hpx::for_loop is deprecated. Please use "
+        "hpx::experimental::for_loop instead.")
+    inline constexpr hpx::experimental::for_loop_t for_loop{};
+
+    HPX_DEPRECATED_V(1, 8,
+        "hpx::for_loop_n is deprecated. Please use "
+        "hpx::experimental::for_loop_n instead.")
+    inline constexpr hpx::experimental::for_loop_n_t for_loop_n{};
+
+    HPX_DEPRECATED_V(1, 8,
+        "hpx::for_loop_strided is deprecated. Please use "
+        "hpx::experimental::for_loop_strided instead.")
+    inline constexpr hpx::experimental::for_loop_strided_t for_loop_strided{};
+
+    HPX_DEPRECATED_V(1, 8,
+        "hpx::for_loop_n_strided is deprecated. Please use "
+        "hpx::experimental::for_loop_n_strided instead.")
+    inline constexpr hpx::experimental::for_loop_n_strided_t
+        for_loop_n_strided{};
 }    // namespace hpx
 
 #if defined(HPX_HAVE_THREAD_DESCRIPTION)
 namespace hpx { namespace traits {
     template <typename ExPolicy, typename F, typename S, typename Tuple>
     struct get_function_address<
-        parallel::v2::detail::part_iterations<ExPolicy, F, S, Tuple>>
+        hpx::parallel::v2::detail::part_iterations<ExPolicy, F, S, Tuple>>
     {
         static constexpr std::size_t call(
-            parallel::v2::detail::part_iterations<ExPolicy, F, S, Tuple> const&
-                f) noexcept
+            hpx::parallel::v2::detail::part_iterations<ExPolicy, F, S,
+                Tuple> const& f) noexcept
         {
             return get_function_address<std::decay_t<F>>::call(f.f_);
         }
@@ -1566,11 +1579,11 @@ namespace hpx { namespace traits {
 
     template <typename ExPolicy, typename F, typename S, typename Tuple>
     struct get_function_annotation<
-        parallel::v2::detail::part_iterations<ExPolicy, F, S, Tuple>>
+        hpx::parallel::v2::detail::part_iterations<ExPolicy, F, S, Tuple>>
     {
         static constexpr char const* call(
-            parallel::v2::detail::part_iterations<ExPolicy, F, S, Tuple> const&
-                f) noexcept
+            hpx::parallel::v2::detail::part_iterations<ExPolicy, F, S,
+                Tuple> const& f) noexcept
         {
             return get_function_annotation<std::decay_t<F>>::call(f.f_);
         }
@@ -1579,11 +1592,11 @@ namespace hpx { namespace traits {
 #if HPX_HAVE_ITTNOTIFY != 0 && !defined(HPX_HAVE_APEX)
     template <typename ExPolicy, typename F, typename S, typename Tuple>
     struct get_function_annotation_itt<
-        parallel::v2::detail::part_iterations<ExPolicy, F, S, Tuple>>
+        hpx::parallel::v2::detail::part_iterations<ExPolicy, F, S, Tuple>>
     {
         static util::itt::string_handle call(
-            parallel::v2::detail::part_iterations<ExPolicy, F, S, Tuple> const&
-                f) noexcept
+            hpx::parallel::v2::detail::part_iterations<ExPolicy, F, S,
+                Tuple> const& f) noexcept
         {
             return get_function_annotation_itt<std::decay_t<F>>::call(f.f_);
         }

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/for_loop_induction.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/for_loop_induction.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2018 Hartmut Kaiser
+//  Copyright (c) 2007-2022 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -17,172 +17,170 @@
 #include <type_traits>
 #include <utility>
 
-namespace hpx { namespace parallel { inline namespace v2 {
-    namespace detail {
-        /// \cond NOINTERNAL
+namespace hpx::parallel { inline namespace v2 { namespace detail {
+    /// \cond NOINTERNAL
 
-        ///////////////////////////////////////////////////////////////////////
-        template <typename T>
-        struct induction_helper
+    ///////////////////////////////////////////////////////////////////////
+    template <typename T>
+    struct induction_helper
+    {
+        constexpr induction_helper(T var) noexcept
+          : var_(var)
+          , curr_(var)
         {
-            constexpr induction_helper(T var) noexcept
-              : var_(var)
-              , curr_(var)
-            {
-            }
+        }
 
-            HPX_HOST_DEVICE
-            constexpr void init_iteration(std::size_t index) noexcept
-            {
-                curr_ = parallel::v1::detail::next(var_, index);
-            }
-
-            HPX_HOST_DEVICE
-            constexpr T const& iteration_value() const noexcept
-            {
-                return curr_;
-            }
-
-            HPX_HOST_DEVICE
-            constexpr void next_iteration() noexcept
-            {
-                ++curr_;
-            }
-
-            HPX_HOST_DEVICE
-            constexpr void exit_iteration(std::size_t /*index*/) noexcept {}
-
-        private:
-            typename std::decay<T>::type var_;
-            T curr_;
-        };
-
-        template <typename T>
-        struct induction_helper<T&>
+        HPX_HOST_DEVICE
+        constexpr void init_iteration(std::size_t index) noexcept
         {
-            constexpr induction_helper(T& var) noexcept
-              : live_out_var_(var)
-              , var_(var)
-              , curr_(var)
-            {
-            }
+            curr_ = parallel::v1::detail::next(var_, index);
+        }
 
-            HPX_HOST_DEVICE
-            constexpr void init_iteration(std::size_t index) noexcept
-            {
-                curr_ = parallel::v1::detail::next(var_, index);
-            }
-
-            HPX_HOST_DEVICE
-            constexpr T const& iteration_value() const noexcept
-            {
-                return curr_;
-            }
-
-            HPX_HOST_DEVICE
-            constexpr void next_iteration() noexcept
-            {
-                ++curr_;
-            }
-
-            HPX_HOST_DEVICE
-            constexpr void exit_iteration(std::size_t index) noexcept
-            {
-                live_out_var_ =
-                    parallel::v1::detail::next(live_out_var_, index);
-            }
-
-        private:
-            T& live_out_var_;
-            T var_;
-            T curr_;
-        };
-
-        ///////////////////////////////////////////////////////////////////////
-        template <typename T>
-        struct induction_stride_helper
+        HPX_HOST_DEVICE
+        constexpr T const& iteration_value() const noexcept
         {
-            constexpr induction_stride_helper(
-                T var, std::size_t stride) noexcept
-              : var_(var)
-              , curr_(var)
-              , stride_(stride)
-            {
-            }
+            return curr_;
+        }
 
-            HPX_HOST_DEVICE
-            constexpr void init_iteration(std::size_t index) noexcept
-            {
-                curr_ = parallel::v1::detail::next(var_, stride_ * index);
-            }
-
-            HPX_HOST_DEVICE
-            constexpr T const& iteration_value() const noexcept
-            {
-                return curr_;
-            }
-
-            HPX_HOST_DEVICE
-            constexpr void next_iteration() noexcept
-            {
-                curr_ = parallel::v1::detail::next(curr_, stride_);
-            }
-
-            HPX_HOST_DEVICE
-            constexpr void exit_iteration(std::size_t /*index*/) noexcept {}
-
-        private:
-            typename std::decay<T>::type var_;
-            T curr_;
-            std::size_t stride_;
-        };
-
-        template <typename T>
-        struct induction_stride_helper<T&>
+        HPX_HOST_DEVICE
+        constexpr void next_iteration() noexcept
         {
-            constexpr induction_stride_helper(
-                T& var, std::size_t stride) noexcept
-              : live_out_var_(var)
-              , var_(var)
-              , curr_(var)
-              , stride_(stride)
-            {
-            }
+            ++curr_;
+        }
 
-            HPX_HOST_DEVICE
-            constexpr void init_iteration(std::size_t index) noexcept
-            {
-                curr_ = parallel::v1::detail::next(var_, stride_ * index);
-            }
+        HPX_HOST_DEVICE
+        constexpr void exit_iteration(std::size_t /*index*/) noexcept {}
 
-            HPX_HOST_DEVICE
-            constexpr T const& iteration_value() const noexcept
-            {
-                return curr_;
-            }
+    private:
+        typename std::decay<T>::type var_;
+        T curr_;
+    };
 
-            HPX_HOST_DEVICE
-            constexpr void next_iteration() noexcept
-            {
-                curr_ = parallel::v1::detail::next(curr_, stride_);
-            }
+    template <typename T>
+    struct induction_helper<T&>
+    {
+        constexpr induction_helper(T& var) noexcept
+          : live_out_var_(var)
+          , var_(var)
+          , curr_(var)
+        {
+        }
 
-            HPX_HOST_DEVICE
-            constexpr void exit_iteration(std::size_t index) noexcept
-            {
-                live_out_var_ =
-                    parallel::v1::detail::next(live_out_var_, stride_ * index);
-            }
+        HPX_HOST_DEVICE
+        constexpr void init_iteration(std::size_t index) noexcept
+        {
+            curr_ = parallel::v1::detail::next(var_, index);
+        }
 
-        private:
-            T& live_out_var_;
-            T var_;
-            T curr_;
-            std::size_t stride_;
-        };
+        HPX_HOST_DEVICE
+        constexpr T const& iteration_value() const noexcept
+        {
+            return curr_;
+        }
 
-        /// \endcond
-    }    // namespace detail
+        HPX_HOST_DEVICE
+        constexpr void next_iteration() noexcept
+        {
+            ++curr_;
+        }
+
+        HPX_HOST_DEVICE
+        constexpr void exit_iteration(std::size_t index) noexcept
+        {
+            live_out_var_ = parallel::v1::detail::next(live_out_var_, index);
+        }
+
+    private:
+        T& live_out_var_;
+        T var_;
+        T curr_;
+    };
+
+    ///////////////////////////////////////////////////////////////////////
+    template <typename T>
+    struct induction_stride_helper
+    {
+        constexpr induction_stride_helper(T var, std::size_t stride) noexcept
+          : var_(var)
+          , curr_(var)
+          , stride_(stride)
+        {
+        }
+
+        HPX_HOST_DEVICE
+        constexpr void init_iteration(std::size_t index) noexcept
+        {
+            curr_ = parallel::v1::detail::next(var_, stride_ * index);
+        }
+
+        HPX_HOST_DEVICE
+        constexpr T const& iteration_value() const noexcept
+        {
+            return curr_;
+        }
+
+        HPX_HOST_DEVICE
+        constexpr void next_iteration() noexcept
+        {
+            curr_ = parallel::v1::detail::next(curr_, stride_);
+        }
+
+        HPX_HOST_DEVICE
+        constexpr void exit_iteration(std::size_t /*index*/) noexcept {}
+
+    private:
+        typename std::decay<T>::type var_;
+        T curr_;
+        std::size_t stride_;
+    };
+
+    template <typename T>
+    struct induction_stride_helper<T&>
+    {
+        constexpr induction_stride_helper(T& var, std::size_t stride) noexcept
+          : live_out_var_(var)
+          , var_(var)
+          , curr_(var)
+          , stride_(stride)
+        {
+        }
+
+        HPX_HOST_DEVICE
+        constexpr void init_iteration(std::size_t index) noexcept
+        {
+            curr_ = parallel::v1::detail::next(var_, stride_ * index);
+        }
+
+        HPX_HOST_DEVICE
+        constexpr T const& iteration_value() const noexcept
+        {
+            return curr_;
+        }
+
+        HPX_HOST_DEVICE
+        constexpr void next_iteration() noexcept
+        {
+            curr_ = parallel::v1::detail::next(curr_, stride_);
+        }
+
+        HPX_HOST_DEVICE
+        constexpr void exit_iteration(std::size_t index) noexcept
+        {
+            live_out_var_ =
+                parallel::v1::detail::next(live_out_var_, stride_ * index);
+        }
+
+    private:
+        T& live_out_var_;
+        T var_;
+        T curr_;
+        std::size_t stride_;
+    };
+
+    /// \endcond
+}}}    // namespace hpx::parallel::v2::detail
+
+namespace hpx::experimental {
 
     /// The function template returns an induction object of unspecified type
     /// having a value type and encapsulating an initial value \a value of that
@@ -214,18 +212,42 @@ namespace hpx { namespace parallel { inline namespace v2 {
     ///          object.
     ///
     template <typename T>
-    HPX_FORCEINLINE constexpr detail::induction_stride_helper<T> induction(
-        T&& value, std::size_t stride)
+    HPX_FORCEINLINE constexpr hpx::parallel::v2::detail::
+        induction_stride_helper<T>
+        induction(T&& value, std::size_t stride)
     {
-        return detail::induction_stride_helper<T>(
+        return hpx::parallel::v2::detail::induction_stride_helper<T>(
             HPX_FORWARD(T, value), stride);
     }
 
     /// \cond NOINTERNAL
     template <typename T>
-    HPX_FORCEINLINE constexpr detail::induction_helper<T> induction(T&& value)
+    HPX_FORCEINLINE constexpr hpx::parallel::v2::detail::induction_helper<T>
+    induction(T&& value)
     {
-        return detail::induction_helper<T>(HPX_FORWARD(T, value));
+        return hpx::parallel::v2::detail::induction_helper<T>(
+            HPX_FORWARD(T, value));
     }
     /// \endcond
-}}}    // namespace hpx::parallel::v2
+}    // namespace hpx::experimental
+
+namespace hpx::parallel { inline namespace v2 {
+
+    template <typename T>
+    HPX_DEPRECATED_V(1, 8,
+        "hpx::hpx::parallel::induction is deprecated. Please use "
+        "hpx::experimental::induction instead.")
+    constexpr decltype(auto) induction(T&& value, std::size_t stride)
+    {
+        return hpx::experimental::induction(HPX_FORWARD(T, value), stride);
+    }
+
+    template <typename T>
+    HPX_DEPRECATED_V(1, 8,
+        "hpx::hpx::parallel::induction is deprecated. Please use "
+        "hpx::experimental::induction instead.")
+    constexpr decltype(auto) induction(T&& value)
+    {
+        return hpx::experimental::induction(HPX_FORWARD(T, value));
+    }
+}}    // namespace hpx::parallel::v2

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/for_loop_reduction.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/for_loop_reduction.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2018 Hartmut Kaiser
+//  Copyright (c) 2007-2022 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -27,59 +27,59 @@
 #include <type_traits>
 #include <utility>
 
-namespace hpx { namespace parallel { inline namespace v2 {
-    namespace detail {
-        /// \cond NOINTERNAL
+namespace hpx::parallel { inline namespace v2 { namespace detail {
 
-        ///////////////////////////////////////////////////////////////////////
-        template <typename T, typename Op>
-        struct reduction_helper
+    ///////////////////////////////////////////////////////////////////////
+    /// \cond NOINTERNAL
+    template <typename T, typename Op>
+    struct reduction_helper
+    {
+        template <typename Op_>
+        constexpr reduction_helper(T& var, T const& identity, Op_&& op)
+          : var_(var)
+          , op_(HPX_FORWARD(Op_, op))
         {
-            template <typename Op_>
-            constexpr reduction_helper(T& var, T const& identity, Op_&& op)
-              : var_(var)
-              , op_(HPX_FORWARD(Op_, op))
-            {
-                std::size_t cores =
-                    hpx::parallel::execution::detail::get_os_thread_count();
-                data_.reset(new hpx::util::cache_line_data<T>[cores]);
-                for (std::size_t i = 0; i != cores; ++i)
-                    data_[i].data_ = identity;
-            }
+            std::size_t cores =
+                hpx::parallel::execution::detail::get_os_thread_count();
+            data_.reset(new hpx::util::cache_line_data<T>[cores]);
+            for (std::size_t i = 0; i != cores; ++i)
+                data_[i].data_ = identity;
+        }
 
-            constexpr void init_iteration(std::size_t)
-            {
-                HPX_ASSERT(hpx::get_worker_thread_num() <
-                    hpx::parallel::execution::detail::get_os_thread_count());
-            }
+        constexpr void init_iteration(std::size_t)
+        {
+            HPX_ASSERT(hpx::get_worker_thread_num() <
+                hpx::parallel::execution::detail::get_os_thread_count());
+        }
 
-            constexpr T& iteration_value()
-            {
-                return data_[hpx::get_worker_thread_num()].data_;
-            }
+        constexpr T& iteration_value()
+        {
+            return data_[hpx::get_worker_thread_num()].data_;
+        }
 
-            constexpr void next_iteration() noexcept {}
+        constexpr void next_iteration() noexcept {}
 
-            void exit_iteration(std::size_t /*index*/)
-            {
-                std::size_t cores =
-                    hpx::parallel::execution::detail::get_os_thread_count();
-                for (std::size_t i = 0; i != cores; ++i)
-                    var_ = op_(var_, data_[i].data_);
-            }
+        void exit_iteration(std::size_t /*index*/)
+        {
+            std::size_t cores =
+                hpx::parallel::execution::detail::get_os_thread_count();
+            for (std::size_t i = 0; i != cores; ++i)
+                var_ = op_(var_, data_[i].data_);
+        }
 
-        private:
-            T& var_;
-            Op op_;
+    private:
+        T& var_;
+        Op op_;
 #if defined(HPX_HAVE_CXX17_SHARED_PTR_ARRAY)
-            std::shared_ptr<hpx::util::cache_line_data<T>[]> data_;
+        std::shared_ptr<hpx::util::cache_line_data<T>[]> data_;
 #else
-            boost::shared_array<hpx::util::cache_line_data<T>> data_;
+        boost::shared_array<hpx::util::cache_line_data<T>> data_;
 #endif
-        };
+    };
+    /// \endcond
+}}}    // namespace hpx::parallel::v2::detail
 
-        /// \endcond
-    }    // namespace detail
+namespace hpx::experimental {
 
     /// The function template returns a reduction object of unspecified type
     /// having a value type and encapsulating an identity value for the
@@ -131,111 +131,265 @@ namespace hpx { namespace parallel { inline namespace v2 {
     ///          it the two views to be combined.
     ///
     template <typename T, typename Op>
-    HPX_FORCEINLINE constexpr detail::reduction_helper<T,
-        typename std::decay<Op>::type>
+    HPX_FORCEINLINE constexpr hpx::parallel::v2::detail::reduction_helper<T,
+        std::decay_t<Op>>
     reduction(T& var, T const& identity, Op&& combiner)
     {
-        return detail::reduction_helper<T, typename std::decay<Op>::type>(
+        return hpx::parallel::v2::detail::reduction_helper<T,
+            typename std::decay<Op>::type>(
             var, identity, HPX_FORWARD(Op, combiner));
     }
 
     /// \cond NOINTERNAL
     template <typename T>
-    HPX_FORCEINLINE constexpr detail::reduction_helper<T, std::plus<T>>
+    HPX_FORCEINLINE constexpr hpx::parallel::v2::detail::reduction_helper<T,
+        std::plus<T>>
     reduction_plus(T& var)
     {
         return reduction(var, T(), std::plus<T>());
     }
 
     template <typename T>
-    HPX_FORCEINLINE constexpr detail::reduction_helper<T, std::plus<T>>
+    HPX_FORCEINLINE constexpr hpx::parallel::v2::detail::reduction_helper<T,
+        std::plus<T>>
     reduction_plus(T& var, T const& identity)
     {
         return reduction(var, identity, std::plus<T>());
     }
 
     template <typename T>
-    HPX_FORCEINLINE constexpr detail::reduction_helper<T, std::multiplies<T>>
+    HPX_FORCEINLINE constexpr hpx::parallel::v2::detail::reduction_helper<T,
+        std::multiplies<T>>
     reduction_multiplies(T& var)
     {
         return reduction(var, T(1), std::multiplies<T>());
     }
 
     template <typename T>
-    HPX_FORCEINLINE constexpr detail::reduction_helper<T, std::multiplies<T>>
+    HPX_FORCEINLINE constexpr hpx::parallel::v2::detail::reduction_helper<T,
+        std::multiplies<T>>
     reduction_multiplies(T& var, T const& identity)
     {
         return reduction(var, identity, std::multiplies<T>());
     }
 
     template <typename T>
-    HPX_FORCEINLINE constexpr detail::reduction_helper<T, std::bit_and<T>>
+    HPX_FORCEINLINE constexpr hpx::parallel::v2::detail::reduction_helper<T,
+        std::bit_and<T>>
     reduction_bit_and(T& var)
     {
         return reduction(var, ~(T()), std::bit_and<T>());
     }
 
     template <typename T>
-    HPX_FORCEINLINE constexpr detail::reduction_helper<T, std::bit_and<T>>
+    HPX_FORCEINLINE constexpr hpx::parallel::v2::detail::reduction_helper<T,
+        std::bit_and<T>>
     reduction_bit_and(T& var, T const& identity)
     {
         return reduction(var, identity, std::bit_and<T>());
     }
 
     template <typename T>
-    HPX_FORCEINLINE constexpr detail::reduction_helper<T, std::bit_or<T>>
+    HPX_FORCEINLINE constexpr hpx::parallel::v2::detail::reduction_helper<T,
+        std::bit_or<T>>
     reduction_bit_or(T& var)
     {
         return reduction(var, T(), std::bit_or<T>());
     }
 
     template <typename T>
-    HPX_FORCEINLINE constexpr detail::reduction_helper<T, std::bit_or<T>>
+    HPX_FORCEINLINE constexpr hpx::parallel::v2::detail::reduction_helper<T,
+        std::bit_or<T>>
     reduction_bit_or(T& var, T const& identity)
     {
         return reduction(var, identity, std::bit_or<T>());
     }
 
     template <typename T>
-    HPX_FORCEINLINE constexpr detail::reduction_helper<T, std::bit_xor<T>>
+    HPX_FORCEINLINE constexpr hpx::parallel::v2::detail::reduction_helper<T,
+        std::bit_xor<T>>
     reduction_bit_xor(T& var)
     {
         return reduction(var, T(), std::bit_xor<T>());
     }
 
     template <typename T>
-    HPX_FORCEINLINE constexpr detail::reduction_helper<T, std::bit_xor<T>>
+    HPX_FORCEINLINE constexpr hpx::parallel::v2::detail::reduction_helper<T,
+        std::bit_xor<T>>
     reduction_bit_xor(T& var, T const& identity)
     {
         return reduction(var, identity, std::bit_xor<T>());
     }
 
     template <typename T>
-    HPX_FORCEINLINE constexpr detail::reduction_helper<T, v1::detail::min_of<T>>
+    HPX_FORCEINLINE constexpr hpx::parallel::v2::detail::reduction_helper<T,
+        hpx::parallel::v1::detail::min_of<T>>
     reduction_min(T& var)
     {
-        return reduction(var, var, v1::detail::min_of<T>());
+        return reduction(var, var, hpx::parallel::v1::detail::min_of<T>());
     }
 
     template <typename T>
-    HPX_FORCEINLINE constexpr detail::reduction_helper<T, v1::detail::min_of<T>>
+    HPX_FORCEINLINE constexpr hpx::parallel::v2::detail::reduction_helper<T,
+        hpx::parallel::v1::detail::min_of<T>>
     reduction_min(T& var, T const& identity)
     {
-        return reduction(var, identity, v1::detail::min_of<T>());
+        return reduction(var, identity, hpx::parallel::v1::detail::min_of<T>());
     }
 
     template <typename T>
-    HPX_FORCEINLINE constexpr detail::reduction_helper<T, v1::detail::max_of<T>>
+    HPX_FORCEINLINE constexpr hpx::parallel::v2::detail::reduction_helper<T,
+        hpx::parallel::v1::detail::max_of<T>>
     reduction_max(T& var)
     {
-        return reduction(var, var, v1::detail::max_of<T>());
+        return reduction(var, var, hpx::parallel::v1::detail::max_of<T>());
     }
 
     template <typename T>
-    HPX_FORCEINLINE constexpr detail::reduction_helper<T, v1::detail::max_of<T>>
+    HPX_FORCEINLINE constexpr hpx::parallel::v2::detail::reduction_helper<T,
+        hpx::parallel::v1::detail::max_of<T>>
     reduction_max(T& var, T const& identity)
     {
-        return reduction(var, identity, v1::detail::max_of<T>());
+        return reduction(var, identity, hpx::parallel::v1::detail::max_of<T>());
     }
     /// \endcond
-}}}    // namespace hpx::parallel::v2
+}    // namespace hpx::experimental
+
+namespace hpx::parallel { inline namespace v2 {
+
+    template <typename T, typename Op>
+    HPX_DEPRECATED_V(1, 8,
+        "hpx::hpx::parallel::reduction is deprecated. Please use "
+        "hpx::experimental::reduction instead.")
+    constexpr decltype(auto) reduction(T& var, T const& identity, Op&& combiner)
+    {
+        return hpx::experimental::reduction(
+            var, identity, HPX_FORWARD(Op, combiner));
+    }
+
+    template <typename T>
+    HPX_DEPRECATED_V(1, 8,
+        "hpx::hpx::parallel::reduction_plus is deprecated. Please use "
+        "hpx::experimental::reduction_plus instead.")
+    constexpr decltype(auto) reduction_plus(T& var)
+    {
+        return hpx::experimental::reduction_plus(var);
+    }
+
+    template <typename T>
+    HPX_DEPRECATED_V(1, 8,
+        "hpx::hpx::parallel::reduction_plus is deprecated. Please use "
+        "hpx::experimental::reduction_plus instead.")
+    constexpr decltype(auto) reduction_plus(T& var, T const& identity)
+    {
+        return hpx::experimental::reduction_plus(var, identity);
+    }
+
+    template <typename T>
+    HPX_DEPRECATED_V(1, 8,
+        "hpx::hpx::parallel::reduction_multiplies is deprecated. Please use "
+        "hpx::experimental::reduction_multiplies instead.")
+    constexpr decltype(auto) reduction_multiplies(T& var)
+    {
+        return hpx::experimental::reduction_multiplies(var);
+    }
+
+    template <typename T>
+    HPX_DEPRECATED_V(1, 8,
+        "hpx::hpx::parallel::reduction_multiplies is deprecated. Please use "
+        "hpx::experimental::reduction_multiplies instead.")
+    constexpr decltype(auto) reduction_multiplies(T& var, T const& identity)
+    {
+        return hpx::experimental::reduction_multiplies(var, identity);
+    }
+
+    template <typename T>
+    HPX_DEPRECATED_V(1, 8,
+        "hpx::hpx::parallel::reduction_bit_and is deprecated. Please use "
+        "hpx::experimental::reduction_bit_and instead.")
+    constexpr decltype(auto) reduction_bit_and(T& var)
+    {
+        return hpx::experimental::reduction_bit_and(var);
+    }
+
+    template <typename T>
+    HPX_DEPRECATED_V(1, 8,
+        "hpx::hpx::parallel::reduction_bit_and is deprecated. Please use "
+        "hpx::experimental::reduction_bit_and instead.")
+    constexpr decltype(auto) reduction_bit_and(T& var, T const& identity)
+    {
+        return hpx::experimental::reduction_bit_and(var, identity);
+    }
+
+    template <typename T>
+    HPX_DEPRECATED_V(1, 8,
+        "hpx::hpx::parallel::reduction_bit_or is deprecated. Please use "
+        "hpx::experimental::reduction_bit_or instead.")
+    constexpr decltype(auto) reduction_bit_or(T& var)
+    {
+        return hpx::experimental::reduction_bit_or(var);
+    }
+
+    template <typename T>
+    HPX_DEPRECATED_V(1, 8,
+        "hpx::hpx::parallel::reduction_bit_or is deprecated. Please use "
+        "hpx::experimental::reduction_bit_or instead.")
+    constexpr decltype(auto) reduction_bit_or(T& var, T const& identity)
+    {
+        return hpx::experimental::reduction_bit_or(var, identity);
+    }
+
+    template <typename T>
+    HPX_DEPRECATED_V(1, 8,
+        "hpx::hpx::parallel::reduction_bit_xor is deprecated. Please use "
+        "hpx::experimental::reduction_bit_xor instead.")
+    constexpr decltype(auto) reduction_bit_xor(T& var)
+    {
+        return hpx::experimental::reduction_bit_xor(var);
+    }
+
+    template <typename T>
+    HPX_DEPRECATED_V(1, 8,
+        "hpx::hpx::parallel::reduction_bit_xor is deprecated. Please use "
+        "hpx::experimental::reduction_bit_xor instead.")
+    constexpr decltype(auto) reduction_bit_xor(T& var, T const& identity)
+    {
+        return hpx::experimental::reduction_bit_xor(var, identity);
+    }
+
+    template <typename T>
+    HPX_DEPRECATED_V(1, 8,
+        "hpx::hpx::parallel::reduction_min is deprecated. Please use "
+        "hpx::experimental::reduction_min instead.")
+    constexpr decltype(auto) reduction_min(T& var)
+    {
+        return hpx::experimental::reduction_min(var);
+    }
+
+    template <typename T>
+    HPX_DEPRECATED_V(1, 8,
+        "hpx::hpx::parallel::reduction_min is deprecated. Please use "
+        "hpx::experimental::reduction_min instead.")
+    constexpr decltype(auto) reduction_min(T& var, T const& identity)
+    {
+        return hpx::experimental::reduction_min(var, identity);
+    }
+
+    template <typename T>
+    HPX_DEPRECATED_V(1, 8,
+        "hpx::hpx::parallel::reduction_max is deprecated. Please use "
+        "hpx::experimental::reduction_max instead.")
+    constexpr decltype(auto) reduction_max(T& var)
+    {
+        return hpx::experimental::reduction_max(var);
+    }
+
+    template <typename T>
+    HPX_DEPRECATED_V(1, 8,
+        "hpx::hpx::parallel::reduction_max is deprecated. Please use "
+        "hpx::experimental::reduction_max instead.")
+    constexpr decltype(auto) reduction_max(T& var, T const& identity)
+    {
+        return hpx::experimental::reduction_max(var, identity);
+    }
+}}    // namespace hpx::parallel::v2

--- a/libs/core/algorithms/include/hpx/parallel/container_algorithms/for_loop.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/container_algorithms/for_loop.hpp
@@ -1,5 +1,5 @@
 //  Copyright (c) 2020 ETH Zurich
-//  Copyright (c) 2007-2018 Hartmut Kaiser
+//  Copyright (c) 2007-2022 Hartmut Kaiser
 //  Copyright (c) 2016 Thomas Heller
 //
 //  SPDX-License-Identifier: BSL-1.0
@@ -9,7 +9,7 @@
 #pragma once
 
 #if defined(DOXYGEN)
-namespace hpx { namespace ranges {
+namespace hpx { namespace ranges { namespace experimental {
     /// The for_loop implements loop functionality over a range specified by
     /// iterator bounds. These algorithms resemble for_each from the
     /// Parallelism TS, but leave to the programmer when and if to dereference
@@ -712,7 +712,7 @@ namespace hpx { namespace ranges {
     template <typename ExPolicy, typename Rng, typename S, typename... Args>
     typename util::detail::algorithm_result<ExPolicy>::type for_loop_strided(
         ExPolicy&& policy, Rng&& rng, S stride, Args&&... args);
-}}    // namespace hpx::ranges
+}}}    // namespace hpx::ranges::experimental
 
 #else
 
@@ -732,7 +732,8 @@ namespace hpx { namespace ranges {
 #include <type_traits>
 #include <utility>
 
-namespace hpx { namespace ranges {
+namespace hpx::ranges::experimental {
+
     inline constexpr struct for_loop_t final
       : hpx::detail::tag_parallel_algorithm<for_loop_t>
     {
@@ -745,16 +746,17 @@ namespace hpx { namespace ranges {
                 hpx::traits::is_sentinel_for<Sent, Iter>::value
             )>
         // clang-format on
-        friend typename parallel::util::detail::algorithm_result<ExPolicy>::type
-        tag_fallback_invoke(hpx::ranges::for_loop_t, ExPolicy&& policy,
-            Iter first, Sent last, Args&&... args)
+        friend typename hpx::parallel::util::detail::algorithm_result<
+            ExPolicy>::type
+        tag_fallback_invoke(hpx::ranges::experimental::for_loop_t,
+            ExPolicy&& policy, Iter first, Sent last, Args&&... args)
         {
             static_assert(sizeof...(Args) >= 1,
                 "for_loop must be called with at least a function object");
 
             using hpx::util::make_index_pack;
-            return parallel::v2::detail::for_loop(HPX_FORWARD(ExPolicy, policy),
-                first, last, 1,
+            return hpx::parallel::v2::detail::for_loop(
+                HPX_FORWARD(ExPolicy, policy), first, last, 1,
                 typename make_index_pack<sizeof...(Args) - 1>::type(),
                 HPX_FORWARD(Args, args)...);
         }
@@ -766,15 +768,16 @@ namespace hpx { namespace ranges {
                 hpx::traits::is_sentinel_for<Sent, Iter>::value
             )>
         // clang-format on
-        friend void tag_fallback_invoke(
-            hpx::ranges::for_loop_t, Iter first, Sent last, Args&&... args)
+        friend void tag_fallback_invoke(hpx::ranges::experimental::for_loop_t,
+            Iter first, Sent last, Args&&... args)
         {
             static_assert(sizeof...(Args) >= 1,
                 "for_loop must be called with at least a function object");
 
             using hpx::util::make_index_pack;
-            return parallel::v2::detail::for_loop(hpx::execution::seq, first,
-                last, 1, typename make_index_pack<sizeof...(Args) - 1>::type(),
+            return hpx::parallel::v2::detail::for_loop(hpx::execution::seq,
+                first, last, 1,
+                typename make_index_pack<sizeof...(Args) - 1>::type(),
                 HPX_FORWARD(Args, args)...);
         }
 
@@ -785,16 +788,18 @@ namespace hpx { namespace ranges {
                 hpx::traits::is_range<R>::value
             )>
         // clang-format on
-        friend typename parallel::util::detail::algorithm_result<ExPolicy>::type
-        tag_fallback_invoke(
-            hpx::ranges::for_loop_t, ExPolicy&& policy, R&& rng, Args&&... args)
+        friend typename hpx::parallel::util::detail::algorithm_result<
+            ExPolicy>::type
+        tag_fallback_invoke(hpx::ranges::experimental::for_loop_t,
+            ExPolicy&& policy, R&& rng, Args&&... args)
         {
             static_assert(sizeof...(Args) >= 1,
                 "for_loop must be called with at least a function object");
 
             using hpx::util::make_index_pack;
-            return parallel::v2::detail::for_loop(HPX_FORWARD(ExPolicy, policy),
-                hpx::util::begin(rng), hpx::util::end(rng), 1,
+            return hpx::parallel::v2::detail::for_loop(
+                HPX_FORWARD(ExPolicy, policy), hpx::util::begin(rng),
+                hpx::util::end(rng), 1,
                 typename make_index_pack<sizeof...(Args) - 1>::type(),
                 HPX_FORWARD(Args, args)...);
         }
@@ -806,13 +811,13 @@ namespace hpx { namespace ranges {
             )>
         // clang-format on
         friend void tag_fallback_invoke(
-            hpx::ranges::for_loop_t, Rng&& rng, Args&&... args)
+            hpx::ranges::experimental::for_loop_t, Rng&& rng, Args&&... args)
         {
             static_assert(sizeof...(Args) >= 1,
                 "for_loop must be called with at least a function object");
 
             using hpx::util::make_index_pack;
-            return parallel::v2::detail::for_loop(hpx::execution::seq,
+            return hpx::parallel::v2::detail::for_loop(hpx::execution::seq,
                 hpx::util::begin(rng), hpx::util::end(rng), 1,
                 typename make_index_pack<sizeof...(Args) - 1>::type(),
                 HPX_FORWARD(Args, args)...);
@@ -834,16 +839,16 @@ namespace hpx { namespace ranges {
             )>
         // clang-format on
         friend typename parallel::util::detail::algorithm_result<ExPolicy>::type
-        tag_fallback_invoke(hpx::ranges::for_loop_strided_t, ExPolicy&& policy,
-            Iter first, Sent last, S stride, Args&&... args)
+        tag_fallback_invoke(hpx::ranges::experimental::for_loop_strided_t,
+            ExPolicy&& policy, Iter first, Sent last, S stride, Args&&... args)
         {
             static_assert(sizeof...(Args) >= 1,
                 "for_loop_strided must be called with at least a function "
                 "object");
 
             using hpx::util::make_index_pack;
-            return parallel::v2::detail::for_loop(HPX_FORWARD(ExPolicy, policy),
-                first, last, stride,
+            return hpx::parallel::v2::detail::for_loop(
+                HPX_FORWARD(ExPolicy, policy), first, last, stride,
                 typename make_index_pack<sizeof...(Args) - 1>::type(),
                 HPX_FORWARD(Args, args)...);
         }
@@ -856,16 +861,17 @@ namespace hpx { namespace ranges {
                 hpx::traits::is_sentinel_for<Sent, Iter>::value
             )>
         // clang-format on
-        friend void tag_fallback_invoke(hpx::ranges::for_loop_strided_t,
-            Iter first, Sent last, S stride, Args&&... args)
+        friend void tag_fallback_invoke(
+            hpx::ranges::experimental::for_loop_strided_t, Iter first,
+            Sent last, S stride, Args&&... args)
         {
             static_assert(sizeof...(Args) >= 1,
                 "for_loop_strided must be called with at least a function "
                 "object");
 
             using hpx::util::make_index_pack;
-            return parallel::v2::detail::for_loop(hpx::execution::seq, first,
-                last, stride,
+            return hpx::parallel::v2::detail::for_loop(hpx::execution::seq,
+                first, last, stride,
                 typename make_index_pack<sizeof...(Args) - 1>::type(),
                 HPX_FORWARD(Args, args)...);
         }
@@ -878,17 +884,19 @@ namespace hpx { namespace ranges {
                 hpx::traits::is_range<Rng>::value
             )>
         // clang-format on
-        friend typename parallel::util::detail::algorithm_result<ExPolicy>::type
-        tag_fallback_invoke(hpx::ranges::for_loop_strided_t, ExPolicy&& policy,
-            Rng&& rng, S stride, Args&&... args)
+        friend typename hpx::parallel::util::detail::algorithm_result<
+            ExPolicy>::type
+        tag_fallback_invoke(hpx::ranges::experimental::for_loop_strided_t,
+            ExPolicy&& policy, Rng&& rng, S stride, Args&&... args)
         {
             static_assert(sizeof...(Args) >= 1,
                 "for_loop_strided must be called with at least a function "
                 "object");
 
             using hpx::util::make_index_pack;
-            return parallel::v2::detail::for_loop(HPX_FORWARD(ExPolicy, policy),
-                hpx::util::begin(rng), hpx::util::end(rng), stride,
+            return hpx::parallel::v2::detail::for_loop(
+                HPX_FORWARD(ExPolicy, policy), hpx::util::begin(rng),
+                hpx::util::end(rng), stride,
                 typename make_index_pack<sizeof...(Args) - 1>::type(),
                 HPX_FORWARD(Args, args)...);
         }
@@ -900,20 +908,35 @@ namespace hpx { namespace ranges {
                 hpx::traits::is_range<Rng>::value
             )>
         // clang-format on
-        friend void tag_fallback_invoke(hpx::ranges::for_loop_strided_t,
-            Rng&& rng, S stride, Args&&... args)
+        friend void tag_fallback_invoke(
+            hpx::ranges::experimental::for_loop_strided_t, Rng&& rng, S stride,
+            Args&&... args)
         {
             static_assert(sizeof...(Args) >= 1,
                 "for_loop_strided must be called with at least a function "
                 "object");
 
             using hpx::util::make_index_pack;
-            return parallel::v2::detail::for_loop(hpx::execution::seq,
+            return hpx::parallel::v2::detail::for_loop(hpx::execution::seq,
                 hpx::util::begin(rng), hpx::util::end(rng), stride,
                 typename make_index_pack<sizeof...(Args) - 1>::type(),
                 HPX_FORWARD(Args, args)...);
         }
     } for_loop_strided{};
-}}    // namespace hpx::ranges
+}    // namespace hpx::ranges::experimental
 
-#endif
+namespace hpx::ranges {
+
+    HPX_DEPRECATED_V(1, 8,
+        "hpx::ranges::for_loop is deprecated. Please use "
+        "hpx::ranges::experimental::for_loop instead.")
+    inline constexpr hpx::ranges::experimental::for_loop_t for_loop{};
+
+    HPX_DEPRECATED_V(1, 8,
+        "hpx::ranges::for_loop_strided is deprecated. Please use "
+        "hpx::ranges::experimental::for_loop_strided instead.")
+    inline constexpr hpx::ranges::experimental::for_loop_strided_t
+        for_loop_strided{};
+}    // namespace hpx::ranges
+
+#endif    // DOXYGEN

--- a/libs/core/algorithms/tests/performance/foreach_scaling_helpers.hpp
+++ b/libs/core/algorithms/tests/performance/foreach_scaling_helpers.hpp
@@ -187,15 +187,15 @@ void measure_sequential_forloop(
         disable_stealing_parameter dsp;
 
         // invoke sequential for_loop
-        hpx::for_loop(hpx::execution::seq.with(dsp),
+        hpx::experimental::for_loop(hpx::execution::seq.with(dsp),
             std::begin(data_representation), std::end(data_representation),
             [](iterator) { worker_timed(delay); });
     }
     else
     {
         // invoke sequential for_loop
-        hpx::for_loop(hpx::execution::seq, std::begin(data_representation),
-            std::end(data_representation),
+        hpx::experimental::for_loop(hpx::execution::seq,
+            std::begin(data_representation), std::end(data_representation),
             [](iterator) { worker_timed(delay); });
     }
 }
@@ -215,14 +215,14 @@ void measure_parallel_forloop(
         disable_stealing_parameter dsp;
 
         // invoke parallel for_loop
-        hpx::for_loop(hpx::execution::par.with(cs, dsp).on(exec),
+        hpx::experimental::for_loop(hpx::execution::par.with(cs, dsp).on(exec),
             std::begin(data_representation), std::end(data_representation),
             [](iterator) { worker_timed(delay); });
     }
     else
     {
         // invoke parallel for_loop
-        hpx::for_loop(hpx::execution::par.with(cs).on(exec),
+        hpx::experimental::for_loop(hpx::execution::par.with(cs).on(exec),
             std::begin(data_representation), std::end(data_representation),
             [](iterator) { worker_timed(delay); });
     }
@@ -244,7 +244,7 @@ hpx::future<void> measure_task_forloop(
         disable_stealing_parameter dsp;
 
         // invoke parallel for_loop
-        return hpx::for_loop(
+        return hpx::experimental::for_loop(
             hpx::execution::par(hpx::execution::task).with(cs, dsp).on(exec),
             std::begin(*data_representation), std::end(*data_representation),
             [](iterator) { worker_timed(delay); })
@@ -253,7 +253,7 @@ hpx::future<void> measure_task_forloop(
     else
     {
         // invoke parallel for_loop
-        return hpx::for_loop(
+        return hpx::experimental::for_loop(
             hpx::execution::par(hpx::execution::task).with(cs).on(exec),
             std::begin(*data_representation), std::end(*data_representation),
             [](iterator) { worker_timed(delay); })

--- a/libs/core/algorithms/tests/regressions/for_loop_2281.cpp
+++ b/libs/core/algorithms/tests/regressions/for_loop_2281.cpp
@@ -21,7 +21,7 @@ int hpx_main()
     hpx::lcos::local::spinlock mtx;
     std::set<hpx::thread::id> thread_ids;
 
-    hpx::for_loop(hpx::execution::par, 0, 100, [&](int) {
+    hpx::experimental::for_loop(hpx::execution::par, 0, 100, [&](int) {
         std::lock_guard<hpx::lcos::local::spinlock> l(mtx);
         thread_ids.insert(hpx::this_thread::get_id());
     });
@@ -30,7 +30,7 @@ int hpx_main()
 
     thread_ids.clear();
 
-    hpx::for_loop_n(hpx::execution::par, 0, 100, [&](int) {
+    hpx::experimental::for_loop_n(hpx::execution::par, 0, 100, [&](int) {
         std::lock_guard<hpx::lcos::local::spinlock> l(mtx);
         thread_ids.insert(hpx::this_thread::get_id());
     });

--- a/libs/core/algorithms/tests/unit/algorithms/for_loop.cpp
+++ b/libs/core/algorithms/tests/unit/algorithms/for_loop.cpp
@@ -35,8 +35,9 @@ void test_for_loop(ExPolicy&& policy, IteratorTag)
     std::vector<std::size_t> c(10007);
     std::iota(std::begin(c), std::end(c), gen());
 
-    hpx::for_loop(std::forward<ExPolicy>(policy), iterator(std::begin(c)),
-        iterator(std::end(c)), [](iterator it) { *it = 42; });
+    hpx::experimental::for_loop(std::forward<ExPolicy>(policy),
+        iterator(std::begin(c)), iterator(std::end(c)),
+        [](iterator it) { *it = 42; });
 
     // verify values
     std::size_t count = 0;
@@ -56,8 +57,9 @@ void test_for_loop_async(ExPolicy&& p, IteratorTag)
     std::vector<std::size_t> c(10007);
     std::iota(std::begin(c), std::end(c), gen());
 
-    auto f = hpx::for_loop(std::forward<ExPolicy>(p), iterator(std::begin(c)),
-        iterator(std::end(c)), [](iterator it) { *it = 42; });
+    auto f = hpx::experimental::for_loop(std::forward<ExPolicy>(p),
+        iterator(std::begin(c)), iterator(std::end(c)),
+        [](iterator it) { *it = 42; });
     f.wait();
 
     // verify values
@@ -98,7 +100,7 @@ void test_for_loop_idx(ExPolicy&& policy)
     std::vector<std::size_t> c(10007);
     std::iota(std::begin(c), std::end(c), gen());
 
-    hpx::for_loop(std::forward<ExPolicy>(policy), 0, c.size(),
+    hpx::experimental::for_loop(std::forward<ExPolicy>(policy), 0, c.size(),
         [&c](std::size_t i) { c[i] = 42; });
 
     // verify values
@@ -116,7 +118,7 @@ void test_for_loop_idx_async(ExPolicy&& p)
     std::vector<std::size_t> c(10007);
     std::iota(std::begin(c), std::end(c), gen());
 
-    auto f = hpx::for_loop(std::forward<ExPolicy>(p), 0, c.size(),
+    auto f = hpx::experimental::for_loop(std::forward<ExPolicy>(p), 0, c.size(),
         [&c](std::size_t i) { c[i] = 42; });
     f.wait();
 

--- a/libs/core/algorithms/tests/unit/algorithms/for_loop_exception.cpp
+++ b/libs/core/algorithms/tests/unit/algorithms/for_loop_exception.cpp
@@ -80,8 +80,9 @@ void test_for_loop_exception(ExPolicy&& policy, IteratorTag)
     bool caught_exception = false;
     try
     {
-        hpx::for_loop(std::forward<ExPolicy>(policy), iterator(std::begin(c)),
-            iterator(std::end(c)), throw_always(dis(gen)));
+        hpx::experimental::for_loop(std::forward<ExPolicy>(policy),
+            iterator(std::begin(c)), iterator(std::end(c)),
+            throw_always(dis(gen)));
 
         HPX_TEST(false);
     }
@@ -113,9 +114,9 @@ void test_for_loop_exception_async(ExPolicy&& p, IteratorTag)
     bool returned_from_algorithm = false;
     try
     {
-        auto f =
-            hpx::for_loop(std::forward<ExPolicy>(p), iterator(std::begin(c)),
-                iterator(std::end(c)), throw_always(dis(gen)));
+        auto f = hpx::experimental::for_loop(std::forward<ExPolicy>(p),
+            iterator(std::begin(c)), iterator(std::end(c)),
+            throw_always(dis(gen)));
         returned_from_algorithm = true;
         f.get();
 
@@ -153,8 +154,9 @@ void test_for_loop_bad_alloc(ExPolicy policy, IteratorTag)
     bool caught_exception = false;
     try
     {
-        hpx::for_loop(std::forward<ExPolicy>(policy), iterator(std::begin(c)),
-            iterator(std::end(c)), throw_bad_alloc(dis(gen)));
+        hpx::experimental::for_loop(std::forward<ExPolicy>(policy),
+            iterator(std::begin(c)), iterator(std::end(c)),
+            throw_bad_alloc(dis(gen)));
 
         HPX_TEST(false);
     }
@@ -185,9 +187,9 @@ void test_for_loop_bad_alloc_async(ExPolicy p, IteratorTag)
     bool returned_from_algorithm = false;
     try
     {
-        auto f =
-            hpx::for_loop(std::forward<ExPolicy>(p), iterator(std::begin(c)),
-                iterator(std::end(c)), throw_bad_alloc(dis(gen)));
+        auto f = hpx::experimental::for_loop(std::forward<ExPolicy>(p),
+            iterator(std::begin(c)), iterator(std::end(c)),
+            throw_bad_alloc(dis(gen)));
         returned_from_algorithm = true;
         f.get();
 
@@ -249,7 +251,7 @@ void test_for_loop_idx_exception(ExPolicy&& policy, IteratorTag)
     bool caught_exception = false;
     try
     {
-        hpx::for_loop(std::forward<ExPolicy>(policy), 0, c.size(),
+        hpx::experimental::for_loop(std::forward<ExPolicy>(policy), 0, c.size(),
             throw_always(dis(gen)));
 
         HPX_TEST(false);
@@ -279,7 +281,7 @@ void test_for_loop_idx_exception_async(ExPolicy&& p, IteratorTag)
     bool returned_from_algorithm = false;
     try
     {
-        auto f = hpx::for_loop(
+        auto f = hpx::experimental::for_loop(
             std::forward<ExPolicy>(p), 0, c.size(), throw_always(dis(gen)));
         returned_from_algorithm = true;
         f.get();
@@ -315,7 +317,7 @@ void test_for_loop_idx_bad_alloc(ExPolicy&& policy)
     bool caught_exception = false;
     try
     {
-        hpx::for_loop(std::forward<ExPolicy>(policy), 0, c.size(),
+        hpx::experimental::for_loop(std::forward<ExPolicy>(policy), 0, c.size(),
             throw_bad_alloc(dis(gen)));
 
         HPX_TEST(false);
@@ -344,7 +346,7 @@ void test_for_loop_idx_bad_alloc_async(ExPolicy&& p)
     bool returned_from_algorithm = false;
     try
     {
-        auto f = hpx::for_loop(
+        auto f = hpx::experimental::for_loop(
             std::forward<ExPolicy>(p), 0, c.size(), throw_bad_alloc(dis(gen)));
         returned_from_algorithm = true;
         f.get();

--- a/libs/core/algorithms/tests/unit/algorithms/for_loop_induction.cpp
+++ b/libs/core/algorithms/tests/unit/algorithms/for_loop_induction.cpp
@@ -36,9 +36,9 @@ void test_for_loop_induction(ExPolicy&& policy, IteratorTag)
     std::vector<std::size_t> d(10007);
     std::iota(std::begin(c), std::end(c), gen());
 
-    hpx::for_loop(std::forward<ExPolicy>(policy), iterator(std::begin(c)),
-        iterator(std::end(c)), hpx::parallel::induction(0),
-        [&d](iterator it, std::size_t i) {
+    hpx::experimental::for_loop(std::forward<ExPolicy>(policy),
+        iterator(std::begin(c)), iterator(std::end(c)),
+        hpx::experimental::induction(0), [&d](iterator it, std::size_t i) {
             *it = 42;
             d[i] = 42;
         });
@@ -67,9 +67,9 @@ void test_for_loop_induction_stride(ExPolicy&& policy, IteratorTag)
     std::vector<std::size_t> d(10007);
     std::iota(std::begin(c), std::end(c), gen());
 
-    hpx::for_loop(std::forward<ExPolicy>(policy), iterator(std::begin(c)),
-        iterator(std::end(c)), hpx::parallel::induction(0),
-        hpx::parallel::induction(0, 2),
+    hpx::experimental::for_loop(std::forward<ExPolicy>(policy),
+        iterator(std::begin(c)), iterator(std::end(c)),
+        hpx::experimental::induction(0), hpx::experimental::induction(0, 2),
         [&d](iterator it, std::size_t i, std::size_t j) {
             *it = 42;
             d[i] = 42;
@@ -102,9 +102,9 @@ void test_for_loop_induction_life_out(ExPolicy&& policy, IteratorTag)
 
     std::size_t curr = 0;
 
-    hpx::for_loop(std::forward<ExPolicy>(policy), iterator(std::begin(c)),
-        iterator(std::end(c)), hpx::parallel::induction(curr),
-        [&d](iterator it, std::size_t i) {
+    hpx::experimental::for_loop(std::forward<ExPolicy>(policy),
+        iterator(std::begin(c)), iterator(std::end(c)),
+        hpx::experimental::induction(curr), [&d](iterator it, std::size_t i) {
             *it = 42;
             d[i] = 42;
         });
@@ -137,9 +137,10 @@ void test_for_loop_induction_stride_life_out(ExPolicy&& policy, IteratorTag)
     std::size_t curr1 = 0;
     std::size_t curr2 = 0;
 
-    hpx::for_loop(std::forward<ExPolicy>(policy), iterator(std::begin(c)),
-        iterator(std::end(c)), hpx::parallel::induction(curr1),
-        hpx::parallel::induction(curr2, 2),
+    hpx::experimental::for_loop(std::forward<ExPolicy>(policy),
+        iterator(std::begin(c)), iterator(std::end(c)),
+        hpx::experimental::induction(curr1),
+        hpx::experimental::induction(curr2, 2),
         [&d](iterator it, std::size_t i, std::size_t j) {
             *it = 42;
             d[i] = 42;
@@ -198,8 +199,8 @@ void test_for_loop_induction_idx(ExPolicy&& policy)
     std::vector<std::size_t> c(10007);
     std::iota(std::begin(c), std::end(c), gen());
 
-    hpx::for_loop(std::forward<ExPolicy>(policy), 0, c.size(),
-        hpx::parallel::induction(0), [&c](std::size_t i, std::size_t j) {
+    hpx::experimental::for_loop(std::forward<ExPolicy>(policy), 0, c.size(),
+        hpx::experimental::induction(0), [&c](std::size_t i, std::size_t j) {
             c[i] = 42;
             HPX_TEST_EQ(i, j);
         });
@@ -222,8 +223,8 @@ void test_for_loop_induction_stride_idx(ExPolicy&& policy)
     std::vector<std::size_t> c(10007);
     std::iota(std::begin(c), std::end(c), gen());
 
-    hpx::for_loop(std::forward<ExPolicy>(policy), 0, c.size(),
-        hpx::parallel::induction(0), hpx::parallel::induction(0, 2),
+    hpx::experimental::for_loop(std::forward<ExPolicy>(policy), 0, c.size(),
+        hpx::experimental::induction(0), hpx::experimental::induction(0, 2),
         [&c](std::size_t i, std::size_t j, std::size_t k) {
             c[i] = 42;
             HPX_TEST_EQ(i, j);

--- a/libs/core/algorithms/tests/unit/algorithms/for_loop_induction_async.cpp
+++ b/libs/core/algorithms/tests/unit/algorithms/for_loop_induction_async.cpp
@@ -36,9 +36,9 @@ void test_for_loop_induction(ExPolicy&& policy, IteratorTag)
     std::vector<std::size_t> d(10007);
     std::iota(std::begin(c), std::end(c), gen());
 
-    auto f = hpx::for_loop(std::forward<ExPolicy>(policy),
+    auto f = hpx::experimental::for_loop(std::forward<ExPolicy>(policy),
         iterator(std::begin(c)), iterator(std::end(c)),
-        hpx::parallel::induction(0), [&d](iterator it, std::size_t i) {
+        hpx::experimental::induction(0), [&d](iterator it, std::size_t i) {
             *it = 42;
             d[i] = 42;
         });
@@ -68,9 +68,9 @@ void test_for_loop_induction_stride(ExPolicy&& policy, IteratorTag)
     std::vector<std::size_t> d(10007);
     std::iota(std::begin(c), std::end(c), gen());
 
-    auto f = hpx::for_loop(std::forward<ExPolicy>(policy),
+    auto f = hpx::experimental::for_loop(std::forward<ExPolicy>(policy),
         iterator(std::begin(c)), iterator(std::end(c)),
-        hpx::parallel::induction(0), hpx::parallel::induction(0, 2),
+        hpx::experimental::induction(0), hpx::experimental::induction(0, 2),
         [&d](iterator it, std::size_t i, std::size_t j) {
             *it = 42;
             d[i] = 42;
@@ -104,9 +104,9 @@ void test_for_loop_induction_life_out(ExPolicy&& policy, IteratorTag)
 
     std::size_t curr = 0;
 
-    auto f = hpx::for_loop(std::forward<ExPolicy>(policy),
+    auto f = hpx::experimental::for_loop(std::forward<ExPolicy>(policy),
         iterator(std::begin(c)), iterator(std::end(c)),
-        hpx::parallel::induction(curr), [&d](iterator it, std::size_t i) {
+        hpx::experimental::induction(curr), [&d](iterator it, std::size_t i) {
             *it = 42;
             d[i] = 42;
         });
@@ -140,9 +140,10 @@ void test_for_loop_induction_stride_life_out(ExPolicy&& policy, IteratorTag)
     std::size_t curr1 = 0;
     std::size_t curr2 = 0;
 
-    auto f = hpx::for_loop(std::forward<ExPolicy>(policy),
+    auto f = hpx::experimental::for_loop(std::forward<ExPolicy>(policy),
         iterator(std::begin(c)), iterator(std::end(c)),
-        hpx::parallel::induction(curr1), hpx::parallel::induction(curr2, 2),
+        hpx::experimental::induction(curr1),
+        hpx::experimental::induction(curr2, 2),
         [&d](iterator it, std::size_t i, std::size_t j) {
             *it = 42;
             d[i] = 42;
@@ -198,8 +199,9 @@ void test_for_loop_induction_idx(ExPolicy&& policy)
     std::vector<std::size_t> c(10007);
     std::iota(std::begin(c), std::end(c), gen());
 
-    auto f = hpx::for_loop(std::forward<ExPolicy>(policy), 0, c.size(),
-        hpx::parallel::induction(0), [&c](std::size_t i, std::size_t j) {
+    auto f = hpx::experimental::for_loop(std::forward<ExPolicy>(policy), 0,
+        c.size(), hpx::experimental::induction(0),
+        [&c](std::size_t i, std::size_t j) {
             c[i] = 42;
             HPX_TEST_EQ(i, j);
         });
@@ -223,13 +225,14 @@ void test_for_loop_induction_stride_idx(ExPolicy&& policy)
     std::vector<std::size_t> c(10007);
     std::iota(std::begin(c), std::end(c), gen());
 
-    auto f = hpx::for_loop(std::forward<ExPolicy>(policy), 0, c.size(),
-        hpx::parallel::induction(0), hpx::parallel::induction(0, 2),
-        [&c](std::size_t i, std::size_t j, std::size_t k) {
-            c[i] = 42;
-            HPX_TEST_EQ(i, j);
-            HPX_TEST_EQ(2 * i, k);
-        });
+    auto f =
+        hpx::experimental::for_loop(std::forward<ExPolicy>(policy), 0, c.size(),
+            hpx::experimental::induction(0), hpx::experimental::induction(0, 2),
+            [&c](std::size_t i, std::size_t j, std::size_t k) {
+                c[i] = 42;
+                HPX_TEST_EQ(i, j);
+                HPX_TEST_EQ(2 * i, k);
+            });
     f.wait();
 
     // verify values

--- a/libs/core/algorithms/tests/unit/algorithms/for_loop_n.cpp
+++ b/libs/core/algorithms/tests/unit/algorithms/for_loop_n.cpp
@@ -35,8 +35,8 @@ void test_for_loop_n(ExPolicy&& policy, IteratorTag)
     std::vector<std::size_t> c(10007);
     std::iota(std::begin(c), std::end(c), gen());
 
-    hpx::for_loop_n(std::forward<ExPolicy>(policy), iterator(std::begin(c)),
-        c.size(), [](iterator it) { *it = 42; });
+    hpx::experimental::for_loop_n(std::forward<ExPolicy>(policy),
+        iterator(std::begin(c)), c.size(), [](iterator it) { *it = 42; });
 
     // verify values
     std::size_t count = 0;
@@ -56,8 +56,8 @@ void test_for_loop_n_async(ExPolicy&& p, IteratorTag)
     std::vector<std::size_t> c(10007);
     std::iota(std::begin(c), std::end(c), gen());
 
-    auto f = hpx::for_loop_n(std::forward<ExPolicy>(p), iterator(std::begin(c)),
-        c.size(), [](iterator it) { *it = 42; });
+    auto f = hpx::experimental::for_loop_n(std::forward<ExPolicy>(p),
+        iterator(std::begin(c)), c.size(), [](iterator it) { *it = 42; });
     f.wait();
 
     // verify values
@@ -98,7 +98,7 @@ void test_for_loop_n_idx(ExPolicy&& policy)
     std::vector<std::size_t> c(10007);
     std::iota(std::begin(c), std::end(c), gen());
 
-    hpx::for_loop_n(std::forward<ExPolicy>(policy), 0, c.size(),
+    hpx::experimental::for_loop_n(std::forward<ExPolicy>(policy), 0, c.size(),
         [&c](std::size_t i) { c[i] = 42; });
 
     // verify values
@@ -116,8 +116,8 @@ void test_for_loop_n_idx_async(ExPolicy&& p)
     std::vector<std::size_t> c(10007);
     std::iota(std::begin(c), std::end(c), gen());
 
-    auto f = hpx::for_loop_n(std::forward<ExPolicy>(p), 0, c.size(),
-        [&c](std::size_t i) { c[i] = 42; });
+    auto f = hpx::experimental::for_loop_n(std::forward<ExPolicy>(p), 0,
+        c.size(), [&c](std::size_t i) { c[i] = 42; });
     f.wait();
 
     // verify values

--- a/libs/core/algorithms/tests/unit/algorithms/for_loop_n_strided.cpp
+++ b/libs/core/algorithms/tests/unit/algorithms/for_loop_n_strided.cpp
@@ -43,7 +43,7 @@ void test_for_loop_n_strided(ExPolicy&& policy, IteratorTag)
 
     int stride = dis(gen);    //-V103
 
-    hpx::for_loop_n_strided(std::forward<ExPolicy>(policy),
+    hpx::experimental::for_loop_n_strided(std::forward<ExPolicy>(policy),
         iterator(std::begin(c)), c.size(), stride,
         [](iterator it) { *it = 42; });
 
@@ -80,7 +80,7 @@ void test_for_loop_n_strided_async(ExPolicy&& p, IteratorTag)
 
     int stride = dis(gen);    //-V103
 
-    auto f = hpx::for_loop_n_strided(std::forward<ExPolicy>(p),
+    auto f = hpx::experimental::for_loop_n_strided(std::forward<ExPolicy>(p),
         iterator(std::begin(c)), c.size(), stride,
         [](iterator it) { *it = 42; });
     f.wait();
@@ -138,8 +138,8 @@ void test_for_loop_n_strided_idx(ExPolicy&& policy)
 
     int stride = dis(gen);    //-V103
 
-    hpx::for_loop_n_strided(std::forward<ExPolicy>(policy), 0, c.size(), stride,
-        [&c](std::size_t i) { c[i] = 42; });
+    hpx::experimental::for_loop_n_strided(std::forward<ExPolicy>(policy), 0,
+        c.size(), stride, [&c](std::size_t i) { c[i] = 42; });
 
     // verify values
     std::size_t count = 0;
@@ -171,8 +171,8 @@ void test_for_loop_n_strided_idx_async(ExPolicy&& p)
 
     int stride = dis(gen);    //-V103
 
-    auto f = hpx::for_loop_n_strided(std::forward<ExPolicy>(p), 0, c.size(),
-        stride, [&c](std::size_t i) { c[i] = 42; });
+    auto f = hpx::experimental::for_loop_n_strided(std::forward<ExPolicy>(p), 0,
+        c.size(), stride, [&c](std::size_t i) { c[i] = 42; });
     f.wait();
 
     // verify values

--- a/libs/core/algorithms/tests/unit/algorithms/for_loop_reduction.cpp
+++ b/libs/core/algorithms/tests/unit/algorithms/for_loop_reduction.cpp
@@ -36,8 +36,9 @@ void test_for_loop_reduction_plus(ExPolicy&& policy, IteratorTag)
     std::iota(std::begin(c), std::end(c), gen());
 
     std::size_t sum = 0;
-    hpx::for_loop(std::forward<ExPolicy>(policy), iterator(std::begin(c)),
-        iterator(std::end(c)), hpx::parallel::reduction_plus(sum),
+    hpx::experimental::for_loop(std::forward<ExPolicy>(policy),
+        iterator(std::begin(c)), iterator(std::end(c)),
+        hpx::experimental::reduction_plus(sum),
         [](iterator it, std::size_t& sum) { sum += *it; });
 
     // verify values
@@ -59,8 +60,9 @@ void test_for_loop_reduction_multiplies(ExPolicy&& policy, IteratorTag)
     std::iota(std::begin(c), std::end(c), gen());
 
     std::size_t prod = 0;
-    hpx::for_loop(std::forward<ExPolicy>(policy), iterator(std::begin(c)),
-        iterator(std::end(c)), hpx::parallel::reduction_multiplies(prod),
+    hpx::experimental::for_loop(std::forward<ExPolicy>(policy),
+        iterator(std::begin(c)), iterator(std::end(c)),
+        hpx::experimental::reduction_multiplies(prod),
         [](iterator it, std::size_t& prod) { prod *= *it; });
 
     // verify values
@@ -83,8 +85,9 @@ void test_for_loop_reduction_min(ExPolicy&& policy, IteratorTag)
 
     std::size_t minval = c[0];
 
-    hpx::for_loop(std::forward<ExPolicy>(policy), iterator(std::begin(c)),
-        iterator(std::end(c)), hpx::parallel::reduction_min(minval),
+    hpx::experimental::for_loop(std::forward<ExPolicy>(policy),
+        iterator(std::begin(c)), iterator(std::end(c)),
+        hpx::experimental::reduction_min(minval),
         [](iterator it, std::size_t& minval) {
             minval = (std::min)(minval, *it);
         });
@@ -131,8 +134,8 @@ void test_for_loop_reduction_bit_and_idx(ExPolicy&& policy)
     std::iota(std::begin(c), std::end(c), gen());
 
     std::size_t bits = ~std::size_t(0);
-    hpx::for_loop(std::forward<ExPolicy>(policy), 0, c.size(),
-        hpx::parallel::reduction_bit_and(bits),
+    hpx::experimental::for_loop(std::forward<ExPolicy>(policy), 0, c.size(),
+        hpx::experimental::reduction_bit_and(bits),
         [&c](std::size_t i, std::size_t& bits) { bits &= c[i]; });
 
     // verify values
@@ -151,8 +154,8 @@ void test_for_loop_reduction_bit_or_idx(ExPolicy&& policy)
     std::iota(std::begin(c), std::end(c), gen());
 
     std::size_t bits = 0;
-    hpx::for_loop(std::forward<ExPolicy>(policy), 0, c.size(),
-        hpx::parallel::reduction_bit_or(bits),
+    hpx::experimental::for_loop(std::forward<ExPolicy>(policy), 0, c.size(),
+        hpx::experimental::reduction_bit_or(bits),
         [&c](std::size_t i, std::size_t& bits) { bits |= c[i]; });
 
     // verify values

--- a/libs/core/algorithms/tests/unit/algorithms/for_loop_reduction_async.cpp
+++ b/libs/core/algorithms/tests/unit/algorithms/for_loop_reduction_async.cpp
@@ -36,10 +36,10 @@ void test_for_loop_reduction_plus(ExPolicy&& policy, IteratorTag)
     std::iota(std::begin(c), std::end(c), gen());
 
     std::size_t sum = 0;
-    auto f =
-        hpx::for_loop(std::forward<ExPolicy>(policy), iterator(std::begin(c)),
-            iterator(std::end(c)), hpx::parallel::reduction_plus(sum),
-            [](iterator it, std::size_t& sum) { sum += *it; });
+    auto f = hpx::experimental::for_loop(std::forward<ExPolicy>(policy),
+        iterator(std::begin(c)), iterator(std::end(c)),
+        hpx::experimental::reduction_plus(sum),
+        [](iterator it, std::size_t& sum) { sum += *it; });
     f.wait();
 
     // verify values
@@ -61,10 +61,10 @@ void test_for_loop_reduction_multiplies(ExPolicy&& policy, IteratorTag)
     std::iota(std::begin(c), std::end(c), gen());
 
     std::size_t prod = 0;
-    auto f =
-        hpx::for_loop(std::forward<ExPolicy>(policy), iterator(std::begin(c)),
-            iterator(std::end(c)), hpx::parallel::reduction_multiplies(prod),
-            [](iterator it, std::size_t& prod) { prod *= *it; });
+    auto f = hpx::experimental::for_loop(std::forward<ExPolicy>(policy),
+        iterator(std::begin(c)), iterator(std::end(c)),
+        hpx::experimental::reduction_multiplies(prod),
+        [](iterator it, std::size_t& prod) { prod *= *it; });
     f.wait();
 
     // verify values
@@ -87,12 +87,12 @@ void test_for_loop_reduction_min(ExPolicy&& policy, IteratorTag)
 
     std::size_t minval = c[0];
 
-    auto f =
-        hpx::for_loop(std::forward<ExPolicy>(policy), iterator(std::begin(c)),
-            iterator(std::end(c)), hpx::parallel::reduction_min(minval),
-            [](iterator it, std::size_t& minval) {
-                minval = (std::min)(minval, *it);
-            });
+    auto f = hpx::experimental::for_loop(std::forward<ExPolicy>(policy),
+        iterator(std::begin(c)), iterator(std::end(c)),
+        hpx::experimental::reduction_min(minval),
+        [](iterator it, std::size_t& minval) {
+            minval = (std::min)(minval, *it);
+        });
     f.wait();
 
     // verify values
@@ -134,8 +134,8 @@ void test_for_loop_reduction_bit_and_idx(ExPolicy&& policy)
     std::iota(std::begin(c), std::end(c), gen());
 
     std::size_t bits = ~std::size_t(0);
-    auto f = hpx::for_loop(std::forward<ExPolicy>(policy), 0, c.size(),
-        hpx::parallel::reduction_bit_and(bits),
+    auto f = hpx::experimental::for_loop(std::forward<ExPolicy>(policy), 0,
+        c.size(), hpx::experimental::reduction_bit_and(bits),
         [&c](std::size_t i, std::size_t& bits) { bits &= c[i]; });
     f.wait();
 
@@ -155,8 +155,8 @@ void test_for_loop_reduction_bit_or_idx(ExPolicy&& policy)
     std::iota(std::begin(c), std::end(c), gen());
 
     std::size_t bits = 0;
-    auto f = hpx::for_loop(std::forward<ExPolicy>(policy), 0, c.size(),
-        hpx::parallel::reduction_bit_or(bits),
+    auto f = hpx::experimental::for_loop(std::forward<ExPolicy>(policy), 0,
+        c.size(), hpx::experimental::reduction_bit_or(bits),
         [&c](std::size_t i, std::size_t& bits) { bits |= c[i]; });
     f.wait();
 

--- a/libs/core/algorithms/tests/unit/algorithms/for_loop_strided.cpp
+++ b/libs/core/algorithms/tests/unit/algorithms/for_loop_strided.cpp
@@ -43,7 +43,7 @@ void test_for_loop_strided(ExPolicy&& policy, IteratorTag)
 
     int stride = dis(gen);    //-V103
 
-    hpx::for_loop_strided(std::forward<ExPolicy>(policy),
+    hpx::experimental::for_loop_strided(std::forward<ExPolicy>(policy),
         iterator(std::begin(c)), iterator(std::end(c)), stride,
         [](iterator it) { *it = 42; });
 
@@ -80,7 +80,7 @@ void test_for_loop_strided_async(ExPolicy&& p, IteratorTag)
 
     int stride = dis(gen);    //-V103
 
-    auto f = hpx::for_loop_strided(std::forward<ExPolicy>(p),
+    auto f = hpx::experimental::for_loop_strided(std::forward<ExPolicy>(p),
         iterator(std::begin(c)), iterator(std::end(c)), stride,
         [](iterator it) { *it = 42; });
     f.wait();
@@ -138,8 +138,8 @@ void test_for_loop_strided_idx(ExPolicy&& policy)
 
     int stride = dis(gen);    //-V103
 
-    hpx::for_loop_strided(std::forward<ExPolicy>(policy), 0, c.size(), stride,
-        [&c](std::size_t i) { c[i] = 42; });
+    hpx::experimental::for_loop_strided(std::forward<ExPolicy>(policy), 0,
+        c.size(), stride, [&c](std::size_t i) { c[i] = 42; });
 
     // verify values
     std::size_t count = 0;
@@ -171,8 +171,8 @@ void test_for_loop_strided_idx_async(ExPolicy&& p)
 
     int stride = dis(gen);    //-V103
 
-    auto f = hpx::for_loop_strided(std::forward<ExPolicy>(p), 0, c.size(),
-        stride, [&c](std::size_t i) { c[i] = 42; });
+    auto f = hpx::experimental::for_loop_strided(std::forward<ExPolicy>(p), 0,
+        c.size(), stride, [&c](std::size_t i) { c[i] = 42; });
     f.wait();
 
     // verify values

--- a/libs/core/algorithms/tests/unit/container_algorithms/for_loop_exception_range.cpp
+++ b/libs/core/algorithms/tests/unit/container_algorithms/for_loop_exception_range.cpp
@@ -77,7 +77,7 @@ void test_for_loop_exception(ExPolicy&& policy)
     bool caught_exception = false;
     try
     {
-        hpx::ranges::for_loop(
+        hpx::ranges::experimental::for_loop(
             std::forward<ExPolicy>(policy), c, throw_always(dis(gen)));
 
         HPX_TEST(false);
@@ -107,7 +107,7 @@ void test_for_loop_exception_async(ExPolicy&& p)
     bool returned_from_algorithm = false;
     try
     {
-        auto f = hpx::ranges::for_loop(
+        auto f = hpx::ranges::experimental::for_loop(
             std::forward<ExPolicy>(p), c, throw_always(dis(gen)));
         returned_from_algorithm = true;
         f.get();
@@ -143,7 +143,7 @@ void test_for_loop_bad_alloc(ExPolicy policy)
     bool caught_exception = false;
     try
     {
-        hpx::ranges::for_loop(
+        hpx::ranges::experimental::for_loop(
             std::forward<ExPolicy>(policy), c, throw_bad_alloc(dis(gen)));
 
         HPX_TEST(false);
@@ -172,7 +172,7 @@ void test_for_loop_bad_alloc_async(ExPolicy p)
     bool returned_from_algorithm = false;
     try
     {
-        auto f = hpx::ranges::for_loop(
+        auto f = hpx::ranges::experimental::for_loop(
             std::forward<ExPolicy>(p), c, throw_bad_alloc(dis(gen)));
         returned_from_algorithm = true;
         f.get();

--- a/libs/core/algorithms/tests/unit/container_algorithms/for_loop_induction_async_range.cpp
+++ b/libs/core/algorithms/tests/unit/container_algorithms/for_loop_induction_async_range.cpp
@@ -35,8 +35,8 @@ void test_for_loop_induction(ExPolicy&& policy)
     std::vector<std::size_t> d(10007);
     std::iota(std::begin(c), std::end(c), gen());
 
-    auto f = hpx::ranges::for_loop(std::forward<ExPolicy>(policy), c,
-        hpx::parallel::induction(0), [&d](iterator it, std::size_t i) {
+    auto f = hpx::ranges::experimental::for_loop(std::forward<ExPolicy>(policy),
+        c, hpx::experimental::induction(0), [&d](iterator it, std::size_t i) {
             *it = 42;
             d[i] = 42;
         });
@@ -65,8 +65,8 @@ void test_for_loop_induction_stride(ExPolicy&& policy)
     std::vector<std::size_t> d(10007);
     std::iota(std::begin(c), std::end(c), gen());
 
-    auto f = hpx::ranges::for_loop(std::forward<ExPolicy>(policy), c,
-        hpx::parallel::induction(0), hpx::parallel::induction(0, 2),
+    auto f = hpx::ranges::experimental::for_loop(std::forward<ExPolicy>(policy),
+        c, hpx::experimental::induction(0), hpx::experimental::induction(0, 2),
         [&d](iterator it, std::size_t i, std::size_t j) {
             *it = 42;
             d[i] = 42;
@@ -99,8 +99,9 @@ void test_for_loop_induction_life_out(ExPolicy&& policy)
 
     std::size_t curr = 0;
 
-    auto f = hpx::ranges::for_loop(std::forward<ExPolicy>(policy), c,
-        hpx::parallel::induction(curr), [&d](iterator it, std::size_t i) {
+    auto f = hpx::ranges::experimental::for_loop(std::forward<ExPolicy>(policy),
+        c, hpx::experimental::induction(curr),
+        [&d](iterator it, std::size_t i) {
             *it = 42;
             d[i] = 42;
         });
@@ -133,8 +134,9 @@ void test_for_loop_induction_stride_life_out(ExPolicy&& policy)
     std::size_t curr1 = 0;
     std::size_t curr2 = 0;
 
-    auto f = hpx::ranges::for_loop(std::forward<ExPolicy>(policy), c,
-        hpx::parallel::induction(curr1), hpx::parallel::induction(curr2, 2),
+    auto f = hpx::ranges::experimental::for_loop(std::forward<ExPolicy>(policy),
+        c, hpx::experimental::induction(curr1),
+        hpx::experimental::induction(curr2, 2),
         [&d](iterator it, std::size_t i, std::size_t j) {
             *it = 42;
             d[i] = 42;

--- a/libs/core/algorithms/tests/unit/container_algorithms/for_loop_induction_range.cpp
+++ b/libs/core/algorithms/tests/unit/container_algorithms/for_loop_induction_range.cpp
@@ -35,8 +35,8 @@ void test_for_loop_induction(ExPolicy&& policy)
     std::vector<std::size_t> d(10007);
     std::iota(std::begin(c), std::end(c), gen());
 
-    hpx::ranges::for_loop(std::forward<ExPolicy>(policy), c,
-        hpx::parallel::induction(0), [&d](iterator it, std::size_t i) {
+    hpx::ranges::experimental::for_loop(std::forward<ExPolicy>(policy), c,
+        hpx::experimental::induction(0), [&d](iterator it, std::size_t i) {
             *it = 42;
             d[i] = 42;
         });
@@ -64,8 +64,8 @@ void test_for_loop_induction_stride(ExPolicy&& policy)
     std::vector<std::size_t> d(10007);
     std::iota(std::begin(c), std::end(c), gen());
 
-    hpx::ranges::for_loop(std::forward<ExPolicy>(policy), c,
-        hpx::parallel::induction(0), hpx::parallel::induction(0, 2),
+    hpx::ranges::experimental::for_loop(std::forward<ExPolicy>(policy), c,
+        hpx::experimental::induction(0), hpx::experimental::induction(0, 2),
         [&d](iterator it, std::size_t i, std::size_t j) {
             *it = 42;
             d[i] = 42;
@@ -97,8 +97,8 @@ void test_for_loop_induction_life_out(ExPolicy&& policy)
 
     std::size_t curr = 0;
 
-    hpx::ranges::for_loop(std::forward<ExPolicy>(policy), c,
-        hpx::parallel::induction(curr), [&d](iterator it, std::size_t i) {
+    hpx::ranges::experimental::for_loop(std::forward<ExPolicy>(policy), c,
+        hpx::experimental::induction(curr), [&d](iterator it, std::size_t i) {
             *it = 42;
             d[i] = 42;
         });
@@ -130,8 +130,9 @@ void test_for_loop_induction_stride_life_out(ExPolicy&& policy)
     std::size_t curr1 = 0;
     std::size_t curr2 = 0;
 
-    hpx::ranges::for_loop(std::forward<ExPolicy>(policy), c,
-        hpx::parallel::induction(curr1), hpx::parallel::induction(curr2, 2),
+    hpx::ranges::experimental::for_loop(std::forward<ExPolicy>(policy), c,
+        hpx::experimental::induction(curr1),
+        hpx::experimental::induction(curr2, 2),
         [&d](iterator it, std::size_t i, std::size_t j) {
             *it = 42;
             d[i] = 42;

--- a/libs/core/algorithms/tests/unit/container_algorithms/for_loop_range.cpp
+++ b/libs/core/algorithms/tests/unit/container_algorithms/for_loop_range.cpp
@@ -34,7 +34,7 @@ void test_for_loop(ExPolicy&& policy)
     std::vector<std::size_t> c(10007);
     std::iota(std::begin(c), std::end(c), gen());
 
-    hpx::ranges::for_loop(
+    hpx::ranges::experimental::for_loop(
         std::forward<ExPolicy>(policy), c, [](iterator it) { *it = 42; });
 
     // verify values
@@ -54,7 +54,7 @@ void test_for_loop_async(ExPolicy&& p)
     std::vector<std::size_t> c(10007);
     std::iota(std::begin(c), std::end(c), gen());
 
-    auto f = hpx::ranges::for_loop(
+    auto f = hpx::ranges::experimental::for_loop(
         std::forward<ExPolicy>(p), c, [](iterator it) { *it = 42; });
     f.wait();
 

--- a/libs/core/algorithms/tests/unit/container_algorithms/for_loop_reduction_async_range.cpp
+++ b/libs/core/algorithms/tests/unit/container_algorithms/for_loop_reduction_async_range.cpp
@@ -35,8 +35,8 @@ void test_for_loop_reduction_plus(ExPolicy&& policy)
     std::iota(std::begin(c), std::end(c), gen());
 
     std::size_t sum = 0;
-    auto f = hpx::ranges::for_loop(std::forward<ExPolicy>(policy), c,
-        hpx::parallel::reduction_plus(sum),
+    auto f = hpx::ranges::experimental::for_loop(std::forward<ExPolicy>(policy),
+        c, hpx::experimental::reduction_plus(sum),
         [](iterator it, std::size_t& sum) { sum += *it; });
     f.wait();
 
@@ -58,8 +58,8 @@ void test_for_loop_reduction_multiplies(ExPolicy&& policy)
     std::iota(std::begin(c), std::end(c), gen());
 
     std::size_t prod = 0;
-    auto f = hpx::ranges::for_loop(std::forward<ExPolicy>(policy), c,
-        hpx::parallel::reduction_multiplies(prod),
+    auto f = hpx::ranges::experimental::for_loop(std::forward<ExPolicy>(policy),
+        c, hpx::experimental::reduction_multiplies(prod),
         [](iterator it, std::size_t& prod) { prod *= *it; });
     f.wait();
 
@@ -82,8 +82,8 @@ void test_for_loop_reduction_min(ExPolicy&& policy)
 
     std::size_t minval = c[0];
 
-    auto f = hpx::ranges::for_loop(std::forward<ExPolicy>(policy), c,
-        hpx::parallel::reduction_min(minval),
+    auto f = hpx::ranges::experimental::for_loop(std::forward<ExPolicy>(policy),
+        c, hpx::experimental::reduction_min(minval),
         [](iterator it, std::size_t& minval) {
             minval = (std::min)(minval, *it);
         });

--- a/libs/core/algorithms/tests/unit/container_algorithms/for_loop_reduction_range.cpp
+++ b/libs/core/algorithms/tests/unit/container_algorithms/for_loop_reduction_range.cpp
@@ -35,8 +35,8 @@ void test_for_loop_reduction_plus(ExPolicy&& policy)
     std::iota(std::begin(c), std::end(c), gen());
 
     std::size_t sum = 0;
-    hpx::ranges::for_loop(std::forward<ExPolicy>(policy), c,
-        hpx::parallel::reduction_plus(sum),
+    hpx::ranges::experimental::for_loop(std::forward<ExPolicy>(policy), c,
+        hpx::experimental::reduction_plus(sum),
         [](iterator it, std::size_t& sum) { sum += *it; });
 
     // verify values
@@ -57,8 +57,8 @@ void test_for_loop_reduction_multiplies(ExPolicy&& policy)
     std::iota(std::begin(c), std::end(c), gen());
 
     std::size_t prod = 0;
-    hpx::ranges::for_loop(std::forward<ExPolicy>(policy), c,
-        hpx::parallel::reduction_multiplies(prod),
+    hpx::ranges::experimental::for_loop(std::forward<ExPolicy>(policy), c,
+        hpx::experimental::reduction_multiplies(prod),
         [](iterator it, std::size_t& prod) { prod *= *it; });
 
     // verify values
@@ -80,8 +80,8 @@ void test_for_loop_reduction_min(ExPolicy&& policy)
 
     std::size_t minval = c[0];
 
-    hpx::ranges::for_loop(std::forward<ExPolicy>(policy), c,
-        hpx::parallel::reduction_min(minval),
+    hpx::ranges::experimental::for_loop(std::forward<ExPolicy>(policy), c,
+        hpx::experimental::reduction_min(minval),
         [](iterator it, std::size_t& minval) {
             minval = (std::min)(minval, *it);
         });

--- a/libs/core/algorithms/tests/unit/container_algorithms/for_loop_strided_range.cpp
+++ b/libs/core/algorithms/tests/unit/container_algorithms/for_loop_strided_range.cpp
@@ -42,8 +42,8 @@ void test_for_loop_strided(ExPolicy&& policy)
 
     int stride = dis(gen);    //-V103
 
-    hpx::ranges::for_loop_strided(std::forward<ExPolicy>(policy), c, stride,
-        [](iterator it) { *it = 42; });
+    hpx::ranges::experimental::for_loop_strided(std::forward<ExPolicy>(policy),
+        c, stride, [](iterator it) { *it = 42; });
 
     // verify values
     std::size_t count = 0;
@@ -77,7 +77,7 @@ void test_for_loop_strided_async(ExPolicy&& p)
 
     int stride = dis(gen);    //-V103
 
-    auto f = hpx::ranges::for_loop_strided(
+    auto f = hpx::ranges::experimental::for_loop_strided(
         std::forward<ExPolicy>(p), c, stride, [](iterator it) { *it = 42; });
     f.wait();
 

--- a/libs/core/async_cuda/tests/unit/cublas_matmul.cpp
+++ b/libs/core/async_cuda/tests/unit/cublas_matmul.cpp
@@ -67,7 +67,7 @@ template <typename T>
 void matrixMulCPU(T* C, const T* A, const T* B, unsigned int hA,
     unsigned int wA, unsigned int wB)
 {
-    hpx::for_loop(hpx::execution::par, 0, hA, [&](int i) {
+    hpx::experimental::for_loop(hpx::execution::par, 0, hA, [&](int i) {
         for (unsigned int j = 0; j < wB; ++j)
         {
             T sum = 0;
@@ -92,7 +92,7 @@ inline bool compare_L2_err(const float* reference, const float* data,
     float error = 0;
     float ref = 0;
 
-    hpx::for_loop(hpx::execution::par, 0, len, [&](int i) {
+    hpx::experimental::for_loop(hpx::execution::par, 0, len, [&](int i) {
         float diff = reference[i] - data[i];
         error += diff * diff;
         ref += reference[i] * reference[i];

--- a/libs/core/resource_partitioner/examples/oversubscribing_resource_partitioner.cpp
+++ b/libs/core/resource_partitioner/examples/oversubscribing_resource_partitioner.cpp
@@ -146,7 +146,7 @@ int hpx_main(/*hpx::program_options::variables_map& vm*/)
 
     // test a parallel algorithm on custom pool with high priority
     hpx::execution::static_chunk_size fixed(1);
-    hpx::for_loop_strided(
+    hpx::experimental::for_loop_strided(
         hpx::execution::par.with(fixed).on(high_priority_executor), 0,
         loop_count, 1, [&](std::size_t i) {
             std::lock_guard<hpx::lcos::local::mutex> lock(m);
@@ -162,7 +162,7 @@ int hpx_main(/*hpx::program_options::variables_map& vm*/)
     thread_set.clear();
 
     // test a parallel algorithm on custom pool with normal priority
-    hpx::for_loop_strided(
+    hpx::experimental::for_loop_strided(
         hpx::execution::par.with(fixed).on(normal_priority_executor), 0,
         loop_count, 1, [&](std::size_t i) {
             std::lock_guard<hpx::lcos::local::mutex> lock(m);
@@ -179,8 +179,9 @@ int hpx_main(/*hpx::program_options::variables_map& vm*/)
     thread_set.clear();
 
     // test a parallel algorithm on mpi_executor
-    hpx::for_loop_strided(hpx::execution::par.with(fixed).on(mpi_executor), 0,
-        loop_count, 1, [&](std::size_t i) {
+    hpx::experimental::for_loop_strided(
+        hpx::execution::par.with(fixed).on(mpi_executor), 0, loop_count, 1,
+        [&](std::size_t i) {
             std::lock_guard<hpx::lcos::local::mutex> lock(m);
             if (thread_set.insert(std::this_thread::get_id()).second)
             {
@@ -198,7 +199,7 @@ int hpx_main(/*hpx::program_options::variables_map& vm*/)
     //     auto normal_priority_async_policy = hpx::launch::async_policy();
 
     // test a parallel algorithm on custom pool with high priority
-    hpx::for_loop_strided(
+    hpx::experimental::for_loop_strided(
         hpx::execution::par.with(fixed /*, high_priority_async_policy*/)
             .on(mpi_executor),
         0, loop_count, 1, [&](std::size_t i) {

--- a/libs/core/resource_partitioner/examples/simple_resource_partitioner.cpp
+++ b/libs/core/resource_partitioner/examples/simple_resource_partitioner.cpp
@@ -134,7 +134,7 @@ int hpx_main(hpx::program_options::variables_map&)
 
     // test a parallel algorithm on custom pool with high priority
     hpx::execution::static_chunk_size fixed(1);
-    hpx::for_loop_strided(
+    hpx::experimental::for_loop_strided(
         hpx::execution::par.with(fixed).on(high_priority_executor), 0,
         loop_count, 1, [&](std::size_t i) {
             std::lock_guard<hpx::lcos::local::mutex> lock(m);
@@ -150,7 +150,7 @@ int hpx_main(hpx::program_options::variables_map&)
     thread_set.clear();
 
     // test a parallel algorithm on custom pool with normal priority
-    hpx::for_loop_strided(
+    hpx::experimental::for_loop_strided(
         hpx::execution::par.with(fixed).on(normal_priority_executor), 0,
         loop_count, 1, [&](std::size_t i) {
             std::lock_guard<hpx::lcos::local::mutex> lock(m);
@@ -167,8 +167,9 @@ int hpx_main(hpx::program_options::variables_map&)
     thread_set.clear();
 
     // test a parallel algorithm on mpi_executor
-    hpx::for_loop_strided(hpx::execution::par.with(fixed).on(mpi_executor), 0,
-        loop_count, 1, [&](std::size_t i) {
+    hpx::experimental::for_loop_strided(
+        hpx::execution::par.with(fixed).on(mpi_executor), 0, loop_count, 1,
+        [&](std::size_t i) {
             std::lock_guard<hpx::lcos::local::mutex> lock(m);
             if (thread_set.insert(std::this_thread::get_id()).second)
             {
@@ -186,7 +187,7 @@ int hpx_main(hpx::program_options::variables_map&)
     //     auto normal_priority_async_policy = hpx::launch::async_policy();
 
     // test a parallel algorithm on custom pool with high priority
-    hpx::for_loop_strided(
+    hpx::experimental::for_loop_strided(
         hpx::execution::par.with(fixed /*, high_priority_async_policy*/)
             .on(mpi_executor),
         0, loop_count, 1, [&](std::size_t i) {

--- a/libs/full/collectives/tests/performance/osu/osu_bibw.cpp
+++ b/libs/full/collectives/tests/performance/osu/osu_bibw.cpp
@@ -53,9 +53,9 @@ hpx::future<void> send_async(
 {
     using buffer_type = hpx::serialization::serialize_buffer<char>;
 
-    using hpx::for_loop;
     using hpx::execution::par;
     using hpx::execution::task;
+    using hpx::experimental::for_loop;
 
     return for_loop(par(task), 0, window_size, [dest, size](std::uint64_t) {
         // Note: The original benchmark uses MPI_Isend which does not
@@ -76,8 +76,8 @@ HPX_PLAIN_DIRECT_ACTION(irecv)
 ///////////////////////////////////////////////////////////////////////////////
 void recv_async(hpx::id_type dest, std::size_t size, std::size_t window_size)
 {
-    using hpx::for_loop;
     using hpx::execution::par;
+    using hpx::experimental::for_loop;
 
     for_loop(par, 0, window_size, [dest, size](std::uint64_t) {
         irecv_action recv;

--- a/libs/full/resiliency_distributed/tests/performance/replay/1d_stencil_distributed.cpp
+++ b/libs/full/resiliency_distributed/tests/performance/replay/1d_stencil_distributed.cpp
@@ -191,7 +191,7 @@ int hpx_main(hpx::program_options::variables_map& vm)
     for (stencil& s : U)
         s.resize(num_subdomains);
 
-    hpx::for_loop(hpx::execution::par, 0, num_subdomains,
+    hpx::experimental::for_loop(hpx::execution::par, 0, num_subdomains,
         [&U, subdomain_width, num_subdomains](std::size_t i) {
             U[0][i] =
                 partition_data(subdomain_width, double(i), num_subdomains);
@@ -263,7 +263,7 @@ int hpx_main(hpx::program_options::variables_map& vm)
                     std::ref(current[i - 1]), std::ref(current[i + 1]));
         }
 
-        hpx::for_loop(hpx::execution::par, 1, num_subdomains - 1,
+        hpx::experimental::for_loop(hpx::execution::par, 1, num_subdomains - 1,
             [&next, &futures](
                 std::size_t i) { next[i] = futures[i - 1].get(); });
 

--- a/libs/full/resiliency_distributed/tests/performance/replay/1d_stencil_replay_distributed.cpp
+++ b/libs/full/resiliency_distributed/tests/performance/replay/1d_stencil_replay_distributed.cpp
@@ -317,7 +317,7 @@ int hpx_main(hpx::program_options::variables_map& vm)
     for (stencil& s : U)
         s.resize(num_subdomains);
 
-    hpx::for_loop(hpx::execution::par, 0, num_subdomains,
+    hpx::experimental::for_loop(hpx::execution::par, 0, num_subdomains,
         [&U, subdomain_width, num_subdomains](std::size_t i) {
             U[0][i] =
                 partition_data(subdomain_width, double(i), num_subdomains);
@@ -409,7 +409,7 @@ int hpx_main(hpx::program_options::variables_map& vm)
                         });
         }
 
-        hpx::for_loop(hpx::execution::par, 1, num_subdomains - 1,
+        hpx::experimental::for_loop(hpx::execution::par, 1, num_subdomains - 1,
             [&next, &futures](
                 std::size_t i) { next[i] = futures[i - 1].get(); });
 

--- a/tests/performance/local/future_overhead.cpp
+++ b/tests/performance/local/future_overhead.cpp
@@ -238,7 +238,7 @@ void measure_function_futures_limiting_executor(
     {
         hpx::execution::experimental::limiting_executor<Executor> signal_exec(
             exec, tasks, tasks + 1000);
-        hpx::for_loop(
+        hpx::experimental::for_loop(
             hpx::execution::par.with(fixed), 0, count, [&](std::uint64_t) {
                 hpx::apply(signal_exec, [&]() {
                     null_function();
@@ -305,7 +305,7 @@ void measure_function_futures_for_loop(std::uint64_t count, bool csv,
 {
     // start the clock
     high_resolution_timer walltime;
-    hpx::for_loop(
+    hpx::experimental::for_loop(
         hpx::execution::par.on(exec).with(
             hpx::execution::static_chunk_size(1), unlimited_number_of_chunks()),
         0, count, [](std::uint64_t) { null_function(); });


### PR DESCRIPTION
- move hpx::parallel::induction/reduction into namespace hpx::experimental
- move hpx::ranges::for_loop et.al. into hpx::ranges::experimental

`for_loop` and friends have not been accepted into the standard. We're moving it out of the way.