### PR TITLE
Fix sync_wait

### DIFF
--- a/libs/core/algorithms/tests/unit/container_algorithms/foreach_tests.hpp
+++ b/libs/core/algorithms/tests/unit/container_algorithms/foreach_tests.hpp
@@ -348,9 +348,9 @@ void test_for_each_sender(ExPolicy&& p, IteratorTag)
     auto rng = hpx::util::make_iterator_range(
         iterator(std::begin(c)), iterator(std::end(c)));
     auto f = [](std::size_t& v) { v = 42; };
-    auto result = ex::just(rng, f) |
-        hpx::ranges::for_each(std::forward<ExPolicy>(p)) | tt::sync_wait();
-    HPX_TEST(*result == iterator(std::end(c)));
+    auto result = hpx::get<0>(*(ex::just(rng, f) |
+        hpx::ranges::for_each(std::forward<ExPolicy>(p)) | tt::sync_wait()));
+    HPX_TEST(result == iterator(std::end(c)));
 
     // verify values
     std::size_t count = 0;

--- a/libs/core/algorithms/tests/unit/container_algorithms/foreach_tests.hpp
+++ b/libs/core/algorithms/tests/unit/container_algorithms/foreach_tests.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2014-2015 Hartmut Kaiser
+//  Copyright (c) 2014-2022 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -350,7 +350,7 @@ void test_for_each_sender(ExPolicy&& p, IteratorTag)
     auto f = [](std::size_t& v) { v = 42; };
     auto result = ex::just(rng, f) |
         hpx::ranges::for_each(std::forward<ExPolicy>(p)) | tt::sync_wait();
-    HPX_TEST(result == iterator(std::end(c)));
+    HPX_TEST(*result == iterator(std::end(c)));
 
     // verify values
     std::size_t count = 0;

--- a/libs/core/async_cuda/tests/unit/transform_stream.cu
+++ b/libs/core/async_cuda/tests/unit/transform_stream.cu
@@ -186,7 +186,8 @@ int hpx_main()
         auto s1 = ex::just(1);
         auto s2 = cu::transform_stream(std::move(s1), dummy{});
         HPX_TEST_EQ(
-            tt::sync_wait(ex::transfer(std::move(s2), ex::thread_pool_scheduler{})),
+            hpx::get<0>(*tt::sync_wait(ex::transfer(std::move(s2),
+                ex::thread_pool_scheduler{}))),
             2.0);
         HPX_TEST_EQ(dummy::host_void_calls.load(), std::size_t(0));
         HPX_TEST_EQ(dummy::stream_void_calls.load(), std::size_t(0));
@@ -203,7 +204,8 @@ int hpx_main()
         auto s3 = cu::transform_stream(std::move(s2), dummy{});
         auto s4 = cu::transform_stream(std::move(s3), dummy{});
         HPX_TEST_EQ(
-            tt::sync_wait(ex::transfer(std::move(s4), ex::thread_pool_scheduler{})),
+            hpx::get<0>(*tt::sync_wait(ex::transfer(std::move(s4),
+                ex::thread_pool_scheduler{}))),
             4.0);
         HPX_TEST_EQ(dummy::host_void_calls.load(), std::size_t(0));
         HPX_TEST_EQ(dummy::stream_void_calls.load(), std::size_t(0));
@@ -222,7 +224,8 @@ int hpx_main()
         auto s4 = ex::then(std::move(s3), dummy{});
         auto s5 = cu::transform_stream(std::move(s4), dummy{});
         HPX_TEST_EQ(
-            tt::sync_wait(ex::transfer(std::move(s5), ex::thread_pool_scheduler{})),
+            hpx::get<0>(*tt::sync_wait(ex::transfer(std::move(s5),
+                ex::thread_pool_scheduler{}))),
             4.0);
         HPX_TEST_EQ(dummy::host_void_calls.load(), std::size_t(0));
         HPX_TEST_EQ(dummy::stream_void_calls.load(), std::size_t(0));
@@ -240,7 +243,7 @@ int hpx_main()
         auto s4 = cu::transform_stream(std::move(s3), dummy{});
         auto s5 = ex::transfer(std::move(s4), ex::thread_pool_scheduler{});
         auto s6 = ex::then(std::move(s5), dummy{});
-        HPX_TEST_EQ(tt::sync_wait(std::move(s6)), 4.0);
+        HPX_TEST_EQ(hpx::get<0>(*tt::sync_wait(std::move(s6))), 4.0);
         HPX_TEST_EQ(dummy::host_void_calls.load(), std::size_t(0));
         HPX_TEST_EQ(dummy::stream_void_calls.load(), std::size_t(0));
         HPX_TEST_EQ(dummy::host_int_calls.load(), std::size_t(2));
