### PR TITLE
docs: fix broken api algo links

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ packages
 .vs
 .idea
 cmake-build*
+/.cache

--- a/cmake/templates/conf.py.in
+++ b/cmake/templates/conf.py.in
@@ -173,10 +173,17 @@ for lib in hpx_libs.keys():
         module_api_ref = open(basedir + '/full_api.rst', 'w')
         module_api_ref.write(api_ref_header.format(module))
         header_refs = ''
+        header_names = set()
         for source in module_sources[1]:
             header = source[len('include/'):]
             header_splitted = re.split('[/ .]',header)
+            
             header_name = header_splitted[-2]
+            # create a new, longer header name if current one already exists
+            if header_name in header_names:
+                header_name = '{0}_{1}'.format(header_splitted[-3], header_name)
+            header_names.add(header_name)
+                                
             header_ref = open(basedir + '/' + header_name + '.rst', 'w')
             header_ref.write(api_header_file.format(header, module))
             header_ref.close()


### PR DESCRIPTION
Fixes broken algorithm links on the public API page.

## Proposed Changes

  - added vscode's cache directory to gitignore 
  - remove part of the commit that broke the links

### Before and After

![Screenshot_20220607_183753](https://user-images.githubusercontent.com/61645613/172513538-8b5401b0-ce33-43d9-85bb-6fa2218bd6ce.png)

![Screenshot_20220607_183732](https://user-images.githubusercontent.com/61645613/172513679-04020b11-a3a9-4e2c-bab6-9c94ecd99fdd.png)



