### PR TITLE
Implement P2690 for our algorithms

### DIFF
--- a/libs/core/algorithms/include/hpx/parallel/util/detail/sender_util.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/util/detail/sender_util.hpp
@@ -13,7 +13,9 @@
 #include <hpx/execution/traits/is_execution_policy.hpp>
 #include <hpx/execution_base/completion_signatures.hpp>
 #include <hpx/execution_base/sender.hpp>
+#include <hpx/executors/execute_on.hpp>
 #include <hpx/executors/execution_policy.hpp>
+#include <hpx/executors/explicit_scheduler_executor.hpp>
 
 #include <type_traits>
 #include <utility>
@@ -99,8 +101,8 @@ namespace hpx::detail {
 
     // Helper base class for implementing parallel algorithm CPOs. See
     // tag_fallback documentation for details. Compared to tag_fallback this
-    // adds two tag_fallback_invoke overloads that are generic for all
-    // parallel algorithms:
+    // adds two tag_fallback_invoke overloads that are generic for all parallel
+    // algorithms:
     //
     //   1. An overload taking a predecessor sender which sends all arguments
     //      for the regular parallel algorithm overload, except an execution
@@ -111,24 +113,27 @@ namespace hpx::detail {
     //      a predecessor sender: partially_applied_algorithm(predecessor). The
     //      predecessor can also be supplied  using the operator| overload:
     //      predecessor | partially_applied_parallel_algorithm.
+    //   3. In the context of the experimental support for p2500
+    //      (wg21.link/p2500) this also adds two overloads that take a either
+    //      scheduler or a policy_aware_scheduler as its first argument (instead
+    //      of the usual execution policy). These overloads use an scheduler
+    //      based executor that is rewrapped into an execution policy which is
+    //      then passed on to the underlying algorithm APIs.
     template <typename Tag>
     struct tag_parallel_algorithm : hpx::functional::detail::tag_fallback<Tag>
     {
         // clang-format off
-        template <typename Predecessor, typename ExPolicy,
+        template <typename Sender, typename ExPolicy,
             HPX_CONCEPT_REQUIRES_(
                 hpx::is_execution_policy_v<ExPolicy> &&
-               !detail::is_bound_algorithm_v<Predecessor> &&
-                hpx::execution::experimental::is_sender_v<
-                    std::decay_t<Predecessor>>
+               !detail::is_bound_algorithm_v<Sender> &&
+                hpx::execution::experimental::is_sender_v<Sender>
             )>
         // clang-format on
-        friend auto tag_fallback_invoke(
-            Tag, Predecessor&& predecessor, ExPolicy&& policy)
+        friend auto tag_fallback_invoke(Tag, Sender&& sender, ExPolicy&& policy)
         {
             return detail::then_with_bound_algorithm<Tag>(
-                HPX_FORWARD(Predecessor, predecessor),
-                HPX_FORWARD(ExPolicy, policy));
+                HPX_FORWARD(Sender, sender), HPX_FORWARD(ExPolicy, policy));
         }
 
         // clang-format off
@@ -141,6 +146,53 @@ namespace hpx::detail {
         {
             return hpx::execution::experimental::detail::partial_algorithm<Tag,
                 ExPolicy>{HPX_FORWARD(ExPolicy, policy)};
+        }
+
+        // Experimental support for P2500 (wg21.link/p2500)
+        //
+        // Wrap the given scheduler in an explicit_scheduler_executor and a
+        // matching execution policy. Forward call to algorithm by passing the
+        // resulting rewrapped execution policy.
+        //
+        // clang-format off
+        template <typename Scheduler, typename... Ts,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::execution::experimental::is_scheduler_v<Scheduler>
+            )>
+        // clang-format on
+        friend auto tag_fallback_invoke(
+            Tag tag, Scheduler&& scheduler, Ts&&... ts)
+        {
+            using namespace hpx::execution::experimental;
+
+            explicit_scheduler_executor<std::decay_t<Scheduler>> exec(
+                HPX_FORWARD(Scheduler, scheduler));
+
+            return tag(
+                hpx::execution::par.on(HPX_MOVE(exec)), HPX_FORWARD(Ts, ts)...);
+        }
+
+        // Extract the scheduler and the execution policy from the given
+        // policy_aware_scheduler, rewrap those and forward the resulting
+        // execution policy to the underlying algorithm.
+        //
+        // clang-format off
+        template <typename Scheduler, typename... Ts,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::execution::experimental::is_policy_aware_scheduler_v<
+                    std::decay_t<Scheduler>>
+            )>
+        // clang-format on
+        friend auto tag_invoke(Tag tag, Scheduler&& scheduler, Ts&&... ts)
+        {
+            using namespace hpx::execution::experimental;
+            using scheduler_type = std::decay_t<Scheduler>;
+
+            auto policy = scheduler.get_policy();
+            explicit_scheduler_executor<scheduler_type> exec(
+                HPX_FORWARD(Scheduler, scheduler));
+
+            return tag(policy.on(HPX_MOVE(exec)), HPX_FORWARD(Ts, ts)...);
         }
     };
 }    // namespace hpx::detail

