### PR TITLE
Updating used version of Visual Studio

### DIFF
--- a/.github/workflows/windows_debug.yml
+++ b/.github/workflows/windows_debug.yml
@@ -16,17 +16,17 @@ jobs:
     - uses: actions/checkout@v2
     - uses: jwlawson/actions-setup-cmake@v1.9
       with:
-        cmake-version: '3.18.x'
+        cmake-version: '3.22.x'
     - name: Install dependencies
       run: |
         md C:\projects
         $client = new-object System.Net.WebClient
-        $client.DownloadFile("https://rostam.cct.lsu.edu/download/builder/vcpkg-export-hpx-dependencies.7z","C:\projects\vcpkg-export-hpx-dependencies.7z")
+        $client.DownloadFile("https://rostam.cct.lsu.edu/download/builder/vcpkg-export-hpx-dependencies-2022.7z","C:\projects\vcpkg-export-hpx-dependencies.7z")
         7z x C:\projects\vcpkg-export-hpx-dependencies.7z -y -oC:\projects\vcpkg
     - name: Configure
       shell: bash
       run: |
-          cmake . -Bbuild -G'Visual Studio 16 2019' \
+          cmake . -Bbuild -G'Visual Studio 17 2022' \
               -DCMAKE_BUILD_TYPE=Debug \
               -DCMAKE_TOOLCHAIN_FILE='C:/projects/vcpkg/scripts/buildsystems/vcpkg.cmake' \
               -DHPX_WITH_FETCH_ASIO=ON \

--- a/.github/workflows/windows_release.yml
+++ b/.github/workflows/windows_release.yml
@@ -16,17 +16,17 @@ jobs:
     - uses: actions/checkout@v2
     - uses: jwlawson/actions-setup-cmake@v1.9
       with:
-        cmake-version: '3.18.x'
+        cmake-version: '3.22.x'
     - name: Install dependencies
       run: |
         md C:\projects
         $client = new-object System.Net.WebClient
-        $client.DownloadFile("https://rostam.cct.lsu.edu/download/builder/vcpkg-export-hpx-dependencies.7z","C:\projects\vcpkg-export-hpx-dependencies.7z")
+        $client.DownloadFile("https://rostam.cct.lsu.edu/download/builder/vcpkg-export-hpx-dependencies-2022.7z","C:\projects\vcpkg-export-hpx-dependencies.7z")
         7z x C:\projects\vcpkg-export-hpx-dependencies.7z -y -oC:\projects\vcpkg
     - name: Configure
       shell: bash
       run: |
-          cmake . -Bbuild -G'Visual Studio 16 2019' \
+          cmake . -Bbuild -G'Visual Studio 17 2022' \
               -DCMAKE_BUILD_TYPE=Release \
               -DCMAKE_TOOLCHAIN_FILE='C:/projects/vcpkg/scripts/buildsystems/vcpkg.cmake' \
               -DHPX_WITH_FETCH_ASIO=ON \


### PR DESCRIPTION
Github has removed VS2019 from the used Windows image