### PR TITLE
add option hpx:force_ipv4 to force resolving hostnames to ipv4 adresses

### DIFF
--- a/docs/sphinx/manual/launching_and_configuring_hpx_applications.rst
+++ b/docs/sphinx/manual/launching_and_configuring_hpx_applications.rst
@@ -1461,6 +1461,13 @@ The predefined command line options for any application using
    Sed-style search and replace (``s/search/replace/``) used to transform host
    names to the proper network interconnect.
 
+.. option:: --hpx:force_ipv4
+
+   Network hostnames will be resolved to ipv4 adresses instead of using the
+   first resolved endpoint. This is especially useful on Windows where the
+   local hostname will resolve to an ipv6 adress while remote network hostnames
+   are commonly resolved to ipv4 adresses.
+
 .. option:: --hpx:localities arg
 
    The number of localities to wait for at application startup (default: ``1``).

--- a/libs/core/asio/include/hpx/asio/asio_util.hpp
+++ b/libs/core/asio/include/hpx/asio/asio_util.hpp
@@ -27,7 +27,7 @@ namespace hpx { namespace util {
 
     ///////////////////////////////////////////////////////////////////////////
     HPX_CORE_EXPORT bool get_endpoint(std::string const& addr,
-        std::uint16_t port, asio::ip::tcp::endpoint& ep);
+        std::uint16_t port, asio::ip::tcp::endpoint& ep, bool force_ipv4 = false);
 
     HPX_CORE_EXPORT std::string get_endpoint_name(
         asio::ip::tcp::endpoint const& ep);
@@ -36,7 +36,7 @@ namespace hpx { namespace util {
     // properly resolve a give host name to the corresponding IP address
     HPX_CORE_EXPORT asio::ip::tcp::endpoint resolve_hostname(
         std::string const& hostname, std::uint16_t port,
-        asio::io_context& io_service);
+        asio::io_context& io_service, bool force_ipv4 = false);
 
     ///////////////////////////////////////////////////////////////////////////
     // return the public IP address of the local node

--- a/libs/core/asio/include/hpx/asio/map_hostnames.hpp
+++ b/libs/core/asio/include/hpx/asio/map_hostnames.hpp
@@ -27,7 +27,7 @@ namespace hpx { namespace util {
             transform_function_type;
 
         map_hostnames(bool debug = false)
-          : debug_(debug)
+          : ipv4_(false), debug_(debug)
         {
         }
 
@@ -46,12 +46,18 @@ namespace hpx { namespace util {
             transform_ = f;
         }
 
+        void force_ipv4(bool const& f)
+        {
+            ipv4_ = f;
+        }
+
         std::string map(std::string host_name, std::uint16_t port) const;
 
     private:
         transform_function_type transform_;
         std::string suffix_;
         std::string prefix_;
+        bool ipv4_;
         bool debug_;
     };
 }}    // namespace hpx::util

--- a/libs/core/asio/include/hpx/asio/map_hostnames.hpp
+++ b/libs/core/asio/include/hpx/asio/map_hostnames.hpp
@@ -46,7 +46,7 @@ namespace hpx { namespace util {
             transform_ = f;
         }
 
-        void force_ipv4(bool const& f)
+        void force_ipv4(bool f)
         {
             ipv4_ = f;
         }

--- a/libs/core/asio/src/map_hostnames.cpp
+++ b/libs/core/asio/src/map_hostnames.cpp
@@ -48,7 +48,7 @@ namespace hpx { namespace util {
         // do full host name resolution
         asio::io_context io_service;
         asio::ip::tcp::endpoint ep = util::resolve_hostname(
-            prefix_ + host_name + suffix_, port, io_service);
+            prefix_ + host_name + suffix_, port, io_service, ipv4_);
 
         std::string resolved_addr(util::get_endpoint_name(ep));
         if (debug_)

--- a/libs/full/command_line_handling/src/command_line_handling.cpp
+++ b/libs/full/command_line_handling/src/command_line_handling.cpp
@@ -647,6 +647,7 @@ namespace hpx { namespace util {
             mapnames.use_suffix(vm["hpx:ifsuffix"].as<std::string>());
         if (vm.count("hpx:ifprefix"))
             mapnames.use_prefix(vm["hpx:ifprefix"].as<std::string>());
+        mapnames.force_ipv4(vm.count("hpx:force_ipv4") > 0);
 
         // The AGAS host name and port number are pre-initialized from
         //the command line

--- a/libs/full/command_line_handling/src/parse_command_line.cpp
+++ b/libs/full/command_line_handling/src/parse_command_line.cpp
@@ -479,6 +479,7 @@ namespace hpx { namespace util {
                 ("hpx:iftransform", value<std::string>(),
                   "sed-style search and replace (s/search/replace/) used to "
                   "transform host names to the proper network interconnect")
+                ("hpx:force_ipv4", "Force ipv4 for resolving network hostnames")
 #endif
 #if defined(HPX_HAVE_DISTRIBUTED_RUNTIME)
                 ("hpx:localities", value<std::size_t>(),


### PR DESCRIPTION
## Proposed Changes

  - add an option to force resolving hostnames to ipv4 adresses

## Any background context you want to provide?

Local hostnames on windows are commonly resolved to ipv6 addresses while remote hostnames resolved to ipv4 addresses. This leads to hpx applications to listen on the wrong addresses if using hostnames on windows. 

The following code might also be related to this since pinging localhost returns a ipv6 `::1` instead of ipv4. 

https://github.com/STEllAR-GROUP/hpx/blob/435ae68f04084df3fa652ef76571b78db1980e8d/libs/core/asio/src/map_hostnames.cpp#L26-L36

## Checklist

Not all points below apply to all pull requests.

- [x] I have added a new feature ~~and have added tests to go along with it.~~ (I don't even see where to add a test here;somewhere in CI?)
- [ ] ~~I have fixed a bug and have added a regression test~~.
- [ ] ~~I have added a test using random numbers; I have made sure it uses a seed, and that random numbers generated are valid inputs for the tests~~.

## Other comment.

Maybe HPX should detect ipv4/ipv6 mismatch on its own since it has to lookup the endpoints any way?
