### PR TITLE
Add back explicit template parameter to `ignore_while_checking` to compile with nvcc

### DIFF
--- a/libs/core/execution/include/hpx/execution/algorithms/sync_wait.hpp
+++ b/libs/core/execution/include/hpx/execution/algorithms/sync_wait.hpp
@@ -139,7 +139,7 @@ namespace hpx::execution::experimental::detail {
         {
             std::unique_lock<mutex_type> l(state.mtx);
             state.set_called = true;
-            hpx::util::ignore_while_checking il(&l);
+            hpx::util::ignore_while_checking<decltype(l)> il(&l);
             HPX_UNUSED(il);
 
             state.cond_var.notify_one();


### PR DESCRIPTION
This fails to compile at least with GCC 9.3.0 and CUDA 11.3 unless the template parameter is specified explicitly.