### PR TITLE
Support new datapar backend : SVE

### DIFF
--- a/.github/workflows/linux_crosscompile_arm_sve_release.yml
+++ b/.github/workflows/linux_crosscompile_arm_sve_release.yml
@@ -45,7 +45,7 @@ jobs:
       run: |
           cmake --build build --target core
           cmake --build build --target tests.unit.modules.algorithms.datapar_algorithms
-          cmake --build build --target ninja tests.regressions.modules.algorithms.for_each_datapar
+          cmake --build build --target tests.regressions.modules.algorithms.for_each_datapar
     - name: Test
       shell: bash
       run: |

--- a/.github/workflows/linux_crosscompile_arm_sve_release.yml
+++ b/.github/workflows/linux_crosscompile_arm_sve_release.yml
@@ -37,16 +37,19 @@ jobs:
               -DCMAKE_CXX_FLAGS=-march=armv8-a+sve \
               -DBOOST_ROOT=/opt/install/boost/release/boost \
               -DHWLOC_ROOT=/opt/install/hwloc \
-              -DHPX_WITH_GENERIC_CONTEXT_COROUTINES=On
+              -DHPX_WITH_GENERIC_CONTEXT_COROUTINES=On \
+              -DHPX_WITH_DATAPAR_BACKEND=SVE \
+              -DSVE_ROOT=/opt/install/sve/release/sve
     - name: Build
       shell: bash
       run: |
           cmake --build build --target core
-          cmake --build build --target tests.unit.modules.algorithms
+          cmake --build build --target tests.unit.modules.algorithms.datapar_algorithms
+          cmake --build build --target ninja tests.regressions.modules.algorithms.for_each_datapar
     - name: Test
       shell: bash
       run: |
           cd build
           ctest \
             --output-on-failure \
-            --tests-regex tests.unit.modules.algorithms
+            --tests-regex datapar

--- a/cmake/HPX_SetupDatapar.cmake
+++ b/cmake/HPX_SetupDatapar.cmake
@@ -92,10 +92,11 @@ if("${HPX_WITH_DATAPAR_BACKEND}" STREQUAL "STD_EXPERIMENTAL_SIMD")
   endif()
 endif()
 
-# # ##############################################################################
-# # HPX SVE configuration
-# # ##############################################################################
-if ("${HPX_WITH_DATAPAR_BACKEND}" STREQUAL "SVE")
+# #
+# ##############################################################################
+# # HPX SVE configuration #
+# ##############################################################################
+if("${HPX_WITH_DATAPAR_BACKEND}" STREQUAL "SVE")
   hpx_option(
     HPX_WITH_FETCH_SVE
     BOOL
@@ -118,14 +119,17 @@ if ("${HPX_WITH_DATAPAR_BACKEND}" STREQUAL "SVE")
   include(HPX_SetupSVE)
   hpx_option(
     HPX_WITH_DATAPAR BOOL
-    "Enable data parallel algorithm support using SVE library (default: ON)"
-    ON ADVANCED)
+    "Enable data parallel algorithm support using SVE library (default: ON)" ON
+    ADVANCED
+  )
   hpx_add_config_define(HPX_HAVE_DATAPAR_SVE)
   hpx_add_config_define(HPX_HAVE_DATAPAR)
 endif()
 
-if (("${HPX_WITH_DATAPAR_BACKEND}" STREQUAL "STD_EXPERIMENTAL_SIMD") OR ("${HPX_WITH_DATAPAR_BACKEND}" STREQUAL "SVE"))
-    hpx_add_config_define(HPX_HAVE_DATAPAR_EXPERIMENTAL_SIMD)
+if(("${HPX_WITH_DATAPAR_BACKEND}" STREQUAL "STD_EXPERIMENTAL_SIMD")
+   OR ("${HPX_WITH_DATAPAR_BACKEND}" STREQUAL "SVE")
+)
+  hpx_add_config_define(HPX_HAVE_DATAPAR_EXPERIMENTAL_SIMD)
 endif()
 
 if(HPX_WITH_DATAPAR)

--- a/cmake/HPX_SetupDatapar.cmake
+++ b/cmake/HPX_SetupDatapar.cmake
@@ -11,9 +11,9 @@ set(DATAPAR_BACKEND "NONE")
 hpx_option(
   HPX_WITH_DATAPAR_BACKEND
   STRING
-  "Define which vectorization library should be used. Options are: VC, EVE, STD_EXPERIMENTAL_SIMD, NONE"
+  "Define which vectorization library should be used. Options are: VC, EVE, STD_EXPERIMENTAL_SIMD, SVE; NONE"
   ${DATAPAR_BACKEND}
-  STRINGS "VC;EVE;STD_EXPERIMENTAL_SIMD;NONE"
+  STRINGS "VC;EVE;STD_EXPERIMENTAL_SIMD;SVE;NONE"
 )
 include(HPX_AddDefinitions)
 
@@ -90,6 +90,42 @@ if("${HPX_WITH_DATAPAR_BACKEND}" STREQUAL "STD_EXPERIMENTAL_SIMD")
       "Could not find std experimental/simd. Use CXX COMPILER GCC 11 OR CLANG 12 AND ABOVE "
     )
   endif()
