### PR TITLE
[P2300] Fix: declval cannot be ODR used

### DIFF
--- a/libs/core/execution_base/tests/include/coroutine_task.hpp
+++ b/libs/core/execution_base/tests/include/coroutine_task.hpp
@@ -37,8 +37,7 @@ inline constexpr bool well_formed = is_valid<T, As...>::value;
 
 template <typename T>
 inline constexpr bool stop_token_provider = std::integral_constant<bool,
-    !std::is_same_v<decltype(hpx::execution::experimental::get_stop_token(
-                        std::declval<T>())),
+    !std::is_same_v<hpx::execution::experimental::stop_token_of_t<T>,
         void>>::value;
 
 template <typename T>
@@ -166,7 +165,7 @@ struct default_task_context_impl::awaiter_context<ParentPromise,
 };
 
 template <typename Token>
-inline bool unstoppable_token = std::declval<Token>().stop_possible();
+inline bool unstoppable_token = !Token::stop_possible();
 
 // // If the parent coroutine's stop token is unstoppable, there's no point
 // // forwarding stop tokens or stop requests at all.

--- a/libs/core/execution_base/tests/unit/coroutine_utils.cpp
+++ b/libs/core/execution_base/tests/unit/coroutine_utils.cpp
@@ -54,7 +54,10 @@ struct promise
 template <typename Awaiter>
 struct awaitable_sender_1
 {
-    Awaiter operator co_await();
+    Awaiter operator co_await()
+    {
+        return Awaiter{};
+    }
 };
 
 struct awaiter
@@ -184,11 +187,11 @@ int main()
     try
     {
         // Awaitables are implicitly senders:
-        auto [i] = hpx::this_thread::experimental::sync_wait(
+        auto i = hpx::this_thread::experimental::sync_wait(
             async_answer(hpx::execution::experimental::just(42),
                 hpx::execution::experimental::just()))
-                       .value();
-        std::cout << "The answer is " << i << '\n';
+                     .value();
+        std::cout << "The answer is " << hpx::get<0>(i) << '\n';
     }
     catch (std::exception& e)
     {


### PR DESCRIPTION
- flyby: used predefined `stop_token_of_t` instead of redefining it

Signed-off-by: Shreyas Atre <shreyasatre16@gmail.com>

## Fixes

https://cdash.cscs.ch/viewBuildError.php?buildid=43534

## Any background context you want to provide?

- `std::declval` is not supposed to be ODR used.