--- a/libs/core/algorithms/tests/unit/algorithms/CMakeLists.txt
+++ b/libs/core/algorithms/tests/unit/algorithms/CMakeLists.txt
@@ -53,6 +53,7 @@ set(tests
     foreach_executors
     foreach_prefetching
     foreach_sender
+    foreach_scheduler
     foreachn
     foreachn_exception
     foreachn_bad_alloc

--- a/libs/core/algorithms/tests/unit/algorithms/foreach_scheduler.cpp
+++ b/libs/core/algorithms/tests/unit/algorithms/foreach_scheduler.cpp
@@ -1,0 +1,248 @@
+//  Copyright (c) 2014-2022 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/local/execution.hpp>
+#include <hpx/local/init.hpp>
+#include <hpx/local/thread.hpp>
+#include <hpx/modules/async_base.hpp>
+#include <hpx/modules/iterator_support.hpp>
+#include <hpx/modules/testing.hpp>
+#include <hpx/parallel/algorithms/for_each.hpp>
+
+#include <algorithm>
+#include <cstddef>
+#include <iostream>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "test_utils.hpp"
+
+///////////////////////////////////////////////////////////////////////////////
+template <typename Policy, typename IteratorTag>
+void test_for_each_explicit_scheduler(Policy l, IteratorTag)
+{
+    using base_iterator = std::vector<std::size_t>::iterator;
+    using iterator = test::test_iterator<base_iterator, IteratorTag>;
+
+    std::vector<std::size_t> c(10007);
+    std::iota(std::begin(c), std::end(c), std::rand());
+
+    namespace ex = hpx::execution::experimental;
+
+    auto f = [](std::size_t& v) { v = 42; };
+
+    using scheduler_t = ex::thread_pool_policy_scheduler<Policy>;
+
+    auto result = hpx::for_each(
+        scheduler_t(l), iterator(std::begin(c)), iterator(std::end(c)), f);
+    HPX_TEST(result == iterator(std::end(c)));
+
+    // verify values
+    std::size_t count = 0;
+    std::for_each(std::begin(c), std::end(c), [&count](std::size_t v) -> void {
+        HPX_TEST_EQ(v, std::size_t(42));
+        ++count;
+    });
+    HPX_TEST_EQ(count, c.size());
+}
+
+template <typename Policy, typename ExPolicy, typename IteratorTag>
+void test_for_each_execute_on(Policy l, ExPolicy&& policy, IteratorTag)
+{
+    using base_iterator = std::vector<std::size_t>::iterator;
+    using iterator = test::test_iterator<base_iterator, IteratorTag>;
+
+    std::vector<std::size_t> c(10007);
+    std::iota(std::begin(c), std::end(c), std::rand());
+
+    namespace ex = hpx::execution::experimental;
+
+    auto f = [](std::size_t& v) { v = 42; };
+
+    using scheduler_t = ex::thread_pool_policy_scheduler<Policy>;
+
+    auto result = hpx::for_each(
+        ex::execute_on(scheduler_t(l), std::forward<ExPolicy>(policy)),
+        iterator(std::begin(c)), iterator(std::end(c)), f);
+    HPX_TEST(result == iterator(std::end(c)));
+
+    // verify values
+    std::size_t count = 0;
+    std::for_each(std::begin(c), std::end(c), [&count](std::size_t v) -> void {
+        HPX_TEST_EQ(v, std::size_t(42));
+        ++count;
+    });
+    HPX_TEST_EQ(count, c.size());
+}
+
+template <typename Policy, typename ExPolicy, typename IteratorTag>
+void test_for_each_execute_on_async(Policy l, ExPolicy&& policy, IteratorTag)
+{
+    using base_iterator = std::vector<std::size_t>::iterator;
+    using iterator = test::test_iterator<base_iterator, IteratorTag>;
+
+    std::vector<std::size_t> c(10007);
+    std::iota(std::begin(c), std::end(c), std::rand());
+
+    namespace ex = hpx::execution::experimental;
+    namespace tt = hpx::this_thread::experimental;
+
+    auto f = [](std::size_t& v) { v = 42; };
+
+    using scheduler_t = ex::thread_pool_policy_scheduler<Policy>;
+
+    auto result = hpx::for_each(ex::execute_on(scheduler_t(l),
+                                    std::forward<ExPolicy>(policy)),
+                      iterator(std::begin(c)), iterator(std::end(c)), f) |
+        tt::sync_wait();
+    HPX_TEST(hpx::get<0>(*result) == iterator(std::end(c)));
+
+    // verify values
+    std::size_t count = 0;
+    std::for_each(std::begin(c), std::end(c), [&count](std::size_t v) -> void {
+        HPX_TEST_EQ(v, std::size_t(42));
+        ++count;
+    });
+    HPX_TEST_EQ(count, c.size());
+}
+
+///////////////////////////////////////////////////////////////////////////////
+template <typename Policy, typename ExPolicy, typename IteratorTag>
+void test_for_each_execute_on_sender(Policy l, ExPolicy&& policy, IteratorTag)
+{
+    static_assert(hpx::is_async_execution_policy_v<ExPolicy>,
+        "hpx::is_async_execution_policy_v<ExPolicy>");
+
+    using base_iterator = std::vector<std::size_t>::iterator;
+    using iterator = test::test_iterator<base_iterator, IteratorTag>;
+
+    std::vector<std::size_t> c(10007);
+    std::iota(std::begin(c), std::end(c), std::rand());
+
+    namespace ex = hpx::execution::experimental;
+    namespace tt = hpx::this_thread::experimental;
+
+    auto f = [](std::size_t& v) { v = 42; };
+
+    using scheduler_t = ex::thread_pool_policy_scheduler<Policy>;
+
+    auto result = ex::just(iterator(std::begin(c)), iterator(std::end(c)), f) |
+        hpx::for_each(
+            ex::execute_on(scheduler_t(l), std::forward<ExPolicy>(policy))) |
+        tt::sync_wait();
+    HPX_TEST(hpx::get<0>(*result) == iterator(std::end(c)));
+
+    // verify values
+    std::size_t count = 0;
+    std::for_each(std::begin(c), std::end(c), [&count](std::size_t v) -> void {
+        HPX_TEST_EQ(v, std::size_t(42));
+        ++count;
+    });
+    HPX_TEST_EQ(count, c.size());
+}
+
+template <typename IteratorTag>
+void test_for_each_scheduler()
+{
+    using namespace hpx::execution;
+
+    test_for_each_explicit_scheduler(hpx::launch::sync, IteratorTag());
+    test_for_each_explicit_scheduler(hpx::launch::async, IteratorTag());
+}
+
+template <typename IteratorTag>
+void test_for_each_executeon()
+{
+    using namespace hpx::execution;
+
+    test_for_each_execute_on(hpx::launch::sync, seq, IteratorTag());
+    test_for_each_execute_on(hpx::launch::sync, unseq, IteratorTag());
+    test_for_each_execute_on(hpx::launch::async, par, IteratorTag());
+    test_for_each_execute_on(hpx::launch::async, par_unseq, IteratorTag());
+
+    test_for_each_execute_on_async(hpx::launch::sync, seq(task), IteratorTag());
+    test_for_each_execute_on_async(
+        hpx::launch::sync, unseq(task), IteratorTag());
+    test_for_each_execute_on_async(
+        hpx::launch::async, par(task), IteratorTag());
+    test_for_each_execute_on_async(
+        hpx::launch::async, par_unseq(task), IteratorTag());
+}
+
+template <typename IteratorTag>
+void test_for_each_execute_on_sender()
+{
+    using namespace hpx::execution;
+
+    test_for_each_execute_on_sender(
+        hpx::launch::sync, seq(task), IteratorTag());
+    test_for_each_execute_on_sender(
+        hpx::launch::sync, unseq(task), IteratorTag());
+    test_for_each_execute_on_sender(
+        hpx::launch::async, par(task), IteratorTag());
+    test_for_each_execute_on_sender(
+        hpx::launch::async, par_unseq(task), IteratorTag());
+}
+
+void for_each_sender_test_direct()
+{
+    test_for_each_scheduler<std::random_access_iterator_tag>();
+    test_for_each_scheduler<std::forward_iterator_tag>();
+}
+
+void for_each_test_execute_on()
+{
+    test_for_each_executeon<std::random_access_iterator_tag>();
+    test_for_each_executeon<std::forward_iterator_tag>();
+}
+
+void for_each_test_execute_on_sender()
+{
+    test_for_each_execute_on_sender<std::random_access_iterator_tag>();
+    test_for_each_execute_on_sender<std::forward_iterator_tag>();
+}
+
+///////////////////////////////////////////////////////////////////////////////
+int hpx_main(hpx::program_options::variables_map& vm)
+{
+    unsigned int seed = (unsigned int) std::time(nullptr);
+    if (vm.count("seed"))
+        seed = vm["seed"].as<unsigned int>();
+
+    std::cout << "using seed: " << seed << std::endl;
+    std::srand(seed);
+
+    for_each_sender_test_direct();
+    for_each_test_execute_on();
+    for_each_test_execute_on_sender();
+
+    return hpx::local::finalize();
+}
+
+int main(int argc, char* argv[])
+{
+    // add command line option which controls the random number generator seed
+    using namespace hpx::program_options;
+    options_description desc_commandline(
+        "Usage: " HPX_APPLICATION_STRING " [options]");
+
+    desc_commandline.add_options()("seed,s", value<unsigned int>(),
+        "the random number generator seed to use for this run");
+
+    // By default this test should run on all available cores
+    std::vector<std::string> const cfg = {"hpx.os_threads=all"};
+
+    // Initialize and run HPX
+    hpx::local::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::local::init(hpx_main, argc, argv, init_args), 0,
+        "HPX main exited with non-zero status");
+
+    return hpx::util::report_errors();
+}

