### PR TITLE
Optimize LCI parcelport

### DIFF
--- a/libs/core/lci_base/include/hpx/lci_base/lci_environment.hpp
+++ b/libs/core/lci_base/include/hpx/lci_base/lci_environment.hpp
@@ -18,6 +18,7 @@
 #include <cstdlib>
 #include <string>
 #include <thread>
+#include <atomic>
 
 #include <hpx/config/warnings_prefix.hpp>
 

--- a/libs/core/lci_base/include/hpx/lci_base/lci_environment.hpp
+++ b/libs/core/lci_base/include/hpx/lci_base/lci_environment.hpp
@@ -17,6 +17,7 @@
 
 #include <cstdlib>
 #include <string>
+#include <thread>
 
 #include <hpx/config/warnings_prefix.hpp>
 
@@ -28,6 +29,8 @@ namespace hpx { namespace util {
         static LCI_error_t init_lci();
         static void init(int* argc, char*** argv, runtime_configuration& cfg);
         static void finalize();
+
+        static void progress_fn();
 
         static bool enabled();
 
@@ -75,6 +78,8 @@ namespace hpx { namespace util {
         static LCI_endpoint_t h_ep_;
         static LCI_comp_t rt_cq_r_;
         static LCI_comp_t h_cq_r_;
+        static std::thread* prg_thread_p;
+        static std::atomic<bool> prg_thread_flag;
     };
 }}    // namespace hpx::util
 

--- a/libs/core/lci_base/include/hpx/lci_base/lci_environment.hpp
+++ b/libs/core/lci_base/include/hpx/lci_base/lci_environment.hpp
@@ -15,10 +15,10 @@
 #include <hpx/modules/runtime_configuration.hpp>
 #include <hpx/synchronization/spinlock.hpp>
 
+#include <atomic>
 #include <cstdlib>
 #include <string>
 #include <thread>
-#include <atomic>
 
 #include <hpx/config/warnings_prefix.hpp>
 

--- a/libs/core/lci_base/src/lci_environment.cpp
+++ b/libs/core/lci_base/src/lci_environment.cpp
@@ -7,6 +7,7 @@
 
 #include <hpx/config.hpp>
 
+#include <hpx/assert.hpp>
 #include <hpx/modules/lci_base.hpp>
 #include <hpx/modules/logging.hpp>
 #include <hpx/modules/runtime_configuration.hpp>
@@ -14,6 +15,7 @@
 
 #include <boost/tokenizer.hpp>
 
+#include <atomic>
 #include <cstddef>
 #include <cstdlib>
 #include <string>

--- a/libs/full/parcelport_lci/include/hpx/parcelport_lci/receiver_connection.hpp
+++ b/libs/full/parcelport_lci/include/hpx/parcelport_lci/receiver_connection.hpp
@@ -41,7 +41,7 @@ namespace hpx::parcelset::policies::lci {
     public:
         receiver_connection(int src, header h, Parcelport& pp) noexcept
           : state_(initialized)
-          , src_(src)
+          , src_rank(src)
           , tag_(h.tag())
           , header_(h)
           , request_ptr_(nullptr)
@@ -86,9 +86,31 @@ namespace hpx::parcelset::policies::lci {
             return false;
         }
 
-        int get_src_rank()
+        bool unified_recv(void* buffer, int length, int rank, LCI_tag_t tag)
         {
-            return src_;
+            LCI_error_t ret;
+            if (length <= LCI_MEDIUM_SIZE)
+            {
+                LCI_mbuffer_t mbuffer;
+                mbuffer.address = buffer;
+                mbuffer.length = length;
+                ret = LCI_recvm(util::lci_environment::lci_endpoint(), mbuffer,
+                    rank, tag, sync_, nullptr);
+            }
+            else
+            {
+                LCI_lbuffer_t lbuffer;
+                lbuffer.address = buffer;
+                lbuffer.length = length;
+                lbuffer.segment = LCI_SEGMENT_ALL;
+                ret = LCI_recvl(util::lci_environment::lci_endpoint(), lbuffer,
+                    src_rank, tag_, sync_, nullptr);
+            }
+            if (ret == LCI_OK)
+            {
+                request_ptr_ = &sync_;
+            }
+            return ret == LCI_OK;
         }
 
         bool receive_transmission_chunks(std::size_t num_thread = -1)
@@ -98,30 +120,20 @@ namespace hpx::parcelset::policies::lci {
                 static_cast<std::uint32_t>(buffer_.num_chunks_.first));
             std::size_t num_non_zero_copy_chunks = static_cast<std::size_t>(
                 static_cast<std::uint32_t>(buffer_.num_chunks_.second));
-            buffer_.transmission_chunks_.resize(
-                num_zero_copy_chunks + num_non_zero_copy_chunks);
+
+            auto& tchunks = buffer_.transmission_chunks_;
+            tchunks.resize(num_zero_copy_chunks + num_non_zero_copy_chunks);
             if (num_zero_copy_chunks != 0)
             {
                 buffer_.chunks_.resize(num_zero_copy_chunks);
-                {
-                    LCI_lbuffer_t lbuf_;
-                    lbuf_.address = buffer_.transmission_chunks_.data();
-                    lbuf_.length =
-                        static_cast<int>(buffer_.transmission_chunks_.size() *
-                            sizeof(buffer_type::transmission_chunk_type));
-                    lbuf_.segment = LCI_SEGMENT_ALL;
-                    if (LCI_recvl(util::lci_environment::lci_endpoint(), lbuf_,
-                            get_src_rank(), tag_, sync_, nullptr) != LCI_OK)
-                    {
-                        return false;
-                    }
-
-                    request_ptr_ = &sync_;
-                }
+                int tchunks_length = static_cast<int>(tchunks.size() *
+                    sizeof(buffer_type::transmission_chunk_type));
+                bool ret = unified_recv(
+                    tchunks.data(), tchunks_length, src_rank, tag_);
+                if (!ret)
+                    return false;
             }
-
             state_ = rcvd_transmission_chunks;
-
             return receive_data(num_thread);
         }
 
@@ -138,21 +150,12 @@ namespace hpx::parcelset::policies::lci {
             }
             else
             {
-                LCI_lbuffer_t lbuf_;
-                lbuf_.address = buffer_.data_.data();
-                lbuf_.length = static_cast<int>(buffer_.data_.size());
-                lbuf_.segment = LCI_SEGMENT_ALL;
-
-                if (LCI_recvl(util::lci_environment::lci_endpoint(), lbuf_,
-                        get_src_rank(), tag_, sync_, nullptr) != LCI_OK)
-                {
+                bool ret = unified_recv(buffer_.data_.data(),
+                    static_cast<int>(buffer_.data_.size()), src_rank, tag_);
+                if (!ret)
                     return false;
-                }
-
-                request_ptr_ = &sync_;
             }
             state_ = rcvd_data;
-
             return receive_chunks(num_thread);
         }
 
