### PR TITLE
Modernizing modules of levels 0 to 5

### DIFF
--- a/cmake/HPX_AddConfigTest.cmake
+++ b/cmake/HPX_AddConfigTest.cmake
@@ -242,6 +242,15 @@ function(hpx_check_for_unistd_h)
 endfunction()
 
 # ##############################################################################
+function(hpx_check_for_builtin_forward_move)
+  add_hpx_config_test(
+    HPX_WITH_BUILTIN_FORWARD_MOVE
+    SOURCE cmake/tests/builtin_forward_move.cpp
+    FILE ${ARGN}
+  )
+endfunction()
+
+# ##############################################################################
 function(hpx_check_for_libfun_std_experimental_optional)
   add_hpx_config_test(
     HPX_WITH_LIBFUN_EXPERIMENTAL_OPTIONAL

--- a/cmake/HPX_PerformCxxFeatureTests.cmake
+++ b/cmake/HPX_PerformCxxFeatureTests.cmake
@@ -165,4 +165,6 @@ function(hpx_perform_cxx_feature_tests)
     )
   endif()
 
+  hpx_check_for_builtin_forward_move(DEFINITIONS HPX_HAVE_BUILTIN_FORWARD_MOVE)
+
 endfunction()

--- a/cmake/templates/config_defines_entries_for_modules.cpp.in
+++ b/cmake/templates/config_defines_entries_for_modules.cpp.in
@@ -1,4 +1,4 @@
-//  Copyright (c) 2017-2021 Hartmut Kaiser
+//  Copyright (c) 2017-2022 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -8,7 +8,7 @@
 
 #include <hpx/modules/config_registry.hpp>
 
