### PR TITLE
Converting async combinators into CPOs

### DIFF
--- a/libs/core/async_combinators/CMakeLists.txt
+++ b/libs/core/async_combinators/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2019 The STE||AR-Group
+# Copyright (c) 2019-2022 The STE||AR-Group
 #
 # SPDX-License-Identifier: BSL-1.0
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -41,7 +41,13 @@ add_hpx_module(
   HEADERS ${async_combinators_headers}
   COMPAT_HEADERS ${async_combinators_compat_headers}
   EXCLUDE_FROM_GLOBAL_HEADER "hpx/async_combinators/future_wait.hpp"
-  MODULE_DEPENDENCIES hpx_async_base hpx_config hpx_errors hpx_futures
-                      hpx_memory hpx_pack_traversal
+  MODULE_DEPENDENCIES
+    hpx_async_base
+    hpx_config
+    hpx_errors
+    hpx_futures
+    hpx_memory
+    hpx_pack_traversal
+    hpx_tag_invoke
   CMAKE_SUBDIRS examples tests
 )

--- a/libs/core/async_combinators/include/hpx/async_combinators/wait_all.hpp
+++ b/libs/core/async_combinators/include/hpx/async_combinators/wait_all.hpp
@@ -78,6 +78,25 @@ namespace hpx {
     /// of all given futures. It AND-composes all future objects given and
     /// returns after they finished executing.
     ///
+    /// \param f        A \a future or \a shared_future for which
+    ///                 \a wait_all should wait.
+    ///
+    /// \note The function \a wait_all returns after the future has become
+    ///       ready. The input future is still valid after \a wait_all
+    ///       returns.
+    ///
+    /// \note           The function wait_all will rethrow any exceptions
+    ///                 captured by the future while becoming ready. If this
+    ///                 behavior is undesirable, use \a wait_all_nothrow
+    ///                 instead.
+    ///
+    template <typename T>
+    void wait_all(hpx::future<T> const& f);
+
+    /// The function \a wait_all is an operator allowing to join on the result
+    /// of all given futures. It AND-composes all future objects given and
+    /// returns after they finished executing.
+    ///
     /// \param futures  An arbitrary number of \a future or \a shared_future
     ///                 objects, possibly holding different types for which
     ///                 \a wait_all should wait.
@@ -126,6 +145,7 @@ namespace hpx {
 #include <hpx/config.hpp>
 #include <hpx/async_combinators/detail/throw_if_exceptional.hpp>
 #include <hpx/datastructures/tuple.hpp>
+#include <hpx/functional/tag_invoke.hpp>
 #include <hpx/futures/detail/future_data.hpp>
 #include <hpx/futures/traits/acquire_shared_state.hpp>
 #include <hpx/futures/traits/detail/future_traits.hpp>
@@ -148,186 +168,122 @@ namespace hpx {
 #include <vector>
 
 ///////////////////////////////////////////////////////////////////////////////
-namespace hpx {
+#if !defined(HPX_INTEL_VERSION)
+#define HPX_WAIT_ALL_FORCEINLINE HPX_FORCEINLINE
+#else
+#define HPX_WAIT_ALL_FORCEINLINE
+#endif
 
-    // forward declare wait_all()
+namespace hpx::detail {
+
+    ///////////////////////////////////////////////////////////////////////
+    template <typename Future, typename Enable = void>
+    struct is_future_or_shared_state : traits::is_future<Future>
+    {
+    };
+
+    template <typename R>
+    struct is_future_or_shared_state<
+        hpx::intrusive_ptr<hpx::lcos::detail::future_data_base<R>>>
+      : std::true_type
+    {
+    };
+
+    template <typename R>
+    struct is_future_or_shared_state<std::reference_wrapper<R>>
+      : is_future_or_shared_state<R>
+    {
+    };
+
+    template <typename R>
+    inline constexpr bool is_future_or_shared_state_v =
+        is_future_or_shared_state<R>::value;
+
+    ///////////////////////////////////////////////////////////////////////
+    template <typename Range, typename Enable = void>
+    struct is_future_or_shared_state_range : std::false_type
+    {
+    };
+
+    template <typename T>
+    struct is_future_or_shared_state_range<std::vector<T>>
+      : is_future_or_shared_state<T>
+    {
+    };
+
+    template <typename T, std::size_t N>
+    struct is_future_or_shared_state_range<std::array<T, N>>
+      : is_future_or_shared_state<T>
+    {
+    };
+
+    template <typename R>
+    inline constexpr bool is_future_or_shared_state_range_v =
+        is_future_or_shared_state_range<R>::value;
+
+    ///////////////////////////////////////////////////////////////////////
+    template <typename Future, typename Enable = void>
+    struct future_or_shared_state_result;
+
     template <typename Future>
-    void wait_all(std::vector<Future>&& values);
+    struct future_or_shared_state_result<Future,
+        std::enable_if_t<hpx::traits::is_future_v<Future>>>
+      : hpx::traits::future_traits<Future>
+    {
+    };
 
-    namespace detail {
-        ///////////////////////////////////////////////////////////////////////
-        template <typename Future, typename Enable = void>
-        struct is_future_or_shared_state : traits::is_future<Future>
+    template <typename R>
+    struct future_or_shared_state_result<
+        hpx::intrusive_ptr<hpx::lcos::detail::future_data_base<R>>>
+    {
+        using type = R;
+    };
+
+    template <typename R>
+    using future_or_shared_state_result_t =
+        typename future_or_shared_state_result<R>::type;
+
+    ///////////////////////////////////////////////////////////////////////
+    template <typename Tuple>
+    struct wait_all_frame    //-V690
+      : hpx::lcos::detail::future_data<void>
+    {
+    private:
+        using base_type = hpx::lcos::detail::future_data<void>;
+        using init_no_addref = typename base_type::init_no_addref;
+
+        wait_all_frame(wait_all_frame const&) = delete;
+        wait_all_frame(wait_all_frame&&) = delete;
+
+        wait_all_frame& operator=(wait_all_frame const&) = delete;
+        wait_all_frame& operator=(wait_all_frame&&) = delete;
+
+        template <std::size_t I>
+        struct is_end
+          : std::integral_constant<bool, hpx::tuple_size<Tuple>::value == I>
         {
         };
 
-        template <typename R>
-        struct is_future_or_shared_state<
-            hpx::intrusive_ptr<hpx::lcos::detail::future_data_base<R>>>
-          : std::true_type
+        template <std::size_t I>
+        static constexpr bool is_end_v = is_end<I>::value;
+
+    public:
+        wait_all_frame(Tuple const& t)
+          : base_type(init_no_addref{})
+          , t_(t)
         {
-        };
+        }
 
-        template <typename R>
-        struct is_future_or_shared_state<std::reference_wrapper<R>>
-          : is_future_or_shared_state<R>
+    protected:
+        // Current element is a range (vector or array) of futures
+        template <std::size_t I, typename Iter>
+        void await_range(Iter&& next, Iter&& end)
         {
-        };
-
-        template <typename R>
-        inline constexpr bool is_future_or_shared_state_v =
-            is_future_or_shared_state<R>::value;
-
-        ///////////////////////////////////////////////////////////////////////
-        template <typename Range, typename Enable = void>
-        struct is_future_or_shared_state_range : std::false_type
-        {
-        };
-
-        template <typename T>
-        struct is_future_or_shared_state_range<std::vector<T>>
-          : is_future_or_shared_state<T>
-        {
-        };
-
-        template <typename T, std::size_t N>
-        struct is_future_or_shared_state_range<std::array<T, N>>
-          : is_future_or_shared_state<T>
-        {
-        };
-
-        template <typename R>
-        inline constexpr bool is_future_or_shared_state_range_v =
-            is_future_or_shared_state_range<R>::value;
-
-        ///////////////////////////////////////////////////////////////////////
-        template <typename Future, typename Enable = void>
-        struct future_or_shared_state_result;
-
-        template <typename Future>
-        struct future_or_shared_state_result<Future,
-            std::enable_if_t<hpx::traits::is_future_v<Future>>>
-          : hpx::traits::future_traits<Future>
-        {
-        };
-
-        template <typename R>
-        struct future_or_shared_state_result<
-            hpx::intrusive_ptr<hpx::lcos::detail::future_data_base<R>>>
-        {
-            using type = R;
-        };
-
-        template <typename R>
-        using future_or_shared_state_result_t =
-            typename future_or_shared_state_result<R>::type;
-
-        ///////////////////////////////////////////////////////////////////////
-        template <typename Tuple>
-        struct wait_all_frame    //-V690
-          : hpx::lcos::detail::future_data<void>
-        {
-        private:
-            using base_type = hpx::lcos::detail::future_data<void>;
-            using init_no_addref = typename base_type::init_no_addref;
-
-            wait_all_frame(wait_all_frame const&) = delete;
-            wait_all_frame(wait_all_frame&&) = delete;
-
-            wait_all_frame& operator=(wait_all_frame const&) = delete;
-            wait_all_frame& operator=(wait_all_frame&&) = delete;
-
-            template <std::size_t I>
-            struct is_end
-              : std::integral_constant<bool, hpx::tuple_size<Tuple>::value == I>
+            hpx::intrusive_ptr<wait_all_frame> this_(this);
+            for (/**/; next != end; ++next)
             {
-            };
-
-            template <std::size_t I>
-            static constexpr bool is_end_v = is_end<I>::value;
-
-        public:
-            wait_all_frame(Tuple const& t)
-              : base_type(init_no_addref{})
-              , t_(t)
-            {
-            }
-
-        protected:
-            // Current element is a range (vector or array) of futures
-            template <std::size_t I, typename Iter>
-            void await_range(Iter&& next, Iter&& end)
-            {
-                hpx::intrusive_ptr<wait_all_frame> this_(this);
-                for (/**/; next != end; ++next)
-                {
-                    auto next_future_data =
-                        hpx::traits::detail::get_shared_state(*next);
-
-                    if (next_future_data)
-                    {
-                        if (!next_future_data->is_ready())
-                        {
-                            next_future_data->execute_deferred();
-
-                            // execute_deferred might have made the future ready
-                            if (!next_future_data->is_ready())
-                            {
-                                // Attach a continuation to this future which will
-                                // re-evaluate it and continue to the next element
-                                // in the sequence (if any).
-                                next_future_data->set_on_completed(
-                                    [this_ = HPX_MOVE(this_),
-                                        next = HPX_FORWARD(Iter, next),
-                                        end = HPX_FORWARD(
-                                            Iter, end)]() mutable -> void {
-                                        this_->template await_range<I>(
-                                            HPX_MOVE(next), HPX_MOVE(end));
-                                    });
-
-                                // explicitly destruct iterators as those might
-                                // become dangling after we make ourselves ready
-                                next = std::decay_t<Iter>{};
-                                end = std::decay_t<Iter>{};
-
-                                return;
-                            }
-                        }
-
-                        // check whether the current future is exceptional
-                        if (!has_exceptional_results_ &&
-                            next_future_data->has_exception())
-                        {
-                            has_exceptional_results_ = true;
-                        }
-                    }
-                }
-
-                // explicitly destruct iterators as those might become dangling
-                // after we make ourselves ready
-                next = std::decay_t<Iter>{};
-                end = std::decay_t<Iter>{};
-
-                // All elements of the sequence are ready now, proceed to the
-                // next argument.
-                do_await<I + 1>();
-            }
-
-            template <std::size_t I>
-            HPX_FORCEINLINE void await_range()
-            {
-                await_range<I>(
-                    hpx::util::begin(hpx::util::unwrap_ref(hpx::get<I>(t_))),
-                    hpx::util::end(hpx::util::unwrap_ref(hpx::get<I>(t_))));
-            }
-
-            // Current element is a simple future
-            template <std::size_t I>
-            HPX_FORCEINLINE void await_future()
-            {
-                hpx::intrusive_ptr<wait_all_frame> this_(this);
                 auto next_future_data =
-                    hpx::traits::detail::get_shared_state(hpx::get<I>(t_));
+                    hpx::traits::detail::get_shared_state(*next);
 
                 if (next_future_data)
                 {
@@ -339,12 +295,21 @@ namespace hpx {
                         if (!next_future_data->is_ready())
                         {
                             // Attach a continuation to this future which will
-                            // re-evaluate it and continue to the next argument
-                            // (if any).
+                            // re-evaluate it and continue to the next element
+                            // in the sequence (if any).
                             next_future_data->set_on_completed(
-                                [this_ = HPX_MOVE(this_)]() -> void {
-                                    this_->template await_future<I>();
+                                [this_ = HPX_MOVE(this_),
+                                    next = HPX_FORWARD(Iter, next),
+                                    end = HPX_FORWARD(
+                                        Iter, end)]() mutable -> void {
+                                    this_->template await_range<I>(
+                                        HPX_MOVE(next), HPX_MOVE(end));
                                 });
+
+                            // explicitly destruct iterators as those might
+                            // become dangling after we make ourselves ready
+                            next = std::decay_t<Iter>{};
+                            end = std::decay_t<Iter>{};
 
                             return;
                         }
@@ -357,68 +322,164 @@ namespace hpx {
                         has_exceptional_results_ = true;
                     }
                 }
-
-                do_await<I + 1>();
             }
 
-            template <std::size_t I>
-            HPX_FORCEINLINE void do_await()
+            // explicitly destruct iterators as those might become dangling
+            // after we make ourselves ready
+            next = std::decay_t<Iter>{};
+            end = std::decay_t<Iter>{};
+
+            // All elements of the sequence are ready now, proceed to the
+            // next argument.
+            do_await<I + 1>();
+        }
+
+        template <std::size_t I>
+        HPX_FORCEINLINE void await_range()
+        {
+            await_range<I>(
+                hpx::util::begin(hpx::util::unwrap_ref(hpx::get<I>(t_))),
+                hpx::util::end(hpx::util::unwrap_ref(hpx::get<I>(t_))));
+        }
+
+        // Current element is a simple future
+        template <std::size_t I>
+        HPX_FORCEINLINE void await_future()
+        {
+            hpx::intrusive_ptr<wait_all_frame> this_(this);
+            auto next_future_data =
+                hpx::traits::detail::get_shared_state(hpx::get<I>(t_));
+
+            if (next_future_data)
             {
-                // Check if end of the tuple is reached
-                if constexpr (is_end_v<I>)
+                if (!next_future_data->is_ready())
                 {
-                    // simply make ourself ready
-                    this->set_value(util::unused);
+                    next_future_data->execute_deferred();
+
+                    // execute_deferred might have made the future ready
+                    if (!next_future_data->is_ready())
+                    {
+                        // Attach a continuation to this future which will
+                        // re-evaluate it and continue to the next argument
+                        // (if any).
+                        next_future_data->set_on_completed(
+                            [this_ = HPX_MOVE(this_)]() -> void {
+                                this_->template await_future<I>();
+                            });
+
+                        return;
+                    }
+                }
+
+                // check whether the current future is exceptional
+                if (!has_exceptional_results_ &&
+                    next_future_data->has_exception())
+                {
+                    has_exceptional_results_ = true;
+                }
+            }
+
+            do_await<I + 1>();
+        }
+
+        template <std::size_t I>
+        HPX_FORCEINLINE void do_await()
+        {
+            // Check if end of the tuple is reached
+            if constexpr (is_end_v<I>)
+            {
+                // simply make ourself ready
+                this->set_value(util::unused);
+            }
+            else
+            {
+                using future_type = hpx::util::decay_unwrap_t<
+                    typename hpx::tuple_element<I, Tuple>::type>;
+
+                if constexpr (is_future_or_shared_state_v<future_type>)
+                {
+                    await_future<I>();
                 }
                 else
                 {
-                    using future_type = hpx::util::decay_unwrap_t<
-                        typename hpx::tuple_element<I, Tuple>::type>;
-
-                    if constexpr (is_future_or_shared_state_v<future_type>)
-                    {
-                        await_future<I>();
-                    }
-                    else
-                    {
-                        static_assert(
-                            is_future_or_shared_state_range_v<future_type>,
-                            "element must be future or range of futures");
-                        await_range<I>();
-                    }
+                    static_assert(
+                        is_future_or_shared_state_range_v<future_type>,
+                        "element must be future or range of futures");
+                    await_range<I>();
                 }
             }
+        }
 
-        public:
-            bool wait_all()
+    public:
+        bool wait_all()
+        {
+            do_await<0>();
+
+            // If there are still futures which are not ready, suspend
+            // and wait.
+            if (!this->is_ready())
             {
-                do_await<0>();
-
-                // If there are still futures which are not ready, suspend
-                // and wait.
-                if (!this->is_ready())
-                {
-                    this->wait();
-                }
-
-                // return whether at least one of the futures has become
-                // exceptional
-                return has_exceptional_results_;
+                this->wait();
             }
 
-        private:
-            Tuple const& t_;
-            bool has_exceptional_results_ = false;
-        };
-    }    // namespace detail
+            // return whether at least one of the futures has become
+            // exceptional
+            return has_exceptional_results_;
+        }
+
+    private:
+        Tuple const& t_;
+        bool has_exceptional_results_ = false;
+    };
+}    // namespace hpx::detail
+
+namespace hpx {
 
     ///////////////////////////////////////////////////////////////////////////
-    template <typename Future>
-    bool wait_all_nothrow(std::vector<Future> const& values)
+    inline constexpr struct wait_all_nothrow_t final
+      : hpx::functional::tag<wait_all_nothrow_t>
     {
-        if (!values.empty())
+    private:
+        template <typename Future>
+        friend bool tag_invoke(
+            wait_all_nothrow_t, std::vector<Future> const& values)
         {
-            using result_type = hpx::tuple<std::vector<Future> const&>;
+            if (!values.empty())
+            {
+                using result_type = hpx::tuple<std::vector<Future> const&>;
+                using frame_type = hpx::detail::wait_all_frame<result_type>;
+
+                result_type data(values);
+
+                // frame is initialized with initial reference count
+                hpx::intrusive_ptr<frame_type> frame(
+                    new frame_type(data), false);
+                return frame->wait_all();
+            }
+            return false;
+        }
+
+        template <typename Future>
+        friend HPX_WAIT_ALL_FORCEINLINE bool tag_invoke(
+            wait_all_nothrow_t, std::vector<Future>& values)
+        {
+            return tag_invoke(wait_all_nothrow_t{},
+                const_cast<std::vector<Future> const&>(values));
+        }
+
+        template <typename Future>
+        friend HPX_WAIT_ALL_FORCEINLINE bool tag_invoke(
+            wait_all_nothrow_t, std::vector<Future>&& values)
+        {
+            return tag_invoke(wait_all_nothrow_t{},
+                const_cast<std::vector<Future> const&>(values));
+        }
+
+        template <typename Future, std::size_t N>
+        friend bool tag_invoke(
+            wait_all_nothrow_t, std::array<Future, N> const& values)
+        {
+            using result_type = hpx::tuple<std::array<Future, N> const&>;
             using frame_type = hpx::detail::wait_all_frame<result_type>;
 
             result_type data(values);
@@ -427,213 +488,234 @@ namespace hpx {
             hpx::intrusive_ptr<frame_type> frame(new frame_type(data), false);
             return frame->wait_all();
         }
-        return false;
-    }
 
-    template <typename Future>
-    void wait_all(std::vector<Future> const& values)
-    {
-        if (hpx::wait_all_nothrow(values))
+        template <typename Future, std::size_t N>
+        friend HPX_WAIT_ALL_FORCEINLINE bool tag_invoke(
+            wait_all_nothrow_t, std::array<Future, N>& values)
         {
-            hpx::detail::throw_if_exceptional(values);
+            return tag_invoke(wait_all_nothrow_t{},
+                const_cast<std::array<Future, N> const&>(values));
         }
-    }
 
-    template <typename Future>
-    HPX_FORCEINLINE bool wait_all_nothrow(std::vector<Future>& values)
-    {
-        return hpx::wait_all_nothrow(
-            const_cast<std::vector<Future> const&>(values));
-    }
-
-    template <typename Future>
-    HPX_FORCEINLINE void wait_all(std::vector<Future>& values)
-    {
-        if (hpx::wait_all_nothrow(
-                const_cast<std::vector<Future> const&>(values)))
+        template <typename Iterator,
+            typename Enable =
+                std::enable_if_t<hpx::traits::is_iterator_v<Iterator>>>
+        friend bool tag_invoke(wait_all_nothrow_t, Iterator begin, Iterator end)
         {
-            hpx::detail::throw_if_exceptional(values);
+            if (begin == end)
+            {
+                return false;
+            }
+
+            auto values = traits::acquire_shared_state<Iterator>()(begin, end);
+            return tag_invoke(wait_all_nothrow_t{}, values);
         }
-    }
 
-    template <typename Future>
-#if !defined(HPX_INTEL_VERSION)
-    HPX_FORCEINLINE
-#endif
-        bool
-        wait_all_nothrow(std::vector<Future>&& values)
-    {
-        return hpx::wait_all_nothrow(
-            const_cast<std::vector<Future> const&>(values));
-    }
-
-    template <typename Future>
-#if !defined(HPX_INTEL_VERSION)
-    HPX_FORCEINLINE
-#endif
-        void
-        wait_all(std::vector<Future>&& values)
-    {
-        if (hpx::wait_all_nothrow(
-                const_cast<std::vector<Future> const&>(values)))
+        friend HPX_WAIT_ALL_FORCEINLINE constexpr bool tag_invoke(
+            wait_all_nothrow_t) noexcept
         {
-            hpx::detail::throw_if_exceptional(values);
+            return false;
         }
-    }
+
+        template <typename... Ts>
+        friend bool tag_invoke(wait_all_nothrow_t, Ts&&... ts)
+        {
+            if constexpr (sizeof...(Ts) != 0)
+            {
+                using result_type =
+                    hpx::tuple<traits::detail::shared_state_ptr_for_t<Ts>...>;
+                using frame_type = detail::wait_all_frame<result_type>;
+
+                result_type values =
+                    result_type(hpx::traits::detail::get_shared_state(ts)...);
+
+                // frame is initialized with initial reference count
+                hpx::intrusive_ptr<frame_type> frame(
+                    new frame_type(values), false);
+                return frame->wait_all();
+            }
+            return false;
+        }
+
+        template <typename T>
+        friend HPX_WAIT_ALL_FORCEINLINE bool tag_invoke(
+            wait_all_nothrow_t, hpx::future<T> const& f)
+        {
+            f.wait();
+            return f.has_exception();
+        }
+
+        template <typename T>
+        friend HPX_WAIT_ALL_FORCEINLINE bool tag_invoke(
+            wait_all_nothrow_t, hpx::shared_future<T> const& f)
+        {
+            f.wait();
+            return f.has_exception();
+        }
+    } wait_all_nothrow{};
 
     ///////////////////////////////////////////////////////////////////////////
-    template <typename Future, std::size_t N>
-    bool wait_all_nothrow(std::array<Future, N> const& values)
+    inline constexpr struct wait_all_t final : hpx::functional::tag<wait_all_t>
     {
-        using result_type = hpx::tuple<std::array<Future, N> const&>;
-        using frame_type = hpx::detail::wait_all_frame<result_type>;
-
-        result_type data(values);
-
-        // frame is initialized with initial reference count
-        hpx::intrusive_ptr<frame_type> frame(new frame_type(data), false);
-        return frame->wait_all();
-    }
-
-    template <typename Future, std::size_t N>
-    void wait_all(std::array<Future, N> const& values)
-    {
-        if (hpx::wait_all_nothrow(values))
+    private:
+        template <typename Future>
+        friend HPX_WAIT_ALL_FORCEINLINE void tag_invoke(
+            wait_all_t, std::vector<Future> const& values)
         {
-            hpx::detail::throw_if_exceptional(values);
-        }
-    }
-
-    template <typename Future, std::size_t N>
-    HPX_FORCEINLINE bool wait_all_nothrow(std::array<Future, N>& values)
-    {
-        return hpx::wait_all_nothrow(
-            const_cast<std::array<Future, N> const&>(values));
-    }
-
-    template <typename Future, std::size_t N>
-    HPX_FORCEINLINE void wait_all(std::array<Future, N>& values)
-    {
-        if (hpx::wait_all_nothrow(
-                const_cast<std::array<Future, N> const&>(values)))
-        {
-            hpx::detail::throw_if_exceptional(values);
-        }
-    }
-
-    template <typename Future, std::size_t N>
-    HPX_FORCEINLINE bool wait_all_nothrow(std::array<Future, N>&& values)
-    {
-        return hpx::wait_all_nothrow(
-            const_cast<std::array<Future, N> const&>(values));
-    }
-
-    template <typename Future, std::size_t N>
-    HPX_FORCEINLINE void wait_all(std::array<Future, N>&& values)
-    {
-        if (hpx::wait_all_nothrow(
-                const_cast<std::array<Future, N> const&>(values)))
-        {
-            hpx::detail::throw_if_exceptional(values);
-        }
-    }
-
-    ///////////////////////////////////////////////////////////////////////////
-    template <typename Iterator,
-        typename Enable =
-            std::enable_if_t<hpx::traits::is_iterator_v<Iterator>>>
-    bool wait_all_nothrow(Iterator begin, Iterator end)
-    {
-        if (begin != end)
-        {
-            auto values = traits::acquire_shared_state<Iterator>()(begin, end);
-            return hpx::wait_all_nothrow(values);
-        }
-        return false;
-    }
-
-    template <typename Iterator,
-        typename Enable =
-            std::enable_if_t<hpx::traits::is_iterator_v<Iterator>>>
-    void wait_all(Iterator begin, Iterator end)
-    {
-        if (begin != end)
-        {
-            auto values = traits::acquire_shared_state<Iterator>()(begin, end);
             if (hpx::wait_all_nothrow(values))
             {
                 hpx::detail::throw_if_exceptional(values);
             }
         }
-    }
 
-    ///////////////////////////////////////////////////////////////////////////
-    template <typename Iterator,
-        typename Enable =
-            std::enable_if_t<hpx::traits::is_iterator_v<Iterator>>>
-    bool wait_all_n_nothrow(Iterator begin, std::size_t count)
-    {
-        if (count != 0)
+        template <typename Future>
+        friend HPX_WAIT_ALL_FORCEINLINE void tag_invoke(
+            wait_all_t, std::vector<Future>& values)
         {
-            auto values =
-                traits::acquire_shared_state<Iterator>()(begin, count);
-            return hpx::wait_all_nothrow(values);
+            if (hpx::wait_all_nothrow(
+                    const_cast<std::vector<Future> const&>(values)))
+            {
+                hpx::detail::throw_if_exceptional(values);
+            }
         }
-        return false;
-    }
 
-    template <typename Iterator,
-        typename Enable =
-            std::enable_if_t<hpx::traits::is_iterator_v<Iterator>>>
-    void wait_all_n(Iterator begin, std::size_t count)
-    {
-        if (count != 0)
+        template <typename Future>
+        friend HPX_WAIT_ALL_FORCEINLINE void tag_invoke(
+            wait_all_t, std::vector<Future>&& values)
         {
-            auto values =
-                traits::acquire_shared_state<Iterator>()(begin, count);
+            if (hpx::wait_all_nothrow(
+                    const_cast<std::vector<Future> const&>(values)))
+            {
+                hpx::detail::throw_if_exceptional(values);
+            }
+        }
+
+        template <typename Future, std::size_t N>
+        friend HPX_WAIT_ALL_FORCEINLINE void tag_invoke(
+            wait_all_t, std::array<Future, N> const& values)
+        {
             if (hpx::wait_all_nothrow(values))
             {
                 hpx::detail::throw_if_exceptional(values);
             }
         }
-    }
+
+        template <typename Future, std::size_t N>
+        friend HPX_WAIT_ALL_FORCEINLINE void tag_invoke(
+            wait_all_t, std::array<Future, N>& values)
+        {
+            if (hpx::wait_all_nothrow(
+                    const_cast<std::array<Future, N> const&>(values)))
+            {
+                hpx::detail::throw_if_exceptional(values);
+            }
+        }
+
+        template <typename Future, std::size_t N>
+        friend HPX_WAIT_ALL_FORCEINLINE void tag_invoke(
+            wait_all_t, std::array<Future, N>&& values)
+        {
+            if (hpx::wait_all_nothrow(
+                    const_cast<std::array<Future, N> const&>(values)))
+            {
+                hpx::detail::throw_if_exceptional(values);
+            }
+        }
+
+        template <typename Iterator,
+            typename Enable =
+                std::enable_if_t<hpx::traits::is_iterator_v<Iterator>>>
+        friend void tag_invoke(wait_all_t, Iterator begin, Iterator end)
+        {
+            if (begin != end)
+            {
+                auto values =
+                    traits::acquire_shared_state<Iterator>()(begin, end);
+                if (hpx::wait_all_nothrow(values))
+                {
+                    hpx::detail::throw_if_exceptional(values);
+                }
+            }
+        }
+
+        friend HPX_WAIT_ALL_FORCEINLINE void tag_invoke(wait_all_t) noexcept {}
+
+        template <typename... Ts>
+        friend HPX_WAIT_ALL_FORCEINLINE void tag_invoke(wait_all_t, Ts&&... ts)
+        {
+            if (hpx::wait_all_nothrow(ts...))
+            {
+                hpx::detail::throw_if_exceptional(HPX_FORWARD(Ts, ts)...);
+            }
+        }
+
+        template <typename T>
+        friend HPX_WAIT_ALL_FORCEINLINE void tag_invoke(
+            wait_all_t, hpx::future<T> const& f)
+        {
+            if (hpx::wait_all_nothrow(f))
+            {
+                hpx::detail::throw_if_exceptional(f);
+            }
+        }
+
+        template <typename T>
+        friend HPX_WAIT_ALL_FORCEINLINE void tag_invoke(
+            wait_all_t, hpx::shared_future<T> const& f)
+        {
+            if (hpx::wait_all_nothrow(f))
+            {
+                hpx::detail::throw_if_exceptional(f);
+            }
+        }
+    } wait_all{};
 
     ///////////////////////////////////////////////////////////////////////////
-    constexpr inline bool wait_all_nothrow() noexcept
+    inline constexpr struct wait_all_n_nothrow_t final
+      : hpx::functional::tag<wait_all_n_nothrow_t>
     {
-        return false;
-    }
-    constexpr inline void wait_all() noexcept {}
+    private:
+        template <typename Iterator,
+            typename Enable =
+                std::enable_if_t<hpx::traits::is_iterator_v<Iterator>>>
+        friend bool tag_invoke(
+            wait_all_n_nothrow_t, Iterator begin, std::size_t count)
+        {
+            if (count == 0)
+            {
+                return false;
+            }
+
+            auto values =
+                traits::acquire_shared_state<Iterator>()(begin, count);
+            return hpx::wait_all_nothrow(values);
+        }
+    } wait_all_n_nothrow{};
 
     ///////////////////////////////////////////////////////////////////////////
-    template <typename... Ts>
-    bool wait_all_nothrow(Ts&&... ts)
+    inline constexpr struct wait_all_n_t final
+      : hpx::functional::tag<wait_all_n_t>
     {
-        if constexpr (sizeof...(Ts) != 0)
+    private:
+        template <typename Iterator,
+            typename Enable =
+                std::enable_if_t<hpx::traits::is_iterator_v<Iterator>>>
+        friend void tag_invoke(wait_all_n_t, Iterator begin, std::size_t count)
         {
-            using result_type =
-                hpx::tuple<traits::detail::shared_state_ptr_for_t<Ts>...>;
-            using frame_type = detail::wait_all_frame<result_type>;
-
-            result_type values =
-                result_type(hpx::traits::detail::get_shared_state(ts)...);
-
-            // frame is initialized with initial reference count
-            hpx::intrusive_ptr<frame_type> frame(new frame_type(values), false);
-            return frame->wait_all();
+            if (count != 0)
+            {
+                auto values =
+                    traits::acquire_shared_state<Iterator>()(begin, count);
+                if (hpx::wait_all_nothrow(values))
+                {
+                    hpx::detail::throw_if_exceptional(values);
+                }
+            }
         }
-        return false;
-    }
-
-    template <typename... Ts>
-    void wait_all(Ts&&... ts)
-    {
-        if (hpx::wait_all_nothrow(ts...))
-        {
-            hpx::detail::throw_if_exceptional(HPX_FORWARD(Ts, ts)...);
-        }
-    }
+    } wait_all_n{};
 }    // namespace hpx
+
+#undef HPX_WAIT_ALL_FORCEINLINE
 
 namespace hpx::lcos {
 

--- a/libs/core/async_combinators/include/hpx/async_combinators/wait_any.hpp
+++ b/libs/core/async_combinators/include/hpx/async_combinators/wait_any.hpp
@@ -122,6 +122,7 @@ namespace hpx {
 #include <hpx/config.hpp>
 #include <hpx/async_combinators/wait_some.hpp>
 #include <hpx/datastructures/tuple.hpp>
+#include <hpx/functional/tag_invoke.hpp>
 #include <hpx/futures/future.hpp>
 #include <hpx/iterator_support/traits/is_iterator.hpp>
 #include <hpx/preprocessor/strip_parens.hpp>
@@ -136,139 +137,177 @@ namespace hpx {
 namespace hpx {
 
     ///////////////////////////////////////////////////////////////////////////
-    template <typename Future>
-    bool wait_any_nothrow(std::vector<Future> const& futures)
+    inline constexpr struct wait_any_nothrow_t final
+      : hpx::functional::tag<wait_any_nothrow_t>
     {
-        return hpx::wait_some_nothrow(1, futures);
-    }
+    private:
+        template <typename Future>
+        friend HPX_FORCEINLINE bool tag_invoke(
+            wait_any_nothrow_t, std::vector<Future> const& futures)
+        {
+            return hpx::wait_some_nothrow(1, futures);
+        }
 
-    template <typename Future>
-    void wait_any(std::vector<Future> const& futures)
-    {
-        hpx::wait_some(1, futures);
-    }
+        template <typename Future>
+        friend HPX_FORCEINLINE bool tag_invoke(
+            wait_any_nothrow_t, std::vector<Future>& lazy_values)
+        {
+            return tag_invoke(wait_any_nothrow_t{},
+                const_cast<std::vector<Future> const&>(lazy_values));
+        }
 
-    template <typename Future>
-    bool wait_any_nothrow(std::vector<Future>& lazy_values)
-    {
-        return hpx::wait_any_nothrow(
-            const_cast<std::vector<Future> const&>(lazy_values));
-    }
+        template <typename Future>
+        friend HPX_FORCEINLINE bool tag_invoke(
+            wait_any_nothrow_t, std::vector<Future>&& lazy_values)
+        {
+            return tag_invoke(wait_any_nothrow_t{},
+                const_cast<std::vector<Future> const&>(lazy_values));
+        }
 
-    template <typename Future>
-    void wait_any(std::vector<Future>& lazy_values)
-    {
-        hpx::wait_any(const_cast<std::vector<Future> const&>(lazy_values));
-    }
+        template <typename Future, std::size_t N>
+        friend HPX_FORCEINLINE bool tag_invoke(
+            wait_any_nothrow_t, std::array<Future, N> const& futures)
+        {
+            return hpx::wait_some_nothrow(1, futures);
+        }
 
-    template <typename Future>
-    bool wait_any_nothrow(std::vector<Future>&& lazy_values)
-    {
-        return hpx::wait_any_nothrow(
-            const_cast<std::vector<Future> const&>(lazy_values));
-    }
+        template <typename Future, std::size_t N>
+        friend HPX_FORCEINLINE bool tag_invoke(
+            wait_any_nothrow_t, std::array<Future, N>& lazy_values)
+        {
+            return tag_invoke(wait_any_nothrow_t{},
+                const_cast<std::array<Future, N> const&>(lazy_values));
+        }
 
-    template <typename Future>
-    void wait_any(std::vector<Future>&& lazy_values)
-    {
-        hpx::wait_any(const_cast<std::vector<Future> const&>(lazy_values));
-    }
+        template <typename Future, std::size_t N>
+        friend HPX_FORCEINLINE bool tag_invoke(
+            wait_any_nothrow_t, std::array<Future, N>&& lazy_values)
+        {
+            return tag_invoke(wait_any_nothrow_t{},
+                const_cast<std::array<Future, N> const&>(lazy_values));
+        }
 
-    ///////////////////////////////////////////////////////////////////////////
-    template <typename Future, std::size_t N>
-    bool wait_any_nothrow(std::array<Future, N> const& futures)
-    {
-        return hpx::wait_some_nothrow(1, futures);
-    }
+        template <typename Iterator,
+            typename Enable =
+                std::enable_if_t<hpx::traits::is_iterator_v<Iterator>>>
+        friend HPX_FORCEINLINE bool tag_invoke(
+            wait_any_nothrow_t, Iterator begin, Iterator end)
+        {
+            return hpx::wait_some_nothrow(1, begin, end);
+        }
 
-    template <typename Future, std::size_t N>
-    void wait_any(std::array<Future, N> const& futures)
-    {
-        hpx::wait_some(1, futures);
-    }
+        friend HPX_FORCEINLINE bool tag_invoke(wait_any_nothrow_t)
+        {
+            return hpx::wait_some_nothrow(0);
+        }
 
-    template <typename Future, std::size_t N>
-    bool wait_any_nothrow(std::array<Future, N>& lazy_values)
-    {
-        return hpx::wait_any_nothrow(
-            const_cast<std::array<Future, N> const&>(lazy_values));
-    }
-
-    template <typename Future, std::size_t N>
-    void wait_any(std::array<Future, N>& lazy_values)
-    {
-        hpx::wait_any(const_cast<std::array<Future, N> const&>(lazy_values));
-    }
-
-    template <typename Future, std::size_t N>
-    bool wait_any_nothrow(std::array<Future, N>&& lazy_values)
-    {
-        return hpx::wait_any_nothrow(
-            const_cast<std::array<Future, N> const&>(lazy_values));
-    }
-
-    template <typename Future, std::size_t N>
-    void wait_any(std::array<Future, N>&& lazy_values)
-    {
-        hpx::wait_any(const_cast<std::array<Future, N> const&>(lazy_values));
-    }
+        template <typename... Ts>
+        friend HPX_FORCEINLINE bool tag_invoke(wait_any_nothrow_t, Ts&&... ts)
+        {
+            return hpx::wait_some_nothrow(1, HPX_FORWARD(Ts, ts)...);
+        }
+    } wait_any_nothrow{};
 
     ///////////////////////////////////////////////////////////////////////////
-    template <typename Iterator,
-        typename Enable =
-            std::enable_if_t<hpx::traits::is_iterator_v<Iterator>>>
-    bool wait_any_nothrow(Iterator begin, Iterator end)
+    inline constexpr struct wait_any_t final : hpx::functional::tag<wait_any_t>
     {
-        return hpx::wait_some_nothrow(1, begin, end);
-    }
+    private:
+        template <typename Future>
+        friend HPX_FORCEINLINE void tag_invoke(
+            wait_any_t, std::vector<Future> const& futures)
+        {
+            hpx::wait_some(1, futures);
+        }
 
-    template <typename Iterator,
-        typename Enable =
-            std::enable_if_t<hpx::traits::is_iterator_v<Iterator>>>
-    void wait_any(Iterator begin, Iterator end)
-    {
-        hpx::wait_some(1, begin, end);
-    }
+        template <typename Future>
+        friend HPX_FORCEINLINE void tag_invoke(
+            wait_any_t, std::vector<Future>& lazy_values)
+        {
+            tag_invoke(wait_any_t{},
+                const_cast<std::vector<Future> const&>(lazy_values));
+        }
 
-    inline bool wait_any_nothrow()
-    {
-        return hpx::wait_some_nothrow(0);
-    }
+        template <typename Future>
+        friend HPX_FORCEINLINE void tag_invoke(
+            wait_any_t, std::vector<Future>&& lazy_values)
+        {
+            tag_invoke(wait_any_t{},
+                const_cast<std::vector<Future> const&>(lazy_values));
+        }
 
-    inline void wait_any()
-    {
-        hpx::wait_some(0);
-    }
+        template <typename Future, std::size_t N>
+        friend HPX_FORCEINLINE void tag_invoke(
+            wait_any_t, std::array<Future, N> const& futures)
+        {
+            hpx::wait_some(1, futures);
+        }
+
+        template <typename Future, std::size_t N>
+        friend HPX_FORCEINLINE void tag_invoke(
+            wait_any_t, std::array<Future, N>& lazy_values)
+        {
+            tag_invoke(wait_any_t{},
+                const_cast<std::array<Future, N> const&>(lazy_values));
+        }
+
+        template <typename Future, std::size_t N>
+        friend HPX_FORCEINLINE void tag_invoke(
+            wait_any_t, std::array<Future, N>&& lazy_values)
+        {
+            tag_invoke(wait_any_t{},
+                const_cast<std::array<Future, N> const&>(lazy_values));
+        }
+
+        template <typename Iterator,
+            typename Enable =
+                std::enable_if_t<hpx::traits::is_iterator_v<Iterator>>>
+        friend HPX_FORCEINLINE void tag_invoke(
+            wait_any_t, Iterator begin, Iterator end)
+        {
+            hpx::wait_some(1, begin, end);
+        }
+
+        friend HPX_FORCEINLINE void tag_invoke(wait_any_t)
+        {
+            hpx::wait_some(0);
+        }
+
+        template <typename... Ts>
+        friend HPX_FORCEINLINE void tag_invoke(wait_any_t, Ts&&... ts)
+        {
+            hpx::wait_some(1, HPX_FORWARD(Ts, ts)...);
+        }
+    } wait_any{};
 
     ///////////////////////////////////////////////////////////////////////////
-    template <typename Iterator,
-        typename Enable =
-            std::enable_if_t<hpx::traits::is_iterator_v<Iterator>>>
-    bool wait_any_n_nothrow(Iterator begin, std::size_t count)
+    inline constexpr struct wait_any_n_nothrow_t final
+      : hpx::functional::tag<wait_any_n_nothrow_t>
     {
-        return hpx::wait_some_n_nothrow(1, begin, count);
-    }
-
-    template <typename Iterator,
-        typename Enable =
-            std::enable_if_t<hpx::traits::is_iterator_v<Iterator>>>
-    void wait_any_n(Iterator begin, std::size_t count)
-    {
-        hpx::wait_some_n(1, begin, count);
-    }
+    private:
+        template <typename Iterator,
+            typename Enable =
+                std::enable_if_t<hpx::traits::is_iterator_v<Iterator>>>
+        friend HPX_FORCEINLINE bool tag_invoke(
+            wait_any_n_nothrow_t, Iterator begin, std::size_t count)
+        {
+            return hpx::wait_some_n_nothrow(1, begin, count);
+        }
+    } wait_any_n_nothrow{};
 
     ///////////////////////////////////////////////////////////////////////////
-    template <typename... Ts>
-    bool wait_any_nothrow(Ts&&... ts)
+    inline constexpr struct wait_any_n_t final
+      : hpx::functional::tag<wait_any_n_t>
     {
-        return hpx::wait_some_nothrow(1, HPX_FORWARD(Ts, ts)...);
-    }
-
-    template <typename... Ts>
-    void wait_any(Ts&&... ts)
-    {
-        hpx::wait_some(1, HPX_FORWARD(Ts, ts)...);
-    }
+    private:
+        template <typename Iterator,
+            typename Enable =
+                std::enable_if_t<hpx::traits::is_iterator_v<Iterator>>>
+        friend HPX_FORCEINLINE void tag_invoke(
+            wait_any_n_t, Iterator begin, std::size_t count)
+        {
+            hpx::wait_some_n(1, begin, count);
+        }
+    } wait_any_n{};
 }    // namespace hpx
 
 namespace hpx::lcos {

--- a/libs/core/async_combinators/include/hpx/async_combinators/wait_some.hpp
+++ b/libs/core/async_combinators/include/hpx/async_combinators/wait_some.hpp
@@ -145,6 +145,7 @@ namespace hpx {
 #include <hpx/async_combinators/detail/throw_if_exceptional.hpp>
 #include <hpx/datastructures/tuple.hpp>
 #include <hpx/functional/deferred_call.hpp>
+#include <hpx/functional/tag_invoke.hpp>
 #include <hpx/futures/future.hpp>
 #include <hpx/futures/traits/acquire_shared_state.hpp>
 #include <hpx/futures/traits/detail/future_traits.hpp>
@@ -335,293 +336,332 @@ namespace hpx {
     }    // namespace detail
 
     ///////////////////////////////////////////////////////////////////////////
-    template <typename Future>
-    bool wait_some_nothrow(std::size_t n, std::vector<Future> const& values)
+    inline constexpr struct wait_some_nothrow_t final
+      : hpx::functional::tag<wait_some_nothrow_t>
     {
-        static_assert(
-            hpx::traits::is_future_v<Future>, "invalid use of hpx::wait_some");
-
-        if (n == 0)
+    private:
+        template <typename Future>
+        friend bool tag_invoke(wait_some_nothrow_t, std::size_t n,
+            std::vector<Future> const& values)
         {
+            static_assert(hpx::traits::is_future_v<Future>,
+                "invalid use of hpx::wait_some");
+
+            if (n == 0)
+            {
+                return false;
+            }
+
+            if (n > values.size())
+            {
+                HPX_THROW_EXCEPTION(hpx::bad_parameter, "hpx::wait_some",
+                    "number of results to wait for is out of bounds");
+                return false;
+            }
+
+            auto lazy_values = traits::acquire_shared_state_disp()(values);
+            auto f = detail::get_wait_some_frame(lazy_values, n);
+
+            return (*f)();
+        }
+
+        template <typename Future>
+        friend HPX_FORCEINLINE bool tag_invoke(
+            wait_some_nothrow_t, std::size_t n, std::vector<Future>& values)
+        {
+            return tag_invoke(wait_some_nothrow_t{}, n,
+                const_cast<std::vector<Future> const&>(values));
+        }
+
+        template <typename Future>
+        friend HPX_FORCEINLINE bool tag_invoke(
+            wait_some_nothrow_t, std::size_t n, std::vector<Future>&& values)
+        {
+            return tag_invoke(wait_some_nothrow_t{}, n,
+                const_cast<std::vector<Future> const&>(values));
+        }
+
+        template <typename Future, std::size_t N>
+        friend bool tag_invoke(wait_some_nothrow_t, std::size_t n,
+            std::array<Future, N> const& values)
+        {
+            static_assert(
+                hpx::traits::is_future_v<Future>, "invalid use of wait_some");
+
+            if (n == 0)
+            {
+                return false;
+            }
+
+            if (n > values.size())
+            {
+                HPX_THROW_EXCEPTION(hpx::bad_parameter, "hpx::wait_some",
+                    "number of results to wait for is out of bounds");
+                return false;
+            }
+
+            auto lazy_values = traits::acquire_shared_state_disp()(values);
+            auto f = detail::get_wait_some_frame(lazy_values, n);
+
+            return (*f)();
+        }
+
+        template <typename Future, std::size_t N>
+        friend HPX_FORCEINLINE bool tag_invoke(wait_some_nothrow_t,
+            std::size_t n, std::array<Future, N>& lazy_values)
+        {
+            return tag_invoke(wait_some_nothrow_t{}, n,
+                const_cast<std::array<Future, N> const&>(lazy_values));
+        }
+
+        template <typename Future, std::size_t N>
+        friend HPX_FORCEINLINE bool tag_invoke(wait_some_nothrow_t,
+            std::size_t n, std::array<Future, N>&& lazy_values)
+        {
+            return tag_invoke(wait_some_nothrow_t{}, n,
+                const_cast<std::array<Future, N> const&>(lazy_values));
+        }
+
+        template <typename Iterator,
+            typename Enable =
+                std::enable_if_t<hpx::traits::is_iterator_v<Iterator>>>
+        friend bool tag_invoke(
+            wait_some_nothrow_t, std::size_t n, Iterator begin, Iterator end)
+        {
+            auto values = traits::acquire_shared_state<Iterator>()(begin, end);
+            auto f = detail::get_wait_some_frame(values, n);
+
+            return (*f)();
+        }
+
+        friend bool tag_invoke(wait_some_nothrow_t, std::size_t n)
+        {
+            if (n != 0)
+            {
+                HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                    "hpx::wait_some_nothrow",
+                    "number of results to wait for is out of bounds");
+            }
             return false;
         }
 
-        if (n > values.size())
+        template <typename T>
+        friend bool tag_invoke(
+            wait_some_nothrow_t, std::size_t n, hpx::future<T>&& f)
         {
-            HPX_THROW_EXCEPTION(hpx::bad_parameter, "hpx::wait_some",
-                "number of results to wait for is out of bounds");
-            return false;
+            if (n != 1)
+            {
+                HPX_THROW_EXCEPTION(hpx::bad_parameter, "hpx::wait_some",
+                    "number of results to wait for is out of bounds");
+                return false;
+            }
+
+            f.wait();
+            return f.has_exception();
         }
 
-        auto lazy_values = traits::acquire_shared_state_disp()(values);
-        auto f = detail::get_wait_some_frame(lazy_values, n);
-
-        return (*f)();
-    }
-
-    template <typename Future>
-    void wait_some(std::size_t n, std::vector<Future> const& values)
-    {
-        if (hpx::wait_some_nothrow(n, values))
+        template <typename T>
+        friend bool tag_invoke(
+            wait_some_nothrow_t, std::size_t n, hpx::shared_future<T>&& f)
         {
-            hpx::detail::throw_if_exceptional(values);
+            if (n != 1)
+            {
+                HPX_THROW_EXCEPTION(hpx::bad_parameter, "hpx::wait_some",
+                    "number of results to wait for is out of bounds");
+                return false;
+            }
+
+            f.wait();
+            return f.has_exception();
         }
-    }
 
-    template <typename Future>
-    bool wait_some_nothrow(std::size_t n, std::vector<Future>& values)
-    {
-        return hpx::wait_some_nothrow(
-            n, const_cast<std::vector<Future> const&>(values));
-    }
-
-    template <typename Future>
-    void wait_some(std::size_t n, std::vector<Future>& values)
-    {
-        if (hpx::wait_some_nothrow(
-                n, const_cast<std::vector<Future> const&>(values)))
+        template <typename... Ts>
+        friend bool tag_invoke(wait_some_nothrow_t, std::size_t n, Ts&&... ts)
         {
-            hpx::detail::throw_if_exceptional(values);
-        }
-    }
+            if (n == 0)
+            {
+                return false;
+            }
 
-    template <typename Future>
-    bool wait_some_nothrow(std::size_t n, std::vector<Future>&& values)
-    {
-        return hpx::wait_some_nothrow(
-            n, const_cast<std::vector<Future> const&>(values));
-    }
+            if (n > sizeof...(Ts))
+            {
+                HPX_THROW_EXCEPTION(hpx::bad_parameter, "hpx::lcos::wait_some",
+                    "number of results to wait for is out of bounds");
+                return false;
+            }
 
-    template <typename Future>
-    void wait_some(std::size_t n, std::vector<Future>&& values)
-    {
-        if (hpx::wait_some_nothrow(
-                n, const_cast<std::vector<Future> const&>(values)))
-        {
-            hpx::detail::throw_if_exceptional(values);
+            using result_type =
+                hpx::tuple<traits::detail::shared_state_ptr_for_t<Ts>...>;
+
+            result_type values(traits::detail::get_shared_state(ts)...);
+            auto f = detail::get_wait_some_frame(values, n);
+
+            return (*f)();
         }
-    }
+    } wait_some_nothrow{};
 
     ///////////////////////////////////////////////////////////////////////////
