### PR TITLE
Clean up scan_partitioner

### DIFF
--- a/libs/core/algorithms/include/hpx/parallel/algorithms/remove.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/remove.hpp
@@ -230,8 +230,8 @@ namespace hpx {
 #include <hpx/parallel/util/foreach_partitioner.hpp>
 #include <hpx/parallel/util/invoke_projected.hpp>
 #include <hpx/parallel/util/loop.hpp>
+#include <hpx/parallel/util/partitioner.hpp>
 #include <hpx/parallel/util/projection_identity.hpp>
-#include <hpx/parallel/util/scan_partitioner.hpp>
 #include <hpx/parallel/util/transfer.hpp>
 #include <hpx/parallel/util/zip_iterator.hpp>
 
@@ -308,20 +308,16 @@ namespace hpx { namespace parallel { inline namespace v1 {
 #else
                 boost::shared_array<bool> flags(new bool[count]);
 #endif
-                std::size_t init = 0u;
 
                 using hpx::get;
                 using hpx::util::make_zip_iterator;
-                typedef util::scan_partitioner<ExPolicy, Iter, std::size_t,
-                    void, util::scan_partitioner_sequential_f3_tag>
-                    scan_partitioner_type;
 
                 // Note: replacing the invoke() with HPX_INVOKE()
                 // below makes gcc generate errors
                 auto f1 = [pred = HPX_FORWARD(Pred, pred),
                               proj = HPX_FORWARD(Proj, proj)](
                               zip_iterator part_begin,
-                              std::size_t part_size) -> std::size_t {
+                              std::size_t part_size) -> void {
                     // MSVC complains if pred or proj is captured by ref below
                     util::loop_n<std::decay_t<ExPolicy>>(part_begin, part_size,
                         [pred, proj](zip_iterator it) mutable {
@@ -330,34 +326,15 @@ namespace hpx { namespace parallel { inline namespace v1 {
 
                             get<1>(*it) = f;
                         });
-
-                    // There is no need to return the partition result.
-                    // But, the scan_partitioner doesn't support 'void' as
-                    // Result1. So, unavoidably return non-meaning value.
-                    return 0u;
                 };
 
-                auto f2 = hpx::unwrapping(
-                    [](std::size_t, std::size_t) -> std::size_t {
-                        // There is no need to propagate the partition
-                        // results. But, the scan_partitioner doesn't
-                        // support 'void' as Result1. So, unavoidably
-                        // return non-meaning value.
-                        return 0u;
-                    });
+                auto f2 = [flags, first, count](
+                              auto&& results) mutable -> Iter {
+                    HPX_UNUSED(results);
 
-                std::shared_ptr<Iter> dest_ptr = std::make_shared<Iter>(first);
-                auto f3 =
-                    [dest_ptr, flags](zip_iterator part_begin,
-                        std::size_t part_size,
-                        hpx::shared_future<std::size_t> curr,
-                        hpx::shared_future<std::size_t> next) mutable -> void {
-                    HPX_UNUSED(flags);
-
-                    curr.get();    // rethrow exceptions
-                    next.get();    // rethrow exceptions
-
-                    Iter& dest = *dest_ptr;
+                    auto part_begin = make_zip_iterator(first, flags.get());
+                    auto dest = first;
+                    auto part_size = count;
 
                     using execution_policy_type = std::decay_t<ExPolicy>;
                     if (dest == get<0>(part_begin.get_iterator_tuple()))
@@ -383,34 +360,13 @@ namespace hpx { namespace parallel { inline namespace v1 {
                                     *dest++ = HPX_MOVE(get<0>(*it));
                             });
                     }
+                    return dest;
                 };
 
-                auto f4 =
-                    [dest_ptr, flags](
-                        std::vector<hpx::shared_future<std::size_t>>&& items,
-                        std::vector<hpx::future<void>>&& data) mutable -> Iter {
-                    HPX_UNUSED(flags);
-
-                    // make sure iterators embedded in function object that is
-                    // attached to futures are invalidated
-                    util::detail::clear_container(items);
-                    util::detail::clear_container(data);
-
-                    return *dest_ptr;
-                };
-
-                return scan_partitioner_type::call(
+                return util::partitioner<ExPolicy, Iter, void>::call(
                     HPX_FORWARD(ExPolicy, policy),
-                    make_zip_iterator(first, flags.get()), count, init,
-                    // step 1 performs first part of scan algorithm
-                    HPX_MOVE(f1),
-                    // step 2 propagates the partition results from left
-                    // to right
-                    HPX_MOVE(f2),
-                    // step 3 runs final accumulation on each partition
-                    HPX_MOVE(f3),
-                    // step 4 use this return value
-                    HPX_MOVE(f4));
+                    make_zip_iterator(first, flags.get()), count, HPX_MOVE(f1),
+                    HPX_MOVE(f2));
             }
         };
         /// \endcond

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/unique.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/unique.hpp
@@ -312,6 +312,7 @@ namespace hpx {
 #include <hpx/parallel/util/detail/sender_util.hpp>
 #include <hpx/parallel/util/foreach_partitioner.hpp>
 #include <hpx/parallel/util/loop.hpp>
+#include <hpx/parallel/util/partitioner.hpp>
 #include <hpx/parallel/util/projection_identity.hpp>
 #include <hpx/parallel/util/scan_partitioner.hpp>
 #include <hpx/parallel/util/transfer.hpp>
@@ -407,20 +408,15 @@ namespace hpx { namespace parallel { inline namespace v1 {
 #else
                 boost::shared_array<bool> flags(new bool[count]);
 #endif
-                std::size_t init = 0u;
-
                 flags[0] = false;
 
                 using hpx::get;
                 using hpx::util::make_zip_iterator;
-                using scan_partitioner_type =
-                    util::scan_partitioner<ExPolicy, FwdIter, std::size_t, void,
-                        util::scan_partitioner_sequential_f3_tag>;
 
                 auto f1 = [pred = HPX_FORWARD(Pred, pred),
                               proj = HPX_FORWARD(Proj, proj)](
                               zip_iterator part_begin,
-                              std::size_t part_size) -> std::size_t {
+                              std::size_t part_size) -> void {
                     FwdIter base = get<0>(part_begin.get_iterator_tuple());
 
                     // Note: replacing the invoke() with HPX_INVOKE()
@@ -437,26 +433,16 @@ namespace hpx { namespace parallel { inline namespace v1 {
                             if (!(get<1>(*it) = f))
                                 base = get<0>(it.get_iterator_tuple());
                         });
-
-                    // There is no need to return the partition result.
-                    // But, the scan_partitioner doesn't support 'void' as
-                    // Result1. So, unavoidably return non-meaning value.
-                    return 0u;
                 };
 
-                std::shared_ptr<FwdIter> dest_ptr =
-                    std::make_shared<FwdIter>(first);
-                auto f3 =
-                    [dest_ptr, flags](zip_iterator part_begin,
-                        std::size_t part_size,
-                        hpx::shared_future<std::size_t> curr,
-                        hpx::shared_future<std::size_t> next) mutable -> void {
-                    HPX_UNUSED(flags);
+                auto f2 = [flags, first, count](
+                              auto&& results) mutable -> FwdIter {
+                    // HPX_UNUSED(flags);
+                    HPX_UNUSED(results);
 
-                    curr.get();    // rethrow exceptions
-                    next.get();    // rethrow exceptions
-
-                    FwdIter& dest = *dest_ptr;
+                    auto part_begin = make_zip_iterator(first, flags.get());
+                    auto dest = first;
+                    auto part_size = count;
 
                     using execution_policy_type = std::decay_t<ExPolicy>;
                     if (dest == get<0>(part_begin.get_iterator_tuple()))
@@ -482,50 +468,14 @@ namespace hpx { namespace parallel { inline namespace v1 {
                                     *dest++ = HPX_MOVE(get<0>(*it));
                             });
                     }
+
+                    return dest;
                 };
 
-                auto f4 =
-                    [dest_ptr = HPX_MOVE(dest_ptr), first, count, flags](
-                        std::vector<hpx::shared_future<std::size_t>>&& items,
-                        std::vector<hpx::future<void>>&& data) mutable
-                    -> FwdIter {
-                    // make sure iterators embedded in function object that is
-                    // attached to futures are invalidated
-                    util::detail::clear_container(items);
-                    util::detail::clear_container(data);
-
-                    if (!flags[count - 1])
-                    {
-                        std::advance(first, count - 1);
-                        if (first != (*dest_ptr))
-                            *(*dest_ptr)++ = HPX_MOVE(*first);
-                        else
-                            ++(*dest_ptr);
-                    }
-                    return *dest_ptr;
-                };
-
-                return scan_partitioner_type::call(
+                return util::partitioner<ExPolicy, FwdIter, void>::call(
                     HPX_FORWARD(ExPolicy, policy),
-                    make_zip_iterator(first, flags.get()), count - 1, init,
-                    // step 1 performs first part of scan algorithm
-                    HPX_MOVE(f1),
-                    // step 2 propagates the partition results from left
-                    // to right
-                    [](hpx::shared_future<std::size_t> fut1,
-                        hpx::shared_future<std::size_t> fut2) -> std::size_t {
-                        fut1.get();
-                        fut2.get();    // propagate exceptions
-                        // There is no need to propagate the partition
-                        // results. But, the scan_partitioner doesn't
-                        // support 'void' as Result1. So, unavoidably
-                        // return non-meaning value.
-                        return 0u;
-                    },
-                    // step 3 runs final accumulation on each partition
-                    HPX_MOVE(f3),
-                    // step 4 use this return value
-                    HPX_MOVE(f4));
+                    make_zip_iterator(first, flags.get()), count - 1,
+                    HPX_MOVE(f1), HPX_MOVE(f2));
             }
         };
         /// \endcond

--- a/libs/core/algorithms/include/hpx/parallel/util/scan_partitioner.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/util/scan_partitioner.hpp
@@ -37,20 +37,14 @@
 
 ///////////////////////////////////////////////////////////////////////////////
 namespace hpx { namespace parallel { namespace util {
-    struct scan_partitioner_normal_tag
-    {
-    };
-    struct scan_partitioner_sequential_f3_tag
-    {
-    };
 
     ///////////////////////////////////////////////////////////////////////////
     namespace detail {
         ///////////////////////////////////////////////////////////////////////
         // The static partitioner simply spawns one chunk of iterations for
         // each available core.
-        template <typename ExPolicy, typename ScanPartTag, typename R,
-            typename Result1, typename Result2>
+        template <typename ExPolicy, typename R, typename Result1,
+            typename Result2>
         struct scan_static_partitioner
         {
             using parameters_type = typename ExPolicy::executor_parameters_type;
@@ -65,9 +59,8 @@ namespace hpx { namespace parallel { namespace util {
 
             template <typename ExPolicy_, typename FwdIter, typename T,
                 typename F1, typename F2, typename F3, typename F4>
-            static R call(scan_partitioner_normal_tag, ExPolicy_ policy,
-                FwdIter first, std::size_t count, T&& init, F1&& f1, F2&& f2,
-                F3&& f3, F4&& f4)
+            static R call(ExPolicy_ policy, FwdIter first, std::size_t count,
+                T&& init, F1&& f1, F2&& f2, F3&& f3, F4&& f4)
             {
 #if defined(HPX_COMPUTE_DEVICE_CODE)
                 HPX_UNUSED(policy);
@@ -185,188 +178,7 @@ namespace hpx { namespace parallel { namespace util {
 #endif
             }
 
-            template <typename ExPolicy_, typename FwdIter, typename T,
-                typename F1, typename F2, typename F3, typename F4>
-            static R call(scan_partitioner_sequential_f3_tag, ExPolicy_ policy,
-                FwdIter first, std::size_t count, T&& init, F1&& f1, F2&& f2,
-                F3&& f3, F4&& f4)
-            {
-#if defined(HPX_COMPUTE_DEVICE_CODE)
-                HPX_UNUSED(policy);
-                HPX_UNUSED(first);
-                HPX_UNUSED(count);
-                HPX_UNUSED(init);
-                HPX_UNUSED(f1);
-                HPX_UNUSED(f2);
-                HPX_UNUSED(f3);
-                HPX_UNUSED(f4);
-                HPX_ASSERT(false);
-                return R();
-#else
-                // inform parameter traits
-                scoped_executor_parameters scoped_params(
-                    policy.parameters(), policy.executor());
-
-                std::vector<hpx::shared_future<Result1>> workitems;
-                std::vector<hpx::future<Result2>> finalitems;
-                std::list<std::exception_ptr> errors;
-                try
-                {
-                    // pre-initialize first intermediate result
-                    workitems.push_back(
-                        make_ready_future(HPX_FORWARD(T, init)));
-
-                    HPX_ASSERT(count > 0);
-                    FwdIter first_ = first;
-                    std::size_t count_ = count;
-                    bool tested = false;
-
-                    // estimate a chunk size based on number of cores used
-                    typedef typename execution::extract_has_variable_chunk_size<
-                        parameters_type>::type has_variable_chunk_size;
-
-                    auto shape = detail::get_bulk_iteration_shape(
-                        has_variable_chunk_size(), policy, workitems, f1, first,
-                        count, 1);
-
-                    // schedule every chunk on a separate thread
-                    std::size_t size = hpx::util::size(shape);
-
-                    // If the size of count was enough to warrant testing for a
-                    // chunk, pre-initialize second intermediate result.
-                    if (workitems.size() == 2)
-                    {
-                        workitems.reserve(size + 2);
-                        finalitems.reserve(size + 1);
-
-                        hpx::shared_future<Result1> curr = workitems[1];
-                        workitems[1] =
-                            dataflow(hpx::launch::sync, f2, workitems[0], curr);
-                        tested = true;
-                    }
-                    else
-                    {
-                        workitems.reserve(size + 1);
-                        finalitems.reserve(size);
-                    }
-
-                    // Schedule first step of scan algorithm, step 2 is
-                    // performed as soon as the current partition and the
-                    // partition to the left is ready.
-                    for (auto const& elem : shape)
-                    {
-                        FwdIter it = hpx::get<0>(elem);
-                        std::size_t size = hpx::get<1>(elem);
-
-                        hpx::shared_future<Result1> prev = workitems.back();
-                        auto curr = execution::async_execute(
-                            policy.executor(), f1, it, size)
-                                        .share();
-
-                        workitems.push_back(
-                            dataflow(hpx::launch::sync, f2, prev, curr));
-                    }
-
-                    // In the code below, performs step 3 sequentially.
-                    auto shape_iter = std::begin(shape);
-
-                    // First, perform f3 of the first partition.
-                    if (tested)
-                    {
-                        HPX_ASSERT(count_ > count);
-
-                        finalitems.push_back(
-                            dataflow(hpx::launch::sync, f3, first_,
-                                count_ - count, workitems[0], workitems[1]));
-                    }
-                    else
-                    {
-                        auto elem = *shape_iter++;
-                        FwdIter it = hpx::get<0>(elem);
-                        std::size_t size = hpx::get<1>(elem);
-
-                        finalitems.push_back(dataflow(hpx::launch::sync, f3, it,
-                            size, workitems[0], workitems[1]));
-                    }
-
-                    HPX_ASSERT(finalitems.size() >= 1);
-
-                    // Perform f3 sequentially from the second to the end
-                    // of partitions.
-                    for (std::size_t widx = 1ul; shape_iter != std::end(shape);
-                         ++shape_iter, ++widx)
-                    {
-                        auto elem = *shape_iter;
-                        FwdIter it = hpx::get<0>(elem);
-                        std::size_t size = hpx::get<1>(elem);
-
-                        // Wait the completion of f3 on previous partition.
-                        finalitems.back().wait();
-
-                        finalitems.push_back(dataflow(hpx::launch::sync, f3, it,
-                            size, workitems[widx], workitems[widx + 1]));
-                    }
-
-                    scoped_params.mark_end_of_scheduling();
-                }
-                catch (...)
-                {
-                    handle_local_exceptions::call(
-                        std::current_exception(), errors);
-                }
-                return reduce(HPX_MOVE(workitems), HPX_MOVE(finalitems),
-                    HPX_MOVE(errors), HPX_FORWARD(F4, f4));
-#endif
-            }
-
-            template <typename ExPolicy_, typename FwdIter, typename T,
-                typename F1, typename F2, typename F3, typename F4>
-            static R call(ExPolicy_&& policy, FwdIter first, std::size_t count,
-                T&& init, F1&& f1, F2&& f2, F3&& f3, F4&& f4)
-            {
-                return call(ScanPartTag{}, HPX_FORWARD(ExPolicy_, policy),
-                    first, count, HPX_FORWARD(T, init), HPX_FORWARD(F1, f1),
-                    HPX_FORWARD(F2, f2), HPX_FORWARD(F3, f3),
-                    HPX_FORWARD(F4, f4));
-            }
-
         private:
-            template <typename F>
-            static R reduce(
-                std::vector<hpx::shared_future<Result1>>&& workitems,
-                std::vector<hpx::future<Result2>>&& finalitems,
-                std::list<std::exception_ptr>&& errors, F&& f)
-            {
-#if defined(HPX_COMPUTE_DEVICE_CODE)
-                HPX_UNUSED(workitems);
-                HPX_UNUSED(finalitems);
-                HPX_UNUSED(errors);
-                HPX_UNUSED(f);
-                HPX_ASSERT(false);
-                return R();
-#else
-                // wait for all tasks to finish
-                if (hpx::wait_all_nothrow(workitems, finalitems) ||
-                    !errors.empty())
-                {
-                    // always rethrow if 'errors' is not empty or 'workitems' or
-                    // 'finalitems' have an exceptional future
-                    handle_local_exceptions::call(workitems, errors);
-                    handle_local_exceptions::call(finalitems, errors);
-                }
-
-                try
-                {
-                    return f(HPX_MOVE(workitems), HPX_MOVE(finalitems));
-                }
-                catch (...)
-                {
-                    // rethrow either bad_alloc or exception_list
-                    handle_local_exceptions::call(std::current_exception());
-                }
-#endif
-            }
-
             template <typename F>
             static R reduce(std::vector<Result1>&& workitems,
                 std::vector<hpx::future<Result2>>&& finalitems,
@@ -402,8 +214,8 @@ namespace hpx { namespace parallel { namespace util {
         };
 
         ///////////////////////////////////////////////////////////////////////
-        template <typename ExPolicy, typename ScanPartTag, typename R,
-            typename Result1, typename Result2>
+        template <typename ExPolicy, typename R, typename Result1,
+            typename Result2>
         struct scan_task_static_partitioner
         {
             template <typename ExPolicy_, typename FwdIter, typename T,
@@ -417,9 +229,9 @@ namespace hpx { namespace parallel { namespace util {
                         f2 = HPX_FORWARD(F2, f2), f3 = HPX_FORWARD(F3, f3),
                         f4 = HPX_FORWARD(F4, f4)]() mutable -> R {
                         using partitioner_type =
-                            scan_static_partitioner<ExPolicy, ScanPartTag, R,
-                                Result1, Result2>;
-                        return partitioner_type::call(ScanPartTag{},
+                            scan_static_partitioner<ExPolicy, R, Result1,
+                                Result2>;
+                        return partitioner_type::call(
                             HPX_FORWARD(ExPolicy_, policy), first, count,
                             HPX_MOVE(init), f1, f2, f3, f4);
                     });
@@ -432,15 +244,13 @@ namespace hpx { namespace parallel { namespace util {
     // R:           overall result type
     // Result1:     intermediate result type of first and second step
     // Result2:     intermediate result of the third step
-    // ScanPartTag: select appropriate policy of scan partitioner
     template <typename ExPolicy, typename R = void, typename Result1 = R,
-        typename Result2 = void,
-        typename ScanPartTag = scan_partitioner_normal_tag>
+        typename Result2 = void>
     struct scan_partitioner
       : detail::select_partitioner<typename std::decay<ExPolicy>::type,
             detail::scan_static_partitioner,
-            detail::scan_task_static_partitioner>::template apply<ScanPartTag,
-            R, Result1, Result2>
+            detail::scan_task_static_partitioner>::template apply<R, Result1,
+            Result2>
     {
     };
 }}}    // namespace hpx::parallel::util


### PR DESCRIPTION
  - Removed scan_partitioner sequential f3 implementation (obsolete)
  - Refactored parallel algorithms that used above implementation ("remove" and "unique") to use util::partitioner instead
  - Marginal performance improvement (if any)

