### PR TITLE
ATOMIC_INIT_FLAG is deprecated starting C++20

### DIFF
--- a/cmake/HPX_AddConfigTest.cmake
+++ b/cmake/HPX_AddConfigTest.cmake
@@ -251,6 +251,18 @@ function(hpx_check_for_libfun_std_experimental_optional)
 endfunction()
 
 # ##############################################################################
+# ATOMIC_FLAG_INIT is deprecated starting C++20. Here we check whether using it
+# will cause failures (-Werror,-Wdeprecated-pragma), so we check for it
+# separately.
+function(hpx_check_for_cxx11_atomic_init_flag)
+  add_hpx_config_test(
+    HPX_WITH_CXX11_ATOMIC_INIT_FLAG
+    SOURCE cmake/tests/cxx11_atomic_init_flag.cpp
+    FILE ${ARGN}
+  )
+endfunction()
+
+# ##############################################################################
 function(hpx_check_for_cxx11_std_atomic)
   # Make sure HPX_HAVE_LIBATOMIC is removed from the cache if necessary
   if(NOT HPX_WITH_CXX11_ATOMIC)

--- a/cmake/HPX_PerformCxxFeatureTests.cmake
+++ b/cmake/HPX_PerformCxxFeatureTests.cmake
@@ -12,8 +12,25 @@
 # C++ feature tests
 # ##############################################################################
 function(hpx_perform_cxx_feature_tests)
+
+  set(atomics_additional_flags COMPILE_DEFINITIONS
+                               HPX_HAVE_CXX11_ATOMIC_INIT_FLAG
+  )
+  if(HPX_WITH_CXX_STANDARD GREATER_EQUAL 20)
+    # ATOMIC_FLAG_INIT is deprecated starting C++20. Here we check whether using
+    # it will cause failures (-Werror,-Wdeprecated-pragma), so we can disable
+    # its use in the test for C++11 atomics below.
+    hpx_check_for_cxx11_atomic_init_flag(
+      DEFINITIONS HPX_HAVE_CXX11_ATOMIC_INIT_FLAG
+    )
+    if(NOT HPX_WITH_CXX11_ATOMIC_INIT_FLAG)
+      set(atomics_additional_flags)
+    endif()
+  endif()
+
   hpx_check_for_cxx11_std_atomic(
     REQUIRED "HPX needs support for C++11 std::atomic"
+    ${atomics_additional_flags}
   )
 
   # Separately check for 128 bit atomics

--- a/cmake/tests/cxx11_atomic_init_flag.cpp
+++ b/cmake/tests/cxx11_atomic_init_flag.cpp
@@ -1,0 +1,13 @@
+//  Copyright (c) 2017 Agustin Berge
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <atomic>
+
+int main()
+{
+    std::atomic_flag af = ATOMIC_FLAG_INIT;
+    (void) af;
+}

--- a/cmake/tests/cxx11_std_atomic.cpp
+++ b/cmake/tests/cxx11_std_atomic.cpp
@@ -20,7 +20,12 @@ void test_atomic()
 
 int main()
 {
+// ATOMIC_FLAG_INIT is deprecated starting C++20
+#if defined(HPX_HAVE_CXX20_ATOMIC_INIT_FLAG)
     std::atomic_flag af = ATOMIC_FLAG_INIT;
+#else
+    std::atomic_flag af;
+#endif
     if (af.test_and_set())
         af.clear();
 

--- a/libs/core/execution_base/tests/unit/execution_context.cpp
+++ b/libs/core/execution_base/tests/unit/execution_context.cpp
@@ -100,7 +100,11 @@ struct simple_spinlock
         locked_.clear();
     }
 
+#if defined(HPX_HAVE_CXX11_ATOMIC_INIT_FLAG)
     std::atomic_flag locked_ = ATOMIC_FLAG_INIT;
+#else
+    std::atomic_flag locked_;
+#endif
 };
 
 void test_yield()

--- a/libs/core/functional/tests/unit/is_invocable.cpp
+++ b/libs/core/functional/tests/unit/is_invocable.cpp
@@ -117,6 +117,9 @@ void functions_byrvref_params()
 
 void member_function_pointers()
 {
+// clang in C++20 mode complains about invalid float->double promotion that
+// can't be disabled :/
+#if !defined(HPX_CLANG_VERSION)
     typedef int (X::*f)(double);
     HPX_TEST_MSG(
         (hpx::is_invocable_v<f, X*, float> == true), "mem-fun-ptr/ptr");
@@ -152,6 +155,7 @@ void member_function_pointers()
         "const-mem-fun-ptr/smart-ptr");
     HPX_TEST_MSG((hpx::is_invocable_v<fc, smart_ptr<X const>, float> == true),
         "const-mem-fun-ptr/smart-const-ptr");
+#endif
 }
 
 void member_object_pointers()

--- a/libs/core/threading_base/tests/regressions/thread_stacksize_current.cpp
+++ b/libs/core/threading_base/tests/regressions/thread_stacksize_current.cpp
@@ -63,9 +63,22 @@ int hpx_main()
 
 int main(int argc, char** argv)
 {
-    std::vector<std::string> schedulers = {"local", "local-priority-fifo",
-        "local-priority-lifo", "static", "static-priority", "abp-priority-fifo",
-        "abp-priority-lifo", "shared-priority"};
+    // clang-format off
+    std::vector<std::string> schedulers = {
+        "local",
+        "local-priority-fifo",
+#if defined(HPX_HAVE_CXX11_STD_ATOMIC_128BIT)
+        "local-priority-lifo",
+#endif
+        "static",
+        "static-priority",
+#if defined(HPX_HAVE_CXX11_STD_ATOMIC_128BIT)
+        "abp-priority-fifo",
+        "abp-priority-lifo",
+#endif
+        "shared-priority"
+    };
+    // clang-format on
     for (auto const& scheduler : schedulers)
     {
         hpx::local::init_params iparams;


### PR DESCRIPTION
- this disables the use of ATOMIC_INIT_FLAG if needed (clang 14 complains about its use)
