### PR TITLE
Fix minor doxygen parsing typo

### DIFF
--- a/libs/core/algorithms/include/hpx/parallel/container_algorithms/partial_sort.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/container_algorithms/partial_sort.hpp
@@ -174,11 +174,11 @@ namespace hpx { namespace ranges {
     /// calling thread.
     ///
     /// \returns  The \a partial_sort algorithm returns \a
-    ///           typename hpx::traits::range_iterator<Rng>::type.
+    ///           typename hpx::traits::range_iterator_t<Rng>.
     ///           It returns \a last.
     template <typename Rng, typename Comp, typename Proj>
-    hpx::traits::range_iterator<Rng>_t
-    partial_sort(Rng&& rng,, hpx::traits::range_iterator<Rng>_t middle,
+    hpx::traits::range_iterator_t<Rng>
+    partial_sort(Rng&& rng,, hpx::traits::range_iterator_t<Rng> middle,
         Comp&& comp = Comp(), Proj&& proj = Proj());
 
     ///////////////////////////////////////////////////////////////////////////
@@ -239,19 +239,19 @@ namespace hpx { namespace ranges {
     /// threads, and indeterminately sequenced within each thread.
     ///
     /// \returns  The \a partial_sort algorithm returns a
-    ///           \a hpx::future<typename hpx::traits::range_iterator<Rng>
-    ///           ::type> if the execution policy is of type
+    ///           \a hpx::future<typename hpx::traits::range_iterator_t<Rng>
+    ///           if the execution policy is of type
     ///           \a sequenced_task_policy or
     ///           \a parallel_task_policy and returns \a
-    ///           typename hpx::traits::range_iterator<Rng>::type
+    ///           typename hpx::traits::range_iterator_t<Rng>
     ///           otherwise.
     ///           It returns \a last.
     ///
     template <typename ExPolicy, typename Rng, typename Comp, typename Proj>
     util::detail::algorithm_result_t<ExPolicy,
-        hpx::traits::range_iterator<Rng>_t>
+        hpx::traits::range_iterator_t<Rng>>
     partial_sort(ExPolicy&& policy, Rng&& rng,
-        hpx::traits::range_iterator<Rng>_t middle,
+        hpx::traits::range_iterator_t<Rng> middle,
         Comp&& comp = Comp(), Proj&& proj = Proj());
 
     // clang-format on

--- a/libs/core/algorithms/include/hpx/parallel/container_algorithms/sort.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/container_algorithms/sort.hpp
@@ -251,8 +251,8 @@ namespace hpx { namespace ranges {
     /// threads, and indeterminately sequenced within each thread.
     ///
     /// \returns  The \a sort algorithm returns a
-    ///           \a hpx::future<typename hpx::traits::range_iterator<Rng>
-    ///           ::type> if the execution policy is of type
+    ///           \a hpx::future<typename hpx::traits::range_iterator_t<Rng>
+    ///           if the execution policy is of type
     ///           \a sequenced_task_policy or
     ///           \a parallel_task_policy and returns \a
     ///           typename hpx::traits::range_iterator<Rng>::type
@@ -261,7 +261,7 @@ namespace hpx { namespace ranges {
     ///
     template <typename ExPolicy, typename Rng, typename Pred, typename Proj>
     typename util::detail::algorithm_result<ExPolicy,
-        typename hpx::traits::range_iterator<Rng>::type>::type
+        typename hpx::traits::range_iterator_t<Rng>>::type
     sort(ExPolicy&& policy, Rng&& rng, Comp&& comp, Proj&&);
 
     // clang-format on

--- a/libs/core/algorithms/include/hpx/parallel/container_algorithms/stable_sort.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/container_algorithms/stable_sort.hpp
@@ -251,8 +251,8 @@ namespace hpx { namespace ranges {
     /// threads, and indeterminately sequenced within each thread.
     ///
     /// \returns  The \a stable_sort algorithm returns a
-    ///           \a hpx::future<typename hpx::traits::range_iterator<Rng>
-    ///           ::type> if the execution policy is of type
+    ///           \a hpx::future<typename hpx::traits::range_iterator_t<Rng>
+    ///           if the execution policy is of type
     ///           \a sequenced_task_policy or
     ///           \a parallel_task_policy and returns \a
     ///           typename hpx::traits::range_iterator<Rng>::type
@@ -261,7 +261,7 @@ namespace hpx { namespace ranges {
     ///
     template <typename ExPolicy, typename Rng, typename Pred, typename Proj>
     typename util::detail::algorithm_result<ExPolicy,
-        typename hpx::traits::range_iterator<Rng>::type>::type
+        typename hpx::traits::range_iterator_t<Rng>>::type
     stable_sort(ExPolicy&& policy, Rng&& rng, Comp&& comp, Proj&&);
 
     // clang-format on

--- a/libs/core/algorithms/include/hpx/parallel/container_algorithms/unique.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/container_algorithms/unique.hpp
@@ -195,8 +195,8 @@ namespace hpx { namespace ranges {
     /// calling thread.
     ///
     /// \returns  The \a unique algorithm returns
-    ///           \a subrange_t<typename hpx::traits::range_iterator<Rng>
-    ///           ::type,hpx::traits::range_iterator_t<Rng>>.
+    ///           \a subrange_t<typename hpx::traits::range_iterator_t<Rng>,
+    ///           hpx::traits::range_iterator_t<Rng>>.
     ///           The \a unique algorithm returns an object {ret, last},
     ///           where ret is a past-the-end iterator for a new
     ///           subrange.


### PR DESCRIPTION
Fixes minor typo that might cause hyperlink to break in Doxygen. The warning stems from line #199 and everything below that fails to link to our docs page. Let's merge it as it is a typo anyways and see if it also fixes the linking problem.

I don't think the `\a` clause has to be an one-liner, does it?

