### PR TITLE
Fix CTRL+C on windows

### DIFF
--- a/libs/core/runtime_local/src/runtime_local.cpp
+++ b/libs/core/runtime_local/src/runtime_local.cpp
@@ -103,23 +103,23 @@ namespace hpx {
         {
         case CTRL_C_EVENT:
             handle_termination("Ctrl-C");
-            return TRUE;
+            break;
 
         case CTRL_BREAK_EVENT:
             handle_termination("Ctrl-Break");
-            return TRUE;
+            break;
 
         case CTRL_CLOSE_EVENT:
             handle_termination("Ctrl-Close");
-            return TRUE;
+            break;
 
         case CTRL_LOGOFF_EVENT:
             handle_termination("Logoff");
-            return TRUE;
+            break;
 
         case CTRL_SHUTDOWN_EVENT:
             handle_termination("Shutdown");
-            return TRUE;
+            break;
 
         default:
             break;

--- a/libs/core/runtime_local/src/runtime_local.cpp
+++ b/libs/core/runtime_local/src/runtime_local.cpp
@@ -93,8 +93,6 @@ namespace hpx {
             std::cerr << "{what}: " << (reason ? reason : "Unknown reason")
                       << "\n";
         }
-
-        std::terminate();
     }
 
     HPX_CORE_EXPORT BOOL WINAPI termination_handler(DWORD ctrl_type)


### PR DESCRIPTION
According to https://docs.microsoft.com/en-us/windows/console/setconsolectrlhandler
returning TRUE will stop further execution of installed handlers and stop the normal handler from running.

- [x] I have fixed a bug

