### PR TITLE
Adding support for pure sender/receiver based executors to parallel algorithms

### DIFF
--- a/cmake/HPX_AddConfigTest.cmake
+++ b/cmake/HPX_AddConfigTest.cmake
@@ -440,6 +440,15 @@ function(hpx_check_for_cxx17_copy_elision)
 endfunction()
 
 # ##############################################################################
+function(hpx_check_for_cxx17_optional_copy_elision)
+  add_hpx_config_test(
+    HPX_WITH_CXX17_OPTIONAL_COPY_ELISION
+    SOURCE cmake/tests/cxx17_optional_copy_elision.cpp
+    FILE ${ARGN}
+  )
+endfunction()
+
+# ##############################################################################
 function(hpx_check_for_cxx20_coroutines)
   if(NOT HPX_WITH_CXX20_COROUTINES)
     unset(HPX_CXX20_COROUTINES_FLAGS)

--- a/cmake/HPX_PerformCxxFeatureTests.cmake
+++ b/cmake/HPX_PerformCxxFeatureTests.cmake
@@ -77,6 +77,10 @@ function(hpx_perform_cxx_feature_tests)
 
   hpx_check_for_cxx17_copy_elision(DEFINITIONS HPX_HAVE_CXX17_COPY_ELISION)
 
+  hpx_check_for_cxx17_optional_copy_elision(
+    DEFINITIONS HPX_HAVE_CXX17_OPTIONAL_COPY_ELISION
+  )
+
   # C++20 feature tests
   if(HPX_WITH_CXX_STANDARD GREATER_EQUAL 20)
     hpx_check_for_cxx20_coroutines(DEFINITIONS HPX_HAVE_CXX20_COROUTINES)

--- a/cmake/tests/cxx17_optional_copy_elision.cpp
+++ b/cmake/tests/cxx17_optional_copy_elision.cpp
@@ -1,0 +1,57 @@
+//  Copyright (c) 2021 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+// we know that the sender/receiver functionalities require proper
+// implementation of copy elision, and MSVC currently doesn't get
+// this quite right
+
+#include <new>
+#include <optional>
+#include <utility>
+
+template <typename F>
+class with_result_of_t
+{
+    F&& f;
+
+public:
+    using type = decltype(std::declval<F&&>()());
+
+    explicit with_result_of_t(F&& f)
+      : f(std::forward<F>(f))
+    {
+    }
+    operator type()
+    {
+        return std::forward<F>(f)();
+    }
+};
+
+template <typename F>
+inline with_result_of_t<F> with_result_of(F&& f)
+{
+    return with_result_of_t<F>(std::forward<F>(f));
+}
+
+struct cant_do_anything
+{
+    cant_do_anything() = default;
+    cant_do_anything(cant_do_anything&&) = delete;
+    cant_do_anything(cant_do_anything const&) = delete;
+    cant_do_anything& operator=(cant_do_anything&&) = delete;
+    cant_do_anything& operator=(cant_do_anything const&) = delete;
+};
+
+cant_do_anything f()
+{
+    return {};
+}
+
+int main()
+{
+    std::optional<cant_do_anything> value;
+    value.emplace(with_result_of(&f));
+}

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/detail/dispatch.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/detail/dispatch.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2021 Hartmut Kaiser
+//  Copyright (c) 2007-2022 Hartmut Kaiser
 //  Copyright (c) 2021 Giannis Gonidelis
 //
 //  SPDX-License-Identifier: BSL-1.0
@@ -20,6 +20,7 @@
 #include <hpx/parallel/util/detail/scoped_executor_parameters.hpp>
 #include <hpx/parallel/util/result_types.hpp>
 #include <hpx/serialization/serialization_fwd.hpp>
+#include <hpx/type_support/unused.hpp>
 
 #if defined(HPX_HAVE_CXX17_STD_EXECUTION_POLICES)
 #include <execution>
@@ -103,9 +104,8 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
         ///////////////////////////////////////////////////////////////////////
         // this equivalent to sequential execution
         template <typename ExPolicy, typename... Args>
-        HPX_HOST_DEVICE hpx::parallel::util::detail::algorithm_result_t<
-            ExPolicy, local_result_type>
-        operator()(ExPolicy&& policy, Args&&... args) const
+        HPX_HOST_DEVICE decltype(auto) operator()(
+            ExPolicy&& policy, Args&&... args) const
         {
 #if !defined(__CUDA_ARCH__)
             try
@@ -120,17 +120,19 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
                     parameters_type, executor_type>
                     scoped_param(policy.parameters(), policy.executor());
 
-                return hpx::parallel::util::detail::
-                    algorithm_result<ExPolicy, local_result_type>::get(
-                        Derived::sequential(HPX_FORWARD(ExPolicy, policy),
-                            HPX_FORWARD(Args, args)...));
+                return Derived::sequential(
+                    HPX_FORWARD(ExPolicy, policy), HPX_FORWARD(Args, args)...);
 #if !defined(__CUDA_ARCH__)
             }
             catch (...)
             {
                 // this does not return
-                return hpx::parallel::v1::detail::handle_exception<ExPolicy,
-                    local_result_type>::call();
+                using policy_type =
+                    decltype(hpx::execution::experimental::to_non_task(
+                        std::declval<ExPolicy&&>()));
+                return hpx::parallel::v1::detail::handle_exception<policy_type,
+                    std::conditional_t<std::is_void_v<local_result_type>,
+                        hpx::util::unused_type, local_result_type>>::call();
             }
 #endif
         }
@@ -140,17 +142,29 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
         // main sequential dispatch entry points
 
         template <typename ExPolicy, typename... Args>
