### PR TITLE
Remove the mutex lock in the critical path of get_partitioner.

### DIFF
--- a/libs/core/resource_partitioner/src/partitioner.cpp
+++ b/libs/core/resource_partitioner/src/partitioner.cpp
@@ -85,10 +85,15 @@ namespace hpx::resource {
 
         std::unique_ptr<detail::partitioner>& get_partitioner()
         {
-            std::lock_guard<std::recursive_mutex> l(partitioner_mtx());
             std::unique_ptr<detail::partitioner>& part = partitioner_ref();
-            if (!part)
-                part.reset(new detail::partitioner);
+            if (HPX_UNLIKELY(!part))
+            {
+                std::lock_guard<std::recursive_mutex> l(partitioner_mtx());
+                if (!part)
+                {
+                    part.reset(new detail::partitioner);
+                }
+            }
             return part;
         }
 


### PR DESCRIPTION
Remove the mutex lock in the critical path of hpx::resource::detail::get_partitioner.

The protected variable `partitioner_ref` is only set once during initialization.