### PR TITLE
add cmake option HPX_WITH_PARCELPORT_COUNTERS

### DIFF
--- a/.jenkins/cscs/env-common.sh
+++ b/.jenkins/cscs/env-common.sh
@@ -18,3 +18,6 @@ export CCACHE_MAXFILES=50000
 
 configure_extra_options+=" -DCMAKE_BUILD_TYPE=${build_type}"
 configure_extra_options+=" -DHPX_WITH_CHECK_MODULE_DEPENDENCIES=ON"
+if [ "${build_type}" = "Debug" ]; then
+    configure_extra_options+=" -DHPX_WITH_PARCELPORT_COUNTERS=ON"
+fi

--- a/.jenkins/lsu/env-common.sh
+++ b/.jenkins/lsu/env-common.sh
@@ -6,3 +6,6 @@
 
 configure_extra_options+=" -DCMAKE_BUILD_TYPE=${build_type}"
 configure_extra_options+=" -DHPX_WITH_CHECK_MODULE_DEPENDENCIES=ON"
+if [ "${build_type}" = "Debug" ]; then
+    configure_extra_options+=" -DHPX_WITH_PARCELPORT_COUNTERS=ON"
+fi

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1142,6 +1142,14 @@ if(HPX_WITH_NETWORKING)
     hpx_add_config_define(HPX_HAVE_PARCELPORT_TCP)
   endif()
   hpx_option(
+    HPX_WITH_PARCELPORT_COUNTERS BOOL
+    "Enable performance counters reporting parcelport statistics." OFF
+    CATEGORY "Parcelport"
+  )
+  if(HPX_WITH_PARCELPORT_COUNTERS)
+    hpx_add_config_define(HPX_HAVE_PARCELPORT_COUNTERS)
+  endif()
+  hpx_option(
     HPX_WITH_PARCELPORT_ACTION_COUNTERS
     BOOL
     "Enable performance counters reporting parcelport statistics on a per-action basis."

--- a/docs/sphinx/manual/optimizing_hpx_applications.rst
+++ b/docs/sphinx/manual/optimizing_hpx_applications.rst
@@ -1008,10 +1008,15 @@ system and application performance.
        (see ``<operation``, e.g. ``en`` or ``eceived``) for the specified
        ``<connection_type>``.
 
+       The performance counters are available only if the compile time constant
+       ``HPX_HAVE_PARCELPORT_COUNTERS`` was defined while compiling the |hpx|
+       core library (which is not defined by default). The corresponding cmake
+       configuration constant is ``HPX_WITH_PARCELPORT_COUNTERS``.
+
        The performance counters for the connection type ``mpi`` are available
        only if the compile time constant ``HPX_HAVE_PARCELPORT_MPI`` was defined
-       while compiling the |hpx| core library (which is not defined by default,
-       the corresponding cmake configuration constant is
+       while compiling the |hpx| core library (which is not defined by default).
+       The corresponding cmake configuration constant is
        ``HPX_WITH_PARCELPORT_MPI``.
 
        Please see :ref:`cmake_variables` for more details.
@@ -1039,10 +1044,15 @@ system and application performance.
        operation for the specified ``<connection_type>`` the given
        :term:`locality` (see ``<operation``, e.g. ``en`` or ``eceived``).
 
+       The performance counters are available only if the compile time constant
+       ``HPX_HAVE_PARCELPORT_COUNTERS`` was defined while compiling the |hpx|
+       core library (which is not defined by default). The corresponding cmake
+       configuration constant is ``HPX_WITH_PARCELPORT_COUNTERS``.
+
        The performance counters for the connection type ``mpi`` are available
        only if the compile time constant ``HPX_HAVE_PARCELPORT_MPI`` was defined
-       while compiling the |hpx| core library (which is not defined by default,
-       the corresponding cmake configuration constant is
+       while compiling the |hpx| core library (which is not defined by default).
+       The corresponding cmake configuration constant is
        ``HPX_WITH_PARCELPORT_MPI``.
 
        Please see :ref:`cmake_variables` for more details.
@@ -1069,10 +1079,15 @@ system and application performance.
        e.g. ``sent`` or ``received`` possibly compressed) for the specified
        ``<connection_type>`` by the given :term:`locality`.
 
+       The performance counters are available only if the compile time constant
+       ``HPX_HAVE_PARCELPORT_COUNTERS`` was defined while compiling the |hpx|
+       core library (which is not defined by default). The corresponding cmake
+       configuration constant is ``HPX_WITH_PARCELPORT_COUNTERS``.
+
        The performance counters for the connection type ``mpi`` are available
        only if the compile time constant ``HPX_HAVE_PARCELPORT_MPI`` was defined
-       while compiling the |hpx| core library (which is not defined by default,
-       the corresponding cmake configuration constant is
+       while compiling the |hpx| core library (which is not defined by default).
+       The corresponding cmake configuration constant is
        ``HPX_WITH_PARCELPORT_MPI``.
 
        Please see :ref:`cmake_variables` for more details.
@@ -1102,10 +1117,15 @@ system and application performance.
        the specified ``<connection_type>`` on the given :term:`locality` (see
        ``<operation``, e.g. ``sent`` or ``received``).
 
+       The performance counters are available only if the compile time constant
+       ``HPX_HAVE_PARCELPORT_COUNTERS`` was defined while compiling the |hpx|
+       core library (which is not defined by default). The corresponding cmake
+       configuration constant is ``HPX_WITH_PARCELPORT_COUNTERS``.
+
        The performance counters for the connection type ``mpi`` are available
        only if the compile time constant ``HPX_HAVE_PARCELPORT_MPI`` was defined
-       while compiling the |hpx| core library (which is not defined by default,
-       the corresponding cmake configuration constant is
+       while compiling the |hpx| core library (which is not defined by default).
+       The corresponding cmake configuration constant is
        ``HPX_WITH_PARCELPORT_MPI``.
 
        Please see :ref:`cmake_variables` for more details.
@@ -1162,10 +1182,15 @@ system and application performance.
        ``<connection_type`` by the given :term:`locality` (see ``operation>``,
        e.g. ``sent`` or ``received``.
 
+       The performance counters are available only if the compile time constant
+       ``HPX_HAVE_PARCELPORT_COUNTERS`` was defined while compiling the |hpx|
+       core library (which is not defined by default). The corresponding cmake
+       configuration constant is ``HPX_WITH_PARCELPORT_COUNTERS``.
+
        The performance counters for the connection type ``mpi`` are available
        only if the compile time constant ``HPX_HAVE_PARCELPORT_MPI`` was defined
-       while compiling the |hpx| core library (which is not defined by default,
-       the corresponding cmake configuration constant is
+       while compiling the |hpx| core library (which is not defined by default).
+       The corresponding cmake configuration constant is
        ``HPX_WITH_PARCELPORT_MPI``.
 
        Please see :ref:`cmake_variables` for more details.
@@ -1192,10 +1217,15 @@ system and application performance.
        specified ``<connection_type>`` by the given :term:`locality` (see
        ``<operation``, e.g. ``sent`` or ``received``)
 
+       The performance counters are available only if the compile time constant
+       ``HPX_HAVE_PARCELPORT_COUNTERS`` was defined while compiling the |hpx|
+       core library (which is not defined by default). The corresponding cmake
+       configuration constant is ``HPX_WITH_PARCELPORT_COUNTERS``.
+
        The performance counters for the connection type ``mpi`` are available
        only if the compile time constant ``HPX_HAVE_PARCELPORT_MPI`` was defined
-       while compiling the |hpx| core library (which is not defined by default,
-       the corresponding cmake configuration constant is
+       while compiling the |hpx| core library (which is not defined by default).
+       The corresponding cmake configuration constant is
        ``HPX_WITH_PARCELPORT_MPI``.
 
        Please see :ref:`cmake_variables` for more details.
@@ -1227,8 +1257,8 @@ system and application performance.
 
        The performance counters for the connection type ``mpi`` are available
        only if the compile time constant ``HPX_HAVE_PARCELPORT_MPI`` was defined
-       while compiling the |hpx| core library (which is not defined by default,
-       the corresponding cmake configuration constant is
+       while compiling the |hpx| core library (which is not defined by default).
+       The corresponding cmake configuration constant is
        ``HPX_WITH_PARCELPORT_MPI``.
 
        Please see :ref:`cmake_variables` for more details.

--- a/libs/full/actions/include/hpx/actions/transfer_base_action.hpp
+++ b/libs/full/actions/include/hpx/actions/transfer_base_action.hpp
@@ -349,7 +349,8 @@ namespace hpx { namespace actions {
     }
 }}    // namespace hpx::actions
 
-#if defined(HPX_HAVE_PARCELPORT_ACTION_COUNTERS)
+#if defined(HPX_HAVE_PARCELPORT_COUNTERS) &&                                   \
+    defined(HPX_HAVE_PARCELPORT_ACTION_COUNTERS)
 #include <hpx/actions_base/detail/per_action_data_counter_registry.hpp>
 
 namespace hpx { namespace actions { namespace detail {

--- a/libs/full/actions_base/include/hpx/actions_base/detail/per_action_data_counter_registry.hpp
+++ b/libs/full/actions_base/include/hpx/actions_base/detail/per_action_data_counter_registry.hpp
@@ -8,7 +8,9 @@
 
 #include <hpx/config.hpp>
 
-#if defined(HPX_HAVE_PARCELPORT_ACTION_COUNTERS) && defined(HPX_HAVE_NETWORKING)
+#if defined(HPX_HAVE_PARCELPORT_COUNTERS) &&                                   \
+    defined(HPX_HAVE_PARCELPORT_ACTION_COUNTERS) &&                            \
+    defined(HPX_HAVE_NETWORKING)
 #include <hpx/functional/function.hpp>
 #include <hpx/hashing/jenkins_hash.hpp>
 #include <hpx/type_support/static.hpp>

--- a/libs/full/actions_base/src/detail/per_action_data_counter_registry.cpp
+++ b/libs/full/actions_base/src/detail/per_action_data_counter_registry.cpp
@@ -6,7 +6,9 @@
 
 #include <hpx/config.hpp>
 
-#if defined(HPX_HAVE_PARCELPORT_ACTION_COUNTERS) && defined(HPX_HAVE_NETWORKING)
+#if defined(HPX_HAVE_PARCELPORT_COUNTERS) &&                                   \
+    defined(HPX_HAVE_PARCELPORT_ACTION_COUNTERS) &&                            \
+    defined(HPX_HAVE_NETWORKING)
 #include <hpx/actions_base/detail/per_action_data_counter_registry.hpp>
 #include <hpx/functional/bind_front.hpp>
 #include <hpx/modules/errors.hpp>

--- a/libs/full/parcelport_lci/include/hpx/parcelport_lci/receiver_connection.hpp
+++ b/libs/full/parcelport_lci/include/hpx/parcelport_lci/receiver_connection.hpp
@@ -50,10 +50,11 @@ namespace hpx::parcelset::policies::lci {
         {
             header_.assert_valid();
 
+#if defined(HPX_HAVE_PARCELPORT_COUNTERS)
             parcelset::data_point& data = buffer_.data_point_;
             data.time_ = timer_.elapsed_nanoseconds();
             data.bytes_ = static_cast<std::size_t>(header_.numbytes());
-
+#endif
             buffer_.data_.resize(static_cast<std::size_t>(header_.size()));
             buffer_.num_chunks_ = header_.num_chunks();
 
@@ -211,9 +212,10 @@ namespace hpx::parcelset::policies::lci {
                 LCI_sync_free(&sync_others);
                 sync_others = nullptr;
             }
+#if defined(HPX_HAVE_PARCELPORT_COUNTERS)
             parcelset::data_point& data = buffer_.data_point_;
             data.time_ = timer_.elapsed_nanoseconds() - data.time_;
-
+#endif
             {
                 LCI_short_t short_rt_;
                 *(int*) &short_rt_ = tag_;
@@ -229,8 +231,9 @@ namespace hpx::parcelset::policies::lci {
             return true;
         }
 
+#if defined(HPX_HAVE_PARCELPORT_COUNTERS)
         hpx::chrono::high_resolution_timer timer_;
-
+#endif
         connection_state state_;
 
         int src_rank;

--- a/libs/full/parcelport_lci/include/hpx/parcelport_lci/sender_connection.hpp
+++ b/libs/full/parcelport_lci/include/hpx/parcelport_lci/sender_connection.hpp
@@ -87,8 +87,10 @@ namespace hpx::parcelset::policies::lci {
             HPX_ASSERT(!postprocess_handler_);
             HPX_ASSERT(!buffer_.data_.empty());
 
+#if defined(HPX_HAVE_PARCELPORT_COUNTERS)
             buffer_.data_point_.time_ =
                 hpx::chrono::high_resolution_clock::now();
+#endif
             chunks_idx_ = 0;
             tag_ = acquire_tag(sender_);
             header_ = header(buffer_, tag_);
@@ -288,10 +290,12 @@ namespace hpx::parcelset::policies::lci {
             error_code ec;
             handler_(ec);
             handler_.reset();
+#if defined(HPX_HAVE_PARCELPORT_COUNTERS)
             buffer_.data_point_.time_ =
                 hpx::chrono::high_resolution_clock::now() -
                 buffer_.data_point_.time_;
             pp_->add_sent_data(buffer_.data_point_);
+#endif
             buffer_.clear();
 
             state_ = initialized;

--- a/libs/full/parcelport_libfabric/src/rma_receiver.cpp
+++ b/libs/full/parcelport_libfabric/src/rma_receiver.cpp
@@ -138,10 +138,11 @@ namespace hpx::parcelset::policies::libfabric {
 
         buffer.num_chunks_ = std::make_pair(zc_chunks, oo_chunks);
         buffer.data_size_ = header_->message_size();
+#if defined(HPX_HAVE_PARCELPORT_COUNTERS)
         parcelset::data_point& data = buffer.data_point_;
-
         data.bytes_ = static_cast<std::size_t>(header_->message_size());
         data.time_ = hpx::chrono::high_resolution_clock::now() - start_time_;
+#endif
         LOG_DEBUG_MSG("receiver "
             << hexpointer(this)
             << "calling parcel decode for complete NORMAL parcel");
@@ -472,11 +473,11 @@ namespace hpx::parcelset::policies::libfabric {
 
         buffer.num_chunks_ = std::make_pair(zc_chunks, oo_chunks);
         buffer.data_size_ = header_->message_size();
+#if defined(HPX_HAVE_PARCELPORT_COUNTERS)
         parcelset::data_point& data = buffer.data_point_;
-
         data.bytes_ = static_cast<std::size_t>(header_->message_size());
         data.time_ = hpx::chrono::high_resolution_clock::now() - start_time_;
-
+#endif
         LOG_DEBUG_MSG("receiver "
             << hexpointer(this)
             << "calling parcel decode for ZEROCOPY complete parcel");

--- a/libs/full/parcelport_libfabric/src/sender.cpp
+++ b/libs/full/parcelport_libfabric/src/sender.cpp
@@ -29,7 +29,9 @@ namespace hpx::parcelset::policies::libfabric {
     // The main message send routine
     void sender::async_write_impl()
     {
+#if defined(HPX_HAVE_PARCELPORT_COUNTERS)
         buffer_.data_point_.time_ = hpx::chrono::high_resolution_clock::now();
+#endif
         HPX_ASSERT(message_region_ == nullptr);
         HPX_ASSERT(completion_count_ == 0);
         // increment counter of total messages sent
@@ -267,9 +269,11 @@ namespace hpx::parcelset::policies::libfabric {
             memory_pool_->deallocate(region);
         }
         rma_regions_.clear();
+#if defined(HPX_HAVE_PARCELPORT_COUNTERS)
         buffer_.data_point_.time_ = hpx::chrono::high_resolution_clock::now() -
             buffer_.data_point_.time_;
         parcelport_->add_sent_data(buffer_.data_point_);
+#endif
         postprocess_handler_(this);
     }
 

--- a/libs/full/parcelport_mpi/include/hpx/parcelport_mpi/receiver_connection.hpp
+++ b/libs/full/parcelport_mpi/include/hpx/parcelport_mpi/receiver_connection.hpp
@@ -56,11 +56,11 @@ namespace hpx::parcelset::policies::mpi {
           , pp_(pp)
         {
             header_.assert_valid();
-
+#if defined(HPX_HAVE_PARCELPORT_COUNTERS)
             parcelset::data_point& data = buffer_.data_point_;
             data.time_ = timer_.elapsed_nanoseconds();
             data.bytes_ = static_cast<std::size_t>(header_.numbytes());
-
+#endif
             buffer_.data_.resize(static_cast<std::size_t>(header_.size()));
             buffer_.num_chunks_ = header_.num_chunks();
         }
@@ -180,10 +180,10 @@ namespace hpx::parcelset::policies::mpi {
             {
                 return false;
             }
-
+#if defined(HPX_HAVE_PARCELPORT_COUNTERS)
             parcelset::data_point& data = buffer_.data_point_;
             data.time_ = timer_.elapsed_nanoseconds() - data.time_;
-
+#endif
             {
                 util::mpi_environment::scoped_lock l;
                 MPI_Isend(&tag_, 1, MPI_INT, src_, 1,
@@ -229,8 +229,9 @@ namespace hpx::parcelset::policies::mpi {
             return false;
         }
 
+#if defined(HPX_HAVE_PARCELPORT_COUNTERS)
         hpx::chrono::high_resolution_timer timer_;
-
+#endif
         connection_state state_;
 
         int src_;

--- a/libs/full/parcelport_mpi/include/hpx/parcelport_mpi/sender_connection.hpp
+++ b/libs/full/parcelport_mpi/include/hpx/parcelport_mpi/sender_connection.hpp
@@ -94,8 +94,10 @@ namespace hpx::parcelset::policies::mpi {
             HPX_ASSERT(!postprocess_handler_);
             HPX_ASSERT(!buffer_.data_.empty());
 
+#if defined(HPX_HAVE_PARCELPORT_COUNTERS)
             buffer_.data_point_.time_ =
                 hpx::chrono::high_resolution_clock::now();
+#endif
             request_ptr_ = nullptr;
             chunks_idx_ = 0;
             tag_ = acquire_tag(sender_);
@@ -249,10 +251,12 @@ namespace hpx::parcelset::policies::mpi {
             error_code ec(throwmode::lightweight);
             handler_(ec);
             handler_.reset();
+#if defined(HPX_HAVE_PARCELPORT_COUNTERS)
             buffer_.data_point_.time_ =
                 hpx::chrono::high_resolution_clock::now() -
                 buffer_.data_point_.time_;
             pp_->add_sent_data(buffer_.data_point_);
+#endif
             buffer_.clear();
 
             state_ = initialized;

--- a/libs/full/parcelset/include/hpx/parcelset/encode_parcels.hpp
+++ b/libs/full/parcelset/include/hpx/parcelset/encode_parcels.hpp
@@ -91,10 +91,11 @@ namespace hpx::parcelset {
             LPT_(debug) << binary_archive_content(buffer);
 #endif
 
+#if defined(HPX_HAVE_PARCELPORT_COUNTERS)
             parcelset::data_point& data = buffer.data_point_;
             data.bytes_ = buffer.data_.size();
             data.raw_bytes_ = arg_size;
-
+#endif
             // prepare chunk data for transmission, the transmission_chunks data
             // first holds all zero-copy, then all non-zero-copy chunk infos
             using transmission_chunk_type =
@@ -182,8 +183,9 @@ namespace hpx::parcelset {
                 buffer.chunks_.reserve(num_chunks);
 
                 // mark start of serialization
+#if defined(HPX_HAVE_PARCELPORT_COUNTERS)
                 hpx::chrono::high_resolution_timer timer;
-
+#endif
                 {
                     // Serialize the data
                     if (filter.get() != nullptr)
@@ -200,7 +202,8 @@ namespace hpx::parcelset {
 
                     for (std::size_t i = 0; i != parcels_sent; ++i)
                     {
-#if defined(HPX_HAVE_PARCELPORT_ACTION_COUNTERS)
+#if defined(HPX_HAVE_PARCELPORT_COUNTERS) &&                                   \
+    defined(HPX_HAVE_PARCELPORT_ACTION_COUNTERS)
                         std::size_t archive_pos = archive.current_pos();
                         std::int64_t serialize_time =
                             timer.elapsed_nanoseconds();
@@ -217,7 +220,8 @@ namespace hpx::parcelset {
 
                         archive << ps[i];
 
-#if defined(HPX_HAVE_PARCELPORT_ACTION_COUNTERS)
+#if defined(HPX_HAVE_PARCELPORT_COUNTERS) &&                                   \
+    defined(HPX_HAVE_PARCELPORT_ACTION_COUNTERS)
                         parcelset::data_point action_data;
                         action_data.bytes_ =
                             archive.current_pos() - archive_pos;
@@ -234,8 +238,10 @@ namespace hpx::parcelset {
                 }
 
                 // store the time required for serialization
+#if defined(HPX_HAVE_PARCELPORT_COUNTERS)
                 buffer.data_point_.serialization_time_ =
                     timer.elapsed_nanoseconds();
+#endif
             }
             catch (hpx::exception const& e)
             {
@@ -276,7 +282,9 @@ namespace hpx::parcelset {
             return 0;
         }
 
+#if defined(HPX_HAVE_PARCELPORT_COUNTERS)
         buffer.data_point_.num_parcels_ = parcels_sent;
+#endif
         detail::encode_finalize(buffer, arg_size);
 
         return parcels_sent;

--- a/libs/full/parcelset/include/hpx/parcelset/parcel_buffer.hpp
+++ b/libs/full/parcelset/include/hpx/parcelset/parcel_buffer.hpp
@@ -70,7 +70,9 @@ namespace hpx::parcelset {
             size_ = 0;
             data_size_ = 0;
             header_size_ = 0;
+#if defined(HPX_HAVE_PARCELPORT_COUNTERS)
             data_point_ = parcelset::data_point();
+#endif
         }
 
         BufferType data_;
@@ -86,7 +88,9 @@ namespace hpx::parcelset {
         std::uint64_t header_size_;
 
         /// Counters and their data containers.
+#if defined(HPX_HAVE_PARCELPORT_COUNTERS)
         parcelset::data_point data_point_;
+#endif
     };
 }    // namespace hpx::parcelset
 

--- a/libs/full/parcelset/include/hpx/parcelset/parcelhandler.hpp
+++ b/libs/full/parcelset/include/hpx/parcelset/parcelhandler.hpp
@@ -263,6 +263,10 @@ namespace hpx::parcelset {
         ///////////////////////////////////////////////////////////////////////
         // Performance counter data
 
+        // number of parcels routed
+        std::int64_t get_parcel_routed_count(bool reset);
+
+#if defined(HPX_HAVE_PARCELPORT_COUNTERS)
         // number of parcels sent
         std::int64_t get_parcel_send_count(
             std::string const& pp_type, bool reset) const;
@@ -270,9 +274,6 @@ namespace hpx::parcelset {
         // number of messages sent
         std::int64_t get_message_send_count(
             std::string const& pp_type, bool reset) const;
-
-        // number of parcels routed
-        std::int64_t get_parcel_routed_count(bool reset);
 
         // number of parcels received
         std::int64_t get_parcel_receive_count(
@@ -323,8 +324,9 @@ namespace hpx::parcelset {
 
         std::int64_t get_buffer_allocate_time_received(
             std::string const& pp_type, bool reset) const;
-
-#if defined(HPX_HAVE_PARCELPORT_ACTION_COUNTERS)
+#endif
+#if defined(HPX_HAVE_PARCELPORT_COUNTERS) &&                                   \
+    defined(HPX_HAVE_PARCELPORT_ACTION_COUNTERS)
         // same as above, just separated data for each action
         // number of parcels sent
         std::int64_t get_action_parcel_send_count(std::string const& pp_type,

--- a/libs/full/parcelset/src/parcelhandler.cpp
+++ b/libs/full/parcelset/src/parcelhandler.cpp
@@ -978,6 +978,12 @@ namespace hpx::parcelset {
     ///////////////////////////////////////////////////////////////////////////
     // Performance counter data
 
+    // number of parcels routed
+    std::int64_t parcelhandler::get_parcel_routed_count(bool reset)
+    {
+        return util::get_and_reset_value(count_routed_, reset);
+    }
+#if defined(HPX_HAVE_PARCELPORT_COUNTERS)
     // number of parcels sent
     std::int64_t parcelhandler::get_parcel_send_count(
         std::string const& pp_type, bool reset) const
@@ -985,12 +991,6 @@ namespace hpx::parcelset {
         error_code ec(throwmode::lightweight);
         parcelport* pp = find_parcelport(pp_type, ec);
         return pp ? pp->get_parcel_send_count(reset) : 0;
-    }
-
-    // number of parcels routed
-    std::int64_t parcelhandler::get_parcel_routed_count(bool reset)
-    {
-        return util::get_and_reset_value(count_routed_, reset);
     }
 
     // number of messages sent
@@ -1111,18 +1111,8 @@ namespace hpx::parcelset {
         return pp ? pp->get_buffer_allocate_time_received(reset) : 0;
     }
 
-    // connection stack statistics
-    std::int64_t parcelhandler::get_connection_cache_statistics(
-        std::string const& pp_type,
-        parcelport::connection_cache_statistics_type stat_type,
-        bool reset) const
-    {
-        error_code ec(throwmode::lightweight);
-        parcelport* pp = find_parcelport(pp_type, ec);
-        return pp ? pp->get_connection_cache_statistics(stat_type, reset) : 0;
-    }
-
-#if defined(HPX_HAVE_PARCELPORT_ACTION_COUNTERS)
+#if defined(HPX_HAVE_PARCELPORT_COUNTERS) &&                                   \
+    defined(HPX_HAVE_PARCELPORT_ACTION_COUNTERS)
     // same as above, just separated data for each action
     // number of parcels sent
     std::int64_t parcelhandler::get_action_parcel_send_count(
@@ -1182,6 +1172,17 @@ namespace hpx::parcelset {
         return pp ? pp->get_action_data_received(action, reset) : 0;
     }
 #endif
+#endif
+    // connection stack statistics
+    std::int64_t parcelhandler::get_connection_cache_statistics(
+        std::string const& pp_type,
+        parcelport::connection_cache_statistics_type stat_type,
+        bool reset) const
+    {
+        error_code ec(throwmode::lightweight);
+        parcelport* pp = find_parcelport(pp_type, ec);
+        return pp ? pp->get_connection_cache_statistics(stat_type, reset) : 0;
+    }
 
     std::vector<plugins::parcelport_factory_base*>&
     parcelhandler::get_parcelport_factories()

--- a/libs/full/parcelset/tests/unit/put_parcels.cpp
+++ b/libs/full/parcelset/tests/unit/put_parcels.cpp
@@ -274,7 +274,7 @@ int hpx_main(hpx::program_options::variables_map& vm)
         test_task_group_argument(id);
     }
 
-#if defined(HPX_HAVE_NETWORKING)
+#if defined(HPX_HAVE_NETWORKING) && defined(PX_HAVE_PARCELPORT_COUNTERS)
     if (hpx::is_networking_enabled())
     {
         // compare number of parcels with number of messages generated

--- a/libs/full/parcelset_base/include/hpx/parcelset_base/detail/per_action_data_counter.hpp
+++ b/libs/full/parcelset_base/include/hpx/parcelset_base/detail/per_action_data_counter.hpp
@@ -8,7 +8,9 @@
 
 #include <hpx/config.hpp>
 
-#if defined(HPX_HAVE_PARCELPORT_ACTION_COUNTERS) && defined(HPX_HAVE_NETWORKING)
+#if defined(HPX_HAVE_PARCELPORT_COUNTERS) &&                                   \
+    defined(HPX_HAVE_PARCELPORT_ACTION_COUNTERS) &&                            \
+    defined(HPX_HAVE_NETWORKING)
 #include <hpx/modules/hashing.hpp>
 #include <hpx/modules/synchronization.hpp>
 

--- a/libs/full/parcelset_base/include/hpx/parcelset_base/parcelport.hpp
+++ b/libs/full/parcelset_base/include/hpx/parcelset_base/parcelport.hpp
@@ -185,7 +185,7 @@ namespace hpx::parcelset {
             util::runtime_configuration const& ini) const = 0;
 
         /// Performance counter data
-
+#if defined(HPX_HAVE_PARCELPORT_COUNTERS)
         /// number of parcels sent
         std::int64_t get_parcel_send_count(bool reset);
 
@@ -228,10 +228,9 @@ namespace hpx::parcelset {
 
         std::int64_t get_buffer_allocate_time_sent(bool reset);
         std::int64_t get_buffer_allocate_time_received(bool reset);
-
-        std::int64_t get_pending_parcels_count(bool /*reset*/);
-
-#if defined(HPX_HAVE_PARCELPORT_ACTION_COUNTERS)
+#endif
+#if defined(HPX_HAVE_PARCELPORT_COUNTERS) &&                                   \
+    defined(HPX_HAVE_PARCELPORT_ACTION_COUNTERS)
         // same as above, just separated data for each action
         // number of parcels sent
         std::int64_t get_action_parcel_send_count(
@@ -257,14 +256,17 @@ namespace hpx::parcelset {
         // total data received (bytes)
         std::int64_t get_action_data_received(std::string const&, bool reset);
 #endif
+        std::int64_t get_pending_parcels_count(bool /*reset*/);
 
         ///////////////////////////////////////////////////////////////////////
         /// Update performance counter data
+#if defined(HPX_HAVE_PARCELPORT_COUNTERS)
         void add_received_data(parcelset::data_point const& data);
 
         void add_sent_data(parcelset::data_point const& data);
-
-#if defined(HPX_HAVE_PARCELPORT_ACTION_COUNTERS)
+#endif
+#if defined(HPX_HAVE_PARCELPORT_COUNTERS) &&                                   \
+    defined(HPX_HAVE_PARCELPORT_ACTION_COUNTERS)
         void add_received_data(
             char const* action, parcelset::data_point const& data);
 
@@ -313,11 +315,13 @@ namespace hpx::parcelset {
         std::int64_t const max_inbound_message_size_;
         std::int64_t const max_outbound_message_size_;
 
+#if defined(HPX_HAVE_PARCELPORT_COUNTERS)
         // Overall parcel statistics
         parcelset::gatherer parcels_sent_;
         parcelset::gatherer parcels_received_;
-
-#if defined(HPX_HAVE_PARCELPORT_ACTION_COUNTERS)
+#endif
+#if defined(HPX_HAVE_PARCELPORT_COUNTERS) &&                                   \
+    defined(HPX_HAVE_PARCELPORT_ACTION_COUNTERS)
         // Per-action based parcel statistics
         detail::per_action_data_counter action_parcels_sent_;
         detail::per_action_data_counter action_parcels_received_;

--- a/libs/full/parcelset_base/src/detail/per_action_data_counter.cpp
+++ b/libs/full/parcelset_base/src/detail/per_action_data_counter.cpp
@@ -6,7 +6,9 @@
 
 #include <hpx/config.hpp>
 
-#if defined(HPX_HAVE_PARCELPORT_ACTION_COUNTERS) && defined(HPX_HAVE_NETWORKING)
+#if defined(HPX_HAVE_PARCELPORT_COUNTERS) &&                                   \
+    defined(HPX_HAVE_PARCELPORT_ACTION_COUNTERS) &&                            \
+    defined(HPX_HAVE_NETWORKING)
 #include <hpx/parcelset_base/detail/per_action_data_counter.hpp>
 
 #include <cstdint>

--- a/libs/full/performance_counters/include/hpx/performance_counters/counter_creators.hpp
+++ b/libs/full/performance_counters/include/hpx/performance_counters/counter_creators.hpp
@@ -146,7 +146,8 @@ namespace hpx { namespace performance_counters {
         counter_info const&, discover_counter_func const&,
         discover_counters_mode, error_code&);
 
-#if defined(HPX_HAVE_PARCELPORT_ACTION_COUNTERS)
+#if defined(HPX_HAVE_PARCELPORT_COUNTERS) &&                                   \
+    defined(HPX_HAVE_PARCELPORT_ACTION_COUNTERS)
     ///////////////////////////////////////////////////////////////////////////
     // Creation function for per-action parcel data counters
     HPX_EXPORT naming::gid_type per_action_data_counter_creator(

--- a/libs/full/performance_counters/include/hpx/performance_counters/per_action_data_counter_discoverer.hpp
+++ b/libs/full/performance_counters/include/hpx/performance_counters/per_action_data_counter_discoverer.hpp
@@ -8,7 +8,9 @@
 
 #include <hpx/config.hpp>
 
-#if defined(HPX_HAVE_PARCELPORT_ACTION_COUNTERS) && defined(HPX_HAVE_NETWORKING)
+#if defined(HPX_HAVE_PARCELPORT_COUNTERS) &&                                   \
+    defined(HPX_HAVE_PARCELPORT_ACTION_COUNTERS) &&                            \
+    defined(HPX_HAVE_NETWORKING)
 #include <hpx/actions_base/detail/per_action_data_counter_registry.hpp>
 #include <hpx/performance_counters/counters_fwd.hpp>
 

--- a/libs/full/performance_counters/src/parcelhandler_counter_types.cpp
+++ b/libs/full/performance_counters/src/parcelhandler_counter_types.cpp
@@ -24,6 +24,7 @@ namespace hpx::performance_counters {
     void register_parcelhandler_counter_types(
         parcelset::parcelhandler& ph, std::string const& pp_type)
     {
+#if defined(HPX_HAVE_PARCELPORT_COUNTERS)
         if (!ph.is_networking_enabled())
         {
             return;
@@ -33,8 +34,8 @@ namespace hpx::performance_counters {
         using placeholders::_2;
 
         using parcelset::parcelhandler;
-
-#if defined(HPX_HAVE_PARCELPORT_ACTION_COUNTERS)
+#if defined(HPX_HAVE_PARCELPORT_COUNTERS) &&                                   \
+    defined(HPX_HAVE_PARCELPORT_ACTION_COUNTERS)
         hpx::function<std::int64_t(std::string const&, bool)> num_parcel_sends(
             hpx::bind_front(
                 &parcelhandler::get_action_parcel_send_count, &ph, pp_type));
@@ -58,7 +59,8 @@ namespace hpx::performance_counters {
         hpx::function<std::int64_t(bool)> receiving_time(
             hpx::bind_front(&parcelhandler::get_receiving_time, &ph, pp_type));
 
-#if defined(HPX_HAVE_PARCELPORT_ACTION_COUNTERS)
+#if defined(HPX_HAVE_PARCELPORT_COUNTERS) &&                                   \
+    defined(HPX_HAVE_PARCELPORT_ACTION_COUNTERS)
         hpx::function<std::int64_t(std::string const&, bool)>
             sending_serialization_time(hpx::bind_front(
                 &parcelhandler::get_action_sending_serialization_time, &ph,
@@ -76,7 +78,8 @@ namespace hpx::performance_counters {
                 &ph, pp_type));
 #endif
 
-#if defined(HPX_HAVE_PARCELPORT_ACTION_COUNTERS)
+#if defined(HPX_HAVE_PARCELPORT_COUNTERS) &&                                   \
+    defined(HPX_HAVE_PARCELPORT_ACTION_COUNTERS)
         hpx::function<std::int64_t(std::string const&, bool)> data_sent(
             hpx::bind_front(
                 &parcelhandler::get_action_data_sent, &ph, pp_type));
@@ -112,7 +115,8 @@ namespace hpx::performance_counters {
                         "connection type for the referenced locality",
                         pp_type),
                     HPX_PERFORMANCE_COUNTER_V1,
-#if defined(HPX_HAVE_PARCELPORT_ACTION_COUNTERS)
+#if defined(HPX_HAVE_PARCELPORT_COUNTERS) &&                                   \
+    defined(HPX_HAVE_PARCELPORT_ACTION_COUNTERS)
                     hpx::bind(
                         &performance_counters::per_action_data_counter_creator,
                         _1, HPX_MOVE(num_parcel_sends), _2),
@@ -132,7 +136,8 @@ namespace hpx::performance_counters {
                         "connection type for the referenced locality",
                         pp_type),
                     HPX_PERFORMANCE_COUNTER_V1,
-#if defined(HPX_HAVE_PARCELPORT_ACTION_COUNTERS)
+#if defined(HPX_HAVE_PARCELPORT_COUNTERS) &&                                   \
+    defined(HPX_HAVE_PARCELPORT_ACTION_COUNTERS)
                     hpx::bind(
                         &performance_counters::per_action_data_counter_creator,
                         _1, HPX_MOVE(num_parcel_receives), _2),
@@ -203,7 +208,8 @@ namespace hpx::performance_counters {
                         "referenced locality",
                         pp_type),
                     HPX_PERFORMANCE_COUNTER_V1,
-#if defined(HPX_HAVE_PARCELPORT_ACTION_COUNTERS)
+#if defined(HPX_HAVE_PARCELPORT_COUNTERS) &&                                   \
+    defined(HPX_HAVE_PARCELPORT_ACTION_COUNTERS)
                     hpx::bind(
                         &performance_counters::per_action_data_counter_creator,
                         _1, HPX_MOVE(sending_serialization_time), _2),
@@ -223,7 +229,8 @@ namespace hpx::performance_counters {
                         "referenced locality",
                         pp_type),
                     HPX_PERFORMANCE_COUNTER_V1,
-#if defined(HPX_HAVE_PARCELPORT_ACTION_COUNTERS)
+#if defined(HPX_HAVE_PARCELPORT_COUNTERS) &&                                   \
+    defined(HPX_HAVE_PARCELPORT_ACTION_COUNTERS)
                     hpx::bind(
                         &performance_counters::per_action_data_counter_creator,
                         _1, HPX_MOVE(receiving_serialization_time), _2),
@@ -273,7 +280,8 @@ namespace hpx::performance_counters {
                         "type by the referenced locality",
                         pp_type),
                     HPX_PERFORMANCE_COUNTER_V1,
-#if defined(HPX_HAVE_PARCELPORT_ACTION_COUNTERS)
+#if defined(HPX_HAVE_PARCELPORT_COUNTERS) &&                                   \
+    defined(HPX_HAVE_PARCELPORT_ACTION_COUNTERS)
                     hpx::bind(
                         &performance_counters::per_action_data_counter_creator,
                         _1, HPX_MOVE(data_sent), _2),
@@ -294,7 +302,8 @@ namespace hpx::performance_counters {
                         "type by the referenced locality",
                         pp_type),
                     HPX_PERFORMANCE_COUNTER_V1,
-#if defined(HPX_HAVE_PARCELPORT_ACTION_COUNTERS)
+#if defined(HPX_HAVE_PARCELPORT_COUNTERS) &&                                   \
+    defined(HPX_HAVE_PARCELPORT_ACTION_COUNTERS)
                     hpx::bind(
                         &performance_counters::per_action_data_counter_creator,
                         _1, HPX_MOVE(data_received), _2),
@@ -334,6 +343,10 @@ namespace hpx::performance_counters {
 
         performance_counters::install_counter_types(
             counter_types, sizeof(counter_types) / sizeof(counter_types[0]));
+#else
+        HPX_UNUSED(ph);
+        HPX_UNUSED(pp_type);
+#endif
     }
 
     ///////////////////////////////////////////////////////////////////////////

--- a/libs/full/performance_counters/src/per_action_data_counter_discoverer.cpp
+++ b/libs/full/performance_counters/src/per_action_data_counter_discoverer.cpp
@@ -6,7 +6,9 @@
 
 #include <hpx/config.hpp>
 
-#if defined(HPX_HAVE_PARCELPORT_ACTION_COUNTERS) && defined(HPX_HAVE_NETWORKING)
+#if defined(HPX_HAVE_PARCELPORT_COUNTERS) &&                                   \
+    defined(HPX_HAVE_PARCELPORT_ACTION_COUNTERS) &&                            \
+    defined(HPX_HAVE_NETWORKING)
 #include <hpx/actions_base/detail/invocation_count_registry.hpp>
 #include <hpx/modules/errors.hpp>
 #include <hpx/performance_counters/counter_creators.hpp>

--- a/libs/full/performance_counters/src/server/per_action_data_counters.cpp
+++ b/libs/full/performance_counters/src/server/per_action_data_counters.cpp
@@ -6,7 +6,9 @@
 
 #include <hpx/config.hpp>
 
-#if defined(HPX_HAVE_PARCELPORT_ACTION_COUNTERS) && defined(HPX_HAVE_NETWORKING)
+#if defined(HPX_HAVE_PARCELPORT_COUNTERS) &&                                   \
+    defined(HPX_HAVE_PARCELPORT_ACTION_COUNTERS) &&                            \
+    defined(HPX_HAVE_NETWORKING)
 #include <hpx/functional/bind_front.hpp>
 #include <hpx/functional/function.hpp>
 #include <hpx/performance_counters/counter_creators.hpp>


### PR DESCRIPTION
Turn on/off the performance counters related to parcelport
Those counters can be expensive due to the locks when gathering data