### PR TITLE
Change discover counters mode enum to enum class

### DIFF
--- a/components/parcel_plugins/coalescing/include/hpx/parcel_coalescing/counter_registry.hpp
+++ b/components/parcel_plugins/coalescing/include/hpx/parcel_coalescing/counter_registry.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2016 Hartmut Kaiser
+//  Copyright (c) 2016-2022 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying

--- a/components/parcel_plugins/coalescing/src/coalescing_counter_registry.cpp
+++ b/components/parcel_plugins/coalescing/src/coalescing_counter_registry.cpp
@@ -214,7 +214,7 @@ namespace hpx::plugins::parcel {
         performance_counters::discover_counter_func const& f,
         performance_counters::discover_counters_mode mode, error_code& ec)
     {
-        if (mode == performance_counters::discover_counters_minimal ||
+        if (mode == performance_counters::discover_counters_mode::minimal ||
             p.parentinstancename_.empty() || p.instancename_.empty())
         {
             if (p.parentinstancename_.empty())
@@ -232,7 +232,7 @@ namespace hpx::plugins::parcel {
 
         if (p.parameters_.empty())
         {
-            if (mode == performance_counters::discover_counters_minimal)
+            if (mode == performance_counters::discover_counters_mode::minimal)
             {
                 std::string fullname;
                 performance_counters::get_counter_name(p, fullname, ec);

--- a/components/performance_counters/papi/include/hpx/components/performance_counters/papi/server/papi.hpp
+++ b/components/performance_counters/papi/include/hpx/components/performance_counters/papi/server/papi.hpp
@@ -274,8 +274,12 @@ namespace hpx { namespace performance_counters { namespace papi {
             {
                 val.time_ = timestamp_;
                 val.value_ = value_;
+<<<<<<< HEAD
                 val.status_ =
                     hpx::performance_counters::counter_status::new_data;
+=======
+                val.status_ = hpx::performance_counters::new_data;
+>>>>>>> 1a3461daee (Convert enum counter_status to enum class)
                 val.scaling_ = 1;
                 val.scale_inverse_ = false;
             }

--- a/components/performance_counters/papi/src/papi_startup.cpp
+++ b/components/performance_counters/papi/src/papi_startup.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2013 Hartmut Kaiser
+//  Copyright (c) 2007-2022 Hartmut Kaiser
 //  Copyright (c) 2011-2012 Maciej Brodowicz
 //
 //  SPDX-License-Identifier: BSL-1.0
@@ -116,7 +116,7 @@ namespace hpx { namespace performance_counters { namespace papi {
         std::uint32_t tix = 0;
         while (!((label = tm.get_thread_label(tix++)).empty()))
         {
-            if (mode == discover_counters_minimal)
+            if (mode == discover_counters_mode::minimal)
             {
                 size_t pos = label.find_last_of('#');
                 if (pos == label.npos)

--- a/examples/performance_counters/sine/sine.cpp
+++ b/examples/performance_counters/sine/sine.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2012 Hartmut Kaiser
+//  Copyright (c) 2007-2022 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -96,7 +96,8 @@ namespace performance_counters { namespace sine {
         if (!status_is_valid(status))
             return false;
 
-        if (mode == hpx::performance_counters::discover_counters_minimal ||
+        if (mode ==
+                hpx::performance_counters::discover_counters_mode::minimal ||
             p.parentinstancename_.empty() || p.instancename_.empty())
         {
             if (p.parentinstancename_.empty())
@@ -117,8 +118,8 @@ namespace performance_counters { namespace sine {
         }
         else if (p.instancename_ == "instance#*")
         {
-            HPX_ASSERT(
-                mode == hpx::performance_counters::discover_counters_full);
+            HPX_ASSERT(mode ==
+                hpx::performance_counters::discover_counters_mode::full);
 
             // FIXME: expand for all instances
             p.instancename_ = "instance";

--- a/libs/full/init_runtime/src/hpx_init.cpp
+++ b/libs/full/init_runtime/src/hpx_init.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2021 Hartmut Kaiser
+//  Copyright (c) 2007-2022 Hartmut Kaiser
 //  Copyright (c)      2017 Shoshana Jakobovits
 //  Copyright (c) 2010-2011 Phillip LeBlanc, Dylan Stark
 //  Copyright (c)      2011 Bryce Lelbach
@@ -181,8 +181,8 @@ namespace hpx { namespace detail {
     {
         // list all counter names
         list_counter_names_header(true);
-        performance_counters::discover_counter_types(
-            &list_counter, performance_counters::discover_counters_minimal);
+        performance_counters::discover_counter_types(&list_counter,
+            performance_counters::discover_counters_mode::minimal);
     }
 
     void list_counter_names_full()
@@ -190,7 +190,7 @@ namespace hpx { namespace detail {
         // list all counter names
         list_counter_names_header(false);
         performance_counters::discover_counter_types(
-            &list_counter, performance_counters::discover_counters_full);
+            &list_counter, performance_counters::discover_counters_mode::full);
     }
 
     ///////////////////////////////////////////////////////////////////////////
@@ -234,15 +234,15 @@ namespace hpx { namespace detail {
         // list all counter information
         list_counter_infos_header(true);
         performance_counters::discover_counter_types(&list_counter_info,
-            performance_counters::discover_counters_minimal);
+            performance_counters::discover_counters_mode::minimal);
     }
 
     void list_counter_infos_full()
     {
         // list all counter information
         list_counter_infos_header(false);
-        performance_counters::discover_counter_types(
-            &list_counter_info, performance_counters::discover_counters_full);
+        performance_counters::discover_counter_types(&list_counter_info,
+            performance_counters::discover_counters_mode::full);
     }
 
     ///////////////////////////////////////////////////////////////////////////

--- a/libs/full/performance_counters/include/hpx/performance_counters/action_invocation_counter_discoverer.hpp
+++ b/libs/full/performance_counters/include/hpx/performance_counters/action_invocation_counter_discoverer.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2015-2020 Hartmut Kaiser
+//  Copyright (c) 2015-2022 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying

--- a/libs/full/performance_counters/include/hpx/performance_counters/counter_creators.hpp
+++ b/libs/full/performance_counters/include/hpx/performance_counters/counter_creators.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2012 Hartmut Kaiser
+//  Copyright (c) 2007-2022 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying

--- a/libs/full/performance_counters/include/hpx/performance_counters/counters.hpp
+++ b/libs/full/performance_counters/include/hpx/performance_counters/counters.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2016 Hartmut Kaiser
+//  Copyright (c) 2007-2022 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying

--- a/libs/full/performance_counters/include/hpx/performance_counters/counters_fwd.hpp
+++ b/libs/full/performance_counters/include/hpx/performance_counters/counters_fwd.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2017 Hartmut Kaiser
+//  Copyright (c) 2017-2022 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -212,7 +212,7 @@ namespace hpx { namespace performance_counters {
 
 #define HPX_COUNTER_STATUS_UNSCOPED_ENUM_DEPRECATION_MSG                       \
     "The unscoped counter_status names are deprecated. Please use "            \
-    "counter_status::<type> instead."
+    "counter_status::<status> instead."
 
     HPX_DEPRECATED_V(1, 9, HPX_COUNTER_STATUS_UNSCOPED_ENUM_DEPRECATION_MSG)
     inline constexpr counter_status status_valid_data =
@@ -317,11 +317,26 @@ namespace hpx { namespace performance_counters {
     typedef hpx::function<bool(counter_info const&, error_code&)>
         discover_counter_func;
 
-    enum discover_counters_mode
+    enum class discover_counters_mode
     {
-        discover_counters_minimal,
-        discover_counters_full    // fully expand all wild cards
+        minimal,
+        full    // fully expand all wild cards
     };
+
+#define HPX_DISCOVER_COUNTERS_MODE_UNSCOPED_ENUM_DEPRECATION_MSG               \
+    "The unscoped discover counters mode names are deprecated. Please use "    \
+    "discover_counters_mode::<mode> instead."
+
+    HPX_DEPRECATED_V(
+        1, 9, HPX_DISCOVER_COUNTERS_MODE_UNSCOPED_ENUM_DEPRECATION_MSG)
+    inline constexpr discover_counters_mode discover_counters_minimal =
+        discover_counters_mode::minimal;
+    HPX_DEPRECATED_V(
+        1, 9, HPX_DISCOVER_COUNTERS_MODE_UNSCOPED_ENUM_DEPRECATION_MSG)
+    inline constexpr discover_counters_mode discover_counters_full =
+        discover_counters_mode::full;
+
+#undef HPX_DISCOVER_COUNTERS_MODE_UNSCOPED_ENUM_DEPRECATION_MSG
 
     // This declares the type of a function, which will be called by
     // HPX whenever it needs to discover all performance counter
@@ -514,36 +529,36 @@ namespace hpx { namespace performance_counters {
     /// \brief Call the supplied function for each registered counter type
     HPX_EXPORT counter_status discover_counter_types(
         discover_counter_func const& discover_counter,
-        discover_counters_mode mode = discover_counters_minimal,
+        discover_counters_mode mode = discover_counters_mode::minimal,
         error_code& ec = throws);
 
     /// \brief Return a list of all available counter descriptions.
     HPX_EXPORT counter_status discover_counter_types(
         std::vector<counter_info>& counters,
-        discover_counters_mode mode = discover_counters_minimal,
+        discover_counters_mode mode = discover_counters_mode::minimal,
         error_code& ec = throws);
 
     /// \brief Call the supplied function for the given registered counter type.
     HPX_EXPORT counter_status discover_counter_type(std::string const& name,
         discover_counter_func const& discover_counter,
-        discover_counters_mode mode = discover_counters_minimal,
+        discover_counters_mode mode = discover_counters_mode::minimal,
         error_code& ec = throws);
 
     HPX_EXPORT counter_status discover_counter_type(counter_info const& info,
         discover_counter_func const& discover_counter,
-        discover_counters_mode mode = discover_counters_minimal,
+        discover_counters_mode mode = discover_counters_mode::minimal,
         error_code& ec = throws);
 
     /// \brief Return a list of matching counter descriptions for the given
     ///        registered counter type.
     HPX_EXPORT counter_status discover_counter_type(std::string const& name,
         std::vector<counter_info>& counters,
-        discover_counters_mode mode = discover_counters_minimal,
+        discover_counters_mode mode = discover_counters_mode::minimal,
         error_code& ec = throws);
 
     HPX_EXPORT counter_status discover_counter_type(counter_info const& info,
         std::vector<counter_info>& counters,
-        discover_counters_mode mode = discover_counters_minimal,
+        discover_counters_mode mode = discover_counters_mode::minimal,
         error_code& ec = throws);
 
     /// \brief call the supplied function will all expanded versions of the

--- a/libs/full/performance_counters/include/hpx/performance_counters/per_action_data_counter_discoverer.hpp
+++ b/libs/full/performance_counters/include/hpx/performance_counters/per_action_data_counter_discoverer.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2015-2020 Hartmut Kaiser
+//  Copyright (c) 2015-2022 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying

--- a/libs/full/performance_counters/include/hpx/performance_counters/registry.hpp
+++ b/libs/full/performance_counters/include/hpx/performance_counters/registry.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2013 Hartmut Kaiser
+//  Copyright (c) 2007-2022 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying

--- a/libs/full/performance_counters/src/action_invocation_counter_discoverer.cpp
+++ b/libs/full/performance_counters/src/action_invocation_counter_discoverer.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2020 Hartmut Kaiser
+//  Copyright (c) 2007-2022 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -32,7 +32,7 @@ namespace hpx { namespace performance_counters {
 
         map_type const& map = registry.registered_counters();
 
-        if (mode == performance_counters::discover_counters_minimal ||
+        if (mode == performance_counters::discover_counters_mode::minimal ||
             p.parentinstancename_.empty() || p.instancename_.empty())
         {
             if (p.parentinstancename_.empty())
@@ -50,7 +50,7 @@ namespace hpx { namespace performance_counters {
 
         if (p.parameters_.empty())
         {
-            if (mode == performance_counters::discover_counters_minimal)
+            if (mode == performance_counters::discover_counters_mode::minimal)
             {
                 std::string fullname;
                 performance_counters::get_counter_name(p, fullname, ec);

--- a/libs/full/performance_counters/src/counter_creators.cpp
+++ b/libs/full/performance_counters/src/counter_creators.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2021 Hartmut Kaiser
+//  Copyright (c) 2007-2022 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -63,7 +63,7 @@ namespace hpx { namespace performance_counters {
         if (!status_is_valid(status))
             return false;
 
-        if (mode == discover_counters_minimal ||
+        if (mode == discover_counters_mode::minimal ||
             p.parentinstancename_.empty() || p.instancename_.empty())
         {
             if (p.parentinstancename_.empty())
@@ -112,7 +112,7 @@ namespace hpx { namespace performance_counters {
         if (!status_is_valid(status))
             return false;
 
-        if (mode == discover_counters_minimal ||
+        if (mode == discover_counters_mode::minimal ||
             p.parentinstancename_.empty() || p.instancename_.empty())
         {
             if (p.parentinstancename_.empty())
@@ -183,7 +183,7 @@ namespace hpx { namespace performance_counters {
             p.parentinstanceindex_ = 0;
         }
 
-        if (mode == discover_counters_minimal ||
+        if (mode == discover_counters_mode::minimal ||
             p.parentinstancename_.empty() || p.instancename_.empty())
         {
             if (p.parentinstancename_.empty())
@@ -228,7 +228,7 @@ namespace hpx { namespace performance_counters {
         if (!status_is_valid(status))
             return false;
 
-        if (mode == discover_counters_minimal ||
+        if (mode == discover_counters_mode::minimal ||
             p.parentinstancename_.empty() || p.instancename_.empty())
         {
             if (p.parentinstancename_.empty())
@@ -284,7 +284,7 @@ namespace hpx { namespace performance_counters {
         if (!status_is_valid(status))
             return false;
 
-        if (mode == discover_counters_minimal ||
+        if (mode == discover_counters_mode::minimal ||
             p.parentinstancename_.empty() || p.instancename_.empty() ||
             p.subinstancename_.empty())
         {
@@ -351,7 +351,7 @@ namespace hpx { namespace performance_counters {
         if (!status_is_valid(status))
             return false;
 
-        if (mode == discover_counters_minimal ||
+        if (mode == discover_counters_mode::minimal ||
             p.parentinstancename_.empty() || p.instancename_.empty() ||
             p.subinstancename_.empty())
         {
@@ -401,7 +401,7 @@ namespace hpx { namespace performance_counters {
         if (!status_is_valid(status))
             return false;
 
-        if (mode == discover_counters_minimal ||
+        if (mode == discover_counters_mode::minimal ||
             p.parentinstancename_.empty() || p.instancename_.empty())
         {
             if (p.parentinstancename_.empty())

--- a/libs/full/performance_counters/src/counters.cpp
+++ b/libs/full/performance_counters/src/counters.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2021 Hartmut Kaiser
+//  Copyright (c) 2007-2022 Hartmut Kaiser
 //  Copyright (c)      2011 Bryce Lelbach
 //
 //  SPDX-License-Identifier: BSL-1.0
@@ -848,7 +848,7 @@ namespace hpx { namespace performance_counters {
             // discover all base names
             std::vector<counter_info> counter_infos;
             counter_status status = discover_counter_type(p.parentinstancename_,
-                counter_infos, discover_counters_full, ec);
+                counter_infos, discover_counters_mode::full, ec);
             if (!status_is_valid(status) || ec)
                 return false;
 

--- a/libs/full/performance_counters/src/per_action_data_counter_discoverer.cpp
+++ b/libs/full/performance_counters/src/per_action_data_counter_discoverer.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2020 Hartmut Kaiser
+//  Copyright (c) 2007-2022 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -35,7 +35,7 @@ namespace hpx { namespace performance_counters {
 
         map_type const& map = registry.registered_counters();
 
-        if (mode == performance_counters::discover_counters_minimal ||
+        if (mode == performance_counters::discover_counters_mode::minimal ||
             p.parentinstancename_.empty() || p.instancename_.empty())
         {
             if (p.parentinstancename_.empty())

--- a/libs/full/performance_counters/src/performance_counter.cpp
+++ b/libs/full/performance_counters/src/performance_counter.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2020 Hartmut Kaiser
+//  Copyright (c) 2007-2022 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -220,8 +220,8 @@ namespace hpx { namespace performance_counters {
         std::vector<performance_counter> counters;
 
         std::vector<counter_info> infos;
-        counter_status status =
-            discover_counter_type(name, infos, discover_counters_full, ec);
+        counter_status status = discover_counter_type(
+            name, infos, discover_counters_mode::full, ec);
         if (!status_is_valid(status) || ec)
             return counters;
 

--- a/libs/full/performance_counters/src/performance_counter_set.cpp
+++ b/libs/full/performance_counters/src/performance_counter_set.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2016-2021 Hartmut Kaiser
+//  Copyright (c) 2016-2022 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -122,7 +122,8 @@ namespace hpx { namespace performance_counters {
         util::expand(n);
 
         // find matching counter types
-        discover_counter_type(n, HPX_MOVE(func), discover_counters_full, ec);
+        discover_counter_type(
+            n, HPX_MOVE(func), discover_counters_mode::full, ec);
         if (ec)
             return;
 
@@ -145,7 +146,7 @@ namespace hpx { namespace performance_counters {
             util::expand(n);
 
             // find matching counter types
-            discover_counter_type(n, func, discover_counters_full, ec);
+            discover_counter_type(n, func, discover_counters_mode::full, ec);
             if (ec)
                 return;
         }

--- a/libs/full/performance_counters/src/registry.cpp
+++ b/libs/full/performance_counters/src/registry.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2015 Hartmut Kaiser
+//  Copyright (c) 2007-2022 Hartmut Kaiser
 //  Copyright (c)      2011 Bryce Lelbach
 //
 //  SPDX-License-Identifier: BSL-1.0
@@ -150,7 +150,7 @@ namespace hpx { namespace performance_counters {
                 return counter_status::counter_type_unknown;
             }
 
-            if (mode == discover_counters_full)
+            if (mode == discover_counters_mode::full)
             {
                 using hpx::placeholders::_1;
                 discover_counter = hpx::bind(
@@ -173,7 +173,7 @@ namespace hpx { namespace performance_counters {
             if (ec)
                 return counter_status::invalid_data;
 
-            if (mode == discover_counters_full)
+            if (mode == discover_counters_mode::full)
             {
                 using hpx::placeholders::_1;
                 discover_counter = hpx::bind(
@@ -246,7 +246,7 @@ namespace hpx { namespace performance_counters {
         // Introducing this temporary silence a report about a potential memory
         // from clang's static analyzer
         discover_counter_func discover_counter_;
-        if (mode == discover_counters_full)
+        if (mode == discover_counters_mode::full)
         {
             using hpx::placeholders::_1;
             discover_counter_ = hpx::bind(&expand_counter_info, _1,

--- a/libs/full/performance_counters/src/server/action_invocation_counter.cpp
+++ b/libs/full/performance_counters/src/server/action_invocation_counter.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2015 Hartmut Kaiser
+//  Copyright (c) 2007-2022 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying

--- a/libs/full/performance_counters/src/server/per_action_data_counters.cpp
+++ b/libs/full/performance_counters/src/server/per_action_data_counters.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2016 Hartmut Kaiser
+//  Copyright (c) 2016-2022 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying

--- a/libs/full/performance_counters/src/threadmanager_counter_types.cpp
+++ b/libs/full/performance_counters/src/threadmanager_counter_types.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2017 Hartmut Kaiser
+//  Copyright (c) 2007-2022 Hartmut Kaiser
 //  Copyright (c)      2011 Bryce Lelbach, Katelyn Kufahl
 //  Copyright (c) 2008-2009 Chirag Dekate, Anshul Tandon
 //  Copyright (c) 2015 Patricia Grubel
@@ -261,7 +261,7 @@ namespace hpx { namespace performance_counters { namespace detail {
             return false;
         }
 
-        if (mode == discover_counters_minimal ||
+        if (mode == discover_counters_mode::minimal ||
             p.parentinstancename_.empty() || p.instancename_.empty())
         {
             if (p.parentinstancename_.empty())
@@ -285,7 +285,7 @@ namespace hpx { namespace performance_counters { namespace detail {
             p.instancename_ = "allocator#*";
             p.instanceindex_ = -1;
 
-            if (mode == discover_counters_full)
+            if (mode == discover_counters_mode::full)
             {
                 for (std::size_t t = 0; t != HPX_COROUTINE_NUM_ALL_HEAPS; ++t)
                 {

--- a/tests/performance/local/activate_counters.cpp
+++ b/tests/performance/local/activate_counters.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2021 Hartmut Kaiser
+//  Copyright (c) 2007-2022 Hartmut Kaiser
 //  Copyright (c) 2013      Bryce Adelstein-Lelbach
 //
 //  SPDX-License-Identifier: BSL-1.0
@@ -80,8 +80,8 @@ namespace hpx { namespace util {
                 util::expand(name);
 
                 // find matching counter type
-                performance_counters::discover_counter_type(
-                    name, func, performance_counters::discover_counters_full);
+                performance_counters::discover_counter_type(name, func,
+                    performance_counters::discover_counters_mode::full);
             }
         }
 


### PR DESCRIPTION
Final enum to enum class conversion for performance counters module (`discover_counter_mode`). It's minimal and couldn't find any local fails so I will let CI guide me. I would hope for these PRs to go to 1.9.

