### PR TITLE
Improve MPI initialization

### DIFF
--- a/libs/core/mpi_base/CMakeLists.txt
+++ b/libs/core/mpi_base/CMakeLists.txt
@@ -35,8 +35,8 @@ add_hpx_module(
   SOURCES ${mpi_base_sources}
   HEADERS ${mpi_base_headers}
   COMPAT_HEADERS ${mpi_base_compat_headers}
-  MODULE_DEPENDENCIES hpx_logging hpx_runtime_configuration hpx_string_util
-                      hpx_util
+  MODULE_DEPENDENCIES hpx_format hpx_logging hpx_runtime_configuration
+                      hpx_string_util hpx_util
   DEPENDENCIES ${additional_dependencies}
   CMAKE_SUBDIRS examples tests
 )

--- a/libs/core/mpi_base/src/mpi_environment.cpp
+++ b/libs/core/mpi_base/src/mpi_environment.cpp
@@ -1,6 +1,7 @@
 //  Copyright (c) 2013-2015 Thomas Heller
 //  Copyright (c)      2020 Google
 //  Copyright (c)      2022 Patrick Diehl
+//  Copyright (c)      2023 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -110,8 +111,23 @@ namespace hpx::util {
     int mpi_environment::is_initialized_ = -1;
 
     ///////////////////////////////////////////////////////////////////////////
