### PR TITLE
Add non-contiguous index queue and use it in thread_pool_bulk_scheduler

### DIFF
--- a/libs/core/algorithms/CMakeLists.txt
+++ b/libs/core/algorithms/CMakeLists.txt
@@ -178,6 +178,7 @@ set(algorithms_headers
     hpx/parallel/spmd_block.hpp
     hpx/parallel/task_block.hpp
     hpx/parallel/task_group.hpp
+    hpx/parallel/util/adapt_placement_mode.hpp
     hpx/parallel/util/cancellation_token.hpp
     hpx/parallel/util/compare_projected.hpp
     hpx/parallel/util/detail/algorithm_result.hpp

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/all_any_none.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/all_any_none.hpp
@@ -325,6 +325,7 @@ namespace hpx {
 
 #include <hpx/config.hpp>
 #include <hpx/concepts/concepts.hpp>
+#include <hpx/coroutines/thread_enums.hpp>
 #include <hpx/functional/invoke.hpp>
 #include <hpx/iterator_support/range.hpp>
 #include <hpx/iterator_support/traits/is_iterator.hpp>
@@ -336,6 +337,7 @@ namespace hpx {
 #include <hpx/parallel/algorithms/detail/dispatch.hpp>
 #include <hpx/parallel/algorithms/detail/distance.hpp>
 #include <hpx/parallel/algorithms/detail/find.hpp>
+#include <hpx/parallel/util/cancellation_token.hpp>
 #include <hpx/parallel/util/detail/algorithm_result.hpp>
 #include <hpx/parallel/util/invoke_projected.hpp>
 #include <hpx/parallel/util/loop.hpp>
@@ -357,7 +359,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
         /// \cond NOINTERNAL
         struct none_of : public detail::algorithm<none_of, bool>
         {
-            none_of()
+            constexpr none_of() noexcept
               : none_of::algorithm("none_of")
             {
             }
@@ -384,20 +386,22 @@ namespace hpx { namespace parallel { inline namespace v1 {
                         true);
                 }
 
+                using policy_type = std::decay_t<ExPolicy>;
+
                 util::cancellation_token<> tok;
                 auto f1 = [op = HPX_FORWARD(F, op), tok,
                               proj = HPX_FORWARD(Proj, proj)](
                               FwdIter part_begin,
                               std::size_t part_count) mutable -> bool {
-                    detail::sequential_find_if<std::decay_t<ExPolicy>>(
-                        part_begin, part_count, tok, HPX_FORWARD(F, op),
+                    detail::sequential_find_if<policy_type>(part_begin,
+                        part_count, tok, HPX_FORWARD(F, op),
                         HPX_FORWARD(Proj, proj));
 
                     return !tok.was_cancelled();
                 };
 
-                return util::partitioner<ExPolicy, bool>::call(
-                    HPX_FORWARD(ExPolicy, policy), first,
+                return util::partitioner<policy_type, bool>::call(
+                    HPX_FORWARD(decltype(policy), policy), first,
                     detail::distance(first, last), HPX_MOVE(f1),
                     [](auto&& results) {
                         return detail::sequential_find_if_not<
@@ -419,7 +423,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
         /// \cond NOINTERNAL
         struct any_of : public detail::algorithm<any_of, bool>
         {
-            any_of()
+            constexpr any_of() noexcept
               : any_of::algorithm("any_of")
             {
             }
@@ -446,20 +450,22 @@ namespace hpx { namespace parallel { inline namespace v1 {
                         false);
                 }
 
+                using policy_type = std::decay_t<ExPolicy>;
+
                 util::cancellation_token<> tok;
                 auto f1 = [op = HPX_FORWARD(F, op), tok,
                               proj = HPX_FORWARD(Proj, proj)](
                               FwdIter part_begin,
                               std::size_t part_count) mutable -> bool {
-                    detail::sequential_find_if<std::decay_t<ExPolicy>>(
-                        part_begin, part_count, tok, HPX_FORWARD(F, op),
+                    detail::sequential_find_if<policy_type>(part_begin,
+                        part_count, tok, HPX_FORWARD(F, op),
                         HPX_FORWARD(Proj, proj));
 
                     return tok.was_cancelled();
                 };
 
-                return util::partitioner<ExPolicy, bool>::call(
-                    HPX_FORWARD(ExPolicy, policy), first,
+                return util::partitioner<policy_type, bool>::call(
+                    HPX_FORWARD(decltype(policy), policy), first,
                     detail::distance(first, last), HPX_MOVE(f1),
                     [](auto&& results) {
                         return detail::sequential_find_if<
@@ -481,7 +487,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
         /// \cond NOINTERNAL
         struct all_of : public detail::algorithm<all_of, bool>
         {
-            all_of()
+            constexpr all_of() noexcept
               : all_of::algorithm("all_of")
             {
             }
@@ -507,20 +513,22 @@ namespace hpx { namespace parallel { inline namespace v1 {
                         true);
                 }
 
+                using policy_type = std::decay_t<ExPolicy>;
+
                 util::cancellation_token<> tok;
                 auto f1 = [op = HPX_FORWARD(F, op), tok,
                               proj = HPX_FORWARD(Proj, proj)](
                               FwdIter part_begin,
                               std::size_t part_count) mutable -> bool {
-                    detail::sequential_find_if_not<std::decay_t<ExPolicy>>(
-                        part_begin, part_count, tok, HPX_FORWARD(F, op),
+                    detail::sequential_find_if_not<policy_type>(part_begin,
+                        part_count, tok, HPX_FORWARD(F, op),
                         HPX_FORWARD(Proj, proj));
 
                     return !tok.was_cancelled();
                 };
 
-                return util::partitioner<ExPolicy, bool>::call(
-                    HPX_FORWARD(ExPolicy, policy), first,
+                return util::partitioner<policy_type, bool>::call(
+                    HPX_FORWARD(decltype(policy), policy), first,
                     detail::distance(first, last), HPX_MOVE(f1),
                     [](auto&& results) {
                         return detail::sequential_find_if_not<

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/detail/upper_lower_bound.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/detail/upper_lower_bound.hpp
@@ -10,7 +10,6 @@
 #include <hpx/functional/invoke.hpp>
 
 #include <hpx/parallel/algorithms/detail/distance.hpp>
-#include <hpx/parallel/util/cancellation_token.hpp>
 
 #include <functional>
 #include <iterator>

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/lexicographical_compare.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/lexicographical_compare.hpp
@@ -169,6 +169,7 @@ namespace hpx {
 #include <hpx/parallel/algorithms/detail/dispatch.hpp>
 #include <hpx/parallel/algorithms/for_each.hpp>
 #include <hpx/parallel/algorithms/mismatch.hpp>
+#include <hpx/parallel/util/cancellation_token.hpp>
 #include <hpx/parallel/util/detail/algorithm_result.hpp>
 #include <hpx/parallel/util/detail/clear_container.hpp>
 #include <hpx/parallel/util/loop.hpp>
@@ -190,7 +191,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
         struct lexicographical_compare
           : public detail::algorithm<lexicographical_compare, bool>
         {
-            lexicographical_compare()
+            constexpr lexicographical_compare() noexcept
               : lexicographical_compare::algorithm("lexicographical_compare")
             {
             }
@@ -219,7 +220,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 typename FwdIter2, typename Sent2, typename Pred,
                 typename Proj1, typename Proj2>
             static typename util::detail::algorithm_result<ExPolicy, bool>::type
-            parallel(ExPolicy&& policy, FwdIter1 first1, Sent1 last1,
+            parallel(ExPolicy&& orgpolicy, FwdIter1 first1, Sent1 last1,
                 FwdIter2 first2, Sent2 last2, Pred&& pred, Proj1&& proj1,
                 Proj2&& proj2)
             {
@@ -244,14 +245,19 @@ namespace hpx { namespace parallel { inline namespace v1 {
                         false);
                 }
 
+                decltype(auto) policy = parallel::util::adapt_placement_mode(
+                    HPX_FORWARD(ExPolicy, orgpolicy),
+                    hpx::threads::thread_placement_hint::breadth_first);
+
+                using policy_type = std::decay_t<decltype(policy)>;
+
                 std::size_t count = (std::min)(count1, count2);
-                util::cancellation_token<std::size_t> tok(count);
+                hpx::parallel::util::cancellation_token<std::size_t> tok(count);
 
                 auto f1 = [tok, pred, proj1, proj2](zip_iterator it,
                               std::size_t part_count,
                               std::size_t base_idx) mutable -> void {
-                    util::loop_idx_n<std::decay_t<ExPolicy>>(base_idx, it,
-                        part_count, tok,
+                    util::loop_idx_n<policy_type>(base_idx, it, part_count, tok,
                         [&pred, &tok, &proj1, &proj2](
                             reference t, std::size_t i) mutable -> void {
                             using hpx::get;
@@ -288,9 +294,12 @@ namespace hpx { namespace parallel { inline namespace v1 {
                     return first2 != last2;
                 };
 
-                return util::partitioner<ExPolicy, bool, void>::call_with_index(
-                    HPX_FORWARD(ExPolicy, policy), zip_iterator(first1, first2),
-                    count, 1, HPX_MOVE(f1), HPX_MOVE(f2));
+                using partitioner_type =
+                    util::partitioner<policy_type, bool, void>;
+                return partitioner_type::call_with_index(
+                    HPX_FORWARD(decltype(policy), policy),
+                    zip_iterator(first1, first2), count, 1, HPX_MOVE(f1),
+                    HPX_MOVE(f2));
             }
         };
         /// \endcond

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/uninitialized_copy.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/uninitialized_copy.hpp
@@ -200,6 +200,7 @@ namespace hpx {
 #include <hpx/executors/execution_policy.hpp>
 #include <hpx/parallel/algorithms/detail/dispatch.hpp>
 #include <hpx/parallel/algorithms/detail/distance.hpp>
+#include <hpx/parallel/util/cancellation_token.hpp>
 #include <hpx/parallel/util/detail/algorithm_result.hpp>
 #include <hpx/parallel/util/detail/clear_container.hpp>
 #include <hpx/parallel/util/detail/sender_util.hpp>

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/uninitialized_default_construct.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/uninitialized_default_construct.hpp
@@ -172,6 +172,7 @@ namespace hpx {
 #include <hpx/executors/execution_policy.hpp>
 #include <hpx/parallel/algorithms/detail/dispatch.hpp>
 #include <hpx/parallel/algorithms/detail/distance.hpp>
+#include <hpx/parallel/util/cancellation_token.hpp>
 #include <hpx/parallel/util/detail/algorithm_result.hpp>
 #include <hpx/parallel/util/detail/clear_container.hpp>
 #include <hpx/parallel/util/detail/sender_util.hpp>

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/uninitialized_fill.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/uninitialized_fill.hpp
@@ -173,6 +173,7 @@ namespace hpx {
 #include <hpx/executors/execution_policy.hpp>
 #include <hpx/parallel/algorithms/detail/dispatch.hpp>
 #include <hpx/parallel/algorithms/detail/distance.hpp>
+#include <hpx/parallel/util/cancellation_token.hpp>
 #include <hpx/parallel/util/detail/algorithm_result.hpp>
 #include <hpx/parallel/util/detail/clear_container.hpp>
 #include <hpx/parallel/util/detail/sender_util.hpp>

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/uninitialized_move.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/uninitialized_move.hpp
@@ -203,6 +203,7 @@ namespace hpx {
 #include <hpx/executors/execution_policy.hpp>
 #include <hpx/parallel/algorithms/detail/dispatch.hpp>
 #include <hpx/parallel/algorithms/detail/distance.hpp>
+#include <hpx/parallel/util/cancellation_token.hpp>
 #include <hpx/parallel/util/detail/algorithm_result.hpp>
 #include <hpx/parallel/util/detail/clear_container.hpp>
 #include <hpx/parallel/util/detail/sender_util.hpp>

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/uninitialized_value_construct.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/uninitialized_value_construct.hpp
@@ -169,6 +169,7 @@ namespace hpx {
 #include <hpx/executors/execution_policy.hpp>
 #include <hpx/parallel/algorithms/detail/dispatch.hpp>
 #include <hpx/parallel/algorithms/detail/distance.hpp>
+#include <hpx/parallel/util/cancellation_token.hpp>
 #include <hpx/parallel/util/detail/algorithm_result.hpp>
 #include <hpx/parallel/util/detail/clear_container.hpp>
 #include <hpx/parallel/util/detail/sender_util.hpp>

--- a/libs/core/algorithms/include/hpx/parallel/datapar/adjacent_find.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/datapar/adjacent_find.hpp
@@ -20,6 +20,7 @@
 #include <hpx/parallel/datapar/iterator_helpers.hpp>
 #include <hpx/parallel/datapar/loop.hpp>
 #include <hpx/parallel/datapar/zip_iterator.hpp>
+#include <hpx/parallel/util/cancellation_token.hpp>
 #include <hpx/parallel/util/result_types.hpp>
 
 #include <cstddef>

--- a/libs/core/algorithms/include/hpx/parallel/datapar/equal.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/datapar/equal.hpp
@@ -17,6 +17,7 @@
 #include <hpx/parallel/algorithms/detail/equal.hpp>
 #include <hpx/parallel/datapar/handle_local_exceptions.hpp>
 #include <hpx/parallel/datapar/loop.hpp>
+#include <hpx/parallel/util/cancellation_token.hpp>
 #include <hpx/parallel/util/result_types.hpp>
 #include <hpx/parallel/util/zip_iterator.hpp>
 

--- a/libs/core/algorithms/include/hpx/parallel/datapar/find.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/datapar/find.hpp
@@ -19,6 +19,7 @@
 #include <hpx/parallel/datapar/iterator_helpers.hpp>
 #include <hpx/parallel/datapar/loop.hpp>
 #include <hpx/parallel/datapar/zip_iterator.hpp>
+#include <hpx/parallel/util/cancellation_token.hpp>
 #include <hpx/parallel/util/result_types.hpp>
 
 #include <cstddef>

--- a/libs/core/algorithms/include/hpx/parallel/datapar/mismatch.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/datapar/mismatch.hpp
@@ -18,6 +18,7 @@
 #include <hpx/parallel/algorithms/detail/mismatch.hpp>
 #include <hpx/parallel/datapar/handle_local_exceptions.hpp>
 #include <hpx/parallel/datapar/loop.hpp>
+#include <hpx/parallel/util/cancellation_token.hpp>
 #include <hpx/parallel/util/detail/algorithm_result.hpp>
 #include <hpx/parallel/util/result_types.hpp>
 #include <hpx/parallel/util/zip_iterator.hpp>

--- a/libs/core/algorithms/include/hpx/parallel/datapar/transform_loop.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/datapar/transform_loop.hpp
@@ -17,7 +17,6 @@
 #include <hpx/functional/tag_invoke.hpp>
 #include <hpx/iterator_support/traits/is_iterator.hpp>
 #include <hpx/parallel/datapar/iterator_helpers.hpp>
-#include <hpx/parallel/util/cancellation_token.hpp>
 #include <hpx/parallel/util/transform_loop.hpp>
 
 #include <algorithm>

--- a/libs/core/algorithms/include/hpx/parallel/util/adapt_placement_mode.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/util/adapt_placement_mode.hpp
@@ -1,0 +1,53 @@
+//  Copyright (c) 2022 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include <hpx/config.hpp>
+#include <hpx/async_base/scheduling_properties.hpp>
+#include <hpx/concepts/concepts.hpp>
+#include <hpx/coroutines/thread_enums.hpp>
+#include <hpx/executors/execution_policy_hint.hpp>
+#include <hpx/properties/property.hpp>
+
+namespace hpx::parallel::util {
+
+    // clang-format off
+    template <typename ExPolicy,
+        HPX_CONCEPT_REQUIRES_(
+            hpx::is_execution_policy_v<ExPolicy>
+        )>
+    // clang-format on
+    decltype(auto) adapt_placement_mode(
+        ExPolicy&& policy, hpx::threads::thread_placement_hint placement)
+    {
+        constexpr bool supports_placement_hint =
+            hpx::functional::is_tag_invocable_v<
+                hpx::execution::experimental::with_hint_t,
+                std::decay_t<ExPolicy>, hpx::threads::thread_schedule_hint>;
+
+        if constexpr (supports_placement_hint)
+        {
+            hpx::threads::thread_schedule_hint hint =
+                hpx::execution::experimental::get_hint(policy);
+
+            // modify placement hint only if it is the default (do not overwrite
+            // user supplied values)
+            if (hint.placement_mode ==
+                hpx::threads::thread_placement_hint::none)
+            {
+                hint.placement_mode = placement;
+            }
+
+            return hpx::execution::experimental::with_hint(
+                HPX_FORWARD(ExPolicy, policy), hint);
+        }
+        else
+        {
+            return HPX_FORWARD(ExPolicy, policy);
+        }
+    }
+}    // namespace hpx::parallel::util

--- a/libs/core/algorithms/include/hpx/parallel/util/loop.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/util/loop.hpp
@@ -14,7 +14,6 @@
 #include <hpx/functional/detail/tag_fallback_invoke.hpp>
 #include <hpx/functional/invoke_result.hpp>
 #include <hpx/iterator_support/traits/is_iterator.hpp>
-#include <hpx/parallel/util/cancellation_token.hpp>
 #include <hpx/parallel/util/projection_identity.hpp>
 
 #include <algorithm>

--- a/libs/core/algorithms/include/hpx/parallel/util/partitioner.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/util/partitioner.hpp
@@ -203,7 +203,7 @@ namespace hpx { namespace parallel { namespace util {
 
             template <typename ExPolicy_, typename FwdIter, typename F1,
                 typename F2>
-            static auto call(ExPolicy_&& policy, FwdIter first,
+            static decltype(auto) call(ExPolicy_&& policy, FwdIter first,
                 std::size_t count, F1&& f1, F2&& f2)
             {
                 // inform parameter traits
@@ -228,8 +228,9 @@ namespace hpx { namespace parallel { namespace util {
 
             template <typename ExPolicy_, typename FwdIter, typename Stride,
                 typename F1, typename F2>
-            static auto call_with_index(ExPolicy_&& policy, FwdIter first,
-                std::size_t count, Stride stride, F1&& f1, F2&& f2)
+            static decltype(auto) call_with_index(ExPolicy_&& policy,
+                FwdIter first, std::size_t count, Stride stride, F1&& f1,
+                F2&& f2)
             {
                 // inform parameter traits
                 scoped_executor_parameters scoped_params(
@@ -254,8 +255,8 @@ namespace hpx { namespace parallel { namespace util {
             template <typename ExPolicy_, typename FwdIter, typename F1,
                 typename F2, typename Data>
             // requires is_container<Data>
-            static auto call_with_data(ExPolicy_&& policy, FwdIter first,
-                std::size_t count, F1&& f1, F2&& f2,
+            static decltype(auto) call_with_data(ExPolicy_&& policy,
+                FwdIter first, std::size_t count, F1&& f1, F2&& f2,
                 std::vector<std::size_t> const& chunk_sizes, Data&& data)
             {
                 // inform parameter traits

--- a/libs/core/algorithms/include/hpx/parallel/util/transform_loop.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/util/transform_loop.hpp
@@ -10,7 +10,6 @@
 #include <hpx/datastructures/tuple.hpp>
 #include <hpx/execution/traits/is_execution_policy.hpp>
 #include <hpx/functional/detail/invoke.hpp>
-#include <hpx/parallel/util/cancellation_token.hpp>
 #include <hpx/parallel/util/result_types.hpp>
 
 #include <algorithm>

--- a/libs/core/algorithms/tests/unit/algorithms/CMakeLists.txt
+++ b/libs/core/algorithms/tests/unit/algorithms/CMakeLists.txt
@@ -44,6 +44,7 @@ set(tests
     fill
     filln
     find
+    find_sender
     findend
     findfirstof
     findfirstof_binary

--- a/libs/core/algorithms/tests/unit/algorithms/find_sender.cpp
+++ b/libs/core/algorithms/tests/unit/algorithms/find_sender.cpp
@@ -1,0 +1,100 @@
+//  Copyright (c) 2021 Srinivas Yadav
+//  Copyright (c) 2014 Grant Mercer
+//  Copyright (c) 2022 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/local/init.hpp>
+
+#include <iostream>
+#include <string>
+#include <vector>
+
+#include "find_tests.hpp"
+
+////////////////////////////////////////////////////////////////////////////
+template <typename IteratorTag>
+void test_find_explicit_sender_direct()
+{
+    using namespace hpx::execution;
+
+    test_find_explicit_sender_direct(hpx::launch::sync, seq, IteratorTag());
+    test_find_explicit_sender_direct(hpx::launch::sync, unseq, IteratorTag());
+
+    test_find_explicit_sender_direct(hpx::launch::async, par, IteratorTag());
+    test_find_explicit_sender_direct(
+        hpx::launch::async, par_unseq, IteratorTag());
+
+    test_find_explicit_sender_direct_async(
+        hpx::launch::sync, seq(task), IteratorTag());
+    test_find_explicit_sender_direct_async(
+        hpx::launch::sync, unseq(task), IteratorTag());
+    test_find_explicit_sender_direct_async(
+        hpx::launch::async, par(task), IteratorTag());
+    test_find_explicit_sender_direct_async(
+        hpx::launch::async, par_unseq(task), IteratorTag());
+}
+
+void find_test_explicit_sender_direct()
+{
+    test_find_explicit_sender_direct<std::random_access_iterator_tag>();
+    test_find_explicit_sender_direct<std::forward_iterator_tag>();
+}
+
+template <typename IteratorTag>
+void test_find_explicit_sender()
+{
+    using namespace hpx::execution;
+
+    test_find_explicit_sender(hpx::launch::sync, seq(task), IteratorTag());
+    test_find_explicit_sender(hpx::launch::sync, unseq(task), IteratorTag());
+    test_find_explicit_sender(hpx::launch::async, par(task), IteratorTag());
+    test_find_explicit_sender(
+        hpx::launch::async, par_unseq(task), IteratorTag());
+}
+
+void find_test_explicit_sender()
+{
+    test_find_explicit_sender<std::random_access_iterator_tag>();
+    test_find_explicit_sender<std::forward_iterator_tag>();
+}
+
+int hpx_main(hpx::program_options::variables_map& vm)
+{
+    if (vm.count("seed"))
+        seed = vm["seed"].as<unsigned int>();
+
+    std::cout << "using seed: " << seed << std::endl;
+    gen.seed(seed);
+
+    find_test_explicit_sender_direct();
+    find_test_explicit_sender();
+
+    return hpx::local::finalize();
+}
+
+int main(int argc, char* argv[])
+{
+    // add command line option which controls the random number generator seed
+    using namespace hpx::program_options;
+    options_description desc_commandline(
+        "Usage: " HPX_APPLICATION_STRING " [options]");
+
+    desc_commandline.add_options()("seed,s", value<unsigned int>(),
+        "the random number generator seed to use for this run");
+
+    // By default this test should run on all available cores
+    std::vector<std::string> const cfg = {"hpx.os_threads=all"};
+
+    // Initialize and run HPX
+    hpx::local::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::local::init(hpx_main, argc, argv, init_args), 0,
+        "HPX main exited with non-zero status");
+
+    return hpx::util::report_errors();
+}

--- a/libs/core/concurrency/CMakeLists.txt
+++ b/libs/core/concurrency/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2019 The STE||AR-Group
+# Copyright (c) 2019-2022 The STE||AR-Group
 #
 # SPDX-License-Identifier: BSL-1.0
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -14,6 +14,7 @@ set(concurrency_headers
     hpx/concurrency/deque.hpp
     hpx/concurrency/detail/contiguous_index_queue.hpp
     hpx/concurrency/detail/freelist.hpp
+    hpx/concurrency/detail/non_contiguous_index_queue.hpp
     hpx/concurrency/detail/tagged_ptr_pair.hpp
     hpx/concurrency/spinlock.hpp
     hpx/concurrency/spinlock_pool.hpp

--- a/libs/core/concurrency/tests/unit/CMakeLists.txt
+++ b/libs/core/concurrency/tests/unit/CMakeLists.txt
@@ -4,9 +4,10 @@
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-set(tests contiguous_index_queue lockfree_fifo)
+set(tests contiguous_index_queue lockfree_fifo non_contiguous_index_queue)
 
 set(contiguous_index_queue_PARAMETERS THREADS_PER_LOCALITY 4)
+set(non_contiguous_index_queue_PARAMETERS THREADS_PER_LOCALITY 4)
 
 foreach(test ${tests})
   set(sources ${test}.cpp)

--- a/libs/core/concurrency/tests/unit/contiguous_index_queue.cpp
+++ b/libs/core/concurrency/tests/unit/contiguous_index_queue.cpp
@@ -140,7 +140,7 @@ void test_concurrent_worker(pop_mode m, std::size_t thread_index,
 void test_concurrent(pop_mode m)
 {
     std::uint32_t first = 33;
-    std::uint32_t last = 73210;
+    std::uint32_t last = 732100;
     hpx::concurrency::detail::contiguous_index_queue<> q{first, last};
 
     std::size_t const num_threads = hpx::get_num_worker_threads();

--- a/libs/core/concurrency/tests/unit/non_contiguous_index_queue.cpp
+++ b/libs/core/concurrency/tests/unit/non_contiguous_index_queue.cpp
@@ -149,7 +149,7 @@ void test_concurrent_worker(pop_mode m, std::size_t thread_index,
 void test_concurrent(pop_mode m)
 {
     std::uint32_t first = 33;
-    std::uint32_t last = 73211;
+    std::uint32_t last = 731813;
     std::uint32_t step = 7;
     hpx::concurrency::detail::non_contiguous_index_queue<> q{first, last, step};
 

--- a/libs/core/coroutines/include/hpx/coroutines/thread_enums.hpp
+++ b/libs/core/coroutines/include/hpx/coroutines/thread_enums.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2016 Hartmut Kaiser
+//  Copyright (c) 2007-2022 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -216,6 +216,21 @@ namespace hpx { namespace threads {
     };
 
     ///////////////////////////////////////////////////////////////////////////
+    /// \enum thread_placement_hint
+    ///
+    /// The type of hint given to the scheduler related to thread placement
+    enum class thread_placement_hint : std::uint8_t
+    {
+        /// A hint that tells the scheduler to prefer spreading thread placement
+        /// on a breadth-first basis.
+        breadth_first = 0,
+
+        /// A hint that tells the scheduler to prefer spreading thread placement
+        /// on a depth-first basis.
+        depth_first = 1
+    };
+
+    ///////////////////////////////////////////////////////////////////////////
     /// \brief A hint given to a scheduler to guide where a task should be
     /// scheduled.
     ///
@@ -224,37 +239,41 @@ namespace hpx { namespace threads {
     struct thread_schedule_hint
     {
         /// Construct a default hint with mode thread_schedule_hint_mode::none.
-        constexpr thread_schedule_hint() noexcept
-          : hint(-1)
-          , mode(thread_schedule_hint_mode::none)
-        {
-        }
+        constexpr thread_schedule_hint() noexcept = default;
 
         /// Construct a hint with mode thread_schedule_hint_mode::thread and the
         /// given hint as the local thread number.
-        constexpr explicit thread_schedule_hint(
-            std::int16_t thread_hint) noexcept
+        constexpr explicit thread_schedule_hint(std::int16_t thread_hint,
+            thread_placement_hint placement =
+                thread_placement_hint::breadth_first) noexcept
           : hint(thread_hint)
           , mode(thread_schedule_hint_mode::thread)
+          , placement_mode(placement)
         {
         }
 
         /// Construct a hint with the given mode and hint. The numerical hint is
         /// unused when the mode is thread_schedule_hint_mode::none.
-        constexpr thread_schedule_hint(
-            thread_schedule_hint_mode mode, std::int16_t hint) noexcept
+        constexpr thread_schedule_hint(thread_schedule_hint_mode mode,
+            std::int16_t hint,
+            thread_placement_hint placement =
+                thread_placement_hint::breadth_first) noexcept
           : hint(hint)
           , mode(mode)
+          , placement_mode(placement)
         {
         }
 
         /// \cond NOINTERNAL
-        bool operator==(thread_schedule_hint const& rhs) const noexcept
+        constexpr bool operator==(
+            thread_schedule_hint const& rhs) const noexcept
         {
-            return mode == rhs.mode && hint == rhs.hint;
+            return mode == rhs.mode && hint == rhs.hint &&
+                placement_mode == rhs.placement_mode;
         }
 
-        bool operator!=(thread_schedule_hint const& rhs) const noexcept
+        constexpr bool operator!=(
+            thread_schedule_hint const& rhs) const noexcept
         {
             return !(*this == rhs);
         }
@@ -262,9 +281,13 @@ namespace hpx { namespace threads {
 
         /// The hint associated with the mode. The interepretation of this hint
         /// depends on the given mode.
-        std::int16_t hint;
+        std::int16_t hint = -1;
 
         /// The mode of the scheduling hint.
-        thread_schedule_hint_mode mode;
+        thread_schedule_hint_mode mode = thread_schedule_hint_mode::none;
+
+        /// The mode of the desired thread placement.
+        thread_placement_hint placement_mode =
+            thread_placement_hint::breadth_first;
     };
 }}    // namespace hpx::threads

--- a/libs/core/coroutines/include/hpx/coroutines/thread_enums.hpp
+++ b/libs/core/coroutines/include/hpx/coroutines/thread_enums.hpp
@@ -221,13 +221,31 @@ namespace hpx { namespace threads {
     /// The type of hint given to the scheduler related to thread placement
     enum class thread_placement_hint : std::uint8_t
     {
-        /// A hint that tells the scheduler to prefer spreading thread placement
-        /// on a breadth-first basis.
-        breadth_first = 0,
+        /// No hint is specified. The implementation is free to chose what
+        /// placement methods to use.
+        none = 0,
 
         /// A hint that tells the scheduler to prefer spreading thread placement
-        /// on a depth-first basis.
-        depth_first = 1
+        /// on a depth-first basis (i.e. consecutively scheduled threads are
+        /// placed on the same core).
+        depth_first = 1,
+
+        /// A hint that tells the scheduler to prefer spreading thread placement
+        /// on a breadth-first basis (i.e. consecutively scheduled threads are
+        /// placed on the neighboring cores).
+        breadth_first = 2,
+
+        /// A hint that tells the scheduler to prefer spreading thread placement
+        /// on a depth-first basis (i.e. consecutively scheduled threads are
+        /// placed on the same core). Threads are being scheduled in reverse
+        /// order.
+        depth_first_reverse = 5,
+
+        /// A hint that tells the scheduler to prefer spreading thread placement
+        /// on a breadth-first basis (i.e. consecutively scheduled threads are
+        /// placed on the neighboring cores). Threads are being scheduled in
+        /// reverse order.
+        breadth_first_reverse = 6
     };
 
     ///////////////////////////////////////////////////////////////////////////
@@ -245,7 +263,7 @@ namespace hpx { namespace threads {
         /// given hint as the local thread number.
         constexpr explicit thread_schedule_hint(std::int16_t thread_hint,
             thread_placement_hint placement =
-                thread_placement_hint::breadth_first) noexcept
+                thread_placement_hint::none) noexcept
           : hint(thread_hint)
           , mode(thread_schedule_hint_mode::thread)
           , placement_mode(placement)
@@ -257,7 +275,7 @@ namespace hpx { namespace threads {
         constexpr thread_schedule_hint(thread_schedule_hint_mode mode,
             std::int16_t hint,
             thread_placement_hint placement =
-                thread_placement_hint::breadth_first) noexcept
+                thread_placement_hint::none) noexcept
           : hint(hint)
           , mode(mode)
           , placement_mode(placement)
@@ -287,7 +305,6 @@ namespace hpx { namespace threads {
         thread_schedule_hint_mode mode = thread_schedule_hint_mode::none;
 
         /// The mode of the desired thread placement.
-        thread_placement_hint placement_mode =
-            thread_placement_hint::breadth_first;
+        thread_placement_hint placement_mode = thread_placement_hint::none;
     };
 }}    // namespace hpx::threads

--- a/libs/core/executors/CMakeLists.txt
+++ b/libs/core/executors/CMakeLists.txt
@@ -17,6 +17,7 @@ set(executors_headers
     hpx/executors/detail/hierarchical_spawning.hpp
     hpx/executors/exception_list.hpp
     hpx/executors/execution_policy_annotation.hpp
+    hpx/executors/execution_policy_hint.hpp
     hpx/executors/execution_policy_fwd.hpp
     hpx/executors/execution_policy_mappings.hpp
     hpx/executors/execution_policy_parameters.hpp

--- a/libs/core/executors/include/hpx/executors/execution_policy_annotation.hpp
+++ b/libs/core/executors/include/hpx/executors/execution_policy_annotation.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2021 Hartmut Kaiser
+//  Copyright (c) 2021-2022 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -9,24 +9,30 @@
 #pragma once
 
 #include <hpx/config.hpp>
+#include <hpx/concepts/concepts.hpp>
 #include <hpx/execution/executors/execution_parameters.hpp>
 #include <hpx/execution/executors/rebind_executor.hpp>
 #include <hpx/execution/traits/is_execution_policy.hpp>
 #include <hpx/executors/annotating_executor.hpp>
+#include <hpx/functional/tag_invoke.hpp>
 #include <hpx/properties/property.hpp>
 
 #include <string>
 #include <type_traits>
 #include <utility>
 
-namespace hpx { namespace execution { namespace experimental {
+namespace hpx::execution::experimental {
 
     // with_annotation property implementation for execution policies
     // that simply forwards to the embedded executor
     // clang-format off
     template <typename ExPolicy,
         HPX_CONCEPT_REQUIRES_(
-            hpx::is_execution_policy_v<ExPolicy>
+            hpx::is_execution_policy_v<ExPolicy> &&
+            hpx::functional::is_tag_invocable_v<
+                hpx::execution::experimental::with_annotation_t,
+                typename std::decay_t<ExPolicy>::executor_type,
+                const char*>
         )>
     // clang-format on
     constexpr decltype(auto) tag_invoke(
@@ -43,7 +49,11 @@ namespace hpx { namespace execution { namespace experimental {
     // clang-format off
     template <typename ExPolicy,
         HPX_CONCEPT_REQUIRES_(
-            hpx::is_execution_policy_v<ExPolicy>
+            hpx::is_execution_policy_v<ExPolicy> &&
+            hpx::functional::is_tag_invocable_v<
+                hpx::execution::experimental::with_annotation_t,
+                typename std::decay_t<ExPolicy>::executor_type,
+                std::string>
         )>
     // clang-format on
     decltype(auto) tag_invoke(hpx::execution::experimental::with_annotation_t,
@@ -72,4 +82,4 @@ namespace hpx { namespace execution { namespace experimental {
     {
         return hpx::execution::experimental::get_annotation(policy.executor());
     }
-}}}    // namespace hpx::execution::experimental
+}    // namespace hpx::execution::experimental

--- a/libs/core/executors/include/hpx/executors/execution_policy_hint.hpp
+++ b/libs/core/executors/include/hpx/executors/execution_policy_hint.hpp
@@ -1,0 +1,67 @@
+//  Copyright (c) 2022 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+/// \file hpx/execution/execution_policy_annotation.hpp
+
+#pragma once
+
+#include <hpx/config.hpp>
+#include <hpx/async_base/scheduling_properties.hpp>
+#include <hpx/concepts/concepts.hpp>
+#include <hpx/coroutines/thread_enums.hpp>
+#include <hpx/execution/executors/execution_parameters.hpp>
+#include <hpx/execution/executors/rebind_executor.hpp>
+#include <hpx/execution/traits/is_execution_policy.hpp>
+#include <hpx/functional/tag_invoke.hpp>
+#include <hpx/properties/property.hpp>
+
+#include <type_traits>
+#include <utility>
+
+namespace hpx::execution::experimental {
+
+    // with_hint property implementation for execution policies that simply
+    // forwards to the embedded executor
+
+    // clang-format off
+    template <typename ExPolicy,
+        HPX_CONCEPT_REQUIRES_(
+            hpx::is_execution_policy_v<ExPolicy> &&
+            hpx::functional::is_tag_invocable_v<
+                hpx::execution::experimental::with_hint_t,
+                typename std::decay_t<ExPolicy>::executor_type,
+                hpx::threads::thread_schedule_hint>
+        )>
+    // clang-format on
+    constexpr decltype(auto) tag_invoke(
+        hpx::execution::experimental::with_hint_t, ExPolicy&& policy,
+        hpx::threads::thread_schedule_hint hint)
+    {
+        auto exec =
+            hpx::execution::experimental::with_hint(policy.executor(), hint);
+
+        return hpx::parallel::execution::create_rebound_policy(
+            policy, HPX_MOVE(exec), policy.parameters());
+    }
+
+    // get_hint property implementation for execution policies that simply
+    // forwards to the embedded executor
+
+    // clang-format off
+    template <typename ExPolicy,
+        HPX_CONCEPT_REQUIRES_(
+            hpx::is_execution_policy_v<ExPolicy> &&
+            hpx::functional::is_tag_invocable_v<
+                hpx::execution::experimental::get_hint_t,
+                typename std::decay_t<ExPolicy>::executor_type>
+        )>
+    // clang-format on
+    constexpr decltype(auto) tag_invoke(
+        hpx::execution::experimental::get_hint_t, ExPolicy&& policy)
+    {
+        return hpx::execution::experimental::get_hint(policy.executor());
+    }
+}    // namespace hpx::execution::experimental

--- a/libs/core/executors/tests/unit/explicit_scheduler_executor.cpp
+++ b/libs/core/executors/tests/unit/explicit_scheduler_executor.cpp
@@ -213,20 +213,30 @@ void test_executor(Executor&& exec)
     test_bulk_then_void(exec);
 }
 
-int hpx_main()
+void tests(hpx::threads::thread_placement_hint placement)
 {
     using namespace hpx::execution::experimental;
 
+    hpx::threads::thread_schedule_hint hint;
+    hint.placement_mode = placement;
+
     {
-        auto exec = explicit_scheduler_executor(thread_pool_scheduler{});
+        auto exec = with_hint(
+            explicit_scheduler_executor(thread_pool_scheduler{}), hint);
         test_executor(exec);
     }
 
     {
-        auto exec = explicit_scheduler_executor(
-            thread_pool_policy_scheduler<hpx::launch::sync_policy>{});
+        auto exec = with_hint(explicit_scheduler_executor(
+            thread_pool_policy_scheduler<hpx::launch::sync_policy>{}), hint);
         test_executor(exec);
     }
+}
+
+int hpx_main()
+{
+    tests(hpx::threads::thread_placement_hint::breadth_first);
+    tests(hpx::threads::thread_placement_hint::depth_first);
 
     return hpx::local::finalize();
 }

--- a/libs/core/executors/tests/unit/explicit_scheduler_executor.cpp
+++ b/libs/core/executors/tests/unit/explicit_scheduler_executor.cpp
@@ -227,8 +227,10 @@ void tests(hpx::threads::thread_placement_hint placement)
     }
 
     {
-        auto exec = with_hint(explicit_scheduler_executor(
-            thread_pool_policy_scheduler<hpx::launch::sync_policy>{}), hint);
+        auto exec = with_hint(
+            explicit_scheduler_executor(
+                thread_pool_policy_scheduler<hpx::launch::sync_policy>{}),
+            hint);
         test_executor(exec);
     }
 }


### PR DESCRIPTION
This changes the sequence of partitions scheduled on the same core.

@hcq9102 Could you please run your performance scripts for the S/R executor using PR to see if this behaves differently for larger numbers of cores?