### PR TITLE
Support for new performance tool suite : LIKWID

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2056,6 +2056,15 @@ include(HPX_SetupAsio)
 include(HPX_SetupAllocator)
 include(HPX_SetupHwloc)
 
+# Setup likwid
+hpx_option(
+  HPX_WITH_LIKWID BOOL "Enable Likwid instrumentation support." OFF
+  CATEGORY "Profiling"
+)
+if (HPX_WITH_LIKWID)
+  include(HPX_SetupLikwid)
+endif()
+
 # reset external source lists
 add_hpx_library_sources_noglob(hpx_external)
 add_hpx_library_headers_noglob(hpx_external)

--- a/cmake/FindLIKWID.cmake
+++ b/cmake/FindLIKWID.cmake
@@ -1,0 +1,52 @@
+# Copyright (c) 2022 Srinivas Yadav
+# SPDX-License-Identifier: BSL-1.0
+# Distributed under the Boost Software License, Version 1.0. (See accompanying
+# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+if(NOT TARGET LIKWID::likwid)
+
+  find_path(
+    LIKWID_INCLUDE_DIR likwid.h
+    HINTS "${LIKWID_ROOT}" ENV LIKWID_ROOT "${HPX_LIKWID_ROOT}"
+    PATH_SUFFIXES include
+  )
+
+  if(NOT LIKWID_INCLUDE_DIR)
+    hpx_error(
+    "Could not find likwid.h"
+    )
+  endif()
+  message(STATUS "Found likwid header: ${LIKWID_INCLUDE_DIR}")
+
+  find_library(
+    LIKWID_LIBRARY likwid
+    HINTS "${LIKWID_ROOT}" ENV LIKWID_ROOT "${HPX_LIKWID_ROOT}"
+    PATH_SUFFIXES lib
+  )
+
+  if(NOT LIKWID_LIBRARY)
+    hpx_error(
+    "Could not find likwid library"
+    )
+  endif()
+  message(STATUS "Found likwid library: ${LIKWID_LIBRARY}")
+
+  if(LIKWID_ROOT)
+  # The call to file is for compatibility with windows paths
+    file(TO_CMAKE_PATH ${LIKWID_ROOT} LIKWID_ROOT)
+    elseif("$ENV{LIKWID_ROOT}")
+    file(TO_CMAKE_PATH $ENV{LIKWID_ROOT} LIKWID_ROOT)
+    else()
+    file(TO_CMAKE_PATH "${LIKWID_INCLUDE_DIR}" LIKWID_INCLUDE_DIR)
+    string(REPLACE "/include" "" LIKWID_ROOT "${LIKWID_INCLUDE_DIR}")
+  endif()
+
+  mark_as_advanced(LIKWID_ROOT LIKWID_LIBRARY LIKWID_INCLUDE_DIR)
+
+  add_library(LIKWID::likwid INTERFACE IMPORTED)
+  target_include_directories(
+    LIKWID::likwid SYSTEM INTERFACE ${LIKWID_INCLUDE_DIR}
+  )
+  target_link_libraries(LIKWID::likwid INTERFACE ${LIKWID_LIBRARY})
+  target_compile_definitions(LIKWID::likwid INTERFACE LIKWID_PERFMON)
+endif()

--- a/cmake/HPX_SetupLikwid.cmake
+++ b/cmake/HPX_SetupLikwid.cmake
@@ -1,0 +1,6 @@
+# Copyright (c) 2022 Srinivas Yadav
+# SPDX-License-Identifier: BSL-1.0
+# Distributed under the Boost Software License, Version 1.0. (See accompanying
+# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+find_package(LIKWID REQUIRED)

--- a/cmake/templates/HPXConfig.cmake.in
+++ b/cmake/templates/HPXConfig.cmake.in
@@ -144,6 +144,12 @@ include(HPX_SetupPapi)
 # CUDA
 include(HPX_SetupCUDA)
 
+# LIKWID
+if(HPX_WITH_LIKWID)
+  set(HPX_LIKWID_ROOT "@LIKWID_ROOT@")
+  include(HPX_SetupLikwid)
+endif()
+
 include(HPX_SetupMPI)
 if((HPX_WITH_NETWORKING AND HPX_WITH_PARCELPORT_MPI) OR HPX_WITH_ASYNC_MPI)
   hpx_setup_mpi()

