### PR TITLE
Adding parameters API: measure_iteration

### DIFF
--- a/docs/sphinx/api/public_api.rst
+++ b/docs/sphinx/api/public_api.rst
@@ -406,20 +406,21 @@ Classes
 
 .. table:: Classes of header ``hpx/execution.hpp``
 
-   ========================================================  ========================================================
-   Class                                                     C++ standard
-   ========================================================  ========================================================
-   :cpp:class:`hpx::execution::sequenced_policy`             :cppreference-generic:`algorithm,execution_policy_tag_t`
-   :cpp:class:`hpx::execution::parallel_policy`              :cppreference-generic:`algorithm,execution_policy_tag_t`
-   :cpp:class:`hpx::execution::parallel_unsequenced_policy`  :cppreference-generic:`algorithm,execution_policy_tag_t`
+   =====================================================================  ========================================================
+   Class                                                                  C++ standard
+   =====================================================================  ========================================================
+   :cpp:class:`hpx::execution::sequenced_policy`                          :cppreference-generic:`algorithm,execution_policy_tag_t`
+   :cpp:class:`hpx::execution::parallel_policy`                           :cppreference-generic:`algorithm,execution_policy_tag_t`
+   :cpp:class:`hpx::execution::parallel_unsequenced_policy`               :cppreference-generic:`algorithm,execution_policy_tag_t`
    :cpp:class:`hpx::execution::sequenced_task_policy`
    :cpp:class:`hpx::execution::parallel_task_policy`
-   :cpp:class:`hpx::execution::auto_chunk_size`
-   :cpp:class:`hpx::execution::dynamic_chunk_size`
-   :cpp:class:`hpx::execution::guided_chunk_size`
-   :cpp:class:`hpx::execution::persistent_auto_chunk_size`
-   :cpp:class:`hpx::execution::static_chunk_size`
-   ========================================================  ========================================================
+   :cpp:class:`hpx::execution::experimental::auto_chunk_size`
+   :cpp:class:`hpx::execution::experimental::dynamic_chunk_size`
+   :cpp:class:`hpx::execution::experimental::guided_chunk_size`
+   :cpp:class:`hpx::execution::experimental::persistent_auto_chunk_size`
+   :cpp:class:`hpx::execution::experimental::static_chunk_size`
+   :cpp:class:`hpx::execution::experimental::num_cores`
+   =====================================================================  ========================================================
 
 .. _public_api_header_hpx_functional:
 

--- a/docs/sphinx/manual/writing_single_node_hpx_applications.rst
+++ b/docs/sphinx/manual/writing_single_node_hpx_applications.rst
@@ -809,11 +809,11 @@ exposed and accessible through a corresponding customization point, e.g.
 ``get_chunk_size()``.
 
 With ``executor_parameter_traits``, clients access all types of executor
-parameters uniformly::
+parameters uniformly, e.g.::
 
     std::size_t chunk_size =
-        hpx::execution::get_chunk_size(my_parameter,
-            my_executor, [](auto){ return 0; }, num_cores, num_tasks);
+        hpx::execution::get_chunk_size(my_parameter, my_executor,
+            num_cores, num_tasks);
 
 This call synchronously retrieves the size of a single chunk of loop iterations
 (or similar) to combine for execution on a single |hpx| thread if the overall

--- a/docs/sphinx/manual/writing_single_node_hpx_applications.rst
+++ b/docs/sphinx/manual/writing_single_node_hpx_applications.rst
@@ -826,9 +826,10 @@ for an example of this executor parameter type.
 
 Other functions in the interface exist to discover whether an executor parameter
 type should be invoked once (i.e., it returns a static chunk size; see
-:cpp:class:`hpx::execution::static_chunk_size`) or whether it should be invoked
+:cpp:class:`hpx::execution::experimental::static_chunk_size`) or whether it
+should be invoked
 for each scheduled chunk of work (i.e., it returns a variable chunk size; for an
-example, see :cpp:class:`hpx::execution::guided_chunk_size`).
+example, see :cpp:class:`hpx::execution::experimental::guided_chunk_size`).
 
 Although this interface appears to require executor parameter type authors to
 implement all different basic operations, none are required. In
@@ -837,23 +838,27 @@ parameter types will naturally specialize all operations for maximum efficiency.
 
 |hpx|  implements the following executor parameter types:
 
-* :cpp:class:`hpx::execution::auto_chunk_size`: Loop iterations are divided into
-  pieces and then assigned to threads. The number of loop iterations combined is
+* :cpp:class:`hpx::execution::experimental::auto_chunk_size`: Loop iterations
+  are divided into pieces and then assigned to threads. The number of loop
+  iterations combined is
   determined based on measurements of how long the execution of 1% of the
   overall number of iterations takes. This executor parameter type makes sure
   that as many loop iterations are combined as necessary to run for the amount
   of time specified.
-* :cpp:class:`hpx::execution::static_chunk_size`: Loop iterations are divided
+* :cpp:class:`hpx::execution::experimental::static_chunk_size`: Loop iterations
+  are divided
   into pieces of a given size and then assigned to threads. If the size is not
   specified, the iterations are, if possible, evenly divided contiguously among
   the threads. This executor parameters type is equivalent to OpenMP's STATIC
   scheduling directive.
-* :cpp:class:`hpx::execution::dynamic_chunk_size`: Loop iterations are divided
+* :cpp:class:`hpx::execution::experimental::dynamic_chunk_size`: Loop iterations
+  are divided
   into pieces of a given size and then dynamically scheduled among the cores;
   when a core finishes one chunk, it is dynamically assigned another. If the
   size is not specified, the default chunk size is 1. This executor parameter
   type is equivalent to OpenMP's DYNAMIC scheduling directive.
