### PR TITLE
defaults boost.context on riscv64

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1557,6 +1557,8 @@ hpx_option(
 include(HPX_SetupCUDA)
 include(HPX_PerformCxxFeatureTests)
 hpx_perform_cxx_feature_tests()
+include(TargetArch)
+target_architecture(__target_arch)
 
 # ##############################################################################
 # Set configuration option to use Boost.Context or not. This depends on the
@@ -1568,6 +1570,11 @@ endif()
 if("${HPX_PLATFORM_UC}" STREQUAL "BLUEGENEQ")
   set(__use_generic_coroutine_context ON)
 endif()
+# If compiling for riscv64, automatically bake in Boost.Context
+if(${__target_arch} STREQUAL "riscv64")
+  set(__use_generic_coroutine_context ON)
+endif()
+
 hpx_option(
   HPX_WITH_GENERIC_CONTEXT_COROUTINES
   BOOL
@@ -1939,9 +1946,7 @@ else()
   endif()
 
   set(__has_timestamp_support OFF)
-  include(TargetArch)
 
-  target_architecture(__target_arch)
   if("${__target_arch}" STREQUAL "i386"
      OR "${__target_arch}" STREQUAL "ix86"
      OR "${__target_arch}" STREQUAL "x86_64"

--- a/cmake/TargetArch.cmake
+++ b/cmake/TargetArch.cmake
@@ -146,15 +146,6 @@ function(target_architecture output_var)
       # Get rid of the value marker leaving just the architecture name
       string(REPLACE "cmake_ARCH " "" ARCH "${ARCH}")
 
-      # If compiling for riscv64, automatically bake in Boost.Context
-      if(ARCH STREQUAL "riscv64")
-        hpx_set_option(
-            HPX_WITH_GENERIC_CONTEXT_COROUTINES
-            VALUE ON
-            FORCE
-        )
-      endif()
-
       # If we are compiling with an unknown architecture this variable should
       # already be set to "unknown" but in the case that it's empty (i.e. due to
       # a typo in the code), then set it to unknown

--- a/cmake/TargetArch.cmake
+++ b/cmake/TargetArch.cmake
@@ -146,6 +146,15 @@ function(target_architecture output_var)
       # Get rid of the value marker leaving just the architecture name
       string(REPLACE "cmake_ARCH " "" ARCH "${ARCH}")
 
+      # If compiling for riscv64, automatically bake in Boost.Context
+      if(ARCH STREQUAL "riscv64")
+        hpx_set_option(
+            HPX_WITH_GENERIC_CONTEXT_COROUTINES
+            VALUE ON
+            FORCE
+        )
+      endif()
+
       # If we are compiling with an unknown architecture this variable should
       # already be set to "unknown" but in the case that it's empty (i.e. due to
       # a typo in the code), then set it to unknown


### PR DESCRIPTION
## Fixes #

N/A

## Proposed Changes

  - when riscv64 detected, automatically sets `HPX_WITH_GENERIC_CONTEXT_COROUTINES=ON` (Boost.Context)
 
## Any background context you want to provide?

- eases compilation process for users; "quality of life" modification.

## Checklist

Not all points below apply to all pull requests.

- [x] I have added a new feature and have added tests to go along with it.
- [ ] I have fixed a bug and have added a regression test.
- [ ] I have added a test using random numbers; I have made sure it uses a seed, and that random numbers generated are valid inputs for the tests.
