### PR TITLE
Remove mimalloc version constraint

### DIFF
--- a/cmake/HPX_SetupAllocator.cmake
+++ b/cmake/HPX_SetupAllocator.cmake
@@ -78,7 +78,7 @@ if(NOT TARGET hpx_dependencies_allocator)
     # ##########################################################################
     # MIMALLOC
     if("${HPX_WITH_MALLOC_UPPER}" STREQUAL "MIMALLOC")
-      find_package(mimalloc 1.0)
+      find_package(mimalloc)
       if(NOT mimalloc_FOUND)
         hpx_error(${allocator_error})
       endif()


### PR DESCRIPTION
At least on linux there is no need to constrain the version since mimalloc is only being linked, no mimalloc APIs are used by HPX. I don't know if this works on Windows, but I assume it does.