### PR TITLE
Update CI integration for EVE

### DIFF
--- a/.github/workflows/linux_crosscompile_arm_eve_sve_release.yml
+++ b/.github/workflows/linux_crosscompile_arm_eve_sve_release.yml
@@ -1,0 +1,55 @@
+# Copyright (c) 2023 Srinivas Yadav
+#
+# SPDX-License-Identifier: BSL-1.0
+# Distributed under the Boost Software License, Version 1.0. (See accompanying
+# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+name: Linux CROSSCOMPILE ARM EVE SVE CI (Release)
+
+on: [pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    container: stellargroup/crosscompile_arm_sve_build_env:1
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Configure
+      shell: bash
+      run: |
+          cmake \
+              . \
+              -Bbuild \
+              -GNinja \
+              -DCMAKE_BUILD_TYPE=Release \
+              -DCMAKE_SYSTEM_NAME=Linux \
+              -DCMAKE_SYSTEM_PROCESSOR=arm \
+              -DCMAKE_CROSSCOMPILING=ON \
+              -DCMAKE_CROSSCOMPILING_EMULATOR=/usr/bin/qemu-aarch64 \
+              -DHPX_WITH_MALLOC=system \
+              -DHPX_WITH_FETCH_ASIO=ON \
+              -DHPX_WITH_EXAMPLES=ON \
+              -DHPX_WITH_TESTS=ON \
+              -DHPX_WITH_TESTS_MAX_THREADS_PER_LOCALITY=2 \
+              -DHPX_WITH_CHECK_MODULE_DEPENDENCIES=On \
+              -DHPX_WITH_CXX_STANDARD=20 \
+              -DCMAKE_CXX_FLAGS="-march=armv8-a+sve -msve-vector-bits=512" \
+              -DBOOST_ROOT=/opt/install/boost/release/boost \
+              -DHWLOC_ROOT=/opt/install/hwloc \
+              -DHPX_WITH_GENERIC_CONTEXT_COROUTINES=On \
+              -DHPX_WITH_DATAPAR_BACKEND=EVE \
+              -DHPX_WITH_FETCH_EVE=ON
+    - name: Build
+      shell: bash
+      run: |
+          cmake --build build --target core
+          cmake --build build --target tests.unit.modules.algorithms.datapar_algorithms
+          cmake --build build --target tests.regressions.modules.algorithms.for_each_datapar
+    - name: Test
+      shell: bash
+      run: |
+          cd build
+          ctest \
+            --output-on-failure \
+            --tests-regex datapar

--- a/.jenkins/lsu/env-gcc-12.sh
+++ b/.jenkins/lsu/env-gcc-12.sh
@@ -24,7 +24,9 @@ configure_extra_options+=" -DHPX_WITH_PARCELPORT_MPI=ON"
 configure_extra_options+=" -DHPX_WITH_PARCELPORT_LCI=ON"
 configure_extra_options+=" -DHPX_WITH_FETCH_LCI=ON"
 configure_extra_options+=" -DHPX_WITH_PARCELPORT_LCI_BACKEND=ibv"
-configure_extra_options+=" -DHPX_WITH_DATAPAR_BACKEND=STD_EXPERIMENTAL_SIMD"
+configure_extra_options+=" -DHPX_WITH_DATAPAR_BACKEND=EVE"
+configure_extra_options+=" -DHPX_WITH_FETCH_EVE=ON"
+configure_extra_options+=" -DHPX_WITH_EVE_TAG=main"
 
 # The pwrapi library still needs to be set up properly on rostam
 # configure_extra_options+=" -DHPX_WITH_POWER_COUNTER=ON"

--- a/cmake/HPX_SetupDatapar.cmake
+++ b/cmake/HPX_SetupDatapar.cmake
@@ -52,7 +52,7 @@ if("${HPX_WITH_DATAPAR_BACKEND}" STREQUAL "EVE")
     ADVANCED
   )
   hpx_option(
-    HPX_WITH_EVE_TAG STRING "Eve repository tag or branch" "hpx-v1.9.0"
+    HPX_WITH_EVE_TAG STRING "Eve repository tag or branch" "v2023.02.15"
     CATEGORY "Build Targets"
     ADVANCED
   )


### PR DESCRIPTION
Use latest eve release tag `v2023.02.15`, which supports SVE.
Update lsu gcc-12 CI to test EVE datapar backend with master branch.
Add new GitHub action to test SVE vectorization with EVE. 
