### PR TITLE
Adding abridged static scheduler that supports running background threads only

### DIFF
--- a/libs/core/schedulers/CMakeLists.txt
+++ b/libs/core/schedulers/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2019 The STE||AR-Group
+# Copyright (c) 2019-2023 The STE||AR-Group
 #
 # SPDX-License-Identifier: BSL-1.0
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -7,6 +7,7 @@
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 
 set(schedulers_headers
+    hpx/schedulers/background_scheduler.hpp
     hpx/schedulers/deadlock_detection.hpp
     hpx/schedulers/local_priority_queue_scheduler.hpp
     hpx/schedulers/local_queue_scheduler.hpp

--- a/libs/core/schedulers/include/hpx/modules/schedulers.hpp
+++ b/libs/core/schedulers/include/hpx/modules/schedulers.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2013 Hartmut Kaiser
+//  Copyright (c) 2007-2023 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -8,6 +8,7 @@
 
 #include <hpx/config.hpp>
 
+#include <hpx/schedulers/background_scheduler.hpp>
 #include <hpx/schedulers/local_priority_queue_scheduler.hpp>
 #include <hpx/schedulers/local_queue_scheduler.hpp>
 #include <hpx/schedulers/shared_priority_queue_scheduler.hpp>

--- a/libs/core/schedulers/include/hpx/schedulers/background_scheduler.hpp
+++ b/libs/core/schedulers/include/hpx/schedulers/background_scheduler.hpp
@@ -1,0 +1,132 @@
+//  Copyright (c) 2007-2022 Hartmut Kaiser
+//  Copyright (c) 2011      Bryce Lelbach
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include <hpx/config.hpp>
+#include <hpx/assert.hpp>
+#include <hpx/modules/logging.hpp>
+#include <hpx/schedulers/deadlock_detection.hpp>
+#include <hpx/schedulers/local_queue_scheduler.hpp>
+#include <hpx/schedulers/lockfree_queue_backends.hpp>
+#include <hpx/schedulers/thread_queue.hpp>
+#include <hpx/threading_base/thread_data.hpp>
+#include <hpx/topology/topology.hpp>
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <vector>
+
+#include <hpx/config/warnings_prefix.hpp>
+
+///////////////////////////////////////////////////////////////////////////////
+namespace hpx::threads::policies {
+
+    ///////////////////////////////////////////////////////////////////////////
+#if defined(HPX_HAVE_CXX11_STD_ATOMIC_128BIT)
+    using default_static_queue_scheduler_terminated_queue = lockfree_lifo;
+#else
+    using default_static_queue_scheduler_terminated_queue = lockfree_fifo;
+#endif
+
+    ///////////////////////////////////////////////////////////////////////////
+    // The background_scheduler_scheduler runs only background work
+    template <typename Mutex = std::mutex,
+        typename PendingQueuing = lockfree_fifo,
+        typename StagedQueuing = lockfree_fifo,
+        typename TerminatedQueuing =
+            default_static_queue_scheduler_terminated_queue>
+    class background_scheduler
+      : public local_queue_scheduler<Mutex, PendingQueuing, StagedQueuing,
+            TerminatedQueuing>
+    {
+    public:
+        using base_type = local_queue_scheduler<Mutex, PendingQueuing,
+            StagedQueuing, TerminatedQueuing>;
+
+        explicit background_scheduler(
+            typename base_type::init_parameter_type const& init,
+            bool deferred_initialization = true)
+          : base_type(init, deferred_initialization)
+        {
+        }
+
+        static std::string get_scheduler_name()
+        {
+            return "background_scheduler";
+        }
+
+        void set_scheduler_mode(scheduler_mode mode) override
+        {
+            // this scheduler does not support stealing or numa stealing, but
+            // needs to enable background work
+            mode = scheduler_mode(mode & ~scheduler_mode::enable_stealing);
+            mode = scheduler_mode(mode & ~scheduler_mode::enable_stealing_numa);
+            mode = scheduler_mode(mode | ~scheduler_mode::do_background_work);
+            mode =
+                scheduler_mode(mode | ~scheduler_mode::do_background_work_only);
+            scheduler_base::set_scheduler_mode(mode);
+        }
+
+        // Return the next thread to be executed, return false if none is
+        // available. Note that this scheduler can't be used for any real work,
+        // only background work is processed by the scheduling loop
+        bool get_next_thread(
+            std::size_t, bool, threads::thread_id_ref_type&, bool) override
+        {
+            return false;
+        }
+
+        // This is a function which gets called periodically by the thread
+        // manager to allow for maintenance tasks to be executed in the
+        // scheduler. Returns true if the OS thread calling this function has to
+        // be terminated (i.e. no more work has to be done).
+        bool wait_or_add_new(std::size_t, bool running, std::int64_t&, bool,
+            std::size_t&) override
+        {
+            return !running;
+        }
+
+        void create_thread(
+            thread_init_data&, thread_id_ref_type*, error_code&) override
+        {
+            HPX_THROW_EXCEPTION(error::bad_function_call,
+                "background_scheduler::create_thread",
+                "This scheduler does not support managing 'normal' threads");
+        }
+
+        void schedule_thread(threads::thread_id_ref_type,
+            threads::thread_schedule_hint, bool,
+            thread_priority = thread_priority::default_) override
+        {
+            HPX_THROW_EXCEPTION(error::bad_function_call,
+                "background_scheduler::schedule_thread",
+                "This scheduler does not support managing 'normal' threads");
+        }
+
+        void schedule_thread_last(threads::thread_id_ref_type,
+            threads::thread_schedule_hint, bool,
+            thread_priority = thread_priority::default_) override
+        {
+            HPX_THROW_EXCEPTION(error::bad_function_call,
+                "background_scheduler::schedule_thread_last",
+                "This scheduler does not support managing 'normal' threads");
+        }
+
+        void destroy_thread(threads::thread_data*) override
+        {
+            HPX_THROW_EXCEPTION(error::bad_function_call,
+                "background_scheduler::destroy_thread",
+                "This scheduler does not support managing 'normal' threads");
+        }
+    };
+}    // namespace hpx::threads::policies
+
+#include <hpx/config/warnings_suffix.hpp>

--- a/libs/core/thread_pools/src/scheduled_thread_pool.cpp
+++ b/libs/core/thread_pools/src/scheduled_thread_pool.cpp
@@ -5,6 +5,7 @@
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <hpx/config.hpp>
+#include <hpx/schedulers/background_scheduler.hpp>
 #include <hpx/schedulers/local_priority_queue_scheduler.hpp>
 #include <hpx/schedulers/local_queue_scheduler.hpp>
 #include <hpx/schedulers/shared_priority_queue_scheduler.hpp>
@@ -22,6 +23,10 @@ template class HPX_CORE_EXPORT hpx::threads::detail::scheduled_thread_pool<
 template class HPX_CORE_EXPORT hpx::threads::policies::static_queue_scheduler<>;
 template class HPX_CORE_EXPORT hpx::threads::detail::scheduled_thread_pool<
     hpx::threads::policies::static_queue_scheduler<>>;
+
+template class HPX_CORE_EXPORT hpx::threads::policies::background_scheduler<>;
+template class HPX_CORE_EXPORT hpx::threads::detail::scheduled_thread_pool<
+    hpx::threads::policies::background_scheduler<>>;
 
 template class HPX_CORE_EXPORT
     hpx::threads::policies::local_priority_queue_scheduler<>;

--- a/libs/core/threading_base/include/hpx/threading_base/scheduler_mode.hpp
+++ b/libs/core/threading_base/include/hpx/threading_base/scheduler_mode.hpp
@@ -74,6 +74,12 @@ namespace hpx::threads::policies {
         /// exponential idle-back off
         enable_idle_backoff = 0x0800,
 
+        /// The scheduler will only call a provided callback function from a
+        /// special HPX thread to enable performing background-work, for
+        /// instance driving networking progress or garbage-collect AGAS. No
+        /// 'normal' work scheduling is performed.
+        do_background_work_only = 0x1000,
+
         // clang-format off
         /// This option represents the default mode.
         default_ =
@@ -99,7 +105,8 @@ namespace hpx::threads::policies {
             assign_work_thread_parent |
             steal_high_priority_first |
             steal_after_local |
-            enable_idle_backoff
+            enable_idle_backoff |
+            do_background_work_only
         // clang-format on
     };
 

--- a/libs/core/threadmanager/include/hpx/modules/threadmanager.hpp
+++ b/libs/core/threadmanager/include/hpx/modules/threadmanager.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2020 Hartmut Kaiser
+//  Copyright (c) 2007-2023 Hartmut Kaiser
 //  Copyright (c) 2007-2009 Chirag Dekate, Anshul Tandon
 //  Copyright (c)      2011 Bryce Lelbach, Katelyn Kufahl
 //  Copyright (c)      2017 Shoshana Jakobovits
@@ -393,6 +393,34 @@ namespace hpx { namespace threads {
 #endif
 
     private:
+        policies::thread_queue_init_parameters get_init_parameters() const;
+        void create_scheduler_user_defined(
+            hpx::resource::scheduler_function const&,
+            thread_pool_init_parameters const&,
+            policies::thread_queue_init_parameters const&);
+        void create_scheduler_local(thread_pool_init_parameters const&,
+            policies::thread_queue_init_parameters const&, std::size_t);
+        void create_scheduler_local_priority_fifo(
+            thread_pool_init_parameters const&,
+            policies::thread_queue_init_parameters const&, std::size_t);
+        void create_scheduler_local_priority_lifo(
+            thread_pool_init_parameters const&,
+            policies::thread_queue_init_parameters const&, std::size_t);
+        void create_scheduler_static(thread_pool_init_parameters const&,
+            policies::thread_queue_init_parameters const&, std::size_t);
+        void create_scheduler_static_priority(
+            thread_pool_init_parameters const&,
+            policies::thread_queue_init_parameters const&, std::size_t);
+        void create_scheduler_abp_priority_fifo(
+            thread_pool_init_parameters const&,
+            policies::thread_queue_init_parameters const&, std::size_t);
+        void create_scheduler_abp_priority_lifo(
+            thread_pool_init_parameters const&,
+            policies::thread_queue_init_parameters const&, std::size_t);
+        void create_scheduler_shared_priority(
+            thread_pool_init_parameters const&,
+            policies::thread_queue_init_parameters const&, std::size_t);
+
         mutable mutex_type mtx_;    // mutex protecting the members
 
         hpx::util::runtime_configuration& rtcfg_;


### PR DESCRIPTION
@JiakunYan This adds a new scheduler that is an abridged version of the static scheduler. This one allows running background threads only, no real work can be submitted to it. You can enable this scheduler by calling
```
    rp.create_thread_pool("lci-progress-pool",
        hpx::resource::scheduling_policy::static_,   // note: use static_
        hpx::threads::policies::scheduler_mode::do_background_work_only);
```
Please let me know if this resolves your issues.