### PR TITLE
Adding simple average power consumption performance counter

### DIFF
--- a/.jenkins/lsu/env-clang-11.sh
+++ b/.jenkins/lsu/env-clang-11.sh
@@ -10,6 +10,7 @@ module load llvm/11
 module load boost/1.73.0-${build_type,,}
 module load hwloc
 module load openmpi
+module load pwrapi/1.1.1
 
 export HPXRUN_RUNWRAPPER=srun
 export CXX_STD="17"
@@ -24,6 +25,7 @@ configure_extra_options+=" -DHPX_WITH_PARCELPORT_LCI=ON"
 configure_extra_options+=" -DHPX_WITH_FETCH_LCI=ON"
 configure_extra_options+=" -DHPX_WITH_PARCELPORT_LCI_BACKEND=ibv"
 configure_extra_options+=" -DHPX_WITH_LOGGING=OFF"
+configure_extra_options+=" -DHPX_WITH_POWER_COUNTER=ON"
 
 # Make sure HWLOC does not report 'cores'. This is purely an option to enable
 # testing the topology code under conditions close to those on FreeBSD.

--- a/.jenkins/lsu/env-clang-11.sh
+++ b/.jenkins/lsu/env-clang-11.sh
@@ -25,7 +25,9 @@ configure_extra_options+=" -DHPX_WITH_PARCELPORT_LCI=ON"
 configure_extra_options+=" -DHPX_WITH_FETCH_LCI=ON"
 configure_extra_options+=" -DHPX_WITH_PARCELPORT_LCI_BACKEND=ibv"
 configure_extra_options+=" -DHPX_WITH_LOGGING=OFF"
-configure_extra_options+=" -DHPX_WITH_POWER_COUNTER=ON"
+
+# The pwrapi library still needs to be set up properly on rostam
+# configure_extra_options+=" -DHPX_WITH_POWER_COUNTER=ON"
 
 # Make sure HWLOC does not report 'cores'. This is purely an option to enable
 # testing the topology code under conditions close to those on FreeBSD.

--- a/.jenkins/lsu/env-clang-12.sh
+++ b/.jenkins/lsu/env-clang-12.sh
@@ -26,7 +26,9 @@ configure_extra_options+=" -DHPX_WITH_PARCELPORT_LCI=ON"
 configure_extra_options+=" -DHPX_WITH_FETCH_LCI=ON"
 configure_extra_options+=" -DHPX_WITH_PARCELPORT_LCI_BACKEND=ibv"
 configure_extra_options+=" -DHPX_WITH_LOGGING=OFF"
-configure_extra_options+=" -DHPX_WITH_POWER_COUNTER=ON"
+
+# The pwrapi library still needs to be set up properly on rostam
+# configure_extra_options+=" -DHPX_WITH_POWER_COUNTER=ON"
 
 # Make sure HWLOC does not report 'cores'. This is purely an option to enable
 # testing the topology code under conditions close to those on FreeBSD.

--- a/.jenkins/lsu/env-clang-12.sh
+++ b/.jenkins/lsu/env-clang-12.sh
@@ -10,6 +10,7 @@ module load llvm/12
 module load boost/1.75.0-${build_type,,}
 module load hwloc
 module load openmpi
+module load pwrapi/1.1.1
 
 export HPXRUN_RUNWRAPPER=srun
 export CXX_STD="20"
@@ -25,6 +26,7 @@ configure_extra_options+=" -DHPX_WITH_PARCELPORT_LCI=ON"
 configure_extra_options+=" -DHPX_WITH_FETCH_LCI=ON"
 configure_extra_options+=" -DHPX_WITH_PARCELPORT_LCI_BACKEND=ibv"
 configure_extra_options+=" -DHPX_WITH_LOGGING=OFF"
+configure_extra_options+=" -DHPX_WITH_POWER_COUNTER=ON"
 
 # Make sure HWLOC does not report 'cores'. This is purely an option to enable
 # testing the topology code under conditions close to those on FreeBSD.

