### PR TITLE
thread_support/CMakeLists: Fix build issue

### DIFF
--- a/libs/core/thread_support/CMakeLists.txt
+++ b/libs/core/thread_support/CMakeLists.txt
@@ -18,7 +18,7 @@ set(thread_support_compat_headers
     hpx/thread_support.hpp => hpx/modules/thread_support.hpp
     hpx/util/assert_owns_lock.hpp => hpx/modules/thread_support.hpp
     hpx/util/atomic_count.hpp => hpx/modules/thread_support.hpp
-    hpx/util/set_thread_name. => hpx/modules/thread_support.hpp
+    hpx/util/set_thread_name.hpp => hpx/modules/thread_support.hpp
     hpx/util/thread_specific_ptr.hpp => hpx/modules/thread_support.hpp
     hpx/util/unlock_guard.hpp => hpx/modules/thread_support.hpp
 )


### PR DESCRIPTION
Fix typo in libs/core/thread_support/CMakeLists.txt which was causing a build failure.

## Checklist

Not all points below apply to all pull requests.

- [ ] I have added a new feature and have added tests to go along with it.
- [x] I have fixed a bug
- [ ] I have added a test using random numbers; I have made sure it uses a seed, and that random numbers generated are valid inputs for the tests.
