### PR TITLE
Generalize the use of then() and dataflow

### DIFF
--- a/libs/core/algorithms/include/hpx/parallel/algorithms/detail/dispatch.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/detail/dispatch.hpp
@@ -179,8 +179,23 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
         HPX_FORCEINLINE static constexpr decltype(auto) call2(
             ExPolicy&& policy, std::false_type, Args&&... args)
         {
-            return Derived::parallel(
-                HPX_FORWARD(ExPolicy, policy), HPX_FORWARD(Args, args)...);
+            using result_handler =
+                hpx::parallel::util::detail::algorithm_result<ExPolicy,
+                    local_result_type>;
+            using result_type = decltype(Derived::parallel(
+                HPX_FORWARD(ExPolicy, policy), HPX_FORWARD(Args, args)...));
+
+            if constexpr (std::is_void_v<result_type>)
+            {
+                Derived::parallel(
+                    HPX_FORWARD(ExPolicy, policy), HPX_FORWARD(Args, args)...);
+                return result_handler::get();
+            }
+            else
+            {
+                return result_handler::get(Derived::parallel(
+                    HPX_FORWARD(ExPolicy, policy), HPX_FORWARD(Args, args)...));
+            }
         }
 
         template <typename ExPolicy, typename... Args>

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/for_each.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/for_each.hpp
@@ -475,9 +475,8 @@ namespace hpx { namespace parallel { inline namespace v1 {
 
             template <typename ExPolicy, typename FwdIter, typename F,
                 typename Proj = util::projection_identity>
-            static util::detail::algorithm_result_t<ExPolicy, FwdIter> parallel(
-                ExPolicy&& policy, FwdIter first, std::size_t count, F&& f,
-                Proj&& proj /* = Proj()*/)
+            static decltype(auto) parallel(ExPolicy&& policy, FwdIter first,
+                std::size_t count, F&& f, Proj&& proj /* = Proj()*/)
             {
                 if constexpr (!hpx::execution_policy_has_scheduler_executor_v<
                                   ExPolicy>)

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/reverse.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/reverse.hpp
@@ -232,9 +232,8 @@ namespace hpx { namespace parallel { inline namespace v1 {
             }
 
             template <typename ExPolicy, typename BidirIter, typename Sent>
-            static typename util::detail::algorithm_result<ExPolicy,
-                BidirIter>::type
-            parallel(ExPolicy&& policy, BidirIter first, Sent last)
+            static decltype(auto) parallel(
+                ExPolicy&& policy, BidirIter first, Sent last)
             {
                 using destination_iterator = std::reverse_iterator<BidirIter>;
                 using zip_iterator =
@@ -255,8 +254,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                             std::swap(get<0>(t), get<1>(t));
                         },
                         util::projection_identity()),
-                    [last2](
-                        zip_iterator const&) -> BidirIter { return last2; });
+                    [last2](auto) -> BidirIter { return last2; });
             }
         };
         /// \endcond
@@ -265,18 +263,17 @@ namespace hpx { namespace parallel { inline namespace v1 {
     // clang-format off
     template <typename ExPolicy, typename BidirIter,
         HPX_CONCEPT_REQUIRES_(
-            hpx::is_execution_policy<ExPolicy>::value &&
-            hpx::traits::is_iterator<BidirIter>::value
+            hpx::is_execution_policy_v<ExPolicy> &&
+            hpx::traits::is_iterator_v<BidirIter>
         )>
     // clang-format on
     HPX_DEPRECATED_V(1, 7,
         "hpx::parallel::reverse is deprecated, use hpx::reverse "
         "instead")
-        typename util::detail::algorithm_result<ExPolicy, BidirIter>::type
-        reverse(ExPolicy&& policy, BidirIter first, BidirIter last)
+        util::detail::algorithm_result_t<ExPolicy, BidirIter> reverse(
+            ExPolicy&& policy, BidirIter first, BidirIter last)
     {
-        static_assert(
-            (hpx::traits::is_bidirectional_iterator<BidirIter>::value),
+        static_assert((hpx::traits::is_bidirectional_iterator_v<BidirIter>),
             "Requires at least bidirectional iterator.");
 
         return detail::reverse<BidirIter>().call(
@@ -320,8 +317,8 @@ namespace hpx { namespace parallel { inline namespace v1 {
 
             template <typename ExPolicy, typename BidirIter, typename Sent,
                 typename FwdIter>
-            static typename util::detail::algorithm_result<ExPolicy,
-                util::in_out_result<BidirIter, FwdIter>>::type
+            static util::detail::algorithm_result_t<ExPolicy,
+                util::in_out_result<BidirIter, FwdIter>>
             parallel(ExPolicy&& policy, BidirIter first, Sent last,
                 FwdIter dest_first)
             {
@@ -345,22 +342,20 @@ namespace hpx { namespace parallel { inline namespace v1 {
     // clang-format off
     template <typename ExPolicy, typename BidirIter, typename FwdIter,
         HPX_CONCEPT_REQUIRES_(
-            hpx::traits::is_iterator<BidirIter>::value &&
-            hpx::is_execution_policy<ExPolicy>::value &&
-            hpx::traits::is_iterator<FwdIter>::value
+            hpx::traits::is_iterator_v<BidirIter> &&
+            hpx::is_execution_policy_v<ExPolicy> &&
+            hpx::traits::is_iterator_v<FwdIter>
         )>
     // clang-format on
     HPX_DEPRECATED_V(1, 7,
         "hpx::parallel::reverse_copy is deprecated, use hpx::reverse_copy "
-        "instead") typename util::detail::algorithm_result<ExPolicy,
-        util::in_out_result<BidirIter, FwdIter>>::type
-        reverse_copy(ExPolicy&& policy, BidirIter first, BidirIter last,
-            FwdIter dest_first)
+        "instead") util::detail::algorithm_result_t<ExPolicy,
+        util::in_out_result<BidirIter, FwdIter>> reverse_copy(ExPolicy&& policy,
+        BidirIter first, BidirIter last, FwdIter dest_first)
     {
-        static_assert(
-            (hpx::traits::is_bidirectional_iterator<BidirIter>::value),
+        static_assert((hpx::traits::is_bidirectional_iterator_v<BidirIter>),
             "Requires at least bidirectional iterator.");
-        static_assert((hpx::traits::is_forward_iterator<FwdIter>::value),
+        static_assert((hpx::traits::is_forward_iterator_v<FwdIter>),
             "Requires at least forward iterator.");
 
         return detail::reverse_copy<util::in_out_result<BidirIter, FwdIter>>()
@@ -369,8 +364,9 @@ namespace hpx { namespace parallel { inline namespace v1 {
 }}}    // namespace hpx::parallel::v1
 
 namespace hpx {
+
     ///////////////////////////////////////////////////////////////////////////
-    // DPO for hpx::reverse
+    // CPO for hpx::reverse
     inline constexpr struct reverse_t final
       : hpx::detail::tag_parallel_algorithm<reverse_t>
     {
@@ -378,14 +374,13 @@ namespace hpx {
         // clang-format off
         template <typename BidirIter,
             HPX_CONCEPT_REQUIRES_(
-                hpx::traits::is_iterator<BidirIter>::value
+                hpx::traits::is_iterator_v<BidirIter>
             )>
         // clang-format on
         friend void tag_fallback_invoke(
             hpx::reverse_t, BidirIter first, BidirIter last)
         {
-            static_assert(
-                (hpx::traits::is_bidirectional_iterator<BidirIter>::value),
+            static_assert((hpx::traits::is_bidirectional_iterator_v<BidirIter>),
                 "Requires at least bidirectional iterator.");
 
             hpx::parallel::v1::detail::reverse<BidirIter>().call(
@@ -395,17 +390,14 @@ namespace hpx {
         // clang-format off
         template <typename ExPolicy, typename BidirIter,
             HPX_CONCEPT_REQUIRES_(
-                hpx::traits::is_iterator<BidirIter>::value &&
-                hpx::is_execution_policy<ExPolicy>::value
+                hpx::traits::is_iterator_v<BidirIter> &&
+                hpx::is_execution_policy_v<ExPolicy>
             )>
         // clang-format on
-        friend typename parallel::util::detail::algorithm_result<ExPolicy,
-            void>::type
-        tag_fallback_invoke(
+        friend decltype(auto) tag_fallback_invoke(
             hpx::reverse_t, ExPolicy&& policy, BidirIter first, BidirIter last)
         {
-            static_assert(
-                (hpx::traits::is_bidirectional_iterator<BidirIter>::value),
+            static_assert((hpx::traits::is_bidirectional_iterator_v<BidirIter>),
                 "Requires at least bidirectional iterator.");
 
             return parallel::util::detail::algorithm_result<ExPolicy>::get(
@@ -415,7 +407,7 @@ namespace hpx {
     } reverse{};
 
     ///////////////////////////////////////////////////////////////////////////
-    // DPO for hpx::reverse_copy
+    // CPO for hpx::reverse_copy
     inline constexpr struct reverse_copy_t final
       : hpx::detail::tag_parallel_algorithm<reverse_copy_t>
     {
@@ -423,18 +415,17 @@ namespace hpx {
         // clang-format off
         template <typename BidirIter, typename OutIter,
             HPX_CONCEPT_REQUIRES_(
-                hpx::traits::is_iterator<BidirIter>::value &&
-                hpx::traits::is_iterator<OutIter>::value
+                hpx::traits::is_iterator_v<BidirIter> &&
+                hpx::traits::is_iterator_v<OutIter>
             )>
         // clang-format on
         friend OutIter tag_fallback_invoke(
             hpx::reverse_copy_t, BidirIter first, BidirIter last, OutIter dest)
         {
-            static_assert(
-                (hpx::traits::is_bidirectional_iterator<BidirIter>::value),
+            static_assert((hpx::traits::is_bidirectional_iterator_v<BidirIter>),
                 "Requires at least bidirectional iterator.");
 
-            static_assert((hpx::traits::is_output_iterator<OutIter>::value),
+            static_assert((hpx::traits::is_output_iterator_v<OutIter>),
                 "Requires at least output iterator.");
 
             return parallel::util::get_second_element(
@@ -447,21 +438,19 @@ namespace hpx {
         // clang-format off
         template <typename ExPolicy, typename BidirIter, typename FwdIter,
             HPX_CONCEPT_REQUIRES_(
-                hpx::traits::is_iterator<BidirIter>::value &&
-                hpx::is_execution_policy<ExPolicy>::value &&
-                hpx::traits::is_iterator<FwdIter>::value
+                hpx::traits::is_iterator_v<BidirIter> &&
+                hpx::is_execution_policy_v<ExPolicy> &&
+                hpx::traits::is_iterator_v<FwdIter>
             )>
         // clang-format on
-        friend typename parallel::util::detail::algorithm_result<ExPolicy,
-            FwdIter>::type
+        friend parallel::util::detail::algorithm_result_t<ExPolicy, FwdIter>
         tag_fallback_invoke(hpx::reverse_copy_t, ExPolicy&& policy,
             BidirIter first, BidirIter last, FwdIter dest)
         {
-            static_assert(
-                (hpx::traits::is_bidirectional_iterator<BidirIter>::value),
+            static_assert((hpx::traits::is_bidirectional_iterator_v<BidirIter>),
                 "Requires at least bidirectional iterator.");
 
-            static_assert((hpx::traits::is_forward_iterator<FwdIter>::value),
+            static_assert((hpx::traits::is_forward_iterator_v<FwdIter>),
                 "Requires at least forward iterator.");
 
             return parallel::util::get_second_element(

--- a/libs/core/algorithms/include/hpx/parallel/util/detail/sender_util.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/util/detail/sender_util.hpp
@@ -97,7 +97,7 @@ namespace hpx::detail {
         }
     }
 
-    // Helper base class for implementing parallel algorithm DPOs. See
+    // Helper base class for implementing parallel algorithm CPOs. See
     // tag_fallback documentation for details. Compared to tag_fallback this
     // adds two tag_fallback_invoke overloads that are generic for all
     // parallel algorithms:

--- a/libs/core/algorithms/tests/unit/algorithms/CMakeLists.txt
+++ b/libs/core/algorithms/tests/unit/algorithms/CMakeLists.txt
@@ -106,8 +106,10 @@ set(tests
     replace_copy_if
     reverse
     reverse_copy
+    reverse_sender
     rotate
     rotate_copy
+    rotate_sender
     search
     searchn
     set_difference

--- a/libs/core/algorithms/tests/unit/algorithms/foreach_sender.cpp
+++ b/libs/core/algorithms/tests/unit/algorithms/foreach_sender.cpp
@@ -7,9 +7,10 @@
 #include <hpx/local/execution.hpp>
 #include <hpx/local/init.hpp>
 #include <hpx/local/thread.hpp>
+#include <hpx/modules/async_base.hpp>
 #include <hpx/modules/iterator_support.hpp>
 #include <hpx/modules/testing.hpp>
-#include <hpx/parallel/container_algorithms/for_each.hpp>
+#include <hpx/parallel/algorithms/for_each.hpp>
 
 #include <algorithm>
 #include <cstddef>

--- a/libs/core/algorithms/tests/unit/algorithms/reverse_sender.cpp
+++ b/libs/core/algorithms/tests/unit/algorithms/reverse_sender.cpp
@@ -1,0 +1,202 @@
+//  Copyright (c) 2007-2022 Hartmut Kaiser
+//  Copyright (c)      2021 Giannis Gonidelis
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/local/execution.hpp>
+#include <hpx/local/init.hpp>
+#include <hpx/local/thread.hpp>
+#include <hpx/modules/async_base.hpp>
+#include <hpx/modules/testing.hpp>
+#include <hpx/parallel/algorithms/reverse.hpp>
+
+#include <cstddef>
+#include <iostream>
+#include <iterator>
+#include <numeric>
+#include <string>
+#include <vector>
+
+#include "test_utils.hpp"
+
+///////////////////////////////////////////////////////////////////////////////
+template <typename Policy, typename ExPolicy, typename IteratorTag>
+void test_reverse_direct(Policy l, ExPolicy&& policy, IteratorTag)
+{
+    static_assert(hpx::is_execution_policy_v<ExPolicy>,
+        "hpx::is_execution_policy_v<ExPolicy>");
+
+    typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+
+    namespace ex = hpx::execution::experimental;
+    namespace tt = hpx::this_thread::experimental;
+
+    std::vector<std::size_t> c(10007);
+    std::vector<std::size_t> d1;
+
+    std::iota(std::begin(c), std::end(c), std::rand());
+    std::copy(std::begin(c), std::end(c), std::back_inserter(d1));
+
+    using scheduler_t = ex::thread_pool_policy_scheduler<Policy>;
+
+    auto exec = ex::explicit_scheduler_executor(scheduler_t(l));
+    hpx::reverse(
+        policy.on(exec), iterator(std::begin(c)), iterator(std::end(c)));
+
+    std::reverse(std::begin(d1), std::end(d1));
+
+    std::size_t count = 0;
+    HPX_TEST(std::equal(std::begin(c), std::end(c), std::begin(d1),
+        [&count](std::size_t v1, std::size_t v2) -> bool {
+            HPX_TEST_EQ(v1, v2);
+            ++count;
+            return v1 == v2;
+        }));
+    HPX_TEST_EQ(count, d1.size());
+}
+
+template <typename Policy, typename ExPolicy, typename IteratorTag>
+void test_reverse(Policy l, ExPolicy&& policy, IteratorTag)
+{
+    static_assert(hpx::is_execution_policy_v<ExPolicy>,
+        "hpx::is_execution_policy_v<ExPolicy>");
+
+    typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+
+    namespace ex = hpx::execution::experimental;
+    namespace tt = hpx::this_thread::experimental;
+
+    std::vector<std::size_t> c(10007);
+    std::vector<std::size_t> d1;
+
+    std::iota(std::begin(c), std::end(c), std::rand());
+    std::copy(std::begin(c), std::end(c), std::back_inserter(d1));
+
+    using scheduler_t = ex::thread_pool_policy_scheduler<Policy>;
+
+    auto exec = ex::explicit_scheduler_executor(scheduler_t(l));
+    ex::just(iterator(std::begin(c)), iterator(std::end(c))) |
+        hpx::reverse(policy.on(exec)) | tt::sync_wait();
+
+    std::reverse(std::begin(d1), std::end(d1));
+
+    std::size_t count = 0;
+    HPX_TEST(std::equal(std::begin(c), std::end(c), std::begin(d1),
+        [&count](std::size_t v1, std::size_t v2) -> bool {
+            HPX_TEST_EQ(v1, v2);
+            ++count;
+            return v1 == v2;
+        }));
+    HPX_TEST_EQ(count, d1.size());
+}
+
+template <typename Policy, typename ExPolicy, typename IteratorTag>
+void test_reverse_async_direct(Policy l, ExPolicy&& p, IteratorTag)
+{
+    typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+
+    namespace ex = hpx::execution::experimental;
+    namespace tt = hpx::this_thread::experimental;
+
+    std::vector<std::size_t> c(10007);
+    std::vector<std::size_t> d1;
+
+    std::iota(std::begin(c), std::end(c), std::rand());
+    std::copy(std::begin(c), std::end(c), std::back_inserter(d1));
+
+    using scheduler_t = ex::thread_pool_policy_scheduler<Policy>;
+
+    auto exec = ex::explicit_scheduler_executor(scheduler_t(l));
+    hpx::reverse(p.on(exec), iterator(std::begin(c)), iterator(std::end(c))) |
+        tt::sync_wait();
+
+    std::reverse(std::begin(d1), std::end(d1));
+
+    std::size_t count = 0;
+    HPX_TEST(std::equal(std::begin(c), std::end(c), std::begin(d1),
+        [&count](std::size_t v1, std::size_t v2) -> bool {
+            HPX_TEST_EQ(v1, v2);
+            ++count;
+            return v1 == v2;
+        }));
+    HPX_TEST_EQ(count, d1.size());
+}
+
+template <typename IteratorTag>
+void test_reverse_direct()
+{
+    using namespace hpx::execution;
+
+    test_reverse_direct(hpx::launch::sync, seq, IteratorTag());
+    test_reverse_direct(hpx::launch::sync, unseq, IteratorTag());
+
+    test_reverse_direct(hpx::launch::async, par, IteratorTag());
+    test_reverse_direct(hpx::launch::async, par_unseq, IteratorTag());
+
+    test_reverse_async_direct(hpx::launch::sync, seq(task), IteratorTag());
+    test_reverse_async_direct(hpx::launch::async, par(task), IteratorTag());
+}
+
+template <typename IteratorTag>
+void test_reverse()
+{
+    using namespace hpx::execution;
+
+    test_reverse(hpx::launch::sync, seq(task), IteratorTag());
+    test_reverse(hpx::launch::sync, unseq(task), IteratorTag());
+
+    test_reverse(hpx::launch::async, par(task), IteratorTag());
+    test_reverse(hpx::launch::async, par_unseq(task), IteratorTag());
+}
+
+void reverse_test()
+{
+    test_reverse_direct<std::random_access_iterator_tag>();
+    test_reverse_direct<std::bidirectional_iterator_tag>();
+
+    test_reverse<std::random_access_iterator_tag>();
+    test_reverse<std::bidirectional_iterator_tag>();
+}
+
+int hpx_main(hpx::program_options::variables_map& vm)
+{
+    unsigned int seed = (unsigned int) std::time(nullptr);
+    if (vm.count("seed"))
+        seed = vm["seed"].as<unsigned int>();
+
+    std::cout << "using seed: " << seed << std::endl;
+    std::srand(seed);
+
+    reverse_test();
+
+    return hpx::local::finalize();
+}
+
+int main(int argc, char* argv[])
+{
+    // add command line option which controls the random number generator seed
+    using namespace hpx::program_options;
+    options_description desc_commandline(
+        "Usage: " HPX_APPLICATION_STRING " [options]");
+
+    desc_commandline.add_options()("seed,s", value<unsigned int>(),
+        "the random number generator seed to use for this run");
+
+    // By default this test should run on all available cores
+    std::vector<std::string> const cfg = {"hpx.os_threads=all"};
+
+    // Initialize and run HPX
+    hpx::local::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::local::init(hpx_main, argc, argv, init_args), 0,
+        "HPX main exited with non-zero status");
+
+    return hpx::util::report_errors();
+}

--- a/libs/core/algorithms/tests/unit/algorithms/rotate_sender.cpp
+++ b/libs/core/algorithms/tests/unit/algorithms/rotate_sender.cpp
@@ -5,6 +5,11 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+#include <hpx/config.hpp>
+
+// Clang V11 ICE's on this test
+#if !defined(HPX_CLANG_VERSION) || (HPX_CLANG_VERSION / 10000) != 11
+
 #include <hpx/local/execution.hpp>
 #include <hpx/local/init.hpp>
 #include <hpx/local/thread.hpp>
@@ -221,3 +226,12 @@ int main(int argc, char* argv[])
 
     return hpx::util::report_errors();
 }
+
+#else
+
+int main(int, char*[])
+{
+    return 0;
+}
+
+#endif

--- a/libs/core/algorithms/tests/unit/algorithms/rotate_sender.cpp
+++ b/libs/core/algorithms/tests/unit/algorithms/rotate_sender.cpp
@@ -1,0 +1,223 @@
+//  Copyright (c) 2007-2022 Hartmut Kaiser
+//  Copyright (c) 2021 Chuanqiu He
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/local/execution.hpp>
+#include <hpx/local/init.hpp>
+#include <hpx/local/thread.hpp>
+#include <hpx/modules/async_base.hpp>
+#include <hpx/modules/iterator_support.hpp>
+#include <hpx/modules/testing.hpp>
+#include <hpx/parallel/algorithms/rotate.hpp>
+
+#include <cstddef>
+#include <iostream>
+#include <iterator>
+#include <numeric>
+#include <string>
+#include <vector>
+
+#include "test_utils.hpp"
+
+///////////////////////////////////////////////////////////////////////////////
+template <typename Policy, typename ExPolicy, typename IteratorTag>
+void test_rotate_direct(Policy l, ExPolicy&& policy, IteratorTag)
+{
+    static_assert(hpx::is_execution_policy_v<ExPolicy>,
+        "hpx::is_execution_policy<ExPolicy>::value");
+
+    using base_iterator = std::vector<std::size_t>::iterator;
+    using iterator = test::test_iterator<base_iterator, IteratorTag>;
+
+    namespace ex = hpx::execution::experimental;
+    namespace tt = hpx::this_thread::experimental;
+
+    std::vector<std::size_t> c(10007);
+    std::vector<std::size_t> d1;
+
+    std::iota(std::begin(c), std::end(c), std::rand());
+    std::copy(std::begin(c), std::end(c), std::back_inserter(d1));
+
+    std::size_t mid_pos = std::rand() % c.size();    //-V104
+    base_iterator mid = std::begin(c);
+    std::advance(mid, mid_pos);
+
+    using scheduler_t = ex::thread_pool_policy_scheduler<Policy>;
+
+    auto exec = ex::explicit_scheduler_executor(scheduler_t(l));
+    hpx::rotate(policy.on(exec), iterator(std::begin(c)), iterator(mid),
+        iterator(std::end(c)));
+
+    base_iterator mid1 = std::begin(d1);
+    std::advance(mid1, mid_pos);
+    std::rotate(std::begin(d1), mid1, std::end(d1));
+
+    std::size_t count = 0;
+    HPX_TEST(std::equal(std::begin(c), std::end(c), std::begin(d1),
+        [&count](std::size_t v1, std::size_t v2) -> bool {
+            HPX_TEST_EQ(v1, v2);
+            ++count;
+            return v1 == v2;
+        }));
+    HPX_TEST_EQ(count, d1.size());
+}
+
+template <typename Policy, typename ExPolicy, typename IteratorTag>
+void test_rotate(Policy l, ExPolicy&& policy, IteratorTag)
+{
+    static_assert(hpx::is_execution_policy_v<ExPolicy>,
+        "hpx::is_execution_policy<ExPolicy>::value");
+
+    using base_iterator = std::vector<std::size_t>::iterator;
+    using iterator = test::test_iterator<base_iterator, IteratorTag>;
+
+    namespace ex = hpx::execution::experimental;
+    namespace tt = hpx::this_thread::experimental;
+
+    std::vector<std::size_t> c(10007);
+    std::vector<std::size_t> d1;
+
+    std::iota(std::begin(c), std::end(c), std::rand());
+    std::copy(std::begin(c), std::end(c), std::back_inserter(d1));
+
+    std::size_t mid_pos = std::rand() % c.size();    //-V104
+    base_iterator mid = std::begin(c);
+    std::advance(mid, mid_pos);
+
+    using scheduler_t = ex::thread_pool_policy_scheduler<Policy>;
+
+    auto exec = ex::explicit_scheduler_executor(scheduler_t(l));
+    ex::just(iterator(std::begin(c)), iterator(mid), iterator(std::end(c))) |
+        hpx::rotate(policy.on(exec)) | tt::sync_wait();
+
+    base_iterator mid1 = std::begin(d1);
+    std::advance(mid1, mid_pos);
+    std::rotate(std::begin(d1), mid1, std::end(d1));
+
+    std::size_t count = 0;
+    HPX_TEST(std::equal(std::begin(c), std::end(c), std::begin(d1),
+        [&count](std::size_t v1, std::size_t v2) -> bool {
+            HPX_TEST_EQ(v1, v2);
+            ++count;
+            return v1 == v2;
+        }));
+    HPX_TEST_EQ(count, d1.size());
+}
+
+template <typename Policy, typename ExPolicy, typename IteratorTag>
+void test_rotate_async_direct(Policy l, ExPolicy&& p, IteratorTag)
+{
+    using base_iterator = std::vector<std::size_t>::iterator;
+    using iterator = test::test_iterator<base_iterator, IteratorTag>;
+
+    namespace ex = hpx::execution::experimental;
+    namespace tt = hpx::this_thread::experimental;
+
+    std::vector<std::size_t> c(10007);
+    std::vector<std::size_t> d1;
+
+    std::iota(std::begin(c), std::end(c), std::rand());
+    std::copy(std::begin(c), std::end(c), std::back_inserter(d1));
+
+    std::size_t mid_pos = std::rand() % c.size();    //-V104
+
+    base_iterator mid = std::begin(c);
+    std::advance(mid, mid_pos);
+
+    using scheduler_t = ex::thread_pool_policy_scheduler<Policy>;
+
+    auto exec = ex::explicit_scheduler_executor(scheduler_t(l));
+    hpx::rotate(p.on(exec), iterator(std::begin(c)), iterator(mid),
+        iterator(std::end(c))) |
+        tt::sync_wait();
+
+    base_iterator mid1 = std::begin(d1);
+    std::advance(mid1, mid_pos);
+    std::rotate(std::begin(d1), mid1, std::end(d1));
+
+    std::size_t count = 0;
+    HPX_TEST(std::equal(std::begin(c), std::end(c), std::begin(d1),
+        [&count](std::size_t v1, std::size_t v2) -> bool {
+            HPX_TEST_EQ(v1, v2);
+            ++count;
+            return v1 == v2;
+        }));
+    HPX_TEST_EQ(count, d1.size());
+}
+
+template <typename IteratorTag>
+void test_rotate_direct()
+{
+    using namespace hpx::execution;
+
+    test_rotate_direct(hpx::launch::sync, seq, IteratorTag());
+    test_rotate_direct(hpx::launch::sync, unseq, IteratorTag());
+
+    test_rotate_direct(hpx::launch::async, par, IteratorTag());
+    test_rotate_direct(hpx::launch::async, par_unseq, IteratorTag());
+
+    test_rotate_async_direct(hpx::launch::sync, seq(task), IteratorTag());
+    test_rotate_async_direct(hpx::launch::async, par(task), IteratorTag());
+}
+
+template <typename IteratorTag>
+void test_rotate()
+{
+    using namespace hpx::execution;
+
+    test_rotate(hpx::launch::sync, seq(task), IteratorTag());
+    test_rotate(hpx::launch::sync, unseq(task), IteratorTag());
+
+    test_rotate(hpx::launch::async, par(task), IteratorTag());
+    test_rotate(hpx::launch::async, par_unseq(task), IteratorTag());
+}
+
+void rotate_test()
+{
+    test_rotate_direct<std::random_access_iterator_tag>();
+    test_rotate_direct<std::forward_iterator_tag>();
+
+    test_rotate<std::random_access_iterator_tag>();
+    test_rotate<std::forward_iterator_tag>();
+}
+
+int hpx_main(hpx::program_options::variables_map& vm)
+{
+    unsigned int seed = (unsigned int) std::time(nullptr);
+    if (vm.count("seed"))
+        seed = vm["seed"].as<unsigned int>();
+
+    std::cout << "using seed: " << seed << std::endl;
+    std::srand(seed);
+
+    rotate_test();
+
+    return hpx::local::finalize();
+}
+
+int main(int argc, char* argv[])
+{
+    // add command line option which controls the random number generator seed
+    using namespace hpx::program_options;
+    options_description desc_commandline(
+        "Usage: " HPX_APPLICATION_STRING " [options]");
+
+    desc_commandline.add_options()("seed,s", value<unsigned int>(),
+        "the random number generator seed to use for this run");
+
+    // By default this test should run on all available cores
+    std::vector<std::string> const cfg = {"hpx.os_threads=all"};
+
+    // Initialize and run HPX
+    hpx::local::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::local::init(hpx_main, argc, argv, init_args), 0,
+        "HPX main exited with non-zero status");
+
+    return hpx::util::report_errors();
+}

--- a/libs/core/algorithms/tests/unit/container_algorithms/foreach_range.cpp
+++ b/libs/core/algorithms/tests/unit/container_algorithms/foreach_range.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2014-2015 Hartmut Kaiser
+//  Copyright (c) 2014-2022 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -31,15 +31,10 @@ void test_for_each()
     test_for_each_async(unseq(task), IteratorTag());
     test_for_each_async(par_unseq(task), IteratorTag());
 
-    test_for_each_sender(seq, IteratorTag());
-    test_for_each_sender(par, IteratorTag());
-    test_for_each_sender(unseq, IteratorTag());
-    test_for_each_sender(par_unseq, IteratorTag());
-
-    test_for_each_sender(seq(task), IteratorTag());
-    test_for_each_sender(par(task), IteratorTag());
-    test_for_each_sender(unseq(task), IteratorTag());
-    test_for_each_sender(par_unseq(task), IteratorTag());
+    test_for_each_sender(hpx::launch::sync, seq(task), IteratorTag());
+    test_for_each_sender(hpx::launch::async, par(task), IteratorTag());
+    test_for_each_sender(hpx::launch::sync, unseq(task), IteratorTag());
+    test_for_each_sender(hpx::launch::async, par_unseq(task), IteratorTag());
 }
 
 void for_each_test()
@@ -65,10 +60,9 @@ void test_for_each_exception()
     test_for_each_exception_async(seq(task), IteratorTag());
     test_for_each_exception_async(par(task), IteratorTag());
 
-    test_for_each_exception_sender(seq, IteratorTag());
-    test_for_each_exception_sender(par, IteratorTag());
-    test_for_each_exception_sender(seq(task), IteratorTag());
-    test_for_each_exception_sender(par(task), IteratorTag());
+    test_for_each_exception_sender(hpx::launch::sync, seq(task), IteratorTag());
+    test_for_each_exception_sender(
+        hpx::launch::async, par(task), IteratorTag());
 }
 
 void for_each_exception_test()
@@ -94,10 +88,9 @@ void test_for_each_bad_alloc()
     test_for_each_bad_alloc_async(seq(task), IteratorTag());
     test_for_each_bad_alloc_async(par(task), IteratorTag());
 
-    test_for_each_bad_alloc_sender(seq, IteratorTag());
-    test_for_each_bad_alloc_sender(par, IteratorTag());
-    test_for_each_bad_alloc_sender(seq(task), IteratorTag());
-    test_for_each_bad_alloc_sender(par(task), IteratorTag());
+    test_for_each_bad_alloc_sender(hpx::launch::sync, seq(task), IteratorTag());
+    test_for_each_bad_alloc_sender(
+        hpx::launch::async, par(task), IteratorTag());
 }
 
 void for_each_bad_alloc_test()

--- a/libs/core/async_base/include/hpx/async_base/dataflow.hpp
+++ b/libs/core/async_base/include/hpx/async_base/dataflow.hpp
@@ -48,7 +48,7 @@ namespace hpx {
         // dataflow<Action>(...) has been removed, this CPO can be moved to
         // namespace hpx.
         inline constexpr struct dataflow_t final
-          : hpx::functional::tag<dataflow_t>
+          : hpx::functional::detail::tag_fallback<dataflow_t>
         {
         private:
             // clang-format off
@@ -57,7 +57,7 @@ namespace hpx {
                     !hpx::traits::is_allocator_v<std::decay_t<F>>
                 )>
             // clang-format on
-            friend constexpr HPX_FORCEINLINE auto tag_invoke(
+            friend constexpr HPX_FORCEINLINE auto tag_fallback_invoke(
                 dataflow_t tag, F&& f, Ts&&... ts)
                 -> decltype(tag(hpx::util::internal_allocator<>{},
                     HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...))

--- a/libs/core/async_base/include/hpx/async_base/scheduling_properties.hpp
+++ b/libs/core/async_base/include/hpx/async_base/scheduling_properties.hpp
@@ -28,30 +28,23 @@ namespace hpx { namespace execution { namespace experimental {
     ///////////////////////////////////////////////////////////////////////////
     namespace detail {
 
-        template <typename Tag, typename... Args>
-        struct property_not_supported
-        {
-            static_assert(sizeof(Tag) == 0,
-                "The given property (Tag) is not supported on the given type "
-                "(first type in Args). Ensure that you are including the "
-                "correct headers if the property is supported. Alternatively, "
-                "implement support for the property by overloading "
-                "tag_invoke for the given property and type. If the property "
-                "is not required, you can use prefer to fall back to the "
-                "identity transformation when a property is not supported.");
-        };
+        // The given property (Tag) is not supported on the given type (first
+        // type in Args). Ensure that you are including the correct headers if
+        // the property is supported. Alternatively, implement support for the
+        // property by overloading tag_invoke for the given property and type.
+        // If the property is not required, you can use prefer to fall back to
+        // the identity transformation when a property is not supported.
+        template <typename Tag, typename... Ts>
+        struct property_not_supported;
 
         template <typename Tag>
         struct property_base : hpx::functional::detail::tag_fallback<Tag>
         {
         private:
             // attempt to improve error messages if property is not supported
-            template <typename... Args>
-            friend HPX_FORCEINLINE constexpr decltype(auto) tag_fallback_invoke(
-                Tag, Args&&... /*args*/) noexcept
-            {
-                return property_not_supported<Tag, Args...>{};
-            }
+            template <typename... Ts>
+            friend constexpr auto tag_fallback_invoke(Tag, Ts&&...) noexcept
+                -> property_not_supported<Tag, Ts...>;
         };
     }    // namespace detail
 

--- a/libs/core/async_base/include/hpx/async_base/scheduling_properties.hpp
+++ b/libs/core/async_base/include/hpx/async_base/scheduling_properties.hpp
@@ -44,7 +44,7 @@ namespace hpx { namespace execution { namespace experimental {
             // attempt to improve error messages if property is not supported
             template <typename... Ts>
             friend constexpr auto tag_fallback_invoke(Tag, Ts&&...) noexcept
-                -> property_not_supported<Tag, Ts...>;
+                -> decltype(property_not_supported<Tag, Ts...>());
         };
     }    // namespace detail
 

--- a/libs/core/datastructures/include/hpx/datastructures/tuple.hpp
+++ b/libs/core/datastructures/include/hpx/datastructures/tuple.hpp
@@ -583,6 +583,9 @@ namespace hpx {
     };
 #endif
 
+    template <class T>
+    inline constexpr std::size_t tuple_size_v = tuple_size<T>::value;
+
     // template <size_t I, class Tuple>
     // class tuple_element
     template <std::size_t I, typename T, typename Enable>

--- a/libs/core/errors/include/hpx/errors/exception.hpp
+++ b/libs/core/errors/include/hpx/errors/exception.hpp
@@ -344,6 +344,8 @@ namespace hpx {
     HPX_CORE_EXPORT std::string get_error_what(exception_info const& xi);
 
     /// \cond NOINTERNAL
+    HPX_CORE_EXPORT std::string get_error_what(std::exception_ptr const& e);
+
     template <typename E>
     std::string get_error_what(E const& e)
     {

--- a/libs/core/errors/src/exception.cpp
+++ b/libs/core/errors/src/exception.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2016 Hartmut Kaiser
+//  Copyright (c) 2007-2022 Hartmut Kaiser
 //  Copyright (c)      2011 Bryce Lelbach
 //
 //  SPDX-License-Identifier: BSL-1.0
@@ -11,6 +11,7 @@
 #include <hpx/errors/error_code.hpp>
 #include <hpx/errors/exception.hpp>
 #include <hpx/errors/exception_info.hpp>
+#include <hpx/errors/exception_list.hpp>
 #include <hpx/modules/format.hpp>
 #include <hpx/modules/logging.hpp>
 
@@ -198,6 +199,8 @@ namespace hpx { namespace detail {
 
     template HPX_CORE_EXPORT std::exception_ptr construct_lightweight_exception(
         hpx::thread_interrupted const&);
+    template HPX_CORE_EXPORT std::exception_ptr construct_lightweight_exception(
+        hpx::exception_list const&);
 
     template <typename Exception>
     HPX_CORE_EXPORT std::exception_ptr construct_custom_exception(
@@ -372,6 +375,26 @@ namespace hpx {
         // error codes in addition to the standard library exceptions.
         std::exception const* se = dynamic_cast<std::exception const*>(&xi);
         return se ? se->what() : std::string("<unknown>");
+    }
+
+    std::string get_error_what(std::exception_ptr const& e)
+    {
+        try
+        {
+            std::rethrow_exception(e);
+        }
+        catch (hpx::thread_interrupted const&)
+        {
+            return "thread_interrupted";
+        }
+        catch (std::exception const& e)
+        {
+            return get_error_what(e);
+        }
+        catch (...)
+        {
+            return "<unknown>";
+        }
     }
 
     ///////////////////////////////////////////////////////////////////////////

--- a/libs/core/errors/src/exception_list.cpp
+++ b/libs/core/errors/src/exception_list.cpp
@@ -150,7 +150,7 @@ namespace hpx {
             hpx::exception ex;
             {
                 util::unlock_guard<std::unique_lock<mutex_type>> ul(l);
-                ex = hpx::exception(hpx::get_error(e));
+                ex = hpx::exception(hpx::get_error(e), hpx::get_error_what(e));
             }
 
             // set the error code for our base class
@@ -161,12 +161,6 @@ namespace hpx {
 
     void exception_list::add_no_lock(std::exception_ptr const& e)
     {
-        if (exceptions_.empty())
-        {
-            // set the error code for our base class
-            static_cast<hpx::exception&>(*this) =
-                hpx::exception(hpx::get_error(e));
-        }
         exceptions_.push_back(e);
     }
 }    // namespace hpx

--- a/libs/core/execution/CMakeLists.txt
+++ b/libs/core/execution/CMakeLists.txt
@@ -7,6 +7,7 @@
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 
 set(execution_headers
+    hpx/execution/algorithms/as_sender.hpp
     hpx/execution/algorithms/bulk.hpp
     hpx/execution/algorithms/detail/is_negative.hpp
     hpx/execution/algorithms/detail/inject_scheduler.hpp

--- a/libs/core/execution/include/hpx/execution/algorithms/as_sender.hpp
+++ b/libs/core/execution/include/hpx/execution/algorithms/as_sender.hpp
@@ -1,0 +1,262 @@
+//  Copyright (c) 2021 ETH Zurich
+//  Copyright (c) 2022 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include <hpx/assert.hpp>
+#include <hpx/concepts/concepts.hpp>
+#include <hpx/errors/try_catch_exception_ptr.hpp>
+#include <hpx/execution/algorithms/detail/partial_algorithm.hpp>
+#include <hpx/execution_base/completion_signatures.hpp>
+#include <hpx/execution_base/operation_state.hpp>
+#include <hpx/execution_base/receiver.hpp>
+#include <hpx/execution_base/sender.hpp>
+#include <hpx/functional/tag_invoke.hpp>
+#include <hpx/futures/detail/future_data.hpp>
+#include <hpx/futures/future.hpp>
+#include <hpx/futures/traits/acquire_shared_state.hpp>
+
+#include <exception>
+#include <type_traits>
+#include <utility>
+
+namespace hpx::execution::experimental {
+
+    namespace detail {
+
+        ///////////////////////////////////////////////////////////////////////////
+        // Operation state for sender compatibility
+        template <typename Receiver, typename Future>
+        class as_sender_operation_state
+        {
+        private:
+            using receiver_type = std::decay_t<Receiver>;
+            using future_type = std::decay_t<Future>;
+            using result_type = typename future_type::result_type;
+
+        public:
+            template <typename Receiver_>
+            as_sender_operation_state(Receiver_&& r, future_type f)
+              : receiver_(HPX_FORWARD(Receiver_, r))
+              , future_(HPX_MOVE(f))
+            {
+            }
+
+            as_sender_operation_state(as_sender_operation_state&&) = delete;
+            as_sender_operation_state& operator=(
+                as_sender_operation_state&&) = delete;
+            as_sender_operation_state(
+                as_sender_operation_state const&) = delete;
+            as_sender_operation_state& operator=(
+                as_sender_operation_state const&) = delete;
+
+            friend void tag_invoke(hpx::execution::experimental::start_t,
+                as_sender_operation_state& os) noexcept
+            {
+                os.start_helper();
+            }
+
+        private:
+            void start_helper() & noexcept
+            {
+                hpx::detail::try_catch_exception_ptr(
+                    [&]() {
+                        auto state = traits::detail::get_shared_state(future_);
+
+                        if (!state)
+                        {
+                            HPX_THROW_EXCEPTION(no_state,
+                                "as_sender_operation_state::start",
+                                "the future has no valid shared state");
+                        }
+
+                        auto on_completed = [this]() mutable {
+                            if (future_.has_value())
+                            {
+                                if constexpr (std::is_void_v<result_type>)
+                                {
+                                    hpx::execution::experimental::set_value(
+                                        HPX_MOVE(receiver_));
+                                }
+                                else
+                                {
+                                    hpx::execution::experimental::set_value(
+                                        HPX_MOVE(receiver_), future_.get());
+                                }
+                            }
+                            else if (future_.has_exception())
+                            {
+                                hpx::execution::experimental::set_error(
+                                    HPX_MOVE(receiver_),
+                                    future_.get_exception_ptr());
+                            }
+                        };
+
+                        if (!state->is_ready(std::memory_order_relaxed))
+                        {
+                            state->execute_deferred();
+
+                            // execute_deferred might have made the future ready
+                            if (!state->is_ready(std::memory_order_relaxed))
+                            {
+                                // The operation state has to be kept alive until
+                                // set_value is called, which means that we don't
+                                // need to move receiver and future into the
+                                // on_completed callback.
+                                state->set_on_completed(HPX_MOVE(on_completed));
+                            }
+                            else
+                            {
+                                on_completed();
+                            }
+                        }
+                        else
+                        {
+                            on_completed();
+                        }
+                    },
+                    [&](std::exception_ptr ep) {
+                        hpx::execution::experimental::set_error(
+                            HPX_MOVE(receiver_), HPX_MOVE(ep));
+                    });
+            }
+
+            HPX_NO_UNIQUE_ADDRESS std::decay_t<Receiver> receiver_;
+            future_type future_;
+        };
+
+        template <typename Future>
+        struct as_sender_sender_base
+        {
+            using result_type = typename std::decay_t<Future>::result_type;
+
+            std::decay_t<Future> future_;
+
+            // Sender compatibility
+            template <typename, typename T>
+            struct completion_signatures_base
+            {
+                template <template <typename...> typename Tuple,
+                    template <typename...> typename Variant>
+                using value_types = Variant<Tuple<result_type>>;
+            };
+
+            template <typename T>
+            struct completion_signatures_base<T, void>
+            {
+                template <template <typename...> typename Tuple,
+                    template <typename...> typename Variant>
+                using value_types = Variant<Tuple<>>;
+            };
+
+            struct completion_signatures
+              : completion_signatures_base<void, result_type>
+            {
+                template <template <typename...> typename Variant>
+                using error_types = Variant<std::exception_ptr>;
+
+                static constexpr bool sends_stopped = false;
+            };
+        };
+
+        template <typename Future>
+        struct as_sender_sender;
+
+        template <typename T>
+        struct as_sender_sender<hpx::future<T>>
+          : public as_sender_sender_base<hpx::future<T>>
+        {
+            using future_type = hpx::future<T>;
+            using base_type = as_sender_sender_base<hpx::future<T>>;
+            using base_type::future_;
+
+            template <typename Future,
+                typename = std::enable_if_t<!std::is_same<std::decay_t<Future>,
+                    as_sender_sender>::value>>
+            explicit as_sender_sender(Future&& future)
+              : base_type{HPX_FORWARD(Future, future)}
+            {
+            }
+
+            as_sender_sender(as_sender_sender&&) = default;
+            as_sender_sender& operator=(as_sender_sender&&) = default;
+            as_sender_sender(as_sender_sender const&) = delete;
+            as_sender_sender& operator=(as_sender_sender const&) = delete;
+
+            template <typename Receiver>
+            friend as_sender_operation_state<Receiver, future_type> tag_invoke(
+                connect_t, as_sender_sender&& s, Receiver&& receiver)
+            {
+                return {HPX_FORWARD(Receiver, receiver), HPX_MOVE(s.future_)};
+            }
+        };
+
+        template <typename T>
+        struct as_sender_sender<hpx::shared_future<T>>
+          : as_sender_sender_base<hpx::shared_future<T>>
+        {
+            using future_type = hpx::shared_future<T>;
+            using base_type = as_sender_sender_base<hpx::shared_future<T>>;
+            using base_type::future_;
+
+            template <typename Future,
+                typename = std::enable_if_t<!std::is_same<std::decay_t<Future>,
+                    as_sender_sender>::value>>
+            explicit as_sender_sender(Future&& future)
+              : base_type{HPX_FORWARD(Future, future)}
+            {
+            }
+
+            as_sender_sender(as_sender_sender&&) = default;
+            as_sender_sender& operator=(as_sender_sender&&) = default;
+            as_sender_sender(as_sender_sender const&) = default;
+            as_sender_sender& operator=(as_sender_sender const&) = default;
+
+            template <typename Receiver>
+            friend as_sender_operation_state<Receiver, future_type> tag_invoke(
+                connect_t, as_sender_sender&& s, Receiver&& receiver)
+            {
+                return {HPX_FORWARD(Receiver, receiver), HPX_MOVE(s.future_)};
+            }
+
+            template <typename Receiver>
+            friend as_sender_operation_state<Receiver, future_type> tag_invoke(
+                connect_t, as_sender_sender& s, Receiver&& receiver)
+            {
+                return {HPX_FORWARD(Receiver, receiver), s.future_};
+            }
+        };
+    }    // namespace detail
+
+    // The as_sender CPO can be used to adapt any HPX future as a sender. The
+    // value provided by the future will be used to call set_value on the
+    // connected receiver once the future has become ready. If the future is
+    // exceptional, set_error will be invoked on the connected receiver.
+    //
+    // The difference to keep_future is that as_future propagates the value
+    // stored in the future while keep_future will propagate the future instance
+    // itself.
+    inline constexpr struct as_sender_t final
+    {
+        // clang-format off
+        template <typename Future,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::traits::is_future_v<std::decay_t<Future>>
+            )>
+        // clang-format on
+        constexpr HPX_FORCEINLINE auto operator()(Future&& future) const
+        {
+            return detail::as_sender_sender<std::decay_t<Future>>(
+                HPX_FORWARD(Future, future));
+        }
+
+        constexpr HPX_FORCEINLINE auto operator()() const
+        {
+            return detail::partial_algorithm<as_sender_t>{};
+        }
+    } as_sender{};
+}    // namespace hpx::execution::experimental

--- a/libs/core/execution/include/hpx/execution/algorithms/detail/inject_scheduler.hpp
+++ b/libs/core/execution/include/hpx/execution/algorithms/detail/inject_scheduler.hpp
@@ -54,7 +54,7 @@ namespace hpx::execution::experimental::detail {
         friend constexpr HPX_FORCEINLINE auto operator|(
             U&& u, inject_scheduler p)
         {
-            return p.invoke(HPX_MOVE(p.scheduler), HPX_FORWARD(U, u));
+            return HPX_MOVE(p).invoke(HPX_MOVE(p.scheduler), HPX_FORWARD(U, u));
         }
     };
 }    // namespace hpx::execution::experimental::detail

--- a/libs/core/execution/include/hpx/execution/algorithms/detail/partial_algorithm.hpp
+++ b/libs/core/execution/include/hpx/execution/algorithms/detail/partial_algorithm.hpp
@@ -31,7 +31,7 @@ namespace hpx::execution::experimental::detail {
 
     public:
         template <typename... Us>
-        constexpr HPX_FORCEINLINE auto invoke(Us&&... us)
+        constexpr HPX_FORCEINLINE auto invoke(Us&&... us) &&
         {
             return Tag{}(
                 HPX_FORWARD(Us, us)..., HPX_MOVE(ts).template get<Is>()...);
@@ -66,7 +66,7 @@ namespace hpx::execution::experimental::detail {
                 hpx::execution::experimental::get_completion_scheduler<
                     hpx::execution::experimental::set_value_t>(u);
 
-            return p.invoke(HPX_MOVE(scheduler), HPX_FORWARD(U, u));
+            return HPX_MOVE(p).invoke(HPX_MOVE(scheduler), HPX_FORWARD(U, u));
         }
 
         // clang-format off
@@ -82,7 +82,7 @@ namespace hpx::execution::experimental::detail {
         friend constexpr HPX_FORCEINLINE auto operator|(
             U&& u, partial_algorithm_base p)
         {
-            return p.invoke(HPX_FORWARD(U, u));
+            return HPX_MOVE(p).invoke(HPX_FORWARD(U, u));
         }
     };
 

--- a/libs/core/execution/include/hpx/execution/algorithms/keep_future.hpp
+++ b/libs/core/execution/include/hpx/execution/algorithms/keep_future.hpp
@@ -159,10 +159,5 @@ namespace hpx { namespace execution { namespace experimental {
             return detail::keep_future_sender<std::decay_t<Future>>(
                 HPX_FORWARD(Future, future));
         }
-
-        constexpr HPX_FORCEINLINE auto operator()() const
-        {
-            return detail::partial_algorithm<keep_future_t>{};
-        }
     } keep_future{};
 }}}    // namespace hpx::execution::experimental

--- a/libs/core/execution/include/hpx/execution/algorithms/sync_wait.hpp
+++ b/libs/core/execution/include/hpx/execution/algorithms/sync_wait.hpp
@@ -217,8 +217,15 @@ namespace hpx::execution::experimental::detail {
             }
             else
             {
-                r.state.value.template emplace<error_type>(
-                    std::exception_ptr(HPX_FORWARD(Error, error)));
+                try
+                {
+                    throw error;
+                }
+                catch (...)
+                {
+                    r.state.value.template emplace<error_type>(
+                        std::current_exception());
+                }
             }
 
             r.loop.finish();
@@ -456,7 +463,7 @@ namespace hpx::this_thread::experimental {
     } sync_wait{};
 
     ////////////////////////////////////////////////////////////////////
-    // DPO for sync_wait_with_variant
+    // CPO for sync_wait_with_variant
 
     // this_thread::sync_wait_with_variant is a sender consumer that submits
     // the work described by the provided sender for execution, similarly to

--- a/libs/core/execution/include/hpx/execution/algorithms/then.hpp
+++ b/libs/core/execution/include/hpx/execution/algorithms/then.hpp
@@ -16,6 +16,7 @@
 #include <hpx/execution_base/receiver.hpp>
 #include <hpx/execution_base/sender.hpp>
 #include <hpx/functional/detail/tag_priority_invoke.hpp>
+#include <hpx/futures/future.hpp>
 #include <hpx/type_support/meta.hpp>
 #include <hpx/type_support/pack.hpp>
 
@@ -225,3 +226,23 @@ namespace hpx::execution::experimental {
         }
     } then{};
 }    // namespace hpx::execution::experimental
+
+// the following enables directly using execution::then_t with futures
+namespace hpx {
+
+    template <typename Result, typename F>
+    constexpr HPX_FORCEINLINE auto tag_invoke(
+        hpx::execution::experimental::then_t, hpx::launch l,
+        hpx::future<Result>&& sender, F&& f)
+    {
+        return sender.then(l, HPX_FORWARD(F, f));
+    }
+
+    template <typename Result, typename F>
+    constexpr HPX_FORCEINLINE auto tag_invoke(
+        hpx::execution::experimental::then_t, hpx::launch l,
+        hpx::shared_future<Result> const& sender, F&& f)
+    {
+        return sender.then(l, HPX_FORWARD(F, f));
+    }
+}    // namespace hpx

--- a/libs/core/execution/include/hpx/execution/algorithms/then.hpp
+++ b/libs/core/execution/include/hpx/execution/algorithms/then.hpp
@@ -226,23 +226,3 @@ namespace hpx::execution::experimental {
         }
     } then{};
 }    // namespace hpx::execution::experimental
-
-// the following enables directly using execution::then_t with futures
-namespace hpx {
-
-    template <typename Result, typename F>
-    constexpr HPX_FORCEINLINE auto tag_invoke(
-        hpx::execution::experimental::then_t, hpx::launch l,
-        hpx::future<Result>&& sender, F&& f)
-    {
-        return sender.then(l, HPX_FORWARD(F, f));
-    }
-
-    template <typename Result, typename F>
-    constexpr HPX_FORCEINLINE auto tag_invoke(
-        hpx::execution::experimental::then_t, hpx::launch l,
-        hpx::shared_future<Result> const& sender, F&& f)
-    {
-        return sender.then(l, HPX_FORWARD(F, f));
-    }
-}    // namespace hpx

--- a/libs/core/execution/include/hpx/execution/algorithms/when_all.hpp
+++ b/libs/core/execution/include/hpx/execution/algorithms/when_all.hpp
@@ -8,6 +8,8 @@
 #pragma once
 
 #include <hpx/config.hpp>
+#include <hpx/async_base/dataflow.hpp>
+#include <hpx/async_base/launch_policy.hpp>
 #include <hpx/concepts/concepts.hpp>
 #include <hpx/datastructures/optional.hpp>
 #include <hpx/datastructures/variant.hpp>
@@ -540,4 +542,29 @@ namespace hpx::execution::experimental {
     {
     } transfer_when_all_with_variant{};
 
+    // the following enables directly using dataflow() with senders
+
+    template <typename F, typename Sender, typename... Senders>
+    constexpr HPX_FORCEINLINE auto tag_invoke(
+        hpx::detail::dataflow_t, F&& f, Sender&& sender, Senders&&... senders)
+        -> decltype(then(when_all(HPX_FORWARD(Sender, sender),
+                             HPX_FORWARD(Senders, senders)...),
+            HPX_FORWARD(F, f)))
+    {
+        return then(when_all(HPX_FORWARD(Sender, sender),
+                        HPX_FORWARD(Senders, senders)...),
+            HPX_FORWARD(F, f));
+    }
+
+    template <typename F, typename Sender, typename... Senders>
+    constexpr HPX_FORCEINLINE auto tag_invoke(hpx::detail::dataflow_t,
+        hpx::launch, F&& f, Sender&& sender, Senders&&... senders)
+        -> decltype(then(when_all(HPX_FORWARD(Sender, sender),
+                             HPX_FORWARD(Senders, senders)...),
+            HPX_FORWARD(F, f)))
+    {
+        return then(when_all(HPX_FORWARD(Sender, sender),
+                        HPX_FORWARD(Senders, senders)...),
+            HPX_FORWARD(F, f));
+    }
 }    // namespace hpx::execution::experimental

--- a/libs/core/execution/include/hpx/execution/executors/execution_parameters_fwd.hpp
+++ b/libs/core/execution/include/hpx/execution/executors/execution_parameters_fwd.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2016-2021 Hartmut Kaiser
+//  Copyright (c) 2016-2022 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <hpx/config.hpp>
+#include <hpx/async_base/scheduling_properties.hpp>
 #include <hpx/concepts/concepts.hpp>
 #include <hpx/execution/traits/executor_traits.hpp>
 #include <hpx/execution_base/execution.hpp>
@@ -19,7 +20,7 @@
 #include <type_traits>
 #include <utility>
 
-namespace hpx { namespace parallel { namespace execution {
+namespace hpx::parallel::execution {
 
     ///////////////////////////////////////////////////////////////////////////
     // Executor information customization points
@@ -291,4 +292,14 @@ namespace hpx { namespace parallel { namespace execution {
                 HPX_FORWARD(Executor, exec));
         }
     } mark_end_execution{};
-}}}    // namespace hpx::parallel::execution
+}    // namespace hpx::parallel::execution
+
+namespace hpx::execution::experimental {
+
+    template <>
+    struct is_scheduling_property<
+        hpx::parallel::execution::with_processing_units_count_t>
+      : std::true_type
+    {
+    };
+}    // namespace hpx::execution::experimental

--- a/libs/core/execution/tests/unit/CMakeLists.txt
+++ b/libs/core/execution/tests/unit/CMakeLists.txt
@@ -5,6 +5,7 @@
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 set(tests
+    algorithm_as_sender
     algorithm_bulk
     algorithm_ensure_started
     algorithm_execute

--- a/libs/core/execution/tests/unit/algorithm_as_sender.cpp
+++ b/libs/core/execution/tests/unit/algorithm_as_sender.cpp
@@ -1,0 +1,160 @@
+//  Copyright (c) 2021 ETH Zurich
+//  Copyright (c) 2022 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/local/execution.hpp>
+#include <hpx/local/init.hpp>
+#include <hpx/modules/testing.hpp>
+
+#include "algorithm_test_utils.hpp"
+
+#include <atomic>
+#include <chrono>
+#include <exception>
+#include <string>
+#include <type_traits>
+#include <utility>
+
+namespace ex = hpx::execution::experimental;
+namespace tt = hpx::this_thread::experimental;
+
+int hpx_main()
+{
+    {
+        std::atomic<bool> set_value_called{false};
+        hpx::future<int> fut = hpx::make_ready_future(42);
+
+        auto s = ex::as_sender(std::move(fut));
+
+        static_assert(ex::is_sender_v<decltype(s)>);
+        static_assert(ex::is_sender_v<decltype(s), ex::empty_env>);
+
+        check_value_types<hpx::variant<hpx::tuple<int>>>(s);
+        check_error_types<hpx::variant<std::exception_ptr>>(s);
+        check_sends_stopped<false>(s);
+
+        auto f = [](int value) { HPX_TEST_EQ(value, 42); };
+        auto r = callback_receiver<decltype(f)>{f, set_value_called};
+        auto os = ex::connect(std::move(s), std::move(r));
+        ex::start(os);
+        HPX_TEST(set_value_called);
+    }
+
+    {
+        std::atomic<bool> set_value_called{false};
+        hpx::future<void> fut = hpx::make_ready_future();
+
+        auto s = ex::as_sender(std::move(fut));
+
+        static_assert(ex::is_sender_v<decltype(s)>);
+        static_assert(ex::is_sender_v<decltype(s), ex::empty_env>);
+
+        check_value_types<hpx::variant<hpx::tuple<>>>(s);
+        check_error_types<hpx::variant<std::exception_ptr>>(s);
+        check_sends_stopped<false>(s);
+
+        auto f = [] {};
+        auto r = callback_receiver<decltype(f)>{f, set_value_called};
+        auto os = ex::connect(std::move(s), std::move(r));
+        ex::start(os);
+        HPX_TEST(set_value_called);
+    }
+
+    {
+        std::atomic<bool> set_value_called{false};
+        hpx::shared_future<int> sf = hpx::make_ready_future(42);
+
+        auto s = ex::as_sender(sf);
+
+        static_assert(ex::is_sender_v<decltype(s)>);
+        static_assert(ex::is_sender_v<decltype(s), ex::empty_env>);
+
+        check_value_types<hpx::variant<hpx::tuple<int>>>(s);
+        check_error_types<hpx::variant<std::exception_ptr>>(s);
+        check_sends_stopped<false>(s);
+
+        auto f = [](int value) { HPX_TEST_EQ(value, 42); };
+        auto r = callback_receiver<decltype(f)>{f, set_value_called};
+        auto os = ex::connect(std::move(s), std::move(r));
+        ex::start(os);
+        HPX_TEST(set_value_called);
+    }
+
+    {
+        std::atomic<bool> set_value_called{false};
+        hpx::shared_future<void> sf = hpx::make_ready_future();
+
+        auto s = ex::as_sender(sf);
+
+        static_assert(ex::is_sender_v<decltype(s)>);
+        static_assert(ex::is_sender_v<decltype(s), ex::empty_env>);
+
+        check_value_types<hpx::variant<hpx::tuple<>>>(s);
+        check_error_types<hpx::variant<std::exception_ptr>>(s);
+        check_sends_stopped<false>(s);
+
+        auto f = [] {};
+        auto r = callback_receiver<decltype(f)>{f, set_value_called};
+        auto os = ex::connect(std::move(s), std::move(r));
+        ex::start(os);
+        HPX_TEST(set_value_called);
+    }
+
+    // future is not ready at start()
+    {
+        std::atomic<bool> set_value_called{false};
+        hpx::future<int> fut =
+            hpx::make_ready_future_after(std::chrono::milliseconds(100), 42);
+
+        auto s = ex::as_sender(std::move(fut));
+
+        static_assert(ex::is_sender_v<decltype(s)>);
+        static_assert(ex::is_sender_v<decltype(s), ex::empty_env>);
+
+        check_value_types<hpx::variant<hpx::tuple<int>>>(s);
+        check_error_types<hpx::variant<std::exception_ptr>>(s);
+        check_sends_stopped<false>(s);
+
+        auto f = [&](int value) {
+            set_value_called = true;
+            HPX_TEST_EQ(value, 42);
+        };
+        tt::sync_wait(std::move(s) | ex::then(f));
+        HPX_TEST(set_value_called);
+    }
+
+    // error path
+    {
+        std::atomic<bool> set_error_called{false};
+        hpx::future<int> fut =
+            hpx::make_exceptional_future<int>(std::runtime_error("error"));
+
+        auto s = ex::as_sender(std::move(fut));
+
+        static_assert(ex::is_sender_v<decltype(s)>);
+        static_assert(ex::is_sender_v<decltype(s), ex::empty_env>);
+
+        check_value_types<hpx::variant<hpx::tuple<int>>>(s);
+        check_error_types<hpx::variant<std::exception_ptr>>(s);
+        check_sends_stopped<false>(s);
+
+        auto r = error_callback_receiver<check_exception_ptr>{
+            check_exception_ptr{}, set_error_called};
+        auto os = ex::connect(std::move(s), std::move(r));
+        ex::start(os);
+        HPX_TEST(set_error_called);
+    }
+
+    return hpx::local::finalize();
+}
+
+int main(int argc, char* argv[])
+{
+    HPX_TEST_EQ_MSG(hpx::local::init(hpx_main, argc, argv), 0,
+        "HPX main exited with non-zero status");
+
+    return hpx::util::report_errors();
+}

--- a/libs/core/execution/tests/unit/algorithm_then.cpp
+++ b/libs/core/execution/tests/unit/algorithm_then.cpp
@@ -5,6 +5,7 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+#include <hpx/local/init.hpp>
 #include <hpx/modules/execution.hpp>
 #include <hpx/modules/futures.hpp>
 #include <hpx/modules/testing.hpp>
@@ -51,11 +52,13 @@ void test_execution_then_return_int()
     hpx::future<int> f1 =
         hpx::make_ready_future_after(std::chrono::milliseconds(100), 1);
     HPX_TEST(f1.valid());
-    hpx::future<int> f2 = hpx::execution::experimental::then(
-        hpx::launch::async, std::move(f1), [](auto&& f) {
-            hpx::this_thread::sleep_for(std::chrono::milliseconds(100));
-            return 2 * f.get();
-        });
+    hpx::future<int> f2 = hpx::execution::experimental::make_future(
+        hpx::execution::experimental::then(
+            hpx::execution::experimental::as_sender(std::move(f1)),
+            [](int value) {
+                hpx::this_thread::sleep_for(std::chrono::milliseconds(100));
+                return 2 * value;
+            }));
     HPX_TEST(f2.valid());
     try
     {
@@ -76,11 +79,11 @@ void test_execution_then_return_void()
     hpx::future<int> f1 =
         hpx::make_ready_future_after(std::chrono::milliseconds(100), 1);
     HPX_TEST(f1.valid());
-    hpx::future<void> f2 = hpx::execution::experimental::then(
-        hpx::launch::async, std::move(f1), [](auto&& f) {
-            f.get();
-            hpx::this_thread::sleep_for(std::chrono::milliseconds(100));
-        });
+    hpx::future<void> f2 = hpx::execution::experimental::make_future(
+        hpx::execution::experimental::then(
+            hpx::execution::experimental::as_sender(std::move(f1)), [](auto) {
+                hpx::this_thread::sleep_for(std::chrono::milliseconds(100));
+            }));
     HPX_TEST(f2.valid());
     try
     {
@@ -101,11 +104,13 @@ void test_execution_then_return_int_shared()
     hpx::shared_future<int> f1 =
         hpx::make_ready_future_after(std::chrono::milliseconds(100), 1);
     HPX_TEST(f1.valid());
-    hpx::future<int> f2 = hpx::execution::experimental::then(
-        hpx::launch::async, std::move(f1), [](auto&& f) {
-            hpx::this_thread::sleep_for(std::chrono::milliseconds(100));
-            return 2 * f.get();
-        });
+    hpx::future<int> f2 = hpx::execution::experimental::make_future(
+        hpx::execution::experimental::then(
+            hpx::execution::experimental::as_sender(std::move(f1)),
+            [](int value) {
+                hpx::this_thread::sleep_for(std::chrono::milliseconds(100));
+                return 2 * value;
+            }));
     HPX_TEST(f2.valid());
     try
     {
@@ -126,11 +131,11 @@ void test_execution_then_return_void_shared()
     hpx::shared_future<int> f1 =
         hpx::make_ready_future_after(std::chrono::milliseconds(100), 1);
     HPX_TEST(f1.valid());
-    hpx::future<void> f2 = hpx::execution::experimental::then(
-        hpx::launch::async, std::move(f1), [](auto&& f) {
-            f.get();
-            hpx::this_thread::sleep_for(std::chrono::milliseconds(100));
-        });
+    hpx::future<void> f2 = hpx::execution::experimental::make_future(
+        hpx::execution::experimental::then(
+            hpx::execution::experimental::as_sender(std::move(f1)), [](auto) {
+                hpx::this_thread::sleep_for(std::chrono::milliseconds(100));
+            }));
     HPX_TEST(f2.valid());
     try
     {
@@ -146,7 +151,7 @@ void test_execution_then_return_void_shared()
     }
 }
 
-int main()
+int hpx_main()
 {
     // Success path
     {
@@ -441,6 +446,14 @@ int main()
     test_execution_then_return_void();
     test_execution_then_return_int_shared();
     test_execution_then_return_void_shared();
+
+    return hpx::local::finalize();
+}
+
+int main(int argc, char* argv[])
+{
+    HPX_TEST_EQ_MSG(hpx::local::init(hpx_main, argc, argv), 0,
+        "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();
 }

--- a/libs/core/execution_base/include/hpx/execution_base/completion_signatures.hpp
+++ b/libs/core/execution_base/include/hpx/execution_base/completion_signatures.hpp
@@ -20,6 +20,7 @@
 
 #include <exception>
 #include <type_traits>
+#include <utility>
 
 namespace hpx::execution::experimental {
 
@@ -465,10 +466,22 @@ namespace hpx::execution::experimental {
         {
         };
 
+        template <typename Sender, typename Env, typename Enable = void>
+        struct completion_signatures_of_is_valid : std::false_type
+        {
+        };
+
+        template <typename Sender, typename Env>
+        struct completion_signatures_of_is_valid<Sender, Env,
+            std::void_t<decltype(get_completion_signatures(
+                std::declval<Sender>(), std::declval<Env>()))>> : std::true_type
+        {
+        };
+
         template <typename Sender, typename Env>
         struct provides_completion_signatures_impl<Sender, Env, true,
-            std::enable_if_t<meta::value<meta::is_valid<
-                                 completion_signatures_of, Sender, Env>> &&
+            std::enable_if_t<
+                meta::value<completion_signatures_of_is_valid<Sender, Env>> &&
                 has_sender_types_v<completion_signatures_of<Sender, Env>>>>
           : std::true_type
         {

--- a/libs/core/executors/include/hpx/executors/dataflow.hpp
+++ b/libs/core/executors/include/hpx/executors/dataflow.hpp
@@ -392,25 +392,25 @@ namespace hpx { namespace lcos { namespace detail {
     };
 
     ///////////////////////////////////////////////////////////////////////////
-    //template <typename Policy, typename Func, typename... Ts,
-    //    typename Frame = dataflow_frame<std::decay_t<Policy>,
-    //        std::decay_t<Func>, hpx::tuple<std::decay_t<Ts>...>>>
-    //typename Frame::type create_dataflow(hpx::util::internal_allocator<>,
-    //    Policy&& policy, Func&& func, Ts&&... ts)
-    //{
-    //    // Create the data that is used to construct the dataflow_frame
-    //    auto data = Frame::construct_from(
-    //        HPX_FORWARD(Policy, policy), HPX_FORWARD(Func, func));
+    template <typename Policy, typename Func, typename... Ts,
+        typename Frame = dataflow_frame<std::decay_t<Policy>,
+            std::decay_t<Func>, hpx::tuple<std::decay_t<Ts>...>>>
+    typename Frame::type create_dataflow(hpx::util::internal_allocator<>,
+        Policy&& policy, Func&& func, Ts&&... ts)
+    {
+        // Create the data that is used to construct the dataflow_frame
+        auto data = Frame::construct_from(
+            HPX_FORWARD(Policy, policy), HPX_FORWARD(Func, func));
 
-    //    // Construct the dataflow_frame and traverse the arguments
-    //    // asynchronously
-    //    hpx::intrusive_ptr<Frame> p = util::traverse_pack_async(
-    //        util::async_traverse_in_place_tag<Frame>{}, HPX_MOVE(data),
-    //        HPX_FORWARD(Ts, ts)...);
+        // Construct the dataflow_frame and traverse the arguments
+        // asynchronously
+        hpx::intrusive_ptr<Frame> p = util::traverse_pack_async(
+            util::async_traverse_in_place_tag<Frame>{}, HPX_MOVE(data),
+            HPX_FORWARD(Ts, ts)...);
 
-    //    using traits::future_access;
-    //    return future_access<typename Frame::type>::create(HPX_MOVE(p));
-    //}
+        using traits::future_access;
+        return future_access<typename Frame::type>::create(HPX_MOVE(p));
+    }
 
     ///////////////////////////////////////////////////////////////////////////
     template <typename Allocator, typename Policy, typename Func,

--- a/libs/core/executors/include/hpx/executors/execution_policy_parameters.hpp
+++ b/libs/core/executors/include/hpx/executors/execution_policy_parameters.hpp
@@ -30,7 +30,7 @@ namespace hpx::parallel::execution {
     template <typename ExPolicy,
         HPX_CONCEPT_REQUIRES_(
             hpx::is_execution_policy_v<ExPolicy> &&
-            hpx::functional::is_tag_invocable_v<
+            hpx::is_invocable_v<
                 with_processing_units_count_t,
                 typename std::decay_t<ExPolicy>::executor_type, std::size_t>
         )>
@@ -49,7 +49,7 @@ namespace hpx::parallel::execution {
         HPX_CONCEPT_REQUIRES_(
             hpx::is_execution_policy_v<ExPolicy> &&
             hpx::traits::is_executor_parameters_v<Params> &&
-            hpx::functional::is_tag_invocable_v<
+            hpx::is_invocable_v<
                 with_processing_units_count_t,
                 typename std::decay_t<ExPolicy>::executor_type, std::size_t> &&
             detail::has_processing_units_count_v<std::decay_t<Params>>
@@ -84,14 +84,15 @@ namespace hpx::parallel::execution {
     // clang-format off
     template <typename ParametersProperty, typename ExPolicy, typename...Ts,
         HPX_CONCEPT_REQUIRES_(
-            hpx::is_execution_policy_v<ExPolicy> &&
-            hpx::functional::is_tag_invocable_v<ParametersProperty,
-                typename std::decay_t<ExPolicy>::executor_type, Ts&&...>
+            hpx::is_execution_policy_v<ExPolicy>
         )>
     // clang-format on
-    constexpr decltype(auto) tag_fallback_invoke(
-        ParametersProperty, ExPolicy&& policy, Ts&&... ts)
+    constexpr auto tag_fallback_invoke(
+        ParametersProperty prop, ExPolicy&& policy, Ts&&... ts)
+        -> decltype(std::declval<ParametersProperty>()(
+            std::declval<typename std::decay_t<ExPolicy>::executor_type>(),
+            std::declval<Ts>()...))
     {
-        return ParametersProperty{}(policy.executor(), HPX_FORWARD(Ts, ts)...);
+        return prop(policy.executor(), HPX_FORWARD(Ts, ts)...);
     }
 }    // namespace hpx::parallel::execution

--- a/libs/core/executors/include/hpx/executors/explicit_scheduler_executor.hpp
+++ b/libs/core/executors/include/hpx/executors/explicit_scheduler_executor.hpp
@@ -255,9 +255,9 @@ namespace hpx::execution::experimental {
     // clang-format on
     auto tag_invoke(Tag tag,
         explicit_scheduler_executor<BaseScheduler> const& exec, Property&& prop)
-        -> decltype(std::declval<Tag>()(std::declval<BaseScheduler>(),
-                        std::declval<Property>()),
-            explicit_scheduler_executor<BaseScheduler>())
+        -> decltype(
+            explicit_scheduler_executor<BaseScheduler>(std::declval<Tag>()(
+                std::declval<BaseScheduler>(), std::declval<Property>())))
     {
         return explicit_scheduler_executor<BaseScheduler>(
             tag(exec.sched(), HPX_FORWARD(Property, prop)));

--- a/libs/core/executors/include/hpx/executors/explicit_scheduler_executor.hpp
+++ b/libs/core/executors/include/hpx/executors/explicit_scheduler_executor.hpp
@@ -92,33 +92,25 @@ namespace hpx::execution::experimental {
             return *this;
         }
 
-        // support all properties exposed by the wrapped scheduler
-        // clang-format off
-        template <typename Tag, typename Property,
-            HPX_CONCEPT_REQUIRES_(
-                hpx::execution::experimental::is_scheduling_property_v<Tag> &&
-                hpx::functional::is_tag_invocable_v<
-                    Tag, BaseScheduler, Property>
-            )>
-        // clang-format on
-        friend explicit_scheduler_executor tag_invoke(
-            Tag tag, explicit_scheduler_executor const& exec, Property&& prop)
+        constexpr BaseScheduler const& sched() const noexcept
         {
-            return explicit_scheduler_executor(hpx::functional::tag_invoke(
-                tag, exec.sched_, HPX_FORWARD(Property, prop)));
+            return sched_;
         }
 
         // clang-format off
-        template <typename Tag,
+        template <typename Parameters,
             HPX_CONCEPT_REQUIRES_(
-                hpx::execution::experimental::is_scheduling_property_v<Tag> &&
-                hpx::functional::is_tag_invocable_v<Tag, BaseScheduler>
+                hpx::traits::is_executor_parameters_v<Parameters>
             )>
         // clang-format on
-        friend decltype(auto) tag_invoke(
-            Tag tag, explicit_scheduler_executor const& exec)
+        friend auto tag_invoke(
+            hpx::parallel::execution::processing_units_count_t tag,
+            Parameters&&, explicit_scheduler_executor const& exec)
+            -> decltype(std::declval<
+                hpx::parallel::execution::processing_units_count_t>()(
+                std::declval<BaseScheduler>()))
         {
-            return hpx::functional::tag_invoke(tag, exec.sched_);
+            return tag(exec.sched_);
         }
 
         // Associate the parallel_execution_tag executor tag type as a default
@@ -253,6 +245,37 @@ namespace hpx::execution::experimental {
     template <typename BaseScheduler>
     explicit explicit_scheduler_executor(BaseScheduler&& sched)
         -> explicit_scheduler_executor<std::decay_t<BaseScheduler>>;
+
+    // support all properties exposed by the wrapped scheduler
+    // clang-format off
+    template <typename Tag, typename BaseScheduler,typename Property,
+        HPX_CONCEPT_REQUIRES_(
+            hpx::execution::experimental::is_scheduling_property_v<Tag>
+        )>
+    // clang-format on
+    auto tag_invoke(Tag tag,
+        explicit_scheduler_executor<BaseScheduler> const& exec, Property&& prop)
+        -> decltype(std::declval<Tag>()(std::declval<BaseScheduler>(),
+                        std::declval<Property>()),
+            explicit_scheduler_executor<BaseScheduler>())
+    {
+        return explicit_scheduler_executor<BaseScheduler>(
+            tag(exec.sched(), HPX_FORWARD(Property, prop)));
+    }
+
+    // clang-format off
+    template <typename Tag, typename BaseScheduler, typename... Ts,
+        HPX_CONCEPT_REQUIRES_(
+            hpx::execution::experimental::is_scheduling_property_v<Tag>
+        )>
+    // clang-format on
+    auto tag_invoke(Tag tag,
+        explicit_scheduler_executor<BaseScheduler> const& exec, Ts&&... ts)
+        -> decltype(std::declval<Tag>()(
+            std::declval<BaseScheduler>(), std::declval<Ts>()...))
+    {
+        return tag(exec.sched(), HPX_FORWARD(Ts, ts)...);
+    }
 }    // namespace hpx::execution::experimental
 
 namespace hpx::parallel::execution {

--- a/libs/core/executors/include/hpx/executors/parallel_executor.hpp
+++ b/libs/core/executors/include/hpx/executors/parallel_executor.hpp
@@ -465,10 +465,12 @@ namespace hpx { namespace execution {
             hpx::execution::experimental::is_scheduling_property_v<Tag>
         )>
     // clang-format on
-    auto tag_invoke(Tag tag, parallel_policy_executor<Policy> const& exec,
-        Property&& prop) -> decltype(std::declval<Tag>()(std::declval<Policy>(),
-                                         std::declval<Property>()),
-        parallel_policy_executor<Policy>())
+    auto tag_invoke(
+        Tag tag, parallel_policy_executor<Policy> const& exec, Property&& prop)
+        -> decltype(std::declval<parallel_policy_executor<Policy>>().policy(
+                        std::declval<Tag>()(
+                            std::declval<Policy>(), std::declval<Property>())),
+            parallel_policy_executor<Policy>())
     {
         auto exec_with_prop = exec;
         exec_with_prop.policy(tag(exec.policy(), HPX_FORWARD(Property, prop)));

--- a/libs/core/executors/include/hpx/executors/parallel_executor.hpp
+++ b/libs/core/executors/include/hpx/executors/parallel_executor.hpp
@@ -165,36 +165,6 @@ namespace hpx { namespace execution {
     private:
         // property implementations
 
-        // support all properties exposed by the embedded policy
-        // clang-format off
-        template <typename Tag, typename Property,
-            HPX_CONCEPT_REQUIRES_(
-                hpx::execution::experimental::is_scheduling_property_v<Tag> &&
-                hpx::functional::is_tag_invocable_v<Tag, Policy, Property>
-            )>
-        // clang-format on
-        friend parallel_policy_executor tag_invoke(
-            Tag tag, parallel_policy_executor const& exec, Property&& prop)
-        {
-            auto exec_with_prop = exec;
-            exec_with_prop.policy_ = hpx::functional::tag_invoke(
-                tag, exec.policy_, HPX_FORWARD(Property, prop));
-            return exec_with_prop;
-        }
-
-        // clang-format off
-        template <typename Tag,
-            HPX_CONCEPT_REQUIRES_(
-                hpx::execution::experimental::is_scheduling_property_v<Tag> &&
-                hpx::functional::is_tag_invocable_v<Tag, Policy>
-            )>
-        // clang-format on
-        friend decltype(auto) tag_invoke(
-            Tag tag, parallel_policy_executor const& exec)
-        {
-            return hpx::functional::tag_invoke(tag, exec.policy_);
-        }
-
 #if defined(HPX_HAVE_THREAD_DESCRIPTION)
         friend constexpr parallel_policy_executor tag_invoke(
             hpx::execution::experimental::with_annotation_t,
@@ -284,6 +254,16 @@ namespace hpx { namespace execution {
         constexpr parallel_policy_executor const& context() const noexcept
         {
             return *this;
+        }
+
+        void policy(Policy policy) noexcept
+        {
+            policy_ = HPX_MOVE(policy);
+        }
+
+        constexpr Policy const& policy() const noexcept
+        {
+            return policy_;
         }
         /// \endcond
 
@@ -477,6 +457,35 @@ namespace hpx { namespace execution {
 #endif
         /// \endcond
     };
+
+    // support all properties exposed by the embedded policy
+    // clang-format off
+    template <typename Tag, typename Policy, typename Property,
+        HPX_CONCEPT_REQUIRES_(
+            hpx::execution::experimental::is_scheduling_property_v<Tag>
+        )>
+    // clang-format on
+    auto tag_invoke(Tag tag, parallel_policy_executor<Policy> const& exec,
+        Property&& prop) -> decltype(std::declval<Tag>()(std::declval<Policy>(),
+                                         std::declval<Property>()),
+        parallel_policy_executor<Policy>())
+    {
+        auto exec_with_prop = exec;
+        exec_with_prop.policy(tag(exec.policy(), HPX_FORWARD(Property, prop)));
+        return exec_with_prop;
+    }
+
+    // clang-format off
+    template <typename Tag,typename Policy,
+        HPX_CONCEPT_REQUIRES_(
+            hpx::execution::experimental::is_scheduling_property_v<Tag>
+        )>
+    // clang-format on
+    auto tag_invoke(Tag tag, parallel_policy_executor<Policy> const& exec)
+        -> decltype(std::declval<Tag>()(std::declval<Policy>()))
+    {
+        return tag(exec.policy());
+    }
 
     using parallel_executor = parallel_policy_executor<hpx::launch>;
 }}    // namespace hpx::execution

--- a/libs/core/executors/include/hpx/executors/thread_pool_scheduler.hpp
+++ b/libs/core/executors/include/hpx/executors/thread_pool_scheduler.hpp
@@ -98,36 +98,6 @@ namespace hpx::execution::experimental {
             return pool_;
         }
 
-        // support all properties exposed by the embedded policy
-        // clang-format off
-        template <typename Tag, typename Property,
-            HPX_CONCEPT_REQUIRES_(
-                hpx::execution::experimental::is_scheduling_property_v<Tag> &&
-                hpx::functional::is_tag_invocable_v<Tag, Policy, Property>
-            )>
-        // clang-format on
-        friend thread_pool_policy_scheduler tag_invoke(Tag tag,
-            thread_pool_policy_scheduler const& scheduler, Property&& prop)
-        {
-            auto scheduler_with_prop = scheduler;
-            scheduler_with_prop.policy_ = hpx::functional::tag_invoke(
-                tag, scheduler.policy_, HPX_FORWARD(Property, prop));
-            return scheduler_with_prop;
-        }
-
-        // clang-format off
-        template <typename Tag,
-            HPX_CONCEPT_REQUIRES_(
-                hpx::execution::experimental::is_scheduling_property_v<Tag> &&
-                hpx::functional::is_tag_invocable_v<Tag, Policy>
-            )>
-        // clang-format on
-        friend decltype(auto) tag_invoke(
-            Tag tag, thread_pool_policy_scheduler const& scheduler)
-        {
-            return hpx::functional::tag_invoke(tag, scheduler.policy_);
-        }
-
         friend constexpr thread_pool_policy_scheduler tag_invoke(
             hpx::parallel::execution::with_processing_units_count_t,
             thread_pool_policy_scheduler const& scheduler,
@@ -321,7 +291,12 @@ namespace hpx::execution::experimental {
             return {sched};
         }
 
-        Policy policy() const
+        void policy(Policy policy) noexcept
+        {
+            policy_ = HPX_MOVE(policy);
+        }
+
+        constexpr Policy const& policy() const noexcept
         {
             return policy_;
         }
@@ -351,6 +326,38 @@ namespace hpx::execution::experimental {
 #endif
         /// \endcond
     };
+
+    // support all properties exposed by the embedded policy
+    // clang-format off
+    template <typename Tag,  typename Policy,typename Property,
+        HPX_CONCEPT_REQUIRES_(
+            hpx::execution::experimental::is_scheduling_property_v<Tag>
+        )>
+    // clang-format on
+    auto tag_invoke(Tag tag,
+        thread_pool_policy_scheduler<Policy> const& scheduler, Property&& prop)
+        -> decltype(std::declval<Tag>()(
+                        std::declval<Policy>(), std::declval<Property>()),
+            thread_pool_policy_scheduler<Policy>())
+    {
+        auto scheduler_with_prop = scheduler;
+        scheduler_with_prop.policy(
+            tag(scheduler.policy(), HPX_FORWARD(Property, prop)));
+        return scheduler_with_prop;
+    }
+
+    // clang-format off
+    template <typename Tag, typename Policy,
+        HPX_CONCEPT_REQUIRES_(
+            hpx::execution::experimental::is_scheduling_property_v<Tag>
+        )>
+    // clang-format on
+    auto tag_invoke(
+        Tag tag, thread_pool_policy_scheduler<Policy> const& scheduler)
+        -> decltype(std::declval<Tag>()(std::declval<Policy>()))
+    {
+        return tag(scheduler.policy());
+    }
 
     using thread_pool_scheduler = thread_pool_policy_scheduler<hpx::launch>;
 }    // namespace hpx::execution::experimental

--- a/libs/core/executors/include/hpx/executors/thread_pool_scheduler.hpp
+++ b/libs/core/executors/include/hpx/executors/thread_pool_scheduler.hpp
@@ -336,8 +336,9 @@ namespace hpx::execution::experimental {
     // clang-format on
     auto tag_invoke(Tag tag,
         thread_pool_policy_scheduler<Policy> const& scheduler, Property&& prop)
-        -> decltype(std::declval<Tag>()(
-                        std::declval<Policy>(), std::declval<Property>()),
+        -> decltype(std::declval<thread_pool_policy_scheduler<Policy>>().policy(
+                        std::declval<Tag>()(
+                            std::declval<Policy>(), std::declval<Property>())),
             thread_pool_policy_scheduler<Policy>())
     {
         auto scheduler_with_prop = scheduler;

--- a/libs/core/functional/tests/regressions/is_callable_1179.cpp
+++ b/libs/core/functional/tests/regressions/is_callable_1179.cpp
@@ -29,8 +29,8 @@ struct p
 ///////////////////////////////////////////////////////////////////////////////
 int main()
 {
-    using hpx::is_invocable_v;
     using hpx::invoke;
+    using hpx::is_invocable_v;
 
     typedef int (s::*mem_fun_ptr)();
     HPX_TEST_MSG((is_invocable_v<mem_fun_ptr, p> == false), "mem-fun-ptr");

--- a/libs/core/futures/CMakeLists.txt
+++ b/libs/core/futures/CMakeLists.txt
@@ -61,7 +61,18 @@ add_hpx_module(
   HEADERS ${futures_headers}
   COMPAT_HEADERS ${futures_compat_headers}
   ADD_TO_GLOBAL_HEADER "hpx/futures/detail/future_transforms.hpp"
-  MODULE_DEPENDENCIES hpx_async_base hpx_config hpx_allocator_support hpx_errors
-                      hpx_memory hpx_synchronization
+  MODULE_DEPENDENCIES
+    hpx_allocator_support
+    hpx_assertion
+    hpx_async_base
+    hpx_concepts
+    hpx_config
+    hpx_errors
+    hpx_functional
+    hpx_memory
+    hpx_serialization
+    hpx_synchronization
+    hpx_timing
+    hpx_type_support
   CMAKE_SUBDIRS examples tests
 )

--- a/libs/core/futures/tests/unit/future_then.cpp
+++ b/libs/core/futures/tests/unit/future_then.cpp
@@ -214,20 +214,18 @@ void test_complex_then_chain_two()
 ///////////////////////////////////////////////////////////////////////////////
 int hpx_main()
 {
-    {
-        test_return_int();
-        test_return_int_launch();
-        test_return_void();
-        test_return_void_launch();
-        test_implicit_unwrapping();
-        test_simple_then();
-        test_simple_deferred_then();
-        test_complex_then();
-        test_complex_then_launch();
-        test_complex_then_chain_one();
-        test_complex_then_chain_one_launch();
-        test_complex_then_chain_two();
-    }
+    test_return_int();
+    test_return_int_launch();
+    test_return_void();
+    test_return_void_launch();
+    test_implicit_unwrapping();
+    test_simple_then();
+    test_simple_deferred_then();
+    test_complex_then();
+    test_complex_then_launch();
+    test_complex_then_chain_one();
+    test_complex_then_chain_one_launch();
+    test_complex_then_chain_two();
 
     hpx::local::finalize();
     return hpx::util::report_errors();

--- a/libs/core/properties/include/hpx/properties/property.hpp
+++ b/libs/core/properties/include/hpx/properties/property.hpp
@@ -20,7 +20,7 @@ namespace hpx { namespace experimental {
     {
         // clang-format off
         template <typename Tag, typename... Tn>
-        friend constexpr HPX_FORCEINLINE auto tag_invoke(
+        friend constexpr HPX_FORCEINLINE auto tag_fallback_invoke(
                 prefer_t, Tag const& tag, Tn&&... tn)
             noexcept(noexcept(tag(HPX_FORWARD(Tn, tn)...)))
             -> decltype(tag(HPX_FORWARD(Tn, tn)...))

--- a/libs/core/properties/include/hpx/properties/property.hpp
+++ b/libs/core/properties/include/hpx/properties/property.hpp
@@ -20,7 +20,7 @@ namespace hpx { namespace experimental {
     {
         // clang-format off
         template <typename Tag, typename... Tn>
-        friend constexpr HPX_FORCEINLINE auto tag_fallback_invoke(
+        friend constexpr HPX_FORCEINLINE auto tag_invoke(
                 prefer_t, Tag const& tag, Tn&&... tn)
             noexcept(noexcept(tag(HPX_FORWARD(Tn, tn)...)))
             -> decltype(tag(HPX_FORWARD(Tn, tn)...))

--- a/libs/core/tag_invoke/CMakeLists.txt
+++ b/libs/core/tag_invoke/CMakeLists.txt
@@ -31,6 +31,8 @@ add_hpx_module(
   SOURCES ${tag_invoke_sources}
   HEADERS ${tag_invoke_headers}
   COMPAT_HEADERS ${tag_invoke_compat_headers}
+  ADD_TO_GLOBAL_HEADER "hpx/functional/detail/tag_fallback_invoke.hpp"
+                       "hpx/functional/detail/tag_priority_invoke.hpp"
   MODULE_DEPENDENCIES hpx_config hpx_type_support
   CMAKE_SUBDIRS examples tests
 )


### PR DESCRIPTION
- futures are not senders anymore (by default), this introduces `as_sender()` that can be used for this purpose
- fixed reverse and rotate algorithms to properly work with sender/receiver based executors
- flyby: modernize reverse and rotate algorithm implementations
- flyby: adding hpx::tuple_size_v (C++17)
