### PR TITLE
Document `task_group` and include in Public API

### DIFF
--- a/cmake/templates/conf.py.in
+++ b/cmake/templates/conf.py.in
@@ -552,6 +552,9 @@ rst_prolog += '''
 .. _upc: https://upc.lbl.gov/
 .. |fortress| replace:: Fortress
 .. _fortress: https://labs.oracle.com/projects/plrg/Publications/index.html
+.. |oneTBB| replace:: oneAPI Threading Building Blocks (oneTBB)
+.. _oneTBB: https://spec.oneapi.io/versions/1.0-rev-3/elements/oneTBB/source/task_scheduler/task_group/task_group_cls.html
+
 
 .. |email_hkaiser| image:: /_static/images/emails/hkaiser.png
 .. |email_theller| image:: /_static/images/emails/theller.png

--- a/docs/sphinx/api/public_api.rst
+++ b/docs/sphinx/api/public_api.rst
@@ -895,7 +895,7 @@ blocks.
 Classes
 -------
 
-.. table:: Classes of header ``hpx/task_black.hpp``
+.. table:: Classes of header ``hpx/task_block.hpp``
 
    +---------------------------------------------------------+
    | Class                                                   |
@@ -908,7 +908,7 @@ Classes
 Functions
 ---------
 
-.. table:: Functions of header ``hpx/task_black.hpp``
+.. table:: Functions of header ``hpx/task_block.hpp``
 
    +-----------------------------------------------------------------+
    | Function                                                        |
@@ -917,6 +917,25 @@ Functions
    +-----------------------------------------------------------------+
    | :cpp:func:`hpx::parallel::v2::define_task_block_restore_thread` |
    +-----------------------------------------------------------------+
+
+.. _public_api_header_hpx_task_group:
+
+``hpx/task_group.hpp``
+======================
+
+The header :hpx-header:`libs/full/include/include,hpx/task_group.hpp` corresponds to the
+``task_group`` feature in |oneTBB|_.
+
+Classes
+-------
+
+.. table:: Classes of header ``hpx/task_group.hpp``
+
+   +---------------------------------------------------------+
+   | Class                                                   |
+   +=========================================================+
+   | :cpp:class:`hpx::execution::experimental::task_group`   |
+   +---------------------------------------------------------+
 
 .. _public_api_header_hpx_thread:
 

--- a/libs/core/algorithms/include/hpx/parallel/task_group.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/task_group.hpp
@@ -30,9 +30,12 @@
 #include <type_traits>
 #include <utility>
 
+/// Top-level namespace
 namespace hpx { namespace execution { namespace experimental {
 
-    ///////////////////////////////////////////////////////////////////////////
+    /// \brief A \c task_group represents concurrent execution of a
+    ///        group of tasks. Tasks can be dynamically added to the
+    //         group while it is executing.
     class task_group
     {
     public:
@@ -55,12 +58,23 @@ namespace hpx { namespace execution { namespace experimental {
         };
 
     public:
-        // Spawns a task to compute f() and returns immediately.
-        // clang-format off
+        /// \brief Adds a task to compute \c f() and returns immediately.
+        ///
+        /// \tparam Executor  The type of the executor to associate with this
+        ///                   execution policy.
+        /// \tparam F         The type of the user defined function to invoke.
+        /// \tparam Ts        The type of additional arguments used to invoke \c f().
+        ///
+        /// \param exec       The executor to use for the execution of the
+        ///                   parallel algorithm the returned execution
+        ///                   policy is used with.
+        /// \param f          The user defined function to invoke inside the task
+        ///                   group.
+        /// \param ts         Additional arguments to use to invoke \c f().
+        /// clang-format off
         template <typename Executor, typename F, typename... Ts,
             HPX_CONCEPT_REQUIRES_(
-                hpx::traits::is_executor_any_v<std::decay_t<Executor>>
-            )>
+                hpx::traits::is_executor_any_v<std::decay_t<Executor>>)>
         // clang-format on
         void run(Executor&& exec, F&& f, Ts&&... ts)
         {
@@ -91,6 +105,14 @@ namespace hpx { namespace execution { namespace experimental {
                 });
         }
 
+        /// \brief Adds a task to compute \c f() and returns immediately.
+        ///
+        /// \tparam F  The type of the user defined function to invoke.
+        /// \tparam Ts The type of additional arguments used to invoke \c f().
+        ///
+        /// \param f   The user defined function to invoke inside the task
+        ///            group.
+        /// \param ts  Additional arguments to use to invoke \c f().
         // clang-format off
         template <typename F, typename... Ts,
             HPX_CONCEPT_REQUIRES_(
@@ -103,10 +125,10 @@ namespace hpx { namespace execution { namespace experimental {
                 HPX_FORWARD(Ts, ts)...);
         }
 
-        // Waits for all tasks in the group to complete.
+        /// \brief Waits for all tasks in the group to complete or be cancelled.
         HPX_CORE_EXPORT void wait();
 
-        // Add an exception to this task_group
+        /// \brief Adds an exception to this \c task_group
         HPX_CORE_EXPORT void add_exception(std::exception_ptr p);
 
     private:


### PR DESCRIPTION
- Add header file `task_group.hpp` to the Public API page
- Add documentation for `task_group`