### PR TITLE
Deprecated hpx::util::invoke_fused in favor of hpx::invoke_fused

### DIFF
--- a/docs/sphinx/api/public_api.rst
+++ b/docs/sphinx/api/public_api.rst
@@ -479,7 +479,7 @@ Functions
    :cpp:func:`hpx::experimental::bind_back`
    :cpp:func:`hpx::bind_front`               :cppreference-generic:`utility/functional,bind_front`
    :cpp:func:`hpx::invoke`                   :cppreference-generic:`utility/functional,invoke`
-   :cpp:func:`hpx::invoke_fused`
+   :cpp:func:`hpx::invoke_fused`             :cppreference-generic:`utility,apply`
    :cpp:func:`hpx::invoke_fused_r`
    :cpp:func:`hpx::mem_fn`                   :cppreference-generic:`utility/functional,mem_fn`
    ========================================  =====================================================

--- a/docs/sphinx/api/public_api.rst
+++ b/docs/sphinx/api/public_api.rst
@@ -480,6 +480,7 @@ Functions
    :cpp:func:`hpx::bind_front`               :cppreference-generic:`utility/functional,bind_front`
    :cpp:func:`hpx::invoke`                   :cppreference-generic:`utility/functional,invoke`
    :cpp:func:`hpx::invoke_fused`
+   :cpp:func:`hpx::invoke_fused_r`
    :cpp:func:`hpx::mem_fn`                   :cppreference-generic:`utility/functional,mem_fn`
    ========================================  =====================================================
 

--- a/docs/sphinx/api/public_api.rst
+++ b/docs/sphinx/api/public_api.rst
@@ -479,7 +479,7 @@ Functions
    :cpp:func:`hpx::experimental::bind_back`
    :cpp:func:`hpx::bind_front`               :cppreference-generic:`utility/functional,bind_front`
    :cpp:func:`hpx::invoke`                   :cppreference-generic:`utility/functional,invoke`
-   :cpp:func:`hpx::util::invoke_fused`
+   :cpp:func:`hpx::invoke_fused`
    :cpp:func:`hpx::mem_fn`                   :cppreference-generic:`utility/functional,mem_fn`
    ========================================  =====================================================
 

