### PR TITLE
Using EVE requires C++20

### DIFF
--- a/.jenkins/lsu/env-clang-13.sh
+++ b/.jenkins/lsu/env-clang-13.sh
@@ -26,8 +26,6 @@ configure_extra_options+=" -DHPX_WITH_PARCELPORT_LCI=ON"
 configure_extra_options+=" -DHPX_WITH_FETCH_LCI=ON"
 configure_extra_options+=" -DHPX_WITH_PARCELPORT_LCI_BACKEND=ibv"
 configure_extra_options+=" -DHPX_WITH_LOGGING=OFF"
-configure_extra_options+=" -DHPX_WITH_DATAPAR_BACKEND=EVE"
-configure_extra_options+=" -DHPX_WITH_FETCH_EVE=ON"
 
 # The pwrapi library still needs to be set up properly on rostam
 # configure_extra_options+=" -DHPX_WITH_POWER_COUNTER=ON"

--- a/.jenkins/lsu/env-clang-14.sh
+++ b/.jenkins/lsu/env-clang-14.sh
@@ -26,6 +26,8 @@ configure_extra_options+=" -DHPX_WITH_PARCELPORT_LCI=ON"
 configure_extra_options+=" -DHPX_WITH_FETCH_LCI=ON"
 configure_extra_options+=" -DHPX_WITH_PARCELPORT_LCI_BACKEND=ibv"
 configure_extra_options+=" -DHPX_WITH_LOGGING=OFF"
+configure_extra_options+=" -DHPX_WITH_DATAPAR_BACKEND=EVE"
+configure_extra_options+=" -DHPX_WITH_FETCH_EVE=ON"
 
 # The pwrapi library still needs to be set up properly on rostam
 # configure_extra_options+=" -DHPX_WITH_POWER_COUNTER=ON"


### PR DESCRIPTION
- fixing configuration of our clang-v13 builder
