### PR TITLE
Do not check for cancellation during each iteration but only once per partition

### DIFF
--- a/libs/core/algorithms/include/hpx/parallel/algorithms/detail/find.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/detail/find.hpp
@@ -36,14 +36,11 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
             sequential_find_t<ExPolicy>, Iterator first, Sentinel last,
             T const& value, Proj proj = Proj())
         {
-            for (; first != last; ++first)
-            {
-                if (HPX_INVOKE(proj, *first) == value)
-                {
-                    return first;
-                }
-            }
-            return first;
+            return util::loop_pred<
+                std::decay_t<hpx::execution::sequenced_policy>>(
+                first, last, [&value, &proj](auto const& curr) {
+                    return HPX_INVOKE(proj, *curr) == value;
+                });
         }
 
         template <typename FwdIter, typename Token, typename T, typename Proj>
@@ -98,14 +95,10 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
             sequential_find_if_t<ExPolicy>, Iterator first, Sentinel last,
             Pred pred, Proj proj = Proj())
         {
-            for (; first != last; ++first)
-            {
-                if (HPX_INVOKE(pred, HPX_INVOKE(proj, *first)))
-                {
-                    return first;
-                }
-            }
-            return first;
+            return util::loop_pred<ExPolicy>(
+                first, last, [&pred, &proj](auto const& curr) {
+                    return HPX_INVOKE(pred, HPX_INVOKE(proj, *curr));
+                });
         }
 
         template <typename FwdIter, typename Token, typename F, typename Proj>
