### PR TITLE
New performance counters related to zero-copy chunks.

### DIFF
--- a/docs/sphinx/manual/optimizing_hpx_applications.rst
+++ b/docs/sphinx/manual/optimizing_hpx_applications.rst
@@ -996,7 +996,7 @@ system and application performance.
 
        ``<operation>`` is one of the following: ``sent``, ``received``
 
-       ``<connection_type`` is one of the following: ``tcp``, ``mpi``
+       ``<connection_type>`` is one of the following: ``tcp``, ``mpi``
      * ``locality#*/total``
 
        where:
@@ -1005,7 +1005,7 @@ system and application performance.
        number of transmitted bytes should be queried for. The :term:`locality`
        id is a (zero based) number identifying the :term:`locality`.
      * Returns the overall number of raw (uncompressed) bytes sent or received
-       (see ``<operation``, e.g. ``en`` or ``eceived``) for the specified
+       (see ``<operation>``, e.g. ``sent`` or ``received``) for the specified
        ``<connection_type>``.
 
        The performance counters are available only if the compile time constant
@@ -1031,7 +1031,7 @@ system and application performance.
 
        ``<operation>`` is one of the following: ``sent``, ``received``
 
-       ``<connection_type`` is one of the following: ``tcp``, ``mpi``
+       ``<connection_type>`` is one of the following: ``tcp``, ``mpi``
      * ``locality#*/total``
 
        where:
@@ -1042,7 +1042,7 @@ system and application performance.
      * Returns the total time (in nanoseconds) between the start of each
        asynchronous transmission operation and the end of the corresponding
        operation for the specified ``<connection_type>`` the given
-       :term:`locality` (see ``<operation``, e.g. ``en`` or ``eceived``).
+       :term:`locality` (see ``<operation>``, e.g. ``sent`` or ``received``).
 
        The performance counters are available only if the compile time constant
        ``HPX_HAVE_PARCELPORT_COUNTERS`` was defined while compiling the |hpx|
@@ -1067,7 +1067,7 @@ system and application performance.
 
        ``<operation>`` is one of the following: ``sent``, ``received``
 
-       ``<connection_type`` is one of the following: ``tcp``, ``mpi``
+       ``<connection_type>`` is one of the following: ``tcp``, ``mpi``
      * ``locality#*/total``
 
        where:
@@ -1105,7 +1105,7 @@ system and application performance.
 
        ``<operation>`` is one of the following: ``sent``, ``received``
 
-       ``<connection_type`` is one of the following: ``tcp``, ``mpi``
+       ``<connection_type>`` is one of the following: ``tcp``, ``mpi``
      * ``locality#*/total``
 
        where:
@@ -1115,7 +1115,7 @@ system and application performance.
        (zero based) number identifying the :term:`locality`.
      * Returns the overall time spent performing outgoing data serialization for
        the specified ``<connection_type>`` on the given :term:`locality` (see
-       ``<operation``, e.g. ``sent`` or ``received``).
+       ``<operation>``, e.g. ``sent`` or ``received``).
 
        The performance counters are available only if the compile time constant
        ``HPX_HAVE_PARCELPORT_COUNTERS`` was defined while compiling the |hpx|
@@ -1170,7 +1170,7 @@ system and application performance.
 
        ``<operation>`` is one of the following: ``sent``, ``received``
 
-       ``<connection_type`` is one of the following: ``tcp``, ``mpi``
+       ``<connection_type>`` is one of the following: ``tcp``, ``mpi``
      * ``locality#*/total``
 
        where:
@@ -1179,7 +1179,7 @@ system and application performance.
        parcels should be queried for. The :term:`locality` id is a (zero based)
        number identifying the :term:`locality`.
      * Returns the overall number of parcels transferred using the specified
