### PR TITLE
Create a dedicated thread pool to run LCI_progress.

### DIFF
--- a/libs/core/lci_base/include/hpx/lci_base/lci_environment.hpp
+++ b/libs/core/lci_base/include/hpx/lci_base/lci_environment.hpp
@@ -17,6 +17,7 @@
 
 #include <atomic>
 #include <cstdlib>
+#include <memory>
 #include <string>
 #include <thread>
 
@@ -31,7 +32,9 @@ namespace hpx { namespace util {
         static void init(int* argc, char*** argv, runtime_configuration& cfg);
         static void finalize();
 
+        static void join_prg_thread_if_running();
         static void progress_fn();
+        static bool do_progress();
 
         static bool enabled();
 
@@ -79,7 +82,7 @@ namespace hpx { namespace util {
         static LCI_endpoint_t h_ep_;
         static LCI_comp_t rt_cq_r_;
         static LCI_comp_t h_cq_r_;
-        static std::thread* prg_thread_p;
+        static std::unique_ptr<std::thread> prg_thread_p;
         static std::atomic<bool> prg_thread_flag;
     };
 }}    // namespace hpx::util

--- a/libs/core/lci_base/src/lci_environment.cpp
+++ b/libs/core/lci_base/src/lci_environment.cpp
@@ -107,7 +107,6 @@ namespace hpx { namespace util {
     // We need this progress thread to send early parcels
     std::unique_ptr<std::thread> lci_environment::prg_thread_p = nullptr;
     std::atomic<bool> lci_environment::prg_thread_flag = false;
-    hpx::spinlock prg_thread_mtx;
 
     ///////////////////////////////////////////////////////////////////////////
     LCI_error_t lci_environment::init_lci()
@@ -225,12 +224,9 @@ namespace hpx { namespace util {
     {
         if (prg_thread_p)
         {
-            std::lock_guard<hpx::spinlock> l(prg_thread_mtx);
-            if (prg_thread_p) {
-                prg_thread_flag = false;
-                prg_thread_p->join();
-                prg_thread_p.reset();
-            }
+            prg_thread_flag = false;
+            prg_thread_p->join();
+            prg_thread_p.reset();
         }
     }
 

--- a/libs/full/parcelport_lci/src/parcelport_lci.cpp
+++ b/libs/full/parcelport_lci/src/parcelport_lci.cpp
@@ -175,7 +175,7 @@ namespace hpx::parcelset {
                 if (stopped_)
                     return false;
 
-                static __thread int do_lci_progress = -1;
+                static thread_local int do_lci_progress = -1;
                 if (do_lci_progress == -1)
                 {
                     if (enable_lci_progress_pool &&

--- a/libs/full/parcelport_lci/src/parcelport_lci.cpp
+++ b/libs/full/parcelport_lci/src/parcelport_lci.cpp
@@ -313,15 +313,27 @@ namespace hpx::traits {
             cfg.num_localities_ =
                 static_cast<std::size_t>(util::lci_environment::size());
             cfg.node_ = static_cast<std::size_t>(util::lci_environment::rank());
-            hpx::parcelset::policies::lci::parcelport::
-                enable_lci_progress_pool = hpx::util::get_entry_as<bool>(
-                    cfg.rtcfg_, "hpx.parcel.lci.rp_prg_pool",
-                    false /* Does not matter*/);
-            hpx::parcelset::policies::lci::parcelport::
-                enable_background_only_scheduler =
-                    hpx::util::get_entry_as<bool>(cfg.rtcfg_,
-                        "hpx.parcel.lci.background_only_scheduler",
+            std::size_t num_threads = hpx::util::get_entry_as<size_t>(
+                cfg.rtcfg_, "hpx.os_threads", 1);
+            if (num_threads > 1)
+            {
+                hpx::parcelset::policies::lci::parcelport::
+                    enable_lci_progress_pool = hpx::util::get_entry_as<bool>(
+                        cfg.rtcfg_, "hpx.parcel.lci.rp_prg_pool",
                         false /* Does not matter*/);
+                hpx::parcelset::policies::lci::parcelport::
+                    enable_background_only_scheduler =
+                        hpx::util::get_entry_as<bool>(cfg.rtcfg_,
+                            "hpx.parcel.lci.background_only_scheduler",
+                            false /* Does not matter*/);
+            }
+            else
+            {
+                hpx::parcelset::policies::lci::parcelport::
+                    enable_lci_progress_pool = false;
+                hpx::parcelset::policies::lci::parcelport::
+                    enable_background_only_scheduler = false;
+            }
         }
 
         static void init(hpx::resource::partitioner& rp) noexcept

--- a/libs/full/parcelport_lci/src/parcelport_lci.cpp
+++ b/libs/full/parcelport_lci/src/parcelport_lci.cpp
@@ -316,8 +316,8 @@ namespace hpx::traits {
                     enable_lci_progress_pool)
             {
                 rp.create_thread_pool("lci-progress-pool",
-                    hpx::resource::scheduling_policy::local,
-                    hpx::threads::policies::scheduler_mode::do_background_work);
+                    hpx::resource::scheduling_policy::static_,
+                    hpx::threads::policies::scheduler_mode::do_background_work_only);
                 rp.add_resource(rp.numa_domains()[0].cores()[0].pus()[0],
                     "lci-progress-pool");
             }
@@ -344,7 +344,7 @@ namespace hpx::traits {
 #endif
                 "max_connections = "
                 "${HPX_HAVE_PARCELPORT_LCI_MAX_CONNECTIONS:8192}\n"
-                "rp_prg_pool = 0\n";
+                "rp_prg_pool = 1\n";
         }
     };
 }    // namespace hpx::traits

--- a/libs/full/parcelport_lci/src/parcelport_lci.cpp
+++ b/libs/full/parcelport_lci/src/parcelport_lci.cpp
@@ -117,7 +117,12 @@ namespace hpx::parcelset {
 
             void initialized() override
             {
-                util::lci_environment::join_prg_thread_if_running();
+                if (util::lci_environment::enabled() &&
+                    hpx::parcelset::policies::lci::parcelport::
+                        enable_lci_progress_pool)
+                {
+                    util::lci_environment::join_prg_thread_if_running();
+                }
             }
 
             // Start the handling of connections.


### PR DESCRIPTION
The `LCI_progress` function is not thread-safe and must be called frequently. Previously, we created a dedicated progress thread using pthread when initializing LCI. However, HPX doesn't know this progress thread and thus cannot bind threads to cores correctly.

This PR uses the new resource partitioner hook in the parcelport to create a thread pool "lci-progress-pool" (which only contains one core) to run LCI_progress.

Fixed:
- The thread pool will be allocated even if users are not using LCI parcelport.