### PR TITLE
Further improvement actions to rotate

### DIFF
--- a/libs/core/algorithms/include/hpx/parallel/algorithms/rotate.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/rotate.hpp
@@ -223,10 +223,10 @@ namespace hpx { namespace parallel { inline namespace v1 {
 
             /*
             add core partition facility:
-                need to deal with 4 cases: 
-                cores >=1 
-                size_right == 0 
-                cores_left>=1 & cores_right >=1 
+                need to deal with 4 cases:
+                cores >=1
+                size_right == 0
+                cores_left>=1 & cores_right >=1
                 cores_left+cores_right = cores;
             */
 
@@ -238,12 +238,12 @@ namespace hpx { namespace parallel { inline namespace v1 {
             if (size_right > 0)
             {
                 double partition_size_ratio =
-                    double(size_left) / (+size_left + size_right);
+                    double(size_left) / (size_left + size_right);
                 // avoid cores_left =0 after integer rounding
                 cores_left = std::max(
                     std::size_t(1), std::size_t(partition_size_ratio * cores));
             }
-            // when size_right==0 & cores==1, cores_right =0, but it should be at least 1.
+            // if size_right==0&cores==1,cores_right =0, should be at least 1.
             std::size_t cores_right =
                 std::max(std::size_t(1), cores - cores_left);
 

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/rotate.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/rotate.hpp
@@ -1,5 +1,5 @@
 //  Copyright (c) 2007-2017 Hartmut Kaiser
-//  Copyright (c)      2021 Chuanqiu He
+//  Copyright (c) 2021-2022 Chuanqiu He
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -201,6 +201,7 @@ namespace hpx {
 #include <algorithm>
 #include <cstddef>
 #include <iterator>
+#include <limits>
 #include <type_traits>
 #include <utility>
 
@@ -215,14 +216,14 @@ namespace hpx { namespace parallel { inline namespace v1 {
         {
             using non_seq = std::false_type;
             // further inprovements:
-            //add core partition facility
+            //add core partition functionability
             //remove unneeded asynchronous code
 
-            std::ptrdiff_t size_left = std::distance(first, new_first);
-            std::ptrdiff_t size_right = std::distance(new_first, last);
+            std::ptrdiff_t size_left = detail::distance(first, new_first);
+            std::ptrdiff_t size_right = detail::distance(new_first, last);
 
             /*
-            add core partition facility:
+            add core partition functionability:
                 need to deal with 4 cases:
                 cores >=1
                 size_right == 0
@@ -237,15 +238,15 @@ namespace hpx { namespace parallel { inline namespace v1 {
             std::size_t cores_left = 1;
             if (size_right > 0)
             {
-                double partition_size_ratio =
-                    double(size_left) / (size_left + size_right);
+                long partition_size_ratio =
+                    long(size_left) / (size_left + size_right);
                 // avoid cores_left =0 after integer rounding
-                cores_left = std::max(
+                cores_left = (std::max)(
                     std::size_t(1), std::size_t(partition_size_ratio * cores));
             }
             // if size_right==0&cores==1,cores_right =0, should be at least 1.
             std::size_t cores_right =
-                std::max(std::size_t(1), cores - cores_left);
+                (std::max)(std::size_t(1), cores - cores_left);
 
             auto p = policy(hpx::execution::task);
 

--- a/libs/core/algorithms/include/hpx/parallel/util/detail/sender_util.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/util/detail/sender_util.hpp
@@ -54,10 +54,10 @@ namespace hpx { namespace detail {
     template <typename Tag, typename ExPolicy, typename Predecessor>
     auto then_with_bound_algorithm(Predecessor&& predecessor, ExPolicy&& policy)
     {
-        // If the given execution policy can has a task policy, i.e. the
-        // algorithm can return a future, we use the task policy since we can
-        // then directly return the future as a sender and avoid potential
-        // blocking that may happen internally.
+        // If the given execution policy has a task policy, i.e. the algorithm
+        // can return a future, we use the task policy since we can then
+        // directly return the future as a sender and avoid potential blocking
+        // that may happen internally.
         if constexpr (hpx::execution::detail::has_async_execution_policy_v<
                           ExPolicy>)
         {

--- a/libs/core/algorithms/tests/unit/algorithms/rotate.cpp
+++ b/libs/core/algorithms/tests/unit/algorithms/rotate.cpp
@@ -169,7 +169,7 @@ void test_rotate_exception(IteratorTag)
             decorated_iterator(mid), decorated_iterator(std::end(c)));
         HPX_TEST(false);
     }
-    catch (hpx::exception_list const& e)
+    catch (hpx::exception_list const&)
     {
         caught_exception = true;
     }

--- a/libs/core/executors/include/hpx/executors/execution_policy.hpp
+++ b/libs/core/executors/include/hpx/executors/execution_policy.hpp
@@ -1326,6 +1326,15 @@ namespace hpx { namespace execution {
             return *this;
         }
 
+        /// Create a new task policy from itself
+        ///
+        /// \returns The task parallel unsequenced policy
+        ///
+        constexpr decltype(auto) operator()(task_policy_tag /*tag*/) const
+        {
+            return *this;
+        }
+
     public:
         /// Return the associated executor object.
         executor_type& executor()
@@ -1394,6 +1403,15 @@ namespace hpx { namespace execution {
         /// \returns The non task unsequenced policy
         ///
         constexpr decltype(auto) operator()(non_task_policy_tag /*tag*/) const
+        {
+            return *this;
+        }
+
+        /// Create a new task policy from itself
+        ///
+        /// \returns The task unsequenced policy
+        ///
+        constexpr decltype(auto) operator()(task_policy_tag /*tag*/) const
         {
             return *this;
         }


### PR DESCRIPTION
 Aim to further improve **_rotate_** algorithm
  -  Adding core partition functionality: enables the left and right sides of rotate to allocate the number of cores as needed
  - Removing the unneeded asynchronous code: decreases the overheads by removing the third step operation of rotate 

## Any background context you want to provide?
add num_cores facility #5763
Making sure num_cores is properly handled by parallel_executor #5792



