### PR TITLE
Support for data-parallelism for reduce, transform reduce, transform_binary_reduce algorithms

### DIFF
--- a/libs/core/algorithms/CMakeLists.txt
+++ b/libs/core/algorithms/CMakeLists.txt
@@ -166,6 +166,7 @@ set(algorithms_headers
     hpx/parallel/datapar/iterator_helpers.hpp
     hpx/parallel/datapar/loop.hpp
     hpx/parallel/datapar/mismatch.hpp
+    hpx/parallel/datapar/reduce.hpp
     hpx/parallel/datapar/transfer.hpp
     hpx/parallel/datapar/transform_loop.hpp
     hpx/parallel/datapar/zip_iterator.hpp

--- a/libs/core/algorithms/CMakeLists.txt
+++ b/libs/core/algorithms/CMakeLists.txt
@@ -34,6 +34,7 @@ set(algorithms_headers
     hpx/parallel/algorithms/detail/mismatch.hpp
     hpx/parallel/algorithms/detail/parallel_stable_sort.hpp
     hpx/parallel/algorithms/detail/pivot.hpp
+    hpx/parallel/algorithms/detail/reduce.hpp
     hpx/parallel/algorithms/detail/rotate.hpp
     hpx/parallel/algorithms/detail/sample_sort.hpp
     hpx/parallel/algorithms/detail/search.hpp

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/detail/reduce.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/detail/reduce.hpp
@@ -34,10 +34,8 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
             ExPolicy&& policy, InIterB first, InIterE last, T init, Reduce&& r)
         {
             util::loop_ind(HPX_FORWARD(ExPolicy, policy), first, last,
-                [&init, reduce_op = HPX_FORWARD(Reduce, r)](
-                    const auto& v) mutable {
-                    init = HPX_INVOKE(reduce_op, init, v);
-                });
+                [&init, &r](
+                    auto const& v) mutable { init = HPX_INVOKE(r, init, v); });
             return init;
         }
 