@@ -257,7 +260,7 @@ int hpx_main()
         auto s4 = cu::transform_stream(std::move(s3), dummy{});
         auto s5 = ex::transfer(std::move(s4), ex::thread_pool_scheduler{});
         auto s6 = ex::then(std::move(s5), dummy{});
-        HPX_TEST_EQ(tt::sync_wait(std::move(s6)), 5.0);
+        HPX_TEST_EQ(hpx::get<0>(*tt::sync_wait(std::move(s6))), 5.0);
         HPX_TEST_EQ(dummy::host_void_calls.load(), std::size_t(0));
         HPX_TEST_EQ(dummy::stream_void_calls.load(), std::size_t(0));
         HPX_TEST_EQ(dummy::host_int_calls.load(), std::size_t(1));

--- a/libs/core/async_mpi/tests/unit/algorithm_transform_mpi.cpp
+++ b/libs/core/async_mpi/tests/unit/algorithm_transform_mpi.cpp
@@ -9,6 +9,7 @@
 #include <hpx/modules/errors.hpp>
 #include <hpx/modules/execution.hpp>
 #include <hpx/modules/testing.hpp>
+#include <hpx/tuple.hpp>
 
 #include "algorithm_test_utils.hpp"
 
@@ -57,7 +58,7 @@ int hpx_main()
                 }
                 auto s = mpi::transform_mpi(
                     ex::just(&data, count, datatype, 0, comm), MPI_Ibcast);
-                auto result = tt::sync_wait(HPX_MOVE(s));
+                auto result = hpx::get<0>(*tt::sync_wait(HPX_MOVE(s)));
                 if (rank != 0)
                 {
                     HPX_TEST_EQ(data, 42);
@@ -82,7 +83,7 @@ int hpx_main()
                         return MPI_Ibcast(
                             data, count, datatype, i, comm, request);
                     });
