### PR TITLE
Integrating sync_wait & sync_wait_with_variant

### DIFF
--- a/libs/core/execution/include/hpx/execution/algorithms/sync_wait.hpp
+++ b/libs/core/execution/include/hpx/execution/algorithms/sync_wait.hpp
@@ -350,7 +350,7 @@ namespace hpx::this_thread::experimental {
         }
 
         // clang-format off
-        template <typename Sender, Sync_wait_type Type,
+        template <typename Sender,
             HPX_CONCEPT_REQUIRES_(
                 hpx::execution::experimental::is_sender_v<Sender,
                     hpx::execution::experimental::detail::sync_wait_receiver_env>
@@ -362,7 +362,7 @@ namespace hpx::this_thread::experimental {
         {
             using receiver_type =
                 hpx::execution::experimental::detail::sync_wait_receiver<Sender,
-                    Type>;
+                    Sync_wait_type::single>;
             using state_type = typename receiver_type::shared_state;
 
             hpx::execution::experimental::run_loop& loop = sched.get_run_loop();
@@ -378,7 +378,7 @@ namespace hpx::this_thread::experimental {
         }
 
         // clang-format off
-        template <typename Sender, Sync_wait_type Type,
+        template <typename Sender,
             HPX_CONCEPT_REQUIRES_(
                 hpx::execution::experimental::is_sender_v<Sender,
                     hpx::execution::experimental::detail::sync_wait_receiver_env>
@@ -389,7 +389,7 @@ namespace hpx::this_thread::experimental {
         {
             using receiver_type =
                 hpx::execution::experimental::detail::sync_wait_receiver<Sender,
-                    Type>;
+                    Sync_wait_type::single>;
             using state_type = typename receiver_type::shared_state;
 
             hpx::execution::experimental::run_loop loop{};
@@ -461,7 +461,7 @@ namespace hpx::this_thread::experimental {
         }
 
         // clang-format off
-        template <typename Sender, Sync_wait_type Type,
+        template <typename Sender,
             HPX_CONCEPT_REQUIRES_(
                 hpx::execution::experimental::is_sender_v<Sender,
                     hpx::execution::experimental::detail::sync_wait_receiver_env>
@@ -473,7 +473,7 @@ namespace hpx::this_thread::experimental {
         {
             using receiver_type =
                 hpx::execution::experimental::detail::sync_wait_receiver<Sender,
-                    Type>;
+                    Sync_wait_type::variant>;
             using state_type = typename receiver_type::shared_state;
 
             hpx::execution::experimental::run_loop& loop = sched.get_run_loop();
@@ -489,7 +489,7 @@ namespace hpx::this_thread::experimental {
         }
 
         // clang-format off
-        template <typename Sender, Sync_wait_type Type,
+        template <typename Sender,
             HPX_CONCEPT_REQUIRES_(
                 hpx::execution::experimental::is_sender_v<Sender,
                     hpx::execution::experimental::detail::sync_wait_receiver_env>
@@ -500,7 +500,7 @@ namespace hpx::this_thread::experimental {
         {
             using receiver_type =
                 hpx::execution::experimental::detail::sync_wait_receiver<Sender,
-                    Type>;
+                    Sync_wait_type::variant>;
             using state_type = typename receiver_type::shared_state;
 
             hpx::execution::experimental::run_loop loop{};

--- a/libs/core/execution/tests/unit/CMakeLists.txt
+++ b/libs/core/execution/tests/unit/CMakeLists.txt
@@ -18,6 +18,7 @@ set(tests
     algorithm_split
     algorithm_start_detached
     algorithm_sync_wait
+    algorithm_sync_wait_with_variant
     algorithm_then
     algorithm_transfer
     algorithm_transfer_just

--- a/libs/core/execution/tests/unit/algorithm_sync_wait_with_variant.cpp
+++ b/libs/core/execution/tests/unit/algorithm_sync_wait_with_variant.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2021 ETH Zurich
+//  Copyright (c) 2022 Hartmut Kaiser
 //  Copyright (c) 2022 Chuanqiu He
 //
 //  SPDX-License-Identifier: BSL-1.0
@@ -115,7 +115,7 @@ int hpx_main()
 
     {
         auto s1 = ex::just(custom_type_non_default_constructible{42});
-        auto result = tt::sync_wait_with_variant(std::move(s1));
+        auto result = tt::sync_wait_with_variant(s1);
         auto v = *result;
         check_value_types<
             hpx::variant<hpx::tuple<custom_type_non_default_constructible>>>(
@@ -173,12 +173,12 @@ int hpx_main()
     }
 
     {
-        auto sender = ex::just(3) | ex::let_error([](std::exception_ptr) {
+        auto sd = ex::just(3) | ex::let_error([](std::exception_ptr) {
             HPX_TEST(false);
             return ex::just(std::string{"err"});
         });
 
-        auto result = tt::sync_wait_with_variant(std::move(sender));
+        auto result = tt::sync_wait_with_variant(sd);
 
         // variant
         auto v = *result;

--- a/libs/core/execution/tests/unit/algorithm_sync_wait_with_variant.cpp
+++ b/libs/core/execution/tests/unit/algorithm_sync_wait_with_variant.cpp
@@ -27,10 +27,6 @@ void tag_invoke(tt::sync_wait_with_variant_t, custom_sender2 s)
 {
     s.tag_invoke_overload_called = true;
 }
-void tag_invoke(tt::sync_wait_with_variant_t, custom_sender_multiTuple s)
-{
-    s.tag_invoke_overload_called = true;
-}
 
 int hpx_main()
 {
@@ -154,7 +150,7 @@ int hpx_main()
         std::atomic<bool> start_called{false};
         std::atomic<bool> connect_called{false};
         std::atomic<bool> tag_invoke_overload_called{false};
-        tt::sync_wait_with_variant(custom_sender_multiTuple{
+        tt::sync_wait_with_variant(custom_sender_multi_tuple{
             start_called, connect_called, tag_invoke_overload_called, true});
         HPX_TEST(start_called);
         HPX_TEST(connect_called);
@@ -165,7 +161,7 @@ int hpx_main()
         std::atomic<bool> start_called{false};
         std::atomic<bool> connect_called{false};
         std::atomic<bool> tag_invoke_overload_called{false};
-        tt::sync_wait_with_variant(custom_sender_multiTuple{
+        tt::sync_wait_with_variant(custom_sender_multi_tuple{
             start_called, connect_called, tag_invoke_overload_called, false});
         HPX_TEST(start_called);
         HPX_TEST(connect_called);
@@ -178,7 +174,7 @@ int hpx_main()
             return ex::just(std::string{"err"});
         });
 
-        auto result = tt::sync_wait_with_variant(sd);
+        auto result = tt::sync_wait_with_variant(std::move(sd));
 
         // variant
         auto v = *result;

--- a/libs/core/execution/tests/unit/algorithm_sync_wait_with_variant.cpp
+++ b/libs/core/execution/tests/unit/algorithm_sync_wait_with_variant.cpp
@@ -1,0 +1,299 @@
+//  Copyright (c) 2021 ETH Zurich
+//  Copyright (c) 2022 Chuanqiu He
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/local/init.hpp>
+#include <hpx/modules/execution.hpp>
+#include <hpx/modules/testing.hpp>
+
+#include "algorithm_test_utils.hpp"
+
+#include <atomic>
+#include <exception>
+#include <stdexcept>
+#include <string>
+#include <type_traits>
+#include <utility>
+
+namespace ex = hpx::execution::experimental;
+namespace tt = hpx::this_thread::experimental;
+
+// NOTE: This is not a conforming sync_wait_with_variant implementation.
+// It only exists to check that the tag_invoke overload is called.
+void tag_invoke(tt::sync_wait_with_variant_t, custom_sender2 s)
+{
+    s.tag_invoke_overload_called = true;
+}
+void tag_invoke(tt::sync_wait_with_variant_t, custom_sender_multiTuple s)
+{
+    s.tag_invoke_overload_called = true;
+}
+
+int hpx_main()
+{
+    // Success path
+    {
+        std::atomic<bool> start_called{false};
+        std::atomic<bool> connect_called{false};
+        std::atomic<bool> tag_invoke_overload_called{false};
+        tt::sync_wait_with_variant(custom_sender{
+            start_called, connect_called, tag_invoke_overload_called});
+        HPX_TEST(start_called);
+        HPX_TEST(connect_called);
+        HPX_TEST(!tag_invoke_overload_called);
+    }
+    // sync_wait_with_variant can accept single value senders :
+    // assume currently have one tuple
+    {
+        auto result = ex::just(42) | tt::sync_wait_with_variant();
+
+        auto v = *result;
+        static_assert(
+            std::is_same_v<decltype(v), hpx::variant<hpx::tuple<int>>>);
+        HPX_TEST(hpx::holds_alternative<hpx::tuple<int>>(v));
+
+        auto t = hpx::get<hpx::tuple<int>>(v);
+        static_assert(std::is_same_v<decltype(t), hpx::tuple<int>>);
+
+        auto i = hpx::get<0>(t);
+        static_assert(std::is_same_v<decltype(i), int>);
+
+        HPX_TEST(i == 42);
+    }
+
+    {
+        auto result = ex::just(3, 4.0) | tt::sync_wait_with_variant();
+
+        auto v = *result;
+        static_assert(
+            std::is_same_v<decltype(v), hpx::variant<hpx::tuple<int, double>>>);
+
+        auto t = hpx::get<hpx::tuple<int, double>>(v);
+        static_assert(std::is_same_v<decltype(t), hpx::tuple<int, double>>);
+
+        auto i = hpx::get<0>(t);
+        static_assert(std::is_same_v<decltype(i), int>);
+
+        HPX_TEST(i == 3);
+
+        auto j = hpx::get<1>(t);
+        static_assert(std::is_same_v<decltype(j), double>);
+
+        HPX_TEST(j == 4.0);
+    }
+
+    {
+        auto result =
+            tt::sync_wait_with_variant(ex::just(3, 4.0, std::string("42")));
+        auto v = *result;
+
+        static_assert(std::is_same_v<decltype(v),
+            hpx::variant<hpx::tuple<int, double, std::string>>>);
+
+        auto t = hpx::get<hpx::tuple<int, double, std::string>>(v);
+        static_assert(
+            std::is_same_v<decltype(t), hpx::tuple<int, double, std::string>>);
+
+        auto i = hpx::get<0>(t);
+        static_assert(std::is_same_v<decltype(i), int>);
+
+        HPX_TEST(i == 3);
+
+        auto j = hpx::get<1>(t);
+        static_assert(std::is_same_v<decltype(j), double>);
+
+        HPX_TEST(j == 4.0);
+
+        auto k = hpx::get<2>(t);
+        static_assert(std::is_same_v<decltype(k), std::string>);
+
+        HPX_TEST(k == "42");
+    }
+
+    {
+        auto s1 = ex::just(custom_type_non_default_constructible{42});
+        auto result = tt::sync_wait_with_variant(std::move(s1));
+        auto v = *result;
+        check_value_types<
+            hpx::variant<hpx::tuple<custom_type_non_default_constructible>>>(
+            s1);
+
+        auto t = hpx::get<hpx::tuple<custom_type_non_default_constructible>>(v);
+        auto p = hpx::get<0>(t);
+        static_assert(
+            std::is_same_v<decltype(p), custom_type_non_default_constructible>);
+
+        HPX_TEST_EQ(p.x, 42);
+    }
+
+    {
+        auto result = tt::sync_wait_with_variant(
+            ex::just(custom_type_non_default_constructible_non_copyable{42}));
+        auto const& v = *result;
+        static_assert(std::is_same_v<std::decay_t<decltype(v)>,
+            hpx::variant<hpx::tuple<
+                custom_type_non_default_constructible_non_copyable>>>);
+
+        auto const& t = hpx::get<
+            hpx::tuple<custom_type_non_default_constructible_non_copyable>>(v);
+        auto const& p = hpx::get<0>(t);
+        static_assert(std::is_same_v<std::decay_t<decltype(p)>,
+            custom_type_non_default_constructible_non_copyable>);
+
+        HPX_TEST_EQ(p.x, 42);
+    }
+
+    // sync_wait_with_variant can accept more than one senders:
+    // (accept variant of multi_tuple senders )
+    // tests a sender which has two different value types
+    // Success path
+    {
+        std::atomic<bool> start_called{false};
+        std::atomic<bool> connect_called{false};
+        std::atomic<bool> tag_invoke_overload_called{false};
+        tt::sync_wait_with_variant(custom_sender_multiTuple{
+            start_called, connect_called, tag_invoke_overload_called, true});
+        HPX_TEST(start_called);
+        HPX_TEST(connect_called);
+        HPX_TEST(!tag_invoke_overload_called);
+    }
+
+    {
+        std::atomic<bool> start_called{false};
+        std::atomic<bool> connect_called{false};
+        std::atomic<bool> tag_invoke_overload_called{false};
+        tt::sync_wait_with_variant(custom_sender_multiTuple{
+            start_called, connect_called, tag_invoke_overload_called, false});
+        HPX_TEST(start_called);
+        HPX_TEST(connect_called);
+        HPX_TEST(!tag_invoke_overload_called);
+    }
+
+    {
+        auto sender = ex::just(3) | ex::let_error([](std::exception_ptr) {
+            HPX_TEST(false);
+            return ex::just(std::string{"err"});
+        });
+
+        auto result = tt::sync_wait_with_variant(std::move(sender));
+
+        // variant
+        auto v = *result;
+        static_assert(std::is_same_v<decltype(v),
+            hpx::variant<hpx::tuple<std::string>, hpx::tuple<int>>>);
+
+        HPX_TEST(hpx::holds_alternative<hpx::tuple<int>>(v));
+
+        // tuple
+        auto t = hpx::get<1>(v);
+        static_assert(std::is_same_v<decltype(t), hpx::tuple<int>>);
+
+        auto i = hpx::get<0>(t);
+        static_assert(std::is_same_v<decltype(i), int>);
+
+        HPX_TEST_EQ(i, 3);
+    }
+
+    {
+        auto s1 = ex::just(custom_type_non_default_constructible{42});
+        auto s2 = ex::let_value(std::move(s1),
+            [](custom_type_non_default_constructible const& value) {
+                HPX_TEST_EQ(value.x, 42);
+                return ex::just(std::to_string(value.x));
+            });
+
+        auto result = tt::sync_wait_with_variant(std::move(s2));
+
+        // variant
+        auto v = *result;
+        static_assert(
+            std::is_same_v<decltype(v), hpx::variant<hpx::tuple<std::string>>>);
+
+        // tuple
+        auto t = hpx::get<0>(v);
+        static_assert(std::is_same_v<decltype(t), hpx::tuple<std::string>>);
+
+        auto j = hpx::get<0>(t);
+        static_assert(std::is_same_v<decltype(j), std::string>);
+
+        HPX_TEST_EQ(j, std::string("42"));
+    }
+
+    // operator| overload
+    {
+        std::atomic<bool> start_called{false};
+        std::atomic<bool> connect_called{false};
+        std::atomic<bool> tag_invoke_overload_called{false};
+        custom_sender{
+            start_called, connect_called, tag_invoke_overload_called} |
+            tt::sync_wait_with_variant();
+        HPX_TEST(start_called);
+        HPX_TEST(connect_called);
+        HPX_TEST(!tag_invoke_overload_called);
+    }
+
+    {
+        auto result = ex::just(3) | tt::sync_wait_with_variant();
+
+        auto v = *result;
+        static_assert(
+            std::is_same_v<decltype(v), hpx::variant<hpx::tuple<int>>>);
+        HPX_TEST(hpx::holds_alternative<hpx::tuple<int>>(v));
+
+        auto t = hpx::get<hpx::tuple<int>>(v);
+        static_assert(std::is_same_v<decltype(t), hpx::tuple<int>>);
+
+        auto i = hpx::get<0>(t);
+        static_assert(std::is_same_v<decltype(i), int>);
+
+        HPX_TEST(i == 3);
+    }
+
+    // tag_invoke overload
+    {
+        std::atomic<bool> start_called{false};
+        std::atomic<bool> connect_called{false};
+        std::atomic<bool> tag_invoke_overload_called{false};
+        tt::sync_wait_with_variant(custom_sender2{custom_sender{
+            start_called, connect_called, tag_invoke_overload_called}});
+        HPX_TEST(!start_called);
+        HPX_TEST(!connect_called);
+        HPX_TEST(tag_invoke_overload_called);
+    }
+
+    // Failure path
+    {
+        bool exception_thrown = false;
+        try
+        {
+            tt::sync_wait_with_variant(error_sender{});
+            HPX_TEST(false);
+        }
+        catch (std::runtime_error const& e)
+        {
+            HPX_TEST_EQ(std::string(e.what()), std::string("error"));
+            exception_thrown = true;
+        }
+        HPX_TEST(exception_thrown);
+    }
+
+    // cancellation path
+    {
+        auto result =
+            (stopped_sender_with_value_type{} | tt::sync_wait_with_variant());
+        HPX_TEST(!result);    // returned optional should be empty
+    }
+
+    return hpx::local::finalize();
+}
+
+int main(int argc, char* argv[])
+{
+    HPX_TEST_EQ_MSG(hpx::local::init(hpx_main, argc, argv), 0,
+        "HPX main exited with non-zero status");
+
+    return hpx::util::report_errors();
+}

--- a/libs/core/execution_base/tests/include/algorithm_test_utils.hpp
+++ b/libs/core/execution_base/tests/include/algorithm_test_utils.hpp
@@ -410,6 +410,61 @@ struct custom_sender
             hpx::execution::experimental::set_error_t(std::exception_ptr)>;
 };
 
+struct custom_sender_multiTuple
+{
+    std::atomic<bool>& start_called;
+    std::atomic<bool>& connect_called;
+    std::atomic<bool>& tag_invoke_overload_called;
+
+    bool expect_set_value = true;
+
+    template <template <class...> class Tuple,
+        template <class...> class Variant>
+    using value_types = Variant<Tuple<>>;
+
+    template <template <class...> class Variant>
+    using error_types = Variant<std::exception_ptr>;
+
+    static constexpr bool sends_stopped = false;
+
+    template <typename R>
+    struct operation_state
+    {
+        std::atomic<bool>& start_called;
+        std::decay_t<R> r;
+        bool expect_set_value = true;
+        friend void tag_invoke(
+            hpx::execution::experimental::start_t, operation_state& os) noexcept
+        {
+            os.start_called = true;
+            if (os.expect_set_value)
+            {
+                hpx::execution::experimental::set_value(std::move(os.r), 3);
+            }
+            else
+            {
+                hpx::execution::experimental::set_value(std::move(os.r), "err");
+            }
+        };
+    };
+
+    template <typename R>
+    friend auto tag_invoke(hpx::execution::experimental::connect_t,
+        custom_sender_multiTuple&& s, R&& r)
+    {
+        s.connect_called = true;
+        return operation_state<R>{s.start_called, std::forward<R>(r)};
+    }
+
+    template <typename Env>
+    friend auto tag_invoke(
+        hpx::execution::experimental::get_completion_signatures_t,
+        custom_sender_multiTuple const&, Env)
+        -> hpx::execution::experimental::completion_signatures<
+            hpx::execution::experimental::set_value_t(int),
+            hpx::execution::experimental::set_value_t(std::string)>;
+};
+
 template <typename T>
 struct custom_typed_sender
 {

--- a/libs/core/execution_base/tests/include/algorithm_test_utils.hpp
+++ b/libs/core/execution_base/tests/include/algorithm_test_utils.hpp
@@ -410,7 +410,7 @@ struct custom_sender
             hpx::execution::experimental::set_error_t(std::exception_ptr)>;
 };
 
-struct custom_sender_multiTuple
+struct custom_sender_multi_tuple
 {
     std::atomic<bool>& start_called;
     std::atomic<bool>& connect_called;
@@ -450,7 +450,7 @@ struct custom_sender_multiTuple
 
     template <typename R>
     friend auto tag_invoke(hpx::execution::experimental::connect_t,
-        custom_sender_multiTuple&& s, R&& r)
+        custom_sender_multi_tuple&& s, R&& r)
     {
         s.connect_called = true;
         return operation_state<R>{s.start_called, std::forward<R>(r)};
@@ -459,7 +459,7 @@ struct custom_sender_multiTuple
     template <typename Env>
     friend auto tag_invoke(
         hpx::execution::experimental::get_completion_signatures_t,
-        custom_sender_multiTuple const&, Env)
+        custom_sender_multi_tuple const&, Env)
         -> hpx::execution::experimental::completion_signatures<
             hpx::execution::experimental::set_value_t(int),
             hpx::execution::experimental::set_value_t(std::string)>;


### PR DESCRIPTION
## Proposed Changes:
Ref: [P2300R5](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2022/p2300r5.html#example-schedulers)
Integrate sync_wait and sync_wait_with_variant.

## Checklist

-  I have added a new feature and have added tests to go along with it.
