### PR TITLE
Protect collective operations against std::vector<bool> idiosyncrasies

### DIFF
--- a/libs/full/collectives/include/hpx/collectives/all_reduce.hpp
+++ b/libs/full/collectives/include/hpx/collectives/all_reduce.hpp
@@ -164,7 +164,8 @@ namespace hpx { namespace traits {
                             data[0], HPX_FORWARD(F, op));
                         data_available = true;
                     }
-                    return data[0];
+                    return Communicator::template handle_bool<std::decay_t<T>>(
+                        data[0]);
                 });
         }
     };

--- a/libs/full/collectives/include/hpx/collectives/broadcast.hpp
+++ b/libs/full/collectives/include/hpx/collectives/broadcast.hpp
@@ -233,7 +233,11 @@ namespace hpx { namespace traits {
                 // step function (invoked for each get)
                 nullptr,
                 // finalizer (invoked after all sites have checked in)
-                [](auto& data, bool&) { return data[0]; }, 1);
+                [](auto& data, bool&) {
+                    return Communicator::template handle_bool<data_type>(
+                        data[0]);
+                },
+                1);
         }
 
         template <typename Result, typename T>
@@ -245,7 +249,11 @@ namespace hpx { namespace traits {
                 // step function (invoked once for set)
                 [&](auto& data) { data[0] = HPX_FORWARD(T, t); },
                 // finalizer (invoked after all sites have checked in)
-                [](auto& data, bool&) { return data[0]; }, 1);
+                [](auto& data, bool&) {
+                    return Communicator::template handle_bool<std::decay_t<T>>(
+                        data[0]);
+                },
+                1);
         }
     };
 }}    // namespace hpx::traits

--- a/libs/full/collectives/include/hpx/collectives/channel_communicator.hpp
+++ b/libs/full/collectives/include/hpx/collectives/channel_communicator.hpp
@@ -14,7 +14,8 @@
 // clang-format off
 namespace hpx { namespace collectives {
 
-    /// Create a new communicator object usable with peer-to-peer channel-based operations
+    /// Create a new communicator object usable with peer-to-peer
+    /// channel-based operations
     ///
     /// This functions creates a new communicator object that can be called in
     /// order to pre-allocate a communicator object usable with multiple
@@ -35,7 +36,8 @@ namespace hpx { namespace collectives {
         num_sites_arg num_sites = num_sites_arg(),
         this_site_arg this_site = this_site_arg());
 
-    /// Create a new communicator object usable with peer-to-peer channel-based operations
+    /// Create a new communicator object usable with peer-to-peer
+    /// channel-based operations
     ///
     /// This functions creates a new communicator object that can be called in
     /// order to pre-allocate a communicator object usable with multiple
@@ -61,17 +63,18 @@ namespace hpx { namespace collectives {
     /// This function sends a value to the given site based on the given
     /// communicator.
     ///
-    /// \param comm     The channel communicator object to use for the data transfer
+    /// \param comm     The channel communicator object to use for the data
+    ///                 transfer
     /// \param site     The destination site
     /// \param value    The value to send
     /// \param tag      The (optional) tag identifying the concrete operation
     ///
-    /// \returns    This function returns a future<void> that becomes ready once the
-    ///             data transfer operation has finished.
+    /// \returns    This function returns a future<void> that becomes ready
+    ///             once the data transfer operation has finished.
     ///
     template <typename T>
     hpx::future<void> set(channel_communicator comm,
-        that_site_arg site, T&& value, tag_arg tag = 0);
+        that_site_arg site, T&& value, tag_arg tag = tag_arg());
 
     /// Send a value to the given site
     ///
@@ -87,7 +90,7 @@ namespace hpx { namespace collectives {
     ///
     template <typename T>
     hpx::future<T> get(channel_communicator comm, that_site_arg site,
-        tag_arg tag = 0);
+        tag_arg tag = tag_arg());
 
 }}
 // clang-format on
@@ -118,11 +121,11 @@ namespace hpx { namespace collectives {
 
     template <typename T>
     hpx::future<T> get(
-        channel_communicator, that_site_arg, tag_arg = tag_arg(0));
+        channel_communicator, that_site_arg, tag_arg = tag_arg());
 
     template <typename T>
     hpx::future<void> set(
-        channel_communicator, that_site_arg, T&&, tag_arg = tag_arg(0));
+        channel_communicator, that_site_arg, T&&, tag_arg = tag_arg());
 
     ///////////////////////////////////////////////////////////////////////////
     class channel_communicator

--- a/libs/full/collectives/include/hpx/collectives/detail/communicator.hpp
+++ b/libs/full/collectives/include/hpx/collectives/detail/communicator.hpp
@@ -229,6 +229,20 @@ namespace hpx { namespace collectives { namespace detail {
             return f;
         }
 
+        // protect against vector<bool> idiosyncrasies
+        template <typename ValueType, typename Data>
+        static decltype(auto) handle_bool(Data&& data)
+        {
+            if constexpr (std::is_same_v<ValueType, bool>)
+            {
+                return bool(data);
+            }
+            else
+            {
+                return HPX_FORWARD(Data, data);
+            }
+        }
+
     private:
         template <typename Communicator, typename Operation>
         friend struct hpx::traits::communication_operation;

--- a/libs/full/collectives/include/hpx/collectives/exclusive_scan.hpp
+++ b/libs/full/collectives/include/hpx/collectives/exclusive_scan.hpp
@@ -180,7 +180,8 @@ namespace hpx { namespace traits {
                         std::swap(data, dest);
                         data_available = true;
                     }
-                    return data[which];
+                    return Communicator::template handle_bool<std::decay_t<T>>(
+                        data[which]);
                 });
         }
     };

--- a/libs/full/collectives/include/hpx/collectives/inclusive_scan.hpp
+++ b/libs/full/collectives/include/hpx/collectives/inclusive_scan.hpp
@@ -167,7 +167,8 @@ namespace hpx { namespace traits {
                         std::swap(data, dest);
                         data_available = true;
                     }
-                    return data[which];
+                    return Communicator::template handle_bool<std::decay_t<T>>(
+                        data[which]);
                 });
         }
     };

