### PR TITLE
Fixing static linking (for Windows)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -601,7 +601,7 @@ jobs:
                 -T test \
                 --no-compress-output \
                 --output-on-failure \
-                --tests-regex `grep -v -e ^# -e ^$ /hpx/source/.circleci/tests.unit1.targets | sed ':b;N;$!bb;s/\n/|/g'` \
+                --tests-regex `grep -v -e ^# -e ^$ /hpx/source/.circleci/tests.unit1.targets | sed ':b;N;$!bb;s/\n/|/g'`
       - run:
           <<: *convert_xml
       - run:

--- a/.github/workflows/tests.examples.targets
+++ b/.github/workflows/tests.examples.targets
@@ -1,0 +1,43 @@
+#  Copyright (c) 2022 Hartmut Kaiser
+#
+#  SPDX-License-Identifier: BSL-1.0
+#  Distributed under the Boost Software License, Version 1.0. (See accompanying
+#  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+#
+# examples that should not be run on Github windows builders
+#
+tests.examples.1d_stencil.1d_stencil_6
+tests.examples.1d_stencil.1d_stencil_7
+tests.examples.async_io.async_io_simple
+tests.examples.modules.checkpoint.1d_stencil_4_checkpoint
+tests.examples.modules.program_options.config_file_types
+tests.examples.modules.program_options.custom_syntax
+tests.examples.modules.program_options.env_options
+tests.examples.modules.program_options.first
+tests.examples.modules.program_options.multiple_sources
+tests.examples.modules.program_options.option_groups
+tests.examples.modules.program_options.options_description
+tests.examples.modules.program_options.options_hierarchy
+tests.examples.modules.program_options.real
+tests.examples.modules.program_options.regex
+tests.examples.modules.program_options.response_file
+tests.examples.modules.resiliency_distributed.distributed.tcp.async_replay_distributed
+tests.examples.modules.resiliency_distributed.distributed.tcp.async_replicate_distributed
+tests.examples.modules.resiliency.1d_stencil_replay_exception
+tests.examples.modules.resiliency.1d_stencil_replay_validate
+tests.examples.modules.resiliency.async_replay
+tests.examples.modules.resiliency.async_replicate_vote
+tests.examples.modules.resiliency.async_replicate
+tests.examples.modules.resiliency.dataflow_replicate
+tests.examples.modules.resiliency.version
+tests.examples.modules.resource_partitioner.async_customization
+tests.examples.modules.resource_partitioner.guided_pool_test
+tests.examples.modules.resource_partitioner.oversubscribing_resource_partitioner
+tests.examples.modules.resource_partitioner.simple_resource_partitioner
+tests.examples.modules.resource_partitioner.simplest_resource_partitioner_1
+tests.examples.modules.resource_partitioner.simplest_resource_partitioner_2
+tests.examples.quickstart.1d_wave_equation
+tests.examples.quickstart.partitioned_vector_spmd_foreach
+tests.examples.quickstart.sort_by_key_demo
+tests.examples.transpose.transpose_block_numa
+tests.examples.modules.collectives.distributed.tcp.channel_communicator

--- a/.github/workflows/windows_release.yml
+++ b/.github/workflows/windows_release.yml
@@ -42,52 +42,19 @@ jobs:
       run: |
           cmake --build build --config Release \
           --target ALL_BUILD \
-          -- -maxcpucount -verbosity:minimal -nologo
+          -- -maxcpucount:2 -verbosity:minimal -nologo
     - name: Install
       shell: bash
       run: |
           cmake --install build --config Release
     - name: Test
-      shell: bash
       run: |
+          Set-Alias -Name grep -Value "C:\Program Files\Git\usr\bin\grep.exe"
+          Set-Alias -Name sed -Value "C:\Program Files\Git\usr\bin\sed.exe"
           cd build