--- a/libs/CMakeLists.txt
+++ b/libs/CMakeLists.txt
@@ -365,6 +365,10 @@ if(HPX_WITH_ITTNOTIFY)
   target_link_libraries(hpx_core PUBLIC Amplifier::amplifier)
 endif()
 
+if(HPX_WITH_LIKWID)
+  target_link_libraries(hpx_core PUBLIC LIKWID::likwid)
+endif()
+
 if(HPX_WITH_MODULES_AS_STATIC_LIBRARIES OR HPX_WITH_STATIC_LINKING)
   target_link_libraries(hpx_core PUBLIC hpx_public_flags)
   target_link_libraries(hpx_core PUBLIC hpx_base_libraries)

--- a/libs/core/CMakeLists.txt
+++ b/libs/core/CMakeLists.txt
@@ -50,6 +50,7 @@ set(_hpx_core_modules
     itt_notify
     lci_base
     lcos_local
+    likwid
     lock_registration
     logging
     memory

--- a/libs/core/likwid/CMakeLists.txt
+++ b/libs/core/likwid/CMakeLists.txt
@@ -1,0 +1,36 @@
+# Copyright (c) 2019-2021 The STE||AR-Group
+#
+# SPDX-License-Identifier: BSL-1.0
+# Distributed under the Boost Software License, Version 1.0. (See accompanying
+# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+# enable likwid module only if HPX_WITH_LIKWID is set
+if(NOT ${HPX_WITH_LIKWID})
+  return()
+endif()
+
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
+
+set(likwid_headers
+  hpx/likwid/likwid_init.hpp
+  hpx/likwid/likwid_executor.hpp
+)
+
+set(likwid_sources
+  likwid_init.cpp
+)
+
+set(execution_optional_dependencies LIKWID::likwid)
+
+include(HPX_AddModule)
+add_hpx_module(
+  core likwid
+  GLOBAL_HEADER_GEN ON
+  SOURCES ${likwid_sources}
+  HEADERS ${likwid_headers}
+  DEPENDENCIES ${execution_optional_dependencies}
+  MODULE_DEPENDENCIES
+  hpx_execution
+  hpx_runtime_local
+  CMAKE_SUBDIRS examples tests
+)

--- a/libs/core/likwid/README.rst
+++ b/libs/core/likwid/README.rst
@@ -1,0 +1,16 @@
+
+..
+    Copyright (c) 2020-2021 The STE||AR-Group
+
+    SPDX-License-Identifier: BSL-1.0
+    Distributed under the Boost Software License, Version 1.0. (See accompanying
+    file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+======
+likwid
+======
+
+This module is part of HPX.
+
+Documentation can be found `here
+<https://hpx-docs.stellar-group.org/latest/html/modules/likwid/docs/index.html>`__.

--- a/libs/core/likwid/docs/index.rst
+++ b/libs/core/likwid/docs/index.rst
@@ -1,0 +1,18 @@
+..
+    Copyright (c) 2020-2021 The STE||AR-Group
+
+    SPDX-License-Identifier: BSL-1.0
+    Distributed under the Boost Software License, Version 1.0. (See accompanying
+    file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+.. _modules_likwid:
+
+======
+likwid
+======
+
+TODO: High-level description of the module.
+
+See the :ref:`API reference <modules_likwid_api>` of this module for more
+details.
+

--- a/libs/core/likwid/examples/CMakeLists.txt
+++ b/libs/core/likwid/examples/CMakeLists.txt
@@ -1,0 +1,16 @@
+# Copyright (c) 2020-2021 The STE||AR-Group
+#
+# SPDX-License-Identifier: BSL-1.0
+# Distributed under the Boost Software License, Version 1.0. (See accompanying
+# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+if(HPX_WITH_EXAMPLES)
+  add_hpx_pseudo_target(examples.modules.likwid)
+  add_hpx_pseudo_dependencies(examples.modules examples.modules.likwid)
+  if(HPX_WITH_TESTS AND HPX_WITH_TESTS_EXAMPLES)
+    add_hpx_pseudo_target(tests.examples.modules.likwid)
+    add_hpx_pseudo_dependencies(
+      tests.examples.modules tests.examples.modules.likwid
+    )
+  endif()
+endif()

--- a/libs/core/likwid/include/hpx/likwid/likwid_executor.hpp
+++ b/libs/core/likwid/include/hpx/likwid/likwid_executor.hpp
@@ -1,0 +1,230 @@
+//  Copyright (c) 2022 Srinivas Yadav
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include <likwid.h>
+#include <hpx/execution/execution.hpp>
+
+namespace hpx { namespace execution {
+
+    ///////////////////////////////////////////////////////////////////////////
+    template <typename BaseExecutor>
+    class likwid_executor
+    {
+    private:
+        struct on_exit
+        {
+            explicit on_exit(likwid_executor const& exec)
+              : exec_(exec)
+            {
+                exec_.on_start_();
+            }
+
+            ~on_exit()
+            {
+                exec_.on_stop_();
+            }
+
+            likwid_executor const& exec_;
+        };
+
+        template <typename F>
+        struct hook_wrapper
+        {
+            template <typename... Ts>
+            decltype(auto) operator()(Ts&&... ts)
+            {
+                on_exit _{exec_};
+                return hpx::invoke(f_, std::forward<Ts>(ts)...);
+            }
+
+            likwid_executor const& exec_;
+            F f_;
+        };
+
+    public:
+        using execution_category = typename 
+            hpx::parallel::execution::executor_execution_category<BaseExecutor>::type;
+        using executor_parameters_type =
+            typename hpx::parallel::execution::executor_parameters_type<BaseExecutor>::type;
+
+        likwid_executor(
+            BaseExecutor& exec, std::string name)
+          : exec_(exec)
+        {
+            on_start_ = [name]() {likwid_markerStartRegion(name.data());};
+            on_stop_ = [name]() {likwid_markerStopRegion(name.data());};
+        }
+
+        bool operator==(likwid_executor const& rhs) const noexcept
+        {
+            return exec_ == rhs.exec_;
+        }
+
+        bool operator!=(likwid_executor const& rhs) const noexcept
+        {
+            return !(*this == rhs);
+        }
+
+        likwid_executor const& context() const noexcept
+        {
+            return *this;
+        }
+
+    private:
+        // OneWayExecutor interface
+        template <typename F, typename... Ts>
+        friend decltype(auto) tag_invoke(hpx::parallel::execution::sync_execute_t,
+            likwid_executor const& exec, F&& f, Ts&&... ts) 
+        {
+            return hpx::parallel::execution::sync_execute(exec.exec_,
+                hook_wrapper<F>{exec, std::forward<F>(f)},
+                std::forward<Ts>(ts)...);
+        }
+
+        // TwoWayExecutor interface
+        template <typename F, typename... Ts>
+        friend decltype(auto) tag_invoke(hpx::parallel::execution::async_execute_t,
+            likwid_executor const& exec, F&& f, Ts&&... ts) 
+        {
+            return hpx::parallel::execution::async_execute(exec.exec_,
+                hook_wrapper<F>{exec, std::forward<F>(f)},
+                std::forward<Ts>(ts)...);
+        }
+
+        template <typename F, typename Future, typename... Ts>
+        friend decltype(auto) tag_invoke(hpx::parallel::execution::then_execute_t,
+            likwid_executor const& exec, F&& f, Future&& predecessor, Ts&&... ts) 
+        {
+            return hpx::parallel::execution::then_execute(exec.exec_,
+                hook_wrapper<F>{exec, std::forward<F>(f)},
+                std::forward<Future>(predecessor), std::forward<Ts>(ts)...);
+        }
+
+        // NonBlockingOneWayExecutor (adapted) interface
+        template <typename F, typename... Ts>
+        friend void tag_invoke(hpx::parallel::execution::post_t,
+            likwid_executor const& exec, F&& f, Ts&&... ts) 
+        {
+            hpx::parallel::execution::post(exec.exec_,
+                hook_wrapper<F>{exec, std::forward<F>(f)},
+                std::forward<Ts>(ts)...);
+        }
+
+        // BulkOneWayExecutor interface
+        template <typename F, typename S, typename... Ts>
+        friend decltype(auto) tag_invoke(hpx::parallel::execution::bulk_sync_execute_t,
+            likwid_executor const& exec, F&& f, S const& shape, Ts&&... ts)
+        {
+            return hpx::parallel::execution::bulk_sync_execute(exec.exec_,
+                hook_wrapper<F>{exec, std::forward<F>(f)}, shape,
+                std::forward<Ts>(ts)...);
+        }
+
+        // BulkTwoWayExecutor interface
+        template <typename F, typename S, typename... Ts>
+        friend decltype(auto) tag_invoke(hpx::parallel::execution::bulk_async_execute_t,
+            likwid_executor const& exec, F&& f, S const& shape, Ts&&... ts)
+        {
+            return hpx::parallel::execution::bulk_async_execute(exec.exec_,
+                hook_wrapper<F>{exec, std::forward<F>(f)}, shape,
+                std::forward<Ts>(ts)...);
+        }
+
+        template <typename F, typename S, typename Future, typename... Ts>
+        friend decltype(auto) tag_invoke(hpx::parallel::execution::bulk_then_execute_t,
+            likwid_executor const& exec, F&& f, S const& shape, Future&& predecessor, Ts&&... ts)
+        {
+            return hpx::parallel::execution::bulk_then_execute(exec.exec_,
+                hook_wrapper<F>{exec, std::forward<F>(f)}, shape,
+                std::forward<Future>(predecessor), std::forward<Ts>(ts)...);
+        }
+
+        // support all properties exposed by the wrapped executor
+        // clang-format off
+        template <typename Tag, typename Property,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::execution::experimental::is_scheduling_property_v<Tag> &&
+                hpx::functional::is_tag_invocable_v<Tag, BaseExecutor, Property>
+            )>
+        // clang-format on
+        friend likwid_executor tag_invoke(
+            Tag tag, likwid_executor const& exec, Property&& prop)
+        {
+            return likwid_executor(hpx::functional::tag_invoke(
+                tag, exec.exec_, HPX_FORWARD(Property, prop)));
+        }
+
+        // clang-format off
+        template <typename Tag,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::execution::experimental::is_scheduling_property_v<Tag> &&
+                hpx::functional::is_tag_invocable_v<Tag, BaseExecutor>
+            )>
+        // clang-format on
+        friend decltype(auto) tag_invoke(
+            Tag tag, likwid_executor const& exec)
+        {
+            return hpx::functional::tag_invoke(tag, exec.exec_);
+        }
+
+    private:
+        using thread_hook = hpx::function<void()>;
+
+        BaseExecutor& exec_;
+        thread_hook on_start_;
+        thread_hook on_stop_;
+    };
+
+    template <typename BaseExecutor>
+    likwid_executor<BaseExecutor> make_likwid_executor(
+        BaseExecutor& exec, std::string name)
+    {
+        return likwid_executor<BaseExecutor>(exec, name);
+    }
+}}
+
+///////////////////////////////////////////////////////////////////////////////
+// simple forwarding implementations of executor traits
+namespace hpx { namespace parallel { namespace execution {
+
+    template <typename BaseExecutor>
+    struct is_one_way_executor<
+        hpx::execution::likwid_executor<BaseExecutor>>
+      : is_one_way_executor<std::decay_t<BaseExecutor>>
+    {
+    };
+
+    template <typename BaseExecutor>
+    struct is_never_blocking_one_way_executor<
+        hpx::execution::likwid_executor<BaseExecutor>>
+      : is_never_blocking_one_way_executor<
+            std::decay_t<BaseExecutor>>
+    {
+    };
+
+    template <typename BaseExecutor>
+    struct is_two_way_executor<
+        hpx::execution::likwid_executor<BaseExecutor>>
+      : is_two_way_executor<std::decay_t<BaseExecutor>>
+    {
+    };
+
+    template <typename BaseExecutor>
+    struct is_bulk_one_way_executor<
+        hpx::execution::likwid_executor<BaseExecutor>>
+      : is_bulk_one_way_executor<std::decay_t<BaseExecutor>>
+    {
+    };
+
+    template <typename BaseExecutor>
+    struct is_bulk_two_way_executor<
+        hpx::execution::likwid_executor<BaseExecutor>>
+      : is_bulk_two_way_executor<std::decay_t<BaseExecutor>>
+    {
+    };
+}}}    // namespace hpx::parallel::execution

--- a/libs/core/likwid/include/hpx/likwid/likwid_init.hpp
+++ b/libs/core/likwid/include/hpx/likwid/likwid_init.hpp
@@ -1,0 +1,33 @@
+//  Copyright (c) 2022 Srinivas Yadav
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include <likwid.h>
+#include <hpx/modules/runtime_local.hpp>
+
+#include <iostream>
+///////////////////////////////////////////////////////////////////////////////
+namespace hpx { namespace parallel { namespace likwid {
+    struct likwid_init;
+
+    extern likwid_init likwid_init_helper;
+
+    void likwid_thread_init()
+    {
+        auto prev = hpx::get_thread_on_start_func();
+        hpx::register_thread_on_start_func
+        (
+            [prev](std::size_t local_thread_num,std::size_t global_thread_num,
+                    char const* pool_name, char const* name_postfix)
+            {
+                likwid_markerThreadInit();
+                if (!prev.empty())
+                    prev(local_thread_num, global_thread_num, pool_name, name_postfix);
+            }
+        );
+    }
+}}}

--- a/libs/core/likwid/src/likwid_init.cpp
+++ b/libs/core/likwid/src/likwid_init.cpp
@@ -1,0 +1,27 @@
+//  Copyright (c) 2022 Srinivas Yadav
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/likwid/likwid_init.hpp>
+
+///////////////////////////////////////////////////////////////////////////////
+namespace hpx { namespace parallel { namespace likwid {
+    struct likwid_init
+    {
+        likwid_init()
+        {
+            // Initalise likwid marker API
+            likwid_markerInit();
+
+            // thread init helper
+            likwid_thread_init();
+        }
+        ~likwid_init()
+        {
+            likwid_markerClose();
+        }
+    };
+    likwid_init likwid_init_helper;
+}}}

--- a/libs/core/likwid/tests/CMakeLists.txt
+++ b/libs/core/likwid/tests/CMakeLists.txt
@@ -1,0 +1,42 @@
+# Copyright (c) 2020-2021 The STE||AR-Group
+#
+# SPDX-License-Identifier: BSL-1.0
+# Distributed under the Boost Software License, Version 1.0. (See accompanying
+# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+include(HPX_Message)
+
+if(HPX_WITH_TESTS)
+  if(HPX_WITH_TESTS_UNIT)
+    add_hpx_pseudo_target(tests.unit.modules.likwid)
+    add_hpx_pseudo_dependencies(
+      tests.unit.modules tests.unit.modules.likwid
+    )
+    add_subdirectory(unit)
+  endif()
+
+  if(HPX_WITH_TESTS_REGRESSIONS)
+    add_hpx_pseudo_target(tests.regressions.modules.likwid)
+    add_hpx_pseudo_dependencies(
+      tests.regressions.modules tests.regressions.modules.likwid
+    )
+    add_subdirectory(regressions)
+  endif()
+
+  if(HPX_WITH_TESTS_BENCHMARKS)
+    add_hpx_pseudo_target(tests.performance.modules.likwid)
+    add_hpx_pseudo_dependencies(
+      tests.performance.modules tests.performance.modules.likwid
+    )
+    add_subdirectory(performance)
+  endif()
+
+  if(HPX_WITH_TESTS_HEADERS)
+    add_hpx_header_tests(
+      modules.likwid
+      HEADERS ${likwid_headers}
+      HEADER_ROOT ${PROJECT_SOURCE_DIR}/include
+      DEPENDENCIES hpx_likwid
+    )
+  endif()
+endif()

--- a/libs/core/likwid/tests/performance/CMakeLists.txt
+++ b/libs/core/likwid/tests/performance/CMakeLists.txt
@@ -1,0 +1,5 @@
+# Copyright (c) 2020-2021 The STE||AR-Group
+#
+# SPDX-License-Identifier: BSL-1.0
+# Distributed under the Boost Software License, Version 1.0. (See accompanying
+# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)

--- a/libs/core/likwid/tests/regressions/CMakeLists.txt
+++ b/libs/core/likwid/tests/regressions/CMakeLists.txt
@@ -1,0 +1,5 @@
+# Copyright (c) 2020-2021 The STE||AR-Group
+#
+# SPDX-License-Identifier: BSL-1.0
+# Distributed under the Boost Software License, Version 1.0. (See accompanying
+# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)

--- a/libs/core/likwid/tests/unit/CMakeLists.txt
+++ b/libs/core/likwid/tests/unit/CMakeLists.txt
@@ -1,0 +1,33 @@
+# Copyright (c) 2020-2021 The STE||AR-Group
+#
+# SPDX-License-Identifier: BSL-1.0
+# Distributed under the Boost Software License, Version 1.0. (See accompanying
+# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+set(tests
+    likwid_executor
+)
+
+foreach(test ${tests})
+  set(sources ${test}.cpp)
+
+  set(${test}_PARAMETERS THREADS_PER_LOCALITY 4)
+
+  source_group("Source Files" FILES ${sources})
+
+  set(folder_name "Tests/Unit/Modules/Core/Likwid")
+
+  # add example executable
+  add_hpx_executable(
+    ${test}_test INTERNAL_FLAGS
+    SOURCES ${sources} ${${test}_FLAGS}
+    EXCLUDE_FROM_ALL
+    HPX_PREFIX ${HPX_BUILD_PREFIX}
+    FOLDER ${folder_name}
+  )
+
+  target_link_libraries(${test}_test PRIVATE hpx_execution_test_utilities)
+
+  add_hpx_unit_test("modules.likwid" ${test} ${${test}_PARAMETERS})
+
+endforeach()