-    template <typename Future, std::size_t N>
-    bool wait_some_nothrow(std::size_t n, std::array<Future, N> const& values)
+    inline constexpr struct wait_some_t final
+      : hpx::functional::tag<wait_some_t>
     {
-        static_assert(
-            hpx::traits::is_future_v<Future>, "invalid use of wait_some");
-
-        if (n == 0)
+    private:
+        template <typename Future>
+        friend void tag_invoke(
+            wait_some_t, std::size_t n, std::vector<Future> const& values)
         {
-            return false;
+            if (hpx::wait_some_nothrow(n, values))
+            {
+                hpx::detail::throw_if_exceptional(values);
+            }
         }
 
-        if (n > values.size())
+        template <typename Future>
+        friend void tag_invoke(
+            wait_some_t, std::size_t n, std::vector<Future>& values)
         {
-            HPX_THROW_EXCEPTION(hpx::bad_parameter, "hpx::wait_some",
-                "number of results to wait for is out of bounds");
-            return false;
+            if (hpx::wait_some_nothrow(
+                    n, const_cast<std::vector<Future> const&>(values)))
+            {
+                hpx::detail::throw_if_exceptional(values);
+            }
         }
 
-        auto lazy_values = traits::acquire_shared_state_disp()(values);
-        auto f = detail::get_wait_some_frame(lazy_values, n);
-
-        return (*f)();
-    }
-
-    template <typename Future, std::size_t N>
-    void wait_some(std::size_t n, std::array<Future, N> const& lazy_values)
-    {
-        if (hpx::wait_some_nothrow(n, lazy_values))
+        template <typename Future>
+        friend void tag_invoke(
+            wait_some_t, std::size_t n, std::vector<Future>&& values)
         {
-            hpx::detail::throw_if_exceptional(lazy_values);
+            if (hpx::wait_some_nothrow(
+                    n, const_cast<std::vector<Future> const&>(values)))
+            {
+                hpx::detail::throw_if_exceptional(values);
+            }
         }
-    }
 
