### PR TITLE
[P2300] enhancements: receiver_of, sender_of improvements

### DIFF
--- a/libs/core/execution_base/include/hpx/execution_base/completion_signatures.hpp
+++ b/libs/core/execution_base/include/hpx/execution_base/completion_signatures.hpp
@@ -10,6 +10,7 @@
 #include <hpx/datastructures/tuple.hpp>
 #include <hpx/datastructures/variant.hpp>
 #include <hpx/execution_base/get_env.hpp>
+#include <hpx/execution_base/receiver.hpp>
 #include <hpx/execution_base/sender.hpp>
 #include <hpx/functional/detail/tag_fallback_invoke.hpp>
 #include <hpx/functional/invoke_result.hpp>
@@ -382,7 +383,7 @@ namespace hpx::execution::experimental {
 
     // The sender_of concept defines the requirements for a sender type that on
     // successful completion sends the specified set of value types.
-    template <class S, class E = no_env, class... Ts>
+    template <class S, class R>
     struct is_sender_of;
 
     namespace detail {
@@ -606,29 +607,56 @@ namespace hpx::execution::experimental {
     inline constexpr bool is_sender_v = is_sender<Sender, Env>::value;
 
     namespace detail {
-        template <bool IsSenderOf, class S, class E = no_env, class... Ts>
-        struct is_sender_of_impl;
 
-        template <class S, class E, class... Ts>
-        struct is_sender_of_impl<false, S, E, Ts...> : std::false_type
+        // Sender may or may not support sends_stopped
+        // In the false case only the value_types and error_types are checked
+        template <class S, class R, class CS,
+            bool sends_stopped = CS::sends_stopped>
+        struct sender_support_sends_stopped;
+
+        template <class S, class R, class CS>
+        struct sender_support_sends_stopped<S, R, CS, true>
+          : std::integral_constant<bool,
+                is_receiver_of_v<R, completion_signatures_of_t<S, env_of_t<R>>>>
         {
         };
 
-        template <class S, class E, class... Ts>
-        struct is_sender_of_impl<true, S, E, Ts...>
+        template <class S, class R, class CS>
+        struct sender_support_sends_stopped<S, R, CS, false>
           : std::integral_constant<bool,
-                is_receiver_of_v<S, completion_signatures_of_t<S, E>>>
+                is_invocable_variant_of_tuples<set_value_t, R,
+                    typename CS::template value_types<hpx::tuple,
+                        hpx::variant>>::value &&
+                    is_invocable_variant<set_error_t, R,
+                        typename CS::template error_types<hpx::variant>>::value>
+        {
+        };
+
+        template <bool IsSenderOf, class S, class R>
+        struct is_sender_of_impl;
+
+        template <class S, class R>
+        struct is_sender_of_impl<false, S, R> : std::false_type
+        {
+        };
+
+        template <class S, class R>
+        struct is_sender_of_impl<true, S, R>
+          : std::integral_constant<bool,
+                sender_support_sends_stopped<S, R,
+                    completion_signatures_of_t<S, env_of_t<R>>>::value>
         {
         };
     }    // namespace detail
 
-    template <class S, class E, class... Ts>
-    struct is_sender_of : detail::is_sender_of_impl<is_sender_v<S>, E, Ts...>
+    template <class S, class R>
+    struct is_sender_of
+      : detail::is_sender_of_impl<is_sender_v<S, env_of_t<R>>, S, R>
     {
     };
 
-    template <class S, class E = no_env, class... Ts>
-    inline constexpr bool is_sender_of_v = is_sender_of<S, E, Ts...>::value;
+    template <class S, class R>
+    inline constexpr bool is_sender_of_v = is_sender_of<S, R>::value;
 
     template <typename Sender, typename Receiver>
     struct is_sender_to

--- a/libs/core/execution_base/include/hpx/execution_base/completion_signatures.hpp
+++ b/libs/core/execution_base/include/hpx/execution_base/completion_signatures.hpp
@@ -380,6 +380,11 @@ namespace hpx::execution::experimental {
     template <typename Sender, typename Receiver>
     struct is_sender_to;
 
+    // The sender_of concept defines the requirements for a sender type that on
+    // successful completion sends the specified set of value types.
+    template <class S, class E = no_env, class... Ts>
+    struct is_sender_of;
+
     namespace detail {
 
         ///////////////////////////////////////////////////////////////////////
@@ -599,6 +604,31 @@ namespace hpx::execution::experimental {
 
     template <typename Sender, typename Env = empty_env>
     inline constexpr bool is_sender_v = is_sender<Sender, Env>::value;
+
+    namespace detail {
+        template <bool IsSenderOf, class S, class E = no_env, class... Ts>
+        struct is_sender_of_impl;
+
+        template <class S, class E, class... Ts>
+        struct is_sender_of_impl<false, S, E, Ts...> : std::false_type
+        {
+        };
+
+        template <class S, class E, class... Ts>
+        struct is_sender_of_impl<true, S, E, Ts...>
+          : std::integral_constant<bool,
+                is_receiver_of_v<S, completion_signatures_of_t<S, E>>>
+        {
+        };
+    }    // namespace detail
+
+    template <class S, class E, class... Ts>
+    struct is_sender_of : detail::is_sender_of_impl<is_sender_v<S>, E, Ts...>
+    {
+    };
+
+    template <class S, class E = no_env, class... Ts>
+    inline constexpr bool is_sender_of_v = is_sender_of<S, E, Ts...>::value;
 
     template <typename Sender, typename Receiver>
     struct is_sender_to

--- a/libs/core/execution_base/include/hpx/execution_base/completion_signatures.hpp
+++ b/libs/core/execution_base/include/hpx/execution_base/completion_signatures.hpp
@@ -616,7 +616,7 @@ namespace hpx::execution::experimental {
         };
 
         template <typename CS, typename... Ts>
-        inline bool constexpr is_same_types = std::same_as<
+        inline bool constexpr is_same_types = std::is_same_v<
             typename CS::template value_types<meta::pack, meta::pack>,
             meta::pack<meta::pack<Ts...>>>;
 

--- a/libs/core/execution_base/include/hpx/execution_base/receiver.hpp
+++ b/libs/core/execution_base/include/hpx/execution_base/receiver.hpp
@@ -8,6 +8,8 @@
 #pragma once
 
 #include <hpx/config/constexpr.hpp>
+#include <hpx/datastructures/tuple.hpp>
+#include <hpx/datastructures/variant.hpp>
 #include <hpx/functional/tag_invoke.hpp>
 #include <hpx/functional/traits/is_invocable.hpp>
 
@@ -91,6 +93,15 @@ namespace hpx { namespace execution { namespace experimental {
     /// requiring one additional completion-signal operation:
     ///     * `hpx::execution::set_value`
     ///
+    /// The `receiver_of` concept takes a receiver and an instance of the
+    /// `completion_signatures<>` class template.
+    /// The `receiver_of` concept, rather than accepting a receiver and some
+    /// value types, is changed to take a receiver and an instance of the
+    /// `completion_signatures<>` class template.
+    /// A sender uses `completion_signatures<>` to describe the signals
+    /// with which it completes. The `receiver_of` concept ensures that a
+    /// particular receiver is capable of receiving those signals.
+    ///
     /// This completion-signal operation adds the following to the Receiver's
     /// contract:
     ///     * If `hpx::execution::set_value` exits with an exception, it
@@ -98,7 +109,7 @@ namespace hpx { namespace execution { namespace experimental {
     ///       `hpx::execution::set_stopped`
     ///
     /// \see hpx::execution::traits::is_receiver
-    template <typename T, typename... As>
+    template <typename Receiver, typename CS>
     struct is_receiver_of;
 
     HPX_HOST_DEVICE_INLINE_CONSTEXPR_VARIABLE
@@ -149,59 +160,97 @@ namespace hpx { namespace execution { namespace experimental {
 
     ///////////////////////////////////////////////////////////////////////
     namespace detail {
-        template <bool IsReceiverOf, typename T, typename... As>
+        template <bool IsReceiverOf, typename T, typename CS>
         struct is_receiver_of_impl;
 
-        template <typename T, typename... As>
-        struct is_receiver_of_impl<false, T, As...> : std::false_type
+        template <typename T, typename CS>
+        struct is_receiver_of_impl<false, T, CS> : std::false_type
         {
         };
 
-        template <typename T, typename... As>
-        struct is_receiver_of_impl<true, T, As...>
+        template <typename CS>
+        auto inline constexpr _variant =
+            typename CS::template value_types<hpx::tuple, hpx::variant>{};
+
+        template <typename CS>
+        auto inline constexpr _variant_idx = (_variant<CS>) .index();
+
+        template <typename CS>
+        auto inline constexpr _tuple = hpx::get<_variant_idx<CS>>(_variant<CS>);
+
+        template <typename CS>
+        inline constexpr auto _tuple_size =
+            hpx::tuple_size<decltype(_tuple<CS>)>{};
+
+        template <typename T, typename R, typename Tuple, std::size_t... I>
+        bool constexpr inline _is_invocable_tuple_unpack(
+            T, R, Tuple&& t, std::index_sequence<I...>)
+        {
+            return hpx::is_invocable_v<std::decay_t<T>&&, std::decay_t<R>&&,
+                decltype(hpx::get<I>(std::forward<Tuple>(t)))...>;
+        }
+
+        template <typename T, typename R, typename Tuple, std::size_t... I>
+        bool constexpr inline _is_invocable_f_tuple_unpack(
+            T&& f, R, Tuple&& t, std::index_sequence<I...>)
+        {
+            return noexcept(f(std::declval<R>(),
+                std::declval<decltype(
+                    hpx::get<I>(std::forward<Tuple>(t)))>()...));
+        }
+
+        template <typename T, typename CS>
+        struct is_receiver_of_impl<true, T, CS>
           : std::integral_constant<bool,
-                hpx::is_invocable_v<set_value_t, std::decay_t<T>&&, As...>>
+                _is_invocable_tuple_unpack(set_value_t{}, T{}, _tuple<CS>,
+                    std::make_index_sequence<_tuple_size<CS>>{}) &&
+                    _is_invocable_tuple_unpack(set_error_t{}, T{}, _tuple<CS>,
+                        std::make_index_sequence<_tuple_size<CS>>{}) &&
+                    CS::sends_stopped>
         {
         };
     }    // namespace detail
 
-    template <typename T, typename... As>
-    struct is_receiver_of
-      : detail::is_receiver_of_impl<is_receiver_v<T>, T, As...>
+    template <typename T, typename CS>
+    struct is_receiver_of : detail::is_receiver_of_impl<is_receiver_v<T>, T, CS>
     {
     };
 
-    template <typename T, typename... As>
-    inline constexpr bool is_receiver_of_v = is_receiver_of<T, As...>::value;
+    template <typename T, typename CS>
+    inline constexpr bool is_receiver_of_v = is_receiver_of<T, CS>::value;
 
     ///////////////////////////////////////////////////////////////////////
     namespace detail {
-        template <bool IsReceiverOf, typename T, typename... As>
+        template <bool IsReceiverOf, typename T, typename CS>
         struct is_nothrow_receiver_of_impl;
 
-        template <typename T, typename... As>
-        struct is_nothrow_receiver_of_impl<false, T, As...> : std::false_type
+        template <typename T, typename CS>
+        struct is_nothrow_receiver_of_impl<false, T, CS> : std::false_type
         {
         };
 
-        template <typename T, typename... As>
-        struct is_nothrow_receiver_of_impl<true, T, As...>
+        template <typename T, typename CS>
+        struct is_nothrow_receiver_of_impl<true, T, CS>
           : std::integral_constant<bool,
-                noexcept(set_value(std::declval<T>(), std::declval<As>()...))>
+                _is_invocable_f_tuple_unpack(set_value, T{}, _tuple<CS>,
+                    std::make_index_sequence<_tuple_size<CS>>{}) &&
+                    _is_invocable_f_tuple_unpack(set_error, T{}, _tuple<CS>,
+                        std::make_index_sequence<_tuple_size<CS>>{}) &&
+                    CS::sends_stopped>
         {
         };
     }    // namespace detail
 
-    template <typename T, typename... As>
+    template <typename T, typename CS>
     struct is_nothrow_receiver_of
       : detail::is_nothrow_receiver_of_impl<
-            is_receiver_v<T> && is_receiver_of_v<T, As...>, T, As...>
+            is_receiver_v<T> && is_receiver_of_v<T, CS>, T, CS>
     {
     };
 
-    template <typename T, typename... As>
+    template <typename T, typename CS>
     inline constexpr bool is_nothrow_receiver_of_v =
-        is_nothrow_receiver_of<T, As...>::value;
+        is_nothrow_receiver_of<T, CS>::value;
 
     namespace detail {
         template <typename CPO>

--- a/libs/core/execution_base/include/hpx/execution_base/receiver.hpp
+++ b/libs/core/execution_base/include/hpx/execution_base/receiver.hpp
@@ -8,10 +8,10 @@
 #pragma once
 
 #include <hpx/config/constexpr.hpp>
-#include <hpx/datastructures/tuple.hpp>
-#include <hpx/datastructures/variant.hpp>
 #include <hpx/functional/tag_invoke.hpp>
 #include <hpx/functional/traits/is_invocable.hpp>
+#include <hpx/type_support/meta.hpp>
+#include <hpx/type_support/pack.hpp>
 
 #include <exception>
 #include <type_traits>
@@ -175,7 +175,7 @@ namespace hpx { namespace execution { namespace experimental {
 
         template <typename F, typename T, typename... Ts>
         struct is_invocable_variant_of_tuples<F, T,
-            hpx::variant<hpx::tuple<Ts...>>>
+            meta::pack<meta::pack<Ts...>>>
           : hpx::is_invocable<F, std::decay_t<T>&&, Ts...>
         {
         };
@@ -186,7 +186,7 @@ namespace hpx { namespace execution { namespace experimental {
         };
 
         template <typename F, typename T, typename... Ts>
-        struct is_invocable_variant<F, T, hpx::variant<Ts...>>
+        struct is_invocable_variant<F, T, meta::pack<Ts...>>
           : hpx::is_invocable<F, std::decay_t<T>&&, Ts...>
         {
         };
@@ -195,11 +195,10 @@ namespace hpx { namespace execution { namespace experimental {
         struct is_receiver_of_impl<true, T, CS>
           : std::integral_constant<bool,
                 is_invocable_variant_of_tuples<set_value_t, T,
-                    typename CS::template value_types<hpx::tuple,
-                        hpx::variant>>::value &&
+                    typename CS::template value_types<meta::pack,
+                        meta::pack>>::value &&
                     is_invocable_variant<set_error_t, T,
-                        typename CS::template error_types<hpx::variant>>::
-                        value &&
+                        typename CS::template error_types<meta::pack>>::value &&
                     CS::sends_stopped>
         {
         };
@@ -222,7 +221,7 @@ namespace hpx { namespace execution { namespace experimental {
 
         template <typename F, typename T, typename... Ts>
         struct is_nothrow_invocable_variant_of_tuples<F, T,
-            hpx::variant<hpx::tuple<Ts...>>>
+            meta::pack<meta::pack<Ts...>>>
           : hpx::functional::is_nothrow_tag_invocable<F, std::decay_t<T>&&,
                 Ts...>
         {
@@ -234,7 +233,7 @@ namespace hpx { namespace execution { namespace experimental {
         };
 
         template <typename F, typename T, typename... Ts>
-        struct is_nothrow_invocable_variant<F, T, hpx::variant<Ts...>>
+        struct is_nothrow_invocable_variant<F, T, meta::pack<Ts...>>
           : hpx::functional::is_nothrow_tag_invocable<F, std::decay_t<T>&&,
                 Ts...>
         {
@@ -252,11 +251,10 @@ namespace hpx { namespace execution { namespace experimental {
         struct is_nothrow_receiver_of_impl<true, T, CS>
           : std::integral_constant<bool,
                 is_nothrow_invocable_variant_of_tuples<set_value_t, T,
-                    typename CS::template value_types<hpx::tuple,
-                        hpx::variant>>::value &&
+                    typename CS::template value_types<meta::pack,
+                        meta::pack>>::value &&
                     is_nothrow_invocable_variant<set_error_t, T,
-                        typename CS::template error_types<hpx::variant>>::
-                        value &&
+                        typename CS::template error_types<meta::pack>>::value &&
                     CS::sends_stopped>
         {
         };

--- a/libs/core/execution_base/tests/unit/basic_receiver.cpp
+++ b/libs/core/execution_base/tests/unit/basic_receiver.cpp
@@ -4,6 +4,7 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+#include <hpx/execution_base/completion_signatures.hpp>
 #include <hpx/execution_base/receiver.hpp>
 #include <hpx/modules/testing.hpp>
 
@@ -212,58 +213,133 @@ int main()
 
     static_assert(is_receiver<mylib::receiver_1>::value,
         "mylib::receiver_1 should be a receiver");
-    static_assert(is_receiver_of<mylib::receiver_1, int>::value,
+    static_assert(
+        is_receiver_of<mylib::receiver_1,
+            hpx::execution::experimental::completion_signatures<
+                hpx::execution::experimental::set_value_t(int()),
+                hpx::execution::experimental::set_error_t(std::exception_ptr),
+                hpx::execution::experimental::set_stopped_t()>>::value,
         "mylib::receiver_1 should be a receiver of an int");
-    static_assert(!is_nothrow_receiver_of<mylib::receiver_1, int>::value,
+    static_assert(
+        !is_nothrow_receiver_of<mylib::receiver_1,
+            hpx::execution::experimental::completion_signatures<
+                hpx::execution::experimental::set_value_t(int()),
+                hpx::execution::experimental::set_error_t(std::exception_ptr),
+                hpx::execution::experimental::set_stopped_t()>>::value,
         "mylib::receiver_1 should not be a nothrow receiver of an int");
-    static_assert(!is_receiver_of<mylib::receiver_1, std::string>::value,
+    static_assert(
+        !is_receiver_of<mylib::receiver_1,
+            hpx::execution::experimental::completion_signatures<
+                hpx::execution::experimental::set_value_t(std::string()),
+                hpx::execution::experimental::set_error_t(std::exception_ptr),
+                hpx::execution::experimental::set_stopped_t()>>::value,
         "mylib::receiver_1 should not be a receiver of a std::string");
 
     static_assert(!is_receiver<mylib::receiver_2>::value,
         "mylib::receiver_2 should not be a receiver of std::exception_ptr");
     static_assert(is_receiver<mylib::receiver_2, int>::value,
         "mylib::receiver_2 should be a receiver");
-    static_assert(!is_receiver_of<mylib::receiver_2, int>::value,
+    static_assert(
+        !is_receiver_of<mylib::receiver_2,
+            hpx::execution::experimental::completion_signatures<
+                hpx::execution::experimental::set_value_t(int()),
+                hpx::execution::experimental::set_error_t(std::exception_ptr),
+                hpx::execution::experimental::set_stopped_t()>>::value,
         "mylib::receiver_2 should not be a receiver of int");
-    static_assert(!is_nothrow_receiver_of<mylib::receiver_2, int>::value,
+    static_assert(
+        !is_nothrow_receiver_of<mylib::receiver_2,
+            hpx::execution::experimental::completion_signatures<
+                hpx::execution::experimental::set_value_t(int()),
+                hpx::execution::experimental::set_error_t(std::exception_ptr),
+                hpx::execution::experimental::set_stopped_t()>>::value,
         "mylib::receiver_2 should not be a nothrow receiver of int");
 
     static_assert(is_receiver<mylib::receiver_1>::value,
         "mylib::receiver_1 should be a receiver");
-    static_assert(is_receiver_of<mylib::receiver_3, int>::value,
+    static_assert(
+        is_receiver_of<mylib::receiver_3,
+            hpx::execution::experimental::completion_signatures<
+                hpx::execution::experimental::set_value_t(int()),
+                hpx::execution::experimental::set_error_t(std::exception_ptr),
+                hpx::execution::experimental::set_stopped_t()>>::value,
         "mylib::receiver_3 should be a receiver of an int");
-    static_assert(is_nothrow_receiver_of<mylib::receiver_3, int>::value,
+    static_assert(
+        is_nothrow_receiver_of<mylib::receiver_3,
+            hpx::execution::experimental::completion_signatures<
+                hpx::execution::experimental::set_value_t(int()),
+                hpx::execution::experimental::set_error_t(std::exception_ptr),
+                hpx::execution::experimental::set_stopped_t()>>::value,
         "mylib::receiver_3 should be a nothrow receiver of an int");
-    static_assert(!is_receiver_of<mylib::receiver_3, std::string>::value,
+    static_assert(
+        !is_receiver_of<mylib::receiver_3,
+            hpx::execution::experimental::completion_signatures<
+                hpx::execution::experimental::set_value_t(std::string()),
+                hpx::execution::experimental::set_error_t(std::exception_ptr),
+                hpx::execution::experimental::set_stopped_t()>>::value,
         "mylib::receiver_3 should not be a receiver of a std::string");
 
     static_assert(!is_receiver<mylib::non_receiver_1>::value,
         "mylib::non_receiver_1 should not be a receiver");
-    static_assert(!is_receiver_of<mylib::non_receiver_1, int>::value,
+    static_assert(
+        !is_receiver_of<mylib::non_receiver_1,
+            hpx::execution::experimental::completion_signatures<
+                hpx::execution::experimental::set_value_t(int()),
+                hpx::execution::experimental::set_error_t(std::exception_ptr),
+                hpx::execution::experimental::set_stopped_t()>>::value,
         "mylib::non_receiver_1 should not be a receiver of int");
     static_assert(!is_receiver<mylib::non_receiver_2>::value,
         "mylib::non_receiver_2 should not be a receiver");
-    static_assert(!is_receiver_of<mylib::non_receiver_2, int>::value,
+    static_assert(
+        !is_receiver_of<mylib::non_receiver_2,
+            hpx::execution::experimental::completion_signatures<
+                hpx::execution::experimental::set_value_t(int()),
+                hpx::execution::experimental::set_error_t(std::exception_ptr),
+                hpx::execution::experimental::set_stopped_t()>>::value,
         "mylib::non_receiver_2 should not be a receiver of int");
     static_assert(!is_receiver<mylib::non_receiver_3>::value,
         "mylib::non_receiver_3 should not be a receiver");
-    static_assert(!is_receiver_of<mylib::non_receiver_3, int>::value,
+    static_assert(
+        !is_receiver_of<mylib::non_receiver_3,
+            hpx::execution::experimental::completion_signatures<
+                hpx::execution::experimental::set_value_t(int()),
+                hpx::execution::experimental::set_error_t(std::exception_ptr),
+                hpx::execution::experimental::set_stopped_t()>>::value,
         "mylib::non_receiver_3 should not be a receiver of int");
     static_assert(is_receiver<mylib::non_receiver_4>::value,
         "mylib::non_receiver_4 should be a receiver");
-    static_assert(!is_receiver_of<mylib::non_receiver_4, int>::value,
+    static_assert(
+        !is_receiver_of<mylib::non_receiver_4,
+            hpx::execution::experimental::completion_signatures<
+                hpx::execution::experimental::set_value_t(int()),
+                hpx::execution::experimental::set_error_t(std::exception_ptr),
+                hpx::execution::experimental::set_stopped_t()>>::value,
         "mylib::non_receiver_4 should not be a receiver of int");
     static_assert(!is_receiver<mylib::non_receiver_5>::value,
         "mylib::non_receiver_5 should not be a receiver");
-    static_assert(!is_receiver_of<mylib::non_receiver_5, int>::value,
+    static_assert(
+        !is_receiver_of<mylib::non_receiver_5,
+            hpx::execution::experimental::completion_signatures<
+                hpx::execution::experimental::set_value_t(int()),
+                hpx::execution::experimental::set_error_t(std::exception_ptr),
+                hpx::execution::experimental::set_stopped_t()>>::value,
         "mylib::non_receiver_5 should not be a receiver of int");
     static_assert(!is_receiver<mylib::non_receiver_6>::value,
         "mylib::non_receiver_6 should not be a receiver");
-    static_assert(!is_receiver_of<mylib::non_receiver_6, int>::value,
+    static_assert(
+        !is_receiver_of<mylib::non_receiver_6,
+            hpx::execution::experimental::completion_signatures<
+                hpx::execution::experimental::set_value_t(int()),
+                hpx::execution::experimental::set_error_t(std::exception_ptr),
+                hpx::execution::experimental::set_stopped_t()>>::value,
         "mylib::non_receiver_6 should not be a receiver of int");
     static_assert(!is_receiver<mylib::non_receiver_7>::value,
         "mylib::non_receiver_7 should not be a receiver");
-    static_assert(!is_receiver_of<mylib::non_receiver_7, int>::value,
+    static_assert(
+        !is_receiver_of<mylib::non_receiver_7,
+            hpx::execution::experimental::completion_signatures<
+                hpx::execution::experimental::set_value_t(int()),
+                hpx::execution::experimental::set_error_t(std::exception_ptr),
+                hpx::execution::experimental::set_stopped_t()>>::value,
         "mylib::non_receiver_7 should not be a receiver of int");
 
     {

--- a/libs/core/execution_base/tests/unit/basic_receiver.cpp
+++ b/libs/core/execution_base/tests/unit/basic_receiver.cpp
@@ -216,21 +216,21 @@ int main()
     static_assert(
         is_receiver_of<mylib::receiver_1,
             hpx::execution::experimental::completion_signatures<
-                hpx::execution::experimental::set_value_t(int()),
+                hpx::execution::experimental::set_value_t(int),
                 hpx::execution::experimental::set_error_t(std::exception_ptr),
                 hpx::execution::experimental::set_stopped_t()>>::value,
         "mylib::receiver_1 should be a receiver of an int");
     static_assert(
         !is_nothrow_receiver_of<mylib::receiver_1,
             hpx::execution::experimental::completion_signatures<
-                hpx::execution::experimental::set_value_t(int()),
+                hpx::execution::experimental::set_value_t(int),
                 hpx::execution::experimental::set_error_t(std::exception_ptr),
                 hpx::execution::experimental::set_stopped_t()>>::value,
         "mylib::receiver_1 should not be a nothrow receiver of an int");
     static_assert(
         !is_receiver_of<mylib::receiver_1,
             hpx::execution::experimental::completion_signatures<
-                hpx::execution::experimental::set_value_t(std::string()),
+                hpx::execution::experimental::set_value_t(std::string),
                 hpx::execution::experimental::set_error_t(std::exception_ptr),
                 hpx::execution::experimental::set_stopped_t()>>::value,
         "mylib::receiver_1 should not be a receiver of a std::string");
@@ -242,14 +242,14 @@ int main()
     static_assert(
         !is_receiver_of<mylib::receiver_2,
             hpx::execution::experimental::completion_signatures<
-                hpx::execution::experimental::set_value_t(int()),
+                hpx::execution::experimental::set_value_t(int),
                 hpx::execution::experimental::set_error_t(std::exception_ptr),
                 hpx::execution::experimental::set_stopped_t()>>::value,
         "mylib::receiver_2 should not be a receiver of int");
     static_assert(
         !is_nothrow_receiver_of<mylib::receiver_2,
             hpx::execution::experimental::completion_signatures<
-                hpx::execution::experimental::set_value_t(int()),
+                hpx::execution::experimental::set_value_t(int),
                 hpx::execution::experimental::set_error_t(std::exception_ptr),
                 hpx::execution::experimental::set_stopped_t()>>::value,
         "mylib::receiver_2 should not be a nothrow receiver of int");
@@ -259,21 +259,21 @@ int main()
     static_assert(
         is_receiver_of<mylib::receiver_3,
             hpx::execution::experimental::completion_signatures<
-                hpx::execution::experimental::set_value_t(int()),
+                hpx::execution::experimental::set_value_t(int),
                 hpx::execution::experimental::set_error_t(std::exception_ptr),
                 hpx::execution::experimental::set_stopped_t()>>::value,
         "mylib::receiver_3 should be a receiver of an int");
     static_assert(
         is_nothrow_receiver_of<mylib::receiver_3,
             hpx::execution::experimental::completion_signatures<
-                hpx::execution::experimental::set_value_t(int()),
+                hpx::execution::experimental::set_value_t(int),
                 hpx::execution::experimental::set_error_t(std::exception_ptr),
                 hpx::execution::experimental::set_stopped_t()>>::value,
         "mylib::receiver_3 should be a nothrow receiver of an int");
     static_assert(
         !is_receiver_of<mylib::receiver_3,
             hpx::execution::experimental::completion_signatures<
-                hpx::execution::experimental::set_value_t(std::string()),
+                hpx::execution::experimental::set_value_t(std::string),
                 hpx::execution::experimental::set_error_t(std::exception_ptr),
                 hpx::execution::experimental::set_stopped_t()>>::value,
         "mylib::receiver_3 should not be a receiver of a std::string");
@@ -283,7 +283,7 @@ int main()
     static_assert(
         !is_receiver_of<mylib::non_receiver_1,
             hpx::execution::experimental::completion_signatures<
-                hpx::execution::experimental::set_value_t(int()),
+                hpx::execution::experimental::set_value_t(int),
                 hpx::execution::experimental::set_error_t(std::exception_ptr),
                 hpx::execution::experimental::set_stopped_t()>>::value,
         "mylib::non_receiver_1 should not be a receiver of int");
@@ -292,7 +292,7 @@ int main()
     static_assert(
         !is_receiver_of<mylib::non_receiver_2,
             hpx::execution::experimental::completion_signatures<
-                hpx::execution::experimental::set_value_t(int()),
+                hpx::execution::experimental::set_value_t(int),
                 hpx::execution::experimental::set_error_t(std::exception_ptr),
                 hpx::execution::experimental::set_stopped_t()>>::value,
         "mylib::non_receiver_2 should not be a receiver of int");
@@ -301,7 +301,7 @@ int main()
     static_assert(
         !is_receiver_of<mylib::non_receiver_3,
             hpx::execution::experimental::completion_signatures<
-                hpx::execution::experimental::set_value_t(int()),
+                hpx::execution::experimental::set_value_t(int),
                 hpx::execution::experimental::set_error_t(std::exception_ptr),
                 hpx::execution::experimental::set_stopped_t()>>::value,
         "mylib::non_receiver_3 should not be a receiver of int");
@@ -310,7 +310,7 @@ int main()
     static_assert(
         !is_receiver_of<mylib::non_receiver_4,
             hpx::execution::experimental::completion_signatures<
-                hpx::execution::experimental::set_value_t(int()),
+                hpx::execution::experimental::set_value_t(int),
                 hpx::execution::experimental::set_error_t(std::exception_ptr),
                 hpx::execution::experimental::set_stopped_t()>>::value,
         "mylib::non_receiver_4 should not be a receiver of int");
@@ -319,7 +319,7 @@ int main()
     static_assert(
         !is_receiver_of<mylib::non_receiver_5,
             hpx::execution::experimental::completion_signatures<
-                hpx::execution::experimental::set_value_t(int()),
+                hpx::execution::experimental::set_value_t(int),
                 hpx::execution::experimental::set_error_t(std::exception_ptr),
                 hpx::execution::experimental::set_stopped_t()>>::value,
         "mylib::non_receiver_5 should not be a receiver of int");
@@ -328,7 +328,7 @@ int main()
     static_assert(
         !is_receiver_of<mylib::non_receiver_6,
             hpx::execution::experimental::completion_signatures<
-                hpx::execution::experimental::set_value_t(int()),
+                hpx::execution::experimental::set_value_t(int),
                 hpx::execution::experimental::set_error_t(std::exception_ptr),
                 hpx::execution::experimental::set_stopped_t()>>::value,
         "mylib::non_receiver_6 should not be a receiver of int");
@@ -337,7 +337,7 @@ int main()
     static_assert(
         !is_receiver_of<mylib::non_receiver_7,
             hpx::execution::experimental::completion_signatures<
-                hpx::execution::experimental::set_value_t(int()),
+                hpx::execution::experimental::set_value_t(int),
                 hpx::execution::experimental::set_error_t(std::exception_ptr),
                 hpx::execution::experimental::set_stopped_t()>>::value,
         "mylib::non_receiver_7 should not be a receiver of int");

--- a/libs/core/execution_base/tests/unit/basic_sender.cpp
+++ b/libs/core/execution_base/tests/unit/basic_sender.cpp
@@ -349,47 +349,72 @@ int main()
                 hpx::execution::experimental::env_of_t<receiver>>>,
         "receiver does not support completion signatures of sender_1");
 
-    static_assert(
-        hpx::execution::experimental::is_sender_of_v<sender_1, receiver>,
-        "sender_1 is a sender to receiver");
-    static_assert(
-        hpx::execution::experimental::is_sender_of_v<sender_2, receiver>,
-        "sender_2 is a sender to receiver");
-    static_assert(
-        hpx::execution::experimental::is_sender_of_v<sender_3, receiver>,
-        "sender_3 is a sender to receiver");
+    static_assert(hpx::execution::experimental::is_sender_of_v<sender_1,
+                      hpx::execution::experimental::env_of_t<receiver>, int>,
+        "sender_1 is a sender of env_of_t<receiver> and value types int");
+    static_assert(hpx::execution::experimental::is_sender_of_v<sender_2,
+                      hpx::execution::experimental::env_of_t<receiver>, int>,
+        "sender_2 is a sender of env_of_t<receiver> and value types int");
+    static_assert(hpx::execution::experimental::is_sender_of_v<sender_3,
+                      hpx::execution::experimental::env_of_t<receiver>, int>,
+        "sender_3 is a sender of env_of_t<receiver> and value types int");
     static_assert(
         hpx::execution::experimental::is_sender_of_v<sender_4<true, int>,
-            receiver>,
-        "sender_4<true,int> is a sender to receiver");
+            hpx::execution::experimental::env_of_t<receiver>, int>,
+        "sender_4<true,int> is a sender of env_of_t<receiver> and value types "
+        "int");
     static_assert(
         hpx::execution::experimental::is_sender_of_v<sender_4<false, int>,
-            receiver>,
-        "sender_4<false,int> is a sender to receiver");
+            hpx::execution::experimental::env_of_t<receiver>, int>,
+        "sender_4<false,int> is a sender of env_of_t<receiver> and value types "
+        "int");
     static_assert(
-        hpx::execution::experimental::is_sender_of_v<sender_1, receiver_2<int>>,
-        "sender_1 is a sender to receiver_2<int>");
+        hpx::execution::experimental::is_sender_of_v<sender_1,
+            hpx::execution::experimental::env_of_t<receiver_2<int>>, int>,
+        "sender_1 is a sender of env_of_t<receiver_2<int>> and value types "
+        "int");
     static_assert(
-        hpx::execution::experimental::is_sender_of_v<sender_2, receiver_2<int>>,
-        "sender_2 is a sender to receiver_2<int>");
+        hpx::execution::experimental::is_sender_of_v<sender_2,
+            hpx::execution::experimental::env_of_t<receiver_2<int>>, int>,
+        "sender_2 is a sender of env_of_t<receiver_2<int>> and value types "
+        "int");
     static_assert(
-        hpx::execution::experimental::is_sender_of_v<sender_3, receiver_2<int>>,
-        "sender_3 is a sender to receiver_2<int>");
-    static_assert(hpx::execution::experimental::is_sender_of_v<
-                      sender_4<true, std::string>, receiver_2<std::string>>,
-        "sender_4<true,std::string> is a sender to receiver_2<std::string>");
-    static_assert(hpx::execution::experimental::is_sender_of_v<
-                      sender_4<true, std::string>, receiver_2<std::string>>,
-        "sender_4<false,std::string> is a sender to receiver_2<std::string>");
-    static_assert(!hpx::execution::experimental::is_sender_of_v<sender_1,
-                      receiver_2<std::string>>,
-        "sender_1 is not a sender to receiver_2<std::string>");
-    static_assert(!hpx::execution::experimental::is_sender_of_v<sender_2,
-                      receiver_2<std::string>>,
-        "sender_2 is not a sender to receiver_2<std::string>");
-    static_assert(!hpx::execution::experimental::is_sender_of_v<sender_3,
-                      receiver_2<std::string>>,
-        "sender_3 is not a sender to receiver_2<std::string>");
+        hpx::execution::experimental::is_sender_of_v<sender_3,
+            hpx::execution::experimental::env_of_t<receiver_2<int>>, int>,
+        "sender_3 is a sender of env_of_t<receiver_2<int>> and value types "
+        "int");
+    static_assert(
+        hpx::execution::experimental::is_sender_of_v<
+            sender_4<true, std::string>,
+            hpx::execution::experimental::env_of_t<receiver_2<std::string>>,
+            std::string>,
+        "sender_4<true,std::string> is a sender of "
+        "env_of_t<receiver_2<std::string>> and value types std::string");
+    static_assert(
+        hpx::execution::experimental::is_sender_of_v<
+            sender_4<true, std::string>,
+            hpx::execution::experimental::env_of_t<receiver_2<std::string>>,
+            std::string>,
+        "sender_4<false,std::string> is a sender of "
+        "env_of_t<receiver_2<std::string>> and value types std::string");
+    static_assert(
+        !hpx::execution::experimental::is_sender_of_v<sender_1,
+            hpx::execution::experimental::env_of_t<receiver_2<std::string>>,
+            std::string>,
+        "sender_1 is not a sender of env_of_t<receiver_2<std::string>> and "
+        "value types std::string");
+    static_assert(
+        !hpx::execution::experimental::is_sender_of_v<sender_2,
+            hpx::execution::experimental::env_of_t<receiver_2<std::string>>,
+            std::string>,
+        "sender_2 is not a sender of env_of_t<receiver_2<std::string>> and "
+        "value types std::string");
+    static_assert(
+        !hpx::execution::experimental::is_sender_of_v<sender_3,
+            hpx::execution::experimental::env_of_t<receiver_2<std::string>>,
+            std::string>,
+        "sender_3 is not a sender of env_of_t<receiver_2<std::string>> and "
+        "value types std::string");
 
     {
         receiver r1;

--- a/libs/core/execution_base/tests/unit/basic_sender.cpp
+++ b/libs/core/execution_base/tests/unit/basic_sender.cpp
@@ -5,6 +5,7 @@
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <hpx/execution_base/completion_signatures.hpp>
+#include <hpx/execution_base/receiver.hpp>
 #include <hpx/execution_base/sender.hpp>
 #include <hpx/modules/functional.hpp>
 #include <hpx/modules/testing.hpp>
@@ -104,6 +105,23 @@ struct receiver
     int i = -1;
 };
 
+template <typename... T>
+struct receiver_2
+{
+    friend void tag_invoke(hpx::execution::experimental::set_error_t,
+        receiver_2&&, std::exception_ptr) noexcept
+    {
+    }
+    friend void tag_invoke(
+        hpx::execution::experimental::set_stopped_t, receiver_2&&) noexcept
+    {
+    }
+    friend void tag_invoke(
+        hpx::execution::experimental::set_value_t, receiver_2&&, T...)
+    {
+    }
+};
+
 struct sender_1
 {
     struct completion_signatures
@@ -196,6 +214,22 @@ struct sender_3
     }
 };
 
+template <bool val, typename T>
+struct sender_4
+{
+    struct completion_signatures
+    {
+        template <template <class...> class Tuple,
+            template <class...> class Variant>
+        using value_types = Variant<Tuple<T>>;
+
+        template <template <class...> class Variant>
+        using error_types = Variant<std::exception_ptr>;
+
+        static constexpr bool sends_stopped = val;
+    };
+};
+
 static std::size_t void_receiver_set_value_calls = 0;
 
 struct void_receiver
@@ -260,6 +294,8 @@ int main()
     static_assert(is_sender_v<sender_1>, "sender_1 is a sender");
     static_assert(is_sender_v<sender_2>, "sender_2 is a sender");
     static_assert(is_sender_v<sender_3>, "sender_3 is a sender");
+    static_assert(is_sender_v<sender_4<true, int>>, "sender_4 is a sender");
+    static_assert(is_sender_v<sender_4<false, int>>, "sender_4 is a sender");
 
     static_assert(
         is_sender_to_v<sender_1, receiver>, "sender_1 is a sender to receiver");
@@ -273,6 +309,87 @@ int main()
         "sender_2 is not a sender to non_sender_2");
     static_assert(!is_sender_to_v<sender_2, sender_2>,
         "sender_2 is not a sender to sender_2");
+
+    static_assert(
+        hpx::execution::experimental::is_receiver_of_v<receiver_2<int>,
+            hpx::execution::experimental::completion_signatures_of_t<
+                sender_4<true, int>,
+                hpx::execution::experimental::env_of_t<receiver_2<int>>>>,
+        "receiver_2<int> supports completion signatures of  "
+        "sender_4<true,int>");
+    static_assert(hpx::execution::experimental::is_receiver_of_v<receiver,
+                      hpx::execution::experimental::completion_signatures_of_t<
+                          sender_4<true, int>,
+                          hpx::execution::experimental::env_of_t<receiver>>>,
+        "receiver supports completion signatures of sender_4<true,int>");
+    static_assert(
+        !hpx::execution::experimental::is_receiver_of_v<receiver_2<std::string>,
+            hpx::execution::experimental::completion_signatures_of_t<
+                sender_4<true, int>,
+                hpx::execution::experimental::env_of_t<
+                    receiver_2<std::string>>>>,
+        "receiver_2<int>  does not support completion signatures of "
+        "sender_4<true,std::string>");
+    static_assert(
+        !hpx::execution::experimental::is_receiver_of_v<receiver_2<int>,
+            hpx::execution::experimental::completion_signatures_of_t<
+                sender_4<false, int>,
+                hpx::execution::experimental::env_of_t<receiver_2<int>>>>,
+        "receiver_2<int>  does not support completion signatures of "
+        "sender_4<false,int>");
+    static_assert(!hpx::execution::experimental::is_receiver_of_v<receiver,
+                      hpx::execution::experimental::completion_signatures_of_t<
+                          sender_4<false, int>,
+                          hpx::execution::experimental::env_of_t<receiver>>>,
+        "receiver does not support completion signatures of "
+        "sender_4<false,int>");
+    static_assert(
+        !hpx::execution::experimental::is_receiver_of_v<receiver,
+            hpx::execution::experimental::completion_signatures_of_t<sender_1,
+                hpx::execution::experimental::env_of_t<receiver>>>,
+        "receiver does not support completion signatures of sender_1");
+
+    static_assert(
+        hpx::execution::experimental::is_sender_of_v<sender_1, receiver>,
+        "sender_1 is a sender to receiver");
+    static_assert(
+        hpx::execution::experimental::is_sender_of_v<sender_2, receiver>,
+        "sender_2 is a sender to receiver");
+    static_assert(
+        hpx::execution::experimental::is_sender_of_v<sender_3, receiver>,
+        "sender_3 is a sender to receiver");
+    static_assert(
+        hpx::execution::experimental::is_sender_of_v<sender_4<true, int>,
+            receiver>,
+        "sender_4<true,int> is a sender to receiver");
+    static_assert(
+        hpx::execution::experimental::is_sender_of_v<sender_4<false, int>,
+            receiver>,
+        "sender_4<false,int> is a sender to receiver");
+    static_assert(
+        hpx::execution::experimental::is_sender_of_v<sender_1, receiver_2<int>>,
+        "sender_1 is a sender to receiver_2<int>");
+    static_assert(
+        hpx::execution::experimental::is_sender_of_v<sender_2, receiver_2<int>>,
+        "sender_2 is a sender to receiver_2<int>");
+    static_assert(
+        hpx::execution::experimental::is_sender_of_v<sender_3, receiver_2<int>>,
+        "sender_3 is a sender to receiver_2<int>");
+    static_assert(hpx::execution::experimental::is_sender_of_v<
+                      sender_4<true, std::string>, receiver_2<std::string>>,
+        "sender_4<true,std::string> is a sender to receiver_2<std::string>");
+    static_assert(hpx::execution::experimental::is_sender_of_v<
+                      sender_4<true, std::string>, receiver_2<std::string>>,
+        "sender_4<false,std::string> is a sender to receiver_2<std::string>");
+    static_assert(!hpx::execution::experimental::is_sender_of_v<sender_1,
+                      receiver_2<std::string>>,
+        "sender_1 is not a sender to receiver_2<std::string>");
+    static_assert(!hpx::execution::experimental::is_sender_of_v<sender_2,
+                      receiver_2<std::string>>,
+        "sender_2 is not a sender to receiver_2<std::string>");
+    static_assert(!hpx::execution::experimental::is_sender_of_v<sender_3,
+                      receiver_2<std::string>>,
+        "sender_3 is not a sender to receiver_2<std::string>");
 
     {
         receiver r1;


### PR DESCRIPTION
Signed-off-by: Shreyas Atre <shreyasatre16@gmail.com>

## Proposed Changes

  - The `receiver_of` concept takes a receiver and an instance of the `completion_signatures<>` class template.
  - The `sender_of` concept defines the requirements for a sender type that on successful completion sends the specified set of value types.

## Checklist

- [x] receiver_of tests
- [x] sender_of tests
