### PR TITLE
Removed references to hpx::vector in comments

### DIFF
--- a/components/containers/partitioned_vector/include/hpx/components/containers/partitioned_vector/partitioned_vector_segmented_iterator.hpp
+++ b/components/containers/partitioned_vector/include/hpx/components/containers/partitioned_vector/partitioned_vector_segmented_iterator.hpp
@@ -36,7 +36,8 @@
 
 namespace hpx { namespace segmented {
     ///////////////////////////////////////////////////////////////////////////
-    // This class wraps plain a vector<>::iterator or vector<>::const_iterator
+    // This class wraps plain a partitioned_vector<>::iterator or
+    // partitioned_vector<>::const_iterator
     template <typename T, typename Data, typename BaseIter>
     class local_raw_vector_iterator
       : public hpx::util::iterator_adaptor<
@@ -232,7 +233,7 @@ namespace hpx { namespace segmented {
 
     ///////////////////////////////////////////////////////////////////////////
     /// This class implements the local iterator functionality for the
-    /// partitioned backend of a hpx::vector.
+    /// partitioned backend of a hpx::partitioned_vector.
     template <typename T, typename Data>
     class local_vector_iterator
       : public hpx::util::iterator_facade<
@@ -544,7 +545,8 @@ namespace hpx { namespace segmented {
     };
 
     ///////////////////////////////////////////////////////////////////////////
-    /// This class implement the segmented iterator for the hpx::vector
+    /// This class implement the segmented iterator for the
+    /// hpx::partitioned_vector.
     template <typename T, typename Data, typename BaseIter>
     class segment_vector_iterator
       : public hpx::util::iterator_adaptor<
@@ -657,7 +659,8 @@ namespace hpx { namespace segmented {
         };
     }    // namespace detail
 
-    /// This class implement the local segmented iterator for the hpx::vector
+    /// This class implement the local segmented iterator for the
+    /// hpx::partitioned_vector.
     template <typename T, typename Data, typename BaseIter>
     class local_segment_vector_iterator
       : public hpx::util::iterator_adaptor<
@@ -744,7 +747,8 @@ namespace hpx { namespace segmented {
     };
 
     ///////////////////////////////////////////////////////////////////////////
-    /// This class implements the (global) iterator functionality for hpx::vector.
+    /// This class implements the (global) iterator functionality for
+    /// hpx::partitioned_vector.
     template <typename T, typename Data>
     class vector_iterator
       : public hpx::util::iterator_facade<vector_iterator<T, Data>, T,

--- a/components/containers/unordered/include/hpx/components/containers/unordered/unordered_map_segmented_iterator.hpp
+++ b/components/containers/unordered/include/hpx/components/containers/unordered/unordered_map_segmented_iterator.hpp
@@ -26,13 +26,12 @@
 #include <type_traits>
 #include <vector>
 
-namespace hpx
-{
+namespace hpx {
     ///////////////////////////////////////////////////////////////////////////
     template <typename Key, typename T, typename Hash = std::hash<Key>,
-        typename KeyEqual = std::equal_to<Key> >
+        typename KeyEqual = std::equal_to<Key>>
     class unordered_map;
-}
+}    // namespace hpx
 
 namespace hpx { namespace segmented {
 
@@ -44,28 +43,30 @@ namespace hpx { namespace segmented {
     class const_segment_unordered_map_iterator;
 
     ///////////////////////////////////////////////////////////////////////////
-    // This class wraps plain a vector<>::iterator or vector<>::const_iterator
+    // This class wraps plain a unordered_map<>::iterator or
+    // unordered_map<>::const_iterator
 
-    /// This class implement the segmented iterator for the hpx::vector
+    /// This class implement the segmented iterator for the hpx::unordered_map
     template <typename Key, typename T, typename Hash, typename KeyEqual,
         typename BaseIter>
     class segment_unordered_map_iterator
       : public hpx::util::iterator_adaptor<
             segment_unordered_map_iterator<Key, T, Hash, KeyEqual, BaseIter>,
-            BaseIter
-        >
+            BaseIter>
     {
     private:
         typedef hpx::util::iterator_adaptor<
-                segment_unordered_map_iterator<Key, T, Hash, KeyEqual, BaseIter>,
-                BaseIter
-            > base_type;
+            segment_unordered_map_iterator<Key, T, Hash, KeyEqual, BaseIter>,
+            BaseIter>
+            base_type;
 
     public:
         explicit segment_unordered_map_iterator(BaseIter const& it,
-                unordered_map<Key, T, Hash, KeyEqual>* data = nullptr)
-          : base_type(it), data_(data)
-        {}
+            unordered_map<Key, T, Hash, KeyEqual>* data = nullptr)
+          : base_type(it)
+          , data_(data)
+        {
+        }
 
         unordered_map<Key, T, Hash, KeyEqual>* get_data()
         {
@@ -90,23 +91,24 @@ namespace hpx { namespace segmented {
         typename BaseIter>
     class const_segment_unordered_map_iterator
       : public hpx::util::iterator_adaptor<
-            const_segment_unordered_map_iterator<
-                Key, T, Hash, KeyEqual, BaseIter>,
-            BaseIter
-        >
+            const_segment_unordered_map_iterator<Key, T, Hash, KeyEqual,
+                BaseIter>,
+            BaseIter>
     {
     private:
         typedef hpx::util::iterator_adaptor<
-                const_segment_unordered_map_iterator<
-                    Key, T, Hash, KeyEqual, BaseIter>,
-                BaseIter
-            > base_type;
+            const_segment_unordered_map_iterator<Key, T, Hash, KeyEqual,
+                BaseIter>,
+            BaseIter>
+            base_type;
 
     public:
         explicit const_segment_unordered_map_iterator(BaseIter const& it,
-                unordered_map<Key, T, Hash, KeyEqual> const* data = nullptr)
-          : base_type(it), data_(data)
-        {}
+            unordered_map<Key, T, Hash, KeyEqual> const* data = nullptr)
+          : base_type(it)
+          , data_(data)
+        {
+        }
 
         unordered_map<Key, T, Hash, KeyEqual> const* get_data() const
         {
@@ -123,95 +125,96 @@ namespace hpx { namespace segmented {
         unordered_map<Key, T, Hash, KeyEqual> const* data_;
     };
 
-//     ///////////////////////////////////////////////////////////////////////////
-//     namespace detail
-//     {
-//         template <typename BaseIterator>
-//         struct is_requested_locality
-//         {
-//             typedef typename std::iterator_traits<BaseIterator>::reference
-//                 reference;
-//
-//             is_requested_locality(std::uint32_t locality_id =
-//                     naming::invalid_locality_id)
-//               : locality_id_(locality_id)
-//             {}
-//
-//             bool operator()(reference val) const
-//             {
-//                 return locality_id_ == naming::invalid_locality_id ||
-//                        locality_id_ == val.locality_id_;
-//             }
-//
-//             std::uint32_t locality_id_;
-//         };
-//     }
-//
-//     /// This class implement the local segmented iterator for the hpx::vector
-//     template <typename T, typename BaseIter>
-//     class local_segment_vector_iterator
-//       : public hpx::util::iterator_adaptor<
-//             segmented::local_segment_vector_iterator<T, BaseIter>, BaseIter,
-//             std::vector<T>, std::forward_iterator_tag
-//         >
-//     {
-//     private:
-//         typedef hpx::util::iterator_adaptor<
-//                 segmented::local_segment_vector_iterator<T, BaseIter>, BaseIter,
-//                 std::vector<T>, std::forward_iterator_tag
-//             > base_type;
-//         typedef detail::is_requested_locality<BaseIter> predicate;
-//
-//     public:
-//         local_segment_vector_iterator(BaseIter const& end)
-//           : base_type(end), predicate_(), end_(end)
-//         {}
-//
-//         local_segment_vector_iterator(
-//                 BaseIter const& it, BaseIter const& end,
-//                 std::uint32_t locality_id)
-//           : base_type(it), predicate_(locality_id), end_(end)
-//         {
-//             satisfy_predicate();
-//         }
-//
-//         bool is_at_end() const
-//         {
-//             return !data_ || this->base() == end_;
-//         }
-//
-//     private:
-//         friend class hpx::util::iterator_core_access;
-//
-//         typename base_type::reference dereference() const
-//         {
-//             HPX_ASSERT(!is_at_end());
-//             return data_->get_data();
-//         }
-//
-//         void increment()
-//         {
-//             ++(this->base_reference());
-//             satisfy_predicate();
-//         }
-//
-//         void satisfy_predicate()
-//         {
-//             while (this->base() != end_ && !predicate_(*this->base()))
-//                 ++(this->base_reference());
-//
-//             if (this->base() != end_)
-//                 data_ = this->base()->local_data_;
-//             else
-//                 data_.reset();
-//         }
-//
-//     private:
-//         std::shared_ptr<server::partitioned_vector<T> > data_;
-//         predicate predicate_;
-//         BaseIter end_;
-//     };
-}}
+    //     ///////////////////////////////////////////////////////////////////////////
+    //     namespace detail
+    //     {
+    //         template <typename BaseIterator>
+    //         struct is_requested_locality
+    //         {
+    //             typedef typename std::iterator_traits<BaseIterator>::reference
+    //                 reference;
+    //
+    //             is_requested_locality(std::uint32_t locality_id =
+    //                     naming::invalid_locality_id)
+    //               : locality_id_(locality_id)
+    //             {}
+    //
+    //             bool operator()(reference val) const
+    //             {
+    //                 return locality_id_ == naming::invalid_locality_id ||
+    //                        locality_id_ == val.locality_id_;
+    //             }
+    //
+    //             std::uint32_t locality_id_;
+    //         };
+    //     }
+    //
+    //     /// This class implement the local segmented iterator for the
+    //     /// hpx::partitioned_vector.
+    //     template <typename T, typename BaseIter>
+    //     class local_segment_vector_iterator
+    //       : public hpx::util::iterator_adaptor<
+    //             segmented::local_segment_vector_iterator<T, BaseIter>, BaseIter,
+    //             std::vector<T>, std::forward_iterator_tag
+    //         >
+    //     {
+    //     private:
+    //         typedef hpx::util::iterator_adaptor<
+    //                 segmented::local_segment_vector_iterator<T, BaseIter>, BaseIter,
+    //                 std::vector<T>, std::forward_iterator_tag
+    //             > base_type;
+    //         typedef detail::is_requested_locality<BaseIter> predicate;
+    //
+    //     public:
+    //         local_segment_vector_iterator(BaseIter const& end)
+    //           : base_type(end), predicate_(), end_(end)
+    //         {}
+    //
+    //         local_segment_vector_iterator(
+    //                 BaseIter const& it, BaseIter const& end,
+    //                 std::uint32_t locality_id)
+    //           : base_type(it), predicate_(locality_id), end_(end)
+    //         {
+    //             satisfy_predicate();
+    //         }
+    //
+    //         bool is_at_end() const
+    //         {
+    //             return !data_ || this->base() == end_;
+    //         }
+    //
+    //     private:
+    //         friend class hpx::util::iterator_core_access;
+    //
+    //         typename base_type::reference dereference() const
+    //         {
+    //             HPX_ASSERT(!is_at_end());
+    //             return data_->get_data();
+    //         }
+    //
+    //         void increment()
+    //         {
+    //             ++(this->base_reference());
+    //             satisfy_predicate();
+    //         }
+    //
+    //         void satisfy_predicate()
+    //         {
+    //             while (this->base() != end_ && !predicate_(*this->base()))
+    //                 ++(this->base_reference());
+    //
+    //             if (this->base() != end_)
+    //                 data_ = this->base()->local_data_;
+    //             else
+    //                 data_.reset();
+    //         }
+    //
+    //     private:
+    //         std::shared_ptr<server::partitioned_vector<T> > data_;
+    //         predicate predicate_;
+    //         BaseIter end_;
+    //     };
+}}    // namespace hpx::segmented
 
 namespace hpx {
 


### PR DESCRIPTION
Some comments for the iterators of `hpx::partitioned_vector` and `hpx::unordered_map` contained references to `hpx::vector`, which was renamed to `hpx::partitioned_vector` a good while ago.
