### PR TITLE
Marking customization points for intrusive_ptr as noexcept

### DIFF
--- a/examples/1d_stencil/1d_stencil_8.cpp
+++ b/examples/1d_stencil/1d_stencil_8.cpp
@@ -114,7 +114,7 @@ private:
         buffer_type data_;
     };
 
-    static void deallocate(double* p)
+    static void deallocate(double* p) noexcept
     {
         alloc_.deallocate(p);
     }

--- a/examples/jacobi/jacobi_component/row_range.hpp
+++ b/examples/jacobi/jacobi_component/row_range.hpp
@@ -46,11 +46,11 @@ namespace jacobi
         std::vector<double> v_;
         hpx::util::atomic_count count_;
 
-        friend void intrusive_ptr_add_ref(value_holder * p)
+        friend void intrusive_ptr_add_ref(value_holder * p) noexcept
         {
             ++p->count_;
         }
-        friend void intrusive_ptr_release(value_holder * p)
+        friend void intrusive_ptr_release(value_holder * p) noexcept
         {
             if (0 == --p->count_)
                 delete p;

--- a/examples/quickstart/zerocopy_rdma.cpp
+++ b/examples/quickstart/zerocopy_rdma.cpp
@@ -65,7 +65,7 @@ public:
         return static_cast<T*>(pointer_);
     }
 