--- a/.jenkins/lsu/env-clang-13.sh
+++ b/.jenkins/lsu/env-clang-13.sh
@@ -26,7 +26,9 @@ configure_extra_options+=" -DHPX_WITH_PARCELPORT_LCI=ON"
 configure_extra_options+=" -DHPX_WITH_FETCH_LCI=ON"
 configure_extra_options+=" -DHPX_WITH_PARCELPORT_LCI_BACKEND=ibv"
 configure_extra_options+=" -DHPX_WITH_LOGGING=OFF"
-configure_extra_options+=" -DHPX_WITH_POWER_COUNTER=ON"
+
+# The pwrapi library still needs to be set up properly on rostam
+# configure_extra_options+=" -DHPX_WITH_POWER_COUNTER=ON"
 
 # Make sure HWLOC does not report 'cores'. This is purely an option to enable
 # testing the topology code under conditions close to those on FreeBSD.

--- a/.jenkins/lsu/env-clang-13.sh
+++ b/.jenkins/lsu/env-clang-13.sh
@@ -10,6 +10,7 @@ module load llvm/13
 module load boost/1.78.0-${build_type,,}
 module load hwloc
 module load openmpi
+module load pwrapi/1.1.1
 
 export HPXRUN_RUNWRAPPER=srun
 export CXX_STD="20"
@@ -25,6 +26,7 @@ configure_extra_options+=" -DHPX_WITH_PARCELPORT_LCI=ON"
 configure_extra_options+=" -DHPX_WITH_FETCH_LCI=ON"
 configure_extra_options+=" -DHPX_WITH_PARCELPORT_LCI_BACKEND=ibv"
 configure_extra_options+=" -DHPX_WITH_LOGGING=OFF"
+configure_extra_options+=" -DHPX_WITH_POWER_COUNTER=ON"
 
 # Make sure HWLOC does not report 'cores'. This is purely an option to enable
 # testing the topology code under conditions close to those on FreeBSD.

--- a/.jenkins/lsu/env-clang-14.sh
+++ b/.jenkins/lsu/env-clang-14.sh
@@ -26,7 +26,9 @@ configure_extra_options+=" -DHPX_WITH_PARCELPORT_LCI=ON"
 configure_extra_options+=" -DHPX_WITH_FETCH_LCI=ON"
 configure_extra_options+=" -DHPX_WITH_PARCELPORT_LCI_BACKEND=ibv"
 configure_extra_options+=" -DHPX_WITH_LOGGING=OFF"
-configure_extra_options+=" -DHPX_WITH_POWER_COUNTER=ON"
+
+# The pwrapi library still needs to be set up properly on rostam
+# configure_extra_options+=" -DHPX_WITH_POWER_COUNTER=ON"
 
 # Make sure HWLOC does not report 'cores'. This is purely an option to enable
 # testing the topology code under conditions close to those on FreeBSD.

--- a/.jenkins/lsu/env-clang-14.sh
+++ b/.jenkins/lsu/env-clang-14.sh
@@ -10,6 +10,7 @@ module load llvm/14
 module load boost/1.79.0-${build_type,,}
 module load hwloc
 module load openmpi
+module load pwrapi/1.1.1
 
 export HPXRUN_RUNWRAPPER=srun
 export CXX_STD="20"
@@ -25,6 +26,7 @@ configure_extra_options+=" -DHPX_WITH_PARCELPORT_LCI=ON"
 configure_extra_options+=" -DHPX_WITH_FETCH_LCI=ON"
 configure_extra_options+=" -DHPX_WITH_PARCELPORT_LCI_BACKEND=ibv"
 configure_extra_options+=" -DHPX_WITH_LOGGING=OFF"
+configure_extra_options+=" -DHPX_WITH_POWER_COUNTER=ON"
 
 # Make sure HWLOC does not report 'cores'. This is purely an option to enable
 # testing the topology code under conditions close to those on FreeBSD.

--- a/.jenkins/lsu/env-gcc-10.sh
+++ b/.jenkins/lsu/env-gcc-10.sh
@@ -25,4 +25,6 @@ configure_extra_options+=" -DHPX_WITH_PARCELPORT_MPI=ON"
 configure_extra_options+=" -DHPX_WITH_PARCELPORT_LCI=ON"
 configure_extra_options+=" -DHPX_WITH_FETCH_LCI=ON"
 configure_extra_options+=" -DHPX_WITH_PARCELPORT_LCI_BACKEND=ibv"
