### PR TITLE
Prevent stalling during shutdown when running hello_world_distributed

### DIFF
--- a/libs/full/collectives/include/hpx/collectives/latch.hpp
+++ b/libs/full/collectives/include/hpx/collectives/latch.hpp
@@ -15,6 +15,8 @@
 #include <exception>
 #include <utility>
 
+#include <hpx/config/warnings_prefix.hpp>
+
 ///////////////////////////////////////////////////////////////////////////////
 namespace hpx::distributed {
 
@@ -162,3 +164,5 @@ namespace hpx::lcos {
         hpx::distributed::latch;
     /// \endcond
 }    // namespace hpx::lcos
+
+#include <hpx/config/warnings_suffix.hpp>

--- a/libs/full/performance_counters/include/hpx/performance_counters/performance_counter.hpp
+++ b/libs/full/performance_counters/include/hpx/performance_counters/performance_counter.hpp
@@ -20,6 +20,8 @@
 #include <utility>
 #include <vector>
 
+#include <hpx/config/warnings_prefix.hpp>
+
 ///////////////////////////////////////////////////////////////////////////////
 namespace hpx { namespace performance_counters {
 
@@ -132,3 +134,5 @@ namespace hpx { namespace performance_counters {
     HPX_EXPORT std::vector<performance_counter> discover_counters(
         std::string const& name, error_code& ec = throws);
 }}    // namespace hpx::performance_counters
+
+#include <hpx/config/warnings_suffix.hpp>


### PR DESCRIPTION
- flyby: fix dll-export warnigs
