### PR TITLE
Adding sync_wait_with_variant

### DIFF
--- a/libs/core/execution/CMakeLists.txt
+++ b/libs/core/execution/CMakeLists.txt
@@ -26,6 +26,7 @@ set(execution_headers
     hpx/execution/algorithms/split.hpp
     hpx/execution/algorithms/start_detached.hpp
     hpx/execution/algorithms/sync_wait.hpp
+    hpx/execution/algorithms/sync_wait_with_variant.hpp
     hpx/execution/algorithms/then.hpp
     hpx/execution/algorithms/transfer.hpp
     hpx/execution/algorithms/transfer_just.hpp

--- a/libs/core/execution/include/hpx/execution/algorithms/sync_wait_with_variant.hpp
+++ b/libs/core/execution/include/hpx/execution/algorithms/sync_wait_with_variant.hpp
@@ -14,7 +14,6 @@
 #include <hpx/datastructures/tuple.hpp>
 #include <hpx/datastructures/variant.hpp>
 #include <hpx/execution/algorithms/detail/partial_algorithm.hpp>
-#include <hpx/execution/algorithms/detail/single_result.hpp>
 #include <hpx/execution_base/completion_signatures.hpp>
 #include <hpx/execution_base/operation_state.hpp>
 #include <hpx/execution_base/sender.hpp>
@@ -111,8 +110,7 @@ namespace hpx::execution::experimental::detail {
 
                 // If the variant holds a hpx::monostate set_stopped was called
                 // we return an empty optional
-                return hpx::optional<
-                    typename single_variant<result_type>::type>();
+                return hpx::optional<result_type>();
             }
         };
 