-configure_extra_options+=" -DHPX_WITH_POWER_COUNTER=ON"
+
+# The pwrapi library still needs to be set up properly on rostam
+# configure_extra_options+=" -DHPX_WITH_POWER_COUNTER=ON"

--- a/.jenkins/lsu/env-gcc-10.sh
+++ b/.jenkins/lsu/env-gcc-10.sh
@@ -10,6 +10,7 @@ module load gcc/10
 module load boost/1.75.0-${build_type,,}
 module load hwloc
 module load openmpi
+module load pwrapi/1.1.1
 
 export HPXRUN_RUNWRAPPER=srun
 export CXX_STD="17"
@@ -24,3 +25,4 @@ configure_extra_options+=" -DHPX_WITH_PARCELPORT_MPI=ON"
 configure_extra_options+=" -DHPX_WITH_PARCELPORT_LCI=ON"
 configure_extra_options+=" -DHPX_WITH_FETCH_LCI=ON"
 configure_extra_options+=" -DHPX_WITH_PARCELPORT_LCI_BACKEND=ibv"
+configure_extra_options+=" -DHPX_WITH_POWER_COUNTER=ON"

--- a/.jenkins/lsu/env-gcc-11.sh
+++ b/.jenkins/lsu/env-gcc-11.sh
@@ -24,4 +24,6 @@ configure_extra_options+=" -DHPX_WITH_PARCELPORT_MPI=ON"
 configure_extra_options+=" -DHPX_WITH_PARCELPORT_LCI=ON"
 configure_extra_options+=" -DHPX_WITH_FETCH_LCI=ON"
 configure_extra_options+=" -DHPX_WITH_PARCELPORT_LCI_BACKEND=ibv"
-configure_extra_options+=" -DHPX_WITH_POWER_COUNTER=ON"
+
+# The pwrapi library still needs to be set up properly on rostam
+# configure_extra_options+=" -DHPX_WITH_POWER_COUNTER=ON"

--- a/.jenkins/lsu/env-gcc-11.sh
+++ b/.jenkins/lsu/env-gcc-11.sh
@@ -10,6 +10,7 @@ module load gcc/11
 module load boost/1.78.0-${build_type,,}
 module load hwloc
 module load openmpi
+module load pwrapi/1.1.1
 
 export HPXRUN_RUNWRAPPER=srun
 export CXX_STD="20"
@@ -23,3 +24,4 @@ configure_extra_options+=" -DHPX_WITH_PARCELPORT_MPI=ON"
 configure_extra_options+=" -DHPX_WITH_PARCELPORT_LCI=ON"
 configure_extra_options+=" -DHPX_WITH_FETCH_LCI=ON"
 configure_extra_options+=" -DHPX_WITH_PARCELPORT_LCI_BACKEND=ibv"
+configure_extra_options+=" -DHPX_WITH_POWER_COUNTER=ON"

--- a/.jenkins/lsu/env-gcc-9.sh
+++ b/.jenkins/lsu/env-gcc-9.sh
@@ -24,4 +24,6 @@ configure_extra_options+=" -DHPX_WITH_PARCELPORT_MPI=ON"
 configure_extra_options+=" -DHPX_WITH_PARCELPORT_LCI=ON"
 configure_extra_options+=" -DHPX_WITH_FETCH_LCI=ON"
 configure_extra_options+=" -DHPX_WITH_PARCELPORT_LCI_BACKEND=ibv"
-configure_extra_options+=" -DHPX_WITH_POWER_COUNTER=ON"
+
+# The pwrapi library still needs to be set up properly on rostam
+# configure_extra_options+=" -DHPX_WITH_POWER_COUNTER=ON"

--- a/.jenkins/lsu/env-gcc-9.sh
+++ b/.jenkins/lsu/env-gcc-9.sh
@@ -10,6 +10,7 @@ module load gcc/9
 module load boost/1.73.0-${build_type,,}
 module load hwloc
 module load openmpi
+module load pwrapi/1.1.1
 
 export HPXRUN_RUNWRAPPER=srun
 export CXX_STD="17"
@@ -23,3 +24,4 @@ configure_extra_options+=" -DHPX_WITH_PARCELPORT_MPI=ON"
 configure_extra_options+=" -DHPX_WITH_PARCELPORT_LCI=ON"
 configure_extra_options+=" -DHPX_WITH_FETCH_LCI=ON"
 configure_extra_options+=" -DHPX_WITH_PARCELPORT_LCI_BACKEND=ibv"