-                auto result = tt::sync_wait(HPX_MOVE(s));
+                auto result = hpx::get<0>(*tt::sync_wait(HPX_MOVE(s)));
                 if (rank != 0)
                 {
                     HPX_TEST_EQ(data, 42);
@@ -138,8 +139,9 @@ int hpx_main()
                 {
                     data = 42;
                 }
-                auto result = ex::just(&data, count, datatype, 0, comm) |
-                    mpi::transform_mpi(MPI_Ibcast) | tt::sync_wait();
+                auto result =
+                    hpx::get<0>(*(ex::just(&data, count, datatype, 0, comm) |
+                        mpi::transform_mpi(MPI_Ibcast) | tt::sync_wait()));
                 if (rank != 0)
                 {
                     HPX_TEST_EQ(data, 42);

--- a/libs/core/async_mpi/tests/unit/algorithm_transform_mpi.cpp
+++ b/libs/core/async_mpi/tests/unit/algorithm_transform_mpi.cpp
@@ -9,7 +9,7 @@
 #include <hpx/modules/errors.hpp>
 #include <hpx/modules/execution.hpp>
 #include <hpx/modules/testing.hpp>
-#include <hpx/tuple.hpp>
+#include <hpx/datastructures/tuple.hpp>
 
 #include "algorithm_test_utils.hpp"
 

--- a/libs/core/async_mpi/tests/unit/algorithm_transform_mpi.cpp
+++ b/libs/core/async_mpi/tests/unit/algorithm_transform_mpi.cpp
@@ -4,12 +4,13 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+#include <hpx/datastructures/tuple.hpp>
+#include <hpx/datastructures/variant.hpp>
 #include <hpx/local/init.hpp>
 #include <hpx/modules/async_mpi.hpp>
 #include <hpx/modules/errors.hpp>
 #include <hpx/modules/execution.hpp>
 #include <hpx/modules/testing.hpp>
-#include <hpx/datastructures/tuple.hpp>
 
 #include "algorithm_test_utils.hpp"
 

--- a/libs/core/execution/include/hpx/execution/algorithms/detail/single_result.hpp
+++ b/libs/core/execution/include/hpx/execution/algorithms/detail/single_result.hpp
@@ -9,10 +9,10 @@
 
 #include <hpx/config.hpp>
 #include <hpx/type_support/meta.hpp>
+#include <hpx/datastructures/variant.hpp>
 
 #include <cstddef>
 #include <type_traits>
-#include <variant>
 
 namespace hpx::execution::experimental::detail {
 

--- a/libs/core/execution/include/hpx/execution/algorithms/detail/single_result.hpp
+++ b/libs/core/execution/include/hpx/execution/algorithms/detail/single_result.hpp
@@ -8,8 +8,9 @@
 #pragma once
 
 #include <hpx/config.hpp>
-#include <hpx/type_support/meta.hpp>
 #include <hpx/datastructures/variant.hpp>
+#include <hpx/type_support/meta.hpp>
+#include <hpx/type_support/pack.hpp>
 
 #include <cstddef>
 #include <type_traits>

--- a/libs/core/execution/include/hpx/execution/algorithms/detail/single_result.hpp
+++ b/libs/core/execution/include/hpx/execution/algorithms/detail/single_result.hpp
@@ -90,6 +90,18 @@ namespace hpx::execution::experimental::detail {
         using type = T;
     };
 
+    template <typename T>
+    struct single_variant<meta::pack<T>>
+    {
+        using type = T;
+    };
+
+    template <typename T>
+    struct single_variant<hpx::variant<T>>
+    {
+        using type = T;
+    };
+
     template <typename Variants>
     using single_variant_t = meta::type<single_variant<Variants>>;
 

--- a/libs/core/execution/tests/unit/algorithm_sync_wait.cpp
+++ b/libs/core/execution/tests/unit/algorithm_sync_wait.cpp
@@ -121,7 +121,7 @@ int hpx_main()
 
     // cancellation path
     {
-        auto result = stopped_sender{} | tt::sync_wait();
+        auto result = hpx::get<0>(*(stopped_sender{} | tt::sync_wait()));
         HPX_TEST(!result);
     }
 

--- a/libs/core/execution/tests/unit/algorithm_sync_wait.cpp
+++ b/libs/core/execution/tests/unit/algorithm_sync_wait.cpp
@@ -121,8 +121,8 @@ int hpx_main()
 
     // cancellation path
     {
-        auto result = hpx::get<0>(*(stopped_sender{} | tt::sync_wait()));
-        HPX_TEST(!result);
+        auto result = stopped_sender_with_value_type{} | tt::sync_wait();
+        HPX_TEST(!result);    // returned optional should be empty
     }
 
     return hpx::local::finalize();

--- a/libs/core/execution/tests/unit/algorithm_sync_wait.cpp
+++ b/libs/core/execution/tests/unit/algorithm_sync_wait.cpp
@@ -42,21 +42,34 @@ int hpx_main()
     }
 
     {
-        HPX_TEST_EQ(tt::sync_wait(ex::just(3)), 3);
+        HPX_TEST_EQ(hpx::get<0>(*tt::sync_wait(ex::just(3))), 3);
     }
 
     {
-        HPX_TEST_EQ(
-            tt::sync_wait(ex::just(custom_type_non_default_constructible{42}))
-                .x,
+        auto result = *tt::sync_wait(ex::just(3, 4.0));
+        HPX_TEST_EQ(hpx::get<0>(result), 3);
+        HPX_TEST_EQ(hpx::get<1>(result), 4.0);
+    }
+
+    {
+        auto result = *tt::sync_wait(ex::just(3, 4.0, std::string("42")));
+        HPX_TEST_EQ(hpx::get<0>(result), 3);
+        HPX_TEST_EQ(hpx::get<1>(result), 4.0);
+        HPX_TEST_EQ(hpx::get<2>(result), std::string("42"));
+    }
+
+    {
+        HPX_TEST_EQ(hpx::get<0>(*tt::sync_wait(ex::just(
+                                    custom_type_non_default_constructible{42})))
+                        .x,
             42);
     }
 
     {
         HPX_TEST_EQ(
-            tt::sync_wait(
-                ex::just(
-                    custom_type_non_default_constructible_non_copyable{42}))
+            hpx::get<0>(
+                *tt::sync_wait(ex::just(
+                    custom_type_non_default_constructible_non_copyable{42})))
                 .x,
             42);
     }
@@ -75,7 +88,7 @@ int hpx_main()
     }
 
     {
-        HPX_TEST_EQ(ex::just(3) | tt::sync_wait(), 3);
+        HPX_TEST_EQ(hpx::get<0>(*(ex::just(3) | tt::sync_wait())), 3);
     }
 
     // tag_invoke overload
@@ -104,6 +117,12 @@ int hpx_main()
             exception_thrown = true;
         }
         HPX_TEST(exception_thrown);
+    }
+
+    // cancellation path
+    {
+        auto result = stopped_sender{} | tt::sync_wait();
+        HPX_TEST(!result);
     }
 
     return hpx::local::finalize();