@@ -184,14 +177,10 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
             sequential_find_if_not_t<ExPolicy>, Iterator first, Sentinel last,
             Pred pred, Proj proj = Proj())
         {
-            for (; first != last; ++first)
-            {
-                if (!HPX_INVOKE(pred, HPX_INVOKE(proj, *first)))
-                {
-                    return first;
-                }
-            }
-            return first;
+            return util::loop_pred<ExPolicy>(
+                first, last, [&pred, &proj](auto const& curr) {
+                    return !HPX_INVOKE(pred, HPX_INVOKE(proj, *curr));
+                });
         }
 
         template <typename FwdIter, typename Token, typename F, typename Proj>

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/find.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/find.hpp
@@ -810,7 +810,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
         template <typename FwdIter>
         struct find : public detail::algorithm<find<FwdIter>, FwdIter>
         {
-            find()
+            constexpr find() noexcept
               : find::algorithm("find")
             {
             }
@@ -881,7 +881,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
         template <typename FwdIter>
         struct find_if : public detail::algorithm<find_if<FwdIter>, FwdIter>
         {
-            find_if()
+            constexpr find_if() noexcept
               : find_if::algorithm("find_if")
             {
             }
@@ -955,7 +955,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
         struct find_if_not
           : public detail::algorithm<find_if_not<FwdIter>, FwdIter>
         {
-            find_if_not()
+            constexpr find_if_not() noexcept
               : find_if_not::algorithm("find_if_not")
             {
             }
@@ -1027,7 +1027,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
         template <typename FwdIter>
         struct find_end : public detail::algorithm<find_end<FwdIter>, FwdIter>
         {
-            find_end()
+            constexpr find_end() noexcept
               : find_end::algorithm("find_end")
             {
             }
@@ -1118,7 +1118,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
         struct find_first_of
           : public detail::algorithm<find_first_of<FwdIter>, FwdIter>
         {
-            find_first_of()
+            constexpr find_first_of() noexcept
               : find_first_of::algorithm("find_first_of")
             {
             }

--- a/libs/core/algorithms/include/hpx/parallel/datapar/find.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/datapar/find.hpp
@@ -35,23 +35,11 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
         static inline Iterator call(
             Iterator first, Sentinel last, T const& val, Proj proj)
         {
-            int offset = 0;
-            util::cancellation_token<> tok;
-
-            auto ret = util::loop_n<std::decay_t<ExPolicy>>(first,
-                std::distance(first, last), tok,
-                [&offset, &val, &tok, &proj](auto const& curr) {
+            return util::loop_pred<std::decay_t<ExPolicy>>(
+                first, last, [&val, &proj](auto const& curr) {
                     auto msk = HPX_INVOKE(proj, *curr) == val;
-                    offset = hpx::parallel::traits::find_first_of(msk);
-                    if (offset != -1)
-                    {
-                        tok.cancel();
-                    }
+                    return hpx::parallel::traits::find_first_of(msk);
                 });
-
-            if (tok.was_cancelled())
-                std::advance(ret, offset);
-            return ret;
         }
 
         template <typename FwdIter, typename Token, typename T, typename Proj>
@@ -78,7 +66,18 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
         sequential_find_t<ExPolicy>, Iterator first, Sentinel last,
         T const& val, Proj proj = Proj())
     {
-        return datapar_find<ExPolicy>::call(first, last, val, proj);
+        if constexpr (hpx::parallel::util::detail::iterator_datapar_compatible<
+                          Iterator>::value)
+        {
+            return datapar_find<ExPolicy>::call(first, last, val, proj);
+        }
+        else
+        {
+            using base_policy_type =
+                decltype((hpx::execution::experimental::to_non_simd(
+                    std::declval<ExPolicy>())));
+            return sequential_find<base_policy_type>(first, last, val, proj);
+        }
     }
 
     template <typename ExPolicy, typename FwdIter, typename Token, typename T,
@@ -102,23 +101,11 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
         static inline Iterator call(
             Iterator first, Sentinel last, Pred pred, Proj proj)
         {
-            int offset = 0;
-            util::cancellation_token<> tok;
-
-            auto ret = util::loop_n<std::decay_t<ExPolicy>>(first,
-                std::distance(first, last), tok,
-                [&offset, &pred, &tok, &proj](auto const& curr) {
+            return util::loop_pred<std::decay_t<ExPolicy>>(
+                first, last, [&pred, &proj](auto const& curr) {
                     auto msk = HPX_INVOKE(pred, HPX_INVOKE(proj, *curr));
-                    offset = hpx::parallel::traits::find_first_of(msk);
-                    if (offset != -1)
-                    {
-                        tok.cancel();
-                    }
+                    return hpx::parallel::traits::find_first_of(msk);
                 });
-
-            if (tok.was_cancelled())
-                std::advance(ret, offset);
-            return ret;
         }
 
         template <typename FwdIter, typename Token, typename F, typename Proj>
@@ -159,7 +146,19 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
         sequential_find_if_t<ExPolicy>, Iterator first, Sentinel last,
         Pred pred, Proj proj = Proj())
     {
-        return datapar_find_if<ExPolicy>::call(first, last, pred, proj);
+        if constexpr (hpx::parallel::util::detail::iterator_datapar_compatible<
+                          Iterator>::value)
+        {
+            return datapar_find_if<ExPolicy>::call(first, last, pred, proj);
+        }
+        else
+        {
+            using base_policy_type =
+                decltype((hpx::execution::experimental::to_non_simd(
+                    std::declval<ExPolicy>())));
+            return sequential_find_if<base_policy_type>(
+                first, last, pred, proj);
+        }
     }
 
     template <typename ExPolicy, typename FwdIter, typename Token, typename F,
@@ -196,24 +195,11 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
         static inline Iterator call(
             Iterator first, Sentinel last, Pred pred, Proj proj)
         {
-            int offset = 0;
-            util::cancellation_token<> tok;
-
-            auto ret =
-                util::loop_n<ExPolicy>(first, std::distance(first, last), tok,
-                    [&offset, &pred, &tok, &proj](
-                        auto const& curr) mutable -> void {
-                        auto msk = !HPX_INVOKE(pred, HPX_INVOKE(proj, *curr));
-                        offset = hpx::parallel::traits::find_first_of(msk);
-                        if (offset != -1)
-                        {
-                            tok.cancel();
-                        }
-                    });
-
-            if (tok.was_cancelled())
-                std::advance(ret, offset);
-            return ret;
+            return util::loop_pred<std::decay_t<ExPolicy>>(
+                first, last, [&pred, &proj](auto const& curr) mutable {
+                    auto msk = !HPX_INVOKE(pred, HPX_INVOKE(proj, *curr));
+                    return hpx::parallel::traits::find_first_of(msk);
+                });
         }
 
         template <typename FwdIter, typename Token, typename F, typename Proj>
@@ -254,7 +240,19 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
         sequential_find_if_not_t<ExPolicy>, Iterator first, Sentinel last,
         Pred pred, Proj proj = Proj())
     {
-        return datapar_find_if_not<ExPolicy>::call(first, last, pred, proj);
+        if constexpr (hpx::parallel::util::detail::iterator_datapar_compatible<
+                          Iterator>::value)
+        {
+            return datapar_find_if_not<ExPolicy>::call(first, last, pred, proj);
+        }
+        else
+        {
+            using base_policy_type =
+                decltype((hpx::execution::experimental::to_non_simd(
+                    std::declval<ExPolicy>())));
+            return sequential_find_if_not<base_policy_type>(
+                first, last, pred, proj);
+        }
     }
 
     template <typename ExPolicy, typename FwdIter, typename Token, typename F,

--- a/libs/core/algorithms/include/hpx/parallel/datapar/loop.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/datapar/loop.hpp
@@ -124,11 +124,11 @@ namespace hpx { namespace parallel { namespace util {
                     traits::vector_pack_size<V>::value;
 
                 End const lastV = last - (size + 1);
-                int offset = 0;
 
                 while (first < lastV)
                 {
-                    offset = datapar_loop_pred_step<Begin>::callv(pred, first);
+                    int offset =
+                        datapar_loop_pred_step<Begin>::callv(pred, first);
                     if (offset != -1)
                     {
                         std::advance(first, offset);


### PR DESCRIPTION
The goal is to improve the performance of the algorithms that rely on optional cancellation (like `hpx::find`, et.al.)