### PR TITLE
Modernize all modules from module level 8

### DIFF
--- a/cmake/HPX_AddConfigTest.cmake
+++ b/cmake/HPX_AddConfigTest.cmake
@@ -570,6 +570,15 @@ function(hpx_check_for_cxx20_trivial_virtual_destructor)
 endfunction()
 
 # ##############################################################################
+function(hpx_check_for_cxx20_std_construct_at)
+  add_hpx_config_test(
+    HPX_WITH_CXX20_STD_CONSTRUCT_AT
+    SOURCE cmake/tests/cxx20_std_construct_at.cpp
+    FILE ${ARGN}
+  )
+endfunction()
+
+# ##############################################################################
 function(hpx_check_for_cxx_lambda_capture_decltype)
   add_hpx_config_test(
     HPX_WITH_CXX_LAMBDA_CAPTURE_DECLTYPE

--- a/cmake/HPX_PerformCxxFeatureTests.cmake
+++ b/cmake/HPX_PerformCxxFeatureTests.cmake
@@ -136,6 +136,10 @@ function(hpx_perform_cxx_feature_tests)
     hpx_check_for_cxx20_trivial_virtual_destructor(
       DEFINITIONS HPX_HAVE_CXX20_TRIVIAL_VIRTUAL_DESTRUCTOR
     )
+
+    hpx_check_for_cxx20_std_construct_at(
+      DEFINITIONS HPX_HAVE_CXX20_STD_CONSTRUCT_AT
+    )
   endif()
 
   hpx_check_for_cxx_lambda_capture_decltype(

--- a/cmake/tests/cxx20_std_construct_at.cpp
+++ b/cmake/tests/cxx20_std_construct_at.cpp
@@ -1,0 +1,24 @@
+//  Copyright (c) 2022 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+// test for availability of hpx::construct_at (C++ 20)
+
+#include <memory>
+
+struct A
+{
+    A(int) {}
+};
+
+int main()
+{
+    unsigned char buffer[sizeof(A)];
+
+    A* ptr = hpx::construct_at(reinterpret_cast<A*>(buffer), 42);
+    std::destroy_at(ptr);
+
+    return 0;
+}

--- a/examples/quickstart/component_with_custom_heap.cpp
+++ b/examples/quickstart/component_with_custom_heap.cpp
@@ -265,11 +265,11 @@ namespace allocator {
                 return nullptr;
             }
 
-            new (pg) alloc_page(alloc_block<T>::allocation_size);
+            hpx::construct_at(pg, alloc_block<T>::allocation_size);
 
             // FIXME: move block construction into alloc_page constructor
             blk = new_chain = (*pg->template get_block<T>())[1];
-            new (blk) alloc_block<T>(pg);
+            hpx::construct_at(blk, pg);
 
             std::size_t blocks =
                 (alloc_page::page_size / alloc_block<T>::allocation_size) - 2;
@@ -277,7 +277,7 @@ namespace allocator {
             do
             {
                 alloc_block<T>* next = (*blk)[1];
-                new (next) alloc_block<T>(pg);
+                hpx::construct_at(next, pg);
 
                 blk->next_free = next;
                 blk = next;
@@ -286,7 +286,7 @@ namespace allocator {
             blk->next_free = nullptr;
 
             blk = pg->template get_block<T>();
-            new (blk) alloc_block<T>(pg);
+            hpx::construct_at(blk, pg);
 
             blk->next_free = nullptr;
         }

--- a/examples/quickstart/custom_serialization.cpp
+++ b/examples/quickstart/custom_serialization.cpp
@@ -11,8 +11,11 @@
 #include <hpx/hpx_main.hpp>
 #include <hpx/include/actions.hpp>
 #include <hpx/include/runtime.hpp>
+#include <hpx/include/util.hpp>
 #include <hpx/serialization.hpp>
+
 #include <iostream>
+#include <memory>
 
 //[point_member_serialization
 struct point_member_serialization
@@ -178,7 +181,7 @@ inline void load_construct_data(
     ar >> g;
 
     // ::new(ptr) construct new object at given address
-    ::new (weight_calc) planet_weight_calculator(g);
+    hpx::construct_at(weight_calc, g);
 }
 //]
 

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/uninitialized_default_construct.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/uninitialized_default_construct.hpp
@@ -166,6 +166,7 @@ namespace hpx {
 
 #include <hpx/config.hpp>
 #include <hpx/iterator_support/traits/is_iterator.hpp>
+#include <hpx/type_support/construct_at.hpp>
 #include <hpx/type_support/void_guard.hpp>
 
 #include <hpx/execution/algorithms/detail/is_negative.hpp>
@@ -214,7 +215,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
             {
                 for (/* */; s_first != first; ++s_first)
                 {
-                    (*s_first).~value_type();
+                    std::destroy_at(std::addressof(*s_first));
                 }
                 throw;
             }
@@ -234,7 +235,9 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 [](InIter it) -> void {
                     ::new (std::addressof(*it)) value_type;
                 },
-                [](InIter it) -> void { (*it).~value_type(); });
+                [](InIter it) -> void {
+                    std::destroy_at(std::addressof(*it));
+                });
         }
 
         ///////////////////////////////////////////////////////////////////////
@@ -341,7 +344,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
             {
                 for (/* */; s_first != first; ++s_first)
                 {
-                    (*s_first).~value_type();
+                    std::destroy_at(std::addressof(*s_first));
                 }
                 throw;
             }

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/uninitialized_value_construct.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/uninitialized_value_construct.hpp
@@ -163,6 +163,7 @@ namespace hpx {
 
 #include <hpx/config.hpp>
 #include <hpx/iterator_support/traits/is_iterator.hpp>
+#include <hpx/type_support/construct_at.hpp>
 #include <hpx/type_support/void_guard.hpp>
 
 #include <hpx/execution/algorithms/detail/is_negative.hpp>
@@ -195,15 +196,12 @@ namespace hpx { namespace parallel { inline namespace v1 {
         template <typename InIter, typename Sent>
         InIter std_uninitialized_value_construct(InIter first, Sent last)
         {
-            using value_type =
-                typename std::iterator_traits<InIter>::value_type;
-
             InIter s_first = first;
             try
             {
                 for (/* */; first != last; ++first)
                 {
-                    ::new (std::addressof(*first)) value_type();
+                    hpx::construct_at(std::addressof(*first));
                 }
                 return first;
             }
@@ -211,7 +209,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
             {
                 for (/* */; s_first != first; ++s_first)
                 {
-                    (*s_first).~value_type();
+                    std::destroy_at(std::addressof(*s_first));
                 }
                 throw;
             }
@@ -223,15 +221,14 @@ namespace hpx { namespace parallel { inline namespace v1 {
             std::size_t count,
             util::cancellation_token<util::detail::no_data>& tok)
         {
-            using value_type =
-                typename std::iterator_traits<InIter>::value_type;
-
             return util::loop_with_cleanup_n_with_token(
                 first, count, tok,
                 [](InIter it) -> void {
-                    ::new (std::addressof(*it)) value_type();
+                    hpx::construct_at(std::addressof(*it));
                 },
-                [](InIter it) -> void { (*it).~value_type(); });
+                [](InIter it) -> void {
+                    std::destroy_at(std::addressof(*it));
+                });
         }
 
         ///////////////////////////////////////////////////////////////////////
@@ -323,15 +320,12 @@ namespace hpx { namespace parallel { inline namespace v1 {
         InIter std_uninitialized_value_construct_n(
             InIter first, std::size_t count)
         {
-            using value_type =
-                typename std::iterator_traits<InIter>::value_type;
-
             InIter s_first = first;
             try
             {
                 for (/* */; count != 0; (void) ++first, --count)
                 {
-                    ::new (std::addressof(*first)) value_type();
+                    hpx::construct_at(std::addressof(*first));
                 }
                 return first;
             }
@@ -339,7 +333,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
             {
                 for (/* */; s_first != first; ++s_first)
                 {
-                    (*s_first).~value_type();
+                    std::destroy_at(std::addressof(*s_first));
                 }
                 throw;
             }

--- a/libs/core/algorithms/include/hpx/parallel/util/low_level.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/util/low_level.hpp
@@ -1,5 +1,5 @@
 //  Copyright (c) 2015-2017 Francisco Jose Tapia
-//  Copyright (c) 2020 Hartmut Kaiser
+//  Copyright (c) 2020-2022 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -9,6 +9,7 @@
 
 #include <hpx/config/forward.hpp>
 #include <hpx/config/move.hpp>
+#include <hpx/type_support/construct_at.hpp>
 
 #include <algorithm>
 #include <functional>
@@ -28,7 +29,7 @@ namespace hpx { namespace parallel { namespace util {
     template <typename Value, typename... Args>
     inline void construct_object(Value* ptr, Args&&... args)
     {
-        (::new (static_cast<void*>(ptr)) Value(HPX_FORWARD(Args, args)...));
+        hpx::construct_at(ptr, HPX_FORWARD(Args, args)...);
     }
 
     /// \brief destroy an object in the memory specified by ptr
@@ -54,13 +55,13 @@ namespace hpx { namespace parallel { namespace util {
             return;
         }
 
-        construct_object(&(*first), HPX_MOVE(val));
+        construct_object(std::addressof(*first), HPX_MOVE(val));
 
         Iter it1 = first, it2 = first + 1;
         while (it2 != last)
         {
             // NOLINTNEXTLINE(bugprone-macro-repeated-side-effects)
-            construct_object(&(*(it2++)), HPX_MOVE(*(it1++)));
+            construct_object(std::addressof(*(it2++)), HPX_MOVE(*(it1++)));
         }
 
         val = HPX_MOVE(*(last - 1));
@@ -74,7 +75,7 @@ namespace hpx { namespace parallel { namespace util {
     template <typename Value, typename... Args>
     inline void construct(Value* ptr, Args&&... args)
     {
-        (::new (static_cast<void*>(ptr)) Value(HPX_FORWARD(Args, args)...));
+        hpx::construct_at(ptr, HPX_FORWARD(Args, args)...);
     }
 
     /// \brief Move objects
@@ -110,7 +111,7 @@ namespace hpx { namespace parallel { namespace util {
         while (first != last)
         {
             // NOLINTNEXTLINE(bugprone-macro-repeated-side-effects)
-            ::new (static_cast<void*>(ptr++)) Value(HPX_MOVE(*(first++)));
+            hpx::construct_at(ptr++, HPX_MOVE(*(first++)));
         }
 
         return ptr;

--- a/libs/core/allocator_support/CMakeLists.txt
+++ b/libs/core/allocator_support/CMakeLists.txt
@@ -31,6 +31,6 @@ add_hpx_module(
   HEADERS ${allocator_support_headers}
   COMPAT_HEADERS ${allocator_support_compat_headers}
   DEPENDENCIES hpx_dependencies_allocator
-  MODULE_DEPENDENCIES hpx_concepts hpx_config hpx_preprocessor
+  MODULE_DEPENDENCIES hpx_concepts hpx_config hpx_preprocessor hpx_type_support
   CMAKE_SUBDIRS examples tests
 )

--- a/libs/core/allocator_support/include/hpx/allocator_support/aligned_allocator.hpp
+++ b/libs/core/allocator_support/include/hpx/allocator_support/aligned_allocator.hpp
@@ -7,6 +7,8 @@
 #pragma once
 
 #include <hpx/config.hpp>
+#include <hpx/preprocessor/cat.hpp>
+#include <hpx/type_support/construct_at.hpp>
 
 #include <cstddef>
 #include <limits>
@@ -14,8 +16,6 @@
 #include <new>
 #include <type_traits>
 #include <utility>
-
-#include <hpx/preprocessor/cat.hpp>
 
 #if defined(HPX_HAVE_JEMALLOC_PREFIX)
 // this is currently used only for jemalloc and if a special API prefix is
@@ -258,7 +258,7 @@ namespace hpx::util {
         template <typename U, typename... Args>
         void construct(U* p, Args&&... args)
         {
-            ::new ((void*) p) U(HPX_FORWARD(Args, args)...);
+            hpx::construct_at(p, HPX_FORWARD(Args, args)...);
         }
 
         template <typename U>

--- a/libs/core/allocator_support/include/hpx/allocator_support/detail/new.hpp
+++ b/libs/core/allocator_support/include/hpx/allocator_support/detail/new.hpp
@@ -6,6 +6,9 @@
 
 #pragma once
 
+#include <hpx/config.hpp>
+#include <hpx/type_support/construct_at.hpp>
+
 #include <utility>
 
 namespace hpx::util::functional {
@@ -26,7 +29,8 @@ namespace hpx::util::functional {
         template <typename... Ts>
         T* operator()(void* p, Ts&&... vs) const
         {
-            return new (p) T(HPX_FORWARD(Ts, vs)...);
+            return hpx::construct_at(
+                static_cast<T*>(p), HPX_FORWARD(Ts, vs)...);
         }
     };
 
@@ -41,7 +45,8 @@ namespace hpx::util::functional {
         template <typename... Ts>
         T* operator()(Ts&&... vs) const
         {
-            return new (p_) T(HPX_FORWARD(Ts, vs)...);
+            return hpx::construct_at(
+                static_cast<T*>(p_), HPX_FORWARD(Ts, vs)...);
         }
 
         void* p_;

--- a/libs/core/allocator_support/include/hpx/allocator_support/internal_allocator.hpp
+++ b/libs/core/allocator_support/include/hpx/allocator_support/internal_allocator.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2018 Hartmut Kaiser
+//  Copyright (c) 2018-2022 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -7,6 +7,8 @@
 #pragma once
 
 #include <hpx/config.hpp>
+#include <hpx/preprocessor/cat.hpp>
+#include <hpx/type_support/construct_at.hpp>
 
 #include <cstddef>
 #include <limits>
@@ -14,8 +16,6 @@
 #include <new>
 #include <type_traits>
 #include <utility>
-
-#include <hpx/preprocessor/cat.hpp>
 
 #if defined(HPX_HAVE_JEMALLOC_PREFIX)
 // this is currently used only for jemalloc and if a special API prefix is
@@ -95,7 +95,7 @@ namespace hpx::util {
         template <typename U, typename... Args>
         void construct(U* p, Args&&... args)
         {
-            ::new ((void*) p) U(HPX_FORWARD(Args, args)...);
+            hpx::construct_at(p, HPX_FORWARD(Args, args)...);
         }
 
         template <typename U>

--- a/libs/core/compute_local/include/hpx/compute_local/host/numa_allocator.hpp
+++ b/libs/core/compute_local/include/hpx/compute_local/host/numa_allocator.hpp
@@ -17,6 +17,7 @@
 #include <hpx/parallel/algorithms/for_each.hpp>
 #include <hpx/runtime_local/get_worker_thread_num.hpp>
 #include <hpx/topology/topology.hpp>
+#include <hpx/type_support/construct_at.hpp>
 
 #include <cstddef>
 #include <limits>
@@ -156,9 +157,9 @@ namespace hpx { namespace parallel { namespace util {
         }
 
         // construction/destruction
-        void construct(pointer p, const T& t)
+        void construct(pointer p, T const& t)
         {
-            new (p) T(t);
+            hpx::construct_at(p, t);
         }
         void destroy(pointer p)
         {

--- a/libs/core/compute_local/include/hpx/compute_local/host/numa_binding_allocator.hpp
+++ b/libs/core/compute_local/include/hpx/compute_local/host/numa_binding_allocator.hpp
@@ -17,6 +17,7 @@
 #include <hpx/runtime_local/runtime_local_fwd.hpp>
 #include <hpx/runtime_local/thread_pool_helpers.hpp>
 #include <hpx/topology/topology.hpp>
+#include <hpx/type_support/construct_at.hpp>
 
 #include <cstddef>
 #include <memory>
@@ -358,10 +359,10 @@ namespace hpx { namespace compute { namespace host {
 
         // Constructs an object of type T in allocated uninitialized storage
         // pointed to by p, using placement-new
-        template <class U, class... A>
-        void construct(U* const p, A&&... args)
+        template <typename U, typename... A>
+        void construct(U* p, A&&... args)
         {
-            new (p) U(HPX_FORWARD(A, args)...);
+            hpx::construct_at(p, HPX_FORWARD(A, args)...);
         }
 
         template <class U>

--- a/libs/core/concurrency/include/hpx/concurrency/deque.hpp
+++ b/libs/core/concurrency/include/hpx/concurrency/deque.hpp
@@ -23,6 +23,7 @@
 #include <hpx/concurrency/detail/freelist.hpp>
 #include <hpx/concurrency/detail/tagged_ptr.hpp>
 #include <hpx/concurrency/detail/tagged_ptr_pair.hpp>
+#include <hpx/type_support/construct_at.hpp>
 
 #include <atomic>
 #include <cstddef>
@@ -264,7 +265,7 @@ namespace hpx::lockfree {
             {
                 throw std::bad_alloc();
             }
-            new (chunk) node(lptr, rptr, v, ltag, rtag);
+            hpx::construct_at(chunk, lptr, rptr, v, ltag, rtag);
             return chunk;
         }
 
@@ -276,7 +277,7 @@ namespace hpx::lockfree {
             {
                 throw std::bad_alloc();
             }
-            new (chunk) node(lptr, rptr, HPX_MOVE(v), ltag, rtag);
+            hpx::construct_at(chunk, lptr, rptr, HPX_MOVE(v), ltag, rtag);
             return chunk;
         }
 

--- a/libs/core/datastructures/include/hpx/datastructures/detail/small_vector.hpp
+++ b/libs/core/datastructures/include/hpx/datastructures/detail/small_vector.hpp
@@ -33,6 +33,7 @@
 
 #include <hpx/config.hpp>
 #include <hpx/assert.hpp>
+#include <hpx/type_support/construct_at.hpp>
 
 #include <algorithm>
 #include <array>
@@ -179,7 +180,7 @@ namespace hpx::detail {
             {
                 throw std::bad_alloc();
             }
-            return new (ptr) storage<T>(capacity);
+            return hpx::construct_at(static_cast<storage<T>*>(ptr), capacity);
         }
 
         static void dealloc(storage* strg)
@@ -482,7 +483,8 @@ namespace hpx::detail {
                 for (auto ptr = d + current_size, end = d + count; ptr != end;
                      ++ptr)
                 {
-                    new (static_cast<void*>(ptr)) T(HPX_FORWARD(Args, args)...);
+                    hpx::construct_at(
+                        static_cast<T*>(ptr), HPX_FORWARD(Args, args)...);
                 }
             }
             set_size<D>(count);
@@ -885,8 +887,9 @@ namespace hpx::detail {
                 if (s < N)
                 {
                     set_direct_and_size(s + 1);
-                    return *new (static_cast<void*>(direct_data() + s))
-                        T(HPX_FORWARD(Args, args)...);
+                    return *hpx::construct_at(
+                        static_cast<T*>(direct_data() + s),
+                        HPX_FORWARD(Args, args)...);
                 }
                 realloc(calculate_new_capacity(N + 1, N));
             }
@@ -900,8 +903,9 @@ namespace hpx::detail {
             }
 
             set_size<direction::indirect>(s + 1);
-            return *new (static_cast<void*>(data<direction::indirect>() + s))
-                T(HPX_FORWARD(Args, args)...);
+            return *hpx::construct_at(
+                static_cast<T*>(data<direction::indirect>() + s),
+                HPX_FORWARD(Args, args)...);
         }
 
         void push_back(T const& value)
@@ -1113,7 +1117,8 @@ namespace hpx::detail {
         auto emplace(const_iterator pos, Args&&... args) -> iterator
         {
             auto* p = make_uninitialized_space(pos, 1);
-            return new (static_cast<void*>(p)) T(HPX_FORWARD(Args, args)...);
+            return hpx::construct_at(
+                static_cast<T*>(p), HPX_FORWARD(Args, args)...);
         }
 
         auto insert(const_iterator pos, T const& value) -> iterator

--- a/libs/core/datastructures/include/hpx/datastructures/member_pack.hpp
+++ b/libs/core/datastructures/include/hpx/datastructures/member_pack.hpp
@@ -14,7 +14,7 @@
 #include <type_traits>
 #include <utility>
 
-namespace hpx { namespace util {
+namespace hpx::util {
 
     namespace detail {
 #if defined(HPX_HAVE_MSVC_NO_UNIQUE_ADDRESS_ATTRIBUTE) ||                      \
@@ -41,6 +41,7 @@ namespace hpx { namespace util {
         {
             return leaf.member;
         }
+
         template <std::size_t I, typename T>
         static constexpr T const& member_get(
             member_leaf<I, T> const& leaf) noexcept
@@ -83,17 +84,20 @@ namespace hpx { namespace util {
         {
             return leaf.member;
         }
+
         template <std::size_t I, typename T>
         static constexpr T& member_get(member_leaf<I, T, true>& leaf) noexcept
         {
             return leaf;
         }
+
         template <std::size_t I, typename T>
         static constexpr T const& member_get(
             member_leaf<I, T, false> const& leaf) noexcept
         {
             return leaf.member;
         }
+
         template <std::size_t I, typename T>
         static constexpr T const& member_get(
             member_leaf<I, T, true> const& leaf) noexcept
@@ -125,17 +129,20 @@ namespace hpx { namespace util {
         {
             return detail::member_get<I>(*this);
         }
+
         template <std::size_t I>
         constexpr decltype(auto) get() const& noexcept
         {
             return detail::member_get<I>(*this);
         }
+
         template <std::size_t I>
         constexpr decltype(auto) get() && noexcept
         {
             using T = decltype(detail::member_type<I>(*this));
             return static_cast<T&&>(detail::member_get<I>(*this));
         }
+
         template <std::size_t I>
         constexpr decltype(auto) get() const&& noexcept
         {
@@ -147,8 +154,7 @@ namespace hpx { namespace util {
     template <typename... Ts>
     using member_pack_for =
         member_pack<util::make_index_pack_t<sizeof...(Ts)>, Ts...>;
-
-}}    // namespace hpx::util
+}    // namespace hpx::util
 
 ///////////////////////////////////////////////////////////////////////////////
 namespace hpx::serialization {

--- a/libs/core/datastructures/include/hpx/datastructures/serialization/tuple.hpp
+++ b/libs/core/datastructures/include/hpx/datastructures/serialization/tuple.hpp
@@ -15,6 +15,7 @@
 #include <hpx/serialization/serialization_fwd.hpp>
 #include <hpx/serialization/traits/is_bitwise_serializable.hpp>
 #include <hpx/serialization/traits/is_not_bitwise_serializable.hpp>
+#include <hpx/type_support/construct_at.hpp>
 #include <hpx/type_support/pack.hpp>
 
 #include <cstddef>
@@ -26,8 +27,8 @@ namespace hpx::traits {
 
     template <typename... Ts>
     struct is_bitwise_serializable<::hpx::tuple<Ts...>>
-      : ::hpx::util::all_of<hpx::traits::is_bitwise_serializable<
-            typename std::remove_const<Ts>::type>...>
+      : ::hpx::util::all_of<
+            hpx::traits::is_bitwise_serializable<std::remove_const_t<Ts>>...>
     {
     };
 
@@ -142,7 +143,7 @@ namespace hpx::serialization {
     template <typename Archive, typename... Ts>
     void serialize(Archive& ar, hpx::tuple<Ts...>& t, unsigned int version)
     {
-        using Is = typename hpx::util::make_index_pack<sizeof...(Ts)>::type;
+        using Is = hpx::util::make_index_pack_t<sizeof...(Ts)>;
         hpx::util::detail::serialize_with_index_pack<Archive, Is, Ts...>::call(
             ar, t, version);
     }
@@ -156,7 +157,7 @@ namespace hpx::serialization {
     void load_construct_data(
         Archive& ar, hpx::tuple<Ts...>* t, unsigned int version)
     {
-        using Is = typename hpx::util::make_index_pack<sizeof...(Ts)>::type;
+        using Is = hpx::util::make_index_pack_t<sizeof...(Ts)>;
         hpx::util::detail::load_construct_data_with_index_pack<Archive, Is,
             Ts...>::call(ar, *t, version);
     }
@@ -165,7 +166,7 @@ namespace hpx::serialization {
     void save_construct_data(
         Archive& ar, hpx::tuple<Ts...> const* t, unsigned int version)
     {
-        using Is = typename hpx::util::make_index_pack<sizeof...(Ts)>::type;
+        using Is = hpx::util::make_index_pack_t<sizeof...(Ts)>;
         hpx::util::detail::save_construct_data_with_index_pack<Archive, Is,
             Ts...>::call(ar, *t, version);
     }

--- a/libs/core/datastructures/include/hpx/datastructures/traits/is_tuple_like.hpp
+++ b/libs/core/datastructures/include/hpx/datastructures/traits/is_tuple_like.hpp
@@ -10,7 +10,7 @@
 
 #include <type_traits>
 
-namespace hpx { namespace traits {
+namespace hpx::traits {
 
     namespace detail {
         template <typename T, typename Enable = void>
@@ -31,4 +31,4 @@ namespace hpx { namespace traits {
     struct is_tuple_like : detail::is_tuple_like_impl<std::remove_cv_t<T>>
     {
     };
-}}    // namespace hpx::traits
+}    // namespace hpx::traits

--- a/libs/core/datastructures/include/hpx/datastructures/traits/supports_streaming_with_any.hpp
+++ b/libs/core/datastructures/include/hpx/datastructures/traits/supports_streaming_with_any.hpp
@@ -11,7 +11,8 @@
 
 #include <type_traits>
 
-namespace hpx { namespace traits {
+namespace hpx::traits {
+
     ///////////////////////////////////////////////////////////////////////////
     // Customization point for streaming with util::any
     template <typename T, typename Enable = void>
@@ -28,4 +29,4 @@ namespace hpx { namespace traits {
         serialization::serialize_buffer<T, Allocator>> : std::false_type
     {
     };
-}}    // namespace hpx::traits
+}    // namespace hpx::traits

--- a/libs/core/datastructures/include/hpx/datastructures/tuple.hpp
+++ b/libs/core/datastructures/include/hpx/datastructures/tuple.hpp
@@ -116,6 +116,7 @@ namespace hpx {
 #endif
 
 namespace hpx {
+
     template <typename... Ts>
     class tuple;
 

--- a/libs/core/datastructures/include/hpx/datastructures/variant_helper.hpp
+++ b/libs/core/datastructures/include/hpx/datastructures/variant_helper.hpp
@@ -25,32 +25,30 @@ namespace hpx {
     namespace adl_barrier {
 
         template <std::size_t I, typename... Ts>
-        constexpr HPX_HOST_DEVICE HPX_FORCEINLINE
-            typename util::at_index<I, Ts...>::type&
-            get(std::variant<Ts...>& var) noexcept
+        constexpr HPX_HOST_DEVICE HPX_FORCEINLINE util::at_index_t<I, Ts...>&
+        get(std::variant<Ts...>& var) noexcept
         {
             return std::get<I>(var);
         }
 
         template <std::size_t I, typename... Ts>
         constexpr HPX_HOST_DEVICE HPX_FORCEINLINE
-            typename util::at_index<I, Ts...>::type const&
+            util::at_index_t<I, Ts...> const&
             get(std::variant<Ts...> const& var) noexcept
         {
             return std::get<I>(var);
         }
 
         template <std::size_t I, typename... Ts>
-        constexpr HPX_HOST_DEVICE HPX_FORCEINLINE
-            typename util::at_index<I, Ts...>::type&&
-            get(std::variant<Ts...>&& var) noexcept
+        constexpr HPX_HOST_DEVICE HPX_FORCEINLINE util::at_index_t<I, Ts...>&&
+        get(std::variant<Ts...>&& var) noexcept
         {
             return std::get<I>(HPX_MOVE(var));
         }
 
         template <std::size_t I, typename... Ts>
         constexpr HPX_HOST_DEVICE HPX_FORCEINLINE
-            typename util::at_index<I, Ts...>::type const&&
+            util::at_index_t<I, Ts...> const&&
             get(std::variant<Ts...> const&& var) noexcept
         {
             return std::get<I>(HPX_MOVE(var));

--- a/libs/core/datastructures/src/serializable_any.cpp
+++ b/libs/core/datastructures/src/serializable_any.cpp
@@ -24,14 +24,14 @@
 #include <vector>
 
 ////////////////////////////////////////////////////////////////////////////////
-namespace hpx { namespace util {
+namespace hpx::util {
 
     ////////////////////////////////////////////////////////////////////////////
     namespace detail {
 
         struct hash_binary_filter : serialization::binary_filter
         {
-            explicit hash_binary_filter(std::size_t seed = 0) noexcept
+            explicit constexpr hash_binary_filter(std::size_t seed = 0) noexcept
               : hash(seed)
             {
             }
@@ -59,7 +59,7 @@ namespace hpx { namespace util {
             void load(void* /* dst */, std::size_t /* dst_count */) override {}
 
             template <class T>
-            void serialize(T&, unsigned)
+            constexpr void serialize(T&, unsigned) noexcept
             {
             }
             HPX_SERIALIZATION_POLYMORPHIC(hash_binary_filter, override);
@@ -70,9 +70,8 @@ namespace hpx { namespace util {
 
     ////////////////////////////////////////////////////////////////////////////
     template <typename Char>
-    std::size_t hash_any::operator()(
-        const basic_any<serialization::input_archive,
-            serialization::output_archive, Char, std::true_type>& elem) const
+    std::size_t hash_any::operator()(basic_any<serialization::input_archive,
+        serialization::output_archive, Char, std::true_type> const& elem) const
     {
         detail::hash_binary_filter hasher;
 
@@ -86,10 +85,10 @@ namespace hpx { namespace util {
     }
 
     template HPX_CORE_EXPORT std::size_t hash_any::operator()(
-        const basic_any<serialization::input_archive,
-            serialization::output_archive, char, std::true_type>& elem) const;
+        basic_any<serialization::input_archive, serialization::output_archive,
+            char, std::true_type> const& elem) const;
 
-    template HPX_CORE_EXPORT std::size_t
-    hash_any::operator()(const basic_any<serialization::input_archive,
-        serialization::output_archive, wchar_t, std::true_type>& elem) const;
-}}    // namespace hpx::util
+    template HPX_CORE_EXPORT std::size_t hash_any::operator()(
+        basic_any<serialization::input_archive, serialization::output_archive,
+            wchar_t, std::true_type> const& elem) const;
+}    // namespace hpx::util

--- a/libs/core/execution/CMakeLists.txt
+++ b/libs/core/execution/CMakeLists.txt
@@ -169,5 +169,6 @@ add_hpx_module(
     hpx_thread_support
     hpx_timing
     hpx_topology
+    hpx_type_support
   CMAKE_SUBDIRS examples tests
 )

--- a/libs/core/execution/include/hpx/execution/executors/polymorphic_executor.hpp
+++ b/libs/core/execution/include/hpx/execution/executors/polymorphic_executor.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2017 Hartmut Kaiser
+//  Copyright (c) 2017-2022 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -17,6 +17,7 @@
 #include <hpx/functional/move_only_function.hpp>
 #include <hpx/futures/future.hpp>
 #include <hpx/modules/thread_support.hpp>
+#include <hpx/type_support/construct_at.hpp>
 
 #include <algorithm>
 #include <cstddef>
@@ -269,7 +270,7 @@ namespace hpx { namespace parallel { namespace execution {
                     get<T>(storage).~T();
 
                 void* buffer = allocate<T>(storage, storage_size);
-                return ::new (buffer) T(get<T>(src));
+                return hpx::construct_at(static_cast<T*>(buffer), get<T>(src));
             }
             void* (*copy)(void*, std::size_t, void const*, bool);
 
@@ -755,7 +756,8 @@ namespace hpx { namespace parallel { namespace execution {
                     buffer = vtable::template allocate<T>(
                         storage, detail::polymorphic_executor_storage_size);
                 }
-                object = ::new (buffer) T(HPX_FORWARD(Exec, exec));
+                object = hpx::construct_at(
+                    static_cast<T*>(buffer), HPX_FORWARD(Exec, exec));
             }
             else
             {

--- a/libs/core/execution_base/include/hpx/execution_base/any_sender.hpp
+++ b/libs/core/execution_base/include/hpx/execution_base/any_sender.hpp
@@ -12,6 +12,7 @@
 #include <hpx/errors/throw_exception.hpp>
 #include <hpx/execution_base/completion_signatures.hpp>
 #include <hpx/execution_base/sender.hpp>
+#include <hpx/type_support/construct_at.hpp>
 
 #include <cstddef>
 #include <cstring>
@@ -207,7 +208,7 @@ namespace hpx::detail {
             if constexpr (can_use_embedded_storage<Impl>())
             {
                 Impl* p = reinterpret_cast<Impl*>(&embedded_storage);
-                new (p) Impl(HPX_FORWARD(Ts, ts)...);
+                hpx::construct_at(p, HPX_FORWARD(Ts, ts)...);
                 object = p;
             }
             else
@@ -439,7 +440,8 @@ namespace hpx::execution::experimental::detail {
 
         void move_into(void* p) override
         {
-            new (p) any_receiver_impl(HPX_MOVE(receiver));
+            hpx::construct_at(
+                static_cast<any_receiver_impl*>(p), HPX_MOVE(receiver));
         }
 
         void set_value(Ts... ts) && override
@@ -625,7 +627,8 @@ namespace hpx::execution::experimental::detail {
 
         void move_into(void* p) override
         {
-            new (p) unique_any_sender_impl(HPX_MOVE(sender));
+            hpx::construct_at(
+                static_cast<unique_any_sender_impl*>(p), HPX_MOVE(sender));
         }
 
         any_operation_state connect(any_receiver<Ts...>&& receiver) && override
@@ -649,7 +652,8 @@ namespace hpx::execution::experimental::detail {
 
         void move_into(void* p) override
         {
-            new (p) any_sender_impl(HPX_MOVE(sender));
+            hpx::construct_at(
+                static_cast<any_sender_impl*>(p), HPX_MOVE(sender));
         }
 
         any_sender_base<Ts...>* clone() const override
@@ -659,7 +663,7 @@ namespace hpx::execution::experimental::detail {
 
         void clone_into(void* p) const override
         {
-            new (p) any_sender_impl(sender);
+            hpx::construct_at(static_cast<any_sender_impl*>(p), sender);
         }
 
         any_operation_state connect(any_receiver<Ts...>&& receiver) & override

--- a/libs/core/functional/include/hpx/functional/detail/basic_function.hpp
+++ b/libs/core/functional/include/hpx/functional/detail/basic_function.hpp
@@ -1,5 +1,5 @@
 //  Copyright (c) 2011 Thomas Heller
-//  Copyright (c) 2013 Hartmut Kaiser
+//  Copyright (c) 2013-2022 Hartmut Kaiser
 //  Copyright (c) 2014-2019 Agustin Berge
 //  Copyright (c) 2017 Google
 //
@@ -17,9 +17,11 @@
 #include <hpx/functional/traits/get_function_address.hpp>
 #include <hpx/functional/traits/get_function_annotation.hpp>
 #include <hpx/functional/traits/is_invocable.hpp>
+#include <hpx/type_support/construct_at.hpp>
 
 #include <cstddef>
 #include <cstring>
+#include <memory>
 #include <new>
 #include <string>
 #include <type_traits>
@@ -168,7 +170,8 @@ namespace hpx { namespace util { namespace detail {
                     HPX_ASSERT(object != nullptr);
                     // reuse object storage
                     buffer = object;
-                    vtable::template get<T>(object).~T();
+                    std::destroy_at(
+                        std::addressof(vtable::template get<T>(object)));
                 }
                 else
                 {
@@ -177,7 +180,8 @@ namespace hpx { namespace util { namespace detail {
                     buffer = vtable::template allocate<T>(
                         storage, function_storage_size);
                 }
-                object = ::new (buffer) T(HPX_FORWARD(F, f));
+                object = hpx::construct_at(
+                    static_cast<T*>(buffer), HPX_FORWARD(F, f));
             }
             else
             {

--- a/libs/core/functional/include/hpx/functional/detail/empty_function.hpp
+++ b/libs/core/functional/include/hpx/functional/detail/empty_function.hpp
@@ -31,25 +31,24 @@ namespace hpx { namespace util { namespace detail {
     template <typename Sig, bool Copyable>
     struct function_vtable;
 
-// NOTE: nvcc (at least CUDA 9.2 and 10.1) fails with an internal compiler error
-// ("there was an error in verifying the lgenfe output!") with this enabled, so
-// we explicitly use the fallback.
+    // NOTE: nvcc (at least CUDA 9.2 and 10.1) fails with an internal compiler
+    // error ("there was an error in verifying the lgenfe output!") with this
+    // enabled, so we explicitly use the fallback.
 #if !defined(HPX_HAVE_CUDA)
-            template <typename Sig>
-            constexpr function_vtable<Sig, true> const*
-            get_empty_function_vtable() noexcept
-            {
-                return &vtables<function_vtable<Sig, true>,
-                    empty_function>::instance;
-            }
+    template <typename Sig>
+    constexpr function_vtable<Sig, true> const*
+    get_empty_function_vtable() noexcept
+    {
+        return &vtables<function_vtable<Sig, true>, empty_function>::instance;
+    }
 #else
-            template <typename Sig>
-            function_vtable<Sig, true> const*
-            get_empty_function_vtable() noexcept
-            {
-                static function_vtable<Sig, true> const empty_vtable =
-                    detail::construct_vtable<empty_function>();
-                return &empty_vtable;
-            }
+    template <typename Sig>
+    function_vtable<Sig, true> const* get_empty_function_vtable() noexcept
+    {
+        static function_vtable<Sig, true> const empty_vtable =
+            function_vtable<Sig, true>(
+                detail::construct_vtable<empty_function>());
+        return &empty_vtable;
+    }
 #endif
 }}}    // namespace hpx::util::detail

--- a/libs/core/functional/include/hpx/functional/detail/vtable/callable_vtable.hpp
+++ b/libs/core/functional/include/hpx/functional/detail/vtable/callable_vtable.hpp
@@ -53,7 +53,7 @@ namespace hpx { namespace util { namespace detail {
 #endif
 
         template <typename T>
-        constexpr callable_info_vtable(construct_vtable<T>) noexcept
+        explicit constexpr callable_info_vtable(construct_vtable<T>) noexcept
 #if defined(HPX_HAVE_THREAD_DESCRIPTION)
           : get_function_address(
                 &callable_info_vtable::template _get_function_address<T>)
@@ -67,7 +67,7 @@ namespace hpx { namespace util { namespace detail {
         {
         }
 
-        constexpr callable_info_vtable(
+        explicit constexpr callable_info_vtable(
             construct_vtable<empty_function>) noexcept
 #if defined(HPX_HAVE_THREAD_DESCRIPTION)
           : get_function_address(nullptr)

--- a/libs/core/functional/include/hpx/functional/detail/vtable/copyable_vtable.hpp
+++ b/libs/core/functional/include/hpx/functional/detail/vtable/copyable_vtable.hpp
@@ -1,5 +1,5 @@
 //  Copyright (c) 2011 Thomas Heller
-//  Copyright (c) 2013 Hartmut Kaiser
+//  Copyright (c) 2013-2022 Hartmut Kaiser
 //  Copyright (c) 2014-2015 Agustin Berge
 //
 //  SPDX-License-Identifier: BSL-1.0
@@ -12,9 +12,11 @@
 #include <hpx/functional/detail/vtable/vtable.hpp>
 
 #include <cstddef>
+#include <memory>
 #include <new>
 
 namespace hpx { namespace util { namespace detail {
+
     struct copyable_vtable
     {
         template <typename T>
@@ -22,20 +24,22 @@ namespace hpx { namespace util { namespace detail {
             void const* src, bool destroy)
         {
             if (destroy)
-                vtable::get<T>(storage).~T();
+            {
+                std::destroy_at(std::addressof(vtable::get<T>(storage)));
+            }
 
             void* buffer = vtable::allocate<T>(storage, storage_size);
             return ::new (buffer) T(vtable::get<T>(src));
         }
         void* (*copy)(void*, std::size_t, void const*, bool);
 
-        constexpr copyable_vtable(std::nullptr_t) noexcept
+        explicit constexpr copyable_vtable(std::nullptr_t) noexcept
           : copy(nullptr)
         {
         }
 
         template <typename T>
-        constexpr copyable_vtable(construct_vtable<T>) noexcept
+        explicit constexpr copyable_vtable(construct_vtable<T>) noexcept
           : copy(&copyable_vtable::template _copy<T>)
         {
         }

--- a/libs/core/functional/include/hpx/functional/detail/vtable/function_vtable.hpp
+++ b/libs/core/functional/include/hpx/functional/detail/vtable/function_vtable.hpp
@@ -52,7 +52,7 @@ namespace hpx { namespace util { namespace detail {
         using copyable_tag = std::integral_constant<bool, false>;
 
         template <typename T>
-        constexpr function_vtable(construct_vtable<T>) noexcept
+        explicit constexpr function_vtable(construct_vtable<T>) noexcept
           : function_base_vtable(construct_vtable<T>(), copyable_tag{})
           , callable_vtable<Sig>(construct_vtable<T>())
         {
@@ -72,7 +72,7 @@ namespace hpx { namespace util { namespace detail {
         using copyable_tag = std::integral_constant<bool, true>;
 
         template <typename T>
-        constexpr function_vtable(construct_vtable<T>) noexcept
+        explicit constexpr function_vtable(construct_vtable<T>) noexcept
           : function_vtable<Sig, false>(construct_vtable<T>(), copyable_tag{})
         {
         }

--- a/libs/core/functional/include/hpx/functional/detail/vtable/vtable.hpp
+++ b/libs/core/functional/include/hpx/functional/detail/vtable/vtable.hpp
@@ -23,7 +23,8 @@ namespace hpx { namespace util { namespace detail {
     template <typename VTable, typename T>
     struct vtables
     {
-        static constexpr VTable instance = detail::construct_vtable<T>();
+        static constexpr VTable instance =
+            VTable(detail::construct_vtable<T>());
     };
 
     template <typename VTable, typename T>
@@ -86,7 +87,7 @@ namespace hpx { namespace util { namespace detail {
         void (*deallocate)(void*, std::size_t storage_size, bool) noexcept;
 
         template <typename T>
-        constexpr vtable(construct_vtable<T>) noexcept
+        explicit constexpr vtable(construct_vtable<T>) noexcept
           : deallocate(&vtable::template _deallocate<T>)
         {
         }

--- a/libs/core/futures/include/hpx/futures/detail/future_data.hpp
+++ b/libs/core/futures/include/hpx/futures/detail/future_data.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2021 Hartmut Kaiser
+//  Copyright (c) 2007-2022 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -24,6 +24,7 @@
 #include <hpx/thread_support/atomic_count.hpp>
 #include <hpx/threading_base/annotated_function.hpp>
 #include <hpx/threading_base/thread_helpers.hpp>
+#include <hpx/type_support/construct_at.hpp>
 #include <hpx/type_support/unused.hpp>
 
 #include <atomic>
@@ -351,15 +352,15 @@ namespace hpx { namespace lcos { namespace detail {
     private:
         static void construct(void* p)
         {
-            ::new (p) result_type();
+            hpx::construct_at(static_cast<result_type*>(p));
         }
 
         template <typename T, typename... Ts>
         static void construct(void* p, T&& t, Ts&&... ts)
         {
-            ::new (p)
-                result_type(future_data_result<Result>::set(HPX_FORWARD(T, t)),
-                    HPX_FORWARD(Ts, ts)...);
+            hpx::construct_at(static_cast<result_type*>(p),
+                future_data_result<Result>::set(HPX_FORWARD(T, t)),
+                HPX_FORWARD(Ts, ts)...);
         }
 
     public:
@@ -396,7 +397,7 @@ namespace hpx { namespace lcos { namespace detail {
         {
             std::exception_ptr* exception_ptr =
                 reinterpret_cast<std::exception_ptr*>(&storage_);
-            ::new ((void*) exception_ptr) std::exception_ptr(e);
+            hpx::construct_at(exception_ptr, e);
             state_.store(exception, std::memory_order_relaxed);
         }
         future_data_base(init_no_addref no_addref, std::exception_ptr&& e)
@@ -404,7 +405,7 @@ namespace hpx { namespace lcos { namespace detail {
         {
             std::exception_ptr* exception_ptr =
                 reinterpret_cast<std::exception_ptr*>(&storage_);
-            ::new ((void*) exception_ptr) std::exception_ptr(HPX_MOVE(e));
+            hpx::construct_at(exception_ptr, HPX_MOVE(e));
             state_.store(exception, std::memory_order_relaxed);
         }
 
@@ -516,7 +517,7 @@ namespace hpx { namespace lcos { namespace detail {
             // set the data
             std::exception_ptr* exception_ptr =
                 reinterpret_cast<std::exception_ptr*>(&storage_);
-            ::new ((void*) exception_ptr) std::exception_ptr(HPX_MOVE(data));
+            hpx::construct_at(exception_ptr, HPX_MOVE(data));
 
             // At this point the lock needs to be acquired to safely access the
             // registered continuations

--- a/libs/core/memory/include/hpx/memory/detail/sp_convertible.hpp
+++ b/libs/core/memory/include/hpx/memory/detail/sp_convertible.hpp
@@ -12,20 +12,13 @@
 #include <hpx/config.hpp>
 
 #include <cstddef>
+#include <type_traits>
 
-namespace hpx { namespace memory { namespace detail {
+namespace hpx::memory::detail {
 
     template <typename Y, typename T>
-    struct sp_convertible
+    struct sp_convertible : std::is_convertible<Y*, T*>
     {
-        typedef char (&yes)[1];
-        typedef char (&no)[2];
-
-        static yes f(T*);
-        static no f(...);
-
-        static constexpr bool value =
-            sizeof((f)(static_cast<Y*>(nullptr))) == sizeof(yes);
     };
 
     template <typename Y, typename T>
@@ -48,5 +41,4 @@ namespace hpx { namespace memory { namespace detail {
 
     template <typename Y, typename T>
     inline constexpr bool sp_convertible_v = sp_convertible<Y, T>::value;
-
-}}}    // namespace hpx::memory::detail
+}    // namespace hpx::memory::detail

--- a/libs/core/memory/include/hpx/memory/intrusive_ptr.hpp
+++ b/libs/core/memory/include/hpx/memory/intrusive_ptr.hpp
@@ -297,7 +297,8 @@ namespace hpx {
     }
 
     template <typename T, typename U>
-    hpx::intrusive_ptr<T> dynamic_pointer_cast(hpx::intrusive_ptr<U> const& p)
+    hpx::intrusive_ptr<T> dynamic_pointer_cast(
+        hpx::intrusive_ptr<U> const& p) noexcept
     {
         return dynamic_cast<T*>(p.get());
     }
@@ -317,7 +318,8 @@ namespace hpx {
     }
 
     template <typename T, typename U>
-    hpx::intrusive_ptr<T> dynamic_pointer_cast(hpx::intrusive_ptr<U>&& p)
+    hpx::intrusive_ptr<T> dynamic_pointer_cast(
+        hpx::intrusive_ptr<U>&& p) noexcept
     {
         T* p2 = dynamic_cast<T*>(p.get());
 

--- a/libs/core/memory/include/hpx/memory/serialization/intrusive_ptr.hpp
+++ b/libs/core/memory/include/hpx/memory/serialization/intrusive_ptr.hpp
@@ -11,7 +11,7 @@
 #include <hpx/modules/memory.hpp>
 #include <hpx/serialization/serialize.hpp>
 
-namespace hpx { namespace serialization {
+namespace hpx::serialization {
 
     template <typename T>
     void load(input_archive& ar, hpx::intrusive_ptr<T>& ptr, unsigned)
@@ -27,4 +27,4 @@ namespace hpx { namespace serialization {
 
     HPX_SERIALIZATION_SPLIT_FREE_TEMPLATE(
         (template <typename T>), (hpx::intrusive_ptr<T>) )
-}}    // namespace hpx::serialization
+}    // namespace hpx::serialization

--- a/libs/core/serialization/include/hpx/serialization/binary_filter.hpp
+++ b/libs/core/serialization/include/hpx/serialization/binary_filter.hpp
@@ -33,7 +33,7 @@ namespace hpx::serialization {
         virtual void load(void* dst, std::size_t dst_count) = 0;
 
         template <typename T>
-        void serialize(T& /*ar*/, unsigned)
+        constexpr void serialize(T& /*ar*/, unsigned) noexcept
         {
         }
         HPX_SERIALIZATION_POLYMORPHIC_ABSTRACT(binary_filter);

--- a/libs/core/static_reinit/include/hpx/static_reinit/reinitializable_static.hpp
+++ b/libs/core/static_reinit/include/hpx/static_reinit/reinitializable_static.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2012 Hartmut Kaiser
+//  Copyright (c) 2007-2022 Hartmut Kaiser
 //  Copyright (c) 2006 Joao Abecasis
 //
 //  SPDX-License-Identifier: BSL-1.0
@@ -56,14 +56,14 @@ namespace hpx { namespace util {
         static void default_construct()
         {
             for (std::size_t i = 0; i < N; ++i)
-                new (get_address(i)) value_type();
+                hpx::construct_at(get_address(i));
         }
 
         template <typename U>
         static void value_construct(U const& v)
         {
             for (std::size_t i = 0; i < N; ++i)
-                new (get_address(i)) value_type(v);
+                hpx::construct_at(get_address(i), v);
         }
 
         static void destruct()

--- a/libs/core/synchronization/include/hpx/synchronization/channel_mpmc.hpp
+++ b/libs/core/synchronization/include/hpx/synchronization/channel_mpmc.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2019 Hartmut Kaiser
+//  Copyright (c) 2019-2022 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -14,6 +14,7 @@
 #include <hpx/modules/errors.hpp>
 #include <hpx/modules/thread_support.hpp>
 #include <hpx/synchronization/spinlock.hpp>
+#include <hpx/type_support/construct_at.hpp>
 
 #include <cstddef>
 #include <memory>
@@ -59,7 +60,7 @@ namespace hpx { namespace lcos { namespace local {
             // invoke constructors for allocated buffer
             for (std::size_t i = 0; i != size_; ++i)
             {
-                new (&buffer_[i]) T();
+                hpx::construct_at(&buffer_[i]);
             }
 
             head_.data_ = 0;

--- a/libs/core/synchronization/include/hpx/synchronization/channel_mpsc.hpp
+++ b/libs/core/synchronization/include/hpx/synchronization/channel_mpsc.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2019 Hartmut Kaiser
+//  Copyright (c) 2019-2022 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -14,6 +14,7 @@
 #include <hpx/modules/errors.hpp>
 #include <hpx/modules/thread_support.hpp>
 #include <hpx/synchronization/spinlock.hpp>
+#include <hpx/type_support/construct_at.hpp>
 
 #include <atomic>
 #include <cstddef>
@@ -62,7 +63,7 @@ namespace hpx { namespace lcos { namespace local {
             // invoke constructors for allocated buffer
             for (std::size_t i = 0; i != size_; ++i)
             {
-                new (&buffer_[i]) T();
+                hpx::construct_at(&buffer_[i]);
             }
 
             head_.data_.store(0, std::memory_order_relaxed);

--- a/libs/core/synchronization/include/hpx/synchronization/channel_spsc.hpp
+++ b/libs/core/synchronization/include/hpx/synchronization/channel_spsc.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2019 Hartmut Kaiser
+//  Copyright (c) 2019-2022 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -12,6 +12,7 @@
 #include <hpx/assert.hpp>
 #include <hpx/modules/concurrency.hpp>
 #include <hpx/modules/errors.hpp>
+#include <hpx/type_support/construct_at.hpp>
 
 #include <atomic>
 #include <cstddef>
@@ -57,7 +58,7 @@ namespace hpx { namespace lcos { namespace local {
             // invoke constructors for allocated buffer
             for (std::size_t i = 0; i != size_; ++i)
             {
-                new (&buffer_[i]) T();
+                hpx::construct_at(&buffer_[i]);
             }
 
             head_.data_.store(0, std::memory_order_relaxed);

--- a/libs/core/threading_base/include/hpx/threading_base/thread_data_stackful.hpp
+++ b/libs/core/threading_base/include/hpx/threading_base/thread_data_stackful.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2021 Hartmut Kaiser
+//  Copyright (c) 2007-2022 Hartmut Kaiser
 //  Copyright (c)      2011 Bryce Lelbach
 //  Copyright (c) 2008-2009 Chirag Dekate, Anshul Tandon
 //
@@ -17,6 +17,7 @@
 #include <hpx/threading_base/execution_agent.hpp>
 #include <hpx/threading_base/thread_data.hpp>
 #include <hpx/threading_base/thread_init_data.hpp>
+#include <hpx/type_support/construct_at.hpp>
 
 #include <cstddef>
 #include <cstdint>
@@ -171,8 +172,8 @@ namespace hpx { namespace threads {
     inline thread_data* thread_data_stackful::create(thread_init_data& data,
         void* queue, std::ptrdiff_t stacksize, thread_id_addref addref)
     {
-        thread_data* p = thread_alloc_.allocate(1);
-        new (p) thread_data_stackful(data, queue, stacksize, addref);
+        thread_data_stackful* p = thread_alloc_.allocate(1);
+        hpx::construct_at(p, data, queue, stacksize, addref);
         return p;
     }
 }}    // namespace hpx::threads

--- a/libs/core/threading_base/include/hpx/threading_base/thread_data_stackless.hpp
+++ b/libs/core/threading_base/include/hpx/threading_base/thread_data_stackless.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2019 Hartmut Kaiser
+//  Copyright (c) 2007-2022 Hartmut Kaiser
 //  Copyright (c)      2011 Bryce Lelbach
 //  Copyright (c) 2008-2009 Chirag Dekate, Anshul Tandon
 //
@@ -17,6 +17,7 @@
 #include <hpx/modules/errors.hpp>
 #include <hpx/threading_base/thread_data.hpp>
 #include <hpx/threading_base/thread_init_data.hpp>
+#include <hpx/type_support/construct_at.hpp>
 
 #include <cstddef>
 #include <memory>
@@ -161,8 +162,8 @@ namespace hpx { namespace threads {
     inline thread_data* thread_data_stackless::create(thread_init_data& data,
         void* queue, std::ptrdiff_t stacksize, thread_id_addref addref)
     {
-        thread_data* p = thread_alloc_.allocate(1);
-        new (p) thread_data_stackless(data, queue, stacksize, addref);
+        thread_data_stackless* p = thread_alloc_.allocate(1);
+        hpx::construct_at(p, data, queue, stacksize, addref);
         return p;
     }
 }}    // namespace hpx::threads

--- a/libs/core/type_support/CMakeLists.txt
+++ b/libs/core/type_support/CMakeLists.txt
@@ -7,6 +7,7 @@
 set(type_support_headers
     hpx/type_support/detail/with_result_of.hpp
     hpx/type_support/detail/wrap_int.hpp
+    hpx/type_support/construct_at.hpp
     hpx/type_support/decay.hpp
     hpx/type_support/detected.hpp
     hpx/type_support/empty_function.hpp

--- a/libs/core/type_support/include/hpx/type_support/construct_at.hpp
+++ b/libs/core/type_support/include/hpx/type_support/construct_at.hpp
@@ -1,0 +1,33 @@
+//  Copyright (c) 2022 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include <hpx/config.hpp>
+
+#include <memory>
+#include <new>
+#include <type_traits>
+#include <utility>
+
+namespace hpx {
+
+#if defined(HPX_HAVE_CXX20_STD_CONSTRUCT_AT)
+    using std::construct_at;
+#else
+    template <typename T, typename... Ts,
+        typename Enable = std::void_t<decltype(
+            ::new (std::declval<void*>()) T(std::declval<Ts>()...))>>
+    constexpr T* construct_at(T* addr, Ts&&... ts) noexcept(noexcept(
+        ::new (const_cast<void*>(static_cast<const volatile void*>(addr)))
+            T(HPX_FORWARD(Ts, ts)...)))
+    {
+        return ::new (const_cast<void*>(
+            static_cast<const volatile void*>(addr))) T(HPX_FORWARD(Ts, ts)...);
+    }
+#endif
+
+}    // namespace hpx

--- a/libs/core/type_support/include/hpx/type_support/static.hpp
+++ b/libs/core/type_support/include/hpx/type_support/static.hpp
@@ -112,7 +112,7 @@ namespace hpx::util {
         {
             static void construct()
             {
-                new (static_::get_address()) value_type();
+                hpx::construct_at(static_::get_address());
                 static destructor d;
             }
         };

--- a/libs/full/checkpoint_base/include/hpx/checkpoint_base/checkpoint_data.hpp
+++ b/libs/full/checkpoint_base/include/hpx/checkpoint_base/checkpoint_data.hpp
@@ -1,5 +1,5 @@
 // Copyright (c) 2018 Adrian Serio
-// Copyright (c) 2018-2021 Hartmut Kaiser
+// Copyright (c) 2018-2022 Hartmut Kaiser
 //
 // SPDX-License-Identifier: BSL-1.0
 // Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -17,7 +17,7 @@
 #include <type_traits>
 #include <utility>
 
-namespace hpx { namespace util {
+namespace hpx::util {
 
     ///////////////////////////////////////////////////////////////////////////
     // tag used to mark serialization archive during check-pointing
@@ -31,8 +31,10 @@ namespace hpx { namespace util {
     /// \tparam Container    Container used to store the check-pointed data.
     /// \tparam Ts           Types of variables to checkpoint
     ///
-    /// \param cont          Container instance used to store the checkpoint data
-    /// \param ts            Variable instances to be inserted into the checkpoint.
+    /// \param cont          Container instance used to store the checkpoint
+    ///                      data
+    /// \param ts            Variable instances to be inserted into the
+    ///                      checkpoint.
     ///
     /// Save_checkpoint_data takes any number of objects which a user may wish
     /// to store in the given container.
@@ -42,8 +44,8 @@ namespace hpx { namespace util {
         // Create serialization archive from checkpoint data member
         hpx::serialization::output_archive ar(data);
 
-        // force check-pointing flag to be created in the archive,
-        // the serialization of id_type's checks for it
+        // force check-pointing flag to be created in the archive, the
+        // serialization of id_type's checks for it
         ar.get_extra_data<checkpointing_tag>();
 
         // Serialize data
@@ -55,7 +57,8 @@ namespace hpx { namespace util {
     ///
     /// \tparam Ts           Types of variables to checkpoint
     ///
-    /// \param ts            Variable instances to be inserted into the checkpoint.
+    /// \param ts            Variable instances to be inserted into the
+    ///                      checkpoint.
     ///
     /// prepare_checkpoint_data takes any number of objects which a user may
     /// wish to store in a subsequent save_checkpoint_data operation. The
@@ -69,8 +72,8 @@ namespace hpx { namespace util {
         hpx::serialization::detail::preprocess_container data;
         hpx::serialization::output_archive ar(data);
 
-        // force check-pointing flag to be created in the archive,
-        // the serialization of id_type's checks for it
+        // force check-pointing flag to be created in the archive, the
+        // serialization of id_type's checks for it
         ar.get_extra_data<checkpointing_tag>();
 
         // Serialize data
@@ -87,10 +90,11 @@ namespace hpx { namespace util {
     ///
     /// \param cont          Container instance used to restore the checkpoint
     ///                      data
-    /// \param ts            Variable instances to be restored from the container
+    /// \param ts            Variable instances to be restored from the
+    ///                      container
     ///
-    /// restore_checkpoint_data takes any number of objects which a user may wish
-    /// to restore from the given container. The sequence of objects has to
+    /// restore_checkpoint_data takes any number of objects which a user may
+    /// wish to restore from the given container. The sequence of objects has to
     /// correspond to the sequence of objects for the corresponding call to
     /// save_checkpoint_data that had used the given container instance.
     template <typename Container, typename... Ts>
@@ -114,9 +118,10 @@ namespace hpx { namespace util {
         (f(ar, ts), ...);
     }
     /// \endcond
-}}    // namespace hpx::util
+}    // namespace hpx::util
 
-namespace hpx { namespace serialization { namespace detail {
+namespace hpx::serialization::detail {
+
     // This is explicitly instantiated to ensure that the id is stable across
     // shared libraries.
     template <>
@@ -125,4 +130,4 @@ namespace hpx { namespace serialization { namespace detail {
         HPX_EXPORT static extra_archive_data_id_type id() noexcept;
         static constexpr void reset(hpx::util::checkpointing_tag*) noexcept {}
     };
-}}}    // namespace hpx::serialization::detail
+}    // namespace hpx::serialization::detail

--- a/libs/full/checkpoint_base/src/checkpoint_data.cpp
+++ b/libs/full/checkpoint_base/src/checkpoint_data.cpp
@@ -1,5 +1,5 @@
 // Copyright (c) 2018 Adrian Serio
-// Copyright (c) 2018-2021 Hartmut Kaiser
+// Copyright (c) 2018-2022 Hartmut Kaiser
 //
 // SPDX-License-Identifier: BSL-1.0
 // Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -10,7 +10,7 @@
 
 #include <cstdint>
 
-namespace hpx { namespace serialization { namespace detail {
+namespace hpx::serialization::detail {
 
     // This is explicitly instantiated to ensure that the id is stable across
     // shared libraries.
@@ -20,4 +20,4 @@ namespace hpx { namespace serialization { namespace detail {
         static std::uint8_t id = 0;
         return &id;
     }
-}}}    // namespace hpx::serialization::detail
+}    // namespace hpx::serialization::detail

--- a/libs/full/collectives/include/hpx/collectives/detail/channel_communicator.hpp
+++ b/libs/full/collectives/include/hpx/collectives/detail/channel_communicator.hpp
@@ -87,7 +87,7 @@ namespace hpx { namespace collectives { namespace detail {
             util::ignore_while_checking il(&l);
             HPX_UNUSED(il);
 
-            data_[which].channels_[tag].set(HPX_MOVE(value));
+            data_[which].channels_[tag].set(unique_any_nonser(HPX_MOVE(value)));
         }
 
         template <typename T>

--- a/libs/full/components_base/include/hpx/components_base/server/create_component.hpp
+++ b/libs/full/components_base/include/hpx/components_base/server/create_component.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2021 Hartmut Kaiser
+//  Copyright (c) 2007-2022 Hartmut Kaiser
 //  Copyright (c) 2011-2017 Thomas Heller
 //
 //  SPDX-License-Identifier: BSL-1.0
@@ -148,7 +148,7 @@ namespace hpx { namespace components { namespace server {
             for (std::size_t i = 0; i != count; ++i, ++storage_it)
             {
                 Component* c = nullptr;
-                c = new (storage_it) Component(HPX_FORWARD(Ts, ts)...);
+                c = new (storage_it) Component(ts...);
                 naming::gid_type gid = c->get_base_gid();
                 if (!gid)
                 {

--- a/libs/full/include/include/hpx/include/util.hpp
+++ b/libs/full/include/include/hpx/include/util.hpp
@@ -20,6 +20,7 @@
 #include <hpx/iterator_support/iterator_facade.hpp>
 #include <hpx/modules/format.hpp>
 #include <hpx/modules/string_util.hpp>
+#include <hpx/modules/type_support.hpp>
 #include <hpx/preprocessor/cat.hpp>
 #include <hpx/preprocessor/expand.hpp>
 #include <hpx/preprocessor/nargs.hpp>
@@ -30,7 +31,6 @@
 #include <hpx/threading_base/annotated_function.hpp>
 #include <hpx/timing/high_resolution_clock.hpp>
 #include <hpx/timing/high_resolution_timer.hpp>
-#include <hpx/type_support/unused.hpp>
 #include <hpx/unwrap.hpp>
 #include <hpx/util/from_string.hpp>
 #include <hpx/util/get_and_reset_value.hpp>


### PR DESCRIPTION
modules: datastructures, hashing, memory, checkpointing_base

- flyby: adding `hpx::construct_at`

working towards https://github.com/STEllAR-GROUP/hpx/issues/5497