-        constexpr hpx::parallel::util::detail::algorithm_result_t<ExPolicy,
-            local_result_type>
-        call2(ExPolicy&& policy, std::true_type, Args&&... args) const
+        constexpr decltype(auto) call2(
+            ExPolicy&& policy, std::true_type, Args&&... args) const
         {
             using result_handler =
                 hpx::parallel::util::detail::algorithm_result<ExPolicy,
                     local_result_type>;
 
             auto exec = policy.executor();    // avoid move after use
-            if constexpr (hpx::is_async_execution_policy_v<
+            if constexpr (hpx::execution_policy_has_scheduler_executor_v<
                               std::decay_t<ExPolicy>>)
+            {
+                // specialization for all execution policies that wrap sender
+                // based executors
+
+                // create a sender running the launched task
+                return result_handler::get(
+                    execution::async_execute(HPX_MOVE(exec), derived(),
+                        hpx::execution::experimental::to_non_task(
+                            HPX_FORWARD(ExPolicy, policy)),
+                        HPX_FORWARD(Args, args)...));
+            }
+            else if constexpr (hpx::is_async_execution_policy_v<
+                                   std::decay_t<ExPolicy>>)
             {
                 // specialization for all task-based (asynchronous) execution
                 // policies
@@ -176,18 +190,16 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
 
         // main parallel dispatch entry point
         template <typename ExPolicy, typename... Args>
-        HPX_FORCEINLINE static constexpr hpx::parallel::util::detail::
-            algorithm_result_t<ExPolicy, local_result_type>
-            call2(ExPolicy&& policy, std::false_type, Args&&... args)
+        HPX_FORCEINLINE static constexpr decltype(auto) call2(
+            ExPolicy&& policy, std::false_type, Args&&... args)
         {
             return Derived::parallel(
                 HPX_FORWARD(ExPolicy, policy), HPX_FORWARD(Args, args)...);
         }
 
         template <typename ExPolicy, typename... Args>
-        HPX_FORCEINLINE constexpr hpx::parallel::util::detail::
-            algorithm_result_t<ExPolicy, local_result_type>
-            call(ExPolicy&& policy, Args&&... args) const
+        HPX_FORCEINLINE constexpr decltype(auto) call(
+            ExPolicy&& policy, Args&&... args) const
         {
             using is_seq = hpx::is_sequenced_execution_policy<ExPolicy>;
             return call2(HPX_FORWARD(ExPolicy, policy), is_seq(),
@@ -197,31 +209,24 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
 #if defined(HPX_HAVE_CXX17_STD_EXECUTION_POLICES)
         // main dispatch entry points for std execution policies
         template <typename... Args>
-        HPX_FORCEINLINE constexpr hpx::parallel::util::detail::
-            algorithm_result_t<hpx::execution::sequenced_policy,
-                local_result_type>
-            call(std::execution::sequenced_policy, Args&&... args) const
+        HPX_FORCEINLINE constexpr decltype(auto) call(
+            std::execution::sequenced_policy, Args&&... args) const
         {
             return call2(hpx::execution::seq, std::true_type(),
                 HPX_FORWARD(Args, args)...);
         }
 
         template <typename... Args>
-        HPX_FORCEINLINE constexpr hpx::parallel::util::detail::
-            algorithm_result_t<hpx::execution::parallel_policy,
-                local_result_type>
-            call(std::execution::parallel_policy, Args&&... args) const
+        HPX_FORCEINLINE constexpr decltype(auto) call(
+            std::execution::parallel_policy, Args&&... args) const
         {
             return call2(hpx::execution::par, std::false_type(),
                 HPX_FORWARD(Args, args)...);
         }
 
         template <typename... Args>
-        HPX_FORCEINLINE constexpr hpx::parallel::util::detail::
-            algorithm_result_t<hpx::execution::parallel_unsequenced_policy,
-                local_result_type>
-            call(std::execution::parallel_unsequenced_policy,
-                Args&&... args) const
+        HPX_FORCEINLINE constexpr decltype(auto) call(
+            std::execution::parallel_unsequenced_policy, Args&&... args) const
         {
             return call2(hpx::execution::par_unseq, std::false_type(),
                 HPX_FORWARD(Args, args)...);
@@ -229,10 +234,8 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
 
 #if defined(HPX_HAVE_CXX20_STD_EXECUTION_POLICES)
         template <typename... Args>
-        HPX_FORCEINLINE constexpr hpx::parallel::util::detail::
-            algorithm_result_t<hpx::execution::unsequenced_policy,
-                local_result_type>
-            call(std::execution::unsequenced_policy, Args&&... args) const
+        HPX_FORCEINLINE constexpr decltype(auto) call(
+            std::execution::unsequenced_policy, Args&&... args) const
         {
             return call2(hpx::execution::unseq, std::false_type(),
                 HPX_FORWARD(Args, args)...);

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/for_each.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/for_each.hpp
@@ -253,6 +253,7 @@ namespace hpx {
 #include <hpx/parallel/util/detail/sender_util.hpp>
 #include <hpx/parallel/util/foreach_partitioner.hpp>
 #include <hpx/parallel/util/loop.hpp>
+#include <hpx/parallel/util/partitioner.hpp>
 #include <hpx/parallel/util/projection_identity.hpp>
 
 #include <algorithm>
@@ -365,6 +366,14 @@ namespace hpx { namespace parallel { inline namespace v1 {
 
             template <typename Iter>
             HPX_HOST_DEVICE HPX_FORCEINLINE constexpr void operator()(
+                Iter part_begin, std::size_t part_size)
+            {
+                util::loop_n<execution_policy_type>(part_begin, part_size,
+                    invoke_projected<fun_type, proj_type>{f_, proj_});
+            }
+
+            template <typename Iter>
+            HPX_HOST_DEVICE HPX_FORCEINLINE constexpr void operator()(
                 Iter part_begin, std::size_t part_size, std::size_t)
             {
                 util::loop_n<execution_policy_type>(part_begin, part_size,
@@ -413,7 +422,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
 
             template <typename Iter>
             HPX_HOST_DEVICE HPX_FORCEINLINE constexpr void operator()(
-                Iter part_begin, std::size_t part_size, std::size_t)
+                Iter part_begin, std::size_t part_size)
             {
                 using value_type = std::decay_t<
                     typename std::iterator_traits<Iter>::reference>;
@@ -427,6 +436,13 @@ namespace hpx { namespace parallel { inline namespace v1 {
                     util::loop_n_ind<execution_policy_type>(
                         part_begin, part_size, f_);
                 }
+            }
+
+            template <typename Iter>
+            HPX_HOST_DEVICE HPX_FORCEINLINE constexpr void operator()(
+                Iter part_begin, std::size_t part_size, std::size_t)
+            {
+                return (*this)(part_begin, part_size);
             }
         };
 
@@ -463,19 +479,22 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 ExPolicy&& policy, FwdIter first, std::size_t count, F&& f,
                 Proj&& proj /* = Proj()*/)
             {
-                if (count != 0)
+                if constexpr (!hpx::execution_policy_has_scheduler_executor_v<
+                                  ExPolicy>)
                 {
-                    auto f1 =
-                        for_each_iteration<ExPolicy, F, std::decay_t<Proj>>(
-                            HPX_FORWARD(F, f), HPX_FORWARD(Proj, proj));
-
-                    return util::foreach_partitioner<ExPolicy>::call(
-                        HPX_FORWARD(ExPolicy, policy), first, count,
-                        HPX_MOVE(f1), util::projection_identity());
+                    if (count == 0)
+                    {
+                        return util::detail::algorithm_result<ExPolicy,
+                            FwdIter>::get(HPX_MOVE(first));
+                    }
                 }
 
-                return util::detail::algorithm_result<ExPolicy, FwdIter>::get(
-                    HPX_MOVE(first));
+                auto f1 = for_each_iteration<ExPolicy, F, std::decay_t<Proj>>(
+                    HPX_FORWARD(F, f), HPX_FORWARD(Proj, proj));
+
+                return util::foreach_partitioner<ExPolicy>::call(
+                    HPX_FORWARD(ExPolicy, policy), first, count, HPX_MOVE(f1),
+                    hpx::identity());
             }
         };
         /// \endcond
@@ -540,20 +559,22 @@ namespace hpx { namespace parallel { inline namespace v1 {
                     hpx::parallel::util::detail::algorithm_result<ExPolicy,
                         FwdIterB>;
 
-                //if (first != last)
+                if constexpr (!hpx::execution_policy_has_scheduler_executor_v<
+                                  ExPolicy>)
                 {
-                    auto f1 =
-                        for_each_iteration<ExPolicy, F, std::decay_t<Proj>>(
-                            HPX_FORWARD(F, f), HPX_FORWARD(Proj, proj));
-
-                    return result_t::get(
-                        util::foreach_partitioner<ExPolicy>::call(
-                            HPX_FORWARD(ExPolicy, policy), first,
-                            detail::distance(first, last), HPX_MOVE(f1),
-                            util::projection_identity()));
+                    if (first == last)
+                    {
+                        return result_t::get(HPX_MOVE(first));
+                    }
                 }
 
-                //return result_t::get(HPX_MOVE(first));
+                auto f1 = for_each_iteration<ExPolicy, F, std::decay_t<Proj>>(
+                    HPX_FORWARD(F, f), HPX_FORWARD(Proj, proj));
+
+                return result_t::get(util::foreach_partitioner<ExPolicy>::call(
+                    HPX_FORWARD(ExPolicy, policy), first,
+                    detail::distance(first, last), HPX_MOVE(f1),
+                    hpx::identity()));
             }
         };
         /// \endcond

--- a/libs/core/algorithms/include/hpx/parallel/container_algorithms/for_loop.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/container_algorithms/for_loop.hpp
@@ -746,31 +746,30 @@ namespace hpx::ranges::experimental {
         // clang-format off
         template <typename ExPolicy, typename Iter, typename Sent, typename... Args,
             HPX_CONCEPT_REQUIRES_(
-                hpx::is_execution_policy<ExPolicy>::value &&
-                hpx::traits::is_iterator<Iter>::value &&
-                hpx::traits::is_sentinel_for<Sent, Iter>::value
+                hpx::is_execution_policy_v<ExPolicy> &&
+                hpx::traits::is_iterator_v<Iter> &&
+                hpx::traits::is_sentinel_for_v<Sent, Iter>
             )>
         // clang-format on
-        friend typename hpx::parallel::util::detail::algorithm_result<
-            ExPolicy>::type
+        friend hpx::parallel::util::detail::algorithm_result_t<ExPolicy>
         tag_fallback_invoke(hpx::ranges::experimental::for_loop_t,
             ExPolicy&& policy, Iter first, Sent last, Args&&... args)
         {
             static_assert(sizeof...(Args) >= 1,
                 "for_loop must be called with at least a function object");
 
-            using hpx::util::make_index_pack;
+            using hpx::util::make_index_pack_t;
             return hpx::parallel::v2::detail::for_loop(
-                HPX_FORWARD(ExPolicy, policy), first, last, 1,
-                typename make_index_pack<sizeof...(Args) - 1>::type(),
+                HPX_FORWARD(ExPolicy, policy), first, last,
+                make_index_pack_t<sizeof...(Args) - 1>(),
                 HPX_FORWARD(Args, args)...);
         }
 
         // clang-format off
         template <typename Iter, typename Sent, typename... Args,
             HPX_CONCEPT_REQUIRES_(
-                hpx::traits::is_iterator<Iter>::value &&
-                hpx::traits::is_sentinel_for<Sent, Iter>::value
+                hpx::traits::is_iterator_v<Iter> &&
+                hpx::traits::is_sentinel_for_v<Sent, Iter>
             )>
         // clang-format on
         friend void tag_fallback_invoke(hpx::ranges::experimental::for_loop_t,
@@ -779,40 +778,37 @@ namespace hpx::ranges::experimental {
             static_assert(sizeof...(Args) >= 1,
                 "for_loop must be called with at least a function object");
 
-            using hpx::util::make_index_pack;
+            using hpx::util::make_index_pack_t;
             return hpx::parallel::v2::detail::for_loop(hpx::execution::seq,
-                first, last, 1,
-                typename make_index_pack<sizeof...(Args) - 1>::type(),
+                first, last, make_index_pack_t<sizeof...(Args) - 1>(),
                 HPX_FORWARD(Args, args)...);
         }
 
         // clang-format off
         template <typename ExPolicy, typename R, typename... Args,
             HPX_CONCEPT_REQUIRES_(
-                hpx::is_execution_policy<ExPolicy>::value &&
+                hpx::is_execution_policy_v<ExPolicy> &&
                 hpx::traits::is_range<R>::value
             )>
         // clang-format on
-        friend typename hpx::parallel::util::detail::algorithm_result<
-            ExPolicy>::type
+        friend hpx::parallel::util::detail::algorithm_result_t<ExPolicy>
         tag_fallback_invoke(hpx::ranges::experimental::for_loop_t,
             ExPolicy&& policy, R&& rng, Args&&... args)
         {
             static_assert(sizeof...(Args) >= 1,
                 "for_loop must be called with at least a function object");
 
-            using hpx::util::make_index_pack;
+            using hpx::util::make_index_pack_t;
             return hpx::parallel::v2::detail::for_loop(
                 HPX_FORWARD(ExPolicy, policy), hpx::util::begin(rng),
-                hpx::util::end(rng), 1,
-                typename make_index_pack<sizeof...(Args) - 1>::type(),
+                hpx::util::end(rng), make_index_pack_t<sizeof...(Args) - 1>(),
                 HPX_FORWARD(Args, args)...);
         }
 
         // clang-format off
         template <typename Rng, typename... Args,
             HPX_CONCEPT_REQUIRES_(
-                hpx::traits::is_range<Rng>::value
+                hpx::traits::is_range_v<Rng>
             )>
         // clang-format on
         friend void tag_fallback_invoke(
@@ -821,10 +817,10 @@ namespace hpx::ranges::experimental {
             static_assert(sizeof...(Args) >= 1,
                 "for_loop must be called with at least a function object");
 
-            using hpx::util::make_index_pack;
+            using hpx::util::make_index_pack_t;
             return hpx::parallel::v2::detail::for_loop(hpx::execution::seq,
-                hpx::util::begin(rng), hpx::util::end(rng), 1,
-                typename make_index_pack<sizeof...(Args) - 1>::type(),
+                hpx::util::begin(rng), hpx::util::end(rng),
+                make_index_pack_t<sizeof...(Args) - 1>(),
                 HPX_FORWARD(Args, args)...);
         }
     } for_loop{};
@@ -837,13 +833,13 @@ namespace hpx::ranges::experimental {
         template <typename ExPolicy, typename Iter, typename Sent, typename S,
             typename... Args,
             HPX_CONCEPT_REQUIRES_(
-                hpx::is_execution_policy<ExPolicy>::value &&
-                std::is_integral<S>::value &&
-                hpx::traits::is_iterator<Iter>::value &&
-                hpx::traits::is_sentinel_for<Sent, Iter>::value
+                hpx::is_execution_policy_v<ExPolicy> &&
+                std::is_integral_v<S> &&
+                hpx::traits::is_iterator_v<Iter> &&
+                hpx::traits::is_sentinel_for_v<Sent, Iter>
             )>
         // clang-format on
-        friend typename parallel::util::detail::algorithm_result<ExPolicy>::type
+        friend parallel::util::detail::algorithm_result_t<ExPolicy>
         tag_fallback_invoke(hpx::ranges::experimental::for_loop_strided_t,
             ExPolicy&& policy, Iter first, Sent last, S stride, Args&&... args)
         {
@@ -851,19 +847,19 @@ namespace hpx::ranges::experimental {
                 "for_loop_strided must be called with at least a function "
                 "object");
 
-            using hpx::util::make_index_pack;
-            return hpx::parallel::v2::detail::for_loop(
+            using hpx::util::make_index_pack_t;
+            return hpx::parallel::v2::detail::for_loop_strided(
                 HPX_FORWARD(ExPolicy, policy), first, last, stride,
-                typename make_index_pack<sizeof...(Args) - 1>::type(),
+                make_index_pack_t<sizeof...(Args) - 1>(),
                 HPX_FORWARD(Args, args)...);
         }
 
         // clang-format off
         template <typename Iter, typename Sent, typename S, typename... Args,
             HPX_CONCEPT_REQUIRES_(
-                std::is_integral<S>::value &&
-                hpx::traits::is_iterator<Iter>::value &&
-                hpx::traits::is_sentinel_for<Sent, Iter>::value
+                std::is_integral_v<S> &&
+                hpx::traits::is_iterator_v<Iter> &&
+                hpx::traits::is_sentinel_for_v<Sent, Iter>
             )>
         // clang-format on
         friend void tag_fallback_invoke(
@@ -874,23 +870,22 @@ namespace hpx::ranges::experimental {
                 "for_loop_strided must be called with at least a function "
                 "object");
 
-            using hpx::util::make_index_pack;
-            return hpx::parallel::v2::detail::for_loop(hpx::execution::seq,
-                first, last, stride,
-                typename make_index_pack<sizeof...(Args) - 1>::type(),
+            using hpx::util::make_index_pack_t;
+            return hpx::parallel::v2::detail::for_loop_strided(
+                hpx::execution::seq, first, last, stride,
+                make_index_pack_t<sizeof...(Args) - 1>(),
                 HPX_FORWARD(Args, args)...);
         }
 
         // clang-format off
         template <typename ExPolicy, typename Rng, typename S, typename... Args,
             HPX_CONCEPT_REQUIRES_(
-                hpx::is_execution_policy<ExPolicy>::value &&
-                std::is_integral<S>::value &&
-                hpx::traits::is_range<Rng>::value
+                hpx::is_execution_policy_v<ExPolicy> &&
+                std::is_integral_v<S> &&
+                hpx::traits::is_range_v<Rng>
             )>
         // clang-format on
-        friend typename hpx::parallel::util::detail::algorithm_result<
-            ExPolicy>::type
+        friend hpx::parallel::util::detail::algorithm_result_t<ExPolicy>
         tag_fallback_invoke(hpx::ranges::experimental::for_loop_strided_t,
             ExPolicy&& policy, Rng&& rng, S stride, Args&&... args)
         {
@@ -898,19 +893,19 @@ namespace hpx::ranges::experimental {
                 "for_loop_strided must be called with at least a function "
                 "object");
 
-            using hpx::util::make_index_pack;
-            return hpx::parallel::v2::detail::for_loop(
+            using hpx::util::make_index_pack_t;
+            return hpx::parallel::v2::detail::for_loop_strided(
                 HPX_FORWARD(ExPolicy, policy), hpx::util::begin(rng),
                 hpx::util::end(rng), stride,
-                typename make_index_pack<sizeof...(Args) - 1>::type(),
+                make_index_pack_t<sizeof...(Args) - 1>(),
                 HPX_FORWARD(Args, args)...);
         }
 
         // clang-format off
         template <typename Rng, typename S, typename... Args,
             HPX_CONCEPT_REQUIRES_(
-                std::is_integral<S>::value &&
-                hpx::traits::is_range<Rng>::value
+                std::is_integral_v<S> &&
+                hpx::traits::is_range_v<Rng>
             )>
         // clang-format on
         friend void tag_fallback_invoke(
@@ -921,10 +916,10 @@ namespace hpx::ranges::experimental {
                 "for_loop_strided must be called with at least a function "
                 "object");
 
-            using hpx::util::make_index_pack;
-            return hpx::parallel::v2::detail::for_loop(hpx::execution::seq,
-                hpx::util::begin(rng), hpx::util::end(rng), stride,
-                typename make_index_pack<sizeof...(Args) - 1>::type(),
+            using hpx::util::make_index_pack_t;
+            return hpx::parallel::v2::detail::for_loop_strided(
+                hpx::execution::seq, hpx::util::begin(rng), hpx::util::end(rng),
+                stride, make_index_pack_t<sizeof...(Args) - 1>(),
                 HPX_FORWARD(Args, args)...);
         }
     } for_loop_strided{};

--- a/libs/core/algorithms/include/hpx/parallel/datapar.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/datapar.hpp
@@ -18,6 +18,7 @@
 #include <hpx/parallel/datapar/fill.hpp>
 #include <hpx/parallel/datapar/find.hpp>
 #include <hpx/parallel/datapar/generate.hpp>
+#include <hpx/parallel/datapar/handle_local_exceptions.hpp>
 #include <hpx/parallel/datapar/iterator_helpers.hpp>
 #include <hpx/parallel/datapar/loop.hpp>
 #include <hpx/parallel/datapar/mismatch.hpp>

--- a/libs/core/algorithms/include/hpx/parallel/util/detail/algorithm_result.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/util/detail/algorithm_result.hpp
@@ -137,6 +137,13 @@ namespace hpx { namespace parallel { namespace util { namespace detail {
         using type = T;
 
         template <typename T_>
+        static constexpr auto get()
+        {
+            namespace ex = hpx::execution::experimental;
+            return ex::just(T());
+        }
+
+        template <typename T_>
         static constexpr auto get(T_&& t)
         {
             namespace ex = hpx::execution::experimental;
@@ -147,6 +154,33 @@ namespace hpx { namespace parallel { namespace util { namespace detail {
             else
             {
                 return ex::just(HPX_FORWARD(T_, t));
+            }
+        }
+    };
+
+    template <typename ExPolicy>
+    struct algorithm_result_impl<ExPolicy, void,
+        std::enable_if_t<
+            hpx::execution_policy_has_scheduler_executor_v<ExPolicy>>>
+    {
+        // The return type of the initiating function.
+        using type = void;
+
+        static constexpr auto get() noexcept {}
+
+        static auto get(hpx::util::unused_type) noexcept {}
+
+        template <typename T_>
+        static constexpr auto get(T_&& t)
+        {
+            namespace ex = hpx::execution::experimental;
+            if constexpr (ex::is_sender_v<std::decay_t<T_>>)
+            {
+                return HPX_FORWARD(T_, t);
+            }
+            else
+            {
+                return ex::just();
             }
         }
     };

--- a/libs/core/algorithms/include/hpx/parallel/util/detail/algorithm_result.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/util/detail/algorithm_result.hpp
@@ -8,6 +8,7 @@
 
 #include <hpx/config.hpp>
 #include <hpx/concepts/concepts.hpp>
+#include <hpx/execution/algorithms/just.hpp>
 #include <hpx/execution/traits/is_execution_policy.hpp>
 #include <hpx/executors/execution_policy_fwd.hpp>
 #include <hpx/functional/detail/invoke.hpp>
@@ -21,7 +22,12 @@ namespace hpx { namespace parallel { namespace util { namespace detail {
 
     ///////////////////////////////////////////////////////////////////////////
     template <typename ExPolicy, typename T, typename Enable = void>
-    struct algorithm_result_impl
+    struct algorithm_result_impl;
+
+    template <typename ExPolicy, typename T>
+    struct algorithm_result_impl<ExPolicy, T,
+        std::enable_if_t<!hpx::is_async_execution_policy_v<ExPolicy> &&
+            !hpx::execution_policy_has_scheduler_executor_v<ExPolicy>>>
     {
         // The return type of the initiating function.
         using type = T;
@@ -34,13 +40,13 @@ namespace hpx { namespace parallel { namespace util { namespace detail {
         }
 
         template <typename T_>
-        static constexpr type get(T_&& t)
+        static constexpr auto get(T_&& t)
         {
             return HPX_FORWARD(T_, t);
         }
 
         template <typename T_>
-        static type get(hpx::future<T_>&& t)
+        static auto get(hpx::future<T_>&& t)
         {
             return t.get();
         }
@@ -48,7 +54,8 @@ namespace hpx { namespace parallel { namespace util { namespace detail {
 
     template <typename ExPolicy>
     struct algorithm_result_impl<ExPolicy, void,
-        std::enable_if_t<!hpx::is_async_execution_policy_v<ExPolicy>>>
+        std::enable_if_t<!hpx::is_async_execution_policy_v<ExPolicy> &&
+            !hpx::execution_policy_has_scheduler_executor_v<ExPolicy>>>
     {
         // The return type of the initiating function.
         using type = void;
@@ -72,7 +79,8 @@ namespace hpx { namespace parallel { namespace util { namespace detail {
 
     template <typename ExPolicy, typename T>
     struct algorithm_result_impl<ExPolicy, T,
-        std::enable_if_t<hpx::is_async_execution_policy_v<ExPolicy>>>
+        std::enable_if_t<hpx::is_async_execution_policy_v<ExPolicy> &&
+            !hpx::execution_policy_has_scheduler_executor_v<ExPolicy>>>
     {
         // The return type of the initiating function.
         using type = hpx::future<T>;
@@ -91,7 +99,8 @@ namespace hpx { namespace parallel { namespace util { namespace detail {
 
     template <typename ExPolicy>
     struct algorithm_result_impl<ExPolicy, void,
-        std::enable_if_t<hpx::is_async_execution_policy_v<ExPolicy>>>
+        std::enable_if_t<hpx::is_async_execution_policy_v<ExPolicy> &&
+            !hpx::execution_policy_has_scheduler_executor_v<ExPolicy>>>
     {
         // The return type of the initiating function.
         using type = hpx::future<void>;
@@ -116,6 +125,29 @@ namespace hpx { namespace parallel { namespace util { namespace detail {
         static type get(hpx::future<T>&& t) noexcept
         {
             return hpx::future<void>(HPX_MOVE(t));
+        }
+    };
+
+    template <typename ExPolicy, typename T>
+    struct algorithm_result_impl<ExPolicy, T,
+        std::enable_if_t<
+            hpx::execution_policy_has_scheduler_executor_v<ExPolicy>>>
+    {
+        // The return type of the initiating function.
+        using type = T;
+
+        template <typename T_>
+        static constexpr auto get(T_&& t)
+        {
+            namespace ex = hpx::execution::experimental;
+            if constexpr (ex::is_sender_v<std::decay_t<T_>>)
+            {
+                return HPX_FORWARD(T_, t);
+            }
+            else
+            {
+                return ex::just(HPX_FORWARD(T_, t));
+            }
         }
     };
 

--- a/libs/core/algorithms/include/hpx/parallel/util/detail/chunk_size_iterator.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/util/detail/chunk_size_iterator.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2021 Hartmut Kaiser
+//  Copyright (c) 2007-2022 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -77,7 +77,7 @@ namespace hpx { namespace parallel { namespace util { namespace detail {
         HPX_HOST_DEVICE chunk_size_iterator() = default;
 
         HPX_HOST_DEVICE chunk_size_iterator(Iterator it, std::size_t chunk_size,
-            std::size_t count = 0, std::size_t current = 0)
+            std::size_t count = 0, std::size_t current = 0) noexcept
           : data_(it, (hpx::detail::min)(chunk_size, count))
           , chunk_size_(chunk_size)
           , last_chunk_size_(get_last_chunk_size(count, chunk_size))
@@ -108,19 +108,20 @@ namespace hpx { namespace parallel { namespace util { namespace detail {
     protected:
         friend class hpx::util::iterator_core_access;
 
-        HPX_HOST_DEVICE bool equal(chunk_size_iterator const& other) const
+        HPX_HOST_DEVICE constexpr bool equal(
+            chunk_size_iterator const& other) const noexcept
         {
             return iterator() == other.iterator() &&
                 chunk_size_ == other.chunk_size_ && current_ == other.current_;
         }
 
-        HPX_HOST_DEVICE typename base_type::reference dereference()
+        HPX_HOST_DEVICE constexpr typename base_type::reference dereference()
             const noexcept
         {
             return data_;
         }
 
-        HPX_HOST_DEVICE void increment(std::size_t offset)
+        HPX_HOST_DEVICE void increment(std::size_t offset) noexcept
         {
             current_ += offset + chunk_size_;
             if (current_ >= count_)
@@ -147,12 +148,12 @@ namespace hpx { namespace parallel { namespace util { namespace detail {
             }
         }
 
-        HPX_HOST_DEVICE void increment()
+        HPX_HOST_DEVICE void increment() noexcept
         {
             increment(0);
         }
 
-        HPX_HOST_DEVICE void decrement(std::size_t offset)
+        HPX_HOST_DEVICE void decrement(std::size_t offset) noexcept
         {
             current_ -= offset + chunk_size_;
             if (current_ == 0)
@@ -181,7 +182,7 @@ namespace hpx { namespace parallel { namespace util { namespace detail {
             typename Enable = std::enable_if_t<
                 hpx::traits::is_bidirectional_iterator_v<Iter> ||
                 std::is_integral_v<Iter>>>
-        HPX_HOST_DEVICE void decrement()
+        HPX_HOST_DEVICE void decrement() noexcept
         {
             decrement(0);
         }
@@ -190,7 +191,7 @@ namespace hpx { namespace parallel { namespace util { namespace detail {
             typename Enable = std::enable_if_t<
                 hpx::traits::is_random_access_iterator_v<Iter> ||
                 std::is_integral_v<Iter>>>
-        HPX_HOST_DEVICE void advance(std::ptrdiff_t n)
+        HPX_HOST_DEVICE void advance(std::ptrdiff_t n) noexcept
         {
             // prepare next value
             if (n > 0)
@@ -207,8 +208,8 @@ namespace hpx { namespace parallel { namespace util { namespace detail {
             typename Enable = std::enable_if_t<
                 hpx::traits::is_random_access_iterator_v<Iter> ||
                 std::is_integral_v<Iter>>>
-        HPX_HOST_DEVICE std::ptrdiff_t distance_to(
-            chunk_size_iterator const& rhs) const
+        HPX_HOST_DEVICE constexpr std::ptrdiff_t distance_to(
+            chunk_size_iterator const& rhs) const noexcept
         {
             return static_cast<std::ptrdiff_t>(
                 ((rhs.iterator() - iterator()) + chunk_size_ - 1) /
@@ -299,19 +300,20 @@ namespace hpx { namespace parallel { namespace util { namespace detail {
     protected:
         friend class hpx::util::iterator_core_access;
 
-        HPX_HOST_DEVICE bool equal(chunk_size_idx_iterator const& other) const
+        HPX_HOST_DEVICE constexpr bool equal(
+            chunk_size_idx_iterator const& other) const noexcept
         {
             return iterator() == other.iterator() &&
                 chunk_size_ == other.chunk_size_ && current_ == other.current_;
         }
 
-        HPX_HOST_DEVICE typename base_type::reference dereference()
+        HPX_HOST_DEVICE constexpr typename base_type::reference dereference()
             const noexcept
         {
             return data_;
         }
 
-        HPX_HOST_DEVICE void increment(std::size_t offset)
+        HPX_HOST_DEVICE void increment(std::size_t offset) noexcept
         {
             base_index() += offset + chunk_size_;
             current_ += offset + chunk_size_;
@@ -339,12 +341,12 @@ namespace hpx { namespace parallel { namespace util { namespace detail {
             }
         }
 
-        HPX_HOST_DEVICE void increment()
+        HPX_HOST_DEVICE void increment() noexcept
         {
             increment(0);
         }
 
-        HPX_HOST_DEVICE void decrement(std::size_t offset)
+        HPX_HOST_DEVICE void decrement(std::size_t offset) noexcept
         {
             base_index() -= offset + chunk_size_;
             current_ -= offset + chunk_size_;
@@ -375,7 +377,7 @@ namespace hpx { namespace parallel { namespace util { namespace detail {
             typename Enable = std::enable_if_t<
                 hpx::traits::is_bidirectional_iterator_v<Iter> ||
                 std::is_integral_v<Iter>>>
-        HPX_HOST_DEVICE void decrement()
+        HPX_HOST_DEVICE void decrement() noexcept
         {
             decrement(0);
         }
@@ -384,7 +386,7 @@ namespace hpx { namespace parallel { namespace util { namespace detail {
             typename Enable = std::enable_if_t<
                 hpx::traits::is_random_access_iterator_v<Iter> ||
                 std::is_integral_v<Iter>>>
-        HPX_HOST_DEVICE void advance(std::ptrdiff_t n)
+        HPX_HOST_DEVICE void advance(std::ptrdiff_t n) noexcept
         {
             // prepare next value
             if (n > 0)
@@ -401,8 +403,8 @@ namespace hpx { namespace parallel { namespace util { namespace detail {
             typename Enable = std::enable_if_t<
                 hpx::traits::is_random_access_iterator_v<Iter> ||
                 std::is_integral_v<Iter>>>
-        HPX_HOST_DEVICE std::ptrdiff_t distance_to(
-            chunk_size_idx_iterator const& rhs) const
+        HPX_HOST_DEVICE constexpr std::ptrdiff_t distance_to(
+            chunk_size_idx_iterator const& rhs) const noexcept
         {
             return static_cast<std::ptrdiff_t>(
                 ((rhs.iterator() - iterator()) + chunk_size_ - 1) /

--- a/libs/core/algorithms/include/hpx/parallel/util/detail/select_partitioner.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/util/detail/select_partitioner.hpp
@@ -28,7 +28,8 @@ namespace hpx { namespace parallel { namespace util { namespace detail {
     template <typename ExPolicy, template <typename...> class Partitioner,
         template <typename...> class TaskPartitioner>
     struct select_partitioner<ExPolicy, Partitioner, TaskPartitioner,
-        std::enable_if_t<hpx::is_async_execution_policy_v<ExPolicy>>>
+        std::enable_if_t<hpx::is_async_execution_policy_v<ExPolicy> &&
+            !hpx::execution_policy_has_scheduler_executor_v<ExPolicy>>>
     {
         template <typename... Args>
         using apply = TaskPartitioner<ExPolicy, Args...>;

--- a/libs/core/algorithms/include/hpx/parallel/util/foreach_partitioner.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/util/foreach_partitioner.hpp
@@ -16,6 +16,7 @@
 #include <hpx/type_support/unused.hpp>
 
 #include <hpx/execution/algorithms/detail/predicates.hpp>
+#include <hpx/execution/algorithms/then.hpp>
 #include <hpx/execution/executors/execution.hpp>
 #include <hpx/execution/executors/execution_parameters.hpp>
 #include <hpx/execution_base/traits/is_executor_parameters.hpp>
@@ -106,7 +107,7 @@ namespace hpx { namespace parallel { namespace util {
 
             template <typename ExPolicy_, typename FwdIter, typename F1,
                 typename F2>
-            static FwdIter call(ExPolicy_&& policy, FwdIter first,
+            static decltype(auto) call(ExPolicy_&& policy, FwdIter first,
                 std::size_t count, F1&& f1, F2&& f2)
             {
                 // inform parameter traits
@@ -134,7 +135,7 @@ namespace hpx { namespace parallel { namespace util {
         private:
             template <typename F, typename Items1, typename Items2,
                 typename FwdIter>
-            static FwdIter reduce(
+            static decltype(auto) reduce(
                 std::pair<Items1, Items2>&& items, F&& f, FwdIter last)
             {
                 // wait for all tasks to finish
@@ -146,20 +147,32 @@ namespace hpx { namespace parallel { namespace util {
                     handle_local_exceptions::call(hpx::get<0>(items));
                     handle_local_exceptions::call(hpx::get<1>(items));
                 }
-                return f(HPX_MOVE(last));
+                return HPX_INVOKE(f, HPX_MOVE(last));
             }
 
             template <typename F, typename Items, typename FwdIter>
-            static FwdIter reduce(Items&& items, F&& f, FwdIter last)
+            static auto reduce(Items&& items, F&& f, FwdIter last)
             {
-                // wait for all tasks to finish
-                if (hpx::wait_all_nothrow(items))
+                namespace ex = hpx::execution::experimental;
+                if constexpr (ex::is_sender_v<std::decay_t<Items>> &&
+                    !hpx::traits::is_future_v<std::decay_t<Items>>)
                 {
-                    // always rethrow if items has at least one exceptional
-                    // future
-                    handle_local_exceptions::call(items);
+                    auto proj = [f = HPX_FORWARD(F, f), last]() mutable {
+                        return HPX_INVOKE(f, HPX_MOVE(last));
+                    };
+                    return ex::then(HPX_FORWARD(Items, items), proj);
                 }
-                return f(HPX_MOVE(last));
+                else
+                {
+                    // wait for all tasks to finish
+                    if (hpx::wait_all_nothrow(items))
+                    {
+                        // always rethrow if items has at least one exceptional
+                        // future
+                        handle_local_exceptions::call(items);
+                    }
+                    return HPX_INVOKE(f, HPX_MOVE(last));
+                }
             }
         };
 
@@ -258,12 +271,6 @@ namespace hpx { namespace parallel { namespace util {
                 return hpx::future<FwdIter>();
 #else
                 // wait for all tasks to finish
-                // Note: the lambda takes the vectors by value (dataflow
-                //       moves those into the lambda) to ensure that they
-                //       will be destroyed before the lambda exists.
-                //       Otherwise the vectors stay alive in the dataflow's
-                //       shared state and may reference data that has gone
-                //       out of scope.
                 return hpx::dataflow(
                     hpx::launch::sync,
                     [last, scoped_params = HPX_MOVE(scoped_params),
@@ -275,6 +282,33 @@ namespace hpx { namespace parallel { namespace util {
                         return f(HPX_MOVE(last));
                     },
                     HPX_MOVE(items));
+#endif
+            }
+
+            template <typename F, typename FwdIter>
+            static hpx::future<FwdIter> reduce(
+                std::shared_ptr<scoped_executor_parameters>&& scoped_params,
+                hpx::future<void>&& item, F&& f, FwdIter last)
+            {
+#if defined(HPX_COMPUTE_DEVICE_CODE)
+                HPX_UNUSED(scoped_params);
+                HPX_UNUSED(item);
+                HPX_UNUSED(f);
+                HPX_UNUSED(last);
+                HPX_ASSERT(false);
+                return hpx::future<FwdIter>();
+#else
+                // wait for the task to finish, invoke the given function before
+                // returning
+                return item.then(hpx::launch::sync,
+                    [last, scoped_params = HPX_MOVE(scoped_params),
+                        f = HPX_FORWARD(F, f)](auto&& r) mutable -> FwdIter {
+                        HPX_UNUSED(scoped_params);
+
+                        handle_local_exceptions::call(HPX_MOVE(r));
+
+                        return f(HPX_MOVE(last));
+                    });
 #endif
             }
         };

--- a/libs/core/algorithms/include/hpx/parallel/util/foreach_partitioner.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/util/foreach_partitioner.hpp
@@ -38,7 +38,10 @@
 
 ///////////////////////////////////////////////////////////////////////////////
 namespace hpx { namespace parallel { namespace util {
+
+    ///////////////////////////////////////////////////////////////////////////
     namespace detail {
+
         template <typename Result, typename ExPolicy, typename FwdIter,
             typename F>
         auto foreach_partition(
@@ -157,10 +160,11 @@ namespace hpx { namespace parallel { namespace util {
                 if constexpr (ex::is_sender_v<std::decay_t<Items>> &&
                     !hpx::traits::is_future_v<std::decay_t<Items>>)
                 {
-                    auto proj = [f = HPX_FORWARD(F, f), last]() mutable {
-                        return HPX_INVOKE(f, HPX_MOVE(last));
-                    };
-                    return ex::then(HPX_FORWARD(Items, items), proj);
+                    return ex::then(HPX_FORWARD(Items, items),
+                        [f = HPX_FORWARD(F, f),
+                            last = HPX_MOVE(last)]() mutable {
+                            return HPX_INVOKE(f, HPX_MOVE(last));
+                        });
                 }
                 else
                 {

--- a/libs/core/algorithms/include/hpx/parallel/util/partitioner.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/util/partitioner.hpp
@@ -18,6 +18,7 @@
 #include <hpx/type_support/empty_function.hpp>
 #include <hpx/type_support/unused.hpp>
 
+#include <hpx/execution/algorithms/then.hpp>
 #include <hpx/execution/executors/execution.hpp>
 #include <hpx/execution/executors/execution_parameters.hpp>
 #include <hpx/execution_base/traits/is_executor_parameters.hpp>
@@ -31,7 +32,6 @@
 #include <cstddef>
 #include <exception>
 #include <iterator>
-#include <list>
 #include <memory>
 #include <type_traits>
 #include <utility>
@@ -39,8 +39,10 @@
 
 ///////////////////////////////////////////////////////////////////////////////
 namespace hpx { namespace parallel { namespace util {
+
     ///////////////////////////////////////////////////////////////////////////
     namespace detail {
+
         template <typename Result, typename ExPolicy, typename FwdIter,
             typename F>
         auto partition(
@@ -200,14 +202,13 @@ namespace hpx { namespace parallel { namespace util {
 
             template <typename ExPolicy_, typename FwdIter, typename F1,
                 typename F2>
-            static R call(ExPolicy_&& policy, FwdIter first, std::size_t count,
-                F1&& f1, F2&& f2)
+            static auto call(ExPolicy_&& policy, FwdIter first,
+                std::size_t count, F1&& f1, F2&& f2)
             {
                 // inform parameter traits
                 scoped_executor_parameters scoped_params(
                     policy.parameters(), policy.executor());
 
-                std::list<std::exception_ptr> errors;
                 try
                 {
                     auto&& items = detail::partition<Result>(
@@ -226,14 +227,13 @@ namespace hpx { namespace parallel { namespace util {
 
             template <typename ExPolicy_, typename FwdIter, typename Stride,
                 typename F1, typename F2>
-            static R call_with_index(ExPolicy_&& policy, FwdIter first,
+            static auto call_with_index(ExPolicy_&& policy, FwdIter first,
                 std::size_t count, Stride stride, F1&& f1, F2&& f2)
             {
                 // inform parameter traits
                 scoped_executor_parameters scoped_params(
                     policy.parameters(), policy.executor());
 
-                std::list<std::exception_ptr> errors;
                 try
                 {
                     auto&& items = detail::partition_with_index<Result>(
@@ -253,7 +253,7 @@ namespace hpx { namespace parallel { namespace util {
             template <typename ExPolicy_, typename FwdIter, typename F1,
                 typename F2, typename Data>
             // requires is_container<Data>
-            static R call_with_data(ExPolicy_&& policy, FwdIter first,
+            static auto call_with_data(ExPolicy_&& policy, FwdIter first,
                 std::size_t count, F1&& f1, F2&& f2,
                 std::vector<std::size_t> const& chunk_sizes, Data&& data)
             {
@@ -280,27 +280,49 @@ namespace hpx { namespace parallel { namespace util {
 
         private:
             template <typename Items, typename F>
-            static R reduce(Items&& workitems, F&& f)
+            static auto reduce(Items&& items, F&& f)
             {
-                // wait for all tasks to finish
-                if (hpx::wait_all_nothrow(workitems))
+                namespace ex = hpx::execution::experimental;
+                if constexpr (ex::is_sender_v<std::decay_t<Items>> &&
+                    !hpx::traits::is_future_v<std::decay_t<Items>>)
                 {
-                    // always rethrow workitems has at least one exceptional
-                    // future
-                    handle_local_exceptions::call(workitems);
+                    return ex::then(HPX_FORWARD(Items, items),
+                        [f = HPX_FORWARD(F, f)](auto&& result) {
+                            return HPX_INVOKE(
+                                f, HPX_FORWARD(decltype(result), result));
+                        });
                 }
-                return f(HPX_MOVE(workitems));
+                else
+                {
+                    // wait for all tasks to finish
+                    if (hpx::wait_all_nothrow(items))
+                    {
+                        // always rethrow workitems has at least one exceptional
+                        // future
+                        handle_local_exceptions::call(items);
+                    }
+                    return HPX_INVOKE(f, HPX_FORWARD(Items, items));
+                }
             }
 
             template <typename Items>
-            static void reduce(Items&& workitems, hpx::util::empty_function)
+            static auto reduce(Items&& items, hpx::util::empty_function)
             {
-                // wait for all tasks to finish
-                if (hpx::wait_all_nothrow(workitems))
+                namespace ex = hpx::execution::experimental;
+                if constexpr (ex::is_sender_v<std::decay_t<Items>> &&
+                    !hpx::traits::is_future_v<std::decay_t<Items>>)
                 {
-                    // always rethrow workitems has at least one exceptional
-                    // future
-                    handle_local_exceptions::call(workitems);
+                    return HPX_FORWARD(Items, items);
+                }
+                else
+                {
+                    // wait for all tasks to finish
+                    if (hpx::wait_all_nothrow(items))
+                    {
+                        // always rethrow workitems has at least one exceptional
+                        // future
+                        handle_local_exceptions::call(items);
+                    }
                 }
             }
 

--- a/libs/core/algorithms/include/hpx/parallel/util/transfer.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/util/transfer.hpp
@@ -86,13 +86,16 @@ namespace hpx { namespace parallel { namespace util {
         {
             using data_type = typename std::iterator_traits<InIter>::value_type;
 
-            char const* const first_ch = to_const_ptr(first);
-            char* const dest_ch = to_ptr(dest);
+            if (count != 0)
+            {
+                char const* const first_ch = to_const_ptr(first);
+                char* const dest_ch = to_ptr(dest);
 
-            std::memmove(dest_ch, first_ch, count * sizeof(data_type));
+                std::memmove(dest_ch, first_ch, count * sizeof(data_type));
 
-            std::advance(first, count);
-            std::advance(dest, count);
+                std::advance(first, count);
+                std::advance(dest, count);
+            }
             return in_out_result<InIter, OutIter>{
                 HPX_MOVE(first), HPX_MOVE(dest)};
         }

--- a/libs/core/algorithms/tests/performance/foreach_scaling_helpers.hpp
+++ b/libs/core/algorithms/tests/performance/foreach_scaling_helpers.hpp
@@ -129,20 +129,43 @@ void measure_parallel_foreach(
     // create executor parameters object
     hpx::execution::static_chunk_size cs(chunk_size);
 
-    if (disable_stealing)
+    if constexpr (hpx::traits::is_scheduler_executor_v<Executor>)
     {
-        // disable stealing from inside the algorithm
-        disable_stealing_parameter dsp;
+        if (disable_stealing)
+        {
+            // disable stealing from inside the algorithm
+            disable_stealing_parameter dsp;
 
-        // invoke parallel for_each
-        hpx::ranges::for_each(hpx::execution::par.with(cs, dsp).on(exec),
-            data_representation, [](std::size_t) { worker_timed(delay); });
+            // invoke parallel for_each
+            hpx::ranges::for_each(hpx::execution::par.with(cs, dsp).on(exec),
+                data_representation, [](std::size_t) { worker_timed(delay); }) |
+                hpx::this_thread::experimental::sync_wait();
+        }
+        else
+        {
+            // invoke parallel for_each
+            hpx::ranges::for_each(hpx::execution::par.with(cs).on(exec),
+                data_representation, [](std::size_t) { worker_timed(delay); }) |
+                hpx::this_thread::experimental::sync_wait();
+        }
     }
     else
     {
-        // invoke parallel for_each
-        hpx::ranges::for_each(hpx::execution::par.with(cs).on(exec),
-            data_representation, [](std::size_t) { worker_timed(delay); });
+        if (disable_stealing)
+        {
+            // disable stealing from inside the algorithm
+            disable_stealing_parameter dsp;
+
+            // invoke parallel for_each
+            hpx::ranges::for_each(hpx::execution::par.with(cs, dsp).on(exec),
+                data_representation, [](std::size_t) { worker_timed(delay); });
+        }
+        else
+        {
+            // invoke parallel for_each
+            hpx::ranges::for_each(hpx::execution::par.with(cs).on(exec),
+                data_representation, [](std::size_t) { worker_timed(delay); });
+        }
     }
 }
 
@@ -209,22 +232,49 @@ void measure_parallel_forloop(
     // create executor parameters object
     hpx::execution::static_chunk_size cs(chunk_size);
 
-    if (disable_stealing)
+    if constexpr (hpx::traits::is_scheduler_executor_v<Executor>)
     {
-        // disable stealing from inside the algorithm
-        disable_stealing_parameter dsp;
+        if (disable_stealing)
+        {
+            // disable stealing from inside the algorithm
+            disable_stealing_parameter dsp;
 
-        // invoke parallel for_loop
-        hpx::experimental::for_loop(hpx::execution::par.with(cs, dsp).on(exec),
-            std::begin(data_representation), std::end(data_representation),
-            [](iterator) { worker_timed(delay); });
+            // invoke parallel for_loop
+            hpx::experimental::for_loop(
+                hpx::execution::par.with(cs, dsp).on(exec),
+                std::begin(data_representation), std::end(data_representation),
+                [](iterator) { worker_timed(delay); }) |
+                hpx::this_thread::experimental::sync_wait();
+        }
+        else
+        {
+            // invoke parallel for_loop
+            hpx::experimental::for_loop(hpx::execution::par.with(cs).on(exec),
+                std::begin(data_representation), std::end(data_representation),
+                [](iterator) { worker_timed(delay); }) |
+                hpx::this_thread::experimental::sync_wait();
+        }
     }
     else
     {
-        // invoke parallel for_loop
-        hpx::experimental::for_loop(hpx::execution::par.with(cs).on(exec),
-            std::begin(data_representation), std::end(data_representation),
-            [](iterator) { worker_timed(delay); });
+        if (disable_stealing)
+        {
+            // disable stealing from inside the algorithm
+            disable_stealing_parameter dsp;
+
+            // invoke parallel for_loop
+            hpx::experimental::for_loop(
+                hpx::execution::par.with(cs, dsp).on(exec),
+                std::begin(data_representation), std::end(data_representation),
+                [](iterator) { worker_timed(delay); });
+        }
+        else
+        {
+            // invoke parallel for_loop
+            hpx::experimental::for_loop(hpx::execution::par.with(cs).on(exec),
+                std::begin(data_representation), std::end(data_representation),
+                [](iterator) { worker_timed(delay); });
+        }
     }
 }
 

--- a/libs/core/algorithms/tests/unit/algorithms/CMakeLists.txt
+++ b/libs/core/algorithms/tests/unit/algorithms/CMakeLists.txt
@@ -49,6 +49,7 @@ set(tests
     findif
     findifnot
     foreach
+    foreach_sender
     foreach_executors
     foreach_prefetching
     foreachn

--- a/libs/core/algorithms/tests/unit/algorithms/CMakeLists.txt
+++ b/libs/core/algorithms/tests/unit/algorithms/CMakeLists.txt
@@ -49,9 +49,9 @@ set(tests
     findif
     findifnot
     foreach
-    foreach_sender
     foreach_executors
     foreach_prefetching
+    foreach_sender
     foreachn
     foreachn_exception
     foreachn_bad_alloc
@@ -63,6 +63,7 @@ set(tests
     for_loop_n_strided
     for_loop_reduction
     for_loop_reduction_async
+    for_loop_sender
     for_loop_strided
     generate
     generaten

--- a/libs/core/algorithms/tests/unit/algorithms/for_loop_sender.cpp
+++ b/libs/core/algorithms/tests/unit/algorithms/for_loop_sender.cpp
@@ -1,0 +1,148 @@
+//  Copyright (c) 2016-2022 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/local/algorithm.hpp>
+#include <hpx/local/init.hpp>
+#include <hpx/modules/testing.hpp>
+
+#include <algorithm>
+#include <cstddef>
+#include <iostream>
+#include <numeric>
+#include <random>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "test_utils.hpp"
+
+///////////////////////////////////////////////////////////////////////////////
+unsigned int seed = std::random_device{}();
+std::mt19937 gen(seed);
+
+template <typename Policy, typename ExPolicy, typename IteratorTag>
+void test_for_loop_sender_direct(Policy l, ExPolicy&& policy, IteratorTag)
+{
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
+
+    typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+
+    std::vector<std::size_t> c(10007);
+    std::iota(std::begin(c), std::end(c), gen());
+
+    namespace ex = hpx::execution::experimental;
+    namespace tt = hpx::this_thread::experimental;
+
+    using scheduler_t = ex::thread_pool_policy_scheduler<Policy>;
+
+    auto exec = ex::explicit_scheduler_executor(scheduler_t(l));
+    hpx::experimental::for_loop(policy.on(exec), iterator(std::begin(c)),
+        iterator(std::end(c)), [](iterator it) { *it = 42; }) |
+        tt::sync_wait();
+
+    // verify values
+    std::size_t count = 0;
+    std::for_each(std::begin(c), std::end(c), [&count](std::size_t v) -> void {
+        HPX_TEST_EQ(v, std::size_t(42));
+        ++count;
+    });
+    HPX_TEST_EQ(count, c.size());
+}
+
+template <typename IteratorTag>
+void test_for_loop()
+{
+    using namespace hpx::execution;
+
+    test_for_loop_sender_direct(hpx::launch::sync, seq, IteratorTag());
+    test_for_loop_sender_direct(hpx::launch::sync, unseq, IteratorTag());
+    test_for_loop_sender_direct(hpx::launch::async, par, IteratorTag());
+    test_for_loop_sender_direct(hpx::launch::async, par_unseq, IteratorTag());
+
+    test_for_loop_sender_direct(hpx::launch::sync, seq(task), IteratorTag());
+    test_for_loop_sender_direct(hpx::launch::sync, unseq(task), IteratorTag());
+    test_for_loop_sender_direct(hpx::launch::async, par(task), IteratorTag());
+    test_for_loop_sender_direct(
+        hpx::launch::async, par_unseq(task), IteratorTag());
+}
+
+void for_loop_test()
+{
+    test_for_loop<std::random_access_iterator_tag>();
+    test_for_loop<std::forward_iterator_tag>();
+}
+
+///////////////////////////////////////////////////////////////////////////////
+//template <typename ExPolicy>
+//void test_for_loop_idx(ExPolicy&& policy)
+//{
+//    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+//        "hpx::is_execution_policy<ExPolicy>::value");
+//
+//    std::vector<std::size_t> c(10007);
+//    std::iota(std::begin(c), std::end(c), gen());
+//
+//    hpx::experimental::for_loop(std::forward<ExPolicy>(policy), 0, c.size(),
+//        [&c](std::size_t i) { c[i] = 42; });
+//
+//    // verify values
+//    std::size_t count = 0;
+//    std::for_each(std::begin(c), std::end(c), [&count](std::size_t v) -> void {
+//        HPX_TEST_EQ(v, std::size_t(42));
+//        ++count;
+//    });
+//    HPX_TEST_EQ(count, c.size());
+//}
+
+//void for_loop_test_idx()
+//{
+//    using namespace hpx::execution;
+//
+//    test_for_loop_idx(seq);
+//    test_for_loop_idx(par);
+//    test_for_loop_idx(par_unseq);
+//}
+
+///////////////////////////////////////////////////////////////////////////////
+int hpx_main(hpx::program_options::variables_map& vm)
+{
+    if (vm.count("seed"))
+        seed = vm["seed"].as<unsigned int>();
+
+    std::cout << "using seed: " << seed << std::endl;
+    gen.seed(seed);
+
+    for_loop_test();
+    //for_loop_test_idx();
+
+    return hpx::local::finalize();
+}
+
+int main(int argc, char* argv[])
+{
+    // add command line option which controls the random number generator seed
+    using namespace hpx::program_options;
+    options_description desc_commandline(
+        "Usage: " HPX_APPLICATION_STRING " [options]");
+
+    desc_commandline.add_options()("seed,s", value<unsigned int>(),
+        "the random number generator seed to use for this run");
+
+    // By default this test should run on all available cores
+    std::vector<std::string> const cfg = {"hpx.os_threads=all"};
+
+    // Initialize and run HPX
+    hpx::local::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::local::init(hpx_main, argc, argv, init_args), 0,
+        "HPX main exited with non-zero status");
+
+    return hpx::util::report_errors();
+}

--- a/libs/core/algorithms/tests/unit/algorithms/foreach_sender.cpp
+++ b/libs/core/algorithms/tests/unit/algorithms/foreach_sender.cpp
@@ -1,0 +1,177 @@
+//  Copyright (c) 2014-2022 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/local/execution.hpp>
+#include <hpx/local/init.hpp>
+#include <hpx/local/thread.hpp>
+#include <hpx/modules/iterator_support.hpp>
+#include <hpx/modules/testing.hpp>
+#include <hpx/parallel/container_algorithms/for_each.hpp>
+
+#include <algorithm>
+#include <cstddef>
+#include <iostream>
+#include <string>
+#include <vector>
+
+#include "test_utils.hpp"
+
+///////////////////////////////////////////////////////////////////////////////
+template <typename Policy, typename ExPolicy, typename IteratorTag>
+void test_for_each_explicit_sender_direct(
+    Policy l, ExPolicy&& policy, IteratorTag)
+{
+    using base_iterator = std::vector<std::size_t>::iterator;
+    using iterator = test::test_iterator<base_iterator, IteratorTag>;
+
+    std::vector<std::size_t> c(10007);
+    std::iota(std::begin(c), std::end(c), std::rand());
+
+    namespace ex = hpx::execution::experimental;
+    namespace tt = hpx::this_thread::experimental;
+
+    auto f = [](std::size_t& v) { v = 42; };
+
+    using scheduler_t = ex::thread_pool_policy_scheduler<Policy>;
+
+    auto exec = ex::explicit_scheduler_executor(scheduler_t(l));
+    auto result = hpx::for_each(policy.on(exec), iterator(std::begin(c)),
+                      iterator(std::end(c)), f) |
+        tt::sync_wait();
+    HPX_TEST(result == iterator(std::end(c)));
+
+    // verify values
+    std::size_t count = 0;
+    std::for_each(std::begin(c), std::end(c), [&count](std::size_t v) -> void {
+        HPX_TEST_EQ(v, std::size_t(42));
+        ++count;
+    });
+    HPX_TEST_EQ(count, c.size());
+}
+
+///////////////////////////////////////////////////////////////////////////////
+template <typename Policy, typename ExPolicy, typename IteratorTag>
+void test_for_each_explicit_sender(Policy l, ExPolicy&& policy, IteratorTag)
+{
+    using base_iterator = std::vector<std::size_t>::iterator;
+    using iterator = test::test_iterator<base_iterator, IteratorTag>;
+
+    std::vector<std::size_t> c(10007);
+    std::iota(std::begin(c), std::end(c), std::rand());
+
+    namespace ex = hpx::execution::experimental;
+    namespace tt = hpx::this_thread::experimental;
+
+    auto f = [](std::size_t& v) { v = 42; };
+
+    using scheduler_t = ex::thread_pool_policy_scheduler<Policy>;
+
+    auto exec = ex::explicit_scheduler_executor(scheduler_t(l));
+    auto result = ex::just(iterator(std::begin(c)), iterator(std::end(c)), f) |
+        hpx::for_each(policy.on(exec)) | tt::sync_wait();
+    HPX_TEST(result == iterator(std::end(c)));
+
+    // verify values
+    std::size_t count = 0;
+    std::for_each(std::begin(c), std::end(c), [&count](std::size_t v) -> void {
+        HPX_TEST_EQ(v, std::size_t(42));
+        ++count;
+    });
+    HPX_TEST_EQ(count, c.size());
+}
+
+template <typename IteratorTag>
+void test_for_each_sender_direct()
+{
+    using namespace hpx::execution;
+
+    test_for_each_explicit_sender_direct(hpx::launch::sync, seq, IteratorTag());
+    test_for_each_explicit_sender_direct(
+        hpx::launch::sync, unseq, IteratorTag());
+    test_for_each_explicit_sender_direct(
+        hpx::launch::async, par, IteratorTag());
+    test_for_each_explicit_sender_direct(
+        hpx::launch::async, par_unseq, IteratorTag());
+
+    test_for_each_explicit_sender_direct(
+        hpx::launch::sync, seq(task), IteratorTag());
+    test_for_each_explicit_sender_direct(
+        hpx::launch::sync, unseq(task), IteratorTag());
+    test_for_each_explicit_sender_direct(
+        hpx::launch::async, par(task), IteratorTag());
+    test_for_each_explicit_sender_direct(
+        hpx::launch::async, par_unseq(task), IteratorTag());
+}
+
+template <typename IteratorTag>
+void test_for_each_sender()
+{
+    using namespace hpx::execution;
+
+    test_for_each_explicit_sender(hpx::launch::sync, seq, IteratorTag());
+    test_for_each_explicit_sender(hpx::launch::sync, unseq, IteratorTag());
+    test_for_each_explicit_sender(hpx::launch::async, par, IteratorTag());
+    test_for_each_explicit_sender(hpx::launch::async, par_unseq, IteratorTag());
+
+    test_for_each_explicit_sender(hpx::launch::sync, seq(task), IteratorTag());
+    test_for_each_explicit_sender(
+        hpx::launch::sync, unseq(task), IteratorTag());
+    test_for_each_explicit_sender(hpx::launch::async, par(task), IteratorTag());
+    test_for_each_explicit_sender(
+        hpx::launch::async, par_unseq(task), IteratorTag());
+}
+
+void for_each_sender_test_direct()
+{
+    test_for_each_sender_direct<std::random_access_iterator_tag>();
+    test_for_each_sender_direct<std::forward_iterator_tag>();
+}
+
+void for_each_sender_test()
+{
+    test_for_each_sender<std::random_access_iterator_tag>();
+    test_for_each_sender<std::forward_iterator_tag>();
+}
+
+///////////////////////////////////////////////////////////////////////////////
+int hpx_main(hpx::program_options::variables_map& vm)
+{
+    unsigned int seed = (unsigned int) std::time(nullptr);
+    if (vm.count("seed"))
+        seed = vm["seed"].as<unsigned int>();
+
+    std::cout << "using seed: " << seed << std::endl;
+    std::srand(seed);
+
+    for_each_sender_test_direct();
+    for_each_sender_test();
+
+    return hpx::local::finalize();
+}
+
+int main(int argc, char* argv[])
+{
+    // add command line option which controls the random number generator seed
+    using namespace hpx::program_options;
+    options_description desc_commandline(
+        "Usage: " HPX_APPLICATION_STRING " [options]");
+
+    desc_commandline.add_options()("seed,s", value<unsigned int>(),
+        "the random number generator seed to use for this run");
+
+    // By default this test should run on all available cores
+    std::vector<std::string> const cfg = {"hpx.os_threads=all"};
+
+    // Initialize and run HPX
+    hpx::local::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::local::init(hpx_main, argc, argv, init_args), 0,
+        "HPX main exited with non-zero status");
+
+    return hpx::util::report_errors();
+}

--- a/libs/core/algorithms/tests/unit/algorithms/foreach_sender.cpp
+++ b/libs/core/algorithms/tests/unit/algorithms/foreach_sender.cpp
@@ -41,7 +41,7 @@ void test_for_each_explicit_sender_direct(
     auto result = hpx::for_each(policy.on(exec), iterator(std::begin(c)),
                       iterator(std::end(c)), f) |
         tt::sync_wait();
-    HPX_TEST(result == iterator(std::end(c)));
+    HPX_TEST(hpx::get<0>(*result) == iterator(std::end(c)));
 
     // verify values
     std::size_t count = 0;
@@ -72,7 +72,7 @@ void test_for_each_explicit_sender(Policy l, ExPolicy&& policy, IteratorTag)
     auto exec = ex::explicit_scheduler_executor(scheduler_t(l));
     auto result = ex::just(iterator(std::begin(c)), iterator(std::end(c)), f) |
         hpx::for_each(policy.on(exec)) | tt::sync_wait();
-    HPX_TEST(result == iterator(std::end(c)));
+    HPX_TEST(hpx::get<0>(*result) == iterator(std::end(c)));
 
     // verify values
     std::size_t count = 0;

--- a/libs/core/algorithms/tests/unit/algorithms/set_union.cpp
+++ b/libs/core/algorithms/tests/unit/algorithms/set_union.cpp
@@ -224,7 +224,7 @@ void set_union_test2()
 
 ///////////////////////////////////////////////////////////////////////////////
 template <typename IteratorTag>
-void test_set_union_exception(IteratorTag)
+void test_set_union_exception(IteratorTag, char const* desc)
 {
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>
@@ -242,7 +242,7 @@ void test_set_union_exception(IteratorTag)
     try
     {
         hpx::set_union(decorated_iterator(std::begin(c1),
-                           []() { throw std::runtime_error("test"); }),
+                           [=]() { throw std::runtime_error(desc); }),
             decorated_iterator(std::end(c1)), std::begin(c2), std::end(c2),
             std::begin(c3));
 
@@ -263,7 +263,7 @@ void test_set_union_exception(IteratorTag)
 }
 
 template <typename ExPolicy, typename IteratorTag>
-void test_set_union_exception(ExPolicy&& policy, IteratorTag)
+void test_set_union_exception(ExPolicy&& policy, IteratorTag, char const* desc)
 {
     static_assert(hpx::is_execution_policy<ExPolicy>::value,
         "hpx::is_execution_policy<ExPolicy>::value");
@@ -285,7 +285,7 @@ void test_set_union_exception(ExPolicy&& policy, IteratorTag)
     {
         hpx::set_union(policy,
             decorated_iterator(
-                std::begin(c1), []() { throw std::runtime_error("test"); }),
+                std::begin(c1), [=]() { throw std::runtime_error(desc); }),
             decorated_iterator(std::end(c1)), std::begin(c2), std::end(c2),
             std::begin(c3));
 
@@ -305,7 +305,7 @@ void test_set_union_exception(ExPolicy&& policy, IteratorTag)
 }
 
 template <typename ExPolicy, typename IteratorTag>
-void test_set_union_exception_async(ExPolicy&& p, IteratorTag)
+void test_set_union_exception_async(ExPolicy&& p, IteratorTag, char const* desc)
 {
     static_assert(hpx::is_execution_policy<ExPolicy>::value,
         "hpx::is_execution_policy<ExPolicy>::value");
@@ -328,7 +328,7 @@ void test_set_union_exception_async(ExPolicy&& p, IteratorTag)
     {
         hpx::future<void> f = hpx::set_union(p,
             decorated_iterator(
-                std::begin(c1), []() { throw std::runtime_error("test"); }),
+                std::begin(c1), [=]() { throw std::runtime_error(desc); }),
             decorated_iterator(std::end(c1)), std::begin(c2), std::end(c2),
             std::begin(c3));
 
@@ -356,16 +356,16 @@ void test_set_union_exception()
 {
     using namespace hpx::execution;
 
-    test_set_union_exception(IteratorTag());
+    test_set_union_exception(IteratorTag(), "no_policy");
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_set_union_exception(seq, IteratorTag());
-    test_set_union_exception(par, IteratorTag());
+    test_set_union_exception(seq, IteratorTag(), "seq");
+    test_set_union_exception(par, IteratorTag(), "par");
 
-    test_set_union_exception_async(seq(task), IteratorTag());
-    test_set_union_exception_async(par(task), IteratorTag());
+    test_set_union_exception_async(seq(task), IteratorTag(), "seq(task)");
+    test_set_union_exception_async(par(task), IteratorTag(), "par(task)");
 }
 
 void set_union_exception_test()

--- a/libs/core/algorithms/tests/unit/container_algorithms/CMakeLists.txt
+++ b/libs/core/algorithms/tests/unit/container_algorithms/CMakeLists.txt
@@ -47,6 +47,7 @@ set(tests
     foreach_adapt
     foreach_range
     foreach_range_projection
+    foreach_range_sender
     generate_range
     includes_range
     inclusive_scan_range

--- a/libs/core/algorithms/tests/unit/container_algorithms/foreach_range_sender.cpp
+++ b/libs/core/algorithms/tests/unit/container_algorithms/foreach_range_sender.cpp
@@ -43,7 +43,7 @@ void test_for_each_explicit_sender_direct(
     auto exec = ex::explicit_scheduler_executor(scheduler_t(l));
     auto result =
         hpx::ranges::for_each(policy.on(exec), rng, f) | tt::sync_wait();
-    HPX_TEST(result == iterator(std::end(c)));
+    HPX_TEST(hpx::get<0>(*result) == iterator(std::end(c)));
 
     // verify values
     std::size_t count = 0;
@@ -77,7 +77,7 @@ void test_for_each_explicit_sender(Policy l, ExPolicy&& policy, IteratorTag)
     auto exec = ex::explicit_scheduler_executor(scheduler_t(l));
     auto result = ex::just(rng, f) | hpx::ranges::for_each(policy.on(exec)) |
         tt::sync_wait();
-    HPX_TEST(result == iterator(std::end(c)));
+    HPX_TEST(hpx::get<0>(*result) == iterator(std::end(c)));
 
     // verify values
     std::size_t count = 0;

--- a/libs/core/algorithms/tests/unit/container_algorithms/foreach_range_sender.cpp
+++ b/libs/core/algorithms/tests/unit/container_algorithms/foreach_range_sender.cpp
@@ -1,0 +1,182 @@
+//  Copyright (c) 2014-2022 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/local/execution.hpp>
+#include <hpx/local/init.hpp>
+#include <hpx/local/thread.hpp>
+#include <hpx/modules/iterator_support.hpp>
+#include <hpx/modules/testing.hpp>
+#include <hpx/parallel/container_algorithms/for_each.hpp>
+
+#include <algorithm>
+#include <cstddef>
+#include <iostream>
+#include <string>
+#include <vector>
+
+#include "test_utils.hpp"
+
+///////////////////////////////////////////////////////////////////////////////
+template <typename Policy, typename ExPolicy, typename IteratorTag>
+void test_for_each_explicit_sender_direct(
+    Policy l, ExPolicy&& policy, IteratorTag)
+{
+    using base_iterator = std::vector<std::size_t>::iterator;
+    using iterator = test::test_iterator<base_iterator, IteratorTag>;
+
+    std::vector<std::size_t> c(10007);
+    std::iota(std::begin(c), std::end(c), std::rand());
+
+    namespace ex = hpx::execution::experimental;
+    namespace tt = hpx::this_thread::experimental;
+
+    auto rng = hpx::util::make_iterator_range(
+        iterator(std::begin(c)), iterator(std::end(c)));
+
+    auto f = [](std::size_t& v) { v = 42; };
+
+    using scheduler_t = ex::thread_pool_policy_scheduler<Policy>;
+
+    auto exec = ex::explicit_scheduler_executor(scheduler_t(l));
+    auto result =
+        hpx::ranges::for_each(policy.on(exec), rng, f) | tt::sync_wait();
+    HPX_TEST(result == iterator(std::end(c)));
+
+    // verify values
+    std::size_t count = 0;
+    std::for_each(std::begin(c), std::end(c), [&count](std::size_t v) -> void {
+        HPX_TEST_EQ(v, std::size_t(42));
+        ++count;
+    });
+    HPX_TEST_EQ(count, c.size());
+}
+
+///////////////////////////////////////////////////////////////////////////////
+template <typename Policy, typename ExPolicy, typename IteratorTag>
+void test_for_each_explicit_sender(Policy l, ExPolicy&& policy, IteratorTag)
+{
+    using base_iterator = std::vector<std::size_t>::iterator;
+    using iterator = test::test_iterator<base_iterator, IteratorTag>;
+
+    std::vector<std::size_t> c(10007);
+    std::iota(std::begin(c), std::end(c), std::rand());
+
+    namespace ex = hpx::execution::experimental;
+    namespace tt = hpx::this_thread::experimental;
+
+    auto rng = hpx::util::make_iterator_range(
+        iterator(std::begin(c)), iterator(std::end(c)));
+
+    auto f = [](std::size_t& v) { v = 42; };
+
+    using scheduler_t = ex::thread_pool_policy_scheduler<Policy>;
+
+    auto exec = ex::explicit_scheduler_executor(scheduler_t(l));
+    auto result = ex::just(rng, f) | hpx::ranges::for_each(policy.on(exec)) |
+        tt::sync_wait();
+    HPX_TEST(result == iterator(std::end(c)));
+
+    // verify values
+    std::size_t count = 0;
+    std::for_each(std::begin(c), std::end(c), [&count](std::size_t v) -> void {
+        HPX_TEST_EQ(v, std::size_t(42));
+        ++count;
+    });
+    HPX_TEST_EQ(count, c.size());
+}
+
+template <typename IteratorTag>
+void test_for_each_sender_direct()
+{
+    using namespace hpx::execution;
+
+    test_for_each_explicit_sender_direct(hpx::launch::sync, seq, IteratorTag());
+    test_for_each_explicit_sender_direct(
+        hpx::launch::sync, unseq, IteratorTag());
+    test_for_each_explicit_sender_direct(
+        hpx::launch::async, par, IteratorTag());
+    test_for_each_explicit_sender_direct(
+        hpx::launch::async, par_unseq, IteratorTag());
+
+    test_for_each_explicit_sender_direct(
+        hpx::launch::sync, seq(task), IteratorTag());
+    test_for_each_explicit_sender_direct(
+        hpx::launch::sync, unseq(task), IteratorTag());
+    test_for_each_explicit_sender_direct(
+        hpx::launch::async, par(task), IteratorTag());
+    test_for_each_explicit_sender_direct(
+        hpx::launch::async, par_unseq(task), IteratorTag());
+}
+
+template <typename IteratorTag>
+void test_for_each_sender()
+{
+    using namespace hpx::execution;
+
+    test_for_each_explicit_sender(hpx::launch::sync, seq, IteratorTag());
+    test_for_each_explicit_sender(hpx::launch::sync, unseq, IteratorTag());
+    test_for_each_explicit_sender(hpx::launch::async, par, IteratorTag());
+    test_for_each_explicit_sender(hpx::launch::async, par_unseq, IteratorTag());
+
+    test_for_each_explicit_sender(hpx::launch::sync, seq(task), IteratorTag());
+    test_for_each_explicit_sender(
+        hpx::launch::sync, unseq(task), IteratorTag());
+    test_for_each_explicit_sender(hpx::launch::async, par(task), IteratorTag());
+    test_for_each_explicit_sender(
+        hpx::launch::async, par_unseq(task), IteratorTag());
+}
+
+void for_each_sender_test_direct()
+{
+    test_for_each_sender_direct<std::random_access_iterator_tag>();
+    test_for_each_sender_direct<std::forward_iterator_tag>();
+}
+
+void for_each_sender_test()
+{
+    test_for_each_sender<std::random_access_iterator_tag>();
+    test_for_each_sender<std::forward_iterator_tag>();
+}
+
+///////////////////////////////////////////////////////////////////////////////
+int hpx_main(hpx::program_options::variables_map& vm)
+{
+    unsigned int seed = (unsigned int) std::time(nullptr);
+    if (vm.count("seed"))
+        seed = vm["seed"].as<unsigned int>();
+
+    std::cout << "using seed: " << seed << std::endl;
+    std::srand(seed);
+
+    for_each_sender_test_direct();
+    for_each_sender_test();
+
+    return hpx::local::finalize();
+}
+
+int main(int argc, char* argv[])
+{
+    // add command line option which controls the random number generator seed
+    using namespace hpx::program_options;
+    options_description desc_commandline(
+        "Usage: " HPX_APPLICATION_STRING " [options]");
+
+    desc_commandline.add_options()("seed,s", value<unsigned int>(),
+        "the random number generator seed to use for this run");
+
+    // By default this test should run on all available cores
+    std::vector<std::string> const cfg = {"hpx.os_threads=all"};
+
+    // Initialize and run HPX
+    hpx::local::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::local::init(hpx_main, argc, argv, init_args), 0,
+        "HPX main exited with non-zero status");
+
+    return hpx::util::report_errors();
+}

--- a/libs/core/algorithms/tests/unit/container_algorithms/partial_sort_copy_range.cpp
+++ b/libs/core/algorithms/tests/unit/container_algorithms/partial_sort_copy_range.cpp
@@ -26,7 +26,11 @@
 unsigned int seed = std::random_device{}();
 std::mt19937 gen(seed);
 
+#if defined(HPX_DEBUG)
+#define SIZE 111
+#else
 #define SIZE 1007
+#endif
 
 template <typename IteratorTag>
 void test_partial_sort_range_sent(IteratorTag)
@@ -119,13 +123,13 @@ void test_partial_sort_range_async_sent(ExPolicy p, IteratorTag)
         auto result = hpx::ranges::partial_sort_copy(p, lst.begin(),
             sentinel<std::uint64_t>{SIZE}, A.begin(),
             sentinel<std::uint64_t>{*(A.begin() + i)}, compare_t());
-        result.wait();
+        result.get();
 
         for (std::uint64_t j = 0; j < i; ++j)
         {
             HPX_ASSERT(A[j] == j);
-        };
-    };
+        }
+    }
 }
 
 template <typename IteratorTag>
@@ -213,13 +217,13 @@ void test_partial_sort_range_async(ExPolicy p, IteratorTag)
         A = B;
 
         auto result = hpx::ranges::partial_sort_copy(p, lst, A, compare_t());
-        result.wait();
+        result.get();
 
         for (std::uint64_t j = 0; j < i; ++j)
         {
             HPX_ASSERT(A[j] == j);
-        };
-    };
+        }
+    }
 }
 
 template <typename IteratorTag>

--- a/libs/core/async_base/include/hpx/async_base/scheduling_properties.hpp
+++ b/libs/core/async_base/include/hpx/async_base/scheduling_properties.hpp
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <hpx/config.hpp>
+#include <hpx/coroutines/thread_enums.hpp>
 #include <hpx/functional/detail/tag_fallback_invoke.hpp>
 
 namespace hpx { namespace execution { namespace experimental {
@@ -46,8 +47,16 @@ namespace hpx { namespace execution { namespace experimental {
     } with_priority{};
 
     inline constexpr struct get_priority_t final
-      : detail::property_base<get_priority_t>
+      : hpx::functional::detail::tag_fallback<get_priority_t>
     {
+    private:
+        // simply return default_ if get_priority is not supported
+        template <typename Target>
+        friend HPX_FORCEINLINE constexpr hpx::threads::thread_priority
+        tag_fallback_invoke(get_priority_t, Target&&) noexcept
+        {
+            return hpx::threads::thread_priority::default_;
+        }
     } get_priority{};
 
     inline constexpr struct with_stacksize_t final
@@ -56,8 +65,16 @@ namespace hpx { namespace execution { namespace experimental {
     } with_stacksize{};
 
     inline constexpr struct get_stacksize_t final
-      : detail::property_base<get_stacksize_t>
+      : hpx::functional::detail::tag_fallback<get_stacksize_t>
     {
+    private:
+        // simply return default_ if get_stacksize is not supported
+        template <typename Target>
+        friend HPX_FORCEINLINE constexpr hpx::threads::thread_stacksize
+        tag_fallback_invoke(get_stacksize_t, Target&&) noexcept
+        {
+            return hpx::threads::thread_stacksize::default_;
+        }
     } get_stacksize{};
 
     inline constexpr struct with_hint_t final
@@ -65,8 +82,17 @@ namespace hpx { namespace execution { namespace experimental {
     {
     } with_hint{};
 
-    inline constexpr struct get_hint_t final : detail::property_base<get_hint_t>
+    inline constexpr struct get_hint_t final
+      : hpx::functional::detail::tag_fallback<get_hint_t>
     {
+    private:
+        // simply return default constructed hint if get_hint is not supported
+        template <typename Target>
+        friend HPX_FORCEINLINE constexpr hpx::threads::thread_schedule_hint
+        tag_fallback_invoke(get_hint_t, Target&&) noexcept
+        {
+            return {};
+        }
     } get_hint{};
 
     inline constexpr struct with_annotation_t final
@@ -75,7 +101,15 @@ namespace hpx { namespace execution { namespace experimental {
     } with_annotation{};
 
     inline constexpr struct get_annotation_t final
-      : detail::property_base<get_annotation_t>
+      : hpx::functional::detail::tag_fallback<get_annotation_t>
     {
+    private:
+        // simply return nullptr if get_annotation is not supported
+        template <typename Target>
+        friend HPX_FORCEINLINE constexpr char const* tag_fallback_invoke(
+            get_annotation_t, Target&&) noexcept
+        {
+            return nullptr;
+        }
     } get_annotation{};
 }}}    // namespace hpx::execution::experimental

--- a/libs/core/compute_local/include/hpx/compute_local/host/block_fork_join_executor.hpp
+++ b/libs/core/compute_local/include/hpx/compute_local/host/block_fork_join_executor.hpp
@@ -273,7 +273,8 @@ namespace hpx::execution::experimental {
         // clang-format off
         template <typename Tag, typename Property,
             HPX_CONCEPT_REQUIRES_(
-                hpx::is_invocable_v<Tag, fork_join_executor, Property>
+                hpx::functional::is_tag_invocable_v<
+                    Tag, fork_join_executor, Property>
             )>
         // clang-format on
         friend block_fork_join_executor tag_invoke(Tag tag,
@@ -287,10 +288,10 @@ namespace hpx::execution::experimental {
         // clang-format off
         template <typename Tag,
             HPX_CONCEPT_REQUIRES_(
-                hpx::is_invocable_v<Tag, fork_join_executor>
+                hpx::functional::is_tag_invocable_v<Tag, fork_join_executor>
             )>
         // clang-format on
-        friend char const* tag_invoke(
+        friend decltype(auto) tag_invoke(
             Tag tag, block_fork_join_executor const& exec) noexcept
         {
             return tag(exec.exec_);

--- a/libs/core/concurrency/include/hpx/concurrency/detail/contiguous_index_queue.hpp
+++ b/libs/core/concurrency/include/hpx/concurrency/detail/contiguous_index_queue.hpp
@@ -13,6 +13,7 @@
 #include <atomic>
 #include <cstdint>
 #include <type_traits>
+#include <utility>
 
 namespace hpx { namespace concurrency { namespace detail {
 
@@ -180,6 +181,12 @@ namespace hpx { namespace concurrency { namespace detail {
         constexpr bool empty() const noexcept
         {
             return current_range.data_.load(std::memory_order_relaxed).empty();
+        }
+
+        std::pair<T, T> get_current_range() const
+        {
+            auto r = current_range.data_.load(std::memory_order_relaxed);
+            return {r.first, r.last};
         }
 
     private:

--- a/libs/core/config/cmake/templates/config_defines.hpp.in
+++ b/libs/core/config/cmake/templates/config_defines.hpp.in
@@ -1,4 +1,5 @@
 //  Copyright (c) 2012-2013 Thomas Heller
+//  Copyright (c) 2022 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -16,5 +17,3 @@
     !defined(HPX_HAVE_MORE_THAN_64_THREADS)
 #define HPX_HAVE_MORE_THAN_64_THREADS
 #endif
-
-

--- a/libs/core/datastructures/include/hpx/datastructures/detail/optional.hpp
+++ b/libs/core/datastructures/include/hpx/datastructures/detail/optional.hpp
@@ -62,7 +62,7 @@ namespace hpx::optional_ns {
         {
         }
 
-        explicit constexpr optional(nullopt_t) noexcept
+        constexpr optional(nullopt_t) noexcept
           : empty_(true)
         {
         }
@@ -328,7 +328,8 @@ namespace hpx::optional_ns {
             empty_ = false;
         }
 
-#if !defined(HPX_HAVE_CXX17_COPY_ELISION)
+#if !defined(HPX_HAVE_CXX17_COPY_ELISION) ||                                   \
+    !defined(HPX_HAVE_CXX17_OPTIONAL_COPY_ELISION)
         // workaround for broken return type copy elison in MSVC
         template <typename F, typename... Ts>
         void emplace_f(F&& f, Ts&&... ts)

--- a/libs/core/datastructures/include/hpx/datastructures/optional.hpp
+++ b/libs/core/datastructures/include/hpx/datastructures/optional.hpp
@@ -8,7 +8,9 @@
 
 #include <hpx/config.hpp>
 
-#if defined(HPX_HAVE_CXX17_COPY_ELISION)
+#if defined(HPX_HAVE_CXX17_COPY_ELISION) &&                                    \
+    defined(HPX_HAVE_CXX17_OPTIONAL_COPY_ELISION)
+
 #include <functional>    // for std::hash<optional<T>>
 #include <optional>
 

--- a/libs/core/execution/include/hpx/execution/algorithms/let_value.hpp
+++ b/libs/core/execution/include/hpx/execution/algorithms/let_value.hpp
@@ -81,8 +81,8 @@ namespace hpx::execution::experimental {
                     template <typename...> typename Variant = meta::pack>
                 using sender_types =
                     meta::apply<
-                        meta::transform<meta::uncurry<meta::unique<
-                                meta::func<successor_sender_types>>>,
+                        meta::transform<meta::uncurry<
+                            meta::func<successor_sender_types>>,
                             meta::func<Variant>>,
                         predecessor_value_types<Tuple>>;
 

--- a/libs/core/execution/include/hpx/execution/algorithms/then.hpp
+++ b/libs/core/execution/include/hpx/execution/algorithms/then.hpp
@@ -133,14 +133,6 @@ namespace hpx::execution::experimental {
             friend auto tag_invoke(get_completion_signatures_t,
                 then_sender const&, Env) -> generate_completion_signatures<Env>;
 
-            //using signatures = hpx::util::detail::concat_inner_packs_t<
-            //    hpx::util::detail::concat_t<hpx::tuple<
-            //        std::size_t, double, std::string>>>;
-
-            //using signatures = typename completion_signatures_of_t<Sender,
-            //    empty_env>::template value_types<gen_value_signature,
-            //    hpx::variant>;
-
             // clang-format off
             template <typename CPO,
                 HPX_CONCEPT_REQUIRES_(

--- a/libs/core/execution/include/hpx/execution/detail/post_policy_dispatch.hpp
+++ b/libs/core/execution/include/hpx/execution/detail/post_policy_dispatch.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2017-2021 Hartmut Kaiser
+//  Copyright (c) 2017-2022 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -31,8 +31,8 @@ namespace hpx::detail {
     template <>
     struct post_policy_dispatch<launch::async_policy>
     {
-        template <typename F, typename... Ts>
-        static void call(launch::async_policy const& policy,
+        template <typename Policy, typename F, typename... Ts>
+        static void call(Policy const& policy,
             hpx::util::thread_description const& desc,
             threads::thread_pool_base* pool, F&& f, Ts&&... ts)
         {
@@ -45,8 +45,8 @@ namespace hpx::detail {
             threads::register_work(data, pool);
         }
 
-        template <typename F, typename... Ts>
-        static void call(launch::async_policy const& policy,
+        template <typename Policy, typename F, typename... Ts>
+        static void call(Policy const& policy,
             hpx::util::thread_description const& desc, F&& f, Ts&&... ts)
         {
             call(policy, desc, threads::detail::get_self_or_default_pool(),
@@ -57,8 +57,8 @@ namespace hpx::detail {
     template <>
     struct post_policy_dispatch<launch::fork_policy>
     {
-        template <typename F, typename... Ts>
-        static void call(launch::fork_policy const& policy,
+        template <typename Policy, typename F, typename... Ts>
+        static void call(Policy const& policy,
             hpx::util::thread_description const& desc,
             threads::thread_pool_base* pool, F&& f, Ts&&... ts)
         {
@@ -87,8 +87,8 @@ namespace hpx::detail {
             }
         }
 
-        template <typename F, typename... Ts>
-        static void call(launch::fork_policy const& policy,
+        template <typename Policy, typename F, typename... Ts>
+        static void call(Policy const& policy,
             hpx::util::thread_description const& desc, F&& f, Ts&&... ts)
         {
             call(policy, desc, threads::detail::get_self_or_default_pool(),
@@ -99,8 +99,8 @@ namespace hpx::detail {
     template <>
     struct post_policy_dispatch<launch::sync_policy>
     {
-        template <typename F, typename... Ts>
-        static void call(launch::sync_policy const& policy,
+        template <typename Policy, typename F, typename... Ts>
+        static void call(Policy const& policy,
             hpx::util::thread_description const&, threads::thread_pool_base*,
             F&& f, Ts&&... ts)
         {
@@ -108,8 +108,8 @@ namespace hpx::detail {
                 policy, HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...);
         }
 
-        template <typename F, typename... Ts>
-        static void call(launch::sync_policy const& policy,
+        template <typename Policy, typename F, typename... Ts>
+        static void call(Policy const& policy,
             hpx::util::thread_description const&, F&& f, Ts&&... ts)
         {
             hpx::detail::sync_launch_policy_dispatch<launch::sync_policy>::call(
@@ -120,8 +120,8 @@ namespace hpx::detail {
     template <>
     struct post_policy_dispatch<launch::deferred_policy>
     {
-        template <typename F, typename... Ts>
-        static void call(launch::deferred_policy const& policy,
+        template <typename Policy, typename F, typename... Ts>
+        static void call(Policy const& policy,
             hpx::util::thread_description const&, threads::thread_pool_base*,
             F&& f, Ts&&... ts)
         {
@@ -130,8 +130,8 @@ namespace hpx::detail {
                 HPX_FORWARD(Ts, ts)...);
         }
 
-        template <typename F, typename... Ts>
-        static void call(launch::deferred_policy const& policy,
+        template <typename Policy, typename F, typename... Ts>
+        static void call(Policy const& policy,
             hpx::util::thread_description const&, F&& f, Ts&&... ts)
         {
             hpx::detail::sync_launch_policy_dispatch<
@@ -150,37 +150,24 @@ namespace hpx::detail {
         {
             if (policy == launch::sync)
             {
-                auto sync_policy = launch::sync_policy(
-                    policy.priority(), policy.stacksize(), policy.hint());
-
-                post_policy_dispatch<launch::sync_policy>::call(sync_policy,
-                    desc, pool, HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...);
+                post_policy_dispatch<launch::sync_policy>::call(policy, desc,
+                    pool, HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...);
             }
             else if (policy == launch::deferred)
             {
                 // execute synchronously
-                auto deferred_policy = launch::deferred_policy(
-                    policy.priority(), policy.stacksize(), policy.hint());
-
-                post_policy_dispatch<launch::deferred_policy>::call(
-                    deferred_policy, desc, pool, HPX_FORWARD(F, f),
-                    HPX_FORWARD(Ts, ts)...);
+                post_policy_dispatch<launch::deferred_policy>::call(policy,
+                    desc, pool, HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...);
             }
             else if (policy == launch::fork)
             {
-                auto fork_policy = launch::fork_policy(
-                    policy.priority(), policy.stacksize(), policy.hint());
-
-                post_policy_dispatch<launch::fork_policy>::call(fork_policy,
-                    desc, pool, HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...);
+                post_policy_dispatch<launch::fork_policy>::call(policy, desc,
+                    pool, HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...);
             }
             else
             {
-                auto async_policy = launch::async_policy(
-                    policy.priority(), policy.stacksize(), policy.hint());
-
-                post_policy_dispatch<launch::async_policy>::call(async_policy,
-                    desc, pool, HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...);
+                post_policy_dispatch<launch::async_policy>::call(policy, desc,
+                    pool, HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...);
             }
         }
 

--- a/libs/core/execution/include/hpx/execution/executors/execution.hpp
+++ b/libs/core/execution/include/hpx/execution/executors/execution.hpp
@@ -926,7 +926,6 @@ namespace hpx { namespace parallel { namespace execution {
                 !hpx::traits::is_two_way_executor_v<Executor> &&
                 !hpx::traits::is_bulk_one_way_executor_v<Executor>>>
         {
-            // returns void if F returns void
             template <typename BulkExecutor, typename F, typename Shape,
                 typename... Ts>
             HPX_FORCEINLINE static auto call_impl(hpx::traits::detail::wrap_int,
@@ -1092,6 +1091,15 @@ namespace hpx { namespace parallel { namespace execution {
                     if (exceptions.size() != 0)
                     {
                         throw exceptions;
+                    }
+                    catch (std::bad_alloc const& ba)
+                    {
+                        throw ba;
+                    }
+                    catch (...)
+                    {
+                        // note: constructor doesn't lock/suspend
+                        throw hpx::exception_list(std::current_exception());
                     }
                 }
             }

--- a/libs/core/execution/include/hpx/execution/executors/execution.hpp
+++ b/libs/core/execution/include/hpx/execution/executors/execution.hpp
@@ -1092,15 +1092,6 @@ namespace hpx { namespace parallel { namespace execution {
                     {
                         throw exceptions;
                     }
-                    catch (std::bad_alloc const& ba)
-                    {
-                        throw ba;
-                    }
-                    catch (...)
-                    {
-                        // note: constructor doesn't lock/suspend
-                        throw hpx::exception_list(std::current_exception());
-                    }
                 }
             }
 

--- a/libs/core/execution/include/hpx/execution/traits/is_execution_policy.hpp
+++ b/libs/core/execution/include/hpx/execution/traits/is_execution_policy.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2016-2020 Hartmut Kaiser
+//  Copyright (c) 2016-2022 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <hpx/config.hpp>
+#include <hpx/execution_base/traits/is_executor.hpp>
 
 #include <type_traits>
 
@@ -178,5 +179,25 @@ namespace hpx {
     template <typename T>
     inline constexpr bool is_vectorpack_execution_policy_v =
         is_vectorpack_execution_policy<T>::value;
+
+    ///////////////////////////////////////////////////////////////////////////
+    // execution_policy_has_scheduler_executor evaluates to true if the executor
+    // the given policy contains returns senders from its scheduling functions
+    template <typename T, typename Enable = void>
+    struct execution_policy_has_scheduler_executor : std::false_type
+    {
+    };
+
+    template <typename T>
+    struct execution_policy_has_scheduler_executor<T,
+        std::void_t<typename std::decay_t<T>::executor_type>>
+      : hpx::traits::is_scheduler_executor<
+            typename std::decay_t<T>::executor_type>
+    {
+    };
+
+    template <typename T>
+    inline constexpr bool execution_policy_has_scheduler_executor_v =
+        execution_policy_has_scheduler_executor<T>::value;
     /// \endcond
 }    // namespace hpx

--- a/libs/core/execution/tests/unit/executor_parameters_dispatching.cpp
+++ b/libs/core/execution/tests/unit/executor_parameters_dispatching.cpp
@@ -332,6 +332,16 @@ void test_processing_units_count()
         HPX_TEST_EQ(num_cores, std::size_t(2));
         HPX_TEST_EQ(params_count, std::size_t(0));
     }
+
+    {
+        auto p = hpx::parallel::execution::with_processing_units_count(
+            hpx::execution::par, 2);
+
+        std::size_t num_cores =
+            hpx::parallel::execution::processing_units_count(p);
+
+        HPX_TEST_EQ(num_cores, std::size_t(2));
+    }
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/libs/core/execution_base/include/hpx/execution_base/any_sender.hpp
+++ b/libs/core/execution_base/include/hpx/execution_base/any_sender.hpp
@@ -34,7 +34,7 @@ namespace hpx::detail {
     template <typename T>
     using empty_vtable_t = typename empty_vtable_type<T>::type;
 
-#if defined(HPX_HAVE_CXX20_TRIVIAL_VIRTUAL_DESTRUCTOR)
+#if !defined(HPX_MSVC) && defined(HPX_HAVE_CXX20_TRIVIAL_VIRTUAL_DESTRUCTOR)
     template <typename T>
     inline constexpr empty_vtable_t<T> empty_vtable{};
 
@@ -287,9 +287,10 @@ namespace hpx::detail {
 }    // namespace hpx::detail
 
 namespace hpx::execution::experimental::detail {
-    struct any_operation_state_base
+    struct HPX_CORE_EXPORT any_operation_state_base
     {
         virtual ~any_operation_state_base() = default;
+
         virtual bool empty() const noexcept
         {
             return false;
@@ -675,7 +676,7 @@ namespace hpx::execution::experimental::detail {
 
 namespace hpx::execution::experimental {
 
-#if !defined(HPX_HAVE_CXX20_TRIVIAL_VIRTUAL_DESTRUCTOR)
+#if defined(HPX_MSVC) || !defined(HPX_HAVE_CXX20_TRIVIAL_VIRTUAL_DESTRUCTOR)
     namespace detail {
         // This helper only exists to make it possible to use
         // any_(unique_)sender in global variables or in general static
@@ -702,7 +703,7 @@ namespace hpx::execution::experimental {
 
     template <typename... Ts>
     class unique_any_sender
-#if !defined(HPX_HAVE_CXX20_TRIVIAL_VIRTUAL_DESTRUCTOR)
+#if defined(HPX_MSVC) || !defined(HPX_HAVE_CXX20_TRIVIAL_VIRTUAL_DESTRUCTOR)
       : private detail::any_sender_static_empty_vtable_helper<Ts...>
 #endif
     {
@@ -765,7 +766,7 @@ namespace hpx::execution::experimental {
 
     template <typename... Ts>
     class any_sender
-#if !defined(HPX_HAVE_CXX20_TRIVIAL_VIRTUAL_DESTRUCTOR)
+#if defined(HPX_MSVC) || !defined(HPX_HAVE_CXX20_TRIVIAL_VIRTUAL_DESTRUCTOR)
       : private detail::any_sender_static_empty_vtable_helper<Ts...>
 #endif
     {

--- a/libs/core/execution_base/include/hpx/execution_base/completion_signatures.hpp
+++ b/libs/core/execution_base/include/hpx/execution_base/completion_signatures.hpp
@@ -387,7 +387,7 @@ namespace hpx::execution::experimental {
 
     // The sender_of concept defines the requirements for a sender type that on
     // successful completion sends the specified set of value types.
-    template <class S, class E = no_env, class... Ts>
+    template <typename S, typename E = no_env, typename... Ts>
     struct is_sender_of;
 
     namespace detail {
@@ -632,7 +632,7 @@ namespace hpx::execution::experimental {
         };
     }    // namespace detail
 
-    template <class S, class E, class... Ts>
+    template <typename S, typename E, typename... Ts>
     struct is_sender_of
       : detail::is_sender_of_impl<is_sender_v<S, E>, S, E, Ts...>
     {

--- a/libs/core/execution_base/include/hpx/execution_base/traits/is_executor.hpp
+++ b/libs/core/execution_base/include/hpx/execution_base/traits/is_executor.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2017-2021 Hartmut Kaiser
+//  Copyright (c) 2017-2022 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -35,6 +35,11 @@ namespace hpx { namespace parallel { namespace execution {
 
         template <typename T>
         struct is_bulk_two_way_executor : std::false_type
+        {
+        };
+
+        template <typename T>
+        struct is_scheduler_executor : std::false_type
         {
         };
     }    // namespace detail
@@ -76,6 +81,15 @@ namespace hpx { namespace parallel { namespace execution {
     template <typename T, typename Enable = void>
     struct is_bulk_two_way_executor
       : detail::is_bulk_two_way_executor<std::decay_t<T>>
+    {
+    };
+
+    ///////////////////////////////////////////////////////////////////////////
+    // is_scheduler_executor evaluates to true for executors that return senders
+    // from their scheduling functions
+    template <typename T, typename Enable = void>
+    struct is_scheduler_executor
+      : detail::is_scheduler_executor<std::decay_t<T>>
     {
     };
 }}}    // namespace hpx::parallel::execution
@@ -162,4 +176,20 @@ namespace hpx { namespace traits {
 
     template <typename T>
     inline constexpr bool is_executor_any_v = is_executor_any<T>::value;
+
+    ///////////////////////////////////////////////////////////////////////////
+    // is_scheduler_executor evaluates to true for executors that return senders
+    // from their scheduling functions
+    template <typename T, typename Enable = void>
+    struct is_scheduler_executor
+      : parallel::execution::is_scheduler_executor<std::decay_t<T>>
+    {
+    };
+
+    template <typename T>
+    using is_scheduler_executor_t = typename is_scheduler_executor<T>::type;
+
+    template <typename T>
+    inline constexpr bool is_scheduler_executor_v =
+        is_scheduler_executor<T>::value;
 }}    // namespace hpx::traits

--- a/libs/core/execution_base/src/any_sender.cpp
+++ b/libs/core/execution_base/src/any_sender.cpp
@@ -15,11 +15,12 @@
 #include <utility>
 
 namespace hpx::execution::experimental::detail {
+
     void empty_any_operation_state::start() & noexcept
     {
         HPX_THROW_EXCEPTION(hpx::bad_function_call,
-            "attempted to call start on empty any_operation_state",
-            "any_operation_state::start");
+            "any_operation_state::start",
+            "attempted to call start on empty any_operation_state");
     }
 
     bool empty_any_operation_state::empty() const noexcept
@@ -36,8 +37,8 @@ namespace hpx::execution::experimental::detail {
     void throw_bad_any_call(char const* class_name, char const* function_name)
     {
         HPX_THROW_EXCEPTION(hpx::bad_function_call,
+            hpx::util::format("{}::{}", class_name, function_name),
             hpx::util::format(
-                "attempted to call {} on empty {}", function_name, class_name),
-            hpx::util::format("{}::{}", class_name, function_name));
+                "attempted to call {} on empty {}", function_name, class_name));
     }
 }    // namespace hpx::execution::experimental::detail

--- a/libs/core/executors/CMakeLists.txt
+++ b/libs/core/executors/CMakeLists.txt
@@ -21,6 +21,7 @@ set(executors_headers
     hpx/executors/execution_policy_mappings.hpp
     hpx/executors/execution_policy_parameters.hpp
     hpx/executors/execution_policy.hpp
+    hpx/executors/explicit_scheduler_executor.hpp
     hpx/executors/fork_join_executor.hpp
     hpx/executors/limiting_executor.hpp
     hpx/executors/parallel_executor_aggregated.hpp

--- a/libs/core/executors/include/hpx/executors/annotating_executor.hpp
+++ b/libs/core/executors/include/hpx/executors/annotating_executor.hpp
@@ -13,7 +13,7 @@
 #include <hpx/execution/executors/execution_parameters.hpp>
 #include <hpx/execution_base/execution.hpp>
 #include <hpx/execution_base/traits/is_executor.hpp>
-#include <hpx/serialization/serialize.hpp>
+#include <hpx/functional/tag_invoke.hpp>
 #include <hpx/threading_base/annotated_function.hpp>
 #include <hpx/type_support/always_void.hpp>
 
@@ -29,6 +29,10 @@ namespace hpx { namespace execution { namespace experimental {
     template <typename BaseExecutor>
     struct annotating_executor
     {
+        static_assert(
+            hpx::traits::is_executor_any_v<std::decay_t<BaseExecutor>>,
+            "annotating_executor requires an executor");
+
         template <typename Executor,
             typename Enable = std::enable_if_t<
                 hpx::traits::is_executor_any_v<Executor> &&
@@ -183,6 +187,25 @@ namespace hpx { namespace execution { namespace experimental {
             return exec.annotation_;
         }
 
+        // support all properties exposed by the wrapped executor
+        template <typename Tag, typename Property,
+            typename Enable = std::enable_if_t<hpx::functional::
+                    is_tag_invocable_v<Tag, BaseExecutor, Property>>>
+        friend annotating_executor tag_invoke(
+            Tag, annotating_executor const& exec, Property&& prop)
+        {
+            return annotating_executor(hpx::functional::tag_invoke(
+                Tag{}, exec.exec_, HPX_FORWARD(Property, prop)));
+        }
+
+        template <typename Tag,
+            typename Enable = std::enable_if_t<
+                hpx::functional::is_tag_invocable_v<Tag, BaseExecutor>>>
+        friend decltype(auto) tag_invoke(Tag, annotating_executor const& exec)
+        {
+            return hpx::functional::tag_invoke(Tag{}, exec.exec_);
+        }
+
     private:
         friend class hpx::serialization::access;
 
@@ -194,10 +217,22 @@ namespace hpx { namespace execution { namespace experimental {
             // clang-format on
         }
 
-        BaseExecutor exec_;
+        std::decay_t<BaseExecutor> exec_;
         char const* const annotation_ = nullptr;
         /// \endcond
     };
+
+    ///////////////////////////////////////////////////////////////////////////
+#if !defined(DOXYGEN)   // doxygen gets confused by the deduction guides
+    template <typename BaseExecutor>
+    explicit annotating_executor(BaseExecutor&& sched, std::string annotation)
+        -> annotating_executor<std::decay_t<BaseExecutor>>;
+
+    template <typename BaseExecutor>
+    explicit annotating_executor(
+        BaseExecutor&& sched, char const* annotation = nullptr)
+        -> annotating_executor<std::decay_t<BaseExecutor>>;
+#endif
 
     ///////////////////////////////////////////////////////////////////////////
     // if the given executor does not support annotations, wrap it into

--- a/libs/core/executors/include/hpx/executors/annotating_executor.hpp
+++ b/libs/core/executors/include/hpx/executors/annotating_executor.hpp
@@ -192,18 +192,19 @@ namespace hpx { namespace execution { namespace experimental {
             typename Enable = std::enable_if_t<hpx::functional::
                     is_tag_invocable_v<Tag, BaseExecutor, Property>>>
         friend annotating_executor tag_invoke(
-            Tag, annotating_executor const& exec, Property&& prop)
+            Tag tag, annotating_executor const& exec, Property&& prop)
         {
             return annotating_executor(hpx::functional::tag_invoke(
-                Tag{}, exec.exec_, HPX_FORWARD(Property, prop)));
+                tag, exec.exec_, HPX_FORWARD(Property, prop)));
         }
 
         template <typename Tag,
             typename Enable = std::enable_if_t<
                 hpx::functional::is_tag_invocable_v<Tag, BaseExecutor>>>
-        friend decltype(auto) tag_invoke(Tag, annotating_executor const& exec)
+        friend decltype(auto) tag_invoke(
+            Tag tag, annotating_executor const& exec)
         {
-            return hpx::functional::tag_invoke(Tag{}, exec.exec_);
+            return hpx::functional::tag_invoke(tag, exec.policy_);
         }
 
     private:
@@ -223,7 +224,7 @@ namespace hpx { namespace execution { namespace experimental {
     };
 
     ///////////////////////////////////////////////////////////////////////////
-#if !defined(DOXYGEN)   // doxygen gets confused by the deduction guides
+#if !defined(DOXYGEN)    // doxygen gets confused by the deduction guides
     template <typename BaseExecutor>
     explicit annotating_executor(BaseExecutor&& sched, std::string annotation)
         -> annotating_executor<std::decay_t<BaseExecutor>>;
@@ -307,6 +308,13 @@ namespace hpx { namespace parallel { namespace execution {
     struct is_bulk_two_way_executor<
         hpx::execution::experimental::annotating_executor<BaseExecutor>>
       : is_bulk_two_way_executor<BaseExecutor>
+    {
+    };
+
+    template <typename BaseExecutor>
+    struct is_scheduler_executor<
+        hpx::execution::experimental::annotating_executor<BaseExecutor>>
+      : is_scheduler_executor<BaseExecutor>
     {
     };
     /// \endcond

--- a/libs/core/executors/include/hpx/executors/datapar/execution_policy_mappings.hpp
+++ b/libs/core/executors/include/hpx/executors/datapar/execution_policy_mappings.hpp
@@ -22,9 +22,10 @@ namespace hpx::execution::experimental {
 
     ///////////////////////////////////////////////////////////////////////////
     // Return the matching non-simd (vectorpack) execution policy
-    inline constexpr struct to_non_simd_t
+    inline constexpr struct to_non_simd_t final
       : hpx::functional::detail::tag_fallback<to_non_simd_t>
     {
+    private:
         // any non-simd policy just returns itself
         template <typename ExPolicy>
         friend constexpr decltype(auto) tag_fallback_invoke(
@@ -42,9 +43,10 @@ namespace hpx::execution::experimental {
     };
 
     // Return the matching simd (vectorpack) execution policy
-    inline constexpr struct to_simd_t
+    inline constexpr struct to_simd_t final
       : hpx::functional::detail::tag_fallback<to_simd_t>
     {
+    private:
         // any simd policy just returns itself
         template <typename ExPolicy>
         friend constexpr decltype(auto) tag_fallback_invoke(

--- a/libs/core/executors/include/hpx/executors/execution_policy_mappings.hpp
+++ b/libs/core/executors/include/hpx/executors/execution_policy_mappings.hpp
@@ -29,9 +29,10 @@ namespace hpx::execution::experimental {
 
     ///////////////////////////////////////////////////////////////////////////
     // Return the matching non-parallel (sequenced) execution policy
-    inline constexpr struct to_non_par_t
+    inline constexpr struct to_non_par_t final
       : hpx::functional::detail::tag_fallback<to_non_par_t>
     {
+    private:
         // any non-parallel policy just returns itself
         template <typename ExPolicy>
         friend constexpr decltype(auto) tag_fallback_invoke(
@@ -49,9 +50,10 @@ namespace hpx::execution::experimental {
     };
 
     // Return the matching parallel execution policy
-    inline constexpr struct to_par_t
+    inline constexpr struct to_par_t final
       : hpx::functional::detail::tag_fallback<to_par_t>
     {
+    private:
         // any parallel policy just returns itself
         template <typename ExPolicy>
         friend constexpr decltype(auto) tag_fallback_invoke(
@@ -70,9 +72,10 @@ namespace hpx::execution::experimental {
 
     ///////////////////////////////////////////////////////////////////////////
     // Return the matching non-task (synchronous) execution policy
-    inline constexpr struct to_non_task_t
+    inline constexpr struct to_non_task_t final
       : hpx::functional::detail::tag_fallback<to_non_task_t>
     {
+    private:
         // any non-task policy just returns itself
         template <typename ExPolicy>
         friend constexpr decltype(auto) tag_fallback_invoke(
@@ -90,9 +93,10 @@ namespace hpx::execution::experimental {
     };
 
     // Return the matching task (asynchronous) execution policy
-    inline constexpr struct to_task_t
+    inline constexpr struct to_task_t final
       : hpx::functional::detail::tag_fallback<to_task_t>
     {
+    private:
         // any task policy just returns itself
         template <typename ExPolicy>
         friend constexpr decltype(auto) tag_fallback_invoke(
@@ -111,9 +115,10 @@ namespace hpx::execution::experimental {
 
     ///////////////////////////////////////////////////////////////////////////
     // Return the matching non-unsequences execution policy
-    inline constexpr struct to_non_unseq_t
+    inline constexpr struct to_non_unseq_t final
       : hpx::functional::detail::tag_fallback<to_non_unseq_t>
     {
+    private:
         // any non-unsequenced policy just returns itself
         template <typename ExPolicy>
         friend constexpr decltype(auto) tag_fallback_invoke(
@@ -131,9 +136,10 @@ namespace hpx::execution::experimental {
     };
 
     // Return the matching unsequenced execution policy
-    inline constexpr struct to_unseq_t
+    inline constexpr struct to_unseq_t final
       : hpx::functional::detail::tag_fallback<to_unseq_t>
     {
+    private:
         // any unsequenced policy just returns itself
         template <typename ExPolicy>
         friend constexpr decltype(auto) tag_fallback_invoke(

--- a/libs/core/executors/include/hpx/executors/execution_policy_parameters.hpp
+++ b/libs/core/executors/include/hpx/executors/execution_policy_parameters.hpp
@@ -80,4 +80,18 @@ namespace hpx::parallel::execution {
     {
         return policy.with(HPX_FORWARD(Params, params));
     }
+
+    // clang-format off
+    template <typename ParametersProperty, typename ExPolicy, typename...Ts,
+        HPX_CONCEPT_REQUIRES_(
+            hpx::is_execution_policy_v<ExPolicy> &&
+            hpx::functional::is_tag_invocable_v<ParametersProperty,
+                typename std::decay_t<ExPolicy>::executor_type, Ts&&...>
+        )>
+    // clang-format on
+    constexpr decltype(auto) tag_fallback_invoke(
+        ParametersProperty, ExPolicy&& policy, Ts&&... ts)
+    {
+        return ParametersProperty{}(policy.executor(), HPX_FORWARD(Ts, ts)...);
+    }
 }    // namespace hpx::parallel::execution

--- a/libs/core/executors/include/hpx/executors/explicit_scheduler_executor.hpp
+++ b/libs/core/executors/include/hpx/executors/explicit_scheduler_executor.hpp
@@ -1,0 +1,247 @@
+//  Copyright (c) 2021-2022 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+/// \file parallel/executors/explicit_scheduler_executor.hpp
+
+#pragma once
+
+#include <hpx/config.hpp>
+#include <hpx/datastructures/tuple.hpp>
+#include <hpx/execution/algorithms/bulk.hpp>
+#include <hpx/execution/algorithms/keep_future.hpp>
+#include <hpx/execution/algorithms/make_future.hpp>
+#include <hpx/execution/algorithms/start_detached.hpp>
+#include <hpx/execution/algorithms/sync_wait.hpp>
+#include <hpx/execution/algorithms/then.hpp>
+#include <hpx/execution/algorithms/transfer.hpp>
+#include <hpx/execution/executors/execution.hpp>
+#include <hpx/execution/executors/execution_parameters.hpp>
+#include <hpx/execution_base/execution.hpp>
+#include <hpx/execution_base/sender.hpp>
+#include <hpx/execution_base/traits/is_executor.hpp>
+#include <hpx/functional/bind_back.hpp>
+#include <hpx/functional/bind_front.hpp>
+#include <hpx/functional/deferred_call.hpp>
+#include <hpx/functional/invoke_fused.hpp>
+#include <hpx/functional/tag_invoke.hpp>
+
+#include <exception>
+#include <string>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+namespace hpx::execution::experimental {
+
+    ///////////////////////////////////////////////////////////////////////////
+    // A explicit_scheduler_executor wraps any P2300 scheduler and implements
+    // the executor functionalities for those. All scheduling functions return
+    // senders.
+    template <typename BaseScheduler>
+    struct explicit_scheduler_executor
+    {
+        static_assert(hpx::execution::experimental::is_scheduler_v<
+                          std::decay_t<BaseScheduler>>,
+            "explicit_scheduler_executor requires a scheduler");
+
+        constexpr explicit_scheduler_executor() = default;
+
+        // clang-format off
+        template <typename Scheduler,
+            typename Enable =
+                std::enable_if_t<
+                   !std::is_same_v<
+                        std::decay_t<Scheduler>, explicit_scheduler_executor> &&
+                    hpx::execution::experimental::is_scheduler_v<Scheduler>>>
+        // clang-format on
+        constexpr explicit explicit_scheduler_executor(Scheduler&& sched)
+          : sched_(HPX_FORWARD(Scheduler, sched))
+        {
+        }
+
+        constexpr explicit_scheduler_executor(
+            explicit_scheduler_executor&&) = default;
+        constexpr explicit_scheduler_executor& operator=(
+            explicit_scheduler_executor&&) = default;
+        constexpr explicit_scheduler_executor(
+            explicit_scheduler_executor const&) = default;
+        constexpr explicit_scheduler_executor& operator=(
+            explicit_scheduler_executor const&) = default;
+
+        /// \cond NOINTERNAL
+        constexpr bool operator==(
+            explicit_scheduler_executor const& rhs) const noexcept
+        {
+            return sched_ == rhs.sched_;
+        }
+
+        constexpr bool operator!=(
+            explicit_scheduler_executor const& rhs) const noexcept
+        {
+            return sched_ != rhs.sched_;
+        }
+
+        constexpr auto const& context() const noexcept
+        {
+            return *this;
+        }
+
+        // support all properties exposed by the wrapped scheduler
+        template <typename Tag, typename Property,
+            typename Enable = std::enable_if_t<hpx::functional::
+                    is_tag_invocable_v<Tag, BaseScheduler, Property>>>
+        friend explicit_scheduler_executor tag_invoke(
+            Tag, explicit_scheduler_executor const& exec, Property&& prop)
+        {
+            return explicit_scheduler_executor(hpx::functional::tag_invoke(
+                Tag{}, exec.sched_, HPX_FORWARD(Property, prop)));
+        }
+
+        template <typename Tag,
+            typename Enable = std::enable_if_t<
+                hpx::functional::is_tag_invocable_v<Tag, BaseScheduler>>>
+        friend decltype(auto) tag_invoke(
+            Tag, explicit_scheduler_executor const& exec)
+        {
+            return hpx::functional::tag_invoke(Tag{}, exec.sched_);
+        }
+
+        // Associate the parallel_execution_tag executor tag type as a default
+        // with this executor.
+        using execution_category =
+            hpx::traits::executor_execution_category_t<BaseScheduler>;
+
+        // Associate the static_chunk_size executor parameters type as a default
+        // with this executor.
+        using executor_parameters_type = static_chunk_size;
+
+        // NonBlockingOneWayExecutor interface
+        template <typename F, typename... Ts>
+        void post(F&& f, Ts&&... ts)
+        {
+            start_detached(then(schedule(sched_),
+                hpx::util::deferred_call(
+                    HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...)));
+        }
+
+        // OneWayExecutor interface
+        template <typename F, typename... Ts>
+        auto sync_execute(F&& f, Ts&&... ts)
+        {
+            return hpx::this_thread::experimental::sync_wait(
+                async_execute(HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...));
+        }
+
+        // TwoWayExecutor interface
+        template <typename F, typename... Ts>
+        auto async_execute(F&& f, Ts&&... ts)
+        {
+            return then(schedule(sched_),
+                hpx::util::deferred_call(
+                    HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...));
+        }
+
+        template <typename F, typename Future, typename... Ts>
+        auto then_execute(F&& f, Future&& predecessor, Ts&&... ts)
+        {
+            auto&& predecessor_transfer_sched =
+                transfer(keep_future(HPX_FORWARD(Future, predecessor)), sched_);
+
+            return then(HPX_MOVE(predecessor_transfer_sched),
+                hpx::bind_back(HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...));
+        }
+
+        // BulkTwoWayExecutor interface
+        template <typename F, typename S, typename... Ts>
+        auto bulk_async_execute(F&& f, S const& shape, Ts&&... ts)
+        {
+            using shape_element =
+                typename hpx::traits::range_traits<S>::value_type;
+            using result_type = hpx::util::detail::invoke_deferred_result_t<F,
+                shape_element, Ts...>;
+
+            static_assert(
+                std::is_void_v<result_type>, "std::is_void_v<result_type>");
+
+            return bulk(schedule(sched_), shape,
+                hpx::bind_back(HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...));
+        }
+
+        template <typename F, typename S, typename... Ts>
+        void bulk_sync_execute(F&& f, S const& shape, Ts&&... ts)
+        {
+            hpx::this_thread::experimental::sync_wait(bulk_async_execute(
+                HPX_FORWARD(F, f), shape, HPX_FORWARD(Ts, ts)...));
+        }
+
+        template <typename F, typename S, typename Future, typename... Ts>
+        auto bulk_then_execute(
+            F&& f, S const& shape, Future&& predecessor, Ts&&... ts)
+        {
+            using result_type =
+                parallel::execution::detail::then_bulk_function_result_t<F, S,
+                    Future, Ts...>;
+
+            static_assert(
+                std::is_void_v<result_type>, "std::is_void_v<result_type>");
+
+            auto prereq =
+                when_all(keep_future(HPX_FORWARD(Future, predecessor)));
+
+            return bulk(transfer(HPX_MOVE(prereq), sched_), shape,
+                hpx::bind_back(HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...));
+        }
+
+    private:
+        std::decay_t<BaseScheduler> sched_;
+        /// \endcond
+    };
+
+    template <typename BaseScheduler>
+    explicit explicit_scheduler_executor(BaseScheduler&& sched)
+        -> explicit_scheduler_executor<std::decay_t<BaseScheduler>>;
+}    // namespace hpx::execution::experimental
+
+namespace hpx { namespace parallel { namespace execution {
+
+    /// \cond NOINTERNAL
+    template <typename BaseScheduler>
+    struct is_one_way_executor<hpx::execution::experimental::
+            explicit_scheduler_executor<BaseScheduler>> : std::true_type
+    {
+    };
+
+    template <typename BaseScheduler>
+    struct is_never_blocking_one_way_executor<hpx::execution::experimental::
+            explicit_scheduler_executor<BaseScheduler>> : std::true_type
+    {
+    };
+
+    template <typename BaseScheduler>
+    struct is_bulk_one_way_executor<hpx::execution::experimental::
+            explicit_scheduler_executor<BaseScheduler>> : std::true_type
+    {
+    };
+
+    template <typename BaseScheduler>
+    struct is_two_way_executor<hpx::execution::experimental::
+            explicit_scheduler_executor<BaseScheduler>> : std::true_type
+    {
+    };
+
+    template <typename BaseScheduler>
+    struct is_bulk_two_way_executor<hpx::execution::experimental::
+            explicit_scheduler_executor<BaseScheduler>> : std::true_type
+    {
+    };
+
+    template <typename BaseScheduler>
+    struct is_scheduler_executor<hpx::execution::experimental::
+            explicit_scheduler_executor<BaseScheduler>> : std::true_type
+    {
+    };
+    /// \endcond
+}}}    // namespace hpx::parallel::execution

--- a/libs/core/executors/include/hpx/executors/limiting_executor.hpp
+++ b/libs/core/executors/include/hpx/executors/limiting_executor.hpp
@@ -365,6 +365,13 @@ namespace hpx { namespace parallel { namespace execution {
       : is_bulk_two_way_executor<std::decay_t<BaseExecutor>>
     {
     };
+
+    template <typename BaseExecutor>
+    struct is_scheduler_executor<
+        hpx::execution::experimental::limiting_executor<BaseExecutor>>
+      : is_scheduler_executor<std::decay_t<BaseExecutor>>
+    {
+    };
 }}}    // namespace hpx::parallel::execution
 
 #include <hpx/config/warnings_suffix.hpp>

--- a/libs/core/executors/include/hpx/executors/parallel_executor.hpp
+++ b/libs/core/executors/include/hpx/executors/parallel_executor.hpp
@@ -88,8 +88,10 @@ namespace hpx { namespace execution {
     struct parallel_policy_executor
     {
         /// Associate the parallel_execution_tag executor tag type as a default
-        /// with this executor.
-        using execution_category = parallel_execution_tag;
+        /// with this executor, except if the given launch policy is synch.
+        using execution_category =
+            std::conditional_t<std::is_same_v<Policy, launch::sync_policy>,
+                sequenced_execution_tag, parallel_execution_tag>;
 
         /// Associate the static_chunk_size executor parameters type as a default
         /// with this executor.

--- a/libs/core/executors/include/hpx/executors/parallel_executor.hpp
+++ b/libs/core/executors/include/hpx/executors/parallel_executor.hpp
@@ -167,11 +167,11 @@ namespace hpx { namespace execution {
             typename Enable = std::enable_if_t<
                 hpx::functional::is_tag_invocable_v<Tag, Policy, Property>>>
         friend parallel_policy_executor tag_invoke(
-            Tag, parallel_policy_executor const& exec, Property&& prop)
+            Tag tag, parallel_policy_executor const& exec, Property&& prop)
         {
             auto exec_with_prop = exec;
-            exec_with_prop.policy_ =
-                Tag{}(exec.policy_, HPX_FORWARD(Property, prop));
+            exec_with_prop.policy_ = hpx::functional::tag_invoke(
+                tag, exec.policy_, HPX_FORWARD(Property, prop));
             return exec_with_prop;
         }
 
@@ -179,9 +179,9 @@ namespace hpx { namespace execution {
             typename Enable = std::enable_if_t<
                 hpx::functional::is_tag_invocable_v<Tag, Policy>>>
         friend decltype(auto) tag_invoke(
-            Tag, parallel_policy_executor const& exec)
+            Tag tag, parallel_policy_executor const& exec)
         {
-            return Tag{}(exec.policy_);
+            return hpx::functional::tag_invoke(tag, exec.policy_);
         }
 
 #if defined(HPX_HAVE_THREAD_DESCRIPTION)
@@ -272,8 +272,9 @@ namespace hpx { namespace execution {
                     "parallel_policy_executor::sync_execute");
 #endif
             HPX_UNUSED(exec);
-            return hpx::detail::sync_launch_policy_dispatch<Policy>::call(
-                launch::sync, HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...);
+            return hpx::detail::sync_launch_policy_dispatch<
+                launch::sync_policy>::call(exec.policy_, HPX_FORWARD(F, f),
+                HPX_FORWARD(Ts, ts)...);
         }
 
         // TwoWayExecutor interface

--- a/libs/core/executors/include/hpx/executors/restricted_thread_pool_executor.hpp
+++ b/libs/core/executors/include/hpx/executors/restricted_thread_pool_executor.hpp
@@ -250,5 +250,11 @@ namespace hpx::parallel::execution {
             hpx::execution::parallel_policy_executor<Policy>>
     {
     };
+
+    template <typename Policy>
+    struct is_scheduler_executor<restricted_policy_executor<Policy>>
+      : is_scheduler_executor<hpx::execution::parallel_policy_executor<Policy>>
+    {
+    };
     /// \endcond
 }    // namespace hpx::parallel::execution

--- a/libs/core/executors/include/hpx/executors/scheduler_executor.hpp
+++ b/libs/core/executors/include/hpx/executors/scheduler_executor.hpp
@@ -107,18 +107,15 @@ namespace hpx::execution::experimental {
             return *this;
         }
 
-    private:
-        // property implementations
-
-        // support all properties exposed by the embedded scheduler
+        // support all properties exposed by the wrapped scheduler
         template <typename Tag, typename Property,
             typename Enable = std::enable_if_t<hpx::functional::
                     is_tag_invocable_v<Tag, BaseScheduler, Property>>>
         friend scheduler_executor tag_invoke(
             Tag, scheduler_executor const& exec, Property&& prop)
         {
-            return scheduler_executor(
-                Tag{}(exec.sched_, HPX_FORWARD(Property, prop)));
+            return scheduler_executor(hpx::functional::tag_invoke(
+                Tag{}, exec.sched_, HPX_FORWARD(Property, prop)));
         }
 
         template <typename Tag,
@@ -126,10 +123,9 @@ namespace hpx::execution::experimental {
                 hpx::functional::is_tag_invocable_v<Tag, BaseScheduler>>>
         friend decltype(auto) tag_invoke(Tag, scheduler_executor const& exec)
         {
-            return Tag{}(exec.sched_);
+            return hpx::functional::tag_invoke(Tag{}, exec.sched_);
         }
 
-    public:
         // Associate the parallel_execution_tag executor tag type as a default
         // with this executor.
         using execution_category = parallel_execution_tag;
@@ -310,7 +306,7 @@ namespace hpx::execution::experimental {
         }
 
     private:
-        BaseScheduler sched_;
+        std::decay_t<BaseScheduler> sched_;
         /// \endcond
     };
 

--- a/libs/core/executors/include/hpx/executors/scheduler_executor.hpp
+++ b/libs/core/executors/include/hpx/executors/scheduler_executor.hpp
@@ -112,18 +112,19 @@ namespace hpx::execution::experimental {
             typename Enable = std::enable_if_t<hpx::functional::
                     is_tag_invocable_v<Tag, BaseScheduler, Property>>>
         friend scheduler_executor tag_invoke(
-            Tag, scheduler_executor const& exec, Property&& prop)
+            Tag tag, scheduler_executor const& exec, Property&& prop)
         {
             return scheduler_executor(hpx::functional::tag_invoke(
-                Tag{}, exec.sched_, HPX_FORWARD(Property, prop)));
+                tag, exec.sched_, HPX_FORWARD(Property, prop)));
         }
 
         template <typename Tag,
             typename Enable = std::enable_if_t<
                 hpx::functional::is_tag_invocable_v<Tag, BaseScheduler>>>
-        friend decltype(auto) tag_invoke(Tag, scheduler_executor const& exec)
+        friend decltype(auto) tag_invoke(
+            Tag tag, scheduler_executor const& exec)
         {
-            return hpx::functional::tag_invoke(Tag{}, exec.sched_);
+            return hpx::functional::tag_invoke(tag, exec.sched_);
         }
 
         // Associate the parallel_execution_tag executor tag type as a default
@@ -150,11 +151,10 @@ namespace hpx::execution::experimental {
 
         // OneWayExecutor interface
         template <typename F, typename... Ts>
-        friend decltype(auto) tag_invoke(
-            hpx::parallel::execution::sync_execute_t,
+        friend auto tag_invoke(hpx::parallel::execution::sync_execute_t,
             scheduler_executor const& exec, F&& f, Ts&&... ts)
         {
-            return hpx::this_thread::experimental::sync_wait(
+            return *hpx::this_thread::experimental::sync_wait(
                 then(schedule(exec.sched_),
                     hpx::util::deferred_call(
                         HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...)));

--- a/libs/core/executors/include/hpx/executors/thread_pool_scheduler.hpp
+++ b/libs/core/executors/include/hpx/executors/thread_pool_scheduler.hpp
@@ -10,10 +10,12 @@
 #include <hpx/config.hpp>
 #include <hpx/assert.hpp>
 #include <hpx/async_base/launch_policy.hpp>
+#include <hpx/concepts/concepts.hpp>
 #include <hpx/coroutines/thread_enums.hpp>
 #include <hpx/errors/try_catch_exception_ptr.hpp>
 #include <hpx/execution/detail/post_policy_dispatch.hpp>
 #include <hpx/execution/executors/execution_parameters.hpp>
+#include <hpx/execution/queries/get_scheduler.hpp>
 #include <hpx/execution_base/completion_scheduler.hpp>
 #include <hpx/execution_base/completion_signatures.hpp>
 #include <hpx/execution_base/receiver.hpp>
@@ -75,83 +77,72 @@ namespace hpx::execution::experimental {
         }
 
         /// \cond NOINTERNAL
-        bool operator==(thread_pool_policy_scheduler const& rhs) const noexcept
+        friend constexpr bool operator==(
+            thread_pool_policy_scheduler const& lhs,
+            thread_pool_policy_scheduler const& rhs) noexcept
         {
-            return pool_ == rhs.pool_ && policy_ == rhs.policy_;
+            return lhs.pool_ == rhs.pool_ && lhs.policy_ == rhs.policy_;
         }
 
-        bool operator!=(thread_pool_policy_scheduler const& rhs) const noexcept
+        friend constexpr bool operator!=(
+            thread_pool_policy_scheduler const& lhs,
+            thread_pool_policy_scheduler const& rhs) noexcept
         {
-            return !(*this == rhs);
+            return !(lhs == rhs);
         }
 
-        hpx::threads::thread_pool_base* get_thread_pool()
+        hpx::threads::thread_pool_base* get_thread_pool() noexcept
         {
             HPX_ASSERT(pool_);
             return pool_;
         }
 
-        // support with_priority property
-        friend thread_pool_policy_scheduler tag_invoke(
-            hpx::execution::experimental::with_priority_t,
-            thread_pool_policy_scheduler const& scheduler,
-            hpx::threads::thread_priority priority)
+        // support all properties exposed by the embedded policy
+        // clang-format off
+        template <typename Tag, typename Property,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::functional::is_tag_invocable_v<Tag, Policy, Property>
+            )>
+        // clang-format on
+        friend thread_pool_policy_scheduler tag_invoke(Tag tag,
+            thread_pool_policy_scheduler const& scheduler, Property&& prop)
         {
-            auto sched_with_priority = scheduler;
-            sched_with_priority.policy_ =
-                hpx::execution::experimental::with_priority(
-                    sched_with_priority.policy_, priority);
-            return sched_with_priority;
+            auto scheduler_with_prop = scheduler;
+            scheduler_with_prop.policy_ =
+                tag(scheduler.policy_, HPX_FORWARD(Property, prop));
+            return scheduler_with_prop;
         }
 
-        friend hpx::threads::thread_priority tag_invoke(
-            hpx::execution::experimental::get_priority_t,
+        // clang-format off
+        template <typename Tag,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::functional::is_tag_invocable_v<Tag, Policy>
+            )>
+        // clang-format on
+        friend decltype(auto) tag_invoke(
+            Tag tag, thread_pool_policy_scheduler const& scheduler)
+        {
+            return tag(scheduler.policy_);
+        }
+
+        friend constexpr thread_pool_policy_scheduler tag_invoke(
+            hpx::parallel::execution::with_processing_units_count_t,
+            thread_pool_policy_scheduler const& scheduler,
+            std::size_t num_cores)
+        {
+            auto scheduler_with_num_cores = scheduler;
+            scheduler_with_num_cores.num_cores_ = num_cores;
+            return scheduler_with_num_cores;
+        }
+
+        friend constexpr std::size_t tag_invoke(
+            hpx::parallel::execution::processing_units_count_t,
             thread_pool_policy_scheduler const& scheduler)
         {
-            return hpx::execution::experimental::get_priority(
-                scheduler.policy_);
+            return scheduler.get_num_cores();
         }
 
-        // support with_stacksize property
-        friend thread_pool_policy_scheduler tag_invoke(
-            hpx::execution::experimental::with_stacksize_t,
-            thread_pool_policy_scheduler const& scheduler,
-            hpx::threads::thread_stacksize stacksize)
-        {
-            auto sched_with_stacksize = scheduler;
-            sched_with_stacksize.policy_ =
-                hpx::execution::experimental::with_stacksize(
-                    sched_with_stacksize.policy_, stacksize);
-            return sched_with_stacksize;
-        }
-
-        friend hpx::threads::thread_stacksize tag_invoke(
-            hpx::execution::experimental::get_stacksize_t,
-            thread_pool_policy_scheduler const& scheduler)
-        {
-            return hpx::execution::experimental::get_stacksize(
-                scheduler.policy_);
-        }
-
-        // support with_hint property
-        friend thread_pool_policy_scheduler tag_invoke(
-            hpx::execution::experimental::with_hint_t,
-            thread_pool_policy_scheduler const& scheduler,
-            hpx::threads::thread_schedule_hint hint)
-        {
-            auto sched_with_hint = scheduler;
-            sched_with_hint.policy_ = hpx::execution::experimental::with_hint(
-                sched_with_hint.policy_, hint);
-            return sched_with_hint;
-        }
-
-        friend hpx::threads::thread_schedule_hint tag_invoke(
-            hpx::execution::experimental::get_hint_t,
-            thread_pool_policy_scheduler const& scheduler)
-        {
-            return hpx::execution::experimental::get_hint(scheduler.policy_);
-        }
-
+#if defined(HPX_HAVE_THREAD_DESCRIPTION)
         // support with_annotation property
         friend constexpr thread_pool_policy_scheduler tag_invoke(
             hpx::execution::experimental::with_annotation_t,
@@ -181,16 +172,27 @@ namespace hpx::execution::experimental {
         {
             return scheduler.annotation_;
         }
+#endif
 
         template <typename F>
-        void execute(F&& f) const
+        void execute(F&& f, Policy const& policy) const
         {
+#if defined(HPX_HAVE_THREAD_DESCRIPTION)
             hpx::util::thread_description desc(f, annotation_);
+#else
+            hpx::util::thread_description desc(f);
+#endif
             auto pool =
                 pool_ ? pool_ : threads::detail::get_self_or_default_pool();
 
             hpx::detail::post_policy_dispatch<Policy>::call(
-                policy_, desc, pool, HPX_FORWARD(F, f));
+                policy, desc, pool, HPX_FORWARD(F, f));
+        }
+
+        template <typename F>
+        HPX_FORCEINLINE void execute(F&& f) const
+        {
+            execute(HPX_FORWARD(F, f), policy_);
         }
 
         template <typename Scheduler, typename Receiver>
@@ -233,22 +235,17 @@ namespace hpx::execution::experimental {
         {
             HPX_NO_UNIQUE_ADDRESS std::decay_t<Scheduler> scheduler;
 
-            template <typename Env>
-            struct generate_completion_signatures
-            {
-                template <template <typename...> typename Tuple,
-                    template <typename...> typename Variant>
-                using value_types = Variant<Tuple<>>;
-
-                template <template <typename...> typename Variant>
-                using error_types = Variant<std::exception_ptr>;
-
-                static constexpr bool sends_stopped = false;
-            };
+            using completion_signatures =
+                hpx::execution::experimental::completion_signatures<
+                    hpx::execution::experimental::set_value_t(),
+                    hpx::execution::experimental::set_error_t(
+                        std::exception_ptr),
+                    hpx::execution::experimental::set_stopped_t()>;
 
             template <typename Env>
-            friend auto tag_invoke(get_completion_signatures_t, sender const&,
-                Env) noexcept -> generate_completion_signatures<Env>;
+            friend auto tag_invoke(
+                hpx::execution::experimental::get_completion_signatures_t,
+                sender const&, Env) noexcept -> completion_signatures;
 
             template <typename Receiver>
             friend operation_state<Scheduler, Receiver> tag_invoke(
@@ -264,9 +261,13 @@ namespace hpx::execution::experimental {
                 return {s.scheduler, HPX_FORWARD(Receiver, receiver)};
             }
 
+            // clang-format off
             template <typename CPO,
-                HPX_CONCEPT_REQUIRES_(std::is_same_v<CPO,
-                    hpx::execution::experimental::set_value_t>)>
+                HPX_CONCEPT_REQUIRES_(
+                    meta::value<meta::one_of<
+                        CPO, set_value_t, set_stopped_t>>
+                )>
+            // clang-format on
             friend constexpr auto tag_invoke(
                 hpx::execution::experimental::get_completion_scheduler_t<CPO>,
                 sender const& s)
@@ -275,14 +276,25 @@ namespace hpx::execution::experimental {
             }
         };
 
+        friend hpx::execution::experimental::forward_progress_guarantee
+        tag_invoke(
+            hpx::execution::experimental::get_forward_progress_guarantee_t,
+            thread_pool_policy_scheduler const&) noexcept
+        {
+            return hpx::execution::experimental::forward_progress_guarantee::
+                parallel;
+        }
+
         friend constexpr sender<thread_pool_policy_scheduler> tag_invoke(
-            schedule_t, thread_pool_policy_scheduler&& sched)
+            hpx::execution::experimental::schedule_t,
+            thread_pool_policy_scheduler&& sched)
         {
             return {HPX_MOVE(sched)};
         }
 
         friend constexpr sender<thread_pool_policy_scheduler> tag_invoke(
-            schedule_t, thread_pool_policy_scheduler const& sched)
+            hpx::execution::experimental::schedule_t,
+            thread_pool_policy_scheduler const& sched)
         {
             return {sched};
         }
@@ -295,10 +307,26 @@ namespace hpx::execution::experimental {
 
     private:
         /// \cond NOINTERNAL
+        std::size_t get_num_cores() const
+        {
+            if (num_cores_ != 0)
+                return num_cores_;
+
+            auto pool =
+                pool_ ? pool_ : threads::detail::get_self_or_default_pool();
+            return pool->get_os_thread_count();
+        }
+        /// \endcond
+
+    private:
+        /// \cond NOINTERNAL
         hpx::threads::thread_pool_base* pool_ =
             hpx::threads::detail::get_self_or_default_pool();
         Policy policy_;
+        std::size_t num_cores_ = 0;
+#if defined(HPX_HAVE_THREAD_DESCRIPTION)
         char const* annotation_ = nullptr;
+#endif
         /// \endcond
     };
 

--- a/libs/core/executors/include/hpx/executors/thread_pool_scheduler_bulk.hpp
+++ b/libs/core/executors/include/hpx/executors/thread_pool_scheduler_bulk.hpp
@@ -9,6 +9,7 @@
 
 #include <hpx/config.hpp>
 #include <hpx/assert.hpp>
+#include <hpx/concepts/concepts.hpp>
 #include <hpx/concurrency/detail/contiguous_index_queue.hpp>
 #include <hpx/coroutines/thread_enums.hpp>
 #include <hpx/datastructures/tuple.hpp>
@@ -29,6 +30,7 @@
 #include <hpx/iterator_support/traits/is_range.hpp>
 #include <hpx/threading_base/annotated_function.hpp>
 #include <hpx/threading_base/register_thread.hpp>
+#include <hpx/type_support/pack.hpp>
 
 #include <atomic>
 #include <cstddef>
@@ -40,578 +42,583 @@
 #include <utility>
 #include <vector>
 
-namespace hpx::execution::experimental {
+namespace hpx::execution::experimental::detail {
 
-    namespace detail {
-        /// This sender represents bulk work that will be performed using the
-        /// thread_pool_scheduler.
-        ///
-        /// The work is chunked into a number of chunks larger than the number
-        /// of worker threads available on the underlying thread pool. The
-        /// chunks are then assigned to worker thread-specific thread-safe index
-        /// queues. One HPX thread is spawned for each underlying worker (OS)
-        /// thread. The HPX thread is responsible for work in one queue. If the
-        /// queue is empty, no HPX thread will be spawned. Once the HPX thread
-        /// has finished working on its own queue, it will attempt to steal work
-        /// from other queues. Since predecessor sender must complete on an HPX
-        /// thread (the completion scheduler is a thread_pool_scheduler;
-        /// otherwise the customization defined in this file is not chosen) it
-        /// will be reused as one of the worker threads.
-        template <typename Policy, typename Sender, typename Shape, typename F>
-        class thread_pool_bulk_sender
+    ///////////////////////////////////////////////////////////////////////////
+    // Compute a chunk size given a number of worker threads and a total number
+    // of items n. Returns a power-of-2 chunk size that produces at most 8 and
+    // at least 4 chunks per worker thread.
+    static constexpr std::uint32_t get_bulk_scheduler_chunk_size(
+        std::uint32_t const num_threads, std::size_t const n)
+    {
+        std::uint32_t chunk_size = 1;
+        while (chunk_size * num_threads * 8 < n)
         {
-        private:
-            thread_pool_policy_scheduler<Policy> scheduler;
-            HPX_NO_UNIQUE_ADDRESS std::decay_t<Sender> sender;
-            HPX_NO_UNIQUE_ADDRESS std::decay_t<Shape> shape;
-            HPX_NO_UNIQUE_ADDRESS std::decay_t<F> f;
+            chunk_size *= 2;
+        }
+        return chunk_size;
+    }
 
-            using size_type = decltype(hpx::util::size(shape));
+    template <std::size_t... Is, typename F, typename T, typename Ts>
+    constexpr void bulk_scheduler_invoke_helper(
+        hpx::util::index_pack<Is...>, F&& f, T&& t, Ts& ts)
+    {
+        HPX_INVOKE(HPX_FORWARD(F, f), HPX_FORWARD(T, t), hpx::get<Is>(ts)...);
+    }
 
-        public:
-            template <typename Sender_, typename Shape_, typename F_>
-            thread_pool_bulk_sender(
-                thread_pool_policy_scheduler<Policy>&& scheduler,
-                Sender_&& sender, Shape_&& shape, F_&& f)
-              : scheduler(HPX_MOVE(scheduler))
-              , sender(HPX_FORWARD(Sender_, sender))
-              , shape(HPX_FORWARD(Shape_, shape))
-              , f(HPX_FORWARD(F_, f))
+    template <typename OperationState>
+    struct task_function;
+
+    template <typename OperationState>
+    struct set_value_loop_visitor
+    {
+        OperationState* const op_state;
+        task_function<OperationState> const* const task_f;
+
+        [[noreturn]] void operator()(hpx::monostate const&) const noexcept
+        {
+            HPX_UNREACHABLE;
+        }
+
+        // Perform the work in one element indexed by index. The index
+        // represents a range of indices (iterators) in the given shape.
+        template <typename Ts>
+        void do_work_chunk(Ts& ts, std::uint32_t const index) const
+        {
+#if HPX_HAVE_ITTNOTIFY != 0 && !defined(HPX_HAVE_APEX)
+            static hpx::util::itt::event notify_event(
+                "set_value_loop_visitor_static::do_work_chunk(chunking)");
+
+            hpx::util::itt::mark_event e(notify_event);
+#endif
+            using index_pack_type = hpx::util::detail::fused_index_pack_t<Ts>;
+
+            auto const i_begin =
+                static_cast<std::size_t>(index) * task_f->chunk_size;
+            auto const i_end = (std::min)(
+                static_cast<std::size_t>(index + 1) * task_f->chunk_size,
+                task_f->size);
+
+            auto it = std::next(hpx::util::begin(op_state->shape), i_begin);
+            for (std::uint32_t i = i_begin; i != i_end; (void) ++it, ++i)
             {
+                bulk_scheduler_invoke_helper(
+                    index_pack_type{}, op_state->f, *it, ts);
+            }
+        }
+
+        // Visit the values sent from the predecessor sender. This function
+        // first tries to handle all chunks in the queue owned by worker_thread.
+        // It then tries to steal chunks from neighboring threads.
+        //
+        // clang-format off
+        template <typename Ts,
+            HPX_CONCEPT_REQUIRES_(
+                !std::is_same_v<std::decay_t<Ts>, hpx::monostate>
+            )>
+        // clang-format on
+        void operator()(Ts& ts) const
+        {
+            auto worker_thread = task_f->worker_thread;
+            auto& local_queue = op_state->queues[worker_thread].data_;
+
+            // Handle local queue first
+            hpx::optional<std::uint32_t> index;
+            while ((index = local_queue.pop_left()))
+            {
+                do_work_chunk(ts, index.value());
             }
 
-            thread_pool_bulk_sender(thread_pool_bulk_sender&&) = default;
-            thread_pool_bulk_sender(thread_pool_bulk_sender const&) = default;
-            thread_pool_bulk_sender& operator=(
-                thread_pool_bulk_sender&&) = default;
-            thread_pool_bulk_sender& operator=(
-                thread_pool_bulk_sender const&) = default;
-
-            template <typename Env>
-            struct generate_completion_signatures
+            // Then steal from neighboring queues
+            for (std::uint32_t offset = 1;
+                 offset != op_state->num_worker_threads; ++offset)
             {
-                template <template <typename...> typename Tuple,
-                    template <typename...> typename Variant>
-                using value_types =
-                    value_types_of_t<Sender, Env, Tuple, Variant>;
+                std::size_t neighbor_thread =
+                    (worker_thread + offset) % op_state->num_worker_threads;
+                auto& neighbor_queue = op_state->queues[neighbor_thread].data_;
 
-                template <template <typename...> typename Variant>
-                using error_types = hpx::util::detail::unique_concat_t<
-                    error_types_of_t<Sender, Env, Variant>,
-                    Variant<std::exception_ptr>>;
-
-                static constexpr bool sends_stopped = false;
-            };
-
-            template <typename Env>
-            friend auto tag_invoke(get_completion_signatures_t,
-                thread_pool_bulk_sender const&, Env)
-                -> generate_completion_signatures<Env>;
-
-            // clang-format off
-            template <typename CPO,
-                HPX_CONCEPT_REQUIRES_(
-                    hpx::execution::experimental::detail::is_receiver_cpo_v<CPO> &&
-                    (std::is_same_v<CPO, hpx::execution::experimental::set_value_t> ||
-                        hpx::execution::experimental::detail::has_completion_scheduler_v<
-                                hpx::execution::experimental::set_error_t,
-                                std::decay_t<Sender>> ||
-                        hpx::execution::experimental::detail::has_completion_scheduler_v<
-                                hpx::execution::experimental::set_stopped_t,
-                                std::decay_t<Sender>>)
-                )>
-            // clang-format on
-            friend constexpr auto tag_invoke(
-                hpx::execution::experimental::get_completion_scheduler_t<CPO>,
-                thread_pool_bulk_sender const& s)
-            {
-                if constexpr (std::is_same_v<std::decay_t<CPO>,
-                                  hpx::execution::experimental::set_value_t>)
+                while ((index = neighbor_queue.pop_right()))
                 {
-                    return s.scheduler;
+                    do_work_chunk(ts, index.value());
+                }
+            }
+        }
+    };
+
+    template <typename OperationState>
+    struct set_value_end_loop_visitor
+    {
+        OperationState* const op_state;
+
+        void operator()(hpx::monostate&&) const
+        {
+            HPX_UNREACHABLE;
+        }
+
+        // Visit the values sent from the predecessor sender. This function is
+        // called once all worker threads have processed their chunks and the
+        // connected receiver should be signalled.
+        //
+        // clang-format off
+        template <typename Ts,
+            HPX_CONCEPT_REQUIRES_(
+                !std::is_same_v<std::decay_t<Ts>, hpx::monostate>
+            )>
+        // clang-format on
+        void operator()(Ts&& ts) const
+        {
+            hpx::util::invoke_fused(
+                hpx::bind_front(hpx::execution::experimental::set_value,
+                    HPX_MOVE(op_state->receiver)),
+                HPX_FORWARD(Ts, ts));
+        }
+    };
+
+    // This struct encapsulates the work done by one worker thread.
+    template <typename OperationState>
+    struct task_function
+    {
+        OperationState* const op_state;
+        std::size_t const size;
+        std::uint32_t const chunk_size;
+        std::uint32_t const worker_thread;
+
+        // Visit the values sent by the predecessor sender.
+        void do_work() const
+        {
+            auto visitor =
+                set_value_loop_visitor<OperationState>{op_state, this};
+            hpx::visit(HPX_MOVE(visitor), op_state->ts);
+        }
+
+        // Store an exception and mark that an exception was thrown in the
+        // operation state. This function assumes that there is a current
+        // exception.
+        void store_exception() const
+        {
+            if (!op_state->exception_thrown.exchange(true))
+            {
+                // NOLINTNEXTLINE(bugprone-throw-keyword-missing)
+                op_state->exception = std::current_exception();
+            }
+        }
+
+        // Finish the work for one worker thread. If this is not the last worker
+        // thread to finish, it will only decrement the counter. If it is the
+        // last thread it will call set_error if there is an exception.
+        // Otherwise it will call set_value on the connected receiver.
+        void finish() const
+        {
+            if (--(op_state->tasks_remaining) == 0)
+            {
+                if (op_state->exception_thrown)
+                {
+                    HPX_ASSERT(op_state->exception);
+                    hpx::execution::experimental::set_error(
+                        HPX_MOVE(op_state->receiver),
+                        HPX_MOVE(op_state->exception));
                 }
                 else
                 {
-                    return hpx::execution::experimental::
-                        get_completion_scheduler<CPO>(s);
+                    auto visitor =
+                        set_value_end_loop_visitor<OperationState>{op_state};
+                    hpx::visit(HPX_MOVE(visitor), HPX_MOVE(op_state->ts));
                 }
             }
+        }
 
-        private:
-            template <typename Receiver>
-            struct operation_state
+        // Entry point for the worker thread. It will attempt to do its local
+        // work, catch any exceptions, and then call set_value or set_error on
+        // the connected receiver.
+        void operator()() const
+        {
+            try
             {
-                struct bulk_receiver
-                {
-                    operation_state* op_state;
-
-                    template <typename E>
-                    friend void tag_invoke(
-                        set_error_t, bulk_receiver&& r, E&& e) noexcept
-                    {
-                        hpx::execution::experimental::set_error(
-                            HPX_MOVE(r.op_state->receiver), HPX_FORWARD(E, e));
-                    }
-
-                    friend void tag_invoke(
-                        set_stopped_t, bulk_receiver&& r) noexcept
-                    {
-                        hpx::execution::experimental::set_stopped(
-                            HPX_MOVE(r.op_state->receiver));
-                    };
-
-                    struct task_function;
-
-                    struct set_value_loop_visitor
-                    {
-                        operation_state* const op_state;
-                        task_function const* const task_f;
-
-                        void operator()(hpx::monostate const&) const
-                        {
-                            HPX_UNREACHABLE;
-                        }
-
-                        // Perform the work in one chunk indexed by index.  The
-                        // index represents a range of indices (iterators) in
-                        // the given shape.
-                        template <typename Ts>
-                        void do_work_chunk(
-                            Ts& ts, std::uint32_t const index) const
-                        {
-                            auto const i_begin = static_cast<size_type>(index) *
-                                task_f->chunk_size;
-                            auto const i_end =
-                                (std::min)(static_cast<size_type>(index + 1) *
-                                        task_f->chunk_size,
-                                    task_f->n);
-                            auto it = hpx::util::begin(op_state->shape);
-                            std::advance(it, i_begin);
-                            for (size_type i = i_begin; i < i_end; ++i)
-                            {
-                                hpx::util::invoke_fused(
-                                    hpx::bind_front(op_state->f, *it), ts);
-                                ++it;
-                            }
-                        }
-
-                        // Visit the values sent from the predecessor sender.
-                        // This function first tries to handle all chunks in the
-                        // queue owned by worker_thread. It then tries to steal
-                        // chunks from neighboring threads.
-                        template <typename Ts,
-                            typename = std::enable_if_t<!std::is_same_v<
-                                std::decay_t<Ts>, hpx::monostate>>>
-                        void operator()(Ts& ts) const
-                        {
-                            auto& local_queue =
-                                op_state->queues[task_f->worker_thread].data_;
-
-                            // Handle local queue first
-                            hpx::optional<std::uint32_t> index;
-                            while ((index = local_queue.pop_left()))
-                            {
-                                do_work_chunk(ts, index.value());
-                            }
-
-                            // Then steal from neighboring queues
-                            for (std::uint32_t offset = 1;
-                                 offset < op_state->num_worker_threads;
-                                 ++offset)
-                            {
-                                std::size_t neighbor_worker_thread =
-                                    (task_f->worker_thread + offset) %
-                                    op_state->num_worker_threads;
-                                auto& neighbor_queue =
-                                    op_state->queues[neighbor_worker_thread]
-                                        .data_;
-
-                                while ((index = neighbor_queue.pop_right()))
-                                {
-                                    do_work_chunk(ts, index.value());
-                                }
-                            }
-                        }
-                    };
-
-                    struct set_value_end_loop_visitor
-                    {
-                        operation_state* const op_state;
-
-                        void operator()(hpx::monostate&&) const
-                        {
-                            std::terminate();
-                        }
-
-                        // Visit the values sent from the predecessor sender.
-                        // This function is called once all worker threads have
-                        // processed their chunks and the connected receiver
-                        // should be signalled.
-                        template <typename Ts,
-                            typename = std::enable_if_t<!std::is_same_v<
-                                std::decay_t<Ts>, hpx::monostate>>>
-                        void operator()(Ts&& ts) const
-                        {
-                            hpx::util::invoke_fused(
-                                hpx::bind_front(
-                                    hpx::execution::experimental::set_value,
-                                    HPX_MOVE(op_state->receiver)),
-                                HPX_FORWARD(Ts, ts));
-                        }
-                    };
-
-                    // This struct encapsulates the work done by one worker thread.
-                    struct task_function
-                    {
-                        operation_state* const op_state;
-                        size_type const n;
-                        std::uint32_t const chunk_size;
-                        std::uint32_t const worker_thread;
-
-                        // Visit the values sent by the predecessor sender.
-                        void do_work() const
-                        {
-                            hpx::visit(set_value_loop_visitor{op_state, this},
-                                op_state->ts);
-                        }
-
-                        // Store an exception and mark that an exception was
-                        // thrown in the operation state. This function assumes
-                        // that there is a current exception.
-                        void store_exception() const
-                        {
-                            if (!op_state->exception_thrown.exchange(true))
-                            {
-                                // NOLINTNEXTLINE(bugprone-throw-keyword-missing)
-                                op_state->exception = std::current_exception();
-                            }
-                        }
-
-                        // Finish the work for one worker thread. If this is not
-                        // the last worker thread to finish, it will only
-                        // decrement the counter. If it is the last thread it
-                        // will call set_error if there is an exception.
-                        // Otherwise it will call set_value on the connected
-                        // receiver.
-                        void finish() const
-                        {
-                            if (--(op_state->tasks_remaining) == 0)
-                            {
-                                if (op_state->exception_thrown)
-                                {
-                                    HPX_ASSERT(op_state->exception.has_value());
-                                    hpx::execution::experimental::set_error(
-                                        HPX_MOVE(op_state->receiver),
-                                        HPX_MOVE(op_state->exception.value()));
-                                }
-                                else
-                                {
-                                    hpx::visit(
-                                        set_value_end_loop_visitor{op_state},
-                                        HPX_MOVE(op_state->ts));
-                                }
-                            }
-                        }
-
-                        // Entry point for the worker thread. It will attempt to
-                        // do its local work, catch any exceptions, and then
-                        // call set_value or set_error on the connected
-                        // receiver.
-                        void operator()()
-                        {
-                            try
-                            {
-                                do_work();
-                            }
-                            catch (...)
-                            {
-                                store_exception();
-                            }
-
-                            finish();
-                        };
-                    };
-
-                    // Compute a chunk size given a number of worker threads and
-                    // a total number of items n. Returns a power-of-2 chunk
-                    // size that produces at most 8 and at least 4 chunks per
-                    // worker thread.
-                    static constexpr std::uint32_t get_chunk_size(
-                        std::uint32_t const num_threads, size_type const n)
-                    {
-                        std::uint32_t chunk_size = 1;
-                        while (chunk_size * num_threads * 8 < n)
-                        {
-                            chunk_size *= 2;
-                        }
-                        return chunk_size;
-                    }
-
-                    // Initialize a queue for a worker thread.
-                    void init_queue(std::uint32_t const worker_thread,
-                        std::uint32_t const num_chunks)
-                    {
-                        auto& queue = op_state->queues[worker_thread].data_;
-                        auto const part_begin = static_cast<std::uint32_t>(
-                            (worker_thread * num_chunks) /
-                            op_state->num_worker_threads);
-                        auto const part_end = static_cast<std::uint32_t>(
-                            ((worker_thread + 1) * num_chunks) /
-                            op_state->num_worker_threads);
-                        queue.reset(part_begin, part_end);
-                    }
-
-                    // Spawn a task which will process a number of chunks. If
-                    // the queue contains no chunks no task will be spawned.
-                    void do_work_task(size_type const n,
-                        std::uint32_t const chunk_size,
-                        std::uint32_t const worker_thread) const
-                    {
-                        task_function task_f{
-                            this->op_state, n, chunk_size, worker_thread};
-
-                        auto& queue = op_state->queues[worker_thread].data_;
-                        if (queue.empty())
-                        {
-                            // If the queue is empty we don't spawn a task. We
-                            // only signal that this "task" is ready.
-                            task_f.finish();
-                            return;
-                        }
-
-                        // Only apply hint if none was given.
-                        auto hint = get_hint(op_state->scheduler);
-                        if (hint == hpx::threads::thread_schedule_hint())
-                        {
-                            hint = hpx::threads::thread_schedule_hint(
-                                hpx::threads::thread_schedule_hint_mode::thread,
-                                worker_thread);
-                        }
-
-                        // Spawn the task.
-                        char const* scheduler_annotation =
-                            get_annotation(op_state->scheduler);
-                        char const* annotation =
-                            scheduler_annotation == nullptr ?
-                            traits::get_function_annotation<
-                                std::decay_t<F>>::call(op_state->f) :
-                            scheduler_annotation;
-
-                        threads::thread_init_data data(
-                            threads::make_thread_function_nullary(
-                                HPX_MOVE(task_f)),
-                            annotation, get_priority(op_state->scheduler), hint,
-                            get_stacksize(op_state->scheduler));
-                        threads::register_work(
-                            data, op_state->scheduler.get_thread_pool());
-                    }
-
-                    // Do the work on the worker thread that called set_value
-                    // from the predecessor sender. This thread participates in
-                    // the work and does not need a new task since it already
-                    // runs on a task.
-                    void do_work_local(size_type n, std::uint32_t chunk_size,
-                        std::uint32_t worker_thread) const
-                    {
-                        char const* scheduler_annotation =
-                            get_annotation(op_state->scheduler);
-                        if (scheduler_annotation)
-                        {
-                            hpx::scoped_annotation ann(scheduler_annotation);
-                            task_function{
-                                this->op_state, n, chunk_size, worker_thread}();
-                        }
-                        else
-                        {
-                            hpx::scoped_annotation ann(op_state->f);
-                            task_function{
-                                this->op_state, n, chunk_size, worker_thread}();
-                        }
-                    }
-
-                    using range_value_type = hpx::traits::iter_value_t<
-                        hpx::traits::range_iterator_t<Shape>>;
-
-                    template <typename... Ts,
-                        typename = std::enable_if_t<
-                            hpx::is_invocable_v<F, range_value_type,
-                                std::add_lvalue_reference_t<Ts>...>>>
-                    friend void tag_invoke(
-                        set_value_t, bulk_receiver&& r, Ts&&... ts) noexcept
-                    {
-                        hpx::detail::try_catch_exception_ptr(
-                            [&]() {
-                                // Don't spawn tasks if there is no work to be
-                                // done
-                                auto const n =
-                                    hpx::util::size(r.op_state->shape);
-                                if (n == 0)
-                                {
-                                    hpx::execution::experimental::set_value(
-                                        HPX_MOVE(r.op_state->receiver),
-                                        HPX_FORWARD(Ts, ts)...);
-                                    return;
-                                }
-
-                                // Calculate chunk size and number of chunks
-                                auto const chunk_size = get_chunk_size(
-                                    std::uint32_t(
-                                        r.op_state->num_worker_threads),
-                                    n);
-                                auto const num_chunks = std::uint32_t(
-                                    (n + chunk_size - 1) / chunk_size);
-
-                                // Store sent values in the operation state
-                                r.op_state->ts
-                                    .template emplace<hpx::tuple<Ts...>>(
-                                        HPX_FORWARD(Ts, ts)...);
-
-                                // Initialize the queues for all worker threads
-                                // so that worker threads can start stealing
-                                // immediately when they start.
-                                for (std::uint32_t worker_thread = 0;
-                                     worker_thread <
-                                     r.op_state->num_worker_threads;
-                                     ++worker_thread)
-                                {
-                                    r.init_queue(worker_thread, num_chunks);
-                                }
-
-                                // Spawn the worker threads for all except the
-                                // local queue.
-                                auto const local_worker_thread = std::uint32_t(
-                                    hpx::get_local_worker_thread_num());
-                                for (std::uint32_t worker_thread = 0;
-                                     worker_thread <
-                                     r.op_state->num_worker_threads;
-                                     ++worker_thread)
-                                {
-                                    // The queue for the local thread is handled
-                                    // later inline.
-                                    if (worker_thread == local_worker_thread)
-                                    {
-                                        continue;
-                                    }
-
-                                    r.do_work_task(
-                                        n, chunk_size, worker_thread);
-                                }
-
-                                // Handle the queue for the local thread.
-                                r.do_work_local(
-                                    n, chunk_size, local_worker_thread);
-                            },
-                            [&](std::exception_ptr ep) {
-                                hpx::execution::experimental::set_error(
-                                    HPX_MOVE(r.op_state->receiver),
-                                    HPX_MOVE(ep));
-                            });
-                    }
-                };
-
-                using operation_state_type =
-                    hpx::execution::experimental::connect_result_t<Sender,
-                        bulk_receiver>;
-
-                thread_pool_policy_scheduler<Policy> scheduler;
-                operation_state_type op_state;
-                std::size_t num_worker_threads =
-                    scheduler.get_thread_pool()->get_os_thread_count();
-                std::vector<hpx::util::cache_aligned_data<
-                    hpx::concurrency::detail::contiguous_index_queue<>>>
-                    queues{num_worker_threads};
-                HPX_NO_UNIQUE_ADDRESS std::decay_t<Shape> shape;
-                HPX_NO_UNIQUE_ADDRESS std::decay_t<F> f;
-                HPX_NO_UNIQUE_ADDRESS std::decay_t<Receiver> receiver;
-                std::atomic<decltype(hpx::util::size(shape))> tasks_remaining{
-                    num_worker_threads};
-
-                hpx::util::detail::prepend_t<value_types_of_t<Sender, empty_env,
-                                                 decayed_tuple, hpx::variant>,
-                    hpx::monostate>
-                    ts;
-                std::atomic<bool> exception_thrown{false};
-                std::optional<std::exception_ptr> exception;
-
-                template <typename Sender_, typename Shape_, typename F_,
-                    typename Receiver_>
-                operation_state(
-                    thread_pool_policy_scheduler<Policy>&& scheduler,
-                    Sender_&& sender, Shape_&& shape, F_&& f,
-                    Receiver_&& receiver)
-                  : scheduler(HPX_MOVE(scheduler))
-                  , op_state(hpx::execution::experimental::connect(
-                        HPX_FORWARD(Sender_, sender), bulk_receiver{this}))
-                  , shape(HPX_FORWARD(Shape_, shape))
-                  , f(HPX_FORWARD(F_, f))
-                  , receiver(HPX_FORWARD(Receiver_, receiver))
-                {
-                }
-
-                friend void tag_invoke(start_t, operation_state& os) noexcept
-                {
-                    hpx::execution::experimental::start(os.op_state);
-                }
-            };
-
-        public:
-            template <typename Receiver>
-            friend auto tag_invoke(
-                connect_t, thread_pool_bulk_sender&& s, Receiver&& receiver)
+                do_work();
+            }
+            catch (...)
             {
-                return operation_state<std::decay_t<Receiver>>{
-                    HPX_MOVE(s.scheduler), HPX_MOVE(s.sender),
-                    HPX_MOVE(s.shape), HPX_MOVE(s.f),
-                    HPX_FORWARD(Receiver, receiver)};
+                store_exception();
             }
 
-            template <typename Receiver>
-            auto tag_invoke(
-                connect_t, thread_pool_bulk_sender& s, Receiver&& receiver)
+            finish();
+        };
+    };
+
+    ///////////////////////////////////////////////////////////////////////
+    template <typename OperationState, typename F, typename Shape>
+    struct bulk_receiver
+    {
+        OperationState* op_state;
+
+        template <typename E>
+        friend void tag_invoke(hpx::execution::experimental::set_error_t,
+            bulk_receiver&& r, E&& e) noexcept
+        {
+            hpx::execution::experimental::set_error(
+                HPX_MOVE(r.op_state->receiver), HPX_FORWARD(E, e));
+        }
+
+        friend void tag_invoke(hpx::execution::experimental::set_stopped_t,
+            bulk_receiver&& r) noexcept
+        {
+            hpx::execution::experimental::set_stopped(
+                HPX_MOVE(r.op_state->receiver));
+        }
+
+        // Initialize a queue for a worker thread.
+        void init_queue(
+            std::uint32_t const worker_thread, std::uint32_t const size)
+        {
+            auto& queue = op_state->queues[worker_thread].data_;
+            auto const part_begin = static_cast<std::uint32_t>(
+                (worker_thread * size) / op_state->num_worker_threads);
+            auto const part_end = static_cast<std::uint32_t>(
+                ((worker_thread + 1) * size) / op_state->num_worker_threads);
+            queue.reset(part_begin, part_end);
+        }
+
+        // Spawn a task which will process a number of chunks. If the queue
+        // contains no chunks no task will be spawned.
+        template <typename Task>
+        void do_work_task(Task&& task_f) const
+        {
+            std::uint32_t const worker_thread = task_f.worker_thread;
+            auto& queue = op_state->queues[worker_thread].data_;
+            if (queue.empty())
             {
-                return operation_state<std::decay_t<Receiver>>{s.scheduler,
-                    s.sender, s.shape, s.f, HPX_FORWARD(Receiver, receiver)};
+                // If the queue is empty we don't spawn a task. We only signal
+                // that this "task" is ready.
+                task_f.finish();
+                return;
+            }
+
+            // apply hint if none was given.
+            auto hint =
+                hpx::execution::experimental::get_hint(op_state->scheduler);
+            if (hint == hpx::threads::thread_schedule_hint())
+            {
+                auto policy = hpx::execution::experimental::with_hint(
+                    op_state->scheduler.policy(),
+                    hpx::threads::thread_schedule_hint(
+                        hpx::threads::thread_schedule_hint_mode::thread,
+                        worker_thread));
+
+                op_state->scheduler.execute(HPX_FORWARD(Task, task_f), policy);
+            }
+            else
+            {
+                op_state->scheduler.execute(HPX_FORWARD(Task, task_f));
+            }
+        }
+
+        // Do the work on the worker thread that called set_value from the
+        // predecessor sender. This thread participates in the work and does not
+        // need a new task since it already runs on a task.
+        template <typename Task>
+        void do_work_local(Task&& task_f) const
+        {
+#if defined(HPX_HAVE_THREAD_DESCRIPTION)
+            char const* scheduler_annotation =
+                hpx::execution::experimental::get_annotation(
+                    op_state->scheduler);
+            if (scheduler_annotation)
+            {
+                hpx::scoped_annotation ann(scheduler_annotation);
+                task_f();
+            }
+            else
+#endif
+            {
+                hpx::scoped_annotation ann(op_state->f);
+                task_f();
+            }
+        }
+
+        using range_value_type =
+            hpx::traits::iter_value_t<hpx::traits::range_iterator_t<Shape>>;
+
+        template <typename... Ts>
+        void execute(Ts&&... ts)
+        {
+            // Don't spawn tasks if there is no work to be done
+            auto const size = std::uint32_t(hpx::util::size(op_state->shape));
+            if (size == 0)
+            {
+                hpx::execution::experimental::set_value(
+                    HPX_MOVE(op_state->receiver), HPX_FORWARD(Ts, ts)...);
+                return;
+            }
+
+            // Calculate chunk size and number of chunks
+            std::uint32_t chunk_size = get_bulk_scheduler_chunk_size(
+                op_state->num_worker_threads, size);
+            std::uint32_t num_chunks = (size + chunk_size - 1) / chunk_size;
+
+            // Store sent values in the operation state
+            op_state->ts.template emplace<hpx::tuple<Ts...>>(
+                HPX_FORWARD(Ts, ts)...);
+
+            // Initialize the queues for all worker threads so that worker
+            // threads can start stealing immediately when they start.
+            for (std::uint32_t worker_thread = 0;
+                 worker_thread < op_state->num_worker_threads; ++worker_thread)
+            {
+                init_queue(worker_thread, num_chunks);
+            }
+
+            // Spawn the worker threads for all except the local queue.
+            auto const local_worker_thread =
+                std::uint32_t(hpx::get_local_worker_thread_num());
+            for (std::uint32_t worker_thread = 0;
+                 worker_thread != op_state->num_worker_threads; ++worker_thread)
+            {
+                // The queue for the local thread is handled later inline.
+                if (worker_thread == local_worker_thread)
+                {
+                    continue;
+                }
+
+                // Schedule task for this worker thread
+                do_work_task(task_function<OperationState>{
+                    this->op_state, size, chunk_size, worker_thread});
+            }
+
+            // Handle the queue for the local thread.
+            do_work_local(task_function<OperationState>{
+                this->op_state, size, chunk_size, local_worker_thread});
+        }
+
+        // clang-format off
+        template <typename... Ts,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::is_invocable_v<F, range_value_type,
+                    std::add_lvalue_reference_t<Ts>...>
+            )>
+        // clang-format on
+        friend void tag_invoke(hpx::execution::experimental::set_value_t,
+            bulk_receiver&& r, Ts&&... ts) noexcept
+        {
+            hpx::detail::try_catch_exception_ptr(
+                [&]() { r.execute(HPX_FORWARD(Ts, ts)...); },
+                [&](std::exception_ptr ep) {
+                    hpx::execution::experimental::set_error(
+                        HPX_MOVE(r.op_state->receiver), HPX_MOVE(ep));
+                });
+        }
+    };
+
+    // This sender represents bulk work that will be performed using the
+    // thread_pool_scheduler.
+    //
+    // The work is chunked into a number of chunks larger than the number of
+    // worker threads available on the underlying thread pool. The chunks are
+    // then assigned to worker thread-specific thread-safe index queues. One HPX
+    // thread is spawned for each underlying worker (OS) thread. The HPX thread
+    // is responsible for work in one queue. If the queue is empty, no HPX
+    // thread will be spawned. Once the HPX thread has finished working on its
+    // own queue, it will attempt to steal work from other queues.
+    //
+    // Since predecessor sender must complete on an HPX thread (the completion
+    // scheduler is a thread_pool_scheduler; otherwise the customization defined
+    // in this file is not chosen) it will be reused as one of the worker
+    // threads.
+    //
+    template <typename Policy, typename Sender, typename Shape, typename F>
+    class thread_pool_bulk_sender
+    {
+    private:
+        thread_pool_policy_scheduler<Policy> scheduler;
+        HPX_NO_UNIQUE_ADDRESS std::decay_t<Sender> sender;
+        HPX_NO_UNIQUE_ADDRESS std::decay_t<Shape> shape;
+        HPX_NO_UNIQUE_ADDRESS std::decay_t<F> f;
+
+    public:
+        template <typename Sender_, typename Shape_, typename F_>
+        thread_pool_bulk_sender(
+            thread_pool_policy_scheduler<Policy>&& scheduler, Sender_&& sender,
+            Shape_&& shape, F_&& f)
+          : scheduler(HPX_MOVE(scheduler))
+          , sender(HPX_FORWARD(Sender_, sender))
+          , shape(HPX_FORWARD(Shape_, shape))
+          , f(HPX_FORWARD(F_, f))
+        {
+        }
+
+        thread_pool_bulk_sender(thread_pool_bulk_sender&&) = default;
+        thread_pool_bulk_sender(thread_pool_bulk_sender const&) = default;
+        thread_pool_bulk_sender& operator=(thread_pool_bulk_sender&&) = default;
+        thread_pool_bulk_sender& operator=(
+            thread_pool_bulk_sender const&) = default;
+
+        template <typename Env>
+        struct generate_completion_signatures
+        {
+            template <template <typename...> typename Tuple,
+                template <typename...> typename Variant>
+            using value_types = value_types_of_t<Sender, Env, Tuple, Variant>;
+
+            template <template <typename...> typename Variant>
+            using error_types = hpx::util::detail::unique_concat_t<
+                error_types_of_t<Sender, Env, Variant>,
+                Variant<std::exception_ptr>>;
+
+            static constexpr bool sends_stopped =
+                sends_stopped_of_v<Sender, Env>;
+        };
+
+        template <typename Env>
+        friend auto tag_invoke(
+            hpx::execution::experimental::get_completion_signatures_t,
+            thread_pool_bulk_sender const&, Env)
+            -> generate_completion_signatures<Env>;
+
+        // clang-format off
+        template <typename CPO,
+            HPX_CONCEPT_REQUIRES_(
+                meta::value<meta::one_of<CPO,
+                    hpx::execution::experimental::set_error_t,
+                    hpx::execution::experimental::set_stopped_t>> &&
+                hpx::execution::experimental::detail::has_completion_scheduler_v<
+                    CPO, std::decay_t<Sender>>
+            )>
+        // clang-format on
+        friend constexpr auto tag_invoke(
+            hpx::execution::experimental::get_completion_scheduler_t<CPO> tag,
+            thread_pool_bulk_sender const& sender)
+        {
+            return tag(sender);
+        }
+
+        friend constexpr auto tag_invoke(
+            hpx::execution::experimental::get_completion_scheduler_t<
+                hpx::execution::experimental::set_value_t>,
+            thread_pool_bulk_sender const& sender)
+        {
+            return sender.scheduler;
+        }
+
+    private:
+        template <typename Receiver>
+        struct operation_state
+        {
+            using operation_state_type =
+                hpx::execution::experimental::connect_result_t<Sender,
+                    bulk_receiver<operation_state, F, Shape>>;
+
+            thread_pool_policy_scheduler<Policy> scheduler;
+            operation_state_type op_state;
+            std::size_t num_worker_threads;
+            std::vector<hpx::util::cache_aligned_data<
+                hpx::concurrency::detail::contiguous_index_queue<>>>
+                queues;
+            HPX_NO_UNIQUE_ADDRESS std::decay_t<Shape> shape;
+            HPX_NO_UNIQUE_ADDRESS std::decay_t<F> f;
+            HPX_NO_UNIQUE_ADDRESS std::decay_t<Receiver> receiver;
+            std::atomic<std::size_t> tasks_remaining{0};
+
+            using value_types = value_types_of_t<Sender, empty_env,
+                decayed_tuple, hpx::variant>;
+            hpx::util::detail::prepend_t<value_types, hpx::monostate> ts;
+            std::atomic<bool> exception_thrown{false};
+            std::exception_ptr exception;
+
+            template <typename Sender_, typename Shape_, typename F_,
+                typename Receiver_>
+            operation_state(thread_pool_policy_scheduler<Policy>&& scheduler,
+                Sender_&& sender, Shape_&& shape, F_&& f, Receiver_&& receiver)
+              : scheduler(HPX_MOVE(scheduler))
+              , op_state(hpx::execution::experimental::connect(
+                    HPX_FORWARD(Sender_, sender),
+                    bulk_receiver<operation_state, F, Shape>{this}))
+              , num_worker_threads(
+                    hpx::parallel::execution::processing_units_count(scheduler))
+              , queues(num_worker_threads)
+              , shape(HPX_FORWARD(Shape_, shape))
+              , f(HPX_FORWARD(F_, f))
+              , receiver(HPX_FORWARD(Receiver_, receiver))
+              , tasks_remaining(num_worker_threads)
+            {
+            }
+
+            friend void tag_invoke(start_t, operation_state& os) noexcept
+            {
+                hpx::execution::experimental::start(os.op_state);
             }
         };
-    }    // namespace detail
+
+    public:
+        template <typename Receiver>
+        friend auto tag_invoke(
+            connect_t, thread_pool_bulk_sender&& s, Receiver&& receiver)
+        {
+            return operation_state<std::decay_t<Receiver>>{
+                HPX_MOVE(s.scheduler), HPX_MOVE(s.sender), HPX_MOVE(s.shape),
+                HPX_MOVE(s.f), HPX_FORWARD(Receiver, receiver)};
+        }
+
+        template <typename Receiver>
+        auto tag_invoke(
+            connect_t, thread_pool_bulk_sender& s, Receiver&& receiver)
+        {
+            return operation_state<std::decay_t<Receiver>>{s.scheduler,
+                s.sender, s.shape, s.f, HPX_FORWARD(Receiver, receiver)};
+        }
+    };
+}    // namespace hpx::execution::experimental::detail
+
+namespace hpx::execution::experimental {
 
     // clang-format off
     template <typename Policy, typename Sender, typename Shape, typename F,
         HPX_CONCEPT_REQUIRES_(
-            !std::is_integral_v<std::decay_t<Shape>>
+            !std::is_integral_v<Shape>
         )>
     // clang-format on
     constexpr auto tag_invoke(bulk_t,
         thread_pool_policy_scheduler<Policy> scheduler, Sender&& sender,
-        Shape&& shape, F&& f)
+        Shape const& shape, F&& f)
     {
         if constexpr (std::is_same_v<Policy, launch::sync_policy>)
         {
-            return hpx::functional::detail::tag_fallback_invoke(bulk_t{},
-                HPX_FORWARD(Sender, sender), HPX_FORWARD(Shape, shape),
-                HPX_FORWARD(F, f));
+            // fall back to non-bulk scheduling if sync execution was requested
+            return detail::bulk_sender<Sender, Shape, F>{
+                HPX_FORWARD(Sender, sender), shape, HPX_FORWARD(F, f)};
         }
         else
         {
-            return detail::thread_pool_bulk_sender<Policy, std::decay_t<Sender>,
-                std::decay_t<Shape>, std::decay_t<F>>{HPX_MOVE(scheduler),
-                HPX_FORWARD(Sender, sender), HPX_FORWARD(Shape, shape),
+            return detail::thread_pool_bulk_sender<Policy, Sender, Shape, F>{
+                HPX_MOVE(scheduler), HPX_FORWARD(Sender, sender), shape,
                 HPX_FORWARD(F, f)};
         }
     }
 
     // clang-format off
-    template <typename Policy, typename Sender, typename Shape, typename F,
+    template <typename Policy, typename Sender, typename Count, typename F,
         HPX_CONCEPT_REQUIRES_(
-            std::is_integral_v<std::decay_t<Shape>>
+            std::is_integral_v<Count>
         )>
     // clang-format on
     constexpr decltype(auto) tag_invoke(bulk_t,
         thread_pool_policy_scheduler<Policy> scheduler, Sender&& sender,
-        Shape&& shape, F&& f)
+        Count const& count, F&& f)
     {
-        return tag_invoke(bulk_t{}, HPX_MOVE(scheduler),
-            HPX_FORWARD(Sender, sender),
-            hpx::util::detail::make_counting_shape(shape), HPX_FORWARD(F, f));
+        if constexpr (std::is_same_v<Policy, launch::sync_policy>)
+        {
+            // fall back to non-bulk scheduling if sync execution was requested
+            return detail::bulk_sender<Sender,
+                hpx::util::detail::counting_shape_type<Count>, F>{
+                HPX_FORWARD(Sender, sender),
+                hpx::util::detail::make_counting_shape(count),
+                HPX_FORWARD(F, f)};
+        }
+        else
+        {
+            return detail::thread_pool_bulk_sender<Policy, Sender,
+                hpx::util::detail::counting_shape_type<Count>, F>{
+                HPX_MOVE(scheduler), HPX_FORWARD(Sender, sender),
+                hpx::util::detail::make_counting_shape(count),
+                HPX_FORWARD(F, f)};
+        }
     }
 }    // namespace hpx::execution::experimental

--- a/libs/core/executors/tests/unit/CMakeLists.txt
+++ b/libs/core/executors/tests/unit/CMakeLists.txt
@@ -9,6 +9,7 @@ set(tests
     annotation_property
     created_executor
     execution_policy_mappings
+    explicit_scheduler_executor
     fork_join_executor
     limiting_executor
     parallel_executor

--- a/libs/core/executors/tests/unit/explicit_scheduler_executor.cpp
+++ b/libs/core/executors/tests/unit/explicit_scheduler_executor.cpp
@@ -1,0 +1,253 @@
+//  Copyright (c) 2007-2022 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/config.hpp>
+
+// Clang V11 ICE's on this test, Clang V8 reports a bogus constexpr problem
+#if !defined(HPX_CLANG_VERSION) ||                                             \
+    ((HPX_CLANG_VERSION / 10000) != 11 && (HPX_CLANG_VERSION / 10000) != 8)
+
+#include <hpx/local/execution.hpp>
+#include <hpx/local/future.hpp>
+#include <hpx/local/init.hpp>
+#include <hpx/local/latch.hpp>
+#include <hpx/local/thread.hpp>
+#include <hpx/modules/testing.hpp>
+
+#include <cstdlib>
+#include <functional>
+#include <string>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+///////////////////////////////////////////////////////////////////////////////
+bool executed = false;
+
+void test_post_f(int passed_through, hpx::latch& l)
+{
+    HPX_TEST_EQ(passed_through, 42);
+
+    executed = true;
+
+    l.count_down(1);
+}
+
+template <typename Executor>
+void test_post(Executor&& exec)
+{
+    executed = false;
+
+    hpx::latch l(2);
+    hpx::parallel::execution::post(exec, &test_post_f, 42, std::ref(l));
+    l.arrive_and_wait();
+
+    HPX_TEST(executed);
+}
+
+///////////////////////////////////////////////////////////////////////////////
+void test(int passed_through)
+{
+    HPX_TEST_EQ(passed_through, 42);
+
+    executed = true;
+}
+
+template <typename Executor>
+void test_sync(Executor&& exec)
+{
+    executed = false;
+
+    hpx::parallel::execution::sync_execute(exec, &test, 42);
+
+    HPX_TEST(executed);
+}
+
+template <typename Executor>
+void test_async(Executor&& exec)
+{
+    executed = false;
+
+    hpx::parallel::execution::async_execute(exec, &test, 42) |
+        hpx::this_thread::experimental::sync_wait();
+
+    HPX_TEST(executed);
+}
+
+///////////////////////////////////////////////////////////////////////////////
+void test_f(hpx::future<void> f, int passed_through)
+{
+    HPX_TEST(f.is_ready());    // make sure, future is ready
+
+    f.get();    // propagate exceptions
+
+    HPX_TEST_EQ(passed_through, 42);
+
+    executed = true;
+}
+
+template <typename Executor>
+void test_then(Executor&& exec)
+{
+    hpx::future<void> f = hpx::make_ready_future();
+
+    executed = false;
+
+    hpx::parallel::execution::then_execute(exec, &test_f, std::move(f), 42) |
+        hpx::this_thread::experimental::sync_wait();
+
+    HPX_TEST(executed);
+}
+
+///////////////////////////////////////////////////////////////////////////////
+void bulk_test_void(int seq, int passed_through)    //-V813
+{
+    HPX_TEST_EQ(passed_through, 42);
+
+    if (seq == 0)
+    {
+        executed = true;
+    }
+}
+
+template <typename Executor>
+void test_bulk_sync_void(Executor&& exec)
+{
+    using hpx::placeholders::_1;
+    using hpx::placeholders::_2;
+
+    executed = false;
+
+    hpx::parallel::execution::bulk_sync_execute(
+        exec, hpx::bind(&bulk_test_void, _1, _2), 107, 42);
+
+    HPX_TEST(executed);
+
+    executed = false;
+
+    hpx::parallel::execution::bulk_sync_execute(exec, &bulk_test_void, 107, 42);
+
+    HPX_TEST(executed);
+}
+
+template <typename Executor>
+void test_bulk_async_void(Executor&& exec)
+{
+    using hpx::placeholders::_1;
+    using hpx::placeholders::_2;
+
+    executed = false;
+
+    hpx::parallel::execution::bulk_async_execute(
+        exec, hpx::bind(&bulk_test_void, _1, _2), 107, 42) |
+        hpx::this_thread::experimental::sync_wait();
+
+    HPX_TEST(executed);
+
+    executed = false;
+
+    hpx::parallel::execution::bulk_async_execute(
+        exec, &bulk_test_void, 107, 42) |
+        hpx::this_thread::experimental::sync_wait();
+
+    HPX_TEST(executed);
+}
+
+///////////////////////////////////////////////////////////////////////////////
+void bulk_test_f_void(int seq, hpx::shared_future<void> f,
+    int passed_through)    //-V813
+{
+    HPX_TEST(f.is_ready());    // make sure, future is ready
+
+    f.get();    // propagate exceptions
+
+    HPX_TEST_EQ(passed_through, 42);
+
+    if (seq == 0)
+    {
+        executed = true;
+    }
+}
+
+template <typename Executor>
+void test_bulk_then_void(Executor&& exec)
+{
+    using hpx::placeholders::_1;
+    using hpx::placeholders::_2;
+    using hpx::placeholders::_3;
+
+    hpx::shared_future<void> f = hpx::make_ready_future();
+
+    executed = false;
+
+    hpx::parallel::execution::bulk_then_execute(
+        exec, hpx::bind(&bulk_test_f_void, _1, _2, _3), 107, f, 42) |
+        hpx::this_thread::experimental::sync_wait();
+
+    HPX_TEST(executed);
+
+    executed = false;
+
+    hpx::parallel::execution::bulk_then_execute(
+        exec, &bulk_test_f_void, 107, f, 42) |
+        hpx::this_thread::experimental::sync_wait();
+
+    HPX_TEST(executed);
+}
+
+///////////////////////////////////////////////////////////////////////////////
+template <typename Executor>
+void test_executor(Executor&& exec)
+{
+    test_post(exec);
+
+    test_sync(exec);
+    test_async(exec);
+    test_then(exec);
+
+    test_bulk_sync_void(exec);
+    test_bulk_async_void(exec);
+    test_bulk_then_void(exec);
+}
+
+int hpx_main()
+{
+    using namespace hpx::execution::experimental;
+
+    {
+        auto exec = explicit_scheduler_executor(thread_pool_scheduler{});
+        test_executor(exec);
+    }
+
+    {
+        auto exec = explicit_scheduler_executor(
+            thread_pool_policy_scheduler<hpx::launch::sync_policy>{});
+        test_executor(exec);
+    }
+
+    return hpx::local::finalize();
+}
+
+int main(int argc, char* argv[])
+{
+    // By default this test should run on all available cores
+    std::vector<std::string> const cfg = {"hpx.os_threads=all"};
+
+    // Initialize and run HPX
+    hpx::local::init_params init_args;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::local::init(hpx_main, argc, argv, init_args), 0,
+        "HPX main exited with non-zero status");
+
+    return hpx::util::report_errors();
+}
+#else
+int main()
+{
+    return 0;
+}
+#endif

--- a/libs/core/executors/tests/unit/thread_pool_scheduler.cpp
+++ b/libs/core/executors/tests/unit/thread_pool_scheduler.cpp
@@ -330,6 +330,7 @@ void test_properties()
         // thread_pool_scheduler holds the property.
     }
 
+#if defined(HPX_HAVE_THREAD_DESCRIPTION)
     {
         char const* annotation = "<test>";
         auto exec_prop = ex::with_annotation(sched, annotation);
@@ -337,14 +338,10 @@ void test_properties()
             std::string(annotation));
 
         auto check = [annotation]() {
-#if defined(HPX_HAVE_THREAD_DESCRIPTION)
             HPX_TEST_EQ(std::string(annotation),
                 hpx::threads::get_thread_description(
                     hpx::threads::get_self_id())
                     .get_description());
-#else
-            (void) annotation;
-#endif
         };
         executed = false;
         auto os = ex::connect(ex::schedule(exec_prop),
@@ -358,6 +355,7 @@ void test_properties()
 
         HPX_TEST(executed);
     }
+#endif
 }
 
 void test_transfer_basic()

--- a/libs/core/threading_base/src/annotated_function.cpp
+++ b/libs/core/threading_base/src/annotated_function.cpp
@@ -24,6 +24,8 @@ namespace hpx::detail {
 
 #else
 
+#include <hpx/threading_base/thread_description.hpp>
+
 #include <string>
 
 namespace hpx::detail {

--- a/libs/core/timed_execution/include/hpx/timed_execution/timed_executors.hpp
+++ b/libs/core/timed_execution/include/hpx/timed_execution/timed_executors.hpp
@@ -542,6 +542,25 @@ namespace hpx { namespace parallel { namespace execution {
                 HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...);
         }
 
+        // support all properties exposed by the wrapped executor
+        template <typename Tag, typename Property,
+            typename Enable = std::enable_if_t<hpx::functional::
+                    is_tag_invocable_v<Tag, BaseExecutor, Property>>>
+        friend timed_executor tag_invoke(
+            Tag tag, timed_executor const& exec, Property&& prop)
+        {
+            return timed_executor(hpx::functional::tag_invoke(
+                tag, exec.exec_, HPX_FORWARD(Property, prop)));
+        }
+
+        template <typename Tag,
+            typename Enable = std::enable_if_t<
+                hpx::functional::is_tag_invocable_v<Tag, BaseExecutor>>>
+        friend decltype(auto) tag_invoke(Tag tag, timed_executor const& exec)
+        {
+            return hpx::functional::tag_invoke(tag, exec.exec_);
+        }
+
         BaseExecutor exec_;
         std::chrono::steady_clock::time_point execute_at_;
     };

--- a/libs/core/type_support/include/hpx/type_support/meta.hpp
+++ b/libs/core/type_support/include/hpx/type_support/meta.hpp
@@ -235,9 +235,13 @@ namespace hpx { namespace meta {
     ///////////////////////////////////////////////////////////////////////////
     namespace detail {
 
+        template <typename... Ts>
+        struct compose_args_helper_not_valid;
+
         template <typename F, typename Pack, typename Enable = void>
         struct compose_args_helper
         {
+            using type = compose_args_helper_not_valid<F, Pack>;
         };
 
         template <typename F, template <class...> typename A, typename... As>

--- a/libs/full/parcelport_tcp/include/hpx/parcelport_tcp/sender.hpp
+++ b/libs/full/parcelport_tcp/include/hpx/parcelport_tcp/sender.hpp
@@ -65,7 +65,7 @@ namespace hpx::parcelset::policies::tcp {
           , pp_(pp)
 #endif
         {
-#if not defined(HPX_HAVE_PARCELPORT_COUNTERS)
+#if !defined(HPX_HAVE_PARCELPORT_COUNTERS)
             HPX_UNUSED(pp);
 #endif
         }


### PR DESCRIPTION
- thread_pool_scheduler now takes an execution policy type
- bulk with a sync scheduler falls back to default bulk implementation
- flyby: add workaround for MSVC failing to compile scheduler_executor test
- flyby: modernize executor customization point implementations
- flyby: add unary and nullary wait_all(future<T>)
- flyby: fixing size_t -> uint32_t conversion warnings
- flyby: making policy mapping CPOs final and tag_invoke friend members private
- flyby: adding missing #include to datapar.hpp
- flyby: fix value_type calculation for let_value
- adding support for s/r for partitioner (and for_loop)
- adding direct s/r support to for_each_scaling benchmark
- adding tests
- added default for get_annotation property (returns nullptr)