-          ctest \
-          --output-on-failure \
-            --build-config Release \
-            --tests-regex tests.examples \
-            --exclude-regex \
-          "tests.examples.1d_stencil.1d_stencil_6|\
-          tests.examples.1d_stencil.1d_stencil_7|\
-          tests.examples.async_io.async_io_simple|\
-          tests.examples.modules.checkpoint.1d_stencil_4_checkpoint|\
-          tests.examples.modules.program_options.config_file_types|\
-          tests.examples.modules.program_options.custom_syntax|\
-          tests.examples.modules.program_options.env_options|\
-          tests.examples.modules.program_options.first|\
-          tests.examples.modules.program_options.multiple_sources|\
-          tests.examples.modules.program_options.option_groups|\
-          tests.examples.modules.program_options.options_description|\
-          tests.examples.modules.program_options.options_hierarchy|\
-          tests.examples.modules.program_options.real|\
-          tests.examples.modules.program_options.regex|\
-          tests.examples.modules.program_options.response_file|\
-          tests.examples.modules.resiliency_distributed.distributed.tcp.async_replay_distributed|\
-          tests.examples.modules.resiliency_distributed.distributed.tcp.async_replicate_distributed|\
-          tests.examples.modules.resiliency.1d_stencil_replay_exception|\
-          tests.examples.modules.resiliency.1d_stencil_replay_validate|\
-          tests.examples.modules.resiliency.async_replay|\
-          tests.examples.modules.resiliency.async_replicate_vote|\
-          tests.examples.modules.resiliency.async_replicate|\
-          tests.examples.modules.resiliency.dataflow_replicate|\
-          tests.examples.modules.resiliency.version|\
-          tests.examples.modules.resource_partitioner.async_customization|\
-          tests.examples.modules.resource_partitioner.guided_pool_test|\
-          tests.examples.modules.resource_partitioner.oversubscribing_resource_partitioner|\
-          tests.examples.modules.resource_partitioner.simple_resource_partitioner|\
-          tests.examples.modules.resource_partitioner.simplest_resource_partitioner_1|\
-          tests.examples.modules.resource_partitioner.simplest_resource_partitioner_2|\
-          tests.examples.quickstart.1d_wave_equation|\
-          tests.examples.quickstart.partitioned_vector_spmd_foreach|\
-          tests.examples.quickstart.sort_by_key_demo|\
-          tests.examples.transpose.transpose_block_numa|\
-          tests.examples.modules.collectives.distributed.tcp.channel_communicator"
+          ctest `
+          --output-on-failure `
+            --build-config Release `
+            --tests-regex tests.examples `
+            --exclude-regex `
+                 $(grep -v  -e ^# -e ^$ D:/a/hpx/hpx/.github/workflows/tests.examples.targets | sed ':b;N;$!bb;s/\n/|/g')

--- a/.github/workflows/windows_release_static.yml
+++ b/.github/workflows/windows_release_static.yml
@@ -1,10 +1,11 @@
 # Copyright (c) 2020 Mikael Simberg
+# Copyright (c) 2022 Hartmut Kaiser
 #
 # SPDX-License-Identifier: BSL-1.0
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-name: Windows CI (Debug)
+name: Windows CI (Release, Static)
 
 on: [pull_request]
 
@@ -27,35 +28,35 @@ jobs:
       shell: bash
       run: |
           cmake . -Bbuild -G'Visual Studio 17 2022' \
-              -DCMAKE_BUILD_TYPE=Debug \
+              -DCMAKE_BUILD_TYPE=Release \
               -DCMAKE_TOOLCHAIN_FILE='C:/projects/vcpkg/scripts/buildsystems/vcpkg.cmake' \
+              -DHPX_WITH_STATIC_LINKING=ON \
               -DHPX_WITH_FETCH_ASIO=ON \
               -DHPX_WITH_EXAMPLES=ON \
               -DHPX_WITH_TESTS=ON \
               -DHPX_WITH_TESTS_UNIT=ON \
               -DHPX_WITH_DEPRECATION_WARNINGS=OFF \
               -DHPX_WITH_TESTS_MAX_THREADS_PER_LOCALITY=2 \
-              -DHPX_COROUTINES_WITH_SWAP_CONTEXT_EMULATION=ON \
               -DHPX_WITH_CHECK_MODULE_DEPENDENCIES=On \
               -DCMAKE_CXX_FLAGS=-permissive-
     - name: Build
       shell: bash
       run: |
-          cmake --build build --config Debug \
+          cmake --build build --config Release \
           --target ALL_BUILD \
           -- -maxcpucount:2 -verbosity:minimal -nologo
     - name: Install
       shell: bash
       run: |
-          cmake --install build --config Debug
+          cmake --install build --config Release
     - name: Test
       run: |
-          Set-Alias -Name grep -Value 'C:\Program Files\Git\usr\bin\grep.exe'
-          Set-Alias -Name sed -Value 'C:\Program Files\Git\usr\bin\sed.exe'
+          Set-Alias -Name grep -Value "C:\Program Files\Git\usr\bin\grep.exe"
+          Set-Alias -Name sed -Value "C:\Program Files\Git\usr\bin\sed.exe"
           cd build
           ctest `
           --output-on-failure `
-            --build-config Debug `
+            --build-config Release `
             --tests-regex tests.examples `
             --exclude-regex `
                  $(grep -v  -e ^# -e ^$ D:/a/hpx/hpx/.github/workflows/tests.examples.targets | sed ':b;N;$!bb;s/\n/|/g')

--- a/cmake/HPX_AddComponent.cmake
+++ b/cmake/HPX_AddComponent.cmake
@@ -201,7 +201,10 @@ function(add_hpx_component name)
     # cmake-format: on
 
     # install PDB if needed
-    if(MSVC)
+    if(MSVC
+       AND NOT ${name}_STATIC
+       AND NOT HPX_WITH_STATIC_LINKING
+    )
       # cmake-format: off
       set(_target_flags
           ${_target_flags}

--- a/cmake/HPX_AddExecutable.cmake
+++ b/cmake/HPX_AddExecutable.cmake
@@ -167,7 +167,10 @@ function(add_hpx_executable name)
     endif()
     set(_target_flags INSTALL INSTALL_FLAGS DESTINATION ${install_destination})
     # install PDB if needed
-    if(MSVC)
+    if(MSVC
+       AND NOT ${name}_STATIC
+       AND NOT HPX_WITH_STATIC_LINKING
+    )
       # cmake-format: off
       set(_target_flags
           ${_target_flags}

--- a/components/containers/partitioned_vector/include/hpx/components/containers/partitioned_vector/partitioned_vector_predef.hpp
+++ b/components/containers/partitioned_vector/include/hpx/components/containers/partitioned_vector/partitioned_vector_predef.hpp
@@ -19,7 +19,8 @@
 ///////////////////////////////////////////////////////////////////////////////
 // declare explicitly instantiated templates
 
-#if !defined(HPX_PARTITIONED_VECTOR_MODULE_EXPORTS)
+#if !defined(HPX_PARTITIONED_VECTOR_MODULE_EXPORTS) &&                         \
+    !defined(HPX_HAVE_STATIC_LINKING)
 
 // partitioned_vector<double>
 HPX_REGISTER_PARTITIONED_VECTOR_DECLARATION(double)

--- a/components/containers/partitioned_vector/src/partitioned_vector_component_double.cpp
+++ b/components/containers/partitioned_vector/src/partitioned_vector_component_double.cpp
@@ -6,11 +6,12 @@
 
 #include <hpx/config.hpp>
 
+#if !defined(HPX_HAVE_STATIC_LINKING)
 #include <hpx/distribution_policies/container_distribution_policy.hpp>
 
 #include <hpx/components/containers/partitioned_vector/export_definitions.hpp>
-#include <hpx/components/containers/partitioned_vector/partitioned_vector_component.hpp>
 #include <hpx/components/containers/partitioned_vector/partitioned_vector.hpp>
+#include <hpx/components/containers/partitioned_vector/partitioned_vector_component.hpp>
 
 #include <vector>
 
@@ -20,7 +21,7 @@ HPX_REGISTER_PARTITIONED_VECTOR(double)
 // arguments
 #if defined(HPX_MSVC)
 #pragma warning(push)
-#pragma warning(disable: 5037)
+#pragma warning(disable : 5037)
 #endif
 
 template class HPX_PARTITIONED_VECTOR_EXPORT
@@ -30,14 +31,14 @@ template class HPX_PARTITIONED_VECTOR_EXPORT
 template class HPX_PARTITIONED_VECTOR_EXPORT
     hpx::partitioned_vector<double, std::vector<double>>;
 template HPX_PARTITIONED_VECTOR_EXPORT
-    hpx::partitioned_vector<double, std::vector<double>>::partitioned_vector(
-        size_type, hpx::container_distribution_policy const&, void*);
+hpx::partitioned_vector<double, std::vector<double>>::partitioned_vector(
+    size_type, hpx::container_distribution_policy const&, void*);
 template HPX_PARTITIONED_VECTOR_EXPORT
-    hpx::partitioned_vector<double, std::vector<double>>::partitioned_vector(
-        size_type, double const&, hpx::container_distribution_policy const&,
-        void*);
+hpx::partitioned_vector<double, std::vector<double>>::partitioned_vector(
+    size_type, double const&, hpx::container_distribution_policy const&, void*);
 
 #if defined(HPX_MSVC)
 #pragma warning(pop)
 #endif
 
+#endif

--- a/components/containers/partitioned_vector/src/partitioned_vector_component_int.cpp
+++ b/components/containers/partitioned_vector/src/partitioned_vector_component_int.cpp
@@ -6,11 +6,12 @@
 
 #include <hpx/config.hpp>
 
+#if !defined(HPX_HAVE_STATIC_LINKING)
 #include <hpx/distribution_policies/container_distribution_policy.hpp>
 
 #include <hpx/components/containers/partitioned_vector/export_definitions.hpp>
-#include <hpx/components/containers/partitioned_vector/partitioned_vector_component.hpp>
 #include <hpx/components/containers/partitioned_vector/partitioned_vector.hpp>
+#include <hpx/components/containers/partitioned_vector/partitioned_vector_component.hpp>
 
 #include <vector>
 
@@ -22,7 +23,7 @@ HPX_REGISTER_PARTITIONED_VECTOR(long_long)
 // arguments
 #if defined(HPX_MSVC)
 #pragma warning(push)
-#pragma warning(disable: 5037)
+#pragma warning(disable : 5037)
 #endif
 
 template class HPX_PARTITIONED_VECTOR_EXPORT
@@ -32,12 +33,11 @@ template class HPX_PARTITIONED_VECTOR_EXPORT
 template class HPX_PARTITIONED_VECTOR_EXPORT
     hpx::partitioned_vector<int, std::vector<int>>;
 template HPX_PARTITIONED_VECTOR_EXPORT
-    hpx::partitioned_vector<int, std::vector<int>>::partitioned_vector(
-        size_type, hpx::container_distribution_policy const&, void*);
+hpx::partitioned_vector<int, std::vector<int>>::partitioned_vector(
+    size_type, hpx::container_distribution_policy const&, void*);
 template HPX_PARTITIONED_VECTOR_EXPORT
-    hpx::partitioned_vector<int, std::vector<int>>::partitioned_vector(
-        size_type, int const&, hpx::container_distribution_policy const&,
-        void*);
+hpx::partitioned_vector<int, std::vector<int>>::partitioned_vector(
+    size_type, int const&, hpx::container_distribution_policy const&, void*);
 
 template class HPX_PARTITIONED_VECTOR_EXPORT
     hpx::server::partitioned_vector<long long, std::vector<long long>>;
@@ -46,14 +46,14 @@ template class HPX_PARTITIONED_VECTOR_EXPORT
 template class HPX_PARTITIONED_VECTOR_EXPORT
     hpx::partitioned_vector<long long, std::vector<long long>>;
 template HPX_PARTITIONED_VECTOR_EXPORT
-    hpx::partitioned_vector<long long, std::vector<long long>>::partitioned_vector(
-        size_type, hpx::container_distribution_policy const&, void*);
-template HPX_PARTITIONED_VECTOR_EXPORT
-    hpx::partitioned_vector<long long, std::vector<long long>>::partitioned_vector(
-        size_type, long long const&, hpx::container_distribution_policy const&,
-        void*);
+hpx::partitioned_vector<long long, std::vector<long long>>::partitioned_vector(
+    size_type, hpx::container_distribution_policy const&, void*);
+template HPX_PARTITIONED_VECTOR_EXPORT hpx::partitioned_vector<long long,
+    std::vector<long long>>::partitioned_vector(size_type, long long const&,
+    hpx::container_distribution_policy const&, void*);
 
 #if defined(HPX_MSVC)
 #pragma warning(pop)
 #endif
 
+#endif

--- a/components/containers/partitioned_vector/src/partitioned_vector_component_std_string.cpp
+++ b/components/containers/partitioned_vector/src/partitioned_vector_component_std_string.cpp
@@ -6,11 +6,12 @@
 
 #include <hpx/config.hpp>
 
+#if !defined(HPX_HAVE_STATIC_LINKING)
 #include <hpx/distribution_policies/container_distribution_policy.hpp>
 
 #include <hpx/components/containers/partitioned_vector/export_definitions.hpp>
-#include <hpx/components/containers/partitioned_vector/partitioned_vector_component.hpp>
 #include <hpx/components/containers/partitioned_vector/partitioned_vector.hpp>
+#include <hpx/components/containers/partitioned_vector/partitioned_vector_component.hpp>
 
 #include <string>
 #include <vector>
@@ -23,7 +24,7 @@ HPX_REGISTER_PARTITIONED_VECTOR(std_string)
 // arguments
 #if defined(HPX_MSVC)
 #pragma warning(push)
-#pragma warning(disable: 5037)
+#pragma warning(disable : 5037)
 #endif
 
 template class HPX_PARTITIONED_VECTOR_EXPORT
@@ -32,16 +33,15 @@ template class HPX_PARTITIONED_VECTOR_EXPORT
     hpx::partitioned_vector_partition<std::string, std::vector<std::string>>;
 template class HPX_PARTITIONED_VECTOR_EXPORT
     hpx::partitioned_vector<std::string, std::vector<std::string>>;
-template HPX_PARTITIONED_VECTOR_EXPORT
-    hpx::partitioned_vector<std::string, std::vector<std::string>>::
-        partitioned_vector(size_type, hpx::container_distribution_policy const&,
-            void*);
-template HPX_PARTITIONED_VECTOR_EXPORT
-    hpx::partitioned_vector<std::string, std::vector<std::string>>::
-        partitioned_vector(size_type, std::string const&,
-        hpx::container_distribution_policy const&, void*);
+template HPX_PARTITIONED_VECTOR_EXPORT hpx::partitioned_vector<std::string,
+    std::vector<std::string>>::partitioned_vector(size_type,
+    hpx::container_distribution_policy const&, void*);
+template HPX_PARTITIONED_VECTOR_EXPORT hpx::partitioned_vector<std::string,
+    std::vector<std::string>>::partitioned_vector(size_type, std::string const&,
+    hpx::container_distribution_policy const&, void*);
 
 #if defined(HPX_MSVC)
 #pragma warning(pop)
 #endif
 
+#endif

--- a/components/containers/partitioned_vector/tests/unit/coarray.cpp
+++ b/components/containers/partitioned_vector/tests/unit/coarray.cpp
@@ -20,6 +20,9 @@
 
 ///////////////////////////////////////////////////////////////////////////////
 // coarray<double> is predefined in the partitioned_vector module
+#if defined(HPX_HAVE_STATIC_LINKING)
+HPX_REGISTER_COARRAY(double)
+#endif
 
 void bulk_test( hpx::lcos::spmd_block block,
                 std::size_t height,

--- a/components/containers/partitioned_vector/tests/unit/coarray_all_reduce.cpp
+++ b/components/containers/partitioned_vector/tests/unit/coarray_all_reduce.cpp
@@ -20,6 +20,9 @@
 
 ///////////////////////////////////////////////////////////////////////////////
 // coarray<double> is predefined in the partitioned_vector module
+#if defined(HPX_HAVE_STATIC_LINKING)
+HPX_REGISTER_COARRAY(double)
+#endif
 
 void bulk_test( hpx::lcos::spmd_block block,
                 std::string values)

--- a/components/containers/partitioned_vector/tests/unit/partitioned_vector_subview.cpp
+++ b/components/containers/partitioned_vector/tests/unit/partitioned_vector_subview.cpp
@@ -23,7 +23,9 @@
 
 ///////////////////////////////////////////////////////////////////////////////
 // The vector types to be used are defined in partitioned_vector module.
-// HPX_REGISTER_PARTITIONED_VECTOR(double)
+#if defined(HPX_HAVE_STATIC_LINKING)
+HPX_REGISTER_PARTITIONED_VECTOR(double)
+#endif
 
 void bulk_test(hpx::lcos::spmd_block block,
     std::size_t N,

--- a/components/containers/partitioned_vector/tests/unit/partitioned_vector_view.cpp
+++ b/components/containers/partitioned_vector/tests/unit/partitioned_vector_view.cpp
@@ -23,7 +23,9 @@
 
 ///////////////////////////////////////////////////////////////////////////////
 // The vector types to be used are defined in partitioned_vector module.
-// HPX_REGISTER_PARTITIONED_VECTOR(double)
+#if defined(HPX_HAVE_STATIC_LINKING)
+HPX_REGISTER_PARTITIONED_VECTOR(double)
+#endif
 
 void bulk_test(hpx::lcos::spmd_block block,
     std::size_t height,

--- a/components/containers/partitioned_vector/tests/unit/partitioned_vector_view_iterator.cpp
+++ b/components/containers/partitioned_vector/tests/unit/partitioned_vector_view_iterator.cpp
@@ -21,7 +21,9 @@
 
 ///////////////////////////////////////////////////////////////////////////////
 // The vector types to be used are defined in partitioned_vector module.
-// HPX_REGISTER_PARTITIONED_VECTOR(double)
+#if defined(HPX_HAVE_STATIC_LINKING)
+HPX_REGISTER_PARTITIONED_VECTOR(double)
+#endif
 
 void bulk_test( hpx::lcos::spmd_block block,
                 std::size_t size_x,

--- a/components/containers/partitioned_vector/tests/unit/serialization_partitioned_vector.cpp
+++ b/components/containers/partitioned_vector/tests/unit/serialization_partitioned_vector.cpp
@@ -20,6 +20,9 @@
 
 // partitioned_vector<int> and partitioned_vector<double> are predefined in the
 // partitioned_vector module
+#if defined(HPX_HAVE_STATIC_LINKING)
+HPX_REGISTER_PARTITIONED_VECTOR(double)
+#endif
 
 typedef unsigned long ulong;
 

--- a/examples/1d_stencil/1d_stencil_channel.cpp
+++ b/examples/1d_stencil/1d_stencil_channel.cpp
@@ -34,7 +34,7 @@
 
 using communication_type = double;
 
-HPX_REGISTER_CHANNEL_DECLARATION(communication_type)
+HPX_REGISTER_CHANNEL_DECLARATION(communication_type, stencil_communication)
 HPX_REGISTER_CHANNEL(communication_type, stencil_communication)
 
 int hpx_main(hpx::program_options::variables_map& vm)

--- a/examples/jacobi_smp/jacobi_hpx.cpp
+++ b/examples/jacobi_smp/jacobi_hpx.cpp
@@ -5,10 +5,10 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include "jacobi.hpp"
-
 #include <hpx/local/chrono.hpp>
 #include <hpx/local/future.hpp>
+
+#include "jacobi.hpp"
 
 #include <cmath>
 #include <cstddef>

--- a/examples/jacobi_smp/jacobi_nonuniform_hpx.cpp
+++ b/examples/jacobi_smp/jacobi_nonuniform_hpx.cpp
@@ -5,11 +5,11 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include "jacobi_nonuniform.hpp"
-
 #include <hpx/local/chrono.hpp>
 #include <hpx/local/functional.hpp>
 #include <hpx/local/future.hpp>
+
+#include "jacobi_nonuniform.hpp"
 
 #include <cstddef>
 #include <functional>

--- a/examples/pipeline/collector.cpp
+++ b/examples/pipeline/collector.cpp
@@ -11,7 +11,7 @@
 
 #include <iostream>
 
-HPX_REGISTER_CHANNEL(int)
+HPX_REGISTER_CHANNEL(int, pipeline)
 
 hpx::future<void> f3(hpx::lcos::channel<int>& c2)
 {

--- a/examples/pipeline/emitter.cpp
+++ b/examples/pipeline/emitter.cpp
@@ -11,7 +11,7 @@
 
 #include <iostream>
 
-HPX_REGISTER_CHANNEL(int)
+HPX_REGISTER_CHANNEL(int, pipeline)
 
 void f1(hpx::lcos::channel<int>& c1)
 {
@@ -20,7 +20,7 @@ void f1(hpx::lcos::channel<int>& c1)
         std::cout << "First Stage: " << i << ". Executed on locality "
                   << hpx::get_locality_id() << " " << hpx::get_locality_name()
                   << '\n';
-        c1.set(i);
+        c1.set(int(i));
         hpx::this_thread::sleep_for(std::chrono::seconds(5));
     }
     c1.close();

--- a/examples/pipeline/worker.cpp
+++ b/examples/pipeline/worker.cpp
@@ -11,7 +11,7 @@
 
 #include <iostream>
 
-HPX_REGISTER_CHANNEL(int)
+HPX_REGISTER_CHANNEL(int, pipeline)
 
 hpx::future<void> f2(hpx::lcos::channel<int>& c1, hpx::lcos::channel<int>& c2)
 {

--- a/examples/quickstart/CMakeLists.txt
+++ b/examples/quickstart/CMakeLists.txt
@@ -33,7 +33,7 @@ set(example_programs
     wait_composition
 )
 
-if(NOT ${CMAKE_SYSTEM_NAME} MATCHES "FreeBSD")
+if(NOT ${CMAKE_SYSTEM_NAME} MATCHES "FreeBSD" AND NOT HPX_WITH_STATIC_LINKING)
   set(example_programs ${example_programs} init_globally)
 endif()
 

--- a/examples/quickstart/matrix_multiplication.cpp
+++ b/examples/quickstart/matrix_multiplication.cpp
@@ -62,8 +62,8 @@ int hpx_main(hpx::program_options::variables_map& vm)
     std::cout << "using seed: " << seed << std::endl;
 
     // Define range of values
-    std::size_t lower = vm["l"].as<std::size_t>();
-    std::size_t upper = vm["u"].as<std::size_t>();
+    int lower = vm["l"].as<int>();
+    int upper = vm["u"].as<int>();
 
     // Matrices have random values in the range [lower, upper]
     std::uniform_int_distribution<element_type> dis(lower, upper);
@@ -112,10 +112,10 @@ int main(int argc, char* argv[])
         hpx::program_options::value<unsigned int>(),
         "The random number generator seed to use for this run")
         ("l",
-        hpx::program_options::value<std::size_t>()->default_value(0),
+        hpx::program_options::value<int>()->default_value(0),
         "Lower limit of range of values")
         ("u",
-        hpx::program_options::value<std::size_t>()->default_value(10),
+        hpx::program_options::value<int>()->default_value(10),
         "Upper limit of range of values");
     // clang-format on
     hpx::local::init_params init_args;

--- a/examples/random_mem_access/random_mem_access_client.cpp
+++ b/examples/random_mem_access/random_mem_access_client.cpp
@@ -50,7 +50,8 @@ int hpx_main(hpx::program_options::variables_map& vm)
         std::vector<hpx::future<void>> barrier;
         for (std::size_t i = 0; i < iterations; i++)
         {
-            std::uniform_int_distribution<> dis(0, array_size - 1);
+            std::uniform_int_distribution<> dis(
+                0, static_cast<int>(array_size - 1));
             std::size_t rn = dis(gen);
             //std::cout << " Random element access: " << rn << std::endl;
             barrier.push_back(accu[rn].add_async());

--- a/examples/spell_check/spell_check_file.cpp
+++ b/examples/spell_check/spell_check_file.cpp
@@ -14,6 +14,7 @@
 #include <hpx/include/runtime.hpp>
 #include <hpx/include/util.hpp>
 
+#include <cstddef>
 #include <fstream>
 #include <iostream>
 #include <string>
@@ -40,7 +41,7 @@ std::string search(int start, int end, std::string const& word)
         {
             int pos = mid / 2;
 
-            int size;
+            std::size_t size;
             //if our value is lower than start, we disregard it.
             if (word.length() >= check.length())
                 size = check.length();
@@ -48,7 +49,7 @@ std::string search(int start, int end, std::string const& word)
                 size = word.length();
             std::string part;
             bool sub = true;
-            for (int i = 0; i < size; i++)
+            for (std::size_t i = 0; i < size; i++)
             {
                 char check_char = static_cast<char>(tolower(check[i]));
                 char word_char = word[i];
@@ -75,13 +76,13 @@ std::string search(int start, int end, std::string const& word)
             return "";
         }
     }
-    int size;
+    std::size_t size;
     //if our value is lower than start, we disregard it.
     if (word.length() >= check.length())
         size = check.length();
     else
         size = word.length();
-    for (int i = 0; i < size; i++)
+    for (std::size_t i = 0; i < size; i++)
     {
         char check_char = static_cast<char>(tolower(check[i]));
         char word_char = word[i];

--- a/examples/spell_check/spell_check_simple.cpp
+++ b/examples/spell_check/spell_check_simple.cpp
@@ -14,6 +14,7 @@
 #include <hpx/include/runtime.hpp>
 #include <hpx/include/util.hpp>
 
+#include <cstddef>
 #include <fstream>
 #include <iostream>
 #include <string>
@@ -40,7 +41,7 @@ std::string search(int start, int end, std::string const& word)
         {
             int pos = mid / 2;
 
-            int size;
+            std::size_t size;
             //if our value is lower than start, we disregard it.
             if (word.length() >= check.length())
                 size = check.length();
@@ -48,7 +49,7 @@ std::string search(int start, int end, std::string const& word)
                 size = word.length();
             std::string part;
             bool sub = true;
-            for (int i = 0; i < size; i++)
+            for (std::size_t i = 0; i < size; i++)
             {
                 char check_char = static_cast<char>(tolower(check[i]));
                 char word_char = word[i];
@@ -75,13 +76,13 @@ std::string search(int start, int end, std::string const& word)
             return word + " was found in this dictionary.\n";
         }
     }
-    int size;
+    std::size_t size;
     //if our value is lower than start, we disregard it.
     if (word.length() >= check.length())
         size = check.length();
     else
         size = word.length();
-    for (int i = 0; i < size; i++)
+    for (std::size_t i = 0; i < size; i++)
     {
         char check_char = static_cast<char>(tolower(check[i]));
         char word_char = word[i];

--- a/examples/throttle/throttle/server/throttle.cpp
+++ b/examples/throttle/throttle/server/throttle.cpp
@@ -14,6 +14,7 @@
 
 #include <chrono>
 #include <cstddef>
+#include <cstdint>
 #include <iostream>
 #include <mutex>
 #include <string>
@@ -121,7 +122,8 @@ namespace throttle { namespace server {
             hpx::threads::make_thread_function_nullary(
                 hpx::bind(&throttle::throttle_controller, this, shepherd)),
             description.c_str(), hpx::threads::thread_priority::high,
-            hpx::threads::thread_schedule_hint(shepherd));
+            hpx::threads::thread_schedule_hint(
+                static_cast<std::uint16_t>(shepherd)));
         hpx::threads::register_thread(data);
     }
 
@@ -135,7 +137,8 @@ namespace throttle { namespace server {
             hpx::threads::make_thread_function_nullary(
                 hpx::bind(&throttle::suspend, this, shepherd)),
             description.c_str(), hpx::threads::thread_priority::high,
-            hpx::threads::thread_schedule_hint(shepherd));
+            hpx::threads::thread_schedule_hint(
+                static_cast<std::uint16_t>(shepherd)));
         hpx::threads::register_thread(data);
     }
 }}    // namespace throttle::server

--- a/examples/transpose/transpose_serial_vector.cpp
+++ b/examples/transpose/transpose_serial_vector.cpp
@@ -1,11 +1,12 @@
 //  Copyright (c) 2014 Thomas Heller
-//  Copyright (c) 2014 Hartmut Kaiser
+//  Copyright (c) 2014-2022 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <hpx/config.hpp>
+
 #if !defined(HPX_COMPUTE_DEVICE_CODE)
 #include <hpx/include/partitioned_vector.hpp>
 #include <hpx/init.hpp>
@@ -20,14 +21,14 @@
 #define COL_SHIFT 1000.00    // Constant to shift column index
 #define ROW_SHIFT 0.001      // Constant to shift row index
 
+#if defined(HPX_HAVE_STATIC_LINKING)
+HPX_REGISTER_PARTITIONED_VECTOR(double)
+#endif
+
 bool verbose = false;
 
 double test_results(
     std::uint64_t order, hpx::partitioned_vector<double> const& trans);
-
-#if !defined(HPX_MSVC)
-HPX_REGISTER_PARTITIONED_VECTOR(double)
-#endif
 
 ///////////////////////////////////////////////////////////////////////////////
 int hpx_main(hpx::program_options::variables_map& vm)

--- a/libs/CMakeLists.txt
+++ b/libs/CMakeLists.txt
@@ -70,13 +70,7 @@ add_hpx_source_group(
 )
 
 if(NOT HPX_WITH_STATIC_LINKING)
-  if(MSVC)
-    # The MSVC linker can't handle a static library as large as we get when
-    # statically linking the main HPX library
-    set(hpx_library_link_mode_core SHARED)
-  else()
-    set(hpx_library_link_mode_core ${hpx_library_link_mode})
-  endif()
+  set(hpx_library_link_mode_core ${hpx_library_link_mode})
 endif()
 
 # ##############################################################################
@@ -245,7 +239,7 @@ install(
 )
 
 # install PDB if needed
-if(MSVC)
+if(MSVC AND NOT HPX_WITH_STATIC_LINKING)
   install(
     FILES $<TARGET_PDB_FILE:hpx_full>
     DESTINATION ${CMAKE_INSTALL_BINDIR}
@@ -317,7 +311,7 @@ foreach(lib ${HPX_LIBS})
   # creation can move here as well.
   if(NOT ${lib} STREQUAL "full")
     string(TOUPPER ${lib} uppercase_lib)
-    add_library(hpx_${lib} SHARED src/empty.cpp)
+    add_library(hpx_${lib} ${hpx_library_link_mode} src/empty.cpp)
     target_compile_definitions(hpx_${lib} PRIVATE HPX_${uppercase_lib}_EXPORTS)
 
     set_target_properties(hpx_${lib} PROPERTIES FOLDER "Core")
@@ -367,7 +361,7 @@ if(HPX_WITH_ITTNOTIFY)
   target_link_libraries(hpx_core PUBLIC Amplifier::amplifier)
 endif()
 
-if(HPX_WITH_MODULES_AS_STATIC_LIBRARIES)
+if(HPX_WITH_MODULES_AS_STATIC_LIBRARIES OR HPX_WITH_STATIC_LINKING)
   target_link_libraries(hpx_core PUBLIC hpx_public_flags)
   target_link_libraries(hpx_core PUBLIC hpx_base_libraries)
   target_link_libraries(hpx_core PUBLIC hpx_dependencies_boost)

--- a/libs/core/asio/src/asio_util.cpp
+++ b/libs/core/asio/src/asio_util.cpp
@@ -31,7 +31,7 @@
 #include <exception>
 #include <system_error>
 
-#if defined(HPX_WINDOWS)
+#if defined(HPX_WINDOWS) && !defined(HPX_HAVE_STATIC_LINKING)
 // Prevent asio from initializing Winsock, the object must be constructed
 // before any Asio's own global objects. With MSVC, this may be accomplished
 // by adding the following code to the DLL:

--- a/libs/core/config/include/hpx/config/export_definitions.hpp
+++ b/libs/core/config/include/hpx/config/export_definitions.hpp
@@ -17,7 +17,7 @@
 
 // clang-format off
 #if defined(_WIN32) || defined(__WIN32__) || defined(WIN32)
-#if !defined(HPX_MODULE_STATIC_LINKING)
+#if !defined(HPX_MODULE_STATIC_LINKING) && !defined(HPX_HAVE_STATIC_LINKING)
 # define HPX_SYMBOL_EXPORT      __declspec(dllexport)
 # define HPX_SYMBOL_IMPORT      __declspec(dllimport)
 # define HPX_SYMBOL_INTERNAL    /* empty */

--- a/libs/core/runtime_local/include/hpx/runtime_local/runtime_local.hpp
+++ b/libs/core/runtime_local/include/hpx/runtime_local/runtime_local.hpp
@@ -46,10 +46,11 @@ namespace hpx {
         ///////////////////////////////////////////////////////////////////////
         // There is no need to protect these global from thread concurrent
         // access as they are access during early startup only.
-        extern std::list<startup_function_type> global_pre_startup_functions;
-        extern std::list<startup_function_type> global_startup_functions;
-        extern std::list<shutdown_function_type> global_pre_shutdown_functions;
-        extern std::list<shutdown_function_type> global_shutdown_functions;
+        extern std::list<startup_function_type>& global_pre_startup_functions();
+        extern std::list<startup_function_type>& global_startup_functions();
+        extern std::list<shutdown_function_type>&
+        global_pre_shutdown_functions();
+        extern std::list<shutdown_function_type>& global_shutdown_functions();
     }    // namespace detail
 
     ///////////////////////////////////////////////////////////////////////////

--- a/libs/core/runtime_local/src/runtime_local.cpp
+++ b/libs/core/runtime_local/src/runtime_local.cpp
@@ -400,30 +400,31 @@ namespace hpx {
 
             // copy over all startup functions registered so far
             for (startup_function_type& f :
-                detail::global_pre_startup_functions)
+                detail::global_pre_startup_functions())
             {
                 add_pre_startup_function(HPX_MOVE(f));
             }
-            detail::global_pre_startup_functions.clear();
+            detail::global_pre_startup_functions().clear();
 
-            for (startup_function_type& f : detail::global_startup_functions)
+            for (startup_function_type& f : detail::global_startup_functions())
             {
                 add_startup_function(HPX_MOVE(f));
             }
-            detail::global_startup_functions.clear();
+            detail::global_startup_functions().clear();
 
             for (shutdown_function_type& f :
-                detail::global_pre_shutdown_functions)
+                detail::global_pre_shutdown_functions())
             {
                 add_pre_shutdown_function(HPX_MOVE(f));
             }
-            detail::global_pre_shutdown_functions.clear();
+            detail::global_pre_shutdown_functions().clear();
 
-            for (shutdown_function_type& f : detail::global_shutdown_functions)
+            for (shutdown_function_type& f :
+                detail::global_shutdown_functions())
             {
                 add_shutdown_function(HPX_MOVE(f));
             }
-            detail::global_shutdown_functions.clear();
+            detail::global_shutdown_functions().clear();
         }
         catch (std::exception const& e)
         {
@@ -1114,10 +1115,31 @@ namespace hpx {
         ///////////////////////////////////////////////////////////////////////
         // There is no need to protect these global from thread concurrent
         // access as they are access during early startup only.
-        std::list<startup_function_type> global_pre_startup_functions;
-        std::list<startup_function_type> global_startup_functions;
-        std::list<shutdown_function_type> global_pre_shutdown_functions;
-        std::list<shutdown_function_type> global_shutdown_functions;
+        std::list<startup_function_type>& global_pre_startup_functions()
+        {
+            static std::list<startup_function_type>
+                global_pre_startup_functions_;
+            return global_pre_startup_functions_;
+        }
+
+        std::list<startup_function_type>& global_startup_functions()
+        {
+            static std::list<startup_function_type> global_startup_functions_;
+            return global_startup_functions_;
+        }
+
+        std::list<shutdown_function_type>& global_pre_shutdown_functions()
+        {
+            static std::list<shutdown_function_type>
+                global_pre_shutdown_functions_;
+            return global_pre_shutdown_functions_;
+        }
+
+        std::list<shutdown_function_type>& global_shutdown_functions()
+        {
+            static std::list<shutdown_function_type> global_shutdown_functions_;
+            return global_shutdown_functions_;
+        }
     }    // namespace detail
 
     ///////////////////////////////////////////////////////////////////////////
@@ -1137,7 +1159,7 @@ namespace hpx {
         }
         else
         {
-            detail::global_pre_startup_functions.push_back(HPX_MOVE(f));
+            detail::global_pre_startup_functions().push_back(HPX_MOVE(f));
         }
     }
 
@@ -1156,7 +1178,7 @@ namespace hpx {
         }
         else
         {
-            detail::global_startup_functions.push_back(HPX_MOVE(f));
+            detail::global_startup_functions().push_back(HPX_MOVE(f));
         }
     }
 
@@ -1176,7 +1198,7 @@ namespace hpx {
         }
         else
         {
-            detail::global_pre_shutdown_functions.push_back(HPX_MOVE(f));
+            detail::global_pre_shutdown_functions().push_back(HPX_MOVE(f));
         }
     }
 
@@ -1196,7 +1218,7 @@ namespace hpx {
         }
         else
         {
-            detail::global_shutdown_functions.push_back(HPX_MOVE(f));
+            detail::global_shutdown_functions().push_back(HPX_MOVE(f));
         }
     }
 

--- a/libs/full/agas/src/detail/interface.cpp
+++ b/libs/full/agas/src/detail/interface.cpp
@@ -634,5 +634,9 @@ namespace hpx { namespace agas {
         }
     };
 
-    agas_interface_functions agas_init;
+    agas_interface_functions& agas_init()
+    {
+        static agas_interface_functions agas_init_;
+        return agas_init_;
+    }
 }}    // namespace hpx::agas

--- a/libs/full/async_distributed/include/hpx/async_distributed/base_lco_with_value.hpp
+++ b/libs/full/async_distributed/include/hpx/async_distributed/base_lco_with_value.hpp
@@ -421,8 +421,9 @@ namespace hpx { namespace components { namespace detail {
         HPX_PP_CAT(                                                            \
             HPX_PP_CAT(base_lco_with_value_, Name), Tag)::set_value_action,    \
         "lco_set_value_action", std::size_t(-1), std::size_t(-1))              \
-/**/
+    /**/
 
+#if !defined(HPX_HAVE_STATIC_LINKING)
 ///////////////////////////////////////////////////////////////////////////////
 HPX_REGISTER_BASE_LCO_WITH_VALUE_DECLARATION(hpx::naming::gid_type, gid_type)
 HPX_REGISTER_BASE_LCO_WITH_VALUE_DECLARATION(
@@ -453,3 +454,4 @@ HPX_REGISTER_BASE_LCO_WITH_VALUE_DECLARATION(
     std::vector<std::uint32_t>, vector_std_uint32_type)
 HPX_REGISTER_BASE_LCO_WITH_VALUE_DECLARATION(hpx::util::section, hpx_section)
 HPX_REGISTER_BASE_LCO_WITH_VALUE_DECLARATION(std::string, std_string)
+#endif

--- a/libs/full/async_distributed/src/base_lco_with_value.cpp
+++ b/libs/full/async_distributed/src/base_lco_with_value.cpp
@@ -5,6 +5,9 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+#include <hpx/config.hpp>
+
+#if !defined(HPX_HAVE_STATIC_LINKING)
 #include <hpx/async_distributed/applier/apply.hpp>
 #include <hpx/async_distributed/apply.hpp>
 #include <hpx/async_distributed/base_lco_with_value.hpp>
@@ -37,3 +40,5 @@ HPX_REGISTER_BASE_LCO_WITH_VALUE_ID(std::vector<hpx::id_type>, vector_id_type,
 HPX_REGISTER_BASE_LCO_WITH_VALUE_ID(hpx::util::unused_type, unused_type,
     hpx::actions::base_lco_with_value_unused_get,
     hpx::actions::base_lco_with_value_unused_set)
+
+#endif

--- a/libs/full/async_distributed/src/base_lco_with_value_1.cpp
+++ b/libs/full/async_distributed/src/base_lco_with_value_1.cpp
@@ -5,6 +5,9 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+#include <hpx/config.hpp>
+
+#if !defined(HPX_HAVE_STATIC_LINKING)
 #include <hpx/async_distributed/applier/apply.hpp>
 #include <hpx/async_distributed/apply.hpp>
 #include <hpx/async_distributed/base_lco_with_value.hpp>
@@ -23,3 +26,5 @@ HPX_REGISTER_BASE_LCO_WITH_VALUE_ID(std::int8_t, int8_t,
 HPX_REGISTER_BASE_LCO_WITH_VALUE_ID(std::uint8_t, uint8_t,
     hpx::actions::base_lco_with_value_uint8_get,
     hpx::actions::base_lco_with_value_uint8_set)
+
+#endif

--- a/libs/full/async_distributed/src/base_lco_with_value_2.cpp
+++ b/libs/full/async_distributed/src/base_lco_with_value_2.cpp
@@ -5,6 +5,9 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+#include <hpx/config.hpp>
+
+#if !defined(HPX_HAVE_STATIC_LINKING)
 #include <hpx/async_distributed/applier/apply.hpp>
 #include <hpx/async_distributed/apply.hpp>
 #include <hpx/async_distributed/base_lco_with_value.hpp>
@@ -23,3 +26,5 @@ HPX_REGISTER_BASE_LCO_WITH_VALUE_ID(std::int32_t, int32_t,
 HPX_REGISTER_BASE_LCO_WITH_VALUE_ID(std::uint32_t, uint32_t,
     hpx::actions::base_lco_with_value_uint32_get,
     hpx::actions::base_lco_with_value_uint32_set)
+
+#endif

--- a/libs/full/async_distributed/src/base_lco_with_value_3.cpp
+++ b/libs/full/async_distributed/src/base_lco_with_value_3.cpp
@@ -5,6 +5,9 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+#include <hpx/config.hpp>
+
+#if !defined(HPX_HAVE_STATIC_LINKING)
 #include <hpx/async_distributed/applier/apply.hpp>
 #include <hpx/async_distributed/apply.hpp>
 #include <hpx/async_distributed/base_lco_with_value.hpp>
@@ -38,3 +41,5 @@ HPX_REGISTER_BASE_LCO_WITH_VALUE_ID(hpx::util::section, hpx_section,
 HPX_REGISTER_BASE_LCO_WITH_VALUE_ID(std::string, std_string,
     hpx::actions::base_lco_with_value_std_string_get,
     hpx::actions::base_lco_with_value_std_string_set)
+
+#endif

--- a/libs/full/components_base/include/hpx/components_base/agas_interface.hpp
+++ b/libs/full/components_base/include/hpx/components_base/agas_interface.hpp
@@ -294,4 +294,8 @@ namespace hpx { namespace agas {
     HPX_EXPORT naming::address_type get_symbol_ns_lva();
     HPX_EXPORT naming::address_type get_runtime_support_lva();
 
+    ///////////////////////////////////////////////////////////////////////////
+    // initialize AGAS interface function wrappers
+    struct agas_interface_functions& agas_init();
+
 }}    // namespace hpx::agas

--- a/libs/full/init_runtime/src/hpx_init.cpp
+++ b/libs/full/init_runtime/src/hpx_init.cpp
@@ -64,7 +64,10 @@
 #include <hpx/init_runtime/pre_main.hpp>
 #include <hpx/modules/async_distributed.hpp>
 #include <hpx/modules/naming.hpp>
+#if defined(HPX_HAVE_NETWORKING)
 #include <hpx/parcelset/parcelhandler.hpp>
+#include <hpx/parcelset_base/locality_interface.hpp>
+#endif
 #include <hpx/performance_counters/counters.hpp>
 #include <hpx/performance_counters/query_counters.hpp>
 #include <hpx/runtime_distributed.hpp>
@@ -713,6 +716,16 @@ namespace hpx {
                 &hpx::terminate);
             hpx::parallel::util::detail::
                 set_parallel_exception_termination_handler(&hpx::terminate);
+
+            // instantiate the interface function initialization objects
+#if defined(HPX_HAVE_DISTRIBUTED_RUNTIME)
+#if defined(HPX_HAVE_NETWORKING)
+            parcelset::locality_init();
+#endif
+            agas::agas_init();
+            agas::runtime_components_init();
+            components::counter_init();
+#endif
 
 #if defined(HPX_NATIVE_MIC) || defined(__bgq__) || defined(__bgqion__)
             unsetenv("LANG");

--- a/libs/full/lcos_distributed/include/hpx/lcos_distributed/server/channel.hpp
+++ b/libs/full/lcos_distributed/include/hpx/lcos_distributed/server/channel.hpp
@@ -146,8 +146,6 @@ namespace hpx { namespace lcos { namespace server {
     HPX_REGISTER_ACTION_DECLARATION(                                           \
         hpx::lcos::server::channel<type>::close_action,                        \
         HPX_PP_CAT(__channel_close_action, HPX_PP_CAT(type, name)))            \
-    HPX_REGISTER_BASE_LCO_WITH_VALUE_DECLARATION(                              \
-        type, type, name, component_tag)                                       \
     /**/
 
 #define HPX_REGISTER_CHANNEL(...)                                              \
@@ -179,5 +177,4 @@ namespace hpx { namespace lcos { namespace server {
         HPX_PP_CAT(__channel_set_generation_action, HPX_PP_CAT(type, name)))   \
     HPX_REGISTER_ACTION(hpx::lcos::server::channel<type>::close_action,        \
         HPX_PP_CAT(__channel_close_action, HPX_PP_CAT(type, name)))            \
-    HPX_REGISTER_BASE_LCO_WITH_VALUE(type, type, name, component_tag)          \
     /**/

--- a/libs/full/parcelset_base/include/hpx/parcelset_base/locality_interface.hpp
+++ b/libs/full/parcelset_base/include/hpx/parcelset_base/locality_interface.hpp
@@ -23,6 +23,11 @@ namespace hpx::parcelset {
     HPX_EXPORT parcelset::parcel create_parcel();
 
     HPX_EXPORT locality create_locality(std::string const& name);
+
+    ///////////////////////////////////////////////////////////////////////////
+    // initialize locality interface function wrappers
+    struct locality_interface_functions& locality_init();
+
 }    // namespace hpx::parcelset
 
 #endif

--- a/libs/full/performance_counters/include/hpx/performance_counters/server/base_performance_counter.hpp
+++ b/libs/full/performance_counters/include/hpx/performance_counters/server/base_performance_counter.hpp
@@ -16,6 +16,8 @@
 #include <hpx/performance_counters/performance_counter_base.hpp>
 #include <hpx/thread_support/atomic_count.hpp>
 
+#include <hpx/config/warnings_prefix.hpp>
+
 ///////////////////////////////////////////////////////////////////////////////
 namespace hpx { namespace performance_counters { namespace server {
 
@@ -111,6 +113,8 @@ namespace hpx { namespace performance_counters { namespace server {
         util::atomic_count invocation_count_;
     };
 }}}    // namespace hpx::performance_counters::server
+
+#include <hpx/config/warnings_suffix.hpp>
 
 HPX_ACTION_HAS_CRITICAL_PRIORITY(hpx::performance_counters::server::
         base_performance_counter ::get_counter_info_action)

--- a/libs/full/runtime_distributed/include/hpx/runtime_distributed/runtime_support.hpp
+++ b/libs/full/runtime_distributed/include/hpx/runtime_distributed/runtime_support.hpp
@@ -152,3 +152,14 @@ namespace hpx { namespace components {
         hpx::id_type gid_;
     };
 }}    // namespace hpx::components
+
+///////////////////////////////////////////////////////////////////////////////
+// initialize runtime interface function wrappers
+namespace hpx::agas {
+    struct runtime_components_init_interface_functions&
+    runtime_components_init();
+}
+
+namespace hpx::components {
+    struct counter_interface_functions& counter_init();
+}    // namespace hpx::components

--- a/libs/full/runtime_distributed/src/locality_interface.cpp
+++ b/libs/full/runtime_distributed/src/locality_interface.cpp
@@ -162,7 +162,11 @@ namespace hpx::parcelset {
         }
     };
 
-    locality_interface_functions locality_init;
+    locality_interface_functions& locality_init()
+    {
+        static locality_interface_functions locality_init_;
+        return locality_init_;
+    }
 }    // namespace hpx::parcelset
 
 #endif

--- a/libs/full/runtime_distributed/src/runtime_support.cpp
+++ b/libs/full/runtime_distributed/src/runtime_support.cpp
@@ -105,7 +105,12 @@ namespace hpx { namespace agas {
         }
     };
 
-    runtime_components_init_interface_functions runtime_components_init;
+    runtime_components_init_interface_functions& runtime_components_init()
+    {
+        static runtime_components_init_interface_functions
+            runtime_components_init_;
+        return runtime_components_init_;
+    }
 }}    // namespace hpx::agas
 
 namespace hpx { namespace components {
@@ -130,5 +135,9 @@ namespace hpx { namespace components {
         }
     };
 
-    counter_interface_functions counter_init;
+    counter_interface_functions& counter_init()
+    {
+        static counter_interface_functions counter_init_;
+        return counter_init_;
+    }
 }}    // namespace hpx::components


### PR DESCRIPTION
- add github actions
- flyby: unify handling of excluded targets for Windows github builders

potentially resolves #5908