+endif()
+
+# # ##############################################################################
+# # HPX SVE configuration
+# # ##############################################################################
+if ("${HPX_WITH_DATAPAR_BACKEND}" STREQUAL "SVE")
+  hpx_option(
+    HPX_WITH_FETCH_SVE
+    BOOL
+    "Use FetchContent to fetch SVE. By default an installed SVE will be used. (default: OFF)"
+    OFF
+    CATEGORY "Build Targets"
+    ADVANCED
+  )
+  hpx_option(
+    HPX_WITH_SVE_TAG STRING "SVE repository tag or branch" "master"
+    CATEGORY "Build Targets"
+    ADVANCED
+  )
+  hpx_option(
+    HPX_WITH_SVE_LENGTH STRING "SVE length to be used." ""
+    CATEGORY "Build Targets"
+    ADVANCED
+  )
+
+  include(HPX_SetupSVE)
+  hpx_option(
+    HPX_WITH_DATAPAR BOOL
+    "Enable data parallel algorithm support using SVE library (default: ON)"
+    ON ADVANCED)
+  hpx_add_config_define(HPX_HAVE_DATAPAR_SVE)
+  hpx_add_config_define(HPX_HAVE_DATAPAR)
+endif()
+
+if (("${HPX_WITH_DATAPAR_BACKEND}" STREQUAL "STD_EXPERIMENTAL_SIMD") OR ("${HPX_WITH_DATAPAR_BACKEND}" STREQUAL "SVE"))
+    hpx_add_config_define(HPX_HAVE_DATAPAR_EXPERIMENTAL_SIMD)
 endif()
 
 if(HPX_WITH_DATAPAR)

--- a/cmake/HPX_SetupSVE.cmake
+++ b/cmake/HPX_SetupSVE.cmake
@@ -16,20 +16,22 @@ if(("${HPX_WITH_DATAPAR_BACKEND}" STREQUAL "SVE") AND NOT TARGET SVE::sve)
       )
     endif()
 
-    if ("${HPX_WITH_SVE_LENGTH}" STREQUAL "")
-      hpx_error("When using HPX_WITH_FETCH_SVE, set HPX_WITH_SVE_LENGTH to appropriate length based on the architecture.")
+    if("${HPX_WITH_SVE_LENGTH}" STREQUAL "")
+      hpx_error(
+        "When using HPX_WITH_FETCH_SVE, set HPX_WITH_SVE_LENGTH to appropriate length based on the architecture."
+      )
     endif()
 
     set(SVE_LENGTH "${HPX_WITH_SVE_LENGTH}")
 
     include(FetchContent)
-    FetchContent_Declare(
+    fetchcontent_declare(
       sve
       GIT_REPOSITORY https://github.com/srinivasyadav18/sve.git
       GIT_TAG ${HPX_WITH_SVE_TAG}
     )
-    
-    FetchContent_MakeAvailable(sve)
+
+    fetchcontent_makeavailable(sve)
 
     set(SVE_ROOT ${sve_SOURCE_DIR})
 
@@ -38,7 +40,7 @@ if(("${HPX_WITH_DATAPAR_BACKEND}" STREQUAL "SVE") AND NOT TARGET SVE::sve)
       EXPORT HPXSVETarget
       COMPONENT core
     )
-  
+
     install(
       DIRECTORY ${SVE_ROOT}/include/
       DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
@@ -47,22 +49,22 @@ if(("${HPX_WITH_DATAPAR_BACKEND}" STREQUAL "SVE") AND NOT TARGET SVE::sve)
       PATTERN "*.hpp"
       PATTERN "*.ipp"
     )
-  
+
     export(
       TARGETS sve
       NAMESPACE SVE::
       FILE "${CMAKE_CURRENT_BINARY_DIR}/lib/cmake/${HPX_PACKAGE_NAME}/HPXSVETarget.cmake"
     )
-  
+
     install(
       EXPORT HPXSVETarget
       NAMESPACE SVE::
       FILE HPXSVETarget.cmake
       DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${HPX_PACKAGE_NAME}
     )
-  
+
   else()
-    if (SVE_ROOT)
+    if(SVE_ROOT)
       find_package(SVE REQUIRED PATHS ${SVE_ROOT})
     else()
       hpx_error("SVE_ROOT not set")