-namespace hpx { namespace @module_name@_cfg {
+namespace hpx::@module_name@_cfg {
 
     config_registry::add_module_config_helper add_config{
     {
@@ -16,4 +16,4 @@ namespace hpx { namespace @module_name@_cfg {
         {@hpx_config_information@
         }
     }};
-}}
+}

--- a/cmake/tests/builtin_forward_move.cpp
+++ b/cmake/tests/builtin_forward_move.cpp
@@ -1,0 +1,38 @@
+//  Copyright (c) 2022 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+// test for std::move and std::forward being built in functions
+
+#if defined(_MSC_VER)
+
+#if !defined(__has_cpp_attribute)
+#define __has_cpp_attribute(x) 0
+#endif
+
+#if __has_cpp_attribute(msvc::intrinsic)
+#define MOVE_FORWARD_ARE_BUILTINS
+#endif
+
+#elif defined(__clang__) || defined(__gcc__)
+
+#if !defined(__has_builtin)
+#define __has_builtin(x) 0
+#endif
+
+#if __has_builtin(move) && __has_builtin(forward)
+#define MOVE_FORWARD_ARE_BUILTINS
+#endif
+
+#endif
+
+#if !defined(MOVE_FORWARD_ARE_BUILTINS)
+#error "std::forward and/or std::move are not implemented as built in functions"
+#endif
+
+int main()
+{
+    return 0;
+}

--- a/libs/core/algorithms/include/hpx/algorithms/traits/pointer_category.hpp
+++ b/libs/core/algorithms/include/hpx/algorithms/traits/pointer_category.hpp
@@ -103,8 +103,8 @@ namespace hpx { namespace traits {
         struct pointer_move_category<Source, Dest, false>
         {
             using type = std::conditional_t<
-                std::is_trivially_assignable<iter_ref_t<Dest>,
-                    std::remove_reference_t<iter_ref_t<Source>>>::value,
+                std::is_trivially_assignable<iter_reference_t<Dest>,
+                    std::remove_reference_t<iter_reference_t<Source>>>::value,
                 typename pointer_category_helper<iter_value_t<Source>,
                     iter_value_t<Dest>>::type,
                 general_pointer_tag>;
@@ -121,8 +121,8 @@ namespace hpx { namespace traits {
         struct pointer_copy_category<Source, Dest, false>
         {
             using type = std::conditional_t<
-                std::is_trivially_assignable<iter_ref_t<Dest>,
-                    iter_ref_t<Source>>::value,
+                std::is_trivially_assignable<iter_reference_t<Dest>,
+                    iter_reference_t<Source>>::value,
                 typename pointer_category_helper<iter_value_t<Source>,
                     iter_value_t<Dest>>::type,
                 general_pointer_tag>;

--- a/libs/core/algorithms/include/hpx/parallel/util/projection_identity.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/util/projection_identity.hpp
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <hpx/config.hpp>
+#include <hpx/type_support/identity.hpp>
 
 #include <type_traits>
 #include <utility>
@@ -15,21 +16,5 @@ namespace hpx { namespace parallel { namespace util {
     ///////////////////////////////////////////////////////////////////////////
     /// \struct projection_identity
     /// \brief this represents the projection identity
-    struct projection_identity
-    {
-        using is_transparent = std::true_type;
-
-        template <typename T>
-        HPX_HOST_DEVICE HPX_FORCEINLINE constexpr T&& operator()(
-            T&& val) const noexcept
-        {
-            return HPX_FORWARD(T, val);
-        }
-    };
+    using projection_identity = hpx::identity;
 }}}    // namespace hpx::parallel::util
-
-namespace hpx {
-
-    // C++20 introduces std::identity
-    using identity = hpx::parallel::util::projection_identity;
-}    // namespace hpx

--- a/libs/core/allocator_support/include/hpx/allocator_support/aligned_allocator.hpp
+++ b/libs/core/allocator_support/include/hpx/allocator_support/aligned_allocator.hpp
@@ -203,7 +203,9 @@ namespace hpx::util {
         using is_always_equal = std::true_type;
         using propagate_on_container_move_assignment = std::true_type;
 
-        aligned_allocator(Allocator const& alloc = Allocator{})
+        explicit aligned_allocator(
+            Allocator const& alloc = Allocator{}) noexcept(noexcept(std::
+                is_nothrow_copy_constructible_v<Allocator>))
           : alloc(alloc)
         {
         }
@@ -248,7 +250,7 @@ namespace hpx::util {
             detail::__aligned_free(alloc, p, size);
         }
 
-        size_type max_size() const noexcept
+        constexpr size_type max_size() const noexcept
         {
             return (std::numeric_limits<size_type>::max)() / sizeof(T);
         }
@@ -260,7 +262,7 @@ namespace hpx::util {
         }
 
         template <typename U>
-        void destroy(U* p)
+        void destroy(U* p) noexcept
         {
             p->~U();
         }
@@ -268,14 +270,14 @@ namespace hpx::util {
 
     template <typename T>
     constexpr bool operator==(
-        aligned_allocator<T> const&, aligned_allocator<T> const&)
+        aligned_allocator<T> const&, aligned_allocator<T> const&) noexcept
     {
         return true;
     }
 
     template <typename T>
     constexpr bool operator!=(
-        aligned_allocator<T> const&, aligned_allocator<T> const&)
+        aligned_allocator<T> const&, aligned_allocator<T> const&) noexcept
     {
         return false;
     }

--- a/libs/core/allocator_support/include/hpx/allocator_support/allocator_deleter.hpp
+++ b/libs/core/allocator_support/include/hpx/allocator_support/allocator_deleter.hpp
@@ -12,7 +12,8 @@
 
 #include <memory>
 
-namespace hpx { namespace util {
+namespace hpx::util {
+
     ///////////////////////////////////////////////////////////////////////////
     template <typename Allocator>
     struct allocator_deleter
@@ -26,4 +27,4 @@ namespace hpx { namespace util {
 
         Allocator alloc_;
     };
-}}    // namespace hpx::util
+}    // namespace hpx::util

--- a/libs/core/allocator_support/include/hpx/allocator_support/detail/new.hpp
+++ b/libs/core/allocator_support/include/hpx/allocator_support/detail/new.hpp
@@ -33,7 +33,7 @@ namespace hpx::util::functional {
     template <typename T>
     struct placement_new_one
     {
-        placement_new_one(void* p)
+        explicit constexpr placement_new_one(void* p) noexcept
           : p_(p)
         {
         }

--- a/libs/core/allocator_support/include/hpx/allocator_support/internal_allocator.hpp
+++ b/libs/core/allocator_support/include/hpx/allocator_support/internal_allocator.hpp
@@ -25,33 +25,34 @@
 
 #include <hpx/config/warnings_prefix.hpp>
 
-namespace hpx { namespace util {
+namespace hpx::util {
+
 #if defined(HPX_HAVE_JEMALLOC_PREFIX)
     ///////////////////////////////////////////////////////////////////////////
     template <typename T = int>
     struct internal_allocator
     {
-        typedef T value_type;
-        typedef T* pointer;
-        typedef const T* const_pointer;
-        typedef T& reference;
-        typedef T const& const_reference;
-        typedef std::size_t size_type;
-        typedef std::ptrdiff_t difference_type;
+        using value_type = T;
+        using pointer = T*;
+        using const_pointer = const T*;
+        using reference = T&;
+        using const_reference = T const&;
+        using size_type = std::size_t;
+        using difference_type = std::ptrdiff_t;
 
         template <typename U>
         struct rebind
         {
-            typedef internal_allocator<U> other;
+            using other = internal_allocator<U>;
         };
 
-        typedef std::true_type is_always_equal;
-        typedef std::true_type propagate_on_container_move_assignment;
+        using is_always_equal = std::true_type;
+        using propagate_on_container_move_assignment = std::true_type;
 
         internal_allocator() = default;
 
         template <typename U>
-        internal_allocator(internal_allocator<U> const&)
+        constexpr internal_allocator(internal_allocator<U> const&) noexcept
         {
         }
 
@@ -86,7 +87,7 @@ namespace hpx { namespace util {
             HPX_PP_CAT(HPX_HAVE_JEMALLOC_PREFIX, free)(p);
         }
 
-        size_type max_size() const noexcept
+        constexpr size_type max_size() const noexcept
         {
             return (std::numeric_limits<size_type>::max)() / sizeof(T);
         }
@@ -98,7 +99,7 @@ namespace hpx { namespace util {
         }
 
         template <typename U>
-        void destroy(U* p)
+        void destroy(U* p) noexcept
         {
             p->~U();
         }
@@ -106,14 +107,14 @@ namespace hpx { namespace util {
 
     template <typename T>
     constexpr bool operator==(
-        internal_allocator<T> const&, internal_allocator<T> const&)
+        internal_allocator<T> const&, internal_allocator<T> const&) noexcept
     {
         return true;
     }
 
     template <typename T>
     constexpr bool operator!=(
-        internal_allocator<T> const&, internal_allocator<T> const&)
+        internal_allocator<T> const&, internal_allocator<T> const&) noexcept
     {
         return false;
     }
@@ -122,6 +123,6 @@ namespace hpx { namespace util {
     template <typename T = int>
     using internal_allocator = std::allocator<T>;
 #endif
-}}    // namespace hpx::util
+}    // namespace hpx::util
 
 #include <hpx/config/warnings_suffix.hpp>

--- a/libs/core/allocator_support/include/hpx/allocator_support/traits/is_allocator.hpp
+++ b/libs/core/allocator_support/include/hpx/allocator_support/traits/is_allocator.hpp
@@ -15,7 +15,7 @@
 #include <type_traits>
 #include <utility>
 
-namespace hpx { namespace traits {
+namespace hpx::traits {
 
     ///////////////////////////////////////////////////////////////////////////
     namespace detail {
@@ -85,4 +85,4 @@ namespace hpx { namespace traits {
 
     template <typename T>
     inline constexpr bool is_allocator_v = is_allocator<T>::value;
-}}    // namespace hpx::traits
+}    // namespace hpx::traits

--- a/libs/core/assertion/include/hpx/assertion/current_function.hpp
+++ b/libs/core/assertion/include/hpx/assertion/current_function.hpp
@@ -14,7 +14,7 @@
 
 #include <hpx/config.hpp>
 
-namespace hpx { namespace assertion { namespace detail {
+namespace hpx::assertion::detail {
 
     constexpr inline void current_function_helper()
     {
@@ -56,4 +56,4 @@ namespace hpx { namespace assertion { namespace detail {
 #endif
     }
 
-}}}    // namespace hpx::assertion::detail
+}    // namespace hpx::assertion::detail

--- a/libs/core/assertion/include/hpx/assertion/evaluate_assert.hpp
+++ b/libs/core/assertion/include/hpx/assertion/evaluate_assert.hpp
@@ -13,9 +13,10 @@
 #include <string>
 #include <utility>
 
-namespace hpx { namespace assertion { namespace detail {
+namespace hpx::assertion::detail {
+
     /// \cond NOINTERNAL
     HPX_CORE_EXPORT void handle_assert(hpx::source_location const& loc,
         const char* expr, std::string const& msg) noexcept;
     /// \endcond
-}}}    // namespace hpx::assertion::detail
+}    // namespace hpx::assertion::detail

--- a/libs/core/assertion/include/hpx/modules/assertion.hpp
+++ b/libs/core/assertion/include/hpx/modules/assertion.hpp
@@ -25,7 +25,8 @@
 #include <string>
 #include <type_traits>
 
-namespace hpx { namespace assertion {
+namespace hpx::assertion {
+
     /// The signature for an assertion handler
     using assertion_handler = void (*)(hpx::source_location const& loc,
         const char* expr, std::string const& msg);
@@ -34,7 +35,7 @@ namespace hpx { namespace assertion {
     /// set already once, the call to this function will be ignored.
     /// \note This function is not thread safe
     HPX_CORE_EXPORT void set_assertion_handler(assertion_handler handler);
-}}    // namespace hpx::assertion
+}    // namespace hpx::assertion
 
 #if defined(DOXYGEN)
 /// \def HPX_ASSERT(expr, msg)

--- a/libs/core/config/include/hpx/config/coroutines_support.hpp
+++ b/libs/core/config/include/hpx/config/coroutines_support.hpp
@@ -13,23 +13,33 @@
 #if defined(__has_include)
 #if __has_include(<coroutine>)
 #include <coroutine>
-namespace hpx { namespace coro {
+
+namespace hpx::coro {
+
     using std::coroutine_handle;
     using std::noop_coroutine;
     using std::suspend_always;
     using std::suspend_never;
-}}    // namespace hpx::coro
+}    // namespace hpx::coro
 #define HPX_COROUTINE_NAMESPACE_STD std
+
 #elif __has_include(<experimental/coroutine>)
 #include <experimental/coroutine>
-namespace hpx { namespace coro {
+
+namespace hpx::coro {
+
     using std::experimental::coroutine_handle;
     using std::experimental::noop_coroutine;
     using std::experimental::suspend_always;
     using std::experimental::suspend_never;
-}}    // namespace hpx::coro
+}    // namespace hpx::coro
 #define HPX_COROUTINE_NAMESPACE_STD std::experimental
+
 #endif
+#endif
+
+#if !defined(HPX_COROUTINE_NAMESPACE_STD)
+#error "Platform does not support C++20 coroutines"
 #endif
 
 #endif    // HPX_HAVE_CXX20_COROUTINES

--- a/libs/core/config/include/hpx/config/detail/compat_error_code.hpp
+++ b/libs/core/config/include/hpx/config/detail/compat_error_code.hpp
@@ -34,14 +34,17 @@ namespace hpx {
             _ec = _compat;
         }
 
+        // different versions of clang-format disagree
+        // clang-format off
         operator boost::system::error_code&() noexcept
         {
             return _compat;
         }
+        // clang-format on
 
         template <typename E,
-            typename Enable = typename std::enable_if<
-                boost::system::is_error_code_enum<E>::value>::type>
+            typename Enable =
+                std::enable_if_t<boost::system::is_error_code_enum<E>::value>>
         static bool equal(std::error_code const& lhs, E rhs) noexcept
         {
             return lhs == std::error_code(make_error_code(rhs));

--- a/libs/core/config/include/hpx/config/forward.hpp
+++ b/libs/core/config/include/hpx/config/forward.hpp
@@ -6,8 +6,19 @@
 
 #pragma once
 
-#if defined(HPX_HAVE_CXX_LAMBDA_CAPTURE_DECLTYPE)
+#include <hpx/config/defines.hpp>
+
+#if defined(HPX_HAVE_BUILTIN_FORWARD_MOVE)
+#include <utility>
+
+#define HPX_FORWARD(T, ...) std::forward<T>(__VA_ARGS__)
+
+#elif defined(HPX_HAVE_CXX_LAMBDA_CAPTURE_DECLTYPE)
+
 #define HPX_FORWARD(T, ...) static_cast<decltype(__VA_ARGS__)&&>(__VA_ARGS__)
+
 #else
+
 #define HPX_FORWARD(T, ...) static_cast<T&&>(__VA_ARGS__)
+
 #endif

--- a/libs/core/config/include/hpx/config/move.hpp
+++ b/libs/core/config/include/hpx/config/move.hpp
@@ -6,7 +6,17 @@
 
 #pragma once
 
+#include <hpx/config/defines.hpp>
+
+#if defined(HPX_HAVE_BUILTIN_FORWARD_MOVE)
+#include <utility>
+
+#define HPX_MOVE(...) std::move(__VA_ARGS__)
+
+#else
 #include <type_traits>
 
 #define HPX_MOVE(...)                                                          \
     static_cast<std::remove_reference_t<decltype(__VA_ARGS__)>&&>(__VA_ARGS__)
+
+#endif

--- a/libs/core/config_registry/include/hpx/modules/config_registry.hpp
+++ b/libs/core/config_registry/include/hpx/modules/config_registry.hpp
@@ -29,7 +29,7 @@
 #define HPX_CONFIG_REGISTRY_EXPORT /* empty */
 #endif
 
-namespace hpx { namespace config_registry {
+namespace hpx::config_registry {
     struct module_config
     {
         std::string module_name;
@@ -45,4 +45,4 @@ namespace hpx { namespace config_registry {
     {
         add_module_config_helper(module_config const& config);
     };
-}}    // namespace hpx::config_registry
+}    // namespace hpx::config_registry

--- a/libs/core/config_registry/src/config_entries.cpp
+++ b/libs/core/config_registry/src/config_entries.cpp
@@ -8,9 +8,9 @@
 
 #include <hpx/modules/config_registry.hpp>
 
-namespace hpx { namespace config_registry_cfg {
+namespace hpx::config_registry_cfg {
 
     config_registry::add_module_config_helper add_config{
         {"config_registry", {}}};
 
-}}    // namespace hpx::config_registry_cfg
+}    // namespace hpx::config_registry_cfg

--- a/libs/core/config_registry/src/config_registry.cpp
+++ b/libs/core/config_registry/src/config_registry.cpp
@@ -9,8 +9,10 @@
 
 #include <vector>
 
-namespace hpx { namespace config_registry {
+namespace hpx::config_registry {
+
     namespace detail {
+
         std::vector<module_config>& get_module_configs()
         {
             static std::vector<module_config> configs;
@@ -33,4 +35,4 @@ namespace hpx { namespace config_registry {
     {
         add_module_config(config);
     }
-}}    // namespace hpx::config_registry
+}    // namespace hpx::config_registry

--- a/libs/core/debugging/include/hpx/debugging/attach_debugger.hpp
+++ b/libs/core/debugging/include/hpx/debugging/attach_debugger.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2012 Hartmut Kaiser
+//  Copyright (c) 2007-2022 Hartmut Kaiser
 //  Copyright (c) 2017      Denis Blank
 //
 //  SPDX-License-Identifier: BSL-1.0
@@ -8,10 +8,10 @@
 #pragma once
 
 #include <hpx/config.hpp>
-#include <string>
 
-namespace hpx { namespace util {
+namespace hpx::util {
+
     /// Tries to break an attached debugger, if not supported a loop is
     /// invoked which gives enough time to attach a debugger manually.
     HPX_CORE_EXPORT void attach_debugger();
-}}    // namespace hpx::util
+}    // namespace hpx::util

--- a/libs/core/debugging/include/hpx/debugging/backtrace.hpp
+++ b/libs/core/debugging/include/hpx/debugging/backtrace.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2013 Hartmut Kaiser
+//  Copyright (c) 2007-2022 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -15,7 +15,8 @@
 #include <cstddef>
 #include <string>
 
-namespace hpx { namespace util {
+namespace hpx::util {
+
     class backtrace
     {
     };
@@ -25,6 +26,6 @@ namespace hpx { namespace util {
     {
         return "";
     }
-}}    // namespace hpx::util
+}    // namespace hpx::util
 
 #endif

--- a/libs/core/debugging/include/hpx/debugging/backtrace/backtrace.hpp
+++ b/libs/core/debugging/include/hpx/debugging/backtrace/backtrace.hpp
@@ -1,6 +1,6 @@
 //
 //  Copyright (c) 2011 Bryce Lelbach
-//  Copyright (c) 2011-2012 Hartmut Kaiser
+//  Copyright (c) 2011-2022 Hartmut Kaiser
 //  Copyright (c) 2010 Artyom Beilis (Tonkikh)
 //
 //  SPDX-License-Identifier: BSL-1.0
@@ -18,8 +18,10 @@
 #include <vector>
 
 ///////////////////////////////////////////////////////////////////////////////
-namespace hpx { namespace util {
+namespace hpx::util {
+
     namespace stack_trace {
+
         HPX_CORE_EXPORT std::size_t trace(void** addresses, std::size_t size);
         HPX_CORE_EXPORT void write_symbols(
             void* const* addresses, std::size_t size, std::ostream&);
@@ -43,14 +45,14 @@ namespace hpx { namespace util {
                 frames_.resize(size);
         }
 
-        virtual ~backtrace() noexcept {}
+        virtual ~backtrace() = default;
 
-        std::size_t stack_size() const
+        std::size_t stack_size() const noexcept
         {
             return frames_.size();
         }
 
-        void* return_address(std::size_t frame_no) const
+        void* return_address(std::size_t frame_no) const noexcept
         {
             if (frame_no < stack_size())
                 return frames_[frame_no];
@@ -89,10 +91,11 @@ namespace hpx { namespace util {
     };
 
     namespace details {
+
         class trace_manip
         {
         public:
-            trace_manip(backtrace const* tr)
+            explicit constexpr trace_manip(backtrace const* tr) noexcept
               : tr_(tr)
             {
             }
@@ -126,4 +129,4 @@ namespace hpx { namespace util {
     {
         return backtrace(frames_no).trace();
     }
-}}    // namespace hpx::util
+}    // namespace hpx::util

--- a/libs/core/debugging/include/hpx/debugging/demangle_helper.hpp
+++ b/libs/core/debugging/include/hpx/debugging/demangle_helper.hpp
@@ -1,5 +1,5 @@
 //  Copyright (c) 2017 John Biddiscombe
-//  Copyright (c) 2007-2012 Hartmut Kaiser
+//  Copyright (c) 2007-2022 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -16,7 +16,8 @@
 // --------------------------------------------------------------------
 // Always present regardless of compiler : used by serialization code
 // --------------------------------------------------------------------
-namespace hpx { namespace util { namespace debug {
+namespace hpx::util::debug {
+
     template <typename T>
     struct demangle_helper
     {
@@ -25,18 +26,20 @@ namespace hpx { namespace util { namespace debug {
             return typeid(T).name();
         }
     };
-}}}    // namespace hpx::util::debug
+}    // namespace hpx::util::debug
 
 #if defined(__GNUG__)
 
+#include <cstdlib>
 #include <cxxabi.h>
+
 #include <memory>
-#include <stdlib.h>
 
 // --------------------------------------------------------------------
 // if available : demangle an arbitrary c++ type using gnu utility
 // --------------------------------------------------------------------
-namespace hpx { namespace util { namespace debug {
+namespace hpx::util::debug {
+
     template <typename T>
     class cxxabi_demangle_helper
     {
@@ -56,20 +59,21 @@ namespace hpx { namespace util { namespace debug {
     private:
         std::unique_ptr<char, void (*)(void*)> demangled_;
     };
-
-}}}    // namespace hpx::util::debug
+}    // namespace hpx::util::debug
 
 #else
 
-namespace hpx { namespace util { namespace debug {
+namespace hpx::util::debug {
+
     template <typename T>
     using cxxabi_demangle_helper = demangle_helper<T>;
-}}}    // namespace hpx::util::debug
+}    // namespace hpx::util::debug
 
 #endif
 
 ///////////////////////////////////////////////////////////////////////////////
-namespace hpx { namespace util { namespace debug {
+namespace hpx::util::debug {
+
     template <typename T>
     struct type_id
     {
@@ -112,10 +116,10 @@ namespace hpx { namespace util { namespace debug {
     }
 
     template <typename T, typename... Args>
-    inline typename std::enable_if<sizeof...(Args) != 0, std::string>::type
-    print_type(const char* delim = "")
+    inline std::enable_if_t<sizeof...(Args) != 0, std::string> print_type(
+        const char* delim = "")
     {
         std::string temp(cxx_type_id<T>::typeid_.type_id());
         return temp + delim + print_type<Args...>(delim);
     }
-}}}    // namespace hpx::util::debug
+}    // namespace hpx::util::debug

--- a/libs/core/debugging/include/hpx/debugging/print.hpp
+++ b/libs/core/debugging/include/hpx/debugging/print.hpp
@@ -59,7 +59,7 @@
 
 // ------------------------------------------------------------
 /// \cond NODETAIL
-namespace hpx { namespace debug {
+namespace hpx::debug {
 
     // ------------------------------------------------------------------
     // format as zero padded int
@@ -72,7 +72,7 @@ namespace hpx { namespace debug {
         template <int N, typename T>
         struct dec
         {
-            constexpr dec(T const& v)
+            explicit constexpr dec(T const& v) noexcept
               : data_(v)
             {
             }
@@ -89,7 +89,7 @@ namespace hpx { namespace debug {
     }    // namespace detail
 
     template <int N = 2, typename T>
-    constexpr detail::dec<N, T> dec(T const& v)
+    constexpr detail::dec<N, T> dec(T const& v) noexcept
     {
         return detail::dec<N, T>(v);
     }
@@ -99,8 +99,8 @@ namespace hpx { namespace debug {
     // ------------------------------------------------------------------
     struct ptr
     {
-        HPX_CORE_EXPORT ptr(void const* v);
-        HPX_CORE_EXPORT ptr(std::uintptr_t v);
+        HPX_CORE_EXPORT explicit ptr(void const* v) noexcept;
+        HPX_CORE_EXPORT explicit ptr(std::uintptr_t v) noexcept;
 
         void const* data_;
 
@@ -120,10 +120,9 @@ namespace hpx { namespace debug {
         struct hex;
 
         template <int N, typename T>
-        struct hex<N, T,
-            typename std::enable_if<!std::is_pointer<T>::value>::type>
+        struct hex<N, T, std::enable_if_t<!std::is_pointer_v<T>>>
         {
-            constexpr hex(T const& v)
+            explicit constexpr hex(T const& v) noexcept
               : data_(v)
             {
             }
@@ -141,10 +140,9 @@ namespace hpx { namespace debug {
         HPX_CORE_EXPORT void print_ptr(std::ostream& os, void* v, int n);
 
         template <int N, typename T>
-        struct hex<N, T,
-            typename std::enable_if<std::is_pointer<T>::value>::type>
+        struct hex<N, T, std::enable_if_t<std::is_pointer_v<T>>>
         {
-            constexpr hex(T const& v)
+            explicit constexpr hex(T const& v) noexcept
               : data_(v)
             {
             }
@@ -161,7 +159,7 @@ namespace hpx { namespace debug {
     }    // namespace detail
 
     template <int N = 4, typename T>
-    constexpr detail::hex<N, T> hex(T const& v)
+    constexpr detail::hex<N, T> hex(T const& v) noexcept
     {
         return detail::hex<N, T>(v);
     }
@@ -177,7 +175,7 @@ namespace hpx { namespace debug {
         template <int N = 8, typename T = int>
         struct bin
         {
-            constexpr bin(T const& v)
+            explicit constexpr bin(T const& v) noexcept
               : data_(v)
             {
             }
@@ -194,7 +192,7 @@ namespace hpx { namespace debug {
     }    // namespace detail
 
     template <int N = 8, typename T>
-    constexpr detail::bin<N, T> bin(T const& v)
+    constexpr detail::bin<N, T> bin(T const& v) noexcept
     {
         return detail::bin<N, T>(v);
     }
@@ -210,7 +208,7 @@ namespace hpx { namespace debug {
     template <int N = 20>
     struct str
     {
-        constexpr str(char const* v)
+        explicit constexpr str(char const* v) noexcept
           : data_(v)
         {
         }
@@ -229,8 +227,8 @@ namespace hpx { namespace debug {
     // ------------------------------------------------------------------
     struct ipaddr
     {
-        HPX_CORE_EXPORT ipaddr(void const* a);
-        HPX_CORE_EXPORT ipaddr(std::uint32_t a);
+        HPX_CORE_EXPORT explicit ipaddr(void const* a) noexcept;
+        HPX_CORE_EXPORT explicit ipaddr(std::uint32_t a) noexcept;
 
         std::uint8_t const* data_;
         std::uint32_t const ipdata_;
@@ -243,6 +241,7 @@ namespace hpx { namespace debug {
     // helper class for printing time since start
     // ------------------------------------------------------------------
     namespace detail {
+
         struct current_time_print_helper
         {
             HPX_CORE_EXPORT friend std::ostream& operator<<(
@@ -253,7 +252,7 @@ namespace hpx { namespace debug {
     // ------------------------------------------------------------------
     // helper function for printing CRC32
     // ------------------------------------------------------------------
-    constexpr inline std::uint32_t crc32(void const*, std::size_t)
+    constexpr inline std::uint32_t crc32(void const*, std::size_t) noexcept
     {
         return 0;
     }
@@ -266,7 +265,7 @@ namespace hpx { namespace debug {
     struct mem_crc32
     {
         HPX_CORE_EXPORT mem_crc32(
-            void const* a, std::size_t len, char const* txt);
+            void const* a, std::size_t len, char const* txt) noexcept;
 
         std::uint64_t const* addr_;
         std::size_t const len_;
@@ -433,85 +432,89 @@ namespace hpx { namespace debug {
     template <>
     struct enable_print<false>
     {
-        constexpr enable_print(const char*) {}
+        explicit constexpr enable_print(const char*) noexcept {}
 
-        constexpr bool is_enabled() const
+        constexpr bool is_enabled() const noexcept
         {
             return false;
         }
 
         template <typename... Args>
-        constexpr void debug(Args const&...) const
+        constexpr void debug(Args const&...) const noexcept
         {
         }
 
         template <typename... Args>
-        constexpr void warning(Args const&...) const
+        constexpr void warning(Args const&...) const noexcept
         {
         }
 
         template <typename... Args>
-        constexpr void trace(Args const&...) const
+        constexpr void trace(Args const&...) const noexcept
         {
         }
 
         template <typename... Args>
-        constexpr void error(Args const&...) const
+        constexpr void error(Args const&...) const noexcept
         {
         }
 
         template <typename... Args>
-        constexpr void timed(Args const&...) const
+        constexpr void timed(Args const&...) const noexcept
         {
         }
 
         template <typename T>
-        constexpr void array(std::string const&, std::vector<T> const&) const
+        constexpr void array(
+            std::string const&, std::vector<T> const&) const noexcept
         {
         }
 
         template <typename T, std::size_t N>
-        constexpr void array(std::string const&, std::array<T, N> const&) const
+        constexpr void array(
+            std::string const&, std::array<T, N> const&) const noexcept
         {
         }
 
         template <typename T>
-        constexpr void array(std::string const&, T const*, std::size_t) const
+        constexpr void array(
+            std::string const&, T const*, std::size_t) const noexcept
         {
         }
 
         template <typename... Args>
-        constexpr bool scope(Args const&...)
+        constexpr bool scope(Args const&...) noexcept
         {
             return true;
         }
 
         template <typename T, typename... Args>
-        constexpr bool declare_variable(Args const&...) const
+        constexpr bool declare_variable(Args const&...) const noexcept
         {
             return true;
         }
 
         template <typename T, typename V>
-        constexpr void set(T&, V const&)
+        constexpr void set(T&, V const&) noexcept
         {
         }
 
         // @todo, return void so that timers have zero footprint when disabled
         template <typename... Args>
-        constexpr int make_timer(const double, Args const&...) const
+        constexpr int make_timer(const double, Args const&...) const noexcept
         {
             return 0;
         }
 
         template <typename Expr>
-        constexpr bool eval(Expr const&)
+        constexpr bool eval(Expr const&) noexcept
         {
             return true;
         }
     };
 
     namespace detail {
+
         template <typename T>
         HPX_CORE_EXPORT void print_array(
             std::string const& name, T const* data, std::size_t size);
@@ -525,17 +528,17 @@ namespace hpx { namespace debug {
         char const* prefix_;
 
     public:
-        constexpr enable_print()
+        constexpr enable_print() noexcept
           : prefix_("")
         {
         }
 
-        constexpr enable_print(const char* p)
+        explicit constexpr enable_print(const char* p) noexcept
           : prefix_(p)
         {
         }
 
-        constexpr bool is_enabled() const
+        constexpr bool is_enabled() const noexcept
         {
             return true;
         }
@@ -624,6 +627,5 @@ namespace hpx { namespace debug {
             return e();
         }
     };
-
-}}    // namespace hpx::debug
+}    // namespace hpx::debug
 /// \endcond

--- a/libs/core/debugging/src/attach_debugger.cpp
+++ b/libs/core/debugging/src/attach_debugger.cpp
@@ -16,13 +16,14 @@
 
 #if defined(HPX_WINDOWS)
 #include <Windows.h>
-#endif    // HPX_WINDOWS
+#endif
 
 #if defined(_POSIX_VERSION)
 #include <asio/ip/host_name.hpp>
 #endif
 
-namespace hpx { namespace util {
+namespace hpx::util {
+
     void attach_debugger()
     {
 #if defined(_POSIX_VERSION) && defined(HPX_HAVE_UNISTD_H)
@@ -39,4 +40,4 @@ namespace hpx { namespace util {
         DebugBreak();
 #endif
     }
-}}    // namespace hpx::util
+}    // namespace hpx::util

--- a/libs/core/debugging/src/backtrace.cpp
+++ b/libs/core/debugging/src/backtrace.cpp
@@ -1,6 +1,6 @@
 //
 //  Copyright (c) 2011 Bryce Lelbach
-//  Copyright (c) 2011-2012 Hartmut Kaiser
+//  Copyright (c) 2011-2022 Hartmut Kaiser
 //  Copyright (c) 2010 Artyom Beilis (Tonkikh)
 //
 //  SPDX-License-Identifier: BSL-1.0
@@ -64,11 +64,12 @@
 #include <winbase.h>
 #endif
 
-namespace hpx { namespace util { namespace stack_trace {
+namespace hpx::util::stack_trace {
+
 #if defined(HPX_HAVE_EXECINFO) && defined(HPX_HAVE_UNWIND)
     struct trace_data
     {
-        trace_data(void** array, std::size_t size)
+        constexpr trace_data(void** array, std::size_t size) noexcept
           : array_(array)
           , size_(size)
           , cfa_(0)
@@ -267,6 +268,7 @@ namespace hpx { namespace util { namespace stack_trace {
         }
         return res;
     }
+
     void write_symbols(
         void* const* addresses, std::size_t size, std::ostream& out)
     {
@@ -346,6 +348,7 @@ namespace hpx { namespace util { namespace stack_trace {
 #elif defined(HPX_MSVC)
 
     namespace {
+
         HANDLE hProcess = nullptr;
         bool syms_ready = false;
 
@@ -480,6 +483,6 @@ namespace hpx { namespace util { namespace stack_trace {
     }
 
 #endif
-}}}    // namespace hpx::util::stack_trace
+}    // namespace hpx::util::stack_trace
 
 #endif

--- a/libs/core/debugging/src/print.cpp
+++ b/libs/core/debugging/src/print.cpp
@@ -34,7 +34,7 @@ HPX_CORE_EXPORT char** freebsd_environ = nullptr;
 
 // ------------------------------------------------------------
 /// \cond NODETAIL
-namespace hpx { namespace debug {
+namespace hpx::debug {
 
     // ------------------------------------------------------------------
     // format as zero padded int
@@ -66,12 +66,12 @@ namespace hpx { namespace debug {
     // ------------------------------------------------------------------
     // format as pointer
     // ------------------------------------------------------------------
-    ptr::ptr(void const* v)
+    ptr::ptr(void const* v) noexcept
       : data_(v)
     {
     }
 
-    ptr::ptr(std::uintptr_t v)
+    ptr::ptr(std::uintptr_t v) noexcept
       : data_(reinterpret_cast<void const*>(v))
     {
     }
@@ -140,6 +140,7 @@ namespace hpx { namespace debug {
     // format as padded string
     // ------------------------------------------------------------------
     namespace detail {
+
         void print_str(std::ostream& os, char const* v, int N)
         {
             os << std::left << std::setfill(' ') << std::setw(N) << v;
@@ -149,13 +150,13 @@ namespace hpx { namespace debug {
     // ------------------------------------------------------------------
     // format as ip address
     // ------------------------------------------------------------------
-    ipaddr::ipaddr(void const* a)
+    ipaddr::ipaddr(void const* a) noexcept
       : data_(reinterpret_cast<std::uint8_t const*>(a))
       , ipdata_(0)
     {
     }
 
-    ipaddr::ipaddr(std::uint32_t a)
+    ipaddr::ipaddr(std::uint32_t a) noexcept
       : data_(reinterpret_cast<const uint8_t*>(&ipdata_))
       , ipdata_(a)
     {
@@ -172,6 +173,7 @@ namespace hpx { namespace debug {
     // helper class for printing time since start
     // ------------------------------------------------------------------
     namespace detail {
+
         std::ostream& operator<<(
             std::ostream& os, current_time_print_helper const&)
         {
@@ -214,7 +216,8 @@ namespace hpx { namespace debug {
     // useful for debugging corruptions in buffers during
     // rma or other transfers
     // ------------------------------------------------------------------
-    mem_crc32::mem_crc32(void const* a, std::size_t len, char const* txt)
+    mem_crc32::mem_crc32(
+        void const* a, std::size_t len, char const* txt) noexcept
       : addr_(reinterpret_cast<const uint64_t*>(a))
       , len_(len)
       , txt_(txt)
@@ -255,8 +258,12 @@ namespace hpx { namespace debug {
 #if !defined(__FreeBSD__)
                 gethostname(hostname_, std::size_t(12));
 #endif
-                std::string temp = "(" + std::to_string(guess_rank()) + ")";
-                std::strcat(hostname_, temp.c_str());
+                int rank = guess_rank();
+                if (rank != -1)
+                {
+                    std::string temp = "(" + std::to_string(guess_rank()) + ")";
+                    std::strcat(hostname_, temp.c_str());
+                }
             }
             return hostname_;
         }
@@ -269,7 +276,7 @@ namespace hpx { namespace debug {
             char** env = environ;
 #endif
             std::vector<std::string> env_strings{"_RANK=", "_NODEID="};
-            for (char** current = env; *current; current++)
+            for (char** current = env; *current; ++current)
             {
                 auto e = std::string(*current);
                 for (auto s : env_strings)
@@ -307,5 +314,5 @@ namespace hpx { namespace debug {
         template HPX_CORE_EXPORT void print_array(
             std::string const&, std::uint64_t const*, std::size_t);
     }    // namespace detail
-}}       // namespace hpx::debug
+}    // namespace hpx::debug
 /// \endcond

--- a/libs/core/execution/include/hpx/execution/traits/future_then_result_exec.hpp
+++ b/libs/core/execution/include/hpx/execution/traits/future_then_result_exec.hpp
@@ -44,7 +44,7 @@ namespace hpx { namespace traits {
             using result_type = util::lazy_conditional_t<
                 hpx::traits::detail::is_unique_future_v<cont_result>,
                 hpx::traits::future_traits<cont_result>,
-                hpx::util::identity<cont_result>>;
+                hpx::type_identity<cont_result>>;
 
             using type = hpx::future<result_type>;
         };

--- a/libs/core/filesystem/include/hpx/modules/filesystem.hpp
+++ b/libs/core/filesystem/include/hpx/modules/filesystem.hpp
@@ -23,7 +23,8 @@
 #include <string>
 #include <system_error>
 
-namespace hpx { namespace filesystem {
+namespace hpx::filesystem {
+
     using namespace std::filesystem;
     using std::filesystem::canonical;
 
@@ -61,8 +62,7 @@ namespace hpx { namespace filesystem {
             return canonical(p, ec);
         }
     }
-
-}}    // namespace hpx::filesystem
+}    // namespace hpx::filesystem
 #else
 #include <hpx/config/detail/compat_error_code.hpp>
 
@@ -74,7 +74,8 @@ static_assert(BOOST_FILESYSTEM_VERSION == 3,
     "HPX requires Boost.Filesystem version 3 (or support for the C++17 "
     "filesystem library)");
 
-namespace hpx { namespace filesystem {
+namespace hpx::filesystem {
+
     using namespace boost::filesystem;
 
     using boost::filesystem::canonical;
@@ -94,6 +95,5 @@ namespace hpx { namespace filesystem {
     {
         return is_regular_file(p, compat_error_code(ec));
     }
-
-}}    // namespace hpx::filesystem
+}    // namespace hpx::filesystem
 #endif

--- a/libs/core/format/include/hpx/util/bad_lexical_cast.hpp
+++ b/libs/core/format/include/hpx/util/bad_lexical_cast.hpp
@@ -12,7 +12,7 @@
 
 #include <hpx/config/warnings_prefix.hpp>
 
-namespace hpx { namespace util {
+namespace hpx::util {
 
     class HPX_CORE_EXPORT bad_lexical_cast : public std::bad_cast
     {
@@ -61,7 +61,6 @@ namespace hpx { namespace util {
             detail::throw_bad_lexical_cast(typeid(Source), typeid(Target));
         }
     }    // namespace detail
-
-}}    // namespace hpx::util
+}    // namespace hpx::util
 
 #include <hpx/config/warnings_suffix.hpp>

--- a/libs/core/format/include/hpx/util/from_string.hpp
+++ b/libs/core/format/include/hpx/util/from_string.hpp
@@ -19,9 +19,10 @@
 #include <type_traits>
 #include <utility>
 
-namespace hpx { namespace util {
+namespace hpx::util {
 
     namespace detail {
+
         template <typename T, typename Enable = void>
         struct from_string
         {
@@ -228,5 +229,4 @@ namespace hpx { namespace util {
             return HPX_FORWARD(U, default_value);
         }
     }
-
-}}    // namespace hpx::util
+}    // namespace hpx::util

--- a/libs/core/format/include/hpx/util/to_string.hpp
+++ b/libs/core/format/include/hpx/util/to_string.hpp
@@ -13,9 +13,10 @@
 #include <string>
 #include <type_traits>
 
-namespace hpx { namespace util {
+namespace hpx::util {
 
     namespace detail {
+
         template <typename T, typename Enable = void>
         struct to_string
         {
@@ -27,8 +28,8 @@ namespace hpx { namespace util {
 
         template <typename T>
         struct to_string<T,
-            typename std::enable_if<std::is_integral<T>::value ||
-                std::is_floating_point<T>::value>::type>
+            std::enable_if_t<std::is_integral_v<T> ||
+                std::is_floating_point_v<T>>>
         {
             static std::string call(T const& value)
             {
@@ -49,5 +50,4 @@ namespace hpx { namespace util {
             return detail::throw_bad_lexical_cast<T, std::string>();
         }
     }
-
-}}    // namespace hpx::util
+}    // namespace hpx::util

--- a/libs/core/format/src/format.cpp
+++ b/libs/core/format/src/format.cpp
@@ -20,7 +20,8 @@
 #include <string>
 #include <string_view>
 
-namespace hpx { namespace util { namespace detail {
+namespace hpx::util::detail {
+
     ///////////////////////////////////////////////////////////////////////////
     inline std::size_t format_atoi(
         std::string_view str, std::size_t* pos = nullptr) noexcept
@@ -122,4 +123,4 @@ namespace hpx { namespace util { namespace detail {
         detail::format_to(os, format_str, args, count);
         return os.str();
     }
-}}}    // namespace hpx::util::detail
+}    // namespace hpx::util::detail

--- a/libs/core/format/src/util/bad_lexical_cast.cpp
+++ b/libs/core/format/src/util/bad_lexical_cast.cpp
@@ -8,22 +8,22 @@
 
 #include <typeinfo>
 
-namespace hpx { namespace util {
+namespace hpx::util {
 
     const char* bad_lexical_cast::what() const noexcept
     {
-        return "bad lexical cast: "
-               "source type value could not be interpreted as target";
+        return "bad lexical cast: source type value could not be interpreted "
+               "as target";
     }
 
     bad_lexical_cast::~bad_lexical_cast() noexcept = default;
 
     namespace detail {
+
         void throw_bad_lexical_cast(std::type_info const& source_type,
             std::type_info const& target_type)
         {
             throw bad_lexical_cast(source_type, target_type);
         }
     }    // namespace detail
-
-}}    // namespace hpx::util
+}    // namespace hpx::util

--- a/libs/core/futures/include/hpx/futures/traits/future_then_result.hpp
+++ b/libs/core/futures/include/hpx/futures/traits/future_then_result.hpp
@@ -56,7 +56,7 @@ namespace hpx { namespace traits {
             using result_type = util::lazy_conditional_t<
                 hpx::traits::detail::is_unique_future<cont_result>::value,
                 hpx::traits::future_traits<cont_result>,
-                hpx::util::identity<cont_result>>;
+                hpx::type_identity<cont_result>>;
 
             using type = hpx::future<result_type>;
         };

--- a/libs/core/hardware/include/hpx/hardware/timestamp/bgq.hpp
+++ b/libs/core/hardware/include/hpx/hardware/timestamp/bgq.hpp
@@ -23,7 +23,7 @@
 #include <hpx/hardware/timestamp/cuda.hpp>
 #endif
 
-namespace hpx { namespace util { namespace hardware {
+namespace hpx::util::hardware {
 
     HPX_HOST_DEVICE inline std::uint64_t timestamp()
     {
@@ -33,7 +33,6 @@ namespace hpx { namespace util { namespace hardware {
         return GetTimeBase();
 #endif
     }
-
-}}}    // namespace hpx::util::hardware
+}    // namespace hpx::util::hardware
 
 #endif

--- a/libs/core/hardware/include/hpx/hardware/timestamp/cuda.hpp
+++ b/libs/core/hardware/include/hpx/hardware/timestamp/cuda.hpp
@@ -12,7 +12,7 @@
 
 #include <cstdint>
 
-namespace hpx { namespace util { namespace hardware {
+namespace hpx::util::hardware {
 
     HPX_DEVICE inline std::uint64_t timestamp_cuda()
     {
@@ -20,5 +20,4 @@ namespace hpx { namespace util { namespace hardware {
         asm volatile("mov.u64 %0, %%globaltimer;" : "=l"(cur));
         return cur;
     }
-
-}}}    // namespace hpx::util::hardware
+}    // namespace hpx::util::hardware

--- a/libs/core/hardware/include/hpx/hardware/timestamp/linux_generic.hpp
+++ b/libs/core/hardware/include/hpx/hardware/timestamp/linux_generic.hpp
@@ -18,7 +18,7 @@
 #include <hpx/hardware/timestamp/cuda.hpp>
 #endif
 
-namespace hpx { namespace util { namespace hardware {
+namespace hpx::util::hardware {
 
     HPX_HOST_DEVICE inline std::uint64_t timestamp()
     {
@@ -30,5 +30,4 @@ namespace hpx { namespace util { namespace hardware {
         return 1000 * res.tv_sec + res.tv_nsec / 1000000;
 #endif
     }
-
-}}}    // namespace hpx::util::hardware
+}    // namespace hpx::util::hardware

--- a/libs/core/hardware/include/hpx/hardware/timestamp/linux_riscv_64.hpp
+++ b/libs/core/hardware/include/hpx/hardware/timestamp/linux_riscv_64.hpp
@@ -12,7 +12,7 @@
 
 #include <cstdint>
 
-namespace hpx { namespace util { namespace hardware {
+namespace hpx::util::hardware {
 
     // clang-format off
     HPX_HOST_DEVICE inline std::uint64_t timestamp()
@@ -25,5 +25,4 @@ namespace hpx { namespace util { namespace hardware {
         return val;
     }
     // clang-format on
-
-}}}    // namespace hpx::util::hardware
+}    // namespace hpx::util::hardware

--- a/libs/core/hardware/include/hpx/hardware/timestamp/linux_x86_32.hpp
+++ b/libs/core/hardware/include/hpx/hardware/timestamp/linux_x86_32.hpp
@@ -16,7 +16,7 @@
 #include <hpx/hardware/timestamp/cuda.hpp>
 #endif
 
-namespace hpx { namespace util { namespace hardware {
+namespace hpx::util::hardware {
 
     // clang-format off
     HPX_HOST_DEVICE inline std::uint64_t timestamp()
@@ -26,27 +26,26 @@ namespace hpx { namespace util { namespace hardware {
 #else
         std::uint64_t r = 0;
 
-        #if defined(HPX_HAVE_RDTSCP)
-            __asm__ __volatile__(
-                "rdtscp ;\n"
-                : "=A"(r)
-                :
-                : "%ecx");
-        #elif defined(HPX_HAVE_RDTSC)
-            __asm__ __volatile__(
-                "movl %%ebx, %%edi ;\n"
-                "xorl %%eax, %%eax ;\n"
-                "cpuid ;\n"
-                "rdtsc ;\n"
-                "movl %%edi, %%ebx ;\n"
-                : "=A"(r)
-                :
-                : "%edi", "%ecx");
-        #endif
+#if defined(HPX_HAVE_RDTSCP)
+        __asm__ __volatile__(
+            "rdtscp ;\n"
+            : "=A"(r)
+            :
+            : "%ecx");
+#elif defined(HPX_HAVE_RDTSC)
+        __asm__ __volatile__(
+            "movl %%ebx, %%edi ;\n"
+            "xorl %%eax, %%eax ;\n"
+            "cpuid ;\n"
+            "rdtsc ;\n"
+            "movl %%edi, %%ebx ;\n"
+            : "=A"(r)
+            :
+            : "%edi", "%ecx");
+#endif
 
         return r;
 #endif
     }
     // clang-format on
-
-}}}    // namespace hpx::util::hardware
+}    // namespace hpx::util::hardware

--- a/libs/core/hardware/include/hpx/hardware/timestamp/linux_x86_64.hpp
+++ b/libs/core/hardware/include/hpx/hardware/timestamp/linux_x86_64.hpp
@@ -16,7 +16,7 @@
 #include <hpx/hardware/timestamp/cuda.hpp>
 #endif
 
-namespace hpx { namespace util { namespace hardware {
+namespace hpx::util::hardware {
 
     // clang-format off
     HPX_HOST_DEVICE inline std::uint64_t timestamp()
@@ -25,23 +25,24 @@ namespace hpx { namespace util { namespace hardware {
         return timestamp_cuda();
 #else
         std::uint32_t lo = 0, hi = 0;
-        #if defined(HPX_HAVE_RDTSCP)
-            __asm__ __volatile__(
-                "rdtscp ;\n"
-                : "=a"(lo), "=d"(hi)
-                :
-                : "rcx");
-        #elif defined(HPX_HAVE_RDTSC)
-            __asm__ __volatile__(
-                "cpuid ;\n"
-                "rdtsc ;\n"
-                : "=a"(lo), "=d"(hi)
-                :
-                : "rbx", "rcx");
-        #endif
+
+#if defined(HPX_HAVE_RDTSCP)
+        __asm__ __volatile__(
+            "rdtscp ;\n"
+            : "=a"(lo), "=d"(hi)
+            :
+            : "rcx");
+#elif defined(HPX_HAVE_RDTSC)
+        __asm__ __volatile__(
+            "cpuid ;\n"
+            "rdtsc ;\n"
+            : "=a"(lo), "=d"(hi)
+            :
+            : "rbx", "rcx");
+#endif
+
         return ((static_cast<std::uint64_t>(hi)) << 32) | lo;
 #endif
     }
     // clang-format on
-
-}}}    // namespace hpx::util::hardware
+}    // namespace hpx::util::hardware

--- a/libs/core/hardware/include/hpx/hardware/timestamp/msvc.hpp
+++ b/libs/core/hardware/include/hpx/hardware/timestamp/msvc.hpp
@@ -21,7 +21,8 @@
 #include <hpx/hardware/timestamp/cuda.hpp>
 #endif
 
-namespace hpx { namespace util { namespace hardware {
+namespace hpx::util::hardware {
+
     HPX_HOST_DEVICE inline std::uint64_t timestamp()
     {
 #if defined(HPX_HAVE_CUDA) && defined(HPX_COMPUTE_DEVICE_CODE)
@@ -32,6 +33,6 @@ namespace hpx { namespace util { namespace hardware {
         return static_cast<std::uint64_t>(now.QuadPart);
 #endif
     }
-}}}    // namespace hpx::util::hardware
+}    // namespace hpx::util::hardware
 
 #endif

--- a/libs/core/init_runtime_local/src/init_logging.cpp
+++ b/libs/core/init_runtime_local/src/init_logging.cpp
@@ -220,27 +220,27 @@ namespace hpx { namespace util {
         switch (dest_)
         {
         default:
-        case destination_hpx:
+        case logging_destination::hpx:
             LHPX_CONSOLE_(level_) << msg;
             break;
 
-        case destination_timing:
+        case logging_destination::timing:
             LTIM_CONSOLE_(level_) << msg;
             break;
 
-        case destination_agas:
+        case logging_destination::agas:
             LAGAS_CONSOLE_(level_) << msg;
             break;
 
-        case destination_parcel:
+        case logging_destination::parcel:
             LPT_CONSOLE_(level_) << msg;
             break;
 
-        case destination_app:
+        case logging_destination::app:
             LAPP_CONSOLE_(level_) << msg;
             break;
 
-        case destination_debuglog:
+        case logging_destination::debuglog:
             LDEB_CONSOLE_ << msg;
             break;
         }
@@ -360,8 +360,8 @@ namespace hpx { namespace util {
                 if (logformat.empty())
                     logformat = "|\\n";
 
-                set_console_dest(
-                    writer, "console", lvl, destination_agas);    //-V106
+                set_console_dest(writer, "console", lvl,
+                    logging_destination::agas);    //-V106
                 writer.write(logformat, logdest);
                 define_formatters(writer);
 
@@ -410,8 +410,8 @@ namespace hpx { namespace util {
                 if (logformat.empty())
                     logformat = "|\\n";
 
-                set_console_dest(
-                    writer, "console", lvl, destination_parcel);    //-V106
+                set_console_dest(writer, "console", lvl,
+                    logging_destination::parcel);    //-V106
                 writer.write(logformat, logdest);
                 define_formatters(writer);
 
@@ -461,8 +461,8 @@ namespace hpx { namespace util {
                 if (logformat.empty())
                     logformat = "|\\n";
 
-                set_console_dest(
-                    writer, "console", lvl, destination_timing);    //-V106
+                set_console_dest(writer, "console", lvl,
+                    logging_destination::timing);    //-V106
                 writer.write(logformat, logdest);
                 define_formatters(writer);
 
@@ -512,8 +512,8 @@ namespace hpx { namespace util {
 
             if (hpx::util::logging::level::disable_all != lvl)
             {
-                set_console_dest(
-                    writer, "console", lvl, destination_hpx);    //-V106
+                set_console_dest(writer, "console", lvl,
+                    logging_destination::hpx);    //-V106
                 writer.write(logformat, logdest);
                 define_formatters(writer);
 
@@ -521,8 +521,8 @@ namespace hpx { namespace util {
                 hpx_logger()->set_enabled(lvl);
 
                 // errors are logged to the given destination and to cerr
-                set_console_dest(
-                    error_writer, "console", lvl, destination_hpx);    //-V106
+                set_console_dest(error_writer, "console", lvl,
+                    logging_destination::hpx);    //-V106
 #if !defined(ANDROID) && !defined(__ANDROID__)
                 if (logdest != "cerr")
                     error_writer.write(logformat, logdest + " cerr");
@@ -537,8 +537,8 @@ namespace hpx { namespace util {
                 // errors are always logged to cerr
                 if (!isconsole)
                 {
-                    set_console_dest(
-                        writer, "console", lvl, destination_hpx);    //-V106
+                    set_console_dest(writer, "console", lvl,
+                        logging_destination::hpx);    //-V106
                     error_writer.write(logformat, "console");
                 }
                 else
@@ -597,8 +597,8 @@ namespace hpx { namespace util {
                 if (logformat.empty())
                     logformat = "|\\n";
 
-                set_console_dest(
-                    writer, "console", lvl, destination_app);    //-V106
+                set_console_dest(writer, "console", lvl,
+                    logging_destination::app);    //-V106
                 writer.write(logformat, logdest);
                 define_formatters(writer);
 
@@ -648,8 +648,8 @@ namespace hpx { namespace util {
                 if (logformat.empty())
                     logformat = "|\\n";
 
-                set_console_dest(
-                    writer, "console", lvl, destination_debuglog);    //-V106
+                set_console_dest(writer, "console", lvl,
+                    logging_destination::debuglog);    //-V106
                 writer.write(logformat, logdest);
                 define_formatters(writer);
 
@@ -965,32 +965,32 @@ namespace hpx { namespace util {
     {
         switch (dest)
         {
-        case destination_hpx:
+        case logging_destination::hpx:
             hpx_logger()->set_enabled(logging::level::disable_all);
             hpx_console_logger()->set_enabled(logging::level::disable_all);
             break;
 
-        case destination_timing:
+        case logging_destination::timing:
             timing_logger()->set_enabled(logging::level::disable_all);
             timing_console_logger()->set_enabled(logging::level::disable_all);
             break;
 
-        case destination_agas:
+        case logging_destination::agas:
             agas_logger()->set_enabled(logging::level::disable_all);
             agas_console_logger()->set_enabled(logging::level::disable_all);
             break;
 
-        case destination_parcel:
+        case logging_destination::parcel:
             parcel_logger()->set_enabled(logging::level::disable_all);
             parcel_console_logger()->set_enabled(logging::level::disable_all);
             break;
 
-        case destination_app:
+        case logging_destination::app:
             app_logger()->set_enabled(logging::level::disable_all);
             app_console_logger()->set_enabled(logging::level::disable_all);
             break;
 
-        case destination_debuglog:
+        case logging_destination::debuglog:
             debuglog_logger()->set_enabled(logging::level::disable_all);
             debuglog_console_logger()->set_enabled(logging::level::disable_all);
             break;
@@ -1008,7 +1008,7 @@ namespace hpx { namespace util {
 
         switch (dest)
         {
-        case destination_hpx:
+        case logging_destination::hpx:
             detail::init_hpx_log(lvl, logdest, logformat,
                 detail::default_isconsole, detail::default_set_console_dest,
                 detail::default_define_formatters);
@@ -1016,7 +1016,7 @@ namespace hpx { namespace util {
                 lvl, HPX_MOVE(logdest), HPX_MOVE(logformat));
             break;
 
-        case destination_timing:
+        case logging_destination::timing:
             detail::init_debuglog_log(lvl, logdest, logformat,
                 detail::default_isconsole, detail::default_set_console_dest,
                 detail::default_define_formatters);
@@ -1024,7 +1024,7 @@ namespace hpx { namespace util {
                 lvl, HPX_MOVE(logdest), HPX_MOVE(logformat));
             break;
 
-        case destination_agas:
+        case logging_destination::agas:
             detail::init_agas_log(lvl, logdest, logformat,
                 detail::default_isconsole, detail::default_set_console_dest,
                 detail::default_define_formatters);
@@ -1032,7 +1032,7 @@ namespace hpx { namespace util {
                 lvl, HPX_MOVE(logdest), HPX_MOVE(logformat));
             break;
 
-        case destination_parcel:
+        case logging_destination::parcel:
             detail::init_parcel_log(lvl, logdest, logformat,
                 detail::default_isconsole, detail::default_set_console_dest,
                 detail::default_define_formatters);
@@ -1040,7 +1040,7 @@ namespace hpx { namespace util {
                 lvl, HPX_MOVE(logdest), HPX_MOVE(logformat));
             break;
 
-        case destination_app:
+        case logging_destination::app:
             detail::init_app_log(lvl, logdest, logformat,
                 detail::default_isconsole, detail::default_set_console_dest,
                 detail::default_define_formatters);
@@ -1048,7 +1048,7 @@ namespace hpx { namespace util {
                 lvl, HPX_MOVE(logdest), HPX_MOVE(logformat));
             break;
 
-        case destination_debuglog:
+        case logging_destination::debuglog:
             detail::init_debuglog_log(lvl, logdest, logformat,
                 detail::default_isconsole, detail::default_set_console_dest,
                 detail::default_define_formatters);

--- a/libs/core/iterator_support/include/hpx/iterator_support/boost_iterator_categories.hpp
+++ b/libs/core/iterator_support/include/hpx/iterator_support/boost_iterator_categories.hpp
@@ -56,22 +56,21 @@ namespace hpx { namespace iterators {
         struct std_category_to_traversal
           : hpx::util::lazy_conditional<
                 std::is_convertible_v<Cat, std::random_access_iterator_tag>,
-                hpx::util::identity<random_access_traversal_tag>,
+                hpx::type_identity<random_access_traversal_tag>,
                 hpx::util::lazy_conditional<
                     std::is_convertible_v<Cat, std::bidirectional_iterator_tag>,
-                    hpx::util::identity<bidirectional_traversal_tag>,
+                    hpx::type_identity<bidirectional_traversal_tag>,
                     hpx::util::lazy_conditional<
                         std::is_convertible_v<Cat, std::forward_iterator_tag>,
-                        hpx::util::identity<forward_traversal_tag>,
+                        hpx::type_identity<forward_traversal_tag>,
                         hpx::util::lazy_conditional<
                             std::is_convertible_v<Cat, std::input_iterator_tag>,
-                            hpx::util::identity<single_pass_traversal_tag>,
+                            hpx::type_identity<single_pass_traversal_tag>,
                             hpx::util::lazy_conditional<
                                 std::is_convertible_v<Cat,
                                     std::output_iterator_tag>,
-                                hpx::util::identity<
-                                    incrementable_traversal_tag>,
-                                hpx::util::identity<no_traversal_tag>>>>>>
+                                hpx::type_identity<incrementable_traversal_tag>,
+                                hpx::type_identity<no_traversal_tag>>>>>>
         {
         };
     }    // namespace detail
@@ -81,7 +80,7 @@ namespace hpx { namespace iterators {
     struct iterator_category_to_traversal
       : hpx::util::lazy_conditional<
             std::is_convertible_v<Cat, incrementable_traversal_tag>,
-            hpx::util::identity<Cat>, detail::std_category_to_traversal<Cat>>
+            hpx::type_identity<Cat>, detail::std_category_to_traversal<Cat>>
     {
     };
 
@@ -98,21 +97,21 @@ namespace hpx { namespace iterators {
     struct pure_traversal_tag
       : hpx::util::lazy_conditional<
             std::is_convertible_v<Traversal, random_access_traversal_tag>,
-            hpx::util::identity<random_access_traversal_tag>,
+            hpx::type_identity<random_access_traversal_tag>,
             hpx::util::lazy_conditional<
                 std::is_convertible_v<Traversal, bidirectional_traversal_tag>,
-                hpx::util::identity<bidirectional_traversal_tag>,
+                hpx::type_identity<bidirectional_traversal_tag>,
                 hpx::util::lazy_conditional<
                     std::is_convertible_v<Traversal, forward_traversal_tag>,
-                    hpx::util::identity<forward_traversal_tag>,
+                    hpx::type_identity<forward_traversal_tag>,
                     hpx::util::lazy_conditional<std::is_convertible_v<Traversal,
                                                     single_pass_traversal_tag>,
-                        hpx::util::identity<single_pass_traversal_tag>,
+                        hpx::type_identity<single_pass_traversal_tag>,
                         hpx::util::lazy_conditional<
                             std::is_convertible_v<Traversal,
                                 incrementable_traversal_tag>,
-                            hpx::util::identity<incrementable_traversal_tag>,
-                            hpx::util::identity<no_traversal_tag>>>>>>
+                            hpx::type_identity<incrementable_traversal_tag>,
+                            hpx::type_identity<no_traversal_tag>>>>>>
     {
     };
 

--- a/libs/core/iterator_support/include/hpx/iterator_support/counting_iterator.hpp
+++ b/libs/core/iterator_support/include/hpx/iterator_support/counting_iterator.hpp
@@ -43,12 +43,12 @@ namespace hpx { namespace util {
 
             using base_traversal =
                 util::lazy_conditional<std::is_integral_v<Incrementable>,
-                    util::identity<std::random_access_iterator_tag>,
+                    hpx::type_identity<std::random_access_iterator_tag>,
                     iterator_category<Incrementable>>;
 
             using traversal =
                 util::lazy_conditional_t<std::is_void_v<CategoryOrTraversal>,
-                    base_traversal, util::identity<CategoryOrTraversal>>;
+                    base_traversal, hpx::type_identity<CategoryOrTraversal>>;
 
             // calculate difference_type of the resulting iterator
             template <typename Integer>
@@ -79,7 +79,7 @@ namespace hpx { namespace util {
 
             using difference =
                 util::lazy_conditional_t<std::is_void_v<Difference>,
-                    base_difference, util::identity<Difference>>;
+                    base_difference, hpx::type_identity<Difference>>;
 
             using type = iterator_adaptor<counting_iterator<Incrementable,
                                               CategoryOrTraversal, Difference>,

--- a/libs/core/iterator_support/include/hpx/iterator_support/iterator_adaptor.hpp
+++ b/libs/core/iterator_support/include/hpx/iterator_support/iterator_adaptor.hpp
@@ -79,12 +79,12 @@ namespace hpx { namespace util {
             using iterator_category =
                 util::lazy_conditional_t<std::is_void_v<Category>,
                     category_iterator_traits_helper<Base>,
-                    util::identity<Category>>;
+                    hpx::type_identity<Category>>;
 
             using difference_type =
                 util::lazy_conditional_t<std::is_void_v<Difference>,
                     difference_type_iterator_traits_helper<Base>,
-                    util::identity<Difference>>;
+                    hpx::type_identity<Difference>>;
 
             using type = iterator_facade<Derived, value_type, iterator_category,
                 reference_type, difference_type, Pointer>;

--- a/libs/core/iterator_support/include/hpx/iterator_support/traits/is_iterator.hpp
+++ b/libs/core/iterator_support/include/hpx/iterator_support/traits/is_iterator.hpp
@@ -30,7 +30,7 @@ namespace hpx::traits {
     using iter_pointer_t = typename std::iterator_traits<Iter>::pointer;
 
     template <typename Iter>
-    using iter_ref_t = typename std::iterator_traits<Iter>::reference;
+    using iter_reference_t = typename std::iterator_traits<Iter>::reference;
 
     template <typename Iter>
     using iter_category_t =
@@ -58,10 +58,8 @@ namespace hpx::traits {
 
             static char test(...);
 
-            enum
-            {
-                value = sizeof(test(std::declval<T>())) == sizeof(void*)
-            };
+            static constexpr bool value =
+                sizeof(test(std::declval<T>())) == sizeof(void*);
         };
 
         ///////////////////////////////////////////////////////////////////////

--- a/libs/core/iterator_support/include/hpx/iterator_support/transform_iterator.hpp
+++ b/libs/core/iterator_support/include/hpx/iterator_support/transform_iterator.hpp
@@ -34,20 +34,21 @@ namespace hpx { namespace util {
             using reference_type =
                 util::lazy_conditional_t<std::is_void_v<Reference>,
                     util::invoke_result<Transformer, Iterator>,
-                    util::identity<Reference>>;
+                    hpx::type_identity<Reference>>;
 
             using value_type = util::lazy_conditional_t<std::is_void_v<Value>,
-                std::remove_reference<reference_type>, util::identity<Value>>;
+                std::remove_reference<reference_type>,
+                hpx::type_identity<Value>>;
 
             using iterator_category =
                 util::lazy_conditional_t<std::is_void_v<Category>,
                     category_iterator_traits_helper<Iterator>,
-                    util::identity<Category>>;
+                    hpx::type_identity<Category>>;
 
             using difference_type =
                 util::lazy_conditional_t<std::is_void_v<Difference>,
                     difference_type_iterator_traits_helper<Iterator>,
-                    util::identity<Difference>>;
+                    hpx::type_identity<Difference>>;
 
             using type = hpx::util::iterator_adaptor<
                 transform_iterator<Iterator, Transformer, Reference, Value,

--- a/libs/core/itt_notify/include/hpx/itt_notify/thread_name.hpp
+++ b/libs/core/itt_notify/include/hpx/itt_notify/thread_name.hpp
@@ -10,8 +10,9 @@
 
 #include <string>
 
-namespace hpx { namespace detail {
+namespace hpx::detail {
+
     /// Helper utility to set and store a name for the current operating system
     /// thread. Returns a reference to the name for the current thread.
     HPX_CORE_EXPORT std::string& thread_name();
-}}    // namespace hpx::detail
+}    // namespace hpx::detail

--- a/libs/core/itt_notify/include/hpx/modules/itt_notify.hpp
+++ b/libs/core/itt_notify/include/hpx/modules/itt_notify.hpp
@@ -166,12 +166,12 @@ HPX_CORE_EXPORT void itt_metadata_add(___itt_domain* domain, ___itt_id* id,
     ___itt_string_handle* key, void const* data) noexcept;
 
 ///////////////////////////////////////////////////////////////////////////////
-namespace hpx { namespace util {
+namespace hpx::util {
 
     struct thread_description;
-}}    // namespace hpx::util
+}    // namespace hpx::util
 
-namespace hpx { namespace util { namespace itt {
+namespace hpx::util::itt {
 
     struct stack_context
     {
@@ -503,7 +503,7 @@ namespace hpx { namespace util { namespace itt {
     {
         e.start();
     }
-}}}    // namespace hpx::util::itt
+}    // namespace hpx::util::itt
 
 #else
 
@@ -644,12 +644,12 @@ inline constexpr void itt_metadata_add(
 }
 
 //////////////////////////////////////////////////////////////////////////////
-namespace hpx { namespace util {
+namespace hpx::util {
 
     struct thread_description;
-}}    // namespace hpx::util
+}    // namespace hpx::util
 
-namespace hpx { namespace util { namespace itt {
+namespace hpx::util::itt {
 
     struct stack_context
     {
@@ -780,6 +780,6 @@ namespace hpx { namespace util { namespace itt {
     };
 
     inline constexpr void event_tick(event const&) noexcept {}
-}}}    // namespace hpx::util::itt
+}    // namespace hpx::util::itt
 
 #endif    // HPX_HAVE_ITTNOTIFY

--- a/libs/core/itt_notify/src/itt_notify.cpp
+++ b/libs/core/itt_notify/src/itt_notify.cpp
@@ -246,7 +246,7 @@ bool use_ittnotify_api = false;
     HPX_INTERNAL_ITT_SYNC(sync_destroy, obj)
 
 ///////////////////////////////////////////////////////////////////////////////
-namespace hpx { namespace util { namespace itt {
+namespace hpx::util::itt {
 
     stack_context::stack_context()
     {
@@ -475,7 +475,7 @@ namespace hpx { namespace util { namespace itt {
             HPX_ITT_COUNTER_DESTROY(id_);
         }
     }
-}}}    // namespace hpx::util::itt
+}    // namespace hpx::util::itt
 
 ///////////////////////////////////////////////////////////////////////////////
 void itt_sync_create(

--- a/libs/core/itt_notify/src/thread_name.cpp
+++ b/libs/core/itt_notify/src/thread_name.cpp
@@ -9,10 +9,11 @@
 
 #include <string>
 
-namespace hpx { namespace detail {
+namespace hpx::detail {
+
     std::string& thread_name()
     {
         static thread_local std::string thread_name_;
         return thread_name_;
     }
-}}    // namespace hpx::detail
+}    // namespace hpx::detail

--- a/libs/core/logging/include/hpx/logging/detail/logger.hpp
+++ b/libs/core/logging/include/hpx/logging/detail/logger.hpp
@@ -24,7 +24,7 @@
 #include <utility>
 #include <vector>
 
-namespace hpx { namespace util { namespace logging {
+namespace hpx::util::logging {
 
     /**
     @brief The logger class. Every log from your application is an instance of
@@ -183,4 +183,4 @@ namespace hpx { namespace util { namespace logging {
         writer::named_write m_writer;
         level m_level;
     };
-}}}    // namespace hpx::util::logging
+}    // namespace hpx::util::logging

--- a/libs/core/logging/include/hpx/logging/detail/macros.hpp
+++ b/libs/core/logging/include/hpx/logging/detail/macros.hpp
@@ -22,7 +22,7 @@
 
 #include <string>
 
-namespace hpx { namespace util { namespace logging {
+namespace hpx::util::logging::destination {
 
     /**
 @page macros Macros - how, what for?
@@ -154,5 +154,4 @@ HPX_DEFINE_LOG(g_l, logger_type)
 
 #define HPX_LOG_FORMAT(NAME, LEVEL, FORMAT, ...)                               \
     HPX_LOG_USE_LOG(NAME, LEVEL).format(FORMAT, __VA_ARGS__)
-
-}}}    // namespace hpx::util::logging
+}    // namespace hpx::util::logging::destination

--- a/libs/core/logging/include/hpx/logging/format/destinations.hpp
+++ b/libs/core/logging/include/hpx/logging/format/destinations.hpp
@@ -25,11 +25,11 @@
 #include <ostream>
 #include <string>
 
-namespace hpx { namespace util { namespace logging { namespace destination {
+namespace hpx::util::logging::destination {
 
     /**
     @brief Writes the string to console
-*/
+    */
     struct cout : manipulator
     {
         HPX_CORE_EXPORT static std::unique_ptr<cout> make();
@@ -42,7 +42,7 @@ namespace hpx { namespace util { namespace logging { namespace destination {
 
     /**
     @brief Writes the string to cerr
-*/
+    */
     struct cerr : manipulator
     {
         HPX_CORE_EXPORT static std::unique_ptr<cerr> make();
@@ -59,7 +59,7 @@ namespace hpx { namespace util { namespace logging { namespace destination {
     @note:
     The stream must outlive this object! Or, clear() the stream,
     before the stream is deleted.
-*/
+    */
     struct stream : manipulator
     {
         HPX_CORE_EXPORT static std::unique_ptr<stream> make(
@@ -68,16 +68,16 @@ namespace hpx { namespace util { namespace logging { namespace destination {
         HPX_CORE_EXPORT ~stream();
 
         /**
-        @brief resets the stream. Further output will be written to this stream
-    */
+         @brief resets the stream. Further output will be written to this stream
+         */
         void set_stream(std::ostream* stream_ptr)
         {
             ptr = stream_ptr;
         }
 
         /**
-        @brief clears the stream. Further output will be ignored
-    */
+         @brief clears the stream. Further output will be ignored
+         */
         void clear()
         {
             ptr = nullptr;
@@ -97,7 +97,7 @@ namespace hpx { namespace util { namespace logging { namespace destination {
     @brief Writes the string to output debug window
 
     For non-Windows systems, this is the console.
-*/
+     */
     struct dbg_window : manipulator
     {
         HPX_CORE_EXPORT static std::unique_ptr<dbg_window> make();
@@ -110,13 +110,13 @@ namespace hpx { namespace util { namespace logging { namespace destination {
 
     /**
     @brief Writes the string to a file
-*/
+    */
     struct file : manipulator
     {
         /**
-    @brief settings for when constructing a file class. To see how it's used,
-    see @ref dealing_with_flags.
-*/
+         @brief settings for when constructing a file class. To see how it's used,
+         see @ref dealing_with_flags.
+        */
         struct file_settings
         {
             file_settings()
@@ -143,7 +143,7 @@ namespace hpx { namespace util { namespace logging { namespace destination {
         @param file_name name of the file
         @param set [optional] file settings - see file_settings class,
         and @ref dealing_with_flags
-    */
+        */
         HPX_CORE_EXPORT static std::unique_ptr<file> make(
             std::string const& file_name, file_settings set = {});
 
@@ -159,5 +159,4 @@ namespace hpx { namespace util { namespace logging { namespace destination {
         std::string name;
         file_settings settings;
     };
-
-}}}}    // namespace hpx::util::logging::destination
+}    // namespace hpx::util::logging::destination

--- a/libs/core/logging/include/hpx/logging/format/formatters.hpp
+++ b/libs/core/logging/include/hpx/logging/format/formatters.hpp
@@ -22,7 +22,7 @@
 #include <memory>
 #include <string>
 
-namespace hpx { namespace util { namespace logging { namespace formatter {
+namespace hpx::util::logging::formatter {
 
     /**
 @brief prefixes each message with an index.
@@ -51,38 +51,37 @@ This will output something similar to:
     };
 
     /**
-@brief Prefixes the message with a high-precision time (.
-You pass the format string at construction.
+    @brief Prefixes the message with a high-precision time (
+    You pass the format string at construction.
 
-@code
-#include <hpx/logging/format/formatters.hpp>
-@endcode
+    @code
+    #include <hpx/logging/format/formatters.hpp>
+    @endcode
 
-Internally, it uses hpx::util::date_time::microsec_time_clock.
-So, our precision matches this class.
+    Internally, it uses hpx::util::date_time::microsec_time_clock.
+    So, our precision matches this class.
 
-The format can contain escape sequences:
-$dd - day, 2 digits
-$MM - month, 2 digits
-$yy - year, 2 digits
-$yyyy - year, 4 digits
-$hh - hour, 2 digits
-$mm - minute, 2 digits
-$ss - second, 2 digits
-$mili - milliseconds
-$micro - microseconds (if the high precision clock allows; otherwise, it pads zeros)
-$nano - nanoseconds (if the high precision clock allows; otherwise, it pads zeros)
+    The format can contain escape sequences:
+    $dd - day, 2 digits
+    $MM - month, 2 digits
+    $yy - year, 2 digits
+    $yyyy - year, 4 digits
+    $hh - hour, 2 digits
+    $mm - minute, 2 digits
+    $ss - second, 2 digits
+    $mili - milliseconds
+    $micro - microseconds (if the high precision clock allows; otherwise, it pads zeros)
+    $nano - nanoseconds (if the high precision clock allows; otherwise, it pads zeros)
 
+    Example:
 
-Example:
+    @code
+    high_precision_time("$mm:$ss:$micro");
+    @endcode
 
-@code
-high_precision_time("$mm:$ss:$micro");
-@endcode
-
-@param convert [optional] In case there needs to be a conversion between
-std::(w)string and the string that holds your logged message. See convert_format.
-*/
+    @param convert [optional] In case there needs to be a conversion between
+    std::(w)string and the string that holds your logged message. See convert_format.
+    */
     struct high_precision_time : manipulator
     {
         HPX_CORE_EXPORT static std::unique_ptr<high_precision_time> make(
@@ -98,11 +97,11 @@ std::(w)string and the string that holds your logged message. See convert_format
     };
 
     /**
-@brief Writes the thread_id to the log
+    @brief Writes the thread_id to the log
 
-@param convert [optional] In case there needs to be a conversion between
-std::(w)string and the string that holds your logged message. See convert_format.
-*/
+    @param convert [optional] In case there needs to be a conversion between
+    std::(w)string and the string that holds your logged message. See convert_format.
+    */
     struct thread_id : manipulator
     {
         HPX_CORE_EXPORT static std::unique_ptr<thread_id> make();
@@ -112,5 +111,4 @@ std::(w)string and the string that holds your logged message. See convert_format
     protected:
         thread_id() = default;
     };
-
-}}}}    // namespace hpx::util::logging::formatter
+}    // namespace hpx::util::logging::formatter

--- a/libs/core/logging/include/hpx/logging/format/named_write.hpp
+++ b/libs/core/logging/include/hpx/logging/format/named_write.hpp
@@ -27,7 +27,7 @@
 #include <utility>
 #include <vector>
 
-namespace hpx { namespace util { namespace logging { namespace detail {
+namespace hpx::util::logging::detail {
 
     template <typename T>
     struct named
@@ -266,8 +266,7 @@ In the above example, I know that the available destinations are @c out_file,
         std::vector<destination::manipulator*> write_steps;
         std::string format_string;
     };
-
-}}}}    // namespace hpx::util::logging::detail
+}    // namespace hpx::util::logging::detail
 
 namespace hpx { namespace util { namespace logging { namespace writer {
 

--- a/libs/core/logging/include/hpx/logging/level.hpp
+++ b/libs/core/logging/include/hpx/logging/level.hpp
@@ -20,7 +20,7 @@
 
 #include <string_view>
 
-namespace hpx { namespace util { namespace logging {
+namespace hpx::util::logging {
 
     /**
     @brief Handling levels - classes that can hold and/or deal with levels
@@ -58,5 +58,4 @@ namespace hpx { namespace util { namespace logging {
     ////////////////////////////////////////////////////////////////////////////
     HPX_CORE_EXPORT void format_value(
         std::ostream& os, std::string_view spec, level value);
-
-}}}    // namespace hpx::util::logging
+}    // namespace hpx::util::logging

--- a/libs/core/logging/include/hpx/logging/logging.hpp
+++ b/libs/core/logging/include/hpx/logging/logging.hpp
@@ -20,7 +20,7 @@
 #include <hpx/logging/detail/macros.hpp>
 #include <hpx/logging/level.hpp>
 
-namespace hpx { namespace util { namespace logging {
+namespace hpx::util::logging {
 
     /**
 @file hpx/logging/logging.hpp
@@ -35,5 +35,4 @@ then you can include this one instead:
 @endcode
 
 */
-
-}}}    // namespace hpx::util::logging
+}    // namespace hpx::util::logging

--- a/libs/core/logging/include/hpx/logging/manipulator.hpp
+++ b/libs/core/logging/include/hpx/logging/manipulator.hpp
@@ -24,7 +24,7 @@
 #include <string>
 #include <string_view>
 
-namespace hpx { namespace util { namespace logging {
+namespace hpx::util::logging {
 
     /// @brief Formatter is a manipulator.
     /// It allows you to format the message before writing it to the destination(s)
@@ -87,5 +87,4 @@ namespace hpx { namespace util { namespace logging {
         };
 
     }    // namespace destination
-
-}}}    // namespace hpx::util::logging
+}    // namespace hpx::util::logging

--- a/libs/core/logging/include/hpx/logging/message.hpp
+++ b/libs/core/logging/include/hpx/logging/message.hpp
@@ -26,7 +26,7 @@
 #include <string_view>
 #include <utility>
 
-namespace hpx { namespace util { namespace logging {
+namespace hpx::util::logging {
 
     /**
         @brief Optimizes the formatting for prepending and/or appending strings to
@@ -109,7 +109,7 @@ namespace hpx { namespace util { namespace logging {
             return m_full_msg;
         }
 
-        bool empty() const
+        bool empty() const noexcept
         {
             return full_string().empty();
         }
@@ -126,4 +126,4 @@ namespace hpx { namespace util { namespace logging {
         mutable bool m_full_msg_computed;
         mutable std::string m_full_msg;
     };
-}}}    // namespace hpx::util::logging
+}    // namespace hpx::util::logging

--- a/libs/core/logging/include/hpx/modules/logging.hpp
+++ b/libs/core/logging/include/hpx/modules/logging.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2017 Hartmut Kaiser
+//  Copyright (c) 2007-2022 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -9,15 +9,47 @@
 #include <hpx/config.hpp>
 
 namespace hpx {
-    enum logging_destination
+
+    enum class logging_destination
     {
-        destination_hpx = 0,
-        destination_timing = 1,
-        destination_agas = 2,
-        destination_parcel = 3,
-        destination_app = 4,
-        destination_debuglog = 5
+        hpx = 0,
+        timing = 1,
+        agas = 2,
+        parcel = 3,
+        app = 4,
+        debuglog = 5
     };
+
+#define HPX_LOGGING_DESTINATION_UNSCOPED_ENUM_DEPRECATION_MSG                  \
+    "The unscoped logging_destination names are deprecated. Please use "       \
+    "logging_destination::<value> instead."
+
+    HPX_DEPRECATED_V(
+        1, 9, HPX_LOGGING_DESTINATION_UNSCOPED_ENUM_DEPRECATION_MSG)
+    inline constexpr logging_destination destination_hpx =
+        logging_destination::hpx;
+    HPX_DEPRECATED_V(
+        1, 9, HPX_LOGGING_DESTINATION_UNSCOPED_ENUM_DEPRECATION_MSG)
+    inline constexpr logging_destination destination_timing =
+        logging_destination::timing;
+    HPX_DEPRECATED_V(
+        1, 9, HPX_LOGGING_DESTINATION_UNSCOPED_ENUM_DEPRECATION_MSG)
+    inline constexpr logging_destination destination_agas =
+        logging_destination::agas;
+    HPX_DEPRECATED_V(
+        1, 9, HPX_LOGGING_DESTINATION_UNSCOPED_ENUM_DEPRECATION_MSG)
+    inline constexpr logging_destination destination_parcel =
+        logging_destination::parcel;
+    HPX_DEPRECATED_V(
+        1, 9, HPX_LOGGING_DESTINATION_UNSCOPED_ENUM_DEPRECATION_MSG)
+    inline constexpr logging_destination destination_app =
+        logging_destination::app;
+    HPX_DEPRECATED_V(
+        1, 9, HPX_LOGGING_DESTINATION_UNSCOPED_ENUM_DEPRECATION_MSG)
+    inline constexpr logging_destination destination_debuglog =
+        logging_destination::debuglog;
+
+#undef HPX_LOGGING_DESTINATION_UNSCOPED_ENUM_DEPRECATION_MSG
 }    // namespace hpx
 
 #if defined(HPX_HAVE_LOGGING)
@@ -41,10 +73,13 @@ namespace hpx {
 #define LBT_(lvl) LHPX_(lvl, "  [BT] ")  /* bootstrap */
 
 ////////////////////////////////////////////////////////////////////////////////
-namespace hpx { namespace util {
+namespace hpx::util {
+
+    // clang-format off
 
     ////////////////////////////////////////////////////////////////////////////
     namespace detail {
+
         HPX_CORE_EXPORT hpx::util::logging::level get_log_level(
             std::string const& env, bool allow_always = false);
     }
@@ -59,8 +94,8 @@ namespace hpx { namespace util {
 #define LAGAS_ENABLED(lvl)                                                     \
     hpx::util::agas_logger()->is_enabled(::hpx::util::logging::level::lvl) /**/
 
-        ////////////////////////////////////////////////////////////////////////
-        HPX_CORE_EXPORT HPX_DECLARE_LOG(parcel)
+    ////////////////////////////////////////////////////////////////////////////
+    HPX_CORE_EXPORT HPX_DECLARE_LOG(parcel)
 
 #define LPT_(lvl)                                                              \
     HPX_LOG_FORMAT(hpx::util::parcel, ::hpx::util::logging::level::lvl, "{} ", \
@@ -70,8 +105,8 @@ namespace hpx { namespace util {
     hpx::util::parcel_logger()->is_enabled(                                    \
         ::hpx::util::logging::level::lvl) /**/
 
-        ////////////////////////////////////////////////////////////////////////
-        HPX_CORE_EXPORT HPX_DECLARE_LOG(timing)
+    ////////////////////////////////////////////////////////////////////////////
+    HPX_CORE_EXPORT HPX_DECLARE_LOG(timing)
 
 #define LTIM_(lvl)                                                             \
     HPX_LOG_FORMAT(hpx::util::timing, ::hpx::util::logging::level::lvl, "{} ", \
@@ -84,8 +119,8 @@ namespace hpx { namespace util {
     hpx::util::timing_logger()->is_enabled(                                    \
         ::hpx::util::logging::level::lvl) /**/
 
-        ////////////////////////////////////////////////////////////////////////
-        HPX_CORE_EXPORT HPX_DECLARE_LOG(hpx)
+    ////////////////////////////////////////////////////////////////////////////
+    HPX_CORE_EXPORT HPX_DECLARE_LOG(hpx)
 
 #define LHPX_(lvl, cat)                                                        \
     HPX_LOG_FORMAT(hpx::util::hpx, ::hpx::util::logging::level::lvl, "{}{}",   \
@@ -94,8 +129,8 @@ namespace hpx { namespace util {
 #define LHPX_ENABLED(lvl)                                                      \
     hpx::util::hpx_logger()->is_enabled(::hpx::util::logging::level::lvl) /**/
 
-        ////////////////////////////////////////////////////////////////////////
-        HPX_CORE_EXPORT HPX_DECLARE_LOG(app)
+    ////////////////////////////////////////////////////////////////////////////
+    HPX_CORE_EXPORT HPX_DECLARE_LOG(app)
 
 #define LAPP_(lvl)                                                             \
     HPX_LOG_FORMAT(hpx::util::app, ::hpx::util::logging::level::lvl, "{} ",    \
@@ -104,9 +139,9 @@ namespace hpx { namespace util {
 #define LAPP_ENABLED(lvl)                                                      \
     hpx::util::app_logger()->is_enabled(::hpx::util::logging::level::lvl) /**/
 
-        ////////////////////////////////////////////////////////////////////////
-        // special debug logging channel
-        HPX_CORE_EXPORT HPX_DECLARE_LOG(debuglog)
+    ////////////////////////////////////////////////////////////////////////////
+    // special debug logging channel
+    HPX_CORE_EXPORT HPX_DECLARE_LOG(debuglog)
 
 #define LDEB_                                                                  \
     HPX_LOG_FORMAT(hpx::util::debuglog, ::hpx::util::logging::level::error,    \
@@ -116,24 +151,26 @@ namespace hpx { namespace util {
     hpx::util::debuglog_logger()->is_enabled(                                  \
         ::hpx::util::logging::level::error) /**/
 
-        ////////////////////////////////////////////////////////////////////////
-        // errors are logged in a special manner (always to cerr and additionally,
-        // if enabled to 'normal' logging destination as well)
-        HPX_CORE_EXPORT HPX_DECLARE_LOG(hpx_error)
+    ////////////////////////////////////////////////////////////////////////////
+    // errors are logged in a special manner (always to cerr and additionally,
+    // if enabled to 'normal' logging destination as well)
+    HPX_CORE_EXPORT HPX_DECLARE_LOG(hpx_error)
 
 #define LFATAL_                                                                \
     HPX_LOG_FORMAT(hpx::util::hpx_error, ::hpx::util::logging::level::fatal,   \
-        "{} [ERR] ", ::hpx::util::logging::level::fatal) /**/
+        "{} [ERR] ", ::hpx::util::logging::level::fatal)
 
-            HPX_CORE_EXPORT HPX_DECLARE_LOG(agas_console) HPX_CORE_EXPORT
-        HPX_DECLARE_LOG(parcel_console) HPX_CORE_EXPORT
-        HPX_DECLARE_LOG(timing_console) HPX_CORE_EXPORT
-        HPX_DECLARE_LOG(hpx_console) HPX_CORE_EXPORT
-        HPX_DECLARE_LOG(app_console)
+    HPX_CORE_EXPORT HPX_DECLARE_LOG(agas_console)
+    HPX_CORE_EXPORT HPX_DECLARE_LOG(parcel_console)
+    HPX_CORE_EXPORT HPX_DECLARE_LOG(timing_console)
+    HPX_CORE_EXPORT HPX_DECLARE_LOG(hpx_console)
+    HPX_CORE_EXPORT HPX_DECLARE_LOG(app_console)
 
-        // special debug logging channel
-        HPX_CORE_EXPORT HPX_DECLARE_LOG(debuglog_console)
-}}    // namespace hpx::util
+    // special debug logging channel
+    HPX_CORE_EXPORT HPX_DECLARE_LOG(debuglog_console)
+
+    // clang-format on
+}    // namespace hpx::util
 
 ///////////////////////////////////////////////////////////////////////////////
 #define LAGAS_CONSOLE_(lvl)                                                    \
@@ -169,7 +206,7 @@ namespace hpx { namespace util {
 // helper type to forward logging during bootstrap to two destinations
 struct bootstrap_logging
 {
-    constexpr bootstrap_logging() {}
+    constexpr bootstrap_logging() noexcept {}
 };
 
 template <typename T>
@@ -181,12 +218,13 @@ bootstrap_logging const& operator<<(bootstrap_logging const& l, T const& t)
     return l;
 }
 
-constexpr bootstrap_logging lbt_;
+inline constexpr bootstrap_logging lbt_;
 
 #else
 // logging is disabled all together
 
-namespace hpx { namespace util {
+namespace hpx ::util {
+
     namespace detail {
         struct dummy_log_impl
         {
@@ -205,7 +243,7 @@ namespace hpx { namespace util {
                 return *this;
             }
         };
-        constexpr dummy_log_impl dummy_log;
+        inline constexpr dummy_log_impl dummy_log;
     }    // namespace detail
 
     // clang-format off
@@ -244,17 +282,18 @@ namespace hpx { namespace util {
     #define LDEB_ENABLED          (false)
 
     // clang-format on
-
-}}    // namespace hpx::util
+}    // namespace hpx::util
 
 struct bootstrap_logging
 {
-    constexpr bootstrap_logging() {}
+    constexpr bootstrap_logging() noexcept {}
 };
-constexpr bootstrap_logging lbt_;
+
+inline constexpr bootstrap_logging lbt_;
 
 template <typename T>
-bootstrap_logging const& operator<<(bootstrap_logging const& l, T&&)
+constexpr bootstrap_logging const& operator<<(
+    bootstrap_logging const& l, T&&) noexcept
 {
     return l;
 }

--- a/libs/core/logging/src/format/destination/defaults_destination.cpp
+++ b/libs/core/logging/src/format/destination/defaults_destination.cpp
@@ -26,7 +26,7 @@
 #include <windows.h>
 #endif
 
-namespace hpx { namespace util { namespace logging { namespace destination {
+namespace hpx::util::logging::destination {
 
     cout::~cout() = default;
 
@@ -98,5 +98,4 @@ namespace hpx { namespace util { namespace logging { namespace destination {
     {
         return std::unique_ptr<dbg_window>(new dbg_window_impl());
     }
-
-}}}}    // namespace hpx::util::logging::destination
+}    // namespace hpx::util::logging::destination

--- a/libs/core/logging/src/format/destination/file.cpp
+++ b/libs/core/logging/src/format/destination/file.cpp
@@ -25,7 +25,7 @@
 #include <mutex>
 #include <string>
 
-namespace hpx { namespace util { namespace logging { namespace destination {
+namespace hpx::util::logging::destination {
 
     file::~file() = default;
 
@@ -90,5 +90,4 @@ namespace hpx { namespace util { namespace logging { namespace destination {
     {
         return std::unique_ptr<file>(new file_impl(file_name, set));
     }
-
-}}}}    // namespace hpx::util::logging::destination
+}    // namespace hpx::util::logging::destination

--- a/libs/core/logging/src/format/formatter/defaults_formatter.cpp
+++ b/libs/core/logging/src/format/formatter/defaults_formatter.cpp
@@ -23,7 +23,7 @@
 #include <memory>
 #include <ostream>
 
-namespace hpx { namespace util { namespace logging { namespace formatter {
+namespace hpx::util::logging::formatter {
 
     idx::~idx() = default;
 
@@ -47,5 +47,4 @@ namespace hpx { namespace util { namespace logging { namespace formatter {
     {
         return std::unique_ptr<idx>(new idx_impl());
     }
-
-}}}}    // namespace hpx::util::logging::formatter
+}    // namespace hpx::util::logging::formatter

--- a/libs/core/logging/src/format/formatter/high_precision_time.cpp
+++ b/libs/core/logging/src/format/formatter/high_precision_time.cpp
@@ -32,7 +32,7 @@
 #include <mutex>
 #endif
 
-namespace hpx { namespace util { namespace logging { namespace formatter {
+namespace hpx::util::logging::formatter {
 
     high_precision_time::~high_precision_time() = default;
 
@@ -129,5 +129,4 @@ namespace hpx { namespace util { namespace logging { namespace formatter {
         return std::unique_ptr<high_precision_time>(
             new high_precision_time_impl(format));
     }
-
-}}}}    // namespace hpx::util::logging::formatter
+}    // namespace hpx::util::logging::formatter

--- a/libs/core/logging/src/format/formatter/thread_id.cpp
+++ b/libs/core/logging/src/format/formatter/thread_id.cpp
@@ -28,7 +28,7 @@
 #include <pthread.h>
 #endif
 
-namespace hpx { namespace util { namespace logging { namespace formatter {
+namespace hpx::util::logging::formatter {
 
     thread_id::~thread_id() = default;
 
@@ -50,5 +50,4 @@ namespace hpx { namespace util { namespace logging { namespace formatter {
     {
         return std::unique_ptr<thread_id>(new thread_id_impl());
     }
-
-}}}}    // namespace hpx::util::logging::formatter
+}    // namespace hpx::util::logging::formatter

--- a/libs/core/logging/src/format/named_write.cpp
+++ b/libs/core/logging/src/format/named_write.cpp
@@ -26,7 +26,7 @@
 #include <sstream>
 #include <string>
 
-namespace hpx { namespace util { namespace logging { namespace detail {
+namespace hpx::util::logging::detail {
 
     static std::string unescape(std::string escaped)
     {
@@ -270,8 +270,7 @@ namespace hpx { namespace util { namespace logging { namespace detail {
             named.string(stripped_str);
         }
     }    // namespace
-
-}}}}    // namespace hpx::util::logging::detail
+}    // namespace hpx::util::logging::detail
 
 namespace hpx { namespace util { namespace logging { namespace writer {
 

--- a/libs/core/logging/src/level.cpp
+++ b/libs/core/logging/src/level.cpp
@@ -16,7 +16,7 @@
 #include <string_view>
 
 ///////////////////////////////////////////////////////////////////////////////
-namespace hpx { namespace util { namespace logging {
+namespace hpx::util::logging {
 
     static std::string levelname(level value)
     {
@@ -51,7 +51,6 @@ namespace hpx { namespace util { namespace logging {
         os << std::right << std::setfill(' ') << std::setw(10)
            << levelname(value);
     }
-
-}}}    // namespace hpx::util::logging
+}    // namespace hpx::util::logging
 
 #endif    // HPX_HAVE_LOGGING

--- a/libs/core/logging/src/logging.cpp
+++ b/libs/core/logging/src/logging.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2017 Hartmut Kaiser
+//  Copyright (c) 2007-2022 Hartmut Kaiser
 //  Copyright (c)      2011 Bryce Lelbach
 //
 //  SPDX-License-Identifier: BSL-1.0
@@ -20,7 +20,8 @@
 #include <vector>
 
 ///////////////////////////////////////////////////////////////////////////////
-namespace hpx { namespace util {
+namespace hpx::util {
+
     HPX_DEFINE_LOG(agas, disable_all)
     HPX_DEFINE_LOG(agas_console, disable_all)
     HPX_DEFINE_LOG(app, disable_all)
@@ -38,6 +39,7 @@ namespace hpx { namespace util {
     HPX_DEFINE_LOG(timing_console, disable_all)
 
     namespace detail {
+
         hpx::util::logging::level get_log_level(
             std::string const& env, bool allow_always)
         {
@@ -72,12 +74,12 @@ namespace hpx { namespace util {
             }
         }
     }    // namespace detail
-}}       // namespace hpx::util
+}    // namespace hpx::util
 
 ///////////////////////////////////////////////////////////////////////////////
 #include <hpx/logging/detail/logger.hpp>
 
-namespace hpx { namespace util { namespace logging {
+namespace hpx::util::logging {
 
     void logger::turn_cache_off()
     {
@@ -93,7 +95,6 @@ namespace hpx { namespace util { namespace logging {
         for (auto& msg : msgs)
             m_writer(msg);
     }
-
-}}}    // namespace hpx::util::logging
+}    // namespace hpx::util::logging
 
 #endif    // HPX_HAVE_LOGGING

--- a/libs/core/logging/src/manipulator.cpp
+++ b/libs/core/logging/src/manipulator.cpp
@@ -16,7 +16,7 @@
 
 #include <hpx/logging/manipulator.hpp>
 
-namespace hpx { namespace util { namespace logging {
+namespace hpx::util::logging {
 
     namespace formatter {
 
@@ -29,5 +29,4 @@ namespace hpx { namespace util { namespace logging {
         manipulator::~manipulator() = default;
 
     }    // namespace destination
-
-}}}    // namespace hpx::util::logging
+}    // namespace hpx::util::logging

--- a/libs/core/properties/include/hpx/properties/property.hpp
+++ b/libs/core/properties/include/hpx/properties/property.hpp
@@ -13,7 +13,7 @@
 #include <type_traits>
 #include <utility>
 
-namespace hpx { namespace experimental {
+namespace hpx::experimental {
 
     inline constexpr struct prefer_t
       : hpx::functional::detail::tag_fallback<prefer_t>
@@ -21,7 +21,7 @@ namespace hpx { namespace experimental {
         // clang-format off
         template <typename Tag, typename... Tn>
         friend constexpr HPX_FORCEINLINE auto tag_fallback_invoke(
-                prefer_t, Tag const& tag, Tn&&... tn)
+                prefer_t, Tag tag, Tn&&... tn)
             noexcept(noexcept(tag(HPX_FORWARD(Tn, tn)...)))
             -> decltype(tag(HPX_FORWARD(Tn, tn)...))
         // clang-format on
@@ -44,4 +44,4 @@ namespace hpx { namespace experimental {
             return HPX_FORWARD(T0, t0);
         }
     } prefer{};
-}}    // namespace hpx::experimental
+}    // namespace hpx::experimental

--- a/libs/core/serialization/include/hpx/serialization/detail/pointer.hpp
+++ b/libs/core/serialization/include/hpx/serialization/detail/pointer.hpp
@@ -154,7 +154,7 @@ namespace hpx::serialization {
         public:
             using type = util::lazy_conditional_t<
                 hpx::traits::is_serialized_with_id_v<referred_type>,
-                hpx::util::identity<polymorphic_with_id>,
+                hpx::type_identity<polymorphic_with_id>,
                 std::conditional<
                     hpx::traits::is_intrusive_polymorphic_v<referred_type>,
                     intrusive_polymorphic,

--- a/libs/core/tag_invoke/include/hpx/functional/detail/invoke.hpp
+++ b/libs/core/tag_invoke/include/hpx/functional/detail/invoke.hpp
@@ -57,7 +57,7 @@ namespace hpx::util::detail {
         T C::*pm;
 
     public:
-        constexpr invoke_mem_obj(T C::*pm) noexcept
+        explicit constexpr invoke_mem_obj(T C::*pm) noexcept
           : pm(pm)
         {
         }
@@ -88,7 +88,7 @@ namespace hpx::util::detail {
         T C::*pm;
 
     public:
-        constexpr invoke_mem_fun(T C::*pm) noexcept
+        explicit constexpr invoke_mem_fun(T C::*pm) noexcept
           : pm(pm)
         {
         }

--- a/libs/core/tag_invoke/include/hpx/functional/detail/tag_fallback_invoke.hpp
+++ b/libs/core/tag_invoke/include/hpx/functional/detail/tag_fallback_invoke.hpp
@@ -134,13 +134,13 @@ namespace hpx::functional::detail {
             }
 
             friend constexpr bool operator==(
-                tag_fallback_invoke_t, tag_fallback_invoke_t)
+                tag_fallback_invoke_t, tag_fallback_invoke_t) noexcept
             {
                 return true;
             }
 
             friend constexpr bool operator!=(
-                tag_fallback_invoke_t, tag_fallback_invoke_t)
+                tag_fallback_invoke_t, tag_fallback_invoke_t) noexcept
             {
                 return false;
             }

--- a/libs/core/tag_invoke/include/hpx/functional/detail/tag_priority_invoke.hpp
+++ b/libs/core/tag_invoke/include/hpx/functional/detail/tag_priority_invoke.hpp
@@ -135,13 +135,13 @@ namespace hpx::functional::detail {
             }
 
             friend constexpr bool operator==(
-                tag_override_invoke_t, tag_override_invoke_t)
+                tag_override_invoke_t, tag_override_invoke_t) noexcept
             {
                 return true;
             }
 
             friend constexpr bool operator!=(
-                tag_override_invoke_t, tag_override_invoke_t)
+                tag_override_invoke_t, tag_override_invoke_t) noexcept
             {
                 return false;
             }

--- a/libs/core/tag_invoke/include/hpx/functional/tag_invoke.hpp
+++ b/libs/core/tag_invoke/include/hpx/functional/tag_invoke.hpp
@@ -133,12 +133,14 @@ namespace hpx::functional {
                 return tag_invoke(tag, HPX_FORWARD(Ts, ts)...);
             }
 
-            friend constexpr bool operator==(tag_invoke_t, tag_invoke_t)
+            friend constexpr bool operator==(
+                tag_invoke_t, tag_invoke_t) noexcept
             {
                 return true;
             }
 
-            friend constexpr bool operator!=(tag_invoke_t, tag_invoke_t)
+            friend constexpr bool operator!=(
+                tag_invoke_t, tag_invoke_t) noexcept
             {
                 return false;
             }
@@ -163,6 +165,7 @@ namespace hpx::functional {
         is_tag_invocable<Tag, Args...>::value;
 
     namespace detail {
+
         template <typename Sig, bool Invocable>
         struct is_nothrow_tag_invocable_impl;
 

--- a/libs/core/tag_invoke/include/hpx/functional/traits/is_invocable.hpp
+++ b/libs/core/tag_invoke/include/hpx/functional/traits/is_invocable.hpp
@@ -20,6 +20,7 @@
 namespace hpx {
 
     namespace detail {
+
         ///////////////////////////////////////////////////////////////////////
         template <typename T, typename Enable = void>
         struct is_invocable_impl : std::false_type

--- a/libs/core/thread_support/include/hpx/thread_support/assert_owns_lock.hpp
+++ b/libs/core/thread_support/include/hpx/thread_support/assert_owns_lock.hpp
@@ -15,7 +15,8 @@
 #include <type_traits>
 
 ///////////////////////////////////////////////////////////////////////////////
-namespace hpx { namespace util { namespace detail {
+namespace hpx::util::detail {
+
     HPX_HAS_MEMBER_XXX_TRAIT_DEF(owns_lock)
 
     template <typename Lock>
@@ -29,7 +30,7 @@ namespace hpx { namespace util { namespace detail {
     }
 
     template <typename Lock>
-    typename std::enable_if<has_owns_lock<Lock>::value>::type assert_owns_lock(
+    std::enable_if_t<has_owns_lock_v<Lock>> assert_owns_lock(
         Lock& l, long) noexcept
     {
         HPX_ASSERT_LOCKED(l, l.owns_lock());
@@ -37,13 +38,13 @@ namespace hpx { namespace util { namespace detail {
     }
 
     template <typename Lock>
-    typename std::enable_if<has_owns_lock<Lock>::value>::type
-    assert_doesnt_own_lock(Lock& l, long) noexcept
+    std::enable_if_t<has_owns_lock_v<Lock>> assert_doesnt_own_lock(
+        Lock& l, long) noexcept
     {
         HPX_ASSERT_LOCKED(l, !l.owns_lock());
         HPX_UNUSED(l);
     }
-}}}    // namespace hpx::util::detail
+}    // namespace hpx::util::detail
 
 #define HPX_ASSERT_OWNS_LOCK(l) ::hpx::util::detail::assert_owns_lock(l, 0L)
 

--- a/libs/core/thread_support/include/hpx/thread_support/atomic_count.hpp
+++ b/libs/core/thread_support/include/hpx/thread_support/atomic_count.hpp
@@ -11,7 +11,8 @@
 
 #include <atomic>
 
-namespace hpx { namespace util {
+namespace hpx::util {
+
     class atomic_count
     {
     public:
@@ -59,4 +60,4 @@ namespace hpx { namespace util {
     private:
         std::atomic<long> value_;
     };
-}}    // namespace hpx::util
+}    // namespace hpx::util

--- a/libs/core/thread_support/include/hpx/thread_support/set_thread_name.hpp
+++ b/libs/core/thread_support/include/hpx/thread_support/set_thread_name.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2013 Hartmut Kaiser
+//  Copyright (c) 2007-2022 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -11,15 +11,19 @@
 #if defined(WIN32) || defined(_WIN32) || defined(__WIN32__)
 #include <windows.h>
 
-namespace hpx { namespace util {
+namespace hpx::util {
+
     HPX_CORE_EXPORT void set_thread_name(
         char const* /*threadName*/, DWORD /*dwThreadID*/ = DWORD(-1));
-}}    // namespace hpx::util
+}    // namespace hpx::util
 
 #else
 
-namespace hpx { namespace util {
-    inline void set_thread_name(char const* /*thread_name*/) {}
-}}    // namespace hpx::util
+namespace hpx::util {
+
+    inline constexpr void set_thread_name(char const* /*thread_name*/) noexcept
+    {
+    }
+}    // namespace hpx::util
 
 #endif

--- a/libs/core/thread_support/include/hpx/thread_support/spinlock.hpp
+++ b/libs/core/thread_support/include/hpx/thread_support/spinlock.hpp
@@ -16,7 +16,7 @@
 
 #include <atomic>
 
-namespace hpx { namespace util { namespace detail {
+namespace hpx::util::detail {
 
     /// Lockable spinlock class
     struct spinlock
@@ -30,15 +30,16 @@ namespace hpx { namespace util { namespace detail {
         HPX_CORE_EXPORT void yield_k(unsigned) noexcept;
 
     public:
-        spinlock() noexcept
+        constexpr spinlock() noexcept
           : m(false)
         {
         }
 
         HPX_FORCEINLINE bool try_lock() noexcept
         {
-            // First do a relaxed load to check if lock is free in order to prevent
-            // unnecessary cache misses if someone does while(!try_lock())
+            // First do a relaxed load to check if lock is free in order to
+            // prevent unnecessary cache misses if someone does
+            // while(!try_lock())
             return !m.load(std::memory_order_relaxed) &&
                 !m.exchange(true, std::memory_order_acquire);
         }
@@ -59,5 +60,4 @@ namespace hpx { namespace util { namespace detail {
             m.store(false, std::memory_order_release);
         }
     };
-
-}}}    // namespace hpx::util::detail
+}    // namespace hpx::util::detail

--- a/libs/core/thread_support/include/hpx/thread_support/thread_specific_ptr.hpp
+++ b/libs/core/thread_support/include/hpx/thread_support/thread_specific_ptr.hpp
@@ -11,7 +11,7 @@
 #include <hpx/config.hpp>
 #include <hpx/assert.hpp>
 
-// Needed to get potentially get _GLIBCXX_HAVE_TLS
+// Needed to potentially get _GLIBCXX_HAVE_TLS
 #include <cstdlib>
 
 // clang-format off
@@ -22,31 +22,32 @@
 #endif
 // clang-format on
 
-#if (!defined(__ANDROID__) && !defined(ANDROID)) && !defined(__bgq__)
+#if !defined(__ANDROID__) && !defined(ANDROID) && !defined(__bgq__)
 
-namespace hpx { namespace util {
+namespace hpx::util {
+
     template <typename T, typename Tag>
     struct HPX_CORE_EXPORT_THREAD_SPECIFIC_PTR thread_specific_ptr
     {
-        typedef T element_type;
+        using element_type = T;
 
-        T* get() const
+        T* get() const noexcept
         {
             return ptr_;
         }
 
-        T* operator->() const
+        T* operator->() const noexcept
         {
             return ptr_;
         }
 
-        T& operator*() const
+        T& operator*() const noexcept
         {
             HPX_ASSERT(nullptr != ptr_);
             return *ptr_;
         }
 
-        void reset(T* new_value = nullptr)
+        void reset(T* new_value = nullptr) noexcept
         {
             delete ptr_;
             ptr_ = new_value;
@@ -58,20 +59,22 @@ namespace hpx { namespace util {
 
     template <typename T, typename Tag>
     thread_local T* thread_specific_ptr<T, Tag>::ptr_ = nullptr;
-}}    // namespace hpx::util
+}    // namespace hpx::util
 
 #else
 
 #include <hpx/type_support/static.hpp>
 #include <pthread.h>
 
-namespace hpx { namespace util {
+namespace hpx::util {
+
     namespace detail {
+
         struct thread_specific_ptr_key
         {
             thread_specific_ptr_key()
             {
-                //pthread_once(&key_once, &thread_specific_ptr_key::make_key);
+                // pthread_once(&key_once, &thread_specific_ptr_key::make_key);
                 pthread_key_create(&key, nullptr);
             }
 
@@ -82,7 +85,7 @@ namespace hpx { namespace util {
     template <typename T, typename Tag>
     struct HPX_CORE_EXPORT_THREAD_SPECIFIC_PTR thread_specific_ptr
     {
-        typedef T element_type;
+        using element_type = T;
 
         static pthread_key_t get_key()
         {
@@ -128,6 +131,6 @@ namespace hpx { namespace util {
             pthread_setspecific(thread_specific_ptr<T, Tag>::get_key(), ptr);
         }
     };
-}}    // namespace hpx::util
+}    // namespace hpx::util
 
 #endif

--- a/libs/core/thread_support/include/hpx/thread_support/unlock_guard.hpp
+++ b/libs/core/thread_support/include/hpx/thread_support/unlock_guard.hpp
@@ -41,7 +41,7 @@ namespace hpx {
     public:
         using mutex_type = Mutex;
 
-        explicit unlock_guard(Mutex& m)
+        explicit constexpr unlock_guard(Mutex& m) noexcept
           : m_(m)
         {
             m_.unlock();
@@ -57,11 +57,10 @@ namespace hpx {
     };
 }    // namespace hpx
 
-namespace hpx { namespace util {
+namespace hpx::util {
 
     template <typename Mutex>
     using unlock_guard HPX_DEPRECATED_V(1, 9,
-        "hpx::util::unlock_guard is deprecated, use "
-        "hpx::unlock_guard instead") = hpx::unlock_guard<Mutex>;
-
-}}    // namespace hpx::util
+        "hpx::util::unlock_guard is deprecated, use hpx::unlock_guard "
+        "instead") = hpx::unlock_guard<Mutex>;
+}    // namespace hpx::util

--- a/libs/core/thread_support/src/set_thread_name.cpp
+++ b/libs/core/thread_support/src/set_thread_name.cpp
@@ -13,7 +13,7 @@
 
 #include <hpx/thread_support/set_thread_name.hpp>
 
-namespace hpx { namespace util {
+namespace hpx::util {
     DWORD const MS_VC_EXCEPTION = 0x406D1388;
 
 #pragma pack(push, 8)
@@ -44,6 +44,6 @@ namespace hpx { namespace util {
         {
         }
     }
-}}    // namespace hpx::util
+}    // namespace hpx::util
 
 #endif

--- a/libs/core/timing/include/hpx/timing/high_resolution_clock.hpp
+++ b/libs/core/timing/include/hpx/timing/high_resolution_clock.hpp
@@ -17,7 +17,7 @@
 #include <chrono>
 #include <cstdint>
 
-namespace hpx { namespace chrono {
+namespace hpx::chrono {
 
     /// \brief Class \c hpx::chrono::high_resolution_clock represents the clock
     ///        with the smallest tick period provided by the implementation. It
@@ -46,8 +46,8 @@ namespace hpx { namespace chrono {
         // returned by this clock.
         static constexpr std::uint64_t(min)() noexcept
         {
-            typedef std::chrono::duration_values<std::chrono::nanoseconds>
-                duration_values;
+            using duration_values =
+                std::chrono::duration_values<std::chrono::nanoseconds>;
             return (duration_values::min)().count();
         }
 
@@ -55,9 +55,9 @@ namespace hpx { namespace chrono {
         // returned by this clock.
         static constexpr std::uint64_t(max)() noexcept
         {
-            typedef std::chrono::duration_values<std::chrono::nanoseconds>
-                duration_values;
+            using duration_values =
+                std::chrono::duration_values<std::chrono::nanoseconds>;
             return (duration_values::max)().count();
         }
     };
-}}    // namespace hpx::chrono
+}    // namespace hpx::chrono

--- a/libs/core/timing/include/hpx/timing/high_resolution_timer.hpp
+++ b/libs/core/timing/include/hpx/timing/high_resolution_timer.hpp
@@ -13,7 +13,7 @@
 
 #include <cstdint>
 
-namespace hpx { namespace chrono {
+namespace hpx::chrono {
 
     /// \brief high_resolution_timer is a timer object which measures
     ///        the elapsed time
@@ -91,4 +91,4 @@ namespace hpx { namespace chrono {
     private:
         std::uint64_t start_time_;
     };
-}}    // namespace hpx::chrono
+}    // namespace hpx::chrono

--- a/libs/core/timing/include/hpx/timing/scoped_timer.hpp
+++ b/libs/core/timing/include/hpx/timing/scoped_timer.hpp
@@ -12,11 +12,12 @@
 
 #include <cstdint>
 
-namespace hpx { namespace util {
+namespace hpx::util {
+
     template <typename T>
     struct scoped_timer
     {
-        scoped_timer(T& t, bool enabled = true)
+        explicit scoped_timer(T& t, bool enabled = true)
           : started_at_(enabled ? hpx::chrono::high_resolution_clock::now() : 0)
           , t_(enabled ? &t : nullptr)
         {
@@ -48,7 +49,7 @@ namespace hpx { namespace util {
             return *this;
         }
 
-        bool enabled() const noexcept
+        constexpr bool enabled() const noexcept
         {
             return t_ != nullptr;
         }
@@ -57,4 +58,4 @@ namespace hpx { namespace util {
         std::uint64_t started_at_;
         T* t_;
     };
-}}    // namespace hpx::util
+}    // namespace hpx::util

--- a/libs/core/timing/include/hpx/timing/steady_clock.hpp
+++ b/libs/core/timing/include/hpx/timing/steady_clock.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2012 Hartmut Kaiser
+//  Copyright (c) 2007-2022 Hartmut Kaiser
 //  Copyright (c) 2014-2016 Agustin Berge
 //
 //  SPDX-License-Identifier: BSL-1.0
@@ -14,21 +14,23 @@
 
 #include <chrono>
 
-namespace hpx { namespace chrono {
+namespace hpx::chrono {
+
     using std::chrono::steady_clock;
 
     class steady_time_point
     {
-        typedef steady_clock::time_point value_type;
+        using value_type = steady_clock::time_point;
 
     public:
-        constexpr steady_time_point(value_type const& abs_time) noexcept
+        /*implicit*/ constexpr steady_time_point(
+            value_type const& abs_time) noexcept
           : _abs_time(abs_time)
         {
         }
 
         template <typename Clock, typename Duration>
-        constexpr steady_time_point(
+        /*implicit*/ constexpr steady_time_point(
             std::chrono::time_point<Clock, Duration> const& abs_time) noexcept
           : _abs_time(std::chrono::time_point_cast<value_type::duration>(
                 steady_clock::now() + (abs_time - Clock::now())))
@@ -46,7 +48,7 @@ namespace hpx { namespace chrono {
 
     class steady_duration
     {
-        typedef steady_clock::duration value_type;
+        using value_type = steady_clock::duration;
 
     public:
         constexpr steady_duration() noexcept
@@ -54,13 +56,14 @@ namespace hpx { namespace chrono {
         {
         }
 
-        constexpr steady_duration(value_type const& rel_time) noexcept
+        /*implicit*/ constexpr steady_duration(
+            value_type const& rel_time) noexcept
           : _rel_time(rel_time)
         {
         }
 
         template <typename Rep, typename Period>
-        constexpr steady_duration(
+        /*implicit*/ constexpr steady_duration(
             std::chrono::duration<Rep, Period> const& rel_time) noexcept
           : _rel_time(std::chrono::duration_cast<value_type>(rel_time))
         {
@@ -84,4 +87,4 @@ namespace hpx { namespace chrono {
 
     inline constexpr steady_duration null_duration{};
 
-}}    // namespace hpx::chrono
+}    // namespace hpx::chrono

--- a/libs/core/timing/include/hpx/timing/tick_counter.hpp
+++ b/libs/core/timing/include/hpx/timing/tick_counter.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2005-2012 Hartmut Kaiser
+//  Copyright (c) 2005-2022 Hartmut Kaiser
 //  Copyright (c) 2014      Bryce Adelstein-Lelbach
 //
 //  SPDX-License-Identifier: BSL-1.0
@@ -11,7 +11,8 @@
 
 #include <cstdint>
 
-namespace hpx { namespace util {
+namespace hpx::util {
+
     ///////////////////////////////////////////////////////////////////////////
     //
     //  tick_counter - a timer
@@ -20,7 +21,7 @@ namespace hpx { namespace util {
     class tick_counter
     {
     public:
-        tick_counter(std::uint64_t& output)
+        explicit tick_counter(std::uint64_t& output)
           : start_time_(take_time_stamp())
           , output_(output)
         {
@@ -41,4 +42,4 @@ namespace hpx { namespace util {
         std::uint64_t const start_time_;
         std::uint64_t& output_;
     };
-}}    // namespace hpx::util
+}    // namespace hpx::util

--- a/libs/core/type_support/include/hpx/type_support/decay.hpp
+++ b/libs/core/type_support/include/hpx/type_support/decay.hpp
@@ -13,10 +13,11 @@
 #include <type_traits>
 #include <utility>
 
-namespace hpx { namespace util {
+namespace hpx::util {
 
     ///////////////////////////////////////////////////////////////////////////
     namespace detail {
+
         template <typename TD>
         struct decay_unwrap_impl
         {
@@ -37,4 +38,4 @@ namespace hpx { namespace util {
 
     template <typename T>
     using decay_unwrap_t = typename decay_unwrap<T>::type;
-}}    // namespace hpx::util
+}    // namespace hpx::util

--- a/libs/core/type_support/include/hpx/type_support/detail/with_result_of.hpp
+++ b/libs/core/type_support/include/hpx/type_support/detail/with_result_of.hpp
@@ -8,7 +8,8 @@
 
 #include <utility>
 
-namespace hpx { namespace util { namespace detail {
+namespace hpx::util::detail {
+
     // Based on
     // https://quuxplusone.github.io/blog/2018/05/17/super-elider-round-2/ and
     // https://akrzemi1.wordpress.com/2018/05/16/rvalues-redefined/.
@@ -26,20 +27,20 @@ namespace hpx { namespace util { namespace detail {
     public:
         using type = decltype(std::declval<F&&>()());
 
-        explicit with_result_of_t(F&& f)
+        explicit with_result_of_t(F&& f) noexcept
           : f(HPX_FORWARD(F, f))
         {
         }
 
-        operator type()
+        operator type() noexcept
         {
             return HPX_FORWARD(F, f)();
         }
     };
 
     template <typename F>
-    inline with_result_of_t<F> with_result_of(F&& f)
+    inline with_result_of_t<F> with_result_of(F&& f) noexcept
     {
         return with_result_of_t<F>(HPX_FORWARD(F, f));
     }
-}}}    // namespace hpx::util::detail
+}    // namespace hpx::util::detail

--- a/libs/core/type_support/include/hpx/type_support/detail/wrap_int.hpp
+++ b/libs/core/type_support/include/hpx/type_support/detail/wrap_int.hpp
@@ -8,10 +8,11 @@
 
 #include <hpx/config.hpp>
 
-namespace hpx { namespace traits { namespace detail {
+namespace hpx::traits::detail {
+
     // wraps int so that int argument is favored over wrap_int
     struct wrap_int
     {
-        constexpr wrap_int(int) {}
+        /*implicit*/ constexpr wrap_int(int) noexcept {}
     };
-}}}    // namespace hpx::traits::detail
+}    // namespace hpx::traits::detail

--- a/libs/core/type_support/include/hpx/type_support/detected.hpp
+++ b/libs/core/type_support/include/hpx/type_support/detected.hpp
@@ -11,7 +11,8 @@
 #include <type_traits>
 #include <utility>
 
-namespace hpx { namespace util {
+namespace hpx::util {
+
     // hpx::util::nonesuch is a class type used by hpx::util::detected_t to
     // indicate detection failure.
     struct nonesuch
@@ -24,6 +25,7 @@ namespace hpx { namespace util {
 
     ///////////////////////////////////////////////////////////////////////////
     namespace detail {
+
         template <typename Default, typename AlwaysVoid,
             template <typename...> class Op, typename... Args>
         struct detector
@@ -64,8 +66,8 @@ namespace hpx { namespace util {
     //
     // - If the template-id Op<Args...> is valid, then value_t is an alias for
     //   std::true_type, and type is an alias for Op<Args...>;
-    // - Otherwise, value_t is an alias for std::false_type and type is an
-    //   alias for Default.
+    // - Otherwise, value_t is an alias for std::false_type and type is an alias
+    //   for Default.
     template <typename Default, template <typename...> class Op,
         typename... Args>
     using detected_or = detail::detector<Default, void, Op, Args...>;
@@ -85,4 +87,4 @@ namespace hpx { namespace util {
     template <typename To, template <typename...> class Op, typename... Args>
     using is_detected_convertible =
         std::is_convertible<detected_t<Op, Args...>, To>;
-}}    // namespace hpx::util
+}    // namespace hpx::util

--- a/libs/core/type_support/include/hpx/type_support/empty_function.hpp
+++ b/libs/core/type_support/include/hpx/type_support/empty_function.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2021 Hartmut Kaiser
+//  Copyright (c) 2021-2022 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -6,7 +6,7 @@
 
 #pragma once
 
-namespace hpx { namespace util {
+namespace hpx::util {
 
     struct empty_function
     {
@@ -15,4 +15,4 @@ namespace hpx { namespace util {
         {
         }
     };
-}}    // namespace hpx::util
+}    // namespace hpx::util

--- a/libs/core/type_support/include/hpx/type_support/identity.hpp
+++ b/libs/core/type_support/include/hpx/type_support/identity.hpp
@@ -6,10 +6,38 @@
 
 #pragma once
 
-namespace hpx { namespace util {
-    template <typename T>
+#include <hpx/config.hpp>
+
+#include <functional>
+#include <type_traits>
+
+namespace hpx {
+
     struct identity
+    {
+        using is_transparent = std::true_type;
+
+        template <typename T>
+        HPX_HOST_DEVICE constexpr T&& operator()(T&& t) const noexcept
+        {
+            return HPX_FORWARD(T, t);
+        }
+    };
+
+    template <typename T>
+    struct type_identity
     {
         using type = T;
     };
-}}    // namespace hpx::util
+
+    template <typename T>
+    using type_identity_t = typename type_identity<T>::type;
+}    // namespace hpx
+
+namespace hpx::util {
+
+    template <typename T>
+    using identity HPX_DEPRECATED_V(1, 9,
+        "hpx::util::identity is deprecated, use hpx::type_identity instead") =
+        hpx::type_identity<T>;
+}    // namespace hpx::util

--- a/libs/core/type_support/include/hpx/type_support/lazy_conditional.hpp
+++ b/libs/core/type_support/include/hpx/type_support/lazy_conditional.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2016 Hartmut Kaiser
+//  Copyright (c) 2016-2022 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -8,12 +8,13 @@
 
 #include <type_traits>
 
-namespace hpx { namespace util {
+namespace hpx::util {
+
     template <bool Enable, typename C1, typename C2>
-    struct lazy_conditional : std::conditional<Enable, C1, C2>::type
+    struct lazy_conditional : std::conditional_t<Enable, C1, C2>
     {
     };
 
     template <bool Enable, typename C1, typename C2>
     using lazy_conditional_t = typename lazy_conditional<Enable, C1, C2>::type;
-}}    // namespace hpx::util
+}    // namespace hpx::util

--- a/libs/core/type_support/include/hpx/type_support/lazy_enable_if.hpp
+++ b/libs/core/type_support/include/hpx/type_support/lazy_enable_if.hpp
@@ -6,7 +6,8 @@
 
 #pragma once
 
-namespace hpx { namespace util {
+namespace hpx::util {
+
     template <bool Enable, typename T>
     struct lazy_enable_if
     {
@@ -17,4 +18,4 @@ namespace hpx { namespace util {
     {
         using type = typename T::type;
     };
-}}    // namespace hpx::util
+}    // namespace hpx::util

--- a/libs/core/type_support/include/hpx/type_support/meta.hpp
+++ b/libs/core/type_support/include/hpx/type_support/meta.hpp
@@ -14,7 +14,7 @@
 #include <type_traits>
 #include <utility>
 
-namespace hpx { namespace meta {
+namespace hpx::meta {
 
     ///////////////////////////////////////////////////////////////////////////
     // make an alias template that extracts the embedded ::type of T
@@ -478,4 +478,4 @@ namespace hpx { namespace meta {
         using apply =
             std::enable_if_t<sizeof...(As) <= 1, meta::type<front<As..., Ty>>>;
     };
-}}    // namespace hpx::meta
+}    // namespace hpx::meta

--- a/libs/core/type_support/include/hpx/type_support/pack.hpp
+++ b/libs/core/type_support/include/hpx/type_support/pack.hpp
@@ -11,7 +11,7 @@
 #include <cstddef>
 #include <type_traits>
 
-namespace hpx { namespace util {
+namespace hpx::util {
 
     template <typename... Ts>
     struct pack
@@ -32,6 +32,7 @@ namespace hpx { namespace util {
 
     ///////////////////////////////////////////////////////////////////////////
     namespace detail {
+
         template <typename Left, typename Right>
         struct make_index_pack_join;
 
@@ -74,6 +75,7 @@ namespace hpx { namespace util {
     ///////////////////////////////////////////////////////////////////////////
     // Workaround for clang bug [https://bugs.llvm.org/show_bug.cgi?id=35077]
     namespace detail {
+
         template <typename T>
         struct is_true : std::integral_constant<bool, (bool) T::value>
         {
@@ -87,6 +89,7 @@ namespace hpx { namespace util {
 
     ///////////////////////////////////////////////////////////////////////////
     namespace detail {
+
         template <typename... Ts>
         struct always_true : std::true_type
         {
@@ -98,10 +101,10 @@ namespace hpx { namespace util {
         };
 
         template <typename... Ts>
-        static std::false_type all_of(...);
+        static constexpr std::false_type all_of(...);
 
         template <typename... Ts>
-        static auto all_of(int)
+        static constexpr auto all_of(int)
             -> always_true<std::enable_if_t<is_true<Ts>::value>...>;
     }    // namespace detail
 
@@ -120,11 +123,12 @@ namespace hpx { namespace util {
     inline constexpr bool all_of_v = all_of<Ts...>::value;
 
     namespace detail {
-        template <typename... Ts>
-        static std::true_type any_of(...);
 
         template <typename... Ts>
-        static auto any_of(int)
+        static constexpr std::true_type any_of(...);
+
+        template <typename... Ts>
+        static constexpr auto any_of(int)
             -> always_false<std::enable_if_t<is_false<Ts>::value>...>;
     }    // namespace detail
 
@@ -157,6 +161,7 @@ namespace hpx { namespace util {
 
     ///////////////////////////////////////////////////////////////////////////
     namespace detail {
+
         struct empty
         {
         };
@@ -192,15 +197,15 @@ namespace hpx { namespace util {
         };
 
         template <std::size_t J>
-        static empty at_index_check(...);
+        static constexpr empty at_index_check(...);
 
         template <std::size_t J, typename T>
-        static indexed<J, T> at_index_check(indexed<J, T> const&);
+        static constexpr indexed<J, T> at_index_check(indexed<J, T> const&);
 
         template <std::size_t I, typename Ts>
         struct at_index_impl
           : decltype(detail::at_index_check<I>(
-                indexer<Ts, typename make_index_pack<Ts::size>::type>()))
+                indexer<Ts, make_index_pack_t<Ts::size>>()))
         {
         };
 #endif
@@ -215,6 +220,7 @@ namespace hpx { namespace util {
     using at_index_t = typename at_index<I, Ts...>::type;
 
     namespace detail {
+
         template <typename Pack, template <typename> class Transformer>
         struct transform;
 
@@ -360,4 +366,4 @@ namespace hpx { namespace util {
         template <template <typename...> class NewPack, typename OldPack>
         using change_pack_t = typename change_pack<NewPack, OldPack>::type;
     }    // namespace detail
-}}       // namespace hpx::util
+}    // namespace hpx::util

--- a/libs/core/type_support/include/hpx/type_support/static.hpp
+++ b/libs/core/type_support/include/hpx/type_support/static.hpp
@@ -24,7 +24,8 @@
 #endif
 // clang-format on
 
-namespace hpx { namespace util {
+namespace hpx::util {
+
 #if defined(HPX_GCC_VERSION) || defined(HPX_CLANG_VERSION) ||                  \
     (HPX_INTEL_VERSION > 1200 && !defined(HPX_WINDOWS)) || defined(HPX_MSVC)
 
@@ -39,10 +40,9 @@ namespace hpx { namespace util {
         HPX_NON_COPYABLE(static_);
 
     public:
-        typedef T value_type;
-
-        typedef T& reference;
-        typedef T const& const_reference;
+        using value_type = T;
+        using reference = T&;
+        using const_reference = T const&;
 
         static_()
         {
@@ -97,7 +97,7 @@ namespace hpx { namespace util {
         HPX_NON_COPYABLE(static_);
 
     public:
-        typedef T value_type;
+        using value_type = T;
 
     private:
         struct destructor
@@ -118,44 +118,44 @@ namespace hpx { namespace util {
         };
 
     public:
-        typedef T& reference;
-        typedef T const& const_reference;
+        using reference = T&;
+        using const_reference = T const&;
 
         static_()
         {
             std::call_once(constructed_, &default_constructor::construct);
         }
 
-        operator reference()
+        operator reference() noexcept
         {
             return this->get();
         }
 
-        operator const_reference() const
+        operator const_reference() const noexcept
         {
             return this->get();
         }
 
-        reference get()
+        reference get() noexcept
         {
             return *this->get_address();
         }
 
-        const_reference get() const
+        const_reference get() const noexcept
         {
             return *this->get_address();
         }
 
     private:
-        typedef typename std::add_pointer<value_type>::type pointer;
+        using pointer = std::add_pointer_t<value_type>;
 
-        static pointer get_address()
+        static pointer get_address() noexcept
         {
             return reinterpret_cast<pointer>(data_);
         }
 
-        typedef typename std::aligned_storage<sizeof(value_type),
-            std::alignment_of<value_type>::value>::type storage_type;
+        using storage_type = std::aligned_storage_t<sizeof(value_type),
+            std::alignment_of_v<value_type>>;
 
         static storage_type data_;
         static std::once_flag constructed_;
@@ -167,4 +167,4 @@ namespace hpx { namespace util {
     template <typename T, typename Tag>
     std::once_flag static_<T, Tag>::constructed_;
 #endif
-}}    // namespace hpx::util
+}    // namespace hpx::util

--- a/libs/core/type_support/include/hpx/type_support/unused.hpp
+++ b/libs/core/type_support/include/hpx/type_support/unused.hpp
@@ -16,7 +16,8 @@
 #endif
 // clang-format on
 
-namespace hpx { namespace util {
+namespace hpx::util {
+
     ///////////////////////////////////////////////////////////////////////////
     // We do not import fusion::unused_type anymore to avoid boost::fusion
     // being turned into an associate namespace, as this interferes with ADL
@@ -37,7 +38,8 @@ namespace hpx { namespace util {
         }
 
         template <typename T>
-        constexpr HPX_HOST_DEVICE HPX_FORCEINLINE unused_type(T const&) noexcept
+        /*implicit*/ constexpr HPX_HOST_DEVICE HPX_FORCEINLINE unused_type(
+            T const&) noexcept
         {
         }
 
@@ -79,9 +81,11 @@ namespace hpx { namespace util {
 
 #if defined(HPX_MSVC_NVCC)
     HPX_CONSTANT
+#else
+    inline constexpr
 #endif
-    constexpr unused_type unused = unused_type();
-}}    // namespace hpx::util
+    unused_type unused = unused_type();
+}    // namespace hpx::util
 
 //////////////////////////////////////////////////////////////////////////////
 // use this to silence compiler warnings related to unused function arguments.

--- a/libs/core/type_support/include/hpx/type_support/unwrap_ref.hpp
+++ b/libs/core/type_support/include/hpx/type_support/unwrap_ref.hpp
@@ -10,7 +10,7 @@
 
 #include <functional>
 
-namespace hpx { namespace util {
+namespace hpx::util {
 
     template <typename T>
     struct unwrap_reference
@@ -34,8 +34,9 @@ namespace hpx { namespace util {
     using unwrap_reference_t = typename unwrap_reference<T>::type;
 
     template <typename T>
-    HPX_FORCEINLINE unwrap_reference_t<T>& unwrap_ref(T& t)
+    HPX_HOST_DEVICE HPX_FORCEINLINE constexpr unwrap_reference_t<T>& unwrap_ref(
+        T& t) noexcept
     {
         return t;
     }
-}}    // namespace hpx::util
+}    // namespace hpx::util

--- a/libs/core/type_support/include/hpx/type_support/void_guard.hpp
+++ b/libs/core/type_support/include/hpx/type_support/void_guard.hpp
@@ -8,7 +8,8 @@
 
 #include <hpx/config.hpp>
 
-namespace hpx { namespace util {
+namespace hpx::util {
+
     ///////////////////////////////////////////////////////////////////////////
     // This utility simplifies templates returning compatible types
     //
@@ -29,4 +30,4 @@ namespace hpx { namespace util {
         {
         }
     };
-}}    // namespace hpx::util
+}    // namespace hpx::util

--- a/libs/full/runtime_components/src/console_logging.cpp
+++ b/libs/full/runtime_components/src/console_logging.cpp
@@ -48,27 +48,27 @@ namespace hpx { namespace components {
             switch (get<0>(msg))
             {
             default:
-            case destination_hpx:
+            case logging_destination::hpx:
                 LHPX_CONSOLE_(get<1>(msg)) << fail_msg << get<2>(msg);
                 break;
 
-            case destination_timing:
+            case logging_destination::timing:
                 LTIM_CONSOLE_(get<1>(msg)) << fail_msg << get<2>(msg);
                 break;
 
-            case destination_agas:
+            case logging_destination::agas:
                 LAGAS_CONSOLE_(get<1>(msg)) << fail_msg << get<2>(msg);
                 break;
 
-            case destination_parcel:
+            case logging_destination::parcel:
                 LPT_CONSOLE_(get<1>(msg)) << fail_msg << get<2>(msg);
                 break;
 
-            case destination_app:
+            case logging_destination::app:
                 LAPP_CONSOLE_(get<1>(msg)) << fail_msg << get<2>(msg);
                 break;
 
-            case destination_debuglog:
+            case logging_destination::debuglog:
                 LDEB_CONSOLE_ << fail_msg << get<2>(msg);
                 break;
             }

--- a/libs/full/runtime_components/src/server/console_logging_server.cpp
+++ b/libs/full/runtime_components/src/server/console_logging_server.cpp
@@ -61,27 +61,27 @@ namespace hpx { namespace components { namespace server {
 
             switch (dest)
             {
-            case destination_hpx:
+            case logging_destination::hpx:
                 LHPX_CONSOLE_(level) << s;
                 break;
 
-            case destination_timing:
+            case logging_destination::timing:
                 LTIM_CONSOLE_(level) << s;
                 break;
 
-            case destination_agas:
+            case logging_destination::agas:
                 LAGAS_CONSOLE_(level) << s;
                 break;
 
-            case destination_parcel:
+            case logging_destination::parcel:
                 LPT_CONSOLE_(level) << s;
                 break;
 
-            case destination_app:
+            case logging_destination::app:
                 LAPP_CONSOLE_(level) << s;
                 break;
 
-            case destination_debuglog:
+            case logging_destination::debuglog:
                 LDEB_CONSOLE_ << s;
                 break;
 


### PR DESCRIPTION
- flyby: HPX_FORWARD/HPX_MOVE now expand to std::forward and std::move if those are implemented as builtin functions

working towards #5497