### PR TITLE
Making default constructor of hpx::mutex constexpr

### DIFF
--- a/libs/core/algorithms/tests/unit/container_algorithms/foreach_tests.hpp
+++ b/libs/core/algorithms/tests/unit/container_algorithms/foreach_tests.hpp
@@ -62,7 +62,7 @@ void test_for_each_seq(IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_for_each(ExPolicy&& policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::is_execution_policy<ExPolicy>::value);
+    static_assert(hpx::is_execution_policy<ExPolicy>::value);
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -155,7 +155,7 @@ void test_for_each_exception_seq(IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_for_each_exception(ExPolicy&& policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::is_execution_policy<ExPolicy>::value);
+    static_assert(hpx::is_execution_policy<ExPolicy>::value);
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -268,7 +268,7 @@ void test_for_each_bad_alloc_seq(IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_for_each_bad_alloc(ExPolicy&& policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(hpx::is_execution_policy<ExPolicy>::value);
+    static_assert(hpx::is_execution_policy<ExPolicy>::value);
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;

--- a/libs/core/algorithms/tests/unit/container_algorithms/foreach_tests_projection.hpp
+++ b/libs/core/algorithms/tests/unit/container_algorithms/foreach_tests_projection.hpp
@@ -55,7 +55,7 @@ void test_for_each_seq(IteratorTag, Proj&& proj)
 template <typename ExPolicy, typename IteratorTag, typename Proj>
 void test_for_each(ExPolicy&& policy, IteratorTag, Proj&& proj)
 {
-    BOOST_STATIC_ASSERT(hpx::is_execution_policy<ExPolicy>::value);
+    static_assert(hpx::is_execution_policy<ExPolicy>::value);
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -151,7 +151,7 @@ void test_for_each_exception_seq(IteratorTag, Proj&& proj)
 template <typename ExPolicy, typename IteratorTag, typename Proj>
 void test_for_each_exception(ExPolicy policy, IteratorTag, Proj&& proj)
 {
-    BOOST_STATIC_ASSERT(hpx::is_execution_policy<ExPolicy>::value);
+    static_assert(hpx::is_execution_policy<ExPolicy>::value);
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -266,7 +266,7 @@ void test_for_each_bad_alloc_seq(IteratorTag, Proj&& proj)
 template <typename ExPolicy, typename IteratorTag, typename Proj>
 void test_for_each_bad_alloc(ExPolicy policy, IteratorTag, Proj&& proj)
 {
-    BOOST_STATIC_ASSERT(hpx::is_execution_policy<ExPolicy>::value);
+    static_assert(hpx::is_execution_policy<ExPolicy>::value);
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;

--- a/libs/core/concurrency/include/hpx/concurrency/cache_line_data.hpp
+++ b/libs/core/concurrency/include/hpx/concurrency/cache_line_data.hpp
@@ -71,9 +71,10 @@ namespace hpx {
             typename NeedsPadding = typename detail::needs_padding<Data>::type>
         struct cache_aligned_data
         {
-            // We have an explicit (non-default) constructor here to avoid for
-            // the entire cache-line to be initialized by the compiler.
-            cache_aligned_data()
+            // We have an explicit (default) constructor here to avoid for the
+            // entire cache-line to be initialized by the compiler.
+            constexpr cache_aligned_data() noexcept(
+                std::is_nothrow_default_constructible_v<Data>)
               : data_()
             {
             }
@@ -122,9 +123,10 @@ namespace hpx {
             typename NeedsPadding = typename detail::needs_padding<Data>::type>
         struct cache_aligned_data_derived : Data
         {
-            // We have an explicit (non-default) constructor here to avoid for
-            // the entire cache-line to be initialized by the compiler.
-            cache_aligned_data_derived()
+            // We have an explicit (default) constructor here to avoid for the
+            // entire cache-line to be initialized by the compiler.
+            constexpr cache_aligned_data_derived() noexcept(
+                std::is_nothrow_default_constructible_v<Data>)
               : Data()
             {
             }

--- a/libs/core/config/include/hpx/config/constexpr.hpp
+++ b/libs/core/config/include/hpx/config/constexpr.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2013 Hartmut Kaiser
+//  Copyright (c) 2013-2022 Hartmut Kaiser
 //  Copyright (c) 2015 Thomas Heller
 //
 //  SPDX-License-Identifier: BSL-1.0
@@ -18,4 +18,12 @@
 #define HPX_HOST_DEVICE_INLINE_CONSTEXPR_VARIABLE HPX_DEVICE static const
 #else
 #define HPX_HOST_DEVICE_INLINE_CONSTEXPR_VARIABLE inline constexpr
+#endif
+
+/// This macro evaluates to ``constexpr`` for host code and expands nothing for
+/// NVCC
+#if defined(__NVCC__)
+#define HPX_HOST_DEVICE_CONSTEXPR
+#else
+#define HPX_HOST_DEVICE_CONSTEXPR constexpr
 #endif

--- a/libs/core/datastructures/CMakeLists.txt
+++ b/libs/core/datastructures/CMakeLists.txt
@@ -46,6 +46,7 @@ endif()
 set(datastructures_headers
     hpx/datastructures/any.hpp
     hpx/datastructures/detail/dynamic_bitset.hpp
+    hpx/datastructures/detail/intrusive_list.hpp
     hpx/datastructures/detail/small_vector.hpp
     hpx/datastructures/detail/optional.hpp
     hpx/datastructures/detail/variant.hpp

--- a/libs/core/datastructures/include/hpx/datastructures/detail/intrusive_list.hpp
+++ b/libs/core/datastructures/include/hpx/datastructures/detail/intrusive_list.hpp
@@ -1,0 +1,175 @@
+//  Copyright (c) 2022 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+// See http://www.boost.org/libs/intrusive for documentation.
+
+#pragma once
+
+#include <hpx/config.hpp>
+#include <hpx/assert.hpp>
+
+#include <cstddef>
+#include <utility>
+
+namespace hpx::detail {
+
+    template <typename Entry>
+    class intrusive_list
+    {
+    public:
+        constexpr intrusive_list() noexcept = default;
+
+        intrusive_list(intrusive_list const&) = delete;
+        intrusive_list& operator=(intrusive_list const&) = delete;
+
+        intrusive_list(intrusive_list&&) = default;
+        intrusive_list& operator=(intrusive_list&&) = default;
+
+        void push_back(Entry& e) noexcept
+        {
+            if (last_entry == nullptr)
+            {
+                HPX_ASSERT(num_entries == 0);
+                HPX_ASSERT(root == nullptr);
+
+                e.prev = nullptr;
+                e.next = nullptr;
+
+                root = &e;
+                last_entry = &e;
+            }
+            else
+            {
+                HPX_ASSERT(num_entries != 0);
+                HPX_ASSERT(root != nullptr);
+
+                e.prev = last_entry;
+                e.next = nullptr;
+
+                last_entry->next = &e;
+                last_entry = &e;
+            }
+            ++num_entries;
+        }
+
+        void pop_front() noexcept
+        {
+            HPX_ASSERT(num_entries != 0);
+
+            --num_entries;
+            if (root->next != nullptr)
+            {
+                root->next->prev = nullptr;
+            }
+            else
+            {
+                last_entry = nullptr;
+            }
+            root = root->next;
+        }
+
+        void splice(intrusive_list& queue) noexcept
+        {
+            Entry* start = queue.front();
+            Entry* end = queue.back();
+
+            if (start != nullptr)
+            {
+                start->prev = last_entry;
+            }
+
+            if (last_entry != nullptr)
+            {
+                last_entry->next = start;
+                if (end != nullptr)
+                {
+                    last_entry = end;
+                }
+            }
+            else
+            {
+                root = start;
+                last_entry = end;
+            }
+
+            num_entries += queue.size();
+
+            queue.reset();
+        }
+
+        void erase(Entry const* e) noexcept
+        {
+            HPX_ASSERT(num_entries != 0);
+            HPX_ASSERT(e != nullptr);
+
+            --num_entries;
+            if (e->next != nullptr)
+            {
+                e->next->prev = e->prev;
+            }
+            else
+            {
+                last_entry = e->prev;
+            }
+
+            if (e->prev != nullptr)
+            {
+                e->prev->next = e->next;
+            }
+            else
+            {
+                root = e->next;
+            }
+        }
+
+        void reset() noexcept
+        {
+            num_entries = 0;
+            root = nullptr;
+            last_entry = nullptr;
+        }
+
+        Entry* front() noexcept
+        {
+            return root;
+        }
+        constexpr Entry const* front() const noexcept
+        {
+            return root;
+        }
+
+        Entry* back() noexcept
+        {
+            return last_entry;
+        }
+        constexpr Entry const* back() const noexcept
+        {
+            return last_entry;
+        }
+
+        constexpr std::size_t size() const noexcept
+        {
+            return num_entries;
+        }
+
+        constexpr bool empty() const noexcept
+        {
+            return num_entries == 0;
+        }
+
+        void swap(intrusive_list& rhs) noexcept
+        {
+            std::swap(num_entries, rhs.num_entries);
+            std::swap(root, rhs.root);
+            std::swap(last_entry, rhs.last_entry);
+        }
+
+    private:
+        std::size_t num_entries = 0;
+        Entry* root = nullptr;
+        Entry* last_entry = nullptr;
+    };
+}    // namespace hpx::detail

--- a/libs/core/datastructures/tests/unit/CMakeLists.txt
+++ b/libs/core/datastructures/tests/unit/CMakeLists.txt
@@ -13,6 +13,7 @@ set(tests
     dynamic_bitset3
     dynamic_bitset4
     dynamic_bitset5
+    intrusive_list
     is_tuple_like
     serializable_any
     serializable_boost_any

--- a/libs/core/datastructures/tests/unit/intrusive_list.cpp
+++ b/libs/core/datastructures/tests/unit/intrusive_list.cpp
@@ -1,0 +1,446 @@
+//  Copyright (c) 2022 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/datastructures/detail/intrusive_list.hpp>
+#include <hpx/modules/testing.hpp>
+
+#include <cstddef>
+
+struct entry
+{
+    int value;
+
+    entry* next = nullptr;
+    entry* prev = nullptr;
+};
+
+void test_default_constructed()
+{
+    hpx::detail::intrusive_list<entry> list;
+
+    HPX_TEST_EQ(list.size(), std::size_t(0));
+    HPX_TEST(list.empty());
+
+    HPX_TEST(list.front() == nullptr);
+    HPX_TEST(list.back() == nullptr);
+}
+
+void test_default_constructed_splice()
+{
+    hpx::detail::intrusive_list<entry> list1;
+    hpx::detail::intrusive_list<entry> list2;
+
+    list1.splice(list2);
+
+    HPX_TEST_EQ(list1.size(), std::size_t(0));
+    HPX_TEST(list1.empty());
+
+    HPX_TEST(list1.front() == nullptr);
+    HPX_TEST(list1.back() == nullptr);
+}
+
+void test_one_element()
+{
+    hpx::detail::intrusive_list<entry> list;
+    entry e1{1};
+
+    list.push_back(e1);
+
+    HPX_TEST_EQ(e1.value, 1);
+    HPX_TEST(e1.prev == nullptr);
+    HPX_TEST(e1.next == nullptr);
+
+    HPX_TEST_EQ(list.size(), std::size_t(1));
+    HPX_TEST(!list.empty());
+
+    HPX_TEST(list.front() == &e1);
+    HPX_TEST(list.back() == &e1);
+
+    list.pop_front();
+
+    HPX_TEST_EQ(list.size(), std::size_t(0));
+    HPX_TEST(list.empty());
+
+    HPX_TEST(list.front() == nullptr);
+    HPX_TEST(list.back() == nullptr);
+}
+
+void test_one_element_erase()
+{
+    hpx::detail::intrusive_list<entry> list;
+    entry e1{1};
+
+    list.push_back(e1);
+
+    HPX_TEST_EQ(e1.value, 1);
+    HPX_TEST(e1.prev == nullptr);
+    HPX_TEST(e1.next == nullptr);
+
+    HPX_TEST_EQ(list.size(), std::size_t(1));
+    HPX_TEST(!list.empty());
+
+    HPX_TEST(list.front() == &e1);
+    HPX_TEST(list.back() == &e1);
+
+    list.erase(&e1);
+
+    HPX_TEST_EQ(list.size(), std::size_t(0));
+    HPX_TEST(list.empty());
+
+    HPX_TEST(list.front() == nullptr);
+    HPX_TEST(list.back() == nullptr);
+}
+
+void test_two_elements()
+{
+    hpx::detail::intrusive_list<entry> list;
+    entry e1{1};
+    entry e2{2};
+
+    // add two entries
+    list.push_back(e1);
+    list.push_back(e2);
+
+    HPX_TEST_EQ(e1.value, 1);
+    HPX_TEST(e1.prev == nullptr);
+    HPX_TEST(e1.next == &e2);
+
+    HPX_TEST_EQ(e2.value, 2);
+    HPX_TEST(e2.prev == &e1);
+    HPX_TEST(e2.next == nullptr);
+
+    HPX_TEST_EQ(list.size(), std::size_t(2));
+    HPX_TEST(!list.empty());
+
+    HPX_TEST(list.front() == &e1);
+    HPX_TEST(list.back() == &e2);
+
+    // remove e1
+    list.pop_front();
+
+    HPX_TEST_EQ(list.size(), std::size_t(1));
+    HPX_TEST(!list.empty());
+
+    HPX_TEST(list.front() == &e2);
+    HPX_TEST(list.back() == &e2);
+
+    HPX_TEST_EQ(e2.value, 2);
+    HPX_TEST(e2.prev == nullptr);
+    HPX_TEST(e2.next == nullptr);
+
+    // remove e2
+    list.pop_front();
+
+    HPX_TEST_EQ(list.size(), std::size_t(0));
+    HPX_TEST(list.empty());
+
+    HPX_TEST(list.front() == nullptr);
+    HPX_TEST(list.back() == nullptr);
+}
+
+void test_two_elements_erase()
+{
+    hpx::detail::intrusive_list<entry> list;
+    entry e1{1};
+    entry e2{2};
+
+    // add two entries
+    list.push_back(e1);
+    list.push_back(e2);
+
+    HPX_TEST_EQ(e1.value, 1);
+    HPX_TEST(e1.prev == nullptr);
+    HPX_TEST(e1.next == &e2);
+
+    HPX_TEST_EQ(e2.value, 2);
+    HPX_TEST(e2.prev == &e1);
+    HPX_TEST(e2.next == nullptr);
+
+    HPX_TEST_EQ(list.size(), std::size_t(2));
+    HPX_TEST(!list.empty());
+
+    HPX_TEST(list.front() == &e1);
+    HPX_TEST(list.back() == &e2);
+
+    // remove e1
+    list.erase(&e1);
+
+    HPX_TEST_EQ(list.size(), std::size_t(1));
+    HPX_TEST(!list.empty());
+
+    HPX_TEST(list.front() == &e2);
+    HPX_TEST(list.back() == &e2);
+
+    HPX_TEST_EQ(e2.value, 2);
+    HPX_TEST(e2.prev == nullptr);
+    HPX_TEST(e2.next == nullptr);
+
+    // remove e2
+    list.erase(&e2);
+
+    HPX_TEST_EQ(list.size(), std::size_t(0));
+    HPX_TEST(list.empty());
+
+    HPX_TEST(list.front() == nullptr);
+    HPX_TEST(list.back() == nullptr);
+}
+
+void test_two_elements_erase_reverse()
+{
+    hpx::detail::intrusive_list<entry> list;
+    entry e1{1};
+    entry e2{2};
+
+    // add two entries
+    list.push_back(e1);
+    list.push_back(e2);
+
+    HPX_TEST_EQ(e1.value, 1);
+    HPX_TEST(e1.prev == nullptr);
+    HPX_TEST(e1.next == &e2);
+
+    HPX_TEST_EQ(e2.value, 2);
+    HPX_TEST(e2.prev == &e1);
+    HPX_TEST(e2.next == nullptr);
+
+    HPX_TEST_EQ(list.size(), std::size_t(2));
+    HPX_TEST(!list.empty());
+
+    HPX_TEST(list.front() == &e1);
+    HPX_TEST(list.back() == &e2);
+
+    // remove e2
+    list.erase(&e2);
+
+    HPX_TEST_EQ(list.size(), std::size_t(1));
+    HPX_TEST(!list.empty());
+
+    HPX_TEST(list.front() == &e1);
+    HPX_TEST(list.back() == &e1);
+
+    HPX_TEST_EQ(e1.value, 1);
+    HPX_TEST(e1.prev == nullptr);
+    HPX_TEST(e1.next == nullptr);
+
+    // remove e1
+    list.erase(&e1);
+
+    HPX_TEST_EQ(list.size(), std::size_t(0));
+    HPX_TEST(list.empty());
+
+    HPX_TEST(list.front() == nullptr);
+    HPX_TEST(list.back() == nullptr);
+}
+
+void test_three_elements_iterate()
+{
+    hpx::detail::intrusive_list<entry> list;
+    entry e1{1};
+    entry e2{2};
+    entry e3{3};
+
+    // add three entries
+    list.push_back(e1);
+    list.push_back(e2);
+    list.push_back(e3);
+
+    HPX_TEST_EQ(e1.value, 1);
+    HPX_TEST(e1.prev == nullptr);
+    HPX_TEST(e1.next == &e2);
+
+    HPX_TEST_EQ(e2.value, 2);
+    HPX_TEST(e2.prev == &e1);
+    HPX_TEST(e2.next == &e3);
+
+    HPX_TEST_EQ(e3.value, 3);
+    HPX_TEST(e3.prev == &e2);
+    HPX_TEST(e3.next == nullptr);
+
+    HPX_TEST_EQ(list.size(), std::size_t(3));
+    HPX_TEST(!list.empty());
+
+    HPX_TEST(list.front() == &e1);
+    HPX_TEST(list.back() == &e3);
+
+    // iterate
+    int i = 1;
+    for (entry* qe = list.front(); qe != nullptr; qe = qe->next, ++i)
+    {
+        HPX_TEST_EQ(qe->value, i);
+    }
+    HPX_TEST_EQ(i, 4);
+
+    i = 3;
+    for (entry* qe = list.back(); qe != nullptr; qe = qe->prev, --i)
+    {
+        HPX_TEST_EQ(qe->value, i);
+    }
+    HPX_TEST_EQ(i, 0);
+
+    // remove e2
+    list.erase(&e2);
+
+    HPX_TEST_EQ(list.size(), std::size_t(2));
+    HPX_TEST(!list.empty());
+
+    HPX_TEST(list.front() == &e1);
+    HPX_TEST(list.back() == &e3);
+}
+
+void test_three_elements_swap()
+{
+    hpx::detail::intrusive_list<entry> list1;
+    entry e1{1};
+    entry e2{2};
+    entry e3{3};
+
+    // add entries
+    list1.push_back(e1);
+    list1.push_back(e2);
+    list1.push_back(e3);
+
+    hpx::detail::intrusive_list<entry> list2;
+    entry e4{4};
+    entry e5{5};
+
+    list2.push_back(e4);
+    list2.push_back(e5);
+
+    list1.swap(list2);
+
+    HPX_TEST_EQ(list1.size(), std::size_t(2));
+    HPX_TEST_EQ(list2.size(), std::size_t(3));
+
+    // iterate
+    int i = 1;
+    for (entry* qe = list2.front(); qe != nullptr; qe = qe->next, ++i)
+    {
+        HPX_TEST_EQ(qe->value, i);
+    }
+    HPX_TEST_EQ(i, 4);
+
+    for (entry* qe = list1.front(); qe != nullptr; qe = qe->next, ++i)
+    {
+        HPX_TEST_EQ(qe->value, i);
+    }
+    HPX_TEST_EQ(i, 6);
+}
+
+void test_three_elements_splice()
+{
+    hpx::detail::intrusive_list<entry> list1;
+    entry e1{1};
+    entry e2{2};
+    entry e3{3};
+
+    // add entries
+    list1.push_back(e1);
+    list1.push_back(e2);
+    list1.push_back(e3);
+
+    hpx::detail::intrusive_list<entry> list2;
+    entry e4{4};
+    entry e5{5};
+
+    list2.push_back(e4);
+    list2.push_back(e5);
+
+    list1.splice(list2);
+
+    HPX_TEST_EQ(list1.size(), std::size_t(5));
+    HPX_TEST_EQ(list2.size(), std::size_t(0));
+
+    // iterate
+    int i = 1;
+    for (entry* qe = list1.front(); qe != nullptr; qe = qe->next, ++i)
+    {
+        HPX_TEST_EQ(qe->value, i);
+    }
+    HPX_TEST_EQ(i, 6);
+
+    i = 5;
+    for (entry* qe = list1.back(); qe != nullptr; qe = qe->prev, --i)
+    {
+        HPX_TEST_EQ(qe->value, i);
+    }
+    HPX_TEST_EQ(i, 0);
+}
+
+void test_three_elements_empty_splice()
+{
+    hpx::detail::intrusive_list<entry> list1;
+    entry e1{1};
+    entry e2{2};
+    entry e3{3};
+
+    // add entries
+    list1.push_back(e1);
+    list1.push_back(e2);
+    list1.push_back(e3);
+
+    hpx::detail::intrusive_list<entry> list2;
+
+    list1.splice(list2);
+
+    HPX_TEST_EQ(list1.size(), std::size_t(3));
+    HPX_TEST(!list1.empty());
+
+    HPX_TEST(list1.front() == &e1);
+    HPX_TEST(list1.back() == &e3);
+
+    HPX_TEST_EQ(list2.size(), std::size_t(0));
+    HPX_TEST(list2.empty());
+
+    HPX_TEST(list2.front() == nullptr);
+    HPX_TEST(list2.back() == nullptr);
+}
+
+void test_three_elements_splice_empty()
+{
+    hpx::detail::intrusive_list<entry> list1;
+    entry e1{1};
+    entry e2{2};
+    entry e3{3};
+
+    // add entries
+    list1.push_back(e1);
+    list1.push_back(e2);
+    list1.push_back(e3);
+
+    hpx::detail::intrusive_list<entry> list2;
+
+    list2.splice(list1);
+
+    HPX_TEST_EQ(list1.size(), std::size_t(0));
+    HPX_TEST(list1.empty());
+
+    HPX_TEST(list1.front() == nullptr);
+    HPX_TEST(list1.back() == nullptr);
+
+    HPX_TEST_EQ(list2.size(), std::size_t(3));
+    HPX_TEST(!list2.empty());
+
+    HPX_TEST(list2.front() == &e1);
+    HPX_TEST(list2.back() == &e3);
+}
+
+int main()
+{
+    test_default_constructed();
+    test_default_constructed_splice();
+    test_one_element();
+    test_one_element_erase();
+    test_two_elements();
+    test_two_elements_erase();
+    test_two_elements_erase_reverse();
+    test_three_elements_iterate();
+    test_three_elements_swap();
+    test_three_elements_splice();
+    test_three_elements_empty_splice();
+    test_three_elements_splice_empty();
+
+    return hpx::util::report_errors();
+}

--- a/libs/core/synchronization/include/hpx/synchronization/mutex.hpp
+++ b/libs/core/synchronization/include/hpx/synchronization/mutex.hpp
@@ -80,10 +80,10 @@ namespace hpx {
         ///
         /// \param description description of the \a mutex.
         ///
-#if HPX_HAVE_ITTNOTIFY != 0
+#if defined(HPX_HAVE_ITTNOTIFY)
         HPX_CORE_EXPORT mutex(char const* const description = "");
 #else
-        constexpr mutex(char const* const description = "") noexcept
+        HPX_HOST_DEVICE_CONSTEXPR mutex(char const* const = "") noexcept
           : owner_id_(threads::invalid_thread_id)
         {
         }

--- a/libs/core/synchronization/include/hpx/synchronization/mutex.hpp
+++ b/libs/core/synchronization/include/hpx/synchronization/mutex.hpp
@@ -80,7 +80,14 @@ namespace hpx {
         ///
         /// \param description description of the \a mutex.
         ///
+#if HPX_HAVE_ITTNOTIFY != 0
         HPX_CORE_EXPORT mutex(char const* const description = "");
+#else
+        constexpr mutex(char const* const description = "") noexcept
+          : owner_id_(threads::invalid_thread_id)
+        {
+        }
+#endif
 
         ///
         /// \brief Destroys the \a mutex.

--- a/libs/core/synchronization/include/hpx/synchronization/spinlock.hpp
+++ b/libs/core/synchronization/include/hpx/synchronization/spinlock.hpp
@@ -46,6 +46,7 @@ namespace hpx {
             std::atomic<bool> v_;
 
         public:
+#if defined(HPX_HAVE_ITTNOTIFY)
             spinlock() noexcept
               : v_(false)
             {
@@ -58,12 +59,21 @@ namespace hpx {
                 HPX_ITT_SYNC_CREATE(this, "hpx::spinlock", desc);
             }
 
-#if defined(HPX_HAVE_ITTNOTIFY)
             ~spinlock()
             {
                 HPX_ITT_SYNC_DESTROY(this);
             }
 #else
+            constexpr spinlock() noexcept
+              : v_(false)
+            {
+            }
+
+            explicit constexpr spinlock(char const* const) noexcept
+              : v_(false)
+            {
+            }
+
             ~spinlock() = default;
 #endif
 

--- a/libs/core/synchronization/src/detail/condition_variable.cpp
+++ b/libs/core/synchronization/src/detail/condition_variable.cpp
@@ -6,6 +6,7 @@
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <hpx/assert.hpp>
+#include <hpx/execution_base/agent_ref.hpp>
 #include <hpx/execution_base/this_thread.hpp>
 #include <hpx/modules/errors.hpp>
 #include <hpx/modules/logging.hpp>
@@ -24,11 +25,47 @@
 #include <mutex>
 #include <utility>
 
-namespace hpx { namespace lcos { namespace local { namespace detail {
+namespace hpx::lcos::local::detail {
 
     ///////////////////////////////////////////////////////////////////////////
-    condition_variable::condition_variable() = default;
+    struct condition_variable::queue_entry
+    {
+        constexpr queue_entry(
+            hpx::execution_base::agent_ref ctx, void* q) noexcept
+          : ctx_(ctx)
+          , q_(q)
+        {
+        }
 
+        hpx::execution_base::agent_ref ctx_;
+        void* q_;
+
+        queue_entry* next = nullptr;
+        queue_entry* prev = nullptr;
+    };
+
+    struct condition_variable::reset_queue_entry
+    {
+        explicit constexpr reset_queue_entry(
+            condition_variable::queue_entry& e) noexcept
+          : e_(e)
+        {
+        }
+
+        ~reset_queue_entry()
+        {
+            if (e_.ctx_)
+            {
+                condition_variable::queue_type* q =
+                    static_cast<condition_variable::queue_type*>(e_.q_);
+                q->erase(&e_);    // remove entry from queue
+            }
+        }
+
+        condition_variable::queue_entry& e_;
+    };
+
+    ///////////////////////////////////////////////////////////////////////////
     condition_variable::~condition_variable()
     {
         if (!queue_.empty())
@@ -42,7 +79,8 @@ namespace hpx { namespace lcos { namespace local { namespace detail {
         }
     }
 
-    bool condition_variable::empty(std::unique_lock<mutex_type>& lock) const
+    bool condition_variable::empty(
+        std::unique_lock<mutex_type>& lock) const noexcept
     {
         HPX_ASSERT_OWNS_LOCK(lock);
         HPX_UNUSED(lock);
@@ -51,7 +89,7 @@ namespace hpx { namespace lcos { namespace local { namespace detail {
     }
 
     std::size_t condition_variable::size(
-        std::unique_lock<mutex_type>& lock) const
+        std::unique_lock<mutex_type>& lock) const noexcept
     {
         HPX_ASSERT_OWNS_LOCK(lock);
         HPX_UNUSED(lock);
@@ -68,10 +106,10 @@ namespace hpx { namespace lcos { namespace local { namespace detail {
 
         if (!queue_.empty())
         {
-            auto ctx = queue_.front().ctx_;
+            auto ctx = queue_.front()->ctx_;
 
             // remove item from queue before error handling
-            queue_.front().ctx_.reset();
+            queue_.front()->ctx_.reset();
             queue_.pop_front();
 
             if (HPX_UNLIKELY(!ctx))
@@ -110,15 +148,17 @@ namespace hpx { namespace lcos { namespace local { namespace detail {
         if (!queue.empty())
         {
             // update reference to queue for all queue entries
-            for (queue_entry& qe : queue)
-                qe.q_ = &queue;
+            for (queue_entry* qe = queue_.front(); qe != nullptr; qe = qe->next)
+            {
+                qe->q_ = &queue;
+            }
 
             do
             {
-                auto ctx = queue.front().ctx_;
+                auto ctx = queue.front()->ctx_;
 
                 // remove item from queue before error handling
-                queue.front().ctx_.reset();
+                queue.front()->ctx_.reset();
                 queue.pop_front();
 
                 if (HPX_UNLIKELY(!ctx))
@@ -162,7 +202,7 @@ namespace hpx { namespace lcos { namespace local { namespace detail {
         queue_entry f(this_ctx, &queue_);
         queue_.push_back(f);
 
-        reset_queue_entry r(f, queue_);
+        reset_queue_entry r(f);
         {
             // suspend this thread
             util::unlock_guard<std::unique_lock<mutex_type>> ul(lock);
@@ -185,7 +225,7 @@ namespace hpx { namespace lcos { namespace local { namespace detail {
         queue_entry f(this_ctx, &queue_);
         queue_.push_back(f);
 
-        reset_queue_entry r(f, queue_);
+        reset_queue_entry r(f);
         {
             // suspend this thread
             util::unlock_guard<std::unique_lock<mutex_type>> ul(lock);
@@ -207,15 +247,17 @@ namespace hpx { namespace lcos { namespace local { namespace detail {
             queue.swap(queue_);
 
             // update reference to queue for all queue entries
-            for (queue_entry& qe : queue)
-                qe.q_ = &queue;
+            for (queue_entry* qe = queue_.front(); qe != nullptr; qe = qe->next)
+            {
+                qe->q_ = &queue;
+            }
 
             while (!queue.empty())
             {
-                auto ctx = queue.front().ctx_;
+                auto ctx = queue.front()->ctx_;
 
                 // remove item from queue before error handling
-                queue.front().ctx_.reset();
+                queue.front()->ctx_.reset();
                 queue.pop_front();
 
                 if (HPX_UNLIKELY(!ctx))
@@ -239,13 +281,12 @@ namespace hpx { namespace lcos { namespace local { namespace detail {
 
     // re-add the remaining items to the original queue
     void condition_variable::prepend_entries(
-        std::unique_lock<mutex_type>& lock, queue_type& queue)
+        std::unique_lock<mutex_type>& lock, queue_type& queue) noexcept
     {
         HPX_ASSERT_OWNS_LOCK(lock);
         HPX_UNUSED(lock);
 
-        // splice is constant time only if it == end
-        queue.splice(queue.end(), queue_);
+        queue.splice(queue_);
         queue_.swap(queue);
     }
 
@@ -262,5 +303,4 @@ namespace hpx { namespace lcos { namespace local { namespace detail {
             delete p;
         }
     }
-
-}}}}    // namespace hpx::lcos::local::detail
+}    // namespace hpx::lcos::local::detail

--- a/libs/core/synchronization/src/mutex.cpp
+++ b/libs/core/synchronization/src/mutex.cpp
@@ -24,12 +24,14 @@
 namespace hpx {
 
     ///////////////////////////////////////////////////////////////////////////
+#if HPX_HAVE_ITTNOTIFY != 0
     mutex::mutex(char const* const description)
       : owner_id_(threads::invalid_thread_id)
     {
         HPX_ITT_SYNC_CREATE(this, "hpx::mutex", description);
         HPX_ITT_SYNC_RENAME(this, "hpx::mutex");
     }
+#endif
 
     mutex::~mutex()
     {

--- a/libs/core/thread_support/include/hpx/thread_support/atomic_count.hpp
+++ b/libs/core/thread_support/include/hpx/thread_support/atomic_count.hpp
@@ -18,7 +18,7 @@ namespace hpx { namespace util {
         HPX_NON_COPYABLE(atomic_count);
 
     public:
-        explicit atomic_count(long value) noexcept
+        constexpr explicit atomic_count(long value) noexcept
           : value_(value)
         {
         }


### PR DESCRIPTION
Fixes #6008

This also helps with #3440