--- a/libs/core/execution/include/hpx/execution/algorithms/sync_wait_with_variant.hpp
+++ b/libs/core/execution/include/hpx/execution/algorithms/sync_wait_with_variant.hpp
@@ -1,0 +1,214 @@
+//  Copyright (c) 2020 ETH Zurich
+//  Copyright (c) 2022 Hartmut Kaiser
+//  Copyright (c) 2022 Chuanqiu He
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include <hpx/config.hpp>
+#include <hpx/concepts/concepts.hpp>
+#include <hpx/datastructures/optional.hpp>
+#include <hpx/datastructures/tuple.hpp>
+#include <hpx/datastructures/variant.hpp>
+#include <hpx/execution/algorithms/detail/partial_algorithm.hpp>
+#include <hpx/execution/algorithms/detail/single_result.hpp>
+#include <hpx/execution_base/completion_signatures.hpp>
+#include <hpx/execution_base/operation_state.hpp>
+#include <hpx/execution_base/sender.hpp>
+#include <hpx/functional/detail/tag_priority_invoke.hpp>
+#include <hpx/synchronization/condition_variable.hpp>
+#include <hpx/synchronization/spinlock.hpp>
+#include <hpx/type_support/meta.hpp>
+#include <hpx/type_support/pack.hpp>
+#include <hpx/type_support/unused.hpp>
+
+#include <atomic>
+#include <exception>
+#include <mutex>
+#include <type_traits>
+#include <utility>
+
+namespace hpx::execution::experimental::detail {
+
+    struct sync_wait_with_variant_error_visitor
+    {
+        void operator()(std::exception_ptr ep) const
+        {
+            std::rethrow_exception(ep);
+        }
+
+        template <typename Error>
+        void operator()(Error& error) const
+        {
+            throw error;
+        }
+    };
+
+    template <typename Sender>
+    struct sync_wait_with_variant_receiver
+    {
+        // value and error_types of the predecessor sender
+        template <template <typename...> class Tuple,
+            template <typename...> class Variant>
+        using predecessor_value_types =
+            value_types_of_t<Sender, empty_env, Tuple, Variant>;
+
+        template <template <typename...> class Variant>
+        using predecessor_error_types =
+            error_types_of_t<Sender, empty_env, Variant>;
+
+        // The template should compute the result type of whatever returned from
+        // sync_wait_with_variant, which should be optional of the variant of
+        // the tuples.
+        using result_type = predecessor_value_types<hpx::tuple, hpx::variant>;
+
+        // The type of errors to store in the variant. This in itself is a
+        // variant.
+        using error_type =
+            hpx::util::detail::unique_t<hpx::util::detail::prepend_t<
+                predecessor_error_types<hpx::variant>, std::exception_ptr>>;
+
+        // We use a spinlock here to allow taking the lock on non-HPX threads.
+        using mutex_type = hpx::spinlock;
+
+        struct shared_state
+        {
+            // We use a spinlock here to allow taking the lock on non-HPX
+            // threads.
+            hpx::condition_variable cond_var;
+            mutex_type mtx;
+            std::atomic<bool> set_called = false;
+            hpx::variant<hpx::monostate, error_type, result_type> value;
+
+            void wait()
+            {
+                if (!set_called)
+                {
+                    std::unique_lock<mutex_type> l(mtx);
+                    if (!set_called)
+                    {
+                        cond_var.wait(l);
+                    }
+                }
+            }
+
+            auto get_value()
+            {
+                if (hpx::holds_alternative<result_type>(value))
+                {
+                    //  wrap it into an optional
+                    return hpx::make_optional(
+                        hpx::get<result_type>(HPX_MOVE(value)));
+                }
+                else if (hpx::holds_alternative<error_type>(value))
+                {
+                    hpx::visit(sync_wait_with_variant_error_visitor{},
+                        hpx::get<error_type>(value));
+                }
+
+                // If the variant holds a hpx::monostate set_stopped was called
+                // we return an empty optional
+                return hpx::optional<
+                    typename single_variant<result_type>::type>();
+            }
+        };
+
+        shared_state& state;
+
+        void signal_set_called() noexcept
+        {
+            std::unique_lock<mutex_type> l(state.mtx);
+            state.set_called = true;
+            hpx::util::ignore_while_checking<decltype(l)> il(&l);
+            HPX_UNUSED(il);
+
+            state.cond_var.notify_one();
+        }
+
+        template <typename Error>
+        friend void tag_invoke(set_error_t, sync_wait_with_variant_receiver&& r,
+            Error&& error) noexcept
+        {
+            r.state.value.template emplace<error_type>(
+                HPX_FORWARD(Error, error));
+            r.signal_set_called();
+        }
+
+        friend void tag_invoke(
+            set_stopped_t, sync_wait_with_variant_receiver&& r) noexcept
+        {
+            r.signal_set_called();
+        }
+
+        template <typename... Us>
+        friend void tag_invoke(set_value_t, sync_wait_with_variant_receiver&& r,
+            Us&&... us) noexcept
+        {
+            r.state.value.template emplace<result_type>(
+                hpx::forward_as_tuple(HPX_FORWARD(Us, us)...));
+            r.signal_set_called();
+        }
+    };
+}    // namespace hpx::execution::experimental::detail
+
+namespace hpx::this_thread::experimental {
+
+    inline constexpr struct sync_wait_with_variant_t final
+      : hpx::functional::detail::tag_priority<sync_wait_with_variant_t>
+    {
+    private:
+        // clang-format off
+        template <typename Sender,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::execution::experimental::is_sender_v<Sender> &&
+                hpx::execution::experimental::detail::
+                    is_completion_scheduler_tag_invocable_v<
+                        hpx::execution::experimental::set_value_t,
+                        Sender, sync_wait_with_variant_t
+                    >
+            )>
+        // clang-format on
+        friend constexpr HPX_FORCEINLINE auto tag_override_invoke(
+            sync_wait_with_variant_t, Sender&& sender)
+        {
+            auto scheduler =
+                hpx::execution::experimental::get_completion_scheduler<
+                    hpx::execution::experimental::set_value_t>(sender);
+
+            return hpx::functional::tag_invoke(sync_wait_with_variant_t{},
+                HPX_MOVE(scheduler), HPX_FORWARD(Sender, sender));
+        }
+
+        // clang-format off
+        template <typename Sender,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::execution::experimental::is_sender_v<Sender>
+            )>
+        // clang-format on
+        friend constexpr HPX_FORCEINLINE auto tag_fallback_invoke(
+            sync_wait_with_variant_t, Sender&& sender)
+        {
+            using receiver_type = hpx::execution::experimental::detail::
+                sync_wait_with_variant_receiver<Sender>;
+            using state_type = typename receiver_type::shared_state;
+
+            state_type state{};
+            auto op_state = hpx::execution::experimental::connect(
+                HPX_FORWARD(Sender, sender), receiver_type{state});
+            hpx::execution::experimental::start(op_state);
+
+            state.wait();
+            return state.get_value();
+        }
+
+        friend constexpr HPX_FORCEINLINE auto tag_fallback_invoke(
+            sync_wait_with_variant_t)
+        {
+            return hpx::execution::experimental::detail::partial_algorithm<
+                sync_wait_with_variant_t>{};
+        }
+    } sync_wait_with_variant{};
+}    // namespace hpx::this_thread::experimental

