### PR TITLE
Add --start-group and --end-group before libraries are added for linking

### DIFF
--- a/cmake/templates/hpxcxx.in
+++ b/cmake/templates/hpxcxx.in
@@ -126,12 +126,14 @@ if pkg in os.environ:
 else:
     os.environ[pkg] = pkgconf
 
+args += ["-Wl,--start-group"]
 if application:
     args += ["`pkg-config --cflags --libs hpx_application" + pkgconf_suffix + "`"]
 elif component:
     args += ["`pkg-config --cflags --libs hpx_component" + pkgconf_suffix + "`"]
 else:
     args += ["`pkg-config --cflags hpx_application" + pkgconf_suffix + "`"]
+args += ["-Wl,--end-group"]
 
 if not component and not application and not minusc:
     usage()


### PR DESCRIPTION

Recently, I attempted to compile simple_resource_partitioner.cpp using hpxcxx and got some undefined symbols, but these symbols were defined in libhpx_init.a, a library that is already on the link line.

## Proposed Changes
Add -Wl,--start-group before linking libs and -Wl,--end-group after linking libs.