--- a/libs/core/likwid/tests/unit/likwid_executor.cpp
+++ b/libs/core/likwid/tests/unit/likwid_executor.cpp
@@ -1,0 +1,64 @@
+//  Copyright (c) 2022 Srinivas Yadav
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/local/execution.hpp>
+#include <hpx/local/algorithm.hpp>
+#include <hpx/local/init.hpp>
+#include <hpx/modules/likwid.hpp>
+#include <hpx/modules/testing.hpp>
+
+#include <algorithm>
+#include <iterator>
+#include <numeric>
+#include <string>
+#include <vector>
+#include <random>
+
+////////////////////////////////////////////////////////////////////////////////
+int seed = std::random_device{}();
+std::mt19937 gen(seed);
+
+template <typename ExPolicy>
+void test_likwid_executor(ExPolicy policy)
+{
+    std::vector<int> c(10007);
+    std::iota(std::begin(c), std::end(c), gen());
+
+    hpx::for_each(policy.on(
+        hpx::execution::likwid_executor(policy.executor(), "compute")),
+        std::begin(c), std::end(c), [](auto t) {return t*t*t;});
+}
+
+void test_for_each()
+{
+    using namespace hpx::execution;
+
+    test_likwid_executor(seq);
+    test_likwid_executor(par);
+}
+
+int hpx_main()
+{
+    std::cout << "using seed: " << seed << std::endl;
+    std::srand(seed);
+    test_for_each();
+    return hpx::local::finalize();
+}
+
+int main(int argc, char* argv[])
+{
+    // By default this test should run on all available cores
+    std::vector<std::string> const cfg = {"hpx.os_threads=all"};
+
+    // Initialize and run HPX
+    hpx::local::init_params init_args;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::local::init(hpx_main, argc, argv, init_args), 0,
+        "HPX main exited with non-zero status");
+
+    return hpx::util::report_errors();
+}

--- a/libs/core/modules.rst
+++ b/libs/core/modules.rst
@@ -53,6 +53,7 @@ Core modules
    /libs/core/itt_notify/docs/index.rst
    /libs/core/lci_base/docs/index.rst
    /libs/core/lcos_local/docs/index.rst
+   /libs/core/likwid/docs/index.rst
    /libs/core/lock_registration/docs/index.rst
    /libs/core/logging/docs/index.rst
    /libs/core/memory/docs/index.rst


### PR DESCRIPTION
## Proposed Changes

Adds support to use LIKWID using executors
  - Added cmake integration to find and link LIKWID library with HPX
  - Added new executor named `likwid_executor` 
  - Added unit tests for likwid_exectuor
