### PR TITLE
Splitting documentation generation steps on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -336,15 +336,45 @@ jobs:
           path: /tmp/spelling_suggestions.txt
           destination: /hpx/artifacts/spelling_suggestions.txt
 
-  docs:
+  docs-html:
     <<: *defaults
     steps:
       - attach_workspace:
           at: /hpx
       - run:
-          name: Building Sphinx Documentation
+          name: Building Sphinx Documentation (HTML)
           command: |
-              ninja -j1 docs
+                ninja -j1 docs-html
+          no_output_timeout: 2h
+      - persist_to_workspace:
+          root: /hpx
+          paths:
+            - ./build
+
+  docs-singlehtml:
+    <<: *defaults
+    steps:
+      - attach_workspace:
+          at: /hpx
+      - run:
+          name: Building Sphinx Documentation (Single Page HTML)
+          command: |
+                ninja -j1 docs-singlehtml
+          no_output_timeout: 2h
+      - persist_to_workspace:
+          root: /hpx
+          paths:
+            - ./build
+
+  docs-latexpdf:
+    <<: *defaults
+    steps:
+      - attach_workspace:
+          at: /hpx
+      - run:
+          name: Building Sphinx Documentation (pdf)
+          command: |
+                ninja -j1 docs-latexpdf
           no_output_timeout: 2h
       - persist_to_workspace:
           root: /hpx
@@ -830,7 +860,21 @@ workflows:
           <<: *core_dependency
       - tests.headers3:
           <<: *core_dependency
-      - docs:
+      - docs-html:
+          requires:
+            - configure
+            # Force docs to be built after examples so that workspace doesn't
+            # have conflicts
+            - tests.examples
+          <<: *gh_pages_filter
+      - docs-singlehtml:
+          requires:
+            - configure
+            # Force docs to be built after examples so that workspace doesn't
+            # have conflicts
+            - tests.examples
+          <<: *gh_pages_filter
+      - docs-latexpdf:
           requires:
             - configure
             # Force docs to be built after examples so that workspace doesn't
@@ -839,7 +883,9 @@ workflows:
           <<: *gh_pages_filter
       - docs_push:
           requires:
-            - docs
+            - docs-html
+            - docs-singlehtml
+            - docs-latexpdf
           <<: *docs_push_filter
       - install:
           requires:

--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -217,6 +217,10 @@ create_symbolic_link(
 hpx_source_to_doxygen(hpx_autodoc DEPENDENCIES ${doxygen_dependencies})
 
 add_custom_target(docs)
+add_custom_target(docs-html)
+add_custom_target(docs-singlehtml)
+add_custom_target(docs-latexpdf)
+add_custom_target(docs-man)
 
 set(SPHINX_DOCS_HTML_OUTPUT_FILE "index.html")
 set(SPHINX_DOCS_SINGLEHTML_OUTPUT_FILE "index.html")
@@ -258,8 +262,9 @@ foreach(output_format ${HPX_WITH_DOCUMENTATION_OUTPUT_FORMATS})
   )
 
   add_custom_target(
-    docs-${output_format} ALL DEPENDS ${SPHINX_DOCS_OUTPUT_FILE}
+    docs-${output_format}-file ALL DEPENDS ${SPHINX_DOCS_OUTPUT_FILE}
   )
+  add_dependencies(docs-${output_format} docs-${output_format}-file)
 
   add_dependencies(docs docs-${output_format})
 endforeach()


### PR DESCRIPTION
CircleCI documentation generation times out for master and release branches (after recent changes). This PR slits the generation of the html, singlehtml, and latexpdf docs into separate steps in the hope that those will not time out separately anymore.