--- a/libs/core/execution_base/tests/include/algorithm_test_utils.hpp
+++ b/libs/core/execution_base/tests/include/algorithm_test_utils.hpp
@@ -145,6 +145,36 @@ struct stopped_sender
             hpx::execution::experimental::set_stopped_t()>;
 };
 
+struct stopped_sender_with_value_type
+{
+    template <typename R>
+    struct operation_state
+    {
+        std::decay_t<R> r;
+        friend void tag_invoke(
+            hpx::execution::experimental::start_t, operation_state& os) noexcept
+        {
+            hpx::execution::experimental::set_stopped(std::move(os.r));
+        }
+    };
+
+    template <typename R>
+    friend operation_state<R> tag_invoke(
+        hpx::execution::experimental::connect_t, stopped_sender_with_value_type,
+        R&& r)
+    {
+        return {std::forward<R>(r)};
+    }
+
+    template <typename Env>
+    friend auto tag_invoke(
+        hpx::execution::experimental::get_completion_signatures_t,
+        stopped_sender_with_value_type const&, Env)
+        -> hpx::execution::experimental::completion_signatures<
+            hpx::execution::experimental::set_stopped_t(),
+            hpx::execution::experimental::set_value_t()>;
+};
+
 template <typename F>
 struct callback_receiver
 {

--- a/libs/core/executors/tests/unit/thread_pool_scheduler.cpp
+++ b/libs/core/executors/tests/unit/thread_pool_scheduler.cpp
@@ -181,7 +181,7 @@ void test_sender_receiver_then_sync_wait()
         ++then_count;
         return 42;
     });
-    auto result = tt::sync_wait(std::move(work));
+    auto result = hpx::get<0>(*(tt::sync_wait(std::move(work))));
     HPX_TEST_EQ(then_count, std::size_t(1));
     static_assert(
         std::is_same<int, typename std::decay<decltype(result)>::type>::value,
@@ -678,8 +678,8 @@ void test_future_sender()
 
         static_assert(ex::is_sender_v<std::decay_t<decltype(f)>>,
             "a future should be a sender");
-        static_assert(std::is_void<decltype(
-                          hpx::get<0>(*tt::sync_wait(std::move(f))))>::value,
+        static_assert(
+            std::is_void<decltype(tt::sync_wait(std::move(f)))>::value,
             "sync_wait should return void");
 
         tt::sync_wait(std::move(f));
@@ -710,7 +710,7 @@ void test_future_sender()
         static_assert(ex::is_sender_v<std::decay_t<decltype(f)>>,
             "a future should be a sender");
 
-        HPX_TEST_EQ(tt::sync_wait(std::move(f)), 42);
+        HPX_TEST_EQ(hpx::get<0>(*tt::sync_wait(std::move(f))), 42);
         HPX_TEST(called);
 
         bool exception_thrown = false;
@@ -747,8 +747,8 @@ void test_future_sender()
 
         static_assert(ex::is_sender_v<std::decay_t<decltype(sf)>>,
             "a shared_future should be a sender");
-        static_assert(std::is_void<decltype(
-                          hpx::get<0>(*tt::sync_wait(std::move(sf))))>::value,
+        static_assert(
+            std::is_void<decltype(tt::sync_wait(std::move(sf)))>::value,
             "sync_wait should return void");
 
         tt::sync_wait(sf);
@@ -779,9 +779,9 @@ void test_future_sender()
         static_assert(ex::is_sender_v<std::decay_t<decltype(sf)>>,
             "a shared_future should be a sender");
 
-        HPX_TEST_EQ(tt::sync_wait(sf), 42);
-        HPX_TEST_EQ(tt::sync_wait(sf), 42);
-        HPX_TEST_EQ(tt::sync_wait(std::move(sf)), 42);
+        HPX_TEST_EQ(hpx::get<0>(*tt::sync_wait(sf)), 42);
+        HPX_TEST_EQ(hpx::get<0>(*tt::sync_wait(sf)), 42);
+        HPX_TEST_EQ(hpx::get<0>(*tt::sync_wait(std::move(sf))), 42);
         HPX_TEST_EQ(calls, std::size_t(1));
 
         bool exception_thrown = false;
@@ -844,8 +844,8 @@ void test_future_sender()
 
     // mixing senders and futures
     {
-        HPX_TEST_EQ(tt::sync_wait(ex::make_future(
-                        ex::transfer_just(ex::thread_pool_scheduler{}, 42))),
+        HPX_TEST_EQ(hpx::get<0>(*tt::sync_wait(ex::make_future(
+                        ex::transfer_just(ex::thread_pool_scheduler{}, 42)))),
             42);
     }
 
@@ -889,21 +889,21 @@ void test_ensure_started()
 
     {
         auto s = ex::transfer_just(sched, 42) | ex::ensure_started();
-        HPX_TEST_EQ(tt::sync_wait(std::move(s)), 42);
+        HPX_TEST_EQ(hpx::get<0>(*tt::sync_wait(std::move(s))), 42);
     }
 
     {
         auto s = ex::transfer_just(sched, 42) | ex::ensure_started() |
             ex::transfer(sched);
-        HPX_TEST_EQ(tt::sync_wait(std::move(s)), 42);
+        HPX_TEST_EQ(hpx::get<0>(*tt::sync_wait(std::move(s))), 42);
     }
 
     {
         auto s = ex::transfer_just(sched, 42) | ex::ensure_started();
-        HPX_TEST_EQ(tt::sync_wait(s), 42);
-        HPX_TEST_EQ(tt::sync_wait(s), 42);
-        HPX_TEST_EQ(tt::sync_wait(s), 42);
-        HPX_TEST_EQ(tt::sync_wait(std::move(s)), 42);
+        HPX_TEST_EQ(hpx::get<0>(*tt::sync_wait(s)), 42);
+        HPX_TEST_EQ(hpx::get<0>(*tt::sync_wait(s)), 42);
+        HPX_TEST_EQ(hpx::get<0>(*tt::sync_wait(s)), 42);
+        HPX_TEST_EQ(hpx::get<0>(*tt::sync_wait(std::move(s))), 42);
     }
 }
 
@@ -935,9 +935,10 @@ void test_ensure_started_when_all()
             ++successor_task_calls;
             return 2;
         });
-        HPX_TEST_EQ(ex::when_all(succ1, succ2) |
+        HPX_TEST_EQ(
+            hpx::get<0>(*(ex::when_all(succ1, succ2) |
                 ex::then([](int const& x, int const& y) { return x + y; }) |
-                tt::sync_wait(),
+                tt::sync_wait())),
             3);
         HPX_TEST_EQ(first_task_calls, std::size_t(1));
         HPX_TEST_EQ(successor_task_calls, std::size_t(2));
@@ -969,9 +970,10 @@ void test_ensure_started_when_all()
             ++successor_task_calls;
             return x + 2;
         });
