### PR TITLE
Deprecate `hpx::util::unlock_guard` in favor of `hpx::unlock_guard`

### DIFF
--- a/components/iostreams/include/hpx/components/iostreams/server/order_output.hpp
+++ b/components/iostreams/include/hpx/components/iostreams/server/order_output.hpp
@@ -17,8 +17,7 @@
 #include <mutex>
 #include <utility>
 
-namespace hpx { namespace iostreams { namespace detail
-{
+namespace hpx { namespace iostreams { namespace detail {
     struct order_output
     {
         typedef std::map<std::uint64_t, buffer> output_data_type;
@@ -31,14 +30,14 @@ namespace hpx { namespace iostreams { namespace detail
         {
             detail::buffer in(buf_in);
             std::unique_lock<Mutex> l(mtx);
-            data_type& data = output_data_map_[locality_id]; //-V108
+            data_type& data = output_data_map_[locality_id];    //-V108
 
             if (count == data.first)
             {
                 // this is the next expected output line
                 {
                     // output the line as requested
-                    util::unlock_guard<std::unique_lock<Mutex> > ul(l);
+                    unlock_guard<std::unique_lock<Mutex>> ul(l);
                     in.write(write_f, mtx);
                 }
                 ++data.first;
@@ -50,7 +49,7 @@ namespace hpx { namespace iostreams { namespace detail
                     buffer next_in = (*next).second;
                     {
                         // output the next line
-                        util::unlock_guard<std::unique_lock<Mutex> > ul(l);
+                        unlock_guard<std::unique_lock<Mutex>> ul(l);
                         next_in.write(write_f, mtx);
                     }
                     data.second.erase(next);
@@ -70,7 +69,4 @@ namespace hpx { namespace iostreams { namespace detail
     private:
         output_data_map_type output_data_map_;
     };
-}}}
-
-
-
+}}}    // namespace hpx::iostreams::detail

--- a/components/parcel_plugins/coalescing/src/coalescing_message_handler.cpp
+++ b/components/parcel_plugins/coalescing/src/coalescing_message_handler.cpp
@@ -259,13 +259,13 @@ namespace hpx::plugins::parcel {
         {
             stopped_ = true;
             {
-                hpx::util::unlock_guard<std::unique_lock<mutex_type>> ul(l);
+                hpx::unlock_guard<std::unique_lock<mutex_type>> ul(l);
                 timer_.stop();    // interrupt timer
             }
         }
         else if (cancel_timer)
         {
-            hpx::util::unlock_guard<std::unique_lock<mutex_type>> ul(l);
+            hpx::unlock_guard<std::unique_lock<mutex_type>> ul(l);
             timer_.stop();    // interrupt timer
         }
 

--- a/examples/quickstart/component_with_custom_heap.cpp
+++ b/examples/quickstart/component_with_custom_heap.cpp
@@ -256,7 +256,7 @@ namespace allocator {
         alloc_block<T>* new_chain = nullptr;
 
         {
-            hpx::util::unlock_guard<std::unique_lock<mutex_type>> ul(lk);
+            hpx::unlock_guard<std::unique_lock<mutex_type>> ul(lk);
 
             // allocate new page
             pg = reinterpret_cast<alloc_page*>(std::malloc(sizeof(alloc_page)));

--- a/examples/throttle/throttle/server/throttle.cpp
+++ b/examples/throttle/throttle/server/throttle.cpp
@@ -100,7 +100,7 @@ namespace throttle { namespace server {
 
         {
             // put this shepherd thread to sleep for 100ms
-            hpx::util::unlock_guard<std::unique_lock<mutex_type>> ul(l);
+            hpx::unlock_guard<std::unique_lock<mutex_type>> ul(l);
 
             std::this_thread::sleep_for(std::chrono::milliseconds(100));
         }

--- a/libs/core/errors/src/exception_list.cpp
+++ b/libs/core/errors/src/exception_list.cpp
@@ -149,7 +149,7 @@ namespace hpx {
         {
             hpx::exception ex;
             {
-                util::unlock_guard<std::unique_lock<mutex_type>> ul(l);
+                unlock_guard<std::unique_lock<mutex_type>> ul(l);
                 ex = hpx::exception(hpx::get_error(e), hpx::get_error_what(e));
             }
 

--- a/libs/core/include_local/include/hpx/local/mutex.hpp
+++ b/libs/core/include_local/include/hpx/local/mutex.hpp
@@ -13,5 +13,5 @@
 #include <hpx/thread_support/unlock_guard.hpp>
 
 namespace hpx {
-    using hpx::util::unlock_guard;
+    using hpx::unlock_guard;
 }    // namespace hpx

--- a/libs/core/include_local/include/hpx/local/mutex.hpp
+++ b/libs/core/include_local/include/hpx/local/mutex.hpp
@@ -11,7 +11,3 @@
 #include <hpx/synchronization/once.hpp>
 #include <hpx/synchronization/recursive_mutex.hpp>
 #include <hpx/thread_support/unlock_guard.hpp>
-
-namespace hpx {
-    using hpx::unlock_guard;
-}    // namespace hpx

--- a/libs/core/ini/src/ini.cpp
+++ b/libs/core/ini/src/ini.cpp
@@ -354,7 +354,7 @@ namespace hpx { namespace util {
             if (it != sections_.end())
             {
                 std::string sub_sec_name = sec_name.substr(i + 1);
-                hpx::util::unlock_guard<std::unique_lock<mutex_type>> ul(l);
+                hpx::unlock_guard<std::unique_lock<mutex_type>> ul(l);
                 return (*it).second.has_section(sub_sec_name);
             }
             return false;
@@ -373,7 +373,7 @@ namespace hpx { namespace util {
             if (it != sections_.end())
             {
                 std::string sub_sec_name = sec_name.substr(i + 1);
-                hpx::util::unlock_guard<std::unique_lock<mutex_type>> ul(l);
+                hpx::unlock_guard<std::unique_lock<mutex_type>> ul(l);
                 return (*it).second.get_section(sub_sec_name);
             }
 
@@ -406,7 +406,7 @@ namespace hpx { namespace util {
             if (it != sections_.end())
             {
                 std::string sub_sec_name = sec_name.substr(i + 1);
-                hpx::util::unlock_guard<std::unique_lock<mutex_type>> ul(l);
+                hpx::unlock_guard<std::unique_lock<mutex_type>> ul(l);
                 return (*it).second.get_section(sub_sec_name);
             }
 
@@ -469,7 +469,7 @@ namespace hpx { namespace util {
                     std::string value = e.first;
                     entry_changed_func f = e.second;
 
-                    hpx::util::unlock_guard<std::unique_lock<mutex_type>> ul(l);
+                    hpx::unlock_guard<std::unique_lock<mutex_type>> ul(l);
                     f(fullkey, value);
                 }
             }
@@ -518,7 +518,7 @@ namespace hpx { namespace util {
                     std::string value = it->second.first;
                     entry_changed_func f = it->second.second;
 
-                    hpx::util::unlock_guard<std::unique_lock<mutex_type>> ul(l);
+                    hpx::unlock_guard<std::unique_lock<mutex_type>> ul(l);
                     f(fullkey, value);
                 }
             }
@@ -535,7 +535,7 @@ namespace hpx { namespace util {
                     std::string value = p.first->second.first;
                     entry_changed_func f = p.first->second.second;
 
-                    hpx::util::unlock_guard<std::unique_lock<mutex_type>> ul(l);
+                    hpx::unlock_guard<std::unique_lock<mutex_type>> ul(l);
                     f(key, value);
                 }
             }
@@ -635,7 +635,7 @@ namespace hpx { namespace util {
             {
                 section_map::const_iterator cit = sections_.find(sub_sec);
                 HPX_ASSERT(cit != sections_.end());
-                hpx::util::unlock_guard<std::unique_lock<mutex_type>> ul(l);
+                hpx::unlock_guard<std::unique_lock<mutex_type>> ul(l);
                 return (*cit).second.has_entry(sub_key);
             }
             return false;
@@ -655,7 +655,7 @@ namespace hpx { namespace util {
             {
                 section_map::const_iterator cit = sections_.find(sub_sec);
                 HPX_ASSERT(cit != sections_.end());
-                hpx::util::unlock_guard<std::unique_lock<mutex_type>> ul(l);
+                hpx::unlock_guard<std::unique_lock<mutex_type>> ul(l);
                 return (*cit).second.get_entry(sub_key);
             }
 

--- a/libs/core/lcos_local/include/hpx/lcos_local/and_gate.hpp
+++ b/libs/core/lcos_local/include/hpx/lcos_local/and_gate.hpp
@@ -311,7 +311,7 @@ namespace hpx { namespace lcos { namespace local {
                     &base_and_gate::test_condition, this, generation_value));
 
                 {
-                    hpx::util::unlock_guard<Lock> ul(l);
+                    hpx::unlock_guard<Lock> ul(l);
                     f.get();
                 }    // make sure lock gets re-acquired
             }

--- a/libs/core/lcos_local/include/hpx/lcos_local/channel.hpp
+++ b/libs/core/lcos_local/include/hpx/lcos_local/channel.hpp
@@ -217,7 +217,7 @@ namespace hpx { namespace lcos { namespace local {
                 std::exception_ptr e;
 
                 {
-                    util::unlock_guard<std::unique_lock<mutex_type>> ul(l);
+                    unlock_guard<std::unique_lock<mutex_type>> ul(l);
                     e = HPX_GET_EXCEPTION(hpx::future_cancelled,
                         hpx::throwmode::lightweight, "hpx::lcos::local::close",
                         "canceled waiting on this entry");
@@ -509,7 +509,7 @@ namespace hpx { namespace lcos { namespace local {
                 // canceled at this point
                 std::exception_ptr e;
                 {
-                    util::unlock_guard<std::unique_lock<mutex_type>> ul(l);
+                    unlock_guard<std::unique_lock<mutex_type>> ul(l);
                     e = std::exception_ptr(HPX_GET_EXCEPTION(
                         hpx::future_cancelled, "hpx::lcos::local::close",
                         "canceled waiting on this entry"));

--- a/libs/core/lcos_local/include/hpx/lcos_local/trigger.hpp
+++ b/libs/core/lcos_local/include/hpx/lcos_local/trigger.hpp
@@ -181,7 +181,7 @@ namespace hpx { namespace lcos { namespace local {
                     &base_trigger::test_condition, this, generation_value));
 
                 {
-                    hpx::util::unlock_guard<Lock> ul(l);
+                    hpx::unlock_guard<Lock> ul(l);
                     f.get();
                 }    // make sure lock gets re-acquired
             }

--- a/libs/core/runtime_local/src/interval_timer.cpp
+++ b/libs/core/runtime_local/src/interval_timer.cpp
@@ -81,7 +81,7 @@ namespace hpx { namespace util { namespace detail {
             {
                 first_start_ = false;
 
-                util::unlock_guard<std::unique_lock<mutex_type>> ul(l);
+                unlock_guard<std::unique_lock<mutex_type>> ul(l);
                 if (pre_shutdown_)
                 {
                     register_pre_shutdown_function(util::deferred_call(
@@ -258,7 +258,7 @@ namespace hpx { namespace util { namespace detail {
             bool result = false;
 
             {
-                util::unlock_guard<std::unique_lock<mutex_type>> ul(l);
+                unlock_guard<std::unique_lock<mutex_type>> ul(l);
                 result = f_();    // invoke the supplied function
             }
 
@@ -301,7 +301,7 @@ namespace hpx { namespace util { namespace detail {
             // FIXME: registering threads might lead to thread suspension since
             // the allocators use hpx::spinlock. Unlocking the lock here would
             // be the right thing but leads to crashes and hangs at shutdown.
-            // util::unlock_guard<std::unique_lock<mutex_type> > ul(l);
+            // unlock_guard<std::unique_lock<mutex_type> > ul(l);
             hpx::threads::thread_init_data data(
                 hpx::threads::make_thread_function(hpx::bind_front(
                     &interval_timer::evaluate, this->shared_from_this())),

--- a/libs/core/runtime_local/src/pool_timer.cpp
+++ b/libs/core/runtime_local/src/pool_timer.cpp
@@ -132,7 +132,7 @@ namespace hpx { namespace util { namespace detail {
             {
                 first_start_ = false;
 
-                util::unlock_guard<std::unique_lock<mutex_type>> ul(l);
+                unlock_guard<std::unique_lock<mutex_type>> ul(l);
                 if (pre_shutdown_)
                 {
                     register_pre_shutdown_function(util::deferred_call(

--- a/libs/core/schedulers/include/hpx/schedulers/thread_queue.hpp
+++ b/libs/core/schedulers/include/hpx/schedulers/thread_queue.hpp
@@ -180,7 +180,7 @@ namespace hpx { namespace threads { namespace policies {
             else
 #endif
             {
-                hpx::util::unlock_guard<Lock> ull(lk);
+                hpx::unlock_guard<Lock> ull(lk);
 
                 // Allocate a new thread object.
                 threads::thread_data* p = nullptr;

--- a/libs/core/synchronization/include/hpx/synchronization/condition_variable.hpp
+++ b/libs/core/synchronization/include/hpx/synchronization/condition_variable.hpp
@@ -213,7 +213,7 @@ namespace hpx {
             HPX_UNUSED(ignore_lock);
 
             std::unique_lock<mutex_type> l(data->mtx_);
-            util::unlock_guard<std::unique_lock<Mutex>> unlock(lock);
+            unlock_guard<std::unique_lock<Mutex>> unlock(lock);
 
             // The following ensures that the inner lock will be unlocked
             // before the outer to avoid deadlock (fixes issue #3608)
@@ -320,7 +320,7 @@ namespace hpx {
             HPX_UNUSED(ignore_lock);
 
             std::unique_lock<mutex_type> l(data->mtx_);
-            util::unlock_guard<std::unique_lock<Mutex>> unlock(lock);
+            unlock_guard<std::unique_lock<Mutex>> unlock(lock);
 
             // The following ensures that the inner lock will be unlocked
             // before the outer to avoid deadlock (fixes issue #3608)
@@ -695,7 +695,7 @@ namespace hpx {
             HPX_UNUSED(ignore_lock);
 
             std::unique_lock<mutex_type> l(data->mtx_);
-            util::unlock_guard<Lock> unlock(lock);
+            unlock_guard<Lock> unlock(lock);
 
             // The following ensures that the inner lock will be unlocked
             // before the outer to avoid deadlock (fixes issue #3608)
@@ -812,7 +812,7 @@ namespace hpx {
             HPX_UNUSED(ignore_lock);
 
             std::unique_lock<mutex_type> l(data->mtx_);
-            util::unlock_guard<Lock> unlock(lock);
+            unlock_guard<Lock> unlock(lock);
 
             // The following ensures that the inner lock will be unlocked
             // before the outer to avoid deadlock (fixes issue #3608)
@@ -1069,7 +1069,7 @@ namespace hpx {
                     return false;
                 }
 
-                util::unlock_guard<Lock> unlock(lock);
+                unlock_guard<Lock> unlock(lock);
 
                 // The following ensures that the inner lock will be unlocked
                 // before the outer to avoid deadlock (fixes issue #3608)
@@ -1164,7 +1164,7 @@ namespace hpx {
                         return false;
                     }
 
-                    util::unlock_guard<Lock> unlock(lock);
+                    unlock_guard<Lock> unlock(lock);
 
                     // The following ensures that the inner lock will be unlocked
                     // before the outer to avoid deadlock (fixes issue #3608)

--- a/libs/core/synchronization/src/detail/condition_variable.cpp
+++ b/libs/core/synchronization/src/detail/condition_variable.cpp
@@ -205,7 +205,7 @@ namespace hpx::lcos::local::detail {
         reset_queue_entry r(f);
         {
             // suspend this thread
-            util::unlock_guard<std::unique_lock<mutex_type>> ul(lock);
+            unlock_guard<std::unique_lock<mutex_type>> ul(lock);
             this_ctx.suspend();
         }
 
@@ -228,7 +228,7 @@ namespace hpx::lcos::local::detail {
         reset_queue_entry r(f);
         {
             // suspend this thread
-            util::unlock_guard<std::unique_lock<mutex_type>> ul(lock);
+            unlock_guard<std::unique_lock<mutex_type>> ul(lock);
             this_ctx.sleep_until(abs_time.value());
         }
 
@@ -271,7 +271,7 @@ namespace hpx::lcos::local::detail {
                     "condition_variable::abort_all: pending thread: {}", ctx);
 
                 // unlock while notifying thread as this can suspend
-                util::unlock_guard<std::unique_lock<Mutex>> unlock(lock);
+                unlock_guard<std::unique_lock<Mutex>> unlock(lock);
 
                 // forcefully abort thread, do not throw
                 ctx.abort();

--- a/libs/core/synchronization/src/stop_token.cpp
+++ b/libs/core/synchronization/src/stop_token.cpp
@@ -284,7 +284,7 @@ namespace hpx { namespace detail {
             {
                 // Don't hold lock while executing callback so we don't
                 // block other threads from unregistering callbacks.
-                util::unlock_guard ul(*this);
+                unlock_guard ul(*this);
                 cb->execute();
             }
 

--- a/libs/core/synchronization/tests/unit/condition_variable.cpp
+++ b/libs/core/synchronization/tests/unit/condition_variable.cpp
@@ -538,7 +538,7 @@ void test_condition_waits()
         HPX_TEST(lock ? true : false);
 
         {
-            hpx::util::unlock_guard<unique_lock> ul(lock);
+            hpx::unlock_guard<unique_lock> ul(lock);
             hpx::this_thread::sleep_for(std::chrono::milliseconds(1));
         }
 
@@ -550,7 +550,7 @@ void test_condition_waits()
         HPX_TEST_EQ(data.awoken, 1);
 
         {
-            hpx::util::unlock_guard<unique_lock> ul(lock);
+            hpx::unlock_guard<unique_lock> ul(lock);
             hpx::this_thread::sleep_for(std::chrono::milliseconds(1));
         }
 
@@ -562,7 +562,7 @@ void test_condition_waits()
         HPX_TEST_EQ(data.awoken, 2);
 
         {
-            hpx::util::unlock_guard<unique_lock> ul(lock);
+            hpx::unlock_guard<unique_lock> ul(lock);
             hpx::this_thread::sleep_for(std::chrono::milliseconds(1));
         }
 
@@ -574,7 +574,7 @@ void test_condition_waits()
         HPX_TEST_EQ(data.awoken, 3);
 
         {
-            hpx::util::unlock_guard<unique_lock> ul(lock);
+            hpx::unlock_guard<unique_lock> ul(lock);
             hpx::this_thread::sleep_for(std::chrono::milliseconds(1));
         }
 
@@ -586,7 +586,7 @@ void test_condition_waits()
         HPX_TEST_EQ(data.awoken, 4);
 
         {
-            hpx::util::unlock_guard<unique_lock> ul(lock);
+            hpx::unlock_guard<unique_lock> ul(lock);
             hpx::this_thread::sleep_for(std::chrono::milliseconds(1));
         }
 

--- a/libs/core/thread_pools/include/hpx/thread_pools/scheduled_thread_pool_impl.hpp
+++ b/libs/core/thread_pools/include/hpx/thread_pools/scheduled_thread_pool_impl.hpp
@@ -252,7 +252,7 @@ namespace hpx { namespace threads { namespace detail {
 
                     {
                         // unlock the lock while joining
-                        util::unlock_guard<Lock> ul(l);
+                        unlock_guard<Lock> ul(l);
                         remove_processing_unit_internal(i);
                     }
                 }

--- a/libs/core/thread_support/include/hpx/thread_support/unlock_guard.hpp
+++ b/libs/core/thread_support/include/hpx/thread_support/unlock_guard.hpp
@@ -9,7 +9,7 @@
 
 #include <hpx/config.hpp>
 
-namespace hpx { namespace util {
+namespace hpx {
     ///////////////////////////////////////////////////////////////////////////
     // This is a helper structure to make sure a lock gets unlocked and locked
     // again in a scope.
@@ -36,4 +36,13 @@ namespace hpx { namespace util {
     private:
         Mutex& m_;
     };
+}    // namespace hpx
+
+namespace hpx { namespace util {
+
+    template <typename Mutex>
+    using unlock_guard HPX_DEPRECATED_V(1, 9,
+        "hpx::util::unlock_guard is deprecated, use "
+        "hpx::unlock_guard instead") = hpx::unlock_guard<Mutex>;
+
 }}    // namespace hpx::util

--- a/libs/core/thread_support/include/hpx/thread_support/unlock_guard.hpp
+++ b/libs/core/thread_support/include/hpx/thread_support/unlock_guard.hpp
@@ -5,6 +5,8 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+/// \file unlock_guard.hpp
+
 #pragma once
 
 #include <hpx/config.hpp>
@@ -13,6 +15,23 @@ namespace hpx {
     ///////////////////////////////////////////////////////////////////////////
     // This is a helper structure to make sure a lock gets unlocked and locked
     // again in a scope.
+    /// \brief The class \c unlock_guard is a mutex wrapper that provides a
+    ///        convenient mechanism for releasing a mutex for the duration of
+    ///        a scoped block.
+    /// \details \c unlock_guard performs the opposite functionality of
+    ///          \c lock_guard.
+    ///          When a \c lock_guard object is created, it attempts to take
+    ///          ownership of the mutex it is given. When control leaves the
+    ///          scope in which the \c lock_guard object was created, the
+    ///          \c lock_guard is destructed and the mutex is released.
+    ///          Accordingly, when an \c unlock_guard object is created, it
+    ///          attempts to release the ownership of the mutex it is given.
+    ///          So, when control leaves the scope in which the \c unlock_guard
+    ///          object was created, the \c unlock_guard is
+    ///          destructed and the mutex is owned again. In this way, the
+    ///          mutex is unlocked in the constructor and locked in the
+    ///          desctuctor, so that one can have an unlocked section within
+    ///          a locked one.
     template <typename Mutex>
     class unlock_guard
     {

--- a/libs/core/threading/src/thread.cpp
+++ b/libs/core/threading/src/thread.cpp
@@ -219,7 +219,7 @@ namespace hpx {
                 hpx::bind_front(&resume_thread, HPX_MOVE(this_id))))
         {
             // wait for thread to be terminated
-            util::unlock_guard ul(l);
+            unlock_guard ul(l);
             this_thread::suspend(
                 threads::thread_schedule_state::suspended, "thread::join");
         }

--- a/libs/core/threading/tests/unit/condition_variable4.cpp
+++ b/libs/core/threading/tests/unit/condition_variable4.cpp
@@ -53,7 +53,7 @@ void producer_consumer(double prod_sec, double cons_sec, bool interrupt)
                 int item;
 
                 {
-                    hpx::util::unlock_guard<hpx::mutex> ul(items_mtx);
+                    hpx::unlock_guard<hpx::mutex> ul(items_mtx);
                     item = next_value();
                     if (prod_sec > 0)
                     {
@@ -73,7 +73,7 @@ void producer_consumer(double prod_sec, double cons_sec, bool interrupt)
         for (;;)
         {
             {
-                hpx::util::unlock_guard<hpx::mutex> ul(items_mtx);
+                hpx::unlock_guard<hpx::mutex> ul(items_mtx);
                 if (cons_sec > 0)
                 {
                     hpx::this_thread::sleep_for(cons_sleep);

--- a/libs/core/threading_base/src/thread_data.cpp
+++ b/libs/core/threading_base/src/thread_data.cpp
@@ -124,8 +124,7 @@ namespace hpx { namespace threads {
         while (!exit_funcs_.empty())
         {
             {
-                hpx::util::unlock_guard<
-                    std::unique_lock<hpx::util::detail::spinlock>>
+                hpx::unlock_guard<std::unique_lock<hpx::util::detail::spinlock>>
                     ul(l);
                 if (!exit_funcs_.front().empty())
                     exit_funcs_.front()();

--- a/libs/full/agas/src/addressing_service.cpp
+++ b/libs/full/agas/src/addressing_service.cpp
@@ -282,7 +282,7 @@ namespace hpx { namespace agas {
             // The locality hasn't been requested to be resolved yet. Do it now.
             parcelset::endpoints_type endpoints;
             {
-                hpx::util::unlock_guard<std::unique_lock<mutex_type>> ul(l);
+                hpx::unlock_guard<std::unique_lock<mutex_type>> ul(l);
                 endpoints = locality_ns_->resolve_locality(gid);
                 if (endpoints.empty())
                 {

--- a/libs/full/agas_base/src/server/symbol_namespace_server.cpp
+++ b/libs/full/agas_base/src/server/symbol_namespace_server.cpp
@@ -185,7 +185,7 @@ namespace hpx { namespace agas { namespace server {
                 std::shared_ptr<naming::gid_type> current_gid = gid_it->second;
 
                 {
-                    util::unlock_guard<std::unique_lock<mutex_type>> ul(l);
+                    unlock_guard<std::unique_lock<mutex_type>> ul(l);
 
                     // split the credit as the receiving end will expect to keep the
                     // object alive
@@ -304,7 +304,7 @@ namespace hpx { namespace agas { namespace server {
 
                 // hold on to entry while map is unlocked
                 std::shared_ptr<naming::gid_type> current_gid(it->second);
-                util::unlock_guard<std::unique_lock<mutex_type>> ul(l);
+                unlock_guard<std::unique_lock<mutex_type>> ul(l);
 
                 found[it->first] =
                     naming::detail::split_gid_if_needed(*current_gid).get();
@@ -321,7 +321,7 @@ namespace hpx { namespace agas { namespace server {
 
                 // hold on to entry while map is unlocked
                 std::shared_ptr<naming::gid_type> current_gid(it->second);
-                util::unlock_guard<std::unique_lock<mutex_type>> ul(l);
+                unlock_guard<std::unique_lock<mutex_type>> ul(l);
 
                 found[it->first] =
                     naming::detail::split_gid_if_needed(*current_gid).get();
@@ -356,7 +356,7 @@ namespace hpx { namespace agas { namespace server {
                 // split the credit as the receiving end will expect to keep the
                 // object alive
                 {
-                    util::unlock_guard<std::unique_lock<mutex_type>> ul(l);
+                    unlock_guard<std::unique_lock<mutex_type>> ul(l);
                     new_gid =
                         naming::detail::split_gid_if_needed(*current_gid).get();
 

--- a/libs/full/components_base/include/hpx/components_base/server/locking_hook.hpp
+++ b/libs/full/components_base/include/hpx/components_base/server/locking_hook.hpp
@@ -166,7 +166,7 @@ namespace hpx { namespace components {
                 threads::thread_restart_state::unknown;
 
             {
-                util::unlock_guard ul(mtx_);
+                unlock_guard ul(mtx_);
                 result = threads::get_self().yield_impl(state);
             }
 

--- a/libs/full/components_base/include/hpx/components_base/server/wrapper_heap_list.hpp
+++ b/libs/full/components_base/include/hpx/components_base/server/wrapper_heap_list.hpp
@@ -61,7 +61,7 @@ namespace hpx { namespace components { namespace detail {
             {
                 if ((*it)->did_alloc(p))
                 {
-                    util::unlock_guard ul(guard);
+                    unlock_guard ul(guard);
                     return (*it)->get_gid(id_range_, p, type_);
                 }
             }

--- a/libs/full/components_base/src/generate_unique_ids.cpp
+++ b/libs/full/components_base/src/generate_unique_ids.cpp
@@ -30,7 +30,7 @@ namespace hpx { namespace util {
             std::size_t count_ = (std::max)(std::size_t(range_delta), count);
 
             {
-                unlock_guard ul(l);
+                hpx::unlock_guard ul(l);
                 lower = hpx::agas::get_next_id(count_);
             }
 

--- a/libs/full/components_base/src/server/one_size_heap_list.cpp
+++ b/libs/full/components_base/src/server/one_size_heap_list.cpp
@@ -65,7 +65,7 @@ namespace hpx { namespace util {
                     bool allocated = false;
 
                     {
-                        util::unlock_guard ul(guard);
+                        hpx::unlock_guard ul(guard);
                         allocated = heap->alloc(&p, count);
                     }
 
@@ -108,7 +108,7 @@ namespace hpx { namespace util {
             bool result = false;
 
             {
-                util::unlock_guard ul(guard);
+                hpx::unlock_guard ul(guard);
                 result = heap->alloc((void**) &p, count);
             }
 
@@ -176,7 +176,7 @@ namespace hpx { namespace util {
             bool did_allocate = false;
 
             {
-                util::unlock_guard ull(ul);
+                hpx::unlock_guard ull(ul);
                 did_allocate = heap->did_alloc(p);
                 if (did_allocate)
                 {
@@ -204,7 +204,7 @@ namespace hpx { namespace util {
         std::unique_lock ul(mtx_);
         for (typename list_type::value_type const& heap : heap_list_)
         {
-            util::unlock_guard ull(ul);
+            hpx::unlock_guard ull(ul);
             if (heap->did_alloc(p))
             {
                 return true;

--- a/libs/full/components_base/src/server/wrapper_heap.cpp
+++ b/libs/full/components_base/src/server/wrapper_heap.cpp
@@ -258,7 +258,7 @@ namespace hpx { namespace components { namespace detail {
             {
                 // this is the first call to get_gid() for this heap - allocate
                 // a sufficiently large range of global ids
-                util::unlock_guard ul(l);
+                unlock_guard ul(l);
                 base_gid = ids.get_id(parameters_.capacity);
 
                 // register the global ids and the base address of this heap
@@ -284,7 +284,7 @@ namespace hpx { namespace components { namespace detail {
             else
             {
                 // unbind the range which is not needed anymore
-                util::unlock_guard ul(l);
+                unlock_guard ul(l);
                 agas::unbind_range_local(base_gid, parameters_.capacity);
             }
         }
@@ -327,7 +327,7 @@ namespace hpx { namespace components { namespace detail {
             naming::gid_type base_gid = base_gid_;
             base_gid_ = naming::invalid_gid;
 
-            util::unlock_guard ull(lk);
+            unlock_guard ull(lk);
             agas::unbind_range_local(base_gid, parameters_.capacity);
         }
 

--- a/libs/full/lcos_distributed/include/hpx/lcos_distributed/server/object_semaphore.hpp
+++ b/libs/full/lcos_distributed/include/hpx/lcos_distributed/server/object_semaphore.hpp
@@ -114,7 +114,7 @@ namespace hpx { namespace lcos { namespace server {
                 thread_queue_.pop_front();
 
                 {
-                    util::unlock_guard<std::unique_lock<mutex_type>> ul(l);
+                    unlock_guard<std::unique_lock<mutex_type>> ul(l);
 
                     // set the LCO's result
                     applier::trigger(id, HPX_MOVE(value));

--- a/libs/full/naming/include/hpx/naming/detail/preprocess_gid_types.hpp
+++ b/libs/full/naming/include/hpx/naming/detail/preprocess_gid_types.hpp
@@ -70,7 +70,7 @@ namespace hpx::serialization::detail {
                 split_gids_.clear();
 
                 // now return credits to AGAS
-                util::unlock_guard<Lock> ul(l);
+                unlock_guard<Lock> ul(l);
 
                 for (auto const& gid : gids)
                 {

--- a/libs/full/naming/src/credit_handling.cpp
+++ b/libs/full/naming/src/credit_handling.cpp
@@ -364,8 +364,7 @@ namespace hpx::naming {
 
             std::int64_t result = 0;
             {
-                hpx::util::unlock_guard<std::unique_lock<gid_type::mutex_type>>
-                    ul(l);
+                hpx::unlock_guard<std::unique_lock<gid_type::mutex_type>> ul(l);
                 result = agas::incref(launch::sync, unlocked_gid, added_credit);
             }
 

--- a/libs/full/parcelset/src/parcelhandler.cpp
+++ b/libs/full/parcelset/src/parcelhandler.cpp
@@ -366,7 +366,7 @@ namespace hpx::parcelset {
                     {
                         std::shared_ptr<policies::message_handler> p(
                             (*it).second);
-                        util::unlock_guard<std::unique_lock<mutex_type>> ul(l);
+                        unlock_guard<std::unique_lock<mutex_type>> ul(l);
                         did_some_work = p->flush(flush_mode, stop_buffering) ||
                             did_some_work;
                     }

--- a/libs/full/performance_counters/src/server/statistics_counter.cpp
+++ b/libs/full/performance_counters/src/server/statistics_counter.cpp
@@ -488,7 +488,7 @@ namespace hpx { namespace performance_counters { namespace server {
             hpx::id_type base_counter_id;
             {
                 // We need to unlock the lock here since get_counter might suspend
-                util::unlock_guard<std::unique_lock<mutex_type>> unlock(l);
+                unlock_guard<std::unique_lock<mutex_type>> unlock(l);
                 base_counter_id = get_counter(base_counter_name_, ec);
             }
 

--- a/libs/full/runtime_components/src/console_logging.cpp
+++ b/libs/full/runtime_components/src/console_logging.cpp
@@ -250,8 +250,7 @@ namespace hpx { namespace components {
             {
                 naming::gid_type raw_prefix;
                 {
-                    util::unlock_guard<std::unique_lock<prefix_mutex_type>> ul(
-                        l);
+                    unlock_guard<std::unique_lock<prefix_mutex_type>> ul(l);
                     naming::get_agas_client().get_console_locality(raw_prefix);
                 }
 

--- a/libs/full/runtime_distributed/src/server/runtime_support_server.cpp
+++ b/libs/full/runtime_distributed/src/server/runtime_support_server.cpp
@@ -364,7 +364,7 @@ namespace hpx { namespace components { namespace server {
                 dijkstra_color_ = false;    // start off with white
 
                 {
-                    util::unlock_guard<dijkstra_scoped_lock> ul(l);
+                    unlock_guard<dijkstra_scoped_lock> ul(l);
                     send_dijkstra_termination_token(target_id - 1,
                         initiating_locality_id, num_localities,
                         dijkstra_color_);
@@ -612,7 +612,7 @@ namespace hpx { namespace components { namespace server {
             stop_called_ = true;
 
             {
-                util::unlock_guard<std::mutex> ul(mtx_);
+                unlock_guard<std::mutex> ul(mtx_);
 
                 util::runtime_configuration& cfg = get_runtime().get_config();
                 std::size_t shutdown_check_count =


### PR DESCRIPTION
- Deprecate `hpx::util::unlock_guard` in favor of `hpx::unlock_guard`
- Add corresponding documentation