### PR TITLE
Forking Boost.Tokenizer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2345,7 +2345,6 @@ if(HPX_WITH_PRECOMPILED_HEADERS)
       <boost/lockfree/queue.hpp>
       <boost/optional.hpp>
       <boost/spirit/home/x3.hpp>
-      <boost/tokenizer.hpp>
   )
 
   if(HPX_WITH_CXX17_FILESYSTEM)

--- a/components/process/src/util/posix/search_path_u.cpp
+++ b/components/process/src/util/posix/search_path_u.cpp
@@ -3,7 +3,7 @@
 // Copyright (c) 2009 Boris Schaeling
 // Copyright (c) 2010 Felipe Tanus, Boris Schaeling
 // Copyright (c) 2011, 2012 Jeff Flinn, Boris Schaeling
-// Copyright (c) 2016 Hartmut Kaiser
+// Copyright (c) 2016-2022 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 // Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -15,8 +15,7 @@
 #include <hpx/components/process/util/search_path.hpp>
 #include <hpx/modules/errors.hpp>
 #include <hpx/modules/filesystem.hpp>
-
-#include <boost/tokenizer.hpp>
+#include <hpx/modules/string_util.hpp>
 
 #include <unistd.h>
 
@@ -24,24 +23,24 @@
 #include <stdexcept>
 #include <string>
 