-       ``<connection_type`` by the given :term:`locality` (see ``operation>``,
+       ``<connection_type>`` by the given :term:`locality` (see ``operation>``,
        e.g. ``sent`` or ``received``.
 
        The performance counters are available only if the compile time constant
@@ -1205,7 +1205,7 @@ system and application performance.
 
        ``<operation>`` is one of the following: ``sent``, ``received``
 
-       ``<connection_type`` is one of the following: ``tcp``, ``mpi``
+       ``<connection_type>`` is one of the following: ``tcp``, ``mpi``
      * ``locality#*/total``
 
        where:
@@ -1215,7 +1215,147 @@ system and application performance.
        number identifying the :term:`locality`.
      * Returns the overall number of messages [#]_ transferred using the
        specified ``<connection_type>`` by the given :term:`locality` (see
-       ``<operation``, e.g. ``sent`` or ``received``)
+       ``<operation>``, e.g. ``sent`` or ``received``)
+
+       The performance counters are available only if the compile time constant
+       ``HPX_HAVE_PARCELPORT_COUNTERS`` was defined while compiling the |hpx|
+       core library (which is not defined by default). The corresponding cmake
+       configuration constant is ``HPX_WITH_PARCELPORT_COUNTERS``.
+
+       The performance counters for the connection type ``mpi`` are available
+       only if the compile time constant ``HPX_HAVE_PARCELPORT_MPI`` was defined
+       while compiling the |hpx| core library (which is not defined by default).
+       The corresponding cmake configuration constant is
+       ``HPX_WITH_PARCELPORT_MPI``.
+
+       Please see :ref:`cmake_variables` for more details.
+     * None
+   * * ``/parcelport/count/<connection_type>/zero_copy_chunks/<operation>``
+
+       .. _parcelport-count-connection-type-zero_copy_chunks-operation:
+
+       :ref:`??<parcelport-count-connection-type-zero_copy_chunks-operation>`
+
+       where:
+
+       ``<operation>`` is one of the following: ``sent``, ``received``
+
+       ``<connection_type>`` is one of the following: ``tcp``, ``mpi``
+     * ``locality#*/total``
+
+       where:
+
+       ``*`` is the :term:`locality` id of the :term:`locality` the overall
+       number of transmitted bytes should be queried for. The :term:`locality`
+       id is a (zero based) number identifying the :term:`locality`.
+     * Returns the overall number of zero-copy chunks sent or received
+       (see ``<operation>``, e.g. ``sent`` or ``received``) for the specified
+       ``<connection_type>``.
+
+       The performance counters are available only if the compile time constant
+       ``HPX_HAVE_PARCELPORT_COUNTERS`` was defined while compiling the |hpx|
+       core library (which is not defined by default). The corresponding cmake
+       configuration constant is ``HPX_WITH_PARCELPORT_COUNTERS``.
+
+       The performance counters for the connection type ``mpi`` are available
+       only if the compile time constant ``HPX_HAVE_PARCELPORT_MPI`` was defined
+       while compiling the |hpx| core library (which is not defined by default).
+       The corresponding cmake configuration constant is
+       ``HPX_WITH_PARCELPORT_MPI``.
+
+       Please see :ref:`cmake_variables` for more details.
+     * None
+   * * ``/parcelport/count-max/<connection_type>/zero_copy_chunks/<operation>``
+
+       .. _parcelport-count-max-connection-type-zero_copy_chunks-operation:
+
+       :ref:`??<parcelport-count-max-connection-type-zero_copy_chunks-operation>`
+
+       where:
+
+       ``<operation>`` is one of the following: ``sent``, ``received``
+
+       ``<connection_type>`` is one of the following: ``tcp``, ``mpi``
+     * ``locality#*/total``
+
+       where:
+
+       ``*`` is the :term:`locality` id of the :term:`locality` the overall
+       number of transmitted bytes should be queried for. The :term:`locality`
+       id is a (zero based) number identifying the :term:`locality`.
+     * Returns the maximum number of zero-copy chunks sent or received per message
+       (see ``<operation>``, e.g. ``sent`` or ``received``) for the specified
+       ``<connection_type>``.
+
+       The performance counters are available only if the compile time constant
+       ``HPX_HAVE_PARCELPORT_COUNTERS`` was defined while compiling the |hpx|
+       core library (which is not defined by default). The corresponding cmake
+       configuration constant is ``HPX_WITH_PARCELPORT_COUNTERS``.
+
+       The performance counters for the connection type ``mpi`` are available
+       only if the compile time constant ``HPX_HAVE_PARCELPORT_MPI`` was defined
+       while compiling the |hpx| core library (which is not defined by default).
+       The corresponding cmake configuration constant is
+       ``HPX_WITH_PARCELPORT_MPI``.
+
+       Please see :ref:`cmake_variables` for more details.
+     * None
+   * * ``/parcelport/size/<connection_type>/zero_copy_chunks/<operation>``
+
+       .. _parcelport-size-connection-type-zero_copy_chunks-operation:
+
+       :ref:`??<parcelport-size-connection-type-zero_copy_chunks-operation>`
+
+       where:
+
+       ``<operation>`` is one of the following: ``sent``, ``received``
+
+       ``<connection_type>`` is one of the following: ``tcp``, ``mpi``
+     * ``locality#*/total``
+
+       where:
+
+       ``*`` is the :term:`locality` id of the :term:`locality` the overall
+       number of transmitted bytes should be queried for. The :term:`locality`
+       id is a (zero based) number identifying the :term:`locality`.
+     * Returns the overall size of zero-copy chunks sent or received
+       (see ``<operation>``, e.g. ``sent`` or ``received``) for the specified
+       ``<connection_type>``.
+
+       The performance counters are available only if the compile time constant
+       ``HPX_HAVE_PARCELPORT_COUNTERS`` was defined while compiling the |hpx|
+       core library (which is not defined by default). The corresponding cmake
+       configuration constant is ``HPX_WITH_PARCELPORT_COUNTERS``.
+
+       The performance counters for the connection type ``mpi`` are available
+       only if the compile time constant ``HPX_HAVE_PARCELPORT_MPI`` was defined
+       while compiling the |hpx| core library (which is not defined by default).
+       The corresponding cmake configuration constant is
+       ``HPX_WITH_PARCELPORT_MPI``.
+
+       Please see :ref:`cmake_variables` for more details.
+     * None
+   * * ``/parcelport/size-max/<connection_type>/zero_copy_chunks/<operation>``
+
+       .. _parcelport-size-max-connection-type-zero_copy_chunks-operation:
+
+       :ref:`??<parcelport-size-max-connection-type-zero_copy_chunks-operation>`
+
+       where:
+
+       ``<operation>`` is one of the following: ``sent``, ``received``
+
+       ``<connection_type>`` is one of the following: ``tcp``, ``mpi``
+     * ``locality#*/total``
+
+       where:
+
+       ``*`` is the :term:`locality` id of the :term:`locality` the overall
+       number of transmitted bytes should be queried for. The :term:`locality`
+       id is a (zero based) number identifying the :term:`locality`.
+     * Returns the maximum size of zero-copy chunks sent or received
+       (see ``<operation>``, e.g. ``sent`` or ``received``) for the specified
+       ``<connection_type>``.
 
        The performance counters are available only if the compile time constant
        ``HPX_HAVE_PARCELPORT_COUNTERS`` was defined while compiling the |hpx|
@@ -1241,7 +1381,7 @@ system and application performance.
        ``<cache_statistics>`` is one of the following: ``cache/insertions``,
        ``cache/evictions``, ``cache/hits``, ``cache/misses``
 
-       `<connection_type`` is one of the following: ``tcp``, ``mpi``
+       ``<connection_type>`` is one of the following: ``tcp``, ``mpi``
      * ``locality#*/total``
 
        where:
@@ -1271,7 +1411,7 @@ system and application performance.
 
        where:
 
-       ``<operation>`` is one of the following: ``send``, ``receive``
+       ``<operation>`` is one of the following: ``sent``, ``receive``
      * ``locality#*/total``
 
        where:
@@ -1280,7 +1420,7 @@ system and application performance.
        should be queried. The :term:`locality` id is a (zero based) number
        identifying the :term:`locality`.
      * Returns the current number of parcels stored in the :term:`parcel` queue (see
-       ``<operation`` for which queue to query, e.g. ``sent`` or ``received``).
+       ``<operation>`` for which queue to query, e.g. ``sent`` or ``received``).
      * None
 
 .. list-table:: Thread manager performance counters

--- a/libs/full/parcelset/include/hpx/parcelset/decode_parcels.hpp
+++ b/libs/full/parcelset/include/hpx/parcelset/decode_parcels.hpp
@@ -49,6 +49,20 @@ namespace hpx::parcelset {
 
         std::size_t num_zero_copy_chunks = static_cast<std::size_t>(
             static_cast<std::uint32_t>(buffer.num_chunks_.first));
+#if defined(HPX_HAVE_PARCELPORT_COUNTERS)
+        HPX_ASSERT(num_zero_copy_chunks == buffer.chunks_.size());
+        parcelset::data_point& data = buffer.data_point_;
+        data.num_zchunks_ += buffer.chunks_.size();
+        data.num_zchunks_per_msg_max_ =
+            (std::max)(data.num_zchunks_per_msg_max_,
+                (std::int64_t) buffer.chunks_.size());
+        for (auto& chunk : buffer.chunks_)
+        {
+            data.size_zchunks_total_ += chunk.size();
+            data.size_zchunks_max_ =
+                (std::max)(data.size_zchunks_max_, (std::int64_t) chunk.size());
+        }
+#endif
 
         if (num_zero_copy_chunks != 0)
         {

--- a/libs/full/parcelset/include/hpx/parcelset/encode_parcels.hpp
+++ b/libs/full/parcelset/include/hpx/parcelset/encode_parcels.hpp
@@ -120,6 +120,17 @@ namespace hpx::parcelset {
                 count_chunks_type(static_cast<std::uint32_t>(chunks.size()),
                     static_cast<std::uint32_t>(
                         buffer.chunks_.size() - chunks.size()));
+#if defined(HPX_HAVE_PARCELPORT_COUNTERS)
+            data.num_zchunks_ += chunks.size();
+            data.num_zchunks_per_msg_max_ = (std::max)(
+                data.num_zchunks_per_msg_max_, (std::int64_t) chunks.size());
+            for (auto& chunk : chunks)
+            {
+                data.size_zchunks_total_ += chunk.second;
+                data.size_zchunks_max_ = (std::max)(
+                    data.size_zchunks_max_, (std::int64_t) chunk.second);
+            }
+#endif
 
             if (!chunks.empty())
             {

--- a/libs/full/parcelset/include/hpx/parcelset/parcelhandler.hpp
+++ b/libs/full/parcelset/include/hpx/parcelset/parcelhandler.hpp
@@ -324,6 +324,38 @@ namespace hpx::parcelset {
 
         std::int64_t get_buffer_allocate_time_received(
             std::string const& pp_type, bool reset) const;
+
+        // total zero-copy chunks sent
+        std::int64_t get_zchunks_send_count(
+            std::string const& pp_type, bool reset) const;
+
+        // total zero-copy chunks received
+        std::int64_t get_zchunks_recv_count(
+            std::string const& pp_type, bool reset) const;
+
+        // the maximum number of zero-copy chunks per message sent
+        std::int64_t get_zchunks_send_per_msg_count_max(
+            std::string const& pp_type, bool reset) const;
+
+        // the maximum number of zero-copy chunks per message received
+        std::int64_t get_zchunks_recv_per_msg_count_max(
+            std::string const& pp_type, bool reset) const;
+
+        // the size of zero-copy chunks per message sent
+        std::int64_t get_zchunks_send_size(
+            std::string const& pp_type, bool reset) const;
+
+        // the size of zero-copy chunks per message received
+        std::int64_t get_zchunks_recv_size(
+            std::string const& pp_type, bool reset) const;
+
+        // the maximum size of zero-copy chunks per message sent
+        std::int64_t get_zchunks_send_size_max(
+            std::string const& pp_type, bool reset) const;
+
+        // the maximum size of zero-copy chunks per message received
+        std::int64_t get_zchunks_recv_size_max(
+            std::string const& pp_type, bool reset) const;
 #endif
 #if defined(HPX_HAVE_PARCELPORT_COUNTERS) &&                                   \
     defined(HPX_HAVE_PARCELPORT_ACTION_COUNTERS)

--- a/libs/full/parcelset/src/parcelhandler.cpp
+++ b/libs/full/parcelset/src/parcelhandler.cpp
@@ -1111,6 +1111,78 @@ namespace hpx::parcelset {
         return pp ? pp->get_buffer_allocate_time_received(reset) : 0;
     }
 
+    // total zero-copy chunks sent
+    std::int64_t parcelhandler::get_zchunks_send_count(
+        std::string const& pp_type, bool reset) const
+    {
+        error_code ec(throwmode::lightweight);
+        parcelport* pp = find_parcelport(pp_type, ec);
+        return pp ? pp->get_zchunks_send_count(reset) : 0;
+    }
+
+    // total zero-copy chunks received
+    std::int64_t parcelhandler::get_zchunks_recv_count(
+        std::string const& pp_type, bool reset) const
+    {
+        error_code ec(throwmode::lightweight);
+        parcelport* pp = find_parcelport(pp_type, ec);
+        return pp ? pp->get_zchunks_recv_count(reset) : 0;
+    }
+
+    // the maximum number of zero-copy chunks per message sent
+    std::int64_t parcelhandler::get_zchunks_send_per_msg_count_max(
+        std::string const& pp_type, bool reset) const
+    {
+        error_code ec(throwmode::lightweight);
+        parcelport* pp = find_parcelport(pp_type, ec);
+        return pp ? pp->get_zchunks_send_per_msg_count_max(reset) : 0;
+    }
+
+    // the maximum number of zero-copy chunks per message received
+    std::int64_t parcelhandler::get_zchunks_recv_per_msg_count_max(
+        std::string const& pp_type, bool reset) const
+    {
+        error_code ec(throwmode::lightweight);
+        parcelport* pp = find_parcelport(pp_type, ec);
+        return pp ? pp->get_zchunks_recv_per_msg_count_max(reset) : 0;
+    }
+
+    // the size of zero-copy chunks per message sent
+    std::int64_t parcelhandler::get_zchunks_send_size(
+        std::string const& pp_type, bool reset) const
+    {
+        error_code ec(throwmode::lightweight);
+        parcelport* pp = find_parcelport(pp_type, ec);
+        return pp ? pp->get_zchunks_send_size(reset) : 0;
+    }
+
+    // the size of zero-copy chunks per message received
+    std::int64_t parcelhandler::get_zchunks_recv_size(
+        std::string const& pp_type, bool reset) const
+    {
+        error_code ec(throwmode::lightweight);
+        parcelport* pp = find_parcelport(pp_type, ec);
+        return pp ? pp->get_zchunks_recv_size(reset) : 0;
+    }
+
+    // the maximum size of zero-copy chunks per message sent
+    std::int64_t parcelhandler::get_zchunks_send_size_max(
+        std::string const& pp_type, bool reset) const
+    {
+        error_code ec(throwmode::lightweight);
+        parcelport* pp = find_parcelport(pp_type, ec);
+        return pp ? pp->get_zchunks_send_size_max(reset) : 0;
+    }
+
+    // the maximum size of zero-copy chunks per message received
+    std::int64_t parcelhandler::get_zchunks_recv_size_max(
+        std::string const& pp_type, bool reset) const
+    {
+        error_code ec(throwmode::lightweight);
+        parcelport* pp = find_parcelport(pp_type, ec);
+        return pp ? pp->get_zchunks_recv_size_max(reset) : 0;
+    }
+
 #if defined(HPX_HAVE_PARCELPORT_COUNTERS) &&                                   \
     defined(HPX_HAVE_PARCELPORT_ACTION_COUNTERS)
     // same as above, just separated data for each action

--- a/libs/full/parcelset_base/include/hpx/parcelset_base/detail/data_point.hpp
+++ b/libs/full/parcelset_base/include/hpx/parcelset_base/detail/data_point.hpp
@@ -34,5 +34,17 @@ namespace hpx::parcelset {
 
         /// The time spent for allocating buffers
         std::int64_t buffer_allocate_time_ = 0;
+
+        //// number of zero-copy chunks in total
+        std::int64_t num_zchunks_ = 0;
+
+        //// maximum number of zero-copy chunks per message
+        std::int64_t num_zchunks_per_msg_max_ = 0;
+
+        //// size of zero-copy chunks in total
+        std::int64_t size_zchunks_total_ = 0;
+
+        //// maximum size of zero-copy chunks
+        std::int64_t size_zchunks_max_ = 0;
     };
 }    // namespace hpx::parcelset

--- a/libs/full/parcelset_base/include/hpx/parcelset_base/detail/gatherer.hpp
+++ b/libs/full/parcelset_base/include/hpx/parcelset_base/detail/gatherer.hpp
@@ -36,6 +36,10 @@ namespace hpx::parcelset {
             inline std::int64_t total_time(bool reset);
             inline std::int64_t total_serialization_time(bool reset);
             inline std::int64_t total_buffer_allocate_time(bool reset);
+            inline std::int64_t num_zchunks(bool reset);
+            inline std::int64_t num_zchunks_per_msg_max(bool reset);
+            inline std::int64_t size_zchunks_total(bool reset);
+            inline std::int64_t size_zchunks_max(bool reset);
 
         private:
             std::int64_t overall_bytes_ = 0;
@@ -44,8 +48,11 @@ namespace hpx::parcelset {
             std::int64_t num_parcels_ = 0;
             std::int64_t num_messages_ = 0;
             std::int64_t overall_raw_bytes_ = 0;
-
             std::int64_t buffer_allocate_time_;
+            std::int64_t num_zchunks_ = 0;
+            std::int64_t num_zchunks_per_msg_max_ = 0;
+            std::int64_t size_zchunks_total_ = 0;
+            std::int64_t size_zchunks_max_ = 0;
 
             // Create mutex for accumulator functions.
             Mutex acc_mtx;
@@ -63,6 +70,12 @@ namespace hpx::parcelset {
             overall_raw_bytes_ += x.raw_bytes_;
             ++num_messages_;
             buffer_allocate_time_ += x.buffer_allocate_time_;
+            num_zchunks_ += x.num_zchunks_;
+            num_zchunks_per_msg_max_ = (std::max)(
+                num_zchunks_per_msg_max_, x.num_zchunks_per_msg_max_);
+            size_zchunks_total_ += x.size_zchunks_total_;
+            size_zchunks_max_ =
+                (std::max)(size_zchunks_max_, x.size_zchunks_max_);
         }
 
         template <typename Mutex>
@@ -112,6 +125,34 @@ namespace hpx::parcelset {
         {
             std::lock_guard l(acc_mtx);
             return util::get_and_reset_value(buffer_allocate_time_, reset);
+        }
+
+        template <typename Mutex>
+        std::int64_t gatherer<Mutex>::num_zchunks(bool reset)
+        {
+            std::lock_guard l(acc_mtx);
+            return util::get_and_reset_value(num_zchunks_, reset);
+        }
+
+        template <typename Mutex>
+        std::int64_t gatherer<Mutex>::num_zchunks_per_msg_max(bool reset)
+        {
+            std::lock_guard l(acc_mtx);
+            return util::get_and_reset_value(num_zchunks_per_msg_max_, reset);
+        }
+
+        template <typename Mutex>
+        std::int64_t gatherer<Mutex>::size_zchunks_total(bool reset)
+        {
+            std::lock_guard l(acc_mtx);
+            return util::get_and_reset_value(size_zchunks_total_, reset);
+        }
+
+        template <typename Mutex>
+        std::int64_t gatherer<Mutex>::size_zchunks_max(bool reset)
+        {
+            std::lock_guard l(acc_mtx);
+            return util::get_and_reset_value(size_zchunks_max_, reset);
         }
     }    // namespace detail
 

--- a/libs/full/parcelset_base/include/hpx/parcelset_base/parcelport.hpp
+++ b/libs/full/parcelset_base/include/hpx/parcelset_base/parcelport.hpp
@@ -228,6 +228,30 @@ namespace hpx::parcelset {
 
         std::int64_t get_buffer_allocate_time_sent(bool reset);
         std::int64_t get_buffer_allocate_time_received(bool reset);
+
+        //// total zero-copy chunks sent
+        std::int64_t get_zchunks_send_count(bool reset);
+
+        //// total zero-copy chunks received
+        std::int64_t get_zchunks_recv_count(bool reset);
+
+        //// the maximum number of zero-copy chunks per message sent
+        std::int64_t get_zchunks_send_per_msg_count_max(bool reset);
+
+        //// the maximum number of zero-copy chunks per message received
+        std::int64_t get_zchunks_recv_per_msg_count_max(bool reset);
+
+        //// the size of zero-copy chunks per message sent
+        std::int64_t get_zchunks_send_size(bool reset);
+
+        //// the size of zero-copy chunks per message received
+        std::int64_t get_zchunks_recv_size(bool reset);
+
+        //// the maximum size of zero-copy chunks per message sent
+        std::int64_t get_zchunks_send_size_max(bool reset);
+
+        //// the maximum size of zero-copy chunks per message received
+        std::int64_t get_zchunks_recv_size_max(bool reset);
 #endif
 #if defined(HPX_HAVE_PARCELPORT_COUNTERS) &&                                   \
     defined(HPX_HAVE_PARCELPORT_ACTION_COUNTERS)

--- a/libs/full/parcelset_base/src/parcelport.cpp
+++ b/libs/full/parcelset_base/src/parcelport.cpp
@@ -214,6 +214,54 @@ namespace hpx::parcelset {
     {
         return parcels_received_.total_buffer_allocate_time(reset);
     }
+
+    //// total zero-copy chunks sent
+    std::int64_t parcelport::get_zchunks_send_count(bool reset)
+    {
+        return parcels_sent_.num_zchunks(reset);
+    }
+
+    //// total zero-copy chunks received
+    std::int64_t parcelport::get_zchunks_recv_count(bool reset)
+    {
+        return parcels_received_.num_zchunks(reset);
+    }
+
+    //// the maximum number of zero-copy chunks per message sent
+    std::int64_t parcelport::get_zchunks_send_per_msg_count_max(bool reset)
+    {
+        return parcels_sent_.num_zchunks_per_msg_max(reset);
+    }
+
+    //// the maximum number of zero-copy chunks per message received
+    std::int64_t parcelport::get_zchunks_recv_per_msg_count_max(bool reset)
+    {
+        return parcels_received_.num_zchunks_per_msg_max(reset);
+    }
+
+    //// the size of zero-copy chunks per message sent
+    std::int64_t parcelport::get_zchunks_send_size(bool reset)
+    {
+        return parcels_sent_.size_zchunks_total(reset);
+    }
+
+    //// the size of zero-copy chunks per message received
+    std::int64_t parcelport::get_zchunks_recv_size(bool reset)
+    {
+        return parcels_received_.size_zchunks_total(reset);
+    }
+
+    //// the maximum size of zero-copy chunks per message sent
+    std::int64_t parcelport::get_zchunks_send_size_max(bool reset)
+    {
+        return parcels_sent_.size_zchunks_max(reset);
+    }
+
+    //// the maximum size of zero-copy chunks per message received
+    std::int64_t parcelport::get_zchunks_recv_size_max(bool reset)
+    {
+        return parcels_received_.size_zchunks_max(reset);
+    }
 #endif
     ///////////////////////////////////////////////////////////////////////////
 #if defined(HPX_HAVE_PARCELPORT_COUNTERS) &&                                   \

--- a/libs/full/performance_counters/src/parcelhandler_counter_types.cpp
+++ b/libs/full/performance_counters/src/parcelhandler_counter_types.cpp
@@ -105,6 +105,30 @@ namespace hpx::performance_counters {
             hpx::bind_front(&parcelhandler::get_buffer_allocate_time_received,
                 &ph, pp_type));
 
+        hpx::function<std::int64_t(bool)> num_zchunks_send(hpx::bind_front(
+            &parcelhandler::get_zchunks_send_count, &ph, pp_type));
+        hpx::function<std::int64_t(bool)> num_zchunks_recv(hpx::bind_front(
+            &parcelhandler::get_zchunks_recv_count, &ph, pp_type));
+
+        hpx::function<std::int64_t(bool)> num_zchunks_send_per_msg_max(
+            hpx::bind_front(&parcelhandler::get_zchunks_send_per_msg_count_max,
+                &ph, pp_type));
+        hpx::function<std::int64_t(bool)> num_zchunks_recv_per_msg_max(
+            hpx::bind_front(&parcelhandler::get_zchunks_recv_per_msg_count_max,
+                &ph, pp_type));
+
+        hpx::function<std::int64_t(bool)> size_zchunks_send(hpx::bind_front(
+            &parcelhandler::get_zchunks_send_size, &ph, pp_type));
+        hpx::function<std::int64_t(bool)> size_zchunks_recv(hpx::bind_front(
+            &parcelhandler::get_zchunks_recv_size, &ph, pp_type));
+
+        hpx::function<std::int64_t(bool)> size_zchunks_send_per_msg_max(
+            hpx::bind_front(
+                &parcelhandler::get_zchunks_send_size_max, &ph, pp_type));
+        hpx::function<std::int64_t(bool)> size_zchunks_recv_per_msg_max(
+            hpx::bind_front(
+                &parcelhandler::get_zchunks_recv_size_max, &ph, pp_type));
+
         performance_counters::generic_counter_type_data const counter_types[] =
             {
                 {hpx::util::format("/parcels/count/{}/sent", pp_type),
@@ -339,6 +363,119 @@ namespace hpx::performance_counters {
                         &performance_counters::locality_raw_counter_creator, _1,
                         HPX_MOVE(buffer_allocate_time_sent), _2),
                     &performance_counters::locality_counter_discoverer, "ns"},
+                {hpx::util::format(
+                     "/parcelport/count/{}/zero_copy_chunks/sent", pp_type),
+                    performance_counters::counter_type::
+                        monotonically_increasing,
+                    hpx::util::format(
+                        "returns the total number of zero-copy chunks sent "
+                        "using the {} connection type for the referenced "
+                        "locality",
+                        pp_type),
+                    HPX_PERFORMANCE_COUNTER_V1,
+                    hpx::bind(
+                        &performance_counters::locality_raw_counter_creator, _1,
+                        HPX_MOVE(num_zchunks_send), _2),
+                    &performance_counters::locality_counter_discoverer, ""},
+                {hpx::util::format(
+                     "/parcelport/count/{}/zero_copy_chunks/received", pp_type),
+                    performance_counters::counter_type::
+                        monotonically_increasing,
+                    hpx::util::format(
+                        "returns the total number of zero-copy chunks received "
+                        "using the {} connection type for the referenced "
+                        "locality",
+                        pp_type),
+                    HPX_PERFORMANCE_COUNTER_V1,
+                    hpx::bind(
+                        &performance_counters::locality_raw_counter_creator, _1,
+                        HPX_MOVE(num_zchunks_recv), _2),
+                    &performance_counters::locality_counter_discoverer, ""},
+                {hpx::util::format(
+                     "/parcelport/count-max/{}/zero_copy_chunks/sent", pp_type),
+                    performance_counters::counter_type::
+                        monotonically_increasing,
+                    hpx::util::format(
+                        "returns the maximum number of zero-copy chunks per "
+                        "message sent using the {} connection type for the "
+                        "referenced locality",
+                        pp_type),
+                    HPX_PERFORMANCE_COUNTER_V1,
+                    hpx::bind(
+                        &performance_counters::locality_raw_counter_creator, _1,
+                        HPX_MOVE(num_zchunks_send_per_msg_max), _2),
+                    &performance_counters::locality_counter_discoverer, ""},
+                {hpx::util::format(
+                     "/parcelport/count-max/{}/zero_copy_chunks/received",
+                     pp_type),
+                    performance_counters::counter_type::
+                        monotonically_increasing,
+                    hpx::util::format(
+                        "returns the maximum number of zero-copy chunks per "
+                        "message received using the {} connection type for the "
+                        "referenced locality",
+                        pp_type),
+                    HPX_PERFORMANCE_COUNTER_V1,
+                    hpx::bind(
+                        &performance_counters::locality_raw_counter_creator, _1,
+                        HPX_MOVE(num_zchunks_recv_per_msg_max), _2),
+                    &performance_counters::locality_counter_discoverer, ""},
+                {hpx::util::format(
+                     "/parcelport/size/{}/zero_copy_chunks/sent", pp_type),
+                    performance_counters::counter_type::
+                        monotonically_increasing,
+                    hpx::util::format(
+                        "returns the total size of zero-copy chunks sent using "
+                        "the {} connection type for the referenced locality",
+                        pp_type),
+                    HPX_PERFORMANCE_COUNTER_V1,
+                    hpx::bind(
+                        &performance_counters::locality_raw_counter_creator, _1,
+                        HPX_MOVE(size_zchunks_send), _2),
+                    &performance_counters::locality_counter_discoverer, ""},
+                {hpx::util::format(
+                     "/parcelport/size/{}/zero_copy_chunks/received", pp_type),
+                    performance_counters::counter_type::
+                        monotonically_increasing,
+                    hpx::util::format(
+                        "returns the total size of zero-copy chunks received "
+                        "using the {} connection type for the referenced "
+                        "locality",
+                        pp_type),
+                    HPX_PERFORMANCE_COUNTER_V1,
+                    hpx::bind(
+                        &performance_counters::locality_raw_counter_creator, _1,
+                        HPX_MOVE(size_zchunks_recv), _2),
+                    &performance_counters::locality_counter_discoverer, ""},
+                {hpx::util::format(
+                     "/parcelport/size-max/{}/zero_copy_chunks/sent", pp_type),
+                    performance_counters::counter_type::
+                        monotonically_increasing,
+                    hpx::util::format(
+                        "returns the maximum size of zero-copy chunks sent "
+                        "using the {} connection type for the referenced "
+                        "locality",
+                        pp_type),
+                    HPX_PERFORMANCE_COUNTER_V1,
+                    hpx::bind(
+                        &performance_counters::locality_raw_counter_creator, _1,
+                        HPX_MOVE(size_zchunks_send_per_msg_max), _2),
+                    &performance_counters::locality_counter_discoverer, ""},
+                {hpx::util::format(
+                     "/parcelport/size-max/{}/zero_copy_chunks/received",
+                     pp_type),
+                    performance_counters::counter_type::
+                        monotonically_increasing,
+                    hpx::util::format(
+                        "returns the maximum size of zero-copy chunks received "
+                        "using the {} connection type for the referenced "
+                        "locality",
+                        pp_type),
+                    HPX_PERFORMANCE_COUNTER_V1,
+                    hpx::bind(
+                        &performance_counters::locality_raw_counter_creator, _1,
+                        HPX_MOVE(size_zchunks_recv_per_msg_max), _2),
+                    &performance_counters::locality_counter_discoverer, ""},
             };
 
         performance_counters::install_counter_types(


### PR DESCRIPTION
/parcelport/count/{tcp|mpi|lci}/zero_copy_chunks/{sent|received}: total number of zero-copy chunks
/parcelport/count-max/{tcp|mpi|lci}/zero_copy_chunks/{sent|received}: maximum number of zero-copy chunks per message
/parcelport/size/{tcp|mpi|lci}/zero_copy_chunks/{sent|received}: total size of zero-copy chunks
/parcelport/size-max/{tcp|mpi|lci}/zero_copy_chunks/{sent|received}: maximum size of zero-copy chunks