### PR TITLE
Fixing background scheduler to properly exit in the end

### DIFF
--- a/libs/core/resource_partitioner/include/hpx/resource_partitioner/detail/partitioner.hpp
+++ b/libs/core/resource_partitioner/include/hpx/resource_partitioner/detail/partitioner.hpp
@@ -51,10 +51,12 @@ namespace hpx::resource::detail {
         static std::size_t num_threads_overall;
 
         init_pool_data(std::string const& name, scheduling_policy policy,
-            hpx::threads::policies::scheduler_mode mode);
+            hpx::threads::policies::scheduler_mode mode,
+            background_work_function func = background_work_function());
 
         init_pool_data(std::string const& name, scheduler_function create_func,
-            hpx::threads::policies::scheduler_mode mode);
+            hpx::threads::policies::scheduler_mode mode,
+            background_work_function func = background_work_function());
 
     private:
         friend class resource::detail::partitioner;
@@ -72,6 +74,9 @@ namespace hpx::resource::detail {
         std::size_t num_threads_;
         hpx::threads::policies::scheduler_mode mode_;
         scheduler_function create_function_;
+
+        // possible additional beckground work to run on this scheduler
+        background_work_function background_work_;
     };
 
     ///////////////////////////////////////////////////////////////////////
@@ -89,12 +94,14 @@ namespace hpx::resource::detail {
         void create_thread_pool(std::string const& name,
             scheduling_policy sched = scheduling_policy::unspecified,
             hpx::threads::policies::scheduler_mode =
-                hpx::threads::policies::scheduler_mode::default_);
+                hpx::threads::policies::scheduler_mode::default_,
+            background_work_function func = background_work_function());
 
         // create a thread_pool with a callback function for creating a custom
         // scheduler
-        void create_thread_pool(
-            std::string const& name, scheduler_function scheduler_creation);
+        void create_thread_pool(std::string const& name,
+            scheduler_function scheduler_creation,
+            background_work_function func = background_work_function());
 
         // Functions to add processing units to thread pools via the
         // pu/core/numa_domain API
