### PR TITLE
Use C++20 std::source_location, if available

### DIFF
--- a/cmake/HPX_AddConfigTest.cmake
+++ b/cmake/HPX_AddConfigTest.cmake
@@ -459,6 +459,15 @@ function(hpx_check_for_cxx20_lambda_capture)
 endfunction()
 
 # ##############################################################################
+function(hpx_check_for_cxx20_source_location)
+  add_hpx_config_test(
+    HPX_WITH_CXX20_SOURCE_LOCATION
+    SOURCE cmake/tests/cxx20_source_location.cpp
+    FILE ${ARGN}
+  )
+endfunction()
+
+# ##############################################################################
 function(hpx_check_for_cxx20_perfect_pack_capture)
   add_hpx_config_test(
     HPX_WITH_CXX20_PERFECT_PACK_CAPTURE

--- a/cmake/HPX_PerformCxxFeatureTests.cmake
+++ b/cmake/HPX_PerformCxxFeatureTests.cmake
@@ -73,6 +73,10 @@ function(hpx_perform_cxx_feature_tests)
       DEFINITIONS HPX_HAVE_CXX20_LAMBDA_CAPTURE
     )
 
+    hpx_check_for_cxx20_source_location(
+      DEFINITIONS HPX_HAVE_CXX20_SOURCE_LOCATION
+    )
+
     hpx_check_for_cxx20_perfect_pack_capture(
       DEFINITIONS HPX_HAVE_CXX20_PERFECT_PACK_CAPTURE
     )

--- a/cmake/tests/cxx20_source_location.cpp
+++ b/cmake/tests/cxx20_source_location.cpp
@@ -1,0 +1,19 @@
+//  Copyright (c) 2022 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+// test for availability of std::source_location (C++20)
+
+#include <iostream>
+#include <source_location>
+
+int main()
+{
+    std::cout << "file: " << location.file_name() << "(" << location.line()
+              << ":" << location.column() << ") `" << location.function_name()
+              << '\n';
+
+    return 0;
+}

