### PR TITLE
Block fork join executor

### DIFF
--- a/libs/core/affinity/src/affinity_data.cpp
+++ b/libs/core/affinity/src/affinity_data.cpp
@@ -206,7 +206,7 @@ namespace hpx { namespace threads { namespace policies { namespace detail {
             return ret;
         }
 
-        for (std::size_t thread_num = 0; thread_num < num_threads_;
+        for (std::size_t thread_num = 0; thread_num != num_threads_;
              ++thread_num)
         {
             ret |= get_pu_mask(topo, thread_num);
@@ -230,7 +230,7 @@ namespace hpx { namespace threads { namespace policies { namespace detail {
             threads::resize(pu_mask, hardware_concurrency());
             threads::set(pu_mask, pu_num);
 
-            for (std::size_t num_thread = 0; num_thread < num_threads_;
+            for (std::size_t num_thread = 0; num_thread != num_threads_;
                  ++num_thread)
             {
                 mask_cref_type affinity_mask = get_pu_mask(topo, num_thread);

--- a/libs/core/algorithms/tests/performance/foreach_report.cpp
+++ b/libs/core/algorithms/tests/performance/foreach_report.cpp
@@ -13,6 +13,7 @@
 #include <hpx/local/chrono.hpp>
 #include <hpx/local/execution.hpp>
 #include <hpx/local/init.hpp>
+#include <hpx/modules/compute_local.hpp>
 #include <hpx/modules/testing.hpp>
 
 #include "foreach_scaling_helpers.hpp"

--- a/libs/core/allocator_support/include/hpx/allocator_support/internal_allocator.hpp
+++ b/libs/core/allocator_support/include/hpx/allocator_support/internal_allocator.hpp
@@ -51,7 +51,7 @@ namespace hpx { namespace util {
         internal_allocator() = default;
 
         template <typename U>
-        explicit internal_allocator(internal_allocator<U> const&)
+        internal_allocator(internal_allocator<U> const&)
         {
         }
 

--- a/libs/core/compute_local/CMakeLists.txt
+++ b/libs/core/compute_local/CMakeLists.txt
@@ -12,6 +12,7 @@ set(compute_local_headers
     hpx/compute_local/host.hpp
     hpx/compute_local/host/block_allocator.hpp
     hpx/compute_local/host/block_executor.hpp
+    hpx/compute_local/host/block_fork_join_executor.hpp
     hpx/compute_local/host/get_targets.hpp
     hpx/compute_local/host/numa_allocator.hpp
     hpx/compute_local/host/numa_binding_allocator.hpp

--- a/libs/core/compute_local/include/hpx/compute_local/host/block_allocator.hpp
+++ b/libs/core/compute_local/include/hpx/compute_local/host/block_allocator.hpp
@@ -1,7 +1,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 //  Copyright (c) 2020 ETH Zurich
 //  Copyright (c) 2016 Thomas Heller
-//  Copyright (c) 2016 Hartmut Kaiser
+//  Copyright (c) 2016-2022 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -38,8 +38,8 @@ namespace hpx { namespace compute { namespace host {
         /// The policy_allocator allocates blocks of memory touched according to
         /// the distribution policy of the given executor.
         template <typename T, typename Policy,
-            typename Enable = typename std::enable_if<
-                hpx::is_execution_policy<Policy>::value>::type>
+            typename Enable =
+                std::enable_if_t<hpx::is_execution_policy_v<Policy>>>
         struct policy_allocator
         {
             using policy_type = Policy;

--- a/libs/core/compute_local/include/hpx/compute_local/host/block_fork_join_executor.hpp
+++ b/libs/core/compute_local/include/hpx/compute_local/host/block_fork_join_executor.hpp
@@ -1,0 +1,278 @@
+//  Copyright (c) 2022 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+/// \file block_fork_join_executor.hpp
+
+#pragma once
+
+#include <hpx/config.hpp>
+#include <hpx/compute_local/host/numa_domains.hpp>
+#include <hpx/compute_local/host/target.hpp>
+#include <hpx/coroutines/thread_enums.hpp>
+#include <hpx/errors/try_catch_exception_ptr.hpp>
+#include <hpx/execution/executors/execution_parameters.hpp>
+#include <hpx/execution_base/this_thread.hpp>
+#include <hpx/execution_base/traits/is_executor.hpp>
+#include <hpx/executors/fork_join_executor.hpp>
+#include <hpx/iterator_support/counting_shape.hpp>
+#include <hpx/iterator_support/iterator_range.hpp>
+#include <hpx/resource_partitioner/detail/partitioner.hpp>
+#include <hpx/topology/cpu_mask.hpp>
+
+#include <chrono>
+#include <cstddef>
+#include <exception>
+#include <iterator>
+#include <string>
+#include <type_traits>
+#include <vector>
+
+namespace hpx::execution::experimental {
+
+    /// \brief An executor with fork-join (blocking) semantics.
+    ///
+    /// The block_fork_join_executor creates on construction a set of worker
+    /// threads that are kept alive for the duration of the executor. Copying
+    /// the executor has reference semantics, i.e. copies of a
+    /// fork_join_executor hold a reference to the worker threads of the
+    /// original instance. Scheduling work through the executor concurrently
+    /// from different threads is undefined behaviour.
+    ///
+    /// The executor keeps a set of worker threads alive for the lifetime of the
+    /// executor, meaning other work will not be executed while the executor is
+    /// busy or waiting for work. The executor has a customizable delay after
+    /// which it will yield to other work.  Since starting and resuming the
+    /// worker threads is a slow operation the executor should be reused
+    /// whenever possible for multiple adjacent parallel algorithms or
+    /// invocations of bulk_(a)sync_execute.
+    ///
+    /// This behaviour is similar to the plain \a fork_join_executor except that
+    /// the block_fork_join_executor creates a hierarchy of fork_join_executors,
+    /// one for each target used to initialize it.
+    class block_fork_join_executor
+    {
+        static hpx::threads::mask_type cores_for_targets(
+            std::vector<compute::host::target> const& targets)
+        {
+            // This makes sure that each given set of targets gets exactly one
+            // core assigned that will be used as the 'main' thread for the
+            // corresponding fork_join_executor instance. This makes also sure
+            // that the executing (current) thread is associated with one of the
+            // targets.
+            auto& rp = hpx::resource::get_partitioner();
+            std::size_t this_pu = rp.get_pu_num(hpx::get_worker_thread_num());
+            hpx::threads::mask_type mask(hpx::threads::hardware_concurrency());
+            bool this_thread_is_represented = false;
+            for (auto const& t : targets)
+            {
+                auto target_mask = t.native_handle().get_device();
+                if (!this_thread_is_represented &&
+                    hpx::threads::test(target_mask, this_pu))
+                {
+                    hpx::threads::set(mask, this_pu);
+                    this_thread_is_represented = true;
+                }
+                else
+                {
+                    hpx::threads::set(
+                        mask, hpx::threads::find_first(target_mask));
+                }
+            }
+
+            // The block_fork_join_executor will expose bad performance if the
+            // current thread is not part of any of the given targets.
+            if (!this_thread_is_represented)
+            {
+                HPX_THROW_EXCEPTION(bad_parameter,
+                    "block_fork_join_executor::cores_for_targets",
+                    "The thread used to initialize the "
+                    "block_fork_join_executor should be part of at least one "
+                    "of the given targets");
+            }
+            return mask;
+        }
+
+    public:
+        /// \cond NOINTERNAL
+        using execution_category = hpx::execution::parallel_execution_tag;
+        using executor_parameters_type = hpx::execution::static_chunk_size;
+
+        bool operator==(block_fork_join_executor const& rhs) const noexcept
+        {
+            return exec_ == rhs.exec_ && block_execs_ == rhs.block_execs_;
+        }
+
+        bool operator!=(block_fork_join_executor const& rhs) const noexcept
+        {
+            return !(*this == rhs);
+        }
+
+        block_fork_join_executor const& context() const noexcept
+        {
+            return *this;
+        }
+        /// \endcond
+
+        /// \brief Construct a block_fork_join_executor.
+        ///
+        /// \param priority The priority of the worker threads.
+        /// \param stacksize The stacksize of the worker threads. Must not be
+        ///                  nostack.
+        /// \param schedule The loop schedule of the parallel regions.
+        /// \param yield_delay The time after which the executor yields to
+        ///        other work if it hasn't received any new work for bulk
+        ///        execution.
+        ///
+        /// \note   This constructor will create one fork_join_executor for
+        ///         each numa domain
+        explicit block_fork_join_executor(
+            threads::thread_priority priority = threads::thread_priority::bound,
+            threads::thread_stacksize stacksize =
+                threads::thread_stacksize::small_,
+            fork_join_executor::loop_schedule schedule =
+                fork_join_executor::loop_schedule::static_,
+            std::chrono::nanoseconds yield_delay = std::chrono::milliseconds(1))
+          : block_fork_join_executor(compute::host::numa_domains(), priority,
+                stacksize, schedule, yield_delay)
+        {
+        }
+
+        /// \brief Construct a block_fork_join_executor.
+        ///
+        /// \param targets  The list of targets to use for thread placement
+        /// \param priority The priority of the worker threads.
+        /// \param stacksize The stacksize of the worker threads. Must not be
+        ///                  nostack.
+        /// \param schedule The loop schedule of the parallel regions.
+        /// \param yield_delay The time after which the executor yields to
+        ///        other work if it hasn't received any new work for bulk
+        ///        execution.
+        ///
+        /// \note   This constructor will create one fork_join_executor for
+        ///         each given target
+        explicit block_fork_join_executor(
+            std::vector<compute::host::target> const& targets,
+            threads::thread_priority priority = threads::thread_priority::bound,
+            threads::thread_stacksize stacksize =
+                threads::thread_stacksize::small_,
+            fork_join_executor::loop_schedule schedule =
+                fork_join_executor::loop_schedule::static_,
+            std::chrono::nanoseconds yield_delay = std::chrono::milliseconds(1))
+          : exec_(cores_for_targets(targets), priority, stacksize,
+                fork_join_executor::loop_schedule::static_, yield_delay)
+        {
+            block_execs_.reserve(targets.size());
+            for (std::size_t i = 0; i != targets.size(); ++i)
+            {
+                block_execs_.emplace_back(
+                    fork_join_executor::init_mode::no_init);
+            }
+
+            auto init_f = [&](std::size_t index) {
+                // create the sub-executors
+                block_execs_[index] = fork_join_executor(
+                    targets[index].native_handle().get_device(), priority,
+                    stacksize, schedule, yield_delay);
+            };
+            exec_.bulk_sync_execute(
+                init_f, hpx::util::detail::make_counting_shape(targets.size()));
+        }
+
+        template <typename F, typename S, typename... Ts>
+        void bulk_sync_execute(F&& f, S const& shape, Ts&&... ts)
+        {
+            std::size_t num_targets = block_execs_.size();
+
+            auto outer_func = [&](std::size_t index, auto&& f,
+                                  auto const& shape, auto&&... ts) {
+                // calculate the new shape dimensions
+                std::size_t size = std::size(shape);
+
+                auto const part_begin = (index * size) / num_targets;
+                auto const part_end = ((index + 1) * size) / num_targets;
+
+                auto inner_shape = hpx::util::make_iterator_range(
+                    std::next(std::begin(shape), part_begin),
+                    std::next(std::begin(shape), part_end));
+
+                // invoke bulk_sync_execute on one of the inner executors
+                block_execs_[index].bulk_sync_execute(
+                    HPX_FORWARD(decltype(f), f), inner_shape,
+                    HPX_FORWARD(decltype(ts), ts)...);
+            };
+            auto outer_shape =
+                hpx::util::detail::make_counting_shape(num_targets);
+
+            exec_.bulk_sync_execute(outer_func, outer_shape, HPX_FORWARD(F, f),
+                shape, HPX_FORWARD(Ts, ts)...);
+        }
+
+        template <typename F, typename S, typename... Ts>
+        decltype(auto) bulk_async_execute(F&& f, S const& shape, Ts&&... ts)
+        {
+            // Forward to the synchronous version as we can't create
+            // futures to the completion of the parallel region (this HPX
+            // thread participates in computation).
+            return hpx::detail::try_catch_exception_ptr(
+                [&]() {
+                    bulk_sync_execute(
+                        HPX_FORWARD(F, f), shape, HPX_FORWARD(Ts, ts)...);
+                    return hpx::make_ready_future();
+                },
+                [&](std::exception_ptr&& ep) {
+                    return hpx::make_exceptional_future<void>(HPX_MOVE(ep));
+                });
+        }
+
+        friend block_fork_join_executor tag_invoke(
+            hpx::execution::experimental::with_annotation_t,
+            block_fork_join_executor const& exec,
+            char const* annotation) noexcept
+        {
+            auto exec_with_annotation = exec;
+            hpx::execution::experimental::with_annotation(
+                exec_with_annotation.exec_, annotation);
+            return exec_with_annotation;
+        }
+
+        friend block_fork_join_executor tag_invoke(
+            hpx::execution::experimental::with_annotation_t,
+            block_fork_join_executor const& exec, std::string annotation)
+        {
+            auto exec_with_annotation = exec;
+            hpx::execution::experimental::with_annotation(
+                exec_with_annotation.exec_, HPX_MOVE(annotation));
+            return exec_with_annotation;
+        }
+
+        friend char const* tag_invoke(
+            hpx::execution::experimental::get_annotation_t,
+            block_fork_join_executor const& exec) noexcept
+        {
+            return hpx::execution::experimental::get_annotation(exec.exec_);
+        }
+
+    private:
+        fork_join_executor exec_;
+        std::vector<fork_join_executor> block_execs_;
+    };
+}    // namespace hpx::execution::experimental
+
+namespace hpx::parallel::execution {
+    /// \cond NOINTERNAL
+    template <>
+    struct is_bulk_one_way_executor<
+        hpx::execution::experimental::block_fork_join_executor> : std::true_type
+    {
+    };
+
+    template <>
+    struct is_bulk_two_way_executor<
+        hpx::execution::experimental::block_fork_join_executor> : std::true_type
+    {
+    };
+    /// \endcond
+}    // namespace hpx::parallel::execution

--- a/libs/core/compute_local/tests/unit/CMakeLists.txt
+++ b/libs/core/compute_local/tests/unit/CMakeLists.txt
@@ -1,11 +1,11 @@
 # Copyright (c) 2019 John Biddiscombe
-# Copyright (c) 2016 Hartmut Kaiser
+# Copyright (c) 2016-2022 Hartmut Kaiser
 #
 # SPDX-License-Identifier: BSL-1.0
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-set(tests block_allocator numa_allocator)
+set(tests block_allocator block_fork_join_executor numa_allocator)
 
 # NB. threads = -2 = threads = 'cores' NB. threads = -1 = threads = 'all'
 set(numa_allocator_PARAMETERS

--- a/libs/core/compute_local/tests/unit/block_fork_join_executor.cpp
+++ b/libs/core/compute_local/tests/unit/block_fork_join_executor.cpp
@@ -153,28 +153,6 @@ void test_bulk_async_exception(ExecutorArgs&&... args)
     HPX_TEST(caught_exception);
 }
 
-void static_check_executor()
-{
-    using namespace hpx::traits;
-
-    static_assert(!has_sync_execute_member<block_fork_join_executor>::value,
-        "!has_sync_execute_member<block_fork_join_executor>::value");
-    static_assert(!has_async_execute_member<block_fork_join_executor>::value,
-        "!has_async_execute_member<block_fork_join_executor>::value");
-    static_assert(!has_then_execute_member<block_fork_join_executor>::value,
-        "!has_then_execute_member<block_fork_join_executor>::value");
-    static_assert(has_bulk_sync_execute_member<block_fork_join_executor>::value,
-        "has_bulk_sync_execute_member<block_fork_join_executor>::value");
-    static_assert(
-        has_bulk_async_execute_member<block_fork_join_executor>::value,
-        "has_bulk_async_execute_member<block_fork_join_executor>::value");
-    static_assert(
-        !has_bulk_then_execute_member<block_fork_join_executor>::value,
-        "!has_bulk_then_execute_member<block_fork_join_executor>::value");
-    static_assert(!has_post_member<block_fork_join_executor>::value,
-        "!has_post_member<block_fork_join_executor>::value");
-}
-
 template <typename... ExecutorArgs>
 void test_executor(hpx::threads::thread_priority priority,
     hpx::threads::thread_stacksize stacksize,
@@ -192,8 +170,6 @@ void test_executor(hpx::threads::thread_priority priority,
 ///////////////////////////////////////////////////////////////////////////////
 int hpx_main()
 {
-    static_check_executor();
-
     // thread_stacksize::nostack cannot be used with the block_fork_join_executor
     // because it prevents other work from running when yielding. Using
     // thread_priority::low hangs for unknown reasons.

--- a/libs/core/config/include/hpx/config/compiler_fence.hpp
+++ b/libs/core/config/include/hpx/config/compiler_fence.hpp
@@ -15,7 +15,8 @@
 /// Generates assembly that serves as a fence to the compiler CPU to disable
 /// optimization. Usually implemented in the form of a memory barrier.
 #define HPX_COMPILER_FENCE
-/// Generates assembly the executes a "pause" instruction. Useful in spinning
+
+/// Generates assembly that executes a "pause" instruction. Useful in spinning
 /// loops.
 #define HPX_SMT_PAUSE
 
@@ -46,7 +47,8 @@ extern "C" void _mm_pause();
 // According to: https://stackoverflow.com/questions/5425506/equivalent-of-x86-pause-instruction-for-ppc
 #define HPX_SMT_PAUSE __asm__ __volatile__("or 27,27,27")
 #elif defined(__arm__)
-#define HPX_SMT_PAUSE __asm__ __volatile__("yield")
+// according to: https://mysqlonarm.github.io/Porting-Optimizing-HPC-for-ARM/
+#define HPX_SMT_PAUSE __asm__ __volatile__("yield" : : : "memory")
 #elif defined(__riscv)
 // According to:
 //

--- a/libs/core/coroutines/src/thread_enums.cpp
+++ b/libs/core/coroutines/src/thread_enums.cpp
@@ -93,6 +93,7 @@ namespace hpx { namespace threads {
             "high (recursive)",
             "boost",
             "high (non-recursive)",
+            "bound",
         };
         // clang-format on
     }    // namespace strings
@@ -100,7 +101,7 @@ namespace hpx { namespace threads {
     char const* get_thread_priority_name(thread_priority priority)
     {
         if (priority < thread_priority::default_ ||
-            priority > thread_priority::high)
+            priority > thread_priority::bound)
         {
             return "unknown";
         }

--- a/libs/core/executors/CMakeLists.txt
+++ b/libs/core/executors/CMakeLists.txt
@@ -94,13 +94,15 @@ add_hpx_module(
     hpx_config
     hpx_errors
     hpx_execution
+    hpx_format
     hpx_futures
     hpx_hardware
     hpx_io_service
     hpx_itt_notify
-    hpx_properties
-    hpx_threading
-    hpx_errors
     hpx_memory
+    hpx_properties
+    hpx_resource_partitioner
+    hpx_threading
+    hpx_topology
   CMAKE_SUBDIRS examples tests
 )

--- a/libs/core/executors/tests/unit/thread_pool_scheduler.cpp
+++ b/libs/core/executors/tests/unit/thread_pool_scheduler.cpp
@@ -259,9 +259,10 @@ void test_properties()
     hpx::condition_variable cond;
     bool executed{false};
 
-    constexpr std::array<hpx::threads::thread_priority, 3> priorities{
+    constexpr std::array<hpx::threads::thread_priority, 4> priorities{
         {hpx::threads::thread_priority::low,
             hpx::threads::thread_priority::normal,
+            hpx::threads::thread_priority::bound,
             hpx::threads::thread_priority::high}};
 
     for (auto const prio : priorities)

--- a/libs/core/iterator_support/include/hpx/iterator_support/counting_iterator.hpp
+++ b/libs/core/iterator_support/include/hpx/iterator_support/counting_iterator.hpp
@@ -191,7 +191,7 @@ namespace hpx { namespace util {
     // Manufacture a counting iterator for an arbitrary incrementable type
     template <typename Incrementable>
     HPX_HOST_DEVICE inline constexpr counting_iterator<Incrementable>
-    make_counting_iterator(Incrementable x)
+    make_counting_iterator(Incrementable x) noexcept
     {
         return counting_iterator<Incrementable>(x);
     }

--- a/libs/core/iterator_support/include/hpx/iterator_support/counting_shape.hpp
+++ b/libs/core/iterator_support/include/hpx/iterator_support/counting_shape.hpp
@@ -21,10 +21,19 @@ namespace hpx { namespace util { namespace detail {
 
     template <typename Incrementable>
     HPX_HOST_DEVICE inline constexpr counting_shape_type<Incrementable>
-    make_counting_shape(Incrementable n)
+    make_counting_shape(Incrementable n) noexcept
     {
         return hpx::util::make_iterator_range(
             hpx::util::make_counting_iterator(Incrementable(0)),
             hpx::util::make_counting_iterator(n));
+    }
+
+    template <typename Incrementable>
+    HPX_HOST_DEVICE inline constexpr counting_shape_type<Incrementable>
+    make_counting_shape(Incrementable b, Incrementable e) noexcept
+    {
+        return hpx::util::make_iterator_range(
+            hpx::util::make_counting_iterator(b),
+            hpx::util::make_counting_iterator(e));
     }
 }}}    // namespace hpx::util::detail

--- a/libs/core/iterator_support/include/hpx/iterator_support/iterator_range.hpp
+++ b/libs/core/iterator_support/include/hpx/iterator_support/iterator_range.hpp
@@ -59,7 +59,7 @@ namespace hpx { namespace util {
         typename Sentinel = traits::range_iterator_t<Range>>
     constexpr std::enable_if_t<traits::is_range_v<Range>,
         iterator_range<Iterator, Sentinel>>
-    make_iterator_range(Range& r)
+    make_iterator_range(Range& r) noexcept
     {
         return iterator_range<Iterator, Sentinel>(util::begin(r), util::end(r));
     }
@@ -69,7 +69,7 @@ namespace hpx { namespace util {
         typename Sentinel = traits::range_iterator_t<Range const>>
     constexpr std::enable_if_t<traits::is_range_v<Range>,
         iterator_range<Iterator, Sentinel>>
-    make_iterator_range(Range const& r)
+    make_iterator_range(Range const& r) noexcept
     {
         return iterator_range<Iterator, Sentinel>(util::begin(r), util::end(r));
     }

--- a/libs/core/resource_partitioner/include/hpx/resource_partitioner/detail/partitioner.hpp
+++ b/libs/core/resource_partitioner/include/hpx/resource_partitioner/detail/partitioner.hpp
@@ -151,9 +151,10 @@ namespace hpx { namespace resource { namespace detail {
         std::string const& get_pool_name(std::size_t index) const;
         std::size_t get_pool_index(std::string const& pool_name) const;
 
-        std::size_t get_pu_num(std::size_t global_thread_num);
+        std::size_t get_pu_num(std::size_t global_thread_num) const;
         threads::mask_cref_type get_pu_mask(
             std::size_t global_thread_num) const;
+        std::size_t get_thread_occupancy(std::size_t pu_num) const;
 
         void init(resource::partitioner_mode rpmode, hpx::util::section cfg,
             hpx::threads::policies::detail::affinity_data affinity_data);

--- a/libs/core/resource_partitioner/src/detail_partitioner.cpp
+++ b/libs/core/resource_partitioner/src/detail_partitioner.cpp
@@ -858,9 +858,14 @@ namespace hpx { namespace resource { namespace detail {
         return initial_thread_pools_[index].pool_name_;
     }
 
-    size_t partitioner::get_pu_num(std::size_t global_thread_num)
+    std::size_t partitioner::get_pu_num(std::size_t global_thread_num) const
     {
         return affinity_data_.get_pu_num(global_thread_num);
+    }
+
+    std::size_t partitioner::get_thread_occupancy(std::size_t pu_num) const
+    {
+        return affinity_data_.get_thread_occupancy(topo_, pu_num);
     }
 
     threads::mask_cref_type partitioner::get_pu_mask(

--- a/libs/core/schedulers/include/hpx/schedulers/local_queue_scheduler.hpp
+++ b/libs/core/schedulers/include/hpx/schedulers/local_queue_scheduler.hpp
@@ -458,7 +458,7 @@ namespace hpx { namespace threads { namespace policies {
         /// Schedule the passed thread
         void schedule_thread(threads::thread_id_ref_type thrd,
             threads::thread_schedule_hint schedulehint, bool allow_fallback,
-            thread_priority /* priority */ = thread_priority::normal) override
+            thread_priority /* priority */ = thread_priority::default_) override
         {
             // NOTE: This scheduler ignores NUMA hints.
             std::size_t num_thread = std::size_t(-1);
@@ -501,7 +501,7 @@ namespace hpx { namespace threads { namespace policies {
 
         void schedule_thread_last(threads::thread_id_ref_type thrd,
             threads::thread_schedule_hint schedulehint, bool allow_fallback,
-            thread_priority /* priority */ = thread_priority::normal) override
+            thread_priority /* priority */ = thread_priority::default_) override
         {
             // NOTE: This scheduler ignores NUMA hints.
             std::size_t num_thread = std::size_t(-1);
@@ -579,6 +579,7 @@ namespace hpx { namespace threads { namespace policies {
                 {
                 case thread_priority::default_:
                 case thread_priority::low:
+                case thread_priority::bound:
                 case thread_priority::normal:
                 case thread_priority::boost:
                 case thread_priority::high:
@@ -603,6 +604,7 @@ namespace hpx { namespace threads { namespace policies {
             {
             case thread_priority::default_:
             case thread_priority::low:
+            case thread_priority::bound:
             case thread_priority::normal:
             case thread_priority::boost:
             case thread_priority::high:

--- a/libs/core/schedulers/include/hpx/schedulers/shared_priority_queue_scheduler.hpp
+++ b/libs/core/schedulers/include/hpx/schedulers/shared_priority_queue_scheduler.hpp
@@ -707,7 +707,7 @@ namespace hpx { namespace threads { namespace policies {
         /// Schedule the passed thread
         void schedule_thread(threads::thread_id_ref_type thrd,
             threads::thread_schedule_hint schedulehint, bool allow_fallback,
-            thread_priority priority = thread_priority::normal) override
+            thread_priority priority = thread_priority::default_) override
         {
             HPX_ASSERT(get_thread_id_data(thrd)->get_scheduler_base() == this);
 
@@ -815,6 +815,11 @@ namespace hpx { namespace threads { namespace policies {
                 debug::dec<3>(thread_num), "D", debug::dec<2>(domain_num), "Q",
                 debug::dec<3>(q_index));
 
+            if (priority == thread_priority::default_)
+            {
+                priority = get_thread_id_data(thrd)->get_priority();
+            }
+
             numa_holder_[domain_num].thread_queue(q_index)->schedule_thread(
                 thrd, priority, false);
         }
@@ -823,7 +828,7 @@ namespace hpx { namespace threads { namespace policies {
         /// just put it on the normal queue for now
         void schedule_thread_last(threads::thread_id_ref_type thrd,
             threads::thread_schedule_hint schedulehint, bool allow_fallback,
-            thread_priority priority = thread_priority::normal) override
+            thread_priority priority = thread_priority::default_) override
         {
             spq_deb.debug(debug::str<>("schedule_thread_last"));
             schedule_thread(thrd, schedulehint, allow_fallback, priority);

--- a/libs/core/threading_base/include/hpx/threading_base/annotated_function.hpp
+++ b/libs/core/threading_base/include/hpx/threading_base/annotated_function.hpp
@@ -31,10 +31,6 @@
 #include <utility>
 
 namespace hpx {
-    namespace detail {
-        HPX_CORE_EXPORT char const* store_function_annotation(std::string name);
-    }    // namespace detail
-
 #if defined(HPX_HAVE_THREAD_DESCRIPTION)
     ///////////////////////////////////////////////////////////////////////////
     namespace detail {

--- a/libs/core/threading_base/include/hpx/threading_base/scheduler_base.hpp
+++ b/libs/core/threading_base/include/hpx/threading_base/scheduler_base.hpp
@@ -228,12 +228,12 @@ namespace hpx { namespace threads { namespace policies {
         virtual void schedule_thread(threads::thread_id_ref_type thrd,
             threads::thread_schedule_hint schedulehint,
             bool allow_fallback = false,
-            thread_priority priority = thread_priority::normal) = 0;
+            thread_priority priority = thread_priority::default_) = 0;
 
         virtual void schedule_thread_last(threads::thread_id_ref_type thrd,
             threads::thread_schedule_hint schedulehint,
             bool allow_fallback = false,
-            thread_priority priority = thread_priority::normal) = 0;
+            thread_priority priority = thread_priority::default_) = 0;
 
         virtual void destroy_thread(threads::thread_data* thrd) = 0;
 

--- a/libs/core/threading_base/src/create_work.cpp
+++ b/libs/core/threading_base/src/create_work.cpp
@@ -90,6 +90,7 @@ namespace hpx { namespace threads { namespace detail {
 
         data.run_now = (thread_priority::high == data.priority ||
             thread_priority::high_recursive == data.priority ||
+            thread_priority::bound == data.priority ||
             thread_priority::boost == data.priority);
 
         thread_id_ref_type id = invalid_thread_id;

--- a/libs/core/topology/include/hpx/topology/cpu_mask.hpp
+++ b/libs/core/topology/include/hpx/topology/cpu_mask.hpp
@@ -32,57 +32,60 @@
 
 namespace hpx { namespace threads {
     /// \cond NOINTERNAL
+
+    [[nodiscard]] HPX_CORE_EXPORT unsigned int hardware_concurrency();
+
 #if !defined(HPX_HAVE_MORE_THAN_64_THREADS) ||                                 \
     (defined(HPX_HAVE_MAX_CPU_COUNT) && HPX_HAVE_MAX_CPU_COUNT <= 64)
-    typedef std::uint64_t mask_type;
-    typedef std::uint64_t mask_cref_type;
+    using mask_type = std::uint64_t;
+    using mask_cref_type = std::uint64_t;
 
-    inline std::uint64_t bits(std::size_t idx)
+    constexpr inline std::uint64_t bits(std::size_t idx) noexcept
     {
         HPX_ASSERT(idx < CHAR_BIT * sizeof(mask_type));
         return std::uint64_t(1) << idx;
     }
 
-    inline bool any(mask_cref_type mask)
+    constexpr inline bool any(mask_cref_type mask) noexcept
     {
         return mask != 0;
     }
 
-    inline mask_type not_(mask_cref_type mask)
+    constexpr inline mask_type not_(mask_cref_type mask) noexcept
     {
         return ~mask;
     }
 
-    inline bool test(mask_cref_type mask, std::size_t idx)
+    constexpr inline bool test(mask_cref_type mask, std::size_t idx) noexcept
     {
         HPX_ASSERT(idx < CHAR_BIT * sizeof(mask_type));
         return (bits(idx) & mask) != 0;
     }
 
-    inline void set(mask_type& mask, std::size_t idx)
+    constexpr inline void set(mask_type& mask, std::size_t idx) noexcept
     {
         HPX_ASSERT(idx < CHAR_BIT * sizeof(mask_type));
         mask |= bits(idx);
     }
 
-    inline void unset(mask_type& mask, std::size_t idx)
+    constexpr inline void unset(mask_type& mask, std::size_t idx) noexcept
     {
         HPX_ASSERT(idx < CHAR_BIT * sizeof(mask_type));
         mask &= not_(bits(idx));
     }
 
-    inline std::size_t mask_size(mask_cref_type /*mask*/)
+    constexpr inline std::size_t mask_size(mask_cref_type /*mask*/) noexcept
     {
         return CHAR_BIT * sizeof(mask_type);
     }
 
-    inline void resize(mask_type& /*mask*/, std::size_t s)
+    constexpr inline void resize(mask_type& /*mask*/, std::size_t s) noexcept
     {
         HPX_ASSERT(s <= CHAR_BIT * sizeof(mask_type));
         HPX_UNUSED(s);
     }
 
-    inline std::size_t find_first(mask_cref_type mask)
+    constexpr inline std::size_t find_first(mask_cref_type mask) noexcept
     {
         if (mask)
         {
@@ -98,36 +101,39 @@ namespace hpx { namespace threads {
         return ~std::size_t(0);
     }
 
-    inline bool equal(mask_cref_type lhs, mask_cref_type rhs, std::size_t = 0)
+    constexpr inline bool equal(
+        mask_cref_type lhs, mask_cref_type rhs, std::size_t = 0) noexcept
     {
         return lhs == rhs;
     }
 
     // return true if at least one of the masks has a bit set
-    inline bool bit_or(mask_cref_type lhs, mask_cref_type rhs, std::size_t = 0)
+    constexpr inline bool bit_or(
+        mask_cref_type lhs, mask_cref_type rhs, std::size_t = 0) noexcept
     {
         return (lhs | rhs) != 0;
     }
 
     // return true if at least one bit is set in both masks
-    inline bool bit_and(mask_cref_type lhs, mask_cref_type rhs, std::size_t = 0)
+    constexpr inline bool bit_and(
+        mask_cref_type lhs, mask_cref_type rhs, std::size_t = 0) noexcept
     {
         return (lhs & rhs) != 0;
     }
 
-    // returns the number of bits set
-    // taken from https://graphics.stanford.edu/~seander/bithacks.html#CountBitsSetKernighan
-    inline std::size_t count(mask_cref_type mask)
+    // returns the number of bits set, taken from:
+    // https://graphics.stanford.edu/~seander/bithacks.html#CountBitsSetKernighan
+    constexpr inline std::size_t count(mask_type mask) noexcept
     {
-        std::size_t c;    // c accumulates the total bits set in v
-        for (c = 0; mask; c++)
+        std::size_t c = 0;    // c accumulates the total bits set in v
+        for (; mask; ++c)
         {
             mask &= mask - 1;    // clear the least significant bit set
         }
         return c;
     }
 
-    inline void reset(mask_type& mask)
+    constexpr inline void reset(mask_type& mask) noexcept
     {
         mask = 0ull;
     }
@@ -135,15 +141,20 @@ namespace hpx { namespace threads {
 #else
     // clang-format off
 #  if defined(HPX_HAVE_MAX_CPU_COUNT)
-    typedef std::bitset<HPX_HAVE_MAX_CPU_COUNT> mask_type;
-    typedef std::bitset<HPX_HAVE_MAX_CPU_COUNT> const& mask_cref_type;
+    using mask_type = std::bitset<HPX_HAVE_MAX_CPU_COUNT>;
+    using mask_cref_type = std::bitset<HPX_HAVE_MAX_CPU_COUNT> const&;
+
+    inline void set(mask_type& mask, std::size_t idx) noexcept;
+
 #  else
-    typedef hpx::detail::dynamic_bitset<std::uint64_t> mask_type;
-    typedef hpx::detail::dynamic_bitset<std::uint64_t> const& mask_cref_type;
+    using mask_type = hpx::detail::dynamic_bitset<std::uint64_t>;
+    using mask_cref_type = hpx::detail::dynamic_bitset<std::uint64_t> const&;
+
+    inline void set(mask_type& mask, std::size_t idx) noexcept;
 #  endif
     // clang-format on
 
-    inline bool any(mask_cref_type mask)
+    inline bool any(mask_cref_type mask) noexcept
     {
         return mask.any();
     }
@@ -153,22 +164,22 @@ namespace hpx { namespace threads {
         return ~mask;
     }
 
-    inline bool test(mask_cref_type mask, std::size_t idx)
+    inline bool test(mask_cref_type mask, std::size_t idx) noexcept
     {
         return mask.test(idx);
     }
 
-    inline void set(mask_type& mask, std::size_t idx)
+    inline void set(mask_type& mask, std::size_t idx) noexcept
     {
         mask.set(idx);
     }
 
-    inline void unset(mask_type& mask, std::size_t idx)
+    inline void unset(mask_type& mask, std::size_t idx) noexcept
     {
         mask.set(idx, 0);
     }
 
-    inline std::size_t mask_size(mask_cref_type mask)
+    inline std::size_t mask_size(mask_cref_type mask) noexcept
     {
         return mask.size();
     }
@@ -185,7 +196,7 @@ namespace hpx { namespace threads {
 #  endif
     }
 
-    inline std::size_t find_first(mask_cref_type mask)
+    inline std::size_t find_first(mask_cref_type mask) noexcept
     {
 #  if defined(HPX_HAVE_MAX_CPU_COUNT)
         if (mask.any())
@@ -203,7 +214,8 @@ namespace hpx { namespace threads {
     }
     // clang-format on
 
-    inline bool equal(mask_cref_type lhs, mask_cref_type rhs, std::size_t = 0)
+    inline bool equal(
+        mask_cref_type lhs, mask_cref_type rhs, std::size_t = 0) noexcept
     {
         return lhs == rhs;
     }
@@ -221,12 +233,12 @@ namespace hpx { namespace threads {
     }
 
     // returns the number of bits set
-    inline std::size_t count(mask_cref_type mask)
+    inline std::size_t count(mask_cref_type mask) noexcept
     {
         return mask.count();
     }
 
-    inline void reset(mask_type& mask)
+    inline void reset(mask_type& mask) noexcept
     {
         mask.reset();
     }

--- a/libs/core/topology/include/hpx/topology/topology.hpp
+++ b/libs/core/topology/include/hpx/topology/topology.hpp
@@ -412,8 +412,6 @@ namespace hpx { namespace threads {
     ///////////////////////////////////////////////////////////////////////////
     HPX_CORE_EXPORT topology& create_topology();
 
-    [[nodiscard]] HPX_CORE_EXPORT unsigned int hardware_concurrency();
-
     ///////////////////////////////////////////////////////////////////////////
     // abstract away memory page size, calls to system functions are
     // expensive, so return a value initialized at startup

--- a/tests/performance/local/stream.cpp
+++ b/tests/performance/local/stream.cpp
@@ -22,6 +22,7 @@
 #include <hpx/local/execution.hpp>
 #include <hpx/local/thread.hpp>
 #include <hpx/modules/compute.hpp>
+#include <hpx/modules/compute_local.hpp>
 #include <hpx/modules/format.hpp>
 #include <hpx/type_support/unused.hpp>
 #include <hpx/version.hpp>


### PR DESCRIPTION
The `block_fork_join_executor` is building on top of a set of plain `fork_join_executor`s such that those build a hierarchy of executors allowing to restrict the necessary synchronization to a subset of cores for each of those executors. This allows to build for instance a NUMA-aware `fork_join_executor`, where each of the NUMA-domains has its own executor and those are combined into a higher-level executor that performs synchronization between the NUMA-domains.

The hope is that this executor helps reducing cross-NUMA domain synchronization. 

This PR contains a couple of flyby changes:

- adding support for `thread_priority::bound` to the default scheduler
- replace some of the uses of `boost::irange` with our `hpx::util::detail::make_counting_shape`
- added `thread_description(std::string desc)` constructor
- added the use of the new executor to the stream benchmark

This PR relies on #5868.