### PR TITLE
Add back explicit template parameters to lock_guards for nvcc

### DIFF
--- a/libs/core/execution/include/hpx/execution/algorithms/run_loop.hpp
+++ b/libs/core/execution/include/hpx/execution/algorithms/run_loop.hpp
@@ -320,7 +320,7 @@ namespace hpx::execution::experimental {
         void finish()
         {
             std::unique_lock l(mtx);
-            hpx::util::ignore_while_checking il(&l);
+            hpx::util::ignore_while_checking<decltype(l)> il(&l);
             HPX_UNUSED(il);
             stop = true;
             cond_var.notify_all();

--- a/libs/core/executors/include/hpx/executors/fork_join_executor.hpp
+++ b/libs/core/executors/include/hpx/executors/fork_join_executor.hpp
@@ -554,7 +554,8 @@ namespace hpx { namespace execution { namespace experimental {
                             }
                         },
                         [&](std::exception_ptr&& ep) {
-                            std::lock_guard l(exception_mutex);
+                            std::lock_guard<decltype(exception_mutex)> l(
+                                exception_mutex);
                             if (!exception)
                             {
                                 exception = HPX_MOVE(ep);
@@ -629,7 +630,8 @@ namespace hpx { namespace execution { namespace experimental {
                             }
                         },
                         [&](std::exception_ptr&& ep) {
-                            std::lock_guard l(exception_mutex);
+                            std::lock_guard<decltype(exception_mutex)> l(
+                                exception_mutex);
                             if (!exception)
                             {
                                 exception = HPX_MOVE(ep);


### PR DESCRIPTION
Fixes compilation with nvcc. I can also make the template arguments conditional on whether CUDA was enabled or not if you prefer.