### PR TITLE
Fix doxygen warnings when building documentation

### DIFF
--- a/libs/core/algorithms/include/hpx/parallel/algorithms/for_loop_induction.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/for_loop_induction.hpp
@@ -232,7 +232,7 @@ namespace hpx::experimental {
 }    // namespace hpx::experimental
 
 namespace hpx::parallel { inline namespace v2 {
-
+    /// \cond NOINTERNAL
     template <typename T>
     HPX_DEPRECATED_V(1, 8,
         "hpx::hpx::parallel::induction is deprecated. Please use "
@@ -250,4 +250,5 @@ namespace hpx::parallel { inline namespace v2 {
     {
         return hpx::experimental::induction(HPX_FORWARD(T, value));
     }
+    /// \endcond
 }}    // namespace hpx::parallel::v2

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/for_loop_reduction.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/for_loop_reduction.hpp
@@ -256,7 +256,7 @@ namespace hpx::experimental {
 }    // namespace hpx::experimental
 
 namespace hpx::parallel { inline namespace v2 {
-
+    /// \cond NOINTERNAL
     template <typename T, typename Op>
     HPX_DEPRECATED_V(1, 8,
         "hpx::hpx::parallel::reduction is deprecated. Please use "
@@ -392,4 +392,5 @@ namespace hpx::parallel { inline namespace v2 {
     {
         return hpx::experimental::reduction_max(var, identity);
     }
+    /// \endcond
 }}    // namespace hpx::parallel::v2

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/uninitialized_default_construct.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/uninitialized_default_construct.hpp
@@ -11,8 +11,8 @@
 #if defined(DOXYGEN)
 namespace hpx {
 
-    /// Constructs objects of type typename iterator_traits<ForwardIt>
-    /// ::value_type in the uninitialized storage designated by the range
+    /// Constructs objects of type typename iterator_traits<ForwardIt> 
+    /// in the uninitialized storage designated by the range
     /// by default-initialization. If an exception is thrown during the
     /// initialization, the function has no effects.
     ///
@@ -38,7 +38,7 @@ namespace hpx {
     void uninitialized_default_construct(FwdIter first, FwdIter last);
 
     /// Constructs objects of type typename iterator_traits<ForwardIt>
-    /// ::value_type in the uninitialized storage designated by the range
+    /// in the uninitialized storage designated by the range
     /// by default-initialization. If an exception is thrown during the
     /// initialization, the function has no effects.
     ///
@@ -81,7 +81,7 @@ namespace hpx {
         ExPolicy&& policy, FwdIter first, FwdIter last);
 
     /// Constructs objects of type typename iterator_traits<ForwardIt>
-    /// ::value_type in the uninitialized storage designated by the range
+    /// in the uninitialized storage designated by the range
     /// [first, first + count) by default-initialization. If an exception
     /// is thrown during the initialization, the function has no effects.
     ///
@@ -113,7 +113,7 @@ namespace hpx {
     FwdIter uninitialized_default_construct_n(FwdIter first, Size count);
 
     /// Constructs objects of type typename iterator_traits<ForwardIt>
-    /// ::value_type in the uninitialized storage designated by the range
+    /// in the uninitialized storage designated by the range
     /// [first, first + count) by default-initialization. If an exception
     /// is thrown during the initialization, the function has no effects.
     ///

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/uninitialized_value_construct.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/uninitialized_value_construct.hpp
@@ -13,7 +13,7 @@ namespace hpx {
     // clang-format off
 
     /// Constructs objects of type typename iterator_traits<ForwardIt>
-    /// ::value_type in the uninitialized storage designated by the range
+    /// in the uninitialized storage designated by the range
     /// by value-initialization. If an exception is thrown during the
     /// initialization, the function has no effects.
     ///
@@ -39,7 +39,7 @@ namespace hpx {
     void uninitialized_value_construct(FwdIter first, FwdIter last);
 
     /// Constructs objects of type typename iterator_traits<ForwardIt>
-    /// ::value_type in the uninitialized storage designated by the range
+    /// in the uninitialized storage designated by the range
     /// by value-initialization. If an exception is thrown during the
     /// initialization, the function has no effects.
     ///
@@ -82,7 +82,7 @@ namespace hpx {
         ExPolicy&& policy, FwdIter first, FwdIter last);
 
     /// Constructs objects of type typename iterator_traits<ForwardIt>
-    /// ::value_type in the uninitialized storage designated by the range
+    /// in the uninitialized storage designated by the range
     /// [first, first + count) by value-initialization. If an exception
     /// is thrown during the initialization, the function has no effects.
     ///
@@ -114,7 +114,7 @@ namespace hpx {
     FwdIter uninitialized_value_construct_n(FwdIter first, Size count);
 
     /// Constructs objects of type typename iterator_traits<ForwardIt>
-    /// ::value_type in the uninitialized storage designated by the range
+    /// in the uninitialized storage designated by the range
     /// [first, first + count) by value-initialization. If an exception
     /// is thrown during the initialization, the function has no effects.
     ///

--- a/libs/core/algorithms/include/hpx/parallel/container_algorithms/replace.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/container_algorithms/replace.hpp
@@ -585,7 +585,7 @@ namespace hpx { namespace ranges {
     ///
     /// \returns  The \a replace_copy algorithm returns an
     ///           \a in_out_result<typename hpx::traits::range_iterator<
-    ///             Rng>::type, OutIter>.
+    ///             Rng>, OutIter>.
     ///           The \a copy algorithm returns the pair of the input iterator
     ///           \a last and the output iterator to the
     ///           element in the destination range, one past the last element

--- a/libs/core/algorithms/include/hpx/parallel/container_algorithms/reverse.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/container_algorithms/reverse.hpp
@@ -232,7 +232,7 @@ namespace hpx { namespace ranges {
     ///
     /// \returns  The \a reverse_copy algorithm returns a
     ///           \a ranges::reverse_copy_result<
-    ///           typename hpx::traits::range_iterator<Rng>::type, OutIter>>::type.
+    ///           typename hpx::traits::range_iterator<Rng>::type, OutIter>.
     ///           The \a reverse_copy algorithm returns
     ///           an object equal to {last, result + N} where N = last - first
     ///

--- a/libs/core/algorithms/include/hpx/parallel/container_algorithms/uninitialized_copy.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/container_algorithms/uninitialized_copy.hpp
@@ -136,9 +136,8 @@ namespace hpx { namespace ranges {
     /// the calling thread.
     ///
     /// \returns  The \a uninitialized_copy algorithm returns an
-    ///           \a in_out_result<typename hpx::traits::range_traits<Rng1>
-    ///           ::iterator_type, typename hpx::traits::range_traits<Rng2>
-    ///           ::iterator_type>.
+    ///           \a in_out_result<typename hpx::traits::range_traits<Rng1>, 
+    ///           typename hpx::traits::range_traits<Rng2>>.
     ///           The \a uninitialized_copy algorithm returns an input iterator
     ///           to one past the last element copied from and the output
     ///           iterator to the element in the destination range, one past

--- a/libs/core/algorithms/include/hpx/parallel/container_algorithms/uninitialized_default_construct.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/container_algorithms/uninitialized_default_construct.hpp
@@ -15,7 +15,7 @@ namespace hpx { namespace ranges {
     // clang-format off
 
     /// Constructs objects of type typename iterator_traits<ForwardIt>
-    /// ::value_type in the uninitialized storage designated by the range
+    /// in the uninitialized storage designated by the range
     /// by default-initialization. If an exception is thrown during the
     /// initialization, the function has no effects.
     ///
@@ -47,7 +47,7 @@ namespace hpx { namespace ranges {
         FwdIter first, Sent last);
 
     /// Constructs objects of type typename iterator_traits<ForwardIt>
-    /// ::value_type in the uninitialized storage designated by the range
+    /// in the uninitialized storage designated by the range
     /// by default-initialization. If an exception is thrown during the
     /// initialization, the function has no effects.
     ///
@@ -95,7 +95,7 @@ namespace hpx { namespace ranges {
         ExPolicy&& policy, FwdIter first, Sent last);
 
     /// Constructs objects of type typename iterator_traits<ForwardIt>
-    /// ::value_type in the uninitialized storage designated by the range
+    /// in the uninitialized storage designated by the range
     /// by default-initialization. If an exception is thrown during the
     /// initialization, the function has no effects.
     ///
@@ -113,8 +113,7 @@ namespace hpx { namespace ranges {
     /// sequential order in the calling thread.
     ///
     /// \returns  The \a uninitialized_default_construct algorithm returns a
-    ///           returns \a hpx::traits::range_traits<Rng>
-    ///           ::iterator_type.
+    ///           returns \a hpx::traits::range_traits<Rng>.
     ///           The \a uninitialized_default_construct algorithm returns
     ///           the output iterator to the element in the range, one past
     ///           the last element constructed.
@@ -124,7 +123,7 @@ namespace hpx { namespace ranges {
     uninitialized_default_construct(Rng&& rng);
 
     /// Constructs objects of type typename iterator_traits<ForwardIt>
-    /// ::value_type in the uninitialized storage designated by the range
+    /// in the uninitialized storage designated by the range
     /// by default-initialization. If an exception is thrown during the
     /// initialization, the function has no effects.
     ///
@@ -154,9 +153,8 @@ namespace hpx { namespace ranges {
     /// sequenced within each thread.
     ///
     /// \returns  The \a uninitialized_default_construct algorithm returns a
-    ///           \a hpx::future<typename hpx::traits::range_traits<Rng>
-    ///           ::iterator_type>, if the
-    ///           execution policy is of type \a sequenced_task_policy
+    ///           \a hpx::future<typename hpx::traits::range_traits<Rng>>,
+    ///           if the execution policy is of type \a sequenced_task_policy
     ///           or \a parallel_task_policy and returns \a typename
     ///           hpx::traits::range_traits<Rng>::iterator_type otherwise.
     ///           The \a uninitialized_default_construct algorithm returns
@@ -169,7 +167,7 @@ namespace hpx { namespace ranges {
     uninitialized_default_construct(ExPolicy&& policy, Rng&& rng);
 
     /// Constructs objects of type typename iterator_traits<ForwardIt>
-    /// ::value_type in the uninitialized storage designated by the range
+    /// in the uninitialized storage designated by the range
     /// [first, first + count) by default-initialization. If an exception
     /// is thrown during the initialization, the function has no effects.
     ///
@@ -201,7 +199,7 @@ namespace hpx { namespace ranges {
     FwdIter uninitialized_default_construct_n(FwdIter first, Size count);
 
     /// Constructs objects of type typename iterator_traits<ForwardIt>
-    /// ::value_type in the uninitialized storage designated by the range
+    /// in the uninitialized storage designated by the range
     /// [first, first + count) by default-initialization. If an exception
     /// is thrown during the initialization, the function has no effects.
     ///

--- a/libs/core/algorithms/include/hpx/parallel/container_algorithms/uninitialized_fill.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/container_algorithms/uninitialized_fill.hpp
@@ -111,8 +111,7 @@ namespace hpx { namespace ranges {
     /// the calling thread.
     ///
     /// \returns  The \a uninitialized_fill algorithm returns a
-    ///           returns \a hpx::traits::range_traits<Rng>
-    ///           ::iterator_type.
+    ///           returns \a hpx::traits::range_traits<Rng>.
     ///           The \a uninitialized_fill algorithm returns the output
     ///           iterator to the element in the range, one past
     ///           the last element copied.
@@ -153,9 +152,8 @@ namespace hpx { namespace ranges {
     /// within each thread.
     ///
     /// \returns  The \a uninitialized_fill algorithm returns a
-    ///           \a hpx::future<typename hpx::traits::range_traits<Rng>
-    ///           ::iterator_type>, if the
-    ///           execution policy is of type \a sequenced_task_policy
+    ///           \a hpx::future<typename hpx::traits::range_traits<Rng>>,
+    ///           if the execution policy is of type \a sequenced_task_policy
     ///           or \a parallel_task_policy and returns \a typename
     ///           hpx::traits::range_traits<Rng>::iterator_type otherwise.
     ///           The \a uninitialized_fill algorithm returns the

--- a/libs/core/algorithms/include/hpx/parallel/container_algorithms/uninitialized_move.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/container_algorithms/uninitialized_move.hpp
@@ -139,9 +139,8 @@ namespace hpx { namespace ranges {
     /// the calling thread.
     ///
     /// \returns  The \a uninitialized_move algorithm returns an
-    ///           \a in_out_result<typename hpx::traits::range_traits<Rng1>
-    ///           ::iterator_type, typename hpx::traits::range_traits<Rng2>
-    ///           ::iterator_type>.
+    ///           \a in_out_result<typename hpx::traits::range_traits<Rng1>,
+    ///           typename hpx::traits::range_traits<Rng2>.
     ///           The \a uninitialized_move algorithm returns an input iterator
     ///           to one past the last element moved from and the output
     ///           iterator to the element in the destination range, one past

--- a/libs/core/algorithms/include/hpx/parallel/container_algorithms/uninitialized_value_construct.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/container_algorithms/uninitialized_value_construct.hpp
@@ -15,7 +15,7 @@ namespace hpx { namespace ranges {
     // clang-format off
 
     /// Constructs objects of type typename iterator_traits<ForwardIt>
-    /// ::value_type in the uninitialized storage designated by the range
+    /// in the uninitialized storage designated by the range
     /// by value-initialization. If an exception is thrown during the
     /// initialization, the function has no effects.
     ///
@@ -47,7 +47,7 @@ namespace hpx { namespace ranges {
         FwdIter first, Sent last);
 
     /// Constructs objects of type typename iterator_traits<ForwardIt>
-    /// ::value_type in the uninitialized storage designated by the range
+    /// in the uninitialized storage designated by the range
     /// by value-initialization. If an exception is thrown during the
     /// initialization, the function has no effects.
     ///
@@ -95,7 +95,7 @@ namespace hpx { namespace ranges {
         ExPolicy&& policy, FwdIter first, Sent last);
 
     /// Constructs objects of type typename iterator_traits<ForwardIt>
-    /// ::value_type in the uninitialized storage designated by the range
+    /// in the uninitialized storage designated by the range
     /// by value-initialization. If an exception is thrown during the
     /// initialization, the function has no effects.
     ///
@@ -113,8 +113,7 @@ namespace hpx { namespace ranges {
     /// sequential order in the calling thread.
     ///
     /// \returns  The \a uninitialized_value_construct algorithm returns a
-    ///           returns \a hpx::traits::range_traits<Rng>
-    ///           ::iterator_type.
+    ///           returns \a hpx::traits::range_traits<Rng>.
     ///           The \a uninitialized_value_construct algorithm returns
     ///           the output iterator to the element in the range, one past
     ///           the last element constructed.
@@ -124,7 +123,7 @@ namespace hpx { namespace ranges {
     uninitialized_value_construct(Rng&& rng);
 
     /// Constructs objects of type typename iterator_traits<ForwardIt>
-    /// ::value_type in the uninitialized storage designated by the range
+    /// in the uninitialized storage designated by the range
     /// by value-initialization. If an exception is thrown during the
     /// initialization, the function has no effects.
     ///
@@ -154,9 +153,8 @@ namespace hpx { namespace ranges {
     /// sequenced within each thread.
     ///
     /// \returns  The \a uninitialized_value_construct algorithm returns a
-    ///           \a hpx::future<typename hpx::traits::range_traits<Rng>
-    ///           ::iterator_type>, if the
-    ///           execution policy is of type \a sequenced_task_policy
+    ///           \a hpx::future<typename hpx::traits::range_traits<Rng>>,
+    ///           if the execution policy is of type \a sequenced_task_policy
     ///           or \a parallel_task_policy and returns \a typename
     ///           hpx::traits::range_traits<Rng>::iterator_type otherwise.
     ///           The \a uninitialized_value_construct algorithm returns
@@ -169,7 +167,7 @@ namespace hpx { namespace ranges {
     uninitialized_value_construct(ExPolicy&& policy, Rng&& rng);
 
     /// Constructs objects of type typename iterator_traits<ForwardIt>
-    /// ::value_type in the uninitialized storage designated by the range
+    /// in the uninitialized storage designated by the range
     /// [first, first + count) by value-initialization. If an exception
     /// is thrown during the initialization, the function has no effects.
     ///
@@ -201,7 +199,7 @@ namespace hpx { namespace ranges {
     FwdIter uninitialized_value_construct_n(FwdIter first, Size count);
 
     /// Constructs objects of type typename iterator_traits<ForwardIt>
-    /// ::value_type in the uninitialized storage designated by the range
+    /// in the uninitialized storage designated by the range
     /// [first, first + count) by value-initialization. If an exception
     /// is thrown during the initialization, the function has no effects.
     ///

--- a/libs/core/synchronization/include/hpx/synchronization/barrier.hpp
+++ b/libs/core/synchronization/include/hpx/synchronization/barrier.hpp
@@ -123,7 +123,7 @@ namespace hpx {
         ///                 expected is 0 this object can only be destroyed.-
         ///                 end note]
         ///
-        /// \throws:        Any exception thrown by CompletionFunction's move
+        /// \throws         Any exception thrown by CompletionFunction's move
         ///                 constructor.
         constexpr explicit barrier(
             std::ptrdiff_t expected, OnCompletion completion = OnCompletion())
@@ -175,7 +175,7 @@ namespace hpx {
         ///
         /// \returns:       The constructed arrival_token object.
         ///
-        /// \throws:        system_error when an exception is required
+        /// \throws         system_error when an exception is required
         ///                 ([thread.req.exception]).
         ///
         /// Error conditions: Any of the error conditions allowed for mutex
@@ -199,7 +199,7 @@ namespace hpx {
         ///                 point for a previous phase, the call returns
         ///                 immediately. - end note ]
         ///
-        /// \throws:        system_error when an exception is required
+        /// \throws         system_error when an exception is required
         ///                 ([thread.req.exception]).
         /// Error conditions: Any of the error conditions allowed for mutex
         ///                 types ([thread.mutex.requirements.mutex]).
@@ -236,7 +236,7 @@ namespace hpx {
         ///                 the start of the phase completion step for the
         ///                 current phase.
         ///
-        /// \throws:        system_error when an exception is required
+        /// \throws         system_error when an exception is required
         ///                 ([thread.req.exception]).Error conditions:
         ///                 Any of the error conditions allowed for mutex
         ///                 types ([thread.mutex.requirements.mutex]).

--- a/libs/full/collectives/include/hpx/collectives/all_gather.hpp
+++ b/libs/full/collectives/include/hpx/collectives/all_gather.hpp
@@ -18,7 +18,7 @@ namespace hpx { namespace collectives {
     /// the given base name.
     ///
     /// \param  basename    The base name identifying the all_gather operation
-    /// \param  local_result The value to transmit to all
+    /// \param  result      The value to transmit to all
     ///                     participating sites from this call site.
     /// \param  num_sites   The number of participating sites (default: all
     ///                     localities).
@@ -30,7 +30,7 @@ namespace hpx { namespace collectives {
     /// \param this_site    The sequence number of this invocation (usually
     ///                     the locality id). This value is optional and
     ///                     defaults to whatever hpx::get_locality_id() returns.
-    /// \params root_site   The site that is responsible for creating the
+    /// \param root_site   The site that is responsible for creating the
     ///                     all_gather support object. This value is optional
     ///                     and defaults to '0' (zero).
     ///
@@ -52,9 +52,9 @@ namespace hpx { namespace collectives {
     /// the given base name.
     ///
     /// \param  comm        A communicator object returned from \a create_communicator
-    /// \param  local_result The value to transmit to all
+    /// \param  result      The value to transmit to all
     ///                     participating sites from this call site.
-    /// \param this_site    The sequence number of this invocation (usually
+    /// \param  this_site   The sequence number of this invocation (usually
     ///                     the locality id). This value is optional and
     ///                     defaults to whatever hpx::get_locality_id() returns.
     ///

--- a/libs/full/collectives/include/hpx/collectives/all_reduce.hpp
+++ b/libs/full/collectives/include/hpx/collectives/all_reduce.hpp
@@ -18,7 +18,7 @@ namespace hpx { namespace collectives {
     /// the given base name.
     ///
     /// \param  basename    The base name identifying the all_reduce operation
-    /// \param  local_result The value to transmit to all
+    /// \param  result      The value to transmit to all
     ///                     participating sites from this call site.
     /// \param  op          Reduction operation to apply to all values supplied
     ///                     from all participating sites
@@ -32,7 +32,7 @@ namespace hpx { namespace collectives {
     /// \param this_site    The sequence number of this invocation (usually
     ///                     the locality id). This value is optional and
     ///                     defaults to whatever hpx::get_locality_id() returns.
-    /// \params root_site   The site that is responsible for creating the
+    /// \param root_site    The site that is responsible for creating the
     ///                     all_reduce support object. This value is optional
     ///                     and defaults to '0' (zero).
     ///
@@ -53,11 +53,11 @@ namespace hpx { namespace collectives {
     /// the given base name.
     ///
     /// \param  comm        A communicator object returned from \a create_communicator
-    /// \param  local_result The value to transmit to all
+    /// \param  result      The value to transmit to all
     ///                     participating sites from this call site.
     /// \param  op          Reduction operation to apply to all values supplied
     ///                     from all participating sites
-    /// \param this_site    The sequence number of this invocation (usually
+    /// \param  this_site   The sequence number of this invocation (usually
     ///                     the locality id). This value is optional and
     ///                     defaults to whatever hpx::get_locality_id() returns.
     ///

--- a/libs/full/collectives/include/hpx/collectives/all_to_all.hpp
+++ b/libs/full/collectives/include/hpx/collectives/all_to_all.hpp
@@ -18,7 +18,7 @@ namespace hpx { namespace collectives {
     /// the given base name.
     ///
     /// \param  basename    The base name identifying the all_to_all operation
-    /// \param  local_result The value to transmit to all
+    /// \param  result      The value to transmit to all
     ///                     participating sites from this call site.
     /// \param  num_sites   The number of participating sites (default: all
     ///                     localities).
@@ -30,7 +30,7 @@ namespace hpx { namespace collectives {
     /// \param this_site    The sequence number of this invocation (usually
     ///                     the locality id). This value is optional and
     ///                     defaults to whatever hpx::get_locality_id() returns.
-    /// \params root_site   The site that is responsible for creating the
+    /// \param root_site    The site that is responsible for creating the
     ///                     all_to_all support object. This value is optional
     ///                     and defaults to '0' (zero).
     ///
@@ -52,9 +52,9 @@ namespace hpx { namespace collectives {
     /// the given base name.
     ///
     /// \param  comm        A communicator object returned from \a create_communicator
-    /// \param  local_result The value to transmit to all
+    /// \param  result      The value to transmit to all
     ///                     participating sites from this call site.
-    /// \param this_site    The sequence number of this invocation (usually
+    /// \param  this_site   The sequence number of this invocation (usually
     ///                     the locality id). This value is optional and
     ///                     defaults to whatever hpx::get_locality_id() returns.
     ///

--- a/libs/full/collectives/include/hpx/collectives/create_communicator.hpp
+++ b/libs/full/collectives/include/hpx/collectives/create_communicator.hpp
@@ -32,7 +32,7 @@ namespace hpx { namespace collectives {
     /// \param this_site    The sequence number of this invocation (usually
     ///                     the locality id). This value is optional and
     ///                     defaults to whatever hpx::get_locality_id() returns.
-    /// \params root_site   The site that is responsible for creating the
+    /// \param root_site    The site that is responsible for creating the
     ///                     collective support object. This value is optional
     ///                     and defaults to '0' (zero).
     ///

--- a/libs/full/collectives/include/hpx/collectives/exclusive_scan.hpp
+++ b/libs/full/collectives/include/hpx/collectives/exclusive_scan.hpp
@@ -18,7 +18,7 @@ namespace hpx { namespace collectives {
     /// received from all call sites operating on the given base name.
     ///
     /// \param  basename    The base name identifying the exclusive_scan operation
-    /// \param  local_result The value to transmit to all
+    /// \param  result      The value to transmit to all
     ///                     participating sites from this call site.
     /// \param  op          Reduction operation to apply to all values supplied
     ///                     from all participating sites
@@ -32,7 +32,7 @@ namespace hpx { namespace collectives {
     /// \param this_site    The sequence number of this invocation (usually
     ///                     the locality id). This value is optional and
     ///                     defaults to whatever hpx::get_locality_id() returns.
-    /// \params root_site   The site that is responsible for creating the
+    /// \param root_site    The site that is responsible for creating the
     ///                     exclusive_scan support object. This value is optional
     ///                     and defaults to '0' (zero).
     ///
@@ -57,11 +57,11 @@ namespace hpx { namespace collectives {
     /// received from all call sites operating on the given base name.
     ///
     /// \param  comm        A communicator object returned from \a create_communicator
-    /// \param  local_result The value to transmit to all
+    /// \param  result      The value to transmit to all
     ///                     participating sites from this call site.
     /// \param  op          Reduction operation to apply to all values supplied
     ///                     from all participating sites
-    /// \param this_site    The sequence number of this invocation (usually
+    /// \param  this_site   The sequence number of this invocation (usually
     ///                     the locality id). This value is optional and
     ///                     defaults to whatever hpx::get_locality_id() returns.
     ///

--- a/libs/full/collectives/include/hpx/collectives/inclusive_scan.hpp
+++ b/libs/full/collectives/include/hpx/collectives/inclusive_scan.hpp
@@ -18,7 +18,7 @@ namespace hpx { namespace collectives {
     /// received from all call sites operating on the given base name.
     ///
     /// \param  basename    The base name identifying the inclusive_scan operation
-    /// \param  local_result The value to transmit to all
+    /// \param  result      The value to transmit to all
     ///                     participating sites from this call site.
     /// \param  op          Reduction operation to apply to all values supplied
     ///                     from all participating sites
@@ -32,7 +32,7 @@ namespace hpx { namespace collectives {
     /// \param this_site    The sequence number of this invocation (usually
     ///                     the locality id). This value is optional and
     ///                     defaults to whatever hpx::get_locality_id() returns.
-    /// \params root_site   The site that is responsible for creating the
+    /// \param root_site    The site that is responsible for creating the
     ///                     inclusive_scan support object. This value is optional
     ///                     and defaults to '0' (zero).
     ///
@@ -53,11 +53,11 @@ namespace hpx { namespace collectives {
     /// received from all call sites operating on the given base name.
     ///
     /// \param  comm        A communicator object returned from \a create_communicator
-    /// \param  local_result The value to transmit to all
+    /// \param  result      The value to transmit to all
     ///                     participating sites from this call site.
     /// \param  op          Reduction operation to apply to all values supplied
     ///                     from all participating sites
-    /// \param this_site    The sequence number of this invocation (usually
+    /// \param  this_site   The sequence number of this invocation (usually
     ///                     the locality id). This value is optional and
     ///                     defaults to whatever hpx::get_locality_id() returns.
     ///

--- a/libs/full/collectives/include/hpx/collectives/reduce.hpp
+++ b/libs/full/collectives/include/hpx/collectives/reduce.hpp
@@ -18,7 +18,7 @@ namespace hpx { namespace collectives {
     /// the given base name.
     ///
     /// \param  basename    The base name identifying the all_reduce operation
-    /// \param  local_result A value to reduce on the central reduction point
+    /// \param  result      A value to reduce on the central reduction point
     ///                     from this call site.
     /// \param  op          Reduction operation to apply to all values supplied
     ///                     from all participating sites
@@ -53,7 +53,7 @@ namespace hpx { namespace collectives {
     /// \param  local_result A value to reduce on the root_site from this call site.
     /// \param  op          Reduction operation to apply to all values supplied
     ///                     from all participating sites
-    /// \param this_site    The sequence number of this invocation (usually
+    /// \param  this_site   The sequence number of this invocation (usually
     ///                     the locality id). This value is optional and
     ///                     defaults to whatever hpx::get_locality_id() returns.
     ///
@@ -78,10 +78,10 @@ namespace hpx { namespace collectives {
     ///                     given base name. This is optional and needs to be
     ///                     supplied only if the reduction operation on the given
     ///                     base name has to be performed more than once.
-    /// \param this_site    The sequence number of this invocation (usually
+    /// \param  this_site   The sequence number of this invocation (usually
     ///                     the locality id). This value is optional and
     ///                     defaults to whatever hpx::get_locality_id() returns.
-    /// \param root_site    The sequence number of the central reduction point
+    /// \param  root_site   The sequence number of the central reduction point
     ///                     (usually the locality id). This value is optional
     ///                     and defaults to 0.
     ///

--- a/libs/full/collectives/include/hpx/collectives/scatter.hpp
+++ b/libs/full/collectives/include/hpx/collectives/scatter.hpp
@@ -23,10 +23,10 @@ namespace hpx { namespace collectives {
     ///                     given base name. This is optional and needs to be
     ///                     supplied only if the scatter operation on the given
     ///                     base name has to be performed more than once.
-    /// \param this_site    The sequence number of this invocation (usually
+    /// \param  this_site   The sequence number of this invocation (usually
     ///                     the locality id). This value is optional and
     ///                     defaults to whatever hpx::get_locality_id() returns.
-    /// \param root_site    The sequence number of the central scatter point
+    /// \param  root_site   The sequence number of the central scatter point
     ///                     (usually the locality id). This value is optional
     ///                     and defaults to 0.
     ///
@@ -46,7 +46,7 @@ namespace hpx { namespace collectives {
     /// the given base name.
     ///
     /// \param  comm        A communicator object returned from \a create_communicator
-    /// \param this_site    The sequence number of this invocation (usually
+    /// \param  this_site   The sequence number of this invocation (usually
     ///                     the locality id). This value is optional and
     ///                     defaults to whatever hpx::get_locality_id() returns.
     ///
@@ -73,7 +73,7 @@ namespace hpx { namespace collectives {
     ///                     given base name. This is optional and needs to be
     ///                     supplied only if the scatter operation on the given
     ///                     base name has to be performed more than once.
-    /// \param this_site    The sequence number of this invocation (usually
+    /// \param  this_site   The sequence number of this invocation (usually
     ///                     the locality id). This value is optional and
     ///                     defaults to whatever hpx::get_locality_id() returns.
     ///
@@ -94,9 +94,9 @@ namespace hpx { namespace collectives {
     /// site (where the corresponding \a scatter_from is executed)
     ///
     /// \param  comm        A communicator object returned from \a create_communicator
-    /// \param  num_sites   The number of participating sites (default: all
-    ///                     localities).
-    /// \param this_site    The sequence number of this invocation (usually
+    /// \param  result      The value to transmit to the central scatter point
+    ///                     from this call site.
+    /// \param  this_site   The sequence number of this invocation (usually
     ///                     the locality id). This value is optional and
     ///                     defaults to whatever hpx::get_locality_id() returns.
     ///

--- a/libs/full/performance_counters/include/hpx/performance_counters/counters.hpp
+++ b/libs/full/performance_counters/include/hpx/performance_counters/counters.hpp
@@ -242,8 +242,8 @@ namespace hpx { namespace performance_counters {
     /// instance. Generally, a full name of a counter instance has the
     /// structure:
     ///
-    ///    /objectname{parentinstancename#parentindex/instancename#instanceindex}
-    ///      /countername#parameters
+    ///    /objectname{parentinstancename#parentindex/instancename}
+    ///      /countername
     ///
     /// i.e.
     ///    /queue{localityprefix/thread#2}/length


### PR DESCRIPTION
Fix warnings including missing arguments, deprecations, link requests etc.
