### PR TITLE
Exposing zero-copy serialization threshold through configuration option

### DIFF
--- a/docs/sphinx/manual/launching_and_configuring_hpx_applications.rst
+++ b/docs/sphinx/manual/launching_and_configuring_hpx_applications.rst
@@ -504,6 +504,11 @@ The ``hpx.parcel`` configuration section
      * This property defines whether this :term:`locality` is allowed to utilize
        zero copy optimizations during serialization of :term:`parcel` data. The default
        is the same value as set for ``hpx.parcel.array_optimization``.
+   * * ``hpx.parcel.zero_copy_serialization_threshold``
+     * This property defines the threshold value (in bytes) starting at which the
+       serialization layer will apply zero-copy optimizations for serialized
+       entities. The default value is defined by the preprocessor constant
+       ``HPX_ZERO_COPY_SERIALIZATION_THRESHOLD``.
    * * ``hpx.parcel.async_serialization``
      * This property defines whether this :term:`locality` is allowed to spawn a
        new thread for serialization (this is both for encoding and decoding
@@ -511,6 +516,9 @@ The ``hpx.parcel`` configuration section
    * * ``hpx.parcel.message_handlers``
      * This property defines whether message handlers are loaded. The default is
        ``0``.
+   * * ``hpx.parcel.max_background_threads``
+     * This property defines how many cores should be used to perform background
+       operations. The default is ``-1`` (all cores).
 
 The following settings relate to the TCP/IP parcelport.
 
@@ -520,12 +528,14 @@ The following settings relate to the TCP/IP parcelport.
    enable = ${HPX_HAVE_PARCELPORT_TCP:$[hpx.parcel.enabled]}
    array_optimization = ${HPX_PARCEL_TCP_ARRAY_OPTIMIZATION:$[hpx.parcel.array_optimization]}
    zero_copy_optimization = ${HPX_PARCEL_TCP_ZERO_COPY_OPTIMIZATION:$[hpx.parcel.zero_copy_optimization]}
+   zero_copy_serialization_threshold =  ${HPX_PARCEL_TCP_ZERO_COPY_SERIALIZATION_THRESHOLD:$[hpx.parcel.zero_copy_serialization_threshold]}
    async_serialization = ${HPX_PARCEL_TCP_ASYNC_SERIALIZATION:$[hpx.parcel.async_serialization]}
    parcel_pool_size = ${HPX_PARCEL_TCP_PARCEL_POOL_SIZE:$[hpx.threadpools.parcel_pool_size]}
    max_connections =  ${HPX_PARCEL_TCP_MAX_CONNECTIONS:$[hpx.parcel.max_connections]}
    max_connections_per_locality = ${HPX_PARCEL_TCP_MAX_CONNECTIONS_PER_LOCALITY:$[hpx.parcel.max_connections_per_locality]}
    max_message_size =  ${HPX_PARCEL_TCP_MAX_MESSAGE_SIZE:$[hpx.parcel.max_message_size]}
    max_outbound_message_size =  ${HPX_PARCEL_TCP_MAX_OUTBOUND_MESSAGE_SIZE:$[hpx.parcel.max_outbound_message_size]}
+   max_background_threads =  ${HPX_PARCEL_TCP_MAX_BACKGROUND_THREADS:$[hpx.parcel.max_background_threads]}
 
 .. _ini_hpx_parcel_tcp:
 
@@ -548,6 +558,11 @@ The following settings relate to the TCP/IP parcelport.
        zero copy optimizations in the TCP/IP parcelport during serialization of
        parcel data. The default is the same value as set for
        ``hpx.parcel.zero_copy_optimization``.
+   * * ``hpx.parcel.tcp.zero_copy_serialization_threshold``
+     * This property defines the threshold value (in bytes) starting at which the
+       serialization layer will apply zero-copy optimizations for serialized
+       entities. The default is the same value as set for
+       ``hpx.parcel.zero_copy_serialization_threshold``.
    * * ``hpx.parcel.tcp.async_serialization``
      * This property defines whether this :term:`locality` is allowed to spawn a
        new thread for serialization in the TCP/IP parcelport (this is both for
@@ -573,6 +588,9 @@ The following settings relate to the TCP/IP parcelport.
      * This property defines the maximum allowed outbound coalesced message size
        which will be transferable through the :term:`parcel` layer. The default is
        taken from ``hpx.parcel.max_outbound_connections``.
+   * * ``hpx.parcel.tcp.max_background_threads``
+     * This property defines how many cores should be used to perform background
+       operations. The default is taken from ``hpx.parcel.max_background_threads``.
 
 The following settings relate to the MPI parcelport. These settings take effect
 only if the compile time constant ``HPX_HAVE_PARCELPORT_MPI`` is set (the
@@ -589,6 +607,7 @@ equivalent cmake variable is ``HPX_WITH_PARCELPORT_MPI`` and has to be set to
    processor_name = <MPI_processor_name>
    array_optimization = ${HPX_HAVE_PARCEL_MPI_ARRAY_OPTIMIZATION:$[hpx.parcel.array_optimization]}
    zero_copy_optimization = ${HPX_HAVE_PARCEL_MPI_ZERO_COPY_OPTIMIZATION:$[hpx.parcel.zero_copy_optimization]}
+   zero_copy_serialization_threshold =  ${HPX_PARCEL_MPI_ZERO_COPY_SERIALIZATION_THRESHOLD:$[hpx.parcel.zero_copy_serialization_threshold]}
    use_io_pool = ${HPX_HAVE_PARCEL_MPI_USE_IO_POOL:$1}
    async_serialization = ${HPX_HAVE_PARCEL_MPI_ASYNC_SERIALIZATION:$[hpx.parcel.async_serialization]}
    parcel_pool_size = ${HPX_HAVE_PARCEL_MPI_PARCEL_POOL_SIZE:$[hpx.threadpools.parcel_pool_size]}
@@ -596,6 +615,7 @@ equivalent cmake variable is ``HPX_WITH_PARCELPORT_MPI`` and has to be set to
    max_connections_per_locality = ${HPX_HAVE_PARCEL_MPI_MAX_CONNECTIONS_PER_LOCALITY:$[hpx.parcel.max_connections_per_locality]}
    max_message_size =  ${HPX_HAVE_PARCEL_MPI_MAX_MESSAGE_SIZE:$[hpx.parcel.max_message_size]}
    max_outbound_message_size =  ${HPX_HAVE_PARCEL_MPI_MAX_OUTBOUND_MESSAGE_SIZE:$[hpx.parcel.max_outbound_message_size]}
+   max_background_threads =  ${HPX_PARCEL_MPI_MAX_BACKGROUND_THREADS:$[hpx.parcel.max_background_threads]}
 
 .. _ini_hpx_parcel_mpi:
 
@@ -634,6 +654,11 @@ equivalent cmake variable is ``HPX_WITH_PARCELPORT_MPI`` and has to be set to
        zero copy optimizations in the MPI parcelport during serialization of
        parcel data. The default is the same value as set for
        ``hpx.parcel.zero_copy_optimization``.
+   * * ``hpx.parcel.mpi.zero_copy_serialization_threshold``
+     * This property defines the threshold value (in bytes) starting at which the
+       serialization layer will apply zero-copy optimizations for serialized
+       entities. The default is the same value as set for
+       ``hpx.parcel.zero_copy_serialization_threshold``.
    * * ``hpx.parcel.mpi.use_io_pool``
      * This property can be set to run the progress thread inside of HPX threads
        instead of a separate thread pool. The default is ``1``.
@@ -662,6 +687,9 @@ equivalent cmake variable is ``HPX_WITH_PARCELPORT_MPI`` and has to be set to
      * This property defines the maximum allowed outbound coalesced message size
        which will be transferable through the :term:`parcel` layer. The default is
        taken from ``hpx.parcel.max_outbound_connections``.
+   * * ``hpx.parcel.tcp.max_background_threads``
+     * This property defines how many cores should be used to perform background
+       operations. The default is taken from ``hpx.parcel.max_background_threads``.
 
 The ``hpx.agas`` configuration section
 ......................................

--- a/libs/core/serialization/include/hpx/serialization/container.hpp
+++ b/libs/core/serialization/include/hpx/serialization/container.hpp
@@ -41,6 +41,8 @@ namespace hpx::serialization {
             return false;
         }
         virtual void set_filter(binary_filter* filter) = 0;
+        virtual void set_zero_copy_serialization_threshold(
+            std::size_t zero_copy_serialization_threshold) = 0;
         virtual void load_binary(void* address, std::size_t count) = 0;
         virtual void load_binary_chunk(void* address, std::size_t count) = 0;
     };

--- a/libs/core/serialization/include/hpx/serialization/input_archive.hpp
+++ b/libs/core/serialization/include/hpx/serialization/input_archive.hpp
@@ -73,6 +73,12 @@ namespace hpx::serialization {
             load(flags);
             flags_ = flags;
 
+            // load the zero-copy limit used by the other end
+            std::size_t zero_copy_serialization_threshold;
+            load(zero_copy_serialization_threshold);
+            buffer_->set_zero_copy_serialization_threshold(
+                zero_copy_serialization_threshold);
+
             bool has_filter = false;
             load(has_filter);
 

--- a/libs/core/serialization/include/hpx/serialization/input_container.hpp
+++ b/libs/core/serialization/include/hpx/serialization/input_container.hpp
@@ -56,6 +56,8 @@ namespace hpx::serialization {
           , current_(0)
           , filter_()
           , decompressed_size_(inbound_data_size)
+          , zero_copy_serialization_threshold_(
+                HPX_ZERO_COPY_SERIALIZATION_THRESHOLD)
           , chunks_(nullptr)
           , current_chunk_(std::size_t(-1))
           , current_chunk_size_(0)
@@ -69,6 +71,8 @@ namespace hpx::serialization {
           , current_(0)
           , filter_()
           , decompressed_size_(inbound_data_size)
+          , zero_copy_serialization_threshold_(
+                HPX_ZERO_COPY_SERIALIZATION_THRESHOLD)
           , chunks_(nullptr)
           , current_chunk_(std::size_t(-1))
           , current_chunk_size_(0)
@@ -95,6 +99,18 @@ namespace hpx::serialization {
                         "archive data bstream is too short");
                     return;
                 }
+            }
+        }
+
+        void set_zero_copy_serialization_threshold(
+            std::size_t zero_copy_serialization_threshold) override
+        {
+            zero_copy_serialization_threshold_ =
+                zero_copy_serialization_threshold;
+            if (zero_copy_serialization_threshold_ == 0)
+            {
+                zero_copy_serialization_threshold_ =
+                    HPX_ZERO_COPY_SERIALIZATION_THRESHOLD;
             }
         }
 
@@ -150,7 +166,7 @@ namespace hpx::serialization {
             HPX_ASSERT((std::int64_t) count >= 0);
 
             if (chunks_ == nullptr ||
-                count < HPX_ZERO_COPY_SERIALIZATION_THRESHOLD ||
+                count < zero_copy_serialization_threshold_ ||
                 filter_ != nullptr)
             {
                 // fall back to serialization_chunk-less archive
@@ -183,6 +199,7 @@ namespace hpx::serialization {
         std::size_t current_;
         std::unique_ptr<binary_filter> filter_;
         std::size_t decompressed_size_;
+        std::size_t zero_copy_serialization_threshold_;
 
         std::vector<serialization_chunk> const* chunks_;
         std::size_t current_chunk_;

--- a/libs/full/parcelset/include/hpx/parcelset/encode_parcels.hpp
+++ b/libs/full/parcelset/include/hpx/parcelset/encode_parcels.hpp
@@ -192,7 +192,8 @@ namespace hpx::parcelset {
                     }
 
                     serialization::output_archive archive(buffer.data_,
-                        archive_flags, &buffer.chunks_, filter.get());
+                        archive_flags, &buffer.chunks_, filter.get(),
+                        pp.get_zero_copy_serialization_threshold());
 
                     if (num_parcels != std::size_t(-1))
                         archive << parcels_sent;    //-V128

--- a/libs/full/parcelset/src/parcelhandler.cpp
+++ b/libs/full/parcelset/src/parcelhandler.cpp
@@ -1250,6 +1250,12 @@ namespace hpx::parcelset {
         ini_defs.emplace_back(
             "message_handlers = ${HPX_PARCEL_MESSAGE_HANDLERS:0}");
 #endif
+        ini_defs.emplace_back(
+            "zero_copy_serialization_threshold = "
+            "${HPX_PARCEL_ZERO_COPY_SERIALIZATION_THRESHOLD:" HPX_PP_STRINGIZE(
+                HPX_ZERO_COPY_SERIALIZATION_THRESHOLD) "}");
+        ini_defs.emplace_back("max_background_threads = "
+                              "${HPX_PARCEL_MAX_BACKGROUND_THREADS:-1}");
 
         for (plugins::parcelport_factory_base* f :
             parcelhandler::get_parcelport_factories())

--- a/libs/full/parcelset_base/include/hpx/parcelset_base/parcelport.hpp
+++ b/libs/full/parcelset_base/include/hpx/parcelset_base/parcelport.hpp
@@ -62,7 +62,8 @@ namespace hpx::parcelset {
 
         /// Construct the parcelport on the given locality.
         parcelport(util::runtime_configuration const& ini, locality const& here,
-            std::string const& type);
+            std::string const& type,
+            std::size_t zero_copy_serialization_threshold);
 
         /// Virtual destructor
         virtual ~parcelport() = default;
@@ -70,14 +71,18 @@ namespace hpx::parcelset {
         virtual bool can_bootstrap() const = 0;
 
         /// Access the parcelport priority (negative if disabled)
-        int priority() const;
+        int priority() const noexcept;
 
         /// Retrieve the type of the locality represented by this parcelport
-        std::string const& type() const;
+        std::string const& type() const noexcept;
 
         /// This accessor returns a reference to the locality this parcelport
         /// is associated with.
-        locality const& here() const;
+        locality const& here() const noexcept;
+
+        /// Return the threshold to use for deciding whether to zero-copy
+        // serialize an entity
+        std::size_t get_zero_copy_serialization_threshold() const noexcept;
 
         /// Start the parcelport I/O thread pool.
         ///
@@ -269,19 +274,19 @@ namespace hpx::parcelset {
 
         /// Return the configured maximal allowed inbound message data
         /// size
-        std::int64_t get_max_inbound_message_size() const;
+        std::int64_t get_max_inbound_message_size() const noexcept;
 
         /// Return the configured maximal allowed outbound message data
         /// size
-        std::int64_t get_max_outbound_message_size() const;
+        std::int64_t get_max_outbound_message_size() const noexcept;
 
         /// Return whether it is allowed to apply array optimizations
-        bool allow_array_optimizations() const;
+        bool allow_array_optimizations() const noexcept;
 
         /// Return whether it is allowed to apply zero copy optimizations
-        bool allow_zero_copy_optimizations() const;
+        bool allow_zero_copy_optimizations() const noexcept;
 
-        bool async_serialization() const;
+        bool async_serialization() const noexcept;
 
         // callback while bootstrap the parcel layer
         void early_pending_parcel_handler(
@@ -328,6 +333,8 @@ namespace hpx::parcelset {
         /// priority of the parcelport
         int priority_;
         std::string type_;
+
+        std::size_t zero_copy_serialization_threshold_;
     };
 }    // namespace hpx::parcelset
 

--- a/libs/full/parcelset_base/src/parcelport.cpp
+++ b/libs/full/parcelset_base/src/parcelport.cpp
@@ -33,7 +33,8 @@ namespace hpx::parcelset {
 
     ///////////////////////////////////////////////////////////////////////////
     parcelport::parcelport(util::runtime_configuration const& ini,
-        locality const& here, std::string const& type)
+        locality const& here, std::string const& type,
+        std::size_t zero_copy_serialization_threshold)
       : num_parcel_destinations_(0)
       , here_(here)
       , max_inbound_message_size_(ini.get_max_inbound_message_size())
@@ -44,6 +45,7 @@ namespace hpx::parcelset {
       , priority_(hpx::util::get_entry_as<int>(
             ini, "hpx.parcel." + type + ".priority", 0))
       , type_(type)
+      , zero_copy_serialization_threshold_(zero_copy_serialization_threshold)
     {
         std::string key("hpx.parcel.");
         key += type;
@@ -70,17 +72,23 @@ namespace hpx::parcelset {
         }
     }
 
-    int parcelport::priority() const
+    int parcelport::priority() const noexcept
     {
         return priority_;
     }
 
-    std::string const& parcelport::type() const
+    std::string const& parcelport::type() const noexcept
     {
         return type_;
     }
 
-    locality const& parcelport::here() const
+    std::size_t parcelport::get_zero_copy_serialization_threshold()
+        const noexcept
+    {
+        return zero_copy_serialization_threshold_;
+    }
+
+    locality const& parcelport::here() const noexcept
     {
         return here_;
     }
@@ -283,27 +291,27 @@ namespace hpx::parcelset {
         return pp.get_max_inbound_message_size();
     }
 
-    std::int64_t parcelport::get_max_inbound_message_size() const
+    std::int64_t parcelport::get_max_inbound_message_size() const noexcept
     {
         return max_inbound_message_size_;
     }
 
-    std::int64_t parcelport::get_max_outbound_message_size() const
+    std::int64_t parcelport::get_max_outbound_message_size() const noexcept
     {
         return max_outbound_message_size_;
     }
 
-    bool parcelport::allow_array_optimizations() const
+    bool parcelport::allow_array_optimizations() const noexcept
     {
         return allow_array_optimizations_;
     }
 
-    bool parcelport::allow_zero_copy_optimizations() const
+    bool parcelport::allow_zero_copy_optimizations() const noexcept
     {
         return allow_zero_copy_optimizations_;
     }
 
-    bool parcelport::async_serialization() const
+    bool parcelport::async_serialization() const noexcept
     {
         return async_serialization_;
     }

--- a/libs/full/plugin_factories/include/hpx/plugin_factories/parcelport_factory.hpp
+++ b/libs/full/plugin_factories/include/hpx/plugin_factories/parcelport_factory.hpp
@@ -110,6 +110,14 @@ namespace hpx::plugins {
                 name_uc +
                 "_ZERO_COPY_OPTIMIZATION:"
                 "$[hpx.parcel.zero_copy_optimization]}");
+            fillini.emplace_back(
+                "zero_copy_serialization_threshold = ${HPX_PARCEL_" + name_uc +
+                "_ZERO_COPY_SERIALIZATION_THRESHOLD:"
+                "$[hpx.parcel.zero_copy_serialization_threshold]}");
+            fillini.emplace_back("max_background_threads = ${HPX_PARCEL_" +
+                name_uc +
+                "_MAX_BACKGROUND_THREADS:"
+                "$[hpx.parcel.max_background_threads]}");
             fillini.emplace_back("async_serialization = ${HPX_PARCEL_" +
                 name_uc +
                 "_ASYNC_SERIALIZATION:"


### PR DESCRIPTION
- this adds a new configuration option `hpx.parcel.zero_copy_serialization_threshold`
- flyby: rename `hpx.max_backgroud_threads` to `hpx.parcel.max_background_threads`,
- expose parcelport specific `hpx.parcel.<pptype>.max_background_threads` and `hpx.parcel.<pptype>.zero_copy_serialization_threshold` (those default to the respective 'global' setting)
- added missing documentation for both