-    template <typename Future, std::size_t N>
-    bool wait_some_nothrow(std::size_t n, std::array<Future, N>& lazy_values)
-    {
-        return hpx::wait_some_nothrow(
-            n, const_cast<std::array<Future, N> const&>(lazy_values));
-    }
-
-    template <typename Future, std::size_t N>
-    void wait_some(std::size_t n, std::array<Future, N>& lazy_values)
-    {
-        if (hpx::wait_some_nothrow(
-                n, const_cast<std::array<Future, N> const&>(lazy_values)))
+        template <typename Future, std::size_t N>
+        friend void tag_invoke(wait_some_t, std::size_t n,
+            std::array<Future, N> const& lazy_values)
         {
-            hpx::detail::throw_if_exceptional(lazy_values);
+            if (hpx::wait_some_nothrow(n, lazy_values))
+            {
+                hpx::detail::throw_if_exceptional(lazy_values);
+            }
         }
-    }
 
-    template <typename Future, std::size_t N>
-    bool wait_some_nothrow(std::size_t n, std::array<Future, N>&& lazy_values)
-    {
-        return hpx::wait_some_nothrow(
-            n, const_cast<std::array<Future, N> const&>(lazy_values));
-    }
-
-    template <typename Future, std::size_t N>
-    void wait_some(std::size_t n, std::array<Future, N>&& lazy_values)
-    {
-        if (hpx::wait_some_nothrow(
-                n, const_cast<std::array<Future, N> const&>(lazy_values)))
+        template <typename Future, std::size_t N>
+        friend void tag_invoke(
+            wait_some_t, std::size_t n, std::array<Future, N>& lazy_values)
         {
-            hpx::detail::throw_if_exceptional(lazy_values);
+            if (hpx::wait_some_nothrow(
+                    n, const_cast<std::array<Future, N> const&>(lazy_values)))
+            {
+                hpx::detail::throw_if_exceptional(lazy_values);
+            }
         }
-    }
+
+        template <typename Future, std::size_t N>
+        friend void tag_invoke(
+            wait_some_t, std::size_t n, std::array<Future, N>&& lazy_values)
+        {
+            if (hpx::wait_some_nothrow(
+                    n, const_cast<std::array<Future, N> const&>(lazy_values)))
+            {
+                hpx::detail::throw_if_exceptional(lazy_values);
+            }
+        }
+
+        template <typename Iterator,
+            typename Enable =
+                std::enable_if_t<hpx::traits::is_iterator_v<Iterator>>>
+        friend void tag_invoke(
+            wait_some_t, std::size_t n, Iterator begin, Iterator end)
+        {
+            auto values = traits::acquire_shared_state<Iterator>()(begin, end);
+            auto f = detail::get_wait_some_frame(values, n);
+
+            if ((*f)())
+            {
+                hpx::detail::throw_if_exceptional(values);
+            }
+        }
+
+        friend void tag_invoke(wait_some_t, std::size_t n)
+        {
+            if (n != 0)
+            {
+                HPX_THROW_EXCEPTION(hpx::bad_parameter, "hpx::wait_some",
+                    "number of results to wait for is out of bounds");
+            }
+        }
+
+        template <typename T>
+        friend void tag_invoke(wait_some_t, std::size_t n, hpx::future<T>&& f)
+        {
+            if (hpx::wait_some_nothrow(n, HPX_MOVE(f)))
+            {
+                hpx::detail::throw_if_exceptional(f);
+            }
+        }
+
+        template <typename T>
+        friend void tag_invoke(
+            wait_some_t, std::size_t n, hpx::shared_future<T>&& f)
+        {
+            if (hpx::wait_some_nothrow(n, HPX_MOVE(f)))
+            {
+                hpx::detail::throw_if_exceptional(f);
+            }
+        }
+
+        template <typename... Ts>
+        friend void tag_invoke(wait_some_t, std::size_t n, Ts&&... ts)
+        {
+            if (hpx::wait_some_nothrow(n, ts...))
+            {
+                hpx::detail::throw_if_exceptional(HPX_FORWARD(Ts, ts)...);
+            }
+        }
+    } wait_some{};
 
     ///////////////////////////////////////////////////////////////////////////
