### PR TITLE
Adding notification function for parcelports to be called after early parcel handling

### DIFF
--- a/libs/full/parcelset/src/parcelhandler.cpp
+++ b/libs/full/parcelset/src/parcelhandler.cpp
@@ -59,9 +59,10 @@
 #endif
 
 ///////////////////////////////////////////////////////////////////////////////
-namespace hpx { namespace detail {
+namespace hpx::detail {
+
     void dijkstra_make_black();    // forward declaration only
-}}                                 // namespace hpx::detail
+}    // namespace hpx::detail
 
 ///////////////////////////////////////////////////////////////////////////////
 namespace hpx::parcelset {
@@ -185,6 +186,13 @@ namespace hpx::parcelset {
                     {
                         if (pp.first > 0)
                             pp.second->run(false);
+                    }
+
+                    // early parcel handling is finished, normal operation is
+                    // about to start
+                    if (pp.first > 0)
+                    {
+                        pp.second->initialized();
                     }
                 },
                 [&](std::exception_ptr&& e) {

--- a/libs/full/parcelset_base/include/hpx/parcelset_base/parcelport.hpp
+++ b/libs/full/parcelset_base/include/hpx/parcelset_base/parcelport.hpp
@@ -91,6 +91,11 @@ namespace hpx::parcelset {
         ///                 the routine returns immediately.
         virtual bool run(bool blocking = true) = 0;
 
+        /// Notify the parcelport that the parcel layer has been initialized
+        /// globally. This function is being called after the early parcels have
+        /// been processed and normal operation is about to start.
+        virtual void initialized();
+
         virtual void flush_parcels() = 0;
 
         /// Stop the parcelport I/O thread pool.

--- a/libs/full/parcelset_base/src/parcelport.cpp
+++ b/libs/full/parcelset_base/src/parcelport.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2021 Hartmut Kaiser
+//  Copyright (c) 2007-2023 Hartmut Kaiser
 //  Copyright (c) 2013-2014 Thomas Heller
 //
 //  SPDX-License-Identifier: BSL-1.0
@@ -92,6 +92,8 @@ namespace hpx::parcelset {
     {
         return here_;
     }
+
+    void parcelport::initialized() {}
 
     bool parcelport::can_connect(
         locality const&, bool use_alternative_parcelport)


### PR DESCRIPTION
Parcelports now can override a new function `void initialized()` that will be called after early parcel handling is finished and before the thread pools are operational (i.e. before background work starts).

@JiakunYan please let me know if this is what you requested.