-        HPX_TEST_EQ(ex::when_all(succ1, succ2) |
+        HPX_TEST_EQ(
+            hpx::get<0>(*(ex::when_all(succ1, succ2) |
                 ex::then([](int const& x, int const& y) { return x + y; }) |
-                tt::sync_wait(),
+                tt::sync_wait())),
             9);
         HPX_TEST_EQ(first_task_calls, std::size_t(1));
         HPX_TEST_EQ(successor_task_calls, std::size_t(2));
@@ -1002,9 +1004,10 @@ void test_ensure_started_when_all()
             ++successor_task_calls;
             return x + 2;
         });
-        HPX_TEST_EQ(ex::when_all(succ1, succ2) |
+        HPX_TEST_EQ(
+            hpx::get<0>(*(ex::when_all(succ1, succ2) |
                 ex::then([](int const& x, int const& y) { return x + y; }) |
-                tt::sync_wait(),
+                tt::sync_wait())),
             9);
         HPX_TEST_EQ(first_task_calls, std::size_t(1));
         HPX_TEST_EQ(successor_task_calls, std::size_t(2));
@@ -1021,21 +1024,21 @@ void test_split()
 
     {
         auto s = ex::transfer_just(sched, 42) | ex::split();
-        HPX_TEST_EQ(tt::sync_wait(std::move(s)), 42);
+        HPX_TEST_EQ(hpx::get<0>(*tt::sync_wait(std::move(s))), 42);
     }
 
     {
         auto s =
             ex::transfer_just(sched, 42) | ex::split() | ex::transfer(sched);
-        HPX_TEST_EQ(tt::sync_wait(std::move(s)), 42);
+        HPX_TEST_EQ(hpx::get<0>(*tt::sync_wait(std::move(s))), 42);
     }
 
     {
         auto s = ex::transfer_just(sched, 42) | ex::split();
-        HPX_TEST_EQ(tt::sync_wait(s), 42);
-        HPX_TEST_EQ(tt::sync_wait(s), 42);
-        HPX_TEST_EQ(tt::sync_wait(s), 42);
-        HPX_TEST_EQ(tt::sync_wait(std::move(s)), 42);
+        HPX_TEST_EQ(hpx::get<0>(*tt::sync_wait(s)), 42);
+        HPX_TEST_EQ(hpx::get<0>(*tt::sync_wait(s)), 42);
+        HPX_TEST_EQ(hpx::get<0>(*tt::sync_wait(s)), 42);
+        HPX_TEST_EQ(hpx::get<0>(*tt::sync_wait(std::move(s))), 42);
     }
 }
 