@@ -46,7 +44,7 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
             FwdIterB part_begin, std::size_t part_size, T init, Reduce r)
         {
             util::loop_n_ind<ExPolicy>(
-                part_begin, part_size, [&r, &init](const auto& v) mutable {
+                part_begin, part_size, [&init, &r](auto const& v) mutable {
                     init = HPX_INVOKE(r, init, v);
                 });
             return init;
@@ -59,11 +57,8 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
             Convert&& conv)
         {
             util::loop_ind(HPX_FORWARD(ExPolicy, policy), first, last,
-                [&init, reduce_op = HPX_FORWARD(Reduce, r),
-                    conv_op = HPX_FORWARD(Convert, conv)](
-                    const auto& v) mutable {
-                    auto cnv = conv_op(v);
-                    init = HPX_INVOKE(reduce_op, init, cnv);
+                [&init, &r, &conv](auto const& v) mutable {
+                    init = HPX_INVOKE(r, init, HPX_INVOKE(conv, v));
                 });
             return init;
         }
@@ -74,9 +69,8 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
             Convert conv)
         {
             util::loop_n_ind<ExPolicy>(part_begin, part_size,
-                [&r, &conv, &init](const auto& v) mutable {
-                    auto cnv = conv(v);
-                    init = HPX_INVOKE(r, init, cnv);
+                [&init, &r, &conv](auto const& v) mutable {
+                    init = HPX_INVOKE(r, init, HPX_INVOKE(conv, v));
                 });
             return init;
         }
@@ -88,11 +82,8 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
             Convert&& conv)
         {
             util::loop2<ExPolicy>(first1, last1, first2,
-                [&init, reduce_op = HPX_FORWARD(Reduce, r),
-                    convert_op = HPX_FORWARD(Convert, conv)](
-                    Iter1 it1, Iter2 it2) mutable {
-                    init = HPX_INVOKE(
-                        reduce_op, init, HPX_INVOKE(convert_op, *it1, *it2));
+                [&init, &r, &conv](Iter1 it1, Iter2 it2) mutable {
+                    init = HPX_INVOKE(r, init, HPX_INVOKE(conv, *it1, *it2));
                 });
             return init;
         }

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/detail/reduce.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/detail/reduce.hpp
@@ -103,48 +103,10 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
     inline constexpr sequential_reduce_t<ExPolicy> sequential_reduce =
         sequential_reduce_t<ExPolicy>{};
 #else
-    template <typename ExPolicy, typename InIterB, typename InIterE, typename T,
-        typename Reduce>
-    HPX_HOST_DEVICE HPX_FORCEINLINE T sequential_reduce(
-        ExPolicy&& policy, InIterB first, InIterE last, T init, Reduce&& r)
+    template <typename ExPolicy, typename... Args>
+    HPX_HOST_DEVICE HPX_FORCEINLINE auto sequential_reduce(Args&&... args)
     {
-        return sequential_reduce_t<ExPolicy>{}(HPX_FORWARD(ExPolicy, policy),
-            first, last, init, HPX_FORWARD(Reduce, r));
-    }
-
-    template <typename ExPolicy, typename T, typename FwdIterB, typename Reduce>
-    HPX_HOST_DEVICE HPX_FORCEINLINE T sequential_reduce(
-        FwdIterB part_begin, std::size_t part_size, T init, Reduce r)
-    {
-        return sequential_reduce_t<ExPolicy>{}(part_begin, part_size, init, r);
-    }
-
-    template <typename ExPolicy, typename Iter, typename Sent, typename T,
-        typename Reduce, typename Convert>
-    HPX_HOST_DEVICE HPX_FORCEINLINE T sequential_reduce(ExPolicy&& policy,
-        Iter first, Sent last, T init, Reduce&& r, Convert&& conv)
-    {
-        return sequential_reduce_t<ExPolicy>{}(HPX_FORWARD(ExPolicy, policy),
-            first, last, init, HPX_FORWARD(Reduce, r),
-            HPX_FORWARD(Convert, conv));
-    }
-
-    template <typename ExPolicy, typename T, typename Iter, typename Reduce,
-        typename Convert>
-    HPX_HOST_DEVICE HPX_FORCEINLINE T sequential_reduce(
-        Iter part_begin, std::size_t part_size, T init, Reduce r, Convert conv)
-    {
-        return sequential_reduce_t<ExPolicy>{}(
-            part_begin, part_size, init, r, conv);
-    }
-
-    template <typename ExPolicy, typename Iter1, typename Sent, typename Iter2,
-        typename T, typename Reduce, typename Convert>
-    HPX_HOST_DEVICE HPX_FORCEINLINE T sequential_reduce(Iter1 first1,
-        Sent last1, Iter2 first2, T init, Reduce&& r, Convert&& conv)
-    {
-        return sequential_reduce_t<ExPolicy>{}(first1, last1, first2, init,
-            HPX_FORWARD(Reduce, r), HPX_FORWARD(Convert, conv));
+        return sequential_reduce_t<ExPolicy>{}(std::forward<Args>(args)...);
     }
 #endif
 

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/detail/reduce.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/detail/reduce.hpp
@@ -31,8 +31,7 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
         template <typename InIterB, typename InIterE, typename T,
             typename Reduce>
         friend inline constexpr T tag_fallback_invoke(sequential_reduce_t,
-            ExPolicy&& policy, InIterB first, InIterE last, T&& init,
-            Reduce&& r)
+            ExPolicy&& policy, InIterB first, InIterE last, T init, Reduce&& r)
         {
             util::loop_ind(HPX_FORWARD(ExPolicy, policy), first, last,
                 [&init, reduce_op = HPX_FORWARD(Reduce, r)](
@@ -56,7 +55,7 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
         template <typename Iter, typename Sent, typename T, typename Reduce,
             typename Convert>
         friend inline constexpr auto tag_fallback_invoke(sequential_reduce_t,
-            ExPolicy&& policy, Iter first, Sent last, T&& init, Reduce&& r,
+            ExPolicy&& policy, Iter first, Sent last, T init, Reduce&& r,
             Convert&& conv)
         {
             util::loop_ind(HPX_FORWARD(ExPolicy, policy), first, last,
@@ -85,7 +84,7 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
         template <typename Iter1, typename Sent, typename Iter2, typename T,
             typename Reduce, typename Convert>
         friend inline constexpr T tag_fallback_invoke(sequential_reduce_t,
-            Iter1 first1, Sent last1, Iter2 first2, T&& init, Reduce&& r,
+            Iter1 first1, Sent last1, Iter2 first2, T init, Reduce&& r,
             Convert&& conv)
         {
             util::loop2<ExPolicy>(first1, last1, first2,
@@ -107,10 +106,10 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
     template <typename ExPolicy, typename InIterB, typename InIterE, typename T,
         typename Reduce>
     HPX_HOST_DEVICE HPX_FORCEINLINE T sequential_reduce(
-        ExPolicy&& policy, InIterB first, InIterE last, T&& init, Reduce&& r)
+        ExPolicy&& policy, InIterB first, InIterE last, T init, Reduce&& r)
     {
         return sequential_reduce_t<ExPolicy>{}(HPX_FORWARD(ExPolicy, policy),
-            first, last, HPX_FORWARD(T, init), HPX_FORWARD(Reduce, r));
+            first, last, init, HPX_FORWARD(Reduce, r));
     }
 
     template <typename ExPolicy, typename T, typename FwdIterB, typename Reduce>
@@ -123,10 +122,10 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
     template <typename ExPolicy, typename Iter, typename Sent, typename T,
         typename Reduce, typename Convert>
     HPX_HOST_DEVICE HPX_FORCEINLINE T sequential_reduce(ExPolicy&& policy,
-        Iter first, Sent last, T&& init, Reduce&& r, Convert&& conv)
+        Iter first, Sent last, T init, Reduce&& r, Convert&& conv)
     {
         return sequential_reduce_t<ExPolicy>{}(HPX_FORWARD(ExPolicy, policy),
-            first, last, HPX_FORWARD(T, init), HPX_FORWARD(Reduce, r),
+            first, last, init, HPX_FORWARD(Reduce, r),
             HPX_FORWARD(Convert, conv));
     }
 
@@ -142,11 +141,10 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
     template <typename ExPolicy, typename Iter1, typename Sent, typename Iter2,
         typename T, typename Reduce, typename Convert>
     HPX_HOST_DEVICE HPX_FORCEINLINE T sequential_reduce(Iter1 first1,
-        Sent last1, Iter2 first2, T&& init, Reduce&& r, Convert&& conv)
+        Sent last1, Iter2 first2, T init, Reduce&& r, Convert&& conv)
     {
-        return sequential_reduce_t<ExPolicy>{}(first1, last1, first2,
-            HPX_FORWARD(T, init), HPX_FORWARD(Reduce, r),
-            HPX_FORWARD(Convert, conv));
+        return sequential_reduce_t<ExPolicy>{}(first1, last1, first2, init,
+            HPX_FORWARD(Reduce, r), HPX_FORWARD(Convert, conv));
     }
 #endif
 

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/detail/reduce.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/detail/reduce.hpp
@@ -1,0 +1,103 @@
+//  Copyright (c) 2022 Srinivas Yadav
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include <hpx/config.hpp>
+#include <hpx/execution/traits/is_execution_policy.hpp>
+#include <hpx/functional/detail/tag_fallback_invoke.hpp>
+#include <hpx/functional/invoke.hpp>
+#include <hpx/parallel/algorithms/detail/advance_to_sentinel.hpp>
+#include <hpx/parallel/util/compare_projected.hpp>
+#include <hpx/parallel/util/loop.hpp>
+#include <hpx/parallel/util/projection_identity.hpp>
+
+#include <algorithm>
+#include <cstddef>
+#include <iostream>
+#include <type_traits>
+#include <utility>
+
+namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
+
+    template <typename ExPolicy>
+    struct sequential_reduce_t final
+      : hpx::functional::detail::tag_fallback<sequential_reduce_t<ExPolicy>>
+    {
+    private:
+        template <typename InIterB, typename InIterE, typename T,
+            typename Reduce>
+        friend inline constexpr T tag_fallback_invoke(sequential_reduce_t,
+            ExPolicy&& policy, InIterB first, InIterE last, T&& init,
+            Reduce&& r)
+        {
+            util::loop_ind(HPX_FORWARD(ExPolicy, policy), first, last,
+                [&init, reduce_op = HPX_FORWARD(Reduce, r)](
+                    auto& v) { init = HPX_INVOKE(reduce_op, init, v); });
+            return init;
+        }
+
+        template <typename T, typename FwdIterB, typename Reduce>
+        friend inline constexpr T tag_fallback_invoke(sequential_reduce_t,
+            FwdIterB part_begin, std::size_t part_size, T init, Reduce r)
+        {
+            util::loop_n_ind<ExPolicy>(part_begin, part_size,
+                [&r, &init](auto& v) { init = HPX_INVOKE(r, init, v); });
+            return init;
+        }
+
+        template <typename Iter, typename Sent, typename T, typename Reduce,
+            typename Convert>
+        friend inline constexpr auto tag_fallback_invoke(sequential_reduce_t,
+            ExPolicy&& policy, Iter first, Sent last, T&& init, Reduce&& r,
+            Convert&& conv)
+        {
+            util::loop_ind(HPX_FORWARD(ExPolicy, policy), first, last,
+                [&init, reduce_op = HPX_FORWARD(Reduce, r),
+                    conv_op = HPX_FORWARD(Convert, conv)](auto& v) {
+                    auto cnv = conv_op(v);
+                    init = HPX_INVOKE(reduce_op, init, cnv);
+                });
+            return init;
+        }
+
+        template <typename T, typename Iter, typename Reduce, typename Convert>
+        friend inline constexpr auto tag_fallback_invoke(sequential_reduce_t,
+            Iter part_begin, std::size_t part_size, T init, Reduce r,
+            Convert conv)
+        {
+            util::loop_n_ind<ExPolicy>(
+                part_begin, part_size, [&r, &conv, &init](auto& v) {
+                    auto cnv = conv(v);
+                    init = HPX_INVOKE(r, init, cnv);
+                });
+            return init;
+        }
+
+        template <typename Iter1, typename Sent, typename Iter2, typename T,
+            typename Reduce, typename Convert>
+        friend inline constexpr T tag_fallback_invoke(sequential_reduce_t,
+            Iter1 first1, Sent last1, Iter2 first2, T&& init, Reduce&& r,
+            Convert&& conv)
+        {
+            util::loop2<ExPolicy>(first1, last1, first2,
+                [&init, reduce_op = HPX_FORWARD(Reduce, r),
+                    convert_op = HPX_FORWARD(Convert, conv)](
+                    Iter1 it1, Iter2 it2) {
+                    init = HPX_INVOKE(
+                        reduce_op, init, HPX_INVOKE(convert_op, *it1, *it2));
+                });
+            return init;
+        }
+    };
+
+#if !defined(HPX_COMPUTE_DEVICE_CODE)
+    template <typename ExPolicy>
+    inline constexpr sequential_reduce_t<ExPolicy> sequential_reduce =
+        sequential_reduce_t<ExPolicy>{};
+#endif
+
+}}}}    // namespace hpx::parallel::v1::detail

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/transform_reduce.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/transform_reduce.hpp
@@ -391,12 +391,13 @@ namespace hpx { namespace parallel { inline namespace v1 {
                     Iter last1 = it1;
                     std::advance(last1, part_size);
 
-                    auto result = HPX_INVOKE(op2, *it1, *it2);
+                    auto&& result = HPX_INVOKE(op2, *it1, *it2);
                     ++it1;
                     ++it2;
 
                     return detail::sequential_reduce<ExPolicy>(it1, last1, it2,
-                        result, HPX_FORWARD(Op1, op1), HPX_FORWARD(Op2, op2));
+                        HPX_MOVE(result), HPX_FORWARD(Op1, op1),
+                        HPX_FORWARD(Op2, op2));
                 };
 
                 using hpx::util::make_zip_iterator;

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/transform_reduce.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/transform_reduce.hpp
@@ -267,6 +267,7 @@ namespace hpx {
 #include <hpx/parallel/algorithms/detail/accumulate.hpp>
 #include <hpx/parallel/algorithms/detail/dispatch.hpp>
 #include <hpx/parallel/algorithms/detail/distance.hpp>
+#include <hpx/parallel/algorithms/detail/reduce.hpp>
 #include <hpx/parallel/util/detail/algorithm_result.hpp>
 #include <hpx/parallel/util/loop.hpp>
 #include <hpx/parallel/util/partitioner.hpp>
@@ -286,69 +287,6 @@ namespace hpx { namespace parallel { inline namespace v1 {
     // transform_reduce
     namespace detail {
 
-        ///////////////////////////////////////////////////////////////////////
-        template <typename T, typename ExPolicy, typename Reduce,
-            typename Convert>
-        struct transform_reduce_iteration
-        {
-            using execution_policy_type = typename std::decay<ExPolicy>::type;
-            using reduce_type = typename std::decay<Reduce>::type;
-            using convert_type = typename std::decay<Convert>::type;
-
-            reduce_type reduce_;
-            convert_type convert_;
-
-            template <typename Reduce_, typename Convert_>
-            HPX_HOST_DEVICE transform_reduce_iteration(
-                Reduce_&& reduce, Convert_&& convert)
-              : reduce_(HPX_FORWARD(Reduce_, reduce))
-              , convert_(HPX_FORWARD(Convert_, convert))
-            {
-            }
-
-#if !defined(__NVCC__) && !defined(__CUDACC__)
-            transform_reduce_iteration(
-                transform_reduce_iteration const&) = default;
-            transform_reduce_iteration(transform_reduce_iteration&&) = default;
-#else
-            HPX_HOST_DEVICE transform_reduce_iteration(
-                transform_reduce_iteration const& rhs)
-              : reduce_(rhs.reduce_)
-              , convert_(rhs.convert_)
-            {
-            }
-
-            HPX_HOST_DEVICE transform_reduce_iteration(
-                transform_reduce_iteration&& rhs)
-              : reduce_(HPX_MOVE(rhs.reduce_))
-              , convert_(HPX_MOVE(rhs.convert_))
-            {
-            }
-#endif
-
-            transform_reduce_iteration& operator=(
-                transform_reduce_iteration const&) = default;
-            transform_reduce_iteration& operator=(
-                transform_reduce_iteration&&) = default;
-
-            template <typename Iter>
-            HPX_HOST_DEVICE HPX_FORCEINLINE T operator()(
-                Iter part_begin, std::size_t part_size)
-            {
-                using reference =
-                    typename std::iterator_traits<Iter>::reference;
-
-                T val = HPX_INVOKE(convert_, *part_begin);
-                return util::accumulate_n(++part_begin, --part_size,
-                    HPX_MOVE(val),
-                    [HPX_CXX20_CAPTURE_THIS(=)](
-                        T const& res, reference next) mutable -> T {
-                        return HPX_INVOKE(
-                            reduce_, res, HPX_INVOKE(convert_, next));
-                    });
-            }
-        };
-
         template <typename T>
         struct transform_reduce
           : public detail::algorithm<transform_reduce<T>, T>
@@ -360,16 +298,13 @@ namespace hpx { namespace parallel { inline namespace v1 {
 
             template <typename ExPolicy, typename Iter, typename Sent,
                 typename T_, typename Reduce, typename Convert>
-            static T sequential(ExPolicy, Iter first, Sent last, T_&& init,
-                Reduce&& r, Convert&& conv)
+            static T sequential(ExPolicy&& policy, Iter first, Sent last,
+                T_&& init, Reduce&& r, Convert&& conv)
             {
-                using value_type =
-                    typename std::iterator_traits<Iter>::value_type;
-
-                return detail::accumulate(first, last, HPX_FORWARD(T_, init),
-                    [&r, &conv](T const& res, value_type const& next) -> T {
-                        return HPX_INVOKE(r, res, HPX_INVOKE(conv, next));
-                    });
+                return sequential_reduce<ExPolicy>(
+                    HPX_FORWARD(ExPolicy, policy), first, last,
+                    HPX_FORWARD(T_, init), HPX_FORWARD(Reduce, r),
+                    HPX_FORWARD(Convert, conv));
             }
 
             template <typename ExPolicy, typename Iter, typename Sent,
@@ -385,9 +320,12 @@ namespace hpx { namespace parallel { inline namespace v1 {
                         HPX_MOVE(init_));
                 }
 
-                auto f1 =
-                    transform_reduce_iteration<T, ExPolicy, Reduce, Convert>(
-                        HPX_FORWARD(Reduce, r), HPX_FORWARD(Convert, conv));
+                auto f1 = [r, conv](
+                              Iter part_begin, std::size_t part_size) mutable {
+                    auto val = HPX_INVOKE(conv, *part_begin);
+                    return detail::sequential_reduce<ExPolicy>(
+                        ++part_begin, --part_size, HPX_MOVE(val), r, conv);
+                };
 
                 return util::partitioner<ExPolicy, T>::call(
                     HPX_FORWARD(ExPolicy, policy), first,
@@ -395,8 +333,9 @@ namespace hpx { namespace parallel { inline namespace v1 {
                     hpx::unwrapping([init = HPX_FORWARD(T_, init),
                                         r = HPX_FORWARD(Reduce, r)](
                                         auto&& results) mutable -> T {
-                        return util::accumulate_n(hpx::util::begin(results),
-                            hpx::util::size(results), init, r);
+                        return detail::sequential_reduce<ExPolicy>(
+                            hpx::util::begin(results), hpx::util::size(results),
+                            init, r);
                     }));
             }
         };
@@ -450,51 +389,9 @@ namespace hpx { namespace parallel { inline namespace v1 {
             static T sequential(ExPolicy&& /* policy */, Iter first1,
                 Sent last1, Iter2 first2, T_ init, Op1&& op1, Op2&& op2)
             {
-                if (first1 == last1)
-                {
-                    return init;
-                }
-
-                // check whether we should apply vectorization
-                if (!util::loop_optimization<ExPolicy>(first1, last1))
-                {
-                    util::loop2<ExPolicy>(std::false_type(), first1, last1,
-                        first2,
-                        transform_reduce_binary_partition<Op1, Op2, T>{
-                            HPX_FORWARD(Op1, op1), HPX_FORWARD(Op2, op2),
-                            init});
-                    return init;
-                }
-
-                // loop_step properly advances the iterators
-                auto part_sum = util::loop_step<ExPolicy>(std::true_type(),
-                    transform_reduce_binary_indirect<Op2>{op2}, first1, first2);
-
-                std::pair<Iter, Iter2> p = util::loop2<ExPolicy>(
-                    std::true_type(), first1, last1, first2,
-                    transform_reduce_binary_partition<Op1, Op2,
-                        decltype(part_sum)>{op1, op2, part_sum});
-
-                // this is to support vectorization, it will call op1 for each
-                // of the elements of a value-pack
-                auto result = util::detail::accumulate_values<ExPolicy>(
-                    [&op1](T const& sum, T&& val) -> T {
-                        return HPX_INVOKE(op1, sum, val);
-                    },
-                    HPX_MOVE(part_sum), HPX_MOVE(init));
-
-                // the vectorization might not cover all of the sequences,
-                // handle the remainder directly
-                if (p.first != last1)
-                {
-                    util::loop2<ExPolicy>(std::false_type(), p.first, last1,
-                        p.second,
-                        transform_reduce_binary_partition<Op1, Op2,
-                            decltype(result)>{HPX_FORWARD(Op1, op1),
-                            HPX_FORWARD(Op2, op2), result});
-                }
-
-                return util::detail::extract_value<ExPolicy>(result);
+                return sequential_reduce<ExPolicy>(first1, last1, first2,
+                    HPX_FORWARD(T_, init), HPX_FORWARD(Op1, op1),
+                    HPX_FORWARD(Op2, op2));
             }
 
             template <typename ExPolicy, typename Iter, typename Sent,
@@ -525,52 +422,12 @@ namespace hpx { namespace parallel { inline namespace v1 {
                     Iter last1 = it1;
                     std::advance(last1, part_size);
 
-                    if (!util::loop_optimization<ExPolicy>(it1, last1))
-                    {
-                        // loop_step properly advances the iterators
-                        auto result =
-                            util::loop_step<ExPolicy>(std::false_type(),
-                                transform_reduce_binary_indirect<Op2>{op2}, it1,
-                                it2);
+                    auto result = HPX_INVOKE(op2, *it1, *it2);
+                    ++it1;
+                    ++it2;
 
-                        util::loop2<ExPolicy>(std::false_type(), it1, last1,
-                            it2,
-                            transform_reduce_binary_partition<Op1, Op2,
-                                decltype(result)>{HPX_FORWARD(Op1, op1),
-                                HPX_FORWARD(Op2, op2), result});
-
-                        return util::detail::extract_value<ExPolicy>(result);
-                    }
-
-                    // loop_step properly advances the iterators
-                    auto part_sum = util::loop_step<ExPolicy>(std::true_type(),
-                        transform_reduce_binary_indirect<Op2>{op2}, it1, it2);
-
-                    std::pair<Iter, Iter2> p =
-                        util::loop2<ExPolicy>(std::true_type(), it1, last1, it2,
-                            transform_reduce_binary_partition<Op1, Op2,
-                                decltype(part_sum)>{op1, op2, part_sum});
-
-                    // this is to support vectorization, it will call op1
-                    // for each of the elements of a value-pack
-                    auto result = util::detail::accumulate_values<ExPolicy>(
-                        [&op1](T const& sum, T&& val) -> T {
-                            return HPX_INVOKE(op1, sum, val);
-                        },
-                        part_sum);
-
-                    // the vectorization might not cover all of the sequences,
-                    // handle the remainder directly
-                    if (p.first != last1)
-                    {
-                        util::loop2<ExPolicy>(std::false_type(), p.first, last1,
-                            p.second,
-                            transform_reduce_binary_partition<Op1, Op2,
-                                decltype(result)>{HPX_FORWARD(Op1, op1),
-                                HPX_FORWARD(Op2, op2), result});
-                    }
-
-                    return util::detail::extract_value<ExPolicy>(result);
+                    return sequential_reduce<ExPolicy>(it1, last1, it2, result,
+                        HPX_FORWARD(Op1, op1), HPX_FORWARD(Op2, op2));
                 };
 
                 using hpx::util::make_zip_iterator;

--- a/libs/core/algorithms/include/hpx/parallel/datapar.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/datapar.hpp
@@ -21,6 +21,7 @@
 #include <hpx/parallel/datapar/iterator_helpers.hpp>
 #include <hpx/parallel/datapar/loop.hpp>
 #include <hpx/parallel/datapar/mismatch.hpp>
+#include <hpx/parallel/datapar/reduce.hpp>
 #include <hpx/parallel/datapar/transfer.hpp>
 #include <hpx/parallel/datapar/transform_loop.hpp>
 #include <hpx/parallel/datapar/zip_iterator.hpp>

--- a/libs/core/algorithms/include/hpx/parallel/datapar/reduce.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/datapar/reduce.hpp
@@ -31,8 +31,8 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
     {
         template <typename InIterB, typename InIterE, typename T,
             typename Reduce>
-        HPX_HOST_DEVICE HPX_FORCEINLINE static T call(ExPolicy&& policy,
-            InIterB first, InIterE last, T&& init, Reduce&& r)
+        HPX_HOST_DEVICE HPX_FORCEINLINE static T call(
+            ExPolicy&& policy, InIterB first, InIterE last, T init, Reduce&& r)
         {
             util::loop_ind(HPX_FORWARD(ExPolicy, policy), first, last,
                 [&init, reduce_op = HPX_FORWARD(Reduce, r)](auto& val) {
@@ -58,7 +58,7 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
         template <typename Iter, typename Sent, typename T, typename Reduce,
             typename Convert>
         HPX_HOST_DEVICE HPX_FORCEINLINE static T call(ExPolicy&& policy,
-            Iter first, Sent last, T&& init, Reduce&& r, Convert&& conv)
+            Iter first, Sent last, T init, Reduce&& r, Convert&& conv)
         {
             util::loop_ind(HPX_FORWARD(ExPolicy, policy), first, last,
                 [&init, reduce_op = HPX_FORWARD(Reduce, r),
@@ -87,7 +87,7 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
         template <typename Iter1, typename Sent, typename Iter2, typename T,
             typename Reduce, typename Convert>
         HPX_HOST_DEVICE HPX_FORCEINLINE static T call(Iter1 first1, Sent last1,
-            Iter2 first2, T&& init, Reduce&& r, Convert&& conv)
+            Iter2 first2, T init, Reduce&& r, Convert&& conv)
         {
             util::loop2<ExPolicy>(first1, last1, first2,
                 [&init, reduce_op = HPX_FORWARD(Reduce, r),
@@ -107,7 +107,7 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
         HPX_CONCEPT_REQUIRES_(
             hpx::is_vectorpack_execution_policy<ExPolicy>::value)>
     HPX_HOST_DEVICE HPX_FORCEINLINE T tag_invoke(sequential_reduce_t<ExPolicy>,
-        ExPolicy&& policy, InIterB first, InIterE last, T&& init, Reduce&& r)
+        ExPolicy&& policy, InIterB first, InIterE last, T init, Reduce&& r)
     {
         if constexpr (hpx::parallel::util::detail::iterator_datapar_compatible<
                           InIterB>::value &&
@@ -115,15 +115,15 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
                 InIterE>::value)
         {
             return datapar_reduce<ExPolicy>::call(HPX_FORWARD(ExPolicy, policy),
-                first, last, HPX_FORWARD(T, init), HPX_FORWARD(Reduce, r));
+                first, last, init, HPX_FORWARD(Reduce, r));
         }
         else
         {
             using execution_policy_type = typename std::decay_t<ExPolicy>;
             using base_policy_type =
                 typename execution_policy_type::base_policy_type;
-            return sequential_reduce<base_policy_type>(base_policy_type{},
-                first, last, HPX_FORWARD(T, init), HPX_FORWARD(Reduce, r));
+            return sequential_reduce<base_policy_type>(
+                base_policy_type{}, first, last, init, HPX_FORWARD(Reduce, r));
         }
     }
 
@@ -154,7 +154,7 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
         HPX_CONCEPT_REQUIRES_(
             hpx::is_vectorpack_execution_policy<ExPolicy>::value)>
     HPX_HOST_DEVICE HPX_FORCEINLINE T tag_invoke(sequential_reduce_t<ExPolicy>,
-        ExPolicy&& policy, Iter first, Sent last, T&& init, Reduce&& r,
+        ExPolicy&& policy, Iter first, Sent last, T init, Reduce&& r,
         Convert&& conv)
     {
         if constexpr (hpx::parallel::util::detail::iterator_datapar_compatible<
@@ -163,7 +163,7 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
                 Sent>::value)
         {
             return datapar_reduce<ExPolicy>::call(HPX_FORWARD(ExPolicy, policy),
-                first, last, HPX_FORWARD(T, init), HPX_FORWARD(Reduce, r),
+                first, last, init, HPX_FORWARD(Reduce, r),
                 HPX_FORWARD(Convert, conv));
         }
         else
@@ -172,7 +172,7 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
             using base_policy_type =
                 typename execution_policy_type::base_policy_type;
             return sequential_reduce<base_policy_type>(base_policy_type{},
-                first, last, HPX_FORWARD(T, init), HPX_FORWARD(Reduce, r),
+                first, last, init, HPX_FORWARD(Reduce, r),
                 HPX_FORWARD(Convert, conv));
         }
     }
@@ -205,7 +205,7 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
         HPX_CONCEPT_REQUIRES_(
             hpx::is_vectorpack_execution_policy<ExPolicy>::value)>
     HPX_HOST_DEVICE HPX_FORCEINLINE T tag_invoke(sequential_reduce_t<ExPolicy>,
-        Iter1 first1, Sent last1, Iter2 first2, T&& init, Reduce&& r,
+        Iter1 first1, Sent last1, Iter2 first2, T init, Reduce&& r,
         Convert&& conv)
     {
         if constexpr (hpx::parallel::util::detail::iterator_datapar_compatible<
@@ -213,9 +213,8 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
             hpx::parallel::util::detail::iterator_datapar_compatible<
                 Iter2>::value)
         {
-            return datapar_reduce<ExPolicy>::call(first1, last1, first2,
-                HPX_FORWARD(T, init), HPX_FORWARD(Reduce, r),
-                HPX_FORWARD(Convert, conv));
+            return datapar_reduce<ExPolicy>::call(first1, last1, first2, init,
+                HPX_FORWARD(Reduce, r), HPX_FORWARD(Convert, conv));
         }
         else
         {
@@ -223,8 +222,7 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
             using base_policy_type =
                 typename execution_policy_type::base_policy_type;
             return sequential_reduce<base_policy_type>(first1, last1, first2,
-                HPX_FORWARD(T, init), HPX_FORWARD(Reduce, r),
-                HPX_FORWARD(Convert, conv));
+                init, HPX_FORWARD(Reduce, r), HPX_FORWARD(Convert, conv));
         }
     }
 }}}}    // namespace hpx::parallel::v1::detail

--- a/libs/core/algorithms/include/hpx/parallel/datapar/reduce.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/datapar/reduce.hpp
@@ -1,0 +1,231 @@
+//  Copyright (c) 2022 Srinivas Yadav
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include <hpx/config.hpp>
+
+#if defined(HPX_HAVE_DATAPAR)
+#include <hpx/execution/traits/is_execution_policy.hpp>
+#include <hpx/execution/traits/vector_pack_reduce.hpp>
+#include <hpx/executors/datapar/execution_policy.hpp>
+#include <hpx/functional/tag_invoke.hpp>
+#include <hpx/parallel/algorithms/detail/distance.hpp>
+#include <hpx/parallel/algorithms/detail/reduce.hpp>
+#include <hpx/parallel/datapar/loop.hpp>
+#include <hpx/parallel/util/result_types.hpp>
+#include <hpx/parallel/util/zip_iterator.hpp>
+
+#include <cstddef>
+#include <type_traits>
+#include <utility>
+
+namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
+
+    ///////////////////////////////////////////////////////////////////////////
+    template <typename ExPolicy>
+    struct datapar_reduce
+    {
+        template <typename InIterB, typename InIterE, typename T,
+            typename Reduce>
+        HPX_HOST_DEVICE HPX_FORCEINLINE static T call(ExPolicy&& policy,
+            InIterB first, InIterE last, T&& init, Reduce&& r)
+        {
+            util::loop_ind(HPX_FORWARD(ExPolicy, policy), first, last,
+                [&init, reduce_op = HPX_FORWARD(Reduce, r)](auto& val) {
+                    T partial_res =
+                        hpx::parallel::traits::reduce(reduce_op, val);
+                    init = reduce_op(init, partial_res);
+                });
+            return init;
+        }
+
+        template <typename T, typename FwdIterB, typename Reduce>
+        HPX_HOST_DEVICE HPX_FORCEINLINE static T call(
+            FwdIterB part_begin, std::size_t part_size, T init, Reduce r)
+        {
+            util::loop_n_ind<ExPolicy>(
+                part_begin, part_size, [&r, &init](auto& val) {
+                    T partial_res = hpx::parallel::traits::reduce(r, val);
+                    init = r(init, partial_res);
+                });
+            return init;
+        }
+
+        template <typename Iter, typename Sent, typename T, typename Reduce,
+            typename Convert>
+        HPX_HOST_DEVICE HPX_FORCEINLINE static T call(ExPolicy&& policy,
+            Iter first, Sent last, T&& init, Reduce&& r, Convert&& conv)
+        {
+            util::loop_ind(HPX_FORWARD(ExPolicy, policy), first, last,
+                [&init, reduce_op = HPX_FORWARD(Reduce, r),
+                    conv_op = HPX_FORWARD(Convert, conv)](const auto& v) {
+                    auto cnv = conv_op(v);
+                    T partial_res =
+                        hpx::parallel::traits::reduce(reduce_op, cnv);
+                    init = reduce_op(init, partial_res);
+                });
+            return init;
+        }
+
+        template <typename T, typename Iter, typename Reduce, typename Convert>
+        HPX_HOST_DEVICE HPX_FORCEINLINE static T call(Iter part_begin,
+            std::size_t part_size, T init, Reduce r, Convert conv)
+        {
+            util::loop_n_ind<ExPolicy>(
+                part_begin, part_size, [&r, &conv, &init](const auto& v) {
+                    auto cnv = conv(v);
+                    T partial_res = hpx::parallel::traits::reduce(r, cnv);
+                    init = r(init, partial_res);
+                });
+            return init;
+        }
+
+        template <typename Iter1, typename Sent, typename Iter2, typename T,
+            typename Reduce, typename Convert>
+        HPX_HOST_DEVICE HPX_FORCEINLINE static T call(Iter1 first1, Sent last1,
+            Iter2 first2, T&& init, Reduce&& r, Convert&& conv)
+        {
+            util::loop2<ExPolicy>(first1, last1, first2,
+                [&init, reduce_op = HPX_FORWARD(Reduce, r),
+                    convert_op = HPX_FORWARD(Convert, conv)](
+                    auto it1, auto it2) {
+                    auto conv = HPX_INVOKE(convert_op, it1, it2);
+                    auto partial_res =
+                        hpx::parallel::traits::reduce(reduce_op, conv);
+                    init = HPX_INVOKE(reduce_op, init, partial_res);
+                });
+            return init;
+        }
+    };
+
+    template <typename ExPolicy, typename InIterB, typename InIterE, typename T,
+        typename Reduce,
+        HPX_CONCEPT_REQUIRES_(
+            hpx::is_vectorpack_execution_policy<ExPolicy>::value)>
+    HPX_HOST_DEVICE HPX_FORCEINLINE T tag_invoke(sequential_reduce_t<ExPolicy>,
+        ExPolicy&& policy, InIterB first, InIterE last, T&& init, Reduce&& r)
+    {
+        if constexpr (hpx::parallel::util::detail::iterator_datapar_compatible<
+                          InIterB>::value &&
+            hpx::parallel::util::detail::iterator_datapar_compatible<
+                InIterE>::value)
+        {
+            return datapar_reduce<ExPolicy>::call(HPX_FORWARD(ExPolicy, policy),
+                first, last, HPX_FORWARD(T, init), HPX_FORWARD(Reduce, r));
+        }
+        else
+        {
+            using execution_policy_type = typename std::decay_t<ExPolicy>;
+            using base_policy_type =
+                typename execution_policy_type::base_policy_type;
+            return sequential_reduce<base_policy_type>(base_policy_type{},
+                first, last, HPX_FORWARD(T, init), HPX_FORWARD(Reduce, r));
+        }
+    }
+
+    template <typename ExPolicy, typename T, typename FwdIter, typename Reduce,
+        HPX_CONCEPT_REQUIRES_(
+            hpx::is_vectorpack_execution_policy<ExPolicy>::value)>
+    HPX_HOST_DEVICE HPX_FORCEINLINE T tag_invoke(sequential_reduce_t<ExPolicy>,
+        FwdIter part_begin, std::size_t part_size, T init, Reduce r)
+    {
+        if constexpr (hpx::parallel::util::detail::iterator_datapar_compatible<
+                          FwdIter>::value)
+        {
+            return datapar_reduce<ExPolicy>::call(
+                part_begin, part_size, init, r);
+        }
+        else
+        {
+            using execution_policy_type = typename std::decay_t<ExPolicy>;
+            using base_policy_type =
+                typename execution_policy_type::base_policy_type;
+            return sequential_reduce<base_policy_type>(
+                part_begin, part_size, init, r);
+        }
+    }
+
+    template <typename ExPolicy, typename Iter, typename Sent, typename T,
+        typename Reduce, typename Convert,
+        HPX_CONCEPT_REQUIRES_(
+            hpx::is_vectorpack_execution_policy<ExPolicy>::value)>
+    HPX_HOST_DEVICE HPX_FORCEINLINE T tag_invoke(sequential_reduce_t<ExPolicy>,
+        ExPolicy&& policy, Iter first, Sent last, T&& init, Reduce&& r,
+        Convert&& conv)
+    {
+        if constexpr (hpx::parallel::util::detail::iterator_datapar_compatible<
+                          Iter>::value &&
+            hpx::parallel::util::detail::iterator_datapar_compatible<
+                Sent>::value)
+        {
+            return datapar_reduce<ExPolicy>::call(HPX_FORWARD(ExPolicy, policy),
+                first, last, HPX_FORWARD(T, init), HPX_FORWARD(Reduce, r),
+                HPX_FORWARD(Convert, conv));
+        }
+        else
+        {
+            using execution_policy_type = typename std::decay_t<ExPolicy>;
+            using base_policy_type =
+                typename execution_policy_type::base_policy_type;
+            return sequential_reduce<base_policy_type>(base_policy_type{},
+                first, last, HPX_FORWARD(T, init), HPX_FORWARD(Reduce, r),
+                HPX_FORWARD(Convert, conv));
+        }
+    }
+
+    template <typename ExPolicy, typename T, typename Iter, typename Reduce,
+        typename Convert,
+        HPX_CONCEPT_REQUIRES_(
+            hpx::is_vectorpack_execution_policy<ExPolicy>::value)>
+    HPX_HOST_DEVICE HPX_FORCEINLINE T tag_invoke(sequential_reduce_t<ExPolicy>,
+        Iter part_begin, std::size_t part_size, T init, Reduce r, Convert conv)
+    {
+        if constexpr (hpx::parallel::util::detail::iterator_datapar_compatible<
+                          Iter>::value)
+        {
+            return datapar_reduce<ExPolicy>::call(
+                part_begin, part_size, init, r, conv);
+        }
+        else
+        {
+            using execution_policy_type = typename std::decay_t<ExPolicy>;
+            using base_policy_type =
+                typename execution_policy_type::base_policy_type;
+            return sequential_reduce<base_policy_type>(
+                part_begin, part_size, init, r, conv);
+        }
+    }
+
+    template <typename ExPolicy, typename Iter1, typename Sent, typename Iter2,
+        typename T, typename Reduce, typename Convert,
+        HPX_CONCEPT_REQUIRES_(
+            hpx::is_vectorpack_execution_policy<ExPolicy>::value)>
+    HPX_HOST_DEVICE HPX_FORCEINLINE T tag_invoke(sequential_reduce_t<ExPolicy>,
+        Iter1 first1, Sent last1, Iter2 first2, T&& init, Reduce&& r,
+        Convert&& conv)
+    {
+        if constexpr (hpx::parallel::util::detail::iterator_datapar_compatible<
+                          Iter1>::value &&
+            hpx::parallel::util::detail::iterator_datapar_compatible<
+                Iter2>::value)
+        {
+            return datapar_reduce<ExPolicy>::call(first1, last1, first2,
+                HPX_FORWARD(T, init), HPX_FORWARD(Reduce, r),
+                HPX_FORWARD(Convert, conv));
+        }
+        else
+        {
+            using execution_policy_type = typename std::decay_t<ExPolicy>;
+            using base_policy_type =
+                typename execution_policy_type::base_policy_type;
+            return sequential_reduce<base_policy_type>(first1, last1, first2,
+                HPX_FORWARD(T, init), HPX_FORWARD(Reduce, r),
+                HPX_FORWARD(Convert, conv));
+        }
+    }
+}}}}    // namespace hpx::parallel::v1::detail
+#endif

--- a/libs/core/algorithms/include/hpx/parallel/util/loop.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/util/loop.hpp
@@ -27,64 +27,6 @@
 namespace hpx { namespace parallel { namespace util {
 
     ///////////////////////////////////////////////////////////////////////////
-    template <typename ExPolicy>
-    struct loop_step_t final
-      : hpx::functional::detail::tag_fallback<loop_step_t<ExPolicy>>
-    {
-    private:
-        template <typename VecOnly, typename F, typename... Iters>
-        friend HPX_HOST_DEVICE HPX_FORCEINLINE
-            typename hpx::util::invoke_result<F, Iters...>::type
-            tag_fallback_invoke(hpx::parallel::util::loop_step_t<ExPolicy>,
-                VecOnly&&, F&& f, Iters&... its)
-        {
-            return HPX_INVOKE(HPX_FORWARD(F, f), (its++)...);
-        }
-    };
-
-#if !defined(HPX_COMPUTE_DEVICE_CODE)
-    template <typename ExPolicy>
-    inline constexpr loop_step_t<ExPolicy> loop_step = loop_step_t<ExPolicy>{};
-#else
-    template <typename ExPolicy, typename VecOnly, typename F,
-        typename... Iters>
-    HPX_HOST_DEVICE HPX_FORCEINLINE
-        typename hpx::util::invoke_result<F, Iters...>::type
-        loop_step(VecOnly&& v, F&& f, Iters&... its)
-    {
-        return hpx::parallel::util::loop_step_t<ExPolicy>{}(
-            HPX_FORWARD(VecOnly, v), HPX_FORWARD(F, f), (its)...);
-    }
-#endif
-
-    template <typename ExPolicy>
-    struct loop_optimization_t final
-      : hpx::functional::detail::tag_fallback<loop_optimization_t<ExPolicy>>
-    {
-    private:
-        template <typename Iter>
-        friend HPX_HOST_DEVICE HPX_FORCEINLINE constexpr bool
-            tag_fallback_invoke(
-                hpx::parallel::util::loop_optimization_t<ExPolicy>, Iter, Iter)
-        {
-            return false;
-        }
-    };
-
-#if !defined(HPX_COMPUTE_DEVICE_CODE)
-    template <typename ExPolicy>
-    inline constexpr loop_optimization_t<ExPolicy> loop_optimization =
-        loop_optimization_t<ExPolicy>{};
-#else
-    template <typename ExPolicy, typename Iter>
-    HPX_HOST_DEVICE HPX_FORCEINLINE constexpr bool loop_optimization(
-        Iter it1, Iter it2)
-    {
-        return hpx::parallel::util::loop_optimization_t<ExPolicy>{}(it1, it2);
-    }
-#endif
-
-    ///////////////////////////////////////////////////////////////////////////
     namespace detail {
 
         // Helper class to repeatedly call a function starting from a given
@@ -272,12 +214,11 @@ namespace hpx { namespace parallel { namespace util {
       : hpx::functional::detail::tag_fallback<loop2_t<ExPolicy>>
     {
     private:
-        template <typename VecOnly, typename Begin1, typename End1,
-            typename Begin2, typename F>
+        template <typename Begin1, typename End1, typename Begin2, typename F>
         friend HPX_HOST_DEVICE
             HPX_FORCEINLINE constexpr std::pair<Begin1, Begin2>
             tag_fallback_invoke(hpx::parallel::util::loop2_t<ExPolicy>,
-                VecOnly&&, Begin1 begin1, End1 end1, Begin2 begin2, F&& f)
+                Begin1 begin1, End1 end1, Begin2 begin2, F&& f)
         {
             return detail::loop2<Begin1, Begin2>::call(
                 begin1, end1, begin2, HPX_FORWARD(F, f));
@@ -288,13 +229,13 @@ namespace hpx { namespace parallel { namespace util {
     template <typename ExPolicy>
     inline constexpr loop2_t<ExPolicy> loop2 = loop2_t<ExPolicy>{};
 #else
-    template <typename ExPolicy, typename VecOnly, typename Begin1,
-        typename End1, typename Begin2, typename F>
+    template <typename ExPolicy, typename Begin1, typename End1,
+        typename Begin2, typename F>
     HPX_HOST_DEVICE HPX_FORCEINLINE constexpr std::pair<Begin1, Begin2> loop2(
-        VecOnly&& v, Begin1 begin1, End1 end1, Begin2 begin2, F&& f)
+        Begin1 begin1, End1 end1, Begin2 begin2, F&& f)
     {
         return hpx::parallel::util::loop2_t<ExPolicy>{}(
-            HPX_FORWARD(VecOnly, v), begin1, end1, begin2, HPX_FORWARD(F, f));
+            begin1, end1, begin2, HPX_FORWARD(F, f));
     }
 #endif
 

--- a/libs/core/algorithms/tests/unit/algorithms/reduce_tests.hpp
+++ b/libs/core/algorithms/tests/unit/algorithms/reduce_tests.hpp
@@ -1,0 +1,350 @@
+//  Copyright (c) 2014-2020 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include <hpx/modules/testing.hpp>
+#include <hpx/parallel/algorithms/reduce.hpp>
+
+#include <cstddef>
+#include <iostream>
+#include <iterator>
+#include <numeric>
+#include <random>
+#include <string>
+#include <vector>
+
+#include "test_utils.hpp"
+
+int seed = std::random_device{}();
+std::mt19937 gen(seed);
+
+///////////////////////////////////////////////////////////////////////////////
+template <typename IteratorTag>
+void test_reduce1(IteratorTag)
+{
+    using base_iterator = std::vector<std::size_t>::iterator;
+    using iterator = test::test_iterator<base_iterator, IteratorTag>;
+
+    std::vector<std::size_t> c(10007);
+    std::iota(std::begin(c), std::end(c), gen());
+
+    std::size_t val(42);
+    auto op = [val](auto v1, auto v2) { return v1 * v2; };
+
+    std::size_t r1 =
+        hpx::reduce(iterator(std::begin(c)), iterator(std::end(c)), val, op);
+
+    // verify values
+    std::size_t r2 = std::accumulate(std::begin(c), std::end(c), val, op);
+    HPX_TEST_EQ(r1, r2);
+}
+
+template <typename ExPolicy, typename IteratorTag>
+void test_reduce1(ExPolicy policy, IteratorTag)
+{
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
+
+    typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+
+    std::vector<std::size_t> c(10007);
+    std::iota(std::begin(c), std::end(c), gen());
+
+    std::size_t val(42);
+    auto op = [val](auto v1, auto v2) { return v1 * v2; };
+
+    std::size_t r1 = hpx::reduce(
+        policy, iterator(std::begin(c)), iterator(std::end(c)), val, op);
+
+    // verify values
+    std::size_t r2 = std::accumulate(std::begin(c), std::end(c), val, op);
+    HPX_TEST_EQ(r1, r2);
+}
+
+template <typename ExPolicy, typename IteratorTag>
+void test_reduce1_async(ExPolicy p, IteratorTag)
+{
+    typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+
+    std::vector<std::size_t> c(10007);
+    std::iota(std::begin(c), std::end(c), gen());
+
+    std::size_t val(42);
+    auto op = [val](auto v1, auto v2) { return v1 * v2; };
+
+    hpx::future<std::size_t> f =
+        hpx::reduce(p, iterator(std::begin(c)), iterator(std::end(c)), val, op);
+    f.wait();
+
+    // verify values
+    std::size_t r2 = std::accumulate(std::begin(c), std::end(c), val, op);
+    HPX_TEST_EQ(f.get(), r2);
+}
+
+///////////////////////////////////////////////////////////////////////////////
+template <typename IteratorTag>
+void test_reduce2(IteratorTag)
+{
+    using base_iterator = std::vector<std::size_t>::iterator;
+    using iterator = test::test_iterator<base_iterator, IteratorTag>;
+
+    std::vector<std::size_t> c(10007);
+    std::iota(std::begin(c), std::end(c), gen());
+
+    std::size_t const val(42);
+    std::size_t r1 =
+        hpx::reduce(iterator(std::begin(c)), iterator(std::end(c)), val);
+
+    // verify values
+    std::size_t r2 = std::accumulate(std::begin(c), std::end(c), val);
+    HPX_TEST_EQ(r1, r2);
+}
+
+template <typename ExPolicy, typename IteratorTag>
+void test_reduce2(ExPolicy policy, IteratorTag)
+{
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
+
+    typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+
+    std::vector<std::size_t> c(10007);
+    std::iota(std::begin(c), std::end(c), gen());
+
+    std::size_t const val(42);
+    std::size_t r1 = hpx::reduce(
+        policy, iterator(std::begin(c)), iterator(std::end(c)), val);
+
+    // verify values
+    std::size_t r2 = std::accumulate(std::begin(c), std::end(c), val);
+    HPX_TEST_EQ(r1, r2);
+}
+
+template <typename ExPolicy, typename IteratorTag>
+void test_reduce2_async(ExPolicy p, IteratorTag)
+{
+    typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+
+    std::vector<std::size_t> c(10007);
+    std::iota(std::begin(c), std::end(c), gen());
+
+    std::size_t const val(42);
+    hpx::future<std::size_t> f =
+        hpx::reduce(p, iterator(std::begin(c)), iterator(std::end(c)), val);
+    f.wait();
+
+    // verify values
+    std::size_t r2 = std::accumulate(std::begin(c), std::end(c), val);
+    HPX_TEST_EQ(f.get(), r2);
+}
+
+///////////////////////////////////////////////////////////////////////////////
+template <typename IteratorTag>
+void test_reduce3(IteratorTag)
+{
+    using base_iterator = std::vector<std::size_t>::iterator;
+    using iterator = test::test_iterator<base_iterator, IteratorTag>;
+
+    std::vector<std::size_t> c(10007);
+    std::iota(std::begin(c), std::end(c), gen());
+
+    std::size_t r1 =
+        hpx::reduce(iterator(std::begin(c)), iterator(std::end(c)));
+
+    // verify values
+    std::size_t r2 =
+        std::accumulate(std::begin(c), std::end(c), std::size_t(0));
+    HPX_TEST_EQ(r1, r2);
+}
+
+template <typename ExPolicy, typename IteratorTag>
+void test_reduce3(ExPolicy policy, IteratorTag)
+{
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
+
+    typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+
+    std::vector<std::size_t> c(10007);
+    std::iota(std::begin(c), std::end(c), gen());
+
+    std::size_t r1 =
+        hpx::reduce(policy, iterator(std::begin(c)), iterator(std::end(c)));
+
+    // verify values
+    std::size_t r2 =
+        std::accumulate(std::begin(c), std::end(c), std::size_t(0));
+    HPX_TEST_EQ(r1, r2);
+}
+
+template <typename ExPolicy, typename IteratorTag>
+void test_reduce3_async(ExPolicy p, IteratorTag)
+{
+    typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+
+    std::vector<std::size_t> c(10007);
+    std::iota(std::begin(c), std::end(c), gen());
+
+    hpx::future<std::size_t> f =
+        hpx::reduce(p, iterator(std::begin(c)), iterator(std::end(c)));
+    f.wait();
+
+    // verify values
+    std::size_t r2 =
+        std::accumulate(std::begin(c), std::end(c), std::size_t(0));
+    HPX_TEST_EQ(f.get(), r2);
+}
+
+///////////////////////////////////////////////////////////////////////////////
+template <typename ExPolicy, typename IteratorTag>
+void test_reduce_exception(ExPolicy policy, IteratorTag)
+{
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
+
+    typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+
+    std::vector<std::size_t> c(10007);
+    std::iota(std::begin(c), std::end(c), gen());
+
+    bool caught_exception = false;
+    try
+    {
+        hpx::reduce(policy, iterator(std::begin(c)), iterator(std::end(c)),
+            std::size_t(42), [](auto v1, auto v2) {
+                return throw std::runtime_error("test"), v1 + v2;
+            });
+
+        HPX_TEST(false);
+    }
+    catch (hpx::exception_list const& e)
+    {
+        caught_exception = true;
+        test::test_num_exceptions<ExPolicy, IteratorTag>::call(policy, e);
+    }
+    catch (...)
+    {
+        HPX_TEST(false);
+    }
+
+    HPX_TEST(caught_exception);
+}
+
+template <typename ExPolicy, typename IteratorTag>
+void test_reduce_exception_async(ExPolicy p, IteratorTag)
+{
+    typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+
+    std::vector<std::size_t> c(10007);
+    std::iota(std::begin(c), std::end(c), gen());
+
+    bool caught_exception = false;
+    bool returned_from_algorithm = false;
+    try
+    {
+        hpx::future<void> f =
+            hpx::reduce(p, iterator(std::begin(c)), iterator(std::end(c)),
+                std::size_t(42), [](auto v1, auto v2) {
+                    return throw std::runtime_error("test"), v1 + v2;
+                });
+        returned_from_algorithm = true;
+        f.get();
+
+        HPX_TEST(false);
+    }
+    catch (hpx::exception_list const& e)
+    {
+        caught_exception = true;
+        test::test_num_exceptions<ExPolicy, IteratorTag>::call(p, e);
+    }
+    catch (...)
+    {
+        HPX_TEST(false);
+    }
+
+    HPX_TEST(caught_exception);
+    HPX_TEST(returned_from_algorithm);
+}
+
+///////////////////////////////////////////////////////////////////////////////
+template <typename ExPolicy, typename IteratorTag>
+void test_reduce_bad_alloc(ExPolicy policy, IteratorTag)
+{
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
+
+    typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+
+    std::vector<std::size_t> c(10007);
+    std::iota(std::begin(c), std::end(c), gen());
+
+    bool caught_exception = false;
+    try
+    {
+        hpx::reduce(policy, iterator(std::begin(c)), iterator(std::end(c)),
+            std::size_t(42), [](auto v1, auto v2) {
+                return throw std::bad_alloc(), v1 + v2;
+            });
+
+        HPX_TEST(false);
+    }
+    catch (std::bad_alloc const&)
+    {
+        caught_exception = true;
+    }
+    catch (...)
+    {
+        HPX_TEST(false);
+    }
+
+    HPX_TEST(caught_exception);
+}
+
+template <typename ExPolicy, typename IteratorTag>
+void test_reduce_bad_alloc_async(ExPolicy p, IteratorTag)
+{
+    typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+
+    std::vector<std::size_t> c(10007);
+    std::iota(std::begin(c), std::end(c), gen());
+
+    bool caught_exception = false;
+    bool returned_from_algorithm = false;
+    try
+    {
+        hpx::future<void> f =
+            hpx::reduce(p, iterator(std::begin(c)), iterator(std::end(c)),
+                std::size_t(42), [](auto v1, auto v2) {
+                    return throw std::bad_alloc(), v1 + v2;
+                });
+        returned_from_algorithm = true;
+        f.get();
+
+        HPX_TEST(false);
+    }
+    catch (std::bad_alloc const&)
+    {
+        caught_exception = true;
+    }
+    catch (...)
+    {
+        HPX_TEST(false);
+    }
+
+    HPX_TEST(caught_exception);
+    HPX_TEST(returned_from_algorithm);
+}

--- a/libs/core/algorithms/tests/unit/algorithms/reduce_tests.hpp
+++ b/libs/core/algorithms/tests/unit/algorithms/reduce_tests.hpp
@@ -33,7 +33,7 @@ void test_reduce1(IteratorTag)
     std::iota(std::begin(c), std::end(c), gen());
 
     std::size_t val(42);
-    auto op = [val](auto v1, auto v2) { return v1 * v2; };
+    auto op = [](auto v1, auto v2) { return v1 * v2; };
 
     std::size_t r1 =
         hpx::reduce(iterator(std::begin(c)), iterator(std::end(c)), val, op);
@@ -56,7 +56,7 @@ void test_reduce1(ExPolicy policy, IteratorTag)
     std::iota(std::begin(c), std::end(c), gen());
 
     std::size_t val(42);
-    auto op = [val](auto v1, auto v2) { return v1 * v2; };
+    auto op = [](auto v1, auto v2) { return v1 * v2; };
 
     std::size_t r1 = hpx::reduce(
         policy, iterator(std::begin(c)), iterator(std::end(c)), val, op);
@@ -76,7 +76,7 @@ void test_reduce1_async(ExPolicy p, IteratorTag)
     std::iota(std::begin(c), std::end(c), gen());
 
     std::size_t val(42);
-    auto op = [val](auto v1, auto v2) { return v1 * v2; };
+    auto op = [](auto v1, auto v2) { return v1 * v2; };
 
     hpx::future<std::size_t> f =
         hpx::reduce(p, iterator(std::begin(c)), iterator(std::end(c)), val, op);
@@ -254,11 +254,10 @@ void test_reduce_exception_async(ExPolicy p, IteratorTag)
     bool returned_from_algorithm = false;
     try
     {
-        hpx::future<void> f =
-            hpx::reduce(p, iterator(std::begin(c)), iterator(std::end(c)),
-                std::size_t(42), [](auto v1, auto v2) {
-                    return throw std::runtime_error("test"), v1 + v2;
-                });
+        hpx::future<void> f = hpx::reduce(p, iterator(std::begin(c)),
+            iterator(std::end(c)), std::size_t(42), [](auto v1, auto v2) {
+                return throw std::runtime_error("test"), v1 + v2;
+            });
         returned_from_algorithm = true;
         f.get();
 
@@ -295,9 +294,8 @@ void test_reduce_bad_alloc(ExPolicy policy, IteratorTag)
     try
     {
         hpx::reduce(policy, iterator(std::begin(c)), iterator(std::end(c)),
-            std::size_t(42), [](auto v1, auto v2) {
-                return throw std::bad_alloc(), v1 + v2;
-            });
+            std::size_t(42),
+            [](auto v1, auto v2) { return throw std::bad_alloc(), v1 + v2; });
 
         HPX_TEST(false);
     }
@@ -326,11 +324,9 @@ void test_reduce_bad_alloc_async(ExPolicy p, IteratorTag)
     bool returned_from_algorithm = false;
     try
     {
-        hpx::future<void> f =
-            hpx::reduce(p, iterator(std::begin(c)), iterator(std::end(c)),
-                std::size_t(42), [](auto v1, auto v2) {
-                    return throw std::bad_alloc(), v1 + v2;
-                });
+        hpx::future<void> f = hpx::reduce(p, iterator(std::begin(c)),
+            iterator(std::end(c)), std::size_t(42),
+            [](auto v1, auto v2) { return throw std::bad_alloc(), v1 + v2; });
         returned_from_algorithm = true;
         f.get();
 

--- a/libs/core/algorithms/tests/unit/algorithms/reduce_tests.hpp
+++ b/libs/core/algorithms/tests/unit/algorithms/reduce_tests.hpp
@@ -26,20 +26,20 @@ std::mt19937 gen(seed);
 template <typename IteratorTag>
 void test_reduce1(IteratorTag)
 {
-    using base_iterator = std::vector<std::size_t>::iterator;
+    using base_iterator = std::vector<int>::iterator;
     using iterator = test::test_iterator<base_iterator, IteratorTag>;
 
-    std::vector<std::size_t> c(10007);
+    std::vector<int> c(10007);
     std::iota(std::begin(c), std::end(c), gen());
 
-    std::size_t val(42);
+    int val(42);
     auto op = [](auto v1, auto v2) { return v1 * v2; };
 
-    std::size_t r1 =
+    int r1 =
         hpx::reduce(iterator(std::begin(c)), iterator(std::end(c)), val, op);
 
     // verify values
-    std::size_t r2 = std::accumulate(std::begin(c), std::end(c), val, op);
+    int r2 = std::accumulate(std::begin(c), std::end(c), val, op);
     HPX_TEST_EQ(r1, r2);
 }
 
@@ -49,41 +49,41 @@ void test_reduce1(ExPolicy policy, IteratorTag)
     static_assert(hpx::is_execution_policy<ExPolicy>::value,
         "hpx::is_execution_policy<ExPolicy>::value");
 
-    typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef std::vector<int>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
 
-    std::vector<std::size_t> c(10007);
+    std::vector<int> c(10007);
     std::iota(std::begin(c), std::end(c), gen());
 
-    std::size_t val(42);
+    int val(42);
     auto op = [](auto v1, auto v2) { return v1 * v2; };
 
-    std::size_t r1 = hpx::reduce(
+    int r1 = hpx::reduce(
         policy, iterator(std::begin(c)), iterator(std::end(c)), val, op);
 
     // verify values
-    std::size_t r2 = std::accumulate(std::begin(c), std::end(c), val, op);
+    int r2 = std::accumulate(std::begin(c), std::end(c), val, op);
     HPX_TEST_EQ(r1, r2);
 }
 
 template <typename ExPolicy, typename IteratorTag>
 void test_reduce1_async(ExPolicy p, IteratorTag)
 {
-    typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef std::vector<int>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
 
-    std::vector<std::size_t> c(10007);
+    std::vector<int> c(10007);
     std::iota(std::begin(c), std::end(c), gen());
 
-    std::size_t val(42);
+    int val(42);
     auto op = [](auto v1, auto v2) { return v1 * v2; };
 
-    hpx::future<std::size_t> f =
+    hpx::future<int> f =
         hpx::reduce(p, iterator(std::begin(c)), iterator(std::end(c)), val, op);
     f.wait();
 
     // verify values
-    std::size_t r2 = std::accumulate(std::begin(c), std::end(c), val, op);
+    int r2 = std::accumulate(std::begin(c), std::end(c), val, op);
     HPX_TEST_EQ(f.get(), r2);
 }
 
@@ -91,18 +91,17 @@ void test_reduce1_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_reduce2(IteratorTag)
 {
-    using base_iterator = std::vector<std::size_t>::iterator;
+    using base_iterator = std::vector<int>::iterator;
     using iterator = test::test_iterator<base_iterator, IteratorTag>;
 
-    std::vector<std::size_t> c(10007);
+    std::vector<int> c(10007);
     std::iota(std::begin(c), std::end(c), gen());
 
-    std::size_t const val(42);
-    std::size_t r1 =
-        hpx::reduce(iterator(std::begin(c)), iterator(std::end(c)), val);
+    int const val(42);
+    int r1 = hpx::reduce(iterator(std::begin(c)), iterator(std::end(c)), val);
 
     // verify values
-    std::size_t r2 = std::accumulate(std::begin(c), std::end(c), val);
+    int r2 = std::accumulate(std::begin(c), std::end(c), val);
     HPX_TEST_EQ(r1, r2);
 }
 
@@ -112,37 +111,37 @@ void test_reduce2(ExPolicy policy, IteratorTag)
     static_assert(hpx::is_execution_policy<ExPolicy>::value,
         "hpx::is_execution_policy<ExPolicy>::value");
 
-    typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef std::vector<int>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
 
-    std::vector<std::size_t> c(10007);
+    std::vector<int> c(10007);
     std::iota(std::begin(c), std::end(c), gen());
 
-    std::size_t const val(42);
-    std::size_t r1 = hpx::reduce(
+    int const val(42);
+    int r1 = hpx::reduce(
         policy, iterator(std::begin(c)), iterator(std::end(c)), val);
 
     // verify values
-    std::size_t r2 = std::accumulate(std::begin(c), std::end(c), val);
+    int r2 = std::accumulate(std::begin(c), std::end(c), val);
     HPX_TEST_EQ(r1, r2);
 }
 
 template <typename ExPolicy, typename IteratorTag>
 void test_reduce2_async(ExPolicy p, IteratorTag)
 {
-    typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef std::vector<int>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
 
-    std::vector<std::size_t> c(10007);
+    std::vector<int> c(10007);
     std::iota(std::begin(c), std::end(c), gen());
 
-    std::size_t const val(42);
-    hpx::future<std::size_t> f =
+    int const val(42);
+    hpx::future<int> f =
         hpx::reduce(p, iterator(std::begin(c)), iterator(std::end(c)), val);
     f.wait();
 
     // verify values
-    std::size_t r2 = std::accumulate(std::begin(c), std::end(c), val);
+    int r2 = std::accumulate(std::begin(c), std::end(c), val);
     HPX_TEST_EQ(f.get(), r2);
 }
 
@@ -150,18 +149,16 @@ void test_reduce2_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_reduce3(IteratorTag)
 {
-    using base_iterator = std::vector<std::size_t>::iterator;
+    using base_iterator = std::vector<int>::iterator;
     using iterator = test::test_iterator<base_iterator, IteratorTag>;
 
-    std::vector<std::size_t> c(10007);
+    std::vector<int> c(10007);
     std::iota(std::begin(c), std::end(c), gen());
 
-    std::size_t r1 =
-        hpx::reduce(iterator(std::begin(c)), iterator(std::end(c)));
+    int r1 = hpx::reduce(iterator(std::begin(c)), iterator(std::end(c)));
 
     // verify values
-    std::size_t r2 =
-        std::accumulate(std::begin(c), std::end(c), std::size_t(0));
+    int r2 = std::accumulate(std::begin(c), std::end(c), int(0));
     HPX_TEST_EQ(r1, r2);
 }
 
@@ -171,37 +168,35 @@ void test_reduce3(ExPolicy policy, IteratorTag)
     static_assert(hpx::is_execution_policy<ExPolicy>::value,
         "hpx::is_execution_policy<ExPolicy>::value");
 
-    typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef std::vector<int>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
 
-    std::vector<std::size_t> c(10007);
+    std::vector<int> c(10007);
     std::iota(std::begin(c), std::end(c), gen());
 
-    std::size_t r1 =
+    int r1 =
         hpx::reduce(policy, iterator(std::begin(c)), iterator(std::end(c)));
 
     // verify values
-    std::size_t r2 =
-        std::accumulate(std::begin(c), std::end(c), std::size_t(0));
+    int r2 = std::accumulate(std::begin(c), std::end(c), int(0));
     HPX_TEST_EQ(r1, r2);
 }
 
 template <typename ExPolicy, typename IteratorTag>
 void test_reduce3_async(ExPolicy p, IteratorTag)
 {
-    typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef std::vector<int>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
 
-    std::vector<std::size_t> c(10007);
+    std::vector<int> c(10007);
     std::iota(std::begin(c), std::end(c), gen());
 
-    hpx::future<std::size_t> f =
+    hpx::future<int> f =
         hpx::reduce(p, iterator(std::begin(c)), iterator(std::end(c)));
     f.wait();
 
     // verify values
-    std::size_t r2 =
-        std::accumulate(std::begin(c), std::end(c), std::size_t(0));
+    int r2 = std::accumulate(std::begin(c), std::end(c), int(0));
     HPX_TEST_EQ(f.get(), r2);
 }
 
@@ -212,17 +207,17 @@ void test_reduce_exception(ExPolicy policy, IteratorTag)
     static_assert(hpx::is_execution_policy<ExPolicy>::value,
         "hpx::is_execution_policy<ExPolicy>::value");
 
-    typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef std::vector<int>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
 
-    std::vector<std::size_t> c(10007);
+    std::vector<int> c(10007);
     std::iota(std::begin(c), std::end(c), gen());
 
     bool caught_exception = false;
     try
     {
         hpx::reduce(policy, iterator(std::begin(c)), iterator(std::end(c)),
-            std::size_t(42), [](auto v1, auto v2) {
+            int(42), [](auto v1, auto v2) {
                 return throw std::runtime_error("test"), v1 + v2;
             });
 
@@ -244,10 +239,10 @@ void test_reduce_exception(ExPolicy policy, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_reduce_exception_async(ExPolicy p, IteratorTag)
 {
-    typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef std::vector<int>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
 
-    std::vector<std::size_t> c(10007);
+    std::vector<int> c(10007);
     std::iota(std::begin(c), std::end(c), gen());
 
     bool caught_exception = false;
@@ -255,7 +250,7 @@ void test_reduce_exception_async(ExPolicy p, IteratorTag)
     try
     {
         hpx::future<void> f = hpx::reduce(p, iterator(std::begin(c)),
-            iterator(std::end(c)), std::size_t(42), [](auto v1, auto v2) {
+            iterator(std::end(c)), int(42), [](auto v1, auto v2) {
                 return throw std::runtime_error("test"), v1 + v2;
             });
         returned_from_algorithm = true;
@@ -284,17 +279,17 @@ void test_reduce_bad_alloc(ExPolicy policy, IteratorTag)
     static_assert(hpx::is_execution_policy<ExPolicy>::value,
         "hpx::is_execution_policy<ExPolicy>::value");
 
-    typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef std::vector<int>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
 
-    std::vector<std::size_t> c(10007);
+    std::vector<int> c(10007);
     std::iota(std::begin(c), std::end(c), gen());
 
     bool caught_exception = false;
     try
     {
         hpx::reduce(policy, iterator(std::begin(c)), iterator(std::end(c)),
-            std::size_t(42),
+            int(42),
             [](auto v1, auto v2) { return throw std::bad_alloc(), v1 + v2; });
 
         HPX_TEST(false);
@@ -314,10 +309,10 @@ void test_reduce_bad_alloc(ExPolicy policy, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_reduce_bad_alloc_async(ExPolicy p, IteratorTag)
 {
-    typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef std::vector<int>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
 
-    std::vector<std::size_t> c(10007);
+    std::vector<int> c(10007);
     std::iota(std::begin(c), std::end(c), gen());
 
     bool caught_exception = false;
@@ -325,7 +320,7 @@ void test_reduce_bad_alloc_async(ExPolicy p, IteratorTag)
     try
     {
         hpx::future<void> f = hpx::reduce(p, iterator(std::begin(c)),
-            iterator(std::end(c)), std::size_t(42),
+            iterator(std::end(c)), int(42),
             [](auto v1, auto v2) { return throw std::bad_alloc(), v1 + v2; });
         returned_from_algorithm = true;
         f.get();

--- a/libs/core/algorithms/tests/unit/datapar_algorithms/CMakeLists.txt
+++ b/libs/core/algorithms/tests/unit/datapar_algorithms/CMakeLists.txt
@@ -34,9 +34,11 @@ if(HPX_WITH_DATAPAR_VC OR HPX_WITH_CXX20_EXPERIMENTAL_SIMD)
       mismatch_binary_datapar
       mismatch_datapar
       none_of_datapar
+      reduce_datapar
       transform_binary_datapar
       transform_binary2_datapar
       transform_datapar
+      transform_reduce_datapar
       transform_reduce_binary_datapar
   )
 endif()

--- a/libs/core/algorithms/tests/unit/datapar_algorithms/reduce_datapar.cpp
+++ b/libs/core/algorithms/tests/unit/datapar_algorithms/reduce_datapar.cpp
@@ -1,9 +1,10 @@
-//  Copyright (c) 2014-2020 Hartmut Kaiser
+//  Copyright (c) 2022 Srinivas Yadav
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+#include <hpx/include/datapar.hpp>
 #include <hpx/local/init.hpp>
 
 #include <cstddef>
@@ -11,7 +12,7 @@
 #include <string>
 #include <vector>
 
-#include "reduce_tests.hpp"
+#include "../algorithms/reduce_tests.hpp"
 
 ///////////////////////////////////////////////////////////////////////////////
 template <typename IteratorTag>
@@ -19,13 +20,11 @@ void test_reduce1()
 {
     using namespace hpx::execution;
 
-    test_reduce1(IteratorTag());
-    test_reduce1(seq, IteratorTag());
-    test_reduce1(par, IteratorTag());
-    test_reduce1(par_unseq, IteratorTag());
+    test_reduce1(simd, IteratorTag());
+    test_reduce1(par_simd, IteratorTag());
 
-    test_reduce1_async(seq(task), IteratorTag());
-    test_reduce1_async(par(task), IteratorTag());
+    test_reduce1_async(simd(task), IteratorTag());
+    test_reduce1_async(par_simd(task), IteratorTag());
 }
 
 void reduce_test1()
@@ -40,13 +39,11 @@ void test_reduce2()
 {
     using namespace hpx::execution;
 
-    test_reduce2(IteratorTag());
-    test_reduce2(seq, IteratorTag());
-    test_reduce2(par, IteratorTag());
-    test_reduce2(par_unseq, IteratorTag());
+    test_reduce2(simd, IteratorTag());
+    test_reduce2(par_simd, IteratorTag());
 
-    test_reduce2_async(seq(task), IteratorTag());
-    test_reduce2_async(par(task), IteratorTag());
+    test_reduce2_async(simd(task), IteratorTag());
+    test_reduce2_async(par_simd(task), IteratorTag());
 }
 
 void reduce_test2()
@@ -61,13 +58,11 @@ void test_reduce3()
 {
     using namespace hpx::execution;
 
-    test_reduce3(IteratorTag());
-    test_reduce3(seq, IteratorTag());
-    test_reduce3(par, IteratorTag());
-    test_reduce3(par_unseq, IteratorTag());
+    test_reduce3(simd, IteratorTag());
+    test_reduce3(par_simd, IteratorTag());
 
-    test_reduce3_async(seq(task), IteratorTag());
-    test_reduce3_async(par(task), IteratorTag());
+    test_reduce3_async(simd(task), IteratorTag());
+    test_reduce3_async(par_simd(task), IteratorTag());
 }
 
 void reduce_test3()
@@ -82,14 +77,11 @@ void test_reduce_exception()
 {
     using namespace hpx::execution;
 
-    // If the execution policy object is of type vector_execution_policy,
-    // std::terminate shall be called. therefore we do not test exceptions
-    // with a vector execution policy
-    test_reduce_exception(seq, IteratorTag());
-    test_reduce_exception(par, IteratorTag());
+    test_reduce_exception(simd, IteratorTag());
+    test_reduce_exception(par_simd, IteratorTag());
 
-    test_reduce_exception_async(seq(task), IteratorTag());
-    test_reduce_exception_async(par(task), IteratorTag());
+    test_reduce_exception_async(simd(task), IteratorTag());
+    test_reduce_exception_async(par_simd(task), IteratorTag());
 }
 
 void reduce_exception_test()
@@ -104,14 +96,11 @@ void test_reduce_bad_alloc()
 {
     using namespace hpx::execution;
 
-    // If the execution policy object is of type vector_execution_policy,
-    // std::terminate shall be called. therefore we do not test exceptions
-    // with a vector execution policy
-    test_reduce_bad_alloc(seq, IteratorTag());
-    test_reduce_bad_alloc(par, IteratorTag());
+    test_reduce_bad_alloc(simd, IteratorTag());
+    test_reduce_bad_alloc(par_simd, IteratorTag());
 
-    test_reduce_bad_alloc_async(seq(task), IteratorTag());
-    test_reduce_bad_alloc_async(par(task), IteratorTag());
+    test_reduce_bad_alloc_async(simd(task), IteratorTag());
+    test_reduce_bad_alloc_async(par_simd(task), IteratorTag());
 }
 
 void reduce_bad_alloc_test()

--- a/libs/core/algorithms/tests/unit/datapar_algorithms/transform_reduce_datapar.cpp
+++ b/libs/core/algorithms/tests/unit/datapar_algorithms/transform_reduce_datapar.cpp
@@ -1,0 +1,129 @@
+//  Copyright (c) 2022 Srinivas Yadav
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/include/datapar.hpp>
+#include <hpx/local/init.hpp>
+#include <hpx/modules/testing.hpp>
+#include <hpx/parallel/algorithms/transform_reduce.hpp>
+
+#include <algorithm>
+#include <cstddef>
+#include <iostream>
+#include <iterator>
+#include <numeric>
+#include <string>
+#include <vector>
+
+#include "../algorithms/test_utils.hpp"
+
+///////////////////////////////////////////////////////////////////////////////
+template <typename ExPolicy, typename IteratorTag>
+void test_transform_reduce(ExPolicy&& policy, IteratorTag)
+{
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
+
+    typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+
+    std::vector<std::size_t> c(10007);
+    std::iota(std::begin(c), std::end(c), std::rand());
+
+    auto reduce_op = [](auto v1, auto v2) { return v1 + v2; };
+
+    auto convert_op = [](auto val) { return val * val; };
+
+    std::size_t const init = std::size_t(1);
+
+    std::size_t r1 = hpx::transform_reduce(policy, iterator(std::begin(c)),
+        iterator(std::end(c)), init, reduce_op, convert_op);
+
+    // verify values
+    std::size_t r2 = std::accumulate(std::begin(c), std::end(c), init,
+        [&reduce_op, &convert_op](
+            auto res, auto val) { return reduce_op(res, convert_op(val)); });
+
+    HPX_TEST_EQ(r1, r2);
+    HPX_TEST_EQ(r1, r2);
+}
+
+template <typename ExPolicy, typename IteratorTag>
+void test_transform_reduce_async(ExPolicy&& p, IteratorTag)
+{
+    typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+
+    std::vector<std::size_t> c(10007);
+    std::iota(std::begin(c), std::end(c), std::rand());
+
+    std::size_t val = 42;
+    auto op = std::plus<>{};
+
+    hpx::future<std::size_t> f =
+        hpx::transform_reduce(p, iterator(std::begin(c)), iterator(std::end(c)),
+            val, op, [](auto v) { return v; });
+    f.wait();
+
+    // verify values
+    std::size_t r2 = std::accumulate(std::begin(c), std::end(c), val, op);
+    HPX_TEST_EQ(f.get(), r2);
+}
+
+template <typename IteratorTag>
+void test_transform_reduce()
+{
+    using namespace hpx::execution;
+
+    test_transform_reduce(simd, IteratorTag());
+    test_transform_reduce(par_simd, IteratorTag());
+
+    test_transform_reduce_async(simd(task), IteratorTag());
+    test_transform_reduce_async(par_simd(task), IteratorTag());
+}
+
+void transform_reduce_test()
+{
+    test_transform_reduce<std::random_access_iterator_tag>();
+    test_transform_reduce<std::forward_iterator_tag>();
+}
+
+int hpx_main(hpx::program_options::variables_map& vm)
+{
+    unsigned int seed = (unsigned int) std::time(nullptr);
+    if (vm.count("seed"))
+        seed = vm["seed"].as<unsigned int>();
+
+    std::cout << "using seed: " << seed << std::endl;
+    std::srand(seed);
+
+    transform_reduce_test();
+
+    return hpx::local::finalize();
+}
+
+int main(int argc, char* argv[])
+{
+    // add command line option which controls the random number generator seed
+    using namespace hpx::program_options;
+    options_description desc_commandline(
+        "Usage: " HPX_APPLICATION_STRING " [options]");
+
+    desc_commandline.add_options()("seed,s", value<unsigned int>(),
+        "the random number generator seed to use for this run");
+
+    //By default run on all available cores
+    std::vector<std::string> const cfg = {"hpx.os_threads=all"};
+
+    // Initialize and run HPX
+    hpx::local::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::local::init(hpx_main, argc, argv, init_args), 0,
+        "HPX main exited with non-zero status");
+
+    return hpx::util::report_errors();
+}

--- a/libs/core/algorithms/tests/unit/datapar_algorithms/transform_reduce_datapar.cpp
+++ b/libs/core/algorithms/tests/unit/datapar_algorithms/transform_reduce_datapar.cpp
@@ -26,23 +26,23 @@ void test_transform_reduce(ExPolicy&& policy, IteratorTag)
     static_assert(hpx::is_execution_policy<ExPolicy>::value,
         "hpx::is_execution_policy<ExPolicy>::value");
 
-    typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef std::vector<int>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
 
-    std::vector<std::size_t> c(10007);
+    std::vector<int> c(10007);
     std::iota(std::begin(c), std::end(c), std::rand());
 
     auto reduce_op = [](auto v1, auto v2) { return v1 + v2; };
 
     auto convert_op = [](auto val) { return val * val; };
 
-    std::size_t const init = std::size_t(1);
+    int const init = int(1);
 
-    std::size_t r1 = hpx::transform_reduce(policy, iterator(std::begin(c)),
+    int r1 = hpx::transform_reduce(policy, iterator(std::begin(c)),
         iterator(std::end(c)), init, reduce_op, convert_op);
 
     // verify values
-    std::size_t r2 = std::accumulate(std::begin(c), std::end(c), init,
+    int r2 = std::accumulate(std::begin(c), std::end(c), init,
         [&reduce_op, &convert_op](
             auto res, auto val) { return reduce_op(res, convert_op(val)); });
 
@@ -53,22 +53,21 @@ void test_transform_reduce(ExPolicy&& policy, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_transform_reduce_async(ExPolicy&& p, IteratorTag)
 {
-    typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef std::vector<int>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
 
-    std::vector<std::size_t> c(10007);
+    std::vector<int> c(10007);
     std::iota(std::begin(c), std::end(c), std::rand());
 
-    std::size_t val = 42;
+    int val = 42;
     auto op = std::plus<>{};
 
-    hpx::future<std::size_t> f =
-        hpx::transform_reduce(p, iterator(std::begin(c)), iterator(std::end(c)),
-            val, op, [](auto v) { return v; });
+    hpx::future<int> f = hpx::transform_reduce(p, iterator(std::begin(c)),
+        iterator(std::end(c)), val, op, [](auto v) { return v; });
     f.wait();
 
     // verify values
-    std::size_t r2 = std::accumulate(std::begin(c), std::end(c), val, op);
+    int r2 = std::accumulate(std::begin(c), std::end(c), val, op);
     HPX_TEST_EQ(f.get(), r2);
 }
 

--- a/libs/core/execution/CMakeLists.txt
+++ b/libs/core/execution/CMakeLists.txt
@@ -58,6 +58,7 @@ set(execution_headers
     hpx/execution/traits/detail/simd/vector_pack_count_bits.hpp
     hpx/execution/traits/detail/simd/vector_pack_find.hpp
     hpx/execution/traits/detail/simd/vector_pack_load_store.hpp
+    hpx/execution/traits/detail/simd/vector_pack_reduce.hpp
     hpx/execution/traits/detail/simd/vector_pack_type.hpp
     hpx/execution/traits/detail/vc/vector_pack_alignment_size.hpp
     hpx/execution/traits/detail/vc/vector_pack_all_any_none.hpp
@@ -73,6 +74,7 @@ set(execution_headers
     hpx/execution/traits/vector_pack_count_bits.hpp
     hpx/execution/traits/vector_pack_find.hpp
     hpx/execution/traits/vector_pack_load_store.hpp
+    hpx/execution/traits/vector_pack_reduce.hpp
     hpx/execution/traits/vector_pack_type.hpp
 )
 
@@ -103,6 +105,7 @@ set(execution_compat_headers
     hpx/parallel/traits/vector_pack_find.hpp => hpx/execution.hpp
     hpx/parallel/traits/vector_pack_count_bits.hpp => hpx/execution.hpp
     hpx/parallel/traits/vector_pack_load_store.hpp => hpx/execution.hpp
+    hpx/parallel/traits/vector_pack_load_reduce.hpp => hpx/execution.hpp
     hpx/parallel/traits/vector_pack_type.hpp => hpx/execution.hpp
     hpx/sync_launch_policy_dispatch.hpp => hpx/execution.hpp
     hpx/traits/executor_traits.hpp => hpx/execution.hpp

--- a/libs/core/execution/CMakeLists.txt
+++ b/libs/core/execution/CMakeLists.txt
@@ -65,6 +65,7 @@ set(execution_headers
     hpx/execution/traits/detail/vc/vector_pack_count_bits.hpp
     hpx/execution/traits/detail/vc/vector_pack_find.hpp
     hpx/execution/traits/detail/vc/vector_pack_load_store.hpp
+    hpx/execution/traits/detail/vc/vector_pack_reduce.hpp
     hpx/execution/traits/detail/vc/vector_pack_type.hpp
     hpx/execution/traits/executor_traits.hpp
     hpx/execution/traits/future_then_result_exec.hpp

--- a/libs/core/execution/include/hpx/execution/traits/detail/simd/vector_pack_reduce.hpp
+++ b/libs/core/execution/include/hpx/execution/traits/detail/simd/vector_pack_reduce.hpp
@@ -17,7 +17,7 @@ namespace hpx { namespace parallel { namespace traits {
     ///////////////////////////////////////////////////////////////////////
     template <typename T, typename Abi, typename Reduce>
     HPX_HOST_DEVICE HPX_FORCEINLINE T reduce(
-        Reduce r, std::experimental::simd<T, Abi>& val)
+        Reduce r, std::experimental::simd<T, Abi> const& val)
     {
         return std::experimental::reduce(val, r);
     }

--- a/libs/core/execution/include/hpx/execution/traits/detail/simd/vector_pack_reduce.hpp
+++ b/libs/core/execution/include/hpx/execution/traits/detail/simd/vector_pack_reduce.hpp
@@ -19,8 +19,7 @@ namespace hpx { namespace parallel { namespace traits {
     HPX_HOST_DEVICE HPX_FORCEINLINE T reduce(
         Reduce r, std::experimental::simd<T, Abi>& val)
     {
-        using mask_type = typename std::experimental::simd<T, Abi>::mask_type;
-        return std::experimental::reduce(where(mask_type(true), val), T(1), r);
+        return std::experimental::reduce(val, r);
     }
 }}}    // namespace hpx::parallel::traits
 

--- a/libs/core/execution/include/hpx/execution/traits/detail/simd/vector_pack_reduce.hpp
+++ b/libs/core/execution/include/hpx/execution/traits/detail/simd/vector_pack_reduce.hpp
@@ -1,0 +1,27 @@
+//  Copyright (c) 2022 Srinivas Yadav
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include <hpx/config.hpp>
+
+#if defined(HPX_HAVE_CXX20_EXPERIMENTAL_SIMD)
+#include <cstddef>
+
+#include <experimental/simd>
+
+namespace hpx { namespace parallel { namespace traits {
+    ///////////////////////////////////////////////////////////////////////
+    template <typename T, typename Abi, typename Reduce>
+    HPX_HOST_DEVICE HPX_FORCEINLINE T reduce(
+        Reduce r, std::experimental::simd<T, Abi>& val)
+    {
+        using mask_type = typename std::experimental::simd<T, Abi>::mask_type;
+        return std::experimental::reduce(where(mask_type(true), val), T(1), r);
+    }
+}}}    // namespace hpx::parallel::traits
+
+#endif

--- a/libs/core/execution/include/hpx/execution/traits/detail/vc/vector_pack_reduce.hpp
+++ b/libs/core/execution/include/hpx/execution/traits/detail/vc/vector_pack_reduce.hpp
@@ -8,21 +8,25 @@
 
 #include <hpx/config.hpp>
 
-#if defined(HPX_HAVE_DATAPAR)
+#if defined(HPX_HAVE_DATAPAR_VC)
+#include <cstddef>
 
-#if !defined(__CUDACC__)
+#include <Vc/Vc>
+#include <Vc/global.h>
 
 namespace hpx { namespace parallel { namespace traits {
     ///////////////////////////////////////////////////////////////////////
-    template <typename T, typename Reduce>
-    HPX_HOST_DEVICE HPX_FORCEINLINE T reduce(Reduce, T val)
+    template <typename T, typename Abi, typename Reduce>
+    HPX_HOST_DEVICE HPX_FORCEINLINE T reduce(
+        Reduce r, Vc::Vector<T, Abi> const& val)
     {
-        return val;
+        T init = val[0];
+        for (std::size_t i = 1; i != val.size(); i++)
+        {
+            init = HPX_INVOKE(r, init, val[i]);
+        }
+        return init;
     }
 }}}    // namespace hpx::parallel::traits
-
-#include <hpx/execution/traits/detail/simd/vector_pack_reduce.hpp>
-#include <hpx/execution/traits/detail/vc/vector_pack_reduce.hpp>
-#endif
 
 #endif

--- a/libs/core/execution/include/hpx/execution/traits/vector_pack_reduce.hpp
+++ b/libs/core/execution/include/hpx/execution/traits/vector_pack_reduce.hpp
@@ -1,0 +1,27 @@
+//  Copyright (c) 2022 Srinivas Yadav
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include <hpx/config.hpp>
+
+#if defined(HPX_HAVE_DATAPAR)
+
+#if !defined(__CUDACC__)
+
+namespace hpx { namespace parallel { namespace traits {
+    ///////////////////////////////////////////////////////////////////////
+    template <typename T, typename Reduce>
+    HPX_HOST_DEVICE HPX_FORCEINLINE T reduce(Reduce, T val)
+    {
+        return val;
+    }
+}}}    // namespace hpx::parallel::traits
+
+#include <hpx/execution/traits/detail/simd/vector_pack_reduce.hpp>
+#endif
+
+#endif


### PR DESCRIPTION
Contributes to Fixing #2333 

## Proposed Changes

  - Adapts new **vector_pack** trait `reduce` to support simd reductions.
  - Adapts new **CPO** `sequential_reduce` to support tag_fallback overloads on `reduce, transform_reduce, transform_reduce_binary` algorithms.
  - Adds tag dispatching overloads to support data-parallelism on `reduce, transform_reduce, transform_reduce_binary` algorithms.
  - Adds unit tests to newly supported data-parallel algorithms.
