### PR TITLE
adds risc-v 64 bit support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1979,6 +1979,8 @@ else()
                                               "ppc64"
   )
     set(__has_timestamp_support ON)
+  elseif("${__target_arch}" STREQUAL "riscv64")
+    set(__has_timestamp_support ON)
   elseif("${__target_arch}" STREQUAL "bgq")
     set(__has_timestamp_support ON)
   elseif("${__target_arch}" STREQUAL "s390x")

--- a/cmake/TargetArch.cmake
+++ b/cmake/TargetArch.cmake
@@ -39,6 +39,8 @@ set(archdetect_cpp_code
         #else
             #error cmake_ARCH arm
         #endif
+    #elif defined(__riscv)
+        #error cmake_ARCH riscv64
     #elif defined(__i386) || defined(__i386__) || defined(_M_IX86)
         #error cmake_ARCH i386
     #elif defined(__i486__) || defined(__i586__) || defined(__i686__)

--- a/libs/core/config/include/hpx/config/compiler_fence.hpp
+++ b/libs/core/config/include/hpx/config/compiler_fence.hpp
@@ -1,5 +1,6 @@
 //  Copyright (c) 2008 Peter Dimov
 //  Copyright (c) 2017 Agustin Berge
+//  Copyright (c) 2022 Christopher Taylor 
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -46,6 +47,17 @@ extern "C" void _mm_pause();
 #define HPX_SMT_PAUSE __asm__ __volatile__("or 27,27,27")
 #elif defined(__arm__)
 #define HPX_SMT_PAUSE __asm__ __volatile__("yield")
+#elif defined(__riscv)
+// According to:
+//
+// https://blog.jiejiss.com/Rust-is-incompatible-with-LLVM-at-least-partially/
+// https://github.com/riscv/riscv-isa-manual/issues/43
+// https://stackoverflow.com/questions/68537854/pause-instruction-unrecognized-opcode-pause-in-risc-v
+//
+// gcc/clang assembler will not currently (2022) accept `fence w,unknown`;
+// `hand-rolling` the instruction (see below) does the job.
+// 
+#define HPX_SMT_PAUSE __asm__ __volatile__(".insn i 0x0F, 0, x0, x0, 0x010")
 #else
 #define HPX_SMT_PAUSE HPX_COMPILER_FENCE
 #endif

--- a/libs/core/coroutines/include/hpx/coroutines/detail/get_stack_pointer.hpp
+++ b/libs/core/coroutines/include/hpx/coroutines/detail/get_stack_pointer.hpp
@@ -1,4 +1,5 @@
 //  Copyright (c) 2013-2016 Thomas Heller
+//  Copyright (c) 2022 Christopher Taylor 
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0.
@@ -43,6 +44,8 @@ namespace hpx { namespace threads { namespace coroutines { namespace detail {
         asm("stw %%r1, 0(%0)" : "=&r"(stack_ptr_p));
 #elif defined(__arm__)
         asm("mov %0, sp" : "=r"(stack_ptr));
+#elif defined(__riscv)
+        __asm__ __volatile__("add %0, x0, sp" : "=r"(stack_ptr));
 #endif
         return stack_ptr;
 #endif

--- a/libs/core/hardware/CMakeLists.txt
+++ b/libs/core/hardware/CMakeLists.txt
@@ -25,7 +25,6 @@ set(hardware_compat_headers
     hpx/util/hardware/timestamp/linux_generic.hpp => hpx/modules/hardware.hpp
     hpx/util/hardware/timestamp/linux_x86_32.hpp => hpx/modules/hardware.hpp
     hpx/util/hardware/timestamp/linux_x86_64.hpp => hpx/modules/hardware.hpp
-    hpx/util/hardware/timestamp/linux_riscv_64.hpp => hpx/modules/hardware.hpp
     hpx/util/hardware/timestamp/msvc.hpp => hpx/modules/hardware.hpp
     hpx/util/hardware/timestamp.hpp => hpx/modules/hardware.hpp
 )

--- a/libs/core/hardware/CMakeLists.txt
+++ b/libs/core/hardware/CMakeLists.txt
@@ -13,6 +13,7 @@ set(hardware_headers
     hpx/hardware/timestamp/linux_generic.hpp
     hpx/hardware/timestamp/linux_x86_32.hpp
     hpx/hardware/timestamp/linux_x86_64.hpp
+    hpx/hardware/timestamp/linux_riscv_64.hpp
     hpx/hardware/timestamp/msvc.hpp
     hpx/hardware/timestamp.hpp
 )
@@ -24,6 +25,7 @@ set(hardware_compat_headers
     hpx/util/hardware/timestamp/linux_generic.hpp => hpx/modules/hardware.hpp
     hpx/util/hardware/timestamp/linux_x86_32.hpp => hpx/modules/hardware.hpp
     hpx/util/hardware/timestamp/linux_x86_64.hpp => hpx/modules/hardware.hpp
+    hpx/util/hardware/timestamp/linux_riscv_64.hpp => hpx/modules/hardware.hpp
     hpx/util/hardware/timestamp/msvc.hpp => hpx/modules/hardware.hpp
     hpx/util/hardware/timestamp.hpp => hpx/modules/hardware.hpp
 )
@@ -42,6 +44,7 @@ add_hpx_module(
     "hpx/hardware/timestamp/linux_generic.hpp"
     "hpx/hardware/timestamp/linux_x86_32.hpp"
     "hpx/hardware/timestamp/linux_x86_64.hpp"
+    "hpx/hardware/timestamp/linux_riscv_64.hpp"
     "hpx/hardware/timestamp/msvc.hpp"
   SOURCES ${hardware_sources}
   HEADERS ${hardware_headers}

--- a/libs/core/hardware/include/hpx/hardware/timestamp.hpp
+++ b/libs/core/hardware/include/hpx/hardware/timestamp.hpp
@@ -39,6 +39,8 @@
     #include <hpx/hardware/timestamp/linux_generic.hpp>
 #elif defined(__bgq__)
     #include <hpx/hardware/timestamp/bgq.hpp>
+#elif defined(__riscv)
+    #include <hpx/hardware/timestamp/linux_riscv_64.hpp>
 #else
     #error Unsupported platform.
 #endif

--- a/libs/core/hardware/include/hpx/hardware/timestamp/linux_riscv_64.hpp
+++ b/libs/core/hardware/include/hpx/hardware/timestamp/linux_riscv_64.hpp
@@ -1,0 +1,29 @@
+////////////////////////////////////////////////////////////////////////////////
+//  Copyright (c) 2022 Christopher Taylor 
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include <hpx/config.hpp>
+
+#include <cstdint>
+
+namespace hpx { namespace util { namespace hardware {
+
+    // clang-format off
+    HPX_HOST_DEVICE inline std::uint64_t timestamp()
+    {
+        std::uint64_t val = 0;
+        __asm__ __volatile__(
+                "rdtime %0;\n"
+                : "=r"(val)
+                :: );
+        return val;
+    }
+    // clang-format on
+
+}}}    // namespace hpx::util::hardware


### PR DESCRIPTION
## Fixes #

N/A; adds processor support (new feature)

## Proposed Changes

  - adds risc-v 64 bit support; required small changes to CMake build scripts and runtime source pertaining to compiler-fence, stack-pointer access, and timestamp.
 
## Any background context you want to provide?

PR provides support for risc-v 64 bit processors. PR developed and tested in the following hardware and software environment:

 - Hardware: SiFive HiFive Unleashed
 - OS: Ubuntu 10.3.0-1
 - Compiler: gcc/g++ 10.3.0
 - Cluster Management: Slurm 20.11.4
 - Parcelport tested: TCP/IP

Compiled using the following flags:

`cmake -D HPX_WITH_GENERIC_CONTEXT_COROUTINES=ON -DHPX_WITH_FETCH_ASIO=ON -DBOOST_ROOT=<PATH_TO_BOOST> -DHPX_WITH_MALLOC=tcmalloc ..`

The existing suite of example and test programs work.

## Checklist

Not all points below apply to all pull requests.

- [x] I have added a new feature and have added tests to go along with it.
- [ ] I have fixed a bug and have added a regression test.
- [ ] I have added a test using random numbers; I have made sure it uses a seed, and that random numbers generated are valid inputs for the tests.
