### PR TITLE
Fixing serialization to work with buffers of unsigned chars

### DIFF
--- a/components/parcel_plugins/binary_filter/bzip2/include/hpx/binary_filter/bzip2_serialization_filter.hpp
+++ b/components/parcel_plugins/binary_filter/bzip2/include/hpx/binary_filter/bzip2_serialization_filter.hpp
@@ -80,13 +80,14 @@ namespace hpx::plugins::compression {
         {
         }
 
-        void load(void* dst, std::size_t dst_count);
-        void save(void const* src, std::size_t src_count);
-        bool flush(void* dst, std::size_t dst_count, std::size_t& written);
+        void load(void* dst, std::size_t dst_count) override;
+        void save(void const* src, std::size_t src_count) override;
+        bool flush(
+            void* dst, std::size_t dst_count, std::size_t& written) override;
 
-        void set_max_length(std::size_t size);
-        std::size_t init_data(
-            char const* buffer, std::size_t size, std::size_t buffer_size);
+        void set_max_length(std::size_t size) override;
+        std::size_t init_data(void const* buffer, std::size_t size,
+            std::size_t buffer_size) override;
 
     protected:
         std::size_t load_impl(void* dst, std::size_t dst_count, void const* src,
@@ -101,7 +102,7 @@ namespace hpx::plugins::compression {
         {
         }
 
-        HPX_SERIALIZATION_POLYMORPHIC(bzip2_serialization_filter);
+        HPX_SERIALIZATION_POLYMORPHIC(bzip2_serialization_filter, override);
 
         detail::bzip2_compdecomp compdecomp_;
         std::vector<char> buffer_;

--- a/components/parcel_plugins/binary_filter/bzip2/src/bzip2_serialization_filter.cpp
+++ b/components/parcel_plugins/binary_filter/bzip2/src/bzip2_serialization_filter.cpp
@@ -128,7 +128,7 @@ namespace hpx::plugins::compression {
     }
 
     std::size_t bzip2_serialization_filter::init_data(
-        char const* buffer, std::size_t size, std::size_t buffer_size)
+        void const* buffer, std::size_t size, std::size_t buffer_size)
     {
         buffer_.resize(buffer_size);
         std::size_t s = load_impl(buffer_.data(), buffer_size, buffer, size);

--- a/components/parcel_plugins/binary_filter/snappy/include/hpx/binary_filter/snappy_serialization_filter.hpp
+++ b/components/parcel_plugins/binary_filter/snappy/include/hpx/binary_filter/snappy_serialization_filter.hpp
@@ -31,13 +31,14 @@ namespace hpx::plugins::compression {
         {
         }
 
-        void load(void* dst, std::size_t dst_count);
-        void save(void const* src, std::size_t src_count);
-        bool flush(void* dst, std::size_t dst_count, std::size_t& written);
+        void load(void* dst, std::size_t dst_count) override;
+        void save(void const* src, std::size_t src_count) override;
+        bool flush(
+            void* dst, std::size_t dst_count, std::size_t& written) override;
 
-        void set_max_length(std::size_t size);
-        std::size_t init_data(
-            char const* buffer, std::size_t size, std::size_t buffer_size);
+        void set_max_length(std::size_t size) override;
+        std::size_t init_data(void const* buffer, std::size_t size,
+            std::size_t buffer_size) override;
 
     private:
         // serialization support
@@ -48,7 +49,7 @@ namespace hpx::plugins::compression {
         {
         }
 
-        HPX_SERIALIZATION_POLYMORPHIC(snappy_serialization_filter);
+        HPX_SERIALIZATION_POLYMORPHIC(snappy_serialization_filter, override);
 
         std::vector<char> buffer_;
         std::size_t current_;

--- a/components/parcel_plugins/binary_filter/snappy/src/snappy_serialization_filter.cpp
+++ b/components/parcel_plugins/binary_filter/snappy/src/snappy_serialization_filter.cpp
@@ -35,10 +35,11 @@ namespace hpx::plugins::compression {
 
     ///////////////////////////////////////////////////////////////////////////
     std::size_t snappy_serialization_filter::init_data(
-        char const* buffer, std::size_t size, std::size_t buffer_size)
+        void const* buffer, std::size_t size, std::size_t buffer_size)
     {
         buffer_.resize(buffer_size);
-        snappy::RawUncompress(buffer, size, buffer_.data());
+        snappy::RawUncompress(
+            static_cast<char const*>(buffer), size, buffer_.data());
         current_ = 0;
         return buffer_.size();
     }

--- a/components/parcel_plugins/binary_filter/zlib/include/hpx/binary_filter/zlib_serialization_filter.hpp
+++ b/components/parcel_plugins/binary_filter/zlib/include/hpx/binary_filter/zlib_serialization_filter.hpp
@@ -67,13 +67,13 @@ namespace hpx::plugins::compression {
         {
         }
 
-        void load(void* dst, std::size_t dst_count);
-        void save(void const* src, std::size_t src_count);
-        bool flush(void* dst, std::size_t dst_count, std::size_t& written);
+        void load(void* dst, std::size_t dst_count) override;
+        void save(void const* src, std::size_t src_count) override;
+        bool flush(void* dst, std::size_t dst_count, std::size_t& written) override;
 
-        void set_max_length(std::size_t size);
+        void set_max_length(std::size_t size) override;
         std::size_t init_data(
-            char const* buffer, std::size_t size, std::size_t buffer_size);
+            void const* buffer, std::size_t size, std::size_t buffer_size) override;
 
     protected:
         std::size_t load_impl(void* dst, std::size_t dst_count, void const* src,
@@ -88,7 +88,7 @@ namespace hpx::plugins::compression {
         {
         }
 
-        HPX_SERIALIZATION_POLYMORPHIC(zlib_serialization_filter);
+        HPX_SERIALIZATION_POLYMORPHIC(zlib_serialization_filter, override);
 
         detail::zlib_compdecomp compdecomp_;
         std::vector<char> buffer_;

--- a/components/parcel_plugins/binary_filter/zlib/src/zlib_serialization_filter.cpp
+++ b/components/parcel_plugins/binary_filter/zlib/src/zlib_serialization_filter.cpp
@@ -93,7 +93,7 @@ namespace hpx::plugins::compression {
     }
 
     std::size_t zlib_serialization_filter::init_data(
-        char const* buffer, std::size_t size, std::size_t buffer_size)
+        void const* buffer, std::size_t size, std::size_t buffer_size)
     {
         buffer_.resize(buffer_size);
         std::size_t s = load_impl(buffer_.data(), buffer_size, buffer, size);

--- a/libs/core/datastructures/include/hpx/datastructures/serialization/serializable_any.hpp
+++ b/libs/core/datastructures/include/hpx/datastructures/serialization/serializable_any.hpp
@@ -1,6 +1,6 @@
 /*=============================================================================
     Copyright (c) 2013 Shuangyang Yang
-    Copyright (c) 2007-2019 Hartmut Kaiser
+    Copyright (c) 2007-2022 Hartmut Kaiser
     Copyright (c) Christopher Diggins 2005
     Copyright (c) Pablo Aguilar 2005
     Copyright (c) Kevlin Henney 2001
@@ -89,18 +89,18 @@ namespace hpx { namespace util { namespace detail { namespace any {
             base_type::stream_out = Vtable::stream_out;
         }
 
-        virtual base_type* get_ptr()
+        virtual base_type* get_ptr() override
         {
             return Vtable::get_ptr();
         }
 
-        void save_object(void* const* object, OArch& ar, unsigned)
+        void save_object(void* const* object, OArch& ar, unsigned) override
         {
             // clang-format off
             ar & Vtable::get(object);
             // clang-format on
         }
-        void load_object(void** object, IArch& ar, unsigned)
+        void load_object(void** object, IArch& ar, unsigned) override
         {
             // clang-format off
             ar & Vtable::construct(object);
@@ -114,7 +114,7 @@ namespace hpx { namespace util { namespace detail { namespace any {
             ar & hpx::serialization::base_object<base_type>(*this);
             // clang-format on
         }
-        HPX_SERIALIZATION_POLYMORPHIC_TEMPLATE(fxn_ptr);
+        HPX_SERIALIZATION_POLYMORPHIC_TEMPLATE(fxn_ptr, override);
     };
 }}}}    // namespace hpx::util::detail::any
 
@@ -340,7 +340,9 @@ namespace hpx { namespace util {
         void load(IArch& ar, const unsigned version)
         {
             bool is_empty;
-            ar& is_empty;
+            // clang-format off
+            ar & is_empty;
+            // clang-format on
 
             if (is_empty)
             {
@@ -360,7 +362,10 @@ namespace hpx { namespace util {
         void save(OArch& ar, const unsigned version) const
         {
             bool is_empty = !has_value();
-            ar& is_empty;
+            // clang-format off
+            ar & is_empty;
+            // clang-format on
+
             if (!is_empty)
             {
                 ar << hpx::serialization::detail::raw_ptr(table);

--- a/libs/core/datastructures/src/serializable_any.cpp
+++ b/libs/core/datastructures/src/serializable_any.cpp
@@ -1,6 +1,6 @@
 /*=============================================================================
     Copyright (c) 2013 Shuangyang Yang
-    Copyright (c) 2007-2019 Hartmut Kaiser
+    Copyright (c) 2007-2022 Hartmut Kaiser
     Copyright (c) Christopher Diggins 2005
     Copyright (c) Pablo Aguilar 2005
     Copyright (c) Kevlin Henney 2001
@@ -31,38 +31,38 @@ namespace hpx { namespace util {
 
         struct hash_binary_filter : serialization::binary_filter
         {
-            explicit hash_binary_filter(std::size_t seed = 0)
+            explicit hash_binary_filter(std::size_t seed = 0) noexcept
               : hash(seed)
             {
             }
 
             // compression API
-            void set_max_length(std::size_t /* size */) {}
-            void save(void const* src, std::size_t src_count)
+            void set_max_length(std::size_t /* size */) override {}
+            void save(void const* src, std::size_t src_count) override
             {
                 char const* data = static_cast<char const*>(src);
                 boost::hash_range(hash, data, data + src_count);
             }
-            bool flush(
-                void* /* dst */, std::size_t dst_count, std::size_t& written)
+            bool flush(void* /* dst */, std::size_t dst_count,
+                std::size_t& written) override
             {
                 written = dst_count;
                 return true;
             }
 
             // decompression API
-            std::size_t init_data(char const* /* buffer */,
-                std::size_t /* size */, std::size_t /* buffer_size */)
+            std::size_t init_data(void const* /* buffer */,
+                std::size_t /* size */, std::size_t /* buffer_size */) override
             {
                 return 0;
             }
-            void load(void* /* dst */, std::size_t /* dst_count */) {}
+            void load(void* /* dst */, std::size_t /* dst_count */) override {}
 
             template <class T>
             void serialize(T&, unsigned)
             {
             }
-            HPX_SERIALIZATION_POLYMORPHIC(hash_binary_filter);
+            HPX_SERIALIZATION_POLYMORPHIC(hash_binary_filter, override);
 
             std::size_t hash;
         };

--- a/libs/core/memory/tests/unit/intrusive_ptr_polymorphic.cpp
+++ b/libs/core/memory/tests/unit/intrusive_ptr_polymorphic.cpp
@@ -68,7 +68,7 @@ struct E : D
     {
     }
 
-    const char* foo()
+    const char* foo() override
     {
         return "E::foo";
     }
@@ -86,7 +86,7 @@ struct E : D
         ar& b;
     }
     HPX_SERIALIZATION_SPLIT_MEMBER();
-    HPX_SERIALIZATION_POLYMORPHIC_SPLITTED(E);
+    HPX_SERIALIZATION_POLYMORPHIC_SPLITTED(E, override);
 };
 
 class F : public E
@@ -100,7 +100,7 @@ class F : public E
         ar& hpx::serialization::base_object<E>(*this);
         ar& c;
     }
-    HPX_SERIALIZATION_POLYMORPHIC(F)
+    HPX_SERIALIZATION_POLYMORPHIC(F, override)
 
 public:
     explicit F(int c = 3)
@@ -108,7 +108,7 @@ public:
     {
     }
 
-    const char* foo()
+    const char* foo() override
     {
         return "F::foo";
     }

--- a/libs/core/serialization/include/hpx/serialization/binary_filter.hpp
+++ b/libs/core/serialization/include/hpx/serialization/binary_filter.hpp
@@ -29,7 +29,7 @@ namespace hpx::serialization {
 
         // decompression API
         virtual std::size_t init_data(
-            char const* buffer, std::size_t size, std::size_t buffer_size) = 0;
+            void const* buffer, std::size_t size, std::size_t buffer_size) = 0;
         virtual void load(void* dst, std::size_t dst_count) = 0;
 
         template <typename T>

--- a/libs/core/serialization/include/hpx/serialization/input_archive.hpp
+++ b/libs/core/serialization/include/hpx/serialization/input_archive.hpp
@@ -146,12 +146,18 @@ namespace hpx::serialization {
 #if defined(HPX_SERIALIZATION_HAVE_SUPPORTS_ENDIANESS)
             else if constexpr (std::is_unsigned_v<T>)
             {
+                static_assert(sizeof(T) <= sizeof(std::uint64_t),
+                    "integral type is larger than supported");
+
                 std::uint64_t ul;
                 load_integral(ul);
                 t = static_cast<T>(ul);
             }
             else
             {
+                static_assert(sizeof(T) <= sizeof(std::int64_t),
+                    "integral type is larger than supported");
+
                 std::int64_t l;
                 load_integral(l);
                 t = static_cast<T>(l);
@@ -159,12 +165,18 @@ namespace hpx::serialization {
 #else
             else if constexpr (std::is_unsigned_v<T>)
             {
+                static_assert(sizeof(T) <= sizeof(std::uint64_t),
+                    "integral type is larger than supported");
+
                 std::uint64_t ul;
                 load_binary(&ul, sizeof(std::uint64_t));
                 t = static_cast<T>(ul);
             }
             else
             {
+                static_assert(sizeof(T) <= sizeof(std::int64_t),
+                    "integral type is larger than supported");
+
                 std::int64_t ul;
                 load_binary(&ul, sizeof(std::int64_t));
                 t = static_cast<T>(ul);
@@ -180,6 +192,11 @@ namespace hpx::serialization {
         void load(double& d)
         {
             load_binary(&d, sizeof(double));
+        }
+
+        void load(long double& d)
+        {
+            load_binary(&d, sizeof(long double));
         }
 
         void load(char& c)

--- a/libs/core/serialization/include/hpx/serialization/output_archive.hpp
+++ b/libs/core/serialization/include/hpx/serialization/output_archive.hpp
@@ -244,20 +244,32 @@ namespace hpx::serialization {
 #if defined(HPX_SERIALIZATION_HAVE_SUPPORTS_ENDIANESS)
             else if constexpr (std::is_unsigned_v<T>)
             {
+                static_assert(sizeof(T) <= sizeof(std::uint64_t),
+                    "integral type is larger than supported");
+
                 save_integral(static_cast<std::uint64_t>(t));
             }
             else
             {
+                static_assert(sizeof(T) <= sizeof(std::int64_t),
+                    "integral type is larger than supported");
+
                 save_integral(static_cast<std::int64_t>(t));
             }
 #else
             else if constexpr (std::is_unsigned_v<T>)
             {
+                static_assert(sizeof(T) <= sizeof(std::uint64_t),
+                    "integral type is larger than supported");
+
                 auto val = static_cast<std::uint64_t>(t);
                 save_binary(&val, sizeof(std::uint64_t));
             }
             else
             {
+                static_assert(sizeof(T) <= sizeof(std::int64_t),
+                    "integral type is larger than supported");
+
                 auto val = static_cast<std::int64_t>(t);
                 save_binary(&val, sizeof(std::int64_t));
             }
@@ -272,6 +284,11 @@ namespace hpx::serialization {
         void save(double d)
         {
             save_binary(&d, sizeof(double));
+        }
+
+        void save(long double d)
+        {
+            save_binary(&d, sizeof(long double));
         }
 
         void save(char c)

--- a/libs/core/serialization/tests/regressions/CMakeLists.txt
+++ b/libs/core/serialization/tests/regressions/CMakeLists.txt
@@ -5,7 +5,7 @@
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 set(tests buffer_overrun_2839 non_default_constructible_5886
-          not_bitwise_shared_ptr_serialization
+          not_bitwise_shared_ptr_serialization serialization_unsigned_buffer
 )
 
 foreach(test ${tests})

--- a/libs/core/serialization/tests/regressions/serialization_unsigned_buffer.cpp
+++ b/libs/core/serialization/tests/regressions/serialization_unsigned_buffer.cpp
@@ -40,7 +40,7 @@ struct A
 void test_bool()
 {
     {
-        std::vector<char> buffer;
+        std::vector<std::uint8_t> buffer;
         hpx::serialization::output_archive oarchive(buffer);
 
         bool b = true;
@@ -64,7 +64,7 @@ void test_bool()
         HPX_TEST_EQ(b, true);
     }
     {
-        std::vector<char> buffer;
+        std::vector<std::uint8_t> buffer;
         hpx::serialization::output_archive oarchive(buffer);
 
         auto b = A<bool>(true);
@@ -93,7 +93,7 @@ template <typename T>
 void test(T min, T max)
 {
     {
-        std::vector<char> buffer;
+        std::vector<std::uint8_t> buffer;
         hpx::serialization::output_archive oarchive(buffer);
         for (T c = min; c < max; ++c)
         {
@@ -108,7 +108,7 @@ void test(T min, T max)
         }
     }
     {
-        std::vector<char> buffer;
+        std::vector<std::uint8_t> buffer;
         hpx::serialization::output_archive oarchive(buffer);
         for (T c = min; c < max; ++c)
         {
@@ -129,7 +129,7 @@ template <typename T>
 void test_fp(T min, T max)
 {
     {
-        std::vector<char> buffer;
+        std::vector<std::uint8_t> buffer;
         hpx::serialization::output_archive oarchive(buffer);
         for (T c = min; c < max; c += static_cast<T>(0.5))
         {
@@ -144,7 +144,7 @@ void test_fp(T min, T max)
         }
     }
     {
-        std::vector<char> buffer;
+        std::vector<std::uint8_t> buffer;
         hpx::serialization::output_archive oarchive(buffer);
         for (T c = min; c < max; c += static_cast<T>(0.5))
         {

--- a/libs/core/serialization/tests/unit/not_bitwise_serializable.cpp
+++ b/libs/core/serialization/tests/unit/not_bitwise_serializable.cpp
@@ -8,7 +8,6 @@
 #define HPX_SERIALIZATION_HAVE_ALL_TYPES_ARE_BITWISE_SERIALIZABLE
 
 #include <hpx/config.hpp>
-#include <hpx/local/init.hpp>
 #include <hpx/modules/serialization.hpp>
 #include <hpx/modules/testing.hpp>
 
@@ -97,7 +96,7 @@ struct B
 
 HPX_IS_NOT_BITWISE_SERIALIZABLE(B)
 
-int hpx_main()
+int main(int, char*[])
 {
     {
         std::vector<char> buffer;
@@ -172,12 +171,5 @@ int hpx_main()
         HPX_TEST_EQ(ib.a, 42);
         HPX_TEST_EQ(ib.b, 42.0);
     }
-
-    return hpx::local::finalize();
-}
-
-int main(int argc, char* argv[])
-{
-    hpx::local::init(hpx_main, argc, argv);
     return hpx::util::report_errors();
 }

--- a/libs/core/serialization/tests/unit/polymorphic/polymorphic_pointer.cpp
+++ b/libs/core/serialization/tests/unit/polymorphic/polymorphic_pointer.cpp
@@ -69,7 +69,7 @@ struct D : B
       , d(89)
     {
     }
-    void f() {}
+    void f() override {}
 
     int d;
 
@@ -80,7 +80,7 @@ struct D : B
         ar& hpx::serialization::base_object<B>(*this);
         ar& d;
     }
-    HPX_SERIALIZATION_POLYMORPHIC(D);
+    HPX_SERIALIZATION_POLYMORPHIC(D, override);
 };
 
 int main()

--- a/libs/core/serialization/tests/unit/polymorphic/polymorphic_reference.cpp
+++ b/libs/core/serialization/tests/unit/polymorphic/polymorphic_reference.cpp
@@ -68,7 +68,7 @@ struct D : B
       , d(89)
     {
     }
-    void f() {}
+    void f() override {}
 
     int d;
 
@@ -79,7 +79,7 @@ struct D : B
         ar& hpx::serialization::base_object<B>(*this);
         ar& d;
     }
-    HPX_SERIALIZATION_POLYMORPHIC(D);
+    HPX_SERIALIZATION_POLYMORPHIC(D, override);
 };
 
 int main()

--- a/libs/core/serialization/tests/unit/polymorphic/polymorphic_template.cpp
+++ b/libs/core/serialization/tests/unit/polymorphic/polymorphic_template.cpp
@@ -47,7 +47,7 @@ struct B : A<T>
     }
     B() = default;
 
-    void foo() const {}
+    void foo() const override {}
 
     template <typename Ar>
     void serialize(Ar& ar, unsigned)
@@ -55,7 +55,7 @@ struct B : A<T>
         ar& hpx::serialization::base_object<A<T>>(*this);
         ar& b;
     }
-    HPX_SERIALIZATION_POLYMORPHIC_TEMPLATE(B);
+    HPX_SERIALIZATION_POLYMORPHIC_TEMPLATE(B, override);
 };
 
 int main()

--- a/libs/core/serialization/tests/unit/polymorphic/smart_ptr_polymorphic.cpp
+++ b/libs/core/serialization/tests/unit/polymorphic/smart_ptr_polymorphic.cpp
@@ -55,7 +55,7 @@ struct B : A
     {
     }
 
-    const char* foo()
+    const char* foo() override
     {
         return "B::foo";
     }
@@ -73,7 +73,7 @@ struct B : A
         ar& b;
     }
     HPX_SERIALIZATION_SPLIT_MEMBER();
-    HPX_SERIALIZATION_POLYMORPHIC_SPLITTED(B);
+    HPX_SERIALIZATION_POLYMORPHIC_SPLITTED(B, override);
 };
 
 class C : public B
@@ -87,7 +87,7 @@ class C : public B
         ar& hpx::serialization::base_object<B>(*this);
         ar& c;
     }
-    HPX_SERIALIZATION_POLYMORPHIC(C)
+    HPX_SERIALIZATION_POLYMORPHIC(C, override)
 
 public:
     explicit C(int c = 3)
@@ -95,7 +95,7 @@ public:
     {
     }
 
-    const char* foo()
+    const char* foo() override
     {
         return "C::foo";
     }
@@ -190,7 +190,7 @@ struct E : D
     {
     }
 
-    const char* foo()
+    const char* foo() override
     {
         return "E::foo";
     }
@@ -208,7 +208,7 @@ struct E : D
         ar& b;
     }
     HPX_SERIALIZATION_SPLIT_MEMBER();
-    HPX_SERIALIZATION_POLYMORPHIC_SPLITTED(E);
+    HPX_SERIALIZATION_POLYMORPHIC_SPLITTED(E, override);
 };
 
 class F : public E
@@ -222,7 +222,7 @@ class F : public E
         ar& hpx::serialization::base_object<E>(*this);
         ar& c;
     }
-    HPX_SERIALIZATION_POLYMORPHIC(F)
+    HPX_SERIALIZATION_POLYMORPHIC(F, override)
 
 public:
     explicit F(int c = 3)
@@ -230,7 +230,7 @@ public:
     {
     }
 
-    const char* foo()
+    const char* foo() override
     {
         return "F::foo";
     }


### PR DESCRIPTION
- flyby: add 'override' specifiers to compression filters
- flyby: add tests for explicitly signed and long long integral types
- flyby: add support for long double to serialization