+configure_extra_options+=" -DHPX_WITH_POWER_COUNTER=ON"

--- a/cmake/FindPWR.cmake
+++ b/cmake/FindPWR.cmake
@@ -1,0 +1,74 @@
+# Copyright (c)      2014 Thomas Heller
+# Copyright (c) 2007-2022 Hartmut Kaiser
+# Copyright (c) 2010-2011 Matt Anderson
+# Copyright (c) 2011      Bryce Lelbach
+#
+# SPDX-License-Identifier: BSL-1.0
+# Distributed under the Boost Software License, Version 1.0. (See accompanying
+# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+if(NOT TARGET PWR::pwr)
+  find_package(PkgConfig QUIET)
+  pkg_check_modules(PC_PWR QUIET pwr)
+
+  find_path(
+    PWR_INCLUDE_DIR pwr.h
+    HINTS ${PWR_ROOT}
+          ENV
+          PWR_ROOT
+          ${HPX_PWR_ROOT}
+          ${PC_PWR_MINIMAL_INCLUDEDIR}
+          ${PC_PWR_MINIMAL_INCLUDE_DIRS}
+          ${PC_PWR_INCLUDEDIR}
+          ${PC_PWR_INCLUDE_DIRS}
+    PATH_SUFFIXES include
+  )
+
+  find_library(
+    PWR_LIBRARY
+    NAMES pwr libpwr
+    HINTS ${PWR_ROOT}
+          ENV
+          PWR_ROOT
+          ${HPX_PWR_ROOT}
+          ${PC_PWR_MINIMAL_LIBDIR}
+          ${PC_PWR_MINIMAL_LIBRARY_DIRS}
+          ${PC_PWR_LIBDIR}
+          ${PC_PWR_LIBRARY_DIRS}
+    PATH_SUFFIXES lib lib64
+  )
+
+  # Set PWR_ROOT in case the other hints are used
+  if(PWR_ROOT)
+    # The call to file is for compatibility with windows paths
+    file(TO_CMAKE_PATH ${PWR_ROOT} PWR_ROOT)
+  elseif("$ENV{PWR_ROOT}")
+    file(TO_CMAKE_PATH $ENV{PWR_ROOT} PWR_ROOT)
+  else()
+    file(TO_CMAKE_PATH "${PWR_INCLUDE_DIR}" PWR_INCLUDE_DIR)
+    string(REPLACE "/include" "" PWR_ROOT "${PWR_INCLUDE_DIR}")
+  endif()
+
+  set(PWR_LIBRARIES ${PWR_LIBRARY})
+  set(PWR_INCLUDE_DIRS ${PWR_INCLUDE_DIR})
+
+  find_package_handle_standard_args(PWR DEFAULT_MSG PWR_LIBRARY PWR_INCLUDE_DIR)
+
+  get_property(
+    _type
+    CACHE PWR_ROOT
+    PROPERTY TYPE
+  )
+  if(_type)
+    set_property(CACHE PWR_ROOT PROPERTY ADVANCED 1)
+    if("x${_type}" STREQUAL "xUNINITIALIZED")
+      set_property(CACHE PWR_ROOT PROPERTY TYPE PATH)
+    endif()
+  endif()
+
+  add_library(PWR::pwr INTERFACE IMPORTED)
+  target_include_directories(PWR::pwr SYSTEM INTERFACE ${PWR_INCLUDE_DIR})
+  target_link_libraries(PWR::pwr INTERFACE ${PWR_LIBRARIES})
+
+  mark_as_advanced(PWR_ROOT PWR_LIBRARY PWR_INCLUDE_DIR)
+endif()

--- a/cmake/FindPWR.cmake
+++ b/cmake/FindPWR.cmake
@@ -10,6 +10,9 @@
 if(NOT TARGET PWR::pwr)
   find_package(PkgConfig QUIET)
   pkg_check_modules(PC_PWR QUIET pwr)