--- a/libs/core/execution_base/include/hpx/execution_base/sender.hpp
+++ b/libs/core/execution_base/include/hpx/execution_base/sender.hpp
@@ -167,9 +167,11 @@ namespace hpx { namespace execution { namespace experimental {
     // clang-format off
     template <typename Scheduler>
     struct is_scheduler<Scheduler,
-        std::enable_if_t<hpx::is_invocable_v<schedule_t, Scheduler> &&
-            std::is_copy_constructible_v<Scheduler> &&
-            hpx::traits::is_equality_comparable_v<Scheduler>>> : std::true_type
+        std::enable_if_t<
+            hpx::is_invocable_v<schedule_t, std::decay_t<Scheduler>> &&
+            std::is_copy_constructible_v<std::decay_t<Scheduler>> &&
+            hpx::traits::is_equality_comparable_v<std::decay_t<Scheduler>>>>
+      : std::true_type
     {
     };
     // clang-format on

--- a/libs/core/executors/CMakeLists.txt
+++ b/libs/core/executors/CMakeLists.txt
@@ -15,6 +15,7 @@ set(executors_headers
     hpx/executors/async.hpp
     hpx/executors/dataflow.hpp
     hpx/executors/detail/hierarchical_spawning.hpp
+    hpx/executors/execute_on.hpp
     hpx/executors/exception_list.hpp
     hpx/executors/execution_policy_annotation.hpp
     hpx/executors/execution_policy_fwd.hpp

--- a/libs/core/executors/include/hpx/executors/execute_on.hpp
+++ b/libs/core/executors/include/hpx/executors/execute_on.hpp
@@ -1,0 +1,135 @@
+//  Copyright (c) 2022 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include <hpx/config.hpp>
+#include <hpx/concepts/concepts.hpp>
+#include <hpx/concepts/has_member_xxx.hpp>
+#include <hpx/execution_base/sender.hpp>
+#include <hpx/executors/execution_policy.hpp>
+#include <hpx/executors/explicit_scheduler_executor.hpp>
+#include <hpx/functional/detail/tag_fallback_invoke.hpp>
+
+#include <type_traits>
+#include <utility>
+
+namespace hpx::execution::experimental {
+
+    namespace detail {
+
+        template <typename Scheduler, typename Enable = void>
+        struct exposes_policy_aware_scheduler_types : std::false_type
+        {
+        };
+
+        template <typename Scheduler>
+        struct exposes_policy_aware_scheduler_types<Scheduler,
+            std::void_t<typename Scheduler::policy_type,
+                typename Scheduler::base_scheduler_type>> : std::true_type
+        {
+        };
+
+        template <typename Scheduler, typename Enable = void>
+        struct exposes_get_policy : std::false_type
+        {
+        };
+
+        template <typename Scheduler>
+        struct exposes_get_policy<Scheduler,
+            std::enable_if_t<hpx::is_execution_policy_v<decltype(
+                std::declval<Scheduler>().get_policy())>>> : std::true_type
+        {
+        };
+    }    // namespace detail
+
+    ///////////////////////////////////////////////////////////////////////////
+    template <typename Scheduler, typename ExPolicy>
+    struct scheduler_and_policy : std::decay_t<Scheduler>
+    {
+        using base_scheduler_type = std::decay_t<Scheduler>;
+        using policy_type = std::decay_t<ExPolicy>;
+
+        template <typename Scheduler_, typename ExPolicy_>
+        scheduler_and_policy(Scheduler_&& sched, ExPolicy_&& policy)
+          : base_scheduler_type(HPX_FORWARD(Scheduler_, sched))
+          , policy(HPX_FORWARD(ExPolicy_, policy))
+        {
+        }
+
+        policy_type const& get_policy() const
+        {
+            return policy;
+        }
+
+        policy_type policy;
+    };
+
+    // different versions of clang-format disagree
+    // clang-format off
+    template <typename Scheduler, typename ExPolicy>
+    scheduler_and_policy(Scheduler&&, ExPolicy&&)
+        -> scheduler_and_policy<std::decay_t<Scheduler>,
+            std::decay_t<ExPolicy>>;
+    // clang-format on
+
+    // Experimental support for facilities from p2500 (wg21.link/p2500)
+    inline namespace p2500 {
+
+        ///////////////////////////////////////////////////////////////////////
+        // policy_aware_scheduler is a concept for parallel algorithms that
+        // represents a combined scheduler and execution_policy entity. It
+        // allows to get both execution policy type and execution policy object
+        // parallel algorithm is called with.
+        //
+        // Customizations of the parallel algorithms can reuse the existing
+        // implementation of parallel algorithms with ExecutionPolicy template
+        // parameter for "known" base_scheduler_type type.
+        template <typename Scheduler, typename Enable = void>
+        struct is_policy_aware_scheduler : std::false_type
+        {
+        };
+
+        template <typename Scheduler>
+        struct is_policy_aware_scheduler<Scheduler,
+            std::enable_if_t<is_scheduler_v<Scheduler> &&
+                detail::exposes_policy_aware_scheduler_types<
+                    std::decay_t<Scheduler>>::value &&
+                detail::exposes_get_policy<Scheduler>::value>> : std::true_type
+        {
+        };
+
+        template <typename Scheduler>
+        inline constexpr bool is_policy_aware_scheduler_v =
+            is_policy_aware_scheduler<Scheduler>::value;
+
+        ///////////////////////////////////////////////////////////////////////
+        // execute_on is the customization point that serves the purpose to tie
+        // scheduler and execution_policy.
+        //
+        // It's up to scheduler customization to check if it can work with the
+        // passed execution policy.
+        inline constexpr struct execute_on_t final
+          : hpx::functional::detail::tag_fallback<execute_on_t>
+        {
+        private:
+            // clang-format off
+            template <typename Scheduler, typename ExPolicy,
+                HPX_CONCEPT_REQUIRES_(
+                    hpx::execution::experimental::is_scheduler_v<
+                        std::decay_t<Scheduler>> &&
+                    hpx::is_execution_policy_v<ExPolicy>
+                )>
+            // clang-format on
+            friend constexpr HPX_FORCEINLINE auto tag_fallback_invoke(
+                execute_on_t, Scheduler&& scheduler, ExPolicy&& policy)
+            {
+                return scheduler_and_policy(HPX_FORWARD(Scheduler, scheduler),
+                    HPX_FORWARD(ExPolicy, policy));
+            }
+        } execute_on{};
+    }    // namespace p2500
+}    // namespace hpx::execution::experimental


### PR DESCRIPTION
This PR adds the facilities that are proposed by [P2690](http://wg21.link/p2690). It also adds default implementations for all of our algorithms.

Coincidentally, this goes beyond P2690 as it also enables asynchronous invocations of the algorithms using the new facilities. Here are a couple of examples:
```
// synchronous parallel invocation
hpx::for_each(scheduler_t(), std::begin(c), std::end(c), f);

// synchronous invocation using hpx::execution::par
hpx::for_each(ex::execute_on(scheduler_t(), hpx::execution::par), std::begin(c), std::end(c), f);

// asynchronous invocation using hpx::execution::par
hpx::for_each(
    ex::execute_on(scheduler_t(), hpx::execution::par(hpx::execution::task)), std::begin(c), std::end(c), f) | 
tt::sync_wait();

// asynchronous invocation using hpx::execution::par as part of a S/R chain
ex::just(std::begin(c), std::end(c), f) |
    hpx::for_each(
        ex::execute_on(scheduler_t(), hpx::execution::par(hpx::execution::task))) |
    tt::sync_wait();
```