### PR TITLE
loop and transform_loop unseq adaptation

### DIFF
--- a/libs/core/algorithms/CMakeLists.txt
+++ b/libs/core/algorithms/CMakeLists.txt
@@ -176,6 +176,7 @@ set(algorithms_headers
     hpx/parallel/spmd_block.hpp
     hpx/parallel/task_block.hpp
     hpx/parallel/task_group.hpp
+    hpx/parallel/unseq.hpp
     hpx/parallel/util/cancellation_token.hpp
     hpx/parallel/util/compare_projected.hpp
     hpx/parallel/util/detail/algorithm_result.hpp

--- a/libs/core/algorithms/CMakeLists.txt
+++ b/libs/core/algorithms/CMakeLists.txt
@@ -177,6 +177,7 @@ set(algorithms_headers
     hpx/parallel/task_block.hpp
     hpx/parallel/task_group.hpp
     hpx/parallel/unseq.hpp
+    hpx/parallel/unseq/loop.hpp
     hpx/parallel/unseq/transform_loop.hpp
     hpx/parallel/util/cancellation_token.hpp
     hpx/parallel/util/compare_projected.hpp

--- a/libs/core/algorithms/CMakeLists.txt
+++ b/libs/core/algorithms/CMakeLists.txt
@@ -177,6 +177,7 @@ set(algorithms_headers
     hpx/parallel/task_block.hpp
     hpx/parallel/task_group.hpp
     hpx/parallel/unseq.hpp
+    hpx/parallel/unseq/transform_loop.hpp
     hpx/parallel/util/cancellation_token.hpp
     hpx/parallel/util/compare_projected.hpp
     hpx/parallel/util/detail/algorithm_result.hpp

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/for_each.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/for_each.hpp
@@ -249,6 +249,7 @@ namespace hpx {
 #include <hpx/modules/executors.hpp>
 #include <hpx/parallel/algorithms/detail/dispatch.hpp>
 #include <hpx/parallel/algorithms/detail/distance.hpp>
+#include <hpx/parallel/unseq/loop.hpp>
 #include <hpx/parallel/util/detail/algorithm_result.hpp>
 #include <hpx/parallel/util/detail/sender_util.hpp>
 #include <hpx/parallel/util/foreach_partitioner.hpp>

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/for_loop.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/for_loop.hpp
@@ -751,6 +751,7 @@ namespace hpx { namespace experimental {
 #include <hpx/parallel/algorithms/detail/dispatch.hpp>
 #include <hpx/parallel/algorithms/for_loop_induction.hpp>
 #include <hpx/parallel/algorithms/for_loop_reduction.hpp>
+#include <hpx/parallel/unseq/loop.hpp>
 #include <hpx/parallel/util/detail/algorithm_result.hpp>
 #include <hpx/parallel/util/loop.hpp>
 #include <hpx/parallel/util/partitioner.hpp>

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/transform.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/transform.hpp
@@ -293,6 +293,7 @@ namespace hpx {
 #include <hpx/executors/execution_policy.hpp>
 #include <hpx/parallel/algorithms/detail/dispatch.hpp>
 #include <hpx/parallel/algorithms/detail/distance.hpp>
+#include <hpx/parallel/unseq/transform_loop.hpp>
 #include <hpx/parallel/util/detail/algorithm_result.hpp>
 #include <hpx/parallel/util/foreach_partitioner.hpp>
 #include <hpx/parallel/util/projection_identity.hpp>

--- a/libs/core/algorithms/include/hpx/parallel/unseq.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/unseq.hpp
@@ -7,4 +7,5 @@
 #pragma once
 
 #include <hpx/execution.hpp>
+#include <hpx/parallel/unseq/loop.hpp>
 #include <hpx/parallel/unseq/transform_loop.hpp>

--- a/libs/core/algorithms/include/hpx/parallel/unseq.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/unseq.hpp
@@ -1,0 +1,9 @@
+//  Copyright (c) 2022 A Kishore Kumar
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include <hpx/config.hpp>

--- a/libs/core/algorithms/include/hpx/parallel/unseq.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/unseq.hpp
@@ -6,4 +6,5 @@
 
 #pragma once
 
-#include <hpx/config.hpp>
+#include <hpx/execution.hpp>
+#include <hpx/parallel/unseq/transform_loop.hpp>

--- a/libs/core/algorithms/include/hpx/parallel/unseq/loop.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/unseq/loop.hpp
@@ -1,0 +1,356 @@
+//  Copyright (c) 2022 A Kishore Kumar
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include <hpx/config.hpp>
+
+#include <hpx/executors/execution_policy.hpp>
+#include <hpx/functional/tag_invoke.hpp>
+#include <hpx/parallel/util/loop.hpp>
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <iterator>
+#include <type_traits>
+#include <utility>
+
+namespace hpx { namespace parallel { namespace util {
+
+    ///////////////////////////////////////////////////////////////////////////
+    namespace detail {
+        ///////////////////////////////////////////////////////////////////////
+        struct unseq_loop_n
+        {
+            template <typename InIter, typename F>
+            HPX_HOST_DEVICE HPX_FORCEINLINE static InIter call(
+                InIter it, std::size_t count, F&& f)
+            {
+                // clang-format off
+                HPX_IVDEP HPX_UNROLL HPX_VECTORIZE
+                for (std::size_t i = 0; i < count; i++)
+                {
+                    HPX_INVOKE(f, it);
+                    ++it;
+                }
+                // clang-format on
+                return it;
+            }
+
+            template <typename InIter, typename CancelToken, typename F>
+            HPX_HOST_DEVICE HPX_FORCEINLINE static InIter call(
+                InIter it, std::size_t count, CancelToken& tok,
+                F&& f)
+            {
+                // clang-format off
+                HPX_IVDEP HPX_UNROLL HPX_VECTORIZE
+                for (std::size_t i = 0; i < count; i++)
+                {
+                    HPX_INVOKE(f, it);
+                    if (tok.was_cancelled())
+                        return it;
+                    ++it;
+                }
+                // clang-format on
+                return it;
+            }
+        };
+
+        struct unseq_loop_n_ind
+        {
+            template <typename InIter, typename F>
+            HPX_HOST_DEVICE HPX_FORCEINLINE static InIter call(
+                InIter it, std::size_t count, F&& f)
+            {
+                // clang-format off
+                HPX_IVDEP HPX_UNROLL HPX_VECTORIZE
+                for (std::size_t i = 0; i < count; i++)
+                {
+                    HPX_INVOKE(f, *it);
+                    ++it;
+                }
+                // clang-format on
+                return it;
+            }
+        };
+
+        ///////////////////////////////////////////////////////////////////////
+        struct unseq_loop
+        {
+            template <typename Begin, typename End, typename F>
+            HPX_HOST_DEVICE HPX_FORCEINLINE static typename std::enable_if<
+                hpx::traits::is_random_access_iterator_v<Begin>, Begin>::type
+            call(Begin it, End end, F&& f)
+            {
+                return unseq_loop_n::call(
+                    it, std::distance(it, end), HPX_FORWARD(F, f));
+            }
+
+            template <typename Begin, typename End, typename F>
+            HPX_HOST_DEVICE HPX_FORCEINLINE static typename std::enable_if<
+                !hpx::traits::is_random_access_iterator_v<Begin>, Begin>::type
+            call(Begin it, End end, F&& f)
+            {
+                for (/* */; it != end; it++)
+                {
+                    HPX_INVOKE(f, it);
+                }
+            }
+
+            template <typename Begin, typename End, typename CancelToken,
+                typename F>
+            HPX_HOST_DEVICE HPX_FORCEINLINE static typename std::enable_if<
+                hpx::traits::is_random_access_iterator_v<Begin>, Begin>::type
+            call(Begin it, End end, CancelToken& tok,
+                F&& f)
+            {
+                return unseq_loop_n::call(
+                    it, std::distance(it, end), tok, HPX_FORWARD(F, f));
+            }
+
+            template <typename Begin, typename End, typename CancelToken,
+                typename F>
+            HPX_HOST_DEVICE HPX_FORCEINLINE static typename std::enable_if<
+                !hpx::traits::is_random_access_iterator_v<Begin>, Begin>::type
+            call(Begin it, End end, CancelToken& tok,
+                F&& f)
+            {
+                for (/* */; it != end; ++it)
+                {
+                    HPX_INVOKE(f, it);
+                    if (tok.was_cancelled())
+                        return it;
+                }
+                return it;
+            }
+        };
+
+        struct unseq_loop_ind
+        {
+            template <typename Begin, typename End, typename F>
+            HPX_HOST_DEVICE HPX_FORCEINLINE static typename std::enable_if<
+                hpx::traits::is_random_access_iterator_v<Begin>, Begin>::type
+            call(Begin it, End end, F&& f)
+            {
+                return unseq_loop_n_ind::call(
+                    it, std::distance(it, end), HPX_FORWARD(F, f));
+            }
+
+            template <typename Begin, typename End, typename F>
+            HPX_HOST_DEVICE HPX_FORCEINLINE static typename std::enable_if<
+                !hpx::traits::is_random_access_iterator_v<Begin>, Begin>::type
+            call(Begin it, End end, F&& f)
+            {
+                for (/* */; it != end; ++it)
+                {
+                    HPX_INVOKE(f, *it);
+                }
+                return it;
+            }
+        };
+
+        ///////////////////////////////////////////////////////////////////////
+        struct unseq_loop2
+        {
+            template <typename InIter1, typename InIter2, typename F>
+            HPX_HOST_DEVICE HPX_FORCEINLINE static typename std::enable_if<
+                hpx::traits::is_random_access_iterator_v<InIter1> and
+                    hpx::traits::is_random_access_iterator_v<InIter2>,
+                std::pair<InIter1, InIter2>>::type
+            call(InIter1 it1, InIter1 last1,
+                InIter2 it2, F&& f)
+            {
+                std::size_t count = std::distance(it1, last1);
+                // clang-format off
+                HPX_IVDEP HPX_UNROLL HPX_VECTORIZE
+                for (std::size_t i = 0; i < count; i++)
+                {
+                    HPX_INVOKE(f, it1, it2);
+                    ++it1, ++it2;
+                }
+                // clang-format on
+                return std::make_pair(HPX_MOVE(it1), HPX_MOVE(it2));
+            }
+
+            template <typename InIter1, typename InIter2, typename F>
+            HPX_HOST_DEVICE HPX_FORCEINLINE static typename std::enable_if<
+                !hpx::traits::is_random_access_iterator_v<InIter1> or
+                    !hpx::traits::is_random_access_iterator_v<InIter2>,
+                std::pair<InIter1, InIter2>>::type
+            call(InIter1 it1, InIter1 last1,
+                InIter2 it2, F&& f)
+            {
+                for (/* */; it1 != last1; it1++, it2++)
+                {
+                    HPX_INVOKE(f, it1, it2);
+                }
+                return std::make_pair(HPX_MOVE(it1), HPX_MOVE(it2));
+            }
+        };
+
+        ///////////////////////////////////////////////////////////////////////
+        struct unseq_loop_idx_n
+        {
+            template <typename Iter, typename F>
+            HPX_HOST_DEVICE HPX_FORCEINLINE static Iter call(
+                std::size_t base_idx, Iter it, std::size_t count,
+                F&& f)
+            {
+                // clang-format off
+                HPX_IVDEP HPX_UNROLL HPX_VECTORIZE
+                for (std::size_t i = 0; i < count; i++)
+                {
+                    HPX_INVOKE(f, *it, base_idx);
+                    ++it, ++base_idx;
+                }
+                // clang-format on
+                return it;
+            }
+
+            template <typename Iter, typename CancelToken, typename F>
+            HPX_HOST_DEVICE HPX_FORCEINLINE static Iter call(
+                std::size_t base_idx, Iter it, std::size_t count,
+                CancelToken& tok, F&& f)
+            {
+                HPX_IVDEP HPX_UNROLL HPX_VECTORIZE for (std::size_t i = 0;
+                                                        i < count; i++)
+                {
+                    if (tok.was_cancelled(base_idx))
+                    {
+                        break;
+                    }
+                    HPX_INVOKE(f, *it, base_idx);
+                    ++it, ++base_idx;
+                }
+                return it;
+            }
+        };
+    }    // namespace detail
+
+    ///////////////////////////////////////////////////////////////////////////
+    template <typename Begin, typename End, typename F>
+    HPX_HOST_DEVICE HPX_FORCEINLINE Begin tag_invoke(
+        hpx::parallel::util::loop_t, hpx::execution::unsequenced_policy,
+        Begin begin, End end, F&& f)
+    {
+        return detail::unseq_loop::call(begin, end, HPX_FORWARD(F, f));
+    }
+
+    template <typename Begin, typename End, typename F>
+    HPX_HOST_DEVICE HPX_FORCEINLINE Begin tag_invoke(
+        hpx::parallel::util::loop_t, hpx::execution::unsequenced_task_policy,
+        Begin begin, End end, F&& f)
+    {
+        return detail::unseq_loop::call(begin, end, HPX_FORWARD(F, f));
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    template <typename Begin, typename End, typename CancelToken, typename F>
+    HPX_HOST_DEVICE HPX_FORCEINLINE Begin tag_invoke(
+        hpx::parallel::util::loop_t, hpx::execution::unsequenced_policy,
+        Begin begin, End end, CancelToken& tok, F&& f)
+    {
+        return detail::unseq_loop::call(
+            begin, end, tok, HPX_FORWARD(F, f));
+    }
+
+    template <typename Begin, typename End, typename CancelToken, typename F>
+    HPX_HOST_DEVICE HPX_FORCEINLINE Begin tag_invoke(
+        hpx::parallel::util::loop_t, hpx::execution::unsequenced_task_policy,
+        Begin begin, End end, CancelToken& tok, F&& f)
+    {
+        return detail::unseq_loop::call(
+            begin, end, tok, HPX_FORWARD(F, f));
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    template <typename Begin, typename End, typename F>
+    HPX_HOST_DEVICE HPX_FORCEINLINE Begin tag_invoke(
+        hpx::parallel::util::loop_ind_t, hpx::execution::unsequenced_policy,
+        Begin begin, End end, F&& f)
+    {
+        return detail::unseq_loop_ind::call(
+            begin, end, HPX_FORWARD(F, f));
+    }
+
+    template <typename Begin, typename End, typename F>
+    HPX_HOST_DEVICE HPX_FORCEINLINE Begin tag_invoke(
+        hpx::parallel::util::loop_ind_t,
+        hpx::execution::unsequenced_task_policy, Begin begin, End end, F&& f)
+    {
+        return detail::unseq_loop_ind::call(
+            begin, end, HPX_FORWARD(F, f));
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    template <typename ExPolicy, typename Iter1, typename Iter2, typename F>
+    HPX_HOST_DEVICE HPX_FORCEINLINE constexpr typename std::enable_if<
+        hpx::is_unsequenced_execution_policy_v<ExPolicy>,
+        std::pair<Iter1, Iter2>>::type
+    tag_invoke(hpx::parallel::util::loop2_t<ExPolicy>, Iter1 first1,
+        Iter1 last1, Iter2 first2, F&& f)
+    {
+        return detail::unseq_loop2::call(
+            first1, last1, first2, HPX_FORWARD(F, f));
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    template <typename ExPolicy, typename Iter, typename F>
+    HPX_HOST_DEVICE HPX_FORCEINLINE constexpr typename std::enable_if<
+        hpx::is_unsequenced_execution_policy_v<ExPolicy>, Iter>::type
+    tag_invoke(hpx::parallel::util::loop_n_t<ExPolicy>, Iter it,
+        std::size_t count, F&& f)
+    {
+        return hpx::parallel::util::detail::unseq_loop_n::call(
+            it, count, HPX_FORWARD(F, f));
+    }
+
+    template <typename ExPolicy, typename Iter, typename CancelToken,
+        typename F>
+    HPX_HOST_DEVICE HPX_FORCEINLINE constexpr typename std::enable_if<
+        hpx::is_unsequenced_execution_policy_v<ExPolicy>, Iter>::type
+    tag_invoke(hpx::parallel::util::loop_n_t<ExPolicy>, Iter it,
+        std::size_t count, CancelToken& tok, F&& f)
+    {
+        return hpx::parallel::util::detail::unseq_loop_n::call(
+            it, count, tok, HPX_FORWARD(F, f));
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    template <typename ExPolicy, typename Iter, typename F>
+    HPX_HOST_DEVICE HPX_FORCEINLINE constexpr typename std::enable_if<
+        hpx::is_unsequenced_execution_policy_v<ExPolicy>, Iter>::type
+    tag_invoke(hpx::parallel::util::loop_n_ind_t<ExPolicy>, Iter it,
+        std::size_t count, F&& f)
+    {
+        return hpx::parallel::util::detail::unseq_loop_n_ind::call(
+            it, count, HPX_FORWARD(F, f));
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    template <typename ExPolicy, typename Iter, typename F>
+    HPX_HOST_DEVICE HPX_FORCEINLINE constexpr typename std::enable_if<
+        hpx::is_unsequenced_execution_policy_v<ExPolicy>, Iter>::type
+    tag_invoke(hpx::parallel::util::loop_idx_n_t<ExPolicy>,
+        std::size_t base_idx, Iter it, std::size_t count, F&& f)
+    {
+        return hpx::parallel::util::detail::unseq_loop_idx_n::call(
+            base_idx, it, count, HPX_FORWARD(F, f));
+    }
+
+    template <typename ExPolicy, typename Iter, typename CancelToken,
+        typename F>
+    HPX_HOST_DEVICE HPX_FORCEINLINE constexpr typename std::enable_if<
+        hpx::is_unsequenced_execution_policy_v<ExPolicy>, Iter>::type
+    tag_invoke(hpx::parallel::util::loop_idx_n_t<ExPolicy>,
+        std::size_t base_idx, Iter it, std::size_t count, CancelToken& tok,
+        F&& f)
+    {
+        return hpx::parallel::util::detail::unseq_loop_idx_n::call(
+            base_idx, it, count, tok, HPX_FORWARD(F, f));
+    }
+}}}    // namespace hpx::parallel::util

--- a/libs/core/algorithms/include/hpx/parallel/unseq/transform_loop.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/unseq/transform_loop.hpp
@@ -1,0 +1,554 @@
+//  Copyright (c) 2022 A Kishore Kumar
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include <hpx/config.hpp>
+
+#include <hpx/executors/execution_policy.hpp>
+#include <hpx/functional/tag_invoke.hpp>
+#include <hpx/parallel/util/cancellation_token.hpp>
+#include <hpx/parallel/util/transform_loop.hpp>
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <iterator>
+#include <type_traits>
+#include <utility>
+
+namespace hpx { namespace parallel { namespace util {
+
+    namespace detail {
+        ///////////////////////////////////////////////////////////////////////
+        struct unseq_transform_loop_n
+        {
+            template <typename InIter, typename OutIter, typename F>
+            HPX_HOST_DEVICE HPX_FORCEINLINE static typename std::enable_if<
+                hpx::traits::is_random_access_iterator_v<InIter> and
+                    hpx::traits::is_random_access_iterator_v<OutIter>,
+                std::pair<InIter, OutIter>>::type
+            call(InIter HPX_RESTRICT it, std::size_t count,
+                OutIter HPX_RESTRICT dest, F&& f)
+            {
+                // clang-format off
+                HPX_IVDEP HPX_UNROLL HPX_VECTORIZE
+                for (std::size_t i = 0; i < count; i++)
+                {
+                    *dest++ = HPX_INVOKE(f, it);
+                    ++it;
+                }
+                // clang-format on
+                return std::make_pair(HPX_MOVE(it), HPX_MOVE(dest));
+            }
+
+            template <typename InIter, typename OutIter, typename F>
+            HPX_HOST_DEVICE HPX_FORCEINLINE static typename std::enable_if<
+                !hpx::traits::is_random_access_iterator_v<InIter> or
+                    !hpx::traits::is_random_access_iterator_v<OutIter>,
+                std::pair<InIter, OutIter>>::type
+            call(InIter HPX_RESTRICT it, std::size_t count,
+                OutIter HPX_RESTRICT dest, F&& f)
+            {
+                return util::transform_loop_n<hpx::execution::sequenced_policy>(
+                    it, count, dest, HPX_FORWARD(F, f));
+            }
+        };
+    }    // namespace detail
+
+    template <typename ExPolicy, typename Iter, typename OutIter, typename F>
+    HPX_HOST_DEVICE HPX_FORCEINLINE typename std::enable_if<
+        hpx::is_unsequenced_execution_policy_v<ExPolicy>,
+        std::pair<Iter, OutIter>>::type
+    tag_invoke(hpx::parallel::util::transform_loop_n_t<ExPolicy>,
+        Iter HPX_RESTRICT it, std::size_t count, OutIter HPX_RESTRICT dest,
+        F&& f)
+    {
+        return detail::unseq_transform_loop_n::call(
+            it, count, dest, HPX_FORWARD(F, f));
+    }
+
+    namespace detail {
+        ///////////////////////////////////////////////////////////////////////
+        struct unseq_transform_loop_n_ind
+        {
+            template <typename InIter, typename OutIter, typename F>
+            HPX_HOST_DEVICE HPX_FORCEINLINE static typename std::enable_if<
+                hpx::traits::is_random_access_iterator_v<InIter> and
+                    hpx::traits::is_random_access_iterator_v<OutIter>,
+                std::pair<InIter, OutIter>>::type
+            call(InIter HPX_RESTRICT it, std::size_t count,
+                OutIter HPX_RESTRICT dest, F&& f)
+            {
+                // clang-format off
+                HPX_IVDEP HPX_UNROLL HPX_VECTORIZE
+                for (std::size_t i = 0; i < count; i++)
+                {
+                    *dest++ = HPX_INVOKE(f, *it);
+                    ++it;
+                }
+                // clang-format on
+                return std::make_pair(HPX_MOVE(it), HPX_MOVE(dest));
+            }
+
+            template <typename InIter, typename OutIter, typename F>
+            HPX_HOST_DEVICE HPX_FORCEINLINE static typename std::enable_if<
+                !hpx::traits::is_random_access_iterator_v<InIter> or
+                    !hpx::traits::is_random_access_iterator_v<OutIter>,
+                std::pair<InIter, OutIter>>::type
+            call(InIter HPX_RESTRICT it, std::size_t count,
+                OutIter HPX_RESTRICT dest, F&& f)
+            {
+                return util::transform_loop_n_ind<
+                    hpx::execution::sequenced_policy>(
+                    it, count, dest, HPX_FORWARD(F, f));
+            }
+        };
+    }    // namespace detail
+
+    template <typename ExPolicy, typename Iter, typename OutIter, typename F>
+    HPX_HOST_DEVICE HPX_FORCEINLINE constexpr typename std::enable_if<
+        hpx::is_unsequenced_execution_policy_v<ExPolicy>,
+        std::pair<Iter, OutIter>>::type
+    tag_invoke(hpx::parallel::util::transform_loop_n_ind_t<ExPolicy>,
+        Iter HPX_RESTRICT it, std::size_t count, OutIter HPX_RESTRICT dest,
+        F&& f)
+    {
+        return detail::unseq_transform_loop_n_ind::call(
+            it, count, dest, HPX_FORWARD(F, f));
+    }
+
+    namespace detail {
+        ///////////////////////////////////////////////////////////////////////
+        struct unseq_transform_loop
+        {
+            template <typename InIter, typename OutIter, typename F>
+            HPX_HOST_DEVICE HPX_FORCEINLINE static typename std::enable_if<
+                hpx::traits::is_random_access_iterator_v<InIter> and
+                    hpx::traits::is_random_access_iterator_v<OutIter>,
+                util::in_out_result<InIter, OutIter>>::type
+            call(InIter HPX_RESTRICT it, InIter HPX_RESTRICT last,
+                OutIter HPX_RESTRICT dest, F&& f)
+            {
+                auto ret =
+                    util::transform_loop_n<hpx::execution::unsequenced_policy>(
+                        it, std::distance(it, last), dest, HPX_FORWARD(F, f));
+                return util::in_out_result<InIter, OutIter>{
+                    HPX_MOVE(ret.first), HPX_MOVE(ret.second)};
+            }
+
+            template <typename InIter, typename OutIter, typename F>
+            HPX_HOST_DEVICE HPX_FORCEINLINE static typename std::enable_if<
+                !hpx::traits::is_random_access_iterator_v<InIter> or
+                    !hpx::traits::is_random_access_iterator_v<OutIter>,
+                util::in_out_result<InIter, OutIter>>::type
+            call(InIter HPX_RESTRICT it, InIter HPX_RESTRICT last,
+                OutIter HPX_RESTRICT dest, F&& f)
+            {
+                return util::transform_loop(
+                    hpx::execution::seq, it, last, dest, HPX_FORWARD(F, f));
+            }
+        };
+    }    // namespace detail
+
+    template <typename IterB, typename IterE, typename OutIter, typename F>
+    HPX_HOST_DEVICE
+        HPX_FORCEINLINE constexpr util::in_out_result<IterB, OutIter>
+        tag_invoke(hpx::parallel::util::transform_loop_t,
+            hpx::execution::unsequenced_policy, IterB HPX_RESTRICT it,
+            IterE HPX_RESTRICT end, OutIter HPX_RESTRICT dest, F&& f)
+    {
+        return detail::unseq_transform_loop::call(
+            it, end, dest, HPX_FORWARD(F, f));
+    }
+
+    template <typename IterB, typename IterE, typename OutIter, typename F>
+    HPX_HOST_DEVICE
+        HPX_FORCEINLINE constexpr util::in_out_result<IterB, OutIter>
+        tag_invoke(hpx::parallel::util::transform_loop_t,
+            hpx::execution::unsequenced_task_policy, IterB HPX_RESTRICT it,
+            IterE HPX_RESTRICT end, OutIter HPX_RESTRICT dest, F&& f)
+    {
+        return detail::unseq_transform_loop::call(
+            it, end, dest, HPX_FORWARD(F, f));
+    }
+
+    namespace detail {
+        ///////////////////////////////////////////////////////////////////////
+        struct unseq_transform_loop_ind
+        {
+            template <typename InIter, typename OutIter, typename F>
+            HPX_HOST_DEVICE HPX_FORCEINLINE static typename std::enable_if<
+                hpx::traits::is_random_access_iterator_v<InIter> and
+                    hpx::traits::is_random_access_iterator_v<OutIter>,
+                util::in_out_result<InIter, OutIter>>::type
+            call(InIter HPX_RESTRICT it, InIter HPX_RESTRICT last,
+                OutIter HPX_RESTRICT dest, F&& f)
+            {
+                auto ret = util::transform_loop_n_ind<
+                    hpx::execution::unsequenced_policy>(
+                    it, std::distance(it, last), dest, HPX_FORWARD(F, f));
+                return util::in_out_result<InIter, OutIter>{
+                    HPX_MOVE(ret.first), HPX_MOVE(ret.second)};
+            }
+
+            template <typename InIter, typename OutIter, typename F>
+            HPX_HOST_DEVICE HPX_FORCEINLINE static typename std::enable_if<
+                !hpx::traits::is_random_access_iterator_v<InIter> or
+                    !hpx::traits::is_random_access_iterator_v<OutIter>,
+                util::in_out_result<InIter, OutIter>>::type
+            call(InIter HPX_RESTRICT it, InIter HPX_RESTRICT last,
+                OutIter HPX_RESTRICT dest, F&& f)
+            {
+                return util::transform_loop_ind(
+                    hpx::execution::seq, it, last, dest, HPX_FORWARD(F, f));
+            }
+        };
+    }    // namespace detail
+
+    template <typename IterB, typename IterE, typename OutIter, typename F>
+    HPX_HOST_DEVICE
+        HPX_FORCEINLINE constexpr util::in_out_result<IterB, OutIter>
+        tag_invoke(hpx::parallel::util::transform_loop_ind_t,
+            hpx::execution::unsequenced_policy, IterB HPX_RESTRICT it,
+            IterE HPX_RESTRICT end, OutIter HPX_RESTRICT dest, F&& f)
+    {
+        return detail::unseq_transform_loop_ind::call(
+            it, end, dest, HPX_FORWARD(F, f));
+    }
+
+    template <typename IterB, typename IterE, typename OutIter, typename F>
+    HPX_HOST_DEVICE
+        HPX_FORCEINLINE constexpr util::in_out_result<IterB, OutIter>
+        tag_invoke(hpx::parallel::util::transform_loop_ind_t,
+            hpx::execution::unsequenced_task_policy, IterB HPX_RESTRICT it,
+            IterE HPX_RESTRICT end, OutIter HPX_RESTRICT dest, F&& f)
+    {
+        return detail::unseq_transform_loop_ind::call(
+            it, end, dest, HPX_FORWARD(F, f));
+    }
+
+    namespace detail {
+        ///////////////////////////////////////////////////////////////////////
+        struct unseq_transform_binary_loop_n
+        {
+            template <typename InIter1, typename InIter2, typename OutIter,
+                typename F>
+            HPX_HOST_DEVICE HPX_FORCEINLINE static typename std::enable_if<
+                hpx::traits::is_random_access_iterator_v<InIter1> and
+                    hpx::traits::is_random_access_iterator_v<InIter2> and
+                    hpx::traits::is_random_access_iterator_v<OutIter>,
+                hpx::tuple<InIter1, InIter2, OutIter>>::type
+            call(InIter1 HPX_RESTRICT first1, std::size_t count,
+                InIter2 HPX_RESTRICT first2, OutIter HPX_RESTRICT dest, F&& f)
+            {
+                // clang-format off
+                HPX_IVDEP HPX_UNROLL HPX_VECTORIZE
+                for (std::size_t i = 0; i < count; i++)
+                {
+                    *dest++ = HPX_INVOKE(f, first1, first2);
+                    ++first1, ++first2;
+                }
+                // clang-format on
+                return hpx::make_tuple(
+                    HPX_MOVE(first1), HPX_MOVE(first2), HPX_MOVE(dest));
+            }
+
+            template <typename InIter1, typename InIter2, typename OutIter,
+                typename F>
+            HPX_HOST_DEVICE HPX_FORCEINLINE static typename std::enable_if<
+                !hpx::traits::is_random_access_iterator_v<InIter1> or
+                    !hpx::traits::is_random_access_iterator_v<InIter2> or
+                    !hpx::traits::is_random_access_iterator_v<OutIter>,
+                hpx::tuple<InIter1, InIter2, OutIter>>::type
+            call(InIter1 HPX_RESTRICT first1, std::size_t count,
+                InIter2 HPX_RESTRICT first2, OutIter HPX_RESTRICT dest, F&& f)
+            {
+                return util::transform_binary_loop_n<
+                    hpx::execution::sequenced_policy>(
+                    first1, count, first2, dest, HPX_FORWARD(F, f));
+            }
+        };
+    }    // namespace detail
+
+    template <typename ExPolicy, typename InIter1, typename InIter2,
+        typename OutIter, typename F>
+    HPX_HOST_DEVICE HPX_FORCEINLINE typename std::enable_if<
+        hpx::is_unsequenced_execution_policy_v<ExPolicy>,
+        hpx::tuple<InIter1, InIter2, OutIter>>::type
+    tag_invoke(hpx::parallel::util::transform_binary_loop_n_t<ExPolicy>,
+        InIter1 HPX_RESTRICT first1, std::size_t count,
+        InIter2 HPX_RESTRICT first2, OutIter HPX_RESTRICT dest, F&& f)
+    {
+        return detail::unseq_transform_binary_loop_n::call(
+            first1, count, first2, dest, HPX_FORWARD(F, f));
+    }
+
+    namespace detail {
+        ///////////////////////////////////////////////////////////////////////
+        struct unseq_transform_binary_loop
+        {
+            template <typename InIter1, typename InIter2, typename OutIter,
+                typename F>
+            HPX_HOST_DEVICE HPX_FORCEINLINE static typename std::enable_if<
+                hpx::traits::is_random_access_iterator_v<InIter1> and
+                    hpx::traits::is_random_access_iterator_v<InIter2> and
+                    hpx::traits::is_random_access_iterator_v<OutIter>,
+                util::in_in_out_result<InIter1, InIter2, OutIter>>::type
+            call(InIter1 HPX_RESTRICT first1, InIter1 HPX_RESTRICT last1,
+                InIter2 HPX_RESTRICT first2, OutIter HPX_RESTRICT dest, F&& f)
+            {
+                auto ret = util::transform_binary_loop_n<
+                    hpx::execution::unsequenced_policy>(first1,
+                    std::distance(first1, last1), first2, dest,
+                    HPX_FORWARD(F, f));
+                return util::in_in_out_result<InIter1, InIter2, OutIter>{
+                    hpx::get<0>(ret), hpx::get<1>(ret), hpx::get<2>(ret)};
+            }
+
+            template <typename InIter1, typename InIter2, typename OutIter,
+                typename F>
+            HPX_HOST_DEVICE HPX_FORCEINLINE static typename std::enable_if<
+                !hpx::traits::is_random_access_iterator_v<InIter1> or
+                    !hpx::traits::is_random_access_iterator_v<InIter2> or
+                    !hpx::traits::is_random_access_iterator_v<OutIter>,
+                util::in_in_out_result<InIter1, InIter2, OutIter>>::type
+            call(InIter1 HPX_RESTRICT first1, InIter1 HPX_RESTRICT last1,
+                InIter2 HPX_RESTRICT first2, OutIter HPX_RESTRICT dest, F&& f)
+            {
+                return util::transform_binary_loop<
+                    hpx::execution::sequenced_policy>(
+                    first1, last1, first2, dest, HPX_FORWARD(F, f));
+            }
+
+            template <typename InIter1, typename InIter2, typename OutIter,
+                typename F>
+            HPX_HOST_DEVICE HPX_FORCEINLINE static typename std::enable_if<
+                hpx::traits::is_random_access_iterator_v<InIter1> and
+                    hpx::traits::is_random_access_iterator_v<InIter2> and
+                    hpx::traits::is_random_access_iterator_v<OutIter>,
+                util::in_in_out_result<InIter1, InIter2, OutIter>>::type
+            call(InIter1 HPX_RESTRICT first1, InIter1 HPX_RESTRICT last1,
+                InIter2 HPX_RESTRICT first2, InIter2 HPX_RESTRICT last2,
+                OutIter dest, F&& f)
+            {
+                // clang-format off
+                std::size_t count = (std::min) (std::distance(first1, last1),
+                    std::distance(first2, last2));
+                // clang-format on
+                auto ret = util::transform_binary_loop_n<
+                    hpx::execution::unsequenced_policy>(
+                    first1, count, first2, dest, HPX_FORWARD(F, f));
+                return util::in_in_out_result<InIter1, InIter2, OutIter>{
+                    hpx::get<0>(ret), hpx::get<1>(ret), hpx::get<2>(ret)};
+            }
+
+            template <typename InIter1, typename InIter2, typename OutIter,
+                typename F>
+            HPX_HOST_DEVICE HPX_FORCEINLINE static typename std::enable_if<
+                !hpx::traits::is_random_access_iterator_v<InIter1> or
+                    !hpx::traits::is_random_access_iterator_v<InIter2> or
+                    !hpx::traits::is_random_access_iterator_v<OutIter>,
+                util::in_in_out_result<InIter1, InIter2, OutIter>>::type
+            call(InIter1 HPX_RESTRICT first1, InIter1 HPX_RESTRICT last1,
+                InIter2 HPX_RESTRICT first2, InIter2 HPX_RESTRICT last2,
+                OutIter dest, F&& f)
+            {
+                return util::transform_binary_loop<
+                    hpx::execution::sequenced_policy>(
+                    first1, last1, first2, last2, dest, HPX_FORWARD(F, f));
+            }
+        };
+    }    // namespace detail
+
+    template <typename ExPolicy, typename InIter1, typename InIter2,
+        typename OutIter, typename F>
+    HPX_HOST_DEVICE HPX_FORCEINLINE typename std::enable_if<
+        hpx::is_unsequenced_execution_policy_v<ExPolicy>,
+        util::in_in_out_result<InIter1, InIter2, OutIter>>::type
+    tag_invoke(hpx::parallel::util::transform_binary_loop_t<ExPolicy>,
+        InIter1 HPX_RESTRICT first1, InIter1 HPX_RESTRICT last1,
+        InIter2 HPX_RESTRICT first2, OutIter HPX_RESTRICT dest, F&& f)
+    {
+        return detail::unseq_transform_binary_loop::call(
+            first1, last1, first2, dest, HPX_FORWARD(F, f));
+    }
+
+    template <typename ExPolicy, typename InIter1, typename InIter2,
+        typename OutIter, typename F>
+    HPX_HOST_DEVICE HPX_FORCEINLINE typename std::enable_if<
+        hpx::is_unsequenced_execution_policy_v<ExPolicy>,
+        util::in_in_out_result<InIter1, InIter2, OutIter>>::type
+    tag_invoke(hpx::parallel::util::transform_binary_loop_t<ExPolicy>,
+        InIter1 HPX_RESTRICT first1, InIter1 HPX_RESTRICT last1,
+        InIter2 HPX_RESTRICT first2, InIter2 HPX_RESTRICT last2, OutIter dest,
+        F&& f)
+    {
+        return detail::unseq_transform_binary_loop::call(
+            first1, last1, first2, last2, dest, HPX_FORWARD(F, f));
+    }
+
+    namespace detail {
+        ///////////////////////////////////////////////////////////////////////
+        struct unseq_transform_binary_loop_ind_n
+        {
+            template <typename InIter1, typename InIter2, typename OutIter,
+                typename F>
+            HPX_HOST_DEVICE HPX_FORCEINLINE static typename std::enable_if<
+                hpx::traits::is_random_access_iterator_v<InIter1> and
+                    hpx::traits::is_random_access_iterator_v<InIter2> and
+                    hpx::traits::is_random_access_iterator_v<OutIter>,
+                hpx::tuple<InIter1, InIter2, OutIter>>::type
+            call(InIter1 HPX_RESTRICT first1, std::size_t count,
+                InIter2 HPX_RESTRICT first2, OutIter HPX_RESTRICT dest, F&& f)
+            {
+                // clang-format off
+                HPX_IVDEP HPX_UNROLL HPX_VECTORIZE
+                for (std::size_t i = 0; i < count; i++)
+                {
+                    *dest++ = HPX_INVOKE(f, *first1, *first2);
+                    ++first1, ++first2;
+                }
+                // clang-format on
+                return hpx::make_tuple(
+                    HPX_MOVE(first1), HPX_MOVE(first2), HPX_MOVE(dest));
+            }
+
+            template <typename InIter1, typename InIter2, typename OutIter,
+                typename F>
+            HPX_HOST_DEVICE HPX_FORCEINLINE static typename std::enable_if<
+                !hpx::traits::is_random_access_iterator_v<InIter1> or
+                    !hpx::traits::is_random_access_iterator_v<InIter2> or
+                    !hpx::traits::is_random_access_iterator_v<OutIter>,
+                hpx::tuple<InIter1, InIter2, OutIter>>::type
+            call(InIter1 HPX_RESTRICT first1, std::size_t count,
+                InIter2 HPX_RESTRICT first2, OutIter HPX_RESTRICT dest, F&& f)
+            {
+                return util::transform_binary_loop_ind_n<
+                    hpx::execution::sequenced_policy>(
+                    first1, count, first2, dest, HPX_FORWARD(F, f));
+            }
+        };
+    }    // namespace detail
+
+    template <typename ExPolicy, typename InIter1, typename InIter2,
+        typename OutIter, typename F>
+    HPX_HOST_DEVICE HPX_FORCEINLINE typename std::enable_if<
+        hpx::is_unsequenced_execution_policy_v<ExPolicy>,
+        hpx::tuple<InIter1, InIter2, OutIter>>::type
+    tag_invoke(hpx::parallel::util::transform_binary_loop_ind_n_t<ExPolicy>,
+        InIter1 HPX_RESTRICT first1, std::size_t count,
+        InIter2 HPX_RESTRICT first2, OutIter HPX_RESTRICT dest, F&& f)
+    {
+        return detail::unseq_transform_binary_loop_ind_n::call(
+            first1, count, first2, dest, HPX_FORWARD(F, f));
+    }
+
+    namespace detail {
+        ///////////////////////////////////////////////////////////////////////
+        struct unseq_transform_binary_loop_ind
+        {
+            template <typename InIter1, typename InIter2, typename OutIter,
+                typename F>
+            HPX_HOST_DEVICE HPX_FORCEINLINE static typename std::enable_if<
+                hpx::traits::is_random_access_iterator_v<InIter1> and
+                    hpx::traits::is_random_access_iterator_v<InIter2> and
+                    hpx::traits::is_random_access_iterator_v<OutIter>,
+                util::in_in_out_result<InIter1, InIter2, OutIter>>::type
+            call(InIter1 HPX_RESTRICT first1, InIter1 HPX_RESTRICT last1,
+                InIter2 HPX_RESTRICT first2, OutIter HPX_RESTRICT dest, F&& f)
+            {
+                auto ret = util::transform_binary_loop_ind_n<
+                    hpx::execution::unsequenced_policy>(first1,
+                    std::distance(first1, last1), first2, dest,
+                    HPX_FORWARD(F, f));
+                return util::in_in_out_result<InIter1, InIter2, OutIter>{
+                    hpx::get<0>(ret), hpx::get<1>(ret), hpx::get<2>(ret)};
+            }
+
+            template <typename InIter1, typename InIter2, typename OutIter,
+                typename F>
+            HPX_HOST_DEVICE HPX_FORCEINLINE static typename std::enable_if<
+                !hpx::traits::is_random_access_iterator_v<InIter1> or
+                    !hpx::traits::is_random_access_iterator_v<InIter2> or
+                    !hpx::traits::is_random_access_iterator_v<OutIter>,
+                util::in_in_out_result<InIter1, InIter2, OutIter>>::type
+            call(InIter1 HPX_RESTRICT first1, InIter1 HPX_RESTRICT last1,
+                InIter2 HPX_RESTRICT first2, OutIter HPX_RESTRICT dest, F&& f)
+            {
+                return util::transform_binary_loop_ind<
+                    hpx::execution::sequenced_policy>(
+                    first1, last1, first2, dest, HPX_FORWARD(F, f));
+            }
+
+            template <typename InIter1, typename InIter2, typename OutIter,
+                typename F>
+            HPX_HOST_DEVICE HPX_FORCEINLINE static typename std::enable_if<
+                hpx::traits::is_random_access_iterator_v<InIter1> and
+                    hpx::traits::is_random_access_iterator_v<InIter2> and
+                    hpx::traits::is_random_access_iterator_v<OutIter>,
+                util::in_in_out_result<InIter1, InIter2, OutIter>>::type
+            call(InIter1 HPX_RESTRICT first1, InIter1 HPX_RESTRICT last1,
+                InIter2 HPX_RESTRICT first2, InIter2 HPX_RESTRICT last2,
+                OutIter HPX_RESTRICT dest, F&& f)
+            {
+                // clang-format off
+                std::size_t count = (std::min) (std::distance(first1, last1),
+                    std::distance(first2, last2));
+                // clang-format on
+
+                auto ret = util::transform_binary_loop_ind_n<
+                    hpx::execution::unsequenced_policy>(
+                    first1, count, first2, dest, HPX_FORWARD(F, f));
+                return util::in_in_out_result<InIter1, InIter2, OutIter>{
+                    hpx::get<0>(ret), hpx::get<1>(ret), hpx::get<2>(ret)};
+            }
+
+            template <typename InIter1, typename InIter2, typename OutIter,
+                typename F>
+            HPX_HOST_DEVICE HPX_FORCEINLINE static typename std::enable_if<
+                !hpx::traits::is_random_access_iterator_v<InIter1> or
+                    !hpx::traits::is_random_access_iterator_v<InIter2> or
+                    !hpx::traits::is_random_access_iterator_v<OutIter>,
+                util::in_in_out_result<InIter1, InIter2, OutIter>>::type
+            call(InIter1 HPX_RESTRICT first1, InIter1 HPX_RESTRICT last1,
+                InIter2 HPX_RESTRICT first2, InIter2 HPX_RESTRICT last2,
+                OutIter HPX_RESTRICT dest, F&& f)
+            {
+                return util::transform_binary_loop_ind<
+                    hpx::execution::sequenced_policy>(
+                    first1, last1, first2, last2, dest, HPX_FORWARD(F, f));
+            }
+        };
+    }    // namespace detail
+
+    template <typename ExPolicy, typename InIter1, typename InIter2,
+        typename OutIter, typename F>
+    HPX_HOST_DEVICE HPX_FORCEINLINE typename std::enable_if<
+        hpx::is_unsequenced_execution_policy_v<ExPolicy>,
+        util::in_in_out_result<InIter1, InIter2, OutIter>>::type
+    tag_invoke(hpx::parallel::util::transform_binary_loop_ind_t<ExPolicy>,
+        InIter1 HPX_RESTRICT first1, InIter1 HPX_RESTRICT last1,
+        InIter2 HPX_RESTRICT first2, OutIter HPX_RESTRICT dest, F&& f)
+    {
+        return detail::unseq_transform_binary_loop_ind::call(
+            first1, last1, first2, dest, HPX_FORWARD(F, f));
+    }
+
+    template <typename ExPolicy, typename InIter1, typename InIter2,
+        typename OutIter, typename F>
+    HPX_HOST_DEVICE HPX_FORCEINLINE typename std::enable_if<
+        hpx::is_unsequenced_execution_policy_v<ExPolicy>,
+        util::in_in_out_result<InIter1, InIter2, OutIter>>::type
+    tag_invoke(hpx::parallel::util::transform_binary_loop_ind_t<ExPolicy>,
+        InIter1 HPX_RESTRICT first1, InIter1 HPX_RESTRICT last1,
+        InIter2 HPX_RESTRICT first2, InIter2 HPX_RESTRICT last2,
+        OutIter HPX_RESTRICT dest, F&& f)
+    {
+        return detail::unseq_transform_binary_loop_ind::call(
+            first1, last1, first2, last2, dest, HPX_FORWARD(F, f));
+    }
+}}}    // namespace hpx::parallel::util

--- a/libs/core/algorithms/tests/unit/CMakeLists.txt
+++ b/libs/core/algorithms/tests/unit/CMakeLists.txt
@@ -5,7 +5,7 @@
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 # add subdirectories
-set(subdirs algorithms block container_algorithms)
+set(subdirs algorithms block container_algorithms unseq_algorithms)
 
 if(HPX_WITH_DATAPAR)
   set(subdirs ${subdirs} datapar_algorithms)

--- a/libs/core/algorithms/tests/unit/unseq_algorithms/CMakeLists.txt
+++ b/libs/core/algorithms/tests/unit/unseq_algorithms/CMakeLists.txt
@@ -1,0 +1,22 @@
+set(tests "")
+
+foreach(test ${tests})
+  set(sources ${test}.cpp)
+
+  set(${test}_PARAMETERS THREADS_PER_LOCALITY 4)
+
+  source_group("Source Files" FILES ${sources})
+
+  # add example executable
+  add_hpx_executable(
+    ${test}_test INTERNAL_FLAGS
+    SOURCES ${sources} ${${test}_FLAGS}
+    EXCLUDE_FROM_ALL
+    HPX_PREFIX ${HPX_BUILD_PREFIX}
+    FOLDER "Tests/Unit/Modules/Core/Algorithms/Unseq"
+  )
+
+  add_hpx_unit_test(
+    "modules.algorithms.unseq_algorithms" ${test} ${${test}_PARAMETERS}
+  )
+endforeach()

--- a/libs/core/algorithms/tests/unit/unseq_algorithms/CMakeLists.txt
+++ b/libs/core/algorithms/tests/unit/unseq_algorithms/CMakeLists.txt
@@ -1,4 +1,7 @@
-set(tests "")
+set(tests
+    transform_binary2_unseq
+    transform_binary_unseq
+    transform_unseq)
 
 foreach(test ${tests})
   set(sources ${test}.cpp)

--- a/libs/core/algorithms/tests/unit/unseq_algorithms/CMakeLists.txt
+++ b/libs/core/algorithms/tests/unit/unseq_algorithms/CMakeLists.txt
@@ -1,4 +1,7 @@
 set(tests
+    foreach_unseq
+    foreach_unseq_zipiter
+    foreachn_unseq
     transform_binary2_unseq
     transform_binary_unseq
     transform_unseq)

--- a/libs/core/algorithms/tests/unit/unseq_algorithms/foreach_unseq.cpp
+++ b/libs/core/algorithms/tests/unit/unseq_algorithms/foreach_unseq.cpp
@@ -1,0 +1,71 @@
+//  Copyright (c) 2016 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/local/init.hpp>
+#include <hpx/parallel/unseq.hpp>
+
+#include <iostream>
+#include <string>
+#include <vector>
+
+#include "../algorithms/foreach_tests.hpp"
+
+///////////////////////////////////////////////////////////////////////////////
+template <typename IteratorTag>
+void test_for_each()
+{
+    using namespace hpx::execution;
+
+    test_for_each(unseq, IteratorTag());
+    test_for_each(par_unseq, IteratorTag());
+
+    test_for_each_async(unseq(task), IteratorTag());
+    test_for_each_async(par_unseq(task), IteratorTag());
+}
+
+void for_each_test()
+{
+    test_for_each<std::random_access_iterator_tag>();
+    test_for_each<std::forward_iterator_tag>();
+}
+
+///////////////////////////////////////////////////////////////////////////////
+int hpx_main(hpx::program_options::variables_map& vm)
+{
+    unsigned int seed = (unsigned int) std::time(nullptr);
+    if (vm.count("seed"))
+        seed = vm["seed"].as<unsigned int>();
+
+    std::cout << "using seed: " << seed << std::endl;
+    std::srand(seed);
+
+    for_each_test();
+    return hpx::local::finalize();
+}
+
+int main(int argc, char* argv[])
+{
+    // add command line option which controls the random number generator seed
+    using namespace hpx::program_options;
+    options_description desc_commandline(
+        "Usage: " HPX_APPLICATION_STRING " [options]");
+
+    desc_commandline.add_options()("seed,s", value<unsigned int>(),
+        "the random number generator seed to use for this run");
+
+    // By default this test should run on all available cores
+    std::vector<std::string> const cfg = {"hpx.os_threads=all"};
+
+    // Initialize and run HPX
+    hpx::local::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::local::init(hpx_main, argc, argv, init_args), 0,
+        "HPX main exited with non-zero status");
+
+    return hpx::util::report_errors();
+}

--- a/libs/core/algorithms/tests/unit/unseq_algorithms/foreach_unseq_zipiter.cpp
+++ b/libs/core/algorithms/tests/unit/unseq_algorithms/foreach_unseq_zipiter.cpp
@@ -1,0 +1,114 @@
+//  Copyright (c) 2016 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/local/init.hpp>
+#include <hpx/modules/testing.hpp>
+#include <hpx/parallel/algorithms/for_each.hpp>
+#include <hpx/parallel/unseq.hpp>
+
+#include <cstddef>
+#include <iostream>
+#include <iterator>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include <hpx/modules/program_options.hpp>
+
+#include "../algorithms/test_utils.hpp"
+
+///////////////////////////////////////////////////////////////////////////////
+struct set_42
+{
+    template <typename Tuple>
+    void operator()(Tuple&& t)
+    {
+        hpx::get<0>(t) = 42;
+        hpx::get<1>(t) = 42;
+    }
+};
+
+///////////////////////////////////////////////////////////////////////////////
+template <typename ExPolicy, typename IteratorTag>
+void for_each_zipiter_test(ExPolicy&& policy, IteratorTag)
+{
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
+
+    typedef std::vector<int>::iterator base_iterator;
+    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+
+    std::vector<int> c(10007), d(10007);
+    std::iota(std::begin(c), std::end(c), std::rand());
+    std::iota(std::begin(d), std::end(d), std::rand());
+
+    auto begin = hpx::util::make_zip_iterator(
+        iterator(std::begin(c)), iterator(std::begin(d)));
+    auto end = hpx::util::make_zip_iterator(
+        iterator(std::end(c)), iterator(std::end(d)));
+
+    hpx::for_each(std::forward<ExPolicy>(policy), begin, end, set_42());
+
+    // verify values
+    std::size_t count = 0;
+    std::for_each(std::begin(c), std::end(c), [&count](int v) -> void {
+        HPX_TEST_EQ(v, int(42));
+        ++count;
+    });
+    HPX_TEST_EQ(count, c.size());
+}
+
+template <typename IteratorTag>
+void for_each_zipiter_test()
+{
+    using namespace hpx::execution;
+
+    for_each_zipiter_test(par_unseq, IteratorTag());
+}
+
+void for_each_zipiter_test()
+{
+    for_each_zipiter_test<std::random_access_iterator_tag>();
+}
+
+///////////////////////////////////////////////////////////////////////////////
+int hpx_main(hpx::program_options::variables_map& vm)
+{
+    unsigned int seed = (unsigned int) std::time(nullptr);
+    if (vm.count("seed"))
+        seed = vm["seed"].as<unsigned int>();
+
+    std::cout << "using seed: " << seed << std::endl;
+    std::srand(seed);
+
+    for_each_zipiter_test();
+
+    return hpx::local::finalize();
+}
+
+int main(int argc, char* argv[])
+{
+    // add command line option which controls the random number generator seed
+    using namespace hpx::program_options;
+    options_description desc_commandline(
+        "Usage: " HPX_APPLICATION_STRING " [options]");
+
+    desc_commandline.add_options()("seed,s", value<unsigned int>(),
+        "the random number generator seed to use for this run");
+
+    // By default this test should run on all available cores
+    std::vector<std::string> const cfg = {"hpx.os_threads=all"};
+
+    // Initialize and run HPX
+    hpx::local::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::local::init(hpx_main, argc, argv, init_args), 0,
+        "HPX main exited with non-zero status");
+
+    return hpx::util::report_errors();
+}

--- a/libs/core/algorithms/tests/unit/unseq_algorithms/foreachn_unseq.cpp
+++ b/libs/core/algorithms/tests/unit/unseq_algorithms/foreachn_unseq.cpp
@@ -1,0 +1,72 @@
+//  Copyright (c) 2014 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/local/init.hpp>
+#include <hpx/parallel/unseq.hpp>
+
+#include <cstddef>
+#include <iostream>
+#include <string>
+#include <vector>
+
+#include "../algorithms/foreach_tests.hpp"
+
+///////////////////////////////////////////////////////////////////////////////
+template <typename IteratorTag>
+void test_for_each_n()
+{
+    using namespace hpx::execution;
+
+    test_for_each_n(unseq, IteratorTag());
+    test_for_each_n(par_unseq, IteratorTag());
+
+    test_for_each_n_async(unseq(task), IteratorTag());
+    test_for_each_n_async(par_unseq(task), IteratorTag());
+}
+
+void for_each_n_test()
+{
+    test_for_each_n<std::random_access_iterator_tag>();
+    test_for_each_n<std::forward_iterator_tag>();
+}
+
+///////////////////////////////////////////////////////////////////////////////
+int hpx_main(hpx::program_options::variables_map& vm)
+{
+    unsigned int seed = (unsigned int) std::time(nullptr);
+    if (vm.count("seed"))
+        seed = vm["seed"].as<unsigned int>();
+
+    std::cout << "using seed: " << seed << std::endl;
+    std::srand(seed);
+
+    for_each_n_test();
+    return hpx::local::finalize();
+}
+
+int main(int argc, char* argv[])
+{
+    // add command line option which controls the random number generator seed
+    using namespace hpx::program_options;
+    options_description desc_commandline(
+        "Usage: " HPX_APPLICATION_STRING " [options]");
+
+    desc_commandline.add_options()("seed,s", value<unsigned int>(),
+        "the random number generator seed to use for this run");
+
+    // By default this test should run on all available cores
+    std::vector<std::string> const cfg = {"hpx.os_threads=all"};
+
+    // Initialize and run HPX
+    hpx::local::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::local::init(hpx_main, argc, argv, init_args), 0,
+        "HPX main exited with non-zero status");
+
+    return hpx::util::report_errors();
+}

--- a/libs/core/algorithms/tests/unit/unseq_algorithms/transform_binary2_unseq.cpp
+++ b/libs/core/algorithms/tests/unit/unseq_algorithms/transform_binary2_unseq.cpp
@@ -1,0 +1,72 @@
+//  Copyright (c) 2014-2016 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/local/init.hpp>
+#include <hpx/parallel/unseq.hpp>
+
+#include <iostream>
+#include <string>
+#include <vector>
+
+#include "../algorithms/transform_binary2_tests.hpp"
+
+///////////////////////////////////////////////////////////////////////////////
+template <typename IteratorTag>
+void test_transform_binary2()
+{
+    using namespace hpx::execution;
+
+    test_transform_binary2(unseq, IteratorTag());
+    test_transform_binary2(par_unseq, IteratorTag());
+
+    test_transform_binary2_async(unseq(task), IteratorTag());
+    test_transform_binary2_async(par_unseq(task), IteratorTag());
+}
+
+void transform_binary2_test()
+{
+    test_transform_binary2<std::random_access_iterator_tag>();
+    test_transform_binary2<std::forward_iterator_tag>();
+}
+
+///////////////////////////////////////////////////////////////////////////////
+int hpx_main(hpx::program_options::variables_map& vm)
+{
+    unsigned int seed = (unsigned int) std::time(nullptr);
+    if (vm.count("seed"))
+        seed = vm["seed"].as<unsigned int>();
+
+    std::cout << "using seed: " << seed << std::endl;
+    std::srand(seed);
+
+    transform_binary2_test();
+    // Bad alloc and exceptions should trigger a call to std::terminate.
+    // Hence, no tests for them.
+    return hpx::local::finalize();
+}
+
+int main(int argc, char* argv[])
+{
+    // add command line option which controls the random number generator seed
+    using namespace hpx::program_options;
+    options_description desc_commandline(
+        "Usage: " HPX_APPLICATION_STRING " [options]");
+
+    desc_commandline.add_options()("seed,s", value<unsigned int>(),
+        "the random number generator seed to use for this run");
+    // By default this test should run on all available cores
+    std::vector<std::string> const cfg = {"hpx.os_threads=all"};
+
+    // Initialize and run HPX
+    hpx::local::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::local::init(hpx_main, argc, argv, init_args), 0,
+        "HPX main exited with non-zero status");
+
+    return hpx::util::report_errors();
+}

--- a/libs/core/algorithms/tests/unit/unseq_algorithms/transform_binary_unseq.cpp
+++ b/libs/core/algorithms/tests/unit/unseq_algorithms/transform_binary_unseq.cpp
@@ -1,0 +1,72 @@
+//  Copyright (c) 2014-2016 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/local/init.hpp>
+#include <hpx/parallel/unseq.hpp>
+
+#include <iostream>
+#include <string>
+#include <vector>
+
+#include "../algorithms/transform_binary_tests.hpp"
+
+///////////////////////////////////////////////////////////////////////////////
+template <typename IteratorTag>
+void test_transform_binary()
+{
+    using namespace hpx::execution;
+
+    test_transform_binary(unseq, IteratorTag());
+    test_transform_binary(par_unseq, IteratorTag());
+
+    test_transform_binary_async(unseq(task), IteratorTag());
+    test_transform_binary_async(par_unseq(task), IteratorTag());
+}
+
+void transform_binary_test()
+{
+    test_transform_binary<std::random_access_iterator_tag>();
+    test_transform_binary<std::forward_iterator_tag>();
+}
+
+///////////////////////////////////////////////////////////////////////////////
+int hpx_main(hpx::program_options::variables_map& vm)
+{
+    unsigned int seed = (unsigned int) std::time(nullptr);
+    if (vm.count("seed"))
+        seed = vm["seed"].as<unsigned int>();
+
+    std::cout << "using seed: " << seed << std::endl;
+    std::srand(seed);
+
+    transform_binary_test();
+    // Bad alloc and exceptions should trigger a call to std::terminate.
+    // Hence, no tests for them.
+    return hpx::local::finalize();
+}
+
+int main(int argc, char* argv[])
+{
+    // add command line option which controls the random number generator seed
+    using namespace hpx::program_options;
+    options_description desc_commandline(
+        "Usage: " HPX_APPLICATION_STRING " [options]");
+
+    desc_commandline.add_options()("seed,s", value<unsigned int>(),
+        "the random number generator seed to use for this run");
+    // By default this test should run on all available cores
+    std::vector<std::string> const cfg = {"hpx.os_threads=all"};
+
+    // Initialize and run HPX
+    hpx::local::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::local::init(hpx_main, argc, argv, init_args), 0,
+        "HPX main exited with non-zero status");
+
+    return hpx::util::report_errors();
+}

--- a/libs/core/algorithms/tests/unit/unseq_algorithms/transform_unseq.cpp
+++ b/libs/core/algorithms/tests/unit/unseq_algorithms/transform_unseq.cpp
@@ -1,0 +1,73 @@
+//  Copyright (c) 2014-2016 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/local/init.hpp>
+#include <hpx/parallel/unseq.hpp>
+
+#include <iostream>
+#include <string>
+#include <vector>
+
+#include "../algorithms/transform_tests.hpp"
+
+///////////////////////////////////////////////////////////////////////////////
+template <typename IteratorTag>
+void test_transform()
+{
+    using namespace hpx::execution;
+
+    test_transform(unseq, IteratorTag());
+    test_transform(par_unseq, IteratorTag());
+
+    test_transform_async(unseq(task), IteratorTag());
+    test_transform_async(par_unseq(task), IteratorTag());
+}
+
+void transform_test()
+{
+    test_transform<std::random_access_iterator_tag>();
+    test_transform<std::forward_iterator_tag>();
+}
+
+///////////////////////////////////////////////////////////////////////////////
+int hpx_main(hpx::program_options::variables_map& vm)
+{
+    unsigned int seed = (unsigned int) std::time(nullptr);
+    if (vm.count("seed"))
+        seed = vm["seed"].as<unsigned int>();
+
+    std::cout << "using seed: " << seed << std::endl;
+    std::srand(seed);
+
+    transform_test();
+    // Bad alloc and exceptions should trigger a call to std::terminate.
+    // Hence, no tests for them.
+    return hpx::local::finalize();
+}
+
+int main(int argc, char* argv[])
+{
+    // add command line option which controls the random number generator seed
+    using namespace hpx::program_options;
+    options_description desc_commandline(
+        "Usage: " HPX_APPLICATION_STRING " [options]");
+
+    desc_commandline.add_options()("seed,s", value<unsigned int>(),
+        "the random number generator seed to use for this run");
+
+    // By default this test should run on all available cores
+    std::vector<std::string> const cfg = {"hpx.os_threads=all"};
+
+    // Initialize and run HPX
+    hpx::local::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::local::init(hpx_main, argc, argv, init_args), 0,
+        "HPX main exited with non-zero status");
+
+    return hpx::util::report_errors();
+}

--- a/libs/core/config/CMakeLists.txt
+++ b/libs/core/config/CMakeLists.txt
@@ -12,6 +12,7 @@ set(config_headers
     hpx/config/asio.hpp
     hpx/config/attributes.hpp
     hpx/config/autolink.hpp
+    hpx/config/auto_vectorization.hpp
     hpx/config/branch_hints.hpp
     hpx/config/compiler_fence.hpp
     hpx/config/compiler_specific.hpp

--- a/libs/core/config/include/hpx/config.hpp
+++ b/libs/core/config/include/hpx/config.hpp
@@ -17,6 +17,7 @@
 #endif
 
 #include <hpx/config/attributes.hpp>
+#include <hpx/config/auto_vectorization.hpp>
 #include <hpx/config/branch_hints.hpp>
 #include <hpx/config/compiler_fence.hpp>
 #include <hpx/config/compiler_specific.hpp>

--- a/libs/core/config/include/hpx/config/auto_vectorization.hpp
+++ b/libs/core/config/include/hpx/config/auto_vectorization.hpp
@@ -1,0 +1,96 @@
+//  Copyright (c) 2022 A Kishore Kumar
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include <hpx/config/compiler_specific.hpp>
+
+#if defined(DOXYGEN)
+/// Instructs the compiler to ignore assumed vector dependencies.
+#define HPX_IVDEP
+/// Instructs the compiler to attempt to force-vectorize the loop
+#define HPX_VECTORIZE
+/// The compiler will not propagate no-alias metadata of a variable marked with
+/// restrict
+#define HPX_RESTRICT
+/// Instructs the compiler to unroll the loop
+#define HPX_UNROLL
+#else
+
+#ifdef _MSC_VER
+#define HPX_PRAGMA(x) __pragma(x)
+#else
+#define HPX_PRAGMA(x) _Pragma(#x)
+#endif
+
+/* Use OpenMP backend for compilers which support OpenMP */
+#if (_OPENMP >= 201307) || (__INTEL_COMPILER >= 1600) ||                       \
+    (defined(__clang__) && HPX_CLANG_VERSION >= 30700)
+#define HPX_IVDEP 
+#define HPX_VECTORIZE HPX_PRAGMA(omp simd)
+#define HPX_VECTOR_REDUCTION(CLAUSE) HPX_PRAGMA(omp simd reduction(CLAUSE))
+#define HPX_DECLARE_SIMD _PSTL_PRAGMA(omp declare simd)
+
+/* Fallback to compiler-specific backends */
+#elif defined(HPX_INTEL_VERSION)
+#define HPX_IVDEP HPX_PRAGMA(ivdep)
+#define HPX_VECTORIZE HPX_PRAGMA(vector always dynamic_align novecremainder)
+#define HPX_VECTOR_REDUCTION(CLAUSE)
+#define HPX_DECLARE_SIMD
+
+#elif defined(HPX_CLANG_VERSION)
+#define HPX_IVDEP HPX_PRAGMA(clang loop vectorize(enable))
+#define HPX_VECTORIZE HPX_PRAGMA(clang loop interleave(enable))
+#define HPX_VECTOR_REDUCTION(CLAUSE)
+#define HPX_DECLARE_SIMD
+
+#elif defined(HPX_GCC_VERSION)
+#define HPX_IVDEP HPX_PRAGMA(GCC ivdep)
+#define HPX_VECTORIZE
+#define HPX_VECTOR_REDUCTION(CLAUSE)
+#define HPX_DECLARE_SIMD
+
+#else
+#define HPX_IVDEP
+#define HPX_VECTORIZE
+#define HPX_VECTOR_REDUCTION(CLAUSE)
+#define HPX_DECLARE_SIMD
+#endif
+
+#if defined(HPX_INTEL_VERSION)
+#define HPX_RESTRICT __restrict
+#define HPX_UNROLL HPX_PRAGMA(unroll)
+#define HPX_UNROLL_N(N) HPX_PRAGMA(unroll(N))
+
+#elif defined(HPX_CLANG_VERSION)
+#define HPX_RESTRICT __restrict
+#define HPX_UNROLL HPX_PRAGMA(clang loop unroll(enable))
+#define HPX_UNROLL_N(N) HPX_PRAGMA(clang loop unroll_count(N))
+
+#elif defined(HPX_GCC_VERSION)
+#define HPX_RESTRICT __restrict__
+#define HPX_UNROLL                                                             \
+    HPX_PRAGMA(                                                                \
+        GCC unroll 8)    // GCC does not have an auto unroll constant picker
+#define HPX_UNROLL_N(N) HPX_PRAGMA(GCC unroll N)
+
+#else
+#define HPX_RESTRICT
+#define HPX_UNROLL
+#define HPX_UNROLL_N(N)
+#endif
+
+#ifdef __AVX512F__
+#define HPX_LANE_SIZE 64
+#elifdef __AVX2__
+#define HPX_LANE_SIZE 32
+#elifdef __SSE3__
+#define HPX_LANE_SIZE 16
+#else
+#define HPX_LANE_SIZE 64
+#endif
+
+#endif

--- a/libs/full/include/CMakeLists.txt
+++ b/libs/full/include/CMakeLists.txt
@@ -101,6 +101,7 @@ set(include_headers
     hpx/include/threadmanager.hpp
     hpx/include/threads.hpp
     hpx/include/traits.hpp
+    hpx/include/unseq.hpp
     hpx/include/util.hpp
     hpx/latch.hpp
     hpx/memory.hpp

--- a/libs/full/include/include/hpx/include/unseq.hpp
+++ b/libs/full/include/include/hpx/include/unseq.hpp
@@ -1,0 +1,9 @@
+//  Copyright (c) 2022 A Kishore Kumar
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include <hpx/parallel/unseq.hpp>


### PR DESCRIPTION
## Proposed Changes
- Implements the unseq adaptation of `util::loop` and `transform_loop`. Will affect `transform`, `for_each` and `for_loop`.
- Added tests for both.

## Any background context you want to provide?
This is based on #6016
