### PR TITLE
Avoid ambiguities wrt tag_invoke

### DIFF
--- a/.jenkins/lsu/env-gcc-10-cuda-11.sh
+++ b/.jenkins/lsu/env-gcc-10-cuda-11.sh
@@ -9,7 +9,7 @@ module load cmake
 module load gcc/10
 module load boost/1.75.0-${build_type,,}
 module load hwloc
-module load cuda/11
+module load cuda/11.5
 module load openmpi
 
 export CXX_STD="17"

--- a/libs/core/async_combinators/include/hpx/async_combinators/wait_all.hpp
+++ b/libs/core/async_combinators/include/hpx/async_combinators/wait_all.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2022 Hartmut Kaiser
+//  Copyright (c) 2007-2023 Hartmut Kaiser
 //  Copyright (c) 2013 Agustin Berge
 //
 //  SPDX-License-Identifier: BSL-1.0
@@ -441,8 +441,7 @@ namespace hpx {
     {
     private:
         template <typename Future>
-        friend bool tag_invoke(
-            wait_all_nothrow_t, std::vector<Future> const& values)
+        static bool wait_all_nothrow_impl(std::vector<Future> const& values)
         {
             if (!values.empty())
             {
@@ -460,10 +459,17 @@ namespace hpx {
         }
 
         template <typename Future>
+        friend bool tag_invoke(
+            wait_all_nothrow_t, std::vector<Future> const& values)
+        {
+            return wait_all_nothrow_t::wait_all_nothrow_impl(values);
+        }
+
+        template <typename Future>
         friend HPX_WAIT_ALL_FORCEINLINE bool tag_invoke(
             wait_all_nothrow_t, std::vector<Future>& values)
         {
-            return tag_invoke(wait_all_nothrow_t{},
+            return wait_all_nothrow_t::wait_all_nothrow_impl(
                 const_cast<std::vector<Future> const&>(values));
         }
 
@@ -471,13 +477,12 @@ namespace hpx {
         friend HPX_WAIT_ALL_FORCEINLINE bool tag_invoke(
             wait_all_nothrow_t, std::vector<Future>&& values)
         {
-            return tag_invoke(wait_all_nothrow_t{},
+            return wait_all_nothrow_t::wait_all_nothrow_impl(
                 const_cast<std::vector<Future> const&>(values));
         }
 
         template <typename Future, std::size_t N>
-        friend bool tag_invoke(
-            wait_all_nothrow_t, std::array<Future, N> const& values)
+        static bool wait_all_nothrow_impl(std::array<Future, N> const& values)
         {
             using result_type = hpx::tuple<std::array<Future, N> const&>;
             using frame_type = hpx::detail::wait_all_frame<result_type>;
@@ -490,10 +495,17 @@ namespace hpx {
         }
 
         template <typename Future, std::size_t N>
+        friend bool tag_invoke(
+            wait_all_nothrow_t, std::array<Future, N> const& values)
+        {
+            return wait_all_nothrow_t::wait_all_nothrow_impl(values);
+        }
+
+        template <typename Future, std::size_t N>
         friend HPX_WAIT_ALL_FORCEINLINE bool tag_invoke(
             wait_all_nothrow_t, std::array<Future, N>& values)
         {
-            return tag_invoke(wait_all_nothrow_t{},
+            return wait_all_nothrow_t::wait_all_nothrow_impl(
                 const_cast<std::array<Future, N> const&>(values));
         }
 
@@ -508,7 +520,7 @@ namespace hpx {
             }
 
             auto values = traits::acquire_shared_state<Iterator>()(begin, end);
-            return tag_invoke(wait_all_nothrow_t{}, values);
+            return wait_all_nothrow_t::wait_all_nothrow_impl(values);
         }
 
         friend HPX_WAIT_ALL_FORCEINLINE constexpr bool tag_invoke(

--- a/libs/core/async_combinators/include/hpx/async_combinators/wait_any.hpp
+++ b/libs/core/async_combinators/include/hpx/async_combinators/wait_any.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2022 Hartmut Kaiser
+//  Copyright (c) 2007-2023 Hartmut Kaiser
 //  Copyright (c) 2013 Agustin Berge
 //
 //  SPDX-License-Identifier: BSL-1.0
@@ -213,17 +213,24 @@ namespace hpx {
     {
     private:
         template <typename Future>
-        friend HPX_FORCEINLINE void tag_invoke(
-            wait_any_t, std::vector<Future> const& futures)
+        static HPX_FORCEINLINE void wait_any_impl(
+            std::vector<Future> const& futures)
         {
             hpx::wait_some(1, futures);
         }
 
         template <typename Future>
         friend HPX_FORCEINLINE void tag_invoke(
+            wait_any_t, std::vector<Future> const& futures)
+        {
+            wait_any_t::wait_any_impl(futures);
+        }
+
+        template <typename Future>
+        friend HPX_FORCEINLINE void tag_invoke(
             wait_any_t, std::vector<Future>& lazy_values)
         {
-            tag_invoke(wait_any_t{},
+            wait_any_t::wait_any_impl(
                 const_cast<std::vector<Future> const&>(lazy_values));
         }
 
@@ -231,22 +238,29 @@ namespace hpx {
         friend HPX_FORCEINLINE void tag_invoke(
             wait_any_t, std::vector<Future>&& lazy_values)
         {
-            tag_invoke(wait_any_t{},
+            wait_any_t::wait_any_impl(
                 const_cast<std::vector<Future> const&>(lazy_values));
         }
 
         template <typename Future, std::size_t N>
-        friend HPX_FORCEINLINE void tag_invoke(
-            wait_any_t, std::array<Future, N> const& futures)
+        static HPX_FORCEINLINE void wait_any_impl(
+            std::array<Future, N> const& futures)
         {
             hpx::wait_some(1, futures);
         }
 
         template <typename Future, std::size_t N>
         friend HPX_FORCEINLINE void tag_invoke(
+            wait_any_t, std::array<Future, N> const& futures)
+        {
+            wait_any_t::wait_any_impl(futures);
+        }
+
+        template <typename Future, std::size_t N>
+        friend HPX_FORCEINLINE void tag_invoke(
             wait_any_t, std::array<Future, N>& lazy_values)
         {
-            tag_invoke(wait_any_t{},
+            wait_any_t::wait_any_impl(
                 const_cast<std::array<Future, N> const&>(lazy_values));
         }
 
@@ -254,7 +268,7 @@ namespace hpx {
         friend HPX_FORCEINLINE void tag_invoke(
             wait_any_t, std::array<Future, N>&& lazy_values)
         {
-            tag_invoke(wait_any_t{},
+            wait_any_t::wait_any_impl(
                 const_cast<std::array<Future, N> const&>(lazy_values));
         }
 

--- a/libs/core/async_combinators/include/hpx/async_combinators/wait_some.hpp
+++ b/libs/core/async_combinators/include/hpx/async_combinators/wait_some.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2022 Hartmut Kaiser
+//  Copyright (c) 2007-2023 Hartmut Kaiser
 //  Copyright (c) 2013 Agustin Berge
 //
 //  SPDX-License-Identifier: BSL-1.0
@@ -343,8 +343,8 @@ namespace hpx {
     {
     private:
         template <typename Future>
-        friend bool tag_invoke(wait_some_nothrow_t, std::size_t n,
-            std::vector<Future> const& values)
+        static bool wait_some_nothrow_impl(
+            std::size_t n, std::vector<Future> const& values)
         {
             static_assert(hpx::traits::is_future_v<Future>,
                 "invalid use of hpx::wait_some");
@@ -368,24 +368,31 @@ namespace hpx {
         }
 
         template <typename Future>
+        friend bool tag_invoke(wait_some_nothrow_t, std::size_t n,
+            std::vector<Future> const& values)
+        {
+            return wait_some_nothrow_t::wait_some_nothrow_impl(n, values);
+        }
+
+        template <typename Future>
         friend HPX_FORCEINLINE bool tag_invoke(
             wait_some_nothrow_t, std::size_t n, std::vector<Future>& values)
         {
-            return tag_invoke(wait_some_nothrow_t{}, n,
-                const_cast<std::vector<Future> const&>(values));
+            return wait_some_nothrow_t::wait_some_nothrow_impl(
+                n, const_cast<std::vector<Future> const&>(values));
         }
 
         template <typename Future>
         friend HPX_FORCEINLINE bool tag_invoke(
             wait_some_nothrow_t, std::size_t n, std::vector<Future>&& values)
         {
-            return tag_invoke(wait_some_nothrow_t{}, n,
-                const_cast<std::vector<Future> const&>(values));
+            return wait_some_nothrow_t::wait_some_nothrow_impl(
+                n, const_cast<std::vector<Future> const&>(values));
         }
 
         template <typename Future, std::size_t N>
-        friend bool tag_invoke(wait_some_nothrow_t, std::size_t n,
-            std::array<Future, N> const& values)
+        static bool wait_some_nothrow_impl(
+            std::size_t n, std::array<Future, N> const& values)
         {
             static_assert(
                 hpx::traits::is_future_v<Future>, "invalid use of wait_some");
@@ -409,19 +416,26 @@ namespace hpx {
         }
 
         template <typename Future, std::size_t N>
+        friend bool tag_invoke(wait_some_nothrow_t, std::size_t n,
+            std::array<Future, N> const& values)
+        {
+            return wait_some_nothrow_t::wait_some_nothrow_impl(n, values);
+        }
+
+        template <typename Future, std::size_t N>
         friend HPX_FORCEINLINE bool tag_invoke(wait_some_nothrow_t,
             std::size_t n, std::array<Future, N>& lazy_values)
         {
-            return tag_invoke(wait_some_nothrow_t{}, n,
-                const_cast<std::array<Future, N> const&>(lazy_values));
+            return wait_some_nothrow_t::wait_some_nothrow_impl(
+                n, const_cast<std::array<Future, N> const&>(lazy_values));
         }
 
         template <typename Future, std::size_t N>
         friend HPX_FORCEINLINE bool tag_invoke(wait_some_nothrow_t,
             std::size_t n, std::array<Future, N>&& lazy_values)
         {
-            return tag_invoke(wait_some_nothrow_t{}, n,
-                const_cast<std::array<Future, N> const&>(lazy_values));
+            return wait_some_nothrow_t::wait_some_nothrow_impl(
+                n, const_cast<std::array<Future, N> const&>(lazy_values));
         }
 
         template <typename Iterator,

--- a/libs/core/coroutines/include/hpx/coroutines/detail/coroutine_impl.hpp
+++ b/libs/core/coroutines/include/hpx/coroutines/detail/coroutine_impl.hpp
@@ -102,7 +102,7 @@ namespace hpx::threads::coroutines::detail {
         }
 
 #if defined(HPX_HAVE_THREAD_PHASE_INFORMATION)
-        std::size_t get_thread_phase() const noexcept
+        constexpr std::size_t get_thread_phase() const noexcept
         {
             return this->phase();
         }

--- a/libs/core/threading_base/include/hpx/threading_base/detail/reset_lco_description.hpp
+++ b/libs/core/threading_base/include/hpx/threading_base/detail/reset_lco_description.hpp
@@ -14,6 +14,8 @@
 #include <hpx/threading_base/thread_description.hpp>
 #include <hpx/threading_base/threading_base_fwd.hpp>
 
+#include <hpx/config/warnings_prefix.hpp>
+
 namespace hpx::threads::detail {
 
     struct HPX_CORE_EXPORT reset_lco_description
@@ -29,5 +31,7 @@ namespace hpx::threads::detail {
         error_code& ec_;
     };
 }    // namespace hpx::threads::detail
+
+#include <hpx/config/warnings_suffix.hpp>
 
 #endif    // HPX_HAVE_THREAD_DESCRIPTION


### PR DESCRIPTION
- this fixes ambiguities if another library defines its own tag_invoke overloads
- flyby: add missing constexpr, suppress dllexport warnings