--- a/cmake/HPX_SetupSVE.cmake
+++ b/cmake/HPX_SetupSVE.cmake
@@ -1,0 +1,71 @@
+# Copyright (c) 2022 Srinivas Yadav
+#
+# SPDX-License-Identifier: BSL-1.0
+# Distributed under the Boost Software License, Version 1.0. (See accompanying
+# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+if(("${HPX_WITH_DATAPAR_BACKEND}" STREQUAL "SVE") AND NOT TARGET SVE::sve)
+  if(HPX_WITH_FETCH_SVE)
+    if(FETCHCONTENT_SOURCE_DIR_SVE)
+      hpx_info(
+        "HPX_WITH_FETCH_SVE=${HPX_WITH_FETCH_SVE}, SVE will be used through CMake's FetchContent and installed alongside HPX (FETCHCONTENT_SOURCE_DIR_SVE=${FETCHCONTENT_SOURCE_DIR_SVE})"
+      )
+    else()
+      hpx_info(
+        "HPX_WITH_FETCH_SVE=${HPX_WITH_FETCH_SVE}, SVE will be fetched using CMake's FetchContent and installed alongside HPX (HPX_WITH_SVE_TAG=${HPX_WITH_SVE_TAG})"
+      )
+    endif()
+
+    if ("${HPX_WITH_SVE_LENGTH}" STREQUAL "")
+      hpx_error("When using HPX_WITH_FETCH_SVE, set HPX_WITH_SVE_LENGTH to appropriate length based on the architecture.")
+    endif()
+
+    set(SVE_LENGTH "${HPX_WITH_SVE_LENGTH}")
+
+    include(FetchContent)
+    FetchContent_Declare(
+      sve
+      GIT_REPOSITORY https://github.com/srinivasyadav18/sve.git
+      GIT_TAG ${HPX_WITH_SVE_TAG}
+    )
+    
+    FetchContent_MakeAvailable(sve)
+
+    set(SVE_ROOT ${sve_SOURCE_DIR})
+
+    install(
+      TARGETS sve
+      EXPORT HPXSVETarget
+      COMPONENT core
+    )
+  
+    install(
+      DIRECTORY ${SVE_ROOT}/include/
+      DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+      COMPONENT core
+      FILES_MATCHING
+      PATTERN "*.hpp"
+      PATTERN "*.ipp"
+    )
+  
+    export(
+      TARGETS sve
+      NAMESPACE SVE::
+      FILE "${CMAKE_CURRENT_BINARY_DIR}/lib/cmake/${HPX_PACKAGE_NAME}/HPXSVETarget.cmake"
+    )
+  
+    install(
+      EXPORT HPXSVETarget
+      NAMESPACE SVE::
+      FILE HPXSVETarget.cmake
+      DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${HPX_PACKAGE_NAME}
+    )
+  
+  else()
+    if (SVE_ROOT)
+      find_package(SVE REQUIRED PATHS ${SVE_ROOT})
+    else()
+      hpx_error("SVE_ROOT not set")
+    endif()
+  endif()
+endif()

--- a/cmake/templates/HPXConfig.cmake.in
+++ b/cmake/templates/HPXConfig.cmake.in
@@ -52,6 +52,15 @@ if("${HPX_WITH_DATAPAR_BACKEND}" STREQUAL "EVE")
   endif()
 endif()
 
+if("${HPX_WITH_DATAPAR_BACKEND}" STREQUAL "SVE")
+  if(HPX_WITH_FETCH_SVE)
+    include("${CMAKE_CURRENT_LIST_DIR}/HPXSVETarget.cmake")
+  else()
+    set(SVE_ROOT "@SVE_ROOT@")
+    include(HPX_SetupSVE)
+  endif()
+endif()
+
 include("${CMAKE_CURRENT_LIST_DIR}/HPXInternalTargets.cmake")
 include("${CMAKE_CURRENT_LIST_DIR}/HPXTargets.cmake")
 

--- a/libs/CMakeLists.txt
+++ b/libs/CMakeLists.txt
@@ -357,6 +357,10 @@ if("${HPX_WITH_DATAPAR_BACKEND}" STREQUAL "EVE")
   target_link_libraries(hpx_core PUBLIC Eve::eve)
 endif()
 
+if("${HPX_WITH_DATAPAR_BACKEND}" STREQUAL "SVE")
+  target_link_libraries(hpx_core PUBLIC SVE::sve)
+endif()
+
 if(HPX_WITH_ITTNOTIFY)
   target_link_libraries(hpx_core PUBLIC Amplifier::amplifier)
 endif()

