### PR TITLE
Futures attempt to execute threads directly if those have not started executing

### DIFF
--- a/.jenkins/cscs/env-clang-13.sh
+++ b/.jenkins/cscs/env-clang-13.sh
@@ -30,6 +30,7 @@ configure_extra_options+=" -DHPX_WITH_COMPILER_WARNINGS=ON"
 configure_extra_options+=" -DHPX_WITH_COMPILER_WARNINGS_AS_ERRORS=ON"
 configure_extra_options+=" -DHPX_WITH_SPINLOCK_DEADLOCK_DETECTION=ON"
 configure_extra_options+=" -DHPX_WITH_UNITY_BUILD=ON"
+configure_extra_options+=" -DHPX_COROUTINES_WITH_THREAD_SCHEDULE_HINT_RUNS_AS_CHILD=ON"
 
 # enable extra counters to verify everything compiles
 configure_extra_options+=" -DHPX_WITH_BACKGROUND_THREAD_COUNTERS=ON"

--- a/.jenkins/lsu/batch.sh
+++ b/.jenkins/lsu/batch.sh
@@ -22,6 +22,7 @@ ulimit -l unlimited
 set +e
 ctest \
     ${ctest_extra_args} \
+    --output-on-failure \
     -S ${src_dir}/.jenkins/lsu/ctest.cmake \
     -DCTEST_CONFIGURE_EXTRA_OPTIONS="${configure_extra_options}" \
     -DCTEST_BUILD_CONFIGURATION_NAME="${configuration_name_with_build_type}" \

--- a/.jenkins/lsu/env-clang-11.sh
+++ b/.jenkins/lsu/env-clang-11.sh
@@ -31,3 +31,5 @@ configure_extra_options+=" -DHPX_WITH_LOGGING=OFF"
 # Make sure HWLOC does not report 'cores'. This is purely an option to enable
 # testing the topology code under conditions close to those on FreeBSD.
 configure_extra_options+=" -DHPX_TOPOLOGY_WITH_ADDITIONAL_HWLOC_TESTING=ON"
+
+configure_extra_options+=" -DHPX_COROUTINES_WITH_THREAD_SCHEDULE_HINT_RUNS_AS_CHILD=ON"

--- a/.jenkins/lsu/env-clang-12.sh
+++ b/.jenkins/lsu/env-clang-12.sh
@@ -32,3 +32,5 @@ configure_extra_options+=" -DHPX_WITH_LOGGING=OFF"
 # Make sure HWLOC does not report 'cores'. This is purely an option to enable
 # testing the topology code under conditions close to those on FreeBSD.
 configure_extra_options+=" -DHPX_TOPOLOGY_WITH_ADDITIONAL_HWLOC_TESTING=ON"
+
+configure_extra_options+=" -DHPX_COROUTINES_WITH_THREAD_SCHEDULE_HINT_RUNS_AS_CHILD=ON"

--- a/.jenkins/lsu/env-gcc-10.sh
+++ b/.jenkins/lsu/env-gcc-10.sh
@@ -27,3 +27,5 @@ configure_extra_options+=" -DHPX_WITH_FETCH_LCI=ON"
 
 # The pwrapi library still needs to be set up properly on rostam
 # configure_extra_options+=" -DHPX_WITH_POWER_COUNTER=ON"
+
+configure_extra_options+=" -DHPX_COROUTINES_WITH_THREAD_SCHEDULE_HINT_RUNS_AS_CHILD=ON"

--- a/.jenkins/lsu/env-gcc-9.sh
+++ b/.jenkins/lsu/env-gcc-9.sh
@@ -26,3 +26,5 @@ configure_extra_options+=" -DHPX_WITH_FETCH_LCI=ON"
 
 # The pwrapi library still needs to be set up properly on rostam
 # configure_extra_options+=" -DHPX_WITH_POWER_COUNTER=ON"
+
+configure_extra_options+=" -DHPX_COROUTINES_WITH_THREAD_SCHEDULE_HINT_RUNS_AS_CHILD=ON"

--- a/docs/sphinx/manual/hpx_runtime_and_resources.rst
+++ b/docs/sphinx/manual/hpx_runtime_and_resources.rst
@@ -42,12 +42,11 @@ turned on, work stealing is done from queues associated with the same NUMA domai
 first, only after that work is stolen from other NUMA domains.
 
 This scheduler is enabled at build time by default using the FIFO
-(first-in-first-out) queing policy. This policy can be invoked using
+(first-in-first-out) queueing policy. This policy can be invoked using
 :option:`--hpx:queuing`\ ``local-priority-fifo``. The scheduler can also be
 enabled using the LIFO (last-in-first-out) policy. This is not the default
 policy and must be invoked using the command line option
-:option:`--hpx:queuing`\
-``=local-priority-lifo``.
+:option:`--hpx:queuing`\ ``local-priority-lifo``.
 
 Static priority scheduling policy
 ---------------------------------
@@ -63,7 +62,7 @@ robin fashion. There is no thread stealing in this policy.
 Local scheduling policy
 -----------------------
 
-* invoke using: :option:`--hpx:queuing`\ ``=local`` (or ``-ql``)
+* invoke using: :option:`--hpx:queuing`\ ``local`` (or ``-ql``)
 * flag to turn on for build: ``HPX_THREAD_SCHEDULERS=all`` or
   ``HPX_THREAD_SCHEDULERS=local``
 
@@ -73,7 +72,7 @@ thread pulls its tasks (user threads).
 Static scheduling policy
 ------------------------
 
-* invoke using: :option:`--hpx:queuing`\ ``=static``
+* invoke using: :option:`--hpx:queuing`\ ``static``
 * flag to turn on for build: ``HPX_THREAD_SCHEDULERS=all`` or
   ``HPX_THREAD_SCHEDULERS=static``
 
@@ -84,7 +83,7 @@ robin fashion. There is no thread stealing in this policy.
 Priority ABP scheduling policy
 ------------------------------
 
-* invoke using: :option:`--hpx:queuing`\ ``=abp-priority-fifo``
+* invoke using: :option:`--hpx:queuing`\ ``abp-priority-fifo``
 * flag to turn on for build: ``HPX_THREAD_SCHEDULERS=all`` or
   ``HPX_THREAD_SCHEDULERS=abp-priority``
 
@@ -102,8 +101,8 @@ domain first, only after that work is stolen from other NUMA domains.
 
 This scheduler can be used with two underlying queuing policies (FIFO:
 first-in-first-out, and LIFO: last-in-first-out). In order to use the LIFO
-policy use the command line option :option:`--hpx:queuing`\
-``=abp-priority-lifo``.
+policy use the command line option
+:option:`--hpx:queuing`\ ``=abp-priority-lifo``.
 
 ..
     Questions, concerns and notes:

--- a/libs/core/async_base/include/hpx/async_base/scheduling_properties.hpp
+++ b/libs/core/async_base/include/hpx/async_base/scheduling_properties.hpp
@@ -64,6 +64,11 @@ namespace hpx::execution::experimental {
     {
     } with_priority{};
 
+    template <>
+    struct is_scheduling_property<with_priority_t> : std::true_type
+    {
+    };
+
     inline constexpr struct get_priority_t final
       : hpx::functional::detail::tag_fallback<get_priority_t>
     {
@@ -87,6 +92,11 @@ namespace hpx::execution::experimental {
       : detail::property_base<with_stacksize_t>
     {
     } with_stacksize{};
+
+    template <>
+    struct is_scheduling_property<with_stacksize_t> : std::true_type
+    {
+    };
 
     inline constexpr struct get_stacksize_t final
       : hpx::functional::detail::tag_fallback<get_stacksize_t>
@@ -112,6 +122,11 @@ namespace hpx::execution::experimental {
     {
     } with_hint{};
 
+    template <>
+    struct is_scheduling_property<with_hint_t> : std::true_type
+    {
+    };
+
     inline constexpr struct get_hint_t final
       : hpx::functional::detail::tag_fallback<get_hint_t>
     {
@@ -135,6 +150,11 @@ namespace hpx::execution::experimental {
       : detail::property_base<with_annotation_t>
     {
     } with_annotation{};
+
+    template <>
+    struct is_scheduling_property<with_annotation_t> : std::true_type
+    {
+    };
 
     inline constexpr struct get_annotation_t final
       : hpx::functional::detail::tag_fallback<get_annotation_t>

--- a/libs/core/config/cmake/templates/config_version.hpp.in
+++ b/libs/core/config/cmake/templates/config_version.hpp.in
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2020 Hartmut Kaiser
+//  Copyright (c) 2007-2023 Hartmut Kaiser
 //  Copyright (c)      2011 Bryce Lelbach
 //  Copyright (c)      2013 Adrian Serio
 //
@@ -30,8 +30,9 @@
 /// ``HPX_VERSION_FULL & 0x00FF00 == HPX_VERSION_MINOR``
 /// ``HPX_VERSION_FULL & 0x0000FF == HPX_VERSION_SUBMINOR``
 #define HPX_VERSION_FULL                                                       \
-    ((HPX_VERSION_MAJOR << 16) | (HPX_VERSION_MINOR << 8) |                    \
-        HPX_VERSION_SUBMINOR)
+    ((HPX_PP_CAT(0x, HPX_VERSION_MAJOR) << 16) |                               \
+        (HPX_PP_CAT(0x, HPX_VERSION_MINOR) << 8) |                             \
+        HPX_PP_CAT(0x, HPX_VERSION_SUBMINOR))
 
 /// Evaluates to the release date of this HPX version in the format YYYYMMDD.
 #define HPX_VERSION_DATE @HPX_VERSION_DATE@

--- a/libs/core/coroutines/CMakeLists.txt
+++ b/libs/core/coroutines/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2020 The STE||AR-Group
+# Copyright (c) 2019-2023 The STE||AR-Group
 #
 # SPDX-License-Identifier: BSL-1.0
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -13,6 +13,23 @@ hpx_option(
   ADVANCED
   MODULE COROUTINES
 )
+
+hpx_option(
+  HPX_COROUTINES_WITH_THREAD_SCHEDULE_HINT_RUNS_AS_CHILD
+  BOOL
+  "Futures attempt to run associated threads directly if those have not been started (default: OFF)"
+  OFF
+  CATEGORY "Thread Manager"
+  ADVANCED
+  MODULE COROUTINES
+)
+
+if(HPX_COROUTINES_WITH_THREAD_SCHEDULE_HINT_RUNS_AS_CHILD)
+  hpx_add_config_define_namespace(
+    DEFINE HPX_COROUTINES_HAVE_THREAD_SCHEDULE_HINT_RUNS_AS_CHILD
+    NAMESPACE COROUTINES
+  )
+endif()
 
 set(coroutines_headers
     hpx/coroutines/coroutine.hpp
@@ -29,6 +46,7 @@ set(coroutines_headers
     hpx/coroutines/detail/coroutine_impl.hpp
     hpx/coroutines/detail/coroutine_self.hpp
     hpx/coroutines/detail/coroutine_stackful_self.hpp
+    hpx/coroutines/detail/coroutine_stackful_self_direct.hpp
     hpx/coroutines/detail/coroutine_stackless_self.hpp
     hpx/coroutines/detail/get_stack_pointer.hpp
     hpx/coroutines/detail/posix_utility.hpp

--- a/libs/core/coroutines/include/hpx/coroutines/coroutine.hpp
+++ b/libs/core/coroutines/include/hpx/coroutines/coroutine.hpp
@@ -1,5 +1,5 @@
 //  Copyright (c) 2006, Giovanni P. Deretta
-//  Copyright (c) 2007-2021 Hartmut Kaiser
+//  Copyright (c) 2007-2023 Hartmut Kaiser
 //
 //  This code may be used under either of the following two licences:
 //
@@ -149,6 +149,12 @@ namespace hpx::threads::coroutines {
             impl_.invoke();
 
             return impl_.result();
+        }
+
+        HPX_FORCEINLINE result_type invoke_directly(arg_type arg = arg_type())
+        {
+            HPX_ASSERT(impl_.is_ready());
+            return impl_.invoke_directly(arg);
         }
 
         bool is_ready() const noexcept

--- a/libs/core/coroutines/include/hpx/coroutines/detail/context_generic_context.hpp
+++ b/libs/core/coroutines/include/hpx/coroutines/detail/context_generic_context.hpp
@@ -252,8 +252,11 @@ namespace hpx::threads::coroutines {
                 return (std::numeric_limits<std::ptrdiff_t>::max)();
             }
 #endif
-            void reset_stack() const
+            void reset_stack(bool direct_execution)
             {
+                if (direct_execution)
+                    return;
+
                 if (ctx_)
                 {
 #if defined(HPX_USE_POSIX_STACK_UTILITIES)

--- a/libs/core/coroutines/include/hpx/coroutines/detail/context_linux_x86.hpp
+++ b/libs/core/coroutines/include/hpx/coroutines/detail/context_linux_x86.hpp
@@ -282,8 +282,8 @@ namespace hpx::threads::coroutines::detail::lx {
 
         using context_impl_base = x86_linux_context_impl_base;
 
-        // Create a context that on restore invokes Functor on
-        //  a new stack. The stack size can be optionally specified.
+        // Create a context that on restore invokes Functor on a new stack. The
+        // stack size can be optionally specified.
         explicit x86_linux_context_impl(std::ptrdiff_t stack_size = -1)
           : m_stack_size(stack_size == -1 ?
                     static_cast<std::ptrdiff_t>(default_stack_size) :
@@ -365,8 +365,11 @@ namespace hpx::threads::coroutines::detail::lx {
             return m_stack_size;
         }
 
-        void reset_stack()
+        void reset_stack(bool direct_execution)
         {
+            if (direct_execution)
+                return;
+
             HPX_ASSERT(m_stack);
             if (posix::reset_stack(
                     m_stack, static_cast<std::size_t>(m_stack_size)))
@@ -379,7 +382,10 @@ namespace hpx::threads::coroutines::detail::lx {
 
         void rebind_stack()
         {
-            HPX_ASSERT(m_stack);
+            // directly executed coroutine, no need to allocate a stack
+            if (m_stack == nullptr)
+                return;
+
 #if defined(HPX_HAVE_COROUTINE_COUNTERS)
             increment_stack_recycle_count();
 #endif
@@ -527,8 +533,8 @@ namespace hpx::threads::coroutines::detail::lx {
 #endif
     };
 
-    // Free function. Saves the current context in @p from
-    // and restores the context in @p to.
+    // Free function. Saves the current context in @p from and restores the
+    // context in @p to.
     // @note This function is found by ADL.
     inline void swap_context(x86_linux_context_impl_base& from,
         x86_linux_context_impl_base const& to, default_hint) noexcept

--- a/libs/core/coroutines/include/hpx/coroutines/detail/context_posix.hpp
+++ b/libs/core/coroutines/include/hpx/coroutines/detail/context_posix.hpp
@@ -346,8 +346,11 @@ namespace hpx::threads::coroutines {
                 return (std::numeric_limits<std::ptrdiff_t>::max)();
             }
 #endif
-            void reset_stack()
+            void reset_stack(bool direct_execution)
             {
+                if (direct_execution)
+                    return;
+
                 if (m_stack)
                 {
                     if (posix::reset_stack(

--- a/libs/core/coroutines/include/hpx/coroutines/detail/context_windows_fibers.hpp
+++ b/libs/core/coroutines/include/hpx/coroutines/detail/context_windows_fibers.hpp
@@ -35,10 +35,12 @@
 #include <hpx/config.hpp>
 #include <hpx/coroutines/config/defines.hpp>
 #include <hpx/assert.hpp>
+#include <hpx/coroutines/detail/get_stack_pointer.hpp>
 #include <hpx/coroutines/detail/swap_context.hpp>
 
 #include <cstddef>
 #include <cstdint>
+#include <cstring>
 #include <system_error>
 
 #if defined(HPX_HAVE_COROUTINE_COUNTERS)
@@ -279,7 +281,7 @@ namespace hpx::threads::coroutines {
                 return stacksize_;
             }
 
-            static constexpr void reset_stack() noexcept {}
+            static constexpr void reset_stack(bool) noexcept {}
 
 #if defined(HPX_HAVE_COROUTINE_COUNTERS)
             void rebind_stack() noexcept
@@ -294,7 +296,8 @@ namespace hpx::threads::coroutines {
             // https://stackoverflow.com/a/20930496/269943
             static std::ptrdiff_t get_available_stack_space() noexcept
             {
-                MEMORY_BASIC_INFORMATION mbi = {};        // page range
+                MEMORY_BASIC_INFORMATION mbi = {};    // page range
+                std::memset(&mbi, '\0', sizeof(mbi));
                 VirtualQuery(&mbi, &mbi, sizeof(mbi));    // get range
                 return reinterpret_cast<std::ptrdiff_t>(&mbi) -
                     reinterpret_cast<std::ptrdiff_t>(mbi.AllocationBase);

--- a/libs/core/coroutines/include/hpx/coroutines/detail/coroutine_impl.hpp
+++ b/libs/core/coroutines/include/hpx/coroutines/detail/coroutine_impl.hpp
@@ -78,6 +78,10 @@ namespace hpx::threads::coroutines::detail {
         // execute the coroutine using normal context switching
         HPX_CORE_EXPORT void operator()() noexcept;
 
+        // execute the coroutine function directly in the context of the calling
+        // thread
+        HPX_CORE_EXPORT result_type invoke_directly(arg_type arg);
+
     public:
         void bind_result(result_type const& res) noexcept
         {
@@ -112,16 +116,18 @@ namespace hpx::threads::coroutines::detail {
             this->super_type::init();
         }
 
-        void reset()
+        void reset(bool direct_execution)
         {
             // First reset the function and arguments
+            m_result =
+                result_type(thread_schedule_state::unknown, invalid_thread_id);
             m_arg = nullptr;
             m_fun.reset();
 
             // Then reset the id and stack as they may be used by the
             // destructors of the thread function above
             this->super_type::reset();
-            this->reset_stack();
+            this->reset_stack(direct_execution);
         }
 
         void rebind(functor_type&& f, thread_id_type id)

--- a/libs/core/coroutines/include/hpx/coroutines/detail/coroutine_self.hpp
+++ b/libs/core/coroutines/include/hpx/coroutines/detail/coroutine_self.hpp
@@ -123,6 +123,11 @@ namespace hpx::threads::coroutines::detail {
 
         virtual thread_id_type get_thread_id() const noexcept = 0;
 
+        virtual thread_id_type get_outer_thread_id() const noexcept
+        {
+            return get_thread_id();
+        }
+
         virtual std::size_t get_thread_phase() const noexcept = 0;
 
         virtual std::ptrdiff_t get_available_stack_space() const noexcept = 0;

--- a/libs/core/coroutines/include/hpx/coroutines/detail/coroutine_stackful_self.hpp
+++ b/libs/core/coroutines/include/hpx/coroutines/detail/coroutine_stackful_self.hpp
@@ -22,7 +22,7 @@ namespace hpx::threads::coroutines::detail {
     {
     public:
         explicit coroutine_stackful_self(
-            impl_type* pimpl, coroutine_self* next_self = nullptr) noexcept
+            coroutine_impl* pimpl, coroutine_self* next_self = nullptr) noexcept
           : coroutine_self(next_self)
           , pimpl_(pimpl)
         {
@@ -138,7 +138,7 @@ namespace hpx::threads::coroutines::detail {
             return pimpl_->get_continuation_recursion_count();
         }
 
-    private:
+    protected:
         coroutine_impl* get_impl() noexcept override
         {
             return pimpl_;

--- a/libs/core/coroutines/include/hpx/coroutines/detail/coroutine_stackful_self_direct.hpp
+++ b/libs/core/coroutines/include/hpx/coroutines/detail/coroutine_stackful_self_direct.hpp
@@ -1,0 +1,77 @@
+//  Copyright (c) 2019-2023 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include <hpx/config.hpp>
+#include <hpx/assert.hpp>
+#include <hpx/coroutines/detail/coroutine_accessor.hpp>
+#include <hpx/coroutines/detail/coroutine_impl.hpp>
+#include <hpx/coroutines/detail/coroutine_stackful_self.hpp>
+#include <hpx/coroutines/thread_enums.hpp>
+#include <hpx/coroutines/thread_id_type.hpp>
+
+#include <cstddef>
+#include <limits>
+#include <utility>
+
+namespace hpx::threads::coroutines::detail {
+
+    class coroutine_stackful_self_direct : public coroutine_stackful_self
+    {
+    public:
+        explicit coroutine_stackful_self_direct(
+            coroutine_impl* pimpl, coroutine_self* next_self)
+          : coroutine_stackful_self(pimpl, next_self)
+          , next_self_(next_self)
+        {
+            HPX_ASSERT(next_self_);
+        }
+
+        // direct execution of a thread needs to use the executing context for
+        // yielding
+        arg_type yield_impl(result_type arg) override
+        {
+            return next_self_->yield_impl(arg);
+        }
+
+        thread_id_type get_outer_thread_id() const noexcept override
+        {
+            return next_self_->get_outer_thread_id();
+        }
+
+#if defined(HPX_HAVE_THREAD_PHASE_INFORMATION)
+        std::size_t get_thread_phase() const noexcept override
+        {
+            return next_self_->get_thread_phase();
+        }
+#endif
+
+#if defined(HPX_HAVE_THREADS_GET_STACK_POINTER)
+        // return the executing thread's available stack space
+        std::ptrdiff_t get_available_stack_space() const noexcept override
+        {
+            return next_self_->get_available_stack_space();
+        }
+#endif
+
+        // return the executing thread's recursion count
+        std::size_t& get_continuation_recursion_count() noexcept override
+        {
+            return next_self_->get_continuation_recursion_count();
+        }
+
+    private:
+        // if we chain direct calls the executing thread needs to be inherited
+        // down
+        coroutine_impl* get_impl() noexcept override
+        {
+            return coroutine_accessor::get_impl(*next_self_);
+        }
+
+        coroutine_self* next_self_;
+    };
+}    // namespace hpx::threads::coroutines::detail

--- a/libs/core/coroutines/include/hpx/coroutines/detail/coroutine_stackless_self.hpp
+++ b/libs/core/coroutines/include/hpx/coroutines/detail/coroutine_stackless_self.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2019 Hartmut Kaiser
+//  Copyright (c) 2019-2023 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -16,12 +16,12 @@
 #include <limits>
 #include <utility>
 
-namespace hpx ::threads::coroutines {
+namespace hpx::threads::coroutines {
 
     class stackless_coroutine;
 }    // namespace hpx::threads::coroutines
 
-namespace hpx ::threads::coroutines::detail {
+namespace hpx::threads::coroutines::detail {
 
     class coroutine_stackless_self : public coroutine_self
     {
@@ -30,6 +30,7 @@ namespace hpx ::threads::coroutines::detail {
           : coroutine_self(nullptr)
           , pimpl_(pimpl)
         {
+            HPX_ASSERT(pimpl_);
         }
 
         arg_type yield_impl(result_type) override
@@ -41,14 +42,12 @@ namespace hpx ::threads::coroutines::detail {
 
         thread_id_type get_thread_id() const noexcept override
         {
-            HPX_ASSERT(pimpl_);
             return pimpl_->get_thread_id();
         }
 
 #if defined(HPX_HAVE_THREAD_PHASE_INFORMATION)
         std::size_t get_thread_phase() const noexcept override
         {
-            HPX_ASSERT(pimpl_);
             return pimpl_->get_thread_phase();
         }
 #else
@@ -65,47 +64,39 @@ namespace hpx ::threads::coroutines::detail {
 
         std::size_t get_thread_data() const noexcept override
         {
-            HPX_ASSERT(pimpl_);
             return pimpl_->get_thread_data();
         }
         std::size_t set_thread_data(std::size_t data) noexcept override
         {
-            HPX_ASSERT(pimpl_);
             return pimpl_->set_thread_data(data);
         }
 
 #if defined(HPX_HAVE_LIBCDS)
         std::size_t get_libcds_data() const override
         {
-            HPX_ASSERT(pimpl_);
             return pimpl_->get_libcds_data();
         }
         std::size_t set_libcds_data(std::size_t data) override
         {
-            HPX_ASSERT(pimpl_);
             return pimpl_->set_libcds_data(data);
         }
 
         std::size_t get_libcds_hazard_pointer_data() const override
         {
-            HPX_ASSERT(pimpl_);
             return pimpl_->get_libcds_hazard_pointer_data();
         }
         std::size_t set_libcds_hazard_pointer_data(std::size_t data) override
         {
-            HPX_ASSERT(pimpl_);
             return pimpl_->set_libcds_hazard_pointer_data(data);
         }
 
         std::size_t get_libcds_dynamic_hazard_pointer_data() const override
         {
-            HPX_ASSERT(pimpl_);
             return pimpl_->get_libcds_dynamic_hazard_pointer_data();
         }
         std::size_t set_libcds_dynamic_hazard_pointer_data(
             std::size_t data) override
         {
-            HPX_ASSERT(pimpl_);
             return pimpl_->set_libcds_dynamic_hazard_pointer_data(data);
         }
 #endif
@@ -113,7 +104,6 @@ namespace hpx ::threads::coroutines::detail {
 #if defined(HPX_HAVE_THREAD_LOCAL_STORAGE)
         tss_storage* get_thread_tss_data() override
         {
-            HPX_ASSERT(pimpl_);
             return pimpl_->get_thread_tss_data(false);
         }
 #else
@@ -126,7 +116,6 @@ namespace hpx ::threads::coroutines::detail {
 #if defined(HPX_HAVE_THREAD_LOCAL_STORAGE)
         tss_storage* get_or_create_thread_tss_data() override
         {
-            HPX_ASSERT(pimpl_);
             return pimpl_->get_thread_tss_data(true);
         }
 #else
@@ -138,7 +127,6 @@ namespace hpx ::threads::coroutines::detail {
 
         std::size_t& get_continuation_recursion_count() noexcept override
         {
-            HPX_ASSERT(pimpl_);
             return pimpl_->get_continuation_recursion_count();
         }
 

--- a/libs/core/coroutines/include/hpx/coroutines/thread_enums.hpp
+++ b/libs/core/coroutines/include/hpx/coroutines/thread_enums.hpp
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include <hpx/coroutines/config/defines.hpp>
 #include <hpx/coroutines/detail/combined_tagged_state.hpp>
 
 #include <cstdint>
@@ -46,10 +47,12 @@ namespace hpx::threads {
                                           but allows to create a thread in
                                           pending state without scheduling it
                                           (internal, do not use) */
-        pending_boost = 8             /*!< this is not a real thread state,
+        pending_boost = 8,            /*!< this is not a real thread state,
                                           but allows to suspend a thread in
                                           pending state without high priority
                                           rescheduling */
+        deleted = 9                   /*!< thread has been stopped and was
+                                          deleted */
     };
     // clang-format on
 
@@ -220,7 +223,7 @@ namespace hpx::threads {
     /// \enum thread_placement_hint
     ///
     /// The type of hint given to the scheduler related to thread placement
-    enum class thread_placement_hint : std::uint8_t
+    enum class thread_placement_hint : std::int8_t
     {
         /// No hint is specified. The implementation is free to chose what
         /// placement methods to use.
@@ -254,7 +257,7 @@ namespace hpx::threads {
     ///
     /// The type of hint given to the scheduler related to whether it is ok to
     /// share the invoked function object between threads
-    enum class thread_sharing_hint : std::uint8_t
+    enum class thread_sharing_hint : std::int8_t
     {
         /// No hint is specified. The implementation is free to chose what
         /// sharing methods to use.
@@ -273,16 +276,15 @@ namespace hpx::threads {
 
     constexpr bool do_not_share_function(thread_sharing_hint hint) noexcept
     {
-        return static_cast<std::uint8_t>(hint) &
-            static_cast<std::uint8_t>(
+        return static_cast<std::int8_t>(hint) &
+            static_cast<std::int8_t>(
                 thread_sharing_hint::do_not_share_function);
     }
 
     constexpr bool do_not_combine_tasks(thread_sharing_hint hint) noexcept
     {
-        return static_cast<std::uint8_t>(hint) &
-            static_cast<std::uint8_t>(
-                thread_sharing_hint::do_not_combine_tasks);
+        return static_cast<std::int8_t>(hint) &
+            static_cast<std::int8_t>(thread_sharing_hint::do_not_combine_tasks);
     }
 
     constexpr thread_sharing_hint operator|(
@@ -291,6 +293,40 @@ namespace hpx::threads {
         return static_cast<thread_sharing_hint>(
             static_cast<std::uint8_t>(lhs) | static_cast<std::uint8_t>(rhs));
     }
+
+    ///////////////////////////////////////////////////////////////////////////
+    /// \enum thread_placement_hint
+    ///
+    /// The type of hint given to the scheduler related running a thread as a
+    /// child directly in the context of the parent thread
+    enum class thread_execution_hint : std::int8_t
+    {
+        /// No hint is specified. Always run the thread in its own execution
+        /// environment.
+        none = 0,
+
+        /// Attempt to run the thread in the execution context of the parent
+        /// thread.
+        run_as_child = 1,
+    };
+
+    constexpr bool run_as_child(thread_execution_hint hint) noexcept
+    {
+        return static_cast<std::int8_t>(hint) &
+            static_cast<std::int8_t>(thread_execution_hint::run_as_child);
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    /// Default value to use for runs-as-child mode (if \a true, then futures
+    /// will attempt to execute associated threads directly if they have not
+    /// started running).
+#if defined(HPX_COROUTINES_HAVE_THREAD_SCHEDULE_HINT_RUNS_AS_CHILD)
+    inline constexpr thread_execution_hint default_runs_as_child_hint =
+        thread_execution_hint::run_as_child;
+#else
+    inline constexpr thread_execution_hint default_runs_as_child_hint =
+        thread_execution_hint::none;
+#endif
 
     ///////////////////////////////////////////////////////////////////////////
     /// \brief A hint given to a scheduler to guide where a task should be
@@ -306,6 +342,8 @@ namespace hpx::threads {
                 static_cast<std::int8_t>(thread_placement_hint::none))
           , sharing_mode_bits(
                 static_cast<std::int8_t>(thread_sharing_hint::none))
+          , runs_as_child_mode_bits(
+                static_cast<std::int8_t>(default_runs_as_child_hint))
         {
         }
 
@@ -313,11 +351,13 @@ namespace hpx::threads {
         /// given hint as the local thread number.
         constexpr explicit thread_schedule_hint(std::int16_t thread_hint,
             thread_placement_hint placement = thread_placement_hint::none,
+            thread_execution_hint runs_as_child = default_runs_as_child_hint,
             thread_sharing_hint sharing = thread_sharing_hint::none) noexcept
           : hint(thread_hint)
           , mode(thread_schedule_hint_mode::thread)
           , placement_mode_bits(static_cast<std::int8_t>(placement))
           , sharing_mode_bits(static_cast<std::int8_t>(sharing))
+          , runs_as_child_mode_bits(static_cast<std::int8_t>(runs_as_child))
         {
         }
 
@@ -326,11 +366,13 @@ namespace hpx::threads {
         constexpr thread_schedule_hint(thread_schedule_hint_mode mode,
             std::int16_t hint,
             thread_placement_hint placement = thread_placement_hint::none,
+            thread_execution_hint runs_as_child = default_runs_as_child_hint,
             thread_sharing_hint sharing = thread_sharing_hint::none) noexcept
           : hint(hint)
           , mode(mode)
           , placement_mode_bits(static_cast<std::int8_t>(placement))
           , sharing_mode_bits(static_cast<std::int8_t>(sharing))
+          , runs_as_child_mode_bits(static_cast<std::int8_t>(runs_as_child))
         {
         }
 
@@ -340,7 +382,8 @@ namespace hpx::threads {
         {
             return mode == rhs.mode && hint == rhs.hint &&
                 placement_mode() == rhs.placement_mode() &&
-                sharing_mode() == rhs.sharing_mode();
+                sharing_mode() == rhs.sharing_mode() &&
+                runs_as_child_mode() == rhs.runs_as_child_mode();
         }
 
         constexpr bool operator!=(
@@ -359,7 +402,7 @@ namespace hpx::threads {
         }
         void placement_mode(thread_placement_hint bits) noexcept
         {
-            placement_mode_bits = static_cast<std::int8_t>(bits);
+            placement_mode_bits = static_cast<std::uint8_t>(bits);
         }
 
         [[nodiscard]] constexpr thread_sharing_hint sharing_mode()
@@ -369,7 +412,17 @@ namespace hpx::threads {
         }
         void sharing_mode(thread_sharing_hint bits) noexcept
         {
-            sharing_mode_bits = static_cast<std::int8_t>(bits);
+            sharing_mode_bits = static_cast<std::uint8_t>(bits);
+        }
+
+        [[nodiscard]] constexpr thread_execution_hint runs_as_child_mode()
+            const noexcept
+        {
+            return static_cast<thread_execution_hint>(runs_as_child_mode_bits);
+        }
+        void runs_as_child_mode(thread_execution_hint bits) noexcept
+        {
+            runs_as_child_mode_bits = static_cast<std::uint8_t>(bits);
         }
 
         /// The hint associated with the mode. The interpretation of this hint
@@ -380,9 +433,13 @@ namespace hpx::threads {
         thread_schedule_hint_mode mode = thread_schedule_hint_mode::none;
 
         /// The mode of the desired thread placement.
-        std::int8_t placement_mode_bits : 6;
+        std::uint8_t placement_mode_bits : 5;
 
         /// The mode of the desired sharing hint
-        std::int8_t sharing_mode_bits : 2;
+        std::uint8_t sharing_mode_bits : 2;
+
+        /// The thread will run as a child directly in the context of the
+        /// current thread
+        std::uint8_t runs_as_child_mode_bits : 1;
     };
 }    // namespace hpx::threads

--- a/libs/core/coroutines/src/thread_enums.cpp
+++ b/libs/core/coroutines/src/thread_enums.cpp
@@ -29,7 +29,8 @@ namespace hpx::threads {
             "terminated",
             "staged",
             "pending_do_not_schedule",
-            "pending_boost"
+            "pending_boost",
+            "deleted"
         };
         // clang-format on
 
@@ -37,8 +38,8 @@ namespace hpx::threads {
 
     char const* get_thread_state_name(thread_schedule_state state) noexcept
     {
-        if (state < thread_schedule_state::active ||
-            state > thread_schedule_state::pending_boost)
+        if (state < thread_schedule_state::unknown ||
+            state > thread_schedule_state::deleted)
         {
             return "unknown";
         }

--- a/libs/core/debugging/src/print.cpp
+++ b/libs/core/debugging/src/print.cpp
@@ -257,7 +257,7 @@ namespace hpx::debug {
         [[nodiscard]] char const* hostname_print_helper::get_hostname() const
         {
             static bool initialized = false;
-            static char hostname_[20] = {'\0'};
+            static char hostname_[32] = {'\0'};
             if (!initialized)
             {
                 initialized = true;
@@ -265,7 +265,7 @@ namespace hpx::debug {
                 gethostname(hostname_, static_cast<std::size_t>(12));
 #endif
                 int const rank = guess_rank();
-                if (rank != -1)
+                if (rank >= 0)
                 {
 #if defined(HPX_GCC_VERSION) && HPX_GCC_VERSION >= 110000
 #pragma GCC diagnostic push

--- a/libs/core/execution/include/hpx/execution/detail/async_launch_policy_dispatch.hpp
+++ b/libs/core/execution/include/hpx/execution/detail/async_launch_policy_dispatch.hpp
@@ -148,7 +148,7 @@ namespace hpx::detail {
         HPX_FORCEINLINE static std::enable_if_t<
             traits::detail::is_deferred_invocable_v<F, Ts...>,
             hpx::future<util::detail::invoke_deferred_result_t<F, Ts...>>>
-        call(Policy&& policy, hpx::threads::thread_description const& desc,
+        call(Policy policy, hpx::threads::thread_description const& desc,
             threads::thread_pool_base* pool, F&& f, Ts&&... ts)
         {
             HPX_ASSERT(pool);
@@ -172,10 +172,8 @@ namespace hpx::detail {
             lcos::local::futures_factory<result_type()> p(
                 util::deferred_call(HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...));
 
-            threads::thread_id_ref_type tid =
-                p.post(pool, desc.get_description(), HPX_MOVE(policy));
-
-            if (tid)
+            if (threads::thread_id_ref_type tid =
+                    p.post(pool, desc.get_description(), HPX_MOVE(policy)))
             {
                 auto runs_as_child = hint.runs_as_child_mode();
                 if (runs_as_child ==
@@ -230,7 +228,7 @@ namespace hpx::detail {
         HPX_FORCEINLINE static std::enable_if_t<
             traits::detail::is_deferred_invocable_v<F, Ts...>,
             hpx::future<util::detail::invoke_deferred_result_t<F, Ts...>>>
-        call(Policy&& policy, hpx::threads::thread_description const& desc,
+        call(Policy policy, hpx::threads::thread_description const& desc,
             threads::thread_pool_base* pool, F&& f, Ts&&... ts)
         {
             HPX_ASSERT(pool != nullptr);
@@ -258,7 +256,7 @@ namespace hpx::detail {
                 p.post(pool, desc.get_description(), policy);
 
             // make sure this thread is executed last
-            threads::thread_id_type tid_self = threads::get_self_id();
+            threads::thread_id_type const tid_self = threads::get_self_id();
             if (tid && tid_self &&
                 get_thread_id_data(tid)->get_scheduler_base() ==
                     get_thread_id_data(tid_self)->get_scheduler_base())

--- a/libs/core/execution/include/hpx/execution/detail/future_exec.hpp
+++ b/libs/core/execution/include/hpx/execution/detail/future_exec.hpp
@@ -153,8 +153,8 @@ namespace hpx::lcos::detail {
     struct post_policy_spawner
     {
         template <typename F>
-        threads::thread_id_ref_type operator()(
-            F&& f, hpx::threads::thread_description desc) const
+        void operator()(F&& f, hpx::threads::thread_description desc,
+            threads::thread_id_ref_type& id) const
         {
             threads::thread_init_data data(
                 threads::make_thread_function_nullary(HPX_FORWARD(F, f)),
@@ -163,7 +163,7 @@ namespace hpx::lcos::detail {
                 threads::thread_stacksize::default_,
                 threads::thread_schedule_state::pending);
 
-            return threads::register_thread(data);
+            threads::register_thread(data, id);
         }
     };
 
@@ -173,11 +173,11 @@ namespace hpx::lcos::detail {
         Executor exec;
 
         template <typename F>
-        threads::thread_id_ref_type operator()(
-            F&& f, hpx::threads::thread_description) const
+        void operator()(F&& f, hpx::threads::thread_description,
+            threads::thread_id_ref_type& id) const
         {
+            id = threads::invalid_thread_id;
             hpx::parallel::execution::post(exec, HPX_FORWARD(F, f));
-            return threads::invalid_thread_id;
         }
     };
 

--- a/libs/core/execution/include/hpx/execution/detail/post_policy_dispatch.hpp
+++ b/libs/core/execution/include/hpx/execution/detail/post_policy_dispatch.hpp
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <hpx/config.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/async_base/launch_policy.hpp>
 #include <hpx/coroutines/thread_enums.hpp>
 #include <hpx/execution/detail/sync_launch_policy_dispatch.hpp>
@@ -32,25 +33,38 @@ namespace hpx::detail {
     struct post_policy_dispatch<launch::async_policy>
     {
         template <typename Policy, typename F, typename... Ts>
-        static void call(Policy const& policy,
+        static void call(Policy policy,
             hpx::threads::thread_description const& desc,
             threads::thread_pool_base* pool, F&& f, Ts&&... ts)
         {
+            auto hint = policy.hint();
+            if (hint.runs_as_child_mode() ==
+                hpx::threads::thread_execution_hint::run_as_child)
+            {
+                if (!pool->get_scheduler()->supports_direct_execution())
+                {
+                    hint.runs_as_child_mode(
+                        hpx::threads::thread_execution_hint::none);
+                    policy.set_hint(hint);
+                }
+            }
+
             threads::thread_init_data data(
                 threads::make_thread_function_nullary(hpx::util::deferred_call(
                     HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...)),
-                desc, policy.priority(), policy.hint(), policy.stacksize(),
+                desc, policy.priority(), hint, policy.stacksize(),
                 threads::thread_schedule_state::pending);
 
             threads::register_work(data, pool);
         }
 
         template <typename Policy, typename F, typename... Ts>
-        static void call(Policy const& policy,
+        static void call(Policy&& policy,
             hpx::threads::thread_description const& desc, F&& f, Ts&&... ts)
         {
-            call(policy, desc, threads::detail::get_self_or_default_pool(),
-                HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...);
+            call(HPX_FORWARD(Policy, policy), desc,
+                threads::detail::get_self_or_default_pool(), HPX_FORWARD(F, f),
+                HPX_FORWARD(Ts, ts)...);
         }
     };
 
@@ -58,16 +72,30 @@ namespace hpx::detail {
     struct post_policy_dispatch<launch::fork_policy>
     {
         template <typename Policy, typename F, typename... Ts>
-        static void call(Policy const& policy,
+        static void call(Policy policy,
             hpx::threads::thread_description const& desc,
             threads::thread_pool_base* pool, F&& f, Ts&&... ts)
         {
+            auto hint = policy.hint();
+            if (hint.runs_as_child_mode() ==
+                hpx::threads::thread_execution_hint::run_as_child)
+            {
+                if (!pool->get_scheduler()->supports_direct_execution())
+                {
+                    hint.runs_as_child_mode(
+                        hpx::threads::thread_execution_hint::none);
+                    policy.set_hint(hint);
+                }
+            }
+
             threads::thread_init_data data(
                 threads::make_thread_function_nullary(hpx::util::deferred_call(
                     HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...)),
                 desc, policy.priority(),
                 threads::thread_schedule_hint(
-                    static_cast<std::int16_t>(get_worker_thread_num())),
+                    threads::thread_schedule_hint_mode::thread,
+                    static_cast<std::int16_t>(get_worker_thread_num()),
+                    hint.placement_mode(), hint.runs_as_child_mode()),
                 policy.stacksize(),
                 threads::thread_schedule_state::pending_do_not_schedule, true);
 
@@ -88,11 +116,12 @@ namespace hpx::detail {
         }
 
         template <typename Policy, typename F, typename... Ts>
-        static void call(Policy const& policy,
+        static void call(Policy&& policy,
             hpx::threads::thread_description const& desc, F&& f, Ts&&... ts)
         {
-            call(policy, desc, threads::detail::get_self_or_default_pool(),
-                HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...);
+            call(HPX_FORWARD(Policy, policy), desc,
+                threads::detail::get_self_or_default_pool(), HPX_FORWARD(F, f),
+                HPX_FORWARD(Ts, ts)...);
         }
     };
 
@@ -100,20 +129,22 @@ namespace hpx::detail {
     struct post_policy_dispatch<launch::sync_policy>
     {
         template <typename Policy, typename F, typename... Ts>
-        static void call(Policy const& policy,
+        static void call(Policy&& policy,
             hpx::threads::thread_description const&, threads::thread_pool_base*,
             F&& f, Ts&&... ts)
         {
             hpx::detail::sync_launch_policy_dispatch<launch::sync_policy>::call(
-                policy, HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...);
+                HPX_FORWARD(Policy, policy), HPX_FORWARD(F, f),
+                HPX_FORWARD(Ts, ts)...);
         }
 
         template <typename Policy, typename F, typename... Ts>
-        static void call(Policy const& policy,
+        static void call(Policy&& policy,
             hpx::threads::thread_description const&, F&& f, Ts&&... ts)
         {
             hpx::detail::sync_launch_policy_dispatch<launch::sync_policy>::call(
-                policy, HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...);
+                HPX_FORWARD(Policy, policy), HPX_FORWARD(F, f),
+                HPX_FORWARD(Ts, ts)...);
         }
     };
 
@@ -121,22 +152,22 @@ namespace hpx::detail {
     struct post_policy_dispatch<launch::deferred_policy>
     {
         template <typename Policy, typename F, typename... Ts>
-        static void call(Policy const& policy,
+        static void call(Policy&& policy,
             hpx::threads::thread_description const&, threads::thread_pool_base*,
             F&& f, Ts&&... ts)
         {
             hpx::detail::sync_launch_policy_dispatch<
-                launch::deferred_policy>::call(policy, HPX_FORWARD(F, f),
-                HPX_FORWARD(Ts, ts)...);
+                launch::deferred_policy>::call(HPX_FORWARD(Policy, policy),
+                HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...);
         }
 
         template <typename Policy, typename F, typename... Ts>
-        static void call(Policy const& policy,
+        static void call(Policy&& policy,
             hpx::threads::thread_description const&, F&& f, Ts&&... ts)
         {
             hpx::detail::sync_launch_policy_dispatch<
-                launch::deferred_policy>::call(policy, HPX_FORWARD(F, f),
-                HPX_FORWARD(Ts, ts)...);
+                launch::deferred_policy>::call(HPX_FORWARD(Policy, policy),
+                HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...);
         }
     };
 
@@ -144,39 +175,69 @@ namespace hpx::detail {
     struct post_policy_dispatch
     {
         template <typename F, typename... Ts>
-        static void call(Policy const& policy,
+        static void call(Policy policy,
             hpx::threads::thread_description const& desc,
             threads::thread_pool_base* pool, F&& f, Ts&&... ts)
         {
+            HPX_ASSERT(pool != nullptr);
+
+            auto hint = policy.hint();
+            if (hint.runs_as_child_mode() ==
+                hpx::threads::thread_execution_hint::run_as_child)
+            {
+                if (!pool->get_scheduler()->supports_direct_execution())
+                {
+                    hint.runs_as_child_mode(
+                        hpx::threads::thread_execution_hint::none);
+                    policy.set_hint(hint);
+                }
+            }
+
             if (policy == launch::sync)
             {
-                post_policy_dispatch<launch::sync_policy>::call(policy, desc,
-                    pool, HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...);
+                auto mod_policy = launch::sync_policy(
+                    policy.priority(), policy.stacksize(), hint);
+
+                post_policy_dispatch<launch::sync_policy>::call(
+                    HPX_MOVE(mod_policy), desc, pool, HPX_FORWARD(F, f),
+                    HPX_FORWARD(Ts, ts)...);
             }
             else if (policy == launch::deferred)
             {
-                // execute synchronously
-                post_policy_dispatch<launch::deferred_policy>::call(policy,
-                    desc, pool, HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...);
+                auto mod_policy = launch::deferred_policy(
+                    policy.priority(), policy.stacksize(), hint);
+
+                post_policy_dispatch<launch::deferred_policy>::call(
+                    HPX_MOVE(mod_policy), desc, pool, HPX_FORWARD(F, f),
+                    HPX_FORWARD(Ts, ts)...);
             }
             else if (policy == launch::fork)
             {
-                post_policy_dispatch<launch::fork_policy>::call(policy, desc,
-                    pool, HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...);
+                auto mod_policy = launch::fork_policy(
+                    policy.priority(), policy.stacksize(), hint);
+
+                post_policy_dispatch<launch::fork_policy>::call(
+                    HPX_MOVE(mod_policy), desc, pool, HPX_FORWARD(F, f),
+                    HPX_FORWARD(Ts, ts)...);
             }
             else
             {
-                post_policy_dispatch<launch::async_policy>::call(policy, desc,
-                    pool, HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...);
+                auto mod_policy = launch::async_policy(
+                    policy.priority(), policy.stacksize(), hint);
+
+                post_policy_dispatch<launch::async_policy>::call(
+                    HPX_MOVE(mod_policy), desc, pool, HPX_FORWARD(F, f),
+                    HPX_FORWARD(Ts, ts)...);
             }
         }
 
         template <typename F, typename... Ts>
-        static void call(Policy const& policy,
+        static void call(Policy&& policy,
             hpx::threads::thread_description const& desc, F&& f, Ts&&... ts)
         {
-            call(policy, desc, threads::detail::get_self_or_default_pool(),
-                HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...);
+            call(HPX_FORWARD(Policy, policy), desc,
+                threads::detail::get_self_or_default_pool(), HPX_FORWARD(F, f),
+                HPX_FORWARD(Ts, ts)...);
         }
     };
 }    // namespace hpx::detail

--- a/libs/core/executors/include/hpx/executors/dataflow.hpp
+++ b/libs/core/executors/include/hpx/executors/dataflow.hpp
@@ -348,13 +348,9 @@ namespace hpx::lcos::detail {
         // clang-format on
         HPX_FORCEINLINE void finalize(Executor&& exec, Futures_&& futures)
         {
-#if defined(HPX_CUDA_VERSION)
-            std::forward<Executor>(exec)
-#else
-            HPX_FORWARD(Executor, exec)
-#endif
-                .dataflow_finalize(
-                    this, HPX_MOVE(func_), HPX_FORWARD(Futures_, futures));
+            // uses std::forward for HPX_CUDA_VERSION
+            std::forward<Executor>(exec).dataflow_finalize(
+                this, HPX_MOVE(func_), HPX_FORWARD(Futures_, futures));
         }
 
     public:

--- a/libs/core/futures/CMakeLists.txt
+++ b/libs/core/futures/CMakeLists.txt
@@ -7,6 +7,7 @@
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 
 set(futures_headers
+    hpx/futures/detail/execute_thread.hpp
     hpx/futures/future.hpp
     hpx/futures/future_fwd.hpp
     hpx/futures/futures_factory.hpp
@@ -51,7 +52,7 @@ set(futures_compat_headers
 )
 # cmake-format: on
 
-set(futures_sources future_data.cpp)
+set(futures_sources detail/execute_thread.cpp future_data.cpp)
 
 include(HPX_AddModule)
 add_hpx_module(
@@ -69,10 +70,12 @@ add_hpx_module(
     hpx_config
     hpx_errors
     hpx_functional
+    hpx_logging
     hpx_memory
     hpx_serialization
     hpx_synchronization
     hpx_timing
+    hpx_threading_base
     hpx_type_support
   CMAKE_SUBDIRS examples tests
 )

--- a/libs/core/futures/include/hpx/futures/detail/execute_thread.hpp
+++ b/libs/core/futures/include/hpx/futures/detail/execute_thread.hpp
@@ -1,0 +1,15 @@
+//  Copyright (c) 2019-2023 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include <hpx/config.hpp>
+#include <hpx/threading_base/thread_data.hpp>
+
+namespace hpx::threads::detail {
+
+    HPX_CORE_EXPORT bool execute_thread(thread_id_ref_type thrd);
+}    // namespace hpx::threads::detail

--- a/libs/core/futures/include/hpx/futures/futures_factory.hpp
+++ b/libs/core/futures/include/hpx/futures/futures_factory.hpp
@@ -8,6 +8,7 @@
 
 #include <hpx/config.hpp>
 #include <hpx/assert.hpp>
+
 #include <hpx/allocator_support/allocator_deleter.hpp>
 #include <hpx/allocator_support/internal_allocator.hpp>
 #include <hpx/async_base/launch_policy.hpp>

--- a/libs/core/futures/include/hpx/futures/futures_factory.hpp
+++ b/libs/core/futures/include/hpx/futures/futures_factory.hpp
@@ -143,8 +143,8 @@ namespace hpx::lcos::local {
                     {
                         HPX_ASSERT(
                             this->runs_child_ == threads::invalid_thread_id);
-                        this->runs_child_ =
-                            threads::register_thread(data, pool, ec);
+                        threads::register_thread(
+                            data, pool, this->runs_child_, ec);
                         return this->runs_child_;
                     }
 
@@ -164,8 +164,7 @@ namespace hpx::lcos::local {
                         threads::thread_schedule_state::suspended, true);
 
                     HPX_ASSERT(this->runs_child_ == threads::invalid_thread_id);
-                    this->runs_child_ =
-                        threads::register_thread(data, pool, ec);
+                    threads::register_thread(data, pool, this->runs_child_, ec);
 
                     // now run the thread
                     threads::set_thread_state(this->runs_child_.noref(),

--- a/libs/core/futures/include/hpx/futures/packaged_continuation.hpp
+++ b/libs/core/futures/include/hpx/futures/packaged_continuation.hpp
@@ -10,6 +10,7 @@
 #include <hpx/config.hpp>
 #include <hpx/allocator_support/allocator_deleter.hpp>
 #include <hpx/allocator_support/internal_allocator.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/async_base/launch_policy.hpp>
 #include <hpx/errors/try_catch_exception_ptr.hpp>
 #include <hpx/futures/detail/future_data.hpp>
@@ -225,12 +226,12 @@ namespace hpx::lcos::detail {
         {
             ensure_started();
 
+            HPX_ASSERT(!this->runs_child_);
+
             hpx::intrusive_ptr<continuation> this_(this);
             hpx::threads::thread_description desc(f_, "async");
-
-            spawner(
+            this->runs_child_ = spawner(
                 [this_ = HPX_MOVE(this_), f = HPX_MOVE(f)]() mutable -> void {
-                    reset_id r(*this_);
                     this_->template run_impl<Unwrap>(HPX_MOVE(f));
                 },
                 desc);

--- a/libs/core/futures/include/hpx/futures/packaged_continuation.hpp
+++ b/libs/core/futures/include/hpx/futures/packaged_continuation.hpp
@@ -230,17 +230,11 @@ namespace hpx::lcos::detail {
 
             hpx::intrusive_ptr<continuation> this_(this);
             hpx::threads::thread_description desc(f_, "async");
-            auto thrd = spawner(
+            spawner(
                 [this_ = HPX_MOVE(this_), f = HPX_MOVE(f)]() mutable -> void {
                     this_->template run_impl<Unwrap>(HPX_MOVE(f));
                 },
-                desc);
-
-            std::lock_guard<mutex_type> l(mtx_);
-            if (!this->base_type::is_ready())
-            {
-                this->runs_child_ = HPX_MOVE(thrd);
-            }
+                desc, this->runs_child_);
         }
 
     public:
@@ -261,8 +255,8 @@ namespace hpx::lcos::detail {
                     if (this->is_ready())
                         return;    // nothing we can do
 
-                    // 26110: Caller failing to hold lock 'l'
 #if defined(HPX_MSVC)
+// 26110: Caller failing to hold lock 'l'
 #pragma warning(push)
 #pragma warning(disable : 26110)
 #endif

--- a/libs/core/futures/include/hpx/futures/traits/is_future.hpp
+++ b/libs/core/futures/include/hpx/futures/traits/is_future.hpp
@@ -66,13 +66,12 @@ namespace hpx::traits {
 
     ///////////////////////////////////////////////////////////////////////////
     template <typename... Ts>
-    struct is_future_any : hpx::util::any_of<is_future<Ts>...>
-    {
-    };
+    using is_future_any = hpx::util::any_of<is_future<Ts>...>;
 
     template <typename... Ts>
     inline constexpr bool is_future_any_v = is_future_any<Ts...>::value;
 
+    ///////////////////////////////////////////////////////////////////////////
     template <typename Future>
     struct is_ref_wrapped_future : std::false_type
     {

--- a/libs/core/futures/src/detail/execute_thread.cpp
+++ b/libs/core/futures/src/detail/execute_thread.cpp
@@ -1,0 +1,210 @@
+//  Copyright (c) 2019-2023 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/config.hpp>
+#include <hpx/assert.hpp>
+#include <hpx/async_base/launch_policy.hpp>
+#include <hpx/coroutines/thread_enums.hpp>
+#include <hpx/execution_base/this_thread.hpp>
+#include <hpx/functional/deferred_call.hpp>
+#include <hpx/futures/detail/execute_thread.hpp>
+#include <hpx/futures/future.hpp>
+#include <hpx/futures/futures_factory.hpp>
+#include <hpx/threading_base/detail/switch_status.hpp>
+#include <hpx/threading_base/register_thread.hpp>
+#include <hpx/threading_base/set_thread_state.hpp>
+#include <hpx/threading_base/thread_data.hpp>
+#include <hpx/threading_base/thread_helpers.hpp>
+
+#include <cstddef>
+#include <cstdint>
+#include <utility>
+
+namespace hpx::threads::detail {
+
+#if !defined(HPX_HAVE_THREADS_GET_STACK_POINTER)
+    ///////////////////////////////////////////////////////////////////////////
+    // reuse the continuation recursion count here as well
+    struct execute_thread_recursion_count
+    {
+        execute_thread_recursion_count() noexcept
+          : count_(threads::get_continuation_recursion_count())
+        {
+            ++count_;
+        }
+        ~execute_thread_recursion_count() noexcept
+        {
+            --count_;
+        }
+
+        std::size_t& count_;
+    };
+#endif
+
+    // make sure thread invocation does not recurse deeper than allowed
+    HPX_FORCEINLINE coroutine_type::result_type handle_execute_thread(
+        thread_id_type const& thrd)
+    {
+        auto* thrdptr = get_thread_id_data(thrd);
+
+        // We need to run the completion on a new thread
+        HPX_ASSERT(nullptr != hpx::threads::get_self_ptr());
+
+#if defined(HPX_HAVE_THREADS_GET_STACK_POINTER)
+        bool recurse_asynchronously =
+            !this_thread::has_sufficient_stack_space();
+#else
+        execute_thread_recursion_count cnt;
+        bool recurse_asynchronously =
+            cnt.count_ > HPX_CONTINUATION_MAX_RECURSION_DEPTH;
+#endif
+        if (!recurse_asynchronously)
+        {
+            // directly execute continuation on this thread
+            return thrdptr->invoke_directly();
+        }
+
+        LTM_(error).format(
+            "handle_execute_thread: couldn't directly execute thread({}), "
+            "description({})",
+            thrdptr, thrdptr->get_description());
+
+        return {thread_schedule_state::pending, invalid_thread_id};
+    }
+
+    bool execute_thread(thread_id_ref_type thrd)
+    {
+        auto* thrdptr = get_thread_id_data(thrd);
+        thread_state state = thrdptr->get_state();
+        thread_schedule_state state_val = state.state();
+
+        // the given thread can be executed inline if its state is 'pending'
+        // (i.e. not running and not finished running)
+        if (state_val != thread_schedule_state::pending)
+        {
+            return false;
+        }
+
+        bool reschedule = false;
+
+        // don't directly run any threads that have started running 'normally'
+        // and were suspended afterwards
+        if (thrdptr->runs_as_child())
+        {
+            LTM_(error).format(
+                "execute_thread: attempting to directly execute thread({}), "
+                "description({}), runs_as_child({})",
+                thrdptr, thrdptr->get_description(),
+                thrdptr->runs_as_child(std::memory_order_relaxed));
+
+            // tries to set state to active (only if state is still the same as
+            // 'state')
+            switch_status thrd_stat(thrd, state);
+            if (HPX_UNLIKELY(!thrd_stat.is_valid()))
+            {
+                // state change failed
+                LTM_(error).format(
+                    "execute_thread: couldn't directly execute "
+                    "thread({}), description({}), state change failed",
+                    thrdptr, thrdptr->get_description());
+
+                // switch_status will not reset thread state
+                return false;
+            }
+
+            HPX_ASSERT(
+                thrdptr->get_state().state() == thread_schedule_state::active);
+
+            if (HPX_UNLIKELY(
+                    thrd_stat.get_previous() != thread_schedule_state::pending))
+            {
+                // thread was not pending
+                LTM_(error).format(
+                    "execute_thread: couldn't directly execute "
+                    "thread({}), description({}), thread not pending",
+                    thrdptr, thrdptr->get_description());
+
+                // switch_status will reset state to what it was before
+                return false;
+            }
+
+            // check again, making sure the state has not changed in the mean
+            // time
+            if (thrdptr->runs_as_child())
+            {
+#if defined(HPX_HAVE_APEX)
+                // get the APEX data pointer, in case we are resuming the thread
+                // and have to restore any leaf timers from direct actions, etc.
+                util::external_timer::scoped_timer profiler(
+                    thrdptr->get_timer_data());
+
+                thrd_stat = handle_execute_thread(thrd.noref());
+
+                thread_schedule_state s = thrd_stat.get_previous();
+                if (s == thread_schedule_state::terminated ||
+                    s == thread_schedule_state::deleted)
+                {
+                    profiler.stop();
+
+                    // just in case, clean up the now dead pointer.
+                    thrdptr->set_timer_data(nullptr);
+                }
+                else
+                {
+                    profiler.yield();
+                }
+#else
+                thrd_stat = handle_execute_thread(thrd.noref());
+#endif
+            }
+            else
+            {
+                // reschedule thread as it could have been dropped on the floor
+                // by the scheduler while the status was set to active here
+                reschedule = true;
+            }
+
+            // store and retrieve the new state in the thread
+            if (HPX_LIKELY(thrd_stat.store_state(state)))
+            {
+                // direct execution doesn't support specifying the next
+                // thread to execute
+                HPX_ASSERT(thrd_stat.get_next_thread() == nullptr);
+
+                state_val = state.state();
+                if (state_val == thread_schedule_state::pending)
+                {
+                    // explicitly reschedule thread as it was not executed
+                    // directly
+                    reschedule = true;
+                }
+            }
+
+            LTM_(error).format("execute_thread: directly executed thread({}), "
+                               "description({}), returned state({})",
+                thrdptr, thrdptr->get_description(), state_val);
+
+            // any exception thrown from the thread will reset its state at this
+            // point
+        }
+
+        if (reschedule)
+        {
+            LTM_(error).format(
+                "execute_thread: rescheduling thread after failing to directly "
+                "execute thread({}), description({})",
+                thrdptr, thrdptr->get_description());
+
+            set_thread_state(thrd.noref(), thread_schedule_state::pending,
+                thread_restart_state::signaled);
+            auto* scheduler = thrdptr->get_scheduler_base();
+            scheduler->schedule_thread_last(thrd, thread_schedule_hint());
+        }
+
+        HPX_ASSERT(state_val != thread_schedule_state::terminated);
+        return state_val == thread_schedule_state::deleted;
+    }
+}    // namespace hpx::threads::detail

--- a/libs/core/futures/src/detail/execute_thread.cpp
+++ b/libs/core/futures/src/detail/execute_thread.cpp
@@ -201,7 +201,11 @@ namespace hpx::threads::detail {
             set_thread_state(thrd.noref(), thread_schedule_state::pending,
                 thread_restart_state::signaled);
             auto* scheduler = thrdptr->get_scheduler_base();
-            scheduler->schedule_thread_last(thrd, thread_schedule_hint());
+
+            auto const hint = thread_schedule_hint(static_cast<std::int16_t>(
+                thrdptr->get_last_worker_thread_num()));
+            scheduler->schedule_thread_last(HPX_MOVE(thrd), hint);
+            scheduler->do_some_work(hint.hint);
         }
 
         HPX_ASSERT(state_val != thread_schedule_state::terminated);

--- a/libs/core/futures/src/future_data.cpp
+++ b/libs/core/futures/src/future_data.cpp
@@ -122,7 +122,7 @@ namespace hpx::lcos::detail {
             return false;
         }
 
-        auto state = this->state_.load(std::memory_order_acquire);
+        auto const state = this->state_.load(std::memory_order_acquire);
         if (state != this->empty)
         {
             return false;

--- a/libs/core/futures/src/future_data.cpp
+++ b/libs/core/futures/src/future_data.cpp
@@ -117,7 +117,8 @@ namespace hpx::lcos::detail {
     bool future_data_base<traits::detail::future_data_void>::execute_thread()
     {
         // we try to directly execute the thread exactly once
-        if (!runs_child_)
+        threads::thread_id_ref_type runs_child = runs_child_;
+        if (!runs_child)
         {
             return false;
         }
@@ -129,7 +130,6 @@ namespace hpx::lcos::detail {
         }
 
         // this thread would block on the future
-        threads::thread_id_ref_type runs_child = runs_child_;
 
         auto* thrd = get_thread_id_data(runs_child);
         HPX_UNUSED(thrd);    // might be unused

--- a/libs/core/futures/src/future_data.cpp
+++ b/libs/core/futures/src/future_data.cpp
@@ -8,13 +8,16 @@
 #include <hpx/futures/future.hpp>
 
 #include <hpx/config.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/async_base/launch_policy.hpp>
 #include <hpx/errors/try_catch_exception_ptr.hpp>
 #include <hpx/execution_base/this_thread.hpp>
 #include <hpx/functional/deferred_call.hpp>
 #include <hpx/functional/move_only_function.hpp>
+#include <hpx/futures/detail/execute_thread.hpp>
 #include <hpx/futures/futures_factory.hpp>
 #include <hpx/modules/errors.hpp>
+#include <hpx/modules/logging.hpp>
 #include <hpx/modules/memory.hpp>
 
 #include <cstddef>
@@ -95,8 +98,68 @@ namespace hpx::lcos::detail {
     }
 
     ///////////////////////////////////////////////////////////////////////////
-    future_data_base<traits::detail::future_data_void>::~future_data_base() =
-        default;
+    future_data_base<traits::detail::future_data_void>::~future_data_base()
+    {
+        if (runs_child_ != threads::invalid_thread_id)
+        {
+            auto* thrd = get_thread_id_data(runs_child_);
+            (void) thrd;
+            LTM_(debug).format(
+                "task_object::~task_object({}), description({}): "
+                "destroy runs_as_child thread",
+                thrd, thrd->get_description(), thrd->get_thread_phase());
+
+            runs_child_ = threads::invalid_thread_id;
+        }
+    }
+
+    // try to performed scoped execution of the associated thread (if any)
+    bool future_data_base<traits::detail::future_data_void>::execute_thread()
+    {
+        // we try to directly execute the thread exactly once
+        if (!runs_child_)
+        {
+            return false;
+        }
+
+        auto state = this->state_.load(std::memory_order_acquire);
+        if (state != this->empty)
+        {
+            return false;
+        }
+
+        // this thread would block on the future
+        threads::thread_id_ref_type runs_child = runs_child_;
+
+        auto* thrd = get_thread_id_data(runs_child);
+        HPX_UNUSED(thrd);    // might be unused
+
+        LTM_(debug).format("task_object::get_result_void: attempting to "
+                           "directly execute child({}), description({})",
+            thrd, thrd->get_description());
+
+        if (threads::detail::execute_thread(HPX_MOVE(runs_child)))
+        {
+            // don't try running this twice
+            runs_child_.reset();
+
+            LTM_(debug).format("task_object::get_result_void: successfully "
+                               "directly executed child({}), description({})",
+                thrd, thrd->get_description());
+
+            // thread terminated, mark as being destroyed
+            HPX_ASSERT(thrd->get_state().state() ==
+                threads::thread_schedule_state::deleted);
+
+            return true;
+        }
+
+        LTM_(debug).format("task_object::get_result_void: failed to "
+                           "directly execute child({}), description({})",
+            thrd, thrd->get_description());
+
+        return false;
+    }
 
     static util::unused_type unused_;
 
@@ -111,8 +174,8 @@ namespace hpx::lcos::detail {
             return nullptr;
         }
 
-        // No locking is required. Once a future has been made ready, which
-        // is a postcondition of wait, either:
+        // No locking is required. Once a future has been made ready, which is a
+        // postcondition of wait, either:
         //
         // - there is only one writer (future), or
         // - there are multiple readers only (shared_future, lock hurts
@@ -139,16 +202,15 @@ namespace hpx::lcos::detail {
             return nullptr;
         }
 
-        // the thread has been re-activated by one of the actions
-        // supported by this promise (see promise::set_event
-        // and promise::set_exception).
+        // the thread has been re-activated by one of the actions supported by
+        // this promise (see promise::set_event and promise::set_exception).
         if (s == exception)
         {
             auto const* exception_ptr =
                 static_cast<std::exception_ptr const*>(storage);
 
-            // an error has been reported in the meantime, throw or set
-            // the error code
+            // an error has been reported in the meantime, throw or set the
+            // error code
             if (&ec == &throws)
             {
                 std::rethrow_exception(*exception_ptr);
@@ -171,8 +233,8 @@ namespace hpx::lcos::detail {
                 on_completed();
             },
             [&](std::exception_ptr ep) {
-                // If the completion handler throws an exception, there's nothing
-                // we can do, report the exception and terminate.
+                // If the completion handler throws an exception, there's
+                // nothing we can do, report the exception and terminate.
                 if (run_on_completed_error_handler)
                 {
                     run_on_completed_error_handler(HPX_MOVE(ep));
@@ -193,15 +255,14 @@ namespace hpx::lcos::detail {
         }
     }
 
-    // make sure continuation invocation does not recurse deeper than
-    // allowed
+    // make sure continuation invocation does not recurse deeper than allowed
     template <typename Callback>
     void
     future_data_base<traits::detail::future_data_void>::handle_on_completed(
         Callback&& on_completed)
     {
-        // We need to run the completion on a new thread if we are on a
-        // non HPX thread.
+        // We need to run the completion on a new thread if we are on a non HPX
+        // thread.
 #if defined(HPX_HAVE_THREADS_GET_STACK_POINTER)
         bool recurse_asynchronously =
             !this_thread::has_sufficient_stack_space();
@@ -219,7 +280,6 @@ namespace hpx::lcos::detail {
         else
         {
             // re-spawn continuation on a new thread
-
             hpx::detail::try_catch_exception_ptr(
                 [&]() {
                     // clang-format off

--- a/libs/core/futures/tests/unit/CMakeLists.txt
+++ b/libs/core/futures/tests/unit/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2007-2017 Hartmut Kaiser
+# Copyright (c) 2007-2023 Hartmut Kaiser
 # Copyright (c) 2011-2012 Bryce Adelstein-Lelbach
 #
 # SPDX-License-Identifier: BSL-1.0
@@ -6,6 +6,7 @@
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 set(tests
+    direct_scoped_execution
     future
     future_ref
     future_then

--- a/libs/core/futures/tests/unit/direct_scoped_execution.cpp
+++ b/libs/core/futures/tests/unit/direct_scoped_execution.cpp
@@ -5,10 +5,10 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include <hpx/init.hpp>
 #include <hpx/chrono.hpp>
 #include <hpx/execution.hpp>
 #include <hpx/future.hpp>
+#include <hpx/init.hpp>
 #include <hpx/modules/format.hpp>
 #include <hpx/modules/testing.hpp>
 

--- a/libs/core/futures/tests/unit/direct_scoped_execution.cpp
+++ b/libs/core/futures/tests/unit/direct_scoped_execution.cpp
@@ -1,0 +1,87 @@
+//  Copyright (c) 2011 Bryce Lelbach
+//  Copyright (c) 2021 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/init.hpp>
+#include <hpx/local/chrono.hpp>
+#include <hpx/local/execution.hpp>
+#include <hpx/local/future.hpp>
+#include <hpx/modules/format.hpp>
+#include <hpx/modules/testing.hpp>
+
+#include <cstdint>
+#include <iostream>
+#include <string>
+#include <vector>
+
+bool use_scoping = true;
+
+///////////////////////////////////////////////////////////////////////////////
+std::uint64_t fibonacci(std::uint64_t n)
+{
+    if (n < 2)
+        return n;
+
+    hpx::threads::thread_schedule_hint hint;
+    hint.runs_as_child_mode(use_scoping ?
+            hpx::threads::thread_execution_hint::run_as_child :
+            hpx::threads::thread_execution_hint::none);
+
+    auto exec = hpx::execution::experimental::with_hint(
+        hpx::execution::parallel_executor{}, hint);
+
+    hpx::future<std::uint64_t> n1 = hpx::async(exec, fibonacci, n - 1);
+    std::uint64_t const n2 = fibonacci(n - 2);
+
+    // wait for the Futures to return their values
+    return n1.get() + n2;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+int hpx_main(hpx::program_options::variables_map& vm)
+{
+    // extract command line argument, i.e. fib(N)
+    std::uint64_t const n = vm["n-value"].as<std::uint64_t>();
+
+    use_scoping = vm.count("non-scoped") == 0;
+
+    {
+        // Keep track of the time required to execute.
+        hpx::chrono::high_resolution_timer const t;
+
+        std::uint64_t const r = fibonacci(n);
+
+        char const* fmt = "fibonacci({1}) == {2}\nelapsed time: {3} [s]\n";
+        hpx::util::format_to(std::cout, fmt, n, r, t.elapsed());
+    }
+
+    return hpx::finalize();    // Handles HPX shutdown
+}
+
+///////////////////////////////////////////////////////////////////////////////
+int main(int argc, char* argv[])
+{
+    // Configure application-specific options
+    hpx::program_options::options_description desc_commandline(
+        "Usage: " HPX_APPLICATION_STRING " [options]");
+
+    // clang-format off
+    desc_commandline.add_options()
+        ("n-value",
+            hpx::program_options::value<std::uint64_t>()->default_value(10),
+            "n value for the Fibonacci function")
+        ("non-scoped", "run created threads without scoping");
+    // clang-format on
+
+    // use LIFO scheduler
+    hpx::init_params params;
+    params.desc_cmdline = desc_commandline;
+
+    // Initialize and run HPX
+    hpx::init(argc, argv, params);
+
+    return hpx::util::report_errors();
+}

--- a/libs/core/futures/tests/unit/direct_scoped_execution.cpp
+++ b/libs/core/futures/tests/unit/direct_scoped_execution.cpp
@@ -6,9 +6,9 @@
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <hpx/init.hpp>
-#include <hpx/local/chrono.hpp>
-#include <hpx/local/execution.hpp>
-#include <hpx/local/future.hpp>
+#include <hpx/chrono.hpp>
+#include <hpx/execution.hpp>
+#include <hpx/future.hpp>
 #include <hpx/modules/format.hpp>
 #include <hpx/modules/testing.hpp>
 

--- a/libs/core/init_runtime_local/src/init_runtime_local.cpp
+++ b/libs/core/init_runtime_local/src/init_runtime_local.cpp
@@ -500,6 +500,9 @@ namespace hpx {
                             return result;
                         }
 
+                        rp.assign_cores(hpx::util::get_entry_as<std::size_t>(
+                            cmdline.rtcfg_, "hpx.first_used_core", 0));
+
                         // If thread_pools initialization in user main
                         if (params.rp_callback)
                         {

--- a/libs/core/init_runtime_local/src/init_runtime_local.cpp
+++ b/libs/core/init_runtime_local/src/init_runtime_local.cpp
@@ -357,14 +357,14 @@ namespace hpx {
                 }
 
                 // non-blocking version
-                start(*rt, cfg.hpx_main_f_, cfg.vm_, HPX_MOVE(startup),
-                    HPX_MOVE(shutdown));
+                int const result = start(*rt, cfg.hpx_main_f_, cfg.vm_,
+                    HPX_MOVE(startup), HPX_MOVE(shutdown));
 
                 // pointer to runtime is stored in TLS
                 hpx::runtime* p = rt.release();
                 (void) p;
 
-                return 0;
+                return result;
             }
 
             ////////////////////////////////////////////////////////////////////////

--- a/libs/core/resource_partitioner/include/hpx/resource_partitioner/partitioner.hpp
+++ b/libs/core/resource_partitioner/include/hpx/resource_partitioner/partitioner.hpp
@@ -205,6 +205,9 @@ namespace hpx::resource {
         // resource partitioner called in hpx_init
         HPX_CORE_EXPORT void configure_pools();
 
+        // Local runtime only: initialize first_core and pus_needed
+        HPX_CORE_EXPORT void assign_cores(std::size_t first_core);
+
     private:
         detail::partitioner& partitioner_;
     };

--- a/libs/core/resource_partitioner/src/detail_partitioner.cpp
+++ b/libs/core/resource_partitioner/src/detail_partitioner.cpp
@@ -948,6 +948,8 @@ namespace hpx::resource::detail {
         affinity_data_ = affinity_data;
 
         fill_topology_vectors();
+
+        pus_needed_ = assign_cores(0);
     }
 
     scheduler_function partitioner::get_pool_creator(std::size_t index) const

--- a/libs/core/resource_partitioner/src/partitioner.cpp
+++ b/libs/core/resource_partitioner/src/partitioner.cpp
@@ -228,4 +228,10 @@ namespace hpx::resource {
     {
         partitioner_.configure_pools();
     }
+
+    // Local runtime only: initialize first_core and pus_needed
+    void partitioner::assign_cores(std::size_t first_core)
+    {
+        partitioner_.assign_cores(first_core);
+    }
 }    // namespace hpx::resource

--- a/libs/core/resource_partitioner/tests/unit/CMakeLists.txt
+++ b/libs/core/resource_partitioner/tests/unit/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2017 Hartmut Kaiser
+# Copyright (c) 2017-2023 Hartmut Kaiser
 #
 # SPDX-License-Identifier: BSL-1.0
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -33,13 +33,24 @@ set(used_pus_PARAMETERS THREADS_PER_LOCALITY 4 RUN_SERIAL)
 
 set(scheduler_priority_check_PARAMETERS THREADS_PER_LOCALITY -1)
 set(shutdown_suspended_pus_PARAMETERS THREADS_PER_LOCALITY 4)
-set(suspend_disabled_PARAMETERS THREADS_PER_LOCALITY 4)
-set(suspend_pool_PARAMETERS THREADS_PER_LOCALITY 4)
-set(suspend_pool_external_PARAMETERS THREADS_PER_LOCALITY 4)
-set(suspend_runtime_PARAMETERS THREADS_PER_LOCALITY 4)
-set(suspend_thread_PARAMETERS THREADS_PER_LOCALITY 4)
-set(suspend_thread_external_PARAMETERS THREADS_PER_LOCALITY 4)
-set(suspend_thread_timed_PARAMETERS THREADS_PER_LOCALITY 4)
+
+if(CMAKE_SYSTEM_NAME MATCHES "Linux")
+  set(additional_parameters "--hpx:ini=hpx.stacks.use_guard_pages=0")
+endif()
+
+set(suspend_disabled_PARAMETERS THREADS_PER_LOCALITY 4 ${additional_parameters})
+set(suspend_pool_PARAMETERS THREADS_PER_LOCALITY 4 ${additional_parameters})
+set(suspend_pool_external_PARAMETERS THREADS_PER_LOCALITY 4
+                                     ${additional_parameters}
+)
+set(suspend_runtime_PARAMETERS THREADS_PER_LOCALITY 4 ${additional_parameters})
+set(suspend_thread_PARAMETERS THREADS_PER_LOCALITY 4 ${additional_parameters})
+set(suspend_thread_external_PARAMETERS THREADS_PER_LOCALITY 4
+                                       ${additional_parameters}
+)
+set(suspend_thread_timed_PARAMETERS THREADS_PER_LOCALITY 4
+                                    ${additional_parameters}
+)
 
 foreach(test ${tests})
   set(sources ${test}.cpp)

--- a/libs/core/resource_partitioner/tests/unit/scheduler_binding_check.cpp
+++ b/libs/core/resource_partitioner/tests/unit/scheduler_binding_check.cpp
@@ -61,14 +61,16 @@ void threadLoop()
         HPX_TEST_EQ(thread_actual, thread_expected);
     };
 
-    std::size_t threads = hpx::get_num_worker_threads();
     // launch tasks on threads using numbering 0,1,2,3...0,1,2,3
+    std::size_t threads = hpx::get_num_worker_threads();
     for (std::size_t i = 0; i < iterations; ++i)
     {
         auto exec = hpx::execution::parallel_executor(
             hpx::threads::thread_priority::bound,
             hpx::threads::thread_stacksize::default_,
-            hpx::threads::thread_schedule_hint(std::int16_t(i % threads)));
+            hpx::threads::thread_schedule_hint(
+                hpx::threads::thread_schedule_hint_mode::thread,
+                std::int16_t(i % threads)));
         hpx::async(exec, f, i, (i % threads)).get();
     }
 

--- a/libs/core/resource_partitioner/tests/unit/suspend_pool.cpp
+++ b/libs/core/resource_partitioner/tests/unit/suspend_pool.cpp
@@ -46,10 +46,15 @@ int hpx_main()
 
     hpx::threads::thread_pool_base& worker_pool =
         hpx::resource::get_thread_pool("worker");
-    hpx::execution::parallel_executor worker_exec(
+    hpx::execution::parallel_executor exec(
         &hpx::resource::get_thread_pool("worker"));
     std::size_t const worker_pool_threads =
         hpx::resource::get_num_threads("worker");
+
+    hpx::threads::thread_schedule_hint hint;
+    hint.runs_as_child_mode(hpx::threads::thread_execution_hint::none);
+
+    auto worker_exec = hpx::execution::experimental::with_hint(exec, hint);
 
     {
         // Suspend and resume pool with future

--- a/libs/core/resource_partitioner/tests/unit/suspend_pool.cpp
+++ b/libs/core/resource_partitioner/tests/unit/suspend_pool.cpp
@@ -19,15 +19,13 @@
 #include <hpx/semaphore.hpp>
 #include <hpx/thread.hpp>
 
-#include <atomic>
 #include <cstddef>
-#include <memory>
 #include <string>
 #include <utility>
 #include <vector>
 
-std::size_t const max_threads = (std::min)(
-    std::size_t(4), std::size_t(hpx::threads::hardware_concurrency()));
+std::size_t const max_threads = (std::min)(static_cast<std::size_t>(4),
+    static_cast<std::size_t>(hpx::threads::hardware_concurrency()));
 
 int hpx_main()
 {
@@ -55,7 +53,7 @@ int hpx_main()
 
     {
         // Suspend and resume pool with future
-        hpx::chrono::high_resolution_timer t;
+        hpx::chrono::high_resolution_timer const t;
 
         while (t.elapsed() < 1)
         {
@@ -78,7 +76,7 @@ int hpx_main()
     {
         // Suspend and resume pool with callback
         hpx::counting_semaphore_var<> sem;
-        hpx::chrono::high_resolution_timer t;
+        hpx::chrono::high_resolution_timer const t;
 
         while (t.elapsed() < 1)
         {
@@ -106,7 +104,7 @@ int hpx_main()
 
     {
         // Suspend pool with some threads already suspended
-        hpx::chrono::high_resolution_timer t;
+        hpx::chrono::high_resolution_timer const t;
 
         while (t.elapsed() < 1)
         {
@@ -144,7 +142,9 @@ void test_scheduler(
     init_args.cfg = {"hpx.os_threads=" + std::to_string(max_threads)};
     init_args.rp_callback = [scheduler](auto& rp,
                                 hpx::program_options::variables_map const&) {
-        rp.create_thread_pool("worker", scheduler);
+        rp.create_thread_pool("worker", scheduler,
+            hpx::threads::policies::scheduler_mode::default_ |
+                hpx::threads::policies::scheduler_mode::enable_elasticity);
 
         std::size_t const worker_pool_threads = max_threads - 1;
         HPX_ASSERT(worker_pool_threads >= 1);
@@ -173,7 +173,7 @@ int main(int argc, char* argv[])
 {
     HPX_ASSERT(max_threads >= 2);
 
-    std::vector<hpx::resource::scheduling_policy> schedulers = {
+    std::vector<hpx::resource::scheduling_policy> const schedulers = {
         hpx::resource::scheduling_policy::local,
         hpx::resource::scheduling_policy::local_priority_fifo,
 #if defined(HPX_HAVE_CXX11_STD_ATOMIC_128BIT)

--- a/libs/core/runtime_local/include/hpx/runtime_local/runtime_local.hpp
+++ b/libs/core/runtime_local/include/hpx/runtime_local/runtime_local.hpp
@@ -378,15 +378,9 @@ namespace hpx {
 
         virtual std::string get_locality_name() const;
 
-        virtual std::uint32_t assign_cores(std::string const&, std::uint32_t)
-        {
-            return std::uint32_t(-1);
-        }
+        virtual std::uint32_t assign_cores(std::string const&, std::uint32_t);
 
-        virtual std::uint32_t assign_cores()
-        {
-            return std::uint32_t(-1);
-        }
+        virtual std::uint32_t assign_cores();
 
         hpx::program_options::options_description const& get_app_options() const
         {

--- a/libs/core/runtime_local/src/runtime_local.cpp
+++ b/libs/core/runtime_local/src/runtime_local.cpp
@@ -651,6 +651,17 @@ namespace hpx {
         return "console";
     }
 
+    std::uint32_t runtime::assign_cores(std::string const&, std::uint32_t)
+    {
+        return 0;
+    }
+
+    std::uint32_t runtime::assign_cores()
+    {
+        return static_cast<std::uint32_t>(
+            hpx::resource::get_partitioner().assign_cores(0));
+    }
+
     ///////////////////////////////////////////////////////////////////////////
     threads::policies::callback_notifier::on_startstop_type
     get_thread_on_start_func()

--- a/libs/core/schedulers/include/hpx/schedulers/local_priority_queue_scheduler.hpp
+++ b/libs/core/schedulers/include/hpx/schedulers/local_priority_queue_scheduler.hpp
@@ -1632,7 +1632,7 @@ namespace hpx::threads::policies {
             queues_[num_thread].data_->on_error(num_thread, e);
         }
 
-        void reset_thread_distribution() override
+        void reset_thread_distribution() noexcept override
         {
             curr_queue_.store(0, std::memory_order_release);
         }

--- a/libs/core/schedulers/include/hpx/schedulers/queue_holder_thread.hpp
+++ b/libs/core/schedulers/include/hpx/schedulers/queue_holder_thread.hpp
@@ -392,7 +392,9 @@ namespace hpx::threads::policies {
         void create_thread(thread_init_data& data, thread_id_ref_type* tid,
             std::size_t thread_num, error_code& ec)
         {
-            if (thread_num != thread_num_)
+            if (thread_num != thread_num_ &&
+                (data.initial_state == thread_schedule_state::pending ||
+                    data.initial_state == thread_schedule_state::pending_boost))
             {
                 data.run_now = false;
             }

--- a/libs/core/schedulers/include/hpx/schedulers/thread_queue.hpp
+++ b/libs/core/schedulers/include/hpx/schedulers/thread_queue.hpp
@@ -1176,9 +1176,6 @@ namespace hpx::threads::policies {
                         parameters_.small_stacksize_, thread_id_addref::no);
                 HPX_ASSERT(p);
 
-                // We initialize the stack eagerly
-                p->init();
-
                 // Finally, store the thread for later use
                 thread_heap_small_.emplace_back(p);
             }

--- a/libs/core/schedulers/include/hpx/schedulers/thread_queue.hpp
+++ b/libs/core/schedulers/include/hpx/schedulers/thread_queue.hpp
@@ -398,8 +398,12 @@ namespace hpx::threads::policies {
                     thread_id_type tid(todelete);
                     --terminated_items_count_;
 
-                    // this thread has to be in this map
-                    HPX_ASSERT(thread_map_.find(tid) != thread_map_.end());
+                    // this thread has to be managed by this queue, it may have
+                    // ended up on the terminate threads list more than once,
+                    // however
+                    HPX_ASSERT(
+                        &get_thread_id_data(tid)->get_queue<thread_queue>() ==
+                        this);
 
                     if (thread_map_.erase(tid) != 0)
                     {
@@ -426,9 +430,12 @@ namespace hpx::threads::policies {
                     thread_id_type tid(todelete);
                     --terminated_items_count_;
 
-                    // this thread has to be in this map, except if it has changed
-                    // its priority, then it could be elsewhere
-                    HPX_ASSERT(thread_map_.find(tid) != thread_map_.end());
+                    // this thread has to be managed by this queue, it may have
+                    // ended up on the terminate threads list more than once,
+                    // however
+                    HPX_ASSERT(
+                        &get_thread_id_data(tid)->get_queue<thread_queue>() ==
+                        this);
 
                     if (thread_map_.erase(tid) != 0)
                     {
@@ -888,6 +895,7 @@ namespace hpx::threads::policies {
             threads::thread_id_ref_type thrd, bool other_end = false)
         {
             ++work_items_count_.data_;
+
 #ifdef HPX_HAVE_THREAD_QUEUE_WAITTIME
             work_items_.push(new thread_description{HPX_MOVE(thrd),
                                  hpx::chrono::high_resolution_clock::now()},

--- a/libs/core/synchronization/include/hpx/synchronization/counting_semaphore.hpp
+++ b/libs/core/synchronization/include/hpx/synchronization/counting_semaphore.hpp
@@ -10,7 +10,7 @@
 #pragma once
 
 #include <hpx/config.hpp>
-#include <hpx/memory/intrusive_ptr.hpp>
+#include <hpx/modules/memory.hpp>
 #include <hpx/synchronization/detail/counting_semaphore.hpp>
 #include <hpx/synchronization/spinlock.hpp>
 #include <hpx/timing/steady_clock.hpp>

--- a/libs/core/synchronization/include/hpx/synchronization/sliding_semaphore.hpp
+++ b/libs/core/synchronization/include/hpx/synchronization/sliding_semaphore.hpp
@@ -7,7 +7,7 @@
 #pragma once
 
 #include <hpx/config.hpp>
-#include <hpx/memory/intrusive_ptr.hpp>
+#include <hpx/modules/memory.hpp>
 #include <hpx/synchronization/detail/sliding_semaphore.hpp>
 #include <hpx/synchronization/spinlock.hpp>
 

--- a/libs/core/thread_pools/CMakeLists.txt
+++ b/libs/core/thread_pools/CMakeLists.txt
@@ -43,5 +43,6 @@ add_hpx_module(
     hpx_itt_notify
     hpx_logging
     hpx_schedulers
+    hpx_threading_base
   CMAKE_SUBDIRS examples tests
 )

--- a/libs/core/thread_pools/include/hpx/thread_pools/scheduled_thread_pool.hpp
+++ b/libs/core/thread_pools/include/hpx/thread_pools/scheduled_thread_pool.hpp
@@ -123,7 +123,7 @@ namespace hpx::threads::detail {
             return sched_->Scheduler::enumerate_threads(f, state);
         }
 
-        void reset_thread_distribution() override
+        void reset_thread_distribution() noexcept override
         {
             return sched_->Scheduler::reset_thread_distribution();
         }

--- a/libs/core/threading_base/CMakeLists.txt
+++ b/libs/core/threading_base/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2019 The STE||AR-Group
+# Copyright (c) 2019-2023 The STE||AR-Group
 #
 # SPDX-License-Identifier: BSL-1.0
 # Distributed under the Boost Software License, Version 1.0. (See accompanying

--- a/libs/core/threading_base/include/hpx/threading_base/register_thread.hpp
+++ b/libs/core/threading_base/include/hpx/threading_base/register_thread.hpp
@@ -97,6 +97,7 @@ namespace hpx::threads {
     ///
     /// \param data       [in] The data to use for creating the thread.
     /// \param pool       [in] The thread pool to use for launching the work.
+    /// \param id         [out] The id of the newly created thread (if applicable)
     /// \param ec         [in,out] This represents the error status on exit,
     ///                   if this is pre-initialized to \a hpx#throws the
     ///                   function will throw on error instead.
@@ -111,14 +112,21 @@ namespace hpx::threads {
     ///                   throw but returns the result code using the parameter
     ///                   \a ec. Otherwise it throws an instance
     ///                   of hpx#exception.
-    inline threads::thread_id_ref_type register_thread(
-        threads::thread_init_data& data, threads::thread_pool_base* pool,
+    inline void register_thread(threads::thread_init_data& data,
+        threads::thread_pool_base* pool, threads::thread_id_ref_type& id,
         error_code& ec = throws)
     {
         HPX_ASSERT(pool);
         data.run_now = true;
-        threads::thread_id_ref_type id = threads::invalid_thread_id;
         pool->create_thread(data, id, ec);
+    }
+
+    inline threads::thread_id_ref_type register_thread(
+        threads::thread_init_data& data, threads::thread_pool_base* pool,
+        error_code& ec = throws)
+    {
+        threads::thread_id_ref_type id = threads::invalid_thread_id;
+        register_thread(data, pool, id, ec);
         return id;
     }
 
@@ -128,6 +136,7 @@ namespace hpx::threads {
     ///        on an HPX thread.
     ///
     /// \param data       [in] The data to use for creating the thread.
+    /// \param id         [out] The id of the newly created thread (if applicable)
     /// \param ec         [in,out] This represents the error status on exit,
     ///                   if this is pre-initialized to \a hpx#throws the
     ///                   function will throw on error instead.
@@ -141,6 +150,12 @@ namespace hpx::threads {
     ///                   \a hpx#throws this function doesn't throw but returns
     ///                   the result code using the parameter \a ec. Otherwise
     ///                   it throws an instance of hpx#exception.
+    inline void register_thread(threads::thread_init_data& data,
+        threads::thread_id_ref_type& id, error_code& ec = throws)
+    {
+        register_thread(data, detail::get_self_or_default_pool(), id, ec);
+    }
+
     inline threads::thread_id_ref_type register_thread(
         threads::thread_init_data& data, error_code& ec = throws)
     {

--- a/libs/core/threading_base/include/hpx/threading_base/scheduler_base.hpp
+++ b/libs/core/threading_base/include/hpx/threading_base/scheduler_base.hpp
@@ -239,7 +239,7 @@ namespace hpx::threads::policies {
             std::size_t num_thread = std::size_t(-1)) const = 0;
 #endif
 
-        virtual void reset_thread_distribution() {}
+        virtual void reset_thread_distribution() noexcept {}
 
         std::ptrdiff_t get_stack_size(
             threads::thread_stacksize stacksize) const noexcept;
@@ -269,6 +269,12 @@ namespace hpx::threads::policies {
 
         detail::polling_status custom_polling_function() const;
         std::size_t get_polling_work_count() const;
+
+        // almost all schedulers support direct execution
+        virtual bool supports_direct_execution() const noexcept
+        {
+            return true;
+        }
 
     protected:
         // the scheduler mode, protected from false sharing

--- a/libs/core/threading_base/include/hpx/threading_base/thread_data.hpp
+++ b/libs/core/threading_base/include/hpx/threading_base/thread_data.hpp
@@ -9,6 +9,8 @@
 #pragma once
 
 #include <hpx/config.hpp>
+#include <hpx/assert.hpp>
+
 #include <hpx/concurrency/spinlock_pool.hpp>
 #include <hpx/coroutines/coroutine.hpp>
 #include <hpx/coroutines/detail/combined_tagged_state.hpp>
@@ -18,7 +20,6 @@
 #include <hpx/functional/function.hpp>
 #include <hpx/modules/errors.hpp>
 #include <hpx/modules/logging.hpp>
-#include <hpx/modules/memory.hpp>
 #include <hpx/threading_base/thread_description.hpp>
 #include <hpx/threading_base/thread_init_data.hpp>
 #if defined(HPX_HAVE_APEX)
@@ -31,9 +32,11 @@
 #include <forward_list>
 #include <memory>
 #include <mutex>
-#include <stack>
-#include <string>
 #include <utility>
+
+#if defined(HPX_HAVE_THREAD_BACKTRACE_ON_SUSPENSION)
+#include <string>
+#endif
 
 #include <hpx/config/warnings_prefix.hpp>
 

--- a/libs/core/threading_base/include/hpx/threading_base/thread_data.hpp
+++ b/libs/core/threading_base/include/hpx/threading_base/thread_data.hpp
@@ -107,7 +107,7 @@ namespace hpx::threads {
         ///
         /// \note           This function will be seldom used directly. Most of
         ///                 the time the state of a thread will have to be
-        ///                 changed using the threadmanager. Moreover,
+        ///                 changed using the thread-manager. Moreover,
         ///                 changing the thread state using this function does
         ///                 not change its scheduling status. It only sets the
         ///                 thread's status word. To change the thread's
@@ -361,7 +361,7 @@ namespace hpx::threads {
         {
             return nullptr;
         }
-        static char const* set_backtrace(char const*) noexcept
+        static constexpr char const* set_backtrace(char const*) noexcept
         {
             return nullptr;
         }
@@ -370,7 +370,7 @@ namespace hpx::threads {
         {
             return nullptr;
         }
-        static util::backtrace const* set_backtrace(
+        static constexpr util::backtrace const* set_backtrace(
             util::backtrace const*) noexcept
         {
             return nullptr;
@@ -485,6 +485,14 @@ namespace hpx::threads {
         void run_thread_exit_callbacks();
         void free_thread_exit_callbacks();
 
+        // no need to protect the variables related to scoped children as those
+        // are supposed to be accessed by ourselves only
+        bool runs_as_child(
+            std::memory_order mo = std::memory_order_acquire) const noexcept
+        {
+            return runs_as_child_.load(mo);
+        }
+
         HPX_FORCEINLINE constexpr bool is_stackless() const noexcept
         {
             return is_stackless_;
@@ -533,6 +541,14 @@ namespace hpx::threads {
         inline coroutine_type::result_type operator()(
             hpx::execution_base::this_thread::detail::agent_storage*
                 agent_storage);
+
+        /// \brief Directly execute the thread function (inline)
+        ///
+        /// \returns        This function returns the thread state the thread
+        ///                 should be scheduled from this point on. The thread
+        ///                 manager will use the returned value to set the
+        ///                 thread's scheduling status.
+        inline coroutine_type::result_type invoke_directly();
 
         virtual thread_id_type get_thread_id() const
         {
@@ -623,6 +639,9 @@ namespace hpx::threads {
         bool ran_exit_funcs_;
         bool const is_stackless_;
 
+        // support scoped child execution
+        std::atomic<bool> runs_as_child_;
+
         // Singly linked list (heap-allocated)
         std::forward_list<hpx::function<void()>> exit_funcs_;
 
@@ -641,13 +660,13 @@ namespace hpx::threads {
 #endif
     };
 
-    HPX_FORCEINLINE thread_data* get_thread_id_data(
+    HPX_FORCEINLINE constexpr thread_data* get_thread_id_data(
         thread_id_ref_type const& tid) noexcept
     {
         return static_cast<thread_data*>(tid.get().get());
     }
 
-    HPX_FORCEINLINE thread_data* get_thread_id_data(
+    HPX_FORCEINLINE constexpr thread_data* get_thread_id_data(
         thread_id_type const& tid) noexcept
     {
         return static_cast<thread_data*>(tid.get());
@@ -678,6 +697,13 @@ namespace hpx::threads {
     /// The function \a get_self_id returns the HPX thread id of the current
     /// thread (or zero if the current thread is not a HPX thread).
     HPX_CORE_EXPORT thread_id_type get_self_id() noexcept;
+
+    /// The function \a get_outer_self_id returns the HPX thread id of
+    /// the current outer thread (or zero if the current thread is not a HPX
+    /// thread). This usually returns the same as \a get_self_id, except for
+    /// directly executed threads, in which case this returns the thread id
+    /// of the outermost HPX thread.
+    HPX_CORE_EXPORT thread_id_type get_outer_self_id() noexcept;
 
     /// The function \a get_parent_id returns the HPX thread id of the
     /// current thread's parent (or zero if the current thread is not a
@@ -733,10 +759,24 @@ namespace hpx::threads {
     HPX_FORCEINLINE coroutine_type::result_type thread_data::operator()(
         hpx::execution_base::this_thread::detail::agent_storage* agent_storage)
     {
+        // once a thread has started it can't be run directly anymore
+        runs_as_child_.store(false, std::memory_order_release);
+
         if (is_stackless())
         {
             return static_cast<thread_data_stackless*>(this)->call();
         }
         return static_cast<thread_data_stackful*>(this)->call(agent_storage);
+    }
+
+    HPX_FORCEINLINE coroutine_type::result_type thread_data::invoke_directly()
+    {
+        HPX_ASSERT(runs_as_child());
+
+        if (is_stackless())
+        {
+            return static_cast<thread_data_stackless*>(this)->call();
+        }
+        return static_cast<thread_data_stackful*>(this)->invoke_directly();
     }
 }    // namespace hpx::threads

--- a/libs/core/threading_base/include/hpx/threading_base/thread_data.hpp
+++ b/libs/core/threading_base/include/hpx/threading_base/thread_data.hpp
@@ -774,7 +774,7 @@ namespace hpx::threads {
 
     HPX_FORCEINLINE coroutine_type::result_type thread_data::invoke_directly()
     {
-        HPX_ASSERT(runs_as_child());
+        HPX_ASSERT(runs_as_child(std::memory_order_relaxed));
 
         if (is_stackless())
         {

--- a/libs/core/threading_base/include/hpx/threading_base/thread_data_stackful.hpp
+++ b/libs/core/threading_base/include/hpx/threading_base/thread_data_stackful.hpp
@@ -77,7 +77,7 @@ namespace hpx::threads {
                 set_state_ex(thread_restart_state::signaled));
 
             if (result.first == thread_schedule_state::terminated &&
-                runs_as_child())
+                runs_as_child(std::memory_order_relaxed))
             {
                 result.first = thread_schedule_state::deleted;
             }

--- a/libs/core/threading_base/include/hpx/threading_base/thread_data_stackful.hpp
+++ b/libs/core/threading_base/include/hpx/threading_base/thread_data_stackful.hpp
@@ -68,6 +68,23 @@ namespace hpx::threads {
             return coroutine_(set_state_ex(thread_restart_state::signaled));
         }
 
+        HPX_FORCEINLINE coroutine_type::result_type invoke_directly()
+        {
+            HPX_ASSERT(get_state().state() == thread_schedule_state::active);
+            HPX_ASSERT(this == coroutine_.get_thread_id().get());
+
+            coroutine_type::result_type result = coroutine_.invoke_directly(
+                set_state_ex(thread_restart_state::signaled));
+
+            if (result.first == thread_schedule_state::terminated &&
+                runs_as_child())
+            {
+                result.first = thread_schedule_state::deleted;
+            }
+
+            return result;
+        }
+
 #if defined(HPX_DEBUG)
         thread_id_type get_thread_id() const override
         {

--- a/libs/core/threading_base/include/hpx/threading_base/thread_pool_base.hpp
+++ b/libs/core/threading_base/include/hpx/threading_base/thread_pool_base.hpp
@@ -467,7 +467,7 @@ namespace hpx::threads {
             return false;
         }
 
-        virtual void reset_thread_distribution() {}
+        virtual void reset_thread_distribution() noexcept {}
 
         virtual void abort_all_suspended_threads() {}
         virtual bool cleanup_terminated(bool /*delete_all*/)

--- a/libs/core/threading_base/src/create_work.cpp
+++ b/libs/core/threading_base/src/create_work.cpp
@@ -5,6 +5,7 @@
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <hpx/config.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/modules/coroutines.hpp>
 #include <hpx/modules/errors.hpp>
 #include <hpx/modules/logging.hpp>
@@ -91,8 +92,11 @@ namespace hpx::threads::detail {
 
         // create the new thread
         if (data.priority == thread_priority::default_)
+        {
             data.priority = thread_priority::normal;
+        }
 
+        HPX_ASSERT(!data.run_now);
         data.run_now = (thread_priority::high == data.priority ||
             thread_priority::high_recursive == data.priority ||
             thread_priority::bound == data.priority ||

--- a/libs/core/threading_base/src/execution_agent.cpp
+++ b/libs/core/threading_base/src/execution_agent.cpp
@@ -66,10 +66,12 @@ namespace hpx::threads {
         if (k < 4)    //-V112
         {
         }
+#if defined(HPX_SMT_PAUSE)
         else if (k < 16)
         {
             HPX_SMT_PAUSE;
         }
+#endif
         else if (k < 32 || k & 1)    //-V112
         {
             do_yield(desc, hpx::threads::thread_schedule_state::pending_boost);

--- a/libs/core/threading_base/src/set_thread_state.cpp
+++ b/libs/core/threading_base/src/set_thread_state.cpp
@@ -158,7 +158,8 @@ namespace hpx::threads::detail {
 
                 return previous_state;    // done
             }
-
+            case thread_schedule_state::deleted:
+                [[fallthrough]];
             case thread_schedule_state::terminated:
             {
                 LTM_(warning).format(

--- a/libs/core/threading_base/src/set_thread_state_timed.cpp
+++ b/libs/core/threading_base/src/set_thread_state_timed.cpp
@@ -83,7 +83,7 @@ namespace hpx::threads::detail {
         // create a new thread in suspended state, which will execute the
         // requested set_state when timer fires and will re-awaken this thread,
         // allowing the deadline_timer to go out of scope gracefully
-        thread_id_ref_type const self_id = get_self_id();    // keep alive
+        thread_id_ref_type const self_id = get_outer_self_id();    // keep alive
 
         std::shared_ptr<std::atomic<bool>> triggered(
             std::make_shared<std::atomic<bool>>(false));

--- a/libs/core/threading_base/src/thread_data.cpp
+++ b/libs/core/threading_base/src/thread_data.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2021 Hartmut Kaiser
+//  Copyright (c) 2007-2023 Hartmut Kaiser
 //  Copyright (c) 2008-2009 Chirag Dekate, Anshul Tandon
 //  Copyright (c) 2011      Bryce Lelbach
 //
@@ -72,6 +72,8 @@ namespace hpx::threads {
       , enabled_interrupt_(true)
       , ran_exit_funcs_(false)
       , is_stackless_(is_stackless)
+      , runs_as_child_(init_data.schedulehint.runs_as_child_mode() ==
+            hpx::threads::thread_execution_hint::run_as_child)
       , scheduler_base_(init_data.scheduler_base)
       , last_worker_thread_num_(static_cast<std::size_t>(-1))
       , stacksize_(stacksize)
@@ -88,8 +90,7 @@ namespace hpx::threads {
         // purposes
         if (parent_thread_id_ == nullptr)
         {
-            thread_self* self = get_self_ptr();
-            if (self)
+            if (thread_self const* self = get_self_ptr())
             {
                 parent_thread_id_ = threads::get_self_id();
                 parent_thread_phase_ = self->get_thread_phase();
@@ -142,7 +143,8 @@ namespace hpx::threads {
             spinlock_pool::spinlock_for(this));
 
         if (ran_exit_funcs_ ||
-            get_state().state() == thread_schedule_state::terminated)
+            get_state().state() == thread_schedule_state::terminated ||
+            get_state().state() == thread_schedule_state::deleted)
         {
             return false;
         }
@@ -218,6 +220,11 @@ namespace hpx::threads {
         requested_interrupt_ = false;
         enabled_interrupt_ = true;
         ran_exit_funcs_ = false;
+
+        runs_as_child_.store(init_data.schedulehint.runs_as_child_mode() ==
+                hpx::threads::thread_execution_hint::run_as_child,
+            std::memory_order_relaxed);
+
         exit_funcs_.clear();
         scheduler_base_ = init_data.scheduler_base;
         last_worker_thread_num_ = static_cast<std::size_t>(-1);
@@ -310,6 +317,16 @@ namespace hpx::threads {
             HPX_LIKELY(nullptr != self))
         {
             return self->get_thread_id();
+        }
+        return threads::invalid_thread_id;
+    }
+
+    thread_id_type get_outer_self_id() noexcept
+    {
+        if (thread_self const* self = get_self_ptr();
+            HPX_LIKELY(nullptr != self))
+        {
+            return self->get_outer_thread_id();
         }
         return threads::invalid_thread_id;
     }
@@ -408,8 +425,8 @@ namespace hpx::threads {
     std::shared_ptr<hpx::util::external_timer::task_wrapper>
     get_self_timer_data()
     {
-        thread_data* thrd_data = get_self_id_data();
-        if (HPX_LIKELY(nullptr != thrd_data))
+        if (thread_data* thrd_data = get_self_id_data();
+            HPX_LIKELY(nullptr != thrd_data))
         {
             return thrd_data->get_timer_data();
         }
@@ -419,8 +436,8 @@ namespace hpx::threads {
     void set_self_timer_data(
         std::shared_ptr<hpx::util::external_timer::task_wrapper> data)
     {
-        thread_data* thrd_data = get_self_id_data();
-        if (HPX_LIKELY(nullptr != thrd_data))
+        if (thread_data* thrd_data = get_self_id_data();
+            HPX_LIKELY(nullptr != thrd_data))
         {
             thrd_data->set_timer_data(data);
         }

--- a/libs/core/threading_base/src/thread_helpers.cpp
+++ b/libs/core/threading_base/src/thread_helpers.cpp
@@ -438,7 +438,7 @@ namespace hpx::this_thread {
         threads::thread_self& self = threads::get_self();
 
         // keep alive
-        threads::thread_id_ref_type id = self.get_thread_id();
+        threads::thread_id_ref_type id = self.get_outer_thread_id();
 
         // handle interruption, if needed
         threads::interruption_point(id.noref(), ec);
@@ -509,7 +509,7 @@ namespace hpx::this_thread {
         threads::thread_self& self = threads::get_self();
 
         // keep alive
-        threads::thread_id_ref_type id = self.get_thread_id();
+        threads::thread_id_ref_type id = self.get_outer_thread_id();
 
         // handle interruption, if needed
         threads::interruption_point(id.noref(), ec);

--- a/libs/core/threadmanager/include/hpx/modules/threadmanager.hpp
+++ b/libs/core/threadmanager/include/hpx/modules/threadmanager.hpp
@@ -297,7 +297,7 @@ namespace hpx { namespace threads {
             }
         }
 
-        void reset_thread_distribution()
+        void reset_thread_distribution() noexcept
         {
             for (auto& pool_iter : pools_)
             {

--- a/libs/full/runtime_distributed/src/runtime_distributed.cpp
+++ b/libs/full/runtime_distributed/src/runtime_distributed.cpp
@@ -1623,6 +1623,7 @@ namespace hpx {
 
         std::uint32_t current = (*it).second;
         (*it).second += cores_needed;
+
         return current;
     }
 
@@ -1749,6 +1750,14 @@ namespace hpx {
         components::component_type type, error_code& ec)
     {
         std::vector<hpx::id_type> locality_ids;
+        if (nullptr == hpx::applier::get_applier_ptr())
+        {
+            HPX_THROWS_IF(ec, hpx::error::invalid_status,
+                "hpx::find_all_localities",
+                "the runtime system is not available at this time");
+            return locality_ids;
+        }
+
         hpx::applier::get_applier().get_localities(locality_ids, type, ec);
         return locality_ids;
     }
@@ -1756,6 +1765,14 @@ namespace hpx {
     std::vector<hpx::id_type> find_all_localities(error_code& ec)
     {
         std::vector<hpx::id_type> locality_ids;
+        if (nullptr == hpx::applier::get_applier_ptr())
+        {
+            HPX_THROWS_IF(ec, hpx::error::invalid_status,
+                "hpx::find_all_localities",
+                "the runtime system is not available at this time");
+            return locality_ids;
+        }
+
         hpx::applier::get_applier().get_localities(locality_ids, ec);
         return locality_ids;
     }
@@ -1764,6 +1781,14 @@ namespace hpx {
         components::component_type type, error_code& ec)
     {
         std::vector<hpx::id_type> locality_ids;
+        if (nullptr == hpx::applier::get_applier_ptr())
+        {
+            HPX_THROWS_IF(ec, hpx::error::invalid_status,
+                "hpx::find_remote_localities",
+                "the runtime system is not available at this time");
+            return locality_ids;
+        }
+
         hpx::applier::get_applier().get_remote_localities(
             locality_ids, type, ec);
         return locality_ids;
@@ -1772,14 +1797,30 @@ namespace hpx {
     std::vector<hpx::id_type> find_remote_localities(error_code& ec)
     {
         std::vector<hpx::id_type> locality_ids;
+        if (nullptr == hpx::applier::get_applier_ptr())
+        {
+            HPX_THROWS_IF(ec, hpx::error::invalid_status,
+                "hpx::find_remote_localities",
+                "the runtime system is not available at this time");
+            return locality_ids;
+        }
+
         hpx::applier::get_applier().get_remote_localities(
             locality_ids, components::component_invalid, ec);
+
         return locality_ids;
     }
 
     // find a locality supporting the given component
     hpx::id_type find_locality(components::component_type type, error_code& ec)
     {
+        if (nullptr == hpx::applier::get_applier_ptr())
+        {
+            HPX_THROWS_IF(ec, hpx::error::invalid_status, "hpx::find_locality",
+                "the runtime system is not available at this time");
+            return hpx::invalid_id;
+        }
+
         std::vector<hpx::id_type> locality_ids;
         hpx::applier::get_applier().get_localities(locality_ids, type, ec);
 


### PR DESCRIPTION
- adding new API function hpx::threads::get_outer_self_id