@@ -168,22 +171,12 @@ namespace hpx::parcelset::policies::lci {
                     buffer_.transmission_chunks_[idx].second;
 
                 data_type& c = buffer_.chunks_[idx];
-                // If the LCI_recvl returns LCI_ERR_RETRY this resize can happen
-                // multiple times. I hope the resize is clever enough that
-                // it would not introduce additional overhead.
                 c.resize(chunk_size);
                 {
-                    LCI_lbuffer_t lbuf_;
-                    lbuf_.address = c.data();
-                    lbuf_.length = static_cast<int>(c.size());
-                    lbuf_.segment = LCI_SEGMENT_ALL;
-                    if (LCI_recvl(util::lci_environment::lci_endpoint(), lbuf_,
-                            get_src_rank(), tag_, sync_, nullptr) != LCI_OK)
-                    {
+                    bool ret = unified_recv(
+                        c.data(), static_cast<int>(c.size()), src_rank, tag_);
+                    if (!ret)
                         return false;
-                    }
-
-                    request_ptr_ = &sync_;
                 }
                 ++chunks_idx_;
             }
@@ -223,7 +216,7 @@ namespace hpx::parcelset::policies::lci {
                 LCI_short_t short_rt_;
                 *(int*) &short_rt_ = tag_;
                 if (LCI_puts(util::lci_environment::rt_endpoint(), short_rt_,
-                        get_src_rank(), 1, LCI_DEFAULT_COMP_REMOTE) != LCI_OK)
+                        src_rank, 1, LCI_DEFAULT_COMP_REMOTE) != LCI_OK)
                 {
                     return false;
                 }
