### PR TITLE
Moving function and function_ref into namespace hpx

### DIFF
--- a/components/iostreams/include/hpx/components/iostreams/write_functions.hpp
+++ b/components/iostreams/include/hpx/components/iostreams/write_functions.hpp
@@ -23,7 +23,7 @@
 namespace hpx { namespace iostreams
 {
 
-typedef util::function_nonser<void(std::vector<char> const&)> write_function_type;
+typedef hpx::function<void(std::vector<char> const&)> write_function_type;
 
 ///////////////////////////////////////////////////////////////////////////////
 // Write function that works on STL OutputIterators

--- a/components/parcel_plugins/binary_filter/bzip2/tests/regressions/function_serialization_728_bzip2.cpp
+++ b/components/parcel_plugins/binary_filter/bzip2/tests/regressions/function_serialization_728_bzip2.cpp
@@ -32,7 +32,7 @@ struct functor
     }
 };
 
-int pass_functor(hpx::util::function<int()> const& f)
+int pass_functor(hpx::function<int(), true> const& f)
 {
     return f();
 }
@@ -41,7 +41,7 @@ HPX_DECLARE_PLAIN_ACTION(pass_functor, pass_functor_action)
 HPX_ACTION_USES_BZIP2_COMPRESSION(pass_functor_action)
 HPX_PLAIN_ACTION(pass_functor, pass_functor_action)
 
-void worker(hpx::util::function<int()> const& f)
+void worker(hpx::function<int(), true> const& f)
 {
     pass_functor_action act;
 
@@ -63,7 +63,7 @@ int hpx_main()
 
     {
         functor g;
-        hpx::util::function<int()> f(g);
+        hpx::function<int(), true> f(g);
 
         std::vector<hpx::future<void>> futures;
 

--- a/components/parcel_plugins/binary_filter/snappy/tests/regressions/function_serialization_728_snappy.cpp
+++ b/components/parcel_plugins/binary_filter/snappy/tests/regressions/function_serialization_728_snappy.cpp
@@ -32,7 +32,7 @@ struct functor
     }
 };
 
-int pass_functor(hpx::util::function<int()> const& f)
+int pass_functor(hpx::function<int(), true> const& f)
 {
     return f();
 }
@@ -41,7 +41,7 @@ HPX_DECLARE_PLAIN_ACTION(pass_functor, pass_functor_action)
 HPX_ACTION_USES_SNAPPY_COMPRESSION(pass_functor_action)
 HPX_PLAIN_ACTION(pass_functor, pass_functor_action)
 
-void worker(hpx::util::function<int()> const& f)
+void worker(hpx::function<int(), true> const& f)
 {
     pass_functor_action act;
 
@@ -63,7 +63,7 @@ int hpx_main()
 
     {
         functor g;
-        hpx::util::function<int()> f(g);
+        hpx::function<int(), true> f(g);
 
         std::vector<hpx::future<void>> futures;
 

--- a/components/parcel_plugins/binary_filter/zlib/tests/regressions/function_serialization_728_zlib.cpp
+++ b/components/parcel_plugins/binary_filter/zlib/tests/regressions/function_serialization_728_zlib.cpp
@@ -32,7 +32,7 @@ struct functor
     }
 };
 
-int pass_functor(hpx::util::function<int()> const& f)
+int pass_functor(hpx::function<int(), true> const& f)
 {
     return f();
 }
@@ -41,7 +41,7 @@ HPX_DECLARE_PLAIN_ACTION(pass_functor, pass_functor_action)
 HPX_ACTION_USES_ZLIB_COMPRESSION(pass_functor_action)
 HPX_PLAIN_ACTION(pass_functor, pass_functor_action)
 
-void worker(hpx::util::function<int()> const& f)
+void worker(hpx::function<int(), true> const& f)
 {
     pass_functor_action act;
 
@@ -63,7 +63,7 @@ int hpx_main()
 
     {
         functor g;
-        hpx::util::function<int()> f(g);
+        hpx::function<int(), true> f(g);
 
         std::vector<hpx::future<void>> futures;
 

--- a/components/parcel_plugins/coalescing/include/hpx/parcel_coalescing/counter_registry.hpp
+++ b/components/parcel_plugins/coalescing/include/hpx/parcel_coalescing/counter_registry.hpp
@@ -35,11 +35,11 @@ namespace hpx::plugins::parcel {
     public:
         coalescing_counter_registry() {}
 
-        using get_counter_type = util::function_nonser<std::int64_t(bool)>;
+        using get_counter_type = hpx::function<std::int64_t(bool)>;
         using get_counter_values_type =
-            util::function_nonser<std::vector<std::int64_t>(bool)>;
+            hpx::function<std::vector<std::int64_t>(bool)>;
         using get_counter_values_creator_type =
-            util::function_nonser<void(std::int64_t, std::int64_t, std::int64_t,
+            hpx::function<void(std::int64_t, std::int64_t, std::int64_t,
                 get_counter_values_type&)>;
 
         struct counter_functions

--- a/components/parcel_plugins/coalescing/include/hpx/parcel_coalescing/message_handler.hpp
+++ b/components/parcel_plugins/coalescing/include/hpx/parcel_coalescing/message_handler.hpp
@@ -61,7 +61,7 @@ namespace hpx::plugins::parcel {
         void get_time_between_parcels_histogram_creator(
             std::int64_t min_boundary, std::int64_t max_boundary,
             std::int64_t num_buckets,
-            util::function_nonser<std::vector<std::int64_t>(bool)>& result);
+            hpx::function<std::vector<std::int64_t>(bool)>& result);
 
         // register the given action
         static void register_action(char const* action, error_code& ec);

--- a/components/parcel_plugins/coalescing/src/coalescing_message_handler.cpp
+++ b/components/parcel_plugins/coalescing/src/coalescing_message_handler.cpp
@@ -405,7 +405,7 @@ namespace hpx::plugins::parcel {
     void coalescing_message_handler::get_time_between_parcels_histogram_creator(
         std::int64_t min_boundary, std::int64_t max_boundary,
         std::int64_t num_buckets,
-        util::function_nonser<std::vector<std::int64_t>(bool)>& result)
+        hpx::function<std::vector<std::int64_t>(bool)>& result)
     {
         std::lock_guard<mutex_type> l(mtx_);
         if (time_between_parcels_)

--- a/components/parcel_plugins/coalescing/src/performance_counters.cpp
+++ b/components/parcel_plugins/coalescing/src/performance_counters.cpp
@@ -82,7 +82,7 @@ namespace hpx::plugins::parcel {
             return counter_(reset);
         }
 
-        hpx::util::function_nonser<std::int64_t(bool)> counter_;
+        hpx::function<std::int64_t(bool)> counter_;
         std::string parameters_;
     };
 
@@ -118,7 +118,7 @@ namespace hpx::plugins::parcel {
             }
 
             // ask registry
-            hpx::util::function_nonser<std::int64_t(bool)> f =
+            hpx::function<std::int64_t(bool)> f =
                 coalescing_counter_registry::instance().get_parcels_counter(
                     paths.parameters_);
 
@@ -163,7 +163,7 @@ namespace hpx::plugins::parcel {
             return counter_(reset);
         }
 
-        hpx::util::function_nonser<std::int64_t(bool)> counter_;
+        hpx::function<std::int64_t(bool)> counter_;
         std::string parameters_;
     };
 
@@ -199,7 +199,7 @@ namespace hpx::plugins::parcel {
             }
 
             // ask registry
-            hpx::util::function_nonser<std::int64_t(bool)> f =
+            hpx::function<std::int64_t(bool)> f =
                 coalescing_counter_registry::instance().get_messages_counter(
                     paths.parameters_);
 
@@ -245,7 +245,7 @@ namespace hpx::plugins::parcel {
             return counter_(reset);
         }
 
-        hpx::util::function_nonser<std::int64_t(bool)> counter_;
+        hpx::function<std::int64_t(bool)> counter_;
         std::string parameters_;
     };
 
@@ -283,7 +283,7 @@ namespace hpx::plugins::parcel {
             }
 
             // ask registry
-            hpx::util::function_nonser<std::int64_t(bool)> f =
+            hpx::function<std::int64_t(bool)> f =
                 coalescing_counter_registry::instance()
                     .get_parcels_per_message_counter(paths.parameters_);
 
@@ -332,7 +332,7 @@ namespace hpx::plugins::parcel {
             return counter_(reset);
         }
 
-        hpx::util::function_nonser<std::int64_t(bool)> counter_;
+        hpx::function<std::int64_t(bool)> counter_;
         std::string parameters_;
     };
 
@@ -369,7 +369,7 @@ namespace hpx::plugins::parcel {
             }
 
             // ask registry
-            hpx::util::function_nonser<std::int64_t(bool)> f =
+            hpx::function<std::int64_t(bool)> f =
                 coalescing_counter_registry::instance()
                     .get_average_time_between_parcels_counter(
                         paths.parameters_);
@@ -441,7 +441,7 @@ namespace hpx::plugins::parcel {
         }
 
         hpx::lcos::local::spinlock mtx_;
-        hpx::util::function_nonser<std::vector<std::int64_t>(bool)> counter_;
+        hpx::function<std::vector<std::int64_t>(bool)> counter_;
         std::string action_name_;
         std::int64_t min_boundary_;
         std::int64_t max_boundary_;
@@ -510,7 +510,7 @@ namespace hpx::plugins::parcel {
                 num_buckets = util::from_string<std::int64_t>(params[3]);
 
             // ask registry
-            hpx::util::function_nonser<std::vector<std::int64_t>(bool)> f =
+            hpx::function<std::vector<std::int64_t>(bool)> f =
                 coalescing_counter_registry::instance()
                     .get_time_between_parcels_histogram_counter(
                         params[0], min_boundary, max_boundary, num_buckets);

--- a/components/parcel_plugins/coalescing/tests/regressions/function_serialization_728.cpp
+++ b/components/parcel_plugins/coalescing/tests/regressions/function_serialization_728.cpp
@@ -35,7 +35,7 @@ struct functor
     }
 };
 
-int pass_functor(hpx::util::function<int()> const& f)
+int pass_functor(hpx::function<int(), true> const& f)
 {
     return f();
 }
@@ -44,7 +44,7 @@ HPX_DECLARE_PLAIN_ACTION(pass_functor, pass_functor_action)
 HPX_ACTION_USES_MESSAGE_COALESCING(pass_functor_action)
 HPX_PLAIN_ACTION(pass_functor, pass_functor_action)
 
