### PR TITLE
fix: Compilation errors for -std=c++17 builders

### DIFF
--- a/libs/core/execution_base/tests/unit/completion_signatures.cpp
+++ b/libs/core/execution_base/tests/unit/completion_signatures.cpp
@@ -319,6 +319,8 @@ void test_sender3()
         ex::detail::no_completion_signatures>);
 }
 
+#if defined(HPX_HAVE_CXX20_COROUTINES)
+
 template <typename Awaiter>
 struct promise
 {
@@ -466,6 +468,8 @@ void test_awaitable_sender3(Signatures)
     // static_assert(std::is_same_v<error_types_of, error_types>);
 }
 
+#endif    // HPX_HAVE_CXX20_COROUTINES
+
 int main()
 {
     {
@@ -542,6 +546,8 @@ int main()
 
     test_sender3();
 
+#if defined(HPX_HAVE_CXX20_COROUTINES)
+
     {
         test_awaitable_sender1(signature_error_values(std::exception_ptr()),
             hpx::coro::suspend_always{});
@@ -553,6 +559,8 @@ int main()
         // test_awaitable_sender2(signature_error_values(std::exception_ptr()));
         // test_awaitable_sender3(signature_error_values(std::exception_ptr()));
     }
+
+#endif    // HPX_HAVE_CXX20_COROUTINES
 
     return hpx::util::report_errors();
 }


### PR DESCRIPTION
- Wrap completion_signatures awaitable tests using HPX_HAVE_CXX20_COROUTINES

Signed-off-by: Shreyas Atre <shreyasatre16@gmail.com>

Fixes #
https://github.com/STEllAR-GROUP/hpx/runs/7716108866?check_suite_focus=true

