### PR TITLE
Fix building on musl.

### DIFF
--- a/components/performance_counters/memory/src/mem_counter_linux.cpp
+++ b/components/performance_counters/memory/src/mem_counter_linux.cpp
@@ -14,6 +14,11 @@
 #include <sys/types.h>
 #include <unistd.h>
 
+// Fix for musl. Use linux/param.h for EXEC_PAGESIZE
+#ifdef __linux__
+#include <linux/param.h>
+#endif
+
 #include <hpx/modules/errors.hpp>
 #include <hpx/modules/format.hpp>
 

--- a/libs/core/coroutines/include/hpx/coroutines/detail/context_linux_x86.hpp
+++ b/libs/core/coroutines/include/hpx/coroutines/detail/context_linux_x86.hpp
@@ -37,6 +37,11 @@
 #include <stdexcept>
 #include <sys/param.h>
 
+// Fix for musl. Use linux/param.h for EXEC_PAGESIZE
+#ifdef __linux__
+#include <linux/param.h>
+#endif
+
 #if defined(HPX_HAVE_STACKOVERFLOW_DETECTION)
 
 #include <cstring>

--- a/libs/core/coroutines/include/hpx/coroutines/detail/posix_utility.hpp
+++ b/libs/core/coroutines/include/hpx/coroutines/detail/posix_utility.hpp
@@ -55,6 +55,10 @@
 #include <sys/param.h>
 
 #include <stdexcept>
+// Fix for musl. Use linux/param.h for EXEC_PAGESIZE
+#ifdef __linux__
+#include <linux/param.h>
+#endif
 #endif
 
 #if defined(__FreeBSD__)

--- a/libs/core/debugging/src/backtrace.cpp
+++ b/libs/core/debugging/src/backtrace.cpp
@@ -19,7 +19,9 @@
 
 #if (defined(__linux) || defined(__APPLE__) || defined(__sun)) &&              \
     (!defined(__ANDROID__) || !defined(ANDROID))
+#if defined(__GLIBC__)
 #define HPX_HAVE_EXECINFO
+#endif
 #define HPX_HAVE_DLFCN
 #if defined(__GNUC__) && !defined(__clang__)
 #define HPX_HAVE_UNWIND

--- a/libs/core/plugin/include/hpx/plugin/detail/dll_dlopen.hpp
+++ b/libs/core/plugin/include/hpx/plugin/detail/dll_dlopen.hpp
@@ -319,6 +319,7 @@ namespace hpx { namespace util { namespace plugin {
             std::string result;
 
 #if !defined(__ANDROID__) && !defined(ANDROID) && !defined(__APPLE__)
+#if defined(RTLD_DI_ORIGIN)
             char directory[PATH_MAX] = {'\0'};
             const_cast<dll&>(*this).LoadLibrary(ec);
             if (!ec && ::dlinfo(dll_handle, RTLD_DI_ORIGIN, directory) < 0)
@@ -333,6 +334,9 @@ namespace hpx { namespace util { namespace plugin {
             }
             result = directory;
             ::dlerror();    // Clear the error state.
+#else
+            result = path(dll_name).parent_path().string();
+#endif
 #elif defined(__APPLE__)
             // SO staticfloat's solution
             const_cast<dll&>(*this).LoadLibrary(ec);


### PR DESCRIPTION
These are some patches that make it possible to build hpx on musl.


Signed-off-by: brahmajit das <brahmajit.xyz@gmail.com>

Fixes #5946

## Proposed Changes

- EXEC_PAGESIZE is not defined under musl so including linux/param.h
  where it should be defined. Header linux/param.h does not depend on
  any libc and hence can use included on any linux system.
- execinfo.h is only present on glibc and ulibc, but not on musl so
  before defining HPX_HAVE_EXECINFO it's being checked whether we're on
  a glibc or ulibc system
- RTLD_DI_ORIGIN is not present on musl, hence the alternate
  the solution is implemented if RTLD_DI_ORIGIN is undefined.

## Any background context you want to provide?

hpx was failing to build with musl libc, these patches should fix them without affecting other libc systems

## Checklist

- [ ] I have added a new feature and have added tests to go along with it.
- [ ] I have fixed a bug and have added a regression test.
- [ ] I have added a test using random numbers; I have made sure it uses a seed, and that random numbers generated are valid inputs for the tests.
