### PR TITLE
Fix EVE datapar with cxx_standard less than 20

### DIFF
--- a/cmake/HPX_SetupDatapar.cmake
+++ b/cmake/HPX_SetupDatapar.cmake
@@ -43,6 +43,12 @@ endif()
 # HPX Eve configuration
 # ##############################################################################
 if("${HPX_WITH_DATAPAR_BACKEND}" STREQUAL "EVE")
+  if("${HPX_WITH_CXX_STANDARD}" LESS "20")
+    hpx_error(
+      "HPX_WITH_DATAPAR_BACKEND set to ${HPX_WITH_DATAPAR_BACKEND} requires HPX_WITH_CXX_STANDARD >= 20, currently set to ${HPX_WITH_CXX_STANDARD}"
+    )
+  endif()
+
   hpx_option(
     HPX_WITH_FETCH_EVE
     BOOL


### PR DESCRIPTION
Fixes issue #6164  by using ``hpx_error`` if  ``HPX_WITH_DATAPAR_BACKEND=EVE`` is used with ``HPX_WITH_CXX_STANDARD`` less than 20. 
