### PR TITLE
Adding parcelport initialization hook for resource partitioner operation

### DIFF
--- a/libs/core/plugin/include/hpx/plugin/traits/plugin_config_data.hpp
+++ b/libs/core/plugin/include/hpx/plugin/traits/plugin_config_data.hpp
@@ -1,12 +1,10 @@
-//  Copyright (c) 2007-2013 Hartmut Kaiser
+//  Copyright (c) 2007-2022 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #pragma once
-
-#include <hpx/config.hpp>
 
 namespace hpx { namespace traits {
 
@@ -16,7 +14,7 @@ namespace hpx { namespace traits {
     struct plugin_config_data
     {
         // by default no additional config data is injected into the factory
-        static char const* call()
+        static constexpr char const* call() noexcept
         {
             return nullptr;
         }

--- a/libs/full/init_runtime/src/hpx_init.cpp
+++ b/libs/full/init_runtime/src/hpx_init.cpp
@@ -858,6 +858,13 @@ namespace hpx {
                         params.rp_callback(rp, cmdline.vm_);
                     }
 
+#if defined(HPX_HAVE_NETWORKING)
+                    if (cmdline.num_localities_ != 1 || cmdline.node_ != 0 ||
+                        cmdline.rtcfg_.enable_networking())
+                    {
+                        parcelset::parcelhandler::init(rp);
+                    }
+#endif
                     // Setup all internal parameters of the resource_partitioner
                     rp.configure_pools();
                 }

--- a/libs/full/parcelport_lci/src/parcelport_lci.cpp
+++ b/libs/full/parcelport_lci/src/parcelport_lci.cpp
@@ -12,6 +12,7 @@
 #include <hpx/modules/errors.hpp>
 #include <hpx/modules/execution_base.hpp>
 #include <hpx/modules/functional.hpp>
+#include <hpx/modules/resource_partitioner.hpp>
 #include <hpx/modules/runtime_configuration.hpp>
 #include <hpx/modules/runtime_local.hpp>
 #include <hpx/modules/synchronization.hpp>
@@ -251,6 +252,7 @@ namespace hpx::traits {
         {
             return "50";
         }
+
         static void init(
             int* argc, char*** argv, util::command_line_handling& cfg)
         {
@@ -259,6 +261,9 @@ namespace hpx::traits {
                 static_cast<std::size_t>(util::lci_environment::size());
             cfg.node_ = static_cast<std::size_t>(util::lci_environment::rank());
         }
+
+        // TODO: implement creation of custom thread pool here
+        static void init(hpx::resource::partitioner&) noexcept {}
 
         static void destroy()
         {

--- a/libs/full/parcelport_libfabric/include/hpx/parcelport_libfabric/parcelport_libfabric.hpp
+++ b/libs/full/parcelport_libfabric/include/hpx/parcelport_libfabric/parcelport_libfabric.hpp
@@ -12,6 +12,7 @@
 // util
 #include <hpx/modules/command_line_handling.hpp>
 #include <hpx/modules/format.hpp>
+#include <hpx/modules/resource_partitioner.hpp>
 #include <hpx/modules/runtime_configuration.hpp>
 #include <hpx/modules/runtime_local.hpp>
 #include <hpx/modules/threading_base.hpp>
@@ -255,6 +256,10 @@ namespace hpx { namespace traits {
 
             FUNC_END_DEBUG_MSG;
         }
+
+        // by default no additional initialization using the resource
+        // partitioner is required
+        static constexpr void init(hpx::resource::partitioner&) noexcept {}
 
         static void destroy() {}
 

--- a/libs/full/parcelport_mpi/src/parcelport_mpi.cpp
+++ b/libs/full/parcelport_mpi/src/parcelport_mpi.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2021 Hartmut Kaiser
+//  Copyright (c) 2007-2022 Hartmut Kaiser
 //  Copyright (c) 2014-2015 Thomas Heller
 //  Copyright (c)      2020 Google
 //
@@ -13,6 +13,7 @@
 #include <hpx/modules/execution_base.hpp>
 #include <hpx/modules/functional.hpp>
 #include <hpx/modules/mpi_base.hpp>
+#include <hpx/modules/resource_partitioner.hpp>
 #include <hpx/modules/runtime_configuration.hpp>
 #include <hpx/modules/runtime_local.hpp>
 #include <hpx/modules/synchronization.hpp>
@@ -275,6 +276,10 @@ namespace hpx::traits {
                 static_cast<std::size_t>(util::mpi_environment::size());
             cfg.node_ = static_cast<std::size_t>(util::mpi_environment::rank());
         }
+
+        // by default no additional initialization using the resource
+        // partitioner is required
+        static constexpr void init(hpx::resource::partitioner&) noexcept {}
 
         static void destroy()
         {

--- a/libs/full/parcelport_tcp/src/parcelport_tcp.cpp
+++ b/libs/full/parcelport_tcp/src/parcelport_tcp.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2021 Hartmut Kaiser
+//  Copyright (c) 2007-2022 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -7,9 +7,9 @@
 #include <hpx/config.hpp>
 
 #if defined(HPX_HAVE_NETWORKING) && defined(HPX_HAVE_PARCELPORT_TCP)
-#include <hpx/plugin/traits/plugin_config_data.hpp>
-
+#include <hpx/modules/resource_partitioner.hpp>
 #include <hpx/parcelport_tcp/connection_handler.hpp>
+#include <hpx/plugin/traits/plugin_config_data.hpp>
 #include <hpx/plugin_factories/parcelport_factory.hpp>
 
 namespace hpx::traits {
@@ -34,6 +34,10 @@ namespace hpx::traits {
             util::command_line_handling& /* cfg */) noexcept
         {
         }
+
+        // by default no additional initialization using the resource
+        // partitioner is required
+        static constexpr void init(hpx::resource::partitioner&) noexcept {}
 
         static constexpr void destroy() noexcept {}
 

--- a/libs/full/parcelset/include/hpx/parcelset/parcelhandler.hpp
+++ b/libs/full/parcelset/include/hpx/parcelset/parcelhandler.hpp
@@ -1,5 +1,5 @@
 //  Copyright (c)      2014 Thomas Heller
-//  Copyright (c) 2007-2021 Hartmut Kaiser
+//  Copyright (c) 2007-2022 Hartmut Kaiser
 //  Copyright (c)      2011 Bryce Lelbach
 //
 //  SPDX-License-Identifier: BSL-1.0
@@ -15,6 +15,7 @@
 #include <hpx/modules/errors.hpp>
 #include <hpx/modules/functional.hpp>
 #include <hpx/modules/logging.hpp>
+#include <hpx/modules/resource_partitioner.hpp>
 #include <hpx/modules/synchronization.hpp>
 #include <hpx/modules/threadmanager.hpp>
 #include <hpx/modules/timing.hpp>
@@ -478,6 +479,7 @@ namespace hpx::parcelset {
 
         static void init(
             int* argc, char*** argv, util::command_line_handling& cfg);
+        static void init(hpx::resource::partitioner& rp);
     };
 
     std::vector<std::string> load_runtime_configuration();

--- a/libs/full/parcelset/src/parcelhandler.cpp
+++ b/libs/full/parcelset/src/parcelhandler.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2021 Hartmut Kaiser
+//  Copyright (c) 2007-2022 Hartmut Kaiser
 //  Copyright (c) 2013-2014 Thomas Heller
 //  Copyright (c) 2007      Richard D Guidry Jr
 //  Copyright (c) 2011      Bryce Lelbach & Katelyn Kufahl
@@ -19,6 +19,7 @@
 #include <hpx/modules/itt_notify.hpp>
 #include <hpx/modules/logging.hpp>
 #include <hpx/modules/preprocessor.hpp>
+#include <hpx/modules/resource_partitioner.hpp>
 #include <hpx/modules/runtime_configuration.hpp>
 #include <hpx/modules/runtime_local.hpp>
 #include <hpx/modules/string_util.hpp>
@@ -1276,6 +1277,17 @@ namespace hpx::parcelset {
             get_parcelport_factories())
         {
             factory->init(argc, argv, cfg);
+        }
+    }
+
+    void parcelhandler::init(hpx::resource::partitioner& rp)
+    {
+        HPX_ASSERT(hpx::is_networking_enabled());
+
+        for (plugins::parcelport_factory_base* factory :
+            get_parcelport_factories())
+        {
+            factory->init(rp);
         }
     }
 

--- a/libs/full/plugin_factories/include/hpx/plugin_factories/parcelport_factory.hpp
+++ b/libs/full/plugin_factories/include/hpx/plugin_factories/parcelport_factory.hpp
@@ -1,5 +1,5 @@
 //  Copyright (c)      2014 Thomas Heller
-//  Copyright (c) 2007-2021 Hartmut Kaiser
+//  Copyright (c) 2007-2022 Hartmut Kaiser
 //  Copyright (c)      2020 Google
 //
 //  SPDX-License-Identifier: BSL-1.0
@@ -12,6 +12,7 @@
 #if defined(HPX_HAVE_NETWORKING)
 #include <hpx/modules/prefix.hpp>
 #include <hpx/modules/preprocessor.hpp>
+#include <hpx/modules/resource_partitioner.hpp>
 #include <hpx/modules/runtime_configuration.hpp>
 #include <hpx/modules/string_util.hpp>
 #include <hpx/plugin/traits/plugin_config_data.hpp>
@@ -143,6 +144,12 @@ namespace hpx::plugins {
         {
             // initialize the parcelport with the parameters we got passed in at start
             traits::plugin_config_data<Parcelport>::init(argc, argv, cfg);
+        }
+
+        void init(hpx::resource::partitioner& rp) override
+        {
+            // initialize the parcelport with the parameters we got passed in at start
+            traits::plugin_config_data<Parcelport>::init(rp);
         }
 
         /// Create a new instance of a message handler

--- a/libs/full/plugin_factories/include/hpx/plugin_factories/parcelport_factory_base.hpp
+++ b/libs/full/plugin_factories/include/hpx/plugin_factories/parcelport_factory_base.hpp
@@ -1,5 +1,5 @@
 //  Copyright (c)      2014 Thomas Heller
-//  Copyright (c) 2007-2021 Hartmut Kaiser
+//  Copyright (c) 2007-2022 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <hpx/config.hpp>
+#include <hpx/modules/resource_partitioner.hpp>
 #include <hpx/modules/runtime_configuration.hpp>
 #include <hpx/modules/threading_base.hpp>
 
@@ -32,6 +33,7 @@ namespace hpx::plugins {
 
         virtual void init(
             int* argc, char*** argv, util::command_line_handling& cfg) = 0;
+        virtual void init(hpx::resource::partitioner& rp) = 0;
 
         /// Create a new instance of a parcelport
         ///


### PR DESCRIPTION
This adds a hook to all parcelports that will be invoked during initialization giving each parcelport a chance to create thread pools or perform other initialization work involving the resource partitioner.