--- a/libs/core/algorithms/include/hpx/parallel/task_group.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/task_group.hpp
@@ -75,7 +75,7 @@ namespace hpx { namespace execution { namespace experimental {
                     std::exception_ptr p;
                     try
                     {
-                        hpx::util::invoke_fused(HPX_MOVE(f), HPX_MOVE(t));
+                        hpx::invoke_fused(HPX_MOVE(f), HPX_MOVE(t));
                         return;
                     }
                     catch (...)

--- a/libs/core/algorithms/include/hpx/parallel/util/detail/partitioner_iteration.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/util/detail/partitioner_iteration.hpp
@@ -16,7 +16,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 namespace hpx { namespace parallel { namespace util { namespace detail {
     // Hand-crafted function object allowing to replace a more complex
-    // bind(functional::invoke_fused(), f1, _1)
+    // bind(hpx::functional::invoke_fused(), f1, _1)
     template <typename Result, typename F>
     struct partitioner_iteration
     {
@@ -25,7 +25,7 @@ namespace hpx { namespace parallel { namespace util { namespace detail {
         template <typename T>
         HPX_HOST_DEVICE HPX_FORCEINLINE Result operator()(T&& t)
         {
-            return hpx::util::invoke_fused_r<Result>(f_, HPX_FORWARD(T, t));
+            return hpx::invoke_fused_r<Result>(f_, HPX_FORWARD(T, t));
         }
     };
 }}}}    // namespace hpx::parallel::util::detail

--- a/libs/core/compute_local/include/hpx/compute_local/host/block_allocator.hpp
+++ b/libs/core/compute_local/include/hpx/compute_local/host/block_allocator.hpp
@@ -161,7 +161,7 @@ namespace hpx { namespace compute { namespace host {
                                 [&arguments, p](iterator_type it) {
                                     using hpx::util::functional::
                                         placement_new_one;
-                                    hpx::util::invoke_fused(
+                                    hpx::invoke_fused(
                                         placement_new_one<U>(p + *it),
                                         arguments);
                                 },

--- a/libs/core/execution/include/hpx/execution/algorithms/let_value.hpp
+++ b/libs/core/execution/include/hpx/execution/algorithms/let_value.hpp
@@ -277,7 +277,7 @@ namespace hpx::execution::experimental {
                         {
                             using operation_state_type =
                                 decltype(hpx::execution::experimental::connect(
-                                    hpx::util::invoke_fused(HPX_MOVE(f), t),
+                                    hpx::invoke_fused(HPX_MOVE(f), t),
                                     std::declval<Receiver>()));
 
 #if defined(HPX_HAVE_CXX17_COPY_ELISION)
@@ -289,7 +289,7 @@ namespace hpx::execution::experimental {
                                 .template emplace<operation_state_type>(
                                     hpx::util::detail::with_result_of([&]() {
                                         return hpx::execution::experimental::
-                                            connect(hpx::util::invoke_fused(
+                                            connect(hpx::invoke_fused(
                                                         HPX_MOVE(f), t),
                                                 HPX_MOVE(receiver));
                                     }));
@@ -299,7 +299,7 @@ namespace hpx::execution::experimental {
                             op_state.successor_op_state
                                 .template emplace_f<operation_state_type>(
                                     hpx::execution::experimental::connect,
-                                    hpx::util::invoke_fused(HPX_MOVE(f), t),
+                                    hpx::invoke_fused(HPX_MOVE(f), t),
                                     HPX_MOVE(receiver));
 #endif
                             hpx::visit(

--- a/libs/core/execution/include/hpx/execution/algorithms/schedule_from.hpp
+++ b/libs/core/execution/include/hpx/execution/algorithms/schedule_from.hpp
@@ -269,7 +269,7 @@ namespace hpx::execution::experimental {
                             !std::is_same_v<std::decay_t<Ts>, hpx::monostate>>>
                     void operator()(Ts&& ts)
                     {
-                        hpx::util::invoke_fused(
+                        hpx::invoke_fused(
                             hpx::bind_front(
                                 hpx::execution::experimental::set_value,
                                 HPX_MOVE(receiver)),

--- a/libs/core/execution/include/hpx/execution/algorithms/split.hpp
+++ b/libs/core/execution/include/hpx/execution/algorithms/split.hpp
@@ -77,7 +77,7 @@ namespace hpx::execution::experimental {
             void operator()(Ts const& ts) noexcept
             {
                 // FIXME: check whether it is ok to move the receiver
-                hpx::util::invoke_fused(
+                hpx::invoke_fused(
                     hpx::bind_front(hpx::execution::experimental::set_value,
                         HPX_MOVE(receiver)),
                     ts);

--- a/libs/core/execution_base/tests/unit/any_sender.cpp
+++ b/libs/core/execution_base/tests/unit/any_sender.cpp
@@ -75,7 +75,7 @@ struct non_copyable_sender
         friend void tag_invoke(
             hpx::execution::experimental::start_t, operation_state& os) noexcept
         {
-            hpx::util::invoke_fused(
+            hpx::invoke_fused(
                 hpx::bind_front(
                     hpx::execution::experimental::set_value, std::move(os.r)),
                 std::move(os.ts));
@@ -127,7 +127,7 @@ struct sender
         friend void tag_invoke(
             hpx::execution::experimental::start_t, operation_state& os) noexcept
         {
-            hpx::util::invoke_fused(
+            hpx::invoke_fused(
                 hpx::bind_front(
                     hpx::execution::experimental::set_value, std::move(os.r)),
                 std::move(os.ts));

--- a/libs/core/executors/include/hpx/executors/dataflow.hpp
+++ b/libs/core/executors/include/hpx/executors/dataflow.hpp
@@ -86,7 +86,7 @@ namespace hpx { namespace lcos { namespace detail {
     {
         static auto error(F f, Args args)
         {
-            hpx::util::invoke_fused(HPX_MOVE(f), HPX_MOVE(args));
+            hpx::invoke_fused(HPX_MOVE(f), HPX_MOVE(args));
         }
 
         using type = decltype(error(std::declval<F>(), std::declval<Args>()));
@@ -104,7 +104,7 @@ namespace hpx { namespace lcos { namespace detail {
     struct dataflow_return_impl<false, Policy, F, Args,
         std::enable_if_t<traits::is_launch_policy_v<Policy>>>
     {
-        using type = hpx::future<util::detail::invoke_fused_result_t<F, Args>>;
+        using type = hpx::future<hpx::detail::invoke_fused_result_t<F, Args>>;
     };
 
     template <typename Executor, typename F, typename Args>
@@ -221,14 +221,14 @@ namespace hpx { namespace lcos { namespace detail {
                 [&]() {
                     if constexpr (is_void::value)
                     {
-                        util::invoke_fused(
+                        hpx::invoke_fused(
                             HPX_MOVE(func_), HPX_FORWARD(Futures_, futures));
 
                         this->set_data(util::unused_type());
                     }
                     else
                     {
-                        this->set_data(util::invoke_fused(
+                        this->set_data(hpx::invoke_fused(
                             HPX_MOVE(func_), HPX_FORWARD(Futures_, futures)));
                     }
                 },

--- a/libs/core/executors/include/hpx/executors/fork_join_executor.hpp
+++ b/libs/core/executors/include/hpx/executors/fork_join_executor.hpp
@@ -500,8 +500,7 @@ namespace hpx { namespace execution { namespace experimental {
             struct thread_function_helper
             {
                 using argument_pack_type = std::decay_t<Tuple>;
-                using index_pack_type =
-                    hpx::util::detail::fused_index_pack_t<Tuple>;
+                using index_pack_type = hpx::detail::fused_index_pack_t<Tuple>;
 
                 template <std::size_t... Is_, typename F_, typename A_,
                     typename Tuple_>

--- a/libs/core/executors/include/hpx/executors/guided_pool_executor.hpp
+++ b/libs/core/executors/include/hpx/executors/guided_pool_executor.hpp
@@ -473,8 +473,7 @@ namespace hpx { namespace parallel { namespace execution {
             auto unwrapped_futures_tuple = hpx::util::map_pack(
                 detail::future_extract_value{}, predecessor);
 
-            int domain =
-                hpx::util::invoke_fused(exec.hint_, unwrapped_futures_tuple);
+            int domain = hpx::invoke_fused(exec.hint_, unwrapped_futures_tuple);
 #endif
 
 #ifndef GUIDED_EXECUTOR_DEBUG

--- a/libs/core/executors/include/hpx/executors/scheduler_executor.hpp
+++ b/libs/core/executors/include/hpx/executors/scheduler_executor.hpp
@@ -57,7 +57,7 @@ namespace hpx::execution::experimental {
             return [f = HPX_FORWARD(F, f),
                        t = hpx::make_tuple(HPX_FORWARD(Ts, ts)...)](
                        auto i, auto&& predecessor, auto& v) mutable {
-                v[i] = hpx::util::invoke_fused(
+                v[i] = hpx::invoke_fused(
                     hpx::bind_front(HPX_FORWARD(F, f), i,
                         HPX_FORWARD(decltype(predecessor), predecessor)),
                     HPX_MOVE(t));

--- a/libs/core/executors/include/hpx/executors/thread_pool_scheduler_bulk.hpp
+++ b/libs/core/executors/include/hpx/executors/thread_pool_scheduler_bulk.hpp
@@ -136,7 +136,7 @@ namespace hpx::execution::experimental::detail {
 
             hpx::util::itt::mark_event e(notify_event);
 #endif
-            using index_pack_type = hpx::util::detail::fused_index_pack_t<Ts>;
+            using index_pack_type = hpx::detail::fused_index_pack_t<Ts>;
 
             auto const i_begin =
                 static_cast<std::size_t>(index) * task_f->chunk_size;
@@ -212,7 +212,7 @@ namespace hpx::execution::experimental::detail {
         // clang-format on
         void operator()(Ts&& ts) const
         {
-            hpx::util::invoke_fused(
+            hpx::invoke_fused(
                 hpx::bind_front(hpx::execution::experimental::set_value,
                     HPX_MOVE(op_state->receiver)),
                 HPX_FORWARD(Ts, ts));

--- a/libs/core/functional/docs/index.rst
+++ b/libs/core/functional/docs/index.rst
@@ -24,6 +24,7 @@ their arguments.
 * :cpp:func:`hpx::invoke`
 * :cpp:func:`hpx::invoke_r`
 * :cpp:func:`hpx::invoke_fused`
+* :cpp:func:`hpx::invoke_fused_r`
 * :cpp:func:`hpx::util::mem_fn`
 * :cpp:func:`hpx::util::one_shot`
 * :cpp:func:`hpx::util::protect`

--- a/libs/core/functional/docs/index.rst
+++ b/libs/core/functional/docs/index.rst
@@ -23,7 +23,7 @@ their arguments.
 * :cpp:func:`hpx::util::deferred_call`
 * :cpp:func:`hpx::invoke`
 * :cpp:func:`hpx::invoke_r`
-* :cpp:func:`hpx::util::invoke_fused`
+* :cpp:func:`hpx::invoke_fused`
 * :cpp:func:`hpx::util::mem_fn`
 * :cpp:func:`hpx::util::one_shot`
 * :cpp:func:`hpx::util::protect`

--- a/libs/core/functional/include/hpx/functional/invoke_fused.hpp
+++ b/libs/core/functional/include/hpx/functional/invoke_fused.hpp
@@ -73,7 +73,7 @@ namespace hpx {
     }    // namespace detail
 
     /// Invokes the given callable object f with the content of
-    /// the sequenced type t (tuples, pairs)
+    /// the sequenced type t (tuples, pairs).
     ///
     /// \param f Must be a callable object. If f is a member function pointer,
     ///          the first argument in the sequenced type will be treated as
@@ -88,7 +88,11 @@ namespace hpx {
     /// \throws std::exception like objects thrown by call to object f
     ///         with the arguments contained in the sequenceable type t.
     ///
-    /// \note This function is similar to `std::apply` (C++17)
+    /// \note This function is similar to `std::apply` (C++17). The difference
+    ///       between \c hpx::invoke and \c hpx::invoke_fused is that the later
+    ///       unpacks the tuples while the former cannot. Turning a tuple into a
+    ///       parameter pack is not a trivial operation which makes
+    ///       \c hpx::invoke_fused rather useful.
     template <typename F, typename Tuple>
     constexpr HPX_HOST_DEVICE HPX_FORCEINLINE
         typename detail::invoke_fused_result<F, Tuple>::type
@@ -105,6 +109,9 @@ namespace hpx {
     ///
     /// \tparam R The result type of the function when it's called
     ///           with the content of the given sequenced type.
+    /// \note The difference between \c hpx::invoke_fused and
+    ///       \c hpx::invoke_fused_r is that the later allows to
+    ///       specify the return type as well.
     template <typename R, typename F, typename Tuple>
     constexpr HPX_HOST_DEVICE HPX_FORCEINLINE R
     invoke_fused_r(F&& f, Tuple&& t) noexcept(

--- a/libs/core/functional/include/hpx/functional/invoke_fused.hpp
+++ b/libs/core/functional/include/hpx/functional/invoke_fused.hpp
@@ -17,14 +17,14 @@
 #include <type_traits>
 #include <utility>
 
-namespace hpx::util {
+namespace hpx {
 
     ///////////////////////////////////////////////////////////////////////////
     namespace detail {
 
         template <typename Tuple>
         struct fused_index_pack
-          : make_index_pack<hpx::tuple_size<std::decay_t<Tuple>>::value>
+          : util::make_index_pack<hpx::tuple_size<std::decay_t<Tuple>>::value>
         {
         };
 
@@ -36,15 +36,15 @@ namespace hpx::util {
         struct invoke_fused_result_impl;
 
         template <typename F, typename Tuple, std::size_t... Is>
-        struct invoke_fused_result_impl<F, Tuple&, index_pack<Is...>>
-          : util::invoke_result<F,
+        struct invoke_fused_result_impl<F, Tuple&, util::index_pack<Is...>>
+          : hpx::util::invoke_result<F,
                 typename hpx::tuple_element<Is, Tuple>::type&...>
         {
         };
 
         template <typename F, typename Tuple, std::size_t... Is>
-        struct invoke_fused_result_impl<F, Tuple&&, index_pack<Is...>>
-          : util::invoke_result<F,
+        struct invoke_fused_result_impl<F, Tuple&&, util::index_pack<Is...>>
+          : hpx::util::invoke_result<F,
                 typename hpx::tuple_element<Is, Tuple>::type&&...>
         {
         };
@@ -63,9 +63,9 @@ namespace hpx::util {
         template <std::size_t... Is, typename F, typename Tuple>
         constexpr HPX_HOST_DEVICE HPX_FORCEINLINE
             typename invoke_fused_result<F, Tuple>::type
-            invoke_fused_impl(index_pack<Is...>, F&& f, Tuple&& t) noexcept(
-                noexcept(HPX_INVOKE(
-                    HPX_FORWARD(F, f), hpx::get<Is>(HPX_FORWARD(Tuple, t))...)))
+            invoke_fused_impl(util::index_pack<Is...>, F&& f,
+                Tuple&& t) noexcept(noexcept(HPX_INVOKE(HPX_FORWARD(F, f),
+                hpx::get<Is>(HPX_FORWARD(Tuple, t))...)))
         {
             return HPX_INVOKE(
                 HPX_FORWARD(F, f), hpx::get<Is>(HPX_FORWARD(Tuple, t))...);
@@ -125,14 +125,14 @@ namespace hpx::util {
         {
             template <typename F, typename Tuple>
             constexpr HPX_HOST_DEVICE HPX_FORCEINLINE
-                typename util::detail::invoke_fused_result<F, Tuple>::type
+                typename hpx::detail::invoke_fused_result<F, Tuple>::type
                 operator()(F&& f, Tuple&& t) const
-                noexcept(noexcept(util::detail::invoke_fused_impl(
-                    util::detail::fused_index_pack_t<Tuple>{},
-                    HPX_FORWARD(F, f), HPX_FORWARD(Tuple, t))))
+                noexcept(noexcept(hpx::detail::invoke_fused_impl(
+                    hpx::detail::fused_index_pack_t<Tuple>{}, HPX_FORWARD(F, f),
+                    HPX_FORWARD(Tuple, t))))
             {
-                using index_pack = util::detail::fused_index_pack_t<Tuple>;
-                return util::detail::invoke_fused_impl(
+                using index_pack = hpx::detail::fused_index_pack_t<Tuple>;
+                return hpx::detail::invoke_fused_impl(
                     index_pack{}, HPX_FORWARD(F, f), HPX_FORWARD(Tuple, t));
             }
         };
@@ -143,16 +143,67 @@ namespace hpx::util {
             template <typename F, typename Tuple>
             constexpr HPX_HOST_DEVICE HPX_FORCEINLINE R operator()(
                 F&& f, Tuple&& t) const
-                noexcept(noexcept(util::detail::invoke_fused_impl(
-                    util::detail::fused_index_pack_t<Tuple>{},
-                    HPX_FORWARD(F, f), HPX_FORWARD(Tuple, t))))
+                noexcept(noexcept(hpx::detail::invoke_fused_impl(
+                    hpx::detail::fused_index_pack_t<Tuple>{}, HPX_FORWARD(F, f),
+                    HPX_FORWARD(Tuple, t))))
             {
-                using index_pack = util::detail::fused_index_pack_t<Tuple>;
+                using index_pack = hpx::detail::fused_index_pack_t<Tuple>;
                 return util::void_guard<R>(),
-                       util::detail::invoke_fused_impl(index_pack{},
+                       hpx::detail::invoke_fused_impl(index_pack{},
                            HPX_FORWARD(F, f), HPX_FORWARD(Tuple, t));
             }
         };
     }    // namespace functional
     /// \endcond
+}    // namespace hpx
+
+/// \cond NOINTERN
+namespace hpx::util {
+
+    template <typename F, typename Tuple>
+    HPX_DEPRECATED_V(1, 9,
+        "hpx::util::invoke_fused is deprecated, use hpx::invoke_fused instead")
+    constexpr HPX_HOST_DEVICE HPX_FORCEINLINE
+        typename hpx::detail::invoke_fused_result<F, Tuple>::type
+        invoke_fused(F&& f, Tuple&& t) noexcept(
+            noexcept(hpx::detail::invoke_fused_impl(
+                hpx::detail::fused_index_pack_t<Tuple>{}, HPX_FORWARD(F, f),
+                HPX_FORWARD(Tuple, t))))
+    {
+        using index_pack = hpx::detail::fused_index_pack_t<Tuple>;
+        return hpx::detail::invoke_fused_impl(
+            index_pack{}, HPX_FORWARD(F, f), HPX_FORWARD(Tuple, t));
+    }
+
+    template <typename R, typename F, typename Tuple>
+    HPX_DEPRECATED_V(1, 9,
+        "hpx::util::invoke_fused_r is deprecated, use hpx::invoke_fused_r "
+        "instead")
+    constexpr HPX_HOST_DEVICE HPX_FORCEINLINE R
+        invoke_fused_r(F&& f, Tuple&& t) noexcept(
+            noexcept(hpx::detail::invoke_fused_impl(
+                hpx::detail::fused_index_pack_t<Tuple>{}, HPX_FORWARD(F, f),
+                HPX_FORWARD(Tuple, t))))
+    {
+        using index_pack = hpx::detail::fused_index_pack_t<Tuple>;
+        return util::void_guard<R>(),
+               hpx::detail::invoke_fused_impl(
+                   index_pack{}, HPX_FORWARD(F, f), HPX_FORWARD(Tuple, t));
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    /// \cond NOINTERNAL
+    namespace functional {
+
+        using invoke_fused HPX_DEPRECATED_V(1, 9,
+            "hpx::util::invoke_fused is deprecated, use hpx::invoke_fused "
+            "instead") = hpx::functional::invoke_fused;
+
+        template <typename R>
+        using invoke_fused_r HPX_DEPRECATED_V(1, 9,
+            "hpx::util::invoke_fused_r is deprecated, use hpx::invoke_fused_r "
+            "instead") = hpx::functional::invoke_fused_r<R>;
+    }    // namespace functional
+    /// \endcond
 }    // namespace hpx::util
+/// \endcond

--- a/libs/core/include_local/include/hpx/local/functional.hpp
+++ b/libs/core/include_local/include/hpx/local/functional.hpp
@@ -22,6 +22,6 @@
 
 namespace hpx {
 
-    using hpx::util::invoke_fused;
+    using hpx::invoke_fused;
     using hpx::util::mem_fn;
 }    // namespace hpx

--- a/libs/core/lcos_local/tests/unit/local_dataflow_external_future.cpp
+++ b/libs/core/lcos_local/tests/unit/local_dataflow_external_future.cpp
@@ -68,7 +68,7 @@ struct external_future_executor
             [&]() {
                 if constexpr (is_void)
                 {
-                    hpx::util::invoke_fused(
+                    hpx::invoke_fused(
                         std::forward<F>(f), std::forward<Futures>(futures));
 
                     // Signal completion from another thread/task.
@@ -82,7 +82,7 @@ struct external_future_executor
                 }
                 else
                 {
-                    auto&& r = hpx::util::invoke_fused(
+                    auto&& r = hpx::invoke_fused(
                         std::forward<F>(f), std::forward<Futures>(futures));
 
                     // Signal completion from another thread/task.
@@ -147,7 +147,7 @@ struct external_future_additional_argument_executor
                 additional_argument a{};
                 if constexpr (is_void)
                 {
-                    hpx::util::invoke_fused(std::forward<F>(f),
+                    hpx::invoke_fused(std::forward<F>(f),
                         hpx::tuple_cat(
                             hpx::tie(a), std::forward<Futures>(futures)));
 
@@ -162,7 +162,7 @@ struct external_future_additional_argument_executor
                 }
                 else
                 {
-                    auto&& r = hpx::util::invoke_fused(std::forward<F>(f),
+                    auto&& r = hpx::invoke_fused(std::forward<F>(f),
                         hpx::tuple_cat(
                             hpx::tie(a), std::forward<Futures>(futures)));
 

--- a/libs/core/pack_traversal/include/hpx/pack_traversal/detail/pack_traversal_async_impl.hpp
+++ b/libs/core/pack_traversal/include/hpx/pack_traversal/detail/pack_traversal_async_impl.hpp
@@ -438,17 +438,22 @@ namespace hpx {
                 // Do nothing if the visitor doesn't accept the type
             }
 
-            /// Async traverse a single element which isn't a container or
-            /// tuple like type. This function is SFINAEd out if the element
-            /// isn't accepted by the visitor.
-            template <typename Current,
-                typename = typename always_void<
-                    decltype(std::declval<Frame>()->traverse(
-                        *std::declval<Current>()))>::type>
-            void async_traverse_one_impl(
-                container_category_tag<false, false>, Current&& current)
+            // different versions of clang-format disagree
+            // clang-format off
+
+            /// Async traverse a single element which isn't a container or tuple
+            /// like type. This function is SFINAEd out if the element isn't
+            /// accepted by the visitor.
+            ///
             /// SFINAE this out if the visitor doesn't accept
             /// the given element
+            template <typename Current,
+                typename = typename always_void<decltype(
+                    std::declval<Frame>()->traverse(
+                        *std::declval<Current>()))>::type>
+            // clang-format on
+            void async_traverse_one_impl(
+                container_category_tag<false, false>, Current&& current)
             {
                 if (!frame_->traverse(*current))
                 {

--- a/libs/core/pack_traversal/include/hpx/pack_traversal/detail/pack_traversal_async_impl.hpp
+++ b/libs/core/pack_traversal/include/hpx/pack_traversal/detail/pack_traversal_async_impl.hpp
@@ -442,8 +442,8 @@ namespace hpx {
             /// tuple like type. This function is SFINAEd out if the element
             /// isn't accepted by the visitor.
             template <typename Current,
-                typename = typename always_void<decltype(
-                    std::declval<Frame>()->traverse(
+                typename = typename always_void<
+                    decltype(std::declval<Frame>()->traverse(
                         *std::declval<Current>()))>::type>
             void async_traverse_one_impl(
                 container_category_tag<false, false>, Current&& current)
@@ -630,7 +630,7 @@ namespace hpx {
         void resume_traversal_callable<Frame, State>::operator()()
         {
             auto hierarchy = hpx::tuple_cat(hpx::make_tuple(frame_), state_);
-            util::invoke_fused(resume_state_callable{}, HPX_MOVE(hierarchy));
+            hpx::invoke_fused(resume_state_callable{}, HPX_MOVE(hierarchy));
         }
 
         /// Gives access to types related to the traversal frame

--- a/libs/core/pack_traversal/include/hpx/pack_traversal/detail/pack_traversal_impl.hpp
+++ b/libs/core/pack_traversal/include/hpx/pack_traversal/detail/pack_traversal_impl.hpp
@@ -199,10 +199,10 @@ namespace hpx { namespace util { namespace detail {
         /// may contain spread types
         template <typename C, typename... T>
         constexpr auto apply_spread_impl(std::true_type, C&& callable,
-            T&&... args) -> decltype(invoke_fused(HPX_FORWARD(C, callable),
+            T&&... args) -> decltype(hpx::invoke_fused(HPX_FORWARD(C, callable),
             hpx::tuple_cat(undecorate(HPX_FORWARD(T, args))...)))
         {
-            return invoke_fused(HPX_FORWARD(C, callable),
+            return hpx::invoke_fused(HPX_FORWARD(C, callable),
                 hpx::tuple_cat(undecorate(HPX_FORWARD(T, args))...));
         }
 
@@ -650,13 +650,14 @@ namespace hpx { namespace util { namespace detail {
         /// to a container of the same type which may contain
         /// different types.
         template <typename Strategy, typename T, typename M>
-        auto
-        remap(Strategy, T&& container, M&& mapper) -> decltype(invoke_fused(
-            std::declval<tuple_like_remapper<Strategy,
-                typename std::decay<M>::type, typename std::decay<T>::type>>(),
-            HPX_FORWARD(T, container)))
+        auto remap(Strategy, T&& container, M&& mapper)
+            -> decltype(hpx::invoke_fused(
+                std::declval<
+                    tuple_like_remapper<Strategy, typename std::decay<M>::type,
+                        typename std::decay<T>::type>>(),
+                HPX_FORWARD(T, container)))
         {
-            return invoke_fused(
+            return hpx::invoke_fused(
                 tuple_like_remapper<Strategy, typename std::decay<M>::type,
                     typename std::decay<T>::type>{HPX_FORWARD(M, mapper)},
                 HPX_FORWARD(T, container));

--- a/libs/core/pack_traversal/include/hpx/pack_traversal/detail/unwrap_impl.hpp
+++ b/libs/core/pack_traversal/include/hpx/pack_traversal/detail/unwrap_impl.hpp
@@ -172,10 +172,10 @@ namespace hpx { namespace util { namespace detail {
         template <typename C, typename T>
         static auto apply(C&& callable, T&& unwrapped)
             // There is no trait for the invoke_fused result
-            -> decltype(invoke_fused(
+            -> decltype(hpx::invoke_fused(
                 HPX_FORWARD(C, callable), HPX_FORWARD(T, unwrapped)))
         {
-            return invoke_fused(
+            return hpx::invoke_fused(
                 HPX_FORWARD(C, callable), HPX_FORWARD(T, unwrapped));
         }
     };

--- a/libs/core/resiliency/include/hpx/resiliency/async_replicate_executor.hpp
+++ b/libs/core/resiliency/include/hpx/resiliency/async_replicate_executor.hpp
@@ -49,7 +49,7 @@ namespace hpx { namespace resiliency { namespace experimental {
                                 t = hpx::make_tuple(HPX_FORWARD(Ts, ts)...)](
                                 std::size_t) mutable -> result_type {
                     // ignore argument (invocation count of bulk_execute)
-                    return hpx::util::invoke_fused(f, t);
+                    return hpx::invoke_fused(f, t);
                 };
 
                 auto&& results = hpx::parallel::execution::bulk_async_execute(
@@ -144,7 +144,7 @@ namespace hpx { namespace resiliency { namespace experimental {
                                 t = hpx::make_tuple(HPX_FORWARD(Ts, ts)...)](
                                 std::size_t) mutable {
                     // ignore argument (invocation count of bulk_execute)
-                    hpx::util::invoke_fused(f, t);
+                    hpx::invoke_fused(f, t);
 
                     // return non-void result to force executor into providing a
                     // future for each invocation (returning void might optimize

--- a/libs/core/resource_partitioner/examples/async_customization.cpp
+++ b/libs/core/resource_partitioner/examples/async_customization.cpp
@@ -175,7 +175,7 @@ private:
         // invoke a function with the unwrapped tuple future types to demonstrate
         // that we can access them
         std::cout << "when_all(fut) : tuple       : ";
-        util::invoke_fused(
+        invoke_fused(
             [](const auto&... ts) {
                 std::cout << print_type<decltype(ts)...>(" | ") << "\n";
             },
@@ -220,7 +220,7 @@ private:
         // invoke a function with the unwrapped tuple future types to demonstrate
         // that we can access them
         std::cout << "dataflow      : tuple       : ";
-        util::invoke_fused(
+        invoke_fused(
             [](const auto&... ts) {
                 std::cout << print_type<decltype(ts)...>(" | ") << "\n";
             },

--- a/libs/core/resource_partitioner/examples/async_customization.cpp
+++ b/libs/core/resource_partitioner/examples/async_customization.cpp
@@ -175,7 +175,7 @@ private:
         // invoke a function with the unwrapped tuple future types to demonstrate
         // that we can access them
         std::cout << "when_all(fut) : tuple       : ";
-        invoke_fused(
+        hpx::invoke_fused(
             [](const auto&... ts) {
                 std::cout << print_type<decltype(ts)...>(" | ") << "\n";
             },
@@ -220,7 +220,7 @@ private:
         // invoke a function with the unwrapped tuple future types to demonstrate
         // that we can access them
         std::cout << "dataflow      : tuple       : ";
-        invoke_fused(
+        hpx::invoke_fused(
             [](const auto&... ts) {
                 std::cout << print_type<decltype(ts)...>(" | ") << "\n";
             },

--- a/libs/full/actions_base/include/hpx/actions_base/basic_action.hpp
+++ b/libs/full/actions_base/include/hpx/actions_base/basic_action.hpp
@@ -108,7 +108,7 @@ namespace hpx { namespace actions {
                         "Executing {}.", Action::get_action_name(lva_));
 
                     // invoke the action, ignoring the return value
-                    util::invoke_fused(action_invoke<Action>{lva_, comptype_},
+                    hpx::invoke_fused(action_invoke<Action>{lva_, comptype_},
                         HPX_MOVE(args_));
                 }
                 catch (hpx::thread_interrupted const&)
@@ -179,7 +179,7 @@ namespace hpx { namespace actions {
 
                 traits::action_trigger_continuation<
                     typename Action::continuation_type>::call(HPX_MOVE(cont_),
-                    util::functional::invoke_fused{},
+                    hpx::functional::invoke_fused{},
                     action_invoke<Action>{lva_, comptype_}, HPX_MOVE(args_));
 
                 return threads::thread_result_type(


### PR DESCRIPTION
Deprecated:
-  `hpx::util::invoke_fused` in favor of `hpx::invoke_fused`
-  `hpx::util::invoke_fused_r` in favor of `hpx::invoke_fused_r`

Working towards resolving https://github.com/STEllAR-GROUP/hpx/issues/6000