--- a/libs/full/collectives/include/hpx/collectives/reduce.hpp
+++ b/libs/full/collectives/include/hpx/collectives/reduce.hpp
@@ -255,10 +255,12 @@ namespace hpx { namespace traits {
                     HPX_ASSERT(!data.empty());
                     if (data.size() > 1)
                     {
-                        return hpx::reduce(++data.begin(), data.end(), data[0],
-                            HPX_FORWARD(F, op));
+                        return Communicator::template handle_bool<
+                            std::decay_t<T>>(hpx::reduce(++data.begin(),
+                            data.end(), data[0], HPX_FORWARD(F, op)));
                     }
-                    return data[0];
+                    return Communicator::template handle_bool<std::decay_t<T>>(
+                        data[0]);
                 });
         }
 

--- a/libs/full/collectives/include/hpx/collectives/scatter.hpp
+++ b/libs/full/collectives/include/hpx/collectives/scatter.hpp
@@ -242,7 +242,10 @@ namespace hpx { namespace traits {
                 // step function (invoked once for get)
                 nullptr,
                 // finalizer (invoked after all sites have checked in)
-                [which](auto& data, bool&) { return HPX_MOVE(data[which]); });
+                [which](auto& data, bool&) {
+                    return Communicator::template handle_bool<data_type>(
+                        HPX_MOVE(data[which]));
+                });
         }
 
         template <typename Result, typename T>
@@ -254,7 +257,10 @@ namespace hpx { namespace traits {
                 // step function (invoked once for set)
                 [&](auto& data) { data = HPX_MOVE(t); },
                 // finalizer (invoked after all sites have checked in)
-                [which](auto& data, bool&) { return HPX_MOVE(data[which]); });
+                [which](auto& data, bool&) {
+                    return Communicator::template handle_bool<T>(
+                        HPX_MOVE(data[which]));
+                });
         }
     };
 }}    // namespace hpx::traits

