### PR TITLE
Unseq adaptation for for_each, transform, reduce, transform_reduce, etc.

### DIFF
--- a/libs/core/algorithms/CMakeLists.txt
+++ b/libs/core/algorithms/CMakeLists.txt
@@ -178,6 +178,7 @@ set(algorithms_headers
     hpx/parallel/spmd_block.hpp
     hpx/parallel/task_block.hpp
     hpx/parallel/task_group.hpp
+    hpx/parallel/unseq.hpp
     hpx/parallel/util/adapt_placement_mode.hpp
     hpx/parallel/util/adapt_sharing_mode.hpp
     hpx/parallel/util/adapt_thread_priority.hpp

--- a/libs/core/algorithms/CMakeLists.txt
+++ b/libs/core/algorithms/CMakeLists.txt
@@ -180,6 +180,8 @@ set(algorithms_headers
     hpx/parallel/task_group.hpp
     hpx/parallel/unseq.hpp
     hpx/parallel/unseq/loop.hpp
+    hpx/parallel/unseq/reduce.hpp
+    hpx/parallel/unseq/reduce_helpers.hpp
     hpx/parallel/unseq/transform_loop.hpp
     hpx/parallel/util/adapt_placement_mode.hpp
     hpx/parallel/util/adapt_sharing_mode.hpp

--- a/libs/core/algorithms/CMakeLists.txt
+++ b/libs/core/algorithms/CMakeLists.txt
@@ -179,6 +179,7 @@ set(algorithms_headers
     hpx/parallel/task_block.hpp
     hpx/parallel/task_group.hpp
     hpx/parallel/unseq.hpp
+    hpx/parallel/unseq/loop.hpp
     hpx/parallel/unseq/transform_loop.hpp
     hpx/parallel/util/adapt_placement_mode.hpp
     hpx/parallel/util/adapt_sharing_mode.hpp

--- a/libs/core/algorithms/CMakeLists.txt
+++ b/libs/core/algorithms/CMakeLists.txt
@@ -179,6 +179,7 @@ set(algorithms_headers
     hpx/parallel/task_block.hpp
     hpx/parallel/task_group.hpp
     hpx/parallel/unseq.hpp
+    hpx/parallel/unseq/transform_loop.hpp
     hpx/parallel/util/adapt_placement_mode.hpp
     hpx/parallel/util/adapt_sharing_mode.hpp
     hpx/parallel/util/adapt_thread_priority.hpp

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/for_each.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/for_each.hpp
@@ -245,6 +245,7 @@ namespace hpx {
 #include <hpx/modules/executors.hpp>
 #include <hpx/parallel/algorithms/detail/dispatch.hpp>
 #include <hpx/parallel/algorithms/detail/distance.hpp>
+#include <hpx/parallel/unseq/loop.hpp>
 #include <hpx/parallel/util/detail/algorithm_result.hpp>
 #include <hpx/parallel/util/detail/sender_util.hpp>
 #include <hpx/parallel/util/foreach_partitioner.hpp>

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/for_each.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/for_each.hpp
@@ -245,7 +245,6 @@ namespace hpx {
 #include <hpx/modules/executors.hpp>
 #include <hpx/parallel/algorithms/detail/dispatch.hpp>
 #include <hpx/parallel/algorithms/detail/distance.hpp>
-#include <hpx/parallel/unseq/loop.hpp>
 #include <hpx/parallel/util/detail/algorithm_result.hpp>
 #include <hpx/parallel/util/detail/sender_util.hpp>
 #include <hpx/parallel/util/foreach_partitioner.hpp>
@@ -443,6 +442,7 @@ namespace hpx::parallel {
     ///////////////////////////////////////////////////////////////////////////
     // for_each
     namespace detail {
+
         /// \cond NOINTERNAL
         template <typename Iter>
         struct for_each : public algorithm<for_each<Iter>, Iter>
@@ -454,12 +454,12 @@ namespace hpx::parallel {
 
             template <typename ExPolicy, typename InIterB, typename InIterE,
                 typename F, typename Proj>
-            static constexpr InIterB sequential(ExPolicy&& policy,
-                InIterB first, InIterE last, F&& f, Proj&& proj)
+            static constexpr InIterB sequential(
+                [[maybe_unused]] ExPolicy&& policy, InIterB first, InIterE last,
+                F&& f, Proj&& proj)
             {
                 if constexpr (hpx::traits::is_random_access_iterator_v<InIterB>)
                 {
-                    HPX_UNUSED(policy);
                     return util::loop_n<std::decay_t<ExPolicy>>(first,
                         static_cast<std::size_t>(detail::distance(first, last)),
                         util::invoke_projected_ind<F, std::decay_t<Proj>>{
@@ -476,12 +476,12 @@ namespace hpx::parallel {
 
             template <typename ExPolicy, typename InIterB, typename InIterE,
                 typename F>
-            static constexpr InIterB sequential(ExPolicy&& policy,
-                InIterB first, InIterE last, F&& f, hpx::identity)
+            static constexpr InIterB sequential(
+                [[maybe_unused]] ExPolicy&& policy, InIterB first, InIterE last,
+                F&& f, hpx::identity)
             {
                 if constexpr (hpx::traits::is_random_access_iterator_v<InIterB>)
                 {
-                    HPX_UNUSED(policy);
                     return util::loop_n_ind<std::decay_t<ExPolicy>>(first,
                         static_cast<std::size_t>(detail::distance(first, last)),
                         HPX_FORWARD(F, f));

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/for_loop.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/for_loop.hpp
@@ -1100,8 +1100,8 @@ namespace hpx::parallel {
                 {
                     return util::detail::algorithm_result<ExPolicy>::get(
                         util::partitioner<ExPolicy>::call(
-                            HPX_FORWARD(ExPolicy, policy), first, size,
-                            part_iterations<ExPolicy, F>{HPX_FORWARD(F, f)},
+                        HPX_FORWARD(ExPolicy, policy), first, size,
+                        part_iterations<ExPolicy, F>{HPX_FORWARD(F, f)},
                             hpx::util::empty_function{}));
                 }
                 else
@@ -1127,14 +1127,14 @@ namespace hpx::parallel {
                         util::partitioner<policy_type>::call_with_index(
                             hinted_policy, first, size, 1,
                             part_iterations<policy_type, F, void, args_type>{
-                                HPX_FORWARD(F, f), args},
+                            HPX_FORWARD(F, f), args},
                             [=](auto&&) mutable {
-                                auto pack =
+                            auto pack =
                                     hpx::util::make_index_pack_t<sizeof...(
                                         Ts)>();
-                                // make sure live-out variables are properly set on
-                                // return
-                                detail::exit_iteration(args, pack, size);
+                            // make sure live-out variables are properly set on
+                            // return
+                            detail::exit_iteration(args, pack, size);
                                 return hpx::util::unused;
                             }));
                 }
@@ -1270,18 +1270,18 @@ namespace hpx::parallel {
                         {
                             return util::detail::algorithm_result<ExPolicy>::
                                 get(util::partitioner<ExPolicy>::call(
-                                    HPX_FORWARD(ExPolicy, policy), first, size,
-                                    part_iterations<ExPolicy, F, S>{
-                                        HPX_FORWARD(F, f)},
+                                HPX_FORWARD(ExPolicy, policy), first, size,
+                                part_iterations<ExPolicy, F, S>{
+                                    HPX_FORWARD(F, f)},
                                     [](auto&&) { return hpx::util::unused; }));
                         }
                     }
 
                     return util::detail::algorithm_result<ExPolicy>::get(
                         util::partitioner<ExPolicy>::call_with_index(
-                            HPX_FORWARD(ExPolicy, policy), first, size, stride,
-                            part_iterations<ExPolicy, F, S>{
-                                HPX_FORWARD(F, f), stride},
+                        HPX_FORWARD(ExPolicy, policy), first, size, stride,
+                        part_iterations<ExPolicy, F, S>{
+                            HPX_FORWARD(F, f), stride},
                             [](auto&&) { return hpx::util::unused; }));
                 }
                 else
@@ -1307,14 +1307,14 @@ namespace hpx::parallel {
                         util::partitioner<policy_type>::call_with_index(
                             hinted_policy, first, size, stride,
                             part_iterations<policy_type, F, S, args_type>{
-                                HPX_FORWARD(F, f), stride, args},
+                            HPX_FORWARD(F, f), stride, args},
                             [=](auto&&) mutable {
-                                auto pack =
+                            auto pack =
                                     hpx::util::make_index_pack_t<sizeof...(
                                         Ts)>();
-                                // make sure live-out variables are properly set on
-                                // return
-                                detail::exit_iteration(args, pack, size);
+                            // make sure live-out variables are properly set on
+                            // return
+                            detail::exit_iteration(args, pack, size);
                                 return hpx::util::unused;
                             }));
                 }

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/for_loop.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/for_loop.hpp
@@ -1100,8 +1100,8 @@ namespace hpx::parallel {
                 {
                     return util::detail::algorithm_result<ExPolicy>::get(
                         util::partitioner<ExPolicy>::call(
-                        HPX_FORWARD(ExPolicy, policy), first, size,
-                        part_iterations<ExPolicy, F>{HPX_FORWARD(F, f)},
+                            HPX_FORWARD(ExPolicy, policy), first, size,
+                            part_iterations<ExPolicy, F>{HPX_FORWARD(F, f)},
                             hpx::util::empty_function{}));
                 }
                 else
@@ -1127,14 +1127,14 @@ namespace hpx::parallel {
                         util::partitioner<policy_type>::call_with_index(
                             hinted_policy, first, size, 1,
                             part_iterations<policy_type, F, void, args_type>{
-                            HPX_FORWARD(F, f), args},
+                                HPX_FORWARD(F, f), args},
                             [=](auto&&) mutable {
-                            auto pack =
+                                auto pack =
                                     hpx::util::make_index_pack_t<sizeof...(
                                         Ts)>();
-                            // make sure live-out variables are properly set on
-                            // return
-                            detail::exit_iteration(args, pack, size);
+                                // make sure live-out variables are properly set on
+                                // return
+                                detail::exit_iteration(args, pack, size);
                                 return hpx::util::unused;
                             }));
                 }
@@ -1270,18 +1270,18 @@ namespace hpx::parallel {
                         {
                             return util::detail::algorithm_result<ExPolicy>::
                                 get(util::partitioner<ExPolicy>::call(
-                                HPX_FORWARD(ExPolicy, policy), first, size,
-                                part_iterations<ExPolicy, F, S>{
-                                    HPX_FORWARD(F, f)},
+                                    HPX_FORWARD(ExPolicy, policy), first, size,
+                                    part_iterations<ExPolicy, F, S>{
+                                        HPX_FORWARD(F, f)},
                                     [](auto&&) { return hpx::util::unused; }));
                         }
                     }
 
                     return util::detail::algorithm_result<ExPolicy>::get(
                         util::partitioner<ExPolicy>::call_with_index(
-                        HPX_FORWARD(ExPolicy, policy), first, size, stride,
-                        part_iterations<ExPolicy, F, S>{
-                            HPX_FORWARD(F, f), stride},
+                            HPX_FORWARD(ExPolicy, policy), first, size, stride,
+                            part_iterations<ExPolicy, F, S>{
+                                HPX_FORWARD(F, f), stride},
                             [](auto&&) { return hpx::util::unused; }));
                 }
                 else
@@ -1307,14 +1307,14 @@ namespace hpx::parallel {
                         util::partitioner<policy_type>::call_with_index(
                             hinted_policy, first, size, stride,
                             part_iterations<policy_type, F, S, args_type>{
-                            HPX_FORWARD(F, f), stride, args},
+                                HPX_FORWARD(F, f), stride, args},
                             [=](auto&&) mutable {
-                            auto pack =
+                                auto pack =
                                     hpx::util::make_index_pack_t<sizeof...(
                                         Ts)>();
-                            // make sure live-out variables are properly set on
-                            // return
-                            detail::exit_iteration(args, pack, size);
+                                // make sure live-out variables are properly set on
+                                // return
+                                detail::exit_iteration(args, pack, size);
                                 return hpx::util::unused;
                             }));
                 }

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/reduce.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/reduce.hpp
@@ -362,7 +362,6 @@ namespace hpx {
 #include <hpx/parallel/algorithms/detail/dispatch.hpp>
 #include <hpx/parallel/algorithms/detail/distance.hpp>
 #include <hpx/parallel/algorithms/detail/reduce.hpp>
-#include <hpx/parallel/unseq/reduce.hpp>
 #include <hpx/parallel/util/detail/algorithm_result.hpp>
 #include <hpx/parallel/util/detail/sender_util.hpp>
 #include <hpx/parallel/util/loop.hpp>

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/reduce.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/reduce.hpp
@@ -362,6 +362,7 @@ namespace hpx {
 #include <hpx/parallel/algorithms/detail/dispatch.hpp>
 #include <hpx/parallel/algorithms/detail/distance.hpp>
 #include <hpx/parallel/algorithms/detail/reduce.hpp>
+#include <hpx/parallel/unseq/reduce.hpp>
 #include <hpx/parallel/util/detail/algorithm_result.hpp>
 #include <hpx/parallel/util/detail/sender_util.hpp>
 #include <hpx/parallel/util/loop.hpp>

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/transform.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/transform.hpp
@@ -282,6 +282,7 @@ namespace hpx {
 #include <hpx/iterator_support/traits/is_iterator.hpp>
 #include <hpx/parallel/algorithms/detail/dispatch.hpp>
 #include <hpx/parallel/algorithms/detail/distance.hpp>
+#include <hpx/parallel/unseq/transform_loop.hpp>
 #include <hpx/parallel/util/detail/algorithm_result.hpp>
 #include <hpx/parallel/util/detail/sender_util.hpp>
 #include <hpx/parallel/util/foreach_partitioner.hpp>

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/transform.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/transform.hpp
@@ -282,7 +282,6 @@ namespace hpx {
 #include <hpx/iterator_support/traits/is_iterator.hpp>
 #include <hpx/parallel/algorithms/detail/dispatch.hpp>
 #include <hpx/parallel/algorithms/detail/distance.hpp>
-#include <hpx/parallel/unseq/transform_loop.hpp>
 #include <hpx/parallel/util/detail/algorithm_result.hpp>
 #include <hpx/parallel/util/detail/sender_util.hpp>
 #include <hpx/parallel/util/foreach_partitioner.hpp>
@@ -333,7 +332,7 @@ namespace hpx::parallel {
         template <typename F>
         struct transform_projected<F, hpx::identity>
         {
-            std::decay_t<F> f_;
+            std::decay_t<F> f_{};
 
             template <typename F_>
             HPX_HOST_DEVICE constexpr transform_projected(

--- a/libs/core/algorithms/include/hpx/parallel/unseq.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/unseq.hpp
@@ -7,4 +7,5 @@
 #pragma once
 
 #include <hpx/execution.hpp>
+#include <hpx/parallel/unseq/loop.hpp>
 #include <hpx/parallel/unseq/transform_loop.hpp>

--- a/libs/core/algorithms/include/hpx/parallel/unseq.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/unseq.hpp
@@ -1,0 +1,9 @@
+//  Copyright (c) 2022 A Kishore Kumar
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include <hpx/config.hpp>

--- a/libs/core/algorithms/include/hpx/parallel/unseq.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/unseq.hpp
@@ -8,4 +8,5 @@
 
 #include <hpx/execution.hpp>
 #include <hpx/parallel/unseq/loop.hpp>
+#include <hpx/parallel/unseq/reduce.hpp>
 #include <hpx/parallel/unseq/transform_loop.hpp>

--- a/libs/core/algorithms/include/hpx/parallel/unseq.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/unseq.hpp
@@ -1,4 +1,5 @@
 //  Copyright (c) 2022 A Kishore Kumar
+//  Copyright (c) 2023 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -6,7 +7,6 @@
 
 #pragma once
 
-#include <hpx/execution.hpp>
 #include <hpx/parallel/unseq/loop.hpp>
 #include <hpx/parallel/unseq/reduce.hpp>
 #include <hpx/parallel/unseq/transform_loop.hpp>

--- a/libs/core/algorithms/include/hpx/parallel/unseq.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/unseq.hpp
@@ -6,4 +6,5 @@
 
 #pragma once
 
-#include <hpx/config.hpp>
+#include <hpx/execution.hpp>
+#include <hpx/parallel/unseq/transform_loop.hpp>

--- a/libs/core/algorithms/include/hpx/parallel/unseq/loop.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/unseq/loop.hpp
@@ -1,0 +1,356 @@
+//  Copyright (c) 2022 A Kishore Kumar
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include <hpx/config.hpp>
+
+#include <hpx/executors/execution_policy.hpp>
+#include <hpx/functional/tag_invoke.hpp>
+#include <hpx/parallel/util/loop.hpp>
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <iterator>
+#include <type_traits>
+#include <utility>
+
+namespace hpx { namespace parallel { namespace util {
+
+    ///////////////////////////////////////////////////////////////////////////
+    namespace detail {
+        ///////////////////////////////////////////////////////////////////////
+        struct unseq_loop_n
+        {
+            template <typename InIter, typename F>
+            HPX_HOST_DEVICE HPX_FORCEINLINE static InIter call(
+                InIter it, std::size_t count, F&& f)
+            {
+                // clang-format off
+                HPX_IVDEP HPX_UNROLL HPX_VECTORIZE
+                for (std::size_t i = 0; i < count; i++)
+                {
+                    HPX_INVOKE(f, it);
+                    ++it;
+                }
+                // clang-format on
+                return it;
+            }
+
+            template <typename InIter, typename CancelToken, typename F>
+            HPX_HOST_DEVICE HPX_FORCEINLINE static InIter call(
+                InIter it, std::size_t count, CancelToken& tok,
+                F&& f)
+            {
+                // clang-format off
+                HPX_IVDEP HPX_UNROLL HPX_VECTORIZE
+                for (std::size_t i = 0; i < count; i++)
+                {
+                    HPX_INVOKE(f, it);
+                    if (tok.was_cancelled())
+                        return it;
+                    ++it;
+                }
+                // clang-format on
+                return it;
+            }
+        };
+
+        struct unseq_loop_n_ind
+        {
+            template <typename InIter, typename F>
+            HPX_HOST_DEVICE HPX_FORCEINLINE static InIter call(
+                InIter it, std::size_t count, F&& f)
+            {
+                // clang-format off
+                HPX_IVDEP HPX_UNROLL HPX_VECTORIZE
+                for (std::size_t i = 0; i < count; i++)
+                {
+                    HPX_INVOKE(f, *it);
+                    ++it;
+                }
+                // clang-format on
+                return it;
+            }
+        };
+
+        ///////////////////////////////////////////////////////////////////////
+        struct unseq_loop
+        {
+            template <typename Begin, typename End, typename F>
+            HPX_HOST_DEVICE HPX_FORCEINLINE static typename std::enable_if<
+                hpx::traits::is_random_access_iterator_v<Begin>, Begin>::type
+            call(Begin it, End end, F&& f)
+            {
+                return unseq_loop_n::call(
+                    it, std::distance(it, end), HPX_FORWARD(F, f));
+            }
+
+            template <typename Begin, typename End, typename F>
+            HPX_HOST_DEVICE HPX_FORCEINLINE static typename std::enable_if<
+                !hpx::traits::is_random_access_iterator_v<Begin>, Begin>::type
+            call(Begin it, End end, F&& f)
+            {
+                for (/* */; it != end; it++)
+                {
+                    HPX_INVOKE(f, it);
+                }
+            }
+
+            template <typename Begin, typename End, typename CancelToken,
+                typename F>
+            HPX_HOST_DEVICE HPX_FORCEINLINE static typename std::enable_if<
+                hpx::traits::is_random_access_iterator_v<Begin>, Begin>::type
+            call(Begin it, End end, CancelToken& tok,
+                F&& f)
+            {
+                return unseq_loop_n::call(
+                    it, std::distance(it, end), tok, HPX_FORWARD(F, f));
+            }
+
+            template <typename Begin, typename End, typename CancelToken,
+                typename F>
+            HPX_HOST_DEVICE HPX_FORCEINLINE static typename std::enable_if<
+                !hpx::traits::is_random_access_iterator_v<Begin>, Begin>::type
+            call(Begin it, End end, CancelToken& tok,
+                F&& f)
+            {
+                for (/* */; it != end; ++it)
+                {
+                    HPX_INVOKE(f, it);
+                    if (tok.was_cancelled())
+                        return it;
+                }
+                return it;
+            }
+        };
+
+        struct unseq_loop_ind
+        {
+            template <typename Begin, typename End, typename F>
+            HPX_HOST_DEVICE HPX_FORCEINLINE static typename std::enable_if<
+                hpx::traits::is_random_access_iterator_v<Begin>, Begin>::type
+            call(Begin it, End end, F&& f)
+            {
+                return unseq_loop_n_ind::call(
+                    it, std::distance(it, end), HPX_FORWARD(F, f));
+            }
+
+            template <typename Begin, typename End, typename F>
+            HPX_HOST_DEVICE HPX_FORCEINLINE static typename std::enable_if<
+                !hpx::traits::is_random_access_iterator_v<Begin>, Begin>::type
+            call(Begin it, End end, F&& f)
+            {
+                for (/* */; it != end; ++it)
+                {
+                    HPX_INVOKE(f, *it);
+                }
+                return it;
+            }
+        };
+
+        ///////////////////////////////////////////////////////////////////////
+        struct unseq_loop2
+        {
+            template <typename InIter1, typename InIter2, typename F>
+            HPX_HOST_DEVICE HPX_FORCEINLINE static typename std::enable_if<
+                hpx::traits::is_random_access_iterator_v<InIter1> and
+                    hpx::traits::is_random_access_iterator_v<InIter2>,
+                std::pair<InIter1, InIter2>>::type
+            call(InIter1 it1, InIter1 last1,
+                InIter2 it2, F&& f)
+            {
+                std::size_t count = std::distance(it1, last1);
+                // clang-format off
+                HPX_IVDEP HPX_UNROLL HPX_VECTORIZE
+                for (std::size_t i = 0; i < count; i++)
+                {
+                    HPX_INVOKE(f, it1, it2);
+                    ++it1, ++it2;
+                }
+                // clang-format on
+                return std::make_pair(HPX_MOVE(it1), HPX_MOVE(it2));
+            }
+
+            template <typename InIter1, typename InIter2, typename F>
+            HPX_HOST_DEVICE HPX_FORCEINLINE static typename std::enable_if<
+                !hpx::traits::is_random_access_iterator_v<InIter1> or
+                    !hpx::traits::is_random_access_iterator_v<InIter2>,
+                std::pair<InIter1, InIter2>>::type
+            call(InIter1 it1, InIter1 last1,
+                InIter2 it2, F&& f)
+            {
+                for (/* */; it1 != last1; it1++, it2++)
+                {
+                    HPX_INVOKE(f, it1, it2);
+                }
+                return std::make_pair(HPX_MOVE(it1), HPX_MOVE(it2));
+            }
+        };
+
+        ///////////////////////////////////////////////////////////////////////
+        struct unseq_loop_idx_n
+        {
+            template <typename Iter, typename F>
+            HPX_HOST_DEVICE HPX_FORCEINLINE static Iter call(
+                std::size_t base_idx, Iter it, std::size_t count,
+                F&& f)
+            {
+                // clang-format off
+                HPX_IVDEP HPX_UNROLL HPX_VECTORIZE
+                for (std::size_t i = 0; i < count; i++)
+                {
+                    HPX_INVOKE(f, *it, base_idx);
+                    ++it, ++base_idx;
+                }
+                // clang-format on
+                return it;
+            }
+
+            template <typename Iter, typename CancelToken, typename F>
+            HPX_HOST_DEVICE HPX_FORCEINLINE static Iter call(
+                std::size_t base_idx, Iter it, std::size_t count,
+                CancelToken& tok, F&& f)
+            {
+                HPX_IVDEP HPX_UNROLL HPX_VECTORIZE for (std::size_t i = 0;
+                                                        i < count; i++)
+                {
+                    if (tok.was_cancelled(base_idx))
+                    {
+                        break;
+                    }
+                    HPX_INVOKE(f, *it, base_idx);
+                    ++it, ++base_idx;
+                }
+                return it;
+            }
+        };
+    }    // namespace detail
+
+    ///////////////////////////////////////////////////////////////////////////
+    template <typename Begin, typename End, typename F>
+    HPX_HOST_DEVICE HPX_FORCEINLINE Begin tag_invoke(
+        hpx::parallel::util::loop_t, hpx::execution::unsequenced_policy,
+        Begin begin, End end, F&& f)
+    {
+        return detail::unseq_loop::call(begin, end, HPX_FORWARD(F, f));
+    }
+
+    template <typename Begin, typename End, typename F>
+    HPX_HOST_DEVICE HPX_FORCEINLINE Begin tag_invoke(
+        hpx::parallel::util::loop_t, hpx::execution::unsequenced_task_policy,
+        Begin begin, End end, F&& f)
+    {
+        return detail::unseq_loop::call(begin, end, HPX_FORWARD(F, f));
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    template <typename Begin, typename End, typename CancelToken, typename F>
+    HPX_HOST_DEVICE HPX_FORCEINLINE Begin tag_invoke(
+        hpx::parallel::util::loop_t, hpx::execution::unsequenced_policy,
+        Begin begin, End end, CancelToken& tok, F&& f)
+    {
+        return detail::unseq_loop::call(
+            begin, end, tok, HPX_FORWARD(F, f));
+    }
+
+    template <typename Begin, typename End, typename CancelToken, typename F>
+    HPX_HOST_DEVICE HPX_FORCEINLINE Begin tag_invoke(
+        hpx::parallel::util::loop_t, hpx::execution::unsequenced_task_policy,
+        Begin begin, End end, CancelToken& tok, F&& f)
+    {
+        return detail::unseq_loop::call(
+            begin, end, tok, HPX_FORWARD(F, f));
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    template <typename Begin, typename End, typename F>
+    HPX_HOST_DEVICE HPX_FORCEINLINE Begin tag_invoke(
+        hpx::parallel::util::loop_ind_t, hpx::execution::unsequenced_policy,
+        Begin begin, End end, F&& f)
+    {
+        return detail::unseq_loop_ind::call(
+            begin, end, HPX_FORWARD(F, f));
+    }
+
+    template <typename Begin, typename End, typename F>
+    HPX_HOST_DEVICE HPX_FORCEINLINE Begin tag_invoke(
+        hpx::parallel::util::loop_ind_t,
+        hpx::execution::unsequenced_task_policy, Begin begin, End end, F&& f)
+    {
+        return detail::unseq_loop_ind::call(
+            begin, end, HPX_FORWARD(F, f));
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    template <typename ExPolicy, typename Iter1, typename Iter2, typename F>
+    HPX_HOST_DEVICE HPX_FORCEINLINE constexpr typename std::enable_if<
+        hpx::is_unsequenced_execution_policy_v<ExPolicy>,
+        std::pair<Iter1, Iter2>>::type
+    tag_invoke(hpx::parallel::util::loop2_t<ExPolicy>, Iter1 first1,
+        Iter1 last1, Iter2 first2, F&& f)
+    {
+        return detail::unseq_loop2::call(
+            first1, last1, first2, HPX_FORWARD(F, f));
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    template <typename ExPolicy, typename Iter, typename F>
+    HPX_HOST_DEVICE HPX_FORCEINLINE constexpr typename std::enable_if<
+        hpx::is_unsequenced_execution_policy_v<ExPolicy>, Iter>::type
+    tag_invoke(hpx::parallel::util::loop_n_t<ExPolicy>, Iter it,
+        std::size_t count, F&& f)
+    {
+        return hpx::parallel::util::detail::unseq_loop_n::call(
+            it, count, HPX_FORWARD(F, f));
+    }
+
+    template <typename ExPolicy, typename Iter, typename CancelToken,
+        typename F>
+    HPX_HOST_DEVICE HPX_FORCEINLINE constexpr typename std::enable_if<
+        hpx::is_unsequenced_execution_policy_v<ExPolicy>, Iter>::type
+    tag_invoke(hpx::parallel::util::loop_n_t<ExPolicy>, Iter it,
+        std::size_t count, CancelToken& tok, F&& f)
+    {
+        return hpx::parallel::util::detail::unseq_loop_n::call(
+            it, count, tok, HPX_FORWARD(F, f));
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    template <typename ExPolicy, typename Iter, typename F>
+    HPX_HOST_DEVICE HPX_FORCEINLINE constexpr typename std::enable_if<
+        hpx::is_unsequenced_execution_policy_v<ExPolicy>, Iter>::type
+    tag_invoke(hpx::parallel::util::loop_n_ind_t<ExPolicy>, Iter it,
+        std::size_t count, F&& f)
+    {
+        return hpx::parallel::util::detail::unseq_loop_n_ind::call(
+            it, count, HPX_FORWARD(F, f));
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    template <typename ExPolicy, typename Iter, typename F>
+    HPX_HOST_DEVICE HPX_FORCEINLINE constexpr typename std::enable_if<
+        hpx::is_unsequenced_execution_policy_v<ExPolicy>, Iter>::type
+    tag_invoke(hpx::parallel::util::loop_idx_n_t<ExPolicy>,
+        std::size_t base_idx, Iter it, std::size_t count, F&& f)
+    {
+        return hpx::parallel::util::detail::unseq_loop_idx_n::call(
+            base_idx, it, count, HPX_FORWARD(F, f));
+    }
+
+    template <typename ExPolicy, typename Iter, typename CancelToken,
+        typename F>
+    HPX_HOST_DEVICE HPX_FORCEINLINE constexpr typename std::enable_if<
+        hpx::is_unsequenced_execution_policy_v<ExPolicy>, Iter>::type
+    tag_invoke(hpx::parallel::util::loop_idx_n_t<ExPolicy>,
+        std::size_t base_idx, Iter it, std::size_t count, CancelToken& tok,
+        F&& f)
+    {
+        return hpx::parallel::util::detail::unseq_loop_idx_n::call(
+            base_idx, it, count, tok, HPX_FORWARD(F, f));
+    }
+}}}    // namespace hpx::parallel::util

--- a/libs/core/algorithms/include/hpx/parallel/unseq/reduce.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/unseq/reduce.hpp
@@ -7,24 +7,16 @@
 #pragma once
 
 #include <hpx/config.hpp>
-
-#include <hpx/executors/execution_policy.hpp>
 #include <hpx/execution/traits/is_execution_policy.hpp>
-#include <hpx/functional/tag_invoke.hpp>
+#include <hpx/executors/execution_policy.hpp>
 #include <hpx/parallel/algorithms/detail/reduce.hpp>
-#include <hpx/parallel/unseq.hpp>
-#include <hpx/parallel/util/result_types.hpp>
-
-#include <hpx/parallel/algorithms/detail/distance.hpp>
 #include <hpx/parallel/unseq/reduce_helpers.hpp>
-#include <hpx/parallel/util/result_types.hpp>
-#include <hpx/parallel/util/zip_iterator.hpp>
 
 #include <cstddef>
 #include <type_traits>
 #include <utility>
 
-namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
+namespace hpx::parallel::detail {
 
     ///////////////////////////////////////////////////////////////////////////
     template <typename ExPolicy>
@@ -198,5 +190,4 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
         return unseq_reduce<ExPolicy>::call(first1, last1, first2, init,
             HPX_FORWARD(Reduce, r), HPX_FORWARD(Convert, conv));
     }
-
-}}}}    // namespace hpx::parallel::v1::detail
+}    // namespace hpx::parallel::detail

--- a/libs/core/algorithms/include/hpx/parallel/unseq/reduce.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/unseq/reduce.hpp
@@ -1,4 +1,5 @@
 //  Copyright (c) 2022 A Kishore Kumar
+//  Copyright (c) 2023 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -19,175 +20,131 @@
 namespace hpx::parallel::detail {
 
     ///////////////////////////////////////////////////////////////////////////
-    template <typename ExPolicy>
-    struct unseq_reduce
+    // clang-format off
+    template <typename ExPolicy, typename InIterB, typename InIterE, typename T,
+        typename Reduce,
+        HPX_CONCEPT_REQUIRES_(
+            hpx::is_unsequenced_execution_policy_v<ExPolicy>
+        )>
+    // clang-format on
+    HPX_HOST_DEVICE HPX_FORCEINLINE constexpr T tag_invoke(
+        sequential_reduce_t<ExPolicy>, ExPolicy&&, InIterB first, InIterE last,
+        T init, Reduce&& r)
     {
-        using sequenced_policy = hpx::execution::sequenced_policy;
-
-        template <typename InIterB, typename InIterE, typename T,
-            typename Reduce>
-        HPX_HOST_DEVICE HPX_FORCEINLINE static typename std::enable_if<
-            hpx::traits::is_random_access_iterator_v<InIterB>, T>::type
-        call(ExPolicy&& /* policy */, InIterB first, InIterE last, T init,
-            Reduce&& r)
+        if constexpr (hpx::traits::is_random_access_iterator_v<InIterB>)
         {
             return hpx::parallel::util::detail::unseq_reduce_n::reduce(first,
                 std::distance(first, last), HPX_FORWARD(T, init),
                 HPX_FORWARD(Reduce, r), [&](auto const v) { return v; });
         }
-
-        template <typename InIterB, typename InIterE, typename T,
-            typename Reduce>
-        HPX_HOST_DEVICE HPX_FORCEINLINE static typename std::enable_if<
-            !hpx::traits::is_random_access_iterator_v<InIterB>, T>::type
-        call(ExPolicy&& /* policy */, InIterB first, InIterE last, T init,
-            Reduce&& r)
+        else
         {
+            using sequenced_policy = hpx::execution::sequenced_policy;
             return sequential_reduce<sequenced_policy>(
                 sequenced_policy{}, first, last, init, HPX_FORWARD(Reduce, r));
         }
+    }
 
-        template <typename T, typename FwdIterB, typename Reduce>
-        HPX_HOST_DEVICE HPX_FORCEINLINE static typename std::enable_if<
-            hpx::traits::is_random_access_iterator_v<FwdIterB>, T>::type
-        call(FwdIterB part_begin, std::size_t part_size, T init, Reduce r)
+    // clang-format off
+    template <typename ExPolicy, typename T, typename FwdIter, typename Reduce,
+        HPX_CONCEPT_REQUIRES_(
+            hpx::is_unsequenced_execution_policy_v<ExPolicy>
+        )>
+    // clang-format on
+    HPX_HOST_DEVICE HPX_FORCEINLINE constexpr T tag_invoke(
+        sequential_reduce_t<ExPolicy>, FwdIter part_begin,
+        std::size_t part_size, T init, Reduce r)
+    {
+        if constexpr (hpx::traits::is_random_access_iterator_v<FwdIter>)
         {
             return hpx::parallel::util::detail::unseq_reduce_n::reduce(
                 part_begin, part_size, HPX_FORWARD(T, init),
                 HPX_FORWARD(Reduce, r), [&](auto const v) { return v; });
         }
-
-        template <typename T, typename FwdIterB, typename Reduce>
-        HPX_HOST_DEVICE HPX_FORCEINLINE static typename std::enable_if<
-            !hpx::traits::is_random_access_iterator_v<FwdIterB>, T>::type
-        call(FwdIterB part_begin, std::size_t part_size, T init, Reduce r)
+        else
         {
             return sequential_reduce<hpx::execution::sequenced_policy>(
                 part_begin, part_size, init, r);
         }
+    }
 
-        template <typename Iter, typename Sent, typename T, typename Reduce,
-            typename Convert>
-        HPX_HOST_DEVICE HPX_FORCEINLINE static typename std::enable_if<
-            hpx::traits::is_random_access_iterator_v<Iter>, T>::type
-        call(ExPolicy&& /* policy */, Iter first, Sent last, T init, Reduce&& r,
-            Convert&& conv)
+    // clang-format off
+    template <typename ExPolicy, typename Iter, typename Sent, typename T,
+        typename Reduce, typename Convert,
+        HPX_CONCEPT_REQUIRES_(
+            hpx::is_unsequenced_execution_policy_v<ExPolicy>
+        )>
+    // clang-format on
+    HPX_HOST_DEVICE HPX_FORCEINLINE constexpr T tag_invoke(
+        sequential_reduce_t<ExPolicy>, ExPolicy&&, Iter first, Sent last,
+        T init, Reduce&& r, Convert&& conv)
+    {
+        if constexpr (hpx::traits::is_random_access_iterator_v<Iter>)
         {
             return hpx::parallel::util::detail::unseq_reduce_n::reduce(first,
                 std::distance(first, last), HPX_FORWARD(T, init),
                 HPX_FORWARD(Reduce, r), HPX_FORWARD(Convert, conv));
         }
-
-        template <typename Iter, typename Sent, typename T, typename Reduce,
-            typename Convert>
-        HPX_HOST_DEVICE HPX_FORCEINLINE static typename std::enable_if<
-            !hpx::traits::is_random_access_iterator_v<Iter>, T>::type
-        call(ExPolicy&& /* policy */, Iter first, Sent last, T init, Reduce&& r,
-            Convert&& conv)
+        else
         {
+            using sequenced_policy = hpx::execution::sequenced_policy;
             return sequential_reduce<sequenced_policy>(sequenced_policy{},
                 first, last, init, HPX_FORWARD(Reduce, r),
                 HPX_FORWARD(Convert, conv));
         }
+    }
 
-        template <typename T, typename Iter, typename Reduce, typename Convert>
-        HPX_HOST_DEVICE HPX_FORCEINLINE static typename std::enable_if<
-            hpx::traits::is_random_access_iterator_v<Iter>, T>::type
-        call(Iter part_begin, std::size_t part_size, T init, Reduce r,
-            Convert conv)
+    // clang-format off
+    template <typename ExPolicy, typename T, typename Iter, typename Reduce,
+        typename Convert,
+        HPX_CONCEPT_REQUIRES_(
+            hpx::is_unsequenced_execution_policy_v<ExPolicy>
+        )>
+    // clang-format on
+    HPX_HOST_DEVICE HPX_FORCEINLINE constexpr T tag_invoke(
+        sequential_reduce_t<ExPolicy>, Iter part_begin, std::size_t part_size,
+        T init, Reduce r, Convert conv)
+    {
+        if constexpr (hpx::traits::is_random_access_iterator_v<Iter>)
         {
             return hpx::parallel::util::detail::unseq_reduce_n::reduce(
                 part_begin, part_size, HPX_FORWARD(T, init),
                 HPX_FORWARD(Reduce, r), HPX_FORWARD(Convert, conv));
         }
-
-        template <typename T, typename Iter, typename Reduce, typename Convert>
-        HPX_HOST_DEVICE HPX_FORCEINLINE static typename std::enable_if<
-            !hpx::traits::is_random_access_iterator_v<Iter>, T>::type
-        call(Iter part_begin, std::size_t part_size, T init, Reduce r,
-            Convert conv)
+        else
         {
-            return sequential_reduce<sequenced_policy>(
+            return sequential_reduce<hpx::execution::sequenced_policy>(
                 part_begin, part_size, init, r, conv);
         }
+    }
 
-        template <typename Iter1, typename Sent, typename Iter2, typename T,
-            typename Reduce, typename Convert>
-        HPX_HOST_DEVICE HPX_FORCEINLINE static typename std::enable_if<
-            hpx::traits::is_random_access_iterator_v<Iter1> and
-                hpx::traits::is_random_access_iterator_v<Iter2>,
-            T>::type
-        call(Iter1 first1, Sent last1, Iter2 first2, T init, Reduce&& r,
-            Convert&& conv)
+    // clang-format off
+    template <typename ExPolicy, typename Iter1, typename Sent, typename Iter2,
+        typename T, typename Reduce, typename Convert,
+        HPX_CONCEPT_REQUIRES_(
+            hpx::is_unsequenced_execution_policy_v<ExPolicy>
+        )>
+    // clang-format on
+    HPX_HOST_DEVICE HPX_FORCEINLINE constexpr T tag_invoke(
+        sequential_reduce_t<ExPolicy>, Iter1 first1, Sent last1, Iter2 first2,
+        T init, Reduce&& r, Convert&& conv)
+    {
+        constexpr bool iterators_are_random_access =
+            hpx::traits::is_random_access_iterator_v<Iter1> &&
+            hpx::traits::is_random_access_iterator_v<Iter2>;
+
+        if constexpr (iterators_are_random_access)
         {
             return hpx::parallel::util::detail::unseq_binary_reduce_n::reduce(
                 first1, first2, std::distance(first1, last1),
                 HPX_FORWARD(T, init), HPX_FORWARD(Reduce, r),
                 HPX_FORWARD(Convert, conv));
         }
-
-        template <typename Iter1, typename Sent, typename Iter2, typename T,
-            typename Reduce, typename Convert>
-        HPX_HOST_DEVICE HPX_FORCEINLINE static typename std::enable_if<
-            !hpx::traits::is_random_access_iterator_v<Iter1> or
-                !hpx::traits::is_random_access_iterator_v<Iter2>,
-            T>::type
-        call(Iter1 first1, Sent last1, Iter2 first2, T init, Reduce&& r,
-            Convert&& conv)
+        else
         {
-            return sequential_reduce<sequenced_policy>(first1, last1, first2,
-                init, HPX_FORWARD(Reduce, r), HPX_FORWARD(Convert, conv));
+            return sequential_reduce<hpx::execution::sequenced_policy>(first1,
+                last1, first2, init, HPX_FORWARD(Reduce, r),
+                HPX_FORWARD(Convert, conv));
         }
-    };
-
-    template <typename ExPolicy, typename InIterB, typename InIterE, typename T,
-        typename Reduce,
-        HPX_CONCEPT_REQUIRES_(hpx::is_unsequenced_execution_policy_v<ExPolicy>)>
-    HPX_HOST_DEVICE HPX_FORCEINLINE T tag_invoke(sequential_reduce_t<ExPolicy>,
-        ExPolicy&& policy, InIterB first, InIterE last, T init, Reduce&& r)
-    {
-        return unseq_reduce<ExPolicy>::call(HPX_FORWARD(ExPolicy, policy),
-            first, last, init, HPX_FORWARD(Reduce, r));
-    }
-
-    template <typename ExPolicy, typename T, typename FwdIter, typename Reduce,
-        HPX_CONCEPT_REQUIRES_(hpx::is_unsequenced_execution_policy_v<ExPolicy>)>
-    HPX_HOST_DEVICE HPX_FORCEINLINE T tag_invoke(sequential_reduce_t<ExPolicy>,
-        FwdIter part_begin, std::size_t part_size, T init, Reduce r)
-    {
-        return unseq_reduce<ExPolicy>::call(part_begin, part_size, init, r);
-    }
-
-    template <typename ExPolicy, typename Iter, typename Sent, typename T,
-        typename Reduce, typename Convert,
-        HPX_CONCEPT_REQUIRES_(hpx::is_unsequenced_execution_policy_v<ExPolicy>)>
-    HPX_HOST_DEVICE HPX_FORCEINLINE T tag_invoke(sequential_reduce_t<ExPolicy>,
-        ExPolicy&& policy, Iter first, Sent last, T init, Reduce&& r,
-        Convert&& conv)
-    {
-        return unseq_reduce<ExPolicy>::call(HPX_FORWARD(ExPolicy, policy),
-            first, last, init, HPX_FORWARD(Reduce, r),
-            HPX_FORWARD(Convert, conv));
-    }
-
-    template <typename ExPolicy, typename T, typename Iter, typename Reduce,
-        typename Convert,
-        HPX_CONCEPT_REQUIRES_(hpx::is_unsequenced_execution_policy_v<ExPolicy>)>
-    HPX_HOST_DEVICE HPX_FORCEINLINE T tag_invoke(sequential_reduce_t<ExPolicy>,
-        Iter part_begin, std::size_t part_size, T init, Reduce r, Convert conv)
-    {
-        return unseq_reduce<ExPolicy>::call(
-            part_begin, part_size, init, r, conv);
-    }
-
-    template <typename ExPolicy, typename Iter1, typename Sent, typename Iter2,
-        typename T, typename Reduce, typename Convert,
-        HPX_CONCEPT_REQUIRES_(hpx::is_unsequenced_execution_policy_v<ExPolicy>)>
-    HPX_HOST_DEVICE HPX_FORCEINLINE T tag_invoke(sequential_reduce_t<ExPolicy>,
-        Iter1 first1, Sent last1, Iter2 first2, T init, Reduce&& r,
-        Convert&& conv)
-    {
-        return unseq_reduce<ExPolicy>::call(first1, last1, first2, init,
-            HPX_FORWARD(Reduce, r), HPX_FORWARD(Convert, conv));
     }
 }    // namespace hpx::parallel::detail

--- a/libs/core/algorithms/include/hpx/parallel/unseq/reduce.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/unseq/reduce.hpp
@@ -1,0 +1,202 @@
+//  Copyright (c) 2022 A Kishore Kumar
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include <hpx/config.hpp>
+
+#include <hpx/executors/execution_policy.hpp>
+#include <hpx/execution/traits/is_execution_policy.hpp>
+#include <hpx/functional/tag_invoke.hpp>
+#include <hpx/parallel/algorithms/detail/reduce.hpp>
+#include <hpx/parallel/unseq.hpp>
+#include <hpx/parallel/util/result_types.hpp>
+
+#include <hpx/parallel/algorithms/detail/distance.hpp>
+#include <hpx/parallel/unseq/reduce_helpers.hpp>
+#include <hpx/parallel/util/result_types.hpp>
+#include <hpx/parallel/util/zip_iterator.hpp>
+
+#include <cstddef>
+#include <type_traits>
+#include <utility>
+
+namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
+
+    ///////////////////////////////////////////////////////////////////////////
+    template <typename ExPolicy>
+    struct unseq_reduce
+    {
+        using sequenced_policy = hpx::execution::sequenced_policy;
+
+        template <typename InIterB, typename InIterE, typename T,
+            typename Reduce>
+        HPX_HOST_DEVICE HPX_FORCEINLINE static typename std::enable_if<
+            hpx::traits::is_random_access_iterator_v<InIterB>, T>::type
+        call(ExPolicy&& /* policy */, InIterB first, InIterE last, T init,
+            Reduce&& r)
+        {
+            return hpx::parallel::util::detail::unseq_reduce_n::reduce(first,
+                std::distance(first, last), HPX_FORWARD(T, init),
+                HPX_FORWARD(Reduce, r), [&](auto const v) { return v; });
+        }
+
+        template <typename InIterB, typename InIterE, typename T,
+            typename Reduce>
+        HPX_HOST_DEVICE HPX_FORCEINLINE static typename std::enable_if<
+            !hpx::traits::is_random_access_iterator_v<InIterB>, T>::type
+        call(ExPolicy&& /* policy */, InIterB first, InIterE last, T init,
+            Reduce&& r)
+        {
+            return sequential_reduce<sequenced_policy>(
+                sequenced_policy{}, first, last, init, HPX_FORWARD(Reduce, r));
+        }
+
+        template <typename T, typename FwdIterB, typename Reduce>
+        HPX_HOST_DEVICE HPX_FORCEINLINE static typename std::enable_if<
+            hpx::traits::is_random_access_iterator_v<FwdIterB>, T>::type
+        call(FwdIterB part_begin, std::size_t part_size, T init, Reduce r)
+        {
+            return hpx::parallel::util::detail::unseq_reduce_n::reduce(
+                part_begin, part_size, HPX_FORWARD(T, init),
+                HPX_FORWARD(Reduce, r), [&](auto const v) { return v; });
+        }
+
+        template <typename T, typename FwdIterB, typename Reduce>
+        HPX_HOST_DEVICE HPX_FORCEINLINE static typename std::enable_if<
+            !hpx::traits::is_random_access_iterator_v<FwdIterB>, T>::type
+        call(FwdIterB part_begin, std::size_t part_size, T init, Reduce r)
+        {
+            return sequential_reduce<hpx::execution::sequenced_policy>(
+                part_begin, part_size, init, r);
+        }
+
+        template <typename Iter, typename Sent, typename T, typename Reduce,
+            typename Convert>
+        HPX_HOST_DEVICE HPX_FORCEINLINE static typename std::enable_if<
+            hpx::traits::is_random_access_iterator_v<Iter>, T>::type
+        call(ExPolicy&& /* policy */, Iter first, Sent last, T init, Reduce&& r,
+            Convert&& conv)
+        {
+            return hpx::parallel::util::detail::unseq_reduce_n::reduce(first,
+                std::distance(first, last), HPX_FORWARD(T, init),
+                HPX_FORWARD(Reduce, r), HPX_FORWARD(Convert, conv));
+        }
+
+        template <typename Iter, typename Sent, typename T, typename Reduce,
+            typename Convert>
+        HPX_HOST_DEVICE HPX_FORCEINLINE static typename std::enable_if<
+            !hpx::traits::is_random_access_iterator_v<Iter>, T>::type
+        call(ExPolicy&& /* policy */, Iter first, Sent last, T init, Reduce&& r,
+            Convert&& conv)
+        {
+            return sequential_reduce<sequenced_policy>(sequenced_policy{},
+                first, last, init, HPX_FORWARD(Reduce, r),
+                HPX_FORWARD(Convert, conv));
+        }
+
+        template <typename T, typename Iter, typename Reduce, typename Convert>
+        HPX_HOST_DEVICE HPX_FORCEINLINE static typename std::enable_if<
+            hpx::traits::is_random_access_iterator_v<Iter>, T>::type
+        call(Iter part_begin, std::size_t part_size, T init, Reduce r,
+            Convert conv)
+        {
+            return hpx::parallel::util::detail::unseq_reduce_n::reduce(
+                part_begin, part_size, HPX_FORWARD(T, init),
+                HPX_FORWARD(Reduce, r), HPX_FORWARD(Convert, conv));
+        }
+
+        template <typename T, typename Iter, typename Reduce, typename Convert>
+        HPX_HOST_DEVICE HPX_FORCEINLINE static typename std::enable_if<
+            !hpx::traits::is_random_access_iterator_v<Iter>, T>::type
+        call(Iter part_begin, std::size_t part_size, T init, Reduce r,
+            Convert conv)
+        {
+            return sequential_reduce<sequenced_policy>(
+                part_begin, part_size, init, r, conv);
+        }
+
+        template <typename Iter1, typename Sent, typename Iter2, typename T,
+            typename Reduce, typename Convert>
+        HPX_HOST_DEVICE HPX_FORCEINLINE static typename std::enable_if<
+            hpx::traits::is_random_access_iterator_v<Iter1> and
+                hpx::traits::is_random_access_iterator_v<Iter2>,
+            T>::type
+        call(Iter1 first1, Sent last1, Iter2 first2, T init, Reduce&& r,
+            Convert&& conv)
+        {
+            return hpx::parallel::util::detail::unseq_binary_reduce_n::reduce(
+                first1, first2, std::distance(first1, last1),
+                HPX_FORWARD(T, init), HPX_FORWARD(Reduce, r),
+                HPX_FORWARD(Convert, conv));
+        }
+
+        template <typename Iter1, typename Sent, typename Iter2, typename T,
+            typename Reduce, typename Convert>
+        HPX_HOST_DEVICE HPX_FORCEINLINE static typename std::enable_if<
+            !hpx::traits::is_random_access_iterator_v<Iter1> or
+                !hpx::traits::is_random_access_iterator_v<Iter2>,
+            T>::type
+        call(Iter1 first1, Sent last1, Iter2 first2, T init, Reduce&& r,
+            Convert&& conv)
+        {
+            return sequential_reduce<sequenced_policy>(first1, last1, first2,
+                init, HPX_FORWARD(Reduce, r), HPX_FORWARD(Convert, conv));
+        }
+    };
+
+    template <typename ExPolicy, typename InIterB, typename InIterE, typename T,
+        typename Reduce,
+        HPX_CONCEPT_REQUIRES_(hpx::is_unsequenced_execution_policy_v<ExPolicy>)>
+    HPX_HOST_DEVICE HPX_FORCEINLINE T tag_invoke(sequential_reduce_t<ExPolicy>,
+        ExPolicy&& policy, InIterB first, InIterE last, T init, Reduce&& r)
+    {
+        return unseq_reduce<ExPolicy>::call(HPX_FORWARD(ExPolicy, policy),
+            first, last, init, HPX_FORWARD(Reduce, r));
+    }
+
+    template <typename ExPolicy, typename T, typename FwdIter, typename Reduce,
+        HPX_CONCEPT_REQUIRES_(hpx::is_unsequenced_execution_policy_v<ExPolicy>)>
+    HPX_HOST_DEVICE HPX_FORCEINLINE T tag_invoke(sequential_reduce_t<ExPolicy>,
+        FwdIter part_begin, std::size_t part_size, T init, Reduce r)
+    {
+        return unseq_reduce<ExPolicy>::call(part_begin, part_size, init, r);
+    }
+
+    template <typename ExPolicy, typename Iter, typename Sent, typename T,
+        typename Reduce, typename Convert,
+        HPX_CONCEPT_REQUIRES_(hpx::is_unsequenced_execution_policy_v<ExPolicy>)>
+    HPX_HOST_DEVICE HPX_FORCEINLINE T tag_invoke(sequential_reduce_t<ExPolicy>,
+        ExPolicy&& policy, Iter first, Sent last, T init, Reduce&& r,
+        Convert&& conv)
+    {
+        return unseq_reduce<ExPolicy>::call(HPX_FORWARD(ExPolicy, policy),
+            first, last, init, HPX_FORWARD(Reduce, r),
+            HPX_FORWARD(Convert, conv));
+    }
+
+    template <typename ExPolicy, typename T, typename Iter, typename Reduce,
+        typename Convert,
+        HPX_CONCEPT_REQUIRES_(hpx::is_unsequenced_execution_policy_v<ExPolicy>)>
+    HPX_HOST_DEVICE HPX_FORCEINLINE T tag_invoke(sequential_reduce_t<ExPolicy>,
+        Iter part_begin, std::size_t part_size, T init, Reduce r, Convert conv)
+    {
+        return unseq_reduce<ExPolicy>::call(
+            part_begin, part_size, init, r, conv);
+    }
+
+    template <typename ExPolicy, typename Iter1, typename Sent, typename Iter2,
+        typename T, typename Reduce, typename Convert,
+        HPX_CONCEPT_REQUIRES_(hpx::is_unsequenced_execution_policy_v<ExPolicy>)>
+    HPX_HOST_DEVICE HPX_FORCEINLINE T tag_invoke(sequential_reduce_t<ExPolicy>,
+        Iter1 first1, Sent last1, Iter2 first2, T init, Reduce&& r,
+        Convert&& conv)
+    {
+        return unseq_reduce<ExPolicy>::call(first1, last1, first2, init,
+            HPX_FORWARD(Reduce, r), HPX_FORWARD(Convert, conv));
+    }
+
+}}}}    // namespace hpx::parallel::v1::detail

--- a/libs/core/algorithms/include/hpx/parallel/unseq/reduce_helpers.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/unseq/reduce_helpers.hpp
@@ -1,0 +1,456 @@
+//  Copyright (c) 2022 A Kishore Kumar
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include <hpx/config.hpp>
+
+#include <hpx/functional/detail/invoke.hpp>
+#include <hpx/functional/invoke_result.hpp>
+#include <cstdint>
+
+///////////////////////////////////////////////////////////////////////////////
+namespace hpx { namespace parallel { namespace util { namespace detail {
+    ///////////////////////////////////////////////////////////////////////////
+    // TODO: Make it detect template even for implicit convertible operations
+    template <typename T, typename Operation>
+    using is_arithmetic_plus_reduction = std::integral_constant<bool,
+        std::is_arithmetic_v<T> and std::is_same_v<Operation, std::plus<T>>>;
+
+    template <typename T, typename Operation>
+    using is_arithmetic_minus_reduction = std::integral_constant<bool,
+        std::is_arithmetic_v<T> and std::is_same_v<Operation, std::minus<T>>>;
+
+    template <typename T, typename Operation>
+    using is_arithmetic_multiplies_reduction = std::integral_constant<bool,
+        std::is_arithmetic_v<T> and
+            std::is_same_v<Operation, std::multiplies<T>>>;
+
+    template <typename T, typename Operation>
+    using is_arithmetic_bit_and_reduction = std::integral_constant<bool,
+        std::is_arithmetic_v<T> and std::is_same_v<Operation, std::bit_and<T>>>;
+
+    template <typename T, typename Operation>
+    using is_arithmetic_bit_or_reduction = std::integral_constant<bool,
+        std::is_arithmetic_v<T> and std::is_same_v<Operation, std::bit_or<T>>>;
+
+    template <typename T, typename Operation>
+    using is_arithmetic_bit_xor_reduction = std::integral_constant<bool,
+        std::is_arithmetic_v<T> and std::is_same_v<Operation, std::bit_xor<T>>>;
+
+    template <typename T, typename Operation>
+    using is_arithmetic_logical_and_reduction = std::integral_constant<bool,
+        std::is_arithmetic_v<T> and
+            std::is_same_v<Operation, std::logical_and<T>>>;
+
+    template <typename T, typename Operation>
+    using is_arithmetic_logical_or_reduction = std::integral_constant<bool,
+        std::is_arithmetic_v<T> and
+            std::is_same_v<Operation, std::logical_or<T>>>;
+
+    template <typename T, typename Operation>
+    using is_not_omp_reduction = std::integral_constant<bool,
+        !is_arithmetic_plus_reduction<T, Operation>::value and
+            !is_arithmetic_minus_reduction<T, Operation>::value and
+            !is_arithmetic_multiplies_reduction<T, Operation>::value and
+            !is_arithmetic_bit_and_reduction<T, Operation>::value and
+            !is_arithmetic_bit_or_reduction<T, Operation>::value and
+            !is_arithmetic_bit_xor_reduction<T, Operation>::value and
+            !is_arithmetic_logical_and_reduction<T, Operation>::value and
+            !is_arithmetic_logical_or_reduction<T, Operation>::value>;
+
+    ///////////////////////////////////////////////////////////////////////////
+    struct unseq_reduce_n
+    {
+        /* Will only be called when the iterators are all random access */
+        template <typename Iter1, typename T, typename Convert, typename Reduce>
+        HPX_HOST_DEVICE HPX_FORCEINLINE static typename std::enable_if<
+            is_arithmetic_plus_reduction<T, Reduce>::value, T>::type
+        reduce(Iter1 it, std::size_t count, T init, Reduce /* */,
+            Convert conv)
+        {
+            HPX_VECTOR_REDUCTION(+ : init)
+            for (std::size_t i = 0; i < count; i++)
+            {
+                init += HPX_INVOKE(conv, *it);
+                ++it;
+            }
+            return init;
+        }
+
+        template <typename Iter1, typename T, typename Convert, typename Reduce>
+        HPX_HOST_DEVICE HPX_FORCEINLINE static typename std::enable_if<
+            is_arithmetic_minus_reduction<T, Reduce>::value, T>::type
+        reduce(Iter1 it, std::size_t count, T init, Reduce /* */,
+            Convert conv)
+        {
+            HPX_VECTOR_REDUCTION(- : init)
+            for (std::size_t i = 0; i < count; i++)
+            {
+                init -= HPX_INVOKE(conv, *it);
+                ++it;
+            }
+            return init;
+        }
+
+        template <typename Iter1, typename T, typename Convert, typename Reduce>
+        HPX_HOST_DEVICE HPX_FORCEINLINE static typename std::enable_if<
+            is_arithmetic_multiplies_reduction<T, Reduce>::value, T>::type
+        reduce(Iter1 it, std::size_t count, T init, Reduce /* */,
+            Convert conv)
+        {
+            HPX_VECTOR_REDUCTION(* : init)
+            for (std::size_t i = 0; i < count; i++)
+            {
+                init *= HPX_INVOKE(conv, *it);
+                ++it;
+            }
+            return init;
+        }
+
+        template <typename Iter1, typename T, typename Convert, typename Reduce>
+        HPX_HOST_DEVICE HPX_FORCEINLINE static typename std::enable_if<
+            is_arithmetic_bit_and_reduction<T, Reduce>::value, T>::type
+        reduce(Iter1 it, std::size_t count, T init, Reduce /* */,
+            Convert conv)
+        {
+            HPX_VECTOR_REDUCTION(& : init)
+            for (std::size_t i = 0; i < count; i++)
+            {
+                init &= HPX_INVOKE(conv, *it);
+                ++it;
+            }
+            return init;
+        }
+
+        template <typename Iter1, typename T, typename Convert, typename Reduce>
+        HPX_HOST_DEVICE HPX_FORCEINLINE static typename std::enable_if<
+            is_arithmetic_bit_or_reduction<T, Reduce>::value, T>::type
+        reduce(Iter1 it, std::size_t count, T init, Reduce /* */,
+            Convert conv)
+        {
+            HPX_VECTOR_REDUCTION(| : init)
+            for (std::size_t i = 0; i < count; i++)
+            {
+                init |= HPX_INVOKE(conv, *it);
+                ++it;
+            }
+            return init;
+        }
+
+        template <typename Iter1, typename T, typename Convert, typename Reduce>
+        HPX_HOST_DEVICE HPX_FORCEINLINE static typename std::enable_if<
+            is_arithmetic_bit_xor_reduction<T, Reduce>::value, T>::type
+        reduce(Iter1 it, std::size_t count, T init, Reduce /* */,
+            Convert conv)
+        {
+            HPX_VECTOR_REDUCTION(^ : init)
+            for (std::size_t i = 0; i < count; i++)
+            {
+                init ^= HPX_INVOKE(conv, *it);
+                ++it;
+            }
+            return init;
+        }
+
+        template <typename Iter1, typename T, typename Convert, typename Reduce>
+        HPX_HOST_DEVICE HPX_FORCEINLINE static typename std::enable_if<
+            is_arithmetic_logical_and_reduction<T, Reduce>::value, T>::type
+        reduce(Iter1 it, std::size_t count, T init, Reduce /* */,
+            Convert conv)
+        {
+            HPX_VECTOR_REDUCTION(&& : init)
+            for (std::size_t i = 0; i < count; i++)
+            {
+                init = HPX_INVOKE(conv, *it) && init;
+                ++it;
+            }
+            return init;
+        }
+
+        template <typename Iter1, typename T, typename Convert, typename Reduce>
+        HPX_HOST_DEVICE HPX_FORCEINLINE static typename std::enable_if<
+            is_arithmetic_logical_or_reduction<T, Reduce>::value, T>::type
+        reduce(Iter1 it, std::size_t count, T init, Reduce /* */,
+            Convert conv)
+        {
+            HPX_VECTOR_REDUCTION(|| : init)
+            for (std::size_t i = 0; i < count; i++)
+            {
+                init = HPX_INVOKE(conv, *it) || init;
+                ++it;
+            }
+            return init;
+        }
+
+        template <typename Iter1, typename T, typename Convert, typename Reduce>
+        HPX_HOST_DEVICE HPX_FORCEINLINE static
+            typename std::enable_if<is_not_omp_reduction<T, Reduce>::value,
+                T>::type
+            reduce(Iter1 it, std::size_t count, T init, Reduce r,
+                Convert conv)
+        {
+            const std::size_t block_size = HPX_LANE_SIZE / sizeof(T);
+
+            // To small, just run sequential
+            if (count <= (block_size << 1))
+            {
+                for (std::size_t i = 0; i < count; i++)
+                {
+                    init = HPX_INVOKE(r, init, HPX_INVOKE(conv, *it));
+                    ++it;
+                }
+            }
+            else
+            {
+                alignas(HPX_LANE_SIZE) std::uint8_t block[HPX_LANE_SIZE];
+                T* tblock = reinterpret_cast<T*>(block);
+                /* Initialize block[i] = r(f(2*i), f(2*i + 1)) */
+                for (std::size_t i = 0; i < (block_size << 1); i += 2)
+                {
+                    ::new (tblock + i / 2) T(HPX_INVOKE(
+                        r, HPX_INVOKE(conv, *it), HPX_INVOKE(conv, *(it + 1))));
+                    it += 2;
+                }
+                /* Vectorized loop */
+                const std::size_t limit = block_size * (count / block_size);
+                for (std::size_t i = (block_size << 1); i < limit;
+                     i += block_size)
+                {
+                    HPX_VECTORIZE
+                    for (std::size_t j = 0; j < block_size; j++)
+                    {
+                        tblock[j] = HPX_INVOKE(
+                            r, tblock[j], HPX_INVOKE(conv, *(it + j)));
+                    }
+                    it += block_size;
+                }
+                /* Remainder */
+                HPX_VECTORIZE
+                for (std::size_t i = 0; i < count - limit; i++)
+                {
+                    tblock[i] = HPX_INVOKE(r, tblock[i], HPX_INVOKE(conv, *it));
+                    ++it;
+                }
+                /* Merge */
+                for (std::size_t i = 0; i < block_size; i++)
+                {
+                    init = HPX_INVOKE(r, init, tblock[i]);
+                }
+                /* Cleanup resources */
+                HPX_VECTORIZE
+                for (std::size_t i = 0; i < block_size; i++)
+                {
+                    tblock[i].~T();
+                }
+            }
+            return init;
+        }
+    };
+
+    ///////////////////////////////////////////////////////////////////////////
+    struct unseq_binary_reduce_n
+    {
+        /* Will only be called when the iterators are all random access */
+        template <typename Iter1, typename Iter2, typename T, typename Convert,
+            typename Reduce>
+        HPX_HOST_DEVICE HPX_FORCEINLINE static typename std::enable_if<
+            is_arithmetic_plus_reduction<T, Reduce>::value, T>::type
+        reduce(Iter1 it1, Iter2 it2,
+            std::size_t count, T init, Reduce /* */, Convert conv)
+        {
+            HPX_VECTOR_REDUCTION(+ : init)
+            for (std::size_t i = 0; i < count; i++)
+            {
+                init += HPX_INVOKE(conv, *it1, *it2);
+                ++it1, ++it2;
+            }
+            return init;
+        }
+
+        template <typename Iter1, typename Iter2, typename T, typename Convert,
+            typename Reduce>
+        HPX_HOST_DEVICE HPX_FORCEINLINE static typename std::enable_if<
+            is_arithmetic_minus_reduction<T, Reduce>::value, T>::type
+        reduce(Iter1 it1, Iter2 it2,
+            std::size_t count, T init, Reduce /* */, Convert conv)
+        {
+            HPX_VECTOR_REDUCTION(- : init)
+            for (std::size_t i = 0; i < count; i++)
+            {
+                init -= HPX_INVOKE(conv, *it1, *it2);
+                ++it1, ++it2;
+            }
+            return init;
+        }
+
+        template <typename Iter1, typename Iter2, typename T, typename Convert,
+            typename Reduce>
+        HPX_HOST_DEVICE HPX_FORCEINLINE static typename std::enable_if<
+            is_arithmetic_multiplies_reduction<T, Reduce>::value, T>::type
+        reduce(Iter1 it1, Iter2 it2,
+            std::size_t count, T init, Reduce /* */, Convert conv)
+        {
+            HPX_VECTOR_REDUCTION(* : init)
+            for (std::size_t i = 0; i < count; i++)
+            {
+                init *= HPX_INVOKE(conv, *it1, *it2);
+                ++it1, ++it2;
+            }
+            return init;
+        }
+
+        template <typename Iter1, typename Iter2, typename T, typename Convert,
+            typename Reduce>
+        HPX_HOST_DEVICE HPX_FORCEINLINE static typename std::enable_if<
+            is_arithmetic_bit_and_reduction<T, Reduce>::value, T>::type
+        reduce(Iter1 it1, Iter2 it2,
+            std::size_t count, T init, Reduce /* */, Convert conv)
+        {
+            HPX_VECTOR_REDUCTION(& : init)
+            for (std::size_t i = 0; i < count; i++)
+            {
+                init &= HPX_INVOKE(conv, *it1, *it2);
+                ++it1, ++it2;
+            }
+            return init;
+        }
+
+        template <typename Iter1, typename Iter2, typename T, typename Convert,
+            typename Reduce>
+        HPX_HOST_DEVICE HPX_FORCEINLINE static typename std::enable_if<
+            is_arithmetic_bit_or_reduction<T, Reduce>::value, T>::type
+        reduce(Iter1 it1, Iter2 it2,
+            std::size_t count, T init, Reduce /* */, Convert conv)
+        {
+            HPX_VECTOR_REDUCTION(| : init)
+            for (std::size_t i = 0; i < count; i++)
+            {
+                init |= HPX_INVOKE(conv, *it1, *it2);
+                ++it1, ++it2;
+            }
+            return init;
+        }
+
+        template <typename Iter1, typename Iter2, typename T, typename Convert,
+            typename Reduce>
+        HPX_HOST_DEVICE HPX_FORCEINLINE static typename std::enable_if<
+            is_arithmetic_bit_xor_reduction<T, Reduce>::value, T>::type
+        reduce(Iter1 it1, Iter2 it2,
+            std::size_t count, T init, Reduce /* */, Convert conv)
+        {
+            HPX_VECTOR_REDUCTION(^ : init)
+            for (std::size_t i = 0; i < count; i++)
+            {
+                init ^= HPX_INVOKE(conv, *it1, *it2);
+                ++it1, ++it2;
+            }
+            return init;
+        }
+
+        template <typename Iter1, typename Iter2, typename T, typename Convert,
+            typename Reduce>
+        HPX_HOST_DEVICE HPX_FORCEINLINE static typename std::enable_if<
+            is_arithmetic_logical_and_reduction<T, Reduce>::value, T>::type
+        reduce(Iter1 it1, Iter2 it2,
+            std::size_t count, T init, Reduce /* */, Convert conv)
+        {
+            HPX_VECTOR_REDUCTION(&& : init)
+            for (std::size_t i = 0; i < count; i++)
+            {
+                init = HPX_INVOKE(conv, *it1, *it2) && init;
+                ++it1, ++it2;
+            }
+            return init;
+        }
+
+        template <typename Iter1, typename Iter2, typename T, typename Convert,
+            typename Reduce>
+        HPX_HOST_DEVICE HPX_FORCEINLINE static typename std::enable_if<
+            is_arithmetic_logical_or_reduction<T, Reduce>::value, T>::type
+        reduce(Iter1 it1, Iter2 it2,
+            std::size_t count, T init, Reduce /* */, Convert conv)
+        {
+            HPX_VECTOR_REDUCTION(|| : init)
+            for (std::size_t i = 0; i < count; i++)
+            {
+                init = HPX_INVOKE(conv, *it1, *it2) || init;
+                ++it1, ++it2;
+            }
+            return init;
+        }
+
+        template <typename Iter1, typename Iter2, typename T, typename Convert,
+            typename Reduce>
+        HPX_HOST_DEVICE HPX_FORCEINLINE static
+            typename std::enable_if<is_not_omp_reduction<T, Reduce>::value,
+                T>::type
+            reduce(Iter1 it1, Iter2 it2,
+                std::size_t count, T init, Reduce r, Convert conv)
+        {
+            const std::size_t block_size = HPX_LANE_SIZE / (sizeof(T) * 8);
+
+            // To small, just run sequential
+            if (count <= (block_size << 1))
+            {
+                for (std::size_t i = 0; i < count; i++)
+                {
+                    init = HPX_INVOKE(r, init, HPX_INVOKE(conv, *it1, *it2));
+                    ++it1, ++it2;
+                }
+            }
+            else
+            {
+                alignas(HPX_LANE_SIZE) std::uint8_t block[HPX_LANE_SIZE];
+                T* tblock = reinterpret_cast<T*>(block);
+                /* Initialize block[i] = r(f(2*i), f(2*i + 1)) */
+                for (std::size_t i = 0; i < block_size; i++)
+                {
+                    ::new (tblock + i)
+                        T(HPX_INVOKE(r, HPX_INVOKE(conv, *it1, *it2),
+                            HPX_INVOKE(conv, *(it1 + 1), *(it2 + 1))));
+                    it1 += 2;
+                    it2 += 2;
+                }
+                /* Vectorized loop */
+                const std::size_t limit = block_size * (count / block_size);
+                for (std::size_t i = (block_size << 1); i < limit;
+                     i += block_size)
+                {
+                    HPX_VECTORIZE
+                    for (std::size_t j = 0; j < block_size; j++)
+                    {
+                        tblock[j] = HPX_INVOKE(r, tblock[j],
+                            HPX_INVOKE(conv, *(it1 + j), *(it2 + j)));
+                    }
+                    it1 += block_size;
+                    it2 += block_size;
+                }
+                /* Remainder */
+                HPX_VECTORIZE
+                for (std::size_t i = 0; i < count - limit; i++)
+                {
+                    tblock[i] =
+                        HPX_INVOKE(r, tblock[i], HPX_INVOKE(conv, *it1, *it2));
+                    ++it1, ++it2;
+                }
+                /* Merge */
+                for (std::size_t i = 0; i < block_size; i++)
+                {
+                    init = HPX_INVOKE(r, init, tblock[i]);
+                }
+                /* Cleanup resources */
+                HPX_VECTORIZE
+                for (std::size_t i = 0; i < block_size; i++)
+                {
+                    tblock[i].~T();
+                }
+            }
+            return init;
+        }
+    };
+
+}}}}    // namespace hpx::parallel::util::detail

--- a/libs/core/algorithms/include/hpx/parallel/unseq/transform_loop.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/unseq/transform_loop.hpp
@@ -1,4 +1,5 @@
 //  Copyright (c) 2022 A Kishore Kumar
+//  Copyright (c) 2023 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -7,62 +8,59 @@
 #pragma once
 
 #include <hpx/config.hpp>
-
 #include <hpx/executors/execution_policy.hpp>
-#include <hpx/functional/tag_invoke.hpp>
-#include <hpx/parallel/util/cancellation_token.hpp>
 #include <hpx/parallel/util/transform_loop.hpp>
 
 #include <algorithm>
 #include <cstddef>
-#include <cstdint>
 #include <iterator>
 #include <type_traits>
 #include <utility>
 
-namespace hpx { namespace parallel { namespace util {
+namespace hpx::parallel::util {
 
     namespace detail {
+
         ///////////////////////////////////////////////////////////////////////
         struct unseq_transform_loop_n
         {
             template <typename InIter, typename OutIter, typename F>
-            HPX_HOST_DEVICE HPX_FORCEINLINE static typename std::enable_if<
-                hpx::traits::is_random_access_iterator_v<InIter> and
-                    hpx::traits::is_random_access_iterator_v<OutIter>,
-                std::pair<InIter, OutIter>>::type
-            call(InIter HPX_RESTRICT it, std::size_t count,
-                OutIter HPX_RESTRICT dest, F&& f)
+            HPX_HOST_DEVICE
+                HPX_FORCEINLINE static constexpr std::pair<InIter, OutIter>
+                call(InIter HPX_RESTRICT it, std::size_t num,
+                    OutIter HPX_RESTRICT dest, F&& f)
             {
-                // clang-format off
-                HPX_IVDEP HPX_UNROLL HPX_VECTORIZE
-                for (std::size_t i = 0; i < count; i++)
-                {
-                    *dest++ = HPX_INVOKE(f, it);
-                    ++it;
-                }
-                // clang-format on
-                return std::make_pair(HPX_MOVE(it), HPX_MOVE(dest));
-            }
+                constexpr bool iterators_are_random_access =
+                    hpx::traits::is_random_access_iterator_v<InIter> &&
+                    hpx::traits::is_random_access_iterator_v<OutIter>;
 
-            template <typename InIter, typename OutIter, typename F>
-            HPX_HOST_DEVICE HPX_FORCEINLINE static typename std::enable_if<
-                !hpx::traits::is_random_access_iterator_v<InIter> or
-                    !hpx::traits::is_random_access_iterator_v<OutIter>,
-                std::pair<InIter, OutIter>>::type
-            call(InIter HPX_RESTRICT it, std::size_t count,
-                OutIter HPX_RESTRICT dest, F&& f)
-            {
-                return util::transform_loop_n<hpx::execution::sequenced_policy>(
-                    it, count, dest, HPX_FORWARD(F, f));
+                if constexpr (iterators_are_random_access)
+                {
+                    // clang-format off
+                    HPX_IVDEP HPX_UNROLL HPX_VECTORIZE
+                    for (std::size_t i = 0; i != num; ++i)
+                    {
+                        *dest = HPX_INVOKE(f, it);
+                        ++it, ++dest;
+                    }
+                    // clang-format on
+
+                    return std::make_pair(HPX_MOVE(it), HPX_MOVE(dest));
+                }
+                else
+                {
+                    return util::transform_loop_n<
+                        hpx::execution::sequenced_policy>(
+                        it, num, dest, HPX_FORWARD(F, f));
+                }
             }
         };
     }    // namespace detail
 
     template <typename ExPolicy, typename Iter, typename OutIter, typename F>
-    HPX_HOST_DEVICE HPX_FORCEINLINE typename std::enable_if<
+    HPX_HOST_DEVICE HPX_FORCEINLINE constexpr std::enable_if_t<
         hpx::is_unsequenced_execution_policy_v<ExPolicy>,
-        std::pair<Iter, OutIter>>::type
+        std::pair<Iter, OutIter>>
     tag_invoke(hpx::parallel::util::transform_loop_n_t<ExPolicy>,
         Iter HPX_RESTRICT it, std::size_t count, OutIter HPX_RESTRICT dest,
         F&& f)
@@ -72,47 +70,47 @@ namespace hpx { namespace parallel { namespace util {
     }
 
     namespace detail {
+
         ///////////////////////////////////////////////////////////////////////
         struct unseq_transform_loop_n_ind
         {
             template <typename InIter, typename OutIter, typename F>
-            HPX_HOST_DEVICE HPX_FORCEINLINE static typename std::enable_if<
-                hpx::traits::is_random_access_iterator_v<InIter> and
-                    hpx::traits::is_random_access_iterator_v<OutIter>,
-                std::pair<InIter, OutIter>>::type
-            call(InIter HPX_RESTRICT it, std::size_t count,
-                OutIter HPX_RESTRICT dest, F&& f)
+            HPX_HOST_DEVICE
+                HPX_FORCEINLINE static constexpr std::pair<InIter, OutIter>
+                call(InIter HPX_RESTRICT it, std::size_t num,
+                    OutIter HPX_RESTRICT dest, F&& f)
             {
-                // clang-format off
-                HPX_IVDEP HPX_UNROLL HPX_VECTORIZE
-                for (std::size_t i = 0; i < count; i++)
-                {
-                    *dest++ = HPX_INVOKE(f, *it);
-                    ++it;
-                }
-                // clang-format on
-                return std::make_pair(HPX_MOVE(it), HPX_MOVE(dest));
-            }
+                constexpr bool iterators_are_random_access =
+                    hpx::traits::is_random_access_iterator_v<InIter> &&
+                    hpx::traits::is_random_access_iterator_v<OutIter>;
 
-            template <typename InIter, typename OutIter, typename F>
-            HPX_HOST_DEVICE HPX_FORCEINLINE static typename std::enable_if<
-                !hpx::traits::is_random_access_iterator_v<InIter> or
-                    !hpx::traits::is_random_access_iterator_v<OutIter>,
-                std::pair<InIter, OutIter>>::type
-            call(InIter HPX_RESTRICT it, std::size_t count,
-                OutIter HPX_RESTRICT dest, F&& f)
-            {
-                return util::transform_loop_n_ind<
-                    hpx::execution::sequenced_policy>(
-                    it, count, dest, HPX_FORWARD(F, f));
+                if constexpr (iterators_are_random_access)
+                {
+                    // clang-format off
+                    HPX_IVDEP HPX_UNROLL HPX_VECTORIZE
+                    for (std::size_t i = 0; i != num; ++i)
+                    {
+                        *dest = HPX_INVOKE(f, *it);
+                        ++it, ++dest;
+                    }
+                    // clang-format on
+
+                    return std::make_pair(HPX_MOVE(it), HPX_MOVE(dest));
+                }
+                else
+                {
+                    return util::transform_loop_n_ind<
+                        hpx::execution::sequenced_policy>(
+                        it, num, dest, HPX_FORWARD(F, f));
+                }
             }
         };
     }    // namespace detail
 
     template <typename ExPolicy, typename Iter, typename OutIter, typename F>
-    HPX_HOST_DEVICE HPX_FORCEINLINE constexpr typename std::enable_if<
+    HPX_HOST_DEVICE HPX_FORCEINLINE constexpr std::enable_if_t<
         hpx::is_unsequenced_execution_policy_v<ExPolicy>,
-        std::pair<Iter, OutIter>>::type
+        std::pair<Iter, OutIter>>
     tag_invoke(hpx::parallel::util::transform_loop_n_ind_t<ExPolicy>,
         Iter HPX_RESTRICT it, std::size_t count, OutIter HPX_RESTRICT dest,
         F&& f)
@@ -122,34 +120,36 @@ namespace hpx { namespace parallel { namespace util {
     }
 
     namespace detail {
+
         ///////////////////////////////////////////////////////////////////////
         struct unseq_transform_loop
         {
             template <typename InIter, typename OutIter, typename F>
-            HPX_HOST_DEVICE HPX_FORCEINLINE static typename std::enable_if<
-                hpx::traits::is_random_access_iterator_v<InIter> and
-                    hpx::traits::is_random_access_iterator_v<OutIter>,
-                util::in_out_result<InIter, OutIter>>::type
-            call(InIter HPX_RESTRICT it, InIter HPX_RESTRICT last,
-                OutIter HPX_RESTRICT dest, F&& f)
+            HPX_HOST_DEVICE
+                HPX_FORCEINLINE static constexpr util::in_out_result<InIter,
+                    OutIter>
+                call(InIter HPX_RESTRICT it, InIter HPX_RESTRICT last,
+                    OutIter HPX_RESTRICT dest, F&& f)
             {
-                auto ret =
-                    util::transform_loop_n<hpx::execution::unsequenced_policy>(
-                        it, std::distance(it, last), dest, HPX_FORWARD(F, f));
-                return util::in_out_result<InIter, OutIter>{
-                    HPX_MOVE(ret.first), HPX_MOVE(ret.second)};
-            }
+                constexpr bool iterators_are_random_access =
+                    hpx::traits::is_random_access_iterator_v<InIter> &&
+                    hpx::traits::is_random_access_iterator_v<OutIter>;
 
-            template <typename InIter, typename OutIter, typename F>
-            HPX_HOST_DEVICE HPX_FORCEINLINE static typename std::enable_if<
-                !hpx::traits::is_random_access_iterator_v<InIter> or
-                    !hpx::traits::is_random_access_iterator_v<OutIter>,
-                util::in_out_result<InIter, OutIter>>::type
-            call(InIter HPX_RESTRICT it, InIter HPX_RESTRICT last,
-                OutIter HPX_RESTRICT dest, F&& f)
-            {
-                return util::transform_loop(
-                    hpx::execution::seq, it, last, dest, HPX_FORWARD(F, f));
+                if constexpr (iterators_are_random_access)
+                {
+                    auto&& in_out = util::transform_loop_n<
+                        hpx::execution::unsequenced_policy>(
+                        it, std::distance(it, last), dest, HPX_FORWARD(F, f));
+
+                    return util::in_out_result<InIter, OutIter>{
+                        HPX_MOVE(hpx::get<0>(in_out)),
+                        HPX_MOVE(hpx::get<1>(in_out))};
+                }
+                else
+                {
+                    return util::transform_loop(
+                        hpx::execution::seq, it, last, dest, HPX_FORWARD(F, f));
+                }
             }
         };
     }    // namespace detail
@@ -177,34 +177,36 @@ namespace hpx { namespace parallel { namespace util {
     }
 
     namespace detail {
+
         ///////////////////////////////////////////////////////////////////////
         struct unseq_transform_loop_ind
         {
             template <typename InIter, typename OutIter, typename F>
-            HPX_HOST_DEVICE HPX_FORCEINLINE static typename std::enable_if<
-                hpx::traits::is_random_access_iterator_v<InIter> and
-                    hpx::traits::is_random_access_iterator_v<OutIter>,
-                util::in_out_result<InIter, OutIter>>::type
-            call(InIter HPX_RESTRICT it, InIter HPX_RESTRICT last,
-                OutIter HPX_RESTRICT dest, F&& f)
+            HPX_HOST_DEVICE
+                HPX_FORCEINLINE static constexpr util::in_out_result<InIter,
+                    OutIter>
+                call(InIter HPX_RESTRICT it, InIter HPX_RESTRICT last,
+                    OutIter HPX_RESTRICT dest, F&& f)
             {
-                auto ret = util::transform_loop_n_ind<
-                    hpx::execution::unsequenced_policy>(
-                    it, std::distance(it, last), dest, HPX_FORWARD(F, f));
-                return util::in_out_result<InIter, OutIter>{
-                    HPX_MOVE(ret.first), HPX_MOVE(ret.second)};
-            }
+                constexpr bool iterators_are_random_access =
+                    hpx::traits::is_random_access_iterator_v<InIter> &&
+                    hpx::traits::is_random_access_iterator_v<OutIter>;
 
-            template <typename InIter, typename OutIter, typename F>
-            HPX_HOST_DEVICE HPX_FORCEINLINE static typename std::enable_if<
-                !hpx::traits::is_random_access_iterator_v<InIter> or
-                    !hpx::traits::is_random_access_iterator_v<OutIter>,
-                util::in_out_result<InIter, OutIter>>::type
-            call(InIter HPX_RESTRICT it, InIter HPX_RESTRICT last,
-                OutIter HPX_RESTRICT dest, F&& f)
-            {
-                return util::transform_loop_ind(
-                    hpx::execution::seq, it, last, dest, HPX_FORWARD(F, f));
+                if constexpr (iterators_are_random_access)
+                {
+                    auto&& in_out = util::transform_loop_n_ind<
+                        hpx::execution::unsequenced_policy>(
+                        it, std::distance(it, last), dest, HPX_FORWARD(F, f));
+
+                    return util::in_out_result<InIter, OutIter>{
+                        HPX_MOVE(hpx::get<0>(in_out)),
+                        HPX_MOVE(hpx::get<1>(in_out))};
+                }
+                else
+                {
+                    return util::transform_loop_ind(
+                        hpx::execution::seq, it, last, dest, HPX_FORWARD(F, f));
+                }
             }
         };
     }    // namespace detail
@@ -232,143 +234,144 @@ namespace hpx { namespace parallel { namespace util {
     }
 
     namespace detail {
+
         ///////////////////////////////////////////////////////////////////////
         struct unseq_transform_binary_loop_n
         {
             template <typename InIter1, typename InIter2, typename OutIter,
                 typename F>
-            HPX_HOST_DEVICE HPX_FORCEINLINE static typename std::enable_if<
-                hpx::traits::is_random_access_iterator_v<InIter1> and
-                    hpx::traits::is_random_access_iterator_v<InIter2> and
-                    hpx::traits::is_random_access_iterator_v<OutIter>,
-                hpx::tuple<InIter1, InIter2, OutIter>>::type
-            call(InIter1 HPX_RESTRICT first1, std::size_t count,
+            HPX_HOST_DEVICE HPX_FORCEINLINE static constexpr hpx::tuple<InIter1,
+                InIter2, OutIter>
+            call(InIter1 HPX_RESTRICT first1, std::size_t num,
                 InIter2 HPX_RESTRICT first2, OutIter HPX_RESTRICT dest, F&& f)
             {
-                // clang-format off
-                HPX_IVDEP HPX_UNROLL HPX_VECTORIZE
-                for (std::size_t i = 0; i < count; i++)
-                {
-                    *dest++ = HPX_INVOKE(f, first1, first2);
-                    ++first1, ++first2;
-                }
-                // clang-format on
-                return hpx::make_tuple(
-                    HPX_MOVE(first1), HPX_MOVE(first2), HPX_MOVE(dest));
-            }
+                constexpr bool iterators_are_random_access =
+                    hpx::traits::is_random_access_iterator_v<InIter1> &&
+                    hpx::traits::is_random_access_iterator_v<InIter2> &&
+                    hpx::traits::is_random_access_iterator_v<OutIter>;
 
-            template <typename InIter1, typename InIter2, typename OutIter,
-                typename F>
-            HPX_HOST_DEVICE HPX_FORCEINLINE static typename std::enable_if<
-                !hpx::traits::is_random_access_iterator_v<InIter1> or
-                    !hpx::traits::is_random_access_iterator_v<InIter2> or
-                    !hpx::traits::is_random_access_iterator_v<OutIter>,
-                hpx::tuple<InIter1, InIter2, OutIter>>::type
-            call(InIter1 HPX_RESTRICT first1, std::size_t count,
-                InIter2 HPX_RESTRICT first2, OutIter HPX_RESTRICT dest, F&& f)
-            {
-                return util::transform_binary_loop_n<
-                    hpx::execution::sequenced_policy>(
-                    first1, count, first2, dest, HPX_FORWARD(F, f));
+                if constexpr (iterators_are_random_access)
+                {
+                    // clang-format off
+                    HPX_IVDEP HPX_UNROLL HPX_VECTORIZE
+                    for (std::size_t i = 0; i != num; ++i)
+                    {
+                        *dest = HPX_INVOKE(f, first1, first2);
+                        ++first1, ++first2, ++dest;
+                    }
+                    // clang-format on
+
+                    return hpx::make_tuple(
+                        HPX_MOVE(first1), HPX_MOVE(first2), HPX_MOVE(dest));
+                }
+                else
+                {
+                    return util::transform_binary_loop_n<
+                        hpx::execution::sequenced_policy>(
+                        first1, num, first2, dest, HPX_FORWARD(F, f));
+                }
             }
         };
     }    // namespace detail
 
     template <typename ExPolicy, typename InIter1, typename InIter2,
         typename OutIter, typename F>
-    HPX_HOST_DEVICE HPX_FORCEINLINE typename std::enable_if<
-        hpx::is_unsequenced_execution_policy_v<ExPolicy>,
-        hpx::tuple<InIter1, InIter2, OutIter>>::type
-    tag_invoke(hpx::parallel::util::transform_binary_loop_n_t<ExPolicy>,
-        InIter1 HPX_RESTRICT first1, std::size_t count,
-        InIter2 HPX_RESTRICT first2, OutIter HPX_RESTRICT dest, F&& f)
+    HPX_HOST_DEVICE HPX_FORCEINLINE
+        std::enable_if_t<hpx::is_unsequenced_execution_policy_v<ExPolicy>,
+            hpx::tuple<InIter1, InIter2, OutIter>>
+        tag_invoke(hpx::parallel::util::transform_binary_loop_n_t<ExPolicy>,
+            InIter1 HPX_RESTRICT first1, std::size_t count,
+            InIter2 HPX_RESTRICT first2, OutIter HPX_RESTRICT dest, F&& f)
     {
         return detail::unseq_transform_binary_loop_n::call(
             first1, count, first2, dest, HPX_FORWARD(F, f));
     }
 
     namespace detail {
+
         ///////////////////////////////////////////////////////////////////////
         struct unseq_transform_binary_loop
         {
             template <typename InIter1, typename InIter2, typename OutIter,
                 typename F>
-            HPX_HOST_DEVICE HPX_FORCEINLINE static typename std::enable_if<
-                hpx::traits::is_random_access_iterator_v<InIter1> and
-                    hpx::traits::is_random_access_iterator_v<InIter2> and
-                    hpx::traits::is_random_access_iterator_v<OutIter>,
-                util::in_in_out_result<InIter1, InIter2, OutIter>>::type
-            call(InIter1 HPX_RESTRICT first1, InIter1 HPX_RESTRICT last1,
-                InIter2 HPX_RESTRICT first2, OutIter HPX_RESTRICT dest, F&& f)
+            HPX_HOST_DEVICE
+                HPX_FORCEINLINE static constexpr util::in_in_out_result<InIter1,
+                    InIter2, OutIter>
+                call(InIter1 HPX_RESTRICT first1, InIter1 HPX_RESTRICT last1,
+                    InIter2 HPX_RESTRICT first2, OutIter HPX_RESTRICT dest,
+                    F&& f)
             {
-                auto ret = util::transform_binary_loop_n<
-                    hpx::execution::unsequenced_policy>(first1,
-                    std::distance(first1, last1), first2, dest,
-                    HPX_FORWARD(F, f));
-                return util::in_in_out_result<InIter1, InIter2, OutIter>{
-                    hpx::get<0>(ret), hpx::get<1>(ret), hpx::get<2>(ret)};
+                constexpr bool iterators_are_random_access =
+                    hpx::traits::is_random_access_iterator_v<InIter1> &&
+                    hpx::traits::is_random_access_iterator_v<InIter2> &&
+                    hpx::traits::is_random_access_iterator_v<OutIter>;
+
+                if constexpr (iterators_are_random_access)
+                {
+                    auto&& in_in_out = util::transform_binary_loop_n<
+                        hpx::execution::unsequenced_policy>(first1,
+                        std::distance(first1, last1), first2, dest,
+                        HPX_FORWARD(F, f));
+
+                    return util::in_in_out_result<InIter1, InIter2, OutIter>{
+                        HPX_MOVE(hpx::get<0>(in_in_out)),
+                        HPX_MOVE(hpx::get<1>(in_in_out)),
+                        HPX_MOVE(hpx::get<2>(in_in_out))};
+                }
+                else
+                {
+                    return util::transform_binary_loop<
+                        hpx::execution::sequenced_policy>(
+                        first1, last1, first2, dest, HPX_FORWARD(F, f));
+                }
             }
 
             template <typename InIter1, typename InIter2, typename OutIter,
                 typename F>
-            HPX_HOST_DEVICE HPX_FORCEINLINE static typename std::enable_if<
-                !hpx::traits::is_random_access_iterator_v<InIter1> or
-                    !hpx::traits::is_random_access_iterator_v<InIter2> or
-                    !hpx::traits::is_random_access_iterator_v<OutIter>,
-                util::in_in_out_result<InIter1, InIter2, OutIter>>::type
-            call(InIter1 HPX_RESTRICT first1, InIter1 HPX_RESTRICT last1,
-                InIter2 HPX_RESTRICT first2, OutIter HPX_RESTRICT dest, F&& f)
+            HPX_HOST_DEVICE
+                HPX_FORCEINLINE static constexpr util::in_in_out_result<InIter1,
+                    InIter2, OutIter>
+                call(InIter1 HPX_RESTRICT first1, InIter1 HPX_RESTRICT last1,
+                    InIter2 HPX_RESTRICT first2, InIter2 HPX_RESTRICT last2,
+                    OutIter dest, F&& f)
             {
-                return util::transform_binary_loop<
-                    hpx::execution::sequenced_policy>(
-                    first1, last1, first2, dest, HPX_FORWARD(F, f));
-            }
+                constexpr bool iterators_are_random_access =
+                    hpx::traits::is_random_access_iterator_v<InIter1> &&
+                    hpx::traits::is_random_access_iterator_v<InIter2> &&
+                    hpx::traits::is_random_access_iterator_v<OutIter>;
 
-            template <typename InIter1, typename InIter2, typename OutIter,
-                typename F>
-            HPX_HOST_DEVICE HPX_FORCEINLINE static typename std::enable_if<
-                hpx::traits::is_random_access_iterator_v<InIter1> and
-                    hpx::traits::is_random_access_iterator_v<InIter2> and
-                    hpx::traits::is_random_access_iterator_v<OutIter>,
-                util::in_in_out_result<InIter1, InIter2, OutIter>>::type
-            call(InIter1 HPX_RESTRICT first1, InIter1 HPX_RESTRICT last1,
-                InIter2 HPX_RESTRICT first2, InIter2 HPX_RESTRICT last2,
-                OutIter dest, F&& f)
-            {
-                // clang-format off
-                std::size_t count = (std::min) (std::distance(first1, last1),
-                    std::distance(first2, last2));
-                // clang-format on
-                auto ret = util::transform_binary_loop_n<
-                    hpx::execution::unsequenced_policy>(
-                    first1, count, first2, dest, HPX_FORWARD(F, f));
-                return util::in_in_out_result<InIter1, InIter2, OutIter>{
-                    hpx::get<0>(ret), hpx::get<1>(ret), hpx::get<2>(ret)};
-            }
+                if constexpr (iterators_are_random_access)
+                {
+                    // clang-format off
+                    std::size_t count = (std::min) (
+                        std::distance(first1, last1),
+                        std::distance(first2, last2));
+                    // clang-format on
 
-            template <typename InIter1, typename InIter2, typename OutIter,
-                typename F>
-            HPX_HOST_DEVICE HPX_FORCEINLINE static typename std::enable_if<
-                !hpx::traits::is_random_access_iterator_v<InIter1> or
-                    !hpx::traits::is_random_access_iterator_v<InIter2> or
-                    !hpx::traits::is_random_access_iterator_v<OutIter>,
-                util::in_in_out_result<InIter1, InIter2, OutIter>>::type
-            call(InIter1 HPX_RESTRICT first1, InIter1 HPX_RESTRICT last1,
-                InIter2 HPX_RESTRICT first2, InIter2 HPX_RESTRICT last2,
-                OutIter dest, F&& f)
-            {
-                return util::transform_binary_loop<
-                    hpx::execution::sequenced_policy>(
-                    first1, last1, first2, last2, dest, HPX_FORWARD(F, f));
+                    auto&& in_in_out = util::transform_binary_loop_n<
+                        hpx::execution::unsequenced_policy>(
+                        first1, count, first2, dest, HPX_FORWARD(F, f));
+
+                    return util::in_in_out_result<InIter1, InIter2, OutIter>{
+                        HPX_MOVE(hpx::get<0>(in_in_out)),
+                        HPX_MOVE(hpx::get<1>(in_in_out)),
+                        HPX_MOVE(hpx::get<2>(in_in_out))};
+                }
+                else
+                {
+                    return util::transform_binary_loop<
+                        hpx::execution::sequenced_policy>(
+                        first1, last1, first2, last2, dest, HPX_FORWARD(F, f));
+                }
             }
         };
     }    // namespace detail
 
     template <typename ExPolicy, typename InIter1, typename InIter2,
         typename OutIter, typename F>
-    HPX_HOST_DEVICE HPX_FORCEINLINE typename std::enable_if<
+    HPX_HOST_DEVICE HPX_FORCEINLINE constexpr std::enable_if_t<
         hpx::is_unsequenced_execution_policy_v<ExPolicy>,
-        util::in_in_out_result<InIter1, InIter2, OutIter>>::type
+        util::in_in_out_result<InIter1, InIter2, OutIter>>
     tag_invoke(hpx::parallel::util::transform_binary_loop_t<ExPolicy>,
         InIter1 HPX_RESTRICT first1, InIter1 HPX_RESTRICT last1,
         InIter2 HPX_RESTRICT first2, OutIter HPX_RESTRICT dest, F&& f)
@@ -379,9 +382,9 @@ namespace hpx { namespace parallel { namespace util {
 
     template <typename ExPolicy, typename InIter1, typename InIter2,
         typename OutIter, typename F>
-    HPX_HOST_DEVICE HPX_FORCEINLINE typename std::enable_if<
+    HPX_HOST_DEVICE HPX_FORCEINLINE constexpr std::enable_if_t<
         hpx::is_unsequenced_execution_policy_v<ExPolicy>,
-        util::in_in_out_result<InIter1, InIter2, OutIter>>::type
+        util::in_in_out_result<InIter1, InIter2, OutIter>>
     tag_invoke(hpx::parallel::util::transform_binary_loop_t<ExPolicy>,
         InIter1 HPX_RESTRICT first1, InIter1 HPX_RESTRICT last1,
         InIter2 HPX_RESTRICT first2, InIter2 HPX_RESTRICT last2, OutIter dest,
@@ -392,53 +395,51 @@ namespace hpx { namespace parallel { namespace util {
     }
 
     namespace detail {
+
         ///////////////////////////////////////////////////////////////////////
         struct unseq_transform_binary_loop_ind_n
         {
             template <typename InIter1, typename InIter2, typename OutIter,
                 typename F>
-            HPX_HOST_DEVICE HPX_FORCEINLINE static typename std::enable_if<
-                hpx::traits::is_random_access_iterator_v<InIter1> and
-                    hpx::traits::is_random_access_iterator_v<InIter2> and
-                    hpx::traits::is_random_access_iterator_v<OutIter>,
-                hpx::tuple<InIter1, InIter2, OutIter>>::type
-            call(InIter1 HPX_RESTRICT first1, std::size_t count,
+            HPX_HOST_DEVICE HPX_FORCEINLINE static constexpr hpx::tuple<InIter1,
+                InIter2, OutIter>
+            call(InIter1 HPX_RESTRICT first1, std::size_t num,
                 InIter2 HPX_RESTRICT first2, OutIter HPX_RESTRICT dest, F&& f)
             {
-                // clang-format off
-                HPX_IVDEP HPX_UNROLL HPX_VECTORIZE
-                for (std::size_t i = 0; i < count; i++)
-                {
-                    *dest++ = HPX_INVOKE(f, *first1, *first2);
-                    ++first1, ++first2;
-                }
-                // clang-format on
-                return hpx::make_tuple(
-                    HPX_MOVE(first1), HPX_MOVE(first2), HPX_MOVE(dest));
-            }
+                constexpr bool iterators_are_random_access =
+                    hpx::traits::is_random_access_iterator_v<InIter1> &&
+                    hpx::traits::is_random_access_iterator_v<InIter2> &&
+                    hpx::traits::is_random_access_iterator_v<OutIter>;
 
-            template <typename InIter1, typename InIter2, typename OutIter,
-                typename F>
-            HPX_HOST_DEVICE HPX_FORCEINLINE static typename std::enable_if<
-                !hpx::traits::is_random_access_iterator_v<InIter1> or
-                    !hpx::traits::is_random_access_iterator_v<InIter2> or
-                    !hpx::traits::is_random_access_iterator_v<OutIter>,
-                hpx::tuple<InIter1, InIter2, OutIter>>::type
-            call(InIter1 HPX_RESTRICT first1, std::size_t count,
-                InIter2 HPX_RESTRICT first2, OutIter HPX_RESTRICT dest, F&& f)
-            {
-                return util::transform_binary_loop_ind_n<
-                    hpx::execution::sequenced_policy>(
-                    first1, count, first2, dest, HPX_FORWARD(F, f));
+                if constexpr (iterators_are_random_access)
+                {
+                    // clang-format off
+                    HPX_IVDEP HPX_UNROLL HPX_VECTORIZE
+                    for (std::size_t i = 0; i != num; ++i)
+                    {
+                        *dest = HPX_INVOKE(f, *first1, *first2);
+                        ++first1, ++first2, ++dest;
+                    }
+                    // clang-format on
+
+                    return hpx::make_tuple(
+                        HPX_MOVE(first1), HPX_MOVE(first2), HPX_MOVE(dest));
+                }
+                else
+                {
+                    return util::transform_binary_loop_ind_n<
+                        hpx::execution::sequenced_policy>(
+                        first1, num, first2, dest, HPX_FORWARD(F, f));
+                }
             }
         };
     }    // namespace detail
 
     template <typename ExPolicy, typename InIter1, typename InIter2,
         typename OutIter, typename F>
-    HPX_HOST_DEVICE HPX_FORCEINLINE typename std::enable_if<
+    HPX_HOST_DEVICE HPX_FORCEINLINE constexpr std::enable_if_t<
         hpx::is_unsequenced_execution_policy_v<ExPolicy>,
-        hpx::tuple<InIter1, InIter2, OutIter>>::type
+        hpx::tuple<InIter1, InIter2, OutIter>>
     tag_invoke(hpx::parallel::util::transform_binary_loop_ind_n_t<ExPolicy>,
         InIter1 HPX_RESTRICT first1, std::size_t count,
         InIter2 HPX_RESTRICT first2, OutIter HPX_RESTRICT dest, F&& f)
@@ -448,88 +449,90 @@ namespace hpx { namespace parallel { namespace util {
     }
 
     namespace detail {
+
         ///////////////////////////////////////////////////////////////////////
         struct unseq_transform_binary_loop_ind
         {
             template <typename InIter1, typename InIter2, typename OutIter,
                 typename F>
-            HPX_HOST_DEVICE HPX_FORCEINLINE static typename std::enable_if<
-                hpx::traits::is_random_access_iterator_v<InIter1> and
-                    hpx::traits::is_random_access_iterator_v<InIter2> and
-                    hpx::traits::is_random_access_iterator_v<OutIter>,
-                util::in_in_out_result<InIter1, InIter2, OutIter>>::type
-            call(InIter1 HPX_RESTRICT first1, InIter1 HPX_RESTRICT last1,
-                InIter2 HPX_RESTRICT first2, OutIter HPX_RESTRICT dest, F&& f)
+            HPX_HOST_DEVICE
+                HPX_FORCEINLINE static constexpr util::in_in_out_result<InIter1,
+                    InIter2, OutIter>
+                call(InIter1 HPX_RESTRICT first1, InIter1 HPX_RESTRICT last1,
+                    InIter2 HPX_RESTRICT first2, OutIter HPX_RESTRICT dest,
+                    F&& f)
             {
-                auto ret = util::transform_binary_loop_ind_n<
-                    hpx::execution::unsequenced_policy>(first1,
-                    std::distance(first1, last1), first2, dest,
-                    HPX_FORWARD(F, f));
-                return util::in_in_out_result<InIter1, InIter2, OutIter>{
-                    hpx::get<0>(ret), hpx::get<1>(ret), hpx::get<2>(ret)};
+                constexpr bool iterators_are_random_access =
+                    hpx::traits::is_random_access_iterator_v<InIter1> &&
+                    hpx::traits::is_random_access_iterator_v<InIter2> &&
+                    hpx::traits::is_random_access_iterator_v<OutIter>;
+
+                if constexpr (iterators_are_random_access)
+                {
+                    auto&& in_in_out = util::transform_binary_loop_ind_n<
+                        hpx::execution::unsequenced_policy>(first1,
+                        std::distance(first1, last1), first2, dest,
+                        HPX_FORWARD(F, f));
+
+                    return util::in_in_out_result<InIter1, InIter2, OutIter>{
+                        HPX_MOVE(hpx::get<0>(in_in_out)),
+                        HPX_MOVE(hpx::get<1>(in_in_out)),
+                        HPX_MOVE(hpx::get<2>(in_in_out))};
+                }
+                else
+                {
+                    return util::transform_binary_loop_ind<
+                        hpx::execution::sequenced_policy>(
+                        first1, last1, first2, dest, HPX_FORWARD(F, f));
+                }
             }
 
             template <typename InIter1, typename InIter2, typename OutIter,
                 typename F>
-            HPX_HOST_DEVICE HPX_FORCEINLINE static typename std::enable_if<
-                !hpx::traits::is_random_access_iterator_v<InIter1> or
-                    !hpx::traits::is_random_access_iterator_v<InIter2> or
-                    !hpx::traits::is_random_access_iterator_v<OutIter>,
-                util::in_in_out_result<InIter1, InIter2, OutIter>>::type
-            call(InIter1 HPX_RESTRICT first1, InIter1 HPX_RESTRICT last1,
-                InIter2 HPX_RESTRICT first2, OutIter HPX_RESTRICT dest, F&& f)
+            HPX_HOST_DEVICE
+                HPX_FORCEINLINE static constexpr util::in_in_out_result<InIter1,
+                    InIter2, OutIter>
+                call(InIter1 HPX_RESTRICT first1, InIter1 HPX_RESTRICT last1,
+                    InIter2 HPX_RESTRICT first2, InIter2 HPX_RESTRICT last2,
+                    OutIter HPX_RESTRICT dest, F&& f)
             {
-                return util::transform_binary_loop_ind<
-                    hpx::execution::sequenced_policy>(
-                    first1, last1, first2, dest, HPX_FORWARD(F, f));
-            }
+                constexpr bool iterators_are_random_access =
+                    hpx::traits::is_random_access_iterator_v<InIter1> &&
+                    hpx::traits::is_random_access_iterator_v<InIter2> &&
+                    hpx::traits::is_random_access_iterator_v<OutIter>;
 
-            template <typename InIter1, typename InIter2, typename OutIter,
-                typename F>
-            HPX_HOST_DEVICE HPX_FORCEINLINE static typename std::enable_if<
-                hpx::traits::is_random_access_iterator_v<InIter1> and
-                    hpx::traits::is_random_access_iterator_v<InIter2> and
-                    hpx::traits::is_random_access_iterator_v<OutIter>,
-                util::in_in_out_result<InIter1, InIter2, OutIter>>::type
-            call(InIter1 HPX_RESTRICT first1, InIter1 HPX_RESTRICT last1,
-                InIter2 HPX_RESTRICT first2, InIter2 HPX_RESTRICT last2,
-                OutIter HPX_RESTRICT dest, F&& f)
-            {
-                // clang-format off
-                std::size_t count = (std::min) (std::distance(first1, last1),
-                    std::distance(first2, last2));
-                // clang-format on
+                if constexpr (iterators_are_random_access)
+                {
+                    // clang-format off
+                    std::size_t count = (std::min) (
+                        std::distance(first1, last1),
+                        std::distance(first2, last2));
+                    // clang-format on
 
-                auto ret = util::transform_binary_loop_ind_n<
-                    hpx::execution::unsequenced_policy>(
-                    first1, count, first2, dest, HPX_FORWARD(F, f));
-                return util::in_in_out_result<InIter1, InIter2, OutIter>{
-                    hpx::get<0>(ret), hpx::get<1>(ret), hpx::get<2>(ret)};
-            }
+                    auto&& in_in_out = util::transform_binary_loop_ind_n<
+                        hpx::execution::unsequenced_policy>(
+                        first1, count, first2, dest, HPX_FORWARD(F, f));
 
-            template <typename InIter1, typename InIter2, typename OutIter,
-                typename F>
-            HPX_HOST_DEVICE HPX_FORCEINLINE static typename std::enable_if<
-                !hpx::traits::is_random_access_iterator_v<InIter1> or
-                    !hpx::traits::is_random_access_iterator_v<InIter2> or
-                    !hpx::traits::is_random_access_iterator_v<OutIter>,
-                util::in_in_out_result<InIter1, InIter2, OutIter>>::type
-            call(InIter1 HPX_RESTRICT first1, InIter1 HPX_RESTRICT last1,
-                InIter2 HPX_RESTRICT first2, InIter2 HPX_RESTRICT last2,
-                OutIter HPX_RESTRICT dest, F&& f)
-            {
-                return util::transform_binary_loop_ind<
-                    hpx::execution::sequenced_policy>(
-                    first1, last1, first2, last2, dest, HPX_FORWARD(F, f));
+                    return util::in_in_out_result<InIter1, InIter2, OutIter>{
+                        HPX_MOVE(hpx::get<0>(in_in_out)),
+                        HPX_MOVE(hpx::get<1>(in_in_out)),
+                        HPX_MOVE(hpx::get<2>(in_in_out))};
+                }
+                else
+                {
+                    return util::transform_binary_loop_ind<
+                        hpx::execution::sequenced_policy>(
+                        first1, last1, first2, last2, dest, HPX_FORWARD(F, f));
+                }
             }
         };
     }    // namespace detail
 
     template <typename ExPolicy, typename InIter1, typename InIter2,
         typename OutIter, typename F>
-    HPX_HOST_DEVICE HPX_FORCEINLINE typename std::enable_if<
+    HPX_HOST_DEVICE HPX_FORCEINLINE constexpr std::enable_if_t<
         hpx::is_unsequenced_execution_policy_v<ExPolicy>,
-        util::in_in_out_result<InIter1, InIter2, OutIter>>::type
+        util::in_in_out_result<InIter1, InIter2, OutIter>>
     tag_invoke(hpx::parallel::util::transform_binary_loop_ind_t<ExPolicy>,
         InIter1 HPX_RESTRICT first1, InIter1 HPX_RESTRICT last1,
         InIter2 HPX_RESTRICT first2, OutIter HPX_RESTRICT dest, F&& f)
@@ -540,9 +543,9 @@ namespace hpx { namespace parallel { namespace util {
 
     template <typename ExPolicy, typename InIter1, typename InIter2,
         typename OutIter, typename F>
-    HPX_HOST_DEVICE HPX_FORCEINLINE typename std::enable_if<
+    HPX_HOST_DEVICE HPX_FORCEINLINE constexpr std::enable_if_t<
         hpx::is_unsequenced_execution_policy_v<ExPolicy>,
-        util::in_in_out_result<InIter1, InIter2, OutIter>>::type
+        util::in_in_out_result<InIter1, InIter2, OutIter>>
     tag_invoke(hpx::parallel::util::transform_binary_loop_ind_t<ExPolicy>,
         InIter1 HPX_RESTRICT first1, InIter1 HPX_RESTRICT last1,
         InIter2 HPX_RESTRICT first2, InIter2 HPX_RESTRICT last2,
@@ -551,4 +554,4 @@ namespace hpx { namespace parallel { namespace util {
         return detail::unseq_transform_binary_loop_ind::call(
             first1, last1, first2, last2, dest, HPX_FORWARD(F, f));
     }
-}}}    // namespace hpx::parallel::util
+}    // namespace hpx::parallel::util

--- a/libs/core/algorithms/include/hpx/parallel/unseq/transform_loop.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/unseq/transform_loop.hpp
@@ -1,0 +1,554 @@
+//  Copyright (c) 2022 A Kishore Kumar
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include <hpx/config.hpp>
+
+#include <hpx/executors/execution_policy.hpp>
+#include <hpx/functional/tag_invoke.hpp>
+#include <hpx/parallel/util/cancellation_token.hpp>
+#include <hpx/parallel/util/transform_loop.hpp>
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <iterator>
+#include <type_traits>
+#include <utility>
+
+namespace hpx { namespace parallel { namespace util {
+
+    namespace detail {
+        ///////////////////////////////////////////////////////////////////////
+        struct unseq_transform_loop_n
+        {
+            template <typename InIter, typename OutIter, typename F>
+            HPX_HOST_DEVICE HPX_FORCEINLINE static typename std::enable_if<
+                hpx::traits::is_random_access_iterator_v<InIter> and
+                    hpx::traits::is_random_access_iterator_v<OutIter>,
+                std::pair<InIter, OutIter>>::type
+            call(InIter HPX_RESTRICT it, std::size_t count,
+                OutIter HPX_RESTRICT dest, F&& f)
+            {
+                // clang-format off
+                HPX_IVDEP HPX_UNROLL HPX_VECTORIZE
+                for (std::size_t i = 0; i < count; i++)
+                {
+                    *dest++ = HPX_INVOKE(f, it);
+                    ++it;
+                }
+                // clang-format on
+                return std::make_pair(HPX_MOVE(it), HPX_MOVE(dest));
+            }
+
+            template <typename InIter, typename OutIter, typename F>
+            HPX_HOST_DEVICE HPX_FORCEINLINE static typename std::enable_if<
+                !hpx::traits::is_random_access_iterator_v<InIter> or
+                    !hpx::traits::is_random_access_iterator_v<OutIter>,
+                std::pair<InIter, OutIter>>::type
+            call(InIter HPX_RESTRICT it, std::size_t count,
+                OutIter HPX_RESTRICT dest, F&& f)
+            {
+                return util::transform_loop_n<hpx::execution::sequenced_policy>(
+                    it, count, dest, HPX_FORWARD(F, f));
+            }
+        };
+    }    // namespace detail
+
+    template <typename ExPolicy, typename Iter, typename OutIter, typename F>
+    HPX_HOST_DEVICE HPX_FORCEINLINE typename std::enable_if<
+        hpx::is_unsequenced_execution_policy_v<ExPolicy>,
+        std::pair<Iter, OutIter>>::type
+    tag_invoke(hpx::parallel::util::transform_loop_n_t<ExPolicy>,
+        Iter HPX_RESTRICT it, std::size_t count, OutIter HPX_RESTRICT dest,
+        F&& f)
+    {
+        return detail::unseq_transform_loop_n::call(
+            it, count, dest, HPX_FORWARD(F, f));
+    }
+
+    namespace detail {
+        ///////////////////////////////////////////////////////////////////////
+        struct unseq_transform_loop_n_ind
+        {
+            template <typename InIter, typename OutIter, typename F>
+            HPX_HOST_DEVICE HPX_FORCEINLINE static typename std::enable_if<
+                hpx::traits::is_random_access_iterator_v<InIter> and
+                    hpx::traits::is_random_access_iterator_v<OutIter>,
+                std::pair<InIter, OutIter>>::type
+            call(InIter HPX_RESTRICT it, std::size_t count,
+                OutIter HPX_RESTRICT dest, F&& f)
+            {
+                // clang-format off
+                HPX_IVDEP HPX_UNROLL HPX_VECTORIZE
+                for (std::size_t i = 0; i < count; i++)
+                {
+                    *dest++ = HPX_INVOKE(f, *it);
+                    ++it;
+                }
+                // clang-format on
+                return std::make_pair(HPX_MOVE(it), HPX_MOVE(dest));
+            }
+
+            template <typename InIter, typename OutIter, typename F>
+            HPX_HOST_DEVICE HPX_FORCEINLINE static typename std::enable_if<
+                !hpx::traits::is_random_access_iterator_v<InIter> or
+                    !hpx::traits::is_random_access_iterator_v<OutIter>,
+                std::pair<InIter, OutIter>>::type
+            call(InIter HPX_RESTRICT it, std::size_t count,
+                OutIter HPX_RESTRICT dest, F&& f)
+            {
+                return util::transform_loop_n_ind<
+                    hpx::execution::sequenced_policy>(
+                    it, count, dest, HPX_FORWARD(F, f));
+            }
+        };
+    }    // namespace detail
+
+    template <typename ExPolicy, typename Iter, typename OutIter, typename F>
+    HPX_HOST_DEVICE HPX_FORCEINLINE constexpr typename std::enable_if<
+        hpx::is_unsequenced_execution_policy_v<ExPolicy>,
+        std::pair<Iter, OutIter>>::type
+    tag_invoke(hpx::parallel::util::transform_loop_n_ind_t<ExPolicy>,
+        Iter HPX_RESTRICT it, std::size_t count, OutIter HPX_RESTRICT dest,
+        F&& f)
+    {
+        return detail::unseq_transform_loop_n_ind::call(
+            it, count, dest, HPX_FORWARD(F, f));
+    }
+
+    namespace detail {
+        ///////////////////////////////////////////////////////////////////////
+        struct unseq_transform_loop
+        {
+            template <typename InIter, typename OutIter, typename F>
+            HPX_HOST_DEVICE HPX_FORCEINLINE static typename std::enable_if<
+                hpx::traits::is_random_access_iterator_v<InIter> and
+                    hpx::traits::is_random_access_iterator_v<OutIter>,
+                util::in_out_result<InIter, OutIter>>::type
+            call(InIter HPX_RESTRICT it, InIter HPX_RESTRICT last,
+                OutIter HPX_RESTRICT dest, F&& f)
+            {
+                auto ret =
+                    util::transform_loop_n<hpx::execution::unsequenced_policy>(
+                        it, std::distance(it, last), dest, HPX_FORWARD(F, f));
+                return util::in_out_result<InIter, OutIter>{
+                    HPX_MOVE(ret.first), HPX_MOVE(ret.second)};
+            }
+
+            template <typename InIter, typename OutIter, typename F>
+            HPX_HOST_DEVICE HPX_FORCEINLINE static typename std::enable_if<
+                !hpx::traits::is_random_access_iterator_v<InIter> or
+                    !hpx::traits::is_random_access_iterator_v<OutIter>,
+                util::in_out_result<InIter, OutIter>>::type
+            call(InIter HPX_RESTRICT it, InIter HPX_RESTRICT last,
+                OutIter HPX_RESTRICT dest, F&& f)
+            {
+                return util::transform_loop(
+                    hpx::execution::seq, it, last, dest, HPX_FORWARD(F, f));
+            }
+        };
+    }    // namespace detail
+
+    template <typename IterB, typename IterE, typename OutIter, typename F>
+    HPX_HOST_DEVICE
+        HPX_FORCEINLINE constexpr util::in_out_result<IterB, OutIter>
+        tag_invoke(hpx::parallel::util::transform_loop_t,
+            hpx::execution::unsequenced_policy, IterB HPX_RESTRICT it,
+            IterE HPX_RESTRICT end, OutIter HPX_RESTRICT dest, F&& f)
+    {
+        return detail::unseq_transform_loop::call(
+            it, end, dest, HPX_FORWARD(F, f));
+    }
+
+    template <typename IterB, typename IterE, typename OutIter, typename F>
+    HPX_HOST_DEVICE
+        HPX_FORCEINLINE constexpr util::in_out_result<IterB, OutIter>
+        tag_invoke(hpx::parallel::util::transform_loop_t,
+            hpx::execution::unsequenced_task_policy, IterB HPX_RESTRICT it,
+            IterE HPX_RESTRICT end, OutIter HPX_RESTRICT dest, F&& f)
+    {
+        return detail::unseq_transform_loop::call(
+            it, end, dest, HPX_FORWARD(F, f));
+    }
+
+    namespace detail {
+        ///////////////////////////////////////////////////////////////////////
+        struct unseq_transform_loop_ind
+        {
+            template <typename InIter, typename OutIter, typename F>
+            HPX_HOST_DEVICE HPX_FORCEINLINE static typename std::enable_if<
+                hpx::traits::is_random_access_iterator_v<InIter> and
+                    hpx::traits::is_random_access_iterator_v<OutIter>,
+                util::in_out_result<InIter, OutIter>>::type
+            call(InIter HPX_RESTRICT it, InIter HPX_RESTRICT last,
+                OutIter HPX_RESTRICT dest, F&& f)
+            {
+                auto ret = util::transform_loop_n_ind<
+                    hpx::execution::unsequenced_policy>(
+                    it, std::distance(it, last), dest, HPX_FORWARD(F, f));
+                return util::in_out_result<InIter, OutIter>{
+                    HPX_MOVE(ret.first), HPX_MOVE(ret.second)};
+            }
+
+            template <typename InIter, typename OutIter, typename F>
+            HPX_HOST_DEVICE HPX_FORCEINLINE static typename std::enable_if<
+                !hpx::traits::is_random_access_iterator_v<InIter> or
+                    !hpx::traits::is_random_access_iterator_v<OutIter>,
+                util::in_out_result<InIter, OutIter>>::type
+            call(InIter HPX_RESTRICT it, InIter HPX_RESTRICT last,
+                OutIter HPX_RESTRICT dest, F&& f)
+            {
+                return util::transform_loop_ind(
+                    hpx::execution::seq, it, last, dest, HPX_FORWARD(F, f));
+            }
+        };
+    }    // namespace detail
+
+    template <typename IterB, typename IterE, typename OutIter, typename F>
+    HPX_HOST_DEVICE
+        HPX_FORCEINLINE constexpr util::in_out_result<IterB, OutIter>
+        tag_invoke(hpx::parallel::util::transform_loop_ind_t,
+            hpx::execution::unsequenced_policy, IterB HPX_RESTRICT it,
+            IterE HPX_RESTRICT end, OutIter HPX_RESTRICT dest, F&& f)
+    {
+        return detail::unseq_transform_loop_ind::call(
+            it, end, dest, HPX_FORWARD(F, f));
+    }
+
+    template <typename IterB, typename IterE, typename OutIter, typename F>
+    HPX_HOST_DEVICE
+        HPX_FORCEINLINE constexpr util::in_out_result<IterB, OutIter>
+        tag_invoke(hpx::parallel::util::transform_loop_ind_t,
+            hpx::execution::unsequenced_task_policy, IterB HPX_RESTRICT it,
+            IterE HPX_RESTRICT end, OutIter HPX_RESTRICT dest, F&& f)
+    {
+        return detail::unseq_transform_loop_ind::call(
+            it, end, dest, HPX_FORWARD(F, f));
+    }
+
+    namespace detail {
+        ///////////////////////////////////////////////////////////////////////
+        struct unseq_transform_binary_loop_n
+        {
+            template <typename InIter1, typename InIter2, typename OutIter,
+                typename F>
+            HPX_HOST_DEVICE HPX_FORCEINLINE static typename std::enable_if<
+                hpx::traits::is_random_access_iterator_v<InIter1> and
+                    hpx::traits::is_random_access_iterator_v<InIter2> and
+                    hpx::traits::is_random_access_iterator_v<OutIter>,
+                hpx::tuple<InIter1, InIter2, OutIter>>::type
+            call(InIter1 HPX_RESTRICT first1, std::size_t count,
+                InIter2 HPX_RESTRICT first2, OutIter HPX_RESTRICT dest, F&& f)
+            {
+                // clang-format off
+                HPX_IVDEP HPX_UNROLL HPX_VECTORIZE
+                for (std::size_t i = 0; i < count; i++)
+                {
+                    *dest++ = HPX_INVOKE(f, first1, first2);
+                    ++first1, ++first2;
+                }
+                // clang-format on
+                return hpx::make_tuple(
+                    HPX_MOVE(first1), HPX_MOVE(first2), HPX_MOVE(dest));
+            }
+
+            template <typename InIter1, typename InIter2, typename OutIter,
+                typename F>
+            HPX_HOST_DEVICE HPX_FORCEINLINE static typename std::enable_if<
+                !hpx::traits::is_random_access_iterator_v<InIter1> or
+                    !hpx::traits::is_random_access_iterator_v<InIter2> or
+                    !hpx::traits::is_random_access_iterator_v<OutIter>,
+                hpx::tuple<InIter1, InIter2, OutIter>>::type
+            call(InIter1 HPX_RESTRICT first1, std::size_t count,
+                InIter2 HPX_RESTRICT first2, OutIter HPX_RESTRICT dest, F&& f)
+            {
+                return util::transform_binary_loop_n<
+                    hpx::execution::sequenced_policy>(
+                    first1, count, first2, dest, HPX_FORWARD(F, f));
+            }
+        };
+    }    // namespace detail
+
+    template <typename ExPolicy, typename InIter1, typename InIter2,
+        typename OutIter, typename F>
+    HPX_HOST_DEVICE HPX_FORCEINLINE typename std::enable_if<
+        hpx::is_unsequenced_execution_policy_v<ExPolicy>,
+        hpx::tuple<InIter1, InIter2, OutIter>>::type
+    tag_invoke(hpx::parallel::util::transform_binary_loop_n_t<ExPolicy>,
+        InIter1 HPX_RESTRICT first1, std::size_t count,
+        InIter2 HPX_RESTRICT first2, OutIter HPX_RESTRICT dest, F&& f)
+    {
+        return detail::unseq_transform_binary_loop_n::call(
+            first1, count, first2, dest, HPX_FORWARD(F, f));
+    }
+
+    namespace detail {
+        ///////////////////////////////////////////////////////////////////////
+        struct unseq_transform_binary_loop
+        {
+            template <typename InIter1, typename InIter2, typename OutIter,
+                typename F>
+            HPX_HOST_DEVICE HPX_FORCEINLINE static typename std::enable_if<
+                hpx::traits::is_random_access_iterator_v<InIter1> and
+                    hpx::traits::is_random_access_iterator_v<InIter2> and
+                    hpx::traits::is_random_access_iterator_v<OutIter>,
+                util::in_in_out_result<InIter1, InIter2, OutIter>>::type
+            call(InIter1 HPX_RESTRICT first1, InIter1 HPX_RESTRICT last1,
+                InIter2 HPX_RESTRICT first2, OutIter HPX_RESTRICT dest, F&& f)
+            {
+                auto ret = util::transform_binary_loop_n<
+                    hpx::execution::unsequenced_policy>(first1,
+                    std::distance(first1, last1), first2, dest,
+                    HPX_FORWARD(F, f));
+                return util::in_in_out_result<InIter1, InIter2, OutIter>{
+                    hpx::get<0>(ret), hpx::get<1>(ret), hpx::get<2>(ret)};
+            }
+
+            template <typename InIter1, typename InIter2, typename OutIter,
+                typename F>
+            HPX_HOST_DEVICE HPX_FORCEINLINE static typename std::enable_if<
+                !hpx::traits::is_random_access_iterator_v<InIter1> or
+                    !hpx::traits::is_random_access_iterator_v<InIter2> or
+                    !hpx::traits::is_random_access_iterator_v<OutIter>,
+                util::in_in_out_result<InIter1, InIter2, OutIter>>::type
+            call(InIter1 HPX_RESTRICT first1, InIter1 HPX_RESTRICT last1,
+                InIter2 HPX_RESTRICT first2, OutIter HPX_RESTRICT dest, F&& f)
+            {
+                return util::transform_binary_loop<
+                    hpx::execution::sequenced_policy>(
+                    first1, last1, first2, dest, HPX_FORWARD(F, f));
+            }
+
+            template <typename InIter1, typename InIter2, typename OutIter,
+                typename F>
+            HPX_HOST_DEVICE HPX_FORCEINLINE static typename std::enable_if<
+                hpx::traits::is_random_access_iterator_v<InIter1> and
+                    hpx::traits::is_random_access_iterator_v<InIter2> and
+                    hpx::traits::is_random_access_iterator_v<OutIter>,
+                util::in_in_out_result<InIter1, InIter2, OutIter>>::type
+            call(InIter1 HPX_RESTRICT first1, InIter1 HPX_RESTRICT last1,
+                InIter2 HPX_RESTRICT first2, InIter2 HPX_RESTRICT last2,
+                OutIter dest, F&& f)
+            {
+                // clang-format off
+                std::size_t count = (std::min) (std::distance(first1, last1),
+                    std::distance(first2, last2));
+                // clang-format on
+                auto ret = util::transform_binary_loop_n<
+                    hpx::execution::unsequenced_policy>(
+                    first1, count, first2, dest, HPX_FORWARD(F, f));
+                return util::in_in_out_result<InIter1, InIter2, OutIter>{
+                    hpx::get<0>(ret), hpx::get<1>(ret), hpx::get<2>(ret)};
+            }
+
+            template <typename InIter1, typename InIter2, typename OutIter,
+                typename F>
+            HPX_HOST_DEVICE HPX_FORCEINLINE static typename std::enable_if<
+                !hpx::traits::is_random_access_iterator_v<InIter1> or
+                    !hpx::traits::is_random_access_iterator_v<InIter2> or
+                    !hpx::traits::is_random_access_iterator_v<OutIter>,
+                util::in_in_out_result<InIter1, InIter2, OutIter>>::type
+            call(InIter1 HPX_RESTRICT first1, InIter1 HPX_RESTRICT last1,
+                InIter2 HPX_RESTRICT first2, InIter2 HPX_RESTRICT last2,
+                OutIter dest, F&& f)
+            {
+                return util::transform_binary_loop<
+                    hpx::execution::sequenced_policy>(
+                    first1, last1, first2, last2, dest, HPX_FORWARD(F, f));
+            }
+        };
+    }    // namespace detail
+
+    template <typename ExPolicy, typename InIter1, typename InIter2,
+        typename OutIter, typename F>
+    HPX_HOST_DEVICE HPX_FORCEINLINE typename std::enable_if<
+        hpx::is_unsequenced_execution_policy_v<ExPolicy>,
+        util::in_in_out_result<InIter1, InIter2, OutIter>>::type
+    tag_invoke(hpx::parallel::util::transform_binary_loop_t<ExPolicy>,
+        InIter1 HPX_RESTRICT first1, InIter1 HPX_RESTRICT last1,
+        InIter2 HPX_RESTRICT first2, OutIter HPX_RESTRICT dest, F&& f)
+    {
+        return detail::unseq_transform_binary_loop::call(
+            first1, last1, first2, dest, HPX_FORWARD(F, f));
+    }
+
+    template <typename ExPolicy, typename InIter1, typename InIter2,
+        typename OutIter, typename F>
+    HPX_HOST_DEVICE HPX_FORCEINLINE typename std::enable_if<
+        hpx::is_unsequenced_execution_policy_v<ExPolicy>,
+        util::in_in_out_result<InIter1, InIter2, OutIter>>::type
+    tag_invoke(hpx::parallel::util::transform_binary_loop_t<ExPolicy>,
+        InIter1 HPX_RESTRICT first1, InIter1 HPX_RESTRICT last1,
+        InIter2 HPX_RESTRICT first2, InIter2 HPX_RESTRICT last2, OutIter dest,
+        F&& f)
+    {
+        return detail::unseq_transform_binary_loop::call(
+            first1, last1, first2, last2, dest, HPX_FORWARD(F, f));
+    }
+
+    namespace detail {
+        ///////////////////////////////////////////////////////////////////////
+        struct unseq_transform_binary_loop_ind_n
+        {
+            template <typename InIter1, typename InIter2, typename OutIter,
+                typename F>
+            HPX_HOST_DEVICE HPX_FORCEINLINE static typename std::enable_if<
+                hpx::traits::is_random_access_iterator_v<InIter1> and
+                    hpx::traits::is_random_access_iterator_v<InIter2> and
+                    hpx::traits::is_random_access_iterator_v<OutIter>,
+                hpx::tuple<InIter1, InIter2, OutIter>>::type
+            call(InIter1 HPX_RESTRICT first1, std::size_t count,
+                InIter2 HPX_RESTRICT first2, OutIter HPX_RESTRICT dest, F&& f)
+            {
+                // clang-format off
+                HPX_IVDEP HPX_UNROLL HPX_VECTORIZE
+                for (std::size_t i = 0; i < count; i++)
+                {
+                    *dest++ = HPX_INVOKE(f, *first1, *first2);
+                    ++first1, ++first2;
+                }
+                // clang-format on
+                return hpx::make_tuple(
+                    HPX_MOVE(first1), HPX_MOVE(first2), HPX_MOVE(dest));
+            }
+
+            template <typename InIter1, typename InIter2, typename OutIter,
+                typename F>
+            HPX_HOST_DEVICE HPX_FORCEINLINE static typename std::enable_if<
+                !hpx::traits::is_random_access_iterator_v<InIter1> or
+                    !hpx::traits::is_random_access_iterator_v<InIter2> or
+                    !hpx::traits::is_random_access_iterator_v<OutIter>,
+                hpx::tuple<InIter1, InIter2, OutIter>>::type
+            call(InIter1 HPX_RESTRICT first1, std::size_t count,
+                InIter2 HPX_RESTRICT first2, OutIter HPX_RESTRICT dest, F&& f)
+            {
+                return util::transform_binary_loop_ind_n<
+                    hpx::execution::sequenced_policy>(
+                    first1, count, first2, dest, HPX_FORWARD(F, f));
+            }
+        };
+    }    // namespace detail
+
+    template <typename ExPolicy, typename InIter1, typename InIter2,
+        typename OutIter, typename F>
+    HPX_HOST_DEVICE HPX_FORCEINLINE typename std::enable_if<
+        hpx::is_unsequenced_execution_policy_v<ExPolicy>,
+        hpx::tuple<InIter1, InIter2, OutIter>>::type
+    tag_invoke(hpx::parallel::util::transform_binary_loop_ind_n_t<ExPolicy>,
+        InIter1 HPX_RESTRICT first1, std::size_t count,
+        InIter2 HPX_RESTRICT first2, OutIter HPX_RESTRICT dest, F&& f)
+    {
+        return detail::unseq_transform_binary_loop_ind_n::call(
+            first1, count, first2, dest, HPX_FORWARD(F, f));
+    }
+
+    namespace detail {
+        ///////////////////////////////////////////////////////////////////////
+        struct unseq_transform_binary_loop_ind
+        {
+            template <typename InIter1, typename InIter2, typename OutIter,
+                typename F>
+            HPX_HOST_DEVICE HPX_FORCEINLINE static typename std::enable_if<
+                hpx::traits::is_random_access_iterator_v<InIter1> and
+                    hpx::traits::is_random_access_iterator_v<InIter2> and
+                    hpx::traits::is_random_access_iterator_v<OutIter>,
+                util::in_in_out_result<InIter1, InIter2, OutIter>>::type
+            call(InIter1 HPX_RESTRICT first1, InIter1 HPX_RESTRICT last1,
+                InIter2 HPX_RESTRICT first2, OutIter HPX_RESTRICT dest, F&& f)
+            {
+                auto ret = util::transform_binary_loop_ind_n<
+                    hpx::execution::unsequenced_policy>(first1,
+                    std::distance(first1, last1), first2, dest,
+                    HPX_FORWARD(F, f));
+                return util::in_in_out_result<InIter1, InIter2, OutIter>{
+                    hpx::get<0>(ret), hpx::get<1>(ret), hpx::get<2>(ret)};
+            }
+
+            template <typename InIter1, typename InIter2, typename OutIter,
+                typename F>
+            HPX_HOST_DEVICE HPX_FORCEINLINE static typename std::enable_if<
+                !hpx::traits::is_random_access_iterator_v<InIter1> or
+                    !hpx::traits::is_random_access_iterator_v<InIter2> or
+                    !hpx::traits::is_random_access_iterator_v<OutIter>,
+                util::in_in_out_result<InIter1, InIter2, OutIter>>::type
+            call(InIter1 HPX_RESTRICT first1, InIter1 HPX_RESTRICT last1,
+                InIter2 HPX_RESTRICT first2, OutIter HPX_RESTRICT dest, F&& f)
+            {
+                return util::transform_binary_loop_ind<
+                    hpx::execution::sequenced_policy>(
+                    first1, last1, first2, dest, HPX_FORWARD(F, f));
+            }
+
+            template <typename InIter1, typename InIter2, typename OutIter,
+                typename F>
+            HPX_HOST_DEVICE HPX_FORCEINLINE static typename std::enable_if<
+                hpx::traits::is_random_access_iterator_v<InIter1> and
+                    hpx::traits::is_random_access_iterator_v<InIter2> and
+                    hpx::traits::is_random_access_iterator_v<OutIter>,
+                util::in_in_out_result<InIter1, InIter2, OutIter>>::type
+            call(InIter1 HPX_RESTRICT first1, InIter1 HPX_RESTRICT last1,
+                InIter2 HPX_RESTRICT first2, InIter2 HPX_RESTRICT last2,
+                OutIter HPX_RESTRICT dest, F&& f)
+            {
+                // clang-format off
+                std::size_t count = (std::min) (std::distance(first1, last1),
+                    std::distance(first2, last2));
+                // clang-format on
+
+                auto ret = util::transform_binary_loop_ind_n<
+                    hpx::execution::unsequenced_policy>(
+                    first1, count, first2, dest, HPX_FORWARD(F, f));
+                return util::in_in_out_result<InIter1, InIter2, OutIter>{
+                    hpx::get<0>(ret), hpx::get<1>(ret), hpx::get<2>(ret)};
+            }
+
+            template <typename InIter1, typename InIter2, typename OutIter,
+                typename F>
+            HPX_HOST_DEVICE HPX_FORCEINLINE static typename std::enable_if<
+                !hpx::traits::is_random_access_iterator_v<InIter1> or
+                    !hpx::traits::is_random_access_iterator_v<InIter2> or
+                    !hpx::traits::is_random_access_iterator_v<OutIter>,
+                util::in_in_out_result<InIter1, InIter2, OutIter>>::type
+            call(InIter1 HPX_RESTRICT first1, InIter1 HPX_RESTRICT last1,
+                InIter2 HPX_RESTRICT first2, InIter2 HPX_RESTRICT last2,
+                OutIter HPX_RESTRICT dest, F&& f)
+            {
+                return util::transform_binary_loop_ind<
+                    hpx::execution::sequenced_policy>(
+                    first1, last1, first2, last2, dest, HPX_FORWARD(F, f));
+            }
+        };
+    }    // namespace detail
+
+    template <typename ExPolicy, typename InIter1, typename InIter2,
+        typename OutIter, typename F>
+    HPX_HOST_DEVICE HPX_FORCEINLINE typename std::enable_if<
+        hpx::is_unsequenced_execution_policy_v<ExPolicy>,
+        util::in_in_out_result<InIter1, InIter2, OutIter>>::type
+    tag_invoke(hpx::parallel::util::transform_binary_loop_ind_t<ExPolicy>,
+        InIter1 HPX_RESTRICT first1, InIter1 HPX_RESTRICT last1,
+        InIter2 HPX_RESTRICT first2, OutIter HPX_RESTRICT dest, F&& f)
+    {
+        return detail::unseq_transform_binary_loop_ind::call(
+            first1, last1, first2, dest, HPX_FORWARD(F, f));
+    }
+
+    template <typename ExPolicy, typename InIter1, typename InIter2,
+        typename OutIter, typename F>
+    HPX_HOST_DEVICE HPX_FORCEINLINE typename std::enable_if<
+        hpx::is_unsequenced_execution_policy_v<ExPolicy>,
+        util::in_in_out_result<InIter1, InIter2, OutIter>>::type
+    tag_invoke(hpx::parallel::util::transform_binary_loop_ind_t<ExPolicy>,
+        InIter1 HPX_RESTRICT first1, InIter1 HPX_RESTRICT last1,
+        InIter2 HPX_RESTRICT first2, InIter2 HPX_RESTRICT last2,
+        OutIter HPX_RESTRICT dest, F&& f)
+    {
+        return detail::unseq_transform_binary_loop_ind::call(
+            first1, last1, first2, last2, dest, HPX_FORWARD(F, f));
+    }
+}}}    // namespace hpx::parallel::util

--- a/libs/core/algorithms/tests/unit/CMakeLists.txt
+++ b/libs/core/algorithms/tests/unit/CMakeLists.txt
@@ -5,7 +5,7 @@
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 # add subdirectories
-set(subdirs algorithms block container_algorithms)
+set(subdirs algorithms block container_algorithms unseq_algorithms)
 
 if(HPX_WITH_DATAPAR)
   set(subdirs ${subdirs} datapar_algorithms)

--- a/libs/core/algorithms/tests/unit/algorithms/foreach.cpp
+++ b/libs/core/algorithms/tests/unit/algorithms/foreach.cpp
@@ -23,13 +23,9 @@ void test_for_each()
 
     test_for_each(seq, IteratorTag());
     test_for_each(par, IteratorTag());
-    test_for_each(par_unseq, IteratorTag());
-    test_for_each(unseq, IteratorTag());
 
     test_for_each_async(seq(task), IteratorTag());
     test_for_each_async(par(task), IteratorTag());
-    test_for_each_async(unseq(task), IteratorTag());
-    test_for_each_async(par_unseq(task), IteratorTag());
 }
 
 void for_each_test()

--- a/libs/core/algorithms/tests/unit/algorithms/foreachn.cpp
+++ b/libs/core/algorithms/tests/unit/algorithms/foreachn.cpp
@@ -23,7 +23,6 @@ void test_for_each_n()
 
     test_for_each_n(seq, IteratorTag());
     test_for_each_n(par, IteratorTag());
-    test_for_each_n(par_unseq, IteratorTag());
 
     test_for_each_n_async(seq(task), IteratorTag());
     test_for_each_n_async(par(task), IteratorTag());

--- a/libs/core/algorithms/tests/unit/algorithms/reduce_.cpp
+++ b/libs/core/algorithms/tests/unit/algorithms/reduce_.cpp
@@ -22,7 +22,6 @@ void test_reduce1()
     test_reduce1(IteratorTag());
     test_reduce1(seq, IteratorTag());
     test_reduce1(par, IteratorTag());
-    test_reduce1(par_unseq, IteratorTag());
 
     test_reduce1_async(seq(task), IteratorTag());
     test_reduce1_async(par(task), IteratorTag());
@@ -43,7 +42,6 @@ void test_reduce2()
     test_reduce2(IteratorTag());
     test_reduce2(seq, IteratorTag());
     test_reduce2(par, IteratorTag());
-    test_reduce2(par_unseq, IteratorTag());
 
     test_reduce2_async(seq(task), IteratorTag());
     test_reduce2_async(par(task), IteratorTag());
@@ -64,7 +62,6 @@ void test_reduce3()
     test_reduce3(IteratorTag());
     test_reduce3(seq, IteratorTag());
     test_reduce3(par, IteratorTag());
-    test_reduce3(par_unseq, IteratorTag());
 
     test_reduce3_async(seq(task), IteratorTag());
     test_reduce3_async(par(task), IteratorTag());

--- a/libs/core/algorithms/tests/unit/algorithms/transform.cpp
+++ b/libs/core/algorithms/tests/unit/algorithms/transform.cpp
@@ -21,7 +21,6 @@ void test_transform()
     test_transform(IteratorTag());
     test_transform(seq, IteratorTag());
     test_transform(par, IteratorTag());
-    test_transform(par_unseq, IteratorTag());
 
     test_transform_async(seq(task), IteratorTag());
     test_transform_async(par(task), IteratorTag());

--- a/libs/core/algorithms/tests/unit/algorithms/transform_binary.cpp
+++ b/libs/core/algorithms/tests/unit/algorithms/transform_binary.cpp
@@ -21,7 +21,6 @@ void test_transform_binary()
     test_transform_binary(IteratorTag());
     test_transform_binary(seq, IteratorTag());
     test_transform_binary(par, IteratorTag());
-    test_transform_binary(par_unseq, IteratorTag());
 
     test_transform_binary_async(seq(task), IteratorTag());
     test_transform_binary_async(par(task), IteratorTag());

--- a/libs/core/algorithms/tests/unit/algorithms/transform_binary2.cpp
+++ b/libs/core/algorithms/tests/unit/algorithms/transform_binary2.cpp
@@ -21,7 +21,6 @@ void test_transform_binary2()
     test_transform_binary2(IteratorTag());
     test_transform_binary2(seq, IteratorTag());
     test_transform_binary2(par, IteratorTag());
-    test_transform_binary2(par_unseq, IteratorTag());
 
     test_transform_binary2_async(seq(task), IteratorTag());
     test_transform_binary2_async(par(task), IteratorTag());

--- a/libs/core/algorithms/tests/unit/unseq_algorithms/CMakeLists.txt
+++ b/libs/core/algorithms/tests/unit/unseq_algorithms/CMakeLists.txt
@@ -1,0 +1,22 @@
+set(tests "")
+
+foreach(test ${tests})
+  set(sources ${test}.cpp)
+
+  set(${test}_PARAMETERS THREADS_PER_LOCALITY 4)
+
+  source_group("Source Files" FILES ${sources})
+
+  # add example executable
+  add_hpx_executable(
+    ${test}_test INTERNAL_FLAGS
+    SOURCES ${sources} ${${test}_FLAGS}
+    EXCLUDE_FROM_ALL
+    HPX_PREFIX ${HPX_BUILD_PREFIX}
+    FOLDER "Tests/Unit/Modules/Core/Algorithms/Unseq"
+  )
+
+  add_hpx_unit_test(
+    "modules.algorithms.unseq_algorithms" ${test} ${${test}_PARAMETERS}
+  )
+endforeach()

--- a/libs/core/algorithms/tests/unit/unseq_algorithms/CMakeLists.txt
+++ b/libs/core/algorithms/tests/unit/unseq_algorithms/CMakeLists.txt
@@ -2,8 +2,11 @@ set(tests
     foreach_unseq
     foreach_unseq_zipiter
     foreachn_unseq
+    reduce_unseq
     transform_binary2_unseq
     transform_binary_unseq
+    transform_reduce_binary_unseq
+    transform_reduce_unseq
     transform_unseq)
 
 foreach(test ${tests})

--- a/libs/core/algorithms/tests/unit/unseq_algorithms/CMakeLists.txt
+++ b/libs/core/algorithms/tests/unit/unseq_algorithms/CMakeLists.txt
@@ -1,4 +1,7 @@
-set(tests "")
+set(tests
+    transform_binary2_unseq
+    transform_binary_unseq
+    transform_unseq)
 
 foreach(test ${tests})
   set(sources ${test}.cpp)

--- a/libs/core/algorithms/tests/unit/unseq_algorithms/CMakeLists.txt
+++ b/libs/core/algorithms/tests/unit/unseq_algorithms/CMakeLists.txt
@@ -1,4 +1,7 @@
 set(tests
+    foreach_unseq
+    foreach_unseq_zipiter
+    foreachn_unseq
     transform_binary2_unseq
     transform_binary_unseq
     transform_unseq)

--- a/libs/core/algorithms/tests/unit/unseq_algorithms/CMakeLists.txt
+++ b/libs/core/algorithms/tests/unit/unseq_algorithms/CMakeLists.txt
@@ -1,3 +1,9 @@
+# Copyright (c) 2022 A Kishore Kumar
+#
+# SPDX-License-Identifier: BSL-1.0
+# Distributed under the Boost Software License, Version 1.0. (See accompanying
+# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
 set(tests
     foreach_unseq
     foreach_unseq_zipiter
@@ -7,7 +13,8 @@ set(tests
     transform_binary_unseq
     transform_reduce_binary_unseq
     transform_reduce_unseq
-    transform_unseq)
+    transform_unseq
+)
 
 foreach(test ${tests})
   set(sources ${test}.cpp)

--- a/libs/core/algorithms/tests/unit/unseq_algorithms/foreach_unseq.cpp
+++ b/libs/core/algorithms/tests/unit/unseq_algorithms/foreach_unseq.cpp
@@ -1,0 +1,71 @@
+//  Copyright (c) 2016 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/local/init.hpp>
+#include <hpx/parallel/unseq.hpp>
+
+#include <iostream>
+#include <string>
+#include <vector>
+
+#include "../algorithms/foreach_tests.hpp"
+
+///////////////////////////////////////////////////////////////////////////////
+template <typename IteratorTag>
+void test_for_each()
+{
+    using namespace hpx::execution;
+
+    test_for_each(unseq, IteratorTag());
+    test_for_each(par_unseq, IteratorTag());
+
+    test_for_each_async(unseq(task), IteratorTag());
+    test_for_each_async(par_unseq(task), IteratorTag());
+}
+
+void for_each_test()
+{
+    test_for_each<std::random_access_iterator_tag>();
+    test_for_each<std::forward_iterator_tag>();
+}
+
+///////////////////////////////////////////////////////////////////////////////
+int hpx_main(hpx::program_options::variables_map& vm)
+{
+    unsigned int seed = (unsigned int) std::time(nullptr);
+    if (vm.count("seed"))
+        seed = vm["seed"].as<unsigned int>();
+
+    std::cout << "using seed: " << seed << std::endl;
+    std::srand(seed);
+
+    for_each_test();
+    return hpx::local::finalize();
+}
+
+int main(int argc, char* argv[])
+{
+    // add command line option which controls the random number generator seed
+    using namespace hpx::program_options;
+    options_description desc_commandline(
+        "Usage: " HPX_APPLICATION_STRING " [options]");
+
+    desc_commandline.add_options()("seed,s", value<unsigned int>(),
+        "the random number generator seed to use for this run");
+
+    // By default this test should run on all available cores
+    std::vector<std::string> const cfg = {"hpx.os_threads=all"};
+
+    // Initialize and run HPX
+    hpx::local::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::local::init(hpx_main, argc, argv, init_args), 0,
+        "HPX main exited with non-zero status");
+
+    return hpx::util::report_errors();
+}

--- a/libs/core/algorithms/tests/unit/unseq_algorithms/foreach_unseq.cpp
+++ b/libs/core/algorithms/tests/unit/unseq_algorithms/foreach_unseq.cpp
@@ -4,8 +4,8 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+#include <hpx/local/algorithm.hpp>
 #include <hpx/local/init.hpp>
-#include <hpx/parallel/unseq.hpp>
 
 #include <iostream>
 #include <string>

--- a/libs/core/algorithms/tests/unit/unseq_algorithms/foreach_unseq.cpp
+++ b/libs/core/algorithms/tests/unit/unseq_algorithms/foreach_unseq.cpp
@@ -35,7 +35,7 @@ void for_each_test()
 ///////////////////////////////////////////////////////////////////////////////
 int hpx_main(hpx::program_options::variables_map& vm)
 {
-    unsigned int seed = (unsigned int) std::time(nullptr);
+    auto seed = static_cast<unsigned int>(std::time(nullptr));
     if (vm.count("seed"))
         seed = vm["seed"].as<unsigned int>();
 

--- a/libs/core/algorithms/tests/unit/unseq_algorithms/foreach_unseq_zipiter.cpp
+++ b/libs/core/algorithms/tests/unit/unseq_algorithms/foreach_unseq_zipiter.cpp
@@ -37,24 +37,24 @@ void for_each_zipiter_test(ExPolicy&& policy, IteratorTag)
     static_assert(hpx::is_execution_policy<ExPolicy>::value,
         "hpx::is_execution_policy<ExPolicy>::value");
 
-    typedef std::vector<int>::iterator base_iterator;
-    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+    using base_iterator = std::vector<int>::iterator;
+    using iterator = test::test_iterator<base_iterator, IteratorTag>;
 
     std::vector<int> c(10007), d(10007);
     std::iota(std::begin(c), std::end(c), std::rand());
     std::iota(std::begin(d), std::end(d), std::rand());
 
-    auto begin = hpx::util::make_zip_iterator(
+    auto begin = hpx::util::zip_iterator(
         iterator(std::begin(c)), iterator(std::begin(d)));
-    auto end = hpx::util::make_zip_iterator(
-        iterator(std::end(c)), iterator(std::end(d)));
+    auto end =
+        hpx::util::zip_iterator(iterator(std::end(c)), iterator(std::end(d)));
 
     hpx::for_each(std::forward<ExPolicy>(policy), begin, end, set_42());
 
     // verify values
     std::size_t count = 0;
     std::for_each(std::begin(c), std::end(c), [&count](int v) -> void {
-        HPX_TEST_EQ(v, int(42));
+        HPX_TEST_EQ(v, static_cast<int>(42));
         ++count;
     });
     HPX_TEST_EQ(count, c.size());
@@ -76,7 +76,7 @@ void for_each_zipiter_test()
 ///////////////////////////////////////////////////////////////////////////////
 int hpx_main(hpx::program_options::variables_map& vm)
 {
-    unsigned int seed = (unsigned int) std::time(nullptr);
+    auto seed = static_cast<unsigned int>(std::time(nullptr));
     if (vm.count("seed"))
         seed = vm["seed"].as<unsigned int>();
 

--- a/libs/core/algorithms/tests/unit/unseq_algorithms/foreach_unseq_zipiter.cpp
+++ b/libs/core/algorithms/tests/unit/unseq_algorithms/foreach_unseq_zipiter.cpp
@@ -4,10 +4,9 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+#include <hpx/local/algorithm.hpp>
 #include <hpx/local/init.hpp>
 #include <hpx/modules/testing.hpp>
-#include <hpx/parallel/algorithms/for_each.hpp>
-#include <hpx/parallel/unseq.hpp>
 
 #include <cstddef>
 #include <iostream>

--- a/libs/core/algorithms/tests/unit/unseq_algorithms/foreach_unseq_zipiter.cpp
+++ b/libs/core/algorithms/tests/unit/unseq_algorithms/foreach_unseq_zipiter.cpp
@@ -1,0 +1,114 @@
+//  Copyright (c) 2016 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/local/init.hpp>
+#include <hpx/modules/testing.hpp>
+#include <hpx/parallel/algorithms/for_each.hpp>
+#include <hpx/parallel/unseq.hpp>
+
+#include <cstddef>
+#include <iostream>
+#include <iterator>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include <hpx/modules/program_options.hpp>
+
+#include "../algorithms/test_utils.hpp"
+
+///////////////////////////////////////////////////////////////////////////////
+struct set_42
+{
+    template <typename Tuple>
+    void operator()(Tuple&& t)
+    {
+        hpx::get<0>(t) = 42;
+        hpx::get<1>(t) = 42;
+    }
+};
+
+///////////////////////////////////////////////////////////////////////////////
+template <typename ExPolicy, typename IteratorTag>
+void for_each_zipiter_test(ExPolicy&& policy, IteratorTag)
+{
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
+
+    typedef std::vector<int>::iterator base_iterator;
+    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+
+    std::vector<int> c(10007), d(10007);
+    std::iota(std::begin(c), std::end(c), std::rand());
+    std::iota(std::begin(d), std::end(d), std::rand());
+
+    auto begin = hpx::util::make_zip_iterator(
+        iterator(std::begin(c)), iterator(std::begin(d)));
+    auto end = hpx::util::make_zip_iterator(
+        iterator(std::end(c)), iterator(std::end(d)));
+
+    hpx::for_each(std::forward<ExPolicy>(policy), begin, end, set_42());
+
+    // verify values
+    std::size_t count = 0;
+    std::for_each(std::begin(c), std::end(c), [&count](int v) -> void {
+        HPX_TEST_EQ(v, int(42));
+        ++count;
+    });
+    HPX_TEST_EQ(count, c.size());
+}
+
+template <typename IteratorTag>
+void for_each_zipiter_test()
+{
+    using namespace hpx::execution;
+
+    for_each_zipiter_test(par_unseq, IteratorTag());
+}
+
+void for_each_zipiter_test()
+{
+    for_each_zipiter_test<std::random_access_iterator_tag>();
+}
+
+///////////////////////////////////////////////////////////////////////////////
+int hpx_main(hpx::program_options::variables_map& vm)
+{
+    unsigned int seed = (unsigned int) std::time(nullptr);
+    if (vm.count("seed"))
+        seed = vm["seed"].as<unsigned int>();
+
+    std::cout << "using seed: " << seed << std::endl;
+    std::srand(seed);
+
+    for_each_zipiter_test();
+
+    return hpx::local::finalize();
+}
+
+int main(int argc, char* argv[])
+{
+    // add command line option which controls the random number generator seed
+    using namespace hpx::program_options;
+    options_description desc_commandline(
+        "Usage: " HPX_APPLICATION_STRING " [options]");
+
+    desc_commandline.add_options()("seed,s", value<unsigned int>(),
+        "the random number generator seed to use for this run");
+
+    // By default this test should run on all available cores
+    std::vector<std::string> const cfg = {"hpx.os_threads=all"};
+
+    // Initialize and run HPX
+    hpx::local::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::local::init(hpx_main, argc, argv, init_args), 0,
+        "HPX main exited with non-zero status");
+
+    return hpx::util::report_errors();
+}

--- a/libs/core/algorithms/tests/unit/unseq_algorithms/foreachn_unseq.cpp
+++ b/libs/core/algorithms/tests/unit/unseq_algorithms/foreachn_unseq.cpp
@@ -1,0 +1,72 @@
+//  Copyright (c) 2014 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/local/init.hpp>
+#include <hpx/parallel/unseq.hpp>
+
+#include <cstddef>
+#include <iostream>
+#include <string>
+#include <vector>
+
+#include "../algorithms/foreach_tests.hpp"
+
+///////////////////////////////////////////////////////////////////////////////
+template <typename IteratorTag>
+void test_for_each_n()
+{
+    using namespace hpx::execution;
+
+    test_for_each_n(unseq, IteratorTag());
+    test_for_each_n(par_unseq, IteratorTag());
+
+    test_for_each_n_async(unseq(task), IteratorTag());
+    test_for_each_n_async(par_unseq(task), IteratorTag());
+}
+
+void for_each_n_test()
+{
+    test_for_each_n<std::random_access_iterator_tag>();
+    test_for_each_n<std::forward_iterator_tag>();
+}
+
+///////////////////////////////////////////////////////////////////////////////
+int hpx_main(hpx::program_options::variables_map& vm)
+{
+    unsigned int seed = (unsigned int) std::time(nullptr);
+    if (vm.count("seed"))
+        seed = vm["seed"].as<unsigned int>();
+
+    std::cout << "using seed: " << seed << std::endl;
+    std::srand(seed);
+
+    for_each_n_test();
+    return hpx::local::finalize();
+}
+
+int main(int argc, char* argv[])
+{
+    // add command line option which controls the random number generator seed
+    using namespace hpx::program_options;
+    options_description desc_commandline(
+        "Usage: " HPX_APPLICATION_STRING " [options]");
+
+    desc_commandline.add_options()("seed,s", value<unsigned int>(),
+        "the random number generator seed to use for this run");
+
+    // By default this test should run on all available cores
+    std::vector<std::string> const cfg = {"hpx.os_threads=all"};
+
+    // Initialize and run HPX
+    hpx::local::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::local::init(hpx_main, argc, argv, init_args), 0,
+        "HPX main exited with non-zero status");
+
+    return hpx::util::report_errors();
+}

--- a/libs/core/algorithms/tests/unit/unseq_algorithms/foreachn_unseq.cpp
+++ b/libs/core/algorithms/tests/unit/unseq_algorithms/foreachn_unseq.cpp
@@ -4,8 +4,8 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+#include <hpx/local/algorithm.hpp>
 #include <hpx/local/init.hpp>
-#include <hpx/parallel/unseq.hpp>
 
 #include <cstddef>
 #include <iostream>

--- a/libs/core/algorithms/tests/unit/unseq_algorithms/foreachn_unseq.cpp
+++ b/libs/core/algorithms/tests/unit/unseq_algorithms/foreachn_unseq.cpp
@@ -36,7 +36,7 @@ void for_each_n_test()
 ///////////////////////////////////////////////////////////////////////////////
 int hpx_main(hpx::program_options::variables_map& vm)
 {
-    unsigned int seed = (unsigned int) std::time(nullptr);
+    auto seed = static_cast<unsigned int>(std::time(nullptr));
     if (vm.count("seed"))
         seed = vm["seed"].as<unsigned int>();
 

--- a/libs/core/algorithms/tests/unit/unseq_algorithms/reduce_unseq.cpp
+++ b/libs/core/algorithms/tests/unit/unseq_algorithms/reduce_unseq.cpp
@@ -1,0 +1,111 @@
+//  Copyright (c) 2022 Srinivas Yadav
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/include/unseq.hpp>
+#include <hpx/local/init.hpp>
+
+#include <cstddef>
+#include <iostream>
+#include <string>
+#include <vector>
+
+#include "../algorithms/reduce_tests.hpp"
+
+///////////////////////////////////////////////////////////////////////////////
+template <typename IteratorTag>
+void test_reduce1()
+{
+    using namespace hpx::execution;
+
+    test_reduce1(unseq, IteratorTag());
+    test_reduce1(par_unseq, IteratorTag());
+
+    test_reduce1_async(unseq(task), IteratorTag());
+    test_reduce1_async(par_unseq(task), IteratorTag());
+}
+
+void reduce_test1()
+{
+    test_reduce1<std::random_access_iterator_tag>();
+    test_reduce1<std::forward_iterator_tag>();
+}
+
+///////////////////////////////////////////////////////////////////////////////
+template <typename IteratorTag>
+void test_reduce2()
+{
+    using namespace hpx::execution;
+
+    test_reduce2(unseq, IteratorTag());
+    test_reduce2(par_unseq, IteratorTag());
+
+    test_reduce2_async(unseq(task), IteratorTag());
+    test_reduce2_async(par_unseq(task), IteratorTag());
+}
+
+void reduce_test2()
+{
+    test_reduce2<std::random_access_iterator_tag>();
+    test_reduce2<std::forward_iterator_tag>();
+}
+
+///////////////////////////////////////////////////////////////////////////////
+template <typename IteratorTag>
+void test_reduce3()
+{
+    using namespace hpx::execution;
+
+    test_reduce3(unseq, IteratorTag());
+    test_reduce3(par_unseq, IteratorTag());
+
+    test_reduce3_async(unseq(task), IteratorTag());
+    test_reduce3_async(par_unseq(task), IteratorTag());
+}
+
+void reduce_test3()
+{
+    test_reduce3<std::random_access_iterator_tag>();
+    test_reduce3<std::forward_iterator_tag>();
+}
+
+///////////////////////////////////////////////////////////////////////////////
+int hpx_main(hpx::program_options::variables_map& vm)
+{
+    unsigned int seed = (unsigned int) std::time(nullptr);
+    if (vm.count("seed"))
+        seed = vm["seed"].as<unsigned int>();
+
+    std::cout << "using seed: " << seed << std::endl;
+    gen.seed(seed);
+
+    reduce_test1();
+    reduce_test2();
+    reduce_test3();
+    return hpx::local::finalize();
+}
+
+int main(int argc, char* argv[])
+{
+    // add command line option which controls the random number generator seed
+    using namespace hpx::program_options;
+    options_description desc_commandline(
+        "Usage: " HPX_APPLICATION_STRING " [options]");
+
+    desc_commandline.add_options()("seed,s", value<unsigned int>(),
+        "the random number generator seed to use for this run");
+    // By default this test should run on all available cores
+    std::vector<std::string> const cfg = {"hpx.os_threads=all"};
+
+    // Initialize and run HPX
+    hpx::local::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::local::init(hpx_main, argc, argv, init_args), 0,
+        "HPX main exited with non-zero status");
+
+    return hpx::util::report_errors();
+}

--- a/libs/core/algorithms/tests/unit/unseq_algorithms/reduce_unseq.cpp
+++ b/libs/core/algorithms/tests/unit/unseq_algorithms/reduce_unseq.cpp
@@ -74,7 +74,7 @@ void reduce_test3()
 ///////////////////////////////////////////////////////////////////////////////
 int hpx_main(hpx::program_options::variables_map& vm)
 {
-    unsigned int seed = (unsigned int) std::time(nullptr);
+    auto seed = static_cast<unsigned int>(std::time(nullptr));
     if (vm.count("seed"))
         seed = vm["seed"].as<unsigned int>();
 

--- a/libs/core/algorithms/tests/unit/unseq_algorithms/reduce_unseq.cpp
+++ b/libs/core/algorithms/tests/unit/unseq_algorithms/reduce_unseq.cpp
@@ -4,7 +4,7 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include <hpx/include/unseq.hpp>
+#include <hpx/local/algorithm.hpp>
 #include <hpx/local/init.hpp>
 
 #include <cstddef>

--- a/libs/core/algorithms/tests/unit/unseq_algorithms/transform_binary2_unseq.cpp
+++ b/libs/core/algorithms/tests/unit/unseq_algorithms/transform_binary2_unseq.cpp
@@ -4,8 +4,8 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+#include <hpx/local/algorithm.hpp>
 #include <hpx/local/init.hpp>
-#include <hpx/parallel/unseq.hpp>
 
 #include <iostream>
 #include <string>

--- a/libs/core/algorithms/tests/unit/unseq_algorithms/transform_binary2_unseq.cpp
+++ b/libs/core/algorithms/tests/unit/unseq_algorithms/transform_binary2_unseq.cpp
@@ -1,0 +1,72 @@
+//  Copyright (c) 2014-2016 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/local/init.hpp>
+#include <hpx/parallel/unseq.hpp>
+
+#include <iostream>
+#include <string>
+#include <vector>
+
+#include "../algorithms/transform_binary2_tests.hpp"
+
+///////////////////////////////////////////////////////////////////////////////
+template <typename IteratorTag>
+void test_transform_binary2()
+{
+    using namespace hpx::execution;
+
+    test_transform_binary2(unseq, IteratorTag());
+    test_transform_binary2(par_unseq, IteratorTag());
+
+    test_transform_binary2_async(unseq(task), IteratorTag());
+    test_transform_binary2_async(par_unseq(task), IteratorTag());
+}
+
+void transform_binary2_test()
+{
+    test_transform_binary2<std::random_access_iterator_tag>();
+    test_transform_binary2<std::forward_iterator_tag>();
+}
+
+///////////////////////////////////////////////////////////////////////////////
+int hpx_main(hpx::program_options::variables_map& vm)
+{
+    unsigned int seed = (unsigned int) std::time(nullptr);
+    if (vm.count("seed"))
+        seed = vm["seed"].as<unsigned int>();
+
+    std::cout << "using seed: " << seed << std::endl;
+    std::srand(seed);
+
+    transform_binary2_test();
+    // Bad alloc and exceptions should trigger a call to std::terminate.
+    // Hence, no tests for them.
+    return hpx::local::finalize();
+}
+
+int main(int argc, char* argv[])
+{
+    // add command line option which controls the random number generator seed
+    using namespace hpx::program_options;
+    options_description desc_commandline(
+        "Usage: " HPX_APPLICATION_STRING " [options]");
+
+    desc_commandline.add_options()("seed,s", value<unsigned int>(),
+        "the random number generator seed to use for this run");
+    // By default this test should run on all available cores
+    std::vector<std::string> const cfg = {"hpx.os_threads=all"};
+
+    // Initialize and run HPX
+    hpx::local::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::local::init(hpx_main, argc, argv, init_args), 0,
+        "HPX main exited with non-zero status");
+
+    return hpx::util::report_errors();
+}

--- a/libs/core/algorithms/tests/unit/unseq_algorithms/transform_binary2_unseq.cpp
+++ b/libs/core/algorithms/tests/unit/unseq_algorithms/transform_binary2_unseq.cpp
@@ -35,7 +35,7 @@ void transform_binary2_test()
 ///////////////////////////////////////////////////////////////////////////////
 int hpx_main(hpx::program_options::variables_map& vm)
 {
-    unsigned int seed = (unsigned int) std::time(nullptr);
+    auto seed = static_cast<unsigned int>(std::time(nullptr));
     if (vm.count("seed"))
         seed = vm["seed"].as<unsigned int>();
 

--- a/libs/core/algorithms/tests/unit/unseq_algorithms/transform_binary_unseq.cpp
+++ b/libs/core/algorithms/tests/unit/unseq_algorithms/transform_binary_unseq.cpp
@@ -4,8 +4,8 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+#include <hpx/local/algorithm.hpp>
 #include <hpx/local/init.hpp>
-#include <hpx/parallel/unseq.hpp>
 
 #include <iostream>
 #include <string>

--- a/libs/core/algorithms/tests/unit/unseq_algorithms/transform_binary_unseq.cpp
+++ b/libs/core/algorithms/tests/unit/unseq_algorithms/transform_binary_unseq.cpp
@@ -1,0 +1,72 @@
+//  Copyright (c) 2014-2016 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/local/init.hpp>
+#include <hpx/parallel/unseq.hpp>
+
+#include <iostream>
+#include <string>
+#include <vector>
+
+#include "../algorithms/transform_binary_tests.hpp"
+
+///////////////////////////////////////////////////////////////////////////////
+template <typename IteratorTag>
+void test_transform_binary()
+{
+    using namespace hpx::execution;
+
+    test_transform_binary(unseq, IteratorTag());
+    test_transform_binary(par_unseq, IteratorTag());
+
+    test_transform_binary_async(unseq(task), IteratorTag());
+    test_transform_binary_async(par_unseq(task), IteratorTag());
+}
+
+void transform_binary_test()
+{
+    test_transform_binary<std::random_access_iterator_tag>();
+    test_transform_binary<std::forward_iterator_tag>();
+}
+
+///////////////////////////////////////////////////////////////////////////////
+int hpx_main(hpx::program_options::variables_map& vm)
+{
+    unsigned int seed = (unsigned int) std::time(nullptr);
+    if (vm.count("seed"))
+        seed = vm["seed"].as<unsigned int>();
+
+    std::cout << "using seed: " << seed << std::endl;
+    std::srand(seed);
+
+    transform_binary_test();
+    // Bad alloc and exceptions should trigger a call to std::terminate.
+    // Hence, no tests for them.
+    return hpx::local::finalize();
+}
+
+int main(int argc, char* argv[])
+{
+    // add command line option which controls the random number generator seed
+    using namespace hpx::program_options;
+    options_description desc_commandline(
+        "Usage: " HPX_APPLICATION_STRING " [options]");
+
+    desc_commandline.add_options()("seed,s", value<unsigned int>(),
+        "the random number generator seed to use for this run");
+    // By default this test should run on all available cores
+    std::vector<std::string> const cfg = {"hpx.os_threads=all"};
+
+    // Initialize and run HPX
+    hpx::local::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::local::init(hpx_main, argc, argv, init_args), 0,
+        "HPX main exited with non-zero status");
+
+    return hpx::util::report_errors();
+}

--- a/libs/core/algorithms/tests/unit/unseq_algorithms/transform_binary_unseq.cpp
+++ b/libs/core/algorithms/tests/unit/unseq_algorithms/transform_binary_unseq.cpp
@@ -35,7 +35,7 @@ void transform_binary_test()
 ///////////////////////////////////////////////////////////////////////////////
 int hpx_main(hpx::program_options::variables_map& vm)
 {
-    unsigned int seed = (unsigned int) std::time(nullptr);
+    auto seed = static_cast<unsigned int>(std::time(nullptr));
     if (vm.count("seed"))
         seed = vm["seed"].as<unsigned int>();
 

--- a/libs/core/algorithms/tests/unit/unseq_algorithms/transform_reduce_binary_unseq.cpp
+++ b/libs/core/algorithms/tests/unit/unseq_algorithms/transform_reduce_binary_unseq.cpp
@@ -35,7 +35,7 @@ void transform_reduce_binary_test()
 ///////////////////////////////////////////////////////////////////////////////
 int hpx_main(hpx::program_options::variables_map& vm)
 {
-    unsigned int seed = (unsigned int) std::time(nullptr);
+    auto seed = static_cast<unsigned int>(std::time(nullptr));
     if (vm.count("seed"))
         seed = vm["seed"].as<unsigned int>();
 

--- a/libs/core/algorithms/tests/unit/unseq_algorithms/transform_reduce_binary_unseq.cpp
+++ b/libs/core/algorithms/tests/unit/unseq_algorithms/transform_reduce_binary_unseq.cpp
@@ -1,0 +1,71 @@
+//  Copyright (c) 2015 Daniel Bourgeois
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/local/init.hpp>
+#include <hpx/parallel/unseq.hpp>
+
+#include <iostream>
+#include <string>
+#include <vector>
+
+#include "../algorithms/transform_reduce_binary_tests.hpp"
+
+///////////////////////////////////////////////////////////////////////////////
+template <typename IteratorTag>
+void test_transform_reduce_binary()
+{
+    using namespace hpx::execution;
+
+    test_transform_reduce_binary(unseq, IteratorTag());
+    test_transform_reduce_binary(par_unseq, IteratorTag());
+
+    test_transform_reduce_binary_async(unseq(task), IteratorTag());
+    test_transform_reduce_binary_async(par_unseq(task), IteratorTag());
+}
+
+void transform_reduce_binary_test()
+{
+    test_transform_reduce_binary<std::random_access_iterator_tag>();
+    test_transform_reduce_binary<std::forward_iterator_tag>();
+}
+
+///////////////////////////////////////////////////////////////////////////////
+int hpx_main(hpx::program_options::variables_map& vm)
+{
+    unsigned int seed = (unsigned int) std::time(nullptr);
+    if (vm.count("seed"))
+        seed = vm["seed"].as<unsigned int>();
+
+    std::cout << "using seed: " << seed << std::endl;
+    std::srand(seed);
+
+    transform_reduce_binary_test();
+    return hpx::local::finalize();
+}
+
+int main(int argc, char* argv[])
+{
+    // add command line option which controls the random number generator seed
+    using namespace hpx::program_options;
+    options_description desc_commandline(
+        "Usage: " HPX_APPLICATION_STRING " [options]");
+
+    desc_commandline.add_options()("seed,s", value<unsigned int>(),
+        "the random number generator seed to use for this run");
+
+    // By default this test should run on all available cores
+    std::vector<std::string> const cfg = {"hpx.os_threads=all"};
+
+    // Initialize and run HPX
+    hpx::local::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::local::init(hpx_main, argc, argv, init_args), 0,
+        "HPX main exited with non-zero status");
+
+    return hpx::util::report_errors();
+}

--- a/libs/core/algorithms/tests/unit/unseq_algorithms/transform_reduce_binary_unseq.cpp
+++ b/libs/core/algorithms/tests/unit/unseq_algorithms/transform_reduce_binary_unseq.cpp
@@ -4,8 +4,8 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+#include <hpx/local/algorithm.hpp>
 #include <hpx/local/init.hpp>
-#include <hpx/parallel/unseq.hpp>
 
 #include <iostream>
 #include <string>

--- a/libs/core/algorithms/tests/unit/unseq_algorithms/transform_reduce_unseq.cpp
+++ b/libs/core/algorithms/tests/unit/unseq_algorithms/transform_reduce_unseq.cpp
@@ -4,10 +4,9 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include <hpx/include/unseq.hpp>
+#include <hpx/local/algorithm.hpp>
 #include <hpx/local/init.hpp>
 #include <hpx/modules/testing.hpp>
-#include <hpx/parallel/algorithms/transform_reduce.hpp>
 
 #include <algorithm>
 #include <cstddef>

--- a/libs/core/algorithms/tests/unit/unseq_algorithms/transform_reduce_unseq.cpp
+++ b/libs/core/algorithms/tests/unit/unseq_algorithms/transform_reduce_unseq.cpp
@@ -6,10 +6,9 @@
 
 #include <hpx/local/algorithm.hpp>
 #include <hpx/local/init.hpp>
+#include <hpx/local/numeric.hpp>
 #include <hpx/modules/testing.hpp>
 
-#include <algorithm>
-#include <cstddef>
 #include <iostream>
 #include <iterator>
 #include <numeric>
@@ -35,13 +34,13 @@ void test_transform_reduce(ExPolicy&& policy, IteratorTag)
 
     auto convert_op = [](auto val) { return val * val; };
 
-    int const init = int(1);
+    constexpr int init = static_cast<int>(1);
 
-    int r1 = hpx::transform_reduce(policy, iterator(std::begin(c)),
+    int const r1 = hpx::transform_reduce(policy, iterator(std::begin(c)),
         iterator(std::end(c)), init, reduce_op, convert_op);
 
     // verify values
-    int r2 = std::accumulate(std::begin(c), std::end(c), init,
+    int const r2 = std::accumulate(std::begin(c), std::end(c), init,
         [&reduce_op, &convert_op](
             auto res, auto val) { return reduce_op(res, convert_op(val)); });
 
@@ -66,7 +65,7 @@ void test_transform_reduce_async(ExPolicy&& p, IteratorTag)
     f.wait();
 
     // verify values
-    int r2 = std::accumulate(std::begin(c), std::end(c), val, op);
+    int const r2 = std::accumulate(std::begin(c), std::end(c), val, op);
     HPX_TEST_EQ(f.get(), r2);
 }
 
@@ -90,7 +89,7 @@ void transform_reduce_test()
 
 int hpx_main(hpx::program_options::variables_map& vm)
 {
-    unsigned int seed = (unsigned int) std::time(nullptr);
+    auto seed = static_cast<unsigned int>(std::time(nullptr));
     if (vm.count("seed"))
         seed = vm["seed"].as<unsigned int>();
 

--- a/libs/core/algorithms/tests/unit/unseq_algorithms/transform_reduce_unseq.cpp
+++ b/libs/core/algorithms/tests/unit/unseq_algorithms/transform_reduce_unseq.cpp
@@ -1,0 +1,127 @@
+//  Copyright (c) 2022 Srinivas Yadav
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/include/unseq.hpp>
+#include <hpx/local/init.hpp>
+#include <hpx/modules/testing.hpp>
+#include <hpx/parallel/algorithms/transform_reduce.hpp>
+
+#include <algorithm>
+#include <cstddef>
+#include <iostream>
+#include <iterator>
+#include <numeric>
+#include <string>
+#include <vector>
+
+#include "../algorithms/test_utils.hpp"
+
+///////////////////////////////////////////////////////////////////////////////
+template <typename ExPolicy, typename IteratorTag>
+void test_transform_reduce(ExPolicy&& policy, IteratorTag)
+{
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
+
+    typedef std::vector<int>::iterator base_iterator;
+    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+
+    std::vector<int> c(10007);
+    std::iota(std::begin(c), std::end(c), std::rand());
+
+    auto reduce_op = [](auto v1, auto v2) { return v1 + v2; };
+
+    auto convert_op = [](auto val) { return val * val; };
+
+    int const init = int(1);
+
+    int r1 = hpx::transform_reduce(policy, iterator(std::begin(c)),
+        iterator(std::end(c)), init, reduce_op, convert_op);
+
+    // verify values
+    int r2 = std::accumulate(std::begin(c), std::end(c), init,
+        [&reduce_op, &convert_op](
+            auto res, auto val) { return reduce_op(res, convert_op(val)); });
+
+    HPX_TEST_EQ(r1, r2);
+    HPX_TEST_EQ(r1, r2);
+}
+
+template <typename ExPolicy, typename IteratorTag>
+void test_transform_reduce_async(ExPolicy&& p, IteratorTag)
+{
+    typedef std::vector<int>::iterator base_iterator;
+    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+
+    std::vector<int> c(10007);
+    std::iota(std::begin(c), std::end(c), std::rand());
+
+    int val = 42;
+    auto op = std::plus<>{};
+
+    hpx::future<int> f = hpx::transform_reduce(p, iterator(std::begin(c)),
+        iterator(std::end(c)), val, op, [](auto v) { return v; });
+    f.wait();
+
+    // verify values
+    int r2 = std::accumulate(std::begin(c), std::end(c), val, op);
+    HPX_TEST_EQ(f.get(), r2);
+}
+
+template <typename IteratorTag>
+void test_transform_reduce()
+{
+    using namespace hpx::execution;
+
+    test_transform_reduce(unseq, IteratorTag());
+    test_transform_reduce(par_unseq, IteratorTag());
+
+    test_transform_reduce_async(unseq(task), IteratorTag());
+    test_transform_reduce_async(par_unseq(task), IteratorTag());
+}
+
+void transform_reduce_test()
+{
+    test_transform_reduce<std::random_access_iterator_tag>();
+    test_transform_reduce<std::forward_iterator_tag>();
+}
+
+int hpx_main(hpx::program_options::variables_map& vm)
+{
+    unsigned int seed = (unsigned int) std::time(nullptr);
+    if (vm.count("seed"))
+        seed = vm["seed"].as<unsigned int>();
+
+    std::cout << "using seed: " << seed << std::endl;
+    std::srand(seed);
+
+    transform_reduce_test();
+    return hpx::local::finalize();
+}
+
+int main(int argc, char* argv[])
+{
+    // add command line option which controls the random number generator seed
+    using namespace hpx::program_options;
+    options_description desc_commandline(
+        "Usage: " HPX_APPLICATION_STRING " [options]");
+
+    desc_commandline.add_options()("seed,s", value<unsigned int>(),
+        "the random number generator seed to use for this run");
+
+    //By default run on all available cores
+    std::vector<std::string> const cfg = {"hpx.os_threads=all"};
+
+    // Initialize and run HPX
+    hpx::local::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::local::init(hpx_main, argc, argv, init_args), 0,
+        "HPX main exited with non-zero status");
+
+    return hpx::util::report_errors();
+}

--- a/libs/core/algorithms/tests/unit/unseq_algorithms/transform_unseq.cpp
+++ b/libs/core/algorithms/tests/unit/unseq_algorithms/transform_unseq.cpp
@@ -4,8 +4,8 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+#include <hpx/local/algorithm.hpp>
 #include <hpx/local/init.hpp>
-#include <hpx/parallel/unseq.hpp>
 
 #include <iostream>
 #include <string>

--- a/libs/core/algorithms/tests/unit/unseq_algorithms/transform_unseq.cpp
+++ b/libs/core/algorithms/tests/unit/unseq_algorithms/transform_unseq.cpp
@@ -1,0 +1,73 @@
+//  Copyright (c) 2014-2016 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/local/init.hpp>
+#include <hpx/parallel/unseq.hpp>
+
+#include <iostream>
+#include <string>
+#include <vector>
+
+#include "../algorithms/transform_tests.hpp"
+
+///////////////////////////////////////////////////////////////////////////////
+template <typename IteratorTag>
+void test_transform()
+{
+    using namespace hpx::execution;
+
+    test_transform(unseq, IteratorTag());
+    test_transform(par_unseq, IteratorTag());
+
+    test_transform_async(unseq(task), IteratorTag());
+    test_transform_async(par_unseq(task), IteratorTag());
+}
+
+void transform_test()
+{
+    test_transform<std::random_access_iterator_tag>();
+    test_transform<std::forward_iterator_tag>();
+}
+
+///////////////////////////////////////////////////////////////////////////////
+int hpx_main(hpx::program_options::variables_map& vm)
+{
+    unsigned int seed = (unsigned int) std::time(nullptr);
+    if (vm.count("seed"))
+        seed = vm["seed"].as<unsigned int>();
+
+    std::cout << "using seed: " << seed << std::endl;
+    std::srand(seed);
+
+    transform_test();
+    // Bad alloc and exceptions should trigger a call to std::terminate.
+    // Hence, no tests for them.
+    return hpx::local::finalize();
+}
+
+int main(int argc, char* argv[])
+{
+    // add command line option which controls the random number generator seed
+    using namespace hpx::program_options;
+    options_description desc_commandline(
+        "Usage: " HPX_APPLICATION_STRING " [options]");
+
+    desc_commandline.add_options()("seed,s", value<unsigned int>(),
+        "the random number generator seed to use for this run");
+
+    // By default this test should run on all available cores
+    std::vector<std::string> const cfg = {"hpx.os_threads=all"};
+
+    // Initialize and run HPX
+    hpx::local::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::local::init(hpx_main, argc, argv, init_args), 0,
+        "HPX main exited with non-zero status");
+
+    return hpx::util::report_errors();
+}

--- a/libs/core/algorithms/tests/unit/unseq_algorithms/transform_unseq.cpp
+++ b/libs/core/algorithms/tests/unit/unseq_algorithms/transform_unseq.cpp
@@ -35,7 +35,7 @@ void transform_test()
 ///////////////////////////////////////////////////////////////////////////////
 int hpx_main(hpx::program_options::variables_map& vm)
 {
-    unsigned int seed = (unsigned int) std::time(nullptr);
+    auto seed = static_cast<unsigned int>(std::time(nullptr));
     if (vm.count("seed"))
         seed = vm["seed"].as<unsigned int>();
 

--- a/libs/core/config/CMakeLists.txt
+++ b/libs/core/config/CMakeLists.txt
@@ -12,6 +12,7 @@ set(config_headers
     hpx/config/asio.hpp
     hpx/config/attributes.hpp
     hpx/config/autolink.hpp
+    hpx/config/auto_vectorization.hpp
     hpx/config/branch_hints.hpp
     hpx/config/compiler_fence.hpp
     hpx/config/compiler_specific.hpp

--- a/libs/core/config/include/hpx/config.hpp
+++ b/libs/core/config/include/hpx/config.hpp
@@ -12,6 +12,7 @@
 #include <hpx/config/asio.hpp>
 
 #include <hpx/config/attributes.hpp>
+#include <hpx/config/auto_vectorization.hpp>
 #include <hpx/config/branch_hints.hpp>
 #include <hpx/config/compiler_fence.hpp>
 #include <hpx/config/compiler_specific.hpp>

--- a/libs/core/config/include/hpx/config/auto_vectorization.hpp
+++ b/libs/core/config/include/hpx/config/auto_vectorization.hpp
@@ -1,0 +1,96 @@
+//  Copyright (c) 2022 A Kishore Kumar
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include <hpx/config/compiler_specific.hpp>
+
+#if defined(DOXYGEN)
+/// Instructs the compiler to ignore assumed vector dependencies.
+#define HPX_IVDEP
+/// Instructs the compiler to attempt to force-vectorize the loop
+#define HPX_VECTORIZE
+/// The compiler will not propagate no-alias metadata of a variable marked with
+/// restrict
+#define HPX_RESTRICT
+/// Instructs the compiler to unroll the loop
+#define HPX_UNROLL
+#else
+
+#ifdef _MSC_VER
+#define HPX_PRAGMA(x) __pragma(x)
+#else
+#define HPX_PRAGMA(x) _Pragma(#x)
+#endif
+
+/* Use OpenMP backend for compilers which support OpenMP */
+#if (_OPENMP >= 201307) || (__INTEL_COMPILER >= 1600) ||                       \
+    (defined(__clang__) && HPX_CLANG_VERSION >= 30700)
+#define HPX_IVDEP 
+#define HPX_VECTORIZE HPX_PRAGMA(omp simd)
+#define HPX_VECTOR_REDUCTION(CLAUSE) HPX_PRAGMA(omp simd reduction(CLAUSE))
+#define HPX_DECLARE_SIMD _PSTL_PRAGMA(omp declare simd)
+
+/* Fallback to compiler-specific backends */
+#elif defined(HPX_INTEL_VERSION)
+#define HPX_IVDEP HPX_PRAGMA(ivdep)
+#define HPX_VECTORIZE HPX_PRAGMA(vector always dynamic_align novecremainder)
+#define HPX_VECTOR_REDUCTION(CLAUSE)
+#define HPX_DECLARE_SIMD
+
+#elif defined(HPX_CLANG_VERSION)
+#define HPX_IVDEP HPX_PRAGMA(clang loop vectorize(enable))
+#define HPX_VECTORIZE HPX_PRAGMA(clang loop interleave(enable))
+#define HPX_VECTOR_REDUCTION(CLAUSE)
+#define HPX_DECLARE_SIMD
+
+#elif defined(HPX_GCC_VERSION)
+#define HPX_IVDEP HPX_PRAGMA(GCC ivdep)
+#define HPX_VECTORIZE
+#define HPX_VECTOR_REDUCTION(CLAUSE)
+#define HPX_DECLARE_SIMD
+
+#else
+#define HPX_IVDEP
+#define HPX_VECTORIZE
+#define HPX_VECTOR_REDUCTION(CLAUSE)
+#define HPX_DECLARE_SIMD
+#endif
+
+#if defined(HPX_INTEL_VERSION)
+#define HPX_RESTRICT __restrict
+#define HPX_UNROLL HPX_PRAGMA(unroll)
+#define HPX_UNROLL_N(N) HPX_PRAGMA(unroll(N))
+
+#elif defined(HPX_CLANG_VERSION)
+#define HPX_RESTRICT __restrict
+#define HPX_UNROLL HPX_PRAGMA(clang loop unroll(enable))
+#define HPX_UNROLL_N(N) HPX_PRAGMA(clang loop unroll_count(N))
+
+#elif defined(HPX_GCC_VERSION)
+#define HPX_RESTRICT __restrict__
+#define HPX_UNROLL                                                             \
+    HPX_PRAGMA(                                                                \
+        GCC unroll 8)    // GCC does not have an auto unroll constant picker
+#define HPX_UNROLL_N(N) HPX_PRAGMA(GCC unroll N)
+
+#else
+#define HPX_RESTRICT
+#define HPX_UNROLL
+#define HPX_UNROLL_N(N)
+#endif
+
+#ifdef __AVX512F__
+#define HPX_LANE_SIZE 64
+#elifdef __AVX2__
+#define HPX_LANE_SIZE 32
+#elifdef __SSE3__
+#define HPX_LANE_SIZE 16
+#else
+#define HPX_LANE_SIZE 64
+#endif
+
+#endif

--- a/libs/core/include_local/include/hpx/local/algorithm.hpp
+++ b/libs/core/include_local/include/hpx/local/algorithm.hpp
@@ -9,6 +9,7 @@
 #include <hpx/config.hpp>
 #include <hpx/parallel/algorithm.hpp>
 #include <hpx/parallel/container_algorithms.hpp>
+#include <hpx/parallel/unseq.hpp>
 #if defined(HPX_HAVE_DATAPAR)
 #include <hpx/parallel/datapar.hpp>
 #endif

--- a/libs/full/include/CMakeLists.txt
+++ b/libs/full/include/CMakeLists.txt
@@ -102,6 +102,7 @@ set(include_headers
     hpx/include/threadmanager.hpp
     hpx/include/threads.hpp
     hpx/include/traits.hpp
+    hpx/include/unseq.hpp
     hpx/include/util.hpp
     hpx/latch.hpp
     hpx/memory.hpp

--- a/libs/full/include/include/hpx/include/unseq.hpp
+++ b/libs/full/include/include/hpx/include/unseq.hpp
@@ -1,0 +1,9 @@
+//  Copyright (c) 2022 A Kishore Kumar
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include <hpx/parallel/unseq.hpp>


### PR DESCRIPTION
## Proposed Changes
- New `unseq_reduce` CPOs to accept `unseq` overloads from `transform_reduce`, `reduce` and `transform_reduce_binary` algorithms.
- Adds overloads to accept `unseq` and `par_unseq` overloads for the same algorithms. 
- Unit tests for all three algorithms

## Any background context you want to provide?
This is based off of #6017 
