### PR TITLE
change the default value of HPX_WITH_LCI_TAG to v1.7

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1128,7 +1128,7 @@ if(HPX_WITH_NETWORKING)
   )
   hpx_option(
     HPX_WITH_LCI_TAG STRING "LCI repository tag or branch"
-    "d0b8aef0b33a9011e02fb3910e968d2a5e089449" # jiakun-dev-v1.7
+    "v1.7"
     CATEGORY "Build Targets"
     ADVANCED
   )


### PR DESCRIPTION
Change the default value of HPX_WITH_LCI_TAG to the tag "v1.7".

Previously, it is a hardcoded commit hash value, which will be hard to update if we fix a bug in LCI in the future.