-    void deallocate(pointer p, size_type n)
+    void deallocate(pointer p, size_type n) noexcept
     {
         HPX_ASSERT(p == pointer_ && n == size_);
         HPX_UNUSED(p);

--- a/libs/core/allocator_support/include/hpx/allocator_support/aligned_allocator.hpp
+++ b/libs/core/allocator_support/include/hpx/allocator_support/aligned_allocator.hpp
@@ -158,7 +158,7 @@ namespace hpx { namespace util {
             return p;
         }
 
-        void deallocate(pointer p, size_type)
+        void deallocate(pointer p, size_type) noexcept
         {
             __aligned_free(p);
         }

--- a/libs/core/allocator_support/include/hpx/allocator_support/allocator_deleter.hpp
+++ b/libs/core/allocator_support/include/hpx/allocator_support/allocator_deleter.hpp
@@ -18,7 +18,7 @@ namespace hpx { namespace util {
     struct allocator_deleter
     {
         template <typename SharedState>
-        void operator()(SharedState* state)
+        void operator()(SharedState* state) noexcept
         {
             using traits = std::allocator_traits<Allocator>;
             traits::deallocate(alloc_, state, 1);

--- a/libs/core/allocator_support/include/hpx/allocator_support/internal_allocator.hpp
+++ b/libs/core/allocator_support/include/hpx/allocator_support/internal_allocator.hpp
@@ -81,7 +81,7 @@ namespace hpx { namespace util {
             return p;
         }
 
-        void deallocate(pointer p, size_type n)
+        void deallocate(pointer p, size_type n) noexcept
         {
             HPX_PP_CAT(HPX_HAVE_JEMALLOC_PREFIX, free)(p);
         }

--- a/libs/core/async_cuda/include/hpx/async_cuda/cuda_future.hpp
+++ b/libs/core/async_cuda/include/hpx/async_cuda/cuda_future.hpp
@@ -85,7 +85,7 @@ namespace hpx { namespace cuda { namespace experimental {
                     no_addref, alloc)
             {
                 add_event_callback(
-                    [fdp = hpx::memory::intrusive_ptr<future_data>(this)](
+                    [fdp = hpx::intrusive_ptr<future_data>(this)](
                         cudaError_t status) {
                         HPX_ASSERT(status != cudaErrorNotReady);
 

--- a/libs/core/async_mpi/include/hpx/async_mpi/mpi_future.hpp
+++ b/libs/core/async_mpi/include/hpx/async_mpi/mpi_future.hpp
@@ -85,8 +85,7 @@ namespace hpx { namespace mpi { namespace experimental {
             void add_callback()
             {
                 add_request_callback(
-                    [fdp = hpx::memory::intrusive_ptr<future_data>(this)](
-                        int status) {
+                    [fdp = hpx::intrusive_ptr<future_data>(this)](int status) {
                         if (status == MPI_SUCCESS)
                         {
                             // mark the future as ready by setting the shared_state
@@ -107,7 +106,7 @@ namespace hpx { namespace mpi { namespace experimental {
 
         // -----------------------------------------------------------------
         // intrusive pointer for future_data
-        using future_data_ptr = memory::intrusive_ptr<future_data>;
+        using future_data_ptr = hpx::intrusive_ptr<future_data>;
 
         // -----------------------------------------------------------------
         // a convenience structure to hold state vars

--- a/libs/core/concurrency/include/hpx/concurrency/deque.hpp
+++ b/libs/core/concurrency/include/hpx/concurrency/deque.hpp
@@ -270,7 +270,7 @@ namespace boost { namespace lockfree {
             return chunk;
         }
 
-        void dealloc_node(node* n)
+        void dealloc_node(node* n) noexcept
         {
             if (n != nullptr)
             {

--- a/libs/core/concurrency/include/hpx/concurrency/detail/freelist.hpp
+++ b/libs/core/concurrency/include/hpx/concurrency/detail/freelist.hpp
@@ -31,7 +31,7 @@ namespace boost { namespace lockfree {
             return this->base_type::template allocate<true, false>();
         }
 
-        void deallocate(T* n)
+        void deallocate(T* n) noexcept
         {
             this->base_type::template deallocate<true>(n);
         }
@@ -53,7 +53,7 @@ namespace boost { namespace lockfree {
             return this->base_type::template allocate<true, true>();
         }
 
-        void deallocate(T* n)
+        void deallocate(T* n) noexcept
         {
             this->base_type::template deallocate<true>(n);
         }

--- a/libs/core/coroutines/include/hpx/coroutines/detail/context_generic_context.hpp
+++ b/libs/core/coroutines/include/hpx/coroutines/detail/context_generic_context.hpp
@@ -101,7 +101,7 @@ namespace hpx { namespace threads { namespace coroutines {
                 return static_cast<char*>(limit) + size;
             }
 
-            void deallocate(void* vp, std::size_t size) const
+            void deallocate(void* vp, std::size_t size) const noexcept
             {
                 HPX_ASSERT(vp);
                 void* limit = static_cast<char*>(vp) - size;
@@ -149,7 +149,7 @@ namespace hpx { namespace threads { namespace coroutines {
                 return static_cast<char*>(limit) + size;
             }
 
-            void deallocate(void* vp, std::size_t size) const
+            void deallocate(void* vp, std::size_t size) const noexcept
             {
                 __splitstack_releasecontext(segments_ctx_);
             }

--- a/libs/core/coroutines/include/hpx/coroutines/thread_id_type.hpp
+++ b/libs/core/coroutines/include/hpx/coroutines/thread_id_type.hpp
@@ -167,8 +167,8 @@ namespace hpx { namespace threads {
 
         struct thread_data_reference_counting;
 
-        void intrusive_ptr_add_ref(thread_data_reference_counting* p);
-        void intrusive_ptr_release(thread_data_reference_counting* p);
+        void intrusive_ptr_add_ref(thread_data_reference_counting* p) noexcept;
+        void intrusive_ptr_release(thread_data_reference_counting* p) noexcept;
 
         struct thread_data_reference_counting
         {
@@ -185,12 +185,14 @@ namespace hpx { namespace threads {
             virtual void destroy_thread() = 0;
 
             // reference counting
-            friend void intrusive_ptr_add_ref(thread_data_reference_counting* p)
+            friend void intrusive_ptr_add_ref(
+                thread_data_reference_counting* p) noexcept
             {
                 ++p->count_;
             }
 
-            friend void intrusive_ptr_release(thread_data_reference_counting* p)
+            friend void intrusive_ptr_release(
+                thread_data_reference_counting* p) noexcept
             {
                 HPX_ASSERT(p->count_ != 0);
                 if (--p->count_ == 0)

--- a/libs/core/datastructures/tests/unit/small_vector.cpp
+++ b/libs/core/datastructures/tests/unit/small_vector.cpp
@@ -44,7 +44,7 @@ namespace test {
             return reinterpret_cast<T*>(::new char[sizeof(T) * n]);
         }
 
-        void deallocate(T* p, std::size_t)
+        void deallocate(T* p, std::size_t) noexcept
         {
             delete[](reinterpret_cast<char*>(p));
         }

--- a/libs/core/execution/include/hpx/execution/executors/polymorphic_executor.hpp
+++ b/libs/core/execution/include/hpx/execution/executors/polymorphic_executor.hpp
@@ -31,8 +31,10 @@ namespace hpx { namespace parallel { namespace execution {
     namespace detail {
 
         struct shape_iter_impl_base;
-        HPX_CORE_EXPORT void intrusive_ptr_add_ref(shape_iter_impl_base* p);
-        HPX_CORE_EXPORT void intrusive_ptr_release(shape_iter_impl_base* p);
+        HPX_CORE_EXPORT void intrusive_ptr_add_ref(
+            shape_iter_impl_base* p) noexcept;
+        HPX_CORE_EXPORT void intrusive_ptr_release(
+            shape_iter_impl_base* p) noexcept;
 
         struct shape_iter_impl_base
         {
@@ -244,7 +246,7 @@ namespace hpx { namespace parallel { namespace execution {
 
             template <typename T>
             static void _deallocate(
-                void* obj, std::size_t storage_size, bool destroy)
+                void* obj, std::size_t storage_size, bool destroy) noexcept
             {
                 using storage_t =
                     typename std::aligned_storage<sizeof(T), alignof(T)>::type;
@@ -259,7 +261,7 @@ namespace hpx { namespace parallel { namespace execution {
                     delete static_cast<storage_t*>(obj);
                 }
             }
-            void (*deallocate)(void*, std::size_t storage_size, bool);
+            void (*deallocate)(void*, std::size_t storage_size, bool) noexcept;
 
             template <typename T>
             static void* _copy(void* storage, std::size_t storage_size,

--- a/libs/core/functional/include/hpx/functional/detail/vtable/vtable.hpp
+++ b/libs/core/functional/include/hpx/functional/detail/vtable/vtable.hpp
@@ -68,7 +68,7 @@ namespace hpx { namespace util { namespace detail {
 
         template <typename T>
         static void _deallocate(
-            void* obj, std::size_t storage_size, bool destroy)
+            void* obj, std::size_t storage_size, bool destroy) noexcept
         {
             using storage_t =
                 typename std::aligned_storage<sizeof(T), alignof(T)>::type;
@@ -83,7 +83,7 @@ namespace hpx { namespace util { namespace detail {
                 delete static_cast<storage_t*>(obj);
             }
         }
-        void (*deallocate)(void*, std::size_t storage_size, bool);
+        void (*deallocate)(void*, std::size_t storage_size, bool) noexcept;
 
         template <typename T>
         constexpr vtable(construct_vtable<T>) noexcept

--- a/libs/core/functional/tests/unit/allocator_test.cpp
+++ b/libs/core/functional/tests/unit/allocator_test.cpp
@@ -41,7 +41,7 @@ struct counting_allocator : public std::allocator<T>
         return std::allocator<T>::allocate(n);
     }
 
-    void deallocate(T* p, std::size_t n)
+    void deallocate(T* p, std::size_t n) noexcept
     {
         dealloc_count++;
         std::allocator<T>::deallocate(p, n);

--- a/libs/core/futures/tests/unit/test_allocator.hpp
+++ b/libs/core/futures/tests/unit/test_allocator.hpp
@@ -89,7 +89,7 @@ public:
         return static_cast<pointer>(std::malloc(n * sizeof(T)));
     }
 
-    void deallocate(pointer p, size_type)
+    void deallocate(pointer p, size_type) noexcept
     {
         --count;
         std::free(p);

--- a/libs/core/lcos_local/include/hpx/lcos_local/channel.hpp
+++ b/libs/core/lcos_local/include/hpx/lcos_local/channel.hpp
@@ -85,7 +85,7 @@ namespace hpx { namespace lcos { namespace local {
         }
 
         template <typename T>
-        void intrusive_ptr_release(channel_impl_base<T>* p)
+        void intrusive_ptr_release(channel_impl_base<T>* p) noexcept
         {
             if (p->requires_delete())
             {

--- a/libs/core/memory/include/hpx/memory/intrusive_ptr.hpp
+++ b/libs/core/memory/include/hpx/memory/intrusive_ptr.hpp
@@ -9,6 +9,8 @@
 //  http://www.boost.org/LICENSE_1_0.txt)
 //
 
+// make inspect happy: hpxinspect:noinclude:hpx::intrusive_ptr
+
 #pragma once
 
 #include <hpx/config.hpp>
@@ -22,9 +24,8 @@
 #include <type_traits>
 #include <utility>
 
-namespace hpx { namespace memory {
+namespace hpx {
 
-    //
     //  intrusive_ptr
     //
     //  A smart pointer that uses intrusive reference counting.
@@ -192,130 +193,135 @@ namespace hpx { namespace memory {
 
     template <typename T, typename U>
     inline constexpr bool operator==(
-        intrusive_ptr<T> const& a, intrusive_ptr<U> const& b) noexcept
+        hpx::intrusive_ptr<T> const& a, hpx::intrusive_ptr<U> const& b) noexcept
     {
         return a.get() == b.get();
     }
 
     template <typename T, typename U>
     inline constexpr bool operator!=(
-        intrusive_ptr<T> const& a, intrusive_ptr<U> const& b) noexcept
+        hpx::intrusive_ptr<T> const& a, hpx::intrusive_ptr<U> const& b) noexcept
     {
         return a.get() != b.get();
     }
 
     template <typename T, typename U>
-    inline constexpr bool operator==(intrusive_ptr<T> const& a, U* b) noexcept
+    inline constexpr bool operator==(
+        hpx::intrusive_ptr<T> const& a, U* b) noexcept
     {
         return a.get() == b;
     }
 
     template <typename T, typename U>
-    inline constexpr bool operator!=(intrusive_ptr<T> const& a, U* b) noexcept
+    inline constexpr bool operator!=(
+        hpx::intrusive_ptr<T> const& a, U* b) noexcept
     {
         return a.get() != b;
     }
 
     template <typename T, typename U>
-    inline constexpr bool operator==(T* a, intrusive_ptr<U> const& b) noexcept
+    inline constexpr bool operator==(
+        T* a, hpx::intrusive_ptr<U> const& b) noexcept
     {
         return a == b.get();
     }
 
     template <typename T, typename U>
-    inline constexpr bool operator!=(T* a, intrusive_ptr<U> const& b) noexcept
+    inline constexpr bool operator!=(
+        T* a, hpx::intrusive_ptr<U> const& b) noexcept
     {
         return a != b.get();
     }
 
     template <typename T>
     inline constexpr bool operator==(
-        intrusive_ptr<T> const& p, std::nullptr_t) noexcept
+        hpx::intrusive_ptr<T> const& p, std::nullptr_t) noexcept
     {
         return p.get() == nullptr;
     }
 
     template <typename T>
     inline constexpr bool operator==(
-        std::nullptr_t, intrusive_ptr<T> const& p) noexcept
+        std::nullptr_t, hpx::intrusive_ptr<T> const& p) noexcept
     {
         return p.get() == nullptr;
     }
 
     template <typename T>
     inline constexpr bool operator!=(
-        intrusive_ptr<T> const& p, std::nullptr_t) noexcept
+        hpx::intrusive_ptr<T> const& p, std::nullptr_t) noexcept
     {
         return p.get() != nullptr;
     }
 
     template <typename T>
     inline constexpr bool operator!=(
-        std::nullptr_t, intrusive_ptr<T> const& p) noexcept
+        std::nullptr_t, hpx::intrusive_ptr<T> const& p) noexcept
     {
         return p.get() != nullptr;
     }
 
     template <typename T>
     inline constexpr bool operator<(
-        intrusive_ptr<T> const& a, intrusive_ptr<T> const& b) noexcept
+        hpx::intrusive_ptr<T> const& a, hpx::intrusive_ptr<T> const& b) noexcept
     {
         return std::less<T*>{}(a.get(), b.get());
     }
 
     template <typename T>
-    void swap(intrusive_ptr<T>& lhs, intrusive_ptr<T>& rhs) noexcept
+    void swap(hpx::intrusive_ptr<T>& lhs, hpx::intrusive_ptr<T>& rhs) noexcept
     {
         lhs.swap(rhs);
     }
 
     // mem_fn support
     template <typename T>
-    constexpr T* get_pointer(intrusive_ptr<T> const& p) noexcept
+    constexpr T* get_pointer(hpx::intrusive_ptr<T> const& p) noexcept
     {
         return p.get();
     }
 
     // pointer casts
     template <typename T, typename U>
-    constexpr intrusive_ptr<T> static_pointer_cast(
-        intrusive_ptr<U> const& p) noexcept
+    constexpr hpx::intrusive_ptr<T> static_pointer_cast(
+        hpx::intrusive_ptr<U> const& p) noexcept
     {
         return static_cast<T*>(p.get());
     }
 
     template <typename T, typename U>
-    constexpr intrusive_ptr<T> const_pointer_cast(
-        intrusive_ptr<U> const& p) noexcept
+    constexpr hpx::intrusive_ptr<T> const_pointer_cast(
+        hpx::intrusive_ptr<U> const& p) noexcept
     {
         return const_cast<T*>(p.get());
     }
 
     template <typename T, typename U>
-    intrusive_ptr<T> dynamic_pointer_cast(intrusive_ptr<U> const& p)
+    hpx::intrusive_ptr<T> dynamic_pointer_cast(hpx::intrusive_ptr<U> const& p)
     {
         return dynamic_cast<T*>(p.get());
     }
 
     template <typename T, typename U>
-    constexpr intrusive_ptr<T> static_pointer_cast(
-        intrusive_ptr<U>&& p) noexcept
+    constexpr hpx::intrusive_ptr<T> static_pointer_cast(
+        hpx::intrusive_ptr<U>&& p) noexcept
     {
-        return intrusive_ptr<T>(static_cast<T*>(p.detach()), false);
+        return hpx::intrusive_ptr<T>(static_cast<T*>(p.detach()), false);
     }
 
     template <typename T, typename U>
-    constexpr intrusive_ptr<T> const_pointer_cast(intrusive_ptr<U>&& p) noexcept
+    constexpr hpx::intrusive_ptr<T> const_pointer_cast(
+        hpx::intrusive_ptr<U>&& p) noexcept
     {
-        return intrusive_ptr<T>(const_cast<T*>(p.detach()), false);
+        return hpx::intrusive_ptr<T>(const_cast<T*>(p.detach()), false);
     }
 
     template <typename T, typename U>
-    intrusive_ptr<T> dynamic_pointer_cast(intrusive_ptr<U>&& p)
+    hpx::intrusive_ptr<T> dynamic_pointer_cast(hpx::intrusive_ptr<U>&& p)
     {
         T* p2 = dynamic_cast<T*>(p.get());
 
-        intrusive_ptr<T> r(p2, false);
+        hpx::intrusive_ptr<T> r(p2, false);
 
         if (p2)
             p.detach();
@@ -325,35 +331,100 @@ namespace hpx { namespace memory {
 
     // operator<<
     template <typename Y>
-    std::ostream& operator<<(std::ostream& os, intrusive_ptr<Y> const& p)
+    std::ostream& operator<<(std::ostream& os, hpx::intrusive_ptr<Y> const& p)
     {
         os << p.get();
         return os;
     }
-}}    // namespace hpx::memory
+}    // namespace hpx
 
-namespace hpx {
+namespace hpx::memory {
 
     // hoist intrusive_ptr and friends into this namespace
-    using hpx::memory::intrusive_ptr;
+    template <typename T>
+    using intrusive_ptr HPX_DEPRECATED_V(1, 8,
+        "hpx::memory::intrusive_ptr is deprecated, use hpx::intrusive_ptr "
+        "instead") = hpx::intrusive_ptr<T>;
 
-    using hpx::memory::get_pointer;
+    template <typename T>
+    HPX_DEPRECATED_V(1, 8,
+        "hpx::memory::get_pointer is deprecated, use hpx::get_pointer instead")
+    constexpr T* get_pointer(hpx::intrusive_ptr<T> const& p) noexcept
+    {
+        return hpx::get_pointer(p);
+    }
 
-    using hpx::memory::const_pointer_cast;
-    using hpx::memory::dynamic_pointer_cast;
-    using hpx::memory::static_pointer_cast;
-}    // namespace hpx
+    template <typename T, typename U>
+    HPX_DEPRECATED_V(1, 8,
+        "hpx::memory::const_pointer_cast is deprecated, use "
+        "hpx::const_pointer_cast instead")
+    constexpr hpx::intrusive_ptr<T> const_pointer_cast(
+        hpx::intrusive_ptr<U> const& p) noexcept
+    {
+        return hpx::const_pointer_cast<T>(p);
+    }
+
+    template <typename T, typename U>
+    HPX_DEPRECATED_V(1, 8,
+        "hpx::memory::const_pointer_cast is deprecated, use "
+        "hpx::const_pointer_cast instead")
+    constexpr hpx::intrusive_ptr<T> const_pointer_cast(
+        hpx::intrusive_ptr<U>&& p) noexcept
+    {
+        return hpx::const_pointer_cast<T>(HPX_MOVE(p));
+    }
+
+    template <typename T, typename U>
+    HPX_DEPRECATED_V(1, 8,
+        "hpx::memory::dynamic_pointer_cast is deprecated, use "
+        "hpx::dynamic_pointer_cast instead")
+    constexpr hpx::intrusive_ptr<T> dynamic_pointer_cast(
+        hpx::intrusive_ptr<U> const& p)
+    {
+        return hpx::dynamic_pointer_cast<T>(p);
+    }
+
+    template <typename T, typename U>
+    HPX_DEPRECATED_V(1, 8,
+        "hpx::memory::dynamic_pointer_cast is deprecated, use "
+        "hpx::dynamic_pointer_cast instead")
+    constexpr hpx::intrusive_ptr<T> dynamic_pointer_cast(
+        hpx::intrusive_ptr<U>&& p)
+    {
+        return hpx::dynamic_pointer_cast<T>(HPX_MOVE(p));
+    }
+
+    template <typename T, typename U>
+    HPX_DEPRECATED_V(1, 8,
+        "hpx::memory::static_pointer_cast is deprecated, use "
+        "hpx::static_pointer_cast instead")
+    constexpr hpx::intrusive_ptr<T> static_pointer_cast(
+        hpx::intrusive_ptr<U> const& p) noexcept
+    {
+        return hpx::static_pointer_cast<T>(p);
+    }
+
+    template <typename T, typename U>
+    HPX_DEPRECATED_V(1, 8,
+        "hpx::memory::static_pointer_cast is deprecated, use "
+        "hpx::static_pointer_cast instead")
+    constexpr hpx::intrusive_ptr<T> static_pointer_cast(
+        hpx::intrusive_ptr<U>&& p) noexcept
+    {
+        return hpx::static_pointer_cast<T>(HPX_MOVE(p));
+    }
+}    // namespace hpx::memory
 
 namespace std {
 
     // support hashing
     template <typename T>
-    struct hash<hpx::memory::intrusive_ptr<T>>
+    struct hash<hpx::intrusive_ptr<T>>
     {
         using result_type = std::size_t;
 
         constexpr result_type operator()(
-            hpx::memory::intrusive_ptr<T> const& p) const noexcept
+            hpx::intrusive_ptr<T> const& p) const noexcept
         {
             return hash<T*>{}(p.get());
         }

--- a/libs/core/memory/tests/unit/intrusive_ptr.cpp
+++ b/libs/core/memory/tests/unit/intrusive_ptr.cpp
@@ -65,12 +65,12 @@ namespace N {
             return use_count_;
         }
 
-        inline friend void intrusive_ptr_add_ref(base const* p)
+        inline friend void intrusive_ptr_add_ref(base const* p) noexcept
         {
             ++p->use_count_;
         }
 
-        inline friend void intrusive_ptr_release(base const* p)
+        inline friend void intrusive_ptr_release(base const* p) noexcept
         {
             if (--p->use_count_ == 0)
                 delete p;

--- a/libs/core/memory/tests/unit/intrusive_ptr_move.cpp
+++ b/libs/core/memory/tests/unit/intrusive_ptr_move.cpp
@@ -62,12 +62,12 @@ namespace N {
             return use_count_;
         }
 
-        inline friend void intrusive_ptr_add_ref(base const* p)
+        inline friend void intrusive_ptr_add_ref(base const* p) noexcept
         {
             ++p->use_count_;
         }
 
-        inline friend void intrusive_ptr_release(base const* p)
+        inline friend void intrusive_ptr_release(base const* p) noexcept
         {
             if (--p->use_count_ == 0)
                 delete p;

--- a/libs/core/memory/tests/unit/intrusive_ptr_polymorphic.cpp
+++ b/libs/core/memory/tests/unit/intrusive_ptr_polymorphic.cpp
@@ -46,12 +46,12 @@ private:
     HPX_SERIALIZATION_POLYMORPHIC_ABSTRACT_SPLITTED(D);
 };
 
-void intrusive_ptr_add_ref(D* d)
+void intrusive_ptr_add_ref(D* d) noexcept
 {
     ++d->count;
 }
 
-void intrusive_ptr_release(D* d)
+void intrusive_ptr_release(D* d) noexcept
 {
     if (--d->count == 0)
     {

--- a/libs/core/memory/tests/unit/intrusive_ptr_polymorphic_nonintrusive.cpp
+++ b/libs/core/memory/tests/unit/intrusive_ptr_polymorphic_nonintrusive.cpp
@@ -43,12 +43,12 @@ void save(Archive& ar, const D& d, unsigned)
 }
 HPX_SERIALIZATION_SPLIT_FREE(D)
 
-void intrusive_ptr_add_ref(D* d)
+void intrusive_ptr_add_ref(D* d) noexcept
 {
     ++d->count;
 }
 
-void intrusive_ptr_release(D* d)
+void intrusive_ptr_release(D* d) noexcept
 {
     if (--d->count == 0)
     {

--- a/libs/core/memory/tests/unit/ip_convertible.cpp
+++ b/libs/core/memory/tests/unit/ip_convertible.cpp
@@ -16,9 +16,9 @@ struct W
 {
 };
 
-void intrusive_ptr_add_ref(W*) {}
+void intrusive_ptr_add_ref(W*) noexcept {}
 
-void intrusive_ptr_release(W*) {}
+void intrusive_ptr_release(W*) noexcept {}
 
 struct X : public virtual W
 {

--- a/libs/core/memory/tests/unit/ip_hash.cpp
+++ b/libs/core/memory/tests/unit/ip_hash.cpp
@@ -36,12 +36,12 @@ public:
         return use_count_;
     }
 
-    inline friend void intrusive_ptr_add_ref(base* p)
+    inline friend void intrusive_ptr_add_ref(base* p) noexcept
     {
         ++p->use_count_;
     }
 
-    inline friend void intrusive_ptr_release(base* p)
+    inline friend void intrusive_ptr_release(base* p) noexcept
     {
         if (--p->use_count_ == 0)
             delete p;

--- a/libs/core/memory/tests/unit/serialization_intrusive_ptr.cpp
+++ b/libs/core/memory/tests/unit/serialization_intrusive_ptr.cpp
@@ -30,12 +30,12 @@ struct A
     }
 };
 
-void intrusive_ptr_add_ref(A* a)
+void intrusive_ptr_add_ref(A* a) noexcept
 {
     ++a->count;
 }
 
-void intrusive_ptr_release(A* a)
+void intrusive_ptr_release(A* a) noexcept
 {
     if (--a->count == 0)
     {

--- a/libs/core/pack_traversal/tests/unit/pack_traversal.cpp
+++ b/libs/core/pack_traversal/tests/unit/pack_traversal.cpp
@@ -192,7 +192,7 @@ struct my_allocator
         return std::allocator<T>{}.allocate(n);
     }
 
-    void deallocate(pointer p, size_type n)
+    void deallocate(pointer p, size_type n) noexcept
     {
         return std::allocator<T>{}.deallocate(p, n);
     }

--- a/libs/core/schedulers/include/hpx/schedulers/queue_holder_thread.hpp
+++ b/libs/core/schedulers/include/hpx/schedulers/queue_holder_thread.hpp
@@ -569,7 +569,7 @@ namespace hpx { namespace threads { namespace policies {
         }
 
         // ----------------------------------------------------------------
-        static void deallocate(threads::thread_data* p)
+        static void deallocate(threads::thread_data* p) noexcept
         {
             using threads::thread_data;
             p->~thread_data();

--- a/libs/core/schedulers/include/hpx/schedulers/thread_queue.hpp
+++ b/libs/core/schedulers/include/hpx/schedulers/thread_queue.hpp
@@ -485,7 +485,7 @@ namespace hpx { namespace threads { namespace policies {
             work_items_count_.data_ = 0;
         }
 
-        static void deallocate(threads::thread_data* p)
+        static void deallocate(threads::thread_data* p) noexcept
         {
             p->destroy();
         }

--- a/libs/core/serialization/tests/unit/polymorphic/smart_ptr_polymorphic.cpp
+++ b/libs/core/serialization/tests/unit/polymorphic/smart_ptr_polymorphic.cpp
@@ -168,12 +168,12 @@ private:
     HPX_SERIALIZATION_POLYMORPHIC_ABSTRACT_SPLITTED(D);
 };
 
-void intrusive_ptr_add_ref(D* d)
+void intrusive_ptr_add_ref(D* d) noexcept
 {
     ++d->count;
 }
 
-void intrusive_ptr_release(D* d)
+void intrusive_ptr_release(D* d) noexcept
 {
     if (--d->count == 0)
     {

--- a/libs/core/serialization/tests/unit/polymorphic/smart_ptr_polymorphic_nonintrusive.cpp
+++ b/libs/core/serialization/tests/unit/polymorphic/smart_ptr_polymorphic_nonintrusive.cpp
@@ -164,12 +164,12 @@ void save(Archive& ar, const D& d, unsigned)
 }
 HPX_SERIALIZATION_SPLIT_FREE(D)
 
-void intrusive_ptr_add_ref(D* d)
+void intrusive_ptr_add_ref(D* d) noexcept
 {
     ++d->count;
 }
 
-void intrusive_ptr_release(D* d)
+void intrusive_ptr_release(D* d) noexcept
 {
     if (--d->count == 0)
     {

--- a/libs/core/serialization/tests/unit/serialization_smart_ptr.cpp
+++ b/libs/core/serialization/tests/unit/serialization_smart_ptr.cpp
@@ -112,12 +112,12 @@ struct A
     }
 };
 
-void intrusive_ptr_add_ref(A* a)
+void intrusive_ptr_add_ref(A* a) noexcept
 {
     ++a->count;
 }
 
-void intrusive_ptr_release(A* a)
+void intrusive_ptr_release(A* a) noexcept
 {
     if (--a->count == 0)
     {

--- a/libs/core/synchronization/include/hpx/synchronization/condition_variable.hpp
+++ b/libs/core/synchronization/include/hpx/synchronization/condition_variable.hpp
@@ -37,8 +37,7 @@ namespace hpx { namespace lcos { namespace local {
     {
     private:
         using mutex_type = detail::condition_variable_data::mutex_type;
-        using data_type =
-            hpx::memory::intrusive_ptr<detail::condition_variable_data>;
+        using data_type = hpx::intrusive_ptr<detail::condition_variable_data>;
 
     public:
         condition_variable()
@@ -183,8 +182,7 @@ namespace hpx { namespace lcos { namespace local {
     {
     private:
         using mutex_type = detail::condition_variable_data::mutex_type;
-        using data_type =
-            hpx::memory::intrusive_ptr<detail::condition_variable_data>;
+        using data_type = hpx::intrusive_ptr<detail::condition_variable_data>;
 
     public:
         condition_variable_any()

--- a/libs/core/synchronization/include/hpx/synchronization/detail/condition_variable.hpp
+++ b/libs/core/synchronization/include/hpx/synchronization/detail/condition_variable.hpp
@@ -170,8 +170,10 @@ namespace hpx { namespace lcos { namespace local { namespace detail {
     ///////////////////////////////////////////////////////////////////////////
     struct condition_variable_data;
 
-    HPX_CORE_EXPORT void intrusive_ptr_add_ref(condition_variable_data* p);
-    HPX_CORE_EXPORT void intrusive_ptr_release(condition_variable_data* p);
+    HPX_CORE_EXPORT void intrusive_ptr_add_ref(
+        condition_variable_data* p) noexcept;
+    HPX_CORE_EXPORT void intrusive_ptr_release(
+        condition_variable_data* p) noexcept;
 
     struct condition_variable_data
     {
@@ -187,9 +189,9 @@ namespace hpx { namespace lcos { namespace local { namespace detail {
 
     private:
         friend HPX_CORE_EXPORT void intrusive_ptr_add_ref(
-            condition_variable_data*);
+            condition_variable_data*) noexcept;
         friend HPX_CORE_EXPORT void intrusive_ptr_release(
-            condition_variable_data*);
+            condition_variable_data*) noexcept;
 
         hpx::util::atomic_count count_;
     };

--- a/libs/core/synchronization/include/hpx/synchronization/stop_token.hpp
+++ b/libs/core/synchronization/include/hpx/synchronization/stop_token.hpp
@@ -286,13 +286,13 @@ namespace hpx {
 
     private:
         explicit stop_token(
-            memory::intrusive_ptr<detail::stop_state> const& state) noexcept
+            hpx::intrusive_ptr<detail::stop_state> const& state) noexcept
           : state_(state)
         {
         }
 
     private:
-        memory::intrusive_ptr<detail::stop_state> state_;
+        hpx::intrusive_ptr<detail::stop_state> state_;
     };
 
     ///////////////////////////////////////////////////////////////////////////
@@ -429,7 +429,7 @@ namespace hpx {
         }
 
     private:
-        hpx::memory::intrusive_ptr<detail::stop_state> state_;
+        hpx::intrusive_ptr<detail::stop_state> state_;
     };
 
     ///////////////////////////////////////////////////////////////////////////
@@ -513,7 +513,7 @@ namespace hpx {
 
     private:
         HPX_NO_UNIQUE_ADDRESS Callback callback_;
-        hpx::memory::intrusive_ptr<detail::stop_state> state_;
+        hpx::intrusive_ptr<detail::stop_state> state_;
     };
 
     ////////////////////////////////////////////////////////////////////////////

--- a/libs/core/synchronization/src/detail/condition_variable.cpp
+++ b/libs/core/synchronization/src/detail/condition_variable.cpp
@@ -250,12 +250,12 @@ namespace hpx { namespace lcos { namespace local { namespace detail {
     }
 
     ///////////////////////////////////////////////////////////////////////////
-    void intrusive_ptr_add_ref(condition_variable_data* p)
+    void intrusive_ptr_add_ref(condition_variable_data* p) noexcept
     {
         ++p->count_;
     }
 
-    void intrusive_ptr_release(condition_variable_data* p)
+    void intrusive_ptr_release(condition_variable_data* p) noexcept
     {
         if (0 == --p->count_)
         {

--- a/libs/core/threading_base/include/hpx/threading_base/thread_data.hpp
+++ b/libs/core/threading_base/include/hpx/threading_base/thread_data.hpp
@@ -606,7 +606,7 @@ namespace hpx { namespace threads {
             thread_id_addref addref = thread_id_addref::yes);
 
         virtual ~thread_data() override;
-        virtual void destroy() = 0;
+        virtual void destroy() noexcept = 0;
 
     protected:
         void rebind_base(thread_init_data& init_data);

--- a/libs/core/threading_base/include/hpx/threading_base/thread_data_stackful.hpp
+++ b/libs/core/threading_base/include/hpx/threading_base/thread_data_stackful.hpp
@@ -155,7 +155,7 @@ namespace hpx { namespace threads {
             void* queue, std::ptrdiff_t stacksize,
             thread_id_addref addref = thread_id_addref::yes);
 
-        void destroy() override
+        void destroy() noexcept override
         {
             this->~thread_data_stackful();
             thread_alloc_.deallocate(this, 1);

--- a/libs/core/threading_base/include/hpx/threading_base/thread_data_stackless.hpp
+++ b/libs/core/threading_base/include/hpx/threading_base/thread_data_stackless.hpp
@@ -146,7 +146,7 @@ namespace hpx { namespace threads {
             std::ptrdiff_t stacksize,
             thread_id_addref addref = thread_id_addref::yes);
 
-        void destroy() override
+        void destroy() noexcept override
         {
             this->~thread_data_stackless();
             thread_alloc_.deallocate(this, 1);

--- a/libs/core/topology/include/hpx/topology/topology.hpp
+++ b/libs/core/topology/include/hpx/topology/topology.hpp
@@ -293,7 +293,7 @@ namespace hpx { namespace threads {
         int get_numa_domain(const void* addr) const;
 
         /// Free memory that was previously allocated by allocate
-        void deallocate(void* addr, std::size_t len) const;
+        void deallocate(void* addr, std::size_t len) const noexcept;
 
         void print_vector(
             std::ostream& os, std::vector<std::size_t> const& v) const;

--- a/libs/core/topology/src/topology.cpp
+++ b/libs/core/topology/src/topology.cpp
@@ -1457,7 +1457,7 @@ namespace hpx { namespace threads {
     }
 
     /// Free memory that was previously allocated by allocate
-    void topology::deallocate(void* addr, std::size_t len) const
+    void topology::deallocate(void* addr, std::size_t len) const noexcept
     {
         hwloc_free(topo, addr, len);
     }

--- a/libs/full/async_distributed/include/hpx/async_distributed/detail/promise_lco.hpp
+++ b/libs/full/async_distributed/include/hpx/async_distributed/detail/promise_lco.hpp
@@ -88,11 +88,11 @@ namespace hpx { namespace lcos { namespace detail {
     private:
         // intrusive reference counting, noop since we don't require
         // reference counting here.
-        friend void intrusive_ptr_add_ref(promise_lco_base* /*p*/) {}
+        friend void intrusive_ptr_add_ref(promise_lco_base* /*p*/) noexcept {}
 
         // intrusive reference counting, noop since we don't require
         // reference counting here.
-        friend void intrusive_ptr_release(promise_lco_base* /*p*/) {}
+        friend void intrusive_ptr_release(promise_lco_base* /*p*/) noexcept {}
     };
 
     template <typename Result, typename RemoteResult>

--- a/libs/full/collectives/include/hpx/collectives/detail/barrier_node.hpp
+++ b/libs/full/collectives/include/hpx/collectives/detail/barrier_node.hpp
@@ -87,13 +87,13 @@ namespace hpx { namespace distributed { namespace detail {
         }
 
         // intrusive reference counting
-        friend void intrusive_ptr_add_ref(barrier_node* p)
+        friend void intrusive_ptr_add_ref(barrier_node* p) noexcept
         {
             ++p->count_;
         }
 
         // intrusive reference counting
-        friend void intrusive_ptr_release(barrier_node* p)
+        friend void intrusive_ptr_release(barrier_node* p) noexcept
         {
             if (p && --p->count_ == 0)
             {

--- a/libs/full/components_base/include/hpx/components_base/server/component.hpp
+++ b/libs/full/components_base/include/hpx/components_base/server/component.hpp
@@ -31,7 +31,7 @@ namespace hpx { namespace components { namespace detail {
             HPX_ASSERT(1 == count);
             return alloc_.allocate(count);
         }
-        void free(void* p, std::size_t count)
+        void free(void* p, std::size_t count) noexcept
         {
             HPX_ASSERT(1 == count);
             alloc_.deallocate(static_cast<Component*>(p), count);

--- a/libs/full/components_base/include/hpx/components_base/server/managed_component_base.hpp
+++ b/libs/full/components_base/include/hpx/components_base/server/managed_component_base.hpp
@@ -138,7 +138,8 @@ namespace hpx { namespace components {
         struct manage_lifetime<traits::managed_object_controls_lifetime>
         {
             template <typename Component>
-            static void call(Component* component)
+            static void call(Component* component) noexcept(
+                noexcept(component->finalize()))
             {
                 // The managed_component controls the lifetime of the
                 // component implementation.
@@ -261,14 +262,16 @@ namespace hpx { namespace components {
 
     // reference counting
     template <typename Component, typename Derived>
-    void intrusive_ptr_add_ref(managed_component<Component, Derived>* p)
+    void intrusive_ptr_add_ref(
+        managed_component<Component, Derived>* p) noexcept
     {
         detail_adl_barrier::manage_lifetime<
             traits::managed_component_dtor_policy_t<Component>>::
             addref(p->component_);
     }
     template <typename Component, typename Derived>
-    void intrusive_ptr_release(managed_component<Component, Derived>* p)
+    void intrusive_ptr_release(
+        managed_component<Component, Derived>* p) noexcept
     {
         detail_adl_barrier::manage_lifetime<
             traits::managed_component_dtor_policy_t<Component>>::
@@ -457,10 +460,10 @@ namespace hpx { namespace components {
     public:
         // reference counting
         template <typename C, typename D>
-        friend void intrusive_ptr_add_ref(managed_component<C, D>* p);
+        friend void intrusive_ptr_add_ref(managed_component<C, D>* p) noexcept;
 
         template <typename C, typename D>
-        friend void intrusive_ptr_release(managed_component<C, D>* p);
+        friend void intrusive_ptr_release(managed_component<C, D>* p) noexcept;
 
     protected:
         Component* component_;

--- a/libs/full/components_base/include/hpx/components_base/server/wrapper_heap.hpp
+++ b/libs/full/components_base/include/hpx/components_base/server/wrapper_heap.hpp
@@ -43,7 +43,7 @@ namespace hpx { namespace components { namespace detail {
             {
                 return alloc_.allocate(size);
             }
-            static void free(void* p, std::size_t count)
+            static void free(void* p, std::size_t count) noexcept
             {
                 alloc_.deallocate(static_cast<char*>(p), count);
             }

--- a/libs/full/compute/include/hpx/compute/host/block_allocator.hpp
+++ b/libs/full/compute/include/hpx/compute/host/block_allocator.hpp
@@ -102,9 +102,16 @@ namespace hpx { namespace compute { namespace host {
             // pointer obtained by an earlier call to allocate(). The argument n
             // must be equal to the first argument of the call to allocate() that
             // originally produced p; otherwise, the behavior is undefined.
-            void deallocate(pointer p, size_type n)
+            void deallocate(pointer p, size_type n) noexcept
             {
-                hpx::threads::create_topology().deallocate(p, n);
+                try
+                {
+                    hpx::threads::create_topology().deallocate(p, n);
+                }
+                catch (...)
+                {
+                    ;    // just ignore errors from create_topology
+                }
             }
 
             // Returns the maximum theoretically possible value of n, for which the

--- a/libs/full/compute/include/hpx/compute/host/numa_allocator.hpp
+++ b/libs/full/compute/include/hpx/compute/host/numa_allocator.hpp
@@ -141,7 +141,7 @@ namespace hpx { namespace parallel { namespace util {
             return p;
         }
 
-        void deallocate(pointer p, size_type cnt)
+        void deallocate(pointer p, size_type cnt) noexcept
         {
             topo_.deallocate(p, cnt * sizeof(T));
         }

--- a/libs/full/compute/include/hpx/compute/host/numa_binding_allocator.hpp
+++ b/libs/full/compute/include/hpx/compute/host/numa_binding_allocator.hpp
@@ -330,15 +330,22 @@ namespace hpx { namespace compute { namespace host {
         // pointer obtained by an earlier call to allocate(). The argument n
         // must be equal to the first argument of the call to allocate() that
         // originally produced p; otherwise, the behavior is undefined.
-        void deallocate(pointer p, size_type n)
+        void deallocate(pointer p, size_type n) noexcept
         {
-            nba_deb.debug(debug::str<>("deallocate"),
-                "calling membind for size (bytes) ",
-                debug::hex<2>(n * sizeof(T)));
+            try
+            {
+                nba_deb.debug(debug::str<>("deallocate"),
+                    "calling membind for size (bytes) ",
+                    debug::hex<2>(n * sizeof(T)));
 #ifdef NUMA_BINDING_ALLOCATOR_DEBUG_PAGE_BINDING
-            display_binding(p, binding_helper_);
+                display_binding(p, binding_helper_);
 #endif
-            threads::topology().deallocate(p, n * sizeof(T));
+                threads::create_topology().deallocate(p, n * sizeof(T));
+            }
+            catch (...)
+            {
+                ;    // just ignore errors from create_topology
+            }
         }
 
         // Returns the maximum theoretically possible value of n, for which the

--- a/libs/full/compute/include/hpx/compute/traits/allocator_traits.hpp
+++ b/libs/full/compute/include/hpx/compute/traits/allocator_traits.hpp
@@ -233,7 +233,8 @@ namespace hpx { namespace compute { namespace traits {
             return alloc.allocate(n, hint);
         }
 
-        static void deallocate(Allocator& alloc, pointer p, size_type n)
+        static void deallocate(
+            Allocator& alloc, pointer p, size_type n) noexcept
         {
             alloc.deallocate(p, n);
         }

--- a/libs/full/compute/tests/regressions/for_each_value_proxy.cpp
+++ b/libs/full/compute/tests/regressions/for_each_value_proxy.cpp
@@ -125,7 +125,7 @@ struct test_allocator
     // pointer obtained by an earlier call to allocate(). The argument n
     // must be equal to the first argument of the call to allocate() that
     // originally produced p; otherwise, the behavior is undefined.
-    void deallocate(pointer p, size_type /* n */)
+    void deallocate(pointer p, size_type /* n */) noexcept
     {
         delete[] p;
     }

--- a/libs/full/lcos_distributed/tests/unit/test_allocator.hpp
+++ b/libs/full/lcos_distributed/tests/unit/test_allocator.hpp
@@ -89,7 +89,7 @@ public:
         return static_cast<pointer>(std::malloc(n * sizeof(T)));
     }
 
-    void deallocate(pointer p, size_type)
+    void deallocate(pointer p, size_type) noexcept
     {
         --count;
         std::free(p);

--- a/libs/full/naming/include/hpx/naming/credit_handling.hpp
+++ b/libs/full/naming/include/hpx/naming/credit_handling.hpp
@@ -58,7 +58,7 @@ namespace hpx::naming {
             std::unique_lock<gid_type::mutex_type>& l, gid_type& id);
 
         ///////////////////////////////////////////////////////////////////////
-        HPX_EXPORT void decrement_refcnt(id_type_impl* gid);
+        HPX_EXPORT void decrement_refcnt(id_type_impl* gid) noexcept;
 
         ///////////////////////////////////////////////////////////////////////
         // credit management (called during serialization), this function

--- a/libs/full/naming_base/include/hpx/naming_base/id_type.hpp
+++ b/libs/full/naming_base/include/hpx/naming_base/id_type.hpp
@@ -249,7 +249,7 @@ namespace hpx {
                 return alloc_.allocate(1);
             }
 
-            static void operator delete(void* p, std::size_t size)
+            static void operator delete(void* p, std::size_t size) noexcept
             {
                 if (p == nullptr)
                 {

--- a/tests/performance/network/network_storage/network_storage.cpp
+++ b/tests/performance/network/network_storage/network_storage.cpp
@@ -254,7 +254,7 @@ public:
     return static_cast<T*>(pointer_);
   }
 
-  void deallocate(pointer p, size_type n)
+  void deallocate(pointer p, size_type n) noexcept
   {
     HPX_TEST_EQ(p == pointer_ && n, size_);
   }

--- a/tests/regressions/util/serialize_buffer_1069.cpp
+++ b/tests/regressions/util/serialize_buffer_1069.cpp
@@ -51,7 +51,7 @@ public:
         return std::allocator<T>::allocate(n);
     }
 
-    void deallocate(pointer p, size_type n)
+    void deallocate(pointer p, size_type n) noexcept
     {
         HPX_TEST_EQ(n, static_cast<size_type>(MEMORY_BLOCK_SIZE));
         return std::allocator<T>::deallocate(p, n);


### PR DESCRIPTION
- moving hpx::memory::intrusive_ptr to hpx::intrusive_ptr
- flyby: mark all deallocate() functions as noexcept