-    template <typename Iterator,
-        typename Enable =
-            std::enable_if_t<hpx::traits::is_iterator_v<Iterator>>>
-    bool wait_some_nothrow(std::size_t n, Iterator begin, Iterator end)
+    inline constexpr struct wait_some_n_nothrow_t final
+      : hpx::functional::tag<wait_some_n_nothrow_t>
     {
-        auto values = traits::acquire_shared_state<Iterator>()(begin, end);
-        auto f = detail::get_wait_some_frame(values, n);
-
-        return (*f)();
-    }
-
-    template <typename Iterator,
-        typename Enable =
-            std::enable_if_t<hpx::traits::is_iterator_v<Iterator>>>
-    void wait_some(std::size_t n, Iterator begin, Iterator end)
-    {
-        auto values = traits::acquire_shared_state<Iterator>()(begin, end);
-        auto f = detail::get_wait_some_frame(values, n);
-
-        if ((*f)())
+    private:
+        template <typename Iterator,
+            typename Enable =
+                std::enable_if_t<hpx::traits::is_iterator_v<Iterator>>>
+        friend bool tag_invoke(wait_some_n_nothrow_t, std::size_t n,
+            Iterator begin, std::size_t count)
         {
-            hpx::detail::throw_if_exceptional(values);
+            auto values =
+                traits::acquire_shared_state<Iterator>()(begin, count);
+            auto f = detail::get_wait_some_frame(values, n);
+
+            return (*f)();
         }
-    }
-
-    template <typename Iterator,
-        typename Enable =
-            std::enable_if_t<hpx::traits::is_iterator_v<Iterator>>>
-    bool wait_some_n_nothrow(std::size_t n, Iterator begin, std::size_t count)
-    {
-        auto values = traits::acquire_shared_state<Iterator>()(begin, count);
-        auto f = detail::get_wait_some_frame(values, n);
-
-        return (*f)();
-    }
-
-    template <typename Iterator,
-        typename Enable =
-            std::enable_if_t<hpx::traits::is_iterator_v<Iterator>>>
-    void wait_some_n(std::size_t n, Iterator begin, std::size_t count)
-    {
-        auto values = traits::acquire_shared_state<Iterator>()(begin, count);
-        auto f = detail::get_wait_some_frame(values, n);
-
-        if ((*f)())
-        {
-            hpx::detail::throw_if_exceptional(values);
-        }
-    }
-
-    inline bool wait_some_nothrow(std::size_t n)
-    {
-        if (n != 0)
-        {
-            HPX_THROW_EXCEPTION(hpx::bad_parameter, "hpx::wait_some_nothrow",
-                "number of results to wait for is out of bounds");
-        }
-        return false;
-    }
-
-    inline void wait_some(std::size_t n)
-    {
-        if (n != 0)
-        {
-            HPX_THROW_EXCEPTION(hpx::bad_parameter, "hpx::wait_some",
-                "number of results to wait for is out of bounds");
-        }
-    }
+    } wait_some_n_nothrow{};
 
     ///////////////////////////////////////////////////////////////////////////