-void worker(hpx::util::function<int()> const& f)
+void worker(hpx::function<int(), true> const& f)
 {
     pass_functor_action act;
 
@@ -66,7 +66,7 @@ int hpx_main()
 
     {
         functor g;
-        hpx::util::function<int()> f(g);
+        hpx::function<int(), true> f(g);
 
         std::vector<hpx::future<void>> futures;
 

--- a/docs/sphinx/api/public_api.rst
+++ b/docs/sphinx/api/public_api.rst
@@ -381,7 +381,7 @@ Header ``hpx/local/functional.hpp``
 ===================================
 
 Corresponds to the C++ standard library header
-:cppreference-header:`functional`. :cpp:class:`hpx::util::function` is a more
+:cppreference-header:`functional`. :cpp:class:`hpx::function` is a more
 efficient and serializable replacement for ``std::function``.
 
 Constants
@@ -398,11 +398,9 @@ top-level ``hpx`` namespace.
 Classes
 -------
 
-- :cpp:class:`hpx::util::function`
-- :cpp:class:`hpx::util::function_nonser`
-- :cpp:class:`hpx::util::function_ref`
-- :cpp:class:`hpx::util::unique_function`
-- :cpp:class:`hpx::util::unique_function_nonser`
+- :cpp:class:`hpx::function`
+- :cpp:class:`hpx::function_ref`
+- :cpp:class:`hpx::move_only_function`
 - :cpp:struct:`hpx::traits::is_bind_expression`
 - :cpp:struct:`hpx::traits::is_placeholder`
 - :cpp:struct:`hpx::scoped_annotation`

--- a/examples/quickstart/executor_with_thread_hooks.cpp
+++ b/examples/quickstart/executor_with_thread_hooks.cpp
@@ -154,7 +154,7 @@ namespace executor_example {
         }
 
     private:
-        using thread_hook = hpx::util::function_nonser<void()>;
+        using thread_hook = hpx::function<void()>;
 
         BaseExecutor& exec_;
         thread_hook on_start_;

--- a/examples/quickstart/init_globally.cpp
+++ b/examples/quickstart/init_globally.cpp
@@ -88,9 +88,8 @@ public:
 
         using hpx::util::placeholders::_1;
         using hpx::util::placeholders::_2;
-        hpx::util::function_nonser<int(int, char**)> start_function =
-            hpx::util::bind(
-                &manage_global_runtime_impl::hpx_main, this, _1, _2);
+        hpx::function<int(int, char**)> start_function = hpx::util::bind(
+            &manage_global_runtime_impl::hpx_main, this, _1, _2);
         hpx::init_params init_args;
         init_args.cfg = cfg;
         init_args.mode = hpx::runtime_mode::default_;

--- a/libs/core/algorithms/include/hpx/parallel/util/detail/handle_exception_termination_handler.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/util/detail/handle_exception_termination_handler.hpp
@@ -10,8 +10,7 @@
 #include <hpx/functional/function.hpp>
 
 namespace hpx { namespace parallel { namespace util { namespace detail {
-    using parallel_exception_termination_handler_type =
-        hpx::util::function_nonser<void()>;
+    using parallel_exception_termination_handler_type = hpx::function<void()>;
 
     HPX_CORE_EXPORT void set_parallel_exception_termination_handler(
         parallel_exception_termination_handler_type f);

--- a/libs/core/asio/include/hpx/asio/map_hostnames.hpp
+++ b/libs/core/asio/include/hpx/asio/map_hostnames.hpp
@@ -23,7 +23,7 @@ namespace hpx { namespace util {
     // file
     struct HPX_CORE_EXPORT map_hostnames
     {
-        typedef util::function_nonser<std::string(std::string const&)>
+        typedef hpx::function<std::string(std::string const&)>
             transform_function_type;
 
         map_hostnames(bool debug = false)

--- a/libs/core/async_cuda/include/hpx/async_cuda/detail/cuda_event_callback.hpp
+++ b/libs/core/async_cuda/include/hpx/async_cuda/detail/cuda_event_callback.hpp
@@ -16,14 +16,14 @@
 
 #include <hpx/config.hpp>
 #include <hpx/async_cuda/custom_gpu_api.hpp>
-#include <hpx/functional/unique_function.hpp>
+#include <hpx/functional/move_only_function.hpp>
 #include <hpx/threading_base/thread_pool_base.hpp>
 
 #include <string>
 
 namespace hpx { namespace cuda { namespace experimental { namespace detail {
     using event_callback_function_type =
-        hpx::util::unique_function_nonser<void(cudaError_t)>;
+        hpx::move_only_function<void(cudaError_t)>;
 
     HPX_CORE_EXPORT void add_event_callback(
         event_callback_function_type&& f, cudaStream_t stream);

--- a/libs/core/async_mpi/include/hpx/async_mpi/mpi_future.hpp
+++ b/libs/core/async_mpi/include/hpx/async_mpi/mpi_future.hpp
@@ -8,7 +8,7 @@
 
 #include <hpx/config.hpp>
 #include <hpx/async_mpi/mpi_exception.hpp>
-#include <hpx/functional/unique_function.hpp>
+#include <hpx/functional/move_only_function.hpp>
 #include <hpx/futures/future.hpp>
 #include <hpx/modules/concurrency.hpp>
 #include <hpx/modules/execution_base.hpp>
@@ -31,7 +31,7 @@ namespace hpx { namespace mpi { namespace experimental {
     namespace detail {
 
         using request_callback_function_type =
-            hpx::util::unique_function_nonser<void(int)>;
+            hpx::move_only_function<void(int)>;
 
         HPX_CORE_EXPORT void add_request_callback(
             request_callback_function_type&& f, MPI_Request req);

--- a/libs/core/command_line_handling_local/include/hpx/command_line_handling_local/command_line_handling_local.hpp
+++ b/libs/core/command_line_handling_local/include/hpx/command_line_handling_local/command_line_handling_local.hpp
@@ -23,7 +23,7 @@ namespace hpx { namespace local { namespace detail {
     {
         command_line_handling(hpx::util::runtime_configuration rtcfg,
             std::vector<std::string> ini_config,
-            util::function_nonser<int(hpx::program_options::variables_map& vm)>
+            hpx::function<int(hpx::program_options::variables_map& vm)>
                 hpx_main_f)
           : rtcfg_(rtcfg)
           , ini_config_(ini_config)
@@ -47,8 +47,7 @@ namespace hpx { namespace local { namespace detail {
         hpx::util::runtime_configuration rtcfg_;
 
         std::vector<std::string> ini_config_;
-        util::function_nonser<int(hpx::program_options::variables_map& vm)>
-            hpx_main_f_;
+        hpx::function<int(hpx::program_options::variables_map& vm)> hpx_main_f_;
 
         std::size_t num_threads_;
         std::size_t num_cores_;

--- a/libs/core/coroutines/include/hpx/coroutines/coroutine.hpp
+++ b/libs/core/coroutines/include/hpx/coroutines/coroutine.hpp
@@ -59,8 +59,7 @@ namespace hpx { namespace threads { namespace coroutines {
         using result_type = impl_type::result_type;
         using arg_type = impl_type::arg_type;
 
-        using functor_type =
-            util::unique_function_nonser<result_type(arg_type)>;
+        using functor_type = hpx::move_only_function<result_type(arg_type)>;
 
         coroutine(functor_type&& f, thread_id_type id,
             std::ptrdiff_t stack_size = detail::default_stack_size)

--- a/libs/core/coroutines/include/hpx/coroutines/detail/coroutine_impl.hpp
+++ b/libs/core/coroutines/include/hpx/coroutines/detail/coroutine_impl.hpp
@@ -42,7 +42,7 @@
 #include <hpx/coroutines/detail/coroutine_accessor.hpp>
 #include <hpx/coroutines/thread_enums.hpp>
 #include <hpx/coroutines/thread_id_type.hpp>
-#include <hpx/functional/unique_function.hpp>
+#include <hpx/functional/move_only_function.hpp>
 
 #include <cstddef>
 #include <utility>
@@ -64,8 +64,7 @@ namespace hpx { namespace threads { namespace coroutines { namespace detail {
         using result_type = std::pair<thread_schedule_state, thread_id_type>;
         using arg_type = thread_restart_state;
 
-        using functor_type =
-            util::unique_function_nonser<result_type(arg_type)>;
+        using functor_type = hpx::move_only_function<result_type(arg_type)>;
 
         coroutine_impl(
             functor_type&& f, thread_id_type id, std::ptrdiff_t stack_size)

--- a/libs/core/coroutines/include/hpx/coroutines/detail/coroutine_self.hpp
+++ b/libs/core/coroutines/include/hpx/coroutines/detail/coroutine_self.hpp
@@ -73,8 +73,7 @@ namespace hpx { namespace threads { namespace coroutines { namespace detail {
         using result_type = std::pair<thread_schedule_state, thread_id_type>;
         using arg_type = thread_restart_state;
 
-        using yield_decorator_type =
-            util::function_nonser<arg_type(result_type)>;
+        using yield_decorator_type = hpx::function<arg_type(result_type)>;
 
         explicit coroutine_self(coroutine_self* next_self)
           : next_self_(next_self)

--- a/libs/core/coroutines/include/hpx/coroutines/stackless_coroutine.hpp
+++ b/libs/core/coroutines/include/hpx/coroutines/stackless_coroutine.hpp
@@ -15,7 +15,7 @@
 #include <hpx/coroutines/thread_enums.hpp>
 #include <hpx/coroutines/thread_id_type.hpp>
 #include <hpx/functional/detail/reset_function.hpp>
-#include <hpx/functional/unique_function.hpp>
+#include <hpx/functional/move_only_function.hpp>
 #include <hpx/type_support/unused.hpp>
 
 #include <cstddef>
@@ -54,8 +54,7 @@ namespace hpx { namespace threads { namespace coroutines {
         using result_type = std::pair<thread_schedule_state, thread_id_type>;
         using arg_type = thread_restart_state;
 
-        using functor_type =
-            util::unique_function_nonser<result_type(arg_type)>;
+        using functor_type = hpx::move_only_function<result_type(arg_type)>;
 
         stackless_coroutine(functor_type&& f, thread_id_type id,
             std::ptrdiff_t /*stack_size*/ = default_stack_size)

--- a/libs/core/datastructures/tests/performance/small_vector_benchmark.cpp
+++ b/libs/core/datastructures/tests/performance/small_vector_benchmark.cpp
@@ -88,11 +88,11 @@ int hpx_main(hpx::program_options::variables_map& vm)
     compare<int, 8>(repeat, size);
     compare<int, 16>(repeat, size);
 
-    compare<hpx::util::unique_function_nonser<void()>, 1>(repeat, size);
-    compare<hpx::util::unique_function_nonser<void()>, 2>(repeat, size);
-    compare<hpx::util::unique_function_nonser<void()>, 4>(repeat, size);
-    compare<hpx::util::unique_function_nonser<void()>, 8>(repeat, size);
-    compare<hpx::util::unique_function_nonser<void()>, 16>(repeat, size);
+    compare<hpx::move_only_function<void()>, 1>(repeat, size);
+    compare<hpx::move_only_function<void()>, 2>(repeat, size);
+    compare<hpx::move_only_function<void()>, 4>(repeat, size);
+    compare<hpx::move_only_function<void()>, 8>(repeat, size);
+    compare<hpx::move_only_function<void()>, 16>(repeat, size);
 
     return hpx::local::finalize();
 }

--- a/libs/core/execution/include/hpx/execution/algorithms/split.hpp
+++ b/libs/core/execution/include/hpx/execution/algorithms/split.hpp
@@ -23,7 +23,7 @@
 #include <hpx/functional/bind_front.hpp>
 #include <hpx/functional/detail/tag_fallback_invoke.hpp>
 #include <hpx/functional/invoke_fused.hpp>
-#include <hpx/functional/unique_function.hpp>
+#include <hpx/functional/move_only_function.hpp>
 #include <hpx/modules/memory.hpp>
 #include <hpx/synchronization/spinlock.hpp>
 #include <hpx/thread_support/atomic_count.hpp>
@@ -131,8 +131,7 @@ namespace hpx { namespace execution { namespace experimental {
                 hpx::variant<hpx::monostate, done_type, error_type, value_type>
                     v;
 
-                using continuation_type =
-                    hpx::util::unique_function_nonser<void()>;
+                using continuation_type = hpx::move_only_function<void()>;
                 hpx::detail::small_vector<continuation_type, 1> continuations;
 
                 struct split_receiver

--- a/libs/core/execution/include/hpx/execution/detail/execution_parameter_callbacks.hpp
+++ b/libs/core/execution/include/hpx/execution/detail/execution_parameter_callbacks.hpp
@@ -15,12 +15,12 @@
 ///////////////////////////////////////////////////////////////////////////////
 namespace hpx { namespace parallel { namespace execution { namespace detail {
     /// \cond NOINTERNAL
-    using get_os_thread_count_type = hpx::util::function_nonser<std::size_t()>;
+    using get_os_thread_count_type = hpx::function<std::size_t()>;
     HPX_CORE_EXPORT void set_get_os_thread_count(get_os_thread_count_type f);
     HPX_CORE_EXPORT std::size_t get_os_thread_count();
 
-    using get_pu_mask_type = hpx::util::function_nonser<threads::mask_cref_type(
-        threads::topology&, std::size_t)>;
+    using get_pu_mask_type =
+        hpx::function<threads::mask_cref_type(threads::topology&, std::size_t)>;
     HPX_CORE_EXPORT void set_get_pu_mask(get_pu_mask_type f);
     HPX_CORE_EXPORT threads::mask_cref_type get_pu_mask(
         threads::topology&, std::size_t);

--- a/libs/core/execution/include/hpx/execution/executors/polymorphic_executor.hpp
+++ b/libs/core/execution/include/hpx/execution/executors/polymorphic_executor.hpp
@@ -13,7 +13,7 @@
 #include <hpx/execution_base/execution.hpp>
 #include <hpx/execution_base/traits/is_executor.hpp>
 #include <hpx/functional/function.hpp>
-#include <hpx/functional/unique_function.hpp>
+#include <hpx/functional/move_only_function.hpp>
 #include <hpx/futures/future.hpp>
 #include <hpx/modules/thread_support.hpp>
 
@@ -289,8 +289,7 @@ namespace hpx { namespace parallel { namespace execution {
         template <typename R, typename... Ts>
         struct never_blocking_oneway_vtable<R(Ts...)>
         {
-            using post_function_type =
-                hpx::util::unique_function_nonser<R(Ts...)>;
+            using post_function_type = hpx::move_only_function<R(Ts...)>;
 
             // post
             template <typename T>
@@ -328,7 +327,7 @@ namespace hpx { namespace parallel { namespace execution {
         struct oneway_vtable<R(Ts...)>
         {
             using sync_execute_function_type =
-                hpx::util::unique_function_nonser<R(Ts...)>;
+                hpx::move_only_function<R(Ts...)>;
 
             // sync_execute
             template <typename T>
@@ -369,10 +368,9 @@ namespace hpx { namespace parallel { namespace execution {
         struct twoway_vtable<R(Ts...)>
         {
             using async_execute_function_type =
-                hpx::util::unique_function_nonser<R(Ts...)>;
-            using then_execute_function_type =
-                hpx::util::unique_function_nonser<R(
-                    hpx::shared_future<void> const&, Ts...)>;
+                hpx::move_only_function<R(Ts...)>;
+            using then_execute_function_type = hpx::move_only_function<R(
+                hpx::shared_future<void> const&, Ts...)>;
 
             // async_execute
             template <typename T>
@@ -436,7 +434,7 @@ namespace hpx { namespace parallel { namespace execution {
         struct bulk_oneway_vtable<R(Ts...)>
         {
             using bulk_sync_execute_function_type =
-                hpx::util::function_nonser<R(std::size_t, Ts...)>;
+                hpx::function<R(std::size_t, Ts...)>;
 
             // bulk_sync_execute
             template <typename T>
@@ -481,10 +479,9 @@ namespace hpx { namespace parallel { namespace execution {
         struct bulk_twoway_vtable<R(Ts...)>
         {
             using bulk_async_execute_function_type =
-                hpx::util::function_nonser<R(std::size_t, Ts...)>;
-            using bulk_then_execute_function_type =
-                hpx::util::function_nonser<R(
-                    std::size_t, hpx::shared_future<void> const&, Ts...)>;
+                hpx::function<R(std::size_t, Ts...)>;
+            using bulk_then_execute_function_type = hpx::function<R(
+                std::size_t, hpx::shared_future<void> const&, Ts...)>;
 
             // bulk_async_execute
             template <typename T>

--- a/libs/core/executors/include/hpx/executors/exception_list.hpp
+++ b/libs/core/executors/include/hpx/executors/exception_list.hpp
@@ -178,8 +178,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
         };
 #endif
 
-        using exception_list_termination_handler_type =
-            hpx::util::function_nonser<void()>;
+        using exception_list_termination_handler_type = hpx::function<void()>;
 
         HPX_CORE_EXPORT void set_exception_list_termination_handler(
             exception_list_termination_handler_type f);

--- a/libs/core/executors/include/hpx/executors/service_executors.hpp
+++ b/libs/core/executors/include/hpx/executors/service_executors.hpp
@@ -59,7 +59,7 @@ namespace hpx { namespace parallel { namespace execution { namespace detail {
             typedef typename hpx::util::detail::invoke_deferred_result<F,
                 Ts...>::type result_type;
 
-            hpx::util::unique_function_nonser<result_type()> f_wrapper =
+            hpx::move_only_function<result_type()> f_wrapper =
                 hpx::util::deferred_call(
                     HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...);
             auto t = std::make_shared<post_wrapper_helper<decltype(f_wrapper)>>(
@@ -82,7 +82,7 @@ namespace hpx { namespace parallel { namespace execution { namespace detail {
             typedef typename hpx::util::detail::invoke_deferred_result<F,
                 Ts...>::type result_type;
 
-            hpx::util::unique_function_nonser<result_type()> f_wrapper =
+            hpx::move_only_function<result_type()> f_wrapper =
                 hpx::util::deferred_call(
                     HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...);
             auto t = std::make_shared<

--- a/libs/core/functional/CMakeLists.txt
+++ b/libs/core/functional/CMakeLists.txt
@@ -26,14 +26,14 @@ set(functional_headers
     hpx/functional/invoke.hpp
     hpx/functional/invoke_fused.hpp
     hpx/functional/mem_fn.hpp
+    hpx/functional/move_only_function.hpp
     hpx/functional/one_shot.hpp
     hpx/functional/protect.hpp
-    hpx/functional/unique_function.hpp
     hpx/functional/serialization/detail/serializable_basic_function.hpp
     hpx/functional/serialization/detail/vtable/serializable_function_vtable.hpp
     hpx/functional/serialization/detail/vtable/serializable_vtable.hpp
     hpx/functional/serialization/serializable_function.hpp
-    hpx/functional/serialization/serializable_unique_function.hpp
+    hpx/functional/serialization/serializable_move_only_function.hpp
     hpx/functional/traits/get_action_name.hpp
     hpx/functional/traits/get_function_address.hpp
     hpx/functional/traits/get_function_annotation.hpp

--- a/libs/core/functional/docs/index.rst
+++ b/libs/core/functional/docs/index.rst
@@ -14,9 +14,9 @@ functional
 This module provides function wrappers and helpers for managing functions and
 their arguments.
 
-* :cpp:class:`hpx::util::function`
-* :cpp:class:`hpx::util::function_ref`
-* :cpp:class:`hpx::util::unique_function`
+* :cpp:class:`hpx::function`
+* :cpp:class:`hpx::function_ref_`
+* :cpp:class:`hpx::move_only_function`
 * :cpp:func:`hpx::util::bind`
 * :cpp:func:`hpx::util::bind_back`
 * :cpp:func:`hpx::util::bind_front`

--- a/libs/core/functional/include/hpx/functional/detail/function_registration.hpp
+++ b/libs/core/functional/include/hpx/functional/detail/function_registration.hpp
@@ -1,5 +1,5 @@
 //  Copyright (c) 2011 Thomas Heller
-//  Copyright (c) 2013 Hartmut Kaiser
+//  Copyright (c) 2013-2022 Hartmut Kaiser
 //  Copyright (c) 2014 Agustin Berge
 //
 //  SPDX-License-Identifier: BSL-1.0
@@ -66,14 +66,14 @@ namespace hpx { namespace util { namespace detail {
         HPX_ALWAYS_EXPORT char const* get_function_name<VTable,                \
             std::decay<HPX_PP_STRIP_PARENS(F)>::type>()                        \
         {                                                                      \
-            /*If you encounter this assert while compiling code, that means    \
-         that you have a HPX_UTIL_REGISTER_[UNIQUE_]FUNCTION macro             \
-         somewhere in a source file, but the header in which the function      \
-         is defined misses a HPX_UTIL_REGISTER_[UNIQUE_]FUNCTION_DECLARATION*/ \
+        /* If you encounter this assert while compiling code, that means that */ \
+        /* you have a HPX_UTIL_REGISTER_[MOVE_ONLY_]FUNCTION macro somewhere  */ \
+        /* in a source file, but the header in which the function is defined  */ \
+        /* misses a HPX_UTIL_REGISTER_[MOVE_ONLY_]FUNCTION_DECLARATION        */ \
              static_assert(                                                    \
                  get_function_name_declared<VTable,                            \
                      std::decay<HPX_PP_STRIP_PARENS(F)>::type>::value,         \
-                 "HPX_UTIL_REGISTER_[UNIQUE_]FUNCTION_DECLARATION "            \
+                 "HPX_UTIL_REGISTER_[MOVE_ONLY_]FUNCTION_DECLARATION "         \
                  "missing for " HPX_PP_STRINGIZE(Name));                       \
              return HPX_PP_STRINGIZE(Name);                                    \
         }                                                                      \

--- a/libs/core/functional/include/hpx/functional/detail/reset_function.hpp
+++ b/libs/core/functional/include/hpx/functional/detail/reset_function.hpp
@@ -7,29 +7,18 @@
 #pragma once
 
 #include <hpx/functional/function.hpp>
-#include <hpx/functional/unique_function.hpp>
+#include <hpx/functional/move_only_function.hpp>
 
 namespace hpx { namespace util { namespace detail {
-    template <typename Sig, bool Serializable>
-    inline void reset_function(hpx::util::function<Sig, Serializable>& f)
-    {
-        f.reset();
-    }
 
-    template <typename Sig>
-    inline void reset_function(hpx::util::function_nonser<Sig>& f)
+    template <typename Sig, bool Serializable>
+    inline void reset_function(hpx::function<Sig, Serializable>& f)
     {
         f.reset();
     }
 
     template <typename Sig, bool Serializable>
-    inline void reset_function(hpx::util::unique_function<Sig, Serializable>& f)
-    {
-        f.reset();
-    }
-
-    template <typename Sig>
-    inline void reset_function(hpx::util::unique_function_nonser<Sig>& f)
+    inline void reset_function(hpx::move_only_function<Sig, Serializable>& f)
     {
         f.reset();
     }

--- a/libs/core/functional/include/hpx/functional/function.hpp
+++ b/libs/core/functional/include/hpx/functional/function.hpp
@@ -1,5 +1,5 @@
 //  Copyright (c) 2011 Thomas Heller
-//  Copyright (c) 2013 Hartmut Kaiser
+//  Copyright (c) 2013-2022 Hartmut Kaiser
 //  Copyright (c) 2014-2015 Agustin Berge
 //
 //  SPDX-License-Identifier: BSL-1.0
@@ -19,16 +19,18 @@
 #include <type_traits>
 #include <utility>
 
-namespace hpx { namespace util {
+namespace hpx {
+
     ///////////////////////////////////////////////////////////////////////////
-    template <typename Sig, bool Serializable = true>
+    template <typename Sig, bool Serializable = false>
     class function;
 
     template <typename R, typename... Ts, bool Serializable>
     class function<R(Ts...), Serializable>
-      : public detail::basic_function<R(Ts...), true, Serializable>
+      : public util::detail::basic_function<R(Ts...), true, Serializable>
     {
-        using base_type = detail::basic_function<R(Ts...), true, Serializable>;
+        using base_type =
+            util::detail::basic_function<R(Ts...), true, Serializable>;
 
     public:
         using result_type = R;
@@ -41,22 +43,20 @@ namespace hpx { namespace util {
         function& operator=(function&&) noexcept = default;
 
         // the split SFINAE prevents MSVC from eagerly instantiating things
-        template <typename F, typename FD = typename std::decay<F>::type,
-            typename Enable1 = typename std::enable_if<
-                !std::is_same<FD, function>::value>::type,
+        template <typename F, typename FD = std::decay_t<F>,
+            typename Enable1 = std::enable_if_t<!std::is_same_v<FD, function>>,
             typename Enable2 =
-                typename std::enable_if<is_invocable_r_v<R, FD&, Ts...>>::type>
+                std::enable_if_t<is_invocable_r_v<R, FD&, Ts...>>>
         function(F&& f)
         {
             assign(HPX_FORWARD(F, f));
         }
 
         // the split SFINAE prevents MSVC from eagerly instantiating things
-        template <typename F, typename FD = typename std::decay<F>::type,
-            typename Enable1 = typename std::enable_if<
-                !std::is_same<FD, function>::value>::type,
+        template <typename F, typename FD = std::decay_t<F>,
+            typename Enable1 = std::enable_if_t<!std::is_same_v<FD, function>>,
             typename Enable2 =
-                typename std::enable_if<is_invocable_r_v<R, FD&, Ts...>>::type>
+                std::enable_if_t<is_invocable_r_v<R, FD&, Ts...>>>
         function& operator=(F&& f)
         {
             assign(HPX_FORWARD(F, f));
@@ -69,29 +69,40 @@ namespace hpx { namespace util {
         using base_type::reset;
         using base_type::target;
     };
+}    // namespace hpx
+
+namespace hpx::util {
+
+    template <typename Sig, bool Serializable = true>
+    using function HPX_DEPRECATED_V(1, 8,
+        "hpx::util::function is deprecated. Please use hpx::function "
+        "instead.") = hpx::function<Sig, Serializable>;
 
     template <typename Sig>
-    using function_nonser = function<Sig, false>;
-}}    // namespace hpx::util
+    using function_nonser HPX_DEPRECATED_V(1, 8,
+        "hpx::util::function_nonser is deprecated. Please use hpx::function "
+        "instead.") = hpx::function<Sig>;
+}    // namespace hpx::util
 
 #if defined(HPX_HAVE_THREAD_DESCRIPTION)
 ///////////////////////////////////////////////////////////////////////////////
 namespace hpx { namespace traits {
+
     template <typename Sig, bool Serializable>
-    struct get_function_address<util::function<Sig, Serializable>>
+    struct get_function_address<hpx::function<Sig, Serializable>>
     {
         static constexpr std::size_t call(
-            util::function<Sig, Serializable> const& f) noexcept
+            hpx::function<Sig, Serializable> const& f) noexcept
         {
             return f.get_function_address();
         }
     };
 
     template <typename Sig, bool Serializable>
-    struct get_function_annotation<util::function<Sig, Serializable>>
+    struct get_function_annotation<hpx::function<Sig, Serializable>>
     {
         static constexpr char const* call(
-            util::function<Sig, Serializable> const& f) noexcept
+            hpx::function<Sig, Serializable> const& f) noexcept
         {
             return f.get_function_annotation();
         }
@@ -99,10 +110,10 @@ namespace hpx { namespace traits {
 
 #if HPX_HAVE_ITTNOTIFY != 0 && !defined(HPX_HAVE_APEX)
     template <typename Sig, bool Serializable>
-    struct get_function_annotation_itt<util::function<Sig, Serializable>>
+    struct get_function_annotation_itt<hpx::function<Sig, Serializable>>
     {
         static util::itt::string_handle call(
-            util::function<Sig, Serializable> const& f) noexcept
+            hpx::function<Sig, Serializable> const& f) noexcept
         {
             return f.get_function_annotation_itt();
         }

--- a/libs/core/functional/include/hpx/functional/function_ref.hpp
+++ b/libs/core/functional/include/hpx/functional/function_ref.hpp
@@ -23,12 +23,14 @@
 #include <type_traits>
 #include <utility>
 
-namespace hpx { namespace util {
+namespace hpx {
+
     ///////////////////////////////////////////////////////////////////////////
     template <typename Sig>
     class function_ref;
 
-    namespace detail {
+    namespace util::detail {
+
         template <typename Sig>
         struct function_ref_vtable
           : callable_vtable<Sig>
@@ -60,19 +62,19 @@ namespace hpx { namespace util {
         {
             return false;
         }
-    }    // namespace detail
+    }    // namespace util::detail
 
     ///////////////////////////////////////////////////////////////////////////
     template <typename R, typename... Ts>
     class function_ref<R(Ts...)>
     {
-        using VTable = detail::function_ref_vtable<R(Ts...)>;
+        using VTable = util::detail::function_ref_vtable<R(Ts...)>;
 
     public:
-        template <typename F, typename FD = typename std::decay<F>::type,
-            typename Enable = typename std::enable_if<
-                !std::is_same<FD, function_ref>::value &&
-                is_invocable_r_v<R, F&, Ts...>>::type>
+        template <typename F, typename FD = std::decay_t<F>,
+            typename Enable =
+                std::enable_if_t<!std::is_same_v<FD, function_ref> &&
+                    is_invocable_r_v<R, F&, Ts...>>>
         function_ref(F&& f)
           : object(nullptr)
         {
@@ -85,10 +87,10 @@ namespace hpx { namespace util {
         {
         }
 
-        template <typename F, typename FD = typename std::decay<F>::type,
-            typename Enable = typename std::enable_if<
-                !std::is_same<FD, function_ref>::value &&
-                is_invocable_r_v<R, F&, Ts...>>::type>
+        template <typename F, typename FD = std::decay_t<F>,
+            typename Enable =
+                std::enable_if_t<!std::is_same_v<FD, function_ref> &&
+                    is_invocable_r_v<R, F&, Ts...>>>
         function_ref& operator=(F&& f)
         {
             assign(HPX_FORWARD(F, f));
@@ -103,13 +105,11 @@ namespace hpx { namespace util {
             return *this;
         }
 
-        template <typename F,
-            typename T = typename std::remove_reference<F>::type,
-            typename Enable =
-                typename std::enable_if<!std::is_pointer<T>::value>::type>
+        template <typename F, typename T = std::remove_reference_t<F>,
+            typename Enable = std::enable_if_t<!std::is_pointer_v<T>>>
         void assign(F&& f)
         {
-            HPX_ASSERT(!detail::is_empty_function_ptr(f));
+            HPX_ASSERT(!util::detail::is_empty_function_ptr(f));
 #if defined(HPX_HAVE_THREAD_DESCRIPTION)
             vptr = get_vtable<T>();
 #else
@@ -188,7 +188,7 @@ namespace hpx { namespace util {
         template <typename T>
         static VTable const* get_vtable() noexcept
         {
-            return detail::get_vtable<VTable, T>();
+            return util::detail::get_vtable<VTable, T>();
         }
 
     protected:
@@ -199,26 +199,35 @@ namespace hpx { namespace util {
 #endif
         void* object;
     };
-}}    // namespace hpx::util
+}    // namespace hpx
+
+namespace hpx::util {
+
+    template <typename Sig>
+    using function_ref HPX_DEPRECATED_V(1, 8,
+        "hpx::util::function_ref is deprecated. Please use hpx::function_ref "
+        "instead.") = hpx::function_ref<Sig>;
+}
 
 #if defined(HPX_HAVE_THREAD_DESCRIPTION)
 ///////////////////////////////////////////////////////////////////////////////
 namespace hpx { namespace traits {
+
     template <typename Sig>
-    struct get_function_address<util::function_ref<Sig>>
+    struct get_function_address<hpx::function_ref<Sig>>
     {
         static constexpr std::size_t call(
-            util::function_ref<Sig> const& f) noexcept
+            hpx::function_ref<Sig> const& f) noexcept
         {
             return f.get_function_address();
         }
     };
 
     template <typename Sig>
-    struct get_function_annotation<util::function_ref<Sig>>
+    struct get_function_annotation<hpx::function_ref<Sig>>
     {
         static constexpr char const* call(
-            util::function_ref<Sig> const& f) noexcept
+            hpx::function_ref<Sig> const& f) noexcept
         {
             return f.get_function_annotation();
         }
@@ -226,10 +235,10 @@ namespace hpx { namespace traits {
 
 #if HPX_HAVE_ITTNOTIFY != 0 && !defined(HPX_HAVE_APEX)
     template <typename Sig>
-    struct get_function_annotation_itt<util::function_ref<Sig>>
+    struct get_function_annotation_itt<hpx::function_ref<Sig>>
     {
         static util::itt::string_handle call(
-            util::function_ref<Sig> const& f) noexcept
+            hpx::function_ref<Sig> const& f) noexcept
         {
             return f.get_function_annotation_itt();
         }

--- a/libs/core/functional/include/hpx/functional/serialization/serializable_move_only_function.hpp
+++ b/libs/core/functional/include/hpx/functional/serialization/serializable_move_only_function.hpp
@@ -10,5 +10,5 @@
 #pragma once
 
 #include <hpx/config.hpp>
+#include <hpx/functional/move_only_function.hpp>
 #include <hpx/functional/serialization/detail/serializable_basic_function.hpp>
-#include <hpx/functional/unique_function.hpp>

--- a/libs/core/functional/tests/unit/allocator_test.cpp
+++ b/libs/core/functional/tests/unit/allocator_test.cpp
@@ -81,7 +81,7 @@ static void do_nothing() {}
 
 int main(int, char*[])
 {
-    hpx::util::function_nonser<int(int, int)> f;
+    hpx::function<int(int, int)> f;
     f.assign(plus_int<disable_small_object_optimization>(),
         counting_allocator<int>());
     f.clear();
@@ -110,7 +110,7 @@ int main(int, char*[])
     f.assign(&do_minus, std::allocator<int>());
     f.clear();
 
-    hpx::util::function_nonser<void()> fv;
+    hpx::function<void()> fv;
     alloc_count = 0;
     dealloc_count = 0;
     fv.assign(DoNothing<disable_small_object_optimization>(),
@@ -141,7 +141,7 @@ int main(int, char*[])
     fv.assign(&do_nothing, std::allocator<int>());
     fv.clear();
 
-    hpx::util::function_nonser<void()> fv2;
+    hpx::function<void()> fv2;
     fv.assign(&do_nothing, std::allocator<int>());
     fv2.assign(fv, std::allocator<int>());
 

--- a/libs/core/functional/tests/unit/contains_test.cpp
+++ b/libs/core/functional/tests/unit/contains_test.cpp
@@ -56,7 +56,7 @@ struct Seventeen
 
 static void target_test()
 {
-    hpx::util::function_nonser<int()> f;
+    hpx::function<int()> f;
 
     f = &forty_two;
     HPX_TEST_EQ(*f.target<int (*)()>(), &forty_two);
@@ -74,7 +74,7 @@ static void target_test()
 
 //static void equal_test()
 //{
-//    hpx::util::function_nonser<int()> f;
+//    hpx::function<int()> f;
 //
 //    f = &forty_two;
 //    HPX_TEST(f == &forty_two);
@@ -104,7 +104,7 @@ static void target_test()
 //
 //    HPX_TEST(f.contains(contain_test::ReturnIntFE(17)));
 //
-//    hpx::util::function_nonser<int(void)> g;
+//    hpx::function<int(void)> g;
 //
 //    g = &forty_two;
 //    HPX_TEST(g == &forty_two);
@@ -125,7 +125,7 @@ static void target_test()
 //{
 //    {
 //        ReturnInt ri(17);
-//        hpx::util::function_nonser0<int> f = std::ref(ri);
+//        hpx::function0<int> f = std::ref(ri);
 //
 //        // References and values are equal
 //        HPX_TEST(f == std::ref(ri));
@@ -151,7 +151,7 @@ static void target_test()
 //
 //    {
 //        ReturnInt ri(17);
-//        hpx::util::function_nonser<int(void)> f = std::ref(ri);
+//        hpx::function<int(void)> f = std::ref(ri);
 //
 //        // References and values are equal
 //        HPX_TEST(f == std::ref(ri));

--- a/libs/core/functional/tests/unit/function_args.cpp
+++ b/libs/core/functional/tests/unit/function_args.cpp
@@ -62,7 +62,7 @@ void f_value(counter) {}
 
 void test_by_value()
 {
-    hpx::util::function_nonser<void(counter)> f = f_value;
+    hpx::function<void(counter)> f = f_value;
 
     counter::reset();
 
@@ -81,7 +81,7 @@ void f_lvalue_ref(counter&) {}
 
 void test_by_lvalue_ref()
 {
-    hpx::util::function_nonser<void(counter&)> f = f_lvalue_ref;
+    hpx::function<void(counter&)> f = f_lvalue_ref;
 
     counter::reset();
 
@@ -100,7 +100,7 @@ void f_const_lvalue_ref(counter const&) {}
 
 void test_by_const_lvalue_ref()
 {
-    hpx::util::function_nonser<void(counter const&)> f = f_const_lvalue_ref;
+    hpx::function<void(counter const&)> f = f_const_lvalue_ref;
 
     counter::reset();
 
@@ -119,7 +119,7 @@ void f_rvalue_ref(counter&&) {}
 
 void test_by_rvalue_ref()
 {
-    hpx::util::function_nonser<void(counter &&)> f = f_rvalue_ref;
+    hpx::function<void(counter &&)> f = f_rvalue_ref;
 
     counter::reset();
 

--- a/libs/core/functional/tests/unit/function_arith.cpp
+++ b/libs/core/functional/tests/unit/function_arith.cpp
@@ -29,7 +29,7 @@ struct int_div
 
 int main()
 {
-    hpx::util::function_nonser<double(int x, int y)> f;
+    hpx::function<double(int x, int y)> f;
 
     f = int_div();
     HPX_TEST(f);

--- a/libs/core/functional/tests/unit/function_bind_test.cpp
+++ b/libs/core/functional/tests/unit/function_bind_test.cpp
@@ -28,11 +28,10 @@ int main(int, char*[])
     using hpx::util::placeholders::_1;
     using hpx::util::placeholders::_2;
 
-    hpx::util::function_nonser<unsigned(bool, double)> f1 =
+    hpx::function<unsigned(bool, double)> f1 =
         hpx::util::bind(func_impl, 15, _1, _2);
-    hpx::util::function_nonser<unsigned(double)> f2 =
-        hpx::util::bind(f1, false, _1);
-    hpx::util::function_nonser<unsigned()> f3 = hpx::util::bind(f2, 4.0);
+    hpx::function<unsigned(double)> f2 = hpx::util::bind(f1, false, _1);
+    hpx::function<unsigned()> f3 = hpx::util::bind(f2, 4.0);
 
     HPX_TEST_EQ(f3(), 120u);
 

--- a/libs/core/functional/tests/unit/function_object_size.cpp
+++ b/libs/core/functional/tests/unit/function_object_size.cpp
@@ -13,7 +13,7 @@
 #include <cstdint>
 #include <iostream>
 
-using hpx::util::function;
+using hpx::function;
 
 ///////////////////////////////////////////////////////////////////////////////
 struct small_object

--- a/libs/core/functional/tests/unit/function_ref.cpp
+++ b/libs/core/functional/tests/unit/function_ref.cpp
@@ -110,7 +110,7 @@ struct add_to_obj
 
 static void test_zero_args()
 {
-    typedef hpx::util::function_ref<void()> func_void_type;
+    typedef hpx::function_ref<void()> func_void_type;
 
     write_five_obj five;
     write_three_obj three;
@@ -405,8 +405,8 @@ static void test_zero_args()
 
     // Const vs. non-const
     write_const_1_nonconst_2 one_or_two;
-    const hpx::util::function_ref<void()> v7(one_or_two);
-    hpx::util::function_ref<void()> v8(one_or_two);
+    const hpx::function_ref<void()> v7(one_or_two);
+    hpx::function_ref<void()> v8(one_or_two);
 
     global_int = 0;
     v7();
@@ -417,7 +417,7 @@ static void test_zero_args()
     HPX_TEST_EQ(global_int, 2);
 
     // Test return values
-    typedef hpx::util::function_ref<int()> func_int_type;
+    typedef hpx::function_ref<int()> func_int_type;
     generate_five_obj gen_five;
     generate_three_obj gen_three;
 
@@ -432,7 +432,7 @@ static void test_zero_args()
     HPX_TEST_EQ(i0(), 3);
 
     // Test return values with compatible types
-    typedef hpx::util::function_ref<long()> func_long_type;
+    typedef hpx::function_ref<long()> func_long_type;
     func_long_type i1(gen_five);
 
     HPX_TEST_EQ(i1(), 5);
@@ -448,30 +448,29 @@ static void test_one_arg()
 {
     std::negate<int> neg;
 
-    hpx::util::function_ref<int(int)> f1(neg);
+    hpx::function_ref<int(int)> f1(neg);
     HPX_TEST_EQ(f1(5), -5);
 
-    hpx::util::function_ref<string(string)> id(&identity_str);
+    hpx::function_ref<string(string)> id(&identity_str);
     HPX_TEST_EQ(id("str"), "str");
 
-    hpx::util::function_ref<string(const char*)> id2(&identity_str);
+    hpx::function_ref<string(const char*)> id2(&identity_str);
     HPX_TEST_EQ(id2("foo"), "foo");
 
     add_to_obj add_to(5);
-    hpx::util::function_ref<int(int)> f2(add_to);
+    hpx::function_ref<int(int)> f2(add_to);
     HPX_TEST_EQ(f2(3), 8);
 
-    const hpx::util::function_ref<int(int)> cf2(add_to);
+    const hpx::function_ref<int(int)> cf2(add_to);
     HPX_TEST_EQ(cf2(3), 8);
 }
 
 static void test_two_args()
 {
-    hpx::util::function_ref<string(const string&, const string&)> cat(
-        &string_cat);
+    hpx::function_ref<string(const string&, const string&)> cat(&string_cat);
     HPX_TEST_EQ(cat("str", "ing"), "string");
 
-    hpx::util::function_ref<int(short, short)> sum(&sum_ints);
+    hpx::function_ref<int(short, short)> sum(&sum_ints);
     HPX_TEST_EQ(sum(2, 3), 5);
 }
 
@@ -500,7 +499,7 @@ static void test_ref()
     add_with_throw_on_copy atc;
     try
     {
-        hpx::util::function_ref<int(int, int)> f(std::ref(atc));
+        hpx::function_ref<int(int, int)> f(std::ref(atc));
         HPX_TEST_EQ(f(1, 3), 4);
     }
     catch (std::runtime_error const& /*e*/)
@@ -511,8 +510,8 @@ static void test_ref()
 
 static void test_ptr_ref()
 {
-    typedef hpx::util::function_ref<void()> func_void_type;
-    typedef hpx::util::function_ref<int()> func_int_type;
+    typedef hpx::function_ref<void()> func_void_type;
+    typedef hpx::function_ref<int()> func_int_type;
 
     // Invocation of a function
     void (*void_ptr)() = &write_five;
@@ -575,7 +574,7 @@ struct big_aggregating_structure
 
 static void test_copy_semantics()
 {
-    typedef hpx::util::function_ref<void()> f1_type;
+    typedef hpx::function_ref<void()> f1_type;
 
     big_aggregating_structure obj;
 

--- a/libs/core/functional/tests/unit/function_ref_wrapper.cpp
+++ b/libs/core/functional/tests/unit/function_ref_wrapper.cpp
@@ -27,11 +27,11 @@ struct stateful_type
 int main()
 {
     stateful_type a_function_object;
-    hpx::util::function_nonser<int(int)> f;
+    hpx::function<int(int)> f;
 
     f = std::ref(a_function_object);
     HPX_TEST_EQ(f(42), 42);
-    hpx::util::function_nonser<int(int)> f2(f);
+    hpx::function<int(int)> f2(f);
     HPX_TEST_EQ(f2(42), 42);
 
     return hpx::util::report_errors();

--- a/libs/core/functional/tests/unit/function_target.cpp
+++ b/libs/core/functional/tests/unit/function_target.cpp
@@ -21,13 +21,13 @@ struct foo
 int main()
 {
     {
-        hpx::util::function_nonser<int()> fun = foo();
+        hpx::function<int()> fun = foo();
 
         HPX_TEST(fun.target<foo>() != nullptr);
     }
 
     {
-        hpx::util::function_nonser<int()> fun = foo();
+        hpx::function<int()> fun = foo();
 
         HPX_TEST(fun.target<foo const>() != nullptr);
     }

--- a/libs/core/functional/tests/unit/function_test.cpp
+++ b/libs/core/functional/tests/unit/function_test.cpp
@@ -11,8 +11,8 @@
 
 // For more information, see http://www.boost.org
 
-// NOTE: Warning caused by assignment of hpx::util::function_nonser<float()> to
-// hpx::util::function_nonser<double()> in test_emptiness. Triggered in
+// NOTE: Warning caused by assignment of hpx::function<float()> to
+// hpx::function<double()> in test_emptiness. Triggered in
 // hpx/functional/function.hpp which is included latest by hpx/include/util.hpp.
 #if defined(__clang__)
 #pragma clang diagnostic push
@@ -125,7 +125,7 @@ struct add_to_obj
 
 static void test_zero_args()
 {
-    typedef hpx::util::function_nonser<void()> func_void_type;
+    typedef hpx::function<void()> func_void_type;
 
     write_five_obj five;
     write_three_obj three;
@@ -572,8 +572,8 @@ static void test_zero_args()
 
     // Const vs. non-const
     write_const_1_nonconst_2 one_or_two;
-    const hpx::util::function_nonser<void()> v7(one_or_two);
-    hpx::util::function_nonser<void()> v8(one_or_two);
+    const hpx::function<void()> v7(one_or_two);
+    hpx::function<void()> v8(one_or_two);
 
     global_int = 0;
     v7();
@@ -593,7 +593,7 @@ static void test_zero_args()
     HPX_TEST(v9np.empty());
 
     // Test return values
-    typedef hpx::util::function_nonser<int()> func_int_type;
+    typedef hpx::function<int()> func_int_type;
     generate_five_obj gen_five;
     generate_three_obj gen_three;
 
@@ -611,7 +611,7 @@ static void test_zero_args()
     HPX_TEST(!i0);
 
     // Test return values with compatible types
-    typedef hpx::util::function_nonser<long()> func_long_type;
+    typedef hpx::function<long()> func_long_type;
     func_long_type i1(gen_five);
 
     HPX_TEST_EQ(i1(), 5);
@@ -630,43 +630,42 @@ static void test_one_arg()
 {
     std::negate<int> neg;
 
-    hpx::util::function_nonser<int(int)> f1(neg);
+    hpx::function<int(int)> f1(neg);
     HPX_TEST_EQ(f1(5), -5);
 
-    hpx::util::function_nonser<string(string)> id(&identity_str);
+    hpx::function<string(string)> id(&identity_str);
     HPX_TEST_EQ(id("str"), "str");
 
-    hpx::util::function_nonser<string(const char*)> id2(&identity_str);
+    hpx::function<string(const char*)> id2(&identity_str);
     HPX_TEST_EQ(id2("foo"), "foo");
 
     add_to_obj add_to(5);
-    hpx::util::function_nonser<int(int)> f2(add_to);
+    hpx::function<int(int)> f2(add_to);
     HPX_TEST_EQ(f2(3), 8);
 
-    const hpx::util::function_nonser<int(int)> cf2(add_to);
+    const hpx::function<int(int)> cf2(add_to);
     HPX_TEST_EQ(cf2(3), 8);
 }
 
 static void test_two_args()
 {
-    hpx::util::function_nonser<string(const string&, const string&)> cat(
-        &string_cat);
+    hpx::function<string(const string&, const string&)> cat(&string_cat);
     HPX_TEST_EQ(cat("str", "ing"), "string");
 
-    hpx::util::function_nonser<int(short, short)> sum(&sum_ints);
+    hpx::function<int(short, short)> sum(&sum_ints);
     HPX_TEST_EQ(sum(2, 3), 5);
 }
 
 static void test_emptiness()
 {
-    hpx::util::function_nonser<float()> f1;
+    hpx::function<float()> f1;
     HPX_TEST(f1.empty());
 
-    hpx::util::function_nonser<float()> f2;
+    hpx::function<float()> f2;
     f2 = f1;
     HPX_TEST(f2.empty());
 
-    hpx::util::function_nonser<double()> f3;
+    hpx::function<double()> f3;
     f3 = f2;
     HPX_TEST(f3.empty());
 }
@@ -692,7 +691,7 @@ struct X
 
 static void test_member_functions()
 {
-    hpx::util::function_nonser<int(X*)> f1(&X::twice);
+    hpx::function<int(X*)> f1(&X::twice);
 
     X one(1);
     X five(5);
@@ -700,13 +699,13 @@ static void test_member_functions()
     HPX_TEST_EQ(f1(&one), 2);
     HPX_TEST_EQ(f1(&five), 10);
 
-    hpx::util::function_nonser<int(X*)> f1_2;
+    hpx::function<int(X*)> f1_2;
     f1_2 = &X::twice;
 
     HPX_TEST_EQ(f1_2(&one), 2);
     HPX_TEST_EQ(f1_2(&five), 10);
 
-    hpx::util::function_nonser<int(X&, int)> f2(&X::plus);
+    hpx::function<int(X&, int)> f2(&X::plus);
     HPX_TEST_EQ(f2(one, 3), 4);
     HPX_TEST_EQ(f2(five, 4), 9);
 }
@@ -736,7 +735,7 @@ static void test_ref()
     add_with_throw_on_copy atc;
     try
     {
-        hpx::util::function_nonser<int(int, int)> f(std::ref(atc));
+        hpx::function<int(int, int)> f(std::ref(atc));
         HPX_TEST_EQ(f(1, 3), 4);
     }
     catch (std::runtime_error const& /*e*/)
@@ -749,8 +748,8 @@ static void dummy() {}
 
 static void test_empty_ref()
 {
-    hpx::util::function_nonser<void()> f1;
-    hpx::util::function_nonser<void()> f2(std::ref(f1));
+    hpx::function<void()> f1;
+    hpx::function<void()> f2(std::ref(f1));
 
     try
     {
@@ -776,7 +775,7 @@ static void test_empty_ref()
 
 static void test_exception()
 {
-    hpx::util::function_nonser<int(int, int)> f;
+    hpx::function<int(int, int)> f;
     try
     {
         f(5, 4);
@@ -788,7 +787,7 @@ static void test_exception()
     }
 }
 
-typedef hpx::util::function_nonser<void*(void* reader)> reader_type;
+typedef hpx::function<void*(void* reader)> reader_type;
 typedef std::pair<int, reader_type> mapped_type;
 
 static void test_implicit()
@@ -797,12 +796,12 @@ static void test_implicit()
     m = mapped_type();
 }
 
-static void test_call_obj(hpx::util::function_nonser<int(int, int)> f)
+static void test_call_obj(hpx::function<int(int, int)> f)
 {
     HPX_TEST(!f.empty());
 }
 
-static void test_call_cref(const hpx::util::function_nonser<int(int, int)>& f)
+static void test_call_cref(const hpx::function<int(int, int)>& f)
 {
     HPX_TEST(!f.empty());
 }
@@ -912,7 +911,7 @@ int main(int, char*[])
     test_exception();
     test_implicit();
     test_call();
-    test_move_semantics<hpx::util::function_nonser<void()>>();
+    test_move_semantics<hpx::function<void()>>();
 
     return hpx::util::report_errors();
 }

--- a/libs/core/functional/tests/unit/nothrow_swap.cpp
+++ b/libs/core/functional/tests/unit/nothrow_swap.cpp
@@ -60,8 +60,8 @@ bool MaybeThrowOnCopy::throwOnCopy = false;
 
 int main(int, char*[])
 {
-    hpx::util::function_nonser<int()> f;
-    hpx::util::function_nonser<int()> g;
+    hpx::function<int()> f;
+    hpx::function<int()> g;
 
     MaybeThrowOnCopy::throwOnCopy = false;
     f = MaybeThrowOnCopy(1);

--- a/libs/core/functional/tests/unit/stateless_test.cpp
+++ b/libs/core/functional/tests/unit/stateless_test.cpp
@@ -41,7 +41,7 @@ struct stateless_integer_add
 
 int main(int, char*[])
 {
-    hpx::util::function_nonser<int(int, int)> f;
+    hpx::function<int(int, int)> f;
     f = stateless_integer_add();
 
     return hpx::util::report_errors();

--- a/libs/core/functional/tests/unit/sum_avg.cpp
+++ b/libs/core/functional/tests/unit/sum_avg.cpp
@@ -24,8 +24,7 @@ void do_sum_avg(int values[], int n, int& sum, double& avg)
 
 int main()
 {
-    hpx::util::function_nonser<void(int values[], int n, int& sum, double& avg)>
-        sum_avg;
+    hpx::function<void(int values[], int n, int& sum, double& avg)> sum_avg;
     sum_avg = &do_sum_avg;
 
     return hpx::util::report_errors();

--- a/libs/core/futures/include/hpx/futures/detail/future_data.hpp
+++ b/libs/core/futures/include/hpx/futures/detail/future_data.hpp
@@ -65,7 +65,7 @@ namespace hpx {
 namespace hpx { namespace lcos { namespace detail {
 
     using run_on_completed_error_handler_type =
-        util::function_nonser<void(std::exception_ptr const& e)>;
+        hpx::function<void(std::exception_ptr const& e)>;
     HPX_CORE_EXPORT void set_run_on_completed_error_handler(
         run_on_completed_error_handler_type f);
 
@@ -90,7 +90,7 @@ namespace hpx { namespace lcos { namespace detail {
         future_data_refcnt_base& operator=(future_data_refcnt_base&&) = delete;
 
     public:
-        using completed_callback_type = util::unique_function_nonser<void()>;
+        using completed_callback_type = hpx::move_only_function<void()>;
         using completed_callback_vector_type =
             hpx::detail::small_vector<completed_callback_type, 1>;
 

--- a/libs/core/futures/include/hpx/futures/packaged_task.hpp
+++ b/libs/core/futures/include/hpx/futures/packaged_task.hpp
@@ -8,8 +8,8 @@
 
 #include <hpx/config.hpp>
 #include <hpx/errors/try_catch_exception_ptr.hpp>
+#include <hpx/functional/move_only_function.hpp>
 #include <hpx/functional/traits/is_invocable.hpp>
-#include <hpx/functional/unique_function.hpp>
 #include <hpx/futures/detail/future_data.hpp>
 #include <hpx/futures/promise.hpp>
 #include <hpx/modules/errors.hpp>
@@ -29,7 +29,7 @@ namespace hpx { namespace lcos { namespace local {
     template <typename R, typename... Ts>
     class packaged_task<R(Ts...)>
     {
-        using function_type = util::unique_function_nonser<R(Ts...)>;
+        using function_type = hpx::move_only_function<R(Ts...)>;
 
     public:
         // construction and destruction

--- a/libs/core/futures/src/future_data.cpp
+++ b/libs/core/futures/src/future_data.cpp
@@ -13,7 +13,7 @@
 #include <hpx/errors/try_catch_exception_ptr.hpp>
 #include <hpx/execution_base/this_thread.hpp>
 #include <hpx/functional/deferred_call.hpp>
-#include <hpx/functional/unique_function.hpp>
+#include <hpx/functional/move_only_function.hpp>
 #include <hpx/futures/futures_factory.hpp>
 #include <hpx/modules/errors.hpp>
 #include <hpx/modules/memory.hpp>

--- a/libs/core/include_local/include/hpx/local/functional.hpp
+++ b/libs/core/include_local/include/hpx/local/functional.hpp
@@ -1,4 +1,5 @@
 //  Copyright (c) 2020 ETH Zurich
+//  Copyright (c) 2022 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -13,24 +14,21 @@
 #include <hpx/functional/invoke.hpp>
 #include <hpx/functional/invoke_fused.hpp>
 #include <hpx/functional/mem_fn.hpp>
+#include <hpx/functional/move_only_function.hpp>
 #include <hpx/functional/traits/is_bind_expression.hpp>
 #include <hpx/functional/traits/is_placeholder.hpp>
-#include <hpx/functional/unique_function.hpp>
 #include <hpx/threading_base/annotated_function.hpp>
 #include <hpx/threading_base/scoped_annotation.hpp>
 
 namespace hpx {
+
     using hpx::traits::is_bind_expression;
     using hpx::traits::is_placeholder;
     using hpx::util::bind_back;
     using hpx::util::bind_front;
-    using hpx::util::function;
-    using hpx::util::function_nonser;
     using hpx::util::invoke;
     using hpx::util::invoke_fused;
     using hpx::util::mem_fn;
-    using hpx::util::unique_function;
-    using hpx::util::unique_function_nonser;
 
     namespace placeholders {
         using namespace hpx::util::placeholders;

--- a/libs/core/ini/include/hpx/ini/ini.hpp
+++ b/libs/core/ini/include/hpx/ini/ini.hpp
@@ -37,8 +37,7 @@ namespace hpx { namespace util {
     class HPX_CORE_EXPORT section
     {
     public:
-        typedef util::function_nonser<void(
-            std::string const&, std::string const&)>
+        typedef hpx::function<void(std::string const&, std::string const&)>
             entry_changed_func;
         typedef std::pair<std::string, entry_changed_func> entry_type;
         typedef std::map<std::string, entry_type> entry_map;

--- a/libs/core/ini/src/ini.cpp
+++ b/libs/core/ini/src/ini.cpp
@@ -10,6 +10,8 @@
 
 // System Header Files
 #include <cerrno>
+#include <cstddef>
+#include <cstdint>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
@@ -548,7 +550,7 @@ namespace hpx { namespace util {
 
     template <typename F1, typename F2>
     static HPX_FORCEINLINE
-        util::function_nonser<void(std::string const&, std::string const&)>
+        hpx::function<void(std::string const&, std::string const&)>
         compose_callback(F1&& f1, F2&& f2)
     {
         if (!f1)
@@ -981,28 +983,19 @@ namespace hpx { namespace util {
     }
 
     ///////////////////////////////////////////////////////////////////////////////
-    // explicit instantiation for the correct archive types
-    void serialize(serialization::output_archive& ar,
-        section::entry_type const& data, unsigned int /* version */)
-    {
-        ar << data.first;
-        // do not handle callback function
-    }
-
-    void serialize(serialization::input_archive& ar, section::entry_type& data,
-        unsigned int /* version */)
-    {
-        ar >> data.first;
-        // do not handle callback function
-    }
-
-    ///////////////////////////////////////////////////////////////////////////////
     template <typename Archive>
     void section::save(Archive& ar, const unsigned int /* version */) const
     {
         ar << name_;
         ar << parent_name_;
-        ar << entries_;
+
+        std::uint64_t size = entries_.size();
+        ar << size;
+        for (auto const& val : entries_)
+        {
+            ar << val.first;
+        }
+
         ar << sections_;
     }
 
@@ -1011,7 +1004,20 @@ namespace hpx { namespace util {
     {
         ar >> name_;
         ar >> parent_name_;
-        ar >> entries_;
+
+        std::uint64_t size;
+        ar >> size;    //-V128
+
+        entries_.clear();
+        for (std::size_t i = 0; i < size; ++i)
+        {
+            using value_type = typename entry_map::value_type;
+
+            value_type v;
+            ar >> const_cast<std::string&>(v.first);
+            entries_.insert(entries_.end(), HPX_MOVE(v));
+        }
+
         ar >> sections_;
 
         set_root(this, true);    // make this the current root

--- a/libs/core/init_runtime_local/include/hpx/init_runtime_local/init_runtime_local.hpp
+++ b/libs/core/init_runtime_local/include/hpx/init_runtime_local/init_runtime_local.hpp
@@ -54,7 +54,7 @@ extern char** environ;
 namespace hpx {
     namespace detail {
         HPX_CORE_EXPORT int init_helper(hpx::program_options::variables_map&,
-            util::function_nonser<int(int, char**)> const&);
+            hpx::function<int(int, char**)> const&);
     }
 
     namespace local {
@@ -91,7 +91,7 @@ namespace hpx {
 
             // Utilities to init the thread_pools of the resource partitioner
             using rp_callback_type =
-                hpx::util::function_nonser<void(hpx::resource::partitioner&,
+                hpx::function<void(hpx::resource::partitioner&,
                     hpx::program_options::variables_map const&)>;
         }    // namespace detail
 
@@ -110,14 +110,13 @@ namespace hpx {
 
         namespace detail {
             HPX_CORE_EXPORT int run_or_start(
-                util::function_nonser<int(
+                hpx::function<int(
                     hpx::program_options::variables_map& vm)> const& f,
                 int argc, char** argv, init_params const& params,
                 bool blocking);
 
             inline int init_start_impl(
-                util::function_nonser<int(hpx::program_options::variables_map&)>
-                    f,
+                hpx::function<int(hpx::program_options::variables_map&)> f,
                 int argc, char** argv, init_params const& params, bool blocking)
             {
                 if (argc == 0 || argv == nullptr)
@@ -151,8 +150,8 @@ namespace hpx {
         inline int init(std::function<int(int, char**)> f, int argc,
             char** argv, init_params const& params = init_params())
         {
-            util::function_nonser<int(hpx::program_options::variables_map&)>
-                main_f = hpx::util::bind_back(hpx::detail::init_helper, f);
+            hpx::function<int(hpx::program_options::variables_map&)> main_f =
+                hpx::util::bind_back(hpx::detail::init_helper, f);
             return detail::init_start_impl(
                 HPX_MOVE(main_f), argc, argv, params, true);
         }
@@ -160,8 +159,8 @@ namespace hpx {
         inline int init(std::function<int()> f, int argc, char** argv,
             init_params const& params = init_params())
         {
-            util::function_nonser<int(hpx::program_options::variables_map&)>
-                main_f = hpx::util::bind(f);
+            hpx::function<int(hpx::program_options::variables_map&)> main_f =
+                hpx::util::bind(f);
             return detail::init_start_impl(
                 HPX_MOVE(main_f), argc, argv, params, true);
         }
@@ -169,8 +168,7 @@ namespace hpx {
         inline int init(std::nullptr_t, int argc, char** argv,
             init_params const& params = init_params())
         {
-            util::function_nonser<int(hpx::program_options::variables_map&)>
-                main_f;
+            hpx::function<int(hpx::program_options::variables_map&)> main_f;
             return detail::init_start_impl(
                 HPX_MOVE(main_f), argc, argv, params, true);
         }
@@ -186,8 +184,8 @@ namespace hpx {
         inline bool start(std::function<int(int, char**)> f, int argc,
             char** argv, init_params const& params = init_params())
         {
-            util::function_nonser<int(hpx::program_options::variables_map&)>
-                main_f = hpx::util::bind_back(hpx::detail::init_helper, f);
+            hpx::function<int(hpx::program_options::variables_map&)> main_f =
+                hpx::util::bind_back(hpx::detail::init_helper, f);
             return 0 ==
                 detail::init_start_impl(
                     HPX_MOVE(main_f), argc, argv, params, false);
@@ -196,8 +194,8 @@ namespace hpx {
         inline bool start(std::function<int()> f, int argc, char** argv,
             init_params const& params = init_params())
         {
-            util::function_nonser<int(hpx::program_options::variables_map&)>
-                main_f = hpx::util::bind(f);
+            hpx::function<int(hpx::program_options::variables_map&)> main_f =
+                hpx::util::bind(f);
             return 0 ==
                 detail::init_start_impl(
                     HPX_MOVE(main_f), argc, argv, params, false);
@@ -206,8 +204,7 @@ namespace hpx {
         inline bool start(std::nullptr_t, int argc, char** argv,
             init_params const& params = init_params())
         {
-            util::function_nonser<int(hpx::program_options::variables_map&)>
-                main_f;
+            hpx::function<int(hpx::program_options::variables_map&)> main_f;
             return 0 ==
                 detail::init_start_impl(
                     HPX_MOVE(main_f), argc, argv, params, false);

--- a/libs/core/init_runtime_local/src/init_runtime_local.cpp
+++ b/libs/core/init_runtime_local/src/init_runtime_local.cpp
@@ -72,7 +72,7 @@ namespace hpx {
     namespace detail {
 
         int init_helper(hpx::program_options::variables_map& /*vm*/,
-            util::function_nonser<int(int, char**)> const& f)
+            hpx::function<int(int, char**)> const& f)
         {
             std::string cmdline(
                 hpx::get_config_entry("hpx.reconstructed_cmd_line", ""));
@@ -298,7 +298,7 @@ namespace hpx {
 
             ///////////////////////////////////////////////////////////////////////
             int run(hpx::runtime& rt,
-                util::function_nonser<int(
+                hpx::function<int(
                     hpx::program_options::variables_map& vm)> const& f,
                 hpx::program_options::variables_map& vm,
                 startup_function_type startup, shutdown_function_type shutdown)
@@ -317,7 +317,7 @@ namespace hpx {
             }
 
             int start(hpx::runtime& rt,
-                util::function_nonser<int(
+                hpx::function<int(
                     hpx::program_options::variables_map& vm)> const& f,
                 hpx::program_options::variables_map& vm,
                 startup_function_type startup, shutdown_function_type shutdown)
@@ -433,7 +433,7 @@ namespace hpx {
 
             ///////////////////////////////////////////////////////////////////////
             int run_or_start(
-                util::function_nonser<int(
+                hpx::function<int(
                     hpx::program_options::variables_map& vm)> const& f,
                 int argc, char** argv, init_params const& params, bool blocking)
             {

--- a/libs/core/lcos_local/include/hpx/lcos_local/composable_guard.hpp
+++ b/libs/core/lcos_local/include/hpx/lcos_local/composable_guard.hpp
@@ -83,7 +83,7 @@
 #include <hpx/config.hpp>
 #include <hpx/assert.hpp>
 #include <hpx/functional/deferred_call.hpp>
-#include <hpx/functional/unique_function.hpp>
+#include <hpx/functional/move_only_function.hpp>
 #include <hpx/futures/packaged_task.hpp>
 
 #include <atomic>
@@ -128,7 +128,7 @@ namespace hpx { namespace lcos { namespace local {
 
         HPX_CORE_EXPORT void free(guard_task* task);
 
-        typedef util::unique_function_nonser<void()> guard_function;
+        typedef hpx::move_only_function<void()> guard_function;
     }    // namespace detail
 
     class guard : public detail::debug_object

--- a/libs/core/lcos_local/include/hpx/lcos_local/conditional_trigger.hpp
+++ b/libs/core/lcos_local/include/hpx/lcos_local/conditional_trigger.hpp
@@ -64,6 +64,6 @@ namespace hpx { namespace lcos { namespace local {
 
     private:
         lcos::local::promise<void> promise_;
-        util::function_nonser<bool()> cond_;
+        hpx::function<bool()> cond_;
     };
 }}}    // namespace hpx::lcos::local

--- a/libs/core/lock_registration/include/hpx/lock_registration/detail/register_locks.hpp
+++ b/libs/core/lock_registration/include/hpx/lock_registration/detail/register_locks.hpp
@@ -81,7 +81,7 @@ namespace hpx { namespace util {
     HPX_CORE_EXPORT void ignore_all_locks();
     HPX_CORE_EXPORT void reset_ignored_all();
 
-    using registered_locks_error_handler_type = util::function_nonser<void()>;
+    using registered_locks_error_handler_type = hpx::function<void()>;
 
     /// Sets a handler which gets called when verifying that no locks are held
     /// fails. Can be used to print information at the point of failure such as
@@ -89,7 +89,7 @@ namespace hpx { namespace util {
     HPX_CORE_EXPORT void set_registered_locks_error_handler(
         registered_locks_error_handler_type);
 
-    using register_locks_predicate_type = util::function_nonser<bool()>;
+    using register_locks_predicate_type = hpx::function<bool()>;
 
     /// Sets a predicate which gets called each time a lock is registered,
     /// unregistered, or when locks are verified. If the predicate returns

--- a/libs/core/plugin/include/hpx/plugin/plugin_factory.hpp
+++ b/libs/core/plugin/include/hpx/plugin/plugin_factory.hpp
@@ -113,8 +113,7 @@ namespace hpx { namespace util { namespace plugin {
         get_abstract_factory(dll const& d, std::string const& class_name,
             std::string const& base_name, error_code& ec = throws)
         {
-            typedef hpx::util::function_nonser<void(get_plugins_list_type)>
-                DeleterType;
+            typedef hpx::function<void(get_plugins_list_type)> DeleterType;
 
             std::string plugin_entry(HPX_PLUGIN_SYMBOLS_PREFIX_DYNAMIC_STR
                 "_exported_plugins_list_");
@@ -148,8 +147,7 @@ namespace hpx { namespace util { namespace plugin {
             std::string const& base_name, std::vector<std::string>& names,
             error_code& ec = throws)
         {
-            typedef hpx::util::function_nonser<void(get_plugins_list_type)>
-                DeleterType;
+            typedef hpx::function<void(get_plugins_list_type)> DeleterType;
 
             std::string plugin_entry(HPX_PLUGIN_SYMBOLS_PREFIX_DYNAMIC_STR
                 "_exported_plugins_list_");

--- a/libs/core/resource_partitioner/include/hpx/resource_partitioner/detail/partitioner.hpp
+++ b/libs/core/resource_partitioner/include/hpx/resource_partitioner/detail/partitioner.hpp
@@ -172,9 +172,9 @@ namespace hpx { namespace resource { namespace detail {
         void unassign_pu(std::string const& pool_name, std::size_t virt_core);
 
         std::size_t shrink_pool(std::string const& pool_name,
-            util::function_nonser<void(std::size_t)> const& remove_pu);
+            hpx::function<void(std::size_t)> const& remove_pu);
         std::size_t expand_pool(std::string const& pool_name,
-            util::function_nonser<void(std::size_t)> const& add_pu);
+            hpx::function<void(std::size_t)> const& add_pu);
 
         void set_default_pool_name(const std::string& name)
         {

--- a/libs/core/resource_partitioner/include/hpx/resource_partitioner/partitioner_fwd.hpp
+++ b/libs/core/resource_partitioner/include/hpx/resource_partitioner/partitioner_fwd.hpp
@@ -50,7 +50,7 @@ namespace hpx { namespace resource {
     };
 
     using scheduler_function =
-        util::function_nonser<std::unique_ptr<hpx::threads::thread_pool_base>(
+        hpx::function<std::unique_ptr<hpx::threads::thread_pool_base>(
             hpx::threads::thread_pool_init_parameters,
             hpx::threads::policies::thread_queue_init_parameters)>;
 

--- a/libs/core/resource_partitioner/src/detail_partitioner.cpp
+++ b/libs/core/resource_partitioner/src/detail_partitioner.cpp
@@ -910,7 +910,7 @@ namespace hpx { namespace resource { namespace detail {
     }
 
     std::size_t partitioner::shrink_pool(std::string const& pool_name,
-        util::function_nonser<void(std::size_t)> const& remove_pu)
+        hpx::function<void(std::size_t)> const& remove_pu)
     {
         if (!(mode_ & mode_allow_dynamic_pools))
         {
@@ -955,7 +955,7 @@ namespace hpx { namespace resource { namespace detail {
     }
 
     std::size_t partitioner::expand_pool(std::string const& pool_name,
-        util::function_nonser<void(std::size_t)> const& add_pu)
+        hpx::function<void(std::size_t)> const& add_pu)
     {
         if (!(mode_ & mode_allow_dynamic_pools))
         {

--- a/libs/core/runtime_local/include/hpx/runtime_local/config_entry.hpp
+++ b/libs/core/runtime_local/include/hpx/runtime_local/config_entry.hpp
@@ -31,6 +31,6 @@ namespace hpx {
 
     /// Set the string value of a configuration entry given by \p key.
     HPX_CORE_EXPORT void set_config_entry_callback(std::string const& key,
-        util::function_nonser<void(
-            std::string const&, std::string const&)> const& callback);
+        hpx::function<void(std::string const&, std::string const&)> const&
+            callback);
 }    // namespace hpx

--- a/libs/core/runtime_local/include/hpx/runtime_local/interval_timer.hpp
+++ b/libs/core/runtime_local/include/hpx/runtime_local/interval_timer.hpp
@@ -41,13 +41,11 @@ namespace hpx { namespace util { namespace detail {
 
     public:
         interval_timer();
-        interval_timer(util::function_nonser<bool()> const& f,
-            std::int64_t microsecs, std::string const& description,
-            bool pre_shutdown);
-        interval_timer(util::function_nonser<bool()> const& f,
-            util::function_nonser<void()> const& on_term,
-            std::int64_t microsecs, std::string const& description,
-            bool pre_shutdown);
+        interval_timer(hpx::function<bool()> const& f, std::int64_t microsecs,
+            std::string const& description, bool pre_shutdown);
+        interval_timer(hpx::function<bool()> const& f,
+            hpx::function<void()> const& on_term, std::int64_t microsecs,
+            std::string const& description, bool pre_shutdown);
 
         ~interval_timer();
 
@@ -81,10 +79,9 @@ namespace hpx { namespace util { namespace detail {
 
     private:
         mutable mutex_type mtx_;
-        util::function_nonser<bool()> f_;    ///< function to call
-        util::function_nonser<void()>
-            on_term_;               ///< function to call on termination
-        std::int64_t microsecs_;    ///< time interval
+        hpx::function<bool()> f_;          ///< function to call
+        hpx::function<void()> on_term_;    ///< function to call on termination
+        std::int64_t microsecs_;           ///< time interval
         threads::thread_id_ref_type
             id_;    ///< id of currently scheduled thread
         threads::thread_id_ref_type
@@ -109,19 +106,17 @@ namespace hpx { namespace util {
 
     public:
         interval_timer();
-        interval_timer(util::function_nonser<bool()> const& f,
-            std::int64_t microsecs, std::string const& description = "",
-            bool pre_shutdown = false);
-        interval_timer(util::function_nonser<bool()> const& f,
-            util::function_nonser<void()> const& on_term,
-            std::int64_t microsecs, std::string const& description = "",
-            bool pre_shutdown = false);
+        interval_timer(hpx::function<bool()> const& f, std::int64_t microsecs,
+            std::string const& description = "", bool pre_shutdown = false);
+        interval_timer(hpx::function<bool()> const& f,
+            hpx::function<void()> const& on_term, std::int64_t microsecs,
+            std::string const& description = "", bool pre_shutdown = false);
 
-        interval_timer(util::function_nonser<bool()> const& f,
+        interval_timer(hpx::function<bool()> const& f,
             hpx::chrono::steady_duration const& rel_time,
             char const* description = "", bool pre_shutdown = false);
-        interval_timer(util::function_nonser<bool()> const& f,
-            util::function_nonser<void()> const& on_term,
+        interval_timer(hpx::function<bool()> const& f,
+            hpx::function<void()> const& on_term,
             hpx::chrono::steady_duration const& rel_time,
             char const* description = "", bool pre_shutdown = false);
 

--- a/libs/core/runtime_local/include/hpx/runtime_local/pool_timer.hpp
+++ b/libs/core/runtime_local/include/hpx/runtime_local/pool_timer.hpp
@@ -30,8 +30,8 @@ namespace hpx { namespace util {
     public:
         pool_timer();
 
-        pool_timer(util::function_nonser<bool()> const& f,
-            util::function_nonser<void()> const& on_term,
+        pool_timer(hpx::function<bool()> const& f,
+            hpx::function<void()> const& on_term,
             std::string const& description = "", bool pre_shutdown = true);
 
         ~pool_timer();

--- a/libs/core/runtime_local/include/hpx/runtime_local/runtime_local.hpp
+++ b/libs/core/runtime_local/include/hpx/runtime_local/runtime_local.hpp
@@ -98,7 +98,7 @@ namespace hpx {
         virtual ~runtime();
 
         /// \brief Manage list of functions to call on exit
-        void on_exit(util::function_nonser<void()> const& f);
+        void on_exit(hpx::function<void()> const& f);
 
         /// \brief Manage runtime 'stopped' state
         void starting();
@@ -146,8 +146,7 @@ namespace hpx {
         /// \returns          This function will return the value as returned
         ///                   as the result of the invocation of the function
         ///                   object given by the parameter \p func.
-        virtual int run(
-            util::function_nonser<hpx_main_function_type> const& func);
+        virtual int run(hpx::function<hpx_main_function_type> const& func);
 
         /// \brief Run the HPX runtime system, initially use the given number
         ///        of (OS) threads in the thread-manager and block waiting for
@@ -177,8 +176,7 @@ namespace hpx {
         ///                   return the value as returned as the result of the
         ///                   invocation of the function object given by the
         ///                   parameter \p func. Otherwise it will return zero.
-        virtual int start(
-            util::function_nonser<hpx_main_function_type> const& func,
+        virtual int start(hpx::function<hpx_main_function_type> const& func,
             bool blocking = false);
 
         /// \brief Start the runtime system
@@ -355,8 +353,9 @@ namespace hpx {
             std::string const& label) const;
 
         /// Enumerate all OS threads that have registered with the runtime.
-        virtual bool enumerate_os_threads(util::function_nonser<bool(
-                runtime_local::os_thread_data const&)> const& f) const;
+        virtual bool enumerate_os_threads(
+            hpx::function<bool(runtime_local::os_thread_data const&)> const& f)
+            const;
 
         notification_policy_type::on_startstop_type on_start_func() const;
         notification_policy_type::on_startstop_type on_stop_func() const;
@@ -397,14 +396,14 @@ namespace hpx {
         void deinit_global_data();
 
         threads::thread_result_type run_helper(
-            util::function_nonser<runtime::hpx_main_function_type> const& func,
+            hpx::function<runtime::hpx_main_function_type> const& func,
             int& result, bool call_startup_functions);
 
         void wait_helper(
             std::mutex& mtx, std::condition_variable& cond, bool& running);
 
         // list of functions to call on exit
-        using on_exit_type = std::vector<util::function_nonser<void()>>;
+        using on_exit_type = std::vector<hpx::function<void()>>;
         on_exit_type on_exit_functions_;
         mutable std::mutex mtx_;
 

--- a/libs/core/runtime_local/include/hpx/runtime_local/runtime_local_fwd.hpp
+++ b/libs/core/runtime_local/include/hpx/runtime_local/runtime_local_fwd.hpp
@@ -53,14 +53,14 @@ namespace hpx {
 
     /// Enumerate all OS threads that have registered with the runtime.
     HPX_CORE_EXPORT bool enumerate_os_threads(
-        util::function_nonser<bool(os_thread_data const&)> const& f);
+        hpx::function<bool(os_thread_data const&)> const& f);
 
     /// Return the runtime instance number associated with the runtime instance
     /// the current thread is running in.
     HPX_CORE_EXPORT std::size_t get_runtime_instance_number();
 
     /// Register a function to be called during system shutdown
-    HPX_CORE_EXPORT bool register_on_exit(util::function_nonser<void()> const&);
+    HPX_CORE_EXPORT bool register_on_exit(hpx::function<void()> const&);
 
     /// \cond NOINTERNAL
     namespace util {

--- a/libs/core/runtime_local/include/hpx/runtime_local/shutdown_function.hpp
+++ b/libs/core/runtime_local/include/hpx/runtime_local/shutdown_function.hpp
@@ -10,12 +10,12 @@
 #pragma once
 
 #include <hpx/config.hpp>
-#include <hpx/functional/unique_function.hpp>
+#include <hpx/functional/move_only_function.hpp>
 
 namespace hpx {
     /// The type of a function which is registered to be executed as a
     /// shutdown or pre-shutdown function.
-    typedef util::unique_function_nonser<void()> shutdown_function_type;
+    typedef hpx::move_only_function<void()> shutdown_function_type;
 
     /// \brief Add a function to be executed by a HPX thread during
     /// \a hpx::finalize() but guaranteed before any shutdown function is

--- a/libs/core/runtime_local/include/hpx/runtime_local/startup_function.hpp
+++ b/libs/core/runtime_local/include/hpx/runtime_local/startup_function.hpp
@@ -10,13 +10,13 @@
 #pragma once
 
 #include <hpx/config.hpp>
-#include <hpx/functional/unique_function.hpp>
+#include <hpx/functional/move_only_function.hpp>
 
 namespace hpx {
     ///////////////////////////////////////////////////////////////////////////
     /// The type of a function which is registered to be executed as a
     /// startup or pre-startup function.
-    typedef util::unique_function_nonser<void()> startup_function_type;
+    typedef hpx::move_only_function<void()> startup_function_type;
 
     ///////////////////////////////////////////////////////////////////////////
     /// \brief Add a function to be executed by a HPX thread before hpx_main

--- a/libs/core/runtime_local/include/hpx/runtime_local/thread_mapper.hpp
+++ b/libs/core/runtime_local/include/hpx/runtime_local/thread_mapper.hpp
@@ -37,8 +37,7 @@ namespace hpx { namespace util {
     namespace detail {
 
         // type for callback function invoked when thread is unregistered
-        using thread_mapper_callback_type =
-            util::function_nonser<bool(std::uint32_t)>;
+        using thread_mapper_callback_type = hpx::function<bool(std::uint32_t)>;
 
         // thread-specific data
         class HPX_CORE_EXPORT os_thread_data
@@ -139,7 +138,7 @@ namespace hpx { namespace util {
 
         // enumerate all registered OS threads
         bool enumerate_os_threads(
-            util::function_nonser<bool(os_thread_data const&)> const& f) const;
+            hpx::function<bool(os_thread_data const&)> const& f) const;
 
         // retrieve all data stored for a given thread
         os_thread_data get_os_thread_data(std::string const& label) const;

--- a/libs/core/runtime_local/include/hpx/runtime_local/thread_pool_helpers.hpp
+++ b/libs/core/runtime_local/include/hpx/runtime_local/thread_pool_helpers.hpp
@@ -101,6 +101,6 @@ namespace hpx { namespace threads {
     /// \param state    [in] This specifies the thread-state for which the
     ///                 threads should be enumerated.
     HPX_CORE_EXPORT bool enumerate_threads(
-        util::function_nonser<bool(thread_id_type)> const& f,
+        hpx::function<bool(thread_id_type)> const& f,
         thread_schedule_state state = thread_schedule_state::unknown);
 }}    // namespace hpx::threads

--- a/libs/core/runtime_local/src/interval_timer.cpp
+++ b/libs/core/runtime_local/src/interval_timer.cpp
@@ -35,7 +35,7 @@ namespace hpx { namespace util { namespace detail {
     {
     }
 
-    interval_timer::interval_timer(util::function_nonser<bool()> const& f,
+    interval_timer::interval_timer(hpx::function<bool()> const& f,
         std::int64_t microsecs, std::string const& description,
         bool pre_shutdown)
       : f_(f)
@@ -52,8 +52,8 @@ namespace hpx { namespace util { namespace detail {
     {
     }
 
-    interval_timer::interval_timer(util::function_nonser<bool()> const& f,
-        util::function_nonser<void()> const& on_term, std::int64_t microsecs,
+    interval_timer::interval_timer(hpx::function<bool()> const& f,
+        hpx::function<void()> const& on_term, std::int64_t microsecs,
         std::string const& description, bool pre_shutdown)
       : f_(f)
       , on_term_(on_term)
@@ -349,7 +349,7 @@ namespace hpx { namespace util {
     interval_timer::interval_timer() {}    // -V730
 
     interval_timer::interval_timer(    // -V730
-        util::function_nonser<bool()> const& f, std::int64_t microsecs,
+        hpx::function<bool()> const& f, std::int64_t microsecs,
         std::string const& description, bool pre_shutdown)
       : timer_(std::make_shared<detail::interval_timer>(
             f, microsecs, description, pre_shutdown))
@@ -357,16 +357,16 @@ namespace hpx { namespace util {
     }
 
     interval_timer::interval_timer(    // -V730
-        util::function_nonser<bool()> const& f,
-        util::function_nonser<void()> const& on_term, std::int64_t microsecs,
-        std::string const& description, bool pre_shutdown)
+        hpx::function<bool()> const& f, hpx::function<void()> const& on_term,
+        std::int64_t microsecs, std::string const& description,
+        bool pre_shutdown)
       : timer_(std::make_shared<detail::interval_timer>(
             f, on_term, microsecs, description, pre_shutdown))
     {
     }
 
     interval_timer::interval_timer(    // -V730
-        util::function_nonser<bool()> const& f,
+        hpx::function<bool()> const& f,
         hpx::chrono::steady_duration const& rel_time, char const* description,
         bool pre_shutdown)
       : timer_(std::make_shared<detail::interval_timer>(
@@ -375,8 +375,7 @@ namespace hpx { namespace util {
     }
 
     interval_timer::interval_timer(    // -V730
-        util::function_nonser<bool()> const& f,
-        util::function_nonser<void()> const& on_term,
+        hpx::function<bool()> const& f, hpx::function<void()> const& on_term,
         hpx::chrono::steady_duration const& rel_time, char const* description,
         bool pre_shutdown)
       : timer_(std::make_shared<detail::interval_timer>(f, on_term,

--- a/libs/core/runtime_local/src/pool_timer.cpp
+++ b/libs/core/runtime_local/src/pool_timer.cpp
@@ -38,8 +38,8 @@ namespace hpx { namespace util { namespace detail {
     public:
         pool_timer();
 
-        pool_timer(util::function_nonser<bool()> const& f,
-            util::function_nonser<void()> const& on_term,
+        pool_timer(hpx::function<bool()> const& f,
+            hpx::function<void()> const& on_term,
             std::string const& description, bool pre_shutdown);
 
         ~pool_timer();
@@ -66,9 +66,8 @@ namespace hpx { namespace util { namespace detail {
             asio::basic_waitable_timer<std::chrono::steady_clock>;
 
         mutable mutex_type mtx_;
-        util::function_nonser<bool()> f_;    ///< function to call
-        util::function_nonser<void()>
-            on_term_;                ///< function to call on termination
+        hpx::function<bool()> f_;          ///< function to call
+        hpx::function<void()> on_term_;    ///< function to call on termination
         std::string description_;    ///< description of this interval timer
 
         bool pre_shutdown_;     ///< execute termination during pre-shutdown
@@ -91,9 +90,9 @@ namespace hpx { namespace util { namespace detail {
     {
     }
 
-    pool_timer::pool_timer(util::function_nonser<bool()> const& f,
-        util::function_nonser<void()> const& on_term,
-        std::string const& description, bool pre_shutdown)
+    pool_timer::pool_timer(hpx::function<bool()> const& f,
+        hpx::function<void()> const& on_term, std::string const& description,
+        bool pre_shutdown)
       : f_(f)
       , on_term_(on_term)
       , description_(description)
@@ -210,9 +209,9 @@ namespace hpx { namespace util { namespace detail {
 namespace hpx { namespace util {
     pool_timer::pool_timer() {}
 
-    pool_timer::pool_timer(util::function_nonser<bool()> const& f,
-        util::function_nonser<void()> const& on_term,
-        std::string const& description, bool pre_shutdown)
+    pool_timer::pool_timer(hpx::function<bool()> const& f,
+        hpx::function<void()> const& on_term, std::string const& description,
+        bool pre_shutdown)
       : timer_(std::make_shared<detail::pool_timer>(
             f, on_term, description, pre_shutdown))
     {

--- a/libs/core/runtime_local/src/runtime_local.cpp
+++ b/libs/core/runtime_local/src/runtime_local.cpp
@@ -459,7 +459,7 @@ namespace hpx {
         resource::detail::delete_partitioner();
     }
 
-    void runtime::on_exit(util::function_nonser<void()> const& f)
+    void runtime::on_exit(hpx::function<void()> const& f)
     {
         std::lock_guard<std::mutex> l(mtx_);
         on_exit_functions_.push_back(f);
@@ -474,7 +474,7 @@ namespace hpx {
     {
         state_.store(state_stopped);
 
-        using value_type = util::function_nonser<void()>;
+        using value_type = hpx::function<void()>;
 
         std::lock_guard<std::mutex> l(mtx_);
         for (value_type const& f : on_exit_functions_)
@@ -771,7 +771,7 @@ namespace hpx {
 
     /// Enumerate all OS threads that have registered with the runtime.
     bool enumerate_os_threads(
-        util::function_nonser<bool(os_thread_data const&)> const& f)
+        hpx::function<bool(os_thread_data const&)> const& f)
     {
         return get_runtime().enumerate_os_threads(f);
     }
@@ -810,7 +810,7 @@ namespace hpx {
         get_runtime().get_thread_manager().report_error(num_thread, e);
     }
 
-    bool register_on_exit(util::function_nonser<void()> const& f)
+    bool register_on_exit(hpx::function<void()> const& f)
     {
         runtime* rt = get_runtime_ptr();
         if (nullptr == rt)
@@ -864,8 +864,8 @@ namespace hpx {
     }
 
     void set_config_entry_callback(std::string const& key,
-        util::function_nonser<void(
-            std::string const&, std::string const&)> const& callback)
+        hpx::function<void(std::string const&, std::string const&)> const&
+            callback)
     {
         if (get_runtime_ptr() != nullptr)
         {
@@ -1278,8 +1278,8 @@ namespace hpx {
     }    // namespace detail
 
     threads::thread_result_type runtime::run_helper(
-        util::function_nonser<runtime::hpx_main_function_type> const& func,
-        int& result, bool call_startup)
+        hpx::function<runtime::hpx_main_function_type> const& func, int& result,
+        bool call_startup)
     {
         bool caught_exception = false;
         try
@@ -1353,8 +1353,7 @@ namespace hpx {
     }
 
     int runtime::start(
-        util::function_nonser<hpx_main_function_type> const& func,
-        bool blocking)
+        hpx::function<hpx_main_function_type> const& func, bool blocking)
     {
 #if defined(_WIN64) && defined(HPX_DEBUG) &&                                   \
     !defined(HPX_HAVE_FIBER_BASED_COROUTINES)
@@ -1423,7 +1422,7 @@ namespace hpx {
 
     int runtime::start(bool blocking)
     {
-        util::function_nonser<hpx_main_function_type> empty_main;
+        hpx::function<hpx_main_function_type> empty_main;
         return start(empty_main, blocking);
     }
 
@@ -1725,7 +1724,7 @@ namespace hpx {
     }
 
     ///////////////////////////////////////////////////////////////////////////
-    int runtime::run(util::function_nonser<hpx_main_function_type> const& func)
+    int runtime::run(hpx::function<hpx_main_function_type> const& func)
     {
         // start the main thread function
         start(func);
@@ -1968,7 +1967,7 @@ namespace hpx {
 
     /// Enumerate all OS threads that have registered with the runtime.
     bool runtime::enumerate_os_threads(
-        util::function_nonser<bool(os_thread_data const&)> const& f) const
+        hpx::function<bool(os_thread_data const&)> const& f) const
     {
         return thread_support_->enumerate_os_threads(f);
     }

--- a/libs/core/runtime_local/src/thread_mapper.cpp
+++ b/libs/core/runtime_local/src/thread_mapper.cpp
@@ -285,7 +285,7 @@ namespace hpx { namespace util {
     }
 
     bool thread_mapper::enumerate_os_threads(
-        util::function_nonser<bool(os_thread_data const&)> const& f) const
+        hpx::function<bool(os_thread_data const&)> const& f) const
     {
         std::lock_guard<mutex_type> m(mtx_);
         for (auto const& tinfo : thread_map_)

--- a/libs/core/runtime_local/src/thread_pool_helpers.cpp
+++ b/libs/core/runtime_local/src/thread_pool_helpers.cpp
@@ -94,7 +94,7 @@ namespace hpx { namespace threads {
         return get_thread_manager().get_idle_core_mask();
     }
 
-    bool enumerate_threads(util::function_nonser<bool(thread_id_type)> const& f,
+    bool enumerate_threads(hpx::function<bool(thread_id_type)> const& f,
         thread_schedule_state state)
     {
         return get_thread_manager().enumerate_threads(f, state);

--- a/libs/core/schedulers/include/hpx/schedulers/local_queue_scheduler.hpp
+++ b/libs/core/schedulers/include/hpx/schedulers/local_queue_scheduler.hpp
@@ -634,8 +634,7 @@ namespace hpx { namespace threads { namespace policies {
 
         ///////////////////////////////////////////////////////////////////////
         // Enumerate matching threads from all queues
-        bool enumerate_threads(
-            util::function_nonser<bool(thread_id_type)> const& f,
+        bool enumerate_threads(hpx::function<bool(thread_id_type)> const& f,
             thread_schedule_state state =
                 thread_schedule_state::unknown) const override
         {

--- a/libs/core/schedulers/include/hpx/schedulers/queue_holder_numa.hpp
+++ b/libs/core/schedulers/include/hpx/schedulers/queue_holder_numa.hpp
@@ -244,8 +244,7 @@ namespace hpx { namespace threads { namespace policies {
         }
 
         // ----------------------------------------------------------------
-        bool enumerate_threads(
-            util::function_nonser<bool(thread_id_type)> const& f,
+        bool enumerate_threads(hpx::function<bool(thread_id_type)> const& f,
             thread_schedule_state state) const
         {
             bool result = true;

--- a/libs/core/schedulers/include/hpx/schedulers/queue_holder_thread.hpp
+++ b/libs/core/schedulers/include/hpx/schedulers/queue_holder_thread.hpp
@@ -937,8 +937,7 @@ namespace hpx { namespace threads { namespace policies {
         }
 
         // ------------------------------------------------------------
-        bool enumerate_threads(
-            util::function_nonser<bool(thread_id_type)> const& f,
+        bool enumerate_threads(hpx::function<bool(thread_id_type)> const& f,
             thread_schedule_state state = thread_schedule_state::unknown) const
         {
             std::uint64_t count = thread_map_count_.data_;

--- a/libs/core/schedulers/include/hpx/schedulers/shared_priority_queue_scheduler.hpp
+++ b/libs/core/schedulers/include/hpx/schedulers/shared_priority_queue_scheduler.hpp
@@ -456,10 +456,10 @@ namespace hpx { namespace threads { namespace policies {
         bool steal_by_function(std::size_t domain, std::size_t q_index,
             bool steal_numa, bool steal_core, thread_holder_type* origin,
             T& var, const char* prefix,
-            util::function_nonser<bool(
+            hpx::function<bool(
                 std::size_t, std::size_t, thread_holder_type*, T&, bool, bool)>
                 operation_HP,
-            util::function_nonser<bool(
+            hpx::function<bool(
                 std::size_t, std::size_t, thread_holder_type*, T&, bool, bool)>
                 operation)
         {
@@ -932,8 +932,7 @@ namespace hpx { namespace threads { namespace policies {
 
         //---------------------------------------------------------------------
         // Enumerate matching threads from all queues
-        bool enumerate_threads(
-            util::function_nonser<bool(thread_id_type)> const& f,
+        bool enumerate_threads(hpx::function<bool(thread_id_type)> const& f,
             thread_schedule_state state =
                 thread_schedule_state::unknown) const override
         {

--- a/libs/core/schedulers/include/hpx/schedulers/thread_queue.hpp
+++ b/libs/core/schedulers/include/hpx/schedulers/thread_queue.hpp
@@ -936,8 +936,7 @@ namespace hpx { namespace threads { namespace policies {
             }
         }
 
-        bool enumerate_threads(
-            util::function_nonser<bool(thread_id_type)> const& f,
+        bool enumerate_threads(hpx::function<bool(thread_id_type)> const& f,
             thread_schedule_state state = thread_schedule_state::unknown) const
         {
             std::uint64_t count = thread_map_count_;

--- a/libs/core/serialization/include/hpx/serialization/map.hpp
+++ b/libs/core/serialization/include/hpx/serialization/map.hpp
@@ -90,8 +90,7 @@ namespace hpx::serialization {
 #if !defined(HPX_SERIALIZATION_HAVE_ALL_TYPES_ARE_BITWISE_SERIALIZABLE)
             if (ar.disable_array_optimization() || ar.endianess_differs())
             {
-                ar << t.first;
-                ar << t.second;
+                ar << t.first << t.second;
                 return;
             }
 #else
@@ -102,8 +101,7 @@ namespace hpx::serialization {
         }
         else
         {
-            ar << t.first;
-            ar << t.second;
+            ar << t.first << t.second;
         }
     }
 

--- a/libs/core/serialization/include/hpx/serialization/std_tuple.hpp
+++ b/libs/core/serialization/include/hpx/serialization/std_tuple.hpp
@@ -1,5 +1,4 @@
 //  Copyright (c) 2011-2013 Thomas Heller
-//  Copyright (c) 2011-2020 Hartmut Kaiser
 //  Copyright (c) 2013-2015 Agustin Berge
 //  Copyright (c) 2019 Mikael Simberg
 //  Copyright (c) 2020-2021 Hartmut Kaiser

--- a/libs/core/static_reinit/include/hpx/static_reinit/static_reinit.hpp
+++ b/libs/core/static_reinit/include/hpx/static_reinit/static_reinit.hpp
@@ -15,9 +15,8 @@ namespace hpx { namespace util {
     // the runtime system is about to start and after the runtime system has
     // been terminated. This is used to initialize/reinitialize all
     // singleton instances.
-    HPX_CORE_EXPORT void reinit_register(
-        util::function_nonser<void()> const& construct,
-        util::function_nonser<void()> const& destruct);
+    HPX_CORE_EXPORT void reinit_register(hpx::function<void()> const& construct,
+        hpx::function<void()> const& destruct);
 
     // Invoke all globally registered construction functions
     HPX_CORE_EXPORT void reinit_construct();

--- a/libs/core/static_reinit/src/static_reinit.cpp
+++ b/libs/core/static_reinit/src/static_reinit.cpp
@@ -23,8 +23,8 @@ namespace hpx { namespace util {
         // register_functions function is called from within std::call_once
         typedef util::spinlock mutex_type;
 
-        typedef util::function_nonser<void()> construct_type;
-        typedef util::function_nonser<void()> destruct_type;
+        typedef hpx::function<void()> construct_type;
+        typedef hpx::function<void()> destruct_type;
 
         typedef std::pair<construct_type, destruct_type> value_type;
         typedef std::vector<value_type> reinit_functions_type;
@@ -74,8 +74,8 @@ namespace hpx { namespace util {
     // the runtime system is about to start and after the runtime system has
     // been terminated. This is used to initialize/reinitialize all
     // singleton instances.
-    void reinit_register(util::function_nonser<void()> const& construct,
-        util::function_nonser<void()> const& destruct)
+    void reinit_register(hpx::function<void()> const& construct,
+        hpx::function<void()> const& destruct)
     {
         reinit_functions_storage::get().register_functions(construct, destruct);
     }

--- a/libs/core/synchronization/include/hpx/synchronization/async_rw_mutex.hpp
+++ b/libs/core/synchronization/include/hpx/synchronization/async_rw_mutex.hpp
@@ -13,7 +13,7 @@
 #include <hpx/execution_base/operation_state.hpp>
 #include <hpx/execution_base/receiver.hpp>
 #include <hpx/execution_base/sender.hpp>
-#include <hpx/functional/unique_function.hpp>
+#include <hpx/functional/move_only_function.hpp>
 #include <hpx/synchronization/mutex.hpp>
 
 #include <exception>
@@ -39,8 +39,7 @@ namespace hpx { namespace experimental {
             shared_state_ptr_type next_state;
             hpx::lcos::local::mutex mtx;
             hpx::detail::small_vector<
-                hpx::util::unique_function_nonser<void(shared_state_ptr_type)>,
-                1>
+                hpx::move_only_function<void(shared_state_ptr_type)>, 1>
                 continuations;
 
             async_rw_mutex_shared_state() = default;
@@ -108,8 +107,7 @@ namespace hpx { namespace experimental {
             shared_state_ptr_type next_state;
             hpx::lcos::local::mutex mtx;
             hpx::detail::small_vector<
-                hpx::util::unique_function_nonser<void(shared_state_ptr_type)>,
-                1>
+                hpx::move_only_function<void(shared_state_ptr_type)>, 1>
                 continuations;
 
             async_rw_mutex_shared_state() = default;

--- a/libs/core/testing/include/hpx/modules/testing.hpp
+++ b/libs/core/testing/include/hpx/modules/testing.hpp
@@ -27,7 +27,7 @@
 
 namespace hpx { namespace util {
 
-    using test_failure_handler_type = function_nonser<void()>;
+    using test_failure_handler_type = hpx::function<void()>;
     HPX_CORE_EXPORT void set_test_failure_handler(test_failure_handler_type f);
 
     enum counter_type

--- a/libs/core/testing/include/hpx/testing/performance.hpp
+++ b/libs/core/testing/include/hpx/testing/performance.hpp
@@ -80,7 +80,7 @@ namespace hpx { namespace util {
 
     HPX_CORE_EXPORT void perftests_report(std::string const& name,
         std::string const& exec, const std::size_t steps,
-        function_nonser<void(void)>&& test);
+        hpx::function<void(void)>&& test);
 
     HPX_CORE_EXPORT void perftests_print_times();
 

--- a/libs/core/testing/src/performance.cpp
+++ b/libs/core/testing/src/performance.cpp
@@ -30,7 +30,7 @@ namespace hpx { namespace util {
     }    // namespace detail
 
     void perftests_report(std::string const& name, std::string const& exec,
-        const std::size_t steps, function_nonser<void(void)>&& test)
+        const std::size_t steps, hpx::function<void(void)>&& test)
     {
         if (steps == 0)
             return;

--- a/libs/core/thread_pool_util/include/hpx/thread_pool_util/thread_pool_suspension_helpers.hpp
+++ b/libs/core/thread_pool_util/include/hpx/thread_pool_util/thread_pool_suspension_helpers.hpp
@@ -43,7 +43,7 @@ namespace hpx { namespace threads {
     ///                  is pre-initialized to \a hpx#throws the function will throw
     ///                  on error instead.
     HPX_CORE_EXPORT void resume_processing_unit_cb(thread_pool_base& pool,
-        util::function_nonser<void(void)> callback, std::size_t virt_core,
+        hpx::function<void(void)> callback, std::size_t virt_core,
         error_code& ec = throws);
 
     /// Suspends the given processing unit. When the processing unit has been
@@ -78,7 +78,7 @@ namespace hpx { namespace threads {
     ///                  is pre-initialized to \a hpx#throws the function will throw
     ///                  on error instead.
     HPX_CORE_EXPORT void suspend_processing_unit_cb(
-        util::function_nonser<void(void)> callback, thread_pool_base& pool,
+        hpx::function<void(void)> callback, thread_pool_base& pool,
         std::size_t virt_core, error_code& ec = throws);
 
     /// Resumes the thread pool. When the all OS threads on the thread pool have
@@ -101,7 +101,7 @@ namespace hpx { namespace threads {
     ///                 is pre-initialized to \a hpx#throws the function will throw
     ///                 on error instead.
     HPX_CORE_EXPORT void resume_pool_cb(thread_pool_base& pool,
-        util::function_nonser<void(void)> callback, error_code& ec = throws);
+        hpx::function<void(void)> callback, error_code& ec = throws);
 
     /// Suspends the thread pool. When the all OS threads on the thread pool
     /// have been suspended the returned future will be ready.
@@ -130,5 +130,5 @@ namespace hpx { namespace threads {
     /// \throws hpx::exception if called from an HPX thread which is running
     ///         on the pool itself.
     HPX_CORE_EXPORT void suspend_pool_cb(thread_pool_base& pool,
-        util::function_nonser<void(void)> callback, error_code& ec = throws);
+        hpx::function<void(void)> callback, error_code& ec = throws);
 }}    // namespace hpx::threads

--- a/libs/core/thread_pool_util/src/thread_pool_suspension_helpers.cpp
+++ b/libs/core/thread_pool_util/src/thread_pool_suspension_helpers.cpp
@@ -41,7 +41,7 @@ namespace hpx { namespace threads {
     }
 
     void resume_processing_unit_cb(thread_pool_base& pool,
-        util::function_nonser<void(void)> callback, std::size_t virt_core,
+        hpx::function<void(void)> callback, std::size_t virt_core,
         error_code& ec)
     {
         if (!pool.get_scheduler()->has_scheduler_mode(
@@ -102,7 +102,7 @@ namespace hpx { namespace threads {
     }
 
     void suspend_processing_unit_cb(thread_pool_base& pool,
-        util::function_nonser<void(void)> callback, std::size_t virt_core,
+        hpx::function<void(void)> callback, std::size_t virt_core,
         error_code& ec)
     {
         if (!pool.get_scheduler()->has_scheduler_mode(
@@ -156,7 +156,7 @@ namespace hpx { namespace threads {
     }
 
     void resume_pool_cb(thread_pool_base& pool,
-        util::function_nonser<void(void)> callback, error_code& /* ec */)
+        hpx::function<void(void)> callback, error_code& /* ec */)
     {
         auto resume_direct_wrapper =
             [&pool, callback = HPX_MOVE(callback)]() -> void {
@@ -196,7 +196,7 @@ namespace hpx { namespace threads {
     }
 
     void suspend_pool_cb(thread_pool_base& pool,
-        util::function_nonser<void(void)> callback, error_code& ec)
+        hpx::function<void(void)> callback, error_code& ec)
     {
         if (threads::get_self_ptr() && hpx::this_thread::get_pool() == &pool)
         {

--- a/libs/core/thread_pools/include/hpx/thread_pools/scheduled_thread_pool.hpp
+++ b/libs/core/thread_pools/include/hpx/thread_pools/scheduled_thread_pool.hpp
@@ -116,8 +116,7 @@ namespace hpx { namespace threads { namespace detail {
             return sched_->Scheduler::get_background_thread_count();
         }
 
-        bool enumerate_threads(
-            util::function_nonser<bool(thread_id_type)> const& f,
+        bool enumerate_threads(hpx::function<bool(thread_id_type)> const& f,
             thread_schedule_state state) const override
         {
             return sched_->Scheduler::enumerate_threads(f, state);

--- a/libs/core/thread_pools/include/hpx/thread_pools/scheduling_loop.hpp
+++ b/libs/core/thread_pools/include/hpx/thread_pools/scheduling_loop.hpp
@@ -9,7 +9,7 @@
 #include <hpx/config.hpp>
 #include <hpx/assert.hpp>
 #include <hpx/execution_base/this_thread.hpp>
-#include <hpx/functional/unique_function.hpp>
+#include <hpx/functional/move_only_function.hpp>
 #include <hpx/hardware/timestamp.hpp>
 #include <hpx/modules/itt_notify.hpp>
 #include <hpx/modules/logging.hpp>
@@ -398,8 +398,8 @@ namespace hpx { namespace threads { namespace detail {
 
     struct scheduling_callbacks
     {
-        using callback_type = util::unique_function_nonser<void()>;
-        using background_callback_type = util::unique_function_nonser<bool()>;
+        using callback_type = hpx::move_only_function<void()>;
+        using background_callback_type = hpx::move_only_function<bool()>;
 
         explicit scheduling_callbacks(callback_type&& outer,
             callback_type&& inner = callback_type(),

--- a/libs/core/threading/include/hpx/threading/thread.hpp
+++ b/libs/core/threading/include/hpx/threading/thread.hpp
@@ -10,7 +10,7 @@
 #include <hpx/assert.hpp>
 #include <hpx/functional/deferred_call.hpp>
 #include <hpx/functional/function.hpp>
-#include <hpx/functional/unique_function.hpp>
+#include <hpx/functional/move_only_function.hpp>
 #include <hpx/futures/future_fwd.hpp>
 #include <hpx/modules/errors.hpp>
 #include <hpx/synchronization/spinlock.hpp>
@@ -33,7 +33,7 @@
 namespace hpx {
     ///////////////////////////////////////////////////////////////////////////
     using thread_termination_handler_type =
-        util::function_nonser<void(std::exception_ptr const& e)>;
+        hpx::function<void(std::exception_ptr const& e)>;
     HPX_CORE_EXPORT void set_thread_termination_handler(
         thread_termination_handler_type f);
 
@@ -141,9 +141,9 @@ namespace hpx {
             id_ = threads::invalid_thread_id;
         }
         void start_thread(threads::thread_pool_base* pool,
-            util::unique_function_nonser<void()>&& func);
+            hpx::move_only_function<void()>&& func);
         static threads::thread_result_type thread_function_nullary(
-            util::unique_function_nonser<void()> const& func);
+            hpx::move_only_function<void()> const& func);
 
         mutable mutex_type mtx_;
         threads::thread_id_ref_type id_;

--- a/libs/core/threading/src/thread.cpp
+++ b/libs/core/threading/src/thread.cpp
@@ -7,7 +7,7 @@
 #include <hpx/assert.hpp>
 #include <hpx/functional/bind.hpp>
 #include <hpx/functional/bind_front.hpp>
-#include <hpx/functional/unique_function.hpp>
+#include <hpx/functional/move_only_function.hpp>
 #include <hpx/futures/detail/future_data.hpp>
 #include <hpx/futures/future.hpp>
 #include <hpx/lock_registration/detail/register_locks.hpp>
@@ -114,7 +114,7 @@ namespace hpx {
     }
 
     threads::thread_result_type thread::thread_function_nullary(
-        util::unique_function_nonser<void()> const& func)
+        hpx::move_only_function<void()> const& func)
     {
         try
         {
@@ -161,8 +161,8 @@ namespace hpx {
         return hpx::threads::hardware_concurrency();
     }
 
-    void thread::start_thread(threads::thread_pool_base* pool,
-        util::unique_function_nonser<void()>&& func)
+    void thread::start_thread(
+        threads::thread_pool_base* pool, hpx::move_only_function<void()>&& func)
     {
         HPX_ASSERT(pool);
 

--- a/libs/core/threading_base/include/hpx/threading_base/callback_notifier.hpp
+++ b/libs/core/threading_base/include/hpx/threading_base/callback_notifier.hpp
@@ -20,11 +20,10 @@ namespace hpx { namespace threads { namespace policies {
     class HPX_CORE_EXPORT callback_notifier
     {
     public:
-        typedef util::function_nonser<void(
+        typedef hpx::function<void(
             std::size_t, std::size_t, char const*, char const*)>
             on_startstop_type;
-        typedef util::function_nonser<bool(
-            std::size_t, std::exception_ptr const&)>
+        typedef hpx::function<bool(std::size_t, std::exception_ptr const&)>
             on_error_type;
 
         callback_notifier()

--- a/libs/core/threading_base/include/hpx/threading_base/detail/get_default_pool.hpp
+++ b/libs/core/threading_base/include/hpx/threading_base/detail/get_default_pool.hpp
@@ -14,7 +14,7 @@
 #include <hpx/threading_base/thread_pool_base.hpp>
 
 namespace hpx { namespace threads { namespace detail {
-    using get_default_pool_type = util::function_nonser<thread_pool_base*()>;
+    using get_default_pool_type = hpx::function<thread_pool_base*()>;
     HPX_CORE_EXPORT void set_get_default_pool(get_default_pool_type f);
     HPX_CORE_EXPORT thread_pool_base* get_self_or_default_pool();
 }}}    // namespace hpx::threads::detail

--- a/libs/core/threading_base/include/hpx/threading_base/detail/get_default_timer_service.hpp
+++ b/libs/core/threading_base/include/hpx/threading_base/detail/get_default_timer_service.hpp
@@ -16,8 +16,7 @@
 #include <asio/io_context.hpp>
 
 namespace hpx { namespace threads { namespace detail {
-    using get_default_timer_service_type =
-        util::function_nonser<asio::io_context*()>;
+    using get_default_timer_service_type = hpx::function<asio::io_context*()>;
     HPX_CORE_EXPORT void set_get_default_timer_service(
         get_default_timer_service_type f);
     HPX_CORE_EXPORT asio::io_context* get_default_timer_service();

--- a/libs/core/threading_base/include/hpx/threading_base/external_timer.hpp
+++ b/libs/core/threading_base/include/hpx/threading_base/external_timer.hpp
@@ -20,7 +20,7 @@ namespace hpx { namespace util {
 
 #ifdef HPX_HAVE_APEX
 
-    using enable_parent_task_handler_type = util::function_nonser<bool()>;
+    using enable_parent_task_handler_type = hpx::function<bool()>;
 
     HPX_CORE_EXPORT void set_enable_parent_task_handler(
         enable_parent_task_handler_type f);

--- a/libs/core/threading_base/include/hpx/threading_base/network_background_callback.hpp
+++ b/libs/core/threading_base/include/hpx/threading_base/network_background_callback.hpp
@@ -16,9 +16,8 @@ namespace hpx { namespace threads { namespace detail {
 #if defined(HPX_HAVE_BACKGROUND_THREAD_COUNTERS) &&                            \
     defined(HPX_HAVE_THREAD_IDLE_RATES)
     using network_background_callback_type =
-        util::function_nonser<bool(std::size_t, std::int64_t&, std::int64_t&)>;
+        hpx::function<bool(std::size_t, std::int64_t&, std::int64_t&)>;
 #else
-    using network_background_callback_type =
-        util::function_nonser<bool(std::size_t)>;
+    using network_background_callback_type = hpx::function<bool(std::size_t)>;
 #endif
 }}}    // namespace hpx::threads::detail

--- a/libs/core/threading_base/include/hpx/threading_base/scheduler_base.hpp
+++ b/libs/core/threading_base/include/hpx/threading_base/scheduler_base.hpp
@@ -167,7 +167,7 @@ namespace hpx { namespace threads { namespace policies {
         // depending on the predicate
         std::vector<std::size_t> domain_threads(std::size_t local_id,
             const std::vector<std::size_t>& ts,
-            util::function_nonser<bool(std::size_t, std::size_t)> pred);
+            hpx::function<bool(std::size_t, std::size_t)> pred);
 
 #ifdef HPX_HAVE_THREAD_CREATION_AND_CLEANUP_RATES
         virtual std::uint64_t get_creation_time(bool reset) = 0;
@@ -209,7 +209,7 @@ namespace hpx { namespace threads { namespace policies {
 
         // Enumerate all matching threads
         virtual bool enumerate_threads(
-            util::function_nonser<bool(thread_id_type)> const& f,
+            hpx::function<bool(thread_id_type)> const& f,
             thread_schedule_state state =
                 thread_schedule_state::unknown) const = 0;
 

--- a/libs/core/threading_base/include/hpx/threading_base/thread_data.hpp
+++ b/libs/core/threading_base/include/hpx/threading_base/thread_data.hpp
@@ -504,7 +504,7 @@ namespace hpx { namespace threads {
 
         bool interruption_point(bool throw_on_interrupt = true);
 
-        bool add_thread_exit_callback(util::function_nonser<void()> const& f);
+        bool add_thread_exit_callback(function<void()> const& f);
         void run_thread_exit_callbacks();
         void free_thread_exit_callbacks();
 
@@ -647,7 +647,7 @@ namespace hpx { namespace threads {
         bool const is_stackless_;
 
         // Singly linked list (heap-allocated)
-        std::forward_list<util::function_nonser<void()>> exit_funcs_;
+        std::forward_list<hpx::function<void()>> exit_funcs_;
 
         // reference to scheduler which created/manages this thread
         policies::scheduler_base* scheduler_base_;

--- a/libs/core/threading_base/include/hpx/threading_base/thread_helpers.hpp
+++ b/libs/core/threading_base/include/hpx/threading_base/thread_helpers.hpp
@@ -11,7 +11,7 @@
 
 #include <hpx/config.hpp>
 #include <hpx/coroutines/thread_enums.hpp>
-#include <hpx/functional/unique_function.hpp>
+#include <hpx/functional/move_only_function.hpp>
 #include <hpx/lock_registration/detail/register_locks.hpp>
 #include <hpx/modules/errors.hpp>
 #include <hpx/threading_base/register_thread.hpp>
@@ -382,7 +382,7 @@ namespace hpx { namespace threads {
         thread_id_type const& id, error_code& ec = throws);
 
     HPX_CORE_EXPORT bool add_thread_exit_callback(thread_id_type const& id,
-        util::function_nonser<void()> const& f, error_code& ec = throws);
+        hpx::function<void()> const& f, error_code& ec = throws);
 
     HPX_CORE_EXPORT void free_thread_exit_callbacks(
         thread_id_type const& id, error_code& ec = throws);

--- a/libs/core/threading_base/include/hpx/threading_base/thread_pool_base.hpp
+++ b/libs/core/threading_base/include/hpx/threading_base/thread_pool_base.hpp
@@ -499,7 +499,7 @@ namespace hpx { namespace threads {
 
         ///////////////////////////////////////////////////////////////////////
         virtual bool enumerate_threads(
-            util::function_nonser<bool(thread_id_type)> const& /*f*/,
+            hpx::function<bool(thread_id_type)> const& /*f*/,
             thread_schedule_state /*state*/ =
                 thread_schedule_state::unknown) const
         {

--- a/libs/core/threading_base/include/hpx/threading_base/threading_base_fwd.hpp
+++ b/libs/core/threading_base/include/hpx/threading_base/threading_base_fwd.hpp
@@ -13,7 +13,7 @@
 #include <hpx/coroutines/thread_enums.hpp>
 #include <hpx/coroutines/thread_id_type.hpp>
 #include <hpx/functional/function.hpp>
-#include <hpx/functional/unique_function.hpp>
+#include <hpx/functional/move_only_function.hpp>
 #include <hpx/modules/errors.hpp>
 
 #include <cstddef>
@@ -50,8 +50,7 @@ namespace hpx { namespace threads {
     using thread_arg_type = thread_restart_state;
 
     using thread_function_sig = thread_result_type(thread_arg_type);
-    using thread_function_type =
-        util::unique_function_nonser<thread_function_sig>;
+    using thread_function_type = hpx::move_only_function<thread_function_sig>;
 
     using thread_self = coroutines::detail::coroutine_self;
     using thread_self_impl_type = coroutines::detail::coroutine_impl;

--- a/libs/core/threading_base/src/thread_data.cpp
+++ b/libs/core/threading_base/src/thread_data.cpp
@@ -135,8 +135,7 @@ namespace hpx { namespace threads {
         ran_exit_funcs_ = true;
     }
 
-    bool thread_data::add_thread_exit_callback(
-        util::function_nonser<void()> const& f)
+    bool thread_data::add_thread_exit_callback(hpx::function<void()> const& f)
     {
         std::lock_guard<hpx::util::detail::spinlock> l(
             spinlock_pool::spinlock_for(this));

--- a/libs/core/threading_base/src/thread_helpers.cpp
+++ b/libs/core/threading_base/src/thread_helpers.cpp
@@ -330,7 +330,7 @@ namespace hpx { namespace threads {
     }
 
     bool add_thread_exit_callback(thread_id_type const& id,
-        util::function_nonser<void()> const& f, error_code& ec)
+        hpx::function<void()> const& f, error_code& ec)
     {
         if (HPX_UNLIKELY(!id))
         {

--- a/libs/core/threadmanager/include/hpx/modules/threadmanager.hpp
+++ b/libs/core/threadmanager/include/hpx/modules/threadmanager.hpp
@@ -179,8 +179,7 @@ namespace hpx { namespace threads {
         std::int64_t get_background_thread_count();
 
         // Enumerate all matching threads
-        bool enumerate_threads(
-            util::function_nonser<bool(thread_id_type)> const& f,
+        bool enumerate_threads(hpx::function<bool(thread_id_type)> const& f,
             thread_schedule_state state = thread_schedule_state::unknown) const;
 
         // \brief Abort all threads which are in suspended state. This will set

--- a/libs/core/threadmanager/src/threadmanager.cpp
+++ b/libs/core/threadmanager/src/threadmanager.cpp
@@ -685,7 +685,7 @@ namespace hpx { namespace threads {
     ///////////////////////////////////////////////////////////////////////////
     // Enumerate all matching threads
     bool threadmanager::enumerate_threads(
-        util::function_nonser<bool(thread_id_type)> const& f,
+        hpx::function<bool(thread_id_type)> const& f,
         thread_schedule_state state) const
     {
         std::lock_guard<mutex_type> lk(mtx_);

--- a/libs/full/actions/tests/regressions/function_argument.cpp
+++ b/libs/full/actions/tests/regressions/function_argument.cpp
@@ -26,7 +26,7 @@ using hpx::naming::id_type;
 bool invoked_f = false;
 bool invoked_g = false;
 
-bool f(hpx::util::function<bool()> func)
+bool f(hpx::function<bool(), true> func)
 {
     HPX_TEST(!invoked_f);
     invoked_f = true;
@@ -63,7 +63,7 @@ struct g
 int hpx_main(variables_map&)
 {
     {
-        hpx::util::function<bool()> f = g();
+        hpx::function<bool(), true> f = g();
         std::vector<id_type> prefixes = hpx::find_all_localities();
 
         for (id_type const& prefix : prefixes)

--- a/libs/full/actions_base/include/hpx/actions_base/detail/per_action_data_counter_registry.hpp
+++ b/libs/full/actions_base/include/hpx/actions_base/detail/per_action_data_counter_registry.hpp
@@ -28,7 +28,7 @@ namespace hpx { namespace actions { namespace detail {
         HPX_NON_COPYABLE(per_action_data_counter_registry);
 
     public:
-        using counter_function_type = util::function_nonser<std::int64_t(bool)>;
+        using counter_function_type = hpx::function<std::int64_t(bool)>;
         using map_type =
             std::unordered_set<std::string, hpx::util::jenkins_hash>;
 
@@ -50,8 +50,8 @@ namespace hpx { namespace actions { namespace detail {
         void register_class(std::string action);
 
         counter_function_type get_counter(std::string const& action,
-            hpx::util::function_nonser<std::int64_t(
-                std::string const&, bool)> const& f) const;
+            hpx::function<std::int64_t(std::string const&, bool)> const& f)
+            const;
 
         map_type const& registered_counters() const
         {

--- a/libs/full/actions_base/src/detail/per_action_data_counter_registry.cpp
+++ b/libs/full/actions_base/src/detail/per_action_data_counter_registry.cpp
@@ -44,8 +44,7 @@ namespace hpx { namespace actions { namespace detail {
 
     per_action_data_counter_registry::counter_function_type
     per_action_data_counter_registry::get_counter(std::string const& name,
-        hpx::util::function_nonser<std::int64_t(
-            std::string const&, bool)> const& f) const
+        hpx::function<std::int64_t(std::string const&, bool)> const& f) const
     {
         map_type::const_iterator it = map_.find(name);
         if (it == map_.end())

--- a/libs/full/agas/include/hpx/agas/addressing_service.hpp
+++ b/libs/full/agas/include/hpx/agas/addressing_service.hpp
@@ -56,8 +56,9 @@ namespace hpx { namespace agas {
         using iterate_names_return_type =
             std::map<std::string, naming::id_type>;
 
-        using iterate_types_function_type = hpx::util::function<void(
-            std::string const&, components::component_type)>;
+        using iterate_types_function_type =
+            hpx::function<void(std::string const&, components::component_type),
+                true>;
 
         using mutex_type = hpx::lcos::local::spinlock;
 
@@ -952,7 +953,7 @@ namespace hpx { namespace agas {
         ///                   before the parcel has been delivered to its
         ///                   destination.
         void route(parcelset::parcel p,
-            util::function_nonser<void(
+            hpx::function<void(
                 std::error_code const&, parcelset::parcel const&)>&&,
             threads::thread_priority local_priority =
                 threads::thread_priority::default_);
@@ -1182,13 +1183,12 @@ namespace hpx { namespace agas {
         /// Maintain list of migrated objects
         std::pair<bool, components::pinned_ptr> was_object_migrated(
             naming::gid_type const& gid,
-            util::unique_function_nonser<components::pinned_ptr()>&& f);
+            hpx::move_only_function<components::pinned_ptr()>&& f);
 
         /// Mark the given object as being migrated (if the object is unpinned).
         /// Delay migration until the object is unpinned otherwise.
         hpx::future<void> mark_as_migrated(naming::gid_type const& gid,
-            util::unique_function_nonser<std::pair<bool, hpx::future<void>>()>&&
-                f,
+            hpx::move_only_function<std::pair<bool, hpx::future<void>>()>&& f,
             bool expect_to_be_marked_as_migrating);
 
         /// Remove the given object from the table of migrated objects

--- a/libs/full/agas/src/addressing_service.cpp
+++ b/libs/full/agas/src/addressing_service.cpp
@@ -1217,15 +1217,15 @@ namespace hpx { namespace agas {
 #if defined(HPX_HAVE_NETWORKING)
     ///////////////////////////////////////////////////////////////////////////
     void addressing_service::route(parcelset::parcel p,
-        util::function_nonser<void(
-            std::error_code const&, parcelset::parcel const&)>&& f,
+        hpx::function<void(std::error_code const&, parcelset::parcel const&)>&&
+            f,
         threads::thread_priority local_priority)
     {
         if (HPX_UNLIKELY(nullptr == threads::get_self_ptr()))
         {
             // reschedule this call as an HPX thread
             void (addressing_service::*route_ptr)(parcelset::parcel,
-                util::function_nonser<void(
+                hpx::function<void(
                     std::error_code const&, parcelset::parcel const&)>&&,
                 threads::thread_priority) = &addressing_service::route;
 
@@ -2130,9 +2130,7 @@ namespace hpx { namespace agas {
     ///////////////////////////////////////////////////////////////////////////
     hpx::future<void> addressing_service::mark_as_migrated(
         naming::gid_type const& gid_,
-        util::unique_function_nonser<std::pair<bool, hpx::future<void>>()>&&
-            f    //-V669
-        ,
+        hpx::move_only_function<std::pair<bool, hpx::future<void>>()>&& f,
         bool expect_to_be_marked_as_migrating)
     {
         HPX_UNUSED(expect_to_be_marked_as_migrating);
@@ -2272,7 +2270,7 @@ namespace hpx { namespace agas {
 
     std::pair<bool, components::pinned_ptr>
     addressing_service::was_object_migrated(naming::gid_type const& gid,
-        util::unique_function_nonser<components::pinned_ptr()>&& f    //-V669
+        hpx::move_only_function<components::pinned_ptr()>&& f    //-V669
     )
     {
         if (!gid)

--- a/libs/full/agas/src/detail/interface.cpp
+++ b/libs/full/agas/src/detail/interface.cpp
@@ -12,7 +12,7 @@
 #include <hpx/components_base/generate_unique_ids.hpp>
 #include <hpx/components_base/pinned_ptr.hpp>
 #include <hpx/functional/function.hpp>
-#include <hpx/functional/unique_function.hpp>
+#include <hpx/functional/move_only_function.hpp>
 #include <hpx/runtime_local/runtime_local.hpp>
 
 #include <algorithm>
@@ -447,7 +447,7 @@ namespace hpx { namespace agas { namespace detail { namespace impl {
     }
 
     hpx::future<void> mark_as_migrated(naming::gid_type const& gid,
-        util::unique_function_nonser<std::pair<bool, hpx::future<void>>()>&& f,
+        hpx::move_only_function<std::pair<bool, hpx::future<void>>()>&& f,
         bool expect_to_be_marked_as_migrating)
     {
         return naming::get_agas_client().mark_as_migrated(
@@ -456,7 +456,7 @@ namespace hpx { namespace agas { namespace detail { namespace impl {
 
     std::pair<bool, components::pinned_ptr> was_object_migrated(
         naming::gid_type const& gid,
-        util::unique_function_nonser<components::pinned_ptr()>&& f)
+        hpx::move_only_function<components::pinned_ptr()>&& f)
     {
         return naming::get_agas_client().was_object_migrated(gid, HPX_MOVE(f));
     }
@@ -494,8 +494,8 @@ namespace hpx { namespace agas { namespace detail { namespace impl {
 #if defined(HPX_HAVE_NETWORKING)
     ///////////////////////////////////////////////////////////////////////////
     void route(parcelset::parcel&& p,
-        util::function_nonser<void(
-            std::error_code const&, parcelset::parcel const&)>&& f,
+        hpx::function<void(std::error_code const&, parcelset::parcel const&)>&&
+            f,
         threads::thread_priority local_priority)
     {
         return naming::get_agas_client().route(

--- a/libs/full/agas_base/include/hpx/agas_base/agas_fwd.hpp
+++ b/libs/full/agas_base/include/hpx/agas_base/agas_fwd.hpp
@@ -35,8 +35,9 @@ namespace hpx { namespace agas {
     static constexpr std::uint64_t const locality_ns_msb = 0x100000001ULL;
     static constexpr std::uint64_t const locality_ns_lsb = 0x000000004ULL;
 
-    using iterate_types_function_type = hpx::util::function<void(
-        std::string const&, components::component_type)>;
+    using iterate_types_function_type =
+        hpx::function<void(std::string const&, components::component_type),
+            true>;
 
     struct HPX_EXPORT component_namespace;
     struct HPX_EXPORT locality_namespace;

--- a/libs/full/agas_base/include/hpx/agas_base/detail/bootstrap_component_namespace.hpp
+++ b/libs/full/agas_base/include/hpx/agas_base/detail/bootstrap_component_namespace.hpp
@@ -22,8 +22,8 @@ namespace hpx { namespace agas { namespace detail {
 
     struct bootstrap_component_namespace : component_namespace
     {
-        typedef hpx::util::function<void(
-            std::string const&, components::component_type)>
+        typedef hpx::function<
+            void(std::string const&, components::component_type), true>
             iterate_types_function_type;
 
         naming::address::address_type ptr() const

--- a/libs/full/agas_base/include/hpx/agas_base/primary_namespace.hpp
+++ b/libs/full/agas_base/include/hpx/agas_base/primary_namespace.hpp
@@ -68,7 +68,7 @@ namespace hpx { namespace agas {
 
 #if defined(HPX_HAVE_NETWORKING)
         void route(parcelset::parcel&& p,
-            util::function_nonser<void(
+            hpx::function<void(
                 std::error_code const&, parcelset::parcel const&)>&& f);
 #endif
 

--- a/libs/full/agas_base/src/primary_namespace.cpp
+++ b/libs/full/agas_base/src/primary_namespace.cpp
@@ -207,8 +207,8 @@ namespace hpx { namespace agas {
 
 #if defined(HPX_HAVE_NETWORKING)
     void primary_namespace::route(parcelset::parcel&& p,
-        util::function_nonser<void(
-            std::error_code const&, parcelset::parcel const&)>&& f)
+        hpx::function<void(std::error_code const&, parcelset::parcel const&)>&&
+            f)
     {
         // compose request
         naming::gid_type const& id = p.destination();

--- a/libs/full/async_colocated/include/hpx/async_colocated/async_colocated.hpp
+++ b/libs/full/async_colocated/include/hpx/async_colocated/async_colocated.hpp
@@ -20,7 +20,7 @@
 #include <hpx/async_local/async_fwd.hpp>
 #include <hpx/datastructures/tuple.hpp>
 #include <hpx/functional/bind.hpp>
-#include <hpx/functional/unique_function.hpp>
+#include <hpx/functional/move_only_function.hpp>
 #include <hpx/futures/future.hpp>
 #include <hpx/futures/traits/promise_local_result.hpp>
 #include <hpx/naming_base/id_type.hpp>

--- a/libs/full/async_colocated/include/hpx/async_colocated/register_apply_colocated.hpp
+++ b/libs/full/async_colocated/include/hpx/async_colocated/register_apply_colocated.hpp
@@ -11,7 +11,7 @@
 #include <hpx/async_distributed/bind_action.hpp>
 #include <hpx/datastructures/tuple.hpp>
 #include <hpx/functional/bind.hpp>
-#include <hpx/functional/unique_function.hpp>
+#include <hpx/functional/move_only_function.hpp>
 #include <hpx/naming_base/id_type.hpp>
 #include <hpx/type_support/pack.hpp>
 

--- a/libs/full/async_distributed/include/hpx/async_distributed/continuation.hpp
+++ b/libs/full/async_distributed/include/hpx/async_distributed/continuation.hpp
@@ -16,7 +16,7 @@
 #include <hpx/async_distributed/continuation_fwd.hpp>
 #include <hpx/async_distributed/trigger_lco_fwd.hpp>
 #include <hpx/components_base/agas_interface.hpp>
-#include <hpx/functional/serialization/serializable_unique_function.hpp>
+#include <hpx/functional/serialization/serializable_move_only_function.hpp>
 #include <hpx/futures/traits/future_traits.hpp>
 #include <hpx/modules/errors.hpp>
 #include <hpx/modules/logging.hpp>
@@ -82,7 +82,7 @@ namespace hpx { namespace actions {
     {
     private:
         using function_type =
-            util::unique_function<void(naming::id_type, Result)>;
+            hpx::move_only_function<void(naming::id_type, Result), true>;
 
     public:
         using result_type = Result;
@@ -202,7 +202,7 @@ namespace hpx { namespace actions {
     private:
         using base_type = typed_continuation<RemoteResult>;
         using function_type =
-            util::unique_function<void(naming::id_type, RemoteResult)>;
+            hpx::move_only_function<void(naming::id_type, RemoteResult), true>;
 
     public:
         typed_continuation() = default;
@@ -308,7 +308,8 @@ namespace hpx { namespace actions {
     struct typed_continuation<void, util::unused_type> : continuation
     {
     private:
-        using function_type = util::unique_function<void(naming::id_type)>;
+        using function_type =
+            hpx::move_only_function<void(naming::id_type), true>;
 
     public:
         using result_type = void;

--- a/libs/full/async_distributed/include/hpx/async_distributed/detail/promise_base.hpp
+++ b/libs/full/async_distributed/include/hpx/async_distributed/detail/promise_base.hpp
@@ -15,7 +15,7 @@
 #include <hpx/components_base/server/managed_component_base.hpp>
 #include <hpx/errors/try_catch_exception_ptr.hpp>
 #include <hpx/functional/deferred_call.hpp>
-#include <hpx/functional/unique_function.hpp>
+#include <hpx/functional/move_only_function.hpp>
 #include <hpx/futures/detail/future_data.hpp>
 #include <hpx/futures/traits/future_access.hpp>
 #include <hpx/modules/errors.hpp>
@@ -44,7 +44,7 @@ namespace hpx {
             {
             }
 
-            void set_task(util::unique_function_nonser<void()>&& f)
+            void set_task(hpx::move_only_function<void()>&& f)
             {
                 f_ = HPX_MOVE(f);
             }
@@ -71,7 +71,7 @@ namespace hpx {
                     });
             }
 
-            util::unique_function_nonser<void()> f_;
+            hpx::move_only_function<void()> f_;
         };
 
         template <typename Result, typename Allocator>

--- a/libs/full/async_distributed/tests/unit/util/bind_action.cpp
+++ b/libs/full/async_distributed/tests/unit/util/bind_action.cpp
@@ -179,19 +179,17 @@ void function_bind_test1(hpx::naming::id_type id)
     using hpx::util::placeholders::_1;
     using hpx::util::placeholders::_2;
 
-    hpx::util::function_nonser<int()> f1 =
-        hpx::util::bind<test1_action>(id, 42);
+    hpx::function<int()> f1 = hpx::util::bind<test1_action>(id, 42);
     HPX_TEST_EQ(f1(), 42);
 
-    hpx::util::function_nonser<int(hpx::naming::id_type)> f2 =
+    hpx::function<int(hpx::naming::id_type)> f2 =
         hpx::util::bind<test1_action>(_1, 42);
     HPX_TEST_EQ(f2(id), 42);
 
-    hpx::util::function_nonser<int(int)> f3 =
-        hpx::util::bind<test1_action>(id, _1);
+    hpx::function<int(int)> f3 = hpx::util::bind<test1_action>(id, _1);
     HPX_TEST_EQ(f3(42), 42);
 
-    hpx::util::function_nonser<int(hpx::naming::id_type, int)> f4 =
+    hpx::function<int(hpx::naming::id_type, int)> f4 =
         hpx::util::bind<test1_action>(_1, _2);
     HPX_TEST_EQ(f4(id, 42), 42);
 }
@@ -202,23 +200,23 @@ void function_bind_test2(hpx::naming::id_type id)
     using hpx::util::placeholders::_2;
     test1_action do_test1;
 
-    hpx::util::function_nonser<int()> f1 = hpx::util::bind(do_test1, id, 42);
+    hpx::function<int()> f1 = hpx::util::bind(do_test1, id, 42);
     HPX_TEST_EQ(f1(), 42);
 
-    hpx::util::function_nonser<int(hpx::naming::id_type)> f2 =
+    hpx::function<int(hpx::naming::id_type)> f2 =
         hpx::util::bind(do_test1, _1, 42);
     HPX_TEST_EQ(f2(id), 42);
 
-    hpx::util::function_nonser<int(int)> f3 = hpx::util::bind(do_test1, id, _1);
+    hpx::function<int(int)> f3 = hpx::util::bind(do_test1, id, _1);
     HPX_TEST_EQ(f3(42), 42);
 
-    hpx::util::function_nonser<int(hpx::naming::id_type, int)> f4 =
+    hpx::function<int(hpx::naming::id_type, int)> f4 =
         hpx::util::bind(do_test1, _1, _2);
     HPX_TEST_EQ(f4(id, 42), 42);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-int test2(hpx::util::function<int(hpx::naming::id_type)> f)
+int test2(hpx::function<int(hpx::naming::id_type), true> f)
 {
     return f(hpx::find_here());
 }
@@ -229,11 +227,11 @@ void function_bind_test3(hpx::naming::id_type id)
     using hpx::util::placeholders::_1;
     test1_action do_test1;
 
-    hpx::util::function<int(hpx::naming::id_type)> f1 =
+    hpx::function<int(hpx::naming::id_type), true> f1 =
         hpx::util::bind(do_test1, _1, 42);
 
     test2_action do_test2;
-    hpx::util::function_nonser<int()> f2 = hpx::util::bind(do_test2, id, f1);
+    hpx::function<int()> f2 = hpx::util::bind(do_test2, id, f1);
 
     HPX_TEST_EQ(f2(), 42);
 }
@@ -242,17 +240,16 @@ void function_bind_test4(hpx::naming::id_type id)
 {
     using hpx::util::placeholders::_1;
 
-    hpx::util::function<int(hpx::naming::id_type)> f1 =
+    hpx::function<int(hpx::naming::id_type), true> f1 =
         hpx::util::bind<test1_action>(_1, 42);
 
-    hpx::util::function_nonser<int()> f2 =
-        hpx::util::bind<test2_action>(id, f1);
+    hpx::function<int()> f2 = hpx::util::bind<test2_action>(id, f1);
 
     HPX_TEST_EQ(f2(), 42);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-int test3(hpx::util::function<int()> f)
+int test3(hpx::function<int(), true> f)
 {
     return f();
 }
@@ -260,11 +257,10 @@ HPX_PLAIN_ACTION(test3, test3_action)
 
 void function_bind_test5(hpx::naming::id_type id)
 {
-    hpx::util::function<int()> f1 =
+    hpx::function<int(), true> f1 =
         hpx::util::bind<test1_action>(hpx::find_here(), 42);
 
-    hpx::util::function_nonser<int()> f2 =
-        hpx::util::bind<test3_action>(id, f1);
+    hpx::function<int()> f2 = hpx::util::bind<test3_action>(id, f1);
 
     HPX_TEST_EQ(f2(), 42);
 }
@@ -272,11 +268,11 @@ void function_bind_test5(hpx::naming::id_type id)
 void function_bind_test6(hpx::naming::id_type id)
 {
     test1_action do_test1;
-    hpx::util::function<int()> f1 =
+    hpx::function<int(), true> f1 =
         hpx::util::bind(do_test1, hpx::find_here(), 42);
 
     test3_action do_test3;
-    hpx::util::function_nonser<int()> f2 = hpx::util::bind(do_test3, id, f1);
+    hpx::function<int()> f2 = hpx::util::bind(do_test3, id, f1);
 
     HPX_TEST_EQ(f2(), 42);
 }

--- a/libs/full/collectives/tests/performance/osu/broadcast.hpp
+++ b/libs/full/collectives/tests/performance/osu/broadcast.hpp
@@ -29,7 +29,7 @@
 namespace hpx { namespace lcos {
     namespace detail {
         void broadcast_impl(std::vector<hpx::id_type> ids,
-            hpx::util::function<void(hpx::id_type)> fun,
+            hpx::function<void(hpx::id_type), true> fun,
             std::size_t fan_out = 2);
         HPX_DEFINE_PLAIN_ACTION(broadcast_impl, broadcast_impl_action);
     }    // namespace detail
@@ -132,7 +132,7 @@ namespace hpx { namespace lcos {
 
     namespace detail {
         void broadcast_impl(std::vector<hpx::id_type> ids,
-            hpx::util::function<void(hpx::id_type)> fun, std::size_t fan_out)
+            hpx::function<void(hpx::id_type), true> fun, std::size_t fan_out)
         {
             // Call some action for the fan_out first ids here ...
             std::vector<hpx::future<void>> broadcast_futures;

--- a/libs/full/command_line_handling/include/hpx/command_line_handling/command_line_handling.hpp
+++ b/libs/full/command_line_handling/include/hpx/command_line_handling/command_line_handling.hpp
@@ -26,7 +26,7 @@ namespace hpx { namespace util {
     {
         command_line_handling(runtime_configuration rtcfg,
             std::vector<std::string> ini_config,
-            function_nonser<int(hpx::program_options::variables_map& vm)>
+            hpx::function<int(hpx::program_options::variables_map& vm)>
                 hpx_main_f)
           : rtcfg_(rtcfg)
           , ini_config_(ini_config)
@@ -54,8 +54,7 @@ namespace hpx { namespace util {
         util::runtime_configuration rtcfg_;
 
         std::vector<std::string> ini_config_;
-        util::function_nonser<int(hpx::program_options::variables_map& vm)>
-            hpx_main_f_;
+        hpx::function<int(hpx::program_options::variables_map& vm)> hpx_main_f_;
 
         std::size_t node_;
         std::size_t num_threads_;

--- a/libs/full/components_base/include/hpx/components_base/agas_interface.hpp
+++ b/libs/full/components_base/include/hpx/components_base/agas_interface.hpp
@@ -256,12 +256,12 @@ namespace hpx { namespace agas {
     HPX_EXPORT bool end_migration(naming::id_type const& id);
 
     HPX_EXPORT hpx::future<void> mark_as_migrated(naming::gid_type const& gid,
-        util::unique_function_nonser<std::pair<bool, hpx::future<void>>()>&& f,
+        hpx::move_only_function<std::pair<bool, hpx::future<void>>()>&& f,
         bool expect_to_be_marked_as_migrating);
 
     HPX_EXPORT std::pair<bool, components::pinned_ptr> was_object_migrated(
         naming::gid_type const& gid,
-        util::unique_function_nonser<components::pinned_ptr()>&& f);
+        hpx::move_only_function<components::pinned_ptr()>&& f);
 
     HPX_EXPORT void unmark_as_migrated(naming::gid_type const& gid);
 
@@ -285,8 +285,8 @@ namespace hpx { namespace agas {
     ///////////////////////////////////////////////////////////////////////////
 #if defined(HPX_HAVE_NETWORKING)
     HPX_EXPORT void route(parcelset::parcel&& p,
-        util::function_nonser<void(
-            std::error_code const&, parcelset::parcel const&)>&& f,
+        hpx::function<void(std::error_code const&, parcelset::parcel const&)>&&
+            f,
         threads::thread_priority local_priority =
             threads::thread_priority::default_);
 #endif

--- a/libs/full/components_base/include/hpx/components_base/component_startup_shutdown.hpp
+++ b/libs/full/components_base/include/hpx/components_base/component_startup_shutdown.hpp
@@ -60,9 +60,9 @@ namespace hpx { namespace components {
                 bool HPX_PP_CAT(HPX_PLUGIN_COMPONENT_PREFIX, _startup)(        \
                     startup_function_type & startup_func, bool& pre_startup)   \
                 {                                                              \
-                    util::function_nonser<bool(startup_function_type&, bool&)> \
-                        tmp = static_cast<bool (*)(                            \
-                            startup_function_type&, bool&)>(startup_);         \
+                    hpx::function<bool(startup_function_type&, bool&)> tmp =   \
+                        static_cast<bool (*)(startup_function_type&, bool&)>(  \
+                            startup_);                                         \
                     if (!!tmp)                                                 \
                     {                                                          \
                         return tmp(startup_func, pre_startup);                 \
@@ -73,10 +73,9 @@ namespace hpx { namespace components {
                     shutdown_function_type & shutdown_func,                    \
                     bool& pre_shutdown)                                        \
                 {                                                              \
-                    util::function_nonser<bool(                                \
-                        shutdown_function_type&, bool&)>                       \
-                        tmp = static_cast<bool (*)(                            \
-                            shutdown_function_type&, bool&)>(shutdown_);       \
+                    hpx::function<bool(shutdown_function_type&, bool&)> tmp =  \
+                        static_cast<bool (*)(shutdown_function_type&, bool&)>( \
+                            shutdown_);                                        \
                     if (!!tmp)                                                 \
                     {                                                          \
                         return tmp(shutdown_func, pre_shutdown);               \

--- a/libs/full/components_base/include/hpx/components_base/component_type.hpp
+++ b/libs/full/components_base/include/hpx/components_base/component_type.hpp
@@ -12,7 +12,7 @@
 #include <hpx/assert.hpp>
 #include <hpx/components_base/components_base_fwd.hpp>
 #include <hpx/components_base/traits/component_type_database.hpp>
-#include <hpx/functional/unique_function.hpp>
+#include <hpx/functional/move_only_function.hpp>
 #include <hpx/naming_base/address.hpp>
 #include <hpx/naming_base/gid_type.hpp>
 #include <hpx/naming_base/naming_base.hpp>
@@ -95,7 +95,7 @@ namespace hpx { namespace components {
     HPX_EXPORT component_deleter_type& deleter(component_type type);
 
     HPX_EXPORT bool enumerate_instance_counts(
-        util::unique_function_nonser<bool(component_type)> const& f);
+        hpx::move_only_function<bool(component_type)> const& f);
 
     /// \brief Return the string representation for a given component type id
     HPX_EXPORT std::string const get_component_type_name(component_type type);

--- a/libs/full/components_base/include/hpx/components_base/detail/agas_interface_functions.hpp
+++ b/libs/full/components_base/include/hpx/components_base/detail/agas_interface_functions.hpp
@@ -10,7 +10,7 @@
 #include <hpx/components_base/pinned_ptr.hpp>
 #include <hpx/coroutines/thread_enums.hpp>
 #include <hpx/functional/function.hpp>
-#include <hpx/functional/unique_function.hpp>
+#include <hpx/functional/move_only_function.hpp>
 #include <hpx/futures/future_fwd.hpp>
 #include <hpx/modules/errors.hpp>
 #include <hpx/naming_base/id_type.hpp>
@@ -206,12 +206,12 @@ namespace hpx { namespace agas { namespace detail {
 
     extern HPX_EXPORT hpx::future<void> (*mark_as_migrated)(
         naming::gid_type const& gid,
-        util::unique_function_nonser<std::pair<bool, hpx::future<void>>()>&& f,
+        hpx::move_only_function<std::pair<bool, hpx::future<void>>()>&& f,
         bool expect_to_be_marked_as_migrating);
 
     extern HPX_EXPORT std::pair<bool, components::pinned_ptr> (
         *was_object_migrated)(naming::gid_type const& gid,
-        util::unique_function_nonser<components::pinned_ptr()>&& f);
+        hpx::move_only_function<components::pinned_ptr()>&& f);
 
     extern HPX_EXPORT void (*unmark_as_migrated)(naming::gid_type const& gid);
 
@@ -236,8 +236,7 @@ namespace hpx { namespace agas { namespace detail {
     ///////////////////////////////////////////////////////////////////////////
 #if defined(HPX_HAVE_NETWORKING)
     extern HPX_EXPORT void (*route)(parcelset::parcel&& p,
-        util::function_nonser<void(
-            std::error_code const&, parcelset::parcel const&)>&&,
+        hpx::function<void(std::error_code const&, parcelset::parcel const&)>&&,
         threads::thread_priority local_priority);
 #endif
 

--- a/libs/full/components_base/include/hpx/components_base/server/locking_hook.hpp
+++ b/libs/full/components_base/include/hpx/components_base/server/locking_hook.hpp
@@ -86,9 +86,8 @@ namespace hpx { namespace components {
         }
 
     protected:
-        using yield_decorator_type =
-            util::function_nonser<threads::thread_arg_type(
-                threads::thread_result_type)>;
+        using yield_decorator_type = hpx::function<threads::thread_arg_type(
+            threads::thread_result_type)>;
 
         struct decorate_wrapper
         {

--- a/libs/full/components_base/include/hpx/components_base/server/managed_component_base.hpp
+++ b/libs/full/components_base/include/hpx/components_base/server/managed_component_base.hpp
@@ -18,7 +18,7 @@
 #include <hpx/components_base/server/wrapper_heap_list.hpp>
 #include <hpx/components_base/traits/is_component.hpp>
 #include <hpx/components_base/traits/managed_component_policies.hpp>
-#include <hpx/functional/unique_function.hpp>
+#include <hpx/functional/move_only_function.hpp>
 #include <hpx/modules/errors.hpp>
 
 #include <cstddef>

--- a/libs/full/components_base/src/agas_interface.cpp
+++ b/libs/full/components_base/src/agas_interface.cpp
@@ -343,7 +343,7 @@ namespace hpx { namespace agas {
     }
 
     hpx::future<void> mark_as_migrated(naming::gid_type const& gid,
-        util::unique_function_nonser<std::pair<bool, hpx::future<void>>()>&& f,
+        hpx::move_only_function<std::pair<bool, hpx::future<void>>()>&& f,
         bool expect_to_be_marked_as_migrating)
     {
         return detail::mark_as_migrated(
@@ -352,7 +352,7 @@ namespace hpx { namespace agas {
 
     std::pair<bool, components::pinned_ptr> was_object_migrated(
         naming::gid_type const& gid,
-        util::unique_function_nonser<components::pinned_ptr()>&& f)
+        hpx::move_only_function<components::pinned_ptr()>&& f)
     {
         return detail::was_object_migrated(gid, HPX_MOVE(f));
     }
@@ -397,8 +397,8 @@ namespace hpx { namespace agas {
     ///////////////////////////////////////////////////////////////////////////
 #if defined(HPX_HAVE_NETWORKING)
     void route(parcelset::parcel&& p,
-        util::function_nonser<void(
-            std::error_code const&, parcelset::parcel const&)>&& f,
+        hpx::function<void(std::error_code const&, parcelset::parcel const&)>&&
+            f,
         threads::thread_priority local_priority)
     {
         return detail::route(HPX_MOVE(p), HPX_MOVE(f), local_priority);

--- a/libs/full/components_base/src/component_type.cpp
+++ b/libs/full/components_base/src/component_type.cpp
@@ -7,7 +7,7 @@
 #include <hpx/config.hpp>
 #include <hpx/components_base/agas_interface.hpp>
 #include <hpx/components_base/component_type.hpp>
-#include <hpx/functional/unique_function.hpp>
+#include <hpx/functional/move_only_function.hpp>
 #include <hpx/modules/errors.hpp>
 #include <hpx/naming_base/address.hpp>
 #include <hpx/static_reinit/reinitializable_static.hpp>
@@ -84,7 +84,7 @@ namespace hpx { namespace components {
             }
 
             static bool enumerate_instance_counts(
-                util::unique_function_nonser<bool(component_type)> const& f)
+                hpx::move_only_function<bool(component_type)> const& f)
             {
                 std::vector<component_type> types;
 
@@ -125,7 +125,7 @@ namespace hpx { namespace components {
     }
 
     bool enumerate_instance_counts(
-        util::unique_function_nonser<bool(component_type)> const& f)
+        hpx::move_only_function<bool(component_type)> const& f)
     {
         return detail::component_database::enumerate_instance_counts(f);
     }

--- a/libs/full/components_base/src/detail/agas_interface_functions.cpp
+++ b/libs/full/components_base/src/detail/agas_interface_functions.cpp
@@ -200,12 +200,12 @@ namespace hpx { namespace agas { namespace detail {
     bool (*end_migration)(hpx::id_type const& id) = nullptr;
 
     hpx::future<void> (*mark_as_migrated)(naming::gid_type const& gid,
-        util::unique_function_nonser<std::pair<bool, hpx::future<void>>()>&& f,
+        hpx::move_only_function<std::pair<bool, hpx::future<void>>()>&& f,
         bool expect_to_be_marked_as_migrating) = nullptr;
 
     std::pair<bool, components::pinned_ptr> (*was_object_migrated)(
         naming::gid_type const& gid,
-        util::unique_function_nonser<components::pinned_ptr()>&& f) = nullptr;
+        hpx::move_only_function<components::pinned_ptr()>&& f) = nullptr;
 
     void (*unmark_as_migrated)(naming::gid_type const& gid) = nullptr;
 
@@ -230,8 +230,7 @@ namespace hpx { namespace agas { namespace detail {
     ///////////////////////////////////////////////////////////////////////////
 #if defined(HPX_HAVE_NETWORKING)
     void (*route)(parcelset::parcel&& p,
-        util::function_nonser<void(
-            std::error_code const&, parcelset::parcel const&)>&&,
+        hpx::function<void(std::error_code const&, parcelset::parcel const&)>&&,
         threads::thread_priority local_priority) = nullptr;
 #endif
 

--- a/libs/full/include/include/hpx/include/util.hpp
+++ b/libs/full/include/include/hpx/include/util.hpp
@@ -15,7 +15,7 @@
 #include <hpx/functional/bind_front.hpp>
 #include <hpx/functional/function.hpp>
 #include <hpx/functional/function_ref.hpp>
-#include <hpx/functional/unique_function.hpp>
+#include <hpx/functional/move_only_function.hpp>
 #include <hpx/iterator_support/iterator_adaptor.hpp>
 #include <hpx/iterator_support/iterator_facade.hpp>
 #include <hpx/modules/format.hpp>

--- a/libs/full/init_runtime/include/hpx/hpx_init_impl.hpp
+++ b/libs/full/init_runtime/include/hpx/hpx_init_impl.hpp
@@ -47,8 +47,7 @@ namespace apex {
 namespace hpx {
     namespace detail {
         inline int init_impl(
-            util::function_nonser<int(
-                hpx::program_options::variables_map&)> const& f,
+            hpx::function<int(hpx::program_options::variables_map&)> const& f,
             int argc, char** argv, init_params const& params)
         {
             if (argc == 0 || argv == nullptr)
@@ -127,7 +126,7 @@ namespace hpx {
     inline int init(
         std::nullptr_t, int argc, char** argv, init_params const& params)
     {
-        util::function_nonser<int(hpx::program_options::variables_map&)> main_f;
+        hpx::function<int(hpx::program_options::variables_map&)> main_f;
         return detail::init_impl(HPX_MOVE(main_f), argc, argv, params);
     }
 
@@ -138,8 +137,8 @@ namespace hpx {
     /// console mode or worker mode depending on the command line settings).
     inline int init(init_params const& params)
     {
-        util::function_nonser<int(hpx::program_options::variables_map&)>
-            main_f = static_cast<hpx_main_type>(::hpx_main);
+        hpx::function<int(hpx::program_options::variables_map&)> main_f =
+            static_cast<hpx_main_type>(::hpx_main);
         return detail::init_impl(
             HPX_MOVE(main_f), detail::dummy_argc, detail::dummy_argv, params);
     }

--- a/libs/full/init_runtime/include/hpx/hpx_init_params.hpp
+++ b/libs/full/init_runtime/include/hpx/hpx_init_params.hpp
@@ -47,9 +47,8 @@ namespace hpx {
     /// \cond NOINTERNAL
     namespace resource {
         // Utilities to init the thread_pools of the resource partitioner
-        using rp_callback_type =
-            hpx::util::function_nonser<void(hpx::resource::partitioner&,
-                hpx::program_options::variables_map const&)>;
+        using rp_callback_type = hpx::function<void(hpx::resource::partitioner&,
+            hpx::program_options::variables_map const&)>;
     }    // namespace resource
     /// \endcond
 

--- a/libs/full/init_runtime/include/hpx/hpx_start_impl.hpp
+++ b/libs/full/init_runtime/include/hpx/hpx_start_impl.hpp
@@ -45,8 +45,7 @@ namespace apex {
 namespace hpx {
     namespace detail {
         inline bool start_impl(
-            util::function_nonser<int(
-                hpx::program_options::variables_map&)> const& f,
+            hpx::function<int(hpx::program_options::variables_map&)> const& f,
             int argc, char** argv, init_params const& params)
         {
             if (argc == 0 || argv == nullptr)
@@ -103,8 +102,8 @@ namespace hpx {
     inline bool start(std::function<int(int, char**)> f, int argc, char** argv,
         init_params const& params)
     {
-        util::function_nonser<int(hpx::program_options::variables_map&)>
-            main_f = util::bind_back(detail::init_helper, HPX_MOVE(f));
+        hpx::function<int(hpx::program_options::variables_map&)> main_f =
+            util::bind_back(detail::init_helper, HPX_MOVE(f));
         return detail::start_impl(HPX_MOVE(main_f), argc, argv, params);
     }
 
@@ -118,8 +117,8 @@ namespace hpx {
     /// with the runtime system's execution.
     inline bool start(int argc, char** argv, init_params const& params)
     {
-        util::function_nonser<int(hpx::program_options::variables_map&)>
-            main_f = static_cast<hpx_main_type>(::hpx_main);
+        hpx::function<int(hpx::program_options::variables_map&)> main_f =
+            static_cast<hpx_main_type>(::hpx_main);
         return detail::start_impl(HPX_MOVE(main_f), argc, argv, params);
     }
 
@@ -134,7 +133,7 @@ namespace hpx {
     inline bool start(
         std::nullptr_t, int argc, char** argv, init_params const& params)
     {
-        util::function_nonser<int(hpx::program_options::variables_map&)> main_f;
+        hpx::function<int(hpx::program_options::variables_map&)> main_f;
         return detail::start_impl(HPX_MOVE(main_f), argc, argv, params);
     }
 
@@ -148,8 +147,8 @@ namespace hpx {
     /// with the runtime system's execution.
     inline bool start(init_params const& params)
     {
-        util::function_nonser<int(hpx::program_options::variables_map&)>
-            main_f = static_cast<hpx_main_type>(::hpx_main);
+        hpx::function<int(hpx::program_options::variables_map&)> main_f =
+            static_cast<hpx_main_type>(::hpx_main);
         return detail::start_impl(
             HPX_MOVE(main_f), detail::dummy_argc, detail::dummy_argv, params);
     }

--- a/libs/full/init_runtime/include/hpx/init_runtime/detail/run_or_start.hpp
+++ b/libs/full/init_runtime/include/hpx/init_runtime/detail/run_or_start.hpp
@@ -14,8 +14,8 @@ namespace hpx {
     /// \cond NOINTERNAL
     namespace detail {
         HPX_EXPORT int run_or_start(
-            util::function_nonser<int(
-                hpx::program_options::variables_map& vm)> const& f,
+            hpx::function<int(hpx::program_options::variables_map& vm)> const&
+                f,
             int argc, char** argv, init_params const& params, bool blocking);
     }    // namespace detail
     /// \endcond

--- a/libs/full/init_runtime/src/hpx_init.cpp
+++ b/libs/full/init_runtime/src/hpx_init.cpp
@@ -606,8 +606,8 @@ namespace hpx {
 
         ///////////////////////////////////////////////////////////////////////
         int run(hpx::runtime& rt,
-            util::function_nonser<int(
-                hpx::program_options::variables_map& vm)> const& f,
+            hpx::function<int(hpx::program_options::variables_map& vm)> const&
+                f,
             hpx::program_options::variables_map& vm, runtime_mode mode,
             startup_function_type startup, shutdown_function_type shutdown)
         {
@@ -625,8 +625,8 @@ namespace hpx {
         }
 
         int start(hpx::runtime& rt,
-            util::function_nonser<int(
-                hpx::program_options::variables_map& vm)> const& f,
+            hpx::function<int(hpx::program_options::variables_map& vm)> const&
+                f,
             hpx::program_options::variables_map& vm, runtime_mode mode,
             startup_function_type startup, shutdown_function_type shutdown)
         {
@@ -759,8 +759,9 @@ namespace hpx {
         }
 
         ///////////////////////////////////////////////////////////////////////
-        int run_or_start(util::function_nonser<int(
-                             hpx::program_options::variables_map& vm)> const& f,
+        int run_or_start(
+            hpx::function<int(hpx::program_options::variables_map& vm)> const&
+                f,
             int argc, char** argv, init_params const& params, bool blocking)
         {
             init_environment();

--- a/libs/full/init_runtime/tests/unit/runtime_type.cpp
+++ b/libs/full/init_runtime/tests/unit/runtime_type.cpp
@@ -52,8 +52,8 @@ int main(int argc, char* argv[])
         iparams.mode = hpx::runtime_mode::local;
         ran_hpx_main = false;
 
-        hpx::util::function_nonser<int(hpx::program_options::variables_map&)>
-            func = static_cast<hpx::hpx_main_type>(::hpx_main);
+        hpx::function<int(hpx::program_options::variables_map&)> func =
+            static_cast<hpx::hpx_main_type>(::hpx_main);
 
         hpx::init(func, argc, argv, iparams);
         HPX_TEST(ran_hpx_main);

--- a/libs/full/parcelport_libfabric/include/hpx/parcelport_libfabric/libfabric_controller.hpp
+++ b/libs/full/parcelport_libfabric/include/hpx/parcelport_libfabric/libfabric_controller.hpp
@@ -744,9 +744,9 @@ namespace hpx { namespace parcelset { namespace policies { namespace libfabric {
 
         // types we need for connection and disconnection callback functions
         // into the main parcelport code.
-        typedef util::function_nonser<void(fid_ep* endpoint, uint32_t ipaddr)>
+        typedef hpx::function<void(fid_ep* endpoint, uint32_t ipaddr)>
             ConnectionFunction;
-        typedef util::function_nonser<void(fid_ep* endpoint, uint32_t ipaddr)>
+        typedef hpx::function<void(fid_ep* endpoint, uint32_t ipaddr)>
             DisconnectionFunction;
 
         // --------------------------------------------------------------------

--- a/libs/full/parcelport_libfabric/include/hpx/parcelport_libfabric/pinned_memory_vector.hpp
+++ b/libs/full/parcelport_libfabric/include/hpx/parcelport_libfabric/pinned_memory_vector.hpp
@@ -41,7 +41,7 @@ namespace hpx { namespace parcelset { namespace policies { namespace libfabric {
         typedef pinned_memory_vector<T, Offset, region_type, allocator_type>
             vector_type;
 
-        typedef util::function_nonser<void()> deleter_callback;
+        typedef hpx::function<void()> deleter_callback;
 
         // internal vars
         T* m_array_;

--- a/libs/full/parcelport_libfabric/include/hpx/parcelport_libfabric/rma_receiver.hpp
+++ b/libs/full/parcelport_libfabric/include/hpx/parcelport_libfabric/rma_receiver.hpp
@@ -39,8 +39,7 @@ namespace hpx { namespace parcelset { namespace policies { namespace libfabric {
             header_type::header_block_size;
 
         typedef serialization::serialization_chunk chunk_struct;
-        typedef hpx::util::function_nonser<void(rma_receiver*)>
-            completion_handler;
+        typedef hpx::function<void(rma_receiver*)> completion_handler;
 
         rma_receiver(parcelport* pp, fid_ep* endpoint,
             memory_pool_type* memory_pool, completion_handler&& handler);

--- a/libs/full/parcelport_libfabric/include/hpx/parcelport_libfabric/sender.hpp
+++ b/libs/full/parcelport_libfabric/include/hpx/parcelport_libfabric/sender.hpp
@@ -138,8 +138,8 @@ namespace hpx { namespace parcelset { namespace policies { namespace libfabric {
         performance_counter<unsigned int> sends_deleted_;
         performance_counter<unsigned int> acks_received_;
         //
-        util::unique_function_nonser<void(error_code const&)> handler_;
-        util::function_nonser<void(sender*)> postprocess_handler_;
+        hpx::move_only_function<void(error_code const&)> handler_;
+        hpx::function<void(sender*)> postprocess_handler_;
         //
         struct iovec region_list_[2];
         void* desc_[2];

--- a/libs/full/parcelport_mpi/include/hpx/parcelport_mpi/sender.hpp
+++ b/libs/full/parcelport_mpi/include/hpx/parcelport_mpi/sender.hpp
@@ -68,7 +68,7 @@ namespace hpx::parcelset::policies::mpi {
             if (connection->send())
             {
                 error_code ec(lightweight);
-                util::unique_function_nonser<void(error_code const&,
+                hpx::move_only_function<void(error_code const&,
                     parcelset::locality const&, connection_ptr)>
                     postprocess_handler;
                 std::swap(

--- a/libs/full/parcelport_mpi/include/hpx/parcelport_mpi/sender_connection.hpp
+++ b/libs/full/parcelport_mpi/include/hpx/parcelport_mpi/sender_connection.hpp
@@ -45,7 +45,7 @@ namespace hpx::parcelset::policies::mpi {
         using sender_type = sender;
 
         using write_handler_type =
-            util::function_nonser<void(std::error_code const&, parcel const&)>;
+            hpx::function<void(std::error_code const&, parcel const&)>;
 
         using data_type = std::vector<char>;
 
@@ -289,8 +289,8 @@ namespace hpx::parcelset::policies::mpi {
         sender_type* sender_;
         int tag_;
         int dst_;
-        util::unique_function_nonser<void(error_code const&)> handler_;
-        util::unique_function_nonser<void(error_code const&,
+        hpx::move_only_function<void(error_code const&)> handler_;
+        hpx::move_only_function<void(error_code const&,
             parcelset::locality const&, std::shared_ptr<sender_connection>)>
             postprocess_handler_;
 

--- a/libs/full/parcelport_tcp/include/hpx/parcelport_tcp/sender.hpp
+++ b/libs/full/parcelport_tcp/include/hpx/parcelport_tcp/sender.hpp
@@ -52,7 +52,7 @@ namespace hpx::parcelset::policies::tcp {
       : public parcelset::parcelport_connection<sender, std::vector<char>>
     {
         using postprocess_handler_type =
-            util::unique_function_nonser<void(std::error_code const&)>;
+            hpx::move_only_function<void(std::error_code const&)>;
 
     public:
         // Construct a sending parcelport_connection with the given io_context.
@@ -221,7 +221,7 @@ namespace hpx::parcelset::policies::tcp {
             if (e)
             {
                 // inform post-processing handler of error as well
-                util::unique_function_nonser<void(std::error_code const&,
+                hpx::move_only_function<void(std::error_code const&,
                     parcelset::locality const&, std::shared_ptr<sender>)>
                     postprocess_handler;
                 std::swap(postprocess_handler, postprocess_handler_);
@@ -258,7 +258,7 @@ namespace hpx::parcelset::policies::tcp {
             // Call post-processing handler, which will send remaining pending
             // parcels. Pass along the connection so it can be reused if more
             // parcels have to be sent.
-            util::unique_function_nonser<void(std::error_code const&,
+            hpx::move_only_function<void(std::error_code const&,
                 parcelset::locality const&, std::shared_ptr<sender>)>
                 postprocess_handler;
             std::swap(postprocess_handler, postprocess_handler_);
@@ -278,7 +278,7 @@ namespace hpx::parcelset::policies::tcp {
         parcelset::parcelport* pp_;
 
         postprocess_handler_type handler_;
-        util::unique_function_nonser<void(std::error_code const&,
+        hpx::move_only_function<void(std::error_code const&,
             parcelset::locality const&, std::shared_ptr<sender>)>
             postprocess_handler_;
     };

--- a/libs/full/parcelset/include/hpx/parcelset/detail/parcel_await.hpp
+++ b/libs/full/parcelset/include/hpx/parcelset/detail/parcel_await.hpp
@@ -19,14 +19,14 @@
 
 namespace hpx { namespace parcelset { namespace detail {
 
-    using put_parcel_type = hpx::util::unique_function_nonser<void(
+    using put_parcel_type = hpx::move_only_function<void(
         parcelset::parcel&&, write_handler_type&&)>;
 
     void HPX_EXPORT parcel_await_apply(parcelset::parcel&& p,
         write_handler_type&& f, std::uint32_t archive_flags,
         put_parcel_type pp);
 
-    using put_parcels_type = hpx::util::unique_function_nonser<void(
+    using put_parcels_type = hpx::move_only_function<void(
         std::vector<parcelset::parcel>&&, std::vector<write_handler_type>&&)>;
 
     void HPX_EXPORT parcels_await_apply(std::vector<parcelset::parcel>&& p,

--- a/libs/full/parcelset/include/hpx/parcelset/parcelhandler.hpp
+++ b/libs/full/parcelset/include/hpx/parcelset/parcelhandler.hpp
@@ -374,8 +374,7 @@ namespace hpx::parcelset {
         write_handler_type set_write_handler(write_handler_type f);
 
         bool enum_parcelports(
-            hpx::util::unique_function_nonser<bool(std::string const&)> const&
-                f) const;
+            hpx::move_only_function<bool(std::string const&)> const& f) const;
 
         std::int64_t get_incoming_queue_length(bool /*reset*/) const
         {

--- a/libs/full/parcelset/src/detail/parcel_await.cpp
+++ b/libs/full/parcelset/src/detail/parcel_await.cpp
@@ -31,7 +31,7 @@ namespace hpx::parcelset::detail {
     struct parcel_await_base : std::enable_shared_from_this<Derived>
     {
         using put_parcel_type =
-            hpx::util::unique_function_nonser<void(Parcel&&, Handler&&)>;
+            hpx::move_only_function<void(Parcel&&, Handler&&)>;
 
         parcel_await_base(Parcel&& parcel, Handler&& handler,
             std::uint32_t archive_flags, put_parcel_type pp) noexcept

--- a/libs/full/parcelset/src/parcelhandler.cpp
+++ b/libs/full/parcelset/src/parcelhandler.cpp
@@ -262,8 +262,7 @@ namespace hpx::parcelset {
     }
 
     bool parcelhandler::enum_parcelports(
-        hpx::util::unique_function_nonser<bool(std::string const&)> const& f)
-        const
+        hpx::move_only_function<bool(std::string const&)> const& f) const
     {
         for (pports_type::value_type const& pp : pports_)
         {

--- a/libs/full/parcelset_base/include/hpx/parcelset_base/parcelport.hpp
+++ b/libs/full/parcelset_base/include/hpx/parcelset_base/parcelport.hpp
@@ -57,7 +57,7 @@ namespace hpx::parcelset {
     public:
         using write_handler_type = parcel_write_handler_type;
 
-        using read_handler_type = util::function_nonser<void(parcelport& pp,
+        using read_handler_type = hpx::function<void(parcelport& pp,
             std::shared_ptr<std::vector<char>>, threads::thread_priority)>;
 
         /// Construct the parcelport on the given locality.

--- a/libs/full/parcelset_base/include/hpx/parcelset_base/parcelset_base_fwd.hpp
+++ b/libs/full/parcelset_base/include/hpx/parcelset_base/parcelset_base_fwd.hpp
@@ -24,8 +24,8 @@ namespace hpx::parcelset {
     ///       parcel layer whenever a parcel has been sent by the underlying
     ///       networking library and if no explicit parcel handler function was
     ///       specified for the parcel.
-    using parcel_write_handler_type = util::function_nonser<void(
-        std::error_code const&, parcelset::parcel const&)>;
+    using parcel_write_handler_type =
+        hpx::function<void(std::error_code const&, parcelset::parcel const&)>;
 
     ////////////////////////////////////////////////////////////////////////
     /// Type of background work to perform

--- a/libs/full/parcelset_base/include/hpx/parcelset_base/policies/message_handler.hpp
+++ b/libs/full/parcelset_base/include/hpx/parcelset_base/policies/message_handler.hpp
@@ -26,7 +26,7 @@ namespace hpx::parcelset::policies {
             flush_mode_buffer_full = 2
         };
 
-        using write_handler_type = util::function_nonser<void(
+        using write_handler_type = hpx::function<void(
             std::error_code const&, parcelset::parcel const&)>;
 
         virtual ~message_handler() = default;

--- a/libs/full/performance_counters/include/hpx/performance_counters/counter_creators.hpp
+++ b/libs/full/performance_counters/include/hpx/performance_counters/counter_creators.hpp
@@ -101,13 +101,12 @@ namespace hpx { namespace performance_counters {
     ///   /<objectname>(locality#<locality_id>/total)/<instancename>
     ///
     HPX_EXPORT naming::gid_type locality_raw_counter_creator(
-        counter_info const&,
-        hpx::util::function_nonser<std::int64_t(bool)> const&, error_code&);
+        counter_info const&, hpx::function<std::int64_t(bool)> const&,
+        error_code&);
 
     HPX_EXPORT naming::gid_type locality_raw_values_counter_creator(
         counter_info const&,
-        hpx::util::function_nonser<std::vector<std::int64_t>(bool)> const&,
-        error_code&);
+        hpx::function<std::vector<std::int64_t>(bool)> const&, error_code&);
 
     ///////////////////////////////////////////////////////////////////////////
     /// Creation function for raw counters. The passed function is encapsulating
@@ -152,8 +151,7 @@ namespace hpx { namespace performance_counters {
     // Creation function for per-action parcel data counters
     HPX_EXPORT naming::gid_type per_action_data_counter_creator(
         counter_info const& info,
-        hpx::util::function_nonser<std::int64_t(
-            std::string const&, bool)> const& f,
+        hpx::function<std::int64_t(std::string const&, bool)> const& f,
         error_code& ec);
 
     // Discoverer function for per-action parcel data counters

--- a/libs/full/performance_counters/include/hpx/performance_counters/counters.hpp
+++ b/libs/full/performance_counters/include/hpx/performance_counters/counters.hpp
@@ -367,21 +367,20 @@ namespace hpx { namespace performance_counters {
     /// \brief This declares the type of a function, which will be
     ///        called by HPX whenever a new performance counter instance of a
     ///        particular type needs to be created.
-    typedef hpx::util::function_nonser<naming::gid_type(
-        counter_info const&, error_code&)>
+    typedef hpx::function<naming::gid_type(counter_info const&, error_code&)>
         create_counter_func;
 
     ///////////////////////////////////////////////////////////////////////////
     /// \brief This declares a type of a function, which will be passed to
     ///        a \a discover_counters_func in order to be called for each
     ///        discovered performance counter instance.
-    typedef hpx::util::function_nonser<bool(counter_info const&, error_code&)>
+    typedef hpx::function<bool(counter_info const&, error_code&)>
         discover_counter_func;
 
     /// \brief This declares the type of a function, which will be called by
     ///        HPX whenever it needs to discover all performance counter
     ///        instances of a particular type.
-    typedef hpx::util::function_nonser<bool(counter_info const&,
+    typedef hpx::function<bool(counter_info const&,
         discover_counter_func const&, discover_counters_mode, error_code&)>
         discover_counters_func;
 

--- a/libs/full/performance_counters/include/hpx/performance_counters/counters_fwd.hpp
+++ b/libs/full/performance_counters/include/hpx/performance_counters/counters_fwd.hpp
@@ -231,15 +231,14 @@ namespace hpx { namespace performance_counters {
     // This declares the type of a function, which will be
     // called by HPX whenever a new performance counter instance of a
     // particular type needs to be created.
-    typedef hpx::util::function_nonser<naming::gid_type(
-        counter_info const&, error_code&)>
+    typedef hpx::function<naming::gid_type(counter_info const&, error_code&)>
         create_counter_func;
 
     ///////////////////////////////////////////////////////////////////////////
     // This declares a type of a function, which will be passed to
     // a \a discover_counters_func in order to be called for each
     // discovered performance counter instance.
-    typedef hpx::util::function_nonser<bool(counter_info const&, error_code&)>
+    typedef hpx::function<bool(counter_info const&, error_code&)>
         discover_counter_func;
 
     enum discover_counters_mode
@@ -251,7 +250,7 @@ namespace hpx { namespace performance_counters {
     // This declares the type of a function, which will be called by
     // HPX whenever it needs to discover all performance counter
     // instances of a particular type.
-    typedef hpx::util::function_nonser<bool(counter_info const&,
+    typedef hpx::function<bool(counter_info const&,
         discover_counter_func const&, discover_counters_mode, error_code&)>
         discover_counters_func;
 
@@ -535,24 +534,22 @@ namespace hpx { namespace performance_counters {
         // Helper function for creating counters encapsulating a function
         // returning the counter value.
         HPX_EXPORT naming::gid_type create_raw_counter(counter_info const&,
-            hpx::util::function_nonser<std::int64_t()> const&, error_code&);
+            hpx::function<std::int64_t()> const&, error_code&);
 
         // Helper function for creating counters encapsulating a function
         // returning the counter value.
         HPX_EXPORT naming::gid_type create_raw_counter(counter_info const&,
-            hpx::util::function_nonser<std::int64_t(bool)> const&, error_code&);
+            hpx::function<std::int64_t(bool)> const&, error_code&);
 
         // Helper function for creating counters encapsulating a function
         // returning the counter values array.
         HPX_EXPORT naming::gid_type create_raw_counter(counter_info const&,
-            hpx::util::function_nonser<std::vector<std::int64_t>()> const&,
-            error_code&);
+            hpx::function<std::vector<std::int64_t>()> const&, error_code&);
 
         // Helper function for creating counters encapsulating a function
         // returning the counter values array.
         HPX_EXPORT naming::gid_type create_raw_counter(counter_info const&,
-            hpx::util::function_nonser<std::vector<std::int64_t>(bool)> const&,
-            error_code&);
+            hpx::function<std::vector<std::int64_t>(bool)> const&, error_code&);
 
         // Helper function for creating a new performance counter instance
         // based on a given counter value.

--- a/libs/full/performance_counters/include/hpx/performance_counters/manage_counter_type.hpp
+++ b/libs/full/performance_counters/include/hpx/performance_counters/manage_counter_type.hpp
@@ -66,7 +66,7 @@ namespace hpx { namespace performance_counters {
     ///       have to register each counter type on every locality where a
     ///       corresponding performance counter will be created.
     HPX_EXPORT counter_status install_counter_type(std::string const& name,
-        hpx::util::function_nonser<std::int64_t(bool)> const& counter_value,
+        hpx::function<std::int64_t(bool)> const& counter_value,
         std::string const& helptext = "", std::string const& uom = "",
         counter_type type = counter_raw, error_code& ec = throws);
 
@@ -114,8 +114,7 @@ namespace hpx { namespace performance_counters {
     ///       have to register each counter type on every locality where a
     ///       corresponding performance counter will be created.
     HPX_EXPORT counter_status install_counter_type(std::string const& name,
-        hpx::util::function_nonser<std::vector<std::int64_t>(bool)> const&
-            counter_value,
+        hpx::function<std::vector<std::int64_t>(bool)> const& counter_value,
         std::string const& helptext = "", std::string const& uom = "",
         error_code& ec = throws);
 

--- a/libs/full/performance_counters/include/hpx/performance_counters/registry.hpp
+++ b/libs/full/performance_counters/include/hpx/performance_counters/registry.hpp
@@ -97,29 +97,28 @@ namespace hpx { namespace performance_counters {
         ///        raw_counter based on given function returning the counter
         ///        value
         counter_status create_raw_counter(counter_info const& info,
-            hpx::util::function_nonser<std::int64_t()> const& f,
+            hpx::function<std::int64_t()> const& f, naming::gid_type& id,
+            error_code& ec = throws);
+
+        /// \brief Create a new performance counter instance of type
+        ///        raw_counter based on given function returning the counter
+        ///        value
+        counter_status create_raw_counter(counter_info const& info,
+            hpx::function<std::int64_t(bool)> const& f, naming::gid_type& id,
+            error_code& ec = throws);
+
+        /// \brief Create a new performance counter instance of type
+        ///        raw_counter based on given function returning the counter
+        ///        value
+        counter_status create_raw_counter(counter_info const& info,
+            hpx::function<std::vector<std::int64_t>()> const& f,
             naming::gid_type& id, error_code& ec = throws);
 
         /// \brief Create a new performance counter instance of type
         ///        raw_counter based on given function returning the counter
         ///        value
         counter_status create_raw_counter(counter_info const& info,
-            hpx::util::function_nonser<std::int64_t(bool)> const& f,
-            naming::gid_type& id, error_code& ec = throws);
-
-        /// \brief Create a new performance counter instance of type
-        ///        raw_counter based on given function returning the counter
-        ///        value
-        counter_status create_raw_counter(counter_info const& info,
-            hpx::util::function_nonser<std::vector<std::int64_t>()> const& f,
-            naming::gid_type& id, error_code& ec = throws);
-
-        /// \brief Create a new performance counter instance of type
-        ///        raw_counter based on given function returning the counter
-        ///        value
-        counter_status create_raw_counter(counter_info const& info,
-            hpx::util::function_nonser<std::vector<std::int64_t>(bool)> const&
-                f,
+            hpx::function<std::vector<std::int64_t>(bool)> const& f,
             naming::gid_type& id, error_code& ec = throws);
 
         /// \brief Create a new performance counter instance based on given

--- a/libs/full/performance_counters/include/hpx/performance_counters/server/raw_counter.hpp
+++ b/libs/full/performance_counters/include/hpx/performance_counters/server/raw_counter.hpp
@@ -28,8 +28,8 @@ namespace hpx { namespace performance_counters { namespace server {
 
         raw_counter();
 
-        raw_counter(counter_info const& info,
-            hpx::util::function_nonser<std::int64_t(bool)> f);
+        raw_counter(
+            counter_info const& info, hpx::function<std::int64_t(bool)> f);
 
         hpx::performance_counters::counter_value get_counter_value(
             bool reset = false) override;
@@ -41,7 +41,7 @@ namespace hpx { namespace performance_counters { namespace server {
         naming::address get_current_address() const;
 
     private:
-        hpx::util::function_nonser<std::int64_t(bool)> f_;
+        hpx::function<std::int64_t(bool)> f_;
         bool reset_;
     };
 }}}    // namespace hpx::performance_counters::server

--- a/libs/full/performance_counters/include/hpx/performance_counters/server/raw_values_counter.hpp
+++ b/libs/full/performance_counters/include/hpx/performance_counters/server/raw_values_counter.hpp
@@ -30,7 +30,7 @@ namespace hpx { namespace performance_counters { namespace server {
         raw_values_counter();
 
         raw_values_counter(counter_info const& info,
-            hpx::util::function_nonser<std::vector<std::int64_t>(bool)> f);
+            hpx::function<std::vector<std::int64_t>(bool)> f);
 
         hpx::performance_counters::counter_values_array
         get_counter_values_array(bool reset = false) override;
@@ -43,7 +43,7 @@ namespace hpx { namespace performance_counters { namespace server {
         naming::address get_current_address() const;
 
     private:
-        hpx::util::function_nonser<std::vector<std::int64_t>(bool)> f_;
+        hpx::function<std::vector<std::int64_t>(bool)> f_;
         bool reset_;
     };
 }}}    // namespace hpx::performance_counters::server

--- a/libs/full/performance_counters/src/agas_counter_types.cpp
+++ b/libs/full/performance_counters/src/agas_counter_types.cpp
@@ -26,48 +26,43 @@ namespace hpx { namespace performance_counters {
     void register_agas_counter_types(agas::addressing_service& client)
     {
         // install
-        util::function_nonser<std::int64_t(bool)> cache_entries(
-            util::bind_front(
-                &agas::addressing_service::get_cache_entries, &client));
-        util::function_nonser<std::int64_t(bool)> cache_hits(util::bind_front(
+        hpx::function<std::int64_t(bool)> cache_entries(util::bind_front(
+            &agas::addressing_service::get_cache_entries, &client));
+        hpx::function<std::int64_t(bool)> cache_hits(util::bind_front(
             &agas::addressing_service::get_cache_hits, &client));
-        util::function_nonser<std::int64_t(bool)> cache_misses(util::bind_front(
+        hpx::function<std::int64_t(bool)> cache_misses(util::bind_front(
             &agas::addressing_service::get_cache_misses, &client));
-        util::function_nonser<std::int64_t(bool)> cache_evictions(
-            util::bind_front(
-                &agas::addressing_service::get_cache_evictions, &client));
-        util::function_nonser<std::int64_t(bool)> cache_insertions(
-            util::bind_front(
-                &agas::addressing_service::get_cache_insertions, &client));
+        hpx::function<std::int64_t(bool)> cache_evictions(util::bind_front(
+            &agas::addressing_service::get_cache_evictions, &client));
+        hpx::function<std::int64_t(bool)> cache_insertions(util::bind_front(
+            &agas::addressing_service::get_cache_insertions, &client));
 
-        util::function_nonser<std::int64_t(bool)> cache_get_entry_count(
+        hpx::function<std::int64_t(bool)> cache_get_entry_count(
             util::bind_front(
                 &agas::addressing_service::get_cache_get_entry_count, &client));
-        util::function_nonser<std::int64_t(bool)> cache_insertion_count(
+        hpx::function<std::int64_t(bool)> cache_insertion_count(
             util::bind_front(
                 &agas::addressing_service::get_cache_insertion_entry_count,
                 &client));
-        util::function_nonser<std::int64_t(bool)> cache_update_entry_count(
+        hpx::function<std::int64_t(bool)> cache_update_entry_count(
             util::bind_front(
                 &agas::addressing_service::get_cache_update_entry_count,
                 &client));
-        util::function_nonser<std::int64_t(bool)> cache_erase_entry_count(
+        hpx::function<std::int64_t(bool)> cache_erase_entry_count(
             util::bind_front(
                 &agas::addressing_service::get_cache_erase_entry_count,
                 &client));
 
-        util::function_nonser<std::int64_t(bool)> cache_get_entry_time(
-            util::bind_front(
-                &agas::addressing_service::get_cache_get_entry_time, &client));
-        util::function_nonser<std::int64_t(bool)> cache_insertion_time(
-            util::bind_front(
-                &agas::addressing_service::get_cache_insertion_entry_time,
-                &client));
-        util::function_nonser<std::int64_t(bool)> cache_update_entry_time(
+        hpx::function<std::int64_t(bool)> cache_get_entry_time(util::bind_front(
+            &agas::addressing_service::get_cache_get_entry_time, &client));
+        hpx::function<std::int64_t(bool)> cache_insertion_time(util::bind_front(
+            &agas::addressing_service::get_cache_insertion_entry_time,
+            &client));
+        hpx::function<std::int64_t(bool)> cache_update_entry_time(
             util::bind_front(
                 &agas::addressing_service::get_cache_update_entry_time,
                 &client));
-        util::function_nonser<std::int64_t(bool)> cache_erase_entry_time(
+        hpx::function<std::int64_t(bool)> cache_erase_entry_time(
             util::bind_front(
                 &agas::addressing_service::get_cache_erase_entry_time,
                 &client));

--- a/libs/full/performance_counters/src/component_namespace_counters.cpp
+++ b/libs/full/performance_counters/src/component_namespace_counters.cpp
@@ -172,7 +172,7 @@ namespace hpx { namespace agas { namespace server {
 
         typedef component_namespace::counter_data cd;
 
-        util::function_nonser<std::int64_t(bool)> get_data_func;
+        hpx::function<std::int64_t(bool)> get_data_func;
         if (target == detail::counter_target_count)
         {
             switch (code)

--- a/libs/full/performance_counters/src/counter_creators.cpp
+++ b/libs/full/performance_counters/src/counter_creators.cpp
@@ -446,7 +446,7 @@ namespace hpx { namespace performance_counters {
     ///   /<objectname>{locality#<locality_id>/total}/<instancename>
     ///
     naming::gid_type locality_raw_counter_creator(counter_info const& info,
-        hpx::util::function_nonser<std::int64_t(bool)> const& f, error_code& ec)
+        hpx::function<std::int64_t(bool)> const& f, error_code& ec)
     {
         // verify the validity of the counter instance name
         counter_path_elements paths;
@@ -473,8 +473,7 @@ namespace hpx { namespace performance_counters {
 
     naming::gid_type locality_raw_values_counter_creator(
         counter_info const& info,
-        hpx::util::function_nonser<std::vector<std::int64_t>(bool)> const& f,
-        error_code& ec)
+        hpx::function<std::vector<std::int64_t>(bool)> const& f, error_code& ec)
     {
         // verify the validity of the counter instance name
         counter_path_elements paths;

--- a/libs/full/performance_counters/src/counters.cpp
+++ b/libs/full/performance_counters/src/counters.cpp
@@ -651,7 +651,7 @@ namespace hpx { namespace performance_counters {
         }
 
         naming::gid_type create_raw_counter(counter_info const& info,
-            hpx::util::function_nonser<std::int64_t()> const& f, error_code& ec)
+            hpx::function<std::int64_t()> const& f, error_code& ec)
         {
             HPX_ASSERT(hpx::get_runtime_ptr() != nullptr);
             naming::gid_type gid;
@@ -660,8 +660,7 @@ namespace hpx { namespace performance_counters {
         }
 
         naming::gid_type create_raw_counter(counter_info const& info,
-            hpx::util::function_nonser<std::int64_t(bool)> const& f,
-            error_code& ec)
+            hpx::function<std::int64_t(bool)> const& f, error_code& ec)
         {
             HPX_ASSERT(hpx::get_runtime_ptr() != nullptr);
             naming::gid_type gid;
@@ -670,8 +669,7 @@ namespace hpx { namespace performance_counters {
         }
 
         naming::gid_type create_raw_counter(counter_info const& info,
-            hpx::util::function_nonser<std::vector<std::int64_t>()> const& f,
-            error_code& ec)
+            hpx::function<std::vector<std::int64_t>()> const& f, error_code& ec)
         {
             HPX_ASSERT(hpx::get_runtime_ptr() != nullptr);
             naming::gid_type gid;
@@ -680,8 +678,7 @@ namespace hpx { namespace performance_counters {
         }
 
         naming::gid_type create_raw_counter(counter_info const& info,
-            hpx::util::function_nonser<std::vector<std::int64_t>(bool)> const&
-                f,
+            hpx::function<std::vector<std::int64_t>(bool)> const& f,
             error_code& ec)
         {
             HPX_ASSERT(hpx::get_runtime_ptr() != nullptr);

--- a/libs/full/performance_counters/src/locality_namespace_counters.cpp
+++ b/libs/full/performance_counters/src/locality_namespace_counters.cpp
@@ -172,7 +172,7 @@ namespace hpx { namespace agas { namespace server {
 
         typedef locality_namespace::counter_data cd;
 
-        util::function_nonser<std::int64_t(bool)> get_data_func;
+        hpx::function<std::int64_t(bool)> get_data_func;
         if (target == detail::counter_target_count)
         {
             switch (code)

--- a/libs/full/performance_counters/src/manage_counter_type.cpp
+++ b/libs/full/performance_counters/src/manage_counter_type.cpp
@@ -134,7 +134,7 @@ namespace hpx { namespace performance_counters {
     // provide the data in a way, which will uninstall it automatically during
     // shutdown.
     counter_status install_counter_type(std::string const& name,
-        hpx::util::function_nonser<std::int64_t(bool)> const& counter_value,
+        hpx::function<std::int64_t(bool)> const& counter_value,
         std::string const& helptext, std::string const& uom, counter_type type,
         error_code& ec)
     {
@@ -148,8 +148,7 @@ namespace hpx { namespace performance_counters {
     }
 
     counter_status install_counter_type(std::string const& name,
-        hpx::util::function_nonser<std::vector<std::int64_t>(bool)> const&
-            counter_value,
+        hpx::function<std::vector<std::int64_t>(bool)> const& counter_value,
         std::string const& helptext, std::string const& uom, error_code& ec)
     {
         using hpx::util::placeholders::_1;

--- a/libs/full/performance_counters/src/parcelhandler_counter_types.cpp
+++ b/libs/full/performance_counters/src/parcelhandler_counter_types.cpp
@@ -35,75 +35,70 @@ namespace hpx::performance_counters {
         using parcelset::parcelhandler;
 
 #if defined(HPX_HAVE_PARCELPORT_ACTION_COUNTERS)
-        util::function_nonser<std::int64_t(std::string const&, bool)>
-            num_parcel_sends(util::bind_front(
+        hpx::function<std::int64_t(std::string const&, bool)> num_parcel_sends(
+            util::bind_front(
                 &parcelhandler::get_action_parcel_send_count, &ph, pp_type));
-        util::function_nonser<std::int64_t(std::string const&, bool)>
+        hpx::function<std::int64_t(std::string const&, bool)>
             num_parcel_receives(util::bind_front(
                 &parcelhandler::get_action_parcel_receive_count, &ph, pp_type));
 #else
-        util::function_nonser<std::int64_t(bool)> num_parcel_sends(
-            util::bind_front(
-                &parcelhandler::get_parcel_send_count, &ph, pp_type));
-        util::function_nonser<std::int64_t(bool)> num_parcel_receives(
-            util::bind_front(
-                &parcelhandler::get_parcel_receive_count, &ph, pp_type));
+        hpx::function<std::int64_t(bool)> num_parcel_sends(util::bind_front(
+            &parcelhandler::get_parcel_send_count, &ph, pp_type));
+        hpx::function<std::int64_t(bool)> num_parcel_receives(util::bind_front(
+            &parcelhandler::get_parcel_receive_count, &ph, pp_type));
 #endif
 
-        util::function_nonser<std::int64_t(bool)> num_message_sends(
-            util::bind_front(
-                &parcelhandler::get_message_send_count, &ph, pp_type));
-        util::function_nonser<std::int64_t(bool)> num_message_receives(
-            util::bind_front(
-                &parcelhandler::get_message_receive_count, &ph, pp_type));
+        hpx::function<std::int64_t(bool)> num_message_sends(util::bind_front(
+            &parcelhandler::get_message_send_count, &ph, pp_type));
+        hpx::function<std::int64_t(bool)> num_message_receives(util::bind_front(
+            &parcelhandler::get_message_receive_count, &ph, pp_type));
 
-        util::function_nonser<std::int64_t(bool)> sending_time(
+        hpx::function<std::int64_t(bool)> sending_time(
             util::bind_front(&parcelhandler::get_sending_time, &ph, pp_type));
-        util::function_nonser<std::int64_t(bool)> receiving_time(
+        hpx::function<std::int64_t(bool)> receiving_time(
             util::bind_front(&parcelhandler::get_receiving_time, &ph, pp_type));
 
 #if defined(HPX_HAVE_PARCELPORT_ACTION_COUNTERS)
-        util::function_nonser<std::int64_t(std::string const&, bool)>
+        hpx::function<std::int64_t(std::string const&, bool)>
             sending_serialization_time(util::bind_front(
                 &parcelhandler::get_action_sending_serialization_time, &ph,
                 pp_type));
-        util::function_nonser<std::int64_t(std::string const&, bool)>
+        hpx::function<std::int64_t(std::string const&, bool)>
             receiving_serialization_time(util::bind_front(
                 &parcelhandler::get_action_receiving_serialization_time, &ph,
                 pp_type));
 #else
-        util::function_nonser<std::int64_t(bool)> sending_serialization_time(
+        hpx::function<std::int64_t(bool)> sending_serialization_time(
             util::bind_front(
                 &parcelhandler::get_sending_serialization_time, &ph, pp_type));
-        util::function_nonser<std::int64_t(bool)> receiving_serialization_time(
+        hpx::function<std::int64_t(bool)> receiving_serialization_time(
             util::bind_front(&parcelhandler::get_receiving_serialization_time,
                 &ph, pp_type));
 #endif
 
 #if defined(HPX_HAVE_PARCELPORT_ACTION_COUNTERS)
-        util::function_nonser<std::int64_t(std::string const&, bool)> data_sent(
+        hpx::function<std::int64_t(std::string const&, bool)> data_sent(
             util::bind_front(
                 &parcelhandler::get_action_data_sent, &ph, pp_type));
-        util::function_nonser<std::int64_t(std::string const&, bool)>
-            data_received(util::bind_front(
+        hpx::function<std::int64_t(std::string const&, bool)> data_received(
+            util::bind_front(
                 &parcelhandler::get_action_data_received, &ph, pp_type));
 #else
-        util::function_nonser<std::int64_t(bool)> data_sent(
+        hpx::function<std::int64_t(bool)> data_sent(
             util::bind_front(&parcelhandler::get_data_sent, &ph, pp_type));
-        util::function_nonser<std::int64_t(bool)> data_received(
+        hpx::function<std::int64_t(bool)> data_received(
             util::bind_front(&parcelhandler::get_data_received, &ph, pp_type));
 #endif
 
-        util::function_nonser<std::int64_t(bool)> data_raw_sent(
+        hpx::function<std::int64_t(bool)> data_raw_sent(
             util::bind_front(&parcelhandler::get_raw_data_sent, &ph, pp_type));
-        util::function_nonser<std::int64_t(bool)> data_raw_received(
-            util::bind_front(
-                &parcelhandler::get_raw_data_received, &ph, pp_type));
+        hpx::function<std::int64_t(bool)> data_raw_received(util::bind_front(
+            &parcelhandler::get_raw_data_received, &ph, pp_type));
 
-        util::function_nonser<std::int64_t(bool)> buffer_allocate_time_sent(
+        hpx::function<std::int64_t(bool)> buffer_allocate_time_sent(
             util::bind_front(
                 &parcelhandler::get_buffer_allocate_time_sent, &ph, pp_type));
-        util::function_nonser<std::int64_t(bool)> buffer_allocate_time_received(
+        hpx::function<std::int64_t(bool)> buffer_allocate_time_received(
             util::bind_front(&parcelhandler::get_buffer_allocate_time_received,
                 &ph, pp_type));
 
@@ -350,19 +345,19 @@ namespace hpx::performance_counters {
         using parcelset::parcelhandler;
         using parcelset::parcelport;
 
-        util::function_nonser<std::int64_t(bool)> cache_insertions(
+        hpx::function<std::int64_t(bool)> cache_insertions(
             util::bind_front(&parcelhandler::get_connection_cache_statistics,
                 &ph, pp_type, parcelport::connection_cache_insertions));
-        util::function_nonser<std::int64_t(bool)> cache_evictions(
+        hpx::function<std::int64_t(bool)> cache_evictions(
             util::bind_front(&parcelhandler::get_connection_cache_statistics,
                 &ph, pp_type, parcelport::connection_cache_evictions));
-        util::function_nonser<std::int64_t(bool)> cache_hits(
+        hpx::function<std::int64_t(bool)> cache_hits(
             util::bind_front(&parcelhandler::get_connection_cache_statistics,
                 &ph, pp_type, parcelport::connection_cache_hits));
-        util::function_nonser<std::int64_t(bool)> cache_misses(
+        hpx::function<std::int64_t(bool)> cache_misses(
             util::bind_front(&parcelhandler::get_connection_cache_statistics,
                 &ph, pp_type, parcelport::connection_cache_misses));
-        util::function_nonser<std::int64_t(bool)> cache_reclaims(
+        hpx::function<std::int64_t(bool)> cache_reclaims(
             util::bind_front(&parcelhandler::get_connection_cache_statistics,
                 &ph, pp_type, parcelport::connection_cache_reclaims));
 
@@ -453,11 +448,11 @@ namespace hpx::performance_counters {
         using parcelset::parcelhandler;
 
         // register common counters
-        util::function_nonser<std::int64_t(bool)> incoming_queue_length(
+        hpx::function<std::int64_t(bool)> incoming_queue_length(
             util::bind_front(&parcelhandler::get_incoming_queue_length, &ph));
-        util::function_nonser<std::int64_t(bool)> outgoing_queue_length(
+        hpx::function<std::int64_t(bool)> outgoing_queue_length(
             util::bind_front(&parcelhandler::get_outgoing_queue_length, &ph));
-        util::function_nonser<std::int64_t(bool)> outgoing_routed_count(
+        hpx::function<std::int64_t(bool)> outgoing_routed_count(
             util::bind_front(&parcelhandler::get_parcel_routed_count, &ph));
 
         performance_counters::generic_counter_type_data const counter_types[] =

--- a/libs/full/performance_counters/src/primary_namespace_counters.cpp
+++ b/libs/full/performance_counters/src/primary_namespace_counters.cpp
@@ -172,7 +172,7 @@ namespace hpx { namespace agas { namespace server {
 
         using cd = primary_namespace::counter_data;
 
-        util::function_nonser<std::int64_t(bool)> get_data_func;
+        hpx::function<std::int64_t(bool)> get_data_func;
         if (target == agas::detail::counter_target_count)
         {
             switch (code)

--- a/libs/full/performance_counters/src/registry.cpp
+++ b/libs/full/performance_counters/src/registry.cpp
@@ -399,35 +399,35 @@ namespace hpx { namespace performance_counters {
     counter_status registry::create_raw_counter_value(counter_info const& info,
         std::int64_t* countervalue, naming::gid_type& id, error_code& ec)
     {
-        hpx::util::function_nonser<std::int64_t(bool)> func(
+        hpx::function<std::int64_t(bool)> func(
             util::bind_front(wrap_counter, countervalue));
         return create_raw_counter(info, func, id, ec);
     }
 
     static std::int64_t wrap_raw_counter(
-        hpx::util::function_nonser<std::int64_t()> const& f, bool)
+        hpx::function<std::int64_t()> const& f, bool)
     {
         return f();
     }
 
     static std::vector<std::int64_t> wrap_raw_values_counter(
-        hpx::util::function_nonser<std::vector<std::int64_t>()> const& f, bool)
+        hpx::function<std::vector<std::int64_t>()> const& f, bool)
     {
         return f();
     }
 
     counter_status registry::create_raw_counter(counter_info const& info,
-        hpx::util::function_nonser<std::int64_t()> const& f,
-        naming::gid_type& id, error_code& ec)
+        hpx::function<std::int64_t()> const& f, naming::gid_type& id,
+        error_code& ec)
     {
-        hpx::util::function_nonser<std::int64_t(bool)> func(
+        hpx::function<std::int64_t(bool)> func(
             util::bind_front(&wrap_raw_counter, f));
         return create_raw_counter(info, func, id, ec);
     }
 
     counter_status registry::create_raw_counter(counter_info const& info,
-        hpx::util::function_nonser<std::int64_t(bool)> const& f,
-        naming::gid_type& id, error_code& ec)
+        hpx::function<std::int64_t(bool)> const& f, naming::gid_type& id,
+        error_code& ec)
     {
         // create canonical type name
         std::string type_name;
@@ -498,16 +498,16 @@ namespace hpx { namespace performance_counters {
     }
 
     counter_status registry::create_raw_counter(counter_info const& info,
-        hpx::util::function_nonser<std::vector<std::int64_t>()> const& f,
+        hpx::function<std::vector<std::int64_t>()> const& f,
         naming::gid_type& id, error_code& ec)
     {
-        hpx::util::function_nonser<std::vector<std::int64_t>(bool)> func(
+        hpx::function<std::vector<std::int64_t>(bool)> func(
             util::bind_front(&wrap_raw_values_counter, f));
         return create_raw_counter(info, func, id, ec);
     }
 
     counter_status registry::create_raw_counter(counter_info const& info,
-        hpx::util::function_nonser<std::vector<std::int64_t>(bool)> const& f,
+        hpx::function<std::vector<std::int64_t>(bool)> const& f,
         naming::gid_type& id, error_code& ec)
     {
         // create canonical type name

--- a/libs/full/performance_counters/src/server/action_invocation_counter.cpp
+++ b/libs/full/performance_counters/src/server/action_invocation_counter.cpp
@@ -96,7 +96,7 @@ namespace hpx { namespace performance_counters {
             }
 
             // ask registry
-            hpx::util::function_nonser<std::int64_t(bool)> f =
+            hpx::function<std::int64_t(bool)> f =
                 registry.get_invocation_counter(paths.parameters_);
 
             return detail::create_raw_counter(info, HPX_MOVE(f), ec);

--- a/libs/full/performance_counters/src/server/component_instance_counter.cpp
+++ b/libs/full/performance_counters/src/server/component_instance_counter.cpp
@@ -82,7 +82,7 @@ namespace hpx { namespace performance_counters { namespace detail {
                 return naming::invalid_gid;
             }
 
-            hpx::util::function_nonser<std::int64_t()> f =
+            hpx::function<std::int64_t()> f =
                 util::bind_front(&get_instance_count, type);
             return create_raw_counter(info, HPX_MOVE(f), ec);
         }

--- a/libs/full/performance_counters/src/server/per_action_data_counters.cpp
+++ b/libs/full/performance_counters/src/server/per_action_data_counters.cpp
@@ -58,8 +58,8 @@ namespace hpx { namespace performance_counters {
     // Creation function for per-action parcel data counters
     naming::gid_type per_action_data_counter_creator(counter_info const& info,
         hpx::actions::detail::per_action_data_counter_registry& registry,
-        hpx::util::function_nonser<std::int64_t(
-            std::string const&, bool)> const& counter_func,
+        hpx::function<std::int64_t(std::string const&, bool)> const&
+            counter_func,
         error_code& ec)
     {
         switch (info.type_)
@@ -93,7 +93,7 @@ namespace hpx { namespace performance_counters {
             }
 
             // ask registry
-            hpx::util::function_nonser<std::int64_t(bool)> f =
+            hpx::function<std::int64_t(bool)> f =
                 registry.get_counter(paths.parameters_, counter_func);
 
             return detail::create_raw_counter(info, HPX_MOVE(f), ec);
@@ -108,8 +108,7 @@ namespace hpx { namespace performance_counters {
     }
 
     naming::gid_type per_action_data_counter_creator(counter_info const& info,
-        hpx::util::function_nonser<std::int64_t(
-            std::string const&, bool)> const& f,
+        hpx::function<std::int64_t(std::string const&, bool)> const& f,
         error_code& ec)
     {
         using hpx::actions::detail::per_action_data_counter_registry;

--- a/libs/full/performance_counters/src/server/raw_counter.cpp
+++ b/libs/full/performance_counters/src/server/raw_counter.cpp
@@ -33,8 +33,8 @@ namespace hpx { namespace performance_counters { namespace server {
     {
     }
 
-    raw_counter::raw_counter(counter_info const& info,
-        hpx::util::function_nonser<std::int64_t(bool)> f)
+    raw_counter::raw_counter(
+        counter_info const& info, hpx::function<std::int64_t(bool)> f)
       : base_type_holder(info)
       , f_(HPX_MOVE(f))
       , reset_(false)

--- a/libs/full/performance_counters/src/server/raw_values_counter.cpp
+++ b/libs/full/performance_counters/src/server/raw_values_counter.cpp
@@ -37,7 +37,7 @@ namespace hpx { namespace performance_counters { namespace server {
     }
 
     raw_values_counter::raw_values_counter(counter_info const& info,
-        hpx::util::function_nonser<std::vector<std::int64_t>(bool)> f)
+        hpx::function<std::vector<std::int64_t>(bool)> f)
       : base_type_holder(info)
       , f_(HPX_MOVE(f))
       , reset_(false)

--- a/libs/full/performance_counters/src/symbol_namespace_counters.cpp
+++ b/libs/full/performance_counters/src/symbol_namespace_counters.cpp
@@ -163,7 +163,7 @@ namespace hpx { namespace agas { namespace server {
 
         typedef symbol_namespace::counter_data cd;
 
-        util::function_nonser<std::int64_t(bool)> get_data_func;
+        hpx::function<std::int64_t(bool)> get_data_func;
         if (target == detail::counter_target_count)
         {
             switch (code)

--- a/libs/full/performance_counters/src/threadmanager_counter_types.cpp
+++ b/libs/full/performance_counters/src/threadmanager_counter_types.cpp
@@ -81,7 +81,7 @@ namespace hpx { namespace performance_counters { namespace detail {
         {
             // overall counter
             using detail::create_raw_counter;
-            util::function_nonser<std::int64_t(bool)> f =
+            hpx::function<std::int64_t(bool)> f =
                 util::bind_front(total_func, tm);
             return create_raw_counter(info, HPX_MOVE(f), ec);
         }
@@ -96,7 +96,7 @@ namespace hpx { namespace performance_counters { namespace detail {
                     hpx::resource::get_thread_pool(paths.instanceindex_);
 
                 using detail::create_raw_counter;
-                util::function_nonser<std::int64_t(bool)> f =
+                hpx::function<std::int64_t(bool)> f =
                     util::bind_front(pool_func, &pool_instance,
                         static_cast<std::size_t>(paths.subinstanceindex_));
                 return create_raw_counter(info, HPX_MOVE(f), ec);
@@ -108,9 +108,8 @@ namespace hpx { namespace performance_counters { namespace detail {
         {
             // specific counter from default
             using detail::create_raw_counter;
-            util::function_nonser<std::int64_t(bool)> f =
-                util::bind_front(pool_func, &pool,
-                    static_cast<std::size_t>(paths.instanceindex_));
+            hpx::function<std::int64_t(bool)> f = util::bind_front(pool_func,
+                &pool, static_cast<std::size_t>(paths.instanceindex_));
             return create_raw_counter(info, HPX_MOVE(f), ec);
         }
 
@@ -146,7 +145,7 @@ namespace hpx { namespace performance_counters { namespace detail {
         if (paths.instancename_ == "total" && paths.instanceindex_ == -1)
         {
             // counter for default pool
-            util::function_nonser<std::int64_t()> f = util::bind_back(
+            hpx::function<std::int64_t()> f = util::bind_back(
                 &threads::thread_pool_base::get_scheduler_utilization, &pool);
             return create_raw_counter(info, HPX_MOVE(f), ec);
         }
@@ -155,7 +154,7 @@ namespace hpx { namespace performance_counters { namespace detail {
             if (paths.instanceindex_ < 0)
             {
                 // counter for default pool
-                util::function_nonser<std::int64_t()> f = util::bind_back(
+                hpx::function<std::int64_t()> f = util::bind_back(
                     &threads::thread_pool_base::get_scheduler_utilization,
                     &pool);
                 return create_raw_counter(info, HPX_MOVE(f), ec);
@@ -167,7 +166,7 @@ namespace hpx { namespace performance_counters { namespace detail {
                 threads::thread_pool_base& pool_instance =
                     hpx::resource::get_thread_pool(paths.instanceindex_);
 
-                util::function_nonser<std::int64_t()> f = util::bind_back(
+                hpx::function<std::int64_t()> f = util::bind_back(
                     &threads::thread_pool_base::get_scheduler_utilization,
                     &pool_instance);
                 return create_raw_counter(info, HPX_MOVE(f), ec);
@@ -223,7 +222,7 @@ namespace hpx { namespace performance_counters { namespace detail {
                     hpx::resource::get_thread_pool(paths.instanceindex_);
 
                 using detail::create_raw_counter;
-                util::function_nonser<std::int64_t(bool)> f =
+                hpx::function<std::int64_t(bool)> f =
                     util::bind_front(pool_func, &pool_instance,
                         static_cast<std::size_t>(paths.subinstanceindex_));
                 return create_raw_counter(info, HPX_MOVE(f), ec);
@@ -235,9 +234,8 @@ namespace hpx { namespace performance_counters { namespace detail {
         {
             // specific counter
             using detail::create_raw_counter;
-            util::function_nonser<std::int64_t(bool)> f =
-                util::bind_front(pool_func, &pool,
-                    static_cast<std::size_t>(paths.instanceindex_));
+            hpx::function<std::int64_t(bool)> f = util::bind_front(pool_func,
+                &pool, static_cast<std::size_t>(paths.instanceindex_));
             return create_raw_counter(info, HPX_MOVE(f), ec);
         }
 
@@ -343,8 +341,8 @@ namespace hpx { namespace performance_counters { namespace detail {
     ///////////////////////////////////////////////////////////////////////////
     naming::gid_type counter_creator(counter_info const& info,
         counter_path_elements const& paths,
-        util::function_nonser<std::int64_t(bool)> const& total_creator,
-        util::function_nonser<std::int64_t(bool)> const& individual_creator,
+        hpx::function<std::int64_t(bool)> const& total_creator,
+        hpx::function<std::int64_t(bool)> const& individual_creator,
         char const* individual_name, std::size_t individual_count,
         error_code& ec)
     {
@@ -395,8 +393,8 @@ namespace hpx { namespace performance_counters { namespace detail {
         struct creator_data
         {
             char const* const countername;
-            util::function_nonser<std::int64_t(bool)> total_func;
-            util::function_nonser<std::int64_t(bool)> individual_func;
+            hpx::function<std::int64_t(bool)> total_func;
+            hpx::function<std::int64_t(bool)> individual_func;
             char const* const individual_name;
             std::size_t individual_count;
         };
@@ -406,13 +404,13 @@ namespace hpx { namespace performance_counters { namespace detail {
             {"count/stack-recycles",
                 util::bind_front(&threads::coroutine_type::impl_type::
                                      get_stack_recycle_count),
-                util::function_nonser<std::uint64_t(bool)>(), "", 0},
+                hpx::function<std::uint64_t(bool)>(), "", 0},
 #if !defined(HPX_WINDOWS) && !defined(HPX_HAVE_GENERIC_CONTEXT_COROUTINES)
             // /threads{locality#%d/total}/count/stack-unbinds
             {"count/stack-unbinds",
                 util::bind_front(&threads::coroutine_type::impl_type::
                                      get_stack_unbind_count),
-                util::function_nonser<std::uint64_t(bool)>(), "", 0},
+                hpx::function<std::uint64_t(bool)>(), "", 0},
 #endif
         };
         std::size_t const data_size = sizeof(data) / sizeof(data[0]);

--- a/libs/full/runtime_components/include/hpx/runtime_components/server/console_error_sink_singleton.hpp
+++ b/libs/full/runtime_components/include/hpx/runtime_components/server/console_error_sink_singleton.hpp
@@ -26,7 +26,7 @@ namespace hpx { namespace components { namespace server {
 
     public:
         typedef util::spinlock mutex_type;
-        typedef util::function_nonser<void(std::string const&)> sink_type;
+        typedef hpx::function<void(std::string const&)> sink_type;
 
         console_error_dispatcher()
           : mtx_()

--- a/libs/full/runtime_distributed/include/hpx/runtime_distributed.hpp
+++ b/libs/full/runtime_distributed/include/hpx/runtime_distributed.hpp
@@ -76,7 +76,7 @@ namespace hpx {
         ///                   return the value as returned as the result of the
         ///                   invocation of the function object given by the
         ///                   parameter \p func. Otherwise it will return zero.
-        int start(util::function_nonser<hpx_main_function_type> const& func,
+        int start(hpx::function<hpx_main_function_type> const& func,
             bool blocking = false) override;
 
         ///  \brief Start the runtime system
@@ -179,8 +179,7 @@ namespace hpx {
         /// \returns          This function will return the value as returned
         ///                   as the result of the invocation of the function
         ///                   object given by the parameter \p func.
-        int run(
-            util::function_nonser<hpx_main_function_type> const& func) override;
+        int run(hpx::function<hpx_main_function_type> const& func) override;
 
         /// \brief Run the HPX runtime system, initially use the given number
         ///        of (OS) threads in the thread-manager and block waiting for
@@ -368,7 +367,7 @@ namespace hpx {
 
     private:
         threads::thread_result_type run_helper(
-            util::function_nonser<runtime::hpx_main_function_type> const& func,
+            hpx::function<runtime::hpx_main_function_type> const& func,
             int& result);
 
         void init_global_data();

--- a/libs/full/runtime_distributed/include/hpx/runtime_distributed/big_boot_barrier.hpp
+++ b/libs/full/runtime_distributed/include/hpx/runtime_distributed/big_boot_barrier.hpp
@@ -53,7 +53,7 @@ namespace hpx { namespace agas {
         std::mutex mtx;
         std::size_t connected;
 
-        using thunk_type = util::unique_function_nonser<void()>*;
+        using thunk_type = hpx::move_only_function<void()>*;
         boost::lockfree::queue<thunk_type,
             hpx::util::aligned_allocator<thunk_type>>
             thunks;
@@ -89,7 +89,7 @@ namespace hpx { namespace agas {
 
         ~big_boot_barrier()
         {
-            util::unique_function_nonser<void()>* f;
+            hpx::move_only_function<void()>* f;
             while (thunks.pop(f))
                 delete f;
         }
@@ -125,7 +125,7 @@ namespace hpx { namespace agas {
         // no-op on non-bootstrap localities
         void trigger();
 
-        void add_thunk(util::unique_function_nonser<void()>* f);
+        void add_thunk(hpx::move_only_function<void()>* f);
 
         void add_locality_endpoints(std::uint32_t locality_id,
             parcelset::endpoints_type const& endpoints);

--- a/libs/full/runtime_distributed/src/big_boot_barrier.cpp
+++ b/libs/full/runtime_distributed/src/big_boot_barrier.cpp
@@ -546,8 +546,8 @@ namespace hpx { namespace agas {
             // synchronization.
 
             // delay the final response until the runtime system is up and running
-            util::unique_function_nonser<void()>* thunk =
-                new util::unique_function_nonser<void()>(util::one_shot(
+            hpx::move_only_function<void()>* thunk =
+                new hpx::move_only_function<void()>(util::one_shot(
                     util::bind_front(&big_boot_barrier::apply_notification,
                         &get_big_boot_barrier(), 0,
                         naming::get_locality_id_from_gid(prefix), dest,
@@ -787,7 +787,7 @@ namespace hpx { namespace agas {
     {
         if (service_mode_bootstrap == service_type)
         {
-            util::unique_function_nonser<void()>* p;
+            hpx::move_only_function<void()>* p;
 
             while (thunks.pop(p))
             {
@@ -805,7 +805,7 @@ namespace hpx { namespace agas {
         }
     }
 
-    void big_boot_barrier::add_thunk(util::unique_function_nonser<void()>* f)
+    void big_boot_barrier::add_thunk(hpx::move_only_function<void()>* f)
     {
         std::size_t k = 0;
         while (!thunks.push(f))

--- a/libs/full/runtime_distributed/src/runtime_distributed.cpp
+++ b/libs/full/runtime_distributed/src/runtime_distributed.cpp
@@ -333,8 +333,7 @@ namespace hpx {
     }
 
     threads::thread_result_type runtime_distributed::run_helper(
-        util::function_nonser<runtime::hpx_main_function_type> const& func,
-        int& result)
+        hpx::function<runtime::hpx_main_function_type> const& func, int& result)
     {
         bool caught_exception = false;
         try
@@ -409,8 +408,7 @@ namespace hpx {
     }
 
     int runtime_distributed::start(
-        util::function_nonser<hpx_main_function_type> const& func,
-        bool blocking)
+        hpx::function<hpx_main_function_type> const& func, bool blocking)
     {
 #if defined(_WIN64) && defined(HPX_DEBUG) &&                                   \
     !defined(HPX_HAVE_FIBER_BASED_COROUTINES)
@@ -495,7 +493,7 @@ namespace hpx {
 
     int runtime_distributed::start(bool blocking)
     {
-        util::function_nonser<hpx_main_function_type> empty_main;
+        hpx::function<hpx_main_function_type> empty_main;
         return start(empty_main, blocking);
     }
 
@@ -767,7 +765,7 @@ namespace hpx {
 
     ///////////////////////////////////////////////////////////////////////////
     int runtime_distributed::run(
-        util::function_nonser<hpx_main_function_type> const& func)
+        hpx::function<hpx_main_function_type> const& func)
     {
         // start the main thread function
         start(func);

--- a/libs/full/runtime_distributed/tests/regressions/multiple_init_2918.cpp
+++ b/libs/full/runtime_distributed/tests/regressions/multiple_init_2918.cpp
@@ -24,17 +24,17 @@ int main(int argc, char* argv[])
     using hpx::util::placeholders::_2;
 
     expected = "first";
-    hpx::util::function_nonser<int(int, char**)> callback1 =
+    hpx::function<int(int, char**)> callback1 =
         hpx::util::bind(&hpx_init_test, expected, _1, _2);
     hpx::init(callback1, argc, argv);
 
     expected = "second";
-    hpx::util::function_nonser<int(int, char**)> callback2 =
+    hpx::function<int(int, char**)> callback2 =
         hpx::util::bind(&hpx_init_test, expected, _1, _2);
     hpx::init(callback2, argc, argv);
 
     expected = "third";
-    hpx::util::function_nonser<int(int, char**)> callback3 =
+    hpx::function<int(int, char**)> callback3 =
         hpx::util::bind(&hpx_init_test, expected, _1, _2);
     hpx::init(callback3, argc, argv);
 

--- a/tests/performance/local/function_object_wrapper_overhead.cpp
+++ b/tests/performance/local/function_object_wrapper_overhead.cpp
@@ -11,7 +11,6 @@
 #include <hpx/functional/function.hpp>
 #include <hpx/modules/timing.hpp>
 
-#include <boost/function.hpp>
 #include <hpx/modules/program_options.hpp>
 
 #include <cstdint>
@@ -64,18 +63,13 @@ int app_main(
         run(f, iterations);
     }
     {
-        hpx::util::function<void(), false> f = foo();
-        std::cout << "hpx::util::function (non-serializable)";
+        hpx::function<void(), false> f = foo();
+        std::cout << "hpx::function (non-serializable)";
         run(f, iterations);
     }
     {
-        hpx::util::function<void()> f = foo();
-        std::cout << "hpx::util::function (serializable)";
-        run(f, iterations);
-    }
-    {
-        boost::function<void()> f = foo();
-        std::cout << "boost::function";
+        hpx::function<void(), true> f = foo();
+        std::cout << "hpx::function (serializable)";
         run(f, iterations);
     }
     {

--- a/tests/performance/local/htts_v2/htts2_hpx.cpp
+++ b/tests/performance/local/htts_v2/htts2_hpx.cpp
@@ -38,9 +38,7 @@ struct hpx_driver : htts2::driver
             "hpx.os_threads=" + std::to_string(osthreads_),
             "hpx.run_hpx_main!=0", "hpx.commandline.allow_unknown!=1"};
 
-        hpx::util::function_nonser<int(
-            hpx::program_options::variables_map & vm)>
-            f;
+        hpx::function<int(hpx::program_options::variables_map & vm)> f;
         hpx::program_options::options_description desc;
 
         hpx::local::init_params init_args;

--- a/tests/regressions/threads/run_as_hpx_thread_exceptions_3304.cpp
+++ b/tests/regressions/threads/run_as_hpx_thread_exceptions_3304.cpp
@@ -51,7 +51,7 @@ int main(int argc, char** argv)
     hpx::lcos::local::spinlock mtx;
     hpx::lcos::local::condition_variable_any cond;
 
-    hpx::util::function_nonser<int(int, char**)> start_function =
+    hpx::function<int(int, char**)> start_function =
         hpx::util::bind(&start_func, std::ref(mtx), std::ref(cond));
 
     hpx::start(start_function, argc, argv);

--- a/tools/inspect/deprecated_name_check.cpp
+++ b/tools/inspect/deprecated_name_check.cpp
@@ -54,7 +54,7 @@ namespace boost
       { "(\\bboost\\s*::\\s*unordered_multiset\\b)", "std::unordered_multiset" },
       { "(\\bboost\\s*::\\s*detail\\s*::\\s*atomic_count\\b)",
         "hpx::util::atomic_count" },
-      { "(\\bboost\\s*::\\s*function\\b)", "hpx::util::function_nonser" },
+      { "(\\bboost\\s*::\\s*function\\b)", "hpx::function" },
       { R"((\bboost\s*::\s*intrusive_ptr\b))", "hpx::intrusive_ptr" },
       { "(\\bboost\\s*::\\s*shared_ptr\\b)", "std::shared_ptr" },
       { "(\\bboost\\s*::\\s*make_shared\\b)", "std::make_shared" },

--- a/wrap/src/hpx_wrap.cpp
+++ b/wrap/src/hpx_wrap.cpp
@@ -7,14 +7,13 @@
 #include <hpx/config.hpp>
 
 // The following implementation has been divided for Linux and Mac OSX
-#if defined(HPX_HAVE_DYNAMIC_HPX_MAIN) && \
-    (defined(__linux) || defined(__linux__) || defined(linux) || \
-    defined(__APPLE__))
+#if defined(HPX_HAVE_DYNAMIC_HPX_MAIN) &&                                      \
+    (defined(__linux) || defined(__linux__) || defined(linux) ||               \
+        defined(__APPLE__))
 
 #include <string>
 
-namespace hpx_start
-{
+namespace hpx_start {
     // include_libhpx_wrap is a weak symbol which helps to determine the course
     // of function calls at runtime. It has a default value of `false` which
     // corresponds to the program's entry point being main().
@@ -32,23 +31,22 @@ namespace hpx_start
     // trying to register thread when not linked to libhpx_wrap and using
     // hpx_main.hpp functionality.
     HPX_SYMBOL_EXPORT bool is_linked = true;
-}
+}    // namespace hpx_start
 
+#include <hpx/functional/function.hpp>
 #include <hpx/hpx_finalize.hpp>
 #include <hpx/hpx_init.hpp>
 #include <hpx/runtime_configuration/runtime_mode.hpp>
-#include <hpx/functional/function.hpp>
 
 #include <vector>
 
 ////////////////////////////////////////////////////////////////////////////////
 // Function declarations
 //
-namespace hpx_start
-{
+namespace hpx_start {
     // Main entry point of HPX runtime system
     extern int hpx_entry(int argc, char* argv[]);
-}
+}    // namespace hpx_start
 
 // Program's entry point depending upon Operating System.
 // For Mac OSX it is the program's entry point. In case of Linux
@@ -68,8 +66,7 @@ extern "C" int __wrap_main(int argc, char** argv);
 extern "C" int main(int argc, char** argv);
 #endif
 
-namespace hpx_start
-{
+namespace hpx_start {
     // main entry point of the HPX runtime system
     int hpx_entry(int argc, char* argv[])
     {
@@ -85,8 +82,7 @@ namespace hpx_start
         hpx::finalize();
         return return_value;
     }
-}
-
+}    // namespace hpx_start
 
 // This is the main entry point of C runtime system.
 // The HPX runtime system is initialized here, which
@@ -95,7 +91,7 @@ namespace hpx_start
 extern "C" int initialize_main(int argc, char** argv)
 {
 #if defined(__APPLE__)
-    if(hpx_start::include_libhpx_wrap)
+    if (hpx_start::include_libhpx_wrap)
     {
 #endif
         // Configuring HPX system before runtime
@@ -103,11 +99,10 @@ extern "C" int initialize_main(int argc, char** argv)
             "hpx.commandline.allow_unknown!=1",
             "hpx.commandline.aliasing=0",
         };
-        hpx::util::function_nonser<int(int, char**)> start_function =
-            &hpx_start::hpx_entry;
+        hpx::function<int(int, char**)> start_function = &hpx_start::hpx_entry;
         using hpx::program_options::options_description;
-        options_description desc = options_description(
-            std::string("Usage: ") + ::hpx_start::app_name_libhpx_wrap + " [options]");
+        options_description desc = options_description(std::string("Usage: ") +
+            ::hpx_start::app_name_libhpx_wrap + " [options]");
         // Create the init_params struct
         hpx::init_params iparams;
         iparams.desc_cmdline = desc;
@@ -134,7 +129,7 @@ extern "C" int __wrap_main(int argc, char** argv)
     // from the value of include_libhpx_wrap. If hpx_main
     // is included include_libhpx_wrap is set to 1
     // due to override variable.
-    if(hpx_start::include_libhpx_wrap)
+    if (hpx_start::include_libhpx_wrap)
         return initialize_main(argc, argv);
 
     // call main() since hpx_main.hpp is not included


### PR DESCRIPTION
- rename unique_function to hpx::move_only_function
