### PR TITLE
This properly terminates an application on Ctrl-C on Windows

### DIFF
--- a/libs/core/runtime_local/src/runtime_local.cpp
+++ b/libs/core/runtime_local/src/runtime_local.cpp
@@ -93,6 +93,8 @@ namespace hpx {
             std::cerr << "{what}: " << (reason ? reason : "Unknown reason")
                       << "\n";
         }
+
+        std::terminate();
     }
 
     HPX_CORE_EXPORT BOOL WINAPI termination_handler(DWORD ctrl_type)


### PR DESCRIPTION
See https://github.com/STEllAR-GROUP/hpx/issues/5903#issuecomment-1229500701 for the initial report