@@ -1056,9 +1059,10 @@ void test_split_when_all()
             ++successor_task_calls;
             return 2;
         });
-        HPX_TEST_EQ(ex::when_all(succ1, succ2) |
+        HPX_TEST_EQ(
+            hpx::get<0>(*(ex::when_all(succ1, succ2) |
                 ex::then([](int const& x, int const& y) { return x + y; }) |
-                tt::sync_wait(),
+                tt::sync_wait())),
             3);
         HPX_TEST_EQ(first_task_calls, std::size_t(1));
         HPX_TEST_EQ(successor_task_calls, std::size_t(2));
@@ -1079,9 +1083,10 @@ void test_split_when_all()
             ++successor_task_calls;
             return x + 2;
         });
-        HPX_TEST_EQ(ex::when_all(succ1, succ2) |
+        HPX_TEST_EQ(
+            hpx::get<0>(*(ex::when_all(succ1, succ2) |
                 ex::then([](int const& x, int const& y) { return x + y; }) |
-                tt::sync_wait(),
+                tt::sync_wait())),
             9);
         HPX_TEST_EQ(first_task_calls, std::size_t(1));
         HPX_TEST_EQ(successor_task_calls, std::size_t(2));
@@ -1102,9 +1107,10 @@ void test_split_when_all()
             ++successor_task_calls;
             return x + 2;
         });