--- a/libs/core/execution/CMakeLists.txt
+++ b/libs/core/execution/CMakeLists.txt
@@ -73,6 +73,7 @@ set(execution_headers
     hpx/execution/traits/detail/simd/vector_pack_get_set.hpp
     hpx/execution/traits/detail/simd/vector_pack_load_store.hpp
     hpx/execution/traits/detail/simd/vector_pack_reduce.hpp
+    hpx/execution/traits/detail/simd/vector_pack_simd.hpp
     hpx/execution/traits/detail/simd/vector_pack_type.hpp
     hpx/execution/traits/detail/vc/vector_pack_alignment_size.hpp
     hpx/execution/traits/detail/vc/vector_pack_all_any_none.hpp

--- a/libs/core/execution/CMakeLists.txt
+++ b/libs/core/execution/CMakeLists.txt
@@ -142,6 +142,10 @@ if(TARGET Eve::eve)
   set(execution_optional_dependencies Eve::eve)
 endif()
 
+if(TARGET SVE::sve)
+  set(execution_optional_dependencies SVE::sve)
+endif()
+
 include(HPX_AddModule)
 add_hpx_module(
   core execution

--- a/libs/core/execution/include/hpx/execution/traits/detail/simd/vector_pack_alignment_size.hpp
+++ b/libs/core/execution/include/hpx/execution/traits/detail/simd/vector_pack_alignment_size.hpp
@@ -9,17 +9,18 @@
 
 #include <hpx/config.hpp>
 
-#if defined(HPX_HAVE_DATAPAR_STD_EXPERIMENTAL_SIMD)
+#if defined(HPX_HAVE_DATAPAR_EXPERIMENTAL_SIMD)
+
+#include <hpx/execution/traits/detail/simd/vector_pack_simd.hpp>
+
 #include <cstddef>
 #include <type_traits>
-
-#include <experimental/simd>
 
 ///////////////////////////////////////////////////////////////////////////////
 namespace hpx { namespace parallel { namespace traits {
     ///////////////////////////////////////////////////////////////////////////
     template <typename T>
-    struct is_vector_pack<std::experimental::native_simd<T>> : std::true_type
+    struct is_vector_pack<datapar::experimental::native_simd<T>> : std::true_type
     {
     };
 
@@ -30,7 +31,7 @@ namespace hpx { namespace parallel { namespace traits {
 
     ///////////////////////////////////////////////////////////////////////////
     template <typename T>
-    struct is_scalar_vector_pack<std::experimental::native_simd<T>>
+    struct is_scalar_vector_pack<datapar::experimental::native_simd<T>>
       : std::false_type
     {
     };
@@ -48,10 +49,10 @@ namespace hpx { namespace parallel { namespace traits {
     };
 
     template <typename T, typename Abi>
-    struct vector_pack_alignment<std::experimental::simd<T, Abi>>
+    struct vector_pack_alignment<datapar::experimental::simd<T, Abi>>
     {
-        static std::size_t const value = std::experimental::memory_alignment_v<
-            std::experimental::simd<T, Abi>>;
+        static std::size_t const value = datapar::experimental::memory_alignment_v<
+            datapar::experimental::simd<T, Abi>>;
     };
 
     ///////////////////////////////////////////////////////////////////////////
@@ -62,10 +63,10 @@ namespace hpx { namespace parallel { namespace traits {
     };
 
     template <typename T, typename Abi>
-    struct vector_pack_size<std::experimental::simd<T, Abi>>
+    struct vector_pack_size<datapar::experimental::simd<T, Abi>>
     {
         static std::size_t const value =
-            std::experimental::simd<T, Abi>::size();
+            datapar::experimental::simd<T, Abi>::size();
     };
 }}}    // namespace hpx::parallel::traits
 

--- a/libs/core/execution/include/hpx/execution/traits/detail/simd/vector_pack_alignment_size.hpp
+++ b/libs/core/execution/include/hpx/execution/traits/detail/simd/vector_pack_alignment_size.hpp
@@ -20,7 +20,8 @@
 namespace hpx { namespace parallel { namespace traits {
     ///////////////////////////////////////////////////////////////////////////
     template <typename T>
-    struct is_vector_pack<datapar::experimental::native_simd<T>> : std::true_type
+    struct is_vector_pack<datapar::experimental::native_simd<T>>
+      : std::true_type
     {
     };
 
@@ -51,8 +52,9 @@ namespace hpx { namespace parallel { namespace traits {
     template <typename T, typename Abi>
     struct vector_pack_alignment<datapar::experimental::simd<T, Abi>>
     {
-        static std::size_t const value = datapar::experimental::memory_alignment_v<
-            datapar::experimental::simd<T, Abi>>;
+        static std::size_t const value =
+            datapar::experimental::memory_alignment_v<
+                datapar::experimental::simd<T, Abi>>;
     };
 
     ///////////////////////////////////////////////////////////////////////////

--- a/libs/core/execution/include/hpx/execution/traits/detail/simd/vector_pack_all_any_none.hpp
+++ b/libs/core/execution/include/hpx/execution/traits/detail/simd/vector_pack_all_any_none.hpp
@@ -8,34 +8,35 @@
 
 #include <hpx/config.hpp>
 
-#if defined(HPX_HAVE_DATAPAR_STD_EXPERIMENTAL_SIMD)
-#include <cstddef>
+#if defined(HPX_HAVE_DATAPAR_EXPERIMENTAL_SIMD)
 
-#include <experimental/simd>
+#include <hpx/execution/traits/detail/simd/vector_pack_simd.hpp>
+
+#include <cstddef>
 
 namespace hpx { namespace parallel { namespace traits {
     ///////////////////////////////////////////////////////////////////////
     template <typename T, typename Abi>
     HPX_HOST_DEVICE HPX_FORCEINLINE std::size_t all_of(
-        std::experimental::simd_mask<T, Abi> const& msk)
+        datapar::experimental::simd_mask<T, Abi> const& msk)
     {
-        return std::experimental::all_of(msk);
+        return datapar::experimental::all_of(msk);
     }
 
     ///////////////////////////////////////////////////////////////////////
     template <typename T, typename Abi>
     HPX_HOST_DEVICE HPX_FORCEINLINE std::size_t any_of(
-        std::experimental::simd_mask<T, Abi> const& msk)
+        datapar::experimental::simd_mask<T, Abi> const& msk)
     {
-        return std::experimental::any_of(msk);
+        return datapar::experimental::any_of(msk);
     }
 
     ///////////////////////////////////////////////////////////////////////
     template <typename T, typename Abi>
     HPX_HOST_DEVICE HPX_FORCEINLINE std::size_t none_of(
-        std::experimental::simd_mask<T, Abi> const& msk)
+        datapar::experimental::simd_mask<T, Abi> const& msk)
     {
-        return std::experimental::none_of(msk);
+        return datapar::experimental::none_of(msk);
     }
 }}}    // namespace hpx::parallel::traits
 

--- a/libs/core/execution/include/hpx/execution/traits/detail/simd/vector_pack_conditionals.hpp
+++ b/libs/core/execution/include/hpx/execution/traits/detail/simd/vector_pack_conditionals.hpp
@@ -8,33 +8,31 @@
 
 #include <hpx/config.hpp>
 
-#if defined(HPX_HAVE_DATAPAR_STD_EXPERIMENTAL_SIMD)
-#include <cstddef>
+#if defined(HPX_HAVE_DATAPAR_EXPERIMENTAL_SIMD)
 
-#include <experimental/simd>
+#include <hpx/execution/traits/detail/simd/vector_pack_simd.hpp>
+
+#include <cstddef>
 
 namespace hpx { namespace parallel { namespace traits {
     ////////////////////////////////////////////////////////////////////
     template <typename T, typename Abi>
     HPX_HOST_DEVICE HPX_FORCEINLINE auto choose(
-        std::experimental::simd_mask<T, Abi> const& msk,
-        std::experimental::simd<T, Abi> const& v_true,
-        std::experimental::simd<T, Abi> const& v_false)
+        datapar::experimental::simd_mask<T, Abi> const& msk,
+        datapar::experimental::simd<T, Abi> const& v_true,
+        datapar::experimental::simd<T, Abi> const& v_false)
     {
-        std::experimental::simd<T, Abi> v;
-        where(msk, v) = v_true;
-        where(!msk, v) = v_false;
-        return v;
+        return datapar::experimental::choose(msk, v_true, v_false);
     }
 
     ////////////////////////////////////////////////////////////////////
     template <typename T, typename Abi>
     HPX_HOST_DEVICE HPX_FORCEINLINE void mask_assign(
-        std::experimental::simd_mask<T, Abi> const& msk,
-        std::experimental::simd<T, Abi>& v,
-        std::experimental::simd<T, Abi> const& val)
+        datapar::experimental::simd_mask<T, Abi> const& msk,
+        datapar::experimental::simd<T, Abi>& v,
+        datapar::experimental::simd<T, Abi> const& val)
     {
-        where(msk, v) = val;
+        datapar::experimental::mask_assign(msk, v, val);
     }
 }}}    // namespace hpx::parallel::traits
 

--- a/libs/core/execution/include/hpx/execution/traits/detail/simd/vector_pack_count_bits.hpp
+++ b/libs/core/execution/include/hpx/execution/traits/detail/simd/vector_pack_count_bits.hpp
@@ -9,18 +9,19 @@
 
 #include <hpx/config.hpp>
 
-#if defined(HPX_HAVE_DATAPAR_STD_EXPERIMENTAL_SIMD)
-#include <cstddef>
+#if defined(HPX_HAVE_DATAPAR_EXPERIMENTAL_SIMD)
 
-#include <experimental/simd>
+#include <hpx/execution/traits/detail/simd/vector_pack_simd.hpp>
+
+#include <cstddef>
 
 namespace hpx { namespace parallel { namespace traits {
     ///////////////////////////////////////////////////////////////////////
     template <typename T, typename Abi>
     HPX_HOST_DEVICE HPX_FORCEINLINE std::size_t count_bits(
-        std::experimental::simd_mask<T, Abi> const& mask)
+        datapar::experimental::simd_mask<T, Abi> const& mask)
     {
-        return std::experimental::popcount(mask);
+        return datapar::experimental::popcount(mask);
     }
 }}}    // namespace hpx::parallel::traits
 

--- a/libs/core/execution/include/hpx/execution/traits/detail/simd/vector_pack_find.hpp
+++ b/libs/core/execution/include/hpx/execution/traits/detail/simd/vector_pack_find.hpp
@@ -8,20 +8,21 @@
 
 #include <hpx/config.hpp>
 
-#if defined(HPX_HAVE_DATAPAR_STD_EXPERIMENTAL_SIMD)
-#include <cstddef>
+#if defined(HPX_HAVE_DATAPAR_EXPERIMENTAL_SIMD)
 
-#include <experimental/simd>
+#include <hpx/execution/traits/detail/simd/vector_pack_simd.hpp>
+
+#include <cstddef>
 
 namespace hpx { namespace parallel { namespace traits {
     ///////////////////////////////////////////////////////////////////////
     template <typename T, typename Abi>
     HPX_HOST_DEVICE HPX_FORCEINLINE int find_first_of(
-        std::experimental::simd_mask<T, Abi> const& msk)
+        datapar::experimental::simd_mask<T, Abi> const& msk)
     {
-        if (std::experimental::any_of(msk))
+        if (datapar::experimental::any_of(msk))
         {
-            return std::experimental::find_first_set(msk);
+            return datapar::experimental::find_first_set(msk);
         }
         return -1;
     }

--- a/libs/core/execution/include/hpx/execution/traits/detail/simd/vector_pack_get_set.hpp
+++ b/libs/core/execution/include/hpx/execution/traits/detail/simd/vector_pack_get_set.hpp
@@ -27,11 +27,7 @@ namespace hpx { namespace parallel { namespace traits {
     HPX_HOST_DEVICE HPX_FORCEINLINE auto set(
         Vector& vec, std::size_t index, T val)
     {
-#if defined(HPX_HAVE_DATAPAR_STD_EXPERIMENTAL_SIMD)
-        vec[index] = val;
-#elif defined(HPX_HAVE_DATAPAR_SVE)
-        vec.set(index, val);
-#endif
+        datapar::experimental::set(vec, index, val);
     }
 }}}    // namespace hpx::parallel::traits
 

--- a/libs/core/execution/include/hpx/execution/traits/detail/simd/vector_pack_get_set.hpp
+++ b/libs/core/execution/include/hpx/execution/traits/detail/simd/vector_pack_get_set.hpp
@@ -8,7 +8,10 @@
 
 #include <hpx/config.hpp>
 
-#if defined(HPX_HAVE_DATAPAR_STD_EXPERIMENTAL_SIMD)
+#if defined(HPX_HAVE_DATAPAR_EXPERIMENTAL_SIMD)
+
+#include <hpx/execution/traits/detail/simd/vector_pack_simd.hpp>
+
 #include <cstddef>
 
 namespace hpx { namespace parallel { namespace traits {
@@ -24,7 +27,11 @@ namespace hpx { namespace parallel { namespace traits {
     HPX_HOST_DEVICE HPX_FORCEINLINE auto set(
         Vector& vec, std::size_t index, T val)
     {
+#if defined(HPX_HAVE_DATAPAR_STD_EXPERIMENTAL_SIMD)
         vec[index] = val;
+#elif defined(HPX_HAVE_DATAPAR_SVE)
+        vec.set(index, val);
+#endif
     }
 }}}    // namespace hpx::parallel::traits
 

--- a/libs/core/execution/include/hpx/execution/traits/detail/simd/vector_pack_load_store.hpp
+++ b/libs/core/execution/include/hpx/execution/traits/detail/simd/vector_pack_load_store.hpp
@@ -28,7 +28,8 @@ namespace hpx { namespace parallel { namespace traits {
         template <typename Iter>
         HPX_HOST_DEVICE HPX_FORCEINLINE static V aligned(Iter const& iter)
         {
-            return V(std::addressof(*iter), datapar::experimental::vector_aligned);
+            return V(
+                std::addressof(*iter), datapar::experimental::vector_aligned);
         }
 
         template <typename Iter>

--- a/libs/core/execution/include/hpx/execution/traits/detail/simd/vector_pack_load_store.hpp
+++ b/libs/core/execution/include/hpx/execution/traits/detail/simd/vector_pack_load_store.hpp
@@ -9,12 +9,13 @@
 
 #include <hpx/config.hpp>
 
-#if defined(HPX_HAVE_DATAPAR_STD_EXPERIMENTAL_SIMD)
+#if defined(HPX_HAVE_DATAPAR_EXPERIMENTAL_SIMD)
+
+#include <hpx/execution/traits/detail/simd/vector_pack_simd.hpp>
+
 #include <cstddef>
 #include <iterator>
 #include <memory>
-
-#include <experimental/simd>
 
 ///////////////////////////////////////////////////////////////////////////////
 namespace hpx { namespace parallel { namespace traits {
@@ -27,7 +28,7 @@ namespace hpx { namespace parallel { namespace traits {
         template <typename Iter>
         HPX_HOST_DEVICE HPX_FORCEINLINE static V aligned(Iter const& iter)
         {
-            return V(std::addressof(*iter), std::experimental::vector_aligned);
+            return V(std::addressof(*iter), datapar::experimental::vector_aligned);
         }
 
         template <typename Iter>
@@ -46,7 +47,7 @@ namespace hpx { namespace parallel { namespace traits {
             V& value, Iter const& iter)
         {
             value.copy_to(
-                std::addressof(*iter), std::experimental::vector_aligned);
+                std::addressof(*iter), datapar::experimental::vector_aligned);
         }
 
         template <typename Iter>

--- a/libs/core/execution/include/hpx/execution/traits/detail/simd/vector_pack_reduce.hpp
+++ b/libs/core/execution/include/hpx/execution/traits/detail/simd/vector_pack_reduce.hpp
@@ -8,18 +8,19 @@
 
 #include <hpx/config.hpp>
 
-#if defined(HPX_HAVE_DATAPAR_STD_EXPERIMENTAL_SIMD)
-#include <cstddef>
+#if defined(HPX_HAVE_DATAPAR_EXPERIMENTAL_SIMD)
 
-#include <experimental/simd>
+#include <hpx/execution/traits/detail/simd/vector_pack_simd.hpp>
+
+#include <cstddef>
 
 namespace hpx { namespace parallel { namespace traits {
     ///////////////////////////////////////////////////////////////////////
     template <typename T, typename Abi, typename Reduce>
     HPX_HOST_DEVICE HPX_FORCEINLINE T reduce(
-        Reduce r, std::experimental::simd<T, Abi> const& val)
+        Reduce r, datapar::experimental::simd<T, Abi> const& val)
     {
-        return std::experimental::reduce(val, r);
+        return datapar::experimental::reduce(val, r);
     }
 }}}    // namespace hpx::parallel::traits
 

--- a/libs/core/execution/include/hpx/execution/traits/detail/simd/vector_pack_simd.hpp
+++ b/libs/core/execution/include/hpx/execution/traits/detail/simd/vector_pack_simd.hpp
@@ -1,0 +1,82 @@
+//  Copyright (c) 2022 Srinivas Yadav
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include <hpx/config.hpp>
+
+#if defined(HPX_HAVE_DATAPAR_EXPERIMENTAL_SIMD)
+
+#if defined(HPX_HAVE_DATAPAR_STD_EXPERIMENTAL_SIMD)
+#include <experimental/simd>
+
+namespace hpx { namespace datapar { namespace experimental {
+
+    using std::experimental::simd;
+    using std::experimental::native_simd;
+    using std::experimental::simd_mask;
+    using std::experimental::fixed_size_simd;
+    using std::experimental::is_simd_v;
+
+    using std::experimental::simd_abi::native;
+
+    using std::experimental::memory_alignment_v;
+    using std::experimental::vector_aligned;
+
+    using std::experimental::all_of;
+    using std::experimental::any_of;
+    using std::experimental::none_of;
+    using std::experimental::find_first_set;
+    using std::experimental::popcount;
+    using std::experimental::reduce;
+
+    template <typename T, typename Abi>
+    HPX_HOST_DEVICE HPX_FORCEINLINE auto choose(
+        std::experimental::simd_mask<T, Abi> const& msk,
+        std::experimental::simd<T, Abi> const& v_true,
+        std::experimental::simd<T, Abi> const& v_false)
+    {
+        std::experimental::simd<T, Abi> v;
+        where(msk, v) = v_true;
+        where(!msk, v) = v_false;
+        return v;
+    }
+
+    template <typename T, typename Abi>
+    HPX_HOST_DEVICE HPX_FORCEINLINE void mask_assign(
+        std::experimental::simd_mask<T, Abi> const& msk,
+        std::experimental::simd<T, Abi>& v,
+        std::experimental::simd<T, Abi> const& val)
+    {
+        where(msk, v) = val;
+    }
+
+    template <typename Vector, typename T>
+    HPX_HOST_DEVICE HPX_FORCEINLINE auto set(
+        Vector& vec, std::size_t index, T val)
+    {
+        vec[index] = val;
+    }
+}}}
+#endif
+
+#if defined(HPX_HAVE_DATAPAR_SVE)
+#include <sve/sve.hpp>
+namespace hpx { namespace datapar { namespace experimental {
+
+    using namespace sve::experimental;
+    using simd_abi::native;
+
+    template <typename Vector, typename T>
+    HPX_HOST_DEVICE HPX_FORCEINLINE auto set(
+        Vector& vec, std::size_t index, T val)
+    {
+        vec.set(index, val);
+    }
+}}}
+#endif
+
+#endif

--- a/libs/core/execution/include/hpx/execution/traits/detail/simd/vector_pack_simd.hpp
+++ b/libs/core/execution/include/hpx/execution/traits/detail/simd/vector_pack_simd.hpp
@@ -10,6 +10,8 @@
 
 #if defined(HPX_HAVE_DATAPAR_EXPERIMENTAL_SIMD)
 
+#include <cstddef>
+
 #if defined(HPX_HAVE_DATAPAR_STD_EXPERIMENTAL_SIMD)
 #include <experimental/simd>
 

--- a/libs/core/execution/include/hpx/execution/traits/detail/simd/vector_pack_simd.hpp
+++ b/libs/core/execution/include/hpx/execution/traits/detail/simd/vector_pack_simd.hpp
@@ -15,11 +15,11 @@
 
 namespace hpx { namespace datapar { namespace experimental {
 
-    using std::experimental::simd;
-    using std::experimental::native_simd;
-    using std::experimental::simd_mask;
     using std::experimental::fixed_size_simd;
     using std::experimental::is_simd_v;
+    using std::experimental::native_simd;
+    using std::experimental::simd;
+    using std::experimental::simd_mask;
 
     using std::experimental::simd_abi::native;
 
@@ -28,8 +28,8 @@ namespace hpx { namespace datapar { namespace experimental {
 
     using std::experimental::all_of;
     using std::experimental::any_of;
-    using std::experimental::none_of;
     using std::experimental::find_first_set;
+    using std::experimental::none_of;
     using std::experimental::popcount;
     using std::experimental::reduce;
 
@@ -60,7 +60,7 @@ namespace hpx { namespace datapar { namespace experimental {
     {
         vec[index] = val;
     }
-}}}
+}}}    // namespace hpx::datapar::experimental
 #endif
 
 #if defined(HPX_HAVE_DATAPAR_SVE)
@@ -76,7 +76,7 @@ namespace hpx { namespace datapar { namespace experimental {
     {
         vec.set(index, val);
     }
-}}}
+}}}    // namespace hpx::datapar::experimental
 #endif
 
 #endif

--- a/libs/core/execution/include/hpx/execution/traits/detail/simd/vector_pack_type.hpp
+++ b/libs/core/execution/include/hpx/execution/traits/detail/simd/vector_pack_type.hpp
@@ -9,9 +9,9 @@
 
 #include <hpx/config.hpp>
 
-#if defined(HPX_HAVE_DATAPAR_STD_EXPERIMENTAL_SIMD)
+#if defined(HPX_HAVE_DATAPAR_EXPERIMENTAL_SIMD)
 
-#include <experimental/simd>
+#include <hpx/execution/traits/detail/simd/vector_pack_simd.hpp>
 
 #include <cstddef>
 #include <type_traits>
@@ -23,16 +23,16 @@ namespace hpx { namespace parallel { namespace traits {
         template <typename T, std::size_t N, typename Abi>
         struct vector_pack_type
         {
-            typedef std::experimental::fixed_size_simd<T, N> type;
+            typedef datapar::experimental::fixed_size_simd<T, N> type;
         };
 
         template <typename T, typename Abi>
         struct vector_pack_type<T, 0, Abi>
         {
             typedef typename std::conditional<std::is_void<Abi>::value,
-                std::experimental::simd_abi::native<T>, Abi>::type abi_type;
+                datapar::experimental::native<T>, Abi>::type abi_type;
 
-            typedef std::experimental::simd<T, abi_type> type;
+            typedef datapar::experimental::simd<T, abi_type> type;
         };
 
         template <typename T, typename Abi>
@@ -51,7 +51,7 @@ namespace hpx { namespace parallel { namespace traits {
     ////////////////////////////////////////////////////////////////////
     template <typename T>
     struct vector_pack_mask_type<T,
-        typename std::enable_if_t<std::experimental::is_simd_v<T>>>
+        typename std::enable_if_t<datapar::experimental::is_simd_v<T>>>
     {
         using type = T::mask_type;
     };

--- a/libs/core/execution/include/hpx/execution/traits/detail/simd/vector_pack_type.hpp
+++ b/libs/core/execution/include/hpx/execution/traits/detail/simd/vector_pack_type.hpp
@@ -23,16 +23,16 @@ namespace hpx { namespace parallel { namespace traits {
         template <typename T, std::size_t N, typename Abi>
         struct vector_pack_type
         {
-            typedef datapar::experimental::fixed_size_simd<T, N> type;
+            using type = typename datapar::experimental::fixed_size_simd<T, N>;
         };
 
         template <typename T, typename Abi>
         struct vector_pack_type<T, 0, Abi>
         {
-            typedef typename std::conditional<std::is_void<Abi>::value,
-                datapar::experimental::native<T>, Abi>::type abi_type;
+            using abi_type = std::conditional_t<std::is_void_v<Abi>,
+                datapar::experimental::native<T>, Abi>;
 
-            typedef datapar::experimental::simd<T, abi_type> type;
+            using type = typename datapar::experimental::simd<T, abi_type>;
         };
 
         template <typename T, typename Abi>
@@ -51,7 +51,7 @@ namespace hpx { namespace parallel { namespace traits {
     ////////////////////////////////////////////////////////////////////
     template <typename T>
     struct vector_pack_mask_type<T,
-        typename std::enable_if_t<datapar::experimental::is_simd_v<T>>>
+        std::enable_if_t<datapar::experimental::is_simd_v<T>>>
     {
         using type = T::mask_type;
     };

--- a/libs/core/functional/tests/regressions/is_callable_1179.cpp
+++ b/libs/core/functional/tests/regressions/is_callable_1179.cpp
@@ -29,8 +29,8 @@ struct p
 ///////////////////////////////////////////////////////////////////////////////
 int main()
 {
-    using hpx::is_invocable_v;
     using hpx::invoke;
+    using hpx::is_invocable_v;
 
     typedef int (s::*mem_fun_ptr)();
     HPX_TEST_MSG((is_invocable_v<mem_fun_ptr, p> == false), "mem-fun-ptr");


### PR DESCRIPTION
## Proposed Changes

  - Adds cmake integration for SVE through `find_package(sve)` and `cmake_fetch_content`. 
  - Adds a common namespace and header to use existing vector_pack traits. 
