### PR TITLE
wait_xxx_nothrow functions return whether one of the futures is exceptional

### DIFF
--- a/libs/core/algorithms/include/hpx/parallel/algorithms/make_heap.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/make_heap.hpp
@@ -344,11 +344,12 @@ namespace hpx { namespace parallel { inline namespace v1 {
                                 policy.executor(), op, shapes);
 
                             // Required synchronization per level
-                            hpx::wait_all_nothrow(workitems);
-
-                            // collect exceptions
-                            util::detail::handle_local_exceptions<
-                                ExPolicy>::call(workitems, errors, false);
+                            if (hpx::wait_all_nothrow(workitems))
+                            {
+                                // collect exceptions
+                                util::detail::handle_local_exceptions<
+                                    ExPolicy>::call(workitems, errors, false);
+                            }
                         }
 
                         if (!errors.empty())

--- a/libs/core/algorithms/include/hpx/parallel/util/foreach_partitioner.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/util/foreach_partitioner.hpp
@@ -138,13 +138,14 @@ namespace hpx { namespace parallel { namespace util {
                 std::pair<Items1, Items2>&& items, F&& f, FwdIter last)
             {
                 // wait for all tasks to finish
-                hpx::wait_all_nothrow(hpx::get<0>(items), hpx::get<1>(items));
-
-                // always rethrow if inititems/workitems have at least one
-                // exceptional future
-                handle_local_exceptions::call(hpx::get<0>(items));
-                handle_local_exceptions::call(hpx::get<1>(items));
-
+                if (hpx::wait_all_nothrow(
+                        hpx::get<0>(items), hpx::get<1>(items)))
+                {
+                    // always rethrow if inititems/workitems have at least one
+                    // exceptional future
+                    handle_local_exceptions::call(hpx::get<0>(items));
+                    handle_local_exceptions::call(hpx::get<1>(items));
+                }
                 return f(HPX_MOVE(last));
             }
 
@@ -152,11 +153,12 @@ namespace hpx { namespace parallel { namespace util {
             static FwdIter reduce(Items&& items, F&& f, FwdIter last)
             {
                 // wait for all tasks to finish
-                hpx::wait_all_nothrow(items);
-
-                // always rethrow if items has at least one exceptional future
-                handle_local_exceptions::call(items);
-
+                if (hpx::wait_all_nothrow(items))
+                {
+                    // always rethrow if items has at least one exceptional
+                    // future
+                    handle_local_exceptions::call(items);
+                }
                 return f(HPX_MOVE(last));
             }
         };

--- a/libs/core/algorithms/include/hpx/parallel/util/partitioner.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/util/partitioner.hpp
@@ -283,11 +283,12 @@ namespace hpx { namespace parallel { namespace util {
             static R reduce(Items&& workitems, F&& f)
             {
                 // wait for all tasks to finish
-                hpx::wait_all_nothrow(workitems);
-
-                // always rethrow workitems has at least one exceptional future
-                handle_local_exceptions::call(workitems);
-
+                if (hpx::wait_all_nothrow(workitems))
+                {
+                    // always rethrow workitems has at least one exceptional
+                    // future
+                    handle_local_exceptions::call(workitems);
+                }
                 return f(HPX_MOVE(workitems));
             }
 
@@ -295,10 +296,12 @@ namespace hpx { namespace parallel { namespace util {
             static void reduce(Items&& workitems, hpx::util::empty_function)
             {
                 // wait for all tasks to finish
-                hpx::wait_all_nothrow(workitems);
-
-                // always rethrow workitems has at least one exceptional future
-                handle_local_exceptions::call(workitems);
+                if (hpx::wait_all_nothrow(workitems))
+                {
+                    // always rethrow workitems has at least one exceptional
+                    // future
+                    handle_local_exceptions::call(workitems);
+                }
             }
 
             template <typename Items1, typename Items2, typename F>

--- a/libs/core/algorithms/include/hpx/parallel/util/partitioner_with_cleanup.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/util/partitioner_with_cleanup.hpp
@@ -86,13 +86,13 @@ namespace hpx { namespace parallel { namespace util {
             static R reduce(Items&& workitems, F&& f, Cleanup&& cleanup)
             {
                 // wait for all tasks to finish
-                hpx::wait_all_nothrow(workitems);
-
-                // always rethrow if 'errors' is not empty or workitems has
-                // exceptional future
-                handle_local_exceptions::call_with_cleanup(
-                    workitems, HPX_FORWARD(Cleanup, cleanup));
-
+                if (hpx::wait_all_nothrow(workitems))
+                {
+                    // always rethrow if 'errors' is not empty or workitems has
+                    // exceptional future
+                    handle_local_exceptions::call_with_cleanup(
+                        workitems, HPX_FORWARD(Cleanup, cleanup));
+                }
                 return f(HPX_MOVE(workitems));
             }
 

--- a/libs/core/algorithms/include/hpx/parallel/util/scan_partitioner.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/util/scan_partitioner.hpp
@@ -148,7 +148,10 @@ namespace hpx { namespace parallel { namespace util {
                     }
 
                     // Wait for all f1 tasks to finish
-                    hpx::wait_all_nothrow(workitems);
+                    if (hpx::wait_all_nothrow(workitems))
+                    {
+                        handle_local_exceptions::call(workitems, errors);
+                    }
 
                     // perform f2 sequentially in one go
                     f2results.resize(workitems.size());
@@ -343,12 +346,14 @@ namespace hpx { namespace parallel { namespace util {
                 return R();
 #else
                 // wait for all tasks to finish
-                hpx::wait_all_nothrow(workitems, finalitems);
-
-                // always rethrow if 'errors' is not empty or 'workitems' or
-                // 'finalitems' have an exceptional future
-                handle_local_exceptions::call(workitems, errors);
-                handle_local_exceptions::call(finalitems, errors);
+                if (hpx::wait_all_nothrow(workitems, finalitems) ||
+                    !errors.empty())
+                {
+                    // always rethrow if 'errors' is not empty or 'workitems' or
+                    // 'finalitems' have an exceptional future
+                    handle_local_exceptions::call(workitems, errors);
+                    handle_local_exceptions::call(finalitems, errors);
+                }
 
                 try
                 {
@@ -376,11 +381,12 @@ namespace hpx { namespace parallel { namespace util {
                 return R();
 #else
                 // wait for all tasks to finish
-                hpx::wait_all_nothrow(finalitems);
-
-                // always rethrow if 'errors' is not empty or
-                // 'finalitems' have an exceptional future
-                handle_local_exceptions::call(finalitems, errors);
+                if (hpx::wait_all_nothrow(finalitems) || !errors.empty())
+                {
+                    // always rethrow if 'errors' is not empty or 'finalitems'
+                    // have an exceptional future
+                    handle_local_exceptions::call(finalitems, errors);
+                }
 
                 try
                 {

--- a/libs/core/async_combinators/include/hpx/async_combinators/wait_any.hpp
+++ b/libs/core/async_combinators/include/hpx/async_combinators/wait_any.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2021 Hartmut Kaiser
+//  Copyright (c) 2007-2022 Hartmut Kaiser
 //  Copyright (c) 2013 Agustin Berge
 //
 //  SPDX-License-Identifier: BSL-1.0
@@ -137,9 +137,9 @@ namespace hpx {
 
     ///////////////////////////////////////////////////////////////////////////
     template <typename Future>
-    void wait_any_nothrow(std::vector<Future> const& futures)
+    bool wait_any_nothrow(std::vector<Future> const& futures)
     {
-        hpx::wait_some_nothrow(1, futures);
+        return hpx::wait_some_nothrow(1, futures);
     }
 
     template <typename Future>
@@ -149,9 +149,9 @@ namespace hpx {
     }
 
     template <typename Future>
-    void wait_any_nothrow(std::vector<Future>& lazy_values)
+    bool wait_any_nothrow(std::vector<Future>& lazy_values)
     {
-        hpx::wait_any_nothrow(
+        return hpx::wait_any_nothrow(
             const_cast<std::vector<Future> const&>(lazy_values));
     }
 
@@ -162,9 +162,9 @@ namespace hpx {
     }
 
     template <typename Future>
-    void wait_any_nothrow(std::vector<Future>&& lazy_values)
+    bool wait_any_nothrow(std::vector<Future>&& lazy_values)
     {
-        hpx::wait_any_nothrow(
+        return hpx::wait_any_nothrow(
             const_cast<std::vector<Future> const&>(lazy_values));
     }
 
@@ -176,9 +176,9 @@ namespace hpx {
 
     ///////////////////////////////////////////////////////////////////////////
     template <typename Future, std::size_t N>
-    void wait_any_nothrow(std::array<Future, N> const& futures)
+    bool wait_any_nothrow(std::array<Future, N> const& futures)
     {
-        hpx::wait_some_nothrow(1, futures);
+        return hpx::wait_some_nothrow(1, futures);
     }
 
     template <typename Future, std::size_t N>
@@ -188,9 +188,9 @@ namespace hpx {
     }
 
     template <typename Future, std::size_t N>
-    void wait_any_nothrow(std::array<Future, N>& lazy_values)
+    bool wait_any_nothrow(std::array<Future, N>& lazy_values)
     {
-        hpx::wait_any_nothrow(
+        return hpx::wait_any_nothrow(
             const_cast<std::array<Future, N> const&>(lazy_values));
     }
 
@@ -201,9 +201,9 @@ namespace hpx {
     }
 
     template <typename Future, std::size_t N>
-    void wait_any_nothrow(std::array<Future, N>&& lazy_values)
+    bool wait_any_nothrow(std::array<Future, N>&& lazy_values)
     {
-        hpx::wait_any_nothrow(
+        return hpx::wait_any_nothrow(
             const_cast<std::array<Future, N> const&>(lazy_values));
     }
 
@@ -217,9 +217,9 @@ namespace hpx {
     template <typename Iterator,
         typename Enable =
             std::enable_if_t<hpx::traits::is_iterator_v<Iterator>>>
-    void wait_any_nothrow(Iterator begin, Iterator end)
+    bool wait_any_nothrow(Iterator begin, Iterator end)
     {
-        hpx::wait_some_nothrow(1, begin, end);
+        return hpx::wait_some_nothrow(1, begin, end);
     }
 
     template <typename Iterator,
@@ -230,23 +230,23 @@ namespace hpx {
         hpx::wait_some(1, begin, end);
     }
 
-    inline void wait_any_nothrow()
+    inline bool wait_any_nothrow()
     {
-        hpx::wait_some_nothrow(1);
+        return hpx::wait_some_nothrow(0);
     }
 
     inline void wait_any()
     {
-        hpx::wait_some(1);
+        hpx::wait_some(0);
     }
 
     ///////////////////////////////////////////////////////////////////////////
     template <typename Iterator,
         typename Enable =
             std::enable_if_t<hpx::traits::is_iterator_v<Iterator>>>
-    void wait_any_n_nothrow(Iterator begin, std::size_t count)
+    bool wait_any_n_nothrow(Iterator begin, std::size_t count)
     {
-        hpx::wait_some_n_nothrow(1, begin, count);
+        return hpx::wait_some_n_nothrow(1, begin, count);
     }
 
     template <typename Iterator,
@@ -259,9 +259,9 @@ namespace hpx {
 
     ///////////////////////////////////////////////////////////////////////////
     template <typename... Ts>
-    void wait_any_nothrow(Ts&&... ts)
+    bool wait_any_nothrow(Ts&&... ts)
     {
-        hpx::wait_some_nothrow(1, HPX_FORWARD(Ts, ts)...);
+        return hpx::wait_some_nothrow(1, HPX_FORWARD(Ts, ts)...);
     }
 
     template <typename... Ts>
@@ -338,7 +338,7 @@ namespace hpx::lcos {
         1, 8, "hpx::lcos::wait_any is deprecated. Use hpx::wait_any instead.")
     inline void wait_any(error_code& = throws)
     {
-        hpx::wait_some(1);
+        hpx::wait_some(0);
     }
 
     ///////////////////////////////////////////////////////////////////////////

--- a/libs/core/async_combinators/tests/unit/wait_all.cpp
+++ b/libs/core/async_combinators/tests/unit/wait_all.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2017-2021 Hartmut Kaiser
+//  Copyright (c) 2017-2022 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -13,16 +13,9 @@
 #include <stdexcept>
 #include <vector>
 
-int make_int_slowly()
-{
-    hpx::this_thread::sleep_for(std::chrono::milliseconds(100));
-    return 42;
-}
-
 hpx::future<int> make_future()
 {
-    hpx::packaged_task<int()> task(make_int_slowly);
-    return task.get_future();
+    return hpx::make_ready_future_after(std::chrono::milliseconds(100), 42);
 }
 
 void test_wait_all()
@@ -32,7 +25,7 @@ void test_wait_all()
         future_array.push_back(make_future());
         future_array.push_back(make_future());
 
-        hpx::wait_all_nothrow(future_array);
+        HPX_TEST(!hpx::wait_all_nothrow(future_array));
 
         for (auto& f : future_array)
         {
@@ -43,7 +36,7 @@ void test_wait_all()
         auto f1 = make_future();
         auto f2 = make_future();
 
-        hpx::wait_all_nothrow(f1, f2);
+        HPX_TEST(!hpx::wait_all_nothrow(f1, f2));
 
         HPX_TEST(f1.is_ready());
         HPX_TEST(f2.is_ready());
@@ -57,7 +50,7 @@ void test_wait_all()
         bool caught_exception = false;
         try
         {
-            hpx::wait_all_nothrow(future_array);
+            HPX_TEST(hpx::wait_all_nothrow(future_array));
 
             for (auto& f : future_array)
             {
@@ -146,7 +139,8 @@ void test_wait_all_n()
         future_array.push_back(make_future());
         future_array.push_back(make_future());
 
-        hpx::wait_all_n_nothrow(future_array.begin(), future_array.size());
+        HPX_TEST(!hpx::wait_all_n_nothrow(
+            future_array.begin(), future_array.size()));
 
         for (auto& f : future_array)
         {
@@ -162,7 +156,8 @@ void test_wait_all_n()
         bool caught_exception = false;
         try
         {
-            hpx::wait_all_n_nothrow(future_array.begin(), future_array.size());
+            HPX_TEST(hpx::wait_all_n_nothrow(
+                future_array.begin(), future_array.size()));
 
             for (auto& f : future_array)
             {

--- a/libs/core/async_combinators/tests/unit/wait_all_std_array.cpp
+++ b/libs/core/async_combinators/tests/unit/wait_all_std_array.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2017-2021 Hartmut Kaiser
+//  Copyright (c) 2017-2022 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -13,16 +13,9 @@
 #include <chrono>
 #include <stdexcept>
 
-int make_int_slowly()
-{
-    hpx::this_thread::sleep_for(std::chrono::milliseconds(100));
-    return 42;
-}
-
 hpx::future<int> make_future()
 {
-    hpx::packaged_task<int()> task(make_int_slowly);
-    return task.get_future();
+    return hpx::make_ready_future_after(std::chrono::milliseconds(100), 42);
 }
 
 void test_wait_all()
@@ -32,7 +25,7 @@ void test_wait_all()
         future_array[0] = make_future();
         future_array[1] = make_future();
 
-        hpx::wait_all_nothrow(future_array);
+        HPX_TEST(!hpx::wait_all_nothrow(future_array));
 
         for (auto& f : future_array)
         {
@@ -48,7 +41,7 @@ void test_wait_all()
         bool caught_exception = false;
         try
         {
-            hpx::wait_all_nothrow(future_array);
+            HPX_TEST(hpx::wait_all_nothrow(future_array));
 
             for (auto& f : future_array)
             {
@@ -96,7 +89,7 @@ void test_wait_all_n()
         future_array[0] = make_future();
         future_array[1] = make_future();
 
-        hpx::wait_all_n_nothrow(future_array.begin(), 2);
+        HPX_TEST(!hpx::wait_all_n_nothrow(future_array.begin(), 2));
 
         for (auto& f : future_array)
         {
@@ -112,7 +105,7 @@ void test_wait_all_n()
         bool caught_exception = false;
         try
         {
-            hpx::wait_all_n_nothrow(future_array.begin(), 2);
+            HPX_TEST(hpx::wait_all_n_nothrow(future_array.begin(), 2));
 
             for (auto& f : future_array)
             {

--- a/libs/core/async_combinators/tests/unit/wait_any.cpp
+++ b/libs/core/async_combinators/tests/unit/wait_any.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2017-2021 Hartmut Kaiser
+//  Copyright (c) 2017-2022 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -13,16 +13,9 @@
 #include <stdexcept>
 #include <vector>
 
-int make_int_slowly()
-{
-    hpx::this_thread::sleep_for(std::chrono::milliseconds(100));
-    return 42;
-}
-
 hpx::future<int> make_future()
 {
-    hpx::packaged_task<int()> task(make_int_slowly);
-    return task.get_future();
+    return hpx::make_ready_future_after(std::chrono::milliseconds(100), 42);
 }
 
 void test_wait_any()
@@ -32,7 +25,7 @@ void test_wait_any()
         future_array.push_back(make_future());
         future_array.push_back(make_future());
 
-        hpx::wait_any_nothrow(future_array);
+        HPX_TEST(!hpx::wait_any_nothrow(future_array));
 
         int count = 0;
         for (auto& f : future_array)
@@ -48,7 +41,7 @@ void test_wait_any()
         auto f1 = make_future();
         auto f2 = make_future();
 
-        hpx::wait_any_nothrow(f1, f2);
+        HPX_TEST(!hpx::wait_any_nothrow(f1, f2));
 
         HPX_TEST(f1.is_ready() || f2.is_ready());
     }
@@ -61,7 +54,7 @@ void test_wait_any()
         bool caught_exception = false;
         try
         {
-            hpx::wait_any_nothrow(future_array);
+            HPX_TEST(hpx::wait_any_nothrow(future_array));
 
             int count = 0;
             for (auto& f : future_array)
@@ -115,7 +108,8 @@ void test_wait_any_n()
         future_array.push_back(make_future());
         future_array.push_back(make_future());
 
-        hpx::wait_any_n_nothrow(future_array.begin(), future_array.size());
+        HPX_TEST(!hpx::wait_any_n_nothrow(
+            future_array.begin(), future_array.size()));
 
         int count = 0;
         for (auto& f : future_array)
@@ -136,7 +130,8 @@ void test_wait_any_n()
         bool caught_exception = false;
         try
         {
-            hpx::wait_any_n_nothrow(future_array.begin(), future_array.size());
+            HPX_TEST(hpx::wait_any_n_nothrow(
+                future_array.begin(), future_array.size()));
 
             int count = 0;
             for (auto& f : future_array)

--- a/libs/core/async_combinators/tests/unit/wait_any_std_array.cpp
+++ b/libs/core/async_combinators/tests/unit/wait_any_std_array.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2017-2021 Hartmut Kaiser
+//  Copyright (c) 2017-2022 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -13,16 +13,9 @@
 #include <chrono>
 #include <stdexcept>
 
-int make_int_slowly()
-{
-    hpx::this_thread::sleep_for(std::chrono::milliseconds(100));
-    return 42;
-}
-
 hpx::future<int> make_future()
 {
-    hpx::packaged_task<int()> task(make_int_slowly);
-    return task.get_future();
+    return hpx::make_ready_future_after(std::chrono::milliseconds(100), 42);
 }
 
 void test_wait_any()
@@ -32,7 +25,7 @@ void test_wait_any()
         future_array[0] = make_future();
         future_array[1] = make_future();
 
-        hpx::wait_any_nothrow(future_array);
+        HPX_TEST(!hpx::wait_any_nothrow(future_array));
 
         int count = 0;
         for (auto& f : future_array)
@@ -53,7 +46,7 @@ void test_wait_any()
         bool caught_exception = false;
         try
         {
-            hpx::wait_any_nothrow(future_array);
+            HPX_TEST(hpx::wait_any_nothrow(future_array));
 
             int count = 0;
             for (auto& f : future_array)
@@ -106,7 +99,7 @@ void test_wait_any_n()
         future_array[0] = make_future();
         future_array[1] = make_future();
 
-        hpx::wait_any_n_nothrow(future_array.begin(), 2);
+        HPX_TEST(!hpx::wait_any_n_nothrow(future_array.begin(), 2));
 
         int count = 0;
         for (auto& f : future_array)
@@ -127,7 +120,7 @@ void test_wait_any_n()
         bool caught_exception = false;
         try
         {
-            hpx::wait_any_n_nothrow(future_array.begin(), 2);
+            HPX_TEST(hpx::wait_any_n_nothrow(future_array.begin(), 2));
 
             int count = 0;
             for (auto& f : future_array)

--- a/libs/core/async_combinators/tests/unit/wait_some.cpp
+++ b/libs/core/async_combinators/tests/unit/wait_some.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2017-2021 Hartmut Kaiser
+//  Copyright (c) 2017-2022 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -13,16 +13,9 @@
 #include <stdexcept>
 #include <vector>
 
-int make_int_slowly()
-{
-    hpx::this_thread::sleep_for(std::chrono::milliseconds(100));
-    return 42;
-}
-
 hpx::future<int> make_future()
 {
-    hpx::packaged_task<int()> task(make_int_slowly);
-    return task.get_future();
+    return hpx::make_ready_future_after(std::chrono::milliseconds(100), 42);
 }
 
 void test_wait_some()
@@ -32,7 +25,7 @@ void test_wait_some()
         future_array.push_back(make_future());
         future_array.push_back(make_future());
 
-        hpx::wait_some_nothrow(1, future_array);
+        HPX_TEST(!hpx::wait_some_nothrow(1, future_array));
 
         int count = 0;
         for (auto& f : future_array)
@@ -48,7 +41,7 @@ void test_wait_some()
         auto f1 = make_future();
         auto f2 = make_future();
 
-        hpx::wait_some_nothrow(1, f1, f2);
+        HPX_TEST(!hpx::wait_some_nothrow(1, f1, f2));
 
         HPX_TEST(f1.is_ready() || f2.is_ready());
     }
@@ -61,7 +54,7 @@ void test_wait_some()
         bool caught_exception = false;
         try
         {
-            hpx::wait_some_nothrow(1, future_array);
+            HPX_TEST(hpx::wait_some_nothrow(1, future_array));
 
             int count = 0;
             for (auto& f : future_array)
@@ -135,7 +128,8 @@ void test_wait_some_n()
         future_array.push_back(make_future());
         future_array.push_back(make_future());
 
-        hpx::wait_some_n_nothrow(1, future_array.begin(), future_array.size());
+        HPX_TEST(!hpx::wait_some_n_nothrow(
+            1, future_array.begin(), future_array.size()));
 
         int count = 0;
         for (auto& f : future_array)
@@ -156,8 +150,8 @@ void test_wait_some_n()
         bool caught_exception = false;
         try
         {
-            hpx::wait_some_n_nothrow(
-                1, future_array.begin(), future_array.size());
+            HPX_TEST(hpx::wait_some_n_nothrow(
+                1, future_array.begin(), future_array.size()));
 
             int count = 0;
             for (auto& f : future_array)

--- a/libs/core/async_combinators/tests/unit/wait_some_std_array.cpp
+++ b/libs/core/async_combinators/tests/unit/wait_some_std_array.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2017-2021 Hartmut Kaiser
+//  Copyright (c) 2017-2022 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -13,16 +13,9 @@
 #include <chrono>
 #include <stdexcept>
 
-int make_int_slowly()
-{
-    hpx::this_thread::sleep_for(std::chrono::milliseconds(100));
-    return 42;
-}
-
 hpx::future<int> make_future()
 {
-    hpx::packaged_task<int()> task(make_int_slowly);
-    return task.get_future();
+    return hpx::make_ready_future_after(std::chrono::milliseconds(100), 42);
 }
 
 void test_wait_some()
@@ -32,7 +25,7 @@ void test_wait_some()
         future_array[0] = make_future();
         future_array[1] = make_future();
 
-        hpx::wait_some_nothrow(1, future_array);
+        HPX_TEST(!hpx::wait_some_nothrow(1, future_array));
 
         int count = 0;
         for (auto& f : future_array)
@@ -53,7 +46,7 @@ void test_wait_some()
         bool caught_exception = false;
         try
         {
-            hpx::wait_some_nothrow(1, future_array);
+            HPX_TEST(hpx::wait_some_nothrow(1, future_array));
 
             int count = 0;
             for (auto& f : future_array)
@@ -106,7 +99,7 @@ void test_wait_some_n()
         future_array[0] = make_future();
         future_array[1] = make_future();
 
-        hpx::wait_some_n_nothrow(1, future_array.begin(), 2);
+        HPX_TEST(!hpx::wait_some_n_nothrow(1, future_array.begin(), 2));
 
         int count = 0;
         for (auto& f : future_array)
@@ -127,7 +120,7 @@ void test_wait_some_n()
         bool caught_exception = false;
         try
         {
-            hpx::wait_some_n_nothrow(1, future_array.begin(), 2);
+            HPX_TEST(hpx::wait_some_n_nothrow(1, future_array.begin(), 2));
 
             int count = 0;
             for (auto& f : future_array)

--- a/libs/core/futures/tests/regressions/exception_from_continuation_1613.cpp
+++ b/libs/core/futures/tests/regressions/exception_from_continuation_1613.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2015-2021 Hartmut Kaiser
+//  Copyright (c) 2015-2022 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -61,7 +61,7 @@ void test_exception_from_continuation2()
 
     // make futures ready in backwards sequence
     hpx::apply([&p]() { p.set_value(); });
-    hpx::wait_all_nothrow(results);
+    HPX_TEST(hpx::wait_all_nothrow(results));
 
     HPX_TEST_EQ(recursion_level.load(), NUM_FUTURES);
     HPX_TEST_EQ(exceptions_thrown.load(), std::size_t(1));

--- a/libs/full/compute/include/hpx/compute/host/numa_allocator.hpp
+++ b/libs/full/compute/include/hpx/compute/host/numa_allocator.hpp
@@ -1,5 +1,5 @@
 //  Copyright (c) 2015 Thomas Heller
-//  Copyright (c) 2015-2016 Hartmut Kaiser
+//  Copyright (c) 2015-2022 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -130,11 +130,13 @@ namespace hpx { namespace parallel { namespace util {
 #endif
                     }));
             }
-            hpx::wait_all_nothrow(first_touch);
 
-            for (auto&& f : first_touch)
+            if (hpx::wait_all_nothrow(first_touch))
             {
-                f.get();    // rethrow exceptions
+                for (auto&& f : first_touch)
+                {
+                    f.get();    // rethrow exceptions
+                }
             }
 
             // return the overall memory block

--- a/libs/full/resiliency_distributed/tests/performance/replay/async_replay_distributed.cpp
+++ b/libs/full/resiliency_distributed/tests/performance/replay/async_replay_distributed.cpp
@@ -1,6 +1,6 @@
 //  Copyright (c) 2019 National Technology & Engineering Solutions of Sandia,
 //                     LLC (NTESS).
-//  Copyright (c) 2018-2019 Hartmut Kaiser
+//  Copyright (c) 2018-2022 Hartmut Kaiser
 //  Copyright (c) 2018-2019 Adrian Serio
 //  Copyright (c) 2019-2020 Nikunj Gupta
 //
@@ -131,7 +131,7 @@ int hpx_main(hpx::program_options::variables_map& vm)
             std::rotate(locales.begin(), locales.begin() + 1, locales.end());
         }
 
-        hpx::wait_all_nothrow(tasks);
+        HPX_TEST(!hpx::wait_all_nothrow(tasks));
 
         double elapsed = t.elapsed();
 

--- a/libs/full/resiliency_distributed/tests/performance/replay/async_replay_distributed_validate.cpp
+++ b/libs/full/resiliency_distributed/tests/performance/replay/async_replay_distributed_validate.cpp
@@ -1,6 +1,6 @@
 //  Copyright (c) 2019 National Technology & Engineering Solutions of Sandia,
 //                     LLC (NTESS).
-//  Copyright (c) 2018-2019 Hartmut Kaiser
+//  Copyright (c) 2018-2022 Hartmut Kaiser
 //  Copyright (c) 2018-2019 Adrian Serio
 //  Copyright (c) 2019-2020 Nikunj Gupta
 //
@@ -124,7 +124,7 @@ int hpx_main(hpx::program_options::variables_map& vm)
             std::rotate(locales.begin(), locales.begin() + 1, locales.end());
         }
 
-        hpx::wait_all_nothrow(tasks);
+        HPX_TEST(!hpx::wait_all_nothrow(tasks));
 
         double elapsed = t.elapsed();
         std::cout << "Replay Validate: " << elapsed << std::endl;


### PR DESCRIPTION
This is a potential optimization allowing to skip checking for exceptional futures after calling one of the `wait_xxx_nothrow` functions.