+    [[noreturn]] static void throw_wrong_mpi_mode(int required, int provided)
+    {
+        std::map<int, char const*> levels = {
+            {MPI_THREAD_SINGLE, "MPI_THREAD_SINGLE"},
+            {MPI_THREAD_FUNNELED, "MPI_THREAD_FUNNELED"},
+            {MPI_THREAD_SERIALIZED, "MPI_THREAD_SERIALIZED"},
+            {MPI_THREAD_MULTIPLE, "MPI_THREAD_MULTIPLE"}};
+
+        HPX_THROW_EXCEPTION(hpx::error::invalid_status,
+            "hpx::util::mpi_environment::init",
+            hpx::util::format("MPI doesn't implement minimal requested "
+                              "thread level, required {}, provided {}",
+                levels[required], levels[provided]));
+    }
+
     int mpi_environment::init(
-        int*, char***, const int minimal, const int required, int& provided)
+        int*, char***, int const minimal, int const required, int& provided)
     {
         has_called_init_ = false;
 
@@ -133,17 +149,7 @@ namespace hpx::util {
 
             if (provided < minimal)
             {
-                std::map<int, char const*> levels = {
-                    {MPI_THREAD_SINGLE, "MPI_THREAD_SINGLE"},
-                    {MPI_THREAD_FUNNELED, "MPI_THREAD_FUNNELED"},
-                    {MPI_THREAD_SERIALIZED, "MPI_THREAD_SERIALIZED"},
-                    {MPI_THREAD_MULTIPLE, "MPI_THREAD_MULTIPLE"}};
-
-                HPX_THROW_EXCEPTION(hpx::error::invalid_status,
-                    "hpx::util::mpi_environment::init",
-                    hpx::util::format("MPI doesn't implement minimal requested "
-                                      "thread level, required {}, provided {}",
-                        levels[required], levels[provided]));
+                throw_wrong_mpi_mode(required, provided);
             }
             has_called_init_ = true;
         }
@@ -158,9 +164,7 @@ namespace hpx::util {
 
             if (provided < minimal)
             {
-                HPX_THROW_EXCEPTION(hpx::error::invalid_status,
-                    "hpx::util::mpi_environment::init",
-                    "MPI doesn't provide minimal requested thread level");
+                throw_wrong_mpi_mode(required, provided);
             }
         }
         return retval;
@@ -220,28 +224,30 @@ namespace hpx::util {
             MPI_Error_string(retval, message, &msglen);
             message[msglen] = '\0';
 
-            std::string msg("mpi_environment::init: MPI_Init_thread failed: ");
-            msg = msg + message + ".";
-            throw std::runtime_error(msg.c_str());
+            HPX_THROW_EXCEPTION(hpx::error::invalid_status,
+                "hpx::util::mpi_environment::init",
+                hpx::util::format("MPI_Init_thread failed: {}.", message));
         }
 
         MPI_Comm_dup(MPI_COMM_WORLD, &communicator_);
 
+        // explicitly disable multi-threaded mpi if needed
         if (provided_threading_flag_ <= MPI_THREAD_SERIALIZED)
         {
-            // explicitly disable multi-threaded mpi if needed
             rtcfg.add_entry("hpx.parcel.mpi.multithreaded", "0");
+        }
 
         if (provided_threading_flag_ == MPI_THREAD_FUNNELED)
         {
             enabled_ = false;
             has_called_init_ = false;
-            throw std::runtime_error(
-                "mpi_environment::init: MPI_Init_thread: "
-                "The underlying MPI implementation only supports "
-                "MPI_THREAD_FUNNELED. This mode is not supported by HPX. "
-                "Please pass -hpx:ini=hpx.parcel.mpi.multithreaded=0 to "
-                "explicitly disable MPI multi-threading.");
+            HPX_THROW_EXCEPTION(hpx::error::invalid_status,
+                "hpx::util::mpi_environment::init",
+                "MPI_Init_thread: The underlying MPI implementation only "
+                "supports MPI_THREAD_FUNNELED. This mode is not supported "
+                "by HPX. Please pass "
+                "--hpx:ini=hpx.parcel.mpi.multithreaded=0 to explicitly "
+                "disable MPI multi-threading.");
         }
 
         this_rank = rank();
@@ -337,7 +343,9 @@ namespace hpx::util {
       : locked(true)
     {
         if (!multi_threaded())
+        {
             mtx_.lock();
+        }
     }
 
     mpi_environment::scoped_lock::~scoped_lock()

--- a/libs/full/parcelport_mpi/src/parcelport_mpi.cpp
+++ b/libs/full/parcelport_mpi/src/parcelport_mpi.cpp
@@ -103,6 +103,14 @@ namespace hpx::parcelset {
             static std::size_t background_threads(
                 util::runtime_configuration const& ini)
             {
+                // limit the number of cores accessing MPI to one if
+                // multi-threading in MPI is disabled
+                if (hpx::util::get_entry_as<std::size_t>(
+                        ini, "hpx.parcel.mpi.multithreaded", 1) == 0)
+                {
+                    return 1;
+                }
+
                 return hpx::util::get_entry_as<std::size_t>(ini,
                     "hpx.parcel.mpi.background_threads",
                     HPX_HAVE_PARCELPORT_MPI_BACKGROUND_THREADS);

--- a/libs/full/parcelset/include/hpx/parcelset/parcelport_impl.hpp
+++ b/libs/full/parcelset/include/hpx/parcelset/parcelport_impl.hpp
@@ -343,26 +343,50 @@ namespace hpx::parcelset {
                 parcelset::parcelport::shared_from_this());
         }
 
-        /// Cache specific functionality
+    protected:
+        template <typename F>
+        bool reschedule_on_thread(
+            F&& f, threads::thread_schedule_state state, char const* funcname)
+        {
+            error_code ec(throwmode::lightweight);
+            hpx::threads::thread_init_data data(
+                hpx::threads::make_thread_function_nullary(HPX_FORWARD(F, f)),
+                funcname, threads::thread_priority::normal,
+                threads::thread_schedule_hint(
+                    static_cast<std::int16_t>(get_next_num_thread())),
+                threads::thread_stacksize::default_, state, true);
+
+            auto id = hpx::threads::register_thread(data, ec);
+            if (!ec)
+                return false;
+
+            if (state == threads::thread_schedule_state::suspended)
+            {
+                threads::set_thread_state(id.noref(),
+                    std::chrono::milliseconds(100),
+                    threads::thread_schedule_state::pending,
+                    threads::thread_restart_state::signaled,
+                    threads::thread_priority::boost, true, ec);
+            }
+
+            return true;
+        }
+
+    public:
+        // Cache specific functionality
         void remove_from_connection_cache_delayed(locality const& loc)
         {
             if (operations_in_flight_ != 0)
             {
-                error_code ec(throwmode::lightweight);
-                hpx::threads::thread_init_data data(
-                    hpx::threads::make_thread_function_nullary(
+                if (!connection_handler().reschedule_on_thread(
                         util::deferred_call(
                             &parcelport_impl::remove_from_connection_cache,
-                            this, loc)),
-                    "remove_from_connection_cache_delayed",
-                    threads::thread_priority::normal,
-                    threads::thread_schedule_hint(
-                        static_cast<std::int16_t>(get_next_num_thread())),
-                    threads::thread_stacksize::default_,
-                    threads::thread_schedule_state::pending, true);
-                hpx::threads::register_thread(data, ec);
-                if (!ec)
+                            this, loc),
+                        threads::thread_schedule_state::pending,
+                        "remove_from_connection_cache_delayed"))
+                {
                     return;
+                }
             }
 
             connection_cache_.clear(loc);
@@ -370,27 +394,12 @@ namespace hpx::parcelset {
 
         void remove_from_connection_cache(locality const& loc) override
         {
-            error_code ec(throwmode::lightweight);
-            hpx::threads::thread_init_data data(
-                hpx::threads::make_thread_function_nullary(util::deferred_call(
+            connection_handler().reschedule_on_thread(
+                util::deferred_call(
                     &parcelport_impl::remove_from_connection_cache_delayed,
-                    this, loc)),
-                "remove_from_connection_cache",
-                threads::thread_priority::normal,
-                threads::thread_schedule_hint(
-                    static_cast<std::int16_t>(get_next_num_thread())),
-                threads::thread_stacksize::default_,
-                threads::thread_schedule_state::suspended, true);
-            threads::thread_id_ref_type const id =
-                hpx::threads::register_thread(data, ec);
-            if (ec)
-                return;
-
-            threads::set_thread_state(id.noref(),
-                std::chrono::milliseconds(100),
+                    this, loc),
                 threads::thread_schedule_state::pending,
-                threads::thread_restart_state::signaled,
-                threads::thread_priority::boost, true, ec);
+                "remove_from_connection_cache_delayed");
         }
 
         /// Return the name of this locality


### PR DESCRIPTION
- explicitly set number of MPI background threads to one if MPI is not multi-threaded
- improve generated error message if required threading mode is not supported

This makes it simpler to control the used threading level for MPI