### PR TITLE
Fix incorrect usage of generator expressions

### DIFF
--- a/cmake/HPX_AddModule.cmake
+++ b/cmake/HPX_AddModule.cmake
@@ -437,7 +437,8 @@ function(add_hpx_module libname modulename)
     elseif(MSVC)
       set(_module_target hpx_${modulename})
       target_link_libraries(
-        hpx_${libname} PRIVATE -WHOLEARCHIVE:$<TARGET_FILE:$<TARGET_NAME:hpx_${modulename}>>
+        hpx_${libname}
+        PRIVATE -WHOLEARCHIVE:$<TARGET_FILE:$<TARGET_NAME:hpx_${modulename}>>
       )
     endif()
     target_link_libraries(hpx_${libname} PRIVATE ${_module_target})

--- a/cmake/HPX_AddModule.cmake
+++ b/cmake/HPX_AddModule.cmake
@@ -437,7 +437,7 @@ function(add_hpx_module libname modulename)
     elseif(MSVC)
       set(_module_target hpx_${modulename})
       target_link_libraries(
-        hpx_${libname} PRIVATE -WHOLEARCHIVE:$<TARGET_FILE:hpx_${modulename}>
+        hpx_${libname} PRIVATE -WHOLEARCHIVE:$<TARGET_FILE:$<TARGET_NAME:hpx_${modulename}>>
       )
     endif()
     target_link_libraries(hpx_${libname} PRIVATE ${_module_target})

--- a/cmake/HPX_GeneratePackageUtils.cmake
+++ b/cmake/HPX_GeneratePackageUtils.cmake
@@ -79,7 +79,7 @@ function(
       )
     else()
       set(_libraries
-          $<INSTALL_INTERFACE:-L${CMAKE_INSTALL_LIBDIR};-l$<TARGET_FILE_BASE_NAME:${target}>>$<BUILD_INTERFACE:$<TARGET_FILE:${target}>>
+          $<INSTALL_INTERFACE:-L${CMAKE_INSTALL_LIBDIR};-l$<TARGET_FILE_BASE_NAME:$<TARGET_NAME:${target}>>>$<BUILD_INTERFACE:$<TARGET_FILE:${target}>>
       )
     endif()
   else()
@@ -101,7 +101,7 @@ function(
           )
             set(_libraries
                 ${_libraries}
-                $<INSTALL_INTERFACE:${CMAKE_INSTALL_LIBDIR}/$<TARGET_FILE_NAME:${target}>>$<BUILD_INTERFACE:$<TARGET_FILE:${target}>>
+                $<INSTALL_INTERFACE:${CMAKE_INSTALL_LIBDIR}/$<TARGET_FILE_NAME:$<TARGET_NAME:${target}>>>$<BUILD_INTERFACE:$<TARGET_FILE:${target}>>
             )
           endif()
         elseif("${dep_target}" MATCHES "^-l")


### PR DESCRIPTION
`$<TARGET_NAME:...>` is required for the install interface

Don't yet know what all the code does but it generates wrong stuff in the INSTALL_INTERFACE which needs to be informed about target names. 

see
https://cmake.org/cmake/help/latest/manual/cmake-generator-expressions.7.html#genex:TARGET_NAME

Fixes using static exports of HPX on windows. 
