### PR TITLE
Replace boost::integer::gcd with std::gcd

### DIFF
--- a/tests/performance/local/timed_task_spawn.cpp
+++ b/tests/performance/local/timed_task_spawn.cpp
@@ -411,8 +411,8 @@ int hpx_main(variables_map& vm)
         ///////////////////////////////////////////////////////////////////////
         if (suspended_tasks != 0)
         {
-            std::uint64_t gcd = std::gcd(
-                tasks_per_feeder, suspended_tasks_per_feeder);
+            std::uint64_t gcd =
+                std::gcd(tasks_per_feeder, suspended_tasks_per_feeder);
 
             suspend_step = suspended_tasks_per_feeder / gcd;
             // We check earlier to make sure that there are never more

--- a/tests/performance/local/timed_task_spawn.cpp
+++ b/tests/performance/local/timed_task_spawn.cpp
@@ -19,8 +19,6 @@
 #include <hpx/string_util/classification.hpp>
 #include <hpx/string_util/split.hpp>
 
-#include <boost/integer/common_factor.hpp>
-
 #include <chrono>
 #include <condition_variable>
 #include <cstdint>
@@ -29,6 +27,7 @@
 #include <iostream>
 #include <memory>
 #include <mutex>
+#include <numeric>
 #include <stdexcept>
 #include <string>
 #include <vector>
@@ -412,7 +411,7 @@ int hpx_main(variables_map& vm)
         ///////////////////////////////////////////////////////////////////////
         if (suspended_tasks != 0)
         {
-            std::uint64_t gcd = boost::integer::gcd(
+            std::uint64_t gcd = std::gcd(
                 tasks_per_feeder, suspended_tasks_per_feeder);
 
             suspend_step = suspended_tasks_per_feeder / gcd;


### PR DESCRIPTION
**Context**: 
- `boost::integer::gcd` was being used [here](https://github.com/STEllAR-GROUP/hpx/blob/8927e02a0a8d1c4b7bfae150dbd0f1baa9731efc/tests/performance/local/timed_task_spawn.cpp#L415) to calculate gcd
- [#3440](https://github.com/STEllAR-GROUP/hpx/issues/3440) states we are trying to remove dependence on boost libraries
- [#5497](https://github.com/STEllAR-GROUP/hpx/issues/5497) states we can use C++17 features unconditionally
- `std::gcd` is available from C++17 onwards: https://en.cppreference.com/w/cpp/numeric/gcd

**Proposed change**: Replace `boost::integer::gcd` with `std::gcd`

**Expected Outcome**: HPX is no longer dependent on `boost::integer` 
