### PR TITLE
Clean up command line handling

### DIFF
--- a/examples/quickstart/CMakeLists.txt
+++ b/examples/quickstart/CMakeLists.txt
@@ -15,6 +15,7 @@ set(example_programs
     fibonacci_futures
     fibonacci_local
     file_serialization
+    hello_world_3
     latch_local
     local_channel_docs
     local_channel

--- a/examples/quickstart/hello_world_3.cpp
+++ b/examples/quickstart/hello_world_3.cpp
@@ -1,0 +1,27 @@
+//  Copyright (c) 2007-2022 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+///////////////////////////////////////////////////////////////////////////////
+// The purpose of this example is to initialize the _local_ HPX runtime
+// explicitly and execute a HPX-thread printing "Hello World!" once. That's all.
+
+//[hello_world_3_getting_started
+#include <hpx/local/init.hpp>
+
+#include <iostream>
+
+int hpx_main(int, char**)
+{
+    // Say hello to the world!
+    std::cout << "Hello World!\n" << std::flush;
+    return hpx::local::finalize();
+}
+
+int main(int argc, char* argv[])
+{
+    return hpx::local::init(&hpx_main, argc, argv);
+}
+//]

--- a/libs/core/command_line_handling_local/include/hpx/command_line_handling_local/command_line_handling_local.hpp
+++ b/libs/core/command_line_handling_local/include/hpx/command_line_handling_local/command_line_handling_local.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2012 Hartmut Kaiser
+//  Copyright (c) 2007-2022 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -18,8 +18,12 @@
 #include <utility>
 #include <vector>
 
+#include <hpx/config/warnings_prefix.hpp>
+
 namespace hpx { namespace local { namespace detail {
-    struct command_line_handling
+
+    ///////////////////////////////////////////////////////////////////////////
+    struct HPX_CORE_EXPORT command_line_handling
     {
         command_line_handling(hpx::util::runtime_configuration rtcfg,
             std::vector<std::string> ini_config,
@@ -86,5 +90,40 @@ namespace hpx { namespace local { namespace detail {
 
         std::vector<std::string> preprocess_config_settings(
             int argc, char** argv);
+
+        int finalize_commandline_handling(int argc, char** argv,
+            hpx::program_options::options_description const& help,
+            std::vector<std::string> const& unregistered_options);
+
+        void reconfigure(util::manage_config& cfgmap,
+            hpx::program_options::variables_map& prevm);
+
+        void handle_high_priority_threads(
+            hpx::program_options::variables_map& vm,
+            std::vector<std::string>& ini_config);
     };
+
+    ///////////////////////////////////////////////////////////////////////////
+    HPX_CORE_EXPORT std::string runtime_configuration_string(
+        command_line_handling const& cfg);
+
+    HPX_CORE_EXPORT std::vector<std::string> prepend_options(
+        std::vector<std::string>&& args, std::string&& options);
+
+    HPX_CORE_EXPORT std::string convert_to_log_file(std::string const& dest);
+
+    HPX_CORE_EXPORT std::size_t handle_num_cores(util::manage_config& cfgmap,
+        hpx::program_options::variables_map& vm, std::size_t num_threads,
+        std::size_t num_default_cores);
+
+    HPX_CORE_EXPORT std::size_t get_number_of_default_threads(
+        bool use_process_mask);
+    HPX_CORE_EXPORT std::size_t get_number_of_default_cores(
+        bool use_process_mask);
+
+    HPX_CORE_EXPORT void print_config(
+        std::vector<std::string> const& ini_config);
+
 }}}    // namespace hpx::local::detail
+
+#include <hpx/config/warnings_suffix.hpp>

--- a/libs/core/command_line_handling_local/include/hpx/command_line_handling_local/late_command_line_handling_local.hpp
+++ b/libs/core/command_line_handling_local/include/hpx/command_line_handling_local/late_command_line_handling_local.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2021 Hartmut Kaiser
+//  Copyright (c) 2021-2022 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -11,10 +11,26 @@
 #include <hpx/modules/runtime_configuration.hpp>
 
 #include <cstddef>
+#include <string>
+#include <vector>
 
 namespace hpx { namespace local { namespace detail {
+
     HPX_CORE_EXPORT int handle_late_commandline_options(
         util::runtime_configuration& ini,
         hpx::program_options::options_description const& options,
         void (*handle_print_bind)(std::size_t));
+
+    HPX_CORE_EXPORT void set_unknown_commandline_options(
+        util::runtime_configuration& ini,
+        std::vector<std::string> const& still_unregistered_options);
+
+    HPX_CORE_EXPORT bool handle_full_help(util::runtime_configuration& ini,
+        hpx::program_options::options_description const& options);
+    HPX_CORE_EXPORT bool handle_late_options(util::runtime_configuration& ini,
+        hpx::program_options::variables_map& vm,
+        void (*handle_print_bind)(std::size_t));
+
+    HPX_CORE_EXPORT std::string get_full_commandline(
+        util::runtime_configuration& ini);
 }}}    // namespace hpx::local::detail

--- a/libs/core/command_line_handling_local/include/hpx/command_line_handling_local/parse_command_line_local.hpp
+++ b/libs/core/command_line_handling_local/include/hpx/command_line_handling_local/parse_command_line_local.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2016 Hartmut Kaiser
+//  Copyright (c) 2007-2022 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -12,7 +12,9 @@
 #include <hpx/modules/program_options.hpp>
 
 #include <cstddef>
+#include <map>
 #include <string>
+#include <utility>
 #include <vector>
 
 namespace hpx {
@@ -27,6 +29,7 @@ namespace hpx {
         };
 
         namespace detail {
+            ///////////////////////////////////////////////////////////////////
             inline std::string enquote(std::string const& arg)
             {
                 if (arg.find_first_of(" \t\"") != std::string::npos)
@@ -37,6 +40,58 @@ namespace hpx {
     }        // namespace util
 
     namespace local { namespace detail {
+
+        HPX_CORE_EXPORT std::string trim_whitespace(std::string const& s);
+
+        struct HPX_CORE_EXPORT option_parser
+        {
+            option_parser(util::section const& ini, bool ignore_aliases);
+
+            std::pair<std::string, std::string> operator()(
+                std::string const& s) const;
+
+            util::section const& ini_;
+            bool ignore_aliases_;
+        };
+
+        HPX_CORE_EXPORT hpx::program_options::basic_command_line_parser<char>&
+        get_commandline_parser(
+            hpx::program_options::basic_command_line_parser<char>& p, int mode);
+
+        HPX_CORE_EXPORT std::vector<std::string> read_config_file_options(
+            std::string const& filename, int error_mode);
+
+        enum class options_type
+        {
+            commandline_options,
+            hpx_options,
+            hidden_options,
+            config_options,
+            debugging_options,
+            counter_options,
+            desc_cfgfile,
+            desc_cmdline
+        };
+
+        using options_map =
+            std::map<options_type, hpx::program_options::options_description>;
+
+        HPX_CORE_EXPORT options_map compose_local_options();
+        HPX_CORE_EXPORT void compose_all_options(
+            hpx::program_options::options_description const& app_options,
+            options_map& all_options);
+
+        HPX_CORE_EXPORT std::string reconstruct_command_line(
+            hpx::program_options::variables_map const& vm);
+
+        HPX_CORE_EXPORT bool parse_commandline(util::section const& rtcfg,
+            options_map& all_options,
+            hpx::program_options::options_description const& app_options,
+            std::vector<std::string> const& args,
+            hpx::program_options::variables_map& vm, int error_mode,
+            hpx::program_options::options_description* visible,
+            std::vector<std::string>* unregistered_options);
+
         HPX_CORE_EXPORT bool parse_commandline(hpx::util::section const& rtcfg,
             hpx::program_options::options_description const& app_options,
             std::string const& cmdline, hpx::program_options::variables_map& vm,

--- a/libs/core/init_runtime_local/include/hpx/init_runtime_local/init_runtime_local.hpp
+++ b/libs/core/init_runtime_local/include/hpx/init_runtime_local/init_runtime_local.hpp
@@ -1,6 +1,6 @@
 //  Copyright (c)      2021 ETH Zurich
 //  Copyright (c)      2018 Mikael Simberg
-//  Copyright (c) 2007-2016 Hartmut Kaiser
+//  Copyright (c) 2007-2022 Hartmut Kaiser
 //  Copyright (c) 2010-2011 Phillip LeBlanc, Dylan Stark
 //  Copyright (c)      2011 Bryce Lelbach
 //
@@ -23,6 +23,7 @@
 
 #include <csignal>
 #include <cstddef>
+#include <cstring>
 #include <functional>
 #include <iostream>
 #include <memory>
@@ -79,14 +80,14 @@ namespace hpx {
 
             // Default params to initialize the init_params struct
             HPX_MAYBE_UNUSED static int dummy_argc = 1;
-            HPX_MAYBE_UNUSED static char app_name[] = HPX_APPLICATION_STRING;
+            HPX_MAYBE_UNUSED static char app_name[256] = HPX_APPLICATION_STRING;
             static char* default_argv[2] = {app_name, nullptr};
             HPX_MAYBE_UNUSED static char** dummy_argv = default_argv;
 
             // HPX_APPLICATION_STRING is specific to an application and therefore
             // cannot be in the source file
             HPX_CORE_EXPORT hpx::program_options::options_description const&
-            default_desc();
+            default_desc(char const*);
 
             // Utilities to init the thread_pools of the resource partitioner
             using rp_callback_type =
@@ -96,9 +97,15 @@ namespace hpx {
 
         struct init_params
         {
+            init_params()
+            {
+                std::strncpy(detail::app_name, HPX_APPLICATION_STRING,
+                    sizeof(detail::app_name) - 1);
+            }
+
             std::reference_wrapper<
                 hpx::program_options::options_description const>
-                desc_cmdline = detail::default_desc();
+                desc_cmdline = detail::default_desc(HPX_APPLICATION_STRING);
             std::vector<std::string> cfg;
             mutable startup_function_type startup;
             mutable shutdown_function_type shutdown;

--- a/libs/core/init_runtime_local/src/init_runtime_local.cpp
+++ b/libs/core/init_runtime_local/src/init_runtime_local.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2021 Hartmut Kaiser
+//  Copyright (c) 2007-2022 Hartmut Kaiser
 //  Copyright (c)      2017 Shoshana Jakobovits
 //  Copyright (c) 2010-2011 Phillip LeBlanc, Dylan Stark
 //  Copyright (c)      2011 Bryce Lelbach
@@ -529,10 +529,11 @@ namespace hpx {
                 return result;
             }
 
-            hpx::program_options::options_description const& default_desc()
+            hpx::program_options::options_description const& default_desc(
+                char const* desc)
             {
                 static hpx::program_options::options_description default_desc_(
-                    std::string("Usage: ") + app_name + " [options]");
+                    std::string("Usage: ") + desc + " [options]");
                 return default_desc_;
             }
         }    // namespace detail

--- a/libs/full/command_line_handling/include/hpx/command_line_handling/command_line_handling.hpp
+++ b/libs/full/command_line_handling/include/hpx/command_line_handling/command_line_handling.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2012 Hartmut Kaiser
+//  Copyright (c) 2007-2022 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -8,6 +8,7 @@
 
 #include <hpx/config.hpp>
 #include <hpx/functional/function.hpp>
+#include <hpx/modules/command_line_handling_local.hpp>
 #include <hpx/modules/program_options.hpp>
 #include <hpx/modules/runtime_configuration.hpp>
 #include <hpx/modules/util.hpp>
@@ -25,25 +26,17 @@ namespace hpx { namespace util {
 
     ///////////////////////////////////////////////////////////////////////////
     struct HPX_EXPORT command_line_handling
+      : hpx::local::detail::command_line_handling
     {
+        using base_type = hpx::local::detail::command_line_handling;
+
         command_line_handling(runtime_configuration rtcfg,
             std::vector<std::string> ini_config,
             hpx::function<int(hpx::program_options::variables_map& vm)>
                 hpx_main_f)
-          : rtcfg_(rtcfg)
-          , ini_config_(ini_config)
-          , hpx_main_f_(hpx_main_f)
+          : base_type(rtcfg, HPX_MOVE(ini_config), HPX_MOVE(hpx_main_f))
           , node_(std::size_t(-1))
-          , num_threads_(1)
-          , num_cores_(1)
           , num_localities_(1)
-          , pu_step_(1)
-          , pu_offset_(std::size_t(-1))
-          , numa_sensitive_(0)
-          , use_process_mask_(false)
-          , cmd_line_parsed_(false)
-          , info_printed_(false)
-          , version_printed_(false)
         {
         }
 
@@ -52,34 +45,10 @@ namespace hpx { namespace util {
             std::vector<std::shared_ptr<components::component_registry_base>>&
                 component_registries);
 
-        hpx::program_options::variables_map vm_;
-        util::runtime_configuration rtcfg_;
-
-        std::vector<std::string> ini_config_;
-        hpx::function<int(hpx::program_options::variables_map& vm)> hpx_main_f_;
-
         std::size_t node_;
-        std::size_t num_threads_;
-        std::size_t num_cores_;
         std::size_t num_localities_;
-        std::size_t pu_step_;
-        std::size_t pu_offset_;
-        std::string queuing_;
-        std::string affinity_domain_;
-        std::string affinity_bind_;
-        std::size_t numa_sensitive_;
-        bool use_process_mask_;
-        bool cmd_line_parsed_;
-        bool info_printed_;
-        bool version_printed_;
 
     protected:
-        // Helper functions for checking command line options
-        void check_affinity_domain() const;
-        void check_affinity_description() const;
-        void check_pu_offset() const;
-        void check_pu_step() const;
-
         bool handle_arguments(util::manage_config& cfgmap,
             hpx::program_options::variables_map& vm,
             std::vector<std::string>& ini_config, std::size_t& node,
@@ -87,17 +56,6 @@ namespace hpx { namespace util {
 
         void enable_logging_settings(hpx::program_options::variables_map& vm,
             std::vector<std::string>& ini_config);
-
-        void store_command_line(int argc, char** argv);
-        void store_unregistered_options(std::string const& cmd_name,
-            std::vector<std::string> const& unregistered_options);
-        bool handle_help_options(
-            hpx::program_options::options_description const& help);
-
-        void handle_attach_debugger();
-
-        std::vector<std::string> preprocess_config_settings(
-            int argc, char** argv);
     };
 }}    // namespace hpx::util
 

--- a/libs/full/command_line_handling/src/command_line_handling.cpp
+++ b/libs/full/command_line_handling/src/command_line_handling.cpp
@@ -43,7 +43,10 @@
 #include <vector>
 
 namespace hpx { namespace util {
+
     namespace detail {
+
+        ///////////////////////////////////////////////////////////////////////
         std::string runtime_configuration_string(
             util::command_line_handling const& cfg)
         {
@@ -56,58 +59,9 @@ namespace hpx { namespace util {
             if (cfg.num_localities_ != 1)
                 strm << "  {localities}: " << cfg.num_localities_ << "\n";
 
-            // default scheduler used for this run
-            strm << "  {scheduler}: " << cfg.queuing_ << "\n";
-
-            // amount of threads and cores configured for this run
-            strm << "  {os-threads}: " << cfg.num_threads_ << "\n";
-            strm << "  {cores}: " << cfg.num_cores_ << "\n";
+            strm << hpx::local::detail::runtime_configuration_string(cfg);
 
             return strm.str();
-        }
-
-        ///////////////////////////////////////////////////////////////////////
-        int print_version(std::ostream& out)
-        {
-            out << std::endl << hpx::copyright() << std::endl;
-            out << hpx::complete_version() << std::endl;
-            return 1;
-        }
-
-        int print_info(
-            std::ostream& out, util::command_line_handling const& cfg)
-        {
-            out << "Static configuration:\n---------------------\n";
-            out << hpx::configuration_string() << std::endl;
-
-            out << "Runtime configuration:\n----------------------\n";
-            out << runtime_configuration_string(cfg) << std::endl;
-
-            return 1;
-        }
-
-        ///////////////////////////////////////////////////////////////////////
-        inline void encode(
-            std::string& str, char s, char const* r, std::size_t inc = 1ull)
-        {
-            std::string::size_type pos = 0;
-            while ((pos = str.find_first_of(s, pos)) != std::string::npos)
-            {
-                str.replace(pos, 1, r);
-                pos += inc;
-            }
-        }
-
-        inline std::string encode_string(std::string str)
-        {
-            encode(str, '\n', "\\n");
-            return str;
-        }
-
-        inline std::string encode_and_enquote(std::string str)
-        {
-            encode(str, '\"', "\\\"", 2);
-            return detail::enquote(HPX_MOVE(str));
         }
 
         ///////////////////////////////////////////////////////////////////////
@@ -149,21 +103,6 @@ namespace hpx { namespace util {
                       << " (" << cmdline_localities
                       << "), the application might not run properly."
                       << std::endl;
-        }
-
-        std::string convert_to_log_file(std::string const& dest)
-        {
-            if (dest.empty())
-                return "cout";
-
-            if (dest == "cout" || dest == "cerr" || dest == "console")
-                return dest;
-#if defined(ANDROID) || defined(__ANDROID__)
-            if (dest == "android_log")
-                return dest;
-#endif
-            // everything else is assumed to be a file name
-            return "file(" + dest + ")";
         }
 
         ///////////////////////////////////////////////////////////////////////
@@ -220,152 +159,33 @@ namespace hpx { namespace util {
             return num_localities;
         }
 
-        std::string handle_queuing(util::manage_config& cfgmap,
-            hpx::program_options::variables_map& vm,
-            std::string const& default_)
-        {
-            // command line options is used preferred
-            if (vm.count("hpx:queuing"))
-                return vm["hpx:queuing"].as<std::string>();
-
-            // use either cfgmap value or default
-            return cfgmap.get_value<std::string>("hpx.scheduler", default_);
-        }
-
-        std::string handle_affinity(util::manage_config& cfgmap,
-            hpx::program_options::variables_map& vm,
-            std::string const& default_)
-        {
-            // command line options is used preferred
-            if (vm.count("hpx:affinity"))
-                return vm["hpx:affinity"].as<std::string>();
-
-            // use either cfgmap value or default
-            return cfgmap.get_value<std::string>("hpx.affinity", default_);
-        }
-
-        std::string handle_affinity_bind(util::manage_config& cfgmap,
-            hpx::program_options::variables_map& vm,
-            std::string const& default_)
-        {
-            // command line options is used preferred
-            if (vm.count("hpx:bind"))
-            {
-                std::string affinity_desc;
-
-                std::vector<std::string> bind_affinity =
-                    vm["hpx:bind"].as<std::vector<std::string>>();
-                for (std::string const& s : bind_affinity)
-                {
-                    if (!affinity_desc.empty())
-                        affinity_desc += ";";
-                    affinity_desc += s;
-                }
-
-                return affinity_desc;
-            }
-
-            // use either cfgmap value or default
-            return cfgmap.get_value<std::string>("hpx.bind", default_);
-        }
-
-        std::size_t handle_pu_step(util::manage_config& cfgmap,
-            hpx::program_options::variables_map& vm, std::size_t default_)
-        {
-            // command line options is used preferred
-            if (vm.count("hpx:pu-step"))
-                return vm["hpx:pu-step"].as<std::size_t>();
-
-            // use either cfgmap value or default
-            return cfgmap.get_value<std::size_t>("hpx.pu_step", default_);
-        }
-
-        std::size_t handle_pu_offset(util::manage_config& cfgmap,
-            hpx::program_options::variables_map& vm, std::size_t default_)
-        {
-            // command line options is used preferred
-            if (vm.count("hpx:pu-offset"))
-                return vm["hpx:pu-offset"].as<std::size_t>();
-
-            // use either cfgmap value or default
-            return cfgmap.get_value<std::size_t>("hpx.pu_offset", default_);
-        }
-
-        std::size_t handle_numa_sensitive(util::manage_config& cfgmap,
-            hpx::program_options::variables_map& vm, std::size_t default_)
-        {
-            if (vm.count("hpx:numa-sensitive") != 0)
-            {
-                std::size_t numa_sensitive =
-                    vm["hpx:numa-sensitive"].as<std::size_t>();
-                if (numa_sensitive > 2)
-                {
-                    throw hpx::detail::command_line_error(
-                        "Invalid argument "
-                        "value for --hpx:numa-sensitive. Allowed values are "
-                        "0, 1, or 2");
-                }
-                return numa_sensitive;
-            }
-
-            // use either cfgmap value or default
-            return cfgmap.get_value<std::size_t>(
-                "hpx.numa_sensitive", default_);
-        }
-
         ///////////////////////////////////////////////////////////////////////
-        std::size_t get_number_of_default_threads(bool use_process_mask)
-        {
-            if (use_process_mask)
-            {
-                threads::topology& top = threads::create_topology();
-                return threads::count(top.get_cpubind_mask());
-            }
-            else
-            {
-                return threads::hardware_concurrency();
-            }
-        }
-
         std::size_t get_number_of_default_cores(
             util::batch_environment& env, bool use_process_mask)
         {
-            threads::topology& top = threads::create_topology();
-
-            std::size_t batch_threads = env.retrieve_number_of_threads();
-            std::size_t num_cores = top.get_number_of_cores();
-
+            std::size_t num_cores =
+                hpx::local::detail::get_number_of_default_cores(
+                    use_process_mask);
             if (use_process_mask)
             {
-                threads::mask_type proc_mask = top.get_cpubind_mask();
-                std::size_t num_cores_proc_mask = 0;
-
-                for (std::size_t num_core = 0; num_core < num_cores; ++num_core)
-                {
-                    threads::mask_type core_mask =
-                        top.init_core_affinity_mask_from_core(num_core);
-                    if (threads::bit_and(core_mask, proc_mask))
-                    {
-                        ++num_cores_proc_mask;
-                    }
-                }
-
-                // Using the process mask implies no batch environment
-                return num_cores_proc_mask;
+                return num_cores;
             }
 
+            std::size_t batch_threads = env.retrieve_number_of_threads();
             if (batch_threads == std::size_t(-1))
+            {
                 return num_cores;
+            }
 
             // assuming we assign the first N cores ...
+            threads::topology& top = threads::create_topology();
             std::size_t core = 0;
-            for (; core < num_cores; ++core)
+            for (/**/; core < num_cores; ++core)
             {
                 batch_threads -= top.get_number_of_core_pus(core);
                 if (batch_threads == 0)
                     break;
             }
-
             return core + 1;
         }
 
@@ -376,13 +196,14 @@ namespace hpx { namespace util {
             util::batch_environment& env, bool using_nodelist, bool initial,
             bool use_process_mask)
         {
-            // If using the process mask we override "cores" and "all" options but
-            // keep explicit numeric values.
-            const std::size_t init_threads =
-                get_number_of_default_threads(use_process_mask);
-            const std::size_t init_cores =
-                get_number_of_default_cores(env, use_process_mask);
-            const std::size_t batch_threads = env.retrieve_number_of_threads();
+            // If using the process mask we override "cores" and "all" options
+            // but keep explicit numeric values.
+            std::size_t const init_threads =
+                hpx::local::detail::get_number_of_default_threads(
+                    use_process_mask);
+            std::size_t const init_cores =
+                detail::get_number_of_default_cores(env, use_process_mask);
+            std::size_t const batch_threads = env.retrieve_number_of_threads();
 
             std::string threads_str =
                 cfgmap.get_value<std::string>("hpx.os_threads",
@@ -475,9 +296,9 @@ namespace hpx { namespace util {
             {
                 throw hpx::detail::command_line_error(
                     "Requested more than " HPX_PP_STRINGIZE(
-                        HPX_HAVE_MAX_CPU_COUNT) " hpx.force_min_os_threads "
-                                                "to use for this application, "
-                                                "use the option "
+                        HPX_HAVE_MAX_CPU_COUNT) " hpx.force_min_os_threads to "
+                                                "use for this application, use "
+                                                "the option "
                                                 "-DHPX_WITH_MAX_CPU_COUNT=<N> "
                                                 "when configuring HPX.");
             }
@@ -492,37 +313,6 @@ namespace hpx { namespace util {
                     env.get_batch_name(), threads, batch_threads);
             }
             return threads;
-        }
-
-        std::size_t handle_num_cores(util::manage_config& cfgmap,
-            hpx::program_options::variables_map& vm, std::size_t num_threads,
-            util::batch_environment& env, bool use_process_mask)
-        {
-            std::string cores_str =
-                cfgmap.get_value<std::string>("hpx.cores", "");
-            if ("all" == cores_str)
-            {
-                cfgmap.config_["hpx.cores"] = std::to_string(
-                    get_number_of_default_cores(env, use_process_mask));
-            }
-
-            std::size_t num_cores =
-                cfgmap.get_value<std::size_t>("hpx.cores", num_threads);
-            if (vm.count("hpx:cores"))
-            {
-                cores_str = vm["hpx:cores"].as<std::string>();
-                if ("all" == cores_str)
-                {
-                    num_cores =
-                        get_number_of_default_cores(env, use_process_mask);
-                }
-                else
-                {
-                    num_cores = hpx::util::from_string<std::size_t>(cores_str);
-                }
-            }
-
-            return num_cores;
         }
 
         ///////////////////////////////////////////////////////////////////////
@@ -540,7 +330,8 @@ namespace hpx { namespace util {
         }
 #endif
 
-        void check_networking_options(hpx::program_options::variables_map& vm)
+        void check_networking_options(
+            [[maybe_unused]] hpx::program_options::variables_map& vm)
         {
 #if !defined(HPX_HAVE_NETWORKING)
             check_networking_option(vm, "hpx:agas");
@@ -555,90 +346,23 @@ namespace hpx { namespace util {
             check_networking_option(vm, "hpx:localities");
             check_networking_option(vm, "hpx:node");
             check_networking_option(vm, "hpx:expect-connecting-localities");
-#else
-            HPX_UNUSED(vm);
 #endif
         }
     }    // namespace detail
-
-    ///////////////////////////////////////////////////////////////////////
-    void command_line_handling::check_affinity_domain() const
-    {
-        if (affinity_domain_ != "pu")
-        {
-            if (0 != std::string("pu").find(affinity_domain_) &&
-                0 != std::string("core").find(affinity_domain_) &&
-                0 != std::string("numa").find(affinity_domain_) &&
-                0 != std::string("machine").find(affinity_domain_))
-            {
-                throw hpx::detail::command_line_error(
-                    "Invalid command line option "
-                    "--hpx:affinity, value must be one of: pu, core, numa, "
-                    "or machine.");
-            }
-        }
-    }
-
-    void command_line_handling::check_affinity_description() const
-    {
-        if (affinity_bind_.empty())
-        {
-            return;
-        }
-
-        if (!(pu_offset_ == std::size_t(-1) || pu_offset_ == std::size_t(0)) ||
-            pu_step_ != 1 || affinity_domain_ != "pu")
-        {
-            throw hpx::detail::command_line_error(
-                "Command line option --hpx:bind "
-                "should not be used with --hpx:pu-step, --hpx:pu-offset, "
-                "or --hpx:affinity.");
-        }
-    }
-
-    void command_line_handling::check_pu_offset() const
-    {
-        if (pu_offset_ != std::size_t(-1) &&
-            pu_offset_ >= hpx::threads::hardware_concurrency())
-        {
-            throw hpx::detail::command_line_error(
-                "Invalid command line option "
-                "--hpx:pu-offset, value must be smaller than number of "
-                "available processing units.");
-        }
-    }
-
-    void command_line_handling::check_pu_step() const
-    {
-        if (hpx::threads::hardware_concurrency() > 1 &&
-            (pu_step_ == 0 || pu_step_ >= hpx::threads::hardware_concurrency()))
-        {
-            throw hpx::detail::command_line_error(
-                "Invalid command line option "
-                "--hpx:pu-step, value must be non-zero and smaller "
-                "than "
-                "number of available processing units.");
-        }
-    }
 
     ///////////////////////////////////////////////////////////////////////////
     bool command_line_handling::handle_arguments(util::manage_config& cfgmap,
         hpx::program_options::variables_map& vm,
         std::vector<std::string>& ini_config, std::size_t& node, bool initial)
     {
+        // handle local options
+        base_type::handle_arguments(cfgmap, vm, ini_config);
+
         // verify that no networking options were used if networking was
         // disabled
         detail::check_networking_options(vm);
 
         bool debug_clp = node != std::size_t(-1) && vm.count("hpx:debug-clp");
-
-        if (vm.count("hpx:ini"))
-        {
-            std::vector<std::string> cfg =
-                vm["hpx:ini"].as<std::vector<std::string>>();
-            std::copy(cfg.begin(), cfg.end(), std::back_inserter(ini_config));
-            cfgmap.add(cfg);
-        }
 
         // create host name mapping
         util::map_hostnames mapnames(debug_clp);
@@ -647,7 +371,7 @@ namespace hpx { namespace util {
             mapnames.use_suffix(vm["hpx:ifsuffix"].as<std::string>());
         if (vm.count("hpx:ifprefix"))
             mapnames.use_prefix(vm["hpx:ifprefix"].as<std::string>());
-        mapnames.force_ipv4(vm.count("hpx:force_ipv4") > 0);
+        mapnames.force_ipv4(vm.count("hpx:force_ipv4") != 0);
 
         // The AGAS host name and port number are pre-initialized from
         //the command line
@@ -670,7 +394,6 @@ namespace hpx { namespace util {
         }
 
         // Check command line arguments.
-
         if (vm.count("hpx:iftransform"))
         {
             util::sed_transform iftransform(
@@ -699,9 +422,9 @@ namespace hpx { namespace util {
             if (vm.count("hpx:nodes"))
             {
                 throw hpx::detail::command_line_error(
-                    "Ambiguous command line options. "
-                    "Do not specify more than one of the --hpx:nodefile and "
-                    "--hpx:nodes options at the same time.");
+                    "Ambiguous command line options. Do not specify more than "
+                    "one of the --hpx:nodefile and --hpx:nodes options at the "
+                    "same time.");
             }
             std::string node_file = vm["hpx:nodefile"].as<std::string>();
             ini_config.emplace_back("hpx.nodefile!=" + node_file);
@@ -734,28 +457,10 @@ namespace hpx { namespace util {
             nodelist = vm["hpx:nodes"].as<std::vector<std::string>>();
         }
 #endif
-        use_process_mask_ =
-            (cfgmap.get_value<int>("hpx.use_process_mask", 0) > 0) ||
-            (vm.count("hpx:use-process-mask") > 0);
-
         bool enable_batch_env =
             ((cfgmap.get_value<std::size_t>("hpx.ignore_batch_env", 0) +
                  vm.count("hpx:ignore-batch-env")) == 0) &&
             !use_process_mask_;
-
-#if defined(__APPLE__)
-        if (use_process_mask_)
-        {
-            std::cerr
-                << "Warning: enabled process mask for thread binding, but "
-                   "thread binding is not supported on macOS. Ignoring option."
-                << std::endl;
-            use_process_mask_ = false;
-        }
-#endif
-
-        ini_config.emplace_back(
-            "hpx.use_process_mask!=" + std::to_string(use_process_mask_));
 
 #if defined(HPX_HAVE_MODULE_MPI_BASE)
         bool have_mpi = util::mpi_environment::check_mpi_environment(rtcfg_);
@@ -787,8 +492,8 @@ namespace hpx { namespace util {
         bool expect_connections = false;
         std::uint16_t initial_hpx_port = 0;
 
-        // handling number of localities, those might have already been initialized
-        // from MPI environment
+        // handling number of localities, those might have already been
+        // initialized from MPI environment
         num_localities_ = detail::handle_num_localities(
             cfgmap, vm, env, using_nodelist, num_localities_, initial);
 
@@ -830,13 +535,13 @@ namespace hpx { namespace util {
         node = 0;
 #endif
 
-        // If the user has not specified an explicit runtime mode we
-        // retrieve it from the command line.
+        // If the user has not specified an explicit runtime mode we retrieve it
+        // from the command line.
         if (hpx::runtime_mode::default_ == rtcfg_.mode_)
         {
 #if defined(HPX_HAVE_NETWORKING)
-            // The default mode is console, i.e. all workers need to be
-            // started with --worker/-w.
+            // The default mode is console, i.e. all workers need to be started
+            // with --worker/-w.
             rtcfg_.mode_ = hpx::runtime_mode::console;
             if (vm.count("hpx:local") + vm.count("hpx:console") +
                     vm.count("hpx:worker") + vm.count("hpx:connect") >
@@ -952,8 +657,8 @@ namespace hpx { namespace util {
                     }
                 }
 
-                // store node number in configuration, don't do that if we're on a
-                // worker and the node number is zero
+                // store node number in configuration, don't do that if we're on
+                // a worker and the node number is zero
                 if (!vm.count("hpx:worker") || node != 0)
                 {
                     ini_config.emplace_back(
@@ -984,124 +689,21 @@ namespace hpx { namespace util {
         }
 #endif
 
-        // handle setting related to schedulers
-        queuing_ = detail::handle_queuing(cfgmap, vm, "local-priority-fifo");
-        ini_config.emplace_back("hpx.scheduler=" + queuing_);
-
-        affinity_domain_ = detail::handle_affinity(cfgmap, vm, "pu");
-        ini_config.emplace_back("hpx.affinity=" + affinity_domain_);
-
-        check_affinity_domain();
-
-        affinity_bind_ = detail::handle_affinity_bind(cfgmap, vm, "");
-        if (!affinity_bind_.empty())
-        {
-#if defined(__APPLE__)
-            std::cerr << "Warning: thread binding set to \"" << affinity_bind_
-                      << "\" but thread binding is not supported on macOS. "
-                         "Ignoring option."
-                      << std::endl;
-            affinity_bind_ = "";
-#else
-            ini_config.emplace_back("hpx.bind!=" + affinity_bind_);
-#endif
-        }
-
-        pu_step_ = detail::handle_pu_step(cfgmap, vm, 1);
-#if defined(__APPLE__)
-        if (pu_step_ != 1)
-        {
-            std::cerr << "Warning: PU step set to \"" << pu_step_
-                      << "\" but thread binding is not supported on macOS. "
-                         "Ignoring option."
-                      << std::endl;
-            pu_step_ = 1;
-        }
-#endif
-        ini_config.emplace_back("hpx.pu_step=" + std::to_string(pu_step_));
-
-        check_pu_step();
-
-        pu_offset_ = detail::handle_pu_offset(cfgmap, vm, std::size_t(-1));
-
-        // NOLINTNEXTLINE(bugprone-branch-clone)
-        if (pu_offset_ != std::size_t(-1))
-        {
-#if defined(__APPLE__)
-            std::cerr << "Warning: PU offset set to \"" << pu_offset_
-                      << "\" but thread binding is not supported on macOS. "
-                         "Ignoring option."
-                      << std::endl;
-            pu_offset_ = std::size_t(-1);
-            ini_config.emplace_back("hpx.pu_offset=0");
-#else
-            ini_config.emplace_back(
-                "hpx.pu_offset=" + std::to_string(pu_offset_));
-#endif
-        }
-        else
-        {
-            ini_config.emplace_back("hpx.pu_offset=0");
-        }
-
-        check_pu_offset();
-
-        numa_sensitive_ = detail::handle_numa_sensitive(
-            cfgmap, vm, affinity_bind_.empty() ? 0 : 1);
-        ini_config.emplace_back(
-            "hpx.numa_sensitive=" + std::to_string(numa_sensitive_));
-
-        // default affinity mode is now 'balanced' (only if no pu-step or
-        // pu-offset is given)
-        if (pu_step_ == 1 && pu_offset_ == std::size_t(-1) &&
-            affinity_bind_.empty())
-        {
-#if defined(__APPLE__)
-            affinity_bind_ = "none";
-#else
-            affinity_bind_ = "balanced";
-#endif
-            ini_config.emplace_back("hpx.bind!=" + affinity_bind_);
-        }
-
-        check_affinity_description();
-
         // handle number of cores and threads
         num_threads_ = detail::handle_num_threads(cfgmap, rtcfg_, vm, env,
             using_nodelist, initial, use_process_mask_);
-        num_cores_ = detail::handle_num_cores(
-            cfgmap, vm, num_threads_, env, use_process_mask_);
+
+        num_cores_ =
+            hpx::local::detail::handle_num_cores(cfgmap, vm, num_threads_,
+                detail::get_number_of_default_cores(env, use_process_mask_));
 
         // Set number of cores and OS threads in configuration.
         ini_config.emplace_back(
             "hpx.os_threads=" + std::to_string(num_threads_));
         ini_config.emplace_back("hpx.cores=" + std::to_string(num_cores_));
 
-        if (vm_.count("hpx:high-priority-threads"))
-        {
-            std::size_t num_high_priority_queues =
-                vm_["hpx:high-priority-threads"].as<std::size_t>();
-            if (num_high_priority_queues != std::size_t(-1) &&
-                num_high_priority_queues > num_threads_)
-            {
-                throw hpx::detail::command_line_error(
-                    "Invalid command line option: "
-                    "number of high priority threads ("
-                    "--hpx:high-priority-threads), should not be larger "
-                    "than number of threads (--hpx:threads)");
-            }
-
-            if (!(queuing_ == "local-priority" || queuing_ == "abp-priority"))
-            {
-                throw hpx::detail::command_line_error(
-                    "Invalid command line option --hpx:high-priority-threads, "
-                    "valid for --hpx:queuing=local-priority and "
-                    "--hpx:queuing=abp-priority only");
-            }
-
-            ini_config.emplace_back("hpx.thread_queue.high_priority_queues!=" +
-                std::to_string(num_high_priority_queues));
-        }
+        // handle high-priority threads
+        handle_high_priority_threads(vm, ini_config);
 
         // map host names to ip addresses, if requested
         hpx_host = mapnames.map(hpx_host, hpx_port);
@@ -1112,10 +714,10 @@ namespace hpx { namespace util {
             !vm.count("hpx:agas") && !vm.count("hpx:node"))
         {
             // We assume we have to run the AGAS server if the number of
-            // localities to run on is not specified (or is '1')
-            // and no additional option (--hpx:agas or --hpx:node) has been
-            // specified. That simplifies running small standalone
-            // applications on one locality.
+            // localities to run on is not specified (or is '1') and no
+            // additional option (--hpx:agas or --hpx:node) has been specified.
+            // That simplifies running small standalone applications on one
+            // locality.
             run_agas_server = rtcfg_.mode_ != runtime_mode::connect;
         }
 
@@ -1176,7 +778,6 @@ namespace hpx { namespace util {
                     "Command line option error: can't run AGAS server"
                     "while connecting to a running application.");
             }
-
 #else
             ini_config.emplace_back("hpx.agas.service_mode=bootstrap");
 #endif
@@ -1227,8 +828,7 @@ namespace hpx { namespace util {
                     throw hpx::detail::command_line_error(hpx::util::format(
                         "Invalid argument for option --hpx:print-counter-at: "
                         "'{1}', allowed values: 'startup', 'shutdown' "
-                        "(default), "
-                        "'noshutdown'",
+                        "(default), 'noshutdown'",
                         s));
                 }
             }
@@ -1246,13 +846,7 @@ namespace hpx { namespace util {
 
         if (debug_clp)
         {
-            std::cerr << "Configuration before runtime start:\n";
-            std::cerr << "-----------------------------------\n";
-            for (std::string const& s : ini_config)
-            {
-                std::cerr << s << std::endl;
-            }
-            std::cerr << "-----------------------------------\n";
+            hpx::local::detail::print_config(ini_config);
         }
 
         return true;
@@ -1263,26 +857,16 @@ namespace hpx { namespace util {
         hpx::program_options::variables_map& vm,
         std::vector<std::string>& ini_config)
     {
-#if defined(HPX_HAVE_LOGGING)
-        if (vm.count("hpx:debug-hpx-log"))
-        {
-            ini_config.emplace_back("hpx.logging.console.destination=" +
-                detail::convert_to_log_file(
-                    vm["hpx:debug-hpx-log"].as<std::string>()));
-            ini_config.emplace_back("hpx.logging.destination=" +
-                detail::convert_to_log_file(
-                    vm["hpx:debug-hpx-log"].as<std::string>()));
-            ini_config.emplace_back("hpx.logging.console.level=5");
-            ini_config.emplace_back("hpx.logging.level=5");
-        }
+        base_type::enable_logging_settings(vm, ini_config);
 
+#if defined(HPX_HAVE_LOGGING)
         if (vm.count("hpx:debug-agas-log"))
         {
             ini_config.emplace_back("hpx.logging.console.agas.destination=" +
-                detail::convert_to_log_file(
+                hpx::local::detail::convert_to_log_file(
                     vm["hpx:debug-agas-log"].as<std::string>()));
             ini_config.emplace_back("hpx.logging.agas.destination=" +
-                detail::convert_to_log_file(
+                hpx::local::detail::convert_to_log_file(
                     vm["hpx:debug-agas-log"].as<std::string>()));
             ini_config.emplace_back("hpx.logging.console.agas.level=5");
             ini_config.emplace_back("hpx.logging.agas.level=5");
@@ -1291,43 +875,16 @@ namespace hpx { namespace util {
         if (vm.count("hpx:debug-parcel-log"))
         {
             ini_config.emplace_back("hpx.logging.console.parcel.destination=" +
-                detail::convert_to_log_file(
+                hpx::local::detail::convert_to_log_file(
                     vm["hpx:debug-parcel-log"].as<std::string>()));
             ini_config.emplace_back("hpx.logging.parcel.destination=" +
-                detail::convert_to_log_file(
+                hpx::local::detail::convert_to_log_file(
                     vm["hpx:debug-parcel-log"].as<std::string>()));
             ini_config.emplace_back("hpx.logging.console.parcel.level=5");
             ini_config.emplace_back("hpx.logging.parcel.level=5");
         }
-
-        if (vm.count("hpx:debug-timing-log"))
-        {
-            ini_config.emplace_back("hpx.logging.console.timing.destination=" +
-                detail::convert_to_log_file(
-                    vm["hpx:debug-timing-log"].as<std::string>()));
-            ini_config.emplace_back("hpx.logging.timing.destination=" +
-                detail::convert_to_log_file(
-                    vm["hpx:debug-timing-log"].as<std::string>()));
-            ini_config.emplace_back("hpx.logging.console.timing.level=1");
-            ini_config.emplace_back("hpx.logging.timing.level=1");
-        }
-
-        if (vm.count("hpx:debug-app-log"))
-        {
-            ini_config.emplace_back(
-                "hpx.logging.console.application.destination=" +
-                detail::convert_to_log_file(
-                    vm["hpx:debug-app-log"].as<std::string>()));
-            ini_config.emplace_back("hpx.logging.application.destination=" +
-                detail::convert_to_log_file(
-                    vm["hpx:debug-app-log"].as<std::string>()));
-            ini_config.emplace_back("hpx.logging.console.application.level=5");
-            ini_config.emplace_back("hpx.logging.application.level=5");
-        }
 #else
-        if (vm.count("hpx:debug-hpx-log") || vm.count("hpx:debug-agas-log") ||
-            vm.count("hpx:debug-parcel-log") ||
-            vm.count("hpx:debug-timing-log") || vm.count("hpx:debug-app-log"))
+        if (vm.count("hpx:debug-agas-log") || vm.count("hpx:debug-parcel-log"))
         {
             // clang-format off
             throw hpx::detail::command_line_error(
@@ -1336,191 +893,7 @@ namespace hpx { namespace util {
                 "HPX using the option -DHPX_WITH_LOGGING=On.");
             // clang-format on
         }
-
-        HPX_UNUSED(ini_config);
 #endif
-    }
-
-    ///////////////////////////////////////////////////////////////////////////
-    void command_line_handling::store_command_line(int argc, char** argv)
-    {
-        // Collect the command line for diagnostic purposes.
-        std::string command;
-        std::string cmd_line;
-        std::string options;
-        for (int i = 0; i < argc; ++i)
-        {
-            // quote only if it contains whitespace
-            std::string arg = detail::encode_and_enquote(argv[i]);    //-V108
-
-            cmd_line += arg;
-            if (i == 0)
-            {
-                command = arg;
-            }
-            else
-            {
-                options += " " + arg;
-            }
-
-            if ((i + 1) != argc)
-            {
-                cmd_line += " ";
-            }
-        }
-
-        // Store the program name and the command line.
-        ini_config_.emplace_back("hpx.cmd_line!=" + cmd_line);
-        ini_config_.emplace_back("hpx.commandline.command!=" + command);
-        ini_config_.emplace_back("hpx.commandline.options!=" + options);
-    }
-
-    ///////////////////////////////////////////////////////////////////////////
-    void command_line_handling::store_unregistered_options(
-        std::string const& cmd_name,
-        std::vector<std::string> const& unregistered_options)
-    {
-        std::string unregistered_options_cmd_line;
-
-        if (!unregistered_options.empty())
-        {
-            typedef std::vector<std::string>::const_iterator iterator_type;
-
-            iterator_type end = unregistered_options.end();
-            for (iterator_type it = unregistered_options.begin(); it != end;
-                 ++it)
-                unregistered_options_cmd_line +=
-                    " " + detail::encode_and_enquote(*it);
-
-            ini_config_.emplace_back("hpx.unknown_cmd_line!=" +
-                detail::encode_and_enquote(cmd_name) +
-                unregistered_options_cmd_line);
-        }
-
-        ini_config_.emplace_back("hpx.program_name!=" + cmd_name);
-        ini_config_.emplace_back("hpx.reconstructed_cmd_line!=" +
-            detail::encode_and_enquote(cmd_name) + " " +
-            local::detail::reconstruct_command_line(vm_) + " " +
-            unregistered_options_cmd_line);
-    }
-
-    ///////////////////////////////////////////////////////////////////////////
-    bool command_line_handling::handle_help_options(
-        hpx::program_options::options_description const& help)
-    {
-        if (vm_.count("hpx:help"))
-        {
-            std::string help_option(vm_["hpx:help"].as<std::string>());
-            if (0 == std::string("minimal").find(help_option))
-            {
-                // print static help only
-                std::cout << help << std::endl;
-                return true;
-            }
-            else if (0 == std::string("full").find(help_option))
-            {
-                // defer printing help until after dynamic part has been
-                // acquired
-                std::ostringstream strm;
-                strm << help << std::endl;
-                ini_config_.emplace_back(
-                    "hpx.cmd_line_help!=" + detail::encode_string(strm.str()));
-                ini_config_.emplace_back(
-                    "hpx.cmd_line_help_option!=" + help_option);
-            }
-            else
-            {
-                throw hpx::detail::command_line_error(
-                    hpx::util::format("Invalid argument for option --hpx:help: "
-                                      "'{1}', allowed values: "
-                                      "'minimal' (default) and 'full'",
-                        help_option));
-            }
-        }
-        return false;
-    }
-
-    void command_line_handling::handle_attach_debugger()
-    {
-#if defined(_POSIX_VERSION) || defined(HPX_WINDOWS)
-        if (vm_.count("hpx:attach-debugger"))
-        {
-            std::string option = vm_["hpx:attach-debugger"].as<std::string>();
-            if (option != "off" && option != "startup" &&
-                option != "exception" && option != "test-failure")
-            {
-                // clang-format off
-                std::cerr <<
-                    "hpx::init: command line warning: --hpx:attach-debugger: "
-                    "invalid option: " << option << ". Allowed values are "
-                    "'off', 'startup', 'exception' or 'test-failure'" << std::endl;
-                // clang-format on
-            }
-            else
-            {
-                if (option == "startup")
-                    attach_debugger();
-
-                ini_config_.emplace_back("hpx.attach_debugger!=" + option);
-            }
-        }
-#endif
-    }
-
-    ///////////////////////////////////////////////////////////////////////////
-    // separate command line arguments from configuration settings
-    std::vector<std::string> command_line_handling::preprocess_config_settings(
-        int argc, char** argv)
-    {
-        std::vector<std::string> options;
-        options.reserve(static_cast<std::size_t>(argc) + ini_config_.size());
-
-        // extract all command line arguments from configuration settings and
-        // remove them from this list
-        auto it = std::stable_partition(ini_config_.begin(), ini_config_.end(),
-            [](std::string const& e) { return e.find("--hpx:") != 0; });
-
-        std::move(it, ini_config_.end(), std::back_inserter(options));
-        ini_config_.erase(it, ini_config_.end());
-
-        // store the command line options that came from the configuration
-        // settings in the registry
-        if (!options.empty())
-        {
-            std::string config_options;
-            for (auto const& option : options)
-            {
-                config_options += " " + option;
-            }
-
-            rtcfg_.add_entry("hpx.commandline.config_options", config_options);
-        }
-
-        // now append all original command line options
-        for (int i = 1; i != argc; ++i)
-        {
-            options.emplace_back(argv[i]);
-        }
-
-        return options;
-    }
-
-    ///////////////////////////////////////////////////////////////////////////
-    std::vector<std::string> prepend_options(
-        std::vector<std::string>&& args, std::string&& options)
-    {
-        if (options.empty())
-        {
-            return HPX_MOVE(args);
-        }
-
-        using tokenizer = boost::tokenizer<boost::escaped_list_separator<char>>;
-        boost::escaped_list_separator<char> sep('\\', ' ', '\"');
-        tokenizer tok(options, sep);
-
-        std::vector<std::string> result(tok.begin(), tok.end());
-        std::move(args.begin(), args.end(), std::back_inserter(result));
-        return result;
     }
 
     ///////////////////////////////////////////////////////////////////////////
@@ -1554,16 +927,16 @@ namespace hpx { namespace util {
         std::string prepend_command_line =
             rtcfg_.get_entry("hpx.commandline.prepend_options");
 
-        args = prepend_options(HPX_MOVE(args), HPX_MOVE(prepend_command_line));
+        args = hpx::local::detail::prepend_options(
+            HPX_MOVE(args), HPX_MOVE(prepend_command_line));
 
-        // Initial analysis of the command line options. This is
-        // preliminary as it will not take into account any aliases as
-        // defined in any of the runtime configuration files.
+        // Initial analysis of the command line options. This is preliminary as
+        // it will not take into account any aliases as defined in any of the
+        // runtime configuration files.
         {
-            // Boost V1.47 and before do not properly reset a variables_map
-            // when calling vm.clear(). We work around that problems by
-            // creating a separate instance just for the preliminary
-            // command line handling.
+            // Boost V1.47 and before do not properly reset a variables_map when
+            // calling vm.clear(). We work around that problems by creating a
+            // separate instance just for the preliminary command line handling.
             hpx::program_options::variables_map prevm;
             if (!util::parse_commandline(rtcfg_, desc_cmdline, argv[0], args,
                     prevm, std::size_t(-1), error_mode | util::ignore_aliases,
@@ -1579,33 +952,7 @@ namespace hpx { namespace util {
                 return -2;
             }
 
-            // re-initialize runtime configuration object
-            if (prevm.count("hpx:config"))
-                rtcfg_.reconfigure(prevm["hpx:config"].as<std::string>());
-            else
-                rtcfg_.reconfigure("");
-
-            // Make sure any aliases defined on the command line get used
-            // for the option analysis below.
-            std::vector<std::string> cfg;
-            if (prevm.count("hpx:ini"))
-            {
-                cfg = prevm["hpx:ini"].as<std::vector<std::string>>();
-                cfgmap.add(cfg);
-            }
-
-            // append ini options from command line
-            std::copy(ini_config_.begin(), ini_config_.end(),
-                std::back_inserter(cfg));
-
-            // enable logging if invoked requested from command line
-            std::vector<std::string> ini_config_logging;
-            enable_logging_settings(prevm, ini_config_logging);
-
-            std::copy(ini_config_logging.begin(), ini_config_logging.end(),
-                std::back_inserter(cfg));
-
-            rtcfg_.reconfigure(cfg);
+            reconfigure(cfgmap, prevm);
         }
 
 #if (defined(HPX_HAVE_NETWORKING) && defined(HPX_HAVE_PARCELPORT_MPI)) ||      \
@@ -1632,13 +979,13 @@ namespace hpx { namespace util {
         }
 #endif
 
-        // load plugin modules (after first pass of command line handling,
-        // so that settings given on command line could propagate to modules)
+        // load plugin modules (after first pass of command line handling, so
+        // that settings given on command line could propagate to modules)
         std::vector<std::shared_ptr<plugins::plugin_registry_base>>
             plugin_registries = rtcfg_.load_modules(component_registries);
 
-        // Re-run program option analysis, ini settings (such as aliases)
-        // will be considered now.
+        // Re-run program option analysis, ini settings (such as aliases) will
+        // be considered now.
 
         // minimally assume one locality and this is the console
         if (node_ == std::size_t(-1))
@@ -1650,8 +997,8 @@ namespace hpx { namespace util {
             reg->init(&argc, &argv, rtcfg_);
         }
 
-        // Now re-parse the command line using the node number (if given).
-        // This will additionally detect any --hpx:N:foo options.
+        // Now re-parse the command line using the node number (if given). This
+        // will additionally detect any --hpx:N:foo options.
         hpx::program_options::options_description help;
         std::vector<std::string> unregistered_options;
 
@@ -1671,44 +1018,7 @@ namespace hpx { namespace util {
             return -2;
         }
 
-        // store unregistered command line and arguments
-        store_command_line(argc, argv);
-        store_unregistered_options(argv[0], unregistered_options);
-
-        // add all remaining ini settings to the global configuration
-        rtcfg_.reconfigure(ini_config_);
-
-        // help can be printed only after the runtime mode has been set
-        if (handle_help_options(help))
-        {
-            return 1;    // exit application gracefully
-        }
-
-        // print version/copyright information
-        if (vm_.count("hpx:version"))
-        {
-            if (!version_printed_)
-            {
-                detail::print_version(std::cout);
-                version_printed_ = true;
-            }
-
-            return 1;
-        }
-
-        // print configuration information (static and dynamic)
-        if (vm_.count("hpx:info"))
-        {
-            if (!info_printed_)
-            {
-                detail::print_info(std::cout, *this);
-                info_printed_ = true;
-            }
-
-            return 1;
-        }
-
-        // all is good
-        return 0;
+        return finalize_commandline_handling(
+            argc, argv, help, unregistered_options);
     }
 }}    // namespace hpx::util

--- a/libs/full/command_line_handling/src/parse_command_line.cpp
+++ b/libs/full/command_line_handling/src/parse_command_line.cpp
@@ -24,18 +24,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 namespace hpx { namespace util {
     namespace detail {
-        ///////////////////////////////////////////////////////////////////////
-        inline std::string trim_whitespace(std::string const& s)
-        {
-            using size_type = std::string::size_type;
-
-            size_type first = s.find_first_not_of(" \t");
-            if (std::string::npos == first)
-                return std::string();
-
-            size_type last = s.find_last_not_of(" \t");
-            return s.substr(first, last - first + 1);
-        }
 
         ///////////////////////////////////////////////////////////////////////
         // All command line options which are normally formatted as --hpx:foo
@@ -56,7 +44,8 @@ namespace hpx { namespace util {
                 return false;
             }
 
-            // any --hpx: option without a second ':' is handled elsewhere as well
+            // any --hpx: option without a second ':' is handled elsewhere as
+            // well
             std::string::size_type p = s.find_first_of(':', hpx_prefix_len);
             if (p == std::string::npos)
                 return false;
@@ -65,6 +54,8 @@ namespace hpx { namespace util {
                     s.substr(hpx_prefix_len, p - hpx_prefix_len),
                     std::size_t(-1)) == node)
             {
+                using hpx::local::detail::trim_whitespace;
+
                 // this option is for the current locality only
                 std::string::size_type p1 = s.find_first_of('=', p);
                 if (p1 != std::string::npos)
@@ -91,202 +82,64 @@ namespace hpx { namespace util {
         }
 
         ///////////////////////////////////////////////////////////////////////
-        // Handle aliasing of command line options based on information stored
-        // in the ini-configuration
-        std::pair<std::string, std::string> handle_aliasing(
-            util::section const& ini, std::string const& option)
-        {
-            std::pair<std::string, std::string> result;
-
-            std::string opt(trim_whitespace(option));
-            if (opt.size() < 2 || opt[0] != '-')
-                return result;
-
-            util::section const* sec =
-                ini.get_section("hpx.commandline.aliases");
-            if (nullptr == sec)
-                return result;    // no alias mappings are defined
-
-            // we found shortcut option definitions, try to find mapping
-            std::string expand_to;
-            std::string::size_type start_at = 2;
-            bool long_option = false;
-            if (opt.size() > 2 && opt[1] != '-')
-            {
-                // short option with value: first two letters have to match
-                expand_to = trim_whitespace(
-                    sec->get_entry(opt.substr(0, start_at), ""));
-            }
-            else
-            {
-                // short option (no value) or long option
-                if (opt[1] == '-')
-                {
-                    start_at = opt.find_last_of('=');
-                    long_option = true;
-                }
-
-                if (start_at != std::string::npos)
-                {
-                    expand_to = trim_whitespace(
-                        sec->get_entry(opt.substr(0, start_at), ""));
-                }
-                else
-                {
-                    expand_to = trim_whitespace(sec->get_entry(opt, ""));
-                }
-            }
-
-            if (expand_to.size() < 2 || expand_to.substr(0, 2) != "--")
-                return result;    // no sensible alias is defined for this option
-            expand_to.erase(0, 2);
-
-            std::string::size_type p = expand_to.find_first_of('=');
-            if (p != std::string::npos)
-            {
-                // the option alias defines its own value
-                std::string o(trim_whitespace(expand_to.substr(0, p)));
-                std::string v(trim_whitespace(expand_to.substr(p + 1)));
-                result = std::make_pair(o, v);
-            }
-            else if (start_at != std::string::npos && start_at < opt.size())
-            {
-                // extract value from original option
-                result = std::make_pair(
-                    expand_to, opt.substr(start_at + (long_option ? 1 : 0)));
-            }
-            else
-            {
-                // no value
-                result = std::make_pair(expand_to, std::string());
-            }
-
-            return result;
-        }
-
-        ///////////////////////////////////////////////////////////////////////
         // Additional command line parser which interprets '@something' as an
         // option "options-file" with the value "something". Additionally we
         // resolve defined command line option aliases.
-        struct option_parser
+        struct option_parser : hpx::local::detail::option_parser
         {
+            using base_type = hpx::local::detail::option_parser;
+
             option_parser(
                 util::section const& ini, std::size_t node, bool ignore_aliases)
-              : ini_(ini)
+              : base_type(ini, ignore_aliases)
               , node_(node)
-              , ignore_aliases_(ignore_aliases)
             {
             }
 
             std::pair<std::string, std::string> operator()(
                 std::string const& s) const
             {
-                // handle special syntax for configuration files @filename
-                if ('@' == s[0])
-                    return std::make_pair(
-                        std::string("hpx:options-file"), s.substr(1));
-
                 // handle node specific options
                 std::pair<std::string, std::string> opt;
                 if (handle_node_specific_option(s, node_, opt))
                     return opt;
 
                 // handle aliasing, if enabled
-                if (ini_.get_entry("hpx.commandline.aliasing", "0") == "0" ||
-                    ignore_aliases_)
-                {
-                    return opt;
-                }
-                return handle_aliasing(ini_, s);
+                return static_cast<base_type const&>(*this)(s);
             }
 
-            util::section const& ini_;
             std::size_t node_;
-            bool ignore_aliases_;
         };
 
         ///////////////////////////////////////////////////////////////////////
-        hpx::program_options::basic_command_line_parser<char>&
-        get_commandline_parser(
-            hpx::program_options::basic_command_line_parser<char>& p, int mode)
-        {
-            if ((mode &
-                    ~(util::report_missing_config_file |
-                        util::ignore_aliases)) == util::allow_unregistered)
-            {
-                return p.allow_unregistered();
-            }
-            return p;
-        }
-
-        ///////////////////////////////////////////////////////////////////////
-        // Read all options from a given config file, parse and add them to the
-        // given variables_map
-        bool read_config_file_options(std::string const& filename,
+        // Handle all options from a given config file, parse and add them to
+        // the given variables_map
+        bool handle_config_file_options(std::vector<std::string> const& options,
             hpx::program_options::options_description const& desc,
             hpx::program_options::variables_map& vm, util::section const& rtcfg,
             std::size_t node, int error_mode)
         {
-            std::ifstream ifs(filename.c_str());
-            if (!ifs.is_open())
-            {
-                if (error_mode & util::report_missing_config_file)
-                {
-                    std::cerr
-                        << "hpx::init: command line warning: command line "
-                           "options file not found ("
-                        << filename << ")" << std::endl;
-                }
-                return false;
-            }
-
-            std::vector<std::string> options;
-            std::string line;
-            while (std::getline(ifs, line))
-            {
-                // skip empty lines
-                std::string::size_type pos = line.find_first_not_of(" \t");
-                if (pos == std::string::npos)
-                    continue;
-
-                // strip leading and trailing whitespace
-                line = trim_whitespace(line);
-
-                // skip comment lines
-                if ('#' != line[0])
-                {
-                    std::string::size_type p1 = line.find_first_of(" \t");
-                    if (p1 != std::string::npos)
-                    {
-                        // rebuild the line connecting the parts with a '='
-                        line = trim_whitespace(line.substr(0, p1)) + '=' +
-                            trim_whitespace(line.substr(p1));
-                    }
-                    options.push_back(line);
-                }
-            }
-
             // add options to parsed settings
             if (!options.empty())
             {
-                using hpx::program_options::basic_command_line_parser;
                 using hpx::program_options::command_line_parser;
                 using hpx::program_options::store;
-                using hpx::program_options::value;
-                using namespace hpx::program_options::command_line_style;
+                using hpx::program_options::command_line_style::unix_style;
 
-                store(detail::get_commandline_parser(
+                store(hpx::local::detail::get_commandline_parser(
                           command_line_parser(options)
                               .options(desc)
                               .style(unix_style)
-                              .extra_parser(detail::option_parser(rtcfg, node,
-                                  error_mode & util::ignore_aliases)),
+                              .extra_parser(
+                                  hpx::util::detail::option_parser(rtcfg, node,
+                                      error_mode & util::ignore_aliases)),
                           error_mode & ~util::ignore_aliases)
                           .run(),
                     vm);
                 notify(vm);
+                return true;
             }
-            return true;
+            return false;
         }
 
         // try to find a config file somewhere up the filesystem hierarchy
@@ -308,16 +161,23 @@ namespace hpx { namespace util {
             while (!dir.empty())
             {
                 filesystem::path filename = dir / (appname + ".cfg");
-                bool result = read_config_file_options(filename.string(),
-                    desc_cfgfile, vm, ini, node,
-                    error_mode & ~util::report_missing_config_file);
-                if (result)
-                    break;    // break on the first options file found
+                std::vector<std::string> options =
+                    hpx::local::detail::read_config_file_options(
+                        filename.string(),
+                        error_mode & ~util::report_missing_config_file);
 
-                    // Boost filesystem and C++17 filesystem behave differently
-                    // here. Boost filesystem returns an empty path for
-                    // "/".parent_path() whereas C++17 filesystem will keep
-                    // returning "/".
+                bool result =
+                    handle_config_file_options(options, desc_cfgfile, vm, ini,
+                        node, error_mode & ~util::report_missing_config_file);
+                if (result)
+                {
+                    break;    // break on the first options file found
+                }
+
+                // Boost filesystem and C++17 filesystem behave differently
+                // here. Boost filesystem returns an empty path for
+                // "/".parent_path() whereas C++17 filesystem will keep
+                // returning "/".
 #if !defined(HPX_FILESYSTEM_HAVE_BOOST_FILESYSTEM_COMPATIBILITY)
                 auto dir_prev = dir;
                 dir = dir.parent_path();    // chop off last directory part
@@ -343,79 +203,38 @@ namespace hpx { namespace util {
                 for (std::string const& cfg_file : cfg_files)
                 {
                     // parse a single config file and store the results
-                    read_config_file_options(
-                        cfg_file, desc_cfgfile, vm, ini, node, error_mode);
+                    std::vector<std::string> options =
+                        hpx::local::detail::read_config_file_options(
+                            cfg_file, error_mode);
+
+                    handle_config_file_options(
+                        options, desc_cfgfile, vm, ini, node, error_mode);
                 }
             }
         }
-    }    // namespace detail
 
-    void verify_unknown_options(std::vector<std::string> const& opts)
-    {
-        for (auto const& opt : opts)
+        hpx::local::detail::options_map compose_all_options(
+            hpx::runtime_mode mode)
         {
-            std::string::size_type p = opt.find("--hpx:");
-            if (p != std::string::npos)
-            {
-                throw hpx::detail::command_line_error(
-                    "Unknown/misspelled HPX command line option found: " + opt);
-            }
-        }
-    }
+            using hpx::local::detail::options_type;
+            using hpx::program_options::value;
 
-    ///////////////////////////////////////////////////////////////////////////
-    // parse the command line
-    bool parse_commandline(util::section const& rtcfg,
-        hpx::program_options::options_description const& app_options,
-        std::string const& arg0, std::vector<std::string> const& args,
-        hpx::program_options::variables_map& vm, std::size_t node,
-        int error_mode, hpx::runtime_mode mode,
-        hpx::program_options::options_description* visible,
-        std::vector<std::string>* unregistered_options)
-    {
-        using hpx::program_options::basic_command_line_parser;
-        using hpx::program_options::command_line_parser;
-        using hpx::program_options::options_description;
-        using hpx::program_options::parsed_options;
-        using hpx::program_options::positional_options_description;
-        using hpx::program_options::store;
-        using hpx::program_options::value;
-        using namespace hpx::program_options::command_line_style;
-
-        try
-        {
-            // clang-format off
-            options_description cmdline_options(
-                "HPX options (allowed on command line only)");
-            cmdline_options.add_options()
-                ("hpx:help", value<std::string>()->implicit_value("minimal"),
-                    "print out program usage (default: this message), possible "
-                    "values: 'full' (additionally prints options from components)")
-                ("hpx:version", "print out HPX version and copyright information")
-                ("hpx:info", "print out HPX configuration information")
-                ("hpx:options-file", value<std::vector<std::string> >()->composing(),
-                    "specify a file containing command line options "
-                    "(alternatively: @filepath)")
-            ;
-
-            options_description hpx_options(
-                "HPX options (additionally allowed in an options file)");
-            options_description hidden_options("Hidden options");
-            // clang-format on
+            hpx::local::detail::options_map all_options =
+                hpx::local::detail::compose_local_options();
 
             switch (mode)
             {
             case runtime_mode::default_:
 #if defined(HPX_HAVE_NETWORKING)
                 // clang-format off
-                hpx_options.add_options()
+                all_options[options_type::hpx_options].add_options()
                     ("hpx:worker", "run this instance in worker mode")
                     ("hpx:console", "run this instance in console mode")
                     ("hpx:connect", "run this instance in worker mode, "
                          "but connecting late")
                 ;
 #else
-                hpx_options.add_options()
+                all_options[options_type::hpx_options].add_options()
                     ("hpx:console", "run this instance in console mode")
                 ;
                 // clang-format on
@@ -426,11 +245,12 @@ namespace hpx { namespace util {
             case runtime_mode::worker:
             case runtime_mode::console:
             case runtime_mode::connect:
-                // If the runtime for this application is always run in
-                // worker mode, silently ignore the worker option for
-                // hpx_pbs compatibility.
+                // If the runtime for this application is always run in worker
+                // mode, silently ignore the worker option for hpx_pbs
+                // compatibility.
+
                 // clang-format off
-                hidden_options.add_options()
+                all_options[options_type::hidden_options].add_options()
                     ("hpx:worker", "run this instance in worker mode")
                     ("hpx:console", "run this instance in console mode")
                     ("hpx:connect", "run this instance in worker mode, "
@@ -441,7 +261,7 @@ namespace hpx { namespace util {
 #else
             case runtime_mode::console:
                 // clang-format off
-                hidden_options.add_options()
+                all_options[options_type::hidden_options].add_options()
                     ("hpx:console", "run this instance in console mode")
                 ;
                 // clang-format on
@@ -457,13 +277,17 @@ namespace hpx { namespace util {
             }
 
             // Always add the option to start the local runtime
-            hpx_options.add_options()("hpx:local",
-                "run this instance in local mode (experimental; certain "
-                "functionalities are not available at runtime)");
+            // clang-format off
+            all_options[options_type::hpx_options].add_options()
+                ("hpx:local",
+                  "run this instance in local mode (experimental; certain "
+                  "functionalities are not available at runtime)")
+            ;
+            // clang-format on
 
             // general options definitions
             // clang-format off
-            hpx_options.add_options()
+            all_options[options_type::hpx_options].add_options()
                 ("hpx:run-hpx-main",
                   "run the hpx_main function, regardless of locality mode")
 #if defined(HPX_HAVE_NETWORKING)
@@ -510,89 +334,9 @@ namespace hpx { namespace util {
                   "(default: false if the number of localities is equal to one, "
                   "true if the number of initial localities is larger than 1)")
 #endif
-                ("hpx:pu-offset", value<std::size_t>(),
-                  "the first processing unit this instance of HPX should be "
-                  "run on (default: 0), valid for "
-                  "--hpx:queuing=local, --hpx:queuing=abp-priority, "
-                  "--hpx:queuing=static, --hpx:queuing=static-priority, "
-                  "and --hpx:queuing=local-priority only")
-                ("hpx:pu-step", value<std::size_t>(),
-                  "the step between used processing unit numbers for this "
-                  "instance of HPX (default: 1), valid for "
-                  "--hpx:queuing=local, --hpx:queuing=abp-priority, "
-                  "--hpx:queuing=static, --hpx:queuing=static-priority "
-                  "and --hpx:queuing=local-priority only")
-                ("hpx:affinity", value<std::string>(),
-                  "the affinity domain the OS threads will be confined to, "
-                  "possible values: pu, core, numa, machine (default: pu), valid for "
-                  "--hpx:queuing=local, --hpx:queuing=abp-priority, "
-                  "--hpx:queuing=static, --hpx:queuing=static-priority "
-                  " and --hpx:queuing=local-priority only")
-                ("hpx:bind", value<std::vector<std::string> >()->composing(),
-                  "the detailed affinity description for the OS threads, see "
-                  "the documentation for a detailed description of possible "
-                  "values. Do not use with --hpx:pu-step, --hpx:pu-offset, or "
-                  "--hpx:affinity options. Implies --hpx:numa-sensitive=1"
-                  "(--hpx:bind=none disables defining thread affinities).")
-                ("hpx:use-process-mask", "use the process mask to restrict "
-                 "available hardware resources (implies "
-                 "--hpx:ignore-batch-env)")
-                ("hpx:print-bind",
-                  "print to the console the bit masks calculated from the "
-                  "arguments specified to all --hpx:bind options.")
-                ("hpx:threads", value<std::string>(),
-                 "the number of operating system threads to spawn for this HPX "
-                 "locality (default: 1, using 'all' will spawn one thread for "
-                 "each processing unit")
-                ("hpx:cores", value<std::string>(),
-                 "the number of cores to utilize for this HPX "
-                 "locality (default: 'all', i.e. the number of cores is based on "
-                 "the number of total cores in the system)")
-                ("hpx:queuing", value<std::string>(),
-                  "the queue scheduling policy to use, options are "
-                  "'local', 'local-priority-fifo','local-priority-lifo', "
-                  "'abp-priority-fifo', 'abp-priority-lifo', 'static', and "
-                  "'static-priority' (default: 'local-priority'; "
-                  "all option values can be abbreviated)")
-                ("hpx:high-priority-threads", value<std::size_t>(),
-                  "the number of operating system threads maintaining a high "
-                  "priority queue (default: number of OS threads), valid for "
-                  "--hpx:queuing=local-priority,--hpx:queuing=static-priority, "
-                  " and --hpx:queuing=abp-priority only)")
-                ("hpx:numa-sensitive", value<std::size_t>()->implicit_value(0),
-                  "makes the local-priority scheduler NUMA sensitive ("
-                  "allowed values: 0 - no NUMA sensitivity, 1 - allow only for "
-                  "boundary cores to steal across NUMA domains, 2 - "
-                  "no cross boundary stealing is allowed (default value: 0)")
             ;
 
-            options_description config_options("HPX configuration options");
-            config_options.add_options()
-                ("hpx:app-config", value<std::string>(),
-                  "load the specified application configuration (ini) file")
-                ("hpx:config", value<std::string>()->default_value(""),
-                  "load the specified hpx configuration (ini) file")
-                ("hpx:ini", value<std::vector<std::string> >()->composing(),
-                  "add a configuration definition to the default runtime "
-                  "configuration")
-                ("hpx:exit", "exit after configuring the runtime")
-            ;
-
-            options_description debugging_options("HPX debugging options");
-            debugging_options.add_options()
-                ("hpx:dump-config-initial", "print the initial runtime configuration")
-                ("hpx:dump-config", "print the final runtime configuration")
-                // enable debug output from command line handling
-                ("hpx:debug-clp", "debug command line processing")
-                ("hpx:debug-hpx-log", value<std::string>()->implicit_value("cout"),
-                  "enable all messages on the HPX log channel and send all "
-                  "HPX logs to the target destination")
-                ("hpx:debug-timing-log", value<std::string>()->implicit_value("cout"),
-                  "enable all messages on the timing log channel and send all "
-                  "timing logs to the target destination")
-                ("hpx:debug-app-log", value<std::string>()->implicit_value("cout"),
-                  "enable all messages on the application log channel and send all "
-                  "application logs to the target destination")
+            all_options[options_type::debugging_options].add_options()
                 ("hpx:debug-agas-log", value<std::string>()->implicit_value("cout"),
                   "enable all messages on the AGAS log channel and send all "
                   "AGAS logs to the target destination")
@@ -605,21 +349,13 @@ namespace hpx { namespace util {
                 ("hpx:list-component-types", "list all dynamic component types "
                   "after startup")
 #endif
-#if defined(_POSIX_VERSION) || defined(HPX_WINDOWS)
-                ("hpx:attach-debugger",
-                  value<std::string>()->implicit_value("startup"),
-                  "wait for a debugger to be attached, possible values: "
-                  "off, startup, exception or test-failure (default: startup)")
-#endif
 #if defined(HPX_HAVE_NETWORKING)
                 ("hpx:list-parcel-ports", "list all available parcel-ports")
 #endif
             ;
 
 #if defined(HPX_HAVE_DISTRIBUTED_RUNTIME)
-            options_description counter_options(
-                "HPX options related to performance counters");
-            counter_options.add_options()
+            all_options[options_type::counter_options].add_options()
                 ("hpx:print-counter", value<std::vector<std::string> >()->composing(),
                   "print the specified performance counter either repeatedly "
                   "and/or at the times specified by --hpx:print-counter-at "
@@ -676,137 +412,70 @@ namespace hpx { namespace util {
                   "append counter type description to generated output")
             ;
 #endif
+            // clang-format on
 
-            hidden_options.add_options()
-                ("hpx:ignore", "this option will be silently ignored")
-            ;
-            // clang-format off
+            return all_options;
+        }
+    }    // namespace detail
 
+    ///////////////////////////////////////////////////////////////////////////
+    // parse the command line
+    bool parse_commandline(util::section const& rtcfg,
+        hpx::program_options::options_description const& app_options,
+        std::string const& arg0, std::vector<std::string> const& args,
+        hpx::program_options::variables_map& vm, std::size_t node,
+        int error_mode, hpx::runtime_mode mode,
+        hpx::program_options::options_description* visible,
+        std::vector<std::string>* unregistered_options)
+    {
+        using hpx::local::detail::options_type;
+
+        try
+        {
             // construct the overall options description and parse the
             // command line
-            options_description desc_cmdline;
-            options_description positional_options;
-            desc_cmdline
-                .add(app_options).add(cmdline_options)
-                .add(hpx_options)
-                .add(config_options).add(debugging_options)
-                .add(hidden_options)
-            ;
+            hpx::local::detail::options_map all_options =
+                detail::compose_all_options(mode);
+
+            hpx::local::detail::compose_all_options(app_options, all_options);
+
 #if defined(HPX_HAVE_DISTRIBUTED_RUNTIME)
-            desc_cmdline.add(counter_options);
+            all_options[options_type::desc_cmdline].add(
+                all_options[options_type::counter_options]);
+            all_options[options_type::desc_cfgfile].add(
+                all_options[options_type::counter_options]);
 #endif
+            bool result = hpx::local::detail::parse_commandline(rtcfg,
+                all_options, app_options, args, vm, error_mode, visible,
+                unregistered_options);
 
-            options_description desc_cfgfile;
-            desc_cfgfile
-                .add(app_options).add(hpx_options)
-                .add(config_options)
-                .add(debugging_options).add(hidden_options)
-            ;
-#if defined(HPX_HAVE_DISTRIBUTED_RUNTIME)
-            desc_cfgfile.add(counter_options);
-#endif
-
-            if (rtcfg.get_entry("hpx.commandline.allow_unknown", "0") == "0")
+            if (result && visible != nullptr)
             {
-                // move all positional options into the hpx:positional option
-                // group
-                positional_options_description pd;
-                pd.add("hpx:positional", -1);
-
-                positional_options.add_options()
-                    ("hpx:positional", value<std::vector<std::string> >(),
-                      "positional options")
-                ;
-                desc_cmdline.add(positional_options);
-                desc_cfgfile.add(positional_options);
-
-                // parse command line, allow for unregistered options this point
-                parsed_options opts(detail::get_commandline_parser(
-                        command_line_parser(args)
-                            .options(desc_cmdline)
-                            .positional(pd)
-                            .style(unix_style)
-                            .extra_parser(detail::option_parser(rtcfg, node,
-                                error_mode & util::ignore_aliases)),
-                          error_mode & ~util::ignore_aliases
-                    ).run()
-                );
-
-                // collect unregistered options, if needed
-                if (unregistered_options) {
-                    using hpx::program_options::collect_unrecognized;
-                    using hpx::program_options::exclude_positional;
-                    *unregistered_options =
-                        collect_unrecognized(opts.options, exclude_positional);
-
-                    verify_unknown_options(*unregistered_options);
-                }
-
-                store(opts, vm);
-            }
-            else
-            {
-                // parse command line, allow for unregistered options this point
-                parsed_options opts(detail::get_commandline_parser(
-                        command_line_parser(args)
-                            .options(desc_cmdline)
-                            .style(unix_style)
-                            .extra_parser(detail::option_parser(rtcfg, node,
-                                error_mode & util::ignore_aliases)),
-                        error_mode & ~util::ignore_aliases
-                    ).run()
-                );
-
-                // collect unregistered options, if needed
-                if (unregistered_options) {
-                    using hpx::program_options::collect_unrecognized;
-                    using hpx::program_options::include_positional;
-                    *unregistered_options =
-                        collect_unrecognized(opts.options, include_positional);
-
-                    verify_unknown_options(*unregistered_options);
-                }
-
-                store(opts, vm);
+                (*visible).add(all_options[options_type::counter_options]);
             }
 
-            if (vm.count("hpx:help"))
-            {
-                // collect help information
-                if (visible) {
-                    (*visible)
-                        .add(app_options).add(cmdline_options)
-                        .add(hpx_options)
-                        .add(debugging_options).add(config_options)
-                    ;
-#if defined(HPX_HAVE_DISTRIBUTED_RUNTIME)
-                    (*visible).add(counter_options);
-#endif
-                }
-                return true;
-            }
+            detail::handle_generic_config_options(arg0, vm,
+                all_options[options_type::desc_cfgfile], rtcfg, node,
+                error_mode);
+            detail::handle_config_options(vm,
+                all_options[options_type::desc_cfgfile], rtcfg, node,
+                error_mode);
 
-            notify(vm);
-
-            detail::handle_generic_config_options(
-                arg0, vm, desc_cfgfile, rtcfg, node, error_mode);
-            detail::handle_config_options(
-                vm, desc_cfgfile, rtcfg, node, error_mode);
+            return result;
         }
-        catch (std::exception const& e) {
+        catch (std::exception const& e)
+        {
             if (error_mode & rethrow_on_error)
                 throw;
 
-            std::cerr << "hpx::init: exception caught: "
-                      << e.what() << std::endl;
-            return false;
+            std::cerr << "hpx::init: exception caught: " << e.what()
+                      << std::endl;
         }
-        return true;
+        return false;
     }
 
     ///////////////////////////////////////////////////////////////////////////
-    namespace detail
-    {
+    namespace detail {
         std::string extract_arg0(std::string const& cmdline)
         {
             std::string::size_type p = cmdline.find_first_of(" \t");
@@ -816,10 +485,9 @@ namespace hpx { namespace util {
             }
             return cmdline;
         }
-    }
+    }    // namespace detail
 
-    bool parse_commandline(
-        util::section const& rtcfg,
+    bool parse_commandline(util::section const& rtcfg,
         hpx::program_options::options_description const& app_options,
         std::string const& cmdline, hpx::program_options::variables_map& vm,
         std::size_t node, int error_mode, hpx::runtime_mode mode,
@@ -836,62 +504,4 @@ namespace hpx { namespace util {
             detail::extract_arg0(cmdline), args, vm, node, error_mode, mode,
             visible, unregistered_options);
     }
-
-    ///////////////////////////////////////////////////////////////////////////
-    std::string embed_in_quotes(std::string const& s)
-    {
-        char quote = (s.find_first_of('"') != std::string::npos) ? '\'' : '"';
-
-        if (s.find_first_of("\t ") != std::string::npos)
-            return quote + s + quote;
-        return s;
-    }
-
-    void add_as_option(std::string& command_line, std::string const& k,
-        std::string const& v)
-    {
-        command_line += "--" + k;
-        if (!v.empty())
-            command_line += "=" + v;
-    }
-
-    std::string
-    reconstruct_command_line(hpx::program_options::variables_map const &vm)
-    {
-        std::string command_line;
-        for (auto const& v : vm)
-        {
-            hpx::program_options::any const& value = v.second.value();
-            if (hpx::program_options::any_cast<std::string>(&value)) {
-                add_as_option(command_line, v.first,
-                    embed_in_quotes(v.second.as<std::string>()));
-                if (!command_line.empty())
-                    command_line += " ";
-            }
-            else if (hpx::program_options::any_cast<double>(&value)) {
-                add_as_option(command_line, v.first,
-                    std::to_string(v.second.as<double>()));
-                if (!command_line.empty())
-                    command_line += " ";
-            }
-            else if (hpx::program_options::any_cast<int>(&value)) {
-                add_as_option(command_line, v.first,
-                    std::to_string(v.second.as<int>()));
-                if (!command_line.empty())
-                    command_line += " ";
-            }
-            else if (hpx::program_options::any_cast<std::vector<std::string>>(
-                         &value))
-            {
-                auto const& vec = v.second.as<std::vector<std::string>>();
-                for (std::string const& e : vec)
-                {
-                    add_as_option(command_line, v.first, embed_in_quotes(e));
-                    if (!command_line.empty())
-                        command_line += " ";
-                }
-            }
-        }
-        return command_line;
-    }
-}}
+}}    // namespace hpx::util

--- a/libs/full/init_runtime/include/hpx/hpx_init_params.hpp
+++ b/libs/full/init_runtime/include/hpx/hpx_init_params.hpp
@@ -19,6 +19,7 @@
 #include <hpx/runtime_local/startup_function.hpp>
 #include <hpx/type_support/unused.hpp>
 
+#include <cstring>
 #include <functional>
 #include <string>
 #include <vector>
@@ -97,9 +98,16 @@ namespace hpx {
     ///                     function will be executed.
     struct init_params
     {
+        init_params()
+        {
+            std::strncpy(hpx::local::detail::app_name, HPX_APPLICATION_STRING,
+                sizeof(hpx::local::detail::app_name) - 1);
+        }
+
         // Parameters
         std::reference_wrapper<hpx::program_options::options_description const>
-            desc_cmdline = hpx::local::detail::default_desc();
+            desc_cmdline =
+                hpx::local::detail::default_desc(HPX_APPLICATION_STRING);
         std::vector<std::string> cfg;
         mutable startup_function_type startup;
         mutable shutdown_function_type shutdown;


### PR DESCRIPTION
- flyby: add purely local hello world example
- flyby: fix APPLICATION name for local runtime
