### PR TITLE
Modernize error module

### DIFF
--- a/components/component_storage/include/hpx/components/component_storage/server/migrate_from_storage.hpp
+++ b/components/component_storage/include/hpx/components/component_storage/server/migrate_from_storage.hpp
@@ -128,7 +128,7 @@ namespace hpx { namespace components { namespace server {
     {
         if (!traits::component_supports_migration<Component>::call())
         {
-            HPX_THROW_EXCEPTION(invalid_status,
+            HPX_THROW_EXCEPTION(hpx::error::invalid_status,
                 "hpx::components::server::trigger_migrate_from_storage_here",
                 "attempting to migrate an instance of a component which "
                 "does not support migration");
@@ -137,7 +137,7 @@ namespace hpx { namespace components { namespace server {
 
         if (naming::get_locality_id_from_id(to_resurrect) != get_locality_id())
         {
-            HPX_THROW_EXCEPTION(invalid_status,
+            HPX_THROW_EXCEPTION(hpx::error::invalid_status,
                 "hpx::components::server::trigger_migrate_from_storage_here",
                 "this function has to be executed on the locality responsible "
                 "for managing the address of the given object");

--- a/components/component_storage/include/hpx/components/component_storage/server/migrate_to_storage.hpp
+++ b/components/component_storage/include/hpx/components/component_storage/server/migrate_to_storage.hpp
@@ -82,7 +82,7 @@ namespace hpx { namespace components { namespace server {
             {
                 agas::unmark_as_migrated(to_migrate.get_gid());
 
-                HPX_THROW_EXCEPTION(invalid_status,
+                HPX_THROW_EXCEPTION(hpx::error::invalid_status,
                     "hpx::components::server::migrate_to_storage_here",
                     "attempting to migrate an instance of a component which "
                     "was "
@@ -94,7 +94,7 @@ namespace hpx { namespace components { namespace server {
             {
                 agas::unmark_as_migrated(to_migrate.get_gid());
 
-                HPX_THROW_EXCEPTION(invalid_status,
+                HPX_THROW_EXCEPTION(hpx::error::invalid_status,
                     "hpx::components::server::migrate_to_storage_here",
                     "attempting to migrate an instance of a component which is "
                     "currently pinned");
@@ -138,7 +138,7 @@ namespace hpx { namespace components { namespace server {
     {
         if (!traits::component_supports_migration<Component>::call())
         {
-            HPX_THROW_EXCEPTION(invalid_status,
+            HPX_THROW_EXCEPTION(hpx::error::invalid_status,
                 "hpx::components::server::migrate_to_storage_here",
                 "attempting to migrate an instance of a component which "
                 "does not support migration");
@@ -173,7 +173,7 @@ namespace hpx { namespace components { namespace server {
 #if !defined(HPX_COMPUTE_DEVICE_CODE)
         if (!traits::component_supports_migration<Component>::call())
         {
-            HPX_THROW_EXCEPTION(invalid_status,
+            HPX_THROW_EXCEPTION(hpx::error::invalid_status,
                 "hpx::components::server::trigger_migrate_to_storage_here",
                 "attempting to migrate an instance of a component which "
                 "does not support migration");
@@ -182,7 +182,7 @@ namespace hpx { namespace components { namespace server {
 
         if (naming::get_locality_id_from_id(to_migrate) != get_locality_id())
         {
-            HPX_THROW_EXCEPTION(invalid_status,
+            HPX_THROW_EXCEPTION(hpx::error::invalid_status,
                 "hpx::components::server::trigger_migrate_to_storage_here",
                 "this function has to be executed on the locality responsible "
                 "for managing the address of the given object");
@@ -197,11 +197,10 @@ namespace hpx { namespace components { namespace server {
         future<id_type> f =
             async<action_type>(r.first, to_migrate, r.second, target_storage);
 
-        return f.then(
-            [to_migrate](future<hpx::id_type>&& f) -> hpx::id_type {
-                agas::end_migration(to_migrate);
-                return f.get();
-            });
+        return f.then([to_migrate](future<hpx::id_type>&& f) -> hpx::id_type {
+            agas::end_migration(to_migrate);
+            return f.get();
+        });
 #else
         HPX_ASSERT(false);
         HPX_UNUSED(to_migrate);

--- a/components/component_storage/src/server/component_storage_server.cpp
+++ b/components/component_storage/src/server/component_storage_server.cpp
@@ -10,11 +10,11 @@
 
 #include <vector>
 
-namespace hpx { namespace components { namespace server
-{
+namespace hpx { namespace components { namespace server {
     component_storage::component_storage()
       : data_(container_layout(find_all_localities()))
-    {}
+    {
+    }
 
     ///////////////////////////////////////////////////////////////////////////
     naming::gid_type component_storage::migrate_to_here(
@@ -26,16 +26,16 @@ namespace hpx { namespace components { namespace server
 
         // rebind the object to this storage locality
         naming::address addr(current_lva);
-        addr.address_ = nullptr;       // invalidate lva
+        addr.address_ = nullptr;    // invalidate lva
         if (!agas::bind(launch::sync, gid, addr, this->gid_))
         {
-            HPX_THROW_EXCEPTION(duplicate_component_address,
+            HPX_THROW_EXCEPTION(hpx::error::duplicate_component_address,
                 "component_storage::migrate_to_here",
                 "failed to rebind id {} to storage locality: {}", id, gid_);
             return naming::invalid_gid;
         }
 
-        id.make_unmanaged();            // we can now release the object
+        id.make_unmanaged();    // we can now release the object
         return naming::invalid_gid;
     }
 
@@ -43,9 +43,10 @@ namespace hpx { namespace components { namespace server
         naming::gid_type const& id)
     {
         // return the stored data and erase it from the map
-        return data_.get_value(launch::sync,
-            naming::detail::get_stripped_gid(id), true);
+        return data_.get_value(
+            launch::sync, naming::detail::get_stripped_gid(id), true);
     }
-}}}
+}}}    // namespace hpx::components::server
 
-HPX_REGISTER_UNORDERED_MAP(hpx::naming::gid_type, hpx_component_storage_data_type)
+HPX_REGISTER_UNORDERED_MAP(
+    hpx::naming::gid_type, hpx_component_storage_data_type)

--- a/components/containers/partitioned_vector/include/hpx/runtime/serialization/partitioned_vector.hpp
+++ b/components/containers/partitioned_vector/include/hpx/runtime/serialization/partitioned_vector.hpp
@@ -31,7 +31,7 @@ namespace hpx { namespace serialization
         if (pvec_registered_name.empty())
         {
             HPX_THROW_EXCEPTION(
-                hpx::invalid_status,
+                hpx::error::invalid_status,
                 "hpx::serialization::serialize",
                 "partitioned_vector is not registered");
         }

--- a/components/containers/unordered/include/hpx/components/containers/unordered/partition_unordered_map_component.hpp
+++ b/components/containers/unordered/include/hpx/components/containers/unordered/partition_unordered_map_component.hpp
@@ -225,7 +225,7 @@ namespace hpx { namespace server {
                 partition_unordered_map_.find(key);
             if (it == partition_unordered_map_.end())
             {
-                HPX_THROW_EXCEPTION(bad_parameter,
+                HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
                     "partition_unordered_map::get_value",
                     "unable to find requested key in this partition of the "
                     "unordered_map");
@@ -257,7 +257,7 @@ namespace hpx { namespace server {
                     partition_unordered_map_.find(keys[i]);
                 if (it == partition_unordered_map_.end())
                 {
-                    HPX_THROW_EXCEPTION(bad_parameter,
+                    HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
                         "partition_unordered_map::get_values",
                         "unable to find requested key in this partition of the "
                         "unordered_map");

--- a/components/iostreams/src/standard_streams.cpp
+++ b/components/iostreams/src/standard_streams.cpp
@@ -94,7 +94,7 @@ namespace hpx { namespace iostreams {
     {
         if (!agas::is_console())
         {
-            HPX_THROW_EXCEPTION(service_unavailable,
+            HPX_THROW_EXCEPTION(hpx::error::service_unavailable,
                 "hpx::iostreams::create_cout",
                 "this function should be called on the console only");
         }
@@ -105,7 +105,7 @@ namespace hpx { namespace iostreams {
     {
         if (!agas::is_console())
         {
-            HPX_THROW_EXCEPTION(service_unavailable,
+            HPX_THROW_EXCEPTION(hpx::error::service_unavailable,
                 "hpx::iostreams::create_cerr",
                 "this function should be called on the console only");
         }
@@ -116,7 +116,7 @@ namespace hpx { namespace iostreams {
     {
         if (!agas::is_console())
         {
-            HPX_THROW_EXCEPTION(service_unavailable,
+            HPX_THROW_EXCEPTION(hpx::error::service_unavailable,
                 "hpx::iostreams::create_consolestream",
                 "this function should be called on the console only");
         }
@@ -127,7 +127,7 @@ namespace hpx { namespace iostreams {
     {
         if (get_runtime_ptr() != nullptr && !agas::is_console())
         {
-            HPX_THROW_EXCEPTION(service_unavailable,
+            HPX_THROW_EXCEPTION(hpx::error::service_unavailable,
                 "hpx::iostreams::get_consolestream",
                 "this function should be called on the console only");
         }

--- a/components/parcel_plugins/binary_filter/bzip2/src/bzip2_serialization_filter.cpp
+++ b/components/parcel_plugins/binary_filter/bzip2/src/bzip2_serialization_filter.cpp
@@ -134,7 +134,7 @@ namespace hpx::plugins::compression {
         std::size_t s = load_impl(buffer_.data(), buffer_size, buffer, size);
         if (s > size)
         {
-            HPX_THROW_EXCEPTION(serialization_error,
+            HPX_THROW_EXCEPTION(hpx::error::serialization_error,
                 "bzip2_serialization_filter::load",
                 hpx::util::format(
                     "decompression failure, number of "
@@ -151,7 +151,7 @@ namespace hpx::plugins::compression {
     {
         if (current_ + dst_count > buffer_.size())
         {
-            HPX_THROW_EXCEPTION(serialization_error,
+            HPX_THROW_EXCEPTION(hpx::error::serialization_error,
                 "bzip2_serialization_filter::load",
                 "archive data bstream is too short");
             return;

--- a/components/parcel_plugins/binary_filter/snappy/src/snappy_serialization_filter.cpp
+++ b/components/parcel_plugins/binary_filter/snappy/src/snappy_serialization_filter.cpp
@@ -49,7 +49,7 @@ namespace hpx::plugins::compression {
     {
         if (current_ + dst_count > buffer_.size())
         {
-            HPX_THROW_EXCEPTION(serialization_error,
+            HPX_THROW_EXCEPTION(hpx::error::serialization_error,
                 "snappy_serialization_filter::load",
                 "archive data bstream is too short");
             return;
@@ -89,7 +89,7 @@ namespace hpx::plugins::compression {
 
         if (compressed_length > dst_count)
         {
-            HPX_THROW_EXCEPTION(serialization_error,
+            HPX_THROW_EXCEPTION(hpx::error::serialization_error,
                 "snappy_serialization_filter::flush",
                 "compression failure, flushing did not reach end of data");
             return false;

--- a/components/parcel_plugins/binary_filter/zlib/src/zlib_serialization_filter.cpp
+++ b/components/parcel_plugins/binary_filter/zlib/src/zlib_serialization_filter.cpp
@@ -99,7 +99,7 @@ namespace hpx::plugins::compression {
         std::size_t s = load_impl(buffer_.data(), buffer_size, buffer, size);
         if (s > size)
         {
-            HPX_THROW_EXCEPTION(serialization_error,
+            HPX_THROW_EXCEPTION(hpx::error::serialization_error,
                 "zlib_serialization_filter::load",
                 hpx::util::format(
                     "decompression failure, number of "
@@ -117,7 +117,7 @@ namespace hpx::plugins::compression {
     {
         if (current_ + dst_count > buffer_.size())
         {
-            HPX_THROW_EXCEPTION(serialization_error,
+            HPX_THROW_EXCEPTION(hpx::error::serialization_error,
                 "zlib_serialization_filter::load",
                 "archive data bstream is too short");
             return;

--- a/components/parcel_plugins/coalescing/src/coalescing_counter_registry.cpp
+++ b/components/parcel_plugins/coalescing/src/coalescing_counter_registry.cpp
@@ -37,7 +37,7 @@ namespace hpx::plugins::parcel {
     {
         if (name.empty())
         {
-            HPX_THROW_EXCEPTION(bad_parameter,
+            HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
                 "coalescing_counter_registry::register_action",
                 "Cannot register an action with an empty name");
         }
@@ -86,7 +86,7 @@ namespace hpx::plugins::parcel {
     {
         if (name.empty())
         {
-            HPX_THROW_EXCEPTION(bad_parameter,
+            HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
                 "coalescing_counter_registry::register_action",
                 "Cannot register an action with an empty name");
         }
@@ -111,7 +111,7 @@ namespace hpx::plugins::parcel {
         if (it == map_.end())
         {
             l.unlock();
-            HPX_THROW_EXCEPTION(bad_parameter,
+            HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
                 "coalescing_counter_registry::get_num_parcels_counter",
                 "unknown action type");
             return get_counter_type();
@@ -129,7 +129,7 @@ namespace hpx::plugins::parcel {
         if (it == map_.end())
         {
             l.unlock();
-            HPX_THROW_EXCEPTION(bad_parameter,
+            HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
                 "coalescing_counter_registry::get_num_messages_counter",
                 "unknown action type");
             return get_counter_type();
@@ -147,7 +147,7 @@ namespace hpx::plugins::parcel {
         if (it == map_.end())
         {
             l.unlock();
-            HPX_THROW_EXCEPTION(bad_parameter,
+            HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
                 "coalescing_counter_registry::get_num_messages_counter",
                 "unknown action type");
             return get_counter_type();
@@ -165,7 +165,7 @@ namespace hpx::plugins::parcel {
         if (it == map_.end())
         {
             l.unlock();
-            HPX_THROW_EXCEPTION(bad_parameter,
+            HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
                 "coalescing_counter_registry::"
                 "get_average_time_between_parcels_counter",
                 "unknown action type");
@@ -185,7 +185,7 @@ namespace hpx::plugins::parcel {
         if (it == map_.end())
         {
             l.unlock();
-            HPX_THROW_EXCEPTION(bad_parameter,
+            HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
                 "coalescing_counter_registry::"
                 "get_time_between_parcels_histogram_counter",
                 "unknown action type");
@@ -301,7 +301,7 @@ namespace hpx::plugins::parcel {
                     }
                 }
 
-                HPX_THROWS_IF(ec, bad_parameter,
+                HPX_THROWS_IF(ec, hpx::error::bad_parameter,
                     "coalescing_counter_registry::counter_discoverer",
                     "action type {} does not match any known type, "
                     "known action types: \n{}",
@@ -348,7 +348,7 @@ namespace hpx::plugins::parcel {
                 }
 
                 l.unlock();
-                HPX_THROWS_IF(ec, bad_parameter,
+                HPX_THROWS_IF(ec, hpx::error::bad_parameter,
                     "coalescing_counter_registry::counter_discoverer",
                     "action type {} does not match any known type, "
                     "known action types: \n{}",

--- a/components/parcel_plugins/coalescing/src/coalescing_message_handler.cpp
+++ b/components/parcel_plugins/coalescing/src/coalescing_message_handler.cpp
@@ -202,7 +202,7 @@ namespace hpx::plugins::parcel {
 
         default:
             l.unlock();
-            HPX_THROW_EXCEPTION(bad_parameter,
+            HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
                 "coalescing_message_handler::put_parcel",
                 "unexpected return value from message_buffer::append");
             return;
@@ -377,7 +377,7 @@ namespace hpx::plugins::parcel {
         if (!time_between_parcels_)
         {
             l.unlock();
-            HPX_THROW_EXCEPTION(bad_parameter,
+            HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
                 "coalescing_message_handler::"
                 "get_time_between_parcels_histogram",
                 "parcel-arrival-histogram counter was not initialized for "

--- a/components/parcel_plugins/coalescing/src/performance_counters.cpp
+++ b/components/parcel_plugins/coalescing/src/performance_counters.cpp
@@ -103,7 +103,8 @@ namespace hpx::plugins::parcel {
 
             if (paths.parentinstance_is_basename_)
             {
-                HPX_THROWS_IF(ec, bad_parameter, "num_parcels_counter_creator",
+                HPX_THROWS_IF(ec, hpx::error::bad_parameter,
+                    "num_parcels_counter_creator",
                     "invalid counter name for number of parcels (instance "
                     "name must not be a valid base counter name)");
                 return naming::invalid_gid;
@@ -111,7 +112,8 @@ namespace hpx::plugins::parcel {
 
             if (paths.parameters_.empty())
             {
-                HPX_THROWS_IF(ec, bad_parameter, "num_parcels_counter_creator",
+                HPX_THROWS_IF(ec, hpx::error::bad_parameter,
+                    "num_parcels_counter_creator",
                     "invalid counter parameter for number of parcels: must "
                     "specify an action type");
                 return naming::invalid_gid;
@@ -135,7 +137,8 @@ namespace hpx::plugins::parcel {
         break;
 
         default:
-            HPX_THROWS_IF(ec, bad_parameter, "num_parcels_counter_creator",
+            HPX_THROWS_IF(ec, hpx::error::bad_parameter,
+                "num_parcels_counter_creator",
                 "invalid counter type requested");
             return naming::invalid_gid;
         }
@@ -184,7 +187,8 @@ namespace hpx::plugins::parcel {
 
             if (paths.parentinstance_is_basename_)
             {
-                HPX_THROWS_IF(ec, bad_parameter, "num_messages_counter_creator",
+                HPX_THROWS_IF(ec, hpx::error::bad_parameter,
+                    "num_messages_counter_creator",
                     "invalid counter name for number of parcels (instance "
                     "name must not be a valid base counter name)");
                 return naming::invalid_gid;
@@ -192,7 +196,8 @@ namespace hpx::plugins::parcel {
 
             if (paths.parameters_.empty())
             {
-                HPX_THROWS_IF(ec, bad_parameter, "num_messages_counter_creator",
+                HPX_THROWS_IF(ec, hpx::error::bad_parameter,
+                    "num_messages_counter_creator",
                     "invalid counter parameter for number of parcels: must "
                     "specify an action type");
                 return naming::invalid_gid;
@@ -216,7 +221,8 @@ namespace hpx::plugins::parcel {
         break;
 
         default:
-            HPX_THROWS_IF(ec, bad_parameter, "num_messages_counter_creator",
+            HPX_THROWS_IF(ec, hpx::error::bad_parameter,
+                "num_messages_counter_creator",
                 "invalid counter type requested");
             return naming::invalid_gid;
         }
@@ -266,7 +272,7 @@ namespace hpx::plugins::parcel {
 
             if (paths.parentinstance_is_basename_)
             {
-                HPX_THROWS_IF(ec, bad_parameter,
+                HPX_THROWS_IF(ec, hpx::error::bad_parameter,
                     "num_parcels_per_message_counter_creator",
                     "invalid counter name for number of parcels (instance "
                     "name must not be a valid base counter name)");
@@ -275,7 +281,7 @@ namespace hpx::plugins::parcel {
 
             if (paths.parameters_.empty())
             {
-                HPX_THROWS_IF(ec, bad_parameter,
+                HPX_THROWS_IF(ec, hpx::error::bad_parameter,
                     "num_parcels_per_message_counter_creator",
                     "invalid counter parameter for number of parcels: must "
                     "specify an action type");
@@ -301,7 +307,7 @@ namespace hpx::plugins::parcel {
         break;
 
         default:
-            HPX_THROWS_IF(ec, bad_parameter,
+            HPX_THROWS_IF(ec, hpx::error::bad_parameter,
                 "num_parcels_per_message_counter_creator",
                 "invalid counter type requested");
             return naming::invalid_gid;
@@ -352,7 +358,7 @@ namespace hpx::plugins::parcel {
 
             if (paths.parentinstance_is_basename_)
             {
-                HPX_THROWS_IF(ec, bad_parameter,
+                HPX_THROWS_IF(ec, hpx::error::bad_parameter,
                     "average_time_between_parcels_counter_creator",
                     "invalid counter name for number of parcels (instance "
                     "name must not be a valid base counter name)");
@@ -361,7 +367,7 @@ namespace hpx::plugins::parcel {
 
             if (paths.parameters_.empty())
             {
-                HPX_THROWS_IF(ec, bad_parameter,
+                HPX_THROWS_IF(ec, hpx::error::bad_parameter,
                     "average_time_between_parcels_counter_creator",
                     "invalid counter parameter for number of parcels: must "
                     "specify an action type");
@@ -389,7 +395,7 @@ namespace hpx::plugins::parcel {
         break;
 
         default:
-            HPX_THROWS_IF(ec, bad_parameter,
+            HPX_THROWS_IF(ec, hpx::error::bad_parameter,
                 "average_time_between_parcels_counter_creator",
                 "invalid counter type requested");
             return naming::invalid_gid;
@@ -464,7 +470,7 @@ namespace hpx::plugins::parcel {
 
             if (paths.parentinstance_is_basename_)
             {
-                HPX_THROWS_IF(ec, bad_parameter,
+                HPX_THROWS_IF(ec, hpx::error::bad_parameter,
                     "time_between_parcels_histogram_counter_creator",
                     "invalid counter name for "
                     "time-between-parcels histogram (instance "
@@ -474,7 +480,7 @@ namespace hpx::plugins::parcel {
 
             if (paths.parameters_.empty())
             {
-                HPX_THROWS_IF(ec, bad_parameter,
+                HPX_THROWS_IF(ec, hpx::error::bad_parameter,
                     "time_between_parcels_histogram_counter_creator",
                     "invalid counter parameter for "
                     "time-between-parcels histogram: must "
@@ -494,7 +500,7 @@ namespace hpx::plugins::parcel {
 
             if (params.empty() || params[0].empty())
             {
-                HPX_THROWS_IF(ec, bad_parameter,
+                HPX_THROWS_IF(ec, hpx::error::bad_parameter,
                     "time_between_parcels_histogram_counter_creator",
                     "invalid counter parameter for "
                     "time-between-parcels histogram: "
@@ -530,7 +536,7 @@ namespace hpx::plugins::parcel {
         break;
 
         default:
-            HPX_THROWS_IF(ec, bad_parameter,
+            HPX_THROWS_IF(ec, hpx::error::bad_parameter,
                 "time_between_parcels_histogram_counter_creator",
                 "invalid counter type requested");
             return naming::invalid_gid;

--- a/components/performance_counters/io/src/io_counters.cpp
+++ b/components/performance_counters/io/src/io_counters.cpp
@@ -35,7 +35,7 @@
 #endif
 
 // type to store parser output
-BOOST_FUSION_DEFINE_STRUCT((hpx) (performance_counters) (io), proc_io,
+BOOST_FUSION_DEFINE_STRUCT((hpx)(performance_counters)(io), proc_io,
     (std::uint64_t, riss)(std::uint64_t, wiss)(std::uint64_t, rsysc)(
         std::uint64_t, wsysc)(std::uint64_t, rstor)(std::uint64_t, wstor)(
         std::uint64_t, wcanc))
@@ -81,7 +81,7 @@ namespace hpx { namespace performance_counters { namespace io {
         std::ifstream ins(fn);
 
         if (!ins.is_open())
-            HPX_THROW_EXCEPTION(hpx::no_success,
+            HPX_THROW_EXCEPTION(hpx::error::no_success,
                 "hpx::performance_counters::io::parse_proc_io",
                 hpx::util::format("failed to open /proc/{1}/io", pid));
 
@@ -90,7 +90,7 @@ namespace hpx { namespace performance_counters { namespace io {
         proc_io_parser<iterator> p;
 
         if (!qi::phrase_parse(it, end, p, ascii::space, pio))
-            HPX_THROW_EXCEPTION(hpx::no_success,
+            HPX_THROW_EXCEPTION(hpx::error::no_success,
                 "hpx::performance_counters::io::parse_proc_io",
                 hpx::util::format("failed to parse /proc/{1}/io", pid));
     }

--- a/components/performance_counters/memory_counters/src/mem_counter_linux.cpp
+++ b/components/performance_counters/memory_counters/src/mem_counter_linux.cpp
@@ -104,7 +104,7 @@ namespace hpx { namespace performance_counters { namespace memory {
 
         if (!read_proc_statm(ps, getpid()))
         {
-            HPX_THROW_EXCEPTION(hpx::invalid_data,
+            HPX_THROW_EXCEPTION(hpx::error::invalid_data,
                 "hpx::performance_counters::memory::read_psm_virtual",
                 "failed to parse '/proc/{1}/statm'", getpid());
             return std::uint64_t(-1);
@@ -121,7 +121,7 @@ namespace hpx { namespace performance_counters { namespace memory {
 
         if (!read_proc_statm(ps, getpid()))
         {
-            HPX_THROW_EXCEPTION(hpx::invalid_data,
+            HPX_THROW_EXCEPTION(hpx::error::invalid_data,
                 "hpx::performance_counters::memory::read_psm_resident",
                 "failed to parse '/proc/{1}/statm'", getpid());
             return std::uint64_t(-1);

--- a/components/performance_counters/memory_counters/src/mem_counter_macosx.cpp
+++ b/components/performance_counters/memory_counters/src/mem_counter_macosx.cpp
@@ -29,7 +29,7 @@ namespace hpx { namespace performance_counters { namespace memory
                 reinterpret_cast<task_info_t>(&t_info),
                 &t_info_count) != KERN_SUCCESS)
         {
-            HPX_THROW_EXCEPTION(kernel_error,
+            HPX_THROW_EXCEPTION(hpx::error::kernel_error,
                 "hpx::performance_counters::memory::read_psm_virtual",
                 "task_info failed");
 
@@ -51,7 +51,7 @@ namespace hpx { namespace performance_counters { namespace memory
                 reinterpret_cast<task_info_t>(&t_info),
                 &t_info_count) != KERN_SUCCESS)
         {
-            HPX_THROW_EXCEPTION(kernel_error,
+            HPX_THROW_EXCEPTION(hpx::error::kernel_error,
                 "hpx::performance_counters::memory::read_psm_virtual",
                 "task_info failed");
 

--- a/components/performance_counters/memory_counters/src/mem_counter_windows.cpp
+++ b/components/performance_counters/memory_counters/src/mem_counter_windows.cpp
@@ -14,11 +14,10 @@
 #include <cstring>
 #include <string>
 
-#include <windows.h> // this must go before psapi.h
 #include <psapi.h>
+#include <windows.h>    // this must go before psapi.h
 
-namespace hpx { namespace performance_counters { namespace memory
-{
+namespace hpx { namespace performance_counters { namespace memory {
     ///////////////////////////////////////////////////////////////////////////
     // returns virtual memory value
     std::uint64_t read_psm_virtual(bool)
@@ -33,14 +32,15 @@ namespace hpx { namespace performance_counters { namespace memory
         {
             HRESULT hr = GetLastError();
             LPVOID buffer = 0;
-            if (!FormatMessage(
-                FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM |
-                FORMAT_MESSAGE_IGNORE_INSERTS,
-                nullptr, hr,
-                MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), // Default language
-                (LPTSTR) &buffer, 0, nullptr))
+            if (!FormatMessage(FORMAT_MESSAGE_ALLOCATE_BUFFER |
+                        FORMAT_MESSAGE_FROM_SYSTEM |
+                        FORMAT_MESSAGE_IGNORE_INSERTS,
+                    nullptr, hr,
+                    MAKELANGID(
+                        LANG_NEUTRAL, SUBLANG_DEFAULT),    // Default language
+                    (LPTSTR) &buffer, 0, nullptr))
             {
-                HPX_THROW_EXCEPTION(kernel_error,
+                HPX_THROW_EXCEPTION(hpx::error::kernel_error,
                     "hpx::performance_counters::memory::read_psm_virtual",
                     "format message failed with {:x} (while retrieving message "
                     "for {:x})",
@@ -50,7 +50,7 @@ namespace hpx { namespace performance_counters { namespace memory
 
             std::string msg(static_cast<char*>(buffer));
             LocalFree(buffer);
-            HPX_THROW_EXCEPTION(kernel_error,
+            HPX_THROW_EXCEPTION(hpx::error::kernel_error,
                 "hpx::performance_counters::memory::read_psm_virtual", msg);
             return std::uint64_t(-1);
         }
@@ -72,14 +72,15 @@ namespace hpx { namespace performance_counters { namespace memory
         {
             HRESULT hr = GetLastError();
             LPVOID buffer = 0;
-            if (!FormatMessage(
-                FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM |
-                FORMAT_MESSAGE_IGNORE_INSERTS,
-                nullptr, hr,
-                MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), // Default language
-                (LPTSTR) &buffer, 0, nullptr))
+            if (!FormatMessage(FORMAT_MESSAGE_ALLOCATE_BUFFER |
+                        FORMAT_MESSAGE_FROM_SYSTEM |
+                        FORMAT_MESSAGE_IGNORE_INSERTS,
+                    nullptr, hr,
+                    MAKELANGID(
+                        LANG_NEUTRAL, SUBLANG_DEFAULT),    // Default language
+                    (LPTSTR) &buffer, 0, nullptr))
             {
-                HPX_THROW_EXCEPTION(kernel_error,
+                HPX_THROW_EXCEPTION(hpx::error::kernel_error,
                     "hpx::performance_counters::memory::read_psm_resident",
                     "format message failed with {:x} (while retrieving message "
                     "for {:x})",
@@ -89,7 +90,7 @@ namespace hpx { namespace performance_counters { namespace memory
 
             std::string msg(static_cast<char*>(buffer));
             LocalFree(buffer);
-            HPX_THROW_EXCEPTION(kernel_error,
+            HPX_THROW_EXCEPTION(hpx::error::kernel_error,
                 "hpx::performance_counters::memory::read_psm_resident", msg);
             return std::uint64_t(-1);
         }
@@ -108,14 +109,15 @@ namespace hpx { namespace performance_counters { namespace memory
         {
             HRESULT hr = GetLastError();
             LPVOID buffer = 0;
-            if (!FormatMessage(
-                FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM |
-                FORMAT_MESSAGE_IGNORE_INSERTS,
-                nullptr, hr,
-                MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), // Default language
-                (LPTSTR) &buffer, 0, nullptr))
+            if (!FormatMessage(FORMAT_MESSAGE_ALLOCATE_BUFFER |
+                        FORMAT_MESSAGE_FROM_SYSTEM |
+                        FORMAT_MESSAGE_IGNORE_INSERTS,
+                    nullptr, hr,
+                    MAKELANGID(
+                        LANG_NEUTRAL, SUBLANG_DEFAULT),    // Default language
+                    (LPTSTR) &buffer, 0, nullptr))
             {
-                HPX_THROW_EXCEPTION(kernel_error,
+                HPX_THROW_EXCEPTION(hpx::error::kernel_error,
                     "hpx::performance_counters::memory::read_total_mem_avail",
                     "format message failed with {:x} (while "
                     "retrieving message for {:x})",
@@ -125,13 +127,13 @@ namespace hpx { namespace performance_counters { namespace memory
 
             std::string msg(static_cast<char*>(buffer));
             LocalFree(buffer);
-            HPX_THROW_EXCEPTION(kernel_error,
+            HPX_THROW_EXCEPTION(hpx::error::kernel_error,
                 "hpx::performance_counters::memory::read_total_mem_avail", msg);
             return std::uint64_t(-1);
         }
 
         return mem_status.ullAvailPhys;
     }
-}}}
+}}}    // namespace hpx::performance_counters::memory
 
 #endif

--- a/components/performance_counters/papi/include/hpx/components/performance_counters/papi/util/papi.hpp
+++ b/components/performance_counters/papi/include/hpx/components/performance_counters/papi/util/papi.hpp
@@ -41,7 +41,7 @@ namespace hpx {
     {
         if (rc != ok)
         {
-            HPX_THROW_EXCEPTION(hpx::no_success, fname,
+            HPX_THROW_EXCEPTION(hpx::error::no_success, fname,
                 hpx::util::format("{} ({})", info, PAPI_strerror(rc)));
         }
     }
@@ -219,9 +219,8 @@ namespace hpx {
         {
             PAPI_component_info_t const* ci = PAPI_get_component_info(comp);
             if (!ci)
-                HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                    "hpx::performance_counters::papi::util::native_enumerator("
-                    ")",
+                HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
+                    "hpx::performance_counters::papi::util::native_enumerator",
                     "invalid PAPI component index");
             umasks_present_ = ci->cntr_umasks;
         }

--- a/components/performance_counters/papi/src/papi_startup.cpp
+++ b/components/performance_counters/papi/src/papi_startup.cpp
@@ -64,7 +64,7 @@ namespace hpx { namespace performance_counters { namespace papi {
 
         if (paths.parentinstance_is_basename_)
         {
-            HPX_THROWS_IF(ec, hpx::bad_parameter,
+            HPX_THROWS_IF(ec, hpx::error::bad_parameter,
                 NS_STR "create_papi_counter()",
                 "unsupported counter instance parent name: " +
                     paths.parentinstancename_);
@@ -76,7 +76,7 @@ namespace hpx { namespace performance_counters { namespace papi {
         std::uint32_t tix = util::get_counter_thread(paths, label);
         if (tix == thread_mapper::invalid_index)
         {
-            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+            HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
                 NS_STR "create_papi_counter()",
                 "cannot find thread specified in " + info.fullname_);
         }
@@ -317,7 +317,7 @@ namespace hpx { namespace performance_counters { namespace papi {
         {
             if (PAPI_library_init(PAPI_VER_CURRENT) != PAPI_VER_CURRENT)
             {
-                HPX_THROW_EXCEPTION(hpx::no_success,
+                HPX_THROW_EXCEPTION(hpx::error::no_success,
                     "hpx::performance_counters::papi::check_startup()",
                     "PAPI library initialization failed (version mismatch)");
             }

--- a/components/performance_counters/papi/src/server/papi.cpp
+++ b/components/performance_counters/papi/src/server/papi.cpp
@@ -71,7 +71,7 @@ namespace hpx { namespace performance_counters { namespace papi {
                 "cannot assign component index to event set", locstr);
             pid_t tid = tm.get_linux_thread_id(tix);
             if (tid == -1)
-                HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
                     NS_STR "thread_counters::thread_counters()",
                     "unable to retrieve correct OS thread ID for profiling "
                     "(perhaps thread was not registered)");
@@ -267,14 +267,14 @@ namespace hpx { namespace performance_counters { namespace papi {
             std::uint32_t tix = util::get_counter_thread(cpe, label);
             if (tix == hpx::util::thread_mapper::invalid_index)
             {
-                HPX_THROW_EXCEPTION(
-                    hpx::no_success, locstr, "could not find thread " + label);
+                HPX_THROW_EXCEPTION(hpx::error::no_success, locstr,
+                    "could not find thread " + label);
             }
             // associate low level counters object
             counters_ = get_thread_counters(tix);
             if (!counters_)
             {
-                HPX_THROW_EXCEPTION(hpx::no_success, locstr,
+                HPX_THROW_EXCEPTION(hpx::error::no_success, locstr,
                     "failed to find low level counters for thread " + label);
             }
             // counting is not enabled here; it has to be started explicitly

--- a/components/performance_counters/papi/src/util/papi.cpp
+++ b/components/performance_counters/papi/src/util/papi.cpp
@@ -45,7 +45,7 @@ namespace hpx {
     {
         std::map<std::string, int>::const_iterator it = papi_domain_map.find(s);
         if (it == papi_domain_map.end())
-            HPX_THROW_EXCEPTION(hpx::commandline_option_error,
+            HPX_THROW_EXCEPTION(hpx::error::commandline_option_error,
                 NS_STR "check_options()",
                 "invalid argument " + s + " to --hpx:papi-domain");
         return it->second;
@@ -90,7 +90,7 @@ namespace hpx {
         variables_map vm;
         if (!retrieve_commandline_arguments(get_options_description(), vm))
         {
-            HPX_THROW_EXCEPTION(hpx::commandline_option_error,
+            HPX_THROW_EXCEPTION(hpx::error::commandline_option_error,
                 NS_STR "get_options()",
                 "failed to handle command line options");
         }
@@ -129,7 +129,7 @@ namespace hpx {
         {
             std::string v = vm["hpx:papi-event-info"].as<std::string>();
             if (v != "preset" && v != "native" && v != "all")
-                HPX_THROW_EXCEPTION(hpx::commandline_option_error,
+                HPX_THROW_EXCEPTION(hpx::error::commandline_option_error,
                     NS_STR "check_options()",
                     "unsupported mode " + v + " in --hpx:papi-event-info");
         }
@@ -144,11 +144,12 @@ namespace hpx {
         }
         // FIXME: implement multiplexing properly and uncomment below when done
         if (vm.count("hpx:papi-multiplex"))
-            HPX_THROW_EXCEPTION(hpx::not_implemented, NS_STR "check_options()",
+            HPX_THROW_EXCEPTION(hpx::error::not_implemented,
+                NS_STR "check_options()",
                 "counter multiplexing is currently not supported");
 #if 0
         if (vm.count("hpx:papi-multiplex") && vm["hpx:papi-multiplex"].as<long>() < 0)
-            HPX_THROW_EXCEPTION(hpx::commandline_option_error,
+            HPX_THROW_EXCEPTION(hpx::error::commandline_option_error,
                 NS_STR "check_options()",
                 "argument to --hpx:papi-multiplex must be positive");
 #endif

--- a/components/performance_counters/power/src/power_counter.cpp
+++ b/components/performance_counters/power/src/power_counter.cpp
@@ -74,7 +74,7 @@ namespace hpx::performance_counters::power {
             if (rc != PWR_RET_SUCCESS || cntxt == nullptr)
             {
                 l.unlock();
-                HPX_THROW_EXCEPTION(bad_request, "power::init",
+                HPX_THROW_EXCEPTION(hpx::error::bad_request, "power::init",
                     hpx::util::format(
                         "PWR_CntxtInit returned error: {} (locality: {})", rc,
                         hpx::get_locality_name()));
@@ -84,7 +84,7 @@ namespace hpx::performance_counters::power {
             if (rc != PWR_RET_SUCCESS || obj == nullptr)
             {
                 l.unlock();
-                HPX_THROW_EXCEPTION(bad_request, "power::init",
+                HPX_THROW_EXCEPTION(hpx::error::bad_request, "power::init",
                     hpx::util::format(
                         "PWR_CntxtGetObjByName returned error: {} "
                         "(locality: {})",
@@ -102,7 +102,8 @@ namespace hpx::performance_counters::power {
             if (rc != PWR_RET_SUCCESS)
             {
                 l.unlock();
-                HPX_THROW_EXCEPTION(bad_request, "power::sample_power",
+                HPX_THROW_EXCEPTION(hpx::error::bad_request,
+                    "power::sample_power",
                     hpx::util::format(
                         "PWR_ObjAttrGetValue returned error: {} (locality: {})",
                         rc, hpx::get_locality_name()));

--- a/components/process/include/hpx/components/process/util/posix/terminate.hpp
+++ b/components/process/include/hpx/components/process/util/posix/terminate.hpp
@@ -25,7 +25,7 @@ void terminate(const Process &p)
 {
     if (::kill(p.pid, SIGKILL) == -1)
     {
-        HPX_THROW_EXCEPTION(invalid_status,
+        HPX_THROW_EXCEPTION(hpx::error::invalid_status,
             "process::terminate", "kill(2) failed");
     }
 }
@@ -35,7 +35,7 @@ void terminate(const Process &p, hpx::error_code &ec)
 {
     if (::kill(p.pid, SIGKILL) == -1)
     {
-        HPX_THROWS_IF(ec, invalid_status,
+        HPX_THROWS_IF(ec, hpx::error::invalid_status,
             "process::terminate", "kill(2) failed");
     }
     else

--- a/components/process/include/hpx/components/process/util/posix/wait_for_exit.hpp
+++ b/components/process/include/hpx/components/process/util/posix/wait_for_exit.hpp
@@ -32,7 +32,7 @@ inline int wait_for_exit(const Process &p)
 
     if (ret == -1)
     {
-        HPX_THROW_EXCEPTION(invalid_status,
+        HPX_THROW_EXCEPTION(hpx::error::invalid_status,
             "process::wait_for_exit", "waitpid(2) failed");
     }
     return WEXITSTATUS(status);
@@ -50,7 +50,7 @@ inline int wait_for_exit(const Process &p, hpx::error_code &ec)
 
     if (ret == -1)
     {
-        HPX_THROWS_IF(ec, invalid_status,
+        HPX_THROWS_IF(ec, hpx::error::invalid_status,
             "process::wait_for_exit", "waitpid(2) failed");
     }
     else

--- a/components/process/include/hpx/components/process/util/windows/initializers/throw_on_error.hpp
+++ b/components/process/include/hpx/components/process/util/windows/initializers/throw_on_error.hpp
@@ -21,40 +21,41 @@
 
 namespace hpx { namespace components { namespace process { namespace windows {
 
-namespace initializers {
+    namespace initializers {
 
-class throw_on_error : public initializer_base
-{
-public:
-    template <class WindowsExecutor>
-    void on_CreateProcess_error(WindowsExecutor&) const
-    {
-        HRESULT hr = GetLastError();
-        LPVOID buffer = 0;
-        if (!FormatMessage(
-            FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM |
-            FORMAT_MESSAGE_IGNORE_INSERTS,
-            nullptr, hr,
-            MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), // Default language
-            (LPTSTR) &buffer, 0, nullptr))
+        class throw_on_error : public initializer_base
         {
-            HPX_THROW_EXCEPTION(kernel_error, "process::on_CreateProcess_error",
-                "format message failed with {:x} (while retrieving message for "
-                "{:x})",
-                GetLastError(), hr);
-            return;
-        }
+        public:
+            template <class WindowsExecutor>
+            void on_CreateProcess_error(WindowsExecutor&) const
+            {
+                HRESULT hr = GetLastError();
+                LPVOID buffer = 0;
+                if (!FormatMessage(FORMAT_MESSAGE_ALLOCATE_BUFFER |
+                            FORMAT_MESSAGE_FROM_SYSTEM |
+                            FORMAT_MESSAGE_IGNORE_INSERTS,
+                        nullptr, hr,
+                        MAKELANGID(LANG_NEUTRAL,
+                            SUBLANG_DEFAULT),    // Default language
+                        (LPTSTR) &buffer, 0, nullptr))
+                {
+                    HPX_THROW_EXCEPTION(hpx::error::kernel_error,
+                        "process::on_CreateProcess_error",
+                        "format message failed with {:x} (while retrieving "
+                        "message for "
+                        "{:x})",
+                        GetLastError(), hr);
+                    return;
+                }
 
-        std::string msg("CreateProcess() failed: ");
-        msg += static_cast<char*>(buffer);
-        LocalFree(buffer);
-        HPX_THROW_EXCEPTION(kernel_error,
-            "process::on_CreateProcess_error", msg);
-    }
-};
+                std::string msg("CreateProcess() failed: ");
+                msg += static_cast<char*>(buffer);
+                LocalFree(buffer);
+                HPX_THROW_EXCEPTION(hpx::error::kernel_error,
+                    "process::on_CreateProcess_error", msg);
+            }
+        };
 
-}
-
-}}}}
+}}}}}    // namespace hpx::components::process::windows::initializers
 
 #endif

--- a/components/process/include/hpx/components/process/util/windows/terminate.hpp
+++ b/components/process/include/hpx/components/process/util/windows/terminate.hpp
@@ -25,7 +25,7 @@ void terminate(const Process &p)
 {
     if (!::TerminateProcess(p.process_handle(), EXIT_FAILURE))
     {
-        HPX_THROW_EXCEPTION(invalid_status,
+        HPX_THROW_EXCEPTION(hpx::error::invalid_status,
             "process::terminate", "TerminateProcess() failed");
     }
 }
@@ -35,7 +35,7 @@ void terminate(const Process &p, hpx::error_code &ec)
 {
     if (!::TerminateProcess(p.process_handle(), EXIT_FAILURE))
     {
-        HPX_THROWS_IF(ec, invalid_status,
+        HPX_THROWS_IF(ec, hpx::error::invalid_status,
             "process::terminate", "TerminateProcess() failed");
     }
     else

--- a/components/process/include/hpx/components/process/util/windows/wait_for_exit.hpp
+++ b/components/process/include/hpx/components/process/util/windows/wait_for_exit.hpp
@@ -23,14 +23,14 @@ inline int wait_for_exit(const Process &p)
 {
     if (::WaitForSingleObject(p.process_handle(), INFINITE) == WAIT_FAILED)
     {
-        HPX_THROW_EXCEPTION(invalid_status,
+        HPX_THROW_EXCEPTION(hpx::error::invalid_status,
             "process::wait_for_exit", "WaitForSingleObject() failed");
     }
 
     DWORD exit_code;
     if (!::GetExitCodeProcess(p.process_handle(), &exit_code))
     {
-        HPX_THROW_EXCEPTION(invalid_status,
+        HPX_THROW_EXCEPTION(hpx::error::invalid_status,
             "process::wait_for_exit", "GetExitCodeProcess() failed");
     }
     return static_cast<int>(exit_code);
@@ -43,12 +43,12 @@ inline int wait_for_exit(const Process &p, hpx::error_code &ec)
 
     if (::WaitForSingleObject(p.process_handle(), INFINITE) == WAIT_FAILED)
     {
-        HPX_THROWS_IF(ec, invalid_status,
+        HPX_THROWS_IF(ec, hpx::error::invalid_status,
             "process::wait_for_exit", "WaitForSingleObject() failed");
     }
     else if (!::GetExitCodeProcess(p.process_handle(), &exit_code))
     {
-        HPX_THROWS_IF(ec, invalid_status,
+        HPX_THROWS_IF(ec, hpx::error::invalid_status,
             "process::wait_for_exit", "GetExitCodeProcess() failed");
     }
     else

--- a/components/process/src/util/posix/create_pipe_u.cpp
+++ b/components/process/src/util/posix/create_pipe_u.cpp
@@ -25,7 +25,7 @@ namespace hpx { namespace components { namespace process { namespace posix
         int fds[2];
         if (::pipe(fds) == -1)
         {
-            HPX_THROW_EXCEPTION(invalid_status,
+            HPX_THROW_EXCEPTION(hpx::error::invalid_status,
                 "posix::create_pipe", "pipe(2) failed");
         }
         return pipe(fds[0], fds[1]);
@@ -36,7 +36,7 @@ namespace hpx { namespace components { namespace process { namespace posix
         int fds[2] = { 0, 0 };
         if (::pipe(fds) == -1)
         {
-            HPX_THROWS_IF(ec, invalid_status,
+            HPX_THROWS_IF(ec, hpx::error::invalid_status,
                 "posix::create_pipe", "pipe(2) failed");
         }
         else

--- a/components/process/src/util/posix/search_path_u.cpp
+++ b/components/process/src/util/posix/search_path_u.cpp
@@ -31,7 +31,8 @@ namespace hpx { namespace components { namespace process { namespace posix {
             path = ::getenv("PATH");
             if (path.empty())
             {
-                HPX_THROW_EXCEPTION(invalid_status, "process::search_path",
+                HPX_THROW_EXCEPTION(hpx::error::invalid_status,
+                    "process::search_path",
                     "Environment variable PATH not found");
             }
         }

--- a/components/process/src/util/windows/create_pipe_w.cpp
+++ b/components/process/src/util/windows/create_pipe_w.cpp
@@ -23,7 +23,7 @@ namespace hpx { namespace components { namespace process { namespace windows
         HANDLE handles[2];
         if (!::CreatePipe(&handles[0], &handles[1], nullptr, 0))
         {
-            HPX_THROW_EXCEPTION(invalid_status,
+            HPX_THROW_EXCEPTION(hpx::error::invalid_status,
                 "posix::create_pipe", "CreatePipe() failed");
         }
         return make_pipe(handles[0], handles[1]);
@@ -34,7 +34,7 @@ namespace hpx { namespace components { namespace process { namespace windows
         HANDLE handles[2] = { nullptr, nullptr };
         if (!::CreatePipe(&handles[0], &handles[1], nullptr, 0))
         {
-            HPX_THROWS_IF(ec, invalid_status,
+            HPX_THROWS_IF(ec, hpx::error::invalid_status,
                 "posix::create_pipe", "CreatePipe() failed");
         }
         else

--- a/components/process/src/util/windows/search_path_w.cpp
+++ b/components/process/src/util/windows/search_path_w.cpp
@@ -35,7 +35,8 @@ namespace hpx { namespace components { namespace process { namespace windows {
             path = ::_wgetenv(L"PATH");
             if (path.empty())
             {
-                HPX_THROW_EXCEPTION(invalid_status, "process::search_path",
+                HPX_THROW_EXCEPTION(hpx::error::invalid_status,
+                    "process::search_path",
                     "Environment variable PATH not found");
             }
         }
@@ -76,7 +77,8 @@ namespace hpx { namespace components { namespace process { namespace windows {
             path = ::getenv("PATH");
             if (path.empty())
             {
-                HPX_THROW_EXCEPTION(invalid_status, "process::search_path",
+                HPX_THROW_EXCEPTION(hpx::error::invalid_status,
+                    "process::search_path",
                     "Environment variable PATH not found");
             }
         }

--- a/components/process/src/util/windows/shell_path_w.cpp
+++ b/components/process/src/util/windows/shell_path_w.cpp
@@ -18,31 +18,28 @@
 
 #include <windows.h>
 
-namespace hpx { namespace components { namespace process { namespace windows
-{
+namespace hpx { namespace components { namespace process { namespace windows {
     filesystem::path shell_path()
     {
         TCHAR sysdir[MAX_PATH];
         UINT size = ::GetSystemDirectory(sysdir, sizeof(sysdir));
         if (!size)
         {
-            HPX_THROW_EXCEPTION(invalid_status,
-                "process::shell_path",
-                "GetSystemDirectory() failed");
+            HPX_THROW_EXCEPTION(hpx::error::invalid_status,
+                "process::shell_path", "GetSystemDirectory() failed");
         }
         filesystem::path p = sysdir;
         return p / "cmd.exe";
     }
 
-    filesystem::path shell_path(hpx::error_code &ec)
+    filesystem::path shell_path(hpx::error_code& ec)
     {
         TCHAR sysdir[MAX_PATH];
         UINT size = ::GetSystemDirectory(sysdir, sizeof(sysdir));
         filesystem::path p;
         if (!size)
         {
-            HPX_THROWS_IF(ec, invalid_status,
-                "process::shell_path",
+            HPX_THROWS_IF(ec, hpx::error::invalid_status, "process::shell_path",
                 "GetSystemDirectory() failed");
         }
         else
@@ -53,6 +50,6 @@ namespace hpx { namespace components { namespace process { namespace windows
         }
         return p;
     }
-}}}}
+}}}}    // namespace hpx::components::process::windows
 
 #endif

--- a/docs/sphinx/manual/writing_distributed_hpx_applications.rst
+++ b/docs/sphinx/manual/writing_distributed_hpx_applications.rst
@@ -556,7 +556,8 @@ executed::
         void some_function_with_error(int arg)
         {
             if (arg < 0) {
-                HPX_THROW_EXCEPTION(bad_parameter, "some_function_with_error",
+                HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
+                    "some_function_with_error",
                     "some really bad error happened");
             }
             // do something else...
@@ -569,7 +570,7 @@ executed::
 
 The use of :c:macro:`HPX_THROW_EXCEPTION` to report the error encapsulates the
 creation of a :cpp:class:`hpx::exception` which is initialized with the error
-code ``hpx::bad_parameter``. Additionally it carries the passed strings, the
+code ``hpx::error::bad_parameter``. Additionally it carries the passed strings, the
 information about the file name, line number, and call stack of the point the
 exception was thrown from.
 

--- a/examples/cancelable_action/cancelable_action_client.cpp
+++ b/examples/cancelable_action/cancelable_action_client.cpp
@@ -61,7 +61,7 @@ void handle_interruption_using_error_code(hpx::id_type const& id)
     ca.do_it(ec);
 
     // we should get an error reporting hpx::thread_interrupted
-    HPX_ASSERT(ec && ec.value() == hpx::thread_cancelled);
+    HPX_ASSERT(ec && ec.value() == hpx::error::thread_cancelled);
 
     // wait for the cancellation thread to exit
     t.join();

--- a/examples/interpolate1d/interpolate1d/read_values.cpp
+++ b/examples/interpolate1d/interpolate1d/read_values.cpp
@@ -60,8 +60,8 @@ namespace interpolate1d {
 
             if (numdims != 1)
             {
-                HPX_THROW_EXCEPTION(hpx::no_success, "extract_data_range",
-                    "number of dimensions was not 1");
+                HPX_THROW_EXCEPTION(hpx::error::no_success,
+                    "extract_data_range", "number of dimensions was not 1");
             }
 
             // Get the dimension size of each dimension in the dataspace.
@@ -80,7 +80,7 @@ namespace interpolate1d {
         catch (H5::Exception const& e)
         {
             HPX_THROW_EXCEPTION(
-                hpx::no_success, "extract_data_range", e.getDetailMsg());
+                hpx::error::no_success, "extract_data_range", e.getDetailMsg());
         }
         return 0;    // keep compiler happy
     }
@@ -106,7 +106,7 @@ namespace interpolate1d {
 
             if (numdims != 1)
             {
-                HPX_THROW_EXCEPTION(hpx::no_success, "extract_data",
+                HPX_THROW_EXCEPTION(hpx::error::no_success, "extract_data",
                     "number of dimensions was not 1");
             }
 
@@ -119,7 +119,7 @@ namespace interpolate1d {
         catch (H5::Exception const& e)
         {
             HPX_THROW_EXCEPTION(
-                hpx::no_success, "extract_data", e.getDetailMsg());
+                hpx::error::no_success, "extract_data", e.getDetailMsg());
         }
     }
 }    // namespace interpolate1d

--- a/examples/interpolate1d/interpolate1d/server/partition.cpp
+++ b/examples/interpolate1d/interpolate1d/server/partition.cpp
@@ -59,8 +59,8 @@ namespace interpolate1d { namespace server {
     {
         if (value < min_value_ || value > max_value_)
         {
-            HPX_THROW_EXCEPTION(hpx::bad_parameter, "partition::interpolate",
-                "argument out of range");
+            HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
+                "partition::interpolate", "argument out of range");
             return 0;
         }
 

--- a/examples/performance_counters/sine/sine.cpp
+++ b/examples/performance_counters/sine/sine.cpp
@@ -61,11 +61,11 @@ namespace performance_counters { namespace sine {
         using hpx::program_options::variables_map;
         using hpx::util::retrieve_commandline_arguments;
 
-        // Retrieve command line using the Boost.ProgramOptions library.
+        // Retrieve command line using the HPX.ProgramOptions library.
         variables_map vm;
         if (!retrieve_commandline_arguments(command_line_options(), vm))
         {
-            HPX_THROW_EXCEPTION(hpx::commandline_option_error,
+            HPX_THROW_EXCEPTION(hpx::error::commandline_option_error,
                 "sine::need_perf_counters",
                 "Failed to handle command line options");
             return false;
@@ -155,7 +155,7 @@ namespace performance_counters { namespace sine {
 
         if (paths.parentinstance_is_basename_)
         {
-            HPX_THROWS_IF(ec, hpx::bad_parameter,
+            HPX_THROWS_IF(ec, hpx::error::bad_parameter,
                 "sine::explicit_sine_counter_creator",
                 "invalid counter instance parent name: " +
                     paths.parentinstancename_);
@@ -193,7 +193,7 @@ namespace performance_counters { namespace sine {
             return id;
         }
 
-        HPX_THROWS_IF(ec, hpx::bad_parameter,
+        HPX_THROWS_IF(ec, hpx::error::bad_parameter,
             "sine::explicit_sine_counter_creator",
             "invalid counter instance name: " + paths.instancename_);
         return hpx::naming::invalid_gid;
@@ -261,7 +261,7 @@ namespace performance_counters { namespace sine {
         // check whether the performance counters need to be enabled
         if (!need_perf_counters())
         {
-            HPX_THROW_EXCEPTION(hpx::dynamic_link_failure,
+            HPX_THROW_EXCEPTION(hpx::error::dynamic_link_failure,
                 "performance_counters::sine::get_startup",
                 "the sine component is not enabled on the commandline "
                 "(--sine), bailing out");

--- a/examples/quickstart/error_handling.cpp
+++ b/examples/quickstart/error_handling.cpp
@@ -16,7 +16,8 @@
 //[error_handling_raise_exception
 void raise_exception()
 {
-    HPX_THROW_EXCEPTION(hpx::no_success, "raise_exception", "simulated error");
+    HPX_THROW_EXCEPTION(
+        hpx::error::no_success, "raise_exception", "simulated error");
 }
 HPX_PLAIN_ACTION(raise_exception, raise_exception_action)
 //]

--- a/examples/quickstart/fibonacci_futures_distributed.cpp
+++ b/examples/quickstart/fibonacci_futures_distributed.cpp
@@ -212,7 +212,7 @@ void init_globals()
     if (!hpx::util::retrieve_commandline_arguments(
             get_commandline_options(), vm))
     {
-        HPX_THROW_EXCEPTION(hpx::commandline_option_error,
+        HPX_THROW_EXCEPTION(hpx::error::commandline_option_error,
             "fibonacci_futures_distributed",
             "failed to handle command line options");
         return;
@@ -223,7 +223,7 @@ void init_globals()
     threshold = vm["threshold"].as<unsigned int>();
     if (threshold < 2 || threshold > n)
     {
-        HPX_THROW_EXCEPTION(hpx::commandline_option_error,
+        HPX_THROW_EXCEPTION(hpx::error::commandline_option_error,
             "fibonacci_futures_distributed",
             "wrong command line argument value for option 'threshold', "
             "should be in between 2 and n-value, value specified: " +
@@ -234,7 +234,7 @@ void init_globals()
     distribute_at = vm["distribute-at"].as<unsigned int>();
     if (distribute_at < 2 || distribute_at > n)
     {
-        HPX_THROW_EXCEPTION(hpx::commandline_option_error,
+        HPX_THROW_EXCEPTION(hpx::error::commandline_option_error,
             "fibonacci_futures_distributed",
             "wrong command line argument value for option 'distribute-at', "
             "should be in between 2 and n-value, value specified: " +

--- a/examples/sheneos/sheneos/interpolator.cpp
+++ b/examples/sheneos/sheneos/interpolator.cpp
@@ -302,7 +302,7 @@ namespace sheneos {
             break;
 
         default:
-            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+            HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
                 "sheneos::interpolator::get_dimension",
                 "value of parameter 'what' is not valid");
             break;
@@ -339,7 +339,7 @@ namespace sheneos {
 
             if (result.size() != indices.size())
             {
-                HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
                     "interpolator::on_completed_bulk_one",
                     "inconsistent sizes of result and index arrays");
             }
@@ -446,7 +446,7 @@ namespace sheneos {
 
             if (result.size() != indices.size())
             {
-                HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
                     "interpolator::on_completed_bulk",
                     "inconsistent sizes of result and index arrays");
             }

--- a/examples/sheneos/sheneos/read_values.cpp
+++ b/examples/sheneos/sheneos/read_values.cpp
@@ -71,8 +71,8 @@ namespace sheneos {
         }
         catch (H5::Exception const& e)
         {
-            HPX_THROW_EXCEPTION(
-                hpx::no_success, "sheneos::extract_data", e.getDetailMsg());
+            HPX_THROW_EXCEPTION(hpx::error::no_success, "sheneos::extract_data",
+                e.getDetailMsg());
         }
     }
 
@@ -119,7 +119,7 @@ namespace sheneos {
         {
             std::string msg = e.getDetailMsg().c_str();
             HPX_THROW_EXCEPTION(
-                hpx::no_success, "sheneos::extract_data_range", msg);
+                hpx::error::no_success, "sheneos::extract_data_range", msg);
         }
 
         // This return statement keeps the compiler from whining.
@@ -178,8 +178,8 @@ namespace sheneos {
         }
         catch (H5::Exception const& e)
         {
-            HPX_THROW_EXCEPTION(
-                hpx::no_success, "sheneos::extract_data", e.getDetailMsg());
+            HPX_THROW_EXCEPTION(hpx::error::no_success, "sheneos::extract_data",
+                e.getDetailMsg());
         }
     }
 }    // namespace sheneos

--- a/examples/sheneos/sheneos/server/partition3d.cpp
+++ b/examples/sheneos/sheneos/server/partition3d.cpp
@@ -118,7 +118,7 @@ namespace sheneos { namespace server {
     {
         if (value < min_value_[d] || value > max_value_[d])
         {
-            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+            HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
                 "sheneos::partition3d::get_index", "argument out of range");
             return 0;
         }
@@ -283,7 +283,7 @@ namespace sheneos { namespace server {
 
         if (detail::more_than_one_value_requested(eosvalue))
         {
-            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+            HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
                 "partition3d::interpolate_one",
                 "requested to interpolate more than one physical value: " +
                     std::to_string(eosvalue));
@@ -332,7 +332,8 @@ namespace sheneos { namespace server {
             break;
         }
 
-        HPX_THROW_EXCEPTION(hpx::bad_parameter, "partition3d::interpolate_one",
+        HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
+            "partition3d::interpolate_one",
             "requested to interpolate unknown physical value: " +
                 std::to_string(eosvalue));
 

--- a/examples/startup_shutdown/startup_shutdown.cpp
+++ b/examples/startup_shutdown/startup_shutdown.cpp
@@ -56,7 +56,7 @@ namespace startup_shutdown {
         variables_map vm;
         if (!hpx::util::retrieve_commandline_arguments(desc_commandline, vm))
         {
-            HPX_THROW_EXCEPTION(hpx::not_implemented,
+            HPX_THROW_EXCEPTION(hpx::error::not_implemented,
                 "startup_shutdown::startup",
                 "Failed to handle command line options");
         }

--- a/examples/throttle/throttle/server/throttle.cpp
+++ b/examples/throttle/throttle/server/throttle.cpp
@@ -53,7 +53,7 @@ namespace throttle { namespace server {
 
         if (shepherd >= blocked_os_threads_.size())
         {
-            HPX_THROW_EXCEPTION(hpx::bad_parameter, "throttle::suspend",
+            HPX_THROW_EXCEPTION(hpx::error::bad_parameter, "throttle::suspend",
                 "invalid thread number");
         }
 
@@ -71,7 +71,7 @@ namespace throttle { namespace server {
 
         if (shepherd >= blocked_os_threads_.size())
         {
-            HPX_THROW_EXCEPTION(hpx::bad_parameter, "throttle::resume",
+            HPX_THROW_EXCEPTION(hpx::error::bad_parameter, "throttle::resume",
                 "invalid thread number");
         }
 
@@ -84,8 +84,8 @@ namespace throttle { namespace server {
 
         if (shepherd >= blocked_os_threads_.size())
         {
-            HPX_THROW_EXCEPTION(hpx::bad_parameter, "throttle::is_suspended",
-                "invalid thread number");
+            HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
+                "throttle::is_suspended", "invalid thread number");
         }
 
         return blocked_os_threads_[shepherd];

--- a/init/src/hpx_user_main.cpp
+++ b/init/src/hpx_user_main.cpp
@@ -17,28 +17,28 @@
 // depending on whether the main executable defines this symbol or not.
 int hpx_startup::user_main()
 {
-//     std::string cmdline(hpx::get_config_entry("hpx.reconstructed_cmd_line", ""));
-//
-//     using namespace hpx::program_options;
-// #if defined(HPX_WINDOWS)
-//     std::vector<std::string> args = split_winmain(cmdline);
-// #else
-//     std::vector<std::string> args = split_unix(cmdline);
-// #endif
-//
-//     // Copy all arguments which are not hpx related to a temporary array
-//     std::vector<char*> argv(args.size());
-//     std::size_t argcount = 0;
-//     for(std::size_t i = 0; i < args.size(); ++i)
-//     {
-//         if (0 != args[i].find("--hpx:"))
-//             argv[argcount++] = const_cast<char*>(args[i].data());
-//     }
-//
-//     // Invoke hpx_main
-//     return user_main(static_cast<int>(argcount), argv.data());
-    HPX_THROW_EXCEPTION(hpx::not_implemented,
+    //     std::string cmdline(hpx::get_config_entry("hpx.reconstructed_cmd_line", ""));
+    //
+    //     using namespace hpx::program_options;
+    // #if defined(HPX_WINDOWS)
+    //     std::vector<std::string> args = split_winmain(cmdline);
+    // #else
+    //     std::vector<std::string> args = split_unix(cmdline);
+    // #endif
+    //
+    //     // Copy all arguments which are not hpx related to a temporary array
+    //     std::vector<char*> argv(args.size());
+    //     std::size_t argcount = 0;
+    //     for(std::size_t i = 0; i < args.size(); ++i)
+    //     {
+    //         if (0 != args[i].find("--hpx:"))
+    //             argv[argcount++] = const_cast<char*>(args[i].data());
+    //     }
+    //
+    //     // Invoke hpx_main
+    //     return user_main(static_cast<int>(argcount), argv.data());
+    HPX_THROW_EXCEPTION(hpx::error::not_implemented, "hpx_startup::user_main",
         "The console locality does not implement any main entry point usable "
-        "as the main HPX thread (e.g. no hpx_main, hpx_startup::user_main, etc.)",
-        "hpx_startup::user_main");
+        "as the main HPX thread (e.g. no hpx_main, hpx_startup::user_main, "
+        "etc.)");
 }

--- a/libs/core/affinity/src/affinity_data.cpp
+++ b/libs/core/affinity/src/affinity_data.cpp
@@ -106,7 +106,7 @@ namespace hpx { namespace threads { namespace policies { namespace detail {
             std::size_t num_initialized = count_initialized(affinity_masks_);
             if (num_initialized != num_threads_)
             {
-                HPX_THROW_EXCEPTION(bad_parameter,
+                HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
                     "affinity_data::affinity_data",
                     "The number of OS threads requested ({1}) does not match "
                     "the number of threads to bind ({2})",

--- a/libs/core/affinity/src/parse_affinity_options.cpp
+++ b/libs/core/affinity/src/parse_affinity_options.cpp
@@ -170,7 +170,8 @@ namespace hpx { namespace threads { namespace detail {
         std::string::const_iterator begin = spec.begin();
         if (!detail::parse(begin, spec.end(), mappings) || begin != spec.end())
         {
-            HPX_THROWS_IF(ec, bad_parameter, "parse_affinity_options",
+            HPX_THROWS_IF(ec, hpx::error::bad_parameter,
+                "parse_affinity_options",
                 "failed to parse affinity specification: " + spec);
             return;
         }
@@ -211,7 +212,8 @@ namespace hpx { namespace threads { namespace detail {
                     if (default_last <= std::size_t(*first))
                     {
                         result.clear();
-                        HPX_THROWS_IF(ec, bad_parameter, "extract_bounds",
+                        HPX_THROWS_IF(ec, hpx::error::bad_parameter,
+                            "extract_bounds",
                             "the resource id given is larger than the "
                             "number of existing resources");
                         return result;
@@ -224,7 +226,8 @@ namespace hpx { namespace threads { namespace detail {
                     if (default_last <= std::size_t(-*second))
                     {
                         result.clear();
-                        HPX_THROWS_IF(ec, bad_parameter, "extract_bounds",
+                        HPX_THROWS_IF(ec, hpx::error::bad_parameter,
+                            "extract_bounds",
                             "the upper limit given is larger than the "
                             "number of existing resources");
                         return result;
@@ -238,7 +241,8 @@ namespace hpx { namespace threads { namespace detail {
                     if (default_last <= std::size_t(*second))
                     {
                         result.clear();
-                        HPX_THROWS_IF(ec, bad_parameter, "extract_bounds",
+                        HPX_THROWS_IF(ec, hpx::error::bad_parameter,
+                            "extract_bounds",
                             "the upper limit given is larger than the "
                             "number of existing resources");
                         return result;
@@ -254,7 +258,8 @@ namespace hpx { namespace threads { namespace detail {
                 if (default_last <= std::size_t(*first))
                 {
                     result.clear();
-                    HPX_THROWS_IF(ec, bad_parameter, "extract_bounds",
+                    HPX_THROWS_IF(ec, hpx::error::bad_parameter,
+                        "extract_bounds",
                         "the resource id given is larger than the number "
                         "of existing resources");
                     return result;
@@ -345,7 +350,8 @@ namespace hpx { namespace threads { namespace detail {
         }
 
         default:
-            HPX_THROWS_IF(ec, bad_parameter, "extract_socket_or_numanode_mask",
+            HPX_THROWS_IF(ec, hpx::error::bad_parameter,
+                "extract_socket_or_numanode_mask",
                 "unexpected specification type {}",
                 spec_type::type_name(s.type_));
             break;
@@ -415,7 +421,7 @@ namespace hpx { namespace threads { namespace detail {
         break;
 
         default:
-            HPX_THROWS_IF(ec, bad_parameter, "extract_core_mask",
+            HPX_THROWS_IF(ec, hpx::error::bad_parameter, "extract_core_mask",
                 "unexpected specification type {}",
                 spec_type::type_name(s.type_));
             break;
@@ -498,7 +504,7 @@ namespace hpx { namespace threads { namespace detail {
         break;
 
         default:
-            HPX_THROWS_IF(ec, bad_parameter, "extract_pu_mask",
+            HPX_THROWS_IF(ec, hpx::error::bad_parameter, "extract_pu_mask",
                 "unexpected specification type {}",
                 spec_type::type_name(s.type_));
             break;
@@ -515,14 +521,14 @@ namespace hpx { namespace threads { namespace detail {
         mapping_type& m = fmt.second;
         if (m.size() != 3)
         {
-            HPX_THROWS_IF(ec, bad_parameter, "decode_mapping",
+            HPX_THROWS_IF(ec, hpx::error::bad_parameter, "decode_mapping",
                 "bad size of mappings specification array");
             return;
         }
 
         if (b.begin() == b.end())
         {
-            HPX_THROWS_IF(ec, bad_parameter, "decode_mapping",
+            HPX_THROWS_IF(ec, hpx::error::bad_parameter, "decode_mapping",
                 "no {1} mapping bounds are specified",
                 spec_type::type_name(fmt.first.type_));
             return;
@@ -716,7 +722,8 @@ namespace hpx { namespace threads { namespace detail {
 
             if (num_threads > num_pus_proc_mask)
             {
-                HPX_THROWS_IF(ec, bad_parameter, "check_num_threads",
+                HPX_THROWS_IF(ec, hpx::error::bad_parameter,
+                    "check_num_threads",
                     "specified number of threads ({1}) is larger than number "
                     "of processing units available in process mask ({2})",
                     num_threads, num_pus_proc_mask);
@@ -728,7 +735,8 @@ namespace hpx { namespace threads { namespace detail {
 
             if (num_threads > num_threads_available)
             {
-                HPX_THROWS_IF(ec, bad_parameter, "check_num_threads",
+                HPX_THROWS_IF(ec, hpx::error::bad_parameter,
+                    "check_num_threads",
                     "specified number of threads ({1}) is larger than number "
                     "of available processing units ({2})",
                     num_threads, num_threads_available);
@@ -771,7 +779,7 @@ namespace hpx { namespace threads { namespace detail {
 
                     if (any(affinities[num_thread]))
                     {
-                        HPX_THROWS_IF(ec, bad_parameter,
+                        HPX_THROWS_IF(ec, hpx::error::bad_parameter,
                             "decode_compact_distribution",
                             "affinity mask for thread {1} has already been set",
                             num_thread);
@@ -816,7 +824,7 @@ namespace hpx { namespace threads { namespace detail {
             {
                 if (any(affinities[num_thread]))
                 {
-                    HPX_THROWS_IF(ec, bad_parameter,
+                    HPX_THROWS_IF(ec, hpx::error::bad_parameter,
                         "decode_scatter_distribution",
                         "affinity mask for thread {1} has already been set",
                         num_thread);
@@ -930,7 +938,7 @@ namespace hpx { namespace threads { namespace detail {
             {
                 if (any(affinities[num_thread]))
                 {
-                    HPX_THROWS_IF(ec, bad_parameter,
+                    HPX_THROWS_IF(ec, hpx::error::bad_parameter,
                         "decode_balanced_distribution",
                         "affinity mask for thread {1} has already been set",
                         num_thread);
@@ -1077,7 +1085,7 @@ namespace hpx { namespace threads { namespace detail {
                 {
                     if (any(affinities[num_thread]))
                     {
-                        HPX_THROWS_IF(ec, bad_parameter,
+                        HPX_THROWS_IF(ec, hpx::error::bad_parameter,
                             "decode_numabalanced_distribution",
                             "affinity mask for thread {1} has already been set",
                             num_thread);
@@ -1165,7 +1173,8 @@ namespace hpx { namespace threads {
         {
             if (use_process_mask)
             {
-                HPX_THROWS_IF(ec, bad_parameter, "parse_affinity_options",
+                HPX_THROWS_IF(ec, hpx::error::bad_parameter,
+                    "parse_affinity_options",
                     "can't use --hpx:use-process-mask with custom thread "
                     "bindings");
             }
@@ -1177,14 +1186,16 @@ namespace hpx { namespace threads {
             {
                 if (m.first.type_ != detail::spec_type::thread)
                 {
-                    HPX_THROWS_IF(ec, bad_parameter, "parse_affinity_options",
+                    HPX_THROWS_IF(ec, hpx::error::bad_parameter,
+                        "parse_affinity_options",
                         "bind specification ({1}) is ill formatted", spec);
                     return;
                 }
 
                 if (m.second.size() != 3)
                 {
-                    HPX_THROWS_IF(ec, bad_parameter, "parse_affinity_options",
+                    HPX_THROWS_IF(ec, hpx::error::bad_parameter,
+                        "parse_affinity_options",
                         "bind specification ({1}) is ill formatted", spec);
                     return;
                 }
@@ -1193,7 +1204,8 @@ namespace hpx { namespace threads {
                     m.second[1].type_ == detail::spec_type::unknown &&
                     m.second[2].type_ == detail::spec_type::unknown)
                 {
-                    HPX_THROWS_IF(ec, bad_parameter, "parse_affinity_options",
+                    HPX_THROWS_IF(ec, hpx::error::bad_parameter,
+                        "parse_affinity_options",
                         "bind specification ({1}) is ill formatted", spec);
                     return;
                 }

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/destroy.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/destroy.hpp
@@ -181,11 +181,9 @@ namespace hpx { namespace parallel { inline namespace v1 {
         template <typename Iter, typename Sent>
         Iter sequential_destroy(Iter first, Sent last)
         {
-            using value_type = typename std::iterator_traits<Iter>::value_type;
-
             for (/* */; first != last; ++first)
             {
-                std::addressof(*first)->~value_type();
+                std::destroy_at(std::addressof(*first));
             }
             return first;
         }
@@ -207,10 +205,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 [](Iter first, std::size_t count, std::size_t) {
                     return util::loop_n<std::decay_t<ExPolicy>>(
                         first, count, [](Iter it) -> void {
-                            using value_type =
-                                typename std::iterator_traits<Iter>::value_type;
-
-                            std::addressof(*it)->~value_type();
+                            std::destroy_at(std::addressof(*it));
                         });
                 },
                 util::projection_identity());
@@ -254,13 +249,10 @@ namespace hpx { namespace parallel { inline namespace v1 {
         template <typename Iter>
         Iter sequential_destroy_n(Iter first, std::size_t count)
         {
-            using value_type = typename std::iterator_traits<Iter>::value_type;
-
             for (/* */; count != 0; (void) ++first, --count)
             {
-                std::addressof(*first)->~value_type();
+                std::destroy_at(std::addressof(*first));
             }
-
             return first;
         }
 

--- a/libs/core/algorithms/include/hpx/parallel/task_block.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/task_block.hpp
@@ -41,7 +41,7 @@ namespace hpx { namespace parallel { inline namespace v2 {
     {
     public:
         task_canceled_exception() noexcept
-          : hpx::exception(hpx::task_canceled_exception)
+          : hpx::exception(hpx::error::task_canceled_exception)
         {
         }
     };
@@ -181,8 +181,8 @@ namespace hpx { namespace parallel { inline namespace v2 {
             // 'active' to be usable.
             if (id_ != threads::get_self_id())
             {
-                HPX_THROW_EXCEPTION(task_block_not_active, "task_block::run",
-                    "the task_block is not active");
+                HPX_THROW_EXCEPTION(hpx::error::task_block_not_active,
+                    "task_block::run", "the task_block is not active");
             }
 
             tasks_.run(
@@ -230,8 +230,8 @@ namespace hpx { namespace parallel { inline namespace v2 {
             // 'active' to be usable.
             if (id_ != threads::get_self_id())
             {
-                HPX_THROW_EXCEPTION(task_block_not_active, "task_block::run",
-                    "the task_block is not active");
+                HPX_THROW_EXCEPTION(hpx::error::task_block_not_active,
+                    "task_block::run", "the task_block is not active");
             }
 
             tasks_.run(HPX_FORWARD(Executor, exec), HPX_FORWARD(F, f),
@@ -270,8 +270,8 @@ namespace hpx { namespace parallel { inline namespace v2 {
             // 'active' to be usable.
             if (id_ != threads::get_self_id())
             {
-                HPX_THROW_EXCEPTION(task_block_not_active, "task_block::run",
-                    "the task_block is not active");
+                HPX_THROW_EXCEPTION(hpx::error::task_block_not_active,
+                    "task_block::run", "the task_block is not active");
                 return;
             }
 

--- a/libs/core/algorithms/include/hpx/parallel/util/low_level.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/util/low_level.hpp
@@ -38,7 +38,7 @@ namespace hpx { namespace parallel { namespace util {
     template <typename Value>
     inline void destroy_object(Value* ptr)
     {
-        ptr->~Value();
+        std::destroy_at(ptr);
     }
 
     /// Initialize a range of objects with the object val moving across them
@@ -124,10 +124,9 @@ namespace hpx { namespace parallel { namespace util {
     template <typename Iter, typename Sent>
     inline void destroy(Iter first, Sent last)
     {
-        using value_type = typename std::iterator_traits<Iter>::value_type;
         while (first != last)
         {
-            (&(*(first++)))->~value_type();
+            std::destroy_at(&(*(first++)));
         }
     }
 

--- a/libs/core/algorithms/src/task_group.cpp
+++ b/libs/core/algorithms/src/task_group.cpp
@@ -102,7 +102,8 @@ namespace hpx::execution::experimental {
             }
             else
             {
-                HPX_THROW_EXCEPTION(invalid_status, "task_group::serialize",
+                HPX_THROW_EXCEPTION(hpx::error::invalid_status,
+                    "task_group::serialize",
                     "task_group must be ready in order for it to be "
                     "serialized");
             }

--- a/libs/core/algorithms/tests/unit/block/task_block.cpp
+++ b/libs/core/algorithms/tests/unit/block/task_block.cpp
@@ -201,7 +201,7 @@ void define_task_block_exceptions_test3()
     }
     catch (hpx::exception const& e)
     {
-        HPX_TEST_EQ(int(e.get_error()), int(hpx::task_block_not_active));
+        HPX_TEST_EQ(int(e.get_error()), int(hpx::error::task_block_not_active));
     }
     catch (...)
     {
@@ -229,7 +229,7 @@ void define_task_block_exceptions_test4()
     }
     catch (hpx::exception const& e)
     {
-        HPX_TEST_EQ(int(e.get_error()), int(hpx::task_block_not_active));
+        HPX_TEST_EQ(int(e.get_error()), int(hpx::error::task_block_not_active));
     }
     catch (...)
     {

--- a/libs/core/algorithms/tests/unit/block/task_block_executor.cpp
+++ b/libs/core/algorithms/tests/unit/block/task_block_executor.cpp
@@ -305,7 +305,7 @@ void define_task_block_exceptions_test3(Executor& exec)
     }
     catch (hpx::exception const& e)
     {
-        HPX_TEST_EQ(int(e.get_error()), int(hpx::task_block_not_active));
+        HPX_TEST_EQ(int(e.get_error()), int(hpx::error::task_block_not_active));
     }
     catch (...)
     {
@@ -334,7 +334,7 @@ void define_task_block_exceptions_test4(Executor& exec)
     }
     catch (hpx::exception const& e)
     {
-        HPX_TEST_EQ(int(e.get_error()), int(hpx::task_block_not_active));
+        HPX_TEST_EQ(int(e.get_error()), int(hpx::error::task_block_not_active));
     }
     catch (...)
     {

--- a/libs/core/algorithms/tests/unit/block/task_block_par.cpp
+++ b/libs/core/algorithms/tests/unit/block/task_block_par.cpp
@@ -117,7 +117,7 @@ void define_task_block_exceptions_test2()
     }
     catch (hpx::exception const& e)
     {
-        HPX_TEST_EQ(int(e.get_error()), int(hpx::task_block_not_active));
+        HPX_TEST_EQ(int(e.get_error()), int(hpx::error::task_block_not_active));
     }
     catch (...)
     {

--- a/libs/core/allocator_support/include/hpx/allocator_support/aligned_allocator.hpp
+++ b/libs/core/allocator_support/include/hpx/allocator_support/aligned_allocator.hpp
@@ -262,7 +262,7 @@ namespace hpx::util {
         template <typename U>
         void destroy(U* p)
         {
-            p->~U();
+            std::destroy_at(p);
         }
     };
 

--- a/libs/core/allocator_support/include/hpx/allocator_support/internal_allocator.hpp
+++ b/libs/core/allocator_support/include/hpx/allocator_support/internal_allocator.hpp
@@ -100,7 +100,7 @@ namespace hpx { namespace util {
         template <typename U>
         void destroy(U* p)
         {
-            p->~U();
+            std::destroy_at(p);
         }
     };
 

--- a/libs/core/asio/src/asio_util.cpp
+++ b/libs/core/asio/src/asio_util.cpp
@@ -127,7 +127,7 @@ namespace hpx { namespace util {
         }
 
         // report errors
-        HPX_THROW_EXCEPTION(network_error, "util::resolve_hostname",
+        HPX_THROW_EXCEPTION(hpx::error::network_error, "util::resolve_hostname",
             "{} (while trying to resolve: {}:{})", errors.get_message(),
             hostname, port);
         return tcp::endpoint();
@@ -157,7 +157,8 @@ namespace hpx { namespace util {
         }
 
         // report errors
-        HPX_THROW_EXCEPTION(network_error, "util::resolve_public_ip_address",
+        HPX_THROW_EXCEPTION(hpx::error::network_error,
+            "util::resolve_public_ip_address",
             "{} (while trying to resolve public ip address)",
             errors.get_message());
         return "";
@@ -193,7 +194,7 @@ namespace hpx { namespace util {
         }
         if (i == 2)
         {
-            HPX_THROW_EXCEPTION(bad_parameter, "cleanup_ip_address",
+            HPX_THROW_EXCEPTION(hpx::error::bad_parameter, "cleanup_ip_address",
                 "Invalid IP address string");
         }
 
@@ -205,8 +206,8 @@ namespace hpx { namespace util {
         if (inet_ntop(domain[i], buf, str, INET6_ADDRSTRLEN) == nullptr)
         {
 #endif
-            HPX_THROW_EXCEPTION(
-                bad_parameter, "cleanup_ip_address", "inet_ntop failure");
+            HPX_THROW_EXCEPTION(hpx::error::bad_parameter, "cleanup_ip_address",
+                "inet_ntop failure");
         }
         return std::string(str);
     }
@@ -252,7 +253,7 @@ namespace hpx { namespace util {
         }
 
         // report errors
-        HPX_THROW_EXCEPTION(network_error, "connect_begin",
+        HPX_THROW_EXCEPTION(hpx::error::network_error, "connect_begin",
             "{} (while trying to connect to: {}:{})", errors.get_message(),
             address, port);
 
@@ -315,7 +316,7 @@ namespace hpx { namespace util {
         }
 
         // report errors
-        HPX_THROW_EXCEPTION(network_error, "accept_begin",
+        HPX_THROW_EXCEPTION(hpx::error::network_error, "accept_begin",
             "{} (while trying to resolve: {}:{}))", errors.get_message(),
             address, port);
         return endpoint_iterator_type();

--- a/libs/core/async_combinators/include/hpx/async_combinators/split_future.hpp
+++ b/libs/core/async_combinators/include/hpx/async_combinators/split_future.hpp
@@ -241,7 +241,7 @@ namespace hpx {
                         result_type* result = state->get_result();
                         if (i >= result->size())
                         {
-                            HPX_THROW_EXCEPTION(length_error,
+                            HPX_THROW_EXCEPTION(hpx::error::length_error,
                                 "split_continuation::on_ready",
                                 "index out of bounds");
                         }

--- a/libs/core/async_combinators/include/hpx/async_combinators/wait_some.hpp
+++ b/libs/core/async_combinators/include/hpx/async_combinators/wait_some.hpp
@@ -352,7 +352,7 @@ namespace hpx {
 
             if (n > values.size())
             {
-                HPX_THROW_EXCEPTION(hpx::bad_parameter, "hpx::wait_some",
+                HPX_THROW_EXCEPTION(hpx::error::bad_parameter, "hpx::wait_some",
                     "number of results to wait for is out of bounds");
                 return false;
             }
@@ -393,7 +393,7 @@ namespace hpx {
 
             if (n > values.size())
             {
-                HPX_THROW_EXCEPTION(hpx::bad_parameter, "hpx::wait_some",
+                HPX_THROW_EXCEPTION(hpx::error::bad_parameter, "hpx::wait_some",
                     "number of results to wait for is out of bounds");
                 return false;
             }
@@ -436,7 +436,7 @@ namespace hpx {
         {
             if (n != 0)
             {
-                HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
                     "hpx::wait_some_nothrow",
                     "number of results to wait for is out of bounds");
             }
@@ -449,7 +449,7 @@ namespace hpx {
         {
             if (n != 1)
             {
-                HPX_THROW_EXCEPTION(hpx::bad_parameter, "hpx::wait_some",
+                HPX_THROW_EXCEPTION(hpx::error::bad_parameter, "hpx::wait_some",
                     "number of results to wait for is out of bounds");
                 return false;
             }
@@ -464,7 +464,7 @@ namespace hpx {
         {
             if (n != 1)
             {
-                HPX_THROW_EXCEPTION(hpx::bad_parameter, "hpx::wait_some",
+                HPX_THROW_EXCEPTION(hpx::error::bad_parameter, "hpx::wait_some",
                     "number of results to wait for is out of bounds");
                 return false;
             }
@@ -483,7 +483,8 @@ namespace hpx {
 
             if (n > sizeof...(Ts))
             {
-                HPX_THROW_EXCEPTION(hpx::bad_parameter, "hpx::lcos::wait_some",
+                HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
+                    "hpx::lcos::wait_some",
                     "number of results to wait for is out of bounds");
                 return false;
             }
@@ -586,7 +587,7 @@ namespace hpx {
         {
             if (n != 0)
             {
-                HPX_THROW_EXCEPTION(hpx::bad_parameter, "hpx::wait_some",
+                HPX_THROW_EXCEPTION(hpx::error::bad_parameter, "hpx::wait_some",
                     "number of results to wait for is out of bounds");
             }
         }

--- a/libs/core/async_combinators/include/hpx/async_combinators/when_some.hpp
+++ b/libs/core/async_combinators/include/hpx/async_combinators/when_some.hpp
@@ -431,9 +431,9 @@ namespace hpx {
             if (n > values.size())
             {
                 return hpx::make_exceptional_future<
-                    when_some_result<result_type>>(
-                    HPX_GET_EXCEPTION(hpx::bad_parameter, "hpx::when_some",
-                        "number of results to wait for is out of bounds"));
+                    when_some_result<result_type>>(HPX_GET_EXCEPTION(
+                    hpx::error::bad_parameter, "hpx::when_some",
+                    "number of results to wait for is out of bounds"));
             }
 
             auto f = std::make_shared<lcos::detail::when_some<result_type>>(
@@ -479,7 +479,7 @@ namespace hpx {
             }
 
             return hpx::make_exceptional_future<when_some_result<result_type>>(
-                HPX_GET_EXCEPTION(hpx::bad_parameter, "hpx::when_some",
+                HPX_GET_EXCEPTION(hpx::error::bad_parameter, "hpx::when_some",
                     "number of results to wait for is out of bounds"));
         }
 
@@ -500,9 +500,9 @@ namespace hpx {
             if (n > 1 + sizeof...(Ts))
             {
                 return hpx::make_exceptional_future<
-                    when_some_result<result_type>>(
-                    HPX_GET_EXCEPTION(hpx::bad_parameter, "hpx::when_some",
-                        "number of results to wait for is out of bounds"));
+                    when_some_result<result_type>>(HPX_GET_EXCEPTION(
+                    hpx::error::bad_parameter, "hpx::when_some",
+                    "number of results to wait for is out of bounds"));
             }
 
             traits::acquire_future_disp func;

--- a/libs/core/async_cuda/include/hpx/async_cuda/cublas_executor.hpp
+++ b/libs/core/async_cuda/include/hpx/async_cuda/cublas_executor.hpp
@@ -88,7 +88,7 @@ namespace hpx { namespace cuda { namespace experimental {
     struct HPX_CORE_EXPORT cublas_exception : hpx::exception
     {
         cublas_exception(const std::string& msg, cublasStatus_t err)
-          : hpx::exception(hpx::bad_function_call, msg)
+          : hpx::exception(hpx::error::bad_function_call, msg)
           , err_(err)
         {
         }

--- a/libs/core/async_cuda/include/hpx/async_cuda/cuda_exception.hpp
+++ b/libs/core/async_cuda/include/hpx/async_cuda/cuda_exception.hpp
@@ -21,7 +21,7 @@ namespace hpx { namespace cuda { namespace experimental {
     struct cuda_exception : hpx::exception
     {
         cuda_exception(const std::string& msg, cudaError_t err)
-          : hpx::exception(hpx::bad_function_call, msg)
+          : hpx::exception(hpx::error::bad_function_call, msg)
           , err_(err)
         {
         }

--- a/libs/core/async_cuda/include/hpx/async_cuda/cuda_future.hpp
+++ b/libs/core/async_cuda/include/hpx/async_cuda/cuda_future.hpp
@@ -163,10 +163,11 @@ namespace hpx { namespace cuda { namespace experimental {
 
                 if (error != cudaSuccess)
                 {
-                    this_->set_exception(HPX_GET_EXCEPTION(kernel_error,
-                        "cuda::detail::future_data::stream_callback()",
-                        std::string("cudaStreamAddCallback failed: ") +
-                            cudaGetErrorString(error)));
+                    this_->set_exception(
+                        HPX_GET_EXCEPTION(hpx::error::kernel_error,
+                            "cuda::detail::future_data::stream_callback()",
+                            std::string("cudaStreamAddCallback failed: ") +
+                                cudaGetErrorString(error)));
                     return;
                 }
 

--- a/libs/core/async_cuda/src/cuda_event_callback.cpp
+++ b/libs/core/async_cuda/src/cuda_event_callback.cpp
@@ -109,8 +109,8 @@ namespace hpx { namespace cuda { namespace experimental { namespace detail {
         cudaEvent_t event;
         if (!cuda_event_pool::get_event_pool().pop(event))
         {
-            HPX_THROW_EXCEPTION(
-                invalid_status, "add_event_callback", "could not get an event");
+            HPX_THROW_EXCEPTION(hpx::error::invalid_status,
+                "add_event_callback", "could not get an event");
         }
         check_cuda_error(cudaEventRecord(event, stream));
 

--- a/libs/core/async_cuda/src/cuda_target.cpp
+++ b/libs/core/async_cuda/src/cuda_target.cpp
@@ -28,7 +28,8 @@ namespace hpx { namespace cuda { namespace experimental {
         if (error != cudaSuccess)
         {
             // report error
-            HPX_THROW_EXCEPTION(kernel_error, "cuda::init_processing_unit()",
+            HPX_THROW_EXCEPTION(hpx::error::kernel_error,
+                "cuda::init_processing_unit()",
                 std::string("cudaGetDeviceProperties failed: ") +
                     cudaGetErrorString(error));
         }
@@ -145,7 +146,7 @@ namespace hpx { namespace cuda { namespace experimental {
             cudaError_t error = cudaSetDevice(device_);
             if (error != cudaSuccess)
             {
-                HPX_THROW_EXCEPTION(kernel_error,
+                HPX_THROW_EXCEPTION(hpx::error::kernel_error,
                     "cuda::experimental::target::native_handle::get_stream()",
                     std::string("cudaSetDevice failed: ") +
                         cudaGetErrorString(error));
@@ -153,7 +154,7 @@ namespace hpx { namespace cuda { namespace experimental {
             error = cudaStreamCreateWithFlags(&stream_, cudaStreamNonBlocking);
             if (error != cudaSuccess)
             {
-                HPX_THROW_EXCEPTION(kernel_error,
+                HPX_THROW_EXCEPTION(hpx::error::kernel_error,
                     "cuda::experimental::target::native_handle::get_stream()",
                     std::string("cudaStreamCreate failed: ") +
                         cudaGetErrorString(error));
@@ -169,7 +170,7 @@ namespace hpx { namespace cuda { namespace experimental {
 
         if (stream == 0)
         {
-            HPX_THROW_EXCEPTION(invalid_status,
+            HPX_THROW_EXCEPTION(hpx::error::invalid_status,
                 "cuda::experimental::target::synchronize",
                 "no stream available");
         }
@@ -177,7 +178,7 @@ namespace hpx { namespace cuda { namespace experimental {
         cudaError_t error = cudaStreamSynchronize(stream);
         if (error != cudaSuccess)
         {
-            HPX_THROW_EXCEPTION(kernel_error,
+            HPX_THROW_EXCEPTION(hpx::error::kernel_error,
                 "cuda::experimental::target::synchronize",
                 std::string("cudaStreamSynchronize failed: ") +
                     cudaGetErrorString(error));

--- a/libs/core/async_cuda/src/get_targets.cpp
+++ b/libs/core/async_cuda/src/get_targets.cpp
@@ -23,7 +23,7 @@ namespace hpx { namespace cuda { namespace experimental {
         cudaError_t error = cudaGetDeviceCount(&device_count);
         if (error != cudaSuccess)
         {
-            HPX_THROW_EXCEPTION(kernel_error,
+            HPX_THROW_EXCEPTION(hpx::error::kernel_error,
                 "cuda::experimental::get_local_targets()",
                 std::string("cudaGetDeviceCount failed: ") +
                     cudaGetErrorString(error));
@@ -31,7 +31,7 @@ namespace hpx { namespace cuda { namespace experimental {
 
         if (device_count == 0)
         {
-            HPX_THROW_EXCEPTION(kernel_error,
+            HPX_THROW_EXCEPTION(hpx::error::kernel_error,
                 "cuda::experimental::get_local_targets()",
                 "cudaGetDeviceCount failed: could not find any devices");
         }

--- a/libs/core/async_mpi/include/hpx/async_mpi/mpi_exception.hpp
+++ b/libs/core/async_mpi/include/hpx/async_mpi/mpi_exception.hpp
@@ -39,7 +39,7 @@ namespace hpx::mpi::experimental {
         explicit mpi_exception(int err_code, const std::string& msg = "")
           : err_code_(err_code)
         {
-            hpx::exception(hpx::bad_function_call,
+            hpx::exception(hpx::error::bad_function_call,
                 msg + std::string(" MPI returned with error: ") +
                     detail::error_message(err_code));
         }

--- a/libs/core/async_mpi/src/mpi_future.cpp
+++ b/libs/core/async_mpi/src/mpi_future.cpp
@@ -140,7 +140,7 @@ namespace hpx { namespace mpi { namespace experimental {
         void hpx_MPI_Handler(MPI_Comm*, int* errorcode, ...)
         {
             mpi_debug.debug(debug::str<>("hpx_MPI_Handler"));
-            HPX_THROW_EXCEPTION(invalid_status, "hpx_MPI_Handler",
+            HPX_THROW_EXCEPTION(hpx::error::invalid_status, "hpx_MPI_Handler",
                 detail::error_message(*errorcode));
         }
 
@@ -336,7 +336,7 @@ namespace hpx { namespace mpi { namespace experimental {
 
                 if (requests_vector.size() != request_callback_vector.size())
                 {
-                    HPX_THROW_EXCEPTION(invalid_status,
+                    HPX_THROW_EXCEPTION(hpx::error::invalid_status,
                         "hpx::mpi::experimental::poll",
                         "Fatal Error: Mismatch in vectors");
                 }
@@ -431,7 +431,7 @@ namespace hpx { namespace mpi { namespace experimental {
             {
                 mpi_debug.error(debug::str<>("hpx::mpi::experimental::init"),
                     "init failed");
-                HPX_THROW_EXCEPTION(invalid_status,
+                HPX_THROW_EXCEPTION(hpx::error::invalid_status,
                     "hpx::mpi::experimental::init",
                     "the MPI installation doesn't allow multiple threads");
             }

--- a/libs/core/compute_local/include/hpx/compute_local/host/block_fork_join_executor.hpp
+++ b/libs/core/compute_local/include/hpx/compute_local/host/block_fork_join_executor.hpp
@@ -68,7 +68,7 @@ namespace hpx::execution::experimental {
                 auto target_mask = targets[0].native_handle().get_device();
                 if (!hpx::threads::test(target_mask, this_pu))
                 {
-                    HPX_THROW_EXCEPTION(bad_parameter,
+                    HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
                         "block_fork_join_executor::cores_for_targets",
                         "The thread used to initialize the "
                         "block_fork_join_executor should be part of the given "
@@ -104,7 +104,7 @@ namespace hpx::execution::experimental {
             // current thread is not part of any of the given targets.
             if (!this_thread_is_represented)
             {
-                HPX_THROW_EXCEPTION(bad_parameter,
+                HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
                     "block_fork_join_executor::cores_for_targets",
                     "The thread used to initialize the "
                     "block_fork_join_executor should be part of at least one "

--- a/libs/core/compute_local/include/hpx/compute_local/host/numa_binding_allocator.hpp
+++ b/libs/core/compute_local/include/hpx/compute_local/host/numa_binding_allocator.hpp
@@ -367,7 +367,7 @@ namespace hpx { namespace compute { namespace host {
         template <class U>
         void destroy(U* const p)
         {
-            p->~U();
+            std::destroy_at(p);
         }
 
         // a utility function that is slightly faster than the hwloc provided one
@@ -388,7 +388,7 @@ namespace hpx { namespace compute { namespace host {
                 }
                 return -1;
             }
-            HPX_THROW_EXCEPTION(kernel_error, "get_numa_domain",
+            HPX_THROW_EXCEPTION(hpx::error::kernel_error, "get_numa_domain",
                 "Error getting numa domain with syscall");
 #else
             return threads::get_topology().get_numa_domain(page);
@@ -412,7 +412,8 @@ namespace hpx { namespace compute { namespace host {
             if (syscall(__NR_move_pages, 0, count, pages.data(), nullptr,
                     status.data(), 0) < 0)
             {
-                HPX_THROW_EXCEPTION(kernel_error, "get_page_numa_domains",
+                HPX_THROW_EXCEPTION(hpx::error::kernel_error,
+                    "get_page_numa_domains",
                     "Error getting numa domains with syscall");
             }
 

--- a/libs/core/compute_local/tests/regressions/for_each_value_proxy.cpp
+++ b/libs/core/compute_local/tests/regressions/for_each_value_proxy.cpp
@@ -166,7 +166,7 @@ public:
     template <typename U>
     void destroy(U* p)
     {
-        p->~U();
+        std::destroy_at(p);
     }
 };
 

--- a/libs/core/concurrency/include/hpx/concurrency/deque.hpp
+++ b/libs/core/concurrency/include/hpx/concurrency/deque.hpp
@@ -284,7 +284,7 @@ namespace hpx::lockfree {
         {
             if (n != nullptr)
             {
-                n->~node();
+                std::destroy_at(n);
                 pool_.deallocate(n);
             }
         }

--- a/libs/core/concurrency/include/hpx/concurrency/detail/freelist_stack.hpp
+++ b/libs/core/concurrency/include/hpx/concurrency/detail/freelist_stack.hpp
@@ -22,6 +22,7 @@
 #include <atomic>
 #include <cstddef>
 #include <cstdint>
+#include <memory>
 #include <type_traits>
 
 namespace hpx::lockfree::detail {
@@ -73,14 +74,14 @@ namespace hpx::lockfree::detail {
         void destruct(tagged_node_handle const& tagged_ptr) noexcept
         {
             T* n = tagged_ptr.get_ptr();
-            n->~T();
+            std::destroy_at(n);
             deallocate<ThreadSafe>(n);
         }
 
         template <bool ThreadSafe>
         void destruct(T* n) noexcept
         {
-            n->~T();
+            std::destroy_at(n);
             deallocate<ThreadSafe>(n);
         }
 
@@ -375,7 +376,7 @@ namespace hpx::lockfree::detail {
         {
             if (count > 65535)
             {
-                HPX_THROW_EXCEPTION(bad_parameter,
+                HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
                     "runtime_sized_freelist_storage::runtime_sized_freelist_"
                     "storage",
                     "hpx::concurrency: freelist size is limited to a maximum "
@@ -457,14 +458,14 @@ namespace hpx::lockfree::detail {
         {
             index_t index = tagged_index.get_index();
             T* n = NodeStorage::nodes() + index;
-            n->~T();
+            std::destroy_at(n);
             deallocate<ThreadSafe>(index);
         }
 
         template <bool ThreadSafe>
         void destruct(T* n)
         {
-            n->~T();
+            std::destroy_at(n);
             deallocate<ThreadSafe>(
                 static_cast<index_t>(n - NodeStorage::nodes()));
         }

--- a/libs/core/coroutines/src/detail/tss.cpp
+++ b/libs/core/coroutines/src/detail/tss.cpp
@@ -67,7 +67,7 @@ namespace hpx { namespace threads { namespace coroutines { namespace detail {
         coroutine_self* self = coroutine_self::get_self();
         if (nullptr == self)
         {
-            HPX_THROW_EXCEPTION(null_thread_id,
+            HPX_THROW_EXCEPTION(hpx::error::null_thread_id,
                 "hpx::threads::coroutines::detail::get_tss_thread_data",
                 "null thread id encountered");
             return 0;
@@ -96,7 +96,7 @@ namespace hpx { namespace threads { namespace coroutines { namespace detail {
         coroutine_self* self = coroutine_self::get_self();
         if (nullptr == self)
         {
-            HPX_THROW_EXCEPTION(null_thread_id,
+            HPX_THROW_EXCEPTION(hpx::error::null_thread_id,
                 "hpx::threads::coroutines::detail::set_tss_thread_data",
                 "null thread id encountered");
             return 0;
@@ -136,7 +136,7 @@ namespace hpx { namespace threads { namespace coroutines { namespace detail {
         coroutine_self* self = coroutine_self::get_self();
         if (nullptr == self)
         {
-            HPX_THROW_EXCEPTION(null_thread_id,
+            HPX_THROW_EXCEPTION(hpx::error::null_thread_id,
                 "hpx::threads::coroutines::detail::find_tss_data",
                 "null thread id encountered");
             return nullptr;
@@ -174,7 +174,7 @@ namespace hpx { namespace threads { namespace coroutines { namespace detail {
         coroutine_self* self = coroutine_self::get_self();
         if (nullptr == self)
         {
-            HPX_THROW_EXCEPTION(null_thread_id,
+            HPX_THROW_EXCEPTION(hpx::error::null_thread_id,
                 "hpx::threads::coroutines::detail::add_new_tss_node",
                 "null thread id encountered");
             return;
@@ -201,7 +201,7 @@ namespace hpx { namespace threads { namespace coroutines { namespace detail {
         coroutine_self* self = coroutine_self::get_self();
         if (nullptr == self)
         {
-            HPX_THROW_EXCEPTION(null_thread_id,
+            HPX_THROW_EXCEPTION(hpx::error::null_thread_id,
                 "hpx::threads::coroutines::detail::erase_tss_node",
                 "null thread id encountered");
             return;

--- a/libs/core/datastructures/include/hpx/datastructures/any.hpp
+++ b/libs/core/datastructures/include/hpx/datastructures/any.hpp
@@ -25,6 +25,7 @@
 #include <cstddef>
 #include <initializer_list>
 #include <iosfwd>
+#include <memory>
 #include <stdexcept>
 #include <type_traits>
 #include <typeinfo>
@@ -244,11 +245,11 @@ namespace hpx { namespace util { namespace detail { namespace any {
             }
             static void static_delete(void** x)
             {
-                reinterpret_cast<T*>(x)->~T();
+                std::destroy_at(reinterpret_cast<T*>(x));
             }
             static void destruct(void** x)
             {
-                reinterpret_cast<T*>(x)->~T();
+                std::destroy_at(reinterpret_cast<T*>(x));
             }
             static void clone(void* const* src, void** dest)
             {
@@ -302,7 +303,7 @@ namespace hpx { namespace util { namespace detail { namespace any {
             static void destruct(void** x)
             {
                 // destruct only, we'll reuse memory
-                (*reinterpret_cast<T**>(x))->~T();
+                std::destroy_at(*reinterpret_cast<T**>(x));
             }
             static void clone(void* const* src, void** dest)
             {
@@ -355,11 +356,11 @@ namespace hpx { namespace util { namespace detail { namespace any {
             }
             static void static_delete(void** x)
             {
-                reinterpret_cast<T*>(x)->~T();
+                std::destroy_at(reinterpret_cast<T*>(x));
             }
             static void destruct(void** x)
             {
-                reinterpret_cast<T*>(x)->~T();
+                std::destroy_at(reinterpret_cast<T*>(x));
             }
             static bool equal_to(void* const* x, void* const* y)
             {
@@ -405,7 +406,7 @@ namespace hpx { namespace util { namespace detail { namespace any {
             static void destruct(void** x)
             {
                 // destruct only, we'll reuse memory
-                (*reinterpret_cast<T**>(x))->~T();
+                std::destroy_at(*reinterpret_cast<T**>(x));
             }
             static bool equal_to(void* const* x, void* const* y)
             {

--- a/libs/core/datastructures/include/hpx/datastructures/detail/dynamic_bitset.hpp
+++ b/libs/core/datastructures/include/hpx/datastructures/detail/dynamic_bitset.hpp
@@ -1523,8 +1523,8 @@ namespace hpx::detail {
         // large bitsets but is required by the specification, sorry
         if (find_next(ulong_width - 1) != npos)
         {
-            HPX_THROW_EXCEPTION(
-                hpx::out_of_range, "hpx::dynamic_bitset::to_ulong", "overflow");
+            HPX_THROW_EXCEPTION(hpx::error::out_of_range,
+                "hpx::dynamic_bitset::to_ulong", "overflow");
         }
 
         // Ok, from now on we can be sure there's no "on" bit

--- a/libs/core/datastructures/include/hpx/datastructures/detail/optional.hpp
+++ b/libs/core/datastructures/include/hpx/datastructures/detail/optional.hpp
@@ -11,6 +11,7 @@
 #include <cstddef>
 #include <exception>
 #include <functional>
+#include <memory>
 #include <new>
 #include <stdexcept>
 #include <string>
@@ -171,7 +172,7 @@ namespace hpx::optional_ns {
             {
                 if (other.empty_)
                 {
-                    reinterpret_cast<T*>(&storage_)->~T();
+                    std::destroy_at(reinterpret_cast<T*>(&storage_));
                     empty_ = true;
                 }
                 else
@@ -186,7 +187,7 @@ namespace hpx::optional_ns {
         {
             if (!empty_)
             {
-                reinterpret_cast<T*>(&storage_)->~T();
+                std::destroy_at(reinterpret_cast<T*>(&storage_));
                 empty_ = true;
             }
 
@@ -219,7 +220,7 @@ namespace hpx::optional_ns {
         {
             if (!empty_)
             {
-                reinterpret_cast<T*>(&storage_)->~T();
+                std::destroy_at(reinterpret_cast<T*>(&storage_));
                 empty_ = true;
             }
             return *this;
@@ -321,7 +322,7 @@ namespace hpx::optional_ns {
         {
             if (!empty_)
             {
-                reinterpret_cast<T*>(&storage_)->~T();
+                std::destroy_at(reinterpret_cast<T*>(&storage_));
                 empty_ = true;
             }
             new (&storage_) T(HPX_FORWARD(Ts, ts)...);
@@ -336,7 +337,7 @@ namespace hpx::optional_ns {
         {
             if (!empty_)
             {
-                reinterpret_cast<T*>(&storage_)->~T();
+                std::destroy_at(reinterpret_cast<T*>(&storage_));
                 empty_ = true;
             }
             new (&storage_) T(HPX_FORWARD(F, f)(HPX_FORWARD(Ts, ts)...));
@@ -367,7 +368,7 @@ namespace hpx::optional_ns {
             optional* non_empty = empty_ ? &other : this;
 
             new (&empty->storage_) T(HPX_MOVE(**non_empty));
-            reinterpret_cast<T*>(&non_empty->storage_)->~T();
+            std::destroy_at(reinterpret_cast<T*>(&non_empty->storage_));
 
             empty->empty_ = false;
             non_empty->empty_ = true;
@@ -377,7 +378,7 @@ namespace hpx::optional_ns {
         {
             if (!empty_)
             {
-                reinterpret_cast<T*>(&storage_)->~T();
+                std::destroy_at(reinterpret_cast<T*>(&storage_));
                 empty_ = true;
             }
         }

--- a/libs/core/datastructures/include/hpx/datastructures/detail/small_vector.hpp
+++ b/libs/core/datastructures/include/hpx/datastructures/detail/small_vector.hpp
@@ -457,7 +457,7 @@ namespace hpx::detail {
             else
             {
                 auto s = size<D>() - 1;
-                (data<D>() + s)->~T();
+                std::destroy_at(data<D>() + s);
                 set_size<D>(s);
             }
         }

--- a/libs/core/datastructures/tests/unit/bitset_test.hpp
+++ b/libs/core/datastructures/tests/unit/bitset_test.hpp
@@ -770,7 +770,7 @@ struct bitset_test
             catch (hpx::exception& ex)
             {
                 // Good!
-                HPX_TEST(ex.get_error() == hpx::out_of_range);
+                HPX_TEST(ex.get_error() == hpx::error::out_of_range);
             }
             catch (...)
             {

--- a/libs/core/errors/include/hpx/errors/error.hpp
+++ b/libs/core/errors/include/hpx/errors/error.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2015 Hartmut Kaiser
+//  Copyright (c) 2007-2022 Hartmut Kaiser
 //  Copyright (c) 2011      Bryce Lelbach
 //  Copyright (c) 2014      Anuj R. Sharma
 //
@@ -12,17 +12,19 @@
 
 #include <hpx/config.hpp>
 
+#include <cstdint>
 #include <string>
 #include <system_error>
 
 ///////////////////////////////////////////////////////////////////////////////
 namespace hpx {
+
     ///////////////////////////////////////////////////////////////////////////
     /// \brief Possible error conditions
     ///
     /// This enumeration lists all possible error conditions which can be
     /// reported from any of the API functions.
-    enum error
+    enum class error : std::int16_t
     {
         success = 0,
         ///< The operation was successful
@@ -144,10 +146,187 @@ namespace hpx {
         last_error,
 
         system_error_flag = 0x4000L,
-        error_upper_bound =
-            0x7fffL    // force this enum type to be at least 16 bits.
+
+        // force this enum type to be at least 16 bits.
+        error_upper_bound = 0x7fffL
         /// \endcond
     };
+
+    inline constexpr bool operator==(int lhs, error rhs) noexcept
+    {
+        return lhs == static_cast<int>(rhs);
+    }
+
+    inline constexpr bool operator==(error lhs, int rhs) noexcept
+    {
+        return static_cast<int>(lhs) == rhs;
+    }
+
+    inline constexpr bool operator!=(int lhs, error rhs) noexcept
+    {
+        return !(lhs == rhs);
+    }
+
+    inline constexpr bool operator!=(error lhs, int rhs) noexcept
+    {
+        return !(lhs == rhs);
+    }
+
+    inline constexpr bool operator<(int lhs, error rhs) noexcept
+    {
+        return lhs < static_cast<int>(rhs);
+    }
+
+    inline constexpr bool operator>=(int lhs, error rhs) noexcept
+    {
+        return !(lhs < rhs);
+    }
+
+    inline constexpr int operator&(error lhs, error rhs) noexcept
+    {
+        return static_cast<int>(lhs) & static_cast<int>(rhs);
+    }
+
+    inline constexpr int operator&(int lhs, error rhs) noexcept
+    {
+        return lhs & static_cast<int>(rhs);
+    }
+
+    inline constexpr int operator|=(int lhs, error rhs) noexcept
+    {
+        return lhs | static_cast<int>(rhs);
+    }
+
+#define HPX_ERROR_UNSCOPED_ENUM_DEPRECATION_MSG                                \
+    "The unscoped hpx::error names are deprecated. Please use "                \
+    "hpx::error::<value> instead."
+
+    HPX_DEPRECATED_V(1, 9, HPX_ERROR_UNSCOPED_ENUM_DEPRECATION_MSG)
+    inline constexpr error success = error::success;
+    HPX_DEPRECATED_V(1, 9, HPX_ERROR_UNSCOPED_ENUM_DEPRECATION_MSG)
+    inline constexpr error no_success = error::no_success;
+    HPX_DEPRECATED_V(1, 9, HPX_ERROR_UNSCOPED_ENUM_DEPRECATION_MSG)
+    inline constexpr error not_implemented = error::not_implemented;
+    HPX_DEPRECATED_V(1, 9, HPX_ERROR_UNSCOPED_ENUM_DEPRECATION_MSG)
+    inline constexpr error out_of_memory = error::out_of_memory;
+    HPX_DEPRECATED_V(1, 9, HPX_ERROR_UNSCOPED_ENUM_DEPRECATION_MSG)
+    inline constexpr error bad_action_code = error::bad_action_code;
+    HPX_DEPRECATED_V(1, 9, HPX_ERROR_UNSCOPED_ENUM_DEPRECATION_MSG)
+    inline constexpr error bad_component_type = error::bad_component_type;
+    HPX_DEPRECATED_V(1, 9, HPX_ERROR_UNSCOPED_ENUM_DEPRECATION_MSG)
+    inline constexpr error network_error = error::network_error;
+    HPX_DEPRECATED_V(1, 9, HPX_ERROR_UNSCOPED_ENUM_DEPRECATION_MSG)
+    inline constexpr error version_too_new = error::version_too_new;
+    HPX_DEPRECATED_V(1, 9, HPX_ERROR_UNSCOPED_ENUM_DEPRECATION_MSG)
+    inline constexpr error version_too_old = error::version_too_old;
+    HPX_DEPRECATED_V(1, 9, HPX_ERROR_UNSCOPED_ENUM_DEPRECATION_MSG)
+    inline constexpr error version_unknown = error::version_unknown;
+    HPX_DEPRECATED_V(1, 9, HPX_ERROR_UNSCOPED_ENUM_DEPRECATION_MSG)
+    inline constexpr error unknown_component_address =
+        error::unknown_component_address;
+    HPX_DEPRECATED_V(1, 9, HPX_ERROR_UNSCOPED_ENUM_DEPRECATION_MSG)
+    inline constexpr error duplicate_component_address =
+        error::duplicate_component_address;
+    HPX_DEPRECATED_V(1, 9, HPX_ERROR_UNSCOPED_ENUM_DEPRECATION_MSG)
+    inline constexpr error invalid_status = error::invalid_status;
+    HPX_DEPRECATED_V(1, 9, HPX_ERROR_UNSCOPED_ENUM_DEPRECATION_MSG)
+    inline constexpr error bad_parameter = error::bad_parameter;
+    HPX_DEPRECATED_V(1, 9, HPX_ERROR_UNSCOPED_ENUM_DEPRECATION_MSG)
+    inline constexpr error internal_server_error = error::internal_server_error;
+    HPX_DEPRECATED_V(1, 9, HPX_ERROR_UNSCOPED_ENUM_DEPRECATION_MSG)
+    inline constexpr error service_unavailable = error::service_unavailable;
+    HPX_DEPRECATED_V(1, 9, HPX_ERROR_UNSCOPED_ENUM_DEPRECATION_MSG)
+    inline constexpr error bad_request = error::bad_request;
+    HPX_DEPRECATED_V(1, 9, HPX_ERROR_UNSCOPED_ENUM_DEPRECATION_MSG)
+    inline constexpr error repeated_request = error::repeated_request;
+    HPX_DEPRECATED_V(1, 9, HPX_ERROR_UNSCOPED_ENUM_DEPRECATION_MSG)
+    inline constexpr error lock_error = error::lock_error;
+    HPX_DEPRECATED_V(1, 9, HPX_ERROR_UNSCOPED_ENUM_DEPRECATION_MSG)
+    inline constexpr error duplicate_console = error::duplicate_console;
+    HPX_DEPRECATED_V(1, 9, HPX_ERROR_UNSCOPED_ENUM_DEPRECATION_MSG)
+    inline constexpr error no_registered_console = error::no_registered_console;
+    HPX_DEPRECATED_V(1, 9, HPX_ERROR_UNSCOPED_ENUM_DEPRECATION_MSG)
+    inline constexpr error startup_timed_out = error::startup_timed_out;
+    HPX_DEPRECATED_V(1, 9, HPX_ERROR_UNSCOPED_ENUM_DEPRECATION_MSG)
+    inline constexpr error uninitialized_value = error::uninitialized_value;
+    HPX_DEPRECATED_V(1, 9, HPX_ERROR_UNSCOPED_ENUM_DEPRECATION_MSG)
+    inline constexpr error bad_response_type = error::bad_response_type;
+    HPX_DEPRECATED_V(1, 9, HPX_ERROR_UNSCOPED_ENUM_DEPRECATION_MSG)
+    inline constexpr error deadlock = error::deadlock;
+    HPX_DEPRECATED_V(1, 9, HPX_ERROR_UNSCOPED_ENUM_DEPRECATION_MSG)
+    inline constexpr error assertion_failure = error::assertion_failure;
+    HPX_DEPRECATED_V(1, 9, HPX_ERROR_UNSCOPED_ENUM_DEPRECATION_MSG)
+    inline constexpr error null_thread_id = error::null_thread_id;
+    HPX_DEPRECATED_V(1, 9, HPX_ERROR_UNSCOPED_ENUM_DEPRECATION_MSG)
+    inline constexpr error invalid_data = error::invalid_data;
+    HPX_DEPRECATED_V(1, 9, HPX_ERROR_UNSCOPED_ENUM_DEPRECATION_MSG)
+    inline constexpr error yield_aborted = error::yield_aborted;
+    HPX_DEPRECATED_V(1, 9, HPX_ERROR_UNSCOPED_ENUM_DEPRECATION_MSG)
+    inline constexpr error dynamic_link_failure = error::dynamic_link_failure;
+    HPX_DEPRECATED_V(1, 9, HPX_ERROR_UNSCOPED_ENUM_DEPRECATION_MSG)
+    inline constexpr error commandline_option_error =
+        error::commandline_option_error;
+    HPX_DEPRECATED_V(1, 9, HPX_ERROR_UNSCOPED_ENUM_DEPRECATION_MSG)
+    inline constexpr error serialization_error = error::serialization_error;
+    HPX_DEPRECATED_V(1, 9, HPX_ERROR_UNSCOPED_ENUM_DEPRECATION_MSG)
+    inline constexpr error unhandled_exception = error::unhandled_exception;
+    HPX_DEPRECATED_V(1, 9, HPX_ERROR_UNSCOPED_ENUM_DEPRECATION_MSG)
+    inline constexpr error kernel_error = error::kernel_error;
+    HPX_DEPRECATED_V(1, 9, HPX_ERROR_UNSCOPED_ENUM_DEPRECATION_MSG)
+    inline constexpr error broken_task = error::broken_task;
+    HPX_DEPRECATED_V(1, 9, HPX_ERROR_UNSCOPED_ENUM_DEPRECATION_MSG)
+    inline constexpr error task_moved = error::task_moved;
+    HPX_DEPRECATED_V(1, 9, HPX_ERROR_UNSCOPED_ENUM_DEPRECATION_MSG)
+    inline constexpr error task_already_started = error::task_already_started;
+    HPX_DEPRECATED_V(1, 9, HPX_ERROR_UNSCOPED_ENUM_DEPRECATION_MSG)
+    inline constexpr error future_already_retrieved =
+        error::future_already_retrieved;
+    HPX_DEPRECATED_V(1, 9, HPX_ERROR_UNSCOPED_ENUM_DEPRECATION_MSG)
+    inline constexpr error promise_already_satisfied =
+        error::promise_already_satisfied;
+    HPX_DEPRECATED_V(1, 9, HPX_ERROR_UNSCOPED_ENUM_DEPRECATION_MSG)
+    inline constexpr error future_does_not_support_cancellation =
+        error::future_does_not_support_cancellation;
+    HPX_DEPRECATED_V(1, 9, HPX_ERROR_UNSCOPED_ENUM_DEPRECATION_MSG)
+    inline constexpr error future_can_not_be_cancelled =
+        error::future_can_not_be_cancelled;
+    HPX_DEPRECATED_V(1, 9, HPX_ERROR_UNSCOPED_ENUM_DEPRECATION_MSG)
+    inline constexpr error no_state = error::no_state;
+    HPX_DEPRECATED_V(1, 9, HPX_ERROR_UNSCOPED_ENUM_DEPRECATION_MSG)
+    inline constexpr error broken_promise = error::broken_promise;
+    HPX_DEPRECATED_V(1, 9, HPX_ERROR_UNSCOPED_ENUM_DEPRECATION_MSG)
+    inline constexpr error thread_resource_error = error::thread_resource_error;
+    HPX_DEPRECATED_V(1, 9, HPX_ERROR_UNSCOPED_ENUM_DEPRECATION_MSG)
+    inline constexpr error future_cancelled = error::future_cancelled;
+    HPX_DEPRECATED_V(1, 9, HPX_ERROR_UNSCOPED_ENUM_DEPRECATION_MSG)
+    inline constexpr error thread_cancelled = error::thread_cancelled;
+    HPX_DEPRECATED_V(1, 9, HPX_ERROR_UNSCOPED_ENUM_DEPRECATION_MSG)
+    inline constexpr error thread_not_interruptable =
+        error::thread_not_interruptable;
+    HPX_DEPRECATED_V(1, 9, HPX_ERROR_UNSCOPED_ENUM_DEPRECATION_MSG)
+    inline constexpr error duplicate_component_id =
+        error::duplicate_component_id;
+    HPX_DEPRECATED_V(1, 9, HPX_ERROR_UNSCOPED_ENUM_DEPRECATION_MSG)
+    inline constexpr error unknown_error = error::unknown_error;
+    HPX_DEPRECATED_V(1, 9, HPX_ERROR_UNSCOPED_ENUM_DEPRECATION_MSG)
+    inline constexpr error bad_plugin_type = error::bad_plugin_type;
+    HPX_DEPRECATED_V(1, 9, HPX_ERROR_UNSCOPED_ENUM_DEPRECATION_MSG)
+    inline constexpr error filesystem_error = error::filesystem_error;
+    HPX_DEPRECATED_V(1, 9, HPX_ERROR_UNSCOPED_ENUM_DEPRECATION_MSG)
+    inline constexpr error bad_function_call = error::bad_function_call;
+    HPX_DEPRECATED_V(1, 9, HPX_ERROR_UNSCOPED_ENUM_DEPRECATION_MSG)
+    inline constexpr error task_canceled_exception =
+        error::task_canceled_exception;
+    HPX_DEPRECATED_V(1, 9, HPX_ERROR_UNSCOPED_ENUM_DEPRECATION_MSG)
+    inline constexpr error task_block_not_active = error::task_block_not_active;
+    HPX_DEPRECATED_V(1, 9, HPX_ERROR_UNSCOPED_ENUM_DEPRECATION_MSG)
+    inline constexpr error out_of_range = error::out_of_range;
+    HPX_DEPRECATED_V(1, 9, HPX_ERROR_UNSCOPED_ENUM_DEPRECATION_MSG)
+    inline constexpr error length_error = error::length_error;
+    HPX_DEPRECATED_V(1, 9, HPX_ERROR_UNSCOPED_ENUM_DEPRECATION_MSG)
+    inline constexpr error migration_needs_retry = error::migration_needs_retry;
+
+#undef HPX_ERROR_UNSCOPED_ENUM_DEPRECATION_MSG
 
     /// \cond NOINTERNAL
     char const* const error_names[] = {

--- a/libs/core/errors/include/hpx/errors/error_code.hpp
+++ b/libs/core/errors/include/hpx/errors/error_code.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2013 Hartmut Kaiser
+//  Copyright (c) 2007-2022 Hartmut Kaiser
 //  Copyright (c) 2011      Bryce Lelbach
 //
 //  SPDX-License-Identifier: BSL-1.0
@@ -20,6 +20,7 @@
 
 ///////////////////////////////////////////////////////////////////////////////
 namespace hpx {
+
     /// \cond NODETAIL
     namespace detail {
         HPX_CORE_EXPORT std::exception_ptr access_exception(error_code const&);
@@ -42,16 +43,19 @@ namespace hpx {
 
     ///////////////////////////////////////////////////////////////////////////
     /// \brief Returns generic HPX error category used for new errors.
-    HPX_CORE_EXPORT std::error_category const& get_hpx_category();
+    HPX_CORE_EXPORT std::error_category const& get_hpx_category() noexcept;
 
     /// \brief Returns generic HPX error category used for errors re-thrown
     ///        after the exception has been de-serialized.
-    HPX_CORE_EXPORT std::error_category const& get_hpx_rethrow_category();
+    HPX_CORE_EXPORT std::error_category const&
+    get_hpx_rethrow_category() noexcept;
 
     /// \cond NOINTERNAL
-    HPX_CORE_EXPORT std::error_category const& get_lightweight_hpx_category();
+    HPX_CORE_EXPORT std::error_category const&
+    get_lightweight_hpx_category() noexcept;
 
-    HPX_CORE_EXPORT std::error_category const& get_hpx_category(throwmode mode);
+    HPX_CORE_EXPORT std::error_category const& get_hpx_category(
+        throwmode mode) noexcept;
 
     inline std::error_code make_system_error_code(
         error e, throwmode mode = throwmode::plain)
@@ -90,7 +94,7 @@ namespace hpx {
         ///
         /// \throws nothing
         explicit error_code(throwmode mode = throwmode::plain)
-          : std::error_code(make_system_error_code(success, mode))
+          : std::error_code(make_system_error_code(hpx::error::success, mode))
         {
         }
 
@@ -210,10 +214,12 @@ namespace hpx {
 
         /// \brief Clear this error_code object.
         /// The postconditions of invoking this method are
-        /// * value() == hpx::success and category() == hpx::get_hpx_category()
+        /// * value() == hpx::error::success and
+        ///   category() == hpx::get_hpx_category()
         void clear()
         {
-            this->std::error_code::assign(success, get_hpx_category());
+            this->std::error_code::assign(
+                static_cast<int>(hpx::error::success), get_hpx_category());
             exception_ = std::exception_ptr();
         }
 
@@ -247,6 +253,7 @@ namespace hpx {
     {
         return error_code(e, mode);
     }
+
     inline error_code make_error_code(error e, char const* func,
         char const* file, long line, throwmode mode = throwmode::plain)
     {
@@ -259,6 +266,7 @@ namespace hpx {
     {
         return error_code(e, msg, mode);
     }
+
     inline error_code make_error_code(error e, char const* msg,
         char const* func, char const* file, long line,
         throwmode mode = throwmode::plain)
@@ -272,19 +280,21 @@ namespace hpx {
     {
         return error_code(e, msg, mode);
     }
+
     inline error_code make_error_code(error e, std::string const& msg,
         char const* func, char const* file, long line,
         throwmode mode = throwmode::plain)
     {
         return error_code(e, msg, func, file, line, mode);
     }
+
     inline error_code make_error_code(std::exception_ptr const& e)
     {
         return error_code(e);
     }
     ///@}
 
-    /// \brief Returns error_code(hpx::success, "success", mode).
+    /// \brief Returns error_code(hpx::error::success, "success", mode).
     inline error_code make_success_code(throwmode mode = throwmode::plain)
     {
         return error_code(mode);

--- a/libs/core/errors/include/hpx/errors/exception.hpp
+++ b/libs/core/errors/include/hpx/errors/exception.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2019 Hartmut Kaiser
+//  Copyright (c) 2007-2022 Hartmut Kaiser
 //  Copyright (c) 2011      Bryce Lelbach
 //
 //  SPDX-License-Identifier: BSL-1.0
@@ -26,6 +26,7 @@
 
 ///////////////////////////////////////////////////////////////////////////////
 namespace hpx {
+
     ///////////////////////////////////////////////////////////////////////////
     /// \brief A hpx::exception is the main exception type used by HPX to
     ///        report errors.
@@ -42,7 +43,7 @@ namespace hpx {
         ///
         /// \param e    The parameter \p e holds the hpx::error code the new
         ///             exception should encapsulate.
-        explicit exception(error e = success);
+        explicit exception(error e = hpx::error::success);
 
         /// Construct a hpx::exception from a boost#system_error.
         explicit exception(std::system_error const& e);
@@ -83,7 +84,7 @@ namespace hpx {
         /// Destruct a hpx::exception
         ///
         /// \throws nothing
-        ~exception() noexcept;
+        ~exception();
 
         /// The function \a get_error() returns the hpx::error code stored
         /// in the referenced instance of a hpx::exception. It returns
@@ -215,7 +216,7 @@ namespace hpx {
             {
             }
 
-            ~std_exception() noexcept {}
+            ~std_exception() = default;
 
             const char* what() const noexcept override
             {
@@ -234,7 +235,7 @@ namespace hpx {
             {
             }
 
-            ~bad_alloc() noexcept {}
+            ~bad_alloc() = default;
 
             const char* what() const noexcept override
             {
@@ -253,7 +254,7 @@ namespace hpx {
             {
             }
 
-            ~bad_exception() noexcept {}
+            ~bad_exception() = default;
 
             const char* what() const noexcept override
             {
@@ -272,7 +273,7 @@ namespace hpx {
             {
             }
 
-            ~bad_cast() noexcept {}
+            ~bad_cast() = default;
 
             const char* what() const noexcept override
             {
@@ -291,7 +292,7 @@ namespace hpx {
             {
             }
 
-            ~bad_typeid() noexcept {}
+            ~bad_typeid() = default;
 
             const char* what() const noexcept override
             {

--- a/libs/core/errors/include/hpx/errors/exception_fwd.hpp
+++ b/libs/core/errors/include/hpx/errors/exception_fwd.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2014 Hartmut Kaiser
+//  Copyright (c) 2007-2022 Hartmut Kaiser
 //  Copyright (c) 2011      Bryce Lelbach
 //
 //  SPDX-License-Identifier: BSL-1.0
@@ -15,6 +15,7 @@
 #include <cstdint>
 
 namespace hpx {
+
     /// \cond NOINTERNAL
     // forward declaration
     class error_code;

--- a/libs/core/errors/include/hpx/errors/exception_info.hpp
+++ b/libs/core/errors/include/hpx/errors/exception_info.hpp
@@ -24,6 +24,7 @@
 #endif
 
 namespace hpx {
+
     ///////////////////////////////////////////////////////////////////////////
     template <typename Tag, typename Type>
     struct error_info
@@ -36,7 +37,7 @@ namespace hpx {
         {
         }
 
-        explicit error_info(Type&& value)
+        explicit error_info(Type&& value) noexcept
           : _value(HPX_MOVE(value))
         {
         }
@@ -52,7 +53,7 @@ namespace hpx {
         {                                                                      \
         }                                                                      \
                                                                                \
-        explicit NAME(TYPE&& value)                                            \
+        explicit NAME(TYPE&& value) noexcept                                   \
           : error_info(HPX_FORWARD(TYPE, value))                               \
         {                                                                      \
         }                                                                      \
@@ -60,6 +61,7 @@ namespace hpx {
 
     ///////////////////////////////////////////////////////////////////////////
     namespace detail {
+
         class exception_info_node_base
         {
         public:
@@ -149,10 +151,11 @@ namespace hpx {
 
     ///////////////////////////////////////////////////////////////////////////
     namespace detail {
+
         struct exception_with_info_base : public exception_info
         {
             exception_with_info_base(
-                std::type_info const& type, exception_info xi)
+                std::type_info const& type, exception_info xi) noexcept
               : exception_info(HPX_MOVE(xi))
               , type(type)
             {
@@ -172,7 +175,7 @@ namespace hpx {
             {
             }
 
-            explicit exception_with_info(E&& e, exception_info xi)
+            explicit exception_with_info(E&& e, exception_info xi) noexcept
               : E(HPX_MOVE(e))
               , exception_with_info_base(typeid(E), HPX_MOVE(xi))
             {
@@ -184,10 +187,10 @@ namespace hpx {
     [[noreturn]] void throw_with_info(
         E&& e, exception_info&& xi = exception_info())
     {
-        using ED = typename std::decay<E>::type;
-        static_assert(std::is_class<ED>::value && !std::is_final<ED>::value,
+        using ED = std::decay_t<E>;
+        static_assert(std::is_class_v<ED> && !std::is_final_v<ED>,
             "E shall be a valid base class");
-        static_assert(!std::is_base_of<exception_info, ED>::value,
+        static_assert(!std::is_base_of_v<exception_info, ED>,
             "E shall not derive from exception_info");
 
         throw detail::exception_with_info<ED>(HPX_FORWARD(E, e), HPX_MOVE(xi));
@@ -201,13 +204,13 @@ namespace hpx {
 
     ///////////////////////////////////////////////////////////////////////////
     template <typename E>
-    exception_info* get_exception_info(E& e)
+    exception_info* get_exception_info(E& e) noexcept
     {
         return dynamic_cast<exception_info*>(std::addressof(e));
     }
 
     template <typename E>
-    exception_info const* get_exception_info(E const& e)
+    exception_info const* get_exception_info(E const& e) noexcept
     {
         return dynamic_cast<exception_info const*>(std::addressof(e));
     }

--- a/libs/core/errors/include/hpx/errors/exception_list.hpp
+++ b/libs/core/errors/include/hpx/errors/exception_list.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2016 Hartmut Kaiser
+//  Copyright (c) 2007-2022 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -23,6 +23,7 @@
 
 ///////////////////////////////////////////////////////////////////////////////
 namespace hpx {
+
     /// The class exception_list is a container of exception_ptr objects
     /// parallel algorithms may use to communicate uncaught exceptions
     /// encountered during parallel execution to the caller of the algorithm
@@ -60,10 +61,10 @@ namespace hpx {
         explicit exception_list(exception_list_type&& l);
 
         exception_list(exception_list const& l);
-        exception_list(exception_list&& l);
+        exception_list(exception_list&& l) noexcept;
 
         exception_list& operator=(exception_list const& l);
-        exception_list& operator=(exception_list&& l);
+        exception_list& operator=(exception_list&& l) noexcept;
 
         ///
         void add(std::exception_ptr const& e);

--- a/libs/core/errors/include/hpx/errors/throw_exception.hpp
+++ b/libs/core/errors/include/hpx/errors/throw_exception.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2013 Hartmut Kaiser
+//  Copyright (c) 2007-2022 Hartmut Kaiser
 //  Copyright (c) 2011      Bryce Lelbach
 //
 //  SPDX-License-Identifier: BSL-1.0
@@ -25,7 +25,8 @@
 #include <hpx/config/warnings_prefix.hpp>
 
 /// \cond NODETAIL
-namespace hpx { namespace detail {
+namespace hpx::detail {
+
     template <typename Exception>
     [[noreturn]] HPX_CORE_EXPORT void throw_exception(Exception const& e,
         std::string const& func, std::string const& file, long line);
@@ -63,7 +64,7 @@ namespace hpx { namespace detail {
         hpx::error_code& ec, exception const& e, std::string const& func);
 
     [[noreturn]] HPX_CORE_EXPORT void throw_thread_interrupted_exception();
-}}    // namespace hpx::detail
+}    // namespace hpx::detail
 /// \endcond
 
 namespace hpx {
@@ -151,7 +152,8 @@ namespace hpx {
 ///          // Throw a hpx::exception initialized from the given parameters.
 ///          // Additionally associate with this exception some detailed
 ///          // diagnostic information about the throw-site.
-///          HPX_THROW_EXCEPTION(hpx::no_success, "raise_exception", "simulated error");
+///          HPX_THROW_EXCEPTION(hpx::error::no_success, "raise_exception",
+///             "simulated error");
 ///      }
 /// \endcode
 ///

--- a/libs/core/errors/src/error_code.cpp
+++ b/libs/core/errors/src/error_code.cpp
@@ -27,11 +27,16 @@ namespace hpx {
 
             std::string message(int value) const
             {
-                if (value >= success && value < last_error)
+                if (value >= hpx::error::success &&
+                    value < hpx::error::last_error)
+                {
                     return std::string("HPX(") + error_names[value] +
                         ")";    //-V108
-                if (value & system_error_flag)
+                }
+                if (value & hpx::error::system_error_flag)
+                {
                     return std::string("HPX(system_error)");
+                }
                 return "HPX(unknown_error)";
             }
         };
@@ -61,25 +66,25 @@ namespace hpx {
     }    // namespace detail
 
     ///////////////////////////////////////////////////////////////////////////
-    std::error_category const& get_hpx_category()
+    std::error_category const& get_hpx_category() noexcept
     {
         static detail::hpx_category hpx_category;
         return hpx_category;
     }
 
-    std::error_category const& get_hpx_rethrow_category()
+    std::error_category const& get_hpx_rethrow_category() noexcept
     {
         static detail::hpx_category_rethrow hpx_category_rethrow;
         return hpx_category_rethrow;
     }
 
-    std::error_category const& get_lightweight_hpx_category()
+    std::error_category const& get_lightweight_hpx_category() noexcept
     {
         static detail::lightweight_hpx_category lightweight_hpx_category;
         return lightweight_hpx_category;
     }
 
-    std::error_category const& get_hpx_category(throwmode mode)
+    std::error_category const& get_hpx_category(throwmode mode) noexcept
     {
         switch (mode)
         {
@@ -101,15 +106,19 @@ namespace hpx {
     error_code::error_code(error e, throwmode mode)
       : std::error_code(make_system_error_code(e, mode))
     {
-        if (e != success && e != no_success && !(mode & throwmode::lightweight))
+        if (e != hpx::error::success && e != hpx::error::no_success &&
+            !(mode & throwmode::lightweight))
+        {
             exception_ = detail::get_exception(e, "", mode);
+        }
     }
 
     error_code::error_code(
         error e, char const* func, char const* file, long line, throwmode mode)
       : std::error_code(make_system_error_code(e, mode))
     {
-        if (e != success && e != no_success && !(mode & throwmode::lightweight))
+        if (e != hpx::error::success && e != hpx::error::no_success &&
+            !(mode & throwmode::lightweight))
         {
             exception_ = detail::get_exception(e, "", mode, func, file, line);
         }
@@ -118,15 +127,19 @@ namespace hpx {
     error_code::error_code(error e, char const* msg, throwmode mode)
       : std::error_code(make_system_error_code(e, mode))
     {
-        if (e != success && e != no_success && !(mode & throwmode::lightweight))
+        if (e != hpx::error::success && e != hpx::error::no_success &&
+            !(mode & throwmode::lightweight))
+        {
             exception_ = detail::get_exception(e, msg, mode);
+        }
     }
 
     error_code::error_code(error e, char const* msg, char const* func,
         char const* file, long line, throwmode mode)
       : std::error_code(make_system_error_code(e, mode))
     {
-        if (e != success && e != no_success && !(mode & throwmode::lightweight))
+        if (e != hpx::error::success && e != hpx::error::no_success &&
+            !(mode & throwmode::lightweight))
         {
             exception_ = detail::get_exception(e, msg, mode, func, file, line);
         }
@@ -135,15 +148,19 @@ namespace hpx {
     error_code::error_code(error e, std::string const& msg, throwmode mode)
       : std::error_code(make_system_error_code(e, mode))
     {
-        if (e != success && e != no_success && !(mode & throwmode::lightweight))
+        if (e != hpx::error::success && e != hpx::error::no_success &&
+            !(mode & throwmode::lightweight))
+        {
             exception_ = detail::get_exception(e, msg, mode);
+        }
     }
 
     error_code::error_code(error e, std::string const& msg, char const* func,
         char const* file, long line, throwmode mode)
       : std::error_code(make_system_error_code(e, mode))
     {
-        if (e != success && e != no_success && !(mode & throwmode::lightweight))
+        if (e != hpx::error::success && e != hpx::error::no_success &&
+            !(mode & throwmode::lightweight))
         {
             exception_ = detail::get_exception(e, msg, mode, func, file, line);
         }
@@ -181,7 +198,7 @@ namespace hpx {
 
     ///////////////////////////////////////////////////////////////////////////
     error_code::error_code(error_code const& rhs)
-      : std::error_code(rhs.value() == success ?
+      : std::error_code(rhs.value() == hpx::error::success ?
                 make_success_code(
                     (category() == get_lightweight_hpx_category()) ?
                         hpx::throwmode::lightweight :
@@ -196,7 +213,7 @@ namespace hpx {
     {
         if (this != &rhs)
         {
-            if (rhs.value() == success)
+            if (rhs.value() == hpx::error::success)
             {
                 // if the rhs is a success code, we maintain our throw mode
                 this->std::error_code::operator=(make_success_code(

--- a/libs/core/errors/src/exception_list.cpp
+++ b/libs/core/errors/src/exception_list.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2015 Hartmut Kaiser
+//  Copyright (c) 2007-2022 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -55,7 +55,7 @@ namespace hpx {
                           // to take its address for comparison purposes.
 
     exception_list::exception_list()
-      : hpx::exception(hpx::success)
+      : hpx::exception(hpx::error::success)
       , mtx_()
     {
     }
@@ -68,7 +68,8 @@ namespace hpx {
     }
 
     exception_list::exception_list(exception_list_type&& l)
-      : hpx::exception(!l.empty() ? hpx::get_error(l.front()) : success)
+      : hpx::exception(
+            !l.empty() ? hpx::get_error(l.front()) : hpx::error::success)
       , exceptions_(HPX_MOVE(l))
       , mtx_()
     {
@@ -81,7 +82,7 @@ namespace hpx {
     {
     }
 
-    exception_list::exception_list(exception_list&& l)
+    exception_list::exception_list(exception_list&& l) noexcept
       : hpx::exception(HPX_MOVE(static_cast<hpx::exception&>(l)))
       , exceptions_(HPX_MOVE(l.exceptions_))
       , mtx_()
@@ -99,7 +100,7 @@ namespace hpx {
         return *this;
     }
 
-    exception_list& exception_list::operator=(exception_list&& l)
+    exception_list& exception_list::operator=(exception_list&& l) noexcept
     {
         if (this != &l)
         {
@@ -115,7 +116,7 @@ namespace hpx {
     {
         std::lock_guard<mutex_type> l(mtx_);
         if (exceptions_.empty())
-            return hpx::no_success;
+            return hpx::error::no_success;
         return hpx::get_error(exceptions_.front());
     }
 

--- a/libs/core/errors/src/throw_exception.cpp
+++ b/libs/core/errors/src/throw_exception.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2013 Hartmut Kaiser
+//  Copyright (c) 2007-2022 Hartmut Kaiser
 //  Copyright (c)      2011 Bryce Lelbach
 //
 //  SPDX-License-Identifier: BSL-1.0
@@ -14,7 +14,8 @@
 #include <string>
 #include <system_error>
 
-namespace hpx { namespace detail {
+namespace hpx::detail {
+
     [[noreturn]] void throw_exception(error errcode, std::string const& msg,
         std::string const& func, std::string const& file, long line)
     {
@@ -89,4 +90,4 @@ namespace hpx { namespace detail {
     {
         throw hpx::thread_interrupted();
     }
-}}    // namespace hpx::detail
+}    // namespace hpx::detail

--- a/libs/core/errors/tests/unit/exception.cpp
+++ b/libs/core/errors/tests/unit/exception.cpp
@@ -16,7 +16,8 @@
 
 void throw_always()
 {
-    HPX_THROW_EXCEPTION(hpx::no_success, "throw_always", "simulated error");
+    HPX_THROW_EXCEPTION(
+        hpx::error::no_success, "throw_always", "simulated error");
 }
 
 std::exception_ptr test_transport()

--- a/libs/core/execution/include/hpx/execution/algorithms/as_sender.hpp
+++ b/libs/core/execution/include/hpx/execution/algorithms/as_sender.hpp
@@ -69,7 +69,7 @@ namespace hpx::execution::experimental {
 
                         if (!state)
                         {
-                            HPX_THROW_EXCEPTION(no_state,
+                            HPX_THROW_EXCEPTION(hpx::error::no_state,
                                 "as_sender_operation_state::start",
                                 "the future has no valid shared state");
                         }

--- a/libs/core/execution/include/hpx/execution/algorithms/keep_future.hpp
+++ b/libs/core/execution/include/hpx/execution/algorithms/keep_future.hpp
@@ -39,7 +39,7 @@ namespace hpx { namespace execution { namespace experimental {
 
                         if (!state)
                         {
-                            HPX_THROW_EXCEPTION(no_state,
+                            HPX_THROW_EXCEPTION(hpx::error::no_state,
                                 "operation_state::start",
                                 "the future has no valid shared state");
                         }

--- a/libs/core/execution/src/execution_parameter_callbacks.cpp
+++ b/libs/core/execution/src/execution_parameter_callbacks.cpp
@@ -34,7 +34,7 @@ namespace hpx { namespace parallel { namespace execution { namespace detail {
         }
         else
         {
-            HPX_THROW_EXCEPTION(invalid_status,
+            HPX_THROW_EXCEPTION(hpx::error::invalid_status,
                 "hpx::parallel::execution::detail::get_os_thread_count",
                 "No fallback handler for get_os_thread_count is installed. "
                 "Please start the runtime if you haven't done so. If you "
@@ -66,7 +66,7 @@ namespace hpx { namespace parallel { namespace execution { namespace detail {
         }
         else
         {
-            HPX_THROW_EXCEPTION(invalid_status,
+            HPX_THROW_EXCEPTION(hpx::error::invalid_status,
                 "hpx::parallel::execution::detail::get_pu_mask",
                 "No fallback handler for get_pu_mask is installed. Please "
                 "start the runtime if you haven't done so. If you intended "

--- a/libs/core/execution/src/polymorphic_executor.cpp
+++ b/libs/core/execution/src/polymorphic_executor.cpp
@@ -21,7 +21,7 @@ namespace hpx { namespace parallel { namespace execution { namespace detail {
     ///////////////////////////////////////////////////////////////////////////
     [[noreturn]] void throw_bad_polymorphic_executor()
     {
-        hpx::throw_exception(bad_function_call,
+        hpx::throw_exception(hpx::error::bad_function_call,
             "empty polymorphic_executor object should not be used",
             "polymorphic_executor::operator()");
     }

--- a/libs/core/execution_base/include/hpx/execution_base/this_thread.hpp
+++ b/libs/core/execution_base/include/hpx/execution_base/this_thread.hpp
@@ -114,8 +114,8 @@ namespace hpx { namespace util {
             if (k > 32 && get_spinlock_break_on_deadlock_enabled() &&
                 k > get_spinlock_deadlock_detection_limit())
             {
-                HPX_THROW_EXCEPTION(
-                    deadlock, thread_name, "possible deadlock detected");
+                HPX_THROW_EXCEPTION(hpx::error::deadlock, thread_name,
+                    "possible deadlock detected");
             }
 #endif
             hpx::execution_base::this_thread::yield_k(k, thread_name);

--- a/libs/core/execution_base/src/any_sender.cpp
+++ b/libs/core/execution_base/src/any_sender.cpp
@@ -18,7 +18,7 @@ namespace hpx::execution::experimental::detail {
 
     void empty_any_operation_state::start() & noexcept
     {
-        HPX_THROW_EXCEPTION(hpx::bad_function_call,
+        HPX_THROW_EXCEPTION(hpx::error::bad_function_call,
             "any_operation_state::start",
             "attempted to call start on empty any_operation_state");
     }
@@ -36,7 +36,7 @@ namespace hpx::execution::experimental::detail {
 
     void throw_bad_any_call(char const* class_name, char const* function_name)
     {
-        HPX_THROW_EXCEPTION(hpx::bad_function_call,
+        HPX_THROW_EXCEPTION(hpx::error::bad_function_call,
             hpx::util::format("{}::{}", class_name, function_name),
             hpx::util::format(
                 "attempted to call {} on empty {}", function_name, class_name));

--- a/libs/core/execution_base/src/this_thread.cpp
+++ b/libs/core/execution_base/src/this_thread.cpp
@@ -150,7 +150,7 @@ namespace hpx { namespace execution_base {
 
             if (aborted_)
             {
-                HPX_THROW_EXCEPTION(yield_aborted, "suspend",
+                HPX_THROW_EXCEPTION(hpx::error::yield_aborted, "suspend",
                     "std::thread({}) aborted (yield returned wait_abort)", id_);
             }
         }

--- a/libs/core/execution_base/tests/unit/any_sender.cpp
+++ b/libs/core/execution_base/tests/unit/any_sender.cpp
@@ -311,7 +311,7 @@ void test_any_sender(F&& f, Ts&&... ts)
         }
         catch (hpx::exception const& e)
         {
-            HPX_TEST_EQ(e.get_error(), hpx::bad_function_call);
+            HPX_TEST_EQ(e.get_error(), hpx::error::bad_function_call);
         }
         catch (...)
         {
@@ -332,7 +332,7 @@ void test_any_sender(F&& f, Ts&&... ts)
         }
         catch (hpx::exception const& e)
         {
-            HPX_TEST_EQ(e.get_error(), hpx::bad_function_call);
+            HPX_TEST_EQ(e.get_error(), hpx::error::bad_function_call);
         }
         catch (...)
         {
@@ -387,7 +387,7 @@ void test_unique_any_sender(F&& f, Ts&&... ts)
         }
         catch (hpx::exception const& e)
         {
-            HPX_TEST_EQ(e.get_error(), hpx::bad_function_call);
+            HPX_TEST_EQ(e.get_error(), hpx::error::bad_function_call);
         }
         catch (...)
         {
@@ -447,7 +447,7 @@ void test_any_sender_set_error()
         }
         catch (hpx::exception const& e)
         {
-            HPX_TEST_EQ(e.get_error(), hpx::bad_function_call);
+            HPX_TEST_EQ(e.get_error(), hpx::error::bad_function_call);
         }
         catch (...)
         {
@@ -468,7 +468,7 @@ void test_any_sender_set_error()
         }
         catch (hpx::exception const& e)
         {
-            HPX_TEST_EQ(e.get_error(), hpx::bad_function_call);
+            HPX_TEST_EQ(e.get_error(), hpx::error::bad_function_call);
         }
         catch (...)
         {
@@ -506,7 +506,7 @@ void test_unique_any_sender_set_error()
         }
         catch (hpx::exception const& e)
         {
-            HPX_TEST_EQ(e.get_error(), hpx::bad_function_call);
+            HPX_TEST_EQ(e.get_error(), hpx::error::bad_function_call);
         }
         catch (...)
         {

--- a/libs/core/executors/include/hpx/executors/current_executor.hpp
+++ b/libs/core/executors/include/hpx/executors/current_executor.hpp
@@ -23,12 +23,14 @@ namespace hpx { namespace threads {
     /// \throws If <code>&ec != &throws</code>, never throws, but will set \a ec
     ///         to an appropriate value when an error occurs. Otherwise, this
     ///         function will throw an \a hpx#exception with an error code of
-    ///         \a hpx#yield_aborted if it is signaled with \a wait_aborted.
-    ///         If called outside of a HPX-thread, this function will throw
-    ///         an \a hpx#exception with an error code of \a hpx::null_thread_id.
+    ///         \a hpx#error#yield_aborted if it is signaled with \a
+    ///            wait_aborted.
+    ///         If called outside of a HPX-thread, this function will throw an
+    ///         \a hpx#exception with an error code of \a
+    ///            hpx#error#null_thread_id.
     ///         If this function is called while the thread-manager is not
     ///         running, it will throw an \a hpx#exception with an error code of
-    ///         \a hpx#invalid_status.
+    ///         \a hpx#error#invalid_status.
     ///
     HPX_CORE_EXPORT hpx::execution::parallel_executor get_executor(
         thread_id_type const& id, error_code& ec = throws);
@@ -41,12 +43,14 @@ namespace hpx { namespace this_thread {
     /// \throws If <code>&ec != &throws</code>, never throws, but will set \a ec
     ///         to an appropriate value when an error occurs. Otherwise, this
     ///         function will throw an \a hpx#exception with an error code of
-    ///         \a hpx#yield_aborted if it is signaled with \a wait_aborted.
-    ///         If called outside of a HPX-thread, this function will throw
-    ///         an \a hpx#exception with an error code of \a hpx::null_thread_id.
+    ///         \a hpx#error#yield_aborted if it is signaled with \a
+    ///            wait_aborted.
+    ///         If called outside of a HPX-thread, this function will throw an
+    ///         \a hpx#exception with an error code of \a
+    ///            hpx#error#null_thread_id.
     ///         If this function is called while the thread-manager is not
     ///         running, it will throw an \a hpx#exception with an error code of
-    ///         \a hpx#invalid_status.
+    ///         \a hpx#error#invalid_status.
     ///
     HPX_CORE_EXPORT hpx::execution::parallel_executor get_executor(
         error_code& ec = throws);

--- a/libs/core/executors/include/hpx/executors/fork_join_executor.hpp
+++ b/libs/core/executors/include/hpx/executors/fork_join_executor.hpp
@@ -459,7 +459,7 @@ namespace hpx { namespace execution { namespace experimental {
                 HPX_ASSERT(pool_);
                 if (num_threads_ > pool_->get_os_thread_count())
                 {
-                    HPX_THROW_EXCEPTION(bad_parameter,
+                    HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
                         "for_join_executor::shared_data::shared_data",
                         hpx::util::format("unexpected number of PUs in given "
                                           "mask: {}, available threads: {}",
@@ -793,7 +793,7 @@ namespace hpx { namespace execution { namespace experimental {
         {
             if (stacksize == threads::thread_stacksize::nostack)
             {
-                HPX_THROW_EXCEPTION(bad_parameter,
+                HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
                     "fork_join_executor::fork_join_executor",
                     "The fork_join_executor does not support using "
                     "thread_stacksize::nostack as the stacksize (stackful "
@@ -823,7 +823,7 @@ namespace hpx { namespace execution { namespace experimental {
         {
             if (stacksize == threads::thread_stacksize::nostack)
             {
-                HPX_THROW_EXCEPTION(bad_parameter,
+                HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
                     "fork_join_executor::fork_join_executor",
                     "The fork_join_executor does not support using "
                     "thread_stacksize::nostack as the stacksize (stackful "

--- a/libs/core/executors/src/current_executor.cpp
+++ b/libs/core/executors/src/current_executor.cpp
@@ -15,8 +15,8 @@ namespace hpx { namespace threads {
     {
         if (HPX_UNLIKELY(!id))
         {
-            HPX_THROWS_IF(ec, null_thread_id, "hpx::threads::get_executor",
-                "null thread id encountered");
+            HPX_THROWS_IF(ec, hpx::error::null_thread_id,
+                "hpx::threads::get_executor", "null thread id encountered");
             return hpx::execution::parallel_executor();
         }
 

--- a/libs/core/functional/include/hpx/functional/function.hpp
+++ b/libs/core/functional/include/hpx/functional/function.hpp
@@ -26,15 +26,14 @@ namespace hpx {
     ///////////////////////////////////////////////////////////////////////////
     /// Class template hpx::function is a general-purpose polymorphic function
     /// wrapper. Instances of hpx::function can store, copy, and invoke any
-    /// CopyConstructible Callable target -- functions, lambda expressions,
-    /// bind expressions, or other function objects, as well as pointers to
-    /// member functions and pointers to data members.
-    /// The stored callable object is called the target of hpx::function.
-    /// If an hpx::function contains no target, it is called empty. Invoking the
-    /// target of an empty hpx::function results in hpx::bad_function_call
-    /// exception being thrown.
-    /// hpx::function satisfies the requirements of CopyConstructible and
-    /// CopyAssignable.
+    /// CopyConstructible Callable target -- functions, lambda expressions, bind
+    /// expressions, or other function objects, as well as pointers to member
+    /// functions and pointers to data members. The stored callable object is
+    /// called the target of hpx::function. If an hpx::function contains no
+    /// target, it is called empty. Invoking the target of an empty
+    /// hpx::function results in \a hpx#error#bad_function_call exception being
+    /// thrown. hpx::function satisfies the requirements of CopyConstructible
+    /// and CopyAssignable.
     template <typename Sig, bool Serializable = false>
     class function;
 

--- a/libs/core/functional/src/empty_function.cpp
+++ b/libs/core/functional/src/empty_function.cpp
@@ -13,7 +13,7 @@
 namespace hpx { namespace util { namespace detail {
     [[noreturn]] void throw_bad_function_call()
     {
-        hpx::throw_exception(bad_function_call,
+        hpx::throw_exception(hpx::error::bad_function_call,
             "empty function object should not be used",
             "empty_function::operator()");
     }

--- a/libs/core/futures/include/hpx/futures/detail/future_data.hpp
+++ b/libs/core/futures/include/hpx/futures/detail/future_data.hpp
@@ -277,7 +277,8 @@ namespace hpx { namespace lcos { namespace detail {
         }
         virtual void cancel()
         {
-            HPX_THROW_EXCEPTION(future_does_not_support_cancellation,
+            HPX_THROW_EXCEPTION(
+                hpx::error::future_does_not_support_cancellation,
                 "future_data_base::cancel",
                 "this future does not support cancellation");
         }
@@ -316,19 +317,20 @@ namespace hpx { namespace lcos { namespace detail {
 
         virtual std::string const& get_registered_name() const
         {
-            HPX_THROW_EXCEPTION(invalid_status,
+            HPX_THROW_EXCEPTION(hpx::error::invalid_status,
                 "future_data_base::get_registered_name",
                 "this future does not support name registration");
         }
         virtual void set_registered_name(std::string /*name*/)
         {
-            HPX_THROW_EXCEPTION(invalid_status,
+            HPX_THROW_EXCEPTION(hpx::error::invalid_status,
                 "future_data_base::set_registered_name",
                 "this future does not support name registration");
         }
         virtual bool register_as(std::string /*name*/, bool /*manage_lifetime*/)
         {
-            HPX_THROW_EXCEPTION(invalid_status, "future_data_base::register_as",
+            HPX_THROW_EXCEPTION(hpx::error::invalid_status,
+                "future_data_base::register_as",
                 "this future does not support name registration");
         }
 
@@ -417,14 +419,15 @@ namespace hpx { namespace lcos { namespace detail {
         /// manager the function will return.
         ///
         /// \param ec     [in,out] this represents the error status on exit,
-        ///               if this is pre-initialized to \a hpx#throws
-        ///               the function will throw on error instead. If the
-        ///               operation blocks and is aborted because the object
-        ///               went out of scope, the code \a hpx#yield_aborted is
-        ///               set or thrown.
+        ///               if this is pre-initialized to \a hpx#throws the
+        ///               function will throw on error instead. If the operation
+        ///               blocks and is aborted because the object went out of
+        ///               scope, the code \a hpx#error#yield_aborted is set or
+        ///               thrown.
         ///
         /// \note         If there has been an error reported (using the action
-        ///               \a base_lco#set_exception), this function will throw an
+        ///               \a base_lco#set_exception), this function will throw
+        ///                  an
         ///               exception encapsulating the reported error code and
         ///               error description if <code>&ec == &throws</code>.
         virtual result_type* get_result(error_code& ec = throws)
@@ -472,7 +475,7 @@ namespace hpx { namespace lcos { namespace detail {
                 // this future should be 'empty' still (it can't be made ready
                 // more than once).
                 l.unlock();
-                HPX_THROW_EXCEPTION(promise_already_satisfied,
+                HPX_THROW_EXCEPTION(hpx::error::promise_already_satisfied,
                     "future_data_base::set_value",
                     "data has already been set for this future");
                 return;
@@ -532,7 +535,7 @@ namespace hpx { namespace lcos { namespace detail {
                 // this future should be 'empty' still (it can't be made ready
                 // more than once).
                 l.unlock();
-                HPX_THROW_EXCEPTION(promise_already_satisfied,
+                HPX_THROW_EXCEPTION(hpx::error::promise_already_satisfied,
                     "future_data_base::set_exception",
                     "data has already been set for this future");
                 return;
@@ -613,14 +616,14 @@ namespace hpx { namespace lcos { namespace detail {
             {
                 result_type* value_ptr =
                     reinterpret_cast<result_type*>(&storage_);
-                value_ptr->~result_type();
+                std::destroy_at(value_ptr);
                 break;
             }
             case exception:
             {
                 std::exception_ptr* exception_ptr =
                     reinterpret_cast<std::exception_ptr*>(&storage_);
-                exception_ptr->~exception_ptr();
+                std::destroy_at(exception_ptr);
                 break;
             }
             default:
@@ -888,7 +891,7 @@ namespace hpx { namespace lcos { namespace detail {
             if (started_)
             {
                 l.unlock();
-                HPX_THROW_EXCEPTION(task_already_started,
+                HPX_THROW_EXCEPTION(hpx::error::task_already_started,
                     "task_base::check_started",
                     "this task has already been started");
                 return;
@@ -1029,14 +1032,15 @@ namespace hpx { namespace lcos { namespace detail {
                         this->started_ = true;
 
                         l.unlock();
-                        this->set_error(future_cancelled,
+                        this->set_error(hpx::error::future_cancelled,
                             "task_base<Result>::cancel",
                             "future has been canceled");
                     }
                     else
                     {
                         l.unlock();
-                        HPX_THROW_EXCEPTION(future_can_not_be_cancelled,
+                        HPX_THROW_EXCEPTION(
+                            hpx::error::future_can_not_be_cancelled,
                             "task_base<Result>::cancel",
                             "future can't be canceled at this time");
                     }

--- a/libs/core/futures/include/hpx/futures/future.hpp
+++ b/libs/core/futures/include/hpx/futures/future.hpp
@@ -108,7 +108,8 @@ namespace hpx { namespace lcos { namespace detail {
         }
         else
         {
-            HPX_THROW_EXCEPTION(invalid_status, "serialize_future_load",
+            HPX_THROW_EXCEPTION(hpx::error::invalid_status,
+                "serialize_future_load",
                 "attempting to deserialize a future with an unknown state");
         }
     }
@@ -147,7 +148,8 @@ namespace hpx { namespace lcos { namespace detail {
         }
         else
         {
-            HPX_THROW_EXCEPTION(invalid_status, "serialize_future_load",
+            HPX_THROW_EXCEPTION(hpx::error::invalid_status,
+                "serialize_future_load",
                 "attempting to deserialize a future with an unknown state");
         }
     }
@@ -177,7 +179,8 @@ namespace hpx { namespace lcos { namespace detail {
             }
             else
             {
-                HPX_THROW_EXCEPTION(invalid_status, "serialize_future_save",
+                HPX_THROW_EXCEPTION(hpx::error::invalid_status,
+                    "serialize_future_save",
                     "future must be ready in order for it to be serialized");
             }
             return;
@@ -228,7 +231,8 @@ namespace hpx { namespace lcos { namespace detail {
             }
             else
             {
-                HPX_THROW_EXCEPTION(invalid_status, "serialize_future_save",
+                HPX_THROW_EXCEPTION(hpx::error::invalid_status,
+                    "serialize_future_save",
                     "future must be ready in order for it to be serialized");
             }
             return;
@@ -530,7 +534,7 @@ namespace hpx { namespace lcos { namespace detail {
         {
             if (!shared_state_)
             {
-                HPX_THROW_EXCEPTION(no_state,
+                HPX_THROW_EXCEPTION(hpx::error::no_state,
                     "future_base<R>::get_exception_ptr",
                     "this future has no valid shared state");
             }
@@ -591,7 +595,7 @@ namespace hpx { namespace lcos { namespace detail {
 
             if (!fut.shared_state_)
             {
-                HPX_THROWS_IF(ec, no_state, "future_base<R>::then",
+                HPX_THROWS_IF(ec, hpx::error::no_state, "future_base<R>::then",
                     "this future has no valid shared state");
                 return result_type();
             }
@@ -611,7 +615,7 @@ namespace hpx { namespace lcos { namespace detail {
 
             if (!fut.shared_state_)
             {
-                HPX_THROWS_IF(ec, no_state, "future_base<R>::then",
+                HPX_THROWS_IF(ec, hpx::error::no_state, "future_base<R>::then",
                     "this future has no valid shared state");
                 return result_type();
             }
@@ -632,7 +636,8 @@ namespace hpx { namespace lcos { namespace detail {
 
             if (!fut.shared_state_)
             {
-                HPX_THROWS_IF(ec, no_state, "future_base<R>::then_alloc",
+                HPX_THROWS_IF(ec, hpx::error::no_state,
+                    "future_base<R>::then_alloc",
                     "this future has no valid shared state");
                 return result_type();
             }
@@ -646,7 +651,7 @@ namespace hpx { namespace lcos { namespace detail {
         {
             if (!shared_state_)
             {
-                HPX_THROWS_IF(ec, no_state, "future_base<R>::wait",
+                HPX_THROWS_IF(ec, hpx::error::no_state, "future_base<R>::wait",
                     "this future has no valid shared state");
                 return;
             }
@@ -670,7 +675,8 @@ namespace hpx { namespace lcos { namespace detail {
         {
             if (!shared_state_)
             {
-                HPX_THROWS_IF(ec, no_state, "future_base<R>::wait_until",
+                HPX_THROWS_IF(ec, hpx::error::no_state,
+                    "future_base<R>::wait_until",
                     "this future has no valid shared state");
                 return hpx::future_status::uninitialized;
             }
@@ -865,7 +871,7 @@ namespace hpx {
         {
             if (!this->shared_state_)
             {
-                HPX_THROW_EXCEPTION(no_state, "future<R>::get",
+                HPX_THROW_EXCEPTION(hpx::error::no_state, "future<R>::get",
                     "this future has no valid shared state");
             }
 
@@ -885,7 +891,7 @@ namespace hpx {
         {
             if (!this->shared_state_)
             {
-                HPX_THROWS_IF(ec, no_state, "future<R>::get",
+                HPX_THROWS_IF(ec, hpx::error::no_state, "future<R>::get",
                     "this future has no valid shared state");
                 return lcos::detail::future_value<R>::get_default();
             }
@@ -1147,7 +1153,8 @@ namespace hpx {
         {
             if (!this->shared_state_)
             {
-                HPX_THROW_EXCEPTION(no_state, "shared_future<R>::get",
+                HPX_THROW_EXCEPTION(hpx::error::no_state,
+                    "shared_future<R>::get",
                     "this future has no valid shared state");
             }
 
@@ -1166,7 +1173,7 @@ namespace hpx {
             using result_type = typename shared_state_type::result_type;
             if (!this->shared_state_)
             {
-                HPX_THROWS_IF(ec, no_state, "shared_future<R>::get",
+                HPX_THROWS_IF(ec, hpx::error::no_state, "shared_future<R>::get",
                     "this future has no valid shared state");
                 static result_type res(
                     lcos::detail::future_value<R>::get_default());

--- a/libs/core/futures/include/hpx/futures/futures_factory.hpp
+++ b/libs/core/futures/include/hpx/futures/futures_factory.hpp
@@ -714,7 +714,7 @@ namespace hpx { namespace lcos { namespace local {
         {
             if (!task_)
             {
-                HPX_THROW_EXCEPTION(task_moved,
+                HPX_THROW_EXCEPTION(hpx::error::task_moved,
                     "futures_factory<Result()>::operator()",
                     "futures_factory invalid (has it been moved?)");
                 return;
@@ -737,7 +737,7 @@ namespace hpx { namespace lcos { namespace local {
         {
             if (!task_)
             {
-                HPX_THROW_EXCEPTION(task_moved,
+                HPX_THROW_EXCEPTION(hpx::error::task_moved,
                     "futures_factory<Result()>::post()",
                     "futures_factory invalid (has it been moved?)");
                 return threads::invalid_thread_id;
@@ -751,14 +751,14 @@ namespace hpx { namespace lcos { namespace local {
         {
             if (!task_)
             {
-                HPX_THROWS_IF(ec, task_moved,
+                HPX_THROWS_IF(ec, hpx::error::task_moved,
                     "futures_factory<Result()>::get_future",
                     "futures_factory invalid (has it been moved?)");
                 return hpx::future<Result>();
             }
             if (future_obtained_)
             {
-                HPX_THROWS_IF(ec, future_already_retrieved,
+                HPX_THROWS_IF(ec, hpx::error::future_already_retrieved,
                     "futures_factory<Result()>::get_future",
                     "future already has been retrieved from this factory");
                 return hpx::future<Result>();
@@ -779,7 +779,7 @@ namespace hpx { namespace lcos { namespace local {
         {
             if (!task_)
             {
-                HPX_THROW_EXCEPTION(task_moved,
+                HPX_THROW_EXCEPTION(hpx::error::task_moved,
                     "futures_factory<Result()>::set_exception",
                     "futures_factory invalid (has it been moved?)");
                 return;

--- a/libs/core/futures/include/hpx/futures/packaged_continuation.hpp
+++ b/libs/core/futures/include/hpx/futures/packaged_continuation.hpp
@@ -99,7 +99,8 @@ namespace hpx { namespace lcos { namespace detail {
 
                 if (ptr == nullptr)
                 {
-                    HPX_THROW_EXCEPTION(no_state, "invoke_continuation",
+                    HPX_THROW_EXCEPTION(hpx::error::no_state,
+                        "invoke_continuation",
                         "the inner future has no valid shared state");
                 }
 
@@ -203,7 +204,8 @@ namespace hpx { namespace lcos { namespace detail {
                 std::lock_guard<mutex_type> l(mtx_);
                 if (started_)
                 {
-                    HPX_THROWS_IF(ec, task_already_started, "continuation::run",
+                    HPX_THROWS_IF(ec, hpx::error::task_already_started,
+                        "continuation::run",
                         "this task has already been started");
                     return;
                 }
@@ -223,7 +225,7 @@ namespace hpx { namespace lcos { namespace detail {
                 std::lock_guard<mutex_type> l(mtx_);
                 if (started_)
                 {
-                    HPX_THROWS_IF(ec, task_already_started,
+                    HPX_THROWS_IF(ec, hpx::error::task_already_started,
                         "continuation::run_nounwrap",
                         "this task has already been started");
                     return;
@@ -268,7 +270,7 @@ namespace hpx { namespace lcos { namespace detail {
                 if (started_)
                 {
                     l.unlock();
-                    HPX_THROWS_IF(ec, task_already_started,
+                    HPX_THROWS_IF(ec, hpx::error::task_already_started,
                         "continuation::async",
                         "this task has already been started");
                     return;
@@ -298,7 +300,7 @@ namespace hpx { namespace lcos { namespace detail {
                 if (started_)
                 {
                     l.unlock();
-                    HPX_THROWS_IF(ec, task_already_started,
+                    HPX_THROWS_IF(ec, hpx::error::task_already_started,
                         "continuation::async_nounwrap",
                         "this task has already been started");
                     return;
@@ -344,14 +346,15 @@ namespace hpx { namespace lcos { namespace detail {
                         this->started_ = true;
 
                         l.unlock();
-                        this->set_error(future_cancelled,
+                        this->set_error(hpx::error::future_cancelled,
                             "continuation<Future, ContResult>::cancel",
                             "future has been canceled");
                     }
                     else
                     {
                         l.unlock();
-                        HPX_THROW_EXCEPTION(future_can_not_be_cancelled,
+                        HPX_THROW_EXCEPTION(
+                            hpx::error::future_can_not_be_cancelled,
                             "continuation<Future, ContResult>::cancel",
                             "future can't be canceled at this time");
                     }
@@ -382,7 +385,8 @@ namespace hpx { namespace lcos { namespace detail {
 
             if (ptr == nullptr)
             {
-                HPX_THROW_EXCEPTION(no_state, "continuation::attach",
+                HPX_THROW_EXCEPTION(hpx::error::no_state,
+                    "continuation::attach",
                     "the future to attach has no valid shared state");
             }
 
@@ -419,7 +423,8 @@ namespace hpx { namespace lcos { namespace detail {
 
             if (ptr == nullptr)
             {
-                HPX_THROW_EXCEPTION(no_state, "continuation::attach",
+                HPX_THROW_EXCEPTION(hpx::error::no_state,
+                    "continuation::attach",
                     "the future to attach has no valid shared state");
             }
 
@@ -457,7 +462,8 @@ namespace hpx { namespace lcos { namespace detail {
 
             if (ptr == nullptr)
             {
-                HPX_THROW_EXCEPTION(no_state, "continuation::attach_nounwrap",
+                HPX_THROW_EXCEPTION(hpx::error::no_state,
+                    "continuation::attach_nounwrap",
                     "the future to attach has no valid shared state");
             }
 
@@ -494,7 +500,8 @@ namespace hpx { namespace lcos { namespace detail {
 
             if (ptr == nullptr)
             {
-                HPX_THROW_EXCEPTION(no_state, "continuation::attach_nounwrap",
+                HPX_THROW_EXCEPTION(hpx::error::no_state,
+                    "continuation::attach_nounwrap",
                     "the future to attach has no valid shared state");
             }
 
@@ -613,7 +620,7 @@ namespace hpx { namespace lcos { namespace detail {
 
                     if (ptr == nullptr)
                     {
-                        HPX_THROW_EXCEPTION(no_state,
+                        HPX_THROW_EXCEPTION(hpx::error::no_state,
                             "unwrap_continuation<ContResult>::on_outer_ready",
                             "the inner future has no valid shared state");
                     }
@@ -659,7 +666,7 @@ namespace hpx { namespace lcos { namespace detail {
 
             if (ptr == nullptr)
             {
-                HPX_THROW_EXCEPTION(no_state,
+                HPX_THROW_EXCEPTION(hpx::error::no_state,
                     "unwrap_continuation<ContResult>::attach",
                     "the future has no valid shared state");
             }

--- a/libs/core/futures/include/hpx/futures/packaged_task.hpp
+++ b/libs/core/futures/include/hpx/futures/packaged_task.hpp
@@ -80,7 +80,7 @@ namespace hpx {
         {
             if (function_.empty())
             {
-                HPX_THROW_EXCEPTION(no_state,
+                HPX_THROW_EXCEPTION(hpx::error::no_state,
                     "packaged_task<Signature>::operator()",
                     "this packaged_task has no valid shared state");
                 return;
@@ -110,7 +110,7 @@ namespace hpx {
         {
             if (function_.empty())
             {
-                HPX_THROWS_IF(ec, no_state,
+                HPX_THROWS_IF(ec, hpx::error::no_state,
                     "packaged_task<Signature>::get_future",
                     "this packaged_task has no valid shared state");
                 return hpx::future<R>();
@@ -127,7 +127,8 @@ namespace hpx {
         {
             if (function_.empty())
             {
-                HPX_THROWS_IF(ec, no_state, "packaged_task<Signature>::reset",
+                HPX_THROWS_IF(ec, hpx::error::no_state,
+                    "packaged_task<Signature>::reset",
                     "this packaged_task has no valid shared state");
                 return;
             }

--- a/libs/core/futures/include/hpx/futures/promise.hpp
+++ b/libs/core/futures/include/hpx/futures/promise.hpp
@@ -120,7 +120,7 @@ namespace hpx {
             {
                 if (future_retrieved_ || shared_future_retrieved_)
                 {
-                    HPX_THROWS_IF(ec, future_already_retrieved,
+                    HPX_THROWS_IF(ec, hpx::error::future_already_retrieved,
                         "detail::promise_base<R>::get_future",
                         "future or shared future has already been retrieved "
                         "from this promise");
@@ -129,7 +129,7 @@ namespace hpx {
 
                 if (shared_state_ == nullptr)
                 {
-                    HPX_THROWS_IF(ec, no_state,
+                    HPX_THROWS_IF(ec, hpx::error::no_state,
                         "detail::promise_base<R>::get_future",
                         "this promise has no valid shared state");
                     return hpx::future<R>();
@@ -144,7 +144,7 @@ namespace hpx {
             {
                 if (future_retrieved_)
                 {
-                    HPX_THROWS_IF(ec, future_already_retrieved,
+                    HPX_THROWS_IF(ec, hpx::error::future_already_retrieved,
                         "detail::promise_base<R>::get_shared_future",
                         "future has already been retrieved from this promise");
                     return hpx::shared_future<R>();
@@ -152,7 +152,7 @@ namespace hpx {
 
                 if (shared_state_ == nullptr)
                 {
-                    HPX_THROWS_IF(ec, no_state,
+                    HPX_THROWS_IF(ec, hpx::error::no_state,
                         "detail::promise_base<R>::get_shared_future",
                         "this promise has no valid shared state");
                     return hpx::shared_future<R>();
@@ -170,7 +170,7 @@ namespace hpx {
             {
                 if (shared_state_ == nullptr)
                 {
-                    HPX_THROW_EXCEPTION(no_state,
+                    HPX_THROW_EXCEPTION(hpx::error::no_state,
                         "detail::promise_base<R>::set_value",
                         "this promise has no valid shared state");
                     return;
@@ -178,7 +178,7 @@ namespace hpx {
 
                 if (shared_state_->is_ready())
                 {
-                    HPX_THROW_EXCEPTION(promise_already_satisfied,
+                    HPX_THROW_EXCEPTION(hpx::error::promise_already_satisfied,
                         "detail::promise_base<R>::set_value",
                         "result has already been stored for this promise");
                     return;
@@ -192,7 +192,7 @@ namespace hpx {
             {
                 if (shared_state_ == nullptr)
                 {
-                    HPX_THROW_EXCEPTION(no_state,
+                    HPX_THROW_EXCEPTION(hpx::error::no_state,
                         "detail::promise_base<R>::set_exception",
                         "this promise has no valid shared state");
                     return;
@@ -200,7 +200,7 @@ namespace hpx {
 
                 if (shared_state_->is_ready())
                 {
-                    HPX_THROW_EXCEPTION(promise_already_satisfied,
+                    HPX_THROW_EXCEPTION(hpx::error::promise_already_satisfied,
                         "detail::promise_base<R>::set_exception",
                         "result has already been stored for this promise");
                     return;
@@ -216,7 +216,7 @@ namespace hpx {
                     (future_retrieved_ || shared_future_retrieved_) &&
                     !shared_state_->is_ready())
                 {
-                    shared_state_->set_error(broken_promise, fun,
+                    shared_state_->set_error(hpx::error::broken_promise, fun,
                         "abandoning not ready shared state");
                 }
             }
@@ -244,7 +244,7 @@ namespace hpx {
     ///     was a shared state created by hpx::async which is not yet ready, this
     ///     operation does not block.
     ///   - abandon: the promise stores the exception of type hpx::future_error with
-    ///     error code hpx::future_errc::broken_promise, makes the shared state ready,
+    ///     error code hpx::error::broken_promise, makes the shared state ready,
     ///     and then releases it.
     /// The promise is the "push" end of the promise-future communication channel: the
     /// operation that stores a value in the shared state synchronizes-with (as defined

--- a/libs/core/futures/src/future_data.cpp
+++ b/libs/core/futures/src/future_data.cpp
@@ -124,7 +124,8 @@ namespace hpx { namespace lcos { namespace detail {
         if (s == empty)
         {
             // the value has already been moved out of this future
-            HPX_THROWS_IF(ec, no_state, "future_data_base::get_result",
+            HPX_THROWS_IF(ec, hpx::error::no_state,
+                "future_data_base::get_result",
                 "this future has no valid shared state");
             return nullptr;
         }

--- a/libs/core/futures/tests/regressions/exception_from_continuation_1613.cpp
+++ b/libs/core/futures/tests/regressions/exception_from_continuation_1613.cpp
@@ -25,7 +25,7 @@ void test_exception_from_continuation1()
     hpx::future<void> f2 = f1.then([](hpx::future<void>&& f1) {
         HPX_TEST(f1.has_value());
         HPX_THROW_EXCEPTION(
-            hpx::invalid_status, "lambda", "testing exceptions");
+            hpx::error::invalid_status, "lambda", "testing exceptions");
     });
 
     p.set_value();
@@ -55,7 +55,7 @@ void test_exception_from_continuation2()
 
                 ++exceptions_thrown;
                 HPX_THROW_EXCEPTION(
-                    hpx::invalid_status, "lambda", "testing exceptions");
+                    hpx::error::invalid_status, "lambda", "testing exceptions");
             }));
     }
 

--- a/libs/core/futures/tests/regressions/future_unwrap_878.cpp
+++ b/libs/core/futures/tests/regressions/future_unwrap_878.cpp
@@ -22,7 +22,7 @@ int hpx_main()
     try
     {
         //promise.set_value(42);
-        throw hpx::bad_parameter;
+        throw hpx::error::bad_parameter;
     }
     catch (...)
     {

--- a/libs/core/futures/tests/unit/future.cpp
+++ b/libs/core/futures/tests/unit/future.cpp
@@ -114,7 +114,7 @@ void test_initial_state()
     }
     catch (hpx::exception const& e)
     {
-        HPX_TEST_EQ(e.get_error(), hpx::no_state);
+        HPX_TEST_EQ(e.get_error(), hpx::error::no_state);
     }
     catch (...)
     {
@@ -150,7 +150,7 @@ void test_cannot_get_future_twice()
     }
     catch (hpx::exception const& e)
     {
-        HPX_TEST_EQ(e.get_error(), hpx::future_already_retrieved);
+        HPX_TEST_EQ(e.get_error(), hpx::error::future_already_retrieved);
     }
     catch (...)
     {
@@ -247,7 +247,7 @@ void test_invoking_a_packaged_task_twice_throws()
     }
     catch (hpx::exception const& e)
     {
-        HPX_TEST_EQ(e.get_error(), hpx::promise_already_satisfied);
+        HPX_TEST_EQ(e.get_error(), hpx::error::promise_already_satisfied);
     }
     catch (...)
     {
@@ -272,7 +272,7 @@ void test_cannot_get_future_twice_from_task()
     }
     catch (hpx::exception const& e)
     {
-        HPX_TEST_EQ(e.get_error(), hpx::future_already_retrieved);
+        HPX_TEST_EQ(e.get_error(), hpx::error::future_already_retrieved);
     }
     catch (...)
     {
@@ -490,7 +490,7 @@ void test_packaged_task_can_be_moved()
     }
     catch (hpx::exception const& e)
     {
-        HPX_TEST_EQ(e.get_error(), hpx::no_state);
+        HPX_TEST_EQ(e.get_error(), hpx::error::no_state);
     }
     catch (...)
     {
@@ -522,7 +522,7 @@ void test_destroying_a_promise_stores_broken_promise()
     }
     catch (hpx::exception const& e)
     {
-        HPX_TEST_EQ(e.get_error(), hpx::broken_promise);
+        HPX_TEST_EQ(e.get_error(), hpx::error::broken_promise);
     }
     catch (...)
     {
@@ -548,7 +548,7 @@ void test_destroying_a_packaged_task_stores_broken_task()
     }
     catch (hpx::exception const& e)
     {
-        HPX_TEST_EQ(e.get_error(), hpx::broken_promise);
+        HPX_TEST_EQ(e.get_error(), hpx::error::broken_promise);
     }
     catch (...)
     {

--- a/libs/core/futures/tests/unit/shared_future.cpp
+++ b/libs/core/futures/tests/unit/shared_future.cpp
@@ -94,7 +94,7 @@ void test_initial_state()
     }
     catch (hpx::exception const& e)
     {
-        HPX_TEST_EQ(e.get_error(), hpx::no_state);
+        HPX_TEST_EQ(e.get_error(), hpx::error::no_state);
     }
     catch (...)
     {
@@ -130,7 +130,7 @@ void test_cannot_get_future_twice()
     }
     catch (hpx::exception const& e)
     {
-        HPX_TEST_EQ(e.get_error(), hpx::future_already_retrieved);
+        HPX_TEST_EQ(e.get_error(), hpx::error::future_already_retrieved);
     }
     catch (...)
     {
@@ -225,7 +225,7 @@ void test_invoking_a_packaged_task_twice_throws()
     }
     catch (hpx::exception const& e)
     {
-        HPX_TEST_EQ(e.get_error(), hpx::promise_already_satisfied);
+        HPX_TEST_EQ(e.get_error(), hpx::error::promise_already_satisfied);
     }
     catch (...)
     {
@@ -250,7 +250,7 @@ void test_cannot_get_future_twice_from_task()
     }
     catch (hpx::exception const& e)
     {
-        HPX_TEST_EQ(e.get_error(), hpx::future_already_retrieved);
+        HPX_TEST_EQ(e.get_error(), hpx::error::future_already_retrieved);
     }
     catch (...)
     {
@@ -554,7 +554,7 @@ void test_packaged_task_can_be_moved()
     }
     catch (hpx::exception const& e)
     {
-        HPX_TEST_EQ(e.get_error(), hpx::no_state);
+        HPX_TEST_EQ(e.get_error(), hpx::error::no_state);
     }
     catch (...)
     {
@@ -586,7 +586,7 @@ void test_destroying_a_promise_stores_broken_promise()
     }
     catch (hpx::exception const& e)
     {
-        HPX_TEST_EQ(e.get_error(), hpx::broken_promise);
+        HPX_TEST_EQ(e.get_error(), hpx::error::broken_promise);
     }
     catch (...)
     {
@@ -612,7 +612,7 @@ void test_destroying_a_packaged_task_stores_broken_task()
     }
     catch (hpx::exception const& e)
     {
-        HPX_TEST_EQ(e.get_error(), hpx::broken_promise);
+        HPX_TEST_EQ(e.get_error(), hpx::error::broken_promise);
     }
     catch (...)
     {

--- a/libs/core/futures/tests/unit/test_allocator.hpp
+++ b/libs/core/futures/tests/unit/test_allocator.hpp
@@ -108,7 +108,7 @@ public:
 
     void destroy(pointer p)
     {
-        p->~T();
+        std::destroy_at(p);
     }
 
     friend bool operator==(test_allocator const& x, test_allocator const& y)

--- a/libs/core/ini/src/ini.cpp
+++ b/libs/core/ini/src/ini.cpp
@@ -381,8 +381,9 @@ namespace hpx { namespace util {
             if (name.empty())
                 name = "<root>";
 
-            HPX_THROW_EXCEPTION(bad_parameter, "section::get_section",
-                "No such section ({}) in section: {}", sec_name, name);
+            HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
+                "section::get_section", "No such section ({}) in section: {}",
+                sec_name, name);
             return nullptr;
         }
 
@@ -390,7 +391,7 @@ namespace hpx { namespace util {
         if (it != sections_.end())
             return &((*it).second);
 
-        HPX_THROW_EXCEPTION(bad_parameter, "section::get_section",
+        HPX_THROW_EXCEPTION(hpx::error::bad_parameter, "section::get_section",
             "No such section ({}) in section: {}", sec_name, get_name());
         return nullptr;
     }
@@ -414,8 +415,9 @@ namespace hpx { namespace util {
             if (name.empty())
                 name = "<root>";
 
-            HPX_THROW_EXCEPTION(bad_parameter, "section::get_section",
-                "No such section ({}) in section: {}", sec_name, name);
+            HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
+                "section::get_section", "No such section ({}) in section: {}",
+                sec_name, name);
             return nullptr;
         }
 
@@ -423,7 +425,7 @@ namespace hpx { namespace util {
         if (it != sections_.end())
             return &((*it).second);
 
-        HPX_THROW_EXCEPTION(bad_parameter, "section::get_section",
+        HPX_THROW_EXCEPTION(hpx::error::bad_parameter, "section::get_section",
             "No such section ({}) in section: {}", sec_name, get_name());
         return nullptr;
     }
@@ -659,7 +661,7 @@ namespace hpx { namespace util {
                 return (*cit).second.get_entry(sub_key);
             }
 
-            HPX_THROW_EXCEPTION(bad_parameter, "section::get_entry",
+            HPX_THROW_EXCEPTION(hpx::error::bad_parameter, "section::get_entry",
                 "No such key ({}) in section: {}", key, get_name());
             return "";
         }
@@ -671,7 +673,7 @@ namespace hpx { namespace util {
             return expand(l, (*cit).second.first);
         }
 
-        HPX_THROW_EXCEPTION(bad_parameter, "section::get_entry",
+        HPX_THROW_EXCEPTION(hpx::error::bad_parameter, "section::get_entry",
             "No such section ({}) in section: {}", key, get_name());
         return "";
     }
@@ -821,7 +823,7 @@ namespace hpx { namespace util {
         if (!line.empty())
             msg += " (offending entry: " + line + ")";
 
-        HPX_THROW_EXCEPTION(no_success, "section::line_msg", msg);
+        HPX_THROW_EXCEPTION(hpx::error::no_success, "section::line_msg", msg);
     }
 
     ///////////////////////////////////////////////////////////////////////////////

--- a/libs/core/init_runtime_local/src/init_runtime_local.cpp
+++ b/libs/core/init_runtime_local/src/init_runtime_local.cpp
@@ -124,14 +124,14 @@ namespace hpx {
         {
             if (!threads::get_self_ptr())
             {
-                HPX_THROWS_IF(ec, invalid_status, "hpx::finalize",
+                HPX_THROWS_IF(ec, hpx::error::invalid_status, "hpx::finalize",
                     "this function can be called from an HPX thread only");
                 return -1;
             }
 
             if (!is_running())
             {
-                HPX_THROWS_IF(ec, invalid_status, "hpx::finalize",
+                HPX_THROWS_IF(ec, hpx::error::invalid_status, "hpx::finalize",
                     "the runtime system is not active (did you already "
                     "call finalize?)");
                 return -1;
@@ -143,7 +143,7 @@ namespace hpx {
             runtime* rt = get_runtime_ptr();
             if (nullptr == rt)
             {
-                HPX_THROWS_IF(ec, invalid_status, "hpx::finalize",
+                HPX_THROWS_IF(ec, hpx::error::invalid_status, "hpx::finalize",
                     "the runtime system is not active (did you already "
                     "call hpx::stop?)");
                 return -1;
@@ -158,7 +158,7 @@ namespace hpx {
         {
             if (threads::get_self_ptr())
             {
-                HPX_THROWS_IF(ec, invalid_status, "hpx::stop",
+                HPX_THROWS_IF(ec, hpx::error::invalid_status, "hpx::stop",
                     "this function cannot be called from an HPX thread");
                 return -1;
             }
@@ -167,7 +167,7 @@ namespace hpx {
                 get_runtime_ptr());    // take ownership!
             if (nullptr == rt.get())
             {
-                HPX_THROWS_IF(ec, invalid_status, "hpx::stop",
+                HPX_THROWS_IF(ec, hpx::error::invalid_status, "hpx::stop",
                     "the runtime system is not active (did you already "
                     "call hpx::stop?)");
                 return -1;
@@ -186,7 +186,7 @@ namespace hpx {
         {
             if (threads::get_self_ptr())
             {
-                HPX_THROWS_IF(ec, invalid_status, "hpx::suspend",
+                HPX_THROWS_IF(ec, hpx::error::invalid_status, "hpx::suspend",
                     "this function cannot be called from an HPX thread");
                 return -1;
             }
@@ -194,7 +194,7 @@ namespace hpx {
             runtime* rt = get_runtime_ptr();
             if (nullptr == rt)
             {
-                HPX_THROWS_IF(ec, invalid_status, "hpx::suspend",
+                HPX_THROWS_IF(ec, hpx::error::invalid_status, "hpx::suspend",
                     "the runtime system is not active (did you already "
                     "call hpx::stop?)");
                 return -1;
@@ -208,7 +208,7 @@ namespace hpx {
         {
             if (threads::get_self_ptr())
             {
-                HPX_THROWS_IF(ec, invalid_status, "hpx::resume",
+                HPX_THROWS_IF(ec, hpx::error::invalid_status, "hpx::resume",
                     "this function cannot be called from an HPX thread");
                 return -1;
             }
@@ -216,7 +216,7 @@ namespace hpx {
             runtime* rt = get_runtime_ptr();
             if (nullptr == rt)
             {
-                HPX_THROWS_IF(ec, invalid_status, "hpx::resume",
+                HPX_THROWS_IF(ec, hpx::error::invalid_status, "hpx::resume",
                     "the runtime system is not active (did you already "
                     "call hpx::stop?)");
                 return -1;

--- a/libs/core/io_service/src/io_service_pool.cpp
+++ b/libs/core/io_service/src/io_service_pool.cpp
@@ -50,7 +50,7 @@ namespace hpx { namespace util {
         pool_size_ = pool_size;
         if (pool_size_ == 0)
         {
-            HPX_THROW_EXCEPTION(bad_parameter,
+            HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
                 "io_service_pool::io_service_pool",
                 "io_service_pool size is 0");
             return;

--- a/libs/core/lcos_local/include/hpx/lcos_local/and_gate.hpp
+++ b/libs/core/lcos_local/include/hpx/lcos_local/and_gate.hpp
@@ -194,7 +194,8 @@ namespace hpx { namespace lcos { namespace local {
                 // out of bounds index
                 l.unlock();
                 outer_lock.unlock();
-                HPX_THROWS_IF(ec, bad_parameter, "base_and_gate<>::set",
+                HPX_THROWS_IF(ec, hpx::error::bad_parameter,
+                    "base_and_gate<>::set",
                     "index is out of range for this base_and_gate");
                 return false;
             }
@@ -203,7 +204,8 @@ namespace hpx { namespace lcos { namespace local {
                 // segment already filled, logic error
                 l.unlock();
                 outer_lock.unlock();
-                HPX_THROWS_IF(ec, bad_parameter, "base_and_gate<>::set",
+                HPX_THROWS_IF(ec, hpx::error::bad_parameter,
+                    "base_and_gate<>::set",
                     "input with the given index has already been triggered");
                 return false;
             }
@@ -296,7 +298,7 @@ namespace hpx { namespace lcos { namespace local {
             if (generation_value < generation_)
             {
                 l.unlock();
-                HPX_THROWS_IF(ec, hpx::invalid_status, function_name,
+                HPX_THROWS_IF(ec, hpx::error::invalid_status, function_name,
                     "sequencing error, generational counter too small");
                 return;
             }
@@ -333,7 +335,7 @@ namespace hpx { namespace lcos { namespace local {
                 if (new_generation < generation_)
                 {
                     l.unlock();
-                    HPX_THROW_EXCEPTION(hpx::invalid_status,
+                    HPX_THROW_EXCEPTION(hpx::error::invalid_status,
                         "and_gate::next_generation",
                         "sequencing error, new generational counter value too "
                         "small");
@@ -379,7 +381,8 @@ namespace hpx { namespace lcos { namespace local {
                 // reset happens while part of the slots are filled
                 l.unlock();
                 outer_lock.unlock();
-                HPX_THROWS_IF(ec, bad_parameter, "base_and_gate<>::init",
+                HPX_THROWS_IF(ec, hpx::error::bad_parameter,
+                    "base_and_gate<>::init",
                     "initializing this base_and_gate while slots are filled");
                 return;
             }

--- a/libs/core/lcos_local/include/hpx/lcos_local/channel.hpp
+++ b/libs/core/lcos_local/include/hpx/lcos_local/channel.hpp
@@ -121,7 +121,7 @@ namespace hpx { namespace lcos { namespace local {
                     {
                         l.unlock();
                         return hpx::make_exceptional_future<T>(
-                            HPX_GET_EXCEPTION(hpx::invalid_status,
+                            HPX_GET_EXCEPTION(hpx::error::invalid_status,
                                 "hpx::lcos::local::channel::get",
                                 "this channel is empty and was closed"));
                     }
@@ -130,7 +130,7 @@ namespace hpx { namespace lcos { namespace local {
                     {
                         l.unlock();
                         return hpx::make_exceptional_future<T>(
-                            HPX_GET_EXCEPTION(hpx::invalid_status,
+                            HPX_GET_EXCEPTION(hpx::error::invalid_status,
                                 "hpx::lcos::local::channel::get",
                                 "this channel is empty and is not accessible "
                                 "by any other thread causing a deadlock"));
@@ -150,7 +150,7 @@ namespace hpx { namespace lcos { namespace local {
                     {
                         l.unlock();
                         return hpx::make_exceptional_future<T>(
-                            HPX_GET_EXCEPTION(hpx::invalid_status,
+                            HPX_GET_EXCEPTION(hpx::error::invalid_status,
                                 "hpx::lcos::local::channel::get",
                                 "this channel is closed and the requested value"
                                 "has not been received yet"));
@@ -184,9 +184,10 @@ namespace hpx { namespace lcos { namespace local {
                 if (closed_)
                 {
                     l.unlock();
-                    return hpx::make_exceptional_future<void>(HPX_GET_EXCEPTION(
-                        hpx::invalid_status, "hpx::lcos::local::channel::set",
-                        "attempting to write to a closed channel"));
+                    return hpx::make_exceptional_future<void>(
+                        HPX_GET_EXCEPTION(hpx::error::invalid_status,
+                            "hpx::lcos::local::channel::set",
+                            "attempting to write to a closed channel"));
                 }
 
                 ++set_generation_;
@@ -203,7 +204,7 @@ namespace hpx { namespace lcos { namespace local {
                 if (closed_)
                 {
                     l.unlock();
-                    HPX_THROW_EXCEPTION(hpx::invalid_status,
+                    HPX_THROW_EXCEPTION(hpx::error::invalid_status,
                         "hpx::lcos::local::channel::close",
                         "attempting to close an already closed channel");
                     return 0;
@@ -218,7 +219,7 @@ namespace hpx { namespace lcos { namespace local {
 
                 {
                     unlock_guard<std::unique_lock<mutex_type>> ul(l);
-                    e = HPX_GET_EXCEPTION(hpx::future_cancelled,
+                    e = HPX_GET_EXCEPTION(hpx::error::future_cancelled,
                         hpx::throwmode::lightweight, "hpx::lcos::local::close",
                         "canceled waiting on this entry");
                 }
@@ -304,7 +305,7 @@ namespace hpx { namespace lcos { namespace local {
                     {
                         l.unlock();
                         return hpx::make_exceptional_future<void>(
-                            HPX_GET_EXCEPTION(hpx::invalid_status,
+                            HPX_GET_EXCEPTION(hpx::error::invalid_status,
                                 "hpx::lcos::local::detail::"
                                 "one_element_queue_async::push",
                                 "attempting to write to a busy queue"));
@@ -350,7 +351,7 @@ namespace hpx { namespace lcos { namespace local {
                     {
                         l.unlock();
                         return hpx::make_exceptional_future<T>(
-                            HPX_GET_EXCEPTION(hpx::invalid_status,
+                            HPX_GET_EXCEPTION(hpx::error::invalid_status,
                                 "hpx::lcos::local::detail::"
                                 "one_element_queue_async::pop",
                                 "attempting to read from an empty queue"));
@@ -422,7 +423,7 @@ namespace hpx { namespace lcos { namespace local {
                     {
                         l.unlock();
                         return hpx::make_exceptional_future<T>(
-                            HPX_GET_EXCEPTION(hpx::invalid_status,
+                            HPX_GET_EXCEPTION(hpx::error::invalid_status,
                                 "hpx::lcos::local::channel::get",
                                 "this channel is empty and was closed"));
                     }
@@ -431,7 +432,7 @@ namespace hpx { namespace lcos { namespace local {
                     {
                         l.unlock();
                         return hpx::make_exceptional_future<T>(
-                            HPX_GET_EXCEPTION(hpx::invalid_status,
+                            HPX_GET_EXCEPTION(hpx::error::invalid_status,
                                 "hpx::lcos::local::channel::get",
                                 "this channel is empty and is not accessible "
                                 "by any other thread causing a deadlock"));
@@ -444,10 +445,11 @@ namespace hpx { namespace lcos { namespace local {
                     // the requested item must be available, otherwise this
                     // would create a deadlock
                     l.unlock();
-                    return hpx::make_exceptional_future<T>(HPX_GET_EXCEPTION(
-                        hpx::invalid_status, "hpx::lcos::local::channel::get",
-                        "this channel is closed and the requested value"
-                        "has not been received yet"));
+                    return hpx::make_exceptional_future<T>(
+                        HPX_GET_EXCEPTION(hpx::error::invalid_status,
+                            "hpx::lcos::local::channel::get",
+                            "this channel is closed and the requested value"
+                            "has not been received yet"));
                 }
 
                 return f;
@@ -477,9 +479,10 @@ namespace hpx { namespace lcos { namespace local {
                 if (closed_)
                 {
                     l.unlock();
-                    return hpx::make_exceptional_future<void>(HPX_GET_EXCEPTION(
-                        hpx::invalid_status, "hpx::lcos::local::channel::set",
-                        "attempting to write to a closed channel"));
+                    return hpx::make_exceptional_future<void>(
+                        HPX_GET_EXCEPTION(hpx::error::invalid_status,
+                            "hpx::lcos::local::channel::set",
+                            "attempting to write to a closed channel"));
                 }
 
                 return buffer_.push(HPX_MOVE(t), l);
@@ -492,7 +495,7 @@ namespace hpx { namespace lcos { namespace local {
                 if (closed_)
                 {
                     l.unlock();
-                    HPX_THROW_EXCEPTION(hpx::invalid_status,
+                    HPX_THROW_EXCEPTION(hpx::error::invalid_status,
                         "hpx::lcos::local::channel::close",
                         "attempting to close an already closed channel");
                     return 0;
@@ -511,7 +514,7 @@ namespace hpx { namespace lcos { namespace local {
                 {
                     unlock_guard<std::unique_lock<mutex_type>> ul(l);
                     e = std::exception_ptr(HPX_GET_EXCEPTION(
-                        hpx::future_cancelled, "hpx::lcos::local::close",
+                        hpx::error::future_cancelled, "hpx::lcos::local::close",
                         "canceled waiting on this entry"));
                 }
 

--- a/libs/core/lcos_local/include/hpx/lcos_local/receive_buffer.hpp
+++ b/libs/core/lcos_local/include/hpx/lcos_local/receive_buffer.hpp
@@ -233,7 +233,7 @@ namespace hpx { namespace lcos { namespace local {
                     std::make_pair(step, std::make_shared<entry_data>()));
                 if (!res.second)
                 {
-                    HPX_THROW_EXCEPTION(invalid_status,
+                    HPX_THROW_EXCEPTION(hpx::error::invalid_status,
                         "base_receive_buffer::get_buffer_entry",
                         "couldn't insert a new entry into the receive buffer");
                 }
@@ -455,7 +455,7 @@ namespace hpx { namespace lcos { namespace local {
                     std::make_pair(step, std::make_shared<entry_data>()));
                 if (!res.second)
                 {
-                    HPX_THROW_EXCEPTION(invalid_status,
+                    HPX_THROW_EXCEPTION(hpx::error::invalid_status,
                         "base_receive_buffer::get_buffer_entry",
                         "couldn't insert a new entry into the receive buffer");
                 }

--- a/libs/core/lcos_local/include/hpx/lcos_local/trigger.hpp
+++ b/libs/core/lcos_local/include/hpx/lcos_local/trigger.hpp
@@ -166,7 +166,7 @@ namespace hpx { namespace lcos { namespace local {
 
             if (generation_value < generation_)
             {
-                HPX_THROWS_IF(ec, hpx::invalid_status, function_name,
+                HPX_THROWS_IF(ec, hpx::error::invalid_status, function_name,
                     "sequencing error, generational counter too small");
                 return;
             }

--- a/libs/core/lock_registration/src/register_locks.cpp
+++ b/libs/core/lock_registration/src/register_locks.cpp
@@ -287,7 +287,8 @@ namespace hpx { namespace util {
                     }
                     else
                     {
-                        HPX_THROW_EXCEPTION(invalid_status, "verify_no_locks",
+                        HPX_THROW_EXCEPTION(hpx::error::invalid_status,
+                            "verify_no_locks",
                             "suspending thread while at least one lock is "
                             "being held (default handler)");
                     }
@@ -310,7 +311,8 @@ namespace hpx { namespace util {
         //    // we throw an error if there are still registered locks for
         //    // this OS-thread
         //    if (!held_locks.empty()) {
-        //        HPX_THROW_EXCEPTION(invalid_status, "force_error_on_lock",
+        //        HPX_THROW_EXCEPTION(hpx::error::invalid_status,
+        //            "force_error_on_lock",
         //            "At least one lock is held while thread is being "
         //            terminated or interrupted.");
         //    }
@@ -334,7 +336,7 @@ namespace hpx { namespace util {
                     // this can happen if the lock was registered to be ignore
                     // on a different OS thread
                     // HPX_THROW_EXCEPTION(
-                    //     invalid_status, "set_ignore_status",
+                    //     hpx::error::invalid_status, "set_ignore_status",
                     //     "The given lock has not been registered.");
                     return;
                 }

--- a/libs/core/mpi_base/src/mpi_environment.cpp
+++ b/libs/core/mpi_base/src/mpi_environment.cpp
@@ -129,7 +129,7 @@ namespace hpx { namespace util {
 
             if (provided < minimal)
             {
-                HPX_THROW_EXCEPTION(invalid_status,
+                HPX_THROW_EXCEPTION(hpx::error::invalid_status,
                     "hpx::util::mpi_environment::init",
                     "MPI doesn't provide minimal requested thread level");
             }

--- a/libs/core/plugin/include/hpx/plugin/detail/dll_dlopen.hpp
+++ b/libs/core/plugin/include/hpx/plugin/detail/dll_dlopen.hpp
@@ -235,7 +235,8 @@ namespace hpx { namespace util { namespace plugin {
                 lock.unlock();
 
                 // report error
-                HPX_THROWS_IF(ec, dynamic_link_failure, "plugin::get", str);
+                HPX_THROWS_IF(
+                    ec, hpx::error::dynamic_link_failure, "plugin::get", str);
                 return std::pair<SymbolType, Deleter>();
             }
 
@@ -257,7 +258,8 @@ namespace hpx { namespace util { namespace plugin {
                 lock.unlock();
 
                 // report error
-                HPX_THROWS_IF(ec, filesystem_error, "plugin::get", str);
+                HPX_THROWS_IF(
+                    ec, hpx::error::filesystem_error, "plugin::get", str);
                 return std::pair<SymbolType, Deleter>();
             }
 
@@ -299,8 +301,8 @@ namespace hpx { namespace util { namespace plugin {
 
                     lock.unlock();
 
-                    HPX_THROWS_IF(
-                        ec, filesystem_error, "plugin::LoadLibrary", str);
+                    HPX_THROWS_IF(ec, hpx::error::filesystem_error,
+                        "plugin::LoadLibrary", str);
                     return;
                 }
 
@@ -329,8 +331,8 @@ namespace hpx { namespace util { namespace plugin {
                     "'{}' has been loaded from (dlerror: {})",
                     dll_name, dlerror());
 
-                HPX_THROWS_IF(
-                    ec, filesystem_error, "plugin::get_directory", str);
+                HPX_THROWS_IF(ec, hpx::error::filesystem_error,
+                    "plugin::get_directory", str);
             }
             result = directory;
             ::dlerror();    // Clear the error state.

--- a/libs/core/plugin/include/hpx/plugin/detail/dll_windows.hpp
+++ b/libs/core/plugin/include/hpx/plugin/detail/dll_windows.hpp
@@ -160,7 +160,8 @@ namespace hpx { namespace util { namespace plugin {
                     symbol_name, dll_name);
 
                 // report error
-                HPX_THROWS_IF(ec, dynamic_link_failure, "plugin::get", str);
+                HPX_THROWS_IF(
+                    ec, hpx::error::dynamic_link_failure, "plugin::get", str);
                 return std::pair<SymbolType, Deleter>();
             }
 
@@ -175,7 +176,8 @@ namespace hpx { namespace util { namespace plugin {
                     "Hpx.Plugin: Could not open shared library '{}'", dll_name);
 
                 // report error
-                HPX_THROWS_IF(ec, filesystem_error, "plugin::get", str);
+                HPX_THROWS_IF(
+                    ec, hpx::error::filesystem_error, "plugin::get", str);
                 return std::pair<SymbolType, Deleter>();
             }
             HPX_ASSERT(handle == dll_handle);
@@ -209,8 +211,8 @@ namespace hpx { namespace util { namespace plugin {
                         "Hpx.Plugin: Could not open shared library '{}'",
                         dll_name);
 
-                    HPX_THROWS_IF(
-                        ec, filesystem_error, "plugin::LoadLibrary", str);
+                    HPX_THROWS_IF(ec, hpx::error::filesystem_error,
+                        "plugin::LoadLibrary", str);
                     return;
                 }
             }
@@ -239,8 +241,8 @@ namespace hpx { namespace util { namespace plugin {
                     "'{}' has been loaded from.",
                     dll_name);
 
-                HPX_THROWS_IF(
-                    ec, filesystem_error, "plugin::get_directory", str);
+                HPX_THROWS_IF(ec, hpx::error::filesystem_error,
+                    "plugin::get_directory", str);
                 return buffer;
             }
 

--- a/libs/core/plugin/include/hpx/plugin/plugin_factory.hpp
+++ b/libs/core/plugin/include/hpx/plugin/plugin_factory.hpp
@@ -53,7 +53,7 @@ namespace hpx { namespace util { namespace plugin {
 
                 if (!xw)
                 {
-                    HPX_THROWS_IF(ec, filesystem_error,
+                    HPX_THROWS_IF(ec, hpx::error::filesystem_error,
                         "get_abstract_factory_static",
                         "Hpx.Plugin: Can't cast to the right factory type\n");
                     return std::pair<abstract_factory<BasePlugin>*,
@@ -102,7 +102,7 @@ namespace hpx { namespace util { namespace plugin {
                     str << " No classes exist.";
                 }
 
-                HPX_THROWS_IF(ec, filesystem_error,
+                HPX_THROWS_IF(ec, hpx::error::filesystem_error,
                     "get_abstract_factory_static", str.str());
                 return std::pair<abstract_factory<BasePlugin>*, dll_handle>();
             }

--- a/libs/core/prefix/src/find_prefix.cpp
+++ b/libs/core/prefix/src/find_prefix.cpp
@@ -134,7 +134,7 @@ namespace hpx { namespace util {
         char exe_path[MAX_PATH + 1] = {'\0'};
         if (!GetModuleFileNameA(nullptr, exe_path, sizeof(exe_path)))
         {
-            HPX_THROW_EXCEPTION(hpx::dynamic_link_failure,
+            HPX_THROW_EXCEPTION(hpx::error::dynamic_link_failure,
                 "get_executable_filename",
                 "unable to find executable filename");
         }
@@ -210,7 +210,7 @@ namespace hpx { namespace util {
             }
         }
 
-        HPX_THROW_EXCEPTION(hpx::dynamic_link_failure,
+        HPX_THROW_EXCEPTION(hpx::error::dynamic_link_failure,
             "get_executable_filename", "unable to find executable filename");
 
 #elif defined(__APPLE__)
@@ -221,7 +221,7 @@ namespace hpx { namespace util {
 
         if (0 != _NSGetExecutablePath(exe_path, &len))
         {
-            HPX_THROW_EXCEPTION(hpx::dynamic_link_failure,
+            HPX_THROW_EXCEPTION(hpx::error::dynamic_link_failure,
                 "get_executable_filename",
                 "unable to find executable filename");
         }

--- a/libs/core/resource_partitioner/examples/oversubscribing_resource_partitioner.cpp
+++ b/libs/core/resource_partitioner/examples/oversubscribing_resource_partitioner.cpp
@@ -71,7 +71,7 @@ int hpx_main(/*hpx::program_options::variables_map& vm*/)
 
     if (num_threads == 1)
     {
-        HPX_THROW_EXCEPTION(hpx::commandline_option_error, "hpx_main",
+        HPX_THROW_EXCEPTION(hpx::error::commandline_option_error, "hpx_main",
             "the oversubscribing_resource_partitioner example requires at "
             "least 2 worker threads (1 given)");
     }

--- a/libs/core/resource_partitioner/src/detail_partitioner.cpp
+++ b/libs/core/resource_partitioner/src/detail_partitioner.cpp
@@ -36,13 +36,13 @@ namespace hpx { namespace resource { namespace detail {
     [[noreturn]] void throw_runtime_error(
         std::string const& func, std::string const& message)
     {
-        HPX_THROW_EXCEPTION(invalid_status, func, message);
+        HPX_THROW_EXCEPTION(hpx::error::invalid_status, func, message);
     }
 
     [[noreturn]] void throw_invalid_argument(
         std::string const& func, std::string const& message)
     {
-        HPX_THROW_EXCEPTION(bad_parameter, func, message);
+        HPX_THROW_EXCEPTION(hpx::error::bad_parameter, func, message);
     }
 
     ///////////////////////////////////////////////////////////////////////////
@@ -925,7 +925,8 @@ namespace hpx { namespace resource { namespace detail {
     {
         if (!(mode_ & mode_allow_dynamic_pools))
         {
-            HPX_THROW_EXCEPTION(bad_parameter, "partitioner::shrink_pool",
+            HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
+                "partitioner::shrink_pool",
                 "dynamic pools have not been enabled for the partitioner");
         }
 
@@ -953,7 +954,8 @@ namespace hpx { namespace resource { namespace detail {
 
         if (!has_non_exclusive_pus)
         {
-            HPX_THROW_EXCEPTION(bad_parameter, "partitioner::shrink_pool",
+            HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
+                "partitioner::shrink_pool",
                 "pool '{}' has no non-exclusive pus associated", pool_name);
         }
 
@@ -970,7 +972,8 @@ namespace hpx { namespace resource { namespace detail {
     {
         if (!(mode_ & mode_allow_dynamic_pools))
         {
-            HPX_THROW_EXCEPTION(bad_parameter, "partitioner::expand_pool",
+            HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
+                "partitioner::expand_pool",
                 "dynamic pools have not been enabled for the partitioner");
         }
 
@@ -998,7 +1001,8 @@ namespace hpx { namespace resource { namespace detail {
 
         if (!has_non_exclusive_pus)
         {
-            HPX_THROW_EXCEPTION(bad_parameter, "partitioner::expand_pool",
+            HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
+                "partitioner::expand_pool",
                 "pool '{}' has no non-exclusive pus associated", pool_name);
         }
 

--- a/libs/core/resource_partitioner/src/partitioner.cpp
+++ b/libs/core/resource_partitioner/src/partitioner.cpp
@@ -109,7 +109,7 @@ namespace hpx { namespace resource {
         {
             // if the resource partitioner is not accessed for the first time
             // if the command-line parsing has not yet been done
-            HPX_THROW_EXCEPTION(invalid_status,
+            HPX_THROW_EXCEPTION(hpx::error::invalid_status,
                 "hpx::resource::get_partitioner",
                 "can be called only after the resource partitioner has "
                 "been initialized and before it has been deleted.");

--- a/libs/core/runtime_configuration/src/runtime_configuration.cpp
+++ b/libs/core/runtime_configuration/src/runtime_configuration.cpp
@@ -771,7 +771,7 @@ namespace hpx { namespace util {
             else
             {
                 // REVIEW: exception type is overused
-                HPX_THROW_EXCEPTION(bad_parameter,
+                HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
                     "runtime_configuration::get_agas_service_mode",
                     "invalid AGAS router mode \"{}\"", m);
             }

--- a/libs/core/runtime_local/include/hpx/runtime_local/service_executors.hpp
+++ b/libs/core/runtime_local/include/hpx/runtime_local/service_executors.hpp
@@ -53,7 +53,7 @@ namespace hpx { namespace parallel { namespace execution {
                 break;
             }
 
-            HPX_THROW_EXCEPTION(bad_parameter,
+            HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
                 "hpx::threads::detail::get_service_pool",
                 "unknown pool executor type");
             return nullptr;

--- a/libs/core/runtime_local/src/get_locality_name.cpp
+++ b/libs/core/runtime_local/src/get_locality_name.cpp
@@ -18,7 +18,7 @@ namespace hpx { namespace detail {
         runtime* rt = get_runtime_ptr();
         if (rt == nullptr)
         {
-            HPX_THROW_EXCEPTION(invalid_status,
+            HPX_THROW_EXCEPTION(hpx::error::invalid_status,
                 "hpx::detail::get_locality_name",
                 "the runtime system is not operational at this point");
             return "";

--- a/libs/core/runtime_local/src/interval_timer.cpp
+++ b/libs/core/runtime_local/src/interval_timer.cpp
@@ -275,7 +275,7 @@ namespace hpx { namespace util { namespace detail {
         catch (hpx::exception const& e)
         {
             // the lock above might throw yield_aborted
-            if (e.get_error() != yield_aborted)
+            if (e.get_error() != hpx::error::yield_aborted)
                 throw;
         }
 

--- a/libs/core/runtime_local/src/runtime_handlers.cpp
+++ b/libs/core/runtime_local/src/runtime_handlers.cpp
@@ -68,7 +68,7 @@ namespace hpx { namespace detail {
             strm << " (" << msg << ")";
         }
 
-        hpx::exception e(hpx::assertion_failure, strm.str());
+        hpx::exception e(hpx::error::assertion_failure, strm.str());
         std::cerr << hpx::diagnostic_information(hpx::detail::get_exception(
                          e, loc.function_name(), loc.file_name(), loc.line()))
                   << std::endl;
@@ -112,14 +112,16 @@ namespace hpx { namespace detail {
         {
             if (back_trace.empty())
             {
-                HPX_THROW_EXCEPTION(invalid_status, "verify_no_locks",
+                HPX_THROW_EXCEPTION(hpx::error::invalid_status,
+                    "verify_no_locks",
                     "suspending thread while at least one lock is "
                     "being held (stack backtrace was disabled at "
                     "compile time)");
             }
             else
             {
-                HPX_THROW_EXCEPTION(invalid_status, "verify_no_locks",
+                HPX_THROW_EXCEPTION(hpx::error::invalid_status,
+                    "verify_no_locks",
                     "suspending thread while at least one lock is "
                     "being held, stack backtrace: {}",
                     back_trace);
@@ -138,7 +140,8 @@ namespace hpx { namespace detail {
         hpx::runtime* rt = get_runtime_ptr();
         if (rt == nullptr)
         {
-            HPX_THROW_EXCEPTION(invalid_status, "hpx::detail::get_default_pool",
+            HPX_THROW_EXCEPTION(hpx::error::invalid_status,
+                "hpx::detail::get_default_pool",
                 "The runtime system is not active");
         }
 
@@ -150,7 +153,7 @@ namespace hpx { namespace detail {
         hpx::runtime* rt = get_runtime_ptr();
         if (rt == nullptr)
         {
-            HPX_THROW_EXCEPTION(invalid_status,
+            HPX_THROW_EXCEPTION(hpx::error::invalid_status,
                 "hpx::detail::get_default_timer_service",
                 "The runtime system is not active");
         }

--- a/libs/core/runtime_local/src/runtime_local.cpp
+++ b/libs/core/runtime_local/src/runtime_local.cpp
@@ -174,10 +174,11 @@ namespace hpx {
 
 ///////////////////////////////////////////////////////////////////////////////
 namespace hpx {
+
     ///////////////////////////////////////////////////////////////////////////
     HPX_CORE_EXPORT void HPX_CDECL new_handler()
     {
-        HPX_THROW_EXCEPTION(out_of_memory, "new_handler",
+        HPX_THROW_EXCEPTION(hpx::error::out_of_memory, "new_handler",
             "new allocator failed to allocate memory");
     }
 
@@ -931,7 +932,8 @@ namespace hpx {
         runtime* rt = get_runtime_ptr();
         if (nullptr == rt)
         {
-            HPX_THROW_EXCEPTION(invalid_status, "hpx::get_os_thread_count()",
+            HPX_THROW_EXCEPTION(hpx::error::invalid_status,
+                "hpx::get_os_thread_count()",
                 "the runtime system has not been initialized yet");
             return std::size_t(0);
         }
@@ -943,7 +945,7 @@ namespace hpx {
         runtime* rt = get_runtime_ptr();
         if (nullptr == rt)
         {
-            HPX_THROW_EXCEPTION(invalid_status,
+            HPX_THROW_EXCEPTION(hpx::error::invalid_status,
                 "hpx::is_scheduler_numa_sensitive",
                 "the runtime system has not been initialized yet");
             return false;
@@ -1075,7 +1077,8 @@ namespace hpx { namespace threads {
         hpx::runtime* rt = hpx::get_runtime_ptr();
         if (rt == nullptr)
         {
-            HPX_THROW_EXCEPTION(invalid_status, "hpx::threads::get_topology",
+            HPX_THROW_EXCEPTION(hpx::error::invalid_status,
+                "hpx::threads::get_topology",
                 "the hpx runtime system has not been initialized yet");
         }
         return rt->get_topology();
@@ -1160,7 +1163,7 @@ namespace hpx {
         {
             if (rt->get_state() > hpx::state::pre_startup)
             {
-                HPX_THROW_EXCEPTION(invalid_status,
+                HPX_THROW_EXCEPTION(hpx::error::invalid_status,
                     "register_pre_startup_function",
                     "Too late to register a new pre-startup function.");
                 return;
@@ -1180,7 +1183,8 @@ namespace hpx {
         {
             if (rt->get_state() > hpx::state::startup)
             {
-                HPX_THROW_EXCEPTION(invalid_status, "register_startup_function",
+                HPX_THROW_EXCEPTION(hpx::error::invalid_status,
+                    "register_startup_function",
                     "Too late to register a new startup function.");
                 return;
             }
@@ -1199,7 +1203,7 @@ namespace hpx {
         {
             if (rt->get_state() > hpx::state::pre_shutdown)
             {
-                HPX_THROW_EXCEPTION(invalid_status,
+                HPX_THROW_EXCEPTION(hpx::error::invalid_status,
                     "register_pre_shutdown_function",
                     "Too late to register a new pre-shutdown function.");
                 return;
@@ -1219,7 +1223,7 @@ namespace hpx {
         {
             if (rt->get_state() > hpx::state::shutdown)
             {
-                HPX_THROW_EXCEPTION(invalid_status,
+                HPX_THROW_EXCEPTION(hpx::error::invalid_status,
                     "register_shutdown_function",
                     "Too late to register a new shutdown function.");
                 return;
@@ -1296,7 +1300,8 @@ namespace hpx {
                     {
                         std::string boundcpu_str = threads::to_string(boundcpu);
                         std::string pu_mask_str = threads::to_string(pu_mask);
-                        HPX_THROW_EXCEPTION(invalid_status, "handle_print_bind",
+                        HPX_THROW_EXCEPTION(hpx::error::invalid_status,
+                            "handle_print_bind",
                             hpx::util::format(
                                 "unexpected mismatch between locality {1}: "
                                 "binding reported from HWLOC({2}) and HPX({3}) "
@@ -1639,7 +1644,7 @@ namespace hpx {
 
         if (state_.load() != hpx::state::running)
         {
-            HPX_THROW_EXCEPTION(invalid_status, "runtime::suspend",
+            HPX_THROW_EXCEPTION(hpx::error::invalid_status, "runtime::suspend",
                 "Can only suspend runtime from running state");
             return -1;
         }
@@ -1669,7 +1674,7 @@ namespace hpx {
 
         if (state_.load() != hpx::state::sleeping)
         {
-            HPX_THROW_EXCEPTION(invalid_status, "runtime::resume",
+            HPX_THROW_EXCEPTION(hpx::error::invalid_status, "runtime::resume",
                 "Can only resume runtime from suspended state");
             return -1;
         }
@@ -1881,10 +1886,12 @@ namespace hpx {
                         used_processing_units),
                     ec);
 
-                // comment this out for now as on CircleCI this is causing unending grief
+                // comment this out for now as on CircleCI this is causing
+                // unending grief
                 //if (ec)
                 //{
-                //    HPX_THROW_EXCEPTION(kernel_error, "runtime::init_tss_ex",
+                //    HPX_THROW_EXCEPTION(hpx::error::kernel_error,
+                //        "runtime::init_tss_ex",
                 //        "failed to set thread affinity mask ({}) for service "
                 //        "thread: {}",
                 //        hpx::threads::to_string(used_processing_units),
@@ -1963,8 +1970,9 @@ namespace hpx {
         if (0 == std::strncmp(name, "main", 4))    //-V112
             return &main_pool_;
 
-        HPX_THROW_EXCEPTION(bad_parameter, "runtime::get_thread_pool",
-            "unknown thread pool requested: {}", name);
+        HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
+            "runtime::get_thread_pool", "unknown thread pool requested: {}",
+            name);
         return nullptr;
     }
 
@@ -2031,7 +2039,8 @@ namespace hpx {
         runtime* rt = get_runtime_ptr();
         if (nullptr == rt)
         {
-            HPX_THROW_EXCEPTION(invalid_status, "hpx::get_num_worker_threads",
+            HPX_THROW_EXCEPTION(hpx::error::invalid_status,
+                "hpx::get_num_worker_threads",
                 "the runtime system has not been initialized yet");
             return std::size_t(0);
         }
@@ -2046,7 +2055,8 @@ namespace hpx {
         runtime* rt = get_runtime_ptr();
         if (nullptr == rt)
         {
-            HPX_THROW_EXCEPTION(invalid_status, "hpx::get_num_localities",
+            HPX_THROW_EXCEPTION(hpx::error::invalid_status,
+                "hpx::get_num_localities",
                 "the runtime system has not been initialized yet");
             return std::size_t(0);
         }
@@ -2059,7 +2069,7 @@ namespace hpx {
         runtime* rt = get_runtime_ptr();
         if (nullptr == rt)
         {
-            HPX_THROW_EXCEPTION(invalid_status,
+            HPX_THROW_EXCEPTION(hpx::error::invalid_status,
                 "hpx::get_initial_num_localities",
                 "the runtime system has not been initialized yet");
             return std::size_t(0);
@@ -2073,7 +2083,8 @@ namespace hpx {
         runtime* rt = get_runtime_ptr();
         if (nullptr == rt)
         {
-            HPX_THROW_EXCEPTION(invalid_status, "hpx::get_num_localities",
+            HPX_THROW_EXCEPTION(hpx::error::invalid_status,
+                "hpx::get_num_localities",
                 "the runtime system has not been initialized yet");
             return make_ready_future(std::uint32_t(0));
         }

--- a/libs/core/runtime_local/src/thread_mapper.cpp
+++ b/libs/core/runtime_local/src/thread_mapper.cpp
@@ -95,7 +95,7 @@ namespace hpx { namespace util {
         {
             if (tinfo.tid_ == tid)
             {
-                HPX_THROW_EXCEPTION(bad_parameter,
+                HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
                     "thread_mapper::register_thread",
                     "thread already registered");
             }

--- a/libs/core/schedulers/include/hpx/schedulers/local_priority_queue_scheduler.hpp
+++ b/libs/core/schedulers/include/hpx/schedulers/local_priority_queue_scheduler.hpp
@@ -977,7 +977,7 @@ namespace hpx { namespace threads { namespace policies {
                 default:
                 case thread_priority::unknown:
                 {
-                    HPX_THROW_EXCEPTION(bad_parameter,
+                    HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
                         "local_priority_queue_scheduler::get_thread_count",
                         "unknown thread priority value "
                         "(thread_priority::unknown)");
@@ -1043,7 +1043,7 @@ namespace hpx { namespace threads { namespace policies {
             default:
             case thread_priority::unknown:
             {
-                HPX_THROW_EXCEPTION(bad_parameter,
+                HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
                     "local_priority_queue_scheduler::get_thread_count",
                     "unknown thread priority value "
                     "(thread_priority::unknown)");

--- a/libs/core/schedulers/include/hpx/schedulers/local_queue_scheduler.hpp
+++ b/libs/core/schedulers/include/hpx/schedulers/local_queue_scheduler.hpp
@@ -589,7 +589,7 @@ namespace hpx { namespace threads { namespace policies {
                 default:
                 case thread_priority::unknown:
                 {
-                    HPX_THROW_EXCEPTION(bad_parameter,
+                    HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
                         "local_queue_scheduler::get_thread_count",
                         "unknown thread priority value "
                         "(thread_priority::unknown)");
@@ -618,7 +618,7 @@ namespace hpx { namespace threads { namespace policies {
             default:
             case thread_priority::unknown:
             {
-                HPX_THROW_EXCEPTION(bad_parameter,
+                HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
                     "local_queue_scheduler::get_thread_count",
                     "unknown thread priority value "
                     "(thread_priority::unknown)");

--- a/libs/core/schedulers/include/hpx/schedulers/queue_holder_thread.hpp
+++ b/libs/core/schedulers/include/hpx/schedulers/queue_holder_thread.hpp
@@ -581,7 +581,7 @@ namespace hpx { namespace threads { namespace policies {
         static void deallocate(threads::thread_data* p) noexcept
         {
             using threads::thread_data;
-            p->~thread_data();
+            std::destroy_at(p);
             thread_alloc_.deallocate(p, 1);
         }
 
@@ -607,7 +607,7 @@ namespace hpx { namespace threads { namespace policies {
                     debug::threadinfo<thread_id_type*>(&tid));
 
                 lk.unlock();
-                HPX_THROW_EXCEPTION(hpx::out_of_memory,
+                HPX_THROW_EXCEPTION(hpx::error::out_of_memory,
                     "queue_holder_thread::add_to_thread_map",
                     "Couldn't add new thread to the thread map {}", map_size);
             }
@@ -809,7 +809,7 @@ namespace hpx { namespace threads { namespace policies {
             default:
             case thread_priority::unknown:
             {
-                HPX_THROW_EXCEPTION(bad_parameter,
+                HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
                     "queue_holder_thread::get_thread_count_staged",
                     "unknown thread priority value (thread_priority::unknown)");
             }
@@ -860,7 +860,7 @@ namespace hpx { namespace threads { namespace policies {
             default:
             case thread_priority::unknown:
             {
-                HPX_THROW_EXCEPTION(bad_parameter,
+                HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
                     "queue_holder_thread::get_thread_count_pending",
                     "unknown thread priority value (thread_priority::unknown)");
             }
@@ -956,7 +956,7 @@ namespace hpx { namespace threads { namespace policies {
             }
             else if (state == thread_schedule_state::staged)
             {
-                HPX_THROW_EXCEPTION(bad_parameter,
+                HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
                     "queue_holder_thread::iterate_threads",
                     "can't iterate over thread ids of staged threads");
                 return false;

--- a/libs/core/schedulers/include/hpx/schedulers/shared_priority_queue_scheduler.hpp
+++ b/libs/core/schedulers/include/hpx/schedulers/shared_priority_queue_scheduler.hpp
@@ -405,7 +405,7 @@ namespace hpx { namespace threads { namespace policies {
                 break;
             }
             default:
-                HPX_THROW_EXCEPTION(bad_parameter,
+                HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
                     "shared_priority_queue_scheduler::create_thread",
                     "Invalid schedule hint mode: {}",
                     static_cast<std::size_t>(data.schedulehint.mode));
@@ -805,7 +805,7 @@ namespace hpx { namespace threads { namespace policies {
             }
 
             default:
-                HPX_THROW_EXCEPTION(bad_parameter,
+                HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
                     "shared_priority_queue_scheduler::schedule_thread",
                     "Invalid schedule hint mode: {}",
                     static_cast<std::size_t>(schedulehint.mode));
@@ -1229,7 +1229,7 @@ namespace hpx { namespace threads { namespace policies {
         {
             if (thread_num > num_workers_)
             {
-                HPX_THROW_EXCEPTION(bad_parameter,
+                HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
                     "shared_priority_queue_scheduler::on_stop_thread",
                     "Invalid thread number: {}", std::to_string(thread_num));
             }
@@ -1241,7 +1241,7 @@ namespace hpx { namespace threads { namespace policies {
         {
             if (thread_num > num_workers_)
             {
-                HPX_THROW_EXCEPTION(bad_parameter,
+                HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
                     "shared_priority_queue_scheduler::on_error",
                     "Invalid thread number: {}", std::to_string(thread_num));
             }
@@ -1251,7 +1251,7 @@ namespace hpx { namespace threads { namespace policies {
 #ifdef HPX_HAVE_THREAD_CREATION_AND_CLEANUP_RATES
         std::uint64_t get_creation_time(bool /* reset */) override
         {
-            HPX_THROW_EXCEPTION(invalid_status,
+            HPX_THROW_EXCEPTION(hpx::error::invalid_status,
                 "shared_priority_scheduler::get_creation_time",
                 "the shared_priority_scheduler does not support the "
                 "get_creation_time performance counter");
@@ -1259,7 +1259,7 @@ namespace hpx { namespace threads { namespace policies {
         }
         std::uint64_t get_cleanup_time(bool /* reset */) override
         {
-            HPX_THROW_EXCEPTION(invalid_status,
+            HPX_THROW_EXCEPTION(hpx::error::invalid_status,
                 "shared_priority_scheduler::get_cleanup_time",
                 "the shared_priority_scheduler does not support the "
                 "get_cleanup_time performance counter");
@@ -1271,7 +1271,7 @@ namespace hpx { namespace threads { namespace policies {
         std::int64_t get_num_pending_misses(
             std::size_t /* num */, bool /* reset */) override
         {
-            HPX_THROW_EXCEPTION(invalid_status,
+            HPX_THROW_EXCEPTION(hpx::error::invalid_status,
                 "shared_priority_scheduler::get_num_pending_misses",
                 "the shared_priority_scheduler does not support the "
                 "get_num_pending_misses performance counter");
@@ -1281,7 +1281,7 @@ namespace hpx { namespace threads { namespace policies {
         std::int64_t get_num_pending_accesses(
             std::size_t /* num */, bool /* reset */) override
         {
-            HPX_THROW_EXCEPTION(invalid_status,
+            HPX_THROW_EXCEPTION(hpx::error::invalid_status,
                 "shared_priority_scheduler::get_num_pending_accesses",
                 "the shared_priority_scheduler does not support the "
                 "get_num_pending_accesses performance counter");
@@ -1291,7 +1291,7 @@ namespace hpx { namespace threads { namespace policies {
         std::int64_t get_num_stolen_from_pending(
             std::size_t /* num */, bool /* reset */) override
         {
-            HPX_THROW_EXCEPTION(invalid_status,
+            HPX_THROW_EXCEPTION(hpx::error::invalid_status,
                 "shared_priority_scheduler::get_num_stolen_from_pending",
                 "the shared_priority_scheduler does not support the "
                 "get_num_stolen_from_pending performance counter");
@@ -1301,7 +1301,7 @@ namespace hpx { namespace threads { namespace policies {
         std::int64_t get_num_stolen_to_pending(
             std::size_t /* num */, bool /* reset */) override
         {
-            HPX_THROW_EXCEPTION(invalid_status,
+            HPX_THROW_EXCEPTION(hpx::error::invalid_status,
                 "shared_priority_scheduler::get_creation_time",
                 "the shared_priority_scheduler does not support the "
                 "get_creation_time performance counter");
@@ -1311,7 +1311,7 @@ namespace hpx { namespace threads { namespace policies {
         std::int64_t get_num_stolen_from_staged(
             std::size_t /* num */, bool /* reset */) override
         {
-            HPX_THROW_EXCEPTION(invalid_status,
+            HPX_THROW_EXCEPTION(hpx::error::invalid_status,
                 "shared_priority_scheduler::get_num_stolen_from_staged",
                 "the shared_priority_scheduler does not support the "
                 "get_num_stolen_from_staged performance counter");
@@ -1321,7 +1321,7 @@ namespace hpx { namespace threads { namespace policies {
         std::int64_t get_num_stolen_to_staged(
             std::size_t /* num */, bool /* reset */) override
         {
-            HPX_THROW_EXCEPTION(invalid_status,
+            HPX_THROW_EXCEPTION(hpx::error::invalid_status,
                 "shared_priority_scheduler::get_num_stolen_to_staged",
                 "the shared_priority_scheduler does not support the "
                 "get_num_stolen_to_staged performance counter");
@@ -1333,7 +1333,7 @@ namespace hpx { namespace threads { namespace policies {
         std::int64_t get_average_thread_wait_time(
             std::size_t /* num_thread */ = std::size_t(-1)) const override
         {
-            HPX_THROW_EXCEPTION(invalid_status,
+            HPX_THROW_EXCEPTION(hpx::error::invalid_status,
                 "shared_priority_scheduler::get_average_thread_wait_time",
                 "the shared_priority_scheduler does not support the "
                 "get_average_thread_wait_time performance counter");
@@ -1342,7 +1342,7 @@ namespace hpx { namespace threads { namespace policies {
         std::int64_t get_average_task_wait_time(
             std::size_t /* num_thread */ = std::size_t(-1)) const override
         {
-            HPX_THROW_EXCEPTION(invalid_status,
+            HPX_THROW_EXCEPTION(hpx::error::invalid_status,
                 "shared_priority_scheduler::get_average_task_wait_time",
                 "the shared_priority_scheduler does not support the "
                 "get_average_task_wait_time performance counter");

--- a/libs/core/schedulers/include/hpx/schedulers/thread_queue.hpp
+++ b/libs/core/schedulers/include/hpx/schedulers/thread_queue.hpp
@@ -234,7 +234,7 @@ namespace hpx { namespace threads { namespace policies {
                 threads::thread_id_ref_type thrd;
                 create_thread_object(thrd, data, lk);
 
-                task->~task_description();
+                std::destroy_at(task);
                 task_description_alloc_.deallocate(task, 1);
 
                 // add the new entry to the map of all threads
@@ -245,7 +245,7 @@ namespace hpx { namespace threads { namespace policies {
                 {
                     --addfrom->new_tasks_count_.data_;
                     lk.unlock();
-                    HPX_THROW_EXCEPTION(hpx::out_of_memory,
+                    HPX_THROW_EXCEPTION(hpx::error::out_of_memory,
                         "thread_queue::add_new",
                         "Couldn't add new thread to the thread map");
                     return 0;
@@ -685,7 +685,7 @@ namespace hpx { namespace threads { namespace policies {
                     if (HPX_UNLIKELY(!p.second))
                     {
                         lk.unlock();
-                        HPX_THROWS_IF(ec, hpx::out_of_memory,
+                        HPX_THROWS_IF(ec, hpx::error::out_of_memory,
                             "thread_queue::create_thread",
                             "Couldn't add new thread to the map of threads");
                         return;
@@ -729,7 +729,7 @@ namespace hpx { namespace threads { namespace policies {
             // away (can't be scheduled).
             if (data.initial_state != thread_schedule_state::pending)
             {
-                HPX_THROW_EXCEPTION(bad_parameter,
+                HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
                     "thread_queue::create_thread",
                     "staged tasks must have 'pending' as their initial state");
             }
@@ -947,7 +947,7 @@ namespace hpx { namespace threads { namespace policies {
             }
             else if (state == thread_schedule_state::staged)
             {
-                HPX_THROW_EXCEPTION(bad_parameter,
+                HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
                     "thread_queue::iterate_threads",
                     "can't iterate over thread ids of staged threads");
                 return false;

--- a/libs/core/schedulers/include/hpx/schedulers/thread_queue_mc.hpp
+++ b/libs/core/schedulers/include/hpx/schedulers/thread_queue_mc.hpp
@@ -188,7 +188,7 @@ namespace hpx { namespace threads { namespace policies {
         // Return the number of existing threads with the given state.
         std::int64_t get_thread_count() const
         {
-            HPX_THROW_EXCEPTION(bad_parameter, "get_thread_count",
+            HPX_THROW_EXCEPTION(hpx::error::bad_parameter, "get_thread_count",
                 "use get_queue_length_staged/get_queue_length_pending");
             return 0;
         }
@@ -244,7 +244,7 @@ namespace hpx { namespace threads { namespace policies {
             // away (can't be scheduled).
             if (data.initial_state != thread_schedule_state::pending)
             {
-                HPX_THROW_EXCEPTION(bad_parameter,
+                HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
                     "thread_queue_mc::create_thread",
                     "staged tasks must have 'pending' as their initial state");
             }

--- a/libs/core/serialization/include/hpx/serialization/boost_variant.hpp
+++ b/libs/core/serialization/include/hpx/serialization/boost_variant.hpp
@@ -91,7 +91,7 @@ namespace hpx { namespace serialization {
         {
             // this might happen if a type was removed from the list of variant
             // types
-            HPX_THROW_EXCEPTION(serialization_error,
+            HPX_THROW_EXCEPTION(hpx::error::serialization_error,
                 "load<Archive, Variant, version>",
                 "type was removed from the list of variant types");
         }

--- a/libs/core/serialization/include/hpx/serialization/detail/polymorphic_id_factory.hpp
+++ b/libs/core/serialization/include/hpx/serialization/detail/polymorphic_id_factory.hpp
@@ -110,8 +110,8 @@ namespace hpx::serialization::detail {
 #else
                 HPX_UNUSED(name);
 #endif
-                HPX_THROW_EXCEPTION(
-                    serialization_error, "polymorphic_id_factory::create", msg);
+                HPX_THROW_EXCEPTION(hpx::error::serialization_error,
+                    "polymorphic_id_factory::create", msg);
             }
 
             ctor_t ctor = vec[id];

--- a/libs/core/serialization/include/hpx/serialization/detail/polymorphic_nonintrusive_factory.hpp
+++ b/libs/core/serialization/include/hpx/serialization/detail/polymorphic_nonintrusive_factory.hpp
@@ -118,13 +118,13 @@ namespace hpx::serialization::detail {
         {
             if (!typeinfo.name() && std::string(typeinfo.name()).empty())
             {
-                HPX_THROW_EXCEPTION(serialization_error,
+                HPX_THROW_EXCEPTION(hpx::error::serialization_error,
                     "polymorphic_nonintrusive_factory::register_class",
                     "Cannot register a factory with an empty type name");
             }
             if (class_name.empty())
             {
-                HPX_THROW_EXCEPTION(serialization_error,
+                HPX_THROW_EXCEPTION(hpx::error::serialization_error,
                     "polymorphic_nonintrusive_factory::register_class",
                     "Cannot register a factory with an empty name");
             }

--- a/libs/core/serialization/include/hpx/serialization/input_archive.hpp
+++ b/libs/core/serialization/include/hpx/serialization/input_archive.hpp
@@ -59,7 +59,7 @@ namespace hpx::serialization {
             if ((endianness && (endian::native == endian::little)) ||
                 (!endianness && (endian::native == endian::big)))
             {
-                HPX_THROW_EXCEPTION(hpx::bad_request,
+                HPX_THROW_EXCEPTION(hpx::error::bad_request,
                     "hpx::serialization::input_archive::input_archive",
                     "Converting endianness is not supported by the "
                     "serialization library, please reconfigure HPX with "

--- a/libs/core/serialization/include/hpx/serialization/input_container.hpp
+++ b/libs/core/serialization/include/hpx/serialization/input_container.hpp
@@ -94,7 +94,7 @@ namespace hpx::serialization {
 
                 if (decompressed_size_ < current_)
                 {
-                    HPX_THROW_EXCEPTION(serialization_error,
+                    HPX_THROW_EXCEPTION(hpx::error::serialization_error,
                         "input_container::set_filter",
                         "archive data bstream is too short");
                     return;
@@ -125,7 +125,7 @@ namespace hpx::serialization {
                 std::size_t new_current = current_ + count;
                 if (new_current > access_traits::size(cont_))
                 {
-                    HPX_THROW_EXCEPTION(serialization_error,
+                    HPX_THROW_EXCEPTION(hpx::error::serialization_error,
                         "input_container::load_binary",
                         "archive data bstream is too short");
                     return;
@@ -149,7 +149,7 @@ namespace hpx::serialization {
                         // raise an error if we read past the serialization_chunk
                         if (current_chunk_size_ > current_chunk_size)
                         {
-                            HPX_THROW_EXCEPTION(serialization_error,
+                            HPX_THROW_EXCEPTION(hpx::error::serialization_error,
                                 "input_container::load_binary",
                                 "archive data bstream structure mismatch");
                             return;
@@ -180,7 +180,7 @@ namespace hpx::serialization {
 
                 if (get_chunk_size(current_chunk_) != count)
                 {
-                    HPX_THROW_EXCEPTION(serialization_error,
+                    HPX_THROW_EXCEPTION(hpx::error::serialization_error,
                         "input_container::load_binary_chunk",
                         "archive data bstream data chunk size mismatch");
                     return;

--- a/libs/core/serialization/include/hpx/serialization/serialize_buffer.hpp
+++ b/libs/core/serialization/include/hpx/serialization/serialize_buffer.hpp
@@ -167,7 +167,7 @@ namespace hpx::serialization {
             else
             {
                 // can't take ownership of const buffer
-                HPX_THROW_EXCEPTION(bad_parameter,
+                HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
                     "serialize_buffer::serialize_buffer",
                     "can't take ownership of const data");
             }
@@ -239,7 +239,7 @@ namespace hpx::serialization {
             else
             {
                 // can't take ownership of const buffer
-                HPX_THROW_EXCEPTION(bad_parameter,
+                HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
                     "serialize_buffer::serialize_buffer",
                     "can't take ownership of const data");
             }

--- a/libs/core/serialization/include/hpx/serialization/variant.hpp
+++ b/libs/core/serialization/include/hpx/serialization/variant.hpp
@@ -91,7 +91,7 @@ namespace hpx::serialization {
         {
             // this might happen if a type was removed from the list of variant
             // types
-            HPX_THROW_EXCEPTION(serialization_error,
+            HPX_THROW_EXCEPTION(hpx::error::serialization_error,
                 "load<Archive, Variant, version>",
                 "type was removed from the list of variant types");
         }

--- a/libs/core/serialization/src/detail/polymorphic_id_factory.cpp
+++ b/libs/core/serialization/src/detail/polymorphic_id_factory.cpp
@@ -60,7 +60,7 @@ namespace hpx { namespace serialization { namespace detail {
 
         if (!p.second)
         {
-            HPX_THROW_EXCEPTION(invalid_status,
+            HPX_THROW_EXCEPTION(hpx::error::invalid_status,
                 "polymorphic_id_factory::register_typename",
                 "failed to insert {} into typename_to_id_t registry",
                 type_name);
@@ -140,7 +140,7 @@ namespace hpx { namespace serialization { namespace detail {
 
         if (id == id_registry::invalid_id)
         {
-            HPX_THROW_EXCEPTION(serialization_error,
+            HPX_THROW_EXCEPTION(hpx::error::serialization_error,
                 "polymorphic_id_factory::get_id", "Unknown typename: {}",
                 type_name);
         }

--- a/libs/core/serialization/src/detail/polymorphic_intrusive_factory.cpp
+++ b/libs/core/serialization/src/detail/polymorphic_intrusive_factory.cpp
@@ -26,7 +26,7 @@ namespace hpx { namespace serialization { namespace detail {
     {
         if (name.empty())
         {
-            HPX_THROW_EXCEPTION(serialization_error,
+            HPX_THROW_EXCEPTION(hpx::error::serialization_error,
                 "polymorphic_intrusive_factory::register_class",
                 "Cannot register a factory with an empty name");
         }

--- a/libs/core/serialization/tests/unit/serialization_std_variant.cpp
+++ b/libs/core/serialization/tests/unit/serialization_std_variant.cpp
@@ -108,7 +108,7 @@ int main()
     }
     catch (hpx::exception const& e)
     {
-        if (e.get_error() == hpx::serialization_error)
+        if (e.get_error() == hpx::error::serialization_error)
         {
             caught_exception = true;
         }

--- a/libs/core/static_reinit/include/hpx/static_reinit/reinitializable_static.hpp
+++ b/libs/core/static_reinit/include/hpx/static_reinit/reinitializable_static.hpp
@@ -69,7 +69,7 @@ namespace hpx { namespace util {
         static void destruct()
         {
             for (std::size_t i = 0; i < N; ++i)
-                get_address(i)->~value_type();
+                std::destroy_at(get_address(i));
         }
 
         ///////////////////////////////////////////////////////////////////////

--- a/libs/core/string_util/include/hpx/string_util/token_functions.hpp
+++ b/libs/core/string_util/include/hpx/string_util/token_functions.hpp
@@ -105,7 +105,7 @@ namespace hpx::string_util {
         {
             if (++next == end)
             {
-                HPX_THROW_EXCEPTION(invalid_status,
+                HPX_THROW_EXCEPTION(hpx::error::invalid_status,
                     "escaped_list_separator::do_escape",
                     "cannot end with escape");
             }
@@ -122,7 +122,7 @@ namespace hpx::string_util {
             }
             else
             {
-                HPX_THROW_EXCEPTION(invalid_status,
+                HPX_THROW_EXCEPTION(hpx::error::invalid_status,
                     "escaped_list_separator::do_escape",
                     "unknown escape sequence");
             }

--- a/libs/core/synchronization/include/hpx/synchronization/channel_mpmc.hpp
+++ b/libs/core/synchronization/include/hpx/synchronization/channel_mpmc.hpp
@@ -95,7 +95,7 @@ namespace hpx { namespace lcos { namespace local {
             // invoke destructors for allocated buffer
             for (std::size_t i = 0; i != size_; ++i)
             {
-                (&buffer_[i])->~T();
+                std::destroy_at(&buffer_[i]);
             }
 
             if (!closed_)
@@ -178,7 +178,7 @@ namespace hpx { namespace lcos { namespace local {
             if (closed_)
             {
                 l.unlock();
-                HPX_THROW_EXCEPTION(hpx::invalid_status,
+                HPX_THROW_EXCEPTION(hpx::error::invalid_status,
                     "hpx::lcos::local::bounded_channel::close",
                     "attempting to close an already closed channel");
             }

--- a/libs/core/synchronization/include/hpx/synchronization/channel_mpsc.hpp
+++ b/libs/core/synchronization/include/hpx/synchronization/channel_mpsc.hpp
@@ -107,7 +107,7 @@ namespace hpx { namespace lcos { namespace local {
             // invoke destructors for allocated buffer
             for (std::size_t i = 0; i != size_; ++i)
             {
-                (&buffer_[i])->~T();
+                std::destroy_at(&buffer_[i]);
             }
 
             if (!closed_.load(std::memory_order_relaxed))
@@ -177,7 +177,7 @@ namespace hpx { namespace lcos { namespace local {
             bool expected = false;
             if (!closed_.compare_exchange_weak(expected, true))
             {
-                HPX_THROW_EXCEPTION(hpx::invalid_status,
+                HPX_THROW_EXCEPTION(hpx::error::invalid_status,
                     "hpx::lcos::local::base_channel_mpsc::close",
                     "attempting to close an already closed channel");
             }

--- a/libs/core/synchronization/include/hpx/synchronization/channel_spsc.hpp
+++ b/libs/core/synchronization/include/hpx/synchronization/channel_spsc.hpp
@@ -100,7 +100,7 @@ namespace hpx { namespace lcos { namespace local {
             // invoke destructors for allocated buffer
             for (std::size_t i = 0; i != size_; ++i)
             {
-                (&buffer_[i])->~T();
+                std::destroy_at(&buffer_[i]);
             }
 
             if (!closed_.load(std::memory_order_relaxed))
@@ -167,7 +167,7 @@ namespace hpx { namespace lcos { namespace local {
             bool expected = false;
             if (!closed_.compare_exchange_weak(expected, true))
             {
-                HPX_THROW_EXCEPTION(hpx::invalid_status,
+                HPX_THROW_EXCEPTION(hpx::error::invalid_status,
                     "hpx::lcos::local::channel_spsc::close",
                     "attempting to close an already closed channel");
             }

--- a/libs/core/synchronization/include/hpx/synchronization/lock_types.hpp
+++ b/libs/core/synchronization/include/hpx/synchronization/lock_types.hpp
@@ -121,12 +121,12 @@ namespace hpx {
         {
             if (m == nullptr)
             {
-                HPX_THROW_EXCEPTION(
-                    lock_error, "mutex::unlock", "upgrade_lock has no mutex");
+                HPX_THROW_EXCEPTION(hpx::error::lock_error, "mutex::unlock",
+                    "upgrade_lock has no mutex");
             }
             if (owns_lock())
             {
-                HPX_THROW_EXCEPTION(lock_error, "mutex::unlock",
+                HPX_THROW_EXCEPTION(hpx::error::lock_error, "mutex::unlock",
                     "upgrade_lock already owns the mutex");
             }
             m->lock_upgrade();
@@ -136,12 +136,12 @@ namespace hpx {
         {
             if (m == nullptr)
             {
-                HPX_THROW_EXCEPTION(
-                    lock_error, "mutex::unlock", "upgrade_lock has no mutex");
+                HPX_THROW_EXCEPTION(hpx::error::lock_error, "mutex::unlock",
+                    "upgrade_lock has no mutex");
             }
             if (owns_lock())
             {
-                HPX_THROW_EXCEPTION(lock_error, "mutex::unlock",
+                HPX_THROW_EXCEPTION(hpx::error::lock_error, "mutex::unlock",
                     "upgrade_lock already owns the mutex");
             }
             is_locked = m->try_lock_upgrade();
@@ -151,12 +151,12 @@ namespace hpx {
         {
             if (m == nullptr)
             {
-                HPX_THROW_EXCEPTION(
-                    lock_error, "mutex::unlock", "upgrade_lock has no mutex");
+                HPX_THROW_EXCEPTION(hpx::error::lock_error, "mutex::unlock",
+                    "upgrade_lock has no mutex");
             }
             if (!owns_lock())
             {
-                HPX_THROW_EXCEPTION(lock_error, "mutex::unlock",
+                HPX_THROW_EXCEPTION(hpx::error::lock_error, "mutex::unlock",
                     "upgrade_lock doesn't own the mutex");
             }
             m->unlock_upgrade();

--- a/libs/core/synchronization/include/hpx/synchronization/recursive_mutex.hpp
+++ b/libs/core/synchronization/include/hpx/synchronization/recursive_mutex.hpp
@@ -63,10 +63,11 @@ namespace hpx {
             /// Acquires ownership of the \a recursive_mutex. Suspends the
             /// current HPX-thread if ownership cannot be obtained immediately.
             ///
-            /// \throws Throws \a hpx#bad_parameter if an error occurs while
-            ///         suspending. Throws \a hpx#yield_aborted if the mutex is
-            ///         destroyed while suspended. Throws \a hpx#null_thread_id if
-            ///         called outside of a HPX-thread.
+            /// \throws Throws \a hpx#error#bad_parameter if an error occurs
+            ///         while suspending. Throws \a hpx#error#yield_aborted if
+            ///         the mutex is destroyed while suspended. Throws \a
+            ///         hpx#error#null_thread_id if called outside of a
+            ///         HPX-thread.
             void lock()
             {
                 auto ctx = hpx::execution_base::this_thread::agent();
@@ -84,9 +85,10 @@ namespace hpx {
 
             /// Release ownership of the \a recursive_mutex.
             ///
-            /// \throws Throws \a hpx#bad_parameter if an error occurs while
-            ///         releasing the mutex. Throws \a hpx#null_thread_id if called
-            ///         outside of a HPX-thread.
+            /// \throws Throws \a hpx#error#bad_parameter if an error occurs
+            ///         while releasing the mutex. Throws \a
+            ///         hpx#error#null_thread_id if called outside of a
+            ///         HPX-thread.
             void unlock()
             {
                 if (0 == --recursion_count)

--- a/libs/core/synchronization/src/detail/condition_variable.cpp
+++ b/libs/core/synchronization/src/detail/condition_variable.cpp
@@ -116,7 +116,7 @@ namespace hpx::lcos::local::detail {
             {
                 lock.unlock();
 
-                HPX_THROWS_IF(ec, null_thread_id,
+                HPX_THROWS_IF(ec, hpx::error::null_thread_id,
                     "condition_variable::notify_one",
                     "null thread id encountered");
                 return false;
@@ -166,7 +166,7 @@ namespace hpx::lcos::local::detail {
                     prepend_entries(lock, queue);
                     lock.unlock();
 
-                    HPX_THROWS_IF(ec, null_thread_id,
+                    HPX_THROWS_IF(ec, hpx::error::null_thread_id,
                         "condition_variable::notify_all",
                         "null thread id encountered");
                     return;

--- a/libs/core/synchronization/src/mutex.cpp
+++ b/libs/core/synchronization/src/mutex.cpp
@@ -50,7 +50,7 @@ namespace hpx {
         {
             HPX_ITT_SYNC_CANCEL(this);
             l.unlock();
-            HPX_THROWS_IF(ec, deadlock, description,
+            HPX_THROWS_IF(ec, hpx::error::deadlock, description,
                 "The calling thread already owns the mutex");
             return;
         }
@@ -103,7 +103,7 @@ namespace hpx {
         if (HPX_UNLIKELY(owner_id_ != self_id))
         {
             l.unlock();
-            HPX_THROWS_IF(ec, lock_error, "mutex::unlock",
+            HPX_THROWS_IF(ec, hpx::error::lock_error, "mutex::unlock",
                 "The calling thread does not own the mutex");
             return;
         }

--- a/libs/core/synchronization/tests/unit/shared_mutex/thread_group.hpp
+++ b/libs/core/synchronization/tests/unit/shared_mutex/thread_group.hpp
@@ -89,7 +89,7 @@ namespace test {
             {
                 if (is_thread_in(thrd))
                 {
-                    HPX_THROW_EXCEPTION(hpx::thread_resource_error,
+                    HPX_THROW_EXCEPTION(hpx::error::thread_resource_error,
                         "thread_group::add_thread",
                         "resource_deadlock_would_occur: trying to add a "
                         "duplicated thread");
@@ -115,7 +115,7 @@ namespace test {
         {
             if (is_this_thread_in())
             {
-                HPX_THROW_EXCEPTION(hpx::thread_resource_error,
+                HPX_THROW_EXCEPTION(hpx::error::thread_resource_error,
                     "thread_group::join_all",
                     "resource_deadlock_would_occur: trying joining itself");
                 return;

--- a/libs/core/thread_pool_util/src/thread_pool_suspension_helpers.cpp
+++ b/libs/core/thread_pool_util/src/thread_pool_suspension_helpers.cpp
@@ -22,17 +22,18 @@ namespace hpx { namespace threads {
     {
         if (!threads::get_self_ptr())
         {
-            HPX_THROW_EXCEPTION(invalid_status, "resume_processing_unit",
+            HPX_THROW_EXCEPTION(hpx::error::invalid_status,
+                "resume_processing_unit",
                 "cannot call resume_processing_unit from outside HPX, use"
                 "resume_processing_unit_cb instead");
         }
         else if (!pool.get_scheduler()->has_scheduler_mode(
                      policies::scheduler_mode::enable_elasticity))
         {
-            return hpx::make_exceptional_future<void>(
-                HPX_GET_EXCEPTION(invalid_status, "resume_processing_unit",
-                    "this thread pool does not support suspending "
-                    "processing units"));
+            return hpx::make_exceptional_future<void>(HPX_GET_EXCEPTION(
+                hpx::error::invalid_status, "resume_processing_unit",
+                "this thread pool does not support suspending "
+                "processing units"));
         }
 
         return hpx::async([&pool, virt_core]() -> void {
@@ -47,7 +48,8 @@ namespace hpx { namespace threads {
         if (!pool.get_scheduler()->has_scheduler_mode(
                 policies::scheduler_mode::enable_elasticity))
         {
-            HPX_THROWS_IF(ec, invalid_status, "resume_processing_unit_cb",
+            HPX_THROWS_IF(ec, hpx::error::invalid_status,
+                "resume_processing_unit_cb",
                 "this thread pool does not support suspending "
                 "processing units");
             return;
@@ -74,26 +76,27 @@ namespace hpx { namespace threads {
     {
         if (!threads::get_self_ptr())
         {
-            HPX_THROW_EXCEPTION(invalid_status, "suspend_processing_unit",
+            HPX_THROW_EXCEPTION(hpx::error::invalid_status,
+                "suspend_processing_unit",
                 "cannot call suspend_processing_unit from outside HPX, use"
                 "suspend_processing_unit_cb instead");
         }
         if (!pool.get_scheduler()->has_scheduler_mode(
                 policies::scheduler_mode::enable_elasticity))
         {
-            return hpx::make_exceptional_future<void>(
-                HPX_GET_EXCEPTION(invalid_status, "suspend_processing_unit",
-                    "this thread pool does not support suspending "
-                    "processing units"));
+            return hpx::make_exceptional_future<void>(HPX_GET_EXCEPTION(
+                hpx::error::invalid_status, "suspend_processing_unit",
+                "this thread pool does not support suspending "
+                "processing units"));
         }
         if (!pool.get_scheduler()->has_scheduler_mode(
                 policies::scheduler_mode::enable_stealing) &&
             hpx::this_thread::get_pool() == &pool)
         {
-            return hpx::make_exceptional_future<void>(
-                HPX_GET_EXCEPTION(invalid_status, "suspend_processing_unit",
-                    "this thread pool does not support suspending "
-                    "processing units from itself (no thread stealing)"));
+            return hpx::make_exceptional_future<void>(HPX_GET_EXCEPTION(
+                hpx::error::invalid_status, "suspend_processing_unit",
+                "this thread pool does not support suspending "
+                "processing units from itself (no thread stealing)"));
         }
 
         return hpx::async([&pool, virt_core]() -> void {
@@ -108,7 +111,8 @@ namespace hpx { namespace threads {
         if (!pool.get_scheduler()->has_scheduler_mode(
                 policies::scheduler_mode::enable_elasticity))
         {
-            HPX_THROWS_IF(ec, invalid_status, "suspend_processing_unit_cb",
+            HPX_THROWS_IF(ec, hpx::error::invalid_status,
+                "suspend_processing_unit_cb",
                 "this thread pool does not support suspending processing "
                 "units");
             return;
@@ -126,7 +130,7 @@ namespace hpx { namespace threads {
                     policies::scheduler_mode::enable_stealing) &&
                 hpx::this_thread::get_pool() == &pool)
             {
-                HPX_THROW_EXCEPTION(invalid_status,
+                HPX_THROW_EXCEPTION(hpx::error::invalid_status,
                     "suspend_processing_unit_cb",
                     "this thread pool does not support suspending "
                     "processing units from itself (no thread stealing)");
@@ -144,7 +148,7 @@ namespace hpx { namespace threads {
     {
         if (!threads::get_self_ptr())
         {
-            HPX_THROW_EXCEPTION(invalid_status, "resume_pool",
+            HPX_THROW_EXCEPTION(hpx::error::invalid_status, "resume_pool",
                 "cannot call resume_pool from outside HPX, use resume_pool_cb "
                 "or the member function resume_direct instead");
             return hpx::make_ready_future();
@@ -177,7 +181,7 @@ namespace hpx { namespace threads {
     {
         if (!threads::get_self_ptr())
         {
-            HPX_THROW_EXCEPTION(invalid_status, "suspend_pool",
+            HPX_THROW_EXCEPTION(hpx::error::invalid_status, "suspend_pool",
                 "cannot call suspend_pool from outside HPX, use "
                 "suspend_pool_cb or the member function suspend_direct "
                 "instead");
@@ -186,7 +190,7 @@ namespace hpx { namespace threads {
         if (threads::get_self_ptr() && hpx::this_thread::get_pool() == &pool)
         {
             return hpx::make_exceptional_future<void>(
-                HPX_GET_EXCEPTION(bad_parameter, "suspend_pool",
+                HPX_GET_EXCEPTION(hpx::error::bad_parameter, "suspend_pool",
                     "cannot suspend a pool from itself"));
         }
 
@@ -199,7 +203,7 @@ namespace hpx { namespace threads {
     {
         if (threads::get_self_ptr() && hpx::this_thread::get_pool() == &pool)
         {
-            HPX_THROWS_IF(ec, bad_parameter, "suspend_pool_cb",
+            HPX_THROWS_IF(ec, hpx::error::bad_parameter, "suspend_pool_cb",
                 "cannot suspend a pool from itself");
             return;
         }

--- a/libs/core/thread_pools/include/hpx/thread_pools/scheduled_thread_pool_impl.hpp
+++ b/libs/core/thread_pools/include/hpx/thread_pools/scheduled_thread_pool_impl.hpp
@@ -283,7 +283,7 @@ namespace hpx { namespace threads { namespace detail {
         if (0 == pool_threads)
         {
             HPX_THROW_EXCEPTION(
-                bad_parameter, "run", "number of threads is zero");
+                hpx::error::bad_parameter, "run", "number of threads is zero");
         }
 
         if (!threads_.empty() ||
@@ -412,7 +412,7 @@ namespace hpx { namespace threads { namespace detail {
     {
         if (threads::get_self_ptr() && hpx::this_thread::get_pool() == this)
         {
-            HPX_THROWS_IF(ec, bad_parameter,
+            HPX_THROWS_IF(ec, hpx::error::bad_parameter,
                 "scheduled_thread_pool<Scheduler>::suspend_direct",
                 "cannot suspend a pool from itself");
             return;
@@ -577,7 +577,7 @@ namespace hpx { namespace threads { namespace detail {
             {
                 // Repackage exceptions to avoid slicing.
                 hpx::throw_with_info(
-                    hpx::exception(unhandled_exception, e.what()));
+                    hpx::exception(hpx::error::unhandled_exception, e.what()));
             }
         }
         catch (...)
@@ -606,7 +606,7 @@ namespace hpx { namespace threads { namespace detail {
             !sched_->Scheduler::is_state(hpx::state::running))
         {
             // thread-manager is not currently running
-            HPX_THROWS_IF(ec, invalid_status,
+            HPX_THROWS_IF(ec, hpx::error::invalid_status,
                 "thread_pool<Scheduler>::create_thread",
                 "invalid state: thread pool is not running");
             return;
@@ -627,7 +627,7 @@ namespace hpx { namespace threads { namespace detail {
             !sched_->Scheduler::is_state(hpx::state::running))
         {
             // thread-manager is not currently running
-            HPX_THROWS_IF(ec, invalid_status,
+            HPX_THROWS_IF(ec, hpx::error::invalid_status,
                 "thread_pool<Scheduler>::create_work",
                 "invalid state: thread pool is not running");
             return invalid_thread_id;
@@ -1864,7 +1864,7 @@ namespace hpx { namespace threads { namespace detail {
         if (threads_[virt_core].joinable())
         {
             l.unlock();
-            HPX_THROWS_IF(ec, bad_parameter,
+            HPX_THROWS_IF(ec, hpx::error::bad_parameter,
                 "scheduled_thread_pool<Scheduler>::add_processing_unit",
                 "the given virtual core has already been added to this "
                 "thread pool");
@@ -1895,7 +1895,7 @@ namespace hpx { namespace threads { namespace detail {
         if (threads_.size() <= virt_core || !threads_[virt_core].joinable())
         {
             l.unlock();
-            HPX_THROWS_IF(ec, bad_parameter,
+            HPX_THROWS_IF(ec, hpx::error::bad_parameter,
                 "scheduled_thread_pool<Scheduler>::remove_processing_unit",
                 "the given virtual core has already been stopped to run on "
                 "this thread pool");
@@ -1955,7 +1955,7 @@ namespace hpx { namespace threads { namespace detail {
         if (threads_.size() <= virt_core || !threads_[virt_core].joinable())
         {
             l.unlock();
-            HPX_THROWS_IF(ec, bad_parameter,
+            HPX_THROWS_IF(ec, hpx::error::bad_parameter,
                 "scheduled_thread_pool<Scheduler>::suspend_processing_unit_"
                 "direct",
                 "the given virtual core has already been stopped to run on "
@@ -1995,7 +1995,7 @@ namespace hpx { namespace threads { namespace detail {
         if (threads_.size() <= virt_core || !threads_[virt_core].joinable())
         {
             l.unlock();
-            HPX_THROWS_IF(ec, bad_parameter,
+            HPX_THROWS_IF(ec, hpx::error::bad_parameter,
                 "scheduled_thread_pool<Scheduler>::resume_processing_unit",
                 "the given virtual core has already been stopped to run on "
                 "this thread pool");

--- a/libs/core/threading/src/thread.cpp
+++ b/libs/core/threading/src/thread.cpp
@@ -60,7 +60,7 @@ namespace hpx {
         {
             l2.unlock();
             l.unlock();
-            HPX_THROW_EXCEPTION(invalid_status,
+            HPX_THROW_EXCEPTION(hpx::error::invalid_status,
                 "thread::operator=", "destroying running thread");
         }
         id_ = rhs.id_;
@@ -76,8 +76,8 @@ namespace hpx {
             {
                 try
                 {
-                    HPX_THROW_EXCEPTION(invalid_status, "thread::~thread",
-                        "destroying running thread");
+                    HPX_THROW_EXCEPTION(hpx::error::invalid_status,
+                        "thread::~thread", "destroying running thread");
                 }
                 catch (...)
                 {
@@ -106,8 +106,8 @@ namespace hpx {
         threads::thread_id_type id = threads::get_self_id();
         if (id == threads::invalid_thread_id)
         {
-            HPX_THROW_EXCEPTION(null_thread_id, "run_thread_exit_callbacks",
-                "null thread id encountered");
+            HPX_THROW_EXCEPTION(hpx::error::null_thread_id,
+                "run_thread_exit_callbacks", "null thread id encountered");
         }
         threads::run_thread_exit_callbacks(id);
         threads::free_thread_exit_callbacks(id);
@@ -180,8 +180,8 @@ namespace hpx {
         pool->create_thread(data, id_, ec);
         if (ec)
         {
-            HPX_THROW_EXCEPTION(thread_resource_error, "thread::start_thread",
-                "Could not create thread");
+            HPX_THROW_EXCEPTION(hpx::error::thread_resource_error,
+                "thread::start_thread", "Could not create thread");
             return;
         }
     }
@@ -199,7 +199,7 @@ namespace hpx {
         if (!joinable_locked())
         {
             l.unlock();
-            HPX_THROW_EXCEPTION(invalid_status, "thread::join",
+            HPX_THROW_EXCEPTION(hpx::error::invalid_status, "thread::join",
                 "trying to join a non joinable thread");
         }
 
@@ -208,8 +208,8 @@ namespace hpx {
         if (this_id == id_)
         {
             l.unlock();
-            HPX_THROW_EXCEPTION(thread_resource_error, "thread::join",
-                "hpx::thread: trying joining itself");
+            HPX_THROW_EXCEPTION(hpx::error::thread_resource_error,
+                "thread::join", "hpx::thread: trying joining itself");
             return;
         }
         this_thread::interruption_point();
@@ -323,7 +323,7 @@ namespace hpx {
                 if (!this->is_ready())
                 {
                     threads::interrupt_thread(id_.noref());
-                    this->set_error(thread_cancelled,
+                    this->set_error(hpx::error::thread_cancelled,
                         "thread_task_base::cancel", "future has been canceled");
                     id_ = threads::invalid_thread_id;
                 }
@@ -348,7 +348,7 @@ namespace hpx {
     {
         if (id_ == threads::invalid_thread_id)
         {
-            HPX_THROWS_IF(ec, null_thread_id, "thread::get_future",
+            HPX_THROWS_IF(ec, hpx::error::null_thread_id, "thread::get_future",
                 "null thread id encountered");
             return hpx::future<void>();
         }
@@ -357,7 +357,8 @@ namespace hpx {
         hpx::intrusive_ptr<lcos::detail::future_data<void>> base(p);
         if (!p->valid())
         {
-            HPX_THROWS_IF(ec, thread_resource_error, "thread::get_future",
+            HPX_THROWS_IF(ec, hpx::error::thread_resource_error,
+                "thread::get_future",
                 "Could not create future as thread has been terminated.");
             return hpx::future<void>();
         }

--- a/libs/core/threading/tests/unit/condition_variable_race.cpp
+++ b/libs/core/threading/tests/unit/condition_variable_race.cpp
@@ -17,6 +17,7 @@
 #include <atomic>
 #include <cstdlib>
 #include <cstring>
+#include <memory>
 #include <mutex>
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -160,7 +161,7 @@ void test_cv_mutex()
         std::unique_lock<hpx::mutex> ul{m};
         f_ready = true;
         cv->notify_one();
-        cv->~condition_variable();
+        std::destroy_at(cv);
         // NOLINTNEXTLINE(bugprone-undefined-memory-manipulation)
         std::memset(
             (void*) cv, 0x55, sizeof(*cv));    // UB but OK to ensure the check
@@ -203,7 +204,7 @@ void test_cv_any_mutex()
         std::unique_lock<hpx::mutex> ul{m};
         f_ready = true;
         cv->notify_one();
-        cv->~condition_variable_any();
+        std::destroy_at(cv);
         // NOLINTNEXTLINE(bugprone-undefined-memory-manipulation)
         std::memset(
             (void*) cv, 0x55, sizeof(*cv));    // UB but OK to ensure the check

--- a/libs/core/threading/tests/unit/error_callback.cpp
+++ b/libs/core/threading/tests/unit/error_callback.cpp
@@ -24,7 +24,7 @@ bool on_thread_error(std::size_t, std::exception_ptr const&)
 ///////////////////////////////////////////////////////////////////////////////
 int hpx_main()
 {
-    HPX_THROW_EXCEPTION(hpx::invalid_status, "test", "test");
+    HPX_THROW_EXCEPTION(hpx::error::invalid_status, "test", "test");
     return hpx::local::finalize();
 }
 

--- a/libs/core/threading/tests/unit/thread.cpp
+++ b/libs/core/threading/tests/unit/thread.cpp
@@ -189,7 +189,7 @@ void do_test_thread_no_interrupt_if_interrupts_disabled_at_interruption_point()
     }
     catch (hpx::exception& e)
     {
-        HPX_TEST_EQ(e.get_error(), hpx::thread_not_interruptable);
+        HPX_TEST_EQ(e.get_error(), hpx::error::thread_not_interruptable);
         caught = true;
     }
 
@@ -350,7 +350,7 @@ void test_double_join()
     }
     catch (hpx::exception& e)
     {
-        HPX_TEST_EQ(e.get_error(), hpx::invalid_status);
+        HPX_TEST_EQ(e.get_error(), hpx::error::invalid_status);
         caught = true;
     }
 

--- a/libs/core/threading_base/include/hpx/threading_base/thread_data.hpp
+++ b/libs/core/threading_base/include/hpx/threading_base/thread_data.hpp
@@ -467,7 +467,7 @@ namespace hpx { namespace threads {
             if (flag && !enabled_interrupt_)
             {
                 l.unlock();
-                HPX_THROW_EXCEPTION(thread_not_interruptable,
+                HPX_THROW_EXCEPTION(hpx::error::thread_not_interruptable,
                     "thread_data::interrupt",
                     "interrupts are disabled for this thread");
                 return;

--- a/libs/core/threading_base/include/hpx/threading_base/thread_data_stackful.hpp
+++ b/libs/core/threading_base/include/hpx/threading_base/thread_data_stackful.hpp
@@ -20,6 +20,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <memory>
 #include <utility>
 
 #include <hpx/config/warnings_prefix.hpp>
@@ -157,7 +158,7 @@ namespace hpx { namespace threads {
 
         void destroy() noexcept override
         {
-            this->~thread_data_stackful();
+            std::destroy_at(this);
             thread_alloc_.deallocate(this, 1);
         }
 

--- a/libs/core/threading_base/include/hpx/threading_base/thread_data_stackless.hpp
+++ b/libs/core/threading_base/include/hpx/threading_base/thread_data_stackless.hpp
@@ -19,6 +19,7 @@
 #include <hpx/threading_base/thread_init_data.hpp>
 
 #include <cstddef>
+#include <memory>
 #include <utility>
 
 #include <hpx/config/warnings_prefix.hpp>
@@ -148,7 +149,7 @@ namespace hpx { namespace threads {
 
         void destroy() noexcept override
         {
-            this->~thread_data_stackless();
+            std::destroy_at(this);
             thread_alloc_.deallocate(this, 1);
         }
 

--- a/libs/core/threading_base/include/hpx/threading_base/thread_helpers.hpp
+++ b/libs/core/threading_base/include/hpx/threading_base/thread_helpers.hpp
@@ -423,12 +423,14 @@ namespace hpx { namespace threads {
     /// \throws If <code>&ec != &throws</code>, never throws, but will set \a ec
     ///         to an appropriate value when an error occurs. Otherwise, this
     ///         function will throw an \a hpx#exception with an error code of
-    ///         \a hpx#yield_aborted if it is signaled with \a wait_aborted.
-    ///         If called outside of a HPX-thread, this function will throw
-    ///         an \a hpx#exception with an error code of \a hpx::null_thread_id.
+    ///         \a hpx#error#yield_aborted if it is signaled with \a
+    ///            wait_aborted.
+    ///         If called outside of a HPX-thread, this function will throw an
+    ///         \a hpx#exception with an error code of \a
+    ///            hpx#error#null_thread_id.
     ///         If this function is called while the thread-manager is not
     ///         running, it will throw an \a hpx#exception with an error code of
-    ///         \a hpx#invalid_status.
+    ///         \a hpx#error#invalid_status.
     HPX_CORE_EXPORT threads::thread_pool_base* get_pool(
         thread_id_type const& id, error_code& ec = throws);
 }}    // namespace hpx::threads
@@ -436,20 +438,22 @@ namespace hpx { namespace threads {
 namespace hpx { namespace this_thread {
     ///////////////////////////////////////////////////////////////////////////
     /// The function \a suspend will return control to the thread manager
-    /// (suspends the current thread). It sets the new state of this thread
-    /// to the thread state passed as the parameter.
+    /// (suspends the current thread). It sets the new state of this thread to
+    /// the thread state passed as the parameter.
     ///
     /// \note Must be called from within a HPX-thread.
     ///
     /// \throws If <code>&ec != &throws</code>, never throws, but will set \a ec
     ///         to an appropriate value when an error occurs. Otherwise, this
     ///         function will throw an \a hpx#exception with an error code of
-    ///         \a hpx#yield_aborted if it is signaled with \a wait_aborted.
-    ///         If called outside of a HPX-thread, this function will throw
-    ///         an \a hpx#exception with an error code of \a hpx::null_thread_id.
+    ///         \a hpx#error#yield_aborted if it is signaled with \a
+    ///            wait_aborted.
+    ///         If called outside of a HPX-thread, this function will throw an
+    ///         \a hpx#exception with an error code of \a
+    ///            hpx#error#null_thread_id.
     ///         If this function is called while the thread-manager is not
     ///         running, it will throw an \a hpx#exception with an error code of
-    ///         \a hpx#invalid_status.
+    ///         \a hpx#error#invalid_status.
     ///
     HPX_CORE_EXPORT threads::thread_restart_state suspend(
         threads::thread_schedule_state state, threads::thread_id_type id,
@@ -458,20 +462,22 @@ namespace hpx { namespace this_thread {
         error_code& ec = throws);
 
     /// The function \a suspend will return control to the thread manager
-    /// (suspends the current thread). It sets the new state of this thread
-    /// to the thread state passed as the parameter.
+    /// (suspends the current thread). It sets the new state of this thread to
+    /// the thread state passed as the parameter.
     ///
     /// \note Must be called from within a HPX-thread.
     ///
     /// \throws If <code>&ec != &throws</code>, never throws, but will set \a ec
     ///         to an appropriate value when an error occurs. Otherwise, this
     ///         function will throw an \a hpx#exception with an error code of
-    ///         \a hpx#yield_aborted if it is signaled with \a wait_aborted.
-    ///         If called outside of a HPX-thread, this function will throw
-    ///         an \a hpx#exception with an error code of \a hpx::null_thread_id.
+    ///         \a hpx#error#yield_aborted if it is signaled with \a
+    ///            wait_aborted.
+    ///         If called outside of a HPX-thread, this function will throw an
+    ///         \a hpx#exception with an error code of \a
+    ///            hpx#error#null_thread_id.
     ///         If this function is called while the thread-manager is not
     ///         running, it will throw an \a hpx#exception with an error code of
-    ///         \a hpx#invalid_status.
+    ///         \a hpx#error#invalid_status.
     ///
     inline threads::thread_restart_state suspend(
         threads::thread_schedule_state state =
@@ -484,8 +490,8 @@ namespace hpx { namespace this_thread {
     }
 
     /// The function \a suspend will return control to the thread manager
-    /// (suspends the current thread). It sets the new state of this thread
-    /// to \a suspended and schedules a wakeup for this threads at the given
+    /// (suspends the current thread). It sets the new state of this thread to
+    /// \a suspended and schedules a wakeup for this threads at the given
     /// time.
     ///
     /// \note Must be called from within a HPX-thread.
@@ -493,12 +499,14 @@ namespace hpx { namespace this_thread {
     /// \throws If <code>&ec != &throws</code>, never throws, but will set \a ec
     ///         to an appropriate value when an error occurs. Otherwise, this
     ///         function will throw an \a hpx#exception with an error code of
-    ///         \a hpx#yield_aborted if it is signaled with \a wait_aborted.
-    ///         If called outside of a HPX-thread, this function will throw
-    ///         an \a hpx#exception with an error code of \a hpx::null_thread_id.
+    ///         \a hpx#error#yield_aborted if it is signaled with \a
+    ///            wait_aborted.
+    ///         If called outside of a HPX-thread, this function will throw an
+    ///         \a hpx#exception with an error code of \a
+    ///            hpx#error#null_thread_id.
     ///         If this function is called while the thread-manager is not
     ///         running, it will throw an \a hpx#exception with an error code of
-    ///         \a hpx#invalid_status.
+    ///         \a hpx#error#invalid_status.
     ///
     HPX_CORE_EXPORT threads::thread_restart_state suspend(
         hpx::chrono::steady_time_point const& abs_time,
@@ -508,8 +516,8 @@ namespace hpx { namespace this_thread {
         error_code& ec = throws);
 
     /// The function \a suspend will return control to the thread manager
-    /// (suspends the current thread). It sets the new state of this thread
-    /// to \a suspended and schedules a wakeup for this threads at the given
+    /// (suspends the current thread). It sets the new state of this thread to
+    /// \a suspended and schedules a wakeup for this threads at the given
     /// time.
     ///
     /// \note Must be called from within a HPX-thread.
@@ -517,12 +525,14 @@ namespace hpx { namespace this_thread {
     /// \throws If <code>&ec != &throws</code>, never throws, but will set \a ec
     ///         to an appropriate value when an error occurs. Otherwise, this
     ///         function will throw an \a hpx#exception with an error code of
-    ///         \a hpx#yield_aborted if it is signaled with \a wait_aborted.
-    ///         If called outside of a HPX-thread, this function will throw
-    ///         an \a hpx#exception with an error code of \a hpx::null_thread_id.
+    ///         \a hpx#error#yield_aborted if it is signaled with \a
+    ///            wait_aborted.
+    ///         If called outside of a HPX-thread, this function will throw an
+    ///         \a hpx#exception with an error code of \a
+    ///            hpx#error#null_thread_id.
     ///         If this function is called while the thread-manager is not
     ///         running, it will throw an \a hpx#exception with an error code of
-    ///         \a hpx#invalid_status.
+    ///         \a hpx#error#invalid_status.
     ///
     inline threads::thread_restart_state suspend(
         hpx::chrono::steady_time_point const& abs_time,
@@ -534,8 +544,8 @@ namespace hpx { namespace this_thread {
     }
 
     /// The function \a suspend will return control to the thread manager
-    /// (suspends the current thread). It sets the new state of this thread
-    /// to \a suspended and schedules a wakeup for this threads after the given
+    /// (suspends the current thread). It sets the new state of this thread to
+    /// \a suspended and schedules a wakeup for this threads after the given
     /// duration.
     ///
     /// \note Must be called from within a HPX-thread.
@@ -543,12 +553,14 @@ namespace hpx { namespace this_thread {
     /// \throws If <code>&ec != &throws</code>, never throws, but will set \a ec
     ///         to an appropriate value when an error occurs. Otherwise, this
     ///         function will throw an \a hpx#exception with an error code of
-    ///         \a hpx#yield_aborted if it is signaled with \a wait_aborted.
-    ///         If called outside of a HPX-thread, this function will throw
-    ///         an \a hpx#exception with an error code of \a hpx::null_thread_id.
+    ///         \a hpx#error#yield_aborted if it is signaled with \a
+    ///            wait_aborted.
+    ///         If called outside of a HPX-thread, this function will throw an
+    ///         \a hpx#exception with an error code of \a
+    ///            hpx#error#null_thread_id.
     ///         If this function is called while the thread-manager is not
     ///         running, it will throw an \a hpx#exception with an error code of
-    ///         \a hpx#invalid_status.
+    ///         \a hpx#error#invalid_status.
     ///
     inline threads::thread_restart_state suspend(
         hpx::chrono::steady_duration const& rel_time,
@@ -561,8 +573,8 @@ namespace hpx { namespace this_thread {
     }
 
     /// The function \a suspend will return control to the thread manager
-    /// (suspends the current thread). It sets the new state of this thread
-    /// to \a suspended and schedules a wakeup for this threads after the given
+    /// (suspends the current thread). It sets the new state of this thread to
+    /// \a suspended and schedules a wakeup for this threads after the given
     /// duration.
     ///
     /// \note Must be called from within a HPX-thread.
@@ -570,12 +582,14 @@ namespace hpx { namespace this_thread {
     /// \throws If <code>&ec != &throws</code>, never throws, but will set \a ec
     ///         to an appropriate value when an error occurs. Otherwise, this
     ///         function will throw an \a hpx#exception with an error code of
-    ///         \a hpx#yield_aborted if it is signaled with \a wait_aborted.
-    ///         If called outside of a HPX-thread, this function will throw
-    ///         an \a hpx#exception with an error code of \a hpx::null_thread_id.
+    ///         \a hpx#error#yield_aborted if it is signaled with \a
+    ///            wait_aborted.
+    ///         If called outside of a HPX-thread, this function will throw an
+    ///         \a hpx#exception with an error code of \a
+    ///            hpx#error#null_thread_id.
     ///         If this function is called while the thread-manager is not
     ///         running, it will throw an \a hpx#exception with an error code of
-    ///         \a hpx#invalid_status.
+    ///         \a hpx#error#invalid_status.
     ///
     inline threads::thread_restart_state suspend(
         hpx::chrono::steady_duration const& rel_time,
@@ -588,8 +602,8 @@ namespace hpx { namespace this_thread {
     }
 
     /// The function \a suspend will return control to the thread manager
-    /// (suspends the current thread). It sets the new state of this thread
-    /// to \a suspended and schedules a wakeup for this threads after the given
+    /// (suspends the current thread). It sets the new state of this thread to
+    /// \a suspended and schedules a wakeup for this threads after the given
     /// time (specified in milliseconds).
     ///
     /// \note Must be called from within a HPX-thread.
@@ -597,12 +611,14 @@ namespace hpx { namespace this_thread {
     /// \throws If <code>&ec != &throws</code>, never throws, but will set \a ec
     ///         to an appropriate value when an error occurs. Otherwise, this
     ///         function will throw an \a hpx#exception with an error code of
-    ///         \a hpx#yield_aborted if it is signaled with \a wait_aborted.
-    ///         If called outside of a HPX-thread, this function will throw
-    ///         an \a hpx#exception with an error code of \a hpx::null_thread_id.
+    ///         \a hpx#error#yield_aborted if it is signaled with \a
+    ///            wait_aborted.
+    ///         If called outside of a HPX-thread, this function will throw an
+    ///         \a hpx#exception with an error code of \a
+    ///            hpx#error#null_thread_id.
     ///         If this function is called while the thread-manager is not
     ///         running, it will throw an \a hpx#exception with an error code of
-    ///         \a hpx#invalid_status.
+    ///         \a hpx#error#invalid_status.
     ///
     inline threads::thread_restart_state suspend(std::uint64_t ms,
         util::thread_description const& description = util::thread_description(
@@ -618,12 +634,14 @@ namespace hpx { namespace this_thread {
     /// \throws If <code>&ec != &throws</code>, never throws, but will set \a ec
     ///         to an appropriate value when an error occurs. Otherwise, this
     ///         function will throw an \a hpx#exception with an error code of
-    ///         \a hpx#yield_aborted if it is signaled with \a wait_aborted.
-    ///         If called outside of a HPX-thread, this function will throw
-    ///         an \a hpx#exception with an error code of \a hpx::null_thread_id.
+    ///         \a hpx#error#yield_aborted if it is signaled with \a
+    ///            wait_aborted.
+    ///         If called outside of a HPX-thread, this function will throw an
+    ///         \a hpx#exception with an error code of \a
+    ///            hpx#error#null_thread_id.
     ///         If this function is called while the thread-manager is not
     ///         running, it will throw an \a hpx#exception with an error code of
-    ///         \a hpx#invalid_status.
+    ///         \a hpx#error#invalid_status.
     HPX_CORE_EXPORT threads::thread_pool_base* get_pool(
         error_code& ec = throws);
 

--- a/libs/core/threading_base/include/hpx/threading_base/thread_init_data.hpp
+++ b/libs/core/threading_base/include/hpx/threading_base/thread_init_data.hpp
@@ -48,7 +48,7 @@ namespace hpx { namespace threads {
         {
             if (initial_state == thread_schedule_state::staged)
             {
-                HPX_THROW_EXCEPTION(bad_parameter,
+                HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
                     "thread_init_data::thread_init_data",
                     "threads shouldn't have 'staged' as their initial state");
             }
@@ -139,7 +139,7 @@ namespace hpx { namespace threads {
 
             if (initial_state == thread_schedule_state::staged)
             {
-                HPX_THROW_EXCEPTION(bad_parameter,
+                HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
                     "thread_init_data::thread_init_data",
                     "threads shouldn't have 'staged' as their initial state");
             }

--- a/libs/core/threading_base/src/create_thread.cpp
+++ b/libs/core/threading_base/src/create_thread.cpp
@@ -36,8 +36,9 @@ namespace hpx { namespace threads { namespace detail {
 
         default:
         {
-            HPX_THROWS_IF(ec, bad_parameter, "threads::detail::create_thread",
-                "invalid initial state: {}", data.initial_state);
+            HPX_THROWS_IF(ec, hpx::error::bad_parameter,
+                "threads::detail::create_thread", "invalid initial state: {}",
+                data.initial_state);
             return;
         }
         }
@@ -45,8 +46,8 @@ namespace hpx { namespace threads { namespace detail {
 #ifdef HPX_HAVE_THREAD_DESCRIPTION
         if (!data.description)
         {
-            HPX_THROWS_IF(ec, bad_parameter, "threads::detail::create_thread",
-                "description is nullptr");
+            HPX_THROWS_IF(ec, hpx::error::bad_parameter,
+                "threads::detail::create_thread", "description is nullptr");
             return;
         }
 #endif

--- a/libs/core/threading_base/src/create_work.cpp
+++ b/libs/core/threading_base/src/create_work.cpp
@@ -29,8 +29,9 @@ namespace hpx { namespace threads { namespace detail {
 
         default:
         {
-            HPX_THROWS_IF(ec, bad_parameter, "thread::detail::create_work",
-                "invalid initial state: {}", data.initial_state);
+            HPX_THROWS_IF(ec, hpx::error::bad_parameter,
+                "thread::detail::create_work", "invalid initial state: {}",
+                data.initial_state);
             return invalid_thread_id;
         }
         }
@@ -38,8 +39,8 @@ namespace hpx { namespace threads { namespace detail {
 #ifdef HPX_HAVE_THREAD_DESCRIPTION
         if (!data.description)
         {
-            HPX_THROWS_IF(ec, bad_parameter, "thread::detail::create_work",
-                "description is nullptr");
+            HPX_THROWS_IF(ec, hpx::error::bad_parameter,
+                "thread::detail::create_work", "description is nullptr");
             return invalid_thread_id;
         }
 #endif

--- a/libs/core/threading_base/src/execution_agent.cpp
+++ b/libs/core/threading_base/src/execution_agent.cpp
@@ -44,7 +44,8 @@ namespace hpx { namespace threads {
         thread_id_type id = self_.get_thread_id();
         if (HPX_UNLIKELY(!id))
         {
-            HPX_THROW_EXCEPTION(null_thread_id, "execution_agent::description",
+            HPX_THROW_EXCEPTION(hpx::error::null_thread_id,
+                "execution_agent::description",
                 "null thread id encountered (is this executed on a "
                 "HPX-thread?)");
         }
@@ -151,7 +152,8 @@ namespace hpx { namespace threads {
         thread_id_ref_type id = self_.get_thread_id();    // keep alive
         if (HPX_UNLIKELY(!id))
         {
-            HPX_THROW_EXCEPTION(null_thread_id, "execution_agent::do_yield",
+            HPX_THROW_EXCEPTION(hpx::error::null_thread_id,
+                "execution_agent::do_yield",
                 "null thread id encountered (is this executed on a "
                 "HPX-thread?)");
         }
@@ -193,7 +195,7 @@ namespace hpx { namespace threads {
         // handle interrupt and abort
         if (statex == threads::thread_restart_state::abort)
         {
-            HPX_THROW_EXCEPTION(yield_aborted, desc,
+            HPX_THROW_EXCEPTION(hpx::error::yield_aborted, desc,
                 "thread({}) aborted (yield returned wait_abort)",
                 description());
         }

--- a/libs/core/threading_base/src/get_default_pool.cpp
+++ b/libs/core/threading_base/src/get_default_pool.cpp
@@ -59,7 +59,7 @@ namespace hpx { namespace threads { namespace detail {
                     // hpx_main.hpp is included but not linked to libhpx_wrap
                     if (!hpx_start::is_linked && hpx_start::include_libhpx_wrap)
                     {
-                        HPX_THROW_EXCEPTION(invalid_status,
+                        HPX_THROW_EXCEPTION(hpx::error::invalid_status,
                             "hpx::threads::detail::get_self_or_default_pool",
                             "Attempting to use hpx_main.hpp functionality "
                             "without linking to libhpx_wrap. If you're using "
@@ -71,7 +71,7 @@ namespace hpx { namespace threads { namespace detail {
                             "for library link order and other subtle nuances.");
                     }
 #endif
-                    HPX_THROW_EXCEPTION(invalid_status,
+                    HPX_THROW_EXCEPTION(hpx::error::invalid_status,
                         "hpx::threads::detail::get_self_or_default_pool",
                         "Attempting to register a thread outside the HPX "
                         "runtime and no default pool handler is installed. "

--- a/libs/core/threading_base/src/get_default_timer_service.cpp
+++ b/libs/core/threading_base/src/get_default_timer_service.cpp
@@ -32,14 +32,14 @@ namespace hpx { namespace threads { namespace detail {
         else
         {
 #if defined(HPX_HAVE_TIMER_POOL)
-            HPX_THROW_EXCEPTION(invalid_status,
+            HPX_THROW_EXCEPTION(hpx::error::invalid_status,
                 "hpx::threads::detail::get_default_timer_service",
                 "No timer service installed. When running timed "
                 "threads without a runtime a timer service has to be "
                 "installed manually using "
                 "hpx::threads::detail::set_get_default_timer_service.");
 #else
-            HPX_THROW_EXCEPTION(invalid_status,
+            HPX_THROW_EXCEPTION(hpx::error::invalid_status,
                 "hpx::threads::detail::get_default_timer_service",
                 "No timer service installed. Rebuild HPX with "
                 "HPX_WITH_TIMER_POOL=ON or provide a timer service "

--- a/libs/core/threading_base/src/set_thread_state.cpp
+++ b/libs/core/threading_base/src/set_thread_state.cpp
@@ -31,7 +31,7 @@ namespace hpx { namespace threads { namespace detail {
     {
         if (HPX_UNLIKELY(!thrd))
         {
-            HPX_THROW_EXCEPTION(null_thread_id,
+            HPX_THROW_EXCEPTION(hpx::error::null_thread_id,
                 "threads::detail::set_active_state",
                 "null thread id encountered");
             return thread_result_type(
@@ -74,7 +74,7 @@ namespace hpx { namespace threads { namespace detail {
     {
         if (HPX_UNLIKELY(!thrd))
         {
-            HPX_THROWS_IF(ec, null_thread_id,
+            HPX_THROWS_IF(ec, hpx::error::null_thread_id,
                 "threads::detail::set_thread_state",
                 "null thread id encountered");
             return thread_state(
@@ -84,7 +84,7 @@ namespace hpx { namespace threads { namespace detail {
         // set_state can't be used to force a thread into active state
         if (new_state == thread_schedule_state::active)
         {
-            HPX_THROWS_IF(ec, bad_parameter,
+            HPX_THROWS_IF(ec, hpx::error::bad_parameter,
                 "threads::detail::set_thread_state", "invalid new state: {}",
                 new_state);
             return thread_state(
@@ -201,7 +201,7 @@ namespace hpx { namespace threads { namespace detail {
                     // NOLINTNEXTLINE(bugprone-branch-clone)
                     LTM_(fatal) << str;
 
-                    HPX_THROWS_IF(ec, bad_parameter,
+                    HPX_THROWS_IF(ec, hpx::error::bad_parameter,
                         "threads::detail::set_thread_state", str);
                     return thread_state(thread_schedule_state::unknown,
                         thread_restart_state::unknown);

--- a/libs/core/threading_base/src/set_thread_state_timed.cpp
+++ b/libs/core/threading_base/src/set_thread_state_timed.cpp
@@ -40,7 +40,7 @@ namespace hpx { namespace threads { namespace detail {
     {
         if (HPX_UNLIKELY(!thrd))
         {
-            HPX_THROW_EXCEPTION(null_thread_id,
+            HPX_THROW_EXCEPTION(hpx::error::null_thread_id,
                 "threads::detail::wake_timer_thread",
                 "null thread id encountered (id)");
             return thread_result_type(
@@ -49,7 +49,7 @@ namespace hpx { namespace threads { namespace detail {
 
         if (HPX_UNLIKELY(!timer_id))
         {
-            HPX_THROW_EXCEPTION(null_thread_id,
+            HPX_THROW_EXCEPTION(hpx::error::null_thread_id,
                 "threads::detail::wake_timer_thread",
                 "null thread id encountered (timer_id)");
             return thread_result_type(
@@ -81,8 +81,8 @@ namespace hpx { namespace threads { namespace detail {
     {
         if (HPX_UNLIKELY(!thrd))
         {
-            HPX_THROW_EXCEPTION(null_thread_id, "threads::detail::at_timer",
-                "null thread id encountered");
+            HPX_THROW_EXCEPTION(hpx::error::null_thread_id,
+                "threads::detail::at_timer", "null thread id encountered");
             return thread_result_type(
                 thread_schedule_state::terminated, invalid_thread_id);
         }
@@ -173,7 +173,7 @@ namespace hpx { namespace threads { namespace detail {
     {
         if (HPX_UNLIKELY(!thrd))
         {
-            HPX_THROWS_IF(ec, null_thread_id,
+            HPX_THROWS_IF(ec, hpx::error::null_thread_id,
                 "threads::detail::set_thread_state",
                 "null thread id encountered");
             return invalid_thread_id;

--- a/libs/core/threading_base/src/thread_data.cpp
+++ b/libs/core/threading_base/src/thread_data.cpp
@@ -259,7 +259,7 @@ namespace hpx { namespace threads {
         thread_self* p = get_self_ptr();
         if (HPX_UNLIKELY(p == nullptr))
         {
-            HPX_THROW_EXCEPTION(null_thread_id, "threads::get_self",
+            HPX_THROW_EXCEPTION(hpx::error::null_thread_id, "threads::get_self",
                 "null thread id encountered (is this executed on a "
                 "HPX-thread?)");
         }
@@ -290,7 +290,8 @@ namespace hpx { namespace threads {
 
         if (HPX_UNLIKELY(p == nullptr))
         {
-            HPX_THROWS_IF(ec, null_thread_id, "threads::get_self_ptr_checked",
+            HPX_THROWS_IF(ec, hpx::error::null_thread_id,
+                "threads::get_self_ptr_checked",
                 "null thread id encountered (is this executed on a "
                 "HPX-thread?)");
             return nullptr;

--- a/libs/core/threading_base/src/thread_description.cpp
+++ b/libs/core/threading_base/src/thread_description.cpp
@@ -101,7 +101,7 @@ namespace hpx { namespace threads {
     {
         if (HPX_UNLIKELY(!id))
         {
-            HPX_THROWS_IF(ec, null_thread_id,
+            HPX_THROWS_IF(ec, hpx::error::null_thread_id,
                 "hpx::threads::set_thread_description",
                 "null thread id encountered");
             return util::thread_description();
@@ -118,7 +118,7 @@ namespace hpx { namespace threads {
     {
         if (HPX_UNLIKELY(!id))
         {
-            HPX_THROWS_IF(ec, null_thread_id,
+            HPX_THROWS_IF(ec, hpx::error::null_thread_id,
                 "hpx::threads::get_thread_lco_description",
                 "null thread id encountered");
             return nullptr;
@@ -136,7 +136,7 @@ namespace hpx { namespace threads {
     {
         if (HPX_UNLIKELY(!id))
         {
-            HPX_THROWS_IF(ec, null_thread_id,
+            HPX_THROWS_IF(ec, hpx::error::null_thread_id,
                 "hpx::threads::set_thread_lco_description",
                 "null thread id encountered");
             return nullptr;

--- a/libs/core/threading_base/src/thread_helpers.cpp
+++ b/libs/core/threading_base/src/thread_helpers.cpp
@@ -99,8 +99,8 @@ namespace hpx { namespace threads {
     {
         if (HPX_UNLIKELY(!id))
         {
-            HPX_THROWS_IF(ec, null_thread_id, "hpx::threads::interrupt_thread",
-                "null thread id encountered");
+            HPX_THROWS_IF(ec, hpx::error::null_thread_id,
+                "hpx::threads::interrupt_thread", "null thread id encountered");
             return;
         }
 
@@ -119,7 +119,7 @@ namespace hpx { namespace threads {
     {
         if (HPX_UNLIKELY(!id))
         {
-            HPX_THROWS_IF(ec, null_thread_id,
+            HPX_THROWS_IF(ec, hpx::error::null_thread_id,
                 "hpx::threads::interruption_point",
                 "null thread id encountered");
             return;
@@ -137,7 +137,7 @@ namespace hpx { namespace threads {
     {
         if (HPX_UNLIKELY(!id))
         {
-            HPX_THROW_EXCEPTION(null_thread_id,
+            HPX_THROW_EXCEPTION(hpx::error::null_thread_id,
                 "hpx::threads::get_thread_interruption_enabled",
                 "null thread id encountered");
             return false;
@@ -154,7 +154,7 @@ namespace hpx { namespace threads {
     {
         if (HPX_UNLIKELY(!id))
         {
-            HPX_THROW_EXCEPTION(null_thread_id,
+            HPX_THROW_EXCEPTION(hpx::error::null_thread_id,
                 "hpx::threads::get_thread_interruption_enabled",
                 "null thread id encountered");
             return false;
@@ -171,7 +171,7 @@ namespace hpx { namespace threads {
     {
         if (HPX_UNLIKELY(!id))
         {
-            HPX_THROWS_IF(ec, null_thread_id,
+            HPX_THROWS_IF(ec, hpx::error::null_thread_id,
                 "hpx::threads::get_thread_interruption_requested",
                 "null thread id encountered");
             return false;
@@ -188,8 +188,8 @@ namespace hpx { namespace threads {
     {
         if (HPX_UNLIKELY(!id))
         {
-            HPX_THROWS_IF(ec, null_thread_id, "hpx::threads::get_thread_data",
-                "null thread id encountered");
+            HPX_THROWS_IF(ec, hpx::error::null_thread_id,
+                "hpx::threads::get_thread_data", "null thread id encountered");
             return 0;
         }
 
@@ -201,8 +201,8 @@ namespace hpx { namespace threads {
     {
         if (HPX_UNLIKELY(!id))
         {
-            HPX_THROWS_IF(ec, null_thread_id, "hpx::threads::set_thread_data",
-                "null thread id encountered");
+            HPX_THROWS_IF(ec, hpx::error::null_thread_id,
+                "hpx::threads::set_thread_data", "null thread id encountered");
             return 0;
         }
 
@@ -214,8 +214,8 @@ namespace hpx { namespace threads {
     {
         if (HPX_UNLIKELY(!id))
         {
-            HPX_THROWS_IF(ec, null_thread_id, "hpx::threads::get_libcds_data",
-                "null thread id encountered");
+            HPX_THROWS_IF(ec, hpx::error::null_thread_id,
+                "hpx::threads::get_libcds_data", "null thread id encountered");
             return 0;
         }
 
@@ -227,8 +227,8 @@ namespace hpx { namespace threads {
     {
         if (HPX_UNLIKELY(!id))
         {
-            HPX_THROWS_IF(ec, null_thread_id, "hpx::threads::set_libcds_data",
-                "null thread id encountered");
+            HPX_THROWS_IF(ec, hpx::error::null_thread_id,
+                "hpx::threads::set_libcds_data", "null thread id encountered");
             return 0;
         }
 
@@ -240,7 +240,7 @@ namespace hpx { namespace threads {
     {
         if (HPX_UNLIKELY(!id))
         {
-            HPX_THROWS_IF(ec, null_thread_id,
+            HPX_THROWS_IF(ec, hpx::error::null_thread_id,
                 "hpx::threads::get_libcds_hazard_pointer_data",
                 "null thread id encountered");
             return 0;
@@ -254,7 +254,7 @@ namespace hpx { namespace threads {
     {
         if (HPX_UNLIKELY(!id))
         {
-            HPX_THROWS_IF(ec, null_thread_id,
+            HPX_THROWS_IF(ec, hpx::error::null_thread_id,
                 "hpx::threads::set_libcds_hazard_pointer_data",
                 "null thread id encountered");
             return 0;
@@ -268,7 +268,7 @@ namespace hpx { namespace threads {
     {
         if (HPX_UNLIKELY(!id))
         {
-            HPX_THROWS_IF(ec, null_thread_id,
+            HPX_THROWS_IF(ec, hpx::error::null_thread_id,
                 "hpx::threads::get_libcds_dynamic_hazard_pointer_data",
                 "null thread id encountered");
             return 0;
@@ -282,7 +282,7 @@ namespace hpx { namespace threads {
     {
         if (HPX_UNLIKELY(!id))
         {
-            HPX_THROWS_IF(ec, null_thread_id,
+            HPX_THROWS_IF(ec, hpx::error::null_thread_id,
                 "hpx::threads::set_libcds_dynamic_hazard_pointer_data",
                 "null thread id encountered");
             return 0;
@@ -317,7 +317,7 @@ namespace hpx { namespace threads {
     {
         if (HPX_UNLIKELY(!id))
         {
-            HPX_THROWS_IF(ec, null_thread_id,
+            HPX_THROWS_IF(ec, hpx::error::null_thread_id,
                 "hpx::threads::run_thread_exit_callbacks",
                 "null thread id encountered");
             return;
@@ -334,7 +334,7 @@ namespace hpx { namespace threads {
     {
         if (HPX_UNLIKELY(!id))
         {
-            HPX_THROWS_IF(ec, null_thread_id,
+            HPX_THROWS_IF(ec, hpx::error::null_thread_id,
                 "hpx::threads::add_thread_exit_callback",
                 "null thread id encountered");
             return false;
@@ -350,7 +350,7 @@ namespace hpx { namespace threads {
     {
         if (HPX_UNLIKELY(!id))
         {
-            HPX_THROWS_IF(ec, null_thread_id,
+            HPX_THROWS_IF(ec, hpx::error::null_thread_id,
                 "hpx::threads::add_thread_exit_callback",
                 "null thread id encountered");
             return;
@@ -372,7 +372,7 @@ namespace hpx { namespace threads {
     {
         if (HPX_UNLIKELY(!id))
         {
-            HPX_THROWS_IF(ec, null_thread_id,
+            HPX_THROWS_IF(ec, hpx::error::null_thread_id,
                 "hpx::threads::get_thread_backtrace",
                 "null thread id encountered");
             return nullptr;
@@ -394,7 +394,7 @@ namespace hpx { namespace threads {
     {
         if (HPX_UNLIKELY(!id))
         {
-            HPX_THROWS_IF(ec, null_thread_id,
+            HPX_THROWS_IF(ec, hpx::error::null_thread_id,
                 "hpx::threads::set_thread_backtrace",
                 "null thread id encountered");
             return nullptr;
@@ -411,8 +411,8 @@ namespace hpx { namespace threads {
     {
         if (HPX_UNLIKELY(!id))
         {
-            HPX_THROWS_IF(ec, null_thread_id, "hpx::threads::get_pool",
-                "null thread id encountered");
+            HPX_THROWS_IF(ec, hpx::error::null_thread_id,
+                "hpx::threads::get_pool", "null thread id encountered");
             return nullptr;
         }
 
@@ -491,7 +491,7 @@ namespace hpx { namespace this_thread {
         // handle interrupt and abort
         if (statex == threads::thread_restart_state::abort)
         {
-            HPX_THROWS_IF(ec, yield_aborted, "suspend",
+            HPX_THROWS_IF(ec, hpx::error::yield_aborted, "suspend",
                 "thread({}, {}) aborted (yield returned wait_abort)",
                 id.noref(), threads::get_thread_description(id.noref()));
         }
@@ -589,7 +589,7 @@ namespace hpx { namespace this_thread {
         // handle interrupt and abort
         if (statex == threads::thread_restart_state::abort)
         {
-            HPX_THROWS_IF(ec, yield_aborted, "suspend_at",
+            HPX_THROWS_IF(ec, hpx::error::yield_aborted, "suspend_at",
                 "thread({}, {}) aborted (yield returned wait_abort)",
                 id.noref(), threads::get_thread_description(id.noref()));
         }
@@ -626,8 +626,8 @@ namespace hpx { namespace this_thread {
         std::ptrdiff_t remaining_stack = get_available_stack_space();
         if (remaining_stack < 0)
         {
-            HPX_THROW_EXCEPTION(
-                out_of_memory, "has_sufficient_stack_space", "Stack overflow");
+            HPX_THROW_EXCEPTION(hpx::error::out_of_memory,
+                "has_sufficient_stack_space", "Stack overflow");
         }
         bool sufficient_stack_space =
             std::size_t(remaining_stack) >= space_needed;

--- a/libs/core/threadmanager/src/threadmanager.cpp
+++ b/libs/core/threadmanager/src/threadmanager.cpp
@@ -589,7 +589,8 @@ namespace hpx { namespace threads {
         }
 
         //! FIXME Add names of available pools?
-        HPX_THROW_EXCEPTION(bad_parameter, "threadmanager::get_pool",
+        HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
+            "threadmanager::get_pool",
             "the resource partitioner does not own a thread pool named '{}'.\n",
             pool_name);
     }

--- a/libs/core/topology/src/topology.cpp
+++ b/libs/core/topology/src/topology.cpp
@@ -176,7 +176,8 @@ namespace hpx { namespace threads {
         tid = syscall(SYS_gettid);
         if (setpriority(PRIO_PROCESS, tid, 19))
         {
-            HPX_THROWS_IF(ec, no_success, "topology::reduce_thread_priority",
+            HPX_THROWS_IF(ec, hpx::error::no_success,
+                "topology::reduce_thread_priority",
                 "setpriority returned an error");
             return false;
         }
@@ -184,7 +185,8 @@ namespace hpx { namespace threads {
 
         if (!SetThreadPriority(GetCurrentThread(), THREAD_PRIORITY_LOWEST))
         {
-            HPX_THROWS_IF(ec, no_success, "topology::reduce_thread_priority",
+            HPX_THROWS_IF(ec, hpx::error::no_success,
+                "topology::reduce_thread_priority",
                 "SetThreadPriority returned an error");
             return false;
         }
@@ -210,7 +212,7 @@ namespace hpx { namespace threads {
         int err = hwloc_topology_init(&topo);
         if (err != 0)
         {
-            HPX_THROW_EXCEPTION(no_success, "topology::topology",
+            HPX_THROW_EXCEPTION(hpx::error::no_success, "topology::topology",
                 "Failed to init hwloc topology");
         }
 
@@ -223,7 +225,7 @@ namespace hpx { namespace threads {
             topo, HWLOC_OBJ_CORE, HWLOC_TYPE_FILTER_KEEP_NONE);
         if (err != 0)
         {
-            HPX_THROW_EXCEPTION(no_success, "topology::topology",
+            HPX_THROW_EXCEPTION(hpx::error::no_success, "topology::topology",
                 "Failed to set core filter for hwloc topology");
         }
 #endif
@@ -232,7 +234,7 @@ namespace hpx { namespace threads {
         err = hwloc_topology_load(topo);
         if (err != 0)
         {
-            HPX_THROW_EXCEPTION(no_success, "topology::topology",
+            HPX_THROW_EXCEPTION(hpx::error::no_success, "topology::topology",
                 "Failed to load hwloc topology");
         }
 
@@ -366,7 +368,7 @@ namespace hpx { namespace threads {
             num_cores = hwloc_get_nbobjs_by_type(topo, HWLOC_OBJ_PU);
             if (num_cores <= 0)
             {
-                HPX_THROWS_IF(ec, no_success,
+                HPX_THROWS_IF(ec, hpx::error::no_success,
                     "topology::hwloc_get_nobjs_by_type",
                     "Failed to get number of cores");
                 return std::size_t(-1);
@@ -413,7 +415,7 @@ namespace hpx { namespace threads {
             return socket_affinity_masks_[num_pu];
         }
 
-        HPX_THROWS_IF(ec, bad_parameter,
+        HPX_THROWS_IF(ec, hpx::error::bad_parameter,
             "hpx::threads::topology::get_socket_affinity_mask",
             "thread number {1} is out of range", num_thread);
         return empty_mask;
@@ -432,7 +434,7 @@ namespace hpx { namespace threads {
             return numa_node_affinity_masks_[num_pu];
         }
 
-        HPX_THROWS_IF(ec, bad_parameter,
+        HPX_THROWS_IF(ec, hpx::error::bad_parameter,
             "hpx::threads::topology::get_numa_node_affinity_mask",
             "thread number {1} is out of range", num_thread);
         return empty_mask;
@@ -451,7 +453,7 @@ namespace hpx { namespace threads {
             return core_affinity_masks_[num_pu];
         }
 
-        HPX_THROWS_IF(ec, bad_parameter,
+        HPX_THROWS_IF(ec, hpx::error::bad_parameter,
             "hpx::threads::topology::get_core_affinity_mask",
             "thread number {1} is out of range", num_thread);
         return empty_mask;
@@ -470,7 +472,7 @@ namespace hpx { namespace threads {
             return thread_affinity_masks_[num_pu];
         }
 
-        HPX_THROWS_IF(ec, bad_parameter,
+        HPX_THROWS_IF(ec, hpx::error::bad_parameter,
             "hpx::threads::topology::get_thread_affinity_mask",
             "thread number {1} is out of range", num_thread);
         return empty_mask;
@@ -512,7 +514,7 @@ namespace hpx { namespace threads {
                     hwloc_bitmap_snprintf(buffer.get(), 1024, cpuset);
                     hwloc_bitmap_free(cpuset);
 
-                    HPX_THROWS_IF(ec, kernel_error,
+                    HPX_THROWS_IF(ec, hpx::error::kernel_error,
                         "hpx::threads::topology::set_thread_affinity_mask",
                         "failed to set thread affinity mask ({}) for cpuset {}",
                         hpx::threads::to_string(mask), buffer.get());
@@ -584,7 +586,7 @@ namespace hpx { namespace threads {
                 std::string errstr = std::strerror(errno);
 
                 lk.unlock();
-                HPX_THROW_EXCEPTION(no_success,
+                HPX_THROW_EXCEPTION(hpx::error::no_success,
                     "topology::get_thread_affinity_mask_from_lva",
                     "failed calling 'hwloc_get_area_membind_nodeset', "
                     "reported error: {}",
@@ -732,7 +734,7 @@ namespace hpx { namespace threads {
         int nobjs = hwloc_get_nbobjs_by_type(topo, HWLOC_OBJ_SOCKET);
         if (0 > nobjs)
         {
-            HPX_THROW_EXCEPTION(kernel_error,
+            HPX_THROW_EXCEPTION(hpx::error::kernel_error,
                 "hpx::threads::topology::get_number_of_sockets",
                 "hwloc_get_nbobjs_by_type failed");
             return std::size_t(nobjs);
@@ -745,7 +747,7 @@ namespace hpx { namespace threads {
         int nobjs = hwloc_get_nbobjs_by_type(topo, HWLOC_OBJ_NUMANODE);
         if (0 > nobjs)
         {
-            HPX_THROW_EXCEPTION(kernel_error,
+            HPX_THROW_EXCEPTION(hpx::error::kernel_error,
                 "hpx::threads::topology::get_number_of_numa_nodes",
                 "hwloc_get_nbobjs_by_type failed");
             return std::size_t(nobjs);
@@ -760,7 +762,7 @@ namespace hpx { namespace threads {
         // If num_cores is smaller 0, we have an error
         if (0 > nobjs)
         {
-            HPX_THROW_EXCEPTION(kernel_error,
+            HPX_THROW_EXCEPTION(hpx::error::kernel_error,
                 "hpx::threads::topology::get_number_of_cores",
                 "hwloc_get_nbobjs_by_type(HWLOC_OBJ_CORE) failed");
             return std::size_t(nobjs);
@@ -772,7 +774,7 @@ namespace hpx { namespace threads {
             nobjs = hwloc_get_nbobjs_by_type(topo, HWLOC_OBJ_PU);
             if (0 > nobjs)
             {
-                HPX_THROW_EXCEPTION(kernel_error,
+                HPX_THROW_EXCEPTION(hpx::error::kernel_error,
                     "hpx::threads::topology::get_number_of_cores",
                     "hwloc_get_nbobjs_by_type(HWLOC_OBJ_PU) failed");
                 return std::size_t(nobjs);
@@ -783,7 +785,7 @@ namespace hpx { namespace threads {
         // avoid division by zero, we should always have at least one core
         if (0 == nobjs)
         {
-            HPX_THROW_EXCEPTION(kernel_error,
+            HPX_THROW_EXCEPTION(hpx::error::kernel_error,
                 "hpx::threads::topology::get_number_of_cores",
                 "hwloc_get_nbobjs_by_type reports zero cores/pus");
             return std::size_t(nobjs);
@@ -965,7 +967,7 @@ namespace hpx { namespace threads {
                 hwloc_get_obj_by_type(topo, HWLOC_OBJ_PU, unsigned(i));
             if (!obj)
             {
-                HPX_THROW_EXCEPTION(kernel_error,
+                HPX_THROW_EXCEPTION(hpx::error::kernel_error,
                     "hpx::threads::topology::print_affinity_mask",
                     "object not found");
                 return;
@@ -1014,7 +1016,7 @@ namespace hpx { namespace threads {
             return machine_affinity_mask;
         }
 
-        HPX_THROW_EXCEPTION(kernel_error,
+        HPX_THROW_EXCEPTION(hpx::error::kernel_error,
             "hpx::threads::topology::init_machine_affinity_mask",
             "failed to initialize machine affinity mask");
         return empty_mask;
@@ -1159,7 +1161,7 @@ namespace hpx { namespace threads {
             // core
             if (num_cores <= 0)
             {
-                HPX_THROW_EXCEPTION(kernel_error,
+                HPX_THROW_EXCEPTION(hpx::error::kernel_error,
                     "hpx::threads::topology::init_thread_affinity_mask",
                     "hwloc_get_nbobjs_by_type failed");
                 return empty_mask;
@@ -1235,7 +1237,7 @@ namespace hpx { namespace threads {
             if (hwloc_get_cpubind(topo, cpuset, HWLOC_CPUBIND_THREAD))
             {
                 hwloc_bitmap_free(cpuset);
-                HPX_THROWS_IF(ec, kernel_error,
+                HPX_THROWS_IF(ec, hpx::error::kernel_error,
                     "hpx::threads::topology::get_cpubind_mask",
                     "hwloc_get_cpubind failed");
                 return empty_mask;
@@ -1282,7 +1284,7 @@ namespace hpx { namespace threads {
 #endif
             {
                 hwloc_bitmap_free(cpuset);
-                HPX_THROWS_IF(ec, kernel_error,
+                HPX_THROWS_IF(ec, hpx::error::kernel_error,
                     "hpx::threads::topology::get_cpubind_mask",
                     "hwloc_get_cpubind failed");
                 return empty_mask;
@@ -1355,7 +1357,7 @@ namespace hpx { namespace threads {
                 msg = "the action is not supported";
             if (errno == EXDEV)
                 msg = "the binding cannot be enforced";
-            HPX_THROW_EXCEPTION(kernel_error,
+            HPX_THROW_EXCEPTION(hpx::error::kernel_error,
                 "hpx::threads::topology::set_area_membind_nodeset",
                 "hwloc_set_area_membind_nodeset failed : {}", msg);
             return false;
@@ -1401,7 +1403,7 @@ namespace hpx { namespace threads {
 #endif
             == -1)
         {
-            HPX_THROW_EXCEPTION(kernel_error,
+            HPX_THROW_EXCEPTION(hpx::error::kernel_error,
                 "hpx::threads::topology::get_area_membind_nodeset",
                 "hwloc_get_area_membind_nodeset failed");
             return bitmap_to_mask(ns, HWLOC_OBJ_MACHINE);
@@ -1432,7 +1434,7 @@ namespace hpx { namespace threads {
             return 0;
 #else
             std::string msg(strerror(errno));
-            HPX_THROW_EXCEPTION(kernel_error,
+            HPX_THROW_EXCEPTION(hpx::error::kernel_error,
                 "hpx::threads::topology::get_numa_domain",
                 "hwloc_get_area_memlocation failed {}", msg);
             return -1;
@@ -1461,7 +1463,8 @@ namespace hpx { namespace threads {
 
         if (pu_obj == nullptr)
         {
-            HPX_THROW_EXCEPTION(no_success, "topology::get_core_obj",
+            HPX_THROW_EXCEPTION(hpx::error::no_success,
+                "topology::get_core_obj",
                 "Couldn't find required object representing the given core in "
                 "topology");
         }

--- a/libs/core/type_support/include/hpx/type_support/static.hpp
+++ b/libs/core/type_support/include/hpx/type_support/static.hpp
@@ -8,11 +8,11 @@
 
 #include <hpx/config.hpp>
 
+#include <memory>
 #include <type_traits>
 
 #if !defined(HPX_GCC_VERSION) && !defined(HPX_CLANG_VERSION) &&                \
     !(HPX_INTEL_VERSION > 1200 && !defined(HPX_WINDOWS))
-#include <memory>    // for placement new
 #include <mutex>
 #endif
 
@@ -104,7 +104,7 @@ namespace hpx { namespace util {
         {
             ~destructor()
             {
-                static_::get_address()->~value_type();
+                std::destroy_at(static_::get_address());
             }
         };
 

--- a/libs/core/util/src/regex_from_pattern.cpp
+++ b/libs/core/util/src/regex_from_pattern.cpp
@@ -25,7 +25,8 @@ namespace hpx { namespace util {
             }
             else if (*it == ']')
             {
-                HPX_THROWS_IF(ec, bad_parameter, "regex_from_character_set",
+                HPX_THROWS_IF(ec, hpx::error::bad_parameter,
+                    "regex_from_character_set",
                     "Invalid pattern (empty character set) at: " +
                         std::string(start, end));
                 return "";
@@ -45,7 +46,8 @@ namespace hpx { namespace util {
 
             if (it == end || *it != ']')
             {
-                HPX_THROWS_IF(ec, bad_parameter, "regex_from_character_set",
+                HPX_THROWS_IF(ec, hpx::error::bad_parameter,
+                    "regex_from_character_set",
                     "Invalid pattern (missing closing ']') at: " +
                         std::string(start, end));
                 return "";
@@ -84,7 +86,8 @@ namespace hpx { namespace util {
             case '\\':
                 if (++it == end)
                 {
-                    HPX_THROWS_IF(ec, bad_parameter, "regex_from_pattern",
+                    HPX_THROWS_IF(ec, hpx::error::bad_parameter,
+                        "regex_from_pattern",
                         "Invalid escape sequence at: " + pattern);
                     return "";
                 }

--- a/libs/full/actions_base/src/detail/action_factory.cpp
+++ b/libs/full/actions_base/src/detail/action_factory.cpp
@@ -52,7 +52,7 @@ namespace hpx { namespace actions { namespace detail {
 
         if (!p.second)
         {
-            HPX_THROW_EXCEPTION(invalid_status,
+            HPX_THROW_EXCEPTION(hpx::error::invalid_status,
                 "action_registry::register_typename",
                 "failed to insert {} into typename to id registry.", type_name);
         }
@@ -137,9 +137,9 @@ namespace hpx { namespace actions { namespace detail {
 
         if (id == invalid_id)
         {
-            HPX_THROW_EXCEPTION(serialization_error, "action_registry::get_id",
-                "Unknown typename: {}\n{}", type_name,
-                instance().collect_registered_typenames());
+            HPX_THROW_EXCEPTION(hpx::error::serialization_error,
+                "action_registry::get_id", "Unknown typename: {}\n{}",
+                type_name, instance().collect_registered_typenames());
         }
 
         return id;
@@ -162,8 +162,8 @@ namespace hpx { namespace actions { namespace detail {
 #else
             HPX_UNUSED(name);
 #endif
-            HPX_THROW_EXCEPTION(
-                serialization_error, "action_registry::create", msg);
+            HPX_THROW_EXCEPTION(hpx::error::serialization_error,
+                "action_registry::create", msg);
             return nullptr;
         }
 
@@ -180,8 +180,8 @@ namespace hpx { namespace actions { namespace detail {
 #else
             HPX_UNUSED(name);
 #endif
-            HPX_THROW_EXCEPTION(
-                serialization_error, "action_registry::create", msg);
+            HPX_THROW_EXCEPTION(hpx::error::serialization_error,
+                "action_registry::create", msg);
             return nullptr;
         }
         return !with_continuation ? ctors.first() : ctors.second();

--- a/libs/full/actions_base/src/detail/invocation_count_registry.cpp
+++ b/libs/full/actions_base/src/detail/invocation_count_registry.cpp
@@ -34,7 +34,7 @@ namespace hpx { namespace actions { namespace detail {
     {
         if (name.empty())
         {
-            HPX_THROW_EXCEPTION(bad_parameter,
+            HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
                 "invocation_count_registry::register_class",
                 "Cannot register an action with an empty name");
         }
@@ -53,7 +53,7 @@ namespace hpx { namespace actions { namespace detail {
         map_type::const_iterator it = map_.find(name);
         if (it == map_.end())
         {
-            HPX_THROW_EXCEPTION(bad_parameter,
+            HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
                 "invocation_count_registry::get_invocation_counter",
                 "unknown action type");
             return nullptr;

--- a/libs/full/actions_base/src/detail/per_action_data_counter_registry.cpp
+++ b/libs/full/actions_base/src/detail/per_action_data_counter_registry.cpp
@@ -32,7 +32,7 @@ namespace hpx { namespace actions { namespace detail {
     {
         if (name.empty())
         {
-            HPX_THROW_EXCEPTION(bad_parameter,
+            HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
                 "per_action_data_counter_registry::register_class",
                 "Cannot register an action with an empty name");
         }
@@ -51,7 +51,7 @@ namespace hpx { namespace actions { namespace detail {
         map_type::const_iterator it = map_.find(name);
         if (it == map_.end())
         {
-            HPX_THROW_EXCEPTION(bad_parameter,
+            HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
                 "per_action_data_counter_registry::get_receive_counter",
                 "unknown action type");
             return nullptr;

--- a/libs/full/agas/src/addressing_service.cpp
+++ b/libs/full/agas/src/addressing_service.cpp
@@ -226,7 +226,7 @@ namespace hpx { namespace agas {
                 if (!res.second)
                 {
                     l.unlock();
-                    HPX_THROWS_IF(ec, bad_parameter,
+                    HPX_THROWS_IF(ec, hpx::error::bad_parameter,
                         "addressing_service::register_locality",
                         "locality insertion failed because of a duplicate");
                     return false;
@@ -291,7 +291,7 @@ namespace hpx { namespace agas {
 
                     l.unlock();
 
-                    HPX_THROWS_IF(ec, bad_parameter,
+                    HPX_THROWS_IF(ec, hpx::error::bad_parameter,
                         "addressing_service::resolve_locality", str);
                     return resolved_localities_[naming::invalid_gid];
                 }
@@ -308,7 +308,7 @@ namespace hpx { namespace agas {
                 {
                     l.unlock();
 
-                    HPX_THROWS_IF(ec, internal_server_error,
+                    HPX_THROWS_IF(ec, hpx::error::internal_server_error,
                         "addressing_service::resolve_locality",
                         "resolved locality insertion failed "
                         "due to a locking error or memory corruption");
@@ -1009,7 +1009,7 @@ namespace hpx { namespace agas {
     {
         if (!gid)
         {
-            HPX_THROW_EXCEPTION(bad_parameter,
+            HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
                 "addressing_service::resolve_async", "invalid reference id");
             return make_ready_future(naming::address());
         }
@@ -1038,7 +1038,7 @@ namespace hpx { namespace agas {
     {
         if (!id)
         {
-            HPX_THROW_EXCEPTION(bad_parameter,
+            HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
                 "addressing_service::get_colocation_id_async",
                 "invalid reference id");
             return make_ready_future(hpx::invalid_id);
@@ -1059,7 +1059,7 @@ namespace hpx { namespace agas {
         if (get<0>(rep) == naming::invalid_gid ||
             get<2>(rep) == naming::invalid_gid)
         {
-            HPX_THROW_EXCEPTION(bad_parameter,
+            HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
                 "addressing_service::resolve_full_postproc",
                 "could no resolve global id");
             return addr;
@@ -1098,7 +1098,7 @@ namespace hpx { namespace agas {
     {
         if (!gid)
         {
-            HPX_THROW_EXCEPTION(bad_parameter,
+            HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
                 "addressing_service::resolve_full_async",
                 "invalid reference id");
             return make_ready_future(naming::address());
@@ -1275,7 +1275,7 @@ namespace hpx { namespace agas {
 
         if (HPX_UNLIKELY(0 >= credit))
         {
-            HPX_THROW_EXCEPTION(bad_parameter,
+            HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
                 "addressing_service::incref_async",
                 "invalid credit count of {1}", credit);
             return hpx::future<std::int64_t>();
@@ -1386,8 +1386,9 @@ namespace hpx { namespace agas {
 
         if (HPX_UNLIKELY(credit <= 0))
         {
-            HPX_THROWS_IF(ec, bad_parameter, "addressing_service::decref",
-                "invalid credit count of {1}", credit);
+            HPX_THROWS_IF(ec, hpx::error::bad_parameter,
+                "addressing_service::decref", "invalid credit count of {1}",
+                credit);
             return;
         }
 
@@ -1413,7 +1414,7 @@ namespace hpx { namespace agas {
                 {
                     l.unlock();
 
-                    HPX_THROWS_IF(ec, bad_parameter,
+                    HPX_THROWS_IF(ec, hpx::error::bad_parameter,
                         "addressing_service::decref",
                         "couldn't insert decref request for {1} ({2})", raw,
                         credit);
@@ -1549,7 +1550,7 @@ namespace hpx { namespace agas {
         {
             if (!f.get())
             {
-                HPX_THROW_EXCEPTION(bad_request,
+                HPX_THROW_EXCEPTION(hpx::error::bad_request,
                     "hpx::agas::detail::on_register_event",
                     "request 'symbol_ns_on_event' failed");
                 return hpx::future<hpx::id_type>();
@@ -1665,7 +1666,7 @@ namespace hpx { namespace agas {
                         {
                             // This is impossible under sane conditions.
                             lock.unlock();
-                            HPX_THROWS_IF(ec, invalid_data,
+                            HPX_THROWS_IF(ec, hpx::error::invalid_data,
                                 "addressing_service::update_cache_entry",
                                 "data corruption or lock error occurred in "
                                 "cache");
@@ -1711,7 +1712,7 @@ namespace hpx { namespace agas {
             if (HPX_UNLIKELY(id_msb != idbase_key.get_gid().get_msb()))
             {
                 lock.unlock();
-                HPX_THROWS_IF(ec, internal_server_error,
+                HPX_THROWS_IF(ec, hpx::error::internal_server_error,
                     "addressing_service::get_cache_entry",
                     "bad entry in cache, MSBs of GID base and GID do not "
                     "match");
@@ -1929,7 +1930,7 @@ namespace hpx { namespace agas {
     {
         if (!l.owns_lock())
         {
-            HPX_THROWS_IF(ec, lock_error,
+            HPX_THROWS_IF(ec, hpx::error::lock_error,
                 "addressing_service::send_refcnt_requests",
                 "mutex is not locked");
             return;
@@ -2134,9 +2135,10 @@ namespace hpx { namespace agas {
         HPX_UNUSED(expect_to_be_marked_as_migrating);
         if (!gid_)
         {
-            return hpx::make_exceptional_future<void>(HPX_GET_EXCEPTION(
-                bad_parameter, "addressing_service::mark_as_migrated",
-                "invalid reference gid"));
+            return hpx::make_exceptional_future<void>(
+                HPX_GET_EXCEPTION(hpx::error::bad_parameter,
+                    "addressing_service::mark_as_migrated",
+                    "invalid reference gid"));
         }
 
         HPX_ASSERT(naming::detail::is_migratable(gid_));
@@ -2194,7 +2196,7 @@ namespace hpx { namespace agas {
     {
         if (!gid_)
         {
-            HPX_THROW_EXCEPTION(bad_parameter,
+            HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
                 "addressing_service::unmark_as_migrated",
                 "invalid reference gid");
             return;
@@ -2231,7 +2233,7 @@ namespace hpx { namespace agas {
     {
         if (!id)
         {
-            HPX_THROW_EXCEPTION(bad_parameter,
+            HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
                 "addressing_service::begin_migration", "invalid reference id");
         }
 
@@ -2246,7 +2248,7 @@ namespace hpx { namespace agas {
     {
         if (!id)
         {
-            HPX_THROW_EXCEPTION(bad_parameter,
+            HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
                 "addressing_service::end_migration", "invalid reference id");
         }
 
@@ -2273,7 +2275,7 @@ namespace hpx { namespace agas {
     {
         if (!gid)
         {
-            HPX_THROW_EXCEPTION(bad_parameter,
+            HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
                 "addressing_service::was_object_migrated",
                 "invalid reference gid");
             return std::make_pair(false, components::pinned_ptr());

--- a/libs/full/agas/src/detail/interface.cpp
+++ b/libs/full/agas/src/detail/interface.cpp
@@ -217,8 +217,8 @@ namespace hpx { namespace agas { namespace detail { namespace impl {
         auto* client = naming::get_agas_client_ptr();
         if (nullptr == client)
         {
-            HPX_THROWS_IF(ec, invalid_status, "agas::bind_gid_local",
-                "addressing_service is not valid");
+            HPX_THROWS_IF(ec, hpx::error::invalid_status,
+                "agas::bind_gid_local", "addressing_service is not valid");
             return false;
         }
         return client->bind_local(gid_, addr, ec);
@@ -231,7 +231,8 @@ namespace hpx { namespace agas { namespace detail { namespace impl {
             auto* client = naming::get_agas_client_ptr();
             if (nullptr == client)
             {
-                HPX_THROWS_IF(ec, invalid_status, "agas::unbind_gid_local",
+                HPX_THROWS_IF(ec, hpx::error::invalid_status,
+                    "agas::unbind_gid_local",
                     "addressing_service is not valid");
             }
             else
@@ -241,7 +242,7 @@ namespace hpx { namespace agas { namespace detail { namespace impl {
         }
         else
         {
-            HPX_THROWS_IF(ec, bad_parameter, "agas::unbind_gid",
+            HPX_THROWS_IF(ec, hpx::error::bad_parameter, "agas::unbind_gid",
                 "cannot dereference invalid GID");
         }
     }
@@ -252,8 +253,8 @@ namespace hpx { namespace agas { namespace detail { namespace impl {
         auto* client = naming::get_agas_client_ptr();
         if (nullptr == client)
         {
-            HPX_THROWS_IF(ec, invalid_status, "agas::bind_range_local",
-                "addressing_service is not valid");
+            HPX_THROWS_IF(ec, hpx::error::invalid_status,
+                "agas::bind_range_local", "addressing_service is not valid");
             return false;
         }
         return client->bind_range_local(gid, count, addr, offset, ec);
@@ -265,8 +266,8 @@ namespace hpx { namespace agas { namespace detail { namespace impl {
         auto* client = naming::get_agas_client_ptr();
         if (nullptr == client)
         {
-            HPX_THROWS_IF(ec, invalid_status, "agas::unbind_range_local",
-                "addressing_service is not valid");
+            HPX_THROWS_IF(ec, hpx::error::invalid_status,
+                "agas::unbind_range_local", "addressing_service is not valid");
         }
         else
         {
@@ -356,7 +357,7 @@ namespace hpx { namespace agas { namespace detail { namespace impl {
         runtime* rt = get_runtime_ptr();
         if (rt == nullptr)
         {
-            HPX_THROWS_IF(ec, invalid_status, "get_next_id",
+            HPX_THROWS_IF(ec, hpx::error::invalid_status, "get_next_id",
                 "the runtime system has not been started yet.");
             return naming::invalid_gid;
         }

--- a/libs/full/agas/src/route.cpp
+++ b/libs/full/agas/src/route.cpp
@@ -70,7 +70,8 @@ namespace hpx::agas::server {
             {
                 l.unlock();
 
-                HPX_THROWS_IF(ec, no_success, "primary_namespace::route",
+                HPX_THROWS_IF(ec, hpx::error::no_success,
+                    "primary_namespace::route",
                     "can't route parcel to unknown gid: {}", gid);
 
                 return;

--- a/libs/full/agas_base/src/gva.cpp
+++ b/libs/full/agas_base/src/gva.cpp
@@ -29,7 +29,7 @@ namespace hpx::agas {
     {
         if (version > HPX_AGAS_VERSION)
         {
-            HPX_THROW_EXCEPTION(version_too_new, "gva::load",
+            HPX_THROW_EXCEPTION(hpx::error::version_too_new, "gva::load",
                 "trying to load GVA with unknown version");
         }
 

--- a/libs/full/agas_base/src/primary_namespace.cpp
+++ b/libs/full/agas_base/src/primary_namespace.cpp
@@ -109,7 +109,7 @@ namespace hpx { namespace agas {
             naming::get_locality_id_from_gid(dest);
         if (service_locality_id == naming::invalid_locality_id)
         {
-            HPX_THROWS_IF(ec, bad_parameter,
+            HPX_THROWS_IF(ec, hpx::error::bad_parameter,
                 "primary_namespace::get_service_instance",
                 "can't retrieve a valid locality id from global address "
                 "({1}): ",

--- a/libs/full/agas_base/src/server/component_namespace_server.cpp
+++ b/libs/full/agas_base/src/server/component_namespace_server.cpp
@@ -96,7 +96,7 @@ namespace hpx { namespace agas { namespace server {
             {
                 l.unlock();
 
-                HPX_THROW_EXCEPTION(lock_error,
+                HPX_THROW_EXCEPTION(hpx::error::lock_error,
                     "component_namespace::bind_prefix",
                     "component id table insertion failed due to a locking "
                     "error or memory corruption");
@@ -121,7 +121,7 @@ namespace hpx { namespace agas { namespace server {
                 // Duplicate type registration for this locality.
                 l.unlock();
 
-                HPX_THROW_EXCEPTION(duplicate_component_id,
+                HPX_THROW_EXCEPTION(hpx::error::duplicate_component_id,
                     "component_namespace::bind_prefix",
                     "component id is already registered for the given "
                     "locality, key({1}), prefix({2}), ctype({3})",
@@ -152,7 +152,8 @@ namespace hpx { namespace agas { namespace server {
         {
             l.unlock();
 
-            HPX_THROW_EXCEPTION(lock_error, "component_namespace::bind_prefix",
+            HPX_THROW_EXCEPTION(hpx::error::lock_error,
+                "component_namespace::bind_prefix",
                 "factory table insertion failed due to a locking "
                 "error or memory corruption");
             return components::component_invalid;
@@ -190,7 +191,7 @@ namespace hpx { namespace agas { namespace server {
             {
                 l.unlock();
 
-                HPX_THROW_EXCEPTION(lock_error,
+                HPX_THROW_EXCEPTION(hpx::error::lock_error,
                     "component_namespace::bind_name",
                     "component id table insertion failed due to a locking "
                     "error or memory corruption");

--- a/libs/full/agas_base/src/server/locality_namespace_server.cpp
+++ b/libs/full/agas_base/src/server/locality_namespace_server.cpp
@@ -98,7 +98,7 @@ namespace hpx { namespace agas { namespace server {
         {
             l.unlock();
 
-            HPX_THROW_EXCEPTION(internal_server_error,
+            HPX_THROW_EXCEPTION(hpx::error::internal_server_error,
                 "locality_namespace::allocate",
                 "primary namespace has been exhausted");
         }
@@ -147,7 +147,8 @@ namespace hpx { namespace agas { namespace server {
         {
             l.unlock();
 
-            HPX_THROW_EXCEPTION(lock_error, "locality_namespace::allocate",
+            HPX_THROW_EXCEPTION(hpx::error::lock_error,
+                "locality_namespace::allocate",
                 "partition table insertion failed due to a locking "
                 "error or memory corruption, endpoint({1}), "
                 "prefix({2})",
@@ -164,7 +165,8 @@ namespace hpx { namespace agas { namespace server {
 
             if (!primary_->bind_gid(g, id, id))
             {
-                HPX_THROW_EXCEPTION(bad_request, "locality_namespace::allocate",
+                HPX_THROW_EXCEPTION(hpx::error::bad_request,
+                    "locality_namespace::allocate",
                     "unable to bind prefix({1}) to a gid", prefix);
             }
             return prefix;

--- a/libs/full/agas_base/src/server/primary_namespace_server.cpp
+++ b/libs/full/agas_base/src/server/primary_namespace_server.cpp
@@ -222,7 +222,7 @@ namespace hpx { namespace agas { namespace server {
                 {
                     l.unlock();
 
-                    HPX_THROW_EXCEPTION(bad_parameter,
+                    HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
                         "primary_namespace::bind_gid",
                         "cannot rebind gids for non-migratable objects");
 
@@ -239,7 +239,7 @@ namespace hpx { namespace agas { namespace server {
                     // REVIEW: Is this the right error code to use?
                     l.unlock();
 
-                    HPX_THROW_EXCEPTION(bad_parameter,
+                    HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
                         "primary_namespace::bind_gid",
                         "cannot change block size of existing binding");
                 }
@@ -248,7 +248,7 @@ namespace hpx { namespace agas { namespace server {
                 {
                     l.unlock();
 
-                    HPX_THROW_EXCEPTION(bad_parameter,
+                    HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
                         "primary_namespace::bind_gid",
                         "attempt to update a GVA with an invalid type, "
                         "gid({1}), gva({2}), locality({3})",
@@ -259,7 +259,7 @@ namespace hpx { namespace agas { namespace server {
                 {
                     l.unlock();
 
-                    HPX_THROW_EXCEPTION(bad_parameter,
+                    HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
                         "primary_namespace::bind_gid",
                         "attempt to update a GVA with an invalid "
                         "locality id, "
@@ -296,7 +296,7 @@ namespace hpx { namespace agas { namespace server {
                     // REVIEW: Is this the right error code to use?
                     l.unlock();
 
-                    HPX_THROW_EXCEPTION(bad_parameter,
+                    HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
                         "primary_namespace::bind_gid",
                         "the new GID is contained in an existing range");
                 }
@@ -313,7 +313,7 @@ namespace hpx { namespace agas { namespace server {
                 // REVIEW: Is this the right error code to use?
                 l.unlock();
 
-                HPX_THROW_EXCEPTION(bad_parameter,
+                HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
                     "primary_namespace::bind_gid",
                     "the new GID is contained in an existing range");
             }
@@ -337,7 +337,7 @@ namespace hpx { namespace agas { namespace server {
         {
             l.unlock();
 
-            HPX_THROW_EXCEPTION(internal_server_error,
+            HPX_THROW_EXCEPTION(hpx::error::internal_server_error,
                 "primary_namespace::bind_gid",
                 "MSBs of lower and upper range bound do not match");
         }
@@ -346,7 +346,8 @@ namespace hpx { namespace agas { namespace server {
         {
             l.unlock();
 
-            HPX_THROW_EXCEPTION(bad_parameter, "primary_namespace::bind_gid",
+            HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
+                "primary_namespace::bind_gid",
                 "attempt to insert a GVA with an invalid type, "
                 "gid({1}), gva({2}), locality({3})",
                 id, g, locality);
@@ -358,7 +359,8 @@ namespace hpx { namespace agas { namespace server {
         {
             l.unlock();
 
-            HPX_THROW_EXCEPTION(lock_error, "primary_namespace::bind_gid",
+            HPX_THROW_EXCEPTION(hpx::error::lock_error,
+                "primary_namespace::bind_gid",
                 "GVA table insertion failed due to a locking error or "
                 "memory corruption, gid({1}), gva({2}), locality({3})",
                 id, g, locality);
@@ -441,7 +443,7 @@ namespace hpx { namespace agas { namespace server {
             {
                 l.unlock();
 
-                HPX_THROW_EXCEPTION(bad_parameter,
+                HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
                     "primary_namespace::unbind_gid", "block sizes must match");
             }
 
@@ -508,7 +510,7 @@ namespace hpx { namespace agas { namespace server {
         }
         else
         {
-            HPX_THROW_EXCEPTION(bad_parameter,
+            HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
                 "primary_namespace::increment_credit",
                 "invalid credit count of {1}", credits);
             return 0;
@@ -551,7 +553,7 @@ namespace hpx { namespace agas { namespace server {
             }
             else
             {
-                HPX_THROW_EXCEPTION(bad_parameter,
+                HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
                     "primary_namespace::decrement_credit",
                     "invalid credit count of {1}", credits);
             }
@@ -596,7 +598,7 @@ namespace hpx { namespace agas { namespace server {
                     (lower.get_msb() & naming::gid_type::virtual_memory_mask) ==
                     naming::gid_type::virtual_memory_mask))
             {
-                HPX_THROW_EXCEPTION(internal_server_error,
+                HPX_THROW_EXCEPTION(hpx::error::internal_server_error,
                     "locality_namespace::allocate",
                     "primary namespace has been exhausted");
             }
@@ -707,7 +709,7 @@ namespace hpx { namespace agas { namespace server {
                 {
                     l.unlock();
 
-                    HPX_THROWS_IF(ec, invalid_data,
+                    HPX_THROWS_IF(ec, hpx::error::invalid_data,
                         "primary_namespace::increment",
                         "couldn't create entry in reference count table, "
                         "raw({1}), ref-count({2})",
@@ -767,7 +769,7 @@ namespace hpx { namespace agas { namespace server {
             {
                 l.unlock();
 
-                HPX_THROWS_IF(ec, internal_server_error,
+                HPX_THROWS_IF(ec, hpx::error::internal_server_error,
                     "primary_namespace::resolve_free_list",
                     "primary_namespace::resolve_free_list, failed to resolve "
                     "gid, gid({1})",
@@ -783,7 +785,7 @@ namespace hpx { namespace agas { namespace server {
             {
                 l.unlock();
 
-                HPX_THROWS_IF(ec, internal_server_error,
+                HPX_THROWS_IF(ec, hpx::error::internal_server_error,
                     "primary_namespace::resolve_free_list",
                     "encountered a GVA with an invalid type while performing a "
                     "decrement, gid({1}), gva({2})",
@@ -794,7 +796,7 @@ namespace hpx { namespace agas { namespace server {
             {
                 l.unlock();
 
-                HPX_THROWS_IF(ec, internal_server_error,
+                HPX_THROWS_IF(ec, hpx::error::internal_server_error,
                     "primary_namespace::resolve_free_list",
                     "encountered a GVA with a count of zero while performing a "
                     "decrement, gid({1}), gva({2})",
@@ -876,7 +878,7 @@ namespace hpx { namespace agas { namespace server {
                     {
                         l.unlock();
 
-                        HPX_THROWS_IF(ec, invalid_data,
+                        HPX_THROWS_IF(ec, hpx::error::invalid_data,
                             "primary_namespace::decrement_sweep",
                             "negative entry in reference count table, "
                             "raw({1}), refcount({2})",
@@ -895,7 +897,7 @@ namespace hpx { namespace agas { namespace server {
                     {
                         l.unlock();
 
-                        HPX_THROWS_IF(ec, invalid_data,
+                        HPX_THROWS_IF(ec, hpx::error::invalid_data,
                             "primary_namespace::decrement_sweep",
                             "couldn't create entry in reference count table, "
                             "raw({1}), ref-count({2})",
@@ -915,7 +917,7 @@ namespace hpx { namespace agas { namespace server {
                 {
                     l.unlock();
 
-                    HPX_THROWS_IF(ec, invalid_data,
+                    HPX_THROWS_IF(ec, hpx::error::invalid_data,
                         "primary_namespace::decrement_sweep",
                         "negative entry in reference count table, raw({1}), "
                         "refcount({2})",
@@ -973,7 +975,7 @@ namespace hpx { namespace agas { namespace server {
                 auto deleter = components::deleter(e.gva_.type);
                 if (deleter == nullptr)
                 {
-                    HPX_THROWS_IF(ec, internal_server_error,
+                    HPX_THROWS_IF(ec, hpx::error::internal_server_error,
                         "primary_namespace::free_components_sync",
                         "Attempting to delete object of unknown component "
                         "type: " +
@@ -1042,7 +1044,7 @@ namespace hpx { namespace agas { namespace server {
                     {
                         l.unlock();
 
-                        HPX_THROWS_IF(ec, internal_server_error,
+                        HPX_THROWS_IF(ec, hpx::error::internal_server_error,
                             "primary_namespace::resolve_gid_locked",
                             "MSBs of lower and upper range bound do not "
                             "match");
@@ -1070,7 +1072,7 @@ namespace hpx { namespace agas { namespace server {
                 {
                     l.unlock();
 
-                    HPX_THROWS_IF(ec, internal_server_error,
+                    HPX_THROWS_IF(ec, hpx::error::internal_server_error,
                         "primary_namespace::resolve_gid_locked",
                         "MSBs of lower and upper range bound do not match");
                     return resolved_type(

--- a/libs/full/agas_base/src/server/symbol_namespace_server.cpp
+++ b/libs/full/agas_base/src/server/symbol_namespace_server.cpp
@@ -144,7 +144,8 @@ namespace hpx { namespace agas { namespace server {
         {
             l.unlock();
 
-            HPX_THROW_EXCEPTION(lock_error, "symbol_namespace::bind",
+            HPX_THROW_EXCEPTION(hpx::error::lock_error,
+                "symbol_namespace::bind",
                 "GID table insertion failed due to a locking error or "
                 "memory corruption");
         }
@@ -176,7 +177,7 @@ namespace hpx { namespace agas { namespace server {
                 {
                     l.unlock();
 
-                    HPX_THROW_EXCEPTION(invalid_status,
+                    HPX_THROW_EXCEPTION(hpx::error::invalid_status,
                         "symbol_namespace::bind",
                         "unable to re-locate the entry in the GID table");
                 }

--- a/libs/full/agas_base/src/symbol_namespace.cpp
+++ b/libs/full/agas_base/src/symbol_namespace.cpp
@@ -67,7 +67,7 @@ namespace hpx { namespace agas {
             naming::get_locality_id_from_gid(dest);
         if (service_locality_id == naming::invalid_locality_id)
         {
-            HPX_THROWS_IF(ec, bad_parameter,
+            HPX_THROWS_IF(ec, hpx::error::bad_parameter,
                 "symbol_namespace::get_service_instance",
                 "can't retrieve a valid locality id from global address "
                 "({1}): ",

--- a/libs/full/async_colocated/include/hpx/async_colocated/functional/colocated_helpers.hpp
+++ b/libs/full/async_colocated/include/hpx/async_colocated/functional/colocated_helpers.hpp
@@ -32,7 +32,7 @@ namespace hpx { namespace util { namespace functional {
         {
             if (locality_id == hpx::invalid_id)
             {
-                HPX_THROW_EXCEPTION(hpx::no_success,
+                HPX_THROW_EXCEPTION(hpx::error::no_success,
                     "extract_locality::operator()",
                     "could not resolve colocated locality for id({1})", id);
                 return hpx::invalid_id;

--- a/libs/full/async_colocated/include/hpx/async_colocated/server/destroy_component.hpp
+++ b/libs/full/async_colocated/include/hpx/async_colocated/server/destroy_component.hpp
@@ -14,6 +14,8 @@
 #include <hpx/modules/errors.hpp>
 #include <hpx/naming_base/address.hpp>
 
+#include <memory>
+
 ///////////////////////////////////////////////////////////////////////////////
 namespace hpx { namespace components { namespace server {
 
@@ -41,7 +43,7 @@ namespace hpx { namespace components { namespace server {
         if (!types_are_compatible(type, addr.type_))
         {
             // FIXME: should the component be re-bound ?
-            HPX_THROW_EXCEPTION(hpx::unknown_component_address,
+            HPX_THROW_EXCEPTION(hpx::error::unknown_component_address,
                 "destroy<Component>",
                 "global id: {} is not bound to a component "
                 "instance of type: {}  (it is bound to a {})",
@@ -55,7 +57,7 @@ namespace hpx { namespace components { namespace server {
         // delete the local instances
         Component* c = reinterpret_cast<Component*>(addr.address_);
         c->finalize();
-        c->~Component();
+        std::destroy_at(c);
         component_heap<Component>().free(c, 1);
     }
 
@@ -65,7 +67,7 @@ namespace hpx { namespace components { namespace server {
         naming::address addr;
         if (!agas::resolve_local(gid, addr))
         {
-            HPX_THROW_EXCEPTION(hpx::unknown_component_address,
+            HPX_THROW_EXCEPTION(hpx::error::unknown_component_address,
                 "destroy<Component>",
                 "global id: {} is not bound to any component instance", gid);
             return;

--- a/libs/full/async_distributed/include/hpx/async_distributed/base_lco_with_value.hpp
+++ b/libs/full/async_distributed/include/hpx/async_distributed/base_lco_with_value.hpp
@@ -90,7 +90,7 @@ namespace hpx { namespace lcos {
             else
             {
                 // this shouldn't ever be called
-                HPX_THROW_EXCEPTION(invalid_status,
+                HPX_THROW_EXCEPTION(hpx::error::invalid_status,
                     "base_lco_with_value::set_event_nonvirt",
                     "attempt to use a non-default-constructible return type "
                     "with an action in a context where default-construction "

--- a/libs/full/async_distributed/include/hpx/async_distributed/continuation.hpp
+++ b/libs/full/async_distributed/include/hpx/async_distributed/continuation.hpp
@@ -158,7 +158,7 @@ namespace hpx { namespace actions {
             {
                 if (!this->get_id())
                 {
-                    HPX_THROW_EXCEPTION(invalid_status,
+                    HPX_THROW_EXCEPTION(hpx::error::invalid_status,
                         "typed_continuation<Result>::trigger_value",
                         "attempt to trigger invalid LCO (the id is invalid)");
                     return;
@@ -272,7 +272,7 @@ namespace hpx { namespace actions {
             {
                 if (!this->get_id())
                 {
-                    HPX_THROW_EXCEPTION(invalid_status,
+                    HPX_THROW_EXCEPTION(hpx::error::invalid_status,
                         "typed_continuation<Result>::trigger_value",
                         "attempt to trigger invalid LCO (the id is invalid)");
                     return;

--- a/libs/full/async_distributed/include/hpx/async_distributed/detail/async_implementations.hpp
+++ b/libs/full/async_distributed/include/hpx/async_distributed/detail/async_implementations.hpp
@@ -300,8 +300,8 @@ namespace hpx { namespace detail {
                 launch::deferred, id, HPX_MOVE(addr), HPX_FORWARD(Ts, vs)...);
         }
 
-        HPX_THROW_EXCEPTION(
-            bad_parameter, "async_remote_impl", "unknown launch policy");
+        HPX_THROW_EXCEPTION(hpx::error::bad_parameter, "async_remote_impl",
+            "unknown launch policy");
     }
 
     ///////////////////////////////////////////////////////////////////////////
@@ -531,8 +531,8 @@ namespace hpx { namespace detail {
             }
             else
             {
-                HPX_THROW_EXCEPTION(
-                    bad_parameter, "async_cb_impl", "unknown launch policy");
+                HPX_THROW_EXCEPTION(hpx::error::bad_parameter, "async_cb_impl",
+                    "unknown launch policy");
                 return f;
             }
         }

--- a/libs/full/async_distributed/include/hpx/async_distributed/detail/post_callback.hpp
+++ b/libs/full/async_distributed/include/hpx/async_distributed/detail/post_callback.hpp
@@ -146,7 +146,7 @@ namespace hpx {
     {
         if (!traits::action_is_target_valid<Action>::call(gid))
         {
-            HPX_THROW_EXCEPTION(bad_parameter, "post_p_cb",
+            HPX_THROW_EXCEPTION(hpx::error::bad_parameter, "post_p_cb",
                 "the target (destination) does not match the action type ({})",
                 hpx::actions::detail::get_action_name<Action>());
             return false;
@@ -176,7 +176,7 @@ namespace hpx {
             HPX_FORWARD(Continuation, c), gid, priority,
             HPX_FORWARD(Callback, cb), HPX_FORWARD(Ts, vs)...);
 #else
-        HPX_THROW_EXCEPTION(invalid_status, "hpx::post_cb",
+        HPX_THROW_EXCEPTION(hpx::error::invalid_status, "hpx::post_cb",
             "unexpected attempt to send a parcel with networking disabled");
 #endif
     }

--- a/libs/full/async_distributed/include/hpx/async_distributed/detail/post_implementations.hpp
+++ b/libs/full/async_distributed/include/hpx/async_distributed/detail/post_implementations.hpp
@@ -30,7 +30,8 @@ namespace hpx { namespace detail {
     {
         if (!traits::action_is_target_valid<Action>::call(id))
         {
-            HPX_THROW_EXCEPTION(bad_parameter, "hpx::detail::post_impl",
+            HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
+                "hpx::detail::post_impl",
                 "the target (destination) does not match the action type ({})",
                 hpx::actions::detail::get_action_name<Action>());
             return false;
@@ -67,7 +68,7 @@ namespace hpx { namespace detail {
         return hpx::detail::post_r_p<Action>(HPX_MOVE(addr),
             HPX_FORWARD(Continuation, c), id, priority, HPX_FORWARD(Ts, vs)...);
 #else
-        HPX_THROW_EXCEPTION(invalid_status, "hpx::post_impl",
+        HPX_THROW_EXCEPTION(hpx::error::invalid_status, "hpx::post_impl",
             "unexpected attempt to send a parcel with networking disabled");
 #endif
     }
@@ -82,7 +83,8 @@ namespace hpx { namespace detail {
         {
             if (!traits::action_is_target_valid<Action>::call(id))
             {
-                HPX_THROW_EXCEPTION(bad_parameter, "hpx::detail::post_impl",
+                HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
+                    "hpx::detail::post_impl",
                     "the target (destination) does not match the action type "
                     "({})",
                     hpx::actions::detail::get_action_name<Action>());
@@ -122,7 +124,8 @@ namespace hpx { namespace detail {
                     HPX_FORWARD(Continuation, c), id, priority,
                     HPX_FORWARD(Ts, vs)...);
 #else
-                HPX_THROW_EXCEPTION(invalid_status, "hpx::detail::post_impl",
+                HPX_THROW_EXCEPTION(hpx::error::invalid_status,
+                    "hpx::detail::post_impl",
                     "unexpected attempt to send a parcel with networking "
                     "disabled");
 #endif
@@ -139,7 +142,8 @@ namespace hpx { namespace detail {
     {
         if (!traits::action_is_target_valid<Action>::call(id))
         {
-            HPX_THROW_EXCEPTION(bad_parameter, "hpx::detail::post_impl",
+            HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
+                "hpx::detail::post_impl",
                 "the target (destination) does not match the action type ({})",
                 hpx::actions::detail::get_action_name<Action>());
             return false;
@@ -174,7 +178,7 @@ namespace hpx { namespace detail {
         return hpx::detail::post_r_p<Action>(
             HPX_MOVE(addr), id, priority, HPX_FORWARD(Ts, vs)...);
 #else
-        HPX_THROW_EXCEPTION(invalid_status, "hpx::post_impl",
+        HPX_THROW_EXCEPTION(hpx::error::invalid_status, "hpx::post_impl",
             "unexpected attempt to send a parcel with networking disabled");
 #endif
     }
@@ -188,7 +192,8 @@ namespace hpx { namespace detail {
         {
             if (!traits::action_is_target_valid<Action>::call(id))
             {
-                HPX_THROW_EXCEPTION(bad_parameter, "hpx::detail::post_impl",
+                HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
+                    "hpx::detail::post_impl",
                     "the target (destination) does not match the action type "
                     "({})",
                     hpx::actions::detail::get_action_name<Action>());
@@ -225,7 +230,8 @@ namespace hpx { namespace detail {
                 return hpx::detail::post_r_p<Action>(
                     HPX_MOVE(addr), id, priority, HPX_FORWARD(Ts, vs)...);
 #else
-                HPX_THROW_EXCEPTION(invalid_status, "hpx::detail::post_impl",
+                HPX_THROW_EXCEPTION(hpx::error::invalid_status,
+                    "hpx::detail::post_impl",
                     "unexpected attempt to send a parcel with networking "
                     "disabled");
 #endif
@@ -242,7 +248,8 @@ namespace hpx { namespace detail {
     {
         if (!traits::action_is_target_valid<Action>::call(id))
         {
-            HPX_THROW_EXCEPTION(bad_parameter, "hpx::detail::post_cb_impl",
+            HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
+                "hpx::detail::post_cb_impl",
                 "the target (destination) does not match the action type ({})",
                 hpx::actions::detail::get_action_name<Action>());
             return false;
@@ -296,7 +303,8 @@ namespace hpx { namespace detail {
             HPX_FORWARD(Continuation, c), id, priority,
             HPX_FORWARD(Callback, cb), HPX_FORWARD(Ts, vs)...);
 #else
-        HPX_THROW_EXCEPTION(invalid_status, "hpx::detail::post_cb_impl",
+        HPX_THROW_EXCEPTION(hpx::error::invalid_status,
+            "hpx::detail::post_cb_impl",
             "unexpected attempt to send a parcel with networking disabled");
 #endif
     }
@@ -307,7 +315,8 @@ namespace hpx { namespace detail {
     {
         if (!traits::action_is_target_valid<Action>::call(id))
         {
-            HPX_THROW_EXCEPTION(bad_parameter, "hpx::detail::post_cb_impl",
+            HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
+                "hpx::detail::post_cb_impl",
                 "the target (destination) does not match the action type ({})",
                 hpx::actions::detail::get_action_name<Action>());
             return false;
@@ -358,7 +367,8 @@ namespace hpx { namespace detail {
         return hpx::detail::post_r_p_cb<Action>(HPX_MOVE(addr), id, priority,
             HPX_FORWARD(Callback, cb), HPX_FORWARD(Ts, vs)...);
 #else
-        HPX_THROW_EXCEPTION(invalid_status, "hpx::detail::post_cb_impl",
+        HPX_THROW_EXCEPTION(hpx::error::invalid_status,
+            "hpx::detail::post_cb_impl",
             "unexpected attempt to send a parcel with networking disabled");
 #endif
     }

--- a/libs/full/async_distributed/include/hpx/async_distributed/detail/promise_base.hpp
+++ b/libs/full/async_distributed/include/hpx/async_distributed/detail/promise_base.hpp
@@ -225,21 +225,21 @@ namespace hpx {
             {
                 if (this->shared_state_ == nullptr)
                 {
-                    HPX_THROWS_IF(ec, no_state,
+                    HPX_THROWS_IF(ec, hpx::error::no_state,
                         "detail::promise_base<Result, RemoteResult>::get_id",
                         "this promise has no valid shared state");
                     return hpx::invalid_id;
                 }
                 if (!addr_ || !id_)
                 {
-                    HPX_THROWS_IF(ec, no_state,
+                    HPX_THROWS_IF(ec, hpx::error::no_state,
                         "detail::promise_base<Result, RemoteResult>::get_id",
                         "this promise has no valid LCO");
                     return hpx::invalid_id;
                 }
                 if (!this->future_retrieved_)
                 {
-                    HPX_THROW_EXCEPTION(invalid_status,
+                    HPX_THROW_EXCEPTION(hpx::error::invalid_status,
                         "promise<Result>::get_id",
                         "future has not been retrieved from this promise yet");
                     return hpx::invalid_id;
@@ -268,7 +268,7 @@ namespace hpx {
             {
                 if (!addr_ || !id_)
                 {
-                    HPX_THROWS_IF(ec, no_state,
+                    HPX_THROWS_IF(ec, hpx::error::no_state,
                         "detail::promise_base<Result, RemoteResult>::get_id",
                         "this promise has no valid LCO");
                     return naming::address();
@@ -292,7 +292,7 @@ namespace hpx {
 
                 static void wrapping_deleter(wrapping_type* ptr)
                 {
-                    ptr->~wrapping_type();
+                    std::destroy_at(ptr);
                     hpx::components::component_heap<wrapping_type>().free(ptr);
                 }
 
@@ -350,8 +350,8 @@ namespace hpx {
                 if (this->shared_state_ != nullptr && this->future_retrieved_ &&
                     !(this->shared_state_->is_ready() || id_retrieved_))
                 {
-                    this->shared_state_->set_error(broken_promise, fun,
-                        "abandoning not ready shared state");
+                    this->shared_state_->set_error(hpx::error::broken_promise,
+                        fun, "abandoning not ready shared state");
                     return;
                 }
             }

--- a/libs/full/async_distributed/src/continuation.cpp
+++ b/libs/full/async_distributed/src/continuation.cpp
@@ -65,7 +65,8 @@ namespace hpx { namespace actions {
     {
         if (!id_)
         {
-            HPX_THROW_EXCEPTION(invalid_status, "continuation::trigger_error",
+            HPX_THROW_EXCEPTION(hpx::error::invalid_status,
+                "continuation::trigger_error",
                 "attempt to trigger invalid LCO (the id is invalid)");
             return;
         }
@@ -78,7 +79,8 @@ namespace hpx { namespace actions {
     {
         if (!id_)
         {
-            HPX_THROW_EXCEPTION(invalid_status, "continuation::trigger_error",
+            HPX_THROW_EXCEPTION(hpx::error::invalid_status,
+                "continuation::trigger_error",
                 "attempt to trigger invalid LCO (the id is invalid)");
             return;
         }
@@ -133,7 +135,7 @@ namespace hpx { namespace actions {
         {
             if (!this->get_id())
             {
-                HPX_THROW_EXCEPTION(invalid_status,
+                HPX_THROW_EXCEPTION(hpx::error::invalid_status,
                     "typed_continuation<void>::trigger",
                     "attempt to trigger invalid LCO (the id is invalid)");
                 return;

--- a/libs/full/collectives/include/hpx/collectives/all_gather.hpp
+++ b/libs/full/collectives/include/hpx/collectives/all_gather.hpp
@@ -170,7 +170,7 @@ namespace hpx { namespace collectives {
         if (generation == 0)
         {
             return hpx::make_exceptional_future<std::vector<arg_type>>(
-                HPX_GET_EXCEPTION(hpx::bad_parameter,
+                HPX_GET_EXCEPTION(hpx::error::bad_parameter,
                     "hpx::collectives::all_gather",
                     "the generation number shouldn't be zero"));
         }

--- a/libs/full/collectives/include/hpx/collectives/all_reduce.hpp
+++ b/libs/full/collectives/include/hpx/collectives/all_reduce.hpp
@@ -189,7 +189,7 @@ namespace hpx { namespace collectives {
         if (generation == 0)
         {
             return hpx::make_exceptional_future<arg_type>(HPX_GET_EXCEPTION(
-                hpx::bad_parameter, "hpx::collectives::all_reduce",
+                hpx::error::bad_parameter, "hpx::collectives::all_reduce",
                 "the generation number shouldn't be zero"));
         }
 

--- a/libs/full/collectives/include/hpx/collectives/all_to_all.hpp
+++ b/libs/full/collectives/include/hpx/collectives/all_to_all.hpp
@@ -179,7 +179,7 @@ namespace hpx { namespace collectives {
         if (generation == 0)
         {
             return hpx::make_exceptional_future<std::vector<T>>(
-                HPX_GET_EXCEPTION(hpx::bad_parameter,
+                HPX_GET_EXCEPTION(hpx::error::bad_parameter,
                     "hpx::collectives::all_to_all",
                     "the generation number shouldn't be zero"));
         }

--- a/libs/full/collectives/include/hpx/collectives/broadcast.hpp
+++ b/libs/full/collectives/include/hpx/collectives/broadcast.hpp
@@ -274,7 +274,7 @@ namespace hpx { namespace collectives {
         if (generation == 0)
         {
             return hpx::make_exceptional_future<arg_type>(HPX_GET_EXCEPTION(
-                hpx::bad_parameter, "hpx::collectives::broadcast_to",
+                hpx::error::bad_parameter, "hpx::collectives::broadcast_to",
                 "the generation number shouldn't be zero"));
         }
 
@@ -337,7 +337,7 @@ namespace hpx { namespace collectives {
         if (generation == 0)
         {
             return hpx::make_exceptional_future<T>(HPX_GET_EXCEPTION(
-                hpx::bad_parameter, "hpx::collectives::broadcast_from",
+                hpx::error::bad_parameter, "hpx::collectives::broadcast_from",
                 "the generation number shouldn't be zero"));
         }
 

--- a/libs/full/collectives/include/hpx/collectives/broadcast_direct.hpp
+++ b/libs/full/collectives/include/hpx/collectives/broadcast_direct.hpp
@@ -552,9 +552,9 @@ namespace hpx { namespace lcos {
         {
             typedef typename detail::broadcast_result<Action>::type result_type;
 
-            return hpx::make_exceptional_future<result_type>(
-                HPX_GET_EXCEPTION(bad_parameter, "hpx::lcos::broadcast",
-                    "empty list of targets for broadcast operation"));
+            return hpx::make_exceptional_future<result_type>(HPX_GET_EXCEPTION(
+                hpx::error::bad_parameter, "hpx::lcos::broadcast",
+                "empty list of targets for broadcast operation"));
         }
 
         return hpx::detail::async_colocated<broadcast_impl_action>(ids[0],
@@ -581,7 +581,8 @@ namespace hpx { namespace lcos {
 
         if (ids.empty())
         {
-            HPX_THROW_EXCEPTION(hpx::bad_parameter, "hpx::lcos::broadcast_post",
+            HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
+                "hpx::lcos::broadcast_post",
                 "empty list of targets for broadcast operation");
             return;
         }

--- a/libs/full/collectives/include/hpx/collectives/detail/latch.hpp
+++ b/libs/full/collectives/include/hpx/collectives/detail/latch.hpp
@@ -123,8 +123,8 @@ namespace hpx { namespace lcos { namespace server {
             catch (std::exception const& e)
             {
                 // rethrow again, but this time using the native hpx mechanics
-                HPX_THROW_EXCEPTION(hpx::no_success, "latch::set_exception",
-                    hpx::diagnostic_information(e));
+                HPX_THROW_EXCEPTION(hpx::error::no_success,
+                    "latch::set_exception", hpx::diagnostic_information(e));
             }
         }
 

--- a/libs/full/collectives/include/hpx/collectives/exclusive_scan.hpp
+++ b/libs/full/collectives/include/hpx/collectives/exclusive_scan.hpp
@@ -205,7 +205,7 @@ namespace hpx { namespace collectives {
         if (generation == 0)
         {
             return hpx::make_exceptional_future<arg_type>(HPX_GET_EXCEPTION(
-                hpx::bad_parameter, "hpx::collectives::exclusive_scan",
+                hpx::error::bad_parameter, "hpx::collectives::exclusive_scan",
                 "the generation number shouldn't be zero"));
         }
 

--- a/libs/full/collectives/include/hpx/collectives/fold.hpp
+++ b/libs/full/collectives/include/hpx/collectives/fold.hpp
@@ -364,7 +364,7 @@ namespace hpx { namespace lcos {
         if (ids.empty())
         {
             return hpx::make_exceptional_future<action_result>(
-                HPX_GET_EXCEPTION(bad_parameter, "hpx::lcos::fold",
+                HPX_GET_EXCEPTION(hpx::error::bad_parameter, "hpx::lcos::fold",
                     "empty list of targets for fold operation"));
         }
 
@@ -420,7 +420,8 @@ namespace hpx { namespace lcos {
         if (ids.empty())
         {
             return hpx::make_exceptional_future<action_result>(
-                HPX_GET_EXCEPTION(bad_parameter, "hpx::lcos::inverse_fold",
+                HPX_GET_EXCEPTION(hpx::error::bad_parameter,
+                    "hpx::lcos::inverse_fold",
                     "empty list of targets for inverse_fold operation"));
         }
 
@@ -434,7 +435,7 @@ namespace hpx { namespace lcos {
         if (ids.empty())
         {
             return hpx::make_exceptional_future<action_result>(hpx::exception(
-                hpx::bad_parameter, "array of targets is empty"));
+                hpx::error::bad_parameter, "array of targets is empty"));
         }
 
         return hpx::detail::async_colocated<fold_impl_action>(inverted_ids[0],

--- a/libs/full/collectives/include/hpx/collectives/gather.hpp
+++ b/libs/full/collectives/include/hpx/collectives/gather.hpp
@@ -282,7 +282,7 @@ namespace hpx { namespace collectives {
         if (generation == 0)
         {
             return hpx::make_exceptional_future<std::vector<arg_type>>(
-                HPX_GET_EXCEPTION(hpx::bad_parameter,
+                HPX_GET_EXCEPTION(hpx::error::bad_parameter,
                     "hpx::collectives::gather_here",
                     "the generation number shouldn't be zero"));
         }
@@ -347,7 +347,7 @@ namespace hpx { namespace collectives {
         if (generation == 0)
         {
             return hpx::make_exceptional_future<void>(HPX_GET_EXCEPTION(
-                hpx::bad_parameter, "hpx::collectives::gather_there",
+                hpx::error::bad_parameter, "hpx::collectives::gather_there",
                 "the generation number shouldn't be zero"));
         }
 

--- a/libs/full/collectives/include/hpx/collectives/inclusive_scan.hpp
+++ b/libs/full/collectives/include/hpx/collectives/inclusive_scan.hpp
@@ -192,7 +192,7 @@ namespace hpx { namespace collectives {
         if (generation == 0)
         {
             return hpx::make_exceptional_future<arg_type>(HPX_GET_EXCEPTION(
-                hpx::bad_parameter, "hpx::collectives::inclusive_scan",
+                hpx::error::bad_parameter, "hpx::collectives::inclusive_scan",
                 "the generation number shouldn't be zero"));
         }
 

--- a/libs/full/collectives/include/hpx/collectives/reduce.hpp
+++ b/libs/full/collectives/include/hpx/collectives/reduce.hpp
@@ -296,7 +296,7 @@ namespace hpx { namespace collectives {
         if (generation == 0)
         {
             return hpx::make_exceptional_future<arg_type>(HPX_GET_EXCEPTION(
-                hpx::bad_parameter, "hpx::collectives::reduce_here",
+                hpx::error::bad_parameter, "hpx::collectives::reduce_here",
                 "the generation number shouldn't be zero"));
         }
 
@@ -361,7 +361,7 @@ namespace hpx { namespace collectives {
         if (generation == 0)
         {
             return hpx::make_exceptional_future<void>(HPX_GET_EXCEPTION(
-                hpx::bad_parameter, "hpx::collectives::reduce_there",
+                hpx::error::bad_parameter, "hpx::collectives::reduce_there",
                 "the generation number shouldn't be zero"));
         }
 

--- a/libs/full/collectives/include/hpx/collectives/reduce_direct.hpp
+++ b/libs/full/collectives/include/hpx/collectives/reduce_direct.hpp
@@ -299,7 +299,8 @@ namespace hpx { namespace lcos {
         if (ids.empty())
         {
             return hpx::make_exceptional_future<action_result>(
-                HPX_GET_EXCEPTION(bad_parameter, "hpx::lcos::reduce",
+                HPX_GET_EXCEPTION(hpx::error::bad_parameter,
+                    "hpx::lcos::reduce",
                     "empty list of targets for reduce operation"));
         }
 

--- a/libs/full/collectives/include/hpx/collectives/scatter.hpp
+++ b/libs/full/collectives/include/hpx/collectives/scatter.hpp
@@ -281,7 +281,7 @@ namespace hpx { namespace collectives {
         if (generation == 0)
         {
             return hpx::make_exceptional_future<T>(HPX_GET_EXCEPTION(
-                hpx::bad_parameter, "hpx::collectives::scatter_from",
+                hpx::error::bad_parameter, "hpx::collectives::scatter_from",
                 "the generation number shouldn't be zero"));
         }
 
@@ -341,7 +341,7 @@ namespace hpx { namespace collectives {
         if (generation == 0)
         {
             return hpx::make_exceptional_future<T>(HPX_GET_EXCEPTION(
-                hpx::bad_parameter, "hpx::collectives::scatter_to",
+                hpx::error::bad_parameter, "hpx::collectives::scatter_to",
                 "the generation number shouldn't be zero"));
         }
 

--- a/libs/full/collectives/src/channel_communicator.cpp
+++ b/libs/full/collectives/src/channel_communicator.cpp
@@ -74,7 +74,7 @@ namespace hpx { namespace collectives {
                 bool result = f.get();
                 if (!result)
                 {
-                    HPX_THROW_EXCEPTION(bad_parameter,
+                    HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
                         "hpx::collectives::detail::create_channel_communicator",
                         hpx::util::format(
                             "the given base name for the communicator "

--- a/libs/full/collectives/src/create_communicator.cpp
+++ b/libs/full/collectives/src/create_communicator.cpp
@@ -76,7 +76,7 @@ namespace hpx { namespace collectives {
                     bool result = f.get();
                     if (!result)
                     {
-                        HPX_THROW_EXCEPTION(bad_parameter,
+                        HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
                             "hpx::collectives::detail::create_communicator",
                             hpx::util::format(
                                 "the given base name for the communicator "

--- a/libs/full/collectives/src/detail/communication_set_node.cpp
+++ b/libs/full/collectives/src/detail/communication_set_node.cpp
@@ -167,7 +167,7 @@ namespace hpx { namespace lcos { namespace detail {
                 bool result = f.get();
                 if (!result)
                 {
-                    HPX_THROW_EXCEPTION(bad_parameter,
+                    HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
                         "hpx::lcos::detail::register_communication_set_name",
                         "the given base name for the communication_set_node "
                         "operation was already registered: {}",

--- a/libs/full/components/include/hpx/components/client_base.hpp
+++ b/libs/full/components/include/hpx/components/client_base.hpp
@@ -453,7 +453,8 @@ namespace hpx { namespace components {
         {
             if (!shared_state_)
             {
-                HPX_THROW_EXCEPTION(no_state, "client_base::get_gid",
+                HPX_THROW_EXCEPTION(hpx::error::no_state,
+                    "client_base::get_gid",
                     "this client_base has no valid shared state");
             }
 
@@ -486,7 +487,7 @@ namespace hpx { namespace components {
         {
             if (!shared_state_)
             {
-                HPX_THROW_EXCEPTION(no_state, "client_base::wait",
+                HPX_THROW_EXCEPTION(hpx::error::no_state, "client_base::wait",
                     "this client_base has no valid shared state");
                 return;
             }
@@ -501,7 +502,7 @@ namespace hpx { namespace components {
         {
             if (!shared_state_)
             {
-                HPX_THROW_EXCEPTION(no_state,
+                HPX_THROW_EXCEPTION(hpx::error::no_state,
                     "client_base<Derived, Stub>::get_exception_ptr",
                     "this client has no valid shared state");
             }
@@ -531,7 +532,7 @@ namespace hpx { namespace components {
 
             if (!shared_state_)
             {
-                HPX_THROW_EXCEPTION(no_state, "client_base::then",
+                HPX_THROW_EXCEPTION(hpx::error::no_state, "client_base::then",
                     "this client_base has no valid shared state");
                 return hpx::future<result_type>();
             }
@@ -586,7 +587,8 @@ namespace hpx { namespace components {
         {
             if (!shared_state_)
             {
-                HPX_THROW_EXCEPTION(no_state, "client_base::register_as",
+                HPX_THROW_EXCEPTION(hpx::error::no_state,
+                    "client_base::register_as",
                     "this client_base has no valid shared state");
             }
 

--- a/libs/full/components/include/hpx/components/get_ptr.hpp
+++ b/libs/full/components/include/hpx/components/get_ptr.hpp
@@ -100,7 +100,7 @@ namespace hpx {
             if (agas::get_locality_id() !=
                 naming::get_locality_id_from_gid(addr.locality_))
             {
-                HPX_THROW_EXCEPTION(bad_parameter,
+                HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
                     "hpx::get_ptr_postproc<Component, Deleter>",
                     "the given component id does not belong to a local object");
                 return std::shared_ptr<Component>();
@@ -108,7 +108,7 @@ namespace hpx {
 
             if (!traits::component_type_is_compatible<Component>::call(addr))
             {
-                HPX_THROW_EXCEPTION(bad_component_type,
+                HPX_THROW_EXCEPTION(hpx::error::bad_component_type,
                     "hpx::get_ptr_postproc<Component, Deleter>",
                     "requested component type does not match the given "
                     "component id");

--- a/libs/full/components/src/basename_registration.cpp
+++ b/libs/full/components/src/basename_registration.cpp
@@ -75,8 +75,8 @@ namespace hpx {
     {    // -V813
         if (basename.empty())
         {
-            HPX_THROW_EXCEPTION(bad_parameter, "hpx::find_all_from_basename",
-                "no basename specified");
+            HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
+                "hpx::find_all_from_basename", "no basename specified");
         }
 
         std::vector<hpx::future<hpx::id_type>> results;
@@ -94,8 +94,8 @@ namespace hpx {
     {    // -V813
         if (basename.empty())
         {
-            HPX_THROW_EXCEPTION(bad_parameter, "hpx::find_from_basename",
-                "no basename specified");
+            HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
+                "hpx::find_from_basename", "no basename specified");
         }
 
         std::vector<hpx::future<hpx::id_type>> results;
@@ -114,8 +114,8 @@ namespace hpx {
     {
         if (basename.empty())
         {
-            HPX_THROW_EXCEPTION(bad_parameter, "hpx::find_from_basename",
-                "no basename specified");
+            HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
+                "hpx::find_from_basename", "no basename specified");
         }
 
         if (sequence_nr == ~static_cast<std::size_t>(0))
@@ -133,8 +133,8 @@ namespace hpx {
     {
         if (basename.empty())
         {
-            HPX_THROW_EXCEPTION(bad_parameter, "hpx::register_with_basename",
-                "no basename specified");
+            HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
+                "hpx::register_with_basename", "no basename specified");
         }
 
         if (sequence_nr == ~static_cast<std::size_t>(0))
@@ -163,8 +163,8 @@ namespace hpx {
     {    // -V813
         if (basename.empty())
         {
-            HPX_THROW_EXCEPTION(bad_parameter, "hpx::unregister_with_basename",
-                "no basename specified");
+            HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
+                "hpx::unregister_with_basename", "no basename specified");
         }
 
         if (sequence_nr == ~static_cast<std::size_t>(0))

--- a/libs/full/components_base/include/hpx/components_base/server/create_component.hpp
+++ b/libs/full/components_base/include/hpx/components_base/server/create_component.hpp
@@ -15,6 +15,7 @@
 #include <hpx/naming_base/address.hpp>
 
 #include <cstddef>
+#include <memory>
 #include <utility>
 #include <vector>
 
@@ -30,7 +31,8 @@ namespace hpx { namespace components { namespace server {
             get_component_type<typename Component::wrapped_type>();
         if (!enabled(type))
         {
-            HPX_THROW_EXCEPTION(bad_request, "components::server::::create",
+            HPX_THROW_EXCEPTION(hpx::error::bad_request,
+                "components::server::::create",
                 "the component is disabled for this locality ({})",
                 get_component_type_name(type));
             return naming::invalid_gid;
@@ -53,10 +55,10 @@ namespace hpx { namespace components { namespace server {
         if (!gid)
         {
             c->finalize();
-            c->~Component();
+            std::destroy_at(c);
             component_heap<Component>().free(c, 1);
 
-            HPX_THROW_EXCEPTION(hpx::unknown_component_address,
+            HPX_THROW_EXCEPTION(hpx::error::unknown_component_address,
                 "create<Component>", "can't assign global id");
         }
         ++instance_count(type);
@@ -72,7 +74,7 @@ namespace hpx { namespace components { namespace server {
             get_component_type<typename Component::wrapped_type>();
         if (!enabled(type))
         {
-            HPX_THROW_EXCEPTION(bad_request,
+            HPX_THROW_EXCEPTION(hpx::error::bad_request,
                 "components::server::create_migrated",
                 "the component is disabled for this locality ({})",
                 get_component_type_name(type));
@@ -105,10 +107,10 @@ namespace hpx { namespace components { namespace server {
         }
 
         c->finalize();
-        c->~Component();
+        std::destroy_at(c);
         component_heap<Component>().free(c, 1);
 
-        HPX_THROW_EXCEPTION(hpx::duplicate_component_address,
+        HPX_THROW_EXCEPTION(hpx::error::duplicate_component_address,
             "create<Component>(naming::gid_type, ctor)",
             "the global id {} is already bound to a different component "
             "instance",
@@ -127,7 +129,8 @@ namespace hpx { namespace components { namespace server {
         std::vector<naming::gid_type> gids;
         if (!enabled(type))
         {
-            HPX_THROW_EXCEPTION(bad_request, "components::server::bulk_create",
+            HPX_THROW_EXCEPTION(hpx::error::bad_request,
+                "components::server::bulk_create",
                 "the component is disabled for this locality ({})",
                 get_component_type_name(type));
             return gids;
@@ -150,8 +153,8 @@ namespace hpx { namespace components { namespace server {
                 if (!gid)
                 {
                     c->finalize();
-                    c->~Component();
-                    HPX_THROW_EXCEPTION(hpx::unknown_component_address,
+                    std::destroy_at(c);
+                    HPX_THROW_EXCEPTION(hpx::error::unknown_component_address,
                         "bulk_create<Component>", "can't assign global id");
                 }
                 gids.push_back(HPX_MOVE(gid));
@@ -166,7 +169,7 @@ namespace hpx { namespace components { namespace server {
             for (std::size_t i = 0; i != succeeded; ++i, ++storage_it)
             {
                 storage_it->finalize();
-                storage_it->~Component();
+                std::destroy_at(storage_it);
                 --instance_count(type);
             }
             component_heap<Component>().free(storage, count);

--- a/libs/full/components_base/include/hpx/components_base/server/fixed_component_base.hpp
+++ b/libs/full/components_base/include/hpx/components_base/server/fixed_component_base.hpp
@@ -79,7 +79,7 @@ namespace hpx { namespace components {
         {
             if (assign_gid)
             {
-                HPX_THROW_EXCEPTION(bad_parameter,
+                HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
                     "fixed_component_base::get_base_gid",
                     "fixed_components must be assigned new gids on creation");
                 return naming::invalid_gid;
@@ -101,7 +101,7 @@ namespace hpx { namespace components {
                     naming::gid_type g = gid_;
                     gid_ = naming::gid_type();    // invalidate GID
 
-                    HPX_THROW_EXCEPTION(duplicate_component_address,
+                    HPX_THROW_EXCEPTION(hpx::error::duplicate_component_address,
                         "fixed_component_base<Component>::get_base_gid",
                         "could not bind_gid(local): {}", g);
                 }
@@ -130,7 +130,7 @@ namespace hpx { namespace components {
         {
             if (gid_)
             {
-                HPX_THROWS_IF(ec, invalid_status,
+                HPX_THROWS_IF(ec, hpx::error::invalid_status,
                     "fixed_component_base::set_locality_id",
                     "can't change locality_id after GID has already been "
                     "registered");

--- a/libs/full/components_base/include/hpx/components_base/server/managed_component_base.hpp
+++ b/libs/full/components_base/include/hpx/components_base/server/managed_component_base.hpp
@@ -23,6 +23,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <memory>
 #include <stdexcept>
 #include <type_traits>
 #include <utility>
@@ -89,7 +90,7 @@ namespace hpx { namespace components {
                 // The managed_component's controls the lifetime of the
                 // component implementation.
                 back_ptr->finalize();
-                back_ptr->~BackPtr();
+                std::destroy_at(back_ptr);
                 component_heap<typename BackPtr::wrapped_type>().free(back_ptr);
             }
         };
@@ -385,7 +386,7 @@ namespace hpx { namespace components {
         {
             if (!component_)
             {
-                HPX_THROW_EXCEPTION(invalid_status,
+                HPX_THROW_EXCEPTION(hpx::error::invalid_status,
                     "managed_component<Component, Derived>::get_checked",
                     "component pointer ({}) is invalid (gid: {})",
                     components::get_component_type_name(
@@ -399,7 +400,7 @@ namespace hpx { namespace components {
         {
             if (!component_)
             {
-                HPX_THROW_EXCEPTION(invalid_status,
+                HPX_THROW_EXCEPTION(hpx::error::invalid_status,
                     "managed_component<Component, Derived>::get_checked",
                     "component pointer ({}) is invalid (gid: {})",
                     components::get_component_type_name(
@@ -447,7 +448,7 @@ namespace hpx { namespace components {
         {
             if (assign_gid)
             {
-                HPX_THROW_EXCEPTION(bad_parameter,
+                HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
                     "managed_component::get_base_gid",
                     "managed_components must be assigned new gids on creation");
                 return naming::invalid_gid;

--- a/libs/full/components_base/include/hpx/components_base/server/migration_support.hpp
+++ b/libs/full/components_base/include/hpx/components_base/server/migration_support.hpp
@@ -196,7 +196,8 @@ namespace hpx { namespace components {
                         l.unlock();
                         return std::make_pair(false,
                             hpx::make_exceptional_future<
-                                void>(HPX_GET_EXCEPTION(invalid_status,
+                                void>(HPX_GET_EXCEPTION(
+                                hpx::error::invalid_status,
                                 "migration_support::mark_as_migrated",
                                 "migration operation is already in flight")));
                     }

--- a/libs/full/components_base/src/component_type.cpp
+++ b/libs/full/components_base/src/component_type.cpp
@@ -199,7 +199,7 @@ namespace hpx { namespace components {
                 type = agas::register_factory(agas::get_locality_id(), name);
                 if (component_invalid == type)
                 {
-                    HPX_THROW_EXCEPTION(duplicate_component_id,
+                    HPX_THROW_EXCEPTION(hpx::error::duplicate_component_id,
                         "get_agas_component_type",
                         "the component name {} is already in use", name);
                 }

--- a/libs/full/components_base/src/server/component_base.cpp
+++ b/libs/full/components_base/src/server/component_base.cpp
@@ -51,7 +51,7 @@ namespace hpx { namespace components { namespace detail {
                     naming::gid_type g = gid_;
                     gid_ = naming::invalid_gid;    // invalidate GID
 
-                    HPX_THROW_EXCEPTION(duplicate_component_address,
+                    HPX_THROW_EXCEPTION(hpx::error::duplicate_component_address,
                         "component_base<Component>::get_base_gid",
                         "failed to bind id: {} to locality: {}", g,
                         agas::get_locality_id());
@@ -68,7 +68,7 @@ namespace hpx { namespace components { namespace detail {
                     naming::gid_type g = gid_;
                     gid_ = naming::invalid_gid;    // invalidate GID
 
-                    HPX_THROW_EXCEPTION(duplicate_component_address,
+                    HPX_THROW_EXCEPTION(hpx::error::duplicate_component_address,
                         "component_base<Component>::get_base_gid",
                         "failed to rebind id: {} to locality: {}", g,
                         agas::get_locality_id());

--- a/libs/full/components_base/src/server/one_size_heap_list.cpp
+++ b/libs/full/components_base/src/server/one_size_heap_list.cpp
@@ -52,8 +52,8 @@ namespace hpx { namespace util {
         if (HPX_UNLIKELY(0 == count))
         {
             guard.unlock();
-            HPX_THROW_EXCEPTION(
-                bad_parameter, name() + "::alloc", "cannot allocate 0 objects");
+            HPX_THROW_EXCEPTION(hpx::error::bad_parameter, name() + "::alloc",
+                "cannot allocate 0 objects");
         }
 
         void* p = nullptr;
@@ -116,7 +116,8 @@ namespace hpx { namespace util {
             {
                 // out of memory
                 guard.unlock();
-                HPX_THROW_EXCEPTION(out_of_memory, name() + "::alloc",
+                HPX_THROW_EXCEPTION(hpx::error::out_of_memory,
+                    name() + "::alloc",
                     "new heap failed to allocate {1} objects", count);
             }
 
@@ -195,7 +196,7 @@ namespace hpx { namespace util {
 
         ul.unlock();
 
-        HPX_THROW_EXCEPTION(bad_parameter, name() + "::free",
+        HPX_THROW_EXCEPTION(hpx::error::bad_parameter, name() + "::free",
             "pointer {1} was not allocated by this {2}", p, name());
     }
 

--- a/libs/full/init_runtime/src/hpx_init.cpp
+++ b/libs/full/init_runtime/src/hpx_init.cpp
@@ -899,7 +899,8 @@ namespace hpx {
                         &hpx::detail::pre_main, &hpx::detail::post_main));
                     break;
 #else
-                    HPX_THROW_EXCEPTION(invalid_status, "run_or_start",
+                    HPX_THROW_EXCEPTION(hpx::error::invalid_status,
+                        "run_or_start",
                         "Attempted to start the runtime in the mode \"{1}\", "
                         "but HPX was compiled with "
                         "HPX_WITH_DISTRIBUTED_RUNTIME=OFF, and \"{1}\" "
@@ -949,14 +950,14 @@ namespace hpx {
     {
         if (!threads::get_self_ptr())
         {
-            HPX_THROWS_IF(ec, invalid_status, "hpx::finalize",
+            HPX_THROWS_IF(ec, hpx::error::invalid_status, "hpx::finalize",
                 "this function can be called from an HPX thread only");
             return -1;
         }
 
         if (!is_running())
         {
-            HPX_THROWS_IF(ec, invalid_status, "hpx::finalize",
+            HPX_THROWS_IF(ec, hpx::error::invalid_status, "hpx::finalize",
                 "the runtime system is not active (did you already "
                 "call finalize?)");
             return -1;
@@ -984,7 +985,7 @@ namespace hpx {
         runtime* rt = get_runtime_ptr();
         if (nullptr == rt)
         {
-            HPX_THROWS_IF(ec, invalid_status, "hpx::finalize",
+            HPX_THROWS_IF(ec, hpx::error::invalid_status, "hpx::finalize",
                 "the runtime system is not active (did you already "
                 "call hpx::stop?)");
             return -1;
@@ -1001,14 +1002,14 @@ namespace hpx {
 #if defined(HPX_HAVE_DISTRIBUTED_RUNTIME)
         if (!threads::get_self_ptr())
         {
-            HPX_THROWS_IF(ec, invalid_status, "hpx::disconnect",
+            HPX_THROWS_IF(ec, hpx::error::invalid_status, "hpx::disconnect",
                 "this function can be called from an HPX thread only");
             return -1;
         }
 
         if (!is_running())
         {
-            HPX_THROWS_IF(ec, invalid_status, "hpx::disconnect",
+            HPX_THROWS_IF(ec, hpx::error::invalid_status, "hpx::disconnect",
                 "the runtime system is not active (did you already "
                 "call finalize?)");
             return -1;
@@ -1039,7 +1040,7 @@ namespace hpx {
 
         if (nullptr == p)
         {
-            HPX_THROWS_IF(ec, invalid_status, "hpx::disconnect",
+            HPX_THROWS_IF(ec, hpx::error::invalid_status, "hpx::disconnect",
                 "the runtime system is not active (did you already "
                 "call finalize?)");
             return -1;

--- a/libs/full/init_runtime/src/pre_main.cpp
+++ b/libs/full/init_runtime/src/pre_main.cpp
@@ -145,7 +145,7 @@ namespace hpx { namespace detail {
                 naming::gid_type console_;
                 if (HPX_UNLIKELY(!agas_client.get_console_locality(console_)))
                 {
-                    HPX_THROW_EXCEPTION(network_error, "pre_main",
+                    HPX_THROW_EXCEPTION(hpx::error::network_error, "pre_main",
                         "no console locality registered");
                 }
 

--- a/libs/full/init_runtime/tests/unit/handled_exception.cpp
+++ b/libs/full/init_runtime/tests/unit/handled_exception.cpp
@@ -16,8 +16,8 @@ bool thrown_exception = false;
 void throw_hpx_exception()
 {
     thrown_exception = true;
-    HPX_THROW_EXCEPTION(
-        hpx::bad_request, "throw_hpx_exception", "testing HPX exception");
+    HPX_THROW_EXCEPTION(hpx::error::bad_request, "throw_hpx_exception",
+        "testing HPX exception");
 }
 
 HPX_PLAIN_ACTION(throw_hpx_exception, throw_hpx_exception_action)

--- a/libs/full/init_runtime/tests/unit/unhandled_exception.cpp
+++ b/libs/full/init_runtime/tests/unit/unhandled_exception.cpp
@@ -15,8 +15,8 @@ bool thrown_exception = false;
 void throw_hpx_exception()
 {
     thrown_exception = true;
-    HPX_THROW_EXCEPTION(
-        hpx::bad_request, "throw_hpx_exception", "testing HPX exception");
+    HPX_THROW_EXCEPTION(hpx::error::bad_request, "throw_hpx_exception",
+        "testing HPX exception");
 }
 
 HPX_PLAIN_ACTION(throw_hpx_exception, throw_hpx_exception_action)

--- a/libs/full/lcos_distributed/tests/unit/promise.cpp
+++ b/libs/full/lcos_distributed/tests/unit/promise.cpp
@@ -28,7 +28,7 @@ HPX_PLAIN_ACTION(test, test_action)
 int test_error()
 {
     HPX_THROW_EXCEPTION(
-        hpx::not_implemented, "test_error", "throwing test exception");
+        hpx::error::not_implemented, "test_error", "throwing test exception");
     return 42;
 }
 HPX_PLAIN_ACTION(test_error, test_error_action)

--- a/libs/full/lcos_distributed/tests/unit/test_allocator.hpp
+++ b/libs/full/lcos_distributed/tests/unit/test_allocator.hpp
@@ -108,7 +108,7 @@ public:
 
     void destroy(pointer p)
     {
-        p->~T();
+        std::destroy_at(p);
     }
 
     friend bool operator==(test_allocator const& x, test_allocator const& y)

--- a/libs/full/naming/src/credit_handling.cpp
+++ b/libs/full/naming/src/credit_handling.cpp
@@ -34,73 +34,73 @@
 #include <mutex>
 #include <utility>
 
-///////////////////////////////////////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////////
 //
 //          Here is how our distributed garbage collection works
 //
 // Each id_type instance - while always referring to some (possibly remote)
 // entity - can either be 'managed' or 'unmanaged'. If an id_type instance is
 // 'unmanaged' it does not perform any garbage collection. Otherwise (if it's
-// 'managed'), all of its copies are globally tracked which allows to
-// automatically delete the entity a particular id_type instance is referring
-// to after the last reference to it goes out of scope.
+// 'managed'), all of its copies are globally tracked, which allows to
+// automatically delete the entity a particular id_type instance is referring to
+// after the last reference to it goes out of scope.
 //
 // An id_type instance is essentially a shared_ptr<> maintaining two reference
 // counts: a local reference count and a global one. The local reference count
-// is incremented whenever the id_type instance is copied locally, and decremented
-// whenever one of the local copies goes out of scope. At the point when the last
-// local copy goes out of scope, it returns its current share of the global
-// reference count back to AGAS. The share of the global reference count owned
-// by all copies of an id_type instance on a single locality is called its
-// credit. Credits are issued in chunks which allows to create a global copy
-// of an id_type instance (like passing it to another locality) without needing
-// to talk to AGAS to request a global reference count increment. The referenced
-// entity is freed when the global reference count falls to zero.
+// is incremented whenever the id_type instance is copied locally, and
+// decremented whenever one of the local copies goes out of scope. At the point
+// when the last local copy goes out of scope, it returns its current share of
+// the global reference count back to AGAS. The share of the global reference
+// count owned by all copies of an id_type instance on a single locality is
+// called its credit. Credits are issued in chunks, which allows to create a
+// global copy of an id_type instance (like passing it to another locality)
+// without needing to talk to AGAS to request a global reference count
+// increment. The referenced entity is freed when the global reference count
+// falls to zero.
 //
 // Any newly created object assumes an initial credit. This credit is not
 // accounted for by AGAS as long as no global increment or decrement requests
-// are received. It is important to understand that there is no way to distinguish
-// whether an object has already been deleted (and therefore no entry exists in
-// the table storing the global reference count for this object) or whether the
-// object is still alive but no increment/decrement requests have been received
-// by AGAS yet. While this is a pure optimization to avoid storing global
-// reference counts for all objects, it has implications for the implemented
-// garbage collection algorithms at large.
+// are received. It is important to understand that there is no way to
+// distinguish whether an object has already been deleted (and therefore no
+// entry exists in the table storing the global reference count for this object)
+// or whether the object is still alive but no increment/decrement requests have
+// been received by AGAS yet. While this is a pure optimization to avoid storing
+// global reference counts for all objects, it has implications for the
+// implemented garbage collection algorithms at large.
 //
 // As long as an id_type instance is not sent to another locality (a locality
 // different from the initial locality creating the referenced entity), all
-// lifetime management for this entity can be handled purely local without
-// even talking to AGAS.
+// lifetime management for this entity can be handled purely local without even
+// talking to AGAS.
 //
 // Sending an id_type instance to another locality (which includes using an
-// id_type as the destination for an action) splits the current credit into
-// two parts. One part stays with the id_type on the sending locality, the
-// other part is sent along to the destination locality where it turns into the
-// global credit associated with the remote copy of the id_type. As stated
-// above, this allows to avoid talking to AGAS for incrementing the global
-// reference count as long as there is sufficient global credit left in order
-// to be split.
+// id_type as the destination for an action) splits the current credit into two
+// parts. One part stays with the id_type on the sending locality, the other
+// part is sent along to the destination locality where it turns into the global
+// credit associated with the remote copy of the id_type. As stated above, this
+// allows to avoid talking to AGAS for incrementing the global reference count
+// as long as there is sufficient global credit left in order to be split.
 //
-// The current share of the global credit associated with an id_type instance
-// is encoded in the bits 88..92 of the underlying gid_type (encoded as the
-// logarithm to the base 2 of the credit value). Bit 94 is a flag which is set
-// whenever the credit is valid. Bit 95 encodes whether the given id_type
-// has been split at any time. This information is needed to be able to decide
+// The current share of the global credit associated with an id_type instance is
+// encoded in the bits 88..92 of the underlying gid_type (encoded as the
+// logarithm to the base 2 of the credit value). Bit 94 is a flag that is set
+// whenever the credit is valid. Bit 95 encodes whether the given id_type has
+// been split at any time. This information is needed to be able to decide
 // whether a garbage collection can be assumed to be a purely local operation.
 // Bit 93 is used by the locking scheme for gid_types.
 //
 // Credit splitting is performed without any additional AGAS traffic as long as
 // sufficient credit is available. If the credit of the id_type to be split is
-// exhausted (reaches the value '1') it has to be replenished. This operation
-// is performed synchronously. This is done to ensure that AGAS has accounted
-// for the requested credit increase.
+// exhausted (reaches the value '1') it has to be replenished. This operation is
+// performed synchronously. This is done to ensure that AGAS has accounted for
+// the requested credit increase.
 //
-// Note that both the id_type instance staying behind and the one sent along
-// are replenished before sending out the parcel at the sending locality.
+// Note that both the id_type instance staying behind and the one sent along are
+// replenished before sending out the parcel at the sending locality.
 //
-///////////////////////////////////////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////////
 
-///////////////////////////////////////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////////
 namespace hpx::naming::detail {
 
     struct gid_serialization_data;
@@ -108,7 +108,7 @@ namespace hpx::naming::detail {
 
 HPX_IS_BITWISE_SERIALIZABLE(hpx::naming::detail::gid_serialization_data)
 
-///////////////////////////////////////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////////
 namespace hpx::naming {
 
     ///////////////////////////////////////////////////////////////////////////
@@ -489,7 +489,7 @@ namespace hpx::naming {
             if (ar.try_get_extra_data<util::checkpointing_tag>() != nullptr)
             {
                 // this is a check-pointing operation, we do not support this
-                HPX_THROW_EXCEPTION(invalid_status,
+                HPX_THROW_EXCEPTION(hpx::error::invalid_status,
                     "id_type_impl::preprocess_gid",
                     "can't check-point managed id_type's, use a component "
                     "client instead");
@@ -551,7 +551,8 @@ namespace hpx::naming {
                 ar.try_get_extra_data<util::checkpointing_tag>() != nullptr)
             {
                 // this is a check-pointing operation, we do not support this
-                HPX_THROW_EXCEPTION(invalid_status, "id_type_impl::save",
+                HPX_THROW_EXCEPTION(hpx::error::invalid_status,
+                    "id_type_impl::save",
                     "can't check-point managed id_type's, use a component "
                     "client instead");
             }
@@ -595,7 +596,8 @@ namespace hpx::naming {
             if (hpx::id_type::management_type::unmanaged != data.type_ &&
                 hpx::id_type::management_type::managed != data.type_)
             {
-                HPX_THROW_EXCEPTION(version_too_new, "id_type::load",
+                HPX_THROW_EXCEPTION(hpx::error::version_too_new,
+                    "id_type::load",
                     "trying to load id_type with unknown deleter");
             }
 

--- a/libs/full/parcelport_tcp/src/connection_handler_tcp.cpp
+++ b/libs/full/parcelport_tcp/src/connection_handler_tcp.cpp
@@ -67,7 +67,8 @@ namespace hpx::parcelset::policies::tcp {
     {
         if (here_.type() != std::string("tcp"))
         {
-            HPX_THROW_EXCEPTION(network_error, "tcp::parcelport::parcelport",
+            HPX_THROW_EXCEPTION(hpx::error::network_error,
+                "tcp::parcelport::parcelport",
                 "this parcelport was instantiated to represent an unexpected "
                 "locality type: {}",
                 here_.type());
@@ -118,8 +119,8 @@ namespace hpx::parcelset::policies::tcp {
         if (errors.size() == tried)
         {
             // all attempts failed
-            HPX_THROW_EXCEPTION(
-                network_error, "tcp::parcelport::run", errors.get_message());
+            HPX_THROW_EXCEPTION(hpx::error::network_error,
+                "tcp::parcelport::run", errors.get_message());
             return false;
         }
         return true;
@@ -202,7 +203,7 @@ namespace hpx::parcelset::policies::tcp {
                 sender_connection->socket().close();
                 sender_connection.reset();
 
-                HPX_THROWS_IF(ec, network_error,
+                HPX_THROWS_IF(ec, hpx::error::network_error,
                     "tcp::connection_handler::get_connection", e.what());
                 return sender_connection;
             }
@@ -216,7 +217,7 @@ namespace hpx::parcelset::policies::tcp {
             if (tolerate_node_faults())
                 return sender_connection;
 
-            HPX_THROWS_IF(ec, network_error,
+            HPX_THROWS_IF(ec, hpx::error::network_error,
                 "tcp::connection_handler::get_connection",
                 "{} (while trying to connect to: {})", error.message(), l);
             return sender_connection;

--- a/libs/full/parcelset/include/hpx/parcelset/connection_cache.hpp
+++ b/libs/full/parcelset/include/hpx/parcelset/connection_cache.hpp
@@ -78,7 +78,7 @@ namespace hpx { namespace util {
         {
             if (max_connections_per_locality_ > max_connections_)
             {
-                HPX_THROW_EXCEPTION(bad_parameter,
+                HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
                     "connection_cache::connection_cache",
                     "the maximum number of connections per locality cannot "
                     "exceed the overall maximum number of connections");

--- a/libs/full/parcelset/include/hpx/parcelset/decode_parcels.hpp
+++ b/libs/full/parcelset/include/hpx/parcelset/decode_parcels.hpp
@@ -198,7 +198,7 @@ namespace hpx::parcelset {
                             (naming::get_locality_id_from_gid(
                                  p.destination_locality()) != here))
                         {
-                            HPX_THROW_EXCEPTION(invalid_status,
+                            HPX_THROW_EXCEPTION(hpx::error::invalid_status,
                                 "hpx::parcelset::decode_message",
                                 "parcel destination does not match locality "
                                 "which received the parcel ({}), {}",
@@ -307,7 +307,7 @@ namespace hpx::parcelset {
                 // serialization library as otherwise we will loose the
                 // e.what() description of the problem, due to slicing.
                 hpx::throw_with_info(
-                    hpx::exception(serialization_error, e.what()));
+                    hpx::exception(hpx::error::serialization_error, e.what()));
             }
         }
         catch (...)

--- a/libs/full/parcelset/include/hpx/parcelset/encode_parcels.hpp
+++ b/libs/full/parcelset/include/hpx/parcelset/encode_parcels.hpp
@@ -282,7 +282,7 @@ namespace hpx::parcelset {
                 // serialization library as otherwise we will loose the
                 // e.what() description of the problem, due to slicing.
                 hpx::throw_with_info(
-                    hpx::exception(serialization_error, e.what()));
+                    hpx::exception(hpx::error::serialization_error, e.what()));
                 return 0;
             }
         }

--- a/libs/full/parcelset/include/hpx/parcelset/parcelport_impl.hpp
+++ b/libs/full/parcelset/include/hpx/parcelset/parcelport_impl.hpp
@@ -268,7 +268,8 @@ namespace hpx::parcelset {
         {
             if (parcels.size() != handlers.size())
             {
-                HPX_THROW_EXCEPTION(bad_parameter, "parcelport::put_parcels",
+                HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
+                    "parcelport::put_parcels",
                     "mismatched number of parcels and handlers");
                 return;
             }
@@ -421,7 +422,7 @@ namespace hpx::parcelset {
                 break;
             }
 
-            HPX_THROW_EXCEPTION(bad_parameter,
+            HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
                 "parcelport_impl::get_connection_cache_statistics",
                 "invalid connection cache statistics type");
             return 0;
@@ -453,7 +454,8 @@ namespace hpx::parcelset {
             {
                 HPX_UNUSED(dest);
                 HPX_UNUSED(p);
-                HPX_THROW_EXCEPTION(network_error, "send_early_parcel",
+                HPX_THROW_EXCEPTION(hpx::error::network_error,
+                    "send_early_parcel",
                     "This parcelport does not support sending early parcels");
             }
         }

--- a/libs/full/parcelset/src/parcel.cpp
+++ b/libs/full/parcelset/src/parcel.cpp
@@ -426,7 +426,8 @@ namespace hpx::parcelset::detail {
         if (HPX_UNLIKELY(
                 !components::types_are_compatible(data_.addr_.type_, comptype)))
         {
-            HPX_THROW_EXCEPTION(bad_component_type, "parcel::determine_lva",
+            HPX_THROW_EXCEPTION(hpx::error::bad_component_type,
+                "parcel::determine_lva",
                 " types are not compatible: destination_type({}) "
                 "action_type({}) parcel ({})",
                 data_.addr_.type_, comptype, *this);

--- a/libs/full/parcelset/src/parcelhandler.cpp
+++ b/libs/full/parcelset/src/parcelhandler.cpp
@@ -478,7 +478,7 @@ namespace hpx::parcelset {
             strm << "\t [" << pp.second->here() << "]\n";
         }
 
-        HPX_THROW_EXCEPTION(network_error,
+        HPX_THROW_EXCEPTION(hpx::error::network_error,
             "parcelhandler::find_appropriate_destination",
             "The locality gid cannot be resolved to a valid endpoint. "
             "No valid parcelport configured. Detailed information:\n{}",
@@ -673,7 +673,8 @@ namespace hpx::parcelset {
 
         if (parcels.size() != handlers.size())
         {
-            HPX_THROW_EXCEPTION(bad_parameter, "parcelhandler::put_parcels",
+            HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
+                "parcelhandler::put_parcels",
                 "mismatched number of parcels and handlers");
             return;
         }
@@ -738,7 +739,8 @@ namespace hpx::parcelset {
             // make sure all parcels go to the same locality
             if (parcels[0].destination_locality() != p.destination_locality())
             {
-                HPX_THROW_EXCEPTION(bad_parameter, "parcelhandler::put_parcels",
+                HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
+                    "parcelhandler::put_parcels",
                     "mismatched destinations, all parcels are expected to "
                     "target the same locality");
                 return;
@@ -902,7 +904,7 @@ namespace hpx::parcelset {
                         ec = make_success_code();
                     else
                         ec = make_error_code(
-                            bad_parameter, throwmode::lightweight);
+                            hpx::error::bad_parameter, throwmode::lightweight);
                 }
                 return (*it).second.get();
             }
@@ -918,7 +920,7 @@ namespace hpx::parcelset {
                 l.unlock();
                 if (!r.second)
                 {
-                    HPX_THROWS_IF(ec, internal_server_error,
+                    HPX_THROWS_IF(ec, hpx::error::internal_server_error,
                         "parcelhandler::get_message_handler",
                         "could not store empty message handler");
                     return nullptr;
@@ -932,7 +934,7 @@ namespace hpx::parcelset {
             l.unlock();
             if (!r.second)
             {
-                HPX_THROWS_IF(ec, internal_server_error,
+                HPX_THROWS_IF(ec, hpx::error::internal_server_error,
                     "parcelhandler::get_message_handler",
                     "could not store newly created message handler");
                 return nullptr;
@@ -944,11 +946,12 @@ namespace hpx::parcelset {
             l.unlock();
             if (&ec != &throws)
             {
-                ec = make_error_code(bad_parameter, throwmode::lightweight);
+                ec = make_error_code(
+                    hpx::error::bad_parameter, throwmode::lightweight);
             }
             else
             {
-                HPX_THROW_EXCEPTION(bad_parameter,
+                HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
                     "parcelhandler::get_message_handler",
                     "couldn't find an appropriate message handler");
             }

--- a/libs/full/parcelset_base/src/locality.cpp
+++ b/libs/full/parcelset_base/src/locality.cpp
@@ -118,7 +118,7 @@ namespace hpx { namespace parcelset {
 
         impl_->save(ar);
 #else
-        HPX_THROW_EXCEPTION(invalid_status, "locality::save",
+        HPX_THROW_EXCEPTION(hpx::error::invalid_status, "locality::save",
             "this shouldn't be called if networking is disabled");
         HPX_UNUSED(ar);
 #endif
@@ -138,7 +138,7 @@ namespace hpx { namespace parcelset {
         impl_->load(ar);
         HPX_ASSERT(impl_->valid());
 #else
-        HPX_THROW_EXCEPTION(invalid_status, "locality::load",
+        HPX_THROW_EXCEPTION(hpx::error::invalid_status, "locality::load",
             "this shouldn't be called if networking is disabled");
         HPX_UNUSED(ar);
 #endif

--- a/libs/full/performance_counters/include/hpx/performance_counters/counters_fwd.hpp
+++ b/libs/full/performance_counters/include/hpx/performance_counters/counters_fwd.hpp
@@ -383,7 +383,8 @@ namespace hpx { namespace performance_counters {
         {
             if (!status_is_valid(status_))
             {
-                HPX_THROWS_IF(ec, invalid_status, "counter_value::get_value<T>",
+                HPX_THROWS_IF(ec, hpx::error::invalid_status,
+                    "counter_value::get_value<T>",
                     "counter value is in invalid status");
                 return T();
             }
@@ -394,7 +395,7 @@ namespace hpx { namespace performance_counters {
             {
                 if (scaling_ == 0)
                 {
-                    HPX_THROWS_IF(ec, uninitialized_value,
+                    HPX_THROWS_IF(ec, hpx::error::uninitialized_value,
                         "counter_value::get_value<T>",
                         "scaling should not be zero");
                     return T();
@@ -471,14 +472,14 @@ namespace hpx { namespace performance_counters {
         {
             if (!status_is_valid(status_))
             {
-                HPX_THROWS_IF(ec, invalid_status,
+                HPX_THROWS_IF(ec, hpx::error::invalid_status,
                     "counter_values_array::get_value<T>",
                     "counter value is in invalid status");
                 return T();
             }
             if (index >= values_.size())
             {
-                HPX_THROWS_IF(ec, bad_parameter,
+                HPX_THROWS_IF(ec, hpx::error::bad_parameter,
                     "counter_values_array::get_value<T>",
                     "index out of bounds");
                 return T();
@@ -490,7 +491,7 @@ namespace hpx { namespace performance_counters {
             {
                 if (scaling_ == 0)
                 {
-                    HPX_THROWS_IF(ec, uninitialized_value,
+                    HPX_THROWS_IF(ec, hpx::error::uninitialized_value,
                         "counter_values_array::get_value<T>",
                         "scaling should not be zero");
                     return T();

--- a/libs/full/performance_counters/src/action_invocation_counter_discoverer.cpp
+++ b/libs/full/performance_counters/src/action_invocation_counter_discoverer.cpp
@@ -109,7 +109,7 @@ namespace hpx { namespace performance_counters {
                     strm << "  " << e.first << "\n";
                 }
 
-                HPX_THROWS_IF(ec, bad_parameter,
+                HPX_THROWS_IF(ec, hpx::error::bad_parameter,
                     "invocation_count_registry::counter_discoverer",
                     strm.str());
                 return false;
@@ -132,7 +132,7 @@ namespace hpx { namespace performance_counters {
                 types += "  " + e.first + "\n";
             }
 
-            HPX_THROWS_IF(ec, bad_parameter,
+            HPX_THROWS_IF(ec, hpx::error::bad_parameter,
                 "invocation_count_registry::counter_discoverer",
                 "action type {} does not match any known type, known action "
                 "types: \n{}",

--- a/libs/full/performance_counters/src/agas_namespace_action_code.cpp
+++ b/libs/full/performance_counters/src/agas_namespace_action_code.cpp
@@ -24,7 +24,7 @@ namespace hpx { namespace agas { namespace detail {
 
         if (p.objectname_ != "agas")
         {
-            HPX_THROWS_IF(ec, bad_parameter, "retrieve_action_code",
+            HPX_THROWS_IF(ec, hpx::error::bad_parameter, "retrieve_action_code",
                 "unknown performance counter (unrelated to AGAS)");
             return invalid_request;
         }
@@ -57,7 +57,7 @@ namespace hpx { namespace agas { namespace detail {
                 return symbol_namespace_services[i].code_;
         }
 
-        HPX_THROWS_IF(ec, bad_parameter, "retrieve_action_code",
+        HPX_THROWS_IF(ec, hpx::error::bad_parameter, "retrieve_action_code",
             "unknown performance counter (unrelated to AGAS)");
         return invalid_request;
     }
@@ -73,7 +73,8 @@ namespace hpx { namespace agas { namespace detail {
 
         if (p.objectname_ != "agas")
         {
-            HPX_THROWS_IF(ec, bad_parameter, "retrieve_action_service_code",
+            HPX_THROWS_IF(ec, hpx::error::bad_parameter,
+                "retrieve_action_service_code",
                 "unknown performance counter (unrelated to AGAS)");
             return invalid_request;
         }
@@ -106,7 +107,8 @@ namespace hpx { namespace agas { namespace detail {
                 return symbol_namespace_services[i].service_code_;
         }
 
-        HPX_THROWS_IF(ec, bad_parameter, "retrieve_action_service_code",
+        HPX_THROWS_IF(ec, hpx::error::bad_parameter,
+            "retrieve_action_service_code",
             "unknown performance counter (unrelated to AGAS)");
         return invalid_request;
     }

--- a/libs/full/performance_counters/src/component_namespace_counters.cpp
+++ b/libs/full/performance_counters/src/component_namespace_counters.cpp
@@ -145,7 +145,7 @@ namespace hpx { namespace agas { namespace server {
 
         if (p.objectname_ != "agas")
         {
-            HPX_THROW_EXCEPTION(bad_parameter,
+            HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
                 "component_namespace::statistics_counter",
                 "unknown performance counter (unrelated to AGAS)");
             return naming::invalid_gid;
@@ -166,7 +166,7 @@ namespace hpx { namespace agas { namespace server {
 
         if (code == invalid_request || target == detail::counter_target_invalid)
         {
-            HPX_THROW_EXCEPTION(bad_parameter,
+            HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
                 "component_namespace::statistics_counter",
                 "unknown performance counter (unrelated to AGAS)");
             return naming::invalid_gid;
@@ -220,7 +220,7 @@ namespace hpx { namespace agas { namespace server {
                 service.counter_data_.enable_all();
                 break;
             default:
-                HPX_THROW_EXCEPTION(bad_parameter,
+                HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
                     "component_namespace::statistics",
                     "bad action code while querying statistics");
                 return naming::invalid_gid;
@@ -272,7 +272,7 @@ namespace hpx { namespace agas { namespace server {
                 service.counter_data_.enable_all();
                 break;
             default:
-                HPX_THROW_EXCEPTION(bad_parameter,
+                HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
                     "component_namespace::statistics",
                     "bad action code while querying statistics");
                 return naming::invalid_gid;

--- a/libs/full/performance_counters/src/counter_creators.cpp
+++ b/libs/full/performance_counters/src/counter_creators.cpp
@@ -456,7 +456,8 @@ namespace hpx { namespace performance_counters {
 
         if (paths.parentinstance_is_basename_)
         {
-            HPX_THROWS_IF(ec, bad_parameter, "locality_raw_counter_creator",
+            HPX_THROWS_IF(ec, hpx::error::bad_parameter,
+                "locality_raw_counter_creator",
                 "invalid counter instance parent name: " +
                     paths.parentinstancename_);
             return naming::invalid_gid;
@@ -466,7 +467,8 @@ namespace hpx { namespace performance_counters {
             return detail::create_raw_counter(
                 info, f, ec);    // overall counter
 
-        HPX_THROWS_IF(ec, bad_parameter, "locality_raw_counter_creator",
+        HPX_THROWS_IF(ec, hpx::error::bad_parameter,
+            "locality_raw_counter_creator",
             "invalid counter instance name: " + paths.instancename_);
         return naming::invalid_gid;
     }
@@ -483,7 +485,7 @@ namespace hpx { namespace performance_counters {
 
         if (paths.parentinstance_is_basename_)
         {
-            HPX_THROWS_IF(ec, bad_parameter,
+            HPX_THROWS_IF(ec, hpx::error::bad_parameter,
                 "locality_raw_values_counter_creator",
                 "invalid counter instance parent name: " +
                     paths.parentinstancename_);
@@ -496,7 +498,8 @@ namespace hpx { namespace performance_counters {
                 info, f, ec);    // overall counter
         }
 
-        HPX_THROWS_IF(ec, bad_parameter, "locality_raw_values_counter_creator",
+        HPX_THROWS_IF(ec, hpx::error::bad_parameter,
+            "locality_raw_values_counter_creator",
             "invalid counter instance name: " + paths.instancename_);
         return naming::invalid_gid;
     }
@@ -538,7 +541,8 @@ namespace hpx { namespace performance_counters {
                 return action(agas_id, name).get_gid();
             }
             default:
-                HPX_THROWS_IF(ec, bad_parameter, "retrieve_statistics_counter",
+                HPX_THROWS_IF(ec, hpx::error::bad_parameter,
+                    "retrieve_statistics_counter",
                     "unknown counter agas counter name: " + name);
                 break;
             }
@@ -570,13 +574,15 @@ namespace hpx { namespace performance_counters {
 
         if (paths.objectname_ != "agas")
         {
-            HPX_THROWS_IF(ec, bad_parameter, "agas_raw_counter_creator",
+            HPX_THROWS_IF(ec, hpx::error::bad_parameter,
+                "agas_raw_counter_creator",
                 "unknown performance counter (unrelated to AGAS)");
             return naming::invalid_gid;
         }
         if (paths.parentinstance_is_basename_)
         {
-            HPX_THROWS_IF(ec, bad_parameter, "agas_raw_counter_creator",
+            HPX_THROWS_IF(ec, hpx::error::bad_parameter,
+                "agas_raw_counter_creator",
                 "invalid counter instance parent name: " +
                     paths.parentinstancename_);
             return naming::invalid_gid;
@@ -592,7 +598,8 @@ namespace hpx { namespace performance_counters {
 
             if (-1 == paths.parentinstanceindex_)
             {
-                HPX_THROWS_IF(ec, bad_parameter, "agas_raw_counter_creator",
+                HPX_THROWS_IF(ec, hpx::error::bad_parameter,
+                    "agas_raw_counter_creator",
                     "invalid parent instance index: -1");
                 return naming::invalid_gid;
             }
@@ -605,7 +612,8 @@ namespace hpx { namespace performance_counters {
             hpx::id_type id = agas::resolve_name(launch::sync, service, ec);
             if (id == hpx::invalid_id)
             {
-                HPX_THROWS_IF(ec, not_implemented, "agas_raw_counter_creator",
+                HPX_THROWS_IF(ec, hpx::error::not_implemented,
+                    "agas_raw_counter_creator",
                     "invalid counter name: " +
                         remove_counter_prefix(info.fullname_));
                 return naming::invalid_gid;
@@ -614,7 +622,8 @@ namespace hpx { namespace performance_counters {
             return detail::retrieve_agas_counter(info.fullname_, id, ec);
         }
 
-        HPX_THROWS_IF(ec, not_implemented, "agas_raw_counter_creator",
+        HPX_THROWS_IF(ec, hpx::error::not_implemented,
+            "agas_raw_counter_creator",
             "invalid counter type name: " + paths.instancename_);
         return naming::invalid_gid;
     }

--- a/libs/full/performance_counters/src/counters.cpp
+++ b/libs/full/performance_counters/src/counters.cpp
@@ -97,7 +97,7 @@ namespace hpx { namespace performance_counters {
     {
         if (path.objectname_.empty())
         {
-            HPX_THROWS_IF(ec, bad_parameter, "get_counter_name",
+            HPX_THROWS_IF(ec, hpx::error::bad_parameter, "get_counter_name",
                 "empty counter object name");
             return counter_status::invalid_data;
         }
@@ -171,8 +171,8 @@ namespace hpx { namespace performance_counters {
     {
         if (path.objectname_.empty())
         {
-            HPX_THROWS_IF(ec, bad_parameter, "get_counter_type_name",
-                "empty counter object name");
+            HPX_THROWS_IF(ec, hpx::error::bad_parameter,
+                "get_counter_type_name", "empty counter object name");
             return counter_status::invalid_data;
         }
 
@@ -198,8 +198,8 @@ namespace hpx { namespace performance_counters {
     {
         if (path.objectname_.empty())
         {
-            HPX_THROWS_IF(ec, bad_parameter, "get_full_counter_type_name",
-                "empty counter object name");
+            HPX_THROWS_IF(ec, hpx::error::bad_parameter,
+                "get_full_counter_type_name", "empty counter object name");
             return counter_status::invalid_data;
         }
 
@@ -230,8 +230,8 @@ namespace hpx { namespace performance_counters {
     {
         if (path.parentinstancename_.empty())
         {
-            HPX_THROWS_IF(ec, bad_parameter, "get_counter_instance_name",
-                "empty counter instance name");
+            HPX_THROWS_IF(ec, hpx::error::bad_parameter,
+                "get_counter_instance_name", "empty counter instance name");
             return counter_status::invalid_data;
         }
 
@@ -303,8 +303,9 @@ namespace hpx { namespace performance_counters {
         path_elements elements;
         if (!parse_counter_name(name, elements))
         {
-            HPX_THROWS_IF(ec, bad_parameter, "get_counter_path_elements",
-                "invalid counter name format: {}", name);
+            HPX_THROWS_IF(ec, hpx::error::bad_parameter,
+                "get_counter_path_elements", "invalid counter name format: {}",
+                name);
             return counter_status::invalid_data;
         }
 
@@ -356,7 +357,7 @@ namespace hpx { namespace performance_counters {
                         elements.instance_.child_.index_, std::int64_t(-2));
                     if (path.instanceindex_ == std::int64_t(-2))
                     {
-                        HPX_THROWS_IF(ec, bad_parameter,
+                        HPX_THROWS_IF(ec, hpx::error::bad_parameter,
                             "get_counter_path_elements",
                             "invalid counter name format: {}", name);
                         return counter_status::invalid_data;
@@ -394,7 +395,8 @@ namespace hpx { namespace performance_counters {
         path_elements elements;
         if (!parse_counter_name(name, elements))
         {
-            HPX_THROWS_IF(ec, bad_parameter, "get_counter_type_path_elements",
+            HPX_THROWS_IF(ec, hpx::error::bad_parameter,
+                "get_counter_type_path_elements",
                 "invalid counter name format: {}", name);
             return counter_status::invalid_data;
         }
@@ -516,7 +518,7 @@ namespace hpx { namespace performance_counters {
     {
         if (hpx::get_runtime_ptr() == nullptr)
         {
-            HPX_THROWS_IF(ec, bad_parameter,
+            HPX_THROWS_IF(ec, hpx::error::bad_parameter,
                 "performance_counters::add_counter_type",
                 "the runtime is not currently running");
             return counter_status::generic_error;
@@ -533,7 +535,7 @@ namespace hpx { namespace performance_counters {
     {
         if (hpx::get_runtime_ptr() == nullptr)
         {
-            HPX_THROWS_IF(ec, bad_parameter,
+            HPX_THROWS_IF(ec, hpx::error::bad_parameter,
                 "performance_counters::discover_counter_types",
                 "the runtime is not currently running");
             return counter_status::generic_error;
@@ -550,7 +552,7 @@ namespace hpx { namespace performance_counters {
     {
         if (hpx::get_runtime_ptr() == nullptr)
         {
-            HPX_THROWS_IF(ec, bad_parameter,
+            HPX_THROWS_IF(ec, hpx::error::bad_parameter,
                 "performance_counters::discover_counter_types",
                 "the runtime is not currently running");
             return counter_status::generic_error;
@@ -565,7 +567,7 @@ namespace hpx { namespace performance_counters {
     {
         if (hpx::get_runtime_ptr() == nullptr)
         {
-            HPX_THROWS_IF(ec, bad_parameter,
+            HPX_THROWS_IF(ec, hpx::error::bad_parameter,
                 "performance_counters::discover_counter_types",
                 "the runtime is not currently running");
             return counter_status::generic_error;
@@ -631,7 +633,7 @@ namespace hpx { namespace performance_counters {
     {
         if (hpx::get_runtime_ptr() == nullptr)
         {
-            HPX_THROWS_IF(ec, bad_parameter,
+            HPX_THROWS_IF(ec, hpx::error::bad_parameter,
                 "performance_counters::get_counter_type",
                 "the runtime is not currently running");
             return counter_status::generic_error;
@@ -766,7 +768,8 @@ namespace hpx { namespace performance_counters {
             registry::instance().get_counter_create_function(info, f, ec);
             if (ec)
             {
-                HPX_THROW_EXCEPTION(bad_parameter, "create_counter_local",
+                HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
+                    "create_counter_local",
                     "no create function for performance counter found: {} ({})",
                     remove_counter_prefix(info.fullname_), ec.get_message());
                 return naming::invalid_gid;
@@ -781,7 +784,8 @@ namespace hpx { namespace performance_counters {
                 paths.parentinstanceindex_ !=
                     static_cast<std::int64_t>(hpx::get_locality_id()))
             {
-                HPX_THROW_EXCEPTION(bad_parameter, "create_counter_local",
+                HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
+                    "create_counter_local",
                     "attempt to create counter on wrong locality ({})",
                     ec.get_message());
                 return hpx::naming::invalid_gid;
@@ -791,7 +795,8 @@ namespace hpx { namespace performance_counters {
             naming::gid_type gid = f(info, ec);
             if (ec)
             {
-                HPX_THROW_EXCEPTION(bad_parameter, "create_counter_local",
+                HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
+                    "create_counter_local",
                     "couldn't create performance counter: {} ({})",
                     remove_counter_prefix(info.fullname_), ec.get_message());
                 return naming::invalid_gid;
@@ -1153,7 +1158,7 @@ namespace hpx { namespace performance_counters {
                             static_cast<std::int32_t>(
                                 get_num_localities(hpx::launch::sync))))
                 {
-                    HPX_THROWS_IF(ec, bad_parameter, "get_counter",
+                    HPX_THROWS_IF(ec, hpx::error::bad_parameter, "get_counter",
                         "attempt to create counter on non-existing locality");
                     return result_type();
                 }

--- a/libs/full/performance_counters/src/locality_namespace_counters.cpp
+++ b/libs/full/performance_counters/src/locality_namespace_counters.cpp
@@ -147,7 +147,7 @@ namespace hpx { namespace agas { namespace server {
 
         if (p.objectname_ != "agas")
         {
-            HPX_THROW_EXCEPTION(bad_parameter,
+            HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
                 "locality_namespace::statistics_counter",
                 "unknown performance counter (unrelated to AGAS)");
         }
@@ -167,7 +167,7 @@ namespace hpx { namespace agas { namespace server {
 
         if (code == invalid_request || target == detail::counter_target_invalid)
         {
-            HPX_THROW_EXCEPTION(bad_parameter,
+            HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
                 "locality_namespace::statistics_counter",
                 "unknown performance counter (unrelated to AGAS)");
         }
@@ -215,7 +215,7 @@ namespace hpx { namespace agas { namespace server {
                 service.counter_data_.enable_all();
                 break;
             default:
-                HPX_THROW_EXCEPTION(bad_parameter,
+                HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
                     "locality_namespace::statistics",
                     "bad action code while querying statistics");
             }
@@ -261,7 +261,7 @@ namespace hpx { namespace agas { namespace server {
                 service.counter_data_.enable_all();
                 break;
             default:
-                HPX_THROW_EXCEPTION(bad_parameter,
+                HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
                     "locality_namespace::statistics",
                     "bad action code while querying statistics");
             }

--- a/libs/full/performance_counters/src/manage_counter.cpp
+++ b/libs/full/performance_counters/src/manage_counter.cpp
@@ -47,7 +47,8 @@ namespace hpx { namespace performance_counters {
     {
         if (counter_ != hpx::invalid_id)
         {
-            HPX_THROWS_IF(ec, hpx::invalid_status, "manage_counter::install",
+            HPX_THROWS_IF(ec, hpx::error::invalid_status,
+                "manage_counter::install",
                 "counter has been already installed");
             return counter_status::invalid_data;
         }

--- a/libs/full/performance_counters/src/manage_counter_type.cpp
+++ b/libs/full/performance_counters/src/manage_counter_type.cpp
@@ -43,7 +43,7 @@ namespace hpx { namespace performance_counters {
         {
             if (counter_status::invalid_data != status_)
             {
-                HPX_THROWS_IF(ec, hpx::invalid_status,
+                HPX_THROWS_IF(ec, hpx::error::invalid_status,
                     "manage_counter_type::install",
                     "counter type {} has been already installed.",
                     info_.fullname_);
@@ -59,7 +59,7 @@ namespace hpx { namespace performance_counters {
         {
             if (counter_status::invalid_data != status_)
             {
-                HPX_THROWS_IF(ec, hpx::invalid_status,
+                HPX_THROWS_IF(ec, hpx::error::invalid_status,
                     "manage_counter_type::install",
                     "generic counter type {} has been already installed.",
                     info_.fullname_);

--- a/libs/full/performance_counters/src/per_action_data_counter_discoverer.cpp
+++ b/libs/full/performance_counters/src/per_action_data_counter_discoverer.cpp
@@ -99,7 +99,7 @@ namespace hpx { namespace performance_counters {
                     types += "  " + e + "\n";
                 }
 
-                HPX_THROWS_IF(ec, bad_parameter,
+                HPX_THROWS_IF(ec, hpx::error::bad_parameter,
                     "per_action_data_counter_registry::counter_discoverer",
                     "action type {} does not match any known type, "
                     "known action types: \n{}",
@@ -124,7 +124,7 @@ namespace hpx { namespace performance_counters {
                 types += "  " + e + "\n";
             }
 
-            HPX_THROWS_IF(ec, bad_parameter,
+            HPX_THROWS_IF(ec, hpx::error::bad_parameter,
                 "per_action_data_counter_registry::counter_discoverer",
                 "action type {} does not match any known type, "
                 "known action types: \n{}",

--- a/libs/full/performance_counters/src/performance_counter_set.cpp
+++ b/libs/full/performance_counters/src/performance_counter_set.cpp
@@ -88,7 +88,7 @@ namespace hpx { namespace performance_counters {
         hpx::id_type id = get_counter(info.fullname_, ec);
         if (HPX_UNLIKELY(!id))
         {
-            HPX_THROWS_IF(ec, bad_parameter,
+            HPX_THROWS_IF(ec, hpx::error::bad_parameter,
                 "performance_counter_set::find_counter",
                 "unknown performance counter: '{1}' ({2})", info.fullname_,
                 ec.get_message());

--- a/libs/full/performance_counters/src/primary_namespace_counters.cpp
+++ b/libs/full/performance_counters/src/primary_namespace_counters.cpp
@@ -145,7 +145,7 @@ namespace hpx { namespace agas { namespace server {
 
         if (p.objectname_ != "agas")
         {
-            HPX_THROW_EXCEPTION(bad_parameter,
+            HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
                 "primary_namespace::statistics_counter",
                 "unknown performance counter (unrelated to AGAS)");
         }
@@ -167,7 +167,7 @@ namespace hpx { namespace agas { namespace server {
         if (code == invalid_request ||
             target == agas::detail::counter_target_invalid)
         {
-            HPX_THROW_EXCEPTION(bad_parameter,
+            HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
                 "primary_namespace::statistics_counter",
                 "unknown performance counter (unrelated to AGAS?)");
         }
@@ -232,7 +232,7 @@ namespace hpx { namespace agas { namespace server {
                 service.counter_data_.enable_all();
                 break;
             default:
-                HPX_THROW_EXCEPTION(bad_parameter,
+                HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
                     "primary_namespace::statistics",
                     "bad action code while querying statistics");
             }
@@ -295,7 +295,7 @@ namespace hpx { namespace agas { namespace server {
                 service.counter_data_.enable_all();
                 break;
             default:
-                HPX_THROW_EXCEPTION(bad_parameter,
+                HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
                     "primary_namespace::statistics",
                     "bad action code while querying statistics");
             }

--- a/libs/full/performance_counters/src/query_counters.cpp
+++ b/libs/full/performance_counters/src/query_counters.cpp
@@ -452,7 +452,8 @@ namespace hpx { namespace util {
         if (counters_.size() == 0)
         {
             // start has not been called yet
-            HPX_THROWS_IF(ec, invalid_status, "query_counters::start_counters",
+            HPX_THROWS_IF(ec, hpx::error::invalid_status,
+                "query_counters::start_counters",
                 "The counters to be evaluated have not been initialized yet");
             return;
         }
@@ -466,7 +467,8 @@ namespace hpx { namespace util {
         if (counters_.size() == 0)
         {
             // start has not been called yet
-            HPX_THROWS_IF(ec, invalid_status, "query_counters::stop_counters",
+            HPX_THROWS_IF(ec, hpx::error::invalid_status,
+                "query_counters::stop_counters",
                 "The counters to be evaluated have not been initialized yet");
             return;
         }
@@ -480,7 +482,8 @@ namespace hpx { namespace util {
         if (counters_.size() == 0)
         {
             // start has not been called yet
-            HPX_THROWS_IF(ec, invalid_status, "query_counters::reset_counters",
+            HPX_THROWS_IF(ec, hpx::error::invalid_status,
+                "query_counters::reset_counters",
                 "The counters to be evaluated have not been initialized yet");
             return;
         }
@@ -494,7 +497,8 @@ namespace hpx { namespace util {
         if (counters_.size() == 0)
         {
             // start has not been called yet
-            HPX_THROWS_IF(ec, invalid_status, "query_counters::reinit_counters",
+            HPX_THROWS_IF(ec, hpx::error::invalid_status,
+                "query_counters::reinit_counters",
                 "The counters to be evaluated have not been initialized yet");
             return;
         }
@@ -642,7 +646,8 @@ namespace hpx { namespace util {
         if (counters_.size() == 0)
         {
             // start has not been called yet
-            HPX_THROWS_IF(ec, invalid_status, "query_counters::evaluate",
+            HPX_THROWS_IF(ec, hpx::error::invalid_status,
+                "query_counters::evaluate",
                 "The counters to be evaluated have not been initialized yet");
             return false;
         }

--- a/libs/full/performance_counters/src/registry.cpp
+++ b/libs/full/performance_counters/src/registry.cpp
@@ -94,7 +94,8 @@ namespace hpx { namespace performance_counters {
         counter_type_map_type::iterator it = locate_counter_type(type_name);
         if (it != countertypes_.end())
         {
-            HPX_THROWS_IF(ec, bad_parameter, "registry::add_counter_type",
+            HPX_THROWS_IF(ec, hpx::error::bad_parameter,
+                "registry::add_counter_type",
                 "counter type already defined: {}", type_name);
             return counter_status::already_defined;
         }
@@ -143,7 +144,7 @@ namespace hpx { namespace performance_counters {
                     types += "  " + (*it).first + "\n";
                 }
 
-                HPX_THROWS_IF(ec, bad_parameter,
+                HPX_THROWS_IF(ec, hpx::error::bad_parameter,
                     "registry::discover_counter_type",
                     "unknown counter type: {}, known counter types: \n{}",
                     type_name, types);
@@ -223,7 +224,7 @@ namespace hpx { namespace performance_counters {
                     types += "  " + (*it).first + "\n";
                 }
 
-                HPX_THROWS_IF(ec, bad_parameter,
+                HPX_THROWS_IF(ec, hpx::error::bad_parameter,
                     "registry::discover_counter_type",
                     "counter type {} does not match any known type, known "
                     "counter types: \n{}",
@@ -299,7 +300,7 @@ namespace hpx { namespace performance_counters {
                 types += "  " + (*it).first + "\n";
             }
 
-            HPX_THROWS_IF(ec, bad_parameter,
+            HPX_THROWS_IF(ec, hpx::error::bad_parameter,
                 "registry::get_counter_create_function",
                 "counter type {} is not defined, known counter types: \n{}",
                 type_name, types);
@@ -308,7 +309,7 @@ namespace hpx { namespace performance_counters {
 
         if ((*it).second.create_counter_.empty())
         {
-            HPX_THROWS_IF(ec, bad_parameter,
+            HPX_THROWS_IF(ec, hpx::error::bad_parameter,
                 "registry::get_counter_create_function",
                 "counter type {} has no associated create function", type_name);
             return counter_status::invalid_data;
@@ -337,7 +338,7 @@ namespace hpx { namespace performance_counters {
             locate_counter_type(type_name);
         if (it == countertypes_.end())
         {
-            HPX_THROWS_IF(ec, bad_parameter,
+            HPX_THROWS_IF(ec, hpx::error::bad_parameter,
                 "registry::get_counter_discovery_function",
                 "counter type {} is not defined", type_name);
             return counter_status::counter_type_unknown;
@@ -345,7 +346,7 @@ namespace hpx { namespace performance_counters {
 
         if ((*it).second.discover_counters_.empty())
         {
-            HPX_THROWS_IF(ec, bad_parameter,
+            HPX_THROWS_IF(ec, hpx::error::bad_parameter,
                 "registry::get_counter_discovery_function",
                 "counter type {} has no associated discovery function",
                 type_name);
@@ -373,8 +374,8 @@ namespace hpx { namespace performance_counters {
         counter_type_map_type::iterator it = locate_counter_type(type_name);
         if (it == countertypes_.end())
         {
-            HPX_THROWS_IF(ec, bad_parameter, "registry::remove_counter_type",
-                "counter type is not defined");
+            HPX_THROWS_IF(ec, hpx::error::bad_parameter,
+                "registry::remove_counter_type", "counter type is not defined");
             return counter_status::counter_type_unknown;
         }
 
@@ -439,8 +440,9 @@ namespace hpx { namespace performance_counters {
         counter_type_map_type::iterator it = locate_counter_type(type_name);
         if (it == countertypes_.end())
         {
-            HPX_THROWS_IF(ec, bad_parameter, "registry::create_raw_counter",
-                "unknown counter type {}", type_name);
+            HPX_THROWS_IF(ec, hpx::error::bad_parameter,
+                "registry::create_raw_counter", "unknown counter type {}",
+                type_name);
             return counter_status::counter_type_unknown;
         }
 
@@ -459,7 +461,8 @@ namespace hpx { namespace performance_counters {
             (counter_type::average_timer != (*it).second.info_.type_ ||
                 counter_type::average_timer != info.type_))
         {
-            HPX_THROWS_IF(ec, bad_parameter, "registry::create_raw_counter",
+            HPX_THROWS_IF(ec, hpx::error::bad_parameter,
+                "registry::create_raw_counter",
                 "invalid counter type requested (only counter_type::raw, "
                 "counter_type::monotonically_increasing, "
                 "counter_type::aggregating, "
@@ -522,8 +525,9 @@ namespace hpx { namespace performance_counters {
         counter_type_map_type::iterator it = locate_counter_type(type_name);
         if (it == countertypes_.end())
         {
-            HPX_THROWS_IF(ec, bad_parameter, "registry::create_raw_counter",
-                "unknown counter type {}", type_name);
+            HPX_THROWS_IF(ec, hpx::error::bad_parameter,
+                "registry::create_raw_counter", "unknown counter type {}",
+                type_name);
             return counter_status::counter_type_unknown;
         }
 
@@ -533,7 +537,8 @@ namespace hpx { namespace performance_counters {
                 (counter_type::raw_values == (*it).second.info_.type_ &&
                     counter_type::raw_values == info.type_)))
         {
-            HPX_THROWS_IF(ec, bad_parameter, "registry::create_raw_counter",
+            HPX_THROWS_IF(ec, hpx::error::bad_parameter,
+                "registry::create_raw_counter",
                 "invalid counter type requested (only counter_histogram or "
                 "counter_raw_values are supported)");
             return counter_status::counter_type_unknown;
@@ -584,8 +589,9 @@ namespace hpx { namespace performance_counters {
         counter_type_map_type::iterator it = locate_counter_type(type_name);
         if (it == countertypes_.end())
         {
-            HPX_THROWS_IF(ec, bad_parameter, "registry::create_counter",
-                "unknown counter type {}", type_name);
+            HPX_THROWS_IF(ec, hpx::error::bad_parameter,
+                "registry::create_counter", "unknown counter type {}",
+                type_name);
             return counter_status::counter_type_unknown;
         }
 
@@ -619,12 +625,14 @@ namespace hpx { namespace performance_counters {
             case counter_type::average_count:
                 [[fallthrough]];
             case counter_type::average_timer:
-                HPX_THROWS_IF(ec, bad_parameter, "registry::create_counter",
+                HPX_THROWS_IF(ec, hpx::error::bad_parameter,
+                    "registry::create_counter",
                     "need function parameter for raw_counter");
                 return counter_status::counter_type_unknown;
 
             default:
-                HPX_THROWS_IF(ec, bad_parameter, "registry::create_counter",
+                HPX_THROWS_IF(ec, hpx::error::bad_parameter,
+                    "registry::create_counter",
                     "invalid counter type requested");
                 return counter_status::counter_type_unknown;
             }
@@ -666,7 +674,7 @@ namespace hpx { namespace performance_counters {
         counter_type_map_type::iterator it = locate_counter_type(type_name);
         if (it == countertypes_.end())
         {
-            HPX_THROWS_IF(ec, bad_parameter,
+            HPX_THROWS_IF(ec, hpx::error::bad_parameter,
                 "registry::create_statistics_counter",
                 "unknown counter type {}", type_name);
             return counter_status::counter_type_unknown;
@@ -676,7 +684,7 @@ namespace hpx { namespace performance_counters {
         if (counter_type::aggregating != (*it).second.info_.type_ ||
             counter_type::aggregating != info.type_)
         {
-            HPX_THROWS_IF(ec, bad_parameter,
+            HPX_THROWS_IF(ec, hpx::error::bad_parameter,
                 "registry::create_statistics_counter",
                 "invalid counter type requested (only "
                 "counter_type::aggregating is "
@@ -849,7 +857,7 @@ namespace hpx { namespace performance_counters {
             }
             else
             {
-                HPX_THROWS_IF(ec, bad_parameter,
+                HPX_THROWS_IF(ec, hpx::error::bad_parameter,
                     "registry::create_statistics_counter",
                     "invalid counter type requested: {}", p.countername_);
                 return counter_status::counter_type_unknown;
@@ -892,7 +900,7 @@ namespace hpx { namespace performance_counters {
         counter_type_map_type::iterator it = locate_counter_type(type_name);
         if (it == countertypes_.end())
         {
-            HPX_THROWS_IF(ec, bad_parameter,
+            HPX_THROWS_IF(ec, hpx::error::bad_parameter,
                 "registry::create_arithmetics_counter",
                 "unknown counter type {}", type_name);
             return counter_status::counter_type_unknown;
@@ -902,7 +910,7 @@ namespace hpx { namespace performance_counters {
         if (counter_type::aggregating != (*it).second.info_.type_ ||
             counter_type::aggregating != info.type_)
         {
-            HPX_THROWS_IF(ec, bad_parameter,
+            HPX_THROWS_IF(ec, hpx::error::bad_parameter,
                 "registry::create_arithmetics_counter",
                 "invalid counter type requested "
                 "(only counter_type::aggregating is supported)");
@@ -959,7 +967,7 @@ namespace hpx { namespace performance_counters {
             }
             else
             {
-                HPX_THROWS_IF(ec, bad_parameter,
+                HPX_THROWS_IF(ec, hpx::error::bad_parameter,
                     "registry::create_arithmetics_counter",
                     "invalid counter type requested: {}", p.countername_);
                 return counter_status::counter_type_unknown;
@@ -1003,7 +1011,7 @@ namespace hpx { namespace performance_counters {
         counter_type_map_type::iterator it = locate_counter_type(type_name);
         if (it == countertypes_.end())
         {
-            HPX_THROWS_IF(ec, bad_parameter,
+            HPX_THROWS_IF(ec, hpx::error::bad_parameter,
                 "registry::create_arithmetics_counter_extended",
                 "unknown counter type {}", type_name);
             return counter_status::counter_type_unknown;
@@ -1013,7 +1021,7 @@ namespace hpx { namespace performance_counters {
         if (counter_type::aggregating != (*it).second.info_.type_ ||
             counter_type::aggregating != info.type_)
         {
-            HPX_THROWS_IF(ec, bad_parameter,
+            HPX_THROWS_IF(ec, hpx::error::bad_parameter,
                 "registry::create_arithmetics_counter_extended",
                 "invalid counter type requested "
                 "(only counter_type::aggregating is supported)");
@@ -1092,7 +1100,7 @@ namespace hpx { namespace performance_counters {
             }
             else
             {
-                HPX_THROWS_IF(ec, bad_parameter,
+                HPX_THROWS_IF(ec, hpx::error::bad_parameter,
                     "registry::create_arithmetics_counter",
                     "invalid counter type requested: {}", p.countername_);
                 return counter_status::counter_type_unknown;
@@ -1141,8 +1149,8 @@ namespace hpx { namespace performance_counters {
         counter_type_map_type::iterator it = locate_counter_type(type_name);
         if (it == countertypes_.end())
         {
-            HPX_THROWS_IF(ec, bad_parameter, "registry::add_counter",
-                "unknown counter type {}", type_name);
+            HPX_THROWS_IF(ec, hpx::error::bad_parameter,
+                "registry::add_counter", "unknown counter type {}", type_name);
             return counter_status::counter_type_unknown;
         }
 
@@ -1203,8 +1211,9 @@ namespace hpx { namespace performance_counters {
         counter_type_map_type::iterator it = locate_counter_type(type_name);
         if (it == countertypes_.end())
         {
-            HPX_THROWS_IF(ec, bad_parameter, "registry::get_counter_type",
-                "unknown counter type {}", type_name);
+            HPX_THROWS_IF(ec, hpx::error::bad_parameter,
+                "registry::get_counter_type", "unknown counter type {}",
+                type_name);
             return counter_status::counter_type_unknown;
         }
 

--- a/libs/full/performance_counters/src/server/action_invocation_counter.cpp
+++ b/libs/full/performance_counters/src/server/action_invocation_counter.cpp
@@ -79,7 +79,7 @@ namespace hpx { namespace performance_counters {
 
             if (paths.parentinstance_is_basename_)
             {
-                HPX_THROWS_IF(ec, bad_parameter,
+                HPX_THROWS_IF(ec, hpx::error::bad_parameter,
                     "action_invocation_counter_creator",
                     "invalid action invocation counter name (instance name "
                     "must not be a valid base counter name)");
@@ -88,7 +88,7 @@ namespace hpx { namespace performance_counters {
 
             if (paths.parameters_.empty())
             {
-                HPX_THROWS_IF(ec, bad_parameter,
+                HPX_THROWS_IF(ec, hpx::error::bad_parameter,
                     "action_invocation_counter_creator",
                     "invalid action invocation counter parameter: must "
                     "specify an action type");
@@ -104,7 +104,7 @@ namespace hpx { namespace performance_counters {
         break;
 
         default:
-            HPX_THROWS_IF(ec, bad_parameter,
+            HPX_THROWS_IF(ec, hpx::error::bad_parameter,
                 "action_invocation_counter_creator",
                 "invalid counter type requested");
             return naming::invalid_gid;

--- a/libs/full/performance_counters/src/server/arithmetics_counter.cpp
+++ b/libs/full/performance_counters/src/server/arithmetics_counter.cpp
@@ -81,7 +81,7 @@ namespace hpx { namespace performance_counters { namespace server {
     {
         if (info.type_ != counter_type::aggregating)
         {
-            HPX_THROW_EXCEPTION(bad_parameter,
+            HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
                 "arithmetics_counter<Operation>::arithmetics_counter",
                 "unexpected counter type specified");
         }
@@ -93,7 +93,7 @@ namespace hpx { namespace performance_counters { namespace server {
         {
             if (counters_.size() < 2)
             {
-                HPX_THROW_EXCEPTION(bad_parameter,
+                HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
                     "arithmetics_counter<Operation>::arithmetics_counter",
                     "the parameter specification for an arithmetic counter "
                     "'/arithmetics/divide' has to expand to more than one "
@@ -249,7 +249,7 @@ namespace hpx { namespace performance_counters { namespace detail {
 
                 if (names.empty())
                 {
-                    HPX_THROWS_IF(ec, bad_parameter,
+                    HPX_THROWS_IF(ec, hpx::error::bad_parameter,
                         "arithmetics_counter_creator",
                         "the parameter specification for an arithmetic counter "
                         "has to expand to at least one counter name: {}",
@@ -264,7 +264,7 @@ namespace hpx { namespace performance_counters { namespace detail {
                             get_counter_path_elements(name, paths, ec) ||
                         ec)
                     {
-                        HPX_THROWS_IF(ec, bad_parameter,
+                        HPX_THROWS_IF(ec, hpx::error::bad_parameter,
                             "arithmetics_counter_creator",
                             "the given (expanded) counter name is not "
                             "a validly formed performance counter name: {}",
@@ -277,7 +277,8 @@ namespace hpx { namespace performance_counters { namespace detail {
             }
             else
             {
-                HPX_THROWS_IF(ec, bad_parameter, "arithmetics_counter_creator",
+                HPX_THROWS_IF(ec, hpx::error::bad_parameter,
+                    "arithmetics_counter_creator",
                     "the parameter specification for an arithmetic counter "
                     "has to be a comma separated list of performance "
                     "counter names, none is given: {}",
@@ -287,7 +288,8 @@ namespace hpx { namespace performance_counters { namespace detail {
         break;
 
         default:
-            HPX_THROWS_IF(ec, bad_parameter, "arithmetics_counter_creator",
+            HPX_THROWS_IF(ec, hpx::error::bad_parameter,
+                "arithmetics_counter_creator",
                 "invalid counter type requested");
             break;
         }

--- a/libs/full/performance_counters/src/server/arithmetics_counter_extended.cpp
+++ b/libs/full/performance_counters/src/server/arithmetics_counter_extended.cpp
@@ -47,7 +47,7 @@ namespace hpx { namespace performance_counters { namespace server {
     {
         if (info.type_ != counter_type::aggregating)
         {
-            HPX_THROW_EXCEPTION(bad_parameter,
+            HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
                 "arithmetics_counter_extended<Statistic>::"
                 "arithmetics_counter_extended",
                 "unexpected counter type specified");
@@ -299,7 +299,7 @@ namespace hpx { namespace performance_counters { namespace detail {
 
                 if (names.empty())
                 {
-                    HPX_THROWS_IF(ec, bad_parameter,
+                    HPX_THROWS_IF(ec, hpx::error::bad_parameter,
                         "arithmetics_counter_extended_creator",
                         "the parameter specification for an arithmetic counter "
                         "has to expand to at least one counter name: {}",
@@ -314,7 +314,7 @@ namespace hpx { namespace performance_counters { namespace detail {
                             get_counter_path_elements(name, paths, ec) ||
                         ec)
                     {
-                        HPX_THROWS_IF(ec, bad_parameter,
+                        HPX_THROWS_IF(ec, hpx::error::bad_parameter,
                             "arithmetics_counter_extended_creator",
                             "the given (expanded) counter name is not "
                             "a validly formed performance counter name: {}",
@@ -327,7 +327,7 @@ namespace hpx { namespace performance_counters { namespace detail {
             }
             else
             {
-                HPX_THROWS_IF(ec, bad_parameter,
+                HPX_THROWS_IF(ec, hpx::error::bad_parameter,
                     "arithmetics_counter_extended_creator",
                     "the parameter specification for an arithmetic counter "
                     "has to be a comma separated list of performance "
@@ -338,7 +338,7 @@ namespace hpx { namespace performance_counters { namespace detail {
         break;
 
         default:
-            HPX_THROWS_IF(ec, bad_parameter,
+            HPX_THROWS_IF(ec, hpx::error::bad_parameter,
                 "arithmetics_counter_extended_creator",
                 "invalid counter type requested");
             break;

--- a/libs/full/performance_counters/src/server/base_performance_counter.cpp
+++ b/libs/full/performance_counters/src/server/base_performance_counter.cpp
@@ -25,20 +25,20 @@ namespace hpx { namespace performance_counters { namespace server {
 
     void base_performance_counter::reset_counter_value()
     {
-        HPX_THROW_EXCEPTION(invalid_status, "reset_counter_value",
+        HPX_THROW_EXCEPTION(hpx::error::invalid_status, "reset_counter_value",
             "reset_counter_value is not implemented for this counter");
     }
 
     void base_performance_counter::set_counter_value(
         counter_value const& /*value*/)
     {
-        HPX_THROW_EXCEPTION(invalid_status, "set_counter_value",
+        HPX_THROW_EXCEPTION(hpx::error::invalid_status, "set_counter_value",
             "set_counter_value is not implemented for this counter");
     }
 
     counter_value base_performance_counter::get_counter_value(bool /*reset*/)
     {
-        HPX_THROW_EXCEPTION(invalid_status, "get_counter_value",
+        HPX_THROW_EXCEPTION(hpx::error::invalid_status, "get_counter_value",
             "get_counter_value is not implemented for this counter");
         return {};
     }
@@ -46,7 +46,8 @@ namespace hpx { namespace performance_counters { namespace server {
     counter_values_array base_performance_counter::get_counter_values_array(
         bool /*reset*/)
     {
-        HPX_THROW_EXCEPTION(invalid_status, "get_counter_values_array",
+        HPX_THROW_EXCEPTION(hpx::error::invalid_status,
+            "get_counter_values_array",
             "get_counter_values_array is not implemented for this "
             "counter");
         return {};

--- a/libs/full/performance_counters/src/server/component_instance_counter.cpp
+++ b/libs/full/performance_counters/src/server/component_instance_counter.cpp
@@ -42,7 +42,7 @@ namespace hpx { namespace performance_counters { namespace detail {
 
             if (paths.parentinstance_is_basename_)
             {
-                HPX_THROWS_IF(ec, bad_parameter,
+                HPX_THROWS_IF(ec, hpx::error::bad_parameter,
                     "component_instance_counter_creator",
                     "invalid instance counter name (instance name must not "
                     "be a valid base counter name)");
@@ -63,7 +63,7 @@ namespace hpx { namespace performance_counters { namespace detail {
                         return true;
                     });
 
-                HPX_THROWS_IF(ec, bad_parameter,
+                HPX_THROWS_IF(ec, hpx::error::bad_parameter,
                     "component_instance_counter_creator", strm.str());
 
                 return naming::invalid_gid;
@@ -75,7 +75,7 @@ namespace hpx { namespace performance_counters { namespace detail {
 
             if (type == components::component_invalid)
             {
-                HPX_THROWS_IF(ec, bad_parameter,
+                HPX_THROWS_IF(ec, hpx::error::bad_parameter,
                     "component_instance_counter_creator",
                     "invalid component type as counter parameter: {}",
                     paths.parameters_);
@@ -89,7 +89,7 @@ namespace hpx { namespace performance_counters { namespace detail {
         break;
 
         default:
-            HPX_THROWS_IF(ec, bad_parameter,
+            HPX_THROWS_IF(ec, hpx::error::bad_parameter,
                 "component_instance_counter_creator",
                 "invalid counter type requested");
             return naming::invalid_gid;

--- a/libs/full/performance_counters/src/server/elapsed_time_counter.cpp
+++ b/libs/full/performance_counters/src/server/elapsed_time_counter.cpp
@@ -36,7 +36,7 @@ namespace hpx { namespace performance_counters { namespace server {
     {
         if (info.type_ != counter_type::elapsed_time)
         {
-            HPX_THROW_EXCEPTION(bad_parameter,
+            HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
                 "elapsed_time_counter::elapsed_time_counter",
                 "unexpected counter type specified for elapsed_time_counter");
         }
@@ -47,7 +47,7 @@ namespace hpx { namespace performance_counters { namespace server {
     {
         if (reset)
         {
-            HPX_THROW_EXCEPTION(bad_parameter,
+            HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
                 "elapsed_time_counter::get_counter_value",
                 "counter /runtime/uptime does no support reset");
         }
@@ -66,7 +66,7 @@ namespace hpx { namespace performance_counters { namespace server {
 
     void elapsed_time_counter::reset_counter_value()
     {
-        HPX_THROW_EXCEPTION(bad_parameter,
+        HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
             "elapsed_time_counter::reset_counter_value",
             "counter /runtime/uptime does no support reset");
     }
@@ -114,7 +114,8 @@ namespace hpx { namespace performance_counters { namespace detail {
             // allowed counter names: /runtime(locality#%d/*)/uptime
             if (paths.parentinstance_is_basename_)
             {
-                HPX_THROWS_IF(ec, bad_parameter, "uptime_counter_creator",
+                HPX_THROWS_IF(ec, hpx::error::bad_parameter,
+                    "uptime_counter_creator",
                     "invalid counter instance parent name: {}",
                     paths.parentinstancename_);
                 return naming::invalid_gid;
@@ -125,8 +126,8 @@ namespace hpx { namespace performance_counters { namespace detail {
         }
 
         default:
-            HPX_THROWS_IF(ec, bad_parameter, "uptime_counter_creator",
-                "invalid counter type requested");
+            HPX_THROWS_IF(ec, hpx::error::bad_parameter,
+                "uptime_counter_creator", "invalid counter type requested");
             return naming::invalid_gid;
         }
     }

--- a/libs/full/performance_counters/src/server/per_action_data_counters.cpp
+++ b/libs/full/performance_counters/src/server/per_action_data_counters.cpp
@@ -77,7 +77,7 @@ namespace hpx { namespace performance_counters {
 
             if (paths.parentinstance_is_basename_)
             {
-                HPX_THROWS_IF(ec, bad_parameter,
+                HPX_THROWS_IF(ec, hpx::error::bad_parameter,
                     "per_action_data_counter_creator",
                     "invalid action invocation counter name (instance name "
                     "must not be a valid base counter name)");
@@ -103,7 +103,8 @@ namespace hpx { namespace performance_counters {
         break;
 
         default:
-            HPX_THROWS_IF(ec, bad_parameter, "per_action_data_counter_creator",
+            HPX_THROWS_IF(ec, hpx::error::bad_parameter,
+                "per_action_data_counter_creator",
                 "invalid counter type requested");
             return naming::invalid_gid;
         }

--- a/libs/full/performance_counters/src/server/raw_counter.cpp
+++ b/libs/full/performance_counters/src/server/raw_counter.cpp
@@ -46,7 +46,8 @@ namespace hpx { namespace performance_counters { namespace server {
             info.type_ != counter_type::average_count &&
             info.type_ != counter_type::average_timer)
         {
-            HPX_THROW_EXCEPTION(bad_parameter, "raw_counter::raw_counter",
+            HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
+                "raw_counter::raw_counter",
                 "unexpected counter type specified for raw_counter");
         }
     }

--- a/libs/full/performance_counters/src/server/raw_values_counter.cpp
+++ b/libs/full/performance_counters/src/server/raw_values_counter.cpp
@@ -45,7 +45,7 @@ namespace hpx { namespace performance_counters { namespace server {
         if (info.type_ != counter_type::histogram &&
             info.type_ != counter_type::raw_values)
         {
-            HPX_THROW_EXCEPTION(bad_parameter,
+            HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
                 "raw_values_counter::raw_values_counter",
                 "unexpected counter type specified for raw_values_counter "
                 "should be counter_type::histogram or "

--- a/libs/full/performance_counters/src/server/statistics_counter.cpp
+++ b/libs/full/performance_counters/src/server/statistics_counter.cpp
@@ -168,7 +168,7 @@ namespace hpx { namespace performance_counters { namespace server {
             {
                 if (parameter2 == 0)
                 {
-                    HPX_THROW_EXCEPTION(bad_parameter,
+                    HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
                         "counter_type_from_statistic<Statistic>",
                         "base rolling window size is specified to be zero");
                 }
@@ -209,7 +209,7 @@ namespace hpx { namespace performance_counters { namespace server {
             {
                 if (parameter2 == 0)
                 {
-                    HPX_THROW_EXCEPTION(bad_parameter,
+                    HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
                         "counter_type_from_statistic<Statistic>",
                         "base rolling window size is specified to be zero");
                 }
@@ -309,7 +309,7 @@ namespace hpx { namespace performance_counters { namespace server {
             {
                 if (parameter2 == 0)
                 {
-                    HPX_THROW_EXCEPTION(bad_parameter,
+                    HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
                         "counter_type_from_statistic<Statistic>",
                         "base rolling window size is specified to be zero");
                 }
@@ -349,7 +349,7 @@ namespace hpx { namespace performance_counters { namespace server {
             {
                 if (parameter2 == 0)
                 {
-                    HPX_THROW_EXCEPTION(bad_parameter,
+                    HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
                         "counter_type_from_statistic<Statistic>",
                         "base rolling window size is specified to be zero");
                 }
@@ -402,14 +402,14 @@ namespace hpx { namespace performance_counters { namespace server {
     {
         if (parameter1 == 0)
         {
-            HPX_THROW_EXCEPTION(bad_parameter,
+            HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
                 "statistics_counter<Statistic>::statistics_counter",
                 "base interval is specified to be zero");
         }
 
         if (info.type_ != counter_type::aggregating)
         {
-            HPX_THROW_EXCEPTION(bad_parameter,
+            HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
                 "statistics_counter<Statistic>::statistics_counter",
                 "unexpected counter type specified");
         }
@@ -460,7 +460,7 @@ namespace hpx { namespace performance_counters { namespace server {
             base_value.scale_inverse_ != prev_value_.scale_inverse_)
         {
             // not supported right now
-            HPX_THROW_EXCEPTION(not_implemented,
+            HPX_THROW_EXCEPTION(hpx::error::not_implemented,
                 "statistics_counter<Statistic>::evaluate",
                 "base counter should keep scaling constant over time");
             return false;
@@ -507,7 +507,7 @@ namespace hpx { namespace performance_counters { namespace server {
             if (HPX_UNLIKELY(ec || !base_counter_id_))
             {
                 // base counter could not be retrieved
-                HPX_THROW_EXCEPTION(bad_parameter,
+                HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
                     "statistics_counter<Statistic>::evaluate_base_counter",
                     "could not get or create performance counter: '{}'",
                     base_counter_name_);
@@ -765,7 +765,8 @@ namespace hpx { namespace performance_counters { namespace detail {
 
             if (!paths.parentinstance_is_basename_)
             {
-                HPX_THROWS_IF(ec, bad_parameter, "statistics_counter_creator",
+                HPX_THROWS_IF(ec, hpx::error::bad_parameter,
+                    "statistics_counter_creator",
                     "invalid aggregate counter "
                     "name (instance name must be valid base counter name)");
                 return naming::invalid_gid;
@@ -784,7 +785,7 @@ namespace hpx { namespace performance_counters { namespace detail {
                 if (!x3::parse(paths.parameters_.begin(),
                         paths.parameters_.end(), x3::uint_ % ',', parameters))
                 {
-                    HPX_THROWS_IF(ec, bad_parameter,
+                    HPX_THROWS_IF(ec, hpx::error::bad_parameter,
                         "statistics_counter_creator",
                         "invalid parameter specification format for "
                         "this counter: {}",
@@ -795,7 +796,7 @@ namespace hpx { namespace performance_counters { namespace detail {
                 {
                     if (parameters.size() > 3)
                     {
-                        HPX_THROWS_IF(ec, bad_parameter,
+                        HPX_THROWS_IF(ec, hpx::error::bad_parameter,
                             "statistics_counter_creator",
                             "too many parameter specifications for "
                             "this counter: {}",
@@ -805,7 +806,7 @@ namespace hpx { namespace performance_counters { namespace detail {
                 }
                 else if (parameters.size() > 2)
                 {
-                    HPX_THROWS_IF(ec, bad_parameter,
+                    HPX_THROWS_IF(ec, hpx::error::bad_parameter,
                         "statistics_counter_creator",
                         "too many parameter specifications for "
                         "this counter: {}",
@@ -829,8 +830,8 @@ namespace hpx { namespace performance_counters { namespace detail {
         break;
 
         default:
-            HPX_THROWS_IF(ec, bad_parameter, "statistics_counter_creator",
-                "invalid counter type requested");
+            HPX_THROWS_IF(ec, hpx::error::bad_parameter,
+                "statistics_counter_creator", "invalid counter type requested");
             return naming::invalid_gid;
         }
     }

--- a/libs/full/performance_counters/src/symbol_namespace_counters.cpp
+++ b/libs/full/performance_counters/src/symbol_namespace_counters.cpp
@@ -139,7 +139,7 @@ namespace hpx { namespace agas { namespace server {
 
         if (p.objectname_ != "agas")
         {
-            HPX_THROW_EXCEPTION(bad_parameter,
+            HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
                 "symbol_namespace::statistics_counter",
                 "unknown performance counter (unrelated to AGAS)");
         }
@@ -158,7 +158,7 @@ namespace hpx { namespace agas { namespace server {
 
         if (code == invalid_request || target == detail::counter_target_invalid)
         {
-            HPX_THROW_EXCEPTION(bad_parameter,
+            HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
                 "symbol_namespace::statistics_counter",
                 "unknown performance counter (unrelated to AGAS)");
         }
@@ -201,7 +201,7 @@ namespace hpx { namespace agas { namespace server {
                 service.counter_data_.enable_all();
                 break;
             default:
-                HPX_THROW_EXCEPTION(bad_parameter,
+                HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
                     "symbol_namespace::statistics",
                     "bad action code while querying statistics");
             }
@@ -242,7 +242,7 @@ namespace hpx { namespace agas { namespace server {
                 service.counter_data_.enable_all();
                 break;
             default:
-                HPX_THROW_EXCEPTION(bad_parameter,
+                HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
                     "symbol_namespace::statistics",
                     "bad action code while querying statistics");
             }

--- a/libs/full/performance_counters/src/threadmanager_counter_types.cpp
+++ b/libs/full/performance_counters/src/threadmanager_counter_types.cpp
@@ -70,7 +70,8 @@ namespace hpx { namespace performance_counters { namespace detail {
 
         if (paths.parentinstance_is_basename_)
         {
-            HPX_THROWS_IF(ec, bad_parameter, "queue_length_counter_creator",
+            HPX_THROWS_IF(ec, hpx::error::bad_parameter,
+                "queue_length_counter_creator",
                 "invalid counter instance parent name: {}",
                 paths.parentinstancename_);
             return naming::invalid_gid;
@@ -113,7 +114,8 @@ namespace hpx { namespace performance_counters { namespace detail {
             return create_raw_counter(info, HPX_MOVE(f), ec);
         }
 
-        HPX_THROWS_IF(ec, bad_parameter, "locality_pool_thread_counter_creator",
+        HPX_THROWS_IF(ec, hpx::error::bad_parameter,
+            "locality_pool_thread_counter_creator",
             "invalid counter instance name: {}", paths.instancename_);
         return naming::invalid_gid;
     }
@@ -133,7 +135,8 @@ namespace hpx { namespace performance_counters { namespace detail {
         // /scheduler{locality#%d/pool#%s/total}/utilization/instantaneous
         if (paths.parentinstance_is_basename_)
         {
-            HPX_THROWS_IF(ec, bad_parameter, "scheduler_utilization_creator",
+            HPX_THROWS_IF(ec, hpx::error::bad_parameter,
+                "scheduler_utilization_creator",
                 "invalid counter instance parent name: {}",
                 paths.parentinstancename_);
             return naming::invalid_gid;
@@ -173,7 +176,8 @@ namespace hpx { namespace performance_counters { namespace detail {
             }
         }
 
-        HPX_THROWS_IF(ec, bad_parameter, "scheduler_utilization_creator",
+        HPX_THROWS_IF(ec, hpx::error::bad_parameter,
+            "scheduler_utilization_creator",
             "invalid counter instance name: {}", paths.instancename_);
         return naming::invalid_gid;
     }
@@ -195,7 +199,7 @@ namespace hpx { namespace performance_counters { namespace detail {
         }
         if (paths.parentinstance_is_basename_)
         {
-            HPX_THROWS_IF(ec, bad_parameter,
+            HPX_THROWS_IF(ec, hpx::error::bad_parameter,
                 "locality_pool_thread_no_total_counter_creator",
                 "invalid counter instance parent name: {}",
                 paths.parentinstancename_);
@@ -206,7 +210,7 @@ namespace hpx { namespace performance_counters { namespace detail {
         if (paths.instancename_ == "total" && paths.instanceindex_ == -1)
         {
             // overall counter, not supported
-            HPX_THROWS_IF(ec, bad_parameter,
+            HPX_THROWS_IF(ec, hpx::error::bad_parameter,
                 "locality_pool_thread_no_total_counter_creator",
                 "invalid counter instance name: {} 'total' is not supported",
                 paths.instancename_);
@@ -239,7 +243,7 @@ namespace hpx { namespace performance_counters { namespace detail {
             return create_raw_counter(info, HPX_MOVE(f), ec);
         }
 
-        HPX_THROWS_IF(ec, bad_parameter,
+        HPX_THROWS_IF(ec, hpx::error::bad_parameter,
             "locality_pool_thread_no_total_counter_creator",
             "invalid counter instance name: {}", paths.instancename_);
         return naming::invalid_gid;
@@ -348,7 +352,7 @@ namespace hpx { namespace performance_counters { namespace detail {
     {
         if (paths.parentinstance_is_basename_)
         {
-            HPX_THROWS_IF(ec, bad_parameter, "counter_creator",
+            HPX_THROWS_IF(ec, hpx::error::bad_parameter, "counter_creator",
                 "invalid counter instance parent name: {}",
                 paths.parentinstancename_);
             return naming::invalid_gid;
@@ -371,7 +375,7 @@ namespace hpx { namespace performance_counters { namespace detail {
             return create_raw_counter(info, individual_creator, ec);
         }
 
-        HPX_THROWS_IF(ec, bad_parameter, "counter_creator",
+        HPX_THROWS_IF(ec, hpx::error::bad_parameter, "counter_creator",
             "invalid counter instance name: {}", paths.instancename_);
         return naming::invalid_gid;
     }
@@ -425,7 +429,8 @@ namespace hpx { namespace performance_counters { namespace detail {
             }
         }
 
-        HPX_THROWS_IF(ec, bad_parameter, "thread_counts_counter_creator",
+        HPX_THROWS_IF(ec, hpx::error::bad_parameter,
+            "thread_counts_counter_creator",
             "invalid counter instance name: {}", paths.instancename_);
         return naming::invalid_gid;
     }

--- a/libs/full/performance_counters/tests/unit/path_elements.cpp
+++ b/libs/full/performance_counters/tests/unit/path_elements.cpp
@@ -403,20 +403,20 @@ namespace test {
             std::string fullname;
             HPX_TEST_EQ(counter_status::valid_data,
                 get_counter_name(t->path_, fullname, ec));
-            HPX_TEST_EQ(ec.value(), hpx::success);
+            HPX_TEST_EQ(ec.value(), hpx::error::success);
             HPX_TEST_EQ(fullname, t->fullname_);
 
             std::string type_name;
             HPX_TEST(counter_status::valid_data ==
                 get_counter_type_name(t->path_, type_name, ec));
-            HPX_TEST_EQ(ec.value(), hpx::success);
+            HPX_TEST_EQ(ec.value(), hpx::error::success);
             HPX_TEST_EQ(type_name, t->typename_);
 
             counter_path_elements p;
 
             HPX_TEST(counter_status::valid_data ==
                 get_counter_path_elements(t->fullname_, p, ec));
-            HPX_TEST_EQ(ec.value(), hpx::success);
+            HPX_TEST_EQ(ec.value(), hpx::error::success);
             HPX_TEST_EQ(p.objectname_, t->path_.objectname_);
             HPX_TEST_EQ(p.parentinstancename_, t->path_.parentinstancename_);
             HPX_TEST_EQ(p.instancename_, t->path_.instancename_);
@@ -428,27 +428,27 @@ namespace test {
             fullname.erase();
             HPX_TEST_EQ(
                 counter_status::valid_data, get_counter_name(p, fullname, ec));
-            HPX_TEST_EQ(ec.value(), hpx::success);
+            HPX_TEST_EQ(ec.value(), hpx::error::success);
             HPX_TEST_EQ(fullname, t->fullname_);
 
             counter_type_path_elements tp1, tp2;
 
             HPX_TEST(counter_status::valid_data ==
                 get_counter_type_path_elements(t->fullname_, tp1, ec));
-            HPX_TEST_EQ(ec.value(), hpx::success);
+            HPX_TEST_EQ(ec.value(), hpx::error::success);
             HPX_TEST_EQ(tp1.objectname_, t->path_.objectname_);
             HPX_TEST_EQ(tp1.countername_, t->path_.countername_);
 
             type_name.erase();
             HPX_TEST_EQ(counter_status::valid_data,
                 get_counter_type_name(tp1, type_name, ec));
-            HPX_TEST_EQ(ec.value(), hpx::success);
+            HPX_TEST_EQ(ec.value(), hpx::error::success);
             HPX_TEST_EQ(type_name, t->typename_);
 
             type_name.erase();
             HPX_TEST(counter_status::valid_data ==
                 get_full_counter_type_name(tp1, type_name, ec));
-            HPX_TEST_EQ(ec.value(), hpx::success);
+            HPX_TEST_EQ(ec.value(), hpx::error::success);
             if (t->path_.parameters_.empty())
             {
                 HPX_TEST_EQ(type_name, t->typename_);
@@ -461,14 +461,14 @@ namespace test {
 
             HPX_TEST(counter_status::valid_data ==
                 get_counter_type_path_elements(t->typename_, tp2, ec));
-            HPX_TEST_EQ(ec.value(), hpx::success);
+            HPX_TEST_EQ(ec.value(), hpx::error::success);
             HPX_TEST_EQ(tp2.objectname_, t->path_.objectname_);
             HPX_TEST_EQ(tp2.countername_, t->path_.countername_);
 
             type_name.erase();
             HPX_TEST_EQ(counter_status::valid_data,
                 get_counter_type_name(tp2, type_name, ec));
-            HPX_TEST_EQ(ec.value(), hpx::success);
+            HPX_TEST_EQ(ec.value(), hpx::error::success);
             HPX_TEST_EQ(type_name, t->typename_);
         }
     }
@@ -505,7 +505,7 @@ namespace test {
             hpx::error_code ec;
             HPX_TEST_EQ(counter_status::invalid_data,
                 get_counter_path_elements(t, p, ec));
-            HPX_TEST_EQ(ec.value(), hpx::bad_parameter);
+            HPX_TEST_EQ(ec.value(), hpx::error::bad_parameter);
         }
 
         // test throwing version
@@ -521,7 +521,7 @@ namespace test {
             }
             catch (hpx::exception const& e)
             {
-                HPX_TEST_EQ(e.get_error(), hpx::bad_parameter);
+                HPX_TEST_EQ(e.get_error(), hpx::error::bad_parameter);
                 caught_exception = true;
             }
             HPX_TEST(caught_exception);

--- a/libs/full/performance_counters/tests/unit/reinit_counters.cpp
+++ b/libs/full/performance_counters/tests/unit/reinit_counters.cpp
@@ -83,7 +83,7 @@ hpx::naming::gid_type test_counter_creator(
 
     if (paths.parentinstance_is_basename_)
     {
-        HPX_THROWS_IF(ec, hpx::bad_parameter, "test_counter_creator",
+        HPX_THROWS_IF(ec, hpx::error::bad_parameter, "test_counter_creator",
             "invalid counter instance parent name: " +
                 paths.parentinstancename_);
         return hpx::naming::invalid_gid;
@@ -118,7 +118,7 @@ hpx::naming::gid_type test_counter_creator(
         return id;
     }
 
-    HPX_THROWS_IF(ec, hpx::bad_parameter, "test_counter_creator",
+    HPX_THROWS_IF(ec, hpx::error::bad_parameter, "test_counter_creator",
         "invalid counter instance name: " + paths.instancename_);
     return hpx::naming::invalid_gid;
 }

--- a/libs/full/runtime_components/include/hpx/runtime_components/create_component_helpers.hpp
+++ b/libs/full/runtime_components/include/hpx/runtime_components/create_component_helpers.hpp
@@ -38,7 +38,7 @@ namespace hpx { namespace components {
     {
         if (!naming::is_locality(gid))
         {
-            HPX_THROW_EXCEPTION(bad_parameter,
+            HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
                 "stubs::runtime_support::create_component_async",
                 "The id passed as the first argument is not representing"
                 " a locality");
@@ -57,7 +57,7 @@ namespace hpx { namespace components {
     {
         if (!naming::is_locality(gid))
         {
-            HPX_THROW_EXCEPTION(bad_parameter,
+            HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
                 "stubs::runtime_support::bulk_create_component_async",
                 "The id passed as the first argument is not representing"
                 " a locality");

--- a/libs/full/runtime_components/include/hpx/runtime_components/default_distribution_policy.hpp
+++ b/libs/full/runtime_components/include/hpx/runtime_components/default_distribution_policy.hpp
@@ -325,7 +325,7 @@ namespace hpx { namespace components {
         {
             if (localities_->empty())
             {
-                HPX_THROW_EXCEPTION(invalid_status,
+                HPX_THROW_EXCEPTION(hpx::error::invalid_status,
                     "default_distribution_policy::default_distribution_"
                     "policy",
                     "unexpectedly empty list of localities");
@@ -338,7 +338,7 @@ namespace hpx { namespace components {
         {
             if (localities_->empty())
             {
-                HPX_THROW_EXCEPTION(invalid_status,
+                HPX_THROW_EXCEPTION(hpx::error::invalid_status,
                     "default_distribution_policy::default_distribution_policy",
                     "unexpectedly empty list of localities");
             }

--- a/libs/full/runtime_components/src/console_error_sink.cpp
+++ b/libs/full/runtime_components/src/console_error_sink.cpp
@@ -45,7 +45,7 @@ namespace hpx { namespace components {
     {
         if (HPX_UNLIKELY(!threads::get_self_ptr()))
         {
-            HPX_THROW_EXCEPTION(null_thread_id,
+            HPX_THROW_EXCEPTION(hpx::error::null_thread_id,
                 "components::console_error_sink",
                 "console_error_sink was not called from a HPX-thread");
         }

--- a/libs/full/runtime_components/src/console_logging.cpp
+++ b/libs/full/runtime_components/src/console_logging.cpp
@@ -89,7 +89,7 @@ namespace hpx { namespace components {
             fallback_console_logging_locked(msgs);
 
             // raise error as this should get called from outside a HPX-thread
-            HPX_THROW_EXCEPTION(null_thread_id,
+            HPX_THROW_EXCEPTION(hpx::error::null_thread_id,
                 "components::console_logging_locked",
                 "console_logging_locked was not called from a HPX-thread");
         }

--- a/libs/full/runtime_components/tests/unit/components/get_ptr.cpp
+++ b/libs/full/runtime_components/tests/unit/components/get_ptr.cpp
@@ -74,7 +74,7 @@ bool test_get_ptr1(hpx::id_type id)
     }
     catch (hpx::exception const& e)
     {
-        HPX_TEST_EQ(int(e.get_error()), int(hpx::bad_parameter));
+        HPX_TEST_EQ(int(e.get_error()), int(hpx::error::bad_parameter));
     }
 
     return false;
@@ -122,7 +122,7 @@ bool test_get_ptr3(hpx::id_type id)
     }
     catch (hpx::exception const& e)
     {
-        HPX_TEST_EQ(int(e.get_error()), int(hpx::bad_parameter));
+        HPX_TEST_EQ(int(e.get_error()), int(hpx::error::bad_parameter));
     }
 
     return false;

--- a/libs/full/runtime_distributed/include/hpx/runtime_distributed/server/migrate_component.hpp
+++ b/libs/full/runtime_distributed/include/hpx/runtime_distributed/server/migrate_component.hpp
@@ -129,7 +129,7 @@ namespace hpx { namespace components { namespace server {
                 agas::unmark_as_migrated(to_migrate.get_gid());
 
                 return hpx::make_exceptional_future<id_type>(
-                    HPX_GET_EXCEPTION(invalid_status,
+                    HPX_GET_EXCEPTION(hpx::error::invalid_status,
                         "hpx::components::server::migrate_component",
                         "attempting to migrate an instance of a component "
                         "that was already migrated"));
@@ -140,7 +140,7 @@ namespace hpx { namespace components { namespace server {
                 agas::unmark_as_migrated(to_migrate.get_gid());
 
                 return hpx::make_exceptional_future<id_type>(
-                    HPX_GET_EXCEPTION(migration_needs_retry,
+                    HPX_GET_EXCEPTION(hpx::error::migration_needs_retry,
                         "hpx::components::server::migrate_component",
                         "attempting to migrate an instance of a component "
                         "that is currently pinned"));
@@ -174,10 +174,11 @@ namespace hpx { namespace components { namespace server {
         {
             agas::unmark_as_migrated(to_migrate.get_gid());
 
-            return hpx::make_exceptional_future<hpx::id_type>(HPX_GET_EXCEPTION(
-                invalid_status, "hpx::components::server::migrate_component",
-                "attempting to migrate an instance of a component that "
-                "does not support migration"));
+            return hpx::make_exceptional_future<hpx::id_type>(
+                HPX_GET_EXCEPTION(hpx::error::invalid_status,
+                    "hpx::components::server::migrate_component",
+                    "attempting to migrate an instance of a component that "
+                    "does not support migration"));
         }
 
         // retrieve pointer to object (must be local)
@@ -211,7 +212,7 @@ namespace hpx { namespace components { namespace server {
         if (!traits::component_supports_migration<Component>::call())
         {
             return hpx::make_exceptional_future<id_type>(
-                HPX_GET_EXCEPTION(invalid_status,
+                HPX_GET_EXCEPTION(hpx::error::invalid_status,
                     "hpx::components::server::trigger_migrate_component",
                     "attempting to migrate an instance of a component that "
                     "does not support migration"));
@@ -220,7 +221,7 @@ namespace hpx { namespace components { namespace server {
         if (naming::get_locality_id_from_id(to_migrate) != get_locality_id())
         {
             return hpx::make_exceptional_future<id_type>(HPX_GET_EXCEPTION(
-                invalid_status,
+                hpx::error::invalid_status,
                 "hpx::components::server::trigger_migrate_component",
                 "this function has to be executed on the locality "
                 "responsible for managing the address of the given object"));
@@ -246,7 +247,7 @@ namespace hpx { namespace components { namespace server {
                         // simply retry if the migration operation detected
                         // a (global) race between scheduled actions waiting
                         // in AGAS and other migration operations
-                        if (e.get_error() == migration_needs_retry)
+                        if (e.get_error() == hpx::error::migration_needs_retry)
                         {
                             return trigger_migrate_component<Component>(
                                 to_migrate, policy, id, addr);
@@ -284,7 +285,7 @@ namespace hpx { namespace components { namespace server {
         if (!traits::component_supports_migration<Component>::call())
         {
             return hpx::make_exceptional_future<id_type>(
-                HPX_GET_EXCEPTION(invalid_status,
+                HPX_GET_EXCEPTION(hpx::error::invalid_status,
                     "hpx::components::server::perform_migrate_component",
                     "attempting to migrate an instance of a component that "
                     "does not support migration"));

--- a/libs/full/runtime_distributed/include/hpx/runtime_distributed/server/runtime_support.hpp
+++ b/libs/full/runtime_distributed/include/hpx/runtime_distributed/server/runtime_support.hpp
@@ -509,7 +509,7 @@ namespace hpx { namespace components { namespace server {
         if (!id || new_instance == nullptr)
         {
             // we should not get here (id should not be invalid)
-            HPX_THROW_EXCEPTION(hpx::invalid_status,
+            HPX_THROW_EXCEPTION(hpx::error::invalid_status,
                 "runtime_support::migrate_component_to_here",
                 "could not create copy of given component");
             return naming::invalid_gid;
@@ -517,7 +517,7 @@ namespace hpx { namespace components { namespace server {
         if (id != migrated_id)
         {
             // we should not get here either (the ids should be the same)
-            HPX_THROW_EXCEPTION(hpx::invalid_status,
+            HPX_THROW_EXCEPTION(hpx::error::invalid_status,
                 "runtime_support::migrate_component_to_here",
                 "could not create copy of given component (the new id is "
                 "different from the original id)");

--- a/libs/full/runtime_distributed/include/hpx/runtime_distributed/stubs/runtime_support.hpp
+++ b/libs/full/runtime_distributed/include/hpx/runtime_distributed/stubs/runtime_support.hpp
@@ -43,7 +43,7 @@ namespace hpx { namespace components { namespace stubs {
         {
             if (!naming::is_locality(gid))
             {
-                HPX_THROW_EXCEPTION(bad_parameter,
+                HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
                     "stubs::runtime_support::create_component_async",
                     "The id passed as the first argument is not representing"
                     " a locality");
@@ -104,7 +104,7 @@ namespace hpx { namespace components { namespace stubs {
         {
             if (!naming::is_locality(gid))
             {
-                HPX_THROW_EXCEPTION(bad_parameter,
+                HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
                     "stubs::runtime_support::bulk_create_component_async",
                     "The id passed as the first argument is not representing"
                     " a locality");
@@ -163,7 +163,7 @@ namespace hpx { namespace components { namespace stubs {
         {
             if (!naming::is_locality(gid))
             {
-                HPX_THROW_EXCEPTION(bad_parameter,
+                HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
                     "stubs::runtime_support::copy_create_component_async",
                     "The id passed as the first argument is not representing"
                     " a locality");
@@ -194,7 +194,7 @@ namespace hpx { namespace components { namespace stubs {
         {
             if (!naming::is_locality(target_locality))
             {
-                HPX_THROW_EXCEPTION(bad_parameter,
+                HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
                     "stubs::runtime_support::migrate_component_async",
                     "The id passed as the first argument is not representing"
                     " a locality");

--- a/libs/full/runtime_distributed/src/big_boot_barrier.cpp
+++ b/libs/full/runtime_distributed/src/big_boot_barrier.cpp
@@ -456,13 +456,15 @@ namespace hpx { namespace agas {
 
         if (HPX_UNLIKELY(agas_client.is_connecting()))
         {
-            HPX_THROW_EXCEPTION(internal_server_error, "agas::register_worker",
+            HPX_THROW_EXCEPTION(hpx::error::internal_server_error,
+                "agas::register_worker",
                 "a locality in connect mode cannot be an AGAS server.");
         }
 
         if (HPX_UNLIKELY(!agas_client.is_bootstrap()))
         {
-            HPX_THROW_EXCEPTION(internal_server_error, "agas::register_worker",
+            HPX_THROW_EXCEPTION(hpx::error::internal_server_error,
+                "agas::register_worker",
                 "registration parcel received by non-bootstrap locality.");
         }
 
@@ -470,7 +472,8 @@ namespace hpx { namespace agas {
         if (prefix != naming::invalid_gid &&
             naming::get_locality_id_from_gid(prefix) == 0)
         {
-            HPX_THROW_EXCEPTION(internal_server_error, "agas::register_worker",
+            HPX_THROW_EXCEPTION(hpx::error::internal_server_error,
+                "agas::register_worker",
                 "worker node ({}) can't suggest locality_id zero, "
                 "this is reserved for the console",
                 header.endpoints);
@@ -480,7 +483,8 @@ namespace hpx { namespace agas {
         if (!agas_client.register_locality(
                 header.endpoints, prefix, header.num_threads))
         {
-            HPX_THROW_EXCEPTION(internal_server_error, "agas::register_worker",
+            HPX_THROW_EXCEPTION(hpx::error::internal_server_error,
+                "agas::register_worker",
                 "attempt to register locality {} more than once",
                 header.endpoints);
             return;
@@ -571,8 +575,9 @@ namespace hpx { namespace agas {
 
         if (HPX_UNLIKELY(agas_client.get_status() != hpx::state::starting))
         {
-            HPX_THROW_EXCEPTION(internal_server_error, "agas::notify_worker",
-                "locality {} has launched early", rt.here());
+            HPX_THROW_EXCEPTION(hpx::error::internal_server_error,
+                "agas::notify_worker", "locality {} has launched early",
+                rt.here());
         }
 
         util::runtime_configuration& cfg = rt.get_config();
@@ -828,7 +833,7 @@ namespace hpx { namespace agas {
             bbb;
         if (bbb.get())
         {
-            HPX_THROW_EXCEPTION(internal_server_error,
+            HPX_THROW_EXCEPTION(hpx::error::internal_server_error,
                 "create_big_boot_barrier",
                 "create_big_boot_barrier was called more than once");
         }
@@ -841,7 +846,7 @@ namespace hpx { namespace agas {
             bbb;
         if (!bbb.get())
         {
-            HPX_THROW_EXCEPTION(internal_server_error,
+            HPX_THROW_EXCEPTION(hpx::error::internal_server_error,
                 "destroy_big_boot_barrier",
                 "big_boot_barrier has not been created yet");
         }
@@ -854,7 +859,8 @@ namespace hpx { namespace agas {
             bbb;
         if (!bbb.get())
         {
-            HPX_THROW_EXCEPTION(internal_server_error, "get_big_boot_barrier",
+            HPX_THROW_EXCEPTION(hpx::error::internal_server_error,
+                "get_big_boot_barrier",
                 "big_boot_barrier has not been created yet");
         }
         return *(bbb.get());

--- a/libs/full/runtime_distributed/src/locality_interface.cpp
+++ b/libs/full/runtime_distributed/src/locality_interface.cpp
@@ -58,7 +58,7 @@ namespace hpx::parcelset {
             if (nullptr != rt)
                 return rt->get_parcel_handler().set_write_handler(f);
 
-            HPX_THROW_EXCEPTION(invalid_status,
+            HPX_THROW_EXCEPTION(hpx::error::invalid_status,
                 "hpx::set_default_parcel_write_handler",
                 "the runtime system is not operational at this point");
         }
@@ -100,7 +100,8 @@ namespace hpx::parcelset {
                     pp, num_messages, interval, ec);
             }
 
-            HPX_THROWS_IF(ec, invalid_status, "create_message_handler",
+            HPX_THROWS_IF(ec, hpx::error::invalid_status,
+                "create_message_handler",
                 "the runtime system is not available at this time");
             return nullptr;
         }

--- a/libs/full/runtime_distributed/src/runtime_distributed.cpp
+++ b/libs/full/runtime_distributed/src/runtime_distributed.cpp
@@ -1240,7 +1240,8 @@ namespace hpx {
         }
         else
         {
-            HPX_THROWS_IF(ec, invalid_status, "start_active_counters",
+            HPX_THROWS_IF(ec, hpx::error::invalid_status,
+                "start_active_counters",
                 "the runtime system is not available at this time");
         }
     }
@@ -1254,7 +1255,8 @@ namespace hpx {
         }
         else
         {
-            HPX_THROWS_IF(ec, invalid_status, "stop_active_counters",
+            HPX_THROWS_IF(ec, hpx::error::invalid_status,
+                "stop_active_counters",
                 "the runtime system is not available at this time");
         }
     }
@@ -1268,7 +1270,8 @@ namespace hpx {
         }
         else
         {
-            HPX_THROWS_IF(ec, invalid_status, "reset_active_counters",
+            HPX_THROWS_IF(ec, hpx::error::invalid_status,
+                "reset_active_counters",
                 "the runtime system is not available at this time");
         }
     }
@@ -1282,7 +1285,8 @@ namespace hpx {
         }
         else
         {
-            HPX_THROWS_IF(ec, invalid_status, "reinit_active_counters",
+            HPX_THROWS_IF(ec, hpx::error::invalid_status,
+                "reinit_active_counters",
                 "the runtime system is not available at this time");
         }
     }
@@ -1297,7 +1301,8 @@ namespace hpx {
         }
         else
         {
-            HPX_THROWS_IF(ec, invalid_status, "evaluate_active_counters",
+            HPX_THROWS_IF(ec, hpx::error::invalid_status,
+                "evaluate_active_counters",
                 "the runtime system is not available at this time");
         }
     }
@@ -1411,7 +1416,7 @@ namespace hpx {
                 // comment this out for now as on CircleCI this is causing unending grief
                 //if (ec)
                 //{
-                //    HPX_THROW_EXCEPTION(kernel_error,
+                //    HPX_THROW_EXCEPTION(hpx::error::kernel_error,
                 //        "runtime_distributed::init_tss_ex",
                 //        "failed to set thread affinity mask ({}) for service "
                 //        "thread: {}",
@@ -1486,7 +1491,7 @@ namespace hpx {
         if (0 == std::strncmp(name, "main", 4))    //-V112
             return &main_pool_;
 
-        HPX_THROW_EXCEPTION(bad_parameter,
+        HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
             "runtime_distributed::get_thread_pool",
             "unknown thread pool requested: {}", name);
         return nullptr;
@@ -1638,7 +1643,7 @@ namespace hpx {
             return rtd->create_binary_filter(
                 binary_filter_type, compress, next_filter, ec);
 
-        HPX_THROWS_IF(ec, invalid_status, "create_binary_filter",
+        HPX_THROWS_IF(ec, hpx::error::invalid_status, "create_binary_filter",
             "the runtime system is not available at this time");
         return nullptr;
     }
@@ -1687,7 +1692,7 @@ namespace hpx {
         runtime* rt = get_runtime_ptr();
         if (nullptr == rt)
         {
-            HPX_THROWS_IF(ec, invalid_status, "hpx::find_here",
+            HPX_THROWS_IF(ec, hpx::error::invalid_status, "hpx::find_here",
                 "the runtime system is not available at this time");
             return hpx::invalid_id;
         }
@@ -1702,7 +1707,8 @@ namespace hpx {
         runtime_distributed* rt = hpx::get_runtime_distributed_ptr();
         if (nullptr == rt)
         {
-            HPX_THROWS_IF(ec, invalid_status, "hpx::find_root_locality",
+            HPX_THROWS_IF(ec, hpx::error::invalid_status,
+                "hpx::find_root_locality",
                 "the runtime system is not available at this time");
             return hpx::invalid_id;
         }
@@ -1710,7 +1716,8 @@ namespace hpx {
         naming::gid_type console_locality;
         if (!rt->get_agas_client().get_console_locality(console_locality))
         {
-            HPX_THROWS_IF(ec, invalid_status, "hpx::find_root_locality",
+            HPX_THROWS_IF(ec, hpx::error::invalid_status,
+                "hpx::find_root_locality",
                 "the root locality is not available at this time");
             return hpx::invalid_id;
         }
@@ -1728,7 +1735,8 @@ namespace hpx {
         std::vector<hpx::id_type> locality_ids;
         if (nullptr == hpx::applier::get_applier_ptr())
         {
-            HPX_THROWS_IF(ec, invalid_status, "hpx::find_all_localities",
+            HPX_THROWS_IF(ec, hpx::error::invalid_status,
+                "hpx::find_all_localities",
                 "the runtime system is not available at this time");
             return locality_ids;
         }
@@ -1742,7 +1750,8 @@ namespace hpx {
         std::vector<hpx::id_type> locality_ids;
         if (nullptr == hpx::applier::get_applier_ptr())
         {
-            HPX_THROWS_IF(ec, invalid_status, "hpx::find_all_localities",
+            HPX_THROWS_IF(ec, hpx::error::invalid_status,
+                "hpx::find_all_localities",
                 "the runtime system is not available at this time");
             return locality_ids;
         }
@@ -1757,7 +1766,8 @@ namespace hpx {
         std::vector<hpx::id_type> locality_ids;
         if (nullptr == hpx::applier::get_applier_ptr())
         {
-            HPX_THROWS_IF(ec, invalid_status, "hpx::find_remote_localities",
+            HPX_THROWS_IF(ec, hpx::error::invalid_status,
+                "hpx::find_remote_localities",
                 "the runtime system is not available at this time");
             return locality_ids;
         }
@@ -1772,7 +1782,8 @@ namespace hpx {
         std::vector<hpx::id_type> locality_ids;
         if (nullptr == hpx::applier::get_applier_ptr())
         {
-            HPX_THROWS_IF(ec, invalid_status, "hpx::find_remote_localities",
+            HPX_THROWS_IF(ec, hpx::error::invalid_status,
+                "hpx::find_remote_localities",
                 "the runtime system is not available at this time");
             return locality_ids;
         }
@@ -1788,7 +1799,7 @@ namespace hpx {
     {
         if (nullptr == hpx::applier::get_applier_ptr())
         {
-            HPX_THROWS_IF(ec, invalid_status, "hpx::find_locality",
+            HPX_THROWS_IF(ec, hpx::error::invalid_status, "hpx::find_locality",
                 "the runtime system is not available at this time");
             return hpx::invalid_id;
         }
@@ -1809,7 +1820,8 @@ namespace hpx {
         runtime_distributed* rt = get_runtime_distributed_ptr();
         if (nullptr == rt)
         {
-            HPX_THROW_EXCEPTION(invalid_status, "hpx::get_num_localities",
+            HPX_THROW_EXCEPTION(hpx::error::invalid_status,
+                "hpx::get_num_localities",
                 "the runtime system has not been initialized yet");
             return 0;
         }
@@ -1823,7 +1835,8 @@ namespace hpx {
         runtime_distributed* rt = get_runtime_distributed_ptr();
         if (nullptr == rt)
         {
-            HPX_THROW_EXCEPTION(invalid_status, "hpx::get_num_localities",
+            HPX_THROW_EXCEPTION(hpx::error::invalid_status,
+                "hpx::get_num_localities",
                 "the runtime system has not been initialized yet");
             return make_ready_future(std::uint32_t(0));
         }

--- a/libs/full/runtime_distributed/src/server/runtime_support_server.cpp
+++ b/libs/full/runtime_distributed/src/server/runtime_support_server.cpp
@@ -400,7 +400,8 @@ namespace hpx { namespace components { namespace server {
     {
         if (find_here() != hpx::find_root_locality())
         {
-            HPX_THROW_EXCEPTION(invalid_status, "runtime_support::shutdown_all",
+            HPX_THROW_EXCEPTION(hpx::error::invalid_status,
+                "runtime_support::shutdown_all",
                 "shutdown_all should be invoked on the root locality only");
             return;
         }
@@ -951,7 +952,7 @@ namespace hpx { namespace components { namespace server {
             if (ec.category() != hpx::get_lightweight_hpx_category())
             {
                 // we don't know anything about this component
-                HPX_THROWS_IF(ec, hpx::bad_plugin_type,
+                HPX_THROWS_IF(ec, hpx::error::bad_plugin_type,
                     "runtime_support::create_message_handler",
                     "attempt to create message handler plugin instance of "
                     "invalid/unknown type: {}",
@@ -960,7 +961,7 @@ namespace hpx { namespace components { namespace server {
             else
             {
                 // lightweight error handling
-                HPX_THROWS_IF(ec, hpx::bad_plugin_type,
+                HPX_THROWS_IF(ec, hpx::error::bad_plugin_type,
                     "runtime_support::create_message_handler",
                     "attempt to create message handler plugin instance of "
                     "invalid/unknown type");
@@ -979,7 +980,7 @@ namespace hpx { namespace components { namespace server {
 
         if (ec)
         {
-            HPX_THROWS_IF(ec, hpx::bad_plugin_type,
+            HPX_THROWS_IF(ec, hpx::error::bad_plugin_type,
                 "runtime_support::register_message_handler",
                 "couldn't register action '{}' for message handler plugin of "
                 "type: {}",
@@ -1013,7 +1014,7 @@ namespace hpx { namespace components { namespace server {
             if (ec.category() != hpx::get_lightweight_hpx_category())
             {
                 // we don't know anything about this component
-                HPX_THROWS_IF(ec, hpx::bad_plugin_type,
+                HPX_THROWS_IF(ec, hpx::error::bad_plugin_type,
                     "runtime_support::create_message_handler",
                     "attempt to create message handler plugin instance of "
                     "invalid/unknown type: {}",
@@ -1022,7 +1023,7 @@ namespace hpx { namespace components { namespace server {
             else
             {
                 // lightweight error handling
-                HPX_THROWS_IF(ec, hpx::bad_plugin_type,
+                HPX_THROWS_IF(ec, hpx::error::bad_plugin_type,
                     "runtime_support::create_message_handler",
                     "attempt to create message handler plugin instance of "
                     "invalid/unknown type");
@@ -1041,7 +1042,7 @@ namespace hpx { namespace components { namespace server {
             factory->create(action, pp, num_messages, interval);
         if (nullptr == mh)
         {
-            HPX_THROWS_IF(ec, hpx::bad_plugin_type,
+            HPX_THROWS_IF(ec, hpx::error::bad_plugin_type,
                 "runtime_support::create_message_handler",
                 "couldn't create message handler plugin of type: {}",
                 message_handler_type);
@@ -1071,7 +1072,7 @@ namespace hpx { namespace components { namespace server {
         {
             l.unlock();
             // we don't know anything about this component
-            HPX_THROWS_IF(ec, hpx::bad_plugin_type,
+            HPX_THROWS_IF(ec, hpx::error::bad_plugin_type,
                 "runtime_support::create_binary_filter",
                 "attempt to create binary filter plugin instance of "
                 "invalid/unknown type: {}",
@@ -1090,7 +1091,7 @@ namespace hpx { namespace components { namespace server {
             factory->create(compress, next_filter);
         if (nullptr == bf)
         {
-            HPX_THROWS_IF(ec, hpx::bad_plugin_type,
+            HPX_THROWS_IF(ec, hpx::error::bad_plugin_type,
                 "runtime_support::create_binary_filter",
                 "couldn't create binary filter plugin of type: {}",
                 binary_filter_type);
@@ -1283,7 +1284,7 @@ namespace hpx { namespace components { namespace server {
                 else
                 {
 #if defined(HPX_HAVE_STATIC_LINKING)
-                    HPX_THROW_EXCEPTION(service_unavailable,
+                    HPX_THROW_EXCEPTION(hpx::error::service_unavailable,
                         "runtime_support::load_components",
                         "static linking configuration does not support dynamic "
                         "loading of component '{}'",
@@ -1300,7 +1301,8 @@ namespace hpx { namespace components { namespace server {
                 LRT_(warning).format(
                     "caught exception while loading {}, {}: {}", instance,
                     e.get_error_code().get_message(), e.what());
-                if (e.get_error_code().value() == hpx::commandline_option_error)
+                if (e.get_error_code().value() ==
+                    hpx::error::commandline_option_error)
                 {
                     std::cerr << "runtime_support::load_components: "
                               << "invalid command line option(s) to "
@@ -1766,7 +1768,7 @@ namespace hpx { namespace components { namespace server {
                 if (sect.get_entry("static", "0") == "1")
                 {
                     // FIXME: implement statically linked plugins
-                    HPX_THROW_EXCEPTION(service_unavailable,
+                    HPX_THROW_EXCEPTION(hpx::error::service_unavailable,
                         "runtime_support::load_plugins",
                         "static linking configuration does not support static "
                         "loading of plugin '{}'",
@@ -1775,7 +1777,7 @@ namespace hpx { namespace components { namespace server {
                 else
                 {
 #if defined(HPX_HAVE_STATIC_LINKING)
-                    HPX_THROW_EXCEPTION(service_unavailable,
+                    HPX_THROW_EXCEPTION(hpx::error::service_unavailable,
                         "runtime_support::load_plugins",
                         "static linking configuration does not support dynamic "
                         "loading of plugin '{}'",
@@ -1792,7 +1794,8 @@ namespace hpx { namespace components { namespace server {
                 LRT_(warning).format(
                     "caught exception while loading {}, {}: {}", instance,
                     e.get_error_code().get_message(), e.what());
-                if (e.get_error_code().value() == hpx::commandline_option_error)
+                if (e.get_error_code().value() ==
+                    hpx::error::commandline_option_error)
                 {
                     std::cerr << "runtime_support::load_plugins: "
                               << "invalid command line option(s) to "

--- a/libs/full/runtime_distributed/src/stubs/runtime_support_stubs.cpp
+++ b/libs/full/runtime_distributed/src/stubs/runtime_support_stubs.cpp
@@ -228,7 +228,7 @@ namespace hpx { namespace components { namespace stubs {
 #if !defined(HPX_COMPUTE_DEVICE_CODE)
         if (!naming::is_locality(targetgid))
         {
-            HPX_THROW_EXCEPTION(bad_parameter,
+            HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
                 "stubs::runtime_support::create_performance_counter_async",
                 "The id passed as the first argument is not representing"
                 " a locality");

--- a/libs/full/runtime_distributed/tests/regressions/unhandled_exception_582.cpp
+++ b/libs/full/runtime_distributed/tests/regressions/unhandled_exception_582.cpp
@@ -12,7 +12,7 @@
 
 int hpx_main()
 {
-    HPX_THROW_EXCEPTION(hpx::invalid_status, "hpx_main", "testing");
+    HPX_THROW_EXCEPTION(hpx::error::invalid_status, "hpx_main", "testing");
     return hpx::finalize();
 }
 
@@ -25,7 +25,7 @@ int main(int argc, char** argv)
     }
     catch (hpx::exception const& e)
     {
-        HPX_TEST(e.get_error() == hpx::invalid_status);
+        HPX_TEST(e.get_error() == hpx::error::invalid_status);
         caught_exception = true;
     }
     catch (...)

--- a/tests/performance/local/activate_counters.cpp
+++ b/tests/performance/local/activate_counters.cpp
@@ -49,7 +49,8 @@ namespace hpx { namespace util {
         hpx::id_type id = performance_counters::get_counter(info.fullname_, ec);
         if (HPX_UNLIKELY(!id))
         {
-            HPX_THROWS_IF(ec, bad_parameter, "activate_counters::find_counter",
+            HPX_THROWS_IF(ec, hpx::error::bad_parameter,
+                "activate_counters::find_counter",
                 hpx::util::format("unknown performance counter: '{1}' ({2})",
                     info.fullname_, ec.get_message()));
             return false;
@@ -135,7 +136,7 @@ namespace hpx { namespace util {
         if (ids_.empty())
         {
             // start has not been called yet
-            HPX_THROWS_IF(ec, invalid_status,
+            HPX_THROWS_IF(ec, hpx::error::invalid_status,
                 "activate_counters::stop_counters",
                 "The counters to be evaluated have not been initialized yet");
             return;
@@ -179,7 +180,7 @@ namespace hpx { namespace util {
         if (ids_.empty())
         {
             // start has not been called yet
-            HPX_THROWS_IF(ec, invalid_status,
+            HPX_THROWS_IF(ec, hpx::error::invalid_status,
                 "activate_counters::reset_counters",
                 "The counters to be evaluated have not been initialized yet");
             return;
@@ -225,7 +226,7 @@ namespace hpx { namespace util {
         if (ids_.empty())
         {
             // start has not been called yet
-            HPX_THROWS_IF(ec, invalid_status,
+            HPX_THROWS_IF(ec, hpx::error::invalid_status,
                 "activate_counters::evaluate_counters_async",
                 "The counters to be evaluated have not been initialized yet");
             return values;

--- a/tests/performance/local/stream.cpp
+++ b/tests/performance/local/stream.cpp
@@ -472,13 +472,13 @@ int hpx_main(hpx::program_options::variables_map& vm)
 
     if (vector_size < 1)
     {
-        HPX_THROW_EXCEPTION(hpx::commandline_option_error, "hpx_main",
+        HPX_THROW_EXCEPTION(hpx::error::commandline_option_error, "hpx_main",
             "Invalid vector size, must be at least 1");
     }
 
     if (iterations < 1)
     {
-        HPX_THROW_EXCEPTION(hpx::commandline_option_error, "hpx_main",
+        HPX_THROW_EXCEPTION(hpx::error::commandline_option_error, "hpx_main",
             "Invalid number of iterations given, must be at least 1");
     }
 
@@ -599,8 +599,8 @@ int hpx_main(hpx::program_options::variables_map& vm)
         }
         else
         {
-            HPX_THROW_EXCEPTION(hpx::commandline_option_error, "hpx_main",
-                "Invalid executor id given (0-4 allowed");
+            HPX_THROW_EXCEPTION(hpx::error::commandline_option_error,
+                "hpx_main", "Invalid executor id given (0-4 allowed");
         }
     }
     time_total = mysecond() - time_total;

--- a/tests/performance/local/stream_report.cpp
+++ b/tests/performance/local/stream_report.cpp
@@ -449,13 +449,13 @@ int hpx_main(hpx::program_options::variables_map& vm)
 
     if (vector_size < 1)
     {
-        HPX_THROW_EXCEPTION(hpx::commandline_option_error, "hpx_main",
+        HPX_THROW_EXCEPTION(hpx::error::commandline_option_error, "hpx_main",
             "Invalid vector size, must be at least 1");
     }
 
     if (iterations < 1)
     {
-        HPX_THROW_EXCEPTION(hpx::commandline_option_error, "hpx_main",
+        HPX_THROW_EXCEPTION(hpx::error::commandline_option_error, "hpx_main",
             "Invalid number of iterations given, must be at least 1");
     }
 

--- a/tests/regressions/threads/run_as_hpx_thread_exceptions_3304.cpp
+++ b/tests/regressions/threads/run_as_hpx_thread_exceptions_3304.cpp
@@ -42,7 +42,7 @@ int start_func(hpx::spinlock& mtx, hpx::condition_variable_any& cond)
 
 void hpx_thread_func()
 {
-    HPX_THROW_EXCEPTION(hpx::invalid_status, "hpx_thread_func", "test");
+    HPX_THROW_EXCEPTION(hpx::error::invalid_status, "hpx_thread_func", "test");
 }
 
 int main(int argc, char** argv)

--- a/tools/inspect/link_check.cpp
+++ b/tools/inspect/link_check.cpp
@@ -508,7 +508,7 @@ namespace boost { namespace inspect {
         {
             target_path = source_path.parent_path() /= path(decoded_path);
         }
-        catch (const fs::filesystem_error&)
+        catch (fs::filesystem_error const&)
         {
             if (!no_link_errors)
             {


### PR DESCRIPTION
- flyby: use c++17 std::destroy_at, where possible

working towards https://github.com/STEllAR-GROUP/hpx/issues/5497