-        HPX_TEST_EQ(ex::when_all(succ1, succ2) |
+        HPX_TEST_EQ(
+            hpx::get<0>(*(ex::when_all(succ1, succ2) |
                 ex::then([](int const& x, int const& y) { return x + y; }) |
-                tt::sync_wait(),
+                tt::sync_wait())),
             9);
         HPX_TEST_EQ(first_task_calls, std::size_t(1));
         HPX_TEST_EQ(successor_task_calls, std::size_t(2));
@@ -1117,67 +1123,70 @@ void test_let_value()
 
     // void predecessor
     {
-        auto result = ex::schedule(sched) |
-            ex::let_value([]() { return ex::just(42); }) | tt::sync_wait();
+        auto result = hpx::get<0>(*(ex::schedule(sched) |
+            ex::let_value([]() { return ex::just(42); }) | tt::sync_wait()));
         HPX_TEST_EQ(result, 42);
     }
 
     {
-        auto result = ex::schedule(sched) |
-            ex::let_value([=]() { return ex::transfer_just(sched, 42); }) |
-            tt::sync_wait();
+        auto result = hpx::get<0>(*(ex::schedule(sched) | ex::let_value([=]() {
+            return ex::transfer_just(sched, 42);
+        }) | tt::sync_wait()));
         HPX_TEST_EQ(result, 42);
     }
 
     {
-        auto result = ex::just() |
-            ex::let_value([=]() { return ex::transfer_just(sched, 42); }) |
-            tt::sync_wait();
+        auto result = hpx::get<0>(*(ex::just() | ex::let_value([=]() {
+            return ex::transfer_just(sched, 42);
+        }) | tt::sync_wait()));
         HPX_TEST_EQ(result, 42);
     }
 
     // int predecessor, value ignored
     {
-        auto result = ex::transfer_just(sched, 43) |
-            ex::let_value([](int&) { return ex::just(42); }) | tt::sync_wait();
+        auto result = hpx::get<0>(*(ex::transfer_just(sched, 43) |
+            ex::let_value([](int&) { return ex::just(42); }) |
+            tt::sync_wait()));
         HPX_TEST_EQ(result, 42);
     }
 
     {
-        auto result = ex::transfer_just(sched, 43) |
+        auto result = hpx::get<0>(*(ex::transfer_just(sched, 43) |
             ex::let_value([=](int&) { return ex::transfer_just(sched, 42); }) |
-            tt::sync_wait();
+            tt::sync_wait()));
         HPX_TEST_EQ(result, 42);
     }
 
     {
-        auto result = ex::just(43) |
-            ex::let_value([=](int&) { return ex::transfer_just(sched, 42); }) |
-            tt::sync_wait();
+        auto result = hpx::get<0>(*(ex::just(43) | ex::let_value([=](int&) {
+            return ex::transfer_just(sched, 42);
+        }) | tt::sync_wait()));
         HPX_TEST_EQ(result, 42);
     }
 
     // int predecessor, value used
     {
-        auto result = ex::transfer_just(sched, 43) | ex::let_value([](int& x) {
-            return ex::just(42) | ex::then([&](int y) { return x + y; });
-        }) | tt::sync_wait();
+        auto result = hpx::get<0>(
+            *(ex::transfer_just(sched, 43) | ex::let_value([](int& x) {
+                return ex::just(42) | ex::then([&](int y) { return x + y; });
+            }) | tt::sync_wait()));
         HPX_TEST_EQ(result, 85);
     }
 
     {
-        auto result = ex::transfer_just(sched, 43) | ex::let_value([=](int& x) {
-            return ex::transfer_just(sched, 42) |
-                ex::then([&](int y) { return x + y; });
-        }) | tt::sync_wait();
+        auto result = hpx::get<0>(
+            *(ex::transfer_just(sched, 43) | ex::let_value([=](int& x) {
+                return ex::transfer_just(sched, 42) |
+                    ex::then([&](int y) { return x + y; });
+            }) | tt::sync_wait()));
         HPX_TEST_EQ(result, 85);
     }
 
     {
-        auto result = ex::just(43) | ex::let_value([=](int& x) {
+        auto result = hpx::get<0>(*(ex::just(43) | ex::let_value([=](int& x) {
             return ex::transfer_just(sched, 42) |
                 ex::then([&](int y) { return x + y; });
-        }) | tt::sync_wait();
+        }) | tt::sync_wait()));
         HPX_TEST_EQ(result, 85);
     }
 
@@ -1265,64 +1274,65 @@ void test_let_error()
 
     // int predecessor
     {
-        auto result = ex::schedule(sched) | ex::then([]() {
+        auto result = hpx::get<0>(*(ex::schedule(sched) | ex::then([]() {
             throw std::runtime_error("error");
             return 43;
         }) | ex::let_error([](std::exception_ptr& ep) {
             check_exception_ptr_message(ep, "error");
             return ex::just(42);
-        }) | tt::sync_wait();
+        }) | tt::sync_wait()));
         HPX_TEST_EQ(result, 42);
     }
 
     {
-        auto result = ex::schedule(sched) | ex::then([]() {
+        auto result = hpx::get<0>(*(ex::schedule(sched) | ex::then([]() {
             throw std::runtime_error("error");
             return 43;
         }) | ex::let_error([=](std::exception_ptr& ep) {
             check_exception_ptr_message(ep, "error");
             return ex::transfer_just(sched, 42);
-        }) | tt::sync_wait();
+        }) | tt::sync_wait()));
         HPX_TEST_EQ(result, 42);
     }
 
     {
-        auto result = ex::just() | ex::then([]() {
+        auto result = hpx::get<0>(*(ex::just() | ex::then([]() {
             throw std::runtime_error("error");
             return 43;
         }) | ex::let_error([=](std::exception_ptr& ep) {
             check_exception_ptr_message(ep, "error");
             return ex::transfer_just(sched, 42);
-        }) | tt::sync_wait();
+        }) | tt::sync_wait()));
         HPX_TEST_EQ(result, 42);
     }
 
     // predecessor doesn't throw, let sender is ignored
     {
-        auto result = ex::transfer_just(sched, 42) |
+        auto result = hpx::get<0>(*(ex::transfer_just(sched, 42) |
             ex::let_error([](std::exception_ptr) {
                 HPX_TEST(false);
                 return ex::just(43);
             }) |
-            tt::sync_wait();
+            tt::sync_wait()));
         HPX_TEST_EQ(result, 42);
     }
 
     {
-        auto result = ex::transfer_just(sched, 42) |
+        auto result = hpx::get<0>(*(ex::transfer_just(sched, 42) |
             ex::let_error([=](std::exception_ptr) {
                 HPX_TEST(false);
                 return ex::transfer_just(sched, 43);
             }) |
-            tt::sync_wait();
+            tt::sync_wait()));
         HPX_TEST_EQ(result, 42);
     }
 
     {
-        auto result = ex::just(42) | ex::let_error([=](std::exception_ptr) {
-            HPX_TEST(false);
-            return ex::transfer_just(sched, 43);
-        }) | tt::sync_wait();
+        auto result =
+            hpx::get<0>(*(ex::just(42) | ex::let_error([=](std::exception_ptr) {
+                HPX_TEST(false);
+                return ex::transfer_just(sched, 43);
+            }) | tt::sync_wait()));
         HPX_TEST_EQ(result, 42);
     }
 }
