### PR TITLE
Allow to disable registering signal handlers

### DIFF
--- a/docs/sphinx/manual/launching_and_configuring_hpx_applications.rst
+++ b/docs/sphinx/manual/launching_and_configuring_hpx_applications.rst
@@ -169,6 +169,7 @@ The `|hpx| configuration section
    master_ini_path = $[hpx.location]/share/hpx-<version>:$[system.executable_prefix]/share/hpx-<version>:$[system.executable_prefix]/../share/hpx-<version>
    ini_path = $[hpx.master_ini_path]/ini
    os_threads = 1
+   cores = all
    localities = 1
    program_name =
    cmd_line =
@@ -182,6 +183,8 @@ The `|hpx| configuration section
    max_busy_loop_count = ${HPX_MAX_BUSY_LOOP_COUNT:<hpx_busy_loop_count_max>}
    max_idle_backoff_time = ${HPX_MAX_IDLE_BACKOFF_TIME:<hpx_idle_backoff_time_max>}
    exception_verbosity = ${HPX_EXCEPTION_VERBOSITY:2}
+   trace_depth = ${HPX_TRACE_DEPTH:20}
+   handle_signals = ${HPX_HANDLE_SIGNALS:1}
 
    [hpx.stacks]
    small_size = ${HPX_SMALL_STACK_SIZE:<hpx_small_stack_size>}
@@ -215,6 +218,9 @@ The `|hpx| configuration section
        (Windows).
    * * ``hpx.os_threads``
      * This setting reflects the number of OS threads used for running
+       |hpx| threads. Defaults to number of detected cores (not hyperthreads/PUs).
+   * * ``hpx.cores``
+     * This setting reflects the number of cores used for running
        |hpx| threads. Defaults to number of detected cores (not hyperthreads/PUs).
    * * ``hpx.localities``
      * This setting reflects the number of localities the application is running
@@ -280,6 +286,17 @@ The `|hpx| configuration section
        thrown exception and the file name, function, and line number where the
        exception was thrown. The default value is ``2`` or the value of the
        environment variable ``HPX_EXCEPTION_VERBOSITY``.
+   * * ``hpx.trace_depth``
+     * This setting defines the number of stack-levels printed in generated
+       stack backtraces. This defaults to ``20``, but can be changed using the
+       cmake ``HPX_WITH_THREAD_BACKTRACE_DEPTH`` configuration setting.
+   * * ``hpx.handle_signals``
+     * This setting defines whether HPX will register signal handlers that will
+       print the configuration information (stack backtrace, system information,
+       etc.) whenever a signal is raised. The default is ``1``. Setting this
+       value to ``0`` can be useful in cases when generating a core-dump on
+       segmentation faults or similar signals is desired. This setting has no
+       effects on non-Linux platforms.
    * * ``hpx.stacks.small_size``
      * This is initialized to the small stack size to be used by |hpx| threads.
        Set by default to the value of the compile time preprocessor constant
@@ -1463,10 +1480,10 @@ The predefined command line options for any application using
 
 .. option:: --hpx:force_ipv4
 
-   Network hostnames will be resolved to ipv4 adresses instead of using the
+   Network hostnames will be resolved to ipv4 addresses instead of using the
    first resolved endpoint. This is especially useful on Windows where the
-   local hostname will resolve to an ipv6 adress while remote network hostnames
-   are commonly resolved to ipv4 adresses.
+   local hostname will resolve to an ipv6 address while remote network hostnames
+   are commonly resolved to ipv4 addresses.
 
 .. option:: --hpx:localities arg
 

--- a/libs/core/coroutines/include/hpx/coroutines/detail/context_linux_x86.hpp
+++ b/libs/core/coroutines/include/hpx/coroutines/detail/context_linux_x86.hpp
@@ -465,18 +465,21 @@ namespace hpx::threads::coroutines::detail::lx {
             // https://rethinkdb.com/blog/handling-stack-overflow-on-custom-stacks/
             // http://www.evanjones.ca/software/threading.html
             //
-            segv_stack.ss_sp = valloc(SEGV_STACK_SIZE);
-            segv_stack.ss_flags = 0;
-            segv_stack.ss_size = SEGV_STACK_SIZE;
+            if (register_signal_handler)
+            {
+                segv_stack.ss_sp = valloc(SEGV_STACK_SIZE);
+                segv_stack.ss_flags = 0;
+                segv_stack.ss_size = SEGV_STACK_SIZE;
 
-            std::memset(&action, '\0', sizeof(action));
-            action.sa_flags = SA_SIGINFO | SA_ONSTACK;
-            action.sa_sigaction = &sigsegv_handler;
+                std::memset(&action, '\0', sizeof(action));
+                action.sa_flags = SA_SIGINFO | SA_ONSTACK;
+                action.sa_sigaction = &sigsegv_handler;
 
-            sigaltstack(&segv_stack, nullptr);
-            sigemptyset(&action.sa_mask);
-            sigaddset(&action.sa_mask, SIGSEGV);
-            sigaction(SIGSEGV, &action, nullptr);
+                sigaltstack(&segv_stack, nullptr);
+                sigemptyset(&action.sa_mask);
+                sigaddset(&action.sa_mask, SIGSEGV);
+                sigaction(SIGSEGV, &action, nullptr);
+            }
 #endif
         }
 