+  if(NOT PC_PWR_FOUND)
+    pkg_check_modules(PC_PWR pwrapi QUIET)
+  endif()
 
   find_path(
     PWR_INCLUDE_DIR pwr.h

--- a/components/performance_counters/CMakeLists.txt
+++ b/components/performance_counters/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2007-2015 Hartmut Kaiser
+# Copyright (c) 2007-2022 Hartmut Kaiser
 # Copyright (c)      2011 Bryce Lelbach
 # Copyright (c)      2013 Jeroen Habraken
 #
@@ -6,7 +6,7 @@
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-set(components io memory papi)
+set(components io memory papi power)
 
 foreach(component ${components})
   add_hpx_pseudo_target(components.performance_counters.${component})

--- a/components/performance_counters/power/CMakeLists.txt
+++ b/components/performance_counters/power/CMakeLists.txt
@@ -1,0 +1,40 @@
+# Copyright (c) 2007-2022 Hartmut Kaiser
+#
+# SPDX-License-Identifier: BSL-1.0
+# Distributed under the Boost Software License, Version 1.0. (See accompanying
+# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+if(NOT HPX_WITH_DISTRIBUTED_RUNTIME)
+  return()
+endif()
+
+# The Power counters depend on th PWR library (http://powerapi.sandia.gov/)
+find_package(PWR QUIET)
+if(NOT PWR_FOUND)
+  return()
+endif()
+
+set(HPX_COMPONENTS
+    ${HPX_COMPONENTS} power
+    CACHE INTERNAL "list of HPX components"
+)
+
+set(power_headers hpx/components/performance_counters/power/power_counter.hpp)
+
+set(power_sources power.cpp power_counter.cpp)
+
+add_hpx_component(
+  power INTERNAL_FLAGS
+  FOLDER "Core/Components/Counters"
+  INSTALL_HEADERS PLUGIN PREPEND_HEADER_ROOT
+  HEADER_ROOT "${CMAKE_CURRENT_SOURCE_DIR}/include"
+  HEADERS ${power_headers}
+  PREPEND_SOURCE_ROOT
+  SOURCE_ROOT "${CMAKE_CURRENT_SOURCE_DIR}/src"
+  SOURCES ${power_sources} ${HPX_WITH_UNITY_BUILD_OPTION}
+  DEPENDENCIES PWR::pwr
+)
+
+add_hpx_pseudo_dependencies(
+  components.performance_counters.power power_component
+)

--- a/components/performance_counters/power/CMakeLists.txt
+++ b/components/performance_counters/power/CMakeLists.txt
@@ -23,8 +23,16 @@ endif()
 # The Power counters depend on the PWR library (http://powerapi.sandia.gov/)
 find_package(PWR QUIET)
 if(NOT PWR_FOUND)
+  hpx_warning("PWR library was not found, setting HPX_WITH_POWER_COUNTER=OFF")
+  hpx_set_option(
+    HPX_WITH_POWER_COUNTER
+    VALUE OFF
+    FORCE
+  )
   return()
 endif()
+
+hpx_add_config_define(HPX_HAVE_POWER_COUNTER)
 
 set(HPX_COMPONENTS
     ${HPX_COMPONENTS} power
@@ -50,3 +58,5 @@ add_hpx_component(
 add_hpx_pseudo_dependencies(
   components.performance_counters.power power_component
 )
+
+add_subdirectory(tests)

--- a/components/performance_counters/power/CMakeLists.txt
+++ b/components/performance_counters/power/CMakeLists.txt
@@ -8,7 +8,19 @@ if(NOT HPX_WITH_DISTRIBUTED_RUNTIME)
   return()
 endif()
 
-# The Power counters depend on th PWR library (http://powerapi.sandia.gov/)
+hpx_option(
+  HPX_WITH_POWER_COUNTER BOOL
+  "Enable use of performance counters based on pwr library (default: OFF)" OFF
+  ADVANCED
+  CATEGORY "Modules"
+  MODULE POWER_COUNTER
+)
+
+if(NOT HPX_WITH_POWER_COUNTER)
+  return()
+endif()
+
+# The Power counters depend on the PWR library (http://powerapi.sandia.gov/)
 find_package(PWR QUIET)
 if(NOT PWR_FOUND)
   return()

--- a/components/performance_counters/power/include/hpx/components/performance_counters/power/power_counter.hpp
+++ b/components/performance_counters/power/include/hpx/components/performance_counters/power/power_counter.hpp
@@ -1,0 +1,17 @@
+// Copyright (c) 2022 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include <hpx/config.hpp>
+
+#include <cstdint>
+
+namespace hpx::performance_counters::power {
+
+    // returns overall power consumption
+    std::uint64_t average_power_consumption(bool);
+}    // namespace hpx::performance_counters::power

--- a/components/performance_counters/power/src/power.cpp
+++ b/components/performance_counters/power/src/power.cpp
@@ -1,0 +1,54 @@
+//  Copyright (c) 2022 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/config.hpp>
+#include <hpx/components_base/component_startup_shutdown.hpp>
+#include <hpx/functional/function.hpp>
+#include <hpx/performance_counters/manage_counter_type.hpp>
+#include <hpx/runtime_configuration/component_factory_base.hpp>
+#include <hpx/runtime_local/startup_function.hpp>
+
+#include <hpx/components/performance_counters/power/power_counter.hpp>
+
+///////////////////////////////////////////////////////////////////////////////
+// Add factory registration functionality, We register the module dynamically
+// as no executable links against it.
+HPX_REGISTER_COMPONENT_MODULE_DYNAMIC()
+
+///////////////////////////////////////////////////////////////////////////////
+namespace hpx::performance_counters::power {
+
+    void register_counter_types()
+    {
+        hpx::performance_counters::install_counter_type(
+            "/runtime/average_power", &average_power_consumption,
+            "returns the average power consumption of the specified locality",
+            "W", hpx::performance_counters::counter_type::raw);
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    bool get_startup(
+        hpx::startup_function_type& startup_func, bool& pre_startup)
+    {
+        // return our startup-function
+
+        // function to run during startup
+        startup_func = register_counter_types;
+
+        // run 'register_counter_types' as pre-startup function
+        pre_startup = true;
+        return true;
+    }
+}    // namespace hpx::performance_counters::power
+
+///////////////////////////////////////////////////////////////////////////////
+// Register a startup function which will be called as a HPX-thread during
+// runtime startup. We use this function to register our performance counter
+// type and performance counter instances.
+//
+// Note that this macro can be used not more than once in one module.
+HPX_REGISTER_STARTUP_MODULE_DYNAMIC(
+    hpx::performance_counters::power::get_startup)

--- a/components/performance_counters/power/src/power_counter.cpp
+++ b/components/performance_counters/power/src/power_counter.cpp
@@ -1,0 +1,123 @@
+// Copyright (c) 2012 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/config.hpp>
+#include <hpx/asssert.hpp>
+#include <hpx/modules/errors.hpp>
+#include <hpx/modules/format.hpp>
+#include <hpx/modules/runtime_local.hpp>
+#include <hpx/modules/synchronization.hpp>
+
+#include <hpx/components/performance_counters/power/power_counter.hpp>
+
+#include <cstdint>
+#include <mutex>
+#include <string>
+
+#include <pwr.h>
+
+namespace hpx::performance_counters::power {
+
+    class power
+    {
+    public:
+        power()
+        {
+            hpx::register_startup_function([this]() { this->init(); });
+        }
+
+        ~power()
+        {
+            if (cntxt != nullptr)
+            {
+                PWR_CntxtDestroy(cntxt);
+            }
+        }
+
+        power(power const&) = delete;
+        power(power&&) = delete;
+        power& operator=(power const&) = delete;
+        power& operator=(power&&) = delete;
+
+        std::uint64_t get_value(bool reset)
+        {
+            std::lock_guard l(mtx);
+
+            PWR_Time now = 0;
+            double energy = 0.0;
+            sample_power(energy, now);
+
+            std::uint64_t value = std::uint64_t(
+                (energy - base_energy) / ((now - base_time) / 1000000000.0));
+
+            if (reset)
+            {
+                base_energy = energy;
+                base_time = now;
+            }
+
+            return value;
+        }
+
+    protected:
+        // delayed initialization
+        void init()
+        {
+            std::lock_guard l(mtx);
+
+            // Get a context
+            int rc = PWR_CntxtInit(
+                PWR_CNTXT_DEFAULT, PWR_ROLE_APP, "application", &cntxt);
+            if (rc != PWR_RET_SUCCESS || cntxt == nullptr)
+            {
+                HPX_THROW_EXCEPTION(bad_request, "power::init",
+                    hpx::format(
+                        "PWR_CntxtInit returned error: {} (locality: {})", rc,
+                        hpx::get_locality_name()));
+            }
+
+            rc = PWR_CntxtGetObjByName(cntxt, "plat.node", &obj);
+            if (rc != PWR_RET_SUCCESS || obj == nullptr)
+            {
+                HPX_THROW_EXCEPTION(bad_request, "power::init",
+                    hpx::format("PWR_CntxtGetObjByName returned error: {} "
+                                "(locality: {})",
+                        rc, hpx::get_locality_name()));
+            }
+
+            sample_power(base_energy, base_time);
+        }
+
+        void sample_power(double& energy, PWR_Time& pwr_time)
+        {
+            rc = PWR_ObjAttrGetValue(obj, PWR_ATTR_ENERGY, &energy, &pwr_time);
+            if (rc != PWR_RET_SUCCESS)
+            {
+                HPX_THROW_EXCEPTION(bad_request, "power::sample_power",
+                    hpx::format(
+                        "PWR_ObjAttrGetValue returned error: {} (locality: {})",
+                        rc, hpx::get_locality_name()));
+            }
+            return energy;
+        }
+
+    private:
+        hpx::spinlock mtx;
+        PWR_Cntxt cntxt = nullptr;
+        PWR_Obj obj = nullptr;
+        double base_energy = 0.0;
+        PWR_Time base_time = 0;
+    };
+
+    power power_api;
+
+    ///////////////////////////////////////////////////////////////////////////
+    // returns overall power consumption
+    std::uint64_t average_power_consumption(bool reset)
+    {
+        return power_api.get_value(reset);
+    }
+}    // namespace hpx::performance_counters::power

--- a/components/performance_counters/power/tests/CMakeLists.txt
+++ b/components/performance_counters/power/tests/CMakeLists.txt
@@ -1,0 +1,36 @@
+# Copyright (c) 2019 The STE||AR-Group
+#
+# SPDX-License-Identifier: BSL-1.0
+# Distributed under the Boost Software License, Version 1.0. (See accompanying
+# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+if(HPX_WITH_TESTS_UNIT)
+  add_hpx_pseudo_target(tests.unit.components.power)
+  add_hpx_pseudo_dependencies(tests.unit.components tests.unit.components.power)
+  add_subdirectory(unit)
+endif()
+
+if(HPX_WITH_TESTS_REGRESSIONS)
+  add_hpx_pseudo_target(tests.regressions.components.power)
+  add_hpx_pseudo_dependencies(
+    tests.regressions.components tests.regressions.components.power
+  )
+  add_subdirectory(regressions)
+endif()
+
+if(HPX_WITH_TESTS_BENCHMARKS)
+  add_hpx_pseudo_target(tests.performance.components.power)
+  add_hpx_pseudo_dependencies(
+    tests.performance.components tests.performance.components.power
+  )
+  add_subdirectory(performance)
+endif()
+
+if(HPX_WITH_TESTS_HEADERS)
+  add_hpx_header_tests(
+    "components.power"
+    HEADERS ${power_headers}
+    HEADER_ROOT "${PROJECT_SOURCE_DIR}/include"
+    COMPONENT_DEPENDENCIES power
+  )
+endif()

--- a/components/performance_counters/power/tests/performance/CMakeLists.txt
+++ b/components/performance_counters/power/tests/performance/CMakeLists.txt
@@ -1,0 +1,5 @@
+# Copyright (c) 2019 The STE||AR-Group
+#
+# SPDX-License-Identifier: BSL-1.0
+# Distributed under the Boost Software License, Version 1.0. (See accompanying
+# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)

--- a/components/performance_counters/power/tests/regressions/CMakeLists.txt
+++ b/components/performance_counters/power/tests/regressions/CMakeLists.txt
@@ -1,0 +1,5 @@
+# Copyright (c) 2019 The STE||AR-Group
+#
+# SPDX-License-Identifier: BSL-1.0
+# Distributed under the Boost Software License, Version 1.0. (See accompanying
+# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)

--- a/components/performance_counters/power/tests/unit/CMakeLists.txt
+++ b/components/performance_counters/power/tests/unit/CMakeLists.txt
@@ -1,0 +1,28 @@
+#  Copyright (c) 2022 Hartmut Kaiser
+#
+# SPDX-License-Identifier: BSL-1.0
+#  Distributed under the Boost Software License, Version 1.0. (See accompanying
+#  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+set(tests power_counter)
+
+set(power_counter_FLAGS COMPONENT_DEPENDENCIES power)
+
+foreach(test ${tests})
+  set(sources ${test}.cpp)
+
+  source_group("Source Files" FILES ${sources})
+
+  set(folder_name "Tests/Unit/Components/Counters/Power")
+
+  # add example executable
+  add_hpx_executable(
+    ${test}_test INTERNAL_FLAGS
+    SOURCES ${sources} ${${test}_FLAGS}
+    EXCLUDE_FROM_ALL
+    HPX_PREFIX ${HPX_BUILD_PREFIX}
+    FOLDER ${folder_name}
+  )
+
+  add_hpx_unit_test("components.power" ${test} ${${test}_PARAMETERS})
+endforeach()

--- a/components/performance_counters/power/tests/unit/power_counter.cpp
+++ b/components/performance_counters/power/tests/unit/power_counter.cpp
@@ -1,0 +1,96 @@
+//  Copyright (c) 2022 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/config.hpp>
+
+#if defined(HPX_HAVE_POWER_COUNTER) && !defined(HPX_COMPUTE_DEVICE_CODE)
+#include <hpx/hpx_main.hpp>
+#include <hpx/include/naming.hpp>
+#include <hpx/include/performance_counters.hpp>
+#include <hpx/include/runtime.hpp>
+#include <hpx/modules/testing.hpp>
+
+#include <cstddef>
+#include <iostream>
+#include <string>
+#include <vector>
+
+// clang-format off
+char const* const power_counter_names[] =
+{
+    "/runtime/average_power",
+    nullptr
+};
+// clang-format on
+
+///////////////////////////////////////////////////////////////////////////////
+void test_all_locality_power_counters(
+    char const* const* counter_names, std::size_t locality_id)
+{
+    for (char const* const* p = counter_names; *p != nullptr; ++p)
+    {
+        // split counter type into counter path elements
+        hpx::performance_counters::counter_path_elements path;
+        HPX_TEST_EQ(
+            hpx::performance_counters::get_counter_path_elements(*p, path),
+            hpx::performance_counters::counter_status::valid_data);
+
+        // augment the counter path elements
+        path.parentinstancename_ = "locality";
+        path.parentinstanceindex_ = locality_id;
+        path.instancename_ = "total";
+        path.instanceindex_ = -1;
+
+        std::string name;
+        HPX_TEST_EQ(hpx::performance_counters::get_counter_name(path, name),
+            hpx::performance_counters::counter_status::valid_data);
+
+        std::cout << name << '\n';
+
+        try
+        {
+            hpx::performance_counters::performance_counter counter(name);
+            HPX_TEST_EQ(counter.get_name(hpx::launch::sync), name);
+            counter.get_value<std::size_t>(hpx::launch::sync);
+        }
+        catch (...)
+        {
+            HPX_TEST(false);    // should never happen
+        }
+    }
+}
+
+///////////////////////////////////////////////////////////////////////////////
+void test_all_locality_power_counters(std::size_t locality_id)
+{
+    test_all_locality_thread_counters(power_counter_names, locality_id);
+}
+
+///////////////////////////////////////////////////////////////////////////////
+void test_all_counters_locality(std::size_t locality_id)
+{
+    // locality/total
+    test_all_locality_power_counters(locality_id);
+}
+
+int main()
+{
+    for (auto const& id : hpx::find_all_localities())
+    {
+        test_all_counters_locality(hpx::naming::get_locality_id_from_id(id));
+    }
+
+    return hpx::util::report_errors();
+}
+
+#else
+
+int main()
+{
+    return 0;
+}
+
+#endif


### PR DESCRIPTION
This adds an HPX performance counter `/runtime{locality#N/total}/average_power`. The power consumption is collected through the PWR library (http://powerapi.sandia.gov/).

The build system expects for the library to be installed, available through pkg_config, or found using the `HPX_PWR_ROOT` cmake variable.