@@ -1469,8 +1479,9 @@ void test_keep_future_sender()
             return 42;
         });
 
-        HPX_TEST_EQ(tt::sync_wait(ex::then(std::move(f) | ex::keep_future(),
-                        [](hpx::future<int>&& f) { return f.get() / 2; })),
+        HPX_TEST_EQ(hpx::get<0>(*tt::sync_wait(
+                        ex::then(std::move(f) | ex::keep_future(),
+                            [](hpx::future<int>&& f) { return f.get() / 2; }))),
             21);
         HPX_TEST(called);
     }
@@ -1569,9 +1580,9 @@ void test_keep_future_sender()
 
         auto fun = hpx::unwrapping(
             [](int&& x, double const& y) { return x * 2 + (int(y) / 2); });
-        HPX_TEST_EQ(ex::when_all(std::move(f) | ex::keep_future(),
-                        sf | ex::keep_future()) |
-                ex::then(fun) | tt::sync_wait(),
+        HPX_TEST_EQ(hpx::get<0>(*(ex::when_all(std::move(f) | ex::keep_future(),
+                                      sf | ex::keep_future()) |
+                        ex::then(fun) | tt::sync_wait())),
             85);
     }
 
@@ -1581,10 +1592,10 @@ void test_keep_future_sender()
 
         auto fun = hpx::unwrapping(
             [](int&& x, double const& y) { return x * 2 + (int(y) / 2); });
-        HPX_TEST_EQ(ex::when_all(std::move(f) | ex::keep_future(),
-                        sf | ex::keep_future()) |
-                ex::transfer(ex::thread_pool_scheduler{}) | ex::then(fun) |
-                tt::sync_wait(),
+        HPX_TEST_EQ(hpx::get<0>(*(ex::when_all(std::move(f) | ex::keep_future(),
+                                      sf | ex::keep_future()) |
+                        ex::transfer(ex::thread_pool_scheduler{}) |
+                        ex::then(fun) | tt::sync_wait())),
             85);
     }
 }

--- a/libs/core/executors/tests/unit/thread_pool_scheduler.cpp
+++ b/libs/core/executors/tests/unit/thread_pool_scheduler.cpp
@@ -679,8 +679,9 @@ void test_future_sender()
         static_assert(ex::is_sender_v<std::decay_t<decltype(f)>>,
             "a future should be a sender");
         static_assert(
-            std::is_void<decltype(tt::sync_wait(std::move(f)))>::value,
-            "sync_wait should return void");
+            std::is_same_v<std::decay_t<decltype(*tt::sync_wait(std::move(f)))>,
+                hpx::tuple<>>,
+            "sync_wait should return hpx::tuple<>");
 
         tt::sync_wait(std::move(f));
         HPX_TEST(called);
@@ -735,8 +736,8 @@ void test_future_sender()
             return 42;
         });
 
-        HPX_TEST_EQ(
-            tt::sync_wait(ex::then(std::move(f), [](int x) { return x / 2; })),
+        HPX_TEST_EQ(hpx::get<0>(*tt::sync_wait(
+                        ex::then(std::move(f), [](int x) { return x / 2; }))),
             21);
         HPX_TEST(called);
     }
@@ -747,9 +748,10 @@ void test_future_sender()
 
         static_assert(ex::is_sender_v<std::decay_t<decltype(sf)>>,
             "a shared_future should be a sender");
-        static_assert(
-            std::is_void<decltype(tt::sync_wait(std::move(sf)))>::value,
-            "sync_wait should return void");
+        static_assert(std::is_same_v<
+                          std::decay_t<decltype(*tt::sync_wait(std::move(sf)))>,
+                          hpx::tuple<>>,
+            "sync_wait should return hpx::tuple<>");
 
         tt::sync_wait(sf);
         tt::sync_wait(sf);


### PR DESCRIPTION
Issue:
_sync_wait implementation assumes the senders send only one single value. (Actually, senders can pass several values);
sync_wait looks at the variant of the predecessor and makes sure that it contains one tuple with one element._
which is not conform to the description of sync_wait in P2300.

revamp :
The result_type should be optional of the variant of the tuples;
The sync_wait works when the variant has one tuple( no matter how many elements in the tuple)