### PR TITLE
Assign global ids to managed component instances that are locally resolvable

### DIFF
--- a/libs/full/agas/tests/regressions/send_gid_keep_component_1624.cpp
+++ b/libs/full/agas/tests/regressions/send_gid_keep_component_1624.cpp
@@ -19,7 +19,7 @@ namespace server {
     struct view_registry
       : hpx::components::managed_component_base<view_registry>
     {
-        int register_view(const hpx::id_type& gid)
+        int register_view(hpx::id_type const& gid)
         {
             hpx::util::format_to(std::cout, "register view at {1} by {2}",
                 this->get_unmanaged_id(), gid)
@@ -50,7 +50,7 @@ namespace client {
         {
         }
 
-        void register_view(const hpx::id_type& viewerId)
+        void register_view(hpx::id_type const& viewerId)
         {
             hpx::async<server::view_registry::register_view_action>(
                 gid_, viewerId)
@@ -88,9 +88,9 @@ namespace server {
 
         // This function does a broadcast to all writers to register a certain
         // region
-        void register_region(const std::vector<hpx::id_type>& writers)
+        void register_region(std::vector<hpx::id_type> const& writers)
         {
-            for (const auto& id : writers)
+            for (auto const& id : writers)
             {
                 hpx::util::format_to(std::cout, "{1} registering region at {2}",
                     this->get_unmanaged_id(), id)
@@ -121,12 +121,12 @@ HPX_REGISTER_ACTION_DECLARATION(
 namespace client {
     struct viewer
     {
-        viewer(const hpx::id_type& gid)
+        viewer(hpx::id_type const& gid)
           : gid_(gid)
         {
         }
 
-        void register_region(const std::vector<hpx::id_type>& writers)
+        void register_region(std::vector<hpx::id_type> const& writers)
         {
             hpx::async<server::viewer::register_region_action>(gid_, writers)
                 .get();

--- a/libs/full/agas_base/include/hpx/agas_base/server/primary_namespace.hpp
+++ b/libs/full/agas_base/include/hpx/agas_base/server/primary_namespace.hpp
@@ -37,11 +37,11 @@
 
 #include <hpx/config/warnings_prefix.hpp>
 
-namespace hpx { namespace agas {
+namespace hpx::agas {
 
     HPX_EXPORT naming::gid_type bootstrap_primary_namespace_gid();
     HPX_EXPORT hpx::id_type bootstrap_primary_namespace_id();
-}}    // namespace hpx::agas
+}    // namespace hpx::agas
 
 /// \brief AGAS's primary namespace maps 128-bit global identifiers (GIDs) to
 /// resolved addresses.
@@ -231,7 +231,7 @@ namespace hpx::agas::server {
         void dump_refcnt_matches(refcnt_table_type::iterator lower_it,
             refcnt_table_type::iterator upper_it, naming::gid_type const& lower,
             naming::gid_type const& upper, std::unique_lock<mutex_type>& l,
-            const char* func_name);
+            char const* func_name);
 #endif
 
         // helper function
@@ -293,6 +293,10 @@ namespace hpx::agas::server {
     private:
         resolved_type resolve_gid_locked(std::unique_lock<mutex_type>& l,
             naming::gid_type const& gid, error_code& ec);
+
+        resolved_type resolve_gid_locked_non_local(
+            std::unique_lock<mutex_type>& l, naming::gid_type const& gid,
+            error_code& ec);
 
         void increment(naming::gid_type const& lower,
             naming::gid_type const& upper, std::int64_t& credits,

--- a/libs/full/components_base/include/hpx/components_base/server/managed_component_base.hpp
+++ b/libs/full/components_base/include/hpx/components_base/server/managed_component_base.hpp
@@ -490,8 +490,8 @@ namespace hpx { namespace components {
             static_cast<Component const&>(*this).get_base_gid();
 
         // The underlying heap will always give us a full set of credits, but
-        // those are valid for the first invocation of get_base_gid() only.
-        // We have to get rid of those credits and properly replenish those.
+        // those are valid for the first invocation of get_base_gid() only. We
+        // have to get rid of those credits and properly replenish those.
         naming::detail::strip_credits_from_gid(gid);
 
         // any invocation causes the credits to be replenished

--- a/libs/full/components_base/include/hpx/components_base/server/wrapper_heap.hpp
+++ b/libs/full/components_base/include/hpx/components_base/server/wrapper_heap.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 1998-2021 Hartmut Kaiser
+//  Copyright (c) 1998-2023 Hartmut Kaiser
 //  Copyright (c)      2011 Bryce Lelbach
 //
 //  SPDX-License-Identifier: BSL-1.0
@@ -10,7 +10,6 @@
 #include <hpx/config.hpp>
 #include <hpx/allocator_support/internal_allocator.hpp>
 #include <hpx/assert.hpp>
-#include <hpx/components_base/generate_unique_ids.hpp>
 #include <hpx/components_base/server/wrapper_heap_base.hpp>
 #include <hpx/modules/itt_notify.hpp>
 #include <hpx/naming_base/id_type.hpp>
@@ -29,7 +28,7 @@
 #define HPX_DEBUG_WRAPPER_HEAP 0
 
 ///////////////////////////////////////////////////////////////////////////////
-namespace hpx { namespace components { namespace detail {
+namespace hpx::components::detail {
 
     ///////////////////////////////////////////////////////////////////////////
     namespace one_size_heap_allocators {
@@ -99,8 +98,8 @@ namespace hpx { namespace components { namespace detail {
         //
         // The pointer given by the parameter p must have been allocated by
         // this instance of a wrapper_heap
-        naming::gid_type get_gid(util::unique_id_ranges& ids, void* p,
-            components::component_type type) override;
+        naming::gid_type get_gid(
+            void* p, components::component_type type) override;
 
         void set_gid(naming::gid_type const& g);
 
@@ -167,6 +166,6 @@ namespace hpx { namespace components { namespace detail {
         {
         }
     };
-}}}    // namespace hpx::components::detail
+}    // namespace hpx::components::detail
 
 #include <hpx/config/warnings_suffix.hpp>

--- a/libs/full/components_base/include/hpx/components_base/server/wrapper_heap_base.hpp
+++ b/libs/full/components_base/include/hpx/components_base/server/wrapper_heap_base.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 1998-2021 Hartmut Kaiser
+//  Copyright (c) 1998-2023 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -8,7 +8,6 @@
 
 #include <hpx/config.hpp>
 #include <hpx/components_base/component_type.hpp>
-#include <hpx/components_base/generate_unique_ids.hpp>
 
 #include <cstddef>
 
@@ -29,8 +28,8 @@ namespace hpx { namespace util {
         virtual bool did_alloc(void* p) const = 0;
         virtual void free(void* p, std::size_t count = 1) = 0;
 
-        virtual naming::gid_type get_gid(util::unique_id_ranges& ids, void* p,
-            components::component_type type) = 0;
+        virtual naming::gid_type get_gid(
+            void* p, components::component_type type) = 0;
 
         virtual std::size_t heap_count() const = 0;
         virtual std::size_t size() const = 0;

--- a/libs/full/components_base/include/hpx/components_base/server/wrapper_heap_list.hpp
+++ b/libs/full/components_base/include/hpx/components_base/server/wrapper_heap_list.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 1998-2021 Hartmut Kaiser
+//  Copyright (c) 1998-2023 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -7,7 +7,6 @@
 #pragma once
 
 #include <hpx/components_base/component_type.hpp>
-#include <hpx/components_base/generate_unique_ids.hpp>
 #include <hpx/components_base/server/one_size_heap_list.hpp>
 #include <hpx/naming_base/id_type.hpp>
 #include <hpx/thread_support/unlock_guard.hpp>
@@ -15,7 +14,7 @@
 #include <type_traits>
 
 ///////////////////////////////////////////////////////////////////////////////
-namespace hpx { namespace components { namespace detail {
+namespace hpx::components::detail {
 
     ///////////////////////////////////////////////////////////////////////////
     // list of managed_component heaps
@@ -62,22 +61,13 @@ namespace hpx { namespace components { namespace detail {
                 if ((*it)->did_alloc(p))
                 {
                     unlock_guard ul(guard);
-                    return (*it)->get_gid(id_range_, p, type_);
+                    return (*it)->get_gid(p, type_);
                 }
             }
             return naming::invalid_gid;
         }
 
-        void set_range(
-            naming::gid_type const& lower, naming::gid_type const& upper)
-        {
-            std::scoped_lock guard(this->mtx_);
-            id_range_.set_range(lower, upper);
-        }
-
     private:
-        util::unique_id_ranges id_range_;
         components::component_type type_;
     };
-
-}}}    // namespace hpx::components::detail
+}    // namespace hpx::components::detail

--- a/libs/full/components_base/src/server/component_base.cpp
+++ b/libs/full/components_base/src/server/component_base.cpp
@@ -90,9 +90,8 @@ namespace hpx { namespace components { namespace detail {
 
         HPX_ASSERT(naming::detail::has_credits(gid));
 
-        // We have to assume this credit was split as otherwise the gid
-        // returned at this point will control the lifetime of the
-        // component.
+        // We have to assume this credit was split as otherwise the gid returned
+        // at this point will control the lifetime of the component.
         naming::detail::set_credit_split_mask_for_gid(gid);
         return gid;
     }

--- a/libs/full/components_base/src/server/wrapper_heap.cpp
+++ b/libs/full/components_base/src/server/wrapper_heap.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 1998-2021 Hartmut Kaiser
+//  Copyright (c) 1998-2023 Hartmut Kaiser
 //  Copyright (c)      2011 Bryce Lelbach
 //
 //  SPDX-License-Identifier: BSL-1.0
@@ -8,7 +8,6 @@
 #include <hpx/config.hpp>
 #include <hpx/assert.hpp>
 #include <hpx/components_base/agas_interface.hpp>
-#include <hpx/components_base/generate_unique_ids.hpp>
 #include <hpx/components_base/server/wrapper_heap.hpp>
 #include <hpx/modules/itt_notify.hpp>
 #include <hpx/modules/logging.hpp>
@@ -28,7 +27,7 @@
 #include <type_traits>
 
 ///////////////////////////////////////////////////////////////////////////////
-namespace hpx { namespace components { namespace detail {
+namespace hpx::components::detail {
 
     namespace one_size_heap_allocators {
 
@@ -68,12 +67,7 @@ namespace hpx { namespace components { namespace detail {
 
     ///////////////////////////////////////////////////////////////////////////
     wrapper_heap::wrapper_heap(char const* class_name,
-#if defined(HPX_DEBUG)
-        std::size_t count,
-#else
-        std::size_t,
-#endif
-        heap_parameters parameters)
+        [[maybe_unused]] std::size_t count, heap_parameters parameters)
       : pool_(nullptr)
       , first_free_(nullptr)
       , parameters_(parameters)
@@ -88,8 +82,7 @@ namespace hpx { namespace components { namespace detail {
       , heap_alloc_function_("wrapper_heap::alloc", class_name)
       , heap_free_function_("wrapper_heap::free", class_name)
     {
-        util::itt::heap_internal_access hia;
-        HPX_UNUSED(hia);
+        [[maybe_unused]] util::itt::heap_internal_access hia;
 
         if (!init_pool())
         {
@@ -116,40 +109,35 @@ namespace hpx { namespace components { namespace detail {
 
     wrapper_heap::~wrapper_heap()
     {
-        util::itt::heap_internal_access hia;
-        HPX_UNUSED(hia);
+        [[maybe_unused]] util::itt::heap_internal_access hia;
 
         tidy();
     }
 
     std::size_t wrapper_heap::size() const
     {
-        util::itt::heap_internal_access hia;
-        HPX_UNUSED(hia);
+        [[maybe_unused]] util::itt::heap_internal_access hia;
 
         return parameters_.capacity - free_size_;
     }
 
     std::size_t wrapper_heap::free_size() const
     {
-        util::itt::heap_internal_access hia;
-        HPX_UNUSED(hia);
+        [[maybe_unused]] util::itt::heap_internal_access hia;
 
         return free_size_;
     }
 
     bool wrapper_heap::is_empty() const
     {
-        util::itt::heap_internal_access hia;
-        HPX_UNUSED(hia);
+        [[maybe_unused]] util::itt::heap_internal_access hia;
 
         return nullptr == pool_;
     }
 
     bool wrapper_heap::has_allocatable_slots() const
     {
-        util::itt::heap_internal_access hia;
-        HPX_UNUSED(hia);
+        [[maybe_unused]] util::itt::heap_internal_access hia;
 
         std::size_t const num_bytes =
             parameters_.capacity * parameters_.element_size;
@@ -188,7 +176,7 @@ namespace hpx { namespace components { namespace detail {
         return true;
     }
 
-    void wrapper_heap::free(void* p, std::size_t count)
+    void wrapper_heap::free([[maybe_unused]] void* p, std::size_t count)
     {
         util::itt::heap_free heap_free(heap_free_function_, p);
 
@@ -213,8 +201,6 @@ namespace hpx { namespace components { namespace detail {
 
         // give memory back to pool
         debug::fill_bytes(p1, freed_value, num_bytes);
-#else
-        HPX_UNUSED(p);
 #endif
 
 #if defined(HPX_DEBUG)
@@ -229,8 +215,8 @@ namespace hpx { namespace components { namespace detail {
     bool wrapper_heap::did_alloc(void* p) const
     {
         // no lock is necessary here as all involved variables are immutable
-        util::itt::heap_internal_access hia;
-        HPX_UNUSED(hia);
+        [[maybe_unused]] util::itt::heap_internal_access hia;
+
         if (nullptr == pool_)
             return false;
         if (nullptr == p)
@@ -242,61 +228,41 @@ namespace hpx { namespace components { namespace detail {
     }
 
     naming::gid_type wrapper_heap::get_gid(
-        util::unique_id_ranges& ids, void* p, components::component_type type)
+        void* p, components::component_type type)
     {
-        util::itt::heap_internal_access hia;
-        HPX_UNUSED(hia);
+        [[maybe_unused]] util::itt::heap_internal_access hia;
 
         HPX_ASSERT(did_alloc(p));
 
-        std::unique_lock l(mtx_);
-
-        if (!base_gid_)
         {
-            naming::gid_type base_gid;
-
-            {
-                // this is the first call to get_gid() for this heap - allocate
-                // a sufficiently large range of global ids
-                unlock_guard ul(l);
-                base_gid = ids.get_id(parameters_.capacity);
-
-                // register the global ids and the base address of this heap
-                // with the AGAS
-                if (!agas::bind_range_local(base_gid, parameters_.capacity,
-                        naming::address(naming::get_gid_from_locality_id(
-                                            agas::get_locality_id()),
-                            type, pool_),
-                        parameters_.element_size))
-                {
-                    return naming::invalid_gid;
-                }
-            }
-
-            // if some other thread has already set the base GID for this
-            // heap, we ignore the result
+            std::unique_lock l(mtx_);
             if (!base_gid_)
             {
-                // this is the first thread succeeding in binding the new gid
-                // range
-                base_gid_ = base_gid;
-            }
-            else
-            {
-                // unbind the range which is not needed anymore
-                unlock_guard ul(l);
-                agas::unbind_range_local(base_gid, parameters_.capacity);
+                // use the pool's base address as the first gid, this will also
+                // allow for the ids to be locally resolvable
+                base_gid_ = naming::replace_locality_id(
+                    naming::replace_component_type(
+                        naming::gid_type(pool_), type),
+                    agas::get_locality_id());
+
+                naming::detail::set_credit_for_gid(
+                    base_gid_, std::int64_t(HPX_GLOBALCREDIT_INITIAL));
             }
         }
 
-        std::uint64_t const distance = static_cast<char*>(p) - pool_;
-        return base_gid_ + distance / parameters_.element_size;
+        naming::gid_type result = base_gid_;
+        result.set_lsb(p);
+
+        // We have to assume this credit was split as otherwise the gid returned
+        // at this point will control the lifetime of the component.
+        naming::detail::set_credit_split_mask_for_gid(result);
+
+        return result;
     }
 
     void wrapper_heap::set_gid(naming::gid_type const& g)
     {
-        util::itt::heap_internal_access hia;
-        HPX_UNUSED(hia);
+        [[maybe_unused]] util::itt::heap_internal_access hia;
 
         std::unique_lock l(mtx_);
         base_gid_ = g;
@@ -389,7 +355,8 @@ namespace hpx { namespace components { namespace detail {
                         !class_name_.empty() ? class_name_.c_str() :
                                                "<Unknown>")
 #if defined(HPX_DEBUG)
-                    .format(": releasing heap: alloc count: {}, free count: {}",
+                    .format(": releasing heap: alloc count: {}, free "
+                            "count: {}",
                         alloc_count_, free_count_)
 #endif
                 << ".";
@@ -413,4 +380,4 @@ namespace hpx { namespace components { namespace detail {
             free_size_ = 0;
         }
     }
-}}}    // namespace hpx::components::detail
+}    // namespace hpx::components::detail

--- a/libs/full/naming_base/src/gid_type.cpp
+++ b/libs/full/naming_base/src/gid_type.cpp
@@ -25,16 +25,6 @@
 namespace hpx::naming {
 
     ///////////////////////////////////////////////////////////////////////////
-    bool operator==(gid_type const& lhs, gid_type const& rhs) noexcept
-    {
-        std::int64_t lhs_msb =
-            detail::strip_internal_bits_from_gid(lhs.id_msb_);
-        std::int64_t rhs_msb =
-            detail::strip_internal_bits_from_gid(rhs.id_msb_);
-
-        return (lhs_msb == rhs_msb) && (lhs.id_lsb_ == rhs.id_lsb_);
-    }
-
     bool operator<(gid_type const& lhs, gid_type const& rhs) noexcept
     {
         std::int64_t lhs_msb =


### PR DESCRIPTION
This will reduce contention while resolving global ids.