### PR TITLE
Use pragma error directive to report warnings as errors on msvc

### DIFF
--- a/cmake/tests/cxx17_aligned_new.cpp
+++ b/cmake/tests/cxx17_aligned_new.cpp
@@ -12,7 +12,7 @@ int main()
 {
 #if defined(_MSC_VER)
 #pragma warning(push)
-#pragma warning(enable: 4316)
+#pragma warning(error: 4316)
 #elif defined(__GNUC__)
 #pragma GCC diagnostic push
 // NOTE: The actual error we're looking for here is triggered by -Waligned-new,


### PR DESCRIPTION
Fixes #6108 

