### PR TITLE
Remove the mutex lock in parcelhandler::invoke_write_handler

### DIFF
--- a/libs/full/parcelset/src/parcelhandler.cpp
+++ b/libs/full/parcelset/src/parcelhandler.cpp
@@ -814,11 +814,7 @@ namespace hpx::parcelset {
     void parcelhandler::invoke_write_handler(
         std::error_code const& ec, parcel const& p) const
     {
-        write_handler_type f;
-        {
-            std::lock_guard<mutex_type> l(mtx_);
-            f = write_handler_;
-        }
+        write_handler_type f = write_handler_;
         f(ec, p);
     }
 


### PR DESCRIPTION
The mutex lock is very expensive as the program needs to acquire it whenever a parcel is sent.

It appears the original mutex lock is used to protect the handler invocation from hpx::set_parcel_write_handler, but I think the code would be ill-formed anyway if the user wants to set the handler when there are parcels on the fly.