### PR TITLE
Add missing ""

### DIFF
--- a/cmake/HPX_GeneratePackageUtils.cmake
+++ b/cmake/HPX_GeneratePackageUtils.cmake
@@ -291,7 +291,7 @@ function(hpx_construct_library_list link_libraries link_options library_list)
     if(IS_ABSOLUTE ${library})
       get_filename_component(_library_path ${library} DIRECTORY)
       get_filename_component(_library_name ${library} NAME_WE)
-      string(REPLACE ${CMAKE_SHARED_LIBRARY_PREFIX} "" _library_name
+      string(REPLACE "${CMAKE_SHARED_LIBRARY_PREFIX}" "" _library_name
                      ${_library_name}
       )
       set(_library_list


### PR DESCRIPTION
Fixes pkg-config file generation on windows where CMAKE_SHARED_LIBRARY_PREFIX is empty. 

## Any background context you want to provide?

Always quote string like inputs to functions because they can be empty.

## Checklist

- [x] I have fixed a bug ~~and have added a regression test~~. (just run with HPX_WITH_PKGCONFIG=ON on windows)
