### PR TITLE
[execution] Add schedule_result_t alias template.

### DIFF
--- a/libs/core/execution_base/include/hpx/execution_base/sender.hpp
+++ b/libs/core/execution_base/include/hpx/execution_base/sender.hpp
@@ -179,6 +179,10 @@ namespace hpx { namespace execution { namespace experimental {
     template <typename Scheduler>
     inline constexpr bool is_scheduler_v = is_scheduler<Scheduler>::value;
 
+    template <typename S>
+    using schedule_result_t = std::enable_if_t<is_scheduler_v<S>,
+        hpx::util::invoke_result_t<schedule_t, S>>;
+
     template <typename S, typename R>
     using connect_result_t = hpx::util::invoke_result_t<connect_t, S, R>;
 }}}    // namespace hpx::execution::experimental

--- a/libs/core/execution_base/include/hpx/execution_base/sender.hpp
+++ b/libs/core/execution_base/include/hpx/execution_base/sender.hpp
@@ -180,8 +180,7 @@ namespace hpx { namespace execution { namespace experimental {
     inline constexpr bool is_scheduler_v = is_scheduler<Scheduler>::value;
 
     template <typename S>
-    using schedule_result_t = std::enable_if_t<is_scheduler_v<S>,
-        hpx::util::invoke_result_t<schedule_t, S>>;
+    using schedule_result_t = hpx::util::invoke_result_t<schedule_t, S>;
 
     template <typename S, typename R>
     using connect_result_t = hpx::util::invoke_result_t<connect_t, S, R>;

--- a/libs/core/execution_base/tests/unit/basic_schedule.cpp
+++ b/libs/core/execution_base/tests/unit/basic_schedule.cpp
@@ -133,11 +133,5 @@ int main()
             sender>,
         "Result of scheduler is a sender");
 
-    static_assert(
-        !std::is_same_v<
-            hpx::execution::experimental::schedule_result_t<non_scheduler_1>,
-            sender>,
-        "Result of non-scheduler is not a sender");
-
     return hpx::util::report_errors();
 }

--- a/libs/core/execution_base/tests/unit/basic_schedule.cpp
+++ b/libs/core/execution_base/tests/unit/basic_schedule.cpp
@@ -122,5 +122,22 @@ int main()
     HPX_TEST_EQ(friend_tag_invoke_schedule_calls, std::size_t(1));
     HPX_TEST_EQ(tag_invoke_schedule_calls, std::size_t(1));
 
+    static_assert(
+        std::is_same_v<
+            hpx::execution::experimental::schedule_result_t<scheduler_1>,
+            sender>,
+        "Result of scheduler is a sender");
+    static_assert(
+        std::is_same_v<
+            hpx::execution::experimental::schedule_result_t<scheduler_2>,
+            sender>,
+        "Result of scheduler is a sender");
+
+    static_assert(
+        !std::is_same_v<
+            hpx::execution::experimental::schedule_result_t<non_scheduler_1>,
+            sender>,
+        "Result of non-scheduler is not a sender");
+
     return hpx::util::report_errors();
 }


### PR DESCRIPTION
- Alias schedule_result_t gives the result type of schedule

Signed-off-by: Shreyas Atre <shreyasatre16@gmail.com>


## Any background context you want to provide?

- https://github.com/STEllAR-GROUP/hpx/issues/5045#issuecomment-868810753
- [X] I have added a new feature and have added tests to go along with it.
- [ ] I have fixed a bug and have added a regression test.
- [ ] I have added a test using random numbers; I have made sure it uses a seed, and that the random numbers generated are valid inputs for the tests.
