### PR TITLE
Make sure wrapping executor does not go out of scope prematurely

### DIFF
--- a/libs/core/algorithms/include/hpx/parallel/algorithms/detail/dispatch.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/detail/dispatch.hpp
@@ -149,7 +149,7 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
                 hpx::parallel::util::detail::algorithm_result<ExPolicy,
                     local_result_type>;
 
-            auto exec = policy.executor();    // avoid move after use
+            decltype(auto) exec = policy.executor();    // avoid use after move
             if constexpr (hpx::is_async_execution_policy_v<ExPolicy>)
             {
                 // specialization for all task-based (asynchronous) execution
@@ -157,20 +157,18 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
 
                 // run the launched task on the requested executor
                 return result_handler::get(execution::async_execute(
-                    HPX_MOVE(exec), derived(), HPX_FORWARD(ExPolicy, policy),
-                    HPX_FORWARD(Args, args)...));
+                    exec, derived(), policy, HPX_FORWARD(Args, args)...));
             }
             else if constexpr (std::is_void_v<local_result_type>)
             {
-                execution::sync_execute(HPX_MOVE(exec), derived(),
-                    HPX_FORWARD(ExPolicy, policy), HPX_FORWARD(Args, args)...);
+                execution::sync_execute(
+                    exec, derived(), policy, HPX_FORWARD(Args, args)...);
                 return result_handler::get();
             }
             else
             {
                 return result_handler::get(execution::sync_execute(
-                    HPX_MOVE(exec), derived(), HPX_FORWARD(ExPolicy, policy),
-                    HPX_FORWARD(Args, args)...));
+                    exec, derived(), policy, HPX_FORWARD(Args, args)...));
             }
         }
 

--- a/libs/core/executors/examples/executor_with_thread_hooks.cpp
+++ b/libs/core/executors/examples/executor_with_thread_hooks.cpp
@@ -176,14 +176,9 @@ namespace executor_example {
         thread_hook on_stop_;
     };
 
-    template <typename BaseExecutor, typename OnStart, typename OnStop>
-    auto make_executor_with_thread_hooks(
-        BaseExecutor&& exec, OnStart&& on_start, OnStop&& on_stop)
-    {
-        return executor_with_thread_hooks<std::decay_t<BaseExecutor>>(
-            std::forward<BaseExecutor>(exec), std::forward<OnStart>(on_start),
-            std::forward<OnStop>(on_stop));
-    }
+    template <typename Executor, typename OnStart, typename OnStop>
+    executor_with_thread_hooks(Executor&&, OnStart&&, OnStop&&)
+        -> executor_with_thread_hooks<std::decay_t<Executor>>;
 }    // namespace executor_example
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -193,36 +188,35 @@ namespace hpx { namespace parallel { namespace execution {
     template <typename BaseExecutor>
     struct is_one_way_executor<
         executor_example::executor_with_thread_hooks<BaseExecutor>>
-      : is_one_way_executor<typename std::decay<BaseExecutor>::type>
+      : is_one_way_executor<std::decay_t<BaseExecutor>>
     {
     };
 
     template <typename BaseExecutor>
     struct is_never_blocking_one_way_executor<
         executor_example::executor_with_thread_hooks<BaseExecutor>>
-      : is_never_blocking_one_way_executor<
-            typename std::decay<BaseExecutor>::type>
+      : is_never_blocking_one_way_executor<std::decay_t<BaseExecutor>>
     {
     };
 
     template <typename BaseExecutor>
     struct is_two_way_executor<
         executor_example::executor_with_thread_hooks<BaseExecutor>>
-      : is_two_way_executor<typename std::decay<BaseExecutor>::type>
+      : is_two_way_executor<std::decay_t<BaseExecutor>>
     {
     };
 
     template <typename BaseExecutor>
     struct is_bulk_one_way_executor<
         executor_example::executor_with_thread_hooks<BaseExecutor>>
-      : is_bulk_one_way_executor<typename std::decay<BaseExecutor>::type>
+      : is_bulk_one_way_executor<std::decay_t<BaseExecutor>>
     {
     };
 
     template <typename BaseExecutor>
     struct is_bulk_two_way_executor<
         executor_example::executor_with_thread_hooks<BaseExecutor>>
-      : is_bulk_two_way_executor<typename std::decay<BaseExecutor>::type>
+      : is_bulk_two_way_executor<std::decay_t<BaseExecutor>>
     {
     };
 }}}    // namespace hpx::parallel::execution