--- a/libs/core/coroutines/include/hpx/coroutines/signal_handler_debugging.hpp
+++ b/libs/core/coroutines/include/hpx/coroutines/signal_handler_debugging.hpp
@@ -17,4 +17,7 @@ namespace hpx::threads::coroutines {
     HPX_CORE_EXPORT extern bool diagnostics_on_terminate;
     HPX_CORE_EXPORT extern int exception_verbosity;
     HPX_CORE_EXPORT extern std::size_t trace_depth;
+#if !defined(HPX_WINDOWS)
+    HPX_CORE_EXPORT extern bool register_signal_handler;
+#endif
 }    // namespace hpx::threads::coroutines

--- a/libs/core/coroutines/src/signal_handler_debugging.cpp
+++ b/libs/core/coroutines/src/signal_handler_debugging.cpp
@@ -20,4 +20,7 @@ namespace hpx::threads::coroutines {
 #else
     std::size_t trace_depth = 0;
 #endif
+#if !defined(HPX_WINDOWS)
+    bool register_signal_handler = 1;
+#endif
 }    // namespace hpx::threads::coroutines

--- a/libs/core/runtime_configuration/src/runtime_configuration.cpp
+++ b/libs/core/runtime_configuration/src/runtime_configuration.cpp
@@ -184,7 +184,9 @@ namespace hpx { namespace util {
             "exception_verbosity = ${HPX_EXCEPTION_VERBOSITY:2}",
             "trace_depth = ${HPX_TRACE_DEPTH:" HPX_PP_STRINGIZE(
                 HPX_PP_EXPAND(HPX_HAVE_THREAD_BACKTRACE_DEPTH)) "}",
-
+#if !defined(HPX_WINDOWS)
+            "handle_signals = ${HPX_HANDLE_SIGNALS:1}",
+#endif
             // arity for collective operations implemented in a tree fashion
             "[hpx.lcos.collectives]",
             "arity = ${HPX_LCOS_COLLECTIVES_ARITY:32}",

--- a/libs/core/runtime_local/src/runtime_local.cpp
+++ b/libs/core/runtime_local/src/runtime_local.cpp
@@ -220,18 +220,28 @@ namespace hpx {
         // Set console control handler to allow server to be stopped.
         SetConsoleCtrlHandler(hpx::termination_handler, TRUE);
 #else
-        struct sigaction new_action;
-        new_action.sa_handler = hpx::termination_handler;
-        sigemptyset(&new_action.sa_mask);
-        new_action.sa_flags = 0;
+        if (util::from_string<int>(get_config_entry("hpx.handle_signals", 1)))
+        {
+            struct sigaction new_action;
+            new_action.sa_handler = hpx::termination_handler;
+            sigemptyset(&new_action.sa_mask);
+            new_action.sa_flags = 0;
 
-        sigaction(SIGINT, &new_action, nullptr);     // Interrupted
-        sigaction(SIGBUS, &new_action, nullptr);     // Bus error
-        sigaction(SIGFPE, &new_action, nullptr);     // Floating point exception
-        sigaction(SIGILL, &new_action, nullptr);     // Illegal instruction
-        sigaction(SIGPIPE, &new_action, nullptr);    // Bad pipe
-        sigaction(SIGSEGV, &new_action, nullptr);    // Segmentation fault
-        sigaction(SIGSYS, &new_action, nullptr);     // Bad syscall
+            sigaction(SIGINT, &new_action, nullptr);    // Interrupted
+            sigaction(SIGBUS, &new_action, nullptr);    // Bus error
+            sigaction(
+                SIGFPE, &new_action, nullptr);    // Floating point exception
+            sigaction(SIGILL, &new_action, nullptr);     // Illegal instruction
+            sigaction(SIGPIPE, &new_action, nullptr);    // Bad pipe
+            sigaction(SIGSEGV, &new_action, nullptr);    // Segmentation fault
+            sigaction(SIGSYS, &new_action, nullptr);     // Bad syscall
+
+            hpx::threads::coroutines::register_signal_handler = false;
+        }
+        else
+        {
+            hpx::threads::coroutines::register_signal_handler = true;
+        }
 #endif
 
         std::set_new_handler(hpx::new_handler);


### PR DESCRIPTION
This adds the `hpx.handle_signals` configuration option (defaults to `1`), which if set to `0` will disable handling signal handlers. This allows to generate core dumps to support debugging.

This is limited to non-windows systems.

@srinivasyadav18 this PR enables using the `--hpx:ini=hpx.handle_signals!=0` command line option instead of commenting out the signal registration. Please verify.