-    template <typename T>
-    bool wait_some_nothrow(std::size_t n, hpx::future<T>&& f)
+    inline constexpr struct wait_some_n_t final
+      : hpx::functional::tag<wait_some_n_t>
     {
-        if (n != 1)
+    private:
+        template <typename Iterator,
+            typename Enable =
+                std::enable_if_t<hpx::traits::is_iterator_v<Iterator>>>
+        friend void tag_invoke(
+            wait_some_n_t, std::size_t n, Iterator begin, std::size_t count)
         {
-            HPX_THROW_EXCEPTION(hpx::bad_parameter, "hpx::wait_some",
-                "number of results to wait for is out of bounds");
-            return false;
+            auto values =
+                traits::acquire_shared_state<Iterator>()(begin, count);
+            auto f = detail::get_wait_some_frame(values, n);
+
+            if ((*f)())
+            {
+                hpx::detail::throw_if_exceptional(values);
+            }
         }
-
-        f.wait();
-
-        return f.has_exception();
-    }
-
-    template <typename T>
-    void wait_some(std::size_t n, hpx::future<T>&& f)
-    {
-        if (hpx::wait_some_nothrow(n, HPX_MOVE(f)))
-        {
-            hpx::detail::throw_if_exceptional(f);
-        }
-    }
-
-    template <typename T>
-    bool wait_some_nothrow(std::size_t n, hpx::shared_future<T>&& f)
-    {
-        if (n != 1)
-        {
-            HPX_THROW_EXCEPTION(hpx::bad_parameter, "hpx::wait_some",
-                "number of results to wait for is out of bounds");
-            return false;
-        }
-
-        f.wait();
-
-        return f.has_exception();
-    }
-
-    template <typename T>
-    void wait_some(std::size_t n, hpx::shared_future<T>&& f)
-    {
-        if (hpx::wait_some_nothrow(n, HPX_MOVE(f)))
-        {
-            hpx::detail::throw_if_exceptional(f);
-        }
-    }
-
-    ///////////////////////////////////////////////////////////////////////////
-    template <typename... Ts>
-    bool wait_some_nothrow(std::size_t n, Ts&&... ts)
-    {
-        if (n == 0)
-        {
-            return false;
-        }
-
-        if (n > sizeof...(Ts))
-        {
-            HPX_THROW_EXCEPTION(hpx::bad_parameter, "hpx::lcos::wait_some",
-                "number of results to wait for is out of bounds");
-            return false;
-        }
-
-        using result_type =
-            hpx::tuple<traits::detail::shared_state_ptr_for_t<Ts>...>;
-
-        result_type values(traits::detail::get_shared_state(ts)...);
-        auto f = detail::get_wait_some_frame(values, n);
-
-        return (*f)();
-    }
-
-    template <typename... Ts>
-    void wait_some(std::size_t n, Ts&&... ts)
-    {
-        if (hpx::wait_some_nothrow(n, ts...))
-        {
-            hpx::detail::throw_if_exceptional(HPX_FORWARD(Ts, ts)...);
-        }
-    }
+    } wait_some_n{};
 }    // namespace hpx
 
 namespace hpx::lcos {

--- a/libs/core/async_combinators/include/hpx/async_combinators/when_any.hpp
+++ b/libs/core/async_combinators/include/hpx/async_combinators/when_any.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2021 Hartmut Kaiser
+//  Copyright (c) 2007-2022 Hartmut Kaiser
 //  Copyright (c) 2013 Agustin Berge
 //
 //  SPDX-License-Identifier: BSL-1.0
@@ -126,6 +126,7 @@ namespace hpx {
 #include <hpx/datastructures/tuple.hpp>
 #include <hpx/execution_base/this_thread.hpp>
 #include <hpx/functional/deferred_call.hpp>
+#include <hpx/functional/tag_invoke.hpp>
 #include <hpx/futures/future.hpp>
 #include <hpx/futures/futures_factory.hpp>
 #include <hpx/futures/traits/acquire_future.hpp>
@@ -205,267 +206,277 @@ namespace hpx {
         std::size_t index;
         Sequence futures;
     };
+}    // namespace hpx
 
-    namespace lcos { namespace detail {
+namespace hpx::lcos::detail {
 
-        ///////////////////////////////////////////////////////////////////////
-        template <typename Sequence>
-        struct when_any;
+    ///////////////////////////////////////////////////////////////////////
+    template <typename Sequence>
+    struct when_any;
 
-        template <typename Sequence>
-        struct set_when_any_callback_impl
+    template <typename Sequence>
+    struct set_when_any_callback_impl
+    {
+        explicit set_when_any_callback_impl(when_any<Sequence>& when) noexcept
+          : when_(when)
+          , idx_(0)
         {
-            explicit set_when_any_callback_impl(
-                when_any<Sequence>& when) noexcept
-              : when_(when)
-              , idx_(0)
-            {
-            }
-
-            template <typename Future>
-            std::enable_if_t<hpx::traits::is_future_v<Future>> operator()(
-                Future& future) const
-            {
-                std::size_t index =
-                    when_.index_.load(std::memory_order_seq_cst);
-
-                if (index == when_any_result<Sequence>::index_error())
-                {
-                    using shared_state_ptr =
-                        hpx::traits::detail::shared_state_ptr_for_t<Future>;
-                    shared_state_ptr const& shared_state =
-                        traits::detail::get_shared_state(future);
-
-                    if (shared_state && !shared_state->is_ready())
-                    {
-                        // handle future only if not enough futures are ready
-                        // yet also, do not touch any futures which are already
-                        // ready
-                        shared_state->execute_deferred();
-
-                        // execute_deferred might have made the future ready
-                        if (!shared_state->is_ready())
-                        {
-                            shared_state->set_on_completed(util::deferred_call(
-                                &detail::when_any<Sequence>::on_future_ready,
-                                when_.shared_from_this(), idx_,
-                                hpx::execution_base::this_thread::agent()));
-                            ++idx_;
-                            return;
-                        }
-                    }
-
-                    if (when_.index_.compare_exchange_strong(index, idx_))
-                    {
-                        when_.goal_reached_on_calling_thread_ = true;
-                    }
-                }
-                ++idx_;
-            }
-
-            template <typename Sequence_>
-            HPX_FORCEINLINE
-                std::enable_if_t<hpx::traits::is_future_range_v<Sequence_>>
-                operator()(Sequence_& sequence) const
-            {
-                apply(sequence);
-            }
-
-            template <typename Tuple, std::size_t... Is>
-            HPX_FORCEINLINE void apply(
-                Tuple& tuple, hpx::util::index_pack<Is...>) const
-            {
-                int const _sequencer[] = {
-                    (((*this)(hpx::get<Is>(tuple))), 0)...};
-                (void) _sequencer;
-            }
-
-            template <typename... Ts>
-            HPX_FORCEINLINE void apply(hpx::tuple<Ts...>& sequence) const
-            {
-                apply(sequence, hpx::util::make_index_pack_t<sizeof...(Ts)>());
-            }
-
-            template <typename Sequence_>
-            HPX_FORCEINLINE void apply(Sequence_& sequence) const
-            {
-                std::for_each(sequence.begin(), sequence.end(), *this);
-            }
-
-            detail::when_any<Sequence>& when_;
-            mutable std::size_t idx_;
-        };
-
-        template <typename Sequence>
-        HPX_FORCEINLINE void set_on_completed_callback(
-            detail::when_any<Sequence>& when)
-        {
-            set_when_any_callback_impl<Sequence> callback(when);
-            callback.apply(when.lazy_values_.futures);
         }
 
-        ///////////////////////////////////////////////////////////////////////
-        template <typename Sequence>
-        struct when_any
-          : std::enable_shared_from_this<when_any<Sequence>>    //-V690
+        template <typename Future>
+        std::enable_if_t<hpx::traits::is_future_v<Future>> operator()(
+            Future& future) const
         {
-        public:
-            void on_future_ready(
-                std::size_t idx, hpx::execution_base::agent_ref ctx)
+            std::size_t index = when_.index_.load(std::memory_order_seq_cst);
+
+            if (index == when_any_result<Sequence>::index_error())
             {
-                std::size_t index_not_initialized =
-                    when_any_result<Sequence>::index_error();
-                if (index_.compare_exchange_strong(index_not_initialized, idx))
+                using shared_state_ptr =
+                    hpx::traits::detail::shared_state_ptr_for_t<Future>;
+                shared_state_ptr const& shared_state =
+                    traits::detail::get_shared_state(future);
+
+                if (shared_state && !shared_state->is_ready())
                 {
-                    // reactivate waiting thread only if it's not us
-                    if (ctx != hpx::execution_base::this_thread::agent())
+                    // handle future only if not enough futures are ready
+                    // yet also, do not touch any futures which are already
+                    // ready
+                    shared_state->execute_deferred();
+
+                    // execute_deferred might have made the future ready
+                    if (!shared_state->is_ready())
                     {
-                        ctx.resume();
-                    }
-                    else
-                    {
-                        goal_reached_on_calling_thread_ = true;
+                        shared_state->set_on_completed(util::deferred_call(
+                            &detail::when_any<Sequence>::on_future_ready,
+                            when_.shared_from_this(), idx_,
+                            hpx::execution_base::this_thread::agent()));
+                        ++idx_;
+                        return;
                     }
                 }
-            }
 
-        private:
-            when_any(when_any const&) = delete;
-            when_any(when_any&) = delete;
-
-            when_any& operator=(when_any const&) = delete;
-            when_any& operator=(when_any&&) = delete;
-
-        public:
-            using argument_type = Sequence;
-
-            when_any(argument_type&& lazy_values) noexcept
-              : lazy_values_(HPX_MOVE(lazy_values))
-              , index_(when_any_result<Sequence>::index_error())
-              , goal_reached_on_calling_thread_(false)
-            {
-            }
-
-            when_any_result<Sequence> operator()()
-            {
-                // set callback functions to executed when future is ready
-                set_on_completed_callback(*this);
-
-                // if one of the requested futures is already set, our
-                // callback above has already been called often enough, otherwise
-                // we suspend ourselves
-                if (!goal_reached_on_calling_thread_)
+                if (when_.index_.compare_exchange_strong(index, idx_))
                 {
-                    // wait for any of the futures to return to become ready
-                    hpx::execution_base::this_thread::suspend(
-                        "hpx::lcos::detail::when_any::operator()");
+                    when_.goal_reached_on_calling_thread_ = true;
                 }
-
-                // that should not happen
-                HPX_ASSERT(
-                    index_.load() != when_any_result<Sequence>::index_error());
-
-                lazy_values_.index = index_.load();
-                return HPX_MOVE(lazy_values_);
             }
-
-            when_any_result<Sequence> lazy_values_;
-            std::atomic<std::size_t> index_;
-            bool goal_reached_on_calling_thread_;
-        };
-    }}    // namespace lcos::detail
-
-    ///////////////////////////////////////////////////////////////////////////
-    template <typename Range>
-    std::enable_if_t<hpx::traits::is_future_range_v<Range>,
-        hpx::future<hpx::when_any_result<std::decay_t<Range>>>>
-    when_any(Range&& values)
-    {
-        using result_type = std::decay_t<Range>;
-
-        auto f = std::make_shared<lcos::detail::when_any<result_type>>(
-            hpx::traits::acquire_future<result_type>()(values));
-
-        lcos::local::futures_factory<hpx::when_any_result<result_type>()> p(
-            [f = HPX_MOVE(f)]() -> hpx::when_any_result<result_type> {
-                return (*f)();
-            });
-
-        auto result = p.get_future();
-        p.apply();
-
-        return result;
-    }
-
-    template <typename Iterator,
-        typename Container =
-            std::vector<hpx::lcos::detail::future_iterator_traits_t<Iterator>>,
-        typename Enable =
-            std::enable_if_t<hpx::traits::is_iterator_v<Iterator>>>
-    hpx::future<hpx::when_any_result<Container>> when_any(
-        Iterator begin, Iterator end)
-    {
-        Container values;
-        traits::detail::reserve_if_random_access_by_range(values, begin, end);
-
-        std::move(begin, end, std::back_inserter(values));
-        return hpx::when_any(HPX_MOVE(values));
-    }
-
-    inline auto when_any()
-    {
-        return hpx::make_ready_future(hpx::when_any_result<hpx::tuple<>>());
-    }
-
-    ///////////////////////////////////////////////////////////////////////////
-    template <typename Iterator,
-        typename Container =
-            std::vector<hpx::lcos::detail::future_iterator_traits_t<Iterator>>,
-        typename Enable =
-            std::enable_if_t<hpx::traits::is_iterator_v<Iterator>>>
-    hpx::future<hpx::when_any_result<Container>> when_any_n(
-        Iterator begin, std::size_t count)
-    {
-        Container values;
-        traits::detail::reserve_if_reservable(values, count);
-
-        while (count-- != 0)
-        {
-            // NOLINTNEXTLINE(bugprone-macro-repeated-side-effects)
-            values.push_back(HPX_MOVE(*begin++));
+            ++idx_;
         }
-        return hpx::when_any(HPX_MOVE(values));
+
+        template <typename Sequence_>
+        HPX_FORCEINLINE
+            std::enable_if_t<hpx::traits::is_future_range_v<Sequence_>>
+            operator()(Sequence_& sequence) const
+        {
+            apply(sequence);
+        }
+
+        template <typename Tuple, std::size_t... Is>
+        HPX_FORCEINLINE void apply(
+            Tuple& tuple, hpx::util::index_pack<Is...>) const
+        {
+            int const _sequencer[] = {(((*this)(hpx::get<Is>(tuple))), 0)...};
+            (void) _sequencer;
+        }
+
+        template <typename... Ts>
+        HPX_FORCEINLINE void apply(hpx::tuple<Ts...>& sequence) const
+        {
+            apply(sequence, hpx::util::make_index_pack_t<sizeof...(Ts)>());
+        }
+
+        template <typename Sequence_>
+        HPX_FORCEINLINE void apply(Sequence_& sequence) const
+        {
+            std::for_each(sequence.begin(), sequence.end(), *this);
+        }
+
+        detail::when_any<Sequence>& when_;
+        mutable std::size_t idx_;
+    };
+
+    template <typename Sequence>
+    HPX_FORCEINLINE void set_on_completed_callback(
+        detail::when_any<Sequence>& when)
+    {
+        set_when_any_callback_impl<Sequence> callback(when);
+        callback.apply(when.lazy_values_.futures);
     }
+
+    ///////////////////////////////////////////////////////////////////////
+    template <typename Sequence>
+    struct when_any
+      : std::enable_shared_from_this<when_any<Sequence>>    //-V690
+    {
+    public:
+        void on_future_ready(
+            std::size_t idx, hpx::execution_base::agent_ref ctx)
+        {
+            std::size_t index_not_initialized =
+                when_any_result<Sequence>::index_error();
+            if (index_.compare_exchange_strong(index_not_initialized, idx))
+            {
+                // reactivate waiting thread only if it's not us
+                if (ctx != hpx::execution_base::this_thread::agent())
+                {
+                    ctx.resume();
+                }
+                else
+                {
+                    goal_reached_on_calling_thread_ = true;
+                }
+            }
+        }
+
+    private:
+        when_any(when_any const&) = delete;
+        when_any(when_any&) = delete;
+
+        when_any& operator=(when_any const&) = delete;
+        when_any& operator=(when_any&&) = delete;
+
+    public:
+        using argument_type = Sequence;
+
+        when_any(argument_type&& lazy_values) noexcept
+          : lazy_values_(HPX_MOVE(lazy_values))
+          , index_(when_any_result<Sequence>::index_error())
+          , goal_reached_on_calling_thread_(false)
+        {
+        }
+
+        when_any_result<Sequence> operator()()
+        {
+            // set callback functions to executed when future is ready
+            set_on_completed_callback(*this);
+
+            // if one of the requested futures is already set, our
+            // callback above has already been called often enough, otherwise
+            // we suspend ourselves
+            if (!goal_reached_on_calling_thread_)
+            {
+                // wait for any of the futures to return to become ready
+                hpx::execution_base::this_thread::suspend(
+                    "hpx::lcos::detail::when_any::operator()");
+            }
+
+            // that should not happen
+            HPX_ASSERT(
+                index_.load() != when_any_result<Sequence>::index_error());
+
+            lazy_values_.index = index_.load();
+            return HPX_MOVE(lazy_values_);
+        }
+
+        when_any_result<Sequence> lazy_values_;
+        std::atomic<std::size_t> index_;
+        bool goal_reached_on_calling_thread_;
+    };
+}    // namespace hpx::lcos::detail
+
+namespace hpx {
 
     ///////////////////////////////////////////////////////////////////////////
-    template <typename T, typename... Ts,
-        typename Enable = std::enable_if_t<!(
-            hpx::traits::is_future_range_v<T> && sizeof...(Ts) == 0)>>
-    hpx::future<
-        hpx::when_any_result<hpx::tuple<hpx::traits::acquire_future_t<T>,
-            hpx::traits::acquire_future_t<Ts>...>>>
-    when_any(T&& t, Ts&&... ts)
+    inline constexpr struct when_any_t final : hpx::functional::tag<when_any_t>
     {
-        using result_type = hpx::tuple<hpx::traits::acquire_future_t<T>,
-            hpx::traits::acquire_future_t<Ts>...>;
+    private:
+        template <typename Range,
+            typename Enable =
+                std::enable_if_t<hpx::traits::is_future_range_v<Range>>>
+        friend hpx::future<hpx::when_any_result<std::decay_t<Range>>>
+        tag_invoke(when_any_t, Range&& values)
+        {
+            using result_type = std::decay_t<Range>;
 
-        hpx::traits::acquire_future_disp func;
-        result_type values(
-            func(HPX_FORWARD(T, t)), func(HPX_FORWARD(Ts, ts))...);
+            auto f = std::make_shared<lcos::detail::when_any<result_type>>(
+                hpx::traits::acquire_future<result_type>()(values));
 
-        auto f = std::make_shared<lcos::detail::when_any<result_type>>(
-            HPX_MOVE(values));
+            lcos::local::futures_factory<hpx::when_any_result<result_type>()> p(
+                [f = HPX_MOVE(f)]() -> hpx::when_any_result<result_type> {
+                    return (*f)();
+                });
 
-        lcos::local::futures_factory<hpx::when_any_result<result_type>()> p(
-            [f = HPX_MOVE(f)]() -> hpx::when_any_result<result_type> {
-                return (*f)();
-            });
+            auto result = p.get_future();
+            p.apply();
 
-        auto result = p.get_future();
-        p.apply();
+            return result;
+        }
 
-        return result;
-    }
+        template <typename Iterator,
+            typename Enable =
+                std::enable_if_t<hpx::traits::is_iterator_v<Iterator>>>
+        friend decltype(auto) tag_invoke(
+            when_any_t, Iterator begin, Iterator end)
+        {
+            using value_type =
+                hpx::lcos::detail::future_iterator_traits_t<Iterator>;
+
+            std::vector<value_type> values;
+            traits::detail::reserve_if_random_access_by_range(
+                values, begin, end);
+
+            std::move(begin, end, std::back_inserter(values));
+            return tag_invoke(when_any_t{}, HPX_MOVE(values));
+        }
+
+        friend auto tag_invoke(when_any_t)
+        {
+            return hpx::make_ready_future(hpx::when_any_result<hpx::tuple<>>());
+        }
+
+        ///////////////////////////////////////////////////////////////////////////
+        template <typename T, typename... Ts,
+            typename Enable = std::enable_if_t<!(
+                hpx::traits::is_future_range_v<T> && sizeof...(Ts) == 0)>>
+        friend auto tag_invoke(when_any_t, T&& t, Ts&&... ts)
+        {
+            using result_type = hpx::tuple<hpx::traits::acquire_future_t<T>,
+                hpx::traits::acquire_future_t<Ts>...>;
+
+            hpx::traits::acquire_future_disp func;
+            result_type values(
+                func(HPX_FORWARD(T, t)), func(HPX_FORWARD(Ts, ts))...);
+
+            auto f = std::make_shared<lcos::detail::when_any<result_type>>(
+                HPX_MOVE(values));
+
+            lcos::local::futures_factory<hpx::when_any_result<result_type>()> p(
+                [f = HPX_MOVE(f)]() -> hpx::when_any_result<result_type> {
+                    return (*f)();
+                });
+
+            auto result = p.get_future();
+            p.apply();
+
+            return result;
+        }
+    } when_any{};
+
+    ///////////////////////////////////////////////////////////////////////////
+    inline constexpr struct when_any_n_t final
+      : hpx::functional::tag<when_any_n_t>
+    {
+    private:
+        template <typename Iterator,
+            typename Enable =
+                std::enable_if_t<hpx::traits::is_iterator_v<Iterator>>>
+        friend decltype(auto) tag_invoke(
+            when_any_n_t, Iterator begin, std::size_t count)
+        {
+            using value_type =
+                hpx::lcos::detail::future_iterator_traits_t<Iterator>;
+
+            std::vector<value_type> values;
+            values.reserve(count);
+
+            while (count-- != 0)
+            {
+                // NOLINTNEXTLINE(bugprone-macro-repeated-side-effects)
+                values.push_back(HPX_MOVE(*begin++));
+            }
+            return hpx::when_any(HPX_MOVE(values));
+        }
+    } when_any_n{};
 }    // namespace hpx
 
 namespace hpx::lcos {

--- a/libs/core/async_combinators/include/hpx/async_combinators/when_each.hpp
+++ b/libs/core/async_combinators/include/hpx/async_combinators/when_each.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2021 Hartmut Kaiser
+//  Copyright (c) 2007-2022 Hartmut Kaiser
 //  Copyright (c) 2013 Agustin Berge
 //  Copyright (c) 2016 Lukas Troska
 //
@@ -148,151 +148,84 @@ namespace hpx {
 #include <vector>
 
 ///////////////////////////////////////////////////////////////////////////////
-namespace hpx {
+namespace hpx::lcos::detail {
 
-    namespace lcos { namespace detail {
+    template <typename Tuple, typename F>
+    struct when_each_frame    //-V690
+      : lcos::detail::future_data<void>
+    {
+        using type = hpx::future<void>;
 
-        template <typename Tuple, typename F>
-        struct when_each_frame    //-V690
-          : lcos::detail::future_data<void>
+    private:
+        when_each_frame(when_each_frame const&) = delete;
+        when_each_frame(when_each_frame&&) = delete;
+
+        when_each_frame& operator=(when_each_frame const&) = delete;
+        when_each_frame& operator=(when_each_frame&&) = delete;
+
+        template <std::size_t I>
+        struct is_end
+          : std::integral_constant<bool, hpx::tuple_size<Tuple>::value == I>
         {
-            using type = hpx::future<void>;
+        };
 
-        private:
-            when_each_frame(when_each_frame const&) = delete;
-            when_each_frame(when_each_frame&&) = delete;
+        template <std::size_t I>
+        static constexpr bool is_end_v = is_end<I>::value;
 
-            when_each_frame& operator=(when_each_frame const&) = delete;
-            when_each_frame& operator=(when_each_frame&&) = delete;
+    public:
+        template <typename Tuple_, typename F_>
+        when_each_frame(Tuple_&& t, F_&& f, std::size_t needed_count)
+          : t_(HPX_FORWARD(Tuple_, t))
+          , f_(HPX_FORWARD(F_, f))
+          , count_(0)
+          , needed_count_(needed_count)
+        {
+        }
 
-            template <std::size_t I>
-            struct is_end
-              : std::integral_constant<bool, hpx::tuple_size<Tuple>::value == I>
+    public:
+        template <std::size_t I>
+        HPX_FORCEINLINE void do_await()
+        {
+            if constexpr (is_end_v<I>)
             {
-            };
-
-            template <std::size_t I>
-            static constexpr bool is_end_v = is_end<I>::value;
-
-        public:
-            template <typename Tuple_, typename F_>
-            when_each_frame(Tuple_&& t, F_&& f, std::size_t needed_count)
-              : t_(HPX_FORWARD(Tuple_, t))
-              , f_(HPX_FORWARD(F_, f))
-              , count_(0)
-              , needed_count_(needed_count)
-            {
+                this->set_value(util::unused);
             }
-
-        public:
-            template <std::size_t I>
-            HPX_FORCEINLINE void do_await()
-            {
-                if constexpr (is_end_v<I>)
-                {
-                    this->set_value(util::unused);
-                }
-                else
-                {
-                    using future_type = hpx::util::decay_unwrap_t<
-                        typename hpx::tuple_element<I, Tuple>::type>;
-
-                    if constexpr (hpx::traits::is_future_v<future_type> ||
-                        hpx::traits::is_ref_wrapped_future_v<future_type>)
-                    {
-                        await_future<I>();
-                    }
-                    else
-                    {
-                        static_assert(
-                            hpx::traits::is_future_range_v<future_type> ||
-                                hpx::traits::is_ref_wrapped_future_range_v<
-                                    future_type>,
-                            "element must be future or range of futures");
-
-                        auto&& curr = hpx::util::unwrap_ref(hpx::get<I>(t_));
-                        await_range<I>(
-                            hpx::util::begin(curr), hpx::util::end(curr));
-                    }
-                }
-            }
-
-        protected:
-            // Current element is a range (vector) of futures
-            template <std::size_t I, typename Iter>
-            void await_range(Iter&& next, Iter&& end)
-            {
-                using future_type =
-                    typename std::iterator_traits<Iter>::value_type;
-
-                hpx::intrusive_ptr<when_each_frame> this_(this);
-                for (/**/; next != end; ++next)
-                {
-                    auto next_future_data =
-                        traits::detail::get_shared_state(*next);
-
-                    if (next_future_data && !next_future_data->is_ready())
-                    {
-                        next_future_data->execute_deferred();
-
-                        // execute_deferred might have made the future ready
-                        if (!next_future_data->is_ready())
-                        {
-                            // Attach a continuation to this future which will
-                            // re-evaluate it and continue to the next argument
-                            // (if any).
-                            next_future_data->set_on_completed(
-                                [this_ = HPX_MOVE(this_), next = HPX_MOVE(next),
-                                    end = HPX_MOVE(end)]() mutable -> void {
-                                    this_->template await_range<I>(
-                                        HPX_MOVE(next), HPX_MOVE(end));
-                                });
-
-                            // explicitly destruct iterators as those might
-                            // become dangling after we make ourselves ready
-                            next = std::decay_t<Iter>{};
-                            end = std::decay_t<Iter>{};
-                            return;
-                        }
-                    }
-
-                    // call supplied callback with or without index
-                    if constexpr (hpx::is_invocable_v<F, std::size_t,
-                                      future_type>)
-                    {
-                        f_(count_, HPX_MOVE(*next));
-                    }
-                    else
-                    {
-                        f_(HPX_MOVE(*next));
-                    }
-
-                    if (++count_ == needed_count_)
-                    {
-                        this->set_value(util::unused);
-
-                        // explicitly destruct iterators as those might
-                        // become dangling after we make ourselves ready
-                        next = std::decay_t<Iter>{};
-                        end = std::decay_t<Iter>{};
-                        return;
-                    }
-                }
-
-                do_await<I + 1>();
-            }
-
-            // Current element is a simple future
-            template <std::size_t I>
-            HPX_FORCEINLINE void await_future()
+            else
             {
                 using future_type = hpx::util::decay_unwrap_t<
                     typename hpx::tuple_element<I, Tuple>::type>;
 
-                hpx::intrusive_ptr<when_each_frame> this_(this);
+                if constexpr (hpx::traits::is_future_v<future_type> ||
+                    hpx::traits::is_ref_wrapped_future_v<future_type>)
+                {
+                    await_future<I>();
+                }
+                else
+                {
+                    static_assert(hpx::traits::is_future_range_v<future_type> ||
+                            hpx::traits::is_ref_wrapped_future_range_v<
+                                future_type>,
+                        "element must be future or range of futures");
 
-                future_type& fut = hpx::get<I>(t_);
-                auto next_future_data = traits::detail::get_shared_state(fut);
+                    auto&& curr = hpx::util::unwrap_ref(hpx::get<I>(t_));
+                    await_range<I>(
+                        hpx::util::begin(curr), hpx::util::end(curr));
+                }
+            }
+        }
+
+    protected:
+        // Current element is a range (vector) of futures
+        template <std::size_t I, typename Iter>
+        void await_range(Iter&& next, Iter&& end)
+        {
+            using future_type = typename std::iterator_traits<Iter>::value_type;
+
+            hpx::intrusive_ptr<when_each_frame> this_(this);
+            for (/**/; next != end; ++next)
+            {
+                auto next_future_data = traits::detail::get_shared_state(*next);
+
                 if (next_future_data && !next_future_data->is_ready())
                 {
                     next_future_data->execute_deferred();
@@ -304,10 +237,16 @@ namespace hpx {
                         // re-evaluate it and continue to the next argument
                         // (if any).
                         next_future_data->set_on_completed(
-                            [this_ = HPX_MOVE(this_)]() -> void {
-                                this_->template await_future<I>();
+                            [this_ = HPX_MOVE(this_), next = HPX_MOVE(next),
+                                end = HPX_MOVE(end)]() mutable -> void {
+                                this_->template await_range<I>(
+                                    HPX_MOVE(next), HPX_MOVE(end));
                             });
 
+                        // explicitly destruct iterators as those might
+                        // become dangling after we make ourselves ready
+                        next = std::decay_t<Iter>{};
+                        end = std::decay_t<Iter>{};
                         return;
                     }
                 }
@@ -315,137 +254,209 @@ namespace hpx {
                 // call supplied callback with or without index
                 if constexpr (hpx::is_invocable_v<F, std::size_t, future_type>)
                 {
-                    f_(count_, HPX_MOVE(fut));
+                    f_(count_, HPX_MOVE(*next));
                 }
                 else
                 {
-                    f_(HPX_MOVE(fut));
+                    f_(HPX_MOVE(*next));
                 }
 
                 if (++count_ == needed_count_)
                 {
                     this->set_value(util::unused);
+
+                    // explicitly destruct iterators as those might
+                    // become dangling after we make ourselves ready
+                    next = std::decay_t<Iter>{};
+                    end = std::decay_t<Iter>{};
                     return;
                 }
-
-                do_await<I + 1>();
             }
 
-        private:
-            Tuple t_;
-            F f_;
-            std::size_t count_;
-            std::size_t needed_count_;
-        };
-    }}    // namespace lcos::detail
-
-    ///////////////////////////////////////////////////////////////////////////
-    template <typename F, typename Future,
-        typename Enable = std::enable_if_t<hpx::traits::is_future_v<Future>>>
-    hpx::future<void> when_each(F&& func, std::vector<Future>& lazy_values)
-    {
-        using argument_type = hpx::tuple<std::vector<Future>>;
-        using frame_type =
-            lcos::detail::when_each_frame<argument_type, std::decay_t<F>>;
-
-        std::vector<Future> values;
-        values.reserve(lazy_values.size());
-
-        std::transform(lazy_values.begin(), lazy_values.end(),
-            std::back_inserter(values), traits::acquire_future_disp());
-
-        hpx::intrusive_ptr<frame_type> p(
-            new frame_type(hpx::forward_as_tuple(HPX_MOVE(values)),
-                HPX_FORWARD(F, func), values.size()));
-
-        p->template do_await<0>();
-
-        return hpx::traits::future_access<typename frame_type::type>::create(
-            HPX_MOVE(p));
-    }
-
-    template <typename F, typename Future>
-    hpx::future<void>    //-V659
-    when_each(F&& f, std::vector<Future>&& values)
-    {
-        return hpx::when_each(HPX_FORWARD(F, f), values);
-    }
-
-    template <typename F, typename Iterator,
-        typename Enable =
-            std::enable_if_t<hpx::traits::is_iterator_v<Iterator>>>
-    hpx::future<Iterator> when_each(F&& f, Iterator begin, Iterator end)
-    {
-        using future_type =
-            typename lcos::detail::future_iterator_traits<Iterator>::type;
-
-        std::vector<future_type> values;
-        traits::detail::reserve_if_random_access_by_range(values, begin, end);
-
-        std::transform(begin, end, std::back_inserter(values),
-            traits::acquire_future_disp());
-
-        return hpx::when_each(HPX_FORWARD(F, f), values)
-            .then(hpx::launch::sync,
-                [end = HPX_MOVE(end)](hpx::future<void> fut) -> Iterator {
-                    fut.get();    // rethrow exceptions, if any
-                    return end;
-                });
-    }
-
-    template <typename F, typename Iterator,
-        typename Enable =
-            std::enable_if_t<hpx::traits::is_iterator_v<Iterator>>>
-    hpx::future<Iterator> when_each_n(F&& f, Iterator begin, std::size_t count)
-    {
-        using future_type =
-            typename lcos::detail::future_iterator_traits<Iterator>::type;
-
-        std::vector<future_type> values;
-        values.reserve(count);
-
-        traits::acquire_future_disp func;
-        while (count-- != 0)
-        {
-            values.push_back(func(*begin++));
+            do_await<I + 1>();
         }
 
-        return hpx::when_each(HPX_FORWARD(F, f), values)
-            .then(hpx::launch::sync,
-                [begin = HPX_MOVE(begin)](hpx::future<void>&& fut) -> Iterator {
-                    fut.get();    // rethrow exceptions, if any
-                    return begin;
-                });
-    }
+        // Current element is a simple future
+        template <std::size_t I>
+        HPX_FORCEINLINE void await_future()
+        {
+            using future_type = hpx::util::decay_unwrap_t<
+                typename hpx::tuple_element<I, Tuple>::type>;
 
-    template <typename F>
-    inline hpx::future<void> when_each(F&&)
-    {
-        return hpx::make_ready_future();
-    }
+            hpx::intrusive_ptr<when_each_frame> this_(this);
+
+            future_type& fut = hpx::get<I>(t_);
+            auto next_future_data = traits::detail::get_shared_state(fut);
+            if (next_future_data && !next_future_data->is_ready())
+            {
+                next_future_data->execute_deferred();
+
+                // execute_deferred might have made the future ready
+                if (!next_future_data->is_ready())
+                {
+                    // Attach a continuation to this future which will
+                    // re-evaluate it and continue to the next argument
+                    // (if any).
+                    next_future_data->set_on_completed(
+                        [this_ = HPX_MOVE(this_)]() -> void {
+                            this_->template await_future<I>();
+                        });
+
+                    return;
+                }
+            }
+
+            // call supplied callback with or without index
+            if constexpr (hpx::is_invocable_v<F, std::size_t, future_type>)
+            {
+                f_(count_, HPX_MOVE(fut));
+            }
+            else
+            {
+                f_(HPX_MOVE(fut));
+            }
+
+            if (++count_ == needed_count_)
+            {
+                this->set_value(util::unused);
+                return;
+            }
+
+            do_await<I + 1>();
+        }
+
+    private:
+        Tuple t_;
+        F f_;
+        std::size_t count_;
+        std::size_t needed_count_;
+    };
+}    // namespace hpx::lcos::detail
+
+namespace hpx {
 
     ///////////////////////////////////////////////////////////////////////////
-    template <typename F, typename... Ts>
-    std::enable_if_t<!hpx::traits::is_future_v<std::decay_t<F>> &&
-            hpx::util::all_of_v<hpx::traits::is_future<Ts>...>,
-        hpx::future<void>>
-    when_each(F&& f, Ts&&... ts)
+    inline constexpr struct when_each_t final
+      : hpx::functional::tag<when_each_t>
     {
-        using argument_type = hpx::tuple<traits::acquire_future_t<Ts>...>;
-        using frame_type =
-            lcos::detail::when_each_frame<argument_type, std::decay_t<F>>;
+    private:
+        template <typename F, typename Future,
+            typename Enable =
+                std::enable_if_t<hpx::traits::is_future_v<Future>>>
+        friend decltype(auto) tag_invoke(
+            when_each_t, F&& func, std::vector<Future>& lazy_values)
+        {
+            using argument_type = hpx::tuple<std::vector<Future>>;
+            using frame_type =
+                lcos::detail::when_each_frame<argument_type, std::decay_t<F>>;
 
-        traits::acquire_future_disp func;
-        argument_type values(func(HPX_FORWARD(Ts, ts))...);
+            std::vector<Future> values;
+            values.reserve(lazy_values.size());
 
-        hpx::intrusive_ptr<frame_type> p(
-            new frame_type(HPX_MOVE(values), HPX_FORWARD(F, f), sizeof...(Ts)));
+            std::transform(lazy_values.begin(), lazy_values.end(),
+                std::back_inserter(values), traits::acquire_future_disp());
 
-        p->template do_await<0>();
+            hpx::intrusive_ptr<frame_type> p(
+                new frame_type(hpx::forward_as_tuple(HPX_MOVE(values)),
+                    HPX_FORWARD(F, func), values.size()));
 
-        return hpx::traits::future_access<typename frame_type::type>::create(
-            HPX_MOVE(p));
-    }
+            p->template do_await<0>();
+
+            return hpx::traits::future_access<
+                typename frame_type::type>::create(HPX_MOVE(p));
+        }
+
+        template <typename F, typename Future>
+        friend decltype(auto) tag_invoke(
+            when_each_t, F&& f, std::vector<Future>&& values)
+        {
+            return tag_invoke(when_each_t{}, HPX_FORWARD(F, f), values);
+        }
+
+        template <typename F, typename Iterator,
+            typename Enable =
+                std::enable_if_t<hpx::traits::is_iterator_v<Iterator>>>
+        friend decltype(auto) tag_invoke(
+            when_each_t, F&& f, Iterator begin, Iterator end)
+        {
+            using future_type =
+                typename lcos::detail::future_iterator_traits<Iterator>::type;
+
+            std::vector<future_type> values;
+            traits::detail::reserve_if_random_access_by_range(
+                values, begin, end);
+
+            std::transform(begin, end, std::back_inserter(values),
+                traits::acquire_future_disp());
+
+            return tag_invoke(when_each_t{}, HPX_FORWARD(F, f), values)
+                .then(hpx::launch::sync,
+                    [end = HPX_MOVE(end)](hpx::future<void> fut) -> Iterator {
+                        fut.get();    // rethrow exceptions, if any
+                        return end;
+                    });
+        }
+
+        template <typename F>
+        friend decltype(auto) tag_invoke(when_each_t, F&&)
+        {
+            return hpx::make_ready_future();
+        }
+
+        template <typename F, typename... Ts,
+            typename Enable =
+                std::enable_if_t<!hpx::traits::is_future_v<std::decay_t<F>> &&
+                    hpx::util::all_of_v<hpx::traits::is_future<Ts>...>>>
+        friend decltype(auto) tag_invoke(when_each_t, F&& f, Ts&&... ts)
+        {
+            using argument_type = hpx::tuple<traits::acquire_future_t<Ts>...>;
+            using frame_type =
+                lcos::detail::when_each_frame<argument_type, std::decay_t<F>>;
+
+            traits::acquire_future_disp func;
+            argument_type values(func(HPX_FORWARD(Ts, ts))...);
+
+            hpx::intrusive_ptr<frame_type> p(new frame_type(
+                HPX_MOVE(values), HPX_FORWARD(F, f), sizeof...(Ts)));
+
+            p->template do_await<0>();
+
+            return hpx::traits::future_access<
+                typename frame_type::type>::create(HPX_MOVE(p));
+        }
+    } when_each{};
+
+    ///////////////////////////////////////////////////////////////////////////
+    inline constexpr struct when_each_n_t final
+      : hpx::functional::tag<when_each_n_t>
+    {
+    private:
+        template <typename F, typename Iterator,
+            typename Enable =
+                std::enable_if_t<hpx::traits::is_iterator_v<Iterator>>>
+        friend decltype(auto) tag_invoke(
+            when_each_n_t, F&& f, Iterator begin, std::size_t count)
+        {
+            using future_type =
+                typename lcos::detail::future_iterator_traits<Iterator>::type;
+
+            std::vector<future_type> values;
+            values.reserve(count);
+
+            traits::acquire_future_disp func;
+            while (count-- != 0)
+            {
+                values.push_back(func(*begin++));
+            }
+
+            return hpx::when_each(HPX_FORWARD(F, f), values)
+                .then(hpx::launch::sync,
+                    [begin = HPX_MOVE(begin)](auto&& fut) -> Iterator {
+                        fut.get();    // rethrow exceptions, if any
+                        return begin;
+                    });
+        }
+    } when_each_n{};
 }    // namespace hpx
 
 namespace hpx::lcos {

--- a/libs/core/async_combinators/include/hpx/async_combinators/when_some.hpp
+++ b/libs/core/async_combinators/include/hpx/async_combinators/when_some.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2021 Hartmut Kaiser
+//  Copyright (c) 2007-2022 Hartmut Kaiser
 //  Copyright (c) 2013 Agustin Berge
 //
 //  SPDX-License-Identifier: BSL-1.0
@@ -184,6 +184,7 @@ namespace hpx {
 #include <hpx/assert.hpp>
 #include <hpx/datastructures/tuple.hpp>
 #include <hpx/functional/deferred_call.hpp>
+#include <hpx/functional/tag_invoke.hpp>
 #include <hpx/futures/future.hpp>
 #include <hpx/futures/futures_factory.hpp>
 #include <hpx/futures/traits/acquire_future.hpp>
@@ -223,322 +224,332 @@ namespace hpx {
         std::vector<std::size_t> indices;
         Sequence futures;
     };
+}    // namespace hpx
 
-    namespace lcos { namespace detail {
+namespace hpx::lcos::detail {
 
-        ///////////////////////////////////////////////////////////////////////
-        template <typename Sequence>
-        struct when_some;
+    ///////////////////////////////////////////////////////////////////////
+    template <typename Sequence>
+    struct when_some;
 
-        template <typename Sequence>
-        struct set_when_some_callback_impl
+    template <typename Sequence>
+    struct set_when_some_callback_impl
+    {
+        explicit set_when_some_callback_impl(when_some<Sequence>& when) noexcept
+          : when_(when)
+          , idx_(0)
         {
-            explicit set_when_some_callback_impl(
-                when_some<Sequence>& when) noexcept
-              : when_(when)
-              , idx_(0)
-            {
-            }
+        }
 
-            template <typename Future>
-            std::enable_if_t<traits::is_future_v<Future>> operator()(
-                Future& future) const
+        template <typename Future>
+        std::enable_if_t<traits::is_future_v<Future>> operator()(
+            Future& future) const
+        {
+            std::size_t counter = when_.count_.load(std::memory_order_seq_cst);
+            if (counter < when_.needed_count_)
             {
-                std::size_t counter =
-                    when_.count_.load(std::memory_order_seq_cst);
-                if (counter < when_.needed_count_)
+                // handle future only if not enough futures are ready
+                // yet also, do not touch any futures which are already
+                // ready
+
+                auto shared_state = traits::detail::get_shared_state(future);
+
+                if (shared_state && !shared_state->is_ready())
                 {
-                    // handle future only if not enough futures are ready
-                    // yet also, do not touch any futures which are already
-                    // ready
+                    shared_state->execute_deferred();
 
-                    auto shared_state =
-                        traits::detail::get_shared_state(future);
-
-                    if (shared_state && !shared_state->is_ready())
+                    // execute_deferred might have made the future ready
+                    if (!shared_state->is_ready())
                     {
-                        shared_state->execute_deferred();
+                        shared_state->set_on_completed(util::deferred_call(
+                            &detail::when_some<Sequence>::on_future_ready,
+                            when_.shared_from_this(), idx_,
+                            hpx::execution_base::this_thread::agent()));
+                        ++idx_;
 
-                        // execute_deferred might have made the future ready
-                        if (!shared_state->is_ready())
-                        {
-                            shared_state->set_on_completed(util::deferred_call(
-                                &detail::when_some<Sequence>::on_future_ready,
-                                when_.shared_from_this(), idx_,
-                                hpx::execution_base::this_thread::agent()));
-                            ++idx_;
-
-                            return;
-                        }
+                        return;
                     }
+                }
 
+                {
+                    using mutex_type =
+                        typename detail::when_some<Sequence>::mutex_type;
+                    std::lock_guard<mutex_type> l(when_.mtx_);
+                    when_.values_.indices.push_back(idx_);
+                }
+
+                if (when_.count_.fetch_add(1) + 1 == when_.needed_count_)
+                {
+                    when_.goal_reached_on_calling_thread_.store(
+                        true, std::memory_order_release);
+                }
+            }
+            ++idx_;
+        }
+
+        template <typename Sequence_>
+        HPX_FORCEINLINE std::enable_if_t<traits::is_future_range_v<Sequence_>>
+        operator()(Sequence_& sequence) const
+        {
+            apply(sequence);
+        }
+
+        template <typename Tuple, std::size_t... Is>
+        HPX_FORCEINLINE void apply(Tuple& tuple, util::index_pack<Is...>) const
+        {
+            int const _sequencer[] = {(((*this)(hpx::get<Is>(tuple))), 0)...};
+            (void) _sequencer;
+        }
+
+        template <typename... Ts>
+        HPX_FORCEINLINE void apply(hpx::tuple<Ts...>& sequence) const
+        {
+            apply(sequence, util::make_index_pack_t<sizeof...(Ts)>());
+        }
+
+        template <typename Sequence_>
+        HPX_FORCEINLINE void apply(Sequence_& sequence) const
+        {
+            std::for_each(sequence.begin(), sequence.end(), *this);
+        }
+
+        detail::when_some<Sequence>& when_;
+        mutable std::size_t idx_;
+    };
+
+    template <typename Sequence>
+    HPX_FORCEINLINE void set_on_completed_callback(
+        detail::when_some<Sequence>& when)
+    {
+        set_when_some_callback_impl<Sequence> callback(when);
+        callback.apply(when.values_.futures);
+    }
+
+    template <typename Sequence>
+    struct when_some
+      : std::enable_shared_from_this<when_some<Sequence>>    //-V690
+    {
+        using mutex_type = hpx::spinlock;
+
+    public:
+        void on_future_ready(
+            std::size_t idx, hpx::execution_base::agent_ref ctx)
+        {
+            std::size_t const new_count = count_.fetch_add(1) + 1;
+            if (new_count <= needed_count_)
+            {
+                {
+                    std::lock_guard<mutex_type> l(this->mtx_);
+                    values_.indices.push_back(idx);
+                }
+
+                if (new_count == needed_count_)
+                {
+                    if (ctx != hpx::execution_base::this_thread::agent())
                     {
-                        using mutex_type =
-                            typename detail::when_some<Sequence>::mutex_type;
-                        std::lock_guard<mutex_type> l(when_.mtx_);
-                        when_.values_.indices.push_back(idx_);
+                        ctx.resume();
                     }
-
-                    if (when_.count_.fetch_add(1) + 1 == when_.needed_count_)
+                    else
                     {
-                        when_.goal_reached_on_calling_thread_.store(
+                        goal_reached_on_calling_thread_.store(
                             true, std::memory_order_release);
                     }
                 }
-                ++idx_;
             }
-
-            template <typename Sequence_>
-            HPX_FORCEINLINE
-                std::enable_if_t<traits::is_future_range_v<Sequence_>>
-                operator()(Sequence_& sequence) const
-            {
-                apply(sequence);
-            }
-
-            template <typename Tuple, std::size_t... Is>
-            HPX_FORCEINLINE void apply(
-                Tuple& tuple, util::index_pack<Is...>) const
-            {
-                int const _sequencer[] = {
-                    (((*this)(hpx::get<Is>(tuple))), 0)...};
-                (void) _sequencer;
-            }
-
-            template <typename... Ts>
-            HPX_FORCEINLINE void apply(hpx::tuple<Ts...>& sequence) const
-            {
-                apply(sequence, util::make_index_pack_t<sizeof...(Ts)>());
-            }
-
-            template <typename Sequence_>
-            HPX_FORCEINLINE void apply(Sequence_& sequence) const
-            {
-                std::for_each(sequence.begin(), sequence.end(), *this);
-            }
-
-            detail::when_some<Sequence>& when_;
-            mutable std::size_t idx_;
-        };
-
-        template <typename Sequence>
-        HPX_FORCEINLINE void set_on_completed_callback(
-            detail::when_some<Sequence>& when)
-        {
-            set_when_some_callback_impl<Sequence> callback(when);
-            callback.apply(when.values_.futures);
         }
 
-        template <typename Sequence>
-        struct when_some
-          : std::enable_shared_from_this<when_some<Sequence>>    //-V690
+    private:
+        when_some(when_some const&) = delete;
+        when_some(when_some&&) = delete;
+
+        when_some& operator=(when_some const&) = delete;
+        when_some& operator=(when_some&&) = delete;
+
+    public:
+        using argument_type = Sequence;
+
+        when_some(argument_type&& values, std::size_t n)
+          : values_(HPX_MOVE(values))
+          , count_(0)
+          , needed_count_(n)
+          , goal_reached_on_calling_thread_(false)
         {
-            using mutex_type = hpx::spinlock;
+        }
 
-        public:
-            void on_future_ready(
-                std::size_t idx, hpx::execution_base::agent_ref ctx)
+        when_some_result<Sequence> operator()()
+        {
+            // set callback functions to executed when future is ready
+            set_on_completed_callback(*this);
+
+            // if all of the requested futures are already set, our
+            // callback above has already been called often enough, otherwise
+            // we suspend ourselves
+            if (!goal_reached_on_calling_thread_.load(
+                    std::memory_order_acquire))
             {
-                std::size_t const new_count = count_.fetch_add(1) + 1;
-                if (new_count <= needed_count_)
-                {
-                    {
-                        std::lock_guard<mutex_type> l(this->mtx_);
-                        values_.indices.push_back(idx);
-                    }
-
-                    if (new_count == needed_count_)
-                    {
-                        if (ctx != hpx::execution_base::this_thread::agent())
-                        {
-                            ctx.resume();
-                        }
-                        else
-                        {
-                            goal_reached_on_calling_thread_.store(
-                                true, std::memory_order_release);
-                        }
-                    }
-                }
+                // wait for any of the futures to return to become ready
+                hpx::execution_base::this_thread::suspend(
+                    "hpx::lcos::detail::when_some::operator()");
             }
 
-        private:
-            when_some(when_some const&) = delete;
-            when_some(when_some&&) = delete;
+            // at least N futures should be ready
+            HPX_ASSERT(count_.load(std::memory_order_acquire) >= needed_count_);
 
-            when_some& operator=(when_some const&) = delete;
-            when_some& operator=(when_some&&) = delete;
+            return HPX_MOVE(values_);
+        }
 
-        public:
-            using argument_type = Sequence;
+        mutable mutex_type mtx_;
+        when_some_result<Sequence> values_;
+        std::atomic<std::size_t> count_;
+        std::size_t needed_count_;
+        std::atomic<bool> goal_reached_on_calling_thread_;
+    };
+}    // namespace hpx::lcos::detail
 
-            when_some(argument_type&& values, std::size_t n)
-              : values_(HPX_MOVE(values))
-              , count_(0)
-              , needed_count_(n)
-              , goal_reached_on_calling_thread_(false)
-            {
-            }
-
-            when_some_result<Sequence> operator()()
-            {
-                // set callback functions to executed when future is ready
-                set_on_completed_callback(*this);
-
-                // if all of the requested futures are already set, our
-                // callback above has already been called often enough, otherwise
-                // we suspend ourselves
-                if (!goal_reached_on_calling_thread_.load(
-                        std::memory_order_acquire))
-                {
-                    // wait for any of the futures to return to become ready
-                    hpx::execution_base::this_thread::suspend(
-                        "hpx::lcos::detail::when_some::operator()");
-                }
-
-                // at least N futures should be ready
-                HPX_ASSERT(
-                    count_.load(std::memory_order_acquire) >= needed_count_);
-
-                return HPX_MOVE(values_);
-            }
-
-            mutable mutex_type mtx_;
-            when_some_result<Sequence> values_;
-            std::atomic<std::size_t> count_;
-            std::size_t needed_count_;
-            std::atomic<bool> goal_reached_on_calling_thread_;
-        };
-    }}    // namespace lcos::detail
+namespace hpx {
 
     ///////////////////////////////////////////////////////////////////////////
-    template <typename Range>
-    std::enable_if_t<traits::is_future_range_v<Range>,
-        hpx::future<when_some_result<std::decay_t<Range>>>>
-    when_some(std::size_t n, Range&& lazy_values)
+    inline constexpr struct when_some_t final
+      : hpx::functional::tag<when_some_t>
     {
-        using result_type = std::decay_t<Range>;
-
-        if (n == 0)
+    private:
+        template <typename Range,
+            typename Enable =
+                std::enable_if_t<traits::is_future_range_v<Range>>>
+        friend auto tag_invoke(when_some_t, std::size_t n, Range&& lazy_values)
         {
-            return hpx::make_ready_future(when_some_result<result_type>());
+            using result_type = std::decay_t<Range>;
+
+            if (n == 0)
+            {
+                return hpx::make_ready_future(when_some_result<result_type>());
+            }
+
+            result_type values =
+                traits::acquire_future<result_type>()(lazy_values);
+
+            if (n > values.size())
+            {
+                return hpx::make_exceptional_future<
+                    when_some_result<result_type>>(
+                    HPX_GET_EXCEPTION(hpx::bad_parameter, "hpx::when_some",
+                        "number of results to wait for is out of bounds"));
+            }
+
+            auto f = std::make_shared<lcos::detail::when_some<result_type>>(
+                HPX_MOVE(values), n);
+
+            lcos::local::futures_factory<when_some_result<result_type>()> p(
+                [f = HPX_MOVE(f)]() -> when_some_result<result_type> {
+                    return (*f)();
+                });
+
+            auto result = p.get_future();
+            p.apply();
+
+            return result;
         }
 
-        result_type values = traits::acquire_future<result_type>()(lazy_values);
-
-        if (n > values.size())
+        template <typename Iterator,
+            typename Enable =
+                std::enable_if_t<hpx::traits::is_iterator_v<Iterator>>>
+        friend decltype(auto) tag_invoke(
+            when_some_t, std::size_t n, Iterator begin, Iterator end)
         {
+            using value_type =
+                typename lcos::detail::future_iterator_traits<Iterator>::type;
+
+            std::vector<value_type> values;
+            traits::detail::reserve_if_random_access_by_range(
+                values, begin, end);
+
+            std::transform(begin, end, std::back_inserter(values),
+                traits::acquire_future_disp());
+
+            return tag_invoke(when_some_t{}, n, HPX_MOVE(values));
+        }
+
+        friend decltype(auto) tag_invoke(when_some_t, std::size_t n)
+        {
+            using result_type = hpx::tuple<>;
+
+            if (n == 0)
+            {
+                return hpx::make_ready_future(when_some_result<result_type>());
+            }
+
             return hpx::make_exceptional_future<when_some_result<result_type>>(
                 HPX_GET_EXCEPTION(hpx::bad_parameter, "hpx::when_some",
                     "number of results to wait for is out of bounds"));
         }
 
-        auto f = std::make_shared<lcos::detail::when_some<result_type>>(
-            HPX_MOVE(values), n);
-
-        lcos::local::futures_factory<when_some_result<result_type>()> p(
-            [f = HPX_MOVE(f)]() -> when_some_result<result_type> {
-                return (*f)();
-            });
-
-        auto result = p.get_future();
-        p.apply();
-
-        return result;
-    }
-
-    template <typename Iterator,
-        typename Container = std::vector<
-            typename lcos::detail::future_iterator_traits<Iterator>::type>,
-        typename Enable =
-            std::enable_if_t<hpx::traits::is_iterator_v<Iterator>>>
-    hpx::future<when_some_result<Container>> when_some(
-        std::size_t n, Iterator begin, Iterator end)
-    {
-        Container values;
-        traits::detail::reserve_if_random_access_by_range(values, begin, end);
-
-        std::transform(begin, end, std::back_inserter(values),
-            traits::acquire_future_disp());
-
-        return hpx::when_some(n, HPX_MOVE(values));
-    }
-
-    template <typename Iterator,
-        typename Container = std::vector<
-            typename lcos::detail::future_iterator_traits<Iterator>::type>,
-        typename Enable =
-            std::enable_if_t<hpx::traits::is_iterator_v<Iterator>>>
-    hpx::future<when_some_result<Container>> when_some_n(
-        std::size_t n, Iterator begin, std::size_t count)
-    {
-        Container values;
-        traits::detail::reserve_if_reservable(values, count);
-
-        traits::acquire_future_disp func;
-        for (std::size_t i = 0; i != count; ++i)
+        ///////////////////////////////////////////////////////////////////////////
+        template <typename T, typename... Ts,
+            typename Enable = std::enable_if_t<!(
+                traits::is_future_range_v<T> && sizeof...(Ts) == 0)>>
+        friend auto tag_invoke(when_some_t, std::size_t n, T&& t, Ts&&... ts)
         {
-            values.push_back(func(*begin++));
+            using result_type = hpx::tuple<traits::acquire_future_t<T>,
+                traits::acquire_future_t<Ts>...>;
+
+            if (n == 0)
+            {
+                return hpx::make_ready_future(when_some_result<result_type>());
+            }
+
+            if (n > 1 + sizeof...(Ts))
+            {
+                return hpx::make_exceptional_future<
+                    when_some_result<result_type>>(
+                    HPX_GET_EXCEPTION(hpx::bad_parameter, "hpx::when_some",
+                        "number of results to wait for is out of bounds"));
+            }
+
+            traits::acquire_future_disp func;
+            result_type values(
+                func(HPX_FORWARD(T, t)), func(HPX_FORWARD(Ts, ts))...);
+
+            auto f = std::make_shared<lcos::detail::when_some<result_type>>(
+                HPX_MOVE(values), n);
+
+            lcos::local::futures_factory<when_some_result<result_type>()> p(
+                [f = HPX_MOVE(f)]() -> when_some_result<result_type> {
+                    return (*f)();
+                });
+
+            auto result = p.get_future();
+            p.apply();
+
+            return result;
         }
-
-        return hpx::when_some(n, HPX_MOVE(values));
-    }
-
-    inline hpx::future<when_some_result<hpx::tuple<>>> when_some(std::size_t n)
-    {
-        using result_type = hpx::tuple<>;
-
-        if (n == 0)
-        {
-            return hpx::make_ready_future(when_some_result<result_type>());
-        }
-
-        return hpx::make_exceptional_future<when_some_result<result_type>>(
-            HPX_GET_EXCEPTION(hpx::bad_parameter, "hpx::when_some",
-                "number of results to wait for is out of bounds"));
-    }
+    } when_some{};
 
     ///////////////////////////////////////////////////////////////////////////
-    template <typename T, typename... Ts>
-    typename std::enable_if<!(traits::is_future_range<T>::value &&
-                                sizeof...(Ts) == 0),
-        hpx::future<when_some_result<
-            hpx::tuple<typename traits::acquire_future<T>::type,
-                typename traits::acquire_future<Ts>::type...>>>>::type
-    when_some(std::size_t n, T&& t, Ts&&... ts)
+    inline constexpr struct when_some_n_t final
+      : hpx::functional::tag<when_some_n_t>
     {
-        using result_type = hpx::tuple<traits::acquire_future_t<T>,
-            traits::acquire_future_t<Ts>...>;
-
-        if (n == 0)
+    private:
+        template <typename Iterator,
+            typename Enable =
+                std::enable_if_t<hpx::traits::is_iterator_v<Iterator>>>
+        friend decltype(auto) tag_invoke(
+            when_some_n_t, std::size_t n, Iterator begin, std::size_t count)
         {
-            return hpx::make_ready_future(when_some_result<result_type>());
+            using value_type =
+                typename lcos::detail::future_iterator_traits<Iterator>::type;
+
+            std::vector<value_type> values;
+            values.reserve(count);
+
+            traits::acquire_future_disp func;
+            for (std::size_t i = 0; i != count; ++i)
+            {
+                values.push_back(func(*begin++));
+            }
+
+            return hpx::when_some(n, HPX_MOVE(values));
         }
-
-        if (n > 1 + sizeof...(Ts))
-        {
-            return hpx::make_exceptional_future<when_some_result<result_type>>(
-                HPX_GET_EXCEPTION(hpx::bad_parameter, "hpx::when_some",
-                    "number of results to wait for is out of bounds"));
-        }
-
-        traits::acquire_future_disp func;
-        result_type values(
-            func(HPX_FORWARD(T, t)), func(HPX_FORWARD(Ts, ts))...);
-
-        auto f = std::make_shared<lcos::detail::when_some<result_type>>(
-            HPX_MOVE(values), n);
-
-        lcos::local::futures_factory<when_some_result<result_type>()> p(
-            [f = HPX_MOVE(f)]() -> when_some_result<result_type> {
-                return (*f)();
-            });
-
-        auto result = p.get_future();
-        p.apply();
-
-        return result;
-    }
+    } when_some_n{};
 }    // namespace hpx
 
 namespace hpx::lcos {

--- a/libs/core/async_combinators/tests/unit/wait_all.cpp
+++ b/libs/core/async_combinators/tests/unit/wait_all.cpp
@@ -21,6 +21,13 @@ hpx::future<int> make_future()
 void test_wait_all()
 {
     {
+        auto f1 = make_future();
+
+        HPX_TEST(!hpx::wait_all_nothrow(f1));
+
+        HPX_TEST(f1.is_ready());
+    }
+    {
         std::vector<hpx::future<int>> future_array;
         future_array.push_back(make_future());
         future_array.push_back(make_future());
@@ -98,6 +105,25 @@ void test_wait_all()
         try
         {
             hpx::wait_all(f1, f2);
+            HPX_TEST(false);
+        }
+        catch (std::runtime_error const&)
+        {
+            caught_exception = true;
+        }
+        catch (...)
+        {
+            HPX_TEST(false);
+        }
+        HPX_TEST(caught_exception);
+    }
+    {
+        auto f1 = hpx::make_exceptional_future<int>(std::runtime_error(""));
+
+        bool caught_exception = false;
+        try
+        {
+            hpx::wait_all(f1);
             HPX_TEST(false);
         }
         catch (std::runtime_error const&)

--- a/libs/core/async_combinators/tests/unit/when_all.cpp
+++ b/libs/core/async_combinators/tests/unit/when_all.cpp
@@ -26,11 +26,10 @@ int make_int_slowly()
     return 42;
 }
 
-template <class Container>
 void test_when_all_from_list()
 {
     unsigned const count = 10;
-    Container futures;
+    std::vector<hpx::future<int>> futures;
     for (unsigned j = 0; j < count; ++j)
     {
         hpx::lcos::local::futures_factory<int()> task(make_int_slowly);
@@ -38,9 +37,8 @@ void test_when_all_from_list()
         task.apply();
     }
 
-    hpx::future<Container> r = hpx::when_all(futures);
-
-    Container result = r.get();
+    auto r = hpx::when_all(futures);
+    auto result = r.get();
 
     HPX_TEST_EQ(futures.size(), result.size());
     for (const auto& f : futures)
@@ -49,12 +47,11 @@ void test_when_all_from_list()
         HPX_TEST(r.is_ready());
 }
 
-template <class Container>
 void test_when_all_from_list_iterators()
 {
     unsigned const count = 10;
 
-    Container futures;
+    std::vector<hpx::future<int>> futures;
     for (unsigned j = 0; j < count; ++j)
     {
         hpx::lcos::local::futures_factory<int()> task(make_int_slowly);
@@ -62,11 +59,8 @@ void test_when_all_from_list_iterators()
         task.apply();
     }
 
-    hpx::future<Container> r =
-        hpx::when_all<typename Container::iterator, Container>(
-            futures.begin(), futures.end());
-
-    Container result = r.get();
+    auto r = hpx::when_all(futures.begin(), futures.end());
+    auto result = r.get();
 
     HPX_TEST_EQ(futures.size(), result.size());
     for (const auto& f : futures)
@@ -258,12 +252,8 @@ using hpx::future;
 int hpx_main(variables_map&)
 {
     {
-        test_when_all_from_list<std::vector<future<int>>>();
-        test_when_all_from_list<std::list<future<int>>>();
-        test_when_all_from_list<std::deque<future<int>>>();
-        test_when_all_from_list_iterators<std::vector<future<int>>>();
-        test_when_all_from_list_iterators<std::list<future<int>>>();
-        test_when_all_from_list_iterators<std::deque<future<int>>>();
+        test_when_all_from_list();
+        test_when_all_from_list_iterators();
         test_when_all_one_future();
         test_when_all_two_futures();
         test_when_all_three_futures();

--- a/libs/core/async_combinators/tests/unit/when_any.cpp
+++ b/libs/core/async_combinators/tests/unit/when_any.cpp
@@ -1,4 +1,4 @@
-//  Copyright (C) 2012 Hartmut Kaiser
+//  Copyright (C) 2012-2022 Hartmut Kaiser
 //  (C) Copyright 2008-10 Anthony Williams
 //
 //  SPDX-License-Identifier: BSL-1.0
@@ -68,10 +68,9 @@ void test_wait_for_either_of_two_futures_2()
     HPX_TEST_EQ(hpx::get<1>(t).get(), 42);
 }
 
-template <class Container>
 void test_wait_for_either_of_two_futures_list_1()
 {
-    Container futures;
+    std::vector<hpx::future<int>> futures;
     hpx::packaged_task<int()> pt1(make_int_slowly);
     futures.push_back(pt1.get_future());
     hpx::packaged_task<int()> pt2(make_int_slowly);
@@ -79,12 +78,12 @@ void test_wait_for_either_of_two_futures_list_1()
 
     pt1();
 
-    hpx::future<hpx::when_any_result<Container>> r = hpx::when_any(futures);
-    hpx::when_any_result<Container> raw = r.get();
+    auto r = hpx::when_any(futures);
+    auto raw = r.get();
 
     HPX_TEST_EQ(raw.index, 0u);
 
-    Container t = std::move(raw.futures);
+    auto t = std::move(raw.futures);
 
     HPX_TEST(!futures.front().valid());
     HPX_TEST(!futures.back().valid());
@@ -93,10 +92,9 @@ void test_wait_for_either_of_two_futures_list_1()
     HPX_TEST_EQ(t.front().get(), 42);
 }
 
-template <class Container>
 void test_wait_for_either_of_two_futures_list_2()
 {
-    Container futures;
+    std::vector<hpx::future<int>> futures;
     hpx::packaged_task<int()> pt1(make_int_slowly);
     futures.push_back(pt1.get_future());
     hpx::packaged_task<int()> pt2(make_int_slowly);
@@ -104,12 +102,12 @@ void test_wait_for_either_of_two_futures_list_2()
 
     pt2();
 
-    hpx::future<hpx::when_any_result<Container>> r = hpx::when_any(futures);
-    hpx::when_any_result<Container> raw = r.get();
+    auto r = hpx::when_any(futures);
+    auto raw = r.get();
 
     HPX_TEST_EQ(raw.index, 1u);
 
-    Container t = std::move(raw.futures);
+    auto t = std::move(raw.futures);
 
     HPX_TEST(!futures.front().valid());
     HPX_TEST(!futures.back().valid());
@@ -309,10 +307,9 @@ void test_wait_for_either_of_four_futures_4()
     HPX_TEST_EQ(hpx::get<3>(t).get(), 42);
 }
 
-template <class Container>
 void test_wait_for_either_of_five_futures_1_from_list()
 {
-    Container futures;
+    std::vector<hpx::future<int>> futures;
 
     hpx::packaged_task<int()> pt1(make_int_slowly);
     hpx::future<int> f1(pt1.get_future());
@@ -332,12 +329,12 @@ void test_wait_for_either_of_five_futures_1_from_list()
 
     pt1();
 
-    hpx::future<hpx::when_any_result<Container>> r = hpx::when_any(futures);
-    hpx::when_any_result<Container> raw = r.get();
+    auto r = hpx::when_any(futures);
+    auto raw = r.get();
 
     HPX_TEST_EQ(raw.index, 0u);
 
-    Container t = std::move(raw.futures);
+    auto t = std::move(raw.futures);
 
     HPX_TEST(!f1.valid());    // NOLINT
     HPX_TEST(!f2.valid());    // NOLINT
@@ -349,12 +346,9 @@ void test_wait_for_either_of_five_futures_1_from_list()
     HPX_TEST_EQ(t.front().get(), 42);
 }
 
-template <class Container>
 void test_wait_for_either_of_five_futures_1_from_list_iterators()
 {
-    typedef typename Container::iterator iterator;
-
-    Container futures;
+    std::vector<hpx::future<int>> futures;
 
     hpx::packaged_task<int()> pt1(make_int_slowly);
     hpx::future<int> f1(pt1.get_future());
@@ -374,13 +368,12 @@ void test_wait_for_either_of_five_futures_1_from_list_iterators()
 
     pt1();
 
-    hpx::future<hpx::when_any_result<Container>> r =
-        hpx::when_any<iterator, Container>(futures.begin(), futures.end());
-    hpx::when_any_result<Container> raw = r.get();
+    auto r = hpx::when_any(futures.begin(), futures.end());
+    auto raw = r.get();
 
     HPX_TEST_EQ(raw.index, 0u);
 
-    Container t = std::move(raw.futures);
+    auto t = std::move(raw.futures);
 
     HPX_TEST(!f1.valid());    // NOLINT
     HPX_TEST(!f2.valid());    // NOLINT
@@ -662,12 +655,8 @@ int hpx_main(variables_map&)
     {
         test_wait_for_either_of_two_futures_1();
         test_wait_for_either_of_two_futures_2();
-        test_wait_for_either_of_two_futures_list_1<std::vector<future<int>>>();
-        test_wait_for_either_of_two_futures_list_1<std::list<future<int>>>();
-        test_wait_for_either_of_two_futures_list_1<std::deque<future<int>>>();
-        test_wait_for_either_of_two_futures_list_2<std::vector<future<int>>>();
-        test_wait_for_either_of_two_futures_list_2<std::list<future<int>>>();
-        test_wait_for_either_of_two_futures_list_2<std::deque<future<int>>>();
+        test_wait_for_either_of_two_futures_list_1();
+        test_wait_for_either_of_two_futures_list_2();
         test_wait_for_either_of_three_futures_1();
         test_wait_for_either_of_three_futures_2();
         test_wait_for_either_of_three_futures_3();
@@ -675,18 +664,8 @@ int hpx_main(variables_map&)
         test_wait_for_either_of_four_futures_2();
         test_wait_for_either_of_four_futures_3();
         test_wait_for_either_of_four_futures_4();
-        test_wait_for_either_of_five_futures_1_from_list<
-            std::vector<future<int>>>();
-        test_wait_for_either_of_five_futures_1_from_list<
-            std::list<future<int>>>();
-        test_wait_for_either_of_five_futures_1_from_list<
-            std::deque<future<int>>>();
-        test_wait_for_either_of_five_futures_1_from_list_iterators<
-            std::vector<future<int>>>();
-        test_wait_for_either_of_five_futures_1_from_list_iterators<
-            std::list<future<int>>>();
-        test_wait_for_either_of_five_futures_1_from_list_iterators<
-            std::deque<future<int>>>();
+        test_wait_for_either_of_five_futures_1_from_list();
+        test_wait_for_either_of_five_futures_1_from_list_iterators();
         test_wait_for_either_of_five_futures_1();
         test_wait_for_either_of_five_futures_2();
         test_wait_for_either_of_five_futures_3();

--- a/libs/core/async_combinators/tests/unit/when_some.cpp
+++ b/libs/core/async_combinators/tests/unit/when_some.cpp
@@ -1,4 +1,4 @@
-//  Copyright (C) 2012 Hartmut Kaiser
+//  Copyright (C) 2012-2022 Hartmut Kaiser
 //  (C) Copyright 2008-10 Anthony Williams
 //
 //  SPDX-License-Identifier: BSL-1.0
@@ -172,10 +172,9 @@ void test_wait_for_two_out_of_five_deferred_futures()
     HPX_TEST(!hpx::get<4>(result.futures).is_ready());
 }
 
-template <class Container>
 void test_wait_for_either_of_two_futures_list_1()
 {
-    Container futures;
+    std::vector<hpx::future<int>> futures;
     hpx::packaged_task<int()> pt1(make_int_slowly);
     futures.push_back(pt1.get_future());
     hpx::packaged_task<int()> pt2(make_int_slowly);
@@ -183,14 +182,13 @@ void test_wait_for_either_of_two_futures_list_1()
 
     pt1();
 
-    hpx::future<hpx::when_some_result<Container>> r =
-        hpx::when_some(1u, futures);
-    hpx::when_some_result<Container> raw = r.get();
+    auto r = hpx::when_some(1u, futures);
+    auto raw = r.get();
 
     HPX_TEST_EQ(raw.indices.size(), 1u);
     HPX_TEST_EQ(raw.indices[0], 0u);
 
-    Container t = std::move(raw.futures);
+    auto t = std::move(raw.futures);
 
     HPX_TEST(!futures.front().valid());
     HPX_TEST(!futures.back().valid());
@@ -199,10 +197,9 @@ void test_wait_for_either_of_two_futures_list_1()
     HPX_TEST_EQ(t.front().get(), 42);
 }
 
-template <class Container>
 void test_wait_for_either_of_two_futures_list_2()
 {
-    Container futures;
+    std::vector<hpx::future<int>> futures;
     hpx::packaged_task<int()> pt1(make_int_slowly);
     futures.push_back(pt1.get_future());
     hpx::packaged_task<int()> pt2(make_int_slowly);
@@ -210,14 +207,13 @@ void test_wait_for_either_of_two_futures_list_2()
 
     pt2();
 
-    hpx::future<hpx::when_some_result<Container>> r =
-        hpx::when_some(1u, futures);
-    hpx::when_some_result<Container> raw = r.get();
+    auto r = hpx::when_some(1u, futures);
+    auto raw = r.get();
 
     HPX_TEST_EQ(raw.indices.size(), 1u);
     HPX_TEST_EQ(raw.indices[0], 1u);
 
-    Container t = std::move(raw.futures);
+    auto t = std::move(raw.futures);
 
     HPX_TEST(!futures.front().valid());
     HPX_TEST(!futures.back().valid());
@@ -226,10 +222,9 @@ void test_wait_for_either_of_two_futures_list_2()
     HPX_TEST_EQ(t.back().get(), 42);
 }
 
-template <class Container>
 void test_wait_for_either_of_five_futures_1_from_list()
 {
-    Container futures;
+    std::vector<hpx::future<int>> futures;
 
     hpx::packaged_task<int()> pt1(make_int_slowly);
     hpx::future<int> f1(pt1.get_future());
@@ -250,14 +245,13 @@ void test_wait_for_either_of_five_futures_1_from_list()
     pt1();
     pt5();
 
-    hpx::future<hpx::when_some_result<Container>> r =
-        hpx::when_some(2u, futures);
-    hpx::when_some_result<Container> raw = r.get();
+    auto r = hpx::when_some(2u, futures);
+    auto raw = r.get();
 
     HPX_TEST_EQ(raw.indices[0], 0u);
     HPX_TEST_EQ(raw.indices[1], 4u);
 
-    Container t = std::move(raw.futures);
+    auto t = std::move(raw.futures);
 
     HPX_TEST(!f1.valid());    // NOLINT
     HPX_TEST(!f2.valid());    // NOLINT
@@ -269,12 +263,9 @@ void test_wait_for_either_of_five_futures_1_from_list()
     HPX_TEST_EQ(t.front().get(), 42);
 }
 
-template <class Container>
 void test_wait_for_either_of_five_futures_1_from_list_iterators()
 {
-    typedef typename Container::iterator iterator;
-
-    Container futures;
+    std::vector<hpx::future<int>> futures;
 
     hpx::packaged_task<int()> pt1(make_int_slowly);
     hpx::future<int> f1(pt1.get_future());
@@ -296,15 +287,14 @@ void test_wait_for_either_of_five_futures_1_from_list_iterators()
     pt3();
     pt5();
 
-    hpx::future<hpx::when_some_result<Container>> r =
-        hpx::when_some<iterator, Container>(3u, futures.begin(), futures.end());
-    hpx::when_some_result<Container> raw = r.get();
+    auto r = hpx::when_some(3u, futures.begin(), futures.end());
+    auto raw = r.get();
 
     HPX_TEST_EQ(raw.indices[0], 0u);
     HPX_TEST_EQ(raw.indices[1], 2u);
     HPX_TEST_EQ(raw.indices[2], 4u);
 
-    Container t = std::move(raw.futures);
+    auto t = std::move(raw.futures);
 
     HPX_TEST(!f1.valid());    // NOLINT
     HPX_TEST(!f2.valid());    // NOLINT
@@ -329,24 +319,10 @@ int hpx_main(variables_map&)
         test_wait_for_three_out_of_five_futures();
         test_wait_for_two_out_of_five_late_futures();
         test_wait_for_two_out_of_five_deferred_futures();
-        test_wait_for_either_of_two_futures_list_1<std::vector<future<int>>>();
-        test_wait_for_either_of_two_futures_list_1<std::list<future<int>>>();
-        test_wait_for_either_of_two_futures_list_1<std::deque<future<int>>>();
-        test_wait_for_either_of_two_futures_list_2<std::vector<future<int>>>();
-        test_wait_for_either_of_two_futures_list_2<std::list<future<int>>>();
-        test_wait_for_either_of_two_futures_list_2<std::deque<future<int>>>();
-        test_wait_for_either_of_five_futures_1_from_list<
-            std::vector<future<int>>>();
-        test_wait_for_either_of_five_futures_1_from_list<
-            std::list<future<int>>>();
-        test_wait_for_either_of_five_futures_1_from_list<
-            std::deque<future<int>>>();
-        test_wait_for_either_of_five_futures_1_from_list_iterators<
-            std::vector<future<int>>>();
-        test_wait_for_either_of_five_futures_1_from_list_iterators<
-            std::list<future<int>>>();
-        test_wait_for_either_of_five_futures_1_from_list_iterators<
-            std::deque<future<int>>>();
+        test_wait_for_either_of_two_futures_list_1();
+        test_wait_for_either_of_two_futures_list_2();
+        test_wait_for_either_of_five_futures_1_from_list();
+        test_wait_for_either_of_five_futures_1_from_list_iterators();
     }
 
     hpx::local::finalize();

--- a/libs/core/execution_base/include/hpx/execution_base/traits/is_executor_parameters.hpp
+++ b/libs/core/execution_base/include/hpx/execution_base/traits/is_executor_parameters.hpp
@@ -77,12 +77,15 @@ namespace hpx { namespace parallel { namespace execution {
         // by default, assume equally sized chunks
     };
 
+#if !defined(DOXYGEN)
+    // doxygen gets confused by the following construct
     template <typename Parameters>
     struct extract_invokes_testing_function<Parameters,
         std::void_t<typename Parameters::invokes_testing_function>>
       : std::true_type
     {
     };
+#endif
 
     template <typename Parameters>
     inline constexpr bool extract_invokes_testing_function_v =


### PR DESCRIPTION
- flyby: add unary wait_all() expecting a single future
