### PR TITLE
Modernize dataflow API

### DIFF
--- a/.cmake-format.py
+++ b/.cmake-format.py
@@ -353,6 +353,7 @@ with section("parse"):
                                     'COMPAT_HEADERS': '+',
                                     'DEPENDENCIES': '+',
                                     'EXCLUDE_FROM_GLOBAL_HEADER': '+',
+                                    'ADD_TO_GLOBAL_HEADER': '+',
                                     'GLOBAL_HEADER_GEN': 1,
                                     'HEADERS': '+',
                                     'OBJECTS': '+',

--- a/cmake/HPX_AddModule.cmake
+++ b/cmake/HPX_AddModule.cmake
@@ -20,6 +20,7 @@ function(add_hpx_module libname modulename)
       MODULE_DEPENDENCIES
       CMAKE_SUBDIRS
       EXCLUDE_FROM_GLOBAL_HEADER
+      ADD_TO_GLOBAL_HEADER
   )
   cmake_parse_arguments(
     ${modulename} "${options}" "${one_value_args}" "${multi_value_args}"
@@ -143,7 +144,8 @@ function(add_hpx_module libname modulename)
     foreach(header_file ${${modulename}_HEADERS})
       # Exclude the files specified
       if((NOT (${header_file} IN_LIST ${modulename}_EXCLUDE_FROM_GLOBAL_HEADER))
-         AND (NOT ("${header_file}" MATCHES "detail"))
+         AND (NOT ("${header_file}" MATCHES "detail")
+              OR ${header_file} IN_LIST ${modulename}_ADD_TO_GLOBAL_HEADER)
       )
         set(module_headers "${module_headers}#include <${header_file}>\n")
       endif()

--- a/libs/core/async_base/CMakeLists.txt
+++ b/libs/core/async_base/CMakeLists.txt
@@ -32,7 +32,7 @@ add_hpx_module(
   HEADERS ${async_base_headers}
   COMPAT_HEADERS ${async_base_compat_headers}
   SOURCES ${async_base_sources}
-  MODULE_DEPENDENCIES hpx_allocator_support hpx_config hpx_coroutines
-                      hpx_tag_invoke
+  MODULE_DEPENDENCIES hpx_allocator_support hpx_concepts hpx_config
+                      hpx_coroutines hpx_tag_invoke
   CMAKE_SUBDIRS examples tests
 )

--- a/libs/core/async_base/include/hpx/async_base/dataflow.hpp
+++ b/libs/core/async_base/include/hpx/async_base/dataflow.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2018 Hartmut Kaiser
+//  Copyright (c) 2007-2022 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -7,40 +7,59 @@
 #pragma once
 
 #include <hpx/config.hpp>
-#include <hpx/allocator_support/internal_allocator.hpp>
+#include <hpx/modules/allocator_support.hpp>
+#include <hpx/modules/concepts.hpp>
+#include <hpx/modules/tag_invoke.hpp>
 
 #include <type_traits>
 #include <utility>
 
 ///////////////////////////////////////////////////////////////////////////////
-namespace hpx { namespace lcos { namespace detail {
-    template <typename FD, typename Enable = void>
-    struct dataflow_dispatch;
-}}}    // namespace hpx::lcos::detail
-
-///////////////////////////////////////////////////////////////////////////////
 namespace hpx {
+
+    namespace detail {
+
+        // This CPO must live in hpx::detail for now as the dataflow function
+        // supports being invoked in two forms: dataflow<Action>(...) and
+        // dataflow(Action{}, ...). The only way to support both syntaxes (for
+        // the time being, we will deprecate dataflow<Action>()) is to have a
+        // real function based API that dispatches to the CPO. Once
+        // dataflow<Action>(...) has been removed, this CPO can be moved to
+        // namespace hpx.
+        inline constexpr struct dataflow_t final
+          : hpx::functional::tag<dataflow_t>
+        {
+        private:
+            // clang-format off
+            template <typename F, typename... Ts,
+                HPX_CONCEPT_REQUIRES_(
+                    !hpx::traits::is_allocator_v<std::decay_t<F>>
+                )>
+            // clang-format on
+            friend constexpr HPX_FORCEINLINE auto tag_invoke(
+                dataflow_t tag, F&& f, Ts&&... ts)
+                -> decltype(tag(hpx::util::internal_allocator<>{},
+                    HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...))
+            {
+                return hpx::functional::tag_invoke(tag,
+                    hpx::util::internal_allocator<>{}, HPX_FORWARD(F, f),
+                    HPX_FORWARD(Ts, ts)...);
+            }
+        } dataflow{};
+    }    // namespace detail
+
     template <typename F, typename... Ts>
-    HPX_FORCEINLINE auto dataflow(F&& f, Ts&&... ts) -> decltype(
-        lcos::detail::dataflow_dispatch<typename std::decay<F>::type>::call(
-            hpx::util::internal_allocator<>{}, HPX_FORWARD(F, f),
-            HPX_FORWARD(Ts, ts)...))
+    HPX_FORCEINLINE decltype(auto) dataflow(F&& f, Ts&&... ts)
     {
-        return lcos::detail::dataflow_dispatch<typename std::decay<F>::type>::
-            call(hpx::util::internal_allocator<>{}, HPX_FORWARD(F, f),
-                HPX_FORWARD(Ts, ts)...);
+        return hpx::detail::dataflow(HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...);
     }
 
-    template <typename Allocator, typename F, typename... Ts>
-    HPX_FORCEINLINE auto dataflow_alloc(
-        Allocator const& alloc, F&& f, Ts&&... ts)
-        -> decltype(
-            lcos::detail::dataflow_dispatch<typename std::decay<F>::type>::call(
-                alloc, HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...))
+    template <typename Allocator, typename... Ts>
+    HPX_DEPRECATED_V(
+        1, 9, "hpx::dataflow_alloc is deprecated, use hpx::dataflow instead")
+    decltype(auto) dataflow_alloc(Allocator const& alloc, Ts&&... ts)
     {
-        return lcos::detail::dataflow_dispatch<
-            typename std::decay<F>::type>::call(alloc, HPX_FORWARD(F, f),
-            HPX_FORWARD(Ts, ts)...);
+        return hpx::detail::dataflow(alloc, HPX_FORWARD(Ts, ts)...);
     }
 }    // namespace hpx
 

--- a/libs/core/executors/CMakeLists.txt
+++ b/libs/core/executors/CMakeLists.txt
@@ -90,12 +90,14 @@ add_hpx_module(
   HEADERS ${executors_headers}
   COMPAT_HEADERS ${executors_compat_headers}
   MODULE_DEPENDENCIES
+    hpx_allocator_support
     hpx_async_base
     hpx_concepts
     hpx_config
     hpx_errors
     hpx_execution
     hpx_format
+    hpx_functional
     hpx_futures
     hpx_hardware
     hpx_io_service

--- a/libs/core/functional/include/hpx/functional/invoke_fused.hpp
+++ b/libs/core/functional/include/hpx/functional/invoke_fused.hpp
@@ -55,6 +55,10 @@ namespace hpx::util {
         {
         };
 
+        template <typename F, typename Tuple>
+        using invoke_fused_result_t =
+            typename invoke_fused_result<F, Tuple>::type;
+
         ///////////////////////////////////////////////////////////////////////
         template <std::size_t... Is, typename F, typename Tuple>
         constexpr HPX_HOST_DEVICE HPX_FORCEINLINE

--- a/libs/core/futures/CMakeLists.txt
+++ b/libs/core/futures/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2020 The STE||AR-Group
+# Copyright (c) 2019-2022 The STE||AR-Group
 #
 # SPDX-License-Identifier: BSL-1.0
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -60,8 +60,7 @@ add_hpx_module(
   SOURCES ${futures_sources}
   HEADERS ${futures_headers}
   COMPAT_HEADERS ${futures_compat_headers}
-  EXCLUDE_FROM_GLOBAL_HEADER "hpx/futures/detail/future_data.hpp"
-                             "hpx/futures/detail/future_transforms.hpp"
+  ADD_TO_GLOBAL_HEADER "hpx/futures/detail/future_transforms.hpp"
   MODULE_DEPENDENCIES hpx_async_base hpx_config hpx_allocator_support hpx_errors
                       hpx_memory hpx_synchronization
   CMAKE_SUBDIRS examples tests

--- a/libs/core/resiliency/include/hpx/resiliency/async_replicate.hpp
+++ b/libs/core/resiliency/include/hpx/resiliency/async_replicate.hpp
@@ -11,6 +11,7 @@
 #pragma once
 
 #include <hpx/resiliency/config.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/resiliency/resiliency_cpos.hpp>
 #include <hpx/resiliency/util.hpp>
 
@@ -63,8 +64,9 @@ namespace hpx { namespace resiliency { namespace experimental {
 
                     std::exception_ptr ex;
 
-                    for (auto&& f : HPX_MOVE(results))
+                    for (auto& f : results)
                     {
+                        HPX_ASSERT(f.is_ready());
                         if (f.has_exception())
                         {
                             // rethrow abort_replicate_exception, if caught

--- a/libs/full/async_distributed/tests/unit/remote_dataflow.cpp
+++ b/libs/full/async_distributed/tests/unit/remote_dataflow.cpp
@@ -1,11 +1,12 @@
 //  Copyright (c) 2013 Thomas Heller
-//  Copyright (c) 2015 Hartmut Kaiser
+//  Copyright (c) 2015-2022 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <hpx/config.hpp>
+
 #if !defined(HPX_COMPUTE_DEVICE_CODE)
 #include <hpx/hpx.hpp>
 #include <hpx/hpx_init.hpp>
@@ -42,7 +43,7 @@ void plain_actions(hpx::id_type const& there)
         hpx::future<void> f1 =
             hpx::dataflow(void_f_action(), here, hpx::make_ready_future(42));
         hpx::future<void> f2 =
-            hpx::dataflow<void_f_action>(here, hpx::make_ready_future(42));
+            hpx::dataflow(void_f_action(), here, hpx::make_ready_future(42));
 
         f1.get();
         f2.get();
@@ -52,7 +53,7 @@ void plain_actions(hpx::id_type const& there)
 
     {
         hpx::future<hpx::id_type> f1 = hpx::dataflow(id_f_action(), there);
-        hpx::future<hpx::id_type> f2 = hpx::dataflow<id_f_action>(there);
+        hpx::future<hpx::id_type> f2 = hpx::dataflow(id_f_action(), there);
 
         HPX_TEST_EQ(there, f1.get());
         HPX_TEST_EQ(there, f2.get());
@@ -68,8 +69,8 @@ void plain_actions(hpx::id_type const& there)
 
             hpx::future<void> f1 = hpx::dataflow(
                 policies[i], void_f_action(), here, hpx::make_ready_future(42));
-            hpx::future<void> f2 = hpx::dataflow<void_f_action>(
-                policies[i], here, hpx::make_ready_future(42));
+            hpx::future<void> f2 = hpx::dataflow(
+                policies[i], void_f_action(), here, hpx::make_ready_future(42));
 
             f1.get();
             f2.get();
@@ -81,7 +82,7 @@ void plain_actions(hpx::id_type const& there)
             hpx::future<hpx::id_type> f1 =
                 hpx::dataflow(policies[i], id_f_action(), there);
             hpx::future<hpx::id_type> f2 =
-                hpx::dataflow<id_f_action>(policies[i], there);
+                hpx::dataflow(policies[i], id_f_action(), there);
 
             HPX_TEST_EQ(there, f1.get());
             HPX_TEST_EQ(there, f2.get());
@@ -95,8 +96,8 @@ void plain_actions(hpx::id_type const& there)
 
         hpx::future<void> f1 = hpx::dataflow(
             policy1, void_f_action(), here, hpx::make_ready_future(42));
-        hpx::future<void> f2 = hpx::dataflow<void_f_action>(
-            policy1, here, hpx::make_ready_future(42));
+        hpx::future<void> f2 = hpx::dataflow(
+            policy1, void_f_action(), here, hpx::make_ready_future(42));
 
         f1.get();
         f2.get();
@@ -115,7 +116,7 @@ void plain_actions(hpx::id_type const& there)
         hpx::future<hpx::id_type> f1 =
             hpx::dataflow(policy2, id_f_action(), there);
         hpx::future<hpx::id_type> f2 =
-            hpx::dataflow<id_f_action>(policy2, there);
+            hpx::dataflow(policy2, id_f_action(), there);
 
         HPX_TEST_EQ(there, f1.get());
         HPX_TEST_EQ(there, f2.get());
@@ -147,4 +148,5 @@ int main(int argc, char* argv[])
         "HPX main exited with non-zero status");
     return hpx::util::report_errors();
 }
+
 #endif


### PR DESCRIPTION
- introduce `hpx::detail::dataflow_t` CPO
- deprecate `dataflow_alloc()` and `dataflow<Action>()`