-* :cpp:class:`hpx::execution::guided_chunk_size`: Iterations are dynamically
+* :cpp:class:`hpx::execution::experimental::guided_chunk_size`: Iterations are
+  dynamically
   assigned to cores in blocks as cores request them until no blocks remain to be
   assigned. This is similar to ``dynamic_chunk_size`` except that the block size
   decreases each time a number of loop iterations is given to a thread. The size

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/detail/set_operation.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/detail/set_operation.hpp
@@ -109,7 +109,8 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
         using buffer_type = typename set_operations_buffer<Iter3>::type;
 
         std::size_t cores = execution::processing_units_count(
-            policy.parameters(), policy.executor());
+            policy.parameters(), policy.executor(), hpx::chrono::null_duration,
+            (std::min)(len1, len2));
 
         std::size_t step = (len1 + cores - 1) / cores;
 

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/make_heap.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/make_heap.hpp
@@ -371,8 +371,9 @@ namespace hpx { namespace parallel { inline namespace v1 {
                         hpx::get<0>(t), hpx::get<1>(t));
                 };
 
-                std::size_t const cores = execution::processing_units_count(
-                    policy.parameters(), policy.executor());
+                std::size_t const cores =
+                    execution::processing_units_count(policy.parameters(),
+                        policy.executor(), hpx::chrono::null_duration, n);
 
                 // Take a standard chunk size (amount of work / cores), and only
                 // take a quarter of that. If our chunk size is too large a LOT
@@ -382,7 +383,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 // average number of levels done sequentially
                 std::size_t chunk_size = execution::get_chunk_size(
                     policy.parameters(), policy.executor(),
-                    [](std::size_t) { return 0; }, cores, n);
+                    hpx::chrono::null_duration, cores, n);
                 chunk_size /= 4;
 
                 std::size_t max_chunks = execution::maximal_number_of_chunks(

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/partial_sort.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/partial_sort.hpp
@@ -399,13 +399,14 @@ namespace hpx { namespace parallel { inline namespace v1 {
             if (middle >= c_last)
             {
                 // figure out the chunk size to use
-                std::size_t const cores = execution::processing_units_count(
-                    policy.parameters(), policy.executor());
+                std::size_t const cores =
+                    execution::processing_units_count(policy.parameters(),
+                        policy.executor(), hpx::chrono::null_duration, nelem);
 
                 // number of elements to sort
                 std::size_t chunk_size = execution::get_chunk_size(
                     policy.parameters(), policy.executor(),
-                    [](std::size_t) { return 0; }, cores, nelem);
+                    hpx::chrono::null_duration, cores, nelem);
 
                 hpx::future<Iter> left = execution::async_execute(
                     policy.executor(), sort_thread_helper(), policy, first,

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/partition.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/partition.hpp
@@ -673,11 +673,12 @@ namespace hpx { namespace parallel { inline namespace v1 {
                     {
                         std::size_t const cores =
                             execution::processing_units_count(
-                                policy.parameters(), policy.executor());
+                                policy.parameters(), policy.executor(),
+                                hpx::chrono::null_duration, size);
 
                         std::size_t chunk_size = execution::get_chunk_size(
                             policy.parameters(), policy.executor(),
-                            [](std::size_t) { return 0; }, cores, size);
+                            hpx::chrono::null_duration, cores, size);
 
                         std::size_t max_chunks =
                             execution::maximal_number_of_chunks(
@@ -1327,7 +1328,8 @@ namespace hpx { namespace parallel { inline namespace v1 {
                     return first;
 
                 std::size_t const cores = execution::processing_units_count(
-                    policy.parameters(), policy.executor());
+                    policy.parameters(), policy.executor(),
+                    hpx::chrono::null_duration, std::distance(first, last));
 
                 // TODO: Find more better block size.
                 const std::size_t block_size = std::size_t(20000);

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/rotate.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/rotate.hpp
@@ -226,7 +226,8 @@ namespace hpx { namespace parallel { inline namespace v1 {
 
             // get number of cores currently used
             std::size_t cores = parallel::execution::processing_units_count(
-                policy.parameters(), policy.executor());
+                policy.parameters(), policy.executor(),
+                hpx::chrono::null_duration, size_left + size_right);
 
             // calculate number of cores to be used for left and right section
             // proportional to the ratio of their sizes

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/sort.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/sort.hpp
@@ -294,15 +294,16 @@ namespace hpx { namespace parallel { inline namespace v1 {
             std::size_t count = last - first;
 
             // figure out the chunk size to use
-            std::size_t const cores = execution::processing_units_count(
-                policy.parameters(), policy.executor());
+            std::size_t const cores =
+                execution::processing_units_count(policy.parameters(),
+                    policy.executor(), hpx::chrono::null_duration, count);
 
             std::size_t max_chunks = execution::maximal_number_of_chunks(
                 policy.parameters(), policy.executor(), cores, count);
 
             std::size_t chunk_size = execution::get_chunk_size(
                 policy.parameters(), policy.executor(),
-                [](std::size_t) { return 0; }, cores, count);
+                hpx::chrono::null_duration, cores, count);
 
             util::detail::adjust_chunk_size_and_max_chunks(
                 cores, count, max_chunks, chunk_size);

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/stable_sort.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/stable_sort.hpp
@@ -227,15 +227,16 @@ namespace hpx { namespace parallel { inline namespace v1 {
                     detail::advance_and_get_distance(last_iter, last);
 
                 // figure out the chunk size to use
-                std::size_t cores = execution::processing_units_count(
-                    policy.parameters(), policy.executor());
+                std::size_t cores =
+                    execution::processing_units_count(policy.parameters(),
+                        policy.executor(), hpx::chrono::null_duration, count);
 
                 std::size_t max_chunks = execution::maximal_number_of_chunks(
                     policy.parameters(), policy.executor(), cores, count);
 
                 std::size_t chunk_size = execution::get_chunk_size(
                     policy.parameters(), policy.executor(),
-                    [](std::size_t) { return 0; }, cores, count);
+                    hpx::chrono::null_duration, cores, count);
 
                 util::detail::adjust_chunk_size_and_max_chunks(
                     cores, count, max_chunks, chunk_size);

--- a/libs/core/algorithms/tests/performance/foreach_scaling_helpers.hpp
+++ b/libs/core/algorithms/tests/performance/foreach_scaling_helpers.hpp
@@ -127,7 +127,7 @@ void measure_parallel_foreach(
     std::vector<std::size_t> const& data_representation, Executor&& exec)
 {
     // create executor parameters object
-    hpx::execution::static_chunk_size cs(chunk_size);
+    hpx::execution::experimental::static_chunk_size cs(chunk_size);
 
     if constexpr (hpx::traits::is_scheduler_executor_v<Executor>)
     {
@@ -173,7 +173,7 @@ hpx::future<void> measure_task_foreach(
     Executor&& exec)
 {
     // create executor parameters object
-    hpx::execution::static_chunk_size cs(chunk_size);
+    hpx::execution::experimental::static_chunk_size cs(chunk_size);
 
     if (disable_stealing)
     {
@@ -228,7 +228,7 @@ void measure_parallel_forloop(
     using iterator = typename std::vector<std::size_t>::const_iterator;
 
     // create executor parameters object
-    hpx::execution::static_chunk_size cs(chunk_size);
+    hpx::execution::experimental::static_chunk_size cs(chunk_size);
 
     if constexpr (hpx::traits::is_scheduler_executor_v<Executor>)
     {
@@ -282,7 +282,7 @@ hpx::future<void> measure_task_forloop(
     using iterator = typename std::vector<std::size_t>::const_iterator;
 
     // create executor parameters object
-    hpx::execution::static_chunk_size cs(chunk_size);
+    hpx::execution::experimental::static_chunk_size cs(chunk_size);
 
     if (disable_stealing)
     {

--- a/libs/core/algorithms/tests/regressions/scan_non_commutative.cpp
+++ b/libs/core/algorithms/tests/regressions/scan_non_commutative.cpp
@@ -25,7 +25,8 @@ void test_scan_non_commutative()
     {
         std::vector<std::string> rs(vs.size());
         hpx::inclusive_scan(
-            hpx::execution::par.with(hpx::execution::static_chunk_size(i)),
+            hpx::execution::par.with(
+                hpx::execution::experimental::static_chunk_size(i)),
             vs.cbegin(), vs.cend(), rs.begin());
         std::cout << rs.back() << "\n";
         bool is_equal =
@@ -37,7 +38,8 @@ void test_scan_non_commutative()
     {
         std::vector<std::string> rs(vs.size());
         hpx::exclusive_scan(
-            hpx::execution::par.with(hpx::execution::static_chunk_size(i)),
+            hpx::execution::par.with(
+                hpx::execution::experimental::static_chunk_size(i)),
             vs.cbegin(), vs.cend(), rs.begin(), std::string("0"));
         std::cout << rs.back() << "\n";
         bool is_equal =

--- a/libs/core/algorithms/tests/unit/block/task_block_executor.cpp
+++ b/libs/core/algorithms/tests/unit/block/task_block_executor.cpp
@@ -15,8 +15,8 @@
 #include <vector>
 
 using hpx::execution::par;
-using hpx::execution::static_chunk_size;
 using hpx::execution::task;
+using hpx::execution::experimental::static_chunk_size;
 using hpx::parallel::define_task_block;
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/libs/core/async_mpi/include/hpx/async_mpi/mpi_executor.hpp
+++ b/libs/core/async_mpi/include/hpx/async_mpi/mpi_executor.hpp
@@ -26,7 +26,8 @@ namespace hpx { namespace mpi { namespace experimental {
         using execution_category = hpx::execution::parallel_execution_tag;
 
         // default params type as we don't do anything special
-        using executor_parameters_type = hpx::execution::static_chunk_size;
+        using executor_parameters_type =
+            hpx::execution::experimental::static_chunk_size;
 
         constexpr explicit executor(MPI_Comm communicator = MPI_COMM_WORLD)
           : communicator_(communicator)

--- a/libs/core/compute_local/include/hpx/compute_local/host/block_executor.hpp
+++ b/libs/core/compute_local/include/hpx/compute_local/host/block_executor.hpp
@@ -40,7 +40,8 @@ namespace hpx { namespace compute { namespace host {
     struct block_executor
     {
     public:
-        using executor_parameters_type = hpx::execution::static_chunk_size;
+        using executor_parameters_type =
+            hpx::execution::experimental::static_chunk_size;
 
         explicit block_executor(std::vector<host::target> const& targets,
             threads::thread_priority priority = threads::thread_priority::high,

--- a/libs/core/compute_local/include/hpx/compute_local/host/block_fork_join_executor.hpp
+++ b/libs/core/compute_local/include/hpx/compute_local/host/block_fork_join_executor.hpp
@@ -116,7 +116,8 @@ namespace hpx::execution::experimental {
     public:
         /// \cond NOINTERNAL
         using execution_category = hpx::execution::parallel_execution_tag;
-        using executor_parameters_type = hpx::execution::static_chunk_size;
+        using executor_parameters_type =
+            hpx::execution::experimental::static_chunk_size;
 
         bool operator==(block_fork_join_executor const& rhs) const noexcept
         {

--- a/libs/core/compute_local/include/hpx/compute_local/host/numa_allocator.hpp
+++ b/libs/core/compute_local/include/hpx/compute_local/host/numa_allocator.hpp
@@ -102,7 +102,8 @@ namespace hpx { namespace parallel { namespace util {
                 first_touch.push_back(hpx::for_each(
                     hpx::execution::par(hpx::execution::task)
                         .on(executors_[i])
-                        .with(hpx::execution::static_chunk_size()),
+                        .with(
+                            hpx::execution::experimental::static_chunk_size()),
                     begin, end,
 #if defined(HPX_DEBUG)
                     [this, i]

--- a/libs/core/compute_local/tests/regressions/parallel_fill_4132.cpp
+++ b/libs/core/compute_local/tests/regressions/parallel_fill_4132.cpp
@@ -38,7 +38,7 @@ int hpx_main()
             std::vector<int> v(num_elems, 0);
             // Force there to be as many chunks as elements
             hpx::fill(hpx::execution::par.on(exec).with(
-                          hpx::execution::static_chunk_size(1)),
+                          hpx::execution::experimental::static_chunk_size(1)),
                 v.begin(), v.end(), 1);
 
             std::for_each(v.begin(), v.end(), [](int x) { HPX_TEST_EQ(x, 1); });

--- a/libs/core/execution/include/hpx/execution/executors/adaptive_static_chunk_size.hpp
+++ b/libs/core/execution/include/hpx/execution/executors/adaptive_static_chunk_size.hpp
@@ -12,9 +12,11 @@
 #include <hpx/config.hpp>
 #include <hpx/execution_base/traits/is_executor_parameters.hpp>
 #include <hpx/serialization/serialize.hpp>
+#include <hpx/timing/steady_clock.hpp>
 
 #include <hpx/execution/executors/execution_parameters_fwd.hpp>
 
+#include <chrono>
 #include <cmath>
 #include <cstddef>
 #include <iostream>
@@ -55,9 +57,10 @@ namespace hpx { namespace execution {
         }
 
         /// \cond NOINTERNAL
-        template <typename Executor, typename F>
-        std::size_t get_chunk_size(
-            Executor& exec, F&&, std::size_t cores, std::size_t input_size)
+        template <typename Executor>
+        std::size_t get_chunk_size(Executor& exec,
+            hpx::chrono::steady_duration const&, std::size_t cores,
+            std::size_t input_size)
         {
             // Make sure the internal round robin counter of the executor is
             // reset

--- a/libs/core/execution/include/hpx/execution/executors/adaptive_static_chunk_size.hpp
+++ b/libs/core/execution/include/hpx/execution/executors/adaptive_static_chunk_size.hpp
@@ -22,7 +22,8 @@
 #include <iostream>
 #include <type_traits>
 
-namespace hpx { namespace execution {
+namespace hpx::execution::experimental {
+
     ///////////////////////////////////////////////////////////////////////////
     /// Loop iterations are divided into pieces of size \a chunk_size and then
     /// assigned to threads. If \a chunk_size is not specified, the iterations
@@ -117,14 +118,24 @@ namespace hpx { namespace execution {
         std::size_t chunk_size_;
         /// \endcond
     };
-}}    // namespace hpx::execution
+}    // namespace hpx::execution::experimental
 
-namespace hpx { namespace parallel { namespace execution {
+namespace hpx::parallel::execution {
+
     /// \cond NOINTERNAL
     template <>
-    struct is_executor_parameters<hpx::execution::adaptive_static_chunk_size>
+    struct is_executor_parameters<
+        hpx::execution::experimental::adaptive_static_chunk_size>
       : std::true_type
     {
     };
     /// \endcond
-}}}    // namespace hpx::parallel::execution
+}    // namespace hpx::parallel::execution
+
+namespace hpx::execution {
+
+    using adaptive_static_chunk_size HPX_DEPRECATED_V(1, 9,
+        "hpx::execution::adaptive_static_chunk_size is deprecated, use "
+        "hpx::execution::experimental::adaptive_static_chunk_size instead") =
+        hpx::execution::experimental::adaptive_static_chunk_size;
+}

--- a/libs/core/execution/include/hpx/execution/executors/auto_chunk_size.hpp
+++ b/libs/core/execution/include/hpx/execution/executors/auto_chunk_size.hpp
@@ -13,6 +13,7 @@
 #include <hpx/execution_base/execution.hpp>
 #include <hpx/execution_base/traits/is_executor_parameters.hpp>
 #include <hpx/serialization/serialize.hpp>
+#include <hpx/timing/high_resolution_clock.hpp>
 #include <hpx/timing/steady_clock.hpp>
 
 #include <algorithm>
@@ -21,7 +22,8 @@
 #include <type_traits>
 #include <utility>
 
-namespace hpx { namespace execution {
+namespace hpx::execution::experimental {
+
     ///////////////////////////////////////////////////////////////////////////
     /// Loop iterations are divided into pieces and then assigned to threads.
     /// The number of loop iterations combined is determined based on
@@ -102,7 +104,7 @@ namespace hpx { namespace execution {
 
         // Estimate a chunk size based on number of cores used.
         template <typename Executor>
-        std::size_t get_chunk_size(Executor&& exec,
+        std::size_t get_chunk_size(Executor&&,
             hpx::chrono::steady_duration const& iteration_duration,
             std::size_t cores, std::size_t count) noexcept
         {
@@ -139,14 +141,23 @@ namespace hpx { namespace execution {
         std::uint64_t num_iters_for_timing_;
         /// \endcond
     };
-}}    // namespace hpx::execution
+}    // namespace hpx::execution::experimental
 
-namespace hpx { namespace parallel { namespace execution {
+namespace hpx::parallel::execution {
+
     /// \cond NOINTERNAL
     template <>
-    struct is_executor_parameters<hpx::execution::auto_chunk_size>
+    struct is_executor_parameters<hpx::execution::experimental::auto_chunk_size>
       : std::true_type
     {
     };
     /// \endcond
-}}}    // namespace hpx::parallel::execution
+}    // namespace hpx::parallel::execution
+
+namespace hpx::execution {
+
+    using auto_chunk_size HPX_DEPRECATED_V(1, 9,
+        "hpx::execution::auto_chunk_size is deprecated, use "
+        "hpx::execution::experimental::auto_chunk_size instead") =
+        hpx::execution::experimental::auto_chunk_size;
+}

--- a/libs/core/execution/include/hpx/execution/executors/auto_chunk_size.hpp
+++ b/libs/core/execution/include/hpx/execution/executors/auto_chunk_size.hpp
@@ -9,12 +9,11 @@
 #pragma once
 
 #include <hpx/config.hpp>
-#include <hpx/execution_base/traits/is_executor_parameters.hpp>
-#include <hpx/modules/timing.hpp>
-#include <hpx/serialization/serialize.hpp>
-
 #include <hpx/execution/executors/execution_parameters.hpp>
 #include <hpx/execution_base/execution.hpp>
+#include <hpx/execution_base/traits/is_executor_parameters.hpp>
+#include <hpx/serialization/serialize.hpp>
+#include <hpx/timing/steady_clock.hpp>
 
 #include <algorithm>
 #include <cstddef>
@@ -65,10 +64,10 @@ namespace hpx { namespace execution {
         // testing function in order to approximate the chunk-size.
         using invokes_testing_function = std::true_type;
 
-        // Estimate a chunk size based on number of cores used.
+        // Estimate execution time for one iteration
         template <typename Executor, typename F>
-        std::size_t get_chunk_size(Executor&& exec, F&& f, std::size_t cores,
-            std::size_t count) noexcept
+        auto measure_iteration(
+            Executor&& exec, F&& f, std::size_t count) noexcept
         {
             // by default use 1% of the iterations
             if (num_iters_for_timing_ == 0)
@@ -92,13 +91,28 @@ namespace hpx { namespace execution {
                     t = (high_resolution_clock::now() - t) / test_chunk_size;
                     if (t != 0 && min_time_ >= t)
                     {
-                        // return chunk size which will create the required
-                        // amount of work
-                        return (std::min)(count, (std::size_t)(min_time_ / t));
+                        // return execution time for one iteration
+                        return std::chrono::nanoseconds(t);
                     }
                 }
             }
 
+            return std::chrono::nanoseconds(0);
+        }
+
+        // Estimate a chunk size based on number of cores used.
+        template <typename Executor>
+        std::size_t get_chunk_size(Executor&& exec,
+            hpx::chrono::steady_duration const& iteration_duration,
+            std::size_t cores, std::size_t count) noexcept
+        {
+            // return chunk size which will create the required amount of work
+            if (iteration_duration.value().count() != 0)
+            {
+                auto ns = std::chrono::duration_cast<std::chrono::nanoseconds>(
+                    iteration_duration.value());
+                return (std::min)(count, (std::size_t)(min_time_ / ns.count()));
+            }
             return (count + cores - 1) / cores;
         }
         /// \endcond

--- a/libs/core/execution/include/hpx/execution/executors/dynamic_chunk_size.hpp
+++ b/libs/core/execution/include/hpx/execution/executors/dynamic_chunk_size.hpp
@@ -11,6 +11,7 @@
 #include <hpx/config.hpp>
 #include <hpx/execution_base/traits/is_executor_parameters.hpp>
 #include <hpx/serialization/serialize.hpp>
+#include <hpx/timing/steady_clock.hpp>
 
 #include <cstddef>
 #include <type_traits>
@@ -40,9 +41,10 @@ namespace hpx { namespace execution {
         }
 
         /// \cond NOINTERNAL
-        template <typename Executor, typename F>
-        constexpr std::size_t get_chunk_size(
-            Executor&, F&&, std::size_t, std::size_t) const noexcept
+        template <typename Executor>
+        constexpr std::size_t get_chunk_size(Executor&,
+            hpx::chrono::steady_duration const&, std::size_t,
+            std::size_t) const noexcept
         {
             return chunk_size_;
         }

--- a/libs/core/execution/include/hpx/execution/executors/dynamic_chunk_size.hpp
+++ b/libs/core/execution/include/hpx/execution/executors/dynamic_chunk_size.hpp
@@ -16,7 +16,8 @@
 #include <cstddef>
 #include <type_traits>
 
-namespace hpx { namespace execution {
+namespace hpx::execution::experimental {
+
     ///////////////////////////////////////////////////////////////////////////
     /// Loop iterations are divided into pieces of size \a chunk_size and then
     /// dynamically scheduled among the threads; when a thread finishes one
@@ -68,14 +69,23 @@ namespace hpx { namespace execution {
         std::size_t chunk_size_;
         /// \endcond
     };
-}}    // namespace hpx::execution
+}    // namespace hpx::execution::experimental
 
-namespace hpx { namespace parallel { namespace execution {
+namespace hpx::parallel::execution {
+
     /// \cond NOINTERNAL
     template <>
-    struct is_executor_parameters<hpx::execution::dynamic_chunk_size>
-      : std::true_type
+    struct is_executor_parameters<
+        hpx::execution::experimental::dynamic_chunk_size> : std::true_type
     {
     };
     /// \endcond
-}}}    // namespace hpx::parallel::execution
+}    // namespace hpx::parallel::execution
+
+namespace hpx::execution {
+
+    using dynamic_chunk_size HPX_DEPRECATED_V(1, 9,
+        "hpx::execution::dynamic_chunk_size is deprecated, use "
+        "hpx::execution::experimental::dynamic_chunk_size instead") =
+        hpx::execution::experimental::dynamic_chunk_size;
+}

--- a/libs/core/execution/include/hpx/execution/executors/execution_parameters.hpp
+++ b/libs/core/execution/include/hpx/execution/executors/execution_parameters.hpp
@@ -19,6 +19,7 @@
 #include <hpx/preprocessor/cat.hpp>
 #include <hpx/preprocessor/stringize.hpp>
 #include <hpx/serialization/base_object.hpp>
+#include <hpx/timing/steady_clock.hpp>
 #include <hpx/type_support/decay.hpp>
 #include <hpx/type_support/detail/wrap_int.hpp>
 #include <hpx/type_support/pack.hpp>
@@ -111,15 +112,15 @@ namespace hpx { namespace parallel { namespace execution {
         struct get_chunk_size_property
         {
             // default implementation
-            template <typename Target, typename F>
+            template <typename Target>
             HPX_FORCEINLINE static constexpr std::size_t get_chunk_size(Target,
-                F&& /*f*/, std::size_t /*cores*/,
-                std::size_t /*num_tasks*/) noexcept
+                hpx::chrono::steady_duration const&, std::size_t,
+                std::size_t) noexcept
             {
-                // return zero for the chunk-size which will tell the
-                // implementation to calculate the chunk size either based
-                // on a specified maximum number of chunks or based on some
-                // internal rule (if no maximum number of chunks was given)
+                // return zero for the chunk-size, which will tell the
+                // implementation to calculate the chunk size either based on a
+                // specified maximum number of chunks or based on some internal
+                // rule (if no maximum number of chunks was given)
                 return 0;
             }
         };
@@ -139,10 +140,11 @@ namespace hpx { namespace parallel { namespace execution {
         struct get_chunk_size_fn_helper<Parameters, Executor_,
             std::enable_if_t<hpx::traits::is_executor_any_v<Executor_>>>
         {
-            template <typename Executor, typename F>
+            template <typename Executor>
             HPX_FORCEINLINE static constexpr std::size_t call(
-                Parameters& params, Executor&& exec, F&& f, std::size_t cores,
-                std::size_t num_tasks)
+                Parameters& params, Executor&& exec,
+                hpx::chrono::steady_duration const& iteration_duration,
+                std::size_t cores, std::size_t num_tasks)
             {
                 auto getprop =
                     get_parameters_chunk_size(HPX_FORWARD(Executor, exec),
@@ -150,17 +152,77 @@ namespace hpx { namespace parallel { namespace execution {
 
                 return getprop.first.get_chunk_size(
                     HPX_FORWARD(decltype(getprop.second), getprop.second),
-                    HPX_FORWARD(F, f), cores, num_tasks);
+                    iteration_duration, cores, num_tasks);
+            }
+
+            template <typename AnyParameters, typename Executor>
+            HPX_FORCEINLINE static constexpr std::size_t call(
+                AnyParameters params, Executor&& exec,
+                hpx::chrono::steady_duration const& iteration_duration,
+                std::size_t cores, std::size_t num_tasks)
+            {
+                return call(static_cast<Parameters&>(params),
+                    HPX_FORWARD(Executor, exec), iteration_duration, cores,
+                    num_tasks);
+            }
+        };
+
+        ///////////////////////////////////////////////////////////////////////
+        // define member traits
+        HPX_HAS_MEMBER_XXX_TRAIT_DEF(measure_iteration)
+
+        ///////////////////////////////////////////////////////////////////////
+        // default property implementation allowing to handle measure_iteration
+        struct measure_iteration_property
+        {
+            // default implementation
+            template <typename Target, typename F>
+            HPX_FORCEINLINE static constexpr decltype(auto) measure_iteration(
+                Target, F&&, std::size_t) noexcept
+            {
+                // return zero for the iteration duration, which will tell the
+                // implementation to calculate the chunk size either based on a
+                // specified maximum number of chunks or based on some internal
+                // rule (if no maximum number of chunks was given)
+                return hpx::chrono::null_duration;
+            }
+        };
+
+        //////////////////////////////////////////////////////////////////////
+        // Generate a type that is guaranteed to support measure_iteration
+        using measure_iteration_t =
+            get_parameters_property_t<measure_iteration_property,
+                has_measure_iteration_t>;
+
+        inline constexpr measure_iteration_t get_parameters_measure_iteration{};
+
+        //////////////////////////////////////////////////////////////////////
+        // customization point for interface measure_iteration()
+        template <typename Parameters, typename Executor_>
+        struct measure_iteration_fn_helper<Parameters, Executor_,
+            std::enable_if_t<hpx::traits::is_executor_any_v<Executor_>>>
+        {
+            template <typename Executor, typename F>
+            HPX_FORCEINLINE static constexpr decltype(auto) call(
+                Parameters& params, Executor&& exec, F&& f,
+                std::size_t num_tasks)
+            {
+                auto getprop = get_parameters_measure_iteration(
+                    HPX_FORWARD(Executor, exec), params,
+                    measure_iteration_property{});
+
+                return getprop.first.measure_iteration(
+                    HPX_FORWARD(decltype(getprop.second), getprop.second),
+                    HPX_FORWARD(F, f), num_tasks);
             }
 
             template <typename AnyParameters, typename Executor, typename F>
-            HPX_FORCEINLINE static constexpr std::size_t call(
-                AnyParameters params, Executor&& exec, F&& f, std::size_t cores,
+            HPX_FORCEINLINE static constexpr decltype(auto) call(
+                AnyParameters params, Executor&& exec, F&& f,
                 std::size_t num_tasks)
             {
                 return call(static_cast<Parameters&>(params),
-                    HPX_FORWARD(Executor, exec), HPX_FORWARD(F, f), cores,
-                    num_tasks);
+                    HPX_FORWARD(Executor, exec), HPX_FORWARD(F, f), num_tasks);
             }
         };
 
@@ -295,7 +357,10 @@ namespace hpx { namespace parallel { namespace execution {
         {
             // default implementation
             template <typename Target>
-            HPX_FORCEINLINE static std::size_t processing_units_count(Target)
+            HPX_FORCEINLINE static std::size_t processing_units_count(Target,
+                hpx::chrono::steady_duration const& =
+                    hpx::chrono::null_duration,
+                std::size_t = 0)
             {
                 return get_os_thread_count();
             }
@@ -319,22 +384,27 @@ namespace hpx { namespace parallel { namespace execution {
         {
             template <typename Executor>
             HPX_FORCEINLINE static constexpr std::size_t call(
-                Parameters& params, Executor&& exec)
+                Parameters& params, Executor&& exec,
+                hpx::chrono::steady_duration const& iteration_duration,
+                std::size_t num_tasks)
             {
                 auto getprop = get_processing_units_count_target(
                     HPX_FORWARD(Executor, exec), params,
                     processing_units_count_property{});
 
                 return getprop.first.processing_units_count(
-                    HPX_FORWARD(decltype(getprop.second), getprop.second));
+                    HPX_FORWARD(decltype(getprop.second), getprop.second),
+                    iteration_duration, num_tasks);
             }
 
             template <typename AnyParameters, typename Executor>
             HPX_FORCEINLINE static constexpr std::size_t call(
-                AnyParameters params, Executor&& exec)
+                AnyParameters params, Executor&& exec,
+                hpx::chrono::steady_duration const& iteration_duration,
+                std::size_t num_tasks)
             {
                 return call(static_cast<Parameters&>(params),
-                    HPX_FORWARD(Executor, exec));
+                    HPX_FORWARD(Executor, exec), iteration_duration, num_tasks);
             }
         };
 
@@ -574,13 +644,35 @@ namespace hpx { namespace parallel { namespace execution {
         struct get_chunk_size_call_helper<T, Wrapper,
             std::enable_if_t<has_get_chunk_size<T>::value>>
         {
-            template <typename Executor, typename F>
-            HPX_FORCEINLINE std::size_t get_chunk_size(Executor&& exec, F&& f,
+            template <typename Executor>
+            HPX_FORCEINLINE std::size_t get_chunk_size(Executor&& exec,
+                hpx::chrono::steady_duration const& iteration_duration,
                 std::size_t cores, std::size_t num_tasks) const
             {
                 auto& wrapped =
                     static_cast<unwrapper<Wrapper> const*>(this)->member_.get();
                 return wrapped.get_chunk_size(HPX_FORWARD(Executor, exec),
+                    iteration_duration, cores, num_tasks);
+            }
+        };
+
+        ///////////////////////////////////////////////////////////////////////
+        template <typename T, typename Wrapper, typename Enable = void>
+        struct measure_iteration_call_helper
+        {
+        };
+
+        template <typename T, typename Wrapper>
+        struct measure_iteration_call_helper<T, Wrapper,
+            std::enable_if_t<has_measure_iteration<T>::value>>
+        {
+            template <typename Executor, typename F>
+            HPX_FORCEINLINE std::size_t measure_iteration(Executor&& exec,
+                F&& f, std::size_t cores, std::size_t num_tasks) const
+            {
+                auto& wrapped =
+                    static_cast<unwrapper<Wrapper> const*>(this)->member_.get();
+                return wrapped.measure_iteration(HPX_FORWARD(Executor, exec),
                     HPX_FORWARD(F, f), cores, num_tasks);
             }
         };
@@ -700,6 +792,7 @@ namespace hpx { namespace parallel { namespace execution {
           : base_member_helper<std::reference_wrapper<T>>
           , maximal_number_of_chunks_call_helper<T, std::reference_wrapper<T>>
           , get_chunk_size_call_helper<T, std::reference_wrapper<T>>
+          , measure_iteration_call_helper<T, std::reference_wrapper<T>>
           , mark_begin_execution_call_helper<T, std::reference_wrapper<T>>
           , mark_end_of_scheduling_call_helper<T, std::reference_wrapper<T>>
           , mark_end_execution_call_helper<T, std::reference_wrapper<T>>
@@ -737,6 +830,7 @@ namespace hpx { namespace parallel { namespace execution {
                 "objects");
 
             HPX_STATIC_ASSERT_ON_PARAMETERS_AMBIGUITY(get_chunk_size);
+            HPX_STATIC_ASSERT_ON_PARAMETERS_AMBIGUITY(measure_iteration);
             HPX_STATIC_ASSERT_ON_PARAMETERS_AMBIGUITY(mark_begin_execution);
             HPX_STATIC_ASSERT_ON_PARAMETERS_AMBIGUITY(mark_end_of_scheduling);
             HPX_STATIC_ASSERT_ON_PARAMETERS_AMBIGUITY(mark_end_execution);

--- a/libs/core/execution/include/hpx/execution/executors/execution_parameters_fwd.hpp
+++ b/libs/core/execution/include/hpx/execution/executors/execution_parameters_fwd.hpp
@@ -14,6 +14,7 @@
 #include <hpx/execution_base/traits/is_executor.hpp>
 #include <hpx/execution_base/traits/is_executor_parameters.hpp>
 #include <hpx/functional/detail/tag_fallback_invoke.hpp>
+#include <hpx/timing/steady_clock.hpp>
 #include <hpx/type_support/decay.hpp>
 
 #include <cstddef>
@@ -29,6 +30,10 @@ namespace hpx::parallel::execution {
         template <typename Parameters, typename Executor,
             typename Enable = void>
         struct get_chunk_size_fn_helper;
+
+        template <typename Parameters, typename Executor,
+            typename Enable = void>
+        struct measure_iteration_fn_helper;
 
         template <typename Parameters, typename Executor,
             typename Enable = void>
@@ -59,28 +64,86 @@ namespace hpx::parallel::execution {
     ///////////////////////////////////////////////////////////////////////////
     // define customization points
 
-    /// Return the number of invocations of the given function \a f which
-    /// should be combined into a single task
+    /// Return the number of invocations of the given function \a f which should
+    /// be combined into a single task
     ///
     /// \param params   [in] The executor parameters object to use for
-    ///                 determining the chunk size for the given number of
-    ///                 tasks \a num_tasks.
+    ///                 determining the chunk size for the given number of tasks
+    ///                 \a num_tasks.
     /// \param exec     [in] The executor object which will be used
     ///                 for scheduling of the loop iterations.
-    /// \param f        [in] The function which will be optionally scheduled
-    ///                 using the given executor.
+    /// \param iteration_duration [in] The time one of the tasks require to be
+    ///                 executed.
     /// \param cores    [in] The number of cores the number of chunks
     ///                 should be determined for.
     /// \param num_tasks [in] The number of tasks the chunk size should be
     ///                 determined for
     ///
-    /// \note  The parameter \a f is expected to be a nullary function
-    ///        returning a `std::size_t` representing the number of
-    ///        iteration the function has already executed (i.e. which
-    ///        don't have to be scheduled anymore).
+    /// \return         The size of the chunks (number of iterations per chunk)
+    ///                 that should be used for parallel execution.
     ///
     inline constexpr struct get_chunk_size_t final
       : hpx::functional::detail::tag_fallback<get_chunk_size_t>
+    {
+    private:
+        // clang-format off
+        template <typename Parameters, typename Executor,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::traits::is_executor_parameters<Parameters>::value &&
+                hpx::traits::is_executor_any<Executor>::value
+            )>
+        // clang-format on
+        friend HPX_FORCEINLINE decltype(auto) tag_fallback_invoke(
+            get_chunk_size_t, Parameters&& params, Executor&& exec,
+            hpx::chrono::steady_duration const& iteration_duration,
+            std::size_t cores, std::size_t num_tasks)
+        {
+            return detail::get_chunk_size_fn_helper<
+                hpx::util::decay_unwrap_t<Parameters>,
+                std::decay_t<Executor>>::call(HPX_FORWARD(Parameters, params),
+                HPX_FORWARD(Executor, exec), iteration_duration, cores,
+                num_tasks);
+        }
+
+        // clang-format off
+        template <typename Parameters, typename Executor,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::traits::is_executor_parameters<Parameters>::value &&
+                hpx::traits::is_executor_any<Executor>::value
+            )>
+        // clang-format on
+        friend HPX_FORCEINLINE decltype(auto) tag_fallback_invoke(
+            get_chunk_size_t tag, Parameters&& params, Executor&& exec,
+            std::size_t cores, std::size_t num_tasks)
+        {
+            return tag(HPX_FORWARD(Parameters, params),
+                HPX_FORWARD(Executor, exec), hpx::chrono::null_duration, cores,
+                num_tasks);
+        }
+    } get_chunk_size{};
+
+    /// Return the measured execution time for one iteration based on running
+    /// the given function.
+    ///
+    /// \param params   [in] The executor parameters object to use for
+    ///                 determining the chunk size for the given number of tasks
+    ///                 \a num_tasks.
+    /// \param exec     [in] The executor object which will be used
+    ///                 for scheduling of the loop iterations.
+    /// \param f        [in] The function which will be optionally scheduled
+    ///                 using the given executor.
+    /// \param num_tasks [in] The number of tasks the chunk size should be
+    ///                 determined for
+    ///
+    /// \note  The parameter \a f is expected to be a nullary function
+    ///        returning a `std::size_t` representing the number of iteration
+    ///        the function has already executed (i.e. which don't have to be
+    ///        scheduled anymore).
+    ///
+    /// \return The execution time for one of the tasks.
+    ///
+    inline constexpr struct measure_iteration_t final
+      : hpx::functional::detail::tag_fallback<measure_iteration_t>
     {
     private:
         // clang-format off
@@ -91,16 +154,15 @@ namespace hpx::parallel::execution {
             )>
         // clang-format on
         friend HPX_FORCEINLINE decltype(auto) tag_fallback_invoke(
-            get_chunk_size_t, Parameters&& params, Executor&& exec, F&& f,
-            std::size_t cores, std::size_t num_tasks)
+            measure_iteration_t, Parameters&& params, Executor&& exec, F&& f,
+            std::size_t num_tasks)
         {
-            return detail::get_chunk_size_fn_helper<
+            return detail::measure_iteration_fn_helper<
                 hpx::util::decay_unwrap_t<Parameters>,
                 std::decay_t<Executor>>::call(HPX_FORWARD(Parameters, params),
-                HPX_FORWARD(Executor, exec), HPX_FORWARD(F, f), cores,
-                num_tasks);
+                HPX_FORWARD(Executor, exec), HPX_FORWARD(F, f), num_tasks);
         }
-    } get_chunk_size{};
+    } measure_iteration{};
 
     /// Return the largest reasonable number of chunks to create for a
     /// single algorithm invocation.
@@ -168,15 +230,20 @@ namespace hpx::parallel::execution {
         }
     } reset_thread_distribution{};
 
-    /// Retrieve the number of (kernel-)threads used by the associated
-    /// executor.
+    /// Retrieve the number of (kernel-)threads used by the associated executor.
     ///
     /// \param params [in] The executor parameters object to use as a
     ///              fallback if the executor does not expose
+    /// \param iteration_duration [in] The time one of the tasks require to be
+    ///                 executed.
+    /// \param num_tasks [in] The number of tasks the number of cores should be
+    ///                 determined for
     ///
-    /// \note This calls params.processing_units_count(Executor&&) if it
-    ///       exists; otherwise it forwards the request to the executor
-    ///       parameters object.
+    /// \note This calls params.processing_units_count(Executor&&) if it exists;
+    ///       otherwise it forwards the request to the executor parameters
+    ///       object.
+    ///
+    /// \return The number of cores to use
     ///
     inline constexpr struct processing_units_count_t final
       : hpx::functional::detail::tag_fallback<processing_units_count_t>
@@ -190,12 +257,30 @@ namespace hpx::parallel::execution {
             )>
         // clang-format on
         friend HPX_FORCEINLINE decltype(auto) tag_fallback_invoke(
-            processing_units_count_t, Parameters&& params, Executor&& exec)
+            processing_units_count_t, Parameters&& params, Executor&& exec,
+            hpx::chrono::steady_duration const& iteration_duration,
+            std::size_t num_tasks)
         {
             return detail::processing_units_count_fn_helper<
                 hpx::util::decay_unwrap_t<Parameters>,
                 std::decay_t<Executor>>::call(HPX_FORWARD(Parameters, params),
-                HPX_FORWARD(Executor, exec));
+                HPX_FORWARD(Executor, exec), iteration_duration, num_tasks);
+        }
+
+        // clang-format off
+        template <typename Parameters, typename Executor,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::traits::is_executor_parameters<Parameters>::value &&
+                hpx::traits::is_executor_any<Executor>::value
+            )>
+        // clang-format on
+        friend HPX_FORCEINLINE decltype(auto) tag_fallback_invoke(
+            processing_units_count_t tag, Parameters&& params, Executor&& exec,
+            std::size_t num_tasks = 0)
+        {
+            return tag(HPX_FORWARD(Parameters, params),
+                HPX_FORWARD(Executor, exec), hpx::chrono::null_duration,
+                num_tasks);
         }
     } processing_units_count{};
 

--- a/libs/core/execution/include/hpx/execution/executors/guided_chunk_size.hpp
+++ b/libs/core/execution/include/hpx/execution/executors/guided_chunk_size.hpp
@@ -11,12 +11,14 @@
 #include <hpx/config.hpp>
 #include <hpx/execution_base/traits/is_executor_parameters.hpp>
 #include <hpx/serialization/serialize.hpp>
+#include <hpx/timing/steady_clock.hpp>
 
 #include <algorithm>
 #include <cstddef>
 #include <type_traits>
 
 namespace hpx { namespace execution {
+
     ///////////////////////////////////////////////////////////////////////////
     /// Iterations are dynamically assigned to threads in blocks as threads
     /// request them until no blocks remain to be assigned. Similar to
@@ -59,9 +61,10 @@ namespace hpx { namespace execution {
         //             return ...;
         //         }
 
-        template <typename Executor, typename F>
-        constexpr std::size_t get_chunk_size(Executor&& /* exec */, F&&,
-            std::size_t cores, std::size_t num_tasks) const noexcept
+        template <typename Executor>
+        constexpr std::size_t get_chunk_size(Executor&& /* exec */,
+            hpx::chrono::steady_duration const&, std::size_t cores,
+            std::size_t num_tasks) const noexcept
         {
             return (std::max)(min_chunk_size_, (num_tasks + cores - 1) / cores);
         }

--- a/libs/core/execution/include/hpx/execution/executors/guided_chunk_size.hpp
+++ b/libs/core/execution/include/hpx/execution/executors/guided_chunk_size.hpp
@@ -17,7 +17,7 @@
 #include <cstddef>
 #include <type_traits>
 
-namespace hpx { namespace execution {
+namespace hpx::execution::experimental {
 
     ///////////////////////////////////////////////////////////////////////////
     /// Iterations are dynamically assigned to threads in blocks as threads
@@ -88,14 +88,23 @@ namespace hpx { namespace execution {
         std::size_t min_chunk_size_;
         /// \endcond
     };
-}}    // namespace hpx::execution
+}    // namespace hpx::execution::experimental
 
-namespace hpx { namespace parallel { namespace execution {
+namespace hpx::parallel::execution {
+
     /// \cond NOINTERNAL
     template <>
-    struct is_executor_parameters<hpx::execution::guided_chunk_size>
-      : std::true_type
+    struct is_executor_parameters<
+        hpx::execution::experimental::guided_chunk_size> : std::true_type
     {
     };
     /// \endcond
-}}}    // namespace hpx::parallel::execution
+}    // namespace hpx::parallel::execution
+
+namespace hpx::execution {
+
+    using guided_chunk_size HPX_DEPRECATED_V(1, 9,
+        "hpx::execution::guided_chunk_size is deprecated, use "
+        "hpx::execution::experimental::guided_chunk_size instead") =
+        hpx::execution::experimental::guided_chunk_size;
+}

--- a/libs/core/execution/include/hpx/execution/executors/num_cores.hpp
+++ b/libs/core/execution/include/hpx/execution/executors/num_cores.hpp
@@ -17,7 +17,7 @@
 #include <cstddef>
 #include <type_traits>
 
-namespace hpx::execution {
+namespace hpx::execution::experimental {
 
     /// Control number of cores in executors which need a functionality
     /// for setting the number of cores to be used by an algorithm directly
@@ -61,13 +61,23 @@ namespace hpx::execution {
         std::size_t num_cores_;
         /// \endcond
     };
-}    // namespace hpx::execution
+}    // namespace hpx::execution::experimental
 
-namespace hpx { namespace parallel { namespace execution {
+namespace hpx::parallel::execution {
+
     /// \cond NOINTERNAL
     template <>
-    struct is_executor_parameters<hpx::execution::num_cores> : std::true_type
+    struct is_executor_parameters<hpx::execution::experimental::num_cores>
+      : std::true_type
     {
     };
     /// \endcond
-}}}    // namespace hpx::parallel::execution
+}    // namespace hpx::parallel::execution
+
+namespace hpx::execution {
+
+    using num_cores HPX_DEPRECATED_V(1, 9,
+        "hpx::execution::num_cores is deprecated, use "
+        "hpx::execution::experimental::num_cores instead") =
+        hpx::execution::experimental::num_cores;
+}

--- a/libs/core/execution/include/hpx/execution/executors/num_cores.hpp
+++ b/libs/core/execution/include/hpx/execution/executors/num_cores.hpp
@@ -12,6 +12,7 @@
 #include <hpx/execution/executors/execution_parameters_fwd.hpp>
 #include <hpx/execution_base/traits/is_executor_parameters.hpp>
 #include <hpx/serialization/serialize.hpp>
+#include <hpx/timing/steady_clock.hpp>
 
 #include <cstddef>
 #include <type_traits>
@@ -35,7 +36,8 @@ namespace hpx::execution {
         /// \cond NOINTERNAL
         // discover the number of cores to use for parallelization
         template <typename Executor>
-        constexpr std::size_t processing_units_count(Executor&&) const noexcept
+        constexpr std::size_t processing_units_count(Executor&&,
+            hpx::chrono::steady_duration const&, std::size_t) const noexcept
         {
             return num_cores_;
         }

--- a/libs/core/execution/include/hpx/execution/executors/persistent_auto_chunk_size.hpp
+++ b/libs/core/execution/include/hpx/execution/executors/persistent_auto_chunk_size.hpp
@@ -1,4 +1,5 @@
 //  Copyright (c) 2016 Zahra Khatami
+//  Copyright (c) 2022 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -10,8 +11,8 @@
 
 #include <hpx/config.hpp>
 #include <hpx/execution_base/traits/is_executor_parameters.hpp>
-#include <hpx/modules/timing.hpp>
 #include <hpx/serialization/serialize.hpp>
+#include <hpx/timing/steady_clock.hpp>
 
 #include <algorithm>
 #include <cstddef>
@@ -19,6 +20,7 @@
 #include <type_traits>
 
 namespace hpx { namespace execution {
+
     ///////////////////////////////////////////////////////////////////////////
     /// Loop iterations are divided into pieces and then assigned to threads.
     /// The number of loop iterations combined is determined based on
@@ -79,10 +81,9 @@ namespace hpx { namespace execution {
         // testing function in order to approximate the chunk-size.
         using invokes_testing_function = std::true_type;
 
-        // Estimate a chunk size based on number of cores used.
+        // Estimate execution time for one iteration
         template <typename Executor, typename F>
-        std::size_t get_chunk_size(Executor& /* exec */, F&& f,
-            std::size_t cores, std::size_t count) noexcept
+        auto measure_iteration(Executor&&, F&& f, std::size_t count) noexcept
         {
             // by default use 1% of the iterations
             if (num_iters_for_timing_ == 0)
@@ -112,13 +113,28 @@ namespace hpx { namespace execution {
 
                     if (t != 0 && min_time_ >= t)
                     {
-                        // return chunk size which will create the required
-                        // amount of work
-                        return (std::min)(count, (std::size_t)(min_time_ / t));
+                        // return execution time for one iteration
+                        return std::chrono::nanoseconds(t);
                     }
                 }
             }
 
+            return std::chrono::nanoseconds(0);
+        }
+
+        // Estimate a chunk size based on number of cores used.
+        template <typename Executor>
+        std::size_t get_chunk_size(Executor& /* exec */,
+            hpx::chrono::steady_duration const& iteration_duration,
+            std::size_t cores, std::size_t count) noexcept
+        {
+            // return chunk size which will create the required amount of work
+            if (iteration_duration.value().count() != 0)
+            {
+                auto ns = std::chrono::duration_cast<std::chrono::nanoseconds>(
+                    iteration_duration.value());
+                return (std::min)(count, (std::size_t)(min_time_ / ns.count()));
+            }
             return (count + cores - 1) / cores;
         }
         /// \endcond

--- a/libs/core/execution/include/hpx/execution/executors/persistent_auto_chunk_size.hpp
+++ b/libs/core/execution/include/hpx/execution/executors/persistent_auto_chunk_size.hpp
@@ -10,8 +10,11 @@
 #pragma once
 
 #include <hpx/config.hpp>
+#include <hpx/execution/executors/execution_parameters.hpp>
+#include <hpx/execution_base/execution.hpp>
 #include <hpx/execution_base/traits/is_executor_parameters.hpp>
 #include <hpx/serialization/serialize.hpp>
+#include <hpx/timing/high_resolution_clock.hpp>
 #include <hpx/timing/steady_clock.hpp>
 
 #include <algorithm>
@@ -19,7 +22,7 @@
 #include <cstdint>
 #include <type_traits>
 
-namespace hpx { namespace execution {
+namespace hpx::execution::experimental {
 
     ///////////////////////////////////////////////////////////////////////////
     /// Loop iterations are divided into pieces and then assigned to threads.
@@ -160,14 +163,24 @@ namespace hpx { namespace execution {
         std::uint64_t num_iters_for_timing_;
         /// \endcond
     };
-}}    // namespace hpx::execution
+}    // namespace hpx::execution::experimental
 
-namespace hpx { namespace parallel { namespace execution {
+namespace hpx::parallel::execution {
+
     /// \cond NOINTERNAL
     template <>
-    struct is_executor_parameters<hpx::execution::persistent_auto_chunk_size>
+    struct is_executor_parameters<
+        hpx::execution::experimental::persistent_auto_chunk_size>
       : std::true_type
     {
     };
     /// \endcond
-}}}    // namespace hpx::parallel::execution
+}    // namespace hpx::parallel::execution
+
+namespace hpx::execution {
+
+    using persistent_auto_chunk_size HPX_DEPRECATED_V(1, 9,
+        "hpx::execution::persistent_auto_chunk_size is deprecated, use "
+        "hpx::execution::experimental::persistent_auto_chunk_size instead") =
+        hpx::execution::experimental::persistent_auto_chunk_size;
+}

--- a/libs/core/execution/include/hpx/execution/executors/static_chunk_size.hpp
+++ b/libs/core/execution/include/hpx/execution/executors/static_chunk_size.hpp
@@ -9,15 +9,16 @@
 #pragma once
 
 #include <hpx/config.hpp>
+#include <hpx/execution/executors/execution_parameters_fwd.hpp>
 #include <hpx/execution_base/traits/is_executor_parameters.hpp>
 #include <hpx/serialization/serialize.hpp>
-
-#include <hpx/execution/executors/execution_parameters_fwd.hpp>
+#include <hpx/timing/steady_clock.hpp>
 
 #include <cstddef>
 #include <type_traits>
 
 namespace hpx { namespace execution {
+
     ///////////////////////////////////////////////////////////////////////////
     /// Loop iterations are divided into pieces of size \a chunk_size and then
     /// assigned to threads. If \a chunk_size is not specified, the iterations
@@ -51,9 +52,10 @@ namespace hpx { namespace execution {
         }
 
         /// \cond NOINTERNAL
-        template <typename Executor, typename F>
-        std::size_t get_chunk_size(
-            Executor& exec, F&&, std::size_t cores, std::size_t num_tasks)
+        template <typename Executor>
+        std::size_t get_chunk_size(Executor& exec,
+            hpx::chrono::steady_duration const&, std::size_t cores,
+            std::size_t num_tasks)
         {
             // Make sure the internal round robin counter of the executor is
             // reset

--- a/libs/core/execution/include/hpx/execution/executors/static_chunk_size.hpp
+++ b/libs/core/execution/include/hpx/execution/executors/static_chunk_size.hpp
@@ -17,7 +17,7 @@
 #include <cstddef>
 #include <type_traits>
 
-namespace hpx { namespace execution {
+namespace hpx::execution::experimental {
 
     ///////////////////////////////////////////////////////////////////////////
     /// Loop iterations are divided into pieces of size \a chunk_size and then
@@ -102,14 +102,23 @@ namespace hpx { namespace execution {
         std::size_t chunk_size_;
         /// \endcond
     };
-}}    // namespace hpx::execution
+}    // namespace hpx::execution::experimental
 
-namespace hpx { namespace parallel { namespace execution {
+namespace hpx::parallel::execution {
+
     /// \cond NOINTERNAL
     template <>
-    struct is_executor_parameters<hpx::execution::static_chunk_size>
-      : std::true_type
+    struct is_executor_parameters<
+        hpx::execution::experimental::static_chunk_size> : std::true_type
     {
     };
     /// \endcond
-}}}    // namespace hpx::parallel::execution
+}    // namespace hpx::parallel::execution
+
+namespace hpx::execution {
+
+    using static_chunk_size HPX_DEPRECATED_V(1, 9,
+        "hpx::execution::static_chunk_size is deprecated, use "
+        "hpx::execution::experimental::static_chunk_size instead") =
+        hpx::execution::experimental::static_chunk_size;
+}

--- a/libs/core/execution/include/hpx/execution/traits/executor_traits.hpp
+++ b/libs/core/execution/include/hpx/execution/traits/executor_traits.hpp
@@ -25,8 +25,11 @@ namespace hpx {
 }    // namespace hpx
 
 namespace hpx { namespace execution {
-    ///////////////////////////////////////////////////////////////////////////
-    struct static_chunk_size;
+
+    namespace experimental {
+        ///////////////////////////////////////////////////////////////////////
+        struct static_chunk_size;
+    }    // namespace experimental
 
     ///////////////////////////////////////////////////////////////////////////
     struct sequenced_execution_tag;
@@ -149,8 +152,9 @@ namespace hpx { namespace parallel { namespace execution {
         using parameters_type = typename T::parameters_type;
 
     public:
-        using type = hpx::util::detected_or_t<hpx::execution::static_chunk_size,
-            parameters_type, Executor>;
+        using type = hpx::util::detected_or_t<
+            hpx::execution::experimental::static_chunk_size, parameters_type,
+            Executor>;
     };
 
     ///////////////////////////////////////////////////////////////////////////

--- a/libs/core/execution/tests/regressions/annotated_minmax_2593.cpp
+++ b/libs/core/execution/tests/regressions/annotated_minmax_2593.cpp
@@ -13,7 +13,7 @@
 
 double compute_minmax(const std::vector<double> v)
 {
-    hpx::execution::static_chunk_size param;
+    hpx::execution::experimental::static_chunk_size param;
     hpx::execution::parallel_task_policy par_policy;
     auto policy = par_policy.with(param);
 

--- a/libs/core/execution/tests/regressions/chunk_size_4118.cpp
+++ b/libs/core/execution/tests/regressions/chunk_size_4118.cpp
@@ -45,7 +45,7 @@ int hpx_main()
     using namespace hpx::util;
 
     // create a fixed chunk size to be used in the algorithm
-    hpx::execution::static_chunk_size fixed(50000);
+    hpx::execution::experimental::static_chunk_size fixed(50000);
 
     // helper-executor to verify the used chunk-size
     test_async_executor exec;

--- a/libs/core/execution/tests/unit/executor_parameters.cpp
+++ b/libs/core/execution/tests/unit/executor_parameters.cpp
@@ -66,12 +66,12 @@ void parameters_test(Parameters&&... params)
 void test_dynamic_chunk_size()
 {
     {
-        hpx::execution::dynamic_chunk_size dcs;
+        hpx::execution::experimental::dynamic_chunk_size dcs;
         parameters_test(dcs);
     }
 
     {
-        hpx::execution::dynamic_chunk_size dcs(100);
+        hpx::execution::experimental::dynamic_chunk_size dcs(100);
         parameters_test(dcs);
     }
 }
@@ -79,31 +79,31 @@ void test_dynamic_chunk_size()
 void test_static_chunk_size()
 {
     {
-        hpx::execution::static_chunk_size scs;
+        hpx::execution::experimental::static_chunk_size scs;
         parameters_test(scs);
     }
 
     {
-        hpx::execution::static_chunk_size scs(100);
+        hpx::execution::experimental::static_chunk_size scs(100);
         parameters_test(scs);
     }
 }
 void test_adaptive_static_chunk_size()
 {
     {
-        hpx::execution::adaptive_static_chunk_size asc;
+        hpx::execution::experimental::adaptive_static_chunk_size asc;
         parameters_test(asc);
     }
 }
 void test_guided_chunk_size()
 {
     {
-        hpx::execution::guided_chunk_size gcs;
+        hpx::execution::experimental::guided_chunk_size gcs;
         parameters_test(gcs);
     }
 
     {
-        hpx::execution::guided_chunk_size gcs(100);
+        hpx::execution::experimental::guided_chunk_size gcs(100);
         parameters_test(gcs);
     }
 }
@@ -111,12 +111,13 @@ void test_guided_chunk_size()
 void test_auto_chunk_size()
 {
     {
-        hpx::execution::auto_chunk_size acs;
+        hpx::execution::experimental::auto_chunk_size acs;
         parameters_test(acs);
     }
 
     {
-        hpx::execution::auto_chunk_size acs(std::chrono::milliseconds(1));
+        hpx::execution::experimental::auto_chunk_size acs(
+            std::chrono::milliseconds(1));
         parameters_test(acs);
     }
 }
@@ -124,18 +125,18 @@ void test_auto_chunk_size()
 void test_persistent_auto_chunk_size()
 {
     {
-        hpx::execution::persistent_auto_chunk_size pacs;
+        hpx::execution::experimental::persistent_auto_chunk_size pacs;
         parameters_test(pacs);
     }
 
     {
-        hpx::execution::persistent_auto_chunk_size pacs(
+        hpx::execution::experimental::persistent_auto_chunk_size pacs(
             std::chrono::milliseconds(0), std::chrono::milliseconds(1));
         parameters_test(pacs);
     }
 
     {
-        hpx::execution::persistent_auto_chunk_size pacs(
+        hpx::execution::experimental::persistent_auto_chunk_size pacs(
             std::chrono::milliseconds(0));
         parameters_test(pacs);
     }
@@ -144,12 +145,12 @@ void test_persistent_auto_chunk_size()
 void test_num_cores()
 {
     {
-        hpx::execution::num_cores nc;
+        hpx::execution::experimental::num_cores nc;
         parameters_test(nc);
     }
 
     {
-        hpx::execution::num_cores nc(2);
+        hpx::execution::experimental::num_cores nc(2);
         parameters_test(nc);
     }
 }
@@ -190,7 +191,7 @@ namespace hpx { namespace parallel { namespace execution {
 void test_combined_hooks()
 {
     timer_hooks_parameters pacs("time_hooks");
-    hpx::execution::auto_chunk_size acs;
+    hpx::execution::experimental::auto_chunk_size acs;
 
     parameters_test(acs, pacs);
     parameters_test(pacs, acs);

--- a/libs/core/execution/tests/unit/executor_parameters.cpp
+++ b/libs/core/execution/tests/unit/executor_parameters.cpp
@@ -141,6 +141,19 @@ void test_persistent_auto_chunk_size()
     }
 }
 
+void test_num_cores()
+{
+    {
+        hpx::execution::num_cores nc;
+        parameters_test(nc);
+    }
+
+    {
+        hpx::execution::num_cores nc(2);
+        parameters_test(nc);
+    }
+}
+
 ///////////////////////////////////////////////////////////////////////////////
 struct timer_hooks_parameters
 {
@@ -199,6 +212,7 @@ int hpx_main(hpx::program_options::variables_map& vm)
     test_guided_chunk_size();
     test_auto_chunk_size();
     test_persistent_auto_chunk_size();
+    test_num_cores();
 
     test_combined_hooks();
 

--- a/libs/core/execution/tests/unit/executor_parameters_dispatching.cpp
+++ b/libs/core/execution/tests/unit/executor_parameters_dispatching.cpp
@@ -418,7 +418,7 @@ void test_processing_units_count()
     {
         params_count = 0;
 
-        hpx::execution::num_cores nc(2);
+        hpx::execution::experimental::num_cores nc(2);
         auto p = hpx::parallel::execution::with_processing_units_count(
             hpx::execution::par, nc);
 

--- a/libs/core/execution/tests/unit/persistent_executor_parameters.cpp
+++ b/libs/core/execution/tests/unit/persistent_executor_parameters.cpp
@@ -24,13 +24,13 @@ void test_persistent_executitor_parameters()
 {
     typedef std::random_access_iterator_tag iterator_tag;
     {
-        hpx::execution::persistent_auto_chunk_size p;
+        hpx::execution::experimental::persistent_auto_chunk_size p;
         auto policy = hpx::execution::par.with(p);
         test_for_each(policy, iterator_tag());
     }
 
     {
-        hpx::execution::persistent_auto_chunk_size p;
+        hpx::execution::experimental::persistent_auto_chunk_size p;
         auto policy = hpx::execution::par(hpx::execution::task).with(p);
         test_for_each_async(policy, iterator_tag());
     }
@@ -38,13 +38,13 @@ void test_persistent_executitor_parameters()
     hpx::execution::parallel_executor par_exec;
 
     {
-        hpx::execution::persistent_auto_chunk_size p;
+        hpx::execution::experimental::persistent_auto_chunk_size p;
         auto policy = hpx::execution::par.on(par_exec).with(p);
         test_for_each(policy, iterator_tag());
     }
 
     {
-        hpx::execution::persistent_auto_chunk_size p;
+        hpx::execution::experimental::persistent_auto_chunk_size p;
         auto policy =
             hpx::execution::par(hpx::execution::task).on(par_exec).with(p);
         test_for_each_async(policy, iterator_tag());
@@ -58,12 +58,12 @@ void test_persistent_executitor_parameters_ref()
     typedef std::random_access_iterator_tag iterator_tag;
 
     {
-        hpx::execution::persistent_auto_chunk_size p;
+        hpx::execution::experimental::persistent_auto_chunk_size p;
         test_for_each(hpx::execution::par.with(std::ref(p)), iterator_tag());
     }
 
     {
-        hpx::execution::persistent_auto_chunk_size p;
+        hpx::execution::experimental::persistent_auto_chunk_size p;
         test_for_each_async(
             hpx::execution::par(hpx::execution::task).with(std::ref(p)),
             iterator_tag());
@@ -72,13 +72,13 @@ void test_persistent_executitor_parameters_ref()
     hpx::execution::parallel_executor par_exec;
 
     {
-        hpx::execution::persistent_auto_chunk_size p;
+        hpx::execution::experimental::persistent_auto_chunk_size p;
         test_for_each(
             hpx::execution::par.on(par_exec).with(std::ref(p)), iterator_tag());
     }
 
     {
-        hpx::execution::persistent_auto_chunk_size p;
+        hpx::execution::experimental::persistent_auto_chunk_size p;
         test_for_each_async(hpx::execution::par(hpx::execution::task)
                                 .on(par_exec)
                                 .with(std::ref(p)),

--- a/libs/core/executors/include/hpx/executors/execution_policy_parameters.hpp
+++ b/libs/core/executors/include/hpx/executors/execution_policy_parameters.hpp
@@ -58,8 +58,11 @@ namespace hpx::parallel::execution {
     constexpr decltype(auto) tag_invoke(
         with_processing_units_count_t, ExPolicy&& policy, Params&& params)
     {
+        // explicitly extract pu count from given parameters object as otherwise
+        // the executor might take precedence
         auto exec = with_processing_units_count(policy.executor(),
-            params.processing_units_count(policy.executor()));
+            params.processing_units_count(
+                policy.executor(), hpx::chrono::null_duration, 0));
 
         return create_rebound_policy(
             policy, HPX_MOVE(exec), policy.parameters());

--- a/libs/core/executors/include/hpx/executors/fork_join_executor.hpp
+++ b/libs/core/executors/include/hpx/executors/fork_join_executor.hpp
@@ -77,7 +77,8 @@ namespace hpx { namespace execution { namespace experimental {
 
         /// \cond NOINTERNAL
         using execution_category = hpx::execution::parallel_execution_tag;
-        using executor_parameters_type = hpx::execution::static_chunk_size;
+        using executor_parameters_type =
+            hpx::execution::experimental::static_chunk_size;
         /// \endcond
 
     private:

--- a/libs/core/executors/include/hpx/executors/parallel_executor.hpp
+++ b/libs/core/executors/include/hpx/executors/parallel_executor.hpp
@@ -38,6 +38,7 @@
 #include <hpx/threading_base/thread_data.hpp>
 #include <hpx/threading_base/thread_helpers.hpp>
 #include <hpx/threading_base/thread_pool_base.hpp>
+#include <hpx/timing/steady_clock.hpp>
 #include <hpx/type_support/unused.hpp>
 
 #include <algorithm>
@@ -204,7 +205,9 @@ namespace hpx { namespace execution {
 
         friend constexpr std::size_t tag_invoke(
             hpx::parallel::execution::processing_units_count_t,
-            parallel_policy_executor const& exec)
+            parallel_policy_executor const& exec,
+            hpx::chrono::steady_duration const& = hpx::chrono::null_duration,
+            std::size_t = 0)
         {
             return exec.get_num_cores();
         }
@@ -231,7 +234,9 @@ namespace hpx { namespace execution {
     public:
         // backwards compatibility support, will be removed in the future
         template <typename Parameters>
-        std::size_t processing_units_count(Parameters&&) const
+        std::size_t processing_units_count(Parameters&&,
+            hpx::chrono::steady_duration const& = hpx::chrono::null_duration,
+            std::size_t = 0) const
         {
             return get_num_cores();
         }

--- a/libs/core/executors/include/hpx/executors/parallel_executor.hpp
+++ b/libs/core/executors/include/hpx/executors/parallel_executor.hpp
@@ -80,6 +80,7 @@ namespace hpx { namespace parallel { namespace execution { namespace detail {
 }}}}    // namespace hpx::parallel::execution::detail
 
 namespace hpx { namespace execution {
+
     ///////////////////////////////////////////////////////////////////////////
     /// A \a parallel_executor creates groups of parallel execution agents
     /// which execute in threads implicitly created by the executor. This
@@ -99,7 +100,7 @@ namespace hpx { namespace execution {
 
         /// Associate the static_chunk_size executor parameters type as a default
         /// with this executor.
-        using executor_parameters_type = static_chunk_size;
+        using executor_parameters_type = experimental::static_chunk_size;
 
         /// Create a new parallel executor
         constexpr explicit parallel_policy_executor(

--- a/libs/core/executors/include/hpx/executors/restricted_thread_pool_executor.hpp
+++ b/libs/core/executors/include/hpx/executors/restricted_thread_pool_executor.hpp
@@ -40,8 +40,6 @@ namespace hpx::parallel::execution {
         using execution_category =
             typename embedded_executor::execution_category;
 
-        /// Associate the static_chunk_size executor parameters type as a default
-        /// with this executor.
         using executor_parameters_type =
             typename embedded_executor::executor_parameters_type;
 

--- a/libs/core/executors/include/hpx/executors/scheduler_executor.hpp
+++ b/libs/core/executors/include/hpx/executors/scheduler_executor.hpp
@@ -31,7 +31,9 @@
 #include <hpx/functional/tag_invoke.hpp>
 #include <hpx/modules/concepts.hpp>
 #include <hpx/modules/topology.hpp>
+#include <hpx/timing/steady_clock.hpp>
 
+#include <cstddef>
 #include <exception>
 #include <string>
 #include <type_traits>
@@ -128,6 +130,19 @@ namespace hpx::execution::experimental {
         using future_type = hpx::future<T>;
 
     private:
+        friend auto tag_invoke(
+            hpx::parallel::execution::processing_units_count_t tag,
+            scheduler_executor const& exec,
+            hpx::chrono::steady_duration const& = hpx::chrono::null_duration,
+            std::size_t = 0)
+            -> decltype(std::declval<
+                hpx::parallel::execution::processing_units_count_t>()(
+                std::declval<BaseScheduler>(),
+                std::declval<hpx::chrono::steady_duration>(), 0))
+        {
+            return tag(exec.sched_);
+        }
+
         // NonBlockingOneWayExecutor interface
         template <typename F, typename... Ts>
         friend decltype(auto) tag_invoke(hpx::parallel::execution::post_t,

--- a/libs/core/executors/include/hpx/executors/sequenced_executor.hpp
+++ b/libs/core/executors/include/hpx/executors/sequenced_executor.hpp
@@ -25,6 +25,7 @@
 #include <hpx/threading_base/detail/get_default_pool.hpp>
 #include <hpx/threading_base/thread_description.hpp>
 #include <hpx/threading_base/thread_num_tss.hpp>
+#include <hpx/timing/steady_clock.hpp>
 #include <hpx/type_support/unused.hpp>
 
 #include <cstddef>
@@ -216,7 +217,9 @@ namespace hpx { namespace execution {
 
         friend constexpr std::size_t tag_invoke(
             hpx::parallel::execution::processing_units_count_t,
-            sequenced_executor const&)
+            sequenced_executor const&,
+            hpx::chrono::steady_duration const& = hpx::chrono::null_duration,
+            std::size_t = 0)
         {
             return 1;
         }

--- a/libs/core/executors/include/hpx/executors/service_executors.hpp
+++ b/libs/core/executors/include/hpx/executors/service_executors.hpp
@@ -44,7 +44,8 @@ namespace hpx { namespace parallel { namespace execution { namespace detail {
 
         // Associate the static_chunk_size executor parameters type as a
         // default with this executor.
-        using executor_parameters_type = hpx::execution::static_chunk_size;
+        using executor_parameters_type =
+            hpx::execution::experimental::static_chunk_size;
 
         explicit service_executor(hpx::util::io_service_pool* pool)
 #if defined(HPX_COMPUTE_HOST_CODE)

--- a/libs/core/executors/include/hpx/executors/thread_pool_scheduler.hpp
+++ b/libs/core/executors/include/hpx/executors/thread_pool_scheduler.hpp
@@ -23,6 +23,7 @@
 #include <hpx/modules/topology.hpp>
 #include <hpx/threading_base/annotated_function.hpp>
 #include <hpx/threading_base/register_thread.hpp>
+#include <hpx/timing/steady_clock.hpp>
 
 #include <cstddef>
 #include <exception>
@@ -110,7 +111,9 @@ namespace hpx::execution::experimental {
 
         friend constexpr std::size_t tag_invoke(
             hpx::parallel::execution::processing_units_count_t,
-            thread_pool_policy_scheduler const& scheduler)
+            thread_pool_policy_scheduler const& scheduler,
+            hpx::chrono::steady_duration const& = hpx::chrono::null_duration,
+            std::size_t = 0)
         {
             return scheduler.get_num_cores();
         }

--- a/libs/core/executors/tests/regressions/parallel_executor_1781.cpp
+++ b/libs/core/executors/tests/regressions/parallel_executor_1781.cpp
@@ -17,7 +17,7 @@ int hpx_main()
     std::vector<int> v(100);
 
     {
-        hpx::execution::static_chunk_size block(1);
+        hpx::execution::experimental::static_chunk_size block(1);
         hpx::execution::parallel_executor exec;
         hpx::ranges::for_each(
             hpx::execution::par.on(exec).with(block), v, [](int) {});

--- a/libs/core/resource_partitioner/examples/oversubscribing_resource_partitioner.cpp
+++ b/libs/core/resource_partitioner/examples/oversubscribing_resource_partitioner.cpp
@@ -145,7 +145,7 @@ int hpx_main(/*hpx::program_options::variables_map& vm*/)
     std::set<std::thread::id> thread_set;
 
     // test a parallel algorithm on custom pool with high priority
-    hpx::execution::static_chunk_size fixed(1);
+    hpx::execution::experimental::static_chunk_size fixed(1);
     hpx::experimental::for_loop_strided(
         hpx::execution::par.with(fixed).on(high_priority_executor), 0,
         loop_count, 1, [&](std::size_t i) {

--- a/libs/core/resource_partitioner/examples/simple_resource_partitioner.cpp
+++ b/libs/core/resource_partitioner/examples/simple_resource_partitioner.cpp
@@ -133,7 +133,7 @@ int hpx_main(hpx::program_options::variables_map&)
     std::set<std::thread::id> thread_set;
 
     // test a parallel algorithm on custom pool with high priority
-    hpx::execution::static_chunk_size fixed(1);
+    hpx::execution::experimental::static_chunk_size fixed(1);
     hpx::experimental::for_loop_strided(
         hpx::execution::par.with(fixed).on(high_priority_executor), 0,
         loop_count, 1, [&](std::size_t i) {

--- a/libs/core/timing/include/hpx/timing/steady_clock.hpp
+++ b/libs/core/timing/include/hpx/timing/steady_clock.hpp
@@ -22,20 +22,20 @@ namespace hpx { namespace chrono {
         typedef steady_clock::time_point value_type;
 
     public:
-        steady_time_point(value_type const& abs_time)
+        constexpr steady_time_point(value_type const& abs_time) noexcept
           : _abs_time(abs_time)
         {
         }
 
         template <typename Clock, typename Duration>
-        steady_time_point(
-            std::chrono::time_point<Clock, Duration> const& abs_time)
+        constexpr steady_time_point(
+            std::chrono::time_point<Clock, Duration> const& abs_time) noexcept
           : _abs_time(std::chrono::time_point_cast<value_type::duration>(
                 steady_clock::now() + (abs_time - Clock::now())))
         {
         }
 
-        value_type const& value() const noexcept
+        constexpr value_type const& value() const noexcept
         {
             return _abs_time;
         }
@@ -49,20 +49,26 @@ namespace hpx { namespace chrono {
         typedef steady_clock::duration value_type;
 
     public:
-        steady_duration(value_type const& rel_time)
+        constexpr steady_duration() noexcept
+          : _rel_time(0)
+        {
+        }
+
+        constexpr steady_duration(value_type const& rel_time) noexcept
           : _rel_time(rel_time)
         {
         }
 
         template <typename Rep, typename Period>
-        steady_duration(std::chrono::duration<Rep, Period> const& rel_time)
+        constexpr steady_duration(
+            std::chrono::duration<Rep, Period> const& rel_time) noexcept
           : _rel_time(std::chrono::duration_cast<value_type>(rel_time))
         {
             if (_rel_time < rel_time)
                 ++_rel_time;
         }
 
-        value_type const& value() const noexcept
+        constexpr value_type const& value() const noexcept
         {
             return _rel_time;
         }
@@ -75,4 +81,7 @@ namespace hpx { namespace chrono {
     private:
         value_type _rel_time;
     };
+
+    inline constexpr steady_duration null_duration{};
+
 }}    // namespace hpx::chrono

--- a/tests/performance/local/future_overhead.cpp
+++ b/tests/performance/local/future_overhead.cpp
@@ -226,7 +226,7 @@ void measure_function_futures_limiting_executor(
 
     // test a parallel algorithm on custom pool with high priority
     auto const chunk_size = count / (num_threads * 2);
-    hpx::execution::static_chunk_size fixed(chunk_size);
+    hpx::execution::experimental::static_chunk_size fixed(chunk_size);
 
     // start the clock
     high_resolution_timer walltime;
@@ -302,7 +302,8 @@ void measure_function_futures_for_loop(std::uint64_t count, bool csv,
     high_resolution_timer walltime;
     hpx::experimental::for_loop(
         hpx::execution::par.on(exec).with(
-            hpx::execution::static_chunk_size(1), unlimited_number_of_chunks()),
+            hpx::execution::experimental::static_chunk_size(1),
+            unlimited_number_of_chunks()),
         0, count, [](std::uint64_t) { null_function(); });
 
     // stop the clock

--- a/tests/performance/local/partitioned_vector_foreach.cpp
+++ b/tests/performance/local/partitioned_vector_foreach.cpp
@@ -81,7 +81,7 @@ int hpx_main(hpx::program_options::variables_map& vm)
     else
     {
         // create executor parameters object
-        hpx::execution::static_chunk_size cs(chunk_size);
+        hpx::execution::experimental::static_chunk_size cs(chunk_size);
 
         // retrieve reference time
         std::vector<int> ref(vector_size);


### PR DESCRIPTION
- split `get_chunk_size` CP into `measure_iteration` and modified `get_chunk_size`
- introducing a breaking change to `get_chunk_size` and `processing_units_count` customization point, those now expect the time for one iteration

The new APIs are:
```
    template <typename Target, typename F>
    hpx::chrono::steady_duration measure_iteration(
        Target&&, F&&, std::size_t num_tasks);

    template <typename Target>
    std::size_t processing_units_count(
        Target&&, hpx::chrono::steady_duration const&, std::size_t num_tasks);

    template <typename Target>
    std::size_t get_chunk_size(Target&&,
        hpx::chrono::steady_duration const&, std::size_t num_cores,
        std::size_t num_tasks);
```
This also moves all executor parameter objects to `namespace hpx::execution::experimental`. 