@@ -143,6 +150,9 @@ namespace hpx::resource::detail {
         std::size_t get_num_threads(std::size_t pool_index) const;
 
         hpx::threads::policies::scheduler_mode get_scheduler_mode(
+            std::size_t pool_index) const;
+
+        background_work_function get_background_work(
             std::size_t pool_index) const;
 
         std::string const& get_pool_name(std::size_t index) const;

--- a/libs/core/resource_partitioner/include/hpx/resource_partitioner/partitioner.hpp
+++ b/libs/core/resource_partitioner/include/hpx/resource_partitioner/partitioner.hpp
@@ -153,11 +153,13 @@ namespace hpx::resource {
         HPX_CORE_EXPORT void create_thread_pool(std::string const& name,
             scheduling_policy sched = scheduling_policy::unspecified,
             hpx::threads::policies::scheduler_mode =
-                hpx::threads::policies::scheduler_mode::default_);
+                hpx::threads::policies::scheduler_mode::default_,
+            background_work_function func = background_work_function());
 
         // Create a custom thread pool with a callback function
-        HPX_CORE_EXPORT void create_thread_pool(
-            std::string const& name, scheduler_function scheduler_creation);
+        HPX_CORE_EXPORT void create_thread_pool(std::string const& name,
+            scheduler_function scheduler_creation,
+            background_work_function func = background_work_function());
 
         // allow the default pool to be renamed to something else
         HPX_CORE_EXPORT void set_default_pool_name(std::string const& name);

--- a/libs/core/resource_partitioner/include/hpx/resource_partitioner/partitioner_fwd.hpp
+++ b/libs/core/resource_partitioner/include/hpx/resource_partitioner/partitioner_fwd.hpp
@@ -86,6 +86,8 @@ namespace hpx::resource {
             hpx::threads::thread_pool_init_parameters,
             hpx::threads::policies::thread_queue_init_parameters)>;
 
+    using background_work_function = hpx::function<bool(std::size_t)>;
+
     // Choose same names as in command-line options except with _ instead of
     // -.
 

--- a/libs/core/resource_partitioner/src/partitioner.cpp
+++ b/libs/core/resource_partitioner/src/partitioner.cpp
@@ -148,15 +148,17 @@ namespace hpx::resource {
     ///////////////////////////////////////////////////////////////////////////
     void partitioner::create_thread_pool(std::string const& name,
         scheduling_policy sched /*= scheduling_policy::unspecified*/,
-        hpx::threads::policies::scheduler_mode mode)
+        hpx::threads::policies::scheduler_mode mode,
+        background_work_function func)
     {
-        partitioner_.create_thread_pool(name, sched, mode);
+        partitioner_.create_thread_pool(name, sched, mode, HPX_MOVE(func));
     }
 
-    void partitioner::create_thread_pool(
-        std::string const& name, scheduler_function scheduler_creation)
+    void partitioner::create_thread_pool(std::string const& name,
+        scheduler_function scheduler_creation, background_work_function func)
     {
-        partitioner_.create_thread_pool(name, scheduler_creation);
+        partitioner_.create_thread_pool(
+            name, scheduler_creation, HPX_MOVE(func));
     }
 
     void partitioner::set_default_pool_name(std::string const& name)

--- a/libs/core/resource_partitioner/tests/unit/CMakeLists.txt
+++ b/libs/core/resource_partitioner/tests/unit/CMakeLists.txt
@@ -5,6 +5,7 @@
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 set(tests
+    background_scheduler
     cross_pool_injection
     named_pool_executor
     resource_partitioner_info
@@ -20,6 +21,8 @@ set(tests
     # suspend_thread_timed
     used_pus
 )
+
+set(background_scheduler_PARAMETERS THREADS_PER_LOCALITY 2)
 
 set(cross_pool_injection_PARAMETERS THREADS_PER_LOCALITY -1 TIMEOUT 300)
 set(scheduler_binding_check_PARAMETERS THREADS_PER_LOCALITY -1)

--- a/libs/core/resource_partitioner/tests/unit/background_scheduler.cpp
+++ b/libs/core/resource_partitioner/tests/unit/background_scheduler.cpp
@@ -1,0 +1,67 @@
+//  Copyright (c) 2023 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/local/init.hpp>
+#include <hpx/modules/resource_partitioner.hpp>
+#include <hpx/modules/testing.hpp>
+
+#include <atomic>
+#include <chrono>
+#include <cstddef>
+#include <string>
+#include <utility>
+#include <vector>
+
+inline constexpr char const* background_pool_name = "background-thread-pool";
+
+std::atomic<bool> background_work_called(false);
+
+bool background_work(std::size_t)
+{
+    auto* pool = hpx::this_thread::get_pool();
+    std::string name = pool->get_pool_name();
+
+    background_work_called = true;
+    HPX_TEST_EQ(name, std::string(background_pool_name));
+
+    return true;
+}
+
+int hpx_main()
+{
+    hpx::this_thread::suspend(std::chrono::seconds(1));
+    return hpx::local::finalize();
+}
+
+void init_resource_partitioner_handler(hpx::resource::partitioner& rp,
+    hpx::program_options::variables_map const& /*vm*/)
+{
+    rp.create_thread_pool(background_pool_name,
+        hpx::resource::scheduling_policy::static_,
+        hpx::threads::policies::scheduler_mode::do_background_work_only,
+        background_work);
+
+    hpx::resource::numa_domain const& d = rp.numa_domains()[0];
+    hpx::resource::core const& c = d.cores()[0];
+    hpx::resource::pu const& p = c.pus()[0];
+
+    rp.add_resource(p, background_pool_name);
+}
+
+int main(int argc, char* argv[])
+{
+    std::vector<std::string> cfg = {"hpx.force_min_os_threads!=2"};
+
+    // Set the callback to init the thread_pools
+    hpx::local::init_params init_args;
+    init_args.cfg = std::move(cfg);
+    init_args.rp_callback = &init_resource_partitioner_handler;
+
+    hpx::local::init(hpx_main, argc, argv, init_args);
+
+    HPX_TEST(background_work_called.load());
+    return hpx::util::report_errors();
+}

--- a/libs/core/schedulers/include/hpx/schedulers/local_priority_queue_scheduler.hpp
+++ b/libs/core/schedulers/include/hpx/schedulers/local_priority_queue_scheduler.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2022 Hartmut Kaiser
+//  Copyright (c) 2007-2023 Hartmut Kaiser
 //  Copyright (c) 2011      Bryce Lelbach
 //
 //  SPDX-License-Identifier: BSL-1.0
@@ -30,7 +30,7 @@
 #include <exception>
 #include <memory>
 #include <mutex>
-#include <string>
+#include <string_view>
 #include <type_traits>
 #include <vector>
 
@@ -166,7 +166,7 @@ namespace hpx::threads::policies {
             }
         }
 
-        static std::string get_scheduler_name()
+        static std::string_view get_scheduler_name()
         {
             return "local_priority_queue_scheduler";
         }
@@ -649,7 +649,7 @@ namespace hpx::threads::policies {
         // Return the next thread to be executed, return false if none is
         // available
         bool get_next_thread(std::size_t num_thread, bool running,
-            threads::thread_id_ref_type& thrd, bool enable_stealing) override
+            threads::thread_id_ref_type& thrd, bool enable_stealing)
         {
             HPX_ASSERT(num_thread < num_queues_);
             thread_queue_type* this_high_priority_queue = nullptr;
@@ -737,7 +737,7 @@ namespace hpx::threads::policies {
             return low_priority_queue_.get_next_thread(thrd);
         }
 
-        /// Schedule the passed thread
+        // Schedule the passed thread
         void schedule_thread(threads::thread_id_ref_type thrd,
             threads::thread_schedule_hint schedulehint,
             bool allow_fallback = false,
@@ -1265,7 +1265,7 @@ namespace hpx::threads::policies {
         // be terminated (i.e. no more work has to be done).
         bool wait_or_add_new(std::size_t num_thread, bool running,
             std::int64_t& idle_loop_count, bool enable_stealing,
-            std::size_t& added) override
+            std::size_t& added)
         {
             bool result = true;
 

--- a/libs/core/schedulers/include/hpx/schedulers/local_queue_scheduler.hpp
+++ b/libs/core/schedulers/include/hpx/schedulers/local_queue_scheduler.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2022 Hartmut Kaiser
+//  Copyright (c) 2007-2023 Hartmut Kaiser
 //  Copyright (c) 2011      Bryce Lelbach
 //
 //  SPDX-License-Identifier: BSL-1.0
@@ -28,7 +28,7 @@
 #include <exception>
 #include <memory>
 #include <mutex>
-#include <string>
+#include <string_view>
 #include <type_traits>
 #include <vector>
 
@@ -131,7 +131,7 @@ namespace hpx::threads::policies {
                 delete queues_[i];
         }
 
-        static std::string get_scheduler_name()
+        static std::string_view get_scheduler_name()
         {
             return "local_queue_scheduler";
         }
@@ -328,9 +328,8 @@ namespace hpx::threads::policies {
 
         // Return the next thread to be executed, return false if none is
         // available
-        virtual bool get_next_thread(std::size_t num_thread, bool running,
-            threads::thread_id_ref_type& thrd,
-            bool /*enable_stealing*/) override
+        bool get_next_thread(std::size_t num_thread, bool running,
+            threads::thread_id_ref_type& thrd, bool /*enable_stealing*/)
         {
             std::size_t queues_size = queues_.size();
 
@@ -711,9 +710,9 @@ namespace hpx::threads::policies {
         // manager to allow for maintenance tasks to be executed in the
         // scheduler. Returns true if the OS thread calling this function has to
         // be terminated (i.e. no more work has to be done).
-        virtual bool wait_or_add_new(std::size_t num_thread, bool running,
+        bool wait_or_add_new(std::size_t num_thread, bool running,
             std::int64_t& idle_loop_count, bool /* enable_stealing */,
-            std::size_t& added) override
+            std::size_t& added)
         {
             std::size_t queues_size = queues_.size();
             HPX_ASSERT(num_thread < queues_.size());

--- a/libs/core/schedulers/include/hpx/schedulers/shared_priority_queue_scheduler.hpp
+++ b/libs/core/schedulers/include/hpx/schedulers/shared_priority_queue_scheduler.hpp
@@ -36,7 +36,7 @@
 #include <memory>
 #include <mutex>
 #include <numeric>
-#include <string>
+#include <string_view>
 #include <type_traits>
 #include <vector>
 
@@ -111,7 +111,7 @@ namespace hpx::threads::policies {
         typename PendingQueuing = concurrentqueue_fifo,
         typename TerminatedQueuing =
             default_shared_priority_queue_scheduler_terminated_queue>
-    class shared_priority_queue_scheduler : public scheduler_base
+    class shared_priority_queue_scheduler final : public scheduler_base
     {
     public:
         using has_periodic_maintenance = std::false_type;
@@ -181,7 +181,7 @@ namespace hpx::threads::policies {
 
         virtual ~shared_priority_queue_scheduler() = default;
 
-        static std::string get_scheduler_name()
+        static std::string_view get_scheduler_name()
         {
             return "shared_priority_queue_scheduler";
         }
@@ -592,8 +592,8 @@ namespace hpx::threads::policies {
         }
 
         // Return the next thread to be executed, return false if none available
-        virtual bool get_next_thread(std::size_t thread_num, bool running,
-            threads::thread_id_ref_type& thrd, bool enable_stealing) override
+        bool get_next_thread(std::size_t thread_num, bool running,
+            threads::thread_id_ref_type& thrd, bool enable_stealing)
         {
             std::size_t this_thread = local_thread_number();
             HPX_ASSERT(this_thread < num_workers_);
@@ -648,9 +648,9 @@ namespace hpx::threads::policies {
         }
 
         // Return the next thread to be executed, return false if none available
-        virtual bool wait_or_add_new(std::size_t /* thread_num */,
-            bool /* running */, std::int64_t& /* idle_loop_count */,
-            bool /*enable_stealing*/, std::size_t& added) override
+        bool wait_or_add_new(std::size_t /* thread_num */, bool /* running */,
+            std::int64_t& /* idle_loop_count */, bool /*enable_stealing*/,
+            std::size_t& added)
         {
             std::size_t this_thread = local_thread_number();
             HPX_ASSERT(this_thread < num_workers_);
@@ -1218,7 +1218,7 @@ namespace hpx::threads::policies {
             {
                 HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
                     "shared_priority_queue_scheduler::on_stop_thread",
-                    "Invalid thread number: {}", std::to_string(thread_num));
+                    "Invalid thread number: {}", thread_num);
             }
             // @TODO Do we need to do any queue related cleanup here?
         }
@@ -1230,7 +1230,7 @@ namespace hpx::threads::policies {
             {
                 HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
                     "shared_priority_queue_scheduler::on_error",
-                    "Invalid thread number: {}", std::to_string(thread_num));
+                    "Invalid thread number: {}", thread_num);
             }
             // @TODO Do we need to do any queue related cleanup here?
         }

--- a/libs/core/schedulers/include/hpx/schedulers/static_priority_queue_scheduler.hpp
+++ b/libs/core/schedulers/include/hpx/schedulers/static_priority_queue_scheduler.hpp
@@ -1,5 +1,5 @@
 //  Copyright (c)      2013 Thomas Heller
-//  Copyright (c) 2007-2022 Hartmut Kaiser
+//  Copyright (c) 2007-2023 Hartmut Kaiser
 //  Copyright (c) 2011      Bryce Lelbach
 //
 //  SPDX-License-Identifier: BSL-1.0
@@ -16,9 +16,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <mutex>
-#include <string>
-
-#include <hpx/config/warnings_prefix.hpp>
+#include <string_view>
 
 ///////////////////////////////////////////////////////////////////////////////
 namespace hpx::threads::policies {
@@ -47,7 +45,7 @@ namespace hpx::threads::policies {
         typename StagedQueuing = lockfree_fifo,
         typename TerminatedQueuing =
             default_static_priority_queue_scheduler_terminated_queue>
-    class HPX_CORE_EXPORT static_priority_queue_scheduler
+    class static_priority_queue_scheduler final
       : public local_priority_queue_scheduler<Mutex, PendingQueuing,
             StagedQueuing, TerminatedQueuing>
     {
@@ -78,11 +76,9 @@ namespace hpx::threads::policies {
             scheduler_base::set_scheduler_mode(mode);
         }
 
-        static std::string get_scheduler_name()
+        static std::string_view get_scheduler_name()
         {
             return "static_priority_queue_scheduler";
         }
     };
 }    // namespace hpx::threads::policies
-
-#include <hpx/config/warnings_suffix.hpp>

--- a/libs/core/schedulers/include/hpx/schedulers/static_queue_scheduler.hpp
+++ b/libs/core/schedulers/include/hpx/schedulers/static_queue_scheduler.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2022 Hartmut Kaiser
+//  Copyright (c) 2007-2023 Hartmut Kaiser
 //  Copyright (c) 2011      Bryce Lelbach
 //
 //  SPDX-License-Identifier: BSL-1.0
@@ -21,10 +21,8 @@
 #include <cstdint>
 #include <memory>
 #include <mutex>
-#include <string>
+#include <string_view>
 #include <vector>
-
-#include <hpx/config/warnings_prefix.hpp>
 
 ///////////////////////////////////////////////////////////////////////////////
 namespace hpx::threads::policies {
@@ -45,7 +43,7 @@ namespace hpx::threads::policies {
         typename StagedQueuing = lockfree_fifo,
         typename TerminatedQueuing =
             default_static_queue_scheduler_terminated_queue>
-    class static_queue_scheduler
+    class static_queue_scheduler final
       : public local_queue_scheduler<Mutex, PendingQueuing, StagedQueuing,
             TerminatedQueuing>
     {
@@ -60,7 +58,7 @@ namespace hpx::threads::policies {
         {
         }
 
-        static std::string get_scheduler_name()
+        static std::string_view get_scheduler_name()
         {
             return "static_queue_scheduler";
         }
@@ -73,11 +71,10 @@ namespace hpx::threads::policies {
             scheduler_base::set_scheduler_mode(mode);
         }
 
-        /// Return the next thread to be executed, return false if none is
-        /// available
+        // Return the next thread to be executed, return false if none is
+        // available
         bool get_next_thread(std::size_t num_thread, bool,
-            threads::thread_id_ref_type& thrd,
-            bool /*enable_stealing*/) override
+            threads::thread_id_ref_type& thrd, bool /*enable_stealing*/)
         {
             using thread_queue_type = typename base_type::thread_queue_type;
 
@@ -102,7 +99,7 @@ namespace hpx::threads::policies {
         // be terminated (i.e. no more work has to be done).
         bool wait_or_add_new(std::size_t num_thread, bool running,
             [[maybe_unused]] std::int64_t& idle_loop_count,
-            bool /*enable_stealing*/, std::size_t& added) override
+            bool /*enable_stealing*/, std::size_t& added)
         {
             HPX_ASSERT(num_thread < this->queues_.size());
 
@@ -149,5 +146,3 @@ namespace hpx::threads::policies {
         }
     };
 }    // namespace hpx::threads::policies
-
-#include <hpx/config/warnings_suffix.hpp>

--- a/libs/core/thread_pools/CMakeLists.txt
+++ b/libs/core/thread_pools/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2019 The STE||AR-Group
+# Copyright (c) 2019-2023 The STE||AR-Group
 #
 # SPDX-License-Identifier: BSL-1.0
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -7,6 +7,9 @@
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 
 set(thread_pools_headers
+    hpx/thread_pools/detail/background_thread.hpp
+    hpx/thread_pools/detail/scheduling_callbacks.hpp
+    hpx/thread_pools/detail/scheduling_counters.hpp
     hpx/thread_pools/detail/scheduling_log.hpp
     hpx/thread_pools/detail/scoped_background_timer.hpp
     hpx/thread_pools/scheduled_thread_pool.hpp
@@ -21,7 +24,9 @@ set(thread_pools_compat_headers
 )
 # cmake-format: on
 
-set(thread_pools_sources detail/scheduling_log.cpp scheduled_thread_pool.cpp)
+set(thread_pools_sources detail/background_thread.cpp detail/scheduling_log.cpp
+                         scheduled_thread_pool.cpp
+)
 
 include(HPX_AddModule)
 add_hpx_module(

--- a/libs/core/thread_pools/include/hpx/thread_pools/detail/background_thread.hpp
+++ b/libs/core/thread_pools/include/hpx/thread_pools/detail/background_thread.hpp
@@ -1,0 +1,65 @@
+//  Copyright (c) 2023 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include <hpx/config.hpp>
+#include <hpx/coroutines/thread_enums.hpp>
+#include <hpx/execution_base/this_thread.hpp>
+#include <hpx/thread_pools/detail/scheduling_callbacks.hpp>
+#include <hpx/thread_pools/detail/scheduling_counters.hpp>
+#include <hpx/threading_base/scheduler_base.hpp>
+#include <hpx/threading_base/threading_base_fwd.hpp>
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+
+namespace hpx::threads::detail {
+
+    ///////////////////////////////////////////////////////////////////////////
+#if defined(HPX_HAVE_BACKGROUND_THREAD_COUNTERS) &&                            \
+    defined(HPX_HAVE_THREAD_IDLE_RATES)
+    struct background_work_exec_time
+    {
+        explicit constexpr background_work_exec_time(
+            scheduling_counters& counters) noexcept
+          : timer(counters.background_work_duration_)
+        {
+        }
+
+        std::int64_t& timer;
+    };
+#else
+    struct background_work_exec_time
+    {
+        constexpr explicit background_work_exec_time(
+            scheduling_counters&) noexcept
+        {
+        }
+    };
+#endif
+
+    ///////////////////////////////////////////////////////////////////////////
+    // Create a new background thread
+    HPX_CORE_EXPORT thread_id_ref_type create_background_thread(
+        threads::policies::scheduler_base& scheduler_base,
+        scheduling_callbacks& callbacks,
+        std::shared_ptr<bool>& background_running, std::size_t num_thread,
+        std::int64_t& idle_loop_count);
+
+    ///////////////////////////////////////////////////////////////////////////
+    // This function tries to invoke the background work thread. It returns
+    // false when we need to give the background thread back to scheduler and
+    // create a new one that is supposed to be executed inside the
+    // scheduling_loop, true otherwise
+    HPX_CORE_EXPORT bool call_background_thread(
+        thread_id_ref_type& background_thread, thread_id_ref_type& next_thrd,
+        threads::policies::scheduler_base& scheduler_base,
+        std::size_t num_thread, background_work_exec_time& exec_time,
+        hpx::execution_base::this_thread::detail::agent_storage*
+            context_storage);
+}    // namespace hpx::threads::detail

--- a/libs/core/thread_pools/include/hpx/thread_pools/detail/scheduling_callbacks.hpp
+++ b/libs/core/thread_pools/include/hpx/thread_pools/detail/scheduling_callbacks.hpp
@@ -1,0 +1,47 @@
+//  Copyright (c) 2023 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include <hpx/config.hpp>
+#include <hpx/functional/move_only_function.hpp>
+
+#include <cstddef>
+#include <cstdint>
+#include <limits>
+#include <utility>
+
+namespace hpx::threads::detail {
+
+    struct scheduling_callbacks
+    {
+        using callback_type = hpx::move_only_function<void()>;
+        using background_callback_type = hpx::move_only_function<bool()>;
+
+        explicit scheduling_callbacks(callback_type&& outer,
+            callback_type&& inner = callback_type(),
+            background_callback_type&& background = background_callback_type(),
+            std::size_t max_background_threads =
+                (std::numeric_limits<std::size_t>::max)(),
+            std::size_t max_idle_loop_count = HPX_IDLE_LOOP_COUNT_MAX,
+            std::size_t max_busy_loop_count = HPX_BUSY_LOOP_COUNT_MAX)
+          : outer_(HPX_MOVE(outer))
+          , inner_(HPX_MOVE(inner))
+          , background_(HPX_MOVE(background))
+          , max_background_threads_(max_background_threads)
+          , max_idle_loop_count_(max_idle_loop_count)
+          , max_busy_loop_count_(max_busy_loop_count)
+        {
+        }
+
+        callback_type outer_;
+        callback_type inner_;
+        background_callback_type background_;
+        std::size_t const max_background_threads_;
+        std::int64_t const max_idle_loop_count_;
+        std::int64_t const max_busy_loop_count_;
+    };
+}    // namespace hpx::threads::detail

--- a/libs/core/thread_pools/include/hpx/thread_pools/detail/scheduling_counters.hpp
+++ b/libs/core/thread_pools/include/hpx/thread_pools/detail/scheduling_counters.hpp
@@ -1,0 +1,78 @@
+//  Copyright (c) 2023 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include <hpx/config.hpp>
+
+#include <cstddef>
+#include <cstdint>
+
+namespace hpx::threads::detail {
+
+    ///////////////////////////////////////////////////////////////////////////
+#if defined(HPX_HAVE_BACKGROUND_THREAD_COUNTERS) &&                            \
+    defined(HPX_HAVE_THREAD_IDLE_RATES)
+    struct scheduling_counters
+    {
+        scheduling_counters(std::int64_t& executed_threads,
+            std::int64_t& executed_thread_phases, std::int64_t& tfunc_time,
+            std::int64_t& exec_time, std::int64_t& idle_loop_count,
+            std::int64_t& busy_loop_count, bool& is_active,
+            std::int64_t& background_work_duration,
+            std::int64_t& background_send_duration,
+            std::int64_t& background_receive_duration) noexcept
+          : executed_threads_(executed_threads)
+          , executed_thread_phases_(executed_thread_phases)
+          , tfunc_time_(tfunc_time)
+          , exec_time_(exec_time)
+          , idle_loop_count_(idle_loop_count)
+          , busy_loop_count_(busy_loop_count)
+          , background_work_duration_(background_work_duration)
+          , background_send_duration_(background_send_duration)
+          , background_receive_duration_(background_receive_duration)
+          , is_active_(is_active)
+        {
+        }
+
+        std::int64_t& executed_threads_;
+        std::int64_t& executed_thread_phases_;
+        std::int64_t& tfunc_time_;
+        std::int64_t& exec_time_;
+        std::int64_t& idle_loop_count_;
+        std::int64_t& busy_loop_count_;
+        std::int64_t& background_work_duration_;
+        std::int64_t& background_send_duration_;
+        std::int64_t& background_receive_duration_;
+        bool& is_active_;
+    };
+#else
+    struct scheduling_counters
+    {
+        scheduling_counters(std::int64_t& executed_threads,
+            std::int64_t& executed_thread_phases, std::int64_t& tfunc_time,
+            std::int64_t& exec_time, std::int64_t& idle_loop_count,
+            std::int64_t& busy_loop_count, bool& is_active) noexcept
+          : executed_threads_(executed_threads)
+          , executed_thread_phases_(executed_thread_phases)
+          , tfunc_time_(tfunc_time)
+          , exec_time_(exec_time)
+          , idle_loop_count_(idle_loop_count)
+          , busy_loop_count_(busy_loop_count)
+          , is_active_(is_active)
+        {
+        }
+
+        std::int64_t& executed_threads_;
+        std::int64_t& executed_thread_phases_;
+        std::int64_t& tfunc_time_;
+        std::int64_t& exec_time_;
+        std::int64_t& idle_loop_count_;
+        std::int64_t& busy_loop_count_;
+        bool& is_active_;
+    };
+#endif    // HPX_HAVE_BACKGROUND_THREAD_COUNTERS
+}    // namespace hpx::threads::detail

--- a/libs/core/thread_pools/include/hpx/thread_pools/detail/scoped_background_timer.hpp
+++ b/libs/core/thread_pools/include/hpx/thread_pools/detail/scoped_background_timer.hpp
@@ -15,7 +15,7 @@
 #if defined(HPX_HAVE_BACKGROUND_THREAD_COUNTERS) &&                            \
     defined(HPX_HAVE_THREAD_IDLE_RATES)
 
-namespace hpx::threads {
+namespace hpx::threads::detail {
 
     ////////////////////////////////////////////////////////////////////////////
     struct background_work_duration_counter
@@ -57,6 +57,6 @@ namespace hpx::threads {
         std::int64_t timestamp_;
         background_work_duration_counter& background_work_duration_;
     };
-}    // namespace hpx::threads
+}    // namespace hpx::threads::detail
 
 #endif

--- a/libs/core/thread_pools/src/detail/background_thread.cpp
+++ b/libs/core/thread_pools/src/detail/background_thread.cpp
@@ -1,0 +1,243 @@
+//  Copyright (c) 2023 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/config.hpp>
+#include <hpx/assert.hpp>
+#include <hpx/execution_base/this_thread.hpp>
+#include <hpx/thread_pools/detail/background_thread.hpp>
+#include <hpx/thread_pools/detail/scheduling_callbacks.hpp>
+#include <hpx/thread_pools/detail/scheduling_counters.hpp>
+#include <hpx/thread_pools/detail/scoped_background_timer.hpp>
+#include <hpx/threading_base/scheduler_base.hpp>
+#include <hpx/threading_base/thread_data.hpp>
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+
+namespace hpx::threads::detail {
+
+    ///////////////////////////////////////////////////////////////////////////
+    thread_id_ref_type create_background_thread(
+        threads::policies::scheduler_base& scheduler_base,
+        scheduling_callbacks& callbacks,
+        std::shared_ptr<bool>& background_running, std::size_t num_thread,
+        std::int64_t& idle_loop_count)
+    {
+        threads::thread_schedule_hint schedulehint(
+            static_cast<std::int16_t>(num_thread));
+
+        thread_id_ref_type background_thread;
+        background_running = std::make_shared<bool>(true);
+
+        thread_init_data background_init(
+            [&, background_running](
+                thread_restart_state) -> thread_result_type {
+                while (*background_running)
+                {
+                    if (callbacks.background_())
+                    {
+                        // we only update the idle_loop_count if
+                        // background_running is true. If it was false, this
+                        // task was given back to the scheduler.
+                        if (*background_running)
+                        {
+                            idle_loop_count = 0;
+                        }
+                    }
+
+                    // Force yield...
+                    hpx::execution_base::this_thread::yield("background_work");
+                }
+
+                return thread_result_type(
+                    thread_schedule_state::terminated, invalid_thread_id);
+            },
+            hpx::threads::thread_description("background_work"),
+            thread_priority::high_recursive, schedulehint,
+            thread_stacksize::large,
+            // Create in suspended to prevent the thread from being scheduled
+            // directly...
+            thread_schedule_state::suspended, true, &scheduler_base);
+
+        scheduler_base.create_thread(
+            background_init, &background_thread, hpx::throws);
+        HPX_ASSERT(background_thread);
+
+        scheduler_base.increment_background_thread_count();
+
+        // We can now set the state to pending
+        get_thread_id_data(background_thread)
+            ->set_state(thread_schedule_state::pending);
+        return background_thread;
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    class switch_status_background
+    {
+    public:
+        switch_status_background(
+            thread_id_ref_type const& t, thread_state prev_state) noexcept
+          : thread_(get_thread_id_data(t))
+          , prev_state_(prev_state)
+          , next_thread_id_(nullptr)
+          , need_restore_state_(
+                thread_->set_state_tagged(thread_schedule_state::active,
+                    prev_state_, orig_state_, std::memory_order_relaxed))
+        {
+        }
+
+        ~switch_status_background()
+        {
+            if (need_restore_state_)
+            {
+                store_state(prev_state_);
+            }
+        }
+
+        constexpr bool is_valid() const noexcept
+        {
+            return need_restore_state_;
+        }
+
+        // allow to change the state the thread will be switched to after
+        // execution
+        thread_state operator=(thread_result_type&& new_state) noexcept
+        {
+            prev_state_ = thread_state(
+                new_state.first, prev_state_.state_ex(), prev_state_.tag() + 1);
+            if (new_state.second != nullptr)
+            {
+                next_thread_id_ = HPX_MOVE(new_state.second);
+            }
+            return prev_state_;
+        }
+
+        // Get the state this thread was in before execution (usually pending),
+        // this helps making sure no other worker-thread is started to execute
+        // this HPX-thread in the meantime.
+        thread_schedule_state get_previous() const noexcept
+        {
+            return prev_state_.state();
+        }
+
+        // This restores the previous state, while making sure that the original
+        // state has not been changed since we started executing this thread.
+        // The function returns true if the state has been set, false otherwise.
+        bool store_state(thread_state& newstate) noexcept
+        {
+            disable_restore();
+            if (thread_->restore_state(prev_state_, orig_state_))
+            {
+                newstate = prev_state_;
+                return true;
+            }
+            return false;
+        }
+
+        // disable default handling in destructor
+        void disable_restore() noexcept
+        {
+            need_restore_state_ = false;
+        }
+
+        constexpr thread_id_ref_type const& get_next_thread() const noexcept
+        {
+            return next_thread_id_;
+        }
+
+        thread_id_ref_type move_next_thread() noexcept
+        {
+            return HPX_MOVE(next_thread_id_);
+        }
+
+    private:
+        thread_data* thread_;
+        thread_state prev_state_;
+        thread_state orig_state_;
+        thread_id_ref_type next_thread_id_;
+        bool need_restore_state_;
+    };
+
+    // This function tries to invoke the background work thread. It returns
+    // false when we need to give the background thread back to scheduler and
+    // create a new one that is supposed to be executed inside the
+    // scheduling_loop, true otherwise
+    bool call_background_thread(thread_id_ref_type& background_thread,
+        thread_id_ref_type& next_thrd,
+        threads::policies::scheduler_base& scheduler_base,
+        std::size_t num_thread,
+        [[maybe_unused]] background_work_exec_time& exec_time,
+        hpx::execution_base::this_thread::detail::agent_storage*
+            context_storage)
+    {
+        if (HPX_UNLIKELY(background_thread))
+        {
+            auto* thrdptr = get_thread_id_data(background_thread);
+            thread_state state = thrdptr->get_state();
+            thread_schedule_state state_val = state.state();
+
+            // we should only deal with pending here.
+            HPX_ASSERT(thread_schedule_state::pending == state_val);
+
+            // tries to set state to active (only if state is still
+            // the same as 'state')
+            detail::switch_status_background thrd_stat(
+                background_thread, state);
+
+            if (HPX_LIKELY(thrd_stat.is_valid() &&
+                    thrd_stat.get_previous() == thread_schedule_state::pending))
+            {
+#if defined(HPX_HAVE_BACKGROUND_THREAD_COUNTERS) &&                            \
+    defined(HPX_HAVE_THREAD_IDLE_RATES)
+                // measure background work duration
+                background_work_duration_counter bg_work_duration(
+                    exec_time.timer);
+                background_exec_time_wrapper bg_exec_time(bg_work_duration);
+#endif    // HPX_HAVE_BACKGROUND_THREAD_COUNTERS
+
+                // invoke background thread
+                thrd_stat = (*thrdptr)(context_storage);
+
+                thread_id_ref_type next = thrd_stat.move_next_thread();
+                if (next != nullptr && next != background_thread)
+                {
+                    if (next_thrd == nullptr)
+                    {
+                        next_thrd = HPX_MOVE(next);
+                    }
+                    else
+                    {
+                        auto* scheduler =
+                            get_thread_id_data(next)->get_scheduler_base();
+                        scheduler->schedule_thread(HPX_MOVE(next),
+                            threads::thread_schedule_hint(
+                                static_cast<std::int16_t>(num_thread)),
+                            true);
+                        scheduler->do_some_work(num_thread);
+                    }
+                }
+            }
+            thrd_stat.store_state(state);
+            state_val = state.state();
+
+            if (HPX_LIKELY(state_val == thread_schedule_state::pending_boost))
+            {
+                thrdptr->set_state(thread_schedule_state::pending);
+            }
+            else if (thread_schedule_state::terminated == state_val)
+            {
+                scheduler_base.decrement_background_thread_count();
+                background_thread = thread_id_type();
+            }
+            else if (thread_schedule_state::suspended == state_val)
+            {
+                return false;
+            }
+        }
+        return true;
+    }
+}    // namespace hpx::threads::detail

--- a/libs/core/threading_base/include/hpx/threading_base/scheduler_base.hpp
+++ b/libs/core/threading_base/include/hpx/threading_base/scheduler_base.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2022 Hartmut Kaiser
+//  Copyright (c) 2007-2023 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -55,7 +55,7 @@ namespace hpx::threads::policies {
     ///////////////////////////////////////////////////////////////////////////
     /// The scheduler_base defines the interface to be implemented by all
     /// scheduler policies
-    struct HPX_CORE_EXPORT scheduler_base
+    struct scheduler_base
     {
     public:
         HPX_NON_COPYABLE(scheduler_base);
@@ -165,7 +165,7 @@ namespace hpx::threads::policies {
         std::size_t domain_from_local_thread_index(std::size_t n);
 
         // assumes queues use index 0..N-1 and correspond to the pool cores
-        std::size_t num_domains(const std::size_t workers);
+        std::size_t num_domains(std::size_t const workers);
 
         // either threads in same domain, or not in same domain
         // depending on the predicate
@@ -226,9 +226,6 @@ namespace hpx::threads::policies {
         virtual void create_thread(
             thread_init_data& data, thread_id_ref_type* id, error_code& ec) = 0;
 
-        virtual bool get_next_thread(std::size_t num_thread, bool running,
-            threads::thread_id_ref_type& thrd, bool enable_stealing) = 0;
-
         virtual void schedule_thread(threads::thread_id_ref_type thrd,
             threads::thread_schedule_hint schedulehint,
             bool allow_fallback = false,
@@ -240,10 +237,6 @@ namespace hpx::threads::policies {
             thread_priority priority = thread_priority::default_) = 0;
 
         virtual void destroy_thread(threads::thread_data* thrd) = 0;
-
-        virtual bool wait_or_add_new(std::size_t num_thread, bool running,
-            std::int64_t& idle_loop_count, bool enable_stealing,
-            std::size_t& added) = 0;
 
         virtual void on_start_thread(std::size_t num_thread) = 0;
         virtual void on_stop_thread(std::size_t num_thread) = 0;

--- a/libs/core/threading_base/include/hpx/threading_base/threading_base_fwd.hpp
+++ b/libs/core/threading_base/include/hpx/threading_base/threading_base_fwd.hpp
@@ -40,7 +40,7 @@ namespace hpx::threads {
 
     namespace policies {
 
-        struct scheduler_base;
+        struct HPX_CORE_EXPORT scheduler_base;
     }
     class HPX_CORE_EXPORT thread_pool_base;
 

--- a/libs/full/runtime_distributed/src/runtime_distributed.cpp
+++ b/libs/full/runtime_distributed/src/runtime_distributed.cpp
@@ -57,6 +57,7 @@
 #include <hpx/runtime_local/state.hpp>
 #include <hpx/runtime_local/thread_hooks.hpp>
 #include <hpx/runtime_local/thread_mapper.hpp>
+#include <hpx/thread_pools/detail/scoped_background_timer.hpp>
 #include <hpx/thread_support/set_thread_name.hpp>
 #include <hpx/threading_base/external_timer.hpp>
 #include <hpx/threading_base/scheduler_mode.hpp>
@@ -118,9 +119,9 @@ namespace hpx {
 #if defined(HPX_HAVE_NETWORKING)
             // count background work duration
             {
-                threads::background_work_duration_counter bg_send_duration(
-                    background_work_exec_time_send);
-                threads::background_exec_time_wrapper bg_exec_time(
+                threads::detail::background_work_duration_counter
+                    bg_send_duration(background_work_exec_time_send);
+                threads::detail::background_exec_time_wrapper bg_exec_time(
                     bg_send_duration);
 
                 if (hpx::parcelset::do_background_work(
@@ -131,9 +132,9 @@ namespace hpx {
             }
 
             {
-                threads::background_work_duration_counter bg_receive_duration(
-                    background_work_exec_time_receive);
-                threads::background_exec_time_wrapper bg_exec_time(
+                threads::detail::background_work_duration_counter
+                    bg_receive_duration(background_work_exec_time_receive);
+                threads::detail::background_exec_time_wrapper bg_exec_time(
                     bg_receive_duration);
 
                 if (hpx::parcelset::do_background_work(num_thread,
@@ -1846,7 +1847,7 @@ namespace hpx {
 }    // namespace hpx
 
 ///////////////////////////////////////////////////////////////////////////////
-namespace hpx { namespace naming {
+namespace hpx::naming {
 
     // shortcut for get_runtime().get_agas_client()
     resolver_client& get_agas_client()
@@ -1860,11 +1861,11 @@ namespace hpx { namespace naming {
         auto* rtd = get_runtime_distributed_ptr();
         return rtd ? &rtd->get_agas_client() : nullptr;
     }
-}}    // namespace hpx::naming
+}    // namespace hpx::naming
 
 ///////////////////////////////////////////////////////////////////////////////
 #if defined(HPX_HAVE_NETWORKING)
-namespace hpx { namespace parcelset {
+namespace hpx::parcelset {
 
     bool do_background_work(
         std::size_t num_thread, parcelport_background_mode mode)
@@ -1886,5 +1887,5 @@ namespace hpx { namespace parcelset {
         auto* rtd = get_runtime_distributed_ptr();
         return rtd ? &rtd->get_parcel_handler() : nullptr;
     }
-}}    // namespace hpx::parcelset
+}    // namespace hpx::parcelset
 #endif


### PR DESCRIPTION
- flyby: add API to add background work to any thread pool
