### PR TITLE
[Docs] Fix example of how to run single/specific test(s)

### DIFF
--- a/docs/sphinx/manual/building_tests_examples.rst
+++ b/docs/sphinx/manual/building_tests_examples.rst
@@ -28,7 +28,7 @@ To control which tests to run use ``ctest``:
 
 .. code-block:: shell-session
 
-    $ ctest --output-on-failure -R tests.unit.modules.algorithms.for_loop
+    $ ctest --output-on-failure -R tests.unit.modules.algorithms.algorithms.for_loop
 
 * To run a whole group of tests:
 


### PR DESCRIPTION
### Context: 
Docs provide an example of how to run single/specific tests. The given test name pattern does not seem to be accurate. 

## Proposed Changes

  -   This PR attempts to fix the test name pattern.

## Any background context you want to provide?

![img](https://user-images.githubusercontent.com/70189550/218329136-7c47266e-f361-4886-91e2-60d16cd94894.PNG)

The correct test name pattern can be found using `ctest -N`


