### PR TITLE
Adding missing pieces to sync_wait, adding run_loop

### DIFF
--- a/libs/core/algorithms/include/hpx/parallel/util/foreach_partitioner.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/util/foreach_partitioner.hpp
@@ -138,7 +138,8 @@ namespace hpx { namespace parallel { namespace util {
         private:
             template <typename F, typename Items1, typename Items2,
                 typename FwdIter>
-            static decltype(auto) reduce(
+
+            static auto reduce(
                 std::pair<Items1, Items2>&& items, F&& f, FwdIter last)
             {
                 // wait for all tasks to finish
@@ -150,7 +151,9 @@ namespace hpx { namespace parallel { namespace util {
                     handle_local_exceptions::call(hpx::get<0>(items));
                     handle_local_exceptions::call(hpx::get<1>(items));
                 }
-                return HPX_INVOKE(f, HPX_MOVE(last));
+
+                // gcc 9 complains here if HPX_INVOKE is used.
+                return hpx::util::invoke(f, HPX_MOVE(last));
             }
 
             template <typename F, typename Items, typename FwdIter>

--- a/libs/core/algorithms/tests/unit/algorithms/partial_sort_copy.cpp
+++ b/libs/core/algorithms/tests/unit/algorithms/partial_sort_copy.cpp
@@ -24,6 +24,12 @@
 
 #include "test_utils.hpp"
 
+#if defined(HPX_DEBUG)
+#define NELEM 111
+#else
+#define NELEM 1007
+#endif
+
 ////////////////////////////////////////////////////////////////////////////
 unsigned int seed = std::random_device{}();
 std::mt19937 gen(seed);
@@ -243,7 +249,6 @@ void test_partial_sort_copy2(IteratorTag)
     using compare_t = std::less<std::uint64_t>;
     std::list<std::uint64_t> lst;
     std::vector<std::uint64_t> A, B;
-    const uint32_t NELEM = 1000;
     A.reserve(NELEM);
     B.reserve(NELEM);
 
@@ -276,7 +281,6 @@ void test_partial_sort_copy2(ExPolicy policy, IteratorTag)
     using compare_t = std::less<std::uint64_t>;
     std::list<std::uint64_t> lst;
     std::vector<std::uint64_t> A, B;
-    const uint32_t NELEM = 1000;
     A.reserve(NELEM);
     B.reserve(NELEM);
 
@@ -309,7 +313,6 @@ void test_partial_sort_copy2_async(ExPolicy p, IteratorTag)
     using compare_t = std::less<std::uint64_t>;
     std::list<std::uint64_t> lst;
     std::vector<std::uint64_t> A, B;
-    const uint32_t NELEM = 1000;
     A.reserve(NELEM);
     B.reserve(NELEM);
 
@@ -363,7 +366,6 @@ void test_partial_sort_copy3(IteratorTag)
     std::list<std::uint64_t> lst;
     std::mt19937 my_rand(0);
     std::vector<std::uint64_t> A, B, C;
-    const uint32_t NELEM = 1000;
     A.reserve(NELEM);
     B.reserve(NELEM);
     C.reserve(NELEM);
@@ -399,7 +401,6 @@ void test_partial_sort_copy3(ExPolicy policy, IteratorTag)
     std::list<std::uint64_t> lst;
     std::mt19937 my_rand(0);
     std::vector<std::uint64_t> A, B, C;
-    const uint32_t NELEM = 1000;
     A.reserve(NELEM);
     B.reserve(NELEM);
     C.reserve(NELEM);
@@ -435,7 +436,6 @@ void test_partial_sort_copy3_async(ExPolicy p, IteratorTag)
     std::list<std::uint64_t> lst;
     std::mt19937 my_rand(0);
     std::vector<std::uint64_t> A, B, C;
-    const uint32_t NELEM = 1000;
     A.reserve(NELEM);
     B.reserve(NELEM);
     C.reserve(NELEM);

--- a/libs/core/algorithms/tests/unit/container_algorithms/foreach_tests.hpp
+++ b/libs/core/algorithms/tests/unit/container_algorithms/foreach_tests.hpp
@@ -7,6 +7,8 @@
 #pragma once
 
 #include <hpx/iterator_support/iterator_range.hpp>
+#include <hpx/modules/execution.hpp>
+#include <hpx/modules/executors.hpp>
 #include <hpx/modules/testing.hpp>
 #include <hpx/parallel/container_algorithms/for_each.hpp>
 

--- a/libs/core/async_mpi/tests/unit/algorithm_transform_mpi.cpp
+++ b/libs/core/async_mpi/tests/unit/algorithm_transform_mpi.cpp
@@ -10,6 +10,7 @@
 #include <hpx/modules/async_mpi.hpp>
 #include <hpx/modules/errors.hpp>
 #include <hpx/modules/execution.hpp>
+#include <hpx/modules/executors.hpp>
 #include <hpx/modules/testing.hpp>
 
 #include "algorithm_test_utils.hpp"

--- a/libs/core/config/include/hpx/config/compiler_specific.hpp
+++ b/libs/core/config/include/hpx/config/compiler_specific.hpp
@@ -158,7 +158,7 @@
 
 #if defined(HPX_HAVE_SANITIZERS)
 #  if defined(__has_feature)
-#  if __has_feature(address_sanitizer)
+#    if __has_feature(address_sanitizer)
 #      define HPX_HAVE_ADDRESS_SANITIZER
 #    endif
 #  elif defined(__SANITIZE_ADDRESS__)   // MSVC defines this

--- a/libs/core/coroutines/include/hpx/coroutines/detail/context_windows_fibers.hpp
+++ b/libs/core/coroutines/include/hpx/coroutines/detail/context_windows_fibers.hpp
@@ -181,7 +181,7 @@ namespace hpx { namespace threads { namespace coroutines {
                 {
                     void const* dummy = nullptr;
                     GetCurrentThreadStackLimits(
-                        (PULONG_PTR) &dummy, (PULONG_PTR) &asan_stack_bottom);
+                        (PULONG_PTR) &asan_stack_bottom, (PULONG_PTR) &dummy);
                 }
                 __sanitizer_start_switch_fiber(
                     fake_stack, asan_stack_bottom, asan_stack_size);

--- a/libs/core/execution/CMakeLists.txt
+++ b/libs/core/execution/CMakeLists.txt
@@ -156,6 +156,7 @@ add_hpx_module(
     hpx_threading
     hpx_pack_traversal
     hpx_errors
+    hpx_lock_registration
     hpx_memory
     hpx_synchronization
     hpx_thread_support

--- a/libs/core/execution/CMakeLists.txt
+++ b/libs/core/execution/CMakeLists.txt
@@ -9,6 +9,7 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 set(execution_headers
     hpx/execution/algorithms/bulk.hpp
     hpx/execution/algorithms/detail/is_negative.hpp
+    hpx/execution/algorithms/detail/inject_scheduler.hpp
     hpx/execution/algorithms/detail/partial_algorithm.hpp
     hpx/execution/algorithms/detail/predicates.hpp
     hpx/execution/algorithms/detail/single_result.hpp
@@ -20,6 +21,7 @@ set(execution_headers
     hpx/execution/algorithms/let_stopped.hpp
     hpx/execution/algorithms/let_value.hpp
     hpx/execution/algorithms/make_future.hpp
+    hpx/execution/algorithms/run_loop.hpp
     hpx/execution/algorithms/schedule_from.hpp
     hpx/execution/algorithms/split.hpp
     hpx/execution/algorithms/start_detached.hpp

--- a/libs/core/execution/include/hpx/execution/algorithms/bulk.hpp
+++ b/libs/core/execution/include/hpx/execution/algorithms/bulk.hpp
@@ -69,11 +69,11 @@ namespace hpx::execution::experimental {
                 )>
             // clang-format on
             friend constexpr auto tag_invoke(
-                hpx::execution::experimental::get_completion_scheduler_t<CPO>,
+                hpx::execution::experimental::get_completion_scheduler_t<CPO>
+                    tag,
                 bulk_sender const& sender)
             {
-                return hpx::execution::experimental::get_completion_scheduler<
-                    CPO>(sender.sender);
+                return tag(sender.sender);
             }
 
             template <typename Receiver>

--- a/libs/core/execution/include/hpx/execution/algorithms/detail/inject_scheduler.hpp
+++ b/libs/core/execution/include/hpx/execution/algorithms/detail/inject_scheduler.hpp
@@ -1,0 +1,72 @@
+//  Copyright (c) 2021 ETH Zurich
+//  Copyright (c) 2022 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include <hpx/concepts/concepts.hpp>
+#include <hpx/datastructures/member_pack.hpp>
+#include <hpx/execution_base/receiver.hpp>
+#include <hpx/execution_base/sender.hpp>
+#include <hpx/type_support/pack.hpp>
+
+#include <cstddef>
+#include <type_traits>
+#include <utility>
+
+namespace hpx::execution::experimental::detail {
+
+    // This is a partial s/r algorithm that injects a given scheduler as the
+    // first argument while tag-invoking the bound algorithm.
+    template <typename Tag, typename Scheduler, typename IsPack, typename... Ts>
+    struct inject_scheduler_base;
+
+    template <typename Tag, typename Scheduler, std::size_t... Is,
+        typename... Ts>
+    struct inject_scheduler_base<Tag, Scheduler, hpx::util::index_pack<Is...>,
+        Ts...>
+    {
+    private:
+        std::decay_t<Scheduler> scheduler;
+        HPX_NO_UNIQUE_ADDRESS hpx::util::member_pack_for<Ts...> ts;
+
+    public:
+        // clang-format off
+        template <typename Scheduler_, typename... Ts_,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::execution::experimental::is_scheduler_v<Scheduler_>
+            )>
+        // clang-format on
+        explicit constexpr inject_scheduler_base(
+            Scheduler_&& scheduler, Ts_&&... ts)
+          : scheduler(HPX_FORWARD(Scheduler_, scheduler))
+          , ts(std::piecewise_construct, HPX_FORWARD(Ts_, ts)...)
+        {
+        }
+
+        inject_scheduler_base(inject_scheduler_base&&) = default;
+        inject_scheduler_base& operator=(inject_scheduler_base&&) = default;
+        inject_scheduler_base(inject_scheduler_base const&) = delete;
+        inject_scheduler_base& operator=(inject_scheduler_base const&) = delete;
+
+        // clang-format off
+        template <typename U,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::execution::experimental::is_sender_v<U>
+            )>
+        // clang-format on
+        friend constexpr HPX_FORCEINLINE auto operator|(
+            U&& u, inject_scheduler_base p)
+        {
+            return Tag{}(HPX_MOVE(p.scheduler), HPX_FORWARD(U, u),
+                HPX_MOVE(p.ts).template get<Is>()...);
+        }
+    };
+
+    template <typename Tag, typename Scheduler, typename... Ts>
+    using inject_scheduler = inject_scheduler_base<Tag, Scheduler,
+        hpx::util::make_index_pack_t<sizeof...(Ts)>, Ts...>;
+}    // namespace hpx::execution::experimental::detail

--- a/libs/core/execution/include/hpx/execution/algorithms/detail/partial_algorithm.hpp
+++ b/libs/core/execution/include/hpx/execution/algorithms/detail/partial_algorithm.hpp
@@ -56,8 +56,7 @@ namespace hpx::execution::experimental::detail {
                 hpx::execution::experimental::detail::
                     is_completion_scheduler_tag_invocable_v<
                         hpx::execution::experimental::set_value_t,
-                        U, Tag
-                    >
+                        U, Tag, Ts...>
             )>
         // clang-format on
         friend constexpr HPX_FORCEINLINE auto operator|(
@@ -77,8 +76,7 @@ namespace hpx::execution::experimental::detail {
                !hpx::execution::experimental::detail::
                     is_completion_scheduler_tag_invocable_v<
                         hpx::execution::experimental::set_value_t,
-                        U, Tag
-                    >
+                        U, Tag, Ts...>
             )>
         // clang-format on
         friend constexpr HPX_FORCEINLINE auto operator|(

--- a/libs/core/execution/include/hpx/execution/algorithms/ensure_started.hpp
+++ b/libs/core/execution/include/hpx/execution/algorithms/ensure_started.hpp
@@ -89,10 +89,13 @@ namespace hpx::execution::experimental {
             hpx::execution::experimental::run_loop_scheduler const& sched,
             Sender&& sender, Allocator const& allocator = {})
         {
-            return detail::split_sender<Sender, Allocator,
+            auto split_sender = detail::split_sender<Sender, Allocator,
                 detail::submission_type::eager,
                 hpx::execution::experimental::run_loop_scheduler>{
                 HPX_FORWARD(Sender, sender), allocator, sched};
+
+            sched.get_run_loop().run();
+            return split_sender;
         }
 
         // clang-format off

--- a/libs/core/execution/include/hpx/execution/algorithms/let_error.hpp
+++ b/libs/core/execution/include/hpx/execution/algorithms/let_error.hpp
@@ -136,6 +136,24 @@ namespace hpx::execution::experimental {
                 let_error_sender const&, Env) noexcept
                 -> generate_completion_signatures<Env>;
 
+            // clang-format off
+            template <typename CPO,
+                HPX_CONCEPT_REQUIRES_(
+                    hpx::execution::experimental::detail::is_receiver_cpo_v<CPO> &&
+                    hpx::execution::experimental::detail::has_completion_scheduler_v<
+                        CPO, predecessor_sender_t>
+                )>
+            // clang-format on
+            friend constexpr auto tag_invoke(
+                hpx::execution::experimental::get_completion_scheduler_t<CPO>
+                    tag,
+                let_error_sender const& sender)
+            {
+                return tag(sender.predecessor_sender);
+            }
+
+            // TODO: add forwarding_sender_query
+
             template <typename Receiver>
             struct operation_state
             {

--- a/libs/core/execution/include/hpx/execution/algorithms/let_error.hpp
+++ b/libs/core/execution/include/hpx/execution/algorithms/let_error.hpp
@@ -12,7 +12,9 @@
 #include <hpx/concepts/concepts.hpp>
 #include <hpx/datastructures/variant.hpp>
 #include <hpx/errors/try_catch_exception_ptr.hpp>
+#include <hpx/execution/algorithms/detail/inject_scheduler.hpp>
 #include <hpx/execution/algorithms/detail/partial_algorithm.hpp>
+#include <hpx/execution/algorithms/run_loop.hpp>
 #include <hpx/execution_base/completion_scheduler.hpp>
 #include <hpx/execution_base/completion_signatures.hpp>
 #include <hpx/execution_base/get_env.hpp>
@@ -33,13 +35,15 @@ namespace hpx::execution::experimental {
 
     namespace detail {
 
-        template <typename PredecessorSender, typename F>
+        template <typename PredecessorSender, typename F,
+            typename Scheduler = no_scheduler>
         struct let_error_sender
         {
             using predecessor_sender_t = std::decay_t<PredecessorSender>;
 
             HPX_NO_UNIQUE_ADDRESS predecessor_sender_t predecessor_sender;
             HPX_NO_UNIQUE_ADDRESS std::decay_t<F> f;
+            HPX_NO_UNIQUE_ADDRESS std::decay_t<Scheduler> scheduler;
 
             template <typename Env = empty_env>
             struct generate_completion_signatures
@@ -137,8 +141,9 @@ namespace hpx::execution::experimental {
                 -> generate_completion_signatures<Env>;
 
             // clang-format off
-            template <typename CPO,
+            template <typename CPO, typename Scheduler_ = Scheduler,
                 HPX_CONCEPT_REQUIRES_(
+                   !hpx::execution::experimental::is_scheduler_v<Scheduler_> &&
                     hpx::execution::experimental::detail::is_receiver_cpo_v<CPO> &&
                     hpx::execution::experimental::detail::has_completion_scheduler_v<
                         CPO, predecessor_sender_t>
@@ -150,6 +155,20 @@ namespace hpx::execution::experimental {
                 let_error_sender const& sender)
             {
                 return tag(sender.predecessor_sender);
+            }
+
+            // clang-format off
+            template <typename CPO, typename Scheduler_ = Scheduler,
+                HPX_CONCEPT_REQUIRES_(
+                    hpx::execution::experimental::is_scheduler_v<Scheduler_> &&
+                    hpx::execution::experimental::detail::is_receiver_cpo_v<CPO>
+                )>
+            // clang-format on
+            friend constexpr auto tag_invoke(
+                hpx::execution::experimental::get_completion_scheduler_t<CPO>,
+                let_error_sender const& sender)
+            {
+                return sender.scheduler;
             }
 
             // TODO: add forwarding_sender_query
@@ -398,6 +417,22 @@ namespace hpx::execution::experimental {
         // clang-format off
         template <typename PredecessorSender, typename F,
             HPX_CONCEPT_REQUIRES_(
+                hpx::execution::experimental::is_sender_v<PredecessorSender>
+            )>
+        // clang-format on
+        friend constexpr HPX_FORCEINLINE auto tag_invoke(let_error_t,
+            hpx::execution::experimental::run_loop_scheduler const& sched,
+            PredecessorSender&& predecessor_sender, F&& f)
+        {
+            return detail::let_error_sender<PredecessorSender, F,
+                hpx::execution::experimental::run_loop_scheduler>{
+                HPX_FORWARD(PredecessorSender, predecessor_sender),
+                HPX_FORWARD(F, f), sched};
+        }
+
+        // clang-format off
+        template <typename PredecessorSender, typename F,
+            HPX_CONCEPT_REQUIRES_(
                 is_sender_v<PredecessorSender>
             )>
         // clang-format on
@@ -406,7 +441,21 @@ namespace hpx::execution::experimental {
         {
             return detail::let_error_sender<PredecessorSender, F>{
                 HPX_FORWARD(PredecessorSender, predecessor_sender),
-                HPX_FORWARD(F, f)};
+                HPX_FORWARD(F, f), detail::no_scheduler{}};
+        }
+
+        // clang-format off
+        template <typename F, typename Scheduler,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::execution::experimental::is_scheduler_v<Scheduler>
+            )>
+        // clang-format on
+        friend constexpr HPX_FORCEINLINE auto tag_fallback_invoke(
+            let_error_t, Scheduler&& scheduler, F&& f)
+        {
+            return hpx::execution::experimental::detail::inject_scheduler<
+                let_error_t, Scheduler, F>{
+                HPX_FORWARD(Scheduler, scheduler), HPX_FORWARD(F, f)};
         }
 
         template <typename F>

--- a/libs/core/execution/include/hpx/execution/algorithms/let_stopped.hpp
+++ b/libs/core/execution/include/hpx/execution/algorithms/let_stopped.hpp
@@ -107,6 +107,24 @@ namespace hpx::execution::experimental {
                 let_stopped_sender const&, Env) noexcept
                 -> generate_completion_signatures<Env>;
 
+            // clang-format off
+            template <typename CPO,
+                HPX_CONCEPT_REQUIRES_(
+                    hpx::execution::experimental::detail::is_receiver_cpo_v<CPO> &&
+                    hpx::execution::experimental::detail::has_completion_scheduler_v<
+                        CPO, predecessor_sender_t>
+                )>
+            // clang-format on
+            friend constexpr auto tag_invoke(
+                hpx::execution::experimental::get_completion_scheduler_t<CPO>
+                    tag,
+                let_stopped_sender const& sender)
+            {
+                return tag(sender.predecessor_sender);
+            }
+
+            // TODO: add forwarding_sender_query
+
             template <typename Receiver>
             struct operation_state
             {

--- a/libs/core/execution/include/hpx/execution/algorithms/let_value.hpp
+++ b/libs/core/execution/include/hpx/execution/algorithms/let_value.hpp
@@ -126,6 +126,24 @@ namespace hpx::execution::experimental {
                 let_value_sender const&, Env) noexcept
                 -> generate_completion_signatures<Env>;
 
+            // clang-format off
+            template <typename CPO,
+                HPX_CONCEPT_REQUIRES_(
+                    hpx::execution::experimental::detail::is_receiver_cpo_v<CPO> &&
+                    hpx::execution::experimental::detail::has_completion_scheduler_v<
+                        CPO, predecessor_sender_t>
+                )>
+            // clang-format on
+            friend constexpr auto tag_invoke(
+                hpx::execution::experimental::get_completion_scheduler_t<CPO>
+                    tag,
+                let_value_sender const& sender)
+            {
+                return tag(sender.predecessor_sender);
+            }
+
+            // TODO: add forwarding_sender_query
+
             template <typename Receiver>
             struct operation_state
             {

--- a/libs/core/execution/include/hpx/execution/algorithms/let_value.hpp
+++ b/libs/core/execution/include/hpx/execution/algorithms/let_value.hpp
@@ -13,7 +13,9 @@
 #include <hpx/datastructures/tuple.hpp>
 #include <hpx/datastructures/variant.hpp>
 #include <hpx/errors/try_catch_exception_ptr.hpp>
+#include <hpx/execution/algorithms/detail/inject_scheduler.hpp>
 #include <hpx/execution/algorithms/detail/partial_algorithm.hpp>
+#include <hpx/execution/algorithms/run_loop.hpp>
 #include <hpx/execution_base/completion_scheduler.hpp>
 #include <hpx/execution_base/completion_signatures.hpp>
 #include <hpx/execution_base/get_env.hpp>
@@ -35,13 +37,15 @@ namespace hpx::execution::experimental {
 
     namespace detail {
 
-        template <typename PredecessorSender, typename F>
+        template <typename PredecessorSender, typename F,
+            typename Scheduler = no_scheduler>
         struct let_value_sender
         {
             using predecessor_sender_t = std::decay_t<PredecessorSender>;
 
             HPX_NO_UNIQUE_ADDRESS predecessor_sender_t predecessor_sender;
             HPX_NO_UNIQUE_ADDRESS std::decay_t<F> f;
+            HPX_NO_UNIQUE_ADDRESS std::decay_t<Scheduler> scheduler;
 
             template <typename Env = empty_env>
             struct generate_completion_signatures
@@ -127,8 +131,9 @@ namespace hpx::execution::experimental {
                 -> generate_completion_signatures<Env>;
 
             // clang-format off
-            template <typename CPO,
+            template <typename CPO, typename Scheduler_ = Scheduler,
                 HPX_CONCEPT_REQUIRES_(
+                   !hpx::execution::experimental::is_scheduler_v<Scheduler_> &&
                     hpx::execution::experimental::detail::is_receiver_cpo_v<CPO> &&
                     hpx::execution::experimental::detail::has_completion_scheduler_v<
                         CPO, predecessor_sender_t>
@@ -140,6 +145,20 @@ namespace hpx::execution::experimental {
                 let_value_sender const& sender)
             {
                 return tag(sender.predecessor_sender);
+            }
+
+            // clang-format off
+            template <typename CPO, typename Scheduler_ = Scheduler,
+                HPX_CONCEPT_REQUIRES_(
+                    hpx::execution::experimental::is_scheduler_v<Scheduler_> &&
+                    hpx::execution::experimental::detail::is_receiver_cpo_v<CPO>
+                )>
+            // clang-format on
+            friend constexpr auto tag_invoke(
+                hpx::execution::experimental::get_completion_scheduler_t<CPO>,
+                let_value_sender const& sender)
+            {
+                return sender.scheduler;
             }
 
             // TODO: add forwarding_sender_query
@@ -392,7 +411,7 @@ namespace hpx::execution::experimental {
         // clang-format off
         template <typename PredecessorSender, typename F,
             HPX_CONCEPT_REQUIRES_(
-                is_sender_v<PredecessorSender> &&
+                hpx::execution::experimental::is_sender_v<PredecessorSender> &&
                 experimental::detail::is_completion_scheduler_tag_invocable_v<
                     hpx::execution::experimental::set_value_t,
                     PredecessorSender, let_value_t, F
@@ -416,7 +435,23 @@ namespace hpx::execution::experimental {
         // clang-format off
         template <typename PredecessorSender, typename F,
             HPX_CONCEPT_REQUIRES_(
-                is_sender_v<PredecessorSender>
+                hpx::execution::experimental::is_sender_v<PredecessorSender>
+            )>
+        // clang-format on
+        friend constexpr HPX_FORCEINLINE auto tag_invoke(let_value_t,
+            hpx::execution::experimental::run_loop_scheduler const& sched,
+            PredecessorSender&& predecessor_sender, F&& f)
+        {
+            return detail::let_value_sender<PredecessorSender, F,
+                hpx::execution::experimental::run_loop_scheduler>{
+                HPX_FORWARD(PredecessorSender, predecessor_sender),
+                HPX_FORWARD(F, f), sched};
+        }
+
+        // clang-format off
+        template <typename PredecessorSender, typename F,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::execution::experimental::is_sender_v<PredecessorSender>
             )>
         // clang-format on
         friend constexpr HPX_FORCEINLINE auto tag_fallback_invoke(
@@ -424,7 +459,21 @@ namespace hpx::execution::experimental {
         {
             return detail::let_value_sender<PredecessorSender, F>{
                 HPX_FORWARD(PredecessorSender, predecessor_sender),
-                HPX_FORWARD(F, f)};
+                HPX_FORWARD(F, f), detail::no_scheduler{}};
+        }
+
+        // clang-format off
+        template <typename F, typename Scheduler,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::execution::experimental::is_scheduler_v<Scheduler>
+            )>
+        // clang-format on
+        friend constexpr HPX_FORCEINLINE auto tag_fallback_invoke(
+            let_value_t, Scheduler&& scheduler, F&& f)
+        {
+            return hpx::execution::experimental::detail::inject_scheduler<
+                let_value_t, Scheduler, F>{
+                HPX_FORWARD(Scheduler, scheduler), HPX_FORWARD(F, f)};
         }
 
         template <typename F>

--- a/libs/core/execution/include/hpx/execution/algorithms/make_future.hpp
+++ b/libs/core/execution/include/hpx/execution/algorithms/make_future.hpp
@@ -116,7 +116,7 @@ namespace hpx::execution::experimental {
                     no_addref, alloc)
               , op_state(hpx::execution::experimental::connect(
                     HPX_FORWARD(Sender, sender),
-                    detail::future_receiver<T, Allocator>{this}))
+                    detail::future_receiver<T, Allocator>{{this}}))
             {
                 hpx::execution::experimental::start(op_state);
             }

--- a/libs/core/execution/include/hpx/execution/algorithms/make_future.hpp
+++ b/libs/core/execution/include/hpx/execution/algorithms/make_future.hpp
@@ -11,11 +11,15 @@
 #include <hpx/allocator_support/internal_allocator.hpp>
 #include <hpx/allocator_support/traits/is_allocator.hpp>
 #include <hpx/errors/try_catch_exception_ptr.hpp>
+#include <hpx/execution/algorithms/detail/inject_scheduler.hpp>
 #include <hpx/execution/algorithms/detail/partial_algorithm.hpp>
 #include <hpx/execution/algorithms/detail/single_result.hpp>
+#include <hpx/execution/algorithms/run_loop.hpp>
 #include <hpx/execution_base/completion_signatures.hpp>
 #include <hpx/execution_base/operation_state.hpp>
+#include <hpx/execution_base/receiver.hpp>
 #include <hpx/execution_base/sender.hpp>
+#include <hpx/functional/detail/tag_priority_invoke.hpp>
 #include <hpx/functional/invoke_result.hpp>
 #include <hpx/futures/detail/future_data.hpp>
 #include <hpx/futures/promise.hpp>
@@ -25,20 +29,32 @@
 
 #include <exception>
 #include <memory>
+#include <type_traits>
 #include <utility>
 
 namespace hpx::execution::experimental {
 
     namespace detail {
 
-        template <typename T, typename Allocator>
-        struct make_future_receiver
+        template <typename Data>
+        struct future_receiver_base
         {
-            hpx::intrusive_ptr<
-                hpx::lcos::detail::future_data_allocator<T, Allocator>>
-                data;
+            hpx::intrusive_ptr<Data> data;
 
-            friend void tag_invoke(set_error_t, make_future_receiver&& r,
+        protected:
+            template <typename U>
+            void set_value(U&& u) && noexcept
+            {
+                hpx::detail::try_catch_exception_ptr(
+                    [&]() { data->set_value(HPX_FORWARD(U, u)); },
+                    [&](std::exception_ptr ep) {
+                        data->set_exception(HPX_MOVE(ep));
+                    });
+                data.reset();
+            }
+
+        private:
+            friend void tag_invoke(set_error_t, future_receiver_base&& r,
                 std::exception_ptr ep) noexcept
             {
                 r.data->set_exception(HPX_MOVE(ep));
@@ -46,53 +62,35 @@ namespace hpx::execution::experimental {
             }
 
             friend void tag_invoke(
-                set_stopped_t, make_future_receiver&&) noexcept
+                set_stopped_t, future_receiver_base&&) noexcept
             {
                 std::terminate();
             }
+        };
 
+        template <typename T, typename Allocator>
+        struct future_receiver
+          : future_receiver_base<
+                hpx::lcos::detail::future_data_allocator<T, Allocator>>
+        {
+        private:
             template <typename U>
             friend void tag_invoke(
-                set_value_t, make_future_receiver&& r, U&& u) noexcept
+                set_value_t, future_receiver&& r, U&& u) noexcept
             {
-                hpx::detail::try_catch_exception_ptr(
-                    [&]() { r.data->set_value(HPX_FORWARD(U, u)); },
-                    [&](std::exception_ptr ep) {
-                        r.data->set_exception(HPX_MOVE(ep));
-                    });
-                r.data.reset();
+                HPX_MOVE(r).set_value(HPX_FORWARD(U, u));
             }
         };
 
         template <typename Allocator>
-        struct make_future_receiver<void, Allocator>
-        {
-            hpx::intrusive_ptr<
+        struct future_receiver<void, Allocator>
+          : future_receiver_base<
                 hpx::lcos::detail::future_data_allocator<void, Allocator>>
-                data;
-
-            friend void tag_invoke(set_error_t, make_future_receiver&& r,
-                std::exception_ptr ep) noexcept
+        {
+        private:
+            friend void tag_invoke(set_value_t, future_receiver&& r) noexcept
             {
-                r.data->set_exception(HPX_MOVE(ep));
-                r.data.reset();
-            }
-
-            friend void tag_invoke(
-                set_stopped_t, make_future_receiver&&) noexcept
-            {
-                std::terminate();
-            }
-
-            friend void tag_invoke(
-                set_value_t, make_future_receiver&& r) noexcept
-            {
-                hpx::detail::try_catch_exception_ptr(
-                    [&]() { r.data->set_value(hpx::util::unused); },
-                    [&](std::exception_ptr ep) {
-                        r.data->set_exception(HPX_MOVE(ep));
-                    });
-                r.data.reset();
+                HPX_MOVE(r).set_value(hpx::util::unused);
             }
         };
 
@@ -118,9 +116,43 @@ namespace hpx::execution::experimental {
                     no_addref, alloc)
               , op_state(hpx::execution::experimental::connect(
                     HPX_FORWARD(Sender, sender),
-                    detail::make_future_receiver<T, Allocator>{this}))
+                    detail::future_receiver<T, Allocator>{this}))
             {
                 hpx::execution::experimental::start(op_state);
+            }
+        };
+
+        template <typename T, typename Allocator, typename OperationState>
+        struct future_data_with_run_loop
+          : future_data<T, Allocator, OperationState>
+        {
+            hpx::execution::experimental::run_loop& loop;
+
+            using base_type = future_data<T, Allocator, OperationState>;
+            using init_no_addref = typename base_type::init_no_addref;
+            using other_allocator = typename base_type::other_allocator;
+
+            template <typename Sender>
+            future_data_with_run_loop(init_no_addref no_addref,
+                other_allocator const& alloc,
+                hpx::execution::experimental::run_loop_scheduler const& sched,
+                Sender&& sender)
+              : base_type(no_addref, alloc, HPX_FORWARD(Sender, sender))
+              , loop(sched.get_run_loop())
+            {
+                this->set_on_completed([this]() { loop.finish(); });
+            }
+
+            hpx::util::unused_type* get_result_void(
+                error_code& ec = throws) override
+            {
+                execute_deferred(ec);
+                return this->base_type::get_result_void(ec);
+            }
+
+            void execute_deferred(error_code& = throws) override
+            {
+                loop.run();
             }
         };
 
@@ -138,10 +170,10 @@ namespace hpx::execution::experimental {
                 std::decay_t<detail::single_result_t<value_types>>;
             using operation_state_type = hpx::util::invoke_result_t<
                 hpx::execution::experimental::connect_t, Sender,
-                detail::make_future_receiver<result_type, allocator_type>>;
+                detail::future_receiver<result_type, allocator_type>>;
 
-            using shared_state = detail::future_data<result_type,
-                allocator_type, operation_state_type>;
+            using shared_state =
+                future_data<result_type, allocator_type, operation_state_type>;
             using init_no_addref = typename shared_state::init_no_addref;
             using other_allocator = typename std::allocator_traits<
                 allocator_type>::template rebind_alloc<shared_state>;
@@ -155,6 +187,44 @@ namespace hpx::execution::experimental {
 
             allocator_traits::construct(alloc, p.get(), init_no_addref{}, alloc,
                 HPX_FORWARD(Sender, sender));
+
+            return hpx::traits::future_access<future<result_type>>::create(
+                p.release(), false);
+        }
+
+        ///////////////////////////////////////////////////////////////////////
+        template <typename Sender, typename Allocator>
+        auto make_future_with_run_loop(
+            hpx::execution::experimental::run_loop_scheduler const& sched,
+            Sender&& sender, Allocator const& allocator)
+        {
+            using allocator_type = Allocator;
+
+            using value_types = hpx::execution::experimental::value_types_of_t<
+                std::decay_t<Sender>, hpx::execution::experimental::empty_env,
+                meta::pack, meta::pack>;
+
+            using result_type =
+                std::decay_t<detail::single_result_t<value_types>>;
+            using operation_state_type = hpx::util::invoke_result_t<
+                hpx::execution::experimental::connect_t, Sender,
+                detail::future_receiver<result_type, allocator_type>>;
+
+            using shared_state = future_data_with_run_loop<result_type,
+                allocator_type, operation_state_type>;
+            using init_no_addref = typename shared_state::init_no_addref;
+            using other_allocator = typename std::allocator_traits<
+                allocator_type>::template rebind_alloc<shared_state>;
+            using allocator_traits = std::allocator_traits<other_allocator>;
+            using unique_ptr = std::unique_ptr<shared_state,
+                util::allocator_deleter<other_allocator>>;
+
+            other_allocator alloc(allocator);
+            unique_ptr p(allocator_traits::allocate(alloc, 1),
+                hpx::util::allocator_deleter<other_allocator>{alloc});
+
+            allocator_traits::construct(alloc, p.get(), init_no_addref{}, alloc,
+                sched, HPX_FORWARD(Sender, sender));
 
             return hpx::traits::future_access<future<result_type>>::create(
                 p.release(), false);
@@ -180,9 +250,47 @@ namespace hpx::execution::experimental {
     // make_future calls std::terminate.
     //
     inline constexpr struct make_future_t final
-      : hpx::functional::detail::tag_fallback<make_future_t>
+      : hpx::functional::detail::tag_priority<make_future_t>
     {
     private:
+        // clang-format off
+        template <typename Sender,
+            typename Allocator = hpx::util::internal_allocator<>,
+            HPX_CONCEPT_REQUIRES_(
+                is_sender_v<Sender> &&
+                hpx::traits::is_allocator_v<Allocator> &&
+                experimental::detail::is_completion_scheduler_tag_invocable_v<
+                    hpx::execution::experimental::set_value_t,
+                    Sender, make_future_t, Allocator
+                >
+            )>
+        // clang-format on
+        friend constexpr HPX_FORCEINLINE auto tag_override_invoke(make_future_t,
+            Sender&& sender, Allocator const& allocator = Allocator{})
+        {
+            auto scheduler =
+                hpx::execution::experimental::get_completion_scheduler<
+                    hpx::execution::experimental::set_value_t>(sender);
+
+            return hpx::functional::tag_invoke(make_future_t{},
+                HPX_MOVE(scheduler), HPX_FORWARD(Sender, sender), allocator);
+        }
+
+        // clang-format off
+        template <typename Sender,
+            typename Allocator = hpx::util::internal_allocator<>,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::execution::experimental::is_sender_v<Sender>
+            )>
+        // clang-format on
+        friend auto tag_invoke(make_future_t,
+            hpx::execution::experimental::run_loop_scheduler const& sched,
+            Sender&& sender, Allocator const& allocator = Allocator{})
+        {
+            return detail::make_future_with_run_loop(
+                sched, HPX_FORWARD(Sender, sender), allocator);
+        }
+
         // clang-format off
         template <typename Sender,
             typename Allocator = hpx::util::internal_allocator<>,
@@ -195,6 +303,22 @@ namespace hpx::execution::experimental {
             Sender&& sender, Allocator const& allocator = Allocator{})
         {
             return detail::make_future(HPX_FORWARD(Sender, sender), allocator);
+        }
+
+        // clang-format off
+        template <typename Scheduler,
+            typename Allocator = hpx::util::internal_allocator<>,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::execution::experimental::is_scheduler_v<Scheduler> &&
+                hpx::traits::is_allocator_v<Allocator>
+            )>
+        // clang-format on
+        friend constexpr HPX_FORCEINLINE auto tag_fallback_invoke(make_future_t,
+            Scheduler&& scheduler, Allocator const& allocator = Allocator{})
+        {
+            return hpx::execution::experimental::detail::inject_scheduler<
+                make_future_t, Scheduler, Allocator>{
+                HPX_FORWARD(Scheduler, scheduler), allocator};
         }
 
         // clang-format off

--- a/libs/core/execution/include/hpx/execution/algorithms/make_future.hpp
+++ b/libs/core/execution/include/hpx/execution/algorithms/make_future.hpp
@@ -32,204 +32,231 @@
 #include <type_traits>
 #include <utility>
 
-namespace hpx::execution::experimental {
+namespace hpx::execution::experimental { namespace detail {
 
-    namespace detail {
+    template <typename Data>
+    struct future_receiver_base
+    {
+        hpx::intrusive_ptr<Data> data;
 
-        template <typename Data>
-        struct future_receiver_base
+    protected:
+        template <typename U>
+        void set_value(U&& u) && noexcept
         {
-            hpx::intrusive_ptr<Data> data;
-
-        protected:
-            template <typename U>
-            void set_value(U&& u) && noexcept
-            {
-                hpx::detail::try_catch_exception_ptr(
-                    [&]() { data->set_value(HPX_FORWARD(U, u)); },
-                    [&](std::exception_ptr ep) {
-                        data->set_exception(HPX_MOVE(ep));
-                    });
-                data.reset();
-            }
-
-        private:
-            friend void tag_invoke(set_error_t, future_receiver_base&& r,
-                std::exception_ptr ep) noexcept
-            {
-                r.data->set_exception(HPX_MOVE(ep));
-                r.data.reset();
-            }
-
-            friend void tag_invoke(
-                set_stopped_t, future_receiver_base&&) noexcept
-            {
-                std::terminate();
-            }
-        };
-
-        template <typename T, typename Allocator>
-        struct future_receiver
-          : future_receiver_base<
-                hpx::lcos::detail::future_data_allocator<T, Allocator>>
-        {
-        private:
-            template <typename U>
-            friend void tag_invoke(
-                set_value_t, future_receiver&& r, U&& u) noexcept
-            {
-                HPX_MOVE(r).set_value(HPX_FORWARD(U, u));
-            }
-        };
-
-        template <typename Allocator>
-        struct future_receiver<void, Allocator>
-          : future_receiver_base<
-                hpx::lcos::detail::future_data_allocator<void, Allocator>>
-        {
-        private:
-            friend void tag_invoke(set_value_t, future_receiver&& r) noexcept
-            {
-                HPX_MOVE(r).set_value(hpx::util::unused);
-            }
-        };
-
-        template <typename T, typename Allocator, typename OperationState>
-        struct future_data
-          : hpx::lcos::detail::future_data_allocator<T, Allocator>
-        {
-            HPX_NON_COPYABLE(future_data);
-
-            using operation_state_type = std::decay_t<OperationState>;
-            using init_no_addref =
-                typename hpx::lcos::detail::future_data_allocator<T,
-                    Allocator>::init_no_addref;
-            using other_allocator = typename std::allocator_traits<
-                Allocator>::template rebind_alloc<future_data>;
-
-            operation_state_type op_state;
-
-            template <typename Sender>
-            future_data(init_no_addref no_addref, other_allocator const& alloc,
-                Sender&& sender)
-              : hpx::lcos::detail::future_data_allocator<T, Allocator>(
-                    no_addref, alloc)
-              , op_state(hpx::execution::experimental::connect(
-                    HPX_FORWARD(Sender, sender),
-                    detail::future_receiver<T, Allocator>{{this}}))
-            {
-                hpx::execution::experimental::start(op_state);
-            }
-        };
-
-        template <typename T, typename Allocator, typename OperationState>
-        struct future_data_with_run_loop
-          : future_data<T, Allocator, OperationState>
-        {
-            hpx::execution::experimental::run_loop& loop;
-
-            using base_type = future_data<T, Allocator, OperationState>;
-            using init_no_addref = typename base_type::init_no_addref;
-            using other_allocator = typename base_type::other_allocator;
-
-            template <typename Sender>
-            future_data_with_run_loop(init_no_addref no_addref,
-                other_allocator const& alloc,
-                hpx::execution::experimental::run_loop_scheduler const& sched,
-                Sender&& sender)
-              : base_type(no_addref, alloc, HPX_FORWARD(Sender, sender))
-              , loop(sched.get_run_loop())
-            {
-                this->set_on_completed([this]() { loop.finish(); });
-            }
-
-            hpx::util::unused_type* get_result_void(
-                error_code& ec = throws) override
-            {
-                execute_deferred(ec);
-                return this->base_type::get_result_void(ec);
-            }
-
-            void execute_deferred(error_code& = throws) override
-            {
-                loop.run();
-            }
-        };
-
-        ///////////////////////////////////////////////////////////////////////
-        template <typename Sender, typename Allocator>
-        auto make_future(Sender&& sender, Allocator const& allocator)
-        {
-            using allocator_type = Allocator;
-
-            using value_types = hpx::execution::experimental::value_types_of_t<
-                std::decay_t<Sender>, hpx::execution::experimental::empty_env,
-                meta::pack, meta::pack>;
-
-            using result_type =
-                std::decay_t<detail::single_result_t<value_types>>;
-            using operation_state_type = hpx::util::invoke_result_t<
-                hpx::execution::experimental::connect_t, Sender,
-                detail::future_receiver<result_type, allocator_type>>;
-
-            using shared_state =
-                future_data<result_type, allocator_type, operation_state_type>;
-            using init_no_addref = typename shared_state::init_no_addref;
-            using other_allocator = typename std::allocator_traits<
-                allocator_type>::template rebind_alloc<shared_state>;
-            using allocator_traits = std::allocator_traits<other_allocator>;
-            using unique_ptr = std::unique_ptr<shared_state,
-                util::allocator_deleter<other_allocator>>;
-
-            other_allocator alloc(allocator);
-            unique_ptr p(allocator_traits::allocate(alloc, 1),
-                hpx::util::allocator_deleter<other_allocator>{alloc});
-
-            allocator_traits::construct(alloc, p.get(), init_no_addref{}, alloc,
-                HPX_FORWARD(Sender, sender));
-
-            return hpx::traits::future_access<future<result_type>>::create(
-                p.release(), false);
+            hpx::detail::try_catch_exception_ptr(
+                [&]() { data->set_value(HPX_FORWARD(U, u)); },
+                [&](std::exception_ptr ep) {
+                    data->set_exception(HPX_MOVE(ep));
+                });
+            data.reset();
         }
 
-        ///////////////////////////////////////////////////////////////////////
-        template <typename Sender, typename Allocator>
-        auto make_future_with_run_loop(
+    private:
+        friend void tag_invoke(set_error_t, future_receiver_base&& r,
+            std::exception_ptr ep) noexcept
+        {
+            r.data->set_exception(HPX_MOVE(ep));
+            r.data.reset();
+        }
+
+        friend void tag_invoke(set_stopped_t, future_receiver_base&&) noexcept
+        {
+            std::terminate();
+        }
+    };
+
+    template <typename T>
+    struct future_receiver
+      : future_receiver_base<hpx::lcos::detail::future_data_base<T>>
+    {
+    private:
+        template <typename U>
+        friend void tag_invoke(set_value_t, future_receiver&& r, U&& u) noexcept
+        {
+            HPX_MOVE(r).set_value(HPX_FORWARD(U, u));
+        }
+    };
+
+    template <>
+    struct future_receiver<void>
+      : future_receiver_base<hpx::lcos::detail::future_data_base<void>>
+    {
+    private:
+        friend void tag_invoke(set_value_t, future_receiver&& r) noexcept
+        {
+            HPX_MOVE(r).set_value(hpx::util::unused);
+        }
+    };
+
+    template <typename T, typename Allocator, typename OperationState,
+        typename Derived = void>
+    struct future_data
+      : hpx::lcos::detail::future_data_allocator<T, Allocator,
+            std::conditional_t<std::is_void_v<Derived>,
+                future_data<T, Allocator, OperationState, Derived>, Derived>>
+    {
+        HPX_NON_COPYABLE(future_data);
+
+        using derived_type =
+            std::conditional_t<std::is_void_v<Derived>, future_data, Derived>;
+        using base_type = hpx::lcos::detail::future_data_allocator<T, Allocator,
+            derived_type>;
+        using operation_state_type = std::decay_t<OperationState>;
+        using init_no_addref = typename base_type::init_no_addref;
+        using other_allocator = typename std::allocator_traits<
+            Allocator>::template rebind_alloc<future_data>;
+
+        operation_state_type op_state;
+
+        template <typename Sender>
+        future_data(init_no_addref no_addref, other_allocator const& alloc,
+            Sender&& sender)
+          : base_type(no_addref, alloc)
+          , op_state(hpx::execution::experimental::connect(
+                HPX_FORWARD(Sender, sender),
+                detail::future_receiver<T>{{this}}))
+        {
+            hpx::execution::experimental::start(op_state);
+        }
+    };
+
+    template <typename T, typename Allocator, typename OperationState>
+    struct future_data_with_run_loop
+      : future_data<T, Allocator, OperationState,
+            future_data_with_run_loop<T, Allocator, OperationState>>
+    {
+        hpx::execution::experimental::run_loop& loop;
+
+        using base_type = future_data<T, Allocator, OperationState,
+            future_data_with_run_loop>;
+        using init_no_addref = typename base_type::init_no_addref;
+        using other_allocator = typename base_type::other_allocator;
+
+        template <typename Sender>
+        future_data_with_run_loop(init_no_addref no_addref,
+            other_allocator const& alloc,
             hpx::execution::experimental::run_loop_scheduler const& sched,
-            Sender&& sender, Allocator const& allocator)
+            Sender&& sender)
+          : base_type(no_addref, alloc, HPX_FORWARD(Sender, sender))
+          , loop(sched.get_run_loop())
         {
-            using allocator_type = Allocator;
-
-            using value_types = hpx::execution::experimental::value_types_of_t<
-                std::decay_t<Sender>, hpx::execution::experimental::empty_env,
-                meta::pack, meta::pack>;
-
-            using result_type =
-                std::decay_t<detail::single_result_t<value_types>>;
-            using operation_state_type = hpx::util::invoke_result_t<
-                hpx::execution::experimental::connect_t, Sender,
-                detail::future_receiver<result_type, allocator_type>>;
-
-            using shared_state = future_data_with_run_loop<result_type,
-                allocator_type, operation_state_type>;
-            using init_no_addref = typename shared_state::init_no_addref;
-            using other_allocator = typename std::allocator_traits<
-                allocator_type>::template rebind_alloc<shared_state>;
-            using allocator_traits = std::allocator_traits<other_allocator>;
-            using unique_ptr = std::unique_ptr<shared_state,
-                util::allocator_deleter<other_allocator>>;
-
-            other_allocator alloc(allocator);
-            unique_ptr p(allocator_traits::allocate(alloc, 1),
-                hpx::util::allocator_deleter<other_allocator>{alloc});
-
-            allocator_traits::construct(alloc, p.get(), init_no_addref{}, alloc,
-                sched, HPX_FORWARD(Sender, sender));
-
-            return hpx::traits::future_access<future<result_type>>::create(
-                p.release(), false);
+            this->set_on_completed([this]() { loop.finish(); });
         }
-    }    // namespace detail
+
+        hpx::util::unused_type* get_result_void(
+            error_code& ec = throws) override
+        {
+            execute_deferred(ec);
+            return this->base_type::get_result_void(ec);
+        }
+
+        void execute_deferred(error_code& = throws) override
+        {
+            loop.run();
+        }
+    };
+
+    ///////////////////////////////////////////////////////////////////////
+    template <typename Sender, typename Allocator>
+    auto make_future(Sender&& sender, Allocator const& allocator)
+    {
+        using allocator_type = Allocator;
+
+        using value_types =
+            hpx::execution::experimental::value_types_of_t<std::decay_t<Sender>,
+                hpx::execution::experimental::empty_env, meta::pack,
+                meta::pack>;
+
+        using result_type = std::decay_t<detail::single_result_t<value_types>>;
+        using operation_state_type =
+            hpx::util::invoke_result_t<hpx::execution::experimental::connect_t,
+                Sender, detail::future_receiver<result_type>>;
+
+        using shared_state =
+            future_data<result_type, allocator_type, operation_state_type>;
+        using init_no_addref = typename shared_state::init_no_addref;
+        using other_allocator = typename std::allocator_traits<
+            allocator_type>::template rebind_alloc<shared_state>;
+        using allocator_traits = std::allocator_traits<other_allocator>;
+        using unique_ptr = std::unique_ptr<shared_state,
+            util::allocator_deleter<other_allocator>>;
+
+        other_allocator alloc(allocator);
+        unique_ptr p(allocator_traits::allocate(alloc, 1),
+            hpx::util::allocator_deleter<other_allocator>{alloc});
+
+        allocator_traits::construct(alloc, p.get(), init_no_addref{}, alloc,
+            HPX_FORWARD(Sender, sender));
+
+        return hpx::traits::future_access<future<result_type>>::create(
+            p.release(), false);
+    }
+
+    ///////////////////////////////////////////////////////////////////////
+    template <typename Sender, typename Allocator>
+    auto make_future_with_run_loop(
+        hpx::execution::experimental::run_loop_scheduler const& sched,
+        Sender&& sender, Allocator const& allocator)
+    {
+        using allocator_type = Allocator;
+
+        using value_types =
+            hpx::execution::experimental::value_types_of_t<std::decay_t<Sender>,
+                hpx::execution::experimental::empty_env, meta::pack,
+                meta::pack>;
+
+        using result_type = std::decay_t<detail::single_result_t<value_types>>;
+        using operation_state_type =
+            hpx::util::invoke_result_t<hpx::execution::experimental::connect_t,
+                Sender, detail::future_receiver<result_type>>;
+
+        using shared_state = future_data_with_run_loop<result_type,
+            allocator_type, operation_state_type>;
+        using init_no_addref = typename shared_state::init_no_addref;
+        using other_allocator = typename std::allocator_traits<
+            allocator_type>::template rebind_alloc<shared_state>;
+        using allocator_traits = std::allocator_traits<other_allocator>;
+        using unique_ptr = std::unique_ptr<shared_state,
+            util::allocator_deleter<other_allocator>>;
+
+        other_allocator alloc(allocator);
+        unique_ptr p(allocator_traits::allocate(alloc, 1),
+            hpx::util::allocator_deleter<other_allocator>{alloc});
+
+        allocator_traits::construct(alloc, p.get(), init_no_addref{}, alloc,
+            sched, HPX_FORWARD(Sender, sender));
+
+        return hpx::traits::future_access<future<result_type>>::create(
+            p.release(), false);
+    }
+}}    // namespace hpx::execution::experimental::detail
+
+namespace hpx { namespace traits { namespace detail {
+
+    template <typename T, typename Allocator, typename OperationState,
+        typename NewAllocator>
+    struct shared_state_allocator<hpx::execution::experimental::detail::
+                                      future_data<T, Allocator, OperationState>,
+        NewAllocator>
+    {
+        using type = hpx::execution::experimental::detail::future_data<T,
+            NewAllocator, OperationState>;
+    };
+
+    template <typename T, typename Allocator, typename OperationState,
+        typename NewAllocator>
+    struct shared_state_allocator<
+        hpx::execution::experimental::detail::future_data_with_run_loop<T,
+            Allocator, OperationState>,
+        NewAllocator>
+    {
+        using type =
+            hpx::execution::experimental::detail::future_data_with_run_loop<T,
+                NewAllocator, OperationState>;
+    };
+}}}    // namespace hpx::traits::detail
+
+namespace hpx::execution::experimental {
 
     ///////////////////////////////////////////////////////////////////////////
     // execution::make_future is a sender consumer that submits the work

--- a/libs/core/execution/include/hpx/execution/algorithms/run_loop.hpp
+++ b/libs/core/execution/include/hpx/execution/algorithms/run_loop.hpp
@@ -1,0 +1,339 @@
+//  Copyright (c) 2022 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include <hpx/config.hpp>
+#include <hpx/assert.hpp>
+#include <hpx/concepts/concepts.hpp>
+#include <hpx/errors/try_catch_exception_ptr.hpp>
+#include <hpx/execution/queries/get_scheduler.hpp>
+#include <hpx/execution/queries/get_stop_token.hpp>
+#include <hpx/execution_base/completion_signatures.hpp>
+#include <hpx/execution_base/execution.hpp>
+#include <hpx/execution_base/get_env.hpp>
+#include <hpx/synchronization/condition_variable.hpp>
+#include <hpx/synchronization/spinlock.hpp>
+#include <hpx/type_support/meta.hpp>
+
+#include <exception>
+#include <mutex>
+
+namespace hpx::execution::experimental {
+
+    // A run_loop is an execution context on which work can be scheduled. It
+    // maintains a simple, thread-safe first-in-first-out queue of work. Its
+    // run() member function removes elements from the queue and executes them
+    // in a loop on whatever thread of execution calls run().
+    //
+    // A run_loop instance has an associated count that corresponds to the
+    // number of work items that are in its queue. Additionally, a run_loop has
+    // an associated state that can be one of starting, running, or finishing.
+    //
+    // Concurrent invocations of the member functions of run_loop, other than
+    // run and its destructor, do not introduce data races. The member functions
+    // pop_front, push_back, and finish execute atomically.
+    //
+    // [Note: Implementations are encouraged to use an intrusive queue of
+    // operation states to hold the work units to make scheduling
+    // allocation-free. -- end note]
+    //
+    class run_loop
+    {
+        struct run_loop_opstate_base
+        {
+            explicit run_loop_opstate_base(run_loop_opstate_base* tail) noexcept
+              : next(this)
+              , tail(tail)
+            {
+            }
+
+            run_loop_opstate_base(run_loop_opstate_base* tail,
+                void (*execute)(run_loop_opstate_base*) noexcept) noexcept
+              : next(tail)
+              , execute_(execute)
+            {
+            }
+
+            run_loop_opstate_base(run_loop_opstate_base&&) = delete;
+            run_loop_opstate_base& operator=(run_loop_opstate_base&&) = delete;
+
+            run_loop_opstate_base* next;
+            union
+            {
+                void (*execute_)(run_loop_opstate_base*) noexcept;
+                run_loop_opstate_base* tail;
+            };
+
+            void execute() noexcept
+            {
+                (*execute_)(this);
+            }
+        };
+
+        template <typename Receiver>
+        struct run_loop_opstate : run_loop_opstate_base
+        {
+            run_loop& loop;
+            HPX_NO_UNIQUE_ADDRESS std::decay_t<Receiver> receiver;
+
+            template <typename Receiver_>
+            run_loop_opstate(run_loop_opstate_base* tail, run_loop& loop,
+                Receiver_&& receiver) noexcept(noexcept(std::
+                    is_nothrow_constructible_v<std::decay_t<Receiver>,
+                        Receiver_>))
+              : run_loop_opstate_base(tail)
+              , loop(loop)
+              , receiver(HPX_FORWARD(Receiver_, receiver))
+            {
+            }
+
+            static void execute(run_loop_opstate_base* p) noexcept
+            {
+                auto& receiver = static_cast<run_loop_opstate*>(p)->receiver;
+                hpx::detail::try_catch_exception_ptr(
+                    [&]() {
+                        if (get_stop_token(get_env(receiver)).stop_requested())
+                        {
+                            hpx::execution::experimental::set_stopped(
+                                HPX_MOVE(receiver));
+                        }
+                        else
+                        {
+                            hpx::execution::experimental::set_value(
+                                HPX_MOVE(receiver));
+                        }
+                    },
+                    [&](std::exception_ptr ep) {
+                        hpx::execution::experimental::set_error(
+                            HPX_MOVE(receiver), HPX_MOVE(ep));
+                    });
+            }
+
+            explicit run_loop_opstate(run_loop_opstate_base* tail) noexcept
+              : run_loop_opstate_base(tail)
+            {
+            }
+
+            run_loop_opstate(
+                run_loop_opstate_base* next, run_loop& loop, Receiver r)
+              : run_loop_opstate_base(next, &execute)
+              , loop(loop)
+              , receiver(HPX_MOVE(r))
+            {
+            }
+
+            friend void tag_invoke(hpx::execution::experimental::start_t,
+                run_loop_opstate& os) noexcept
+            {
+                os.start();
+            }
+
+            void start() noexcept;
+        };
+
+    public:
+        class run_loop_scheduler
+        {
+        public:
+            struct run_loop_sender
+            {
+                explicit run_loop_sender(run_loop& loop) noexcept
+                  : loop(loop)
+                {
+                }
+
+            private:
+                friend run_loop_scheduler;
+
+                template <typename Receiver>
+                using operation_state = run_loop_opstate<Receiver>;
+
+                template <typename Receiver>
+                friend operation_state<Receiver> tag_invoke(
+                    hpx::execution::experimental::connect_t,
+                    run_loop_sender const& s,
+                    Receiver&& receiver) noexcept(noexcept(std::
+                        is_nothrow_constructible_v<operation_state<Receiver>,
+                            run_loop_opstate_base*, run_loop&>))
+                {
+                    return operation_state<Receiver>(
+                        &s.loop.head, s.loop, HPX_FORWARD(Receiver, receiver));
+                }
+
+                // clang-format off
+                template <typename CPO,
+                    HPX_CONCEPT_REQUIRES_(
+                        meta::value<meta::one_of<
+                            std::decay_t<CPO>, set_value_t, set_stopped_t>>
+                    )>
+                // clang-format on
+                friend run_loop_scheduler tag_invoke(
+                    hpx::execution::experimental::get_completion_scheduler_t<
+                        CPO>,
+                    run_loop_sender const& s) noexcept
+                {
+                    return run_loop_scheduler{s.loop};
+                }
+
+                using completion_signatures =
+                    hpx::execution::experimental::completion_signatures<
+                        hpx::execution::experimental::set_value_t(),
+                        hpx::execution::experimental::set_error_t(
+                            std::exception_ptr),
+                        hpx::execution::experimental::set_stopped_t()>;
+
+                template <typename Env>
+                friend auto tag_invoke(
+                    hpx::execution::experimental::get_completion_signatures_t,
+                    run_loop_sender const&, Env) noexcept
+                    -> completion_signatures;
+
+                run_loop& loop;
+            };
+
+            friend run_loop;
+
+        public:
+            explicit run_loop_scheduler(run_loop& loop) noexcept
+              : loop(loop)
+            {
+            }
+
+            run_loop& get_run_loop() const
+            {
+                return loop;
+            }
+
+        private:
+            friend run_loop_sender tag_invoke(
+                hpx::execution::experimental::schedule_t,
+                run_loop_scheduler const& sched) noexcept
+            {
+                return run_loop_sender(sched.loop);
+            }
+
+            friend hpx::execution::experimental::forward_progress_guarantee
+            tag_invoke(
+                hpx::execution::experimental::get_forward_progress_guarantee_t,
+                run_loop_scheduler const&) noexcept
+            {
+                return hpx::execution::experimental::
+                    forward_progress_guarantee::parallel;
+            }
+
+            friend constexpr bool operator==(run_loop_scheduler const& lhs,
+                run_loop_scheduler const& rhs) noexcept
+            {
+                return &lhs.loop == &rhs.loop;
+            }
+            friend constexpr bool operator!=(run_loop_scheduler const& lhs,
+                run_loop_scheduler const& rhs) noexcept
+            {
+                return !(lhs == rhs);
+            }
+
+        private:
+            run_loop& loop;
+        };
+
+    private:
+        friend struct run_loop_scheduler::run_loop_sender;
+
+        hpx::spinlock mtx;
+        hpx::condition_variable cond_var;
+
+        // MSVC doesn't properly handle the friend declaration above
+#if defined(HPX_MSVC)
+    public:
+#endif
+        run_loop_opstate_base head;
+
+    private:
+        bool stop = false;
+
+        void push_back(run_loop_opstate_base* t)
+        {
+            std::unique_lock l(mtx);
+            stop = false;
+            t->next = &head;
+            head.tail = head.tail->next = t;
+            cond_var.notify_one();
+        }
+
+        run_loop_opstate_base* pop_front()
+        {
+            std::unique_lock l(mtx);
+            cond_var.wait(l, [this] { return head.next != &head || stop; });
+            if (head.tail == head.next)
+            {
+                head.tail = &head;
+            }
+
+            // std::exchange(head.next, head.next->next);
+            auto old_val = HPX_MOVE(head.next);
+            head.next = HPX_MOVE(head.next->next);
+            return old_val;
+        }
+
+    public:
+        // [exec.run_loop.ctor] construct/copy/destroy
+        run_loop() noexcept
+          : head(&head)
+        {
+        }
+
+        run_loop(run_loop&&) = delete;
+
+        // If count is not 0 or if state is running, invokes terminate().
+        // Otherwise, has no effects.
+        ~run_loop()
+        {
+            if (head.next != &head || !stop)
+            {
+                std::terminate();
+            }
+        }
+
+        // [exec.run_loop.members] Member functions:
+        run_loop_scheduler get_scheduler()
+        {
+            return run_loop_scheduler(*this);
+        }
+
+        void run()
+        {
+            // Precondition: state is starting.
+            //HPX_ASSERT(head.next != &head || !stop);
+            for (run_loop_opstate_base* t; (t = pop_front()) != &head; /**/)
+            {
+                t->execute();
+            }
+            HPX_ASSERT(stop);    // Postcondition: state is finishing.
+        }
+
+        void finish()
+        {
+            std::unique_lock l(mtx);
+            stop = true;
+            cond_var.notify_all();
+        }
+    };
+
+    using run_loop_scheduler = run_loop::run_loop_scheduler;
+
+    ///////////////////////////////////////////////////////////////////////////
+    template <typename Receiver>
+    inline void run_loop::run_loop_opstate<Receiver>::start() noexcept
+    try
+    {
+        loop.push_back(this);
+    }
+    catch (...)
+    {
+        set_error(HPX_MOVE(receiver), std::current_exception());
+    }
+}    // namespace hpx::execution::experimental

--- a/libs/core/execution/include/hpx/execution/algorithms/schedule_from.hpp
+++ b/libs/core/execution/include/hpx/execution/algorithms/schedule_from.hpp
@@ -86,6 +86,8 @@ namespace hpx::execution::experimental {
                 return sender.scheduler;
             }
 
+            // TODO: add forwarding_sender_query
+
             template <typename Receiver>
             struct operation_state
             {

--- a/libs/core/execution/include/hpx/execution/algorithms/split.hpp
+++ b/libs/core/execution/include/hpx/execution/algorithms/split.hpp
@@ -84,11 +84,6 @@ namespace hpx::execution::experimental {
             }
         };
 
-        // Dummy type used in place of a scheduler if none is given
-        struct no_scheduler
-        {
-        };
-
         template <typename Sender, typename Allocator, submission_type Type,
             typename Scheduler = no_scheduler>
         struct split_sender
@@ -130,7 +125,7 @@ namespace hpx::execution::experimental {
             // clang-format off
             template <typename CPO, typename Scheduler_ = Scheduler,
                 HPX_CONCEPT_REQUIRES_(
-                    is_scheduler_v<Scheduler_> &&
+                    hpx::execution::experimental::is_scheduler_v<Scheduler_> &&
                     is_receiver_cpo_v<std::decay_t<CPO>>
                 )>
             // clang-format on
@@ -452,7 +447,8 @@ namespace hpx::execution::experimental {
                     )>
                 // clang-format on
                 shared_state_run_loop(Sender_&& sender,
-                    shared_state::allocator_type const& alloc, run_loop& loop)
+                    typename shared_state::allocator_type const& alloc,
+                    run_loop& loop)
                   : shared_state(HPX_FORWARD(Sender_, sender), alloc)
                   , loop(loop)
                 {

--- a/libs/core/execution/include/hpx/execution/algorithms/split.hpp
+++ b/libs/core/execution/include/hpx/execution/algorithms/split.hpp
@@ -17,8 +17,10 @@
 #include <hpx/datastructures/tuple.hpp>
 #include <hpx/datastructures/variant.hpp>
 #include <hpx/errors/try_catch_exception_ptr.hpp>
+#include <hpx/execution/algorithms/detail/inject_scheduler.hpp>
 #include <hpx/execution/algorithms/detail/partial_algorithm.hpp>
 #include <hpx/execution/algorithms/detail/single_result.hpp>
+#include <hpx/execution/algorithms/run_loop.hpp>
 #include <hpx/execution_base/completion_scheduler.hpp>
 #include <hpx/execution_base/completion_signatures.hpp>
 #include <hpx/execution_base/operation_state.hpp>
@@ -82,9 +84,17 @@ namespace hpx::execution::experimental {
             }
         };
 
-        template <typename Sender, typename Allocator, submission_type Type>
+        // Dummy type used in place of a scheduler if none is given
+        struct no_scheduler
+        {
+        };
+
+        template <typename Sender, typename Allocator, submission_type Type,
+            typename Scheduler = no_scheduler>
         struct split_sender
         {
+            HPX_NO_UNIQUE_ADDRESS std::decay_t<Scheduler> scheduler;
+
             template <typename Tuple>
             struct value_types_helper
             {
@@ -116,6 +126,22 @@ namespace hpx::execution::experimental {
             friend auto tag_invoke(
                 get_completion_signatures_t, split_sender const&, Env)
                 -> generate_completion_signatures<Env>;
+
+            // clang-format off
+            template <typename CPO, typename Scheduler_ = Scheduler,
+                HPX_CONCEPT_REQUIRES_(
+                   !std::is_same_v<Scheduler_, no_scheduler> &&
+                    is_receiver_cpo_v<std::decay_t<CPO>>
+                )>
+            // clang-format on
+            friend constexpr auto tag_invoke(
+                hpx::execution::experimental::get_completion_scheduler_t<CPO>,
+                split_sender const& sender)
+            {
+                return sender.scheduler;
+            }
+
+            // TODO: add forwarding_sender_query
 
             struct shared_state
             {
@@ -415,8 +441,10 @@ namespace hpx::execution::experimental {
 
             hpx::intrusive_ptr<shared_state> state;
 
-            template <typename Sender_>
-            split_sender(Sender_&& sender, Allocator const& allocator)
+            template <typename Sender_, typename Scheduler_ = no_scheduler>
+            split_sender(Sender_&& sender, Allocator const& allocator,
+                Scheduler_&& scheduler = Scheduler_{})
+              : scheduler(HPX_FORWARD(Scheduler_, scheduler))
             {
                 using allocator_type = Allocator;
                 using other_allocator = typename std::allocator_traits<
@@ -547,7 +575,25 @@ namespace hpx::execution::experimental {
         template <typename Sender,
             typename Allocator = hpx::util::internal_allocator<>,
             HPX_CONCEPT_REQUIRES_(
-                is_sender_v<Sender> &&
+                hpx::execution::experimental::is_sender_v<Sender> &&
+                hpx::traits::is_allocator_v<Allocator>
+            )>
+        // clang-format on
+        friend constexpr HPX_FORCEINLINE auto tag_invoke(split_t,
+            hpx::execution::experimental::run_loop_scheduler const& sched,
+            Sender&& sender, Allocator const& allocator = {})
+        {
+            return detail::split_sender<Sender, Allocator,
+                detail::submission_type::lazy,
+                hpx::execution::experimental::run_loop_scheduler>{
+                HPX_FORWARD(Sender, sender), allocator, sched};
+        }
+
+        // clang-format off
+        template <typename Sender,
+            typename Allocator = hpx::util::internal_allocator<>,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::execution::experimental::is_sender_v<Sender> &&
                 hpx::traits::is_allocator_v<Allocator>
             )>
         // clang-format on
@@ -567,6 +613,21 @@ namespace hpx::execution::experimental {
             Allocator const& = {})
         {
             return sender;
+        }
+
+        // clang-format off
+        template <typename Scheduler, typename Allocator,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::execution::experimental::is_scheduler_v<Scheduler> &&
+                hpx::traits::is_allocator_v<Allocator>
+            )>
+        // clang-format on
+        friend constexpr HPX_FORCEINLINE auto tag_fallback_invoke(
+            split_t, Scheduler&& scheduler, Allocator const& allocator = {})
+        {
+            return hpx::execution::experimental::detail::inject_scheduler<
+                split_t, Scheduler, Allocator>{
+                HPX_FORWARD(Scheduler, scheduler), allocator};
         }
 
         // clang-format off

--- a/libs/core/execution/include/hpx/execution/algorithms/start_detached.hpp
+++ b/libs/core/execution/include/hpx/execution/algorithms/start_detached.hpp
@@ -15,6 +15,7 @@
 #include <hpx/concepts/concepts.hpp>
 #include <hpx/execution/algorithms/detail/inject_scheduler.hpp>
 #include <hpx/execution/algorithms/detail/partial_algorithm.hpp>
+#include <hpx/execution/algorithms/run_loop.hpp>
 #include <hpx/execution_base/completion_scheduler.hpp>
 #include <hpx/execution_base/completion_signatures.hpp>
 #include <hpx/execution_base/operation_state.hpp>
@@ -74,9 +75,11 @@ namespace hpx::execution::experimental {
                 }
             };
 
-        private:
+        protected:
             using allocator_type = typename std::allocator_traits<
                 Allocator>::template rebind_alloc<Derived>;
+
+        private:
             HPX_NO_UNIQUE_ADDRESS allocator_type alloc;
             hpx::util::atomic_count count{0};
 
@@ -123,8 +126,14 @@ namespace hpx::execution::experimental {
         {
             using base_type = operation_state_holder_base<
                 operation_state_holder<Sender, Allocator>, Sender, Allocator>;
+            using allocator_type = typename base_type::allocator_type;
 
-            using base_type::operation_state_holder_base;
+            template <typename Sender_>
+            explicit operation_state_holder(
+                Sender_&& sender, allocator_type const& alloc)
+              : base_type(HPX_FORWARD(Sender_, sender), alloc)
+            {
+            }
 
             static constexpr void finish() noexcept {}
         };

--- a/libs/core/execution/include/hpx/execution/algorithms/sync_wait.hpp
+++ b/libs/core/execution/include/hpx/execution/algorithms/sync_wait.hpp
@@ -8,18 +8,22 @@
 #pragma once
 
 #include <hpx/config.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/concepts/concepts.hpp>
 #include <hpx/datastructures/optional.hpp>
 #include <hpx/datastructures/tuple.hpp>
 #include <hpx/datastructures/variant.hpp>
+#include <hpx/execution/algorithms/detail/inject_scheduler.hpp>
 #include <hpx/execution/algorithms/detail/partial_algorithm.hpp>
 #include <hpx/execution/algorithms/detail/single_result.hpp>
+#include <hpx/execution/algorithms/run_loop.hpp>
+#include <hpx/execution/queries/get_delegatee_scheduler.hpp>
+#include <hpx/execution/queries/get_scheduler.hpp>
 #include <hpx/execution_base/completion_signatures.hpp>
 #include <hpx/execution_base/operation_state.hpp>
+#include <hpx/execution_base/receiver.hpp>
 #include <hpx/execution_base/sender.hpp>
 #include <hpx/functional/detail/tag_priority_invoke.hpp>
-#include <hpx/synchronization/condition_variable.hpp>
-#include <hpx/synchronization/spinlock.hpp>
 #include <hpx/type_support/meta.hpp>
 #include <hpx/type_support/pack.hpp>
 #include <hpx/type_support/unused.hpp>
@@ -27,6 +31,7 @@
 #include <atomic>
 #include <exception>
 #include <mutex>
+#include <system_error>
 #include <type_traits>
 #include <utility>
 
@@ -43,6 +48,27 @@ namespace hpx::execution::experimental::detail {
         void operator()(Error& error) const
         {
             throw error;
+        }
+    };
+
+    struct sync_wait_receiver_env
+    {
+        using scheduler_type =
+            decltype(std::declval<run_loop>().get_scheduler());
+
+        scheduler_type sched;
+
+        friend auto tag_invoke(hpx::execution::experimental::get_scheduler_t,
+            sync_wait_receiver_env const& env) noexcept -> scheduler_type
+        {
+            return env.sched;
+        }
+
+        friend auto tag_invoke(
+            hpx::execution::experimental::get_delegatee_scheduler_t,
+            sync_wait_receiver_env const& env) noexcept -> scheduler_type
+        {
+            return env.sched;
         }
     };
 
@@ -65,11 +91,11 @@ namespace hpx::execution::experimental::detail {
         template <template <typename...> class Tuple,
             template <typename...> class Variant>
         using predecessor_value_types =
-            value_types_of_t<Sender, empty_env, Tuple, Variant>;
+            value_types_of_t<Sender, sync_wait_receiver_env, Tuple, Variant>;
 
         template <template <typename...> class Variant>
         using predecessor_error_types =
-            error_types_of_t<Sender, empty_env, Variant>;
+            error_types_of_t<Sender, sync_wait_receiver_env, Variant>;
 
         // forcing static_assert ensuring variant has exactly one tuple
         //
@@ -92,29 +118,12 @@ namespace hpx::execution::experimental::detail {
             hpx::util::detail::unique_t<hpx::util::detail::prepend_t<
                 predecessor_error_types<hpx::variant>, std::exception_ptr>>;
 
-        // We use a spinlock here to allow taking the lock on non-HPX threads.
-        using mutex_type = hpx::spinlock;
+        using stopped_type = hpx::execution::experimental::set_stopped_t;
 
         struct shared_state
         {
-            // We use a spinlock here to allow taking the lock on non-HPX
-            // threads.
-            hpx::condition_variable cond_var;
-            mutex_type mtx;
-            std::atomic<bool> set_called = false;
-            hpx::variant<hpx::monostate, error_type, result_type> value;
-
-            void wait()
-            {
-                if (!set_called)
-                {
-                    std::unique_lock<mutex_type> l(mtx);
-                    if (!set_called)
-                    {
-                        cond_var.wait(l);
-                    }
-                }
-            }
+            hpx::variant<hpx::monostate, error_type, result_type, stopped_type>
+                value;
 
             auto get_value()
             {
@@ -129,54 +138,171 @@ namespace hpx::execution::experimental::detail {
                 {
                     hpx::visit(
                         sync_wait_error_visitor{}, hpx::get<error_type>(value));
+                    HPX_UNREACHABLE;
                 }
 
-                // If the variant holds a hpx::monostate set_stopped was called
-                // we return an empty optional
+                // Something went very wrong if this assert fired. Essentially
+                // this means that none of set_value/set_error/set_stopped was
+                // called.
+                HPX_ASSERT(hpx::holds_alternative<stopped_type>(value));
                 return hpx::optional<single_result_type>();
             }
         };
 
         shared_state& state;
-
-        void signal_set_called() noexcept
-        {
-            std::unique_lock<mutex_type> l(state.mtx);
-            state.set_called = true;
-            hpx::util::ignore_while_checking<decltype(l)> il(&l);
-            HPX_UNUSED(il);
-
-            state.cond_var.notify_one();
-        }
+        run_loop& loop;
 
         template <typename Error>
         friend void tag_invoke(
             set_error_t, sync_wait_receiver&& r, Error&& error) noexcept
         {
-            r.state.value.template emplace<error_type>(
-                HPX_FORWARD(Error, error));
-            r.signal_set_called();
+            using error_t = std::decay_t<Error>;
+            if constexpr (std::is_same_v<error_t, std::exception_ptr>)
+            {
+                r.state.value.template emplace<error_type>(
+                    HPX_FORWARD(Error, error));
+            }
+            else if constexpr (std::is_same_v<error_t, std::error_code>)
+            {
+                r.state.value.template emplace<error_type>(
+                    std::exception_ptr(std::system_error(error)));
+            }
+            else
+            {
+                r.state.value.template emplace<error_type>(
+                    std::exception_ptr(HPX_FORWARD(Error, error)));
+            }
+
+            r.loop.finish();
         }
 
-        friend void tag_invoke(set_stopped_t, sync_wait_receiver&& r) noexcept
+        friend void tag_invoke(
+            set_stopped_t tag, sync_wait_receiver&& r) noexcept
         {
-            r.signal_set_called();
+            r.state.value.template emplace<stopped_type>(tag);
+            r.loop.finish();
         }
 
-        // possible add it back
         template <typename... Us>
         friend void tag_invoke(
             set_value_t, sync_wait_receiver&& r, Us&&... us) noexcept
         {
             r.state.value.template emplace<result_type>(
                 hpx::forward_as_tuple(HPX_FORWARD(Us, us)...));
-            r.signal_set_called();
+            r.loop.finish();
+        }
+
+        friend sync_wait_receiver_env tag_invoke(
+            hpx::execution::experimental::get_env_t,
+            sync_wait_receiver const& r) noexcept
+        {
+            return {r.loop.get_scheduler()};
         }
     };
 }    // namespace hpx::execution::experimental::detail
 
 namespace hpx::this_thread::experimental {
 
+    // this_thread::sync_wait is a sender consumer that submits the work
+    // described by the provided sender for execution, similarly to
+    // ensure_started, except that it blocks the current std::thread or thread
+    // of main until the work is completed, and returns an optional tuple of
+    // values that were sent by the provided sender on its completion of work.
+    // Where 4.20.1 execution::schedule and 4.20.3 execution::transfer_just are
+    // meant to enter the domain of senders, sync_wait is meant to exit the
+    // domain of senders, retrieving the result of the task graph.
+    //
+    // If the provided sender sends an error instead of values, sync_wait throws
+    // that error as an exception, or rethrows the original exception if the
+    // error is of type std::exception_ptr.
+    //
+    // If the provided sender sends the "stopped" signal instead of values,
+    // sync_wait returns an empty optional.
+    //
+    // For an explanation of the requires clause, see 5.8 All senders are typed.
+    // That clause also explains another sender consumer, built on top of
+    // sync_wait: sync_wait_with_variant.
+    //
+    // Note: This function is specified inside hpx::this_thread::experimental,
+    // and not inside hpx::execution::experimental. This is because sync_wait
+    // has to block the current execution agent, but determining what the
+    // current execution agent is is not reliable. Since the standard does not
+    // specify any functions on the current execution agent other than those in
+    // std::this_thread, this is the flavor of this function that is being
+    // proposed.
+
+    // this_thread::sync_wait and this_thread::sync_wait_with_variant are used
+    // to block a current thread until a sender passed into it as an argument
+    // has completed, and to obtain the values (if any) it completed with.
+    //
+    // For any receiver r created by an implementation of sync_wait and
+    // sync_wait_with_variant, the expressions get_scheduler(get_env(r)) and
+    // get_delegatee_scheduler(get_env(r)) shall be well-formed. For a receiver
+    // created by the default implementation of this_thread::sync_wait, these
+    // expressions shall return a scheduler to the same thread-safe,
+    // first-in-first-out queue of work such that tasks scheduled to the queue
+    // execute on the thread of the caller of sync_wait. [Note: The scheduler
+    // for an instance of execution::run_loop that is a local variable within
+    // sync_wait is one valid implementation. -- end note]
+    //
+    // The templates sync-wait-type and sync-wait-with-variant-type are used to
+    // determine the return types of this_thread::sync_wait and
+    // this_thread::sync_wait_with_variant. Let sync-wait-env be the type of the
+    // expression get_env(r) where r is an instance of the receiver created by
+    // the default implementation of sync_wait. Then:
+    //
+    // template<sender<sync-wait-env> S> using sync-wait-type =
+    //  optional<execution::value_types_of_t< S, sync-wait-env, decayed-tuple,
+    //  type_identity_t>>;
+    //
+    //  template<sender<sync-wait-env> S> using sync-wait-with-variant-type =
+    //  optional<execution::into-variant-type<S, sync-wait-env>>;
+    //
+    // The name this_thread::sync_wait denotes a customization point object. For
+    // some subexpression s, let S be decltype((s)). If execution::sender<S,
+    // sync-wait-env> is false, or the number of the arguments
+    // completion_signatures_of_t<S, sync-wait-env>::value_types passed into the
+    // Variant template parameter is not 1, this_thread::sync_wait is
+    // ill-formed. Otherwise, this_thread::sync_wait is expression-equivalent
+    // to:
+    //
+    // 1. tag_invoke(this_thread::sync_wait,
+    //          execution::get_completion_scheduler< execution::set_value_t>(s),
+    //          s), if this expression is valid.
+    //
+    //      - Mandates: The type of the tag_invoke expression above is
+    //                  sync-wait-type<S, sync-wait-env>.
+    //
+    // 2. Otherwise, tag_invoke(this_thread::sync_wait, s), if this expression
+    //    is valid and its type is.
+    //
+    //      - Mandates: The type of the tag_invoke expression above is
+    //                  sync-wait-type<S, sync-wait-env>.
+    //
+    // 3. Otherwise:
+    //
+    //      1. Constructs a receiver r.
+    //
+    //      2. Calls execution::connect(s, r), resulting in an operation state
+    //         op_state, then calls execution::start(op_state).
+    //
+    //      3. Blocks the current thread until a receiver completion-signal of r
+    //         is called. When it is:
+    //
+    //          1. If execution::set_value(r, ts...) has been called, returns
+    //              sync-wait-type<S, sync-wait-env>{
+    //                  decayed-tuple<decltype(ts)...>{ts...}}.
+    //              If that expression exits exceptionally, the exception is
+    //              propagated to the caller of sync_wait.
+    //
+    //          2. If execution::set_error(r, e) has been called, let E be the
+    //             decayed type of e. If E is exception_ptr, calls
+    //             std::rethrow_exception(e). Otherwise, if the E is error_code,
+    //             throws system_error(e). Otherwise, throws e.
+    //
+    //          3. If execution::set_stopped(r) has been called, returns
+    //             sync-wait-type<S, sync-wait-env>{}.
+    //
     inline constexpr struct sync_wait_t final
       : hpx::functional::detail::tag_priority<sync_wait_t>
     {
@@ -184,7 +310,8 @@ namespace hpx::this_thread::experimental {
         // clang-format off
         template <typename Sender,
             HPX_CONCEPT_REQUIRES_(
-                hpx::execution::experimental::is_sender_v<Sender> &&
+                hpx::execution::experimental::is_sender_v<Sender,
+                    hpx::execution::experimental::detail::sync_wait_receiver_env> &&
                 hpx::execution::experimental::detail::
                     is_completion_scheduler_tag_invocable_v<
                         hpx::execution::experimental::set_value_t,
@@ -206,10 +333,39 @@ namespace hpx::this_thread::experimental {
         // clang-format off
         template <typename Sender,
             HPX_CONCEPT_REQUIRES_(
-                hpx::execution::experimental::is_sender_v<Sender>
+                hpx::execution::experimental::is_sender_v<Sender,
+                    hpx::execution::experimental::detail::sync_wait_receiver_env>
             )>
         // clang-format on
-        friend constexpr HPX_FORCEINLINE auto tag_fallback_invoke(
+        friend auto tag_invoke(sync_wait_t,
+            hpx::execution::experimental::run_loop_scheduler const& sched,
+            Sender&& sender)
+        {
+            using receiver_type =
+                hpx::execution::experimental::detail::sync_wait_receiver<
+                    Sender>;
+            using state_type = typename receiver_type::shared_state;
+
+            hpx::execution::experimental::run_loop& loop = sched.get_run_loop();
+            state_type state{};
+            auto op_state = hpx::execution::experimental::connect(
+                HPX_FORWARD(Sender, sender), receiver_type{state, loop});
+            hpx::execution::experimental::start(op_state);
+
+            // Wait for the variant to be filled in.
+            loop.run();
+
+            return state.get_value();
+        }
+
+        // clang-format off
+        template <typename Sender,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::execution::experimental::is_sender_v<Sender,
+                    hpx::execution::experimental::detail::sync_wait_receiver_env>
+            )>
+        // clang-format on
+        friend HPX_FORCEINLINE auto tag_fallback_invoke(
             sync_wait_t, Sender&& sender)
         {
             using receiver_type =
@@ -217,13 +373,29 @@ namespace hpx::this_thread::experimental {
                     Sender>;
             using state_type = typename receiver_type::shared_state;
 
+            hpx::execution::experimental::run_loop loop{};
             state_type state{};
             auto op_state = hpx::execution::experimental::connect(
-                HPX_FORWARD(Sender, sender), receiver_type{state});
+                HPX_FORWARD(Sender, sender), receiver_type{state, loop});
             hpx::execution::experimental::start(op_state);
 
-            state.wait();
+            // Wait for the variant to be filled in.
+            loop.run();
+
             return state.get_value();
+        }
+
+        // clang-format off
+        template <typename Scheduler,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::execution::experimental::is_scheduler_v<Scheduler>
+            )>
+        // clang-format on
+        friend constexpr HPX_FORCEINLINE auto tag_fallback_invoke(
+            sync_wait_t, Scheduler&& scheduler)
+        {
+            return hpx::execution::experimental::detail::inject_scheduler<
+                sync_wait_t, Scheduler>{HPX_FORWARD(Scheduler, scheduler)};
         }
 
         friend constexpr HPX_FORCEINLINE auto tag_fallback_invoke(sync_wait_t)

--- a/libs/core/execution/include/hpx/execution/algorithms/sync_wait.hpp
+++ b/libs/core/execution/include/hpx/execution/algorithms/sync_wait.hpp
@@ -41,7 +41,7 @@ namespace hpx::execution::experimental::detail {
     {
         void operator()(std::exception_ptr ep) const
         {
-            std::rethrow_exception(ep);
+            std::rethrow_exception(HPX_MOVE(ep));
         }
 
         template <typename Error>

--- a/libs/core/execution/include/hpx/execution/algorithms/then.hpp
+++ b/libs/core/execution/include/hpx/execution/algorithms/then.hpp
@@ -142,12 +142,14 @@ namespace hpx::execution::experimental {
                 )>
             // clang-format on
             friend constexpr auto tag_invoke(
-                hpx::execution::experimental::get_completion_scheduler_t<CPO>,
+                hpx::execution::experimental::get_completion_scheduler_t<CPO>
+                    tag,
                 then_sender const& sender)
             {
-                return hpx::execution::experimental::get_completion_scheduler<
-                    CPO>(sender.sender);
+                return tag(sender.sender);
             }
+
+            // TODO: add forwarding_sender_query
 
             template <typename Receiver>
             friend auto tag_invoke(

--- a/libs/core/execution/include/hpx/execution/algorithms/when_all.hpp
+++ b/libs/core/execution/include/hpx/execution/algorithms/when_all.hpp
@@ -50,8 +50,7 @@ namespace hpx::execution::experimental {
         // passed to when_all. When set_value is called, it will emplace the
         // values sent into the appropriate position in the pack used to store
         // values from all predecessor senders.
-        template <typename OperationState,
-            std::size_t I = OperationState::sender_pack_size>
+        template <typename OperationState>
         struct when_all_receiver
         {
             std::decay_t<OperationState>& op_state;
@@ -118,7 +117,8 @@ namespace hpx::execution::experimental {
                     ...);
             }
 
-            static constexpr std::size_t sender_pack_size = I;
+            static constexpr std::size_t sender_pack_size =
+                OperationState::sender_pack_size;
             using index_pack_type =
                 hpx::util::make_index_pack_t<sender_pack_size>;
 

--- a/libs/core/execution/include/hpx/execution/queries/get_scheduler.hpp
+++ b/libs/core/execution/include/hpx/execution/queries/get_scheduler.hpp
@@ -10,29 +10,40 @@
 #include <hpx/execution/queries/read.hpp>
 #include <hpx/execution_base/get_env.hpp>
 #include <hpx/functional/detail/tag_fallback_invoke.hpp>
+#include <hpx/functional/tag_invoke.hpp>
 
 namespace hpx::execution::experimental {
 
     // [exec.sched_queries.forwarding_scheduler_query]
-    // 1. `execution::forwarding_scheduler_query` is used to ask a
-    // customization point object whether it is a scheduler query that
-    // should be forwarded through scheduler adaptors.
+    //
+    // 1. `execution::forwarding_scheduler_query` is used to ask a customization
+    //    point object whether it is a scheduler query that should be forwarded
+    //    through scheduler adaptors.
+    //
+    //
     // 2. The name `execution::forwarding_scheduler_query` denotes a
-    // customization point object. For some subexpression `t`,
-    // `execution::forwarding_scheduler_query(t)` is expression
-    // equivalent to:
+    //    customization point object. For some subexpression `t`,
+    //    `execution::forwarding_scheduler_query(t)` is expression equivalent
+    //    to:
+    //
     //      1. `tag_invoke(execution::forwarding_scheduler_query, t)`,
-    // contextually converted to bool, if the tag_invoke expression is
-    // well formed.
-    //          Mandates: The tag_invoke expression is indeed
-    //          contextually convertible to bool, that expression and
-    //          the contextual conversion are not potentially-throwing
-    //          and are core constant expressions if t is a core
-    //          constant expression.
+    //         contextually converted to bool, if the tag_invoke expression is
+    //         well formed.
+    //
+    //          - Mandates: The tag_invoke expression is indeed
+    //                      contextually convertible to bool, that expression
+    //                      and the contextual conversion are not potentially-
+    //                      throwing and are core constant expressions if t is
+    //                      a core constant expression.
+    //
     //     2. Otherwise, false.
+    //
     HPX_HOST_DEVICE_INLINE_CONSTEXPR_VARIABLE struct
         forwarding_scheduler_query_t final
-      : hpx::functional::detail::tag_fallback<forwarding_scheduler_query_t>
+      : hpx::functional::detail::tag_fallback_noexcept<
+            forwarding_scheduler_query_t,
+            detail::contextually_convertible_to_bool<
+                forwarding_scheduler_query_t>>
     {
     private:
         template <typename T>
@@ -50,26 +61,34 @@ namespace hpx::execution::experimental {
         weakly_parallel
     };
 
-    // 1. `execution::get_forward_progress_guarantee` is used to ask a scheduler about
-    // the forward progress guarantees of execution agents created by that
-    // scheduler.
+    // 1. `execution::get_forward_progress_guarantee` is used to ask a scheduler
+    //    about the forward progress guarantees of execution agents created by
+    //    that scheduler.
+    //
     // 2. The name `execution::get_forward_progress_guarantee` denotes a
-    // customization point object. For some subexpression s, let S be decltype((s)).
-    // If S does not satisfy execution::scheduler,
-    // execution::get_forward_progress_guarantee is ill-formed. Otherwise,
-    // execution::get_forward_progress_guarantee(s) is expression equivalent to:
+    //    customization point object. For some subexpression s, let S be
+    //    decltype((s)).
+    //
+    //      1. If S does not satisfy execution::scheduler,
+    //         execution::get_forward_progress_guarantee is ill-formed. Otherwise,
+    //         execution::get_forward_progress_guarantee(s) is expression equivalent to:
     //      2. `tag_invoke(execution::get_forward_progress_guarantee, as_const(s))`,
-    // if this expression is well formed.
-    //          Mandates: The tag_invoke expression above is not
-    //          potentially throwing and its type is
-    //          execution::forward_progress_guarantee.
+    //         if this expression is well formed.
+    //
+    //          - Mandates: The tag_invoke expression above is not
+    //                      potentially throwing and its type is
+    //                      execution::forward_progress_guarantee.
+    //
     //          Otherwise, execution::forward_progress_guarantee::weakly_parallel.
-    // 3. If `execution::get_forward_progress_guarantee(s)` for some scheduler s returns
-    // `execution::forward_progress_guarantee::concurrent`, all execution agents
-    // created by that scheduler shall provide the concurrent forward progress
-    // guarantee. If it returns `execution::forward_progress_guarantee::parallel`, all
-    // execution agents created by that scheduler shall provide at least the
-    // parallel forward progress guarantee.
+    //
+    // 3. If `execution::get_forward_progress_guarantee(s)` for some scheduler s
+    //    returns `execution::forward_progress_guarantee::concurrent`, all
+    //    execution agents created by that scheduler shall provide the
+    //    concurrent forward progress guarantee. If it returns
+    //    `execution::forward_progress_guarantee::parallel`, all execution
+    //    agents created by that scheduler shall provide at least the parallel
+    //    forward progress guarantee.
+    //
     HPX_HOST_DEVICE_INLINE_CONSTEXPR_VARIABLE struct
         get_forward_progress_guarantee_t final
       : hpx::functional::detail::tag_fallback_noexcept<

--- a/libs/core/execution/include/hpx/execution/queries/get_stop_token.hpp
+++ b/libs/core/execution/include/hpx/execution/queries/get_stop_token.hpp
@@ -58,8 +58,8 @@ namespace hpx::execution::experimental {
         return hpx::execution::experimental::read(get_stop_token);
     }
 
-    // Helper template allowing to exptract the type of a stop_token
-    // extracted from a receiver environment.
+    // Helper template allowing to extract the type of a stop_token extracted
+    // from a receiver environment.
     template <typename T>
     using stop_token_of_t = std::remove_cv_t<
         std::remove_reference_t<decltype(get_stop_token(std::declval<T>()))>>;

--- a/libs/core/execution/tests/unit/CMakeLists.txt
+++ b/libs/core/execution/tests/unit/CMakeLists.txt
@@ -14,6 +14,7 @@ set(tests
     algorithm_let_error
     algorithm_let_stopped
     algorithm_let_value
+    algorithm_run_loop
     algorithm_split
     algorithm_start_detached
     algorithm_sync_wait
@@ -29,6 +30,7 @@ set(tests
     executor_parameters_timer_hooks
     forwarding_env_query
     forwarding_scheduler_query
+    forwarding_sender_query
     future_then_executor
     minimal_async_executor
     minimal_sync_executor

--- a/libs/core/execution/tests/unit/algorithm_run_loop.cpp
+++ b/libs/core/execution/tests/unit/algorithm_run_loop.cpp
@@ -689,120 +689,119 @@ void test_ensure_started()
     }
 }
 
-// TODO: ensure_started does not fully work with run_loop
-//void test_ensure_started_when_all()
-//{
-//    {
-//        ex::run_loop loop;
-//        auto sched = loop.get_scheduler();
-//
-//        std::atomic<std::size_t> first_task_calls{0};
-//        std::atomic<std::size_t> successor_task_calls{0};
-//        hpx::mutex mtx;
-//        hpx::condition_variable cond;
-//        bool started{false};
-//        auto s = ex::schedule(sched) | ex::then([&]() {
-//            ++first_task_calls;
-//            std::lock_guard l{mtx};
-//            started = true;
-//            cond.notify_one();
-//        }) | ex::ensure_started();
-//        {
-//            std::unique_lock l{mtx};
-//            cond.wait(l, [&]() { return started; });
-//        }
-//        auto succ1 = s | ex::then([&]() {
-//            ++successor_task_calls;
-//            return 1;
-//        });
-//        auto succ2 = s | ex::then([&]() {
-//            ++successor_task_calls;
-//            return 2;
-//        });
-//        HPX_TEST_EQ(
-//            hpx::get<0>(*(ex::when_all(succ1, succ2) |
-//                ex::then([](int const& x, int const& y) { return x + y; }) |
-//                tt::sync_wait())),
-//            3);
-//        HPX_TEST_EQ(first_task_calls, std::size_t(1));
-//        HPX_TEST_EQ(successor_task_calls, std::size_t(2));
-//    }
-//
-//    {
-//        ex::run_loop loop;
-//        auto sched = loop.get_scheduler();
-//
-//        std::atomic<std::size_t> first_task_calls{0};
-//        std::atomic<std::size_t> successor_task_calls{0};
-//        hpx::mutex mtx;
-//        hpx::condition_variable cond;
-//        bool started{false};
-//        auto s = ex::schedule(sched) | ex::then([&]() {
-//            ++first_task_calls;
-//            std::lock_guard l{mtx};
-//            started = true;
-//            cond.notify_one();
-//            return 3;
-//        }) | ex::ensure_started();
-//        {
-//            std::unique_lock l{mtx};
-//            cond.wait(l, [&]() { return started; });
-//        }
-//        HPX_TEST_EQ(first_task_calls, std::size_t(1));
-//        auto succ1 = s | ex::then([&](int const& x) {
-//            ++successor_task_calls;
-//            return x + 1;
-//        });
-//        auto succ2 = s | ex::then([&](int const& x) {
-//            ++successor_task_calls;
-//            return x + 2;
-//        });
-//        HPX_TEST_EQ(
-//            hpx::get<0>(*(ex::when_all(succ1, succ2) |
-//                ex::then([](int const& x, int const& y) { return x + y; }) |
-//                tt::sync_wait())),
-//            9);
-//        HPX_TEST_EQ(first_task_calls, std::size_t(1));
-//        HPX_TEST_EQ(successor_task_calls, std::size_t(2));
-//    }
-//
-//    {
-//        ex::run_loop loop;
-//        auto sched = loop.get_scheduler();
-//
-//        std::atomic<std::size_t> first_task_calls{0};
-//        std::atomic<std::size_t> successor_task_calls{0};
-//        hpx::mutex mtx;
-//        hpx::condition_variable cond;
-//        bool started{false};
-//        auto s = ex::schedule(sched) | ex::then([&]() {
-//            ++first_task_calls;
-//            std::lock_guard l{mtx};
-//            started = true;
-//            cond.notify_one();
-//            return 3;
-//        }) | ex::ensure_started();
-//        {
-//            std::unique_lock l{mtx};
-//            cond.wait(l, [&]() { return started; });
-//        }
-//        auto succ1 = s | ex::transfer(sched) | ex::then([&](int const& x) {
-//            ++successor_task_calls;
-//            return x + 1;
-//        });
-//        auto succ2 = s | ex::transfer(sched) | ex::then([&](int const& x) {
-//            ++successor_task_calls;
-//            return x + 2;
-//        });
-//        HPX_TEST_EQ(
-//            hpx::get<0>(*(ex::when_all(succ1, succ2) |
-//                ex::then([](int const& x, int const& y) { return x + y; }) |
-//                tt::sync_wait())),
-//            9);
-//        HPX_TEST_EQ(first_task_calls, std::size_t(1));
-//        HPX_TEST_EQ(successor_task_calls, std::size_t(2));
-//    }
-//}
+void test_ensure_started_when_all()
+{
+    {
+        ex::run_loop loop;
+        auto sched = loop.get_scheduler();
+
+        std::atomic<std::size_t> first_task_calls{0};
+        std::atomic<std::size_t> successor_task_calls{0};
+        hpx::mutex mtx;
+        hpx::condition_variable cond;
+        bool started{false};
+        auto s = ex::schedule(sched) | ex::then([&]() {
+            ++first_task_calls;
+            std::lock_guard l{mtx};
+            started = true;
+            cond.notify_one();
+        }) | ex::ensure_started();
+        {
+            std::unique_lock l{mtx};
+            cond.wait(l, [&]() { return started; });
+        }
+        auto succ1 = s | ex::then([&]() {
+            ++successor_task_calls;
+            return 1;
+        });
+        auto succ2 = s | ex::then([&]() {
+            ++successor_task_calls;
+            return 2;
+        });
+        HPX_TEST_EQ(
+            hpx::get<0>(*(ex::when_all(succ1, succ2) |
+                ex::then([](int const& x, int const& y) { return x + y; }) |
+                tt::sync_wait(sched))),
+            3);
+        HPX_TEST_EQ(first_task_calls, std::size_t(1));
+        HPX_TEST_EQ(successor_task_calls, std::size_t(2));
+    }
+
+    {
+        ex::run_loop loop;
+        auto sched = loop.get_scheduler();
+
+        std::atomic<std::size_t> first_task_calls{0};
+        std::atomic<std::size_t> successor_task_calls{0};
+        hpx::mutex mtx;
+        hpx::condition_variable cond;
+        bool started{false};
+        auto s = ex::schedule(sched) | ex::then([&]() {
+            ++first_task_calls;
+            std::lock_guard l{mtx};
+            started = true;
+            cond.notify_one();
+            return 3;
+        }) | ex::ensure_started();
+        {
+            std::unique_lock l{mtx};
+            cond.wait(l, [&]() { return started; });
+        }
+        HPX_TEST_EQ(first_task_calls, std::size_t(1));
+        auto succ1 = s | ex::then([&](int const& x) {
+            ++successor_task_calls;
+            return x + 1;
+        });
+        auto succ2 = s | ex::then([&](int const& x) {
+            ++successor_task_calls;
+            return x + 2;
+        });
+        HPX_TEST_EQ(
+            hpx::get<0>(*(ex::when_all(succ1, succ2) |
+                ex::then([](int const& x, int const& y) { return x + y; }) |
+                tt::sync_wait(sched))),
+            9);
+        HPX_TEST_EQ(first_task_calls, std::size_t(1));
+        HPX_TEST_EQ(successor_task_calls, std::size_t(2));
+    }
+
+    {
+        ex::run_loop loop;
+        auto sched = loop.get_scheduler();
+
+        std::atomic<std::size_t> first_task_calls{0};
+        std::atomic<std::size_t> successor_task_calls{0};
+        hpx::mutex mtx;
+        hpx::condition_variable cond;
+        bool started{false};
+        auto s = ex::schedule(sched) | ex::then([&]() {
+            ++first_task_calls;
+            std::lock_guard l{mtx};
+            started = true;
+            cond.notify_one();
+            return 3;
+        }) | ex::ensure_started();
+        {
+            std::unique_lock l{mtx};
+            cond.wait(l, [&]() { return started; });
+        }
+        auto succ1 = s | ex::transfer(sched) | ex::then([&](int const& x) {
+            ++successor_task_calls;
+            return x + 1;
+        });
+        auto succ2 = s | ex::transfer(sched) | ex::then([&](int const& x) {
+            ++successor_task_calls;
+            return x + 2;
+        });
+        HPX_TEST_EQ(
+            hpx::get<0>(*(ex::when_all(succ1, succ2) |
+                ex::then([](int const& x, int const& y) { return x + y; }) |
+                tt::sync_wait(sched))),
+            9);
+        HPX_TEST_EQ(first_task_calls, std::size_t(1));
+        HPX_TEST_EQ(successor_task_calls, std::size_t(2));
+    }
+}
 
 void test_split()
 {
@@ -842,82 +841,106 @@ void test_split()
     }
 }
 
-// TODO: split does not fully work with run_loop
-//void test_split_when_all()
-//{
-//    ex::run_loop loop;
-//    auto sched = loop.get_scheduler();
-//
-//    {
-//        std::atomic<std::size_t> first_task_calls{0};
-//        std::atomic<std::size_t> successor_task_calls{0};
-//        auto s = ex::schedule(sched) | ex::then([&]() { ++first_task_calls; }) |
-//            ex::split();
-//        auto succ1 = s | ex::then([&]() {
-//            ++successor_task_calls;
-//            return 1;
-//        });
-//        auto succ2 = s | ex::then([&]() {
-//            ++successor_task_calls;
-//            return 2;
-//        });
-//        HPX_TEST_EQ(
-//            hpx::get<0>(*(ex::when_all(succ1, succ2) |
-//                ex::then([](int const& x, int const& y) { return x + y; }) |
-//                tt::sync_wait())),
-//            3);
-//        HPX_TEST_EQ(first_task_calls, std::size_t(1));
-//        HPX_TEST_EQ(successor_task_calls, std::size_t(2));
-//    }
-//
-//    {
-//        std::atomic<std::size_t> first_task_calls{0};
-//        std::atomic<std::size_t> successor_task_calls{0};
-//        auto s = ex::schedule(sched) | ex::then([&]() {
-//            ++first_task_calls;
-//            return 3;
-//        }) | ex::split();
-//        auto succ1 = s | ex::then([&](int const& x) {
-//            ++successor_task_calls;
-//            return x + 1;
-//        });
-//        auto succ2 = s | ex::then([&](int const& x) {
-//            ++successor_task_calls;
-//            return x + 2;
-//        });
-//        HPX_TEST_EQ(
-//            hpx::get<0>(*(ex::when_all(succ1, succ2) |
-//                ex::then([](int const& x, int const& y) { return x + y; }) |
-//                tt::sync_wait())),
-//            9);
-//        HPX_TEST_EQ(first_task_calls, std::size_t(1));
-//        HPX_TEST_EQ(successor_task_calls, std::size_t(2));
-//    }
-//
-//    {
-//        std::atomic<std::size_t> first_task_calls{0};
-//        std::atomic<std::size_t> successor_task_calls{0};
-//        auto s = ex::schedule(sched) | ex::then([&]() {
-//            ++first_task_calls;
-//            return 3;
-//        }) | ex::split();
-//        auto succ1 = s | ex::transfer(sched) | ex::then([&](int const& x) {
-//            ++successor_task_calls;
-//            return x + 1;
-//        });
-//        auto succ2 = s | ex::transfer(sched) | ex::then([&](int const& x) {
-//            ++successor_task_calls;
-//            return x + 2;
-//        });
-//        HPX_TEST_EQ(
-//            hpx::get<0>(*(ex::when_all(succ1, succ2) |
-//                ex::then([](int const& x, int const& y) { return x + y; }) |
-//                tt::sync_wait())),
-//            9);
-//        HPX_TEST_EQ(first_task_calls, std::size_t(1));
-//        HPX_TEST_EQ(successor_task_calls, std::size_t(2));
-//    }
-//}
+void test_split_when_all()
+{
+    {
+        ex::run_loop loop;
+        auto sched = loop.get_scheduler();
+
+        std::atomic<std::size_t> first_task_calls{0};
+        std::atomic<std::size_t> successor_task_calls{0};
+        auto s = ex::schedule(sched) | ex::then([&]() {
+            HPX_TEST_EQ(first_task_calls, std::size_t(0));
+            HPX_TEST_EQ(successor_task_calls, std::size_t(0));
+            ++first_task_calls;
+        }) | ex::split();
+        auto succ1 = s | ex::then([&]() {
+            HPX_TEST_EQ(first_task_calls, std::size_t(1));
+            HPX_TEST_EQ(successor_task_calls, std::size_t(0));
+            ++successor_task_calls;
+            return 1;
+        });
+        auto succ2 = s | ex::then([&]() {
+            HPX_TEST_EQ(first_task_calls, std::size_t(1));
+            HPX_TEST_EQ(successor_task_calls, std::size_t(1));
+            ++successor_task_calls;
+            return 2;
+        });
+        HPX_TEST_EQ(
+            hpx::get<0>(*(ex::when_all(succ1, succ2) |
+                ex::then([](int const& x, int const& y) { return x + y; }) |
+                tt::sync_wait(sched))),
+            3);
+        HPX_TEST_EQ(first_task_calls, std::size_t(1));
+        HPX_TEST_EQ(successor_task_calls, std::size_t(2));
+    }
+
+    {
+        ex::run_loop loop;
+        auto sched = loop.get_scheduler();
+
+        std::atomic<std::size_t> first_task_calls{0};
+        std::atomic<std::size_t> successor_task_calls{0};
+        auto s = ex::schedule(sched) | ex::then([&]() {
+            HPX_TEST_EQ(first_task_calls, std::size_t(0));
+            HPX_TEST_EQ(successor_task_calls, std::size_t(0));
+            ++first_task_calls;
+            return 3;
+        }) | ex::split();
+        auto succ1 = s | ex::then([&](int const& x) {
+            HPX_TEST_EQ(first_task_calls, std::size_t(1));
+            HPX_TEST_EQ(successor_task_calls, std::size_t(0));
+            ++successor_task_calls;
+            return x + 1;
+        });
+        auto succ2 = s | ex::then([&](int const& x) {
+            HPX_TEST_EQ(first_task_calls, std::size_t(1));
+            HPX_TEST_EQ(successor_task_calls, std::size_t(1));
+            ++successor_task_calls;
+            return x + 2;
+        });
+        HPX_TEST_EQ(
+            hpx::get<0>(*(ex::when_all(succ1, succ2) |
+                ex::then([](int const& x, int const& y) { return x + y; }) |
+                tt::sync_wait(sched))),
+            9);
+        HPX_TEST_EQ(first_task_calls, std::size_t(1));
+        HPX_TEST_EQ(successor_task_calls, std::size_t(2));
+    }
+
+    {
+        ex::run_loop loop;
+        auto sched = loop.get_scheduler();
+
+        std::atomic<std::size_t> first_task_calls{0};
+        std::atomic<std::size_t> successor_task_calls{0};
+        auto s = ex::schedule(sched) | ex::then([&]() {
+            HPX_TEST_EQ(first_task_calls, std::size_t(0));
+            HPX_TEST_EQ(successor_task_calls, std::size_t(0));
+            ++first_task_calls;
+            return 3;
+        }) | ex::split();
+        auto succ1 = s | ex::transfer(sched) | ex::then([&](int const& x) {
+            HPX_TEST_EQ(first_task_calls, std::size_t(1));
+            HPX_TEST_EQ(successor_task_calls, std::size_t(0));
+            ++successor_task_calls;
+            return x + 1;
+        });
+        auto succ2 = s | ex::transfer(sched) | ex::then([&](int const& x) {
+            HPX_TEST_EQ(first_task_calls, std::size_t(1));
+            HPX_TEST_EQ(successor_task_calls, std::size_t(1));
+            ++successor_task_calls;
+            return x + 2;
+        });
+        HPX_TEST_EQ(
+            hpx::get<0>(*(ex::when_all(succ1, succ2) |
+                ex::then([](int const& x, int const& y) { return x + y; }) |
+                tt::sync_wait(sched))),
+            9);
+        HPX_TEST_EQ(first_task_calls, std::size_t(1));
+        HPX_TEST_EQ(successor_task_calls, std::size_t(2));
+    }
+}
 
 // TODO: let_value does not work with run_loop
 //void test_let_value()
@@ -1706,11 +1729,11 @@ int hpx_main()
     test_future_sender();
     test_keep_future_sender();
     test_ensure_started();
+    test_ensure_started_when_all();
+    test_split();
+    test_split_when_all();
 
     // TODO: add support for run_loop
-    //test_ensure_started_when_all();
-    test_split();
-    //test_split_when_all();
     //test_let_value();
     //test_let_error();
 

--- a/libs/core/execution/tests/unit/algorithm_run_loop.cpp
+++ b/libs/core/execution/tests/unit/algorithm_run_loop.cpp
@@ -1,0 +1,1731 @@
+//  Copyright (c) 2022 Hartmut Kaiser
+//  Copyright (c) 2020 ETH Zurich
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/local/condition_variable.hpp>
+#include <hpx/local/execution.hpp>
+#include <hpx/local/functional.hpp>
+#include <hpx/local/init.hpp>
+#include <hpx/local/mutex.hpp>
+#include <hpx/local/thread.hpp>
+#include <hpx/modules/testing.hpp>
+
+#include "algorithm_test_utils.hpp"
+
+#include <atomic>
+#include <chrono>
+#include <cstddef>
+#include <exception>
+#include <mutex>
+#include <string>
+#include <type_traits>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+namespace ex = hpx::execution::experimental;
+namespace tt = hpx::this_thread::experimental;
+
+void test_concepts()
+{
+    ex::run_loop loop;
+
+    auto sched = loop.get_scheduler();
+    static_assert(ex::is_scheduler_v<decltype(sched)>,
+        "ex::is_scheduler_v<decltype(sched)>");
+
+    auto s = ex::schedule(sched);
+    static_assert(
+        std::is_same_v<ex::schedule_result_t<decltype(sched)>, decltype(s)>,
+        "ex::schedule_result_t<decltype(sched)> must be result of "
+        "ex::schedule(sched)");
+    static_assert(ex::is_sender_v<decltype(s)>, "ex::is_sender_v<decltype(s)>");
+    static_assert(
+        ex::is_sender_of_v<decltype(s)>, "ex::is_sender_of_v<decltype(s)>");
+
+    static_assert(std::is_same_v<ex::error_types_of_t<decltype(s)>,
+                      hpx::variant<std::exception_ptr>>,
+        "ex::error_types_of_t<decltype(s)> must be "
+        "variant<std::exception_ptr>");
+    static_assert(ex::sends_stopped_of_v<decltype(s)>,
+        "ex::sends_stopped_of_v<decltype(s)> must be true");
+
+    loop.finish();
+}
+
+void test_execute()
+{
+    hpx::thread::id parent_id = hpx::this_thread::get_id();
+
+    ex::run_loop loop;
+    ex::execute(loop.get_scheduler(),
+        [parent_id]() { HPX_TEST_EQ(hpx::this_thread::get_id(), parent_id); });
+
+    loop.finish();
+    loop.run();
+}
+
+struct check_context_receiver
+{
+    hpx::thread::id parent_id;
+    ex::run_loop& loop;
+    bool& executed;
+
+    template <typename E>
+    friend void tag_invoke(
+        ex::set_error_t, check_context_receiver&&, E&&) noexcept
+    {
+        HPX_TEST(false);
+    }
+
+    friend void tag_invoke(ex::set_stopped_t, check_context_receiver&&) noexcept
+    {
+        HPX_TEST(false);
+    }
+
+    template <typename... Ts>
+    friend void tag_invoke(ex::set_value_t, check_context_receiver&& r, Ts&&...)
+    {
+        HPX_TEST_EQ(r.parent_id, hpx::this_thread::get_id());
+        HPX_TEST_NEQ(hpx::thread::id(hpx::threads::invalid_thread_id),
+            hpx::this_thread::get_id());
+
+        r.executed = true;
+        r.loop.finish();
+    }
+};
+
+void test_sender_receiver_basic()
+{
+    ex::run_loop loop;
+    auto sched = loop.get_scheduler();
+
+    hpx::thread::id parent_id = hpx::this_thread::get_id();
+    bool executed{false};
+
+    auto begin = ex::schedule(sched);
+    auto os = ex::connect(
+        std::move(begin), check_context_receiver{parent_id, loop, executed});
+    ex::start(os);
+
+    loop.run();
+
+    HPX_TEST(executed);
+}
+
+hpx::thread::id sender_receiver_then_thread_id;
+
+void test_sender_receiver_then()
+{
+    ex::run_loop loop;
+    auto sched = loop.get_scheduler();
+
+    hpx::thread::id parent_id = hpx::this_thread::get_id();
+    bool executed{false};
+
+    auto begin = ex::schedule(sched);
+    auto work1 = ex::then(std::move(begin), [=]() {
+        sender_receiver_then_thread_id = hpx::this_thread::get_id();
+        HPX_TEST_EQ(sender_receiver_then_thread_id, parent_id);
+    });
+    auto work2 = ex::then(std::move(work1), []() {
+        HPX_TEST_EQ(sender_receiver_then_thread_id, hpx::this_thread::get_id());
+    });
+    auto os = ex::connect(
+        std::move(work2), check_context_receiver{parent_id, loop, executed});
+    ex::start(os);
+
+    loop.run();
+
+    HPX_TEST(executed);
+}
+
+void test_sender_receiver_then_wait()
+{
+    ex::run_loop loop;
+    auto sched = loop.get_scheduler();
+
+    hpx::thread::id parent_id = hpx::this_thread::get_id();
+    std::atomic<std::size_t> then_count{0};
+    bool executed{false};
+
+    auto begin = ex::schedule(sched);
+
+    static_assert(
+        ex::detail::is_completion_scheduler_tag_invocable_v<ex::set_value_t,
+            decltype(begin), tt::sync_wait_t>);
+    auto compl_sched_begin =
+        ex::get_completion_scheduler<ex::set_value_t>(begin);
+    HPX_TEST(sched == compl_sched_begin);
+
+    auto work1 = ex::then(std::move(begin), [&then_count, parent_id]() {
+        sender_receiver_then_thread_id = hpx::this_thread::get_id();
+        HPX_TEST_EQ(sender_receiver_then_thread_id, parent_id);
+        ++then_count;
+    });
+
+    static_assert(
+        ex::detail::is_completion_scheduler_tag_invocable_v<ex::set_value_t,
+            decltype(work1), tt::sync_wait_t>);
+    auto compl_sched_work1 =
+        ex::get_completion_scheduler<ex::set_value_t>(work1);
+    HPX_TEST(sched == compl_sched_work1);
+
+    auto work2 = ex::then(std::move(work1), [&then_count, &executed]() {
+        HPX_TEST_EQ(sender_receiver_then_thread_id, hpx::this_thread::get_id());
+        ++then_count;
+        executed = true;
+    });
+
+    static_assert(
+        ex::detail::is_completion_scheduler_tag_invocable_v<ex::set_value_t,
+            decltype(work2), tt::sync_wait_t>);
+    auto compl_sched_work2 =
+        ex::get_completion_scheduler<ex::set_value_t>(work2);
+    HPX_TEST(sched == compl_sched_work1);
+
+    tt::sync_wait(std::move(work2));
+
+    HPX_TEST_EQ(then_count, std::size_t(2));
+    HPX_TEST(executed);
+}
+
+void test_sender_receiver_then_sync_wait()
+{
+    ex::run_loop loop;
+    auto sched = loop.get_scheduler();
+
+    hpx::thread::id parent_id = hpx::this_thread::get_id();
+    std::atomic<std::size_t> then_count{0};
+
+    auto begin = ex::schedule(sched);
+    auto work = ex::then(std::move(begin), [&then_count, parent_id]() {
+        sender_receiver_then_thread_id = hpx::this_thread::get_id();
+        HPX_TEST_EQ(sender_receiver_then_thread_id, parent_id);
+        ++then_count;
+        return 42;
+    });
+    auto result = hpx::get<0>(*(tt::sync_wait(std::move(work))));
+    HPX_TEST_EQ(then_count, std::size_t(1));
+    static_assert(
+        std::is_same<int, typename std::decay<decltype(result)>::type>::value,
+        "result should be an int");
+    HPX_TEST_EQ(result, 42);
+}
+
+void test_sender_receiver_then_arguments()
+{
+    ex::run_loop loop;
+    auto sched = loop.get_scheduler();
+
+    hpx::thread::id parent_id = hpx::this_thread::get_id();
+    std::atomic<std::size_t> then_count{0};
+
+    auto begin = ex::schedule(sched);
+    auto work1 = ex::then(std::move(begin), [&then_count, parent_id]() {
+        sender_receiver_then_thread_id = hpx::this_thread::get_id();
+        HPX_TEST_EQ(sender_receiver_then_thread_id, parent_id);
+        ++then_count;
+        return 3;
+    });
+    auto work2 =
+        ex::then(std::move(work1), [&then_count](int x) -> std::string {
+            HPX_TEST_EQ(
+                sender_receiver_then_thread_id, hpx::this_thread::get_id());
+            ++then_count;
+            return std::string("hello") + std::to_string(x);
+        });
+    auto work3 = ex::then(std::move(work2), [&then_count](std::string s) {
+        HPX_TEST_EQ(sender_receiver_then_thread_id, hpx::this_thread::get_id());
+        ++then_count;
+        return 2 * s.size();
+    });
+    auto result = hpx::get<0>(*tt::sync_wait(std::move(work3)));
+    HPX_TEST_EQ(then_count, std::size_t(3));
+    static_assert(std::is_same<std::size_t,
+                      typename std::decay<decltype(result)>::type>::value,
+        "result should be a std::size_t");
+    HPX_TEST_EQ(result, std::size_t(12));
+}
+
+void test_transfer_basic()
+{
+    ex::run_loop loop;
+    auto sched = loop.get_scheduler();
+
+    hpx::thread::id parent_id = hpx::this_thread::get_id();
+    hpx::thread::id current_id;
+
+    auto begin = ex::schedule(sched);
+    auto work1 = ex::then(begin, [=, &current_id]() {
+        current_id = hpx::this_thread::get_id();
+        HPX_TEST_EQ(current_id, parent_id);
+    });
+    auto work2 = ex::then(work1, [=, &current_id]() {
+        HPX_TEST_EQ(current_id, hpx::this_thread::get_id());
+    });
+    auto transfer1 = ex::transfer(work2, sched);
+    auto work3 = ex::then(transfer1, [=, &current_id]() {
+        hpx::thread::id new_id = hpx::this_thread::get_id();
+        HPX_TEST_EQ(current_id, new_id);
+        current_id = new_id;
+        HPX_TEST_EQ(current_id, parent_id);
+    });
+    auto work4 = ex::then(work3, [=, &current_id]() {
+        HPX_TEST_EQ(current_id, hpx::this_thread::get_id());
+    });
+    auto transfer2 = ex::transfer(work4, sched);
+    auto work5 = ex::then(transfer2, [=, &current_id]() {
+        hpx::thread::id new_id = hpx::this_thread::get_id();
+        HPX_TEST_EQ(current_id, new_id);
+        current_id = new_id;
+        HPX_TEST_EQ(current_id, parent_id);
+    });
+
+    tt::sync_wait(work5);
+}
+
+void test_transfer_arguments()
+{
+    ex::run_loop loop;
+    auto sched = loop.get_scheduler();
+
+    hpx::thread::id parent_id = hpx::this_thread::get_id();
+    hpx::thread::id current_id;
+
+    auto begin = ex::schedule(sched);
+    auto work1 = ex::then(begin, [=, &current_id]() {
+        current_id = hpx::this_thread::get_id();
+        HPX_TEST_EQ(current_id, parent_id);
+        return 3;
+    });
+    auto work2 = ex::then(work1, [=, &current_id](int x) {
+        HPX_TEST_EQ(current_id, hpx::this_thread::get_id());
+        return x / 2.0;
+    });
+    auto transfer1 = ex::transfer(work2, sched);
+    auto work3 = ex::then(transfer1, [=, &current_id](double x) {
+        hpx::thread::id new_id = hpx::this_thread::get_id();
+        HPX_TEST_EQ(current_id, new_id);
+        current_id = new_id;
+        HPX_TEST_EQ(current_id, parent_id);
+        return x / 2;
+    });
+    auto work4 = ex::then(work3, [=, &current_id](int x) {
+        HPX_TEST_EQ(current_id, hpx::this_thread::get_id());
+        return "result: " + std::to_string(x);
+    });
+    auto transfer2 = ex::transfer(work4, sched);
+    auto work5 = ex::then(transfer2, [=, &current_id](std::string s) {
+        hpx::thread::id new_id = hpx::this_thread::get_id();
+        HPX_TEST_EQ(current_id, new_id);
+        current_id = new_id;
+        HPX_TEST_EQ(current_id, parent_id);
+        return s + "!";
+    });
+
+    auto result = hpx::get<0>(*tt::sync_wait(work5));
+    static_assert(std::is_same_v<std::string, std::decay_t<decltype(result)>>,
+        "result should be a std::string");
+    HPX_TEST_EQ(result, std::string("result: 0!"));
+}
+
+void test_just_void()
+{
+    ex::run_loop loop;
+
+    hpx::thread::id parent_id = hpx::this_thread::get_id();
+
+    auto begin = ex::just();
+    auto transfer1 = ex::transfer(begin, loop.get_scheduler());
+    auto work1 = ex::then(transfer1,
+        [parent_id]() { HPX_TEST_EQ(parent_id, hpx::this_thread::get_id()); });
+
+    tt::sync_wait(work1);
+}
+
+void test_just_one_arg()
+{
+    ex::run_loop loop;
+
+    hpx::thread::id parent_id = hpx::this_thread::get_id();
+
+    auto begin = ex::just(3);
+    auto transfer1 = ex::transfer(begin, loop.get_scheduler());
+    auto work1 = ex::then(transfer1, [parent_id](int x) {
+        HPX_TEST_EQ(parent_id, hpx::this_thread::get_id());
+        HPX_TEST_EQ(x, 3);
+    });
+
+    tt::sync_wait(work1);
+}
+
+void test_just_two_args()
+{
+    ex::run_loop loop;
+
+    hpx::thread::id parent_id = hpx::this_thread::get_id();
+
+    auto begin = ex::just(3, std::string("hello"));
+    auto transfer1 = ex::transfer(begin, loop.get_scheduler());
+    auto work1 = ex::then(transfer1, [parent_id](int x, std::string y) {
+        HPX_TEST_EQ(parent_id, hpx::this_thread::get_id());
+        HPX_TEST_EQ(x, 3);
+        HPX_TEST_EQ(y, std::string("hello"));
+    });
+
+    tt::sync_wait(work1);
+}
+
+void test_transfer_just_void()
+{
+    ex::run_loop loop;
+    auto sched = loop.get_scheduler();
+
+    hpx::thread::id parent_id = hpx::this_thread::get_id();
+
+    auto begin = ex::transfer_just(sched);
+    auto work1 = ex::then(begin,
+        [parent_id]() { HPX_TEST_EQ(parent_id, hpx::this_thread::get_id()); });
+
+    tt::sync_wait(work1);
+}
+
+void test_transfer_just_one_arg()
+{
+    ex::run_loop loop;
+    auto sched = loop.get_scheduler();
+
+    hpx::thread::id parent_id = hpx::this_thread::get_id();
+
+    auto begin = ex::transfer_just(sched, 3);
+    auto work1 = ex::then(begin, [parent_id](int x) {
+        HPX_TEST_EQ(parent_id, hpx::this_thread::get_id());
+        HPX_TEST_EQ(x, 3);
+    });
+
+    tt::sync_wait(work1);
+}
+
+void test_transfer_just_two_args()
+{
+    ex::run_loop loop;
+    auto sched = loop.get_scheduler();
+
+    hpx::thread::id parent_id = hpx::this_thread::get_id();
+
+    auto begin = ex::transfer_just(sched, 3, std::string("hello"));
+    auto work1 = ex::then(begin, [parent_id](int x, std::string y) {
+        HPX_TEST_EQ(parent_id, hpx::this_thread::get_id());
+        HPX_TEST_EQ(x, 3);
+        HPX_TEST_EQ(y, std::string("hello"));
+    });
+
+    tt::sync_wait(work1);
+}
+
+// Note: when_all does not propagate the completion scheduler, for this reason
+// any senders coming after it need to be explicitly provided with the required
+// scheduler again.
+void test_when_all()
+{
+    ex::run_loop loop;
+    auto sched = loop.get_scheduler();
+
+    {
+        hpx::thread::id parent_id = hpx::this_thread::get_id();
+
+        auto work1 = ex::schedule(sched) | ex::then([parent_id]() {
+            HPX_TEST_EQ(parent_id, hpx::this_thread::get_id());
+            return 42;
+        });
+
+        auto work2 = ex::schedule(sched) | ex::then([parent_id]() {
+            HPX_TEST_EQ(parent_id, hpx::this_thread::get_id());
+            return std::string("hello");
+        });
+
+        auto work3 = ex::schedule(sched) | ex::then([parent_id]() {
+            HPX_TEST_EQ(parent_id, hpx::this_thread::get_id());
+            return 3.14;
+        });
+
+        auto when1 =
+            ex::when_all(std::move(work1), std::move(work2), std::move(work3));
+
+        bool executed{false};
+        std::move(when1) |
+            ex::then([parent_id, &executed](int x, std::string y, double z) {
+                HPX_TEST_EQ(parent_id, hpx::this_thread::get_id());
+                HPX_TEST_EQ(x, 42);
+                HPX_TEST_EQ(y, std::string("hello"));
+                HPX_TEST_EQ(z, 3.14);
+                executed = true;
+            }) |
+            tt::sync_wait(sched);
+
+        HPX_TEST(executed);
+    }
+
+    {
+        hpx::thread::id parent_id = hpx::this_thread::get_id();
+
+        // The exception is likely to be thrown before set_value from the second
+        // sender is called because the second sender sleeps.
+        auto work1 = ex::schedule(sched) | ex::then([parent_id]() -> int {
+            HPX_TEST_EQ(parent_id, hpx::this_thread::get_id());
+            throw std::runtime_error("error");
+        });
+
+        auto work2 = ex::schedule(sched) | ex::then([parent_id]() {
+            HPX_TEST_EQ(parent_id, hpx::this_thread::get_id());
+            hpx::this_thread::sleep_for(std::chrono::milliseconds(100));
+            return std::string("hello");
+        });
+
+        bool exception_thrown = false;
+
+        try
+        {
+            ex::when_all(std::move(work1), std::move(work2)) |
+                ex::then([parent_id](int x, std::string y) {
+                    HPX_TEST_EQ(parent_id, hpx::this_thread::get_id());
+                    HPX_TEST_EQ(x, 42);
+                    HPX_TEST_EQ(y, std::string("hello"));
+                }) |
+                tt::sync_wait(sched);
+
+            HPX_TEST(false);
+        }
+        catch (std::runtime_error const& e)
+        {
+            HPX_TEST_EQ(std::string(e.what()), std::string("error"));
+            exception_thrown = true;
+        }
+
+        HPX_TEST(exception_thrown);
+    }
+
+    {
+        hpx::thread::id parent_id = hpx::this_thread::get_id();
+
+        // The exception is likely to be thrown after set_value from the second
+        // sender is called because the first sender sleeps before throwing.
+        auto work1 = ex::schedule(sched) | ex::then([parent_id]() -> int {
+            HPX_TEST_EQ(parent_id, hpx::this_thread::get_id());
+            hpx::this_thread::sleep_for(std::chrono::milliseconds(100));
+            throw std::runtime_error("error");
+        });
+
+        auto work2 = ex::schedule(sched) | ex::then([parent_id]() {
+            HPX_TEST_EQ(parent_id, hpx::this_thread::get_id());
+            return std::string("hello");
+        });
+
+        bool exception_thrown = false;
+
+        try
+        {
+            ex::when_all(std::move(work1), std::move(work2)) |
+                ex::then([parent_id](int x, std::string y) {
+                    HPX_TEST_EQ(parent_id, hpx::this_thread::get_id());
+                    HPX_TEST_EQ(x, 42);
+                    HPX_TEST_EQ(y, std::string("hello"));
+                }) |
+                tt::sync_wait(sched);
+
+            HPX_TEST(false);
+        }
+        catch (std::runtime_error const& e)
+        {
+            HPX_TEST_EQ(std::string(e.what()), std::string("error"));
+            exception_thrown = true;
+        }
+
+        HPX_TEST(exception_thrown);
+    }
+}
+
+// Note: make_future does not propagate the completion scheduler, for this
+// reason any senders coming after it need to be explicitly provided with the
+// required scheduler again.
+void test_future_sender()
+{
+    // senders as futures
+    {
+        ex::run_loop loop;
+        auto sched = loop.get_scheduler();
+
+        auto s = ex::transfer_just(sched, 3);
+        auto f = ex::make_future(std::move(s));
+        HPX_TEST_EQ(f.get(), 3);
+    }
+
+    {
+        ex::run_loop loop;
+        auto sched = loop.get_scheduler();
+
+        auto f = ex::transfer_just(sched, 3) | ex::make_future();
+        HPX_TEST_EQ(f.get(), 3);
+    }
+
+    {
+        ex::run_loop loop;
+        auto sched = loop.get_scheduler();
+
+        auto f = ex::just(3) | ex::make_future(sched);
+        HPX_TEST_EQ(f.get(), 3);
+    }
+
+    {
+        ex::run_loop loop;
+        auto sched = loop.get_scheduler();
+
+        std::atomic<bool> called{false};
+        auto s = ex::schedule(sched) | ex::then([&] { called = true; });
+        auto f = ex::make_future(std::move(s));
+        f.get();
+        HPX_TEST(called);
+    }
+
+    {
+        ex::run_loop loop;
+        auto sched = loop.get_scheduler();
+
+        auto s1 = ex::transfer_just(sched, std::size_t(42));
+        auto s2 = ex::transfer_just(sched, 3.14);
+        auto s3 = ex::transfer_just(sched, std::string("hello"));
+        auto f = ex::make_future(sched,
+            ex::then(ex::when_all(std::move(s1), std::move(s2), std::move(s3)),
+                [](std::size_t x, double, std::string z) {
+                    return z.size() + x;
+                }));
+        HPX_TEST_EQ(f.get(), std::size_t(47));
+    }
+
+    // mixing senders and futures
+    {
+        ex::run_loop loop;
+        auto sched = loop.get_scheduler();
+
+        HPX_TEST_EQ(hpx::get<0>(*tt::sync_wait(
+                        sched, ex::make_future(ex::transfer_just(sched, 42)))),
+            42);
+    }
+
+    {
+        ex::run_loop loop;
+        auto sched = loop.get_scheduler();
+
+        HPX_TEST_EQ(ex::make_future(
+                        ex::transfer(hpx::async([]() { return 42; }), sched))
+                        .get(),
+            42);
+    }
+
+    {
+        ex::run_loop loop;
+        auto sched = loop.get_scheduler();
+
+        auto s1 = ex::transfer_just(sched, std::size_t(42));
+        auto s2 = ex::transfer_just(sched, 3.14);
+        auto s3 = ex::transfer_just(sched, std::string("hello"));
+        auto f = ex::make_future(sched,
+            ex::then(ex::when_all(std::move(s1), std::move(s2), std::move(s3)),
+                [](std::size_t x, double, std::string z) {
+                    return z.size() + x;
+                }));
+        auto sf = f.then([](auto&& f) { return f.get() - 40; }).share();
+        auto t1 = sf.then([](auto&& sf) { return sf.get() + 1; });
+        auto t2 = sf.then([](auto&& sf) { return sf.get() + 2; });
+        auto t1s = ex::then(std::move(t1), [](std::size_t x) { return x + 1; });
+        auto t1f = ex::make_future(sched, std::move(t1s));
+        auto last = hpx::dataflow(
+            hpx::unwrapping([](std::size_t x, std::size_t y) { return x + y; }),
+            t1f, t2);
+
+        HPX_TEST_EQ(last.get(), std::size_t(18));
+    }
+}
+
+void test_ensure_started()
+{
+    {
+        ex::run_loop loop;
+        auto sched = loop.get_scheduler();
+
+        ex::schedule(sched) | ex::ensure_started() | tt::sync_wait();
+    }
+
+    {
+        ex::run_loop loop;
+        auto sched = loop.get_scheduler();
+
+        auto s = ex::transfer_just(sched, 42) | ex::ensure_started();
+        HPX_TEST_EQ(hpx::get<0>(*tt::sync_wait(std::move(s))), 42);
+    }
+
+    {
+        ex::run_loop loop;
+        auto sched = loop.get_scheduler();
+
+        auto s = ex::transfer_just(sched, 42) | ex::ensure_started() |
+            ex::transfer(sched);
+        HPX_TEST_EQ(hpx::get<0>(*tt::sync_wait(std::move(s))), 42);
+    }
+
+    {
+        ex::run_loop loop;
+        auto sched = loop.get_scheduler();
+
+        auto s = ex::transfer_just(sched, 42) | ex::ensure_started();
+        HPX_TEST_EQ(hpx::get<0>(*tt::sync_wait(s)), 42);
+        HPX_TEST_EQ(hpx::get<0>(*tt::sync_wait(s)), 42);
+        HPX_TEST_EQ(hpx::get<0>(*tt::sync_wait(s)), 42);
+        HPX_TEST_EQ(hpx::get<0>(*tt::sync_wait(std::move(s))), 42);
+    }
+}
+
+// TODO: ensure_started does not fully work with run_loop
+//void test_ensure_started_when_all()
+//{
+//    {
+//        ex::run_loop loop;
+//        auto sched = loop.get_scheduler();
+//
+//        std::atomic<std::size_t> first_task_calls{0};
+//        std::atomic<std::size_t> successor_task_calls{0};
+//        hpx::mutex mtx;
+//        hpx::condition_variable cond;
+//        bool started{false};
+//        auto s = ex::schedule(sched) | ex::then([&]() {
+//            ++first_task_calls;
+//            std::lock_guard l{mtx};
+//            started = true;
+//            cond.notify_one();
+//        }) | ex::ensure_started();
+//        {
+//            std::unique_lock l{mtx};
+//            cond.wait(l, [&]() { return started; });
+//        }
+//        auto succ1 = s | ex::then([&]() {
+//            ++successor_task_calls;
+//            return 1;
+//        });
+//        auto succ2 = s | ex::then([&]() {
+//            ++successor_task_calls;
+//            return 2;
+//        });
+//        HPX_TEST_EQ(
+//            hpx::get<0>(*(ex::when_all(succ1, succ2) |
+//                ex::then([](int const& x, int const& y) { return x + y; }) |
+//                tt::sync_wait())),
+//            3);
+//        HPX_TEST_EQ(first_task_calls, std::size_t(1));
+//        HPX_TEST_EQ(successor_task_calls, std::size_t(2));
+//    }
+//
+//    {
+//        ex::run_loop loop;
+//        auto sched = loop.get_scheduler();
+//
+//        std::atomic<std::size_t> first_task_calls{0};
+//        std::atomic<std::size_t> successor_task_calls{0};
+//        hpx::mutex mtx;
+//        hpx::condition_variable cond;
+//        bool started{false};
+//        auto s = ex::schedule(sched) | ex::then([&]() {
+//            ++first_task_calls;
+//            std::lock_guard l{mtx};
+//            started = true;
+//            cond.notify_one();
+//            return 3;
+//        }) | ex::ensure_started();
+//        {
+//            std::unique_lock l{mtx};
+//            cond.wait(l, [&]() { return started; });
+//        }
+//        HPX_TEST_EQ(first_task_calls, std::size_t(1));
+//        auto succ1 = s | ex::then([&](int const& x) {
+//            ++successor_task_calls;
+//            return x + 1;
+//        });
+//        auto succ2 = s | ex::then([&](int const& x) {
+//            ++successor_task_calls;
+//            return x + 2;
+//        });
+//        HPX_TEST_EQ(
+//            hpx::get<0>(*(ex::when_all(succ1, succ2) |
+//                ex::then([](int const& x, int const& y) { return x + y; }) |
+//                tt::sync_wait())),
+//            9);
+//        HPX_TEST_EQ(first_task_calls, std::size_t(1));
+//        HPX_TEST_EQ(successor_task_calls, std::size_t(2));
+//    }
+//
+//    {
+//        ex::run_loop loop;
+//        auto sched = loop.get_scheduler();
+//
+//        std::atomic<std::size_t> first_task_calls{0};
+//        std::atomic<std::size_t> successor_task_calls{0};
+//        hpx::mutex mtx;
+//        hpx::condition_variable cond;
+//        bool started{false};
+//        auto s = ex::schedule(sched) | ex::then([&]() {
+//            ++first_task_calls;
+//            std::lock_guard l{mtx};
+//            started = true;
+//            cond.notify_one();
+//            return 3;
+//        }) | ex::ensure_started();
+//        {
+//            std::unique_lock l{mtx};
+//            cond.wait(l, [&]() { return started; });
+//        }
+//        auto succ1 = s | ex::transfer(sched) | ex::then([&](int const& x) {
+//            ++successor_task_calls;
+//            return x + 1;
+//        });
+//        auto succ2 = s | ex::transfer(sched) | ex::then([&](int const& x) {
+//            ++successor_task_calls;
+//            return x + 2;
+//        });
+//        HPX_TEST_EQ(
+//            hpx::get<0>(*(ex::when_all(succ1, succ2) |
+//                ex::then([](int const& x, int const& y) { return x + y; }) |
+//                tt::sync_wait())),
+//            9);
+//        HPX_TEST_EQ(first_task_calls, std::size_t(1));
+//        HPX_TEST_EQ(successor_task_calls, std::size_t(2));
+//    }
+//}
+
+void test_split()
+{
+    {
+        ex::run_loop loop;
+        auto sched = loop.get_scheduler();
+
+        ex::schedule(sched) | ex::split() | tt::sync_wait();
+    }
+
+    {
+        ex::run_loop loop;
+        auto sched = loop.get_scheduler();
+
+        auto s = ex::transfer_just(sched, 42) | ex::split();
+        HPX_TEST_EQ(hpx::get<0>(*tt::sync_wait(std::move(s))), 42);
+    }
+
+    {
+        ex::run_loop loop;
+        auto sched = loop.get_scheduler();
+
+        auto s =
+            ex::transfer_just(sched, 42) | ex::split() | ex::transfer(sched);
+        HPX_TEST_EQ(hpx::get<0>(*tt::sync_wait(std::move(s))), 42);
+    }
+
+    {
+        ex::run_loop loop;
+        auto sched = loop.get_scheduler();
+
+        auto s = ex::transfer_just(sched, 42) | ex::split();
+        HPX_TEST_EQ(hpx::get<0>(*tt::sync_wait(s)), 42);
+        HPX_TEST_EQ(hpx::get<0>(*tt::sync_wait(s)), 42);
+        HPX_TEST_EQ(hpx::get<0>(*tt::sync_wait(s)), 42);
+        HPX_TEST_EQ(hpx::get<0>(*tt::sync_wait(std::move(s))), 42);
+    }
+}
+
+// TODO: split does not fully work with run_loop
+//void test_split_when_all()
+//{
+//    ex::run_loop loop;
+//    auto sched = loop.get_scheduler();
+//
+//    {
+//        std::atomic<std::size_t> first_task_calls{0};
+//        std::atomic<std::size_t> successor_task_calls{0};
+//        auto s = ex::schedule(sched) | ex::then([&]() { ++first_task_calls; }) |
+//            ex::split();
+//        auto succ1 = s | ex::then([&]() {
+//            ++successor_task_calls;
+//            return 1;
+//        });
+//        auto succ2 = s | ex::then([&]() {
+//            ++successor_task_calls;
+//            return 2;
+//        });
+//        HPX_TEST_EQ(
+//            hpx::get<0>(*(ex::when_all(succ1, succ2) |
+//                ex::then([](int const& x, int const& y) { return x + y; }) |
+//                tt::sync_wait())),
+//            3);
+//        HPX_TEST_EQ(first_task_calls, std::size_t(1));
+//        HPX_TEST_EQ(successor_task_calls, std::size_t(2));
+//    }
+//
+//    {
+//        std::atomic<std::size_t> first_task_calls{0};
+//        std::atomic<std::size_t> successor_task_calls{0};
+//        auto s = ex::schedule(sched) | ex::then([&]() {
+//            ++first_task_calls;
+//            return 3;
+//        }) | ex::split();
+//        auto succ1 = s | ex::then([&](int const& x) {
+//            ++successor_task_calls;
+//            return x + 1;
+//        });
+//        auto succ2 = s | ex::then([&](int const& x) {
+//            ++successor_task_calls;
+//            return x + 2;
+//        });
+//        HPX_TEST_EQ(
+//            hpx::get<0>(*(ex::when_all(succ1, succ2) |
+//                ex::then([](int const& x, int const& y) { return x + y; }) |
+//                tt::sync_wait())),
+//            9);
+//        HPX_TEST_EQ(first_task_calls, std::size_t(1));
+//        HPX_TEST_EQ(successor_task_calls, std::size_t(2));
+//    }
+//
+//    {
+//        std::atomic<std::size_t> first_task_calls{0};
+//        std::atomic<std::size_t> successor_task_calls{0};
+//        auto s = ex::schedule(sched) | ex::then([&]() {
+//            ++first_task_calls;
+//            return 3;
+//        }) | ex::split();
+//        auto succ1 = s | ex::transfer(sched) | ex::then([&](int const& x) {
+//            ++successor_task_calls;
+//            return x + 1;
+//        });
+//        auto succ2 = s | ex::transfer(sched) | ex::then([&](int const& x) {
+//            ++successor_task_calls;
+//            return x + 2;
+//        });
+//        HPX_TEST_EQ(
+//            hpx::get<0>(*(ex::when_all(succ1, succ2) |
+//                ex::then([](int const& x, int const& y) { return x + y; }) |
+//                tt::sync_wait())),
+//            9);
+//        HPX_TEST_EQ(first_task_calls, std::size_t(1));
+//        HPX_TEST_EQ(successor_task_calls, std::size_t(2));
+//    }
+//}
+
+// TODO: let_value does not work with run_loop
+//void test_let_value()
+//{
+//    // void predecessor
+//    {
+//        ex::run_loop loop;
+//        auto sched = loop.get_scheduler();
+//
+//        auto result = hpx::get<0>(*(ex::schedule(sched) |
+//            ex::let_value([]() { return ex::just(42); }) | tt::sync_wait()));
+//        HPX_TEST_EQ(result, 42);
+//    }
+//
+//    {
+//        ex::run_loop loop;
+//        auto sched = loop.get_scheduler();
+//
+//        auto result = hpx::get<0>(*(ex::schedule(sched) | ex::let_value([=]() {
+//            return ex::transfer_just(sched, 42);
+//        }) | tt::sync_wait()));
+//        HPX_TEST_EQ(result, 42);
+//    }
+//
+//    {
+//        ex::run_loop loop;
+//        auto sched = loop.get_scheduler();
+//
+//        auto result = hpx::get<0>(*(ex::just() | ex::let_value([=]() {
+//            return ex::transfer_just(sched, 42);
+//        }) | tt::sync_wait()));
+//        HPX_TEST_EQ(result, 42);
+//    }
+//
+//    // int predecessor, value ignored
+//    {
+//        ex::run_loop loop;
+//        auto sched = loop.get_scheduler();
+//
+//        auto result = hpx::get<0>(*(ex::transfer_just(sched, 43) |
+//            ex::let_value([](int&) { return ex::just(42); }) |
+//            tt::sync_wait()));
+//        HPX_TEST_EQ(result, 42);
+//    }
+//
+//    {
+//        ex::run_loop loop;
+//        auto sched = loop.get_scheduler();
+//
+//        auto result = hpx::get<0>(*(ex::transfer_just(sched, 43) |
+//            ex::let_value([=](int&) { return ex::transfer_just(sched, 42); }) |
+//            tt::sync_wait()));
+//        HPX_TEST_EQ(result, 42);
+//    }
+//
+//    {
+//        ex::run_loop loop;
+//        auto sched = loop.get_scheduler();
+//
+//        auto result = hpx::get<0>(*(ex::just(43) | ex::let_value([=](int&) {
+//            return ex::transfer_just(sched, 42);
+//        }) | tt::sync_wait()));
+//        HPX_TEST_EQ(result, 42);
+//    }
+//
+//    // int predecessor, value used
+//    {
+//        ex::run_loop loop;
+//        auto sched = loop.get_scheduler();
+//
+//        auto result = hpx::get<0>(
+//            *(ex::transfer_just(sched, 43) | ex::let_value([](int& x) {
+//                return ex::just(42) | ex::then([&](int y) { return x + y; });
+//            }) | tt::sync_wait()));
+//        HPX_TEST_EQ(result, 85);
+//    }
+//
+//    {
+//        ex::run_loop loop;
+//        auto sched = loop.get_scheduler();
+//
+//        auto result = hpx::get<0>(
+//            *(ex::transfer_just(sched, 43) | ex::let_value([=](int& x) {
+//                return ex::transfer_just(sched, 42) |
+//                    ex::then([&](int y) { return x + y; });
+//            }) | tt::sync_wait()));
+//        HPX_TEST_EQ(result, 85);
+//    }
+//
+//    {
+//        ex::run_loop loop;
+//        auto sched = loop.get_scheduler();
+//
+//        auto result = hpx::get<0>(*(ex::just(43) | ex::let_value([=](int& x) {
+//            return ex::transfer_just(sched, 42) |
+//                ex::then([&](int y) { return x + y; });
+//        }) | tt::sync_wait()));
+//        HPX_TEST_EQ(result, 85);
+//    }
+//
+//    // predecessor throws, let sender is ignored
+//    {
+//        ex::run_loop loop;
+//        auto sched = loop.get_scheduler();
+//
+//        bool exception_thrown = false;
+//
+//        try
+//        {
+//            ex::transfer_just(sched, 43) | ex::then([](int x) -> int {
+//                throw std::runtime_error("error");
+//            }) | ex::let_value([](int&) {
+//                HPX_TEST(false);
+//                return ex::just(0);
+//            }) | tt::sync_wait();
+//
+//            HPX_TEST(false);
+//        }
+//        catch (std::runtime_error const& e)
+//        {
+//            HPX_TEST_EQ(std::string(e.what()), std::string("error"));
+//            exception_thrown = true;
+//        }
+//
+//        HPX_TEST(exception_thrown);
+//    }
+//}
+
+// TODO: let_error does not work with run_loop
+//void test_let_error()
+//{
+//    // void predecessor
+//    {
+//        ex::run_loop loop;
+//        auto sched = loop.get_scheduler();
+//
+//        std::atomic<bool> called{false};
+//        ex::schedule(sched) | ex::then([]() {
+//            throw std::runtime_error("error");
+//        }) | ex::let_error([&called](std::exception_ptr& ep) {
+//            called = true;
+//            check_exception_ptr_message(ep, "error");
+//            return ex::just();
+//        }) | tt::sync_wait();
+//        HPX_TEST(called);
+//    }
+//
+//    {
+//        ex::run_loop loop;
+//        auto sched = loop.get_scheduler();
+//
+//        std::atomic<bool> called{false};
+//        ex::schedule(sched) | ex::then([]() {
+//            throw std::runtime_error("error");
+//        }) | ex::let_error([=, &called](std::exception_ptr& ep) {
+//            called = true;
+//            check_exception_ptr_message(ep, "error");
+//            return ex::transfer_just(sched);
+//        }) | tt::sync_wait();
+//        HPX_TEST(called);
+//    }
+//
+//    {
+//        ex::run_loop loop;
+//        auto sched = loop.get_scheduler();
+//
+//        std::atomic<bool> called{false};
+//        ex::just() | ex::then([]() { throw std::runtime_error("error"); }) |
+//            ex::let_error([=, &called](std::exception_ptr& ep) {
+//                called = true;
+//                check_exception_ptr_message(ep, "error");
+//                return ex::transfer_just(sched);
+//            }) |
+//            tt::sync_wait();
+//        HPX_TEST(called);
+//    }
+//
+//    // int predecessor
+//    {
+//        ex::run_loop loop;
+//        auto sched = loop.get_scheduler();
+//
+//        auto result = hpx::get<0>(*(ex::schedule(sched) | ex::then([]() {
+//            throw std::runtime_error("error");
+//            return 43;
+//        }) | ex::let_error([](std::exception_ptr& ep) {
+//            check_exception_ptr_message(ep, "error");
+//            return ex::just(42);
+//        }) | tt::sync_wait()));
+//        HPX_TEST_EQ(result, 42);
+//    }
+//
+//    {
+//        ex::run_loop loop;
+//        auto sched = loop.get_scheduler();
+//
+//        auto result = hpx::get<0>(*(ex::schedule(sched) | ex::then([]() {
+//            throw std::runtime_error("error");
+//            return 43;
+//        }) | ex::let_error([=](std::exception_ptr& ep) {
+//            check_exception_ptr_message(ep, "error");
+//            return ex::transfer_just(sched, 42);
+//        }) | tt::sync_wait()));
+//        HPX_TEST_EQ(result, 42);
+//    }
+//
+//    {
+//        ex::run_loop loop;
+//        auto sched = loop.get_scheduler();
+//
+//        auto result = hpx::get<0>(*(ex::just() | ex::then([]() {
+//            throw std::runtime_error("error");
+//            return 43;
+//        }) | ex::let_error([=](std::exception_ptr& ep) {
+//            check_exception_ptr_message(ep, "error");
+//            return ex::transfer_just(sched, 42);
+//        }) | tt::sync_wait()));
+//        HPX_TEST_EQ(result, 42);
+//    }
+//
+//    // predecessor doesn't throw, let sender is ignored
+//    {
+//        ex::run_loop loop;
+//        auto sched = loop.get_scheduler();
+//
+//        auto result = hpx::get<0>(*(ex::transfer_just(sched, 42) |
+//            ex::let_error([](std::exception_ptr) {
+//                HPX_TEST(false);
+//                return ex::just(43);
+//            }) |
+//            tt::sync_wait()));
+//        HPX_TEST_EQ(result, 42);
+//    }
+//
+//    {
+//        ex::run_loop loop;
+//        auto sched = loop.get_scheduler();
+//
+//        auto result = hpx::get<0>(*(ex::transfer_just(sched, 42) |
+//            ex::let_error([=](std::exception_ptr) {
+//                HPX_TEST(false);
+//                return ex::transfer_just(sched, 43);
+//            }) |
+//            tt::sync_wait()));
+//        HPX_TEST_EQ(result, 42);
+//    }
+//
+//    {
+//        ex::run_loop loop;
+//        auto sched = loop.get_scheduler();
+//
+//        auto result =
+//            hpx::get<0>(*(ex::just(42) | ex::let_error([=](std::exception_ptr) {
+//                HPX_TEST(false);
+//                return ex::transfer_just(sched, 43);
+//            }) | tt::sync_wait()));
+//        HPX_TEST_EQ(result, 42);
+//    }
+//}
+
+void test_detach()
+{
+    {
+        ex::run_loop loop;
+        auto sched = loop.get_scheduler();
+
+        bool called = false;
+        hpx::mutex mtx;
+        hpx::condition_variable cond;
+        ex::schedule(sched) | ex::then([&]() {
+            std::unique_lock l{mtx};
+            called = true;
+            cond.notify_one();
+        }) | ex::start_detached();
+
+        {
+            std::unique_lock l{mtx};
+            HPX_TEST(cond.wait_for(
+                l, std::chrono::seconds(1), [&]() { return called; }));
+        }
+        HPX_TEST(called);
+    }
+
+    // Values passed to set_value are ignored
+    {
+        ex::run_loop loop;
+        auto sched = loop.get_scheduler();
+
+        bool called = false;
+        hpx::mutex mtx;
+        hpx::condition_variable cond;
+        ex::schedule(sched) | ex::then([&]() {
+            std::lock_guard l{mtx};
+            called = true;
+            cond.notify_one();
+            return 42;
+        }) | ex::start_detached();
+
+        {
+            std::unique_lock l{mtx};
+            HPX_TEST(cond.wait_for(
+                l, std::chrono::seconds(1), [&]() { return called; }));
+        }
+        HPX_TEST(called);
+    }
+}
+
+void test_keep_future_sender()
+{
+    // the future should be passed to then, not it's contained value
+    {
+        ex::run_loop loop;
+        auto sched = loop.get_scheduler();
+
+        hpx::make_ready_future<void>() | ex::keep_future() |
+            ex::then([](hpx::future<void>&& f) { HPX_TEST(f.is_ready()); }) |
+            tt::sync_wait(sched);
+    }
+
+    {
+        ex::run_loop loop;
+        auto sched = loop.get_scheduler();
+
+        hpx::make_ready_future<void>().share() | ex::keep_future() |
+            ex::then(
+                [](hpx::shared_future<void>&& f) { HPX_TEST(f.is_ready()); }) |
+            tt::sync_wait(sched);
+    }
+
+    {
+        ex::run_loop loop;
+        auto sched = loop.get_scheduler();
+
+        hpx::make_ready_future<int>(42) | ex::keep_future() |
+            ex::then([](hpx::future<int>&& f) {
+                HPX_TEST(f.is_ready());
+                HPX_TEST_EQ(f.get(), 42);
+            }) |
+            tt::sync_wait(sched);
+    }
+
+    {
+        ex::run_loop loop;
+        auto sched = loop.get_scheduler();
+
+        hpx::make_ready_future<int>(42).share() | ex::keep_future() |
+            ex::then([](hpx::shared_future<int>&& f) {
+                HPX_TEST(f.is_ready());
+                HPX_TEST_EQ(f.get(), 42);
+            }) |
+            tt::sync_wait(sched);
+    }
+
+    {
+        ex::run_loop loop;
+        auto sched = loop.get_scheduler();
+
+        std::atomic<bool> called{false};
+        auto f = hpx::async([&]() { called = true; });
+
+        auto r = hpx::get<0>(
+            *tt::sync_wait(sched, std::move(f) | ex::keep_future()));
+        static_assert(
+            std::is_same<std::decay_t<decltype(r)>, hpx::future<void>>::value,
+            "sync_wait should return future<void>");
+
+        HPX_TEST(called);
+        HPX_TEST(r.is_ready());
+
+        bool exception_thrown = false;
+        try
+        {
+            // The move is intentional. sync_wait should throw.
+            // NOLINTNEXTLINE(bugprone-use-after-move)
+            tt::sync_wait(sched, std::move(f) | ex::keep_future());
+            HPX_TEST(false);
+        }
+        catch (...)
+        {
+            exception_thrown = true;
+        }
+        HPX_TEST(exception_thrown);
+    }
+
+    {
+        ex::run_loop loop;
+        auto sched = loop.get_scheduler();
+
+        std::atomic<bool> called{false};
+        auto f = hpx::async([&]() {
+            called = true;
+            return 42;
+        });
+
+        auto r = hpx::get<0>(
+            *tt::sync_wait(sched, std::move(f) | ex::keep_future()));
+        static_assert(
+            std::is_same<std::decay_t<decltype(r)>, hpx::future<int>>::value,
+            "sync_wait should return future<int>");
+
+        HPX_TEST(called);
+        HPX_TEST(r.is_ready());
+        HPX_TEST_EQ(r.get(), 42);
+
+        bool exception_thrown = false;
+        try
+        {
+            // The move is intentional. sync_wait should throw.
+            // NOLINTNEXTLINE(bugprone-use-after-move)
+            tt::sync_wait(sched, std::move(f) | ex::keep_future());
+            HPX_TEST(false);
+        }
+        catch (...)
+        {
+            exception_thrown = true;
+        }
+        HPX_TEST(exception_thrown);
+    }
+
+    {
+        ex::run_loop loop;
+        auto sched = loop.get_scheduler();
+
+        std::atomic<bool> called{false};
+        auto f = hpx::async([&]() {
+            called = true;
+            return 42;
+        });
+
+        HPX_TEST_EQ(hpx::get<0>(*tt::sync_wait(sched,
+                        ex::then(std::move(f) | ex::keep_future(),
+                            [](hpx::future<int>&& f) { return f.get() / 2; }))),
+            21);
+        HPX_TEST(called);
+    }
+
+    {
+        ex::run_loop loop;
+        auto sched = loop.get_scheduler();
+
+        std::atomic<std::size_t> calls{0};
+        auto sf = hpx::async([&]() { ++calls; }).share();
+
+        tt::sync_wait(sched, sf | ex::keep_future());
+        tt::sync_wait(sched, sf | ex::keep_future());
+        tt::sync_wait(sched, std::move(sf) | ex::keep_future());
+        HPX_TEST_EQ(calls, std::size_t(1));
+
+        bool exception_thrown = false;
+        try
+        {
+            tt::sync_wait(sched, sf | ex::keep_future());
+            HPX_TEST(false);
+        }
+        catch (...)
+        {
+            exception_thrown = true;
+        }
+        HPX_TEST(exception_thrown);
+    }
+
+    {
+        ex::run_loop loop;
+        auto sched = loop.get_scheduler();
+
+        std::atomic<std::size_t> calls{0};
+        auto sf = hpx::async([&]() {
+            ++calls;
+            return 42;
+        }).share();
+
+        HPX_TEST_EQ(
+            hpx::get<0>(*tt::sync_wait(sched, sf | ex::keep_future())).get(),
+            42);
+        HPX_TEST_EQ(
+            hpx::get<0>(*tt::sync_wait(sched, sf | ex::keep_future())).get(),
+            42);
+        HPX_TEST_EQ(hpx::get<0>(*tt::sync_wait(
+                                    sched, std::move(sf) | ex::keep_future()))
+                        .get(),
+            42);
+        HPX_TEST_EQ(calls, std::size_t(1));
+
+        bool exception_thrown = false;
+        try
+        {
+            tt::sync_wait(sched, sf | ex::keep_future());
+            HPX_TEST(false);
+        }
+        catch (...)
+        {
+            exception_thrown = true;
+        }
+        HPX_TEST(exception_thrown);
+    }
+
+    // Keep future alive across on
+    {
+        ex::run_loop loop;
+        auto sched = loop.get_scheduler();
+
+        auto f = hpx::async([&]() { return 42; });
+
+        auto r = hpx::get<0>(*(std::move(f) | ex::keep_future() |
+            ex::transfer(sched) | tt::sync_wait()));
+        HPX_TEST(r.is_ready());
+        HPX_TEST_EQ(r.get(), 42);
+    }
+
+    {
+        ex::run_loop loop;
+        auto sched = loop.get_scheduler();
+
+        auto sf = hpx::async([&]() { return 42; }).share();
+
+        auto r = hpx::get<0>(*(std::move(sf) | ex::keep_future() |
+            ex::transfer(sched) | tt::sync_wait()));
+        HPX_TEST(r.is_ready());
+        HPX_TEST_EQ(r.get(), 42);
+    }
+
+    {
+        ex::run_loop loop;
+        auto sched = loop.get_scheduler();
+
+        auto sf = hpx::async([&]() {
+            return custom_type_non_default_constructible_non_copyable{42};
+        }).share();
+
+        // NOTE: Without keep_future this should fail to compile, since
+        // sync_wait would receive a const& to the value which requires a copy
+        // or storing a const&. The copy is not possible because the type is
+        // noncopyable, and storing a reference is not acceptable since the
+        // reference may outlive the value.
+        auto r = hpx::get<0>(*(std::move(sf) | ex::keep_future() |
+            ex::transfer(sched) | tt::sync_wait()));
+        HPX_TEST(r.is_ready());
+        HPX_TEST_EQ(r.get().x, 42);
+    }
+
+    // Use unwrapping with keep_future
+    {
+        ex::run_loop loop;
+        auto sched = loop.get_scheduler();
+
+        auto f = hpx::async([]() { return 42; });
+        auto sf = hpx::async([]() { return 3.14; }).share();
+
+        auto fun = hpx::unwrapping(
+            [](int&& x, double const& y) { return x * 2 + (int(y) / 2); });
+        HPX_TEST_EQ(hpx::get<0>(*(ex::when_all(std::move(f) | ex::keep_future(),
+                                      sf | ex::keep_future()) |
+                        ex::then(fun) | tt::sync_wait(sched))),
+            85);
+    }
+
+    {
+        ex::run_loop loop;
+        auto sched = loop.get_scheduler();
+
+        auto f = hpx::async([]() { return 42; });
+        auto sf = hpx::async([]() { return 3.14; }).share();
+
+        auto fun = hpx::unwrapping(
+            [](int&& x, double const& y) { return x * 2 + (int(y) / 2); });
+        HPX_TEST_EQ(hpx::get<0>(*(ex::when_all(std::move(f) | ex::keep_future(),
+                                      sf | ex::keep_future()) |
+                        ex::transfer(sched) | ex::then(fun) | tt::sync_wait())),
+            85);
+    }
+}
+
+void test_bulk()
+{
+    std::vector<int> const ns = {0, 1, 10, 43};
+
+    {
+        ex::run_loop loop;
+        auto sched = loop.get_scheduler();
+
+        for (int n : ns)
+        {
+            std::vector<int> v(n, 0);
+            hpx::thread::id parent_id = hpx::this_thread::get_id();
+
+            ex::schedule(sched) | ex::bulk(n, [&](int i) {
+                ++v[i];
+                HPX_TEST_EQ(parent_id, hpx::this_thread::get_id());
+            }) | tt::sync_wait();
+
+            for (int i = 0; i < n; ++i)
+            {
+                HPX_TEST_EQ(v[i], 1);
+            }
+        }
+    }
+
+    {
+        ex::run_loop loop;
+        auto sched = loop.get_scheduler();
+
+        for (auto n : ns)
+        {
+            std::vector<int> v(n, -1);
+            hpx::thread::id parent_id = hpx::this_thread::get_id();
+
+            auto v_out = hpx::get<0>(*(ex::transfer_just(sched, std::move(v)) |
+                ex::bulk(n,
+                    [&parent_id](int i, std::vector<int>& v) {
+                        v[i] = i;
+                        HPX_TEST_EQ(parent_id, hpx::this_thread::get_id());
+                    }) |
+                tt::sync_wait()));
+
+            for (int i = 0; i < n; ++i)
+            {
+                HPX_TEST_EQ(v_out[i], i);
+            }
+        }
+    }
+
+    {
+        ex::run_loop loop;
+        auto sched = loop.get_scheduler();
+
+        std::unordered_set<std::string> string_map;
+        std::vector<std::string> v = {"hello", "brave", "new", "world"};
+        std::vector<std::string> v_ref = v;
+
+        hpx::mutex mtx;
+
+        ex::schedule(sched) | ex::bulk(std::move(v), [&](std::string const& s) {
+            std::lock_guard lk(mtx);
+            string_map.insert(s);
+        }) | tt::sync_wait();
+
+        for (auto const& s : v_ref)
+        {
+            HPX_TEST(string_map.find(s) != string_map.end());
+        }
+    }
+
+    {
+        ex::run_loop loop;
+        auto sched = loop.get_scheduler();
+
+        for (auto n : ns)
+        {
+            int i_fail = 3;
+
+            std::vector<int> v(n, -1);
+            bool const expect_exception = n > i_fail;
+
+            try
+            {
+                ex::transfer_just(sched) | ex::bulk(n, [&v, i_fail](int i) {
+                    if (i == i_fail)
+                    {
+                        throw std::runtime_error("error");
+                    }
+                    v[i] = i;
+                }) | tt::sync_wait();
+
+                if (expect_exception)
+                {
+                    HPX_TEST(false);
+                }
+            }
+            catch (std::runtime_error const& e)
+            {
+                if (!expect_exception)
+                {
+                    HPX_TEST(false);
+                }
+
+                HPX_TEST_EQ(std::string(e.what()), std::string("error"));
+            }
+
+            if (expect_exception)
+            {
+                HPX_TEST_EQ(v[i_fail], -1);
+            }
+            else
+            {
+                for (int i = 0; i < n; ++i)
+                {
+                    HPX_TEST_EQ(v[i], i);
+                }
+            }
+        }
+    }
+}
+
+void test_completion_scheduler()
+{
+    ex::run_loop loop;
+    auto sched = loop.get_scheduler();
+
+    {
+        auto sender = ex::schedule(sched);
+        auto completion_scheduler =
+            ex::get_completion_scheduler<ex::set_value_t>(sender);
+        static_assert(
+            std::is_same_v<std::decay_t<decltype(completion_scheduler)>,
+                decltype(sched)>,
+            "the completion scheduler should be a run_pool_scheduler");
+    }
+
+    {
+        auto sender = ex::then(ex::schedule(sched), []() {});
+        using hpx::functional::tag_invoke;
+        auto completion_scheduler =
+            ex::get_completion_scheduler<ex::set_value_t>(sender);
+        static_assert(
+            std::is_same_v<std::decay_t<decltype(completion_scheduler)>,
+                decltype(sched)>,
+            "the completion scheduler should be a run_pool_scheduler");
+    }
+
+    {
+        auto sender = ex::transfer_just(sched, 42);
+        auto completion_scheduler =
+            ex::get_completion_scheduler<ex::set_value_t>(sender);
+        static_assert(
+            std::is_same_v<std::decay_t<decltype(completion_scheduler)>,
+                decltype(sched)>,
+            "the completion scheduler should be a run_pool_scheduler");
+    }
+
+    {
+        auto sender = ex::bulk(ex::schedule(sched), 10, [](int) {});
+        auto completion_scheduler =
+            ex::get_completion_scheduler<ex::set_value_t>(sender);
+        static_assert(
+            std::is_same_v<std::decay_t<decltype(completion_scheduler)>,
+                decltype(sched)>,
+            "the completion scheduler should be a run_pool_scheduler");
+    }
+
+    {
+        auto sender = ex::then(
+            ex::bulk(ex::transfer_just(sched, 42), 10, [](int, int) {}),
+            [](int) {});
+        auto completion_scheduler =
+            ex::get_completion_scheduler<ex::set_value_t>(sender);
+        static_assert(
+            std::is_same_v<std::decay_t<decltype(completion_scheduler)>,
+                decltype(sched)>,
+            "the completion scheduler should be a run_pool_scheduler");
+    }
+
+    {
+        auto sender =
+            ex::bulk(ex::then(ex::transfer_just(sched, 42), [](int) {}), 10,
+                [](int, int) {});
+        auto completion_scheduler =
+            ex::get_completion_scheduler<ex::set_value_t>(sender);
+        static_assert(
+            std::is_same_v<std::decay_t<decltype(completion_scheduler)>,
+                decltype(sched)>,
+            "the completion scheduler should be a run_pool_scheduler");
+    }
+
+    loop.finish();
+    loop.run();
+}
+
+int hpx_main()
+{
+    test_concepts();
+    test_execute();
+    test_sender_receiver_basic();
+    test_sender_receiver_then();
+    test_sender_receiver_then_wait();
+    test_sender_receiver_then_sync_wait();
+    test_sender_receiver_then_arguments();
+    test_transfer_basic();
+    test_transfer_arguments();
+    test_just_void();
+    test_just_one_arg();
+    test_just_two_args();
+    test_transfer_just_void();
+    test_transfer_just_one_arg();
+    test_transfer_just_two_args();
+    test_when_all();
+    test_future_sender();
+    test_keep_future_sender();
+    test_ensure_started();
+
+    // TODO: add support for run_loop
+    //test_ensure_started_when_all();
+    test_split();
+    //test_split_when_all();
+    //test_let_value();
+    //test_let_error();
+
+    test_detach();
+    test_bulk();
+
+    test_completion_scheduler();
+
+    return hpx::local::finalize();
+}
+
+int main(int argc, char* argv[])
+{
+    HPX_TEST_EQ_MSG(hpx::local::init(hpx_main, argc, argv), 0,
+        "HPX main exited with non-zero status");
+
+    return hpx::util::report_errors();
+}

--- a/libs/core/execution/tests/unit/algorithm_sync_wait.cpp
+++ b/libs/core/execution/tests/unit/algorithm_sync_wait.cpp
@@ -4,8 +4,8 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+#include <hpx/local/execution.hpp>
 #include <hpx/local/init.hpp>
-#include <hpx/modules/execution.hpp>
 #include <hpx/modules/testing.hpp>
 
 #include "algorithm_test_utils.hpp"

--- a/libs/core/execution/tests/unit/forwarding_sender_query.cpp
+++ b/libs/core/execution/tests/unit/forwarding_sender_query.cpp
@@ -1,0 +1,55 @@
+//  Copyright (c) 2022 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/execution/queries/get_scheduler.hpp>
+#include <hpx/execution_base/completion_scheduler.hpp>
+#include <hpx/functional/tag_invoke.hpp>
+#include <hpx/modules/testing.hpp>
+
+#include <exception>
+#include <string>
+#include <type_traits>
+#include <utility>
+
+namespace ex = hpx::execution::experimental;
+
+namespace mylib {
+
+    inline constexpr struct query_t final : hpx::functional::tag<query_t>
+    {
+        friend constexpr auto tag_invoke(
+            ex::forwarding_sender_query_t, query_t) noexcept
+        {
+            return true;
+        }
+    } query{};
+
+    inline constexpr struct non_query_t
+    {
+    } non_query{};
+
+}    // namespace mylib
+
+int main()
+{
+    static_assert(ex::forwarding_sender_query(mylib::query) == true,
+        "non_query CPO is user implemented to return true");
+
+    static_assert(ex::forwarding_sender_query(mylib::non_query) == false,
+        "invokes tag_fallback which returns false by default");
+
+    static_assert(ex::forwarding_sender_query(
+                      ex::get_completion_scheduler<ex::set_value_t>) == true,
+        "invokes CPO specialization that returns true");
+    static_assert(ex::forwarding_sender_query(
+                      ex::get_completion_scheduler<ex::set_error_t>) == true,
+        "invokes CPO specialization that returns true");
+    static_assert(ex::forwarding_sender_query(
+                      ex::get_completion_scheduler<ex::set_stopped_t>) == true,
+        "invokes CPO specialization that returns true");
+
+    return hpx::util::report_errors();
+}

--- a/libs/core/execution_base/include/hpx/execution_base/sender.hpp
+++ b/libs/core/execution_base/include/hpx/execution_base/sender.hpp
@@ -184,4 +184,11 @@ namespace hpx { namespace execution { namespace experimental {
 
     template <typename S, typename R>
     using connect_result_t = hpx::util::invoke_result_t<connect_t, S, R>;
-}}}    // namespace hpx::execution::experimental
+
+    namespace detail {
+        // Dummy type used in place of a scheduler if none is given
+        struct no_scheduler
+        {
+        };
+    }    // namespace detail
+}}}      // namespace hpx::execution::experimental

--- a/libs/core/execution_base/tests/include/algorithm_test_utils.hpp
+++ b/libs/core/execution_base/tests/include/algorithm_test_utils.hpp
@@ -6,6 +6,7 @@
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <hpx/modules/datastructures.hpp>
+#include <hpx/modules/errors.hpp>
 #include <hpx/modules/execution_base.hpp>
 #include <hpx/modules/testing.hpp>
 
@@ -89,15 +90,12 @@ struct error_sender
         friend void tag_invoke(
             hpx::execution::experimental::start_t, operation_state& os) noexcept
         {
-            try
-            {
-                throw std::runtime_error("error");
-            }
-            catch (...)
-            {
-                hpx::execution::experimental::set_error(
-                    std::move(os.r), std::current_exception());
-            }
+            hpx::detail::try_catch_exception_ptr(
+                []() { throw std::runtime_error("error"); },
+                [&](std::exception_ptr ep) {
+                    hpx::execution::experimental::set_error(
+                        std::move(os.r), std::move(ep));
+                });
         }
     };
 
@@ -285,15 +283,12 @@ struct error_typed_sender
         friend void tag_invoke(
             hpx::execution::experimental::start_t, operation_state& os) noexcept
         {
-            try
-            {
-                throw std::runtime_error("error");
-            }
-            catch (...)
-            {
-                hpx::execution::experimental::set_error(
-                    std::move(os.r), std::current_exception());
-            }
+            hpx::detail::try_catch_exception_ptr(
+                []() { throw std::runtime_error("error"); },
+                [&](std::exception_ptr ep) {
+                    hpx::execution::experimental::set_error(
+                        std::move(os.r), std::move(ep));
+                });
         };
     };
 

--- a/libs/core/execution_base/tests/include/algorithm_test_utils.hpp
+++ b/libs/core/execution_base/tests/include/algorithm_test_utils.hpp
@@ -341,7 +341,14 @@ struct custom_sender_tag_invoke
     struct operation_state
     {
         std::decay_t<R> r;
-        void start() noexcept
+
+        friend void tag_invoke(
+            hpx::execution::experimental::start_t, operation_state& os) noexcept
+        {
+            os.start();
+        }
+
+        void start() & noexcept
         {
             hpx::execution::experimental::set_value(std::move(r));
         }

--- a/libs/core/executors/tests/unit/thread_pool_scheduler.cpp
+++ b/libs/core/executors/tests/unit/thread_pool_scheduler.cpp
@@ -594,15 +594,14 @@ void test_when_all()
 
         // The exception is likely to be thrown before set_value from the second
         // sender is called because the second sender sleeps.
-        auto work1 = ex::schedule(sched) | ex::then([parent_id]() {
+        auto work1 = ex::schedule(sched) | ex::then([parent_id]() -> int {
             HPX_TEST_NEQ(parent_id, hpx::this_thread::get_id());
             throw std::runtime_error("error");
-            return 42;
         });
 
         auto work2 = ex::schedule(sched) | ex::then([parent_id]() {
             HPX_TEST_NEQ(parent_id, hpx::this_thread::get_id());
-            std::this_thread::sleep_for(std::chrono::milliseconds(100));
+            hpx::this_thread::sleep_for(std::chrono::milliseconds(100));
             return std::string("hello");
         });
 
@@ -633,11 +632,10 @@ void test_when_all()
 
         // The exception is likely to be thrown after set_value from the second
         // sender is called because the first sender sleeps before throwing.
-        auto work1 = ex::schedule(sched) | ex::then([parent_id]() {
+        auto work1 = ex::schedule(sched) | ex::then([parent_id]() -> int {
             HPX_TEST_NEQ(parent_id, hpx::this_thread::get_id());
-            std::this_thread::sleep_for(std::chrono::milliseconds(100));
+            hpx::this_thread::sleep_for(std::chrono::milliseconds(100));
             throw std::runtime_error("error");
-            return 42;
         });
 
         auto work2 = ex::schedule(sched) | ex::then([parent_id]() {

--- a/libs/core/futures/include/hpx/futures/detail/future_data.hpp
+++ b/libs/core/futures/include/hpx/futures/detail/future_data.hpp
@@ -133,7 +133,7 @@ namespace hpx { namespace lcos { namespace detail {
         util::atomic_count count_;
     };
 
-    /// support functions for hpx::intrusive_ptr
+    // support functions for hpx::intrusive_ptr
     inline void intrusive_ptr_add_ref(future_data_refcnt_base* p) noexcept
     {
         ++p->count_;
@@ -251,8 +251,7 @@ namespace hpx { namespace lcos { namespace detail {
             exception = 4 | ready
         };
 
-        /// Return whether or not the data is available for this
-        /// \a future.
+        // Return whether or not the data is available for this \a future.
         bool is_ready(
             std::memory_order order = std::memory_order_acquire) const noexcept
         {
@@ -302,9 +301,9 @@ namespace hpx { namespace lcos { namespace detail {
         template <typename Callback>
         static void handle_on_completed(Callback&& on_completed);
 
-        /// Set the callback which needs to be invoked when the future becomes
-        /// ready. If the future is ready the function will be invoked
-        /// immediately.
+        // Set the callback which needs to be invoked when the future becomes
+        // ready. If the future is ready the function will be invoked
+        // immediately.
         void set_on_completed(completed_callback_type data_sink) override;
 
         virtual state wait(error_code& ec = throws);
@@ -600,8 +599,8 @@ namespace hpx { namespace lcos { namespace detail {
                 [&](std::exception_ptr ep) { set_exception(HPX_MOVE(ep)); });
         }
 
-        /// Reset the promise to allow to restart an asynchronous
-        /// operation. Allows any subsequent set_data operation to succeed.
+        // Reset the promise to allow to restart an asynchronous operation.
+        // Allows any subsequent set_data operation to succeed.
         void reset(error_code& /*ec*/ = throws)
         {
             // no locking is required as semantics guarantee a single writer

--- a/libs/core/futures/include/hpx/futures/future.hpp
+++ b/libs/core/futures/include/hpx/futures/future.hpp
@@ -1620,8 +1620,10 @@ namespace hpx {
     {
         using shared_state = lcos::detail::timed_future_data<void>;
 
-        return hpx::traits::future_access<future<void>>::create(
+        hpx::intrusive_ptr<shared_state> p(
             new shared_state(abs_time.value(), hpx::util::unused));
+
+        return hpx::traits::future_access<future<void>>::create(HPX_MOVE(p));
     }
 
     template <typename T>

--- a/libs/core/logging/src/format/formatter/high_precision_time.cpp
+++ b/libs/core/logging/src/format/formatter/high_precision_time.cpp
@@ -110,7 +110,13 @@ namespace hpx { namespace util { namespace logging { namespace formatter {
             size_t start_pos = m_format.find(from);
             if (start_pos == std::string::npos)
                 return false;
-            m_format.replace(start_pos, std::strlen(from), to);
+
+            // MSVC: using std::string::replace triggers ASAN reports
+            // m_format.replace(start_pos, std::strlen(from), to);
+            std::string fmt(m_format.substr(0, start_pos));
+            fmt += to;
+            fmt += m_format.substr(start_pos + std::strlen(from));
+            m_format = HPX_MOVE(fmt);
             return true;
         }
 

--- a/libs/core/schedulers/include/hpx/schedulers/thread_queue.hpp
+++ b/libs/core/schedulers/include/hpx/schedulers/thread_queue.hpp
@@ -134,6 +134,7 @@ namespace hpx { namespace threads { namespace policies {
             std::ptrdiff_t const stacksize =
                 data.scheduler_base->get_stack_size(data.stacksize);
 
+#if !defined(HPX_HAVE_ADDRESS_SANITIZER)
             thread_heap_type* heap = nullptr;
 
             if (stacksize == parameters_.small_stacksize_)
@@ -157,6 +158,7 @@ namespace hpx { namespace threads { namespace policies {
                 heap = &thread_heap_nostack_;
             }
             HPX_ASSERT(heap);
+#endif
 
             if (data.initial_state ==
                     thread_schedule_state::pending_do_not_schedule ||
@@ -167,7 +169,6 @@ namespace hpx { namespace threads { namespace policies {
 
             // ASAN gets confused by reusing threads/stacks
 #if !defined(HPX_HAVE_ADDRESS_SANITIZER)
-
             // Check for an unused thread object.
             if (!heap->empty())
             {

--- a/libs/core/tag_invoke/include/hpx/functional/tag_invoke.hpp
+++ b/libs/core/tag_invoke/include/hpx/functional/tag_invoke.hpp
@@ -110,7 +110,7 @@ namespace hpx { namespace functional {
 namespace hpx::functional {
 
     template <auto& Tag>
-    using tag_t = typename std::decay<decltype(Tag)>::type;
+    using tag_t = std::decay_t<decltype(Tag)>;
 
     namespace tag_invoke_t_ns {
 

--- a/libs/full/actions/tests/unit/serialize_buffer.cpp
+++ b/libs/full/actions/tests/unit/serialize_buffer.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2014 Hartmut Kaiser
+//  Copyright (c) 2014-2022 Hartmut Kaiser
 //  Copyright (c) 2015 Andreas Schaefer
 //
 //  SPDX-License-Identifier: BSL-1.0
@@ -136,7 +136,12 @@ void test_initialization_from_vector(std::size_t max_size)
 ///////////////////////////////////////////////////////////////////////////////
 int hpx_main()
 {
+#if defined(HPX_DEBUG)
+    std::size_t const max_size = 1 << 10;
+#else
     std::size_t const max_size = 1 << 20;
+#endif
+
     std::unique_ptr<char[]> send_buffer(new char[max_size]);
 
     for (hpx::id_type const& loc : hpx::find_all_localities())


### PR DESCRIPTION
- implement execution::run_loop
- implement execution::forwarding_sender_query
- adding missing pieces to make_future, start_detached, sync_wait (make it work with run_loop)
- flyby: refine execution::forwarding_env_query and execution::forwarding_scheduler_query
- flyby: fixing get_completion_scheduler handling for let_xxx, schedule_from, partial algorithm
- flyby: properly constraining forwarding env, sender, and scheduler queries