--- a/libs/core/assertion/include/hpx/assertion/evaluate_assert.hpp
+++ b/libs/core/assertion/include/hpx/assertion/evaluate_assert.hpp
@@ -15,7 +15,7 @@
 
 namespace hpx { namespace assertion { namespace detail {
     /// \cond NOINTERNAL
-    HPX_CORE_EXPORT void handle_assert(source_location const& loc,
+    HPX_CORE_EXPORT void handle_assert(hpx::source_location const& loc,
         const char* expr, std::string const& msg) noexcept;
     /// \endcond
 }}}    // namespace hpx::assertion::detail

--- a/libs/core/assertion/include/hpx/modules/assertion.hpp
+++ b/libs/core/assertion/include/hpx/modules/assertion.hpp
@@ -1,4 +1,5 @@
 //  Copyright (c) 2019 Thomas Heller
+//  Copyright (c) 2022 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -12,7 +13,6 @@
 #pragma once
 
 #include <hpx/config.hpp>
-#include <hpx/assertion/current_function.hpp>
 #include <hpx/assertion/evaluate_assert.hpp>
 #include <hpx/assertion/source_location.hpp>
 #include <hpx/preprocessor/stringize.hpp>
@@ -20,14 +20,15 @@
 #if defined(HPX_COMPUTE_DEVICE_CODE)
 #include <assert.h>
 #endif
+#include <cstdint>
 #include <exception>
 #include <string>
 #include <type_traits>
 
 namespace hpx { namespace assertion {
     /// The signature for an assertion handler
-    using assertion_handler = void (*)(
-        source_location const& loc, const char* expr, std::string const& msg);
+    using assertion_handler = void (*)(hpx::source_location const& loc,
+        const char* expr, std::string const& msg);
 
     /// Set the assertion handler to be used within a program. If the handler has been
     /// set already once, the call to this function will be ignored.
@@ -60,10 +61,8 @@ namespace hpx { namespace assertion {
 #define HPX_ASSERT_(expr, msg)                                                 \
     (!!(expr) ? void() :                                                       \
                 ::hpx::assertion::detail::handle_assert(                       \
-                    ::hpx::assertion::source_location{__FILE__,                \
-                        static_cast<unsigned>(__LINE__),                       \
-                        HPX_ASSERT_CURRENT_FUNCTION},                          \
-                    HPX_PP_STRINGIZE(expr), msg)) /**/
+                    HPX_CURRENT_SOURCE_LOCATION(), HPX_PP_STRINGIZE(expr),     \
+                    msg)) /**/
 
 #if defined(HPX_DEBUG)
 #if defined(HPX_COMPUTE_DEVICE_CODE)

--- a/libs/core/assertion/src/assertion.cpp
+++ b/libs/core/assertion/src/assertion.cpp
@@ -28,7 +28,7 @@ namespace hpx { namespace assertion {
     }
 
     namespace detail {
-        void handle_assert(source_location const& loc, const char* expr,
+        void handle_assert(hpx::source_location const& loc, const char* expr,
             std::string const& msg) noexcept
         {
             if (get_handler() == nullptr)

--- a/libs/core/assertion/src/source_location.cpp
+++ b/libs/core/assertion/src/source_location.cpp
@@ -8,11 +8,12 @@
 
 #include <ostream>
 
-namespace hpx { namespace assertion {
-    std::ostream& operator<<(std::ostream& os, source_location const& loc)
+namespace hpx {
+
+    std::ostream& operator<<(std::ostream& os, hpx::source_location const& loc)
     {
-        os << loc.file_name << ":" << loc.line_number << ": "
-           << loc.function_name;
+        os << loc.file_name() << ":" << loc.line() << ": "
+           << loc.function_name();
         return os;
     }
-}}    // namespace hpx::assertion
+}    // namespace hpx

--- a/libs/core/include_local/CMakeLists.txt
+++ b/libs/core/include_local/CMakeLists.txt
@@ -23,6 +23,7 @@ set(include_local_headers
     hpx/local/runtime.hpp
     hpx/local/semaphore.hpp
     hpx/local/shared_mutex.hpp
+    hpx/local/source_location.hpp
     hpx/local/stop_token.hpp
     hpx/local/system_error.hpp
     hpx/local/task_block.hpp

--- a/libs/core/include_local/include/hpx/local/source_location.hpp
+++ b/libs/core/include_local/include/hpx/local/source_location.hpp
@@ -1,0 +1,9 @@
+//  Copyright (c) 2022 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include <hpx/assertion/source_location.hpp>

--- a/libs/core/runtime_local/include/hpx/runtime_local/runtime_handlers.hpp
+++ b/libs/core/runtime_local/include/hpx/runtime_local/runtime_handlers.hpp
@@ -21,7 +21,7 @@
 
 namespace hpx { namespace detail {
     HPX_NORETURN HPX_CORE_EXPORT void assertion_handler(
-        hpx::assertion::source_location const& loc, const char* expr,
+        hpx::source_location const& loc, const char* expr,
         std::string const& msg);
 #if defined(HPX_HAVE_APEX)
     HPX_CORE_EXPORT bool enable_parent_task_handler();

--- a/libs/core/runtime_local/src/runtime_handlers.cpp
+++ b/libs/core/runtime_local/src/runtime_handlers.cpp
@@ -30,9 +30,8 @@
 
 namespace hpx { namespace detail {
 
-    HPX_NORETURN void assertion_handler(
-        hpx::assertion::source_location const& loc, const char* expr,
-        std::string const& msg)
+    HPX_NORETURN void assertion_handler(hpx::source_location const& loc,
+        const char* expr, std::string const& msg)
     {
         static thread_local bool handling_assertion = false;
 
@@ -49,9 +48,9 @@ namespace hpx { namespace detail {
             }
 
             strm << std::endl;
-            strm << "{file}: " << loc.file_name << std::endl;
-            strm << "{line}: " << loc.line_number << std::endl;
-            strm << "{function}: " << loc.function_name << std::endl;
+            strm << "{file}: " << loc.file_name() << std::endl;
+            strm << "{line}: " << loc.line() << std::endl;
+            strm << "{function}: " << loc.function_name() << std::endl;
 
             std::cerr << strm.str();
 
@@ -71,7 +70,7 @@ namespace hpx { namespace detail {
 
         hpx::exception e(hpx::assertion_failure, strm.str());
         std::cerr << hpx::diagnostic_information(hpx::detail::get_exception(
-                         e, loc.function_name, loc.file_name, loc.line_number))
+                         e, loc.function_name(), loc.file_name(), loc.line()))
                   << std::endl;
         std::abort();
     }

--- a/libs/core/type_support/include/hpx/type_support/meta.hpp
+++ b/libs/core/type_support/include/hpx/type_support/meta.hpp
@@ -106,8 +106,7 @@ namespace hpx { namespace meta {
     template <template <class> typename T, typename T1>
     using is_valid1 = util::is_detected<T, T1>;
 
-    template <template <class, class> typename T, typename T1,
-        typename T2>
+    template <template <class, class> typename T, typename T1, typename T2>
     using is_valid2 = util::is_detected<T, T1, T2>;
 
     template <template <class, class, class> typename T, typename T1,

--- a/libs/full/include/CMakeLists.txt
+++ b/libs/full/include/CMakeLists.txt
@@ -111,6 +111,7 @@ set(include_headers
     hpx/runtime.hpp
     hpx/semaphore.hpp
     hpx/shared_mutex.hpp
+    hpx/source_location.hpp
     hpx/stop_token.hpp
     hpx/system_error.hpp
     hpx/task_block.hpp

--- a/libs/full/include/include/hpx/source_location.hpp
+++ b/libs/full/include/include/hpx/source_location.hpp
@@ -1,0 +1,9 @@
+//  Copyright (c) 2022 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include <hpx/local/source_location.hpp>


### PR DESCRIPTION
- move hpx::assertion::source_location to hpx::source_location
- adding hpx/source_location.hpp header file

Fixes #3995