### PR TITLE
added logic to detect riscv compiler configured for 64 bit target

### DIFF
--- a/cmake/TargetArch.cmake
+++ b/cmake/TargetArch.cmake
@@ -39,7 +39,7 @@ set(archdetect_cpp_code
         #else
             #error cmake_ARCH arm
         #endif
-    #elif defined(__riscv)
+    #elif defined(__riscv) && (__riscv_xlen == 64)
         #error cmake_ARCH riscv64
     #elif defined(__i386) || defined(__i386__) || defined(_M_IX86)
         #error cmake_ARCH i386

--- a/libs/core/hardware/include/hpx/hardware/timestamp/linux_riscv_64.hpp
+++ b/libs/core/hardware/include/hpx/hardware/timestamp/linux_riscv_64.hpp
@@ -10,8 +10,6 @@
 
 #include <hpx/config.hpp>
 
-#if defined(__riscv)
-
 #include <cstdint>
 
 namespace hpx { namespace util { namespace hardware {
@@ -29,5 +27,3 @@ namespace hpx { namespace util { namespace hardware {
     // clang-format on
 
 }}}    // namespace hpx::util::hardware
-
-#endif

--- a/libs/core/hardware/tests/CMakeLists.txt
+++ b/libs/core/hardware/tests/CMakeLists.txt
@@ -36,12 +36,12 @@ if(HPX_WITH_TESTS)
       HEADERS ${hardware_headers}
       HEADER_ROOT ${PROJECT_SOURCE_DIR}/include
       EXCLUDE_FROM_ALL
-        "hpx/hardware/timestamp/msvc.hpp"
+        "hpx/hardware/timestamp/bgq.hpp"
+        "hpx/hardware/timestamp/linux_generic.hpp"
+        "hpx/hardware/timestamp/linux_riscv_64.hpp"
         "hpx/hardware/timestamp/linux_x86_32.hpp"
         "hpx/hardware/timestamp/linux_x86_64.hpp"
-        "hpx/hardware/timestamp/linux_generic.hpp"
-        "hpx/hardware/timestamp/linux_risk_64.hpp"
-        "hpx/hardware/timestamp/bgq.hpp"
+        "hpx/hardware/timestamp/msvc.hpp"
       NOLIBS
       DEPENDENCIES hpx_hardware
     )


### PR DESCRIPTION
## Fixes #

Modification to cmake target detection script. Enforces 64-bit target constraint on risc-v builds.

## Proposed Changes

  - cmake/TargetArch.cmake has 1 modification

## Any background context you want to provide?

Current risc-v support does not check to see if the compiler is configured for the 32 bit or 64 bit build target. This PR enforces a check, in cmake, making sure the 64-bit build target is configured in the compiler.

## Checklist

Not all points below apply to all pull requests.

- [x] I have added a new feature and have added tests to go along with it.
- [ ] I have fixed a bug and have added a regression test.
- [ ] I have added a test using random numbers; I have made sure it uses a seed, and that random numbers generated are valid inputs for the tests.
