### PR TITLE
Patches needed to be able to build HPX 1.8.1 on various platforms

### DIFF
--- a/libs/core/compute_local/include/hpx/compute_local/host/numa_binding_allocator.hpp
+++ b/libs/core/compute_local/include/hpx/compute_local/host/numa_binding_allocator.hpp
@@ -309,7 +309,7 @@ namespace hpx { namespace compute { namespace host {
                         0));
                 nba_deb.debug(debug::str<>("alloc:user(bind)"),
                     debug::hex<12, void*>(result));
-#if defined(NUMA_ALLOCATOR_LINUX)
+#if defined(NUMA_ALLOCATOR_LINUX) && defined(MADV_NOHUGEPAGE)
                 // if Transparent Huge Pages (THP) are enabled, this prevents
                 // pages from being merged into a single numa bound block
                 int ret = madvise(result, n * sizeof(T), MADV_NOHUGEPAGE);

--- a/libs/full/parcelset_base/include/hpx/parcelset_base/locality.hpp
+++ b/libs/full/parcelset_base/include/hpx/parcelset_base/locality.hpp
@@ -15,6 +15,8 @@
 #include <hpx/modules/iterator_support.hpp>
 #include <hpx/modules/serialization.hpp>
 
+#include <hpx/parcelset_base/parcelset_base_fwd.hpp>
+
 #include <map>
 #include <memory>
 #include <string>
@@ -27,7 +29,7 @@
 namespace hpx { namespace parcelset {
 
     //////////////////////////////////////////////////////////////////////////
-    class HPX_EXPORT locality
+    class locality
     {
         template <typename Impl>
         class impl;

--- a/libs/full/parcelset_base/include/hpx/parcelset_base/parcelset_base_fwd.hpp
+++ b/libs/full/parcelset_base/include/hpx/parcelset_base/parcelset_base_fwd.hpp
@@ -14,7 +14,7 @@
 namespace hpx::parcelset {
 
     class HPX_EXPORT parcelport;
-    class /* HPX_EXPORT */ locality;
+    class HPX_EXPORT locality;
     class HPX_EXPORT parcel;
 
     /// The type of a function that can be registered as a parcel write handler

--- a/libs/full/parcelset_base/include/hpx/parcelset_base/parcelset_base_fwd.hpp
+++ b/libs/full/parcelset_base/include/hpx/parcelset_base/parcelset_base_fwd.hpp
@@ -14,7 +14,7 @@
 namespace hpx::parcelset {
 
     class HPX_EXPORT parcelport;
-    class HPX_EXPORT locality;
+    class /* HPX_EXPORT */ locality;
     class HPX_EXPORT parcel;
 
     /// The type of a function that can be registered as a parcel write handler


### PR DESCRIPTION
This PR contains a subset of patches I use to be able to build HPX-1.8.1 on all platforms I use.
Not all patches I use are needed anymore with the current state of the master branch. I left those out.

I did not keep track of which platform (OS, compiler) required which patch, unfortunately. Will do that in future cases.

The second patch, in `parcelset_base_fwd.hpp` is weird, but required in some case(s). IIRC, the `locality` class is already annotated with export somewhere else and the compiler didn't like the second occurrence. I could be wrong.