### PR TITLE
Update Piz Daint Jenkins configuration

### DIFF
--- a/.jenkins/cscs/env-clang-cuda.sh
+++ b/.jenkins/cscs/env-clang-cuda.sh
@@ -8,10 +8,10 @@ export CRAYPE_LINK_TYPE=dynamic
 export APPS_ROOT="/apps/daint/SSL/HPX/packages"
 export CXX_STD="17"
 export HWLOC_ROOT="${APPS_ROOT}/hwloc-2.0.3-gcc-8.3.0"
+export BOOST_ROOT="${APPS_ROOT}/boost-1.75.0-gcc-10.1.0-c++17-debug/"
 
 module load daint-gpu
 module load cudatoolkit/11.0.2_3.38-8.1__g5b73779
-module load Boost/1.75.0-CrayCCE-20.11
 spack load cmake@3.18.6
 spack load ninja@1.10.0
 

--- a/.jenkins/cscs/env-gcc-cuda.sh
+++ b/.jenkins/cscs/env-gcc-cuda.sh
@@ -10,8 +10,8 @@ export CXX_STD="17"
 module load daint-gpu
 module switch PrgEnv-cray PrgEnv-gnu
 module load cudatoolkit
-module load Boost/1.75.0-CrayGNU-20.11
-module load hwloc/.2.0.3
+module load Boost/1.78.0-CrayGNU-21.09
+module load hwloc/2.4.1
 spack load cmake@3.18.6
 spack load ninja@1.10.0
 


### PR DESCRIPTION
Attempt to update the configurations... One of the Boost modules has been removed, hence I'm using one of our Boost installs directly. Since it's header-only the used compiler shouldn't matter.

@hkaiser I'll update the performance CI references separately.