### PR TITLE
Convert enum counter_status to enum class

### DIFF
--- a/components/performance_counters/papi/include/hpx/components/performance_counters/papi/server/papi.hpp
+++ b/components/performance_counters/papi/include/hpx/components/performance_counters/papi/server/papi.hpp
@@ -274,7 +274,8 @@ namespace hpx { namespace performance_counters { namespace papi {
             {
                 val.time_ = timestamp_;
                 val.value_ = value_;
-                val.status_ = hpx::performance_counters::status_new_data;
+                val.status_ =
+                    hpx::performance_counters::counter_status::new_data;
                 val.scaling_ = 1;
                 val.scale_inverse_ = false;
             }

--- a/components/performance_counters/papi/src/server/papi.cpp
+++ b/components/performance_counters/papi/src/server/papi.cpp
@@ -37,294 +37,324 @@
 ///////////////////////////////////////////////////////////////////////////////
 namespace papi_ns = hpx::performance_counters::papi;
 
-typedef hpx::components::component<
-    papi_ns::server::papi_counter
-> papi_counter_type;
+typedef hpx::components::component<papi_ns::server::papi_counter>
+    papi_counter_type;
 
 HPX_REGISTER_DERIVED_COMPONENT_FACTORY_DYNAMIC(
     papi_counter_type, papi_counter, "base_performance_counter")
 
 ///////////////////////////////////////////////////////////////////////////////
-namespace hpx { namespace performance_counters { namespace papi { namespace server
-{
+namespace hpx { namespace performance_counters { namespace papi {
+    namespace server {
 #define NS_STR "hpx::performance_counters::papi::server::"
 
-    ///////////////////////////////////////////////////////////////////////////
-    // static members
-    papi_counter_base::mutex_type papi_counter_base::base_mtx_;
-    papi_counter_base::ttable_type papi_counter_base::thread_state_;
+        ///////////////////////////////////////////////////////////////////////////
+        // static members
+        papi_counter_base::mutex_type papi_counter_base::base_mtx_;
+        papi_counter_base::ttable_type papi_counter_base::thread_state_;
 
-    using hpx::performance_counters::papi::util::papi_call;
+        using hpx::performance_counters::papi::util::papi_call;
 
-    ///////////////////////////////////////////////////////////////////////////
-    // methods
-    thread_counters::thread_counters(std::uint32_t tix):
-        thread_index_(tix), evset_(PAPI_NULL)
-    {
-        char const *locstr =
-            "hpx::performance_counters::papi::server::thread_counters()";
-        hpx::util::thread_mapper& tm =
-            hpx::get_runtime().get_thread_mapper();
-        papi_call(PAPI_create_eventset(&evset_),
-            "could not create PAPI event set", locstr);
-        papi_call(PAPI_assign_eventset_component(evset_, 0),
-            "cannot assign component index to event set", locstr);
-        pid_t tid = tm.get_linux_thread_id(tix);
-        if (tid == -1)
-            HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                NS_STR "thread_counters::thread_counters()",
-                "unable to retrieve correct OS thread ID for profiling "
-                "(perhaps thread was not registered)");
-        papi_call(PAPI_attach(evset_, tid),
-            "failed to attach thread to PAPI event set", locstr);
-        tm.register_callback(tix, [&](std::uint32_t i){return this->terminate(i);});
-    }
-
-    thread_counters::~thread_counters()
-    {
+        ///////////////////////////////////////////////////////////////////////////
+        // methods
+        thread_counters::thread_counters(std::uint32_t tix)
+          : thread_index_(tix)
+          , evset_(PAPI_NULL)
         {
-            std::lock_guard<mutex_type> m(mtx_);
-            finalize();
+            char const* locstr =
+                "hpx::performance_counters::papi::server::thread_counters()";
+            hpx::util::thread_mapper& tm =
+                hpx::get_runtime().get_thread_mapper();
+            papi_call(PAPI_create_eventset(&evset_),
+                "could not create PAPI event set", locstr);
+            papi_call(PAPI_assign_eventset_component(evset_, 0),
+                "cannot assign component index to event set", locstr);
+            pid_t tid = tm.get_linux_thread_id(tix);
+            if (tid == -1)
+                HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                    NS_STR "thread_counters::thread_counters()",
+                    "unable to retrieve correct OS thread ID for profiling "
+                    "(perhaps thread was not registered)");
+            papi_call(PAPI_attach(evset_, tid),
+                "failed to attach thread to PAPI event set", locstr);
+            tm.register_callback(
+                tix, [&](std::uint32_t i) { return this->terminate(i); });
         }
-        // callback cancellation moved outside the mutex to avoid potential deadlock
-        hpx::get_runtime().get_thread_mapper().revoke_callback(thread_index_);
-    }
 
-    bool thread_counters::add_event(papi_counter *cnt)
-    {
-        stop_all();
-        if (PAPI_add_event(evset_, cnt->get_event()) != PAPI_OK)
-            return false;
-        counts_.push_back(cnt->get_value());
-        cnttab_.push_back(cnt);
-        cnt->update_index(counts_.size()-1);
-        return start_all();
-    }
-
-    bool thread_counters::remove_event(papi_counter *cnt)
-    {
-        if (!stop_all() || PAPI_cleanup_eventset(evset_) != PAPI_OK)
-            return false;
-
-        // store the most recent value
-        int rmix = cnt->get_counter_index();
-        cnt->update_state(timestamp_, counts_[rmix], PAPI_COUNTER_STOPPED);
-        // erase entries corresponding to removed event
-        counts_.erase(counts_.begin()+rmix);
-        cnttab_.erase(cnttab_.begin()+rmix);
-        // For the lack of better strategy the remaining events are added in the
-        // same order as before. This avoids reordering of remaining counter
-        // values and at least some surprises on architectures with asymmetric
-        // functionality of counting registers.
-        unsigned i = 0;
-        while (i < counts_.size())
+        thread_counters::~thread_counters()
         {
-            papi_counter *c = cnttab_[i];
-            if (PAPI_add_event(evset_, c->get_event()) != PAPI_OK)
-            { // failed to add event
-                c->update_state(timestamp_, counts_[c->get_counter_index()],
-                                PAPI_COUNTER_SUSPENDED);
-                counts_.erase(counts_.begin()+i);
-                cnttab_.erase(cnttab_.begin()+i);
-                continue;
-            }
-            // update indices of remaining counters
-            c->update_index(i++);
-        }
-        return start_all();
-    }
-
-    bool thread_counters::read_value(papi_counter *cnt, bool reset)
-    {
-        {
-            std::lock_guard<papi_counter_base::mutex_type> lk(cnt->get_global_mtx());
-
-            if (PAPI_accum(evset_, &counts_[0]) != PAPI_OK) return false;
-        }
-        timestamp_ = static_cast<std::int64_t>(hpx::get_system_uptime());
-        cnt->update_state(timestamp_, counts_[cnt->get_counter_index()]);
-        if (reset) counts_[cnt->get_counter_index()] = 0;
-        return true;
-    }
-
-    bool thread_counters::terminate(std::uint32_t)
-    {
-        std::lock_guard<mutex_type> m(mtx_);
-        return finalize();
-    }
-
-    bool thread_counters::start_all()
-    {
-        if (counts_.empty()) return true; // nothing to count
-        return PAPI_start(evset_) == PAPI_OK;
-    }
-
-    bool thread_counters::stop_all()
-    {
-        int stat;
-        if (PAPI_state(evset_, &stat) != PAPI_OK) return false;
-
-        if ((stat & PAPI_RUNNING) != 0)
-        {
-            std::vector<long long> tmp(counts_.size());
-            if (PAPI_stop(evset_, &tmp[0]) != PAPI_OK) return false;
-            // accumulate existing counts before modifying event set
-            if (PAPI_accum(evset_, &counts_[0]) != PAPI_OK) return false;
-            timestamp_ = static_cast<std::int64_t>(hpx::get_system_uptime());
-        }
-        return true;
-    }
-
-    bool thread_counters::finalize()
-    {
-        if (evset_ != PAPI_NULL)
-        {
-            if (stop_all())
             {
-                for (std::uint32_t i = 0; i < cnttab_.size(); ++i)
-                { // retrieve the most recent values for the still active counters
-                    papi_counter *c = cnttab_[i];
-                    if (c->get_status() == PAPI_COUNTER_ACTIVE)
-                        c->update_state(timestamp_, counts_[i], PAPI_COUNTER_TERMINATED);
-                    else c->update_status(PAPI_COUNTER_TERMINATED);
-                }
+                std::lock_guard<mutex_type> m(mtx_);
+                finalize();
             }
-            // release event set resources
-            return PAPI_destroy_eventset(&evset_) == PAPI_OK;
+            // callback cancellation moved outside the mutex to avoid potential deadlock
+            hpx::get_runtime().get_thread_mapper().revoke_callback(
+                thread_index_);
         }
-        return true;
-    }
 
-    ///////////////////////////////////////////////////////////////////////////
-    thread_counters *papi_counter_base::get_thread_counters(std::uint32_t tix)
-    {
-        std::lock_guard<mutex_type> m(base_mtx_);
-
-        // create entry for the thread associated with the counter if it doesn't exist
-        ttable_type::iterator it = thread_state_.find(tix);
-        if (it == thread_state_.end())
+        bool thread_counters::add_event(papi_counter* cnt)
         {
-            hpx::util::ignore_all_while_checking i;
-            HPX_UNUSED(i);
-
-            return thread_state_[tix] = new thread_counters(tix);
+            stop_all();
+            if (PAPI_add_event(evset_, cnt->get_event()) != PAPI_OK)
+                return false;
+            counts_.push_back(cnt->get_value());
+            cnttab_.push_back(cnt);
+            cnt->update_index(counts_.size() - 1);
+            return start_all();
         }
-        else
-            return it->second;
-    }
 
-    ///////////////////////////////////////////////////////////////////////////
-    papi_counter::papi_counter(hpx::performance_counters::counter_info const& info):
-        base_type_holder(info), event_(PAPI_NULL), index_(-1),
-        value_(0), timestamp_(-1), status_(PAPI_COUNTER_STOPPED)
-    {
-        char const *locstr = NS_STR "papi_counter()";
-
-        // extract path elements from counter name
-        counter_path_elements cpe;
-        get_counter_path_elements(info.fullname_, cpe);
-        // convert event name to code and check availability
+        bool thread_counters::remove_event(papi_counter* cnt)
         {
-            std::lock_guard<papi_counter_base::mutex_type> lk(this->get_global_mtx());
-            // papi_call might throw, leading to potential "lock held while
-            // suspending thread" errors. At this point, it is safe to ignore
-            // the lock.
-            hpx::util::ignore_all_while_checking il;
-            HPX_UNUSED(il);
+            if (!stop_all() || PAPI_cleanup_eventset(evset_) != PAPI_OK)
+                return false;
 
-            papi_call(PAPI_event_name_to_code(
-                const_cast<char *>(cpe.countername_.c_str()),
-                const_cast<int *>(&event_)),
-                cpe.countername_+" does not seem to be a valid event name",
-                locstr);
-            papi_call(
-                PAPI_query_event(event_),
-                "event "+cpe.countername_+" is not available on this platform",
-                locstr);
+            // store the most recent value
+            int rmix = cnt->get_counter_index();
+            cnt->update_state(timestamp_, counts_[rmix], PAPI_COUNTER_STOPPED);
+            // erase entries corresponding to removed event
+            counts_.erase(counts_.begin() + rmix);
+            cnttab_.erase(cnttab_.begin() + rmix);
+            // For the lack of better strategy the remaining events are added in the
+            // same order as before. This avoids reordering of remaining counter
+            // values and at least some surprises on architectures with asymmetric
+            // functionality of counting registers.
+            unsigned i = 0;
+            while (i < counts_.size())
+            {
+                papi_counter* c = cnttab_[i];
+                if (PAPI_add_event(evset_, c->get_event()) != PAPI_OK)
+                {    // failed to add event
+                    c->update_state(timestamp_, counts_[c->get_counter_index()],
+                        PAPI_COUNTER_SUSPENDED);
+                    counts_.erase(counts_.begin() + i);
+                    cnttab_.erase(cnttab_.begin() + i);
+                    continue;
+                }
+                // update indices of remaining counters
+                c->update_index(i++);
+            }
+            return start_all();
         }
-        // find OS thread associated with the counter
-        std::string label;
-        std::uint32_t tix = util::get_counter_thread(cpe, label);
-        if (tix == hpx::util::thread_mapper::invalid_index)
+
+        bool thread_counters::read_value(papi_counter* cnt, bool reset)
         {
-            HPX_THROW_EXCEPTION(hpx::no_success, locstr,
-                "could not find thread "+label);
-        }
-        // associate low level counters object
-        counters_ = get_thread_counters(tix);
-        if (!counters_)
-        {
-            HPX_THROW_EXCEPTION(hpx::no_success, locstr,
-                "failed to find low level counters for thread "+label);
-        }
-        // counting is not enabled here; it has to be started explicitly
-    }
+            {
+                std::lock_guard<papi_counter_base::mutex_type> lk(
+                    cnt->get_global_mtx());
 
-    hpx::performance_counters::counter_value papi_counter::get_counter_value(bool reset)
-    {
-        std::lock_guard<thread_counters::mutex_type> m(counters_->get_lock());
-
-        if (status_ == PAPI_COUNTER_ACTIVE)
-            counters_->read_value(this, reset);
-
-        hpx::performance_counters::counter_value value;
-
-        if (timestamp_ != -1) copy_value(value);
-        else value.status_ = hpx::performance_counters::status_invalid_data;
-
-        // clear local copy
-        if (reset) value_ = 0;
-
-        value.count_ = ++invocation_count_;
-
-        return value;
-    }
-
-    bool papi_counter::start()
-    {
-        std::lock_guard<papi_counter_base::mutex_type> lk(get_global_mtx());
-
-        if (status_ == PAPI_COUNTER_ACTIVE) return true;
-        if (counters_->add_event(this))
-        {
-            status_ = PAPI_COUNTER_ACTIVE;
+                if (PAPI_accum(evset_, &counts_[0]) != PAPI_OK)
+                    return false;
+            }
+            timestamp_ = static_cast<std::int64_t>(hpx::get_system_uptime());
+            cnt->update_state(timestamp_, counts_[cnt->get_counter_index()]);
+            if (reset)
+                counts_[cnt->get_counter_index()] = 0;
             return true;
         }
-        status_ = PAPI_COUNTER_SUSPENDED;
-        return false;
-    }
 
-    bool papi_counter::stop()
-    {
-        std::lock_guard<thread_counters::mutex_type> m(counters_->get_lock());
+        bool thread_counters::terminate(std::uint32_t)
+        {
+            std::lock_guard<mutex_type> m(mtx_);
+            return finalize();
+        }
 
-        return stop_counter();
-    }
+        bool thread_counters::start_all()
+        {
+            if (counts_.empty())
+                return true;    // nothing to count
+            return PAPI_start(evset_) == PAPI_OK;
+        }
 
-    void papi_counter::reset()
-    {
-        std::lock_guard<thread_counters::mutex_type> m(counters_->get_lock());
+        bool thread_counters::stop_all()
+        {
+            int stat;
+            if (PAPI_state(evset_, &stat) != PAPI_OK)
+                return false;
 
-        reset_counter();
-    }
+            if ((stat & PAPI_RUNNING) != 0)
+            {
+                std::vector<long long> tmp(counts_.size());
+                if (PAPI_stop(evset_, &tmp[0]) != PAPI_OK)
+                    return false;
+                // accumulate existing counts before modifying event set
+                if (PAPI_accum(evset_, &counts_[0]) != PAPI_OK)
+                    return false;
+                timestamp_ =
+                    static_cast<std::int64_t>(hpx::get_system_uptime());
+            }
+            return true;
+        }
 
-    void papi_counter::finalize()
-    {
-        std::lock_guard<thread_counters::mutex_type> m(counters_->get_lock());
+        bool thread_counters::finalize()
+        {
+            if (evset_ != PAPI_NULL)
+            {
+                if (stop_all())
+                {
+                    for (std::uint32_t i = 0; i < cnttab_.size(); ++i)
+                    {    // retrieve the most recent values for the still active counters
+                        papi_counter* c = cnttab_[i];
+                        if (c->get_status() == PAPI_COUNTER_ACTIVE)
+                            c->update_state(timestamp_, counts_[i],
+                                PAPI_COUNTER_TERMINATED);
+                        else
+                            c->update_status(PAPI_COUNTER_TERMINATED);
+                    }
+                }
+                // release event set resources
+                return PAPI_destroy_eventset(&evset_) == PAPI_OK;
+            }
+            return true;
+        }
 
-        stop_counter();
-        base_type_holder::finalize();
-        base_type::finalize();
-    }
+        ///////////////////////////////////////////////////////////////////////////
+        thread_counters* papi_counter_base::get_thread_counters(
+            std::uint32_t tix)
+        {
+            std::lock_guard<mutex_type> m(base_mtx_);
 
-    naming::address papi_counter::get_current_address() const
-    {
-        return naming::address(
-            naming::get_gid_from_locality_id(hpx::get_locality_id()),
-            components::get_component_type<papi_counter>(),
-            const_cast<papi_counter*>(this));
-    }
+            // create entry for the thread associated with the counter if it doesn't exist
+            ttable_type::iterator it = thread_state_.find(tix);
+            if (it == thread_state_.end())
+            {
+                hpx::util::ignore_all_while_checking i;
+                HPX_UNUSED(i);
 
-}}}}
+                return thread_state_[tix] = new thread_counters(tix);
+            }
+            else
+                return it->second;
+        }
+
+        ///////////////////////////////////////////////////////////////////////////
+        papi_counter::papi_counter(
+            hpx::performance_counters::counter_info const& info)
+          : base_type_holder(info)
+          , event_(PAPI_NULL)
+          , index_(-1)
+          , value_(0)
+          , timestamp_(-1)
+          , status_(PAPI_COUNTER_STOPPED)
+        {
+            char const* locstr = NS_STR "papi_counter()";
+
+            // extract path elements from counter name
+            counter_path_elements cpe;
+            get_counter_path_elements(info.fullname_, cpe);
+            // convert event name to code and check availability
+            {
+                std::lock_guard<papi_counter_base::mutex_type> lk(
+                    this->get_global_mtx());
+                // papi_call might throw, leading to potential "lock held while
+                // suspending thread" errors. At this point, it is safe to ignore
+                // the lock.
+                hpx::util::ignore_all_while_checking il;
+                HPX_UNUSED(il);
+
+                papi_call(PAPI_event_name_to_code(
+                              const_cast<char*>(cpe.countername_.c_str()),
+                              const_cast<int*>(&event_)),
+                    cpe.countername_ +
+                        " does not seem to be a valid event name",
+                    locstr);
+                papi_call(PAPI_query_event(event_),
+                    "event " + cpe.countername_ +
+                        " is not available on this platform",
+                    locstr);
+            }
+            // find OS thread associated with the counter
+            std::string label;
+            std::uint32_t tix = util::get_counter_thread(cpe, label);
+            if (tix == hpx::util::thread_mapper::invalid_index)
+            {
+                HPX_THROW_EXCEPTION(
+                    hpx::no_success, locstr, "could not find thread " + label);
+            }
+            // associate low level counters object
+            counters_ = get_thread_counters(tix);
+            if (!counters_)
+            {
+                HPX_THROW_EXCEPTION(hpx::no_success, locstr,
+                    "failed to find low level counters for thread " + label);
+            }
+            // counting is not enabled here; it has to be started explicitly
+        }
+
+        hpx::performance_counters::counter_value
+        papi_counter::get_counter_value(bool reset)
+        {
+            std::lock_guard<thread_counters::mutex_type> m(
+                counters_->get_lock());
+
+            if (status_ == PAPI_COUNTER_ACTIVE)
+                counters_->read_value(this, reset);
+
+            hpx::performance_counters::counter_value value;
+
+            if (timestamp_ != -1)
+                copy_value(value);
+            else
+                value.status_ =
+                    hpx::performance_counters::counter_status::invalid_data;
+
+            // clear local copy
+            if (reset)
+                value_ = 0;
+
+            value.count_ = ++invocation_count_;
+
+            return value;
+        }
+
+        bool papi_counter::start()
+        {
+            std::lock_guard<papi_counter_base::mutex_type> lk(get_global_mtx());
+
+            if (status_ == PAPI_COUNTER_ACTIVE)
+                return true;
+            if (counters_->add_event(this))
+            {
+                status_ = PAPI_COUNTER_ACTIVE;
+                return true;
+            }
+            status_ = PAPI_COUNTER_SUSPENDED;
+            return false;
+        }
+
+        bool papi_counter::stop()
+        {
+            std::lock_guard<thread_counters::mutex_type> m(
+                counters_->get_lock());
+
+            return stop_counter();
+        }
+
+        void papi_counter::reset()
+        {
+            std::lock_guard<thread_counters::mutex_type> m(
+                counters_->get_lock());
+
+            reset_counter();
+        }
+
+        void papi_counter::finalize()
+        {
+            std::lock_guard<thread_counters::mutex_type> m(
+                counters_->get_lock());
+
+            stop_counter();
+            base_type_holder::finalize();
+            base_type::finalize();
+        }
+
+        naming::address papi_counter::get_current_address() const
+        {
+            return naming::address(
+                naming::get_gid_from_locality_id(hpx::get_locality_id()),
+                components::get_component_type<papi_counter>(),
+                const_cast<papi_counter*>(this));
+        }
+
+}}}}    // namespace hpx::performance_counters::papi::server
 
 #endif

--- a/examples/performance_counters/sine/server/sine.cpp
+++ b/examples/performance_counters/sine/server/sine.cpp
@@ -66,7 +66,7 @@ namespace performance_counters { namespace sine { namespace server {
 
         value.scaling_ = scaling;
         value.scale_inverse_ = true;
-        value.status_ = hpx::performance_counters::status_new_data;
+        value.status_ = hpx::performance_counters::counter_status::new_data;
         value.count_ = ++invocation_count_;
 
         return value;

--- a/libs/full/performance_counters/include/hpx/performance_counters/counters.hpp
+++ b/libs/full/performance_counters/include/hpx/performance_counters/counters.hpp
@@ -183,21 +183,21 @@ namespace hpx { namespace performance_counters {
     ///////////////////////////////////////////////////////////////////////////
     /// \brief Status and error codes used by the functions related to
     ///        performance counters.
-    enum counter_status
+    enum class counter_status
     {
-        status_valid_data,      ///< No error occurred, data is valid
-        status_new_data,        ///< Data is valid and different from last call
-        status_invalid_data,    ///< Some error occurred, data is not value
-        status_already_defined,    ///< The type or instance already has been defined
-        status_counter_unknown,         ///< The counter instance is unknown
-        status_counter_type_unknown,    ///< The counter type is unknown
-        status_generic_error            ///< A unknown error occurred
+        valid_data,         ///< No error occurred, data is valid
+        new_data,           ///< Data is valid and different from last call
+        invalid_data,       ///< Some error occurred, data is not value
+        already_defined,    ///< The type or instance already has been defined
+        counter_unknown,    ///< The counter instance is unknown
+        counter_type_unknown,    ///< The counter type is unknown
+        generic_error            ///< A unknown error occurred
     };
 #endif
 
     inline bool status_is_valid(counter_status s)
     {
-        return s == status_valid_data || s == status_new_data;
+        return s == counter_status::valid_data || s == counter_status::new_data;
     }
 
     ///////////////////////////////////////////////////////////////////////////
@@ -319,14 +319,14 @@ namespace hpx { namespace performance_counters {
         counter_info(counter_type type = counter_type::raw)
           : type_(type)
           , version_(HPX_PERFORMANCE_COUNTER_V1)
-          , status_(status_invalid_data)
+          , status_(counter_status::invalid_data)
         {
         }
 
         counter_info(std::string const& name)
           : type_(counter_type::raw)
           , version_(HPX_PERFORMANCE_COUNTER_V1)
-          , status_(status_invalid_data)
+          , status_(counter_status::invalid_data)
           , fullname_(name)
         {
         }
@@ -337,7 +337,7 @@ namespace hpx { namespace performance_counters {
             std::string const& uom = "")
           : type_(type)
           , version_(version)
-          , status_(status_invalid_data)
+          , status_(counter_status::invalid_data)
           , fullname_(name)
           , helptext_(helptext)
           , unit_of_measure_(uom)

--- a/libs/full/performance_counters/include/hpx/performance_counters/counters_fwd.hpp
+++ b/libs/full/performance_counters/include/hpx/performance_counters/counters_fwd.hpp
@@ -193,16 +193,49 @@ namespace hpx { namespace performance_counters {
     ///////////////////////////////////////////////////////////////////////////
     // Status and error codes used by the functions related to
     // performance counters.
-    enum counter_status
+    enum class counter_status
     {
-        status_valid_data,         // No error occurred, data is valid
-        status_new_data,           // Data is valid and different from last call
-        status_invalid_data,       // Some error occurred, data is not value
-        status_already_defined,    // The type or instance already has been defined
-        status_counter_unknown,         // The counter instance is unknown
-        status_counter_type_unknown,    // The counter type is unknown
-        status_generic_error            // A unknown error occurred
+        valid_data,         // No error occurred, data is valid
+        new_data,           // Data is valid and different from last call
+        invalid_data,       // Some error occurred, data is not value
+        already_defined,    // The type or instance already has been defined
+        counter_unknown,    // The counter instance is unknown
+        counter_type_unknown,    // The counter type is unknown
+        generic_error            // A unknown error occurred
     };
+
+    inline std::ostream& operator<<(
+        std::ostream& os, counter_status const& rhs) noexcept
+    {
+        return (os << static_cast<int>(rhs));
+    }
+
+#define HPX_COUNTER_STATUS_UNSCOPED_ENUM_DEPRECATION_MSG                       \
+    "The unscoped counter_status names are deprecated. Please use "            \
+    "counter_status::<type> instead."
+
+    HPX_DEPRECATED_V(1, 9, HPX_COUNTER_STATUS_UNSCOPED_ENUM_DEPRECATION_MSG)
+    inline constexpr counter_status status_valid_data =
+        counter_status::valid_data;
+    HPX_DEPRECATED_V(1, 9, HPX_COUNTER_STATUS_UNSCOPED_ENUM_DEPRECATION_MSG)
+    inline constexpr counter_status status_new_data = counter_status::new_data;
+    HPX_DEPRECATED_V(1, 9, HPX_COUNTER_STATUS_UNSCOPED_ENUM_DEPRECATION_MSG)
+    inline constexpr counter_status status_invalid_data =
+        counter_status::invalid_data;
+    HPX_DEPRECATED_V(1, 9, HPX_COUNTER_STATUS_UNSCOPED_ENUM_DEPRECATION_MSG)
+    inline constexpr counter_status status_already_defined =
+        counter_status::already_defined;
+    HPX_DEPRECATED_V(1, 9, HPX_COUNTER_STATUS_UNSCOPED_ENUM_DEPRECATION_MSG)
+    inline constexpr counter_status status_counter_unknown =
+        counter_status::counter_unknown;
+    HPX_DEPRECATED_V(1, 9, HPX_COUNTER_STATUS_UNSCOPED_ENUM_DEPRECATION_MSG)
+    inline constexpr counter_status status_counter_type_unknown =
+        counter_status::counter_type_unknown;
+    HPX_DEPRECATED_V(1, 9, HPX_COUNTER_STATUS_UNSCOPED_ENUM_DEPRECATION_MSG)
+    inline constexpr counter_status status_generic_error =
+        counter_status::generic_error;
+
+#undef HPX_COUNTER_STATUS_UNSCOPED_ENUM_DEPRECATION_MSG
 
     inline bool status_is_valid(counter_status s);
 
@@ -314,7 +347,7 @@ namespace hpx { namespace performance_counters {
           , count_(0)
           , value_(value)
           , scaling_(scaling)
-          , status_(status_new_data)
+          , status_(counter_status::new_data)
           , scale_inverse_(scale_inverse)
         {
         }
@@ -380,7 +413,7 @@ namespace hpx { namespace performance_counters {
           , count_(0)
           , values_()
           , scaling_(scaling)
-          , status_(status_new_data)
+          , status_(counter_status::new_data)
           , scale_inverse_(scale_inverse)
         {
         }
@@ -391,7 +424,7 @@ namespace hpx { namespace performance_counters {
           , count_(0)
           , values_(HPX_MOVE(values))
           , scaling_(scaling)
-          , status_(status_new_data)
+          , status_(counter_status::new_data)
           , scale_inverse_(scale_inverse)
         {
         }
@@ -402,7 +435,7 @@ namespace hpx { namespace performance_counters {
           , count_(0)
           , values_(values)
           , scaling_(scaling)
-          , status_(status_new_data)
+          , status_(counter_status::new_data)
           , scale_inverse_(scale_inverse)
         {
         }

--- a/libs/full/performance_counters/include/hpx/performance_counters/manage_counter_type.hpp
+++ b/libs/full/performance_counters/include/hpx/performance_counters/manage_counter_type.hpp
@@ -57,7 +57,7 @@ namespace hpx { namespace performance_counters {
     ///       function doesn't throw but returns the result code using the
     ///       parameter \a ec. Otherwise it throws an instance of hpx::exception.
     ///
-    /// \returns      If successful, this function returns \a status_valid_data,
+    /// \returns      If successful, this function returns \a valid_data,
     ///               otherwise it will either throw an exception or return an
     ///               error_code from the enum \a counter_status (also, see
     ///               note related to parameter \a ec).
@@ -105,7 +105,7 @@ namespace hpx { namespace performance_counters {
     ///       function doesn't throw but returns the result code using the
     ///       parameter \a ec. Otherwise it throws an instance of hpx::exception.
     ///
-    /// \returns      If successful, this function returns \a status_valid_data,
+    /// \returns      If successful, this function returns \a valid_data,
     ///               otherwise it will either throw an exception or return an
     ///               error_code from the enum \a counter_status (also, see
     ///               note related to parameter \a ec).
@@ -132,7 +132,7 @@ namespace hpx { namespace performance_counters {
     ///               if this is pre-initialized to \a hpx#throws
     ///               the function will throw on error instead.
     ///
-    /// \returns      If successful, this function returns \a status_valid_data,
+    /// \returns      If successful, this function returns \a valid_data,
     ///               otherwise it will either throw an exception or return an
     ///               error_code from the enum \a counter_status (also, see
     ///               note related to parameter \a ec).
@@ -168,7 +168,7 @@ namespace hpx { namespace performance_counters {
     ///               if this is pre-initialized to \a hpx#throws
     ///               the function will throw on error instead.
     ///
-    /// \returns      If successful, this function returns \a status_valid_data,
+    /// \returns      If successful, this function returns \a valid_data,
     ///               otherwise it will either throw an exception or return an
     ///               error_code from the enum \a counter_status (also, see
     ///               note related to parameter \a ec).
@@ -214,7 +214,7 @@ namespace hpx { namespace performance_counters {
     ///       function doesn't throw but returns the result code using the
     ///       parameter \a ec. Otherwise it throws an instance of hpx#exception.
     ///
-    /// \returns      If successful, this function returns \a status_valid_data,
+    /// \returns      If successful, this function returns \a valid_data,
     ///               otherwise it will either throw an exception or return an
     ///               error_code from the enum \a counter_status (also, see
     ///               note related to parameter \a ec).

--- a/libs/full/performance_counters/src/counters.cpp
+++ b/libs/full/performance_counters/src/counters.cpp
@@ -99,7 +99,7 @@ namespace hpx { namespace performance_counters {
         {
             HPX_THROWS_IF(ec, bad_parameter, "get_counter_name",
                 "empty counter object name");
-            return status_invalid_data;
+            return counter_status::invalid_data;
         }
 
         result = "/";
@@ -161,7 +161,7 @@ namespace hpx { namespace performance_counters {
 
         if (&ec != &throws)
             ec = make_success_code();
-        return status_valid_data;
+        return counter_status::valid_data;
     }
 
     /// \brief Create a full name of a counter from the contents of the given
@@ -173,7 +173,7 @@ namespace hpx { namespace performance_counters {
         {
             HPX_THROWS_IF(ec, bad_parameter, "get_counter_type_name",
                 "empty counter object name");
-            return status_invalid_data;
+            return counter_status::invalid_data;
         }
 
         result = "/";
@@ -187,7 +187,7 @@ namespace hpx { namespace performance_counters {
 
         if (&ec != &throws)
             ec = make_success_code();
-        return status_valid_data;
+        return counter_status::valid_data;
     }
 
     /// \brief Create a full name of a counter from the contents of the given
@@ -200,7 +200,7 @@ namespace hpx { namespace performance_counters {
         {
             HPX_THROWS_IF(ec, bad_parameter, "get_full_counter_type_name",
                 "empty counter object name");
-            return status_invalid_data;
+            return counter_status::invalid_data;
         }
 
         result = "/";
@@ -220,7 +220,7 @@ namespace hpx { namespace performance_counters {
 
         if (&ec != &throws)
             ec = make_success_code();
-        return status_valid_data;
+        return counter_status::valid_data;
     }
 
     /// \brief Create a name of a counter instance from the contents of the
@@ -232,7 +232,7 @@ namespace hpx { namespace performance_counters {
         {
             HPX_THROWS_IF(ec, bad_parameter, "get_counter_instance_name",
                 "empty counter instance name");
-            return status_invalid_data;
+            return counter_status::invalid_data;
         }
 
         if (path.parentinstance_is_basename_)
@@ -288,7 +288,7 @@ namespace hpx { namespace performance_counters {
 
         if (&ec != &throws)
             ec = make_success_code();
-        return status_valid_data;
+        return counter_status::valid_data;
     }
 
     /// \brief Fill the given \a counter_path_elements instance from the given
@@ -305,7 +305,7 @@ namespace hpx { namespace performance_counters {
         {
             HPX_THROWS_IF(ec, bad_parameter, "get_counter_path_elements",
                 "invalid counter name format: {}", name);
-            return status_invalid_data;
+            return counter_status::invalid_data;
         }
 
         path.objectname_ = elements.object_;
@@ -359,7 +359,7 @@ namespace hpx { namespace performance_counters {
                         HPX_THROWS_IF(ec, bad_parameter,
                             "get_counter_path_elements",
                             "invalid counter name format: {}", name);
-                        return status_invalid_data;
+                        return counter_status::invalid_data;
                     }
                 }
             }
@@ -378,7 +378,7 @@ namespace hpx { namespace performance_counters {
         if (&ec != &throws)
             ec = make_success_code();
 
-        return status_valid_data;
+        return counter_status::valid_data;
     }
 
     /// \brief Fill the given \a counter_type_path_elements instance from the
@@ -396,7 +396,7 @@ namespace hpx { namespace performance_counters {
         {
             HPX_THROWS_IF(ec, bad_parameter, "get_counter_type_path_elements",
                 "invalid counter name format: {}", name);
-            return status_invalid_data;
+            return counter_status::invalid_data;
         }
 
         // but extract only counter type elements
@@ -407,7 +407,7 @@ namespace hpx { namespace performance_counters {
         if (&ec != &throws)
             ec = make_success_code();
 
-        return status_valid_data;
+        return counter_status::valid_data;
     }
 
     /// \brief Return the counter type name from a given full instance name
@@ -519,7 +519,7 @@ namespace hpx { namespace performance_counters {
             HPX_THROWS_IF(ec, bad_parameter,
                 "performance_counters::add_counter_type",
                 "the runtime is not currently running");
-            return status_generic_error;
+            return counter_status::generic_error;
         }
         return registry::instance().add_counter_type(
             info, create_counter, discover_counters, ec);
@@ -536,7 +536,7 @@ namespace hpx { namespace performance_counters {
             HPX_THROWS_IF(ec, bad_parameter,
                 "performance_counters::discover_counter_types",
                 "the runtime is not currently running");
-            return status_generic_error;
+            return counter_status::generic_error;
         }
         return registry::instance().discover_counter_types(
             discover_counter, mode, ec);
@@ -553,7 +553,7 @@ namespace hpx { namespace performance_counters {
             HPX_THROWS_IF(ec, bad_parameter,
                 "performance_counters::discover_counter_types",
                 "the runtime is not currently running");
-            return status_generic_error;
+            return counter_status::generic_error;
         }
         return registry::instance().discover_counter_type(
             info, discover_counter, mode, ec);
@@ -568,7 +568,7 @@ namespace hpx { namespace performance_counters {
             HPX_THROWS_IF(ec, bad_parameter,
                 "performance_counters::discover_counter_types",
                 "the runtime is not currently running");
-            return status_generic_error;
+            return counter_status::generic_error;
         }
         return registry::instance().discover_counter_type(
             name, discover_counter, mode, ec);
@@ -619,7 +619,7 @@ namespace hpx { namespace performance_counters {
         // the runtime could be gone already
         if (hpx::get_runtime_ptr() == nullptr)
         {
-            return status_generic_error;
+            return counter_status::generic_error;
         }
         return registry::instance().remove_counter_type(info, ec);
     }
@@ -634,7 +634,7 @@ namespace hpx { namespace performance_counters {
             HPX_THROWS_IF(ec, bad_parameter,
                 "performance_counters::get_counter_type",
                 "the runtime is not currently running");
-            return status_generic_error;
+            return counter_status::generic_error;
         }
         return registry::instance().get_counter_type(name, info, ec);
     }

--- a/libs/full/performance_counters/src/manage_counter.cpp
+++ b/libs/full/performance_counters/src/manage_counter.cpp
@@ -49,7 +49,7 @@ namespace hpx { namespace performance_counters {
         {
             HPX_THROWS_IF(ec, hpx::invalid_status, "manage_counter::install",
                 "counter has been already installed");
-            return status_invalid_data;
+            return counter_status::invalid_data;
         }
 
         info_ = info;

--- a/libs/full/performance_counters/src/manage_counter_type.cpp
+++ b/libs/full/performance_counters/src/manage_counter_type.cpp
@@ -29,7 +29,7 @@ namespace hpx { namespace performance_counters {
     struct manage_counter_type
     {
         manage_counter_type(counter_info const& info)
-          : status_(status_invalid_data)
+          : status_(counter_status::invalid_data)
           , info_(info)
         {
         }
@@ -41,13 +41,13 @@ namespace hpx { namespace performance_counters {
 
         counter_status install(error_code& ec = throws)
         {
-            if (status_invalid_data != status_)
+            if (counter_status::invalid_data != status_)
             {
                 HPX_THROWS_IF(ec, hpx::invalid_status,
                     "manage_counter_type::install",
                     "counter type {} has been already installed.",
                     info_.fullname_);
-                return status_invalid_data;
+                return counter_status::invalid_data;
             }
 
             return status_ = add_counter_type(info_, ec);
@@ -57,13 +57,13 @@ namespace hpx { namespace performance_counters {
             discover_counters_func const& discover_counters,
             error_code& ec = throws)
         {
-            if (status_invalid_data != status_)
+            if (counter_status::invalid_data != status_)
             {
                 HPX_THROWS_IF(ec, hpx::invalid_status,
                     "manage_counter_type::install",
                     "generic counter type {} has been already installed.",
                     info_.fullname_);
-                return status_invalid_data;
+                return counter_status::invalid_data;
             }
 
             return status_ = add_counter_type(
@@ -72,7 +72,7 @@ namespace hpx { namespace performance_counters {
 
         void uninstall(error_code& ec = throws)
         {
-            if (status_invalid_data != status_)
+            if (counter_status::invalid_data != status_)
                 remove_counter_type(info_, ec);    // ignore errors
         }
 
@@ -104,7 +104,7 @@ namespace hpx { namespace performance_counters {
         // Register the shutdown function which will clean up this counter type.
         get_runtime().add_shutdown_function(
             hpx::bind_front(&counter_type_shutdown, p));
-        return status_valid_data;
+        return counter_status::valid_data;
     }
 
     ///////////////////////////////////////////////////////////////////////////
@@ -127,7 +127,7 @@ namespace hpx { namespace performance_counters {
         // Register the shutdown function which will clean up this counter type.
         get_runtime().add_shutdown_function(
             hpx::bind_front(&counter_type_shutdown, p));
-        return status_valid_data;
+        return counter_status::valid_data;
     }
 
     // Install a new generic performance counter type which uses a function to

--- a/libs/full/performance_counters/src/registry.cpp
+++ b/libs/full/performance_counters/src/registry.cpp
@@ -96,7 +96,7 @@ namespace hpx { namespace performance_counters {
         {
             HPX_THROWS_IF(ec, bad_parameter, "registry::add_counter_type",
                 "counter type already defined: {}", type_name);
-            return status_already_defined;
+            return counter_status::already_defined;
         }
 
         std::pair<counter_type_map_type::iterator, bool> p =
@@ -107,14 +107,14 @@ namespace hpx { namespace performance_counters {
         {
             LPCS_(warning).format(
                 "failed to register counter type {}", type_name);
-            return status_invalid_data;
+            return counter_status::invalid_data;
         }
 
         LPCS_(info).format("counter type {} registered", type_name);
 
         if (&ec != &throws)
             ec = make_success_code();
-        return status_valid_data;
+        return counter_status::valid_data;
     }
 
     /// \brief Call the supplied function for the given registered counter type.
@@ -147,7 +147,7 @@ namespace hpx { namespace performance_counters {
                     "registry::discover_counter_type",
                     "unknown counter type: {}, known counter types: \n{}",
                     type_name, types);
-                return status_counter_type_unknown;
+                return counter_status::counter_type_unknown;
             }
 
             if (mode == discover_counters_full)
@@ -164,14 +164,14 @@ namespace hpx { namespace performance_counters {
                 !(*it).second.discover_counters_(
                     info, discover_counter, mode, ec))
             {
-                return status_invalid_data;
+                return counter_status::invalid_data;
             }
         }
         else
         {
             std::string str_rx(util::regex_from_pattern(type_name, ec));
             if (ec)
-                return status_invalid_data;
+                return counter_status::invalid_data;
 
             if (mode == discover_counters_full)
             {
@@ -184,7 +184,7 @@ namespace hpx { namespace performance_counters {
             counter_path_elements p;
             get_counter_path_elements(fullname, p, ec);
             if (ec)
-                return status_invalid_data;
+                return counter_status::invalid_data;
 
             bool found_one = false;
             std::regex rx(str_rx);
@@ -207,7 +207,7 @@ namespace hpx { namespace performance_counters {
                     !(*it).second.discover_counters_(
                         info, discover_counter, mode, ec))
                 {
-                    return status_invalid_data;
+                    return counter_status::invalid_data;
                 }
             }
 
@@ -228,14 +228,14 @@ namespace hpx { namespace performance_counters {
                     "counter type {} does not match any known type, known "
                     "counter types: \n{}",
                     type_name, types);
-                return status_counter_type_unknown;
+                return counter_status::counter_type_unknown;
             }
         }
 
         if (&ec != &throws)
             ec = make_success_code();
 
-        return status_valid_data;
+        return counter_status::valid_data;
     }
 
     /// \brief Call the supplied function for all registered counter types.
@@ -263,14 +263,14 @@ namespace hpx { namespace performance_counters {
                 !d.second.discover_counters_(
                     d.second.info_, discover_counter_, mode, ec))
             {
-                return status_invalid_data;
+                return counter_status::invalid_data;
             }
         }
 
         if (&ec != &throws)
             ec = make_success_code();
 
-        return status_valid_data;
+        return counter_status::valid_data;
     }
 
     ///////////////////////////////////////////////////////////////////////////
@@ -303,7 +303,7 @@ namespace hpx { namespace performance_counters {
                 "registry::get_counter_create_function",
                 "counter type {} is not defined, known counter types: \n{}",
                 type_name, types);
-            return status_counter_type_unknown;
+            return counter_status::counter_type_unknown;
         }
 
         if ((*it).second.create_counter_.empty())
@@ -311,14 +311,14 @@ namespace hpx { namespace performance_counters {
             HPX_THROWS_IF(ec, bad_parameter,
                 "registry::get_counter_create_function",
                 "counter type {} has no associated create function", type_name);
-            return status_invalid_data;
+            return counter_status::invalid_data;
         }
 
         func = (*it).second.create_counter_;
 
         if (&ec != &throws)
             ec = make_success_code();
-        return status_valid_data;
+        return counter_status::valid_data;
     }
 
     ///////////////////////////////////////////////////////////////////////////
@@ -340,7 +340,7 @@ namespace hpx { namespace performance_counters {
             HPX_THROWS_IF(ec, bad_parameter,
                 "registry::get_counter_discovery_function",
                 "counter type {} is not defined", type_name);
-            return status_counter_type_unknown;
+            return counter_status::counter_type_unknown;
         }
 
         if ((*it).second.discover_counters_.empty())
@@ -349,14 +349,14 @@ namespace hpx { namespace performance_counters {
                 "registry::get_counter_discovery_function",
                 "counter type {} has no associated discovery function",
                 type_name);
-            return status_invalid_data;
+            return counter_status::invalid_data;
         }
 
         func = (*it).second.discover_counters_;
 
         if (&ec != &throws)
             ec = make_success_code();
-        return status_valid_data;
+        return counter_status::valid_data;
     }
 
     ///////////////////////////////////////////////////////////////////////////
@@ -375,7 +375,7 @@ namespace hpx { namespace performance_counters {
         {
             HPX_THROWS_IF(ec, bad_parameter, "registry::remove_counter_type",
                 "counter type is not defined");
-            return status_counter_type_unknown;
+            return counter_status::counter_type_unknown;
         }
 
         LPCS_(info).format("counter type {} unregistered", type_name);
@@ -384,7 +384,7 @@ namespace hpx { namespace performance_counters {
 
         if (&ec != &throws)
             ec = make_success_code();
-        return status_valid_data;
+        return counter_status::valid_data;
     }
 
     ///////////////////////////////////////////////////////////////////////////
@@ -441,7 +441,7 @@ namespace hpx { namespace performance_counters {
         {
             HPX_THROWS_IF(ec, bad_parameter, "registry::create_raw_counter",
                 "unknown counter type {}", type_name);
-            return status_counter_type_unknown;
+            return counter_status::counter_type_unknown;
         }
 
         // make sure the counter type requested is supported
@@ -465,14 +465,14 @@ namespace hpx { namespace performance_counters {
                 "counter_type::aggregating, "
                 "counter_type::elapsed_time, counter_type::average_count, or "
                 "counter_type::average_timer are supported)");
-            return status_counter_type_unknown;
+            return counter_status::counter_type_unknown;
         }
 
         // make sure parent instance name is set properly
         counter_info complemented_info = info;
         complement_counter_info(complemented_info, (*it).second.info_, ec);
         if (ec)
-            return status_invalid_data;
+            return counter_status::invalid_data;
 
         // create the counter as requested
         try
@@ -488,7 +488,7 @@ namespace hpx { namespace performance_counters {
             ec = make_error_code(e.get_error(), e.what());
             LPCS_(warning).format("failed to create raw counter {} ({})",
                 complemented_info.fullname_, e.what());
-            return status_invalid_data;
+            return counter_status::invalid_data;
         }
 
         LPCS_(info).format(
@@ -496,7 +496,7 @@ namespace hpx { namespace performance_counters {
 
         if (&ec != &throws)
             ec = make_success_code();
-        return status_valid_data;
+        return counter_status::valid_data;
     }
 
     counter_status registry::create_raw_counter(counter_info const& info,
@@ -524,7 +524,7 @@ namespace hpx { namespace performance_counters {
         {
             HPX_THROWS_IF(ec, bad_parameter, "registry::create_raw_counter",
                 "unknown counter type {}", type_name);
-            return status_counter_type_unknown;
+            return counter_status::counter_type_unknown;
         }
 
         // make sure the counter type requested is supported
@@ -534,16 +534,16 @@ namespace hpx { namespace performance_counters {
                     counter_type::raw_values == info.type_)))
         {
             HPX_THROWS_IF(ec, bad_parameter, "registry::create_raw_counter",
-                "invalid counter type requested (only counter_type::histogram "
-                "or counter_type::raw_values are supported)");
-            return status_counter_type_unknown;
+                "invalid counter type requested (only counter_histogram or "
+                "counter_raw_values are supported)");
+            return counter_status::counter_type_unknown;
         }
 
         // make sure parent instance name is set properly
         counter_info complemented_info = info;
         complement_counter_info(complemented_info, (*it).second.info_, ec);
         if (ec)
-            return status_invalid_data;
+            return counter_status::invalid_data;
 
         // create the counter as requested
         try
@@ -559,7 +559,7 @@ namespace hpx { namespace performance_counters {
             ec = make_error_code(e.get_error(), e.what());
             LPCS_(warning).format("failed to create raw counter {} ({})",
                 complemented_info.fullname_, e.what());
-            return status_invalid_data;
+            return counter_status::invalid_data;
         }
 
         LPCS_(info).format(
@@ -567,7 +567,7 @@ namespace hpx { namespace performance_counters {
 
         if (&ec != &throws)
             ec = make_success_code();
-        return status_valid_data;
+        return counter_status::valid_data;
     }
 
     ///////////////////////////////////////////////////////////////////////////
@@ -586,14 +586,14 @@ namespace hpx { namespace performance_counters {
         {
             HPX_THROWS_IF(ec, bad_parameter, "registry::create_counter",
                 "unknown counter type {}", type_name);
-            return status_counter_type_unknown;
+            return counter_status::counter_type_unknown;
         }
 
         // make sure parent instance name is set properly
         counter_info complemented_info = info;
         complement_counter_info(complemented_info, (*it).second.info_, ec);
         if (ec)
-            return status_invalid_data;
+            return counter_status::invalid_data;
 
         // create the counter as requested
         try
@@ -621,12 +621,12 @@ namespace hpx { namespace performance_counters {
             case counter_type::average_timer:
                 HPX_THROWS_IF(ec, bad_parameter, "registry::create_counter",
                     "need function parameter for raw_counter");
-                return status_counter_type_unknown;
+                return counter_status::counter_type_unknown;
 
             default:
                 HPX_THROWS_IF(ec, bad_parameter, "registry::create_counter",
                     "invalid counter type requested");
-                return status_counter_type_unknown;
+                return counter_status::counter_type_unknown;
             }
         }
         catch (hpx::exception const& e)
@@ -637,7 +637,7 @@ namespace hpx { namespace performance_counters {
             ec = make_error_code(e.get_error(), e.what());
             LPCS_(warning).format("failed to create counter {} ({})",
                 complemented_info.fullname_, e.what());
-            return status_invalid_data;
+            return counter_status::invalid_data;
         }
 
         LPCS_(info).format(
@@ -645,7 +645,7 @@ namespace hpx { namespace performance_counters {
 
         if (&ec != &throws)
             ec = make_success_code();
-        return status_valid_data;
+        return counter_status::valid_data;
     }
 
     /// \brief Create a new statistics performance counter instance based
@@ -669,7 +669,7 @@ namespace hpx { namespace performance_counters {
             HPX_THROWS_IF(ec, bad_parameter,
                 "registry::create_statistics_counter",
                 "unknown counter type {}", type_name);
-            return status_counter_type_unknown;
+            return counter_status::counter_type_unknown;
         }
 
         // make sure the requested counter type is supported
@@ -681,20 +681,20 @@ namespace hpx { namespace performance_counters {
                 "invalid counter type requested (only "
                 "counter_type::aggregating is "
                 "supported)");
-            return status_counter_type_unknown;
+            return counter_status::counter_type_unknown;
         }
 
         // make sure parent instance name is set properly
         counter_info complemented_info = info;
         complement_counter_info(complemented_info, (*it).second.info_, ec);
         if (ec)
-            return status_invalid_data;
+            return counter_status::invalid_data;
 
         // split name
         counter_path_elements p;
         get_counter_path_elements(complemented_info.fullname_, p, ec);
         if (ec)
-            return status_invalid_data;
+            return counter_status::invalid_data;
 
         // create the counter as requested
         try
@@ -852,7 +852,7 @@ namespace hpx { namespace performance_counters {
                 HPX_THROWS_IF(ec, bad_parameter,
                     "registry::create_statistics_counter",
                     "invalid counter type requested: {}", p.countername_);
-                return status_counter_type_unknown;
+                return counter_status::counter_type_unknown;
             }
         }
         catch (hpx::exception const& e)
@@ -864,7 +864,7 @@ namespace hpx { namespace performance_counters {
             ec = make_error_code(e.get_error(), e.what());
             LPCS_(warning).format("failed to create statistics counter {} ({})",
                 complemented_info.fullname_, e.what());
-            return status_invalid_data;
+            return counter_status::invalid_data;
         }
 
         LPCS_(info).format("statistics counter {} created at {}",
@@ -872,7 +872,7 @@ namespace hpx { namespace performance_counters {
 
         if (&ec != &throws)
             ec = make_success_code();
-        return status_valid_data;
+        return counter_status::valid_data;
     }
 
     /// \brief Create a new arithmetics performance counter instance based
@@ -895,7 +895,7 @@ namespace hpx { namespace performance_counters {
             HPX_THROWS_IF(ec, bad_parameter,
                 "registry::create_arithmetics_counter",
                 "unknown counter type {}", type_name);
-            return status_counter_type_unknown;
+            return counter_status::counter_type_unknown;
         }
 
         // make sure the requested counter type is supported
@@ -906,20 +906,20 @@ namespace hpx { namespace performance_counters {
                 "registry::create_arithmetics_counter",
                 "invalid counter type requested "
                 "(only counter_type::aggregating is supported)");
-            return status_counter_type_unknown;
+            return counter_status::counter_type_unknown;
         }
 
         // make sure parent instance name is set properly
         counter_info complemented_info = info;
         complement_counter_info(complemented_info, (*it).second.info_, ec);
         if (ec)
-            return status_invalid_data;
+            return counter_status::invalid_data;
 
         // split name
         counter_path_elements p;
         get_counter_path_elements(complemented_info.fullname_, p, ec);
         if (ec)
-            return status_invalid_data;
+            return counter_status::invalid_data;
 
         // create the counter as requested
         try
@@ -962,7 +962,7 @@ namespace hpx { namespace performance_counters {
                 HPX_THROWS_IF(ec, bad_parameter,
                     "registry::create_arithmetics_counter",
                     "invalid counter type requested: {}", p.countername_);
-                return status_counter_type_unknown;
+                return counter_status::counter_type_unknown;
             }
         }
         catch (hpx::exception const& e)
@@ -975,7 +975,7 @@ namespace hpx { namespace performance_counters {
             LPCS_(warning).format(
                 "failed to create aggregating counter {} ({})",
                 complemented_info.fullname_, e.what());
-            return status_invalid_data;
+            return counter_status::invalid_data;
         }
 
         LPCS_(info).format("aggregating counter {} created at {}",
@@ -983,7 +983,7 @@ namespace hpx { namespace performance_counters {
 
         if (&ec != &throws)
             ec = make_success_code();
-        return status_valid_data;
+        return counter_status::valid_data;
     }
 
     /// \brief Create a new arithmetics extended performance counter instance
@@ -1006,7 +1006,7 @@ namespace hpx { namespace performance_counters {
             HPX_THROWS_IF(ec, bad_parameter,
                 "registry::create_arithmetics_counter_extended",
                 "unknown counter type {}", type_name);
-            return status_counter_type_unknown;
+            return counter_status::counter_type_unknown;
         }
 
         // make sure the requested counter type is supported
@@ -1017,20 +1017,20 @@ namespace hpx { namespace performance_counters {
                 "registry::create_arithmetics_counter_extended",
                 "invalid counter type requested "
                 "(only counter_type::aggregating is supported)");
-            return status_counter_type_unknown;
+            return counter_status::counter_type_unknown;
         }
 
         // make sure parent instance name is set properly
         counter_info complemented_info = info;
         complement_counter_info(complemented_info, (*it).second.info_, ec);
         if (ec)
-            return status_invalid_data;
+            return counter_status::invalid_data;
 
         // split name
         counter_path_elements p;
         get_counter_path_elements(complemented_info.fullname_, p, ec);
         if (ec)
-            return status_invalid_data;
+            return counter_status::invalid_data;
 
         // create the counter as requested
         try
@@ -1095,7 +1095,7 @@ namespace hpx { namespace performance_counters {
                 HPX_THROWS_IF(ec, bad_parameter,
                     "registry::create_arithmetics_counter",
                     "invalid counter type requested: {}", p.countername_);
-                return status_counter_type_unknown;
+                return counter_status::counter_type_unknown;
             }
         }
         catch (hpx::exception const& e)
@@ -1108,7 +1108,7 @@ namespace hpx { namespace performance_counters {
             LPCS_(warning).format(
                 "failed to create aggregating counter {} ({})",
                 complemented_info.fullname_, e.what());
-            return status_invalid_data;
+            return counter_status::invalid_data;
         }
 
         LPCS_(info).format("aggregating counter {} created at {}",
@@ -1116,7 +1116,7 @@ namespace hpx { namespace performance_counters {
 
         if (&ec != &throws)
             ec = make_success_code();
-        return status_valid_data;
+        return counter_status::valid_data;
     }
 
     ///////////////////////////////////////////////////////////////////////////
@@ -1128,7 +1128,7 @@ namespace hpx { namespace performance_counters {
         counter_info complemented_info = info;
         complement_counter_info(complemented_info, ec);
         if (ec)
-            return status_invalid_data;
+            return counter_status::invalid_data;
 
         // create canonical type name
         std::string type_name;
@@ -1143,7 +1143,7 @@ namespace hpx { namespace performance_counters {
         {
             HPX_THROWS_IF(ec, bad_parameter, "registry::add_counter",
                 "unknown counter type {}", type_name);
-            return status_counter_type_unknown;
+            return counter_status::counter_type_unknown;
         }
 
         // register the canonical name with AGAS
@@ -1151,11 +1151,11 @@ namespace hpx { namespace performance_counters {
         ensure_counter_prefix(name);    // pre-pend prefix, if necessary
         agas::register_name(launch::sync, name, id, ec);
         if (ec)
-            return status_invalid_data;
+            return counter_status::invalid_data;
 
         if (&ec != &throws)
             ec = make_success_code();
-        return status_valid_data;
+        return counter_status::valid_data;
     }
 
     ///////////////////////////////////////////////////////////////////////////
@@ -1166,7 +1166,7 @@ namespace hpx { namespace performance_counters {
         counter_info complemented_info = info;
         complement_counter_info(complemented_info, ec);
         if (ec)
-            return status_invalid_data;
+            return counter_status::invalid_data;
 
         // create canonical name for the counter
         std::string name;
@@ -1182,10 +1182,10 @@ namespace hpx { namespace performance_counters {
         {
             LPCS_(warning).format(
                 "failed to remove counter {}", complemented_info.fullname_);
-            return status_invalid_data;
+            return counter_status::invalid_data;
         }
 
-        return status_valid_data;
+        return counter_status::valid_data;
     }
 
     ///////////////////////////////////////////////////////////////////////////
@@ -1205,14 +1205,14 @@ namespace hpx { namespace performance_counters {
         {
             HPX_THROWS_IF(ec, bad_parameter, "registry::get_counter_type",
                 "unknown counter type {}", type_name);
-            return status_counter_type_unknown;
+            return counter_status::counter_type_unknown;
         }
 
         info = (*it).second.info_;
 
         if (&ec != &throws)
             ec = make_success_code();
-        return status_valid_data;
+        return counter_status::valid_data;
     }
 
     registry& registry::instance()

--- a/libs/full/performance_counters/src/server/arithmetics_counter.cpp
+++ b/libs/full/performance_counters/src/server/arithmetics_counter.cpp
@@ -260,7 +260,7 @@ namespace hpx { namespace performance_counters { namespace detail {
                 for (std::string const& name : names)
                 {
                     counter_path_elements paths;
-                    if (status_valid_data !=
+                    if (counter_status::valid_data !=
                             get_counter_path_elements(name, paths, ec) ||
                         ec)
                     {

--- a/libs/full/performance_counters/src/server/arithmetics_counter_extended.cpp
+++ b/libs/full/performance_counters/src/server/arithmetics_counter_extended.cpp
@@ -310,7 +310,7 @@ namespace hpx { namespace performance_counters { namespace detail {
                 for (std::string const& name : names)
                 {
                     counter_path_elements paths;
-                    if (status_valid_data !=
+                    if (counter_status::valid_data !=
                             get_counter_path_elements(name, paths, ec) ||
                         ec)
                     {

--- a/libs/full/performance_counters/src/server/elapsed_time_counter.cpp
+++ b/libs/full/performance_counters/src/server/elapsed_time_counter.cpp
@@ -60,7 +60,7 @@ namespace hpx { namespace performance_counters { namespace server {
         value.value_ = now;
         value.scaling_ = 1000000000LL;    // coefficient to get seconds
         value.scale_inverse_ = true;
-        value.status_ = status_new_data;
+        value.status_ = counter_status::new_data;
         value.time_ = now;
         value.count_ = ++invocation_count_;
         return value;

--- a/libs/full/performance_counters/src/server/raw_counter.cpp
+++ b/libs/full/performance_counters/src/server/raw_counter.cpp
@@ -59,7 +59,7 @@ namespace hpx { namespace performance_counters { namespace server {
         reset_ = false;
         value.scaling_ = 1;
         value.scale_inverse_ = false;
-        value.status_ = status_new_data;
+        value.status_ = counter_status::new_data;
         value.time_ = static_cast<std::int64_t>(hpx::get_system_uptime());
         value.count_ = ++invocation_count_;
         return value;

--- a/libs/full/performance_counters/src/server/raw_values_counter.cpp
+++ b/libs/full/performance_counters/src/server/raw_values_counter.cpp
@@ -61,7 +61,7 @@ namespace hpx { namespace performance_counters { namespace server {
         reset_ = false;
         values.scaling_ = 1;
         values.scale_inverse_ = false;
-        values.status_ = status_new_data;
+        values.status_ = counter_status::new_data;
         values.time_ = static_cast<std::int64_t>(hpx::get_system_uptime());
         values.count_ = ++invocation_count_;
         return values;

--- a/libs/full/performance_counters/src/server/statistics_counter.cpp
+++ b/libs/full/performance_counters/src/server/statistics_counter.cpp
@@ -427,7 +427,7 @@ namespace hpx { namespace performance_counters { namespace server {
         hpx::performance_counters::counter_value value;
 
         prev_value_.value_ = static_cast<std::int64_t>(value_->get_value());
-        prev_value_.status_ = status_new_data;
+        prev_value_.status_ = counter_status::new_data;
         prev_value_.time_ = static_cast<std::int64_t>(hpx::get_system_uptime());
         prev_value_.count_ = ++invocation_count_;
         has_prev_value_ = true;

--- a/libs/full/performance_counters/tests/unit/all_counters.cpp
+++ b/libs/full/performance_counters/tests/unit/all_counters.cpp
@@ -95,7 +95,7 @@ void test_all_locality_thread_counters(char const* const* counter_names,
         hpx::performance_counters::counter_path_elements path;
         HPX_TEST_EQ(
             hpx::performance_counters::get_counter_path_elements(*p, path),
-            hpx::performance_counters::status_valid_data);
+            hpx::performance_counters::counter_status::valid_data);
 
         // augment the counter path elements
         path.parentinstancename_ = "locality";
@@ -129,7 +129,7 @@ void test_all_locality_thread_counters(char const* const* counter_names,
 
         std::string name;
         HPX_TEST_EQ(hpx::performance_counters::get_counter_name(path, name),
-            hpx::performance_counters::status_valid_data);
+            hpx::performance_counters::counter_status::valid_data);
 
         std::cout << name << '\n';
 

--- a/libs/full/performance_counters/tests/unit/path_elements.cpp
+++ b/libs/full/performance_counters/tests/unit/path_elements.cpp
@@ -401,20 +401,20 @@ namespace test {
             using namespace hpx::performance_counters;
 
             std::string fullname;
-            HPX_TEST_EQ(
-                status_valid_data, get_counter_name(t->path_, fullname, ec));
+            HPX_TEST_EQ(counter_status::valid_data,
+                get_counter_name(t->path_, fullname, ec));
             HPX_TEST_EQ(ec.value(), hpx::success);
             HPX_TEST_EQ(fullname, t->fullname_);
 
             std::string type_name;
-            HPX_TEST(status_valid_data ==
+            HPX_TEST(counter_status::valid_data ==
                 get_counter_type_name(t->path_, type_name, ec));
             HPX_TEST_EQ(ec.value(), hpx::success);
             HPX_TEST_EQ(type_name, t->typename_);
 
             counter_path_elements p;
 
-            HPX_TEST(status_valid_data ==
+            HPX_TEST(counter_status::valid_data ==
                 get_counter_path_elements(t->fullname_, p, ec));
             HPX_TEST_EQ(ec.value(), hpx::success);
             HPX_TEST_EQ(p.objectname_, t->path_.objectname_);
@@ -426,26 +426,27 @@ namespace test {
             HPX_TEST_EQ(p.countername_, t->path_.countername_);
 
             fullname.erase();
-            HPX_TEST_EQ(status_valid_data, get_counter_name(p, fullname, ec));
+            HPX_TEST_EQ(
+                counter_status::valid_data, get_counter_name(p, fullname, ec));
             HPX_TEST_EQ(ec.value(), hpx::success);
             HPX_TEST_EQ(fullname, t->fullname_);
 
             counter_type_path_elements tp1, tp2;
 
-            HPX_TEST(status_valid_data ==
+            HPX_TEST(counter_status::valid_data ==
                 get_counter_type_path_elements(t->fullname_, tp1, ec));
             HPX_TEST_EQ(ec.value(), hpx::success);
             HPX_TEST_EQ(tp1.objectname_, t->path_.objectname_);
             HPX_TEST_EQ(tp1.countername_, t->path_.countername_);
 
             type_name.erase();
-            HPX_TEST_EQ(
-                status_valid_data, get_counter_type_name(tp1, type_name, ec));
+            HPX_TEST_EQ(counter_status::valid_data,
+                get_counter_type_name(tp1, type_name, ec));
             HPX_TEST_EQ(ec.value(), hpx::success);
             HPX_TEST_EQ(type_name, t->typename_);
 
             type_name.erase();
-            HPX_TEST(status_valid_data ==
+            HPX_TEST(counter_status::valid_data ==
                 get_full_counter_type_name(tp1, type_name, ec));
             HPX_TEST_EQ(ec.value(), hpx::success);
             if (t->path_.parameters_.empty())
@@ -458,15 +459,15 @@ namespace test {
                     type_name, t->typename_ + '@' + t->path_.parameters_);
             }
 
-            HPX_TEST(status_valid_data ==
+            HPX_TEST(counter_status::valid_data ==
                 get_counter_type_path_elements(t->typename_, tp2, ec));
             HPX_TEST_EQ(ec.value(), hpx::success);
             HPX_TEST_EQ(tp2.objectname_, t->path_.objectname_);
             HPX_TEST_EQ(tp2.countername_, t->path_.countername_);
 
             type_name.erase();
-            HPX_TEST_EQ(
-                status_valid_data, get_counter_type_name(tp2, type_name, ec));
+            HPX_TEST_EQ(counter_status::valid_data,
+                get_counter_type_name(tp2, type_name, ec));
             HPX_TEST_EQ(ec.value(), hpx::success);
             HPX_TEST_EQ(type_name, t->typename_);
         }
@@ -502,8 +503,8 @@ namespace test {
         for (char const* t = data_bad[0]; nullptr != t; t = data_bad[++i])
         {
             hpx::error_code ec;
-            HPX_TEST_EQ(
-                status_invalid_data, get_counter_path_elements(t, p, ec));
+            HPX_TEST_EQ(counter_status::invalid_data,
+                get_counter_path_elements(t, p, ec));
             HPX_TEST_EQ(ec.value(), hpx::bad_parameter);
         }
 

--- a/libs/full/performance_counters/tests/unit/reinit_counters.cpp
+++ b/libs/full/performance_counters/tests/unit/reinit_counters.cpp
@@ -43,7 +43,7 @@ public:
         hpx::performance_counters::counter_values_array value;
 
         value.time_ = hpx::chrono::high_resolution_clock::now();
-        value.status_ = hpx::performance_counters::status_new_data;
+        value.status_ = hpx::performance_counters::counter_status::new_data;
         value.count_ = ++invocation_count_;
 
         std::vector<std::int64_t> result(value_count_.load());


### PR DESCRIPTION
Convert `enum counter_status` to `enum class counter_status` and remove `status_` prefixes from status values.