### PR TITLE
Docs: Replaced non-existent create_reducer function with create_communicator

### DIFF
--- a/libs/full/collectives/include/hpx/collectives/all_gather.hpp
+++ b/libs/full/collectives/include/hpx/collectives/all_gather.hpp
@@ -51,7 +51,7 @@ namespace hpx { namespace collectives {
     /// This function receives a set of values from all call sites operating on
     /// the given base name.
     ///
-    /// \param  comm        A communicator object returned from \a create_reducer
+    /// \param  comm        A communicator object returned from \a create_communicator
     /// \param  local_result The value to transmit to all
     ///                     participating sites from this call site.
     /// \param this_site    The sequence number of this invocation (usually

--- a/libs/full/collectives/include/hpx/collectives/all_reduce.hpp
+++ b/libs/full/collectives/include/hpx/collectives/all_reduce.hpp
@@ -52,7 +52,7 @@ namespace hpx { namespace collectives {
     /// This function receives a set of values from all call sites operating on
     /// the given base name.
     ///
-    /// \param  comm        A communicator object returned from \a create_reducer
+    /// \param  comm        A communicator object returned from \a create_communicator
     /// \param  local_result The value to transmit to all
     ///                     participating sites from this call site.
     /// \param  op          Reduction operation to apply to all values supplied

--- a/libs/full/collectives/include/hpx/collectives/all_to_all.hpp
+++ b/libs/full/collectives/include/hpx/collectives/all_to_all.hpp
@@ -51,7 +51,7 @@ namespace hpx { namespace collectives {
     /// This function receives a set of values from all call sites operating on
     /// the given base name.
     ///
-    /// \param  comm        A communicator object returned from \a create_reducer
+    /// \param  comm        A communicator object returned from \a create_communicator
     /// \param  local_result The value to transmit to all
     ///                     participating sites from this call site.
     /// \param this_site    The sequence number of this invocation (usually

--- a/libs/full/collectives/include/hpx/collectives/broadcast.hpp
+++ b/libs/full/collectives/include/hpx/collectives/broadcast.hpp
@@ -45,7 +45,7 @@ namespace hpx { namespace collectives {
     /// This function sends a set of values to all call sites operating on
     /// the given base name.
     ///
-    /// \param  comm        A communicator object returned from \a create_reducer
+    /// \param  comm        A communicator object returned from \a create_communicator
     /// \param  local_result A value to transmit to all
     ///                     participating sites from this call site.
     /// \param this_site    The sequence number of this invocation (usually
@@ -88,7 +88,7 @@ namespace hpx { namespace collectives {
     /// This function sends a set of values to all call sites operating on
     /// the given base name.
     ///
-    /// \param  comm        A communicator object returned from \a create_reducer
+    /// \param  comm        A communicator object returned from \a create_communicator
     /// \param this_site    The sequence number of this invocation (usually
     ///                     the locality id). This value is optional and
     ///                     defaults to whatever hpx::get_locality_id() returns.

--- a/libs/full/collectives/include/hpx/collectives/exclusive_scan.hpp
+++ b/libs/full/collectives/include/hpx/collectives/exclusive_scan.hpp
@@ -56,7 +56,7 @@ namespace hpx { namespace collectives {
     /// This function performs an exclusive scan operation on a set of values
     /// received from all call sites operating on the given base name.
     ///
-    /// \param  comm        A communicator object returned from \a create_reducer
+    /// \param  comm        A communicator object returned from \a create_communicator
     /// \param  local_result The value to transmit to all
     ///                     participating sites from this call site.
     /// \param  op          Reduction operation to apply to all values supplied

--- a/libs/full/collectives/include/hpx/collectives/gather.hpp
+++ b/libs/full/collectives/include/hpx/collectives/gather.hpp
@@ -47,7 +47,7 @@ namespace hpx { namespace collectives {
     /// This function receives a set of values from all call sites operating on
     /// the given base name.
     ///
-    /// \param  comm        A communicator object returned from \a create_reducer
+    /// \param  comm        A communicator object returned from \a create_communicator
     /// \param  result      The value to transmit to the central gather point
     ///                     from this call site.
     /// \param this_site    The sequence number of this invocation (usually
@@ -98,7 +98,7 @@ namespace hpx { namespace collectives {
     /// This function transmits the value given by \a result to a central gather
     /// site (where the corresponding \a gather_here is executed)
     ///
-    /// \param  comm        A communicator object returned from \a create_reducer
+    /// \param  comm        A communicator object returned from \a create_communicator
     /// \param  result      The value to transmit to the central gather point
     ///                     from this call site.
     /// \param this_site    The sequence number of this invocation (usually

--- a/libs/full/collectives/include/hpx/collectives/inclusive_scan.hpp
+++ b/libs/full/collectives/include/hpx/collectives/inclusive_scan.hpp
@@ -52,7 +52,7 @@ namespace hpx { namespace collectives {
     /// This function performs an inclusive scan operation on a set of values
     /// received from all call sites operating on the given base name.
     ///
-    /// \param  comm        A communicator object returned from \a create_reducer
+    /// \param  comm        A communicator object returned from \a create_communicator
     /// \param  local_result The value to transmit to all
     ///                     participating sites from this call site.
     /// \param  op          Reduction operation to apply to all values supplied

--- a/libs/full/collectives/include/hpx/collectives/scatter.hpp
+++ b/libs/full/collectives/include/hpx/collectives/scatter.hpp
@@ -45,7 +45,7 @@ namespace hpx { namespace collectives {
     /// This function receives an element of a set of values operating on
     /// the given base name.
     ///
-    /// \param  comm        A communicator object returned from \a create_reducer
+    /// \param  comm        A communicator object returned from \a create_communicator
     /// \param this_site    The sequence number of this invocation (usually
     ///                     the locality id). This value is optional and
     ///                     defaults to whatever hpx::get_locality_id() returns.
@@ -93,7 +93,7 @@ namespace hpx { namespace collectives {
     /// This function transmits the value given by \a result to a central scatter
     /// site (where the corresponding \a scatter_from is executed)
     ///
-    /// \param  comm        A communicator object returned from \a create_reducer
+    /// \param  comm        A communicator object returned from \a create_communicator
     /// \param  num_sites   The number of participating sites (default: all
     ///                     localities).
     /// \param this_site    The sequence number of this invocation (usually


### PR DESCRIPTION
## Fixes 
The collectives headers were mentioning a non-existing function create_reducer to create a communicator.
## Proposed Changes

  -Renamed all create_reducer instances to the correct create_communicator function.
