### PR TITLE
Add option to restrict MPI background work to subset of cores

### DIFF
--- a/libs/core/config/include/hpx/config.hpp
+++ b/libs/core/config/include/hpx/config.hpp
@@ -114,6 +114,18 @@
 #  define HPX_PARCEL_MPI_MAX_REQUESTS 2147483647
 #endif
 
+/// This defines the number of cores that perform background work for the MPI
+/// parcelport
+/// This value can be changed at runtime by setting the configuration parameter:
+///
+///   hpx.parcel.mpi.background_threads = ...
+///
+/// (or by setting the corresponding environment variable
+/// HPX_HAVE_PARCELPORT_MPI_BACKGROUND_THREADS).
+#if !defined(HPX_HAVE_PARCELPORT_MPI_BACKGROUND_THREADS)
+#  define HPX_HAVE_PARCELPORT_MPI_BACKGROUND_THREADS std::size_t(-1)
+#endif
+
 ///////////////////////////////////////////////////////////////////////////////
 /// This defines the number of outgoing (parcel-) connections kept alive (to
 /// each of the other localities). This value can be changed at runtime by


### PR DESCRIPTION
This PR adds an option to the MPI parcelport that allows specifying the maximum number of cores that will participate in the MPI parcelport background work: `--hpx:ini=hpx.parcel.mpi.background_threads!=N`, where `N` is the number of cores that will participate (default is `-1`, meaning all cores participate). Alternatively, this can be set through the environment variable `HPX_HAVE_PARCELPORT_MPI_BACKGROUND_THREADS`.

@diehlpk please verify whether this has any effect on the performance issues you're investigating.