-namespace hpx { namespace components { namespace process { namespace posix
-{
-    std::string search_path(const std::string &filename, std::string path)
+namespace hpx { namespace components { namespace process { namespace posix {
+    std::string search_path(const std::string& filename, std::string path)
     {
         if (path.empty())
         {
             path = ::getenv("PATH");
             if (path.empty())
             {
-                HPX_THROW_EXCEPTION(invalid_status,
-                    "process::search_path",
+                HPX_THROW_EXCEPTION(invalid_status, "process::search_path",
                     "Environment variable PATH not found");
             }
         }
 
         std::string result;
-        typedef boost::tokenizer<boost::char_separator<char> > tokenizer;
-        boost::char_separator<char> sep(":");
+        typedef hpx::string_util::tokenizer<
+            hpx::string_util::char_separator<char>>
+            tokenizer;
+        hpx::string_util::char_separator<char> sep(":");
         tokenizer tok(path, sep);
         for (tokenizer::iterator it = tok.begin(); it != tok.end(); ++it)
         {
@@ -55,6 +54,6 @@ namespace hpx { namespace components { namespace process { namespace posix
         }
         return result;
     }
-}}}}
+}}}}    // namespace hpx::components::process::posix
 
 #endif

--- a/components/process/src/util/windows/search_path_w.cpp
+++ b/components/process/src/util/windows/search_path_w.cpp
@@ -3,7 +3,7 @@
 // Copyright (c) 2009 Boris Schaeling
 // Copyright (c) 2010 Felipe Tanus, Boris Schaeling
 // Copyright (c) 2011, 2012 Jeff Flinn, Boris Schaeling
-// Copyright (c) 2016 Hartmut Kaiser
+// Copyright (c) 2016-2022 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 // Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -15,11 +15,10 @@
 #include <hpx/components/process/util/windows/search_path.hpp>
 #include <hpx/modules/errors.hpp>
 #include <hpx/modules/filesystem.hpp>
+#include <hpx/modules/string_util.hpp>
 
-#include <boost/tokenizer.hpp>
-
-#include <windows.h>
 #include <shellapi.h>
+#include <windows.h>
 
 #include <array>
 #include <cstdlib>
@@ -27,34 +26,34 @@
 #include <string>
 #include <system_error>
 
-namespace hpx { namespace components { namespace process { namespace windows
-{
+namespace hpx { namespace components { namespace process { namespace windows {
 #if defined(_UNICODE) || defined(UNICODE)
-    std::wstring search_path(const std::wstring &filename, std::wstring path)
+    std::wstring search_path(const std::wstring& filename, std::wstring path)
     {
         if (path.empty())
         {
             path = ::_wgetenv(L"PATH");
             if (path.empty())
             {
-                HPX_THROW_EXCEPTION(invalid_status,
-                    "process::search_path",
+                HPX_THROW_EXCEPTION(invalid_status, "process::search_path",
                     "Environment variable PATH not found");
             }
         }
 
-        typedef boost::tokenizer<boost::char_separator<wchar_t>,
-            std::wstring::const_iterator, std::wstring> tokenizer;
-        boost::char_separator<wchar_t> sep(L";");
+        typedef hpx::string_util::tokenizer<
+            hpx::string_util::char_separator<wchar_t>,
+            std::wstring::const_iterator, std::wstring>
+            tokenizer;
+        hpx::string_util::char_separator<wchar_t> sep(L";");
         tokenizer tok(path, sep);
         for (tokenizer::iterator it = tok.begin(); it != tok.end(); ++it)
         {
             filesystem::path p = *it;
             p /= filename;
-            std::array<std::wstring, 4> extensions =
-                { L"", L".exe", L".com", L".bat" };
+            std::array<std::wstring, 4> extensions = {
+                L"", L".exe", L".com", L".bat"};
             for (std::array<std::wstring, 4>::iterator it2 = extensions.begin();
-                it2 != extensions.end(); ++it2)
+                 it2 != extensions.end(); ++it2)
             {
                 filesystem::path p2 = p;
                 p2 += *it2;
@@ -70,30 +69,28 @@ namespace hpx { namespace components { namespace process { namespace windows
         return L"";
     }
 #else
-    std::string search_path(const std::string &filename, std::string path)
+    std::string search_path(const std::string& filename, std::string path)
     {
         if (path.empty())
         {
             path = ::getenv("PATH");
             if (path.empty())
             {
-                HPX_THROW_EXCEPTION(invalid_status,
-                    "process::search_path",
+                HPX_THROW_EXCEPTION(invalid_status, "process::search_path",
                     "Environment variable PATH not found");
             }
         }
 
-        typedef boost::tokenizer<boost::char_separator<char> > tokenizer;
-        boost::char_separator<char> sep(";");
-        tokenizer tok(path, sep);
-        for (tokenizer::iterator it = tok.begin(); it != tok.end(); ++it)
+        hpx::string_util::char_separator<char> sep(";");
+        hpx::string_util::tokenizer tok(path, sep);
+        for (auto it = tok.begin(); it != tok.end(); ++it)
         {
             filesystem::path p = *it;
             p /= filename;
-            std::array<std::string, 4> extensions = //-V112
-                {{ "", ".exe", ".com", ".bat" }};
+            std::array<std::string, 4> extensions =    //-V112
+                {{"", ".exe", ".com", ".bat"}};
             for (std::array<std::string, 4>::iterator it2 = extensions.begin();
-                it2 != extensions.end(); ++it2)
+                 it2 != extensions.end(); ++it2)
             {
                 filesystem::path p2 = p;
                 p2 += *it2;
@@ -110,6 +107,6 @@ namespace hpx { namespace components { namespace process { namespace windows
         return "";
     }
 #endif
-}}}}
+}}}}    // namespace hpx::components::process::windows
 
 #endif

--- a/examples/1d_stencil/1d_stencil_4_repart.cpp
+++ b/examples/1d_stencil/1d_stencil_4_repart.cpp
@@ -44,8 +44,6 @@
 
 #include "print_time_results.hpp"
 
-#include <boost/shared_array.hpp>
-
 using hpx::id_type;
 using hpx::performance_counters::counter_value;
 using hpx::performance_counters::get_counter;

--- a/examples/jacobi/jacobi_component/server/row.hpp
+++ b/examples/jacobi/jacobi_component/server/row.hpp
@@ -15,8 +15,6 @@
 #include <hpx/include/components.hpp>
 #include <hpx/modules/memory.hpp>
 
-#include <boost/smart_ptr/shared_array.hpp>
-
 #include <cstddef>
 
 namespace jacobi { namespace server {

--- a/libs/core/async_cuda/tests/unit/trivial_demo.cu
+++ b/libs/core/async_cuda/tests/unit/trivial_demo.cu
@@ -4,8 +4,6 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include <boost/preprocessor/seq/for_each.hpp>
-
 #include <hpx/config.hpp>
 
 #include <hpx/assert.hpp>
@@ -66,16 +64,11 @@ void cuda_trivial_kernel(T t, cudaStream_t stream)
 // -------------------------------------------------------------------------
 // To make the kernel visible for all template instantiations we might use
 // we must instantiate them here first in the cuda compiled code.
-// Use a simple boost preprocessor macro to allow any types to
-// be added.
 
-// list of types to generate code for
-#define TYPES (double) (float)    //
+template __global__ void trivial_kernel<float>(float);
+template __global__ void copy_kernel<float>(float*, float*);
+template void cuda_trivial_kernel<float>(float, cudaStream_t);
 
-#define GENERATE_SPECIALIZATIONS(_1, _2, elem)                                 \
-    template __global__ void trivial_kernel<elem>(elem);                       \
-    template __global__ void copy_kernel<elem>(elem*, elem*);                  \
-    template void cuda_trivial_kernel<elem>(elem, cudaStream_t);               \
-    //
-
-BOOST_PP_SEQ_FOR_EACH(GENERATE_SPECIALIZATIONS, _, TYPES)
+template __global__ void trivial_kernel<double>(double);
+template __global__ void copy_kernel<double>(double*, double*);
+template void cuda_trivial_kernel<double>(double, cudaStream_t);

--- a/libs/core/batch_environments/src/pjm_environment.cpp
+++ b/libs/core/batch_environments/src/pjm_environment.cpp
@@ -5,9 +5,8 @@
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <hpx/batch_environments/pjm_environment.hpp>
+#include <hpx/string_util/tokenizer.hpp>
 #include <hpx/util/from_string.hpp>
-
-#include <boost/tokenizer.hpp>
 
 #include <algorithm>
 #include <cstddef>
@@ -69,9 +68,8 @@ namespace hpx::util::batch_environments {
             }
             else if ((var = std::getenv("FLIB_AFFINITY_ON_PROCESS")) != nullptr)
             {
-                boost::char_separator<char> sep(",");
-                boost::tokenizer<boost::char_separator<char>> tok(
-                    std::string(var), sep);
+                hpx::string_util::char_separator<char> sep(",");
+                hpx::string_util::tokenizer tok(std::string(var), sep);
                 num_threads_ = static_cast<std::size_t>(
                     std::distance(std::begin(tok), std::end(tok)));
             }

--- a/libs/core/command_line_handling_local/CMakeLists.txt
+++ b/libs/core/command_line_handling_local/CMakeLists.txt
@@ -35,6 +35,7 @@ add_hpx_module(
     hpx_errors
     hpx_filesystem
     hpx_format
+    hpx_string_util
     hpx_topology
     hpx_util
     hpx_version

--- a/libs/core/command_line_handling_local/src/command_line_handling_local.cpp
+++ b/libs/core/command_line_handling_local/src/command_line_handling_local.cpp
@@ -14,14 +14,13 @@
 #include <hpx/modules/format.hpp>
 #include <hpx/modules/program_options.hpp>
 #include <hpx/modules/runtime_configuration.hpp>
+#include <hpx/modules/string_util.hpp>
 #include <hpx/modules/topology.hpp>
 #include <hpx/modules/util.hpp>
 #include <hpx/preprocessor/stringize.hpp>
 #include <hpx/type_support/unused.hpp>
 #include <hpx/util/from_string.hpp>
 #include <hpx/version.hpp>
-
-#include <boost/tokenizer.hpp>
 
 #include <algorithm>
 #include <cstddef>
@@ -837,9 +836,8 @@ namespace hpx { namespace local { namespace detail {
             return HPX_MOVE(args);
         }
 
-        using tokenizer = boost::tokenizer<boost::escaped_list_separator<char>>;
-        boost::escaped_list_separator<char> sep('\\', ' ', '\"');
-        tokenizer tok(options, sep);
+        hpx::string_util::escaped_list_separator sep('\\', ' ', '\"');
+        hpx::string_util::tokenizer tok(options, sep);
 
         std::vector<std::string> result(tok.begin(), tok.end());
         std::move(args.begin(), args.end(), std::back_inserter(result));

--- a/libs/core/datastructures/tests/unit/any_serialization.cpp
+++ b/libs/core/datastructures/tests/unit/any_serialization.cpp
@@ -14,13 +14,6 @@
 #include <typeinfo>
 #include <vector>
 
-#include <boost/config.hpp>
-#if defined(BOOST_NO_STDC_NAMESPACE)
-namespace std {
-    using ::remove;
-}
-#endif
-
 #include <hpx/datastructures/serialization/serializable_any.hpp>
 #include <hpx/local/init.hpp>
 #include <hpx/modules/testing.hpp>

--- a/libs/core/debugging/src/backtrace.cpp
+++ b/libs/core/debugging/src/backtrace.cpp
@@ -15,8 +15,6 @@
 
 #include <hpx/debugging/backtrace/backtrace.hpp>
 
-#include <boost/config.hpp>
-
 #if (defined(__linux) || defined(__APPLE__) || defined(__sun)) &&              \
     (!defined(__ANDROID__) || !defined(ANDROID))
 #if defined(__GLIBC__)

--- a/libs/core/iterator_support/CMakeLists.txt
+++ b/libs/core/iterator_support/CMakeLists.txt
@@ -5,6 +5,7 @@
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 set(iterator_support_headers
+    hpx/iterator_support/detail/minimum_category.hpp
     hpx/iterator_support/traits/is_iterator.hpp
     hpx/iterator_support/traits/is_range.hpp
     hpx/iterator_support/traits/is_sentinel_for.hpp

--- a/libs/core/iterator_support/include/hpx/iterator_support/detail/minimum_category.hpp
+++ b/libs/core/iterator_support/include/hpx/iterator_support/detail/minimum_category.hpp
@@ -1,0 +1,133 @@
+//  Copyright (c) 022 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include <iterator>
+
+namespace hpx::util::detail {
+
+    ///////////////////////////////////////////////////////////////////////
+    template <typename T, typename U>
+    struct minimum_category
+    {
+        static_assert(sizeof(T) == 0 && sizeof(U) == 0,
+            "unknown combination of iterator categories");
+    };
+
+    // random_access_iterator_tag
+    template <>
+    struct minimum_category<std::random_access_iterator_tag,
+        std::random_access_iterator_tag>
+    {
+        using type = std::random_access_iterator_tag;
+    };
+
+    template <>
+    struct minimum_category<std::random_access_iterator_tag,
+        std::bidirectional_iterator_tag>
+    {
+        using type = std::bidirectional_iterator_tag;
+    };
+
+    template <>
+    struct minimum_category<std::bidirectional_iterator_tag,
+        std::random_access_iterator_tag>
+    {
+        using type = std::bidirectional_iterator_tag;
+    };
+
+    template <>
+    struct minimum_category<std::random_access_iterator_tag,
+        std::forward_iterator_tag>
+    {
+        using type = std::forward_iterator_tag;
+    };
+
+    template <>
+    struct minimum_category<std::forward_iterator_tag,
+        std::random_access_iterator_tag>
+    {
+        using type = std::forward_iterator_tag;
+    };
+
+    template <>
+    struct minimum_category<std::random_access_iterator_tag,
+        std::input_iterator_tag>
+    {
+        using type = std::input_iterator_tag;
+    };
+
+    template <>
+    struct minimum_category<std::input_iterator_tag,
+        std::random_access_iterator_tag>
+    {
+        using type = std::input_iterator_tag;
+    };
+
+    // bidirectional_iterator_tag
+    template <>
+    struct minimum_category<std::bidirectional_iterator_tag,
+        std::bidirectional_iterator_tag>
+    {
+        using type = std::bidirectional_iterator_tag;
+    };
+
+    template <>
+    struct minimum_category<std::bidirectional_iterator_tag,
+        std::forward_iterator_tag>
+    {
+        using type = std::forward_iterator_tag;
+    };
+
+    template <>
+    struct minimum_category<std::forward_iterator_tag,
+        std::bidirectional_iterator_tag>
+    {
+        using type = std::forward_iterator_tag;
+    };
+
+    template <>
+    struct minimum_category<std::bidirectional_iterator_tag,
+        std::input_iterator_tag>
+    {
+        using type = std::input_iterator_tag;
+    };
+
+    template <>
+    struct minimum_category<std::input_iterator_tag,
+        std::bidirectional_iterator_tag>
+    {
+        using type = std::input_iterator_tag;
+    };
+
+    // forward_iterator_tag
+    template <>
+    struct minimum_category<std::forward_iterator_tag,
+        std::forward_iterator_tag>
+    {
+        using type = std::forward_iterator_tag;
+    };
+
+    template <>
+    struct minimum_category<std::input_iterator_tag, std::forward_iterator_tag>
+    {
+        using type = std::input_iterator_tag;
+    };
+
+    template <>
+    struct minimum_category<std::forward_iterator_tag, std::input_iterator_tag>
+    {
+        using type = std::input_iterator_tag;
+    };
+
+    // input_iterator_tag
+    template <>
+    struct minimum_category<std::input_iterator_tag, std::input_iterator_tag>
+    {
+        using type = std::input_iterator_tag;
+    };
+}    // namespace hpx::util::detail

--- a/libs/core/iterator_support/include/hpx/iterator_support/zip_iterator.hpp
+++ b/libs/core/iterator_support/include/hpx/iterator_support/zip_iterator.hpp
@@ -10,6 +10,7 @@
 #include <hpx/config.hpp>
 #include <hpx/datastructures/tuple.hpp>
 #include <hpx/functional/invoke_result.hpp>
+#include <hpx/iterator_support/detail/minimum_category.hpp>
 #include <hpx/iterator_support/iterator_facade.hpp>
 #include <hpx/iterator_support/traits/is_iterator.hpp>
 #include <hpx/serialization/serialization_fwd.hpp>
@@ -47,130 +48,6 @@ namespace hpx { namespace util {
         };
 
         ///////////////////////////////////////////////////////////////////////
-        template <typename T, typename U>
-        struct zip_iterator_category_impl
-        {
-            static_assert(sizeof(T) == 0 && sizeof(U) == 0,
-                "unknown combination of iterator categories");
-        };
-
-        // random_access_iterator_tag
-        template <>
-        struct zip_iterator_category_impl<std::random_access_iterator_tag,
-            std::random_access_iterator_tag>
-        {
-            using type = std::random_access_iterator_tag;
-        };
-
-        template <>
-        struct zip_iterator_category_impl<std::random_access_iterator_tag,
-            std::bidirectional_iterator_tag>
-        {
-            using type = std::bidirectional_iterator_tag;
-        };
-
-        template <>
-        struct zip_iterator_category_impl<std::bidirectional_iterator_tag,
-            std::random_access_iterator_tag>
-        {
-            using type = std::bidirectional_iterator_tag;
-        };
-
-        template <>
-        struct zip_iterator_category_impl<std::random_access_iterator_tag,
-            std::forward_iterator_tag>
-        {
-            using type = std::forward_iterator_tag;
-        };
-
-        template <>
-        struct zip_iterator_category_impl<std::forward_iterator_tag,
-            std::random_access_iterator_tag>
-        {
-            using type = std::forward_iterator_tag;
-        };
-
-        template <>
-        struct zip_iterator_category_impl<std::random_access_iterator_tag,
-            std::input_iterator_tag>
-        {
-            using type = std::input_iterator_tag;
-        };
-
-        template <>
-        struct zip_iterator_category_impl<std::input_iterator_tag,
-            std::random_access_iterator_tag>
-        {
-            using type = std::input_iterator_tag;
-        };
-
-        // bidirectional_iterator_tag
-        template <>
-        struct zip_iterator_category_impl<std::bidirectional_iterator_tag,
-            std::bidirectional_iterator_tag>
-        {
-            using type = std::bidirectional_iterator_tag;
-        };
-
-        template <>
-        struct zip_iterator_category_impl<std::bidirectional_iterator_tag,
-            std::forward_iterator_tag>
-        {
-            using type = std::forward_iterator_tag;
-        };
-
-        template <>
-        struct zip_iterator_category_impl<std::forward_iterator_tag,
-            std::bidirectional_iterator_tag>
-        {
-            using type = std::forward_iterator_tag;
-        };
-
-        template <>
-        struct zip_iterator_category_impl<std::bidirectional_iterator_tag,
-            std::input_iterator_tag>
-        {
-            using type = std::input_iterator_tag;
-        };
-
-        template <>
-        struct zip_iterator_category_impl<std::input_iterator_tag,
-            std::bidirectional_iterator_tag>
-        {
-            using type = std::input_iterator_tag;
-        };
-
-        // forward_iterator_tag
-        template <>
-        struct zip_iterator_category_impl<std::forward_iterator_tag,
-            std::forward_iterator_tag>
-        {
-            using type = std::forward_iterator_tag;
-        };
-
-        template <>
-        struct zip_iterator_category_impl<std::input_iterator_tag,
-            std::forward_iterator_tag>
-        {
-            using type = std::input_iterator_tag;
-        };
-
-        template <>
-        struct zip_iterator_category_impl<std::forward_iterator_tag,
-            std::input_iterator_tag>
-        {
-            using type = std::input_iterator_tag;
-        };
-
-        // input_iterator_tag
-        template <>
-        struct zip_iterator_category_impl<std::input_iterator_tag,
-            std::input_iterator_tag>
-        {
-            using type = std::input_iterator_tag;
-        };
-
-        ///////////////////////////////////////////////////////////////////////
         template <typename IteratorTuple, typename Enable = void>
         struct zip_iterator_category;
 
@@ -184,7 +61,7 @@ namespace hpx { namespace util {
         template <typename T, typename U>
         struct zip_iterator_category<hpx::tuple<T, U>,
             std::enable_if_t<hpx::tuple_size<hpx::tuple<T, U>>::value == 2>>
-          : zip_iterator_category_impl<
+          : minimum_category<
                 typename std::iterator_traits<T>::iterator_category,
                 typename std::iterator_traits<U>::iterator_category>
         {
@@ -194,8 +71,8 @@ namespace hpx { namespace util {
         struct zip_iterator_category<hpx::tuple<T, U, Tail...>,
             std::enable_if_t<(
                 hpx::tuple_size<hpx::tuple<T, U, Tail...>>::value > 2)>>
-          : zip_iterator_category_impl<
-                typename zip_iterator_category_impl<
+          : minimum_category<
+                typename minimum_category<
                     typename std::iterator_traits<T>::iterator_category,
                     typename std::iterator_traits<U>::iterator_category>::type,
                 typename zip_iterator_category<hpx::tuple<Tail...>>::type>

--- a/libs/core/lci_base/CMakeLists.txt
+++ b/libs/core/lci_base/CMakeLists.txt
@@ -25,7 +25,8 @@ add_hpx_module(
   GLOBAL_HEADER_GEN ON
   SOURCES ${lci_base_sources}
   HEADERS ${lci_base_headers}
-  MODULE_DEPENDENCIES hpx_logging hpx_runtime_configuration hpx_util
+  MODULE_DEPENDENCIES hpx_logging hpx_runtime_configuration hpx_string_util
+                      hpx_util
   DEPENDENCIES LCI::LCI
   CMAKE_SUBDIRS examples tests
 )

--- a/libs/core/lci_base/src/lci_environment.cpp
+++ b/libs/core/lci_base/src/lci_environment.cpp
@@ -11,9 +11,9 @@
 #include <hpx/modules/lci_base.hpp>
 #include <hpx/modules/logging.hpp>
 #include <hpx/modules/runtime_configuration.hpp>
+#include <hpx/modules/string_util.hpp>
 #include <hpx/modules/util.hpp>
 #include <asio/ip/host_name.hpp>
-#include <boost/tokenizer.hpp>
 
 #include <atomic>
 #include <cstddef>
@@ -36,9 +36,8 @@ namespace hpx { namespace util {
             std::string lci_environment_strings =
                 cfg.get_entry("hpx.parcel.lci.env", default_env);
 
-            boost::char_separator<char> sep(";,: ");
-            boost::tokenizer<boost::char_separator<char>> tokens(
-                lci_environment_strings, sep);
+            hpx::string_util::char_separator sep(";,: ");
+            hpx::string_util::tokenizer tokens(lci_environment_strings, sep);
             for (auto const& tok : tokens)
             {
                 char* env = std::getenv(tok.c_str());

--- a/libs/core/mpi_base/CMakeLists.txt
+++ b/libs/core/mpi_base/CMakeLists.txt
@@ -35,7 +35,8 @@ add_hpx_module(
   SOURCES ${mpi_base_sources}
   HEADERS ${mpi_base_headers}
   COMPAT_HEADERS ${mpi_base_compat_headers}
-  MODULE_DEPENDENCIES hpx_logging hpx_runtime_configuration hpx_util
+  MODULE_DEPENDENCIES hpx_logging hpx_runtime_configuration hpx_string_util
+                      hpx_util
   DEPENDENCIES ${additional_dependencies}
   CMAKE_SUBDIRS examples tests
 )

--- a/libs/core/mpi_base/src/mpi_environment.cpp
+++ b/libs/core/mpi_base/src/mpi_environment.cpp
@@ -11,9 +11,8 @@
 #include <hpx/modules/logging.hpp>
 #include <hpx/modules/mpi_base.hpp>
 #include <hpx/modules/runtime_configuration.hpp>
+#include <hpx/modules/string_util.hpp>
 #include <hpx/modules/util.hpp>
-
-#include <boost/tokenizer.hpp>
 
 #include <cstddef>
 #include <cstdlib>
@@ -35,9 +34,8 @@ namespace hpx { namespace util {
             std::string mpi_environment_strings =
                 cfg.get_entry("hpx.parcel.mpi.env", default_env);
 
-            boost::char_separator<char> sep(";,: ");
-            boost::tokenizer<boost::char_separator<char>> tokens(
-                mpi_environment_strings, sep);
+            hpx::string_util::char_separator sep(";,: ");
+            hpx::string_util::tokenizer tokens(mpi_environment_strings, sep);
             for (auto const& tok : tokens)
             {
                 char* env = std::getenv(tok.c_str());

--- a/libs/core/prefix/src/find_prefix.cpp
+++ b/libs/core/prefix/src/find_prefix.cpp
@@ -1,6 +1,6 @@
 ////////////////////////////////////////////////////////////////////////////////
 //  Copyright (c) 2012 Bryce Adelstein-Lelbach
-//  Copyright (c) 2012-2017 Hartmut Kaiser
+//  Copyright (c) 2012-2022 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -15,6 +15,7 @@
 #include <hpx/prefix/find_prefix.hpp>
 #include <hpx/string_util/classification.hpp>
 #include <hpx/string_util/split.hpp>
+#include <hpx/string_util/tokenizer.hpp>
 #include <hpx/type_support/unused.hpp>
 
 #if defined(HPX_WINDOWS)
@@ -33,8 +34,6 @@
 #include <sys/types.h>
 #include <vector>
 #endif
-
-#include <boost/tokenizer.hpp>
 
 #include <cstdint>
 #include <string>
@@ -87,11 +86,11 @@ namespace hpx { namespace util {
         std::string const& suffix, std::string const& library)
     {
         std::string prefixes = find_prefix(library);
-        typedef boost::tokenizer<boost::char_separator<char>> tokenizer;
-        boost::char_separator<char> sep(HPX_INI_PATH_DELIMITER);
-        tokenizer tokens(prefixes, sep);
+
+        hpx::string_util::char_separator sep(HPX_INI_PATH_DELIMITER);
+        hpx::string_util::tokenizer tokens(prefixes, sep);
         std::string result;
-        for (tokenizer::iterator it = tokens.begin(); it != tokens.end(); ++it)
+        for (auto it = tokens.begin(); it != tokens.end(); ++it)
         {
             if (it != tokens.begin())
                 result += HPX_INI_PATH_DELIMITER;

--- a/libs/core/program_options/CMakeLists.txt
+++ b/libs/core/program_options/CMakeLists.txt
@@ -58,6 +58,6 @@ add_hpx_module(
   COMPAT_HEADERS ${program_options_compat_headers}
   DEPENDENCIES ${__boost_program_options}
   MODULE_DEPENDENCIES hpx_config hpx_datastructures hpx_format
-                      hpx_iterator_support
+                      hpx_iterator_support hpx_string_util
   CMAKE_SUBDIRS examples tests
 )

--- a/libs/core/program_options/examples/option_groups.cpp
+++ b/libs/core/program_options/examples/option_groups.cpp
@@ -26,10 +26,6 @@
 #include <iostream>
 #include <string>
 
-#include <boost/token_functions.hpp>
-#include <boost/tokenizer.hpp>
-
-using namespace boost;
 using namespace hpx::program_options;
 using namespace std;
 

--- a/libs/core/program_options/examples/response_file.cpp
+++ b/libs/core/program_options/examples/response_file.cpp
@@ -17,9 +17,7 @@
 */
 
 #include <hpx/modules/program_options.hpp>
-
-#include <boost/token_functions.hpp>
-#include <boost/tokenizer.hpp>
+#include <hpx/modules/string_util.hpp>
 
 #include <algorithm>
 #include <fstream>
@@ -29,7 +27,6 @@
 #include <utility>
 #include <vector>
 
-using namespace boost;
 using namespace hpx::program_options;
 using namespace std;
 
@@ -87,8 +84,8 @@ int main(int ac, char* av[])
 
             // Split the file content
             string sstr = ss.str();
-            char_separator<char> sep(" \n\r");
-            tokenizer<char_separator<char>> tok(sstr, sep);
+            hpx::string_util::char_separator sep(" \n\r");
+            hpx::string_util::tokenizer tok(sstr, sep);
 
             vector<string> args;
             copy(tok.begin(), tok.end(), back_inserter(args));

--- a/libs/core/program_options/src/options_description.cpp
+++ b/libs/core/program_options/src/options_description.cpp
@@ -11,8 +11,7 @@
 // FIXME: this is only to get multiple_occurrences class
 // should move that to a separate headers.
 #include <hpx/program_options/parsers.hpp>
-
-#include <boost/tokenizer.hpp>
+#include <hpx/string_util/tokenizer.hpp>
 
 #include <climits>
 #include <cstdarg>
@@ -558,17 +557,12 @@ namespace hpx { namespace program_options {
             // conditions!
             HPX_ASSERT(line_length > first_column_width);
 
-            // Note: can't use 'tokenizer' as name of typedef -- borland
-            // will consider uses of 'tokenizer' below as uses of
-            // boost::tokenizer, not typedef.
-            using tok = boost::tokenizer<boost::char_separator<char>>;
+            hpx::string_util::tokenizer paragraphs(desc,
+                hpx::string_util::char_separator(
+                    "\n", "", hpx::string_util::empty_token_policy::keep));
 
-            tok paragraphs(desc,
-                boost::char_separator<char>(
-                    "\n", "", boost::keep_empty_tokens));
-
-            tok::const_iterator par_iter = paragraphs.begin();
-            const tok::const_iterator par_end = paragraphs.end();
+            auto par_iter = paragraphs.begin();
+            auto const par_end = paragraphs.end();
 
             while (par_iter != par_end)    // paragraphs
             {

--- a/libs/core/program_options/src/split.cpp
+++ b/libs/core/program_options/src/split.cpp
@@ -6,31 +6,26 @@
 
 #include <hpx/program_options/config.hpp>
 #include <hpx/program_options/parsers.hpp>
-
-#include <boost/tokenizer.hpp>
+#include <hpx/string_util/tokenizer.hpp>
 
 #include <string>
 #include <vector>
 
 namespace hpx { namespace program_options { namespace detail {
 
-    template <class Char>
+    template <typename Char>
     std::vector<std::basic_string<Char>> split_unix(
-        const std::basic_string<Char>& cmdline,
-        const std::basic_string<Char>& separator,
-        const std::basic_string<Char>& quote,
-        const std::basic_string<Char>& escape)
+        std::basic_string<Char> const& cmdline,
+        std::basic_string<Char> const& separator,
+        std::basic_string<Char> const& quote,
+        std::basic_string<Char> const& escape)
     {
-        using tokenizerT = boost::tokenizer<boost::escaped_list_separator<Char>,
-            typename std::basic_string<Char>::const_iterator,
-            std::basic_string<Char>>;
-
-        tokenizerT tok(cmdline.begin(), cmdline.end(),
-            boost::escaped_list_separator<Char>(escape, separator, quote));
+        hpx::string_util::tokenizer tok(cmdline.begin(), cmdline.end(),
+            hpx::string_util::escaped_list_separator<Char>(
+                escape, separator, quote));
 
         std::vector<std::basic_string<Char>> result;
-        for (typename tokenizerT::iterator cur_token(tok.begin()),
-             end_token(tok.end());
+        for (auto cur_token(tok.begin()), end_token(tok.end());
              cur_token != end_token; ++cur_token)
         {
             if (!cur_token->empty())
@@ -38,7 +33,6 @@ namespace hpx { namespace program_options { namespace detail {
         }
         return result;
     }
-
 }}}    // namespace hpx::program_options::detail
 
 namespace hpx { namespace program_options {
@@ -58,5 +52,4 @@ namespace hpx { namespace program_options {
     {
         return detail::split_unix<wchar_t>(cmdline, separator, quote, escape);
     }
-
 }}    // namespace hpx::program_options

--- a/libs/core/runtime_configuration/CMakeLists.txt
+++ b/libs/core/runtime_configuration/CMakeLists.txt
@@ -56,6 +56,7 @@ add_hpx_module(
     hpx_prefix
     hpx_coroutines
     hpx_version
+    hpx_string_util
     hpx_synchronization
   CMAKE_SUBDIRS examples tests
 )

--- a/libs/core/runtime_configuration/src/init_ini_data.cpp
+++ b/libs/core/runtime_configuration/src/init_ini_data.cpp
@@ -12,13 +12,12 @@
 #include <hpx/modules/filesystem.hpp>
 #include <hpx/modules/logging.hpp>
 #include <hpx/modules/plugin.hpp>
+#include <hpx/modules/string_util.hpp>
 #include <hpx/prefix/find_prefix.hpp>
 #include <hpx/runtime_configuration/component_registry_base.hpp>
 #include <hpx/runtime_configuration/init_ini_data.hpp>
 #include <hpx/runtime_configuration/plugin_registry_base.hpp>
 #include <hpx/version.hpp>
-
-#include <boost/tokenizer.hpp>
 
 #include <algorithm>
 #include <iostream>
@@ -88,20 +87,16 @@ namespace hpx { namespace util {
             ini.get_entry("hpx.master_ini_path_suffixes"));
 
         // split off the separate paths from the given path list
-        typedef boost::tokenizer<boost::char_separator<char>> tokenizer_type;
-
-        boost::char_separator<char> sep(HPX_INI_PATH_DELIMITER);
-        tokenizer_type tok_paths(ini_paths, sep);
-        tokenizer_type::iterator end_paths = tok_paths.end();
-        tokenizer_type tok_suffixes(ini_paths_suffixes, sep);
-        tokenizer_type::iterator end_suffixes = tok_suffixes.end();
+        hpx::string_util::char_separator sep(HPX_INI_PATH_DELIMITER);
+        hpx::string_util::tokenizer tok_paths(ini_paths, sep);
+        auto end_paths = tok_paths.end();
+        hpx::string_util::tokenizer tok_suffixes(ini_paths_suffixes, sep);
+        auto end_suffixes = tok_suffixes.end();
 
         bool result = false;
-        for (tokenizer_type::iterator it = tok_paths.begin(); it != end_paths;
-             ++it)
+        for (auto it = tok_paths.begin(); it != end_paths; ++it)
         {
-            for (tokenizer_type::iterator jt = tok_suffixes.begin();
-                 jt != end_suffixes; ++jt)
+            for (auto jt = tok_suffixes.begin(); jt != end_suffixes; ++jt)
             {
                 std::string path = *it;
                 path += *jt;
@@ -181,12 +176,10 @@ namespace hpx { namespace util {
         std::vector<std::string> ini_paths;
 
         // split off the separate paths from the given path list
-        typedef boost::tokenizer<boost::char_separator<char>> tokenizer_type;
-
-        boost::char_separator<char> sep(HPX_INI_PATH_DELIMITER);
-        tokenizer_type tok(ini_path, sep);
-        tokenizer_type::iterator end = tok.end();
-        for (tokenizer_type::iterator it = tok.begin(); it != end; ++it)
+        hpx::string_util::char_separator sep(HPX_INI_PATH_DELIMITER);
+        hpx::string_util::tokenizer tok(ini_path, sep);
+        auto end = tok.end();
+        for (auto it = tok.begin(); it != end; ++it)
             ini_paths.push_back(*it);
 
         // have all path elements, now find ini files in there...

--- a/libs/core/runtime_configuration/src/runtime_configuration.cpp
+++ b/libs/core/runtime_configuration/src/runtime_configuration.cpp
@@ -9,6 +9,7 @@
 #include <hpx/assert.hpp>
 #include <hpx/modules/filesystem.hpp>
 #include <hpx/modules/itt_notify.hpp>
+#include <hpx/modules/string_util.hpp>
 #include <hpx/prefix/find_prefix.hpp>
 #include <hpx/preprocessor/expand.hpp>
 #include <hpx/preprocessor/stringize.hpp>
@@ -21,8 +22,6 @@
 #include <hpx/util/from_string.hpp>
 #include <hpx/util/get_entry_as.hpp>
 #include <hpx/version.hpp>
-
-#include <boost/tokenizer.hpp>
 
 #include <algorithm>
 #include <cstddef>
@@ -597,22 +596,18 @@ namespace hpx { namespace util {
         // installation location, this allows to install simple components
         // without the need to install an ini file
         // split of the separate paths from the given path list
-        typedef boost::tokenizer<boost::char_separator<char>> tokenizer_type;
+        hpx::string_util::char_separator sep(HPX_INI_PATH_DELIMITER);
+        hpx::string_util::tokenizer tok_path(component_base_paths, sep);
+        hpx::string_util::tokenizer tok_suffixes(component_path_suffixes, sep);
+        auto end_path = tok_path.end();
+        auto end_suffixes = tok_suffixes.end();
 
-        boost::char_separator<char> sep(HPX_INI_PATH_DELIMITER);
-        tokenizer_type tok_path(component_base_paths, sep);
-        tokenizer_type tok_suffixes(component_path_suffixes, sep);
-        tokenizer_type::iterator end_path = tok_path.end();
-        tokenizer_type::iterator end_suffixes = tok_suffixes.end();
-
-        for (tokenizer_type::iterator it = tok_path.begin(); it != end_path;
-             ++it)
+        for (auto it = tok_path.begin(); it != end_path; ++it)
         {
             std::string const& path = *it;
             if (tok_suffixes.begin() != tok_suffixes.end())
             {
-                for (tokenizer_type::iterator jt = tok_suffixes.begin();
-                     jt != end_suffixes; ++jt)
+                for (auto jt = tok_suffixes.begin(); jt != end_suffixes; ++jt)
                 {
                     std::string p = path;
                     p += *jt;

--- a/libs/core/string_util/CMakeLists.txt
+++ b/libs/core/string_util/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2019 The STE||AR-Group
+# Copyright (c) 2019-2022 The STE||AR-Group
 #
 # SPDX-License-Identifier: BSL-1.0
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -7,8 +7,13 @@
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 
 set(string_util_headers
-    hpx/string_util/case_conv.hpp hpx/string_util/classification.hpp
-    hpx/string_util/split.hpp hpx/string_util/trim.hpp
+    hpx/string_util/case_conv.hpp
+    hpx/string_util/classification.hpp
+    hpx/string_util/split.hpp
+    hpx/string_util/token_functions.hpp
+    hpx/string_util/token_iterator.hpp
+    hpx/string_util/tokenizer.hpp
+    hpx/string_util/trim.hpp
 )
 
 include(HPX_AddModule)
@@ -16,5 +21,6 @@ add_hpx_module(
   core string_util
   GLOBAL_HEADER_GEN ON
   HEADERS ${string_util_headers}
+  MODULE_DEPENDENCIES hpx_assertion hpx_config hpx_errors hpx_iterator_support
   CMAKE_SUBDIRS examples tests
 )

--- a/libs/core/string_util/include/hpx/string_util/token_functions.hpp
+++ b/libs/core/string_util/include/hpx/string_util/token_functions.hpp
@@ -1,0 +1,731 @@
+//  Copyright (c) 2022 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+// Copyright John R. Bandela 2001.
+
+// See http://www.boost.org/libs/tokenizer/ for documentation.
+
+// Revision History:
+// 01 Oct 2004   Joaquin M Lopez Munoz
+//      Workaround for a problem with string::assign in msvc-stlport
+// 06 Apr 2004   John Bandela
+//      Fixed a bug involving using char_delimiter with a true input iterator
+// 28 Nov 2003   Robert Zeh and John Bandela
+//      Converted into "fast" functions that avoid using += when
+//      the supplied iterator isn't an input_iterator; based on
+//      some work done at Archelon and a version that was checked into
+//      the boost CVS for a short period of time.
+// 20 Feb 2002   John Maddock
+//      Removed using namespace std declarations and added
+//      workaround for BOOST_NO_STDC_NAMESPACE (the library
+//      can be safely mixed with regex).
+// 06 Feb 2002   Jeremy Siek
+//      Added char_separator.
+// 02 Feb 2002   Jeremy Siek
+//      Removed tabs and a little cleanup.
+
+#pragma once
+
+#include <hpx/config.hpp>
+#include <hpx/assert.hpp>
+#include <hpx/modules/errors.hpp>
+
+#include <algorithm>    // for find_if
+#include <cctype>
+#include <cwctype>
+#include <initializer_list>
+#include <iterator>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace hpx::string_util {
+
+    //=========================================================================
+    // The escaped_list_separator class. Which is a model of TokenizerFunction
+    // An escaped list is a super-set of what is commonly known as a comma
+    // separated value (csv) list.It is separated into fields by a comma or
+    // other character. If the delimiting character is inside quotes, then it is
+    // counted as a regular character.To allow for embedded quotes in a field,
+    // there can be escape sequences using the \ much like C. The role of the
+    // comma, the quotation mark, and the escape character (backslash \), can be
+    // assigned to other characters.
+    template <typename Char,
+        typename Traits = typename std::basic_string<Char>::traits_type>
+    class escaped_list_separator
+    {
+    private:
+        using string_type = std::basic_string<Char, Traits>;
+
+        struct char_eq
+        {
+            Char e_;
+
+            explicit char_eq(Char e) noexcept
+              : e_(e)
+            {
+            }
+
+            bool operator()(Char c) noexcept
+            {
+                return Traits::eq(e_, c);
+            }
+        };
+
+        string_type escape_;
+        string_type c_;
+        string_type quote_;
+        bool last_ = false;
+
+        bool is_escape(Char e)
+        {
+            char_eq f(e);
+            return std::find_if(escape_.begin(), escape_.end(), f) !=
+                escape_.end();
+        }
+
+        bool is_c(Char e)
+        {
+            char_eq f(e);
+            return std::find_if(c_.begin(), c_.end(), f) != c_.end();
+        }
+
+        bool is_quote(Char e)
+        {
+            char_eq f(e);
+            return std::find_if(quote_.begin(), quote_.end(), f) !=
+                quote_.end();
+        }
+
+        template <typename iterator, typename Token>
+        void do_escape(iterator& next, iterator end, Token& tok)
+        {
+            if (++next == end)
+            {
+                HPX_THROW_EXCEPTION(invalid_status,
+                    "escaped_list_separator::do_escape",
+                    "cannot end with escape");
+            }
+
+            if (Traits::eq(*next, 'n'))
+            {
+                tok += '\n';
+                return;
+            }
+            else if (is_quote(*next) || is_c(*next) || is_escape(*next))
+            {
+                tok += *next;
+                return;
+            }
+            else
+            {
+                HPX_THROW_EXCEPTION(invalid_status,
+                    "escaped_list_separator::do_escape",
+                    "unknown escape sequence");
+            }
+        }
+
+    public:
+        explicit escaped_list_separator(
+            Char e = '\\', Char c = ',', Char q = '\"')
+          : escape_(1, e)
+          , c_(1, c)
+          , quote_(1, q)
+        {
+        }
+
+        escaped_list_separator(
+            string_type e, string_type c, string_type q) noexcept
+          : escape_(HPX_MOVE(e))
+          , c_(HPX_MOVE(c))
+          , quote_(HPX_MOVE(q))
+        {
+        }
+
+        void reset() noexcept
+        {
+            last_ = false;
+        }
+
+        template <typename InputIterator, typename Token>
+        bool operator()(InputIterator& next, InputIterator end, Token& tok)
+        {
+            bool bInQuote = false;
+            tok = Token();
+
+            if (next == end)
+            {
+                if (last_)
+                {
+                    last_ = false;
+                    return true;
+                }
+                else
+                {
+                    return false;
+                }
+            }
+
+            last_ = false;
+            for (; next != end; ++next)
+            {
+                if (is_escape(*next))
+                {
+                    do_escape(next, end, tok);
+                }
+                else if (is_c(*next))
+                {
+                    if (!bInQuote)
+                    {
+                        // If we are not in quote, then we are done
+                        ++next;
+
+                        // The last character was a c, that means there is 1
+                        // more blank field
+                        last_ = true;
+                        return true;
+                    }
+                    else
+                    {
+                        tok += *next;
+                    }
+                }
+                else if (is_quote(*next))
+                {
+                    bInQuote = !bInQuote;
+                }
+                else
+                {
+                    tok += *next;
+                }
+            }
+            return true;
+        }
+    };
+
+    //=========================================================================
+    // The classes here are used by offset_separator and char_separator to
+    // implement faster assigning of tokens using assign instead of +=
+
+    namespace detail {
+
+        //=====================================================================
+        // Tokenizer was broken for wide character separators, at least on
+        // Windows, since CRT functions isspace etc only expect values in [0,
+        // 0xFF]. Debug build asserts if higher values are passed in. The traits
+        // extension class should take care of this. Assuming that the
+        // conditional will always get optimized out in the function
+        // implementations, argument types are not a problem since both forms of
+        // character classifiers expect an int.
+        template <typename Traits, int N>
+        struct traits_extension_details : public Traits
+        {
+            using char_type = typename Traits::char_type;
+
+            static bool isspace(char_type c) noexcept
+            {
+                return std::iswspace(c) != 0;
+            }
+
+            static bool ispunct(char_type c) noexcept
+            {
+                return std::iswpunct(c) != 0;
+            }
+        };
+
+        template <typename Traits>
+        struct traits_extension_details<Traits, 1> : public Traits
+        {
+            using char_type = typename Traits::char_type;
+
+            static bool isspace(char_type c) noexcept
+            {
+                return std::isspace(c) != 0;
+            }
+
+            static bool ispunct(char_type c) noexcept
+            {
+                return std::ispunct(c) != 0;
+            }
+        };
+
+        // In case there is no cwctype header, we implement the checks manually.
+        // We make use of the fact that the tested categories should fit in
+        // ASCII.
+        template <typename Traits>
+        struct traits_extension : public Traits
+        {
+            using char_type = typename Traits::char_type;
+
+            static bool isspace(char_type c) noexcept
+            {
+                return traits_extension_details<Traits,
+                    sizeof(char_type)>::isspace(c);
+            }
+
+            static bool ispunct(char_type c) noexcept
+            {
+                return traits_extension_details<Traits,
+                    sizeof(char_type)>::ispunct(c);
+            }
+        };
+
+        // The assign_or_plus_equal struct contains functions that implement
+        // assign, +=, and clearing based on the iterator type. The generic case
+        // does nothing for plus_equal and clearing, while passing through the
+        // call for assign.
+        //
+        // When an input iterator is being used, the situation is reversed. The
+        // assign method does nothing, plus_equal invokes operator +=, and the
+        // clearing method sets the supplied token to the default token
+        // constructor's result.
+        template <typename IteratorTag>
+        struct assign_or_plus_equal
+        {
+            template <typename Iterator, typename Token>
+            static constexpr void assign(Iterator b, Iterator e, Token& t)
+            {
+                t.assign(b, e);
+            }
+
+            template <typename Token, typename Value>
+            static constexpr void plus_equal(Token&, Value&&) noexcept
+            {
+            }
+
+            // If we are doing an assign, there is no need for the the clear.
+            template <typename Token>
+            static constexpr void clear(Token&) noexcept
+            {
+            }
+        };
+
+        template <>
+        struct assign_or_plus_equal<std::input_iterator_tag>
+        {
+            template <class Iterator, class Token>
+            static constexpr void assign(Iterator, Iterator, Token&) noexcept
+            {
+            }
+
+            template <class Token, class Value>
+            static constexpr void plus_equal(Token& t, Value&& v)
+            {
+                t += HPX_FORWARD(Value, v);
+            }
+
+            template <class Token>
+            static constexpr void clear(Token& t)
+            {
+                t = Token();
+            }
+        };
+
+        template <typename Iterator>
+        struct class_iterator_category
+        {
+            using type = typename Iterator::iterator_category;
+        };
+
+        // This portably gets the iterator_tag without partial template
+        // specialization
+        template <typename Iterator>
+        struct get_iterator_category
+        {
+            using iterator_category =
+                std::conditional_t<std::is_pointer_v<Iterator>,
+                    std::random_access_iterator_tag,
+                    typename class_iterator_category<Iterator>::type>;
+        };
+    }    // namespace detail
+
+    //===========================================================================
+    // The offset_separator class, which is a model of TokenizerFunction. Offset
+    // breaks a string into tokens based on a range of offsets
+    class offset_separator
+    {
+    private:
+        std::vector<int> offsets_;
+        unsigned int current_offset_ = 0;
+        bool wrap_offsets_ = true;
+        bool return_partial_last_ = true;
+
+    public:
+        template <typename Iter>
+        offset_separator(Iter begin, Iter end, bool wrap_offsets = true,
+            bool return_partial_last = true)
+          : offsets_(begin, end)
+          , wrap_offsets_(wrap_offsets)
+          , return_partial_last_(return_partial_last)
+        {
+        }
+
+        offset_separator(std::initializer_list<int> init,
+            bool wrap_offsets = true, bool return_partial_last = true)
+          : offsets_(HPX_MOVE(init))
+          , wrap_offsets_(wrap_offsets)
+          , return_partial_last_(return_partial_last)
+        {
+        }
+
+        offset_separator()
+          : offsets_(1, 1)
+        {
+        }
+
+        void reset()
+        {
+            current_offset_ = 0;
+        }
+
+        template <typename InputIterator, typename Token>
+        bool operator()(InputIterator& next, InputIterator end, Token& tok)
+        {
+            using assigner = detail::assign_or_plus_equal<typename detail::
+                    get_iterator_category<InputIterator>::iterator_category>;
+
+            HPX_ASSERT(!offsets_.empty());
+
+            assigner::clear(tok);
+            InputIterator start(next);
+
+            if (next == end)
+            {
+                return false;
+            }
+
+            if (current_offset_ == offsets_.size())
+            {
+                if (wrap_offsets_)
+                {
+                    current_offset_ = 0;
+                }
+                else
+                {
+                    return false;
+                }
+            }
+
+            int c = offsets_[current_offset_];
+            int i = 0;
+            for (; i < c; ++i)
+            {
+                if (next == end)
+                {
+                    break;
+                }
+                assigner::plus_equal(tok, *next++);
+            }
+            assigner::assign(start, next, tok);
+
+            if (!return_partial_last_)
+            {
+                if (i < (c - 1))
+                {
+                    return false;
+                }
+            }
+
+            ++current_offset_;
+            return true;
+        }
+    };
+
+    //=========================================================================
+    // The char_separator class breaks a sequence of characters into tokens
+    // based on the character delimiters (very much like bad old strtok). A
+    // delimiter character can either be kept or dropped. A kept delimiter shows
+    // up as an output token, whereas a dropped delimiter does not.
+
+    // This class replaces the char_delimiters_separator class. The constructor
+    // for the char_delimiters_separator class was too confusing and needed to
+    // be deprecated. However, because of the default arguments to the
+    // constructor, adding the new constructor would cause ambiguity, so instead
+    // I deprecated the whole class. The implementation of the class was also
+    // simplified considerably.
+    enum class empty_token_policy
+    {
+        drop,
+        keep
+    };
+
+    // The out of the box GCC 2.95 on cygwin does not have a char_traits class.
+    template <typename Char,
+        typename Tr = typename std::basic_string<Char>::traits_type>
+    class char_separator
+    {
+        using Traits = detail::traits_extension<Tr>;
+        using string_type = std::basic_string<Char, Tr>;
+
+    public:
+        explicit char_separator(Char const* dropped_delims,
+            Char const* kept_delims = nullptr,
+            empty_token_policy empty_tokens = empty_token_policy::drop)
+          : m_dropped_delims(dropped_delims)
+          , m_use_ispunct(false)
+          , m_use_isspace(false)
+          , m_empty_tokens(empty_tokens)
+        {
+            // Borland workaround
+            if (kept_delims)
+                m_kept_delims = kept_delims;
+        }
+
+        // use ispunct() for kept delimiters and isspace for dropped.
+        char_separator() = default;
+
+        void reset() noexcept {}
+
+        template <typename InputIterator, typename Token>
+        bool operator()(InputIterator& next, InputIterator end, Token& tok)
+        {
+            using assigner = detail::assign_or_plus_equal<typename detail::
+                    get_iterator_category<InputIterator>::iterator_category>;
+
+            assigner::clear(tok);
+
+            // skip past all dropped_delims
+            if (m_empty_tokens == empty_token_policy::drop)
+            {
+                for (; next != end && is_dropped(*next); ++next)
+                {
+                }
+            }
+
+            InputIterator start(next);
+
+            if (m_empty_tokens == empty_token_policy::drop)
+            {
+                if (next == end)
+                    return false;
+
+                // if we are on a kept_delims move past it and stop
+                if (is_kept(*next))
+                {
+                    assigner::plus_equal(tok, *next);
+                    ++next;
+                }
+                else
+                {
+                    // append all the non delim characters
+                    for (; next != end && !is_dropped(*next) && !is_kept(*next);
+                         ++next)
+                    {
+                        assigner::plus_equal(tok, *next);
+                    }
+                }
+            }
+            else
+            {    // m_empty_tokens == empty_token_policy::keep
+
+                // Handle empty token at the end
+                if (next == end)
+                {
+                    if (m_output_done == false)
+                    {
+                        m_output_done = true;
+                        assigner::assign(start, next, tok);
+                        return true;
+                    }
+                    else
+                    {
+                        return false;
+                    }
+                }
+
+                if (is_kept(*next))
+                {
+                    if (m_output_done == false)
+                    {
+                        m_output_done = true;
+                    }
+                    else
+                    {
+                        assigner::plus_equal(tok, *next);
+                        ++next;
+                        m_output_done = false;
+                    }
+                }
+                else if (m_output_done == false && is_dropped(*next))
+                {
+                    m_output_done = true;
+                }
+                else
+                {
+                    if (is_dropped(*next))
+                    {
+                        start = ++next;
+                    }
+
+                    for (; next != end && !is_dropped(*next) && !is_kept(*next);
+                         ++next)
+                    {
+                        assigner::plus_equal(tok, *next);
+                    }
+
+                    m_output_done = true;
+                }
+            }
+
+            assigner::assign(start, next, tok);
+            return true;
+        }
+
+    private:
+        string_type m_kept_delims;
+        string_type m_dropped_delims;
+        bool m_use_ispunct = true;
+        bool m_use_isspace = true;
+        empty_token_policy m_empty_tokens = empty_token_policy::drop;
+        bool m_output_done = false;
+
+        bool is_kept(Char E) const
+        {
+            if (m_kept_delims.length())
+                return m_kept_delims.find(E) != string_type::npos;
+            else if (m_use_ispunct)
+            {
+                return Traits::ispunct(E) != 0;
+            }
+            else
+            {
+                return false;
+            }
+        }
+
+        bool is_dropped(Char E) const
+        {
+            if (m_dropped_delims.length())
+                return m_dropped_delims.find(E) != string_type::npos;
+            else if (m_use_isspace)
+            {
+                return Traits::isspace(E) != 0;
+            }
+            else
+            {
+                return false;
+            }
+        }
+    };
+
+    //===========================================================================
+    // The char_delimiters_separator class, which is a model of
+    // TokenizerFunction. char_delimiters_separator breaks a string into tokens
+    // based on character delimiters. There are 2 types of delimiters.
+    // Returnable delimiters can be returned as tokens. These are often
+    // punctuation. Nonreturnable delimiters cannot be returned as tokens. These
+    // are often whitespace
+
+    // The out of the box GCC 2.95 on cygwin does not have a char_traits class.
+    template <typename Char,
+        typename Tr = typename std::basic_string<Char>::traits_type>
+    class char_delimiters_separator
+    {
+    private:
+        using Traits = detail::traits_extension<Tr>;
+        using string_type = std::basic_string<Char, Tr>;
+
+        string_type returnable_;
+        string_type nonreturnable_;
+        bool return_delims_;
+        bool no_ispunct_;
+        bool no_isspace_;
+
+        bool is_ret(Char E) const noexcept
+        {
+            if (returnable_.length())
+            {
+                return returnable_.find(E) != string_type::npos;
+            }
+            else
+            {
+                if (no_ispunct_)
+                {
+                    return false;
+                }
+                else
+                {
+                    int r = Traits::ispunct(E);
+                    return r != 0;
+                }
+            }
+        }
+
+        bool is_nonret(Char E) const noexcept
+        {
+            if (nonreturnable_.length())
+            {
+                return nonreturnable_.find(E) != string_type::npos;
+            }
+            else
+            {
+                if (no_isspace_)
+                {
+                    return false;
+                }
+                else
+                {
+                    int r = Traits::isspace(E);
+                    return r != 0;
+                }
+            }
+        }
+
+    public:
+        explicit char_delimiters_separator(bool return_delims = false,
+            Char const* returnable = nullptr,
+            Char const* nonreturnable = nullptr)
+          : returnable_(returnable ? returnable : string_type().c_str())
+          , nonreturnable_(
+                nonreturnable ? nonreturnable : string_type().c_str())
+          , return_delims_(return_delims)
+          , no_ispunct_(returnable != nullptr)
+          , no_isspace_(nonreturnable != nullptr)
+        {
+        }
+
+        void reset() noexcept {}
+
+    public:
+        template <typename InputIterator, typename Token>
+        bool operator()(InputIterator& next, InputIterator end, Token& tok)
+        {
+            tok = Token();
+
+            // skip past all nonreturnable delims
+            // skip past the returnable only if we are not returning delims
+            for (; next != end &&
+                 (is_nonret(*next) || (is_ret(*next) && !return_delims_));
+                 ++next)
+            {
+            }
+
+            if (next == end)
+            {
+                return false;
+            }
+
+            // if we are to return delims and we are one a returnable one move
+            // past it and stop
+            if (is_ret(*next) && return_delims_)
+            {
+                tok += *next;
+                ++next;
+            }
+            else
+            {
+                // append all the non delim characters
+                for (; next != end && !is_nonret(*next) && !is_ret(*next);
+                     ++next)
+                {
+                    tok += *next;
+                }
+            }
+
+            return true;
+        }
+    };
+}    // namespace hpx::string_util

--- a/libs/core/string_util/include/hpx/string_util/token_iterator.hpp
+++ b/libs/core/string_util/include/hpx/string_util/token_iterator.hpp
@@ -1,0 +1,160 @@
+//  Copyright (c) 2022 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+// Copyright John R. Bandela 2001
+
+// See http://www.boost.org/libs/tokenizer for documentation.
+
+// Revision History:
+// 16 Jul 2003   John Bandela
+//      Allowed conversions from convertible base iterators
+// 03 Jul 2003   John Bandela
+//      Converted to new iterator adapter
+
+#pragma once
+
+#include <hpx/config.hpp>
+#include <hpx/assert.hpp>
+#include <hpx/iterator_support/detail/minimum_category.hpp>
+#include <hpx/iterator_support/iterator_adaptor.hpp>
+#include <hpx/iterator_support/iterator_facade.hpp>
+#include <hpx/string_util/token_functions.hpp>
+
+#include <string>
+#include <type_traits>
+#include <utility>
+
+namespace hpx::string_util {
+
+    template <typename TokenizerFunc, typename Iterator, typename Type>
+    class token_iterator
+      : public util::iterator_facade<
+            token_iterator<TokenizerFunc, Iterator, Type>, Type,
+            typename util::detail::minimum_category<std::forward_iterator_tag,
+                typename std::iterator_traits<Iterator>::iterator_category>::
+                type,
+            Type const&>
+    {
+    private:
+        friend class util::iterator_core_access;
+
+        TokenizerFunc f_;
+        Iterator begin_;
+        Iterator end_;
+        bool valid_ = false;
+        Type tok_;
+
+        void increment()
+        {
+            HPX_ASSERT(valid_);
+            valid_ = f_(begin_, end_, tok_);
+        }
+
+        Type const& dereference() const noexcept
+        {
+            HPX_ASSERT(valid_);
+            return tok_;
+        }
+
+        template <typename Other>
+        bool equal(Other const& a) const noexcept
+        {
+            return (a.valid_ && valid_) ?
+                ((a.begin_ == begin_) && (a.end_ == end_)) :
+                (a.valid_ == valid_);
+        }
+
+        void initialize()
+        {
+            if (valid_)
+                return;
+
+            f_.reset();
+            valid_ = (begin_ != end_) ? f_(begin_, end_, tok_) : false;
+        }
+
+    public:
+        token_iterator() = default;
+
+        template <typename F>
+        token_iterator(F&& f, Iterator begin, Iterator e = Iterator())
+          : f_(HPX_FORWARD(F, f))
+          , begin_(begin)
+          , end_(e)
+          , tok_()
+        {
+            initialize();
+        }
+
+        explicit token_iterator(Iterator begin, Iterator e = Iterator())
+          : f_()
+          , begin_(begin)
+          , end_(e)
+          , tok_()
+        {
+            initialize();
+        }
+
+        template <typename OtherIter,
+            typename =
+                std::enable_if_t<std::is_convertible_v<OtherIter, Iterator>>>
+        explicit token_iterator(
+            token_iterator<TokenizerFunc, OtherIter, Type> const& t)
+          : f_(t.tokenizer_function())
+          , begin_(t.base())
+          , end_(t.end())
+          , valid_(!t.at_end())
+          , tok_(t.current_token())
+        {
+        }
+
+        Iterator base() const
+        {
+            return begin_;
+        }
+
+        Iterator end() const
+        {
+            return end_;
+        }
+
+        TokenizerFunc const& tokenizer_function() const noexcept
+        {
+            return f_;
+        }
+
+        Type current_token() const
+        {
+            return tok_;
+        }
+
+        bool at_end() const noexcept
+        {
+            return !valid_;
+        }
+    };
+
+    template <typename TokenizerFunc = char_separator<char>,
+        typename Iterator = std::string::const_iterator,
+        typename Type = std::string>
+    struct token_iterator_generator
+    {
+        using type = token_iterator<TokenizerFunc, Iterator, Type>;
+    };
+
+    // Type has to be first because it needs to be explicitly specified as there
+    // is no way the function can deduce it.
+    template <typename Type, typename Iterator, typename TokenizerFunc>
+    typename token_iterator_generator<std::decay_t<TokenizerFunc>, Iterator,
+        Type>::type
+    make_token_iterator(Iterator begin, Iterator end, TokenizerFunc&& fun)
+    {
+        using iterator_type =
+            typename token_iterator_generator<std::decay_t<TokenizerFunc>,
+                Iterator, Type>::type;
+        return iterator_type(HPX_FORWARD(TokenizerFunc, fun), begin, end);
+    }
+}    // namespace hpx::string_util

--- a/libs/core/string_util/include/hpx/string_util/tokenizer.hpp
+++ b/libs/core/string_util/include/hpx/string_util/tokenizer.hpp
@@ -1,0 +1,134 @@
+//  Copyright (c) 2022 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+// (c) Copyright Jeremy Siek and John R. Bandela 2001.
+
+// See http://www.boost.org/libs/tokenizer for documentation
+
+// Revision History:
+// 03 Jul 2003   John Bandela
+//      Converted to new iterator adapter
+// 02 Feb 2002   Jeremy Siek
+//      Removed tabs and a little cleanup.
+
+#pragma once
+
+#include <hpx/iterator_support/traits/is_range.hpp>
+#include <hpx/string_util/token_iterator.hpp>
+
+#include <string>
+#include <type_traits>
+
+namespace hpx::string_util {
+
+    //===========================================================================
+    // A container-view of a tokenized "sequence"
+    template <typename TokenizerFunc = char_separator<char>,
+        typename Iterator = std::string::const_iterator,
+        typename Type = std::string>
+    class tokenizer
+    {
+    private:
+        using TGen = token_iterator_generator<TokenizerFunc, Iterator, Type>;
+
+        // It seems that MSVC does not like the unqualified use of iterator,
+        // Thus we use iter internally when it is used unqualified and
+        // the users of this class will always qualify iterator.
+        using iter = typename TGen::type;
+
+    public:
+        using iterator = iter;
+        using const_iterator = iter;
+        using value_type = Type;
+        using reference = value_type&;
+        using const_reference = value_type const&;
+        using pointer = value_type*;
+        using const_pointer = pointer const;
+        using size_type = void;
+        using difference_type = void;
+
+        template <typename F = TokenizerFunc>
+        tokenizer(Iterator first, Iterator last, F&& f = F())
+          : first_(first)
+          , last_(last)
+          , f_(HPX_FORWARD(F, f))
+        {
+        }
+
+        template <typename Container,
+            typename = std::enable_if_t<traits::is_range_v<Container>>>
+        explicit tokenizer(Container const& c)
+          : first_(c.begin())
+          , last_(c.end())
+          , f_()
+        {
+        }
+
+        template <typename F, typename Container,
+            typename = std::enable_if_t<traits::is_range_v<Container>>>
+        tokenizer(Container const& c, F&& f)
+          : first_(c.begin())
+          , last_(c.end())
+          , f_(HPX_FORWARD(F, f))
+        {
+        }
+
+        void assign(Iterator first, Iterator last)
+        {
+            first_ = first;
+            last_ = last;
+        }
+
+        template <typename F>
+        void assign(Iterator first, Iterator last, F&& f)
+        {
+            assign(first, last);
+            f_ = HPX_FORWARD(F, f);
+        }
+
+        template <typename Container,
+            typename = std::enable_if_t<traits::is_range_v<Container>>>
+        void assign(Container const& c)
+        {
+            assign(c.begin(), c.end());
+        }
+
+        template <typename F, typename Container,
+            typename = std::enable_if_t<traits::is_range_v<Container>>>
+        void assign(Container const& c, F&& f)
+        {
+            assign(c.begin(), c.end(), HPX_FORWARD(F, f));
+        }
+
+        iter begin() const
+        {
+            return iter(f_, first_, last_);
+        }
+
+        iter end() const
+        {
+            return iter(f_, last_, last_);
+        }
+
+    private:
+        Iterator first_;
+        Iterator last_;
+        TokenizerFunc f_;
+    };
+
+    // different clang-format versions disagree
+    // clang-format off
+    template <typename Iterator, typename F>
+    tokenizer(Iterator, Iterator, F&&) -> tokenizer<std::decay_t<F>, Iterator,
+        std::basic_string<typename std::iterator_traits<Iterator>::value_type>>;
+
+    template <typename Container, typename F>
+    tokenizer(Container const&, F&&)
+        -> tokenizer<std::decay_t<F>, traits::range_iterator_t<Container const>,
+            std::basic_string<typename std::iterator_traits<
+                traits::range_iterator_t<Container>>::value_type>>;
+    // clang-format on
+}    // namespace hpx::string_util

--- a/libs/core/string_util/tests/unit/CMakeLists.txt
+++ b/libs/core/string_util/tests/unit/CMakeLists.txt
@@ -4,7 +4,17 @@
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-set(tests string_to_lower string_split string_trim)
+set(tests
+    string_to_lower
+    string_split
+    string_trim
+    tokenizer
+    tokenizer_1
+    tokenizer_2
+    tokenizer_3
+    tokenizer_4
+    tokenizer_5
+)
 
 foreach(test ${tests})
   set(sources ${test}.cpp)

--- a/libs/core/string_util/tests/unit/tokenizer.cpp
+++ b/libs/core/string_util/tests/unit/tokenizer.cpp
@@ -1,0 +1,159 @@
+//  Copyright (c) 2022 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+// (c) Copyright John R. Bandela 2001.
+
+// See http://www.boost.org for updates, documentation, and revision history.
+
+#include <hpx/modules/string_util.hpp>
+#include <hpx/modules/testing.hpp>
+
+#include <algorithm>
+#include <array>
+#include <iterator>
+#include <string>
+
+int main()
+{
+    using namespace hpx::string_util;
+
+    // Use tokenizer
+    {
+        std::string const test_string = ";;Hello|world||-foo--bar;yow;baz|";
+        std::string answer[] = {"Hello", "world", "foo", "bar", "yow", "baz"};
+        using Tok = tokenizer<char_separator<char>>;
+        char_separator<char> sep("-;|");
+        Tok t(test_string, sep);
+        HPX_TEST(std::equal(t.begin(), t.end(), answer));
+    }
+
+    {
+        std::string const test_string = ";;Hello|world||-foo--bar;yow;baz|";
+        std::string answer[] = {"", "", "Hello", "|", "world", "|", "", "|", "",
+            "foo", "", "bar", "yow", "baz", "|", ""};
+        using Tok = tokenizer<char_separator<char>>;
+        char_separator<char> sep("-;", "|", empty_token_policy::keep);
+        Tok t(test_string, sep);
+        HPX_TEST(std::equal(t.begin(), t.end(), answer));
+    }
+
+    {
+        std::string const test_string = "This,,is, a.test..";
+        std::string answer[] = {"This", "is", "a", "test"};
+        using Tok = tokenizer<char_delimiters_separator<char>>;
+        Tok t(test_string);
+        HPX_TEST(std::equal(t.begin(), t.end(), answer));
+    }
+
+    {
+        std::string const test_string =
+            "Field 1,\"embedded,comma\",quote \\\", escape \\\\";
+        std::string answer[] = {
+            "Field 1", "embedded,comma", "quote \"", " escape \\"};
+        using Tok = tokenizer<escaped_list_separator<char>>;
+        Tok t(test_string);
+        HPX_TEST(std::equal(t.begin(), t.end(), answer));
+    }
+
+    {
+        std::string const test_string = ",1,;2\\\";3\\;,4,5^\\,\'6,7\';";
+        std::string answer[] = {
+            "", "1", "", "2\"", "3;", "4", "5\\", "6,7", ""};
+        using Tok = tokenizer<escaped_list_separator<char>>;
+        escaped_list_separator<char> sep("\\^", ",;", "\"\'");
+        Tok t(test_string, sep);
+        HPX_TEST(std::equal(t.begin(), t.end(), answer));
+    }
+
+    {
+        std::string const test_string = "12252001";
+        std::string answer[] = {"12", "25", "2001"};
+        using Tok = tokenizer<offset_separator>;
+        std::array<int, 3> offsets = {{2, 2, 4}};
+        offset_separator func(offsets.begin(), offsets.end());
+        Tok t(test_string, func);
+        HPX_TEST(std::equal(t.begin(), t.end(), answer));
+    }
+
+    // Use token_iterator_generator
+    {
+        std::string const test_string = "This,,is, a.test..";
+        std::string answer[] = {"This", "is", "a", "test"};
+        using Iter =
+            token_iterator_generator<char_delimiters_separator<char>>::type;
+        Iter begin = make_token_iterator<std::string>(test_string.begin(),
+            test_string.end(), char_delimiters_separator<char>());
+        Iter end;
+        HPX_TEST(std::equal(begin, end, answer));
+    }
+
+    {
+        std::string const test_string =
+            "Field 1,\"embedded,comma\",quote \\\", escape \\\\";
+        std::string answer[] = {
+            "Field 1", "embedded,comma", "quote \"", " escape \\"};
+        using Iter =
+            token_iterator_generator<escaped_list_separator<char>>::type;
+        Iter begin = make_token_iterator<std::string>(test_string.begin(),
+            test_string.end(), escaped_list_separator<char>());
+        Iter begin_c(begin);
+        Iter end;
+        HPX_TEST(std::equal(begin, end, answer));
+
+        while (begin_c != end)
+        {
+            HPX_TEST(begin_c.at_end() == 0);
+            ++begin_c;
+        }
+        HPX_TEST(begin_c.at_end());
+    }
+
+    {
+        std::string const test_string = "12252001";
+        std::string answer[] = {"12", "25", "2001"};
+        using Iter = token_iterator_generator<offset_separator>::type;
+        std::array<int, 3> offsets = {{2, 2, 4}};
+        offset_separator func(offsets.begin(), offsets.end());
+        Iter begin = make_token_iterator<std::string>(
+            test_string.begin(), test_string.end(), func);
+        Iter end = make_token_iterator<std::string>(
+            test_string.end(), test_string.end(), func);
+        HPX_TEST(std::equal(begin, end, answer));
+    }
+
+    // Test copying
+    {
+        std::string const test_string = "abcdef";
+        token_iterator_generator<offset_separator>::type beg, end, other;
+        std::array<int, 3> ar = {{1, 2, 3}};
+        offset_separator f(ar.begin(), ar.end());
+        beg = make_token_iterator<std::string>(
+            test_string.begin(), test_string.end(), f);
+
+        ++beg;
+        other = beg;
+        ++other;
+
+        HPX_TEST(*beg == "bc");
+        HPX_TEST(*other == "def");
+
+        other = make_token_iterator<std::string>(
+            test_string.begin(), test_string.end(), f);
+
+        HPX_TEST(*other == "a");
+    }
+
+    // Test non-default constructed char_separator
+    {
+        std::string const test_string = "how,are you, doing";
+        std::string answer[] = {"how", ",", "are you", ",", " doing"};
+        tokenizer t(
+            test_string, char_delimiters_separator<char>(true, ",", ""));
+        HPX_TEST(std::equal(t.begin(), t.end(), answer));
+    }
+
+    return hpx::util::report_errors();
+}

--- a/libs/core/string_util/tests/unit/tokenizer_1.cpp
+++ b/libs/core/string_util/tests/unit/tokenizer_1.cpp
@@ -1,0 +1,32 @@
+//  Copyright (c) 2022 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+// (c) Copyright John R. Bandela 2001.
+
+// See http://www.boost.org/libs/tokenizer for documentation
+
+#include <hpx/modules/string_util.hpp>
+#include <hpx/modules/testing.hpp>
+
+#include <string>
+#include <vector>
+
+int main()
+{
+    std::vector<std::string> tokens;
+
+    std::string s = "This is,  a test";
+    hpx::string_util::tokenizer<> tok(s);
+    for (auto const& t : tok)
+    {
+        tokens.push_back(t);
+    }
+
+    std::vector<std::string> expected = {"This", "is", ",", "a", "test"};
+    HPX_TEST(tokens == expected);
+
+    return hpx::util::report_errors();
+}

--- a/libs/core/string_util/tests/unit/tokenizer_2.cpp
+++ b/libs/core/string_util/tests/unit/tokenizer_2.cpp
@@ -1,0 +1,36 @@
+//  Copyright (c) 2022 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+// (c) Copyright John R. Bandela 2001.
+
+// See http://www.boost.org/libs/tokenizer for documentation
+
+#include <hpx/modules/string_util.hpp>
+#include <hpx/modules/testing.hpp>
+
+#include <string>
+#include <vector>
+
+int main()
+{
+    std::vector<std::string> tokens;
+
+    std::string s =
+        "Field 1,\"putting quotes around fields, allows commas\",Field 3";
+
+    hpx::string_util::tokenizer<hpx::string_util::escaped_list_separator<char>>
+        tok(s);
+    for (auto const& t : tok)
+    {
+        tokens.push_back(t);
+    }
+
+    std::vector<std::string> expected = {
+        "Field 1", "putting quotes around fields, allows commas", "Field 3"};
+    HPX_TEST(tokens == expected);
+
+    return hpx::util::report_errors();
+}

--- a/libs/core/string_util/tests/unit/tokenizer_3.cpp
+++ b/libs/core/string_util/tests/unit/tokenizer_3.cpp
@@ -1,0 +1,35 @@
+//  Copyright (c) 2022 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+// (c) Copyright John R. Bandela 2001.
+
+// See http://www.boost.org/libs/tokenizer for documentation
+
+#include <hpx/modules/string_util.hpp>
+#include <hpx/modules/testing.hpp>
+
+#include <string>
+#include <vector>
+
+int main()
+{
+    std::vector<std::string> tokens;
+
+    std::string s = "12252001";
+    int offsets[] = {2, 2, 4};
+    hpx::string_util::offset_separator f(offsets, offsets + 3);
+    hpx::string_util::tokenizer tok(s, f);
+
+    for (auto const& t : tok)
+    {
+        tokens.push_back(t);
+    }
+
+    std::vector<std::string> expected = {"12", "25", "2001"};
+    HPX_TEST(tokens == expected);
+
+    return hpx::util::report_errors();
+}

--- a/libs/core/string_util/tests/unit/tokenizer_4.cpp
+++ b/libs/core/string_util/tests/unit/tokenizer_4.cpp
@@ -1,0 +1,32 @@
+//  Copyright (c) 2022 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+// (c) Copyright John R. Bandela 2001.
+
+// See http://www.boost.org/libs/tokenizer for documentation
+
+#include <hpx/modules/string_util.hpp>
+#include <hpx/modules/testing.hpp>
+
+#include <string>
+#include <vector>
+
+int main()
+{
+    std::vector<std::string> tokens;
+
+    std::string s = "This is,  a test";
+    hpx::string_util::tokenizer<hpx::string_util::char_separator<char>> tok(s);
+    for (auto const& t : tok)
+    {
+        tokens.push_back(t);
+    }
+
+    std::vector<std::string> expected = {"This", "is", ",", "a", "test"};
+    HPX_TEST(tokens == expected);
+
+    return hpx::util::report_errors();
+}

--- a/libs/core/string_util/tests/unit/tokenizer_5.cpp
+++ b/libs/core/string_util/tests/unit/tokenizer_5.cpp
@@ -1,0 +1,38 @@
+//  Copyright (c) 2022 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+// (c) Copyright John R. Bandela 2001.
+
+// See http://www.boost.org/libs/tokenizer for documentation
+
+#include <hpx/modules/string_util.hpp>
+#include <hpx/modules/testing.hpp>
+
+#include <string>
+#include <vector>
+
+int main()
+{
+    std::vector<std::string> tokens;
+
+    std::string s = "12252001";
+    hpx::string_util::offset_separator f({2, 2, 4});
+
+    auto beg = hpx::string_util::make_token_iterator<std::string>(
+        s.begin(), s.end(), f);
+    auto end =
+        hpx::string_util::make_token_iterator<std::string>(s.end(), s.end(), f);
+
+    for (; beg != end; ++beg)
+    {
+        tokens.push_back(*beg);
+    }
+
+    std::vector<std::string> expected = {"12", "25", "2001"};
+    HPX_TEST(tokens == expected);
+
+    return hpx::util::report_errors();
+}

--- a/libs/full/command_line_handling/src/command_line_handling.cpp
+++ b/libs/full/command_line_handling/src/command_line_handling.cpp
@@ -27,8 +27,6 @@
 #include <hpx/util/from_string.hpp>
 #include <hpx/version.hpp>
 
-#include <boost/tokenizer.hpp>
-
 #include <algorithm>
 #include <cstddef>
 #include <cstdint>

--- a/libs/full/performance_counters/src/server/elapsed_time_counter.cpp
+++ b/libs/full/performance_counters/src/server/elapsed_time_counter.cpp
@@ -13,8 +13,6 @@
 #include <hpx/runtime_local/runtime_local_fwd.hpp>
 #include <hpx/timing/high_resolution_clock.hpp>
 
-#include <boost/version.hpp>
-
 #include <cstdint>
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/libs/full/runtime_distributed/src/server/runtime_support_server.cpp
+++ b/libs/full/runtime_distributed/src/server/runtime_support_server.cpp
@@ -25,6 +25,7 @@
 #include <hpx/modules/errors.hpp>
 #include <hpx/modules/filesystem.hpp>
 #include <hpx/modules/logging.hpp>
+#include <hpx/modules/string_util.hpp>
 #include <hpx/modules/threadmanager.hpp>
 #include <hpx/modules/timing.hpp>
 #include <hpx/performance_counters/counters.hpp>
@@ -54,8 +55,6 @@
 #ifdef HPX_HAVE_LIB_MPI_BASE
 #include <hpx/modules/mpi_base.hpp>
 #endif
-
-#include <boost/tokenizer.hpp>
 
 #include <algorithm>
 #include <cstddef>
@@ -1260,12 +1259,10 @@ namespace hpx { namespace components { namespace server {
                 else
                     component_path = HPX_DEFAULT_COMPONENT_PATH;
 
-                typedef boost::tokenizer<boost::char_separator<char>> tokenizer;
-                boost::char_separator<char> sep(HPX_INI_PATH_DELIMITER);
-                tokenizer tokens(component_path, sep);
+                hpx::string_util::char_separator sep(HPX_INI_PATH_DELIMITER);
+                hpx::string_util::tokenizer tokens(component_path, sep);
                 std::error_code fsec;
-                for (tokenizer::iterator it = tokens.begin();
-                     it != tokens.end(); ++it)
+                for (auto it = tokens.begin(); it != tokens.end(); ++it)
                 {
                     lib = fs::path(*it);
                     fs::path lib_path =
@@ -1751,12 +1748,10 @@ namespace hpx { namespace components { namespace server {
                 else
                     component_path = HPX_DEFAULT_COMPONENT_PATH;
 
-                typedef boost::tokenizer<boost::char_separator<char>> tokenizer;
-                boost::char_separator<char> sep(HPX_INI_PATH_DELIMITER);
-                tokenizer tokens(component_path, sep);
+                hpx::string_util::char_separator sep(HPX_INI_PATH_DELIMITER);
+                hpx::string_util::tokenizer tokens(component_path, sep);
                 std::error_code fsec;
-                for (tokenizer::iterator it = tokens.begin();
-                     it != tokens.end(); ++it)
+                for (auto it = tokens.begin(); it != tokens.end(); ++it)
                 {
                     lib = fs::path(*it);
                     fs::path lib_path =

--- a/tests/performance/local/hpx_tls_overhead.cpp
+++ b/tests/performance/local/hpx_tls_overhead.cpp
@@ -5,13 +5,10 @@
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <hpx/config.hpp>
-
 #include <hpx/modules/format.hpp>
-#include <hpx/modules/timing.hpp>
-#include <hpx/thread_support/thread_specific_ptr.hpp>
-
 #include <hpx/modules/program_options.hpp>
-#include <boost/config.hpp>
+#include <hpx/modules/thread_support.hpp>
+#include <hpx/modules/timing.hpp>
 
 #include <cstdint>
 #include <iostream>

--- a/tools/inspect/end_check.cpp
+++ b/tools/inspect/end_check.cpp
@@ -9,9 +9,10 @@
 //  http://www.boost.org/LICENSE_1_0.txt)
 
 #include <hpx/config.hpp>
+#include <hpx/modules/string_util.hpp>
 
 #include <boost/next_prior.hpp>
-#include <boost/tokenizer.hpp>
+
 #include <iterator>
 #include <string>
 #include "end_check.hpp"
@@ -38,8 +39,9 @@ namespace boost { namespace inspect {
         if (contents.find("hpxinspect:"
                           "noend") != string::npos)
             return;
-        char_separator<char> sep("\n", "", boost::keep_empty_tokens);
-        tokenizer<char_separator<char>> tokens(contents, sep);
+        hpx::string_util::char_separator sep(
+            "\n", "", hpx::string_util::empty_token_policy::keep);
+        hpx::string_util::tokenizer tokens(contents, sep);
         const auto linenumb = std::distance(tokens.begin(), tokens.end());
         std::string lineloc = std::to_string(linenumb);
         // this file deliberately contains errors

--- a/tools/inspect/endline_whitespace_check.cpp
+++ b/tools/inspect/endline_whitespace_check.cpp
@@ -9,9 +9,8 @@
 
 #include <hpx/config.hpp>
 #include <hpx/modules/filesystem.hpp>
+#include <hpx/modules/string_util.hpp>
 
-#include <boost/foreach.hpp>
-#include <boost/tokenizer.hpp>
 #include <functional>
 #include <iostream>
 #include <string>
@@ -53,8 +52,9 @@ namespace boost { namespace inspect {
         size_t p = 0, extend = 0;
         vector<string> someline, lineorder;
 
-        char_separator<char> sep("\n", "", boost::keep_empty_tokens);
-        tokenizer<char_separator<char>> tokens(contents, sep);
+        hpx::string_util::char_separator sep(
+            "\n", "", hpx::string_util::empty_token_policy::keep);
+        hpx::string_util::tokenizer tokens(contents, sep);
         for (const auto& t : tokens)
         {
             size_t rend = t.find_first_of("\r"), size = t.size();
@@ -64,8 +64,9 @@ namespace boost { namespace inspect {
             }
             else
             {
-                char_separator<char> sep2("\r", "", boost::keep_empty_tokens);
-                tokenizer<char_separator<char>> tokens2(t, sep2);
+                hpx::string_util::char_separator sep2(
+                    "\r", "", hpx::string_util::empty_token_policy::keep);
+                hpx::string_util::tokenizer tokens2(t, sep2);
                 for (const auto& u : tokens2)
                 {
                     if (!u.empty() && u.back() == '\r')

--- a/tools/inspect/length_check.cpp
+++ b/tools/inspect/length_check.cpp
@@ -9,13 +9,12 @@
 
 #include <hpx/config.hpp>
 #include <hpx/modules/filesystem.hpp>
+#include <hpx/modules/string_util.hpp>
 
 #include "function_hyper.hpp"
 #include "length_check.hpp"
 
-#include <boost/foreach.hpp>
 #include <boost/regex.hpp>
-#include <boost/tokenizer.hpp>
 
 #include <cstddef>
 #include <functional>
@@ -79,8 +78,9 @@ namespace boost { namespace inspect {
         std::size_t p = 0;
         vector<string> someline, lineorder;
 
-        char_separator<char> sep("\n", "", boost::keep_empty_tokens);
-        tokenizer<char_separator<char>> tokens(contents, sep);
+        hpx::string_util::char_separator sep(
+            "\n", "", hpx::string_util::empty_token_policy::keep);
+        hpx::string_util::tokenizer tokens(contents, sep);
         for (const auto& t : tokens)
         {
             std::size_t rend = t.find_first_of("\r"), size = t.size();
@@ -90,8 +90,9 @@ namespace boost { namespace inspect {
             }
             else
             {
-                char_separator<char> sep2("\r", "", boost::keep_empty_tokens);
-                tokenizer<char_separator<char>> tokens2(t, sep2);
+                hpx::string_util::char_separator sep2(
+                    "\r", "", hpx::string_util::empty_token_policy::keep);
+                hpx::string_util::tokenizer tokens2(t, sep2);
                 for (const auto& u : tokens2)
                 {
                     if (!u.empty() && u.back() == '\r')

--- a/tools/inspect/tab_check.cpp
+++ b/tools/inspect/tab_check.cpp
@@ -8,9 +8,8 @@
 //  http://www.boost.org/LICENSE_1_0.txt)
 
 #include <hpx/config.hpp>
+#include <hpx/modules/string_util.hpp>
 
-#include <boost/foreach.hpp>
-#include <boost/tokenizer.hpp>
 #include <string>
 #include "function_hyper.hpp"
 #include "tab_check.hpp"
@@ -43,8 +42,9 @@ namespace boost { namespace inspect {
         size_t p = 0;
         std::vector<std::string> someline, lineorder;
 
-        char_separator<char> sep("\n", "", boost::keep_empty_tokens);
-        tokenizer<char_separator<char>> tokens(contents, sep);
+        hpx::string_util::char_separator sep(
+            "\n", "", hpx::string_util::empty_token_policy::keep);
+        hpx::string_util::tokenizer tokens(contents, sep);
         for (const auto& t : tokens)
         {
             size_t rend = t.find_first_of("\r"), size = t.size();
@@ -54,8 +54,9 @@ namespace boost { namespace inspect {
             }
             else
             {
-                char_separator<char> sep2("\r", "", boost::keep_empty_tokens);
-                tokenizer<char_separator<char>> tokens2(t, sep2);
+                hpx::string_util::char_separator sep2(
+                    "\r", "", hpx::string_util::empty_token_policy::keep);
+                hpx::string_util::tokenizer tokens2(t, sep2);
                 for (const auto& u : tokens2)
                 {
                     if (!u.empty() && u.back() == '\r')


### PR DESCRIPTION
- flyby: remove more Boost headers that are not needed anymore

Working towards #3440 