--- a/libs/core/execution/tests/unit/CMakeLists.txt
+++ b/libs/core/execution/tests/unit/CMakeLists.txt
@@ -18,6 +18,7 @@ set(tests
     algorithm_split
     algorithm_start_detached
     algorithm_sync_wait
+    algorithm_sync_wait_with_variant
     algorithm_then
     algorithm_transfer
     algorithm_transfer_just

--- a/libs/core/execution/tests/unit/algorithm_sync_wait_with_variant.cpp
+++ b/libs/core/execution/tests/unit/algorithm_sync_wait_with_variant.cpp
@@ -48,31 +48,28 @@ int hpx_main()
 
     {
         auto result = *tt::sync_wait_with_variant(ex::just(3, 4.0));
-        HPX_TEST_EQ(hpx::get<0>(result), 3);
-        HPX_TEST_EQ(hpx::get<1>(result), 4.0);
+        HPX_TEST_EQ(result, ex::just(3, 4.0));
     }
 
     {
         auto result =
             *tt::sync_wait_with_variant(ex::just(3, 4.0, std::string("42")));
-        HPX_TEST_EQ(hpx::get<0>(result), 3);
-        HPX_TEST_EQ(hpx::get<1>(result), 4.0);
-        HPX_TEST_EQ(hpx::get<2>(result), std::string("42"));
+        HPX_TEST_EQ(result, ex::just(3, 4.0, std::string("42")));
     }
 
     {
-        HPX_TEST_EQ(*tt::sync_wait_with_variant(
+        HPX_TEST_EQ(*(tt::sync_wait_with_variant(
                         ex::just(custom_type_non_default_constructible{42}))
-                         .x,
+                            .x),
             42);
     }
 
     {
         HPX_TEST_EQ(
-            *tt::sync_wait_with_variant(
+            *(tt::sync_wait_with_variant(
                 ex::just(
                     custom_type_non_default_constructible_non_copyable{42}))
-                 .x,
+                    .x),
             42);
     }
 
@@ -124,7 +121,7 @@ int hpx_main()
     // cancellation path
     {
         auto result =
-            stopped_sender_with_value_type{} | tt::sync_wait_with_variant();
+            (stopped_sender_with_value_type{} | tt::sync_wait_with_variant());
         HPX_TEST(!result);    // returned optional should be empty
     }
 

--- a/libs/core/execution/tests/unit/algorithm_sync_wait_with_variant.cpp
+++ b/libs/core/execution/tests/unit/algorithm_sync_wait_with_variant.cpp
@@ -1,0 +1,140 @@
+//  Copyright (c) 2021 ETH Zurich
+//  Copyright (c) 2022 Chuanqiu He
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/local/init.hpp>
+#include <hpx/modules/execution.hpp>
+#include <hpx/modules/testing.hpp>
+
+#include "algorithm_test_utils.hpp"
+
+#include <atomic>
+#include <exception>
+#include <stdexcept>
+#include <string>
+#include <type_traits>
+#include <utility>
+
+namespace ex = hpx::execution::experimental;
+namespace tt = hpx::this_thread::experimental;
+
+// NOTE: This is not a conforming sync_wait_with_variant implementation.
+// It only exists to check that the tag_invoke overload is called.
+void tag_invoke(tt::sync_wait_with_variant_t, custom_sender2 s)
+{
+    s.tag_invoke_overload_called = true;
+}
+
+int hpx_main()
+{
+    // Success path
+    {
+        std::atomic<bool> start_called{false};
+        std::atomic<bool> connect_called{false};
+        std::atomic<bool> tag_invoke_overload_called{false};
+        tt::sync_wait_with_variant(custom_sender{
+            start_called, connect_called, tag_invoke_overload_called});
+        HPX_TEST(start_called);
+        HPX_TEST(connect_called);
+        HPX_TEST(!tag_invoke_overload_called);
+    }
+
+    {
+        HPX_TEST_EQ(*tt::sync_wait_with_variant(ex::just(3)), 3);
+    }
+
+    {
+        auto result = *tt::sync_wait_with_variant(ex::just(3, 4.0));
+        HPX_TEST_EQ(hpx::get<0>(result), 3);
+        HPX_TEST_EQ(hpx::get<1>(result), 4.0);
+    }
+
+    {
+        auto result =
+            *tt::sync_wait_with_variant(ex::just(3, 4.0, std::string("42")));
+        HPX_TEST_EQ(hpx::get<0>(result), 3);
+        HPX_TEST_EQ(hpx::get<1>(result), 4.0);
+        HPX_TEST_EQ(hpx::get<2>(result), std::string("42"));
+    }
+
+    {
+        HPX_TEST_EQ(*tt::sync_wait_with_variant(
+                        ex::just(custom_type_non_default_constructible{42}))
+                         .x,
+            42);
+    }
+
+    {
+        HPX_TEST_EQ(
+            *tt::sync_wait_with_variant(
+                ex::just(
+                    custom_type_non_default_constructible_non_copyable{42}))
+                 .x,
+            42);
+    }
+
+    // operator| overload
+    {
+        std::atomic<bool> start_called{false};
+        std::atomic<bool> connect_called{false};
+        std::atomic<bool> tag_invoke_overload_called{false};
+        custom_sender{
+            start_called, connect_called, tag_invoke_overload_called} |
+            tt::sync_wait_with_variant();
+        HPX_TEST(start_called);
+        HPX_TEST(connect_called);
+        HPX_TEST(!tag_invoke_overload_called);
+    }
+
+    {
+        HPX_TEST_EQ(*(ex::just(3) | tt::sync_wait_with_variant()), 3);
+    }
+
+    // tag_invoke overload
+    {
+        std::atomic<bool> start_called{false};
+        std::atomic<bool> connect_called{false};
+        std::atomic<bool> tag_invoke_overload_called{false};
+        tt::sync_wait_with_variant(custom_sender2{custom_sender{
+            start_called, connect_called, tag_invoke_overload_called}});
+        HPX_TEST(!start_called);
+        HPX_TEST(!connect_called);
+        HPX_TEST(tag_invoke_overload_called);
+    }
+
+    // Failure path
+    {
+        bool exception_thrown = false;
+        try
+        {
+            tt::sync_wait_with_variant(error_sender{});
+            HPX_TEST(false);
+        }
+        catch (std::runtime_error const& e)
+        {
+            HPX_TEST_EQ(std::string(e.what()), std::string("error"));
+            exception_thrown = true;
+        }
+        HPX_TEST(exception_thrown);
+    }
+
+    // cancellation path
+    {
+        auto result =
+            stopped_sender_with_value_type{} | tt::sync_wait_with_variant();
+        HPX_TEST(!result);    // returned optional should be empty
+    }
+
+    return hpx::local::finalize();
+}
+
+int main(int argc, char* argv[])
+{
+    HPX_TEST_EQ_MSG(hpx::local::init(hpx_main, argc, argv), 0,
+        "HPX main exited with non-zero status");
+
+    return hpx::util::report_errors();
+}

--- a/libs/core/execution_base/tests/include/algorithm_test_utils.hpp
+++ b/libs/core/execution_base/tests/include/algorithm_test_utils.hpp
@@ -410,6 +410,61 @@ struct custom_sender
             hpx::execution::experimental::set_error_t(std::exception_ptr)>;
 };
 
+struct custom_sender_multiTuple
+{
+    std::atomic<bool>& start_called;
+    std::atomic<bool>& connect_called;
+    std::atomic<bool>& tag_invoke_overload_called;
+
+    bool expect_set_value = true;
+
+    template <template <class...> class Tuple,
+        template <class...> class Variant>
+    using value_types = Variant<Tuple<>>;
+
+    template <template <class...> class Variant>
+    using error_types = Variant<std::exception_ptr>;
+
+    static constexpr bool sends_stopped = false;
+
+    template <typename R>
+    struct operation_state
+    {
+        std::atomic<bool>& start_called;
+        std::decay_t<R> r;
+        bool expect_set_value = true;
+        friend void tag_invoke(
+            hpx::execution::experimental::start_t, operation_state& os) noexcept
+        {
+            os.start_called = true;
+            if (os.expect_set_value)
+            {
+                hpx::execution::experimental::set_value(std::move(os.r), 3);
+            }
+            else
+            {
+                hpx::execution::experimental::set_value(std::move(os.r), "err");
+            }
+        };
+    };
+
+    template <typename R>
+    friend auto tag_invoke(hpx::execution::experimental::connect_t,
+        custom_sender_multiTuple&& s, R&& r)
+    {
+        s.connect_called = true;
+        return operation_state<R>{s.start_called, std::forward<R>(r)};
+    }
+
+    template <typename Env>
+    friend auto tag_invoke(
+        hpx::execution::experimental::get_completion_signatures_t,
+        custom_sender_multiTuple const&, Env)
+        -> hpx::execution::experimental::completion_signatures<
+            hpx::execution::experimental::set_value_t(int),
+            hpx::execution::experimental::set_value_t(std::string)>;
+};
+
 template <typename T>
 struct custom_typed_sender
 {


### PR DESCRIPTION
## Any background context you want to provide?
P2300R5: [sync_wait_with_variant](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2022/p2300r5.html#design-typed)
sync_wait_with_variant, which accepts any sender, but returns an optional whose value type is the variant of all the possible tuples sent by the input sender:
## Checklist

- [x] I have added a new feature and have added tests to go along with it.

