### PR TITLE
Avoid performing late command line handling twice in distributed runtime

### DIFF
--- a/libs/core/command_line_handling_local/include/hpx/command_line_handling_local/late_command_line_handling_local.hpp
+++ b/libs/core/command_line_handling_local/include/hpx/command_line_handling_local/late_command_line_handling_local.hpp
@@ -19,7 +19,7 @@ namespace hpx::local::detail {
     HPX_CORE_EXPORT int handle_late_commandline_options(
         util::runtime_configuration& ini,
         hpx::program_options::options_description const& options,
-        void (*handle_print_bind)(std::size_t));
+        void (*handle_print_bind)(std::size_t) = nullptr);
 
     HPX_CORE_EXPORT void set_unknown_commandline_options(
         util::runtime_configuration& ini,
@@ -29,7 +29,7 @@ namespace hpx::local::detail {
         hpx::program_options::options_description const& options);
     HPX_CORE_EXPORT bool handle_late_options(util::runtime_configuration& ini,
         hpx::program_options::variables_map& vm,
-        void (*handle_print_bind)(std::size_t));
+        void (*handle_print_bind)(std::size_t) = nullptr);
 
     HPX_CORE_EXPORT std::string get_full_commandline(
         util::runtime_configuration& ini);

--- a/libs/core/command_line_handling_local/src/late_command_line_handling_local.cpp
+++ b/libs/core/command_line_handling_local/src/late_command_line_handling_local.cpp
@@ -99,7 +99,7 @@ namespace hpx::local::detail {
         hpx::program_options::variables_map& vm,
         void (*handle_print_bind)(std::size_t))
     {
-        if (vm.count("hpx:print-bind"))
+        if (handle_print_bind != nullptr && vm.count("hpx:print-bind"))
         {
             std::size_t num_threads = hpx::util::from_string<std::size_t>(
                 ini.get_entry("hpx.os_threads", 1));

--- a/libs/core/runtime_local/include/hpx/runtime_local/runtime_local.hpp
+++ b/libs/core/runtime_local/include/hpx/runtime_local/runtime_local.hpp
@@ -398,7 +398,8 @@ namespace hpx {
 
         threads::thread_result_type run_helper(
             hpx::function<runtime::hpx_main_function_type> const& func,
-            int& result, bool call_startup_functions);
+            int& result, bool call_startup_functions,
+            void (*handle_print_bind)(std::size_t) = nullptr);
 
         void wait_helper(
             std::mutex& mtx, std::condition_variable& cond, bool& running);


### PR DESCRIPTION
@weilewei this should fix the issue you were seeing (`--hpx:print-bind` being invoked twice)