### PR TITLE
Modernize naming modules

### DIFF
--- a/components/component_storage/include/hpx/components/component_storage/component_storage.hpp
+++ b/components/component_storage/include/hpx/components/component_storage/component_storage.hpp
@@ -18,8 +18,7 @@
 #include <cstddef>
 #include <vector>
 
-namespace hpx { namespace components
-{
+namespace hpx { namespace components {
     ///////////////////////////////////////////////////////////////////////////
     class HPX_MIGRATE_TO_STORAGE_EXPORT component_storage
       : public client_base<component_storage, server::component_storage>
@@ -29,23 +28,20 @@ namespace hpx { namespace components
 
     public:
         component_storage(hpx::id_type target_locality);
-        component_storage(hpx::future<naming::id_type> && f);
+        component_storage(hpx::future<hpx::id_type>&& f);
 
-        hpx::future<naming::id_type> migrate_to_here(std::vector<char> const&,
-            naming::id_type const&, naming::address const&);
-        naming::id_type migrate_to_here(launch::sync_policy,
-            std::vector<char> const&, naming::id_type const&,
+        hpx::future<hpx::id_type> migrate_to_here(std::vector<char> const&,
+            hpx::id_type const&, naming::address const&);
+        hpx::id_type migrate_to_here(launch::sync_policy,
+            std::vector<char> const&, hpx::id_type const&,
             naming::address const&);
 
-        hpx::future<std::vector<char> > migrate_from_here(
+        hpx::future<std::vector<char>> migrate_from_here(
             naming::gid_type const&);
-        std::vector<char> migrate_from_here(launch::sync_policy,
-            naming::gid_type const&);
+        std::vector<char> migrate_from_here(
+            launch::sync_policy, naming::gid_type const&);
 
         future<std::size_t> size() const;
         std::size_t size(launch::sync_policy) const;
     };
-}}
-
-
-
+}}    // namespace hpx::components

--- a/components/component_storage/include/hpx/components/component_storage/migrate_from_storage.hpp
+++ b/components/component_storage/include/hpx/components/component_storage/migrate_from_storage.hpp
@@ -41,14 +41,14 @@ namespace hpx { namespace components
     ///
     template <typename Component>
 #if defined(DOXYGEN)
-    future<naming::id_type>
+    future<hpx::id_type>
 #else
     inline typename std::enable_if<
-        traits::is_component<Component>::value, future<naming::id_type>
+        traits::is_component<Component>::value, future<hpx::id_type>
     >::type
 #endif
-    migrate_from_storage(naming::id_type const& to_resurrect,
-        naming::id_type const& target = naming::invalid_id)
+    migrate_from_storage(hpx::id_type const& to_resurrect,
+        hpx::id_type const& target = hpx::invalid_id)
     {
         typedef server::trigger_migrate_from_storage_here_action<Component>
             action_type;

--- a/components/component_storage/include/hpx/components/component_storage/migrate_to_storage.hpp
+++ b/components/component_storage/include/hpx/components/component_storage/migrate_to_storage.hpp
@@ -40,14 +40,14 @@ namespace hpx { namespace components
     ///
     template <typename Component>
 #if defined(DOXYGEN)
-    future<naming::id_type>
+    future<hpx::id_type>
 #else
     inline typename std::enable_if<
-        traits::is_component<Component>::value, future<naming::id_type>
+        traits::is_component<Component>::value, future<hpx::id_type>
     >::type
 #endif
-    migrate_to_storage(naming::id_type const& to_migrate,
-        naming::id_type const& target_storage)
+    migrate_to_storage(hpx::id_type const& to_migrate,
+        hpx::id_type const& target_storage)
     {
         typedef server::trigger_migrate_to_storage_here_action<Component>
             action_type;

--- a/components/component_storage/include/hpx/components/component_storage/server/component_storage.hpp
+++ b/components/component_storage/include/hpx/components/component_storage/server/component_storage.hpp
@@ -23,8 +23,7 @@
 #include <vector>
 
 ///////////////////////////////////////////////////////////////////////////////
-namespace hpx { namespace components { namespace server
-{
+namespace hpx { namespace components { namespace server {
     ///////////////////////////////////////////////////////////////////////////
     class HPX_MIGRATE_TO_STORAGE_EXPORT component_storage
       : public component_base<component_storage>
@@ -34,19 +33,22 @@ namespace hpx { namespace components { namespace server
     public:
         component_storage();
 
-        naming::gid_type migrate_to_here(std::vector<char> const&,
-            naming::id_type, naming::address const&);
+        naming::gid_type migrate_to_here(
+            std::vector<char> const&, hpx::id_type, naming::address const&);
         std::vector<char> migrate_from_here(naming::gid_type const&);
-        std::size_t size() const { return data_.size(); }
+        std::size_t size() const
+        {
+            return data_.size();
+        }
 
         HPX_DEFINE_COMPONENT_ACTION(component_storage, migrate_to_here)
         HPX_DEFINE_COMPONENT_ACTION(component_storage, migrate_from_here)
         HPX_DEFINE_COMPONENT_ACTION(component_storage, size)
 
     private:
-        hpx::unordered_map<naming::gid_type, std::vector<char> > data_;
+        hpx::unordered_map<naming::gid_type, std::vector<char>> data_;
     };
-}}}
+}}}    // namespace hpx::components::server
 
 HPX_REGISTER_ACTION_DECLARATION(
     hpx::components::server::component_storage::migrate_to_here_action,
@@ -61,6 +63,3 @@ HPX_REGISTER_ACTION_DECLARATION(
 typedef std::vector<char> hpx_component_storage_data_type;
 HPX_REGISTER_UNORDERED_MAP_DECLARATION(
     hpx::naming::gid_type, hpx_component_storage_data_type)
-
-
-

--- a/components/component_storage/include/hpx/components/component_storage/server/migrate_from_storage.hpp
+++ b/components/component_storage/include/hpx/components/component_storage/server/migrate_from_storage.hpp
@@ -23,8 +23,7 @@
 #include <utility>
 #include <vector>
 
-namespace hpx { namespace components { namespace server
-{
+namespace hpx { namespace components { namespace server {
     ///////////////////////////////////////////////////////////////////////////
     // Migrate given component from the specified storage component
     //
@@ -58,51 +57,47 @@ namespace hpx { namespace components { namespace server
     //       migrated which will delete it once the shared pointer goes out of
     //       scope.
     //
-    namespace detail
-    {
+    namespace detail {
         ///////////////////////////////////////////////////////////////////////
         template <typename Component>
-        future<naming::id_type> migrate_from_storage_here_id(
-            naming::id_type const& target_locality,
+        future<hpx::id_type> migrate_from_storage_here_id(
+            hpx::id_type const& target_locality,
             std::shared_ptr<Component> const& ptr,
-            naming::id_type const& to_resurrect)
+            hpx::id_type const& to_resurrect)
         {
             // and resurrect it on the specified locality
             using hpx::components::runtime_support;
             return runtime_support::migrate_component_async<Component>(
-                        target_locality, ptr, to_resurrect)
-                .then(launch::sync,
-                    [ptr, to_resurrect](future<id_type> && f)
-                    {
-                        ptr->mark_as_migrated();
-                        return f.get();
-                    });
+                target_locality, ptr, to_resurrect)
+                .then(launch::sync, [ptr, to_resurrect](future<id_type>&& f) {
+                    ptr->mark_as_migrated();
+                    return f.get();
+                });
         }
 
         template <typename Component>
-        future<naming::id_type> migrate_from_storage_here_address(
-            naming::address const& addr,
-            std::shared_ptr<Component> const& ptr,
-            naming::id_type const& to_resurrect)
+        future<hpx::id_type> migrate_from_storage_here_address(
+            naming::address const& addr, std::shared_ptr<Component> const& ptr,
+            hpx::id_type const& to_resurrect)
         {
-            naming::id_type id(addr.locality_, id_type::unmanaged);
+            hpx::id_type id(
+                addr.locality_, id_type::management_type::unmanaged);
             return migrate_from_storage_here_id(id, ptr, to_resurrect);
         }
 
         // convert the extracted data into a living component instance
         template <typename Component>
-        future<naming::id_type> migrate_from_storage_here(
-            future<std::vector<char> > && f,
-            naming::id_type const& to_resurrect,
-            naming::address const& addr,
-            naming::id_type const& target_locality)
+        future<hpx::id_type> migrate_from_storage_here(
+            future<std::vector<char>>&& f, hpx::id_type const& to_resurrect,
+            naming::address const& addr, hpx::id_type const& target_locality)
         {
             // recreate the object
             std::shared_ptr<Component> ptr;
 
             {
                 std::vector<char> data = f.get();
-                serialization::input_archive archive(data, data.size(), nullptr);
+                serialization::input_archive archive(
+                    data, data.size(), nullptr);
                 archive >> ptr;
             }
 
@@ -111,26 +106,25 @@ namespace hpx { namespace components { namespace server
 
             // if target locality is not specified, use the address of the last
             // locality where the object was living before
-            if (target_locality == naming::invalid_id)
+            if (target_locality == hpx::invalid_id)
             {
-                return migrate_from_storage_here_address<Component>(addr, ptr,
-                    to_resurrect);
+                return migrate_from_storage_here_address<Component>(
+                    addr, ptr, to_resurrect);
             }
 
             // otherwise directly refer to the locality where the object should
             // be resurrected
-            return migrate_from_storage_here_id(target_locality, ptr,
-                to_resurrect);
+            return migrate_from_storage_here_id(
+                target_locality, ptr, to_resurrect);
         }
-    }
+    }    // namespace detail
 
     ///////////////////////////////////////////////////////////////////////////
     // This is executed on the locality responsible for managing the address
     // resolution for the given object.
     template <typename Component>
-    future<naming::id_type> trigger_migrate_from_storage_here(
-        naming::id_type const& to_resurrect,
-        naming::id_type const& target_locality)
+    future<hpx::id_type> trigger_migrate_from_storage_here(
+        hpx::id_type const& to_resurrect, hpx::id_type const& target_locality)
     {
         if (!traits::component_supports_migration<Component>::call())
         {
@@ -138,7 +132,7 @@ namespace hpx { namespace components { namespace server
                 "hpx::components::server::trigger_migrate_from_storage_here",
                 "attempting to migrate an instance of a component which "
                 "does not support migration");
-            return make_ready_future(naming::invalid_id);
+            return make_ready_future(hpx::invalid_id);
         }
 
         if (naming::get_locality_id_from_id(to_resurrect) != get_locality_id())
@@ -147,7 +141,7 @@ namespace hpx { namespace components { namespace server
                 "hpx::components::server::trigger_migrate_from_storage_here",
                 "this function has to be executed on the locality responsible "
                 "for managing the address of the given object");
-            return make_ready_future(naming::invalid_id);
+            return make_ready_future(hpx::invalid_id);
         }
 
         auto r = agas::begin_migration(to_resurrect).get();
@@ -156,12 +150,10 @@ namespace hpx { namespace components { namespace server
         typedef typename server::component_storage::migrate_from_here_action
             action_type;
         return async<action_type>(r.first, to_resurrect.get_gid())
-            .then(hpx::bind_back(
-                &detail::migrate_from_storage_here<Component>,
+            .then(hpx::bind_back(&detail::migrate_from_storage_here<Component>,
                 to_resurrect, r.second, target_locality))
             .then(
-                [to_resurrect](future<naming::id_type> && f) -> naming::id_type
-                {
+                [to_resurrect](future<hpx::id_type>&& f) -> hpx::id_type {
                     agas::end_migration(to_resurrect);
                     return f.get();
                 });
@@ -169,13 +161,10 @@ namespace hpx { namespace components { namespace server
 
     template <typename Component>
     struct trigger_migrate_from_storage_here_action
-      : ::hpx::actions::action<
-            future<naming::id_type> (*)(naming::id_type const&,
-                naming::id_type const&)
-          , &trigger_migrate_from_storage_here<Component>
-          , trigger_migrate_from_storage_here_action<Component> >
-    {};
-}}}
-
-
-
+      : ::hpx::actions::action<future<hpx::id_type> (*)(
+                                   hpx::id_type const&, hpx::id_type const&),
+            &trigger_migrate_from_storage_here<Component>,
+            trigger_migrate_from_storage_here_action<Component>>
+    {
+    };
+}}}    // namespace hpx::components::server

--- a/components/component_storage/src/component_storage.cpp
+++ b/components/component_storage/src/component_storage.cpp
@@ -22,14 +22,14 @@ namespace hpx { namespace components {
     {
     }
 
-    component_storage::component_storage(hpx::future<naming::id_type>&& f)
+    component_storage::component_storage(hpx::future<hpx::id_type>&& f)
       : base_type(HPX_MOVE(f))
     {
     }
 
     ///////////////////////////////////////////////////////////////////////////
-    hpx::future<naming::id_type> component_storage::migrate_to_here(
-        std::vector<char> const& data, naming::id_type const& id,
+    hpx::future<hpx::id_type> component_storage::migrate_to_here(
+        std::vector<char> const& data, hpx::id_type const& id,
         naming::address const& addr)
     {
 #if !defined(HPX_COMPUTE_DEVICE_CODE)
@@ -40,12 +40,12 @@ namespace hpx { namespace components {
         HPX_UNUSED(data);
         HPX_UNUSED(id);
         HPX_UNUSED(addr);
-        return hpx::make_ready_future(naming::id_type{});
+        return hpx::make_ready_future(hpx::id_type{});
 #endif
     }
 
-    naming::id_type component_storage::migrate_to_here(launch::sync_policy,
-        std::vector<char> const& data, naming::id_type const& id,
+    hpx::id_type component_storage::migrate_to_here(launch::sync_policy,
+        std::vector<char> const& data, hpx::id_type const& id,
         naming::address const& addr)
     {
         return migrate_to_here(data, id, addr).get();

--- a/components/component_storage/src/server/component_storage_server.cpp
+++ b/components/component_storage/src/server/component_storage_server.cpp
@@ -18,7 +18,7 @@ namespace hpx { namespace components { namespace server
 
     ///////////////////////////////////////////////////////////////////////////
     naming::gid_type component_storage::migrate_to_here(
-        std::vector<char> const& data, naming::id_type id,
+        std::vector<char> const& data, hpx::id_type id,
         naming::address const& current_lva)
     {
         naming::gid_type gid(naming::detail::get_stripped_gid(id.get_gid()));

--- a/components/component_storage/tests/unit/migrate_component_to_storage.cpp
+++ b/components/component_storage/tests/unit/migrate_component_to_storage.cpp
@@ -94,7 +94,7 @@ bool test_migrate_component_to_storage(hpx::id_type const& source,
     {
         // create component on given locality
         test_client t1(source);
-        HPX_TEST_NEQ(hpx::naming::invalid_id, t1.get_id());
+        HPX_TEST_NEQ(hpx::invalid_id, t1.get_id());
 
         // the new object should live on the source locality
         HPX_TEST_EQ(t1.call(), source);
@@ -106,7 +106,7 @@ bool test_migrate_component_to_storage(hpx::id_type const& source,
         {
             // migrate of t1 to the target storage
             test_client t2(hpx::components::migrate_to_storage(t1, storage));
-            HPX_TEST_EQ(hpx::naming::invalid_id, t2.get_id());
+            HPX_TEST_EQ(hpx::invalid_id, t2.get_id());
         }
         catch (hpx::exception const&)
         {
@@ -115,7 +115,8 @@ bool test_migrate_component_to_storage(hpx::id_type const& source,
 
         HPX_TEST_EQ(storage.size(hpx::launch::sync), std::size_t(1));
 
-        // make sure all local references go out of scope if t == unmanaged
+        // make sure all local references go out of scope if t ==
+        // management_type::unmanaged
     }
 
     HPX_TEST_EQ(storage.size(hpx::launch::sync), std::size_t(1));
@@ -145,7 +146,7 @@ bool test_migrate_component_to_storage(hpx::id_type const& source,
     {
         // create component on given locality
         test_client t1(source);
-        HPX_TEST_NEQ(hpx::naming::invalid_id, t1.get_id());
+        HPX_TEST_NEQ(hpx::invalid_id, t1.get_id());
 
         // the new object should live on the source locality
         HPX_TEST_EQ(t1.call(), source);
@@ -157,7 +158,7 @@ bool test_migrate_component_to_storage(hpx::id_type const& source,
         {
             // migrate of t1 to the target storage
             test_client t2(hpx::components::migrate_to_storage(t1, storage));
-            HPX_TEST_EQ(hpx::naming::invalid_id, t2.get_id());
+            HPX_TEST_EQ(hpx::invalid_id, t2.get_id());
         }
         catch (hpx::exception const&)
         {
@@ -166,7 +167,8 @@ bool test_migrate_component_to_storage(hpx::id_type const& source,
 
         HPX_TEST_EQ(storage.size(hpx::launch::sync), std::size_t(1));
 
-        // make sure all local references go out of scope if t == unmanaged
+        // make sure all local references go out of scope if t ==
+        // management_type::unmanaged
     }
 
     HPX_TEST_EQ(storage.size(hpx::launch::sync), std::size_t(1));
@@ -196,7 +198,7 @@ bool test_migrate_component_from_storage(
     {
         // create component on given locality
         test_client t1(source);
-        HPX_TEST_NEQ(hpx::naming::invalid_id, t1.get_id());
+        HPX_TEST_NEQ(hpx::invalid_id, t1.get_id());
 
         // the new object should live on the source locality
         HPX_TEST_EQ(t1.call(), source);
@@ -208,7 +210,7 @@ bool test_migrate_component_from_storage(
         {
             // migrate of t1 to the target storage
             test_client t2(hpx::components::migrate_to_storage(t1, storage));
-            HPX_TEST_EQ(hpx::naming::invalid_id, t2.get_id());
+            HPX_TEST_EQ(hpx::invalid_id, t2.get_id());
         }
         catch (hpx::exception const&)
         {
@@ -240,17 +242,17 @@ void test_storage(hpx::id_type const& here, hpx::id_type const& there)
 {
     // create a new storage instance
     hpx::components::component_storage storage(here);
-    HPX_TEST_NEQ(hpx::naming::invalid_id, storage.get_id());
+    HPX_TEST_NEQ(hpx::invalid_id, storage.get_id());
 
     HPX_TEST(test_migrate_component_to_storage(
-        here, storage, hpx::id_type::unmanaged));
+        here, storage, hpx::id_type::management_type::unmanaged));
     HPX_TEST(test_migrate_component_to_storage(
-        here, storage, hpx::id_type::managed));
+        here, storage, hpx::id_type::management_type::managed));
 
     HPX_TEST(test_migrate_component_to_storage(
-        here, there, storage, hpx::id_type::unmanaged));
+        here, there, storage, hpx::id_type::management_type::unmanaged));
     HPX_TEST(test_migrate_component_to_storage(
-        here, there, storage, hpx::id_type::managed));
+        here, there, storage, hpx::id_type::management_type::managed));
 
     //     HPX_TEST(test_migrate_component_from_storage(here, storage));
 }

--- a/components/containers/partitioned_vector/include/hpx/components/containers/coarray/coarray.hpp
+++ b/components/containers/partitioned_vector/include/hpx/components/containers/coarray/coarray.hpp
@@ -124,17 +124,16 @@ namespace hpx {
         using base_type = partitioned_vector_view<T, N, Data>;
         using indices = typename hpx::util::make_index_pack<N>::type;
 
-        std::vector<hpx::naming::id_type> get_unrolled_localities(
-            std::vector<hpx::naming::id_type> const& in,
-            std::size_t num_segments, std::size_t unroll)
+        std::vector<hpx::id_type> get_unrolled_localities(
+            std::vector<hpx::id_type> const& in, std::size_t num_segments,
+            std::size_t unroll)
         {
-            using iterator =
-                typename std::vector<hpx::naming::id_type>::iterator;
+            using iterator = typename std::vector<hpx::id_type>::iterator;
 
             using const_iterator =
-                typename std::vector<hpx::naming::id_type>::const_iterator;
+                typename std::vector<hpx::id_type>::const_iterator;
 
-            std::vector<hpx::naming::id_type> out(num_segments);
+            std::vector<hpx::id_type> out(num_segments);
 
             iterator o_end = out.end();
             const_iterator i_begin = in.cbegin();

--- a/components/iostreams/include/hpx/components/iostreams/ostream.hpp
+++ b/components/iostreams/include/hpx/components/iostreams/ostream.hpp
@@ -133,11 +133,11 @@ namespace hpx { namespace iostreams {
         }
 
         ///////////////////////////////////////////////////////////////////////
-        hpx::future<naming::id_type> create_ostream(
+        hpx::future<hpx::id_type> create_ostream(
             char const* name, std::ostream& strm);
 
         template <typename Tag>
-        hpx::future<naming::id_type> create_ostream(Tag tag)
+        hpx::future<hpx::id_type> create_ostream(Tag tag)
         {
             return create_ostream(
                 get_outstream_name(tag), detail::get_outstream(tag));
@@ -145,10 +145,10 @@ namespace hpx { namespace iostreams {
 
         ///////////////////////////////////////////////////////////////////////
         HPX_IOSTREAMS_EXPORT void release_ostream(
-            char const* name, naming::id_type const& id);
+            char const* name, hpx::id_type const& id);
 
         template <typename Tag>
-        void release_ostream(Tag tag, naming::id_type const& id)
+        void release_ostream(Tag tag, hpx::id_type const& id)
         {
             release_ostream(get_outstream_name(tag), id);
         }

--- a/components/iostreams/src/standard_streams.cpp
+++ b/components/iostreams/src/standard_streams.cpp
@@ -44,14 +44,14 @@ namespace hpx { namespace iostreams { namespace detail {
     }
 
     ///////////////////////////////////////////////////////////////////////////
-    naming::id_type return_id_type(future<bool> f, naming::id_type id)
+    hpx::id_type return_id_type(future<bool> f, hpx::id_type id)
     {
         f.get();    //re-throw any errors
         return id;
     }
 
     ///////////////////////////////////////////////////////////////////////////
-    hpx::future<naming::id_type> create_ostream(
+    hpx::future<hpx::id_type> create_ostream(
         char const* cout_name, std::ostream& strm)
     {
         LRT_(info).format(
@@ -61,9 +61,9 @@ namespace hpx { namespace iostreams { namespace detail {
         {
             typedef components::component<server::output_stream> ostream_type;
 
-            naming::id_type cout_id(
+            hpx::id_type cout_id(
                 components::server::construct<ostream_type>(std::ref(strm)),
-                naming::id_type::managed);
+                hpx::id_type::management_type::managed);
 
             return agas::register_name(cout_name, cout_id)
                 .then(hpx::launch::sync,
@@ -75,7 +75,7 @@ namespace hpx { namespace iostreams { namespace detail {
     }
 
     ///////////////////////////////////////////////////////////////////////////
-    void release_ostream(char const* name, naming::id_type const& /* id */)
+    void release_ostream(char const* name, hpx::id_type const& /* id */)
     {
         LRT_(info).format(
             "detail::release_ostream: destroying '{}' stream object", name);

--- a/components/iostreams/tests/regressions/lost_output_2236.cpp
+++ b/components/iostreams/tests/regressions/lost_output_2236.cpp
@@ -76,8 +76,8 @@ namespace gc {
 
         // ctors
         collector_data()
-          : parent(hpx::naming::invalid_id)
-          , cid(hpx::naming::invalid_id)
+          : parent(hpx::invalid_id)
+          , cid(hpx::invalid_id)
           , minor_id(0)
           , phantom_count(0)
           , rcc(0)
@@ -128,7 +128,7 @@ namespace gc {
             {
                 // use a mutex here?
                 int n = out_refs.size();
-                if (id != hpx::naming::invalid_id)
+                if (id != hpx::invalid_id)
                 {
                     out_refs.push_back(id);
                     incref_(weight, id);
@@ -137,15 +137,15 @@ namespace gc {
             }
             HPX_DEFINE_COMPONENT_ACTION(collectable, add_ref)
 
-            void set_ref(unsigned int index, hpx::naming::id_type id)
+            void set_ref(unsigned int index, hpx::id_type id)
             {
-                hpx::naming::id_type old_id = out_refs.at(index);
+                hpx::id_type old_id = out_refs.at(index);
                 if (id == old_id)
                     return;
                 out_refs[index] = id;
-                if (old_id != hpx::naming::invalid_id)
+                if (old_id != hpx::invalid_id)
                     decref_(weight, old_id);
-                if (id != hpx::naming::invalid_id)
+                if (id != hpx::invalid_id)
                     incref_(weight, id);
             }
             HPX_DEFINE_COMPONENT_ACTION(collectable, set_ref)
@@ -155,10 +155,10 @@ namespace gc {
             HPX_DEFINE_COMPONENT_ACTION(collectable, phantomize_ref)
             void incref(unsigned int weight);
             HPX_DEFINE_COMPONENT_ACTION(collectable, incref)
-            void incref_(unsigned int weight, hpx::naming::id_type id);
+            void incref_(unsigned int weight, hpx::id_type id);
             void decref(unsigned int weight);
             HPX_DEFINE_COMPONENT_ACTION(collectable, decref)
-            void decref_(unsigned int weight, hpx::naming::id_type id);
+            void decref_(unsigned int weight, hpx::id_type id);
 
             void phantom_wait_complete();
 
@@ -339,7 +339,7 @@ namespace gc { namespace server {
             cd->recovered = true;
             for (auto i : out_refs)
             {
-                if (i != hpx::naming::invalid_id)
+                if (i != hpx::invalid_id)
                 {
                     hpx::apply<collectable::recover_action>(i, cd->cid);
                     cd->wc++;
@@ -444,7 +444,7 @@ namespace gc { namespace server {
             cd->phantomized = true;
             for (auto i = out_refs.begin(); i != out_refs.end(); ++i)
             {
-                if (*i != hpx::naming::invalid_id)
+                if (*i != hpx::invalid_id)
                 {
                     cd->wc++;
                     hpx::async<collectable::phantomize_ref_action>(
@@ -464,16 +464,16 @@ namespace gc { namespace server {
         int n = out_refs.size();
         for (int i = 0; i < n; i++)
         {
-            set_ref(i, hpx::naming::invalid_id);
+            set_ref(i, hpx::invalid_id);
         }
     }
 
-    void collectable::incref_(unsigned int weight, hpx::naming::id_type id)
+    void collectable::incref_(unsigned int weight, hpx::id_type id)
     {
         hpx::async<server::collectable::incref_action>(id, weight).wait();
         state();
     }
-    void collectable::decref_(unsigned int weight, hpx::naming::id_type id)
+    void collectable::decref_(unsigned int weight, hpx::id_type id)
     {
         hpx::async<server::collectable::decref_action>(id, weight).wait();
         state();

--- a/components/performance_counters/papi/tests/regressions/papi_counters_basic_functions.cpp
+++ b/components/performance_counters/papi/tests/regressions/papi_counters_basic_functions.cpp
@@ -26,7 +26,7 @@ int hpx_main(hpx::program_options::variables_map&)
 
     std::uint32_t const prefix = hpx::get_locality_id();
     // use floating point instructions here to avoid measuring runtime side effects
-    using hpx::naming::id_type;
+    using hpx::id_type;
     using hpx::performance_counters::get_counter;
     using hpx::performance_counters::performance_counter;
     using hpx::performance_counters::counter_value;

--- a/examples/1d_stencil/1d_stencil_4_repart.cpp
+++ b/examples/1d_stencil/1d_stencil_4_repart.cpp
@@ -46,7 +46,7 @@
 
 #include <boost/shared_array.hpp>
 
-using hpx::naming::id_type;
+using hpx::id_type;
 using hpx::performance_counters::counter_value;
 using hpx::performance_counters::get_counter;
 using hpx::performance_counters::performance_counter;
@@ -55,7 +55,7 @@ using hpx::performance_counters::status_is_valid;
 static bool counters_initialized = false;
 static std::string counter_name = "";
 static apex_event_type end_iteration_event = APEX_CUSTOM_EVENT_1;
-static hpx::naming::id_type counter_id;
+static hpx::id_type counter_id;
 
 void setup_counters()
 {
@@ -79,7 +79,7 @@ void setup_counters()
     {
         std::cerr << "1d_stencil_4_repart: caught exception: " << e.what()
                   << std::endl;
-        counter_id = hpx::naming::invalid_id;
+        counter_id = hpx::invalid_id;
         return;
     }
 }

--- a/examples/1d_stencil/1d_stencil_4_throttle.cpp
+++ b/examples/1d_stencil/1d_stencil_4_throttle.cpp
@@ -38,7 +38,7 @@
 
 #include <apex_api.hpp>
 
-using hpx::naming::id_type;
+using hpx::id_type;
 using hpx::performance_counters::counter_value;
 using hpx::performance_counters::get_counter;
 using hpx::performance_counters::performance_counter;

--- a/examples/apex/apex_balance.cpp
+++ b/examples/apex/apex_balance.cpp
@@ -70,7 +70,7 @@ int hpx_main(hpx::program_options::variables_map& vm)
     // Keep track of the time required to execute.
     hpx::chrono::high_resolution_timer t;
 
-    std::vector<hpx::naming::id_type> localities = hpx::find_all_localities();
+    std::vector<hpx::id_type> localities = hpx::find_all_localities();
     std::vector<double> probabilities(localities.size());
     probabilities[0] = 1.0;
 

--- a/examples/apex/apex_fibonacci.cpp
+++ b/examples/apex/apex_fibonacci.cpp
@@ -37,7 +37,7 @@ std::uint64_t fibonacci(std::uint64_t n)
         return n;
 
     // We restrict ourselves to execute the Fibonacci function locally.
-    hpx::naming::id_type const locality_id = hpx::find_here();
+    hpx::id_type const locality_id = hpx::find_here();
 
     // Invoking the Fibonacci algorithm twice is inefficient.
     // However, we intentionally demonstrate it this way to create some

--- a/examples/apex/apex_policy_engine_active_thread_count.cpp
+++ b/examples/apex/apex_policy_engine_active_thread_count.cpp
@@ -38,7 +38,7 @@ std::uint64_t fibonacci(std::uint64_t n)
         return n;
 
     // We restrict ourselves to execute the Fibonacci function locally.
-    hpx::naming::id_type const locality_id = hpx::find_here();
+    hpx::id_type const locality_id = hpx::find_here();
 
     // Invoking the Fibonacci algorithm twice is inefficient.
     // However, we intentionally demonstrate it this way to create some

--- a/examples/apex/apex_policy_engine_events.cpp
+++ b/examples/apex/apex_policy_engine_events.cpp
@@ -37,7 +37,7 @@ std::uint64_t fibonacci(std::uint64_t n)
         return n;
 
     // We restrict ourselves to execute the Fibonacci function locally.
-    hpx::naming::id_type const locality_id = hpx::find_here();
+    hpx::id_type const locality_id = hpx::find_here();
 
     // Invoking the Fibonacci algorithm twice is inefficient.
     // However, we intentionally demonstrate it this way to create some

--- a/examples/apex/apex_policy_engine_periodic.cpp
+++ b/examples/apex/apex_policy_engine_periodic.cpp
@@ -37,7 +37,7 @@ std::uint64_t fibonacci(std::uint64_t n)
         return n;
 
     // We restrict ourselves to execute the Fibonacci function locally.
-    hpx::naming::id_type const locality_id = hpx::find_here();
+    hpx::id_type const locality_id = hpx::find_here();
 
     // Invoking the Fibonacci algorithm twice is inefficient.
     // However, we intentionally demonstrate it this way to create some

--- a/examples/async_io/async_io_action.cpp
+++ b/examples/async_io/async_io_action.cpp
@@ -69,10 +69,9 @@ int hpx_main()
         // example is run on one locality, we perform the IO operation
         // locally, otherwise we choose one of the remote localities to
         // invoke the async_io_action.
-        hpx::naming::id_type id = hpx::find_here();    // default: local
+        hpx::id_type id = hpx::find_here();    // default: local
 
-        std::vector<hpx::naming::id_type> localities =
-            hpx::find_remote_localities();
+        std::vector<hpx::id_type> localities = hpx::find_remote_localities();
         if (!localities.empty())
             id = localities[0];    // choose the first remote locality
 

--- a/examples/cancelable_action/cancelable_action/cancelable_action.hpp
+++ b/examples/cancelable_action/cancelable_action/cancelable_action.hpp
@@ -36,7 +36,7 @@ namespace examples
 
         /// Create a client side representation of an object which is newly
         /// created on the given locality
-        explicit cancelable_action(hpx::naming::id_type const& target_gid)
+        explicit cancelable_action(hpx::id_type const& target_gid)
           : base_type(hpx::new_<cancelable_action>(target_gid))
         {}
 

--- a/examples/cancelable_action/cancelable_action/stubs/cancelable_action.hpp
+++ b/examples/cancelable_action/cancelable_action/stubs/cancelable_action.hpp
@@ -21,20 +21,20 @@ namespace examples { namespace stubs
     {
         // Do some lengthy work
         static hpx::future<void>
-        do_it_async(hpx::naming::id_type const& gid)
+        do_it_async(hpx::id_type const& gid)
         {
             typedef server::cancelable_action::do_it_action action_type;
             return hpx::async<action_type>(gid);
         }
 
-        static void do_it(hpx::naming::id_type const& gid,
+        static void do_it(hpx::id_type const& gid,
             hpx::error_code& ec = hpx::throws)
         {
             do_it_async(gid).get(ec);
         }
 
         // Cancel the lengthy action above
-        static void cancel_it(hpx::naming::id_type const& gid)
+        static void cancel_it(hpx::id_type const& gid)
         {
             typedef server::cancelable_action::cancel_it_action action_type;
             hpx::apply<action_type>(gid);

--- a/examples/hello_world_component/hello_world_component.hpp
+++ b/examples/hello_world_component/hello_world_component.hpp
@@ -38,11 +38,11 @@ namespace examples
         typedef hpx::components::client_base<hello_world, server::hello_world>
             base_type;
 
-        hello_world(hpx::future<hpx::naming::id_type> && f)
+        hello_world(hpx::future<hpx::id_type> && f)
           : base_type(std::move(f))
         {}
 
-        hello_world(hpx::naming::id_type && f)
+        hello_world(hpx::id_type && f)
           : base_type(std::move(f))
         {}
 

--- a/examples/jacobi/jacobi_component/grid.cpp
+++ b/examples/jacobi/jacobi_component/grid.cpp
@@ -29,7 +29,7 @@ namespace jacobi
         rows.reserve(ny);
         std::vector<hpx::future<void> > init_futures;
         init_futures.reserve(ny);
-        for (hpx::naming::id_type const& id : ids)
+        for (hpx::id_type const& id : ids)
         {
             row r; r.id = id;
             init_futures.push_back(r.init(nx, value));

--- a/examples/jacobi/jacobi_component/row.hpp
+++ b/examples/jacobi/jacobi_component/row.hpp
@@ -28,7 +28,7 @@ namespace jacobi
             return hpx::async<server::row::init_action>(id, nx, value);
         }
 
-        hpx::naming::id_type id;
+        hpx::id_type id;
 
         hpx::future<row_range> get(std::size_t begin, std::size_t end)
         {

--- a/examples/jacobi/jacobi_component/server/solver.hpp
+++ b/examples/jacobi/jacobi_component/server/solver.hpp
@@ -60,7 +60,7 @@ namespace jacobi { namespace server {
             std::vector<hpx::shared_future<void>> init_futures;
             init_futures.reserve(ny);
             std::size_t y = 0;
-            for (hpx::naming::id_type const& id : ids)
+            for (hpx::id_type const& id : ids)
             {
                 //std::cout << y << " " << id << "\n";
                 jacobi::stencil_iterator r;

--- a/examples/jacobi/jacobi_component/solver.hpp
+++ b/examples/jacobi/jacobi_component/solver.hpp
@@ -35,7 +35,7 @@ namespace jacobi {
                 hpx::components::get_component_type<server::solver>();
 
             // get list of locality prefixes
-            std::vector<hpx::naming::id_type> localities =
+            std::vector<hpx::id_type> localities =
                 hpx::find_all_localities(solver_type);
 
             HPX_ASSERT(localities.size() > 0);

--- a/examples/jacobi/jacobi_component/stencil_iterator.hpp
+++ b/examples/jacobi/jacobi_component/stencil_iterator.hpp
@@ -44,7 +44,7 @@ namespace jacobi
             ar & id;
         }
 
-        hpx::naming::id_type id;
+        hpx::id_type id;
     };
 }
 

--- a/examples/nqueen/nqueen_client.cpp
+++ b/examples/nqueen/nqueen_client.cpp
@@ -29,7 +29,7 @@ int hpx_main(hpx::program_options::variables_map&)
 
     std::size_t soln_count_total = 0;
 
-    hpx::naming::id_type locality_ = hpx::find_here();
+    hpx::id_type locality_ = hpx::find_here();
 
     std::cout << "Enter size of board. Default size is 8." << std::endl;
     std::cout << "Command Options: size[value] | default | print | quit"

--- a/examples/quickstart/1d_wave_equation.cpp
+++ b/examples/quickstart/1d_wave_equation.cpp
@@ -42,8 +42,8 @@ using hpx::program_options::options_description;
 using hpx::program_options::value;
 using hpx::program_options::variables_map;
 
-using hpx::naming::id_type;
-using hpx::naming::invalid_id;
+using hpx::id_type;
+using hpx::invalid_id;
 
 using hpx::async;
 using hpx::future;

--- a/examples/quickstart/data_actions.cpp
+++ b/examples/quickstart/data_actions.cpp
@@ -6,8 +6,8 @@
 
 #include <hpx/config.hpp>
 #if !defined(HPX_COMPUTE_DEVICE_CODE)
-#include <hpx/hpx_main.hpp>
 #include <hpx/hpx.hpp>
+#include <hpx/hpx_main.hpp>
 
 #include <iostream>
 #include <type_traits>
@@ -20,14 +20,14 @@ struct plain_data
 {
     static hpx::components::component_type get_component_type()
     {
-        return hpx::components::get_component_type<plain_data<Action> >();
+        return hpx::components::get_component_type<plain_data<Action>>();
     }
     static void set_component_type(hpx::components::component_type type)
     {
-        hpx::components::set_component_type<plain_data<Action> >(type);
+        hpx::components::set_component_type<plain_data<Action>>(type);
     }
 
-    static bool is_target_valid(hpx::naming::id_type const&)
+    static bool is_target_valid(hpx::id_type const&)
     {
         return true;
     }
@@ -36,25 +36,24 @@ struct plain_data
 ///////////////////////////////////////////////////////////////////////////////
 template <typename T, typename Derived>
 struct data_get_action_base
-    : public hpx::actions::basic_action<plain_data<Derived>,
+  : public hpx::actions::basic_action<plain_data<Derived>,
         typename std::remove_pointer<T>::type(), Derived>
-{};
+{
+};
 
-template <typename T, T Data, typename Derived = hpx::actions::detail::this_type>
+template <typename T, T Data,
+    typename Derived = hpx::actions::detail::this_type>
 struct data_get_action
-    : public data_get_action_base<
-        typename std::remove_pointer<T>::type,
+  : public data_get_action_base<typename std::remove_pointer<T>::type,
         typename hpx::actions::detail::action_type<
-            data_get_action<T, Data, Derived>, Derived
-        >::type>
+            data_get_action<T, Data, Derived>, Derived>::type>
 {
     typedef std::false_type direct_execution;
 
     typedef typename std::remove_pointer<T>::type data_type;
 
     // Return the referenced data
-    static data_type invoke(
-        hpx::naming::address::address_type /*lva*/,
+    static data_type invoke(hpx::naming::address::address_type /*lva*/,
         hpx::naming::address::component_type /*comptype*/)
     {
         return *Data;
@@ -64,25 +63,23 @@ struct data_get_action
 ///////////////////////////////////////////////////////////////////////////
 template <typename T, typename Derived>
 struct data_set_action_base
-    : public hpx::actions::basic_action<plain_data<Derived>,
-        void(T), Derived>
-{};
+  : public hpx::actions::basic_action<plain_data<Derived>, void(T), Derived>
+{
+};
 
-template <typename T, T Data, typename Derived = hpx::actions::detail::this_type>
+template <typename T, T Data,
+    typename Derived = hpx::actions::detail::this_type>
 struct data_set_action
-    : public data_set_action_base<
-        typename std::remove_pointer<T>::type,
+  : public data_set_action_base<typename std::remove_pointer<T>::type,
         typename hpx::actions::detail::action_type<
-            data_set_action<T, Data, Derived>, Derived
-        >::type>
+            data_set_action<T, Data, Derived>, Derived>::type>
 {
     typedef typename std::remove_pointer<T>::type data_type;
 
     typedef std::false_type direct_execution;
 
     // Return the referenced data
-    static void invoke(
-        hpx::naming::address::address_type /*lva*/,
+    static void invoke(hpx::naming::address::address_type /*lva*/,
         hpx::naming::address::component_type /*comptype*/,
         data_type const& data)
     {
@@ -91,7 +88,7 @@ struct data_set_action
 };
 
 ///////////////////////////////////////////////////////////////////////////////
-int data = 0;       // this variable is exposed using the actions below
+int data = 0;    // this variable is exposed using the actions below
 
 typedef data_get_action<decltype(&data), &data> get_action;
 typedef data_set_action<decltype(&data), &data> set_action;

--- a/examples/quickstart/fibonacci.cpp
+++ b/examples/quickstart/fibonacci.cpp
@@ -37,7 +37,7 @@ std::uint64_t fibonacci(std::uint64_t n)
         return n;
 
     // We restrict ourselves to execute the Fibonacci function locally.
-    hpx::naming::id_type const locality_id = hpx::find_here();
+    hpx::id_type const locality_id = hpx::find_here();
 
     // Invoking the Fibonacci algorithm twice is inefficient.
     // However, we intentionally demonstrate it this way to create some

--- a/examples/quickstart/fibonacci_one.cpp
+++ b/examples/quickstart/fibonacci_one.cpp
@@ -39,7 +39,7 @@ std::uint64_t fibonacci(std::uint64_t n)
         return n;
 
     // We restrict ourselves to execute the Fibonacci function locally.
-    hpx::naming::id_type const locality_id = hpx::find_here();
+    hpx::id_type const locality_id = hpx::find_here();
 
     // Run one branch of the Fibonacci calculation on this thread, while the
     // other branch is scheduled in a separate thread.

--- a/examples/quickstart/hello_world_distributed.cpp
+++ b/examples/quickstart/hello_world_distributed.cpp
@@ -134,13 +134,13 @@ HPX_PLAIN_ACTION(hello_world_foreman, hello_world_foreman_action)
 int main()
 {
     // Get a list of all available localities.
-    std::vector<hpx::naming::id_type> localities = hpx::find_all_localities();
+    std::vector<hpx::id_type> localities = hpx::find_all_localities();
 
     // Reserve storage space for futures, one for each locality.
     std::vector<hpx::future<void>> futures;
     futures.reserve(localities.size());
 
-    for (hpx::naming::id_type const& node : localities)
+    for (hpx::id_type const& node : localities)
     {
         // Asynchronously start a new task. The task is encapsulated in a
         // future, which we can query to determine if the task has

--- a/examples/quickstart/interest_calculator.cpp
+++ b/examples/quickstart/interest_calculator.cpp
@@ -53,7 +53,7 @@ int hpx_main(variables_map & vm)
         using hpx::make_ready_future;
         using hpx::shared_future;
         using hpx::unwrapping;
-        hpx::naming::id_type here = hpx::find_here();
+        hpx::id_type here = hpx::find_here();
 
         double init_principal=vm["principal"].as<double>(); //Initial principal
         double init_rate=vm["rate"].as<double>(); //Interest rate

--- a/examples/quickstart/pingpong.cpp
+++ b/examples/quickstart/pingpong.cpp
@@ -23,20 +23,20 @@
 #include <vector>
 
 ///////////////////////////////////////////////////////////////////////////////
-const std::size_t vsize_default = 1024*1024;
+const std::size_t vsize_default = 1024 * 1024;
 const std::size_t numiter_default = 5;
 
 ///////////////////////////////////////////////////////////////////////////////
-void on_recv(hpx::naming::id_type to, std::vector<double> const & in,
-    std::size_t counter);
+void on_recv(
+    hpx::id_type to, std::vector<double> const& in, std::size_t counter);
 HPX_PLAIN_ACTION(on_recv, on_recv_action)
 
-void on_recv(hpx::naming::id_type to, std::vector<double> const & in,
-    std::size_t counter)
+void on_recv(
+    hpx::id_type to, std::vector<double> const& in, std::size_t counter)
 {
     // received vector in
-    if (--counter == 0) return;
-
+    if (--counter == 0)
+        return;
 
     // send it to remote locality (to), and wait until it is received
     std::vector<double> data(in);
@@ -46,41 +46,42 @@ void on_recv(hpx::naming::id_type to, std::vector<double> const & in,
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-void on_recv_ind(hpx::naming::id_type to,
-    std::shared_ptr<std::vector<double> > const& in, std::size_t counter);
+void on_recv_ind(hpx::id_type to,
+    std::shared_ptr<std::vector<double>> const& in, std::size_t counter);
 HPX_PLAIN_ACTION(on_recv_ind, on_recv_ind_action)
 
-void on_recv_ind(hpx::naming::id_type to,
-    std::shared_ptr<std::vector<double> > const& in, std::size_t counter)
+void on_recv_ind(hpx::id_type to,
+    std::shared_ptr<std::vector<double>> const& in, std::size_t counter)
 {
     // received vector in
-    if (--counter == 0) return;
+    if (--counter == 0)
+        return;
 
     // send it to remote locality (to), and wait until it is received
-    std::shared_ptr<std::vector<double> > data(
-        std::make_shared<std::vector<double> >(*in));
+    std::shared_ptr<std::vector<double>> data(
+        std::make_shared<std::vector<double>>(*in));
 
     on_recv_ind_action act;
     act(to, hpx::find_here(), data, counter);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-int hpx_main(hpx::program_options::variables_map &b_arg)
+int hpx_main(hpx::program_options::variables_map& b_arg)
 {
     std::size_t const vsize = b_arg["vsize"].as<std::size_t>();
     std::size_t const numiter = b_arg["numiter"].as<std::size_t>() * 2;
     bool verbose = b_arg["verbose"].as<bool>();
 
-    std::vector<hpx::naming::id_type> localities = hpx::find_remote_localities();
+    std::vector<hpx::id_type> localities = hpx::find_remote_localities();
 
-    hpx::naming::id_type to;
-    if(localities.size() == 0)
+    hpx::id_type to;
+    if (localities.size() == 0)
     {
         to = hpx::find_here();
     }
     else
     {
-        to = localities[0]; // send to first remote locality
+        to = localities[0];    // send to first remote locality
     }
 
     // test sending messages back and forth using a larger vector as one of
@@ -90,7 +91,8 @@ int hpx_main(hpx::program_options::variables_map &b_arg)
 
         hpx::chrono::high_resolution_timer timer1;
 
-        if (numiter != 0) {
+        if (numiter != 0)
+        {
             on_recv_action act;
             act(to, hpx::find_here(), data, numiter);
         }
@@ -100,7 +102,8 @@ int hpx_main(hpx::program_options::variables_map &b_arg)
             ((static_cast<double>(vsize * sizeof(double) * numiter) / time) /
                 1024) /
             1024;
-        if (verbose) {
+        if (verbose)
+        {
             std::cout << "[hpx_pingpong]" << std::endl
                       << "total_time(secs)=" << time << std::endl
                       << "vsize=" << vsize << " = " << vsize * sizeof(double)
@@ -109,7 +112,8 @@ int hpx_main(hpx::program_options::variables_map &b_arg)
                       << "localities=" << localities.size() << std::endl
                       << "numiter=" << numiter << std::endl;
         }
-        else {
+        else
+        {
             std::cout << "[hpx_pingpong]"
                       << ":total_time(secs)=" << time << ":vsize=" << vsize
                       << ":bandwidth(MiB/s)=" << bandwidth
@@ -152,14 +156,13 @@ int main(int argc, char* argv[])
     namespace po = hpx::program_options;
     po::options_description description("HPX pingpong example");
 
-    description.add_options()
-        ( "vsize", po::value<std::size_t>()->default_value(vsize_default),
-          "number of elements (doubles) to send/receive  (integer)")
-        ( "numiter", po::value<std::size_t>()->default_value(numiter_default),
-          "number of ping-pong iterations")
-        ( "verbose", po::value<bool>()->default_value(true),
-         "verbosity of output,if false output is for awk")
-        ;
+    description.add_options()("vsize",
+        po::value<std::size_t>()->default_value(vsize_default),
+        "number of elements (doubles) to send/receive  (integer)")("numiter",
+        po::value<std::size_t>()->default_value(numiter_default),
+        "number of ping-pong iterations")("verbose",
+        po::value<bool>()->default_value(true),
+        "verbosity of output,if false output is for awk");
 
     hpx::init_params init_args;
     init_args.desc_cmdline = description;

--- a/examples/quickstart/print_to_console.cpp
+++ b/examples/quickstart/print_to_console.cpp
@@ -46,7 +46,7 @@ struct print_direct_action
 ///////////////////////////////////////////////////////////////////////////////
 int main()
 {
-    hpx::naming::id_type console = hpx::find_root_locality();
+    hpx::id_type console = hpx::find_root_locality();
 
     // print something to the console
     {

--- a/examples/quickstart/sierpinski.cpp
+++ b/examples/quickstart/sierpinski.cpp
@@ -6,7 +6,6 @@
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 ////////////////////////////////////////////////////////////////////////////////
 
-
 // http://www.wikiwand.com/en/Sierpinski_triangle
 // At each iteration, a white triangle in deleted from the middle
 // of every black triangle,
@@ -14,7 +13,6 @@
 
 // Takes two program options, the number of iterations (n-value, with default 5)
 // and the side length of the original triangle (side-length, with default 100)
-
 
 #include <hpx/config.hpp>
 #if !defined(HPX_COMPUTE_DEVICE_CODE)
@@ -29,30 +27,29 @@
 #include <cstdint>
 #include <iostream>
 
-
 // Class representing a Sierpinski triangle
-class sierpinski{
-    public:
+class sierpinski
+{
+public:
     std::uint64_t black_triangles, white_triangles;
     double area;
 
-    sierpinski(){}
-    sierpinski(std::uint64_t black, std::uint64_t white, double area){
+    sierpinski() {}
+    sierpinski(std::uint64_t black, std::uint64_t white, double area)
+    {
         this->black_triangles = black;
         this->white_triangles = white;
         this->area = area;
     }
 
-    inline sierpinski operator+(const sierpinski& other) const {
-        sierpinski res = sierpinski (
-            black_triangles+other.black_triangles,
-            white_triangles+other.white_triangles,
-            area+other.area);
+    inline sierpinski operator+(const sierpinski& other) const
+    {
+        sierpinski res = sierpinski(black_triangles + other.black_triangles,
+            white_triangles + other.white_triangles, area + other.area);
         return res;
     }
 
-
-    private:
+private:
     //Serialization is necessary to transmit objects from one locality to another
     friend class hpx::serialization::access;
     template <class Archive>
@@ -66,24 +63,21 @@ class sierpinski{
     }
 };
 
-
 ///////////////////////////////////////////////////////////////////////////////
 // forward declaration of the get_sierpinski function
 sierpinski get_sierpinski(std::uint64_t n, double len);
-
 
 // This is to generate the required boilerplate we need for the remote
 // invocation to work.
 HPX_PLAIN_ACTION(get_sierpinski, get_sierpinski_action)
 
-
 ///////////////////////////////////////////////////////////////////////////////
 sierpinski get_sierpinski(std::uint64_t n, double len)
 {
     if (n == 0)
-        return sierpinski(1, 0, sqrt(3)/4.0*len*len);
+        return sierpinski(1, 0, sqrt(3) / 4.0 * len * len);
 
-    hpx::naming::id_type const locality_id = hpx::find_here();
+    hpx::id_type const locality_id = hpx::find_here();
 
     // The problem for iteration n is broken down into three sub-problems,
     // each of size n-1 (and side length gets halved). It is very inefficient
@@ -91,15 +85,14 @@ sierpinski get_sierpinski(std::uint64_t n, double len)
     // three times but this is the method used for the sake of using HPX.
 
     get_sierpinski_action s;
-    hpx::future<sierpinski> n1 = hpx::async(s, locality_id, n - 1, len/2);
-    hpx::future<sierpinski> n2 = hpx::async(s, locality_id, n - 1, len/2);
-    hpx::future<sierpinski> n3 = hpx::async(s, locality_id, n - 1, len/2);
+    hpx::future<sierpinski> n1 = hpx::async(s, locality_id, n - 1, len / 2);
+    hpx::future<sierpinski> n2 = hpx::async(s, locality_id, n - 1, len / 2);
+    hpx::future<sierpinski> n3 = hpx::async(s, locality_id, n - 1, len / 2);
 
     sierpinski ans = n1.get() + n2.get() + n3.get();
     ans.white_triangles++;
     return ans;
 }
-
 
 ///////////////////////////////////////////////////////////////////////////////
 int hpx_main(hpx::program_options::variables_map& vm)
@@ -109,7 +102,7 @@ int hpx_main(hpx::program_options::variables_map& vm)
 
     {
         get_sierpinski_action s;
-        sierpinski ans = s(hpx::find_here(), n, (double)len);
+        sierpinski ans = s(hpx::find_here(), n, (double) len);
 
         hpx::cout << "After iteration: " << n << std::endl;
         hpx::cout << "Black triangles: " << ans.black_triangles << std::endl;
@@ -124,19 +117,15 @@ int hpx_main(hpx::program_options::variables_map& vm)
 int main(int argc, char* argv[])
 {
     // Configure application-specific options
-    hpx::program_options::options_description
-        desc_commandline("Usage: " HPX_APPLICATION_STRING " [options]");
+    hpx::program_options::options_description desc_commandline(
+        "Usage: " HPX_APPLICATION_STRING " [options]");
 
-    desc_commandline.add_options()
-        ( "n-value",
-          hpx::program_options::value<std::uint64_t>()->default_value(5),
-          "n value for the Sierpinski function")
-        ;
-    desc_commandline.add_options()
-        ( "side-length",
-          hpx::program_options::value<std::uint64_t>()->default_value(100),
-          "side-length of the original triangle")
-        ;
+    desc_commandline.add_options()("n-value",
+        hpx::program_options::value<std::uint64_t>()->default_value(5),
+        "n value for the Sierpinski function");
+    desc_commandline.add_options()("side-length",
+        hpx::program_options::value<std::uint64_t>()->default_value(100),
+        "side-length of the original triangle");
 
     hpx::init_params init_args;
     init_args.desc_cmdline = desc_commandline;

--- a/examples/sheneos/sheneos_test.cpp
+++ b/examples/sheneos/sheneos_test.cpp
@@ -6,8 +6,8 @@
 
 #include <hpx/config.hpp>
 #if !defined(HPX_COMPUTE_DEVICE_CODE)
-#include <hpx/hpx_init.hpp>
 #include <hpx/hpx.hpp>
+#include <hpx/hpx_init.hpp>
 
 #include <cstddef>
 #include <cstdlib>
@@ -19,8 +19,8 @@
 
 #include "sheneos/interpolator.hpp"
 
-#include <boost/dynamic_bitset.hpp>
 #include <hpx/modules/program_options.hpp>
+#include <boost/dynamic_bitset.hpp>
 
 char const* const shen_symbolic_name = "/sheneos/interpolator_test";
 
@@ -54,7 +54,8 @@ void test_sheneos(std::size_t num_ye_points, std::size_t num_temp_points,
     std::vector<double> values_ye(num_ye_points);
     std::vector<std::size_t> sequence_ye(num_ye_points);
     double ye = min_ye;
-    for (std::size_t i = 0; i < num_ye_points; ++i) {
+    for (std::size_t i = 0; i < num_ye_points; ++i)
+    {
         values_ye[i] = ye;
         sequence_ye[i] = i;
         ye += delta_ye;
@@ -63,7 +64,8 @@ void test_sheneos(std::size_t num_ye_points, std::size_t num_temp_points,
     std::vector<double> values_temp(num_temp_points);
     std::vector<std::size_t> sequence_temp(num_temp_points);
     double temp = min_temp;
-    for (std::size_t i = 0; i < num_temp_points; ++i) {
+    for (std::size_t i = 0; i < num_temp_points; ++i)
+    {
         values_temp[i] = temp;
         sequence_temp[i] = i;
         temp += delta_temp;
@@ -72,7 +74,8 @@ void test_sheneos(std::size_t num_ye_points, std::size_t num_temp_points,
     std::vector<double> values_rho(num_rho_points);
     std::vector<std::size_t> sequence_rho(num_rho_points);
     double rho = min_rho;
-    for (std::size_t i = 0; i < num_rho_points; ++i) {
+    for (std::size_t i = 0; i < num_rho_points; ++i)
+    {
         values_rho[i] = rho;
         sequence_rho[i] = i;
         rho += delta_rho;
@@ -89,7 +92,7 @@ void test_sheneos(std::size_t num_ye_points, std::size_t num_temp_points,
     std::random_shuffle(sequence_rho.begin(), sequence_rho.end());
 
     // Create the three-dimensional future grid.
-    std::vector<hpx::future<std::vector<double> > > tests;
+    std::vector<hpx::future<std::vector<double>>> tests;
     for (std::size_t const& ii : sequence_ye)
     {
         for (std::size_t const& jj : sequence_temp)
@@ -139,7 +142,8 @@ void test_sheneos_one_bulk(std::size_t num_ye_points,
     std::vector<double> values_ye(num_ye_points);
     std::vector<std::size_t> sequence_ye(num_ye_points);
     double ye = min_ye;
-    for (std::size_t i = 0; i < num_ye_points; ++i) {
+    for (std::size_t i = 0; i < num_ye_points; ++i)
+    {
         values_ye[i] = ye;
         sequence_ye[i] = i;
         ye += delta_ye;
@@ -148,7 +152,8 @@ void test_sheneos_one_bulk(std::size_t num_ye_points,
     std::vector<double> values_temp(num_temp_points);
     std::vector<std::size_t> sequence_temp(num_temp_points);
     double temp = min_temp;
-    for (std::size_t i = 0; i < num_temp_points; ++i) {
+    for (std::size_t i = 0; i < num_temp_points; ++i)
+    {
         values_temp[i] = temp;
         sequence_temp[i] = i;
         temp += delta_temp;
@@ -157,7 +162,8 @@ void test_sheneos_one_bulk(std::size_t num_ye_points,
     std::vector<double> values_rho(num_rho_points);
     std::vector<std::size_t> sequence_rho(num_rho_points);
     double rho = min_rho;
-    for (std::size_t i = 0; i < num_rho_points; ++i) {
+    for (std::size_t i = 0; i < num_rho_points; ++i)
+    {
         values_rho[i] = rho;
         sequence_rho[i] = i;
         rho += delta_rho;
@@ -177,7 +183,7 @@ void test_sheneos_one_bulk(std::size_t num_ye_points,
     std::vector<sheneos::sheneos_coord> values;
     values.reserve(num_ye_points * num_temp_points * num_rho_points);
 
-    std::vector<hpx::future<std::vector<double> > > tests;
+    std::vector<hpx::future<std::vector<double>>> tests;
     for (std::size_t const& ii : sequence_ye)
     {
         for (std::size_t const& jj : sequence_temp)
@@ -191,9 +197,9 @@ void test_sheneos_one_bulk(std::size_t num_ye_points,
     }
 
     // Execute bulk operation
-    hpx::future<std::vector<double> > bulk_one_tests =
-        shen.interpolate_one_bulk_async(values,
-            sheneos::server::partition3d::logpress);
+    hpx::future<std::vector<double>> bulk_one_tests =
+        shen.interpolate_one_bulk_async(
+            values, sheneos::server::partition3d::logpress);
 
     std::vector<double> results = hpx::unwrap(bulk_one_tests);
     (void) results;
@@ -206,8 +212,8 @@ HPX_PLAIN_ACTION(test_sheneos_one_bulk, test_one_bulk_action)
 ///////////////////////////////////////////////////////////////////////////////
 /// This is the test function for interpolate_bulk. It will be invoked on all
 /// localities that the benchmark is being run on.
-void test_sheneos_bulk(std::size_t num_ye_points,
-    std::size_t num_temp_points, std::size_t num_rho_points, std::size_t seed)
+void test_sheneos_bulk(std::size_t num_ye_points, std::size_t num_temp_points,
+    std::size_t num_rho_points, std::size_t seed)
 {
     // Create a client instance connected to the already existing interpolation
     // object.
@@ -233,7 +239,8 @@ void test_sheneos_bulk(std::size_t num_ye_points,
     std::vector<double> values_ye(num_ye_points);
     std::vector<std::size_t> sequence_ye(num_ye_points);
     double ye = min_ye;
-    for (std::size_t i = 0; i < num_ye_points; ++i) {
+    for (std::size_t i = 0; i < num_ye_points; ++i)
+    {
         values_ye[i] = ye;
         sequence_ye[i] = i;
         ye += delta_ye;
@@ -242,7 +249,8 @@ void test_sheneos_bulk(std::size_t num_ye_points,
     std::vector<double> values_temp(num_temp_points);
     std::vector<std::size_t> sequence_temp(num_temp_points);
     double temp = min_temp;
-    for (std::size_t i = 0; i < num_temp_points; ++i) {
+    for (std::size_t i = 0; i < num_temp_points; ++i)
+    {
         values_temp[i] = temp;
         sequence_temp[i] = i;
         temp += delta_temp;
@@ -251,7 +259,8 @@ void test_sheneos_bulk(std::size_t num_ye_points,
     std::vector<double> values_rho(num_rho_points);
     std::vector<std::size_t> sequence_rho(num_rho_points);
     double rho = min_rho;
-    for (std::size_t i = 0; i < num_rho_points; ++i) {
+    for (std::size_t i = 0; i < num_rho_points; ++i)
+    {
         values_rho[i] = rho;
         sequence_rho[i] = i;
         rho += delta_rho;
@@ -271,7 +280,7 @@ void test_sheneos_bulk(std::size_t num_ye_points,
     std::vector<sheneos::sheneos_coord> values;
     values.reserve(num_ye_points * num_temp_points * num_rho_points);
 
-    std::vector<hpx::future<std::vector<double> > > tests;
+    std::vector<hpx::future<std::vector<double>>> tests;
     for (std::size_t const& ii : sequence_ye)
     {
         for (std::size_t const& jj : sequence_temp)
@@ -285,7 +294,7 @@ void test_sheneos_bulk(std::size_t num_ye_points,
     }
 
     // Execute bulk operation
-    hpx::future<std::vector<std::vector<double> > > bulk_tests =
+    hpx::future<std::vector<std::vector<double>>> bulk_tests =
         shen.interpolate_bulk_async(values);
 
     std::vector<std::vector<double>> results = hpx::unwrap(bulk_tests);
@@ -303,10 +312,11 @@ void wait_for_task(std::size_t i, hpx::chrono::high_resolution_timer& t)
               << std::endl;
 }
 
-void wait_for_bulk_one_task(std::size_t i, hpx::chrono::high_resolution_timer& t)
+void wait_for_bulk_one_task(
+    std::size_t i, hpx::chrono::high_resolution_timer& t)
 {
-    std::cout << "Finished bulk-one task " << i << ": " << t.elapsed()
-        << " [s]" << std::endl;
+    std::cout << "Finished bulk-one task " << i << ": " << t.elapsed() << " [s]"
+              << std::endl;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -334,7 +344,8 @@ int hpx_main(hpx::program_options::variables_map& vm)
         // Create a distributed interpolation object with the name
         // shen_symbolic_name. The interpolation object will have
         // num_partitions partitions
-        sheneos::interpolator shen(datafilename, shen_symbolic_name, num_partitions);
+        sheneos::interpolator shen(
+            datafilename, shen_symbolic_name, num_partitions);
 
         std::cout << "Created interpolator: " << t.elapsed() << " [s]"
                   << std::endl;
@@ -346,21 +357,21 @@ int hpx_main(hpx::program_options::variables_map& vm)
 
         // Kick off the computation asynchronously. On each locality,
         // num_workers test_actions are created.
-        std::vector<hpx::future<void> > bulk_tests;
-        for (hpx::naming::id_type const& id : locality_ids)
+        std::vector<hpx::future<void>> bulk_tests;
+        for (hpx::id_type const& id : locality_ids)
         {
             for (std::size_t i = 0; i < num_workers; ++i)
             {
-                bulk_tests.push_back(hpx::async<test_bulk_action>(id,
-                    num_ye_points, num_temp_points, num_rho_points, seed));
+                bulk_tests.push_back(hpx::async<test_bulk_action>(
+                    id, num_ye_points, num_temp_points, num_rho_points, seed));
             }
         }
         hpx::wait_all(bulk_tests);
 
         std::cout << "Completed bulk tests: " << t.elapsed() << " [s]"
-            << std::endl;
+                  << std::endl;
 
-    } // Ensure that everything is out of scope before shutdown.
+    }    // Ensure that everything is out of scope before shutdown.
 
     // Shutdown the runtime system.
     return hpx::finalize();
@@ -375,24 +386,23 @@ int main(int argc, char* argv[])
     // Configure application-specific options.
     options_description cmdline("Usage: " HPX_APPLICATION_STRING " [options]");
 
-    cmdline.add_options()
-        ("file", value<std::string>()->default_value(
-                "sheneos_220r_180t_50y_extT_analmu_20100322_SVNr28.h5"),
-            "name of HDF5 data file containing the Shen EOS tables")
-        ("num-ye-points,Y", value<std::size_t>()->default_value(40),
-            "number of points to interpolate on the ye axis")
-        ("num-temp-points,T", value<std::size_t>()->default_value(40),
-            "number of points to interpolate on the temp axis")
-        ("num-rho-points,R", value<std::size_t>()->default_value(40),
-            "number of points to interpolate on the rho axis")
-        ("num-partitions", value<std::size_t>()->default_value(32),
-            "number of partitions to create")
-        ("num-workers", value<std::size_t>()->default_value(1),
-            "number of worker/measurement threads to create")
-        ("seed", value<std::size_t>()->default_value(0),
-            "the seed for the pseudo random number generator (if 0, a seed "
-            "is chosen based on the current system time)")
-    ;
+    cmdline.add_options()("file",
+        value<std::string>()->default_value(
+            "sheneos_220r_180t_50y_extT_analmu_20100322_SVNr28.h5"),
+        "name of HDF5 data file containing the Shen EOS tables")(
+        "num-ye-points,Y", value<std::size_t>()->default_value(40),
+        "number of points to interpolate on the ye axis")("num-temp-points,T",
+        value<std::size_t>()->default_value(40),
+        "number of points to interpolate on the temp axis")("num-rho-points,R",
+        value<std::size_t>()->default_value(40),
+        "number of points to interpolate on the rho axis")("num-partitions",
+        value<std::size_t>()->default_value(32),
+        "number of partitions to create")("num-workers",
+        value<std::size_t>()->default_value(1),
+        "number of worker/measurement threads to create")("seed",
+        value<std::size_t>()->default_value(0),
+        "the seed for the pseudo random number generator (if 0, a seed "
+        "is chosen based on the current system time)");
 
     // Initialize and run HPX.
     hpx::init_params init_args;

--- a/examples/spell_check/spell_check_file.cpp
+++ b/examples/spell_check/spell_check_file.cpp
@@ -211,7 +211,7 @@ int hpx_main()
             {
                 string& single = strs[i];
                 int start = 0;
-                hpx::naming::id_type const locality_id = hpx::find_here();
+                hpx::id_type const locality_id = hpx::find_here();
                 search_action temp;
                 wordRun.push_back(async(temp, locality_id, start, wordcount, single));
                 sAct.push_back(temp);

--- a/examples/spell_check/spell_check_simple.cpp
+++ b/examples/spell_check/spell_check_simple.cpp
@@ -189,7 +189,7 @@ int hpx_main()
             {
                 string& single = strs[i];
                 int start = 0;
-                hpx::naming::id_type const locality_id = hpx::find_here();
+                hpx::id_type const locality_id = hpx::find_here();
                 search_action temp;
                 wordRun.push_back(async(temp, locality_id, start, wordcount, single));
                 sAct.push_back(temp);

--- a/examples/throttle/spin.cpp
+++ b/examples/throttle/spin.cpp
@@ -19,7 +19,7 @@ using hpx::init;
 using hpx::finalize;
 
 using hpx::naming::address;
-using hpx::naming::id_type;
+using hpx::id_type;
 using hpx::naming::get_locality_id_from_gid;
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/examples/throttle/throttle/stubs/throttle.hpp
+++ b/examples/throttle/throttle/stubs/throttle.hpp
@@ -22,7 +22,7 @@ namespace throttle { namespace stubs
     {
         ///////////////////////////////////////////////////////////////////////
         static hpx::future<void>
-        suspend_async(hpx::naming::id_type const& gid, std::size_t thread_num)
+        suspend_async(hpx::id_type const& gid, std::size_t thread_num)
         {
             // Create a future, execute the required action,
             // we simply return the initialized future, the caller needs
@@ -32,14 +32,14 @@ namespace throttle { namespace stubs
         }
 
         static void
-        suspend(hpx::naming::id_type const& gid, std::size_t thread_num)
+        suspend(hpx::id_type const& gid, std::size_t thread_num)
         {
             suspend_async(gid, thread_num).get();
         }
 
         ///////////////////////////////////////////////////////////////////////
         static hpx::future<void>
-        resume_async(hpx::naming::id_type const& gid, std::size_t thread_num)
+        resume_async(hpx::id_type const& gid, std::size_t thread_num)
         {
             // Create a future, execute the required action,
             // we simply return the initialized future, the caller needs
@@ -49,7 +49,7 @@ namespace throttle { namespace stubs
         }
 
         static void
-        resume(hpx::naming::id_type const& gid, std::size_t thread_num)
+        resume(hpx::id_type const& gid, std::size_t thread_num)
         {
             resume_async(gid, thread_num).get();
         }

--- a/examples/throttle/throttle/throttle.hpp
+++ b/examples/throttle/throttle/throttle.hpp
@@ -38,7 +38,7 @@ namespace throttle
           : base_type(id)
         {}
 
-        throttle(hpx::future<hpx::naming::id_type> && gid)
+        throttle(hpx::future<hpx::id_type> && gid)
           : base_type(std::move(gid))
         {}
 

--- a/examples/throttle/throttle_client.cpp
+++ b/examples/throttle/throttle_client.cpp
@@ -30,52 +30,63 @@ using hpx::naming::get_agas_client;
 ///////////////////////////////////////////////////////////////////////////////
 int hpx_main(variables_map& vm)
 {
-    try {
+    try
+    {
         hpx::util::format_to(std::cout, "prefix: {}",
-            hpx::naming::get_locality_id_from_id(hpx::find_here())) << std::endl;
+            hpx::naming::get_locality_id_from_id(hpx::find_here()))
+            << std::endl;
 
         // Try to connect to existing throttle instance, create a new one if
         // this fails.
         char const* throttle_component_name = "/throttle/0";
-        hpx::naming::id_type gid =
+        hpx::id_type gid =
             hpx::agas::resolve_name(hpx::launch::sync, throttle_component_name);
         throttle::throttle t;
-        if (!t.get_id()) {
-            std::vector<hpx::naming::id_type> localities =
+        if (!t.get_id())
+        {
+            std::vector<hpx::id_type> localities =
                 hpx::find_remote_localities();
 
             // create throttle on the console, register the instance with AGAS
             // and add an additional reference count to keep it alive
-            if (!localities.empty()) {
+            if (!localities.empty())
+            {
                 // use AGAS client to get the component type as we do not
                 // register any factories
                 t = hpx::new_<throttle::throttle>(localities[0]);
-                hpx::agas::register_name(hpx::launch::sync,
-                    throttle_component_name, t.get_id());
+                hpx::agas::register_name(
+                    hpx::launch::sync, throttle_component_name, t.get_id());
             }
-            else {
+            else
+            {
                 std::cerr << "Can't find throttle component." << std::endl;
             }
         }
 
         // handle commands
-        if (t.get_id()) {
-            if (vm.count("suspend")) {
+        if (t.get_id())
+        {
+            if (vm.count("suspend"))
+            {
                 t.suspend(vm["suspend"].as<int>());
             }
-            else if (vm.count("resume")) {
+            else if (vm.count("resume"))
+            {
                 t.resume(vm["resume"].as<int>());
             }
-            else if (vm.count("release")) {
+            else if (vm.count("release"))
+            {
                 // unregister from AGAS, remove additional reference count which
                 // will allow for the throttle instance to be released
-                hpx::agas::unregister_name(hpx::launch::sync,
-                    throttle_component_name);
+                hpx::agas::unregister_name(
+                    hpx::launch::sync, throttle_component_name);
             }
         }
     }
-    catch (hpx::exception const& e) {
-        std::cerr << "throttle_client: caught exception: " << e.what() << std::endl;
+    catch (hpx::exception const& e)
+    {
+        std::cerr << "throttle_client: caught exception: " << e.what()
+                  << std::endl;
     }
 
     hpx::disconnect();
@@ -88,18 +99,16 @@ int main(int argc, char* argv[])
     namespace po = hpx::program_options;
 
     // Configure application-specific options
-    po::options_description cmdline("Usage: " HPX_APPLICATION_STRING " [options]");
-    cmdline.add_options()
-        ("suspend", po::value<int>(), "suspend thread with given number")
-        ("resume", po::value<int>(), "resume thread with given number")
-        ("release", "release throttle component instance")
-    ;
+    po::options_description cmdline(
+        "Usage: " HPX_APPLICATION_STRING " [options]");
+    cmdline.add_options()(
+        "suspend", po::value<int>(), "suspend thread with given number")(
+        "resume", po::value<int>(), "resume thread with given number")(
+        "release", "release throttle component instance");
 
     // Disable loading of all external components
     std::vector<std::string> const cfg = {
-        "hpx.components.load_external=0",
-        "hpx.run_hpx_main!=1"
-    };
+        "hpx.components.load_external=0", "hpx.run_hpx_main!=1"};
 
     hpx::init_params init_args;
     init_args.mode = hpx::runtime_mode::connect;

--- a/examples/tuplespace/central_tuplespace/simple_central_tuplespace.hpp
+++ b/examples/tuplespace/central_tuplespace/simple_central_tuplespace.hpp
@@ -14,21 +14,19 @@
 
 #include "stubs/simple_central_tuplespace.hpp"
 
-namespace examples
-{
+namespace examples {
     ///////////////////////////////////////////////////////////////////////////
     /// Client for the \a server::simple_central_tuplespace component.
     //[simple_central_tuplespace_client_inherit
     class simple_central_tuplespace
-      : public hpx::components::client_base<
-            simple_central_tuplespace, stubs::simple_central_tuplespace
-        >
+      : public hpx::components::client_base<simple_central_tuplespace,
+            stubs::simple_central_tuplespace>
     //]
     {
         //[simple_central_tuplespace_base_type
-        typedef hpx::components::client_base<
-            simple_central_tuplespace, stubs::simple_central_tuplespace
-        > base_type;
+        typedef hpx::components::client_base<simple_central_tuplespace,
+            stubs::simple_central_tuplespace>
+            base_type;
         //]
 
         typedef base_type::tuple_type tuple_type;
@@ -36,18 +34,19 @@ namespace examples
     public:
         /// Default construct an empty client side representation (not
         /// connected to any existing component).
-        simple_central_tuplespace()
-        {}
+        simple_central_tuplespace() {}
 
         /// Create a client side representation for the existing
         /// \a server::simple_central_tuplespace instance with the given GID.
-        simple_central_tuplespace(hpx::shared_future<hpx::naming::id_type> const& gid)
+        simple_central_tuplespace(hpx::shared_future<hpx::id_type> const& gid)
           : base_type(gid)
-        {}
+        {
+        }
 
-        simple_central_tuplespace(hpx::naming::id_type const& gid)
+        simple_central_tuplespace(hpx::id_type const& gid)
           : base_type(gid)
-        {}
+        {
+        }
 
         ~simple_central_tuplespace()
         {
@@ -57,28 +56,29 @@ namespace examples
             }
         }
 
-        bool create(std::string const& symbol_name, hpx::id_type const& locality)
+        bool create(
+            std::string const& symbol_name, hpx::id_type const& locality)
         {
-            if(!symbol_name_.empty())
+            if (!symbol_name_.empty())
             {
-                hpx::cerr<<"simple_central_tuplespace::create() "
-                    <<": ERROR! current instance not empty!\n";
+                hpx::cerr << "simple_central_tuplespace::create() "
+                          << ": ERROR! current instance not empty!\n";
                 return false;
             }
-            if(symbol_name_ == symbol_name) // itself
+            if (symbol_name_ == symbol_name)    // itself
             {
-                hpx::cerr<<"simple_central_tuplespace::create() "
-                    <<": ERROR! current instance already attached to "
-                    << symbol_name <<"\n";
+                hpx::cerr << "simple_central_tuplespace::create() "
+                          << ": ERROR! current instance already attached to "
+                          << symbol_name << "\n";
                 return false;
             }
 
             // request gid;
             *this = hpx::components::new_<simple_central_tuplespace>(locality);
-            bool rc = hpx::agas::register_name(hpx::launch::sync, symbol_name,
-                this->get_id());
+            bool rc = hpx::agas::register_name(
+                hpx::launch::sync, symbol_name, this->get_id());
 
-            if(rc)
+            if (rc)
             {
                 symbol_name_ = symbol_name;
             }
@@ -88,15 +88,15 @@ namespace examples
 
         bool connect(std::string const& symbol_name)
         {
-            if(symbol_name_ == symbol_name)
+            if (symbol_name_ == symbol_name)
             {
-                hpx::cerr<<"simple_central_tuplespace::connect()"
-                    <<" : ERROR! current instance already attached to "
-                    << symbol_name <<"\n";
+                hpx::cerr << "simple_central_tuplespace::connect()"
+                          << " : ERROR! current instance already attached to "
+                          << symbol_name << "\n";
                 return false;
             }
 
-            *this = hpx::agas::resolve_name(hpx::launch::sync,symbol_name);
+            *this = hpx::agas::resolve_name(hpx::launch::sync, symbol_name);
 
             return true;
         }
@@ -121,7 +121,8 @@ namespace examples
         int write(hpx::launch::sync_policy, tuple_type const& tuple)
         {
             HPX_ASSERT(this->get_id());
-            return this->base_type::write(hpx::launch::sync, this->get_id(), tuple);
+            return this->base_type::write(
+                hpx::launch::sync, this->get_id(), tuple);
         }
 
         ///////////////////////////////////////////////////////////////////////
@@ -130,8 +131,8 @@ namespace examples
         /// \note This function has fire-and-forget semantics. It will not wait
         ///       for the action to be executed. Instead, it will return
         ///       immediately after the action has has been dispatched.
-        hpx::future<tuple_type>
-            read_async(tuple_type const& tp, double const timeout)
+        hpx::future<tuple_type> read_async(
+            tuple_type const& tp, double const timeout)
         {
             HPX_ASSERT(this->get_id());
             return this->base_type::read_async(this->get_id(), tp, timeout);
@@ -145,8 +146,8 @@ namespace examples
             double const timeout)
         {
             HPX_ASSERT(this->get_id());
-            return this->base_type::read(hpx::launch::sync, this->get_id(),
-                tp, timeout);
+            return this->base_type::read(
+                hpx::launch::sync, this->get_id(), tp, timeout);
         }
         //]
 
@@ -159,12 +160,12 @@ namespace examples
         ///          get() will return immediately; otherwise, it will block
         ///          until the value is ready.
         //[simple_central_tuplespace_client_take_async
-        hpx::future<tuple_type>
-            take_async(tuple_type const& tp, double const timeout)
+        hpx::future<tuple_type> take_async(
+            tuple_type const& tp, double const timeout)
         {
             HPX_ASSERT(this->get_id());
-            return this->base_type::take(hpx::launch::async, this->get_id(),
-                tp, timeout);
+            return this->base_type::take(
+                hpx::launch::async, this->get_id(), tp, timeout);
         }
         //]
 
@@ -175,13 +176,11 @@ namespace examples
             double const timeout)
         {
             HPX_ASSERT(this->get_id());
-            return this->base_type::take(hpx::launch::sync, this->get_id(),
-                tp, timeout);
+            return this->base_type::take(
+                hpx::launch::sync, this->get_id(), tp, timeout);
         }
 
     private:
         std::string symbol_name_;
     };
-} // examples
-
-
+}    // namespace examples

--- a/examples/tuplespace/central_tuplespace/stubs/simple_central_tuplespace.hpp
+++ b/examples/tuplespace/central_tuplespace/stubs/simple_central_tuplespace.hpp
@@ -30,7 +30,7 @@ namespace examples { namespace stubs {
         ///       immediately after the action has has been dispatched.
         //[simple_central_tuplespace_stubs_write_async
         static hpx::future<int> write_async(
-            hpx::naming::id_type const& gid, tuple_type const& tuple)
+            hpx::id_type const& gid, tuple_type const& tuple)
         {
             typedef server::simple_central_tuplespace::write_action action_type;
             return hpx::async<action_type>(gid, tuple);
@@ -40,8 +40,8 @@ namespace examples { namespace stubs {
         /// put \p tuple into tuplespace.
         ///
         /// \note This function is fully synchronous.
-        static int write(hpx::launch::sync_policy,
-            hpx::naming::id_type const& gid, tuple_type const& tuple)
+        static int write(hpx::launch::sync_policy, hpx::id_type const& gid,
+            tuple_type const& tuple)
         {
             typedef server::simple_central_tuplespace::write_action action_type;
             return hpx::async<action_type>(gid, tuple).get();
@@ -54,8 +54,7 @@ namespace examples { namespace stubs {
         ///       for the action to be executed. Instead, it will return
         ///       immediately after the action has has been dispatched.
         static hpx::future<tuple_type> read_async(
-            hpx::naming::id_type const& gid, tuple_type const& tp,
-            double const timeout)
+            hpx::id_type const& gid, tuple_type const& tp, double const timeout)
         {
             typedef server::simple_central_tuplespace::read_action action_type;
             return hpx::async<action_type>(gid, tp, timeout);
@@ -66,8 +65,7 @@ namespace examples { namespace stubs {
         /// \note This function is fully synchronous.
         //[simple_central_tuplespace_stubs_read_sync
         static tuple_type read(hpx::launch::sync_policy,
-            hpx::naming::id_type const& gid, tuple_type const& tp,
-            double const timeout)
+            hpx::id_type const& gid, tuple_type const& tp, double const timeout)
         {
             typedef server::simple_central_tuplespace::read_action action_type;
             return hpx::async<action_type>(gid, tp, timeout).get();
@@ -84,8 +82,7 @@ namespace examples { namespace stubs {
         ///          until the value is ready.
         //[simple_central_tuplespace_stubs_take_async
         static hpx::future<tuple_type> take(hpx::launch::async_policy,
-            hpx::naming::id_type const& gid, tuple_type const& tp,
-            double const timeout)
+            hpx::id_type const& gid, tuple_type const& tp, double const timeout)
         {
             typedef server::simple_central_tuplespace::take_action action_type;
             return hpx::async<action_type>(gid, tp, timeout);
@@ -96,8 +93,7 @@ namespace examples { namespace stubs {
         ///
         /// \note This function is fully synchronous.
         static tuple_type take(hpx::launch::sync_policy,
-            hpx::naming::id_type const& gid, tuple_type const& tp,
-            double const timeout)
+            hpx::id_type const& gid, tuple_type const& tp, double const timeout)
         {
             // The following get yields control while the action is executed.
             return take(hpx::launch::async, gid, tp, timeout).get();

--- a/examples/tuplespace/simple_central_tuplespace_client.cpp
+++ b/examples/tuplespace/simple_central_tuplespace_client.cpp
@@ -143,7 +143,7 @@ int hpx_main()
 
         std::vector<hpx::future<void>> futures;
 
-        for (hpx::naming::id_type const& node : localities)
+        for (hpx::id_type const& node : localities)
         {
             // Asynchronously start a new task. The task is encapsulated in a
             // future, which we can query to determine if the task has

--- a/libs/core/concurrency/include/hpx/concurrency/concurrentqueue.hpp
+++ b/libs/core/concurrency/include/hpx/concurrency/concurrentqueue.hpp
@@ -422,19 +422,19 @@ namespace details
             thread_id_converter<thread_id_t>::prehash(id)));
     }
 
-    template<typename T>
-    static inline bool circular_less_than(T a, T b)
-    {
 #ifdef _MSC_VER
 #pragma warning(push)
 #pragma warning(disable: 4554)
 #endif
+    template<typename T>
+    static inline bool circular_less_than(T a, T b)
+    {
         static_assert(std::is_integral<T>::value && !std::numeric_limits<T>::is_signed, "circular_less_than is intended to be used only with unsigned integer types");
         return static_cast<T>(a - b) > static_cast<T>(static_cast<T>(1) << static_cast<T>(sizeof(T) * CHAR_BIT - 1));
+    }
 #ifdef _MSC_VER
 #pragma warning(pop)
 #endif
-    }
 
     template<typename U>
     static inline char* align_for(char* ptr)

--- a/libs/core/lcos_local/src/preprocess_future.cpp
+++ b/libs/core/lcos_local/src/preprocess_future.cpp
@@ -18,7 +18,7 @@ namespace hpx { namespace serialization { namespace detail {
     extra_archive_data_id_type
     extra_archive_data_helper<preprocess_futures>::id() noexcept
     {
-        static std::uint8_t id;
+        static std::uint8_t id = 0;
         return &id;
     }
 }}}    // namespace hpx::serialization::detail

--- a/libs/core/runtime_local/include/hpx/runtime_local/get_locality_name.hpp
+++ b/libs/core/runtime_local/include/hpx/runtime_local/get_locality_name.hpp
@@ -31,6 +31,6 @@ namespace hpx {
     ///           function is called. The name is retrieved from the underlying
     ///           networking layer and may be different for different parcelports.
     ///
-    /// \see      \a future<std::string> get_locality_name(naming::id_type const& id)
+    /// \see      \a future<std::string> get_locality_name(hpx::id_type const& id)
     HPX_CORE_EXPORT std::string get_locality_name();
 }    // namespace hpx

--- a/libs/core/serialization/src/detail/pointer.cpp
+++ b/libs/core/serialization/src/detail/pointer.cpp
@@ -24,14 +24,14 @@ namespace hpx { namespace serialization {
         extra_archive_data_id_type
         extra_archive_data_helper<input_pointer_tracker>::id() noexcept
         {
-            static std::uint8_t id;
+            static std::uint8_t id = 0;
             return &id;
         }
 
         extra_archive_data_id_type
         extra_archive_data_helper<output_pointer_tracker>::id() noexcept
         {
-            static std::uint8_t id;
+            static std::uint8_t id = 0;
             return &id;
         }
 

--- a/libs/full/actions/include/hpx/actions/apply_helper.hpp
+++ b/libs/full/actions/include/hpx/actions/apply_helper.hpp
@@ -46,7 +46,7 @@ namespace hpx { namespace applier { namespace detail {
     ///////////////////////////////////////////////////////////////////////////
     template <typename Action, typename... Ts>
     void call_async(threads::thread_init_data&& data,
-        naming::id_type const& target, naming::address::address_type lva,
+        hpx::id_type const& target, naming::address::address_type lva,
         naming::address::component_type comptype,
         threads::thread_priority priority, Ts&&... vs)
     {
@@ -87,7 +87,7 @@ namespace hpx { namespace applier { namespace detail {
 
     template <typename Action, typename Continuation, typename... Ts>
     void call_async(threads::thread_init_data&& data, Continuation&& cont,
-        naming::id_type const& target, naming::address::address_type lva,
+        hpx::id_type const& target, naming::address::address_type lva,
         naming::address::component_type comptype,
         threads::thread_priority priority, Ts&&... vs)
     {
@@ -152,7 +152,7 @@ namespace hpx { namespace applier { namespace detail {
     {
         template <typename... Ts>
         static void call(threads::thread_init_data&& data,
-            naming::id_type const& target, naming::address::address_type lva,
+            hpx::id_type const& target, naming::address::address_type lva,
             naming::address::component_type comptype,
             threads::thread_priority priority, Ts&&... vs)
         {
@@ -174,7 +174,7 @@ namespace hpx { namespace applier { namespace detail {
 
         template <typename Continuation, typename... Ts>
         static void call(threads::thread_init_data&& data, Continuation&& cont,
-            naming::id_type const& target, naming::address::address_type lva,
+            hpx::id_type const& target, naming::address::address_type lva,
             naming::address::component_type comptype,
             threads::thread_priority priority, Ts&&... vs)
         {
@@ -204,7 +204,7 @@ namespace hpx { namespace applier { namespace detail {
         // If local and to be directly executed, just call the function
         template <typename... Ts>
         HPX_FORCEINLINE static void call(threads::thread_init_data&& data,
-            naming::id_type const& target, naming::address::address_type lva,
+            hpx::id_type const& target, naming::address::address_type lva,
             naming::address::component_type comptype,
             threads::thread_priority priority, Ts&&... vs)
         {
@@ -224,7 +224,7 @@ namespace hpx { namespace applier { namespace detail {
 
         template <typename Continuation, typename... Ts>
         HPX_FORCEINLINE static void call(threads::thread_init_data&& data,
-            Continuation&& cont, naming::id_type const& target,
+            Continuation&& cont, hpx::id_type const& target,
             naming::address::address_type lva,
             naming::address::component_type comptype,
             threads::thread_priority priority, Ts&&... vs)

--- a/libs/full/actions/include/hpx/actions/apply_helper_fwd.hpp
+++ b/libs/full/actions/include/hpx/actions/apply_helper_fwd.hpp
@@ -17,13 +17,13 @@ namespace hpx { namespace applier { namespace detail {
     ///////////////////////////////////////////////////////////////////////////
     template <typename Action, typename... Ts>
     void call_async(threads::thread_init_data&& data,
-        naming::id_type const& target, naming::address::address_type lva,
+        hpx::id_type const& target, naming::address::address_type lva,
         naming::address::component_type comptype,
         threads::thread_priority priority, Ts&&... vs);
 
     template <typename Action, typename Continuation, typename... Ts>
     void call_async(threads::thread_init_data&& data, Continuation&& cont,
-        naming::id_type const& target, naming::address::address_type lva,
+        hpx::id_type const& target, naming::address::address_type lva,
         naming::address::component_type comptype,
         threads::thread_priority priority, Ts&&... vs);
 

--- a/libs/full/actions/include/hpx/actions/base_action.hpp
+++ b/libs/full/actions/include/hpx/actions/base_action.hpp
@@ -74,7 +74,7 @@ namespace hpx { namespace actions {
         /// \returns      This function returns a proper thread function usable
         ///               for a \a thread.
         virtual threads::thread_function_type get_thread_function(
-            naming::id_type&& target, naming::address_type lva,
+            hpx::id_type&& target, naming::address_type lva,
             naming::component_type comptype) = 0;
 
         /// return the id of the locality of the parent thread

--- a/libs/full/actions/include/hpx/actions/transfer_action.hpp
+++ b/libs/full/actions/include/hpx/actions/transfer_action.hpp
@@ -78,12 +78,12 @@ namespace hpx { namespace actions {
         ///       continuations.
         template <std::size_t... Is>
         threads::thread_function_type get_thread_function(
-            util::index_pack<Is...>, naming::id_type&& target,
+            util::index_pack<Is...>, hpx::id_type&& target,
             naming::address::address_type lva,
             naming::address::component_type comptype);
 
-        threads::thread_function_type get_thread_function(
-            naming::id_type&& target, naming::address::address_type lva,
+        threads::thread_function_type get_thread_function(hpx::id_type&& target,
+            naming::address::address_type lva,
             naming::address::component_type comptype) override;
 
         template <std::size_t... Is>
@@ -136,7 +136,7 @@ namespace hpx { namespace actions {
     template <typename Action>
     template <std::size_t... Is>
     threads::thread_function_type transfer_action<Action>::get_thread_function(
-        util::index_pack<Is...>, naming::id_type&& target,
+        util::index_pack<Is...>, hpx::id_type&& target,
         naming::address::address_type lva,
         naming::address::component_type comptype)
     {
@@ -147,7 +147,7 @@ namespace hpx { namespace actions {
 
     template <typename Action>
     threads::thread_function_type transfer_action<Action>::get_thread_function(
-        naming::id_type&& target, naming::address::address_type lva,
+        hpx::id_type&& target, naming::address::address_type lva,
         naming::address::component_type comptype)
     {
         return get_thread_function(
@@ -161,10 +161,11 @@ namespace hpx { namespace actions {
         naming::gid_type const& target_gid, naming::address::address_type lva,
         naming::address::component_type comptype, std::size_t /*num_thread*/)
     {
-        naming::id_type target;
+        hpx::id_type target;
         if (naming::detail::has_credits(target_gid))
         {
-            target = naming::id_type(target_gid, naming::id_type::managed);
+            target = hpx::id_type(
+                target_gid, hpx::id_type::management_type::managed);
         }
 
         threads::thread_init_data data;

--- a/libs/full/actions/tests/performance/serialization_overhead.cpp
+++ b/libs/full/actions/tests/performance/serialization_overhead.cpp
@@ -49,7 +49,7 @@ std::size_t get_archive_size(hpx::parcelset::parcel const& p,
 double benchmark_serialization(std::size_t data_size, std::size_t iterations,
     bool continuation, bool zerocopy)
 {
-    hpx::naming::id_type const here = hpx::find_here();
+    hpx::id_type const here = hpx::find_here();
     hpx::naming::address addr(hpx::get_locality(),
         hpx::components::component_invalid, (void*) &test_function);
 

--- a/libs/full/actions/tests/regressions/function_argument.cpp
+++ b/libs/full/actions/tests/regressions/function_argument.cpp
@@ -20,7 +20,7 @@ using hpx::program_options::options_description;
 using hpx::program_options::variables_map;
 
 using hpx::async;
-using hpx::naming::id_type;
+using hpx::id_type;
 
 ///////////////////////////////////////////////////////////////////////////////
 bool invoked_f = false;

--- a/libs/full/actions/tests/regressions/wait_all_hang_1946.cpp
+++ b/libs/full/actions/tests/regressions/wait_all_hang_1946.cpp
@@ -38,7 +38,7 @@ int main(int argc, char* argv[])
 int hpx_main()
 {
     // find locality info
-    std::vector<hpx::naming::id_type> locs = hpx::find_all_localities();
+    std::vector<hpx::id_type> locs = hpx::find_all_localities();
 
     // create data
     std::vector<unsigned int> vec;

--- a/libs/full/actions/tests/unit/set_thread_state.cpp
+++ b/libs/full/actions/tests/unit/set_thread_state.cpp
@@ -23,7 +23,7 @@ using hpx::program_options::variables_map;
 
 using std::chrono::milliseconds;
 
-using hpx::naming::id_type;
+using hpx::id_type;
 
 using hpx::threads::register_thread;
 

--- a/libs/full/actions/tests/unit/thread_affinity.cpp
+++ b/libs/full/actions/tests/unit/thread_affinity.cpp
@@ -99,7 +99,7 @@ void thread_affinity_foreman()
     std::size_t const os_threads = hpx::get_os_thread_count();
 
     // Find the global name of the current locality.
-    hpx::naming::id_type const here = hpx::find_here();
+    hpx::id_type const here = hpx::find_here();
 
     // Populate a set with the OS-thread numbers of all OS-threads on this
     // locality. When the hello world message has been printed on a particular
@@ -149,14 +149,13 @@ int hpx_main(hpx::program_options::variables_map& /*vm*/)
 {
     {
         // Get a list of all available localities.
-        std::vector<hpx::naming::id_type> localities =
-            hpx::find_all_localities();
+        std::vector<hpx::id_type> localities = hpx::find_all_localities();
 
         // Reserve storage space for futures, one for each locality.
         std::vector<hpx::future<void>> futures;
         futures.reserve(localities.size());
 
-        for (hpx::naming::id_type const& node : localities)
+        for (hpx::id_type const& node : localities)
         {
             // Asynchronously start a new task. The task is encapsulated in a
             // future, which we can query to determine if the task has

--- a/libs/full/actions/tests/unit/zero_copy_serialization.cpp
+++ b/libs/full/actions/tests/unit/zero_copy_serialization.cpp
@@ -175,7 +175,7 @@ void test_parcel_serialization(hpx::parcelset::parcel outp,
 template <typename Action, typename T>
 void test_normal_serialization(T& arg)
 {
-    hpx::naming::id_type const here = hpx::find_here();
+    hpx::id_type const here = hpx::find_here();
     hpx::naming::address addr(hpx::get_locality(),
         hpx::components::component_invalid, (void*) &test_function1);
 
@@ -208,7 +208,7 @@ void test_normal_serialization(T& arg)
 template <typename T1, typename T2>
 void test_normal_serialization(T1& arg1, T2& arg2)
 {
-    hpx::naming::id_type const here = hpx::find_here();
+    hpx::id_type const here = hpx::find_here();
     hpx::naming::address addr(hpx::get_locality(),
         hpx::components::component_invalid, (void*) &test_function2);
 
@@ -242,7 +242,7 @@ template <typename T1, typename T2>
 void test_normal_serialization(
     double d, T1& arg1, std::string const& s, int i, T2& arg2)
 {
-    hpx::naming::id_type const here = hpx::find_here();
+    hpx::id_type const here = hpx::find_here();
     hpx::naming::address addr(hpx::get_locality(),
         hpx::components::component_invalid, (void*) &test_function2);
 
@@ -276,7 +276,7 @@ void test_normal_serialization(
 template <typename Action, typename T>
 void test_zero_copy_serialization(T& arg)
 {
-    hpx::naming::id_type const here = hpx::find_here();
+    hpx::id_type const here = hpx::find_here();
     hpx::naming::address addr(hpx::get_locality(),
         hpx::components::component_invalid, (void*) &test_function1);
 
@@ -308,7 +308,7 @@ void test_zero_copy_serialization(T& arg)
 template <typename T1, typename T2>
 void test_zero_copy_serialization(T1& arg1, T2& arg2)
 {
-    hpx::naming::id_type const here = hpx::find_here();
+    hpx::id_type const here = hpx::find_here();
     hpx::naming::address addr(hpx::get_locality(),
         hpx::components::component_invalid, (void*) &test_function2);
 
@@ -341,7 +341,7 @@ template <typename T1, typename T2>
 void test_zero_copy_serialization(
     double d, T1& arg1, std::string const& s, int i, T2& arg2)
 {
-    hpx::naming::id_type const here = hpx::find_here();
+    hpx::id_type const here = hpx::find_here();
     hpx::naming::address addr(hpx::get_locality(),
         hpx::components::component_invalid, (void*) &test_function2);
 

--- a/libs/full/actions_base/include/hpx/actions_base/basic_action.hpp
+++ b/libs/full/actions_base/include/hpx/actions_base/basic_action.hpp
@@ -89,7 +89,7 @@ namespace hpx { namespace actions {
         {
         public:
             template <typename... Ts>
-            explicit thread_function(naming::id_type&& target,
+            explicit thread_function(hpx::id_type&& target,
                 naming::address_type lva, naming::component_type comptype,
                 Ts&&... vs)
               : target_(HPX_MOVE(target))
@@ -145,7 +145,7 @@ namespace hpx { namespace actions {
 
         private:
             // This holds the target alive, if necessary.
-            naming::id_type target_;
+            hpx::id_type target_;
             naming::address_type lva_;
             naming::component_type comptype_;
             typename Action::arguments_type args_;
@@ -157,7 +157,7 @@ namespace hpx { namespace actions {
         {
         public:
             template <typename... Ts>
-            explicit continuation_thread_function(naming::id_type&& target,
+            explicit continuation_thread_function(hpx::id_type&& target,
                 typename Action::continuation_type&& cont,
                 naming::address_type lva, naming::component_type comptype,
                 Ts&&... vs)
@@ -189,7 +189,7 @@ namespace hpx { namespace actions {
 
         private:
             // This holds the target alive, if necessary.
-            naming::id_type target_;
+            hpx::id_type target_;
             typename Action::continuation_type cont_;
             naming::address_type lva_;
             naming::component_type comptype_;
@@ -290,11 +290,12 @@ namespace hpx { namespace actions {
         // case no continuation has been supplied.
         template <typename... Ts>
         static threads::thread_function_type construct_thread_function(
-            naming::id_type target, naming::address_type lva,
+            hpx::id_type target, naming::address_type lva,
             naming::component_type comptype, Ts&&... vs)
         {
             if (target &&
-                target.get_management_type() == naming::id_type::unmanaged)
+                target.get_management_type() ==
+                    hpx::id_type::management_type::unmanaged)
             {
                 target = {};
             }
@@ -311,12 +312,13 @@ namespace hpx { namespace actions {
         // case a continuation has been supplied
         template <typename... Ts>
         static threads::thread_function_type construct_thread_function(
-            naming::id_type target, continuation_type&& cont,
+            hpx::id_type target, continuation_type&& cont,
             naming::address_type lva, naming::component_type comptype,
             Ts&&... vs)
         {
             if (target &&
-                target.get_management_type() == naming::id_type::unmanaged)
+                target.get_management_type() ==
+                    hpx::id_type::management_type::unmanaged)
             {
                 target = {};
             }
@@ -354,28 +356,28 @@ namespace hpx { namespace actions {
         ///////////////////////////////////////////////////////////////////////
         template <typename... Ts>
         HPX_FORCEINLINE result_type operator()(launch policy,
-            naming::id_type const& id, error_code& ec, Ts&&... vs) const
+            hpx::id_type const& id, error_code& ec, Ts&&... vs) const
         {
             return sync_invoke(policy, id, ec, HPX_FORWARD(Ts, vs)...);
         }
 
         template <typename... Ts>
         HPX_FORCEINLINE result_type operator()(
-            naming::id_type const& id, error_code& ec, Ts&&... vs) const
+            hpx::id_type const& id, error_code& ec, Ts&&... vs) const
         {
             return sync_invoke(launch::sync, id, ec, HPX_FORWARD(Ts, vs)...);
         }
 
         template <typename... Ts>
         HPX_FORCEINLINE result_type operator()(
-            launch policy, naming::id_type const& id, Ts&&... vs) const
+            launch policy, hpx::id_type const& id, Ts&&... vs) const
         {
             return sync_invoke(policy, id, throws, HPX_FORWARD(Ts, vs)...);
         }
 
         template <typename... Ts>
         HPX_FORCEINLINE result_type operator()(
-            naming::id_type const& id, Ts&&... vs) const
+            hpx::id_type const& id, Ts&&... vs) const
         {
             return sync_invoke(
                 launch::sync, id, throws, HPX_FORWARD(Ts, vs)...);

--- a/libs/full/actions_base/include/hpx/actions_base/plain_action.hpp
+++ b/libs/full/actions_base/include/hpx/actions_base/plain_action.hpp
@@ -42,7 +42,7 @@ namespace hpx { namespace actions {
         struct plain_function
         {
             // Only localities are valid targets for a plain action
-            static bool is_target_valid(naming::id_type const& id) noexcept
+            static bool is_target_valid(hpx::id_type const& id) noexcept
             {
                 return naming::is_locality(id);
             }

--- a/libs/full/actions_base/include/hpx/actions_base/traits/action_is_target_valid.hpp
+++ b/libs/full/actions_base/include/hpx/actions_base/traits/action_is_target_valid.hpp
@@ -20,16 +20,16 @@ namespace hpx { namespace traits {
             // by default we return true if the given id is not referring to a
             // locality
             template <typename Action>
-            static bool call(wrap_int, naming::id_type const& id) noexcept
+            static bool call(wrap_int, hpx::id_type const& id) noexcept
             {
                 // All component types requires valid id for its actions to be
                 // invoked (by default)
-                return !naming::is_locality(id);
+                return !naming::is_locality(id.get_gid());
             }
 
             // forward the call if the component implements the function
             template <typename Action>
-            static auto call(int, naming::id_type const& id) noexcept
+            static auto call(int, hpx::id_type const& id) noexcept
                 -> decltype(Action::component_type::is_target_valid(id))
             {
                 // by default we forward this to the component type
@@ -42,7 +42,7 @@ namespace hpx { namespace traits {
     template <typename Action, typename Enable = void>
     struct action_is_target_valid
     {
-        static bool call(naming::id_type const& id) noexcept
+        static bool call(hpx::id_type const& id) noexcept
         {
             return detail::is_target_valid_helper::template call<Action>(0, id);
         }

--- a/libs/full/actions_base/include/hpx/actions_base/traits/action_was_object_migrated.hpp
+++ b/libs/full/actions_base/include/hpx/actions_base/traits/action_was_object_migrated.hpp
@@ -55,7 +55,7 @@ namespace hpx { namespace traits {
         }
 
         static std::pair<bool, components::pinned_ptr> call(
-            hpx::naming::id_type const& id, naming::address_type lva)
+            hpx::id_type const& id, naming::address_type lva)
         {
             return detail::was_object_migrated_helper::template call<Action>(
                 0, id.get_gid(), lva);

--- a/libs/full/agas/include/hpx/agas/addressing_service.hpp
+++ b/libs/full/agas/include/hpx/agas/addressing_service.hpp
@@ -53,8 +53,7 @@ namespace hpx { namespace agas {
     public:
         using component_id_type = components::component_type;
 
-        using iterate_names_return_type =
-            std::map<std::string, naming::id_type>;
+        using iterate_names_return_type = std::map<std::string, hpx::id_type>;
 
         using iterate_types_function_type =
             hpx::function<void(std::string const&, components::component_type),
@@ -179,7 +178,7 @@ namespace hpx { namespace agas {
         void garbage_collect(error_code& ec = throws);
 
         std::int64_t synchronize_with_async_incref(
-            hpx::future<std::int64_t> fut, naming::id_type const& id,
+            hpx::future<std::int64_t> fut, hpx::id_type const& id,
             std::int64_t compensated_credit);
 
         server::primary_namespace& get_local_primary_namespace_service()
@@ -831,7 +830,7 @@ namespace hpx { namespace agas {
             return resolve_full_local(id, addr, ec);
         }
 
-        bool resolve_local(naming::id_type const& id, naming::address& addr,
+        bool resolve_local(hpx::id_type const& id, naming::address& addr,
             error_code& ec = throws)
         {
             return resolve_local(id.get_gid(), addr, ec);
@@ -846,7 +845,7 @@ namespace hpx { namespace agas {
         }
 
         naming::address resolve_local(
-            naming::id_type const& id, error_code& ec = throws)
+            hpx::id_type const& id, error_code& ec = throws)
         {
             naming::address addr;
             resolve_local(id.get_gid(), addr, ec);
@@ -856,21 +855,21 @@ namespace hpx { namespace agas {
         ///////////////////////////////////////////////////////////////////////////
         hpx::future<naming::address> resolve_async(naming::gid_type const& id);
 
-        hpx::future<naming::address> resolve_async(naming::id_type const& id)
+        hpx::future<naming::address> resolve_async(hpx::id_type const& id)
         {
             return resolve_async(id.get_gid());
         }
 
         ///////////////////////////////////////////////////////////////////////////
-        hpx::future<naming::id_type> get_colocation_id_async(
-            naming::id_type const& id);
+        hpx::future<hpx::id_type> get_colocation_id_async(
+            hpx::id_type const& id);
 
         ///////////////////////////////////////////////////////////////////////////
         bool resolve_full_local(naming::gid_type const& id,
             naming::address& addr, error_code& ec = throws);
 
-        bool resolve_full_local(naming::id_type const& id,
-            naming::address& addr, error_code& ec = throws)
+        bool resolve_full_local(hpx::id_type const& id, naming::address& addr,
+            error_code& ec = throws)
         {
             return resolve_full_local(id.get_gid(), addr, ec);
         }
@@ -884,7 +883,7 @@ namespace hpx { namespace agas {
         }
 
         naming::address resolve_full_local(
-            naming::id_type const& id, error_code& ec = throws)
+            hpx::id_type const& id, error_code& ec = throws)
         {
             naming::address addr;
             resolve_full_local(id.get_gid(), addr, ec);
@@ -894,8 +893,7 @@ namespace hpx { namespace agas {
         hpx::future<naming::address> resolve_full_async(
             naming::gid_type const& id);
 
-        hpx::future<naming::address> resolve_full_async(
-            naming::id_type const& id)
+        hpx::future<naming::address> resolve_full_async(hpx::id_type const& id)
         {
             return resolve_full_async(id.get_gid());
         }
@@ -903,7 +901,7 @@ namespace hpx { namespace agas {
         bool resolve_cached(naming::gid_type const& id, naming::address& addr,
             error_code& ec = throws);
 
-        bool resolve_cached(naming::id_type const& id, naming::address& addr,
+        bool resolve_cached(hpx::id_type const& id, naming::address& addr,
             error_code& ec = throws)
         {
             return resolve_cached(id.get_gid(), addr, ec);
@@ -978,7 +976,7 @@ namespace hpx { namespace agas {
         ///                   of hpx#exception.
         hpx::future<std::int64_t> incref_async(naming::gid_type const& gid,
             std::int64_t credits = 1,
-            naming::id_type const& keep_alive = naming::invalid_id);
+            hpx::id_type const& keep_alive = hpx::invalid_id);
 
         std::int64_t incref(naming::gid_type const& gid,
             std::int64_t credits = 1, error_code& ec = throws)
@@ -1052,9 +1050,9 @@ namespace hpx { namespace agas {
             error_code& ec = throws);
 
         hpx::future<bool> register_name_async(
-            std::string const& name, naming::id_type const& id);
+            std::string const& name, hpx::id_type const& id);
 
-        bool register_name(std::string const& name, naming::id_type const& id,
+        bool register_name(std::string const& name, hpx::id_type const& id,
             error_code& ec = throws);
 
         /// \brief Unregister a global name (release any existing association)
@@ -1079,10 +1077,10 @@ namespace hpx { namespace agas {
         ///                   throw but returns the result code using the
         ///                   parameter \a ec. Otherwise it throws an instance
         ///                   of hpx#exception.
-        hpx::future<naming::id_type> unregister_name_async(
+        hpx::future<hpx::id_type> unregister_name_async(
             std::string const& name);
 
-        naming::id_type unregister_name(
+        hpx::id_type unregister_name(
             std::string const& name, error_code& ec = throws);
 
         /// \brief Query for the global address associated with a given global name.
@@ -1110,10 +1108,9 @@ namespace hpx { namespace agas {
         ///                   throw but returns the result code using the
         ///                   parameter \a ec. Otherwise it throws an instance
         ///                   of hpx#exception.
-        hpx::future<naming::id_type> resolve_name_async(
-            std::string const& name);
+        hpx::future<hpx::id_type> resolve_name_async(std::string const& name);
 
-        naming::id_type resolve_name(
+        hpx::id_type resolve_name(
             std::string const& name, error_code& ec = throws);
 
         /// \brief Install a listener for a given symbol namespace event.
@@ -1176,9 +1173,9 @@ namespace hpx { namespace agas {
         /// start/stop migration of an object
         ///
         /// \returns Current locality and address of the object to migrate
-        hpx::future<std::pair<naming::id_type, naming::address>>
-        begin_migration(naming::id_type const& id);
-        bool end_migration(naming::id_type const& id);
+        hpx::future<std::pair<hpx::id_type, naming::address>> begin_migration(
+            hpx::id_type const& id);
+        bool end_migration(hpx::id_type const& id);
 
         /// Maintain list of migrated objects
         std::pair<bool, components::pinned_ptr> was_object_migrated(

--- a/libs/full/agas/src/addressing_service.cpp
+++ b/libs/full/agas/src/addressing_service.cpp
@@ -387,7 +387,7 @@ namespace hpx { namespace agas {
             std::string key("/0/locality#console");
 
             hpx::id_type resolved_prefix = resolve_name(key);
-            if (resolved_prefix != naming::invalid_id)
+            if (resolved_prefix != hpx::invalid_id)
             {
                 std::uint32_t console =
                     naming::get_locality_id_from_id(resolved_prefix);
@@ -1032,15 +1032,15 @@ namespace hpx { namespace agas {
         return resolve_full_async(gid);
     }
 
-    hpx::future<naming::id_type> addressing_service::get_colocation_id_async(
-        naming::id_type const& id)
+    hpx::future<hpx::id_type> addressing_service::get_colocation_id_async(
+        hpx::id_type const& id)
     {
         if (!id)
         {
             HPX_THROW_EXCEPTION(bad_parameter,
                 "addressing_service::get_colocation_id_async",
                 "invalid reference id");
-            return make_ready_future(naming::invalid_id);
+            return make_ready_future(hpx::invalid_id);
         }
 
         return primary_ns_.colocate(id.get_gid());
@@ -1250,8 +1250,7 @@ namespace hpx { namespace agas {
     // if there was a pending decref request at the point when the incref was sent.
     // The pending decref was subtracted from the amount of credits to incref.
     std::int64_t addressing_service::synchronize_with_async_incref(
-        hpx::future<std::int64_t> fut, naming::id_type const& /* id */
-        ,
+        hpx::future<std::int64_t> fut, hpx::id_type const&,
         std::int64_t compensated_credit)
     {
         return fut.get() + compensated_credit;
@@ -1259,7 +1258,7 @@ namespace hpx { namespace agas {
 
     hpx::future<std::int64_t> addressing_service::incref_async(
         naming::gid_type const& id, std::int64_t credit,
-        naming::id_type const& keep_alive)
+        hpx::id_type const& keep_alive)
     {    // {{{ incref implementation
         naming::gid_type raw(naming::detail::get_stripped_gid(id));
 
@@ -1267,7 +1266,7 @@ namespace hpx { namespace agas {
         {
             // reschedule this call as an HPX thread
             hpx::future<std::int64_t> (addressing_service::*incref_async_ptr)(
-                naming::gid_type const&, std::int64_t, naming::id_type const&) =
+                naming::gid_type const&, std::int64_t, hpx::id_type const&) =
                 &addressing_service::incref_async;
 
             return async(incref_async_ptr, this, raw, credit, keep_alive);
@@ -1281,7 +1280,7 @@ namespace hpx { namespace agas {
             return hpx::future<std::int64_t>();
         }
 
-        HPX_ASSERT(keep_alive != naming::invalid_id);
+        HPX_ASSERT(keep_alive != hpx::invalid_id);
 
         using mapping = refcnt_requests_type::value_type;
 
@@ -1430,7 +1429,7 @@ namespace hpx { namespace agas {
     }    // }}}
 
     ///////////////////////////////////////////////////////////////////////////
-    static bool correct_credit_on_failure(future<bool> f, naming::id_type id,
+    static bool correct_credit_on_failure(future<bool> f, hpx::id_type id,
         std::int64_t mutable_gid_credit, std::int64_t new_gid_credit)
     {
         // Return the credit to the GID if the operation failed
@@ -1457,11 +1456,10 @@ namespace hpx { namespace agas {
     }    // }}}
 
     bool addressing_service::register_name(
-        std::string const& name, naming::id_type const& id, error_code& ec)
+        std::string const& name, hpx::id_type const& id, error_code& ec)
     {
         // We need to modify the reference count.
-        naming::gid_type& mutable_gid =
-            const_cast<naming::id_type&>(id).get_gid();
+        naming::gid_type& mutable_gid = const_cast<hpx::id_type&>(id).get_gid();
         naming::gid_type new_gid =
             naming::detail::split_gid_if_needed(mutable_gid).get();
         std::int64_t new_credit = naming::detail::get_credit_from_gid(new_gid);
@@ -1482,11 +1480,10 @@ namespace hpx { namespace agas {
     }
 
     hpx::future<bool> addressing_service::register_name_async(
-        std::string const& name, naming::id_type const& id)
+        std::string const& name, hpx::id_type const& id)
     {    // {{{
         // We need to modify the reference count.
-        naming::gid_type& mutable_gid =
-            const_cast<naming::id_type&>(id).get_gid();
+        naming::gid_type& mutable_gid = const_cast<hpx::id_type&>(id).get_gid();
         naming::gid_type new_gid =
             naming::detail::split_gid_if_needed(mutable_gid).get();
 
@@ -1504,7 +1501,7 @@ namespace hpx { namespace agas {
     }    // }}}
 
     ///////////////////////////////////////////////////////////////////////////
-    naming::id_type addressing_service::unregister_name(
+    hpx::id_type addressing_service::unregister_name(
         std::string const& name, error_code& ec)
     {    // {{{
         try
@@ -1514,18 +1511,18 @@ namespace hpx { namespace agas {
         catch (hpx::exception const& e)
         {
             HPX_RETHROWS_IF(ec, e, "addressing_service::unregister_name");
-            return naming::invalid_id;
+            return hpx::invalid_id;
         }
     }    // }}}
 
-    hpx::future<naming::id_type> addressing_service::unregister_name_async(
+    hpx::future<hpx::id_type> addressing_service::unregister_name_async(
         std::string const& name)
     {    // {{{
         return symbol_ns_.unbind_async(name);
     }    // }}}
 
     ///////////////////////////////////////////////////////////////////////////
-    naming::id_type addressing_service::resolve_name(
+    hpx::id_type addressing_service::resolve_name(
         std::string const& name, error_code& ec)
     {    // {{{
         try
@@ -1535,11 +1532,11 @@ namespace hpx { namespace agas {
         catch (hpx::exception const& e)
         {
             HPX_RETHROWS_IF(ec, e, "addressing_service::resolve_name");
-            return naming::invalid_id;
+            return hpx::invalid_id;
         }
     }    // }}}
 
-    hpx::future<naming::id_type> addressing_service::resolve_name_async(
+    hpx::future<hpx::id_type> addressing_service::resolve_name_async(
         std::string const& name)
     {    // {{{
         return symbol_ns_.resolve_async(name);
@@ -1564,7 +1561,7 @@ namespace hpx { namespace agas {
     future<hpx::id_type> addressing_service::on_symbol_namespace_event(
         std::string const& name, bool call_for_past_events)
     {
-        hpx::distributed::promise<naming::id_type, naming::gid_type> p;
+        hpx::distributed::promise<hpx::id_type, naming::gid_type> p;
         auto result_f = p.get_future();
 
         hpx::future<bool> f =
@@ -2005,7 +2002,7 @@ namespace hpx { namespace agas {
 #endif
 
             // collect all requests for each locality
-            using requests_type = std::map<naming::id_type,
+            using requests_type = std::map<hpx::id_type,
                 std::vector<hpx::tuple<std::int64_t, naming::gid_type,
                     naming::gid_type>>>;
             requests_type requests;
@@ -2016,9 +2013,9 @@ namespace hpx { namespace agas {
 
                 naming::gid_type raw(e.first);
 
-                naming::id_type target(
+                hpx::id_type target(
                     primary_namespace::get_service_instance(raw),
-                    naming::id_type::unmanaged);
+                    hpx::id_type::management_type::unmanaged);
 
                 requests[target].push_back(hpx::make_tuple(e.second, raw, raw));
             }
@@ -2078,7 +2075,7 @@ namespace hpx { namespace agas {
 #endif
 
         // collect all requests for each locality
-        using requests_type = std::map<naming::id_type,
+        using requests_type = std::map<hpx::id_type,
             std::vector<
                 hpx::tuple<std::int64_t, naming::gid_type, naming::gid_type>>>;
         requests_type requests;
@@ -2090,8 +2087,8 @@ namespace hpx { namespace agas {
 
             naming::gid_type raw(e.first);
 
-            naming::id_type target(primary_namespace::get_service_instance(raw),
-                naming::id_type::unmanaged);
+            hpx::id_type target(primary_namespace::get_service_instance(raw),
+                hpx::id_type::management_type::unmanaged);
 
             requests[target].push_back(hpx::make_tuple(e.second, raw, raw));
         }
@@ -2228,8 +2225,8 @@ namespace hpx { namespace agas {
         }
     }
 
-    hpx::future<std::pair<naming::id_type, naming::address>>
-    addressing_service::begin_migration(naming::id_type const& id)
+    hpx::future<std::pair<hpx::id_type, naming::address>>
+    addressing_service::begin_migration(hpx::id_type const& id)
     {
         if (!id)
         {
@@ -2244,7 +2241,7 @@ namespace hpx { namespace agas {
         return primary_ns_.begin_migration(gid);
     }
 
-    bool addressing_service::end_migration(naming::id_type const& id)
+    bool addressing_service::end_migration(hpx::id_type const& id)
     {
         if (!id)
         {

--- a/libs/full/agas/src/detail/interface.cpp
+++ b/libs/full/agas/src/detail/interface.cpp
@@ -39,13 +39,13 @@ namespace hpx { namespace agas { namespace detail { namespace impl {
     }
 
     future<bool> register_name_async(
-        std::string const& name, naming::id_type const& id)
+        std::string const& name, hpx::id_type const& id)
     {
         return naming::get_agas_client().register_name_async(name, id);
     }
 
     bool register_name_id(
-        std::string const& name, naming::id_type const& id, error_code& ec)
+        std::string const& name, hpx::id_type const& id, error_code& ec)
     {
         if (&ec == &throws)
         {
@@ -55,27 +55,27 @@ namespace hpx { namespace agas { namespace detail { namespace impl {
     }
 
     ///////////////////////////////////////////////////////////////////////////
-    naming::id_type unregister_name(std::string const& name, error_code&)
+    hpx::id_type unregister_name(std::string const& name, error_code&)
     {
         if (!hpx::is_stopped())
         {
             return naming::get_agas_client().unregister_name(name);
         }
-        return naming::invalid_id;
+        return hpx::invalid_id;
     }
 
-    future<naming::id_type> unregister_name_async(std::string const& name)
+    future<hpx::id_type> unregister_name_async(std::string const& name)
     {
         return naming::get_agas_client().unregister_name_async(name);
     }
 
     ///////////////////////////////////////////////////////////////////////////
-    future<naming::id_type> resolve_name_async(std::string const& name)
+    future<hpx::id_type> resolve_name_async(std::string const& name)
     {
         return naming::get_agas_client().resolve_name_async(name);
     }
 
-    naming::id_type resolve_name(std::string const& name, error_code& ec)
+    hpx::id_type resolve_name(std::string const& name, error_code& ec)
     {
         return naming::get_agas_client().resolve_name(name, ec);
     }
@@ -145,12 +145,12 @@ namespace hpx { namespace agas { namespace detail { namespace impl {
     }
 
     ///////////////////////////////////////////////////////////////////////////
-    hpx::future<naming::address> resolve_async(naming::id_type const& id)
+    hpx::future<naming::address> resolve_async(hpx::id_type const& id)
     {
         return naming::get_agas_client().resolve_async(id);
     }
 
-    naming::address resolve(naming::id_type const& id, error_code& ec)
+    naming::address resolve(hpx::id_type const& id, error_code& ec)
     {
         return naming::get_agas_client().resolve_async(id).get(ec);
     }
@@ -286,22 +286,22 @@ namespace hpx { namespace agas { namespace detail { namespace impl {
     }
 
     /// \brief Return an id_type referring to the console locality.
-    naming::id_type get_console_locality(error_code& ec)
+    hpx::id_type get_console_locality(error_code& ec)
     {
         runtime* rt = get_runtime_ptr();
         if (rt == nullptr || rt->get_state() == state::invalid)
         {
-            return naming::invalid_id;
+            return hpx::invalid_id;
         }
 
         naming::gid_type console;
         naming::get_agas_client().get_console_locality(console, ec);
         if (ec)
         {
-            return naming::invalid_id;
+            return hpx::invalid_id;
         }
 
-        return naming::id_type(console, naming::id_type::unmanaged);
+        return hpx::id_type(console, hpx::id_type::management_type::unmanaged);
     }
 
     std::uint32_t get_locality_id(error_code& ec)
@@ -386,7 +386,7 @@ namespace hpx { namespace agas { namespace detail { namespace impl {
 
     ///////////////////////////////////////////////////////////////////////////
     hpx::future<std::int64_t> incref_async(naming::gid_type const& gid,
-        std::int64_t credits, naming::id_type const& keep_alive_)
+        std::int64_t credits, hpx::id_type const& keep_alive_)
     {
         HPX_ASSERT(!naming::detail::is_locked(gid));
 
@@ -395,12 +395,13 @@ namespace hpx { namespace agas { namespace detail { namespace impl {
         if (keep_alive_)
             return resolver.incref_async(gid, credits, keep_alive_);
 
-        naming::id_type keep_alive = naming::id_type(gid, id_type::unmanaged);
+        hpx::id_type keep_alive =
+            hpx::id_type(gid, hpx::id_type::management_type::unmanaged);
         return resolver.incref_async(gid, credits, keep_alive);
     }
 
     std::int64_t incref(naming::gid_type const& gid, std::int64_t credits,
-        naming::id_type const& keep_alive_, error_code&)
+        hpx::id_type const& keep_alive_, error_code&)
     {
         HPX_ASSERT(!naming::detail::is_locked(gid));
 
@@ -410,18 +411,18 @@ namespace hpx { namespace agas { namespace detail { namespace impl {
         {
             return resolver.incref_async(gid, credits, keep_alive_).get();
         }
-        naming::id_type keep_alive = naming::id_type(gid, id_type::unmanaged);
+        hpx::id_type keep_alive =
+            hpx::id_type(gid, hpx::id_type::management_type::unmanaged);
         return resolver.incref_async(gid, credits, keep_alive).get();
     }
 
     ///////////////////////////////////////////////////////////////////////////
-    hpx::future<naming::id_type> get_colocation_id_async(
-        naming::id_type const& id)
+    hpx::future<hpx::id_type> get_colocation_id_async(hpx::id_type const& id)
     {
         return naming::get_agas_client().get_colocation_id_async(id);
     }
 
-    naming::id_type get_colocation_id(naming::id_type const& id, error_code& ec)
+    hpx::id_type get_colocation_id(hpx::id_type const& id, error_code& ec)
     {
         return get_colocation_id_async(id).get(ec);
     }
@@ -435,13 +436,13 @@ namespace hpx { namespace agas { namespace detail { namespace impl {
     }
 
     ///////////////////////////////////////////////////////////////////////////
-    hpx::future<std::pair<naming::id_type, naming::address>> begin_migration(
-        naming::id_type const& id)
+    hpx::future<std::pair<hpx::id_type, naming::address>> begin_migration(
+        hpx::id_type const& id)
     {
         return naming::get_agas_client().begin_migration(id);
     }
 
-    bool end_migration(naming::id_type const& id)
+    bool end_migration(hpx::id_type const& id)
     {
         return naming::get_agas_client().end_migration(id);
     }

--- a/libs/full/agas/src/route.cpp
+++ b/libs/full/agas/src/route.cpp
@@ -91,7 +91,7 @@ namespace hpx::agas::server {
             addr.address_ = g.lva();
         }
 
-        naming::id_type source = p.source_id();
+        hpx::id_type source = p.source_id();
 
         // either send the parcel on its way or execute actions locally
         if (naming::get_locality_id_from_gid(addr.locality_) ==

--- a/libs/full/agas/tests/regressions/duplicate_id_registration_1596.cpp
+++ b/libs/full/agas/tests/regressions/duplicate_id_registration_1596.cpp
@@ -75,13 +75,13 @@ namespace tests { namespace client {
             server::ViewRegistrationListener>
             base_type;
 
-        ViewRegistrationListener(hpx::future<hpx::naming::id_type> gid)
+        ViewRegistrationListener(hpx::future<hpx::id_type> gid)
           : base_type(move(gid))
         {
             cout << "constructed listener client by future" << endl;
         }
 
-        ViewRegistrationListener(hpx::naming::id_type gid)
+        ViewRegistrationListener(hpx::id_type gid)
           : base_type(gid)
         {
             cout << "constructed listener client by gid" << endl;

--- a/libs/full/agas/tests/regressions/pass_by_value_id_type_action.cpp
+++ b/libs/full/agas/tests/regressions/pass_by_value_id_type_action.cpp
@@ -15,10 +15,10 @@
 #include <vector>
 
 ///////////////////////////////////////////////////////////////////////////////
-void test(hpx::naming::id_type) {}
+void test(hpx::id_type) {}
 HPX_PLAIN_ACTION(test, test_action)
 
-hpx::naming::id_type test_return()
+hpx::id_type test_return()
 {
     return hpx::find_here();
 }
@@ -27,12 +27,12 @@ HPX_PLAIN_ACTION(test_return, test_return_action)
 ///////////////////////////////////////////////////////////////////////////////
 int hpx_main(hpx::program_options::variables_map&)
 {
-    std::vector<hpx::naming::id_type> localities = hpx::find_all_localities();
+    std::vector<hpx::id_type> localities = hpx::find_all_localities();
 
-    for (hpx::naming::id_type const& id : localities)
+    for (hpx::id_type const& id : localities)
     {
         {
-            hpx::naming::id_type a = id;
+            hpx::id_type a = id;
 
             test_action act;
             hpx::future<void> f = hpx::async(act, id, a);
@@ -42,7 +42,7 @@ int hpx_main(hpx::program_options::variables_map&)
         }
 
         {
-            hpx::naming::id_type a = id;
+            hpx::id_type a = id;
 
             test_action act;
             act(id, a);
@@ -52,7 +52,7 @@ int hpx_main(hpx::program_options::variables_map&)
 
         {
             test_return_action act;
-            hpx::future<hpx::naming::id_type> f = hpx::async(act, id);
+            hpx::future<hpx::id_type> f = hpx::async(act, id);
 
             HPX_TEST_EQ(id, f.get());
         }

--- a/libs/full/agas/tests/regressions/send_gid_keep_component_1624.cpp
+++ b/libs/full/agas/tests/regressions/send_gid_keep_component_1624.cpp
@@ -19,7 +19,7 @@ namespace server {
     struct view_registry
       : hpx::components::managed_component_base<view_registry>
     {
-        int register_view(const hpx::naming::id_type& gid)
+        int register_view(const hpx::id_type& gid)
         {
             hpx::util::format_to(std::cout, "register view at {1} by {2}",
                 this->get_unmanaged_id(), gid)
@@ -33,7 +33,7 @@ namespace server {
         HPX_DEFINE_COMPONENT_ACTION(view_registry, register_view)
         HPX_DEFINE_COMPONENT_ACTION(view_registry, update)
 
-        std::vector<hpx::naming::id_type> registered_regions_;
+        std::vector<hpx::id_type> registered_regions_;
     };
 }    // namespace server
 
@@ -45,12 +45,12 @@ HPX_REGISTER_ACTION_DECLARATION(server::view_registry::update_action,
 namespace client {
     struct view_registry
     {
-        view_registry(hpx::naming::id_type gid)
+        view_registry(hpx::id_type gid)
           : gid_(gid)
         {
         }
 
-        void register_view(const hpx::naming::id_type& viewerId)
+        void register_view(const hpx::id_type& viewerId)
         {
             hpx::async<server::view_registry::register_view_action>(
                 gid_, viewerId)
@@ -62,7 +62,7 @@ namespace client {
             hpx::async<server::view_registry::update_action>(gid_).get();
         }
 
-        hpx::naming::id_type gid_;
+        hpx::id_type gid_;
     };
 }    // namespace client
 
@@ -88,7 +88,7 @@ namespace server {
 
         // This function does a broadcast to all writers to register a certain
         // region
-        void register_region(const std::vector<hpx::naming::id_type>& writers)
+        void register_region(const std::vector<hpx::id_type>& writers)
         {
             for (const auto& id : writers)
             {
@@ -121,12 +121,12 @@ HPX_REGISTER_ACTION_DECLARATION(
 namespace client {
     struct viewer
     {
-        viewer(const hpx::naming::id_type& gid)
+        viewer(const hpx::id_type& gid)
           : gid_(gid)
         {
         }
 
-        void register_region(const std::vector<hpx::naming::id_type>& writers)
+        void register_region(const std::vector<hpx::id_type>& writers)
         {
             hpx::async<server::viewer::register_region_action>(gid_, writers)
                 .get();
@@ -137,7 +137,7 @@ namespace client {
             hpx::async<server::viewer::update_action>(gid_);
         }
 
-        hpx::naming::id_type gid_;
+        hpx::id_type gid_;
     };
 }    // namespace client
 

--- a/libs/full/agas_base/include/hpx/agas_base/component_namespace.hpp
+++ b/libs/full/agas_base/include/hpx/agas_base/component_namespace.hpp
@@ -26,7 +26,7 @@ namespace hpx { namespace agas {
 
         virtual naming::address::address_type ptr() const = 0;
         virtual naming::address addr() const = 0;
-        virtual naming::id_type gid() const = 0;
+        virtual hpx::id_type gid() const = 0;
 
         virtual components::component_type bind_prefix(
             std::string const& key, std::uint32_t prefix) = 0;

--- a/libs/full/agas_base/include/hpx/agas_base/detail/bootstrap_component_namespace.hpp
+++ b/libs/full/agas_base/include/hpx/agas_base/detail/bootstrap_component_namespace.hpp
@@ -31,7 +31,7 @@ namespace hpx { namespace agas { namespace detail {
             return const_cast<server::component_namespace*>(&server_);
         }
         naming::address addr() const;
-        naming::id_type gid() const;
+        hpx::id_type gid() const;
 
         components::component_type bind_prefix(
             std::string const& key, std::uint32_t prefix);

--- a/libs/full/agas_base/include/hpx/agas_base/detail/bootstrap_locality_namespace.hpp
+++ b/libs/full/agas_base/include/hpx/agas_base/detail/bootstrap_locality_namespace.hpp
@@ -34,7 +34,7 @@ namespace hpx { namespace agas { namespace detail {
             return const_cast<server::locality_namespace*>(&server_);
         }
         naming::address addr() const override;
-        naming::id_type gid() const override;
+        hpx::id_type gid() const override;
 
         std::uint32_t allocate(parcelset::endpoints_type const& endpoints,
             std::uint64_t count, std::uint32_t num_threads,

--- a/libs/full/agas_base/include/hpx/agas_base/detail/hosted_component_namespace.hpp
+++ b/libs/full/agas_base/include/hpx/agas_base/detail/hosted_component_namespace.hpp
@@ -34,7 +34,7 @@ namespace hpx { namespace agas { namespace detail {
         {
             return addr_;
         }
-        naming::id_type gid() const
+        hpx::id_type gid() const
         {
             return gid_;
         }
@@ -56,7 +56,7 @@ namespace hpx { namespace agas { namespace detail {
             components::component_type type);
 
     private:
-        naming::id_type gid_;
+        hpx::id_type gid_;
         naming::address addr_;
     };
 

--- a/libs/full/agas_base/include/hpx/agas_base/detail/hosted_locality_namespace.hpp
+++ b/libs/full/agas_base/include/hpx/agas_base/detail/hosted_locality_namespace.hpp
@@ -39,7 +39,7 @@ namespace hpx { namespace agas { namespace detail {
         {
             return addr_;
         }
-        naming::id_type gid() const override
+        hpx::id_type gid() const override
         {
             return gid_;
         }
@@ -66,7 +66,7 @@ namespace hpx { namespace agas { namespace detail {
         hpx::future<std::uint32_t> get_num_overall_threads_async() override;
 
     private:
-        naming::id_type gid_;
+        hpx::id_type gid_;
         naming::address addr_;
     };
 }}}    // namespace hpx::agas::detail

--- a/libs/full/agas_base/include/hpx/agas_base/locality_namespace.hpp
+++ b/libs/full/agas_base/include/hpx/agas_base/locality_namespace.hpp
@@ -27,7 +27,7 @@ namespace hpx { namespace agas {
 
         virtual naming::address::address_type ptr() const = 0;
         virtual naming::address addr() const = 0;
-        virtual naming::id_type gid() const = 0;
+        virtual hpx::id_type gid() const = 0;
 
         virtual std::uint32_t allocate(
             parcelset::endpoints_type const& endpoints, std::uint64_t count,

--- a/libs/full/agas_base/include/hpx/agas_base/primary_namespace.hpp
+++ b/libs/full/agas_base/include/hpx/agas_base/primary_namespace.hpp
@@ -37,15 +37,14 @@ namespace hpx { namespace agas {
         static naming::gid_type get_service_instance(
             naming::gid_type const& dest, error_code& ec = throws);
 
-        static naming::gid_type get_service_instance(
-            naming::id_type const& dest)
+        static naming::gid_type get_service_instance(hpx::id_type const& dest)
         {
             return get_service_instance(dest.get_gid());
         }
 
         static bool is_service_instance(naming::gid_type const& gid);
 
-        static bool is_service_instance(naming::id_type const& id)
+        static bool is_service_instance(hpx::id_type const& id)
         {
             return is_service_instance(id.get_gid());
         }
@@ -55,10 +54,10 @@ namespace hpx { namespace agas {
 
         naming::address::address_type ptr() const;
         naming::address addr() const;
-        naming::id_type gid() const;
+        hpx::id_type gid() const;
 
-        hpx::future<std::pair<naming::id_type, naming::address>>
-        begin_migration(naming::gid_type const& id);
+        hpx::future<std::pair<hpx::id_type, naming::address>> begin_migration(
+            naming::gid_type const& id);
         bool end_migration(naming::gid_type const& id);
 
         bool bind_gid(gva const& g, naming::gid_type const& id,

--- a/libs/full/agas_base/include/hpx/agas_base/server/component_namespace.hpp
+++ b/libs/full/agas_base/include/hpx/agas_base/server/component_namespace.hpp
@@ -33,7 +33,7 @@
 namespace hpx { namespace agas {
 
     HPX_EXPORT naming::gid_type bootstrap_component_namespace_gid();
-    HPX_EXPORT naming::id_type bootstrap_component_namespace_id();
+    HPX_EXPORT hpx::id_type bootstrap_component_namespace_id();
 }}    // namespace hpx::agas
 
 namespace hpx { namespace agas { namespace server {

--- a/libs/full/agas_base/include/hpx/agas_base/server/locality_namespace.hpp
+++ b/libs/full/agas_base/include/hpx/agas_base/server/locality_namespace.hpp
@@ -31,7 +31,7 @@
 namespace hpx { namespace agas {
 
     HPX_EXPORT naming::gid_type bootstrap_locality_namespace_gid();
-    HPX_EXPORT naming::id_type bootstrap_locality_namespace_id();
+    HPX_EXPORT hpx::id_type bootstrap_locality_namespace_id();
 }}    // namespace hpx::agas
 
 namespace hpx { namespace agas { namespace server {

--- a/libs/full/agas_base/include/hpx/agas_base/server/primary_namespace.hpp
+++ b/libs/full/agas_base/include/hpx/agas_base/server/primary_namespace.hpp
@@ -40,7 +40,7 @@
 namespace hpx { namespace agas {
 
     HPX_EXPORT naming::gid_type bootstrap_primary_namespace_gid();
-    HPX_EXPORT naming::id_type bootstrap_primary_namespace_id();
+    HPX_EXPORT hpx::id_type bootstrap_primary_namespace_id();
 }}    // namespace hpx::agas
 
 /// \brief AGAS's primary namespace maps 128-bit global identifiers (GIDs) to
@@ -270,13 +270,13 @@ namespace hpx::agas::server {
             naming::gid_type const& locality);
 
         // API
-        std::pair<naming::id_type, naming::address> begin_migration(
+        std::pair<hpx::id_type, naming::address> begin_migration(
             naming::gid_type id);
         bool end_migration(naming::gid_type const& id);
 
         resolved_type resolve_gid(naming::gid_type const& id);
 
-        naming::id_type colocate(naming::gid_type const& id);
+        hpx::id_type colocate(naming::gid_type const& id);
 
         naming::address unbind_gid(std::uint64_t count, naming::gid_type id);
 
@@ -424,8 +424,7 @@ HPX_REGISTER_BASE_LCO_WITH_VALUE_DECLARATION(
 typedef hpx::tuple<hpx::naming::gid_type, hpx::agas::gva, hpx::naming::gid_type>
     gva_tuple_type;
 HPX_REGISTER_BASE_LCO_WITH_VALUE_DECLARATION(gva_tuple_type, gva_tuple)
-typedef std::pair<hpx::naming::id_type, hpx::naming::address>
-    std_pair_address_id_type;
+typedef std::pair<hpx::id_type, hpx::naming::address> std_pair_address_id_type;
 HPX_REGISTER_BASE_LCO_WITH_VALUE_DECLARATION(
     std_pair_address_id_type, std_pair_address_id_type)
 typedef std::pair<hpx::naming::gid_type, hpx::naming::gid_type>

--- a/libs/full/agas_base/include/hpx/agas_base/server/symbol_namespace.hpp
+++ b/libs/full/agas_base/include/hpx/agas_base/server/symbol_namespace.hpp
@@ -34,7 +34,7 @@
 namespace hpx { namespace agas {
 
     HPX_EXPORT naming::gid_type bootstrap_symbol_namespace_gid();
-    HPX_EXPORT naming::id_type bootstrap_symbol_namespace_id();
+    HPX_EXPORT hpx::id_type bootstrap_symbol_namespace_id();
 }}    // namespace hpx::agas
 
 namespace hpx { namespace agas { namespace server {

--- a/libs/full/agas_base/include/hpx/agas_base/symbol_namespace.hpp
+++ b/libs/full/agas_base/include/hpx/agas_base/symbol_namespace.hpp
@@ -30,8 +30,7 @@ namespace hpx { namespace agas {
     struct symbol_namespace
     {
         using server_type = server::symbol_namespace;
-        using iterate_names_return_type =
-            std::map<std::string, naming::id_type>;
+        using iterate_names_return_type = std::map<std::string, hpx::id_type>;
 
         static naming::gid_type get_service_instance(
             std::uint32_t service_locality_id);
@@ -39,37 +38,35 @@ namespace hpx { namespace agas {
         static naming::gid_type get_service_instance(
             naming::gid_type const& dest, error_code& ec = throws);
 
-        static naming::gid_type get_service_instance(
-            naming::id_type const& dest)
+        static naming::gid_type get_service_instance(hpx::id_type const& dest)
         {
             return get_service_instance(dest.get_gid());
         }
 
         static bool is_service_instance(naming::gid_type const& gid);
 
-        static bool is_service_instance(naming::id_type const& id)
+        static bool is_service_instance(hpx::id_type const& id)
         {
             return is_service_instance(id.get_gid());
         }
 
-        static naming::id_type symbol_namespace_locality(
-            std::string const& key);
+        static hpx::id_type symbol_namespace_locality(std::string const& key);
 
         symbol_namespace();
         ~symbol_namespace() = default;
 
         naming::address_type ptr() const;
         naming::address addr() const;
-        naming::id_type gid() const;
+        hpx::id_type gid() const;
 
         hpx::future<bool> bind_async(std::string key, naming::gid_type gid);
         bool bind(std::string key, naming::gid_type gid);
 
-        hpx::future<naming::id_type> resolve_async(std::string key) const;
-        naming::id_type resolve(std::string key) const;
+        hpx::future<hpx::id_type> resolve_async(std::string key) const;
+        hpx::id_type resolve(std::string key) const;
 
-        hpx::future<naming::id_type> unbind_async(std::string key);
-        naming::id_type unbind(std::string key);
+        hpx::future<hpx::id_type> unbind_async(std::string key);
+        hpx::id_type unbind(std::string key);
 
         hpx::future<bool> on_event(std::string const& name,
             bool call_for_past_events, hpx::id_type lco);

--- a/libs/full/agas_base/src/detail/bootstrap_component_namespace.cpp
+++ b/libs/full/agas_base/src/detail/bootstrap_component_namespace.cpp
@@ -20,11 +20,11 @@ namespace hpx { namespace agas { namespace detail {
             components::component_agas_component_namespace, this->ptr());
     }
 
-    naming::id_type bootstrap_component_namespace::gid() const
+    hpx::id_type bootstrap_component_namespace::gid() const
     {
-        return naming::id_type(
+        return hpx::id_type(
             naming::gid_type(agas::component_ns_msb, agas::component_ns_lsb),
-            naming::id_type::unmanaged);
+            hpx::id_type::management_type::unmanaged);
     }
 
     components::component_type bootstrap_component_namespace::bind_prefix(

--- a/libs/full/agas_base/src/detail/bootstrap_locality_namespace.cpp
+++ b/libs/full/agas_base/src/detail/bootstrap_locality_namespace.cpp
@@ -34,11 +34,11 @@ namespace hpx { namespace agas { namespace detail {
             components::component_agas_locality_namespace, this->ptr());
     }
 
-    naming::id_type bootstrap_locality_namespace::gid() const
+    hpx::id_type bootstrap_locality_namespace::gid() const
     {
-        return naming::id_type(
+        return hpx::id_type(
             naming::gid_type(agas::locality_ns_msb, agas::locality_ns_lsb),
-            naming::id_type::unmanaged);
+            hpx::id_type::management_type::unmanaged);
     }
 
     std::uint32_t bootstrap_locality_namespace::allocate(

--- a/libs/full/agas_base/src/detail/hosted_component_namespace.cpp
+++ b/libs/full/agas_base/src/detail/hosted_component_namespace.cpp
@@ -22,7 +22,7 @@ namespace hpx { namespace agas { namespace detail {
 
     hosted_component_namespace::hosted_component_namespace(naming::address addr)
       : gid_(naming::gid_type(agas::component_ns_msb, agas::component_ns_lsb),
-            naming::id_type::unmanaged)
+            hpx::id_type::management_type::unmanaged)
       , addr_(addr)
     {
     }

--- a/libs/full/agas_base/src/detail/hosted_locality_namespace.cpp
+++ b/libs/full/agas_base/src/detail/hosted_locality_namespace.cpp
@@ -27,7 +27,7 @@ namespace hpx { namespace agas { namespace detail {
 
     hosted_locality_namespace::hosted_locality_namespace(naming::address addr)
       : gid_(naming::gid_type(agas::locality_ns_msb, agas::locality_ns_lsb),
-            naming::id_type::unmanaged)
+            hpx::id_type::management_type::unmanaged)
       , addr_(addr)
     {
     }

--- a/libs/full/agas_base/src/primary_namespace.cpp
+++ b/libs/full/agas_base/src/primary_namespace.cpp
@@ -144,18 +144,18 @@ namespace hpx { namespace agas {
             hpx::components::component_agas_primary_namespace, this->ptr());
     }
 
-    naming::id_type primary_namespace::gid() const
+    hpx::id_type primary_namespace::gid() const
     {
-        return naming::id_type(get_service_instance(agas::get_locality()),
-            naming::id_type::unmanaged);
+        return hpx::id_type(get_service_instance(agas::get_locality()),
+            hpx::id_type::management_type::unmanaged);
     }
 
-    hpx::future<std::pair<naming::id_type, naming::address>>
+    hpx::future<std::pair<hpx::id_type, naming::address>>
     primary_namespace::begin_migration(naming::gid_type const& id)
     {
 #if !defined(HPX_COMPUTE_DEVICE_CODE)
-        naming::id_type dest = naming::id_type(
-            get_service_instance(id), naming::id_type::unmanaged);
+        hpx::id_type dest = hpx::id_type(
+            get_service_instance(id), hpx::id_type::management_type::unmanaged);
 
         if (naming::get_locality_id_from_gid(dest.get_gid()) ==
             agas::get_locality_id())
@@ -169,7 +169,7 @@ namespace hpx { namespace agas {
         HPX_ASSERT(false);
         HPX_UNUSED(id);
         return hpx::make_ready_future(
-            std::pair<naming::id_type, naming::address>{});
+            std::pair<hpx::id_type, naming::address>{});
 #endif
     }
     bool primary_namespace::end_migration(naming::gid_type const& id)
@@ -189,8 +189,8 @@ namespace hpx { namespace agas {
     future<bool> primary_namespace::bind_gid_async(
         gva g, naming::gid_type id, naming::gid_type locality)
     {
-        naming::id_type dest = naming::id_type(
-            get_service_instance(id), naming::id_type::unmanaged);
+        hpx::id_type dest = hpx::id_type(
+            get_service_instance(id), hpx::id_type::management_type::unmanaged);
         if (naming::get_locality_id_from_gid(dest.get_gid()) ==
             agas::get_locality_id())
         {
@@ -212,8 +212,8 @@ namespace hpx { namespace agas {
     {
         // compose request
         naming::gid_type const& id = p.destination();
-        naming::id_type dest = naming::id_type(
-            get_service_instance(id), naming::id_type::unmanaged);
+        hpx::id_type dest = hpx::id_type(
+            get_service_instance(id), hpx::id_type::management_type::unmanaged);
         if (naming::get_locality_id_from_gid(dest.get_gid()) ==
             agas::get_locality_id())
         {
@@ -241,8 +241,8 @@ namespace hpx { namespace agas {
     future<primary_namespace::resolved_type> primary_namespace::resolve_full(
         naming::gid_type id)
     {
-        naming::id_type dest = naming::id_type(
-            get_service_instance(id), naming::id_type::unmanaged);
+        hpx::id_type dest = hpx::id_type(
+            get_service_instance(id), hpx::id_type::management_type::unmanaged);
 
         if (naming::get_locality_id_from_id(dest) == agas::get_locality_id())
         {
@@ -259,8 +259,8 @@ namespace hpx { namespace agas {
 
     hpx::future<id_type> primary_namespace::colocate(naming::gid_type id)
     {
-        naming::id_type dest = naming::id_type(
-            get_service_instance(id), naming::id_type::unmanaged);
+        hpx::id_type dest = hpx::id_type(
+            get_service_instance(id), hpx::id_type::management_type::unmanaged);
 
         if (naming::get_locality_id_from_id(dest) == agas::get_locality_id())
         {
@@ -271,15 +271,15 @@ namespace hpx { namespace agas {
         return hpx::async(action, HPX_MOVE(dest), id);
 #else
         HPX_ASSERT(false);
-        return hpx::make_ready_future(naming::invalid_id);
+        return hpx::make_ready_future(hpx::invalid_id);
 #endif
     }
 
     future<naming::address> primary_namespace::unbind_gid_async(
         std::uint64_t count, naming::gid_type const& id)
     {
-        naming::id_type dest = naming::id_type(
-            get_service_instance(id), naming::id_type::unmanaged);
+        hpx::id_type dest = hpx::id_type(
+            get_service_instance(id), hpx::id_type::management_type::unmanaged);
         naming::gid_type stripped_id = naming::detail::get_stripped_gid(id);
 
         if (naming::get_locality_id_from_id(dest) == agas::get_locality_id())
@@ -299,8 +299,8 @@ namespace hpx { namespace agas {
     naming::address primary_namespace::unbind_gid(
         std::uint64_t count, naming::gid_type const& id)
     {
-        naming::id_type dest = naming::id_type(
-            get_service_instance(id), naming::id_type::unmanaged);
+        hpx::id_type dest = hpx::id_type(
+            get_service_instance(id), hpx::id_type::management_type::unmanaged);
         naming::gid_type stripped_id = naming::detail::get_stripped_gid(id);
 
         if (naming::get_locality_id_from_id(dest) == agas::get_locality_id())
@@ -319,8 +319,8 @@ namespace hpx { namespace agas {
     future<std::int64_t> primary_namespace::increment_credit(
         std::int64_t credits, naming::gid_type lower, naming::gid_type upper)
     {
-        naming::id_type dest = naming::id_type(
-            get_service_instance(lower), naming::id_type::unmanaged);
+        hpx::id_type dest = hpx::id_type(get_service_instance(lower),
+            hpx::id_type::management_type::unmanaged);
 
         if (naming::get_locality_id_from_id(dest) == agas::get_locality_id())
         {

--- a/libs/full/agas_base/src/server/component_namespace_server.cpp
+++ b/libs/full/agas_base/src/server/component_namespace_server.cpp
@@ -35,10 +35,10 @@ namespace hpx { namespace agas {
         return naming::gid_type(agas::component_ns_msb, agas::component_ns_lsb);
     }
 
-    naming::id_type bootstrap_component_namespace_id()
+    hpx::id_type bootstrap_component_namespace_id()
     {
-        return naming::id_type(agas::component_ns_msb, agas::component_ns_lsb,
-            naming::id_type::unmanaged);
+        return hpx::id_type(agas::component_ns_msb, agas::component_ns_lsb,
+            hpx::id_type::management_type::unmanaged);
     }
 }}    // namespace hpx::agas
 

--- a/libs/full/agas_base/src/server/locality_namespace_server.cpp
+++ b/libs/full/agas_base/src/server/locality_namespace_server.cpp
@@ -37,10 +37,10 @@ namespace hpx { namespace agas {
         return naming::gid_type(agas::primary_ns_msb, agas::locality_ns_lsb);
     }
 
-    naming::id_type bootstrap_locality_namespace_id()
+    hpx::id_type bootstrap_locality_namespace_id()
     {
-        return naming::id_type(agas::locality_ns_msb, agas::locality_ns_lsb,
-            naming::id_type::unmanaged);
+        return hpx::id_type(agas::locality_ns_msb, agas::locality_ns_lsb,
+            hpx::id_type::management_type::unmanaged);
     }
 }}    // namespace hpx::agas
 

--- a/libs/full/agas_base/src/server/primary_namespace_server.cpp
+++ b/libs/full/agas_base/src/server/primary_namespace_server.cpp
@@ -40,10 +40,10 @@ namespace hpx { namespace agas {
         return naming::gid_type(agas::primary_ns_msb, agas::primary_ns_lsb);
     }
 
-    naming::id_type bootstrap_primary_namespace_id()
+    hpx::id_type bootstrap_primary_namespace_id()
     {
-        return naming::id_type(agas::primary_ns_msb, agas::primary_ns_lsb,
-            naming::id_type::unmanaged);
+        return hpx::id_type(agas::primary_ns_msb, agas::primary_ns_lsb,
+            hpx::id_type::management_type::unmanaged);
     }
 }}    // namespace hpx::agas
 
@@ -85,8 +85,8 @@ namespace hpx { namespace agas { namespace server {
     }
 
     // start migration of the given object
-    std::pair<naming::id_type, naming::address>
-    primary_namespace::begin_migration(naming::gid_type id)
+    std::pair<hpx::id_type, naming::address> primary_namespace::begin_migration(
+        naming::gid_type id)
     {
         util::scoped_timer<std::atomic<std::int64_t>> update(
             counter_data_.begin_migration_.time_,
@@ -106,7 +106,7 @@ namespace hpx { namespace agas { namespace server {
                                 "response(no_success)",
                 id);
 
-            return std::make_pair(naming::invalid_id, naming::address());
+            return std::make_pair(hpx::invalid_id, naming::address());
         }
 
         migration_table_type::iterator it = migrating_objects_.find(id);
@@ -128,7 +128,8 @@ namespace hpx { namespace agas { namespace server {
 
         gva const& g(hpx::get<1>(r));
         naming::address addr(g.prefix, g.type, g.lva());
-        naming::id_type loc(hpx::get<2>(r), id_type::unmanaged);
+        hpx::id_type loc(
+            hpx::get<2>(r), hpx::id_type::management_type::unmanaged);
         return std::make_pair(loc, addr);
     }
 
@@ -414,10 +415,10 @@ namespace hpx { namespace agas { namespace server {
         return r;
     }    // }}}
 
-    naming::id_type primary_namespace::colocate(naming::gid_type const& id)
+    hpx::id_type primary_namespace::colocate(naming::gid_type const& id)
     {
-        return naming::id_type(
-            hpx::get<2>(resolve_gid(id)), naming::id_type::unmanaged);
+        return hpx::id_type(hpx::get<2>(resolve_gid(id)),
+            hpx::id_type::management_type::unmanaged);
     }
 
     naming::address primary_namespace::unbind_gid(

--- a/libs/full/agas_base/src/server/symbol_namespace_server.cpp
+++ b/libs/full/agas_base/src/server/symbol_namespace_server.cpp
@@ -42,10 +42,10 @@ namespace hpx { namespace agas {
         return naming::gid_type(agas::symbol_ns_msb, agas::symbol_ns_lsb);
     }
 
-    naming::id_type bootstrap_symbol_namespace_id()
+    hpx::id_type bootstrap_symbol_namespace_id()
     {
-        return naming::id_type(agas::symbol_ns_msb, agas::symbol_ns_lsb,
-            naming::id_type::unmanaged);
+        return hpx::id_type(agas::symbol_ns_msb, agas::symbol_ns_lsb,
+            hpx::id_type::management_type::unmanaged);
     }
 }}    // namespace hpx::agas
 

--- a/libs/full/agas_base/src/symbol_namespace.cpp
+++ b/libs/full/agas_base/src/symbol_namespace.cpp
@@ -84,7 +84,7 @@ namespace hpx { namespace agas {
             agas::symbol_ns_msb;
     }
 
-    naming::id_type symbol_namespace::symbol_namespace_locality(
+    hpx::id_type symbol_namespace::symbol_namespace_locality(
         std::string const& key)
     {
         std::uint32_t hash_value = 0;
@@ -94,8 +94,8 @@ namespace hpx { namespace agas {
             util::jenkins_hash hash;
             hash_value = hash(key) % get_initial_num_localities();
         }
-        return naming::id_type(
-            get_service_instance(hash_value), naming::id_type::unmanaged);
+        return hpx::id_type(get_service_instance(hash_value),
+            hpx::id_type::management_type::unmanaged);
     }
 
     symbol_namespace::symbol_namespace()
@@ -114,17 +114,17 @@ namespace hpx { namespace agas {
             components::component_agas_symbol_namespace, this->ptr());
     }
 
-    naming::id_type symbol_namespace::gid() const
+    hpx::id_type symbol_namespace::gid() const
     {
-        return naming::id_type(get_service_instance(agas::get_locality()),
-            naming::id_type::unmanaged);
+        return hpx::id_type(get_service_instance(agas::get_locality()),
+            hpx::id_type::management_type::unmanaged);
     }
 
     hpx::future<bool> symbol_namespace::bind_async(
         std::string key, naming::gid_type gid)
     {
 #if !defined(HPX_COMPUTE_DEVICE_CODE)
-        naming::id_type dest = symbol_namespace_locality(key);
+        hpx::id_type dest = symbol_namespace_locality(key);
 
         if (naming::get_locality_id_from_id(dest) == agas::get_locality_id())
         {
@@ -143,7 +143,7 @@ namespace hpx { namespace agas {
 
     bool symbol_namespace::bind(std::string key, naming::gid_type gid)
     {
-        naming::id_type dest = symbol_namespace_locality(key);
+        hpx::id_type dest = symbol_namespace_locality(key);
 
         if (naming::get_locality_id_from_id(dest) == agas::get_locality_id())
         {
@@ -161,61 +161,61 @@ namespace hpx { namespace agas {
 #endif
     }
 
-    hpx::future<naming::id_type> symbol_namespace::resolve_async(
+    hpx::future<hpx::id_type> symbol_namespace::resolve_async(
         std::string key) const
     {
-        naming::id_type dest = symbol_namespace_locality(key);
+        hpx::id_type dest = symbol_namespace_locality(key);
 
         if (naming::get_locality_id_from_id(dest) == agas::get_locality_id())
         {
             naming::gid_type raw_gid = server_->resolve(HPX_MOVE(key));
 
             if (naming::detail::has_credits(raw_gid))
-                return hpx::make_ready_future(
-                    naming::id_type(raw_gid, naming::id_type::managed));
+                return hpx::make_ready_future(hpx::id_type(
+                    raw_gid, hpx::id_type::management_type::managed));
 
-            return hpx::make_ready_future(
-                naming::id_type(raw_gid, naming::id_type::unmanaged));
+            return hpx::make_ready_future(hpx::id_type(
+                raw_gid, hpx::id_type::management_type::unmanaged));
         }
 #if !defined(HPX_COMPUTE_DEVICE_CODE)
         server::symbol_namespace::resolve_action action;
         return hpx::async(action, HPX_MOVE(dest), HPX_MOVE(key));
 #else
         HPX_ASSERT(false);
-        return hpx::make_ready_future(naming::id_type{});
+        return hpx::make_ready_future(hpx::id_type{});
 #endif
     }
 
-    naming::id_type symbol_namespace::resolve(std::string key) const
+    hpx::id_type symbol_namespace::resolve(std::string key) const
     {
         return resolve_async(HPX_MOVE(key)).get();
     }
 
-    hpx::future<naming::id_type> symbol_namespace::unbind_async(std::string key)
+    hpx::future<hpx::id_type> symbol_namespace::unbind_async(std::string key)
     {
-        naming::id_type dest = symbol_namespace_locality(key);
+        hpx::id_type dest = symbol_namespace_locality(key);
 
         if (naming::get_locality_id_from_id(dest) == agas::get_locality_id())
         {
             naming::gid_type raw_gid = server_->unbind(HPX_MOVE(key));
 
             if (naming::detail::has_credits(raw_gid))
-                return hpx::make_ready_future(
-                    naming::id_type(raw_gid, naming::id_type::managed));
+                return hpx::make_ready_future(hpx::id_type(
+                    raw_gid, hpx::id_type::management_type::managed));
 
-            return hpx::make_ready_future(
-                naming::id_type(raw_gid, naming::id_type::unmanaged));
+            return hpx::make_ready_future(hpx::id_type(
+                raw_gid, hpx::id_type::management_type::unmanaged));
         }
 #if !defined(HPX_COMPUTE_DEVICE_CODE)
         server::symbol_namespace::unbind_action action;
         return hpx::async(action, HPX_MOVE(dest), HPX_MOVE(key));
 #else
         HPX_ASSERT(false);
-        return hpx::make_ready_future(naming::id_type{});
+        return hpx::make_ready_future(hpx::id_type{});
 #endif
     }
 
-    naming::id_type symbol_namespace::unbind(std::string key)
+    hpx::id_type symbol_namespace::unbind(std::string key)
     {
         return unbind_async(HPX_MOVE(key)).get();
     }
@@ -223,7 +223,7 @@ namespace hpx { namespace agas {
     hpx::future<bool> symbol_namespace::on_event(
         std::string const& name, bool call_for_past_events, hpx::id_type lco)
     {
-        naming::id_type dest = symbol_namespace_locality(name);
+        hpx::id_type dest = symbol_namespace_locality(name);
 
         if (naming::get_locality_id_from_id(dest) == agas::get_locality_id())
         {
@@ -254,8 +254,8 @@ namespace hpx { namespace agas {
         results.reserve(ids.size());
         for (auto id : ids)
         {
-            hpx::id_type target(
-                get_service_instance(id), hpx::id_type::unmanaged);
+            hpx::id_type target(get_service_instance(id),
+                hpx::id_type::management_type::unmanaged);
 
             using iterate_action = server::symbol_namespace::iterate_action;
             results.push_back(
@@ -273,8 +273,9 @@ namespace hpx { namespace agas {
                             naming::detail::has_credits(e.second);
                         result[HPX_MOVE(e.first)] =
                             hpx::id_type(HPX_MOVE(e.second),
-                                has_credits ? naming::id_type::managed :
-                                              naming::id_type::unmanaged);
+                                has_credits ?
+                                    hpx::id_type::management_type::managed :
+                                    hpx::id_type::management_type::unmanaged);
                     }
                 }
                 return result;

--- a/libs/full/async_colocated/include/hpx/async_colocated/apply_colocated.hpp
+++ b/libs/full/async_colocated/include/hpx/async_colocated/apply_colocated.hpp
@@ -26,7 +26,7 @@
 namespace hpx { namespace detail {
     ///////////////////////////////////////////////////////////////////////////
     template <typename Action, typename... Ts>
-    bool apply_colocated(naming::id_type const& gid, Ts&&... vs)
+    bool apply_colocated(hpx::id_type const& gid, Ts&&... vs)
     {
         // shortcut co-location code if target already is a locality
         if (naming::is_locality(gid))
@@ -36,9 +36,9 @@ namespace hpx { namespace detail {
 
         // Attach the requested action as a continuation to a resolve_async
         // call on the locality responsible for the target gid.
-        naming::id_type service_target(
+        hpx::id_type service_target(
             agas::primary_namespace::get_service_instance(gid.get_gid()),
-            naming::id_type::unmanaged);
+            hpx::id_type::management_type::unmanaged);
 
         typedef agas::server::primary_namespace::colocate_action action_type;
 
@@ -54,7 +54,7 @@ namespace hpx { namespace detail {
         typename... Ts>
     bool apply_colocated(
         hpx::actions::basic_action<Component, Signature, Derived> /*act*/,
-        naming::id_type const& gid, Ts&&... vs)
+        hpx::id_type const& gid, Ts&&... vs)
     {
         return apply_colocated<Derived>(gid, HPX_FORWARD(Ts, vs)...);
     }
@@ -62,7 +62,7 @@ namespace hpx { namespace detail {
     template <typename Action, typename Continuation, typename... Ts>
     typename std::enable_if<traits::is_continuation<Continuation>::value,
         bool>::type
-    apply_colocated(Continuation&& cont, naming::id_type const& gid, Ts&&... vs)
+    apply_colocated(Continuation&& cont, hpx::id_type const& gid, Ts&&... vs)
     {
         // shortcut co-location code if target already is a locality
         if (naming::is_locality(gid))
@@ -73,9 +73,9 @@ namespace hpx { namespace detail {
 
         // Attach the requested action as a continuation to a resolve_async
         // call on the locality responsible for the target gid.
-        naming::id_type service_target(
+        hpx::id_type service_target(
             agas::primary_namespace::get_service_instance(gid.get_gid()),
-            naming::id_type::unmanaged);
+            hpx::id_type::management_type::unmanaged);
 
         typedef agas::server::primary_namespace::colocate_action action_type;
 
@@ -93,7 +93,7 @@ namespace hpx { namespace detail {
         typename Derived, typename... Ts>
     bool apply_colocated(Continuation&& cont,
         hpx::actions::basic_action<Component, Signature, Derived> /*act*/,
-        naming::id_type const& gid, Ts&&... vs)
+        hpx::id_type const& gid, Ts&&... vs)
     {
         return apply_colocated<Derived>(
             HPX_FORWARD(Continuation, cont), gid, HPX_FORWARD(Ts, vs)...);

--- a/libs/full/async_colocated/include/hpx/async_colocated/apply_colocated_callback.hpp
+++ b/libs/full/async_colocated/include/hpx/async_colocated/apply_colocated_callback.hpp
@@ -26,8 +26,7 @@
 namespace hpx { namespace detail {
     ///////////////////////////////////////////////////////////////////////////
     template <typename Action, typename Callback, typename... Ts>
-    bool apply_colocated_cb(
-        naming::id_type const& gid, Callback&& cb, Ts&&... vs)
+    bool apply_colocated_cb(hpx::id_type const& gid, Callback&& cb, Ts&&... vs)
     {
         // shortcut co-location code if target already is a locality
         if (naming::is_locality(gid))
@@ -38,9 +37,9 @@ namespace hpx { namespace detail {
 
         // Attach the requested action as a continuation to a resolve_async
         // call on the locality responsible for the target gid.
-        naming::id_type service_target(
+        hpx::id_type service_target(
             agas::primary_namespace::get_service_instance(gid.get_gid()),
-            naming::id_type::unmanaged);
+            hpx::id_type::management_type::unmanaged);
 
         typedef agas::server::primary_namespace::colocate_action action_type;
 
@@ -56,7 +55,7 @@ namespace hpx { namespace detail {
         typename Callback, typename... Ts>
     bool apply_colocated_cb(
         hpx::actions::basic_action<Component, Signature, Derived> /*act*/,
-        naming::id_type const& gid, Callback&& cb, Ts&&... vs)
+        hpx::id_type const& gid, Callback&& cb, Ts&&... vs)
     {
         return apply_colocated_cb<Derived>(
             gid, HPX_FORWARD(Callback, cb), HPX_FORWARD(Ts, vs)...);
@@ -65,8 +64,8 @@ namespace hpx { namespace detail {
     ///////////////////////////////////////////////////////////////////////////
     template <typename Action, typename Continuation, typename Callback,
         typename... Ts>
-    bool apply_colocated_cb(Continuation&& cont, naming::id_type const& gid,
-        Callback&& cb, Ts&&... vs)
+    bool apply_colocated_cb(
+        Continuation&& cont, hpx::id_type const& gid, Callback&& cb, Ts&&... vs)
     {
         // shortcut co-location code if target already is a locality
         if (naming::is_locality(gid))
@@ -78,9 +77,9 @@ namespace hpx { namespace detail {
 
         // Attach the requested action as a continuation to a resolve_async
         // call on the locality responsible for the target gid.
-        naming::id_type service_target(
+        hpx::id_type service_target(
             agas::primary_namespace::get_service_instance(gid.get_gid()),
-            naming::id_type::unmanaged);
+            hpx::id_type::management_type::unmanaged);
 
         typedef agas::server::primary_namespace::colocate_action action_type;
 
@@ -98,7 +97,7 @@ namespace hpx { namespace detail {
         typename Derived, typename Callback, typename... Ts>
     bool apply_colocated_cb(Continuation&& cont,
         hpx::actions::basic_action<Component, Signature, Derived> /*act*/,
-        naming::id_type const& gid, Callback&& cb, Ts&&... vs)
+        hpx::id_type const& gid, Callback&& cb, Ts&&... vs)
     {
         return apply_colocated_cb<Derived>(HPX_FORWARD(Continuation, cont), gid,
             HPX_FORWARD(Callback, cb), HPX_FORWARD(Ts, vs)...);

--- a/libs/full/async_colocated/include/hpx/async_colocated/apply_colocated_callback_fwd.hpp
+++ b/libs/full/async_colocated/include/hpx/async_colocated/apply_colocated_callback_fwd.hpp
@@ -14,26 +14,25 @@
 namespace hpx { namespace detail {
     ///////////////////////////////////////////////////////////////////////////
     template <typename Action, typename Callback, typename... Ts>
-    bool apply_colocated_cb(
-        naming::id_type const& gid, Callback&& cb, Ts&&... vs);
+    bool apply_colocated_cb(hpx::id_type const& gid, Callback&& cb, Ts&&... vs);
 
     template <typename Component, typename Signature, typename Derived,
         typename Callback, typename... Ts>
     bool apply_colocated_cb(
         hpx::actions::basic_action<Component, Signature, Derived> /*act*/,
-        naming::id_type const& gid, Callback&& cb, Ts&&... vs);
+        hpx::id_type const& gid, Callback&& cb, Ts&&... vs);
 
     ///////////////////////////////////////////////////////////////////////////
     template <typename Action, typename Continuation, typename Callback,
         typename... Ts>
-    bool apply_colocated_cb(Continuation&& cont, naming::id_type const& gid,
+    bool apply_colocated_cb(Continuation&& cont, hpx::id_type const& gid,
         Callback&& cb, Ts&&... vs);
 
     template <typename Continuation, typename Component, typename Signature,
         typename Derived, typename Callback, typename... Ts>
     bool apply_colocated_cb(Continuation&& cont,
         hpx::actions::basic_action<Component, Signature, Derived> /*act*/,
-        naming::id_type const& gid, Callback&& cb, Ts&&... vs);
+        hpx::id_type const& gid, Callback&& cb, Ts&&... vs);
 }}    // namespace hpx::detail
 
 #if defined(HPX_HAVE_COLOCATED_BACKWARDS_COMPATIBILITY)

--- a/libs/full/async_colocated/include/hpx/async_colocated/apply_colocated_fwd.hpp
+++ b/libs/full/async_colocated/include/hpx/async_colocated/apply_colocated_fwd.hpp
@@ -16,26 +16,25 @@
 namespace hpx { namespace detail {
     ///////////////////////////////////////////////////////////////////////////
     template <typename Action, typename... Ts>
-    bool apply_colocated(naming::id_type const& gid, Ts&&... vs);
+    bool apply_colocated(hpx::id_type const& gid, Ts&&... vs);
 
     template <typename Component, typename Signature, typename Derived,
         typename... Ts>
     bool apply_colocated(
         hpx::actions::basic_action<Component, Signature, Derived> /*act*/,
-        naming::id_type const& gid, Ts&&... vs);
+        hpx::id_type const& gid, Ts&&... vs);
 
     ///////////////////////////////////////////////////////////////////////////
     template <typename Action, typename Continuation, typename... Ts>
     typename std::enable_if<traits::is_continuation<Continuation>::value,
         bool>::type
-    apply_colocated(
-        Continuation&& cont, naming::id_type const& gid, Ts&&... vs);
+    apply_colocated(Continuation&& cont, hpx::id_type const& gid, Ts&&... vs);
 
     template <typename Continuation, typename Component, typename Signature,
         typename Derived, typename... Ts>
     bool apply_colocated(Continuation&& cont,
         hpx::actions::basic_action<Component, Signature, Derived> /*act*/,
-        naming::id_type const& gid, Ts&&... vs);
+        hpx::id_type const& gid, Ts&&... vs);
 }}    // namespace hpx::detail
 
 #if defined(HPX_HAVE_COLOCATED_BACKWARDS_COMPATIBILITY)

--- a/libs/full/async_colocated/include/hpx/async_colocated/async_colocated.hpp
+++ b/libs/full/async_colocated/include/hpx/async_colocated/async_colocated.hpp
@@ -47,7 +47,7 @@ namespace hpx { namespace detail {
 
 #define HPX_REGISTER_ASYNC_COLOCATED_DECLARATION(Action, Name)                 \
     HPX_UTIL_REGISTER_UNIQUE_FUNCTION_DECLARATION(                             \
-        void(hpx::naming::id_type, hpx::naming::id_type),                      \
+        void(hpx::id_type, hpx::id_type),                                      \
         (hpx::util::functional::detail::async_continuation_impl<               \
             typename hpx::detail::async_colocated_bound_action<Action>::type,  \
             hpx::util::unused_type>),                                          \
@@ -55,8 +55,7 @@ namespace hpx { namespace detail {
     /**/
 
 #define HPX_REGISTER_ASYNC_COLOCATED(Action, Name)                             \
-    HPX_UTIL_REGISTER_UNIQUE_FUNCTION(                                         \
-        void(hpx::naming::id_type, hpx::naming::id_type),                      \
+    HPX_UTIL_REGISTER_UNIQUE_FUNCTION(void(hpx::id_type, hpx::id_type),        \
         (hpx::util::functional::detail::async_continuation_impl<               \
             typename hpx::detail::async_colocated_bound_action<Action>::type,  \
             hpx::util::unused_type>),                                          \
@@ -68,7 +67,7 @@ namespace hpx { namespace detail {
     template <typename Action, typename... Ts>
     hpx::future<typename traits::promise_local_result<
         typename hpx::traits::extract_action<Action>::remote_result_type>::type>
-    async_colocated(naming::id_type const& gid,
+    async_colocated(hpx::id_type const& gid,
         Ts&&...
 #if !defined(HPX_COMPUTE_DEVICE_CODE)
         vs
@@ -77,9 +76,9 @@ namespace hpx { namespace detail {
     {
         // Attach the requested action as a continuation to a resolve_async
         // call on the locality responsible for the target gid.
-        naming::id_type service_target(
+        hpx::id_type service_target(
             agas::primary_namespace::get_service_instance(gid.get_gid()),
-            naming::id_type::unmanaged);
+            hpx::id_type::management_type::unmanaged);
 
 #if !defined(HPX_COMPUTE_DEVICE_CODE)
         using remote_result_type =
@@ -105,7 +104,7 @@ namespace hpx { namespace detail {
             extract_action<Derived>::remote_result_type>::type>
     async_colocated(
         hpx::actions::basic_action<Component, Signature, Derived> /*act*/,
-        naming::id_type const& gid, Ts&&... vs)
+        hpx::id_type const& gid, Ts&&... vs)
     {
         return async_colocated<Derived>(gid, HPX_FORWARD(Ts, vs)...);
     }
@@ -115,7 +114,7 @@ namespace hpx { namespace detail {
     std::enable_if_t<traits::is_continuation_v<Continuation>,
         hpx::future<traits::promise_local_result_t<
             typename hpx::traits::extract_action<Action>::remote_result_type>>>
-    async_colocated(Continuation&& cont, naming::id_type const& gid,
+    async_colocated(Continuation&& cont, hpx::id_type const& gid,
         Ts&&...
 #if !defined(HPX_COMPUTE_DEVICE_CODE)
         vs
@@ -129,9 +128,9 @@ namespace hpx { namespace detail {
 #else
         // Attach the requested action as a continuation to a resolve_async
         // call on the locality responsible for the target gid.
-        naming::id_type service_target(
+        hpx::id_type service_target(
             agas::primary_namespace::get_service_instance(gid.get_gid()),
-            naming::id_type::unmanaged);
+            hpx::id_type::management_type::unmanaged);
 
         using remote_result_type =
             typename hpx::traits::extract_action<Action>::remote_result_type;
@@ -155,7 +154,7 @@ namespace hpx { namespace detail {
             typename hpx::traits::extract_action<Derived>::remote_result_type>>>
     async_colocated(Continuation&& cont,
         hpx::actions::basic_action<Component, Signature, Derived> /*act*/,
-        naming::id_type const& gid, Ts&&... vs)
+        hpx::id_type const& gid, Ts&&... vs)
     {
         return async_colocated<Derived>(
             HPX_FORWARD(Continuation, cont), gid, HPX_FORWARD(Ts, vs)...);

--- a/libs/full/async_colocated/include/hpx/async_colocated/async_colocated_callback.hpp
+++ b/libs/full/async_colocated/include/hpx/async_colocated/async_colocated_callback.hpp
@@ -22,7 +22,7 @@ namespace hpx { namespace detail {
     template <typename Action, typename Callback, typename... Ts>
     hpx::future<typename traits::promise_local_result<
         typename hpx::traits::extract_action<Action>::remote_result_type>::type>
-    async_colocated_cb(naming::id_type const& gid, Callback&& cb,
+    async_colocated_cb(hpx::id_type const& gid, Callback&& cb,
         Ts&&...
 #if !defined(HPX_COMPUTE_DEVICE_CODE)
         vs
@@ -36,9 +36,9 @@ namespace hpx { namespace detail {
 #else
         // Attach the requested action as a continuation to a resolve_async
         // call on the locality responsible for the target gid.
-        naming::id_type service_target(
+        hpx::id_type service_target(
             agas::primary_namespace::get_service_instance(gid.get_gid()),
-            naming::id_type::unmanaged);
+            hpx::id_type::management_type::unmanaged);
 
         typedef typename hpx::traits::extract_action<Action>::remote_result_type
             remote_result_type;
@@ -59,7 +59,7 @@ namespace hpx { namespace detail {
             extract_action<Derived>::remote_result_type>::type>
     async_colocated_cb(
         hpx::actions::basic_action<Component, Signature, Derived> /*act*/,
-        naming::id_type const& gid, Callback&& cb, Ts&&... vs)
+        hpx::id_type const& gid, Callback&& cb, Ts&&... vs)
     {
         return async_colocated_cb<Derived>(
             gid, HPX_FORWARD(Callback, cb), HPX_FORWARD(Ts, vs)...);
@@ -71,7 +71,7 @@ namespace hpx { namespace detail {
     hpx::future<typename traits::promise_local_result<
         typename hpx::traits::extract_action<Action>::remote_result_type>::type>
     async_colocated_cb(
-        Continuation&& cont, naming::id_type const& gid, Callback&& cb,
+        Continuation&& cont, hpx::id_type const& gid, Callback&& cb,
         Ts&&...
 #if !defined(HPX_COMPUTE_DEVICE_CODE)
         vs
@@ -86,9 +86,9 @@ namespace hpx { namespace detail {
 #else
         // Attach the requested action as a continuation to a resolve_async
         // call on the locality responsible for the target gid.
-        naming::id_type service_target(
+        hpx::id_type service_target(
             agas::primary_namespace::get_service_instance(gid.get_gid()),
-            naming::id_type::unmanaged);
+            hpx::id_type::management_type::unmanaged);
 
         typedef typename hpx::traits::extract_action<Action>::remote_result_type
             remote_result_type;
@@ -111,7 +111,7 @@ namespace hpx { namespace detail {
             extract_action<Derived>::remote_result_type>::type>
     async_colocated_cb(Continuation&& cont,
         hpx::actions::basic_action<Component, Signature, Derived> /*act*/,
-        naming::id_type const& gid, Callback&& cb, Ts&&... vs)
+        hpx::id_type const& gid, Callback&& cb, Ts&&... vs)
     {
         return async_colocated_cb<Derived>(HPX_FORWARD(Continuation, cont), gid,
             HPX_FORWARD(Callback, cb), HPX_FORWARD(Ts, vs)...);

--- a/libs/full/async_colocated/include/hpx/async_colocated/async_colocated_callback_fwd.hpp
+++ b/libs/full/async_colocated/include/hpx/async_colocated/async_colocated_callback_fwd.hpp
@@ -15,23 +15,22 @@ namespace hpx { namespace detail {
     template <typename Action, typename Callback, typename... Ts>
     hpx::future<typename traits::promise_local_result<
         typename hpx::traits::extract_action<Action>::remote_result_type>::type>
-    async_colocated_cb(naming::id_type const& gid, Callback&& cb, Ts&&... vs);
+    async_colocated_cb(hpx::id_type const& gid, Callback&& cb, Ts&&... vs);
 
     template <typename Component, typename Signature, typename Derived,
         typename Callback, typename... Ts>
     hpx::future<typename traits::promise_local_result<typename hpx::traits::
             extract_action<Derived>::remote_result_type>::type>
     async_colocated_cb(
-        hpx::actions::basic_action<Component, Signature, Derived> /*act*/
-        ,
-        naming::id_type const& gid, Callback&& cb, Ts&&... vs);
+        hpx::actions::basic_action<Component, Signature, Derived> /*act*/,
+        hpx::id_type const& gid, Callback&& cb, Ts&&... vs);
 
     ///////////////////////////////////////////////////////////////////////////
     template <typename Action, typename Continuation, typename Callback,
         typename... Ts>
     hpx::future<typename traits::promise_local_result<
         typename hpx::traits::extract_action<Action>::remote_result_type>::type>
-    async_colocated_cb(Continuation&& cont, naming::id_type const& gid,
+    async_colocated_cb(Continuation&& cont, hpx::id_type const& gid,
         Callback&& cb, Ts&&... vs);
 
     template <typename Continuation, typename Component, typename Signature,
@@ -39,9 +38,8 @@ namespace hpx { namespace detail {
     hpx::future<typename traits::promise_local_result<typename hpx::traits::
             extract_action<Derived>::remote_result_type>::type>
     async_colocated_cb(Continuation&& cont,
-        hpx::actions::basic_action<Component, Signature, Derived> /*act*/
-        ,
-        naming::id_type const& gid, Callback&& cb, Ts&&... vs);
+        hpx::actions::basic_action<Component, Signature, Derived> /*act*/,
+        hpx::id_type const& gid, Callback&& cb, Ts&&... vs);
 }}    // namespace hpx::detail
 
 #if defined(HPX_HAVE_COLOCATED_BACKWARDS_COMPATIBILITY)

--- a/libs/full/async_colocated/include/hpx/async_colocated/async_colocated_fwd.hpp
+++ b/libs/full/async_colocated/include/hpx/async_colocated/async_colocated_fwd.hpp
@@ -22,14 +22,14 @@ namespace hpx { namespace detail {
     template <typename Action, typename... Ts>
     hpx::future<traits::promise_local_result_t<
         typename hpx::traits::extract_action<Action>::remote_result_type>>
-    async_colocated(naming::id_type const& id, Ts&&... vs);
+    async_colocated(hpx::id_type const& id, Ts&&... vs);
 
     template <typename Component, typename Signature, typename Derived,
         typename... Ts>
     hpx::future<traits::promise_local_result_t<
         typename hpx::traits::extract_action<Derived>::remote_result_type>>
     async_colocated(hpx::actions::basic_action<Component, Signature, Derived>,
-        naming::id_type const& id, Ts&&... vs);
+        hpx::id_type const& id, Ts&&... vs);
 
     ///////////////////////////////////////////////////////////////////////////
     // MSVC complains about ambiguities if it sees this forward declaration
@@ -38,7 +38,7 @@ namespace hpx { namespace detail {
     std::enable_if_t<traits::is_continuation_v<Continuation>,
         hpx::future<traits::promise_local_result_t<
             typename hpx::traits::extract_action<Action>::remote_result_type>>>
-    async_colocated(Continuation&& cont, naming::id_type const& id, Ts&&... vs);
+    async_colocated(Continuation&& cont, hpx::id_type const& id, Ts&&... vs);
 
     template <typename Continuation, typename Component, typename Signature,
         typename Derived, typename... Ts>
@@ -47,7 +47,7 @@ namespace hpx { namespace detail {
             typename hpx::traits::extract_action<Derived>::remote_result_type>>>
     async_colocated(Continuation&& cont,
         hpx::actions::basic_action<Component, Signature, Derived>,
-        naming::id_type const& id, Ts&&... vs);
+        hpx::id_type const& id, Ts&&... vs);
 #endif
 }}    // namespace hpx::detail
 

--- a/libs/full/async_colocated/include/hpx/async_colocated/functional/colocated_helpers.hpp
+++ b/libs/full/async_colocated/include/hpx/async_colocated/functional/colocated_helpers.hpp
@@ -27,15 +27,15 @@ namespace hpx { namespace util { namespace functional {
     ///////////////////////////////////////////////////////////////////////////
     struct extract_locality
     {
-        naming::id_type operator()(
-            naming::id_type const& locality_id, naming::id_type const& id) const
+        hpx::id_type operator()(
+            hpx::id_type const& locality_id, hpx::id_type const& id) const
         {
-            if (locality_id == naming::invalid_id)
+            if (locality_id == hpx::invalid_id)
             {
                 HPX_THROW_EXCEPTION(hpx::no_success,
                     "extract_locality::operator()",
                     "could not resolve colocated locality for id({1})", id);
-                return naming::invalid_id;
+                return hpx::invalid_id;
             }
             return locality_id;
         }
@@ -65,11 +65,11 @@ namespace hpx { namespace util { namespace functional {
                 apply_continuation_impl&& o) = default;
 
             template <typename T>
-            typename util::invoke_result<bound_type, naming::id_type, T>::type
-            operator()(naming::id_type lco, T&& t)
+            typename util::invoke_result<bound_type, hpx::id_type, T>::type
+            operator()(hpx::id_type lco, T&& t)
             {
-                typedef typename util::invoke_result<bound_type,
-                    naming::id_type, T>::type result_type;
+                typedef typename util::invoke_result<bound_type, hpx::id_type,
+                    T>::type result_type;
 
                 bound_.apply_c(HPX_MOVE(cont_), lco, HPX_FORWARD(T, t));
                 return result_type();
@@ -113,11 +113,11 @@ namespace hpx { namespace util { namespace functional {
                 apply_continuation_impl&& o) = default;
 
             template <typename T>
-            typename util::invoke_result<bound_type, naming::id_type, T>::type
-            operator()(naming::id_type lco, T&& t)
+            typename util::invoke_result<bound_type, hpx::id_type, T>::type
+            operator()(hpx::id_type lco, T&& t)
             {
-                typedef typename util::invoke_result<bound_type,
-                    naming::id_type, T>::type result_type;
+                typedef typename util::invoke_result<bound_type, hpx::id_type,
+                    T>::type result_type;
 
                 bound_.apply(lco, HPX_FORWARD(T, t));
                 return result_type();
@@ -186,11 +186,11 @@ namespace hpx { namespace util { namespace functional {
             }
 
             template <typename T>
-            typename util::invoke_result<bound_type, naming::id_type, T>::type
-            operator()(naming::id_type lco, T&& t)
+            typename util::invoke_result<bound_type, hpx::id_type, T>::type
+            operator()(hpx::id_type lco, T&& t)
             {
-                typedef typename util::invoke_result<bound_type,
-                    naming::id_type, T>::type result_type;
+                typedef typename util::invoke_result<bound_type, hpx::id_type,
+                    T>::type result_type;
 
                 bound_.apply_c(HPX_MOVE(cont_), lco, HPX_FORWARD(T, t));
                 return result_type();
@@ -240,11 +240,11 @@ namespace hpx { namespace util { namespace functional {
             }
 
             template <typename T>
-            typename util::invoke_result<bound_type, naming::id_type, T>::type
-            operator()(naming::id_type lco, T&& t)
+            typename util::invoke_result<bound_type, hpx::id_type, T>::type
+            operator()(hpx::id_type lco, T&& t)
             {
-                typedef typename util::invoke_result<bound_type,
-                    naming::id_type, T>::type result_type;
+                typedef typename util::invoke_result<bound_type, hpx::id_type,
+                    T>::type result_type;
 
                 bound_.apply_c(lco, lco, HPX_FORWARD(T, t));
                 return result_type();

--- a/libs/full/async_colocated/include/hpx/async_colocated/get_colocation_id.hpp
+++ b/libs/full/async_colocated/include/hpx/async_colocated/get_colocation_id.hpp
@@ -34,8 +34,8 @@ namespace hpx {
     ///           hpx::exception.
     ///
     /// \see    \a hpx::get_colocation_id()
-    HPX_EXPORT naming::id_type get_colocation_id(launch::sync_policy,
-        naming::id_type const& id, error_code& ec = throws);
+    HPX_EXPORT hpx::id_type get_colocation_id(
+        launch::sync_policy, hpx::id_type const& id, error_code& ec = throws);
 
     /// \brief Asynchronously return the id of the locality where the object
     ///        referenced by the given id is currently located on
@@ -43,6 +43,6 @@ namespace hpx {
     /// \param id [in] The id of the object to locate.
     ///
     /// \see    \a hpx::get_colocation_id(launch::sync_policy)
-    HPX_EXPORT hpx::future<naming::id_type> get_colocation_id(
-        naming::id_type const& id);
+    HPX_EXPORT hpx::future<hpx::id_type> get_colocation_id(
+        hpx::id_type const& id);
 }    // namespace hpx

--- a/libs/full/async_colocated/include/hpx/async_colocated/register_apply_colocated.hpp
+++ b/libs/full/async_colocated/include/hpx/async_colocated/register_apply_colocated.hpp
@@ -33,27 +33,4 @@ namespace hpx { namespace detail {
 }}    // namespace hpx::detail
 
 #define HPX_REGISTER_APPLY_COLOCATED_DECLARATION(Action, Name)
-
-/*
-    HPX_UTIL_REGISTER_UNIQUE_FUNCTION_DECLARATION(                            \
-        void (hpx::naming::id_type, hpx::naming::id_type)                     \
-      , (hpx::util::functional::detail::apply_continuation_impl<              \
-            typename hpx::detail::apply_colocated_bound_action<Action>::type  \
-        >)                                                                    \
-      , Name                                                                  \
-    );                                                                        \
-    */
-/**/
-
 #define HPX_REGISTER_APPLY_COLOCATED(action, name)
-
-/*
-    HPX_UTIL_REGISTER_UNIQUE_FUNCTION(                                        \
-        void (hpx::naming::id_type, hpx::naming::id_type)                     \
-      , (hpx::util::functional::detail::apply_continuation_impl<              \
-            typename hpx::detail::apply_colocated_bound_action<Action>::type  \
-        >)                                                                    \
-      , name                                                                  \
-    );                                                                        \
-    */
-/**/

--- a/libs/full/async_colocated/src/get_colocation_id.cpp
+++ b/libs/full/async_colocated/src/get_colocation_id.cpp
@@ -14,13 +14,13 @@
 
 namespace hpx {
 
-    naming::id_type get_colocation_id(
-        launch::sync_policy, naming::id_type const& id, error_code& ec)
+    hpx::id_type get_colocation_id(
+        launch::sync_policy, hpx::id_type const& id, error_code& ec)
     {
         return agas::get_colocation_id(launch::sync, id, ec);
     }
 
-    future<naming::id_type> get_colocation_id(naming::id_type const& id)
+    future<hpx::id_type> get_colocation_id(hpx::id_type const& id)
     {
         return agas::get_colocation_id(id);
     }

--- a/libs/full/async_colocated/src/server/destroy_component.cpp
+++ b/libs/full/async_colocated/src/server/destroy_component.cpp
@@ -58,8 +58,8 @@ namespace hpx { namespace components { namespace server {
         }
 
         // apply remotely (only if runtime is not stopping)
-        naming::id_type id = get_colocation_id(
-            launch::sync, naming::id_type(gid, naming::id_type::unmanaged));
+        hpx::id_type id = get_colocation_id(launch::sync,
+            hpx::id_type(gid, hpx::id_type::management_type::unmanaged));
 
         hpx_destroy_component_action()(id, gid, addr);
     }

--- a/libs/full/async_distributed/include/hpx/async_distributed/applier/apply.hpp
+++ b/libs/full/async_distributed/include/hpx/async_distributed/applier/apply.hpp
@@ -55,9 +55,8 @@ namespace hpx {
         }
 
         template <typename Action, typename... Ts>
-        inline bool put_parcel(naming::id_type const& id,
-            naming::address&& addr, threads::thread_priority priority,
-            Ts&&... vs)
+        inline bool put_parcel(hpx::id_type const& id, naming::address&& addr,
+            threads::thread_priority priority, Ts&&... vs)
         {
             typedef
                 typename hpx::traits::extract_action<Action>::type action_type;
@@ -70,7 +69,7 @@ namespace hpx {
         }
 
         template <typename Action, typename Continuation, typename... Ts>
-        inline bool put_parcel_cont(naming::id_type const& id,
+        inline bool put_parcel_cont(hpx::id_type const& id,
             naming::address&& addr, threads::thread_priority priority,
             Continuation&& cont, Ts&&... vs)
         {
@@ -86,7 +85,7 @@ namespace hpx {
         }
 
         template <typename Action, typename... Ts>
-        inline bool put_parcel_cb(naming::id_type const& id,
+        inline bool put_parcel_cb(hpx::id_type const& id,
             naming::address&& addr, threads::thread_priority priority,
             parcelset::write_handler_type const& cb, Ts&&... vs)
         {
@@ -101,7 +100,7 @@ namespace hpx {
         }
 
         template <typename Action, typename... Ts>
-        inline bool put_parcel_cb(naming::id_type const& id,
+        inline bool put_parcel_cb(hpx::id_type const& id,
             naming::address&& addr, threads::thread_priority priority,
             parcelset::write_handler_type&& cb, Ts&&... vs)
         {
@@ -117,7 +116,7 @@ namespace hpx {
         }
 
         template <typename Action, typename Continuation, typename... Ts>
-        inline bool put_parcel_cont_cb(naming::id_type const& id,
+        inline bool put_parcel_cont_cb(hpx::id_type const& id,
             naming::address&& addr, threads::thread_priority priority,
             Continuation&& cont, parcelset::write_handler_type const& cb,
             Ts&&... vs)
@@ -134,7 +133,7 @@ namespace hpx {
         }
 
         template <typename Action, typename Continuation, typename... Ts>
-        inline bool put_parcel_cont_cb(naming::id_type const& id,
+        inline bool put_parcel_cont_cb(hpx::id_type const& id,
             naming::address&& addr, threads::thread_priority priority,
             Continuation&& cont, parcelset::write_handler_type&& cb, Ts&&... vs)
         {
@@ -152,7 +151,7 @@ namespace hpx {
 
         // We know it is remote.
         template <typename Action, typename... Ts>
-        inline bool apply_r_p(naming::address&& addr, naming::id_type const& id,
+        inline bool apply_r_p(naming::address&& addr, hpx::id_type const& id,
             threads::thread_priority priority, Ts&&... vs)
         {
             // If remote, create a new parcel to be sent to the destination
@@ -163,7 +162,7 @@ namespace hpx {
 
         template <typename Action, typename... Ts>
         inline bool apply_r(
-            naming::address&& addr, naming::id_type const& gid, Ts&&... vs)
+            naming::address&& addr, hpx::id_type const& gid, Ts&&... vs)
         {
             return apply_r_p<Action>(HPX_MOVE(addr), gid,
                 actions::action_priority<Action>(), HPX_FORWARD(Ts, vs)...);
@@ -172,7 +171,7 @@ namespace hpx {
 
         // We know it is local and has to be directly executed.
         template <typename Action, typename... Ts>
-        inline bool apply_l_p(naming::id_type const& target,
+        inline bool apply_l_p(hpx::id_type const& target,
             naming::address&& addr, threads::thread_priority priority,
             Ts&&... vs)
         {
@@ -201,7 +200,7 @@ namespace hpx {
 
         // same as above, but taking all arguments by value
         template <typename Action, typename... Ts>
-        inline bool apply_l_p_val(naming::id_type const& target,
+        inline bool apply_l_p_val(hpx::id_type const& target,
             naming::address&& addr, threads::thread_priority priority, Ts... vs)
         {
             typedef
@@ -229,7 +228,7 @@ namespace hpx {
 
         template <typename Action, typename... Ts>
         inline bool apply_l(
-            naming::id_type const& target, naming::address&& addr, Ts&&... vs)
+            hpx::id_type const& target, naming::address&& addr, Ts&&... vs)
         {
             return apply_l_p<Action>(target, HPX_MOVE(addr),
                 actions::action_priority<Action>(), HPX_FORWARD(Ts, vs)...);
@@ -238,8 +237,8 @@ namespace hpx {
 
     ///////////////////////////////////////////////////////////////////////////
     template <typename Action, typename... Ts>
-    inline bool apply_p(naming::id_type const& id,
-        threads::thread_priority priority, Ts&&... vs)
+    inline bool apply_p(
+        hpx::id_type const& id, threads::thread_priority priority, Ts&&... vs)
     {
         return hpx::detail::apply_impl<Action>(
             id, priority, HPX_FORWARD(Ts, vs)...);
@@ -279,7 +278,7 @@ namespace hpx {
                 typename... Ts>
             HPX_FORCEINLINE static bool call(
                 hpx::actions::basic_action<Component, Signature, Derived>,
-                naming::id_type const& id, Ts&&... ts)
+                hpx::id_type const& id, Ts&&... ts)
             {
                 return apply_p<Derived>(id, actions::action_priority<Derived>(),
                     HPX_FORWARD(Ts, ts)...);
@@ -320,7 +319,7 @@ namespace hpx {
     }    // namespace detail
 
     template <typename Action, typename... Ts>
-    inline bool apply(naming::id_type const& id, Ts&&... vs)
+    inline bool apply(hpx::id_type const& id, Ts&&... vs)
     {
         return apply_p<Action>(
             id, actions::action_priority<Action>(), HPX_FORWARD(Ts, vs)...);
@@ -356,7 +355,7 @@ namespace hpx {
 #if defined(HPX_HAVE_NETWORKING)
         template <typename Action, typename Continuation, typename... Ts>
         inline bool apply_r_p(naming::address&& addr, Continuation&& c,
-            naming::id_type const& id, threads::thread_priority priority,
+            hpx::id_type const& id, threads::thread_priority priority,
             Ts&&... vs)
         {
             // If remote, create a new parcel to be sent to the destination
@@ -369,7 +368,7 @@ namespace hpx {
         inline typename std::enable_if<
             traits::is_continuation<Continuation>::value, bool>::type
         apply_r(naming::address&& addr, Continuation&& c,
-            naming::id_type const& gid, Ts&&... vs)
+            hpx::id_type const& gid, Ts&&... vs)
         {
             return apply_r_p<Action>(HPX_MOVE(addr),
                 HPX_FORWARD(Continuation, c), gid,
@@ -378,7 +377,7 @@ namespace hpx {
 
         template <typename Action>
         inline bool apply_r_sync_p(naming::address&& addr,
-            naming::id_type const& id, threads::thread_priority priority)
+            hpx::id_type const& id, threads::thread_priority priority)
         {
             typedef
                 typename hpx::traits::extract_action<Action>::type action_type_;
@@ -386,7 +385,8 @@ namespace hpx {
             // If remote, create a new parcel to be sent to the destination
             // Create a new parcel with the gid, action, and arguments
             // Send the parcel through the parcel handler
-            HPX_ASSERT(id.get_management_type() == naming::id_type::unmanaged);
+            HPX_ASSERT(id.get_management_type() ==
+                hpx::id_type::management_type::unmanaged);
             naming::gid_type gid = id.get_gid();
             parcelset::parcel p = parcelset::detail::create_parcel::call(
                 HPX_MOVE(gid), complement_addr<action_type_>(addr),
@@ -403,7 +403,7 @@ namespace hpx {
 
         template <typename Action>
         inline bool apply_r_sync(
-            naming::address&& addr, naming::id_type const& gid)
+            naming::address&& addr, hpx::id_type const& gid)
         {
             return apply_r_sync_p<Action>(
                 HPX_MOVE(addr), gid, actions::action_priority<Action>());
@@ -412,9 +412,9 @@ namespace hpx {
 
         // We know it is local and has to be directly executed.
         template <typename Action, typename Continuation, typename... Ts>
-        inline bool apply_l_p(Continuation&& cont,
-            naming::id_type const& target, naming::address&& addr,
-            threads::thread_priority priority, Ts&&... vs)
+        inline bool apply_l_p(Continuation&& cont, hpx::id_type const& target,
+            naming::address&& addr, threads::thread_priority priority,
+            Ts&&... vs)
         {
             typedef
                 typename hpx::traits::extract_action<Action>::type action_type;
@@ -443,7 +443,7 @@ namespace hpx {
         template <typename Action, typename Continuation, typename... Ts>
         inline typename std::enable_if<
             traits::is_continuation<Continuation>::value, bool>::type
-        apply_l(Continuation&& c, naming::id_type const& target,
+        apply_l(Continuation&& c, hpx::id_type const& target,
             naming::address& addr, Ts&&... vs)
         {
             return apply_l_p<Action>(HPX_FORWARD(Continuation, c), target,
@@ -456,7 +456,7 @@ namespace hpx {
     template <typename Action, typename Continuation, typename... Ts>
     inline typename std::enable_if<traits::is_continuation<Continuation>::value,
         bool>::type
-    apply_p(Continuation&& c, naming::id_type const& gid,
+    apply_p(Continuation&& c, hpx::id_type const& gid,
         threads::thread_priority priority, Ts&&... vs)
     {
         return hpx::detail::apply_impl<Action>(HPX_FORWARD(Continuation, c),
@@ -505,7 +505,7 @@ namespace hpx {
                 typename... Ts>
             HPX_FORCEINLINE static bool call(Continuation&& c,
                 hpx::actions::basic_action<Component, Signature, Derived>,
-                naming::id_type const& id, Ts&&... ts)
+                hpx::id_type const& id, Ts&&... ts)
             {
                 return apply_p<Derived>(HPX_FORWARD(Continuation, c), id,
                     actions::action_priority<Derived>(),
@@ -551,7 +551,7 @@ namespace hpx {
     template <typename Action, typename Continuation, typename... Ts>
     inline typename std::enable_if<traits::is_continuation<Continuation>::value,
         bool>::type
-    apply(Continuation&& c, naming::id_type const& gid, Ts&&... vs)
+    apply(Continuation&& c, hpx::id_type const& gid, Ts&&... vs)
     {
         return apply_p<Action>(HPX_FORWARD(Continuation, c), gid,
             actions::action_priority<Action>(), HPX_FORWARD(Ts, vs)...);
@@ -593,7 +593,7 @@ namespace hpx {
     namespace applier { namespace detail {
         template <typename Action, typename... Ts>
         inline bool apply_c_p(naming::address&& addr,
-            naming::id_type const& contgid, naming::id_type const& gid,
+            hpx::id_type const& contgid, hpx::id_type const& gid,
             threads::thread_priority priority, Ts&&... vs)
         {
             typedef
@@ -610,9 +610,8 @@ namespace hpx {
         }
 
         template <typename Action, typename... Ts>
-        inline bool apply_c(naming::address&& addr,
-            naming::id_type const& contgid, naming::id_type const& gid,
-            Ts&&... vs)
+        inline bool apply_c(naming::address&& addr, hpx::id_type const& contgid,
+            hpx::id_type const& gid, Ts&&... vs)
         {
             typedef
                 typename hpx::traits::extract_action<Action>::local_result_type
@@ -632,9 +631,8 @@ namespace hpx {
 
     ///////////////////////////////////////////////////////////////////////////
     template <typename Action, typename... Ts>
-    inline bool apply_c_p(naming::id_type const& contgid,
-        naming::id_type const& gid, threads::thread_priority priority,
-        Ts&&... vs)
+    inline bool apply_c_p(hpx::id_type const& contgid, hpx::id_type const& gid,
+        threads::thread_priority priority, Ts&&... vs)
     {
         typedef typename hpx::traits::extract_action<Action>::local_result_type
             local_result_type;
@@ -649,7 +647,7 @@ namespace hpx {
 
     template <typename Action, typename... Ts>
     inline bool apply_c(
-        naming::id_type const& contgid, naming::id_type const& gid, Ts&&... vs)
+        hpx::id_type const& contgid, hpx::id_type const& gid, Ts&&... vs)
     {
         typedef typename hpx::traits::extract_action<Action>::local_result_type
             local_result_type;
@@ -666,7 +664,7 @@ namespace hpx {
         typename... Ts>
     inline bool apply_c(
         hpx::actions::basic_action<Component, Signature, Derived> /*act*/,
-        naming::id_type const& contgid, naming::id_type const& gid, Ts&&... vs)
+        hpx::id_type const& contgid, hpx::id_type const& gid, Ts&&... vs)
     {
         typedef typename hpx::traits::extract_action<Derived>::local_result_type
             local_result_type;

--- a/libs/full/async_distributed/include/hpx/async_distributed/applier/apply_callback.hpp
+++ b/libs/full/async_distributed/include/hpx/async_distributed/applier/apply_callback.hpp
@@ -29,9 +29,8 @@ namespace hpx {
     ///////////////////////////////////////////////////////////////////////////
     namespace applier { namespace detail {
         template <typename Action, typename Callback, typename... Ts>
-        inline bool apply_r_p_cb(naming::address&& addr,
-            naming::id_type const& id, threads::thread_priority priority,
-            Callback&& cb, Ts&&... vs)
+        inline bool apply_r_p_cb(naming::address&& addr, hpx::id_type const& id,
+            threads::thread_priority priority, Callback&& cb, Ts&&... vs)
         {
             // If remote, create a new parcel to be sent to the destination
             // Create a new parcel with the gid, action, and arguments
@@ -40,8 +39,8 @@ namespace hpx {
         }
 
         template <typename Action, typename Callback, typename... Ts>
-        inline bool apply_r_cb(naming::address&& addr,
-            naming::id_type const& gid, Callback&& cb, Ts&&... vs)
+        inline bool apply_r_cb(naming::address&& addr, hpx::id_type const& gid,
+            Callback&& cb, Ts&&... vs)
         {
             return apply_r_p_cb<Action>(HPX_MOVE(addr), gid,
                 actions::action_priority<Action>(), HPX_FORWARD(Callback, cb),
@@ -52,7 +51,7 @@ namespace hpx {
 
     ///////////////////////////////////////////////////////////////////////////
     template <typename Action, typename Callback, typename... Ts>
-    inline bool apply_p_cb(naming::id_type const& gid,
+    inline bool apply_p_cb(hpx::id_type const& gid,
         threads::thread_priority priority, Callback&& cb, Ts&&... vs)
     {
         return hpx::detail::apply_cb_impl<Action>(
@@ -60,7 +59,7 @@ namespace hpx {
     }
 
     template <typename Action, typename Callback, typename... Ts>
-    inline bool apply_cb(naming::id_type const& gid, Callback&& cb, Ts&&... vs)
+    inline bool apply_cb(hpx::id_type const& gid, Callback&& cb, Ts&&... vs)
     {
         return apply_p_cb<Action>(gid, actions::action_priority<Action>(),
             HPX_FORWARD(Callback, cb), HPX_FORWARD(Ts, vs)...);
@@ -70,7 +69,7 @@ namespace hpx {
         typename Callback, typename... Ts>
     inline bool apply_cb(
         hpx::actions::basic_action<Component, Signature, Derived> /*act*/,
-        naming::id_type const& gid, Callback&& cb, Ts&&... vs)
+        hpx::id_type const& gid, Callback&& cb, Ts&&... vs)
     {
         return apply_p_cb<Derived>(gid, actions::action_priority<Derived>(),
             HPX_FORWARD(Callback, cb), HPX_FORWARD(Ts, vs)...);
@@ -114,7 +113,7 @@ namespace hpx {
         template <typename Action, typename Continuation, typename Callback,
             typename... Ts>
         inline bool apply_r_p_cb(naming::address&& addr, Continuation&& c,
-            naming::id_type const& id, threads::thread_priority priority,
+            hpx::id_type const& id, threads::thread_priority priority,
             Callback&& cb, Ts&&... vs)
         {
             // If remote, create a new parcel to be sent to the destination
@@ -127,7 +126,7 @@ namespace hpx {
         template <typename Action, typename Continuation, typename Callback,
             typename... Ts>
         inline bool apply_r_cb(naming::address&& addr, Continuation&& c,
-            naming::id_type const& gid, Callback&& cb, Ts&&... vs)
+            hpx::id_type const& gid, Callback&& cb, Ts&&... vs)
         {
             return apply_r_p_cb<Action>(HPX_MOVE(addr),
                 HPX_FORWARD(Continuation, c), gid,
@@ -141,7 +140,7 @@ namespace hpx {
     template <typename Action, typename Continuation, typename Callback,
         typename... Ts>
     inline bool apply_p_cb(Continuation&& c, naming::address&& addr,
-        naming::id_type const& gid, threads::thread_priority priority,
+        hpx::id_type const& gid, threads::thread_priority priority,
         Callback&& cb, Ts&&... vs)
     {
         if (!traits::action_is_target_valid<Action>::call(gid))
@@ -183,7 +182,7 @@ namespace hpx {
 
     template <typename Action, typename Continuation, typename Callback,
         typename... Ts>
-    inline bool apply_p_cb(Continuation&& c, naming::id_type const& gid,
+    inline bool apply_p_cb(Continuation&& c, hpx::id_type const& gid,
         threads::thread_priority priority, Callback&& cb, Ts&&... vs)
     {
         return hpx::detail::apply_cb_impl<Action>(HPX_FORWARD(Continuation, c),
@@ -193,7 +192,7 @@ namespace hpx {
     template <typename Action, typename Continuation, typename Callback,
         typename... Ts>
     inline bool apply_cb(
-        Continuation&& c, naming::id_type const& gid, Callback&& cb, Ts&&... vs)
+        Continuation&& c, hpx::id_type const& gid, Callback&& cb, Ts&&... vs)
     {
         return apply_p_cb<Action>(HPX_FORWARD(Continuation, c), gid,
             actions::action_priority<Action>(), HPX_FORWARD(Callback, cb),
@@ -204,7 +203,7 @@ namespace hpx {
         typename Derived, typename Callback, typename... Ts>
     inline bool apply_cb(Continuation&& c,
         hpx::actions::basic_action<Component, Signature, Derived> /*act*/,
-        naming::id_type const& gid, Callback&& cb, Ts&&... vs)
+        hpx::id_type const& gid, Callback&& cb, Ts&&... vs)
     {
         return apply_p<Derived>(HPX_FORWARD(Continuation, c), gid,
             actions::action_priority<Derived>(), HPX_FORWARD(Callback, cb),
@@ -257,7 +256,7 @@ namespace hpx {
     namespace applier { namespace detail {
         template <typename Action, typename Callback, typename... Ts>
         inline bool apply_c_p_cb(naming::address&& addr,
-            naming::id_type const& contgid, naming::id_type const& gid,
+            hpx::id_type const& contgid, hpx::id_type const& gid,
             threads::thread_priority priority, Callback&& cb, Ts&&... vs)
         {
             typedef
@@ -276,8 +275,8 @@ namespace hpx {
 
         template <typename Action, typename Callback, typename... Ts>
         inline bool apply_c_cb(naming::address&& addr,
-            naming::id_type const& contgid, naming::id_type const& gid,
-            Callback&& cb, Ts&&... vs)
+            hpx::id_type const& contgid, hpx::id_type const& gid, Callback&& cb,
+            Ts&&... vs)
         {
             typedef
                 typename hpx::traits::extract_action<Action>::remote_result_type
@@ -297,8 +296,8 @@ namespace hpx {
 
     ///////////////////////////////////////////////////////////////////////////
     template <typename Action, typename Callback, typename... Ts>
-    inline bool apply_c_p_cb(naming::id_type const& contgid,
-        naming::id_type const& gid, threads::thread_priority priority,
+    inline bool apply_c_p_cb(hpx::id_type const& contgid,
+        hpx::id_type const& gid, threads::thread_priority priority,
         Callback&& cb, Ts&&... vs)
     {
         typedef typename hpx::traits::extract_action<Action>::remote_result_type
@@ -313,8 +312,8 @@ namespace hpx {
     }
 
     template <typename Action, typename Callback, typename... Ts>
-    inline bool apply_c_cb(naming::id_type const& contgid,
-        naming::id_type const& gid, Callback&& cb, Ts&&... vs)
+    inline bool apply_c_cb(hpx::id_type const& contgid, hpx::id_type const& gid,
+        Callback&& cb, Ts&&... vs)
     {
         typedef typename hpx::traits::extract_action<Action>::remote_result_type
             remote_result_type;
@@ -329,8 +328,8 @@ namespace hpx {
     }
 
     template <typename Action, typename Callback, typename... Ts>
-    inline bool apply_c_p_cb(naming::id_type const& contgid,
-        naming::address&& addr, naming::id_type const& gid,
+    inline bool apply_c_p_cb(hpx::id_type const& contgid,
+        naming::address&& addr, hpx::id_type const& gid,
         threads::thread_priority priority, Callback&& cb, Ts&&... vs)
     {
         typedef typename hpx::traits::extract_action<Action>::remote_result_type
@@ -346,9 +345,8 @@ namespace hpx {
     }
 
     template <typename Action, typename Callback, typename... Ts>
-    inline bool apply_c_cb(naming::id_type const& contgid,
-        naming::address&& addr, naming::id_type const& gid, Callback&& cb,
-        Ts&&... vs)
+    inline bool apply_c_cb(hpx::id_type const& contgid, naming::address&& addr,
+        hpx::id_type const& gid, Callback&& cb, Ts&&... vs)
     {
         typedef typename hpx::traits::extract_action<Action>::remote_result_type
             remote_result_type;
@@ -370,8 +368,8 @@ namespace hpx {
             typedef hpx::tuple<Ts...> tuple_type;
 
             template <typename... Ts_>
-            apply_c_p_cb_impl(naming::id_type const& contid,
-                naming::address&& addr, naming::id_type const& id,
+            apply_c_p_cb_impl(hpx::id_type const& contid,
+                naming::address&& addr, hpx::id_type const& id,
                 threads::thread_priority p, Callback&& cb, Ts_&&... vs)
               : contid_(contid)
               , addr_(HPX_MOVE(addr))
@@ -427,9 +425,9 @@ namespace hpx {
             }
 
         private:
-            naming::id_type contid_;
+            hpx::id_type contid_;
             naming::address addr_;
-            naming::id_type id_;
+            hpx::id_type id_;
             threads::thread_priority p_;
             Callback cb_;
             tuple_type args_;
@@ -438,9 +436,9 @@ namespace hpx {
         template <typename Action, typename Callback, typename... Ts>
         apply_c_p_cb_impl<Action, typename std::decay<Callback>::type,
             typename std::decay<Ts>::type...>
-        apply_c_p_cb(naming::id_type const& contid, naming::address&& addr,
-            naming::id_type const& id, threads::thread_priority p,
-            Callback&& cb, Ts&&... vs)
+        apply_c_p_cb(hpx::id_type const& contid, naming::address&& addr,
+            hpx::id_type const& id, threads::thread_priority p, Callback&& cb,
+            Ts&&... vs)
         {
             typedef apply_c_p_cb_impl<Action,
                 typename std::decay<Callback>::type,

--- a/libs/full/async_distributed/include/hpx/async_distributed/applier/apply_continue_fwd.hpp
+++ b/libs/full/async_distributed/include/hpx/async_distributed/applier/apply_continue_fwd.hpp
@@ -12,22 +12,22 @@
 ///////////////////////////////////////////////////////////////////////////////
 namespace hpx {
     template <typename Action, typename Cont, typename... Ts>
-    bool apply_continue(Cont&& cont, naming::id_type const& gid, Ts&&... vs);
+    bool apply_continue(Cont&& cont, hpx::id_type const& gid, Ts&&... vs);
 
     template <typename Component, typename Signature, typename Derived,
         typename Cont, typename... Ts>
     bool apply_continue(
         hpx::actions::basic_action<Component, Signature, Derived> /*act*/,
-        Cont&& cont, naming::id_type const& gid, Ts&&... vs);
+        Cont&& cont, hpx::id_type const& gid, Ts&&... vs);
 
     ///////////////////////////////////////////////////////////////////////////
     template <typename Action, typename... Ts>
     bool apply_continue(
-        naming::id_type const& cont, naming::id_type const& gid, Ts&&... vs);
+        hpx::id_type const& cont, hpx::id_type const& gid, Ts&&... vs);
 
     template <typename Component, typename Signature, typename Derived,
         typename... Ts>
     bool apply_continue(
         hpx::actions::basic_action<Component, Signature, Derived> /*act*/,
-        naming::id_type const& cont, naming::id_type const& gid, Ts&&... vs);
+        hpx::id_type const& cont, hpx::id_type const& gid, Ts&&... vs);
 }    // namespace hpx

--- a/libs/full/async_distributed/include/hpx/async_distributed/applier/detail/apply_implementations_fwd.hpp
+++ b/libs/full/async_distributed/include/hpx/async_distributed/applier/detail/apply_implementations_fwd.hpp
@@ -17,30 +17,29 @@
 namespace hpx { namespace applier { namespace detail {
     // forward declaration only
     template <typename Action, typename Continuation, typename... Ts>
-    inline bool apply_l_p(Continuation&& c, naming::id_type const& target,
+    inline bool apply_l_p(Continuation&& c, hpx::id_type const& target,
         naming::address&& addr, threads::thread_priority priority, Ts&&... vs);
 
     template <typename Action, typename... Ts>
-    inline bool apply_l_p(naming::id_type const& target, naming::address&& addr,
+    inline bool apply_l_p(hpx::id_type const& target, naming::address&& addr,
         threads::thread_priority priority, Ts&&... vs);
 
     template <typename Action, typename Continuation, typename... Ts>
     inline bool apply_r_p(naming::address&& addr, Continuation&& c,
-        naming::id_type const& id, threads::thread_priority priority,
-        Ts&&... vs);
+        hpx::id_type const& id, threads::thread_priority priority, Ts&&... vs);
 
     template <typename Action, typename... Ts>
-    inline bool apply_r_p(naming::address&& addr, naming::id_type const& id,
+    inline bool apply_r_p(naming::address&& addr, hpx::id_type const& id,
         threads::thread_priority priority, Ts&&... vs);
 
     template <typename Action, typename Continuation, typename Callback,
         typename... Ts>
     inline bool apply_r_p_cb(naming::address&& addr, Continuation&& c,
-        naming::id_type const& id, threads::thread_priority priority,
+        hpx::id_type const& id, threads::thread_priority priority,
         Callback&& cb, Ts&&... vs);
 
     template <typename Action, typename Callback, typename... Ts>
-    inline bool apply_r_p_cb(naming::address&& addr, naming::id_type const& id,
+    inline bool apply_r_p_cb(naming::address&& addr, hpx::id_type const& id,
         threads::thread_priority priority, Callback&& cb, Ts&&... vs);
 }}}    // namespace hpx::applier::detail
 

--- a/libs/full/async_distributed/include/hpx/async_distributed/applier/trigger.hpp
+++ b/libs/full/async_distributed/include/hpx/async_distributed/applier/trigger.hpp
@@ -18,23 +18,23 @@
 namespace hpx { namespace applier {
 
     template <typename Arg0>
-    inline void trigger(naming::id_type const& k, Arg0&& arg0)
+    inline void trigger(hpx::id_type const& k, Arg0&& arg0)
     {
         set_lco_value(k, HPX_FORWARD(Arg0, arg0));
     }
 
-    inline void trigger(naming::id_type const& k)
+    inline void trigger(hpx::id_type const& k)
     {
         trigger_lco_event(k);
     }
 
     inline void trigger_error(
-        naming::id_type const& k, std::exception_ptr const& e)
+        hpx::id_type const& k, std::exception_ptr const& e)
     {
         set_lco_error(k, e);
     }
 
-    inline void trigger_error(naming::id_type const& k, std::exception_ptr&& e)
+    inline void trigger_error(hpx::id_type const& k, std::exception_ptr&& e)
     {
         set_lco_error(k, e);
     }

--- a/libs/full/async_distributed/include/hpx/async_distributed/async.hpp
+++ b/libs/full/async_distributed/include/hpx/async_distributed/async.hpp
@@ -66,7 +66,7 @@ namespace hpx { namespace detail {
         HPX_FORCEINLINE static hpx::future<
             typename traits::promise_local_result<typename hpx::traits::
                     extract_action<Action>::remote_result_type>::type>
-        call(Policy_&& launch_policy, naming::id_type const& id, Ts&&... ts)
+        call(Policy_&& launch_policy, hpx::id_type const& id, Ts&&... ts)
         {
             return hpx::detail::async_impl<Action>(
                 HPX_FORWARD(Policy_, launch_policy), id,
@@ -115,15 +115,15 @@ namespace hpx { namespace detail {
         }
     };
 
-    // naming::id_type
+    // hpx::id_type
     template <typename Action>
-    struct async_action_dispatch<Action, naming::id_type>
+    struct async_action_dispatch<Action, hpx::id_type>
     {
         template <typename... Ts>
         HPX_FORCEINLINE static hpx::future<
             typename traits::promise_local_result<typename hpx::traits::
                     extract_action<Action>::remote_result_type>::type>
-        call(naming::id_type const& id, Ts&&... ts)
+        call(hpx::id_type const& id, Ts&&... ts)
         {
             return async_action_dispatch<Action,
                 hpx::detail::async_policy>::call(launch::async, id,
@@ -215,7 +215,7 @@ namespace hpx { namespace detail {
             typename traits::promise_local_result<typename hpx::traits::
                     extract_action<Derived>::remote_result_type>::type>
         call(hpx::actions::basic_action<Component, Signature, Derived> const&,
-            naming::id_type const& id, Ts&&... vs)
+            hpx::id_type const& id, Ts&&... vs)
         {
             return async<Derived>(launch::async, id, HPX_FORWARD(Ts, vs)...);
         }

--- a/libs/full/async_distributed/include/hpx/async_distributed/async_callback.hpp
+++ b/libs/full/async_distributed/include/hpx/async_distributed/async_callback.hpp
@@ -35,7 +35,7 @@ namespace hpx { namespace detail {
         HPX_FORCEINLINE static hpx::future<
             typename traits::promise_local_result<typename traits::
                     extract_action<Action>::remote_result_type>::type>
-        call(Policy_&& launch_policy, naming::id_type const& id, Callback&& cb,
+        call(Policy_&& launch_policy, hpx::id_type const& id, Callback&& cb,
             Ts&&... ts)
         {
             return hpx::detail::async_cb_impl<Action>(
@@ -80,15 +80,15 @@ namespace hpx { namespace detail {
         }
     };
 
-    // naming::id_type
+    // hpx::id_type
     template <typename Action>
-    struct async_cb_action_dispatch<Action, naming::id_type>
+    struct async_cb_action_dispatch<Action, hpx::id_type>
     {
         template <typename Callback, typename... Ts>
         HPX_FORCEINLINE static hpx::future<
             typename traits::promise_local_result<typename traits::
                     extract_action<Action>::remote_result_type>::type>
-        call(naming::id_type const& id, Callback&& cb, Ts&&... ts)
+        call(hpx::id_type const& id, Callback&& cb, Ts&&... ts)
         {
             return async_cb_action_dispatch<Action,
                 hpx::detail::async_policy>::call(launch::async, id,
@@ -167,7 +167,7 @@ namespace hpx { namespace detail {
             typename traits::promise_local_result<typename traits::
                     extract_action<Derived>::remote_result_type>::type>
         call(hpx::actions::basic_action<Component, Signature, Derived> const&,
-            naming::id_type const& id, Callback&& cb, Ts&&... ts)
+            hpx::id_type const& id, Callback&& cb, Ts&&... ts)
         {
             return async_cb<Derived>(
                 id, HPX_FORWARD(Callback, cb), HPX_FORWARD(Ts, ts)...);
@@ -217,7 +217,7 @@ namespace hpx { namespace detail {
                     extract_action<Derived>::remote_result_type>::type>
         call(Policy_&& launch_policy,
             hpx::actions::basic_action<Component, Signature, Derived> const&,
-            naming::id_type const& id, Callback&& cb, Ts&&... ts)
+            hpx::id_type const& id, Callback&& cb, Ts&&... ts)
         {
             return async_cb<Derived>(HPX_FORWARD(Policy_, launch_policy), id,
                 HPX_FORWARD(Callback, cb), HPX_FORWARD(Ts, ts)...);

--- a/libs/full/async_distributed/include/hpx/async_distributed/async_continue.hpp
+++ b/libs/full/async_distributed/include/hpx/async_distributed/async_continue.hpp
@@ -55,7 +55,7 @@ namespace hpx {
     template <typename Action, typename Cont, typename... Ts>
     hpx::future<typename traits::promise_local_result<
         typename detail::result_of_async_continue<Action, Cont>::type>::type>
-    async_continue(Cont&& cont, naming::id_type const& gid, Ts&&... vs)
+    async_continue(Cont&& cont, hpx::id_type const& gid, Ts&&... vs)
     {
         typedef typename traits::promise_remote_result<
             typename detail::result_of_async_continue<Action, Cont>::type>::type
@@ -72,7 +72,7 @@ namespace hpx {
     async_continue(
         hpx::actions::basic_action<Component, Signature, Derived> /*act*/
         ,
-        Cont&& cont, naming::id_type const& gid, Ts&&... vs)
+        Cont&& cont, hpx::id_type const& gid, Ts&&... vs)
     {
         return async_continue<Derived>(
             HPX_FORWARD(Cont, cont), gid, HPX_FORWARD(Ts, vs)...);

--- a/libs/full/async_distributed/include/hpx/async_distributed/async_continue_callback.hpp
+++ b/libs/full/async_distributed/include/hpx/async_distributed/async_continue_callback.hpp
@@ -54,7 +54,7 @@ namespace hpx {
     hpx::future<typename traits::promise_local_result<
         typename detail::result_of_async_continue<Action, Cont>::type>::type>
     async_continue_cb(
-        Cont&& cont, naming::id_type const& gid, Callback&& cb, Ts&&... vs)
+        Cont&& cont, hpx::id_type const& gid, Callback&& cb, Ts&&... vs)
     {
         typedef typename traits::promise_remote_result<
             typename detail::result_of_async_continue<Action, Cont>::type>::type
@@ -70,9 +70,8 @@ namespace hpx {
     hpx::future<typename traits::promise_local_result<
         typename detail::result_of_async_continue<Derived, Cont>::type>::type>
     async_continue_cb(
-        hpx::actions::basic_action<Component, Signature, Derived> /*act*/
-        ,
-        Cont&& cont, naming::id_type const& gid, Callback&& cb, Ts&&... vs)
+        hpx::actions::basic_action<Component, Signature, Derived> /*act*/,
+        Cont&& cont, hpx::id_type const& gid, Callback&& cb, Ts&&... vs)
     {
         return async_continue_cb<Derived>(HPX_FORWARD(Cont, cont), gid,
             HPX_FORWARD(Callback, cb), HPX_FORWARD(Ts, vs)...);
@@ -102,8 +101,7 @@ namespace hpx {
         hpx::future<typename traits::promise_local_result<typename detail::
                 result_of_async_continue<Derived, Cont>::type>::type>>::type
     async_continue_cb(
-        hpx::actions::basic_action<Component, Signature, Derived> /*act*/
-        ,
+        hpx::actions::basic_action<Component, Signature, Derived> /*act*/,
         Cont&& cont, DistPolicy const& policy, Callback&& cb, Ts&&... vs)
     {
         return async_continue_cb<Derived>(HPX_FORWARD(Cont, cont), policy,

--- a/libs/full/async_distributed/include/hpx/async_distributed/async_continue_callback_fwd.hpp
+++ b/libs/full/async_distributed/include/hpx/async_distributed/async_continue_callback_fwd.hpp
@@ -30,16 +30,15 @@ namespace hpx {
     hpx::future<typename traits::promise_local_result<
         typename detail::result_of_async_continue<Action, Cont>::type>::type>
     async_continue_cb(
-        Cont&& cont, naming::id_type const& gid, Callback&& cb, Ts&&... vs);
+        Cont&& cont, hpx::id_type const& gid, Callback&& cb, Ts&&... vs);
 
     template <typename Component, typename Signature, typename Derived,
         typename Cont, typename Callback, typename... Ts>
     hpx::future<typename traits::promise_local_result<
         typename detail::result_of_async_continue<Derived, Cont>::type>::type>
     async_continue_cb(
-        hpx::actions::basic_action<Component, Signature, Derived> /*act*/
-        ,
-        Cont&& cont, naming::id_type const& gid, Callback&& cb, Ts&&... vs);
+        hpx::actions::basic_action<Component, Signature, Derived> /*act*/,
+        Cont&& cont, hpx::id_type const& gid, Callback&& cb, Ts&&... vs);
 
     ///////////////////////////////////////////////////////////////////////////
     // MSVC complains about ambiguities if it sees this forward declaration

--- a/libs/full/async_distributed/include/hpx/async_distributed/async_continue_fwd.hpp
+++ b/libs/full/async_distributed/include/hpx/async_distributed/async_continue_fwd.hpp
@@ -26,7 +26,7 @@ namespace hpx {
         template <typename Action, typename Cont>
         struct result_of_async_continue
           : traits::action_remote_result<typename util::invoke_result<
-                typename std::decay<Cont>::type, naming::id_type,
+                typename std::decay<Cont>::type, hpx::id_type,
                 typename hpx::traits::extract_action<
                     Action>::remote_result_type>::type>
         {
@@ -43,7 +43,7 @@ namespace hpx {
     template <typename Action, typename Cont, typename... Ts>
     hpx::future<typename traits::promise_local_result<
         typename detail::result_of_async_continue<Action, Cont>::type>::type>
-    async_continue(Cont&& cont, naming::id_type const& gid, Ts&&... vs);
+    async_continue(Cont&& cont, hpx::id_type const& gid, Ts&&... vs);
 
     template <typename Component, typename Signature, typename Derived,
         typename Cont, typename... Ts>
@@ -52,7 +52,7 @@ namespace hpx {
     async_continue(
         hpx::actions::basic_action<Component, Signature, Derived> /*act*/
         ,
-        Cont&& cont, naming::id_type const& gid, Ts&&... vs);
+        Cont&& cont, hpx::id_type const& gid, Ts&&... vs);
 
     ///////////////////////////////////////////////////////////////////////////
     // MSVC complains about ambiguities if it sees this forward declaration

--- a/libs/full/async_distributed/include/hpx/async_distributed/base_lco.hpp
+++ b/libs/full/async_distributed/include/hpx/async_distributed/base_lco.hpp
@@ -34,10 +34,10 @@ namespace hpx { namespace lcos {
         virtual void set_exception(std::exception_ptr const& e);
 
         // noop by default
-        virtual void connect(naming::id_type const&);
+        virtual void connect(hpx::id_type const&);
 
         // noop by default
-        virtual void disconnect(naming::id_type const&);
+        virtual void disconnect(hpx::id_type const&);
 
         // components must contain a typedef for wrapping_type defining the
         // managed_component type used to encapsulate instances of this
@@ -77,7 +77,7 @@ namespace hpx { namespace lcos {
         /// overloaded by the derived concrete LCO.
         ///
         /// \param id [in] target id
-        void connect_nonvirt(naming::id_type const& id);
+        void connect_nonvirt(hpx::id_type const& id);
 
         /// The \a function disconnect_nonvirt is called whenever a
         /// \a disconnect_action is applied on a instance of a LCO. This function
@@ -85,7 +85,7 @@ namespace hpx { namespace lcos {
         /// overloaded by the derived concrete LCO.
         ///
         /// \param id [in] target id
-        void disconnect_nonvirt(naming::id_type const& id);
+        void disconnect_nonvirt(hpx::id_type const& id);
 
     public:
         /// Each of the exposed functions needs to be encapsulated into an action

--- a/libs/full/async_distributed/include/hpx/async_distributed/base_lco_with_value.hpp
+++ b/libs/full/async_distributed/include/hpx/async_distributed/base_lco_with_value.hpp
@@ -428,13 +428,12 @@ HPX_REGISTER_BASE_LCO_WITH_VALUE_DECLARATION(hpx::naming::gid_type, gid_type)
 HPX_REGISTER_BASE_LCO_WITH_VALUE_DECLARATION(
     std::vector<hpx::naming::gid_type>, vector_gid_type)
 HPX_REGISTER_BASE_LCO_WITH_VALUE_DECLARATION(
-    hpx::naming::id_type, hpx::naming::gid_type, id_type)
-HPX_REGISTER_BASE_LCO_WITH_VALUE_DECLARATION(
-    hpx::naming::id_type, naming_id_type)
-HPX_REGISTER_BASE_LCO_WITH_VALUE_DECLARATION(std::vector<hpx::naming::id_type>,
+    hpx::id_type, hpx::naming::gid_type, id_type)
+HPX_REGISTER_BASE_LCO_WITH_VALUE_DECLARATION(hpx::id_type, naming_id_type)
+HPX_REGISTER_BASE_LCO_WITH_VALUE_DECLARATION(std::vector<hpx::id_type>,
     std::vector<hpx::naming::gid_type>, vector_id_gid_type)
 HPX_REGISTER_BASE_LCO_WITH_VALUE_DECLARATION(
-    std::vector<hpx::naming::id_type>, vector_id_type)
+    std::vector<hpx::id_type>, vector_id_type)
 HPX_REGISTER_BASE_LCO_WITH_VALUE_DECLARATION(
     hpx::util::unused_type, hpx_unused_type)
 HPX_REGISTER_BASE_LCO_WITH_VALUE_DECLARATION(float)

--- a/libs/full/async_distributed/include/hpx/async_distributed/bind_action.hpp
+++ b/libs/full/async_distributed/include/hpx/async_distributed/bind_action.hpp
@@ -79,7 +79,7 @@ namespace hpx {
 
             template <typename... Us>
             HPX_FORCEINLINE bool apply_c(
-                naming::id_type const& cont, Us&&... vs) const
+                hpx::id_type const& cont, Us&&... vs) const
             {
                 return hpx::apply_c<Action>(cont,
                     detail::bind_eval<Ts const&, sizeof...(Us)>::call(

--- a/libs/full/async_distributed/include/hpx/async_distributed/continuation.hpp
+++ b/libs/full/async_distributed/include/hpx/async_distributed/continuation.hpp
@@ -44,11 +44,11 @@ namespace hpx { namespace actions {
 
         continuation();
 
-        explicit continuation(naming::id_type const& id);
-        explicit continuation(naming::id_type&& id);
+        explicit continuation(hpx::id_type const& id);
+        explicit continuation(hpx::id_type&& id);
 
-        continuation(naming::id_type const& id, naming::address&& addr);
-        continuation(naming::id_type&& id, naming::address&& addr) noexcept;
+        continuation(hpx::id_type const& id, naming::address&& addr);
+        continuation(hpx::id_type&& id, naming::address&& addr) noexcept;
 
         continuation(continuation&& o) noexcept;
         continuation& operator=(continuation&& o) noexcept;
@@ -61,7 +61,7 @@ namespace hpx { namespace actions {
         void serialize(hpx::serialization::input_archive& ar, unsigned);
         void serialize(hpx::serialization::output_archive& ar, unsigned);
 
-        constexpr naming::id_type const& get_id() const noexcept
+        constexpr hpx::id_type const& get_id() const noexcept
         {
             return id_;
         }
@@ -72,7 +72,7 @@ namespace hpx { namespace actions {
         }
 
     protected:
-        naming::id_type id_;
+        hpx::id_type id_;
         naming::address addr_;
     };
 
@@ -82,58 +82,57 @@ namespace hpx { namespace actions {
     {
     private:
         using function_type =
-            hpx::distributed::move_only_function<void(naming::id_type, Result)>;
+            hpx::distributed::move_only_function<void(hpx::id_type, Result)>;
 
     public:
         using result_type = Result;
 
         typed_continuation() = default;
 
-        explicit typed_continuation(naming::id_type const& id)
+        explicit typed_continuation(hpx::id_type const& id)
           : continuation(id)
         {
         }
 
-        explicit typed_continuation(naming::id_type&& id) noexcept
+        explicit typed_continuation(hpx::id_type&& id) noexcept
           : continuation(HPX_MOVE(id))
         {
         }
 
         template <typename F>
-        typed_continuation(naming::id_type const& id, F&& f)
+        typed_continuation(hpx::id_type const& id, F&& f)
           : continuation(id)
           , f_(HPX_FORWARD(F, f))
         {
         }
 
         template <typename F>
-        typed_continuation(naming::id_type&& id, F&& f)
+        typed_continuation(hpx::id_type&& id, F&& f)
           : continuation(HPX_MOVE(id))
           , f_(HPX_FORWARD(F, f))
         {
         }
 
-        typed_continuation(naming::id_type const& id, naming::address&& addr)
+        typed_continuation(hpx::id_type const& id, naming::address&& addr)
           : continuation(id, HPX_MOVE(addr))
         {
         }
 
-        typed_continuation(
-            naming::id_type&& id, naming::address&& addr) noexcept
+        typed_continuation(hpx::id_type&& id, naming::address&& addr) noexcept
           : continuation(HPX_MOVE(id), HPX_MOVE(addr))
         {
         }
 
         template <typename F>
         typed_continuation(
-            naming::id_type const& id, naming::address&& addr, F&& f)
+            hpx::id_type const& id, naming::address&& addr, F&& f)
           : continuation(id, HPX_MOVE(addr))
           , f_(HPX_FORWARD(F, f))
         {
         }
 
         template <typename F>
-        typed_continuation(naming::id_type&& id, naming::address&& addr, F&& f)
+        typed_continuation(hpx::id_type&& id, naming::address&& addr, F&& f)
           : continuation(HPX_MOVE(id), HPX_MOVE(addr))
           , f_(HPX_FORWARD(F, f))
         {
@@ -202,53 +201,52 @@ namespace hpx { namespace actions {
     private:
         using base_type = typed_continuation<RemoteResult>;
         using function_type = hpx::distributed::move_only_function<void(
-            naming::id_type, RemoteResult)>;
+            hpx::id_type, RemoteResult)>;
 
     public:
         typed_continuation() = default;
 
-        explicit typed_continuation(naming::id_type const& id)
+        explicit typed_continuation(hpx::id_type const& id)
           : base_type(id)
         {
         }
 
-        explicit typed_continuation(naming::id_type&& id) noexcept
+        explicit typed_continuation(hpx::id_type&& id) noexcept
           : base_type(HPX_MOVE(id))
         {
         }
 
         template <typename F>
-        typed_continuation(naming::id_type const& id, F&& f)
+        typed_continuation(hpx::id_type const& id, F&& f)
           : base_type(id, HPX_FORWARD(F, f))
         {
         }
 
         template <typename F>
-        typed_continuation(naming::id_type&& id, F&& f)
+        typed_continuation(hpx::id_type&& id, F&& f)
           : base_type(HPX_MOVE(id), HPX_FORWARD(F, f))
         {
         }
 
-        typed_continuation(naming::id_type const& id, naming::address&& addr)
+        typed_continuation(hpx::id_type const& id, naming::address&& addr)
           : base_type(id, HPX_MOVE(addr))
         {
         }
 
-        typed_continuation(
-            naming::id_type&& id, naming::address&& addr) noexcept
+        typed_continuation(hpx::id_type&& id, naming::address&& addr) noexcept
           : base_type(HPX_MOVE(id), HPX_MOVE(addr))
         {
         }
 
         template <typename F>
         typed_continuation(
-            naming::id_type const& id, naming::address&& addr, F&& f)
+            hpx::id_type const& id, naming::address&& addr, F&& f)
           : base_type(id, HPX_MOVE(addr), HPX_FORWARD(F, f))
         {
         }
 
         template <typename F>
-        typed_continuation(naming::id_type&& id, naming::address&& addr, F&& f)
+        typed_continuation(hpx::id_type&& id, naming::address&& addr, F&& f)
           : base_type(HPX_MOVE(id), HPX_MOVE(addr), HPX_FORWARD(F, f))
         {
         }
@@ -309,58 +307,57 @@ namespace hpx { namespace actions {
     {
     private:
         using function_type =
-            hpx::distributed::move_only_function<void(naming::id_type)>;
+            hpx::distributed::move_only_function<void(hpx::id_type)>;
 
     public:
         using result_type = void;
 
         typed_continuation() = default;
 
-        explicit typed_continuation(naming::id_type const& id)
+        explicit typed_continuation(hpx::id_type const& id)
           : continuation(id)
         {
         }
 
-        explicit typed_continuation(naming::id_type&& id) noexcept
+        explicit typed_continuation(hpx::id_type&& id) noexcept
           : continuation(HPX_MOVE(id))
         {
         }
 
         template <typename F>
-        typed_continuation(naming::id_type const& id, F&& f)
+        typed_continuation(hpx::id_type const& id, F&& f)
           : continuation(id)
           , f_(HPX_FORWARD(F, f))
         {
         }
 
         template <typename F>
-        typed_continuation(naming::id_type&& id, F&& f)
+        typed_continuation(hpx::id_type&& id, F&& f)
           : continuation(HPX_MOVE(id))
           , f_(HPX_FORWARD(F, f))
         {
         }
 
-        typed_continuation(naming::id_type const& id, naming::address&& addr)
+        typed_continuation(hpx::id_type const& id, naming::address&& addr)
           : continuation(id, HPX_MOVE(addr))
         {
         }
 
-        typed_continuation(
-            naming::id_type&& id, naming::address&& addr) noexcept
+        typed_continuation(hpx::id_type&& id, naming::address&& addr) noexcept
           : continuation(HPX_MOVE(id), HPX_MOVE(addr))
         {
         }
 
         template <typename F>
         typed_continuation(
-            naming::id_type const& id, naming::address&& addr, F&& f)
+            hpx::id_type const& id, naming::address&& addr, F&& f)
           : continuation(id, HPX_MOVE(addr))
           , f_(HPX_FORWARD(F, f))
         {
         }
 
         template <typename F>
-        typed_continuation(naming::id_type&& id, naming::address&& addr, F&& f)
+        typed_continuation(hpx::id_type&& id, naming::address&& addr, F&& f)
           : continuation(HPX_MOVE(id), HPX_MOVE(addr))
           , f_(HPX_FORWARD(F, f))
         {

--- a/libs/full/async_distributed/include/hpx/async_distributed/dataflow.hpp
+++ b/libs/full/async_distributed/include/hpx/async_distributed/dataflow.hpp
@@ -62,9 +62,8 @@ namespace hpx { namespace lcos { namespace detail {
             typename Signature, typename Derived, typename... Ts>
         HPX_FORCEINLINE static decltype(auto) call(Allocator const& alloc,
             Policy_&& policy,
-            hpx::actions::basic_action<Component, Signature, Derived> const&
-            /* act */,
-            naming::id_type const& id, Ts&&... ts)
+            hpx::actions::basic_action<Component, Signature, Derived> const&,
+            hpx::id_type const& id, Ts&&... ts)
         {
             return detail::create_dataflow_alloc(alloc,
                 HPX_FORWARD(Policy_, policy), Derived{}, id,
@@ -83,7 +82,7 @@ namespace hpx { namespace lcos { namespace detail {
         HPX_FORCEINLINE static decltype(auto) call(Allocator const& alloc,
             hpx::actions::basic_action<Component, Signature, Derived> const&
                 act,
-            naming::id_type const& id, Ts&&... ts)
+            hpx::id_type const& id, Ts&&... ts)
         {
             return dataflow_dispatch_impl<true, launch>::call(
                 alloc, launch::async, act, id, HPX_FORWARD(Ts, ts)...);
@@ -98,7 +97,7 @@ namespace hpx { namespace lcos { namespace detail {
         HPX_FORCEINLINE static hpx::future<
             typename traits::promise_local_result<typename hpx::traits::
                     extract_action<Action>::remote_result_type>::type>
-        call(Allocator const& alloc, naming::id_type const& id, Ts&&... ts)
+        call(Allocator const& alloc, hpx::id_type const& id, Ts&&... ts)
         {
             return dataflow_dispatch_impl<true, Action>::call(
                 alloc, Action(), id, HPX_FORWARD(Ts, ts)...);
@@ -114,7 +113,7 @@ namespace hpx { namespace lcos { namespace detail {
         HPX_FORCEINLINE static hpx::future<
             typename traits::promise_local_result<typename hpx::traits::
                     extract_action<Action>::remote_result_type>::type>
-        call(Allocator const& alloc, Policy&& policy, naming::id_type const& id,
+        call(Allocator const& alloc, Policy&& policy, hpx::id_type const& id,
             Ts&&... ts)
         {
             return dataflow_dispatch_impl<true,

--- a/libs/full/async_distributed/include/hpx/async_distributed/detail/async_implementations.hpp
+++ b/libs/full/async_distributed/include/hpx/async_distributed/detail/async_implementations.hpp
@@ -36,20 +36,20 @@ namespace hpx { namespace detail {
     ///////////////////////////////////////////////////////////////////////////
     struct keep_id_alive
     {
-        explicit keep_id_alive(naming::id_type const& id)
+        explicit keep_id_alive(hpx::id_type const& id)
           : id_(id)
         {
         }
 
         void operator()() const {}
 
-        naming::id_type id_;
+        hpx::id_type id_;
     };
 
     template <typename T>
     future<T> keep_alive(future<T>&& f, id_type const& id)
     {
-        if (id.get_management_type() == naming::id_type::managed)
+        if (id.get_management_type() == hpx::id_type::management_type::managed)
         {
             traits::detail::get_shared_state(f)->set_on_completed(
                 hpx::detail::keep_id_alive(id));
@@ -60,7 +60,7 @@ namespace hpx { namespace detail {
     struct keep_id_and_ptr_alive
     {
         explicit keep_id_and_ptr_alive(
-            naming::id_type const& id, components::pinned_ptr&& p)
+            hpx::id_type const& id, components::pinned_ptr&& p)
           : id_(id)
           , p_(HPX_MOVE(p))
         {
@@ -68,7 +68,7 @@ namespace hpx { namespace detail {
 
         void operator()() const {}
 
-        naming::id_type id_;
+        hpx::id_type id_;
         components::pinned_ptr p_;
     };
 
@@ -76,7 +76,7 @@ namespace hpx { namespace detail {
     future<T> keep_alive(
         future<T>&& f, id_type const& id, components::pinned_ptr&& p)
     {
-        if (id.get_management_type() == naming::id_type::managed)
+        if (id.get_management_type() == hpx::id_type::management_type::managed)
         {
             traits::detail::get_shared_state(f)->set_on_completed(
                 hpx::detail::keep_id_and_ptr_alive(id, HPX_MOVE(p)));
@@ -96,10 +96,11 @@ namespace hpx { namespace detail {
           , id_(id)
           , f_(f)
         {
-            if (id.get_management_type() == naming::id_type::managed)
+            if (id.get_management_type() ==
+                hpx::id_type::management_type::managed)
             {
-                unmanaged_id_ =
-                    naming::id_type(id.get_gid(), naming::id_type::unmanaged);
+                unmanaged_id_ = hpx::id_type(
+                    id.get_gid(), hpx::id_type::management_type::unmanaged);
                 target_is_managed_ = true;
             }
         }
@@ -130,8 +131,8 @@ namespace hpx { namespace detail {
         }
 
         bool target_is_managed_;
-        naming::id_type const& id_;
-        naming::id_type unmanaged_id_;
+        hpx::id_type const& id_;
+        hpx::id_type unmanaged_id_;
         future<Result>& f_;
     };
 
@@ -141,7 +142,7 @@ namespace hpx { namespace detail {
     {
         template <typename... Ts>
         static hpx::future<Result> call(
-            naming::id_type const& /*id*/, naming::address&& addr, Ts&&... vs)
+            hpx::id_type const& /*id*/, naming::address&& addr, Ts&&... vs)
         {
             try
             {
@@ -178,7 +179,7 @@ namespace hpx { namespace detail {
     {
         template <typename... Ts>
         static hpx::future<void> call(
-            naming::id_type const& /*id*/, naming::address&& addr, Ts&&... vs)
+            hpx::id_type const& /*id*/, naming::address&& addr, Ts&&... vs)
         {
             try
             {
@@ -199,7 +200,7 @@ namespace hpx { namespace detail {
     struct sync_local_invoke_cb
     {
         template <typename Callback, typename... Ts>
-        static hpx::future<Result> call(naming::id_type const& id,
+        static hpx::future<Result> call(hpx::id_type const& id,
             naming::address&& addr, Callback&& cb, Ts&&... vs)
         {
             future<Result> f;

--- a/libs/full/async_distributed/include/hpx/async_distributed/detail/promise_base.hpp
+++ b/libs/full/async_distributed/include/hpx/async_distributed/detail/promise_base.hpp
@@ -196,7 +196,7 @@ namespace hpx {
               , addr_(HPX_MOVE(other.addr_))
             {
                 other.id_retrieved_ = false;
-                other.id_ = naming::invalid_id;
+                other.id_ = hpx::invalid_id;
                 other.addr_ = naming::address();
             }
 
@@ -215,12 +215,12 @@ namespace hpx {
                 addr_ = HPX_MOVE(other.addr_);
 
                 other.id_retrieved_ = false;
-                other.id_ = naming::invalid_id;
+                other.id_ = hpx::invalid_id;
                 other.addr_ = naming::address();
                 return *this;
             }
 
-            naming::id_type get_id(
+            hpx::id_type get_id(
                 bool mark_as_started = true, error_code& ec = throws) const
             {
                 if (this->shared_state_ == nullptr)
@@ -228,21 +228,21 @@ namespace hpx {
                     HPX_THROWS_IF(ec, no_state,
                         "detail::promise_base<Result, RemoteResult>::get_id",
                         "this promise has no valid shared state");
-                    return naming::invalid_id;
+                    return hpx::invalid_id;
                 }
                 if (!addr_ || !id_)
                 {
                     HPX_THROWS_IF(ec, no_state,
                         "detail::promise_base<Result, RemoteResult>::get_id",
                         "this promise has no valid LCO");
-                    return naming::invalid_id;
+                    return hpx::invalid_id;
                 }
                 if (!this->future_retrieved_)
                 {
                     HPX_THROW_EXCEPTION(invalid_status,
                         "promise<Result>::get_id",
                         "future has not been retrieved from this promise yet");
-                    return naming::invalid_id;
+                    return hpx::invalid_id;
                 }
 
                 if (mark_as_started)
@@ -254,12 +254,12 @@ namespace hpx {
                 return id_;
             }
 
-            naming::id_type get_id(error_code& ec) const
+            hpx::id_type get_id(error_code& ec) const
             {
                 return get_id(true, ec);
             }
 
-            naming::id_type get_unmanaged_gid(error_code& ec = throws) const
+            hpx::id_type get_unmanaged_gid(error_code& ec = throws) const
             {
                 return get_id(false, ec);
             }
@@ -357,7 +357,7 @@ namespace hpx {
             }
             mutable bool id_retrieved_;
 
-            naming::id_type id_;
+            hpx::id_type id_;
             naming::address addr_;
         };
     }}    // namespace lcos::detail

--- a/libs/full/async_distributed/include/hpx/async_distributed/detail/sync_implementations.hpp
+++ b/libs/full/async_distributed/include/hpx/async_distributed/detail/sync_implementations.hpp
@@ -31,7 +31,7 @@ namespace hpx { namespace detail {
     {
         template <typename... Ts>
         HPX_FORCEINLINE static Result call(
-            naming::id_type const& /*id*/, naming::address&& addr, Ts&&... vs)
+            hpx::id_type const& /*id*/, naming::address&& addr, Ts&&... vs)
         {
             using remote_result_type = typename Action::remote_result_type;
             using get_remote_result_type =
@@ -47,7 +47,7 @@ namespace hpx { namespace detail {
     {
         template <typename... Ts>
         HPX_FORCEINLINE static void call(
-            naming::id_type const& /*id*/, naming::address&& addr, Ts&&... vs)
+            hpx::id_type const& /*id*/, naming::address&& addr, Ts&&... vs)
         {
             Action::execute_function(
                 addr.address_, addr.type_, HPX_FORWARD(Ts, vs)...);

--- a/libs/full/async_distributed/include/hpx/async_distributed/packaged_action.hpp
+++ b/libs/full/async_distributed/include/hpx/async_distributed/packaged_action.hpp
@@ -138,7 +138,7 @@ namespace hpx { namespace lcos {
 
         ///////////////////////////////////////////////////////////////////////
         template <typename... Ts>
-        void do_apply(naming::address&& addr, naming::id_type const& id,
+        void do_apply(naming::address&& addr, hpx::id_type const& id,
             threads::thread_priority priority, Ts&&... vs)
         {
             LLCO_(info).format("packaged_action::do_apply({}, {}) args({})",
@@ -153,7 +153,7 @@ namespace hpx { namespace lcos {
             auto&& f = [shared_state = HPX_MOVE(shared_state)]() {};
 #endif
             naming::address resolved_addr(this->resolve());
-            naming::id_type cont_id(this->get_id(false));
+            hpx::id_type cont_id(this->get_id(false));
             naming::detail::set_dont_store_in_cache(cont_id);
 
             if (addr)
@@ -176,8 +176,8 @@ namespace hpx { namespace lcos {
         }
 
         template <typename... Ts>
-        void do_apply(naming::id_type const& id,
-            threads::thread_priority priority, Ts&&... vs)
+        void do_apply(hpx::id_type const& id, threads::thread_priority priority,
+            Ts&&... vs)
         {
             LLCO_(info).format("packaged_action::do_apply({}, {}) args({})",
                 hpx::actions::detail::get_action_name<action_type>(), id,
@@ -192,7 +192,7 @@ namespace hpx { namespace lcos {
 #endif
 
             naming::address resolved_addr(this->resolve());
-            naming::id_type cont_id(this->get_id(false));
+            hpx::id_type cont_id(this->get_id(false));
             naming::detail::set_dont_store_in_cache(cont_id);
 
             hpx::apply_p_cb<action_type>(
@@ -204,7 +204,7 @@ namespace hpx { namespace lcos {
         }
 
         template <typename Callback, typename... Ts>
-        void do_apply_cb(naming::address&& addr, naming::id_type const& id,
+        void do_apply_cb(naming::address&& addr, hpx::id_type const& id,
             threads::thread_priority priority, Callback&& cb, Ts&&... vs)
         {
             LLCO_(info).format("packaged_action::do_apply_cb({}, {}) args({})",
@@ -222,7 +222,7 @@ namespace hpx { namespace lcos {
 #endif
 
             naming::address resolved_addr(this->resolve());
-            naming::id_type cont_id(this->get_id(false));
+            hpx::id_type cont_id(this->get_id(false));
             naming::detail::set_dont_store_in_cache(cont_id);
 
             if (addr)
@@ -245,7 +245,7 @@ namespace hpx { namespace lcos {
         }
 
         template <typename Callback, typename... Ts>
-        void do_apply_cb(naming::id_type const& id,
+        void do_apply_cb(hpx::id_type const& id,
             threads::thread_priority priority, Callback&& cb, Ts&&... vs)
         {
             LLCO_(info).format("packaged_action::do_apply_cb({}, {}) args({})",
@@ -263,7 +263,7 @@ namespace hpx { namespace lcos {
 #endif
 
             naming::address resolved_addr(this->resolve());
-            naming::id_type cont_id(this->get_id(false));
+            hpx::id_type cont_id(this->get_id(false));
             naming::detail::set_dont_store_in_cache(cont_id);
 
             hpx::apply_p_cb<action_type>(
@@ -290,15 +290,14 @@ namespace hpx { namespace lcos {
         }
 
         template <typename... Ts>
-        void apply(naming::id_type const& id, Ts&&... vs)
+        void apply(hpx::id_type const& id, Ts&&... vs)
         {
             do_apply(id, actions::action_priority<action_type>(),
                 HPX_FORWARD(Ts, vs)...);
         }
 
         template <typename... Ts>
-        void apply(
-            naming::address&& addr, naming::id_type const& id, Ts&&... vs)
+        void apply(naming::address&& addr, hpx::id_type const& id, Ts&&... vs)
         {
             do_apply(HPX_MOVE(addr), id,
                 actions::action_priority<action_type>(),
@@ -306,14 +305,14 @@ namespace hpx { namespace lcos {
         }
 
         template <typename Callback, typename... Ts>
-        void apply_cb(naming::id_type const& id, Callback&& cb, Ts&&... vs)
+        void apply_cb(hpx::id_type const& id, Callback&& cb, Ts&&... vs)
         {
             do_apply_cb(id, actions::action_priority<action_type>(),
                 HPX_FORWARD(Callback, cb), HPX_FORWARD(Ts, vs)...);
         }
 
         template <typename Callback, typename... Ts>
-        void apply_cb(naming::address&& addr, naming::id_type const& id,
+        void apply_cb(naming::address&& addr, hpx::id_type const& id,
             Callback&& cb, Ts&&... vs)
         {
             do_apply_cb(HPX_MOVE(addr), id,
@@ -322,21 +321,21 @@ namespace hpx { namespace lcos {
         }
 
         template <typename... Ts>
-        void apply_p(naming::id_type const& id,
-            threads::thread_priority priority, Ts&&... vs)
+        void apply_p(hpx::id_type const& id, threads::thread_priority priority,
+            Ts&&... vs)
         {
             do_apply(id, priority, HPX_FORWARD(Ts, vs)...);
         }
 
         template <typename... Ts>
-        void apply_p(naming::address&& addr, naming::id_type const& id,
+        void apply_p(naming::address&& addr, hpx::id_type const& id,
             threads::thread_priority priority, Ts&&... vs)
         {
             do_apply(HPX_MOVE(addr), id, priority, HPX_FORWARD(Ts, vs)...);
         }
 
         template <typename Callback, typename... Ts>
-        void apply_p_cb(naming::id_type const& id,
+        void apply_p_cb(hpx::id_type const& id,
             threads::thread_priority priority, Callback&& cb, Ts&&... vs)
         {
             do_apply_cb(id, priority, HPX_FORWARD(Callback, cb),
@@ -344,7 +343,7 @@ namespace hpx { namespace lcos {
         }
 
         template <typename Callback, typename... Ts>
-        void apply_p_cb(naming::address&& addr, naming::id_type const& id,
+        void apply_p_cb(naming::address&& addr, hpx::id_type const& id,
             threads::thread_priority priority, Callback&& cb, Ts&&... vs)
         {
             do_apply_cb(HPX_MOVE(addr), id, priority, HPX_FORWARD(Callback, cb),
@@ -354,7 +353,7 @@ namespace hpx { namespace lcos {
         ///////////////////////////////////////////////////////////////////////
         template <typename... Ts>
         void apply_deferred(
-            naming::address&& addr, naming::id_type const& id, Ts&&... vs)
+            naming::address&& addr, hpx::id_type const& id, Ts&&... vs)
         {
             LLCO_(info).format(
                 "packaged_action::apply_deferred({}, {}) args({})",
@@ -369,7 +368,7 @@ namespace hpx { namespace lcos {
             auto&& f = [shared_state = HPX_MOVE(shared_state)]() {};
 #endif
 
-            naming::id_type cont_id(this->get_id(false));
+            hpx::id_type cont_id(this->get_id(false));
             naming::detail::set_dont_store_in_cache(cont_id);
 
             auto fut = hpx::functional::apply_c_p_cb<action_type>(cont_id,
@@ -380,8 +379,8 @@ namespace hpx { namespace lcos {
         }
 
         template <typename Callback, typename... Ts>
-        void apply_deferred_cb(naming::address&& addr,
-            naming::id_type const& id, Callback&& cb, Ts&&... vs)
+        void apply_deferred_cb(naming::address&& addr, hpx::id_type const& id,
+            Callback&& cb, Ts&&... vs)
         {
             LLCO_(info).format(
                 "packaged_action::apply_deferred({}, {}) args({})",
@@ -398,7 +397,7 @@ namespace hpx { namespace lcos {
                            cb = HPX_FORWARD(Callback, cb)]() { cb(); };
 #endif
 
-            naming::id_type cont_id(this->get_id(false));
+            hpx::id_type cont_id(this->get_id(false));
             naming::detail::set_dont_store_in_cache(cont_id);
 
             auto fut = hpx::functional::apply_c_p_cb<action_type>(cont_id,
@@ -435,7 +434,7 @@ namespace hpx { namespace lcos {
 
         ///////////////////////////////////////////////////////////////////////
         template <typename... Ts>
-        void apply(naming::id_type const& id, Ts&&... vs)
+        void apply(hpx::id_type const& id, Ts&&... vs)
         {
             std::pair<bool, components::pinned_ptr> r;
 
@@ -479,8 +478,7 @@ namespace hpx { namespace lcos {
         }
 
         template <typename... Ts>
-        void apply(
-            naming::address&& addr, naming::id_type const& id, Ts&&... vs)
+        void apply(naming::address&& addr, hpx::id_type const& id, Ts&&... vs)
         {
             std::pair<bool, components::pinned_ptr> r;
 
@@ -525,7 +523,7 @@ namespace hpx { namespace lcos {
         }
 
         template <typename Callback, typename... Ts>
-        void apply_cb(naming::id_type const& id, Callback&& cb, Ts&&... vs)
+        void apply_cb(hpx::id_type const& id, Callback&& cb, Ts&&... vs)
         {
             std::pair<bool, components::pinned_ptr> r;
 
@@ -584,7 +582,7 @@ namespace hpx { namespace lcos {
         }
 
         template <typename Callback, typename... Ts>
-        void apply_cb(naming::address&& addr, naming::id_type const& id,
+        void apply_cb(naming::address&& addr, hpx::id_type const& id,
             Callback&& cb, Ts&&... vs)
         {
             std::pair<bool, components::pinned_ptr> r;

--- a/libs/full/async_distributed/include/hpx/async_distributed/promise.hpp
+++ b/libs/full/async_distributed/include/hpx/async_distributed/promise.hpp
@@ -31,10 +31,10 @@ namespace hpx::distributed {
     ///
     /// \code
     ///     // Create the promise (the expected result is a id_type)
-    ///     lcos::promise<naming::id_type> p;
+    ///     hpx::distributed::promise<hpx::id_type> p;
     ///
     ///     // Get the associated future
-    ///     future<naming::id_type> f = p.get_future();
+    ///     future<hpx::id_type> f = p.get_future();
     ///
     ///     // initiate the action supplying the promise as a
     ///     // continuation
@@ -42,7 +42,7 @@ namespace hpx::distributed {
     ///
     ///     // Wait for the result to be returned, yielding control
     ///     // in the meantime.
-    ///     naming::id_type result = f.get();
+    ///     hpx::id_type result = f.get();
     ///     // ...
     /// \endcode
     ///

--- a/libs/full/async_distributed/include/hpx/async_distributed/put_parcel.hpp
+++ b/libs/full/async_distributed/include/hpx/async_distributed/put_parcel.hpp
@@ -99,11 +99,12 @@ namespace hpx::parcelset {
         }
 
         template <typename PutParcel>
-        void put_parcel_impl(PutParcel&& pp, naming::id_type dest,
+        void put_parcel_impl(PutParcel&& pp, hpx::id_type dest,
             naming::address&& addr,
             std::unique_ptr<actions::base_action>&& action)
         {
-            if (dest.get_management_type() == naming::id_type::unmanaged)
+            if (dest.get_management_type() ==
+                hpx::id_type::management_type::unmanaged)
             {
                 naming::gid_type gid = dest.get_gid();
                 naming::detail::strip_credits_from_gid(gid);
@@ -115,7 +116,7 @@ namespace hpx::parcelset {
                     HPX_MOVE(gid), HPX_MOVE(addr), HPX_MOVE(action)));
             }
             else if (dest.get_management_type() ==
-                naming::id_type::managed_move_credit)
+                hpx::id_type::management_type::managed_move_credit)
             {
                 naming::gid_type gid = naming::detail::move_gid(dest.get_gid());
 
@@ -166,7 +167,7 @@ namespace hpx::parcelset {
 
     template <typename... Args>
     void put_parcel(
-        naming::id_type const& dest, naming::address&& addr, Args&&... args)
+        hpx::id_type const& dest, naming::address&& addr, Args&&... args)
     {
         detail::put_parcel_impl(detail::put_parcel_handler(), dest,
             HPX_MOVE(addr),
@@ -174,7 +175,7 @@ namespace hpx::parcelset {
     }
 
     template <typename Callback, typename... Args>
-    void put_parcel_cb(Callback&& cb, naming::id_type const& dest,
+    void put_parcel_cb(Callback&& cb, hpx::id_type const& dest,
         naming::address&& addr, Args&&... args)
     {
         detail::put_parcel_impl(

--- a/libs/full/async_distributed/include/hpx/async_distributed/put_parcel_fwd.hpp
+++ b/libs/full/async_distributed/include/hpx/async_distributed/put_parcel_fwd.hpp
@@ -39,7 +39,7 @@ namespace hpx::parcelset {
         struct put_parcel_cont
         {
             std::decay_t<PutParcel> pp;
-            naming::id_type dest;
+            hpx::id_type dest;
             naming::address addr;
             std::unique_ptr<actions::base_action> action;
 
@@ -47,17 +47,17 @@ namespace hpx::parcelset {
         };
 
         template <typename PutParcel>
-        void put_parcel_impl(PutParcel&& pp, naming::id_type dest,
+        void put_parcel_impl(PutParcel&& pp, hpx::id_type dest,
             naming::address&& addr,
             std::unique_ptr<actions::base_action>&& action);
     }    // namespace detail
 
     template <typename... Args>
     void put_parcel(
-        naming::id_type const& dest, naming::address&& addr, Args&&... args);
+        hpx::id_type const& dest, naming::address&& addr, Args&&... args);
 
     template <typename Callback, typename... Args>
-    void put_parcel_cb(Callback&& cb, naming::id_type const& dest,
+    void put_parcel_cb(Callback&& cb, hpx::id_type const& dest,
         naming::address&& addr, Args&&... args);
 }    // namespace hpx::parcelset
 

--- a/libs/full/async_distributed/include/hpx/async_distributed/set_lco_value_continuation.hpp
+++ b/libs/full/async_distributed/include/hpx/async_distributed/set_lco_value_continuation.hpp
@@ -18,7 +18,7 @@ namespace hpx { namespace actions {
     struct set_lco_value_continuation
     {
         template <typename T>
-        HPX_FORCEINLINE T operator()(naming::id_type const& lco, T&& t) const
+        HPX_FORCEINLINE T operator()(hpx::id_type const& lco, T&& t) const
         {
             hpx::set_lco_value(lco, HPX_FORWARD(T, t));
 
@@ -32,7 +32,7 @@ namespace hpx { namespace actions {
     struct set_lco_value_unmanaged_continuation
     {
         template <typename T>
-        HPX_FORCEINLINE T operator()(naming::id_type const& lco, T&& t) const
+        HPX_FORCEINLINE T operator()(hpx::id_type const& lco, T&& t) const
         {
             hpx::set_lco_value_unmanaged(lco, HPX_FORWARD(T, t));
 

--- a/libs/full/async_distributed/include/hpx/async_distributed/sync.hpp
+++ b/libs/full/async_distributed/include/hpx/async_distributed/sync.hpp
@@ -70,7 +70,7 @@ namespace hpx { namespace detail {
         // id_type
         template <typename Policy_, typename... Ts>
         HPX_FORCEINLINE static sync_result_t<Action> call(
-            Policy_&& launch_policy, naming::id_type const& id, Ts&&... ts)
+            Policy_&& launch_policy, hpx::id_type const& id, Ts&&... ts)
         {
             return hpx::detail::sync_impl<Action>(
                 HPX_FORWARD(Policy_, launch_policy), id,
@@ -109,13 +109,13 @@ namespace hpx { namespace detail {
         }
     };
 
-    // naming::id_type
+    // hpx::id_type
     template <typename Action>
-    struct sync_action_dispatch<Action, naming::id_type>
+    struct sync_action_dispatch<Action, hpx::id_type>
     {
         template <typename... Ts>
         HPX_FORCEINLINE static decltype(auto) call(
-            naming::id_type const& id, Ts&&... ts)
+            hpx::id_type const& id, Ts&&... ts)
         {
             return sync_action_dispatch<Action, hpx::detail::sync_policy>::call(
                 launch::sync, id, HPX_FORWARD(Ts, ts)...);
@@ -176,7 +176,7 @@ namespace hpx { namespace detail {
             typename... Ts>
         HPX_FORCEINLINE static decltype(auto) call(
             hpx::actions::basic_action<Component, Signature, Derived> const&,
-            naming::id_type const& id, Ts&&... vs)
+            hpx::id_type const& id, Ts&&... vs)
         {
             return sync<Derived>(launch::sync, id, HPX_FORWARD(Ts, vs)...);
         }

--- a/libs/full/async_distributed/include/hpx/async_distributed/transfer_continuation_action.hpp
+++ b/libs/full/async_distributed/include/hpx/async_distributed/transfer_continuation_action.hpp
@@ -88,12 +88,12 @@ namespace hpx { namespace actions {
         ///       continuations.
         template <std::size_t... Is>
         threads::thread_function_type get_thread_function(
-            util::index_pack<Is...>, naming::id_type&& target,
+            util::index_pack<Is...>, hpx::id_type&& target,
             naming::address::address_type lva,
             naming::address::component_type comptype);
 
-        threads::thread_function_type get_thread_function(
-            naming::id_type&& target, naming::address::address_type lva,
+        threads::thread_function_type get_thread_function(hpx::id_type&& target,
+            naming::address::address_type lva,
             naming::address::component_type comptype) override;
 
         template <std::size_t... Is>
@@ -153,7 +153,7 @@ namespace hpx { namespace actions {
     template <std::size_t... Is>
     threads::thread_function_type
     transfer_continuation_action<Action>::get_thread_function(
-        util::index_pack<Is...>, naming::id_type&& target,
+        util::index_pack<Is...>, hpx::id_type&& target,
         naming::address::address_type lva,
         naming::address::component_type comptype)
     {
@@ -165,7 +165,7 @@ namespace hpx { namespace actions {
     template <typename Action>
     threads::thread_function_type
     transfer_continuation_action<Action>::get_thread_function(
-        naming::id_type&& target, naming::address::address_type lva,
+        hpx::id_type&& target, naming::address::address_type lva,
         naming::address::component_type comptype)
     {
         return get_thread_function(
@@ -180,10 +180,11 @@ namespace hpx { namespace actions {
         naming::address::address_type lva,
         naming::address::component_type comptype, std::size_t /*num_thread*/)
     {
-        naming::id_type target;
+        hpx::id_type target;
         if (naming::detail::has_credits(target_gid))
         {
-            target = naming::id_type(target_gid, naming::id_type::managed);
+            target = hpx::id_type(
+                target_gid, hpx::id_type::management_type::managed);
         }
 
         threads::thread_init_data data;

--- a/libs/full/async_distributed/include/hpx/async_distributed/trigger_lco.hpp
+++ b/libs/full/async_distributed/include/hpx/async_distributed/trigger_lco.hpp
@@ -32,19 +32,19 @@ namespace hpx {
     //////////////////////////////////////////////////////////////////////////
     // forward declare the required overload of apply.
     template <typename Action, typename... Ts>
-    bool apply(naming::id_type const& gid, Ts&&... vs);
+    bool apply(hpx::id_type const& gid, Ts&&... vs);
 
     template <typename Component, typename Signature, typename Derived,
         typename Cont, typename... Ts>
     bool apply_continue(
         hpx::actions::basic_action<Component, Signature, Derived>, Cont&& cont,
-        naming::id_type const& gid, Ts&&... vs);
+        hpx::id_type const& gid, Ts&&... vs);
 
     template <typename Component, typename Signature, typename Derived,
         typename... Ts>
     inline bool apply_c(
         hpx::actions::basic_action<Component, Signature, Derived>,
-        naming::id_type const& contgid, naming::id_type const& gid, Ts&&... vs);
+        hpx::id_type const& contgid, hpx::id_type const& gid, Ts&&... vs);
     /// \endcond
 
     /// \cond NOINTERNAL
@@ -111,14 +111,15 @@ namespace hpx {
 
         ///////////////////////////////////////////////////////////////////////
         template <typename Action, typename Result>
-        void set_lco_value(naming::id_type const& id, naming::address&& addr,
+        void set_lco_value(hpx::id_type const& id, naming::address&& addr,
             Result&& t, bool move_credits)
         {
             if (move_credits &&
-                id.get_management_type() != naming::id_type::unmanaged)
+                id.get_management_type() !=
+                    hpx::id_type::management_type::unmanaged)
             {
-                naming::id_type target(
-                    id.get_gid(), naming::id_type::managed_move_credit);
+                hpx::id_type target(id.get_gid(),
+                    hpx::id_type::management_type::managed_move_credit);
                 id.make_unmanaged();
 
                 detail::apply_impl<Action>(target, HPX_MOVE(addr),
@@ -136,14 +137,15 @@ namespace hpx {
         ///////////////////////////////////////////////////////////////////////
         template <typename LocalResult, typename RemoteResult, typename Action,
             typename Result>
-        void set_lco_value(naming::id_type const& id, naming::address&& addr,
-            Result&& t, naming::id_type const& cont, bool move_credits)
+        void set_lco_value(hpx::id_type const& id, naming::address&& addr,
+            Result&& t, hpx::id_type const& cont, bool move_credits)
         {
             if (move_credits &&
-                id.get_management_type() != naming::id_type::unmanaged)
+                id.get_management_type() !=
+                    hpx::id_type::management_type::unmanaged)
             {
-                naming::id_type target(
-                    id.get_gid(), naming::id_type::managed_move_credit);
+                hpx::id_type target(id.get_gid(),
+                    hpx::id_type::management_type::managed_move_credit);
                 id.make_unmanaged();
 
                 detail::apply_impl<Action>(
@@ -164,7 +166,7 @@ namespace hpx {
 
     /// \cond NOINTERNAL
     template <typename Result>
-    void set_lco_value(naming::id_type const& id, naming::address&& addr,
+    void set_lco_value(hpx::id_type const& id, naming::address&& addr,
         Result&& t, bool move_credits)
     {
 #if !defined(HPX_COMPUTE_DEVICE_CODE)
@@ -208,8 +210,8 @@ namespace hpx {
     }
 
     template <typename Result>
-    void set_lco_value(naming::id_type const& id, naming::address&& addr,
-        Result&& t, naming::id_type const& cont, bool move_credits)
+    void set_lco_value(hpx::id_type const& id, naming::address&& addr,
+        Result&& t, hpx::id_type const& cont, bool move_credits)
     {
 #if !defined(HPX_COMPUTE_DEVICE_CODE)
         typedef typename std::decay<Result>::type remote_result_type;

--- a/libs/full/async_distributed/include/hpx/async_distributed/trigger_lco_fwd.hpp
+++ b/libs/full/async_distributed/include/hpx/async_distributed/trigger_lco_fwd.hpp
@@ -30,7 +30,7 @@ namespace hpx {
     /// \param move_credits [in] If this is set to \a true then it is ok to
     ///                     send all credits in \a id along with the generated
     ///                     message. The default value is \a true.
-    HPX_EXPORT void trigger_lco_event(naming::id_type const& id,
+    HPX_EXPORT void trigger_lco_event(hpx::id_type const& id,
         naming::address&& addr, bool move_credits = true);
 
     ///////////////////////////////////////////////////////////////////////////
@@ -42,7 +42,7 @@ namespace hpx {
     ///                     send all credits in \a id along with the generated
     ///                     message. The default value is \a true.
     inline void trigger_lco_event(
-        naming::id_type const& id, bool move_credits = true)
+        hpx::id_type const& id, bool move_credits = true)
     {
         trigger_lco_event(id, naming::address(), move_credits);
     }
@@ -57,8 +57,8 @@ namespace hpx {
     /// \param move_credits [in] If this is set to \a true then it is ok to
     ///                     send all credits in \a id along with the generated
     ///                     message. The default value is \a true.
-    HPX_EXPORT void trigger_lco_event(naming::id_type const& id,
-        naming::address&& addr, naming::id_type const& cont,
+    HPX_EXPORT void trigger_lco_event(hpx::id_type const& id,
+        naming::address&& addr, hpx::id_type const& cont,
         bool move_credits = true);
 
     /// \brief Trigger the LCO referenced by the given id
@@ -69,8 +69,8 @@ namespace hpx {
     /// \param move_credits [in] If this is set to \a true then it is ok to
     ///                     send all credits in \a id along with the generated
     ///                     message. The default value is \a true.
-    inline void trigger_lco_event(naming::id_type const& id,
-        naming::id_type const& cont, bool move_credits = true)
+    inline void trigger_lco_event(hpx::id_type const& id,
+        hpx::id_type const& cont, bool move_credits = true)
     {
         trigger_lco_event(id, naming::address(), cont, move_credits);
     }
@@ -86,7 +86,7 @@ namespace hpx {
     ///                     send all credits in \a id along with the generated
     ///                     message. The default value is \a true.
     template <typename Result>
-    void set_lco_value(naming::id_type const& id, naming::address&& addr,
+    void set_lco_value(hpx::id_type const& id, naming::address&& addr,
         Result&& t, bool move_credits = true);
 
     /// \brief Set the result value for the (managed) LCO referenced by the given id
@@ -100,8 +100,7 @@ namespace hpx {
     template <typename Result>
     typename std::enable_if<!std::is_same<typename std::decay<Result>::type,
         naming::address>::value>::type
-    set_lco_value(
-        naming::id_type const& id, Result&& t, bool move_credits = true)
+    set_lco_value(hpx::id_type const& id, Result&& t, bool move_credits = true)
     {
         naming::address addr(
             nullptr, components::component_base_lco_with_value);
@@ -120,7 +119,7 @@ namespace hpx {
     typename std::enable_if<!std::is_same<typename std::decay<Result>::type,
         naming::address>::value>::type
     set_lco_value_unmanaged(
-        naming::id_type const& id, Result&& t, bool move_credits = true)
+        hpx::id_type const& id, Result&& t, bool move_credits = true)
     {
         naming::address addr(
             nullptr, components::component_base_lco_with_value_unmanaged);
@@ -139,8 +138,8 @@ namespace hpx {
     ///                     send all credits in \a id along with the generated
     ///                     message. The default value is \a true.
     template <typename Result>
-    void set_lco_value(naming::id_type const& id, naming::address&& addr,
-        Result&& t, naming::id_type const& cont, bool move_credits = true);
+    void set_lco_value(hpx::id_type const& id, naming::address&& addr,
+        Result&& t, hpx::id_type const& cont, bool move_credits = true);
 
     /// \brief Set the result value for the (managed) LCO referenced by the given id
     ///
@@ -154,8 +153,8 @@ namespace hpx {
     template <typename Result>
     typename std::enable_if<!std::is_same<typename std::decay<Result>::type,
         naming::address>::value>::type
-    set_lco_value(naming::id_type const& id, Result&& t,
-        naming::id_type const& cont, bool move_credits = true)
+    set_lco_value(hpx::id_type const& id, Result&& t, hpx::id_type const& cont,
+        bool move_credits = true)
     {
         naming::address addr(
             nullptr, components::component_base_lco_with_value);
@@ -175,8 +174,8 @@ namespace hpx {
     template <typename Result>
     typename std::enable_if<!std::is_same<typename std::decay<Result>::type,
         naming::address>::value>::type
-    set_lco_value_unmanaged(naming::id_type const& id, Result&& t,
-        naming::id_type const& cont, bool move_credits = true)
+    set_lco_value_unmanaged(hpx::id_type const& id, Result&& t,
+        hpx::id_type const& cont, bool move_credits = true)
     {
         naming::address addr(
             nullptr, components::component_base_lco_with_value_unmanaged);
@@ -195,7 +194,7 @@ namespace hpx {
     /// \param move_credits [in] If this is set to \a true then it is ok to
     ///                     send all credits in \a id along with the generated
     ///                     message. The default value is \a true.
-    HPX_EXPORT void set_lco_error(naming::id_type const& id,
+    HPX_EXPORT void set_lco_error(hpx::id_type const& id,
         naming::address&& addr, std::exception_ptr const& e,
         bool move_credits = true);
 
@@ -210,7 +209,7 @@ namespace hpx {
     /// \param move_credits [in] If this is set to \a true then it is ok to
     ///                     send all credits in \a id along with the generated
     ///                     message. The default value is \a true.
-    HPX_EXPORT void set_lco_error(naming::id_type const& id,
+    HPX_EXPORT void set_lco_error(hpx::id_type const& id,
         naming::address&& addr, std::exception_ptr&& e,
         bool move_credits = true);
 
@@ -223,7 +222,7 @@ namespace hpx {
     /// \param move_credits [in] If this is set to \a true then it is ok to
     ///                     send all credits in \a id along with the generated
     ///                     message. The default value is \a true.
-    inline void set_lco_error(naming::id_type const& id,
+    inline void set_lco_error(hpx::id_type const& id,
         std::exception_ptr const& e, bool move_credits = true)
     {
         set_lco_error(id, naming::address(), e, move_credits);
@@ -238,7 +237,7 @@ namespace hpx {
     /// \param move_credits [in] If this is set to \a true then it is ok to
     ///                     send all credits in \a id along with the generated
     ///                     message. The default value is \a true.
-    inline void set_lco_error(naming::id_type const& id, std::exception_ptr&& e,
+    inline void set_lco_error(hpx::id_type const& id, std::exception_ptr&& e,
         bool move_credits = true)
     {
         set_lco_error(id, naming::address(), HPX_MOVE(e), move_credits);
@@ -256,9 +255,9 @@ namespace hpx {
     /// \param move_credits [in] If this is set to \a true then it is ok to
     ///                     send all credits in \a id along with the generated
     ///                     message. The default value is \a true.
-    HPX_EXPORT void set_lco_error(naming::id_type const& id,
+    HPX_EXPORT void set_lco_error(hpx::id_type const& id,
         naming::address&& addr, std::exception_ptr const& e,
-        naming::id_type const& cont, bool move_credits = true);
+        hpx::id_type const& cont, bool move_credits = true);
 
     /// \brief Set the error state for the LCO referenced by the given id
     ///
@@ -272,9 +271,9 @@ namespace hpx {
     /// \param move_credits [in] If this is set to \a true then it is ok to
     ///                     send all credits in \a id along with the generated
     ///                     message. The default value is \a true.
-    HPX_EXPORT void set_lco_error(naming::id_type const& id,
+    HPX_EXPORT void set_lco_error(hpx::id_type const& id,
         naming::address&& addr, std::exception_ptr&& e,
-        naming::id_type const& cont, bool move_credits = true);
+        hpx::id_type const& cont, bool move_credits = true);
 
     /// \brief Set the error state for the LCO referenced by the given id
     ///
@@ -286,8 +285,8 @@ namespace hpx {
     /// \param move_credits [in] If this is set to \a true then it is ok to
     ///                     send all credits in \a id along with the generated
     ///                     message. The default value is \a true.
-    inline void set_lco_error(naming::id_type const& id,
-        std::exception_ptr const& e, naming::id_type const& cont,
+    inline void set_lco_error(hpx::id_type const& id,
+        std::exception_ptr const& e, hpx::id_type const& cont,
         bool move_credits = true)
     {
         set_lco_error(id, naming::address(), e, cont, move_credits);
@@ -303,8 +302,8 @@ namespace hpx {
     /// \param move_credits [in] If this is set to \a true then it is ok to
     ///                     send all credits in \a id along with the generated
     ///                     message. The default value is \a true.
-    inline void set_lco_error(naming::id_type const& id, std::exception_ptr&& e,
-        naming::id_type const& cont, bool move_credits = true)
+    inline void set_lco_error(hpx::id_type const& id, std::exception_ptr&& e,
+        hpx::id_type const& cont, bool move_credits = true)
     {
         set_lco_error(id, naming::address(), HPX_MOVE(e), cont, move_credits);
     }

--- a/libs/full/async_distributed/src/base_lco.cpp
+++ b/libs/full/async_distributed/src/base_lco.cpp
@@ -24,9 +24,9 @@ namespace hpx { namespace lcos {
         std::rethrow_exception(e);
     }
 
-    void base_lco::connect(naming::id_type const&) {}
+    void base_lco::connect(hpx::id_type const&) {}
 
-    void base_lco::disconnect(naming::id_type const&) {}
+    void base_lco::disconnect(hpx::id_type const&) {}
 
     components::component_type base_lco::get_component_type() noexcept
     {
@@ -51,12 +51,12 @@ namespace hpx { namespace lcos {
         set_exception(e);
     }
 
-    void base_lco::connect_nonvirt(naming::id_type const& id)
+    void base_lco::connect_nonvirt(hpx::id_type const& id)
     {
         connect(id);
     }
 
-    void base_lco::disconnect_nonvirt(naming::id_type const& id)
+    void base_lco::disconnect_nonvirt(hpx::id_type const& id)
     {
         disconnect(id);
     }

--- a/libs/full/async_distributed/src/base_lco_with_value.cpp
+++ b/libs/full/async_distributed/src/base_lco_with_value.cpp
@@ -21,18 +21,18 @@ HPX_REGISTER_BASE_LCO_WITH_VALUE_ID(hpx::naming::gid_type, gid_type,
 HPX_REGISTER_BASE_LCO_WITH_VALUE_ID(std::vector<hpx::naming::gid_type>,
     vector_gid_type, hpx::actions::base_lco_with_value_vector_gid_get,
     hpx::actions::base_lco_with_value_vector_gid_set)
-HPX_REGISTER_BASE_LCO_WITH_VALUE_ID(hpx::naming::id_type, hpx::naming::gid_type,
+HPX_REGISTER_BASE_LCO_WITH_VALUE_ID(hpx::id_type, hpx::naming::gid_type,
     id_type, hpx::actions::base_lco_with_value_id_get,
     hpx::actions::base_lco_with_value_id_set)
-HPX_REGISTER_BASE_LCO_WITH_VALUE_ID(hpx::naming::id_type, naming_id_type,
+HPX_REGISTER_BASE_LCO_WITH_VALUE_ID(hpx::id_type, naming_id_type,
     hpx::actions::base_lco_with_value_id_type_get,
     hpx::actions::base_lco_with_value_id_type_set)
-HPX_REGISTER_BASE_LCO_WITH_VALUE_ID(std::vector<hpx::naming::id_type>,
+HPX_REGISTER_BASE_LCO_WITH_VALUE_ID(std::vector<hpx::id_type>,
     std::vector<hpx::naming::gid_type>, vector_id_gid_type,
     hpx::actions::base_lco_with_value_vector_id_gid_get,
     hpx::actions::base_lco_with_value_vector_id_gid_set)
-HPX_REGISTER_BASE_LCO_WITH_VALUE_ID(std::vector<hpx::naming::id_type>,
-    vector_id_type, hpx::actions::base_lco_with_value_vector_id_get,
+HPX_REGISTER_BASE_LCO_WITH_VALUE_ID(std::vector<hpx::id_type>, vector_id_type,
+    hpx::actions::base_lco_with_value_vector_id_get,
     hpx::actions::base_lco_with_value_vector_id_set)
 HPX_REGISTER_BASE_LCO_WITH_VALUE_ID(hpx::util::unused_type, unused_type,
     hpx::actions::base_lco_with_value_unused_get,

--- a/libs/full/async_distributed/src/continuation.cpp
+++ b/libs/full/async_distributed/src/continuation.cpp
@@ -23,7 +23,7 @@ namespace hpx { namespace actions {
 
     continuation::continuation() = default;
 
-    continuation::continuation(naming::id_type const& id)
+    continuation::continuation(hpx::id_type const& id)
       : id_(id)
     {
         // Try to resolve the address locally ...
@@ -33,7 +33,7 @@ namespace hpx { namespace actions {
         }
     }
 
-    continuation::continuation(naming::id_type&& id)
+    continuation::continuation(hpx::id_type&& id)
       : id_(HPX_MOVE(id))
     {
         // Try to resolve the address locally ...
@@ -43,15 +43,14 @@ namespace hpx { namespace actions {
         }
     }
 
-    continuation::continuation(
-        naming::id_type const& id, naming::address&& addr)
+    continuation::continuation(hpx::id_type const& id, naming::address&& addr)
       : id_(id)
       , addr_(HPX_MOVE(addr))
     {
     }
 
     continuation::continuation(
-        naming::id_type&& id, naming::address&& addr) noexcept
+        hpx::id_type&& id, naming::address&& addr) noexcept
       : id_(HPX_MOVE(id))
       , addr_(HPX_MOVE(addr))
     {

--- a/libs/full/async_distributed/src/trigger_lco.cpp
+++ b/libs/full/async_distributed/src/trigger_lco.cpp
@@ -22,14 +22,16 @@
 namespace hpx {
 
     void trigger_lco_event(
-        naming::id_type const& id, naming::address&& addr, bool move_credits)
+        hpx::id_type const& id, naming::address&& addr, bool move_credits)
     {
 #if !defined(HPX_COMPUTE_DEVICE_CODE)
         typedef lcos::base_lco::set_event_action set_action;
         if (move_credits &&
-            id.get_management_type() != naming::id_type::unmanaged)
+            id.get_management_type() !=
+                hpx::id_type::management_type::unmanaged)
         {
-            naming::id_type target(id.get_gid(), id_type::managed_move_credit);
+            hpx::id_type target(
+                id.get_gid(), id_type::management_type::managed_move_credit);
             id.make_unmanaged();
 
             detail::apply_impl<set_action>(
@@ -48,8 +50,8 @@ namespace hpx {
 #endif
     }
 
-    void trigger_lco_event(naming::id_type const& id, naming::address&& addr,
-        naming::id_type const& cont, bool move_credits)
+    void trigger_lco_event(hpx::id_type const& id, naming::address&& addr,
+        hpx::id_type const& cont, bool move_credits)
     {
 #if !defined(HPX_COMPUTE_DEVICE_CODE)
         typedef lcos::base_lco::set_event_action set_action;
@@ -58,9 +60,11 @@ namespace hpx {
         typedef hpx::traits::extract_action<set_action>::remote_result_type
             remote_result_type;
         if (move_credits &&
-            id.get_management_type() != naming::id_type::unmanaged)
+            id.get_management_type() !=
+                hpx::id_type::management_type::unmanaged)
         {
-            naming::id_type target(id.get_gid(), id_type::managed_move_credit);
+            hpx::id_type target(
+                id.get_gid(), id_type::management_type::managed_move_credit);
             id.make_unmanaged();
 
             detail::apply_impl<set_action>(
@@ -84,15 +88,17 @@ namespace hpx {
 #endif
     }
 
-    void set_lco_error(naming::id_type const& id, naming::address&& addr,
+    void set_lco_error(hpx::id_type const& id, naming::address&& addr,
         std::exception_ptr const& e, bool move_credits)
     {
 #if !defined(HPX_COMPUTE_DEVICE_CODE)
         typedef lcos::base_lco::set_exception_action set_action;
         if (move_credits &&
-            id.get_management_type() != naming::id_type::unmanaged)
+            id.get_management_type() !=
+                hpx::id_type::management_type::unmanaged)
         {
-            naming::id_type target(id.get_gid(), id_type::managed_move_credit);
+            hpx::id_type target(
+                id.get_gid(), id_type::management_type::managed_move_credit);
             id.make_unmanaged();
 
             detail::apply_impl<set_action>(target, HPX_MOVE(addr),
@@ -112,16 +118,18 @@ namespace hpx {
 #endif
     }
 
-    void set_lco_error(naming::id_type const& id,
+    void set_lco_error(hpx::id_type const& id,
         naming::address&& addr,    //-V659
         std::exception_ptr&& e, bool move_credits)
     {
 #if !defined(HPX_COMPUTE_DEVICE_CODE)
         typedef lcos::base_lco::set_exception_action set_action;
         if (move_credits &&
-            id.get_management_type() != naming::id_type::unmanaged)
+            id.get_management_type() !=
+                hpx::id_type::management_type::unmanaged)
         {
-            naming::id_type target(id.get_gid(), id_type::managed_move_credit);
+            hpx::id_type target(
+                id.get_gid(), id_type::management_type::managed_move_credit);
             id.make_unmanaged();
 
             detail::apply_impl<set_action>(target, HPX_MOVE(addr),
@@ -141,8 +149,8 @@ namespace hpx {
 #endif
     }
 
-    void set_lco_error(naming::id_type const& id, naming::address&& addr,
-        std::exception_ptr const& e, naming::id_type const& cont,
+    void set_lco_error(hpx::id_type const& id, naming::address&& addr,
+        std::exception_ptr const& e, hpx::id_type const& cont,
         bool move_credits)
     {
 #if !defined(HPX_COMPUTE_DEVICE_CODE)
@@ -152,9 +160,11 @@ namespace hpx {
         typedef hpx::traits::extract_action<set_action>::remote_result_type
             remote_result_type;
         if (move_credits &&
-            id.get_management_type() != naming::id_type::unmanaged)
+            id.get_management_type() !=
+                hpx::id_type::management_type::unmanaged)
         {
-            naming::id_type target(id.get_gid(), id_type::managed_move_credit);
+            hpx::id_type target(
+                id.get_gid(), id_type::management_type::managed_move_credit);
             id.make_unmanaged();
 
             detail::apply_impl<set_action>(
@@ -180,9 +190,9 @@ namespace hpx {
 #endif
     }
 
-    void set_lco_error(naming::id_type const& id,
+    void set_lco_error(hpx::id_type const& id,
         naming::address&& addr,    //-V659
-        std::exception_ptr&& e, naming::id_type const& cont, bool move_credits)
+        std::exception_ptr&& e, hpx::id_type const& cont, bool move_credits)
     {
 #if !defined(HPX_COMPUTE_DEVICE_CODE)
         typedef lcos::base_lco::set_exception_action set_action;
@@ -191,9 +201,11 @@ namespace hpx {
         typedef hpx::traits::extract_action<set_action>::remote_result_type
             remote_result_type;
         if (move_credits &&
-            id.get_management_type() != naming::id_type::unmanaged)
+            id.get_management_type() !=
+                hpx::id_type::management_type::unmanaged)
         {
-            naming::id_type target(id.get_gid(), id_type::managed_move_credit);
+            hpx::id_type target(
+                id.get_gid(), id_type::management_type::managed_move_credit);
             id.make_unmanaged();
 
             detail::apply_impl<set_action>(
@@ -226,6 +238,6 @@ namespace hpx {
     // (in release mode only, leads to missing symbols otherwise).
     template bool apply<lcos::base_lco_with_value<util::unused_type,
                             util::unused_type>::set_value_action,
-        util::unused_type>(naming::id_type const&, util::unused_type&&);
+        util::unused_type>(hpx::id_type const&, util::unused_type&&);
 #endif
 }    // namespace hpx

--- a/libs/full/async_distributed/tests/regressions/component_action_move_semantics.cpp
+++ b/libs/full/async_distributed/tests/regressions/component_action_move_semantics.cpp
@@ -25,7 +25,7 @@ using hpx::test::non_movable_object;
 
 ///////////////////////////////////////////////////////////////////////////////
 template <typename Action, typename Object>
-std::size_t pass_object(hpx::naming::id_type id)
+std::size_t pass_object(hpx::id_type id)
 {
     using hpx::test::action_move_semantics;
 
@@ -39,7 +39,7 @@ std::size_t pass_object(hpx::naming::id_type id)
 
 ///////////////////////////////////////////////////////////////////////////////
 template <typename Action, typename Object>
-std::size_t move_object(hpx::naming::id_type id)
+std::size_t move_object(hpx::id_type id)
 {
     using hpx::test::action_move_semantics;
 
@@ -53,7 +53,7 @@ std::size_t move_object(hpx::naming::id_type id)
 
 ///////////////////////////////////////////////////////////////////////////////
 template <typename Action, typename Object>
-std::size_t return_object(hpx::naming::id_type id)
+std::size_t return_object(hpx::id_type id)
 {
     using hpx::test::action_move_semantics;
 
@@ -65,7 +65,7 @@ std::size_t return_object(hpx::naming::id_type id)
 
 ///////////////////////////////////////////////////////////////////////////////
 template <typename Action, typename Object>
-std::size_t return_move_object(hpx::naming::id_type id)
+std::size_t return_move_object(hpx::id_type id)
 {
     using hpx::test::action_move_semantics;
 
@@ -80,8 +80,8 @@ void test_actions()
 {
     using hpx::test::server::action_move_semantics;
 
-    std::vector<hpx::naming::id_type> localities = hpx::find_all_localities();
-    for (hpx::naming::id_type const& id : localities)
+    std::vector<hpx::id_type> localities = hpx::find_all_localities();
+    for (hpx::id_type const& id : localities)
     {
         bool is_local = id == hpx::find_here();
 
@@ -185,8 +185,8 @@ void test_direct_actions()
 {
     using hpx::test::server::action_move_semantics;
 
-    std::vector<hpx::naming::id_type> localities = hpx::find_all_localities();
-    for (hpx::naming::id_type const& id : localities)
+    std::vector<hpx::id_type> localities = hpx::find_all_localities();
+    for (hpx::id_type const& id : localities)
     {
         bool is_local = id == hpx::find_here();
 

--- a/libs/full/async_distributed/tests/regressions/components/action_move_semantics.hpp
+++ b/libs/full/async_distributed/tests/regressions/components/action_move_semantics.hpp
@@ -24,11 +24,11 @@ namespace hpx { namespace test {
             base_type;
 
         action_move_semantics() = default;
-        explicit action_move_semantics(naming::id_type const& id)
+        explicit action_move_semantics(hpx::id_type const& id)
           : base_type(id)
         {
         }
-        action_move_semantics(hpx::future<naming::id_type>&& id)
+        action_move_semantics(hpx::future<hpx::id_type>&& id)
           : base_type(std::move(id))
         {
         }

--- a/libs/full/async_distributed/tests/regressions/dataflow_791.cpp
+++ b/libs/full/async_distributed/tests/regressions/dataflow_791.cpp
@@ -129,7 +129,7 @@ int main(int argc, char* argv[])
 void LU(int numBlocks)
 {
     printf("LU\n");
-    hpx::naming::id_type here = hpx::find_here();
+    hpx::id_type here = hpx::find_here();
     vector<vector<block>> blockList;
     getBlockList(blockList, numBlocks);
     vector<vector<vector<shared_future<block>>>> dfArray(numBlocks);

--- a/libs/full/async_distributed/tests/regressions/plain_action_move_semantics.cpp
+++ b/libs/full/async_distributed/tests/regressions/plain_action_move_semantics.cpp
@@ -27,7 +27,7 @@ using hpx::program_options::options_description;
 using hpx::program_options::value;
 using hpx::program_options::variables_map;
 
-using hpx::naming::id_type;
+using hpx::id_type;
 
 using hpx::actions::action;
 using hpx::actions::direct_action;

--- a/libs/full/async_distributed/tests/unit/util/bind_action.cpp
+++ b/libs/full/async_distributed/tests/unit/util/bind_action.cpp
@@ -23,7 +23,7 @@ int test0()
 }
 HPX_PLAIN_ACTION(test0, test0_action)
 
-void bind_test0(hpx::naming::id_type id)
+void bind_test0(hpx::id_type id)
 {
     using hpx::placeholders::_1;
     using hpx::placeholders::_2;
@@ -34,7 +34,7 @@ void bind_test0(hpx::naming::id_type id)
     HPX_TEST_EQ(hpx::bind<test0_action>(_2)(41, id), 42);
 }
 
-void bind_test1(hpx::naming::id_type id)
+void bind_test1(hpx::id_type id)
 {
     using hpx::placeholders::_1;
     using hpx::placeholders::_2;
@@ -46,7 +46,7 @@ void bind_test1(hpx::naming::id_type id)
     HPX_TEST_EQ(hpx::bind(do_test0, _2)(41, id), 42);
 }
 
-void async_test0(hpx::naming::id_type id)
+void async_test0(hpx::id_type id)
 {
     using hpx::placeholders::_1;
     using hpx::placeholders::_2;
@@ -68,7 +68,7 @@ void async_test0(hpx::naming::id_type id)
     HPX_TEST_EQ(hpx::async<test0_action>(id).get(), 42);
 }
 
-void async_test1(hpx::naming::id_type id)
+void async_test1(hpx::id_type id)
 {
     using hpx::placeholders::_1;
     using hpx::placeholders::_2;
@@ -94,7 +94,7 @@ int test1(int i)
 }
 HPX_PLAIN_ACTION(test1, test1_action)
 
-void bind_test2(hpx::naming::id_type id)
+void bind_test2(hpx::id_type id)
 {
     using hpx::placeholders::_1;
     using hpx::placeholders::_2;
@@ -106,7 +106,7 @@ void bind_test2(hpx::naming::id_type id)
     HPX_TEST_EQ(hpx::bind<test1_action>(_2, _1)(42, id), 42);
 }
 
-void bind_test3(hpx::naming::id_type id)
+void bind_test3(hpx::id_type id)
 {
     using hpx::placeholders::_1;
     using hpx::placeholders::_2;
@@ -119,7 +119,7 @@ void bind_test3(hpx::naming::id_type id)
     HPX_TEST_EQ(hpx::bind(do_test1, _2, _1)(42, id), 42);
 }
 
-void async_test2(hpx::naming::id_type id)
+void async_test2(hpx::id_type id)
 {
     using hpx::placeholders::_1;
     using hpx::placeholders::_2;
@@ -144,7 +144,7 @@ void async_test2(hpx::naming::id_type id)
     HPX_TEST_EQ(hpx::async<test1_action>(id, 42).get(), 42);
 }
 
-void async_test3(hpx::naming::id_type id)
+void async_test3(hpx::id_type id)
 {
     using hpx::placeholders::_1;
     using hpx::placeholders::_2;
@@ -165,7 +165,7 @@ void async_test3(hpx::naming::id_type id)
     HPX_TEST_EQ(hpx::async(do_test1, id, 42).get(), 42);
 }
 
-void function_bind_test1(hpx::naming::id_type id)
+void function_bind_test1(hpx::id_type id)
 {
     using hpx::placeholders::_1;
     using hpx::placeholders::_2;
@@ -173,19 +173,17 @@ void function_bind_test1(hpx::naming::id_type id)
     hpx::function<int()> f1 = hpx::bind<test1_action>(id, 42);
     HPX_TEST_EQ(f1(), 42);
 
-    hpx::function<int(hpx::naming::id_type)> f2 =
-        hpx::bind<test1_action>(_1, 42);
+    hpx::function<int(hpx::id_type)> f2 = hpx::bind<test1_action>(_1, 42);
     HPX_TEST_EQ(f2(id), 42);
 
     hpx::function<int(int)> f3 = hpx::bind<test1_action>(id, _1);
     HPX_TEST_EQ(f3(42), 42);
 
-    hpx::function<int(hpx::naming::id_type, int)> f4 =
-        hpx::bind<test1_action>(_1, _2);
+    hpx::function<int(hpx::id_type, int)> f4 = hpx::bind<test1_action>(_1, _2);
     HPX_TEST_EQ(f4(id, 42), 42);
 }
 
-void function_bind_test2(hpx::naming::id_type id)
+void function_bind_test2(hpx::id_type id)
 {
     using hpx::placeholders::_1;
     using hpx::placeholders::_2;
@@ -194,30 +192,29 @@ void function_bind_test2(hpx::naming::id_type id)
     hpx::function<int()> f1 = hpx::bind(do_test1, id, 42);
     HPX_TEST_EQ(f1(), 42);
 
-    hpx::function<int(hpx::naming::id_type)> f2 = hpx::bind(do_test1, _1, 42);
+    hpx::function<int(hpx::id_type)> f2 = hpx::bind(do_test1, _1, 42);
     HPX_TEST_EQ(f2(id), 42);
 
     hpx::function<int(int)> f3 = hpx::bind(do_test1, id, _1);
     HPX_TEST_EQ(f3(42), 42);
 
-    hpx::function<int(hpx::naming::id_type, int)> f4 =
-        hpx::bind(do_test1, _1, _2);
+    hpx::function<int(hpx::id_type, int)> f4 = hpx::bind(do_test1, _1, _2);
     HPX_TEST_EQ(f4(id, 42), 42);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-int test2(hpx::distributed::function<int(hpx::naming::id_type)> f)
+int test2(hpx::distributed::function<int(hpx::id_type)> f)
 {
     return f(hpx::find_here());
 }
 HPX_PLAIN_ACTION(test2, test2_action)
 
-void function_bind_test3(hpx::naming::id_type id)
+void function_bind_test3(hpx::id_type id)
 {
     using hpx::placeholders::_1;
     test1_action do_test1;
 
-    hpx::distributed::function<int(hpx::naming::id_type)> f1 =
+    hpx::distributed::function<int(hpx::id_type)> f1 =
         hpx::bind(do_test1, _1, 42);
 
     test2_action do_test2;
@@ -226,11 +223,11 @@ void function_bind_test3(hpx::naming::id_type id)
     HPX_TEST_EQ(f2(), 42);
 }
 
-void function_bind_test4(hpx::naming::id_type id)
+void function_bind_test4(hpx::id_type id)
 {
     using hpx::placeholders::_1;
 
-    hpx::distributed::function<int(hpx::naming::id_type)> f1 =
+    hpx::distributed::function<int(hpx::id_type)> f1 =
         hpx::bind<test1_action>(_1, 42);
 
     hpx::function<int()> f2 = hpx::bind<test2_action>(id, f1);
@@ -245,7 +242,7 @@ int test3(hpx::distributed::function<int()> f)
 }
 HPX_PLAIN_ACTION(test3, test3_action)
 
-void function_bind_test5(hpx::naming::id_type id)
+void function_bind_test5(hpx::id_type id)
 {
     hpx::distributed::function<int()> f1 =
         hpx::bind<test1_action>(hpx::find_here(), 42);
@@ -255,7 +252,7 @@ void function_bind_test5(hpx::naming::id_type id)
     HPX_TEST_EQ(f2(), 42);
 }
 
-void function_bind_test6(hpx::naming::id_type id)
+void function_bind_test6(hpx::id_type id)
 {
     test1_action do_test1;
     hpx::distributed::function<int()> f1 =
@@ -316,7 +313,7 @@ void member_bind_test1()
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-void run_tests(hpx::naming::id_type id)
+void run_tests(hpx::id_type id)
 {
     bind_test0(id);
     bind_test1(id);
@@ -346,8 +343,8 @@ void run_local_tests()
 int hpx_main(hpx::program_options::variables_map&)
 {
     // run the test on all localities
-    std::vector<hpx::naming::id_type> localities = hpx::find_all_localities();
-    for (hpx::naming::id_type const& id : localities)
+    std::vector<hpx::id_type> localities = hpx::find_all_localities();
+    for (hpx::id_type const& id : localities)
         run_tests(id);
 
     // run local tests

--- a/libs/full/checkpoint_base/src/checkpoint_data.cpp
+++ b/libs/full/checkpoint_base/src/checkpoint_data.cpp
@@ -17,7 +17,7 @@ namespace hpx { namespace serialization { namespace detail {
     extra_archive_data_id_type
     extra_archive_data_helper<hpx::util::checkpointing_tag>::id() noexcept
     {
-        static std::uint8_t id;
+        static std::uint8_t id = 0;
         return &id;
     }
 }}}    // namespace hpx::serialization::detail

--- a/libs/full/collectives/include/hpx/collectives/create_communicator.hpp
+++ b/libs/full/collectives/include/hpx/collectives/create_communicator.hpp
@@ -74,7 +74,7 @@ namespace hpx { namespace collectives {
         // construction
         communicator() = default;
 
-        explicit communicator(naming::id_type&& id)
+        explicit communicator(hpx::id_type&& id)
           : base_type(HPX_MOVE(id))
         {
         }

--- a/libs/full/collectives/include/hpx/collectives/detail/barrier_node.hpp
+++ b/libs/full/collectives/include/hpx/collectives/detail/barrier_node.hpp
@@ -61,7 +61,7 @@ namespace hpx { namespace distributed { namespace detail {
     private:
         hpx::util::atomic_count count_;
 
-        std::vector<naming::id_type> children_;
+        std::vector<hpx::id_type> children_;
 
     public:
         std::string base_name_;

--- a/libs/full/collectives/include/hpx/collectives/latch.hpp
+++ b/libs/full/collectives/include/hpx/collectives/latch.hpp
@@ -36,25 +36,25 @@ namespace hpx { namespace lcos {
 
         /// Extension: Create a client side representation for the existing
         /// \a server#latch instance with the given global id \a id.
-        latch(naming::id_type const& id)
+        latch(hpx::id_type const& id)
           : base_type(id)
         {
         }
 
         /// Extension: Create a client side representation for the existing
         /// \a server#latch instance with the given global id \a id.
-        latch(hpx::future<naming::id_type>&& f)
+        latch(hpx::future<hpx::id_type>&& f)
           : base_type(HPX_MOVE(f))
         {
         }
 
         /// Extension: Create a client side representation for the existing
         /// \a server#latch instance with the given global id \a id.
-        latch(hpx::shared_future<naming::id_type> const& id)
+        latch(hpx::shared_future<hpx::id_type> const& id)
           : base_type(id)
         {
         }
-        latch(hpx::shared_future<naming::id_type>&& id)
+        latch(hpx::shared_future<hpx::id_type>&& id)
           : base_type(HPX_MOVE(id))
         {
         }

--- a/libs/full/collectives/tests/performance/osu/osu_bw.cpp
+++ b/libs/full/collectives/tests/performance/osu/osu_bw.cpp
@@ -55,7 +55,7 @@ void isend(hpx::serialization::serialize_buffer<char> const&) {}
 HPX_PLAIN_ACTION(isend)
 
 ///////////////////////////////////////////////////////////////////////////////
-double ireceive(hpx::naming::id_type dest, std::size_t loop, std::size_t size,
+double ireceive(hpx::id_type dest, std::size_t loop, std::size_t size,
     std::size_t window_size)
 {
     std::size_t skip = SKIP;

--- a/libs/full/collectives/tests/performance/osu/osu_latency.cpp
+++ b/libs/full/collectives/tests/performance/osu/osu_latency.cpp
@@ -70,7 +70,7 @@ HPX_PLAIN_DIRECT_ACTION(message_double)
 
 ///////////////////////////////////////////////////////////////////////////////
 double receive_double(
-    hpx::naming::id_type dest, std::size_t loop, std::size_t window_size)
+    hpx::id_type dest, std::size_t loop, std::size_t window_size)
 {
     std::size_t skip = SKIP_LARGE;
 
@@ -98,7 +98,7 @@ double receive_double(
     double elapsed = t.elapsed();
     return (elapsed * 1e6) / static_cast<double>(2 * loop * window_size);
 }
-double receive(hpx::naming::id_type dest, char* send_buffer, std::size_t size,
+double receive(hpx::id_type dest, char* send_buffer, std::size_t size,
     std::size_t loop, std::size_t window_size)
 {
     std::size_t skip = SKIP_LARGE;

--- a/libs/full/collectives/tests/performance/osu/osu_multi_lat.cpp
+++ b/libs/full/collectives/tests/performance/osu/osu_multi_lat.cpp
@@ -66,8 +66,7 @@ hpx::serialization::serialize_buffer<char> isend(
 HPX_PLAIN_ACTION(isend)
 
 ///////////////////////////////////////////////////////////////////////////////
-double ireceive(
-    hpx::naming::id_type dest, std::size_t size, std::size_t window_size)
+double ireceive(hpx::id_type dest, std::size_t size, std::size_t window_size)
 {
     int loop = LOOP_SMALL;
     int skip = SKIP_SMALL;

--- a/libs/full/components/include/hpx/components/client.hpp
+++ b/libs/full/components/include/hpx/components/client.hpp
@@ -24,11 +24,11 @@ namespace hpx { namespace components {
         // construction
         client() = default;
 
-        explicit client(naming::id_type const& id)
+        explicit client(hpx::id_type const& id)
           : base_type(id)
         {
         }
-        explicit client(naming::id_type&& id)
+        explicit client(hpx::id_type&& id)
           : base_type(HPX_MOVE(id))
         {
         }
@@ -41,7 +41,7 @@ namespace hpx { namespace components {
           : base_type(HPX_MOVE(f))
         {
         }
-        client(future<naming::id_type>&& f) noexcept
+        client(future<hpx::id_type>&& f) noexcept
           : base_type(HPX_MOVE(f))
         {
         }
@@ -60,12 +60,12 @@ namespace hpx { namespace components {
         }
 
         // copy assignment and move assignment
-        client& operator=(naming::id_type const& id)
+        client& operator=(hpx::id_type const& id)
         {
             base_type::operator=(id);
             return *this;
         }
-        client& operator=(naming::id_type&& id)
+        client& operator=(hpx::id_type&& id)
         {
             base_type::operator=(HPX_MOVE(id));
             return *this;
@@ -81,7 +81,7 @@ namespace hpx { namespace components {
             base_type::operator=(HPX_MOVE(f));
             return *this;
         }
-        client& operator=(future<naming::id_type>&& f) noexcept
+        client& operator=(future<hpx::id_type>&& f) noexcept
         {
             base_type::operator=(HPX_MOVE(f));
             return *this;

--- a/libs/full/components/include/hpx/components/get_ptr.hpp
+++ b/libs/full/components/include/hpx/components/get_ptr.hpp
@@ -33,7 +33,7 @@ namespace hpx {
         ///////////////////////////////////////////////////////////////////////
         struct get_ptr_deleter
         {
-            explicit get_ptr_deleter(naming::id_type const& id) noexcept
+            explicit get_ptr_deleter(hpx::id_type const& id) noexcept
               : id_(id)
             {
             }
@@ -41,17 +41,16 @@ namespace hpx {
             template <typename Component>
             void operator()(Component* p)
             {
-                id_ = naming::invalid_id;    // release component
+                id_ = hpx::invalid_id;    // release component
                 traits::component_pin_support<Component>::unpin(p);
             }
 
-            naming::id_type id_;    // holds component alive
+            hpx::id_type id_;    // holds component alive
         };
 
         struct get_ptr_no_unpin_deleter
         {
-            explicit get_ptr_no_unpin_deleter(
-                naming::id_type const& id) noexcept
+            explicit get_ptr_no_unpin_deleter(hpx::id_type const& id) noexcept
               : id_(id)
             {
             }
@@ -59,16 +58,16 @@ namespace hpx {
             template <typename Component>
             void operator()(Component*)
             {
-                id_ = naming::invalid_id;    // release component
+                id_ = hpx::invalid_id;    // release component
             }
 
-            naming::id_type id_;    // holds component alive
+            hpx::id_type id_;    // holds component alive
         };
 
         struct get_ptr_for_migration_deleter
         {
             explicit get_ptr_for_migration_deleter(
-                naming::id_type const& id) noexcept
+                hpx::id_type const& id) noexcept
               : id_(id)
             {
             }
@@ -88,15 +87,15 @@ namespace hpx {
                                             agas::get_locality_id()),
                             type, p));
                 }
-                id_ = naming::invalid_id;    // release credits
+                id_ = hpx::invalid_id;    // release credits
             }
 
-            naming::id_type id_;    // holds component alive
+            hpx::id_type id_;    // holds component alive
         };
 
         template <typename Component, typename Deleter>
         std::shared_ptr<Component> get_ptr_postproc(
-            naming::address const& addr, naming::id_type const& id)
+            naming::address const& addr, hpx::id_type const& id)
         {
             if (agas::get_locality_id() !=
                 naming::get_locality_id_from_gid(addr.locality_))
@@ -129,7 +128,7 @@ namespace hpx {
         // delete the local instance when it goes out of scope.
         template <typename Component>
         std::shared_ptr<Component> get_ptr_for_migration(
-            naming::address const& addr, naming::id_type const& id)
+            naming::address const& addr, hpx::id_type const& id)
         {
             return get_ptr_postproc<Component, get_ptr_for_migration_deleter>(
                 addr, id);
@@ -163,7 +162,7 @@ namespace hpx {
     ///            returned shared_ptr alive.
     ///
     template <typename Component>
-    hpx::future<std::shared_ptr<Component>> get_ptr(naming::id_type const& id)
+    hpx::future<std::shared_ptr<Component>> get_ptr(hpx::id_type const& id)
     {
         hpx::future<naming::address> f = agas::resolve(id);
         return f.then(hpx::launch::sync,
@@ -241,12 +240,12 @@ namespace hpx {
     ///
 #if defined(DOXYGEN)
     template <typename Component>
-    std::shared_ptr<Component> get_ptr(launch::sync_policy p,
-        naming::id_type const& id, error_code& ec = throws);
+    std::shared_ptr<Component> get_ptr(
+        launch::sync_policy p, hpx::id_type const& id, error_code& ec = throws);
 #else
     template <typename Component>
     std::shared_ptr<Component> get_ptr(
-        launch::sync_policy, naming::id_type const& id, error_code& ec = throws)
+        launch::sync_policy, hpx::id_type const& id, error_code& ec = throws)
     {
         // shortcut for local, non-migratable objects
         naming::gid_type gid = id.get_gid();

--- a/libs/full/components_base/include/hpx/components_base/agas_interface.hpp
+++ b/libs/full/components_base/include/hpx/components_base/agas_interface.hpp
@@ -44,24 +44,23 @@ namespace hpx { namespace agas {
         naming::gid_type const& gid, error_code& ec = throws);
 
     HPX_EXPORT bool register_name(launch::sync_policy, std::string const& name,
-        naming::id_type const& id, error_code& ec = throws);
+        hpx::id_type const& id, error_code& ec = throws);
 
     HPX_EXPORT hpx::future<bool> register_name(
-        std::string const& name, naming::id_type const& id);
+        std::string const& name, hpx::id_type const& id);
 
     ///////////////////////////////////////////////////////////////////////////
-    HPX_EXPORT naming::id_type unregister_name(
+    HPX_EXPORT hpx::id_type unregister_name(
         launch::sync_policy, std::string const& name, error_code& ec = throws);
 
-    HPX_EXPORT hpx::future<naming::id_type> unregister_name(
+    HPX_EXPORT hpx::future<hpx::id_type> unregister_name(
         std::string const& name);
 
     ///////////////////////////////////////////////////////////////////////////
-    HPX_EXPORT naming::id_type resolve_name(
+    HPX_EXPORT hpx::id_type resolve_name(
         launch::sync_policy, std::string const& name, error_code& ec = throws);
 
-    HPX_EXPORT hpx::future<naming::id_type> resolve_name(
-        std::string const& name);
+    HPX_EXPORT hpx::future<hpx::id_type> resolve_name(std::string const& name);
 
     ///////////////////////////////////////////////////////////////////////////
     HPX_EXPORT hpx::future<std::uint32_t> get_num_localities(
@@ -127,13 +126,13 @@ namespace hpx { namespace agas {
         naming::address& addr, error_code& ec = throws);
 
     inline bool is_local_address_cached(
-        naming::id_type const& id, error_code& ec = throws)
+        hpx::id_type const& id, error_code& ec = throws)
     {
         return is_local_address_cached(id.get_gid(), ec);
     }
 
-    inline bool is_local_address_cached(naming::id_type const& id,
-        naming::address& addr, error_code& ec = throws)
+    inline bool is_local_address_cached(
+        hpx::id_type const& id, naming::address& addr, error_code& ec = throws)
     {
         return is_local_address_cached(id.get_gid(), addr, ec);
     }
@@ -145,16 +144,16 @@ namespace hpx { namespace agas {
     ///////////////////////////////////////////////////////////////////////////
     HPX_EXPORT bool is_local_lva_encoded_address(naming::gid_type const& gid);
 
-    inline bool is_local_lva_encoded_address(naming::id_type const& id)
+    inline bool is_local_lva_encoded_address(hpx::id_type const& id)
     {
         return is_local_lva_encoded_address(id.get_gid());
     }
 
     ///////////////////////////////////////////////////////////////////////////
-    HPX_EXPORT hpx::future<naming::address> resolve(naming::id_type const& id);
+    HPX_EXPORT hpx::future<naming::address> resolve(hpx::id_type const& id);
 
-    HPX_EXPORT naming::address resolve(launch::sync_policy,
-        naming::id_type const& id, error_code& ec = throws);
+    HPX_EXPORT naming::address resolve(
+        launch::sync_policy, hpx::id_type const& id, error_code& ec = throws);
 
     HPX_EXPORT bool resolve_local(naming::gid_type const& gid,
         naming::address& addr, error_code& ec = throws);
@@ -206,16 +205,16 @@ namespace hpx { namespace agas {
     /// \brief Invoke an asynchronous garbage collection step on the given target
     ///        locality.
     HPX_EXPORT void garbage_collect_non_blocking(
-        naming::id_type const& id, error_code& ec = throws);
+        hpx::id_type const& id, error_code& ec = throws);
 
     /// \brief Invoke a synchronous garbage collection step on the given target
     ///        locality.
     HPX_EXPORT void garbage_collect(
-        naming::id_type const& id, error_code& ec = throws);
+        hpx::id_type const& id, error_code& ec = throws);
 
     ///////////////////////////////////////////////////////////////////////////
     /// \brief Return an id_type referring to the console locality.
-    HPX_EXPORT naming::id_type get_console_locality(error_code& ec = throws);
+    HPX_EXPORT hpx::id_type get_console_locality(error_code& ec = throws);
 
     ///////////////////////////////////////////////////////////////////////////
     HPX_EXPORT naming::gid_type get_next_id(
@@ -227,33 +226,32 @@ namespace hpx { namespace agas {
 
     ///////////////////////////////////////////////////////////////////////////
     HPX_EXPORT hpx::future<std::int64_t> incref(naming::gid_type const& gid,
-        std::int64_t credits,
-        naming::id_type const& keep_alive = naming::invalid_id);
+        std::int64_t credits, hpx::id_type const& keep_alive = hpx::invalid_id);
 
     HPX_EXPORT std::int64_t incref(launch::sync_policy,
         naming::gid_type const& gid, std::int64_t credits = 1,
-        naming::id_type const& keep_alive = naming::invalid_id,
+        hpx::id_type const& keep_alive = hpx::invalid_id,
         error_code& ec = throws);
 
     ///////////////////////////////////////////////////////////////////////////
     HPX_EXPORT std::int64_t replenish_credits(naming::gid_type& gid);
 
     ///////////////////////////////////////////////////////////////////////////
-    HPX_EXPORT hpx::future<naming::id_type> get_colocation_id(
-        naming::id_type const& id);
+    HPX_EXPORT hpx::future<hpx::id_type> get_colocation_id(
+        hpx::id_type const& id);
 
-    HPX_EXPORT naming::id_type get_colocation_id(launch::sync_policy,
-        naming::id_type const& id, error_code& ec = throws);
+    HPX_EXPORT hpx::id_type get_colocation_id(
+        launch::sync_policy, hpx::id_type const& id, error_code& ec = throws);
 
     ///////////////////////////////////////////////////////////////////////////
     HPX_EXPORT hpx::future<hpx::id_type> on_symbol_namespace_event(
         std::string const& name, bool call_for_past_events);
 
     ///////////////////////////////////////////////////////////////////////////
-    HPX_EXPORT hpx::future<std::pair<naming::id_type, naming::address>>
-    begin_migration(naming::id_type const& id);
+    HPX_EXPORT hpx::future<std::pair<hpx::id_type, naming::address>>
+    begin_migration(hpx::id_type const& id);
 
-    HPX_EXPORT bool end_migration(naming::id_type const& id);
+    HPX_EXPORT bool end_migration(hpx::id_type const& id);
 
     HPX_EXPORT hpx::future<void> mark_as_migrated(naming::gid_type const& gid,
         hpx::move_only_function<std::pair<bool, hpx::future<void>>()>&& f,

--- a/libs/full/components_base/include/hpx/components_base/server/component_base.hpp
+++ b/libs/full/components_base/include/hpx/components_base/server/component_base.hpp
@@ -45,8 +45,8 @@ namespace hpx { namespace components {
             // finalize() will be called just before the instance gets destructed
             static constexpr void finalize() noexcept {}
 
-            HPX_EXPORT naming::id_type get_id(naming::gid_type gid) const;
-            HPX_EXPORT naming::id_type get_unmanaged_id(
+            HPX_EXPORT hpx::id_type get_id(naming::gid_type gid) const;
+            HPX_EXPORT hpx::id_type get_unmanaged_id(
                 naming::gid_type const& gid) const;
 
             static void mark_as_migrated() noexcept
@@ -119,14 +119,14 @@ namespace hpx { namespace components {
                 const_cast<component_base*>(this));
         }
 
-        naming::id_type get_id() const
+        hpx::id_type get_id() const
         {
             // all credits should have been taken already
             return this->detail::base_component::get_id(
                 static_cast<Component const&>(*this).get_base_gid());
         }
 
-        naming::id_type get_unmanaged_id() const
+        hpx::id_type get_unmanaged_id() const
         {
             return this->detail::base_component::get_unmanaged_id(
                 static_cast<Component const&>(*this).get_base_gid());

--- a/libs/full/components_base/include/hpx/components_base/server/fixed_component_base.hpp
+++ b/libs/full/components_base/include/hpx/components_base/server/fixed_component_base.hpp
@@ -110,20 +110,20 @@ namespace hpx { namespace components {
         }
 
     public:
-        naming::id_type get_id() const
+        hpx::id_type get_id() const
         {
             // fixed_address components are created without any credits
             naming::gid_type gid = derived().get_base_gid();
             HPX_ASSERT(!naming::detail::has_credits(gid));
 
             agas::replenish_credits(gid);
-            return naming::id_type(gid, naming::id_type::managed);
+            return hpx::id_type(gid, hpx::id_type::management_type::managed);
         }
 
-        naming::id_type get_unmanaged_id() const
+        hpx::id_type get_unmanaged_id() const
         {
-            return naming::id_type(
-                derived().get_base_gid(), naming::id_type::unmanaged);
+            return hpx::id_type(derived().get_base_gid(),
+                hpx::id_type::management_type::unmanaged);
         }
 
         void set_locality_id(std::uint32_t locality_id, error_code& ec = throws)

--- a/libs/full/components_base/include/hpx/components_base/server/managed_component_base.hpp
+++ b/libs/full/components_base/include/hpx/components_base/server/managed_component_base.hpp
@@ -237,8 +237,8 @@ namespace hpx { namespace components {
         using wrapping_type = managed_component<Component, Wrapper>;
         using base_type_holder = Component;
 
-        naming::id_type get_unmanaged_id() const;
-        naming::id_type get_id() const;
+        hpx::id_type get_unmanaged_id() const;
+        hpx::id_type get_id() const;
 
     protected:
         naming::gid_type get_base_gid() const;
@@ -432,9 +432,10 @@ namespace hpx { namespace components {
 
         ///////////////////////////////////////////////////////////////////////
         /// \brief Return the global id of this \a future instance
-        naming::id_type get_unmanaged_id() const
+        hpx::id_type get_unmanaged_id() const
         {
-            return naming::id_type(get_base_gid(), naming::id_type::unmanaged);
+            return hpx::id_type(
+                get_base_gid(), hpx::id_type::management_type::unmanaged);
         }
 
     public:
@@ -468,8 +469,8 @@ namespace hpx { namespace components {
     ///////////////////////////////////////////////////////////////////////////
     template <typename Component, typename Wrapper, typename CtorPolicy,
         typename DtorPolicy>
-    inline naming::id_type managed_component_base<Component, Wrapper,
-        CtorPolicy, DtorPolicy>::get_unmanaged_id() const
+    inline hpx::id_type managed_component_base<Component, Wrapper, CtorPolicy,
+        DtorPolicy>::get_unmanaged_id() const
     {
         HPX_ASSERT(back_ptr_);
         return back_ptr_->get_unmanaged_id();
@@ -477,8 +478,8 @@ namespace hpx { namespace components {
 
     template <typename Component, typename Wrapper, typename CtorPolicy,
         typename DtorPolicy>
-    inline naming::id_type managed_component_base<Component, Wrapper,
-        CtorPolicy, DtorPolicy>::get_id() const
+    inline hpx::id_type managed_component_base<Component, Wrapper, CtorPolicy,
+        DtorPolicy>::get_id() const
     {
         // all credits should have been taken already
         naming::gid_type gid =
@@ -491,7 +492,7 @@ namespace hpx { namespace components {
 
         // any invocation causes the credits to be replenished
         agas::replenish_credits(gid);
-        return naming::id_type(gid, naming::id_type::managed);
+        return hpx::id_type(gid, hpx::id_type::management_type::managed);
     }
 
     template <typename Component, typename Wrapper, typename CtorPolicy,

--- a/libs/full/components_base/src/agas_interface.cpp
+++ b/libs/full/components_base/src/agas_interface.cpp
@@ -41,36 +41,36 @@ namespace hpx { namespace agas {
     }
 
     bool register_name(launch::sync_policy, std::string const& name,
-        naming::id_type const& id, error_code& ec)
+        hpx::id_type const& id, error_code& ec)
     {
         return detail::register_name_id(name, id, ec);
     }
 
     hpx::future<bool> register_name(
-        std::string const& name, naming::id_type const& id)
+        std::string const& name, hpx::id_type const& id)
     {
         return detail::register_name_async(name, id);
     }
 
     ///////////////////////////////////////////////////////////////////////////
-    naming::id_type unregister_name(
+    hpx::id_type unregister_name(
         launch::sync_policy, std::string const& name, error_code& ec)
     {
         return detail::unregister_name(name, ec);
     }
 
-    hpx::future<naming::id_type> unregister_name(std::string const& name)
+    hpx::future<hpx::id_type> unregister_name(std::string const& name)
     {
         return detail::unregister_name_async(name);
     }
 
     ///////////////////////////////////////////////////////////////////////////
-    hpx::future<naming::id_type> resolve_name(std::string const& name)
+    hpx::future<hpx::id_type> resolve_name(std::string const& name)
     {
         return detail::resolve_name_async(name);
     }
 
-    naming::id_type resolve_name(
+    hpx::id_type resolve_name(
         launch::sync_policy, std::string const& name, error_code& ec)
     {
         return detail::resolve_name(name, ec);
@@ -140,13 +140,13 @@ namespace hpx { namespace agas {
     }
 
     ///////////////////////////////////////////////////////////////////////////
-    hpx::future<naming::address> resolve(naming::id_type const& id)
+    hpx::future<naming::address> resolve(hpx::id_type const& id)
     {
         return detail::resolve_async(id);
     }
 
     naming::address resolve(
-        launch::sync_policy, naming::id_type const& id, error_code& ec)
+        launch::sync_policy, hpx::id_type const& id, error_code& ec)
     {
         return detail::resolve(id, ec);
     }
@@ -236,20 +236,20 @@ namespace hpx { namespace agas {
 
     /// \brief Invoke an asynchronous garbage collection step on the given target
     ///        locality.
-    void garbage_collect_non_blocking(naming::id_type const& id, error_code& ec)
+    void garbage_collect_non_blocking(hpx::id_type const& id, error_code& ec)
     {
         detail::garbage_collect_non_blocking_id(id, ec);
     }
 
     /// \brief Invoke a synchronous garbage collection step on the given target
     ///        locality.
-    void garbage_collect(naming::id_type const& id, error_code& ec)
+    void garbage_collect(hpx::id_type const& id, error_code& ec)
     {
         detail::garbage_collect_id(id, ec);
     }
 
     /// \brief Return an id_type referring to the console locality.
-    naming::id_type get_console_locality(error_code& ec)
+    hpx::id_type get_console_locality(error_code& ec)
     {
         return detail::get_console_locality(ec);
     }
@@ -294,13 +294,13 @@ namespace hpx { namespace agas {
 
     ///////////////////////////////////////////////////////////////////////////
     hpx::future<std::int64_t> incref(naming::gid_type const& gid,
-        std::int64_t credits, naming::id_type const& keep_alive)
+        std::int64_t credits, hpx::id_type const& keep_alive)
     {
         return detail::incref_async(gid, credits, keep_alive);
     }
 
     std::int64_t incref(launch::sync_policy, naming::gid_type const& gid,
-        std::int64_t credits, naming::id_type const& keep_alive, error_code& ec)
+        std::int64_t credits, hpx::id_type const& keep_alive, error_code& ec)
     {
         return detail::incref(gid, credits, keep_alive, ec);
     }
@@ -312,13 +312,13 @@ namespace hpx { namespace agas {
     }
 
     ///////////////////////////////////////////////////////////////////////////
-    hpx::future<naming::id_type> get_colocation_id(naming::id_type const& id)
+    hpx::future<hpx::id_type> get_colocation_id(hpx::id_type const& id)
     {
         return detail::get_colocation_id_async(id);
     }
 
-    naming::id_type get_colocation_id(
-        launch::sync_policy, naming::id_type const& id, error_code& ec)
+    hpx::id_type get_colocation_id(
+        launch::sync_policy, hpx::id_type const& id, error_code& ec)
     {
         return detail::get_colocation_id(id, ec);
     }
@@ -331,13 +331,13 @@ namespace hpx { namespace agas {
     }
 
     ///////////////////////////////////////////////////////////////////////////
-    hpx::future<std::pair<naming::id_type, naming::address>> begin_migration(
-        naming::id_type const& id)
+    hpx::future<std::pair<hpx::id_type, naming::address>> begin_migration(
+        hpx::id_type const& id)
     {
         return detail::begin_migration(id);
     }
 
-    bool end_migration(naming::id_type const& id)
+    bool end_migration(hpx::id_type const& id)
     {
         return detail::end_migration(id);
     }
@@ -362,13 +362,13 @@ namespace hpx { namespace agas {
         return detail::unmark_as_migrated(gid);
     }
 
-    hpx::future<std::map<std::string, naming::id_type>> find_symbols(
+    hpx::future<std::map<std::string, hpx::id_type>> find_symbols(
         std::string const& pattern)
     {
         return detail::find_symbols_async(pattern);
     }
 
-    std::map<std::string, naming::id_type> find_symbols(
+    std::map<std::string, hpx::id_type> find_symbols(
         hpx::launch::sync_policy, std::string const& pattern)
     {
         return detail::find_symbols(pattern);

--- a/libs/full/components_base/src/server/component_base.cpp
+++ b/libs/full/components_base/src/server/component_base.cpp
@@ -141,19 +141,19 @@ namespace hpx { namespace components { namespace detail {
         return gid;
     }
 
-    naming::id_type base_component::get_id(naming::gid_type gid) const
+    hpx::id_type base_component::get_id(naming::gid_type gid) const
     {
         // all credits should have been taken already
         HPX_ASSERT(!naming::detail::has_credits(gid));
 
         // any (subsequent) invocation causes the credits to be replenished
         agas::replenish_credits(gid);
-        return naming::id_type(gid, naming::id_type::managed);
+        return hpx::id_type(gid, hpx::id_type::management_type::managed);
     }
 
-    naming::id_type base_component::get_unmanaged_id(
+    hpx::id_type base_component::get_unmanaged_id(
         naming::gid_type const& gid) const
     {
-        return naming::id_type(gid, naming::id_type::managed);
+        return hpx::id_type(gid, hpx::id_type::management_type::managed);
     }
 }}}    // namespace hpx::components::detail

--- a/libs/full/init_runtime/src/hpx_init.cpp
+++ b/libs/full/init_runtime/src/hpx_init.cpp
@@ -119,8 +119,8 @@ HPX_PLAIN_ACTION_ID(hpx::detail::list_component_type,
     list_component_type_action, hpx::actions::list_component_type_action_id)
 
 typedef hpx::detail::bound_action<list_component_type_action,
-    hpx::util::index_pack<0, 1, 2>, hpx::naming::id_type,
-    hpx::detail::placeholder<1>, hpx::detail::placeholder<2>>
+    hpx::util::index_pack<0, 1, 2>, hpx::id_type, hpx::detail::placeholder<1>,
+    hpx::detail::placeholder<2>>
     bound_list_component_type_action;
 
 HPX_UTIL_REGISTER_FUNCTION_DECLARATION(
@@ -143,7 +143,7 @@ namespace hpx { namespace detail {
     inline void print(std::string const& name, error_code& ec = throws)
     {
 #if defined(HPX_HAVE_DISTRIBUTED_RUNTIME)
-        naming::id_type console(agas::get_console_locality(ec));
+        hpx::id_type console(agas::get_console_locality(ec));
         if (ec)
             return;
 
@@ -249,8 +249,9 @@ namespace hpx { namespace detail {
     void list_symbolic_name(std::string const& name, hpx::id_type const& id)
     {
         std::string str = hpx::util::format("{}, {}, {}", name, id,
-            (id.get_management_type() == id_type::managed ? "managed" :
-                                                            "unmanaged"));
+            (id.get_management_type() == id_type::management_type::managed ?
+                    "management_type::managed" :
+                    "management_type::unmanaged"));
         print(str);
     }
 
@@ -284,7 +285,7 @@ namespace hpx { namespace detail {
         using hpx::placeholders::_1;
         using hpx::placeholders::_2;
 
-        naming::id_type console(agas::get_console_locality());
+        hpx::id_type console(agas::get_console_locality());
         naming::get_agas_client().iterate_types(
             hpx::bind<list_component_type_action>(console, _1, _2));
     }
@@ -1027,7 +1028,7 @@ namespace hpx {
         p->call_shutdown_functions(true);
         p->call_shutdown_functions(false);
 
-        p->stop(shutdown_timeout, naming::invalid_id, true);
+        p->stop(shutdown_timeout, hpx::invalid_id, true);
 #else
         HPX_UNUSED(shutdown_timeout);
         HPX_UNUSED(localwait);

--- a/libs/full/lcos_distributed/include/hpx/lcos_distributed/channel.hpp
+++ b/libs/full/lcos_distributed/include/hpx/lcos_distributed/channel.hpp
@@ -177,22 +177,22 @@ namespace hpx { namespace lcos {
         channel() = default;
 
         // create a new instance of a channel component
-        explicit channel(naming::id_type const& loc)
+        explicit channel(hpx::id_type const& loc)
           : base_type(hpx::new_<lcos::server::channel<T>>(loc))
         {
         }
 
-        explicit channel(hpx::future<naming::id_type>&& id)
+        explicit channel(hpx::future<hpx::id_type>&& id)
           : base_type(HPX_MOVE(id))
         {
         }
 
-        explicit channel(hpx::shared_future<naming::id_type>&& id)
+        explicit channel(hpx::shared_future<hpx::id_type>&& id)
           : base_type(HPX_MOVE(id))
         {
         }
 
-        explicit channel(hpx::shared_future<naming::id_type> const& id)
+        explicit channel(hpx::shared_future<hpx::id_type> const& id)
           : base_type(id)
         {
         }
@@ -362,17 +362,17 @@ namespace hpx { namespace lcos {
         {
         }
 
-        explicit receive_channel(hpx::future<naming::id_type>&& id)
+        explicit receive_channel(hpx::future<hpx::id_type>&& id)
           : base_type(HPX_MOVE(id))
         {
         }
 
-        explicit receive_channel(hpx::shared_future<naming::id_type>&& id)
+        explicit receive_channel(hpx::shared_future<hpx::id_type>&& id)
           : base_type(HPX_MOVE(id))
         {
         }
 
-        explicit receive_channel(hpx::shared_future<naming::id_type> const& id)
+        explicit receive_channel(hpx::shared_future<hpx::id_type> const& id)
           : base_type(id)
         {
         }
@@ -445,17 +445,17 @@ namespace hpx { namespace lcos {
         {
         }
 
-        explicit send_channel(hpx::future<naming::id_type>&& id)
+        explicit send_channel(hpx::future<hpx::id_type>&& id)
           : base_type(HPX_MOVE(id))
         {
         }
 
-        explicit send_channel(hpx::shared_future<naming::id_type>&& id)
+        explicit send_channel(hpx::shared_future<hpx::id_type>&& id)
           : base_type(HPX_MOVE(id))
         {
         }
 
-        explicit send_channel(hpx::shared_future<naming::id_type> const& id)
+        explicit send_channel(hpx::shared_future<hpx::id_type> const& id)
           : base_type(id)
         {
         }

--- a/libs/full/lcos_distributed/include/hpx/lcos_distributed/object_semaphore.hpp
+++ b/libs/full/lcos_distributed/include/hpx/lcos_distributed/object_semaphore.hpp
@@ -30,7 +30,7 @@ namespace hpx { namespace lcos {
 
         object_semaphore() = default;
 
-        explicit object_semaphore(naming::id_type gid)
+        explicit object_semaphore(hpx::id_type gid)
           : base_type(HPX_MOVE(gid))
         {
         }

--- a/libs/full/lcos_distributed/include/hpx/lcos_distributed/server/object_semaphore.hpp
+++ b/libs/full/lcos_distributed/include/hpx/lcos_distributed/server/object_semaphore.hpp
@@ -42,12 +42,12 @@ namespace hpx { namespace lcos { namespace server {
                 boost::intrusive::link_mode<boost::intrusive::normal_link>>
                 hook_type;
 
-            explicit queue_thread_entry(naming::id_type const& id)
+            explicit queue_thread_entry(hpx::id_type const& id)
               : id_(id)
             {
             }
 
-            naming::id_type id_;
+            hpx::id_type id_;
             hook_type slist_hook_;
         };
 
@@ -109,8 +109,8 @@ namespace hpx { namespace lcos { namespace server {
                 else
                     --value_queue_.front().count_;
 
-                naming::id_type id = thread_queue_.front().id_;
-                thread_queue_.front().id_ = naming::invalid_id;
+                hpx::id_type id = thread_queue_.front().id_;
+                thread_queue_.front().id_ = hpx::invalid_id;
                 thread_queue_.pop_front();
 
                 {
@@ -145,7 +145,7 @@ namespace hpx { namespace lcos { namespace server {
             resume(l);
         }
 
-        void get(naming::id_type const& lco)
+        void get(hpx::id_type const& lco)
         {
             // push the LCO's GID onto the queue
             std::unique_ptr<queue_thread_entry> node(
@@ -169,8 +169,8 @@ namespace hpx { namespace lcos { namespace server {
 
             while (!thread_queue_.empty())
             {
-                naming::id_type id = thread_queue_.front().id_;
-                thread_queue_.front().id_ = naming::invalid_id;
+                hpx::id_type id = thread_queue_.front().id_;
+                thread_queue_.front().id_ = hpx::invalid_id;
                 thread_queue_.pop_front();
 
                 LLCO_(info).format(
@@ -203,7 +203,7 @@ namespace hpx { namespace lcos { namespace server {
 
             for (; it != end; ++it)
             {
-                naming::id_type id = it->id_;
+                hpx::id_type id = it->id_;
 
                 LLCO_(info).format(
                     "object_semapohre::wait: waiting for {}", id);

--- a/libs/full/lcos_distributed/tests/regressions/channel_2916.cpp
+++ b/libs/full/lcos_distributed/tests/regressions/channel_2916.cpp
@@ -12,7 +12,7 @@
 
 #include <cstddef>
 
-typedef hpx::naming::id_type locality_id_t;
+typedef hpx::id_type locality_id_t;
 HPX_REGISTER_CHANNEL(locality_id_t)
 
 std::atomic<std::size_t> count(0);

--- a/libs/full/lcos_distributed/tests/unit/future_wait.cpp
+++ b/libs/full/lcos_distributed/tests/unit/future_wait.cpp
@@ -37,7 +37,7 @@ using hpx::future;
 
 using hpx::find_here;
 
-using hpx::naming::id_type;
+using hpx::id_type;
 
 ///////////////////////////////////////////////////////////////////////////////
 struct callback

--- a/libs/full/naming/include/hpx/naming/credit_handling.hpp
+++ b/libs/full/naming/include/hpx/naming/credit_handling.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2020 Hartmut Kaiser
+//  Copyright (c) 2007-2022 Hartmut Kaiser
 //  Copyright (c) 2011 Bryce Lelbach
 //  Copyright (c) 2007 Richard D. Guidry Jr.
 //
@@ -22,7 +22,7 @@
 #include <vector>
 
 ///////////////////////////////////////////////////////////////////////////////
-namespace hpx { namespace naming {
+namespace hpx::naming {
 
     ///////////////////////////////////////////////////////////////////////////
     HPX_EXPORT void decrement_refcnt(gid_type const& gid);
@@ -75,12 +75,15 @@ namespace hpx { namespace naming {
 
         HPX_SERIALIZATION_SPLIT_FREE(id_type_impl)
     }    // namespace detail
+}    // namespace hpx::naming
+
+namespace hpx {
 
     ///////////////////////////////////////////////////////////////////////////
     HPX_EXPORT void save(
-        serialization::output_archive& ar, id_type const&, unsigned int);
+        serialization::output_archive& ar, hpx::id_type const&, unsigned int);
     HPX_EXPORT void load(
-        serialization::input_archive& ar, id_type&, unsigned int);
+        serialization::input_archive& ar, hpx::id_type&, unsigned int);
 
-    HPX_SERIALIZATION_SPLIT_FREE(id_type)
-}}    // namespace hpx::naming
+    HPX_SERIALIZATION_SPLIT_FREE(hpx::id_type)
+}    // namespace hpx

--- a/libs/full/naming/include/hpx/naming/detail/preprocess_gid_types.hpp
+++ b/libs/full/naming/include/hpx/naming/detail/preprocess_gid_types.hpp
@@ -23,7 +23,7 @@
 #include <vector>
 
 ///////////////////////////////////////////////////////////////////////////////
-namespace hpx { namespace serialization { namespace detail {
+namespace hpx::serialization::detail {
 
     ///////////////////////////////////////////////////////////////////////////
     // This class allows to handle credit splitting for gid_types during
@@ -133,4 +133,4 @@ namespace hpx { namespace serialization { namespace detail {
         HPX_EXPORT static extra_archive_data_id_type id() noexcept;
         static constexpr void reset(preprocess_gid_types*) noexcept {}
     };
-}}}    // namespace hpx::serialization::detail
+}    // namespace hpx::serialization::detail

--- a/libs/full/naming/include/hpx/naming/split_gid.hpp
+++ b/libs/full/naming/include/hpx/naming/split_gid.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2014 Hartmut Kaiser
+//  Copyright (c) 2007-2022 Hartmut Kaiser
 //  Copyright (c) 2011 Bryce Lelbach
 //  Copyright (c) 2007 Richard D. Guidry Jr.
 //
@@ -9,17 +9,14 @@
 #pragma once
 
 #include <hpx/config.hpp>
-#include <hpx/datastructures/any.hpp>
 #include <hpx/futures/future.hpp>
 #include <hpx/naming_base/gid_type.hpp>
-#include <hpx/synchronization/spinlock.hpp>
 
-#include <map>
 #include <mutex>
 
-namespace hpx { namespace naming { namespace detail {
+namespace hpx::naming::detail {
 
     HPX_EXPORT hpx::future<gid_type> split_gid_if_needed(gid_type& id);
     HPX_EXPORT hpx::future<gid_type> split_gid_if_needed_locked(
         std::unique_lock<gid_type::mutex_type>& l, gid_type& gid);
-}}}    // namespace hpx::naming::detail
+}    // namespace hpx::naming::detail

--- a/libs/full/naming/src/detail/preprocess_gid_types.cpp
+++ b/libs/full/naming/src/detail/preprocess_gid_types.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2015-2021 Hartmut Kaiser
+//  Copyright (c) 2015-2022 Hartmut Kaiser
 //  Copyright (c) 2015-2016 Thomas Heller
 //
 //  SPDX-License-Identifier: BSL-1.0
@@ -10,14 +10,14 @@
 
 #include <cstdint>
 
-namespace hpx { namespace serialization { namespace detail {
+namespace hpx::serialization::detail {
 
     // This is explicitly instantiated to ensure that the id is stable across
     // shared libraries.
     extra_archive_data_id_type
     extra_archive_data_helper<preprocess_gid_types>::id() noexcept
     {
-        static std::uint8_t id;
+        static std::uint8_t id = 0;
         return &id;
     }
-}}}    // namespace hpx::serialization::detail
+}    // namespace hpx::serialization::detail

--- a/libs/full/naming_base/include/hpx/naming_base/address.hpp
+++ b/libs/full/naming_base/include/hpx/naming_base/address.hpp
@@ -22,7 +22,7 @@
 #define HPX_ADDRESS_VERSION 0x20
 
 ///////////////////////////////////////////////////////////////////////////////
-namespace hpx { namespace naming {
+namespace hpx::naming {
 
     struct address
     {
@@ -93,7 +93,7 @@ namespace hpx { namespace naming {
     };
 
     HPX_EXPORT std::ostream& operator<<(std::ostream& os, address const& addr);
-}}    // namespace hpx::naming
+}    // namespace hpx::naming
 
 HPX_IS_BITWISE_SERIALIZABLE(hpx::naming::address)
 

--- a/libs/full/naming_base/include/hpx/naming_base/gid_type.hpp
+++ b/libs/full/naming_base/include/hpx/naming_base/gid_type.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2020 Hartmut Kaiser
+//  Copyright (c) 2007-2022 Hartmut Kaiser
 //  Copyright (c) 2011 Bryce Lelbach
 //  Copyright (c) 2007 Richard D. Guidry Jr.
 //
@@ -32,7 +32,7 @@
 #define HPX_GIDTYPE_VERSION 0x10
 
 ///////////////////////////////////////////////////////////////////////////////
-namespace hpx { namespace naming {
+namespace hpx::naming {
 
     namespace detail {
 
@@ -105,7 +105,7 @@ namespace hpx { namespace naming {
         {
         }
 
-        explicit inline gid_type(
+        explicit inline constexpr gid_type(
             std::uint64_t msb_id, std::uint64_t lsb_id) noexcept;
         explicit inline gid_type(std::uint64_t msb_id, void* lsb_id) noexcept;
 
@@ -349,7 +349,7 @@ namespace hpx { namespace naming {
         serialization::input_archive& ar, gid_type&, unsigned int version);
 
     HPX_SERIALIZATION_SPLIT_FREE(gid_type)
-}}    // namespace hpx::naming
+}    // namespace hpx::naming
 
 ///////////////////////////////////////////////////////////////////////////////
 // we know that we can serialize a gid as a byte sequence
@@ -504,7 +504,7 @@ namespace hpx { namespace naming {
         }
 
         ///////////////////////////////////////////////////////////////////////
-        inline std::uint32_t get_component_type_from_gid(
+        inline constexpr std::uint32_t get_component_type_from_gid(
             std::uint64_t msb) noexcept
         {
             HPX_ASSERT(!(msb & gid_type::dynamically_assigned));
@@ -512,7 +512,7 @@ namespace hpx { namespace naming {
                 gid_type::component_type_base_mask;
         }
 
-        inline std::uint64_t add_component_type_to_gid(
+        inline constexpr std::uint64_t add_component_type_to_gid(
             std::uint64_t msb, std::uint32_t type) noexcept
         {
             HPX_ASSERT(!(msb & gid_type::dynamically_assigned));
@@ -604,12 +604,12 @@ namespace hpx { namespace naming {
         }
 
         ///////////////////////////////////////////////////////////////////////
-        inline gid_type get_stripped_gid_except_dont_cache(
-            gid_type const& id) noexcept
+        inline constexpr gid_type get_stripped_gid_except_dont_cache(
+            gid_type const& gid) noexcept
         {
             std::uint64_t const msb =
-                strip_internal_bits_except_dont_cache_from_gid(id.get_msb());
-            std::uint64_t const lsb = id.get_lsb();
+                strip_internal_bits_except_dont_cache_from_gid(gid.get_msb());
+            std::uint64_t const lsb = gid.get_lsb();
             return gid_type(msb, lsb);
         }
 
@@ -619,25 +619,25 @@ namespace hpx { namespace naming {
             return msb & ~gid_type::credit_bits_mask;
         }
 
-        constexpr gid_type& strip_credits_from_gid(gid_type& id) noexcept
+        constexpr gid_type& strip_credits_from_gid(gid_type& gid) noexcept
         {
-            id.set_msb(strip_credits_from_gid(id.get_msb()));
-            return id;
+            gid.set_msb(strip_credits_from_gid(gid.get_msb()));
+            return gid;
         }
 
         ///////////////////////////////////////////////////////////////////////
         constexpr std::int16_t get_log2credit_from_gid(
-            gid_type const& id) noexcept
+            gid_type const& gid) noexcept
         {
-            HPX_ASSERT(has_credits(id));
-            return std::int16_t((id.get_msb() >> gid_type::credit_shift) &
+            HPX_ASSERT(has_credits(gid));
+            return std::int16_t((gid.get_msb() >> gid_type::credit_shift) &
                 gid_type::credit_base_mask);
         }
 
-        constexpr std::int64_t get_credit_from_gid(gid_type const& id) noexcept
+        constexpr std::int64_t get_credit_from_gid(gid_type const& gid) noexcept
         {
-            return has_credits(id) ?
-                detail::power2(get_log2credit_from_gid(id)) :
+            return has_credits(gid) ?
+                detail::power2(get_log2credit_from_gid(gid)) :
                 0;
         }
 
@@ -679,7 +679,7 @@ namespace hpx { namespace naming {
     HPX_EXPORT std::ostream& operator<<(std::ostream& os, gid_type const& id);
 
     ///////////////////////////////////////////////////////////////////////////
-    inline gid_type::gid_type(
+    inline constexpr gid_type::gid_type(
         std::uint64_t msb_id, std::uint64_t lsb_id) noexcept
       : id_msb_(naming::detail::strip_lock_from_gid(msb_id))
       , id_lsb_(lsb_id)

--- a/libs/full/naming_base/include/hpx/naming_base/id_type.hpp
+++ b/libs/full/naming_base/include/hpx/naming_base/id_type.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2020 Hartmut Kaiser
+//  Copyright (c) 2007-2022 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -24,17 +24,17 @@
 #include <hpx/config/warnings_prefix.hpp>
 
 ///////////////////////////////////////////////////////////////////////////////
-namespace hpx { namespace naming {
+namespace hpx {
 
-    namespace detail {
+    namespace naming::detail {
 
         ///////////////////////////////////////////////////////////////////////
-        HPX_EXPORT void intrusive_ptr_add_ref(id_type_impl* p);
-        HPX_EXPORT void intrusive_ptr_release(id_type_impl* p);
+        HPX_EXPORT void intrusive_ptr_add_ref(id_type_impl* p) noexcept;
+        HPX_EXPORT void intrusive_ptr_release(id_type_impl* p) noexcept;
 
-        HPX_EXPORT void gid_managed_deleter(id_type_impl* p);
-        HPX_EXPORT void gid_unmanaged_deleter(id_type_impl* p);
-    }    // namespace detail
+        HPX_EXPORT void gid_managed_deleter(id_type_impl* p) noexcept;
+        HPX_EXPORT void gid_unmanaged_deleter(id_type_impl* p) noexcept;
+    }    // namespace naming::detail
 
     ///////////////////////////////////////////////////////////////////////////
     HPX_EXPORT std::ostream& operator<<(std::ostream& os, id_type const& id);
@@ -44,10 +44,10 @@ namespace hpx { namespace naming {
     struct id_type
     {
     private:
-        friend struct detail::id_type_impl;
+        friend struct naming::detail::id_type_impl;
 
     public:
-        enum management_type
+        enum class management_type
         {
             unknown_deleter = -1,
             unmanaged = 0,             ///< unmanaged GID
@@ -56,54 +56,51 @@ namespace hpx { namespace naming {
                                        ///< credits when sent
         };
 
+        friend constexpr bool operator<(
+            management_type lhs, management_type rhs) noexcept
+        {
+            return static_cast<int>(lhs) < static_cast<int>(rhs);
+        }
+        friend constexpr bool operator>(
+            management_type lhs, management_type rhs) noexcept
+        {
+            return static_cast<int>(lhs) > static_cast<int>(rhs);
+        }
+
         constexpr id_type() noexcept = default;
 
         id_type(std::uint64_t lsb_id, management_type t);
-        id_type(gid_type const& gid, management_type t);
+        id_type(naming::gid_type const& gid, management_type t);
         id_type(std::uint64_t msb_id, std::uint64_t lsb_id, management_type t);
 
-        id_type(id_type const& o) noexcept
-          : gid_(o.gid_)
-        {
-        }
-        id_type(id_type&& o) noexcept
-          : gid_(HPX_MOVE(o.gid_))
-        {
-        }
+        id_type(id_type const& o) = default;
+        id_type(id_type&& o) noexcept = default;
 
-        id_type& operator=(id_type const& o) noexcept
-        {
-            gid_ = o.gid_;
-            return *this;
-        }
-        id_type& operator=(id_type&& o) noexcept
-        {
-            gid_ = HPX_MOVE(o.gid_);
-            return *this;
-        }
+        id_type& operator=(id_type const& o) = default;
+        id_type& operator=(id_type&& o) noexcept = default;
 
-        gid_type& get_gid();
-        gid_type const& get_gid() const;
+        naming::gid_type& get_gid();
+        naming::gid_type const& get_gid() const;
 
         // This function is used in AGAS unit tests and application code, do not
         // remove.
-        management_type get_management_type() const;
+        management_type get_management_type() const noexcept;
 
         id_type& operator++();
         id_type operator++(int);
 
-        explicit operator bool() const;
+        explicit operator bool() const noexcept;
 
         // comparison is required as well
         friend HPX_EXPORT bool operator==(
-            id_type const& lhs, id_type const& rhs);
-        friend bool operator!=(id_type const& lhs, id_type const& rhs);
+            id_type const& lhs, id_type const& rhs) noexcept;
+        friend bool operator!=(id_type const& lhs, id_type const& rhs) noexcept;
 
         friend HPX_EXPORT bool operator<(
-            id_type const& lhs, id_type const& rhs);
-        friend bool operator<=(id_type const& lhs, id_type const& rhs);
-        friend bool operator>(id_type const& lhs, id_type const& rhs);
-        friend bool operator>=(id_type const& lhs, id_type const& rhs);
+            id_type const& lhs, id_type const& rhs) noexcept;
+        friend bool operator<=(id_type const& lhs, id_type const& rhs) noexcept;
+        friend bool operator>(id_type const& lhs, id_type const& rhs) noexcept;
+        friend bool operator>=(id_type const& lhs, id_type const& rhs) noexcept;
 
         // access the internal parts of the gid
         std::uint64_t get_msb() const;
@@ -117,11 +114,12 @@ namespace hpx { namespace naming {
         // care, or better, don't use this at all.
         void make_unmanaged() const;
 
-        hpx::intrusive_ptr<detail::id_type_impl>& impl()
+        hpx::intrusive_ptr<naming::detail::id_type_impl>& impl() noexcept
         {
             return gid_;
         }
-        hpx::intrusive_ptr<detail::id_type_impl> const& impl() const
+        constexpr hpx::intrusive_ptr<naming::detail::id_type_impl> const& impl()
+            const noexcept
         {
             return gid_;
         }
@@ -130,43 +128,50 @@ namespace hpx { namespace naming {
         friend HPX_EXPORT std::ostream& operator<<(
             std::ostream& os, id_type const& id);
 
-        hpx::intrusive_ptr<detail::id_type_impl> gid_;
+        hpx::intrusive_ptr<naming::detail::id_type_impl> gid_;
     };
-
-    ///////////////////////////////////////////////////////////////////////////
-    HPX_EXPORT char const* get_management_type_name(id_type::management_type m);
 
     ///////////////////////////////////////////////////////////////////////////
     static id_type const invalid_id = id_type();
 
-    ///////////////////////////////////////////////////////////////////////
-    // Handle conversion to/from locality_id
-    // FIXME: these names are confusing, 'id' appears in identifiers far too
-    // frequently.
-    inline id_type get_id_from_locality_id(std::uint32_t locality_id) noexcept
-    {
-        return id_type(
-            (std::uint64_t(locality_id) + 1) << gid_type::locality_id_shift, 0,
-            id_type::unmanaged);
-    }
+    namespace naming {
 
-    inline std::uint32_t get_locality_id_from_id(id_type const& id) noexcept
-    {
-        return std::uint32_t(id.get_msb() >> gid_type::locality_id_shift) - 1;
-    }
+        ///////////////////////////////////////////////////////////////////////////
+        HPX_EXPORT char const* get_management_type_name(
+            id_type::management_type m) noexcept;
 
-    inline id_type get_locality_from_id(id_type const& id) noexcept
-    {
-        return get_id_from_locality_id(get_locality_id_from_id(id));
-    }
+        ///////////////////////////////////////////////////////////////////////
+        // Handle conversion to/from locality_id
+        // FIXME: these names are confusing, 'id' appears in identifiers far too
+        // frequently.
+        inline id_type get_id_from_locality_id(
+            std::uint32_t locality_id) noexcept
+        {
+            return id_type((std::uint64_t(locality_id) + 1)
+                    << naming::gid_type::locality_id_shift,
+                0, id_type::management_type::unmanaged);
+        }
 
-    inline bool is_locality(id_type const& id) noexcept
-    {
-        return is_locality(id.get_gid());
-    }
+        inline std::uint32_t get_locality_id_from_id(id_type const& id) noexcept
+        {
+            return std::uint32_t(
+                       id.get_msb() >> naming::gid_type::locality_id_shift) -
+                1;
+        }
+
+        inline id_type get_locality_from_id(id_type const& id) noexcept
+        {
+            return get_id_from_locality_id(get_locality_id_from_id(id));
+        }
+
+        inline bool is_locality(id_type const& id) noexcept
+        {
+            return is_locality(id.get_gid());
+        }
+    }    // namespace naming
 
     ///////////////////////////////////////////////////////////////////////////
-    namespace detail {
+    namespace naming::detail {
 
         ///////////////////////////////////////////////////////////////////////
         inline void set_dont_store_in_cache(id_type& id) noexcept
@@ -181,7 +186,7 @@ namespace hpx { namespace naming {
             HPX_NON_COPYABLE(id_type_impl);
 
         private:
-            using deleter_type = void (*)(detail::id_type_impl*);
+            using deleter_type = void (*)(detail::id_type_impl*) noexcept;
             static deleter_type get_deleter(
                 id_type::management_type t) noexcept;
 
@@ -199,7 +204,7 @@ namespace hpx { namespace naming {
             {
             }
 
-            explicit id_type_impl(init_no_addref, std::uint64_t lsb_id,
+            id_type_impl(init_no_addref, std::uint64_t lsb_id,
                 id_type::management_type t) noexcept
               : gid_type(0, lsb_id)
               , count_(1)
@@ -261,92 +266,102 @@ namespace hpx { namespace naming {
 
         private:
             // custom deleter for id_type_impl
-            friend HPX_EXPORT void gid_managed_deleter(id_type_impl* p);
-            friend HPX_EXPORT void gid_unmanaged_deleter(id_type_impl* p);
+            friend HPX_EXPORT void gid_managed_deleter(
+                id_type_impl* p) noexcept;
+            friend HPX_EXPORT void gid_unmanaged_deleter(
+                id_type_impl* p) noexcept;
 
             // reference counting
-            friend HPX_EXPORT void intrusive_ptr_add_ref(id_type_impl* p);
-            friend HPX_EXPORT void intrusive_ptr_release(id_type_impl* p);
+            friend HPX_EXPORT void intrusive_ptr_add_ref(
+                id_type_impl* p) noexcept;
+            friend HPX_EXPORT void intrusive_ptr_release(
+                id_type_impl* p) noexcept;
 
             util::atomic_count count_;
-            id_type::management_type type_ = id_type::unknown_deleter;
+            id_type::management_type type_ =
+                id_type::management_type::unknown_deleter;
 
             static util::internal_allocator<id_type_impl> alloc_;
         };
-    }    // namespace detail
+    }    // namespace naming::detail
 
     ///////////////////////////////////////////////////////////////////////////
     // the local gid is actually just a wrapper around the real thing
     inline id_type::id_type(std::uint64_t lsb_id, management_type t)
-      : gid_(new detail::id_type_impl(
-                 detail::id_type_impl::init_no_addref{}, 0, lsb_id, t),
+      : gid_(new naming::detail::id_type_impl(
+                 naming::detail::id_type_impl::init_no_addref{}, 0, lsb_id, t),
             false)
     {
     }
 
-    inline id_type::id_type(gid_type const& gid, management_type t)
-      : gid_(new detail::id_type_impl(
-                 detail::id_type_impl::init_no_addref{}, gid, t),
+    inline id_type::id_type(naming::gid_type const& gid, management_type t)
+      : gid_(new naming::detail::id_type_impl(
+                 naming::detail::id_type_impl::init_no_addref{}, gid, t),
             false)
     {
-        if (t == unmanaged)
+        if (t == management_type::unmanaged)
         {
-            detail::strip_internal_bits_except_dont_cache_from_gid(*gid_);
+            naming::detail::strip_internal_bits_except_dont_cache_from_gid(
+                *gid_);
         }
     }
 
     inline id_type::id_type(
         std::uint64_t msb_id, std::uint64_t lsb_id, management_type t)
-      : gid_(new detail::id_type_impl(
-                 detail::id_type_impl::init_no_addref{}, msb_id, lsb_id, t),
+      : gid_(new naming::detail::id_type_impl(
+                 naming::detail::id_type_impl::init_no_addref{}, msb_id, lsb_id,
+                 t),
             false)
     {
-        if (t == unmanaged)
+        if (t == management_type::unmanaged)
         {
-            detail::strip_internal_bits_except_dont_cache_from_gid(*gid_);
+            naming::detail::strip_internal_bits_except_dont_cache_from_gid(
+                *gid_);
         }
     }
 
-    inline gid_type& id_type::get_gid()
+    inline naming::gid_type& id_type::get_gid()
     {
         return *gid_;
     }
-    inline gid_type const& id_type::get_gid() const
+    inline naming::gid_type const& id_type::get_gid() const
     {
         return *gid_;
     }
 
     // This function is used in AGAS unit tests and application code, do not
     // remove.
-    inline id_type::management_type id_type::get_management_type() const
+    inline id_type::management_type id_type::get_management_type()
+        const noexcept
     {
-        return gid_->get_management_type();
+        return gid_ ? gid_->get_management_type() :
+                      management_type::unknown_deleter;
     }
 
-    inline id_type::operator bool() const
+    inline id_type::operator bool() const noexcept
     {
         return gid_ && *gid_;
     }
 
     // comparison is required as well
-    inline bool operator!=(id_type const& lhs, id_type const& rhs)
+    inline bool operator!=(id_type const& lhs, id_type const& rhs) noexcept
     {
         return !(lhs == rhs);
     }
 
-    inline bool operator<=(id_type const& lhs, id_type const& rhs)
+    inline bool operator<=(id_type const& lhs, id_type const& rhs) noexcept
     {
         // Deduced from <.
         return !(rhs < lhs);
     }
 
-    inline bool operator>(id_type const& lhs, id_type const& rhs)
+    inline bool operator>(id_type const& lhs, id_type const& rhs) noexcept
     {
         // Deduced from <.
         return rhs < lhs;
     }
 
-    inline bool operator>=(id_type const& lhs, id_type const& rhs)
+    inline bool operator>=(id_type const& lhs, id_type const& rhs) noexcept
     {
         // Deduced from <.
         return !(lhs < rhs);
@@ -379,44 +394,45 @@ namespace hpx { namespace naming {
     {
         gid_->set_management_type(management_type::unmanaged);
     }
-}}    // namespace hpx::naming
+}    // namespace hpx
+
+namespace hpx::naming {
+
+    using id_type HPX_DEPRECATED_V(
+        1, 8, "hpx::naming::id_type is deprecated, use hpx::id_type instead") =
+        hpx::id_type;
+}    // namespace hpx::naming
 
 ///////////////////////////////////////////////////////////////////////////////
 namespace hpx { namespace traits {
 
     template <>
-    struct get_remote_result<naming::id_type, naming::gid_type>
+    struct get_remote_result<hpx::id_type, naming::gid_type>
     {
-        HPX_EXPORT static naming::id_type call(naming::gid_type const& rhs);
+        HPX_EXPORT static hpx::id_type call(naming::gid_type const& rhs);
     };
 
     template <>
     struct promise_local_result<naming::gid_type>
     {
-        typedef naming::id_type type;
+        using type = hpx::id_type;
     };
 
     // we need to specialize this template to allow for automatic conversion of
-    // the vector<naming::gid_type> to a vector<naming::id_type>
+    // the vector<naming::gid_type> to a vector<hpx::id_type>
     template <>
-    struct get_remote_result<std::vector<naming::id_type>,
+    struct get_remote_result<std::vector<hpx::id_type>,
         std::vector<naming::gid_type>>
     {
-        HPX_EXPORT static std::vector<naming::id_type> call(
+        HPX_EXPORT static std::vector<hpx::id_type> call(
             std::vector<naming::gid_type> const& rhs);
     };
 
     template <>
     struct promise_local_result<std::vector<naming::gid_type>>
     {
-        typedef std::vector<naming::id_type> type;
+        using type = std::vector<hpx::id_type>;
     };
 }}    // namespace hpx::traits
-
-namespace hpx {
-
-    // Pulling important types into the main namespace
-    using naming::invalid_id;
-}    // namespace hpx
 
 #include <hpx/config/warnings_suffix.hpp>

--- a/libs/full/naming_base/include/hpx/naming_base/naming_base.hpp
+++ b/libs/full/naming_base/include/hpx/naming_base/naming_base.hpp
@@ -29,9 +29,7 @@ namespace hpx {
 
         struct HPX_EXPORT address;
         struct HPX_EXPORT gid_type;
-        struct HPX_EXPORT id_type;
     }    // namespace naming
 
-    // Pulling important types into the main namespace
-    using naming::id_type;
+    struct HPX_EXPORT id_type;
 }    // namespace hpx

--- a/libs/full/naming_base/include/hpx/naming_base/unmanaged.hpp
+++ b/libs/full/naming_base/include/hpx/naming_base/unmanaged.hpp
@@ -11,7 +11,7 @@
 #include <hpx/config.hpp>
 #include <hpx/naming_base/id_type.hpp>
 
-namespace hpx { namespace naming {
+namespace hpx::naming {
 
     /// The helper function \a hpx::unmanaged can be used to generate
     /// a global identifier which does not participate in the automatic
@@ -31,8 +31,8 @@ namespace hpx { namespace naming {
     ///             the user to take full responsibility for keeping the referenced
     ///             objects alive long enough.
     ///
-    HPX_EXPORT id_type unmanaged(id_type const& id);
-}}    // namespace hpx::naming
+    HPX_EXPORT hpx::id_type unmanaged(hpx::id_type const& id);
+}    // namespace hpx::naming
 
 namespace hpx {
     using naming::unmanaged;

--- a/libs/full/naming_base/src/address.cpp
+++ b/libs/full/naming_base/src/address.cpp
@@ -11,7 +11,7 @@
 #include <cstddef>
 
 ///////////////////////////////////////////////////////////////////////////////
-namespace hpx { namespace naming {
+namespace hpx::naming {
 
     template <typename Archive>
     void address::save(Archive& ar, unsigned int /* version */) const
@@ -37,4 +37,4 @@ namespace hpx { namespace naming {
 
     template HPX_EXPORT void address::load(
         serialization::input_archive&, unsigned int);
-}}    // namespace hpx::naming
+}    // namespace hpx::naming

--- a/libs/full/naming_base/src/gid_type.cpp
+++ b/libs/full/naming_base/src/gid_type.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2020 Hartmut Kaiser
+//  Copyright (c) 2007-2022 Hartmut Kaiser
 //  Copyright (c) 2011      Bryce Lelbach
 //
 //  SPDX-License-Identifier: BSL-1.0
@@ -22,7 +22,7 @@
 #include <utility>
 
 ///////////////////////////////////////////////////////////////////////////////
-namespace hpx { namespace naming {
+namespace hpx::naming {
 
     ///////////////////////////////////////////////////////////////////////////
     bool operator==(gid_type const& lhs, gid_type const& rhs) noexcept
@@ -141,4 +141,4 @@ namespace hpx { namespace naming {
         // strip lock-bit upon receive
         gid.id_msb_ &= ~gid_type::is_locked_mask;
     }
-}}    // namespace hpx::naming
+}    // namespace hpx::naming

--- a/libs/full/naming_base/src/id_type.cpp
+++ b/libs/full/naming_base/src/id_type.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2020 Hartmut Kaiser
+//  Copyright (c) 2007-2022 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -13,25 +13,24 @@
 #include <vector>
 
 ///////////////////////////////////////////////////////////////////////////////
-namespace hpx { namespace naming {
+namespace hpx {
 
     ///////////////////////////////////////////////////////////////////////////
-    util::internal_allocator<detail::id_type_impl> detail::id_type_impl::alloc_;
+    namespace naming::detail {
 
-    ///////////////////////////////////////////////////////////////////////////
-    namespace detail {
+        util::internal_allocator<id_type_impl> id_type_impl::alloc_;
 
         id_type_impl::deleter_type id_type_impl::get_deleter(
-            id_type::management_type t) noexcept
+            hpx::id_type::management_type t) noexcept
         {
             switch (t)
             {
-            case id_type::unmanaged:
+            case hpx::id_type::management_type::unmanaged:
                 return &detail::gid_unmanaged_deleter;
 
-            case id_type::managed:
+            case hpx::id_type::management_type::managed:
                 [[fallthrough]];
-            case id_type::managed_move_credit:
+            case hpx::id_type::management_type::managed_move_credit:
                 return &detail::gid_managed_deleter;
 
             default:
@@ -42,19 +41,19 @@ namespace hpx { namespace naming {
         }
 
         // support functions for hpx::intrusive_ptr
-        void intrusive_ptr_add_ref(id_type_impl* p)
+        void intrusive_ptr_add_ref(id_type_impl* p) noexcept
         {
             ++p->count_;
         }
 
-        void intrusive_ptr_release(id_type_impl* p)
+        void intrusive_ptr_release(id_type_impl* p) noexcept
         {
             if (0 == --p->count_)
             {
                 id_type_impl::get_deleter(p->get_management_type())(p);
             }
         }
-    }    // namespace detail
+    }    // namespace naming::detail
 
     ///////////////////////////////////////////////////////////////////////////
     id_type& id_type::operator++()    // pre-increment
@@ -65,11 +64,11 @@ namespace hpx { namespace naming {
 
     id_type id_type::operator++(int)    // post-increment
     {
-        return id_type((*gid_)++, unmanaged);
+        return id_type((*gid_)++, management_type::unmanaged);
     }
 
     // comparison is required as well
-    bool operator==(id_type const& lhs, id_type const& rhs)
+    bool operator==(id_type const& lhs, id_type const& rhs) noexcept
     {
         if (!lhs)
         {
@@ -82,7 +81,7 @@ namespace hpx { namespace naming {
         return *lhs.gid_ == *rhs.gid_;
     }
 
-    bool operator<(id_type const& lhs, id_type const& rhs)
+    bool operator<(id_type const& lhs, id_type const& rhs) noexcept
     {
         // LHS is null, rhs is not.
         if (!lhs && rhs)
@@ -109,51 +108,56 @@ namespace hpx { namespace naming {
         }
         return os;
     }
+}    // namespace hpx
+
+namespace hpx::naming {
 
     ///////////////////////////////////////////////////////////////////////////
-    constexpr char const* const management_type_names[] = {
-        "unknown_deleter",       // -1
-        "unmanaged",             // 0
-        "managed",               // 1
-        "managed_move_credit"    // 2
+    inline constexpr char const* const management_type_names[] = {
+        "management_type::unknown_deleter",       // -1
+        "management_type::unmanaged",             // 0
+        "management_type::managed",               // 1
+        "management_type::managed_move_credit"    // 2
     };
 
-    char const* get_management_type_name(id_type::management_type m)
+    char const* get_management_type_name(
+        hpx::id_type::management_type m) noexcept
     {
-        if (m < id_type::unknown_deleter || m > id_type::managed_move_credit)
+        if (m < hpx::id_type::management_type::unknown_deleter ||
+            m > hpx::id_type::management_type::managed_move_credit)
         {
             return "invalid";
         }
-        return management_type_names[m + 1];
+        return management_type_names[static_cast<int>(m) + 1];
     }
-}}    // namespace hpx::naming
+}    // namespace hpx::naming
 
 ///////////////////////////////////////////////////////////////////////////////
 namespace hpx { namespace traits {
 
-    naming::id_type get_remote_result<naming::id_type, naming::gid_type>::call(
+    hpx::id_type get_remote_result<hpx::id_type, naming::gid_type>::call(
         naming::gid_type const& rhs)
     {
         bool has_credits = naming::detail::has_credits(rhs);
-        return naming::id_type(rhs,
-            has_credits ? naming::id_type::managed :
-                          naming::id_type::unmanaged);
+        return hpx::id_type(rhs,
+            has_credits ? hpx::id_type::management_type::managed :
+                          hpx::id_type::management_type::unmanaged);
     }
 
     // we need to specialize this template to allow for automatic conversion of
-    // the vector<naming::gid_type> to a vector<naming::id_type>
-    std::vector<naming::id_type> get_remote_result<std::vector<naming::id_type>,
+    // the vector<naming::gid_type> to a vector<hpx::id_type>
+    std::vector<hpx::id_type> get_remote_result<std::vector<hpx::id_type>,
         std::vector<naming::gid_type>>::
         call(std::vector<naming::gid_type> const& rhs)
     {
-        std::vector<naming::id_type> result;
+        std::vector<hpx::id_type> result;
         result.reserve(rhs.size());
         for (naming::gid_type const& r : rhs)
         {
             bool has_credits = naming::detail::has_credits(r);
-            result.push_back(naming::id_type(r,
-                has_credits ? naming::id_type::managed :
-                              naming::id_type::unmanaged));
+            result.push_back(hpx::id_type(r,
+                has_credits ? hpx::id_type::management_type::managed :
+                              hpx::id_type::management_type::unmanaged));
         }
         return result;
     }

--- a/libs/full/naming_base/src/unmanaged.cpp
+++ b/libs/full/naming_base/src/unmanaged.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2020 Hartmut Kaiser
+//  Copyright (c) 2007-2022 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -8,11 +8,11 @@
 #include <hpx/naming_base/id_type.hpp>
 #include <hpx/naming_base/unmanaged.hpp>
 
-namespace hpx { namespace naming {
+namespace hpx::naming {
 
-    id_type unmanaged(id_type const& id)
+    hpx::id_type unmanaged(hpx::id_type const& id)
     {
-        return id_type(detail::strip_internal_bits_from_gid(id.get_msb()),
-            id.get_lsb(), id_type::unmanaged);
+        return hpx::id_type(detail::strip_internal_bits_from_gid(id.get_msb()),
+            id.get_lsb(), hpx::id_type::management_type::unmanaged);
     }
-}}    // namespace hpx::naming
+}    // namespace hpx::naming

--- a/libs/full/parcelset/include/hpx/parcelset/parcel.hpp
+++ b/libs/full/parcelset/include/hpx/parcelset/parcel.hpp
@@ -88,8 +88,8 @@ namespace hpx::parcelset::detail {
         int get_component_type() const override;
         int get_action_type() const override;
 
-        naming::id_type source_id() const override;
-        void set_source_id(naming::id_type const& source_id) override;
+        hpx::id_type source_id() const override;
+        void set_source_id(hpx::id_type const& source_id) override;
 
         void set_destination_id(naming::gid_type&& dest) override;
         naming::gid_type const& destination() const override;

--- a/libs/full/parcelset/src/parcel.cpp
+++ b/libs/full/parcelset/src/parcel.cpp
@@ -216,14 +216,15 @@ namespace hpx::parcelset::detail {
         return static_cast<int>(action_->get_action_type());
     }
 
-    naming::id_type parcel::source_id() const
+    hpx::id_type parcel::source_id() const
     {
-        return naming::id_type(data_.source_id_, naming::id_type::unmanaged);
+        return hpx::id_type(
+            data_.source_id_, hpx::id_type::management_type::unmanaged);
     }
 
-    void parcel::set_source_id(naming::id_type const& source_id)
+    void parcel::set_source_id(hpx::id_type const& source_id)
     {
-        if (source_id != naming::invalid_id)
+        if (source_id != hpx::invalid_id)
         {
             data_.source_id_ = source_id.get_gid();
         }

--- a/libs/full/parcelset/src/parcelhandler.cpp
+++ b/libs/full/parcelset/src/parcelhandler.cpp
@@ -1264,8 +1264,8 @@ namespace hpx::parcelset {
         // ensure the source locality id is set (if no component id is given)
         if (!p.source_id())
         {
-            p.set_source_id(naming::id_type(
-                agas::get_locality(), naming::id_type::unmanaged));
+            p.set_source_id(hpx::id_type(agas::get_locality(),
+                hpx::id_type::management_type::unmanaged));
         }
 
 #if defined(HPX_HAVE_PARCEL_PROFILING)

--- a/libs/full/parcelset_base/include/hpx/parcelset_base/parcel_interface.hpp
+++ b/libs/full/parcelset_base/include/hpx/parcelset_base/parcel_interface.hpp
@@ -49,8 +49,8 @@ namespace hpx::parcelset::detail {
         virtual int get_component_type() const = 0;
         virtual int get_action_type() const = 0;
 
-        virtual naming::id_type source_id() const = 0;
-        virtual void set_source_id(naming::id_type const& source_id) = 0;
+        virtual hpx::id_type source_id() const = 0;
+        virtual void set_source_id(hpx::id_type const& source_id) = 0;
 
         virtual void set_destination_id(naming::gid_type&& dest) = 0;
         virtual naming::gid_type const& destination() const = 0;
@@ -130,8 +130,8 @@ namespace hpx::parcelset {
         int get_component_type() const;
         int get_action_type() const;
 
-        naming::id_type source_id() const;
-        void set_source_id(naming::id_type const& source_id);
+        hpx::id_type source_id() const;
+        void set_source_id(hpx::id_type const& source_id);
         void set_destination_id(naming::gid_type&& dest);
 
         naming::address const& addr() const;

--- a/libs/full/parcelset_base/src/parcel_interface.cpp
+++ b/libs/full/parcelset_base/src/parcel_interface.cpp
@@ -63,12 +63,12 @@ namespace hpx::parcelset {
         return data_->get_action_type();
     }
 
-    naming::id_type parcel::source_id() const
+    hpx::id_type parcel::source_id() const
     {
         return data_->source_id();
     }
 
-    void parcel::set_source_id(naming::id_type const& source_id)
+    void parcel::set_source_id(hpx::id_type const& source_id)
     {
         data_->set_source_id(source_id);
     }

--- a/libs/full/performance_counters/include/hpx/performance_counters/counters.hpp
+++ b/libs/full/performance_counters/include/hpx/performance_counters/counters.hpp
@@ -392,20 +392,20 @@ namespace hpx { namespace performance_counters {
             info, create_counter_func(), discover_counters_func(), ec);
     }
 
-    inline naming::id_type get_counter(std::string const& name, error_code& ec)
+    inline hpx::id_type get_counter(std::string const& name, error_code& ec)
     {
-        hpx::future<naming::id_type> f = get_counter_async(name, ec);
+        hpx::future<hpx::id_type> f = get_counter_async(name, ec);
         if (ec)
-            return naming::invalid_id;
+            return hpx::invalid_id;
 
         return f.get(ec);
     }
 
-    inline naming::id_type get_counter(counter_info const& info, error_code& ec)
+    inline hpx::id_type get_counter(counter_info const& info, error_code& ec)
     {
-        hpx::future<naming::id_type> f = get_counter_async(info, ec);
+        hpx::future<hpx::id_type> f = get_counter_async(info, ec);
         if (ec)
-            return naming::invalid_id;
+            return hpx::invalid_id;
 
         return f.get(ec);
     }

--- a/libs/full/performance_counters/include/hpx/performance_counters/counters_fwd.hpp
+++ b/libs/full/performance_counters/include/hpx/performance_counters/counters_fwd.hpp
@@ -494,19 +494,19 @@ namespace hpx { namespace performance_counters {
     /// \brief Get the global id of an existing performance counter, if the
     ///        counter does not exist yet, the function attempts to create the
     ///        counter based on the given counter name.
-    HPX_EXPORT hpx::future<naming::id_type> get_counter_async(
+    HPX_EXPORT hpx::future<hpx::id_type> get_counter_async(
         std::string name, error_code& ec = throws);
 
-    inline naming::id_type get_counter(
+    inline hpx::id_type get_counter(
         std::string const& name, error_code& ec = throws);
 
     /// \brief Get the global id of an existing performance counter, if the
     ///        counter does not exist yet, the function attempts to create the
     ///        counter based on the given counter info.
-    HPX_EXPORT hpx::future<naming::id_type> get_counter_async(
+    HPX_EXPORT hpx::future<hpx::id_type> get_counter_async(
         counter_info const& info, error_code& ec = throws);
 
-    inline naming::id_type get_counter(
+    inline hpx::id_type get_counter(
         counter_info const& info, error_code& ec = throws);
 
     ///////////////////////////////////////////////////////////////////////////
@@ -522,13 +522,13 @@ namespace hpx { namespace performance_counters {
     ///////////////////////////////////////////////////////////////////////////
     namespace detail {
         /// \brief Add an existing performance counter instance to the registry
-        HPX_EXPORT counter_status add_counter(naming::id_type const& id,
+        HPX_EXPORT counter_status add_counter(hpx::id_type const& id,
             counter_info const& info, error_code& ec = throws);
 
         /// \brief Remove an existing performance counter instance with the
         ///        given id (as returned from \a create_counter)
         HPX_EXPORT counter_status remove_counter(counter_info const& info,
-            naming::id_type const& id, error_code& ec = throws);
+            hpx::id_type const& id, error_code& ec = throws);
 
         ///////////////////////////////////////////////////////////////////////
         // Helper function for creating counters encapsulating a function

--- a/libs/full/performance_counters/include/hpx/performance_counters/manage_counter.hpp
+++ b/libs/full/performance_counters/include/hpx/performance_counters/manage_counter.hpp
@@ -17,6 +17,6 @@
 namespace hpx { namespace performance_counters {
     /// Install a new performance counter in a way, which will uninstall it
     /// automatically during shutdown.
-    HPX_EXPORT void install_counter(naming::id_type const& id,
+    HPX_EXPORT void install_counter(hpx::id_type const& id,
         counter_info const& info, error_code& ec = throws);
 }}    // namespace hpx::performance_counters

--- a/libs/full/performance_counters/include/hpx/performance_counters/performance_counter_set.hpp
+++ b/libs/full/performance_counters/include/hpx/performance_counters/performance_counter_set.hpp
@@ -125,9 +125,9 @@ namespace hpx { namespace performance_counters {
     private:
         mutable mutex_type mtx_;
 
-        std::vector<counter_info> infos_;     // counter instance names
-        std::vector<naming::id_type> ids_;    // global ids of counter instances
-        std::vector<std::uint8_t> reset_;     // != 0 if counter should be reset
+        std::vector<counter_info> infos_;    // counter instance names
+        std::vector<hpx::id_type> ids_;      // global ids of counter instances
+        std::vector<std::uint8_t> reset_;    // != 0 if counter should be reset
 
         mutable std::uint64_t invocation_count_;
         bool print_counters_locally_;    // handle only local counters

--- a/libs/full/performance_counters/include/hpx/performance_counters/registry.hpp
+++ b/libs/full/performance_counters/include/hpx/performance_counters/registry.hpp
@@ -148,12 +148,12 @@ namespace hpx { namespace performance_counters {
             naming::gid_type& id, error_code& ec = throws);
 
         /// \brief Add an existing performance counter instance to the registry
-        counter_status add_counter(naming::id_type const& id,
+        counter_status add_counter(hpx::id_type const& id,
             counter_info const& info, error_code& ec = throws);
 
         /// \brief remove the existing performance counter from the registry
         counter_status remove_counter(counter_info const& info,
-            naming::id_type const& id, error_code& ec = throws);
+            hpx::id_type const& id, error_code& ec = throws);
 
         /// \brief Retrieve counter type information for given counter name
         counter_status get_counter_type(std::string const& name,

--- a/libs/full/performance_counters/include/hpx/performance_counters/server/statistics_counter.hpp
+++ b/libs/full/performance_counters/include/hpx/performance_counters/server/statistics_counter.hpp
@@ -92,7 +92,7 @@ namespace hpx { namespace performance_counters { namespace server {
 
         // name of base counter to be queried
         std::string base_counter_name_;
-        naming::id_type base_counter_id_;
+        hpx::id_type base_counter_id_;
 
         std::unique_ptr<detail::counter_type_from_statistic_base> value_;
         counter_value prev_value_;

--- a/libs/full/performance_counters/src/counter_creators.cpp
+++ b/libs/full/performance_counters/src/counter_creators.cpp
@@ -504,7 +504,7 @@ namespace hpx { namespace performance_counters {
     namespace detail {
 
         naming::gid_type retrieve_agas_counter(std::string const& name,
-            naming::id_type const& agas_id, error_code& ec)
+            hpx::id_type const& agas_id, error_code& ec)
         {
             naming::gid_type id;
 
@@ -602,8 +602,8 @@ namespace hpx { namespace performance_counters {
             service += "/";
             service += service_name;
 
-            naming::id_type id = agas::resolve_name(launch::sync, service, ec);
-            if (id == naming::invalid_id)
+            hpx::id_type id = agas::resolve_name(launch::sync, service, ec);
+            if (id == hpx::invalid_id)
             {
                 HPX_THROWS_IF(ec, not_implemented, "agas_raw_counter_creator",
                     "invalid counter name: " +

--- a/libs/full/performance_counters/src/counters.cpp
+++ b/libs/full/performance_counters/src/counters.cpp
@@ -741,14 +741,14 @@ namespace hpx { namespace performance_counters {
 
         ///////////////////////////////////////////////////////////////////////
         counter_status add_counter(
-            naming::id_type const& id, counter_info const& info, error_code& ec)
+            hpx::id_type const& id, counter_info const& info, error_code& ec)
         {
             HPX_ASSERT(hpx::get_runtime_ptr() != nullptr);
             return registry::instance().add_counter(id, info, ec);
         }
 
         counter_status remove_counter(
-            counter_info const& info, naming::id_type const& id, error_code& ec)
+            counter_info const& info, hpx::id_type const& id, error_code& ec)
         {
             HPX_ASSERT(hpx::get_runtime_ptr() != nullptr);
             return registry::instance().remove_counter(info, id, ec);
@@ -1101,20 +1101,20 @@ namespace hpx { namespace performance_counters {
     }
 
     ///////////////////////////////////////////////////////////////////////////
-    static naming::id_type register_with_agas(
-        std::string const& fullname, hpx::future<naming::id_type> f)
+    static hpx::id_type register_with_agas(
+        std::string const& fullname, hpx::future<hpx::id_type> f)
     {
         // register the canonical name with AGAS
-        naming::id_type id = f.get();
+        hpx::id_type id = f.get();
         agas::register_name(launch::sync, fullname, id);
         return id;
     }
 
     ///////////////////////////////////////////////////////////////////////////
-    hpx::future<naming::id_type> get_counter_async(
+    hpx::future<hpx::id_type> get_counter_async(
         counter_info const& info, error_code& ec)
     {
-        typedef hpx::future<naming::id_type> result_type;
+        typedef hpx::future<hpx::id_type> result_type;
 
         // complement counter info data
         counter_info complemented_info = info;
@@ -1126,9 +1126,9 @@ namespace hpx { namespace performance_counters {
         // pre-pend prefix, if necessary
 
         // ask AGAS for the id of the given counter
-        naming::id_type id =
+        hpx::id_type id =
             agas::resolve_name(launch::sync, complemented_info.fullname_, ec);
-        if (id == naming::invalid_id)
+        if (id == hpx::invalid_id)
         {
             try
             {
@@ -1160,7 +1160,7 @@ namespace hpx { namespace performance_counters {
 
                 // use the runtime_support component of the target locality to
                 // create the new performance counter
-                hpx::future<naming::id_type> f;
+                hpx::future<hpx::id_type> f;
                 if (p.parentinstanceindex_ >= 0)
                 {
                     f = create_performance_counter_async(
@@ -1189,7 +1189,7 @@ namespace hpx { namespace performance_counters {
                 LPCS_(warning).format("failed to create counter {} ({})",
                     remove_counter_prefix(complemented_info.fullname_),
                     e.what());
-                return hpx::future<naming::id_type>();
+                return hpx::future<hpx::id_type>();
             }
         }
         if (ec)
@@ -1198,7 +1198,7 @@ namespace hpx { namespace performance_counters {
         return hpx::make_ready_future(id);
     }
 
-    hpx::future<naming::id_type> get_counter_async(
+    hpx::future<hpx::id_type> get_counter_async(
         std::string name, error_code& ec)
     {
         ensure_counter_prefix(name);    // prepend prefix, if necessary

--- a/libs/full/performance_counters/src/manage_counter.cpp
+++ b/libs/full/performance_counters/src/manage_counter.cpp
@@ -21,7 +21,7 @@ namespace hpx { namespace performance_counters {
     struct manage_counter
     {
         manage_counter()
-          : counter_(naming::invalid_id)
+          : counter_(hpx::invalid_id)
         {
         }
 
@@ -31,21 +31,21 @@ namespace hpx { namespace performance_counters {
         }
 
         // install an (existing) counter
-        counter_status install(naming::id_type const& id,
-            counter_info const& info, error_code& ec = throws);
+        counter_status install(hpx::id_type const& id, counter_info const& info,
+            error_code& ec = throws);
 
         // uninstall the counter
         void uninstall();
 
     private:
         counter_info info_;
-        naming::id_type counter_;
+        hpx::id_type counter_;
     };
 
     counter_status manage_counter::install(
-        naming::id_type const& id, counter_info const& info, error_code& ec)
+        hpx::id_type const& id, counter_info const& info, error_code& ec)
     {
-        if (counter_ != naming::invalid_id)
+        if (counter_ != hpx::invalid_id)
         {
             HPX_THROWS_IF(ec, hpx::invalid_status, "manage_counter::install",
                 "counter has been already installed");
@@ -64,7 +64,7 @@ namespace hpx { namespace performance_counters {
         {
             error_code ec(lightweight);
             detail::remove_counter(info_, counter_, ec);
-            counter_ = naming::invalid_id;
+            counter_ = hpx::invalid_id;
         }
     }
 
@@ -76,7 +76,7 @@ namespace hpx { namespace performance_counters {
     }
 
     void install_counter(
-        naming::id_type const& id, counter_info const& info, error_code& ec)
+        hpx::id_type const& id, counter_info const& info, error_code& ec)
     {
         std::shared_ptr<manage_counter> p = std::make_shared<manage_counter>();
 

--- a/libs/full/performance_counters/src/performance_counter_set.cpp
+++ b/libs/full/performance_counters/src/performance_counter_set.cpp
@@ -85,7 +85,7 @@ namespace hpx { namespace performance_counters {
             }
         }
 
-        naming::id_type id = get_counter(info.fullname_, ec);
+        hpx::id_type id = get_counter(info.fullname_, ec);
         if (HPX_UNLIKELY(!id))
         {
             HPX_THROWS_IF(ec, bad_parameter,

--- a/libs/full/performance_counters/src/registry.cpp
+++ b/libs/full/performance_counters/src/registry.cpp
@@ -1119,7 +1119,7 @@ namespace hpx { namespace performance_counters {
     ///////////////////////////////////////////////////////////////////////////
     /// \brief Add an existing performance counter instance to the registry
     counter_status registry::add_counter(
-        naming::id_type const& id, counter_info const& info, error_code& ec)
+        hpx::id_type const& id, counter_info const& info, error_code& ec)
     {
         // complement counter info data
         counter_info complemented_info = info;
@@ -1156,8 +1156,8 @@ namespace hpx { namespace performance_counters {
     }
 
     ///////////////////////////////////////////////////////////////////////////
-    counter_status registry::remove_counter(counter_info const& info,
-        naming::id_type const& /* id */, error_code& ec)
+    counter_status registry::remove_counter(
+        counter_info const& info, hpx::id_type const& /* id */, error_code& ec)
     {
         // make sure parent instance name is set properly
         counter_info complemented_info = info;

--- a/libs/full/resiliency_distributed/include/hpx/resiliency_distributed/async_replay_distributed.hpp
+++ b/libs/full/resiliency_distributed/include/hpx/resiliency_distributed/async_replay_distributed.hpp
@@ -49,14 +49,13 @@ namespace hpx { namespace resiliency { namespace experimental {
 
             template <std::size_t... Is>
             hpx::future<Result> invoke_distributed(
-                hpx::naming::id_type id, hpx::util::index_pack<Is...>)
+                hpx::id_type id, hpx::util::index_pack<Is...>)
             {
                 return hpx::async(action_, id, std::get<Is>(t_)...);
             }
 
             hpx::future<Result> call(
-                const std::vector<hpx::naming::id_type>& ids,
-                std::size_t iteration = 0)
+                const std::vector<hpx::id_type>& ids, std::size_t iteration = 0)
             {
                 hpx::future<Result> f = invoke_distributed(ids.at(iteration),
                     hpx::util::make_index_pack<
@@ -143,15 +142,15 @@ namespace hpx { namespace resiliency { namespace experimental {
     // abort_replay_exception is thrown).
     template <typename Action, typename... Ts>
     hpx::future<typename hpx::util::detail::invoke_deferred_result<Action,
-        hpx::naming::id_type, Ts...>::type>
-    tag_invoke(async_replay_t, const std::vector<hpx::naming::id_type>& ids,
+        hpx::id_type, Ts...>::type>
+    tag_invoke(async_replay_t, const std::vector<hpx::id_type>& ids,
         Action&& action, Ts&&... ts)
     {
         HPX_ASSERT(ids.size() > 0);
 
         using result_type =
             typename hpx::util::detail::invoke_deferred_result<Action,
-                hpx::naming::id_type, Ts...>::type;
+                hpx::id_type, Ts...>::type;
 
         auto helper = detail::make_distributed_async_replay_helper<result_type>(
             detail::replay_validator{}, HPX_FORWARD(Action, action),
@@ -166,16 +165,15 @@ namespace hpx { namespace resiliency { namespace experimental {
     // abort_replay_exception is thrown).
     template <typename Pred, typename Action, typename... Ts>
     hpx::future<typename hpx::util::detail::invoke_deferred_result<Action,
-        hpx::naming::id_type, Ts...>::type>
-    tag_invoke(async_replay_validate_t,
-        const std::vector<hpx::naming::id_type>& ids, Pred&& pred,
-        Action&& action, Ts&&... ts)
+        hpx::id_type, Ts...>::type>
+    tag_invoke(async_replay_validate_t, const std::vector<hpx::id_type>& ids,
+        Pred&& pred, Action&& action, Ts&&... ts)
     {
         HPX_ASSERT(ids.size() > 0);
 
         using result_type =
             typename hpx::util::detail::invoke_deferred_result<Action,
-                hpx::naming::id_type, Ts...>::type;
+                hpx::id_type, Ts...>::type;
 
         auto helper = detail::make_distributed_async_replay_helper<result_type>(
             HPX_FORWARD(Pred, pred), HPX_FORWARD(Action, action),

--- a/libs/full/resiliency_distributed/include/hpx/resiliency_distributed/async_replicate_distributed.hpp
+++ b/libs/full/resiliency_distributed/include/hpx/resiliency_distributed/async_replicate_distributed.hpp
@@ -35,14 +35,13 @@ namespace hpx { namespace resiliency { namespace experimental {
         ///////////////////////////////////////////////////////////////////////
         template <typename Vote, typename Pred, typename Action, typename... Ts>
         hpx::future<typename hpx::util::detail::invoke_deferred_result<Action,
-            hpx::naming::id_type, Ts...>::type>
-        async_replicate_vote_validate(
-            const std::vector<hpx::naming::id_type>& ids, Vote&& vote,
-            Pred&& pred, Action&& action, Ts&&... ts)
+            hpx::id_type, Ts...>::type>
+        async_replicate_vote_validate(const std::vector<hpx::id_type>& ids,
+            Vote&& vote, Pred&& pred, Action&& action, Ts&&... ts)
         {
             using result_type =
                 typename hpx::util::detail::invoke_deferred_result<Action,
-                    hpx::naming::id_type, Ts...>::type;
+                    hpx::id_type, Ts...>::type;
 
             // launch given function n times
             std::vector<hpx::future<result_type>> results;
@@ -109,9 +108,9 @@ namespace hpx { namespace resiliency { namespace experimental {
     // Return the valid output.
     template <typename Vote, typename Pred, typename Action, typename... Ts>
     hpx::future<typename hpx::util::detail::invoke_deferred_result<Action,
-        hpx::naming::id_type, Ts...>::type>
+        hpx::id_type, Ts...>::type>
     tag_invoke(async_replicate_vote_validate_t,
-        const std::vector<hpx::naming::id_type>& ids, Vote&& vote, Pred&& pred,
+        const std::vector<hpx::id_type>& ids, Vote&& vote, Pred&& pred,
         Action&& action, Ts&&... ts)
     {
         HPX_ASSERT(ids.size() > 0);
@@ -129,10 +128,9 @@ namespace hpx { namespace resiliency { namespace experimental {
     // Return the valid output.
     template <typename Vote, typename Action, typename... Ts>
     hpx::future<typename hpx::util::detail::invoke_deferred_result<Action,
-        hpx::naming::id_type, Ts...>::type>
-    tag_invoke(async_replicate_vote_t,
-        const std::vector<hpx::naming::id_type>& ids, Vote&& vote,
-        Action&& action, Ts&&... ts)
+        hpx::id_type, Ts...>::type>
+    tag_invoke(async_replicate_vote_t, const std::vector<hpx::id_type>& ids,
+        Vote&& vote, Action&& action, Ts&&... ts)
     {
         HPX_ASSERT(ids.size() > 0);
 
@@ -149,10 +147,9 @@ namespace hpx { namespace resiliency { namespace experimental {
     // Return the valid output.
     template <typename Pred, typename Action, typename... Ts>
     hpx::future<typename hpx::util::detail::invoke_deferred_result<Action,
-        hpx::naming::id_type, Ts...>::type>
-    tag_invoke(async_replicate_validate_t,
-        const std::vector<hpx::naming::id_type>& ids, Pred&& pred,
-        Action&& action, Ts&&... ts)
+        hpx::id_type, Ts...>::type>
+    tag_invoke(async_replicate_validate_t, const std::vector<hpx::id_type>& ids,
+        Pred&& pred, Action&& action, Ts&&... ts)
     {
         HPX_ASSERT(ids.size() > 0);
 
@@ -169,8 +166,8 @@ namespace hpx { namespace resiliency { namespace experimental {
     // Return the valid output.
     template <typename Action, typename... Ts>
     hpx::future<typename hpx::util::detail::invoke_deferred_result<Action,
-        hpx::naming::id_type, Ts...>::type>
-    tag_invoke(async_replicate_t, const std::vector<hpx::naming::id_type>& ids,
+        hpx::id_type, Ts...>::type>
+    tag_invoke(async_replicate_t, const std::vector<hpx::id_type>& ids,
         Action&& action, Ts&&... ts)
     {
         HPX_ASSERT(ids.size() > 0);

--- a/libs/full/resiliency_distributed/tests/unit/async_replicate_distributed_plain.cpp
+++ b/libs/full/resiliency_distributed/tests/unit/async_replicate_distributed_plain.cpp
@@ -45,7 +45,7 @@ int vote(std::vector<int>&& results)
 
 int hpx_main()
 {
-    std::vector<hpx::naming::id_type> locals = hpx::find_all_localities();
+    std::vector<hpx::id_type> locals = hpx::find_all_localities();
 
     // Allow a task to replicate on the same locality if there is only 1 locality
     if (locals.size() == 1)

--- a/libs/full/runtime_components/include/hpx/runtime_components/console_error_sink.hpp
+++ b/libs/full/runtime_components/include/hpx/runtime_components/console_error_sink.hpp
@@ -18,7 +18,7 @@ namespace hpx { namespace components {
 
     // Stub function which applies the console_error_sink action.
     HPX_EXPORT void console_error_sink(
-        naming::id_type const& dst, std::exception_ptr const& e);
+        hpx::id_type const& dst, std::exception_ptr const& e);
 
     // Stub function which applies the console_error_sink action.
     HPX_EXPORT void console_error_sink(std::exception_ptr const& e);

--- a/libs/full/runtime_components/include/hpx/runtime_components/create_component_helpers.hpp
+++ b/libs/full/runtime_components/include/hpx/runtime_components/create_component_helpers.hpp
@@ -34,7 +34,7 @@ namespace hpx { namespace components {
     ///////////////////////////////////////////////////////////////////////////
     /// Asynchronously create a new instance of a component
     template <typename Component, typename... Ts>
-    future<naming::id_type> create_async(naming::id_type const& gid, Ts&&... vs)
+    future<hpx::id_type> create_async(hpx::id_type const& gid, Ts&&... vs)
     {
         if (!naming::is_locality(gid))
         {
@@ -42,7 +42,7 @@ namespace hpx { namespace components {
                 "stubs::runtime_support::create_component_async",
                 "The id passed as the first argument is not representing"
                 " a locality");
-            return make_ready_future(naming::invalid_id);
+            return make_ready_future(hpx::invalid_id);
         }
 
         using action_type = server::create_component_action<Component,
@@ -52,8 +52,8 @@ namespace hpx { namespace components {
     }
 
     template <typename Component, typename... Ts>
-    future<std::vector<naming::id_type>> bulk_create_async(
-        naming::id_type const& gid, std::size_t count, Ts&&... vs)
+    future<std::vector<hpx::id_type>> bulk_create_async(
+        hpx::id_type const& gid, std::size_t count, Ts&&... vs)
     {
         if (!naming::is_locality(gid))
         {
@@ -61,7 +61,7 @@ namespace hpx { namespace components {
                 "stubs::runtime_support::bulk_create_component_async",
                 "The id passed as the first argument is not representing"
                 " a locality");
-            return make_ready_future(std::vector<naming::id_type>());
+            return make_ready_future(std::vector<hpx::id_type>());
         }
 
         using action_type = server::bulk_create_component_action<Component,
@@ -71,22 +71,22 @@ namespace hpx { namespace components {
     }
 
     template <typename Component, typename... Ts>
-    naming::id_type create(naming::id_type const& gid, Ts&&... vs)
+    hpx::id_type create(hpx::id_type const& gid, Ts&&... vs)
     {
         return create_async<Component>(gid, HPX_FORWARD(Ts, vs)...).get();
     }
 
     template <typename Component, typename... Ts>
-    std::vector<naming::id_type> bulk_create(
-        naming::id_type const& gid, std::size_t count, Ts&&... vs)
+    std::vector<hpx::id_type> bulk_create(
+        hpx::id_type const& gid, std::size_t count, Ts&&... vs)
     {
         return bulk_create_async<Component>(gid, count, HPX_FORWARD(Ts, vs)...)
             .get();
     }
 
     template <typename Component, typename... Ts>
-    future<naming::id_type> create_colocated_async(
-        naming::id_type const& gid, Ts&&... vs)
+    future<hpx::id_type> create_colocated_async(
+        hpx::id_type const& gid, Ts&&... vs)
     {
         using action_type = server::create_component_action<Component,
             typename std::decay<Ts>::type...>;
@@ -96,15 +96,14 @@ namespace hpx { namespace components {
     }
 
     template <typename Component, typename... Ts>
-    static naming::id_type create_colocated(
-        naming::id_type const& gid, Ts&&... vs)
+    static hpx::id_type create_colocated(hpx::id_type const& gid, Ts&&... vs)
     {
         return create_colocated_async(gid, HPX_FORWARD(Ts, vs)...).get();
     }
 
     template <typename Component, typename... Ts>
-    static future<std::vector<naming::id_type>> bulk_create_colocated_async(
-        naming::id_type const& gid, std::size_t count, Ts&&... vs)
+    static future<std::vector<hpx::id_type>> bulk_create_colocated_async(
+        hpx::id_type const& gid, std::size_t count, Ts&&... vs)
     {
         using action_type = server::bulk_create_component_action<Component,
             typename std::decay<Ts>::type...>;
@@ -114,8 +113,8 @@ namespace hpx { namespace components {
     }
 
     template <typename Component, typename... Ts>
-    std::vector<naming::id_type> bulk_create_colocated(
-        naming::id_type const& id, std::size_t count, Ts&&... vs)
+    std::vector<hpx::id_type> bulk_create_colocated(
+        hpx::id_type const& id, std::size_t count, Ts&&... vs)
     {
         return bulk_create_colocated_async<Component>(
             id, count, HPX_FORWARD(Ts, vs)...)

--- a/libs/full/runtime_components/include/hpx/runtime_components/new.hpp
+++ b/libs/full/runtime_components/include/hpx/runtime_components/new.hpp
@@ -323,7 +323,7 @@ namespace hpx { namespace components {
 
                 hpx::id_type id(components::server::create<component_type>(
                                     HPX_FORWARD(Ts, ts)...),
-                    hpx::id_type::managed);
+                    hpx::id_type::management_type::managed);
                 return hpx::make_ready_future(HPX_MOVE(id));
             }
         };
@@ -345,7 +345,7 @@ namespace hpx { namespace components {
                 {
                     result.push_back(hpx::id_type(
                         components::server::create<component_type>(ts...),
-                        hpx::id_type::managed));
+                        hpx::id_type::management_type::managed));
                 }
 
                 return hpx::make_ready_future(result);
@@ -365,7 +365,7 @@ namespace hpx { namespace components {
 
                 hpx::id_type id(components::server::create<component_type>(
                                     HPX_FORWARD(Ts, ts)...),
-                    hpx::id_type::managed);
+                    hpx::id_type::management_type::managed);
 
                 return id;
             }
@@ -388,7 +388,7 @@ namespace hpx { namespace components {
                 {
                     result.push_back(hpx::id_type(
                         components::server::create<component_type>(ts...),
-                        hpx::id_type::managed));
+                        hpx::id_type::management_type::managed));
                 }
 
                 return result;
@@ -485,7 +485,7 @@ namespace hpx { namespace components {
             {
                 hpx::id_type id(components::server::create<component_type>(
                                     HPX_FORWARD(Ts, ts)...),
-                    hpx::id_type::managed);
+                    hpx::id_type::management_type::managed);
                 return make_client<Client>(HPX_MOVE(id));
             }
         };

--- a/libs/full/runtime_components/src/console_error_sink.cpp
+++ b/libs/full/runtime_components/src/console_error_sink.cpp
@@ -21,7 +21,7 @@ namespace hpx { namespace components {
 
     // Stub function which applies the console_error_sink action.
     void console_error_sink(
-        naming::id_type const& dst, std::exception_ptr const& e)
+        hpx::id_type const& dst, std::exception_ptr const& e)
     {
         // Report the error only if the thread-manager is up.
         if (threads::threadmanager_is(hpx::state::running))
@@ -56,7 +56,8 @@ namespace hpx { namespace components {
             // retrieve console locality
             naming::gid_type console_gid;
             naming::get_agas_client().get_console_locality(console_gid);
-            naming::id_type dst(console_gid, naming::id_type::unmanaged);
+            hpx::id_type dst(
+                console_gid, hpx::id_type::management_type::unmanaged);
 
             hpx::async<server::console_error_sink_action>(dst, e).get();
         }

--- a/libs/full/runtime_components/src/console_logging.cpp
+++ b/libs/full/runtime_components/src/console_logging.cpp
@@ -76,7 +76,7 @@ namespace hpx { namespace components {
     }
 
     void console_logging_locked(
-        naming::id_type const& prefix, messages_type const& msgs)
+        hpx::id_type const& prefix, messages_type const& msgs)
     {
         // If we're not in an HPX thread, we cannot call apply as it may access
         // the AGAS components. We just throw an exception here - there's no
@@ -119,7 +119,7 @@ namespace hpx { namespace components {
 
         pending_logs()
           : prefix_mtx_()
-          , prefix_(naming::invalid_id)
+          , prefix_(hpx::invalid_id)
           , queue_mtx_()
           , activated_(false)
           , is_sending_(false)
@@ -141,7 +141,7 @@ namespace hpx { namespace components {
         bool is_active();
 
         prefix_mutex_type prefix_mtx_;
-        naming::id_type prefix_;
+        hpx::id_type prefix_;
 
         queue_mutex_type queue_mtx_;
         messages_type queue_;
@@ -241,12 +241,12 @@ namespace hpx { namespace components {
     bool pending_logs::ensure_prefix()
     {
         // Resolve the console prefix if it's still invalid.
-        if (HPX_UNLIKELY(naming::invalid_id == prefix_))
+        if (HPX_UNLIKELY(hpx::invalid_id == prefix_))
         {
             std::unique_lock<prefix_mutex_type> l(
                 prefix_mtx_, std::try_to_lock);
 
-            if (l.owns_lock() && (naming::invalid_id == prefix_))
+            if (l.owns_lock() && (hpx::invalid_id == prefix_))
             {
                 naming::gid_type raw_prefix;
                 {
@@ -258,8 +258,8 @@ namespace hpx { namespace components {
                 HPX_ASSERT(naming::invalid_gid != raw_prefix);
                 if (!prefix_)
                 {
-                    prefix_ =
-                        naming::id_type(raw_prefix, naming::id_type::unmanaged);
+                    prefix_ = hpx::id_type(
+                        raw_prefix, hpx::id_type::management_type::unmanaged);
                 }
                 else
                 {

--- a/libs/full/runtime_components/tests/unit/agas/components/managed_refcnt_checker.hpp
+++ b/libs/full/runtime_components/tests/unit/agas/components/managed_refcnt_checker.hpp
@@ -33,7 +33,7 @@ namespace hpx { namespace test {
     private:
         hpx::distributed::promise<void> flag_promise_;
         hpx::future<void> flag_;
-        naming::id_type const locality_;
+        hpx::id_type const locality_;
 
     public:
         typedef server::managed_refcnt_checker server_type;
@@ -49,7 +49,7 @@ namespace hpx { namespace test {
           , flag_promise_()
           , flag_(flag_promise_.get_future())
           , locality_(naming::get_locality_from_gid(locality),
-                naming::id_type::unmanaged)
+                hpx::id_type::management_type::unmanaged)
         {
             static_cast<base_type&>(*this) =
                 hpx::new_<server::managed_refcnt_checker>(
@@ -57,7 +57,7 @@ namespace hpx { namespace test {
         }
 
         /// Create a new component on the target locality.
-        explicit managed_refcnt_monitor(naming::id_type const& locality)
+        explicit managed_refcnt_monitor(hpx::id_type const& locality)
           : base_type()
           , flag_promise_()
           , flag_(flag_promise_.get_future())
@@ -68,12 +68,12 @@ namespace hpx { namespace test {
                     locality_, flag_promise_.get_id());
         }
 
-        hpx::future<void> take_reference_async(naming::id_type const& gid)
+        hpx::future<void> take_reference_async(hpx::id_type const& gid)
         {
             return this->base_type::take_reference_async(get_id(), gid);
         }
 
-        void take_reference(naming::id_type const& gid)
+        void take_reference(hpx::id_type const& gid)
         {
             return this->base_type::take_reference(get_id(), gid);
         }
@@ -126,15 +126,16 @@ namespace hpx { namespace test {
         /// Create a new component on the target locality.
         explicit managed_object(naming::gid_type const& locality)
           : base_type(hpx::new_<server::managed_refcnt_checker>(
-                naming::id_type(locality, naming::id_type::unmanaged),
-                naming::invalid_id))
+                hpx::id_type(
+                    locality, hpx::id_type::management_type::unmanaged),
+                hpx::invalid_id))
         {
         }
 
         /// Create a new component on the target locality.
-        explicit managed_object(naming::id_type const& locality)
+        explicit managed_object(hpx::id_type const& locality)
           : base_type(hpx::new_<server::managed_refcnt_checker>(
-                locality, naming::invalid_id))
+                locality, hpx::invalid_id))
         {
         }
     };

--- a/libs/full/runtime_components/tests/unit/agas/components/server/managed_refcnt_checker.cpp
+++ b/libs/full/runtime_components/tests/unit/agas/components/server/managed_refcnt_checker.cpp
@@ -32,7 +32,7 @@ namespace hpx { namespace test { namespace server {
             hpx::util::format_to(
                 strm, "[{1}/{2}]: held references\n", prefix_, this_);
 
-            for (naming::id_type const& ref : references_)
+            for (hpx::id_type const& ref : references_)
             {
                 strm << "  " << ref << " "
                      << naming::get_management_type_name(
@@ -45,7 +45,7 @@ namespace hpx { namespace test { namespace server {
             agas::garbage_collect();
         }
 
-        if (naming::invalid_id != target_)
+        if (hpx::invalid_id != target_)
         {
             hpx::util::format_to(
                 strm, "[{1}/{2}]: destroying object\n", prefix_, this_);

--- a/libs/full/runtime_components/tests/unit/agas/components/server/managed_refcnt_checker.hpp
+++ b/libs/full/runtime_components/tests/unit/agas/components/server/managed_refcnt_checker.hpp
@@ -22,17 +22,17 @@ namespace hpx { namespace test { namespace server {
       : components::managed_component_base<managed_refcnt_checker>
     {
     private:
-        naming::id_type target_;
-        std::vector<naming::id_type> references_;
+        hpx::id_type target_;
+        std::vector<hpx::id_type> references_;
 
     public:
         managed_refcnt_checker()
-          : target_(naming::invalid_id)
+          : target_(hpx::invalid_id)
           , references_()
         {
         }
 
-        managed_refcnt_checker(naming::id_type const& target)
+        managed_refcnt_checker(hpx::id_type const& target)
           : target_(target)
           , references_()
         {
@@ -40,7 +40,7 @@ namespace hpx { namespace test { namespace server {
 
         ~managed_refcnt_checker();
 
-        void take_reference(naming::id_type const& gid)
+        void take_reference(hpx::id_type const& gid)
         {
             references_.push_back(gid);
         }

--- a/libs/full/runtime_components/tests/unit/agas/components/server/simple_refcnt_checker.cpp
+++ b/libs/full/runtime_components/tests/unit/agas/components/server/simple_refcnt_checker.cpp
@@ -32,7 +32,7 @@ namespace hpx { namespace test { namespace server {
             hpx::util::format_to(
                 strm, "[{1}/{2}]: held references\n", prefix_, this_);
 
-            for (naming::id_type const& ref : references_)
+            for (hpx::id_type const& ref : references_)
             {
                 strm << "  " << ref << " "
                      << naming::get_management_type_name(
@@ -45,7 +45,7 @@ namespace hpx { namespace test { namespace server {
             agas::garbage_collect();
         }
 
-        if (naming::invalid_id != target_)
+        if (hpx::invalid_id != target_)
         {
             hpx::util::format_to(
                 strm, "[{1}/{2}]: destroying object\n", prefix_, this_);

--- a/libs/full/runtime_components/tests/unit/agas/components/server/simple_refcnt_checker.hpp
+++ b/libs/full/runtime_components/tests/unit/agas/components/server/simple_refcnt_checker.hpp
@@ -23,17 +23,17 @@ namespace hpx { namespace test { namespace server {
       : components::component_base<simple_refcnt_checker>
     {
     private:
-        naming::id_type target_;
-        std::vector<naming::id_type> references_;
+        hpx::id_type target_;
+        std::vector<hpx::id_type> references_;
 
     public:
         simple_refcnt_checker()
-          : target_(naming::invalid_id)
+          : target_(hpx::invalid_id)
           , references_()
         {
         }
 
-        simple_refcnt_checker(naming::id_type const& target)
+        simple_refcnt_checker(hpx::id_type const& target)
           : target_(target)
           , references_()
         {
@@ -41,7 +41,7 @@ namespace hpx { namespace test { namespace server {
 
         ~simple_refcnt_checker();
 
-        void take_reference(naming::id_type const& gid)
+        void take_reference(hpx::id_type const& gid)
         {
             references_.push_back(gid);
         }

--- a/libs/full/runtime_components/tests/unit/agas/components/simple_mobile_object.hpp
+++ b/libs/full/runtime_components/tests/unit/agas/components/simple_mobile_object.hpp
@@ -32,7 +32,7 @@ namespace hpx { namespace test {
         typedef server::simple_mobile_object server_type;
 
         /// Create a new component on the target locality.
-        explicit simple_mobile_object(naming::id_type const& id)
+        explicit simple_mobile_object(hpx::id_type const& id)
           : base_type(id)
         {
         }

--- a/libs/full/runtime_components/tests/unit/agas/components/simple_refcnt_checker.hpp
+++ b/libs/full/runtime_components/tests/unit/agas/components/simple_refcnt_checker.hpp
@@ -33,7 +33,7 @@ namespace hpx { namespace test {
     private:
         hpx::distributed::promise<void> flag_promise_;
         hpx::future<void> flag_;
-        naming::id_type const locality_;
+        hpx::id_type const locality_;
 
     public:
         typedef server::simple_refcnt_checker server_type;
@@ -49,7 +49,7 @@ namespace hpx { namespace test {
           , flag_promise_()
           , flag_(flag_promise_.get_future())
           , locality_(naming::get_locality_from_gid(locality),
-                naming::id_type::unmanaged)
+                hpx::id_type::management_type::unmanaged)
         {
             static_cast<base_type&>(*this) =
                 hpx::new_<server::simple_refcnt_checker>(
@@ -57,7 +57,7 @@ namespace hpx { namespace test {
         }
 
         /// Create a new component on the target locality.
-        explicit simple_refcnt_monitor(naming::id_type const& locality)
+        explicit simple_refcnt_monitor(hpx::id_type const& locality)
           : base_type()
           , flag_promise_()
           , flag_(flag_promise_.get_future())
@@ -68,12 +68,12 @@ namespace hpx { namespace test {
                     locality_, flag_promise_.get_id());
         }
 
-        hpx::future<void> take_reference_async(naming::id_type const& gid)
+        hpx::future<void> take_reference_async(hpx::id_type const& gid)
         {
             return this->base_type::take_reference_async(get_id(), gid);
         }
 
-        void take_reference(naming::id_type const& gid)
+        void take_reference(hpx::id_type const& gid)
         {
             return this->base_type::take_reference(get_id(), gid);
         }
@@ -121,15 +121,16 @@ namespace hpx { namespace test {
         /// Create a new component on the target locality.
         explicit simple_object(naming::gid_type const& locality)
           : base_type(hpx::new_<server::simple_refcnt_checker>(
-                naming::id_type(locality, naming::id_type::unmanaged),
-                naming::invalid_id))
+                hpx::id_type(
+                    locality, hpx::id_type::management_type::unmanaged),
+                hpx::invalid_id))
         {
         }
 
         /// Create a new component on the target locality.
-        explicit simple_object(naming::id_type const& locality)
+        explicit simple_object(hpx::id_type const& locality)
           : base_type(hpx::new_<server::simple_refcnt_checker>(
-                locality, naming::invalid_id))
+                locality, hpx::invalid_id))
         {
         }
     };

--- a/libs/full/runtime_components/tests/unit/agas/components/stubs/managed_refcnt_checker.hpp
+++ b/libs/full/runtime_components/tests/unit/agas/components/stubs/managed_refcnt_checker.hpp
@@ -23,7 +23,7 @@ namespace hpx { namespace test { namespace stubs {
       : components::stub_base<server::managed_refcnt_checker>
     {
         static hpx::future<void> take_reference_async(
-            naming::id_type const& this_, naming::id_type const& gid)
+            hpx::id_type const& this_, hpx::id_type const& gid)
         {
             typedef server::managed_refcnt_checker::take_reference_action
                 action_type;
@@ -31,7 +31,7 @@ namespace hpx { namespace test { namespace stubs {
         }
 
         static void take_reference(
-            naming::id_type const& this_, naming::id_type const& gid)
+            hpx::id_type const& this_, hpx::id_type const& gid)
         {
             take_reference_async(this_, gid).get();
         }

--- a/libs/full/runtime_components/tests/unit/agas/components/stubs/simple_refcnt_checker.hpp
+++ b/libs/full/runtime_components/tests/unit/agas/components/stubs/simple_refcnt_checker.hpp
@@ -23,7 +23,7 @@ namespace hpx { namespace test { namespace stubs {
       : components::stub_base<server::simple_refcnt_checker>
     {
         static hpx::future<void> take_reference_async(
-            naming::id_type const& this_, naming::id_type const& gid)
+            hpx::id_type const& this_, hpx::id_type const& gid)
         {
             typedef server::simple_refcnt_checker::take_reference_action
                 action_type;
@@ -31,7 +31,7 @@ namespace hpx { namespace test { namespace stubs {
         }
 
         static void take_reference(
-            naming::id_type const& this_, naming::id_type const& gid)
+            hpx::id_type const& this_, hpx::id_type const& gid)
         {
             take_reference_async(this_, gid).get();
         }

--- a/libs/full/runtime_components/tests/unit/agas/credit_exhaustion.cpp
+++ b/libs/full/runtime_components/tests/unit/agas/credit_exhaustion.cpp
@@ -31,9 +31,9 @@ using hpx::init;
 
 using std::chrono::milliseconds;
 
+using hpx::id_type;
 using hpx::naming::get_locality_id_from_id;
 using hpx::naming::get_management_type_name;
-using hpx::naming::id_type;
 using hpx::naming::detail::get_credit_from_gid;
 
 using hpx::components::component_type;

--- a/libs/full/runtime_components/tests/unit/agas/find_ids_from_prefix.cpp
+++ b/libs/full/runtime_components/tests/unit/agas/find_ids_from_prefix.cpp
@@ -63,7 +63,7 @@ void test_find_all_ids_from_basename()
     test_client t1 = hpx::new_<test_client>(hpx::find_here());
     hpx::id_type client_id = t1.get_id();
 
-    HPX_TEST_NEQ(hpx::naming::invalid_id, client_id);
+    HPX_TEST_NEQ(hpx::invalid_id, client_id);
 
     // register our component with AGAS
     HPX_TEST((hpx::register_with_basename(basename, client_id).get()));
@@ -102,7 +102,7 @@ void test_find_ids_from_basename()
     test_client t1 = hpx::new_<test_client>(hpx::find_here());
     hpx::id_type client_id = t1.get_id();
 
-    HPX_TEST_NEQ(hpx::naming::invalid_id, client_id);
+    HPX_TEST_NEQ(hpx::invalid_id, client_id);
 
     // register our component with AGAS
     HPX_TEST((hpx::register_with_basename(basename, client_id).get()));
@@ -149,7 +149,7 @@ void test_find_id_from_basename()
     test_client t1 = hpx::new_<test_client>(hpx::find_here());
     hpx::id_type client_id = t1.get_id();
 
-    HPX_TEST_NEQ(hpx::naming::invalid_id, client_id);
+    HPX_TEST_NEQ(hpx::invalid_id, client_id);
 
     // register our component with AGAS
     HPX_TEST((hpx::register_with_basename(basename, client_id).get()));

--- a/libs/full/runtime_components/tests/unit/agas/get_colocation_id.cpp
+++ b/libs/full/runtime_components/tests/unit/agas/get_colocation_id.cpp
@@ -63,7 +63,7 @@ struct test_client : hpx::components::client_base<test_client, test_server>
 void test(hpx::id_type there)
 {
     test_client t1 = hpx::new_<test_client>(there);
-    HPX_TEST_NEQ(hpx::naming::invalid_id, t1.get_id());
+    HPX_TEST_NEQ(hpx::invalid_id, t1.get_id());
 
     // the new object should live on the source locality
     HPX_TEST_EQ(t1.call(), there);

--- a/libs/full/runtime_components/tests/unit/agas/local_address_rebind.cpp
+++ b/libs/full/runtime_components/tests/unit/agas/local_address_rebind.cpp
@@ -24,9 +24,9 @@ using hpx::finalize;
 using hpx::find_here;
 using hpx::init;
 
+using hpx::id_type;
 using hpx::naming::address;
 using hpx::naming::gid_type;
-using hpx::naming::id_type;
 using hpx::naming::detail::get_stripped_gid;
 
 using hpx::util::report_errors;

--- a/libs/full/runtime_components/tests/unit/agas/local_embedded_ref_to_local_object.cpp
+++ b/libs/full/runtime_components/tests/unit/agas/local_embedded_ref_to_local_object.cpp
@@ -28,8 +28,8 @@ using hpx::init;
 
 using std::chrono::milliseconds;
 
+using hpx::id_type;
 using hpx::naming::get_management_type_name;
-using hpx::naming::id_type;
 
 using hpx::agas::garbage_collect;
 

--- a/libs/full/runtime_components/tests/unit/agas/local_embedded_ref_to_remote_object.cpp
+++ b/libs/full/runtime_components/tests/unit/agas/local_embedded_ref_to_remote_object.cpp
@@ -30,8 +30,8 @@ using hpx::init;
 
 using std::chrono::milliseconds;
 
+using hpx::id_type;
 using hpx::naming::get_management_type_name;
-using hpx::naming::id_type;
 
 using hpx::components::component_type;
 using hpx::components::get_component_type;

--- a/libs/full/runtime_components/tests/unit/agas/refcnted_symbol_to_local_object.cpp
+++ b/libs/full/runtime_components/tests/unit/agas/refcnted_symbol_to_local_object.cpp
@@ -29,8 +29,8 @@ using hpx::init;
 
 using std::chrono::milliseconds;
 
+using hpx::id_type;
 using hpx::naming::get_management_type_name;
-using hpx::naming::id_type;
 
 using hpx::agas::garbage_collect;
 using hpx::agas::register_name;

--- a/libs/full/runtime_components/tests/unit/agas/refcnted_symbol_to_remote_object.cpp
+++ b/libs/full/runtime_components/tests/unit/agas/refcnted_symbol_to_remote_object.cpp
@@ -30,9 +30,9 @@ using hpx::init;
 
 using std::chrono::milliseconds;
 
+using hpx::id_type;
 using hpx::naming::get_locality_from_id;
 using hpx::naming::get_management_type_name;
-using hpx::naming::id_type;
 
 using hpx::components::component_type;
 using hpx::components::get_component_type;

--- a/libs/full/runtime_components/tests/unit/agas/remote_embedded_ref_to_local_object.cpp
+++ b/libs/full/runtime_components/tests/unit/agas/remote_embedded_ref_to_local_object.cpp
@@ -30,8 +30,8 @@ using hpx::init;
 
 using std::chrono::milliseconds;
 
+using hpx::id_type;
 using hpx::naming::get_management_type_name;
-using hpx::naming::id_type;
 
 using hpx::components::component_type;
 using hpx::components::get_component_type;

--- a/libs/full/runtime_components/tests/unit/agas/remote_embedded_ref_to_remote_object.cpp
+++ b/libs/full/runtime_components/tests/unit/agas/remote_embedded_ref_to_remote_object.cpp
@@ -29,8 +29,8 @@ using hpx::init;
 
 using std::chrono::milliseconds;
 
+using hpx::id_type;
 using hpx::naming::get_management_type_name;
-using hpx::naming::id_type;
 
 using hpx::components::component_type;
 using hpx::components::get_component_type;

--- a/libs/full/runtime_components/tests/unit/agas/scoped_ref_to_local_object.cpp
+++ b/libs/full/runtime_components/tests/unit/agas/scoped_ref_to_local_object.cpp
@@ -28,8 +28,8 @@ using hpx::init;
 
 using std::chrono::milliseconds;
 
+using hpx::id_type;
 using hpx::naming::get_management_type_name;
-using hpx::naming::id_type;
 
 using hpx::agas::garbage_collect;
 

--- a/libs/full/runtime_components/tests/unit/agas/scoped_ref_to_remote_object.cpp
+++ b/libs/full/runtime_components/tests/unit/agas/scoped_ref_to_remote_object.cpp
@@ -29,8 +29,8 @@ using hpx::init;
 
 using std::chrono::milliseconds;
 
+using hpx::id_type;
 using hpx::naming::get_management_type_name;
-using hpx::naming::id_type;
 
 using hpx::components::component_type;
 using hpx::components::get_component_type;

--- a/libs/full/runtime_components/tests/unit/agas/split_credit.cpp
+++ b/libs/full/runtime_components/tests/unit/agas/split_credit.cpp
@@ -28,9 +28,9 @@ using hpx::finalize;
 using hpx::find_here;
 using hpx::init;
 
+using hpx::id_type;
 using hpx::naming::get_locality_id_from_id;
 using hpx::naming::get_management_type_name;
-using hpx::naming::id_type;
 using hpx::naming::detail::get_credit_from_gid;
 using hpx::naming::detail::split_credits_for_gid;
 
@@ -59,7 +59,7 @@ inline std::int64_t get_credit(id_type const& id)
 inline id_type split_credits(id_type const& id)
 {
     return id_type(split_credits_for_gid(const_cast<id_type&>(id).get_gid()),
-        id_type::managed);
+        id_type::management_type::managed);
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/libs/full/runtime_components/tests/unit/agas/uncounted_symbol_to_local_object.cpp
+++ b/libs/full/runtime_components/tests/unit/agas/uncounted_symbol_to_local_object.cpp
@@ -29,9 +29,9 @@ using hpx::init;
 
 using std::chrono::milliseconds;
 
+using hpx::id_type;
 using hpx::naming::get_management_type_name;
 using hpx::naming::gid_type;
-using hpx::naming::id_type;
 using hpx::naming::detail::get_stripped_gid;
 
 using hpx::agas::register_name;

--- a/libs/full/runtime_components/tests/unit/agas/uncounted_symbol_to_remote_object.cpp
+++ b/libs/full/runtime_components/tests/unit/agas/uncounted_symbol_to_remote_object.cpp
@@ -30,9 +30,9 @@ using hpx::init;
 
 using std::chrono::milliseconds;
 
+using hpx::id_type;
 using hpx::naming::get_management_type_name;
 using hpx::naming::gid_type;
-using hpx::naming::id_type;
 using hpx::naming::detail::get_stripped_gid;
 
 using hpx::components::component_type;

--- a/libs/full/runtime_components/tests/unit/components/action_invoke_no_more_than.hpp
+++ b/libs/full/runtime_components/tests/unit/components/action_invoke_no_more_than.hpp
@@ -148,7 +148,7 @@ namespace hpx { namespace actions { namespace detail {
         naming::address addr_;
 
         template <typename T>
-        void operator()(naming::id_type const& id, T&& t)
+        void operator()(hpx::id_type const& id, T&& t)
         {
             if (id)
             {
@@ -157,7 +157,7 @@ namespace hpx { namespace actions { namespace detail {
             construct_semaphore_type::get_sem().signal();
         }
 
-        void operator()(naming::id_type const& id)
+        void operator()(hpx::id_type const& id)
         {
             if (id)
             {

--- a/libs/full/runtime_components/tests/unit/components/copy_component.cpp
+++ b/libs/full/runtime_components/tests/unit/components/copy_component.cpp
@@ -84,13 +84,13 @@ bool test_copy_component(hpx::id_type id)
 {
     // create component on given locality
     test_client t1 = hpx::new_<test_client>(id);
-    HPX_TEST_NEQ(hpx::naming::invalid_id, t1.get_id());
+    HPX_TEST_NEQ(hpx::invalid_id, t1.get_id());
 
     try
     {
         // create a copy of t1 on same locality
         test_client t2(hpx::components::copy<test_server>(t1.get_id()));
-        HPX_TEST_NEQ(hpx::naming::invalid_id, t2.get_id());
+        HPX_TEST_NEQ(hpx::invalid_id, t2.get_id());
 
         // the new object should life on id
         HPX_TEST_EQ(t2.call(), id);
@@ -110,14 +110,14 @@ bool test_copy_component_here(hpx::id_type id)
 {
     // create component on given locality
     test_client t1 = hpx::new_<test_client>(id);
-    HPX_TEST_NEQ(hpx::naming::invalid_id, t1.get_id());
+    HPX_TEST_NEQ(hpx::invalid_id, t1.get_id());
 
     try
     {
         // create a copy of t1 here
         test_client t2(
             hpx::components::copy<test_server>(t1.get_id(), hpx::find_here()));
-        HPX_TEST_NEQ(hpx::naming::invalid_id, t2.get_id());
+        HPX_TEST_NEQ(hpx::invalid_id, t2.get_id());
 
         // the new object should life here
         HPX_TEST_EQ(t2.call(), hpx::find_here());
@@ -137,13 +137,13 @@ bool test_copy_component_there(hpx::id_type id)
 {
     // create component on given locality
     test_client t1 = hpx::new_<test_client>(hpx::find_here());
-    HPX_TEST_NEQ(hpx::naming::invalid_id, t1.get_id());
+    HPX_TEST_NEQ(hpx::invalid_id, t1.get_id());
 
     try
     {
         // create a copy of t1 on given locality
         test_client t2(hpx::components::copy<test_server>(t1.get_id(), id));
-        HPX_TEST_NEQ(hpx::naming::invalid_id, t2.get_id());
+        HPX_TEST_NEQ(hpx::invalid_id, t2.get_id());
 
         // the new object should life there
         HPX_TEST_EQ(t2.call(), id);

--- a/libs/full/runtime_components/tests/unit/components/get_gid.cpp
+++ b/libs/full/runtime_components/tests/unit/components/get_gid.cpp
@@ -66,7 +66,7 @@ struct test_client : client_base<test_client, stub_base<test_server>>
 int main()
 {
     test_client t = hpx::new_<test_client>(find_here());
-    HPX_TEST_NEQ(hpx::naming::invalid_id, t.get_id());
+    HPX_TEST_NEQ(hpx::invalid_id, t.get_id());
 
     t.check_gid();
 

--- a/libs/full/runtime_components/tests/unit/components/get_ptr.cpp
+++ b/libs/full/runtime_components/tests/unit/components/get_ptr.cpp
@@ -60,7 +60,7 @@ struct test_client : hpx::components::client_base<test_client, test_server>
 bool test_get_ptr1(hpx::id_type id)
 {
     test_client t = hpx::new_<test_client>(id);
-    HPX_TEST_NEQ(hpx::naming::invalid_id, t.get_id());
+    HPX_TEST_NEQ(hpx::invalid_id, t.get_id());
 
     try
     {
@@ -83,7 +83,7 @@ bool test_get_ptr1(hpx::id_type id)
 bool test_get_ptr2(hpx::id_type id)
 {
     test_client t = hpx::new_<test_client>(id);
-    HPX_TEST_NEQ(hpx::naming::invalid_id, t.get_id());
+    HPX_TEST_NEQ(hpx::invalid_id, t.get_id());
 
     hpx::future<std::shared_ptr<test_server>> f =
         hpx::get_ptr<test_server>(t.get_id());
@@ -110,7 +110,7 @@ bool test_get_ptr2(hpx::id_type id)
 bool test_get_ptr3(hpx::id_type id)
 {
     test_client t = hpx::new_<test_client>(id);
-    HPX_TEST_NEQ(hpx::naming::invalid_id, t.get_id());
+    HPX_TEST_NEQ(hpx::invalid_id, t.get_id());
 
     try
     {
@@ -131,7 +131,7 @@ bool test_get_ptr3(hpx::id_type id)
 bool test_get_ptr4(hpx::id_type id)
 {
     test_client t = hpx::new_<test_client>(id);
-    HPX_TEST_NEQ(hpx::naming::invalid_id, t.get_id());
+    HPX_TEST_NEQ(hpx::invalid_id, t.get_id());
 
     hpx::future<std::shared_ptr<test_server>> f = hpx::get_ptr(t);
     f.wait();

--- a/libs/full/runtime_components/tests/unit/components/migrate_component.cpp
+++ b/libs/full/runtime_components/tests/unit/components/migrate_component.cpp
@@ -264,7 +264,7 @@ bool test_migrate_component(hpx::id_type source, hpx::id_type target)
 {
     // create component on given locality
     test_client t1 = hpx::new_<test_client>(source, 42);
-    HPX_TEST_NEQ(hpx::naming::invalid_id, t1.get_id());
+    HPX_TEST_NEQ(hpx::invalid_id, t1.get_id());
 
     // the new object should live on the source locality
     HPX_TEST_EQ(t1.call(), source);
@@ -276,7 +276,7 @@ bool test_migrate_component(hpx::id_type source, hpx::id_type target)
         test_client t2(hpx::components::migrate(t1, target));
 
         // wait for migration to be done
-        HPX_TEST_NEQ(hpx::naming::invalid_id, t2.get_id());
+        HPX_TEST_NEQ(hpx::invalid_id, t2.get_id());
 
         // the migrated object should have the same id as before
         HPX_TEST_EQ(t1.get_id(), t2.get_id());
@@ -298,7 +298,7 @@ bool test_migrate_lazy_component(hpx::id_type source, hpx::id_type target)
 {
     // create component on given locality
     test_client t1 = hpx::new_<test_client>(source, 42);
-    HPX_TEST_NEQ(hpx::naming::invalid_id, t1.get_id());
+    HPX_TEST_NEQ(hpx::invalid_id, t1.get_id());
 
     // the new object should live on the source locality
     HPX_TEST_EQ(t1.call(), source);
@@ -310,7 +310,7 @@ bool test_migrate_lazy_component(hpx::id_type source, hpx::id_type target)
         test_client t2(hpx::components::migrate(t1, target));
 
         // wait for migration to be done
-        HPX_TEST_NEQ(hpx::naming::invalid_id, t2.get_id());
+        HPX_TEST_NEQ(hpx::invalid_id, t2.get_id());
 
         // the migrated object should have the same id as before
         HPX_TEST_EQ(t1.get_id(), t2.get_id());
@@ -333,7 +333,7 @@ bool test_migrate_lazy_component_client(
 {
     // create component on given locality
     test_client t1 = hpx::new_<test_client>(source, 42);
-    HPX_TEST_NEQ(hpx::naming::invalid_id, t1.get_id());
+    HPX_TEST_NEQ(hpx::invalid_id, t1.get_id());
 
     // the new object should live on the source locality
     HPX_TEST_EQ(t1.call(), source);
@@ -345,7 +345,7 @@ bool test_migrate_lazy_component_client(
         test_client t2(hpx::components::migrate(t1, target));
 
         // wait for migration to be done
-        HPX_TEST_NEQ(hpx::naming::invalid_id, t2.get_id());
+        HPX_TEST_NEQ(hpx::invalid_id, t2.get_id());
 
         // the migrated object should have the same id as before
         HPX_TEST_EQ(t1.get_id(), t2.get_id());
@@ -368,7 +368,7 @@ bool test_migrate_busy_component(hpx::id_type source, hpx::id_type target)
 {
     // create component on given locality
     test_client t1 = hpx::new_<test_client>(source, 42);
-    HPX_TEST_NEQ(hpx::naming::invalid_id, t1.get_id());
+    HPX_TEST_NEQ(hpx::invalid_id, t1.get_id());
 
     // the new object should live on the source locality
     HPX_TEST_EQ(t1.call(), source);
@@ -385,7 +385,7 @@ bool test_migrate_busy_component(hpx::id_type source, hpx::id_type target)
         HPX_TEST_EQ(t1.get_data(), 42);
 
         // wait for migration to be done
-        HPX_TEST_NEQ(hpx::naming::invalid_id, t2.get_id());
+        HPX_TEST_NEQ(hpx::invalid_id, t2.get_id());
 
         // the migrated object should have the same id as before
         HPX_TEST_EQ(t1.get_id(), t2.get_id());
@@ -411,7 +411,7 @@ bool test_migrate_lazy_busy_component(hpx::id_type source, hpx::id_type target)
 {
     // create component on given locality
     test_client t1 = hpx::new_<test_client>(source, 42);
-    HPX_TEST_NEQ(hpx::naming::invalid_id, t1.get_id());
+    HPX_TEST_NEQ(hpx::invalid_id, t1.get_id());
 
     // the new object should live on the source locality
     HPX_TEST_EQ(t1.call(), source);
@@ -428,7 +428,7 @@ bool test_migrate_lazy_busy_component(hpx::id_type source, hpx::id_type target)
         HPX_TEST_EQ(t1.lazy_get_data(), 42);
 
         // wait for migration to be done
-        HPX_TEST_NEQ(hpx::naming::invalid_id, t2.get_id());
+        HPX_TEST_NEQ(hpx::invalid_id, t2.get_id());
 
         // the migrated object should have the same id as before
         HPX_TEST_EQ(t1.get_id(), t2.get_id());
@@ -454,7 +454,7 @@ bool test_migrate_lazy_busy_component_client(
 {
     // create component on given locality
     test_client t1 = hpx::new_<test_client>(source, 42);
-    HPX_TEST_NEQ(hpx::naming::invalid_id, t1.get_id());
+    HPX_TEST_NEQ(hpx::invalid_id, t1.get_id());
 
     // the new object should live on the source locality
     HPX_TEST_EQ(t1.call(), source);
@@ -471,7 +471,7 @@ bool test_migrate_lazy_busy_component_client(
         HPX_TEST_EQ(t1.lazy_get_client(target).call(), target);
 
         // wait for migration to be done
-        HPX_TEST_NEQ(hpx::naming::invalid_id, t2.get_id());
+        HPX_TEST_NEQ(hpx::invalid_id, t2.get_id());
 
         // the migrated object should have the same id as before
         HPX_TEST_EQ(t1.get_id(), t2.get_id());
@@ -496,7 +496,7 @@ bool test_migrate_lazy_busy_component_client(
 bool test_migrate_component2(hpx::id_type source, hpx::id_type target)
 {
     test_client t1 = hpx::new_<test_client>(source, 42);
-    HPX_TEST_NEQ(hpx::naming::invalid_id, t1.get_id());
+    HPX_TEST_NEQ(hpx::invalid_id, t1.get_id());
 
     // the new object should live on the source locality
     HPX_TEST_EQ(t1.call(), source);
@@ -516,7 +516,7 @@ bool test_migrate_component2(hpx::id_type source, hpx::id_type target)
             HPX_TEST_EQ(t1.get_data(), 42);
 
             // wait for migration to be done
-            HPX_TEST_NEQ(hpx::naming::invalid_id, t2.get_id());
+            HPX_TEST_NEQ(hpx::invalid_id, t2.get_id());
 
             // the migrated object should have the same id as before
             HPX_TEST_EQ(t1.get_id(), t2.get_id());
@@ -544,7 +544,7 @@ bool test_migrate_component2(hpx::id_type source, hpx::id_type target)
 bool test_migrate_lazy_component2(hpx::id_type source, hpx::id_type target)
 {
     test_client t1 = hpx::new_<test_client>(source, 42);
-    HPX_TEST_NEQ(hpx::naming::invalid_id, t1.get_id());
+    HPX_TEST_NEQ(hpx::invalid_id, t1.get_id());
 
     // the new object should live on the source locality
     HPX_TEST_EQ(t1.call(), source);
@@ -564,7 +564,7 @@ bool test_migrate_lazy_component2(hpx::id_type source, hpx::id_type target)
             HPX_TEST_EQ(t1.lazy_get_data(), 42);
 
             // wait for migration to be done
-            HPX_TEST_NEQ(hpx::naming::invalid_id, t2.get_id());
+            HPX_TEST_NEQ(hpx::invalid_id, t2.get_id());
 
             // the migrated object should have the same id as before
             HPX_TEST_EQ(t1.get_id(), t2.get_id());
@@ -593,7 +593,7 @@ bool test_migrate_lazy_component_client2(
     hpx::id_type source, hpx::id_type target)
 {
     test_client t1 = hpx::new_<test_client>(source, 42);
-    HPX_TEST_NEQ(hpx::naming::invalid_id, t1.get_id());
+    HPX_TEST_NEQ(hpx::invalid_id, t1.get_id());
 
     // the new object should live on the source locality
     HPX_TEST_EQ(t1.call(), source);
@@ -613,7 +613,7 @@ bool test_migrate_lazy_component_client2(
             HPX_TEST_EQ(t1.lazy_get_client(target).call(), target);
 
             // wait for migration to be done
-            HPX_TEST_NEQ(hpx::naming::invalid_id, t2.get_id());
+            HPX_TEST_NEQ(hpx::invalid_id, t2.get_id());
 
             // the migrated object should have the same id as before
             HPX_TEST_EQ(t1.get_id(), t2.get_id());
@@ -642,7 +642,7 @@ bool test_migrate_lazy_component_client2(
 bool test_migrate_busy_component2(hpx::id_type source, hpx::id_type target)
 {
     test_client t1 = hpx::new_<test_client>(source, 42);
-    HPX_TEST_NEQ(hpx::naming::invalid_id, t1.get_id());
+    HPX_TEST_NEQ(hpx::invalid_id, t1.get_id());
 
     // the new object should live on the source locality
     HPX_TEST_EQ(t1.call(), source);
@@ -662,7 +662,7 @@ bool test_migrate_busy_component2(hpx::id_type source, hpx::id_type target)
                 HPX_TEST_EQ(t1.get_data(), 42);
 
                 // wait for migration to be done
-                HPX_TEST_NEQ(hpx::naming::invalid_id, t2.get_id());
+                HPX_TEST_NEQ(hpx::invalid_id, t2.get_id());
 
                 // the migrated object should have the same id as before
                 HPX_TEST_EQ(t1.get_id(), t2.get_id());
@@ -712,7 +712,7 @@ bool test_migrate_busy_component2(hpx::id_type source, hpx::id_type target)
 bool test_migrate_lazy_busy_component2(hpx::id_type source, hpx::id_type target)
 {
     test_client t1 = hpx::new_<test_client>(source, 42);
-    HPX_TEST_NEQ(hpx::naming::invalid_id, t1.get_id());
+    HPX_TEST_NEQ(hpx::invalid_id, t1.get_id());
 
     // the new object should live on the source locality
     HPX_TEST_EQ(t1.call(), source);
@@ -732,7 +732,7 @@ bool test_migrate_lazy_busy_component2(hpx::id_type source, hpx::id_type target)
                 HPX_TEST_EQ(t1.lazy_get_data(), 42);
 
                 // wait for migration to be done
-                HPX_TEST_NEQ(hpx::naming::invalid_id, t2.get_id());
+                HPX_TEST_NEQ(hpx::invalid_id, t2.get_id());
 
                 // the migrated object should have the same id as before
                 HPX_TEST_EQ(t1.get_id(), t2.get_id());
@@ -783,7 +783,7 @@ bool test_migrate_lazy_busy_component_client2(
     hpx::id_type source, hpx::id_type target)
 {
     test_client t1 = hpx::new_<test_client>(source, 42);
-    HPX_TEST_NEQ(hpx::naming::invalid_id, t1.get_id());
+    HPX_TEST_NEQ(hpx::invalid_id, t1.get_id());
 
     // the new object should live on the source locality
     HPX_TEST_EQ(t1.call(), source);
@@ -803,7 +803,7 @@ bool test_migrate_lazy_busy_component_client2(
                 HPX_TEST_EQ(t1.lazy_get_client(target).call(), target);
 
                 // wait for migration to be done
-                HPX_TEST_NEQ(hpx::naming::invalid_id, t2.get_id());
+                HPX_TEST_NEQ(hpx::invalid_id, t2.get_id());
 
                 // the migrated object should have the same id as before
                 HPX_TEST_EQ(t1.get_id(), t2.get_id());

--- a/libs/full/runtime_components/tests/unit/components/migrate_polymorphic_component.cpp
+++ b/libs/full/runtime_components/tests/unit/components/migrate_polymorphic_component.cpp
@@ -308,7 +308,7 @@ bool test_migrate_polymorphic_component(
 {
     // create component on given locality
     test_client t1(hpx::new_<test_server>(source, 7, 42));
-    HPX_TEST_NEQ(hpx::naming::invalid_id, t1.get_id());
+    HPX_TEST_NEQ(hpx::invalid_id, t1.get_id());
 
     // the new object should live on the source locality
     HPX_TEST_EQ(t1.call(), source);
@@ -322,7 +322,7 @@ bool test_migrate_polymorphic_component(
         test_client t2(hpx::components::migrate<test_server>(t1, target));
 
         // wait for migration to be done
-        HPX_TEST_NEQ(hpx::naming::invalid_id, t2.get_id());
+        HPX_TEST_NEQ(hpx::invalid_id, t2.get_id());
         hpx::cout << "...completed migrating..." << std::endl;
 
         // the migrated object should have the same id as before
@@ -350,7 +350,7 @@ bool test_migrate_lazy_polymorphic_component(
 {
     // create component on given locality
     test_client t1(hpx::new_<test_server>(source, 7, 42));
-    HPX_TEST_NEQ(hpx::naming::invalid_id, t1.get_id());
+    HPX_TEST_NEQ(hpx::invalid_id, t1.get_id());
 
     // the new object should live on the source locality
     HPX_TEST_EQ(t1.call(), source);
@@ -363,7 +363,7 @@ bool test_migrate_lazy_polymorphic_component(
         test_client t2(hpx::components::migrate<test_server>(t1, target));
 
         // wait for migration to be done
-        HPX_TEST_NEQ(hpx::naming::invalid_id, t2.get_id());
+        HPX_TEST_NEQ(hpx::invalid_id, t2.get_id());
 
         // the migrated object should have the same id as before
         HPX_TEST_EQ(t1.get_id(), t2.get_id());
@@ -388,7 +388,7 @@ bool test_migrate_busy_polymorphic_component(
 {
     // create component on given locality
     test_client t1(hpx::new_<test_server>(source, 7, 42));
-    HPX_TEST_NEQ(hpx::naming::invalid_id, t1.get_id());
+    HPX_TEST_NEQ(hpx::invalid_id, t1.get_id());
 
     // the new object should live on the source locality
     HPX_TEST_EQ(t1.call(), source);
@@ -407,7 +407,7 @@ bool test_migrate_busy_polymorphic_component(
         HPX_TEST_EQ(t1.get_base_data(), 7);
 
         // wait for migration to be done
-        HPX_TEST_NEQ(hpx::naming::invalid_id, t2.get_id());
+        HPX_TEST_NEQ(hpx::invalid_id, t2.get_id());
 
         // the migrated object should have the same id as before
         HPX_TEST_EQ(t1.get_id(), t2.get_id());
@@ -435,7 +435,7 @@ bool test_migrate_lazy_busy_polymorphic_component(
 {
     // create component on given locality
     test_client t1(hpx::new_<test_server>(source, 7, 42));
-    HPX_TEST_NEQ(hpx::naming::invalid_id, t1.get_id());
+    HPX_TEST_NEQ(hpx::invalid_id, t1.get_id());
 
     // the new object should live on the source locality
     HPX_TEST_EQ(t1.call(), source);
@@ -454,7 +454,7 @@ bool test_migrate_lazy_busy_polymorphic_component(
         HPX_TEST_EQ(t1.lazy_get_base_data(), 7);
 
         // wait for migration to be done
-        HPX_TEST_NEQ(hpx::naming::invalid_id, t2.get_id());
+        HPX_TEST_NEQ(hpx::invalid_id, t2.get_id());
 
         // the migrated object should have the same id as before
         HPX_TEST_EQ(t1.get_id(), t2.get_id());
@@ -481,7 +481,7 @@ bool test_migrate_polymorphic_component2(
     hpx::id_type source, hpx::id_type target)
 {
     test_client t1(hpx::new_<test_server>(source, 7, 42));
-    HPX_TEST_NEQ(hpx::naming::invalid_id, t1.get_id());
+    HPX_TEST_NEQ(hpx::invalid_id, t1.get_id());
 
     // the new object should live on the source locality
     HPX_TEST_EQ(t1.call(), source);
@@ -503,7 +503,7 @@ bool test_migrate_polymorphic_component2(
             HPX_TEST_EQ(t1.get_base_data(), 7);
 
             // wait for migration to be done
-            HPX_TEST_NEQ(hpx::naming::invalid_id, t2.get_id());
+            HPX_TEST_NEQ(hpx::invalid_id, t2.get_id());
 
             // the migrated object should have the same id as before
             HPX_TEST_EQ(t1.get_id(), t2.get_id());
@@ -533,7 +533,7 @@ bool test_migrate_lazy_polymorphic_component2(
     hpx::id_type source, hpx::id_type target)
 {
     test_client t1(hpx::new_<test_server>(source, 7, 42));
-    HPX_TEST_NEQ(hpx::naming::invalid_id, t1.get_id());
+    HPX_TEST_NEQ(hpx::invalid_id, t1.get_id());
 
     // the new object should live on the source locality
     HPX_TEST_EQ(t1.call(), source);
@@ -555,7 +555,7 @@ bool test_migrate_lazy_polymorphic_component2(
             HPX_TEST_EQ(t1.lazy_get_base_data(), 7);
 
             // wait for migration to be done
-            HPX_TEST_NEQ(hpx::naming::invalid_id, t2.get_id());
+            HPX_TEST_NEQ(hpx::invalid_id, t2.get_id());
 
             // the migrated object should have the same id as before
             HPX_TEST_EQ(t1.get_id(), t2.get_id());
@@ -586,7 +586,7 @@ bool test_migrate_busy_polymorphic_component2(
     hpx::id_type source, hpx::id_type target)
 {
     test_client t1(hpx::new_<test_server>(source, 7, 42));
-    HPX_TEST_NEQ(hpx::naming::invalid_id, t1.get_id());
+    HPX_TEST_NEQ(hpx::invalid_id, t1.get_id());
 
     // the new object should live on the source locality
     HPX_TEST_EQ(t1.call(), source);
@@ -608,7 +608,7 @@ bool test_migrate_busy_polymorphic_component2(
             HPX_TEST_EQ(t1.get_base_data(), 7);
 
             // wait for migration to be done
-            HPX_TEST_NEQ(hpx::naming::invalid_id, t2.get_id());
+            HPX_TEST_NEQ(hpx::invalid_id, t2.get_id());
 
             // the migrated object should have the same id as before
             HPX_TEST_EQ(t1.get_id(), t2.get_id());
@@ -659,7 +659,7 @@ bool test_migrate_lazy_busy_polymorphic_component2(
     hpx::id_type source, hpx::id_type target)
 {
     test_client t1(hpx::new_<test_server>(source, 7, 42));
-    HPX_TEST_NEQ(hpx::naming::invalid_id, t1.get_id());
+    HPX_TEST_NEQ(hpx::invalid_id, t1.get_id());
 
     // the new object should live on the source locality
     HPX_TEST_EQ(t1.call(), source);
@@ -681,7 +681,7 @@ bool test_migrate_lazy_busy_polymorphic_component2(
             HPX_TEST_EQ(t1.lazy_get_base_data(), 7);
 
             // wait for migration to be done
-            HPX_TEST_NEQ(hpx::naming::invalid_id, t2.get_id());
+            HPX_TEST_NEQ(hpx::invalid_id, t2.get_id());
 
             // the migrated object should have the same id as before
             HPX_TEST_EQ(t1.get_id(), t2.get_id());

--- a/libs/full/runtime_distributed/include/hpx/runtime_distributed/applier.hpp
+++ b/libs/full/runtime_distributed/include/hpx/runtime_distributed/applier.hpp
@@ -101,7 +101,7 @@ namespace hpx { namespace applier {
             components::component_type type = components::component_invalid,
             error_code& ec = throws) const;
 
-        bool get_remote_localities(std::vector<naming::id_type>& locality_ids,
+        bool get_remote_localities(std::vector<hpx::id_type>& locality_ids,
             components::component_type type = components::component_invalid,
             error_code& ec = throws) const;
 
@@ -125,9 +125,9 @@ namespace hpx { namespace applier {
             components::component_type type =
                 components::component_invalid) const;
 
-        bool get_localities(std::vector<naming::id_type>& locality_ids,
+        bool get_localities(std::vector<hpx::id_type>& locality_ids,
             error_code& ec = throws) const;
-        bool get_localities(std::vector<naming::id_type>& locality_ids,
+        bool get_localities(std::vector<hpx::id_type>& locality_ids,
             components::component_type type, error_code& ec = throws) const;
 
         /// By convention the runtime_support has a gid identical to the prefix
@@ -140,7 +140,7 @@ namespace hpx { namespace applier {
 
         /// By convention the runtime_support has a gid identical to the prefix
         /// of the locality the runtime_support is responsible for
-        naming::id_type const& get_runtime_support_gid() const
+        hpx::id_type const& get_runtime_support_gid() const
         {
             HPX_ASSERT(runtime_support_id_);
             return runtime_support_id_;
@@ -151,7 +151,7 @@ namespace hpx { namespace applier {
         parcelset::parcelhandler* parcel_handler_;
 #endif
         threads::threadmanager* thread_manager_;
-        naming::id_type runtime_support_id_;
+        hpx::id_type runtime_support_id_;
     };
 }}    // namespace hpx::applier
 

--- a/libs/full/runtime_distributed/include/hpx/runtime_distributed/copy_component.hpp
+++ b/libs/full/runtime_distributed/include/hpx/runtime_distributed/copy_component.hpp
@@ -41,12 +41,12 @@ namespace hpx { namespace components {
     ///
     template <typename Component>
 #if defined(DOXYGEN)
-    future<naming::id_type>
+    future<hpx::id_type>
 #else
     inline typename std::enable_if<traits::is_component<Component>::value,
-        future<naming::id_type>>::type
+        future<hpx::id_type>>::type
 #endif
-    copy(naming::id_type const& to_copy)
+    copy(hpx::id_type const& to_copy)
     {
         typedef server::copy_component_action_here<Component> action_type;
         return hpx::detail::async_colocated<action_type>(to_copy, to_copy);
@@ -71,12 +71,12 @@ namespace hpx { namespace components {
     ///
     template <typename Component>
 #if defined(DOXYGEN)
-    future<naming::id_type>
+    future<hpx::id_type>
 #else
     inline typename std::enable_if<traits::is_component<Component>::value,
-        future<naming::id_type>>::type
+        future<hpx::id_type>>::type
 #endif
-    copy(naming::id_type const& to_copy, naming::id_type const& target_locality)
+    copy(hpx::id_type const& to_copy, hpx::id_type const& target_locality)
     {
         typedef server::copy_component_action<Component> action_type;
         return hpx::detail::async_colocated<action_type>(
@@ -109,7 +109,7 @@ namespace hpx { namespace components {
     ///
     template <typename Derived, typename Stub>
     Derived copy(client_base<Derived, Stub> const& to_copy,
-        naming::id_type const& target_locality = naming::invalid_id)
+        hpx::id_type const& target_locality = hpx::invalid_id)
     {
         typedef typename client_base<Derived, Stub>::server_component_type
             component_type;

--- a/libs/full/runtime_distributed/include/hpx/runtime_distributed/find_all_localities.hpp
+++ b/libs/full/runtime_distributed/include/hpx/runtime_distributed/find_all_localities.hpp
@@ -41,11 +41,11 @@ namespace hpx {
     ///           hpx::exception.
     ///
     /// \note     This function will return meaningful results only if called
-    ///           from an HPX-thread. It will return \a hpx::naming::invalid_id
+    ///           from an HPX-thread. It will return \a hpx::invalid_id
     ///           otherwise.
     ///
     /// \see      \a hpx::find_all_localities(), \a hpx::find_locality()
-    HPX_EXPORT naming::id_type find_root_locality(error_code& ec = throws);
+    HPX_EXPORT hpx::id_type find_root_locality(error_code& ec = throws);
 
     ///////////////////////////////////////////////////////////////////////////
     /// \brief Return the list of global ids representing all localities
@@ -74,7 +74,7 @@ namespace hpx {
     ///           from an HPX-thread. It will return an empty vector otherwise.
     ///
     /// \see      \a hpx::find_here(), \a hpx::find_locality()
-    HPX_EXPORT std::vector<naming::id_type> find_all_localities(
+    HPX_EXPORT std::vector<hpx::id_type> find_all_localities(
         error_code& ec = throws);
 
     /// \brief Return the list of locality ids of remote localities supporting
@@ -105,6 +105,6 @@ namespace hpx {
     ///           from an HPX-thread. It will return an empty vector otherwise.
     ///
     /// \see      \a hpx::find_here(), \a hpx::find_locality()
-    HPX_EXPORT std::vector<naming::id_type> find_remote_localities(
+    HPX_EXPORT std::vector<hpx::id_type> find_remote_localities(
         error_code& ec = throws);
 }    // namespace hpx

--- a/libs/full/runtime_distributed/include/hpx/runtime_distributed/find_here.hpp
+++ b/libs/full/runtime_distributed/include/hpx/runtime_distributed/find_here.hpp
@@ -38,9 +38,9 @@ namespace hpx {
     ///           hpx::exception.
     ///
     /// \note     This function will return meaningful results only if called
-    ///           from an HPX-thread. It will return \a hpx::naming::invalid_id
+    ///           from an HPX-thread. It will return \a hpx::invalid_id
     ///           otherwise.
     ///
     /// \see      \a hpx::find_all_localities(), \a hpx::find_locality()
-    HPX_EXPORT naming::id_type find_here(error_code& ec = throws);
+    HPX_EXPORT hpx::id_type find_here(error_code& ec = throws);
 }    // namespace hpx

--- a/libs/full/runtime_distributed/include/hpx/runtime_distributed/find_localities.hpp
+++ b/libs/full/runtime_distributed/include/hpx/runtime_distributed/find_localities.hpp
@@ -53,7 +53,7 @@ namespace hpx {
     ///           from an HPX-thread. It will return an empty vector otherwise.
     ///
     /// \see      \a hpx::find_here(), \a hpx::find_locality()
-    HPX_EXPORT std::vector<naming::id_type> find_all_localities(
+    HPX_EXPORT std::vector<hpx::id_type> find_all_localities(
         components::component_type type, error_code& ec = throws);
 
     /// \brief Return the list of locality ids of remote localities supporting
@@ -87,7 +87,7 @@ namespace hpx {
     ///           from an HPX-thread. It will return an empty vector otherwise.
     ///
     /// \see      \a hpx::find_here(), \a hpx::find_locality()
-    HPX_EXPORT std::vector<naming::id_type> find_remote_localities(
+    HPX_EXPORT std::vector<hpx::id_type> find_remote_localities(
         components::component_type type, error_code& ec = throws);
 
     ///////////////////////////////////////////////////////////////////////////
@@ -113,7 +113,7 @@ namespace hpx {
     ///           available to this application which supports the creation of
     ///           instances of the given component type. If no locality
     ///           supporting the given component type is currently available,
-    ///           this function will return \a hpx::naming::invalid_id.
+    ///           this function will return \a hpx::invalid_id.
     ///
     /// \note     As long as \a ec is not pre-initialized to \a hpx::throws this
     ///           function doesn't throw but returns the result code using the
@@ -121,10 +121,10 @@ namespace hpx {
     ///           hpx::exception.
     ///
     /// \note     This function will return meaningful results only if called
-    ///           from an HPX-thread. It will return \a hpx::naming::invalid_id
+    ///           from an HPX-thread. It will return \a hpx::invalid_id
     ///           otherwise.
     ///
     /// \see      \a hpx::find_here(), \a hpx::find_all_localities()
-    HPX_EXPORT naming::id_type find_locality(
+    HPX_EXPORT hpx::id_type find_locality(
         components::component_type type, error_code& ec = throws);
 }    // namespace hpx

--- a/libs/full/runtime_distributed/include/hpx/runtime_distributed/get_locality_name.hpp
+++ b/libs/full/runtime_distributed/include/hpx/runtime_distributed/get_locality_name.hpp
@@ -17,7 +17,7 @@
 
 namespace hpx {
 
-    /// \fn future<std::string> get_locality_name(naming::id_type const& id)
+    /// \fn future<std::string> get_locality_name(hpx::id_type const& id)
     ///
     /// \brief Return the name of the referenced locality.
     ///
@@ -32,5 +32,5 @@ namespace hpx {
     ///           and may be different for different parcel ports.
     ///
     /// \see      \a std::string get_locality_name()
-    HPX_EXPORT future<std::string> get_locality_name(naming::id_type const& id);
+    HPX_EXPORT future<std::string> get_locality_name(hpx::id_type const& id);
 }    // namespace hpx

--- a/libs/full/runtime_distributed/include/hpx/runtime_distributed/migrate_component.hpp
+++ b/libs/full/runtime_distributed/include/hpx/runtime_distributed/migrate_component.hpp
@@ -47,13 +47,13 @@ namespace hpx { namespace components {
     ///
     template <typename Component, typename DistPolicy>
 #if defined(DOXYGEN)
-    future<naming::id_type>
+    future<hpx::id_type>
 #else
     inline typename std::enable_if<traits::is_component<Component>::value &&
             traits::is_distribution_policy<DistPolicy>::value,
-        future<naming::id_type>>::type
+        future<hpx::id_type>>::type
 #endif
-    migrate(naming::id_type const& to_migrate, DistPolicy const& policy)
+    migrate(hpx::id_type const& to_migrate, DistPolicy const& policy)
     {
         typedef server::perform_migrate_component_action<Component, DistPolicy>
             action_type;
@@ -132,13 +132,12 @@ namespace hpx { namespace components {
     ///
     template <typename Component>
 #if defined(DOXYGEN)
-    future<naming::id_type>
+    future<hpx::id_type>
 #else
     inline typename std::enable_if<traits::is_component<Component>::value,
-        future<naming::id_type>>::type
+        future<hpx::id_type>>::type
 #endif
-    migrate(naming::id_type const& to_migrate,
-        naming::id_type const& target_locality)
+    migrate(hpx::id_type const& to_migrate, hpx::id_type const& target_locality)
     {
         return migrate<Component>(to_migrate, hpx::target(target_locality));
     }
@@ -163,7 +162,7 @@ namespace hpx { namespace components {
     ///
     template <typename Derived, typename Stub>
     inline Derived migrate(client_base<Derived, Stub> const& to_migrate,
-        naming::id_type const& target_locality)
+        hpx::id_type const& target_locality)
     {
         typedef typename client_base<Derived, Stub>::server_component_type
             component_type;
@@ -175,7 +174,7 @@ namespace hpx { namespace components {
     // overload to be used for polymorphic objects
     template <typename Component, typename Derived, typename Stub>
     inline Derived migrate(client_base<Derived, Stub> const& to_migrate,
-        naming::id_type const& target_locality)
+        hpx::id_type const& target_locality)
     {
         return Derived(
             migrate<Component>(to_migrate.get_id(), target_locality));

--- a/libs/full/runtime_distributed/include/hpx/runtime_distributed/runtime_support.hpp
+++ b/libs/full/runtime_distributed/include/hpx/runtime_distributed/runtime_support.hpp
@@ -28,11 +28,11 @@ namespace hpx { namespace components {
     public:
         /// Create a client side representation for the existing
         /// \a server#runtime_support instance with the given global id \a gid.
-        runtime_support(naming::id_type const& gid = naming::invalid_id)
-          : gid_(naming::invalid_id == gid ?
-                    naming::id_type(
+        runtime_support(hpx::id_type const& gid = hpx::invalid_id)
+          : gid_(hpx::invalid_id == gid ?
+                    hpx::id_type(
                         applier::get_applier().get_runtime_support_raw_gid(),
-                        naming::id_type::unmanaged) :
+                        hpx::id_type::management_type::unmanaged) :
                     gid)
         {
         }
@@ -42,7 +42,7 @@ namespace hpx { namespace components {
 
         /// Create a new component type using the runtime_support
         template <typename Component, typename... Ts>
-        naming::id_type create_component(Ts&&... vs)
+        hpx::id_type create_component(Ts&&... vs)
         {
             return this->base_type::template create_component<Component>(
                 gid_, HPX_FORWARD(Ts, vs)...);
@@ -50,7 +50,7 @@ namespace hpx { namespace components {
 
         /// Asynchronously create a new component using the runtime_support
         template <typename Component, typename... Ts>
-        hpx::future<naming::id_type> create_component_async(Ts&&... vs)
+        hpx::future<hpx::id_type> create_component_async(Ts&&... vs)
         {
             return this->base_type::template create_component_async<Component>(
                 gid_, HPX_FORWARD(Ts, vs)...);
@@ -59,7 +59,7 @@ namespace hpx { namespace components {
         /// Asynchronously create N new default constructed components using
         /// the runtime_support
         template <typename Component, typename... Ts>
-        std::vector<naming::id_type> bulk_create_component(
+        std::vector<hpx::id_type> bulk_create_component(
             std::size_t /* count */, Ts&&... vs)
         {
             return this->base_type::template bulk_create_component<Component>(
@@ -68,7 +68,7 @@ namespace hpx { namespace components {
 
         /// Asynchronously create a new component using the runtime_support
         template <typename Component, typename... Ts>
-        hpx::future<std::vector<naming::id_type>> bulk_create_components_async(
+        hpx::future<std::vector<hpx::id_type>> bulk_create_components_async(
             std::size_t /* count */, Ts&&... vs)
         {
             return this->base_type::template bulk_create_component<Component>(
@@ -138,7 +138,7 @@ namespace hpx { namespace components {
         }
 
         ///////////////////////////////////////////////////////////////////////
-        naming::id_type const& get_id() const
+        hpx::id_type const& get_id() const
         {
             return gid_;
         }
@@ -149,6 +149,6 @@ namespace hpx { namespace components {
         }
 
     private:
-        naming::id_type gid_;
+        hpx::id_type gid_;
     };
 }}    // namespace hpx::components

--- a/libs/full/runtime_distributed/include/hpx/runtime_distributed/server/copy_component.hpp
+++ b/libs/full/runtime_distributed/include/hpx/runtime_distributed/server/copy_component.hpp
@@ -24,7 +24,7 @@ namespace hpx { namespace components { namespace server {
         // If we know that the new component has to be created local to the old
         // one, we can avoid doing serialization.
         template <typename Component>
-        naming::id_type copy_component_here_postproc(
+        hpx::id_type copy_component_here_postproc(
             std::shared_ptr<Component> ptr)
         {
             // This is executed on the locality where the component lives.
@@ -36,8 +36,8 @@ namespace hpx { namespace components { namespace server {
         }
 
         template <typename Component>
-        naming::id_type copy_component_postproc(std::shared_ptr<Component> ptr,
-            naming::id_type const& target_locality)
+        hpx::id_type copy_component_postproc(
+            std::shared_ptr<Component> ptr, hpx::id_type const& target_locality)
         {
             using stubs::runtime_support;
 
@@ -60,22 +60,22 @@ namespace hpx { namespace components { namespace server {
 
     ///////////////////////////////////////////////////////////////////////////
     template <typename Component>
-    future<naming::id_type> copy_component_here(naming::id_type const& to_copy)
+    future<hpx::id_type> copy_component_here(hpx::id_type const& to_copy)
     {
         future<std::shared_ptr<Component>> f = get_ptr<Component>(to_copy);
         return f.then(
-            [=](future<std::shared_ptr<Component>> f) -> naming::id_type {
+            [=](future<std::shared_ptr<Component>> f) -> hpx::id_type {
                 return detail::copy_component_here_postproc(f.get());
             });
     }
 
     template <typename Component>
-    future<naming::id_type> copy_component(
-        naming::id_type const& to_copy, naming::id_type const& target_locality)
+    future<hpx::id_type> copy_component(
+        hpx::id_type const& to_copy, hpx::id_type const& target_locality)
     {
         future<std::shared_ptr<Component>> f = get_ptr<Component>(to_copy);
         return f.then(
-            [=](future<std::shared_ptr<Component>> f) -> naming::id_type {
+            [=](future<std::shared_ptr<Component>> f) -> hpx::id_type {
                 return detail::copy_component_postproc(
                     f.get(), target_locality);
             });
@@ -83,8 +83,7 @@ namespace hpx { namespace components { namespace server {
 
     template <typename Component>
     struct copy_component_action_here
-      : ::hpx::actions::action<future<naming::id_type> (*)(
-                                   naming::id_type const&),
+      : ::hpx::actions::action<future<hpx::id_type> (*)(hpx::id_type const&),
             &copy_component_here<Component>,
             copy_component_action_here<Component>>
     {
@@ -92,9 +91,8 @@ namespace hpx { namespace components { namespace server {
 
     template <typename Component>
     struct copy_component_action
-      : ::hpx::actions::action<future<naming::id_type> (*)(
-                                   naming::id_type const&,
-                                   naming::id_type const&),
+      : ::hpx::actions::action<future<hpx::id_type> (*)(
+                                   hpx::id_type const&, hpx::id_type const&),
             &copy_component<Component>, copy_component_action<Component>>
     {
     };

--- a/libs/full/runtime_distributed/include/hpx/runtime_distributed/server/migrate_component.hpp
+++ b/libs/full/runtime_distributed/include/hpx/runtime_distributed/server/migrate_component.hpp
@@ -205,7 +205,7 @@ namespace hpx { namespace components { namespace server {
     // resolution for the given object.
     template <typename Component, typename DistPolicy>
     future<id_type> trigger_migrate_component(id_type const& to_migrate,
-        DistPolicy const& policy, naming::id_type const& id,
+        DistPolicy const& policy, hpx::id_type const& id,
         naming::address const& addr)
     {
         if (!traits::component_supports_migration<Component>::call())
@@ -265,7 +265,7 @@ namespace hpx { namespace components { namespace server {
     template <typename Component, typename DistPolicy>
     struct trigger_migrate_component_action
       : ::hpx::actions::action<future<id_type> (*)(id_type const&,
-                                   DistPolicy const&, naming::id_type const&,
+                                   DistPolicy const&, hpx::id_type const&,
                                    naming::address const&),
             &trigger_migrate_component<Component, DistPolicy>,
             trigger_migrate_component_action<Component, DistPolicy>>
@@ -296,8 +296,7 @@ namespace hpx { namespace components { namespace server {
                 [=](future<std::shared_ptr<Component>>&& f) -> future<id_type> {
                     std::shared_ptr<Component> ptr = f.get();
 
-                    using bm_result =
-                        std::pair<naming::id_type, naming::address>;
+                    using bm_result = std::pair<hpx::id_type, naming::address>;
 
                     // mark object in AGAS as being migrated first
                     return agas::begin_migration(to_migrate)

--- a/libs/full/runtime_distributed/include/hpx/runtime_distributed/server/runtime_support.hpp
+++ b/libs/full/runtime_distributed/include/hpx/runtime_distributed/server/runtime_support.hpp
@@ -110,7 +110,7 @@ namespace hpx { namespace components { namespace server {
 
         // This component type requires valid locality id for its actions to
         // be invoked
-        static bool is_target_valid(naming::id_type const& id)
+        static bool is_target_valid(hpx::id_type const& id)
         {
             return naming::is_locality(id);
         }
@@ -138,18 +138,18 @@ namespace hpx { namespace components { namespace server {
 
         template <typename Component>
         naming::gid_type migrate_component_to_here(
-            std::shared_ptr<Component> const& p, naming::id_type);
+            std::shared_ptr<Component> const& p, hpx::id_type);
 
         /// \brief Gracefully shutdown this runtime system instance
-        void shutdown(double timeout, naming::id_type const& respond_to);
+        void shutdown(double timeout, hpx::id_type const& respond_to);
 
         /// \brief Gracefully shutdown runtime system instances on all localities
         void shutdown_all(double timeout);
 
         /// \brief Shutdown this runtime system instance
-        [[noreturn]] void terminate(naming::id_type const& respond_to);
+        [[noreturn]] void terminate(hpx::id_type const& respond_to);
 
-        void terminate_act(naming::id_type const& id)
+        void terminate_act(hpx::id_type const& id)
         {
             terminate(id);
         }
@@ -234,7 +234,7 @@ namespace hpx { namespace components { namespace server {
         ///        be properly stopped.
         ///
         /// \note      This function can be called from any thread.
-        void stop(double timeout, naming::id_type const& respond_to,
+        void stop(double timeout, hpx::id_type const& respond_to,
             bool remove_from_remote_caches);
 
         /// called locally only
@@ -329,7 +329,7 @@ namespace hpx { namespace components { namespace server {
 
         // the name says it all
         std::size_t dijkstra_termination_detection(
-            std::vector<naming::id_type> const& locality_ids);
+            std::vector<hpx::id_type> const& locality_ids);
 
 #if defined(HPX_HAVE_NETWORKING)
         void send_dijkstra_termination_token(std::uint32_t target_locality_id,
@@ -490,7 +490,7 @@ namespace hpx { namespace components { namespace server {
     ///////////////////////////////////////////////////////////////////////////
     template <typename Component>
     naming::gid_type runtime_support::migrate_component_to_here(
-        std::shared_ptr<Component> const& p, naming::id_type to_migrate)
+        std::shared_ptr<Component> const& p, hpx::id_type to_migrate)
     {
         components::component_type const type =
             components::get_component_type<typename Component::wrapped_type>();
@@ -685,7 +685,7 @@ namespace hpx { namespace components { namespace server {
     struct migrate_component_here_action
       : ::hpx::actions::action<naming::gid_type (runtime_support::*)(
                                    std::shared_ptr<Component> const&,
-                                   naming::id_type),
+                                   hpx::id_type),
             &runtime_support::migrate_component_to_here<Component>,
             migrate_component_here_action<Component>>
     {

--- a/libs/full/runtime_distributed/include/hpx/runtime_distributed/stubs/runtime_support.hpp
+++ b/libs/full/runtime_distributed/include/hpx/runtime_distributed/stubs/runtime_support.hpp
@@ -38,8 +38,8 @@ namespace hpx { namespace components { namespace stubs {
         /// to call \a future#get on the result of this function
         /// to obtain the global id of the newly created object.
         template <typename Component, typename... Ts>
-        static hpx::future<naming::id_type> create_component_async(
-            naming::id_type const& gid, Ts&&... vs)
+        static hpx::future<hpx::id_type> create_component_async(
+            hpx::id_type const& gid, Ts&&... vs)
         {
             if (!naming::is_locality(gid))
             {
@@ -47,7 +47,7 @@ namespace hpx { namespace components { namespace stubs {
                     "stubs::runtime_support::create_component_async",
                     "The id passed as the first argument is not representing"
                     " a locality");
-                return hpx::make_ready_future(naming::invalid_id);
+                return hpx::make_ready_future(hpx::invalid_id);
             }
 
             typedef server::create_component_action<Component,
@@ -59,8 +59,8 @@ namespace hpx { namespace components { namespace stubs {
         /// Create a new component \a type using the runtime_support with the
         /// given \a targetgid. Block for the creation to finish.
         template <typename Component, typename... Ts>
-        static naming::id_type create_component(
-            naming::id_type const& gid, Ts&&... vs)
+        static hpx::id_type create_component(
+            hpx::id_type const& gid, Ts&&... vs)
         {
             return create_component_async<Component>(
                 gid, HPX_FORWARD(Ts, vs)...)
@@ -71,9 +71,9 @@ namespace hpx { namespace components { namespace stubs {
         /// colocated with the with the given \a targetgid. This is a
         /// non-blocking call.
         template <typename Component, typename... Ts>
-        static hpx::future<std::vector<naming::id_type>>
+        static hpx::future<std::vector<hpx::id_type>>
         bulk_create_component_colocated_async(
-            naming::id_type const& gid, std::size_t count, Ts&&... vs)
+            hpx::id_type const& gid, std::size_t count, Ts&&... vs)
         {
             typedef server::bulk_create_component_action<Component,
                 typename std::decay<Ts>::type...>
@@ -87,8 +87,8 @@ namespace hpx { namespace components { namespace stubs {
         /// colocated with the with the given \a targetgid. Block for the
         /// creation to finish.
         template <typename Component, typename... Ts>
-        static std::vector<naming::id_type> bulk_create_component_colocated(
-            naming::id_type const& gid, std::size_t count, Ts&&... vs)
+        static std::vector<hpx::id_type> bulk_create_component_colocated(
+            hpx::id_type const& gid, std::size_t count, Ts&&... vs)
         {
             return bulk_create_component_colocated_async<Component>(
                 gid, count, HPX_FORWARD(Ts, vs)...)
@@ -98,9 +98,9 @@ namespace hpx { namespace components { namespace stubs {
         /// Create multiple new components \a type using the runtime_support
         /// on the given locality. This is a  non-blocking call.
         template <typename Component, typename... Ts>
-        static hpx::future<std::vector<naming::id_type>>
+        static hpx::future<std::vector<hpx::id_type>>
         bulk_create_component_async(
-            naming::id_type const& gid, std::size_t count, Ts&&... vs)
+            hpx::id_type const& gid, std::size_t count, Ts&&... vs)
         {
             if (!naming::is_locality(gid))
             {
@@ -108,7 +108,7 @@ namespace hpx { namespace components { namespace stubs {
                     "stubs::runtime_support::bulk_create_component_async",
                     "The id passed as the first argument is not representing"
                     " a locality");
-                return hpx::make_ready_future(std::vector<naming::id_type>());
+                return hpx::make_ready_future(std::vector<hpx::id_type>());
             }
 
             typedef server::bulk_create_component_action<Component,
@@ -120,8 +120,8 @@ namespace hpx { namespace components { namespace stubs {
         /// Create multiple new components \a type using the runtime_support
         /// on the given locality. Block for the creation to finish.
         template <typename Component, typename... Ts>
-        static std::vector<naming::id_type> bulk_create_component(
-            naming::id_type const& gid, std::size_t count, Ts&&... vs)
+        static std::vector<hpx::id_type> bulk_create_component(
+            hpx::id_type const& gid, std::size_t count, Ts&&... vs)
         {
             return bulk_create_component_async<Component>(
                 gid, count, HPX_FORWARD(Ts, vs)...)
@@ -133,8 +133,8 @@ namespace hpx { namespace components { namespace stubs {
         /// to call \a future#get on the result of this function
         /// to obtain the global id of the newly created object.
         template <typename Component, typename... Ts>
-        static hpx::future<naming::id_type> create_component_colocated_async(
-            naming::id_type const& gid, Ts&&... vs)
+        static hpx::future<hpx::id_type> create_component_colocated_async(
+            hpx::id_type const& gid, Ts&&... vs)
         {
             typedef server::create_component_action<Component,
                 typename std::decay<Ts>::type...>
@@ -146,8 +146,8 @@ namespace hpx { namespace components { namespace stubs {
         /// Create a new component \a type using the runtime_support with the
         /// given \a targetgid. Block for the creation to finish.
         template <typename Component, typename... Ts>
-        static naming::id_type create_component_colocated(
-            naming::id_type const& gid, Ts&&... vs)
+        static hpx::id_type create_component_colocated(
+            hpx::id_type const& gid, Ts&&... vs)
         {
             return create_component_colocated_async<Component>(
                 gid, HPX_FORWARD(Ts, vs)...)
@@ -157,8 +157,8 @@ namespace hpx { namespace components { namespace stubs {
         ///////////////////////////////////////////////////////////////////////
         // copy construct a component
         template <typename Component>
-        static hpx::future<naming::id_type> copy_create_component_async(
-            naming::id_type const& gid, std::shared_ptr<Component> const& p,
+        static hpx::future<hpx::id_type> copy_create_component_async(
+            hpx::id_type const& gid, std::shared_ptr<Component> const& p,
             bool local_op)
         {
             if (!naming::is_locality(gid))
@@ -167,7 +167,7 @@ namespace hpx { namespace components { namespace stubs {
                     "stubs::runtime_support::copy_create_component_async",
                     "The id passed as the first argument is not representing"
                     " a locality");
-                return hpx::make_ready_future(naming::invalid_id);
+                return hpx::make_ready_future(hpx::invalid_id);
             }
 
             typedef typename server::copy_create_component_action<Component>
@@ -176,7 +176,7 @@ namespace hpx { namespace components { namespace stubs {
         }
 
         template <typename Component>
-        static naming::id_type copy_create_component(naming::id_type const& gid,
+        static hpx::id_type copy_create_component(hpx::id_type const& gid,
             std::shared_ptr<Component> const& p, bool local_op)
         {
             // The following get yields control while the action above
@@ -188,10 +188,9 @@ namespace hpx { namespace components { namespace stubs {
         ///////////////////////////////////////////////////////////////////////
         // copy construct a component
         template <typename Component>
-        static hpx::future<naming::id_type> migrate_component_async(
-            naming::id_type const& target_locality,
-            std::shared_ptr<Component> const& p,
-            naming::id_type const& to_migrate)
+        static hpx::future<hpx::id_type> migrate_component_async(
+            hpx::id_type const& target_locality,
+            std::shared_ptr<Component> const& p, hpx::id_type const& to_migrate)
         {
             if (!naming::is_locality(target_locality))
             {
@@ -199,7 +198,7 @@ namespace hpx { namespace components { namespace stubs {
                     "stubs::runtime_support::migrate_component_async",
                     "The id passed as the first argument is not representing"
                     " a locality");
-                return hpx::make_ready_future(naming::invalid_id);
+                return hpx::make_ready_future(hpx::invalid_id);
             }
 
             typedef typename server::migrate_component_here_action<Component>
@@ -208,9 +207,9 @@ namespace hpx { namespace components { namespace stubs {
         }
 
         template <typename Component, typename DistPolicy>
-        static hpx::future<naming::id_type> migrate_component_async(
+        static hpx::future<hpx::id_type> migrate_component_async(
             DistPolicy const& policy, std::shared_ptr<Component> const& p,
-            naming::id_type const& to_migrate)
+            hpx::id_type const& to_migrate)
         {
             typedef typename server::migrate_component_here_action<Component>
                 action_type;
@@ -218,9 +217,8 @@ namespace hpx { namespace components { namespace stubs {
         }
 
         template <typename Component, typename Target>
-        static naming::id_type migrate_component(Target const& target,
-            naming::id_type const& to_migrate,
-            std::shared_ptr<Component> const& p)
+        static hpx::id_type migrate_component(Target const& target,
+            hpx::id_type const& to_migrate, std::shared_ptr<Component> const& p)
         {
             // The following get yields control while the action above
             // is executed and the result is returned to the future
@@ -229,68 +227,64 @@ namespace hpx { namespace components { namespace stubs {
         }
 
         ///////////////////////////////////////////////////////////////////////
-        static hpx::future<int> load_components_async(
-            naming::id_type const& gid);
-        static int load_components(naming::id_type const& gid);
+        static hpx::future<int> load_components_async(hpx::id_type const& gid);
+        static int load_components(hpx::id_type const& gid);
 
         static hpx::future<void> call_startup_functions_async(
-            naming::id_type const& gid, bool pre_startup);
+            hpx::id_type const& gid, bool pre_startup);
         static void call_startup_functions(
-            naming::id_type const& gid, bool pre_startup);
+            hpx::id_type const& gid, bool pre_startup);
 
         /// \brief Shutdown the given runtime system
         static hpx::future<void> shutdown_async(
-            naming::id_type const& targetgid, double timeout = -1);
+            hpx::id_type const& targetgid, double timeout = -1);
         static void shutdown(
-            naming::id_type const& targetgid, double timeout = -1);
+            hpx::id_type const& targetgid, double timeout = -1);
 
         /// \brief Shutdown the runtime systems of all localities
         static void shutdown_all(
-            naming::id_type const& targetgid, double timeout = -1);
+            hpx::id_type const& targetgid, double timeout = -1);
 
         static void shutdown_all(double timeout = -1);
 
         ///////////////////////////////////////////////////////////////////////
         /// \brief Retrieve configuration information
         /// \brief Terminate the given runtime system
-        static hpx::future<void> terminate_async(
-            naming::id_type const& targetgid);
+        static hpx::future<void> terminate_async(hpx::id_type const& targetgid);
 
-        static void terminate(naming::id_type const& targetgid);
+        static void terminate(hpx::id_type const& targetgid);
 
         /// \brief Terminate the runtime systems of all localities
-        static void terminate_all(naming::id_type const& targetgid);
+        static void terminate_all(hpx::id_type const& targetgid);
 
         static void terminate_all();
 
         ///////////////////////////////////////////////////////////////////////
-        static void garbage_collect_non_blocking(
-            naming::id_type const& targetgid);
+        static void garbage_collect_non_blocking(hpx::id_type const& targetgid);
 
         static hpx::future<void> garbage_collect_async(
-            naming::id_type const& targetgid);
+            hpx::id_type const& targetgid);
 
-        static void garbage_collect(naming::id_type const& targetgid);
+        static void garbage_collect(hpx::id_type const& targetgid);
 
         ///////////////////////////////////////////////////////////////////////
-        static hpx::future<naming::id_type> create_performance_counter_async(
-            naming::id_type targetgid,
+        static hpx::future<hpx::id_type> create_performance_counter_async(
+            hpx::id_type targetgid,
             performance_counters::counter_info const& info);
-        static naming::id_type create_performance_counter(
-            naming::id_type targetgid,
+        static hpx::id_type create_performance_counter(hpx::id_type targetgid,
             performance_counters::counter_info const& info,
             error_code& ec = throws);
 
         ///////////////////////////////////////////////////////////////////////
         /// \brief Retrieve configuration information
         static hpx::future<util::section> get_config_async(
-            naming::id_type const& targetgid);
+            hpx::id_type const& targetgid);
         static void get_config(
-            naming::id_type const& targetgid, util::section& ini);
+            hpx::id_type const& targetgid, util::section& ini);
 
         ///////////////////////////////////////////////////////////////////////
         static void remove_from_connection_cache_async(
-            naming::id_type const& target, naming::gid_type const& gid,
+            hpx::id_type const& target, naming::gid_type const& gid,
             parcelset::endpoints_type const& endpoints);
     };
 }}}    // namespace hpx::components::stubs

--- a/libs/full/runtime_distributed/src/applier.cpp
+++ b/libs/full/runtime_distributed/src/applier.cpp
@@ -63,8 +63,8 @@ namespace hpx { namespace applier {
     {
         naming::resolver_client& agas_client = naming::get_agas_client();
         runtime_support_id_ =
-            naming::id_type(agas_client.get_local_locality().get_msb(), rts,
-                naming::id_type::unmanaged);
+            hpx::id_type(agas_client.get_local_locality().get_msb(), rts,
+                hpx::id_type::management_type::unmanaged);
     }
 
 #if defined(HPX_HAVE_NETWORKING)
@@ -103,7 +103,7 @@ namespace hpx { namespace applier {
 #endif
     }
 
-    bool applier::get_remote_localities(std::vector<naming::id_type>& prefixes,
+    bool applier::get_remote_localities(std::vector<hpx::id_type>& prefixes,
         components::component_type type, error_code& ec) const
     {
 #if defined(HPX_HAVE_NETWORKING)
@@ -112,7 +112,8 @@ namespace hpx { namespace applier {
             return false;
 
         for (naming::gid_type& gid : raw_prefixes)
-            prefixes.emplace_back(gid, naming::id_type::unmanaged);
+            prefixes.emplace_back(
+                gid, hpx::id_type::management_type::unmanaged);
 #endif
         HPX_UNUSED(prefixes);
         HPX_UNUSED(type);
@@ -136,7 +137,7 @@ namespace hpx { namespace applier {
     }
 
     bool applier::get_localities(
-        std::vector<naming::id_type>& prefixes, error_code& ec) const
+        std::vector<hpx::id_type>& prefixes, error_code& ec) const
     {
         std::vector<naming::gid_type> raw_prefixes;
 #if defined(HPX_HAVE_NETWORKING)
@@ -145,7 +146,8 @@ namespace hpx { namespace applier {
             return false;
 
         for (naming::gid_type& gid : raw_prefixes)
-            prefixes.emplace_back(gid, naming::id_type::unmanaged);
+            prefixes.emplace_back(
+                gid, hpx::id_type::management_type::unmanaged);
 #else
         prefixes.emplace_back(agas::get_console_locality());
 #endif
@@ -154,7 +156,7 @@ namespace hpx { namespace applier {
         return true;
     }
 
-    bool applier::get_localities(std::vector<naming::id_type>& prefixes,
+    bool applier::get_localities(std::vector<hpx::id_type>& prefixes,
         components::component_type type, error_code& ec) const
     {
 #if defined(HPX_HAVE_NETWORKING)
@@ -163,7 +165,8 @@ namespace hpx { namespace applier {
             return false;
 
         for (naming::gid_type& gid : raw_prefixes)
-            prefixes.emplace_back(gid, naming::id_type::unmanaged);
+            prefixes.emplace_back(
+                gid, hpx::id_type::management_type::unmanaged);
 #else
         prefixes.emplace_back(agas::get_console_locality());
 #endif

--- a/libs/full/runtime_distributed/src/big_boot_barrier.cpp
+++ b/libs/full/runtime_distributed/src/big_boot_barrier.cpp
@@ -271,9 +271,9 @@ namespace hpx { namespace agas {
         naming::address addr(
             naming::get_gid_from_locality_id(target_locality_id));
 
-        parcelset::put_parcel(naming::id_type(naming::get_gid_from_locality_id(
-                                                  target_locality_id),
-                                  naming::id_type::unmanaged),
+        parcelset::put_parcel(
+            hpx::id_type(naming::get_gid_from_locality_id(target_locality_id),
+                hpx::id_type::management_type::unmanaged),
             HPX_MOVE(addr), act, HPX_FORWARD(Args, args)...);
     }    // }}}
 

--- a/libs/full/runtime_distributed/src/get_locality_name.cpp
+++ b/libs/full/runtime_distributed/src/get_locality_name.cpp
@@ -17,7 +17,7 @@ HPX_PLAIN_ACTION_ID(hpx::detail::get_locality_name,
 
 namespace hpx {
 
-    future<std::string> get_locality_name(naming::id_type const& id)
+    future<std::string> get_locality_name(hpx::id_type const& id)
     {
         return async<hpx_get_locality_name_action>(id);
     }

--- a/libs/full/runtime_distributed/src/runtime_distributed.cpp
+++ b/libs/full/runtime_distributed/src/runtime_distributed.cpp
@@ -743,7 +743,9 @@ namespace hpx {
             if (agas_client_.get_local_locality() != console_id)
             {
                 components::console_error_sink(
-                    naming::id_type(console_id, naming::id_type::unmanaged), e);
+                    hpx::id_type(
+                        console_id, hpx::id_type::management_type::unmanaged),
+                    e);
             }
         }
 
@@ -1671,29 +1673,29 @@ namespace hpx {
 
     ///////////////////////////////////////////////////////////////////////////
     // Helpers
-    naming::id_type find_here(error_code& ec)
+    hpx::id_type find_here(error_code& ec)
     {
         runtime* rt = get_runtime_ptr();
         if (nullptr == rt)
         {
             HPX_THROWS_IF(ec, invalid_status, "hpx::find_here",
                 "the runtime system is not available at this time");
-            return naming::invalid_id;
+            return hpx::invalid_id;
         }
 
-        static naming::id_type here =
+        static hpx::id_type here =
             naming::get_id_from_locality_id(rt->get_locality_id(ec));
         return here;
     }
 
-    naming::id_type find_root_locality(error_code& ec)
+    hpx::id_type find_root_locality(error_code& ec)
     {
         runtime_distributed* rt = hpx::get_runtime_distributed_ptr();
         if (nullptr == rt)
         {
             HPX_THROWS_IF(ec, invalid_status, "hpx::find_root_locality",
                 "the runtime system is not available at this time");
-            return naming::invalid_id;
+            return hpx::invalid_id;
         }
 
         naming::gid_type console_locality;
@@ -1701,19 +1703,20 @@ namespace hpx {
         {
             HPX_THROWS_IF(ec, invalid_status, "hpx::find_root_locality",
                 "the root locality is not available at this time");
-            return naming::invalid_id;
+            return hpx::invalid_id;
         }
 
         if (&ec != &throws)
             ec = make_success_code();
 
-        return naming::id_type(console_locality, naming::id_type::unmanaged);
+        return hpx::id_type(
+            console_locality, hpx::id_type::management_type::unmanaged);
     }
 
-    std::vector<naming::id_type> find_all_localities(
+    std::vector<hpx::id_type> find_all_localities(
         components::component_type type, error_code& ec)
     {
-        std::vector<naming::id_type> locality_ids;
+        std::vector<hpx::id_type> locality_ids;
         if (nullptr == hpx::applier::get_applier_ptr())
         {
             HPX_THROWS_IF(ec, invalid_status, "hpx::find_all_localities",
@@ -1725,9 +1728,9 @@ namespace hpx {
         return locality_ids;
     }
 
-    std::vector<naming::id_type> find_all_localities(error_code& ec)
+    std::vector<hpx::id_type> find_all_localities(error_code& ec)
     {
-        std::vector<naming::id_type> locality_ids;
+        std::vector<hpx::id_type> locality_ids;
         if (nullptr == hpx::applier::get_applier_ptr())
         {
             HPX_THROWS_IF(ec, invalid_status, "hpx::find_all_localities",
@@ -1739,10 +1742,10 @@ namespace hpx {
         return locality_ids;
     }
 
-    std::vector<naming::id_type> find_remote_localities(
+    std::vector<hpx::id_type> find_remote_localities(
         components::component_type type, error_code& ec)
     {
-        std::vector<naming::id_type> locality_ids;
+        std::vector<hpx::id_type> locality_ids;
         if (nullptr == hpx::applier::get_applier_ptr())
         {
             HPX_THROWS_IF(ec, invalid_status, "hpx::find_remote_localities",
@@ -1755,9 +1758,9 @@ namespace hpx {
         return locality_ids;
     }
 
-    std::vector<naming::id_type> find_remote_localities(error_code& ec)
+    std::vector<hpx::id_type> find_remote_localities(error_code& ec)
     {
-        std::vector<naming::id_type> locality_ids;
+        std::vector<hpx::id_type> locality_ids;
         if (nullptr == hpx::applier::get_applier_ptr())
         {
             HPX_THROWS_IF(ec, invalid_status, "hpx::find_remote_localities",
@@ -1772,21 +1775,20 @@ namespace hpx {
     }
 
     // find a locality supporting the given component
-    naming::id_type find_locality(
-        components::component_type type, error_code& ec)
+    hpx::id_type find_locality(components::component_type type, error_code& ec)
     {
         if (nullptr == hpx::applier::get_applier_ptr())
         {
             HPX_THROWS_IF(ec, invalid_status, "hpx::find_locality",
                 "the runtime system is not available at this time");
-            return naming::invalid_id;
+            return hpx::invalid_id;
         }
 
-        std::vector<naming::id_type> locality_ids;
+        std::vector<hpx::id_type> locality_ids;
         hpx::applier::get_applier().get_localities(locality_ids, type, ec);
 
         if (ec || locality_ids.empty())
-            return naming::invalid_id;
+            return hpx::invalid_id;
 
         // chose first locality to host the object
         return locality_ids.front();

--- a/libs/full/runtime_distributed/src/runtime_support.cpp
+++ b/libs/full/runtime_distributed/src/runtime_support.cpp
@@ -60,8 +60,7 @@ namespace hpx { namespace agas { namespace detail { namespace impl {
 
     /// \brief Invoke an asynchronous garbage collection step on the given target
     ///        locality.
-    void garbage_collect_non_blocking_id(
-        naming::id_type const& id, error_code& ec)
+    void garbage_collect_non_blocking_id(hpx::id_type const& id, error_code& ec)
     {
         try
         {
@@ -78,7 +77,7 @@ namespace hpx { namespace agas { namespace detail { namespace impl {
 
     /// \brief Invoke a synchronous garbage collection step on the given target
     ///        locality.
-    void garbage_collect_id(naming::id_type const& id, error_code& ec)
+    void garbage_collect_id(hpx::id_type const& id, error_code& ec)
     {
         try
         {

--- a/libs/full/runtime_distributed/src/server/runtime_support_server.cpp
+++ b/libs/full/runtime_distributed/src/server/runtime_support_server.cpp
@@ -154,14 +154,14 @@ namespace hpx { namespace components { namespace server {
     // function to be called during shutdown
     // Action: shut down this runtime system instance
     void runtime_support::shutdown(
-        double timeout, naming::id_type const& respond_to)
+        double timeout, hpx::id_type const& respond_to)
     {
         // initiate system shutdown
         stop(timeout, respond_to, false);
     }
 
     // function to be called to terminate this locality immediately
-    void runtime_support::terminate(naming::id_type const& respond_to)
+    void runtime_support::terminate(hpx::id_type const& respond_to)
     {
 #if !defined(HPX_COMPUTE_DEVICE_CODE)
         // push pending logs
@@ -203,7 +203,7 @@ namespace hpx { namespace components { namespace server {
 
     // initiate system shutdown for all localities
     void invoke_shutdown_functions(
-        std::vector<naming::id_type> const& localities, bool pre_shutdown)
+        std::vector<hpx::id_type> const& localities, bool pre_shutdown)
     {
 #if !defined(HPX_COMPUTE_DEVICE_CODE)
         std::vector<hpx::future<void>> results;
@@ -264,7 +264,7 @@ namespace hpx { namespace components { namespace server {
         }
 
 #if !defined(HPX_COMPUTE_DEVICE_CODE)
-        naming::id_type id(naming::get_id_from_locality_id(target_locality_id));
+        hpx::id_type id(naming::get_id_from_locality_id(target_locality_id));
         apply<dijkstra_termination_action>(
             id, initiating_locality_id, num_localities, dijkstra_token);
 #else
@@ -315,7 +315,7 @@ namespace hpx { namespace components { namespace server {
     // Kick off termination detection, this is modeled after Dijkstra's paper:
     // http://www.cs.mcgill.ca/~lli22/575/termination3.pdf.
     std::size_t runtime_support::dijkstra_termination_detection(
-        std::vector<naming::id_type> const& locality_ids)
+        std::vector<hpx::id_type> const& locality_ids)
     {
 #if defined(HPX_HAVE_NETWORKING)
         std::uint32_t num_localities =
@@ -428,7 +428,7 @@ namespace hpx { namespace components { namespace server {
         threads::threadmanager& tm = appl.get_thread_manager();
         tm.resume();
 
-        std::vector<naming::id_type> locality_ids = find_all_localities();
+        std::vector<hpx::id_type> locality_ids = find_all_localities();
         std::size_t count = dijkstra_termination_detection(locality_ids);
 
         LRT_(info).format("runtime_support::shutdown_all: passed first "
@@ -458,7 +458,7 @@ namespace hpx { namespace components { namespace server {
         std::uint32_t locality_id = get_locality_id();
         std::vector<hpx::future<void>> lazy_actions;
 
-        for (naming::id_type const& id : locality_ids)
+        for (hpx::id_type const& id : locality_ids)
         {
             if (locality_id != naming::get_locality_id_from_id(id))
             {
@@ -476,7 +476,7 @@ namespace hpx { namespace components { namespace server {
 
         // Now make sure this local locality gets shut down as well.
         // There is no need to respond...
-        stop(timeout, naming::invalid_id, false);
+        stop(timeout, hpx::invalid_id, false);
     }
 
     ///////////////////////////////////////////////////////////////////////////
@@ -499,7 +499,8 @@ namespace hpx { namespace components { namespace server {
                 if (locality_id != naming::get_locality_id_from_gid(gid))
                 {
                     using components::stubs::runtime_support;
-                    naming::id_type id(gid, naming::id_type::unmanaged);
+                    hpx::id_type id(
+                        gid, hpx::id_type::management_type::unmanaged);
                     lazy_actions.push_back(
                         runtime_support::terminate_async(id));
                 }
@@ -510,7 +511,7 @@ namespace hpx { namespace components { namespace server {
         }
 
         // now make sure this local locality gets terminated as well.
-        terminate(naming::invalid_id);    //good night
+        terminate(hpx::invalid_id);    //good night
     }
 
     ///////////////////////////////////////////////////////////////////////////
@@ -591,8 +592,8 @@ namespace hpx { namespace components { namespace server {
         }
     }
 
-    void runtime_support::stop(double timeout,
-        naming::id_type const& respond_to, bool remove_from_remote_caches)
+    void runtime_support::stop(double timeout, hpx::id_type const& respond_to,
+        bool remove_from_remote_caches)
     {
         std::unique_lock<std::mutex> l(mtx_);
         if (!stop_called_)
@@ -880,7 +881,7 @@ namespace hpx { namespace components { namespace server {
         if (rtd == nullptr)
             return;
 
-        std::vector<naming::id_type> locality_ids = find_remote_localities();
+        std::vector<hpx::id_type> locality_ids = find_remote_localities();
 
         typedef server::runtime_support::remove_from_connection_cache_action
             action_type;
@@ -889,7 +890,7 @@ namespace hpx { namespace components { namespace server {
         callbacks.reserve(locality_ids.size());
 
         action_type act;
-        for (naming::id_type const& id : locality_ids)
+        for (hpx::id_type const& id : locality_ids)
         {
             // console is handled separately
             if (naming::get_locality_id_from_id(id) == 0)

--- a/libs/full/runtime_distributed/src/stubs/runtime_support_stubs.cpp
+++ b/libs/full/runtime_distributed/src/stubs/runtime_support_stubs.cpp
@@ -30,7 +30,7 @@
 namespace hpx { namespace components { namespace stubs {
 
     hpx::future<int> runtime_support::load_components_async(
-        naming::id_type const& gid)
+        hpx::id_type const& gid)
     {
 #if !defined(HPX_COMPUTE_DEVICE_CODE)
         typedef server::runtime_support::load_components_action action_type;
@@ -42,13 +42,13 @@ namespace hpx { namespace components { namespace stubs {
 #endif
     }
 
-    int runtime_support::load_components(naming::id_type const& gid)
+    int runtime_support::load_components(hpx::id_type const& gid)
     {
         return load_components_async(gid).get();
     }
 
     hpx::future<void> runtime_support::call_startup_functions_async(
-        naming::id_type const& gid, bool pre_startup)
+        hpx::id_type const& gid, bool pre_startup)
     {
 #if !defined(HPX_COMPUTE_DEVICE_CODE)
         typedef server::runtime_support::call_startup_functions_action
@@ -63,14 +63,14 @@ namespace hpx { namespace components { namespace stubs {
     }
 
     void runtime_support::call_startup_functions(
-        naming::id_type const& gid, bool pre_startup)
+        hpx::id_type const& gid, bool pre_startup)
     {
         call_startup_functions_async(gid, pre_startup).get();
     }
 
     /// \brief Shutdown the given runtime system
     hpx::future<void> runtime_support::shutdown_async(
-        naming::id_type const& targetgid, double timeout)
+        hpx::id_type const& targetgid, double timeout)
     {
 #if !defined(HPX_COMPUTE_DEVICE_CODE)
         // Create a promise directly and execute the required action.
@@ -82,7 +82,8 @@ namespace hpx { namespace components { namespace stubs {
         auto f = value.get_future();
 
         // We need to make it unmanaged to avoid late refcnt requests
-        id_type gid(value.get_id().get_gid(), id_type::unmanaged);
+        id_type gid(
+            value.get_id().get_gid(), id_type::management_type::unmanaged);
         hpx::apply<action_type>(targetgid, timeout, gid);
 
         return f;
@@ -95,7 +96,7 @@ namespace hpx { namespace components { namespace stubs {
     }
 
     void runtime_support::shutdown(
-        naming::id_type const& targetgid, double timeout)
+        hpx::id_type const& targetgid, double timeout)
     {
         // The following get yields control while the action above
         // is executed and the result is returned to the future
@@ -104,7 +105,7 @@ namespace hpx { namespace components { namespace stubs {
 
     /// \brief Shutdown the runtime systems of all localities
     void runtime_support::shutdown_all(
-        naming::id_type const& targetgid, double timeout)
+        hpx::id_type const& targetgid, double timeout)
     {
 #if !defined(HPX_COMPUTE_DEVICE_CODE)
         hpx::apply<server::runtime_support::shutdown_all_action>(
@@ -120,9 +121,9 @@ namespace hpx { namespace components { namespace stubs {
     {
 #if !defined(HPX_COMPUTE_DEVICE_CODE)
         hpx::apply<server::runtime_support::shutdown_all_action>(
-            hpx::naming::id_type(
+            hpx::id_type(
                 hpx::applier::get_applier().get_runtime_support_raw_gid(),
-                hpx::naming::id_type::unmanaged),
+                hpx::id_type::management_type::unmanaged),
             timeout);
 #else
         HPX_ASSERT(false);
@@ -134,7 +135,7 @@ namespace hpx { namespace components { namespace stubs {
     /// \brief Retrieve configuration information
     /// \brief Terminate the given runtime system
     hpx::future<void> runtime_support::terminate_async(
-        naming::id_type const& targetgid)
+        hpx::id_type const& targetgid)
     {
 #if !defined(HPX_COMPUTE_DEVICE_CODE)
         // Create a future directly and execute the required action.
@@ -154,7 +155,7 @@ namespace hpx { namespace components { namespace stubs {
 #endif
     }
 
-    void runtime_support::terminate(naming::id_type const& targetgid)
+    void runtime_support::terminate(hpx::id_type const& targetgid)
     {
         // The following get yields control while the action above
         // is executed and the result is returned to the future
@@ -162,7 +163,7 @@ namespace hpx { namespace components { namespace stubs {
     }
 
     /// \brief Terminate the runtime systems of all localities
-    void runtime_support::terminate_all(naming::id_type const& targetgid)
+    void runtime_support::terminate_all(hpx::id_type const& targetgid)
     {
 #if !defined(HPX_COMPUTE_DEVICE_CODE)
         hpx::apply<server::runtime_support::terminate_all_action>(targetgid);
@@ -175,10 +176,9 @@ namespace hpx { namespace components { namespace stubs {
     void runtime_support::terminate_all()
     {
 #if !defined(HPX_COMPUTE_DEVICE_CODE)
-        hpx::apply<server::runtime_support::terminate_all_action>(
-            hpx::naming::id_type(
-                hpx::applier::get_applier().get_runtime_support_raw_gid(),
-                hpx::naming::id_type::unmanaged));
+        hpx::apply<server::runtime_support::terminate_all_action>(hpx::id_type(
+            hpx::applier::get_applier().get_runtime_support_raw_gid(),
+            hpx::id_type::management_type::unmanaged));
 #else
         HPX_ASSERT(false);
 #endif
@@ -186,7 +186,7 @@ namespace hpx { namespace components { namespace stubs {
 
     ///////////////////////////////////////////////////////////////////////
     void runtime_support::garbage_collect_non_blocking(
-        naming::id_type const& targetgid)
+        hpx::id_type const& targetgid)
     {
 #if !defined(HPX_COMPUTE_DEVICE_CODE)
         typedef server::runtime_support::garbage_collect_action action_type;
@@ -198,7 +198,7 @@ namespace hpx { namespace components { namespace stubs {
     }
 
     hpx::future<void> runtime_support::garbage_collect_async(
-        naming::id_type const& targetgid)
+        hpx::id_type const& targetgid)
     {
 #if !defined(HPX_COMPUTE_DEVICE_CODE)
         typedef server::runtime_support::garbage_collect_action action_type;
@@ -210,7 +210,7 @@ namespace hpx { namespace components { namespace stubs {
 #endif
     }
 
-    void runtime_support::garbage_collect(naming::id_type const& targetgid)
+    void runtime_support::garbage_collect(hpx::id_type const& targetgid)
     {
 #if !defined(HPX_COMPUTE_DEVICE_CODE)
         typedef server::runtime_support::garbage_collect_action action_type;
@@ -222,9 +222,8 @@ namespace hpx { namespace components { namespace stubs {
     }
 
     ///////////////////////////////////////////////////////////////////////
-    hpx::future<naming::id_type>
-    runtime_support::create_performance_counter_async(naming::id_type targetgid,
-        performance_counters::counter_info const& info)
+    hpx::future<hpx::id_type> runtime_support::create_performance_counter_async(
+        hpx::id_type targetgid, performance_counters::counter_info const& info)
     {
 #if !defined(HPX_COMPUTE_DEVICE_CODE)
         if (!naming::is_locality(targetgid))
@@ -233,7 +232,7 @@ namespace hpx { namespace components { namespace stubs {
                 "stubs::runtime_support::create_performance_counter_async",
                 "The id passed as the first argument is not representing"
                 " a locality");
-            return make_ready_future(naming::invalid_id);
+            return make_ready_future(hpx::invalid_id);
         }
 
         typedef server::runtime_support::create_performance_counter_action
@@ -243,13 +242,13 @@ namespace hpx { namespace components { namespace stubs {
         HPX_ASSERT(false);
         HPX_UNUSED(targetgid);
         HPX_UNUSED(info);
-        return ::hpx::make_ready_future(naming::invalid_id);
+        return ::hpx::make_ready_future(hpx::invalid_id);
 #endif
     }
 
-    naming::id_type runtime_support::create_performance_counter(
-        naming::id_type targetgid,
-        performance_counters::counter_info const& info, error_code& ec)
+    hpx::id_type runtime_support::create_performance_counter(
+        hpx::id_type targetgid, performance_counters::counter_info const& info,
+        error_code& ec)
     {
         return create_performance_counter_async(targetgid, info).get(ec);
     }
@@ -257,7 +256,7 @@ namespace hpx { namespace components { namespace stubs {
     ///////////////////////////////////////////////////////////////////////
     /// \brief Retrieve configuration information
     hpx::future<util::section> runtime_support::get_config_async(
-        naming::id_type const& targetgid)
+        hpx::id_type const& targetgid)
     {
 #if !defined(HPX_COMPUTE_DEVICE_CODE)
         // Create a future, execute the required action,
@@ -273,7 +272,7 @@ namespace hpx { namespace components { namespace stubs {
     }
 
     void runtime_support::get_config(
-        naming::id_type const& targetgid, util::section& ini)
+        hpx::id_type const& targetgid, util::section& ini)
     {
         // The following get yields control while the action above
         // is executed and the result is returned to the future
@@ -282,7 +281,7 @@ namespace hpx { namespace components { namespace stubs {
 
     ///////////////////////////////////////////////////////////////////////
     void runtime_support::remove_from_connection_cache_async(
-        naming::id_type const& target, naming::gid_type const& gid,
+        hpx::id_type const& target, naming::gid_type const& gid,
         parcelset::endpoints_type const& endpoints)
     {
 #if !defined(HPX_COMPUTE_DEVICE_CODE)

--- a/libs/full/segmented_algorithms/include/hpx/parallel/segmented_algorithms/traits/zip_iterator.hpp
+++ b/libs/full/segmented_algorithms/include/hpx/parallel/segmented_algorithms/traits/zip_iterator.hpp
@@ -134,7 +134,7 @@ namespace hpx { namespace traits {
 
         // Extract the base id for the segment referenced by the given segment
         // iterator.
-        static naming::id_type get_id(segment_iterator const& iter)
+        static hpx::id_type get_id(segment_iterator const& iter)
         {
             typedef typename hpx::tuple_element<0,
                 typename iterator::iterator_tuple_type>::type

--- a/tests/performance/local/activate_counters.cpp
+++ b/tests/performance/local/activate_counters.cpp
@@ -46,8 +46,7 @@ namespace hpx { namespace util {
     bool activate_counters::find_counter(
         performance_counters::counter_info const& info, error_code& ec)
     {
-        naming::id_type id =
-            performance_counters::get_counter(info.fullname_, ec);
+        hpx::id_type id = performance_counters::get_counter(info.fullname_, ec);
         if (HPX_UNLIKELY(!id))
         {
             HPX_THROWS_IF(ec, bad_parameter, "activate_counters::find_counter",

--- a/tests/performance/local/activate_counters.hpp
+++ b/tests/performance/local/activate_counters.hpp
@@ -54,7 +54,7 @@ namespace hpx { namespace util {
             return names_[i];
         }
 
-        naming::id_type id(std::size_t i) const
+        hpx::id_type id(std::size_t i) const
         {
             return ids_[i];
         }
@@ -65,9 +65,9 @@ namespace hpx { namespace util {
         }
 
     private:
-        std::vector<std::string> names_;      // counter instance names
-        std::vector<naming::id_type> ids_;    // gids of counter instances
-        std::vector<std::string> uoms_;       // units of measure
+        std::vector<std::string> names_;    // counter instance names
+        std::vector<hpx::id_type> ids_;     // gids of counter instances
+        std::vector<std::string> uoms_;     // units of measure
     };
 }}    // namespace hpx::util
 

--- a/tests/performance/local/future_overhead.cpp
+++ b/tests/performance/local/future_overhead.cpp
@@ -134,7 +134,7 @@ HPX_PLAIN_ACTION(null_function, null_action)
 // Time async action execution using wait each on futures vector
 void measure_action_futures_wait_each(std::uint64_t count, bool csv)
 {
-    const hpx::naming::id_type here = hpx::find_here();
+    const hpx::id_type here = hpx::find_here();
     std::vector<future<double>> futures;
     futures.reserve(count);
 
@@ -152,7 +152,7 @@ void measure_action_futures_wait_each(std::uint64_t count, bool csv)
 // Time async action execution using wait each on futures vector
 void measure_action_futures_wait_all(std::uint64_t count, bool csv)
 {
-    const hpx::naming::id_type here = hpx::find_here();
+    const hpx::id_type here = hpx::find_here();
     std::vector<future<double>> futures;
     futures.reserve(count);
 

--- a/tests/performance/local/libcds_hazard_pointer_overhead.cpp
+++ b/tests/performance/local/libcds_hazard_pointer_overhead.cpp
@@ -40,7 +40,7 @@ using hpx::program_options::value;
 using hpx::program_options::variables_map;
 
 using hpx::find_here;
-using hpx::naming::id_type;
+using hpx::id_type;
 
 using hpx::apply;
 using hpx::async;

--- a/tests/performance/local/sizeof.cpp
+++ b/tests/performance/local/sizeof.cpp
@@ -33,7 +33,7 @@ int hpx_main(
             /**/
 
         cout << HPX_SIZEOF(hpx::naming::gid_type)
-             << HPX_SIZEOF(hpx::naming::id_type)
+             << HPX_SIZEOF(hpx::id_type)
              << HPX_SIZEOF(hpx::naming::address)
              << HPX_SIZEOF(hpx::threads::thread_data)
              << std::flush;

--- a/tests/performance/local/spinlock_overhead1.cpp
+++ b/tests/performance/local/spinlock_overhead1.cpp
@@ -32,7 +32,7 @@ using hpx::program_options::variables_map;
 
 using hpx::find_here;
 
-using hpx::naming::id_type;
+using hpx::id_type;
 
 using hpx::async;
 using hpx::future;

--- a/tests/performance/local/spinlock_overhead2.cpp
+++ b/tests/performance/local/spinlock_overhead2.cpp
@@ -32,7 +32,7 @@ using hpx::program_options::variables_map;
 
 using hpx::find_here;
 
-using hpx::naming::id_type;
+using hpx::id_type;
 
 using hpx::async;
 using hpx::future;

--- a/tests/performance/network/pingpong_performance.cpp
+++ b/tests/performance/network/pingpong_performance.cpp
@@ -49,8 +49,8 @@ int hpx_main(hpx::program_options::variables_map& vm)
     vec.reserve(n);
     received.reserve(n);
     //Find the other locality
-    std::vector<hpx::naming::id_type> dummy = hpx::find_remote_localities();
-    hpx::naming::id_type other_locality = dummy[0];
+    std::vector<hpx::id_type> dummy = hpx::find_remote_localities();
+    hpx::id_type other_locality = dummy[0];
 
 
     for(std::size_t i=0; i<n; ++i)

--- a/tests/regressions/util/serialize_buffer_1069.cpp
+++ b/tests/regressions/util/serialize_buffer_1069.cpp
@@ -8,10 +8,10 @@
 
 #include <hpx/config.hpp>
 #if !defined(HPX_COMPUTE_DEVICE_CODE)
-#include <hpx/hpx_init.hpp>
 #include <hpx/hpx.hpp>
-#include <hpx/serialization/serialize_buffer.hpp>
+#include <hpx/hpx_init.hpp>
 #include <hpx/modules/testing.hpp>
+#include <hpx/serialization/serialize_buffer.hpp>
 
 #if !defined(HPX_HAVE_CXX17_SHARED_PTR_ARRAY)
 #include <boost/shared_array.hpp>
@@ -30,16 +30,20 @@ template <typename T>
 class test_allocator : public std::allocator<T>
 {
 public:
-    typedef T        value_type;
-    typedef T*       pointer;
+    typedef T value_type;
+    typedef T* pointer;
     typedef const T* const_pointer;
-    typedef T&       reference;
+    typedef T& reference;
     typedef const T& const_reference;
-    typedef std::size_t    size_type;
+    typedef std::size_t size_type;
     typedef std::ptrdiff_t difference_type;
 
     // we want to make sure anything else uses the std allocator
-    template <typename U> struct rebind { typedef std::allocator<U> other; };
+    template <typename U>
+    struct rebind
+    {
+        typedef std::allocator<U> other;
+    };
 
     pointer allocate(size_type n, const void* = nullptr)
     {
@@ -53,39 +57,47 @@ public:
         return std::allocator<T>::deallocate(p, n);
     }
 
-    test_allocator() noexcept: std::allocator<T>() {}
-    test_allocator(const test_allocator &a) noexcept: std::allocator<T>(a) {}
+    test_allocator() noexcept
+      : std::allocator<T>()
+    {
+    }
+    test_allocator(const test_allocator& a) noexcept
+      : std::allocator<T>(a)
+    {
+    }
     ~test_allocator() noexcept {}
 };
 
 //----------------------------------------------------------------------------
-typedef hpx::serialization::serialize_buffer<char, test_allocator<char> >
+typedef hpx::serialization::serialize_buffer<char, test_allocator<char>>
     buffer_allocator_type;
 
-buffer_allocator_type allocator_message(buffer_allocator_type const& receive_buffer)
+buffer_allocator_type allocator_message(
+    buffer_allocator_type const& receive_buffer)
 {
-    HPX_TEST_EQ(receive_buffer.size(), static_cast<std::size_t>(MEMORY_BLOCK_SIZE));
+    HPX_TEST_EQ(
+        receive_buffer.size(), static_cast<std::size_t>(MEMORY_BLOCK_SIZE));
     return receive_buffer;
 }
 HPX_PLAIN_ACTION(allocator_message)
-HPX_REGISTER_BASE_LCO_WITH_VALUE_DECLARATION(buffer_allocator_type,
-    serialization_buffer_char_allocator)
-HPX_REGISTER_BASE_LCO_WITH_VALUE(buffer_allocator_type,
-    serialization_buffer_char_allocator)
+HPX_REGISTER_BASE_LCO_WITH_VALUE_DECLARATION(
+    buffer_allocator_type, serialization_buffer_char_allocator)
+HPX_REGISTER_BASE_LCO_WITH_VALUE(
+    buffer_allocator_type, serialization_buffer_char_allocator)
 
 //----------------------------------------------------------------------------
-void receive(hpx::naming::id_type dest, char* send_buffer,
-        std::size_t size, std::size_t window_size)
+void receive(hpx::id_type dest, char* send_buffer, std::size_t size,
+    std::size_t window_size)
 {
-    std::vector<hpx::future<buffer_allocator_type> > recv_buffers;
+    std::vector<hpx::future<buffer_allocator_type>> recv_buffers;
     recv_buffers.reserve(window_size);
 
     allocator_message_action msg;
-    for(std::size_t j = 0; j != window_size; ++j)
+    for (std::size_t j = 0; j != window_size; ++j)
     {
         recv_buffers.push_back(hpx::async(msg, dest,
-            buffer_allocator_type(send_buffer, size,
-                buffer_allocator_type::reference)));
+            buffer_allocator_type(
+                send_buffer, size, buffer_allocator_type::reference)));
     }
     hpx::wait_all(recv_buffers);
 }

--- a/tests/regressions/util/zero_copy_parcels_1001.cpp
+++ b/tests/regressions/util/zero_copy_parcels_1001.cpp
@@ -45,7 +45,7 @@ struct inc
 ///////////////////////////////////////////////////////////////////////////////
 int hpx_main()
 {
-    std::vector<hpx::naming::id_type> localities = hpx::find_remote_localities();
+    std::vector<hpx::id_type> localities = hpx::find_remote_localities();
 
     if (localities.empty())
     {

--- a/tests/unit/apex/apex_action_count.cpp
+++ b/tests/unit/apex/apex_action_count.cpp
@@ -42,7 +42,7 @@ std::uint64_t fibonacci(std::uint64_t n)
         return n;
 
     // We restrict ourselves to execute the Fibonacci function locally.
-    hpx::naming::id_type const locality_id = hpx::find_here();
+    hpx::id_type const locality_id = hpx::find_here();
 
     // Invoking the Fibonacci algorithm twice is inefficient.
     // However, we intentionally demonstrate it this way to create some

--- a/tools/VS/client_base.natvis
+++ b/tools/VS/client_base.natvis
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<!-- Copyright (c) 2016-2017 Hartmut Kaiser                                 -->
+<!-- Copyright (c) 2016-2022 Hartmut Kaiser                                 -->
 
 <!-- Use, modification and distribution are subject to the Boost Software   -->
 <!-- License, Version 1.0. (See accompanying file LICENSE_1_0.txt           -->
@@ -14,7 +14,7 @@
         <DisplayString Condition="shared_state_.px != 0 &amp;&amp; shared_state_.px->state_ == 3">ready(value)</DisplayString>
         <DisplayString Condition="shared_state_.px != 0 &amp;&amp; shared_state_.px->state_ == 5">ready(exception)</DisplayString>
         <Expand>
-            <Item Name="[value]" Condition="shared_state_.px != 0 &amp;&amp; shared_state_.px->state_ == 3">*((hpx::naming::id_type*)(shared_state_.px->storage_.data_.buf))</Item>
+            <Item Name="[value]" Condition="shared_state_.px != 0 &amp;&amp; shared_state_.px->state_ == 3">*((hpx::id_type*)(shared_state_.px->storage_.data_.buf))</Item>
             <Item Name="[exception]" Condition="shared_state_.px != 0 &amp;&amp; shared_state_.px->state_ == 5">*((std::exception_ptr*)(shared_state_.px->storage_.data_.buf))</Item>
             <Item Name="[count]" Condition="shared_state_.px != 0">shared_state_.px->count_</Item>
         </Expand>

--- a/tools/VS/gid_type.natvis
+++ b/tools/VS/gid_type.natvis
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <!-- Copyright (c) 2013 Agustin Berge                                       -->
-<!-- Copyright (c) 2013 Hartmut Kaiser                                      -->
+<!-- Copyright (c) 2013-2022 Hartmut Kaiser                                 -->
 
 <!-- Use, modification and distribution are subject to the Boost Software   -->
 <!-- License, Version 1.0. (See accompanying file LICENSE_1_0.txt           -->
@@ -27,7 +27,7 @@
     </Expand>
   </Type>
 
-  <Type Name="hpx::naming::id_type">
+  <Type Name="hpx::id_type">
     <DisplayString  Condition="gid_.px == 0">empty</DisplayString>
     <DisplayString  Condition="gid_.px != 0">{{ msb={gid_.px->id_msb_,x} lsb={gid_.px->id_lsb_,x} }}</DisplayString>
     <Expand>


### PR DESCRIPTION
- flyby: moving hpx::naming::id_type to hpx::id_type