@@ -245,7 +238,7 @@ namespace hpx::parcelset::policies::lci {
 
         connection_state state_;
 
-        int src_;
+        int src_rank;
         int tag_;
         header header_;
         buffer_type buffer_;

--- a/libs/full/parcelport_lci/include/hpx/parcelport_lci/receiver_connection.hpp
+++ b/libs/full/parcelport_lci/include/hpx/parcelport_lci/receiver_connection.hpp
@@ -104,8 +104,6 @@ namespace hpx::parcelset::policies::lci {
             {
                 buffer_.chunks_.resize(num_zero_copy_chunks);
                 {
-                    util::lci_environment::scoped_lock l;
-
                     LCI_lbuffer_t lbuf_;
                     lbuf_.address = buffer_.transmission_chunks_.data();
                     lbuf_.length =
@@ -115,7 +113,6 @@ namespace hpx::parcelset::policies::lci {
                     if (LCI_recvl(util::lci_environment::lci_endpoint(), lbuf_,
                             get_src_rank(), tag_, sync_, nullptr) != LCI_OK)
                     {
-                        LCI_progress(LCI_UR_DEVICE);
                         return false;
                     }
 
@@ -141,8 +138,6 @@ namespace hpx::parcelset::policies::lci {
             }
             else
             {
-                util::lci_environment::scoped_lock l;
-
                 LCI_lbuffer_t lbuf_;
                 lbuf_.address = buffer_.data_.data();
                 lbuf_.length = static_cast<int>(buffer_.data_.size());
@@ -151,7 +146,6 @@ namespace hpx::parcelset::policies::lci {
                 if (LCI_recvl(util::lci_environment::lci_endpoint(), lbuf_,
                         get_src_rank(), tag_, sync_, nullptr) != LCI_OK)
                 {
-                    LCI_progress(LCI_UR_DEVICE);
                     return false;
                 }
 
@@ -179,8 +173,6 @@ namespace hpx::parcelset::policies::lci {
                 // it would not introduce additional overhead.
                 c.resize(chunk_size);
                 {
-                    util::lci_environment::scoped_lock l;
-
                     LCI_lbuffer_t lbuf_;
                     lbuf_.address = c.data();
                     lbuf_.length = static_cast<int>(c.size());
@@ -188,7 +180,6 @@ namespace hpx::parcelset::policies::lci {
                     if (LCI_recvl(util::lci_environment::lci_endpoint(), lbuf_,
                             get_src_rank(), tag_, sync_, nullptr) != LCI_OK)
                     {
-                        LCI_progress(LCI_UR_DEVICE);
                         return false;
                     }
 
@@ -216,10 +207,6 @@ namespace hpx::parcelset::policies::lci {
             }
             else
             {
-                util::lci_environment::scoped_try_lock l;
-                if (!l.locked)
-                    return false;
-                LCI_progress(LCI_UR_DEVICE);
                 return false;
             }
         }
@@ -233,13 +220,11 @@ namespace hpx::parcelset::policies::lci {
             data.time_ = timer_.elapsed_nanoseconds() - data.time_;
 
             {
-                util::lci_environment::scoped_lock l;
                 LCI_short_t short_rt_;
                 *(int*) &short_rt_ = tag_;
                 if (LCI_puts(util::lci_environment::rt_endpoint(), short_rt_,
                         get_src_rank(), 1, LCI_DEFAULT_COMP_REMOTE) != LCI_OK)
                 {
-                    LCI_progress(LCI_UR_DEVICE);
                     return false;
                 }
             }

--- a/libs/full/parcelport_lci/include/hpx/parcelport_lci/sender.hpp
+++ b/libs/full/parcelport_lci/include/hpx/parcelport_lci/sender.hpp
@@ -102,34 +102,19 @@ namespace hpx::parcelset::policies::lci {
 
         void next_free_tag() noexcept
         {
-            int next_free = -1;
-            {
-                next_free = next_free_tag_locked();
-            }
-
-            if (next_free != -1)
-            {
-                HPX_ASSERT(next_free > 1);
-                tag_provider_.release(next_free);
-            }
-        }
-
-        int next_free_tag_locked() noexcept
-        {
             LCI_request_t request;
             LCI_error_t ret =
                 LCI_queue_pop(util::lci_environment::rt_queue(), &request);
             if (ret == LCI_OK)
             {
-                return *(int*) &request.data.immediate;
+                int next_free = *(int*) &request.data.immediate;
+                HPX_ASSERT(next_free > 1);
+                tag_provider_.release(next_free);
             }
-            return -1;
         }
 
         mutex_type connections_mtx_;
         connection_list connections_;
-
-        mutex_type next_free_tag_mtx_;
     };
 
 }    // namespace hpx::parcelset::policies::lci

--- a/libs/full/parcelport_lci/include/hpx/parcelport_lci/sender_connection.hpp
+++ b/libs/full/parcelport_lci/include/hpx/parcelport_lci/sender_connection.hpp
@@ -144,7 +144,6 @@ namespace hpx::parcelset::policies::lci {
         bool send_header()
         {
             {
-                util::lci_environment::scoped_lock l;
                 HPX_ASSERT(state_ == initialized);
                 HPX_ASSERT(request_ptr_ == nullptr);
                 HPX_ASSERT(LCI_MEDIUM_SIZE >= header_.data_size_);
@@ -155,7 +154,6 @@ namespace hpx::parcelset::policies::lci {
                         medium_header_, get_dst_rank(), 0,
                         LCI_DEFAULT_COMP_REMOTE) != LCI_OK)
                 {
-                    LCI_progress(LCI_UR_DEVICE);
                     return false;
                 }
             }
@@ -181,8 +179,6 @@ namespace hpx::parcelset::policies::lci {
                 chunks = buffer_.transmission_chunks_;
             if (!chunks.empty())
             {
-                util::lci_environment::scoped_lock l;
-
                 LCI_lbuffer_t lbuf_;
                 lbuf_.address = chunks.data();
                 lbuf_.length = static_cast<int>(chunks.size() *
@@ -191,7 +187,6 @@ namespace hpx::parcelset::policies::lci {
                 if (LCI_sendl(util::lci_environment::lci_endpoint(), lbuf_,
                         get_dst_rank(), tag_, sync_, nullptr) != LCI_OK)
                 {
-                    LCI_progress(LCI_UR_DEVICE);
                     return false;
                 }
 
@@ -210,8 +205,6 @@ namespace hpx::parcelset::policies::lci {
 
             if (!header_.piggy_back())
             {
-                util::lci_environment::scoped_lock l;
-
                 LCI_lbuffer_t lbuf_;
                 lbuf_.address = buffer_.data_.data();
                 lbuf_.length = static_cast<int>(buffer_.data_.size());
@@ -219,7 +212,6 @@ namespace hpx::parcelset::policies::lci {
                 if (LCI_sendl(util::lci_environment::lci_endpoint(), lbuf_,
                         get_dst_rank(), tag_, sync_, nullptr) != LCI_OK)
                 {
-                    LCI_progress(LCI_UR_DEVICE);
                     return false;
                 }
 
@@ -243,8 +235,6 @@ namespace hpx::parcelset::policies::lci {
                         return false;
                     else
                     {
-                        util::lci_environment::scoped_lock l;
-
                         LCI_lbuffer_t lbuf_;
                         lbuf_.address = const_cast<void*>(c.data_.cpos_);
                         lbuf_.length = static_cast<int>(c.size_);
@@ -253,7 +243,6 @@ namespace hpx::parcelset::policies::lci {
                                 lbuf_, get_dst_rank(), tag_, sync_,
                                 nullptr) != LCI_OK)
                         {
-                            LCI_progress(LCI_UR_DEVICE);
                             return false;
                         }
                         request_ptr_ = &sync_;
@@ -281,10 +270,6 @@ namespace hpx::parcelset::policies::lci {
             }
             else
             {
-                util::lci_environment::scoped_try_lock l;
-                if (!l.locked)
-                    return false;
-                LCI_progress(LCI_UR_DEVICE);
                 return false;
             }
         }

--- a/libs/full/parcelport_lci/include/hpx/parcelport_lci/sender_connection.hpp
+++ b/libs/full/parcelport_lci/include/hpx/parcelport_lci/sender_connection.hpp
@@ -63,13 +63,10 @@ namespace hpx::parcelset::policies::lci {
           , sender_(s)
           , tag_(-1)
           , dst_rank(dst)
-          , request_ptr_(nullptr)
           , chunks_idx_(0)
-          , ack_(0)
           , pp_(pp)
           , there_(parcelset::locality(locality(dst_rank)))
         {
-            LCI_sync_create(LCI_UR_DEVICE, 1, &sync_);
         }
 
         parcelset::locality const& destination() const noexcept
@@ -92,11 +89,45 @@ namespace hpx::parcelset::policies::lci {
 
             buffer_.data_point_.time_ =
                 hpx::chrono::high_resolution_clock::now();
-            request_ptr_ = nullptr;
             chunks_idx_ = 0;
             tag_ = acquire_tag(sender_);
             header_ = header(buffer_, tag_);
             header_.assert_valid();
+
+            // calculate how many long messages to send
+            int long_msg_num = 0;
+            // data
+            if (!header_.piggy_back() &&
+                static_cast<int>(buffer_.data_.size()) > LCI_MEDIUM_SIZE)
+                ++long_msg_num;
+            // transmission chunks
+            std::size_t num_zero_copy_chunks = static_cast<std::size_t>(
+                static_cast<std::uint32_t>(buffer_.num_chunks_.first));
+            if (num_zero_copy_chunks != 0)
+            {
+                std::vector<
+                    typename parcel_buffer_type::transmission_chunk_type>&
+                    tchunks = buffer_.transmission_chunks_;
+                int tchunks_length = static_cast<int>(tchunks.size() *
+                    sizeof(parcel_buffer_type::transmission_chunk_type));
+                if (tchunks_length > LCI_MEDIUM_SIZE)
+                    ++long_msg_num;
+                // chunks
+                for (auto& chunk : buffer_.chunks_)
+                {
+                    if (chunk.type_ ==
+                            serialization::chunk_type::chunk_type_pointer &&
+                        static_cast<int>(chunk.size_) > LCI_MEDIUM_SIZE)
+                    {
+                        ++long_msg_num;
+                    }
+                }
+            }
+            // create synchronizer
+            if (long_msg_num > 0)
+                LCI_sync_create(LCI_UR_DEVICE, long_msg_num, &sync_);
+            else
+                sync_ = nullptr;
 
             state_ = initialized;
 
@@ -146,7 +177,6 @@ namespace hpx::parcelset::policies::lci {
         {
             {
                 HPX_ASSERT(state_ == initialized);
-                HPX_ASSERT(request_ptr_ == nullptr);
                 HPX_ASSERT(LCI_MEDIUM_SIZE >= header_.data_size_);
                 LCI_mbuffer_t mbuffer;
                 mbuffer.length = header_.data_size_;
@@ -181,10 +211,6 @@ namespace hpx::parcelset::policies::lci {
                 lbuffer.segment = LCI_SEGMENT_ALL;
                 ret = LCI_sendl(util::lci_environment::lci_endpoint(), lbuffer,
                     rank, tag, sync_, nullptr);
-                if (ret == LCI_OK)
-                {
-                    request_ptr_ = &sync_;
-                }
             }
             return ret == LCI_OK;
         }
@@ -192,7 +218,6 @@ namespace hpx::parcelset::policies::lci {
         bool send_transmission_chunks()
         {
             HPX_ASSERT(state_ == sent_header);
-            HPX_ASSERT(request_ptr_ == nullptr);
             std::size_t num_zero_copy_chunks = static_cast<std::size_t>(
                 static_cast<std::uint32_t>(buffer_.num_chunks_.first));
 
@@ -217,9 +242,6 @@ namespace hpx::parcelset::policies::lci {
         bool send_data()
         {
             HPX_ASSERT(state_ == sent_transmission_chunks);
-            if (!request_done())
-                return false;
-
             if (!header_.piggy_back())
             {
                 bool ret = unified_send(buffer_.data_.data(),
@@ -241,16 +263,10 @@ namespace hpx::parcelset::policies::lci {
                     buffer_.chunks_[chunks_idx_];
                 if (c.type_ == serialization::chunk_type::chunk_type_pointer)
                 {
-                    if (!request_done())
+                    bool ret = unified_send(const_cast<void*>(c.data_.cpos_),
+                        static_cast<int>(c.size_), dst_rank, tag_);
+                    if (!ret)
                         return false;
-                    else
-                    {
-                        bool ret =
-                            unified_send(const_cast<void*>(c.data_.cpos_),
-                                static_cast<int>(c.size_), dst_rank, tag_);
-                        if (!ret)
-                            return false;
-                    }
                 }
                 chunks_idx_++;
             }
@@ -259,29 +275,16 @@ namespace hpx::parcelset::policies::lci {
             return done();
         }
 
-        bool request_done()
-        {
-            if (request_ptr_ == nullptr)
-                return true;
-            HPX_ASSERT(request_ptr_ == &sync_);
-
-            LCI_error_t ret = LCI_sync_test(sync_, nullptr);
-            if (ret == LCI_OK)
-            {
-                request_ptr_ = nullptr;
-                return true;
-            }
-            else
-            {
-                return false;
-            }
-        }
-
         bool done()
         {
-            if (!request_done())
-                return false;
-
+            if (sync_ != nullptr)
+            {
+                LCI_error_t ret = LCI_sync_test(sync_, nullptr);
+                if (ret != LCI_OK)
+                    return false;
+                LCI_sync_free(&sync_);
+                sync_ = nullptr;
+            }
             error_code ec;
             handler_(ec);
             handler_.reset();
@@ -307,10 +310,8 @@ namespace hpx::parcelset::policies::lci {
 
         header header_;
 
-        void* request_ptr_;
         LCI_comp_t sync_;
         std::size_t chunks_idx_;
-        char ack_;
 
         parcelset::parcelport* pp_;
 

--- a/libs/full/parcelport_lci/include/hpx/parcelport_lci/sender_connection.hpp
+++ b/libs/full/parcelport_lci/include/hpx/parcelport_lci/sender_connection.hpp
@@ -21,6 +21,7 @@
 #include <hpx/parcelset_base/parcelport.hpp>
 
 #include <cstddef>
+#include <cstdint>
 #include <memory>
 #include <system_error>
 #include <utility>
@@ -61,12 +62,12 @@ namespace hpx::parcelset::policies::lci {
           : state_(initialized)
           , sender_(s)
           , tag_(-1)
-          , dst_(dst)
+          , dst_rank(dst)
           , request_ptr_(nullptr)
           , chunks_idx_(0)
           , ack_(0)
           , pp_(pp)
-          , there_(parcelset::locality(locality(dst_)))
+          , there_(parcelset::locality(locality(dst_rank)))
         {
             LCI_sync_create(LCI_UR_DEVICE, 1, &sync_);
         }
@@ -147,12 +148,11 @@ namespace hpx::parcelset::policies::lci {
                 HPX_ASSERT(state_ == initialized);
                 HPX_ASSERT(request_ptr_ == nullptr);
                 HPX_ASSERT(LCI_MEDIUM_SIZE >= header_.data_size_);
-                LCI_mbuffer_t medium_header_;
-                medium_header_.length = header_.data_size_;
-                medium_header_.address = header_.data();
-                if (LCI_putma(util::lci_environment::h_endpoint(),
-                        medium_header_, get_dst_rank(), 0,
-                        LCI_DEFAULT_COMP_REMOTE) != LCI_OK)
+                LCI_mbuffer_t mbuffer;
+                mbuffer.length = header_.data_size_;
+                mbuffer.address = header_.data();
+                if (LCI_putma(util::lci_environment::h_endpoint(), mbuffer,
+                        dst_rank, 0, LCI_DEFAULT_COMP_REMOTE) != LCI_OK)
                 {
                     return false;
                 }
@@ -162,37 +162,54 @@ namespace hpx::parcelset::policies::lci {
             return send_transmission_chunks();
         }
 
-        int get_dst_rank()
+        bool unified_send(void* buffer, int length, int rank, LCI_tag_t tag)
         {
-            return dst_;
+            LCI_error_t ret;
+            if (length <= LCI_MEDIUM_SIZE)
+            {
+                LCI_mbuffer_t mbuffer;
+                mbuffer.address = buffer;
+                mbuffer.length = length;
+                ret = LCI_sendm(
+                    util::lci_environment::lci_endpoint(), mbuffer, rank, tag);
+            }
+            else
+            {
+                LCI_lbuffer_t lbuffer;
+                lbuffer.address = buffer;
+                lbuffer.length = length;
+                lbuffer.segment = LCI_SEGMENT_ALL;
+                ret = LCI_sendl(util::lci_environment::lci_endpoint(), lbuffer,
+                    rank, tag, sync_, nullptr);
+                if (ret == LCI_OK)
+                {
+                    request_ptr_ = &sync_;
+                }
+            }
+            return ret == LCI_OK;
         }
 
         bool send_transmission_chunks()
         {
             HPX_ASSERT(state_ == sent_header);
-            if (!request_done())
-                return false;
-
             HPX_ASSERT(request_ptr_ == nullptr);
+            std::size_t num_zero_copy_chunks = static_cast<std::size_t>(
+                static_cast<std::uint32_t>(buffer_.num_chunks_.first));
 
             std::vector<typename parcel_buffer_type::transmission_chunk_type>&
-                chunks = buffer_.transmission_chunks_;
-            if (!chunks.empty())
+                tchunks = buffer_.transmission_chunks_;
+            // this makes me very confused
+            // the original condition here is !tchunks.empty()
+            // the receive counterpart has the condition num_zero_copy_chunks != 0
+            if (num_zero_copy_chunks != 0)
             {
-                LCI_lbuffer_t lbuf_;
-                lbuf_.address = chunks.data();
-                lbuf_.length = static_cast<int>(chunks.size() *
+                int tchunks_length = static_cast<int>(tchunks.size() *
                     sizeof(parcel_buffer_type::transmission_chunk_type));
-                lbuf_.segment = LCI_SEGMENT_ALL;
-                if (LCI_sendl(util::lci_environment::lci_endpoint(), lbuf_,
-                        get_dst_rank(), tag_, sync_, nullptr) != LCI_OK)
-                {
+                bool ret = unified_send(
+                    tchunks.data(), tchunks_length, dst_rank, tag_);
+                if (!ret)
                     return false;
-                }
-
-                request_ptr_ = &sync_;
             }
-
             state_ = sent_transmission_chunks;
             return send_data();
         }
@@ -205,17 +222,10 @@ namespace hpx::parcelset::policies::lci {
 
             if (!header_.piggy_back())
             {
-                LCI_lbuffer_t lbuf_;
-                lbuf_.address = buffer_.data_.data();
-                lbuf_.length = static_cast<int>(buffer_.data_.size());
-                lbuf_.segment = LCI_SEGMENT_ALL;
-                if (LCI_sendl(util::lci_environment::lci_endpoint(), lbuf_,
-                        get_dst_rank(), tag_, sync_, nullptr) != LCI_OK)
-                {
+                bool ret = unified_send(buffer_.data_.data(),
+                    static_cast<int>(buffer_.data_.size()), dst_rank, tag_);
+                if (!ret)
                     return false;
-                }
-
-                request_ptr_ = &sync_;
             }
             state_ = sent_data;
             return send_chunks();
@@ -235,20 +245,13 @@ namespace hpx::parcelset::policies::lci {
                         return false;
                     else
                     {
-                        LCI_lbuffer_t lbuf_;
-                        lbuf_.address = const_cast<void*>(c.data_.cpos_);
-                        lbuf_.length = static_cast<int>(c.size_);
-                        lbuf_.segment = LCI_SEGMENT_ALL;
-                        if (LCI_sendl(util::lci_environment::lci_endpoint(),
-                                lbuf_, get_dst_rank(), tag_, sync_,
-                                nullptr) != LCI_OK)
-                        {
+                        bool ret =
+                            unified_send(const_cast<void*>(c.data_.cpos_),
+                                static_cast<int>(c.size_), dst_rank, tag_);
+                        if (!ret)
                             return false;
-                        }
-                        request_ptr_ = &sync_;
                     }
                 }
-
                 chunks_idx_++;
             }
             state_ = sent_chunks;
@@ -296,7 +299,7 @@ namespace hpx::parcelset::policies::lci {
         connection_state state_;
         sender_type* sender_;
         int tag_;
-        int dst_;
+        int dst_rank;
         hpx::move_only_function<void(error_code const&)> handler_;
         hpx::move_only_function<void(error_code const&,
             parcelset::locality const&, std::shared_ptr<sender_connection>)>


### PR DESCRIPTION
Optimize LCI parcelport.

Done:
- only use a single progress thread to call LCI_progress;
- remove all the locks around LCI calls;
- use LCI_sendm or LCI_sendl based on message size. Previously, we only use LCI_sendl.
- simultaneously post multiple send/recv for the same connection. Only synchronize in the end.