### PR TITLE
LCI parcelport: backlog queue, aggregation, separate devices, and more

### DIFF
--- a/libs/core/lci_base/src/lci_environment.cpp
+++ b/libs/core/lci_base/src/lci_environment.cpp
@@ -29,11 +29,27 @@ namespace hpx { namespace util {
         bool detect_lci_environment(
             util::runtime_configuration const& cfg, char const* default_env)
         {
-#if defined(__bgq__)
-            // If running on BG/Q, we can safely assume to always run in an
-            // LCI environment
-            return true;
-#else
+#if !defined(HPX_HAVE_NETWORKING) && defined(HPX_HAVE_PARCELPORT_LCI)
+            return false;
+#endif
+            // We disable the LCI parcelport if any of these hold:
+            //
+            // - The parcelport is explicitly disabled
+            // - The application is not run in an LCI environment
+            // - The TCP parcelport is enabled and has higher priority
+            // - The MPI parcelport is enabled and has higher priority
+            if (get_entry_as(cfg, "hpx.parcel.lci.enable", 1) == 0 ||
+                (get_entry_as(cfg, "hpx.parcel.tcp.enable", 1) &&
+                    (get_entry_as(cfg, "hpx.parcel.tcp.priority", 1) >
+                        get_entry_as(cfg, "hpx.parcel.lci.priority", 0))) ||
+                (get_entry_as(cfg, "hpx.parcel.mpi.enable", 1) &&
+                    (get_entry_as(cfg, "hpx.parcel.mpi.priority", 1) >
+                        get_entry_as(cfg, "hpx.parcel.lci.priority", 0))))
+            {
+                LBT_(info)
+                    << "LCI support disabled via configuration settings\n";
+                return false;
+            }
             std::string lci_environment_strings =
                 cfg.get_entry("hpx.parcel.lci.env", default_env);
 
@@ -54,41 +70,19 @@ namespace hpx { namespace util {
             LBT_(info) << "No known LCI environment variable found, disabling "
                           "LCI support\n";
             return false;
-#endif
         }
     }    // namespace detail
 
     bool lci_environment::check_lci_environment(
-        util::runtime_configuration const& cfg)
-    {    // TODO: this should be returning false when we're using the MPI environment
-#if defined(HPX_HAVE_NETWORKING) && defined(HPX_HAVE_PARCELPORT_LCI)
-        // We disable the LCI parcelport if any of these hold:
-        //
-        // - The parcelport is explicitly disabled
-        // - The application is not run in an LCI environment
-        // - The TCP parcelport is enabled and has higher priority
-        // - The MPI parcelport is enabled and has higher priority
-        if (get_entry_as(cfg, "hpx.parcel.lci.enable", 1) == 0 ||
-            (get_entry_as(cfg, "hpx.parcel.tcp.enable", 1) &&
-                (get_entry_as(cfg, "hpx.parcel.tcp.priority", 1) >
-                    get_entry_as(cfg, "hpx.parcel.lci.priority", 0))) ||
-            (get_entry_as(cfg, "hpx.parcel.mpi.enable", 1) &&
-                (get_entry_as(cfg, "hpx.parcel.mpi.priority", 1) >
-                    get_entry_as(cfg, "hpx.parcel.lci.priority", 0))))
+        util::runtime_configuration& cfg)
+    {
+        bool ret =
+            detail::detect_lci_environment(cfg, HPX_HAVE_PARCELPORT_LCI_ENV);
+        if (!ret)
         {
-            LBT_(info) << "LCI support disabled via configuration settings\n";
-            return false;
+            cfg.add_entry("hpx.parcel.lci.enable", "0");
         }
-
-        // log message was already generated
-        return detail::detect_lci_environment(cfg, HPX_HAVE_PARCELPORT_LCI_ENV);
-#elif defined(HPX_HAVE_MODULE_LCI_BASE)
-        // if LCI futures are enabled while networking is off we need to
-        // check whether we were run using mpirun
-        return detail::detect_lci_environment(cfg, HPX_HAVE_PARCELPORT_LCI_ENV);
-#else
-        return false;
-#endif
+        return ret;
     }
 }}    // namespace hpx::util
 
@@ -99,41 +93,69 @@ namespace hpx { namespace util {
 
     lci_environment::mutex_type lci_environment::mtx_;
     bool lci_environment::enabled_ = false;
-    LCI_endpoint_t lci_environment::ep;
+    bool lci_environment::setuped_ = false;
+    LCI_device_t lci_environment::device_eager;
+    LCI_device_t lci_environment::device_iovec;
+    LCI_endpoint_t lci_environment::ep_eager;
+    LCI_endpoint_t lci_environment::ep_iovec;
     LCI_comp_t lci_environment::scq;
     LCI_comp_t lci_environment::rcq;
-    std::unique_ptr<std::thread> lci_environment::prg_thread_p;
+    // We need this progress thread to send early parcels
+    std::unique_ptr<std::thread> lci_environment::prg_thread_eager_p = nullptr;
+    std::unique_ptr<std::thread> lci_environment::prg_thread_iovec_p = nullptr;
     std::atomic<bool> lci_environment::prg_thread_flag = false;
 
+    bool lci_environment::use_two_device = false;
+    bool lci_environment::enable_send_immediate = false;
+    bool lci_environment::enable_lci_progress_pool = false;
+    bool lci_environment::enable_lci_backlog_queue = false;
+
     ///////////////////////////////////////////////////////////////////////////
-    LCI_error_t lci_environment::init_lci()
+    void lci_environment::init_config(util::runtime_configuration& rtcfg)
     {
-        int lci_initialized = 0;
-        LCI_initialized(&lci_initialized);
-        if (!lci_initialized)
+        enable_lci_progress_pool = hpx::util::get_entry_as<bool>(
+            rtcfg, "hpx.parcel.lci.rp_prg_pool", false /* Does not matter*/);
+        // The default value here does not matter here
+        // the key "hpx.parcel.lci.sendimm" is guaranteed to exist
+        enable_send_immediate = hpx::util::get_entry_as<bool>(
+            rtcfg, "hpx.parcel.lci.sendimm", false /* Does not matter*/);
+        enable_lci_backlog_queue = hpx::util::get_entry_as<bool>(
+            rtcfg, "hpx.parcel.lci.backlog_queue", false /* Does not matter*/);
+        use_two_device =
+            get_entry_as(rtcfg, "hpx.parcel.lci.use_two_device", false);
+
+        if (!enable_send_immediate && enable_lci_backlog_queue)
         {
-            LCI_error_t lci_retval = LCI_initialize();
-            if (lci_retval != LCI_OK)
-                return lci_retval;
+            throw std::runtime_error(
+                "Backlog queue must be used with send_immediate enabled");
         }
+        std::size_t num_threads =
+            hpx::util::get_entry_as<size_t>(rtcfg, "hpx.os_threads", 1);
+        if (enable_lci_progress_pool && num_threads <= 1)
+        {
+            enable_lci_progress_pool = false;
+            fprintf(
+                stderr, "WARNING: set enable_lci_progress_pool to false!\n");
+        }
+        if (use_two_device && enable_lci_progress_pool && num_threads <= 2)
+        {
+            use_two_device = false;
+            fprintf(stderr, "WARNING: set use_two_device to false!\n");
+        }
+    }
 
-        // create ep, scq, rcq
-        LCI_queue_create(LCI_UR_DEVICE, &scq);
-        LCI_queue_create(LCI_UR_DEVICE, &rcq);
-        LCI_plist_t plist_;
-        LCI_plist_create(&plist_);
-        LCI_plist_set_default_comp(plist_, rcq);
-        LCI_plist_set_comp_type(plist_, LCI_PORT_COMMAND, LCI_COMPLETION_QUEUE);
-        LCI_plist_set_comp_type(plist_, LCI_PORT_MESSAGE, LCI_COMPLETION_QUEUE);
-        LCI_endpoint_init(&ep, LCI_UR_DEVICE, plist_);
-        LCI_plist_free(&plist_);
-
-        // create progress thread
-        HPX_ASSERT(prg_thread_flag == false);
-        HPX_ASSERT(prg_thread_p == nullptr);
-        prg_thread_flag = true;
-        prg_thread_p = std::make_unique<std::thread>(progress_fn);
-        return LCI_OK;
+    void set_affinity(pthread_t pthread_handler, size_t target)
+    {
+        cpu_set_t cpuset;
+        CPU_ZERO(&cpuset);
+        CPU_SET(target, &cpuset);
+        int rv =
+            pthread_setaffinity_np(pthread_handler, sizeof(cpuset), &cpuset);
+        if (rv != 0)
+        {
+            fprintf(stderr, "ERROR %d thread affinity didn't work.\n", rv);
+            exit(1);
+        }
     }
 
     ///////////////////////////////////////////////////////////////////////////
@@ -143,29 +165,22 @@ namespace hpx { namespace util {
         if (enabled_)
             return;    // don't call twice
 
-        int this_rank = -1;
-
-        // We assume to use the LCI parcelport if it is not explicitly disabled
-        enabled_ = check_lci_environment(rtcfg);
-        if (!enabled_)
+        LCI_error_t retval;
+        int lci_initialized = 0;
+        LCI_initialized(&lci_initialized);
+        if (!lci_initialized)
         {
-            rtcfg.add_entry("hpx.parcel.lci.enable", "0");
-            return;
+            retval = LCI_initialize();
+            if (LCI_OK != retval)
+            {
+                rtcfg.add_entry("hpx.parcel.lci.enable", "0");
+                enabled_ = false;
+                throw std::runtime_error(
+                    "lci_environment::init: LCI_initialize failed");
+            }
         }
 
-        rtcfg.add_entry("hpx.parcel.bootstrap", "lci");
-
-        LCI_error_t retval = init_lci();
-        if (LCI_OK != retval)
-        {
-            // explicitly disable lci if not run by mpirun
-            rtcfg.add_entry("hpx.parcel.lci.enable", "0");
-            enabled_ = false;
-            throw std::runtime_error(
-                "lci_environment::init: LCI_initialize failed");
-        }
-
-        this_rank = rank();
+        int this_rank = rank();
 
 #if defined(HPX_HAVE_NETWORKING)
         if (this_rank == 0)
@@ -182,7 +197,54 @@ namespace hpx { namespace util {
         rtcfg.mode_ = hpx::runtime_mode::local;
 #endif
 
+        rtcfg.add_entry("hpx.parcel.bootstrap", "lci");
         rtcfg.add_entry("hpx.parcel.lci.rank", std::to_string(this_rank));
+        enabled_ = true;
+    }
+
+    void lci_environment::setup(util::runtime_configuration& rtcfg)
+    {
+        if (!enabled_)
+            return;
+        if (setuped_)
+            return;    // don't call twice
+
+        init_config(rtcfg);
+        // create ep, scq, rcq
+        device_eager = LCI_UR_DEVICE;
+        if (use_two_device)
+            LCI_device_init(&device_iovec);
+        else
+            device_iovec = LCI_UR_DEVICE;
+        LCI_queue_create(LCI_UR_DEVICE /* no use */, &scq);
+        LCI_queue_create(LCI_UR_DEVICE /* no use */, &rcq);
+        LCI_plist_t plist_;
+        LCI_plist_create(&plist_);
+        LCI_plist_set_default_comp(plist_, rcq);
+        LCI_plist_set_comp_type(plist_, LCI_PORT_COMMAND, LCI_COMPLETION_QUEUE);
+        LCI_plist_set_comp_type(plist_, LCI_PORT_MESSAGE, LCI_COMPLETION_QUEUE);
+        LCI_endpoint_init(&ep_eager, device_eager, plist_);
+        LCI_endpoint_init(&ep_iovec, device_iovec, plist_);
+        LCI_plist_free(&plist_);
+
+        // create progress thread
+        HPX_ASSERT(prg_thread_flag == false);
+        HPX_ASSERT(prg_thread_eager_p == nullptr);
+        HPX_ASSERT(prg_thread_iovec_p == nullptr);
+        prg_thread_flag = true;
+        prg_thread_eager_p =
+            std::make_unique<std::thread>(progress_fn, get_device_eager());
+        if (use_two_device)
+            prg_thread_iovec_p =
+                std::make_unique<std::thread>(progress_fn, get_device_iovec());
+        int target = get_entry_as(rtcfg, "hpx.parcel.lci.prg_thread_core", -1);
+        if (target >= 0)
+        {
+            set_affinity(prg_thread_eager_p->native_handle(), target);
+            if (use_two_device)
+                set_affinity(prg_thread_iovec_p->native_handle(), target + 1);
+        }
+        setuped_ = true;
     }
 
     std::string lci_environment::get_processor_name()
@@ -199,11 +261,17 @@ namespace hpx { namespace util {
             LCI_initialized(&lci_init);
             if (lci_init)
             {
-                join_prg_thread_if_running();
-                // create ep, scq, rcq
-                LCI_endpoint_free(&ep);
-                LCI_queue_free(&scq);
-                LCI_queue_free(&rcq);
+                if (setuped_)
+                {
+                    join_prg_thread_if_running();
+                    // create ep, scq, rcq
+                    LCI_endpoint_free(&ep_iovec);
+                    LCI_endpoint_free(&ep_eager);
+                    LCI_queue_free(&scq);
+                    LCI_queue_free(&rcq);
+                    if (use_two_device)
+                        LCI_device_free(&device_iovec);
+                }
                 LCI_finalize();
             }
         }
@@ -211,25 +279,33 @@ namespace hpx { namespace util {
 
     void lci_environment::join_prg_thread_if_running()
     {
-        if (prg_thread_p)
+        if (prg_thread_eager_p || prg_thread_iovec_p)
         {
             prg_thread_flag = false;
-            prg_thread_p->join();
-            prg_thread_p.reset();
+            if (prg_thread_eager_p)
+            {
+                prg_thread_eager_p->join();
+                prg_thread_eager_p.reset();
+            }
+            if (prg_thread_iovec_p)
+            {
+                prg_thread_iovec_p->join();
+                prg_thread_iovec_p.reset();
+            }
         }
     }
 
-    void lci_environment::progress_fn()
+    void lci_environment::progress_fn(LCI_device_t device)
     {
         while (prg_thread_flag)
         {
-            LCI_progress(LCI_UR_DEVICE);
+            LCI_progress(device);
         }
     }
 
-    bool lci_environment::do_progress()
+    bool lci_environment::do_progress(LCI_device_t device)
     {
-        LCI_error_t ret = LCI_progress(LCI_UR_DEVICE);
+        LCI_error_t ret = LCI_progress(device);
         HPX_ASSERT(ret == LCI_OK || ret == LCI_ERR_RETRY);
         return ret == LCI_OK;
     }
@@ -255,9 +331,24 @@ namespace hpx { namespace util {
         return res;
     }
 
-    LCI_endpoint_t& lci_environment::get_endpoint()
+    LCI_device_t& lci_environment::get_device_eager()
     {
-        return ep;
+        return device_eager;
+    }
+
+    LCI_device_t& lci_environment::get_device_iovec()
+    {
+        return device_iovec;
+    }
+
+    LCI_endpoint_t& lci_environment::get_endpoint_eager()
+    {
+        return ep_eager;
+    }
+
+    LCI_endpoint_t& lci_environment::get_endpoint_iovec()
+    {
+        return ep_iovec;
     }
 
     LCI_comp_t& lci_environment::get_scq()

--- a/libs/full/parcelport_lci/CMakeLists.txt
+++ b/libs/full/parcelport_lci/CMakeLists.txt
@@ -11,16 +11,22 @@ endif()
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 
 set(parcelport_lci_headers
-    hpx/parcelport_lci/header.hpp hpx/parcelport_lci/locality.hpp
-    hpx/parcelport_lci/receiver.hpp hpx/parcelport_lci/sender.hpp
+    hpx/parcelport_lci/header.hpp
+    hpx/parcelport_lci/locality.hpp
+    hpx/parcelport_lci/receiver.hpp
+    hpx/parcelport_lci/sender.hpp
     hpx/parcelport_lci/sender_connection.hpp
+    hpx/parcelport_lci/backlog_queue.hpp
+    hpx/parcelport_lci/parcelport_lci.hpp
 )
 
 # cmake-format: off
 set(parcelport_lci_compat_headers)
 # cmake-format: on
 
-set(parcelport_lci_sources locality.cpp parcelport_lci.cpp)
+set(parcelport_lci_sources locality.cpp parcelport_lci.cpp sender.cpp
+                           sender_connection.cpp backlog_queue.cpp
+)
 
 include(HPX_SetupLCI)
 hpx_setup_lci()

--- a/libs/full/parcelport_lci/include/hpx/parcelport_lci/backlog_queue.hpp
+++ b/libs/full/parcelport_lci/include/hpx/parcelport_lci/backlog_queue.hpp
@@ -1,0 +1,35 @@
+//  Copyright (c) 2014-2023 Thomas Heller
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include <hpx/config.hpp>
+
+#if defined(HPX_HAVE_NETWORKING) && defined(HPX_HAVE_PARCELPORT_LCI)
+
+#include <deque>
+#include <memory>
+#include <vector>
+
+namespace hpx::parcelset::policies::lci {
+    struct sender_connection;
+    namespace backlog_queue {
+        using message_type = sender_connection;
+        using message_ptr = std::shared_ptr<message_type>;
+        struct backlog_queue_t
+        {
+            // pending messages per destination
+            std::vector<std::deque<message_ptr>> messages;
+        };
+
+        void push(message_ptr message);
+        bool empty(int dst_rank);
+        bool background_work(size_t num_thread) noexcept;
+        void free();
+    }    // namespace backlog_queue
+}    // namespace hpx::parcelset::policies::lci
+
+#endif

--- a/libs/full/parcelport_lci/include/hpx/parcelport_lci/parcelport_lci.hpp
+++ b/libs/full/parcelport_lci/include/hpx/parcelport_lci/parcelport_lci.hpp
@@ -1,0 +1,199 @@
+//  Copyright (c) 2014-2023 Thomas Heller
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include <hpx/config.hpp>
+
+#if defined(HPX_HAVE_NETWORKING) && defined(HPX_HAVE_PARCELPORT_LCI)
+
+#include <hpx/config/warnings_prefix.hpp>
+
+#include <hpx/modules/lci_base.hpp>
+#include <hpx/parcelport_lci/backlog_queue.hpp>
+#include <hpx/parcelport_lci/header.hpp>
+#include <hpx/parcelport_lci/locality.hpp>
+#include <hpx/parcelport_lci/receiver.hpp>
+#include <hpx/parcelport_lci/sender.hpp>
+#include <hpx/parcelport_lci/sender_connection.hpp>
+
+#include <atomic>
+#include <cstddef>
+#include <memory>
+#include <string>
+#include <type_traits>
+
+namespace hpx::parcelset {
+    namespace policies::lci {
+        class HPX_EXPORT parcelport;
+    }    // namespace policies::lci
+
+    template <>
+    struct connection_handler_traits<policies::lci::parcelport>
+    {
+        using connection_type = policies::lci::sender_connection;
+        using send_early_parcel = std::true_type;
+        using do_background_work = std::true_type;
+        using send_immediate_parcels = std::true_type;
+        using is_connectionless = std::true_type;
+
+        static constexpr const char* type() noexcept
+        {
+            return "lci";
+        }
+
+        static constexpr const char* pool_name() noexcept
+        {
+            return "parcel-pool-lci";
+        }
+
+        static constexpr const char* pool_name_postfix() noexcept
+        {
+            return "-lci";
+        }
+    };
+
+    namespace policies::lci {
+        class HPX_EXPORT parcelport : public parcelport_impl<parcelport>
+        {
+            using base_type = parcelport_impl<parcelport>;
+            static parcelset::locality here();
+            static std::size_t max_connections(
+                util::runtime_configuration const& ini);
+
+        public:
+            using sender_type = sender;
+            parcelport(util::runtime_configuration const& ini,
+                threads::policies::callback_notifier const& notifier);
+
+            ~parcelport();
+
+            void initialized() override;
+            // Start the handling of connections.
+            bool do_run();
+
+            // Stop the handling of connections.
+            void do_stop();
+
+            /// Return the name of this locality
+            std::string get_locality_name() const override;
+
+            std::shared_ptr<sender_connection> create_connection(
+                parcelset::locality const& l, error_code&);
+
+            parcelset::locality agas_locality(
+                util::runtime_configuration const&) const override;
+
+            parcelset::locality create_locality() const override;
+
+            void send_early_parcel(
+                hpx::parcelset::locality const& dest, parcel p) override;
+
+            bool do_background_work(std::size_t num_thread,
+                parcelport_background_mode mode) override;
+
+            bool background_work(
+                std::size_t num_thread, parcelport_background_mode mode);
+
+            bool can_send_immediate();
+
+            // whether the parcelport is sending early parcels
+            static bool is_sending_early_parcel;
+
+        private:
+            using mutex_type = hpx::spinlock;
+
+            std::atomic<bool> stopped_;
+
+            sender sender_;
+            receiver<parcelport> receiver_;
+
+            void io_service_work();
+        };
+    }    // namespace policies::lci
+}    // namespace hpx::parcelset
+#include <hpx/config/warnings_suffix.hpp>
+
+namespace hpx::traits {
+    // Inject additional configuration data into the factory registry for this
+    // type. This information ends up in the system wide configuration database
+    // under the plugin specific section:
+    //
+    //      [hpx.parcel.lci]
+    //      ...
+    //      priority = 200
+    //
+    template <>
+    struct plugin_config_data<hpx::parcelset::policies::lci::parcelport>
+    {
+        static constexpr char const* priority() noexcept
+        {
+            return "50";
+        }
+
+        static void init(int*, char***, util::command_line_handling& cfg)
+        {
+            if (util::lci_environment::enabled())
+            {
+                util::lci_environment::setup(cfg.rtcfg_);
+                cfg.num_localities_ =
+                    static_cast<std::size_t>(util::lci_environment::size());
+                cfg.node_ =
+                    static_cast<std::size_t>(util::lci_environment::rank());
+            }
+        }
+
+        static void init(hpx::resource::partitioner& rp) noexcept
+        {
+            if (util::lci_environment::enabled() &&
+                util::lci_environment::enable_lci_progress_pool)
+            {
+                rp.create_thread_pool("lci-progress-pool-eager",
+                    hpx::resource::scheduling_policy::static_,
+                    hpx::threads::policies::scheduler_mode::
+                        do_background_work_only);
+                if (util::lci_environment::use_two_device)
+                    rp.create_thread_pool("lci-progress-pool-iovec",
+                        hpx::resource::scheduling_policy::static_,
+                        hpx::threads::policies::scheduler_mode::
+                            do_background_work_only);
+                rp.add_resource(rp.numa_domains()[0].cores()[0].pus()[0],
+                    "lci-progress-pool-eager");
+                if (util::lci_environment::use_two_device)
+                    rp.add_resource(rp.numa_domains()[0].cores()[1].pus()[0],
+                        "lci-progress-pool-iovec");
+            }
+        }
+
+        static void destroy()
+        {
+            util::lci_environment::finalize();
+        }
+
+        static constexpr char const* call() noexcept
+        {
+            return
+#if defined(HPX_HAVE_PARCELPORT_LCI_ENV)
+                "env = "
+                "${HPX_HAVE_PARCELPORT_LCI_ENV:" HPX_HAVE_PARCELPORT_LCI_ENV
+                "}\n"
+#else
+                "env = ${HPX_HAVE_PARCELPORT_LCI_ENV:"
+                "MV2_COMM_WORLD_RANK,PMIX_RANK,PMI_RANK,LCI_COMM_WORLD_SIZE,"
+                "ALPS_APP_PE,PALS_NODEID"
+                "}\n"
+#endif
+                "max_connections = "
+                "${HPX_HAVE_PARCELPORT_LCI_MAX_CONNECTIONS:8192}\n"
+                "rp_prg_pool = 1\n"
+                "backlog_queue = 0\n"
+                "use_two_device = 0\n"
+                "prg_thread_core = -1\n";
+        }
+    };
+}    // namespace hpx::traits
+
+#endif

--- a/libs/full/parcelport_lci/include/hpx/parcelport_lci/receiver.hpp
+++ b/libs/full/parcelport_lci/include/hpx/parcelport_lci/receiver.hpp
@@ -122,67 +122,100 @@ namespace hpx::parcelset::policies::lci {
 
             if (request.request.flag == LCI_OK)
             {
-                buffer_type buffer = decode_request(request.request);
-                decode_parcels(pp_, HPX_MOVE(buffer), -1);
+                process_request(request.request);
                 return true;
             }
             return false;
         }
 
-        buffer_type decode_request(LCI_request_t request)
+        void process_request(LCI_request_t request)
         {
-            buffer_type buffer_;
-            header header_;
-            // decode header
             if (request.type == LCI_MEDIUM)
             {
-                // only header
-                header_ = header((char*) request.data.mbuffer.address);
-                header_.assert_valid();
-
-                HPX_ASSERT(
-                    header_.piggy_back_data() && !header_.piggy_back_tchunk());
-                HPX_ASSERT(header_.num_zero_copy_chunks() == 0);
+                size_t consumed = 0;
+                while (consumed < request.data.mbuffer.length)
+                {
+                    buffer_type buffer;
+                    consumed += decode_eager(
+                        (char*) request.data.mbuffer.address + consumed,
+                        buffer);
+                    decode_parcels(pp_, HPX_MOVE(buffer), -1);
+                }
+                HPX_ASSERT(consumed == request.data.mbuffer.length);
             }
             else
             {
                 // iovec
                 HPX_ASSERT(request.type == LCI_IOVEC);
-                header_ = header((char*) request.data.iovec.piggy_back.address);
-                header_.assert_valid();
+                buffer_type buffer;
+                decode_iovec(request.data.iovec, buffer);
+                decode_parcels(pp_, HPX_MOVE(buffer), -1);
             }
+        }
+
+        size_t decode_eager(void* address, buffer_type& buffer)
+        {
 #if defined(HPX_HAVE_PARCELPORT_COUNTERS)
             hpx::chrono::high_resolution_timer timer_;
-            parcelset::data_point& data = buffer_.data_point_;
+            parcelset::data_point& data = buffer.data_point_;
             data.time_ = timer_.elapsed_nanoseconds();
-            data.bytes_ = static_cast<std::size_t>(header_.numbytes());
 #endif
+            // decode header
+            header header_ = header((char*) address);
+            header_.assert_valid();
+            HPX_ASSERT(
+                header_.piggy_back_data() && !header_.piggy_back_tchunk());
+            HPX_ASSERT(header_.num_zero_copy_chunks() == 0);    // decode data
+            // decode data
+            buffer.data_.length = header_.numbytes_nonzero_copy();
+            buffer.data_.ptr = header_.piggy_back_data();
+            // decode transmission chunk
+            int num_zero_copy_chunks = header_.num_zero_copy_chunks();
+            int num_non_zero_copy_chunks = header_.num_non_zero_copy_chunks();
+            buffer.num_chunks_.first = num_zero_copy_chunks;
+            buffer.num_chunks_.second = num_non_zero_copy_chunks;
+#if defined(HPX_HAVE_PARCELPORT_COUNTERS)
+            data.bytes_ = static_cast<std::size_t>(header_.numbytes());
+            data.time_ = timer_.elapsed_nanoseconds() - data.time_;
+#endif
+            return header_.size();
+        }
+
+        void decode_iovec(LCI_iovec_t iovec, buffer_type& buffer)
+        {
+#if defined(HPX_HAVE_PARCELPORT_COUNTERS)
+            hpx::chrono::high_resolution_timer timer_;
+            parcelset::data_point& data = buffer.data_point_;
+            data.time_ = timer_.elapsed_nanoseconds();
+#endif
+            // decode header
+            header header_ = header((char*) iovec.piggy_back.address);
+            header_.assert_valid();
             int i = 0;
             // decode data
             char* piggy_back_data = header_.piggy_back_data();
             if (piggy_back_data)
             {
-                buffer_.data_.length = header_.numbytes_nonzero_copy();
-                buffer_.data_.ptr = piggy_back_data;
+                buffer.data_.length = header_.numbytes_nonzero_copy();
+                buffer.data_.ptr = piggy_back_data;
             }
             else
             {
-                HPX_ASSERT(request.type == LCI_IOVEC);
                 HPX_ASSERT((size_t) header_.numbytes_nonzero_copy() ==
-                    request.data.iovec.lbuffers[i].length);
-                buffer_.data_.length = header_.numbytes_nonzero_copy();
-                buffer_.data_.ptr = request.data.iovec.lbuffers[i].address;
+                    iovec.lbuffers[i].length);
+                buffer.data_.length = header_.numbytes_nonzero_copy();
+                buffer.data_.ptr = iovec.lbuffers[i].address;
                 ++i;
             }
-            // decode transmission chunk
-            int num_zero_copy_chunks = header_.num_zero_copy_chunks();
-            int num_non_zero_copy_chunks = header_.num_non_zero_copy_chunks();
-            buffer_.num_chunks_.first = num_zero_copy_chunks;
-            buffer_.num_chunks_.second = num_non_zero_copy_chunks;
-            if (num_zero_copy_chunks != 0)
+            if (header_.num_zero_copy_chunks() != 0)
             {
-                HPX_ASSERT(request.type == LCI_IOVEC);
-                auto& tchunks = buffer_.transmission_chunks_;
+                // decode transmission chunk
+                int num_zero_copy_chunks = header_.num_zero_copy_chunks();
+                int num_non_zero_copy_chunks =
+                    header_.num_non_zero_copy_chunks();
+                buffer.num_chunks_.first = num_zero_copy_chunks;
+                buffer.num_chunks_.second = num_non_zero_copy_chunks;
+                auto& tchunks = buffer.transmission_chunks_;
                 tchunks.resize(num_zero_copy_chunks + num_non_zero_copy_chunks);
                 int tchunks_length = static_cast<int>(tchunks.size() *
                     sizeof(buffer_type::transmission_chunk_type));
@@ -194,33 +227,30 @@ namespace hpx::parcelset::policies::lci {
                 }
                 else
                 {
-                    HPX_ASSERT((size_t) tchunks_length ==
-                        request.data.iovec.lbuffers[i].length);
+                    HPX_ASSERT(
+                        (size_t) tchunks_length == iovec.lbuffers[i].length);
                     std::memcpy((void*) tchunks.data(),
-                        request.data.iovec.lbuffers[i].address, tchunks_length);
+                        iovec.lbuffers[i].address, tchunks_length);
                     ++i;
                 }
                 // zero-copy chunks
-                buffer_.chunks_.resize(num_zero_copy_chunks);
+                buffer.chunks_.resize(num_zero_copy_chunks);
                 for (int j = 0; j < num_zero_copy_chunks; ++j)
                 {
                     std::size_t chunk_size =
-                        buffer_.transmission_chunks_[j].second;
-                    HPX_ASSERT(
-                        request.data.iovec.lbuffers[i].length == chunk_size);
-                    buffer_wrapper& c = buffer_.chunks_[j];
+                        buffer.transmission_chunks_[j].second;
+                    HPX_ASSERT(iovec.lbuffers[i].length == chunk_size);
+                    buffer_wrapper& c = buffer.chunks_[j];
                     c.length = chunk_size;
-                    c.ptr = request.data.iovec.lbuffers[i].address;
+                    c.ptr = iovec.lbuffers[i].address;
                     ++i;
                 }
             }
-            HPX_ASSERT(
-                request.type == LCI_MEDIUM || i == request.data.iovec.count);
-
+            HPX_ASSERT(i == iovec.count);
 #if defined(HPX_HAVE_PARCELPORT_COUNTERS)
+            data.bytes_ = static_cast<std::size_t>(header_.numbytes());
             data.time_ = timer_.elapsed_nanoseconds() - data.time_;
 #endif
-            return buffer_;
         }
 
         Parcelport& pp_;

--- a/libs/full/parcelport_lci/src/backlog_queue.cpp
+++ b/libs/full/parcelport_lci/src/backlog_queue.cpp
@@ -1,0 +1,82 @@
+//  Copyright (c) 2007-2013 Hartmut Kaiser
+//  Copyright (c) 2014-2015 Thomas Heller
+//  Copyright (c)      2020 Google
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/config.hpp>
+
+#if defined(HPX_HAVE_NETWORKING) && defined(HPX_HAVE_PARCELPORT_LCI)
+
+#include <hpx/modules/lci_base.hpp>
+#include <hpx/parcelport_lci/backlog_queue.hpp>
+#include <hpx/parcelport_lci/header.hpp>
+#include <hpx/parcelport_lci/locality.hpp>
+#include <hpx/parcelport_lci/receiver.hpp>
+#include <hpx/parcelport_lci/sender.hpp>
+#include <hpx/parcelport_lci/sender_connection.hpp>
+
+namespace hpx::parcelset::policies::lci::backlog_queue {
+    thread_local backlog_queue_t tls_backlog_queue;
+
+    void push(message_ptr message)
+    {
+        if (tls_backlog_queue.messages.size() <= (size_t) message->dst_rank)
+        {
+            tls_backlog_queue.messages.resize(message->dst_rank + 1);
+        }
+        auto& message_queue = tls_backlog_queue.messages[message->dst_rank];
+        if (!message_queue.empty())
+        {
+            bool succeed = message_queue.back()->tryMerge(message);
+            if (succeed)
+                return;
+        }
+        tls_backlog_queue.messages[message->dst_rank].push_back(
+            HPX_MOVE(message));
+    }
+
+    bool empty(int dst_rank)
+    {
+        if (tls_backlog_queue.messages.size() <= (size_t) dst_rank)
+        {
+            tls_backlog_queue.messages.resize(dst_rank + 1);
+        }
+        bool ret = tls_backlog_queue.messages[dst_rank].empty();
+        return ret;
+    }
+
+    bool background_work(size_t num_thread) noexcept
+    {
+        bool did_some_work = false;
+        for (size_t i = 0; i < tls_backlog_queue.messages.size(); ++i)
+        {
+            size_t idx = (num_thread + i) % tls_backlog_queue.messages.size();
+            while (idx < tls_backlog_queue.messages.size() &&
+                !tls_backlog_queue.messages[idx].empty())
+            {
+                message_ptr message = tls_backlog_queue.messages[idx].front();
+                //                bool needCallDone = message->isEager();
+                bool isSent = message->send();
+                if (isSent)
+                {
+                    tls_backlog_queue.messages[idx].pop_front();
+                    did_some_work = true;
+                    //                    if (needCallDone) {
+                    //                        message->done();
+                    // it can context switch to another thread at this point
+                    //                    }
+                }
+                else
+                {
+                    break;
+                }
+            }
+        }
+        return did_some_work;
+    }
+}    // namespace hpx::parcelset::policies::lci::backlog_queue
+
+#endif

--- a/libs/full/parcelport_lci/src/parcelport_lci.cpp
+++ b/libs/full/parcelport_lci/src/parcelport_lci.cpp
@@ -9,392 +9,231 @@
 #include <hpx/config.hpp>
 
 #if defined(HPX_HAVE_NETWORKING) && defined(HPX_HAVE_PARCELPORT_LCI)
-#include <hpx/modules/errors.hpp>
-#include <hpx/modules/execution_base.hpp>
-#include <hpx/modules/functional.hpp>
-#include <hpx/modules/resource_partitioner.hpp>
-#include <hpx/modules/runtime_configuration.hpp>
-#include <hpx/modules/runtime_local.hpp>
-#include <hpx/modules/synchronization.hpp>
-#include <hpx/modules/util.hpp>
-#include <hpx/plugin/traits/plugin_config_data.hpp>
 
-#include <hpx/command_line_handling/command_line_handling.hpp>
+#include <hpx/parcelset_base/parcelport.hpp>
+
 #include <hpx/modules/lci_base.hpp>
-#include <hpx/parcelport_lci/header.hpp>
+#include <hpx/parcelport_lci/backlog_queue.hpp>
 #include <hpx/parcelport_lci/locality.hpp>
+#include <hpx/parcelport_lci/parcelport_lci.hpp>
 #include <hpx/parcelport_lci/receiver.hpp>
 #include <hpx/parcelport_lci/sender.hpp>
-#include <hpx/parcelset/parcelport_impl.hpp>
-#include <hpx/parcelset_base/locality.hpp>
-#include <hpx/plugin_factories/parcelport_factory.hpp>
+#include <hpx/parcelport_lci/sender_connection.hpp>
 
-#include <atomic>
 #include <cstddef>
-#include <exception>
 #include <memory>
 #include <string>
-#include <system_error>
 #include <type_traits>
 
-#include <hpx/config/warnings_prefix.hpp>
-
-namespace hpx::parcelset {
-
-    namespace policies::lci {
-        class HPX_EXPORT parcelport;
-    }    // namespace policies::lci
-
-    template <>
-    struct connection_handler_traits<policies::lci::parcelport>
+namespace hpx::parcelset::policies::lci {
+    parcelset::locality parcelport::here()
     {
-        using connection_type = policies::lci::sender_connection;
-        using send_early_parcel = std::true_type;
-        using do_background_work = std::true_type;
-        using send_immediate_parcels = std::true_type;
-        using is_connectionless = std::true_type;
+        return parcelset::locality(locality(util::lci_environment::enabled() ?
+                util::lci_environment::rank() :
+                -1));
+    }
 
-        static constexpr const char* type() noexcept
-        {
-            return "lci";
-        }
-
-        static constexpr const char* pool_name() noexcept
-        {
-            return "parcel-pool-lci";
-        }
-
-        static constexpr const char* pool_name_postfix() noexcept
-        {
-            return "-lci";
-        }
-    };
-
-    namespace policies::lci {
-        class HPX_EXPORT parcelport : public parcelport_impl<parcelport>
-        {
-            using base_type = parcelport_impl<parcelport>;
-
-            static parcelset::locality here()
-            {
-                return parcelset::locality(
-                    locality(util::lci_environment::enabled() ?
-                            util::lci_environment::rank() :
-                            -1));
-            }
-
-            static std::size_t max_connections(
-                util::runtime_configuration const& ini)
-            {
-                return hpx::util::get_entry_as<std::size_t>(ini,
-                    "hpx.parcel.lci.max_connections",
-                    HPX_PARCEL_MAX_CONNECTIONS);
-            }
-
-        public:
-            using sender_type = policies::lci::sender;
-
-            parcelport(util::runtime_configuration const& ini,
-                threads::policies::callback_notifier const& notifier)
-              : base_type(ini, here(), notifier)
-              , stopped_(false)
-              , receiver_(*this)
-            {
-                can_send_immediate_flag = false;
-                if (connection_handler_traits<hpx::parcelset::policies::lci::
-                            parcelport>::send_immediate_parcels::value)
-                {
-                    // The default value here does not matter here
-                    // the key "hpx.parcel.lci.sendimm" is guaranteed to exist
-                    can_send_immediate_flag = hpx::util::get_entry_as<bool>(ini,
-                        "hpx.parcel.lci.sendimm", false /* Does not matter*/);
-                }
-            }
-
-            ~parcelport()
-            {
-                util::lci_environment::finalize();
-            }
-
-            void initialized() override
-            {
-                if (util::lci_environment::enabled() &&
-                    hpx::parcelset::policies::lci::parcelport::
-                        enable_lci_progress_pool)
-                {
-                    util::lci_environment::join_prg_thread_if_running();
-                }
-            }
-
-            // Start the handling of connections.
-            bool do_run()
-            {
-                receiver_.run();
-                sender_.run();
-                for (std::size_t i = 0; i != io_service_pool_.size(); ++i)
-                {
-                    io_service_pool_.get_io_service(int(i)).post(
-                        hpx::bind(&parcelport::io_service_work, this));
-                }
-                return true;
-            }
-
-            // Stop the handling of connections.
-            void do_stop()
-            {
-                while (do_background_work(0, parcelport_background_mode_all))
-                {
-                    if (threads::get_self_ptr())
-                        hpx::this_thread::suspend(
-                            hpx::threads::thread_schedule_state::pending,
-                            "lci::parcelport::do_stop");
-                }
-                stopped_ = true;
-                LCI_barrier();
-            }
-
-            /// Return the name of this locality
-            std::string get_locality_name() const override
-            {
-                // hostname-rank
-                return util::lci_environment::get_processor_name() + "-" +
-                    std::to_string(util::lci_environment::rank());
-            }
-
-            std::shared_ptr<sender_connection> create_connection(
-                parcelset::locality const& l, error_code&)
-            {
-                int dest_rank = l.get<locality>().rank();
-                return sender_.create_connection(dest_rank, this);
-            }
-
-            parcelset::locality agas_locality(
-                util::runtime_configuration const&) const override
-            {
-                return parcelset::locality(
-                    locality(util::lci_environment::enabled() ? 0 : -1));
-            }
-
-            parcelset::locality create_locality() const override
-            {
-                return parcelset::locality(locality());
-            }
-
-            bool background_work(
-                std::size_t /* num_thread */, parcelport_background_mode mode)
-            {
-                if (stopped_)
-                    return false;
-
-                static thread_local int do_lci_progress = -1;
-                if (do_lci_progress == -1)
-                {
-                    if (enable_lci_progress_pool &&
-                        hpx::threads::get_self_id() !=
-                            hpx::threads::invalid_thread_id &&
-                        hpx::this_thread::get_pool() ==
-                            &hpx::resource::get_thread_pool(
-                                "lci-progress-pool"))
-                    {
-                        do_lci_progress = 1;
-                    }
-                    else
-                    {
-                        do_lci_progress = 0;
-                    }
-                }
-
-                bool has_work = false;
-                if (do_lci_progress)
-                {
-                    // magic number
-                    int max_idle_loop_count = 1000;
-                    int idle_loop_count = 0;
-                    while (idle_loop_count < max_idle_loop_count)
-                    {
-                        while (util::lci_environment::do_progress())
-                        {
-                            has_work = true;
-                            idle_loop_count = 0;
-                        }
-                        ++idle_loop_count;
-                    }
-                }
-                else
-                {
-                    if (mode & parcelport_background_mode_send)
-                    {
-                        has_work = sender_.background_work();
-                    }
-                    if (mode & parcelport_background_mode_receive)
-                    {
-                        has_work = receiver_.background_work() || has_work;
-                    }
-                }
-                return has_work;
-            }
-
-            bool can_send_immediate()
-            {
-                return can_send_immediate_flag;
-            }
-
-            static bool enable_lci_progress_pool;
-            static bool enable_background_only_scheduler;
-
-        private:
-            using mutex_type = hpx::spinlock;
-
-            std::atomic<bool> stopped_;
-
-            sender sender_;
-            receiver<parcelport> receiver_;
-            bool can_send_immediate_flag;
-
-            void io_service_work()
-            {
-                std::size_t k = 0;
-                // We only execute work on the IO service while HPX is starting
-                while (hpx::is_starting())
-                {
-                    bool has_work = sender_.background_work();
-                    has_work = receiver_.background_work() || has_work;
-                    if (has_work)
-                    {
-                        k = 0;
-                    }
-                    else
-                    {
-                        ++k;
-                        util::detail::yield_k(k,
-                            "hpx::parcelset::policies::lci::parcelport::"
-                            "io_service_work");
-                    }
-                }
-            }
-
-            void early_write_handler(std::error_code const& ec, parcel const& p)
-            {
-                if (ec)
-                {
-                    // all errors during early parcel handling are fatal
-                    std::exception_ptr exception = hpx::detail::get_exception(
-                        hpx::exception(ec), "lci::early_write_handler",
-                        __FILE__, __LINE__,
-                        "error while handling early parcel: " + ec.message() +
-                            "(" + std::to_string(ec.value()) + ")" +
-                            parcelset::dump_parcel(p));
-
-                    hpx::report_error(exception);
-                }
-            }
-        };
-        bool parcelport::enable_lci_progress_pool = false;
-        bool parcelport::enable_background_only_scheduler = true;
-    }    // namespace policies::lci
-}    // namespace hpx::parcelset
-
-#include <hpx/config/warnings_suffix.hpp>
-
-namespace hpx::traits {
-    // Inject additional configuration data into the factory registry for this
-    // type. This information ends up in the system wide configuration database
-    // under the plugin specific section:
-    //
-    //      [hpx.parcel.lci]
-    //      ...
-    //      priority = 200
-    //
-    template <>
-    struct plugin_config_data<hpx::parcelset::policies::lci::parcelport>
+    std::size_t parcelport::max_connections(
+        util::runtime_configuration const& ini)
     {
-        static constexpr char const* priority() noexcept
+        return hpx::util::get_entry_as<std::size_t>(
+            ini, "hpx.parcel.lci.max_connections", HPX_PARCEL_MAX_CONNECTIONS);
+    }
+
+    parcelport::parcelport(util::runtime_configuration const& ini,
+        threads::policies::callback_notifier const& notifier)
+      : parcelport::base_type(ini, here(), notifier)
+      , stopped_(false)
+      , receiver_(*this)
+    {
+    }
+
+    parcelport::~parcelport()
+    {
+        util::lci_environment::finalize();
+    }
+
+    void parcelport::initialized()
+    {
+        if (util::lci_environment::enabled() &&
+            util::lci_environment::enable_lci_progress_pool)
         {
-            return "50";
+            util::lci_environment::join_prg_thread_if_running();
+        }
+    }
+
+    // Start the handling of connections.
+    bool parcelport::do_run()
+    {
+        receiver_.run();
+        sender_.run();
+        for (std::size_t i = 0; i != io_service_pool_.size(); ++i)
+        {
+            io_service_pool_.get_io_service(int(i)).post(
+                hpx::bind(&parcelport::io_service_work, this));
+        }
+        return true;
+    }
+
+    // Stop the handling of connections.
+    void parcelport::do_stop()
+    {
+        while (do_background_work(0, parcelport_background_mode_all))
+        {
+            if (threads::get_self_ptr())
+                hpx::this_thread::suspend(
+                    hpx::threads::thread_schedule_state::pending,
+                    "lci::parcelport::do_stop");
+        }
+        stopped_ = true;
+        LCI_barrier();
+    }
+
+    /// Return the name of this locality
+    std::string parcelport::get_locality_name() const
+    {
+        // hostname-rank
+        return util::lci_environment::get_processor_name() + "-" +
+            std::to_string(util::lci_environment::rank());
+    }
+
+    std::shared_ptr<sender_connection> parcelport::create_connection(
+        parcelset::locality const& l, error_code&)
+    {
+        int dest_rank = l.get<locality>().rank();
+        return sender_.create_connection(dest_rank, this);
+    }
+
+    parcelset::locality parcelport::agas_locality(
+        util::runtime_configuration const&) const
+    {
+        return parcelset::locality(
+            locality(util::lci_environment::enabled() ? 0 : -1));
+    }
+
+    parcelset::locality parcelport::create_locality() const
+    {
+        return parcelset::locality(locality());
+    }
+
+    void parcelport::send_early_parcel(
+        hpx::parcelset::locality const& dest, parcel p)
+    {
+        is_sending_early_parcel = true;
+        base_type::send_early_parcel(dest, HPX_MOVE(p));
+        is_sending_early_parcel = false;
+    }
+
+    bool parcelport::do_background_work(
+        std::size_t num_thread, parcelport_background_mode mode)
+    {
+        static thread_local int do_lci_progress = -1;
+        if (do_lci_progress == -1)
+        {
+            do_lci_progress = 0;
+            if (util::lci_environment::enable_lci_progress_pool &&
+                hpx::threads::get_self_id() != hpx::threads::invalid_thread_id)
+            {
+                if (hpx::this_thread::get_pool() ==
+                    &hpx::resource::get_thread_pool("lci-progress-pool-eager"))
+                    do_lci_progress = 1;
+                else if (util::lci_environment::use_two_device &&
+                    hpx::this_thread::get_pool() ==
+                        &hpx::resource::get_thread_pool(
+                            "lci-progress-pool-iovec"))
+                    do_lci_progress = 2;
+            }
         }
 
-        static void init(
-            int* argc, char*** argv, util::command_line_handling& cfg)
+        bool has_work = false;
+        // magic number
+        const int max_idle_loop_count = 1000;
+        if (do_lci_progress == 1)
         {
-            util::lci_environment::init(argc, argv, cfg.rtcfg_);
-            cfg.num_localities_ =
-                static_cast<std::size_t>(util::lci_environment::size());
-            cfg.node_ = static_cast<std::size_t>(util::lci_environment::rank());
-            std::size_t num_threads = hpx::util::get_entry_as<size_t>(
-                cfg.rtcfg_, "hpx.os_threads", 1);
-            if (num_threads > 1)
+            int idle_loop_count = 0;
+            while (idle_loop_count < max_idle_loop_count)
             {
-                hpx::parcelset::policies::lci::parcelport::
-                    enable_lci_progress_pool = hpx::util::get_entry_as<bool>(
-                        cfg.rtcfg_, "hpx.parcel.lci.rp_prg_pool",
-                        false /* Does not matter*/);
-                hpx::parcelset::policies::lci::parcelport::
-                    enable_background_only_scheduler =
-                        hpx::util::get_entry_as<bool>(cfg.rtcfg_,
-                            "hpx.parcel.lci.background_only_scheduler",
-                            false /* Does not matter*/);
+                while (util::lci_environment::do_progress(
+                    util::lci_environment::get_device_eager()))
+                {
+                    has_work = true;
+                    idle_loop_count = 0;
+                }
+                ++idle_loop_count;
+            }
+        }
+        else if (do_lci_progress == 2)
+        {
+            // magic number
+            int idle_loop_count = 0;
+            while (idle_loop_count < max_idle_loop_count)
+            {
+                while (util::lci_environment::do_progress(
+                    util::lci_environment::get_device_iovec()))
+                {
+                    has_work = true;
+                    idle_loop_count = 0;
+                }
+                ++idle_loop_count;
+            }
+        }
+        else
+        {
+            has_work = base_type::do_background_work(num_thread, mode);
+        }
+        return has_work;
+    }
+
+    bool parcelport::background_work(
+        std::size_t num_thread, parcelport_background_mode mode)
+    {
+        if (stopped_)
+            return false;
+
+        bool has_work;
+        if (mode & parcelport_background_mode_send)
+        {
+            has_work = sender_.background_work(num_thread);
+            // try to send pending messages
+            has_work = backlog_queue::background_work(num_thread) || has_work;
+        }
+        if (mode & parcelport_background_mode_receive)
+        {
+            has_work = receiver_.background_work() || has_work;
+        }
+        return has_work;
+    }
+
+    bool parcelport::can_send_immediate()
+    {
+        return util::lci_environment::enable_send_immediate;
+    }
+
+    void parcelport::io_service_work()
+    {
+        std::size_t k = 0;
+        // We only execute work on the IO service while HPX is starting
+        // TODO: stop io service work when worker threads start to execute the
+        //  background function
+        while (hpx::is_starting())
+        {
+            bool has_work = sender_.background_work(0);
+            has_work = receiver_.background_work() || has_work;
+            if (has_work)
+            {
+                k = 0;
             }
             else
             {
-                hpx::parcelset::policies::lci::parcelport::
-                    enable_lci_progress_pool = false;
-                hpx::parcelset::policies::lci::parcelport::
-                    enable_background_only_scheduler = false;
+                ++k;
+                util::detail::yield_k(k,
+                    "hpx::parcelset::policies::lci::parcelport::"
+                    "io_service_work");
             }
         }
-
-        static void init(hpx::resource::partitioner& rp) noexcept
-        {
-            if (util::lci_environment::enabled() &&
-                hpx::parcelset::policies::lci::parcelport::
-                    enable_lci_progress_pool)
-            {
-                if (hpx::parcelset::policies::lci::parcelport::
-                        enable_background_only_scheduler)
-                {
-                    rp.create_thread_pool("lci-progress-pool",
-                        hpx::resource::scheduling_policy::static_,
-                        hpx::threads::policies::scheduler_mode::
-                            do_background_work_only);
-                }
-                else
-                {
-                    rp.create_thread_pool("lci-progress-pool",
-                        hpx::resource::scheduling_policy::local,
-                        hpx::threads::policies::scheduler_mode::
-                            do_background_work);
-                }
-                rp.add_resource(rp.numa_domains()[0].cores()[0].pus()[0],
-                    "lci-progress-pool");
-            }
-        }
-
-        static void destroy()
-        {
-            util::lci_environment::finalize();
-        }
-
-        static constexpr char const* call() noexcept
-        {
-            return
-            // TODO: change these for LCI
-#if defined(HPX_HAVE_PARCELPORT_LCI_ENV)
-                "env = "
-                "${HPX_HAVE_PARCELPORT_LCI_ENV:" HPX_HAVE_PARCELPORT_LCI_ENV
-                "}\n"
-#else
-                "env = ${HPX_HAVE_PARCELPORT_LCI_ENV:"
-                "MV2_COMM_WORLD_RANK,PMIX_RANK,PMI_RANK,LCI_COMM_WORLD_SIZE,"
-                "ALPS_APP_PE,PALS_NODEID"
-                "}\n"
-#endif
-                "max_connections = "
-                "${HPX_HAVE_PARCELPORT_LCI_MAX_CONNECTIONS:8192}\n"
-                "rp_prg_pool = 1\n"
-                "background_only_scheduler = 1\n";
-        }
-    };
-}    // namespace hpx::traits
+    }
+    bool parcelport::is_sending_early_parcel = false;
+}    // namespace hpx::parcelset::policies::lci
 
 HPX_REGISTER_PARCELPORT(hpx::parcelset::policies::lci::parcelport, lci)
 

--- a/libs/full/parcelport_lci/src/sender.cpp
+++ b/libs/full/parcelport_lci/src/sender.cpp
@@ -1,0 +1,61 @@
+//  Copyright (c) 2007-2013 Hartmut Kaiser
+//  Copyright (c) 2014-2015 Thomas Heller
+//  Copyright (c)      2020 Google
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/config.hpp>
+
+#if defined(HPX_HAVE_NETWORKING) && defined(HPX_HAVE_PARCELPORT_LCI)
+
+#include <hpx/modules/lci_base.hpp>
+#include <hpx/parcelport_lci/backlog_queue.hpp>
+#include <hpx/parcelport_lci/locality.hpp>
+#include <hpx/parcelport_lci/receiver.hpp>
+#include <hpx/parcelport_lci/sender.hpp>
+#include <hpx/parcelport_lci/sender_connection.hpp>
+
+#include <memory>
+
+namespace hpx::parcelset::policies::lci {
+    sender::connection_ptr sender::create_connection(
+        int dest, parcelset::parcelport* pp)
+    {
+        return std::make_shared<connection_type>(dest, pp);
+    }
+
+    bool sender::background_work(size_t /* num_thread */) noexcept
+    {
+        bool did_some_work = false;
+        // try to accept a new connection
+        LCI_request_t request;
+        request.flag = LCI_ERR_RETRY;
+        LCI_queue_pop(util::lci_environment::get_scq(), &request);
+
+        if (request.flag == LCI_OK)
+        {
+            auto* sharedPtr_p = (connection_ptr*) request.user_context;
+            (*sharedPtr_p)->done();
+            delete sharedPtr_p;
+            did_some_work = true;
+        }
+
+        return did_some_work;
+    }
+
+    bool sender::send(parcelset::parcelport* pp,
+        parcelset::locality const& dest, parcel_buffer_type buffer,
+        callback_fn_type&& callbackFn)
+    {
+        int dest_rank = dest.get<locality>().rank();
+        auto connection = std::make_shared<sender_connection>(dest_rank, pp);
+        connection->buffer_ = HPX_MOVE(buffer);
+        connection->async_write(HPX_MOVE(callbackFn), nullptr);
+        return true;
+    }
+
+}    // namespace hpx::parcelset::policies::lci
+
+#endif

--- a/libs/full/parcelport_lci/src/sender_connection.cpp
+++ b/libs/full/parcelport_lci/src/sender_connection.cpp
@@ -1,0 +1,268 @@
+//  Copyright (c) 2007-2013 Hartmut Kaiser
+//  Copyright (c) 2014-2015 Thomas Heller
+//  Copyright (c)      2020 Google
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/config.hpp>
+
+#if defined(HPX_HAVE_NETWORKING) && defined(HPX_HAVE_PARCELPORT_LCI)
+
+#include <hpx/assert.hpp>
+
+#include <hpx/modules/lci_base.hpp>
+#include <hpx/parcelport_lci/backlog_queue.hpp>
+#include <hpx/parcelport_lci/header.hpp>
+#include <hpx/parcelport_lci/locality.hpp>
+#include <hpx/parcelport_lci/parcelport_lci.hpp>
+#include <hpx/parcelport_lci/receiver.hpp>
+#include <hpx/parcelport_lci/sender.hpp>
+#include <hpx/parcelport_lci/sender_connection.hpp>
+
+#include <memory>
+#include <utility>
+#include <vector>
+
+namespace hpx::parcelset::policies::lci {
+    void sender_connection::async_write(
+        sender_connection::handler_type&& handler,
+        sender_connection::postprocess_handler_type&& parcel_postprocess)
+    {
+        load(HPX_FORWARD(handler_type, handler),
+            HPX_FORWARD(postprocess_handler_type, parcel_postprocess));
+        if (!util::lci_environment::enable_lci_backlog_queue ||
+            HPX_UNLIKELY(parcelport::is_sending_early_parcel))
+        {
+            while (!send())
+                continue;
+            return;
+        }
+        else
+        {
+            if (!backlog_queue::empty(dst_rank))
+            {
+                backlog_queue::push(shared_from_this());
+                return;
+            }
+            bool isSent = send();
+            if (!isSent)
+            {
+                backlog_queue::push(shared_from_this());
+                return;
+            }
+        }
+    }
+
+    bool sender_connection::can_be_eager_message(size_t eager_threshold)
+    {
+        int num_zero_copy_chunks = static_cast<int>(buffer_.num_chunks_.first);
+        if (num_zero_copy_chunks > 0)
+            // if there are non-zero-copy chunks, we have to use iovec
+            return false;
+        size_t header_size = header::data_pos::pos_piggy_back_address;
+        size_t data_size = buffer_.data_.size();
+        size_t tchunk_size = buffer_.transmission_chunks_.size() *
+            sizeof(parcel_buffer_type::transmission_chunk_type);
+        if (header_size + data_size + tchunk_size <= eager_threshold)
+            return true;
+        else
+            return false;
+    }
+
+    void sender_connection::load(sender_connection::handler_type&& handler,
+        sender_connection::postprocess_handler_type&& parcel_postprocess)
+    {
+#if defined(HPX_HAVE_PARCELPORT_COUNTERS)
+        data_point_ = buffer_.data_point_;
+        data_point_.time_ = hpx::chrono::high_resolution_clock::now();
+#endif
+
+        HPX_ASSERT(!handler_);
+        HPX_ASSERT(!postprocess_handler_);
+        HPX_ASSERT(!buffer_.data_.empty());
+        handler_ = HPX_FORWARD(Handler, handler);
+        postprocess_handler_ =
+            HPX_FORWARD(ParcelPostprocess, parcel_postprocess);
+
+        // build header
+        header header_;
+        is_eager = can_be_eager_message(LCI_MEDIUM_SIZE);
+        int num_zero_copy_chunks = static_cast<int>(buffer_.num_chunks_.first);
+        if (is_eager)
+        {
+            while (LCI_mbuffer_alloc(util::lci_environment::get_device_eager(),
+                       &mbuffer) != LCI_OK)
+                continue;
+            HPX_ASSERT(mbuffer.length == (size_t) LCI_MEDIUM_SIZE);
+            header_ = header(buffer_, (char*) mbuffer.address, mbuffer.length);
+            mbuffer.length = header_.size();
+            if (util::lci_environment::enable_send_immediate)
+                done();
+        }
+        else
+        {
+            size_t max_header_size =
+                LCI_get_iovec_piggy_back_size(num_zero_copy_chunks + 2);
+            char* header_buffer = (char*) malloc(max_header_size);
+            header_ = header(buffer_, header_buffer, max_header_size);
+
+            // calculate the exact number of long messages to send
+            int long_msg_num = num_zero_copy_chunks;
+            if (!header_.piggy_back_data())
+                ++long_msg_num;
+            // transmission chunks
+            if (num_zero_copy_chunks != 0 && !header_.piggy_back_tchunk())
+                ++long_msg_num;
+
+            // initialize iovec
+            iovec = LCI_iovec_t();
+            iovec.piggy_back.address = header_.data();
+            iovec.piggy_back.length = header_.size();
+            iovec.count = long_msg_num;
+            int i = 0;
+            iovec.lbuffers =
+                (LCI_lbuffer_t*) malloc(iovec.count * sizeof(LCI_lbuffer_t));
+            if (!header_.piggy_back_data())
+            {
+                // data (non-zero-copy chunks)
+                iovec.lbuffers[i].address = buffer_.data_.data();
+                iovec.lbuffers[i].length = buffer_.data_.size();
+                iovec.lbuffers[i].segment = LCI_SEGMENT_ALL;
+                ++i;
+            }
+            if (num_zero_copy_chunks != 0)
+            {
+                // transmission chunk
+                if (!header_.piggy_back_tchunk())
+                {
+                    std::vector<
+                        typename parcel_buffer_type::transmission_chunk_type>&
+                        tchunks = buffer_.transmission_chunks_;
+                    int tchunks_length = static_cast<int>(tchunks.size() *
+                        sizeof(parcel_buffer_type::transmission_chunk_type));
+                    iovec.lbuffers[i].address = tchunks.data();
+                    iovec.lbuffers[i].length = tchunks_length;
+                    iovec.lbuffers[i].segment = LCI_SEGMENT_ALL;
+                    ++i;
+                }
+                // zero-copy chunks
+                for (int j = 0; j < (int) buffer_.chunks_.size(); ++j)
+                {
+                    serialization::serialization_chunk& c = buffer_.chunks_[j];
+                    if (c.type_ ==
+                        serialization::chunk_type::chunk_type_pointer)
+                    {
+                        HPX_ASSERT(long_msg_num > i);
+                        iovec.lbuffers[i].address =
+                            const_cast<void*>(c.data_.cpos_);
+                        iovec.lbuffers[i].length = c.size_;
+                        iovec.lbuffers[i].segment = LCI_SEGMENT_ALL;
+                        ++i;
+                    }
+                }
+            }
+            HPX_ASSERT(long_msg_num == i);
+            sharedPtr_p =
+                new std::shared_ptr<sender_connection>(shared_from_this());
+        }
+    }
+
+    bool sender_connection::isEager()
+    {
+        return is_eager;
+    }
+
+    bool sender_connection::send()
+    {
+        int ret;
+        if (is_eager)
+        {
+            ret = LCI_putmna(util::lci_environment::get_endpoint_eager(),
+                mbuffer, dst_rank, 0, LCI_DEFAULT_COMP_REMOTE);
+            if (ret == LCI_OK)
+            {
+#if defined(HPX_HAVE_PARCELPORT_COUNTERS)
+                data_point_.time_ = hpx::chrono::high_resolution_clock::now() -
+                    data_point_.time_;
+                pp_->add_sent_data(data_point_);
+#endif
+                if (!util::lci_environment::enable_send_immediate)
+                    done();
+            }
+        }
+        else
+        {
+            void* buffer_to_free = iovec.piggy_back.address;
+            // In order to keep the send_connection object from being
+            // deallocated. We have to allocate a shared_ptr in the heap
+            // and pass a pointer to shared_ptr to LCI.
+            // We will get this pointer back via the send completion queue
+            // after this send completes.
+            ret = LCI_putva(util::lci_environment::get_endpoint_iovec(), iovec,
+                util::lci_environment::get_scq(), dst_rank, 0,
+                LCI_DEFAULT_COMP_REMOTE, sharedPtr_p);
+            // After this point, if ret == OK, this object can be shared by
+            // two threads (the sending thread and the thread polling the
+            // completion queue). Care must be taken to avoid data race.
+            if (ret == LCI_OK)
+            {
+                free(buffer_to_free);
+            }
+        }
+        return ret == LCI_OK;
+    }
+
+    void sender_connection::done()
+    {
+        if (!is_eager)
+        {
+            HPX_ASSERT(iovec.count > 0);
+            free(iovec.lbuffers);
+#if defined(HPX_HAVE_PARCELPORT_COUNTERS)
+            data_point_.time_ =
+                hpx::chrono::high_resolution_clock::now() - data_point_.time_;
+            pp_->add_sent_data(data_point_);
+#endif
+        }
+        error_code ec;
+        handler_(ec);
+        handler_.reset();
+        buffer_.clear();
+
+        if (postprocess_handler_)
+        {
+            hpx::move_only_function<void(error_code const&,
+                parcelset::locality const&, std::shared_ptr<sender_connection>)>
+                postprocess_handler;
+            std::swap(postprocess_handler, postprocess_handler_);
+            error_code ec2;
+            postprocess_handler(ec2, there_, shared_from_this());
+        }
+    }
+
+    bool sender_connection::tryMerge(
+        const std::shared_ptr<sender_connection>& other)
+    {
+        if (!isEager() || !other->isEager())
+        {
+            // we can only merge eager messages
+            return false;
+        }
+        if (mbuffer.length + other->mbuffer.length > (size_t) LCI_MEDIUM_SIZE)
+        {
+            // The sum of two messages are too large
+            return false;
+        }
+        // can merge
+        memcpy((char*) mbuffer.address + mbuffer.length, other->mbuffer.address,
+            other->mbuffer.length);
+        mbuffer.length += other->mbuffer.length;
+        LCI_mbuffer_free(other->mbuffer);
+        //        merged_connections.push_back(other);
+        return true;
+    }
+}    // namespace hpx::parcelset::policies::lci
+
+#endif

--- a/libs/full/parcelport_mpi/src/parcelport_mpi.cpp
+++ b/libs/full/parcelport_mpi/src/parcelport_mpi.cpp
@@ -228,22 +228,6 @@ namespace hpx::parcelset {
                 }
             }
 
-            void early_write_handler(std::error_code const& ec, parcel const& p)
-            {
-                if (ec)
-                {
-                    // all errors during early parcel handling are fatal
-                    std::exception_ptr exception = hpx::detail::get_exception(
-                        hpx::exception(ec), "mpi::early_write_handler",
-                        __FILE__, __LINE__,
-                        "error while handling early parcel: " + ec.message() +
-                            "(" + std::to_string(ec.value()) + ")" +
-                            parcelset::dump_parcel(p));
-
-                    hpx::report_error(exception);
-                }
-            }
-
             std::size_t background_threads_;
         };
     }    // namespace policies::mpi

--- a/libs/full/plugin_factories/include/hpx/plugin_factories/parcelport_factory.hpp
+++ b/libs/full/plugin_factories/include/hpx/plugin_factories/parcelport_factory.hpp
@@ -127,7 +127,7 @@ namespace hpx::plugins {
                 "_PRIORITY:" +
                 traits::plugin_config_data<Parcelport>::priority() + "}");
             fillini.emplace_back(
-                "sendimm = ${HPX_PARCEL_" + name_uc + "_SENDIMM:0}");
+                "sendimm = ${HPX_PARCEL_" + name_uc + "_SENDIMM:1}");
 
             // get the parcelport specific information ...
             char const* more = traits::plugin_config_data<Parcelport>::call();

--- a/libs/full/runtime_distributed/tests/unit/thread_mapper_parcel_pools.cpp
+++ b/libs/full/runtime_distributed/tests/unit/thread_mapper_parcel_pools.cpp
@@ -38,7 +38,7 @@ void enumerate_threads(std::size_t num_custom_threads)
 #ifdef HPX_HAVE_NETWORKING
     std::size_t num_parcel_threads = 0;
     std::vector<std::string> const parcelport_names = {
-        "tcp", "mpi", "libfabric"};
+        "tcp", "mpi", "lci", "libfabric"};
     for (auto parcelport_name : parcelport_names)
     {
         if (hpx::get_config_entry(


### PR DESCRIPTION
More optimizations for LCI parcelport.
- Add a TLS message backlog queue for unsucceeded sends and eager message aggregation. Use option hpx.parcel.lci.backlog_queue to control (default is 0).
- Let users be able to control progress thread pinning. Use option hpx.parcel.lci.prg_thread_core to control. Only valid if hpx.parcel.lci.rp_prg_pool=0
- Use LCI_mbuffer_alloc for eager message
- Use separate devices/progress threads for eager/iovec messages. Use option hpx.parcel.lci.use_two_device to control (default is 0).
- Change the default value of hpx.parcel.lci.sendimm to 1, a.k.a bypass parcel queues and connection caches by default.