@@ -238,7 +232,7 @@ int hpx_main()
     auto on_start = [&]() { ++starts; };
     auto on_stop = [&]() { ++stops; };
 
-    auto exec = executor_example::make_executor_with_thread_hooks(
+    auto exec = executor_example::executor_with_thread_hooks(
         hpx::execution::par.executor(), on_start, on_stop);
 
     hpx::experimental::for_loop(

--- a/libs/core/executors/tests/regressions/CMakeLists.txt
+++ b/libs/core/executors/tests/regressions/CMakeLists.txt
@@ -6,7 +6,7 @@
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 set(tests bulk_then_execute_3182 future_then_async_executor
-          parallel_executor_1781
+          parallel_executor_1781 wrapping_executor
 )
 
 foreach(test ${tests})

--- a/libs/core/executors/tests/regressions/wrapping_executor.cpp
+++ b/libs/core/executors/tests/regressions/wrapping_executor.cpp
@@ -1,0 +1,192 @@
+//  Copyright (c) 2020-2022 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+///////////////////////////////////////////////////////////////////////////////
+// Verify that a wrapping executor does not go out of scope prematurely when
+// used with a seq(task) execution policy.
+
+#include <hpx/assert.hpp>
+#include <hpx/local/algorithm.hpp>
+#include <hpx/local/execution.hpp>
+#include <hpx/local/init.hpp>
+
+#include <algorithm>
+#include <atomic>
+#include <cstddef>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+namespace test {
+
+    template <typename BaseExecutor>
+    class wrapping_executor
+    {
+    public:
+        using execution_category =
+            hpx::traits::executor_execution_category_t<BaseExecutor>;
+        using executor_parameters_type =
+            hpx::traits::executor_parameters_type_t<BaseExecutor>;
+
+        template <typename Executor,
+            typename Enable = std::enable_if_t<
+                !std::is_same_v<wrapping_executor, std::decay_t<Executor>>>>
+        explicit wrapping_executor(Executor&& exec)
+          : exec_(std::forward<Executor>(exec))
+        {
+        }
+
+        bool operator==(wrapping_executor const& rhs) const noexcept
+        {
+            return exec_ == rhs.exec_;
+        }
+
+        bool operator!=(wrapping_executor const& rhs) const noexcept
+        {
+            return !(*this == rhs);
+        }
+
+        wrapping_executor const& context() const noexcept
+        {
+            return *this;
+        }
+
+    private:
+        // OneWayExecutor interface
+        template <typename F, typename... Ts>
+        friend decltype(auto) tag_invoke(
+            hpx::parallel::execution::sync_execute_t,
+            wrapping_executor const& exec, F&& f, Ts&&... ts)
+        {
+            return hpx::parallel::execution::sync_execute(
+                exec.exec_, std::forward<F>(f), std::forward<Ts>(ts)...);
+        }
+
+        // TwoWayExecutor interface
+        template <typename F, typename... Ts>
+        friend decltype(auto) tag_invoke(
+            hpx::parallel::execution::async_execute_t,
+            wrapping_executor const& exec, F&& f, Ts&&... ts)
+        {
+            return hpx::parallel::execution::async_execute(
+                exec.exec_, std::forward<F>(f), std::forward<Ts>(ts)...);
+        }
+
+        template <typename F, typename Future, typename... Ts>
+        friend decltype(auto) tag_invoke(
+            hpx::parallel::execution::then_execute_t,
+            wrapping_executor const& exec, F&& f, Future&& predecessor,
+            Ts&&... ts)
+        {
+            return hpx::parallel::execution::then_execute(exec.exec_,
+                std::forward<F>(f), std::forward<Future>(predecessor),
+                std::forward<Ts>(ts)...);
+        }
+
+        // NonBlockingOneWayExecutor (adapted) interface
+        template <typename F, typename... Ts>
+        friend decltype(auto) tag_invoke(hpx::parallel::execution::post_t,
+            wrapping_executor const& exec, F&& f, Ts&&... ts)
+        {
+            hpx::parallel::execution::post(
+                exec.exec_, std::forward<F>(f), std::forward<Ts>(ts)...);
+        }
+
+        // BulkOneWayExecutor interface
+        template <typename F, typename S, typename... Ts>
+        friend decltype(auto) tag_invoke(
+            hpx::parallel::execution::bulk_sync_execute_t,
+            wrapping_executor const& exec, F&& f, S const& shape, Ts&&... ts)
+        {
+            return hpx::parallel::execution::bulk_sync_execute(
+                exec.exec_, std::forward<F>(f), shape, std::forward<Ts>(ts)...);
+        }
+
+        // BulkTwoWayExecutor interface
+        template <typename F, typename S, typename... Ts>
+        friend decltype(auto) tag_invoke(
+            hpx::parallel::execution::bulk_async_execute_t,
+            wrapping_executor const& exec, F&& f, S const& shape, Ts&&... ts)
+        {
+            return hpx::parallel::execution::bulk_async_execute(
+                exec.exec_, std::forward<F>(f), shape, std::forward<Ts>(ts)...);
+        }
+
+        template <typename F, typename S, typename Future, typename... Ts>
+        friend decltype(auto) tag_invoke(
+            hpx::parallel::execution::bulk_then_execute_t,
+            wrapping_executor const& exec, F&& f, S const& shape,
+            Future&& predecessor, Ts&&... ts)
+        {
+            return hpx::parallel::execution::bulk_then_execute(exec.exec_,
+                std::forward<F>(f), shape, std::forward<Future>(predecessor),
+                std::forward<Ts>(ts)...);
+        }
+
+    private:
+        BaseExecutor exec_;
+    };
+
+    template <typename BaseExecutor>
+    wrapping_executor(BaseExecutor&& exec)
+        -> wrapping_executor<std::decay_t<BaseExecutor>>;
+}    // namespace test
+
+///////////////////////////////////////////////////////////////////////////////
+// simple forwarding implementations of executor traits
+namespace hpx { namespace parallel { namespace execution {
+
+    template <typename BaseExecutor>
+    struct is_one_way_executor<test::wrapping_executor<BaseExecutor>>
+      : is_one_way_executor<std::decay_t<BaseExecutor>>
+    {
+    };
+
+    template <typename BaseExecutor>
+    struct is_never_blocking_one_way_executor<
+        test::wrapping_executor<BaseExecutor>>
+      : is_never_blocking_one_way_executor<std::decay_t<BaseExecutor>>
+    {
+    };
+
+    template <typename BaseExecutor>
+    struct is_two_way_executor<test::wrapping_executor<BaseExecutor>>
+      : is_two_way_executor<std::decay_t<BaseExecutor>>
+    {
+    };
+
+    template <typename BaseExecutor>
+    struct is_bulk_one_way_executor<test::wrapping_executor<BaseExecutor>>
+      : is_bulk_one_way_executor<std::decay_t<BaseExecutor>>
+    {
+    };
+
+    template <typename BaseExecutor>
+    struct is_bulk_two_way_executor<test::wrapping_executor<BaseExecutor>>
+      : is_bulk_two_way_executor<std::decay_t<BaseExecutor>>
+    {
+    };
+}}}    // namespace hpx::parallel::execution
+
+int hpx_main()
+{
+    std::vector<double> v(1000);
+    std::iota(v.begin(), v.end(), 0.0);
+
+    auto exec = test::wrapping_executor(hpx::execution::seq.executor());
+    auto policy = hpx::execution::seq(hpx::execution::task).on(exec);
+
+    auto f =
+        hpx::experimental::for_loop(policy, 0, v.size(), [](std::size_t) {});
+    f.get();
+
+    return hpx::local::finalize();
+}
+
+int main(int argc, char* argv[])
+{
+    return hpx::local::init(hpx_main, argc, argv);
+}


### PR DESCRIPTION
- when used with a seq(task) execution policy
- flyby: modernize executor_with_thread_hooks example
