### PR TITLE
Reduce number of allocations while calling async_bulk_execute

### DIFF
--- a/libs/core/algorithms/CMakeLists.txt
+++ b/libs/core/algorithms/CMakeLists.txt
@@ -178,6 +178,7 @@ set(algorithms_headers
     hpx/parallel/util/detail/algorithm_result.hpp
     hpx/parallel/util/detail/chunk_size.hpp
     hpx/parallel/util/detail/chunk_size_iterator.hpp
+    hpx/parallel/util/detail/clear_container.hpp
     hpx/parallel/util/detail/handle_exception_termination_handler.hpp
     hpx/parallel/util/detail/handle_local_exceptions.hpp
     hpx/parallel/util/detail/handle_remote_exceptions.hpp

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/adjacent_difference.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/adjacent_difference.hpp
@@ -157,6 +157,7 @@ namespace hpx {
 #include <hpx/parallel/algorithms/detail/dispatch.hpp>
 #include <hpx/parallel/algorithms/detail/distance.hpp>
 #include <hpx/parallel/util/detail/algorithm_result.hpp>
+#include <hpx/parallel/util/detail/clear_container.hpp>
 #include <hpx/parallel/util/detail/sender_util.hpp>
 #include <hpx/parallel/util/loop.hpp>
 #include <hpx/parallel/util/partitioner.hpp>
@@ -236,12 +237,10 @@ namespace hpx { namespace parallel { inline namespace v1 {
                         });
                 };
 
-                auto f2 = [dest, count](
-                              std::vector<hpx::future<void>>&& data) mutable
-                    -> FwdIter2 {
+                auto f2 = [dest, count](auto&& data) mutable -> FwdIter2 {
                     // make sure iterators embedded in function object that is
                     // attached to futures are invalidated
-                    data.clear();
+                    util::detail::clear_container(data);
                     std::advance(dest, count);
                     return dest;
                 };

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/adjacent_find.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/adjacent_find.hpp
@@ -128,6 +128,7 @@ namespace hpx {
 #include <hpx/parallel/algorithms/detail/adjacent_find.hpp>
 #include <hpx/parallel/algorithms/detail/dispatch.hpp>
 #include <hpx/parallel/util/detail/algorithm_result.hpp>
+#include <hpx/parallel/util/detail/clear_container.hpp>
 #include <hpx/parallel/util/detail/sender_util.hpp>
 #include <hpx/parallel/util/invoke_projected.hpp>
 #include <hpx/parallel/util/loop.hpp>
@@ -199,11 +200,10 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 };
 
                 auto f2 = [tok, count, first, last](
-                              std::vector<hpx::future<void>>&& data) mutable
-                    -> FwdIter {
+                              auto&& data) mutable -> FwdIter {
                     // make sure iterators embedded in function object that is
                     // attached to futures are invalidated
-                    data.clear();
+                    util::detail::clear_container(data);
                     difference_type adj_find_res = tok.get_data();
                     if (adj_find_res != count)
                         std::advance(first, adj_find_res);

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/all_any_none.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/all_any_none.hpp
@@ -302,7 +302,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 return util::partitioner<ExPolicy, bool>::call(
                     HPX_FORWARD(ExPolicy, policy), first,
                     detail::distance(first, last), HPX_MOVE(f1),
-                    [](std::vector<hpx::future<bool>>&& results) {
+                    [](auto&& results) {
                         return detail::sequential_find_if_not<
                                    hpx::execution::sequenced_policy>(
                                    hpx::util::begin(results),
@@ -364,7 +364,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 return util::partitioner<ExPolicy, bool>::call(
                     HPX_FORWARD(ExPolicy, policy), first,
                     detail::distance(first, last), HPX_MOVE(f1),
-                    [](std::vector<hpx::future<bool>>&& results) {
+                    [](auto&& results) {
                         return detail::sequential_find_if<
                                    hpx::execution::sequenced_policy>(
                                    hpx::util::begin(results),
@@ -425,7 +425,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 return util::partitioner<ExPolicy, bool>::call(
                     HPX_FORWARD(ExPolicy, policy), first,
                     detail::distance(first, last), HPX_MOVE(f1),
-                    [](std::vector<hpx::future<bool>>&& results) {
+                    [](auto&& results) {
                         return detail::sequential_find_if_not<
                                    hpx::execution::sequenced_policy>(
                                    hpx::util::begin(results),

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/copy.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/copy.hpp
@@ -215,6 +215,7 @@ namespace hpx {
 #include <hpx/parallel/algorithms/detail/distance.hpp>
 #include <hpx/parallel/algorithms/detail/transfer.hpp>
 #include <hpx/parallel/util/detail/algorithm_result.hpp>
+#include <hpx/parallel/util/detail/clear_container.hpp>
 #include <hpx/parallel/util/foreach_partitioner.hpp>
 #include <hpx/parallel/util/loop.hpp>
 #include <hpx/parallel/util/projection_identity.hpp>
@@ -537,7 +538,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
 
                     // make sure iterators embedded in function object that is
                     // attached to futures are invalidated
-                    data.clear();
+                    util::detail::clear_container(data);
 
                     return util::in_out_result<FwdIter1, FwdIter3>{
                         HPX_MOVE(first), HPX_MOVE(dest)};

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/count.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/count.hpp
@@ -294,7 +294,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 return util::partitioner<ExPolicy, difference_type>::call(
                     HPX_FORWARD(ExPolicy, policy), first,
                     detail::distance(first, last), HPX_MOVE(f1),
-                    hpx::unwrapping([](std::vector<difference_type>&& results) {
+                    hpx::unwrapping([](auto&& results) {
                         return util::accumulate_n(hpx::util::begin(results),
                             hpx::util::size(results), difference_type(0),
                             std::plus<difference_type>());
@@ -353,7 +353,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 return util::partitioner<ExPolicy, difference_type>::call(
                     HPX_FORWARD(ExPolicy, policy), first,
                     detail::distance(first, last), HPX_MOVE(f1),
-                    hpx::unwrapping([](std::vector<difference_type>&& results) {
+                    hpx::unwrapping([](auto&& results) {
                         return util::accumulate_n(hpx::util::begin(results),
                             hpx::util::size(results), difference_type(0),
                             std::plus<difference_type>());

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/detail/advance_to_sentinel.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/detail/advance_to_sentinel.hpp
@@ -18,7 +18,7 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
     template <typename Iter, typename Sent>
     constexpr inline Iter advance_to_sentinel(Iter first, Sent last)
     {
-        if constexpr (std::is_same<Iter, Sent>::value)
+        if constexpr (std::is_same_v<Iter, Sent>)
         {
             return last;
         }

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/detail/sample_sort.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/detail/sample_sort.hpp
@@ -115,11 +115,8 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
                 hpx::util::make_counting_iterator(std::uint32_t(0)),
                 hpx::util::make_counting_iterator(nthreads));
 
-            hpx::when_all(
-                execution::bulk_async_execute(
-                    exec, [this](std::uint32_t) { this->execute_first(); },
-                    shape))
-                .get();
+            hpx::wait_all(execution::bulk_async_execute(
+                exec, [this](std::uint32_t) { this->execute_first(); }, shape));
 
             construct = true;
         }
@@ -137,10 +134,8 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
                 hpx::util::make_counting_iterator(std::uint32_t(0)),
                 hpx::util::make_counting_iterator(nthreads));
 
-            hpx::when_all(
-                execution::bulk_async_execute(
-                    exec, [this](std::uint32_t) { this->execute(); }, shape))
-                .get();
+            hpx::wait_all(execution::bulk_async_execute(
+                exec, [this](std::uint32_t) { this->execute(); }, shape));
         }
     };
 
@@ -288,14 +283,13 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
             hpx::util::make_counting_iterator(std::uint32_t(0)),
             hpx::util::make_counting_iterator(nthreads));
 
-        hpx::when_all(execution::bulk_async_execute(
-                          exec,
-                          [&, this](std::uint32_t i) {
-                              spin_sort(vmem_thread[i].begin(),
-                                  vmem_thread[i].end(), comp, vbuf_thread[i]);
-                          },
-                          shape))
-            .get();
+        hpx::wait_all(execution::bulk_async_execute(
+            exec,
+            [&, this](std::uint32_t i) {
+                spin_sort(vmem_thread[i].begin(), vmem_thread[i].end(), comp,
+                    vbuf_thread[i]);
+            },
+            shape));
 
         // Obtain the vector of milestones
         std::vector<Iter> vsample;

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/detail/search.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/detail/search.hpp
@@ -17,6 +17,7 @@
 #include <hpx/parallel/algorithms/detail/distance.hpp>
 #include <hpx/parallel/util/compare_projected.hpp>
 #include <hpx/parallel/util/detail/algorithm_result.hpp>
+#include <hpx/parallel/util/detail/clear_container.hpp>
 #include <hpx/parallel/util/loop.hpp>
 #include <hpx/parallel/util/partitioner.hpp>
 
@@ -138,11 +139,10 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
                     });
             };
 
-            auto f2 =
-                [=](std::vector<hpx::future<void>>&& data) mutable -> FwdIter {
+            auto f2 = [=](auto&& data) mutable -> FwdIter {
                 // make sure iterators embedded in function object that is
                 // attached to futures are invalidated
-                data.clear();
+                util::detail::clear_container(data);
                 difference_type search_res = tok.get_data();
                 if (search_res != count)
                     std::advance(first, search_res);
@@ -240,11 +240,10 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
                     });
             };
 
-            auto f2 =
-                [=](std::vector<hpx::future<void>>&& data) mutable -> FwdIter {
+            auto f2 = [=](auto&& data) mutable -> FwdIter {
                 // make sure iterators embedded in function object that is
                 // attached to futures are invalidated
-                data.clear();
+                util::detail::clear_container(data);
                 difference_type search_res = tok.get_data();
                 if (search_res != s_difference_type(count))
                     std::advance(first, search_res);

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/detail/set_operation.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/detail/set_operation.hpp
@@ -15,6 +15,7 @@
 #include <hpx/parallel/algorithms/detail/distance.hpp>
 #include <hpx/parallel/algorithms/detail/upper_lower_bound.hpp>
 #include <hpx/parallel/util/detail/algorithm_result.hpp>
+#include <hpx/parallel/util/detail/clear_container.hpp>
 #include <hpx/parallel/util/foreach_partitioner.hpp>
 #include <hpx/parallel/util/partitioner.hpp>
 #include <hpx/type_support/unused.hpp>
@@ -214,12 +215,12 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
         // different versions of clang-format produce different formatting
         // clang-format off
         auto f2 = [buffer, chunks, cores, first1, first2, dest](
-                      std::vector<future<void>>&& data) -> result_type {
+                      auto&& data) -> result_type {
             // clang-format on
 
             // make sure iterators embedded in function object that is
             // attached to futures are invalidated
-            data.clear();
+            util::detail::clear_container(data);
 
             // accumulate real length and rightmost positions in input sequences
             std::size_t first1_pos = 0;

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/equal.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/equal.hpp
@@ -282,8 +282,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 return util::partitioner<ExPolicy, bool>::call(
                     HPX_FORWARD(ExPolicy, policy),
                     hpx::util::make_zip_iterator(first1, first2), count1,
-                    HPX_MOVE(f1),
-                    [](std::vector<hpx::future<bool>>&& results) -> bool {
+                    HPX_MOVE(f1), [](auto&& results) -> bool {
                         return std::all_of(hpx::util::begin(results),
                             hpx::util::end(results),
                             [](hpx::future<bool>& val) { return val.get(); });
@@ -343,7 +342,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 return util::partitioner<ExPolicy, bool>::call(
                     HPX_FORWARD(ExPolicy, policy),
                     hpx::util::make_zip_iterator(first1, first2), count,
-                    HPX_MOVE(f1), [](std::vector<hpx::future<bool>>&& results) {
+                    HPX_MOVE(f1), [](auto&& results) {
                         return std::all_of(hpx::util::begin(results),
                             hpx::util::end(results),
                             [](hpx::future<bool>& val) { return val.get(); });

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/exclusive_scan.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/exclusive_scan.hpp
@@ -299,6 +299,7 @@ namespace hpx {
 #include <hpx/parallel/algorithms/detail/distance.hpp>
 #include <hpx/parallel/algorithms/inclusive_scan.hpp>
 #include <hpx/parallel/util/detail/algorithm_result.hpp>
+#include <hpx/parallel/util/detail/clear_container.hpp>
 #include <hpx/parallel/util/detail/sender_util.hpp>
 #include <hpx/parallel/util/loop.hpp>
 #include <hpx/parallel/util/partitioner.hpp>
@@ -448,7 +449,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                             std::vector<hpx::future<void>>&& data) {
                             // make sure iterators embedded in function object that is
                             // attached to futures are invalidated
-                            data.clear();
+                            util::detail::clear_container(data);
                             return util::in_out_result<FwdIter1, FwdIter2>{
                                 last_iter, final_dest};
                         });

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/find.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/find.hpp
@@ -388,6 +388,7 @@ namespace hpx {
 #include <hpx/parallel/algorithms/detail/find.hpp>
 #include <hpx/parallel/util/compare_projected.hpp>
 #include <hpx/parallel/util/detail/algorithm_result.hpp>
+#include <hpx/parallel/util/detail/clear_container.hpp>
 #include <hpx/parallel/util/invoke_projected.hpp>
 #include <hpx/parallel/util/loop.hpp>
 #include <hpx/parallel/util/partitioner.hpp>
@@ -448,12 +449,11 @@ namespace hpx { namespace parallel { inline namespace v1 {
                         part_size, tok, val, HPX_FORWARD(Proj, proj));
                 };
 
-                auto f2 =
-                    [tok, count, first, last](
-                        std::vector<hpx::future<void>>&& data) mutable -> Iter {
+                auto f2 = [tok, count, first, last](
+                              auto&& data) mutable -> Iter {
                     // make sure iterators embedded in function object that is
                     // attached to futures are invalidated
-                    data.clear();
+                    util::detail::clear_container(data);
 
                     difference_type find_res =
                         static_cast<difference_type>(tok.get_data());
@@ -524,12 +524,11 @@ namespace hpx { namespace parallel { inline namespace v1 {
                         HPX_FORWARD(Proj, proj));
                 };
 
-                auto f2 =
-                    [tok, count, first, last](
-                        std::vector<hpx::future<void>>&& data) mutable -> Iter {
+                auto f2 = [tok, count, first, last](
+                              auto&& data) mutable -> Iter {
                     // make sure iterators embedded in function object that is
                     // attached to futures are invalidated
-                    data.clear();
+                    util::detail::clear_container(data);
 
                     difference_type find_res =
                         static_cast<difference_type>(tok.get_data());
@@ -601,12 +600,11 @@ namespace hpx { namespace parallel { inline namespace v1 {
                         HPX_FORWARD(Proj, proj));
                 };
 
-                auto f2 =
-                    [tok, count, first, last](
-                        std::vector<hpx::future<void>>&& data) mutable -> Iter {
+                auto f2 = [tok, count, first, last](
+                              auto&& data) mutable -> Iter {
                     // make sure iterators embedded in function object that is
                     // attached to futures are invalidated
-                    data.clear();
+                    util::detail::clear_container(data);
 
                     difference_type find_res =
                         static_cast<difference_type>(tok.get_data());
@@ -694,11 +692,10 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 };
 
                 auto f2 = [tok, count, first1, last1](
-                              std::vector<hpx::future<void>>&& data) mutable
-                    -> Iter1 {
+                              auto&& data) mutable -> Iter1 {
                     // make sure iterators embedded in function object that is
                     // attached to futures are invalidated
-                    data.clear();
+                    util::detail::clear_container(data);
 
                     difference_type find_end_res = tok.get_data();
 
@@ -780,11 +777,10 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 };
 
                 auto f2 = [tok, count, first, last](
-                              std::vector<hpx::future<void>>&& data) mutable
-                    -> FwdIter {
+                              auto&& data) mutable -> FwdIter {
                     // make sure iterators embedded in function object that is
                     // attached to futures are invalidated
-                    data.clear();
+                    util::detail::clear_container(data);
 
                     difference_type find_first_of_res = tok.get_data();
 

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/for_loop.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/for_loop.hpp
@@ -1114,7 +1114,7 @@ namespace hpx::parallel { inline namespace v2 {
                         first, size, stride,
                         part_iterations<ExPolicy, F, S, args_type>{
                             HPX_FORWARD(F, f), stride, args},
-                        [=](std::vector<hpx::future<void>>&&) mutable -> void {
+                        [=](auto&&) mutable -> void {
                             auto pack =
                                 typename hpx::util::make_index_pack<sizeof...(
                                     Ts)>::type();

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/generate.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/generate.hpp
@@ -186,10 +186,11 @@ namespace hpx { namespace parallel { inline namespace v1 {
                     return sequential_generate(
                         HPX_MOVE(policy), part_begin, part_end, HPX_MOVE(f));
                 };
+
                 return util::partitioner<ExPolicy, Iter>::call(
                     HPX_FORWARD(ExPolicy, policy), first,
                     detail::distance(first, last), HPX_MOVE(f1),
-                    [first, last](std::vector<hpx::future<Iter>>&&) {
+                    [first, last](auto&&) {
                         return detail::advance_to_sentinel(first, last);
                     });
             }
@@ -230,8 +231,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 };
                 return util::partitioner<ExPolicy, FwdIter>::call(
                     HPX_FORWARD(ExPolicy, policy), first, count, HPX_MOVE(f1),
-                    [first, count](
-                        std::vector<hpx::future<FwdIter>>&&) mutable {
+                    [first, count](auto&&) mutable {
                         std::advance(first, count);
                         return first;
                     });

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/includes.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/includes.hpp
@@ -287,7 +287,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                     return !tok.was_cancelled();
                 };
 
-                auto f2 = [](std::vector<hpx::future<bool>>&& results) {
+                auto f2 = [](auto&& results) {
                     return std::all_of(hpx::util::begin(results),
                         hpx::util::end(results),
                         [](hpx::future<bool>& val) { return val.get(); });

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/inclusive_scan.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/inclusive_scan.hpp
@@ -433,6 +433,7 @@ namespace hpx {
 #include <hpx/parallel/algorithms/detail/dispatch.hpp>
 #include <hpx/parallel/algorithms/detail/distance.hpp>
 #include <hpx/parallel/util/detail/algorithm_result.hpp>
+#include <hpx/parallel/util/detail/clear_container.hpp>
 #include <hpx/parallel/util/detail/sender_util.hpp>
 #include <hpx/parallel/util/loop.hpp>
 #include <hpx/parallel/util/partitioner.hpp>
@@ -603,7 +604,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                             std::vector<hpx::future<void>>&& data) {
                             // make sure iterators embedded in function object that is
                             // attached to futures are invalidated
-                            data.clear();
+                            util::detail::clear_container(data);
                             return util::in_out_result<FwdIter1, FwdIter2>{
                                 last_iter, final_dest};
                         });

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/is_heap.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/is_heap.hpp
@@ -148,6 +148,7 @@ namespace hpx {
 #include <hpx/parallel/algorithms/detail/dispatch.hpp>
 #include <hpx/parallel/algorithms/detail/distance.hpp>
 #include <hpx/parallel/util/detail/algorithm_result.hpp>
+#include <hpx/parallel/util/detail/clear_container.hpp>
 #include <hpx/parallel/util/loop.hpp>
 #include <hpx/parallel/util/partitioner.hpp>
 #include <hpx/parallel/util/projection_identity.hpp>
@@ -225,12 +226,10 @@ namespace hpx { namespace parallel { inline namespace v1 {
                             }
                         });
                 };
-                auto f2 =
-                    [tok](
-                        std::vector<hpx::future<void>>&& data) mutable -> bool {
+                auto f2 = [tok](auto&& data) mutable -> bool {
                     // make sure iterators embedded in function object that is
                     // attached to futures are invalidated
-                    data.clear();
+                    util::detail::clear_container(data);
 
                     difference_type find_res =
                         static_cast<difference_type>(tok.get_data());
@@ -338,12 +337,10 @@ namespace hpx { namespace parallel { inline namespace v1 {
                             }
                         });
                 };
-                auto f2 =
-                    [tok, second](
-                        std::vector<hpx::future<void>>&& data) mutable -> Iter {
+                auto f2 = [tok, second](auto&& data) mutable -> Iter {
                     // make sure iterators embedded in function object that is
                     // attached to futures are invalidated
-                    data.clear();
+                    util::detail::clear_container(data);
 
                     difference_type find_res =
                         static_cast<difference_type>(tok.get_data());

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/is_partitioned.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/is_partitioned.hpp
@@ -217,8 +217,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                     return fst_bool;
                 };
 
-                auto f2 =
-                    [tok](std::vector<hpx::future<bool>>&& results) -> bool {
+                auto f2 = [tok](auto&& results) -> bool {
                     if (tok.was_cancelled())
                         return false;
                     return sequential_is_partitioned(HPX_MOVE(results));

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/is_sorted.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/is_sorted.hpp
@@ -232,6 +232,7 @@ namespace hpx {
 #include <hpx/parallel/algorithms/detail/is_sorted.hpp>
 #include <hpx/parallel/util/cancellation_token.hpp>
 #include <hpx/parallel/util/detail/algorithm_result.hpp>
+#include <hpx/parallel/util/detail/clear_container.hpp>
 #include <hpx/parallel/util/detail/sender_util.hpp>
 #include <hpx/parallel/util/invoke_projected.hpp>
 #include <hpx/parallel/util/loop.hpp>
@@ -316,7 +317,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                     return !tok.was_cancelled();
                 };
 
-                auto f2 = [](std::vector<hpx::future<bool>>&& results) {
+                auto f2 = [](auto&& results) {
                     return std::all_of(hpx::util::begin(results),
                         hpx::util::end(results),
                         [](hpx::future<bool>& val) -> bool {
@@ -406,12 +407,10 @@ namespace hpx { namespace parallel { inline namespace v1 {
                         }
                     }
                 };
-                auto f2 = [first, tok](
-                              std::vector<hpx::future<void>>&& data) mutable
-                    -> FwdIter {
+                auto f2 = [first, tok](auto&& data) mutable -> FwdIter {
                     // make sure iterators embedded in function object that is
                     // attached to futures are invalidated
-                    data.clear();
+                    util::detail::clear_container(data);
 
                     difference_type loc = tok.get_data();
                     std::advance(first, loc);

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/lexicographical_compare.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/lexicographical_compare.hpp
@@ -168,6 +168,7 @@ namespace hpx {
 #include <hpx/parallel/algorithms/for_each.hpp>
 #include <hpx/parallel/algorithms/mismatch.hpp>
 #include <hpx/parallel/util/detail/algorithm_result.hpp>
+#include <hpx/parallel/util/detail/clear_container.hpp>
 #include <hpx/parallel/util/loop.hpp>
 #include <hpx/parallel/util/partitioner.hpp>
 #include <hpx/parallel/util/zip_iterator.hpp>
@@ -252,22 +253,23 @@ namespace hpx { namespace parallel { inline namespace v1 {
                         [&pred, &tok, &proj1, &proj2](
                             reference t, std::size_t i) mutable -> void {
                             using hpx::get;
-                            if (HPX_INVOKE(pred, HPX_INVOKE(proj1, get<0>(t)),
-                                    HPX_INVOKE(proj2, get<1>(t))) ||
-                                HPX_INVOKE(pred, HPX_INVOKE(proj2, get<1>(t)),
-                                    HPX_INVOKE(proj1, get<0>(t))))
+                            using hpx::util::invoke;
+                            // gcc10/cuda11 complains about using HPX_INVOKE here
+                            if (invoke(pred, invoke(proj1, get<0>(t)),
+                                    invoke(proj2, get<1>(t))) ||
+                                invoke(pred, invoke(proj2, get<1>(t)),
+                                    invoke(proj1, get<0>(t))))
                             {
                                 tok.cancel(i);
                             }
                         });
                 };
 
-                auto f2 =
-                    [tok, first1, first2, last1, last2, pred, proj1, proj2](
-                        std::vector<hpx::future<void>>&& data) mutable -> bool {
+                auto f2 = [tok, first1, first2, last1, last2, pred, proj1,
+                              proj2](auto&& data) mutable -> bool {
                     // make sure iterators embedded in function object that is
                     // attached to futures are invalidated
-                    data.clear();
+                    util::detail::clear_container(data);
 
                     std::size_t mismatched = tok.get_data();
 
@@ -275,8 +277,11 @@ namespace hpx { namespace parallel { inline namespace v1 {
                     std::advance(first2, mismatched);
 
                     if (first1 != last1 && first2 != last2)
-                        return HPX_INVOKE(pred, HPX_INVOKE(proj1, *first1),
-                            HPX_INVOKE(proj2, *first2));
+                    {
+                        using hpx::util::invoke;
+                        return invoke(pred, invoke(proj1, *first1),
+                            invoke(proj2, *first2));
+                    }
 
                     return first2 != last2;
                 };

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/make_heap.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/make_heap.hpp
@@ -271,7 +271,6 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 scoped_executor_parameters scoped_params(
                     policy.parameters(), policy.executor());
 
-                std::vector<hpx::future<void>> workitems;
                 std::list<std::exception_ptr> errors;
 
                 using tuple_type = hpx::tuple<RndIter, std::size_t>;
@@ -341,7 +340,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                             }
 
                             // Reserve items/chunk_size spaces for async calls
-                            workitems = execution::bulk_async_execute(
+                            auto&& workitems = execution::bulk_async_execute(
                                 policy.executor(), op, shapes);
 
                             // Required synchronization per level
@@ -350,7 +349,6 @@ namespace hpx { namespace parallel { inline namespace v1 {
                             // collect exceptions
                             util::detail::handle_local_exceptions<
                                 ExPolicy>::call(workitems, errors, false);
-                            workitems.clear();
                         }
 
                         if (!errors.empty())
@@ -372,8 +370,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 }
 
                 // rethrow exceptions, if any
-                util::detail::handle_local_exceptions<ExPolicy>::call(
-                    workitems, errors);
+                util::detail::handle_local_exceptions<ExPolicy>::call(errors);
 
                 std::advance(first, n);
                 return util::detail::algorithm_result<ExPolicy, RndIter>::get(

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/minmax.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/minmax.hpp
@@ -513,7 +513,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 };
                 auto f2 = [policy, f = HPX_FORWARD(F, f),
                               proj = HPX_FORWARD(Proj, proj)](
-                              std::vector<FwdIter>&& positions) -> FwdIter {
+                              auto&& positions) -> FwdIter {
                     return min_element::sequential_minmax_element_ind(
                         policy, positions.begin(), positions.size(), f, proj);
                 };
@@ -676,7 +676,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 };
                 auto f2 = [policy, f = HPX_FORWARD(F, f),
                               proj = HPX_FORWARD(Proj, proj)](
-                              std::vector<FwdIter>&& positions) -> FwdIter {
+                              auto&& positions) -> FwdIter {
                     return max_element::sequential_minmax_element_ind(
                         policy, positions.begin(), positions.size(), f, proj);
                 };
@@ -866,10 +866,9 @@ namespace hpx { namespace parallel { inline namespace v1 {
                     return sequential_minmax_element(
                         policy, it, part_count, f, proj);
                 };
-                auto f2 =
-                    [policy, f = HPX_FORWARD(F, f),
-                        proj = HPX_FORWARD(Proj, proj)](
-                        std::vector<result_type>&& positions) -> result_type {
+                auto f2 = [policy, f = HPX_FORWARD(F, f),
+                              proj = HPX_FORWARD(Proj, proj)](
+                              auto&& positions) -> result_type {
                     return minmax_element::sequential_minmax_element_ind(
                         policy, positions.begin(), positions.size(), f, proj);
                 };

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/mismatch.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/mismatch.hpp
@@ -183,6 +183,7 @@ namespace hpx {
 #include <hpx/parallel/algorithms/detail/distance.hpp>
 #include <hpx/parallel/algorithms/detail/mismatch.hpp>
 #include <hpx/parallel/util/detail/algorithm_result.hpp>
+#include <hpx/parallel/util/detail/clear_container.hpp>
 #include <hpx/parallel/util/loop.hpp>
 #include <hpx/parallel/util/partitioner.hpp>
 #include <hpx/parallel/util/result_types.hpp>
@@ -274,11 +275,11 @@ namespace hpx { namespace parallel { inline namespace v1 {
                         HPX_FORWARD(Proj1, proj1), HPX_FORWARD(Proj2, proj2));
                 };
 
-                auto f2 = [=](std::vector<hpx::future<void>>&& data) mutable
+                auto f2 = [=](auto&& data) mutable
                     -> util::in_in_result<Iter1, Iter2> {
                     // make sure iterators embedded in function object that is
                     // attached to futures are invalidated
-                    data.clear();
+                    util::detail::clear_container(data);
                     difference_type1 mismatched =
                         static_cast<difference_type1>(tok.get_data());
                     if (mismatched != count1)
@@ -371,11 +372,11 @@ namespace hpx { namespace parallel { inline namespace v1 {
                         base_idx, it, part_count, tok, HPX_FORWARD(F, f));
                 };
 
-                auto f2 = [=](std::vector<hpx::future<void>>&& data) mutable
-                    -> std::pair<FwdIter1, FwdIter2> {
+                auto f2 =
+                    [=](auto&& data) mutable -> std::pair<FwdIter1, FwdIter2> {
                     // make sure iterators embedded in function object that is
                     // attached to futures are invalidated
-                    data.clear();
+                    util::detail::clear_container(data);
                     difference_type mismatched =
                         static_cast<difference_type>(tok.get_data());
                     if (mismatched != count)

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/partition.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/partition.hpp
@@ -1391,7 +1391,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
         hpx::future<FwdIter> parallel_partition(ExPolicy&& policy,
             FwdIter first, FwdIter last, Pred&& pred, Proj&& proj)
         {
-            hpx::future<FwdIter> f = execution::async_execute(
+            return execution::async_execute(
                 policy.executor(), [=]() mutable -> FwdIter {
                     try
                     {
@@ -1403,14 +1403,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                         util::detail::handle_local_exceptions<ExPolicy>::call(
                             std::current_exception());
                     }
-
-                    // Not reachable.
-                    HPX_ASSERT(false);
-                    return partition_helper::call(
-                        policy, first, last, pred, proj);
                 });
-
-            return f;
         }
 
         template <typename FwdIter>

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/reduce.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/reduce.hpp
@@ -279,12 +279,12 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 return util::partitioner<ExPolicy, T>::call(
                     HPX_FORWARD(ExPolicy, policy), first,
                     detail::distance(first, last), HPX_MOVE(f1),
-                    hpx::unwrapping([init = HPX_FORWARD(T_, init),
-                                        r = HPX_FORWARD(Reduce, r)](
-                                        std::vector<T>&& results) -> T {
-                        return util::accumulate_n(hpx::util::begin(results),
-                            hpx::util::size(results), init, r);
-                    }));
+                    hpx::unwrapping(
+                        [init = HPX_FORWARD(T_, init),
+                            r = HPX_FORWARD(Reduce, r)](auto&& results) -> T {
+                            return util::accumulate_n(hpx::util::begin(results),
+                                hpx::util::size(results), init, r);
+                        }));
             }
         };
         /// \endcond

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/remove.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/remove.hpp
@@ -224,6 +224,7 @@ namespace hpx {
 #include <hpx/parallel/algorithms/detail/find.hpp>
 #include <hpx/parallel/algorithms/detail/transfer.hpp>
 #include <hpx/parallel/util/detail/algorithm_result.hpp>
+#include <hpx/parallel/util/detail/clear_container.hpp>
 #include <hpx/parallel/util/foreach_partitioner.hpp>
 #include <hpx/parallel/util/invoke_projected.hpp>
 #include <hpx/parallel/util/loop.hpp>
@@ -390,8 +391,8 @@ namespace hpx { namespace parallel { inline namespace v1 {
 
                     // make sure iterators embedded in function object that is
                     // attached to futures are invalidated
-                    items.clear();
-                    data.clear();
+                    util::detail::clear_container(items);
+                    util::detail::clear_container(data);
 
                     return *dest_ptr;
                 };

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/transform.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/transform.hpp
@@ -212,8 +212,8 @@ namespace hpx { namespace parallel { inline namespace v1 {
         template <typename F, typename Proj>
         struct transform_projected
         {
-            typename std::decay<F>::type& f_;
-            typename std::decay<Proj>::type& proj_;
+            std::decay_t<F>& f_;
+            std::decay_t<Proj>& proj_;
 
             HPX_HOST_DEVICE constexpr transform_projected(
                 F& f, Proj& proj) noexcept
@@ -233,7 +233,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
         template <typename F>
         struct transform_projected<F, util::projection_identity>
         {
-            typename std::decay<F>::type& f_;
+            std::decay_t<F>& f_;
 
             HPX_HOST_DEVICE constexpr transform_projected(
                 F& f, util::projection_identity) noexcept
@@ -382,8 +382,8 @@ namespace hpx { namespace parallel { inline namespace v1 {
 
             template <typename ExPolicy, typename FwdIter1B, typename FwdIter1E,
                 typename FwdIter2, typename F, typename Proj>
-            static typename util::detail::algorithm_result<ExPolicy,
-                util::in_out_result<FwdIter1B, FwdIter2>>::type
+            static util::detail::algorithm_result_t<ExPolicy,
+                util::in_out_result<FwdIter1B, FwdIter2>>
             parallel(ExPolicy&& policy, FwdIter1B first, FwdIter1E last,
                 FwdIter2 dest, F&& f, Proj&& proj)
             {
@@ -590,8 +590,8 @@ namespace hpx { namespace parallel { inline namespace v1 {
             template <typename ExPolicy, typename FwdIter1B, typename FwdIter1E,
                 typename FwdIter2, typename FwdIter3, typename F,
                 typename Proj1, typename Proj2>
-            static typename util::detail::algorithm_result<ExPolicy,
-                util::in_in_out_result<FwdIter1B, FwdIter2, FwdIter3>>::type
+            static util::detail::algorithm_result_t<ExPolicy,
+                util::in_in_out_result<FwdIter1B, FwdIter2, FwdIter3>>
             parallel(ExPolicy&& policy, FwdIter1B first1, FwdIter1E last1,
                 FwdIter2 first2, FwdIter3 dest, F&& f, Proj1&& proj1,
                 Proj2&& proj2)
@@ -665,8 +665,8 @@ namespace hpx { namespace parallel { inline namespace v1 {
             template <typename ExPolicy, typename FwdIter1B, typename FwdIter1E,
                 typename FwdIter2B, typename FwdIter2E, typename FwdIter3,
                 typename F, typename Proj1, typename Proj2>
-            static typename util::detail::algorithm_result<ExPolicy,
-                util::in_in_out_result<FwdIter1B, FwdIter2B, FwdIter3>>::type
+            static util::detail::algorithm_result_t<ExPolicy,
+                util::in_in_out_result<FwdIter1B, FwdIter2B, FwdIter3>>
             parallel(ExPolicy&& policy, FwdIter1B first1, FwdIter1E last1,
                 FwdIter2B first2, FwdIter2E last2, FwdIter3 dest, F&& f,
                 Proj1&& proj1, Proj2&& proj2)
@@ -798,7 +798,7 @@ namespace hpx {
         friend FwdIter2 tag_fallback_invoke(hpx::transform_t, FwdIter1 first,
             FwdIter1 last, FwdIter2 dest, F&& f)
         {
-            static_assert(hpx::traits::is_input_iterator<FwdIter1>::value,
+            static_assert(hpx::traits::is_input_iterator_v<FwdIter1>,
                 "Requires at least input iterator.");
 
             return parallel::util::get_second_element(
@@ -818,12 +818,11 @@ namespace hpx {
                 hpx::traits::is_iterator_v<FwdIter2>
             )>
         // clang-format on
-        friend typename parallel::util::detail::algorithm_result<ExPolicy,
-            FwdIter2>::type
+        friend parallel::util::detail::algorithm_result_t<ExPolicy, FwdIter2>
         tag_fallback_invoke(hpx::transform_t, ExPolicy&& policy, FwdIter1 first,
             FwdIter1 last, FwdIter2 dest, F&& f)
         {
-            static_assert(hpx::traits::is_forward_iterator<FwdIter1>::value,
+            static_assert(hpx::traits::is_forward_iterator_v<FwdIter1>,
                 "Requires at least forward iterator.");
 
             return parallel::util::get_second_element(
@@ -846,8 +845,8 @@ namespace hpx {
         friend FwdIter3 tag_fallback_invoke(hpx::transform_t, FwdIter1 first1,
             FwdIter1 last1, FwdIter2 first2, FwdIter3 dest, F&& f)
         {
-            static_assert(hpx::traits::is_input_iterator<FwdIter1>::value &&
-                    hpx::traits::is_input_iterator<FwdIter2>::value,
+            static_assert(hpx::traits::is_input_iterator_v<FwdIter1> &&
+                    hpx::traits::is_input_iterator_v<FwdIter2>,
                 "Requires at least input iterator.");
 
             using proj_id = hpx::parallel::util::projection_identity;
@@ -871,14 +870,13 @@ namespace hpx {
                 hpx::traits::is_iterator_v<FwdIter3>
             )>
         // clang-format on
-        friend typename parallel::util::detail::algorithm_result<ExPolicy,
-            FwdIter3>::type
+        friend parallel::util::detail::algorithm_result_t<ExPolicy, FwdIter3>
         tag_fallback_invoke(hpx::transform_t, ExPolicy&& policy,
             FwdIter1 first1, FwdIter1 last1, FwdIter2 first2, FwdIter3 dest,
             F&& f)
         {
-            static_assert(hpx::traits::is_input_iterator<FwdIter1>::value &&
-                    hpx::traits::is_input_iterator<FwdIter2>::value,
+            static_assert(hpx::traits::is_input_iterator_v<FwdIter1> &&
+                    hpx::traits::is_input_iterator_v<FwdIter2>,
                 "Requires at least input iterator.");
 
             using proj_id = hpx::parallel::util::projection_identity;

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/transform_exclusive_scan.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/transform_exclusive_scan.hpp
@@ -228,6 +228,7 @@ namespace hpx {
 #include <hpx/parallel/algorithms/detail/distance.hpp>
 #include <hpx/parallel/algorithms/transform_inclusive_scan.hpp>
 #include <hpx/parallel/util/detail/algorithm_result.hpp>
+#include <hpx/parallel/util/detail/clear_container.hpp>
 #include <hpx/parallel/util/detail/sender_util.hpp>
 #include <hpx/parallel/util/loop.hpp>
 #include <hpx/parallel/util/partitioner.hpp>
@@ -369,7 +370,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                         std::vector<hpx::future<void>>&& data) -> result_type {
                         // make sure iterators embedded in function object that is
                         // attached to futures are invalidated
-                        data.clear();
+                        util::detail::clear_container(data);
 
                         return result_type{last_iter, final_dest};
                     });

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/transform_inclusive_scan.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/transform_inclusive_scan.hpp
@@ -414,6 +414,7 @@ namespace hpx {
 #include <hpx/parallel/algorithms/detail/distance.hpp>
 #include <hpx/parallel/algorithms/inclusive_scan.hpp>
 #include <hpx/parallel/util/detail/algorithm_result.hpp>
+#include <hpx/parallel/util/detail/clear_container.hpp>
 #include <hpx/parallel/util/detail/sender_util.hpp>
 #include <hpx/parallel/util/loop.hpp>
 #include <hpx/parallel/util/partitioner.hpp>
@@ -581,7 +582,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                         std::vector<hpx::future<void>>&& data) -> result_type {
                         // make sure iterators embedded in function object that is
                         // attached to futures are invalidated
-                        data.clear();
+                        util::detail::clear_container(data);
                         return result_type{last_iter, final_dest};
                     });
             }

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/transform_reduce.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/transform_reduce.hpp
@@ -394,7 +394,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                     detail::distance(first, last), HPX_MOVE(f1),
                     hpx::unwrapping([init = HPX_FORWARD(T_, init),
                                         r = HPX_FORWARD(Reduce, r)](
-                                        std::vector<T>&& results) mutable -> T {
+                                        auto&& results) mutable -> T {
                         return util::accumulate_n(hpx::util::begin(results),
                             hpx::util::size(results), init, r);
                     }));
@@ -579,7 +579,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                     HPX_FORWARD(ExPolicy, policy),
                     make_zip_iterator(first1, first2), count, HPX_MOVE(f1),
                     [init = HPX_FORWARD(T_, init), op1 = HPX_FORWARD(Op1, op1)](
-                        std::vector<hpx::future<T>>&& results) mutable -> T {
+                        auto&& results) mutable -> T {
                         T ret = HPX_MOVE(init);
                         for (auto&& fut : results)
                         {

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/uninitialized_copy.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/uninitialized_copy.hpp
@@ -200,6 +200,7 @@ namespace hpx {
 #include <hpx/parallel/algorithms/detail/dispatch.hpp>
 #include <hpx/parallel/algorithms/detail/distance.hpp>
 #include <hpx/parallel/util/detail/algorithm_result.hpp>
+#include <hpx/parallel/util/detail/clear_container.hpp>
 #include <hpx/parallel/util/detail/sender_util.hpp>
 #include <hpx/parallel/util/loop.hpp>
 #include <hpx/parallel/util/partitioner_with_cleanup.hpp>
@@ -302,13 +303,11 @@ namespace hpx { namespace parallel { inline namespace v1 {
                                     get<0>(iters), part_size, dest, tok)));
                     },
                     // finalize, called once if no error occurred
-                    [dest, first, count](
-                        std::vector<hpx::future<partition_result_type>>&&
-                            data) mutable
+                    [dest, first, count](auto&& data) mutable
                     -> util::in_out_result<Iter, FwdIter2> {
                         // make sure iterators embedded in function object that is
                         // attached to futures are invalidated
-                        data.clear();
+                        util::detail::clear_container(data);
 
                         std::advance(first, count);
                         std::advance(dest, count);

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/uninitialized_default_construct.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/uninitialized_default_construct.hpp
@@ -175,6 +175,7 @@ namespace hpx {
 #include <hpx/parallel/algorithms/detail/dispatch.hpp>
 #include <hpx/parallel/algorithms/detail/distance.hpp>
 #include <hpx/parallel/util/detail/algorithm_result.hpp>
+#include <hpx/parallel/util/detail/clear_container.hpp>
 #include <hpx/parallel/util/detail/sender_util.hpp>
 #include <hpx/parallel/util/loop.hpp>
 #include <hpx/parallel/util/partitioner_with_cleanup.hpp>
@@ -265,12 +266,10 @@ namespace hpx { namespace parallel { inline namespace v1 {
                                 it, part_size, tok));
                     },
                     // finalize, called once if no error occurred
-                    [first, count](
-                        std::vector<hpx::future<partition_result_type>>&&
-                            data) mutable -> FwdIter {
+                    [first, count](auto&& data) mutable -> FwdIter {
                         // make sure iterators embedded in function object that is
                         // attached to futures are invalidated
-                        data.clear();
+                        util::detail::clear_container(data);
 
                         std::advance(first, count);
                         return first;

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/uninitialized_fill.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/uninitialized_fill.hpp
@@ -180,6 +180,7 @@ namespace hpx {
 #include <hpx/parallel/algorithms/detail/dispatch.hpp>
 #include <hpx/parallel/algorithms/detail/distance.hpp>
 #include <hpx/parallel/util/detail/algorithm_result.hpp>
+#include <hpx/parallel/util/detail/clear_container.hpp>
 #include <hpx/parallel/util/detail/sender_util.hpp>
 #include <hpx/parallel/util/loop.hpp>
 #include <hpx/parallel/util/partitioner_with_cleanup.hpp>
@@ -267,12 +268,10 @@ namespace hpx { namespace parallel { inline namespace v1 {
                                 it, part_size, value, tok));
                     },
                     // finalize, called once if no error occurred
-                    [first, count](
-                        std::vector<hpx::future<partition_result_type>>&&
-                            data) mutable -> Iter {
+                    [first, count](auto&& data) mutable -> Iter {
                         // make sure iterators embedded in function object that is
                         // attached to futures are invalidated
-                        data.clear();
+                        util::detail::clear_container(data);
 
                         std::advance(first, count);
                         return first;

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/uninitialized_move.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/uninitialized_move.hpp
@@ -204,6 +204,7 @@ namespace hpx {
 #include <hpx/parallel/algorithms/detail/dispatch.hpp>
 #include <hpx/parallel/algorithms/detail/distance.hpp>
 #include <hpx/parallel/util/detail/algorithm_result.hpp>
+#include <hpx/parallel/util/detail/clear_container.hpp>
 #include <hpx/parallel/util/detail/sender_util.hpp>
 #include <hpx/parallel/util/loop.hpp>
 #include <hpx/parallel/util/partitioner_with_cleanup.hpp>
@@ -308,13 +309,11 @@ namespace hpx { namespace parallel { inline namespace v1 {
                                     get<0>(iters), part_size, dest, tok)));
                     },
                     // finalize, called once if no error occurred
-                    [first, dest, count](
-                        std::vector<hpx::future<partition_result_type>>&&
-                            data) mutable
+                    [first, dest, count](auto&& data) mutable
                     -> util::in_out_result<Iter, FwdIter2> {
                         // make sure iterators embedded in function object that is
                         // attached to futures are invalidated
-                        data.clear();
+                        util::detail::clear_container(data);
 
                         std::advance(first, count);
                         std::advance(dest, count);

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/uninitialized_value_construct.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/uninitialized_value_construct.hpp
@@ -177,6 +177,7 @@ namespace hpx {
 #include <hpx/parallel/algorithms/detail/dispatch.hpp>
 #include <hpx/parallel/algorithms/detail/distance.hpp>
 #include <hpx/parallel/util/detail/algorithm_result.hpp>
+#include <hpx/parallel/util/detail/clear_container.hpp>
 #include <hpx/parallel/util/detail/sender_util.hpp>
 #include <hpx/parallel/util/loop.hpp>
 #include <hpx/parallel/util/partitioner_with_cleanup.hpp>
@@ -267,12 +268,10 @@ namespace hpx { namespace parallel { inline namespace v1 {
                                 it, part_size, tok));
                     },
                     // finalize, called once if no error occurred
-                    [first, count](
-                        std::vector<hpx::future<partition_result_type>>&&
-                            data) mutable -> FwdIter {
+                    [first, count](auto&& data) mutable -> FwdIter {
                         // make sure iterators embedded in function object that is
                         // attached to futures are invalidated
-                        data.clear();
+                        util::detail::clear_container(data);
 
                         std::advance(first, count);
                         return first;

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/unique.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/unique.hpp
@@ -473,6 +473,7 @@ namespace hpx {
 #include <hpx/parallel/algorithms/detail/distance.hpp>
 #include <hpx/parallel/algorithms/detail/transfer.hpp>
 #include <hpx/parallel/util/detail/algorithm_result.hpp>
+#include <hpx/parallel/util/detail/clear_container.hpp>
 #include <hpx/parallel/util/detail/sender_util.hpp>
 #include <hpx/parallel/util/foreach_partitioner.hpp>
 #include <hpx/parallel/util/loop.hpp>
@@ -655,8 +656,8 @@ namespace hpx { namespace parallel { inline namespace v1 {
                     -> FwdIter {
                     // make sure iterators embedded in function object that is
                     // attached to futures are invalidated
-                    items.clear();
-                    data.clear();
+                    util::detail::clear_container(items);
+                    util::detail::clear_container(data);
 
                     if (!flags[count - 1])
                     {
@@ -906,7 +907,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
 
                     // make sure iterators embedded in function object that is
                     // attached to futures are invalidated
-                    data.clear();
+                    util::detail::clear_container(data);
 
                     return unique_copy_result<FwdIter1, FwdIter2>{
                         HPX_MOVE(last_iter), HPX_MOVE(dest)};

--- a/libs/core/algorithms/include/hpx/parallel/spmd_block.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/spmd_block.hpp
@@ -171,7 +171,7 @@ namespace hpx { namespace lcos { namespace local {
     // Asynchronous version
     template <typename ExPolicy, typename F, typename... Args,
         typename = std::enable_if_t<hpx::is_async_execution_policy_v<ExPolicy>>>
-    std::vector<hpx::future<void>> define_spmd_block(
+    decltype(auto) define_spmd_block(
         ExPolicy&& policy, std::size_t num_images, F&& f, Args&&... args)
     {
         static_assert(hpx::is_async_execution_policy_v<ExPolicy>,
@@ -258,7 +258,7 @@ namespace hpx { namespace parallel { inline namespace v2 {
     // Asynchronous version
     template <typename ExPolicy, typename F, typename... Args,
         typename = std::enable_if_t<hpx::is_async_execution_policy_v<ExPolicy>>>
-    std::vector<hpx::future<void>> define_spmd_block(
+    decltype(auto) define_spmd_block(
         ExPolicy&& policy, std::size_t num_images, F&& f, Args&&... args)
     {
         return hpx::lcos::local::define_spmd_block(

--- a/libs/core/algorithms/include/hpx/parallel/util/detail/algorithm_result.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/util/detail/algorithm_result.hpp
@@ -246,10 +246,9 @@ namespace hpx { namespace parallel { namespace util { namespace detail {
 
     ///////////////////////////////////////////////////////////////////////////
     template <typename ExPolicy, typename T = void>
-    struct algorithm_result
-      : algorithm_result_impl<typename std::decay<ExPolicy>::type, T>
+    struct algorithm_result : algorithm_result_impl<std::decay_t<ExPolicy>, T>
     {
-        static_assert(!std::is_lvalue_reference<T>::value,
+        static_assert(!std::is_lvalue_reference_v<T>,
             "T shouldn't be a lvalue reference");
     };
 
@@ -259,18 +258,18 @@ namespace hpx { namespace parallel { namespace util { namespace detail {
     ///////////////////////////////////////////////////////////////////////////
     template <typename U, typename Conv,
         HPX_CONCEPT_REQUIRES_(hpx::is_invocable_v<Conv, U>)>
-    constexpr typename hpx::util::invoke_result<Conv, U>::type
-    convert_to_result(U&& val, Conv&& conv)
+    constexpr hpx::util::invoke_result_t<Conv, U> convert_to_result(
+        U&& val, Conv&& conv)
     {
         return HPX_INVOKE(conv, val);
     }
 
     template <typename U, typename Conv,
         HPX_CONCEPT_REQUIRES_(hpx::is_invocable_v<Conv, U>)>
-    hpx::future<typename hpx::util::invoke_result<Conv, U>::type>
-    convert_to_result(hpx::future<U>&& f, Conv&& conv)
+    hpx::future<hpx::util::invoke_result_t<Conv, U>> convert_to_result(
+        hpx::future<U>&& f, Conv&& conv)
     {
-        using result_type = typename hpx::util::invoke_result<Conv, U>::type;
+        using result_type = hpx::util::invoke_result_t<Conv, U>;
 
         return hpx::make_future<result_type>(
             HPX_MOVE(f), HPX_FORWARD(Conv, conv));

--- a/libs/core/algorithms/include/hpx/parallel/util/detail/clear_container.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/util/detail/clear_container.hpp
@@ -1,0 +1,59 @@
+//  Copyright (c) 2022 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include <hpx/config.hpp>
+#include <hpx/futures/future.hpp>
+
+#include <array>
+#include <cstddef>
+#include <vector>
+
+///////////////////////////////////////////////////////////////////////////////
+namespace hpx::parallel::util::detail {
+
+    // make sure iterators embedded in function object that is attached to
+    // futures are invalidated
+    template <typename Cont>
+    inline constexpr void clear_container(Cont&) noexcept
+    {
+    }
+
+    template <typename T>
+    inline constexpr void clear_container(
+        std::vector<hpx::future<T>>& v) noexcept
+    {
+        v.clear();
+    }
+
+    template <typename T>
+    inline constexpr void clear_container(
+        std::vector<hpx::shared_future<T>>& v) noexcept
+    {
+        v.clear();
+    }
+
+    template <typename T, std::size_t N>
+    inline constexpr void clear_container(
+        std::array<hpx::future<T>, N>& arr) noexcept
+    {
+        for (auto& f : arr)
+        {
+            f = hpx::future<T>();
+        }
+    }
+
+    template <typename T, std::size_t N>
+    inline constexpr void clear_container(
+        std::array<hpx::shared_future<T>, N>& arr) noexcept
+    {
+        for (auto& f : arr)
+        {
+            f = hpx::future<T>();
+        }
+    }
+}    // namespace hpx::parallel::util::detail

--- a/libs/core/algorithms/include/hpx/parallel/util/detail/handle_local_exceptions.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/util/detail/handle_local_exceptions.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2016 Hartmut Kaiser
+//  Copyright (c) 2007-2022 Hartmut Kaiser
 //  Copyright (c)      2017 Taeguk Kwon
 //
 //  SPDX-License-Identifier: BSL-1.0
@@ -14,8 +14,11 @@
 #include <hpx/modules/errors.hpp>
 #include <hpx/parallel/util/detail/handle_exception_termination_handler.hpp>
 
+#include <array>
+#include <cstddef>
 #include <exception>
 #include <list>
+#include <type_traits>
 #include <utility>
 #include <vector>
 
@@ -29,9 +32,9 @@ namespace hpx { namespace parallel { namespace util { namespace detail {
         ///////////////////////////////////////////////////////////////////////
         // std::bad_alloc has to be handled separately
 #if defined(HPX_COMPUTE_DEVICE_CODE)
-        static void call(std::exception_ptr const&)
+        [[noreturn]] static void call(std::exception_ptr const&)
         {
-            HPX_ASSERT(false);
+            std::terminate();
         }
 #else
         [[noreturn]] static void call(std::exception_ptr const& e)
@@ -74,78 +77,239 @@ namespace hpx { namespace parallel { namespace util { namespace detail {
 #endif
         }
 
+        static void call(std::list<std::exception_ptr>& errors)
+        {
+            if (!errors.empty())
+            {
+                throw exception_list(HPX_MOVE(errors));
+            }
+        }
+
+    private:
+        template <typename Future>
+        static void call_helper_single(Future const& f,
+            std::list<std::exception_ptr>& errors, bool throw_errors)
+        {
+#if defined(HPX_COMPUTE_DEVICE_CODE)
+            HPX_UNUSED(f);
+            HPX_UNUSED(errors);
+            HPX_UNUSED(throw_errors);
+            HPX_ASSERT(false);
+#else
+            // extract exception from future and handle as needed
+            if (f.has_exception())
+            {
+                call(f.get_exception_ptr(), errors);
+            }
+
+            if (throw_errors && !errors.empty())
+            {
+                throw exception_list(HPX_MOVE(errors));
+            }
+#endif
+        }
+
+        template <typename Future>
+        static void call_helper_single(Future const& f, bool throw_errors)
+        {
+#if defined(HPX_COMPUTE_DEVICE_CODE)
+            HPX_UNUSED(f);
+            HPX_UNUSED(throw_errors);
+            HPX_ASSERT(false);
+#else
+            // extract exception from future and handle as needed
+            if (f.has_exception())
+            {
+                std::list<std::exception_ptr> errors;
+                call(f.get_exception_ptr(), errors);
+                if (throw_errors && !errors.empty())
+                {
+                    throw exception_list(HPX_MOVE(errors));
+                }
+            }
+#endif
+        }
+
+    public:
+        template <typename T>
+        static void call(hpx::future<T> const& f,
+            std::list<std::exception_ptr>& errors, bool throw_errors = true)
+        {
+            return call_helper_single(f, errors, throw_errors);
+        }
+
+        template <typename T>
+        static void call(hpx::shared_future<T> const& f,
+            std::list<std::exception_ptr>& errors, bool throw_errors = true)
+        {
+            return call_helper_single(f, errors, throw_errors);
+        }
+
+        template <typename T>
+        static void call(hpx::future<T> const& f, bool throw_errors = true)
+        {
+            return call_helper_single(f, throw_errors);
+        }
+
+        template <typename T>
+        static void call(
+            hpx::shared_future<T> const& f, bool throw_errors = true)
+        {
+            return call_helper_single(f, throw_errors);
+        }
+
+    private:
+        template <typename Cont>
+        static void call_helper(Cont const& workitems,
+            std::list<std::exception_ptr>& errors, bool throw_errors)
+        {
+#if defined(HPX_COMPUTE_DEVICE_CODE)
+            HPX_UNUSED(workitems);
+            HPX_UNUSED(errors);
+            HPX_UNUSED(throw_errors);
+            HPX_ASSERT(false);
+#else
+            if (workitems.empty() && errors.empty())
+            {
+                return;
+            }
+
+            // first extract exception from all futures
+            for (auto const& f : workitems)
+            {
+                if (f.has_exception())
+                {
+                    // rethrow std::bad_alloc or store exception
+                    call(f.get_exception_ptr(), errors);
+                }
+            }
+
+            if (throw_errors && !errors.empty())
+            {
+                throw exception_list(HPX_MOVE(errors));
+            }
+#endif
+        }
+
+        template <typename Cont>
+        static void call_helper(Cont const& workitems, bool throw_errors)
+        {
+#if defined(HPX_COMPUTE_DEVICE_CODE)
+            HPX_UNUSED(workitems);
+            HPX_UNUSED(throw_errors);
+            HPX_ASSERT(false);
+#else
+            if (workitems.empty())
+            {
+                return;
+            }
+
+            // first detect whether there are exceptional futures
+            bool found_exception = false;
+            for (auto const& f : workitems)
+            {
+                if (f.has_exception())
+                {
+                    found_exception = true;
+                    break;
+                }
+            }
+
+            // nothing needs to be done
+            if (!found_exception)
+            {
+                return;
+            }
+
+            // now extract exception from all futures
+            std::list<std::exception_ptr> errors;
+            for (auto const& f : workitems)
+            {
+                if (f.has_exception())
+                {
+                    // rethrow std::bad_alloc or store exception
+                    call(f.get_exception_ptr(), errors);
+                }
+            }
+
+            if (throw_errors && !errors.empty())
+            {
+                throw exception_list(HPX_MOVE(errors));
+            }
+#endif
+        }
+
+    public:
         template <typename T>
         static void call(std::vector<hpx::future<T>> const& workitems,
             std::list<std::exception_ptr>& errors, bool throw_errors = true)
         {
-#if defined(HPX_COMPUTE_DEVICE_CODE)
-            HPX_UNUSED(workitems);
-            HPX_UNUSED(errors);
-            HPX_UNUSED(throw_errors);
-            HPX_ASSERT(false);
-#else
-            if (workitems.empty() && errors.empty())
-            {
-                return;
-            }
-
-            // first extract exception from all futures
-            std::vector<std::exception_ptr> exceptions;
-            exceptions.reserve(workitems.size());
-            for (auto const& f : workitems)
-            {
-                if (f.has_exception())
-                {
-                    exceptions.reserve(workitems.size());
-                    exceptions.push_back(f.get_exception_ptr());
-                }
-            }
-
-            // now handle exceptions as needed
-            for (auto& e : exceptions)
-            {
-                call(e, errors);
-            }
-
-            if (throw_errors && !errors.empty())
-            {
-                throw exception_list(HPX_MOVE(errors));
-            }
-#endif
+            return call_helper(workitems, errors, throw_errors);
         }
 
-        ///////////////////////////////////////////////////////////////////////
+        template <typename T, std::size_t N>
+        static void call(std::array<hpx::future<T>, N> const& workitems,
+            std::list<std::exception_ptr>& errors, bool throw_errors = true)
+        {
+            return call_helper(workitems, errors, throw_errors);
+        }
+
         template <typename T>
         static void call(std::vector<hpx::shared_future<T>> const& workitems,
             std::list<std::exception_ptr>& errors, bool throw_errors = true)
         {
+            return call_helper(workitems, errors, throw_errors);
+        }
+
+        template <typename T, std::size_t N>
+        static void call(std::array<hpx::shared_future<T>, N> const& workitems,
+            std::list<std::exception_ptr>& errors, bool throw_errors = true)
+        {
+            return call_helper(workitems, errors, throw_errors);
+        }
+
+        template <typename T>
+        static void call(std::vector<hpx::future<T>> const& workitems,
+            bool throw_errors = true)
+        {
+            return call_helper(workitems, throw_errors);
+        }
+
+        template <typename T, std::size_t N>
+        static void call(std::array<hpx::future<T>, N> const& workitems,
+            bool throw_errors = true)
+        {
+            return call_helper(workitems, throw_errors);
+        }
+
+        template <typename T>
+        static void call(std::vector<hpx::shared_future<T>> const& workitems,
+            bool throw_errors = true)
+        {
+            return call_helper(workitems, throw_errors);
+        }
+
+        template <typename T, std::size_t N>
+        static void call(std::array<hpx::shared_future<T>, N> const& workitems,
+            bool throw_errors = true)
+        {
+            return call_helper(workitems, throw_errors);
+        }
+
+    private:
+        template <typename Future>
+        static void call_with_cleanup_helper_single(Future const& f,
+            std::list<std::exception_ptr>& errors, bool throw_errors)
+        {
 #if defined(HPX_COMPUTE_DEVICE_CODE)
-            HPX_UNUSED(workitems);
+            HPX_UNUSED(f);
             HPX_UNUSED(errors);
             HPX_UNUSED(throw_errors);
             HPX_ASSERT(false);
 #else
-            if (workitems.empty() && errors.empty())
+            if (f.has_exception())
             {
-                return;
-            }
-
-            // first extract exception from all futures
-            std::vector<std::exception_ptr> exceptions;
-            exceptions.reserve(workitems.size());
-            for (auto const& f : workitems)
-            {
-                if (f.has_exception())
-                {
-                    exceptions.reserve(workitems.size());
-                    exceptions.push_back(f.get_exception_ptr());
-                }
-            }
-
-            // now handle exceptions as needed
-            for (auto& e : exceptions)
-            {
-                call(e, errors);
+                call(f.get_exception_ptr(), errors);
             }
 
             if (throw_errors && !errors.empty())
@@ -155,10 +319,50 @@ namespace hpx { namespace parallel { namespace util { namespace detail {
 #endif
         }
 
+        template <typename Future>
+        static void call_with_cleanup_helper_single(
+            Future const& f, bool throw_errors)
+        {
+#if defined(HPX_COMPUTE_DEVICE_CODE)
+            HPX_UNUSED(f);
+            HPX_UNUSED(throw_errors);
+            HPX_ASSERT(false);
+#else
+            if (f.has_exception())
+            {
+                std::list<std::exception_ptr> errors;
+                call(f.get_exception_ptr(), errors);
+                if (throw_errors && !errors.empty())
+                {
+                    throw exception_list(HPX_MOVE(errors));
+                }
+            }
+#endif
+        }
+
+    public:
         template <typename T, typename Cleanup>
-        static void call_with_cleanup(std::vector<hpx::future<T>>& workitems,
-            std::list<std::exception_ptr>& errors, Cleanup&& cleanup,
+        static void call_with_cleanup(hpx::future<T> const& f,
+            std::list<std::exception_ptr>& errors, Cleanup&&,
             bool throw_errors = true)
+        {
+            return call_with_cleanup_helper_single(f, errors, throw_errors);
+        }
+
+        template <typename T, typename Cleanup,
+            typename Enable = std::enable_if_t<!std::is_same_v<
+                std::decay_t<Cleanup>, std::list<std::exception_ptr>>>>
+        static void call_with_cleanup(
+            hpx::future<T> const& f, Cleanup&&, bool throw_errors = true)
+        {
+            return call_with_cleanup_helper_single(f, throw_errors);
+        }
+
+    private:
+        template <typename Cont, typename Cleanup>
+        static void call_with_cleanup_helper(Cont& workitems,
+            std::list<std::exception_ptr>& errors, Cleanup&& cleanup,
+            bool throw_errors)
         {
 #if defined(HPX_COMPUTE_DEVICE_CODE)
             HPX_UNUSED(workitems);
@@ -220,6 +424,131 @@ namespace hpx { namespace parallel { namespace util { namespace detail {
             }
 #endif
         }
+
+        template <typename Cont, typename Cleanup>
+        static void call_with_cleanup_helper(
+            Cont& workitems, Cleanup&& cleanup, bool throw_errors)
+        {
+#if defined(HPX_COMPUTE_DEVICE_CODE)
+            HPX_UNUSED(workitems);
+            HPX_UNUSED(cleanup);
+            HPX_UNUSED(throw_errors);
+            HPX_ASSERT(false);
+#else
+            if (workitems.empty())
+            {
+                return;
+            }
+
+            // first detect whether there are exceptional futures
+            bool found_exception = false;
+            for (auto const& f : workitems)
+            {
+                if (f.has_exception())
+                {
+                    found_exception = true;
+                    break;
+                }
+            }
+
+            // nothing needs to be done
+            if (!found_exception)
+            {
+                return;
+            }
+
+            // now, handle exceptions and cleanup partitions
+            std::list<std::exception_ptr> errors;
+            std::exception_ptr bad_alloc_exception;
+            for (auto& f : workitems)
+            {
+                if (f.has_exception())
+                {
+                    std::exception_ptr e = f.get_exception_ptr();
+                    bool store_exception = false;
+                    try
+                    {
+                        std::rethrow_exception(e);
+                    }
+                    catch (std::bad_alloc const&)
+                    {
+                        bad_alloc_exception = e;
+                    }
+                    catch (...)
+                    {
+                        store_exception = true;
+                    }
+
+                    // store the exception outside of the catch(...) block to
+                    // avoid problems caused by suspending threads
+                    if (store_exception)
+                    {
+                        errors.push_back(e);
+                    }
+                }
+            }
+
+            // As at least one partition failed with an exception, call
+            // the cleanup function for all others (the failed partitioned
+            // are assumed to have already run the cleanup).
+            for (auto& f : workitems)
+            {
+                if (!f.has_exception())
+                {
+                    cleanup(f.get());
+                }
+            }
+
+            if (bad_alloc_exception)
+            {
+                std::rethrow_exception(bad_alloc_exception);
+            }
+
+            if (throw_errors && !errors.empty())
+            {
+                throw exception_list(HPX_MOVE(errors));
+            }
+#endif
+        }
+
+    public:
+        template <typename T, typename Cleanup>
+        static void call_with_cleanup(std::vector<hpx::future<T>>& workitems,
+            std::list<std::exception_ptr>& errors, Cleanup&& cleanup,
+            bool throw_errors = true)
+        {
+            return call_with_cleanup_helper(
+                workitems, errors, HPX_FORWARD(Cleanup, cleanup), throw_errors);
+        }
+
+        template <typename T, std::size_t N, typename Cleanup>
+        static void call_with_cleanup(std::array<hpx::future<T>, N>& workitems,
+            std::list<std::exception_ptr>& errors, Cleanup&& cleanup,
+            bool throw_errors = true)
+        {
+            return call_with_cleanup_helper(
+                workitems, errors, HPX_FORWARD(Cleanup, cleanup), throw_errors);
+        }
+
+        template <typename T, typename Cleanup,
+            typename Enable = std::enable_if_t<!std::is_same_v<
+                std::decay_t<Cleanup>, std::list<std::exception_ptr>>>>
+        static void call_with_cleanup(std::vector<hpx::future<T>>& workitems,
+            Cleanup&& cleanup, bool throw_errors = true)
+        {
+            return call_with_cleanup_helper(
+                workitems, HPX_FORWARD(Cleanup, cleanup), throw_errors);
+        }
+
+        template <typename T, std::size_t N, typename Cleanup,
+            typename Enable = std::enable_if_t<!std::is_same_v<
+                std::decay_t<Cleanup>, std::list<std::exception_ptr>>>>
+        static void call_with_cleanup(std::array<hpx::future<T>, N>& workitems,
+            Cleanup&& cleanup, bool throw_errors = true)
+        {
+            return call_with_cleanup_helper(
+                workitems, HPX_FORWARD(Cleanup, cleanup), throw_errors);
+        }
     };
 
     template <>
@@ -227,9 +556,9 @@ namespace hpx { namespace parallel { namespace util { namespace detail {
     {
         ///////////////////////////////////////////////////////////////////////
 #if defined(HPX_COMPUTE_DEVICE_CODE)
-        static void call(std::exception_ptr const&)
+        [[noreturn]] static void call(std::exception_ptr const&)
         {
-            HPX_ASSERT(false);
+            std::terminate();
         }
 #else
         [[noreturn]] static void call(std::exception_ptr const&)
@@ -239,10 +568,10 @@ namespace hpx { namespace parallel { namespace util { namespace detail {
 #endif
 
 #if defined(HPX_COMPUTE_DEVICE_CODE)
-        static void call(
+        [[noreturn]] static void call(
             std::exception_ptr const&, std::list<std::exception_ptr>&)
         {
-            HPX_ASSERT(false);
+            std::terminate();
         }
 #else
         [[noreturn]] static void call(
@@ -252,9 +581,59 @@ namespace hpx { namespace parallel { namespace util { namespace detail {
         }
 #endif
 
+        static void call(std::list<std::exception_ptr>& errors)
+        {
+            if (!errors.empty())
+            {
+                parallel_exception_termination_handler();
+            }
+        }
+
+    private:
+        template <typename Future>
+        static void call_helper_single(Future const& f)
+        {
+#if defined(HPX_COMPUTE_DEVICE_CODE)
+            HPX_UNUSED(f);
+            HPX_ASSERT(false);
+#else
+            if (f.has_exception())
+            {
+                parallel_exception_termination_handler();
+            }
+#endif
+        }
+
+    public:
         template <typename T>
-        static void call(std::vector<hpx::future<T>> const& workitems,
+        static void call(hpx::future<T> const& f,
             std::list<std::exception_ptr>&, bool = true)
+        {
+            return call_helper_single(f);
+        }
+
+        template <typename T>
+        static void call(hpx::shared_future<T> const& f,
+            std::list<std::exception_ptr>&, bool = true)
+        {
+            return call_helper_single(f);
+        }
+
+        template <typename T>
+        static void call(hpx::future<T> const& f, bool = true)
+        {
+            return call_helper_single(f);
+        }
+
+        template <typename T>
+        static void call(hpx::shared_future<T> const& f, bool = true)
+        {
+            return call_helper_single(f);
+        }
+
+    private:
+        template <typename Cont>
+        static void call_helper(Cont const& workitems)
         {
 #if defined(HPX_COMPUTE_DEVICE_CODE)
             HPX_UNUSED(workitems);
@@ -268,12 +647,101 @@ namespace hpx { namespace parallel { namespace util { namespace detail {
                 }
             }
 #endif
+        }
+
+    public:
+        template <typename T>
+        static void call(std::vector<hpx::future<T>> const& workitems,
+            std::list<std::exception_ptr>&, bool = true)
+        {
+            return call_helper(workitems);
+        }
+
+        template <typename T, std::size_t N>
+        static void call(std::array<hpx::future<T>, N> const& workitems,
+            std::list<std::exception_ptr>&, bool = true)
+        {
+            return call_helper(workitems);
         }
 
         template <typename T>
         static void call(std::vector<hpx::shared_future<T>> const& workitems,
             std::list<std::exception_ptr>&, bool = true)
         {
+            return call_helper(workitems);
+        }
+
+        template <typename T, std::size_t N>
+        static void call(std::array<hpx::shared_future<T>, N> const& workitems,
+            std::list<std::exception_ptr>&, bool = true)
+        {
+            return call_helper(workitems);
+        }
+
+        template <typename T>
+        static void call(
+            std::vector<hpx::future<T>> const& workitems, bool = true)
+        {
+            return call_helper(workitems);
+        }
+
+        template <typename T, std::size_t N>
+        static void call(
+            std::array<hpx::future<T>, N> const& workitems, bool = true)
+        {
+            return call_helper(workitems);
+        }
+
+        template <typename T>
+        static void call(
+            std::vector<hpx::shared_future<T>> const& workitems, bool = true)
+        {
+            return call_helper(workitems);
+        }
+
+        template <typename T, std::size_t N>
+        static void call(
+            std::array<hpx::shared_future<T>, N> const& workitems, bool = true)
+        {
+            return call_helper(workitems);
+        }
+
+    private:
+        template <typename Future>
+        static void call_with_cleanup_helper_single(Future const& f)
+        {
+#if defined(HPX_COMPUTE_DEVICE_CODE)
+            HPX_UNUSED(f);
+            HPX_ASSERT(false);
+#else
+            if (f.has_exception())
+            {
+                parallel_exception_termination_handler();
+            }
+#endif
+        }
+
+    public:
+        template <typename T, typename Cleanup>
+        static void call_with_cleanup(hpx::future<T> const& f,
+            std::list<std::exception_ptr>&, Cleanup&&, bool = true)
+        {
+            call_with_cleanup_helper_single(f);
+        }
+
+        template <typename T, typename Cleanup,
+            typename Enable = std::enable_if_t<!std::is_same_v<
+                std::decay_t<Cleanup>, std::list<std::exception_ptr>>>>
+        static void call_with_cleanup(
+            hpx::future<T> const& f, Cleanup&&, bool = true)
+        {
+            call_with_cleanup_helper_single(f);
+        }
+
+    private:
+        template <typename Cont>
+        static void call_with_cleanup_helper(Cont const& workitems)
+        {
 #if defined(HPX_COMPUTE_DEVICE_CODE)
             HPX_UNUSED(workitems);
             HPX_ASSERT(false);
@@ -288,109 +756,47 @@ namespace hpx { namespace parallel { namespace util { namespace detail {
 #endif
         }
 
+    public:
         template <typename T, typename Cleanup>
         static void call_with_cleanup(
             std::vector<hpx::future<T>> const& workitems,
             std::list<std::exception_ptr>&, Cleanup&&, bool = true)
         {
-#if defined(HPX_COMPUTE_DEVICE_CODE)
-            HPX_UNUSED(workitems);
-            HPX_ASSERT(false);
-#else
-            for (auto const& f : workitems)
-            {
-                if (f.has_exception())
-                {
-                    parallel_exception_termination_handler();
-                }
-            }
-#endif
+            call_with_cleanup_helper(workitems);
+        }
+
+        template <typename T, std::size_t N, typename Cleanup>
+        static void call_with_cleanup(
+            std::array<hpx::future<T>, N> const& workitems,
+            std::list<std::exception_ptr>&, Cleanup&&, bool = true)
+        {
+            call_with_cleanup_helper(workitems);
+        }
+
+        template <typename T, typename Cleanup,
+            typename Enable = std::enable_if_t<!std::is_same_v<
+                std::decay_t<Cleanup>, std::list<std::exception_ptr>>>>
+        static void call_with_cleanup(
+            std::vector<hpx::future<T>> const& workitems, Cleanup&&,
+            bool = true)
+        {
+            call_with_cleanup_helper(workitems);
+        }
+
+        template <typename T, std::size_t N, typename Cleanup,
+            typename Enable = std::enable_if_t<!std::is_same_v<
+                std::decay_t<Cleanup>, std::list<std::exception_ptr>>>>
+        static void call_with_cleanup(
+            std::array<hpx::future<T>, N> const& workitems, Cleanup&&,
+            bool = true)
+        {
+            call_with_cleanup_helper(workitems);
         }
     };
 
     template <>
     struct handle_local_exceptions<hpx::execution::unsequenced_policy>
+      : handle_local_exceptions<hpx::execution::parallel_unsequenced_policy>
     {
-        ///////////////////////////////////////////////////////////////////////
-#if defined(HPX_COMPUTE_DEVICE_CODE)
-        static void call(std::exception_ptr const&)
-        {
-            HPX_ASSERT(false);
-        }
-#else
-        [[noreturn]] static void call(std::exception_ptr const&)
-        {
-            parallel_exception_termination_handler();
-        }
-#endif
-
-#if defined(HPX_COMPUTE_DEVICE_CODE)
-        static void call(
-            std::exception_ptr const&, std::list<std::exception_ptr>&)
-        {
-            HPX_ASSERT(false);
-        }
-#else
-        [[noreturn]] static void call(
-            std::exception_ptr const&, std::list<std::exception_ptr>&)
-        {
-            parallel_exception_termination_handler();
-        }
-#endif
-
-        template <typename T>
-        static void call(std::vector<hpx::future<T>> const& workitems,
-            std::list<std::exception_ptr>&, bool = true)
-        {
-#if defined(HPX_COMPUTE_DEVICE_CODE)
-            HPX_UNUSED(workitems);
-            HPX_ASSERT(false);
-#else
-            for (auto const& f : workitems)
-            {
-                if (f.has_exception())
-                {
-                    parallel_exception_termination_handler();
-                }
-            }
-#endif
-        }
-
-        template <typename T>
-        static void call(std::vector<hpx::shared_future<T>> const& workitems,
-            std::list<std::exception_ptr>&, bool = true)
-        {
-#if defined(HPX_COMPUTE_DEVICE_CODE)
-            HPX_UNUSED(workitems);
-            HPX_ASSERT(false);
-#else
-            for (auto const& f : workitems)
-            {
-                if (f.has_exception())
-                {
-                    parallel_exception_termination_handler();
-                }
-            }
-#endif
-        }
-
-        template <typename T, typename Cleanup>
-        static void call_with_cleanup(
-            std::vector<hpx::future<T>> const& workitems,
-            std::list<std::exception_ptr>&, Cleanup&&, bool = true)
-        {
-#if defined(HPX_COMPUTE_DEVICE_CODE)
-            HPX_UNUSED(workitems);
-            HPX_ASSERT(false);
-#else
-            for (auto const& f : workitems)
-            {
-                if (f.has_exception())
-                {
-                    parallel_exception_termination_handler();
-                }
-            }
-#endif
-        }
     };
 }}}}    // namespace hpx::parallel::util::detail

--- a/libs/core/algorithms/include/hpx/parallel/util/detail/partitioner_iteration.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/util/detail/partitioner_iteration.hpp
@@ -20,7 +20,7 @@ namespace hpx { namespace parallel { namespace util { namespace detail {
     template <typename Result, typename F>
     struct partitioner_iteration
     {
-        typename std::decay<F>::type f_;
+        std::decay_t<F> f_;
 
         template <typename T>
         HPX_HOST_DEVICE HPX_FORCEINLINE Result operator()(T&& t)
@@ -43,8 +43,7 @@ namespace hpx { namespace traits {
             parallel::util::detail::partitioner_iteration<Result, F> const&
                 f) noexcept
         {
-            return get_function_address<typename std::decay<F>::type>::call(
-                f.f_);
+            return get_function_address<std::decay_t<F>>::call(f.f_);
         }
     };
 
@@ -56,8 +55,7 @@ namespace hpx { namespace traits {
             parallel::util::detail::partitioner_iteration<Result, F> const&
                 f) noexcept
         {
-            return get_function_annotation<typename std::decay<F>::type>::call(
-                f.f_);
+            return get_function_annotation<std::decay_t<F>>::call(f.f_);
         }
     };
 
@@ -70,8 +68,7 @@ namespace hpx { namespace traits {
             parallel::util::detail::partitioner_iteration<Result, F> const&
                 f) noexcept
         {
-            return get_function_annotation_itt<
-                typename std::decay<F>::type>::call(f.f_);
+            return get_function_annotation_itt<std::decay_t<F>>::call(f.f_);
         }
     };
 #endif

--- a/libs/core/algorithms/include/hpx/parallel/util/foreach_partitioner.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/util/foreach_partitioner.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2018 Hartmut Kaiser
+//  Copyright (c) 2007-2022 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -18,6 +18,7 @@
 #include <hpx/execution/algorithms/detail/predicates.hpp>
 #include <hpx/execution/executors/execution.hpp>
 #include <hpx/execution/executors/execution_parameters.hpp>
+#include <hpx/execution_base/traits/is_executor_parameters.hpp>
 #include <hpx/executors/execution_policy.hpp>
 #include <hpx/parallel/util/detail/chunk_size.hpp>
 #include <hpx/parallel/util/detail/handle_local_exceptions.hpp>
@@ -39,28 +40,52 @@ namespace hpx { namespace parallel { namespace util {
     namespace detail {
         template <typename Result, typename ExPolicy, typename FwdIter,
             typename F>
-        std::pair<std::vector<hpx::future<Result>>,
-            std::vector<hpx::future<Result>>>
-        foreach_partition(
+        auto foreach_partition(
             ExPolicy&& policy, FwdIter first, std::size_t count, F&& f)
         {
             // estimate a chunk size based on number of cores used
-            using parameters_type =
-                typename std::decay<ExPolicy>::type::executor_parameters_type;
-            using has_variable_chunk_size =
-                typename execution::extract_has_variable_chunk_size<
-                    parameters_type>::type;
+            using parameters_type = execution::extract_executor_parameters_t<
+                std::decay_t<ExPolicy>>;
+            constexpr bool has_variable_chunk_size =
+                execution::extract_has_variable_chunk_size_v<parameters_type>;
+            constexpr bool invokes_testing_function =
+                execution::extract_invokes_testing_function_v<parameters_type>;
 
-            std::vector<hpx::future<Result>> inititems;
-            auto shape = detail::get_bulk_iteration_shape_idx(
-                has_variable_chunk_size{}, HPX_FORWARD(ExPolicy, policy),
-                inititems, f, first, count, 1);
+            if constexpr (has_variable_chunk_size)
+            {
+                static_assert(!invokes_testing_function,
+                    "parameters object should not expose both, "
+                    "has_variable_chunk_size and invokes_testing_function");
 
-            std::vector<hpx::future<Result>> workitems =
-                execution::bulk_async_execute(policy.executor(),
+                auto&& shape = detail::get_bulk_iteration_shape_idx_variable(
+                    HPX_FORWARD(ExPolicy, policy), first, count);
+
+                return execution::bulk_async_execute(policy.executor(),
                     partitioner_iteration<Result, F>{HPX_FORWARD(F, f)},
                     HPX_MOVE(shape));
-            return std::make_pair(HPX_MOVE(inititems), HPX_MOVE(workitems));
+            }
+            else if constexpr (!invokes_testing_function)
+            {
+                auto&& shape = detail::get_bulk_iteration_shape_idx(
+                    HPX_FORWARD(ExPolicy, policy), first, count);
+
+                return execution::bulk_async_execute(policy.executor(),
+                    partitioner_iteration<Result, F>{HPX_FORWARD(F, f)},
+                    HPX_MOVE(shape));
+            }
+            else
+            {
+                std::vector<hpx::future<Result>> inititems;
+                auto&& shape = detail::get_bulk_iteration_shape_idx(
+                    HPX_FORWARD(ExPolicy, policy), inititems, f, first, count);
+
+                auto&& workitems =
+                    execution::bulk_async_execute(policy.executor(),
+                        partitioner_iteration<Result, F>{HPX_FORWARD(F, f)},
+                        HPX_MOVE(shape));
+
+                return std::make_pair(HPX_MOVE(inititems), HPX_MOVE(workitems));
+            }
         }
 
         ///////////////////////////////////////////////////////////////////////
@@ -89,53 +114,50 @@ namespace hpx { namespace parallel { namespace util {
                     policy.parameters(), policy.executor());
 
                 FwdIter last = parallel::v1::detail::next(first, count);
-
-                std::vector<hpx::future<Result>> inititems, workitems;
-                std::list<std::exception_ptr> errors;
                 try
                 {
-                    std::tie(inititems, workitems) =
-                        detail::foreach_partition<Result>(
-                            HPX_FORWARD(ExPolicy_, policy), first, count,
-                            HPX_FORWARD(F1, f1));
+                    auto&& items = detail::foreach_partition<Result>(
+                        HPX_FORWARD(ExPolicy_, policy), first, count,
+                        HPX_FORWARD(F1, f1));
 
                     scoped_params.mark_end_of_scheduling();
+
+                    return reduce(
+                        HPX_MOVE(items), HPX_FORWARD(F2, f2), HPX_MOVE(last));
                 }
                 catch (...)
                 {
-                    handle_local_exceptions::call(
-                        std::current_exception(), errors);
+                    handle_local_exceptions::call(std::current_exception());
                 }
-                return reduce(HPX_MOVE(inititems), HPX_MOVE(workitems),
-                    HPX_MOVE(errors), HPX_FORWARD(F2, f2), HPX_MOVE(last));
             }
 
         private:
-            template <typename F, typename FwdIter>
-            static FwdIter reduce(std::vector<hpx::future<Result>>&& inititems,
-                std::vector<hpx::future<Result>>&& workitems,
-                std::list<std::exception_ptr>&& errors, F&& f, FwdIter last)
+            template <typename F, typename Items1, typename Items2,
+                typename FwdIter>
+            static FwdIter reduce(
+                std::pair<Items1, Items2>&& items, F&& f, FwdIter last)
             {
                 // wait for all tasks to finish
-                hpx::wait_all_nothrow(workitems);
+                hpx::wait_all_nothrow(hpx::get<0>(items), hpx::get<1>(items));
 
-                // always rethrow if 'errors' is not empty or workitems has
+                // always rethrow if inititems/workitems have at least one
                 // exceptional future
-                handle_local_exceptions::call(inititems, errors);
-                handle_local_exceptions::call(workitems, errors);
+                handle_local_exceptions::call(hpx::get<0>(items));
+                handle_local_exceptions::call(hpx::get<1>(items));
 
-                try
-                {
-                    return f(HPX_MOVE(last));
-                }
-                catch (...)
-                {
-                    // rethrow either bad_alloc or exception_list
-                    handle_local_exceptions::call(std::current_exception());
-                }
+                return f(HPX_MOVE(last));
+            }
 
-                HPX_ASSERT(false);
-                return last;
+            template <typename F, typename Items, typename FwdIter>
+            static FwdIter reduce(Items&& items, F&& f, FwdIter last)
+            {
+                // wait for all tasks to finish
+                hpx::wait_all_nothrow(items);
+
+                // always rethrow if items has at least one exceptional future
+                handle_local_exceptions::call(items);
+
+                return f(HPX_MOVE(last));
             }
         };
 
@@ -164,46 +186,34 @@ namespace hpx { namespace parallel { namespace util {
                         policy.parameters(), policy.executor());
 
                 FwdIter last = parallel::v1::detail::next(first, count);
-
-                std::vector<hpx::future<Result>> inititems, workitems;
-                std::list<std::exception_ptr> errors;
                 try
                 {
-                    std::tie(inititems, workitems) =
-                        detail::foreach_partition<Result>(
-                            HPX_FORWARD(ExPolicy_, policy), first, count,
-                            HPX_FORWARD(F1, f1));
+                    auto&& items = detail::foreach_partition<Result>(
+                        HPX_FORWARD(ExPolicy_, policy), first, count,
+                        HPX_FORWARD(F1, f1));
 
                     scoped_params->mark_end_of_scheduling();
+
+                    return reduce(HPX_MOVE(scoped_params), HPX_MOVE(items),
+                        HPX_FORWARD(F2, f2), HPX_MOVE(last));
                 }
-                catch (std::bad_alloc const&)
+                catch (...)
                 {
                     return hpx::make_exceptional_future<FwdIter>(
                         std::current_exception());
                 }
-                catch (...)
-                {
-                    handle_local_exceptions::call(
-                        std::current_exception(), errors);
-                }
-                return reduce(HPX_MOVE(scoped_params), HPX_MOVE(inititems),
-                    HPX_MOVE(workitems), HPX_MOVE(errors), HPX_FORWARD(F2, f2),
-                    HPX_MOVE(last));
             }
 
         private:
-            template <typename F, typename FwdIter>
+            template <typename F, typename Items1, typename Items2,
+                typename FwdIter>
             static hpx::future<FwdIter> reduce(
                 std::shared_ptr<scoped_executor_parameters>&& scoped_params,
-                std::vector<hpx::future<Result>>&& inititems,
-                std::vector<hpx::future<Result>>&& workitems,
-                std::list<std::exception_ptr>&& errors, F&& f, FwdIter last)
+                std::pair<Items1, Items2>&& items, F&& f, FwdIter last)
             {
 #if defined(HPX_COMPUTE_DEVICE_CODE)
                 HPX_UNUSED(scoped_params);
-                HPX_UNUSED(inititems);
-                HPX_UNUSED(workitems);
-                HPX_UNUSED(errors);
+                HPX_UNUSED(items);
                 HPX_UNUSED(f);
                 HPX_UNUSED(last);
                 HPX_ASSERT(false);
@@ -218,19 +228,51 @@ namespace hpx { namespace parallel { namespace util {
                 //       out of scope.
                 return hpx::dataflow(
                     hpx::launch::sync,
-                    [last, errors = HPX_MOVE(errors),
-                        scoped_params = HPX_MOVE(scoped_params),
+                    [last, scoped_params = HPX_MOVE(scoped_params),
                         f = HPX_FORWARD(F, f)](
-                        std::vector<hpx::future<Result>> r1,
-                        std::vector<hpx::future<Result>> r2) mutable
-                    -> FwdIter {
+                        auto&& r1, auto&& r2) mutable -> FwdIter {
                         HPX_UNUSED(scoped_params);
 
-                        handle_local_exceptions::call(r1, errors);
-                        handle_local_exceptions::call(r2, errors);
+                        handle_local_exceptions::call(r1);
+                        handle_local_exceptions::call(r2);
+
                         return f(HPX_MOVE(last));
                     },
-                    HPX_MOVE(inititems), HPX_MOVE(workitems));
+                    HPX_MOVE(hpx::get<0>(items)), HPX_MOVE(hpx::get<1>(items)));
+#endif
+            }
+
+            template <typename F, typename Items, typename FwdIter>
+            static hpx::future<FwdIter> reduce(
+                std::shared_ptr<scoped_executor_parameters>&& scoped_params,
+                Items&& items, F&& f, FwdIter last)
+            {
+#if defined(HPX_COMPUTE_DEVICE_CODE)
+                HPX_UNUSED(scoped_params);
+                HPX_UNUSED(items);
+                HPX_UNUSED(f);
+                HPX_UNUSED(last);
+                HPX_ASSERT(false);
+                return hpx::future<FwdIter>();
+#else
+                // wait for all tasks to finish
+                // Note: the lambda takes the vectors by value (dataflow
+                //       moves those into the lambda) to ensure that they
+                //       will be destroyed before the lambda exists.
+                //       Otherwise the vectors stay alive in the dataflow's
+                //       shared state and may reference data that has gone
+                //       out of scope.
+                return hpx::dataflow(
+                    hpx::launch::sync,
+                    [last, scoped_params = HPX_MOVE(scoped_params),
+                        f = HPX_FORWARD(F, f)](auto&& r) mutable -> FwdIter {
+                        HPX_UNUSED(scoped_params);
+
+                        handle_local_exceptions::call(r);
+
+                        return f(HPX_MOVE(last));
+                    },
+                    HPX_MOVE(items));
 #endif
             }
         };
@@ -241,7 +283,7 @@ namespace hpx { namespace parallel { namespace util {
     // Result:   intermediate result type of first step (default: void)
     template <typename ExPolicy, typename Result = void>
     struct foreach_partitioner
-      : detail::select_partitioner<typename std::decay<ExPolicy>::type,
+      : detail::select_partitioner<std::decay_t<ExPolicy>,
             detail::foreach_static_partitioner,
             detail::foreach_task_static_partitioner>::template apply<Result>
     {

--- a/libs/core/algorithms/include/hpx/parallel/util/invoke_projected.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/util/invoke_projected.hpp
@@ -18,14 +18,14 @@ namespace hpx { namespace parallel { namespace util {
     template <typename Pred, typename Proj>
     struct invoke_projected
     {
-        using pred_type = typename std::decay<Pred>::type;
-        using proj_type = typename std::decay<Proj>::type;
+        using pred_type = std::decay_t<Pred>;
+        using proj_type = std::decay_t<Proj>;
 
         pred_type pred_;
         proj_type proj_;
 
         template <typename Pred_, typename Proj_>
-        invoke_projected(Pred_&& pred, Proj_&& proj)
+        constexpr invoke_projected(Pred_&& pred, Proj_&& proj)
           : pred_(HPX_FORWARD(Pred_, pred))
           , proj_(HPX_FORWARD(Proj_, proj))
         {
@@ -48,12 +48,12 @@ namespace hpx { namespace parallel { namespace util {
     template <typename Pred>
     struct invoke_projected<Pred, projection_identity>
     {
-        using pred_type = typename std::decay<Pred>::type;
+        using pred_type = std::decay_t<Pred>;
 
         pred_type pred_;
 
         template <typename Pred_>
-        invoke_projected(Pred_&& pred, projection_identity)
+        constexpr invoke_projected(Pred_&& pred, projection_identity)
           : pred_(HPX_FORWARD(Pred_, pred))
         {
         }
@@ -65,7 +65,7 @@ namespace hpx { namespace parallel { namespace util {
         }
 
         template <typename T>
-        auto operator()(T&& t, T&& u)
+        decltype(auto) operator()(T&& t, T&& u)
         {
             return HPX_INVOKE(pred_, HPX_FORWARD(T, t), HPX_FORWARD(T, u));
         }

--- a/libs/core/algorithms/include/hpx/parallel/util/partitioner.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/util/partitioner.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2018 Hartmut Kaiser
+//  Copyright (c) 2007-2022 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -8,10 +8,10 @@
 
 #include <hpx/config.hpp>
 #include <hpx/assert.hpp>
+#include <hpx/async_combinators/wait_all.hpp>
 #if !defined(HPX_COMPUTE_DEVICE_CODE)
 #include <hpx/async_local/dataflow.hpp>
 #endif
-#include <hpx/async_combinators/wait_all.hpp>
 #include <hpx/datastructures/tuple.hpp>
 #include <hpx/iterator_support/range.hpp>
 #include <hpx/modules/errors.hpp>
@@ -20,6 +20,7 @@
 
 #include <hpx/execution/executors/execution.hpp>
 #include <hpx/execution/executors/execution_parameters.hpp>
+#include <hpx/execution_base/traits/is_executor_parameters.hpp>
 #include <hpx/executors/execution_policy.hpp>
 #include <hpx/parallel/util/detail/chunk_size.hpp>
 #include <hpx/parallel/util/detail/handle_local_exceptions.hpp>
@@ -42,66 +43,103 @@ namespace hpx { namespace parallel { namespace util {
     namespace detail {
         template <typename Result, typename ExPolicy, typename FwdIter,
             typename F>
-        std::vector<hpx::future<Result>> partition(
+        auto partition(
             ExPolicy&& policy, FwdIter first, std::size_t count, F&& f)
         {
             // estimate a chunk size based on number of cores used
-            using parameters_type =
-                typename std::decay<ExPolicy>::type::executor_parameters_type;
-            using has_variable_chunk_size =
-                typename execution::extract_has_variable_chunk_size<
-                    parameters_type>::type;
+            using parameters_type = execution::extract_executor_parameters_t<
+                std::decay_t<ExPolicy>>;
+            constexpr bool has_variable_chunk_size =
+                execution::extract_has_variable_chunk_size_v<parameters_type>;
+            constexpr bool invokes_testing_function =
+                execution::extract_invokes_testing_function_v<parameters_type>;
 
-            std::vector<hpx::future<Result>> inititems;
-            auto shape = detail::get_bulk_iteration_shape(
-                has_variable_chunk_size{}, HPX_FORWARD(ExPolicy, policy),
-                inititems, f, first, count, 1);
+            if constexpr (has_variable_chunk_size)
+            {
+                static_assert(!invokes_testing_function,
+                    "parameters object should not expose both, "
+                    "has_variable_chunk_size and invokes_testing_function");
 
-            std::vector<hpx::future<Result>> workitems =
-                execution::bulk_async_execute(policy.executor(),
+                auto&& shape = detail::get_bulk_iteration_shape_variable(
+                    HPX_FORWARD(ExPolicy, policy), first, count);
+
+                return execution::bulk_async_execute(policy.executor(),
                     partitioner_iteration<Result, F>{HPX_FORWARD(F, f)},
                     HPX_MOVE(shape));
+            }
+            else if constexpr (!invokes_testing_function)
+            {
+                auto&& shape = detail::get_bulk_iteration_shape(
+                    HPX_FORWARD(ExPolicy, policy), first, count);
 
-            if (inititems.empty())
-                return workitems;
+                return execution::bulk_async_execute(policy.executor(),
+                    partitioner_iteration<Result, F>{HPX_FORWARD(F, f)},
+                    HPX_MOVE(shape));
+            }
+            else
+            {
+                std::vector<hpx::future<Result>> inititems;
+                auto&& shape = detail::get_bulk_iteration_shape(
+                    HPX_FORWARD(ExPolicy, policy), inititems, f, first, count);
 
-            // add the newly created workitems to the list
-            inititems.insert(inititems.end(),
-                std::make_move_iterator(workitems.begin()),
-                std::make_move_iterator(workitems.end()));
-            return inititems;
+                auto&& workitems =
+                    execution::bulk_async_execute(policy.executor(),
+                        partitioner_iteration<Result, F>{HPX_FORWARD(F, f)},
+                        HPX_MOVE(shape));
+
+                return std::make_pair(HPX_MOVE(inititems), HPX_MOVE(workitems));
+            }
         }
 
         template <typename Result, typename ExPolicy, typename FwdIter,
             typename Stride, typename F>
-        std::vector<hpx::future<Result>> partition_with_index(ExPolicy&& policy,
-            FwdIter first, std::size_t count, Stride stride, F&& f)
+        auto partition_with_index(ExPolicy&& policy, FwdIter first,
+            std::size_t count, Stride stride, F&& f)
         {
             // estimate a chunk size based on number of cores used
-            using parameters_type =
-                typename std::decay<ExPolicy>::type::executor_parameters_type;
-            using has_variable_chunk_size =
-                typename execution::extract_has_variable_chunk_size<
-                    parameters_type>::type;
+            using parameters_type = execution::extract_executor_parameters_t<
+                std::decay_t<ExPolicy>>;
+            constexpr bool has_variable_chunk_size =
+                execution::extract_has_variable_chunk_size_v<parameters_type>;
+            constexpr bool invokes_testing_function =
+                execution::extract_invokes_testing_function_v<parameters_type>;
 
-            std::vector<hpx::future<Result>> inititems;
-            auto shape = detail::get_bulk_iteration_shape_idx(
-                has_variable_chunk_size{}, HPX_FORWARD(ExPolicy, policy),
-                inititems, f, first, count, stride);
+            if constexpr (has_variable_chunk_size)
+            {
+                static_assert(!invokes_testing_function,
+                    "parameters object should not expose both, "
+                    "has_variable_chunk_size and invokes_testing_function");
 
-            std::vector<hpx::future<Result>> workitems =
-                execution::bulk_async_execute(policy.executor(),
+                auto&& shape = detail::get_bulk_iteration_shape_idx_variable(
+                    HPX_FORWARD(ExPolicy, policy), first, count, stride);
+
+                return execution::bulk_async_execute(policy.executor(),
                     partitioner_iteration<Result, F>{HPX_FORWARD(F, f)},
                     HPX_MOVE(shape));
+            }
+            else if constexpr (!invokes_testing_function)
+            {
+                auto&& shape = detail::get_bulk_iteration_shape_idx(
+                    HPX_FORWARD(ExPolicy, policy), first, count, stride);
 
-            if (inititems.empty())
-                return workitems;
+                return execution::bulk_async_execute(policy.executor(),
+                    partitioner_iteration<Result, F>{HPX_FORWARD(F, f)},
+                    HPX_MOVE(shape));
+            }
+            else
+            {
+                std::vector<hpx::future<Result>> inititems;
+                auto&& shape = detail::get_bulk_iteration_shape_idx(
+                    HPX_FORWARD(ExPolicy, policy), inititems, f, first, count,
+                    stride);
 
-            // add the newly created workitems to the list
-            inititems.insert(inititems.end(),
-                std::make_move_iterator(workitems.begin()),
-                std::make_move_iterator(workitems.end()));
-            return inititems;
+                auto&& workitems =
+                    execution::bulk_async_execute(policy.executor(),
+                        partitioner_iteration<Result, F>{HPX_FORWARD(F, f)},
+                        HPX_MOVE(shape));
+
+                return std::make_pair(HPX_MOVE(inititems), HPX_MOVE(workitems));
+            }
         }
 
         template <typename Result, typename ExPolicy, typename FwdIter,
@@ -113,15 +151,12 @@ namespace hpx { namespace parallel { namespace util {
         {
             HPX_ASSERT(hpx::util::size(data) >= hpx::util::size(chunk_sizes));
 
-            typedef typename std::decay<Data>::type data_type;
+            auto data_it = hpx::util::begin(data);
+            auto chunk_size_it = hpx::util::begin(chunk_sizes);
 
-            typename data_type::const_iterator data_it = hpx::util::begin(data);
-            typename std::vector<std::size_t>::const_iterator chunk_size_it =
-                hpx::util::begin(chunk_sizes);
-
-            typedef typename hpx::tuple<typename data_type::value_type, FwdIter,
-                std::size_t>
-                tuple_type;
+            using data_type = std::decay_t<Data>;
+            using tuple_type = hpx::tuple<typename data_type::value_type,
+                FwdIter, std::size_t>;
 
             // schedule every chunk on a separate thread
             std::vector<tuple_type> shape;
@@ -172,23 +207,21 @@ namespace hpx { namespace parallel { namespace util {
                 scoped_executor_parameters scoped_params(
                     policy.parameters(), policy.executor());
 
-                std::vector<hpx::future<Result>> workitems;
                 std::list<std::exception_ptr> errors;
                 try
                 {
-                    workitems = detail::partition<Result>(
+                    auto&& items = detail::partition<Result>(
                         HPX_FORWARD(ExPolicy_, policy), first, count,
                         HPX_FORWARD(F1, f1));
 
                     scoped_params.mark_end_of_scheduling();
+
+                    return reduce(HPX_MOVE(items), HPX_FORWARD(F2, f2));
                 }
                 catch (...)
                 {
-                    handle_local_exceptions::call(
-                        std::current_exception(), errors);
+                    handle_local_exceptions::call(std::current_exception());
                 }
-                return reduce(
-                    HPX_MOVE(workitems), HPX_MOVE(errors), HPX_FORWARD(F2, f2));
             }
 
             template <typename ExPolicy_, typename FwdIter, typename Stride,
@@ -200,23 +233,21 @@ namespace hpx { namespace parallel { namespace util {
                 scoped_executor_parameters scoped_params(
                     policy.parameters(), policy.executor());
 
-                std::vector<hpx::future<Result>> workitems;
                 std::list<std::exception_ptr> errors;
                 try
                 {
-                    workitems = detail::partition_with_index<Result>(
+                    auto&& items = detail::partition_with_index<Result>(
                         HPX_FORWARD(ExPolicy_, policy), first, count, stride,
                         HPX_FORWARD(F1, f1));
 
                     scoped_params.mark_end_of_scheduling();
+
+                    return reduce(HPX_MOVE(items), HPX_FORWARD(F2, f2));
                 }
                 catch (...)
                 {
-                    handle_local_exceptions::call(
-                        std::current_exception(), errors);
+                    handle_local_exceptions::call(std::current_exception());
                 }
-                return reduce(
-                    HPX_MOVE(workitems), HPX_MOVE(errors), HPX_FORWARD(F2, f2));
             }
 
             template <typename ExPolicy_, typename FwdIter, typename F1,
@@ -230,61 +261,58 @@ namespace hpx { namespace parallel { namespace util {
                 scoped_executor_parameters scoped_params(
                     policy.parameters(), policy.executor());
 
-                std::vector<hpx::future<Result>> workitems;
-                std::list<std::exception_ptr> errors;
                 try
                 {
-                    workitems = detail::partition_with_data<Result>(
+                    auto&& items = detail::partition_with_data<Result>(
                         HPX_FORWARD(ExPolicy_, policy), first, count,
                         chunk_sizes, HPX_FORWARD(Data, data),
                         HPX_FORWARD(F1, f1));
 
                     scoped_params.mark_end_of_scheduling();
+
+                    return reduce(HPX_MOVE(items), HPX_FORWARD(F2, f2));
                 }
                 catch (...)
                 {
-                    handle_local_exceptions::call(
-                        std::current_exception(), errors);
+                    handle_local_exceptions::call(std::current_exception());
                 }
-                return reduce(
-                    HPX_MOVE(workitems), HPX_MOVE(errors), HPX_FORWARD(F2, f2));
             }
 
         private:
-            template <typename F>
-            static R reduce(std::vector<hpx::future<Result>>&& workitems,
-                std::list<std::exception_ptr>&& errors, F&& f)
+            template <typename Items, typename F>
+            static R reduce(Items&& workitems, F&& f)
             {
                 // wait for all tasks to finish
                 hpx::wait_all_nothrow(workitems);
 
-                // always rethrow if 'errors' is not empty or workitems has
-                // exceptional future
-                handle_local_exceptions::call(workitems, errors);
+                // always rethrow workitems has at least one exceptional future
+                handle_local_exceptions::call(workitems);
 
-                try
-                {
-                    return f(HPX_MOVE(workitems));
-                }
-                catch (...)
-                {
-                    // rethrow either bad_alloc or exception_list
-                    handle_local_exceptions::call(std::current_exception());
-                    HPX_ASSERT(false);
-                    return f(HPX_MOVE(workitems));
-                }
+                return f(HPX_MOVE(workitems));
             }
 
-            static R reduce(std::vector<hpx::future<Result>>&& workitems,
-                std::list<std::exception_ptr>&& errors,
-                hpx::util::empty_function)
+            template <typename Items>
+            static void reduce(Items&& workitems, hpx::util::empty_function)
             {
                 // wait for all tasks to finish
                 hpx::wait_all_nothrow(workitems);
 
-                // always rethrow if 'errors' is not empty or workitems has
-                // exceptional future
-                handle_local_exceptions::call(workitems, errors);
+                // always rethrow workitems has at least one exceptional future
+                handle_local_exceptions::call(workitems);
+            }
+
+            template <typename Items1, typename Items2, typename F>
+            static R reduce(std::pair<Items1, Items2>&& items, F&& f)
+            {
+                if (items.first.empty())
+                {
+                    return reduce(HPX_MOVE(items.second), HPX_FORWARD(F, f));
+                }
+
+                items.first.insert(items.first.end(),
+                    std::make_move_iterator(items.second.begin()),
+                    std::make_move_iterator(items.second.end()));
+                return reduce(HPX_MOVE(items.first), HPX_FORWARD(F, f));
             }
         };
 
@@ -312,28 +340,22 @@ namespace hpx { namespace parallel { namespace util {
                     std::make_shared<scoped_executor_parameters>(
                         policy.parameters(), policy.executor());
 
-                std::vector<hpx::future<Result>> workitems;
-                std::list<std::exception_ptr> errors;
                 try
                 {
-                    workitems = detail::partition<Result>(
+                    auto&& items = detail::partition<Result>(
                         HPX_FORWARD(ExPolicy_, policy), first, count,
                         HPX_FORWARD(F1, f1));
 
                     scoped_params->mark_end_of_scheduling();
+
+                    return reduce(HPX_MOVE(scoped_params), HPX_MOVE(items),
+                        HPX_FORWARD(F2, f2));
                 }
-                catch (std::bad_alloc const&)
+                catch (...)
                 {
                     return hpx::make_exceptional_future<R>(
                         std::current_exception());
                 }
-                catch (...)
-                {
-                    handle_local_exceptions::call(
-                        std::current_exception(), errors);
-                }
-                return reduce(HPX_MOVE(scoped_params), HPX_MOVE(workitems),
-                    HPX_MOVE(errors), HPX_FORWARD(F2, f2));
             }
 
             template <typename ExPolicy_, typename FwdIter, typename Stride,
@@ -347,28 +369,22 @@ namespace hpx { namespace parallel { namespace util {
                     std::make_shared<scoped_executor_parameters>(
                         policy.parameters(), policy.executor());
 
-                std::vector<hpx::future<Result>> workitems;
-                std::list<std::exception_ptr> errors;
                 try
                 {
-                    workitems = detail::partition_with_index<Result>(
+                    auto&& items = detail::partition_with_index<Result>(
                         HPX_FORWARD(ExPolicy_, policy), first, count, stride,
                         HPX_FORWARD(F1, f1));
 
                     scoped_params->mark_end_of_scheduling();
+
+                    return reduce(HPX_MOVE(scoped_params), HPX_MOVE(items),
+                        HPX_FORWARD(F2, f2));
                 }
-                catch (std::bad_alloc const&)
+                catch (...)
                 {
                     return hpx::make_exceptional_future<R>(
                         std::current_exception());
                 }
-                catch (...)
-                {
-                    handle_local_exceptions::call(
-                        std::current_exception(), errors);
-                }
-                return reduce(HPX_MOVE(scoped_params), HPX_MOVE(workitems),
-                    HPX_MOVE(errors), HPX_FORWARD(F2, f2));
             }
 
             template <typename ExPolicy_, typename FwdIter, typename F1,
@@ -383,55 +399,65 @@ namespace hpx { namespace parallel { namespace util {
                     std::make_shared<scoped_executor_parameters>(
                         policy.parameters(), policy.executor());
 
-                std::vector<hpx::future<Result>> workitems;
-                std::list<std::exception_ptr> errors;
                 try
                 {
-                    workitems = detail::partition_with_data<Result>(
+                    auto&& items = detail::partition_with_data<Result>(
                         HPX_FORWARD(ExPolicy_, policy), first, count,
                         chunk_sizes, HPX_FORWARD(Data, data),
                         HPX_FORWARD(F1, f1));
 
                     scoped_params->mark_end_of_scheduling();
+
+                    return reduce(HPX_MOVE(scoped_params), HPX_MOVE(items),
+                        HPX_FORWARD(F2, f2));
                 }
-                catch (std::bad_alloc const&)
+                catch (...)
                 {
                     return hpx::make_exceptional_future<R>(
                         std::current_exception());
                 }
-                catch (...)
-                {
-                    handle_local_exceptions::call(
-                        std::current_exception(), errors);
-                }
-                return reduce(HPX_MOVE(scoped_params), HPX_MOVE(workitems),
-                    HPX_MOVE(errors), HPX_FORWARD(F2, f2));
             }
 
         private:
-            template <typename F>
+            template <typename Items1, typename Items2, typename F>
             static hpx::future<R> reduce(
                 std::shared_ptr<scoped_executor_parameters>&& scoped_params,
-                std::vector<hpx::future<Result>>&& workitems,
-                std::list<std::exception_ptr>&& errors, F&& f)
+                std::pair<Items1, Items2>&& items, F&& f)
+            {
+                if (items.first.empty())
+                {
+                    return reduce(HPX_MOVE(scoped_params),
+                        HPX_MOVE(items.second), HPX_FORWARD(F, f));
+                }
+
+                items.first.insert(items.first.end(),
+                    std::make_move_iterator(items.second.begin()),
+                    std::make_move_iterator(items.second.end()));
+                return reduce(HPX_MOVE(scoped_params), HPX_MOVE(items.first),
+                    HPX_FORWARD(F, f));
+            }
+
+            template <typename Items, typename F>
+            static hpx::future<R> reduce(
+                std::shared_ptr<scoped_executor_parameters>&& scoped_params,
+                Items&& workitems, F&& f)
             {
 #if defined(HPX_COMPUTE_DEVICE_CODE)
                 HPX_UNUSED(scoped_params);
                 HPX_UNUSED(workitems);
-                HPX_UNUSED(errors);
                 HPX_UNUSED(f);
                 HPX_ASSERT(false);
                 return hpx::future<R>();
 #else
                 // wait for all tasks to finish
                 return hpx::dataflow(
-                    [errors = HPX_MOVE(errors),
-                        scoped_params = HPX_MOVE(scoped_params),
-                        f = HPX_FORWARD(F, f)](
-                        std::vector<hpx::future<Result>>&& r) mutable -> R {
+                    hpx::launch::sync,
+                    [scoped_params = HPX_MOVE(scoped_params),
+                        f = HPX_FORWARD(F, f)](auto&& r) mutable -> R {
                         HPX_UNUSED(scoped_params);
 
-                        handle_local_exceptions::call(r, errors);
+                        handle_local_exceptions::call(r);
+
                         return f(HPX_MOVE(r));
                     },
                     HPX_MOVE(workitems));

--- a/libs/core/algorithms/include/hpx/parallel/util/partitioner_with_cleanup.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/util/partitioner_with_cleanup.hpp
@@ -64,30 +64,26 @@ namespace hpx { namespace parallel { namespace util {
                 scoped_executor_parameters scoped_params(
                     policy.parameters(), policy.executor());
 
-                std::vector<hpx::future<Result>> workitems;
-                std::list<std::exception_ptr> errors;
                 try
                 {
-                    workitems = detail::partition<Result>(
+                    auto&& items = detail::partition<Result>(
                         HPX_FORWARD(ExPolicy_, policy), first, count,
                         HPX_FORWARD(F1, f1));
 
                     scoped_params.mark_end_of_scheduling();
+
+                    return reduce(HPX_MOVE(items), HPX_FORWARD(F2, f2),
+                        HPX_FORWARD(Cleanup, cleanup));
                 }
                 catch (...)
                 {
-                    handle_local_exceptions::call(
-                        std::current_exception(), errors);
+                    handle_local_exceptions::call(std::current_exception());
                 }
-                return reduce(HPX_MOVE(workitems), HPX_MOVE(errors),
-                    HPX_FORWARD(F2, f2), HPX_FORWARD(Cleanup, cleanup));
             }
 
         private:
-            template <typename F, typename Cleanup>
-            static R reduce(std::vector<hpx::future<Result>>&& workitems,
-                std::list<std::exception_ptr>&& errors, F&& f,
-                Cleanup&& cleanup)
+            template <typename Items, typename F, typename Cleanup>
+            static R reduce(Items&& workitems, F&& f, Cleanup&& cleanup)
             {
                 // wait for all tasks to finish
                 hpx::wait_all_nothrow(workitems);
@@ -95,19 +91,27 @@ namespace hpx { namespace parallel { namespace util {
                 // always rethrow if 'errors' is not empty or workitems has
                 // exceptional future
                 handle_local_exceptions::call_with_cleanup(
-                    workitems, errors, HPX_FORWARD(Cleanup, cleanup));
+                    workitems, HPX_FORWARD(Cleanup, cleanup));
 
-                try
+                return f(HPX_MOVE(workitems));
+            }
+
+            template <typename Items1, typename Items2, typename F,
+                typename Cleanup>
+            static R reduce(
+                std::pair<Items1, Items2>&& items, F&& f, Cleanup&& cleanup)
+            {
+                if (items.first.empty())
                 {
-                    return f(HPX_MOVE(workitems));
+                    return reduce(HPX_MOVE(items.second), HPX_FORWARD(F, f),
+                        HPX_FORWARD(Cleanup, cleanup));
                 }
-                catch (...)
-                {
-                    // rethrow either bad_alloc or exception_list
-                    handle_local_exceptions::call(std::current_exception());
-                    HPX_ASSERT(false);
-                    return f(HPX_MOVE(workitems));
-                }
+
+                items.first.insert(items.first.end(),
+                    std::make_move_iterator(items.second.begin()),
+                    std::make_move_iterator(items.second.end()));
+                return reduce(HPX_MOVE(items.first), HPX_FORWARD(F, f),
+                    HPX_FORWARD(Cleanup, cleanup));
             }
         };
 
@@ -135,59 +139,70 @@ namespace hpx { namespace parallel { namespace util {
                     std::make_shared<scoped_executor_parameters>(
                         policy.parameters(), policy.executor());
 
-                std::vector<hpx::future<Result>> workitems;
-                std::list<std::exception_ptr> errors;
                 try
                 {
-                    workitems = detail::partition<Result>(
+                    auto&& items = detail::partition<Result>(
                         HPX_FORWARD(ExPolicy_, policy), first, count,
                         HPX_FORWARD(F1, f1));
 
                     scoped_params->mark_end_of_scheduling();
+
+                    return reduce(HPX_MOVE(scoped_params), HPX_MOVE(items),
+                        HPX_FORWARD(F2, f2), HPX_FORWARD(Cleanup, cleanup));
                 }
                 catch (std::bad_alloc const&)
                 {
                     return hpx::make_exceptional_future<R>(
                         std::current_exception());
                 }
-                catch (...)
-                {
-                    handle_local_exceptions::call(
-                        std::current_exception(), errors);
-                }
-                return reduce(HPX_MOVE(scoped_params), HPX_MOVE(workitems),
-                    HPX_MOVE(errors), HPX_FORWARD(F2, f2),
-                    HPX_FORWARD(Cleanup, cleanup));
             }
 
         private:
-            template <typename F, typename Cleanup>
+            template <typename Items1, typename Items2, typename F,
+                typename Cleanup>
             static hpx::future<R> reduce(
                 std::shared_ptr<scoped_executor_parameters>&& scoped_params,
-                std::vector<hpx::future<Result>>&& workitems,
-                std::list<std::exception_ptr>&& errors, F&& f,
-                Cleanup&& cleanup)
+                std::pair<Items1, Items2>&& items, F&& f, Cleanup&& cleanup)
+            {
+                if (items.first.empty())
+                {
+                    return reduce(HPX_MOVE(scoped_params),
+                        HPX_MOVE(items.second), HPX_FORWARD(F, f),
+                        HPX_FORWARD(Cleanup, cleanup));
+                }
+
+                items.first.insert(items.first.end(),
+                    std::make_move_iterator(items.second.begin()),
+                    std::make_move_iterator(items.second.end()));
+                return reduce(HPX_MOVE(scoped_params), HPX_MOVE(items.first),
+                    HPX_FORWARD(F, f), HPX_FORWARD(Cleanup, cleanup));
+            }
+
+            template <typename Items, typename F, typename Cleanup>
+            static hpx::future<R> reduce(
+                std::shared_ptr<scoped_executor_parameters>&& scoped_params,
+                Items&& workitems, F&& f, Cleanup&& cleanup)
             {
                 // wait for all tasks to finish
 #if defined(HPX_COMPUTE_DEVICE_CODE)
                 HPX_UNUSED(scoped_params);
                 HPX_UNUSED(workitems);
-                HPX_UNUSED(errors);
                 HPX_UNUSED(f);
                 HPX_UNUSED(cleanup);
                 HPX_ASSERT(false);
                 return hpx::future<R>{};
 #else
                 return hpx::dataflow(
-                    [errors = HPX_MOVE(errors),
-                        scoped_params = HPX_MOVE(scoped_params),
+                    hpx::launch::sync,
+                    [scoped_params = HPX_MOVE(scoped_params),
                         f = HPX_FORWARD(F, f),
                         cleanup = HPX_FORWARD(Cleanup, cleanup)](
-                        std::vector<hpx::future<Result>>&& r) mutable -> R {
+                        auto&& r) mutable -> R {
                         HPX_UNUSED(scoped_params);
 
                         handle_local_exceptions::call_with_cleanup(
-                            r, errors, HPX_FORWARD(Cleanup, cleanup));
+                            r, HPX_FORWARD(Cleanup, cleanup));
+
                         return f(HPX_MOVE(r));
                     },
                     HPX_MOVE(workitems));

--- a/libs/core/algorithms/include/hpx/parallel/util/zip_iterator.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/util/zip_iterator.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2015 Hartmut Kaiser
+//  Copyright (c) 2007-2022 Hartmut Kaiser
 //  Copyright (c) 2014 Agustin Berge
 //
 //  SPDX-License-Identifier: BSL-1.0
@@ -19,7 +19,7 @@
 namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
     ///////////////////////////////////////////////////////////////////////////
     template <int N, typename R, typename ZipIter>
-    R get_iter(ZipIter&& zipiter)
+    constexpr R get_iter(ZipIter&& zipiter)
     {
         return hpx::get<N>(zipiter.get_iterator_tuple());
     }
@@ -38,7 +38,8 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
 
     ///////////////////////////////////////////////////////////////////////////
     template <typename ZipIter>
-    typename ZipIter::iterator_tuple_type get_iter_tuple(ZipIter&& zipiter)
+    constexpr typename ZipIter::iterator_tuple_type get_iter_tuple(
+        ZipIter&& zipiter)
     {
         return zipiter.get_iterator_tuple();
     }
@@ -54,8 +55,8 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
 
     ///////////////////////////////////////////////////////////////////////////
     template <typename ZipIter>
-    std::pair<typename hpx::tuple_element<0,
-                  typename ZipIter::iterator_tuple_type>::type,
+    constexpr std::pair<typename hpx::tuple_element<0,
+                            typename ZipIter::iterator_tuple_type>::type,
         typename hpx::tuple_element<1,
             typename ZipIter::iterator_tuple_type>::type>
     get_iter_pair(ZipIter&& zipiter)
@@ -86,8 +87,9 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
 
     ///////////////////////////////////////////////////////////////////////////
     template <typename ZipIter>
-    util::in_in_result<typename hpx::tuple_element<0,
-                           typename ZipIter::iterator_tuple_type>::type,
+    constexpr util::in_in_result<
+        typename hpx::tuple_element<0,
+            typename ZipIter::iterator_tuple_type>::type,
         typename hpx::tuple_element<1,
             typename ZipIter::iterator_tuple_type>::type>
     get_iter_in_in_result(ZipIter&& zipiter)

--- a/libs/core/algorithms/tests/unit/algorithms/make_heap.cpp
+++ b/libs/core/algorithms/tests/unit/algorithms/make_heap.cpp
@@ -186,7 +186,7 @@ void test_make_heap_exception(IteratorTag)
             decorated_iterator(hpx::util::end(c)));
         HPX_TEST(false);
     }
-    catch (hpx::exception_list const& e)
+    catch (hpx::exception_list const&)
     {
         caught_exception = true;
     }
@@ -219,7 +219,7 @@ void test_make_heap_exception(ExPolicy&& policy, IteratorTag)
             decorated_iterator(hpx::util::end(c)));
         HPX_TEST(false);
     }
-    catch (hpx::exception_list const& e)
+    catch (hpx::exception_list const&)
     {
         caught_exception = true;
     }
@@ -254,7 +254,7 @@ void test_make_heap_exception_async(ExPolicy&& p, IteratorTag)
 
         HPX_TEST(false);
     }
-    catch (hpx::exception_list const& e)
+    catch (hpx::exception_list const&)
     {
         caught_exception = true;
     }

--- a/libs/core/algorithms/tests/unit/block/spmd_block.cpp
+++ b/libs/core/algorithms/tests/unit/block/spmd_block.cpp
@@ -106,10 +106,10 @@ int hpx_main()
 
     hpx::parallel::define_spmd_block(num_images, bulk_test, c1.data());
 
-    std::vector<hpx::future<void>> join = hpx::parallel::define_spmd_block(
+    auto&& join = hpx::parallel::define_spmd_block(
         par(task), num_images, bulk_test, c2.data());
 
-    hpx::wait_all(join);
+    hpx::wait_all(std::move(join));
 
     hpx::parallel::define_spmd_block(num_images, bulk_test_function, c3.data());
 

--- a/libs/core/async_base/include/hpx/async_base/launch_policy.hpp
+++ b/libs/core/async_base/include/hpx/async_base/launch_policy.hpp
@@ -335,8 +335,9 @@ namespace hpx {
 
         struct sync_policy : policy_holder<sync_policy>
         {
-            constexpr sync_policy(threads::thread_priority priority =
-                                      threads::thread_priority::default_,
+            constexpr explicit sync_policy(
+                threads::thread_priority priority =
+                    threads::thread_priority::default_,
                 threads::thread_stacksize stacksize =
                     threads::thread_stacksize::default_,
                 threads::thread_schedule_hint hint = {}) noexcept
@@ -397,8 +398,9 @@ namespace hpx {
 
         struct deferred_policy : policy_holder<deferred_policy>
         {
-            constexpr deferred_policy(threads::thread_priority priority =
-                                          threads::thread_priority::default_,
+            constexpr explicit deferred_policy(
+                threads::thread_priority priority =
+                    threads::thread_priority::default_,
                 threads::thread_stacksize stacksize =
                     threads::thread_stacksize::default_,
                 threads::thread_schedule_hint hint = {}) noexcept
@@ -461,8 +463,9 @@ namespace hpx {
 
         struct apply_policy : policy_holder<apply_policy>
         {
-            constexpr apply_policy(threads::thread_priority priority =
-                                       threads::thread_priority::default_,
+            constexpr explicit apply_policy(
+                threads::thread_priority priority =
+                    threads::thread_priority::default_,
                 threads::thread_stacksize stacksize =
                     threads::thread_stacksize::default_,
                 threads::thread_schedule_hint hint = {}) noexcept

--- a/libs/core/execution/include/hpx/execution/detail/async_launch_policy_dispatch.hpp
+++ b/libs/core/execution/include/hpx/execution/detail/async_launch_policy_dispatch.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2021 Hartmut Kaiser
+//  Copyright (c) 2007-2022 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying

--- a/libs/core/execution/include/hpx/execution/detail/future_exec.hpp
+++ b/libs/core/execution/include/hpx/execution/detail/future_exec.hpp
@@ -152,9 +152,8 @@ namespace hpx { namespace lcos { namespace detail {
         template <typename F>
         void operator()(F&& f, hpx::util::thread_description desc)
         {
-            parallel::execution::detail::post_policy_dispatch<
-                hpx::launch::async_policy>::call(hpx::launch::async, desc,
-                HPX_FORWARD(F, f));
+            hpx::detail::post_policy_dispatch<hpx::launch::async_policy>::call(
+                hpx::launch::async, desc, HPX_FORWARD(F, f));
         }
     };
 

--- a/libs/core/execution/include/hpx/execution/detail/post_policy_dispatch.hpp
+++ b/libs/core/execution/include/hpx/execution/detail/post_policy_dispatch.hpp
@@ -9,8 +9,9 @@
 #include <hpx/config.hpp>
 #include <hpx/async_base/launch_policy.hpp>
 #include <hpx/coroutines/thread_enums.hpp>
-#include <hpx/execution/detail/async_launch_policy_dispatch.hpp>
+#include <hpx/execution/detail/sync_launch_policy_dispatch.hpp>
 #include <hpx/functional/deferred_call.hpp>
+#include <hpx/functional/invoke.hpp>
 #include <hpx/threading_base/thread_description.hpp>
 #include <hpx/threading_base/thread_helpers.hpp>
 #include <hpx/threading_base/thread_num_tss.hpp>
@@ -20,12 +21,38 @@
 #include <type_traits>
 #include <utility>
 
-namespace hpx { namespace parallel { namespace execution { namespace detail {
+namespace hpx::detail {
 
     ////////////////////////////////////////////////////////////////////////////
     // forward declaration
     template <typename Policy>
     struct post_policy_dispatch;
+
+    template <>
+    struct post_policy_dispatch<launch::async_policy>
+    {
+        template <typename F, typename... Ts>
+        static void call(launch::async_policy const& policy,
+            hpx::util::thread_description const& desc,
+            threads::thread_pool_base* pool, F&& f, Ts&&... ts)
+        {
+            threads::thread_init_data data(
+                threads::make_thread_function_nullary(hpx::util::deferred_call(
+                    HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...)),
+                desc, policy.priority(), policy.hint(), policy.stacksize(),
+                threads::thread_schedule_state::pending);
+
+            threads::register_work(data, pool);
+        }
+
+        template <typename F, typename... Ts>
+        static void call(launch::async_policy const& policy,
+            hpx::util::thread_description const& desc, F&& f, Ts&&... ts)
+        {
+            call(policy, desc, threads::detail::get_self_or_default_pool(),
+                HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...);
+        }
+    };
 
     template <>
     struct post_policy_dispatch<launch::fork_policy>
@@ -73,19 +100,43 @@ namespace hpx { namespace parallel { namespace execution { namespace detail {
     struct post_policy_dispatch<launch::sync_policy>
     {
         template <typename F, typename... Ts>
-        static void call(launch::sync_policy const&,
-            hpx::util::thread_description const& /* desc */,
-            threads::thread_pool_base* /* pool */, F&& f, Ts&&... ts)
+        static void call(launch::sync_policy const& policy,
+            hpx::util::thread_description const&, threads::thread_pool_base*,
+            F&& f, Ts&&... ts)
         {
-            hpx::detail::call_sync(HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...);
+            hpx::detail::sync_launch_policy_dispatch<launch::sync_policy>::call(
+                policy, HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...);
         }
 
         template <typename F, typename... Ts>
-        static void call(launch::sync_policy const& /* policy */,
-            hpx::util::thread_description const& /* desc */, F&& f,
-            Ts&&... ts) noexcept
+        static void call(launch::sync_policy const& policy,
+            hpx::util::thread_description const&, F&& f, Ts&&... ts)
         {
-            hpx::detail::call_sync(HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...);
+            hpx::detail::sync_launch_policy_dispatch<launch::sync_policy>::call(
+                policy, HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...);
+        }
+    };
+
+    template <>
+    struct post_policy_dispatch<launch::deferred_policy>
+    {
+        template <typename F, typename... Ts>
+        static void call(launch::deferred_policy const& policy,
+            hpx::util::thread_description const&, threads::thread_pool_base*,
+            F&& f, Ts&&... ts)
+        {
+            hpx::detail::sync_launch_policy_dispatch<
+                launch::deferred_policy>::call(policy, HPX_FORWARD(F, f),
+                HPX_FORWARD(Ts, ts)...);
+        }
+
+        template <typename F, typename... Ts>
+        static void call(launch::deferred_policy const& policy,
+            hpx::util::thread_description const&, F&& f, Ts&&... ts)
+        {
+            hpx::detail::sync_launch_policy_dispatch<
+                launch::deferred_policy>::call(policy, HPX_FORWARD(F, f),
+                HPX_FORWARD(Ts, ts)...);
         }
     };
 
@@ -99,9 +150,21 @@ namespace hpx { namespace parallel { namespace execution { namespace detail {
         {
             if (policy == launch::sync)
             {
-                hpx::detail::call_sync(
-                    HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...);
-                return;
+                auto sync_policy = launch::sync_policy(
+                    policy.priority(), policy.stacksize(), policy.hint());
+
+                post_policy_dispatch<launch::sync_policy>::call(sync_policy,
+                    desc, pool, HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...);
+            }
+            else if (policy == launch::deferred)
+            {
+                // execute synchronously
+                auto deferred_policy = launch::deferred_policy(
+                    policy.priority(), policy.stacksize(), policy.hint());
+
+                post_policy_dispatch<launch::deferred_policy>::call(
+                    deferred_policy, desc, pool, HPX_FORWARD(F, f),
+                    HPX_FORWARD(Ts, ts)...);
             }
             else if (policy == launch::fork)
             {
@@ -110,16 +173,15 @@ namespace hpx { namespace parallel { namespace execution { namespace detail {
 
                 post_policy_dispatch<launch::fork_policy>::call(fork_policy,
                     desc, pool, HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...);
-                return;
             }
+            else
+            {
+                auto async_policy = launch::async_policy(
+                    policy.priority(), policy.stacksize(), policy.hint());
 
-            threads::thread_init_data data(
-                threads::make_thread_function_nullary(hpx::util::deferred_call(
-                    HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...)),
-                desc, policy.priority(), policy.hint(), policy.stacksize(),
-                threads::thread_schedule_state::pending);
-
-            threads::register_work(data, pool);
+                post_policy_dispatch<launch::async_policy>::call(async_policy,
+                    desc, pool, HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...);
+            }
         }
 
         template <typename F, typename... Ts>
@@ -130,4 +192,4 @@ namespace hpx { namespace parallel { namespace execution { namespace detail {
                 HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...);
         }
     };
-}}}}    // namespace hpx::parallel::execution::detail
+}    // namespace hpx::detail

--- a/libs/core/execution/include/hpx/execution/detail/sync_launch_policy_dispatch.hpp
+++ b/libs/core/execution/include/hpx/execution/detail/sync_launch_policy_dispatch.hpp
@@ -83,5 +83,25 @@ namespace hpx { namespace detail {
                 throw exception_list(std::current_exception());
             }
         }
+
+        // launch::deferred execute inline
+        template <typename F, typename... Ts>
+        HPX_FORCEINLINE static hpx::util::detail::invoke_deferred_result_t<F,
+            Ts...>
+        call(launch::deferred_policy, F&& f, Ts&&... ts)
+        {
+            try
+            {
+                return HPX_INVOKE(HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...);
+            }
+            catch (std::bad_alloc const& ba)
+            {
+                throw ba;
+            }
+            catch (...)
+            {
+                throw exception_list(std::current_exception());
+            }
+        }
     };
 }}    // namespace hpx::detail

--- a/libs/core/execution/include/hpx/execution/executors/auto_chunk_size.hpp
+++ b/libs/core/execution/include/hpx/execution/executors/auto_chunk_size.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2020 Hartmut Kaiser
+//  Copyright (c) 2007-2022 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -40,7 +40,8 @@ namespace hpx { namespace execution {
         ///       types will use 80 microseconds as the minimal time for which
         ///       any of the scheduled chunks should run.
         ///
-        constexpr auto_chunk_size(std::uint64_t num_iters_for_timing = 0)
+        constexpr auto_chunk_size(
+            std::uint64_t num_iters_for_timing = 0) noexcept
           : min_time_(200000)
           , num_iters_for_timing_(num_iters_for_timing)
         {
@@ -53,17 +54,21 @@ namespace hpx { namespace execution {
         ///                     combined.
         ///
         explicit auto_chunk_size(hpx::chrono::steady_duration const& rel_time,
-            std::uint64_t num_iters_for_timing = 0)
+            std::uint64_t num_iters_for_timing = 0) noexcept
           : min_time_(rel_time.value().count())
           , num_iters_for_timing_(num_iters_for_timing)
         {
         }
 
         /// \cond NOINTERNAL
+        // This executor parameters type synchronously invokes the provided
+        // testing function in order to approximate the chunk-size.
+        using invokes_testing_function = std::true_type;
+
         // Estimate a chunk size based on number of cores used.
         template <typename Executor, typename F>
-        std::size_t get_chunk_size(
-            Executor&& exec, F&& f, std::size_t cores, std::size_t count)
+        std::size_t get_chunk_size(Executor&& exec, F&& f, std::size_t cores,
+            std::size_t count) noexcept
         {
             // by default use 1% of the iterations
             if (num_iters_for_timing_ == 0)

--- a/libs/core/execution/include/hpx/execution/executors/dynamic_chunk_size.hpp
+++ b/libs/core/execution/include/hpx/execution/executors/dynamic_chunk_size.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2017 Hartmut Kaiser
+//  Copyright (c) 2007-2022 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -33,7 +33,8 @@ namespace hpx { namespace execution {
         ///                     number of loop iterations to schedule together.
         ///                     The default chunk size is 1.
         ///
-        constexpr explicit dynamic_chunk_size(std::size_t chunk_size = 1)
+        constexpr explicit dynamic_chunk_size(
+            std::size_t chunk_size = 1) noexcept
           : chunk_size_(chunk_size)
         {
         }
@@ -41,7 +42,7 @@ namespace hpx { namespace execution {
         /// \cond NOINTERNAL
         template <typename Executor, typename F>
         constexpr std::size_t get_chunk_size(
-            Executor&, F&&, std::size_t, std::size_t) const
+            Executor&, F&&, std::size_t, std::size_t) const noexcept
         {
             return chunk_size_;
         }
@@ -54,7 +55,9 @@ namespace hpx { namespace execution {
         template <typename Archive>
         void serialize(Archive& ar, const unsigned int /* version */)
         {
-            ar& chunk_size_;
+            // clang-format off
+            ar & chunk_size_;
+            // clang-format on
         }
         /// \endcond
 

--- a/libs/core/execution/include/hpx/execution/executors/execution.hpp
+++ b/libs/core/execution/include/hpx/execution/executors/execution.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2017-2021 Hartmut Kaiser
+//  Copyright (c) 2017-2022 Hartmut Kaiser
 //  Copyright (c) 2017 Google
 //
 //  SPDX-License-Identifier: BSL-1.0
@@ -77,12 +77,14 @@ namespace hpx { namespace parallel { namespace execution {
             std::enable_if_t<hpx::traits::is_one_way_executor_v<Executor> &&
                 !hpx::traits::is_two_way_executor_v<Executor>>>
         {
+            // clang-format off
             template <typename OneWayExecutor, typename F, typename... Ts>
             HPX_FORCEINLINE static auto call_impl(
                 std::false_type, OneWayExecutor&& exec, F&& f, Ts&&... ts)
-                -> hpx::future<decltype(
-                    sync_execute_dispatch(0, HPX_FORWARD(OneWayExecutor, exec),
-                        HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...))>
+                -> hpx::future<decltype(sync_execute_dispatch(0,
+                    HPX_FORWARD(OneWayExecutor, exec), HPX_FORWARD(F, f),
+                    HPX_FORWARD(Ts, ts)...))>
+            // clang-format on
             {
                 return hpx::make_ready_future(
                     sync_execute_dispatch(0, HPX_FORWARD(OneWayExecutor, exec),
@@ -104,9 +106,11 @@ namespace hpx { namespace parallel { namespace execution {
                 HPX_FORWARD(OneWayExecutor, exec), HPX_FORWARD(F, f),
                 HPX_FORWARD(Ts, ts)...))>
             {
-                using is_void = std::is_void<decltype(
-                    sync_execute_dispatch(0, HPX_FORWARD(OneWayExecutor, exec),
-                        HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...))>;
+                // clang-format off
+                using is_void = std::is_void<decltype(sync_execute_dispatch(0,
+                    HPX_FORWARD(OneWayExecutor, exec), HPX_FORWARD(F, f),
+                    HPX_FORWARD(Ts, ts)...))>;
+                // clang-format on
 
                 return call_impl(
                     is_void(), exec, HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...);
@@ -177,9 +181,11 @@ namespace hpx { namespace parallel { namespace execution {
                 typename... Ts>
             struct result
             {
-                using type = decltype(
-                    call(std::declval<OneWayExecutor>(), std::declval<F>(),
-                        std::declval<Future>(), std::declval<Ts>()...));
+                // clang-format off
+                using type = decltype(call(std::declval<OneWayExecutor>(),
+                    std::declval<F>(), std::declval<Future>(),
+                    std::declval<Ts>()...));
+                // clang-format on
             };
         };
 
@@ -421,9 +427,11 @@ namespace hpx { namespace parallel { namespace execution {
                 typename... Ts>
             struct result
             {
-                using type = decltype(
-                    call(std::declval<TwoWayExecutor>(), std::declval<F>(),
-                        std::declval<Future>(), std::declval<Ts>()...));
+                // clang-format off
+                using type = decltype(call(std::declval<TwoWayExecutor>(),
+                    std::declval<F>(), std::declval<Future>(),
+                    std::declval<Ts>()...));
+                // clang-format on
             };
         };
 
@@ -628,9 +636,11 @@ namespace hpx { namespace parallel { namespace execution {
                 typename... Ts>
             struct result
             {
-                using type = decltype(
-                    call(std::declval<BulkExecutor>(), std::declval<F>(),
-                        std::declval<Shape const&>(), std::declval<Ts>()...));
+                // clang-format off
+                using type = decltype(call(std::declval<BulkExecutor>(),
+                    std::declval<F>(), std::declval<Shape const&>(),
+                    std::declval<Ts>()...));
+                // clang-format on
             };
         };
 
@@ -655,9 +665,11 @@ namespace hpx { namespace parallel { namespace execution {
                 typename... Ts>
             struct result
             {
-                using type = decltype(
-                    call(std::declval<BulkExecutor>(), std::declval<F>(),
-                        std::declval<Shape const&>(), std::declval<Ts>()...));
+                // clang-format off
+                using type = decltype(call(std::declval<BulkExecutor>(),
+                    std::declval<F>(), std::declval<Shape const&>(),
+                    std::declval<Ts>()...));
+                // clang-format on
             };
         };
 
@@ -819,9 +831,11 @@ namespace hpx { namespace parallel { namespace execution {
                 typename... Ts>
             struct result
             {
-                using type = decltype(
-                    call(std::declval<BulkExecutor>(), std::declval<F>(),
-                        std::declval<Shape const&>(), std::declval<Ts>()...));
+                // clang-format off
+                using type = decltype(call(std::declval<BulkExecutor>(),
+                    std::declval<F>(), std::declval<Shape const&>(),
+                    std::declval<Ts>()...));
+                // clang-format on
             };
         };
 
@@ -949,9 +963,11 @@ namespace hpx { namespace parallel { namespace execution {
                 typename... Ts>
             struct result
             {
-                using type = decltype(
-                    call(std::declval<BulkExecutor>(), std::declval<F>(),
-                        std::declval<Shape const&>(), std::declval<Ts>()...));
+                // clang-format off
+                using type = decltype(call(std::declval<BulkExecutor>(),
+                    std::declval<F>(), std::declval<Shape const&>(),
+                    std::declval<Ts>()...));
+                // clang-format on
             };
         };
 
@@ -976,9 +992,11 @@ namespace hpx { namespace parallel { namespace execution {
                 typename... Ts>
             struct result
             {
-                using type = decltype(
-                    call(std::declval<BulkExecutor>(), std::declval<F>(),
-                        std::declval<Shape const&>(), std::declval<Ts>()...));
+                // clang-format off
+                using type = decltype(call(std::declval<BulkExecutor>(),
+                    std::declval<F>(), std::declval<Shape const&>(),
+                    std::declval<Ts>()...));
+                // clang-format on
             };
         };
     }    // namespace detail
@@ -1007,9 +1025,9 @@ namespace hpx { namespace parallel { namespace execution {
                 using shared_state_type =
                     hpx::traits::detail::shared_state_ptr_t<result_type>;
 
-                auto func = make_fused_bulk_sync_execute_helper<result_type>(
-                    exec, HPX_FORWARD(F, f), shape,
-                    hpx::make_tuple(HPX_FORWARD(Ts, ts)...));
+                auto func =
+                    make_fused_bulk_sync_execute_helper(exec, HPX_FORWARD(F, f),
+                        shape, hpx::make_tuple(HPX_FORWARD(Ts, ts)...));
 
                 shared_state_type p =
                     lcos::detail::make_continuation_exec<result_type>(
@@ -1026,9 +1044,9 @@ namespace hpx { namespace parallel { namespace execution {
                 BulkExecutor&& exec, F&& f, Shape const& shape,
                 Future&& predecessor, Ts&&... ts)
             {
-                auto func = make_fused_bulk_sync_execute_helper<void>(exec,
-                    HPX_FORWARD(F, f), shape,
-                    hpx::make_tuple(HPX_FORWARD(Ts, ts)...));
+                auto func =
+                    make_fused_bulk_sync_execute_helper(exec, HPX_FORWARD(F, f),
+                        shape, hpx::make_tuple(HPX_FORWARD(Ts, ts)...));
 
                 hpx::traits::detail::shared_state_ptr_t<void> p =
                     lcos::detail::make_continuation_exec<void>(
@@ -1117,17 +1135,8 @@ namespace hpx { namespace parallel { namespace execution {
                 return hpx::traits::executor_future_t<Executor,
                     bulk_then_execute_result_t<F, Shape, Future, Ts...>>{};
 #else
-                // result_of_t<F(Shape::value_type, Future)>
-                using func_result_type =
-                    then_bulk_function_result_t<F, Shape, Future, Ts...>;
-
-                // std::vector<future<func_result_type>>
-                using result_type =
-                    std::vector<hpx::traits::executor_future_t<Executor,
-                        func_result_type, Ts...>>;
-
-                auto func = make_fused_bulk_async_execute_helper<result_type>(
-                    exec, HPX_FORWARD(F, f), shape,
+                auto func = make_fused_bulk_async_execute_helper(exec,
+                    HPX_FORWARD(F, f), shape,
                     hpx::make_tuple(HPX_FORWARD(Ts, ts)...));
 
                 // void or std::vector<func_result_type>

--- a/libs/core/execution/include/hpx/execution/executors/execution_parameters.hpp
+++ b/libs/core/execution/include/hpx/execution/executors/execution_parameters.hpp
@@ -281,7 +281,7 @@ namespace hpx { namespace parallel { namespace execution {
 
         ///////////////////////////////////////////////////////////////////////
         // default property implementation allowing to handle
-        // reset_thread_distribution
+        // processing_units_count_property
         struct processing_units_count_property
         {
             // default implementation
@@ -294,7 +294,7 @@ namespace hpx { namespace parallel { namespace execution {
 
         //////////////////////////////////////////////////////////////////////
         // Generate a type that is guaranteed to support
-        // reset_thread_distribution
+        // processing_units_count_property
         using get_processing_units_count_target_t =
             get_parameters_property_t<processing_units_count_property,
                 has_processing_units_count_t>;

--- a/libs/core/execution/include/hpx/execution/executors/fused_bulk_execute.hpp
+++ b/libs/core/execution/include/hpx/execution/executors/fused_bulk_execute.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2017-2021 Hartmut Kaiser
+//  Copyright (c) 2017-2022 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -56,8 +56,8 @@ namespace hpx { namespace parallel { namespace execution { namespace detail {
     template <typename F, typename Shape, typename Future, typename... Ts>
     struct bulk_then_execute_result
       : bulk_then_execute_result_impl<F, Shape, Future,
-            std::is_void<
-                then_bulk_function_result_t<F, Shape, Future, Ts...>>::value,
+            std::is_void_v<
+                then_bulk_function_result_t<F, Shape, Future, Ts...>>,
             Ts...>
     {
     };
@@ -81,14 +81,11 @@ namespace hpx { namespace parallel { namespace execution { namespace detail {
             hpx::get<Is>(args)...);
     }
 
-    template <typename Result, typename Executor, typename F, typename Shape,
-        typename Args>
+    template <typename Executor, typename F, typename Shape, typename Args>
     struct fused_bulk_sync_execute_helper;
 
-    template <typename Result, typename Executor, typename F, typename Shape,
-        typename... Ts>
-    struct fused_bulk_sync_execute_helper<Result, Executor, F, Shape,
-        hpx::tuple<Ts...>>
+    template <typename Executor, typename F, typename Shape, typename... Ts>
+    struct fused_bulk_sync_execute_helper<Executor, F, Shape, hpx::tuple<Ts...>>
     {
         Executor exec_;
         F f_;
@@ -96,7 +93,7 @@ namespace hpx { namespace parallel { namespace execution { namespace detail {
         hpx::tuple<Ts...> args_;
 
         template <typename Future>
-        Result operator()(Future&& predecessor)
+        decltype(auto) operator()(Future&& predecessor)
         {
             return fused_bulk_sync_execute(exec_, f_, shape_,
                 HPX_FORWARD(Future, predecessor),
@@ -105,14 +102,13 @@ namespace hpx { namespace parallel { namespace execution { namespace detail {
         }
     };
 
-    template <typename Result, typename Executor, typename F, typename Shape,
-        typename Args>
-    fused_bulk_sync_execute_helper<Result, std::decay_t<Executor>,
-        std::decay_t<F>, Shape, std::decay_t<Args>>
+    template <typename Executor, typename F, typename Shape, typename Args>
+    fused_bulk_sync_execute_helper<std::decay_t<Executor>, std::decay_t<F>,
+        Shape, std::decay_t<Args>>
     make_fused_bulk_sync_execute_helper(
         Executor&& exec, F&& f, Shape const& shape, Args&& args)
     {
-        return fused_bulk_sync_execute_helper<Result, std::decay_t<Executor>,
+        return fused_bulk_sync_execute_helper<std::decay_t<Executor>,
             std::decay_t<F>, Shape, std::decay_t<Args>>{
             HPX_FORWARD(Executor, exec), HPX_FORWARD(F, f), shape,
             HPX_FORWARD(Args, args)};
@@ -133,13 +129,11 @@ namespace hpx { namespace parallel { namespace execution { namespace detail {
             hpx::get<Is>(args)...);
     }
 
-    template <typename Result, typename Executor, typename F, typename Shape,
-        typename Args>
+    template <typename Executor, typename F, typename Shape, typename Args>
     struct fused_bulk_async_execute_helper;
 
-    template <typename Result, typename Executor, typename F, typename Shape,
-        typename... Ts>
-    struct fused_bulk_async_execute_helper<Result, Executor, F, Shape,
+    template <typename Executor, typename F, typename Shape, typename... Ts>
+    struct fused_bulk_async_execute_helper<Executor, F, Shape,
         hpx::tuple<Ts...>>
     {
         Executor exec_;
@@ -148,7 +142,7 @@ namespace hpx { namespace parallel { namespace execution { namespace detail {
         hpx::tuple<Ts...> args_;
 
         template <typename Future>
-        Result operator()(Future&& predecessor)
+        decltype(auto) operator()(Future&& predecessor)
         {
             return fused_bulk_async_execute(exec_, f_, shape_,
                 HPX_FORWARD(Future, predecessor),
@@ -157,14 +151,13 @@ namespace hpx { namespace parallel { namespace execution { namespace detail {
         }
     };
 
-    template <typename Result, typename Executor, typename F, typename Shape,
-        typename Args>
-    fused_bulk_async_execute_helper<Result, std::decay_t<Executor>,
-        std::decay_t<F>, std::decay_t<Shape>, std::decay_t<Args>>
+    template <typename Executor, typename F, typename Shape, typename Args>
+    fused_bulk_async_execute_helper<std::decay_t<Executor>, std::decay_t<F>,
+        std::decay_t<Shape>, std::decay_t<Args>>
     make_fused_bulk_async_execute_helper(
         Executor&& exec, F&& f, Shape&& shape, Args&& args)
     {
-        return fused_bulk_async_execute_helper<Result, std::decay_t<Executor>,
+        return fused_bulk_async_execute_helper<std::decay_t<Executor>,
             std::decay_t<F>, std::decay_t<Shape>, std::decay_t<Args>>{
             HPX_FORWARD(Executor, exec), HPX_FORWARD(F, f),
             HPX_FORWARD(Shape, shape), HPX_FORWARD(Args, args)};

--- a/libs/core/execution/include/hpx/execution/executors/guided_chunk_size.hpp
+++ b/libs/core/execution/include/hpx/execution/executors/guided_chunk_size.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2015 Hartmut Kaiser
+//  Copyright (c) 2007-2022 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -40,7 +40,8 @@ namespace hpx { namespace execution {
         ///                     schedule together.
         ///                     The default minimal chunk size is 1.
         ///
-        constexpr explicit guided_chunk_size(std::size_t min_chunk_size = 1)
+        constexpr explicit guided_chunk_size(
+            std::size_t min_chunk_size = 1) noexcept
           : min_chunk_size_(min_chunk_size)
         {
         }
@@ -48,7 +49,7 @@ namespace hpx { namespace execution {
         /// \cond NOINTERNAL
         // This executor parameters type provides variable chunk sizes and
         // needs to be invoked for each of the chunks to be combined.
-        typedef std::true_type has_variable_chunk_size;
+        using has_variable_chunk_size = std::true_type;
 
         //         template <typename Executor>
         //         static std::size_t get_maximal_number_of_chunks(
@@ -60,7 +61,7 @@ namespace hpx { namespace execution {
 
         template <typename Executor, typename F>
         constexpr std::size_t get_chunk_size(Executor&& /* exec */, F&&,
-            std::size_t cores, std::size_t num_tasks) const
+            std::size_t cores, std::size_t num_tasks) const noexcept
         {
             return (std::max)(min_chunk_size_, (num_tasks + cores - 1) / cores);
         }
@@ -73,7 +74,9 @@ namespace hpx { namespace execution {
         template <typename Archive>
         void serialize(Archive& ar, const unsigned int /* version */)
         {
-            ar& min_chunk_size_;
+            // clang-format off
+            ar & min_chunk_size_;
+            // clang-format on
         }
         /// \endcond
 

--- a/libs/core/execution/include/hpx/execution/executors/persistent_auto_chunk_size.hpp
+++ b/libs/core/execution/include/hpx/execution/executors/persistent_auto_chunk_size.hpp
@@ -38,7 +38,7 @@ namespace hpx { namespace execution {
         ///       any of the scheduled chunks should run.
         ///
         constexpr persistent_auto_chunk_size(
-            std::uint64_t num_iters_for_timing = 0)
+            std::uint64_t num_iters_for_timing = 0) noexcept
           : chunk_size_time_(0)
           , min_time_(200000)
           , num_iters_for_timing_(num_iters_for_timing)
@@ -51,7 +51,7 @@ namespace hpx { namespace execution {
         ///
         explicit persistent_auto_chunk_size(
             hpx::chrono::steady_duration const& time_cs,
-            std::uint64_t num_iters_for_timing = 0)
+            std::uint64_t num_iters_for_timing = 0) noexcept
           : chunk_size_time_(time_cs.value().count())
           , min_time_(200000)
           , num_iters_for_timing_(num_iters_for_timing)
@@ -67,7 +67,7 @@ namespace hpx { namespace execution {
         ///
         persistent_auto_chunk_size(hpx::chrono::steady_duration const& time_cs,
             hpx::chrono::steady_duration const& rel_time,
-            std::uint64_t num_iters_for_timing = 0)
+            std::uint64_t num_iters_for_timing = 0) noexcept
           : chunk_size_time_(time_cs.value().count())
           , min_time_(rel_time.value().count())
           , num_iters_for_timing_(num_iters_for_timing)
@@ -75,10 +75,14 @@ namespace hpx { namespace execution {
         }
 
         /// \cond NOINTERNAL
+        // This executor parameters type synchronously invokes the provided
+        // testing function in order to approximate the chunk-size.
+        using invokes_testing_function = std::true_type;
+
         // Estimate a chunk size based on number of cores used.
         template <typename Executor, typename F>
-        std::size_t get_chunk_size(
-            Executor& /* exec */, F&& f, std::size_t cores, std::size_t count)
+        std::size_t get_chunk_size(Executor& /* exec */, F&& f,
+            std::size_t cores, std::size_t count) noexcept
         {
             // by default use 1% of the iterations
             if (num_iters_for_timing_ == 0)

--- a/libs/core/execution/include/hpx/execution/executors/static_chunk_size.hpp
+++ b/libs/core/execution/include/hpx/execution/executors/static_chunk_size.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2015 Hartmut Kaiser
+//  Copyright (c) 2007-2022 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -34,7 +34,7 @@ namespace hpx { namespace execution {
         ///       the number of available cores and the overall number of loop
         ///       iterations to schedule.
         ///
-        constexpr static_chunk_size()
+        constexpr static_chunk_size() noexcept
           : chunk_size_(0)
         {
         }
@@ -45,7 +45,7 @@ namespace hpx { namespace execution {
         ///                     number of loop iterations to run on a single
         ///                     thread.
         ///
-        constexpr explicit static_chunk_size(std::size_t chunk_size)
+        constexpr explicit static_chunk_size(std::size_t chunk_size) noexcept
           : chunk_size_(chunk_size)
         {
         }
@@ -89,7 +89,9 @@ namespace hpx { namespace execution {
         template <typename Archive>
         void serialize(Archive& ar, const unsigned int /* version */)
         {
-            ar& chunk_size_;
+            // clang-format off
+            ar & chunk_size_;
+            // clang-format on
         }
         /// \endcond
 

--- a/libs/core/execution_base/include/hpx/execution_base/traits/is_executor_parameters.hpp
+++ b/libs/core/execution_base/include/hpx/execution_base/traits/is_executor_parameters.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2014-2021 Hartmut Kaiser
+//  Copyright (c) 2014-2022 Hartmut Kaiser
 //  Copyright (c) 2016 Marcin Copik
 //
 //  SPDX-License-Identifier: BSL-1.0
@@ -8,7 +8,6 @@
 #pragma once
 
 #include <hpx/config.hpp>
-#include <hpx/type_support/always_void.hpp>
 
 #include <functional>
 #include <type_traits>
@@ -38,30 +37,56 @@ namespace hpx { namespace parallel { namespace execution {
 
     template <typename Executor>
     struct extract_executor_parameters<Executor,
-        typename hpx::util::always_void<
-            typename Executor::executor_parameters_type>::type>
+        std::void_t<typename Executor::executor_parameters_type>>
     {
         using type = typename Executor::executor_parameters_type;
     };
 
-    ///////////////////////////////////////////////////////////////////////
-    // If a parameters type exposes 'has_variable_chunk_size' aliased to
-    // std::true_type it is assumed that the number of loop iterations to
-    // combine is different for each of the generated chunks.
+    template <typename Executor>
+    using extract_executor_parameters_t =
+        typename extract_executor_parameters<Executor>::type;
+
+    ///////////////////////////////////////////////////////////////////////////
+    // If a parameters type exposes an embedded type  'has_variable_chunk_size'
+    // it is assumed that the number of loop iterations to combine is different
+    // for each of the generated chunks.
     template <typename Parameters, typename Enable = void>
-    struct extract_has_variable_chunk_size
+    struct extract_has_variable_chunk_size : std::false_type
     {
         // by default, assume equally sized chunks
-        using type = std::false_type;
     };
 
     template <typename Parameters>
     struct extract_has_variable_chunk_size<Parameters,
-        typename hpx::util::always_void<
-            typename Parameters::has_variable_chunk_size>::type>
+        std::void_t<typename Parameters::has_variable_chunk_size>>
+      : std::true_type
     {
-        using type = typename Parameters::has_variable_chunk_size;
     };
+
+    template <typename Parameters>
+    inline constexpr bool extract_has_variable_chunk_size_v =
+        extract_has_variable_chunk_size<Parameters>::value;
+
+    ///////////////////////////////////////////////////////////////////////////
+    // If a parameters type exposes an embedded type 'invokes_testing_function'
+    // it is assumed that the parameters object uses the given function to
+    // determine the number of chunks to apply.
+    template <typename Parameters, typename Enable = void>
+    struct extract_invokes_testing_function : std::false_type
+    {
+        // by default, assume equally sized chunks
+    };
+
+    template <typename Parameters>
+    struct extract_invokes_testing_function<Parameters,
+        std::void_t<typename Parameters::invokes_testing_function>>
+      : std::true_type
+    {
+    };
+
+    template <typename Parameters>
+    inline constexpr bool extract_invokes_testing_function_v =
+        extract_invokes_testing_function<Parameters>::value;
 
     ///////////////////////////////////////////////////////////////////////////
     namespace detail {

--- a/libs/core/executors/CMakeLists.txt
+++ b/libs/core/executors/CMakeLists.txt
@@ -80,6 +80,7 @@ add_hpx_module(
     hpx_async_base
     hpx_concepts
     hpx_config
+    hpx_errors
     hpx_execution
     hpx_futures
     hpx_hardware

--- a/libs/core/executors/include/hpx/executors/detail/hierarchical_spawning.hpp
+++ b/libs/core/executors/include/hpx/executors/detail/hierarchical_spawning.hpp
@@ -11,12 +11,15 @@
 #include <hpx/config.hpp>
 #include <hpx/assert.hpp>
 #include <hpx/async_base/launch_policy.hpp>
+#include <hpx/async_base/scheduling_properties.hpp>
 #include <hpx/coroutines/thread_enums.hpp>
+#include <hpx/errors/try_catch_exception_ptr.hpp>
 #include <hpx/execution/algorithms/detail/predicates.hpp>
 #include <hpx/execution/detail/async_launch_policy_dispatch.hpp>
 #include <hpx/execution/detail/post_policy_dispatch.hpp>
 #include <hpx/execution/executors/execution.hpp>
 #include <hpx/execution/executors/fused_bulk_execute.hpp>
+#include <hpx/functional/invoke.hpp>
 #include <hpx/futures/future.hpp>
 #include <hpx/futures/traits/future_traits.hpp>
 #include <hpx/iterator_support/range.hpp>
@@ -30,12 +33,14 @@
 #include <algorithm>
 #include <cstddef>
 #include <cstdint>
+#include <exception>
 #include <type_traits>
 #include <utility>
 #include <vector>
 
 namespace hpx { namespace parallel { namespace execution { namespace detail {
 
+    ////////////////////////////////////////////////////////////////////////////
     template <typename Launch, typename F, typename S, typename... Ts>
     std::vector<hpx::future<detail::bulk_function_result_t<F, S, Ts...>>>
     hierarchical_bulk_async_execute_helper(
@@ -54,27 +59,29 @@ namespace hpx { namespace parallel { namespace execution { namespace detail {
         results.resize(size);
 
         auto post_policy = policy;
-        post_policy.set_stacksize(threads::thread_stacksize::small_);
+        hpx::execution::experimental::with_stacksize(
+            post_policy, threads::thread_stacksize::small_);
 
         lcos::local::latch l(size);
         std::size_t part_begin = 0;
         auto it = std::begin(shape);
-        for (std::size_t t = 0; t < num_threads; ++t)
+        for (std::size_t t = 0; t != num_threads; ++t)
         {
             std::size_t const part_end = ((t + 1) * size) / num_threads;
             std::size_t const part_size = part_end - part_begin;
 
             auto async_policy = policy;
-            async_policy.set_hint(threads::thread_schedule_hint{
-                static_cast<std::int16_t>(first_thread + t)});
+            hpx::execution::experimental::with_hint(async_policy,
+                threads::thread_schedule_hint{
+                    static_cast<std::int16_t>(first_thread + t)});
 
             if (part_size > hierarchical_threshold)
             {
-                detail::post_policy_dispatch<Launch>::call(post_policy, desc,
-                    pool,
+                hpx::detail::post_policy_dispatch<Launch>::call(post_policy,
+                    desc, pool,
                     [&, part_begin, part_end, part_size, f, it]() mutable {
-                        for (std::size_t part_i = part_begin; part_i < part_end;
-                             ++part_i)
+                        for (std::size_t part_i = part_begin;
+                             part_i != part_end; ++part_i)
                         {
                             results[part_i] =
                                 hpx::detail::async_launch_policy_dispatch<
@@ -89,7 +96,7 @@ namespace hpx { namespace parallel { namespace execution { namespace detail {
             }
             else
             {
-                for (std::size_t part_i = part_begin; part_i < part_end;
+                for (std::size_t part_i = part_begin; part_i != part_end;
                      ++part_i)
                 {
                     results[part_i] =
@@ -102,43 +109,166 @@ namespace hpx { namespace parallel { namespace execution { namespace detail {
 
             part_begin = part_end;
         }
+        HPX_ASSERT(it == hpx::util::end(shape));
 
         l.wait();
 
         return results;
     }
 
+    // This specialization avoids creating a future for each of the scheduled
+    // tasks. It also avoids an additional allocation by directly returning a
+    // hpx::future.
     template <typename Launch, typename F, typename S, typename... Ts>
-    std::vector<hpx::future<detail::bulk_function_result_t<F, S, Ts...>>>
-    hierarchical_bulk_async_execute_helper(threads::thread_pool_base* pool,
-        std::size_t first_thread, std::size_t num_threads,
-        std::size_t hierarchical_threshold, Launch policy, F&& f,
-        S const& shape, Ts&&... ts)
+    decltype(auto) hierarchical_bulk_async_execute_void(
+        hpx::util::thread_description const& desc,
+        threads::thread_pool_base* pool, std::size_t first_thread,
+        std::size_t num_threads, std::size_t hierarchical_threshold,
+        Launch policy, F&& f, S const& shape, Ts&&... ts)
     {
-        hpx::util::thread_description const desc(f,
-            "hpx::parallel::execution::detail::hierarchical_bulk_async_execute_"
-            "helper");
+        HPX_ASSERT(pool);
 
-        return hierarchical_bulk_async_execute_helper(desc, pool, first_thread,
+        return hpx::detail::async_launch_policy_dispatch<Launch>::call(
+            policy, desc, pool,
+            [](hpx::util::thread_description const& desc,
+                threads::thread_pool_base* pool, std::size_t first_thread,
+                std::size_t num_threads, std::size_t hierarchical_threshold,
+                Launch policy, std::decay_t<F> f, S const& shape,
+                std::decay_t<Ts>... ts) {
+                std::size_t const size = hpx::util::size(shape);
+                auto post_policy = policy;
+                hpx::execution::experimental::with_stacksize(
+                    post_policy, threads::thread_stacksize::small_);
+
+                std::exception_ptr e;
+                lcos::local::spinlock mtx_e;
+                lcos::local::latch l(size);
+
+                auto wrapped = [&, f](auto&&... args) mutable {
+                    // properly handle all exceptions thrown from 'f'
+                    hpx::detail::try_catch_exception_ptr(
+                        [&]() {
+                            HPX_INVOKE(f, HPX_FORWARD(decltype(args), args)...);
+                        },
+                        [&](std::exception_ptr ep) {
+                            // store the first caught exception only
+                            std::lock_guard<lcos::local::spinlock> lg(mtx_e);
+                            if (!e)
+                                e = HPX_MOVE(ep);
+                        });
+                    l.count_down(1);
+                };
+
+                std::size_t begin = 0;
+                auto it = std::begin(shape);
+                for (std::size_t t = 0; t != num_threads; ++t)
+                {
+                    auto inner_post_policy = policy;
+                    hpx::execution::experimental::with_hint(inner_post_policy,
+                        threads::thread_schedule_hint{
+                            static_cast<std::int16_t>(first_thread + t)});
+
+                    std::size_t const end = ((t + 1) * size) / num_threads;
+                    std::size_t const part_size = end - begin;
+
+                    auto&& launcher = [&, wrapped, begin, end, it](
+                                          bool direct) mutable {
+                        // launch N-1 tasks
+                        auto iter = it;
+                        for (std::size_t i = begin + direct; i != end;
+                             (void) ++iter, ++i)
+                        {
+                            hpx::detail::post_policy_dispatch<Launch>::call(
+                                inner_post_policy, desc, pool, wrapped, *iter,
+                                ts...);
+                        }
+
+                        // execute last task directly, if needed
+                        if (direct)
+                        {
+                            HPX_INVOKE(wrapped, *iter, ts...);
+                        }
+                    };
+
+                    // launch a special thread to schedule work for each core,
+                    // except the last one
+                    if (t != num_threads - 1 &&
+                        part_size > hierarchical_threshold)
+                    {
+                        hpx::detail::post_policy_dispatch<Launch>::call(
+                            post_policy, desc, pool, HPX_MOVE(launcher), true);
+                        std::advance(it, part_size);
+                    }
+                    else if (part_size != 0)
+                    {
+                        launcher(t == num_threads - 1);
+                        std::advance(it, part_size);
+                    }
+
+                    begin = end;
+                }
+                HPX_ASSERT(it == hpx::util::end(shape));
+
+                l.wait();
+
+                // rethrow any exceptions caught during processing the
+                // bulk_execute, note that we don't need to acquire the lock
+                // at this point as no other threads may access the exception
+                // concurrently
+                if (e)
+                {
+                    std::rethrow_exception(HPX_MOVE(e));
+                }
+            },
+            desc, pool, first_thread, num_threads, hierarchical_threshold,
+            policy, HPX_FORWARD(F, f), shape, HPX_FORWARD(Ts, ts)...);
+    }
+
+    template <typename Launch, typename F, typename S, typename... Ts>
+    decltype(auto) hierarchical_bulk_async_execute(
+        hpx::util::thread_description const& desc,
+        threads::thread_pool_base* pool, std::size_t first_thread,
+        std::size_t num_threads, std::size_t hierarchical_threshold,
+        Launch policy, F&& f, S const& shape, Ts&&... ts)
+    {
+        using result_type = detail::bulk_function_result_t<F, S, Ts...>;
+        if constexpr (!std::is_void_v<result_type>)
+        {
+            return hierarchical_bulk_async_execute_helper(desc, pool,
+                first_thread, num_threads, hierarchical_threshold, policy,
+                HPX_FORWARD(F, f), shape, HPX_FORWARD(Ts, ts)...);
+        }
+        else
+        {
+            return hierarchical_bulk_async_execute_void(desc, pool,
+                first_thread, num_threads, hierarchical_threshold, policy,
+                HPX_FORWARD(F, f), shape, HPX_FORWARD(Ts, ts)...);
+        }
+    }
+
+    template <typename Launch, typename F, typename S, typename... Ts>
+    decltype(auto) hierarchical_bulk_async_execute(
+        threads::thread_pool_base* pool, std::size_t first_thread,
+        std::size_t num_threads, std::size_t hierarchical_threshold,
+        Launch policy, F&& f, S const& shape, Ts&&... ts)
+    {
+        hpx::util::thread_description const desc(
+            f, "hierarchical_bulk_async_execute");
+
+        return hierarchical_bulk_async_execute(desc, pool, first_thread,
             num_threads, hierarchical_threshold, policy, HPX_FORWARD(F, f),
             shape, HPX_FORWARD(Ts, ts)...);
     }
 
+    ////////////////////////////////////////////////////////////////////////////
     template <typename Executor, typename Launch, typename F, typename S,
         typename Future, typename... Ts>
     hpx::future<detail::bulk_then_execute_result_t<F, S, Future, Ts...>>
     hierarchical_bulk_then_execute_helper(Executor&& executor, Launch policy,
         F&& f, S const& shape, Future&& predecessor, Ts&&... ts)
     {
-        using func_result_type = typename detail::then_bulk_function_result<F,
-            S, Future, Ts...>::type;
-
-        // std::vector<future<func_result_type>>
-        using result_type = std::vector<hpx::future<func_result_type>>;
-
-        auto&& func = detail::make_fused_bulk_async_execute_helper<result_type>(
-            executor, HPX_FORWARD(F, f), shape,
-            hpx::make_tuple(HPX_FORWARD(Ts, ts)...));
+        auto&& func = detail::make_fused_bulk_async_execute_helper(executor,
+            HPX_FORWARD(F, f), shape, hpx::make_tuple(HPX_FORWARD(Ts, ts)...));
 
         // void or std::vector<func_result_type>
         using vector_result_type =

--- a/libs/core/executors/include/hpx/executors/fork_join_executor.hpp
+++ b/libs/core/executors/include/hpx/executors/fork_join_executor.hpp
@@ -570,17 +570,12 @@ namespace hpx { namespace execution { namespace experimental {
             }
 
             template <typename F, typename S, typename... Ts>
-            std::vector<hpx::future<hpx::parallel::execution::detail::
-                    bulk_function_result_t<F, S, Ts...>>>
-            bulk_async_execute(F&& f, S const& shape, Ts&&... ts)
+            hpx::future<void> bulk_async_execute(
+                F&& f, S const& shape, Ts&&... ts)
             {
                 // Forward to the synchronous version as we can't create
                 // futures to the completion of the parallel region (this HPX
                 // thread participates in computation).
-                using result_type =
-                    hpx::parallel::execution::detail::bulk_function_result_t<F,
-                        S, Ts...>;
-                std::vector<hpx::future<result_type>> v;
                 try
                 {
                     bulk_sync_execute(
@@ -588,10 +583,12 @@ namespace hpx { namespace execution { namespace experimental {
                 }
                 catch (...)
                 {
-                    v.push_back(hpx::make_exceptional_future<result_type>(
-                        std::current_exception()));
+                    using result_type = hpx::parallel::execution::detail::
+                        bulk_function_result_t<F, S, Ts...>;
+                    return hpx::make_exceptional_future<result_type>(
+                        std::current_exception());
                 }
-                return v;
+                return hpx::make_ready_future();
             }
         };
 

--- a/libs/core/executors/include/hpx/executors/parallel_executor.hpp
+++ b/libs/core/executors/include/hpx/executors/parallel_executor.hpp
@@ -331,23 +331,21 @@ namespace hpx { namespace execution {
             hpx::util::thread_description desc(f, annotation_);
             auto pool =
                 pool_ ? pool_ : threads::detail::get_self_or_default_pool();
-            parallel::execution::detail::post_policy_dispatch<Policy>::call(
+            hpx::detail::post_policy_dispatch<Policy>::call(
                 policy_, desc, pool, HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...);
         }
 
         // BulkTwoWayExecutor interface
         template <typename F, typename S, typename... Ts>
-        std::vector<hpx::future<typename parallel::execution::detail::
-                bulk_function_result<F, S, Ts...>::type>>
-        bulk_async_execute(F&& f, S const& shape, Ts&&... ts) const
+        decltype(auto) bulk_async_execute(
+            F&& f, S const& shape, Ts&&... ts) const
         {
             hpx::util::thread_description desc(f, annotation_);
             auto pool =
                 pool_ ? pool_ : threads::detail::get_self_or_default_pool();
-            return parallel::execution::detail::
-                hierarchical_bulk_async_execute_helper(desc, pool, 0,
-                    get_num_cores(), hierarchical_threshold_, policy_,
-                    HPX_FORWARD(F, f), shape, HPX_FORWARD(Ts, ts)...);
+            return parallel::execution::detail::hierarchical_bulk_async_execute(
+                desc, pool, 0, get_num_cores(), hierarchical_threshold_,
+                policy_, HPX_FORWARD(F, f), shape, HPX_FORWARD(Ts, ts)...);
         }
 
         template <typename F, typename S, typename Future, typename... Ts>

--- a/libs/core/executors/include/hpx/executors/parallel_executor_aggregated.hpp
+++ b/libs/core/executors/include/hpx/executors/parallel_executor_aggregated.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2019 Hartmut Kaiser
+//  Copyright (c) 2007-2022 Hartmut Kaiser
 //  Copyright (c) 2019 Agustin Berge
 //
 //  SPDX-License-Identifier: BSL-1.0
@@ -12,6 +12,7 @@
 #include <hpx/config.hpp>
 #include <hpx/assert.hpp>
 #include <hpx/async_base/launch_policy.hpp>
+#include <hpx/errors/try_catch_exception_ptr.hpp>
 #include <hpx/execution/algorithms/detail/predicates.hpp>
 #include <hpx/execution/detail/async_launch_policy_dispatch.hpp>
 #include <hpx/execution/detail/post_policy_dispatch.hpp>
@@ -110,7 +111,7 @@ namespace hpx { namespace parallel { namespace execution {
             hpx::util::thread_description desc(
                 f, "parallel_executor_aggregated::post");
 
-            detail::post_policy_dispatch<Policy>::call(
+            hpx::detail::post_policy_dispatch<Policy>::call(
                 Policy{}, desc, HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...);
         }
 
@@ -169,17 +170,14 @@ namespace hpx { namespace parallel { namespace execution {
                 {
                     post([&, it] {
                         // properly handle all exceptions thrown from 'f'
-                        try
-                        {
-                            HPX_INVOKE(f, *it, ts...);
-                        }
-                        catch (...)
-                        {
-                            // store the first caught exception only
-                            std::lock_guard<lcos::local::spinlock> l(mtx_e);
-                            if (!e)
-                                e = std::current_exception();
-                        }
+                        hpx::detail::try_catch_exception_ptr(
+                            [&]() { HPX_INVOKE(f, *it, ts...); },
+                            [&](std::exception_ptr ep) {
+                                // store the first caught exception only
+                                std::lock_guard<lcos::local::spinlock> l(mtx_e);
+                                if (!e)
+                                    e = HPX_MOVE(ep);
+                            });
                         // count down the latch in any case
                         l.count_down(1);
                     });
@@ -324,7 +322,7 @@ namespace hpx { namespace parallel { namespace execution {
             hpx::util::thread_description desc(
                 f, "parallel_executor_aggregated::post");
 
-            detail::post_policy_dispatch<hpx::launch>::call(
+            hpx::detail::post_policy_dispatch<hpx::launch>::call(
                 policy_, desc, HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...);
         }
 
@@ -384,20 +382,18 @@ namespace hpx { namespace parallel { namespace execution {
 
                 for (std::size_t i = 0; i != size; ++i, ++it)
                 {
-                    detail::post_policy_dispatch<hpx::launch>::call(
+                    hpx::detail::post_policy_dispatch<hpx::launch>::call(
                         policy_, desc, [&, it]() -> void {
                             // properly handle all exceptions thrown from 'f'
-                            try
-                            {
-                                HPX_INVOKE(f, *it, ts...);
-                            }
-                            catch (...)
-                            {
-                                // store the first caught exception only
-                                std::lock_guard<lcos::local::spinlock> l(mtx_e);
-                                if (!e)
-                                    e = std::current_exception();
-                            }
+                            hpx::detail::try_catch_exception_ptr(
+                                [&]() { HPX_INVOKE(f, *it, ts...); },
+                                [&](std::exception_ptr ep) {
+                                    // store the first caught exception only
+                                    std::lock_guard<lcos::local::spinlock> l(
+                                        mtx_e);
+                                    if (!e)
+                                        e = HPX_MOVE(ep);
+                                });
                             // count down the latch in any case
                             l.count_down(1);
                         });
@@ -421,7 +417,7 @@ namespace hpx { namespace parallel { namespace execution {
 
                     while (size > chunk_size)
                     {
-                        detail::post_policy_dispatch<hpx::launch>::call(
+                        hpx::detail::post_policy_dispatch<hpx::launch>::call(
                             policy_, desc, [&, chunk_size, num_tasks, it] {
                                 spawn_hierarchical(l, chunk_size, num_tasks, f,
                                     it, e, mtx_e, ts...);
@@ -445,16 +441,10 @@ namespace hpx { namespace parallel { namespace execution {
     public:
         // BulkTwoWayExecutor interface
         template <typename F, typename S, typename... Ts>
-        std::vector<hpx::future<void>> bulk_async_execute(
-            F&& f, S const& shape, Ts&&... ts) const
+        auto bulk_async_execute(F&& f, S const& shape, Ts&&... ts) const
         {
-            // for now, wrap single future in a vector to avoid having to
-            // change the executor and algorithm infrastructure
-            std::vector<hpx::future<void>> result;
-            result.push_back(
-                async_execute(sync_exec{policy_, num_spread_, num_tasks_},
-                    HPX_FORWARD(F, f), shape, HPX_FORWARD(Ts, ts)...));
-            return result;
+            return async_execute(sync_exec{policy_, num_spread_, num_tasks_},
+                HPX_FORWARD(F, f), shape, HPX_FORWARD(Ts, ts)...);
         }
 
     private:

--- a/libs/core/executors/include/hpx/executors/restricted_thread_pool_executor.hpp
+++ b/libs/core/executors/include/hpx/executors/restricted_thread_pool_executor.hpp
@@ -144,20 +144,18 @@ namespace hpx { namespace parallel { namespace execution {
             auto policy = launch::async_policy(priority_, stacksize_,
                 threads::thread_schedule_hint(get_next_thread_num()));
 
-            detail::post_policy_dispatch<launch::async_policy>::call(
+            hpx::detail::post_policy_dispatch<launch::async_policy>::call(
                 policy, desc, pool_, HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...);
         }
 
         template <typename F, typename S, typename... Ts>
-        std::vector<hpx::future<
-            typename detail::bulk_function_result<F, S, Ts...>::type>>
-        bulk_async_execute(F&& f, S const& shape, Ts&&... ts) const
+        auto bulk_async_execute(F&& f, S const& shape, Ts&&... ts) const
         {
             auto policy =
                 launch::async_policy(priority_, stacksize_, schedulehint_);
 
-            return detail::hierarchical_bulk_async_execute_helper(pool_,
-                first_thread_, num_threads_, hierarchical_threshold_, policy,
+            return detail::hierarchical_bulk_async_execute(pool_, first_thread_,
+                num_threads_, hierarchical_threshold_, policy,
                 HPX_FORWARD(F, f), shape, HPX_FORWARD(Ts, ts)...);
         }
 

--- a/libs/core/executors/include/hpx/executors/scheduler_executor.hpp
+++ b/libs/core/executors/include/hpx/executors/scheduler_executor.hpp
@@ -243,7 +243,7 @@ namespace hpx::execution::experimental {
 
         // BulkTwoWayExecutor interface
         template <typename F, typename S, typename... Ts>
-        decltype(auto) bulk_async_execute(F&& f, S const& shape, Ts&&... ts)
+        auto bulk_async_execute(F&& f, S const& shape, Ts&&... ts)
         {
             using shape_element =
                 typename hpx::traits::range_traits<S>::value_type;
@@ -252,12 +252,8 @@ namespace hpx::execution::experimental {
 
             if constexpr (std::is_void_v<result_type>)
             {
-                std::vector<hpx::future<void>> results;
-                results.reserve(1);
-                results.emplace_back(make_future(bulk(schedule(sched_), shape,
-                    hpx::bind_back(
-                        HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...))));
-                return results;
+                return make_future(bulk(schedule(sched_), shape,
+                    hpx::bind_back(HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...)));
             }
             else
             {

--- a/libs/core/executors/include/hpx/executors/service_executors.hpp
+++ b/libs/core/executors/include/hpx/executors/service_executors.hpp
@@ -132,15 +132,9 @@ namespace hpx { namespace parallel { namespace execution { namespace detail {
         bulk_then_execute(
             F&& f, Shape const& shape, Future&& predecessor, Ts&&... ts)
         {
-            using func_result_type =
-                typename parallel::execution::detail::then_bulk_function_result<
-                    F, Shape, Future, Ts...>::type;
-            using result_type = std::vector<hpx::future<func_result_type>>;
-
             auto func = parallel::execution::detail::
-                make_fused_bulk_async_execute_helper<result_type>(*this,
-                    HPX_FORWARD(F, f), shape,
-                    hpx::make_tuple(HPX_FORWARD(Ts, ts)...));
+                make_fused_bulk_async_execute_helper(*this, HPX_FORWARD(F, f),
+                    shape, hpx::make_tuple(HPX_FORWARD(Ts, ts)...));
             using vector_result_type =
                 typename parallel::execution::detail::bulk_then_execute_result<
                     F, Shape, Future, Ts...>::type;

--- a/libs/core/executors/tests/unit/fork_join_executor.cpp
+++ b/libs/core/executors/tests/unit/fork_join_executor.cpp
@@ -135,8 +135,7 @@ void test_bulk_async_exception(ExecutorArgs&&... args)
     {
         auto r = hpx::parallel::execution::bulk_async_execute(
             exec, &bulk_test_exception, v, 42);
-        HPX_TEST_EQ(r.size(), std::size_t(1));
-        r[0].get();
+        r.get();
 
         HPX_TEST(false);
     }

--- a/libs/core/functional/include/hpx/functional/deferred_call.hpp
+++ b/libs/core/functional/include/hpx/functional/deferred_call.hpp
@@ -81,8 +81,7 @@ namespace hpx { namespace util {
             deferred(deferred const&) = delete;
             deferred& operator=(deferred const&) = delete;
 
-            HPX_HOST_DEVICE HPX_FORCEINLINE util::invoke_result_t<F, Ts...>
-            operator()()
+            HPX_HOST_DEVICE HPX_FORCEINLINE decltype(auto) operator()()
             {
                 return HPX_INVOKE(
                     HPX_MOVE(_f), HPX_MOVE(_args).template get<Is>()...);

--- a/libs/core/futures/include/hpx/futures/traits/future_access.hpp
+++ b/libs/core/futures/include/hpx/futures/traits/future_access.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2021 Hartmut Kaiser
+//  Copyright (c) 2007-2022 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -11,6 +11,8 @@
 #include <hpx/modules/memory.hpp>
 #include <hpx/type_support/unused.hpp>
 
+#include <array>
+#include <cstddef>
 #include <type_traits>
 #include <utility>
 #include <vector>
@@ -96,6 +98,13 @@ namespace hpx { namespace traits {
         {
             using type =
                 std::vector<typename shared_state_ptr_for<Future>::type>;
+        };
+
+        template <typename Future, std::size_t N>
+        struct shared_state_ptr_for<std::array<Future, N>>
+        {
+            using type =
+                std::array<typename shared_state_ptr_for<Future>::type, N>;
         };
 
         template <typename Future>

--- a/libs/core/futures/include/hpx/futures/traits/is_future.hpp
+++ b/libs/core/futures/include/hpx/futures/traits/is_future.hpp
@@ -39,20 +39,22 @@ namespace hpx { namespace traits {
         struct is_future_customization_point : std::false_type
         {
         };
+
+        template <typename R>
+        struct is_future_customization_point<hpx::future<R>> : std::true_type
+        {
+        };
+
+        template <typename R>
+        struct is_future_customization_point<hpx::shared_future<R>>
+          : std::true_type
+        {
+        };
     }    // namespace detail
 
     template <typename Future>
-    struct is_future : detail::is_future_customization_point<Future>
-    {
-    };
-
-    template <typename R>
-    struct is_future<hpx::future<R>> : std::true_type
-    {
-    };
-
-    template <typename R>
-    struct is_future<hpx::shared_future<R>> : std::true_type
+    struct is_future
+      : detail::is_future_customization_point<std::decay_t<Future>>
     {
     };
 

--- a/libs/core/resiliency/include/hpx/resiliency/async_replicate_executor.hpp
+++ b/libs/core/resiliency/include/hpx/resiliency/async_replicate_executor.hpp
@@ -1,6 +1,6 @@
 //  Copyright (c) 2019 National Technology & Engineering Solutions of Sandia,
 //                     LLC (NTESS).
-//  Copyright (c) 2018-2020 Hartmut Kaiser
+//  Copyright (c) 2018-2022 Hartmut Kaiser
 //  Copyright (c) 2018-2019 Adrian Serio
 //  Copyright (c) 2019 Nikunj Gupta
 //
@@ -44,10 +44,6 @@ namespace hpx { namespace resiliency { namespace experimental {
                     typename hpx::util::detail::invoke_deferred_result<F,
                         Ts...>::type;
 
-                using future_type =
-                    typename hpx::traits::executor_future<Executor,
-                        result_type>::type;
-
                 // launch given function n times
                 auto func = [f = HPX_FORWARD(F, f),
                                 t = hpx::make_tuple(HPX_FORWARD(Ts, ts)...)](
@@ -56,9 +52,8 @@ namespace hpx { namespace resiliency { namespace experimental {
                     return hpx::util::invoke_fused(f, t);
                 };
 
-                std::vector<future_type> results =
-                    hpx::parallel::execution::bulk_async_execute(
-                        HPX_FORWARD(Executor, exec), HPX_MOVE(func), n);
+                auto&& results = hpx::parallel::execution::bulk_async_execute(
+                    HPX_FORWARD(Executor, exec), HPX_MOVE(func), n);
 
                 // wait for all threads to finish executing and return the first
                 // result that passes the predicate, properly handle exceptions
@@ -67,24 +62,27 @@ namespace hpx { namespace resiliency { namespace experimental {
                     hpx::launch::sync,
                     [pred = HPX_FORWARD(Pred, pred),
                         vote = HPX_FORWARD(Vote, vote),
-                        n](std::vector<future_type>&& results) mutable
-                    -> result_type {
+                        n](auto&& results) mutable -> result_type {
                         // Store all valid results
                         std::vector<result_type> valid_results;
                         valid_results.reserve(n);
 
                         std::exception_ptr ex;
 
-                        for (auto&& f : HPX_MOVE(results))
+                        // clang-format off
+                        if constexpr (hpx::traits::is_future_v<
+                                          decltype(results)>)
+                        // clang-format on
                         {
-                            if (f.has_exception())
+                            if (results.has_exception())
                             {
                                 // rethrow abort_replicate_exception, if caught
-                                ex = detail::rethrow_on_abort_replicate(f);
+                                ex =
+                                    detail::rethrow_on_abort_replicate(results);
                             }
                             else
                             {
-                                auto&& result = f.get();
+                                auto&& result = results.get();
                                 if (HPX_INVOKE(pred, result))
                                 {
                                     valid_results.emplace_back(
@@ -92,10 +90,30 @@ namespace hpx { namespace resiliency { namespace experimental {
                                 }
                             }
                         }
+                        else
+                        {
+                            for (auto&& f : HPX_MOVE(results))
+                            {
+                                if (f.has_exception())
+                                {
+                                    // rethrow abort_replicate_exception, if caught
+                                    ex = detail::rethrow_on_abort_replicate(f);
+                                }
+                                else
+                                {
+                                    auto&& result = f.get();
+                                    if (HPX_INVOKE(pred, result))
+                                    {
+                                        valid_results.emplace_back(
+                                            HPX_MOVE(result));
+                                    }
+                                }
+                            }
+                        }
 
                         if (!valid_results.empty())
                         {
-                            return HPX_INVOKE(HPX_FORWARD(Vote, vote),
+                            return hpx::util::invoke(HPX_FORWARD(Vote, vote),
                                 HPX_MOVE(valid_results));
                         }
 
@@ -121,40 +139,60 @@ namespace hpx { namespace resiliency { namespace experimental {
             call(Executor&& exec, std::size_t n, Vote&&, Pred&&, F&& f,
                 Ts&&... ts)
             {
-                using future_type =
-                    typename hpx::traits::executor_future<Executor, void>::type;
-
                 // launch given function n times
                 auto func = [f = HPX_FORWARD(F, f),
                                 t = hpx::make_tuple(HPX_FORWARD(Ts, ts)...)](
                                 std::size_t) mutable {
                     // ignore argument (invocation count of bulk_execute)
                     hpx::util::invoke_fused(f, t);
+
+                    // return non-void result to force executor into providing a
+                    // future for each invocation (returning void might optimize
+                    // bulk_async_execute to return just a single future)
+                    return 0;
                 };
 
-                std::vector<future_type> results =
-                    hpx::parallel::execution::bulk_async_execute(
-                        HPX_FORWARD(Executor, exec), HPX_MOVE(func), n);
+                auto&& results = hpx::parallel::execution::bulk_async_execute(
+                    HPX_FORWARD(Executor, exec), HPX_MOVE(func), n);
 
                 // wait for all threads to finish executing and return the first
                 // result that passes the predicate, properly handle exceptions
                 // do not schedule new thread for the lambda
                 return hpx::dataflow(
                     hpx::launch::sync,
-                    [](std::vector<future_type>&& results) mutable -> void {
+                    [](auto&& results) mutable -> void {
                         std::exception_ptr ex;
 
                         std::size_t count = 0;
-                        for (auto&& f : HPX_MOVE(results))
+                        // clang-format off
+                        if constexpr (hpx::traits::is_future_v<
+                                          decltype(results)>)
+                        // clang-format on
                         {
-                            if (f.has_exception())
+                            if (results.has_exception())
                             {
                                 // rethrow abort_replicate_exception, if caught
-                                ex = detail::rethrow_on_abort_replicate(f);
+                                ex =
+                                    detail::rethrow_on_abort_replicate(results);
                             }
                             else
                             {
                                 ++count;
+                            }
+                        }
+                        else
+                        {
+                            for (auto&& f : HPX_MOVE(results))
+                            {
+                                if (f.has_exception())
+                                {
+                                    // rethrow abort_replicate_exception, if caught
+                                    ex = detail::rethrow_on_abort_replicate(f);
+                                }
+                                else
+                                {
+                                    ++count;
+                                }
                             }
                         }
 

--- a/libs/core/testing/include/hpx/testing/performance.hpp
+++ b/libs/core/testing/include/hpx/testing/performance.hpp
@@ -9,16 +9,17 @@
 #include <hpx/config.hpp>
 #include <hpx/functional/function.hpp>
 
-#include <chrono>
 #include <cstddef>
 #include <map>
 #include <ostream>
 #include <string>
+#include <tuple>
 #include <vector>
 
 namespace hpx { namespace util {
 
     namespace detail {
+
         // Json output for performance reports
         class json_perf_times
         {
@@ -28,40 +29,8 @@ namespace hpx { namespace util {
 
             map_t m_map;
 
-            friend std::ostream& operator<<(
-                std::ostream& strm, json_perf_times const& obj)
-            {
-                strm << "{\n";
-                strm << "  \"outputs\" : [";
-                int outputs = 0;
-                for (auto&& item : obj.m_map)
-                {
-                    if (outputs)
-                        strm << ",";
-                    strm << "\n    {\n";
-                    strm << "      \"name\" : \"" << std::get<0>(item.first)
-                         << "\",\n";
-                    strm << "      \"executor\" : \"" << std::get<1>(item.first)
-                         << "\",\n";
-                    strm << "      \"series\" : [";
-                    int series = 0;
-                    for (auto val : item.second)
-                    {
-                        if (series)
-                            strm << ", ";
-                        strm << val;
-                        ++series;
-                    }
-                    strm << "]\n";
-                    strm << "    }";
-                    ++outputs;
-                }
-                if (outputs)
-                    strm << "\n  ";
-                strm << "]\n";
-                strm << "}\n";
-                return strm;
-            }
+            HPX_CORE_EXPORT friend std::ostream& operator<<(
+                std::ostream& strm, json_perf_times const& obj);
 
         public:
             void add(std::string const& name, std::string const& executor,

--- a/libs/core/testing/src/performance.cpp
+++ b/libs/core/testing/src/performance.cpp
@@ -6,6 +6,7 @@
 
 #include <hpx/testing/performance.hpp>
 
+#include <chrono>
 #include <cstddef>
 #include <iostream>
 #include <string>
@@ -27,6 +28,40 @@ namespace hpx { namespace util {
             times().add(test_name, executor, time);
         }
 
+        HPX_CORE_EXPORT std::ostream& operator<<(
+            std::ostream& strm, json_perf_times const& obj)
+        {
+            strm << "{\n";
+            strm << "  \"outputs\" : [";
+            int outputs = 0;
+            for (auto&& item : obj.m_map)
+            {
+                if (outputs)
+                    strm << ",";
+                strm << "\n    {\n";
+                strm << "      \"name\" : \"" << std::get<0>(item.first)
+                     << "\",\n";
+                strm << "      \"executor\" : \"" << std::get<1>(item.first)
+                     << "\",\n";
+                strm << "      \"series\" : [";
+                int series = 0;
+                for (auto val : item.second)
+                {
+                    if (series)
+                        strm << ", ";
+                    strm << val;
+                    ++series;
+                }
+                strm << "]\n";
+                strm << "    }";
+                ++outputs;
+            }
+            if (outputs)
+                strm << "\n  ";
+            strm << "]\n";
+            strm << "}\n";
+            return strm;
+        }
     }    // namespace detail
 
     void perftests_report(std::string const& name, std::string const& exec,
@@ -56,5 +91,4 @@ namespace hpx { namespace util {
     {
         std::cout << detail::times();
     }
-
 }}    // namespace hpx::util

--- a/libs/full/compute/include/hpx/compute/host/block_allocator.hpp
+++ b/libs/full/compute/include/hpx/compute/host/block_allocator.hpp
@@ -173,7 +173,7 @@ namespace hpx { namespace compute { namespace host {
                         return std::make_pair(it, last);
                     },
                     // finalize, called once if no error occurred
-                    [](std::vector<hpx::future<partition_result_type>>&&) {
+                    [](auto&&) {
                         // do nothing
                     },
                     // cleanup function, called for each partition which

--- a/libs/full/compute/include/hpx/compute/host/block_executor.hpp
+++ b/libs/full/compute/include/hpx/compute/host/block_executor.hpp
@@ -171,9 +171,17 @@ namespace hpx { namespace compute { namespace host {
                         executors_[i], HPX_FORWARD(F, f),
                         util::make_iterator_range(part_begin, part_end),
                         HPX_FORWARD(Ts, ts)...);
-                    results.insert(results.end(),
-                        std::make_move_iterator(futures.begin()),
-                        std::make_move_iterator(futures.end()));
+
+                    if constexpr (hpx::traits::is_future_v<decltype(futures)>)
+                    {
+                        results.push_back(HPX_MOVE(futures));
+                    }
+                    else
+                    {
+                        results.insert(results.end(),
+                            std::make_move_iterator(futures.begin()),
+                            std::make_move_iterator(futures.end()));
+                    }
                 }
                 return results;
             }

--- a/libs/full/segmented_algorithms/include/hpx/parallel/segmented_algorithms/detail/reduce.hpp
+++ b/libs/full/segmented_algorithms/include/hpx/parallel/segmented_algorithms/detail/reduce.hpp
@@ -55,7 +55,7 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
                     return util::accumulate_n(
                         ++part_begin, --part_size, HPX_MOVE(val), r);
                 },
-                hpx::unwrapping([r](std::vector<T>&& results) -> T {
+                hpx::unwrapping([r](auto&& results) -> T {
                     auto rfirst = hpx::util::begin(results);
                     auto rlast = hpx::util::end(results);
                     return util::accumulate<T>(rfirst, rlast, r);
@@ -102,7 +102,7 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
                                 r, HPX_MOVE(res), HPX_INVOKE(conv, next));
                         });
                 },
-                hpx::unwrapping([r](std::vector<T>&& results) -> T {
+                hpx::unwrapping([r](auto&& results) -> T {
                     auto rfirst = hpx::util::begin(results);
                     auto rlast = hpx::util::end(results);
                     return util::accumulate<T>(rfirst, rlast, r);
@@ -149,7 +149,7 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
                     return util::accumulate<T>(it1, last1, it2,
                         HPX_FORWARD(Reduce, r), HPX_FORWARD(Convert, conv));
                 },
-                hpx::unwrapping([r](std::vector<T>&& results) -> T {
+                hpx::unwrapping([r](auto&& results) -> T {
                     auto rfirst1 = hpx::util::begin(results);
                     auto rlast1 = hpx::util::end(results);
                     return util::accumulate<T>(rfirst1, rlast1, r);

--- a/tests/regressions/build/client_1950.cpp
+++ b/tests/regressions/build/client_1950.cpp
@@ -18,7 +18,7 @@
 int hpx_main(hpx::program_options::variables_map& vm)
 {
     {
-        hpx::cout << "Hello World!\n" << hpx::flush;
+        hpx::cout << "Hello World!\n" << std::flush;
 
         hpx::id_type id = hpx::new_<test_server>(hpx::find_here()).get();
         hpx::future<void> f = hpx::async(call_action(), id);


### PR DESCRIPTION
- reduce allocations by reducing the number of created futures and by circumventing using `std::vector` if not needed
- return a single `hpx::future<void>` for bulk execution of chunks that return `void`
- modernized chunk size computation
