### PR TITLE
LCI parcelport: bypass the parcel queue and connection cache.

### DIFF
--- a/libs/full/parcelport_lci/include/hpx/parcelport_lci/sender_connection.hpp
+++ b/libs/full/parcelport_lci/include/hpx/parcelport_lci/sender_connection.hpp
@@ -43,9 +43,8 @@ namespace hpx::parcelset::policies::lci {
             parcelset::parcelport_connection<sender_connection, data_type>;
 
     public:
-        sender_connection(sender_type* s, int dst, parcelset::parcelport* pp)
-          : sender_(s)
-          , dst_rank(dst)
+        sender_connection(int dst, parcelset::parcelport* pp)
+          : dst_rank(dst)
           , pp_(pp)
           , there_(parcelset::locality(locality(dst_rank)))
         {
@@ -222,15 +221,18 @@ namespace hpx::parcelset::policies::lci {
             buffer_.clear();
             iovec.count = -1;
 
-            hpx::move_only_function<void(error_code const&,
-                parcelset::locality const&, std::shared_ptr<sender_connection>)>
-                postprocess_handler;
-            std::swap(postprocess_handler, postprocess_handler_);
-            error_code ec2;
-            postprocess_handler(ec2, there_, shared_from_this());
+            if (postprocess_handler_)
+            {
+                hpx::move_only_function<void(error_code const&,
+                    parcelset::locality const&,
+                    std::shared_ptr<sender_connection>)>
+                    postprocess_handler;
+                std::swap(postprocess_handler, postprocess_handler_);
+                error_code ec2;
+                postprocess_handler(ec2, there_, shared_from_this());
+            }
         }
 
-        sender_type* sender_;
         int dst_rank;
         hpx::move_only_function<void(error_code const&)> handler_;
         hpx::move_only_function<void(error_code const&,

--- a/libs/full/parcelport_libfabric/include/hpx/parcelport_libfabric/connection_handler.hpp
+++ b/libs/full/parcelport_libfabric/include/hpx/parcelport_libfabric/connection_handler.hpp
@@ -33,6 +33,7 @@ namespace hpx::parcelset {
         using send_early_parcel = HPX_PARCELPORT_LIBFABRIC_HAVE_BOOTSTRAPPING;
         using do_background_work = std::true_type;
         using send_immediate_parcels = std::true_type;
+        using is_connectionless = std::false_type;
 
         static constexpr const char* type() noexcept
         {

--- a/libs/full/parcelport_mpi/src/parcelport_mpi.cpp
+++ b/libs/full/parcelport_mpi/src/parcelport_mpi.cpp
@@ -52,6 +52,7 @@ namespace hpx::parcelset {
         using send_early_parcel = std::true_type;
         using do_background_work = std::true_type;
         using send_immediate_parcels = std::false_type;
+        using is_connectionless = std::false_type;
 
         static constexpr const char* type() noexcept
         {

--- a/libs/full/parcelport_tcp/include/hpx/parcelport_tcp/connection_handler.hpp
+++ b/libs/full/parcelport_tcp/include/hpx/parcelport_tcp/connection_handler.hpp
@@ -46,6 +46,7 @@ namespace hpx::parcelset {
         using send_early_parcel = std::true_type;
         using do_background_work = std::false_type;
         using send_immediate_parcels = std::false_type;
+        using is_connectionless = std::false_type;
 
         static constexpr const char* type() noexcept
         {

--- a/libs/full/parcelset/include/hpx/parcelset/parcelport_impl.hpp
+++ b/libs/full/parcelset/include/hpx/parcelset/parcelport_impl.hpp
@@ -488,75 +488,151 @@ namespace hpx::parcelset {
         }
 
     protected:
+        void send_immediate_impl_connectionless(locality const& dest_,
+            write_handler_type* fs, parcel* ps, std::size_t num_parcels)
+        {
+            static_assert(connection_handler_traits<
+                              ConnectionHandler>::is_connectionless::value &&
+                    connection_handler_traits<
+                        ConnectionHandler>::send_immediate_parcels::value,
+                "This parcelport is not suitable for the connectionless "
+                "version of send_immediate!");
+            std::size_t encoded_parcels = 0;
+            std::vector<parcel> parcels;
+            std::vector<write_handler_type> handlers;
+            if (fs == nullptr)
+            {
+                HPX_ASSERT(ps == nullptr);
+                HPX_ASSERT(num_parcels == 0u);
+
+                if (!dequeue_parcels(dest_, parcels, handlers))
+                {
+                    return;
+                }
+
+                ps = parcels.data();
+                fs = handlers.data();
+                num_parcels = parcels.size();
+                HPX_ASSERT(parcels.size() == handlers.size());
+            }
+
+            // encode the parcels
+            typename ConnectionHandler::sender_type::parcel_buffer_type buffer;
+            encoded_parcels = encode_parcels(*this, ps, num_parcels, buffer,
+                archive_flags_, get_max_outbound_message_size());
+
+            typename ConnectionHandler::sender_type::callback_fn_type
+                callback_fn = detail::call_for_each(
+                    detail::call_for_each::handlers_type(
+                        std::make_move_iterator(fs),
+                        std::make_move_iterator(fs + encoded_parcels)),
+                    detail::call_for_each::parcels_type(
+                        std::make_move_iterator(ps),
+                        std::make_move_iterator(ps + encoded_parcels)));
+
+            if (ConnectionHandler::sender_type::send(
+                    this, dest_, HPX_MOVE(buffer), HPX_MOVE(callback_fn)))
+            {
+                // we don't propagate errors for now
+            }
+            if (num_parcels != encoded_parcels && fs != nullptr)
+            {
+                std::vector<parcel> overflow_parcels(
+                    std::make_move_iterator(ps + encoded_parcels),
+                    std::make_move_iterator(ps + num_parcels));
+                std::vector<write_handler_type> overflow_handlers(
+                    std::make_move_iterator(fs + encoded_parcels),
+                    std::make_move_iterator(fs + num_parcels));
+                enqueue_parcels(dest_, HPX_MOVE(overflow_parcels),
+                    HPX_MOVE(overflow_handlers));
+            }
+        }
+
+        void send_immediate_impl_connection(locality const& dest_,
+            write_handler_type* fs, parcel* ps, std::size_t num_parcels)
+        {
+            static_assert(!connection_handler_traits<
+                              ConnectionHandler>::is_connectionless::value &&
+                    connection_handler_traits<
+                        ConnectionHandler>::send_immediate_parcels::value,
+                "This parcelport is not suitable for the connection-oriented "
+                "version of send_immediate!");
+            // First try to get a connection ...
+            std::uint64_t addr;
+            connection* sender =
+                connection_handler().get_connection(dest_, addr);
+
+            // If we couldn't get one ... enqueue the parcel and move on
+            std::size_t encoded_parcels = 0;
+            std::vector<parcel> parcels;
+            std::vector<write_handler_type> handlers;
+            if (sender != nullptr)
+            {
+                if (fs == nullptr)
+                {
+                    HPX_ASSERT(ps == nullptr);
+                    HPX_ASSERT(num_parcels == 0u);
+
+                    if (!dequeue_parcels(dest_, parcels, handlers))
+                    {
+                        // Give this connection back to the connection handler as
+                        // we couldn't dequeue parcels.
+                        connection_handler().reclaim_connection(sender);
+                        return;
+                    }
+
+                    ps = parcels.data();
+                    fs = handlers.data();
+                    num_parcels = parcels.size();
+                    HPX_ASSERT(parcels.size() == handlers.size());
+                }
+
+                // encode the parcels
+                auto encoded_buffer = sender->get_new_buffer();
+                encoded_parcels =
+                    encode_parcels(*this, ps, num_parcels, encoded_buffer,
+                        archive_flags_, get_max_outbound_message_size());
+
+                using handler_type = detail::call_for_each;
+
+                if (sender->parcelport_->async_write(
+                        handler_type(
+                            handler_type::handlers_type(
+                                std::make_move_iterator(fs),
+                                std::make_move_iterator(fs + encoded_parcels)),
+                            handler_type::parcels_type(
+                                std::make_move_iterator(ps),
+                                std::make_move_iterator(ps + encoded_parcels))),
+                        sender, addr, encoded_buffer))
+                {
+                    // we don't propagate errors for now
+                }
+            }
+            if (num_parcels != encoded_parcels && fs != nullptr)
+            {
+                std::vector<parcel> overflow_parcels(
+                    std::make_move_iterator(ps + encoded_parcels),
+                    std::make_move_iterator(ps + num_parcels));
+                std::vector<write_handler_type> overflow_handlers(
+                    std::make_move_iterator(fs + encoded_parcels),
+                    std::make_move_iterator(fs + num_parcels));
+                enqueue_parcels(dest_, HPX_MOVE(overflow_parcels),
+                    HPX_MOVE(overflow_handlers));
+            }
+        }
+
         void send_immediate_impl(locality const& dest_, write_handler_type* fs,
             parcel* ps, std::size_t num_parcels)
         {
             if constexpr (connection_handler_traits<
-                              ConnectionHandler>::send_immediate_parcels::value)
+                              ConnectionHandler>::is_connectionless::value)
             {
-                // First try to get a connection ...
-                std::uint64_t addr;
-                connection* sender =
-                    connection_handler().get_connection(dest_, addr);
-
-                // If we couldn't get one ... enqueue the parcel and move on
-                std::size_t encoded_parcels = 0;
-                std::vector<parcel> parcels;
-                std::vector<write_handler_type> handlers;
-                if (sender != nullptr)
-                {
-                    if (fs == nullptr)
-                    {
-                        HPX_ASSERT(ps == nullptr);
-                        HPX_ASSERT(num_parcels == 0u);
-
-                        if (!dequeue_parcels(dest_, parcels, handlers))
-                        {
-                            // Give this connection back to the connection handler as
-                            // we couldn't dequeue parcels.
-                            connection_handler().reclaim_connection(sender);
-                            return;
-                        }
-
-                        ps = parcels.data();
-                        fs = handlers.data();
-                        num_parcels = parcels.size();
-                        HPX_ASSERT(parcels.size() == handlers.size());
-                    }
-
-                    // encode the parcels
-                    auto encoded_buffer = sender->get_new_buffer();
-                    encoded_parcels =
-                        encode_parcels(*this, ps, num_parcels, encoded_buffer,
-                            archive_flags_, get_max_outbound_message_size());
-
-                    using handler_type = detail::call_for_each;
-
-                    if (sender->parcelport_->async_write(
-                            handler_type(handler_type::handlers_type(
-                                             std::make_move_iterator(fs),
-                                             std::make_move_iterator(
-                                                 fs + encoded_parcels)),
-                                handler_type::parcels_type(
-                                    std::make_move_iterator(ps),
-                                    std::make_move_iterator(
-                                        ps + encoded_parcels))),
-                            sender, addr, encoded_buffer))
-                    {
-                        // we don't propagate errors for now
-                    }
-                }
-                if (num_parcels != encoded_parcels && fs != nullptr)
-                {
-                    std::vector<parcel> overflow_parcels(
-                        std::make_move_iterator(ps + encoded_parcels),
-                        std::make_move_iterator(ps + num_parcels));
-                    std::vector<write_handler_type> overflow_handlers(
-                        std::make_move_iterator(fs + encoded_parcels),
-                        std::make_move_iterator(fs + num_parcels));
-                    enqueue_parcels(dest_, HPX_MOVE(overflow_parcels),
-                        HPX_MOVE(overflow_handlers));
-                }
+                send_immediate_impl_connectionless(dest_, fs, ps, num_parcels);
+            }
+            else if constexpr (connection_handler_traits<ConnectionHandler>::
+                                   send_immediate_parcels::value)
+            {
+                send_immediate_impl_connection(dest_, fs, ps, num_parcels);
             }
             else
             {
@@ -576,8 +652,9 @@ namespace hpx::parcelset {
             // Request new connection from connection cache.
             std::shared_ptr<connection> sender_connection;
 
-            if constexpr (connection_handler_traits<
-                              ConnectionHandler>::send_immediate_parcels::value)
+            if (connection_handler_traits<
+                    ConnectionHandler>::send_immediate_parcels::value &&
+                can_send_immediate_impl())
             {
                 std::terminate();
             }
@@ -779,8 +856,9 @@ namespace hpx::parcelset {
         void get_connection_and_send_parcels(
             locality const& locality_id, bool /* background */ = false)
         {
-            if constexpr (connection_handler_traits<
-                              ConnectionHandler>::send_immediate_parcels::value)
+            if (connection_handler_traits<
+                    ConnectionHandler>::send_immediate_parcels::value &&
+                can_send_immediate_impl())
             {
                 send_immediate_impl(locality_id, nullptr, nullptr, 0);
                 return;

--- a/libs/full/plugin_factories/include/hpx/plugin_factories/parcelport_factory.hpp
+++ b/libs/full/plugin_factories/include/hpx/plugin_factories/parcelport_factory.hpp
@@ -126,6 +126,8 @@ namespace hpx::plugins {
             fillini.emplace_back("priority = ${HPX_PARCEL_" + name_uc +
                 "_PRIORITY:" +
                 traits::plugin_config_data<Parcelport>::priority() + "}");
+            fillini.emplace_back(
+                "sendimm = ${HPX_PARCEL_" + name_uc + "_SENDIMM:0}");
 
             // get the parcelport specific information ...
             char const* more = traits::plugin_config_data<Parcelport>::call();


### PR DESCRIPTION
Originally, when hpx tries to send a parcel, it will (1) push the parcel into a parcel queue corresponding to its destination (2) try to get a "connection" of the destination from the connection cache (3) dequeue multiple parcels from the parcel queue (4) encode the parcels into a message and pass it to the parcelport layer. This process contains multiple attempts of acquiring mutex locks.

This PR optimizes the LCI parcelport so that it could bypass the parcel queue and connection cache. The parcelport layer offers a "send" function. Whenever the upper layer wants to send a parcel, it can directly invoke this function.

This PR shares the same idea as the "send_immediate" feature of the libfabric parcelport (#2379).