### PR TITLE
Deprecated hpx::util::mem_fn in favor of hpx::mem_fn

### DIFF
--- a/libs/core/functional/docs/index.rst
+++ b/libs/core/functional/docs/index.rst
@@ -25,7 +25,7 @@ their arguments.
 * :cpp:func:`hpx::invoke_r`
 * :cpp:func:`hpx::invoke_fused`
 * :cpp:func:`hpx::invoke_fused_r`
-* :cpp:func:`hpx::util::mem_fn`
+* :cpp:func:`hpx::mem_fn`
 * :cpp:func:`hpx::util::one_shot`
 * :cpp:func:`hpx::util::protect`
 * :cpp:class:`hpx::util::result_of`

--- a/libs/core/functional/include/hpx/functional/mem_fn.hpp
+++ b/libs/core/functional/include/hpx/functional/mem_fn.hpp
@@ -12,7 +12,7 @@
 
 #include <utility>
 
-namespace hpx { namespace util {
+namespace hpx {
     ///////////////////////////////////////////////////////////////////////////
     namespace detail {
         template <typename MemberPointer>
@@ -39,6 +39,15 @@ namespace hpx { namespace util {
         };
     }    // namespace detail
 
+    /// \brief Function template hpx::mem_fn generates wrapper objects for pointers
+    ///        to members, which can store, copy, and invoke a pointer to member.
+    ///        Both references and pointers (including smart pointers) to an object
+    ///        can be used when invoking a hpx::mem_fn.
+    ///
+    /// \param pm 	pointer to member that will be wrapped
+    ///
+    /// \return a call wrapper of unspecified type that has the following members:
+    ///         -
     template <typename M, typename C>
     constexpr detail::mem_fn<M C::*> mem_fn(M C::*pm)
     {
@@ -57,4 +66,34 @@ namespace hpx { namespace util {
     {
         return detail::mem_fn<R (C::*)(Ps...) const>(pm);
     }
-}}    // namespace hpx::util
+}    // namespace hpx
+
+/// \cond NOINTERN
+namespace hpx::util {
+
+    template <typename M, typename C>
+    HPX_DEPRECATED_V(
+        1, 9, "hpx::util::mem_fn is deprecated, use hpx::mem_fn instead")
+    constexpr hpx::detail::mem_fn<M C::*> mem_fn(M C::*pm)
+    {
+        return hpx::detail::mem_fn<M C::*>(pm);
+    }
+
+    template <typename R, typename C, typename... Ps>
+    HPX_DEPRECATED_V(
+        1, 9, "hpx::util::mem_fn is deprecated, use hpx::mem_fn instead")
+    constexpr hpx::detail::mem_fn<R (C::*)(Ps...)> mem_fn(R (C::*pm)(Ps...))
+    {
+        return hpx::detail::mem_fn<R (C::*)(Ps...)>(pm);
+    }
+
+    template <typename R, typename C, typename... Ps>
+    HPX_DEPRECATED_V(
+        1, 9, "hpx::util::mem_fn is deprecated, use hpx::mem_fn instead")
+    constexpr hpx::detail::mem_fn<R (C::*)(Ps...) const> mem_fn(
+        R (C::*pm)(Ps...) const)
+    {
+        return hpx::detail::mem_fn<R (C::*)(Ps...) const>(pm);
+    }
+
+}    // namespace hpx::util

--- a/libs/core/functional/include/hpx/functional/mem_fn.hpp
+++ b/libs/core/functional/include/hpx/functional/mem_fn.hpp
@@ -12,6 +12,7 @@
 
 #include <utility>
 
+/// Top level namespace
 namespace hpx {
     ///////////////////////////////////////////////////////////////////////////
     namespace detail {
@@ -39,27 +40,43 @@ namespace hpx {
         };
     }    // namespace detail
 
-    /// \brief Function template hpx::mem_fn generates wrapper objects for pointers
+    /// \brief Function template \c hpx::mem_fn generates wrapper objects for pointers
     ///        to members, which can store, copy, and invoke a pointer to member.
     ///        Both references and pointers (including smart pointers) to an object
-    ///        can be used when invoking a hpx::mem_fn.
+    ///        can be used when invoking a \c hpx::mem_fn.
     ///
-    /// \param pm 	pointer to member that will be wrapped
+    /// \param pm pointer to member that will be wrapped
     ///
-    /// \return a call wrapper of unspecified type that has the following members:
-    ///         -
+    /// \return a call wrapper of unspecified type with the following member:
+    ///         \code
+    ///         template <typename... Ts>
+    ///         constexpr typename util::invoke_result<MemberPointer, Ts...>::type
+    ///         operator()(Ts&&... vs) noexcept;
+    ///         \endcode
+    ///         Let \c fn be the call wrapper returned by a call to \c hpx::mem_fn
+    ///         with a pointer to member \c pm. Then the expression
+    ///         \c fn(t,a2,...,aN) is equivalent to \c HPX_INVOKE(pm,t,a2,...,aN).
+    ///         Thus, the return type of operator() is
+    ///         \c std::result_of<decltype(pm)(Ts&&...)>::type or equivalently
+    ///         \c std::invoke_result_t<decltype(pm),Ts&&...>, and the value in
+    ///         \c noexcept specifier is equal to
+    ///         \c std::is_nothrow_invocable_v<decltype(pm),Ts&&...>) .
+    ///         Each argument in \c vs is perfectly forwarded,
+    ///         as if by \c std::forward<Ts>(vs)... .
     template <typename M, typename C>
     constexpr detail::mem_fn<M C::*> mem_fn(M C::*pm)
     {
         return detail::mem_fn<M C::*>(pm);
     }
 
+    /// \copydoc hpx::mem_fn
     template <typename R, typename C, typename... Ps>
     constexpr detail::mem_fn<R (C::*)(Ps...)> mem_fn(R (C::*pm)(Ps...))
     {
         return detail::mem_fn<R (C::*)(Ps...)>(pm);
     }
 
+    /// \copydoc hpx::mem_fn
     template <typename R, typename C, typename... Ps>
     constexpr detail::mem_fn<R (C::*)(Ps...) const> mem_fn(
         R (C::*pm)(Ps...) const)

--- a/libs/core/functional/tests/unit/mem_fn_derived_test.cpp
+++ b/libs/core/functional/tests/unit/mem_fn_derived_test.cpp
@@ -164,98 +164,98 @@ int main()
 
     std::shared_ptr<X> sp(new X);
 
-    hpx::util::mem_fn (&X::f0)(x);
-    hpx::util::mem_fn (&X::f0)(&x);
-    hpx::util::mem_fn (&X::f0)(sp);
+    hpx::mem_fn (&X::f0)(x);
+    hpx::mem_fn (&X::f0)(&x);
+    hpx::mem_fn (&X::f0)(sp);
 
-    hpx::util::mem_fn (&X::g0)(x);
-    hpx::util::mem_fn (&X::g0)(rcx);
-    hpx::util::mem_fn (&X::g0)(&x);
-    hpx::util::mem_fn (&X::g0)(pcx);
-    hpx::util::mem_fn (&X::g0)(sp);
+    hpx::mem_fn (&X::g0)(x);
+    hpx::mem_fn (&X::g0)(rcx);
+    hpx::mem_fn (&X::g0)(&x);
+    hpx::mem_fn (&X::g0)(pcx);
+    hpx::mem_fn (&X::g0)(sp);
 
-    hpx::util::mem_fn (&X::f1)(x, 1);
-    hpx::util::mem_fn (&X::f1)(&x, 1);
-    hpx::util::mem_fn (&X::f1)(sp, 1);
+    hpx::mem_fn (&X::f1)(x, 1);
+    hpx::mem_fn (&X::f1)(&x, 1);
+    hpx::mem_fn (&X::f1)(sp, 1);
 
-    hpx::util::mem_fn (&X::g1)(x, 1);
-    hpx::util::mem_fn (&X::g1)(rcx, 1);
-    hpx::util::mem_fn (&X::g1)(&x, 1);
-    hpx::util::mem_fn (&X::g1)(pcx, 1);
-    hpx::util::mem_fn (&X::g1)(sp, 1);
+    hpx::mem_fn (&X::g1)(x, 1);
+    hpx::mem_fn (&X::g1)(rcx, 1);
+    hpx::mem_fn (&X::g1)(&x, 1);
+    hpx::mem_fn (&X::g1)(pcx, 1);
+    hpx::mem_fn (&X::g1)(sp, 1);
 
-    hpx::util::mem_fn (&X::f2)(x, 1, 2);
-    hpx::util::mem_fn (&X::f2)(&x, 1, 2);
-    hpx::util::mem_fn (&X::f2)(sp, 1, 2);
+    hpx::mem_fn (&X::f2)(x, 1, 2);
+    hpx::mem_fn (&X::f2)(&x, 1, 2);
+    hpx::mem_fn (&X::f2)(sp, 1, 2);
 
-    hpx::util::mem_fn (&X::g2)(x, 1, 2);
-    hpx::util::mem_fn (&X::g2)(rcx, 1, 2);
-    hpx::util::mem_fn (&X::g2)(&x, 1, 2);
-    hpx::util::mem_fn (&X::g2)(pcx, 1, 2);
-    hpx::util::mem_fn (&X::g2)(sp, 1, 2);
+    hpx::mem_fn (&X::g2)(x, 1, 2);
+    hpx::mem_fn (&X::g2)(rcx, 1, 2);
+    hpx::mem_fn (&X::g2)(&x, 1, 2);
+    hpx::mem_fn (&X::g2)(pcx, 1, 2);
+    hpx::mem_fn (&X::g2)(sp, 1, 2);
 
-    hpx::util::mem_fn (&X::f3)(x, 1, 2, 3);
-    hpx::util::mem_fn (&X::f3)(&x, 1, 2, 3);
-    hpx::util::mem_fn (&X::f3)(sp, 1, 2, 3);
+    hpx::mem_fn (&X::f3)(x, 1, 2, 3);
+    hpx::mem_fn (&X::f3)(&x, 1, 2, 3);
+    hpx::mem_fn (&X::f3)(sp, 1, 2, 3);
 
-    hpx::util::mem_fn (&X::g3)(x, 1, 2, 3);
-    hpx::util::mem_fn (&X::g3)(rcx, 1, 2, 3);
-    hpx::util::mem_fn (&X::g3)(&x, 1, 2, 3);
-    hpx::util::mem_fn (&X::g3)(pcx, 1, 2, 3);
-    hpx::util::mem_fn (&X::g3)(sp, 1, 2, 3);
+    hpx::mem_fn (&X::g3)(x, 1, 2, 3);
+    hpx::mem_fn (&X::g3)(rcx, 1, 2, 3);
+    hpx::mem_fn (&X::g3)(&x, 1, 2, 3);
+    hpx::mem_fn (&X::g3)(pcx, 1, 2, 3);
+    hpx::mem_fn (&X::g3)(sp, 1, 2, 3);
 
-    hpx::util::mem_fn (&X::f4)(x, 1, 2, 3, 4);
-    hpx::util::mem_fn (&X::f4)(&x, 1, 2, 3, 4);
-    hpx::util::mem_fn (&X::f4)(sp, 1, 2, 3, 4);
+    hpx::mem_fn (&X::f4)(x, 1, 2, 3, 4);
+    hpx::mem_fn (&X::f4)(&x, 1, 2, 3, 4);
+    hpx::mem_fn (&X::f4)(sp, 1, 2, 3, 4);
 
-    hpx::util::mem_fn (&X::g4)(x, 1, 2, 3, 4);
-    hpx::util::mem_fn (&X::g4)(rcx, 1, 2, 3, 4);
-    hpx::util::mem_fn (&X::g4)(&x, 1, 2, 3, 4);
-    hpx::util::mem_fn (&X::g4)(pcx, 1, 2, 3, 4);
-    hpx::util::mem_fn (&X::g4)(sp, 1, 2, 3, 4);
+    hpx::mem_fn (&X::g4)(x, 1, 2, 3, 4);
+    hpx::mem_fn (&X::g4)(rcx, 1, 2, 3, 4);
+    hpx::mem_fn (&X::g4)(&x, 1, 2, 3, 4);
+    hpx::mem_fn (&X::g4)(pcx, 1, 2, 3, 4);
+    hpx::mem_fn (&X::g4)(sp, 1, 2, 3, 4);
 
-    hpx::util::mem_fn (&X::f5)(x, 1, 2, 3, 4, 5);
-    hpx::util::mem_fn (&X::f5)(&x, 1, 2, 3, 4, 5);
-    hpx::util::mem_fn (&X::f5)(sp, 1, 2, 3, 4, 5);
+    hpx::mem_fn (&X::f5)(x, 1, 2, 3, 4, 5);
+    hpx::mem_fn (&X::f5)(&x, 1, 2, 3, 4, 5);
+    hpx::mem_fn (&X::f5)(sp, 1, 2, 3, 4, 5);
 
-    hpx::util::mem_fn (&X::g5)(x, 1, 2, 3, 4, 5);
-    hpx::util::mem_fn (&X::g5)(rcx, 1, 2, 3, 4, 5);
-    hpx::util::mem_fn (&X::g5)(&x, 1, 2, 3, 4, 5);
-    hpx::util::mem_fn (&X::g5)(pcx, 1, 2, 3, 4, 5);
-    hpx::util::mem_fn (&X::g5)(sp, 1, 2, 3, 4, 5);
+    hpx::mem_fn (&X::g5)(x, 1, 2, 3, 4, 5);
+    hpx::mem_fn (&X::g5)(rcx, 1, 2, 3, 4, 5);
+    hpx::mem_fn (&X::g5)(&x, 1, 2, 3, 4, 5);
+    hpx::mem_fn (&X::g5)(pcx, 1, 2, 3, 4, 5);
+    hpx::mem_fn (&X::g5)(sp, 1, 2, 3, 4, 5);
 
-    hpx::util::mem_fn (&X::f6)(x, 1, 2, 3, 4, 5, 6);
-    hpx::util::mem_fn (&X::f6)(&x, 1, 2, 3, 4, 5, 6);
-    hpx::util::mem_fn (&X::f6)(sp, 1, 2, 3, 4, 5, 6);
+    hpx::mem_fn (&X::f6)(x, 1, 2, 3, 4, 5, 6);
+    hpx::mem_fn (&X::f6)(&x, 1, 2, 3, 4, 5, 6);
+    hpx::mem_fn (&X::f6)(sp, 1, 2, 3, 4, 5, 6);
 
-    hpx::util::mem_fn (&X::g6)(x, 1, 2, 3, 4, 5, 6);
-    hpx::util::mem_fn (&X::g6)(rcx, 1, 2, 3, 4, 5, 6);
-    hpx::util::mem_fn (&X::g6)(&x, 1, 2, 3, 4, 5, 6);
-    hpx::util::mem_fn (&X::g6)(pcx, 1, 2, 3, 4, 5, 6);
-    hpx::util::mem_fn (&X::g6)(sp, 1, 2, 3, 4, 5, 6);
+    hpx::mem_fn (&X::g6)(x, 1, 2, 3, 4, 5, 6);
+    hpx::mem_fn (&X::g6)(rcx, 1, 2, 3, 4, 5, 6);
+    hpx::mem_fn (&X::g6)(&x, 1, 2, 3, 4, 5, 6);
+    hpx::mem_fn (&X::g6)(pcx, 1, 2, 3, 4, 5, 6);
+    hpx::mem_fn (&X::g6)(sp, 1, 2, 3, 4, 5, 6);
 
-    hpx::util::mem_fn (&X::f7)(x, 1, 2, 3, 4, 5, 6, 7);
-    hpx::util::mem_fn (&X::f7)(&x, 1, 2, 3, 4, 5, 6, 7);
-    hpx::util::mem_fn (&X::f7)(sp, 1, 2, 3, 4, 5, 6, 7);
+    hpx::mem_fn (&X::f7)(x, 1, 2, 3, 4, 5, 6, 7);
+    hpx::mem_fn (&X::f7)(&x, 1, 2, 3, 4, 5, 6, 7);
+    hpx::mem_fn (&X::f7)(sp, 1, 2, 3, 4, 5, 6, 7);
 
-    hpx::util::mem_fn (&X::g7)(x, 1, 2, 3, 4, 5, 6, 7);
-    hpx::util::mem_fn (&X::g7)(rcx, 1, 2, 3, 4, 5, 6, 7);
-    hpx::util::mem_fn (&X::g7)(&x, 1, 2, 3, 4, 5, 6, 7);
-    hpx::util::mem_fn (&X::g7)(pcx, 1, 2, 3, 4, 5, 6, 7);
-    hpx::util::mem_fn (&X::g7)(sp, 1, 2, 3, 4, 5, 6, 7);
+    hpx::mem_fn (&X::g7)(x, 1, 2, 3, 4, 5, 6, 7);
+    hpx::mem_fn (&X::g7)(rcx, 1, 2, 3, 4, 5, 6, 7);
+    hpx::mem_fn (&X::g7)(&x, 1, 2, 3, 4, 5, 6, 7);
+    hpx::mem_fn (&X::g7)(pcx, 1, 2, 3, 4, 5, 6, 7);
+    hpx::mem_fn (&X::g7)(sp, 1, 2, 3, 4, 5, 6, 7);
 
-    hpx::util::mem_fn (&X::f8)(x, 1, 2, 3, 4, 5, 6, 7, 8);
-    hpx::util::mem_fn (&X::f8)(&x, 1, 2, 3, 4, 5, 6, 7, 8);
-    hpx::util::mem_fn (&X::f8)(sp, 1, 2, 3, 4, 5, 6, 7, 8);
+    hpx::mem_fn (&X::f8)(x, 1, 2, 3, 4, 5, 6, 7, 8);
+    hpx::mem_fn (&X::f8)(&x, 1, 2, 3, 4, 5, 6, 7, 8);
+    hpx::mem_fn (&X::f8)(sp, 1, 2, 3, 4, 5, 6, 7, 8);
 
-    hpx::util::mem_fn (&X::g8)(x, 1, 2, 3, 4, 5, 6, 7, 8);
-    hpx::util::mem_fn (&X::g8)(rcx, 1, 2, 3, 4, 5, 6, 7, 8);
-    hpx::util::mem_fn (&X::g8)(&x, 1, 2, 3, 4, 5, 6, 7, 8);
-    hpx::util::mem_fn (&X::g8)(pcx, 1, 2, 3, 4, 5, 6, 7, 8);
-    hpx::util::mem_fn (&X::g8)(sp, 1, 2, 3, 4, 5, 6, 7, 8);
+    hpx::mem_fn (&X::g8)(x, 1, 2, 3, 4, 5, 6, 7, 8);
+    hpx::mem_fn (&X::g8)(rcx, 1, 2, 3, 4, 5, 6, 7, 8);
+    hpx::mem_fn (&X::g8)(&x, 1, 2, 3, 4, 5, 6, 7, 8);
+    hpx::mem_fn (&X::g8)(pcx, 1, 2, 3, 4, 5, 6, 7, 8);
+    hpx::mem_fn (&X::g8)(sp, 1, 2, 3, 4, 5, 6, 7, 8);
 
-    HPX_TEST_EQ(hpx::util::mem_fn(&X::hash)(x), 17610u);
-    HPX_TEST_EQ(hpx::util::mem_fn(&X::hash)(sp), 2155u);
+    HPX_TEST_EQ(hpx::mem_fn(&X::hash)(x), 17610u);
+    HPX_TEST_EQ(hpx::mem_fn(&X::hash)(sp), 2155u);
 
     return hpx::util::report_errors();
 }

--- a/libs/core/functional/tests/unit/mem_fn_dm_test.cpp
+++ b/libs/core/functional/tests/unit/mem_fn_dm_test.cpp
@@ -36,28 +36,28 @@ int main()
 {
     X x = {0};
 
-    hpx::util::mem_fn (&X::m)(x) = 401;
+    hpx::mem_fn (&X::m)(x) = 401;
 
     HPX_TEST_EQ(x.m, 401);
-    HPX_TEST_EQ(hpx::util::mem_fn(&X::m)(x), 401);
+    HPX_TEST_EQ(hpx::mem_fn(&X::m)(x), 401);
 
-    hpx::util::mem_fn (&X::m)(&x) = 502;
+    hpx::mem_fn (&X::m)(&x) = 502;
 
     HPX_TEST_EQ(x.m, 502);
-    HPX_TEST_EQ(hpx::util::mem_fn(&X::m)(&x), 502);
+    HPX_TEST_EQ(hpx::mem_fn(&X::m)(&x), 502);
 
     X* px = &x;
 
-    hpx::util::mem_fn (&X::m)(px) = 603;
+    hpx::mem_fn (&X::m)(px) = 603;
 
     HPX_TEST_EQ(x.m, 603);
-    HPX_TEST_EQ(hpx::util::mem_fn(&X::m)(px), 603);
+    HPX_TEST_EQ(hpx::mem_fn(&X::m)(px), 603);
 
     X const& cx = x;
     X const* pcx = &x;
 
-    HPX_TEST_EQ(hpx::util::mem_fn(&X::m)(cx), 603);
-    HPX_TEST_EQ(hpx::util::mem_fn(&X::m)(pcx), 603);
+    HPX_TEST_EQ(hpx::mem_fn(&X::m)(cx), 603);
+    HPX_TEST_EQ(hpx::mem_fn(&X::m)(pcx), 603);
 
     return hpx::util::report_errors();
 }

--- a/libs/core/functional/tests/unit/mem_fn_eq_test.cpp
+++ b/libs/core/functional/tests/unit/mem_fn_eq_test.cpp
@@ -268,143 +268,134 @@ struct X
 
 int main()
 {
-    HPX_TEST_EQ(hpx::util::mem_fn(&X::dm_1), hpx::util::mem_fn(&X::dm_1));
-    HPX_TEST_NEQ(hpx::util::mem_fn(&X::dm_1), hpx::util::mem_fn(&X::dm_2));
+    HPX_TEST_EQ(hpx::mem_fn(&X::dm_1), hpx::mem_fn(&X::dm_1));
+    HPX_TEST_NEQ(hpx::mem_fn(&X::dm_1), hpx::mem_fn(&X::dm_2));
 
     // 0
 
-    HPX_TEST_EQ(hpx::util::mem_fn(&X::mf0_1), hpx::util::mem_fn(&X::mf0_1));
-    HPX_TEST_NEQ(hpx::util::mem_fn(&X::mf0_1), hpx::util::mem_fn(&X::mf0_2));
+    HPX_TEST_EQ(hpx::mem_fn(&X::mf0_1), hpx::mem_fn(&X::mf0_1));
+    HPX_TEST_NEQ(hpx::mem_fn(&X::mf0_1), hpx::mem_fn(&X::mf0_2));
 
-    HPX_TEST_EQ(hpx::util::mem_fn(&X::cmf0_1), hpx::util::mem_fn(&X::cmf0_1));
-    HPX_TEST_NEQ(hpx::util::mem_fn(&X::cmf0_1), hpx::util::mem_fn(&X::cmf0_2));
+    HPX_TEST_EQ(hpx::mem_fn(&X::cmf0_1), hpx::mem_fn(&X::cmf0_1));
+    HPX_TEST_NEQ(hpx::mem_fn(&X::cmf0_1), hpx::mem_fn(&X::cmf0_2));
 
-    HPX_TEST_EQ(hpx::util::mem_fn(&X::mf0v_1), hpx::util::mem_fn(&X::mf0v_1));
-    HPX_TEST_NEQ(hpx::util::mem_fn(&X::mf0v_1), hpx::util::mem_fn(&X::mf0v_2));
+    HPX_TEST_EQ(hpx::mem_fn(&X::mf0v_1), hpx::mem_fn(&X::mf0v_1));
+    HPX_TEST_NEQ(hpx::mem_fn(&X::mf0v_1), hpx::mem_fn(&X::mf0v_2));
 
-    HPX_TEST_EQ(hpx::util::mem_fn(&X::cmf0v_1), hpx::util::mem_fn(&X::cmf0v_1));
-    HPX_TEST_NEQ(
-        hpx::util::mem_fn(&X::cmf0v_1), hpx::util::mem_fn(&X::cmf0v_2));
+    HPX_TEST_EQ(hpx::mem_fn(&X::cmf0v_1), hpx::mem_fn(&X::cmf0v_1));
+    HPX_TEST_NEQ(hpx::mem_fn(&X::cmf0v_1), hpx::mem_fn(&X::cmf0v_2));
 
     // 1
 
-    HPX_TEST_EQ(hpx::util::mem_fn(&X::mf1_1), hpx::util::mem_fn(&X::mf1_1));
-    HPX_TEST_NEQ(hpx::util::mem_fn(&X::mf1_1), hpx::util::mem_fn(&X::mf1_2));
+    HPX_TEST_EQ(hpx::mem_fn(&X::mf1_1), hpx::mem_fn(&X::mf1_1));
+    HPX_TEST_NEQ(hpx::mem_fn(&X::mf1_1), hpx::mem_fn(&X::mf1_2));
 
-    HPX_TEST_EQ(hpx::util::mem_fn(&X::cmf1_1), hpx::util::mem_fn(&X::cmf1_1));
-    HPX_TEST_NEQ(hpx::util::mem_fn(&X::cmf1_1), hpx::util::mem_fn(&X::cmf1_2));
+    HPX_TEST_EQ(hpx::mem_fn(&X::cmf1_1), hpx::mem_fn(&X::cmf1_1));
+    HPX_TEST_NEQ(hpx::mem_fn(&X::cmf1_1), hpx::mem_fn(&X::cmf1_2));
 
-    HPX_TEST_EQ(hpx::util::mem_fn(&X::mf1v_1), hpx::util::mem_fn(&X::mf1v_1));
-    HPX_TEST_NEQ(hpx::util::mem_fn(&X::mf1v_1), hpx::util::mem_fn(&X::mf1v_2));
+    HPX_TEST_EQ(hpx::mem_fn(&X::mf1v_1), hpx::mem_fn(&X::mf1v_1));
+    HPX_TEST_NEQ(hpx::mem_fn(&X::mf1v_1), hpx::mem_fn(&X::mf1v_2));
 
-    HPX_TEST_EQ(hpx::util::mem_fn(&X::cmf1v_1), hpx::util::mem_fn(&X::cmf1v_1));
-    HPX_TEST_NEQ(
-        hpx::util::mem_fn(&X::cmf1v_1), hpx::util::mem_fn(&X::cmf1v_2));
+    HPX_TEST_EQ(hpx::mem_fn(&X::cmf1v_1), hpx::mem_fn(&X::cmf1v_1));
+    HPX_TEST_NEQ(hpx::mem_fn(&X::cmf1v_1), hpx::mem_fn(&X::cmf1v_2));
 
     // 2
 
-    HPX_TEST_EQ(hpx::util::mem_fn(&X::mf2_1), hpx::util::mem_fn(&X::mf2_1));
-    HPX_TEST_NEQ(hpx::util::mem_fn(&X::mf2_1), hpx::util::mem_fn(&X::mf2_2));
+    HPX_TEST_EQ(hpx::mem_fn(&X::mf2_1), hpx::mem_fn(&X::mf2_1));
+    HPX_TEST_NEQ(hpx::mem_fn(&X::mf2_1), hpx::mem_fn(&X::mf2_2));
 
-    HPX_TEST_EQ(hpx::util::mem_fn(&X::cmf2_1), hpx::util::mem_fn(&X::cmf2_1));
-    HPX_TEST_NEQ(hpx::util::mem_fn(&X::cmf2_1), hpx::util::mem_fn(&X::cmf2_2));
+    HPX_TEST_EQ(hpx::mem_fn(&X::cmf2_1), hpx::mem_fn(&X::cmf2_1));
+    HPX_TEST_NEQ(hpx::mem_fn(&X::cmf2_1), hpx::mem_fn(&X::cmf2_2));
 
-    HPX_TEST_EQ(hpx::util::mem_fn(&X::mf2v_1), hpx::util::mem_fn(&X::mf2v_1));
-    HPX_TEST_NEQ(hpx::util::mem_fn(&X::mf2v_1), hpx::util::mem_fn(&X::mf2v_2));
+    HPX_TEST_EQ(hpx::mem_fn(&X::mf2v_1), hpx::mem_fn(&X::mf2v_1));
+    HPX_TEST_NEQ(hpx::mem_fn(&X::mf2v_1), hpx::mem_fn(&X::mf2v_2));
 
-    HPX_TEST_EQ(hpx::util::mem_fn(&X::cmf2v_1), hpx::util::mem_fn(&X::cmf2v_1));
-    HPX_TEST_NEQ(
-        hpx::util::mem_fn(&X::cmf2v_1), hpx::util::mem_fn(&X::cmf2v_2));
+    HPX_TEST_EQ(hpx::mem_fn(&X::cmf2v_1), hpx::mem_fn(&X::cmf2v_1));
+    HPX_TEST_NEQ(hpx::mem_fn(&X::cmf2v_1), hpx::mem_fn(&X::cmf2v_2));
 
     // 3
 
-    HPX_TEST_EQ(hpx::util::mem_fn(&X::mf3_1), hpx::util::mem_fn(&X::mf3_1));
-    HPX_TEST_NEQ(hpx::util::mem_fn(&X::mf3_1), hpx::util::mem_fn(&X::mf3_2));
+    HPX_TEST_EQ(hpx::mem_fn(&X::mf3_1), hpx::mem_fn(&X::mf3_1));
+    HPX_TEST_NEQ(hpx::mem_fn(&X::mf3_1), hpx::mem_fn(&X::mf3_2));
 
-    HPX_TEST_EQ(hpx::util::mem_fn(&X::cmf3_1), hpx::util::mem_fn(&X::cmf3_1));
-    HPX_TEST_NEQ(hpx::util::mem_fn(&X::cmf3_1), hpx::util::mem_fn(&X::cmf3_2));
+    HPX_TEST_EQ(hpx::mem_fn(&X::cmf3_1), hpx::mem_fn(&X::cmf3_1));
+    HPX_TEST_NEQ(hpx::mem_fn(&X::cmf3_1), hpx::mem_fn(&X::cmf3_2));
 
-    HPX_TEST_EQ(hpx::util::mem_fn(&X::mf3v_1), hpx::util::mem_fn(&X::mf3v_1));
-    HPX_TEST_NEQ(hpx::util::mem_fn(&X::mf3v_1), hpx::util::mem_fn(&X::mf3v_2));
+    HPX_TEST_EQ(hpx::mem_fn(&X::mf3v_1), hpx::mem_fn(&X::mf3v_1));
+    HPX_TEST_NEQ(hpx::mem_fn(&X::mf3v_1), hpx::mem_fn(&X::mf3v_2));
 
-    HPX_TEST_EQ(hpx::util::mem_fn(&X::cmf3v_1), hpx::util::mem_fn(&X::cmf3v_1));
-    HPX_TEST_NEQ(
-        hpx::util::mem_fn(&X::cmf3v_1), hpx::util::mem_fn(&X::cmf3v_2));
+    HPX_TEST_EQ(hpx::mem_fn(&X::cmf3v_1), hpx::mem_fn(&X::cmf3v_1));
+    HPX_TEST_NEQ(hpx::mem_fn(&X::cmf3v_1), hpx::mem_fn(&X::cmf3v_2));
 
     // 4
 
-    HPX_TEST_EQ(hpx::util::mem_fn(&X::mf4_1), hpx::util::mem_fn(&X::mf4_1));
-    HPX_TEST_NEQ(hpx::util::mem_fn(&X::mf4_1), hpx::util::mem_fn(&X::mf4_2));
+    HPX_TEST_EQ(hpx::mem_fn(&X::mf4_1), hpx::mem_fn(&X::mf4_1));
+    HPX_TEST_NEQ(hpx::mem_fn(&X::mf4_1), hpx::mem_fn(&X::mf4_2));
 
-    HPX_TEST_EQ(hpx::util::mem_fn(&X::cmf4_1), hpx::util::mem_fn(&X::cmf4_1));
-    HPX_TEST_NEQ(hpx::util::mem_fn(&X::cmf4_1), hpx::util::mem_fn(&X::cmf4_2));
+    HPX_TEST_EQ(hpx::mem_fn(&X::cmf4_1), hpx::mem_fn(&X::cmf4_1));
+    HPX_TEST_NEQ(hpx::mem_fn(&X::cmf4_1), hpx::mem_fn(&X::cmf4_2));
 
-    HPX_TEST_EQ(hpx::util::mem_fn(&X::mf4v_1), hpx::util::mem_fn(&X::mf4v_1));
-    HPX_TEST_NEQ(hpx::util::mem_fn(&X::mf4v_1), hpx::util::mem_fn(&X::mf4v_2));
+    HPX_TEST_EQ(hpx::mem_fn(&X::mf4v_1), hpx::mem_fn(&X::mf4v_1));
+    HPX_TEST_NEQ(hpx::mem_fn(&X::mf4v_1), hpx::mem_fn(&X::mf4v_2));
 
-    HPX_TEST_EQ(hpx::util::mem_fn(&X::cmf4v_1), hpx::util::mem_fn(&X::cmf4v_1));
-    HPX_TEST_NEQ(
-        hpx::util::mem_fn(&X::cmf4v_1), hpx::util::mem_fn(&X::cmf4v_2));
+    HPX_TEST_EQ(hpx::mem_fn(&X::cmf4v_1), hpx::mem_fn(&X::cmf4v_1));
+    HPX_TEST_NEQ(hpx::mem_fn(&X::cmf4v_1), hpx::mem_fn(&X::cmf4v_2));
 
     // 5
 
-    HPX_TEST_EQ(hpx::util::mem_fn(&X::mf5_1), hpx::util::mem_fn(&X::mf5_1));
-    HPX_TEST_NEQ(hpx::util::mem_fn(&X::mf5_1), hpx::util::mem_fn(&X::mf5_2));
+    HPX_TEST_EQ(hpx::mem_fn(&X::mf5_1), hpx::mem_fn(&X::mf5_1));
+    HPX_TEST_NEQ(hpx::mem_fn(&X::mf5_1), hpx::mem_fn(&X::mf5_2));
 
-    HPX_TEST_EQ(hpx::util::mem_fn(&X::cmf5_1), hpx::util::mem_fn(&X::cmf5_1));
-    HPX_TEST_NEQ(hpx::util::mem_fn(&X::cmf5_1), hpx::util::mem_fn(&X::cmf5_2));
+    HPX_TEST_EQ(hpx::mem_fn(&X::cmf5_1), hpx::mem_fn(&X::cmf5_1));
+    HPX_TEST_NEQ(hpx::mem_fn(&X::cmf5_1), hpx::mem_fn(&X::cmf5_2));
 
-    HPX_TEST_EQ(hpx::util::mem_fn(&X::mf5v_1), hpx::util::mem_fn(&X::mf5v_1));
-    HPX_TEST_NEQ(hpx::util::mem_fn(&X::mf5v_1), hpx::util::mem_fn(&X::mf5v_2));
+    HPX_TEST_EQ(hpx::mem_fn(&X::mf5v_1), hpx::mem_fn(&X::mf5v_1));
+    HPX_TEST_NEQ(hpx::mem_fn(&X::mf5v_1), hpx::mem_fn(&X::mf5v_2));
 
-    HPX_TEST_EQ(hpx::util::mem_fn(&X::cmf5v_1), hpx::util::mem_fn(&X::cmf5v_1));
-    HPX_TEST_NEQ(
-        hpx::util::mem_fn(&X::cmf5v_1), hpx::util::mem_fn(&X::cmf5v_2));
+    HPX_TEST_EQ(hpx::mem_fn(&X::cmf5v_1), hpx::mem_fn(&X::cmf5v_1));
+    HPX_TEST_NEQ(hpx::mem_fn(&X::cmf5v_1), hpx::mem_fn(&X::cmf5v_2));
 
     // 6
 
-    HPX_TEST_EQ(hpx::util::mem_fn(&X::mf6_1), hpx::util::mem_fn(&X::mf6_1));
-    HPX_TEST_NEQ(hpx::util::mem_fn(&X::mf6_1), hpx::util::mem_fn(&X::mf6_2));
+    HPX_TEST_EQ(hpx::mem_fn(&X::mf6_1), hpx::mem_fn(&X::mf6_1));
+    HPX_TEST_NEQ(hpx::mem_fn(&X::mf6_1), hpx::mem_fn(&X::mf6_2));
 
-    HPX_TEST_EQ(hpx::util::mem_fn(&X::cmf6_1), hpx::util::mem_fn(&X::cmf6_1));
-    HPX_TEST_NEQ(hpx::util::mem_fn(&X::cmf6_1), hpx::util::mem_fn(&X::cmf6_2));
+    HPX_TEST_EQ(hpx::mem_fn(&X::cmf6_1), hpx::mem_fn(&X::cmf6_1));
+    HPX_TEST_NEQ(hpx::mem_fn(&X::cmf6_1), hpx::mem_fn(&X::cmf6_2));
 
-    HPX_TEST_EQ(hpx::util::mem_fn(&X::mf6v_1), hpx::util::mem_fn(&X::mf6v_1));
-    HPX_TEST_NEQ(hpx::util::mem_fn(&X::mf6v_1), hpx::util::mem_fn(&X::mf6v_2));
+    HPX_TEST_EQ(hpx::mem_fn(&X::mf6v_1), hpx::mem_fn(&X::mf6v_1));
+    HPX_TEST_NEQ(hpx::mem_fn(&X::mf6v_1), hpx::mem_fn(&X::mf6v_2));
 
-    HPX_TEST_EQ(hpx::util::mem_fn(&X::cmf6v_1), hpx::util::mem_fn(&X::cmf6v_1));
-    HPX_TEST_NEQ(
-        hpx::util::mem_fn(&X::cmf6v_1), hpx::util::mem_fn(&X::cmf6v_2));
+    HPX_TEST_EQ(hpx::mem_fn(&X::cmf6v_1), hpx::mem_fn(&X::cmf6v_1));
+    HPX_TEST_NEQ(hpx::mem_fn(&X::cmf6v_1), hpx::mem_fn(&X::cmf6v_2));
 
     // 7
 
-    HPX_TEST_EQ(hpx::util::mem_fn(&X::mf7_1), hpx::util::mem_fn(&X::mf7_1));
-    HPX_TEST_NEQ(hpx::util::mem_fn(&X::mf7_1), hpx::util::mem_fn(&X::mf7_2));
+    HPX_TEST_EQ(hpx::mem_fn(&X::mf7_1), hpx::mem_fn(&X::mf7_1));
+    HPX_TEST_NEQ(hpx::mem_fn(&X::mf7_1), hpx::mem_fn(&X::mf7_2));
 
-    HPX_TEST_EQ(hpx::util::mem_fn(&X::cmf7_1), hpx::util::mem_fn(&X::cmf7_1));
-    HPX_TEST_NEQ(hpx::util::mem_fn(&X::cmf7_1), hpx::util::mem_fn(&X::cmf7_2));
+    HPX_TEST_EQ(hpx::mem_fn(&X::cmf7_1), hpx::mem_fn(&X::cmf7_1));
+    HPX_TEST_NEQ(hpx::mem_fn(&X::cmf7_1), hpx::mem_fn(&X::cmf7_2));
 
-    HPX_TEST_EQ(hpx::util::mem_fn(&X::mf7v_1), hpx::util::mem_fn(&X::mf7v_1));
-    HPX_TEST_NEQ(hpx::util::mem_fn(&X::mf7v_1), hpx::util::mem_fn(&X::mf7v_2));
+    HPX_TEST_EQ(hpx::mem_fn(&X::mf7v_1), hpx::mem_fn(&X::mf7v_1));
+    HPX_TEST_NEQ(hpx::mem_fn(&X::mf7v_1), hpx::mem_fn(&X::mf7v_2));
 
-    HPX_TEST_EQ(hpx::util::mem_fn(&X::cmf7v_1), hpx::util::mem_fn(&X::cmf7v_1));
-    HPX_TEST_NEQ(
-        hpx::util::mem_fn(&X::cmf7v_1), hpx::util::mem_fn(&X::cmf7v_2));
+    HPX_TEST_EQ(hpx::mem_fn(&X::cmf7v_1), hpx::mem_fn(&X::cmf7v_1));
+    HPX_TEST_NEQ(hpx::mem_fn(&X::cmf7v_1), hpx::mem_fn(&X::cmf7v_2));
 
     // 8
 
-    HPX_TEST_EQ(hpx::util::mem_fn(&X::mf8_1), hpx::util::mem_fn(&X::mf8_1));
-    HPX_TEST_NEQ(hpx::util::mem_fn(&X::mf8_1), hpx::util::mem_fn(&X::mf8_2));
+    HPX_TEST_EQ(hpx::mem_fn(&X::mf8_1), hpx::mem_fn(&X::mf8_1));
+    HPX_TEST_NEQ(hpx::mem_fn(&X::mf8_1), hpx::mem_fn(&X::mf8_2));
 
-    HPX_TEST_EQ(hpx::util::mem_fn(&X::cmf8_1), hpx::util::mem_fn(&X::cmf8_1));
-    HPX_TEST_NEQ(hpx::util::mem_fn(&X::cmf8_1), hpx::util::mem_fn(&X::cmf8_2));
+    HPX_TEST_EQ(hpx::mem_fn(&X::cmf8_1), hpx::mem_fn(&X::cmf8_1));
+    HPX_TEST_NEQ(hpx::mem_fn(&X::cmf8_1), hpx::mem_fn(&X::cmf8_2));
 
-    HPX_TEST_EQ(hpx::util::mem_fn(&X::mf8v_1), hpx::util::mem_fn(&X::mf8v_1));
-    HPX_TEST_NEQ(hpx::util::mem_fn(&X::mf8v_1), hpx::util::mem_fn(&X::mf8v_2));
+    HPX_TEST_EQ(hpx::mem_fn(&X::mf8v_1), hpx::mem_fn(&X::mf8v_1));
+    HPX_TEST_NEQ(hpx::mem_fn(&X::mf8v_1), hpx::mem_fn(&X::mf8v_2));
 
-    HPX_TEST_EQ(hpx::util::mem_fn(&X::cmf8v_1), hpx::util::mem_fn(&X::cmf8v_1));
-    HPX_TEST_NEQ(
-        hpx::util::mem_fn(&X::cmf8v_1), hpx::util::mem_fn(&X::cmf8v_2));
+    HPX_TEST_EQ(hpx::mem_fn(&X::cmf8v_1), hpx::mem_fn(&X::cmf8v_1));
+    HPX_TEST_NEQ(hpx::mem_fn(&X::cmf8v_1), hpx::mem_fn(&X::cmf8v_2));
 
     return hpx::util::report_errors();
 }

--- a/libs/core/functional/tests/unit/mem_fn_rv_test.cpp
+++ b/libs/core/functional/tests/unit/mem_fn_rv_test.cpp
@@ -154,32 +154,32 @@ std::shared_ptr<X> make()
 
 int main()
 {
-    hpx::util::mem_fn (&X::f0)(make());
-    hpx::util::mem_fn (&X::g0)(make());
+    hpx::mem_fn (&X::f0)(make());
+    hpx::mem_fn (&X::g0)(make());
 
-    hpx::util::mem_fn (&X::f1)(make(), 1);
-    hpx::util::mem_fn (&X::g1)(make(), 1);
+    hpx::mem_fn (&X::f1)(make(), 1);
+    hpx::mem_fn (&X::g1)(make(), 1);
 
-    hpx::util::mem_fn (&X::f2)(make(), 1, 2);
-    hpx::util::mem_fn (&X::g2)(make(), 1, 2);
+    hpx::mem_fn (&X::f2)(make(), 1, 2);
+    hpx::mem_fn (&X::g2)(make(), 1, 2);
 
-    hpx::util::mem_fn (&X::f3)(make(), 1, 2, 3);
-    hpx::util::mem_fn (&X::g3)(make(), 1, 2, 3);
+    hpx::mem_fn (&X::f3)(make(), 1, 2, 3);
+    hpx::mem_fn (&X::g3)(make(), 1, 2, 3);
 
-    hpx::util::mem_fn (&X::f4)(make(), 1, 2, 3, 4);
-    hpx::util::mem_fn (&X::g4)(make(), 1, 2, 3, 4);
+    hpx::mem_fn (&X::f4)(make(), 1, 2, 3, 4);
+    hpx::mem_fn (&X::g4)(make(), 1, 2, 3, 4);
 
-    hpx::util::mem_fn (&X::f5)(make(), 1, 2, 3, 4, 5);
-    hpx::util::mem_fn (&X::g5)(make(), 1, 2, 3, 4, 5);
+    hpx::mem_fn (&X::f5)(make(), 1, 2, 3, 4, 5);
+    hpx::mem_fn (&X::g5)(make(), 1, 2, 3, 4, 5);
 
-    hpx::util::mem_fn (&X::f6)(make(), 1, 2, 3, 4, 5, 6);
-    hpx::util::mem_fn (&X::g6)(make(), 1, 2, 3, 4, 5, 6);
+    hpx::mem_fn (&X::f6)(make(), 1, 2, 3, 4, 5, 6);
+    hpx::mem_fn (&X::g6)(make(), 1, 2, 3, 4, 5, 6);
 
-    hpx::util::mem_fn (&X::f7)(make(), 1, 2, 3, 4, 5, 6, 7);
-    hpx::util::mem_fn (&X::g7)(make(), 1, 2, 3, 4, 5, 6, 7);
+    hpx::mem_fn (&X::f7)(make(), 1, 2, 3, 4, 5, 6, 7);
+    hpx::mem_fn (&X::g7)(make(), 1, 2, 3, 4, 5, 6, 7);
 
-    hpx::util::mem_fn (&X::f8)(make(), 1, 2, 3, 4, 5, 6, 7, 8);
-    hpx::util::mem_fn (&X::g8)(make(), 1, 2, 3, 4, 5, 6, 7, 8);
+    hpx::mem_fn (&X::f8)(make(), 1, 2, 3, 4, 5, 6, 7, 8);
+    hpx::mem_fn (&X::g8)(make(), 1, 2, 3, 4, 5, 6, 7, 8);
 
     HPX_TEST_EQ(hash, 2155u);
 

--- a/libs/core/functional/tests/unit/mem_fn_test.cpp
+++ b/libs/core/functional/tests/unit/mem_fn_test.cpp
@@ -160,98 +160,98 @@ int main()
 
     std::shared_ptr<X> sp(new X);
 
-    hpx::util::mem_fn (&X::f0)(x);
-    hpx::util::mem_fn (&X::f0)(&x);
-    hpx::util::mem_fn (&X::f0)(sp);
+    hpx::mem_fn (&X::f0)(x);
+    hpx::mem_fn (&X::f0)(&x);
+    hpx::mem_fn (&X::f0)(sp);
 
-    hpx::util::mem_fn (&X::g0)(x);
-    hpx::util::mem_fn (&X::g0)(rcx);
-    hpx::util::mem_fn (&X::g0)(&x);
-    hpx::util::mem_fn (&X::g0)(pcx);
-    hpx::util::mem_fn (&X::g0)(sp);
+    hpx::mem_fn (&X::g0)(x);
+    hpx::mem_fn (&X::g0)(rcx);
+    hpx::mem_fn (&X::g0)(&x);
+    hpx::mem_fn (&X::g0)(pcx);
+    hpx::mem_fn (&X::g0)(sp);
 
-    hpx::util::mem_fn (&X::f1)(x, 1);
-    hpx::util::mem_fn (&X::f1)(&x, 1);
-    hpx::util::mem_fn (&X::f1)(sp, 1);
+    hpx::mem_fn (&X::f1)(x, 1);
+    hpx::mem_fn (&X::f1)(&x, 1);
+    hpx::mem_fn (&X::f1)(sp, 1);
 
-    hpx::util::mem_fn (&X::g1)(x, 1);
-    hpx::util::mem_fn (&X::g1)(rcx, 1);
-    hpx::util::mem_fn (&X::g1)(&x, 1);
-    hpx::util::mem_fn (&X::g1)(pcx, 1);
-    hpx::util::mem_fn (&X::g1)(sp, 1);
+    hpx::mem_fn (&X::g1)(x, 1);
+    hpx::mem_fn (&X::g1)(rcx, 1);
+    hpx::mem_fn (&X::g1)(&x, 1);
+    hpx::mem_fn (&X::g1)(pcx, 1);
+    hpx::mem_fn (&X::g1)(sp, 1);
 
-    hpx::util::mem_fn (&X::f2)(x, 1, 2);
-    hpx::util::mem_fn (&X::f2)(&x, 1, 2);
-    hpx::util::mem_fn (&X::f2)(sp, 1, 2);
+    hpx::mem_fn (&X::f2)(x, 1, 2);
+    hpx::mem_fn (&X::f2)(&x, 1, 2);
+    hpx::mem_fn (&X::f2)(sp, 1, 2);
 
-    hpx::util::mem_fn (&X::g2)(x, 1, 2);
-    hpx::util::mem_fn (&X::g2)(rcx, 1, 2);
-    hpx::util::mem_fn (&X::g2)(&x, 1, 2);
-    hpx::util::mem_fn (&X::g2)(pcx, 1, 2);
-    hpx::util::mem_fn (&X::g2)(sp, 1, 2);
+    hpx::mem_fn (&X::g2)(x, 1, 2);
+    hpx::mem_fn (&X::g2)(rcx, 1, 2);
+    hpx::mem_fn (&X::g2)(&x, 1, 2);
+    hpx::mem_fn (&X::g2)(pcx, 1, 2);
+    hpx::mem_fn (&X::g2)(sp, 1, 2);
 
-    hpx::util::mem_fn (&X::f3)(x, 1, 2, 3);
-    hpx::util::mem_fn (&X::f3)(&x, 1, 2, 3);
-    hpx::util::mem_fn (&X::f3)(sp, 1, 2, 3);
+    hpx::mem_fn (&X::f3)(x, 1, 2, 3);
+    hpx::mem_fn (&X::f3)(&x, 1, 2, 3);
+    hpx::mem_fn (&X::f3)(sp, 1, 2, 3);
 
-    hpx::util::mem_fn (&X::g3)(x, 1, 2, 3);
-    hpx::util::mem_fn (&X::g3)(rcx, 1, 2, 3);
-    hpx::util::mem_fn (&X::g3)(&x, 1, 2, 3);
-    hpx::util::mem_fn (&X::g3)(pcx, 1, 2, 3);
-    hpx::util::mem_fn (&X::g3)(sp, 1, 2, 3);
+    hpx::mem_fn (&X::g3)(x, 1, 2, 3);
+    hpx::mem_fn (&X::g3)(rcx, 1, 2, 3);
+    hpx::mem_fn (&X::g3)(&x, 1, 2, 3);
+    hpx::mem_fn (&X::g3)(pcx, 1, 2, 3);
+    hpx::mem_fn (&X::g3)(sp, 1, 2, 3);
 
-    hpx::util::mem_fn (&X::f4)(x, 1, 2, 3, 4);
-    hpx::util::mem_fn (&X::f4)(&x, 1, 2, 3, 4);
-    hpx::util::mem_fn (&X::f4)(sp, 1, 2, 3, 4);
+    hpx::mem_fn (&X::f4)(x, 1, 2, 3, 4);
+    hpx::mem_fn (&X::f4)(&x, 1, 2, 3, 4);
+    hpx::mem_fn (&X::f4)(sp, 1, 2, 3, 4);
 
-    hpx::util::mem_fn (&X::g4)(x, 1, 2, 3, 4);
-    hpx::util::mem_fn (&X::g4)(rcx, 1, 2, 3, 4);
-    hpx::util::mem_fn (&X::g4)(&x, 1, 2, 3, 4);
-    hpx::util::mem_fn (&X::g4)(pcx, 1, 2, 3, 4);
-    hpx::util::mem_fn (&X::g4)(sp, 1, 2, 3, 4);
+    hpx::mem_fn (&X::g4)(x, 1, 2, 3, 4);
+    hpx::mem_fn (&X::g4)(rcx, 1, 2, 3, 4);
+    hpx::mem_fn (&X::g4)(&x, 1, 2, 3, 4);
+    hpx::mem_fn (&X::g4)(pcx, 1, 2, 3, 4);
+    hpx::mem_fn (&X::g4)(sp, 1, 2, 3, 4);
 
-    hpx::util::mem_fn (&X::f5)(x, 1, 2, 3, 4, 5);
-    hpx::util::mem_fn (&X::f5)(&x, 1, 2, 3, 4, 5);
-    hpx::util::mem_fn (&X::f5)(sp, 1, 2, 3, 4, 5);
+    hpx::mem_fn (&X::f5)(x, 1, 2, 3, 4, 5);
+    hpx::mem_fn (&X::f5)(&x, 1, 2, 3, 4, 5);
+    hpx::mem_fn (&X::f5)(sp, 1, 2, 3, 4, 5);
 
-    hpx::util::mem_fn (&X::g5)(x, 1, 2, 3, 4, 5);
-    hpx::util::mem_fn (&X::g5)(rcx, 1, 2, 3, 4, 5);
-    hpx::util::mem_fn (&X::g5)(&x, 1, 2, 3, 4, 5);
-    hpx::util::mem_fn (&X::g5)(pcx, 1, 2, 3, 4, 5);
-    hpx::util::mem_fn (&X::g5)(sp, 1, 2, 3, 4, 5);
+    hpx::mem_fn (&X::g5)(x, 1, 2, 3, 4, 5);
+    hpx::mem_fn (&X::g5)(rcx, 1, 2, 3, 4, 5);
+    hpx::mem_fn (&X::g5)(&x, 1, 2, 3, 4, 5);
+    hpx::mem_fn (&X::g5)(pcx, 1, 2, 3, 4, 5);
+    hpx::mem_fn (&X::g5)(sp, 1, 2, 3, 4, 5);
 
-    hpx::util::mem_fn (&X::f6)(x, 1, 2, 3, 4, 5, 6);
-    hpx::util::mem_fn (&X::f6)(&x, 1, 2, 3, 4, 5, 6);
-    hpx::util::mem_fn (&X::f6)(sp, 1, 2, 3, 4, 5, 6);
+    hpx::mem_fn (&X::f6)(x, 1, 2, 3, 4, 5, 6);
+    hpx::mem_fn (&X::f6)(&x, 1, 2, 3, 4, 5, 6);
+    hpx::mem_fn (&X::f6)(sp, 1, 2, 3, 4, 5, 6);
 
-    hpx::util::mem_fn (&X::g6)(x, 1, 2, 3, 4, 5, 6);
-    hpx::util::mem_fn (&X::g6)(rcx, 1, 2, 3, 4, 5, 6);
-    hpx::util::mem_fn (&X::g6)(&x, 1, 2, 3, 4, 5, 6);
-    hpx::util::mem_fn (&X::g6)(pcx, 1, 2, 3, 4, 5, 6);
-    hpx::util::mem_fn (&X::g6)(sp, 1, 2, 3, 4, 5, 6);
+    hpx::mem_fn (&X::g6)(x, 1, 2, 3, 4, 5, 6);
+    hpx::mem_fn (&X::g6)(rcx, 1, 2, 3, 4, 5, 6);
+    hpx::mem_fn (&X::g6)(&x, 1, 2, 3, 4, 5, 6);
+    hpx::mem_fn (&X::g6)(pcx, 1, 2, 3, 4, 5, 6);
+    hpx::mem_fn (&X::g6)(sp, 1, 2, 3, 4, 5, 6);
 
-    hpx::util::mem_fn (&X::f7)(x, 1, 2, 3, 4, 5, 6, 7);
-    hpx::util::mem_fn (&X::f7)(&x, 1, 2, 3, 4, 5, 6, 7);
-    hpx::util::mem_fn (&X::f7)(sp, 1, 2, 3, 4, 5, 6, 7);
+    hpx::mem_fn (&X::f7)(x, 1, 2, 3, 4, 5, 6, 7);
+    hpx::mem_fn (&X::f7)(&x, 1, 2, 3, 4, 5, 6, 7);
+    hpx::mem_fn (&X::f7)(sp, 1, 2, 3, 4, 5, 6, 7);
 
-    hpx::util::mem_fn (&X::g7)(x, 1, 2, 3, 4, 5, 6, 7);
-    hpx::util::mem_fn (&X::g7)(rcx, 1, 2, 3, 4, 5, 6, 7);
-    hpx::util::mem_fn (&X::g7)(&x, 1, 2, 3, 4, 5, 6, 7);
-    hpx::util::mem_fn (&X::g7)(pcx, 1, 2, 3, 4, 5, 6, 7);
-    hpx::util::mem_fn (&X::g7)(sp, 1, 2, 3, 4, 5, 6, 7);
+    hpx::mem_fn (&X::g7)(x, 1, 2, 3, 4, 5, 6, 7);
+    hpx::mem_fn (&X::g7)(rcx, 1, 2, 3, 4, 5, 6, 7);
+    hpx::mem_fn (&X::g7)(&x, 1, 2, 3, 4, 5, 6, 7);
+    hpx::mem_fn (&X::g7)(pcx, 1, 2, 3, 4, 5, 6, 7);
+    hpx::mem_fn (&X::g7)(sp, 1, 2, 3, 4, 5, 6, 7);
 
-    hpx::util::mem_fn (&X::f8)(x, 1, 2, 3, 4, 5, 6, 7, 8);
-    hpx::util::mem_fn (&X::f8)(&x, 1, 2, 3, 4, 5, 6, 7, 8);
-    hpx::util::mem_fn (&X::f8)(sp, 1, 2, 3, 4, 5, 6, 7, 8);
+    hpx::mem_fn (&X::f8)(x, 1, 2, 3, 4, 5, 6, 7, 8);
+    hpx::mem_fn (&X::f8)(&x, 1, 2, 3, 4, 5, 6, 7, 8);
+    hpx::mem_fn (&X::f8)(sp, 1, 2, 3, 4, 5, 6, 7, 8);
 
-    hpx::util::mem_fn (&X::g8)(x, 1, 2, 3, 4, 5, 6, 7, 8);
-    hpx::util::mem_fn (&X::g8)(rcx, 1, 2, 3, 4, 5, 6, 7, 8);
-    hpx::util::mem_fn (&X::g8)(&x, 1, 2, 3, 4, 5, 6, 7, 8);
-    hpx::util::mem_fn (&X::g8)(pcx, 1, 2, 3, 4, 5, 6, 7, 8);
-    hpx::util::mem_fn (&X::g8)(sp, 1, 2, 3, 4, 5, 6, 7, 8);
+    hpx::mem_fn (&X::g8)(x, 1, 2, 3, 4, 5, 6, 7, 8);
+    hpx::mem_fn (&X::g8)(rcx, 1, 2, 3, 4, 5, 6, 7, 8);
+    hpx::mem_fn (&X::g8)(&x, 1, 2, 3, 4, 5, 6, 7, 8);
+    hpx::mem_fn (&X::g8)(pcx, 1, 2, 3, 4, 5, 6, 7, 8);
+    hpx::mem_fn (&X::g8)(sp, 1, 2, 3, 4, 5, 6, 7, 8);
 
-    HPX_TEST_EQ(hpx::util::mem_fn(&X::hash)(x), 17610u);
-    HPX_TEST_EQ(hpx::util::mem_fn(&X::hash)(sp), 2155u);
+    HPX_TEST_EQ(hpx::mem_fn(&X::hash)(x), 17610u);
+    HPX_TEST_EQ(hpx::mem_fn(&X::hash)(sp), 2155u);
 
     return hpx::util::report_errors();
 }

--- a/libs/core/functional/tests/unit/mem_fn_unary_addr_test.cpp
+++ b/libs/core/functional/tests/unit/mem_fn_unary_addr_test.cpp
@@ -173,32 +173,32 @@ int main()
     Y<X> px(&x);
     Y<X const> pcx(&x);
 
-    hpx::util::mem_fn (&X::f0)(px);
-    hpx::util::mem_fn (&X::g0)(pcx);
+    hpx::mem_fn (&X::f0)(px);
+    hpx::mem_fn (&X::g0)(pcx);
 
-    hpx::util::mem_fn (&X::f1)(px, 1);
-    hpx::util::mem_fn (&X::g1)(pcx, 1);
+    hpx::mem_fn (&X::f1)(px, 1);
+    hpx::mem_fn (&X::g1)(pcx, 1);
 
-    hpx::util::mem_fn (&X::f2)(px, 1, 2);
-    hpx::util::mem_fn (&X::g2)(pcx, 1, 2);
+    hpx::mem_fn (&X::f2)(px, 1, 2);
+    hpx::mem_fn (&X::g2)(pcx, 1, 2);
 
-    hpx::util::mem_fn (&X::f3)(px, 1, 2, 3);
-    hpx::util::mem_fn (&X::g3)(pcx, 1, 2, 3);
+    hpx::mem_fn (&X::f3)(px, 1, 2, 3);
+    hpx::mem_fn (&X::g3)(pcx, 1, 2, 3);
 
-    hpx::util::mem_fn (&X::f4)(px, 1, 2, 3, 4);
-    hpx::util::mem_fn (&X::g4)(pcx, 1, 2, 3, 4);
+    hpx::mem_fn (&X::f4)(px, 1, 2, 3, 4);
+    hpx::mem_fn (&X::g4)(pcx, 1, 2, 3, 4);
 
-    hpx::util::mem_fn (&X::f5)(px, 1, 2, 3, 4, 5);
-    hpx::util::mem_fn (&X::g5)(pcx, 1, 2, 3, 4, 5);
+    hpx::mem_fn (&X::f5)(px, 1, 2, 3, 4, 5);
+    hpx::mem_fn (&X::g5)(pcx, 1, 2, 3, 4, 5);
 
-    hpx::util::mem_fn (&X::f6)(px, 1, 2, 3, 4, 5, 6);
-    hpx::util::mem_fn (&X::g6)(pcx, 1, 2, 3, 4, 5, 6);
+    hpx::mem_fn (&X::f6)(px, 1, 2, 3, 4, 5, 6);
+    hpx::mem_fn (&X::g6)(pcx, 1, 2, 3, 4, 5, 6);
 
-    hpx::util::mem_fn (&X::f7)(px, 1, 2, 3, 4, 5, 6, 7);
-    hpx::util::mem_fn (&X::g7)(pcx, 1, 2, 3, 4, 5, 6, 7);
+    hpx::mem_fn (&X::f7)(px, 1, 2, 3, 4, 5, 6, 7);
+    hpx::mem_fn (&X::g7)(pcx, 1, 2, 3, 4, 5, 6, 7);
 
-    hpx::util::mem_fn (&X::f8)(px, 1, 2, 3, 4, 5, 6, 7, 8);
-    hpx::util::mem_fn (&X::g8)(pcx, 1, 2, 3, 4, 5, 6, 7, 8);
+    hpx::mem_fn (&X::f8)(px, 1, 2, 3, 4, 5, 6, 7, 8);
+    hpx::mem_fn (&X::g8)(pcx, 1, 2, 3, 4, 5, 6, 7, 8);
 
     HPX_TEST_EQ(hash, 2155u);
 

--- a/libs/core/functional/tests/unit/mem_fn_void_test.cpp
+++ b/libs/core/functional/tests/unit/mem_fn_void_test.cpp
@@ -143,95 +143,95 @@ int main()
 
     std::shared_ptr<X> sp(new X);
 
-    hpx::util::mem_fn (&X::f0)(x);
-    hpx::util::mem_fn (&X::f0)(&x);
-    hpx::util::mem_fn (&X::f0)(sp);
+    hpx::mem_fn (&X::f0)(x);
+    hpx::mem_fn (&X::f0)(&x);
+    hpx::mem_fn (&X::f0)(sp);
 
-    hpx::util::mem_fn (&X::g0)(x);
-    hpx::util::mem_fn (&X::g0)(rcx);
-    hpx::util::mem_fn (&X::g0)(&x);
-    hpx::util::mem_fn (&X::g0)(pcx);
-    hpx::util::mem_fn (&X::g0)(sp);
+    hpx::mem_fn (&X::g0)(x);
+    hpx::mem_fn (&X::g0)(rcx);
+    hpx::mem_fn (&X::g0)(&x);
+    hpx::mem_fn (&X::g0)(pcx);
+    hpx::mem_fn (&X::g0)(sp);
 
-    hpx::util::mem_fn (&X::f1)(x, 1);
-    hpx::util::mem_fn (&X::f1)(&x, 1);
-    hpx::util::mem_fn (&X::f1)(sp, 1);
+    hpx::mem_fn (&X::f1)(x, 1);
+    hpx::mem_fn (&X::f1)(&x, 1);
+    hpx::mem_fn (&X::f1)(sp, 1);
 
-    hpx::util::mem_fn (&X::g1)(x, 1);
-    hpx::util::mem_fn (&X::g1)(rcx, 1);
-    hpx::util::mem_fn (&X::g1)(&x, 1);
-    hpx::util::mem_fn (&X::g1)(pcx, 1);
-    hpx::util::mem_fn (&X::g1)(sp, 1);
+    hpx::mem_fn (&X::g1)(x, 1);
+    hpx::mem_fn (&X::g1)(rcx, 1);
+    hpx::mem_fn (&X::g1)(&x, 1);
+    hpx::mem_fn (&X::g1)(pcx, 1);
+    hpx::mem_fn (&X::g1)(sp, 1);
 
-    hpx::util::mem_fn (&X::f2)(x, 1, 2);
-    hpx::util::mem_fn (&X::f2)(&x, 1, 2);
-    hpx::util::mem_fn (&X::f2)(sp, 1, 2);
+    hpx::mem_fn (&X::f2)(x, 1, 2);
+    hpx::mem_fn (&X::f2)(&x, 1, 2);
+    hpx::mem_fn (&X::f2)(sp, 1, 2);
 
-    hpx::util::mem_fn (&X::g2)(x, 1, 2);
-    hpx::util::mem_fn (&X::g2)(rcx, 1, 2);
-    hpx::util::mem_fn (&X::g2)(&x, 1, 2);
-    hpx::util::mem_fn (&X::g2)(pcx, 1, 2);
-    hpx::util::mem_fn (&X::g2)(sp, 1, 2);
+    hpx::mem_fn (&X::g2)(x, 1, 2);
+    hpx::mem_fn (&X::g2)(rcx, 1, 2);
+    hpx::mem_fn (&X::g2)(&x, 1, 2);
+    hpx::mem_fn (&X::g2)(pcx, 1, 2);
+    hpx::mem_fn (&X::g2)(sp, 1, 2);
 
-    hpx::util::mem_fn (&X::f3)(x, 1, 2, 3);
-    hpx::util::mem_fn (&X::f3)(&x, 1, 2, 3);
-    hpx::util::mem_fn (&X::f3)(sp, 1, 2, 3);
+    hpx::mem_fn (&X::f3)(x, 1, 2, 3);
+    hpx::mem_fn (&X::f3)(&x, 1, 2, 3);
+    hpx::mem_fn (&X::f3)(sp, 1, 2, 3);
 
-    hpx::util::mem_fn (&X::g3)(x, 1, 2, 3);
-    hpx::util::mem_fn (&X::g3)(rcx, 1, 2, 3);
-    hpx::util::mem_fn (&X::g3)(&x, 1, 2, 3);
-    hpx::util::mem_fn (&X::g3)(pcx, 1, 2, 3);
-    hpx::util::mem_fn (&X::g3)(sp, 1, 2, 3);
+    hpx::mem_fn (&X::g3)(x, 1, 2, 3);
+    hpx::mem_fn (&X::g3)(rcx, 1, 2, 3);
+    hpx::mem_fn (&X::g3)(&x, 1, 2, 3);
+    hpx::mem_fn (&X::g3)(pcx, 1, 2, 3);
+    hpx::mem_fn (&X::g3)(sp, 1, 2, 3);
 
-    hpx::util::mem_fn (&X::f4)(x, 1, 2, 3, 4);
-    hpx::util::mem_fn (&X::f4)(&x, 1, 2, 3, 4);
-    hpx::util::mem_fn (&X::f4)(sp, 1, 2, 3, 4);
+    hpx::mem_fn (&X::f4)(x, 1, 2, 3, 4);
+    hpx::mem_fn (&X::f4)(&x, 1, 2, 3, 4);
+    hpx::mem_fn (&X::f4)(sp, 1, 2, 3, 4);
 
-    hpx::util::mem_fn (&X::g4)(x, 1, 2, 3, 4);
-    hpx::util::mem_fn (&X::g4)(rcx, 1, 2, 3, 4);
-    hpx::util::mem_fn (&X::g4)(&x, 1, 2, 3, 4);
-    hpx::util::mem_fn (&X::g4)(pcx, 1, 2, 3, 4);
-    hpx::util::mem_fn (&X::g4)(sp, 1, 2, 3, 4);
+    hpx::mem_fn (&X::g4)(x, 1, 2, 3, 4);
+    hpx::mem_fn (&X::g4)(rcx, 1, 2, 3, 4);
+    hpx::mem_fn (&X::g4)(&x, 1, 2, 3, 4);
+    hpx::mem_fn (&X::g4)(pcx, 1, 2, 3, 4);
+    hpx::mem_fn (&X::g4)(sp, 1, 2, 3, 4);
 
-    hpx::util::mem_fn (&X::f5)(x, 1, 2, 3, 4, 5);
-    hpx::util::mem_fn (&X::f5)(&x, 1, 2, 3, 4, 5);
-    hpx::util::mem_fn (&X::f5)(sp, 1, 2, 3, 4, 5);
+    hpx::mem_fn (&X::f5)(x, 1, 2, 3, 4, 5);
+    hpx::mem_fn (&X::f5)(&x, 1, 2, 3, 4, 5);
+    hpx::mem_fn (&X::f5)(sp, 1, 2, 3, 4, 5);
 
-    hpx::util::mem_fn (&X::g5)(x, 1, 2, 3, 4, 5);
-    hpx::util::mem_fn (&X::g5)(rcx, 1, 2, 3, 4, 5);
-    hpx::util::mem_fn (&X::g5)(&x, 1, 2, 3, 4, 5);
-    hpx::util::mem_fn (&X::g5)(pcx, 1, 2, 3, 4, 5);
-    hpx::util::mem_fn (&X::g5)(sp, 1, 2, 3, 4, 5);
+    hpx::mem_fn (&X::g5)(x, 1, 2, 3, 4, 5);
+    hpx::mem_fn (&X::g5)(rcx, 1, 2, 3, 4, 5);
+    hpx::mem_fn (&X::g5)(&x, 1, 2, 3, 4, 5);
+    hpx::mem_fn (&X::g5)(pcx, 1, 2, 3, 4, 5);
+    hpx::mem_fn (&X::g5)(sp, 1, 2, 3, 4, 5);
 
-    hpx::util::mem_fn (&X::f6)(x, 1, 2, 3, 4, 5, 6);
-    hpx::util::mem_fn (&X::f6)(&x, 1, 2, 3, 4, 5, 6);
-    hpx::util::mem_fn (&X::f6)(sp, 1, 2, 3, 4, 5, 6);
+    hpx::mem_fn (&X::f6)(x, 1, 2, 3, 4, 5, 6);
+    hpx::mem_fn (&X::f6)(&x, 1, 2, 3, 4, 5, 6);
+    hpx::mem_fn (&X::f6)(sp, 1, 2, 3, 4, 5, 6);
 
-    hpx::util::mem_fn (&X::g6)(x, 1, 2, 3, 4, 5, 6);
-    hpx::util::mem_fn (&X::g6)(rcx, 1, 2, 3, 4, 5, 6);
-    hpx::util::mem_fn (&X::g6)(&x, 1, 2, 3, 4, 5, 6);
-    hpx::util::mem_fn (&X::g6)(pcx, 1, 2, 3, 4, 5, 6);
-    hpx::util::mem_fn (&X::g6)(sp, 1, 2, 3, 4, 5, 6);
+    hpx::mem_fn (&X::g6)(x, 1, 2, 3, 4, 5, 6);
+    hpx::mem_fn (&X::g6)(rcx, 1, 2, 3, 4, 5, 6);
+    hpx::mem_fn (&X::g6)(&x, 1, 2, 3, 4, 5, 6);
+    hpx::mem_fn (&X::g6)(pcx, 1, 2, 3, 4, 5, 6);
+    hpx::mem_fn (&X::g6)(sp, 1, 2, 3, 4, 5, 6);
 
-    hpx::util::mem_fn (&X::f7)(x, 1, 2, 3, 4, 5, 6, 7);
-    hpx::util::mem_fn (&X::f7)(&x, 1, 2, 3, 4, 5, 6, 7);
-    hpx::util::mem_fn (&X::f7)(sp, 1, 2, 3, 4, 5, 6, 7);
+    hpx::mem_fn (&X::f7)(x, 1, 2, 3, 4, 5, 6, 7);
+    hpx::mem_fn (&X::f7)(&x, 1, 2, 3, 4, 5, 6, 7);
+    hpx::mem_fn (&X::f7)(sp, 1, 2, 3, 4, 5, 6, 7);
 
-    hpx::util::mem_fn (&X::g7)(x, 1, 2, 3, 4, 5, 6, 7);
-    hpx::util::mem_fn (&X::g7)(rcx, 1, 2, 3, 4, 5, 6, 7);
-    hpx::util::mem_fn (&X::g7)(&x, 1, 2, 3, 4, 5, 6, 7);
-    hpx::util::mem_fn (&X::g7)(pcx, 1, 2, 3, 4, 5, 6, 7);
-    hpx::util::mem_fn (&X::g7)(sp, 1, 2, 3, 4, 5, 6, 7);
+    hpx::mem_fn (&X::g7)(x, 1, 2, 3, 4, 5, 6, 7);
+    hpx::mem_fn (&X::g7)(rcx, 1, 2, 3, 4, 5, 6, 7);
+    hpx::mem_fn (&X::g7)(&x, 1, 2, 3, 4, 5, 6, 7);
+    hpx::mem_fn (&X::g7)(pcx, 1, 2, 3, 4, 5, 6, 7);
+    hpx::mem_fn (&X::g7)(sp, 1, 2, 3, 4, 5, 6, 7);
 
-    hpx::util::mem_fn (&X::f8)(x, 1, 2, 3, 4, 5, 6, 7, 8);
-    hpx::util::mem_fn (&X::f8)(&x, 1, 2, 3, 4, 5, 6, 7, 8);
-    hpx::util::mem_fn (&X::f8)(sp, 1, 2, 3, 4, 5, 6, 7, 8);
+    hpx::mem_fn (&X::f8)(x, 1, 2, 3, 4, 5, 6, 7, 8);
+    hpx::mem_fn (&X::f8)(&x, 1, 2, 3, 4, 5, 6, 7, 8);
+    hpx::mem_fn (&X::f8)(sp, 1, 2, 3, 4, 5, 6, 7, 8);
 
-    hpx::util::mem_fn (&X::g8)(x, 1, 2, 3, 4, 5, 6, 7, 8);
-    hpx::util::mem_fn (&X::g8)(rcx, 1, 2, 3, 4, 5, 6, 7, 8);
-    hpx::util::mem_fn (&X::g8)(&x, 1, 2, 3, 4, 5, 6, 7, 8);
-    hpx::util::mem_fn (&X::g8)(pcx, 1, 2, 3, 4, 5, 6, 7, 8);
-    hpx::util::mem_fn (&X::g8)(sp, 1, 2, 3, 4, 5, 6, 7, 8);
+    hpx::mem_fn (&X::g8)(x, 1, 2, 3, 4, 5, 6, 7, 8);
+    hpx::mem_fn (&X::g8)(rcx, 1, 2, 3, 4, 5, 6, 7, 8);
+    hpx::mem_fn (&X::g8)(&x, 1, 2, 3, 4, 5, 6, 7, 8);
+    hpx::mem_fn (&X::g8)(pcx, 1, 2, 3, 4, 5, 6, 7, 8);
+    hpx::mem_fn (&X::g8)(sp, 1, 2, 3, 4, 5, 6, 7, 8);
 
     HPX_TEST_EQ(x.hash, 17610u);
     HPX_TEST_EQ(sp->hash, 2155u);

--- a/libs/core/include_local/include/hpx/local/functional.hpp
+++ b/libs/core/include_local/include/hpx/local/functional.hpp
@@ -23,5 +23,5 @@
 namespace hpx {
 
     using hpx::invoke_fused;
-    using hpx::util::mem_fn;
+    using hpx::mem_fn;
 }    // namespace hpx


### PR DESCRIPTION
Deprecated `hpx::util::mem_fn` in favor of `hpx::mem_fn`

Working towards resolving https://github.com/STEllAR-GROUP/hpx/issues/6000