--- a/libs/full/collectives/tests/regressions/CMakeLists.txt
+++ b/libs/full/collectives/tests/regressions/CMakeLists.txt
@@ -1,20 +1,22 @@
-# Copyright (c) 2019 The STE||AR-Group
+# Copyright (c) 2019-2022 The STE||AR-Group
 #
 # SPDX-License-Identifier: BSL-1.0
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 if(HPX_WITH_NETWORKING)
-  set(tests barrier_3792 barrier_hang broadcast_unwrap_future_2885
-            broadcast_wait_for_2822 multiple_gather_ops_2001
+  set(tests
+      barrier_3792 barrier_hang broadcast_unwrap_future_2885
+      broadcast_wait_for_2822 collectives_bool_5940 multiple_gather_ops_2001
   )
 
   set(broadcast_unwrap_future_2885_PARAMETERS LOCALITIES 2 THREADS_PER_LOCALITY
                                               4
   )
   set(broadcast_wait_for_2822_PARAMETERS LOCALITIES 2 THREADS_PER_LOCALITY 4)
-  set(multiple_gather_ops_2001_PARAMETERS LOCALITIES 2)
   set(barrier_3792_PARAMETERS LOCALITIES 3 THREADS_PER_LOCALITY 1)
+  set(collectives_bool_5940_PARAMETERS LOCALITIES 2)
+  set(multiple_gather_ops_2001_PARAMETERS LOCALITIES 2)
 
   foreach(test ${tests})
     set(sources ${test}.cpp)

--- a/libs/full/collectives/tests/regressions/collectives_bool_5940.cpp
+++ b/libs/full/collectives/tests/regressions/collectives_bool_5940.cpp
@@ -1,0 +1,214 @@
+//  Copyright (c) 2022 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/config.hpp>
+
+#if !defined(HPX_COMPUTE_DEVICE_CODE)
+#include <hpx/hpx.hpp>
+#include <hpx/hpx_init.hpp>
+#include <hpx/modules/collectives.hpp>
+#include <hpx/modules/testing.hpp>
+
+#include <cstdint>
+#include <string>
+#include <utility>
+#include <vector>
+
+using namespace hpx::collectives;
+
+constexpr char const* add_reduce_bool_basename = "/test/add_reduce_bool/";
+constexpr char const* broadcast_bool_basename = "/test/broadcast_bool/";
+constexpr char const* exclusive_scan_bool_basename =
+    "/test/exclusive_scan_bool/";
+constexpr char const* inclusive_scan_bool_basename =
+    "/test/inclusive_scan_bool/";
+constexpr char const* reduce_bool_basename = "/test/reduce_bool/";
+constexpr char const* scatter_bool_basename = "/test/scatter_bool/";
+
+void test_all_reduce_bool()
+{
+    std::uint32_t num_localities = hpx::get_num_localities(hpx::launch::sync);
+    std::uint32_t here = hpx::get_locality_id();
+
+    auto all_reduce_bool_client = create_communicator(add_reduce_bool_basename,
+        num_sites_arg(num_localities), this_site_arg(here));
+
+    // test functionality based on immediate local result value
+    for (int i = 0; i != 10; ++i)
+    {
+        bool value = i % 2 ? true : false;
+
+        hpx::future<bool> overall_result = all_reduce(all_reduce_bool_client,
+            value, std::logical_or<>{}, generation_arg(i + 1));
+
+        HPX_TEST_EQ(value, overall_result.get());
+    }
+}
+
+void test_broadcast_bool()
+{
+    std::uint32_t num_localities = hpx::get_num_localities(hpx::launch::sync);
+    HPX_TEST_LTE(std::uint32_t(2), num_localities);
+
+    std::uint32_t here = hpx::get_locality_id();
+
+    auto broadcast_bool_client = create_communicator(broadcast_bool_basename,
+        num_sites_arg(num_localities), this_site_arg(here));
+
+    // test functionality based on immediate local result value
+    for (std::uint32_t i = 0; i != 10; ++i)
+    {
+        bool value = i % 2 ? true : false;
+        if (here == 0)
+        {
+            hpx::future<bool> result = broadcast_to(
+                broadcast_bool_client, value, generation_arg(i + 1));
+
+            HPX_TEST_EQ(value, result.get());
+        }
+        else
+        {
+            hpx::future<bool> result = hpx::collectives::broadcast_from<bool>(
+                broadcast_bool_client, generation_arg(i + 1));
+
+            HPX_TEST_EQ(value, result.get());
+        }
+    }
+}
+
+void test_exclusive_scan_bool()
+{
+    std::uint32_t num_localities = hpx::get_num_localities(hpx::launch::sync);
+    std::uint32_t here = hpx::get_locality_id();
+
+    auto exclusive_scan_bool_client =
+        create_communicator(exclusive_scan_bool_basename,
+            num_sites_arg(num_localities), this_site_arg(here));
+
+    // test functionality based on immediate local result value
+    for (int i = 0; i != 10; ++i)
+    {
+        bool value = i % 2 ? true : false;
+
+        hpx::future<bool> overall_result =
+            exclusive_scan(exclusive_scan_bool_client, value,
+                std::logical_or<>{}, generation_arg(i + 1));
+
+        HPX_TEST_EQ(value, overall_result.get());
+    }
+}
+
+void test_inclusive_scan_bool()
+{
+    std::uint32_t num_localities = hpx::get_num_localities(hpx::launch::sync);
+    std::uint32_t here = hpx::get_locality_id();
+
+    auto inclusive_scan_client =
+        create_communicator(inclusive_scan_bool_basename,
+            num_sites_arg(num_localities), this_site_arg(here));
+
+    // test functionality based on immediate local result value
+    for (int i = 0; i != 10; ++i)
+    {
+        bool value = i % 2 ? true : false;
+
+        hpx::future<bool> overall_result = inclusive_scan(inclusive_scan_client,
+            value, std::logical_or<>{}, generation_arg(i + 1));
+
+        HPX_TEST_EQ(value, overall_result.get());
+    }
+}
+
+void test_reduce_bool()
+{
+    std::uint32_t num_localities = hpx::get_num_localities(hpx::launch::sync);
+    std::uint32_t this_locality = hpx::get_locality_id();
+
+    auto reduce_bool_client = create_communicator(reduce_bool_basename,
+        num_sites_arg(num_localities), this_site_arg(this_locality));
+
+    // test functionality based on immediate local result value
+    for (int i = 0; i != 10; ++i)
+    {
+        bool value = i % 2 ? true : false;
+        if (this_locality == 0)
+        {
+            hpx::future<bool> overall_result = reduce_here(reduce_bool_client,
+                value, std::logical_or<>{}, generation_arg(i + 1));
+
+            HPX_TEST_EQ(value, overall_result.get());
+        }
+        else
+        {
+            hpx::future<void> overall_result = reduce_there(
+                reduce_bool_client, std::move(value), generation_arg(i + 1));
+            overall_result.get();
+        }
+    }
+}
+
+void test_scatter_bool()
+{
+    std::uint32_t num_localities = hpx::get_num_localities(hpx::launch::sync);
+    HPX_TEST_LTE(std::uint32_t(2), num_localities);
+
+    std::uint32_t this_locality = hpx::get_locality_id();
+
+    auto scatter_bool_client =
+        hpx::collectives::create_communicator(scatter_bool_basename,
+            num_sites_arg(num_localities), this_site_arg(this_locality));
+
+    // test functionality based on immediate local result value
+    for (int i = 0; i != 10; ++i)
+    {
+        bool value = i % 2 ? true : false;
+        if (this_locality == 0)
+        {
+            std::vector<bool> data(num_localities);
+            for (std::size_t i = 0; i != data.size(); ++i)
+            {
+                data[i] = value;
+            }
+
+            hpx::future<bool> result = scatter_to(
+                scatter_bool_client, std::move(data), generation_arg(i + 1));
+
+            HPX_TEST_EQ(value, result.get());
+        }
+        else
+        {
+            hpx::future<bool> result =
+                scatter_from<bool>(scatter_bool_client, generation_arg(i + 1));
+
+            HPX_TEST_EQ(value, result.get());
+        }
+    }
+}
+
+int hpx_main()
+{
+    test_all_reduce_bool();
+    test_broadcast_bool();
+    test_exclusive_scan_bool();
+    test_inclusive_scan_bool();
+    test_reduce_bool();
+    test_scatter_bool();
+
+    return hpx::finalize();
+}
+
+int main(int argc, char* argv[])
+{
+    std::vector<std::string> const cfg = {"hpx.run_hpx_main!=1"};
+
+    hpx::init_params init_args;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ(hpx::init(argc, argv, init_args), 0);
+    return hpx::util::report_errors();
+}
+
+#endif

--- a/libs/full/collectives/tests/unit/exclusive_scan_.cpp
+++ b/libs/full/collectives/tests/unit/exclusive_scan_.cpp
@@ -19,7 +19,7 @@
 
 using namespace hpx::collectives;
 
-constexpr char const* all_reduce_direct_basename = "/test/all_reduce_direct/";
+constexpr char const* exclusive_scan_basename = "/test/exclusive_scan/";
 
 void test_one_shot_use()
 {
@@ -32,7 +32,7 @@ void test_one_shot_use()
         std::uint32_t value = here;
 
         hpx::future<std::uint32_t> overall_result =
-            exclusive_scan(all_reduce_direct_basename, value,
+            exclusive_scan(exclusive_scan_basename, value,
                 std::plus<std::uint32_t>{}, num_sites_arg(num_localities),
                 this_site_arg(here), generation_arg(i + 1));
 
@@ -58,9 +58,8 @@ void test_multiple_use()
     std::uint32_t num_localities = hpx::get_num_localities(hpx::launch::sync);
     std::uint32_t here = hpx::get_locality_id();
 
-    auto all_reduce_direct_client =
-        create_communicator(all_reduce_direct_basename,
-            num_sites_arg(num_localities), this_site_arg(here));
+    auto exclusive_scan_client = create_communicator(exclusive_scan_basename,
+        num_sites_arg(num_localities), this_site_arg(here));
 
     // test functionality based on immediate local result value
     for (int i = 0; i != 10; ++i)
@@ -68,7 +67,7 @@ void test_multiple_use()
         std::uint32_t value = here;
 
         hpx::future<std::uint32_t> overall_result = exclusive_scan(
-            all_reduce_direct_client, value, std::plus<std::uint32_t>{});
+            exclusive_scan_client, value, std::plus<std::uint32_t>{});
 
         if (here == 0)
         {
@@ -92,9 +91,8 @@ void test_multiple_use_with_generation()
     std::uint32_t num_localities = hpx::get_num_localities(hpx::launch::sync);
     std::uint32_t here = hpx::get_locality_id();
 
-    auto all_reduce_direct_client =
-        create_communicator(all_reduce_direct_basename,
-            num_sites_arg(num_localities), this_site_arg(here));
+    auto exclusive_scan_client = create_communicator(exclusive_scan_basename,
+        num_sites_arg(num_localities), this_site_arg(here));
 
     // test functionality based on immediate local result value
     for (int i = 0; i != 10; ++i)
@@ -102,7 +100,7 @@ void test_multiple_use_with_generation()
         std::uint32_t value = here;
 
         hpx::future<std::uint32_t> overall_result =
-            exclusive_scan(all_reduce_direct_client, value,
+            exclusive_scan(exclusive_scan_client, value,
                 std::plus<std::uint32_t>{}, generation_arg(i + 1));
 
         if (here == 0)

--- a/libs/full/collectives/tests/unit/inclusive_scan_.cpp
+++ b/libs/full/collectives/tests/unit/inclusive_scan_.cpp
@@ -21,7 +21,7 @@
 
 using namespace hpx::collectives;
 
-constexpr char const* all_reduce_direct_basename = "/test/all_reduce_direct/";
+constexpr char const* inclusive_scan_basename = "/test/inclusive_scan/";
 
 void test_one_shot_use()
 {
@@ -34,7 +34,7 @@ void test_one_shot_use()
         std::uint32_t value = here;
 
         hpx::future<std::uint32_t> overall_result =
-            inclusive_scan(all_reduce_direct_basename, value,
+            inclusive_scan(inclusive_scan_basename, value,
                 std::plus<std::uint32_t>{}, num_sites_arg(num_localities),
                 this_site_arg(here), generation_arg(i + 1));
 
@@ -52,9 +52,8 @@ void test_multiple_use()
     std::uint32_t num_localities = hpx::get_num_localities(hpx::launch::sync);
     std::uint32_t here = hpx::get_locality_id();
 
-    auto all_reduce_direct_client =
-        create_communicator(all_reduce_direct_basename,
-            num_sites_arg(num_localities), this_site_arg(here));
+    auto inclusive_scan_client = create_communicator(inclusive_scan_basename,
+        num_sites_arg(num_localities), this_site_arg(here));
 
     // test functionality based on immediate local result value
     for (int i = 0; i != 10; ++i)
@@ -62,7 +61,7 @@ void test_multiple_use()
         std::uint32_t value = here;
 
         hpx::future<std::uint32_t> overall_result = inclusive_scan(
-            all_reduce_direct_client, value, std::plus<std::uint32_t>{});
+            inclusive_scan_client, value, std::plus<std::uint32_t>{});
 
         std::uint32_t sum = 0;
         for (std::uint32_t j = 0; j != value + 1; ++j)
@@ -78,9 +77,8 @@ void test_multiple_use_with_generation()
     std::uint32_t num_localities = hpx::get_num_localities(hpx::launch::sync);
     std::uint32_t here = hpx::get_locality_id();
 
-    auto all_reduce_direct_client =
-        create_communicator(all_reduce_direct_basename,
-            num_sites_arg(num_localities), this_site_arg(here));
+    auto inclusive_scan_client = create_communicator(inclusive_scan_basename,
+        num_sites_arg(num_localities), this_site_arg(here));
 
     // test functionality based on immediate local result value
     for (int i = 0; i != 10; ++i)
@@ -88,7 +86,7 @@ void test_multiple_use_with_generation()
         std::uint32_t value = here;
 
         hpx::future<std::uint32_t> overall_result =
-            inclusive_scan(all_reduce_direct_client, value,
+            inclusive_scan(inclusive_scan_client, value,
                 std::plus<std::uint32_t>{}, generation_arg(i + 1));
 
         std::uint32_t sum = 0;


### PR DESCRIPTION
- std::vector<T> is internally used to store intermediate results for the collective operations. This change makes sure that automatic return type deduction does not get fooled by the `vector<bool>`'s proxy value_type.
