### PR TITLE
Enable using for_loop with range generators

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1807,12 +1807,13 @@ if(HPX_WITH_COMPILER_WARNINGS)
     hpx_add_compile_flag_if_available(-Wno-attributes)
     hpx_add_compile_flag_if_available(-Wno-cast-align)
 
-    # gcc V12.1 and above complain about possible ABI incompatibilities caused
-    # by the use of std::destructive_interference_size
-    if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU"
-       AND "${CMAKE_CXX_COMPILER_VERSION}" VERSION_GREATER_EQUAL "12.1"
-    )
-      hpx_add_compile_flag_if_available(-Wno-interference-size)
+    if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+      hpx_add_compile_flag_if_available(-Wno-use-after-free)
+      if("${CMAKE_CXX_COMPILER_VERSION}" VERSION_GREATER_EQUAL "12.1")
+        # gcc V12.1 and above complain about possible ABI incompatibilities
+        # caused by the use of std::destructive_interference_size
+        hpx_add_compile_flag_if_available(-Wno-interference-size)
+      endif()
     endif()
 
     # We do not in general guarantee ABI compatibility between C++ standards, so
@@ -2243,15 +2244,15 @@ add_subdirectory(components)
 # ##############################################################################
 # Tests
 # ##############################################################################
+find_package(PythonInterp)
+
+if(NOT PYTHONINTERP_FOUND)
+  hpx_warn(
+    "A python interpreter could not be found. The test suite can not be run automatically."
+  )
+endif()
+
 if(HPX_WITH_TESTS)
-  find_package(PythonInterp)
-
-  if(NOT PYTHONINTERP_FOUND)
-    hpx_warn(
-      "A python interpreter could not be found. The test suite can not be run automatically."
-    )
-  endif()
-
   # pseudo_target added above
   add_subdirectory(tests)
 endif()
@@ -2274,10 +2275,12 @@ if(HPX_WITH_TOOLS OR HPX_WITH_TESTS_BENCHMARKS)
 endif()
 
 # Configure hpxrun.py
-configure_file(
-  "${PROJECT_SOURCE_DIR}/cmake/templates/hpxrun.py.in"
-  "${PROJECT_BINARY_DIR}/bin/hpxrun.py" @ONLY
-)
+if(PYTHONINTERP_FOUND)
+  configure_file(
+    "${PROJECT_SOURCE_DIR}/cmake/templates/hpxrun.py.in"
+    "${PROJECT_BINARY_DIR}/bin/hpxrun.py" @ONLY
+  )
+endif()
 
 # Set up precompiled headers
 if(HPX_WITH_PRECOMPILED_HEADERS)
@@ -2397,19 +2400,21 @@ endif()
 # ##############################################################################
 # installation instructions
 # ##############################################################################
-install(
-  FILES "${PROJECT_BINARY_DIR}/bin/hpxrun.py"
-  DESTINATION ${CMAKE_INSTALL_BINDIR}
-  COMPONENT core
-  PERMISSIONS
-    OWNER_READ
-    OWNER_WRITE
-    OWNER_EXECUTE
-    GROUP_READ
-    GROUP_EXECUTE
-    WORLD_READ
-    WORLD_EXECUTE
-)
+if(PYTHONINTERP_FOUND)
+  install(
+    FILES "${PROJECT_BINARY_DIR}/bin/hpxrun.py"
+    DESTINATION ${CMAKE_INSTALL_BINDIR}
+    COMPONENT core
+    PERMISSIONS
+      OWNER_READ
+      OWNER_WRITE
+      OWNER_EXECUTE
+      GROUP_READ
+      GROUP_EXECUTE
+      WORLD_READ
+      WORLD_EXECUTE
+  )
+endif()
 
 install(
   # install all hpx header files

--- a/cmake/HPX_AddConfigTest.cmake
+++ b/cmake/HPX_AddConfigTest.cmake
@@ -579,6 +579,24 @@ function(hpx_check_for_cxx20_std_construct_at)
 endfunction()
 
 # ##############################################################################
+function(hpx_check_for_cxx20_std_default_sentinel)
+  add_hpx_config_test(
+    HPX_WITH_CXX20_STD_DEFAULT_SENTINEL
+    SOURCE cmake/tests/cxx20_std_default_sentinel.cpp
+    FILE ${ARGN}
+  )
+endfunction()
+
+# ##############################################################################
+function(hpx_check_for_cxx23_std_generator)
+  add_hpx_config_test(
+    HPX_WITH_CXX23_STD_GENERATOR
+    SOURCE cmake/tests/cxx23_std_generator.cpp
+    FILE ${ARGN}
+  )
+endfunction()
+
+# ##############################################################################
 function(hpx_check_for_cxx_lambda_capture_decltype)
   add_hpx_config_test(
     HPX_WITH_CXX_LAMBDA_CAPTURE_DECLTYPE

--- a/cmake/HPX_AddDefinitions.cmake
+++ b/cmake/HPX_AddDefinitions.cmake
@@ -119,21 +119,29 @@ function(write_config_defines_file)
 
   set(hpx_config_defines "\n")
   foreach(def ${DEFINITIONS_VAR})
-    # C++20 specific variable
-    string(FIND ${def} "HAVE_CXX20" _pos)
+    # C++23 specific variable
+    string(FIND ${def} "HAVE_CXX23" _pos)
     if(NOT ${_pos} EQUAL -1)
       set(hpx_config_defines
-          "${hpx_config_defines}#if __cplusplus >= 202002\n#define ${def}\n#endif\n"
+          "${hpx_config_defines}#if __cplusplus >= 202300\n#define ${def}\n#endif\n"
       )
     else()
-      # C++17 specific variable
-      string(FIND ${def} "HAVE_CXX17" _pos)
+      # C++20 specific variable
+      string(FIND ${def} "HAVE_CXX20" _pos)
       if(NOT ${_pos} EQUAL -1)
         set(hpx_config_defines
-            "${hpx_config_defines}#if __cplusplus >= 201500\n#define ${def}\n#endif\n"
+            "${hpx_config_defines}#if __cplusplus >= 202002\n#define ${def}\n#endif\n"
         )
       else()
-        set(hpx_config_defines "${hpx_config_defines}#define ${def}\n")
+        # C++17 specific variable
+        string(FIND ${def} "HAVE_CXX17" _pos)
+        if(NOT ${_pos} EQUAL -1)
+          set(hpx_config_defines
+              "${hpx_config_defines}#if __cplusplus >= 201500\n#define ${def}\n#endif\n"
+          )
+        else()
+          set(hpx_config_defines "${hpx_config_defines}#define ${def}\n")
+        endif()
       endif()
     endif()
   endforeach()

--- a/cmake/HPX_CheckCXXStandard.cmake
+++ b/cmake/HPX_CheckCXXStandard.cmake
@@ -44,6 +44,11 @@ elseif(HPX_WITH_CXX20)
     "HPX_WITH_CXX20 is deprecated. Use HPX_WITH_CXX_STANDARD=20 instead."
   )
   set(HPX_CXX_STANDARD 20)
+elseif(HPX_WITH_CXX23)
+  hpx_warn(
+    "HPX_WITH_CXX23 is deprecated. Use HPX_WITH_CXX_STANDARD=23 instead."
+  )
+  set(HPX_CXX_STANDARD 23)
 endif()
 
 if(CMAKE_CXX_STANDARD)

--- a/cmake/HPX_PerformCxxFeatureTests.cmake
+++ b/cmake/HPX_PerformCxxFeatureTests.cmake
@@ -140,6 +140,14 @@ function(hpx_perform_cxx_feature_tests)
     hpx_check_for_cxx20_std_construct_at(
       DEFINITIONS HPX_HAVE_CXX20_STD_CONSTRUCT_AT
     )
+
+    hpx_check_for_cxx20_std_default_sentinel(
+      DEFINITIONS HPX_HAVE_CXX20_STD_DEFAULT_SENTINEL
+    )
+  endif()
+
+  if(HPX_WITH_CXX_STANDARD GREATER_EQUAL 23)
+    hpx_check_for_cxx23_std_generator(DEFINITIONS HPX_HAVE_CXX23_STD_GENERATOR)
   endif()
 
   hpx_check_for_cxx_lambda_capture_decltype(

--- a/cmake/tests/cxx20_coroutines.cpp
+++ b/cmake/tests/cxx20_coroutines.cpp
@@ -9,18 +9,18 @@
 #if defined(__has_include)
 #if __has_include(<coroutine>)
 #include <coroutine>
-namespace hpx { namespace coro {
+namespace hpx {
     using std::coroutine_handle;
     using std::suspend_always;
     using std::suspend_never;
-}}    // namespace hpx::coro
+}    // namespace hpx
 #else
 #include <experimental/coroutine>
-namespace hpx { namespace coro {
+namespace hpx {
     using std::experimental::coroutine_handle;
     using std::experimental::suspend_always;
     using std::experimental::suspend_never;
-}}    // namespace hpx::coro
+}    // namespace hpx
 #endif
 #endif
 
@@ -36,12 +36,12 @@ struct resumable
             return {};
         }
 
-        hpx::coro::suspend_never initial_suspend() const noexcept
+        hpx::suspend_never initial_suspend() const noexcept
         {
             return {};
         }
 
-        hpx::coro::suspend_never final_suspend() const noexcept
+        hpx::suspend_never final_suspend() const noexcept
         {
             return {};
         }
@@ -58,7 +58,7 @@ struct resumable
     {
         return 42;
     }
-    void await_suspend(hpx::coro::coroutine_handle<promise_type>) const noexcept
+    void await_suspend(hpx::coroutine_handle<promise_type>) const noexcept
     {
     }
 };

--- a/cmake/tests/cxx20_std_default_sentinel.cpp
+++ b/cmake/tests/cxx20_std_default_sentinel.cpp
@@ -1,0 +1,14 @@
+//  Copyright (c) 2023 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <iterator>
+
+int main()
+{
+    [[maybe_unused]] auto sent1 = std::default_sentinel;
+    [[maybe_unused]] auto sent2 = std::default_sentinel_t{};
+    return 0;
+}

--- a/cmake/tests/cxx23_std_generator.cpp
+++ b/cmake/tests/cxx23_std_generator.cpp
@@ -1,0 +1,23 @@
+//  Copyright (c) 2023 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+// test for availability of std::generator (C++ 23)
+
+#include <generator>
+
+std::generator<char> letters(char first)
+{
+    for (;; co_yield first++)
+        ;
+}
+
+int main()
+{
+    for (const char ch : letters('a'))
+    {
+    }
+    return 0;
+}

--- a/components/parcel_plugins/coalescing/src/coalescing_counter_registry.cpp
+++ b/components/parcel_plugins/coalescing/src/coalescing_counter_registry.cpp
@@ -244,7 +244,14 @@ namespace hpx::plugins::parcel {
                 return f(cinfo, ec) && !ec;
             }
 
+#if defined(HPX_GCC_VERSION) && HPX_GCC_VERSION >= 110000
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wrestrict"
+#endif
             p.parameters_ = "*";
+#if defined(HPX_GCC_VERSION) && HPX_GCC_VERSION >= 110000
+#pragma GCC diagnostic pop
+#endif
         }
 
         std::string parameters = p.parameters_;

--- a/examples/quickstart/barrier_docs.cpp
+++ b/examples/quickstart/barrier_docs.cpp
@@ -7,10 +7,10 @@
 // This example is meant for inclusion in the documentation.
 
 //[barrier_docs
-
-#include <hpx/barrier.hpp>
-#include <hpx/future.hpp>
+#include <hpx/local/barrier.hpp>
+#include <hpx/local/future.hpp>
 #include <hpx/local/init.hpp>
+
 #include <iostream>
 
 int hpx_main()
@@ -43,5 +43,4 @@ int main(int argc, char* argv[])
 {
     return hpx::local::init(hpx_main, argc, argv);
 }
-
 //]

--- a/examples/quickstart/condition_variable_docs.cpp
+++ b/examples/quickstart/condition_variable_docs.cpp
@@ -7,11 +7,11 @@
 // This example is meant for inclusion in the documentation.
 
 //[condition_variable_docs
-
-#include <hpx/condition_variable.hpp>
+#include <hpx/local/condition_variable.hpp>
 #include <hpx/local/init.hpp>
-#include <hpx/mutex.hpp>
-#include <hpx/thread.hpp>
+#include <hpx/local/mutex.hpp>
+#include <hpx/local/thread.hpp>
+
 #include <iostream>
 #include <string>
 
@@ -74,5 +74,4 @@ int main(int argc, char* argv[])
 {
     return hpx::local::init(hpx_main, argc, argv);
 }
-
 //]

--- a/examples/quickstart/counting_semaphore_docs.cpp
+++ b/examples/quickstart/counting_semaphore_docs.cpp
@@ -7,10 +7,10 @@
 // This example is meant for inclusion in the documentation.
 
 //[counting_semaphore_docs
-
 #include <hpx/local/init.hpp>
-#include <hpx/synchronization/counting_semaphore.hpp>
-#include <hpx/thread.hpp>
+#include <hpx/local/semaphore.hpp>
+#include <hpx/local/thread.hpp>
+
 #include <iostream>
 
 // initialize the semaphore with a count of 3

--- a/examples/quickstart/mutex_docs.cpp
+++ b/examples/quickstart/mutex_docs.cpp
@@ -7,10 +7,10 @@
 // This example is meant for inclusion in the documentation.
 
 //[mutex_docs
-
-#include <hpx/future.hpp>
+#include <hpx/local/future.hpp>
 #include <hpx/local/init.hpp>
-#include <hpx/mutex.hpp>
+#include <hpx/local/mutex.hpp>
+
 #include <iostream>
 
 int hpx_main()
@@ -38,5 +38,4 @@ int main(int argc, char* argv[])
 {
     return hpx::local::init(hpx_main, argc, argv);
 }
-
 //]

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/detail/generate.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/detail/generate.hpp
@@ -21,8 +21,8 @@ namespace hpx::parallel::detail {
     template <typename Iter, typename Sent, typename F>
     constexpr Iter sequential_generate_helper(Iter first, Sent last, F&& f)
     {
-        return util::loop_ind(hpx::execution::seq, first, last,
-            [f = HPX_FORWARD(F, f)](auto& v) mutable { v = f(); });
+        return util::loop_ind<hpx::execution::sequenced_policy>(
+            first, last, [f = HPX_FORWARD(F, f)](auto& v) mutable { v = f(); });
     }
 
     struct sequential_generate_t

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/detail/reduce.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/detail/reduce.hpp
@@ -24,12 +24,13 @@ namespace hpx::parallel::detail {
     private:
         template <typename InIterB, typename InIterE, typename T,
             typename Reduce>
-        friend constexpr T tag_fallback_invoke(sequential_reduce_t,
-            ExPolicy&& policy, InIterB first, InIterE last, T init, Reduce&& r)
+        friend constexpr T tag_fallback_invoke(sequential_reduce_t, ExPolicy&&,
+            InIterB first, InIterE last, T init, Reduce&& r)
         {
-            util::loop_ind(HPX_FORWARD(ExPolicy, policy), first, last,
-                [&init, &r](
-                    auto const& v) mutable { init = HPX_INVOKE(r, init, v); });
+            util::loop_ind<ExPolicy>(
+                first, last, [&init, &r](auto const& v) mutable {
+                    init = HPX_INVOKE(r, init, v);
+                });
             return init;
         }
 
@@ -47,11 +48,11 @@ namespace hpx::parallel::detail {
         template <typename Iter, typename Sent, typename T, typename Reduce,
             typename Convert>
         friend constexpr auto tag_fallback_invoke(sequential_reduce_t,
-            ExPolicy&& policy, Iter first, Sent last, T init, Reduce&& r,
+            ExPolicy&&, Iter first, Sent last, T init, Reduce&& r,
             Convert&& conv)
         {
-            util::loop_ind(HPX_FORWARD(ExPolicy, policy), first, last,
-                [&init, &r, &conv](auto const& v) mutable {
+            util::loop_ind<std::decay_t<ExPolicy>>(
+                first, last, [&init, &r, &conv](auto const& v) mutable {
                     init = HPX_INVOKE(r, init, HPX_INVOKE(conv, v));
                 });
             return init;

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/for_each.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/for_each.hpp
@@ -482,8 +482,7 @@ namespace hpx::parallel {
             template <typename ExPolicy, typename InIterB, typename InIterE,
                 typename F>
             static constexpr InIterB sequential(
-                [[maybe_unused]] ExPolicy&& policy, InIterB first, InIterE last,
-                F&& f, hpx::identity)
+                ExPolicy&&, InIterB first, InIterE last, F&& f, hpx::identity)
             {
                 if constexpr (hpx::traits::is_random_access_iterator_v<InIterB>)
                 {
@@ -493,8 +492,8 @@ namespace hpx::parallel {
                 }
                 else
                 {
-                    return util::loop_ind(HPX_FORWARD(ExPolicy, policy), first,
-                        last, HPX_FORWARD(F, f));
+                    return util::loop_ind<std::decay_t<ExPolicy>>(
+                        first, last, HPX_FORWARD(F, f));
                 }
             }
 

--- a/libs/core/algorithms/include/hpx/parallel/datapar/fill.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/datapar/fill.hpp
@@ -28,10 +28,10 @@ namespace hpx { namespace parallel { namespace detail {
         template <typename ExPolicy, typename Iter, typename Sent, typename T>
         HPX_HOST_DEVICE HPX_FORCEINLINE static typename std::enable_if<
             util::detail::iterator_datapar_compatible_v<Iter>, Iter>::type
-        call(ExPolicy&& policy, Iter first, Sent last, T const& val)
+        call(ExPolicy&&, Iter first, Sent last, T const& val)
         {
-            hpx::parallel::util::loop_ind(HPX_FORWARD(ExPolicy, policy), first,
-                last, [&val](auto& v) { v = val; });
+            hpx::parallel::util::loop_ind<std::decay_t<ExPolicy>>(
+                first, last, [&val](auto& v) { v = val; });
             return first;
         }
     };

--- a/libs/core/algorithms/include/hpx/parallel/datapar/loop.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/datapar/loop.hpp
@@ -476,7 +476,7 @@ namespace hpx::parallel::util {
     ///////////////////////////////////////////////////////////////////////////
     template <typename Begin, typename End, typename F>
     HPX_HOST_DEVICE HPX_FORCEINLINE Begin tag_invoke(
-        hpx::parallel::util::loop_ind_t, hpx::execution::simd_policy,
+        hpx::parallel::util::loop_ind_t<hpx::execution::simd_policy>,
         Begin begin, End end, F&& f)
     {
         return detail::datapar_loop_ind<Begin>::call(
@@ -485,7 +485,7 @@ namespace hpx::parallel::util {
 
     template <typename Begin, typename End, typename F>
     HPX_HOST_DEVICE HPX_FORCEINLINE Begin tag_invoke(
-        hpx::parallel::util::loop_ind_t, hpx::execution::simd_task_policy,
+        hpx::parallel::util::loop_ind_t<hpx::execution::simd_task_policy>,
         Begin begin, End end, F&& f)
     {
         return detail::datapar_loop_ind<Begin>::call(

--- a/libs/core/algorithms/include/hpx/parallel/datapar/reduce.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/datapar/reduce.hpp
@@ -33,10 +33,10 @@ namespace hpx { namespace parallel { namespace detail {
         template <typename InIterB, typename InIterE, typename T,
             typename Reduce>
         HPX_HOST_DEVICE HPX_FORCEINLINE static T call(
-            ExPolicy&& policy, InIterB first, InIterE last, T init, Reduce&& r)
+            ExPolicy&&, InIterB first, InIterE last, T init, Reduce&& r)
         {
-            util::loop_ind(HPX_FORWARD(ExPolicy, policy), first, last,
-                [&init, &r](auto const& val) mutable {
+            util::loop_ind<ExPolicy>(
+                first, last, [&init, &r](auto const& val) mutable {
                     T partial_res = hpx::parallel::traits::reduce(r, val);
                     init = r(init, partial_res);
                 });
@@ -57,11 +57,11 @@ namespace hpx { namespace parallel { namespace detail {
 
         template <typename Iter, typename Sent, typename T, typename Reduce,
             typename Convert>
-        HPX_HOST_DEVICE HPX_FORCEINLINE static T call(ExPolicy&& policy,
-            Iter first, Sent last, T init, Reduce&& r, Convert&& conv)
+        HPX_HOST_DEVICE HPX_FORCEINLINE static T call(ExPolicy&&, Iter first,
+            Sent last, T init, Reduce&& r, Convert&& conv)
         {
-            util::loop_ind(HPX_FORWARD(ExPolicy, policy), first, last,
-                [&init, &r, &conv](auto const& v) mutable {
+            util::loop_ind<ExPolicy>(
+                first, last, [&init, &r, &conv](auto const& v) mutable {
                     T partial_res = hpx::parallel::traits::reduce(r, conv(v));
                     init = r(init, partial_res);
                 });

--- a/libs/core/algorithms/include/hpx/parallel/datapar/replace.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/datapar/replace.hpp
@@ -31,14 +31,14 @@ namespace hpx { namespace parallel { namespace detail {
     struct datapar_replace
     {
         template <typename InIter, typename T1, typename T2, typename Proj>
-        HPX_HOST_DEVICE HPX_FORCEINLINE static auto call(ExPolicy&& policy,
-            InIter first, InIter last, T1 const& old_value, T2 const& new_value,
-            Proj&& proj)
+        HPX_HOST_DEVICE HPX_FORCEINLINE static auto call(
+            [[maybe_unused]] ExPolicy&& policy, InIter first, InIter last,
+            T1 const& old_value, T2 const& new_value, Proj&& proj)
         {
             if constexpr (hpx::is_sequenced_execution_policy_v<ExPolicy>)
             {
-                return util::loop_ind(HPX_FORWARD(ExPolicy, policy), first,
-                    last, [old_value, new_value, &proj](auto& v) {
+                return util::loop_ind<ExPolicy>(
+                    first, last, [old_value, new_value, &proj](auto& v) {
                         using var_type = std::decay_t<decltype(v)>;
                         traits::mask_assign(
                             HPX_INVOKE(proj, v) == var_type(old_value), v,
@@ -92,13 +92,14 @@ namespace hpx { namespace parallel { namespace detail {
     {
         template <typename InIter, typename Sent, typename F, typename T,
             typename Proj>
-        HPX_HOST_DEVICE HPX_FORCEINLINE static auto call(ExPolicy&& policy,
-            InIter first, Sent last, F&& f, T const& new_value, Proj&& proj)
+        HPX_HOST_DEVICE HPX_FORCEINLINE static auto call(
+            [[maybe_unused]] ExPolicy&& policy, InIter first, Sent last, F&& f,
+            T const& new_value, Proj&& proj)
         {
             if constexpr (hpx::is_sequenced_execution_policy_v<ExPolicy>)
             {
-                return util::loop_ind(HPX_FORWARD(ExPolicy, policy), first,
-                    last, [&f, new_value, &proj](auto& v) {
+                return util::loop_ind<ExPolicy>(
+                    first, last, [&f, new_value, &proj](auto& v) {
                         using var_type = std::decay_t<decltype(v)>;
                         traits::mask_assign(HPX_INVOKE(f, HPX_INVOKE(proj, v)),
                             v, var_type(new_value));

--- a/libs/core/algorithms/include/hpx/parallel/unseq/loop.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/unseq/loop.hpp
@@ -239,17 +239,17 @@ namespace hpx::parallel::util {
     ///////////////////////////////////////////////////////////////////////////
     template <typename Begin, typename End, typename F>
     HPX_HOST_DEVICE HPX_FORCEINLINE Begin tag_invoke(
-        hpx::parallel::util::loop_ind_t, hpx::execution::unsequenced_policy,
+        hpx::parallel::util::loop_ind_t<hpx::execution::unsequenced_policy>,
         Begin HPX_RESTRICT begin, End HPX_RESTRICT end, F&& f)
     {
         return detail::unseq_loop_ind::call(begin, end, HPX_FORWARD(F, f));
     }
 
-    template <typename Begin, typename End, typename F>
+    template <typename ExPolicy, typename Begin, typename End, typename F>
     HPX_HOST_DEVICE HPX_FORCEINLINE Begin tag_invoke(
-        hpx::parallel::util::loop_ind_t,
-        hpx::execution::unsequenced_task_policy, Begin HPX_RESTRICT begin,
-        End HPX_RESTRICT end, F&& f)
+        hpx::parallel::util::loop_ind_t<
+            hpx::execution::unsequenced_task_policy>,
+        Begin HPX_RESTRICT begin, End HPX_RESTRICT end, F&& f)
     {
         return detail::unseq_loop_ind::call(begin, end, HPX_FORWARD(F, f));
     }

--- a/libs/core/algorithms/include/hpx/parallel/util/detail/chunk_size_iterator.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/util/detail/chunk_size_iterator.hpp
@@ -8,10 +8,12 @@
 
 #include <hpx/config.hpp>
 #include <hpx/assert.hpp>
+#include <hpx/concepts/concepts.hpp>
 #include <hpx/datastructures/tuple.hpp>
 #include <hpx/execution/algorithms/detail/predicates.hpp>
 #include <hpx/iterator_support/iterator_facade.hpp>
 #include <hpx/iterator_support/traits/is_iterator.hpp>
+#include <hpx/iterator_support/traits/is_range.hpp>
 #include <hpx/util/min.hpp>
 
 #include <algorithm>
@@ -22,12 +24,12 @@
 ///////////////////////////////////////////////////////////////////////////////
 namespace hpx::parallel::util::detail {
 
-    template <typename Iterator, typename Enable = void>
+    template <typename IterOrR, typename Enable = void>
     struct chunk_size_iterator_category;
 
-    template <typename Iterator>
-    struct chunk_size_iterator_category<Iterator,
-        std::enable_if_t<std::is_integral_v<Iterator>>>
+    template <typename IterOrR>
+    struct chunk_size_iterator_category<IterOrR,
+        std::enable_if_t<std::is_integral_v<IterOrR>>>
     {
         using type = std::random_access_iterator_tag;
     };
@@ -36,30 +38,78 @@ namespace hpx::parallel::util::detail {
     struct chunk_size_iterator_category<Iterator,
         std::enable_if_t<hpx::traits::is_iterator_v<Iterator>>>
     {
-        using type = typename std::iterator_traits<Iterator>::iterator_category;
+        using type = hpx::traits::iter_category_t<Iterator>;
+    };
+
+    template <typename Range>
+    struct chunk_size_iterator_category<Range,
+        std::enable_if_t<hpx::traits::is_range_v<Range>>>
+    {
+        using type = hpx::traits::range_category_t<Range>;
+    };
+
+    template <typename Range>
+    struct chunk_size_iterator_category<Range,
+        std::enable_if_t<hpx::traits::is_range_generator_v<Range>>>
+    {
+        using type = std::random_access_iterator_tag;
+    };
+
+    template <typename IterOrR>
+    using chunk_size_iterator_category_t =
+        typename chunk_size_iterator_category<IterOrR>::type;
+
+    template <typename IterOrR, typename Enable = void>
+    struct iterator_type;
+
+    template <typename T>
+    struct iterator_type<T,
+        std::enable_if_t<std::is_integral_v<T> ||
+            hpx::traits::is_range_generator_v<T>>>
+    {
+        using type = T;
     };
 
     template <typename Iterator>
-    using chunk_size_iterator_category_t =
-        typename chunk_size_iterator_category<Iterator>::type;
+    struct iterator_type<Iterator,
+        std::enable_if_t<hpx::traits::is_iterator_v<Iterator>>>
+    {
+        using type = Iterator;
+    };
+
+    template <typename Range>
+    struct iterator_type<Range,
+        std::enable_if_t<hpx::traits::is_range_v<Range>>>
+    {
+        using type = hpx::traits::range_iterator_t<Range>;
+    };
+
+    template <typename IterOrR>
+    using iterator_type_t = typename iterator_type<IterOrR>::type;
 
     ///////////////////////////////////////////////////////////////////////////
-    template <typename Iterator>
+    template <typename IterOrR>
     struct chunk_size_iterator
-      : public hpx::util::iterator_facade<chunk_size_iterator<Iterator>,
-            hpx::tuple<Iterator, std::size_t> const,
-            chunk_size_iterator_category_t<Iterator>>
+      : hpx::util::iterator_facade<chunk_size_iterator<IterOrR>,
+            hpx::tuple<IterOrR, std::size_t> const,
+            chunk_size_iterator_category_t<IterOrR>>
     {
     private:
-        using base_type =
-            hpx::util::iterator_facade<chunk_size_iterator<Iterator>,
-                hpx::tuple<Iterator, std::size_t> const,
-                chunk_size_iterator_category_t<Iterator>>;
+        using base_type = hpx::util::iterator_facade<chunk_size_iterator,
+            hpx::tuple<IterOrR, std::size_t> const,
+            chunk_size_iterator_category_t<IterOrR>>;
+
+        static_assert(std::is_integral_v<IterOrR> ||
+            hpx::traits::is_iterator_v<IterOrR> ||
+            hpx::traits::is_range_v<IterOrR> ||
+            hpx::traits::is_range_generator_v<IterOrR>);
+
+        static constexpr bool is_iterator = hpx::traits::is_iterator_v<IterOrR>;
 
         HPX_HOST_DEVICE static constexpr std::size_t get_last_chunk_size(
             std::size_t count, std::size_t chunk_size) noexcept
         {
-            std::ptrdiff_t const remainder =
+            auto const remainder =
                 static_cast<std::ptrdiff_t>(count % chunk_size);
             if (remainder != 0)
             {
@@ -77,22 +127,40 @@ namespace hpx::parallel::util::detail {
     public:
         HPX_HOST_DEVICE chunk_size_iterator() = default;
 
-        HPX_HOST_DEVICE chunk_size_iterator(Iterator it, std::size_t chunk_size,
+        HPX_HOST_DEVICE chunk_size_iterator(IterOrR it, std::size_t chunk_size,
             std::size_t count = 0, std::size_t current = 0) noexcept
-          : data_(it, (hpx::detail::min)(chunk_size, count))
-          , chunk_size_(chunk_size)
+          : data_(it, 0)
+          , chunk_size_((hpx::detail::min)(chunk_size, count))
           , last_chunk_size_(get_last_chunk_size(count, chunk_size))
           , count_(count)
           , current_(get_current(current, chunk_size))
         {
+            if (current_ >= count_)
+            {
+                // reached the end of the sequence
+                target() = next(target(), 0, 0);
+                chunk() = 0;
+            }
+            else if (current_ == count_ - last_chunk_size_)
+            {
+                // reached last chunk
+                target() = next(target(), 0, last_chunk_size_);
+                chunk() = last_chunk_size_;
+            }
+            else
+            {
+                // normal chunk
+                target() = next(target(), 0, chunk_size_);
+                chunk() = chunk_size_;
+            }
         }
 
     private:
-        HPX_HOST_DEVICE Iterator& iterator() noexcept
+        HPX_HOST_DEVICE IterOrR& target() noexcept
         {
             return hpx::get<0>(data_);
         }
-        HPX_HOST_DEVICE constexpr Iterator iterator() const noexcept
+        HPX_HOST_DEVICE constexpr IterOrR target() const noexcept
         {
             return hpx::get<0>(data_);
         }
@@ -109,11 +177,11 @@ namespace hpx::parallel::util::detail {
     protected:
         friend class hpx::util::iterator_core_access;
 
+        template <typename IterOrR1>
         HPX_HOST_DEVICE constexpr bool equal(
-            chunk_size_iterator const& other) const noexcept
+            chunk_size_iterator<IterOrR1> const& other) const noexcept
         {
-            return iterator() == other.iterator() &&
-                chunk_size_ == other.chunk_size_ && current_ == other.current_;
+            return current_ == other.current_;
         }
 
         HPX_HOST_DEVICE constexpr typename base_type::reference dereference()
@@ -122,29 +190,42 @@ namespace hpx::parallel::util::detail {
             return data_;
         }
 
+    private:
+        static constexpr IterOrR next(IterOrR const& target, std::size_t first,
+            [[maybe_unused]] std::size_t size)
+        {
+            if constexpr (is_iterator || std::is_integral_v<IterOrR>)
+            {
+                return parallel::detail::next(target, first);
+            }
+            else
+            {
+                return hpx::util::subrange(target, first, size);
+            }
+        }
+
+    protected:
         HPX_HOST_DEVICE void increment(std::size_t offset) noexcept
         {
             current_ += offset + chunk_size_;
             if (current_ >= count_)
             {
                 // reached the end of the sequence
-                iterator() = parallel::detail::next(
-                    iterator(), offset + last_chunk_size_);
+                target() = next(target(), offset + last_chunk_size_, 0);
                 chunk() = 0;
             }
             else if (current_ == count_ - last_chunk_size_)
             {
                 // reached last chunk
-                iterator() =
-                    parallel::detail::next(iterator(), offset + chunk_size_);
+                target() =
+                    next(target(), offset + chunk_size_, last_chunk_size_);
                 chunk() = last_chunk_size_;
             }
             else
             {
                 // normal chunk
                 HPX_ASSERT(current_ < count_ - last_chunk_size_);
-                iterator() =
-                    parallel::detail::next(iterator(), offset + chunk_size_);
+                target() = next(target(), offset + chunk_size_, chunk_size_);
                 chunk() = chunk_size_;
             }
         }
@@ -175,23 +256,25 @@ namespace hpx::parallel::util::detail {
                 chunk() = chunk_size_;
             }
 
-            iterator() = parallel::detail::next(
-                iterator(), -static_cast<std::ptrdiff_t>(offset + chunk()));
+            target() = next(target(),
+                -static_cast<std::ptrdiff_t>(offset + chunk()), chunk());
         }
 
-        template <typename Iter = Iterator,
-            typename Enable = std::enable_if_t<
-                hpx::traits::is_bidirectional_iterator_v<Iter> ||
-                std::is_integral_v<Iter>>>
+        template <typename Iter = IterOrR,
+            HPX_CONCEPT_REQUIRES_(hpx::traits::is_bidirectional_iterator_v<
+                                      iterator_type_t<Iter>> ||
+                hpx::traits::is_range_generator_v<Iter> ||
+                std::is_integral_v<Iter>)>
         HPX_HOST_DEVICE void decrement() noexcept
         {
             decrement(0);
         }
 
-        template <typename Iter = Iterator,
-            typename Enable = std::enable_if_t<
-                hpx::traits::is_random_access_iterator_v<Iter> ||
-                std::is_integral_v<Iter>>>
+        template <typename Iter = IterOrR,
+            HPX_CONCEPT_REQUIRES_(hpx::traits::is_random_access_iterator_v<
+                                      iterator_type_t<Iter>> ||
+                hpx::traits::is_range_generator_v<Iter> ||
+                std::is_integral_v<Iter>)>
         HPX_HOST_DEVICE void advance(std::ptrdiff_t n) noexcept
         {
             // prepare next value
@@ -205,19 +288,20 @@ namespace hpx::parallel::util::detail {
             }
         }
 
-        template <typename Iter = Iterator,
-            typename Enable = std::enable_if_t<
-                hpx::traits::is_random_access_iterator_v<Iter> ||
-                std::is_integral_v<Iter>>>
+        template <typename Iter = IterOrR,
+            HPX_CONCEPT_REQUIRES_(hpx::traits::is_random_access_iterator_v<
+                                      iterator_type_t<Iter>> ||
+                hpx::traits::is_range_generator_v<Iter> ||
+                std::is_integral_v<Iter>)>
         HPX_HOST_DEVICE constexpr std::ptrdiff_t distance_to(
             chunk_size_iterator const& rhs) const noexcept
         {
             return static_cast<std::ptrdiff_t>(
-                (rhs.iterator() - iterator() + chunk_size_ - 1) / chunk_size_);
+                (rhs.current_ - current_ + chunk_size_ - 1) / chunk_size_);
         }
 
     private:
-        hpx::tuple<Iterator, std::size_t> data_;
+        hpx::tuple<IterOrR, std::size_t> data_;
         std::size_t chunk_size_ = 0;
         std::size_t last_chunk_size_ = 0;
         std::size_t count_ = 0;
@@ -225,22 +309,28 @@ namespace hpx::parallel::util::detail {
     };
 
     ///////////////////////////////////////////////////////////////////////////
-    template <typename Iterator>
+    template <typename IterOrR>
     struct chunk_size_idx_iterator
-      : public hpx::util::iterator_facade<chunk_size_idx_iterator<Iterator>,
-            hpx::tuple<Iterator, std::size_t, std::size_t> const,
-            chunk_size_iterator_category_t<Iterator>>
+      : hpx::util::iterator_facade<chunk_size_idx_iterator<IterOrR>,
+            hpx::tuple<IterOrR, std::size_t, std::size_t> const,
+            chunk_size_iterator_category_t<IterOrR>>
     {
     private:
-        using base_type =
-            hpx::util::iterator_facade<chunk_size_idx_iterator<Iterator>,
-                hpx::tuple<Iterator, std::size_t, std::size_t> const,
-                chunk_size_iterator_category_t<Iterator>>;
+        using base_type = hpx::util::iterator_facade<chunk_size_idx_iterator,
+            hpx::tuple<IterOrR, std::size_t, std::size_t> const,
+            chunk_size_iterator_category_t<IterOrR>>;
+
+        static_assert(std::is_integral_v<IterOrR> ||
+            hpx::traits::is_iterator_v<IterOrR> ||
+            hpx::traits::is_range_v<IterOrR> ||
+            hpx::traits::is_range_generator_v<IterOrR>);
+
+        static constexpr bool is_iterator = hpx::traits::is_iterator_v<IterOrR>;
 
         HPX_HOST_DEVICE static constexpr std::size_t get_last_chunk_size(
             std::size_t count, std::size_t chunk_size) noexcept
         {
-            std::ptrdiff_t const remainder =
+            auto const remainder =
                 static_cast<std::ptrdiff_t>(count % chunk_size);
             if (remainder != 0)
             {
@@ -258,23 +348,42 @@ namespace hpx::parallel::util::detail {
     public:
         HPX_HOST_DEVICE chunk_size_idx_iterator() = default;
 
-        HPX_HOST_DEVICE chunk_size_idx_iterator(Iterator it,
+        HPX_HOST_DEVICE chunk_size_idx_iterator(IterOrR it,
             std::size_t chunk_size, std::size_t count = 0,
             std::size_t current = 0, std::size_t base_idx = 0)
-          : data_(it, (hpx::detail::min)(chunk_size, count), base_idx)
-          , chunk_size_(chunk_size)
+          : data_(it, 0, base_idx)
+          , chunk_size_((hpx::detail::min)(chunk_size, count))
           , last_chunk_size_(get_last_chunk_size(count, chunk_size))
           , count_(count)
           , current_(get_current(current, chunk_size))
         {
+            if (current_ >= count_)
+            {
+                // reached the end of the sequence
+                target() = next(target(), 0, 0);
+                chunk() = 0;
+            }
+            else if (current_ == count_ - last_chunk_size_)
+            {
+                // reached last chunk
+                target() = next(target(), 0, last_chunk_size_);
+                chunk() = last_chunk_size_;
+            }
+            else
+            {
+                // normal chunk
+                HPX_ASSERT(current_ < count_ - last_chunk_size_);
+                target() = next(target(), 0, chunk_size_);
+                chunk() = chunk_size_;
+            }
         }
 
     private:
-        HPX_HOST_DEVICE Iterator& iterator() noexcept
+        HPX_HOST_DEVICE IterOrR& target() noexcept
         {
             return hpx::get<0>(data_);
         }
-        HPX_HOST_DEVICE constexpr Iterator iterator() const noexcept
+        HPX_HOST_DEVICE constexpr IterOrR target() const noexcept
         {
             return hpx::get<0>(data_);
         }
@@ -301,11 +410,11 @@ namespace hpx::parallel::util::detail {
     protected:
         friend class hpx::util::iterator_core_access;
 
+        template <typename IterOrR1>
         HPX_HOST_DEVICE constexpr bool equal(
-            chunk_size_idx_iterator const& other) const noexcept
+            chunk_size_idx_iterator<IterOrR1> const& other) const noexcept
         {
-            return iterator() == other.iterator() &&
-                chunk_size_ == other.chunk_size_ && current_ == other.current_;
+            return current_ == other.current_;
         }
 
         HPX_HOST_DEVICE constexpr typename base_type::reference dereference()
@@ -314,6 +423,21 @@ namespace hpx::parallel::util::detail {
             return data_;
         }
 
+    private:
+        static constexpr IterOrR next(IterOrR const& target, std::size_t first,
+            [[maybe_unused]] std::size_t size)
+        {
+            if constexpr (is_iterator || std::is_integral_v<IterOrR>)
+            {
+                return parallel::detail::next(target, first);
+            }
+            else
+            {
+                return hpx::util::subrange(target, first, size);
+            }
+        }
+
+    protected:
         HPX_HOST_DEVICE void increment(std::size_t offset) noexcept
         {
             base_index() += offset + chunk_size_;
@@ -321,23 +445,21 @@ namespace hpx::parallel::util::detail {
             if (current_ >= count_)
             {
                 // reached the end of the sequence
-                iterator() = parallel::detail::next(
-                    iterator(), offset + last_chunk_size_);
+                target() = next(target(), offset + last_chunk_size_, 0);
                 chunk() = 0;
             }
             else if (current_ == count_ - last_chunk_size_)
             {
                 // reached last chunk
-                iterator() =
-                    parallel::detail::next(iterator(), offset + chunk_size_);
+                target() =
+                    next(target(), offset + chunk_size_, last_chunk_size_);
                 chunk() = last_chunk_size_;
             }
             else
             {
                 // normal chunk
                 HPX_ASSERT(current_ < count_ - last_chunk_size_);
-                iterator() =
-                    parallel::detail::next(iterator(), offset + chunk_size_);
+                target() = next(target(), offset + chunk_size_, chunk_size_);
                 chunk() = chunk_size_;
             }
         }
@@ -370,23 +492,25 @@ namespace hpx::parallel::util::detail {
                 chunk() = chunk_size_;
             }
 
-            iterator() = parallel::detail::next(
-                iterator(), -static_cast<std::ptrdiff_t>(offset + chunk()));
+            target() = next(target(),
+                -static_cast<std::ptrdiff_t>(offset + chunk()), chunk());
         }
 
-        template <typename Iter = Iterator,
-            typename Enable = std::enable_if_t<
-                hpx::traits::is_bidirectional_iterator_v<Iter> ||
-                std::is_integral_v<Iter>>>
+        template <typename Iter = IterOrR,
+            HPX_CONCEPT_REQUIRES_(hpx::traits::is_bidirectional_iterator_v<
+                                      iterator_type_t<Iter>> ||
+                hpx::traits::is_range_generator_v<Iter> ||
+                std::is_integral_v<Iter>)>
         HPX_HOST_DEVICE void decrement() noexcept
         {
             decrement(0);
         }
 
-        template <typename Iter = Iterator,
-            typename Enable = std::enable_if_t<
-                hpx::traits::is_random_access_iterator_v<Iter> ||
-                std::is_integral_v<Iter>>>
+        template <typename Iter = IterOrR,
+            HPX_CONCEPT_REQUIRES_(hpx::traits::is_random_access_iterator_v<
+                                      iterator_type_t<Iter>> ||
+                hpx::traits::is_range_generator_v<Iter> ||
+                std::is_integral_v<Iter>)>
         HPX_HOST_DEVICE void advance(std::ptrdiff_t n) noexcept
         {
             // prepare next value
@@ -400,19 +524,20 @@ namespace hpx::parallel::util::detail {
             }
         }
 
-        template <typename Iter = Iterator,
-            typename Enable = std::enable_if_t<
-                hpx::traits::is_random_access_iterator_v<Iter> ||
-                std::is_integral_v<Iter>>>
+        template <typename Iter = IterOrR,
+            HPX_CONCEPT_REQUIRES_(hpx::traits::is_random_access_iterator_v<
+                                      iterator_type_t<Iter>> ||
+                hpx::traits::is_range_generator_v<Iter> ||
+                std::is_integral_v<Iter>)>
         HPX_HOST_DEVICE constexpr std::ptrdiff_t distance_to(
             chunk_size_idx_iterator const& rhs) const noexcept
         {
             return static_cast<std::ptrdiff_t>(
-                (rhs.iterator() - iterator() + chunk_size_ - 1) / chunk_size_);
+                (rhs.current_ - current_ + chunk_size_ - 1) / chunk_size_);
         }
 
     private:
-        hpx::tuple<Iterator, std::size_t, std::size_t> data_;
+        hpx::tuple<IterOrR, std::size_t, std::size_t> data_;
         std::size_t chunk_size_ = 0;
         std::size_t last_chunk_size_ = 0;
         std::size_t count_ = 0;

--- a/libs/core/algorithms/include/hpx/parallel/util/partitioner.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/util/partitioner.hpp
@@ -39,8 +39,8 @@
 ///////////////////////////////////////////////////////////////////////////////
 namespace hpx::parallel::util::detail {
 
-    template <typename Result, typename ExPolicy, typename FwdIter, typename F>
-    auto partition(ExPolicy&& policy, FwdIter first, std::size_t count, F&& f)
+    template <typename Result, typename ExPolicy, typename IterOrR, typename F>
+    auto partition(ExPolicy&& policy, IterOrR it_or_r, std::size_t count, F&& f)
     {
         // estimate a chunk size based on number of cores used
         using parameters_type =
@@ -57,7 +57,7 @@ namespace hpx::parallel::util::detail {
                 "has_variable_chunk_size and invokes_testing_function");
 
             auto&& shape = detail::get_bulk_iteration_shape_variable(
-                HPX_FORWARD(ExPolicy, policy), first, count);
+                HPX_FORWARD(ExPolicy, policy), it_or_r, count);
 
             return execution::bulk_async_execute(policy.executor(),
                 partitioner_iteration<Result, F>{HPX_FORWARD(F, f)},
@@ -66,7 +66,7 @@ namespace hpx::parallel::util::detail {
         else if constexpr (!invokes_testing_function)
         {
             auto&& shape = detail::get_bulk_iteration_shape(
-                HPX_FORWARD(ExPolicy, policy), first, count);
+                HPX_FORWARD(ExPolicy, policy), it_or_r, count);
 
             return execution::bulk_async_execute(policy.executor(),
                 partitioner_iteration<Result, F>{HPX_FORWARD(F, f)},
@@ -76,7 +76,7 @@ namespace hpx::parallel::util::detail {
         {
             std::vector<hpx::future<Result>> inititems;
             auto&& shape = detail::get_bulk_iteration_shape(
-                HPX_FORWARD(ExPolicy, policy), inititems, f, first, count);
+                HPX_FORWARD(ExPolicy, policy), inititems, f, it_or_r, count);
 
             auto&& workitems = execution::bulk_async_execute(policy.executor(),
                 partitioner_iteration<Result, F>{HPX_FORWARD(F, f)},

--- a/libs/core/algorithms/include/hpx/parallel/util/transfer.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/util/transfer.hpp
@@ -91,7 +91,15 @@ namespace hpx::parallel::util {
                 char const* const first_ch = to_const_ptr(first);
                 char* const dest_ch = to_ptr(dest);
 
+#if defined(HPX_GCC_VERSION) && HPX_GCC_VERSION >= 110000
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Warray-bounds"
+#pragma GCC diagnostic ignored "-Wstringop-overread"
+#endif
                 std::memmove(dest_ch, first_ch, count * sizeof(data_type));
+#if defined(HPX_GCC_VERSION) && HPX_GCC_VERSION >= 110000
+#pragma GCC diagnostic pop
+#endif
 
                 std::advance(first, count);
                 std::advance(dest, count);

--- a/libs/core/algorithms/tests/unit/container_algorithms/CMakeLists.txt
+++ b/libs/core/algorithms/tests/unit/container_algorithms/CMakeLists.txt
@@ -38,10 +38,10 @@ set(tests
     find_end_range2
     find_first_of_range
     find_first_of_range2
-    for_loop_range
     for_loop_exception_range
     for_loop_induction_range
     for_loop_induction_async_range
+    for_loop_range
     for_loop_reduction_range
     for_loop_reduction_async_range
     for_loop_strided_range
@@ -123,6 +123,10 @@ set(tests
     unique_range
     unique_copy_range
 )
+
+if(HPX_WITH_CXX20_COROUTINES)
+  set(tests ${tests} for_loop_range_generator)
+endif()
 
 foreach(test ${tests})
   set(sources ${test}.cpp)

--- a/libs/core/algorithms/tests/unit/container_algorithms/for_loop_range_generator.cpp
+++ b/libs/core/algorithms/tests/unit/container_algorithms/for_loop_range_generator.cpp
@@ -1,0 +1,192 @@
+//  Copyright (c) 2016 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/config.hpp>
+
+// clang up to V12 refuses to compile the code below
+#if defined(HPX_HAVE_CXX20_COROUTINES) &&                                      \
+    (!defined(HPX_CLANG_VERSION) || HPX_CLANG_VERSION >= 130000)
+
+#include <hpx/local/algorithm.hpp>
+#include <hpx/local/generator.hpp>
+#include <hpx/local/init.hpp>
+#include <hpx/modules/testing.hpp>
+
+#include <algorithm>
+#include <cstddef>
+#include <iostream>
+#include <numeric>
+#include <random>
+#include <string>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+#include "test_utils.hpp"
+
+///////////////////////////////////////////////////////////////////////////////
+unsigned int seed = std::random_device{}();
+std::mt19937 gen(seed);
+
+///////////////////////////////////////////////////////////////////////////////
+namespace test {
+
+    struct index_pair
+    {
+        int first;
+        int last;
+        int stride = 1;
+
+        [[nodiscard]] constexpr bool operator==(
+            index_pair const& rhs) const noexcept
+        {
+            return first == rhs.first && last == rhs.last &&
+                stride == rhs.stride;
+        }
+    };
+
+    hpx::generator<int&, int> iterate(index_pair p) noexcept
+    {
+        auto const lo = p.first;
+        auto const hi = p.last;
+        auto const stride = p.stride;
+
+        if (stride > 0)
+        {
+            for (auto i = lo; i < hi; i += stride)
+                co_yield i;
+        }
+        else if (stride < 0)
+        {
+            for (auto i = hi - 1; i >= lo; i += stride)
+                co_yield i;
+        }
+    }
+
+    bool empty(index_pair const& p)
+    {
+        return p.first == p.last;
+    }
+
+    auto size(index_pair const& p)
+    {
+        return p.last - p.first;
+    }
+
+    auto distance(index_pair const& p1, index_pair const& p2)
+    {
+        return p1.first - p2.first;
+    }
+
+    index_pair subrange(
+        index_pair const& p, std::ptrdiff_t first, std::size_t size)
+    {
+        return {static_cast<int>(p.first + first),
+            static_cast<int>(p.first + first + size), p.stride};
+    }
+
+    static_assert(hpx::traits::is_range_generator_v<index_pair>);
+}    // namespace test
+
+///////////////////////////////////////////////////////////////////////////////
+template <typename ExPolicy>
+void test_for_loop(ExPolicy&& policy)
+{
+    static_assert(hpx::is_execution_policy_v<ExPolicy>,
+        "hpx::is_execution_policy_v<ExPolicy>");
+
+    std::vector<std::size_t> c(10007);
+    std::iota(std::begin(c), std::end(c), gen());
+
+    hpx::ranges::experimental::for_loop(std::forward<ExPolicy>(policy),
+        test::index_pair{0, static_cast<int>(c.size())},
+        [&](int i) { c[i] = 42; });
+
+    // verify values
+    std::size_t count = 0;
+    std::for_each(std::begin(c), std::end(c), [&count](std::size_t v) -> void {
+        HPX_TEST_EQ(v, static_cast<std::size_t>(42));
+        ++count;
+    });
+    HPX_TEST_EQ(count, c.size());
+}
+
+template <typename ExPolicy>
+void test_for_loop_async(ExPolicy&& p)
+{
+    std::vector<std::size_t> c(10007);
+    std::iota(std::begin(c), std::end(c), gen());
+
+    auto f = hpx::ranges::experimental::for_loop(std::forward<ExPolicy>(p),
+        test::index_pair{0, static_cast<int>(c.size())},
+        [&](int i) { c[i] = 42; });
+    f.wait();
+
+    // verify values
+    std::size_t count = 0;
+    std::for_each(std::begin(c), std::end(c), [&count](std::size_t v) -> void {
+        HPX_TEST_EQ(v, static_cast<std::size_t>(42));
+        ++count;
+    });
+    HPX_TEST_EQ(count, c.size());
+}
+
+void test_for_loop()
+{
+    test_for_loop(hpx::execution::seq);
+    test_for_loop(hpx::execution::par);
+    test_for_loop(hpx::execution::par_unseq);
+
+    test_for_loop_async(hpx::execution::seq(hpx::execution::task));
+    test_for_loop_async(hpx::execution::par(hpx::execution::task));
+}
+
+///////////////////////////////////////////////////////////////////////////////
+int hpx_main(hpx::program_options::variables_map& vm)
+{
+    if (vm.count("seed"))
+        seed = vm["seed"].as<unsigned int>();
+
+    std::cout << "using seed: " << seed << std::endl;
+    gen.seed(seed);
+
+    test_for_loop();
+
+    return hpx::local::finalize();
+}
+
+int main(int argc, char* argv[])
+{
+    // add command line option which controls the random number generator seed
+    using namespace hpx::program_options;
+    options_description desc_commandline(
+        "Usage: " HPX_APPLICATION_STRING " [options]");
+
+    desc_commandline.add_options()("seed,s", value<unsigned int>(),
+        "the random number generator seed to use for this run");
+
+    // By default this test should run on all available cores
+    std::vector<std::string> const cfg = {"hpx.os_threads=all"};
+
+    // Initialize and run HPX
+    hpx::local::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::local::init(hpx_main, argc, argv, init_args), 0,
+        "HPX main exited with non-zero status");
+
+    return hpx::util::report_errors();
+}
+
+#else
+
+int main(int, char*[])
+{
+    return 0;
+}
+
+#endif

--- a/libs/core/async_combinators/include/hpx/async_combinators/detail/throw_if_exceptional.hpp
+++ b/libs/core/async_combinators/include/hpx/async_combinators/detail/throw_if_exceptional.hpp
@@ -22,11 +22,18 @@ namespace hpx::detail {
     template <typename Future>
     void rethrow_if_needed(Future const& f)
     {
+#if defined(HPX_GCC_VERSION) && HPX_GCC_VERSION >= 110000
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wstringop-overflow"
+#endif
         auto shared_state = hpx::traits::detail::get_shared_state(f);
         if (shared_state->has_exception())
         {
             shared_state->get_result_void();    // throws stored exception
         }
+#if defined(HPX_GCC_VERSION) && HPX_GCC_VERSION >= 110000
+#pragma GCC diagnostic pop
+#endif
     }
 
     template <typename Future,

--- a/libs/core/config/CMakeLists.txt
+++ b/libs/core/config/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2019 The STE||AR-Group
+# Copyright (c) 2019-2023 The STE||AR-Group
 #
 # SPDX-License-Identifier: BSL-1.0
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -33,10 +33,6 @@ set(config_headers
     hpx/config/warnings_suffix.hpp
     hpx/config/weak_symbol.hpp
 )
-
-if(HPX_WITH_CXX20_COROUTINES)
-  set(config_headers ${config_headers} hpx/config/coroutines_support.hpp)
-endif()
 
 # Default location is $HPX_ROOT/libs/config/src
 set(config_sources version.cpp)

--- a/libs/core/config/include/hpx/config.hpp
+++ b/libs/core/config/include/hpx/config.hpp
@@ -17,7 +17,6 @@
 #include <hpx/config/compiler_fence.hpp>
 #include <hpx/config/compiler_specific.hpp>
 #include <hpx/config/constexpr.hpp>
-#include <hpx/config/coroutines_support.hpp>
 #include <hpx/config/debug.hpp>
 #include <hpx/config/deprecation.hpp>
 #include <hpx/config/emulate_deleted.hpp>

--- a/libs/core/datastructures/CMakeLists.txt
+++ b/libs/core/datastructures/CMakeLists.txt
@@ -46,6 +46,8 @@ endif()
 set(datastructures_headers
     hpx/datastructures/any.hpp
     hpx/datastructures/detail/dynamic_bitset.hpp
+    hpx/datastructures/detail/flat_map.hpp
+    hpx/datastructures/detail/flat_set.hpp
     hpx/datastructures/detail/intrusive_list.hpp
     hpx/datastructures/detail/small_vector.hpp
     hpx/datastructures/detail/optional.hpp

--- a/libs/core/datastructures/include/hpx/datastructures/detail/dynamic_bitset.hpp
+++ b/libs/core/datastructures/include/hpx/datastructures/detail/dynamic_bitset.hpp
@@ -2163,8 +2163,16 @@ namespace hpx::detail {
 
         if (extra_bits != 0)
         {
+#if defined(HPX_GCC_VERSION) && HPX_GCC_VERSION >= 110000
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wstringop-overread"
+#pragma GCC diagnostic ignored "-Wstringop-overflow"
+#endif
             // NOLINTNEXTLINE(stringop-overflow=)
             highest_block() &= (Block(1) << extra_bits) - 1;
+#if defined(HPX_GCC_VERSION) && HPX_GCC_VERSION >= 110000
+#pragma GCC diagnostic pop
+#endif
         }
     }
 

--- a/libs/core/datastructures/include/hpx/datastructures/detail/flat_map.hpp
+++ b/libs/core/datastructures/include/hpx/datastructures/detail/flat_map.hpp
@@ -1,0 +1,1228 @@
+//  Copyright (C) 2019-2022 T. Zachary Laine
+//  Copyright (c) 2023 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include <hpx/config.hpp>
+#include <hpx/datastructures/detail/flat_set.hpp>
+
+#include <algorithm>
+#include <iterator>
+#include <vector>
+
+#if defined(GNUC) && !defined(clang)
+#include <bits/uses_allocator.h>
+#endif
+
+// clang-format off
+#if (201703L < __cplusplus && defined(cpp_lib_ranges))
+#define CPP20_CONCEPTS 1
+#else
+#define CPP20_CONCEPTS 0
+#endif
+#if (201703L <= __cplusplus && defined(__has_include) &&                       \
+    __has_include(<stl2/ranges.hpp>))
+#define CMCSTL2_CONCEPTS 1
+#else
+#define CMCSTL2_CONCEPTS 0
+#endif
+#define USE_CONCEPTS CPP20_CONCEPTS || CMCSTL2_CONCEPTS
+// clang-format on
+
+#if CPP20_CONCEPTS
+#include <ranges>
+#elif CMCSTL2_CONCEPTS
+#include <stl2/algorithm.hpp>
+#include <stl2/ranges.hpp>
+#endif
+
+#include <cstddef>
+#include <initializer_list>
+#include <stdexcept>
+#include <type_traits>
+#include <utility>
+
+namespace hpx::detail {
+
+#if CMCSTL2_CONCEPTS && !CPP20_CONCEPTS
+    using namespace std::experimental;
+#endif
+
+    template <typename T1, typename T2>
+    struct ref_pair
+    {
+        static_assert(std::is_reference<T1>{} && std::is_reference<T2>{});
+
+        using pair_type = std::pair<remove_cvref_t<T1>, remove_cvref_t<T2>>;
+        using pair_of_references_type =
+            std::pair<remove_cvref_t<T1>&, remove_cvref_t<T2>&>;
+        using const_pair_of_references_type =
+            std::pair<remove_cvref_t<T1> const&, remove_cvref_t<T2> const&>;
+
+        ref_pair(T1 t1, T2 t2)
+          : first(t1)
+          , second(t2)
+        {
+        }
+        ref_pair(ref_pair const& other)
+          : first(other.first)
+          , second(other.second)
+        {
+        }
+        ref_pair(ref_pair&& other) noexcept
+          : first(other.first)
+          , second(other.second)
+        {
+        }
+        ref_pair& operator=(ref_pair const& other)
+        {
+            first = other.first;
+            second = other.second;
+            return *this;
+        }
+        ref_pair& operator=(ref_pair&& other) noexcept
+        {
+            first = other.first;
+            second = other.second;
+            return *this;
+        }
+        ref_pair& operator=(pair_type const& other)
+        {
+            first = other.first;
+            second = other.second;
+            return *this;
+        }
+        ref_pair& operator=(pair_type&& other) noexcept
+        {
+            first = HPX_MOVE(other.first);
+            second = HPX_MOVE(other.second);
+            return *this;
+        }
+        ~ref_pair() = default;
+
+        operator pair_type() const
+        {
+            return pair_type(first, second);
+        }
+        operator pair_of_references_type() const
+        {
+            return pair_of_references_type(first, second);
+        }
+        operator const_pair_of_references_type() const
+        {
+            return const_pair_of_references_type(first, second);
+        }
+        bool operator==(ref_pair rhs) const noexcept
+        {
+            return first == rhs.first && second == rhs.second;
+        }
+        bool operator!=(ref_pair rhs) const noexcept
+        {
+            return !(*this == rhs);
+        }
+        bool operator<(ref_pair rhs) const noexcept
+        {
+            if (first < rhs.first)
+                return true;
+            if (rhs.first < first)
+                return false;
+            return second < rhs.second;
+        }
+
+        T1 first;
+        T2 second;
+    };
+
+    template <typename T1, typename T2>
+    void swap(ref_pair<T1, T2> const& lhs, ref_pair<T1, T2> const& rhs)
+    {
+        using std::swap;
+        swap(lhs.first, rhs.first);
+        swap(lhs.second, rhs.second);
+    }
+
+    template <typename KeyRef, typename TRef, typename KeyIter,
+        typename MappedIter>
+    struct flat_map_iterator
+    {
+        static_assert(std::is_reference<KeyRef>{} && std::is_reference<TRef>{});
+
+        using iterator_category = std::random_access_iterator_tag;
+        using value_type =
+            std::pair<remove_cvref_t<KeyRef>, remove_cvref_t<TRef>>;
+        using difference_type =
+            typename std::iterator_traits<KeyIter>::difference_type;
+        using reference = ref_pair<KeyRef, TRef>;
+
+        struct arrow_proxy
+        {
+            constexpr reference* operator->() noexcept
+            {
+                return &value_;
+            }
+            constexpr reference const* operator->() const noexcept
+            {
+                return &value_;
+            }
+            explicit arrow_proxy(reference value) noexcept
+              : value_(HPX_MOVE(value))
+            {
+            }
+
+        private:
+            reference value_;
+        };
+        using pointer = arrow_proxy;
+
+        flat_map_iterator() = default;
+        flat_map_iterator(KeyIter key_it, MappedIter mapped_it)
+          : key_it_(key_it)
+          , mapped_it_(mapped_it)
+        {
+        }
+
+        template <typename TRef2, typename MappedIter2,
+            typename = std::enable_if_t<std::is_convertible_v<TRef2, TRef> &&
+                std::is_convertible_v<MappedIter2, MappedIter>>>
+        flat_map_iterator(
+            flat_map_iterator<KeyRef, TRef2, KeyIter, MappedIter2> other)
+          : key_it_(other.key_it_)
+          , mapped_it_(other.mapped_it_)
+        {
+        }
+
+        constexpr reference operator*() const noexcept
+        {
+            return ref();
+        }
+        constexpr pointer operator->() const noexcept
+        {
+            return arrow_proxy(ref());
+        }
+
+        constexpr reference operator[](difference_type n) const noexcept
+        {
+            return reference(*(key_it_ + n), *(mapped_it_ + n));
+        }
+
+        flat_map_iterator operator+(difference_type n) const noexcept
+        {
+            return flat_map_iterator(key_it_ + n, mapped_it_ + n);
+        }
+        flat_map_iterator operator-(difference_type n) const noexcept
+        {
+            return flat_map_iterator(key_it_ - n, mapped_it_ - n);
+        }
+
+        flat_map_iterator& operator++() noexcept
+        {
+            ++key_it_;
+            ++mapped_it_;
+            return *this;
+        }
+        flat_map_iterator operator++(int) noexcept
+        {
+            flat_map_iterator tmp(*this);
+            ++key_it_;
+            ++mapped_it_;
+            return tmp;
+        }
+
+        flat_map_iterator& operator--() noexcept
+        {
+            --key_it_;
+            --mapped_it_;
+            return *this;
+        }
+        flat_map_iterator operator--(int) noexcept
+        {
+            flat_map_iterator tmp(*this);
+            --key_it_;
+            --mapped_it_;
+            return tmp;
+        }
+
+        flat_map_iterator& operator+=(difference_type n) noexcept
+        {
+            key_it_ += n;
+            mapped_it_ += n;
+            return *this;
+        }
+        flat_map_iterator& operator-=(difference_type n) noexcept
+        {
+            key_it_ -= n;
+            mapped_it_ -= n;
+            return *this;
+        }
+
+        KeyIter key_iter() const
+        {
+            return key_it_;
+        }
+        MappedIter mapped_iter() const
+        {
+            return mapped_it_;
+        }
+
+        friend bool operator==(flat_map_iterator lhs, flat_map_iterator rhs)
+        {
+            return lhs.key_it_ == rhs.key_it_;
+        }
+        friend bool operator!=(flat_map_iterator lhs, flat_map_iterator rhs)
+        {
+            return !(lhs == rhs);
+        }
+
+        friend bool operator<(flat_map_iterator lhs, flat_map_iterator rhs)
+        {
+            return lhs.key_it_ < rhs.key_it_;
+        }
+        friend bool operator<=(flat_map_iterator lhs, flat_map_iterator rhs)
+        {
+            return lhs == rhs || lhs < rhs;
+        }
+        friend bool operator>(flat_map_iterator lhs, flat_map_iterator rhs)
+        {
+            return rhs < lhs;
+        }
+        friend bool operator>=(flat_map_iterator lhs, flat_map_iterator rhs)
+        {
+            return lhs == rhs || rhs < lhs;
+        }
+
+        friend difference_type operator-(
+            flat_map_iterator lhs, flat_map_iterator rhs)
+        {
+            return lhs.key_it_ - rhs.key_it_;
+        }
+
+    private:
+        template <typename KeyRef2, class TRef2, typename KeyIter2,
+            typename MappedIter2>
+        friend struct flat_map_iterator;
+
+        reference ref() const
+        {
+            return reference(*key_it_, *mapped_it_);
+        }
+
+        KeyIter key_it_;
+        MappedIter mapped_it_;
+    };
+
+    // NOTE: This overload was necessary, since iter_swap(it1, it2) calls
+    // swap(*it1, *it2).  All std::swap() overloads expect lvalues, and
+    // flat_map's iterators produce proxy rvalues when dereferenced.
+    template <typename KeyRef, class TRef>
+    inline void swap(
+        std::pair<KeyRef, TRef>&& lhs, std::pair<KeyRef, TRef>&& rhs)
+    {
+        using std::swap;
+        swap(lhs.first, rhs.first);
+        swap(lhs.second, rhs.second);
+    }
+
+    template <typename Key, typename T, typename Compare = std::less<Key>,
+        typename KeyContainer = std::vector<Key>,
+        typename MappedContainer = std::vector<T>>
+    class flat_map
+    {
+        template <typename Alloc>
+        using uses =
+            std::enable_if_t<std::uses_allocator<KeyContainer, Alloc>::value &&
+                std::uses_allocator<MappedContainer, Alloc>::value>;
+
+        template <typename Container, typename = void>
+        struct has_begin_end : std::false_type
+        {
+        };
+        template <typename Container>
+        struct has_begin_end<Container,
+            std::void_t<decltype(std::begin(std::declval<Container>())),
+                decltype(std::end(std::declval<Container>()))>> : std::true_type
+        {
+        };
+        template <typename Container>
+        using container = std::enable_if_t<has_begin_end<Container>::value>;
+
+    public:
+        // types:
+        using key_type = Key;
+        using mapped_type = T;
+        using value_type = std::pair<key_type const, mapped_type>;
+        using key_compare = Compare;
+        using reference = std::pair<key_type const&, mapped_type&>;
+        using const_reference = std::pair<key_type const&, mapped_type const&>;
+        using size_type = std::size_t;
+        using difference_type = ptrdiff_t;
+        using iterator = flat_map_iterator<key_type const&, mapped_type&,
+            typename KeyContainer::const_iterator,
+            typename MappedContainer::iterator>;    // see 21.2
+        using const_iterator = flat_map_iterator<key_type const&,
+            mapped_type const&, typename KeyContainer::const_iterator,
+            typename MappedContainer::const_iterator>;    // see 21.2
+        using reverse_iterator = flat_map_iterator<key_type const&,
+            mapped_type&, typename KeyContainer::const_reverse_iterator,
+            typename MappedContainer::reverse_iterator>;    // see 21.2
+        using const_reverse_iterator = flat_map_iterator<key_type const&,
+            mapped_type const&, typename KeyContainer::const_reverse_iterator,
+            typename MappedContainer::const_reverse_iterator>;    // see 21.2
+        using key_container_type = KeyContainer;
+        using mapped_container_type = MappedContainer;
+
+        class value_compare
+        {
+            friend flat_map;
+
+        private:
+            key_compare comp;
+            explicit value_compare(key_compare c)
+              : comp(c)
+            {
+            }
+
+        public:
+            bool operator()(const_reference x, const_reference y) const
+            {
+                return comp(x.first, y.first);
+            }
+        };
+
+        struct containers
+        {
+            key_container_type keys;
+            mapped_container_type values;
+        };
+
+        // ??, construct/copy/destroy
+        flat_map()
+          : flat_map(key_compare())
+        {
+        }
+        flat_map(key_container_type key_cont, mapped_container_type mapped_cont)
+          : c{HPX_MOVE(key_cont), HPX_MOVE(mapped_cont)}
+          , compare(key_compare())
+        {
+            mutable_iterator first(c.keys.begin(), c.values.begin());
+            mutable_iterator last(c.keys.end(), c.values.end());
+#if USE_CONCEPTS
+            std::ranges::sort(first, last, value_comp());
+#else
+            std::sort(first, last, value_comp());
+#endif
+        }
+        template <typename Alloc, typename Enable = uses<Alloc>>
+        flat_map(key_container_type const& key_cont,
+            mapped_container_type const& mapped_cont, Alloc const& a)
+          : c{key_container_type(key_cont, a),
+                mapped_container_type(mapped_cont, a)}
+          , compare()
+        {
+            mutable_iterator first(c.keys.begin(), c.values.begin());
+            mutable_iterator last(c.keys.end(), c.values.end());
+#if USE_CONCEPTS
+            std::ranges::sort(first, last, value_comp());
+#else
+            std::sort(first, last, value_comp());
+#endif
+        }
+        template <typename Container, typename Enable = container<Container>>
+        explicit flat_map(
+            Container const& cont, key_compare const& comp = key_compare())
+          : flat_map(std::begin(cont), std::end(cont), comp)
+        {
+        }
+        template <typename Container, typename Alloc,
+            typename Enable1 = container<Container>,
+            typename Enable2 = uses<Alloc>>
+        flat_map(Container const& cont, Alloc const& a)
+          : flat_map(std::begin(cont), std::end(cont), a)
+        {
+        }
+        flat_map(sorted_unique_t, key_container_type key_cont,
+            mapped_container_type mapped_cont)
+          : c{HPX_MOVE(key_cont), HPX_MOVE(mapped_cont)}
+          , compare(key_compare())
+        {
+        }
+        template <typename Alloc, typename Enable = uses<Alloc>>
+        flat_map(sorted_unique_t, key_container_type const& key_cont,
+            mapped_container_type const& mapped_cont, Alloc const& a)
+          : c{key_container_type(key_cont, a),
+                mapped_container_type(mapped_cont, a)}
+          , compare()
+        {
+        }
+        template <typename Container, typename Enable = container<Container>>
+        flat_map(sorted_unique_t s, Container const& cont,
+            key_compare const& comp = key_compare())
+          : flat_map(s, std::begin(cont), std::end(cont), comp)
+        {
+        }
+        template <typename Container, typename Alloc,
+            typename Enable1 = container<Container>,
+            typename Enable2 = uses<Alloc>>
+        flat_map(sorted_unique_t s, Container const& cont, Alloc const& a)
+          : c{key_container_type(a), mapped_container_type(a)}
+          , compare()
+        {
+            c.keys.reserve(cont.size());
+            c.values.reserve(cont.size());
+            insert(s, std::begin(cont), std::end(cont));
+        }
+        explicit flat_map(key_compare const& comp)
+          : c()
+          , compare(comp)
+        {
+        }
+        template <typename Alloc, typename Enable = uses<Alloc>>
+        flat_map(key_compare const& comp, Alloc const& a)
+          : c{key_container_type(a), mapped_container_type(a)}
+          , compare(comp)
+        {
+        }
+        template <typename Alloc, typename Enable = uses<Alloc>>
+        explicit flat_map(Alloc const& a)
+          : c{key_container_type(a), mapped_container_type(a)}
+          , compare()
+        {
+        }
+        template <typename InputIterator>
+        flat_map(InputIterator first, InputIterator last,
+            key_compare const& comp = key_compare())
+          : c()
+          , compare(comp)
+        {
+            insert(first, last);
+        }
+        template <typename InputIterator, typename Alloc,
+            typename Enable = uses<Alloc>>
+        flat_map(InputIterator first, InputIterator last,
+            key_compare const& comp, Alloc const& a)
+          : c{key_container_type(a), mapped_container_type(a)}
+          , compare(comp)
+        {
+            insert(first, last);
+        }
+        template <typename InputIterator, typename Alloc,
+            typename Enable = uses<Alloc>>
+        flat_map(InputIterator first, InputIterator last, Alloc const& a)
+          : flat_map(first, last, key_compare(), a)
+        {
+        }
+        template <typename InputIterator>
+        flat_map(sorted_unique_t s, InputIterator first, InputIterator last,
+            key_compare const& comp = key_compare())
+          : c()
+          , compare(comp)
+        {
+            insert(s, first, last);
+        }
+        template <typename InputIterator, typename Alloc,
+            typename Enable = uses<Alloc>>
+        flat_map(sorted_unique_t s, InputIterator first, InputIterator last,
+            key_compare const& comp, Alloc const& a)
+          : c{key_container_type(a), mapped_container_type(a)}
+          , compare(comp)
+        {
+            insert(s, first, last);
+        }
+        template <typename InputIterator, typename Alloc,
+            typename Enable = uses<Alloc>>
+        flat_map(sorted_unique_t s, InputIterator first, InputIterator last,
+            Alloc const& a)
+          : flat_map(s, first, last, key_compare(), a)
+        {
+        }
+        flat_map(std::initializer_list<value_type>&& il,
+            key_compare const& comp = key_compare())
+          : flat_map(il, comp)
+        {
+        }
+        template <typename Alloc, typename Enable = uses<Alloc>>
+        flat_map(std::initializer_list<value_type>&& il,
+            key_compare const& comp, Alloc const& a)
+          : flat_map(std::begin(il), std::end(il), comp, a)
+        {
+        }
+        template <typename Alloc, typename Enable = uses<Alloc>>
+        flat_map(std::initializer_list<value_type>&& il, Alloc const& a)
+          : flat_map(std::begin(il), std::end(il), key_compare(), a)
+        {
+        }
+        flat_map(sorted_unique_t s, std::initializer_list<value_type>&& il,
+            key_compare const& comp = key_compare())
+          : flat_map(s, il, comp)
+        {
+        }
+        template <typename Alloc, typename Enable = uses<Alloc>>
+        flat_map(sorted_unique_t s, std::initializer_list<value_type>&& il,
+            key_compare const& comp, Alloc const& a)
+          : flat_map(s, std::begin(il), std::end(il), comp, a)
+        {
+        }
+        template <typename Alloc, typename Enable = uses<Alloc>>
+        flat_map(sorted_unique_t s, std::initializer_list<value_type>&& il,
+            Alloc const& a)
+          : flat_map(s, std::begin(il), std::end(il), key_compare(), a)
+        {
+        }
+        flat_map& operator=(std::initializer_list<value_type> il)
+        {
+            flat_map tmp(il, compare);
+            swap(tmp);
+            return *this;
+        }
+
+        // iterators
+        iterator begin() noexcept
+        {
+            return iterator(c.keys.begin(), c.values.begin());
+        }
+        const_iterator begin() const noexcept
+        {
+            return const_iterator(c.keys.begin(), c.values.begin());
+        }
+        iterator end() noexcept
+        {
+            return iterator(c.keys.end(), c.values.end());
+        }
+        const_iterator end() const noexcept
+        {
+            return const_iterator(c.keys.end(), c.values.end());
+        }
+        reverse_iterator rbegin() noexcept
+        {
+            return reverse_iterator(c.keys.rbegin(), c.values.rbegin());
+        }
+        const_reverse_iterator rbegin() const noexcept
+        {
+            return const_reverse_iterator(c.keys.rbegin(), c.values.rbegin());
+        }
+        reverse_iterator rend() noexcept
+        {
+            return reverse_iterator(c.keys.rend(), c.values.rend());
+        }
+        const_reverse_iterator rend() const noexcept
+        {
+            return const_reverse_iterator(c.keys.rend(), c.values.rend());
+        }
+
+        const_iterator cbegin() const noexcept
+        {
+            return begin();
+        }
+        const_iterator cend() const noexcept
+        {
+            return end();
+        }
+        const_reverse_iterator crbegin() const noexcept
+        {
+            return rbegin();
+        }
+        const_reverse_iterator crend() const noexcept
+        {
+            return rend();
+        }
+
+        // ??, capacity
+        [[nodiscard]] bool empty() const noexcept
+        {
+            return c.keys.empty();
+        }
+        size_type size() const noexcept
+        {
+            return c.keys.size();
+        }
+        size_type max_size() const noexcept
+        {
+            return std::min<size_type>(c.keys.max_size(), c.values.max_size());
+        }
+
+        // ??, element access
+        mapped_type& operator[](key_type const& x)
+        {
+            return try_emplace(x).first->second;
+        }
+        mapped_type& operator[](key_type&& x)
+        {
+            return try_emplace(HPX_MOVE(x)).first->second;
+        }
+        mapped_type& at(key_type const& x)
+        {
+            auto it = key_find(x);
+            if (it == c.keys.end())
+                throw std::out_of_range("Value not found by flat_map.at()");
+            return *project(it);
+        }
+        mapped_type const& at(key_type const& x) const
+        {
+            auto it = key_find(x);
+            if (it == c.keys.end())
+                throw std::out_of_range("Value not found by flat_map.at()");
+            return *project(it);
+        }
+
+        // ??, modifiers
+        template <typename... Args,
+            typename Enable = std::enable_if_t<std::is_constructible_v<
+                std::pair<key_type, mapped_type>, Args&&...>>>
+        std::pair<iterator, bool> emplace(Args&&... args)
+        {
+            std::pair<key_type, mapped_type> p(HPX_FORWARD(Args, args)...);
+            return try_emplace(HPX_MOVE(p.first), HPX_MOVE(p.second));
+        }
+        template <typename... Args,
+            typename Enable = std::enable_if_t<std::is_constructible_v<
+                std::pair<key_type, mapped_type>, Args&&...>>>
+        iterator emplace_hint(const_iterator, Args&&... args)
+        {
+            return emplace(HPX_FORWARD(Args, args)...).first;
+        }
+        std::pair<iterator, bool> insert(value_type const& x)
+        {
+            return emplace(x);
+        }
+        std::pair<iterator, bool> insert(value_type&& x)
+        {
+            return emplace(HPX_MOVE(x));
+        }
+        iterator insert(const_iterator position, value_type const& x)
+        {
+            return emplace_hint(position, x);
+        }
+        iterator insert(const_iterator position, value_type&& x)
+        {
+            return emplace_hint(position, HPX_MOVE(x));
+        }
+        template <typename P,
+            typename Enable = std::enable_if_t<
+                std::is_constructible_v<std::pair<key_type, mapped_type>, P&&>>>
+        std::pair<iterator, bool> insert(P&& x)
+        {
+            return emplace(HPX_FORWARD(P, x));
+        }
+        template <typename P,
+            typename Enable = std::enable_if_t<
+                std::is_constructible_v<std::pair<key_type, mapped_type>, P&&>>>
+        iterator insert(const_iterator position, P&& x)
+        {
+            return emplace_hint(position, HPX_FORWARD(P, x));
+        }
+        template <typename InputIterator>
+        void insert(InputIterator first, InputIterator last)
+        {
+            auto const prev_size = size();
+            for (auto it = first; it != last; ++it)
+            {
+                c.keys.push_back(it->first);
+                c.values.push_back(it->second);
+            }
+
+            mutable_iterator inserted_first(
+                c.keys.begin() + prev_size, c.values.begin() + prev_size);
+            mutable_iterator inserted_last(c.keys.end(), c.values.end());
+#if USE_CONCEPTS
+            std::ranges::sort(inserted_first, inserted_last, value_comp());
+#else
+            std::sort(inserted_first, inserted_last, value_comp());
+#endif
+
+            if (!prev_size)
+                return;
+
+            mutable_iterator mutable_first(c.keys.begin(), c.values.begin());
+#if USE_CONCEPTS
+            std::ranges::inplace_merge(
+                mutable_first, inserted_first, inserted_last, value_comp());
+#else
+            std::inplace_merge(
+                mutable_first, inserted_first, inserted_last, value_comp());
+#endif
+        }
+        template <typename InputIterator>
+        void insert(sorted_unique_t, InputIterator first, InputIterator last)
+        {
+            auto const prev_size = size();
+            for (auto it = first; it != last; ++it)
+            {
+                c.keys.push_back(it->first);
+                c.values.push_back(it->second);
+            }
+
+            mutable_iterator inserted_first(
+                c.keys.begin() + prev_size, c.values.begin() + prev_size);
+            mutable_iterator inserted_last(c.keys.end(), c.values.end());
+
+            if (!prev_size)
+                return;
+
+            mutable_iterator mutable_first(c.keys.begin(), c.values.begin());
+#if USE_CONCEPTS
+            std::ranges::inplace_merge(
+                mutable_first, inserted_first, inserted_last, value_comp());
+#else
+            std::inplace_merge(
+                mutable_first, inserted_first, inserted_last, value_comp());
+#endif
+        }
+        void insert(std::initializer_list<value_type> il)
+        {
+            insert(il.begin(), il.end());
+        }
+        void insert(sorted_unique_t s, std::initializer_list<value_type> il)
+        {
+            insert(s, il.begin(), il.end());
+        }
+
+        containers extract() &&
+        {
+            scoped_clear _(this);
+            return HPX_MOVE(c);
+        }
+        void replace(
+            key_container_type&& key_cont, mapped_container_type&& mapped_cont)
+        {
+            scoped_clear _(this);
+            c.keys = HPX_MOVE(key_cont);
+            c.values = HPX_MOVE(mapped_cont);
+            _.release();
+        }
+
+        template <typename... Args,
+            typename Enable = std::enable_if_t<
+                std::is_constructible_v<mapped_type, Args&&...>>>
+        std::pair<iterator, bool> try_emplace(key_type const& k, Args&&... args)
+        {
+            auto it = key_lower_bound(k);
+            if (it == c.keys.end() || compare(*it, k) || compare(k, *it))
+            {
+                auto values_it =
+                    c.values.emplace(project(it), HPX_FORWARD(Args, args)...);
+                it = c.keys.insert(it, k);
+                return std::pair<iterator, bool>(iterator(it, values_it), true);
+            }
+            return std::pair<iterator, bool>(iterator(it, project(it)), false);
+        }
+        template <typename... Args,
+            typename Enable = std::enable_if_t<
+                std::is_constructible_v<mapped_type, Args&&...>>>
+        std::pair<iterator, bool> try_emplace(key_type&& k, Args&&... args)
+        {
+            auto it = key_lower_bound(k);
+            if (it == c.keys.end() || compare(*it, k) || compare(k, *it))
+            {
+                auto values_it =
+                    c.values.emplace(project(it), HPX_FORWARD(Args, args)...);
+                it = c.keys.insert(it, HPX_FORWARD(key_type, k));
+                return std::pair<iterator, bool>(iterator(it, values_it), true);
+            }
+            return std::pair<iterator, bool>(iterator(it, project(it)), false);
+        }
+        template <typename... Args,
+            typename Enable = std::enable_if_t<
+                std::is_constructible_v<mapped_type, Args&&...>>>
+        iterator try_emplace(const_iterator, key_type const& k, Args&&... args)
+        {
+            return try_emplace(k, HPX_FORWARD(Args, args)...).first;
+        }
+        template <typename... Args,
+            typename Enable = std::enable_if_t<
+                std::is_constructible_v<mapped_type, Args&&...>>>
+        iterator try_emplace(const_iterator, key_type&& k, Args&&... args)
+        {
+            return try_emplace(
+                HPX_FORWARD(key_type, k), HPX_FORWARD(Args, args)...)
+                .first;
+        }
+
+        template <typename M,
+            typename Enable =
+                std::enable_if_t<std::is_assignable_v<mapped_type&, M> &&
+                    std::is_constructible_v<mapped_type, M&&>>>
+        std::pair<iterator, bool> insert_or_assign(key_type const& k, M&& obj)
+        {
+            auto it = key_lower_bound(k);
+            if (it == c.keys.end() || compare(*it, k) || compare(k, *it))
+            {
+                auto values_it =
+                    c.values.insert(project(it), HPX_FORWARD(M, obj));
+                it = c.keys.insert(it, k);
+                return std::pair<iterator, bool>(iterator(it, values_it), true);
+            }
+            auto values_it = project(it);
+            *values_it = HPX_FORWARD(M, obj);
+            return std::pair<iterator, bool>(iterator(it, values_it), false);
+        }
+        template <typename M,
+            typename Enable =
+                std::enable_if_t<std::is_assignable_v<mapped_type&, M> &&
+                    std::is_constructible_v<mapped_type, M&&>>>
+        std::pair<iterator, bool> insert_or_assign(key_type&& k, M&& obj)
+        {
+            auto it = key_lower_bound(k);
+            if (it == c.keys.end() || compare(*it, k) || compare(k, *it))
+            {
+                auto values_it =
+                    c.values.insert(project(it), HPX_FORWARD(M, obj));
+                it = c.keys.insert(it, HPX_FORWARD(key_type, k));
+                return std::pair<iterator, bool>(iterator(it, values_it), true);
+            }
+            auto values_it = project(it);
+            *values_it = HPX_FORWARD(M, obj);
+            return std::pair<iterator, bool>(iterator(it, values_it), false);
+        }
+        template <typename M,
+            typename Enable =
+                std::enable_if_t<std::is_assignable_v<mapped_type&, M> &&
+                    std::is_constructible_v<mapped_type, M&&>>>
+        iterator insert_or_assign(const_iterator, key_type const& k, M&& obj)
+        {
+            return insert_or_assign(k, HPX_FORWARD(M, obj)).first;
+        }
+        template <typename M,
+            typename Enable =
+                std::enable_if_t<std::is_assignable_v<mapped_type&, M> &&
+                    std::is_constructible_v<mapped_type, M&&>>>
+        iterator insert_or_assign(const_iterator, key_type&& k, M&& obj)
+        {
+            return insert_or_assign(
+                HPX_FORWARD(key_type, k), HPX_FORWARD(M, obj))
+                .first;
+        }
+
+        iterator erase(iterator position)
+        {
+            return iterator(c.keys.erase(position.key_iter()),
+                c.values.erase(position.mapped_iter()));
+        }
+        iterator erase(const_iterator position)
+        {
+            return iterator(c.keys.erase(position.key_iter()),
+                c.values.erase(position.mapped_iter()));
+        }
+        size_type erase(key_type const& x)
+        {
+            auto it = key_find(x);
+            if (it == c.keys.end())
+                return static_cast<size_type>(0);
+            c.values.erase(project(it));
+            c.keys.erase(it);
+            return static_cast<size_type>(1);
+        }
+        iterator erase(const_iterator first, const_iterator last)
+        {
+            return iterator(c.keys.erase(first.key_iter(), last.key_iter()),
+                c.values.erase(first.mapped_iter(), last.mapped_iter()));
+        }
+
+        void swap(flat_map& fm) noexcept(
+            std::is_nothrow_swappable_v<key_compare>)
+        {
+            using std::swap;
+            swap(compare, fm.compare);
+            swap(c.keys, fm.c.keys);
+            swap(c.values, fm.c.values);
+        }
+        void clear() noexcept
+        {
+            c.keys.clear();
+            c.values.clear();
+        }
+
+        // observers
+        key_compare key_comp() const
+        {
+            return compare;
+        }
+        value_compare value_comp() const
+        {
+            return value_compare(compare);
+        }
+        key_container_type const& keys() const noexcept
+        {
+            return c.keys;
+        }
+        mapped_container_type const& values() const noexcept
+        {
+            return c.values;
+        }
+
+        // map operations
+        iterator find(key_type const& x)
+        {
+            auto it = key_find(x);
+            return iterator(it, project(it));
+        }
+        const_iterator find(key_type const& x) const
+        {
+            auto it = key_find(x);
+            return const_iterator(it, project(it));
+        }
+        template <typename K>
+        iterator find(K const& x)
+        {
+            auto it = key_find(x);
+            return iterator(it, project(it));
+        }
+        template <typename K>
+        const_iterator find(K const& x) const
+        {
+            auto it = key_find(x);
+            return iterator(it, project(it));
+        }
+        size_type count(key_type const& x) const
+        {
+            auto it = key_find(x);
+            return static_cast<size_type>(it == c.keys.end() ? 0 : 1);
+        }
+        template <typename K>
+        size_type count(K const& x) const
+        {
+            auto it = key_find(x);
+            return static_cast<size_type>(it == c.keys.end() ? 0 : 1);
+        }
+        bool contains(key_type const& x) const
+        {
+            return count(x) == static_cast<size_type>(1);
+        }
+        template <typename K>
+        bool contains(K const& x) const
+        {
+            return count(x) == static_cast<size_type>(1);
+        }
+        iterator lower_bound(key_type const& x)
+        {
+            auto it = key_lower_bound(x);
+            return iterator(it, project(it));
+        }
+        const_iterator lower_bound(key_type const& x) const
+        {
+            auto it = key_lower_bound(x);
+            return const_iterator(it, project(it));
+        }
+        template <typename K>
+        iterator lower_bound(K const& x)
+        {
+            auto it = key_lower_bound(x);
+            return iterator(it, project(it));
+        }
+        template <typename K>
+        const_iterator lower_bound(K const& x) const
+        {
+            auto it = key_lower_bound(x);
+            return const_iterator(it, project(it));
+        }
+        iterator upper_bound(key_type const& x)
+        {
+            auto it = key_upper_bound(x);
+            return iterator(it, project(it));
+        }
+        const_iterator upper_bound(key_type const& x) const
+        {
+            auto it = key_upper_bound(x);
+            return const_iterator(it, project(it));
+        }
+        template <typename K>
+        iterator upper_bound(K const& x)
+        {
+            auto it = key_upper_bound(x);
+            return iterator(it, project(it));
+        }
+        template <typename K>
+        const_iterator upper_bound(K const& x) const
+        {
+            auto it = key_upper_bound(x);
+            return const_iterator(it, project(it));
+        }
+        std::pair<iterator, iterator> equal_range(key_type const& k)
+        {
+            iterator const first = lower_bound(k);
+            iterator const last = find_if(first, end(),
+                [&](auto const& x) { return compare(k, x.first); });
+            return std::pair<iterator, iterator>(first, last);
+        }
+        std::pair<const_iterator, const_iterator> equal_range(
+            key_type const& k) const
+        {
+            const_iterator const first = lower_bound(k);
+            const_iterator const last = find_if(first, end(),
+                [&](auto const& x) { return compare(k, x.first); });
+            return std::pair<const_iterator, const_iterator>(first, last);
+        }
+        template <typename K>
+        std::pair<iterator, iterator> equal_range(K const& k)
+        {
+            iterator const first = lower_bound(k);
+            iterator const last = find_if(first, end(),
+                [&](auto const& x) { return compare(k, x.first); });
+            return std::pair<iterator, iterator>(first, last);
+        }
+        template <typename K>
+        std::pair<const_iterator, const_iterator> equal_range(K const& k) const
+        {
+            const_iterator const first = lower_bound(k);
+            const_iterator const last = find_if(first, end(),
+                [&](auto const& x) { return compare(k, x.first); });
+            return std::pair<const_iterator, const_iterator>(first, last);
+        }
+
+        friend bool operator==(flat_map const& x, flat_map const& y)
+        {
+#if USE_CONCEPTS
+            return std::ranges::equal(x, y);
+#else
+            return std::equal(x.begin(), x.end(), y.begin(), y.end());
+#endif
+        }
+        friend bool operator!=(flat_map const& x, flat_map const& y)
+        {
+            return !(x == y);
+        }
+        friend bool operator<(flat_map const& x, flat_map const& y)
+        {
+#if USE_CONCEPTS
+            return std::ranges::lexicographical_compare(
+                x, y, [](auto lhs, auto rhs) { return lhs < rhs; });
+#else
+            return std::lexicographical_compare(
+                x.begin(), x.end(), y.begin(), y.end());
+#endif
+        }
+        friend bool operator>(flat_map const& x, flat_map const& y)
+        {
+            return y < x;
+        }
+        friend bool operator<=(flat_map const& x, flat_map const& y)
+        {
+            return !(y < x);
+        }
+        friend bool operator>=(flat_map const& x, flat_map const& y)
+        {
+            return !(x < y);
+        }
+
+        friend void swap(flat_map& x, flat_map& y) noexcept(noexcept(x.swap(y)))
+        {
+            return x.swap(y);
+        }
+
+    private:
+        containers c;           // exposition only
+        key_compare compare;    // exposition only
+        // exposition only
+        struct scoped_clear
+        {
+            explicit scoped_clear(flat_map* fm)
+              : fm_(fm)
+            {
+            }
+
+            scoped_clear(scoped_clear const&) = delete;
+            scoped_clear(scoped_clear&& rhs) noexcept
+              : fm_(rhs.fm_)
+            {
+                rhs.fm_ = nullptr;
+            }
+
+            scoped_clear& operator=(scoped_clear const&) = delete;
+            scoped_clear& operator=(scoped_clear&& rhs) noexcept
+            {
+                fm_ = rhs.fm_;
+                rhs.fm_ = nullptr;
+                return *this;
+            }
+
+            ~scoped_clear()
+            {
+                if (fm_)
+                    fm_->clear();
+            }
+            void release()
+            {
+                fm_ = nullptr;
+            }
+
+        private:
+            flat_map* fm_;
+        };
+
+        using key_iter_t = typename KeyContainer::iterator;
+        using key_const_iter_t = typename KeyContainer::const_iterator;
+        using mapped_iter_t = typename MappedContainer::iterator;
+        using mapped_const_iter_t = typename MappedContainer::const_iterator;
+
+        using mutable_iterator = flat_map_iterator<key_type&, mapped_type&,
+            key_iter_t, mapped_iter_t>;
+
+        mapped_iter_t project(key_iter_t key_it)
+        {
+            return c.values.begin() + (key_it - c.keys.begin());
+        }
+        mapped_const_iter_t project(key_const_iter_t key_it) const
+        {
+            return c.values.begin() + (key_it - c.keys.begin());
+        }
+
+        template <typename K>
+        key_iter_t key_lower_bound(K const& k)
+        {
+#if USE_CONCEPTS
+            return std::ranges::lower_bound(c.keys, k, compare);
+#else
+            return std::lower_bound(c.keys.begin(), c.keys.end(), k, compare);
+#endif
+        }
+        template <typename K>
+        key_const_iter_t key_lower_bound(K const& k) const
+        {
+#if USE_CONCEPTS
+            return ranges::lower_bound(c.keys, k, compare);
+#else
+            return std::lower_bound(c.keys.begin(), c.keys.end(), k, compare);
+#endif
+        }
+        template <typename K>
+        key_iter_t key_upper_bound(K const& k)
+        {
+#if USE_CONCEPTS
+            return ranges::upper_bound(c.keys, k, compare);
+#else
+            return std::upper_bound(c.keys.begin(), c.keys.end(), k, compare);
+#endif
+        }
+        template <typename K>
+        key_const_iter_t key_upper_bound(K const& k) const
+        {
+#if USE_CONCEPTS
+            return ranges::upper_bound(c.keys, k, compare);
+#else
+            return std::upper_bound(c.keys.begin(), c.keys.end(), k, compare);
+#endif
+        }
+        template <typename K>
+        key_iter_t key_find(K const& k)
+        {
+            auto it = key_lower_bound(k);
+            if (it != c.keys.end() && (compare(*it, k) || compare(k, *it)))
+                it = c.keys.end();
+            return it;
+        }
+        template <typename K>
+        key_const_iter_t key_find(K const& k) const
+        {
+            auto it = key_lower_bound(k);
+            if (it != c.keys.end() && (compare(*it, k) || compare(k, *it)))
+                it = c.keys.end();
+            return it;
+        }
+    };
+}    // namespace hpx::detail
+
+#undef USE_CONCEPTS
+#undef CMCSTL2_CONCEPTS
+#undef CPP20_CONCEPTS

--- a/libs/core/datastructures/include/hpx/datastructures/detail/flat_set.hpp
+++ b/libs/core/datastructures/include/hpx/datastructures/detail/flat_set.hpp
@@ -1,0 +1,933 @@
+//  Copyright (C) 2019-2022 T. Zachary Laine
+//  Copyright (c) 2023 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include <hpx/config.hpp>
+
+#include <algorithm>
+#include <iterator>
+#include <vector>
+
+#if defined(GNUC) && !defined(clang)
+#include <bits/uses_allocator.h>
+#endif
+
+// clang-format off
+#if (201703L < __cplusplus && defined(cpp_lib_ranges))
+#define CPP20_CONCEPTS 1
+#else
+#define CPP20_CONCEPTS 0
+#endif
+#if (201703L <= __cplusplus && defined(__has_include) &&                       \
+    __has_include(<stl2/ranges.hpp>))
+#define CMCSTL2_CONCEPTS 1
+#else
+#define CMCSTL2_CONCEPTS 0
+#endif
+#define USE_CONCEPTS CPP20_CONCEPTS || CMCSTL2_CONCEPTS
+// clang-format on
+
+#if CPP20_CONCEPTS
+#include <ranges>
+#elif CMCSTL2_CONCEPTS
+#include <stl2/algorithm.hpp>
+#include <stl2/ranges.hpp>
+#endif
+
+#include <cstddef>
+#include <initializer_list>
+#include <stdexcept>
+#include <type_traits>
+#include <utility>
+
+namespace hpx::detail {
+
+#if CMCSTL2_CONCEPTS && !CPP20_CONCEPTS
+    using namespace std::experimental;
+#endif
+
+    // TODO: Remove once we have this in C++20 mode ubiquitously.
+    template <typename T>
+    using remove_cvref_t = std::remove_cv_t<std::remove_reference_t<T>>;
+
+    struct sorted_unique_t
+    {
+        explicit sorted_unique_t() = default;
+    };
+    inline constexpr sorted_unique_t sorted_unique{};
+
+    template <typename KeyRef, typename KeyIter>
+    struct flat_set_iterator
+    {
+        static_assert(std::is_reference_v<KeyRef>);
+
+        using iterator_category = std::random_access_iterator_tag;
+        using value_type = remove_cvref_t<KeyRef>;
+        using difference_type =
+            typename std::iterator_traits<KeyIter>::difference_type;
+        using reference = KeyRef;
+
+        struct arrow_proxy
+        {
+            constexpr reference* operator->() noexcept
+            {
+                return &value_;
+            }
+            constexpr reference const* operator->() const noexcept
+            {
+                return &value_;
+            }
+            explicit arrow_proxy(reference value) noexcept
+              : value_(HPX_MOVE(value))
+            {
+            }
+
+        private:
+            reference value_;
+        };
+        using pointer = arrow_proxy;
+
+        flat_set_iterator() = default;
+        explicit flat_set_iterator(KeyIter key_it)
+          : key_it_(key_it)
+        {
+        }
+
+        template <typename KeyRef2, typename KeyIter2,
+            typename Enable =
+                std::enable_if_t<std::is_convertible_v<KeyRef2, KeyRef> &&
+                    std::is_convertible_v<KeyIter2, KeyIter>>>
+        flat_set_iterator(flat_set_iterator<KeyRef2, KeyIter2> other)
+          : key_it_(other.key_it_)
+        {
+        }
+
+        constexpr decltype(auto) operator*() const noexcept
+        {
+            return ref();
+        }
+        constexpr pointer operator->() const noexcept
+        {
+            return arrow_proxy(ref());
+        }
+
+        constexpr auto& operator[](difference_type n) const noexcept
+        {
+            return *(key_it_ + n);
+        }
+
+        flat_set_iterator operator+(difference_type n) const noexcept
+        {
+            return flat_set_iterator(key_it_ + n);
+        }
+        flat_set_iterator operator-(difference_type n) const noexcept
+        {
+            return flat_set_iterator(key_it_ - n);
+        }
+
+        flat_set_iterator& operator++() noexcept
+        {
+            ++key_it_;
+            return *this;
+        }
+        flat_set_iterator operator++(int) noexcept
+        {
+            flat_set_iterator tmp(*this);
+            ++key_it_;
+            return tmp;
+        }
+
+        flat_set_iterator& operator--() noexcept
+        {
+            --key_it_;
+            return *this;
+        }
+        flat_set_iterator operator--(int) noexcept
+        {
+            flat_set_iterator tmp(*this);
+            --key_it_;
+            return tmp;
+        }
+
+        flat_set_iterator& operator+=(difference_type n) noexcept
+        {
+            key_it_ += n;
+            return *this;
+        }
+        flat_set_iterator& operator-=(difference_type n) noexcept
+        {
+            key_it_ -= n;
+            return *this;
+        }
+
+        KeyIter key_iter() const
+        {
+            return key_it_;
+        }
+
+        friend bool operator==(flat_set_iterator lhs, flat_set_iterator rhs)
+        {
+            return lhs.key_it_ == rhs.key_it_;
+        }
+        friend bool operator!=(flat_set_iterator lhs, flat_set_iterator rhs)
+        {
+            return !(lhs == rhs);
+        }
+
+        friend bool operator<(flat_set_iterator lhs, flat_set_iterator rhs)
+        {
+            return lhs.key_it_ < rhs.key_it_;
+        }
+        friend bool operator<=(flat_set_iterator lhs, flat_set_iterator rhs)
+        {
+            return lhs == rhs || lhs < rhs;
+        }
+        friend bool operator>(flat_set_iterator lhs, flat_set_iterator rhs)
+        {
+            return rhs < lhs;
+        }
+        friend bool operator>=(flat_set_iterator lhs, flat_set_iterator rhs)
+        {
+            return lhs == rhs || rhs < lhs;
+        }
+
+        friend difference_type operator-(
+            flat_set_iterator lhs, flat_set_iterator rhs)
+        {
+            return lhs.key_it_ - rhs.key_it_;
+        }
+
+    private:
+        template <typename KeyRef2, typename KeyIter2>
+        friend struct flat_set_iterator;
+
+        auto& ref() const
+        {
+            return *key_it_;
+        }
+
+        KeyIter key_it_;
+    };
+
+    template <typename Key, typename Compare = std::less<Key>,
+        typename KeyContainer = std::vector<Key>>
+    class flat_set
+    {
+        template <typename Alloc>
+        using uses =
+            std::enable_if_t<std::uses_allocator<KeyContainer, Alloc>::value>;
+
+        template <typename Container, typename = void>
+        struct has_begin_end : std::false_type
+        {
+        };
+        template <typename Container>
+        struct has_begin_end<Container,
+            std::void_t<decltype(std::begin(std::declval<Container>())),
+                decltype(std::end(std::declval<Container>()))>> : std::true_type
+        {
+        };
+        template <typename Container>
+        using container = std::enable_if_t<has_begin_end<Container>::value>;
+
+    public:
+        // types:
+        using key_type = Key;
+        using value_type = Key;
+        using key_compare = Compare;
+        using value_compare = Compare;
+        using reference = value_type&;
+        using const_reference = key_type const&;
+        using size_type = std::size_t;
+        using difference_type = ptrdiff_t;
+        using iterator = flat_set_iterator<value_type&,
+            typename KeyContainer::const_iterator>;    // see 21.2
+        using const_iterator = flat_set_iterator<value_type const&,
+            typename KeyContainer::const_iterator>;    // see 21.2
+        using reverse_iterator = flat_set_iterator<value_type&,
+            typename KeyContainer::const_reverse_iterator>;    // see 21.2
+        using const_reverse_iterator = flat_set_iterator<value_type const&,
+            typename KeyContainer::const_reverse_iterator>;    // see 21.2
+        using key_container_type = KeyContainer;
+
+        // ??, construct/copy/destroy
+        flat_set()
+          : flat_set(key_compare())
+        {
+        }
+        explicit flat_set(key_container_type key_cont)
+          : c{HPX_MOVE(key_cont)}
+          , compare(key_compare())
+        {
+            mutable_iterator first(c.begin());
+            mutable_iterator last(c.end());
+#if USE_CONCEPTS
+            std::ranges::sort(first, last, key_comp());
+#else
+            std::sort(first, last, key_comp());
+#endif
+        }
+        template <typename Alloc, typename Enable = uses<Alloc>>
+        flat_set(key_container_type const& key_cont, Alloc const& a)
+          : c{key_container_type(key_cont, a)}
+          , compare()
+        {
+            mutable_iterator first(c.begin());
+            mutable_iterator last(c.end());
+#if USE_CONCEPTS
+            std::ranges::sort(first, last, key_comp());
+#else
+            std::sort(first, last, key_comp());
+#endif
+        }
+        template <typename Container, typename Enable = container<Container>>
+        explicit flat_set(
+            Container const& cont, key_compare const& comp = key_compare())
+          : flat_set(std::begin(cont), std::end(cont), comp)
+        {
+        }
+        template <typename Container, typename Alloc,
+            typename Enable1 = container<Container>,
+            typename Enable2 = uses<Alloc>>
+        flat_set(Container const& cont, Alloc const& a)
+          : flat_set(std::begin(cont), std::end(cont), a)
+        {
+        }
+        flat_set(sorted_unique_t, key_container_type key_cont)
+          : c{HPX_MOVE(key_cont)}
+          , compare(key_compare())
+        {
+        }
+        template <typename Alloc, typename Enable = uses<Alloc>>
+        flat_set(
+            sorted_unique_t, key_container_type const& key_cont, Alloc const& a)
+          : c{key_container_type(key_cont, a)}
+          , compare()
+        {
+        }
+        template <typename Container, typename Enable = container<Container>>
+        flat_set(sorted_unique_t s, Container const& cont,
+            key_compare const& comp = key_compare())
+          : flat_set(s, std::begin(cont), std::end(cont), comp)
+        {
+        }
+        template <typename Container, typename Alloc,
+            typename Enable1 = container<Container>,
+            typename Enable2 = uses<Alloc>>
+        flat_set(sorted_unique_t s, Container const& cont, Alloc const& a)
+          : c{key_container_type(a)}
+          , compare()
+        {
+            c.reserve(cont.size());
+            insert(s, std::begin(cont), std::end(cont));
+        }
+        explicit flat_set(key_compare const& comp)
+          : c()
+          , compare(comp)
+        {
+        }
+        template <typename Alloc, typename Enable = uses<Alloc>>
+        flat_set(key_compare const& comp, Alloc const& a)
+          : c{key_container_type(a)}
+          , compare(comp)
+        {
+        }
+        template <typename Alloc, typename Enable = uses<Alloc>>
+        explicit flat_set(Alloc const& a)
+          : c{key_container_type(a)}
+          , compare()
+        {
+        }
+        template <typename InputIterator>
+        flat_set(InputIterator first, InputIterator last,
+            key_compare const& comp = key_compare())
+          : c()
+          , compare(comp)
+        {
+            insert(first, last);
+        }
+        template <typename InputIterator, typename Alloc,
+            typename Enable = uses<Alloc>>
+        flat_set(InputIterator first, InputIterator last,
+            key_compare const& comp, Alloc const& a)
+          : c{key_container_type(a)}
+          , compare(comp)
+        {
+            insert(first, last);
+        }
+        template <typename InputIterator, typename Alloc,
+            typename Enable = uses<Alloc>>
+        flat_set(InputIterator first, InputIterator last, Alloc const& a)
+          : flat_set(first, last, key_compare(), a)
+        {
+        }
+        template <typename InputIterator>
+        flat_set(sorted_unique_t s, InputIterator first, InputIterator last,
+            key_compare const& comp = key_compare())
+          : c()
+          , compare(comp)
+        {
+            insert(s, first, last);
+        }
+        template <typename InputIterator, typename Alloc,
+            typename Enable = uses<Alloc>>
+        flat_set(sorted_unique_t s, InputIterator first, InputIterator last,
+            key_compare const& comp, Alloc const& a)
+          : c{key_container_type(a)}
+          , compare(comp)
+        {
+            insert(s, first, last);
+        }
+        template <typename InputIterator, typename Alloc,
+            typename Enable = uses<Alloc>>
+        flat_set(sorted_unique_t s, InputIterator first, InputIterator last,
+            Alloc const& a)
+          : flat_set(s, first, last, key_compare(), a)
+        {
+        }
+        flat_set(std::initializer_list<value_type>&& il,
+            key_compare const& comp = key_compare())
+          : flat_set(il, comp)
+        {
+        }
+        template <typename Alloc, typename Enable = uses<Alloc>>
+        flat_set(std::initializer_list<value_type>&& il,
+            key_compare const& comp, Alloc const& a)
+          : flat_set(std::begin(il), std::end(il), comp, a)
+        {
+        }
+        template <typename Alloc, typename Enable = uses<Alloc>>
+        flat_set(std::initializer_list<value_type>&& il, Alloc const& a)
+          : flat_set(std::begin(il), std::end(il), key_compare(), a)
+        {
+        }
+        flat_set(sorted_unique_t s, std::initializer_list<value_type>&& il,
+            key_compare const& comp = key_compare())
+          : flat_set(s, il, comp)
+        {
+        }
+        template <typename Alloc, typename Enable = uses<Alloc>>
+        flat_set(sorted_unique_t s, std::initializer_list<value_type>&& il,
+            key_compare const& comp, Alloc const& a)
+          : flat_set(s, std::begin(il), std::end(il), comp, a)
+        {
+        }
+        template <typename Alloc, typename Enable = uses<Alloc>>
+        flat_set(sorted_unique_t s, std::initializer_list<value_type>&& il,
+            Alloc const& a)
+          : flat_set(s, std::begin(il), std::end(il), key_compare(), a)
+        {
+        }
+        flat_set& operator=(std::initializer_list<value_type> il)
+        {
+            flat_set tmp(il, compare);
+            swap(tmp);
+            return *this;
+        }
+
+        // iterators
+        iterator begin() noexcept
+        {
+            return iterator(c.begin());
+        }
+        const_iterator begin() const noexcept
+        {
+            return const_iterator(c.begin());
+        }
+        iterator end() noexcept
+        {
+            return iterator(c.end());
+        }
+        const_iterator end() const noexcept
+        {
+            return const_iterator(c.end());
+        }
+        reverse_iterator rbegin() noexcept
+        {
+            return reverse_iterator(c.rbegin());
+        }
+        const_reverse_iterator rbegin() const noexcept
+        {
+            return const_reverse_iterator(c.rbegin());
+        }
+        reverse_iterator rend() noexcept
+        {
+            return reverse_iterator(c.rend());
+        }
+        const_reverse_iterator rend() const noexcept
+        {
+            return const_reverse_iterator(c.rend());
+        }
+
+        const_iterator cbegin() const noexcept
+        {
+            return begin();
+        }
+        const_iterator cend() const noexcept
+        {
+            return end();
+        }
+        const_reverse_iterator crbegin() const noexcept
+        {
+            return rbegin();
+        }
+        const_reverse_iterator crend() const noexcept
+        {
+            return rend();
+        }
+
+        // ??, capacity
+        [[nodiscard]] bool empty() const noexcept
+        {
+            return c.empty();
+        }
+        size_type size() const noexcept
+        {
+            return c.size();
+        }
+        size_type max_size() const noexcept
+        {
+            return c.max_size();
+        }
+
+        // ??, modifiers
+        template <typename... Args,
+            typename Enable =
+                std::enable_if_t<std::is_constructible_v<key_type, Args&&...>>>
+        std::pair<iterator, bool> emplace(Args&&... args)
+        {
+            key_type k(HPX_FORWARD(Args, args)...);
+            auto it = key_lower_bound(k);
+            if (it == c.end() || compare(*it, k) || compare(k, *it))
+            {
+                it = c.insert(it, k);
+                return std::pair<iterator, bool>(iterator(it), true);
+            }
+            return std::pair<iterator, bool>(iterator(it), false);
+        }
+        template <typename... Args,
+            typename Enable =
+                std::enable_if_t<std::is_constructible_v<key_type, Args&&...>>>
+        iterator emplace_hint(const_iterator, Args&&... args)
+        {
+            return emplace(HPX_FORWARD(Args, args)...).first;
+        }
+        std::pair<iterator, bool> insert(value_type const& x)
+        {
+            return emplace(x);
+        }
+        std::pair<iterator, bool> insert(value_type&& x)
+        {
+            return emplace(HPX_MOVE(x));
+        }
+        iterator insert(const_iterator position, value_type const& x)
+        {
+            return emplace_hint(position, x);
+        }
+        iterator insert(const_iterator position, value_type&& x)
+        {
+            return emplace_hint(position, HPX_MOVE(x));
+        }
+        template <typename P,
+            typename Enable =
+                std::enable_if_t<std::is_constructible_v<key_type, P&&>>>
+        std::pair<iterator, bool> insert(P&& x)
+        {
+            return emplace(HPX_FORWARD(P, x));
+        }
+        template <typename P,
+            typename Enable =
+                std::enable_if_t<std::is_constructible_v<key_type, P&&>>>
+        iterator insert(const_iterator position, P&& x)
+        {
+            return emplace_hint(position, HPX_FORWARD(P, x));
+        }
+        template <typename InputIterator>
+        void insert(InputIterator first, InputIterator last)
+        {
+            auto const prev_size = size();
+            for (auto it = first; it != last; ++it)
+            {
+                c.push_back(*it);
+            }
+
+            mutable_iterator inserted_first(c.begin() + prev_size);
+            mutable_iterator inserted_last(c.end());
+#if USE_CONCEPTS
+            std::ranges::sort(inserted_first, inserted_last, key_comp());
+#else
+            std::sort(inserted_first, inserted_last, key_comp());
+#endif
+
+            if (!prev_size)
+                return;
+
+            mutable_iterator mutable_first(c.begin());
+#if USE_CONCEPTS
+            std::ranges::inplace_merge(
+                mutable_first, inserted_first, inserted_last, key_comp());
+#else
+            std::inplace_merge(
+                mutable_first, inserted_first, inserted_last, key_comp());
+#endif
+        }
+        template <typename InputIterator>
+        void insert(sorted_unique_t, InputIterator first, InputIterator last)
+        {
+            auto const prev_size = size();
+            for (auto it = first; it != last; ++it)
+            {
+                c.push_back(*it);
+            }
+
+            mutable_iterator inserted_first(c.begin() + prev_size);
+            mutable_iterator inserted_last(c.end());
+
+            if (!prev_size)
+                return;
+
+            mutable_iterator mutable_first(c.begin());
+#if USE_CONCEPTS
+            std::ranges::inplace_merge(
+                mutable_first, inserted_first, inserted_last, key_comp());
+#else
+            std::inplace_merge(
+                mutable_first, inserted_first, inserted_last, key_comp());
+#endif
+        }
+        void insert(std::initializer_list<value_type> il)
+        {
+            insert(il.begin(), il.end());
+        }
+        void insert(sorted_unique_t s, std::initializer_list<value_type> il)
+        {
+            insert(s, il.begin(), il.end());
+        }
+
+        key_container_type extract() &&
+        {
+            scoped_clear _(this);
+            return HPX_MOVE(c);
+        }
+        void replace(key_container_type&& key_cont)
+        {
+            scoped_clear _(this);
+            c = HPX_MOVE(key_cont);
+            _.release();
+        }
+
+        iterator erase(iterator position)
+        {
+            return iterator(c.erase(position.key_iter()));
+        }
+        iterator erase(const_iterator position)
+        {
+            return iterator(c.erase(position.key_iter()));
+        }
+        size_type erase(key_type const& x)
+        {
+            auto it = key_find(x);
+            if (it == c.end())
+                return static_cast<size_type>(0);
+            c.erase(it);
+            return static_cast<size_type>(1);
+        }
+        iterator erase(const_iterator first, const_iterator last)
+        {
+            return iterator(c.erase(first.key_iter(), last.key_iter()));
+        }
+
+        void swap(flat_set& fm) noexcept(
+            std::is_nothrow_swappable_v<key_compare>)
+        {
+            using std::swap;
+            swap(compare, fm.compare);
+            swap(c, fm.c);
+        }
+        void clear() noexcept
+        {
+            c.clear();
+        }
+
+        // observers
+        key_compare key_comp() const
+        {
+            return compare;
+        }
+        value_compare value_comp() const
+        {
+            return compare;
+        }
+        key_container_type const& keys() const noexcept
+        {
+            return c;
+        }
+
+        // map operations
+        iterator find(key_type const& x)
+        {
+            auto it = key_find(x);
+            return iterator(it);
+        }
+        const_iterator find(key_type const& x) const
+        {
+            auto it = key_find(x);
+            return const_iterator(it);
+        }
+        template <typename K>
+        iterator find(K const& x)
+        {
+            auto it = key_find(x);
+            return iterator(it);
+        }
+        template <typename K>
+        const_iterator find(K const& x) const
+        {
+            auto it = key_find(x);
+            return iterator(it);
+        }
+        size_type count(key_type const& x) const
+        {
+            auto it = key_find(x);
+            return static_cast<size_type>(it == c.end() ? 0 : 1);
+        }
+        template <typename K>
+        size_type count(K const& x) const
+        {
+            auto it = key_find(x);
+            return static_cast<size_type>(it == c.end() ? 0 : 1);
+        }
+        bool contains(key_type const& x) const
+        {
+            return count(x) == static_cast<size_type>(1);
+        }
+        template <typename K>
+        bool contains(K const& x) const
+        {
+            return count(x) == static_cast<size_type>(1);
+        }
+        iterator lower_bound(key_type const& x)
+        {
+            auto it = key_lower_bound(x);
+            return iterator(it);
+        }
+        const_iterator lower_bound(key_type const& x) const
+        {
+            auto it = key_lower_bound(x);
+            return const_iterator(it);
+        }
+        template <typename K>
+        iterator lower_bound(K const& x)
+        {
+            auto it = key_lower_bound(x);
+            return iterator(it);
+        }
+        template <typename K>
+        const_iterator lower_bound(K const& x) const
+        {
+            auto it = key_lower_bound(x);
+            return const_iterator(it);
+        }
+        iterator upper_bound(key_type const& x)
+        {
+            auto it = key_upper_bound(x);
+            return iterator(it);
+        }
+        const_iterator upper_bound(key_type const& x) const
+        {
+            auto it = key_upper_bound(x);
+            return const_iterator(it);
+        }
+        template <typename K>
+        iterator upper_bound(K const& x)
+        {
+            auto it = key_upper_bound(x);
+            return iterator(it);
+        }
+        template <typename K>
+        const_iterator upper_bound(K const& x) const
+        {
+            auto it = key_upper_bound(x);
+            return const_iterator(it);
+        }
+        std::pair<iterator, iterator> equal_range(key_type const& k)
+        {
+            iterator const first = lower_bound(k);
+            iterator const last = find_if(
+                first, end(), [&](auto const& x) { return compare(k, x); });
+            return std::pair<iterator, iterator>(first, last);
+        }
+        std::pair<const_iterator, const_iterator> equal_range(
+            key_type const& k) const
+        {
+            const_iterator const first = lower_bound(k);
+            const_iterator const last = find_if(
+                first, end(), [&](auto const& x) { return compare(k, x); });
+            return std::pair<const_iterator, const_iterator>(first, last);
+        }
+        template <typename K>
+        std::pair<iterator, iterator> equal_range(K const& k)
+        {
+            iterator const first = lower_bound(k);
+            iterator const last = find_if(
+                first, end(), [&](auto const& x) { return compare(k, x); });
+            return std::pair<iterator, iterator>(first, last);
+        }
+        template <typename K>
+        std::pair<const_iterator, const_iterator> equal_range(K const& k) const
+        {
+            const_iterator const first = lower_bound(k);
+            const_iterator const last = find_if(
+                first, end(), [&](auto const& x) { return compare(k, x); });
+            return std::pair<const_iterator, const_iterator>(first, last);
+        }
+
+        friend bool operator==(flat_set const& x, flat_set const& y)
+        {
+#if USE_CONCEPTS
+            return std::ranges::equal(x, y);
+#else
+            return std::equal(x.begin(), x.end(), y.begin(), y.end());
+#endif
+        }
+        friend bool operator!=(flat_set const& x, flat_set const& y)
+        {
+            return !(x == y);
+        }
+        friend bool operator<(flat_set const& x, flat_set const& y)
+        {
+#if USE_CONCEPTS
+            return std::ranges::lexicographical_compare(
+                x, y, [](auto lhs, auto rhs) { return lhs < rhs; });
+#else
+            return std::lexicographical_compare(
+                x.begin(), x.end(), y.begin(), y.end());
+#endif
+        }
+        friend bool operator>(flat_set const& x, flat_set const& y)
+        {
+            return y < x;
+        }
+        friend bool operator<=(flat_set const& x, flat_set const& y)
+        {
+            return !(y < x);
+        }
+        friend bool operator>=(flat_set const& x, flat_set const& y)
+        {
+            return !(x < y);
+        }
+
+        friend void swap(flat_set& x, flat_set& y) noexcept(noexcept(x.swap(y)))
+        {
+            return x.swap(y);
+        }
+
+    private:
+        key_container_type c;    // exposition only
+        key_compare compare;     // exposition only
+
+        // exposition only
+        struct scoped_clear
+        {
+            explicit scoped_clear(flat_set* fm)
+              : fm_(fm)
+            {
+            }
+
+            scoped_clear(scoped_clear const&) = delete;
+            scoped_clear(scoped_clear&& rhs) noexcept
+              : fm_(rhs.fm_)
+            {
+                rhs.fm_ = nullptr;
+            }
+
+            scoped_clear& operator=(scoped_clear const&) = delete;
+            scoped_clear& operator=(scoped_clear&& rhs) noexcept
+            {
+                fm_ = rhs.fm_;
+                rhs.fm_ = nullptr;
+                return *this;
+            }
+
+            ~scoped_clear()
+            {
+                if (fm_)
+                    fm_->clear();
+            }
+            void release()
+            {
+                fm_ = nullptr;
+            }
+
+        private:
+            flat_set* fm_;
+        };
+
+        using key_iter_t = typename KeyContainer::iterator;
+        using key_const_iter_t = typename KeyContainer::const_iterator;
+
+        using mutable_iterator = flat_set_iterator<key_type&, key_iter_t>;
+
+        template <typename K>
+        key_iter_t key_lower_bound(K const& k)
+        {
+#if USE_CONCEPTS
+            return std::ranges::lower_bound(c, k, compare);
+#else
+            return std::lower_bound(c.begin(), c.end(), k, compare);
+#endif
+        }
+        template <typename K>
+        key_const_iter_t key_lower_bound(K const& k) const
+        {
+#if USE_CONCEPTS
+            return ranges::lower_bound(c, k, compare);
+#else
+            return std::lower_bound(c.begin(), c.end(), k, compare);
+#endif
+        }
+        template <typename K>
+        key_iter_t key_upper_bound(K const& k)
+        {
+#if USE_CONCEPTS
+            return ranges::upper_bound(c, k, compare);
+#else
+            return std::upper_bound(c.begin(), c.end(), k, compare);
+#endif
+        }
+        template <typename K>
+        key_const_iter_t key_upper_bound(K const& k) const
+        {
+#if USE_CONCEPTS
+            return ranges::upper_bound(c, k, compare);
+#else
+            return std::upper_bound(c.begin(), c.end(), k, compare);
+#endif
+        }
+        template <typename K>
+        key_iter_t key_find(K const& k)
+        {
+            auto it = key_lower_bound(k);
+            if (it != c.end() && (compare(*it, k) || compare(k, *it)))
+                it = c.end();
+            return it;
+        }
+        template <typename K>
+        key_const_iter_t key_find(K const& k) const
+        {
+            auto it = key_lower_bound(k);
+            if (it != c.end() && (compare(*it, k) || compare(k, *it)))
+                it = c.end();
+            return it;
+        }
+    };
+}    // namespace hpx::detail
+
+#undef USE_CONCEPTS
+#undef CMCSTL2_CONCEPTS
+#undef CPP20_CONCEPTS

--- a/libs/core/datastructures/include/hpx/datastructures/tuple.hpp
+++ b/libs/core/datastructures/include/hpx/datastructures/tuple.hpp
@@ -738,6 +738,9 @@ namespace hpx {
     };
 #endif
 
+    template <std::size_t I, typename T>
+    using tuple_element_t = typename tuple_element<I, T>::type;
+
     // 20.4.2.6, element access
     namespace adl_barrier {
 

--- a/libs/core/datastructures/tests/unit/CMakeLists.txt
+++ b/libs/core/datastructures/tests/unit/CMakeLists.txt
@@ -13,6 +13,8 @@ set(tests
     dynamic_bitset3
     dynamic_bitset4
     dynamic_bitset5
+    flat_map
+    flat_set
     intrusive_list
     is_tuple_like
     serializable_any

--- a/libs/core/datastructures/tests/unit/flat_map.cpp
+++ b/libs/core/datastructures/tests/unit/flat_map.cpp
@@ -1,0 +1,741 @@
+//  Copyright (C) 2019-2022 T. Zachary Laine
+//  Copyright (c) 2023 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/datastructures/detail/flat_map.hpp>
+#include <hpx/modules/testing.hpp>
+
+#include <algorithm>
+#include <ostream>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
+
+// dummy implementations for testing macros
+namespace hpx::detail {
+
+    template <typename Key, typename T, typename Compare, typename KeyContainer,
+        typename MappedContainer>
+    std::ostream& operator<<(std::ostream& os,
+        hpx::detail::flat_map<Key, T, Compare, KeyContainer,
+            MappedContainer> const&)
+    {
+        return os;
+    }
+
+    template <typename KeyRef, typename TRef, typename KeyIter,
+        typename MappedIter>
+    std::ostream& operator<<(std::ostream& os,
+        hpx::detail::flat_map_iterator<KeyRef, TRef, KeyIter,
+            MappedIter> const&)
+    {
+        return os;
+    }
+}    // namespace hpx::detail
+
+namespace std {
+
+    template <typename T>
+    std::ostream& operator<<(std::ostream& os, std::vector<T> const&)
+    {
+        return os;
+    }
+}    // namespace std
+
+// Test instantiations.
+template class hpx::detail::flat_map<std::string, int>;
+
+void test_std_flat_map_iterator()
+{
+    using fmap_t = hpx::detail::flat_map<std::string, int>;
+
+    {
+        fmap_t map;
+        fmap_t::iterator mutable_first = map.begin();
+        fmap_t::const_iterator const_first = mutable_first;
+
+        HPX_TEST_EQ(mutable_first, const_first);
+    }
+
+    {
+        fmap_t::containers c = {{"key0", "key1", "key2"}, {0, 1, 2}};
+
+        fmap_t::iterator const first(c.keys.begin(), c.values.begin());
+        fmap_t::iterator const last(c.keys.end(), c.values.end());
+
+        HPX_TEST_EQ(first + 3, last);
+        HPX_TEST_EQ(first, last - 3);
+
+        HPX_TEST_EQ(first[1].first, "key1");
+        HPX_TEST_EQ(last[-3].second, 0);
+
+        HPX_TEST_EQ((*(first + 1)).first, "key1");
+        HPX_TEST_EQ((*(last - 3)).second, 0);
+
+        HPX_TEST_EQ((first + 1)->first, "key1");
+        HPX_TEST_EQ((last - 3)->second, 0);
+
+        HPX_TEST_EQ(first - last, -3);
+        HPX_TEST_EQ(last - first, 3);
+
+        {
+            auto first_copy = first;
+            auto last_copy = last;
+
+            first_copy += 3;
+            last_copy -= 3;
+
+            HPX_TEST_EQ(first_copy, last);
+            HPX_TEST_EQ(last_copy, first);
+        }
+
+        {
+            auto first_copy = first;
+            auto last_copy = last;
+
+            HPX_TEST_EQ(first_copy++, first);
+            HPX_TEST_EQ(first_copy++, first + 1);
+            HPX_TEST_EQ(first_copy++, first + 2);
+            HPX_TEST_EQ(first_copy, last);
+
+            HPX_TEST_EQ(last_copy--, last);
+            HPX_TEST_EQ(last_copy--, last - 1);
+            HPX_TEST_EQ(last_copy--, last - 2);
+            HPX_TEST_EQ(last_copy, first);
+        }
+
+        {
+            auto first_copy = first;
+            auto last_copy = last;
+
+            HPX_TEST_EQ(++first_copy, first + 1);
+            HPX_TEST_EQ(++first_copy, first + 2);
+            HPX_TEST_EQ(++first_copy, last);
+            HPX_TEST_EQ(first_copy, last);
+
+            HPX_TEST_EQ(--last_copy, last - 1);
+            HPX_TEST_EQ(--last_copy, last - 2);
+            HPX_TEST_EQ(--last_copy, first);
+            HPX_TEST_EQ(last_copy, first);
+        }
+
+        HPX_TEST_EQ(first, first);
+        HPX_TEST_NEQ(first, last);
+
+        HPX_TEST_LT(first, last);
+        HPX_TEST_LTE(first, last);
+        HPX_TEST_LTE(first, first);
+    }
+
+    {
+        fmap_t::containers c = {{"key0", "key1", "key2"}, {0, 1, 2}};
+
+        fmap_t::reverse_iterator const first(
+            c.keys.rbegin(), c.values.rbegin());
+        fmap_t::reverse_iterator const last(c.keys.rend(), c.values.rend());
+
+        HPX_TEST_EQ(first + 3, last);
+        HPX_TEST_EQ(first, last - 3);
+
+        HPX_TEST_EQ(first[1].first, "key1");
+        HPX_TEST_EQ(last[-3].second, 2);
+
+        HPX_TEST_EQ((*(first + 1)).first, "key1");
+        HPX_TEST_EQ((*(last - 3)).second, 2);
+
+        HPX_TEST_EQ((first + 1)->first, "key1");
+        HPX_TEST_EQ((last - 3)->second, 2);
+
+        HPX_TEST_EQ(first - last, -3);
+        HPX_TEST_EQ(last - first, 3);
+
+        {
+            auto first_copy = first;
+            auto last_copy = last;
+
+            first_copy += 3;
+            last_copy -= 3;
+
+            HPX_TEST_EQ(first_copy, last);
+            HPX_TEST_EQ(last_copy, first);
+        }
+
+        {
+            auto first_copy = first;
+            auto last_copy = last;
+
+            HPX_TEST_EQ(first_copy++, first);
+            HPX_TEST_EQ(first_copy++, first + 1);
+            HPX_TEST_EQ(first_copy++, first + 2);
+            HPX_TEST_EQ(first_copy, last);
+
+            HPX_TEST_EQ(last_copy--, last);
+            HPX_TEST_EQ(last_copy--, last - 1);
+            HPX_TEST_EQ(last_copy--, last - 2);
+            HPX_TEST_EQ(last_copy, first);
+        }
+
+        {
+            auto first_copy = first;
+            auto last_copy = last;
+
+            HPX_TEST_EQ(++first_copy, first + 1);
+            HPX_TEST_EQ(++first_copy, first + 2);
+            HPX_TEST_EQ(++first_copy, last);
+            HPX_TEST_EQ(first_copy, last);
+
+            HPX_TEST_EQ(--last_copy, last - 1);
+            HPX_TEST_EQ(--last_copy, last - 2);
+            HPX_TEST_EQ(--last_copy, first);
+            HPX_TEST_EQ(last_copy, first);
+        }
+
+        HPX_TEST_EQ(first, first);
+        HPX_TEST_NEQ(first, last);
+
+        HPX_TEST_LT(first, last);
+        HPX_TEST_LTE(first, last);
+        HPX_TEST_LTE(first, first);
+    }
+}
+
+void std_flat_map_ctors_iterators()
+{
+    using fmap_t = hpx::detail::flat_map<std::string, int>;
+    using pair_t = std::pair<std::string, int>;
+
+    auto pair_cmp = [](auto lhs, auto rhs) {
+        return lhs.first == rhs.first && lhs.second == rhs.second;
+    };
+
+    std::initializer_list<pair_t> init_list = {
+        {"key1", 1}, {"key2", 2}, {"key0", 0}};
+    fmap_t::containers const c = {{"key1", "key2", "key0"}, {1, 2, 0}};
+    std::vector<pair_t> const vec = {{"key1", 1}, {"key2", 2}, {"key0", 0}};
+    std::vector<pair_t> sorted_vec = vec;
+    std::sort(sorted_vec.begin(), sorted_vec.end());
+
+    fmap_t const map_from_c(c.keys, c.values);
+    fmap_t const map_from_vec(vec);
+
+    HPX_TEST_EQ(map_from_c, map_from_vec);
+    HPX_TEST(!(map_from_c != map_from_vec));
+
+    fmap_t const map_from_const_map = map_from_c;
+    fmap_t const map_from_map_rvalue = fmap_t(map_from_c);
+
+    HPX_TEST_EQ(map_from_const_map, map_from_vec);
+    HPX_TEST(!(map_from_map_rvalue != map_from_vec));
+
+    {
+        fmap_t map;
+        HPX_TEST(map.empty());
+        HPX_TEST_EQ(map.size(), 0u);
+        HPX_TEST_EQ(map.begin(), map.end());
+    }
+
+    {
+        fmap_t map(c.keys, c.values);
+        HPX_TEST_EQ(map.size(), 3u);
+        HPX_TEST(!(map.empty()));
+        HPX_TEST(std::equal(map.begin(), map.end(), sorted_vec.begin(),
+            sorted_vec.end(), pair_cmp));
+    }
+
+    {
+        fmap_t map(vec.begin(), vec.end());
+        HPX_TEST(std::equal(map.begin(), map.end(), sorted_vec.begin(),
+            sorted_vec.end(), pair_cmp));
+
+        HPX_TEST(std::equal(map.cbegin(), map.cend(), sorted_vec.begin(),
+            sorted_vec.end(), pair_cmp));
+    }
+
+    {
+        fmap_t map(vec);
+        HPX_TEST(std::equal(map.begin(), map.end(), sorted_vec.begin(),
+            sorted_vec.end(), pair_cmp));
+
+        HPX_TEST(std::equal(map.cbegin(), map.cend(), sorted_vec.begin(),
+            sorted_vec.end(), pair_cmp));
+    }
+
+    {
+        hpx::detail::flat_map<std::string, int, std::greater<std::string>> map(
+            vec);
+        HPX_TEST(std::equal(map.rbegin(), map.rend(), sorted_vec.begin(),
+            sorted_vec.end(), pair_cmp));
+
+        HPX_TEST(std::equal(map.crbegin(), map.crend(), sorted_vec.begin(),
+            sorted_vec.end(), pair_cmp));
+    }
+
+    {
+        // This breaks the ctor's contract, since c.keys are not in sorted
+        // order, but it's useful to verify that the resulting contents were
+        // not touched.
+        fmap_t map(hpx::detail::sorted_unique, c.keys, c.values);
+        HPX_TEST_EQ(map.size(), 3u);
+        HPX_TEST(!(map.empty()));
+        HPX_TEST(std::equal(
+            map.begin(), map.end(), vec.begin(), vec.end(), pair_cmp));
+    }
+
+    {
+        // Broken contract, as above.
+        fmap_t map(hpx::detail::sorted_unique, vec.begin(), vec.end());
+        HPX_TEST_EQ(map.size(), 3u);
+        HPX_TEST(!(map.empty()));
+        HPX_TEST(std::equal(
+            map.begin(), map.end(), vec.begin(), vec.end(), pair_cmp));
+    }
+
+    {
+        // Broken contract, as above.
+        fmap_t map(hpx::detail::sorted_unique, vec);
+        HPX_TEST_EQ(map.size(), 3u);
+        HPX_TEST(!(map.empty()));
+        HPX_TEST(std::equal(
+            map.begin(), map.end(), vec.begin(), vec.end(), pair_cmp));
+    }
+
+    {
+        hpx::detail::flat_map<std::string, int, std::greater<std::string>> map;
+        map.insert(vec.begin(), vec.end());
+        HPX_TEST(std::equal(map.rbegin(), map.rend(), sorted_vec.begin(),
+            sorted_vec.end(), pair_cmp));
+    }
+
+    {
+        fmap_t map(init_list);
+        HPX_TEST(std::equal(map.begin(), map.end(), sorted_vec.begin(),
+            sorted_vec.end(), pair_cmp));
+    }
+
+    {
+        // Broken contract, as above.
+        fmap_t map(hpx::detail::sorted_unique, init_list);
+        HPX_TEST(std::equal(
+            map.begin(), map.end(), vec.begin(), vec.end(), pair_cmp));
+    }
+
+    {
+        fmap_t map;
+        map = {pair_t{"key1", 1}, pair_t{"key2", 2}, pair_t{"key0", 0}};
+        HPX_TEST(std::equal(map.begin(), map.end(), sorted_vec.begin(),
+            sorted_vec.end(), pair_cmp));
+    }
+}
+
+void std_flat_map_ctors_allocators_iterators()
+{
+    using fmap_t = hpx::detail::flat_map<std::string, int>;
+    using pair_t = std::pair<std::string, int>;
+
+    auto pair_cmp = [](auto lhs, auto rhs) {
+        return lhs.first == rhs.first && lhs.second == rhs.second;
+    };
+
+    std::initializer_list<pair_t> init_list = {
+        {"key1", 1}, {"key2", 2}, {"key0", 0}};
+    fmap_t::containers const c = {{"key1", "key2", "key0"}, {1, 2, 0}};
+    std::vector<pair_t> const vec = {{"key1", 1}, {"key2", 2}, {"key0", 0}};
+    std::vector<pair_t> sorted_vec = vec;
+    std::sort(sorted_vec.begin(), sorted_vec.end());
+
+    auto allocator = c.keys.get_allocator();
+
+    fmap_t const map_from_c(c.keys, c.values, allocator);
+    fmap_t const map_from_vec(vec, allocator);
+
+    HPX_TEST_EQ(map_from_c, map_from_vec);
+    HPX_TEST(!(map_from_c != map_from_vec));
+
+    fmap_t const map_from_const_map(map_from_c, allocator);
+    fmap_t const map_from_map_rvalue(fmap_t(map_from_c), allocator);
+
+    HPX_TEST_EQ(map_from_const_map, map_from_vec);
+    HPX_TEST(!(map_from_map_rvalue != map_from_vec));
+
+    {
+        fmap_t map(allocator);
+        HPX_TEST(map.empty());
+        HPX_TEST_EQ(map.size(), 0u);
+        HPX_TEST_EQ(map.begin(), map.end());
+    }
+
+    {
+        fmap_t map(c.keys, c.values, allocator);
+        HPX_TEST_EQ(map.size(), 3u);
+        HPX_TEST(!(map.empty()));
+        HPX_TEST(std::equal(map.begin(), map.end(), sorted_vec.begin(),
+            sorted_vec.end(), pair_cmp));
+    }
+
+    {
+        fmap_t map(vec.begin(), vec.end(), allocator);
+        HPX_TEST(std::equal(map.begin(), map.end(), sorted_vec.begin(),
+            sorted_vec.end(), pair_cmp));
+
+        HPX_TEST(std::equal(map.cbegin(), map.cend(), sorted_vec.begin(),
+            sorted_vec.end(), pair_cmp));
+    }
+
+    {
+        fmap_t map(vec, allocator);
+        HPX_TEST(std::equal(map.begin(), map.end(), sorted_vec.begin(),
+            sorted_vec.end(), pair_cmp));
+
+        HPX_TEST(std::equal(map.cbegin(), map.cend(), sorted_vec.begin(),
+            sorted_vec.end(), pair_cmp));
+    }
+
+    {
+        hpx::detail::flat_map<std::string, int, std::greater<>> map(
+            vec, allocator);
+        HPX_TEST(std::equal(map.rbegin(), map.rend(), sorted_vec.begin(),
+            sorted_vec.end(), pair_cmp));
+
+        HPX_TEST(std::equal(map.crbegin(), map.crend(), sorted_vec.begin(),
+            sorted_vec.end(), pair_cmp));
+    }
+
+    {
+        // This breaks the ctor's contract, since c.keys are not in sorted
+        // order, but it's useful to verify that the resulting contents were
+        // not touched.
+        fmap_t map(hpx::detail::sorted_unique, c.keys, c.values, allocator);
+        HPX_TEST_EQ(map.size(), 3u);
+        HPX_TEST(!(map.empty()));
+        HPX_TEST(std::equal(
+            map.begin(), map.end(), vec.begin(), vec.end(), pair_cmp));
+    }
+
+    {
+        // Broken contract, as above.
+        fmap_t map(
+            hpx::detail::sorted_unique, vec.begin(), vec.end(), allocator);
+        HPX_TEST_EQ(map.size(), 3u);
+        HPX_TEST(!(map.empty()));
+        HPX_TEST(std::equal(
+            map.begin(), map.end(), vec.begin(), vec.end(), pair_cmp));
+    }
+
+    {
+        // Broken contract, as above.
+        fmap_t map(hpx::detail::sorted_unique, vec, allocator);
+        HPX_TEST_EQ(map.size(), 3u);
+        HPX_TEST(!(map.empty()));
+        HPX_TEST(std::equal(
+            map.begin(), map.end(), vec.begin(), vec.end(), pair_cmp));
+    }
+
+    {
+        hpx::detail::flat_map<std::string, int, std::greater<std::string>> map(
+            allocator);
+        map.insert(vec.begin(), vec.end());
+        HPX_TEST(std::equal(map.rbegin(), map.rend(), sorted_vec.begin(),
+            sorted_vec.end(), pair_cmp));
+    }
+
+    {
+        fmap_t map(init_list, allocator);
+        HPX_TEST(std::equal(map.begin(), map.end(), sorted_vec.begin(),
+            sorted_vec.end(), pair_cmp));
+    }
+
+    {
+        // Broken contract, as above.
+        fmap_t map(hpx::detail::sorted_unique, init_list, allocator);
+        HPX_TEST(std::equal(
+            map.begin(), map.end(), vec.begin(), vec.end(), pair_cmp));
+    }
+
+    {
+        fmap_t map(allocator);
+        map = {pair_t{"key1", 1}, pair_t{"key2", 2}, pair_t{"key0", 0}};
+        HPX_TEST(std::equal(map.begin(), map.end(), sorted_vec.begin(),
+            sorted_vec.end(), pair_cmp));
+    }
+}
+
+void std_flat_map_index_at()
+{
+    using fmap_t = hpx::detail::flat_map<std::string, int>;
+    using pair_t = std::pair<std::string, int>;
+
+    std::vector<pair_t> const vec = {{"key1", 1}, {"key2", 2}, {"key-1", -1}};
+    std::vector<pair_t> sorted_vec = vec;
+    std::sort(sorted_vec.begin(), sorted_vec.end());
+
+    {
+        fmap_t map(vec);
+        std::string const key_1("key1");
+        HPX_TEST_EQ(map["key-1"], -1);
+        HPX_TEST_EQ(map["key2"], 2);
+        HPX_TEST_EQ(map[key_1], 1);
+        HPX_TEST_EQ(map["foo"], 0);
+
+        map["foo"] = 8;
+
+        HPX_TEST_EQ(map.at("key-1"), -1);
+        HPX_TEST_EQ(map.at("key2"), 2);
+        HPX_TEST_EQ(map.at("key1"), 1);
+        HPX_TEST_EQ(map.at("foo"), 8);
+        HPX_TEST_THROW(map.at("bar"), std::out_of_range);
+
+        fmap_t const& cmap = map;
+        HPX_TEST_THROW(cmap.at("bar"), std::out_of_range);
+    }
+}
+
+void std_flat_map_emplace_insert()
+{
+    using fmap_t = hpx::detail::flat_map<std::string, int>;
+    using rev_fmap_t =
+        hpx::detail::flat_map<std::string, int, std::greater<std::string>>;
+    using pair_t = std::pair<std::string, int>;
+
+    auto pair_cmp = [](auto lhs, auto rhs) {
+        return lhs.first == rhs.first && lhs.second == rhs.second;
+    };
+
+    fmap_t::containers const c = {{"key1", "key2", "key0"}, {1, 2, 0}};
+    std::vector<pair_t> const vec = {{"key1", 1}, {"key2", 2}, {"key0", 0}};
+    std::vector<pair_t> sorted_vec = vec;
+    std::sort(sorted_vec.begin(), sorted_vec.end());
+
+    pair_t const pair1("q", 3);
+    pair_t const pair2("w", 4);
+
+    using foreign_pair_t = std::pair<char const*, short>;
+
+    {
+        foreign_pair_t foreign_pair("e", 5);
+
+        // NOTE: These calls exercise all emplace's and inserts before the range
+        // inserts.
+
+        fmap_t map;
+        map.insert(pair1);
+        map.insert(pair_t("r", 6));
+        map.insert(map.begin(), pair2);
+        map.insert(map.begin(), pair_t("t", 7));
+        map.insert(foreign_pair);
+        map.insert(foreign_pair_t("y", 8));
+
+        std::vector<pair_t> const qwerty_vec = {
+            {"e", 5}, {"q", 3}, {"r", 6}, {"t", 7}, {"w", 4}, {"y", 8}};
+        HPX_TEST(std::equal(map.begin(), map.end(), qwerty_vec.begin(),
+            qwerty_vec.end(), pair_cmp));
+    }
+
+    // NOTE: Already exercised by ctor test:
+    // template<class InputIterator>
+    // void insert(InputIterator first, InputIterator last);
+    // template<class InputIterator>
+    // void insert(sorted_unique_t, InputIterator first, InputIterator last);
+
+    {
+        fmap_t map;
+        map.insert({pair_t{"key1", 1}, pair_t{"key2", 2}, pair_t{"key0", 0}});
+        HPX_TEST_EQ(map.size(), 3u);
+        HPX_TEST(!(map.empty()));
+        HPX_TEST(std::equal(map.begin(), map.end(), sorted_vec.begin(),
+            sorted_vec.end(), pair_cmp));
+    }
+
+    {
+        rev_fmap_t map;
+        map.insert({pair_t{"key1", 1}, pair_t{"key2", 2}, pair_t{"key0", 0}});
+        HPX_TEST_EQ(map.size(), 3u);
+        HPX_TEST(!(map.empty()));
+        HPX_TEST(std::equal(map.rbegin(), map.rend(), sorted_vec.begin(),
+            sorted_vec.end(), pair_cmp));
+    }
+
+    {
+        // This breaks the ctor's contract, since c.keys are not in sorted
+        // order, but it's useful to verify that the resulting contents were
+        // not touched.
+        fmap_t map;
+        map.insert(hpx::detail::sorted_unique,
+            {pair_t{"key1", 1}, pair_t{"key2", 2}, pair_t{"key0", 0}});
+        HPX_TEST_EQ(map.size(), 3u);
+        HPX_TEST(!(map.empty()));
+        HPX_TEST(std::equal(
+            map.begin(), map.end(), vec.begin(), vec.end(), pair_cmp));
+    }
+
+    {
+        // NOTE: These calls exercise all the try_emplace's.
+
+        fmap_t map;
+        map.try_emplace(map.begin(), pair1.first, pair1.second);
+        map.try_emplace(map.begin(), std::string("lucky"), 13);
+
+        std::vector<pair_t> const local_vec = {{"lucky", 13}, {"q", 3}};
+        HPX_TEST(std::equal(map.begin(), map.end(), local_vec.begin(),
+            local_vec.end(), pair_cmp));
+    }
+
+    {
+        // NOTE: These calls exercise all the try_emplace's.
+
+        fmap_t map;
+        map.insert_or_assign(map.begin(), pair1.first, pair1.second);
+        map.insert_or_assign(
+            map.begin(), std::string(pair1.first), pair1.second);
+
+        std::vector<pair_t> const local_vec = {{"q", 3}};
+        HPX_TEST(std::equal(map.begin(), map.end(), local_vec.begin(),
+            local_vec.end(), pair_cmp));
+    }
+}
+
+void std_flat_map_extract_replace()
+{
+    using fmap_t = hpx::detail::flat_map<std::string, int>;
+    using pair_t = std::pair<std::string, int>;
+
+    fmap_t::containers const sorted_c = {{"key0", "key1", "key2"}, {0, 1, 2}};
+    std::vector<pair_t> const vec = {{"key1", 1}, {"key2", 2}, {"key0", 0}};
+
+    fmap_t map1(vec);
+    fmap_t const map1_copy = map1;
+
+    fmap_t::containers extracted_c = std::move(map1).extract();
+    HPX_TEST_EQ(extracted_c.keys, sorted_c.keys);
+    HPX_TEST_EQ(extracted_c.values, sorted_c.values);
+
+    fmap_t map2;
+    map2.replace(std::move(extracted_c.keys), std::move(extracted_c.values));
+    HPX_TEST_EQ(map2, map1_copy);
+}
+
+void std_flat_map_erase_swap()
+{
+    using fmap_t = hpx::detail::flat_map<std::string, int>;
+    using pair_t = std::pair<std::string, int>;
+
+    auto pair_cmp = [](auto lhs, auto rhs) {
+        return lhs.first == rhs.first && lhs.second == rhs.second;
+    };
+
+    std::vector<pair_t> const vec = {{"key0", 0}, {"key1", 1}, {"key2", 2}};
+
+    {
+        fmap_t map(vec);
+        map.erase(map.begin());
+        std::vector<pair_t> const local_vec = {{"key1", 1}, {"key2", 2}};
+        HPX_TEST(std::equal(map.begin(), map.end(), local_vec.begin(),
+            local_vec.end(), pair_cmp));
+    }
+
+    {
+        fmap_t map(vec);
+        map.erase(map.cbegin());
+        std::vector<pair_t> const local_vec = {{"key1", 1}, {"key2", 2}};
+        HPX_TEST(std::equal(map.begin(), map.end(), local_vec.begin(),
+            local_vec.end(), pair_cmp));
+    }
+
+    {
+        fmap_t map(vec);
+        map.erase("key0");
+        std::vector<pair_t> const local_vec = {{"key1", 1}, {"key2", 2}};
+        HPX_TEST(std::equal(map.begin(), map.end(), local_vec.begin(),
+            local_vec.end(), pair_cmp));
+    }
+
+    {
+        fmap_t map(vec);
+        map.erase(map.begin(), map.end());
+        HPX_TEST_EQ(map.begin(), map.end());
+    }
+
+    {
+        fmap_t const orig_map(vec);
+        fmap_t const orig_empty_map;
+
+        auto map1 = orig_map;
+        auto map2 = orig_empty_map;
+
+        std::swap(map1, map2);
+
+        HPX_TEST_EQ(map1, orig_empty_map);
+        HPX_TEST_EQ(map2, orig_map);
+
+        std::swap(map1, map2);
+
+        HPX_TEST_EQ(map1, orig_map);
+        HPX_TEST_EQ(map2, orig_empty_map);
+    }
+}
+
+void std_flat_map_count_contains()
+{
+    using fmap_t = hpx::detail::flat_map<std::string, int>;
+    using pair_t = std::pair<std::string, int>;
+
+    std::vector<pair_t> const vec = {{"key1", 1}, {"key2", 2}, {"key0", 0}};
+
+    fmap_t const map(vec);
+    HPX_TEST_EQ(map.count("key0"), 1u);
+    HPX_TEST_EQ(map.count("key10"), 0u);
+    HPX_TEST(map.count("key0"));
+    HPX_TEST(!(map.count("key10")));
+}
+
+void std_flat_map_equal_range()
+{
+    using fmap_t = hpx::detail::flat_map<std::string, int>;
+    using pair_t = std::pair<std::string, int>;
+
+    std::vector<pair_t> const vec = {{"key1", 1}, {"key2", 2}, {"key0", 0}};
+
+    fmap_t const map(vec);
+    auto const eq_range = map.equal_range("key0");
+    HPX_TEST_EQ(eq_range.first, map.begin());
+    HPX_TEST_EQ(eq_range.second, map.begin() + 1);
+    auto const empty_eq_range = map.equal_range("");
+    HPX_TEST_EQ(empty_eq_range.first, empty_eq_range.second);
+}
+
+void std_flat_map_comparisons()
+{
+    using fmap_t = hpx::detail::flat_map<std::string, int>;
+    using pair_t = std::pair<std::string, int>;
+
+    std::vector<pair_t> const vec = {{"key0", 0}, {"key1", 1}, {"key2", 2}};
+
+    fmap_t const map_123(vec);
+    fmap_t const map_12(vec.begin(), vec.begin() + 2);
+
+    HPX_TEST_EQ(map_123, map_123);
+    HPX_TEST_NEQ(map_123, map_12);
+
+    HPX_TEST_LT(map_12, map_123);
+    HPX_TEST_LTE(map_12, map_123);
+    HPX_TEST_LTE(map_123, map_123);
+}
+
+int main()
+{
+    test_std_flat_map_iterator();
+    std_flat_map_ctors_iterators();
+    std_flat_map_ctors_allocators_iterators();
+    std_flat_map_index_at();
+    std_flat_map_emplace_insert();
+    std_flat_map_extract_replace();
+    std_flat_map_erase_swap();
+    std_flat_map_count_contains();
+    std_flat_map_equal_range();
+    std_flat_map_comparisons();
+
+    return hpx::util::report_errors();
+}

--- a/libs/core/datastructures/tests/unit/flat_set.cpp
+++ b/libs/core/datastructures/tests/unit/flat_set.cpp
@@ -1,0 +1,658 @@
+//  Copyright (C) 2019-2022 T. Zachary Laine
+//  Copyright (c) 2023 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/datastructures/detail/flat_set.hpp>
+#include <hpx/modules/testing.hpp>
+
+#include <algorithm>
+#include <ostream>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
+
+// dummy implementations for testing macros
+namespace hpx::detail {
+
+    template <typename Key, typename Compare, typename KeyContainer>
+    std::ostream& operator<<(std::ostream& os,
+        hpx::detail::flat_set<Key, Compare, KeyContainer> const&)
+    {
+        return os;
+    }
+
+    template <typename KeyRef, typename KeyIter>
+    std::ostream& operator<<(std::ostream& os,
+        hpx::detail::flat_set_iterator<KeyRef, KeyIter> const&)
+    {
+        return os;
+    }
+}    // namespace hpx::detail
+
+namespace std {
+
+    template <typename T>
+    std::ostream& operator<<(std::ostream& os, std::vector<T> const&)
+    {
+        return os;
+    }
+}    // namespace std
+
+// Test instantiations.
+template class hpx::detail::flat_set<std::string>;
+
+void test_std_flat_set_iterator()
+{
+    using fmap_t = hpx::detail::flat_set<std::string>;
+
+    {
+        fmap_t map;
+        fmap_t::iterator mutable_first = map.begin();
+        fmap_t::const_iterator const_first = mutable_first;
+
+        HPX_TEST_EQ(mutable_first, const_first);
+    }
+
+    {
+        fmap_t::key_container_type c = {"key0", "key1", "key2"};
+
+        fmap_t::iterator const first(c.begin());
+        fmap_t::iterator const last(c.end());
+
+        HPX_TEST_EQ(first + 3, last);
+        HPX_TEST_EQ(first, last - 3);
+
+        HPX_TEST_EQ(first[1], "key1");
+        HPX_TEST_EQ(last[-3], "key0");
+
+        HPX_TEST_EQ((*(first + 1)), "key1");
+        HPX_TEST_EQ((*(last - 3)), "key0");
+
+        HPX_TEST_EQ(first - last, -3);
+        HPX_TEST_EQ(last - first, 3);
+
+        {
+            auto first_copy = first;
+            auto last_copy = last;
+
+            first_copy += 3;
+            last_copy -= 3;
+
+            HPX_TEST_EQ(first_copy, last);
+            HPX_TEST_EQ(last_copy, first);
+        }
+
+        {
+            auto first_copy = first;
+            auto last_copy = last;
+
+            HPX_TEST_EQ(first_copy++, first);
+            HPX_TEST_EQ(first_copy++, first + 1);
+            HPX_TEST_EQ(first_copy++, first + 2);
+            HPX_TEST_EQ(first_copy, last);
+
+            HPX_TEST_EQ(last_copy--, last);
+            HPX_TEST_EQ(last_copy--, last - 1);
+            HPX_TEST_EQ(last_copy--, last - 2);
+            HPX_TEST_EQ(last_copy, first);
+        }
+
+        {
+            auto first_copy = first;
+            auto last_copy = last;
+
+            HPX_TEST_EQ(++first_copy, first + 1);
+            HPX_TEST_EQ(++first_copy, first + 2);
+            HPX_TEST_EQ(++first_copy, last);
+            HPX_TEST_EQ(first_copy, last);
+
+            HPX_TEST_EQ(--last_copy, last - 1);
+            HPX_TEST_EQ(--last_copy, last - 2);
+            HPX_TEST_EQ(--last_copy, first);
+            HPX_TEST_EQ(last_copy, first);
+        }
+
+        HPX_TEST_EQ(first, first);
+        HPX_TEST_NEQ(first, last);
+
+        HPX_TEST_LT(first, last);
+        HPX_TEST_LTE(first, last);
+        HPX_TEST_LTE(first, first);
+    }
+
+    {
+        fmap_t::key_container_type c = {"key0", "key1", "key2"};
+
+        fmap_t::reverse_iterator const first(c.rbegin());
+        fmap_t::reverse_iterator const last(c.rend());
+
+        HPX_TEST_EQ(first + 3, last);
+        HPX_TEST_EQ(first, last - 3);
+
+        HPX_TEST_EQ(first[1], "key1");
+        HPX_TEST_EQ(last[-3], "key2");
+
+        HPX_TEST_EQ((*(first + 1)), "key1");
+        HPX_TEST_EQ((*(last - 3)), "key2");
+
+        HPX_TEST_EQ(first - last, -3);
+        HPX_TEST_EQ(last - first, 3);
+
+        {
+            auto first_copy = first;
+            auto last_copy = last;
+
+            first_copy += 3;
+            last_copy -= 3;
+
+            HPX_TEST_EQ(first_copy, last);
+            HPX_TEST_EQ(last_copy, first);
+        }
+
+        {
+            auto first_copy = first;
+            auto last_copy = last;
+
+            HPX_TEST_EQ(first_copy++, first);
+            HPX_TEST_EQ(first_copy++, first + 1);
+            HPX_TEST_EQ(first_copy++, first + 2);
+            HPX_TEST_EQ(first_copy, last);
+
+            HPX_TEST_EQ(last_copy--, last);
+            HPX_TEST_EQ(last_copy--, last - 1);
+            HPX_TEST_EQ(last_copy--, last - 2);
+            HPX_TEST_EQ(last_copy, first);
+        }
+
+        {
+            auto first_copy = first;
+            auto last_copy = last;
+
+            HPX_TEST_EQ(++first_copy, first + 1);
+            HPX_TEST_EQ(++first_copy, first + 2);
+            HPX_TEST_EQ(++first_copy, last);
+            HPX_TEST_EQ(first_copy, last);
+
+            HPX_TEST_EQ(--last_copy, last - 1);
+            HPX_TEST_EQ(--last_copy, last - 2);
+            HPX_TEST_EQ(--last_copy, first);
+            HPX_TEST_EQ(last_copy, first);
+        }
+
+        HPX_TEST_EQ(first, first);
+        HPX_TEST_NEQ(first, last);
+
+        HPX_TEST_LT(first, last);
+        HPX_TEST_LTE(first, last);
+        HPX_TEST_LTE(first, first);
+    }
+}
+
+void std_flat_set_ctors_iterators()
+{
+    using fmap_t = hpx::detail::flat_set<std::string>;
+    using value_t = std::string;
+
+    auto pair_cmp = [](auto lhs, auto rhs) { return lhs == rhs; };
+
+    std::initializer_list<value_t> init_list = {"key1", "key2", "key0"};
+    fmap_t::key_container_type const c = {"key1", "key2", "key0"};
+    std::vector<value_t> const vec = {"key1", "key2", "key0"};
+    std::vector<value_t> sorted_vec = vec;
+    std::sort(sorted_vec.begin(), sorted_vec.end());
+
+    fmap_t const map_from_c(c);
+    fmap_t const map_from_vec(vec);
+
+    HPX_TEST_EQ(map_from_c, map_from_vec);
+    HPX_TEST(!(map_from_c != map_from_vec));
+
+    fmap_t const map_from_const_map = map_from_c;
+    fmap_t const map_from_map_rvalue = fmap_t(map_from_c);
+
+    HPX_TEST_EQ(map_from_const_map, map_from_vec);
+    HPX_TEST(!(map_from_map_rvalue != map_from_vec));
+
+    {
+        fmap_t map;
+        HPX_TEST(map.empty());
+        HPX_TEST_EQ(map.size(), 0u);
+        HPX_TEST_EQ(map.begin(), map.end());
+    }
+
+    {
+        fmap_t map(c);
+        HPX_TEST_EQ(map.size(), 3u);
+        HPX_TEST(!(map.empty()));
+        HPX_TEST(std::equal(map.begin(), map.end(), sorted_vec.begin(),
+            sorted_vec.end(), pair_cmp));
+    }
+
+    {
+        fmap_t map(vec.begin(), vec.end());
+        HPX_TEST(std::equal(map.begin(), map.end(), sorted_vec.begin(),
+            sorted_vec.end(), pair_cmp));
+
+        HPX_TEST(std::equal(map.cbegin(), map.cend(), sorted_vec.begin(),
+            sorted_vec.end(), pair_cmp));
+    }
+
+    {
+        fmap_t map(vec);
+        HPX_TEST(std::equal(map.begin(), map.end(), sorted_vec.begin(),
+            sorted_vec.end(), pair_cmp));
+
+        HPX_TEST(std::equal(map.cbegin(), map.cend(), sorted_vec.begin(),
+            sorted_vec.end(), pair_cmp));
+    }
+
+    {
+        hpx::detail::flat_set<std::string, std::greater<>> map(vec);
+        HPX_TEST(std::equal(map.rbegin(), map.rend(), sorted_vec.begin(),
+            sorted_vec.end(), pair_cmp));
+
+        HPX_TEST(std::equal(map.crbegin(), map.crend(), sorted_vec.begin(),
+            sorted_vec.end(), pair_cmp));
+    }
+
+    {
+        // This breaks the ctor's contract, since c are not in sorted
+        // order, but it's useful to verify that the resulting contents were
+        // not touched.
+        fmap_t map(hpx::detail::sorted_unique, c);
+        HPX_TEST_EQ(map.size(), 3u);
+        HPX_TEST(!(map.empty()));
+        HPX_TEST(std::equal(
+            map.begin(), map.end(), vec.begin(), vec.end(), pair_cmp));
+    }
+
+    {
+        // Broken contract, as above.
+        fmap_t map(hpx::detail::sorted_unique, vec.begin(), vec.end());
+        HPX_TEST_EQ(map.size(), 3u);
+        HPX_TEST(!(map.empty()));
+        HPX_TEST(std::equal(
+            map.begin(), map.end(), vec.begin(), vec.end(), pair_cmp));
+    }
+
+    {
+        // Broken contract, as above.
+        fmap_t map(hpx::detail::sorted_unique, vec);
+        HPX_TEST_EQ(map.size(), 3u);
+        HPX_TEST(!(map.empty()));
+        HPX_TEST(std::equal(
+            map.begin(), map.end(), vec.begin(), vec.end(), pair_cmp));
+    }
+
+    {
+        hpx::detail::flat_set<std::string, std::greater<>> map;
+        map.insert(vec.begin(), vec.end());
+        HPX_TEST(std::equal(map.rbegin(), map.rend(), sorted_vec.begin(),
+            sorted_vec.end(), pair_cmp));
+    }
+
+    {
+        fmap_t map(init_list);
+        HPX_TEST(std::equal(map.begin(), map.end(), sorted_vec.begin(),
+            sorted_vec.end(), pair_cmp));
+    }
+
+    {
+        // Broken contract, as above.
+        fmap_t map(hpx::detail::sorted_unique, init_list);
+        HPX_TEST(std::equal(
+            map.begin(), map.end(), vec.begin(), vec.end(), pair_cmp));
+    }
+
+    {
+        fmap_t map;
+        map = {value_t{"key1"}, value_t{"key2"}, value_t{"key0"}};
+        HPX_TEST(std::equal(map.begin(), map.end(), sorted_vec.begin(),
+            sorted_vec.end(), pair_cmp));
+    }
+}
+
+void std_flat_set_ctors_allocators_iterators()
+{
+    using fmap_t = hpx::detail::flat_set<std::string>;
+    using value_t = std::string;
+
+    auto pair_cmp = [](auto lhs, auto rhs) { return lhs == rhs; };
+
+    std::initializer_list<value_t> init_list = {"key1", "key2", "key0"};
+    fmap_t::key_container_type const c = {"key1", "key2", "key0"};
+    std::vector<value_t> const vec = {"key1", "key2", "key0"};
+    std::vector<value_t> sorted_vec = vec;
+    std::sort(sorted_vec.begin(), sorted_vec.end());
+
+    auto allocator = c.get_allocator();
+
+    fmap_t const map_from_c(c, allocator);
+    fmap_t const map_from_vec(vec, allocator);
+
+    HPX_TEST_EQ(map_from_c, map_from_vec);
+    HPX_TEST(!(map_from_c != map_from_vec));
+
+    fmap_t const map_from_const_map(map_from_c, allocator);
+    fmap_t const map_from_map_rvalue(fmap_t(map_from_c), allocator);
+
+    HPX_TEST_EQ(map_from_const_map, map_from_vec);
+    HPX_TEST(!(map_from_map_rvalue != map_from_vec));
+
+    {
+        fmap_t map(allocator);
+        HPX_TEST(map.empty());
+        HPX_TEST_EQ(map.size(), 0u);
+        HPX_TEST_EQ(map.begin(), map.end());
+    }
+
+    {
+        fmap_t map(c, allocator);
+        HPX_TEST_EQ(map.size(), 3u);
+        HPX_TEST(!(map.empty()));
+        HPX_TEST(std::equal(map.begin(), map.end(), sorted_vec.begin(),
+            sorted_vec.end(), pair_cmp));
+    }
+
+    {
+        fmap_t map(vec.begin(), vec.end(), allocator);
+        HPX_TEST(std::equal(map.begin(), map.end(), sorted_vec.begin(),
+            sorted_vec.end(), pair_cmp));
+
+        HPX_TEST(std::equal(map.cbegin(), map.cend(), sorted_vec.begin(),
+            sorted_vec.end(), pair_cmp));
+    }
+
+    {
+        fmap_t map(vec, allocator);
+        HPX_TEST(std::equal(map.begin(), map.end(), sorted_vec.begin(),
+            sorted_vec.end(), pair_cmp));
+
+        HPX_TEST(std::equal(map.cbegin(), map.cend(), sorted_vec.begin(),
+            sorted_vec.end(), pair_cmp));
+    }
+
+    {
+        hpx::detail::flat_set<std::string, std::greater<>> map(vec, allocator);
+        HPX_TEST(std::equal(map.rbegin(), map.rend(), sorted_vec.begin(),
+            sorted_vec.end(), pair_cmp));
+
+        HPX_TEST(std::equal(map.crbegin(), map.crend(), sorted_vec.begin(),
+            sorted_vec.end(), pair_cmp));
+    }
+
+    {
+        // This breaks the ctor's contract, since c are not in sorted
+        // order, but it's useful to verify that the resulting contents were
+        // not touched.
+        fmap_t map(hpx::detail::sorted_unique, c, allocator);
+        HPX_TEST_EQ(map.size(), 3u);
+        HPX_TEST(!(map.empty()));
+        HPX_TEST(std::equal(
+            map.begin(), map.end(), vec.begin(), vec.end(), pair_cmp));
+    }
+
+    {
+        // Broken contract, as above.
+        fmap_t map(
+            hpx::detail::sorted_unique, vec.begin(), vec.end(), allocator);
+        HPX_TEST_EQ(map.size(), 3u);
+        HPX_TEST(!(map.empty()));
+        HPX_TEST(std::equal(
+            map.begin(), map.end(), vec.begin(), vec.end(), pair_cmp));
+    }
+
+    {
+        // Broken contract, as above.
+        fmap_t map(hpx::detail::sorted_unique, vec, allocator);
+        HPX_TEST_EQ(map.size(), 3u);
+        HPX_TEST(!(map.empty()));
+        HPX_TEST(std::equal(
+            map.begin(), map.end(), vec.begin(), vec.end(), pair_cmp));
+    }
+
+    {
+        hpx::detail::flat_set<std::string, std::greater<>> map(allocator);
+        map.insert(vec.begin(), vec.end());
+        HPX_TEST(std::equal(map.rbegin(), map.rend(), sorted_vec.begin(),
+            sorted_vec.end(), pair_cmp));
+    }
+
+    {
+        fmap_t map(init_list, allocator);
+        HPX_TEST(std::equal(map.begin(), map.end(), sorted_vec.begin(),
+            sorted_vec.end(), pair_cmp));
+    }
+
+    {
+        // Broken contract, as above.
+        fmap_t map(hpx::detail::sorted_unique, init_list, allocator);
+        HPX_TEST(std::equal(
+            map.begin(), map.end(), vec.begin(), vec.end(), pair_cmp));
+    }
+
+    {
+        fmap_t map(allocator);
+        map = {value_t{"key1"}, value_t{"key2"}, value_t{"key0"}};
+        HPX_TEST(std::equal(map.begin(), map.end(), sorted_vec.begin(),
+            sorted_vec.end(), pair_cmp));
+    }
+}
+
+void std_flat_set_emplace_insert()
+{
+    using fmap_t = hpx::detail::flat_set<std::string>;
+    using rev_fmap_t = hpx::detail::flat_set<std::string, std::greater<>>;
+    using value_t = std::string;
+
+    auto pair_cmp = [](auto lhs, auto rhs) { return lhs == rhs; };
+
+    fmap_t::key_container_type const c = {"key1", "key2", "key0"};
+    std::vector<value_t> const vec = {"key1", "key2", "key0"};
+    std::vector<value_t> sorted_vec = vec;
+    std::sort(sorted_vec.begin(), sorted_vec.end());
+
+    value_t const val1("q");
+    value_t const val2("w");
+
+    using foreign_value_t = char const*;
+
+    {
+        foreign_value_t foreign_pair("e");
+
+        // NOTE: These calls exercise all emplace's and inserts before the range
+        // inserts.
+
+        fmap_t map;
+        map.insert(val1);
+        map.insert(value_t("r"));
+        map.insert(map.begin(), val2);
+        map.insert(map.begin(), value_t("t"));
+        map.insert(foreign_pair);
+        map.insert(static_cast<foreign_value_t>("y"));
+
+        std::vector<value_t> const qwerty_vec = {"e", "q", "r", "t", "w", "y"};
+        HPX_TEST(std::equal(map.begin(), map.end(), qwerty_vec.begin(),
+            qwerty_vec.end(), pair_cmp));
+    }
+
+    // NOTE: Already exercised by ctor test:
+    // template<class InputIterator>
+    // void insert(InputIterator first, InputIterator last);
+    // template<class InputIterator>
+    // void insert(sorted_unique_t, InputIterator first, InputIterator last);
+
+    {
+        fmap_t map;
+        map.insert({value_t{"key1"}, value_t{"key2"}, value_t{"key0"}});
+        HPX_TEST_EQ(map.size(), 3u);
+        HPX_TEST(!(map.empty()));
+        HPX_TEST(std::equal(map.begin(), map.end(), sorted_vec.begin(),
+            sorted_vec.end(), pair_cmp));
+    }
+
+    {
+        rev_fmap_t map;
+        map.insert({value_t{"key1"}, value_t{"key2"}, value_t{"key0"}});
+        HPX_TEST_EQ(map.size(), 3u);
+        HPX_TEST(!(map.empty()));
+        HPX_TEST(std::equal(map.rbegin(), map.rend(), sorted_vec.begin(),
+            sorted_vec.end(), pair_cmp));
+    }
+
+    {
+        // This breaks the ctor's contract, since c are not in sorted
+        // order, but it's useful to verify that the resulting contents were
+        // not touched.
+        fmap_t map;
+        map.insert(hpx::detail::sorted_unique,
+            {value_t{"key1"}, value_t{"key2"}, value_t{"key0"}});
+        HPX_TEST_EQ(map.size(), 3u);
+        HPX_TEST(!(map.empty()));
+        HPX_TEST(std::equal(
+            map.begin(), map.end(), vec.begin(), vec.end(), pair_cmp));
+    }
+}
+
+void std_flat_set_extract_replace()
+{
+    using fmap_t = hpx::detail::flat_set<std::string>;
+    using value_t = std::string;
+
+    fmap_t::key_container_type const sorted_c = {"key0", "key1", "key2"};
+    std::vector<value_t> const vec = {"key1", "key2", "key0"};
+
+    fmap_t map1(vec);
+    fmap_t const map1_copy = map1;
+
+    fmap_t::key_container_type extracted_c = std::move(map1).extract();
+    HPX_TEST_EQ(extracted_c, sorted_c);
+
+    fmap_t map2;
+    map2.replace(std::move(extracted_c));
+    HPX_TEST_EQ(map2, map1_copy);
+}
+
+void std_flat_set_erase_swap()
+{
+    using fmap_t = hpx::detail::flat_set<std::string>;
+    using value_t = std::string;
+
+    auto pair_cmp = [](auto lhs, auto rhs) { return lhs == rhs; };
+
+    std::vector<value_t> const vec = {"key0", "key1", "key2"};
+
+    {
+        fmap_t map(vec);
+        map.erase(map.begin());
+        std::vector<value_t> const local_vec = {"key1", "key2"};
+        HPX_TEST(std::equal(map.begin(), map.end(), local_vec.begin(),
+            local_vec.end(), pair_cmp));
+    }
+
+    {
+        fmap_t map(vec);
+        map.erase(map.cbegin());
+        std::vector<value_t> const local_vec = {"key1", "key2"};
+        HPX_TEST(std::equal(map.begin(), map.end(), local_vec.begin(),
+            local_vec.end(), pair_cmp));
+    }
+
+    {
+        fmap_t map(vec);
+        map.erase("key0");
+        std::vector<value_t> const local_vec = {"key1", "key2"};
+        HPX_TEST(std::equal(map.begin(), map.end(), local_vec.begin(),
+            local_vec.end(), pair_cmp));
+    }
+
+    {
+        fmap_t map(vec);
+        map.erase(map.begin(), map.end());
+        HPX_TEST_EQ(map.begin(), map.end());
+    }
+
+    {
+        fmap_t const orig_map(vec);
+        fmap_t const orig_empty_map;
+
+        auto map1 = orig_map;
+        auto map2 = orig_empty_map;
+
+        std::swap(map1, map2);
+
+        HPX_TEST_EQ(map1, orig_empty_map);
+        HPX_TEST_EQ(map2, orig_map);
+
+        std::swap(map1, map2);
+
+        HPX_TEST_EQ(map1, orig_map);
+        HPX_TEST_EQ(map2, orig_empty_map);
+    }
+}
+
+void std_flat_set_count_contains()
+{
+    using fmap_t = hpx::detail::flat_set<std::string>;
+    using value_t = std::string;
+
+    std::vector<value_t> const vec = {"key1", "key2", "key0"};
+
+    fmap_t const map(vec);
+    HPX_TEST_EQ(map.count("key0"), 1u);
+    HPX_TEST_EQ(map.count("key10"), 0u);
+    HPX_TEST(map.count("key0"));
+    HPX_TEST(!(map.count("key10")));
+}
+
+void std_flat_set_equal_range()
+{
+    using fmap_t = hpx::detail::flat_set<std::string>;
+    using value_t = std::string;
+
+    std::vector<value_t> const vec = {"key1", "key2", "key0"};
+
+    fmap_t const map(vec);
+    auto const eq_range = map.equal_range("key0");
+    HPX_TEST_EQ(eq_range.first, map.begin());
+    HPX_TEST_EQ(eq_range.second, map.begin() + 1);
+    auto const empty_eq_range = map.equal_range("");
+    HPX_TEST_EQ(empty_eq_range.first, empty_eq_range.second);
+}
+
+void std_flat_set_comparisons()
+{
+    using fmap_t = hpx::detail::flat_set<std::string>;
+    using value_t = std::string;
+
+    std::vector<value_t> const vec = {"key0", "key1", "key2"};
+
+    fmap_t const map_123(vec);
+    fmap_t const map_12(vec.begin(), vec.begin() + 2);
+
+    HPX_TEST_EQ(map_123, map_123);
+    HPX_TEST_NEQ(map_123, map_12);
+
+    HPX_TEST_LT(map_12, map_123);
+    HPX_TEST_LTE(map_12, map_123);
+    HPX_TEST_LTE(map_123, map_123);
+}
+
+int main()
+{
+    test_std_flat_set_iterator();
+    std_flat_set_ctors_iterators();
+    std_flat_set_ctors_allocators_iterators();
+    std_flat_set_emplace_insert();
+    std_flat_set_extract_replace();
+    std_flat_set_erase_swap();
+    std_flat_set_count_contains();
+    std_flat_set_equal_range();
+    std_flat_set_comparisons();
+
+    return hpx::util::report_errors();
+}

--- a/libs/core/debugging/src/print.cpp
+++ b/libs/core/debugging/src/print.cpp
@@ -264,8 +264,15 @@ namespace hpx::debug {
                 int const rank = guess_rank();
                 if (rank != -1)
                 {
+#if defined(HPX_GCC_VERSION) && HPX_GCC_VERSION >= 110000
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wrestrict"
+#endif
                     std::string const temp =
                         "(" + std::to_string(guess_rank()) + ")";
+#if defined(HPX_GCC_VERSION) && HPX_GCC_VERSION >= 110000
+#pragma GCC diagnostic pop
+#endif
                     std::strcat(hostname_, temp.c_str());
                 }
             }

--- a/libs/core/execution/include/hpx/execution/algorithms/just.hpp
+++ b/libs/core/execution/include/hpx/execution/algorithms/just.hpp
@@ -57,6 +57,10 @@ namespace hpx::execution::experimental {
             just_sender& operator=(just_sender&&) = default;
             just_sender& operator=(just_sender const&) = default;
 
+#if defined(HPX_GCC_VERSION) && HPX_GCC_VERSION >= 110000
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Warray-bounds"
+#endif
             template <typename Receiver>
             struct operation_state
             {
@@ -92,6 +96,9 @@ namespace hpx::execution::experimental {
                         });
                 }
             };
+#if defined(HPX_GCC_VERSION) && HPX_GCC_VERSION >= 110000
+#pragma GCC diagnostic pop
+#endif
 
             template <typename Receiver>
             friend auto tag_invoke(

--- a/libs/core/execution/include/hpx/execution/algorithms/schedule_from.hpp
+++ b/libs/core/execution/include/hpx/execution/algorithms/schedule_from.hpp
@@ -89,6 +89,10 @@ namespace hpx::execution::experimental {
 
             // TODO: add forwarding_sender_query
 
+#if defined(HPX_GCC_VERSION) && HPX_GCC_VERSION >= 110000
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Warray-bounds"
+#endif
             template <typename Receiver>
             struct operation_state
             {
@@ -306,6 +310,9 @@ namespace hpx::execution::experimental {
                     hpx::execution::experimental::start(os.sender_os);
                 }
             };
+#if defined(HPX_GCC_VERSION) && HPX_GCC_VERSION >= 110000
+#pragma GCC diagnostic pop
+#endif
 
             template <typename Receiver>
             friend operation_state<Receiver> tag_invoke(

--- a/libs/core/execution/include/hpx/execution/algorithms/then.hpp
+++ b/libs/core/execution/include/hpx/execution/algorithms/then.hpp
@@ -28,6 +28,10 @@ namespace hpx::execution::experimental {
 
     namespace detail {
 
+#if defined(HPX_GCC_VERSION) && HPX_GCC_VERSION >= 110000
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Warray-bounds"
+#endif
         template <typename Receiver, typename F>
         struct then_receiver
         {
@@ -90,6 +94,9 @@ namespace hpx::execution::experimental {
                 HPX_MOVE(r).set_value_helper(HPX_FORWARD(Ts, ts)...);
             }
         };
+#if defined(HPX_GCC_VERSION) && HPX_GCC_VERSION >= 110000
+#pragma GCC diagnostic pop
+#endif
 
         template <typename Sender, typename F>
         struct then_sender

--- a/libs/core/execution/include/hpx/execution/algorithms/when_all.hpp
+++ b/libs/core/execution/include/hpx/execution/algorithms/when_all.hpp
@@ -230,6 +230,10 @@ namespace hpx::execution::experimental {
                 std::size_t I = num_predecessors - 1>
             struct operation_state;
 
+#if defined(HPX_GCC_VERSION) && HPX_GCC_VERSION >= 110000
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Warray-bounds"
+#endif
             template <typename Receiver, typename SendersPack>
             struct operation_state<Receiver, SendersPack, 0>
             {
@@ -421,6 +425,9 @@ namespace hpx::execution::experimental {
                     hpx::execution::experimental::start(op_state);
                 }
             };
+#if defined(HPX_GCC_VERSION) && HPX_GCC_VERSION >= 110000
+#pragma GCC diagnostic pop
+#endif
 
             template <typename Receiver, typename SendersPack>
             friend void tag_invoke(start_t,

--- a/libs/core/execution_base/include/hpx/execution_base/traits/coroutine_traits.hpp
+++ b/libs/core/execution_base/include/hpx/execution_base/traits/coroutine_traits.hpp
@@ -10,8 +10,8 @@
 
 #if defined(HPX_HAVE_CXX20_COROUTINES)
 
-#include <hpx/config.hpp>
 #include <hpx/concepts/has_member_xxx.hpp>
+#include <hpx/type_support/coroutines_support.hpp>
 #include <hpx/type_support/meta.hpp>
 
 #include <type_traits>
@@ -33,7 +33,7 @@ namespace hpx::execution::experimental {
         template <typename T>
         inline constexpr bool is_await_suspend_result_t_v =
             meta::value<meta::one_of<T, void, bool>> ||
-            is_instance_of<T, hpx::coro::coroutine_handle>;
+            is_instance_of<T, hpx::coroutine_handle>;
 
         template <typename, typename = void>
         inline constexpr bool has_await_ready = false;
@@ -54,7 +54,7 @@ namespace hpx::execution::experimental {
         // clang-format off
         template <typename T, typename Ts>
         using await_suspend_coro_handle_t = decltype(
-            std::declval<T>().await_suspend(hpx::coro::coroutine_handle<Ts>{}));
+            std::declval<T>().await_suspend(hpx::coroutine_handle<Ts>{}));
         // clang-format on
 
         template <typename Awaiter, typename Promise>

--- a/libs/core/execution_base/tests/include/coroutine_task.hpp
+++ b/libs/core/execution_base/tests/include/coroutine_task.hpp
@@ -6,7 +6,6 @@
 
 #pragma once
 
-#include <hpx/config/coroutines_support.hpp>
 #include <hpx/concepts/has_member_xxx.hpp>
 #include <hpx/execution/queries/get_stop_token.hpp>
 #include <hpx/execution_base/completion_signatures.hpp>
@@ -14,6 +13,7 @@
 #include <hpx/execution_base/get_env.hpp>
 #include <hpx/functional/tag_invoke.hpp>
 #include <hpx/synchronization/stop_token.hpp>
+#include <hpx/type_support/coroutines_support.hpp>
 #include <hpx/type_support/meta.hpp>
 
 #include <any>
@@ -305,8 +305,8 @@ private:
         {
             return {};
         }
-        static hpx::coro::coroutine_handle<> await_suspend(
-            hpx::coro::coroutine_handle<_promise> h) noexcept
+        static hpx::coroutine_handle<> await_suspend(
+            hpx::coroutine_handle<_promise> h) noexcept
         {
             return h.promise().continuation();
         }
@@ -320,9 +320,9 @@ private:
         basic_task get_return_object() noexcept
         {
             return basic_task(
-                hpx::coro::coroutine_handle<_promise>::from_promise(*this));
+                hpx::coroutine_handle<_promise>::from_promise(*this));
         }
-        hpx::coro::suspend_always initial_suspend() noexcept
+        hpx::suspend_always initial_suspend() noexcept
         {
             return {};
         }
@@ -347,7 +347,7 @@ private:
     template <typename ParentPromise = void>
     struct task_awaitable
     {
-        hpx::coro::coroutine_handle<_promise> coro_;
+        hpx::coroutine_handle<_promise> coro_;
         std::optional<awaiter_context_t<_promise, ParentPromise>> context_{};
 
         ~task_awaitable()
@@ -364,8 +364,8 @@ private:
         }
 
         template <typename ParentPromise2>
-        hpx::coro::coroutine_handle<> await_suspend(
-            hpx::coro::coroutine_handle<ParentPromise2> parent) noexcept
+        hpx::coroutine_handle<> await_suspend(
+            hpx::coroutine_handle<ParentPromise2> parent) noexcept
         {
             static_assert(
                 hpx::meta::one_of<ParentPromise, ParentPromise2, void>::value);
@@ -421,13 +421,12 @@ private:
         const basic_task&, auto) -> std::conditional_t<std::is_void_v<T>,
         task_traits_t<>, task_traits_t<T>>;
 
-    explicit basic_task(
-        hpx::coro::coroutine_handle<promise_type> hcoro) noexcept
+    explicit basic_task(hpx::coroutine_handle<promise_type> hcoro) noexcept
       : coro_(hcoro)
     {
     }
 
-    hpx::coro::coroutine_handle<promise_type> coro_;
+    hpx::coroutine_handle<promise_type> coro_;
 };
 
 template <typename T, typename Context = default_task_context<T>>

--- a/libs/core/execution_base/tests/unit/completion_signatures.cpp
+++ b/libs/core/execution_base/tests/unit/completion_signatures.cpp
@@ -4,11 +4,11 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include <hpx/config/coroutines_support.hpp>
 #include <hpx/datastructures/tuple.hpp>
 #include <hpx/datastructures/variant.hpp>
 #include <hpx/execution_base/completion_signatures.hpp>
 #include <hpx/modules/testing.hpp>
+#include <hpx/type_support/coroutines_support.hpp>
 
 #include <exception>
 #include <utility>
@@ -324,15 +324,15 @@ void test_sender3()
 template <typename Awaiter>
 struct promise
 {
-    hpx::coro::coroutine_handle<promise> get_return_object()
+    hpx::coroutine_handle<promise> get_return_object()
     {
-        return {hpx::coro::coroutine_handle<promise>::from_promise(*this)};
+        return {hpx::coroutine_handle<promise>::from_promise(*this)};
     }
-    hpx::coro::suspend_always initial_suspend() noexcept
+    hpx::suspend_always initial_suspend() noexcept
     {
         return {};
     }
-    hpx::coro::suspend_always final_suspend() noexcept
+    hpx::suspend_always final_suspend() noexcept
     {
         return {};
     }
@@ -349,7 +349,7 @@ struct promise
 struct awaiter
 {
     void await_ready() {}
-    bool await_suspend(hpx::coro::coroutine_handle<>)
+    bool await_suspend(hpx::coroutine_handle<>)
     {
         return false;
     }
@@ -367,7 +367,7 @@ struct awaitable_sender_1
 
 struct awaitable_sender_2
 {
-    using promise_type = promise<hpx::coro::suspend_always>;
+    using promise_type = promise<hpx::suspend_always>;
 };
 
 struct awaitable_sender_3
@@ -412,7 +412,7 @@ void test_awaitable_sender2(Signatures)
     // static_assert(ex::is_sender_v<awaitable_sender_2>);
 
     // static_assert(ex::is_awaitable_v<awaitable_sender_2,
-    //     promise<hpx::coro::suspend_always>>);
+    //     promise<hpx::suspend_always>>);
 
     // awaitable_sender_2 s;
     // static_assert(!hpx::meta::value<
@@ -550,7 +550,7 @@ int main()
 
     {
         test_awaitable_sender1(signature_error_values(std::exception_ptr()),
-            hpx::coro::suspend_always{});
+            hpx::suspend_always{});
         test_awaitable_sender1(
             signature_error_values(std::exception_ptr(), bool()), awaiter{});
 

--- a/libs/core/execution_base/tests/unit/coroutine_traits.cpp
+++ b/libs/core/execution_base/tests/unit/coroutine_traits.cpp
@@ -4,9 +4,9 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include <hpx/config/coroutines_support.hpp>
 #include <hpx/execution_base/traits/coroutine_traits.hpp>
 #include <hpx/modules/testing.hpp>
+#include <hpx/type_support/coroutines_support.hpp>
 
 #include <utility>
 
@@ -16,28 +16,28 @@ struct awaiter_1
     {
         return false;
     }
-    void await_suspend(hpx::coro::coroutine_handle<>) {}
+    void await_suspend(hpx::coroutine_handle<>) {}
     void await_resume() {}
 };
 
 struct awaiter_2
 {
     void await_ready() {}
-    void await_suspend(hpx::coro::coroutine_handle<>) {}
+    void await_suspend(hpx::coroutine_handle<>) {}
     void await_resume() {}
 };
 
 struct awaiter_3
 {
     void await_ready() {}
-    void await_suspend(hpx::coro::coroutine_handle<>) {}
+    void await_suspend(hpx::coroutine_handle<>) {}
     void await_resume() {}
 };
 
 struct awaiter_4
 {
     void await_ready() {}
-    bool await_suspend(hpx::coro::coroutine_handle<>)
+    bool await_suspend(hpx::coroutine_handle<>)
     {
         return false;
     }
@@ -47,7 +47,7 @@ struct awaiter_4
 struct awaiter_5
 {
     void await_ready() {}
-    bool await_suspend(hpx::coro::coroutine_handle<>)
+    bool await_suspend(hpx::coroutine_handle<>)
     {
         return false;
     }
@@ -66,7 +66,7 @@ struct awaiter_6
     {
         return false;
     }
-    void await_suspend(hpx::coro::coroutine_handle<Promise>) {}
+    void await_suspend(hpx::coroutine_handle<Promise>) {}
     void await_resume() {}
 };
 
@@ -98,15 +98,15 @@ struct non_awaiter_4
 
 struct promise
 {
-    hpx::coro::coroutine_handle<promise> get_return_object()
+    hpx::coroutine_handle<promise> get_return_object()
     {
-        return {hpx::coro::coroutine_handle<promise>::from_promise(*this)};
+        return {hpx::coroutine_handle<promise>::from_promise(*this)};
     }
-    hpx::coro::suspend_always initial_suspend() noexcept
+    hpx::suspend_always initial_suspend() noexcept
     {
         return {};
     }
-    hpx::coro::suspend_always final_suspend() noexcept
+    hpx::suspend_always final_suspend() noexcept
     {
         return {};
     }

--- a/libs/core/functional/include/hpx/functional/bind_back.hpp
+++ b/libs/core/functional/include/hpx/functional/bind_back.hpp
@@ -118,8 +118,8 @@ namespace hpx::detail {
         void serialize(Archive& ar, unsigned int const /*version*/)
         {
             // clang-format off
-                ar & _f;
-                ar & _args;
+            ar & _f;
+            ar & _args;
             // clang-format on
         }
 

--- a/libs/core/futures/include/hpx/futures/future.hpp
+++ b/libs/core/futures/include/hpx/futures/future.hpp
@@ -34,6 +34,7 @@
 #include <hpx/serialization/exception_ptr.hpp>
 #include <hpx/serialization/serialization_fwd.hpp>
 #include <hpx/timing/steady_clock.hpp>
+#include <hpx/type_support/coroutines_support.hpp>
 #include <hpx/type_support/decay.hpp>
 
 #include <exception>

--- a/libs/core/futures/include/hpx/futures/traits/detail/future_await_traits.hpp
+++ b/libs/core/futures/include/hpx/futures/traits/detail/future_await_traits.hpp
@@ -7,7 +7,6 @@
 #pragma once
 
 #include <hpx/config.hpp>
-#include <hpx/config/coroutines_support.hpp>
 
 #if defined(HPX_HAVE_CXX20_COROUTINES)
 
@@ -15,6 +14,7 @@
 #include <hpx/futures/traits/future_access.hpp>
 #include <hpx/modules/allocator_support.hpp>
 #include <hpx/modules/memory.hpp>
+#include <hpx/type_support/coroutines_support.hpp>
 
 #include <cstddef>
 #include <exception>
@@ -26,8 +26,8 @@
 namespace hpx::lcos::detail {
 
     template <typename Promise = void>
-    using coroutine_handle = coro::coroutine_handle<Promise>;
-    using suspend_never = coro::suspend_never;
+    using coroutine_handle = hpx::coroutine_handle<Promise>;
+    using suspend_never = hpx::suspend_never;
 
     ///////////////////////////////////////////////////////////////////////////
     // this was removed from the TS, so we define our own

--- a/libs/core/futures/tests/regressions/set_hpx_limit_798.cpp
+++ b/libs/core/futures/tests/regressions/set_hpx_limit_798.cpp
@@ -23,6 +23,7 @@ double func(double x1, double, double, double, double, double, double)
 int hpx_main()
 {
     hpx::shared_future<double> f = hpx::make_ready_future(1.0);
+
     f = hpx::dataflow(
         hpx::launch::sync, hpx::unwrapping(&func), f, f, f, f, f, f, f);
     return hpx::local::finalize();

--- a/libs/core/include_local/CMakeLists.txt
+++ b/libs/core/include_local/CMakeLists.txt
@@ -17,6 +17,7 @@ set(include_local_headers
     hpx/local/execution.hpp
     hpx/local/functional.hpp
     hpx/local/future.hpp
+    hpx/local/generator.hpp
     hpx/local/latch.hpp
     hpx/local/memory.hpp
     hpx/local/mutex.hpp

--- a/libs/core/include_local/include/hpx/local/generator.hpp
+++ b/libs/core/include_local/include/hpx/local/generator.hpp
@@ -1,0 +1,9 @@
+//  Copyright (c) 2023 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include <hpx/type_support/generator.hpp>

--- a/libs/core/iterator_support/include/hpx/iterator_support/iterator_facade.hpp
+++ b/libs/core/iterator_support/include/hpx/iterator_support/iterator_facade.hpp
@@ -15,6 +15,7 @@
 
 #include <hpx/config.hpp>
 #include <hpx/iterator_support/traits/is_iterator.hpp>
+#include <hpx/type_support/equality.hpp>
 
 #include <cstddef>
 #include <iterator>
@@ -165,7 +166,7 @@ namespace hpx::util {
             }
 
         public:
-            HPX_HOST_DEVICE constexpr reference operator*() const
+            HPX_HOST_DEVICE constexpr decltype(auto) operator*() const
                 noexcept(noexcept(iterator_core_access::dereference<reference>(
                     std::declval<Derived>())))
             {
@@ -556,12 +557,12 @@ namespace hpx::util {
     }
 
     namespace detail {
-        template <typename Facade1, typename Facade2, typename Return>
-        struct enable_operator_interoperable
-          : std::enable_if<std::is_convertible_v<Facade1, Facade2> ||
-                    std::is_convertible_v<Facade2, Facade1>,
-                Return>
+        template <typename Facade1, typename Facade2, typename Return,
+            typename = std::void_t<decltype(iterator_core_access::equal(
+                std::declval<Facade1>(), std::declval<Facade2>()))>>
+        struct enable_operator_equal_interoperable
         {
+            using type = Return;
         };
 
         template <typename Facade1, typename Facade2, typename Return,
@@ -581,8 +582,8 @@ namespace hpx::util {
         typename Derived2, typename T2, typename Category2,                    \
         typename Reference2, typename Distance2, typename Pointer2>            \
     HPX_HOST_DEVICE prefix                                                     \
-        typename hpx::util::detail::enable_operator_interoperable<Derived1,    \
-            Derived2, result_type>::type                                       \
+        typename hpx::util::detail::enable_operator_equal_interoperable<       \
+            Derived1, Derived2, result_type>::type                             \
         operator op(iterator_facade<Derived1, T1, Category1, Reference1,       \
                         Distance1, Pointer1> const& lhs,                       \
             iterator_facade<Derived2, T2, Category2, Reference2, Distance2,    \

--- a/libs/core/iterator_support/include/hpx/iterator_support/iterator_range.hpp
+++ b/libs/core/iterator_support/include/hpx/iterator_support/iterator_range.hpp
@@ -80,6 +80,10 @@ namespace hpx::util {
     iterator_range(Range const& r)
         -> iterator_range<hpx::traits::range_iterator_t<Range const>>;
 
+    template <typename Iterator, typename Sentinel>
+    iterator_range(Iterator it, Sentinel sent)
+        -> iterator_range<Iterator, Sentinel>;
+
     template <typename Range,
         typename Iterator = traits::range_iterator_t<Range>,
         typename Sentinel = traits::range_iterator_t<Range>>

--- a/libs/core/iterator_support/include/hpx/iterator_support/traits/is_range.hpp
+++ b/libs/core/iterator_support/include/hpx/iterator_support/traits/is_range.hpp
@@ -8,29 +8,29 @@
 #pragma once
 
 #include <hpx/iterator_support/range.hpp>
-#include <hpx/iterator_support/traits/is_sentinel_for.hpp>
+#include <hpx/iterator_support/traits/is_iterator.hpp>
 
 #include <iterator>
 #include <type_traits>
+#include <utility>
 
 namespace hpx::traits {
 
     ///////////////////////////////////////////////////////////////////////////
-    template <typename T, typename Enable = void>
-    struct is_range : std::false_type
-    {
-    };
-
     template <typename T>
-    struct is_range<T,
-        std::enable_if_t<hpx::traits::is_sentinel_for<
-            typename util::detail::sentinel<T>::type,
-            typename util::detail::iterator<T>::type>::value>> : std::true_type
-    {
-    };
+    using is_range = util::detail::is_range<T>;
 
     template <typename T>
     inline constexpr bool is_range_v = is_range<T>::value;
+
+    ///////////////////////////////////////////////////////////////////////////
+    // return whether a given type is a range generator (i.e. exposes supports
+    // an iterate function that returns a range)
+    template <typename T>
+    using is_range_generator = util::detail::is_range_generator<T>;
+
+    template <typename T>
+    inline constexpr bool is_range_generator_v = is_range_generator<T>::value;
 
     ///////////////////////////////////////////////////////////////////////////
     template <typename T, typename Enable = void>
@@ -38,8 +38,14 @@ namespace hpx::traits {
     {
     };
 
-    template <typename T>
-    using range_iterator_t = typename range_iterator<T>::type;
+    template <typename Range>
+    struct range_iterator<Range, std::enable_if_t<is_range_generator_v<Range>>>
+    {
+        // clang-format off
+        using type = typename range_iterator<decltype(
+            hpx::util::iterate(std::declval<Range&>()))>::type;
+        // clang-format on
+    };
 
     template <typename T, typename Enable = void>
     struct range_sentinel : util::detail::sentinel<T>
@@ -47,7 +53,14 @@ namespace hpx::traits {
     };
 
     template <typename T>
+    using range_iterator_t = typename range_iterator<T>::type;
+
+    template <typename T>
     using range_sentinel_t = typename range_sentinel<T>::type;
+
+    // return the iterator category encapsulated by the range
+    template <typename T>
+    using range_category_t = iter_category_t<range_iterator_t<T>>;
 
     ///////////////////////////////////////////////////////////////////////////
     template <typename R, bool IsRange = is_range<R>::value>
@@ -62,7 +75,4 @@ namespace hpx::traits {
         using iterator_type = typename util::detail::iterator<R>::type;
         using sentinel_type = typename util::detail::sentinel<R>::type;
     };
-
-    template <typename T>
-    using range_iterator_t = typename range_iterator<T>::type;
 }    // namespace hpx::traits

--- a/libs/core/pack_traversal/include/hpx/pack_traversal/detail/pack_traversal_async_impl.hpp
+++ b/libs/core/pack_traversal/include/hpx/pack_traversal/detail/pack_traversal_async_impl.hpp
@@ -618,7 +618,14 @@ namespace hpx::util::detail {
     void resume_traversal_callable<Frame, State>::operator()()
     {
         auto hierarchy = hpx::tuple_cat(hpx::make_tuple(frame_), state_);
+#if defined(HPX_GCC_VERSION) && HPX_GCC_VERSION >= 110000
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wstringop-overflow"
+#endif
         hpx::invoke_fused(resume_state_callable{}, HPX_MOVE(hierarchy));
+#if defined(HPX_GCC_VERSION) && HPX_GCC_VERSION >= 110000
+#pragma GCC diagnostic pop
+#endif
     }
 
     /// Gives access to types related to the traversal frame

--- a/libs/core/program_options/src/cmdline.cpp
+++ b/libs/core/program_options/src/cmdline.cpp
@@ -611,8 +611,15 @@ namespace hpx::program_options::detail {
         std::string const& tok = args[0];
         if (tok.size() >= 2 && tok[0] == '/')
         {
+#if defined(HPX_GCC_VERSION) && HPX_GCC_VERSION >= 110000
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wrestrict"
+#endif
             std::string name = "-" + tok.substr(1, 1);
-            std::string adjacent = tok.substr(2);
+#if defined(HPX_GCC_VERSION) && HPX_GCC_VERSION >= 110000
+#pragma GCC diagnostic pop
+#endif
+            std::string const adjacent = tok.substr(2);
 
             option opt;
             opt.string_key = HPX_MOVE(name);
@@ -640,7 +647,14 @@ namespace hpx::program_options::detail {
                         is_style_active(long_case_insensitive),
                         is_style_active(short_case_insensitive)))
                 {
+#if defined(HPX_GCC_VERSION) && HPX_GCC_VERSION >= 110000
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wrestrict"
+#endif
                     args[0].insert(0, "-");
+#if defined(HPX_GCC_VERSION) && HPX_GCC_VERSION >= 110000
+#pragma GCC diagnostic pop
+#endif
                     if (args[0][1] == '/')
                         args[0][1] = '-';
                     return parse_long_option(args);

--- a/libs/core/runtime_local/src/runtime_local.cpp
+++ b/libs/core/runtime_local/src/runtime_local.cpp
@@ -1848,7 +1848,16 @@ namespace hpx {
         fullname += context;
         if (postfix && *postfix)
             fullname += postfix;
+
+#if defined(HPX_GCC_VERSION) && HPX_GCC_VERSION >= 110000
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wrestrict"
+#endif
         fullname += "#" + std::to_string(global_thread_num);
+#if defined(HPX_GCC_VERSION) && HPX_GCC_VERSION >= 110000
+#pragma GCC diagnostic pop
+#endif
+
         detail::thread_name() = HPX_MOVE(fullname);
 
         char const* name = detail::thread_name().c_str();

--- a/libs/core/serialization/CMakeLists.txt
+++ b/libs/core/serialization/CMakeLists.txt
@@ -150,6 +150,7 @@ set(serialization_headers
     hpx/serialization/traits/brace_initializable_traits.hpp
     hpx/serialization/traits/is_bitwise_serializable.hpp
     hpx/serialization/traits/is_not_bitwise_serializable.hpp
+    hpx/serialization/traits/is_serializable.hpp
     hpx/serialization/traits/needs_automatic_registration.hpp
     hpx/serialization/traits/polymorphic_traits.hpp
     hpx/serialization/traits/serialization_access_data.hpp

--- a/libs/core/serialization/include/hpx/serialization/traits/is_bitwise_serializable.hpp
+++ b/libs/core/serialization/include/hpx/serialization/traits/is_bitwise_serializable.hpp
@@ -9,6 +9,7 @@
 
 #include <hpx/config.hpp>
 #include <hpx/serialization/config/defines.hpp>
+#include <hpx/serialization/serialization_fwd.hpp>
 
 #include <type_traits>
 

--- a/libs/core/serialization/include/hpx/serialization/traits/is_not_bitwise_serializable.hpp
+++ b/libs/core/serialization/include/hpx/serialization/traits/is_not_bitwise_serializable.hpp
@@ -8,7 +8,7 @@
 
 #include <hpx/config.hpp>
 #include <hpx/serialization/config/defines.hpp>
-#include <hpx/serialization/access.hpp>
+#include <hpx/serialization/traits/is_serializable.hpp>
 
 #include <type_traits>
 
@@ -21,12 +21,10 @@ namespace hpx::traits {
 #if defined(HPX_SERIALIZATION_HAVE_ALL_TYPES_ARE_BITWISE_SERIALIZABLE)
     // By default, any abstract type or type that exposes serialization will be
     // treated as non-bitwise copyable.
-    template <typename T>
+    template <typename T, typename Enable = void>
     struct is_not_bitwise_serializable
       : std::integral_constant<bool,
-            std::is_abstract_v<T> ||
-                hpx::serialization::access::has_serialize_v<T> ||
-                hpx::serialization::has_serialize_adl_v<T>>
+            std::is_abstract_v<T> || hpx::traits::has_serialize_adl_v<T>>
     {
     };
 
@@ -34,7 +32,7 @@ namespace hpx::traits {
     inline constexpr bool is_not_bitwise_serializable_v =
         is_not_bitwise_serializable<T>::value;
 #else
-    template <typename T>
+    template <typename T, typename Enable = void>
     struct is_not_bitwise_serializable : std::true_type
     {
     };

--- a/libs/core/serialization/include/hpx/serialization/traits/is_serializable.hpp
+++ b/libs/core/serialization/include/hpx/serialization/traits/is_serializable.hpp
@@ -1,0 +1,63 @@
+//  Copyright (c) 2023 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include <hpx/config.hpp>
+#include <hpx/serialization/config/defines.hpp>
+#include <hpx/serialization/serialization_fwd.hpp>
+#include <hpx/serialization/traits/brace_initializable_traits.hpp>
+
+#include <type_traits>
+#include <utility>
+
+namespace hpx::traits {
+
+    ///////////////////////////////////////////////////////////////////////////
+    template <typename T>
+    class has_serialize_adl
+    {
+        template <typename T1>
+        static std::false_type test(...);
+
+        // clang-format off
+        template <typename T1,
+            typename = decltype(serialize(
+                std::declval<hpx::serialization::output_archive&>(),
+                std::declval<std::remove_const_t<T1>&>(), 0u))>
+        static std::true_type test(int);
+        // clang-format on
+
+    public:
+        static constexpr bool value = decltype(test<T>(0))::value;
+    };
+
+    template <typename T>
+    inline constexpr bool has_serialize_adl_v = has_serialize_adl<T>::value;
+
+    ///////////////////////////////////////////////////////////////////////////
+    template <typename T>
+    class has_struct_serialization
+    {
+        template <typename T1>
+        static std::false_type test(...);
+
+        template <typename T1,
+            typename = decltype(serialize_struct(
+                std::declval<hpx::serialization::output_archive&>(),
+                std::declval<std::remove_const_t<T1>&>(), 0u,
+                hpx::traits::detail::arity<T1>()))>
+        static std::true_type test(int);
+
+    public:
+        static constexpr bool value = decltype(test<T>(0))::value;
+    };
+
+    template <typename T>
+    inline constexpr bool has_struct_serialization_v =
+        has_struct_serialization<T>::value;
+
+}    // namespace hpx::traits

--- a/libs/core/serialization/tests/unit/serialization_brace_initializable.cpp
+++ b/libs/core/serialization/tests/unit/serialization_brace_initializable.cpp
@@ -35,10 +35,10 @@ static_assert(hpx::traits::is_paren_constructible<A, 3>(),
 
 static_assert(hpx::traits::detail::arity<A>().value == 3,
     "hpx::traits::detail::arity<A>() == size<3>{}");
-static_assert(hpx::serialization::has_struct_serialization<A>::value,
+static_assert(hpx::traits::has_struct_serialization<A>::value,
     "has_struct_serialization<A>::value");
-static_assert(!hpx::serialization::has_serialize_adl<A>::value,
-    "!has_serialize_adl<A>::value");
+static_assert(
+    !hpx::traits::has_serialize_adl<A>::value, "!has_serialize_adl<A>::value");
 
 bool operator==(const A& a1, const A& a2)
 {
@@ -67,10 +67,10 @@ static_assert(hpx::traits::is_paren_constructible<B, 2>(),
 
 static_assert(hpx::traits::detail::arity<B>().value == 2,
     "hpx::traits::detail::arity<B>() == size<2>{}");
-static_assert(hpx::serialization::has_struct_serialization<B>::value,
+static_assert(hpx::traits::has_struct_serialization<B>::value,
     "has_struct_serialization<B>::value");
-static_assert(!hpx::serialization::has_serialize_adl<B>::value,
-    "!has_serialize_adl<B>::value");
+static_assert(
+    !hpx::traits::has_serialize_adl<B>::value, "!has_serialize_adl<B>::value");
 
 bool operator==(const B& b1, const B& b2)
 {

--- a/libs/core/synchronization/include/hpx/synchronization/stop_token.hpp
+++ b/libs/core/synchronization/include/hpx/synchronization/stop_token.hpp
@@ -699,10 +699,17 @@ namespace hpx::p2300_stop_token {
         {
             state_.add_source_count();
         }
+#if defined(HPX_GCC_VERSION) && HPX_GCC_VERSION >= 110000
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Warray-bounds"
+#endif
         ~in_place_stop_source()
         {
             state_.remove_source_count();
         }
+#if defined(HPX_GCC_VERSION) && HPX_GCC_VERSION >= 110000
+#pragma GCC diagnostic pop
+#endif
 
         in_place_stop_source(in_place_stop_source const&) = delete;
         in_place_stop_source(in_place_stop_source&&) noexcept = delete;

--- a/libs/core/threading/tests/unit/stack_check.cpp
+++ b/libs/core/threading/tests/unit/stack_check.cpp
@@ -77,7 +77,7 @@ int hpx_main()
         std::ptrdiff_t stack_now = std::get<2>(i);
         std::cout << "stack remaining 0x" << std::hex << stack_now << "\n";
 #if defined(HPX_HAVE_THREADS_GET_STACK_POINTER)
-        HPX_TEST_LT(current_stack, stack_now);
+        HPX_TEST_LTE(current_stack, stack_now);
 #endif
         current_stack = stack_now;
         my_stack_info.pop();

--- a/libs/core/type_support/CMakeLists.txt
+++ b/libs/core/type_support/CMakeLists.txt
@@ -9,6 +9,7 @@ set(type_support_headers
     hpx/type_support/detail/wrap_int.hpp
     hpx/type_support/construct_at.hpp
     hpx/type_support/decay.hpp
+    hpx/type_support/default_sentinel.hpp
     hpx/type_support/detected.hpp
     hpx/type_support/empty_function.hpp
     hpx/type_support/equality.hpp
@@ -23,6 +24,13 @@ set(type_support_headers
     hpx/type_support/unused.hpp
     hpx/type_support/void_guard.hpp
 )
+
+if(HPX_WITH_CXX20_COROUTINES)
+  set(type_support_headers
+      ${type_support_headers} hpx/type_support/coroutines_support.hpp
+      hpx/type_support/generator.hpp
+  )
+endif()
 
 # cmake-format: off
 set(type_support_compat_headers

--- a/libs/core/type_support/include/hpx/type_support/coroutines_support.hpp
+++ b/libs/core/type_support/include/hpx/type_support/coroutines_support.hpp
@@ -14,25 +14,25 @@
 #if __has_include(<coroutine>)
 #include <coroutine>
 
-namespace hpx::coro {
+namespace hpx {
 
     using std::coroutine_handle;
     using std::noop_coroutine;
     using std::suspend_always;
     using std::suspend_never;
-}    // namespace hpx::coro
+}    // namespace hpx
 #define HPX_COROUTINE_NAMESPACE_STD std
 
 #elif __has_include(<experimental/coroutine>)
 #include <experimental/coroutine>
 
-namespace hpx::coro {
+namespace hpx {
 
     using std::experimental::coroutine_handle;
     using std::experimental::noop_coroutine;
     using std::experimental::suspend_always;
     using std::experimental::suspend_never;
-}    // namespace hpx::coro
+}    // namespace hpx
 #define HPX_COROUTINE_NAMESPACE_STD std::experimental
 
 #endif

--- a/libs/core/type_support/include/hpx/type_support/decay.hpp
+++ b/libs/core/type_support/include/hpx/type_support/decay.hpp
@@ -22,12 +22,24 @@ namespace hpx::util {
         struct decay_unwrap_impl
         {
             using type = TD;
+
+            template <typename T>
+            constexpr static T call(T&& t) noexcept
+            {
+                return std::forward<T>(t);
+            }
         };
 
         template <typename X>
         struct decay_unwrap_impl<::std::reference_wrapper<X>>
         {
             using type = X&;
+
+            constexpr static decltype(auto) call(
+                ::std::reference_wrapper<X> ref) noexcept
+            {
+                return ref.get();
+            }
         };
     }    // namespace detail
 

--- a/libs/core/type_support/include/hpx/type_support/default_sentinel.hpp
+++ b/libs/core/type_support/include/hpx/type_support/default_sentinel.hpp
@@ -1,0 +1,31 @@
+//  Copyright (c) 2023 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include <hpx/config.hpp>
+
+#if defined(HPX_HAVE_CXX20_STD_DEFAULT_SENTINEL)
+
+#include <iterator>
+
+namespace hpx {
+
+    using std::default_sentinel;
+    using std::default_sentinel_t;
+}    // namespace hpx
+
+#else
+
+namespace hpx {
+
+    struct default_sentinel_t
+    {
+    };
+    inline constexpr default_sentinel_t default_sentinel = default_sentinel_t{};
+}    // namespace hpx
+
+#endif

--- a/libs/core/type_support/include/hpx/type_support/generator.hpp
+++ b/libs/core/type_support/include/hpx/type_support/generator.hpp
@@ -1,0 +1,765 @@
+//  Copyright (c) 2023 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include <hpx/config.hpp>
+
+// clang up to V12 refuses to compile the code below
+#if defined(HPX_HAVE_CXX20_COROUTINES) &&                                      \
+    (!defined(HPX_CLANG_VERSION) || HPX_CLANG_VERSION >= 130000)
+#if defined(HPX_HAVE_CXX23_STD_GENERATOR)
+
+#include <generator>
+
+namespace hpx {
+
+    template <typename Ref, typename V = void, typename Allocator = void>
+    using generator = std::generator<Ref, V, Allocator>
+}
+
+#else
+
+#include <hpx/assert.hpp>
+#include <hpx/type_support/coroutines_support.hpp>
+#include <hpx/type_support/default_sentinel.hpp>
+
+#include <algorithm>
+#include <concepts>
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <exception>
+#include <memory>
+#include <new>
+#include <type_traits>
+#include <utility>
+
+#if defined(__STDCPP_DEFAULT_NEW_ALIGNMENT__)
+#define HPX_STDCPP_DEFAULT_NEW_ALIGNMENT __STDCPP_DEFAULT_NEW_ALIGNMENT__
+#else
+#define HPX_STDCPP_DEFAULT_NEW_ALIGNMENT 16
+#endif
+
+// see: Casey Carter, Lewis Baker, Corentin Jabot. std::generator
+// implementation. https://godbolt.org/z/5hcaPcfvP
+
+namespace hpx {
+
+    template <typename Ref, typename V = void, typename Allocator = void>
+    struct generator;
+
+    namespace detail {
+
+        struct alignas(HPX_STDCPP_DEFAULT_NEW_ALIGNMENT) aligned_block
+        {
+            unsigned char pad[HPX_STDCPP_DEFAULT_NEW_ALIGNMENT];
+        };
+
+        template <typename Allocator>
+        using rebind = typename std::allocator_traits<
+            Allocator>::template rebind_alloc<aligned_block>;
+
+        template <typename Allocator>
+        concept has_real_pointers = std::is_void_v<Allocator> ||
+            std::is_pointer_v<
+                typename std::allocator_traits<Allocator>::pointer>;
+
+        // clang-format off
+        template <typename T, typename U>
+        concept common_reference_with =
+            std::same_as<std::common_reference_t<T, U>,
+                std::common_reference_t<U, T>> &&
+            std::is_convertible_v<T, std::common_reference_t<T, U>> &&
+            std::is_convertible_v<U, std::common_reference_t<T, U>>;
+        // clang-format on
+
+        // statically specified allocator type
+        template <typename Alloc = void>
+        class promise_allocator
+        {
+            using Allocator = rebind<Alloc>;
+
+            static char* allocate(Allocator alloc, std::size_t const size)
+            {
+                if constexpr (std::is_default_constructible_v<Allocator> &&
+                    std::allocator_traits<Allocator>::is_always_equal::value)
+                {
+                    // do not store stateless allocator, but store size of block
+                    std::size_t const count = (size + sizeof(aligned_block) +
+                                                  sizeof(std::size_t) - 1) /
+                        sizeof(aligned_block);
+
+                    void* ptr = alloc.allocate(count);
+
+                    char* address = static_cast<char*>(ptr);
+                    *reinterpret_cast<std::size_t*>(address) = size;
+
+                    return address;
+                }
+                else
+                {
+                    // store stateful allocator and size of block
+                    static constexpr std::size_t align =
+                        (std::max)(alignof(Allocator), sizeof(aligned_block));
+
+                    std::size_t const count =
+                        (size + sizeof(Allocator) + sizeof(std::size_t) +
+                            align - 1) /
+                        sizeof(aligned_block);
+
+                    void* const ptr = alloc.allocate(count);
+
+                    char* address = static_cast<char*>(ptr);
+                    *reinterpret_cast<std::size_t*>(address) = size;
+
+                    auto const alloc_address =
+                        (reinterpret_cast<std::uintptr_t>(ptr) + size +
+                            sizeof(std::size_t) + alignof(Allocator) - 1) &
+                        ~(alignof(Allocator) - 1);
+
+                    ::new (reinterpret_cast<void*>(alloc_address))
+                        Allocator(HPX_MOVE(alloc));
+
+                    return address;
+                }
+            }
+
+            static void dealloc(void* const ptr, std::size_t const size)
+            {
+                if constexpr (std::is_default_constructible_v<Allocator> &&
+                    std::allocator_traits<Allocator>::is_always_equal::value)
+                {
+                    // make stateless allocator
+                    Allocator alloc{};
+                    std::size_t const count = (size + sizeof(std::size_t) +
+                                                  sizeof(aligned_block) - 1) /
+                        sizeof(aligned_block);
+
+                    alloc.deallocate(static_cast<aligned_block*>(ptr), count);
+                }
+                else
+                {
+                    // retrieve stateful allocator
+                    auto const address =
+                        (reinterpret_cast<std::uintptr_t>(ptr) +
+                            sizeof(std::size_t) + size + alignof(Allocator) -
+                            1) &
+                        ~(alignof(Allocator) - 1);
+
+                    auto& stored_allocator =
+                        *reinterpret_cast<Allocator*>(address);
+                    Allocator alloc{HPX_MOVE(stored_allocator)};
+                    stored_allocator.~Allocator();
+
+                    static constexpr std::size_t align =
+                        (std::max)(alignof(Allocator), sizeof(aligned_block));
+                    std::size_t const count =
+                        (size + sizeof(std::size_t) + sizeof(Allocator) +
+                            align - 1) /
+                        sizeof(aligned_block);
+
+                    alloc.deallocate(static_cast<aligned_block*>(ptr), count);
+                }
+            }
+
+        public:
+            // Allocator support
+            // clang-format off
+            void* operator new(std::size_t const size)
+                requires std::is_default_constructible_v<Allocator>
+            {
+                return allocate(Allocator{}, size) + sizeof(std::size_t);
+            }
+
+            template <typename Allocator2, typename... Args>
+                requires std::is_convertible_v<Allocator2 const&, Allocator>
+            void* operator new(std::size_t const size, std::allocator_arg_t,
+                Allocator2 const& alloc, Args const&...)
+            {
+                return allocate(
+                           static_cast<Allocator>(static_cast<Alloc>(alloc)),
+                           size) +
+                    sizeof(std::size_t);
+            }
+
+            template <typename This, typename Alloc2, typename... Args>
+                requires std::is_convertible_v<Alloc2 const&, Allocator>
+            void* operator new(std::size_t const size, This const&,
+                std::allocator_arg_t, Alloc2 const& alloc, Args const&...)
+            {
+                return allocate(
+                           static_cast<Allocator>(static_cast<Alloc>(alloc)),
+                           size) +
+                    sizeof(std::size_t);
+            }
+            // clang-format on
+
+            // some older versions of gcc complain about mismatched-new-delete
+            // if this delete overload is missing
+            void operator delete(void* const ptr) noexcept
+            {
+                // the size is stored before the address
+                char* address = static_cast<char*>(ptr) - sizeof(std::size_t);
+                dealloc(address, *reinterpret_cast<std::size_t*>(address));
+            }
+
+            void operator delete(
+                void* const ptr, std::size_t const size) noexcept
+            {
+                char* address = static_cast<char*>(ptr) - sizeof(std::size_t);
+                HPX_ASSERT(*reinterpret_cast<std::size_t*>(address) == size);
+                dealloc(address, size);
+            }
+        };
+
+        // type-erased allocator
+        template <>
+        class promise_allocator<void>
+        {
+            using dealloc_fn = void (*)(void*, std::size_t);
+
+            template <typename ProtoAlloc>
+            static char* allocate(ProtoAlloc const& proto, std::size_t size)
+            {
+                using Allocator = rebind<ProtoAlloc>;
+                auto alloc = static_cast<Allocator>(proto);
+
+                if constexpr (std::is_default_constructible_v<Allocator> &&
+                    std::allocator_traits<Allocator>::is_always_equal::value)
+                {
+                    // don't store stateless allocator, but store size of
+                    // allocated block
+                    dealloc_fn const dealloc = [](void* const ptr,
+                                                   std::size_t const s) {
+                        Allocator alloc{};
+                        std::size_t const count =
+                            (s + sizeof(dealloc_fn) + sizeof(aligned_block) +
+                                sizeof(std::size_t) - 1) /
+                            sizeof(aligned_block);
+
+                        alloc.deallocate(
+                            static_cast<aligned_block*>(ptr), count);
+                    };
+
+                    std::size_t const count =
+                        (size + sizeof(dealloc_fn) + sizeof(std::size_t) +
+                            sizeof(aligned_block) - 1) /
+                        sizeof(aligned_block);
+
+                    void* const ptr = alloc.allocate(count);
+
+                    char* address = static_cast<char*>(ptr);
+                    *reinterpret_cast<std::size_t*>(address) = size;
+
+                    std::memcpy(address + size + sizeof(std::size_t), &dealloc,
+                        sizeof(dealloc));
+
+                    return address;
+                }
+                else
+                {
+                    // store stateful allocator and size of allocated block
+                    static constexpr std::size_t align =
+                        (std::max)(alignof(Allocator), sizeof(aligned_block));
+
+                    dealloc_fn const dealloc = [](void* const ptr,
+                                                   std::size_t s) {
+                        s += sizeof(std::size_t) + sizeof(dealloc_fn);
+                        auto const address =
+                            (reinterpret_cast<std::uintptr_t>(ptr) + s +
+                                alignof(Allocator) - 1) &
+                            ~(alignof(Allocator) - 1);
+
+                        auto& stored_allocator =
+                            *reinterpret_cast<Allocator const*>(address);
+                        Allocator alloc{HPX_MOVE(stored_allocator)};
+                        stored_allocator.~Allocator();
+
+                        std::size_t const count =
+                            (s + sizeof(alloc) + align - 1) /
+                            sizeof(aligned_block);
+
+                        alloc.deallocate(
+                            static_cast<aligned_block*>(ptr), count);
+                    };
+
+                    std::size_t const count =
+                        (size + sizeof(dealloc_fn) + sizeof(alloc) + align +
+                            sizeof(std::size_t) - 1) /
+                        sizeof(aligned_block);
+
+                    void* const ptr = alloc.allocate(count);
+
+                    // store size
+                    char* address = static_cast<char*>(ptr);
+                    *reinterpret_cast<std::size_t*>(address) = size;
+
+                    // store deleter
+                    std::memcpy(address + sizeof(std::size_t) + size, &dealloc,
+                        sizeof(dealloc));
+
+                    size += sizeof(std::size_t) + sizeof(dealloc_fn);
+                    auto const alloc_address =
+                        (reinterpret_cast<uintptr_t>(ptr) + size +
+                            alignof(Allocator) - 1) &
+                        ~(alignof(Allocator) - 1);
+
+                    ::new (reinterpret_cast<void*>(alloc_address))
+                        Allocator{HPX_MOVE(alloc)};
+
+                    return address;
+                }
+            }
+
+        public:
+            // default: new/delete
+            void* operator new(std::size_t const size)
+            {
+                void* const ptr = ::operator new[](
+                    size + sizeof(std::size_t) + sizeof(dealloc_fn));
+
+                dealloc_fn const dealloc = [](void* const p,
+                                               std::size_t const s) {
+                    ::operator delete[](
+                        p, s + sizeof(std::size_t) + sizeof(dealloc_fn));
+                };
+
+                char* address = static_cast<char*>(ptr);
+                *reinterpret_cast<std::size_t*>(address) = size;
+
+                std::memcpy(address + sizeof(std::size_t) + size, &dealloc,
+                    sizeof(dealloc_fn));
+
+                return address + sizeof(std::size_t);
+            }
+
+            template <typename Allocator, typename... Args>
+            void* operator new(std::size_t const size, std::allocator_arg_t,
+                Allocator const& alloc, Args const&...)
+            {
+                return allocate(alloc, size) + sizeof(std::size_t);
+            }
+
+            template <typename This, typename Alloc, typename... Args>
+            void* operator new(size_t const size, This const&,
+                std::allocator_arg_t, Alloc const& alloc, Args const&...)
+            {
+                static_assert(has_real_pointers<Alloc>,
+                    "coroutine allocators must use true pointers");
+                return allocate(alloc, size) + sizeof(std::size_t);
+            }
+
+            // some older versions of gcc complain about mismatched-new-delete
+            // if this delete overload is missing
+            void operator delete(void* const ptr) noexcept
+            {
+                // the size is stored before the address
+                char* address = static_cast<char*>(ptr) - sizeof(std::size_t);
+                std::size_t const size =
+                    *reinterpret_cast<std::size_t*>(address);
+
+                dealloc_fn dealloc;
+                std::memcpy(&dealloc, static_cast<char*>(ptr) + size,
+                    sizeof(dealloc_fn));
+                dealloc(address, size);
+            }
+
+            void operator delete(
+                void* const ptr, std::size_t const size) noexcept
+            {
+                // the size is stored before the address
+                char* address = static_cast<char*>(ptr) - sizeof(std::size_t);
+                HPX_ASSERT(size == *reinterpret_cast<std::size_t*>(address));
+
+                dealloc_fn dealloc;
+                std::memcpy(&dealloc, static_cast<char*>(ptr) + size,
+                    sizeof(dealloc_fn));
+                dealloc(address, size);
+            }
+        };
+
+        template <typename Ref, typename V>
+        using gen_value_t =
+            std::conditional_t<std::is_void_v<V>, std::remove_cvref_t<Ref>, V>;
+
+        template <typename Ref, typename V>
+        using gen_reference_t =
+            std::conditional_t<std::is_void_v<V>, Ref&&, Ref>;
+
+        template <typename Ref>
+        using gen_yield_t =
+            std::conditional_t<std::is_reference_v<Ref>, Ref, Ref const&>;
+
+        template <typename Value, typename Ref>
+        class gen_iter;
+
+        template <typename Yielded>
+        class gen_promise_base
+        {
+        public:
+            static_assert(std::is_reference_v<Yielded>);
+
+            static constexpr hpx::suspend_always initial_suspend() noexcept
+            {
+                return {};
+            }
+
+            [[nodiscard]] static constexpr auto final_suspend() noexcept
+            {
+                return final_awaiter{};
+            }
+
+            [[nodiscard]] hpx::suspend_always yield_value(Yielded val) noexcept
+            {
+                ptr = ::std::addressof(val);
+                return {};
+            }
+
+            // clang-format off
+            [[nodiscard]] auto
+            yield_value(std::remove_reference_t<Yielded> const& val) noexcept(
+                std::is_nothrow_constructible_v<std::remove_cvref_t<Yielded>,
+                    std::remove_reference_t<Yielded> const&>)
+                requires(std::is_rvalue_reference_v<Yielded> &&
+                    std::is_constructible_v<std::remove_cvref_t<Yielded>,
+                        std::remove_reference_t<Yielded> const&>)
+            {
+                return element_awaiter{val};
+            }
+            // clang-format on
+
+            void await_transform() = delete;
+
+            static constexpr void return_void() noexcept {}
+
+            void unhandled_exception()
+            {
+                if (info)
+                {
+                    info->except = ::std::current_exception();
+                }
+                else
+                {
+                    throw;
+                }
+            }
+
+        private:
+            struct element_awaiter
+            {
+                std::remove_cvref_t<Yielded> val;
+
+                [[nodiscard]] static constexpr bool await_ready() noexcept
+                {
+                    return false;
+                }
+
+                template <typename Promise>
+                constexpr void await_suspend(
+                    hpx::coroutine_handle<Promise> handle) noexcept
+                {
+#ifdef __cpp_lib_is_pointer_interconvertible
+                    static_assert(std::is_pointer_interconvertible_base_of_v<
+                        gen_promise_base, Promise>);
+#endif    // __cpp_lib_is_pointer_interconvertible
+
+                    gen_promise_base& current = handle.promise();
+                    current.ptr = ::std::addressof(val);
+                }
+
+                static constexpr void await_resume() noexcept {}
+            };
+
+            struct nest_info
+            {
+                std::exception_ptr except;
+                hpx::coroutine_handle<gen_promise_base> parent;
+                hpx::coroutine_handle<gen_promise_base> root;
+            };
+
+            struct final_awaiter
+            {
+                [[nodiscard]] static constexpr bool await_ready() noexcept
+                {
+                    return false;
+                }
+
+                template <typename Promise>
+                [[nodiscard]] hpx::coroutine_handle<> await_suspend(
+                    hpx::coroutine_handle<Promise> handle) noexcept
+                {
+#ifdef __cpp_lib_is_pointer_interconvertible
+                    static_assert(std::is_pointer_interconvertible_base_of_v<
+                        gen_promise_base, Promise>);
+#endif    // __cpp_lib_is_pointer_interconvertible
+
+                    gen_promise_base& current = handle.promise();
+                    if (!current.info)
+                    {
+                        return hpx::noop_coroutine();
+                    }
+
+                    hpx::coroutine_handle<gen_promise_base> cont =
+                        current.info->parent;
+                    current.info->root.promise().top = cont;
+                    current.info = nullptr;
+                    return cont;
+                }
+
+                static constexpr void await_resume() noexcept {}
+            };
+
+            template <typename Ref, typename V, typename Alloc>
+            struct nested_awaitable
+            {
+                static_assert(std::same_as<gen_yield_t<gen_reference_t<Ref, V>>,
+                    Yielded>);
+
+                nest_info nested;
+                generator<Ref, V, Alloc> gen;
+
+                explicit nested_awaitable(
+                    generator<Ref, V, Alloc>&& gen_) noexcept
+                  : gen(HPX_MOVE(gen_))
+                {
+                }
+
+                [[nodiscard]] constexpr bool await_ready() noexcept
+                {
+                    return !gen.coro;
+                }
+
+                template <typename Promise>
+                [[nodiscard]] hpx::coroutine_handle<gen_promise_base>
+                await_suspend(hpx::coroutine_handle<Promise> current) noexcept
+                {
+#ifdef __cpp_lib_is_pointer_interconvertible
+                    static_assert(std::is_pointer_interconvertible_base_of_v<
+                        gen_promise_base, Promise>);
+#endif    // __cpp_lib_is_pointer_interconvertible
+
+                    auto target =
+                        hpx::coroutine_handle<gen_promise_base>::from_address(
+                            gen._Coro.address());
+                    nested.parent =
+                        hpx::coroutine_handle<gen_promise_base>::from_address(
+                            current.address());
+
+                    gen_promise_base& parent_promise = nested.parent.promise();
+                    if (parent_promise.info)
+                    {
+                        nested.root = parent_promise.info->root;
+                    }
+                    else
+                    {
+                        nested.root = nested.parent;
+                    }
+                    nested.root.promise().top = target;
+                    target.promise().info = ::std::addressof(nested);
+                    return target;
+                }
+
+                void await_resume()
+                {
+                    if (nested.except)
+                    {
+                        ::std::rethrow_exception(HPX_MOVE(nested.except));
+                    }
+                }
+            };
+
+            template <typename, typename>
+            friend class gen_iter;
+
+            // top and info are mutually exclusive, and could potentially be merged.
+            hpx::coroutine_handle<gen_promise_base> top =
+                hpx::coroutine_handle<gen_promise_base>::from_promise(*this);
+            std::add_pointer_t<Yielded> ptr = nullptr;
+            nest_info* info = nullptr;
+        };
+
+        struct gen_secret_tag
+        {
+        };
+
+        template <typename Value, typename Ref>
+        class gen_iter
+        {
+        public:
+            using iterator_category = std::forward_iterator_tag;
+            using value_type = Value;
+            using difference_type = std::ptrdiff_t;
+            using pointer = std::add_pointer_t<value_type>;
+            using reference = Ref;
+
+            gen_iter(gen_iter const& that) = default;
+            gen_iter& operator=(gen_iter const& that) = default;
+
+            gen_iter(gen_iter&& that) noexcept
+              : coro{::std::exchange(that.coro, {})}
+            {
+            }
+
+            ~gen_iter() = default;
+
+            gen_iter& operator=(gen_iter&& that) noexcept
+            {
+                coro = ::std::exchange(that.coro, {});
+                return *this;
+            }
+
+            [[nodiscard]] Ref operator*() const noexcept
+            {
+                HPX_ASSERT_MSG(
+                    !coro.done(), "Can't dereference generator end iterator");
+                return static_cast<Ref>(*coro.promise().top.promise().ptr);
+            }
+
+            gen_iter& operator++()
+            {
+                HPX_ASSERT_MSG(
+                    !coro.done(), "Can't increment generator end iterator");
+                coro.promise().top.resume();
+                return *this;
+            }
+
+            void operator++(int)
+            {
+                ++*this;
+            }
+
+            [[nodiscard]] bool operator==(
+                hpx::default_sentinel_t) const noexcept
+            {
+                return coro.done();
+            }
+
+            [[nodiscard]] bool operator!=(
+                hpx::default_sentinel_t) const noexcept
+            {
+                return !coro.done();
+            }
+
+        private:
+            template <typename, typename, typename>
+            friend struct hpx::generator;
+
+            explicit gen_iter(gen_secret_tag,
+                hpx::coroutine_handle<gen_promise_base<gen_yield_t<Ref>>>
+                    coro_) noexcept
+              : coro{coro_}
+            {
+            }
+
+            hpx::coroutine_handle<gen_promise_base<gen_yield_t<Ref>>> coro;
+        };
+    }    // namespace detail
+
+    template <typename Ref, typename V, typename Allocator>
+    struct generator
+    {
+    private:
+        using value = detail::gen_value_t<Ref, V>;
+        static_assert(std::is_same_v<std::remove_cvref_t<value>, value> &&
+                std::is_object_v<value>,
+            "generator's value type must be a cv-unqualified object type");
+
+        using reference = detail::gen_reference_t<Ref, V>;
+        static_assert(std::is_reference_v<reference> ||
+                (std::is_object_v<reference> &&
+                    std::is_same_v<std::remove_cv_t<reference>, reference> &&
+                    std::is_copy_constructible_v<reference>),
+            "generator's first argument must be a reference type or a "
+            "cv-unqualified copy-constructible object type");
+
+        using rv_reference =
+            std::conditional_t<std::is_lvalue_reference_v<reference>,
+                std::remove_reference_t<reference>&&, reference>;
+
+        static_assert(detail::common_reference_with<reference&&, value&> &&
+                detail::common_reference_with<reference&&, rv_reference&&> &&
+                detail::common_reference_with<rv_reference&&, value const&>,
+            "an iterator with the selected value and reference types cannot "
+            "model indirectly_readable");
+
+        static_assert(detail::has_real_pointers<Allocator>,
+            "generator allocators must use true pointers");
+
+        friend detail::gen_promise_base<detail::gen_yield_t<reference>>;
+
+    public:
+        struct HPX_EMPTY_BASES promise_type
+          : detail::promise_allocator<Allocator>
+          , detail::gen_promise_base<detail::gen_yield_t<reference>>
+        {
+            [[nodiscard]] constexpr generator get_return_object() noexcept
+            {
+                return generator{detail::gen_secret_tag{},
+                    hpx::coroutine_handle<promise_type>::from_promise(*this)};
+            }
+        };
+        static_assert(std::is_standard_layout_v<promise_type>);
+
+#ifdef __cpp_lib_is_pointer_interconvertible
+        static_assert(std::is_pointer_interconvertible_base_of_v<
+            detail::gen_promise_base<detail::gen_yield_t<reference>>,
+            promise_type>);
+#endif    // __cpp_lib_is_pointer_interconvertible
+
+        generator(generator const& that) = delete;
+        generator(generator&& that) noexcept
+          : coro(::std::exchange(that.coro, {}))
+        {
+        }
+
+        ~generator()
+        {
+            if (coro)
+            {
+                coro.destroy();
+            }
+        }
+
+        generator& operator=(generator const& that) = delete;
+        generator& operator=(generator&& that) noexcept
+        {
+            ::std::swap(coro, that.coro);
+            return *this;
+        }
+
+        [[nodiscard]] detail::gen_iter<value, reference> begin() const
+        {
+            // Pre: coro is suspended at its initial suspend point
+            HPX_ASSERT_MSG(coro, "Can't call begin on moved-from generator");
+
+            coro.resume();
+            return detail::gen_iter<value, reference>{detail::gen_secret_tag{},
+                coroutine_handle<detail::gen_promise_base<detail::gen_yield_t<
+                    reference>>>::from_address(coro.address())};
+        }
+
+        [[nodiscard]] static constexpr hpx::default_sentinel_t end() noexcept
+        {
+            return hpx::default_sentinel;
+        }
+
+    private:
+        // for some compilers coro.resume() is not const
+        mutable hpx::coroutine_handle<promise_type> coro = nullptr;
+
+        constexpr explicit generator(detail::gen_secret_tag,
+            hpx::coroutine_handle<promise_type> coro_) noexcept
+          : coro(coro_)
+        {
+        }
+    };
+}    // namespace hpx
+
+#undef HPX_STDCPP_DEFAULT_NEW_ALIGNMENT
+
+#endif
+#endif

--- a/libs/core/type_support/include/hpx/type_support/pack.hpp
+++ b/libs/core/type_support/include/hpx/type_support/pack.hpp
@@ -164,7 +164,7 @@ namespace hpx::util {
     ///////////////////////////////////////////////////////////////////////////
     namespace detail {
 
-        struct empty
+        struct empty_helper
         {
         };
 
@@ -173,7 +173,7 @@ namespace hpx::util {
     (defined(HPX_HAVE_BUILTIN_TYPE_PACK_ELEMENT_CUDA) &&                       \
         defined(HPX_COMPUTE_DEVICE_CODE))
         template <std::size_t I, typename Ts, bool InBounds = (I < Ts::size)>
-        struct at_index_impl : empty
+        struct at_index_impl : empty_helper
         {
         };
 
@@ -199,7 +199,7 @@ namespace hpx::util {
         };
 
         template <std::size_t J>
-        static constexpr empty at_index_check(...);
+        static constexpr empty_helper at_index_check(...);
 
         template <std::size_t J, typename T>
         static constexpr indexed<J, T> at_index_check(indexed<J, T> const&);

--- a/libs/core/type_support/tests/unit/CMakeLists.txt
+++ b/libs/core/type_support/tests/unit/CMakeLists.txt
@@ -1,5 +1,31 @@
-# Copyright (c) 2019 The STE||AR-Group
+# Copyright (c) 2023 The STE||AR-Group
 #
 # SPDX-License-Identifier: BSL-1.0
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+set(tests)
+
+if(HPX_WITH_CXX20_COROUTINES)
+  set(tests ${tests} generator)
+endif()
+
+foreach(test ${tests})
+
+  set(test_PARAMETERS THREADS_PER_LOCALITY 4)
+
+  set(sources ${test}.cpp)
+
+  source_group("Source Files" FILES ${sources})
+
+  add_hpx_executable(
+    ${test}_test INTERNAL_FLAGS
+    SOURCES ${sources} ${${test}_FLAGS}
+    EXCLUDE_FROM_ALL
+    HPX_PREFIX ${HPX_BUILD_PREFIX}
+    FOLDER "Tests/Unit/Modules/Core/TypeSupport"
+  )
+
+  add_hpx_unit_test("modules.type_support" ${test} ${${test}_PARAMETERS})
+
+endforeach()

--- a/libs/core/type_support/tests/unit/generator.cpp
+++ b/libs/core/type_support/tests/unit/generator.cpp
@@ -1,0 +1,350 @@
+//  Copyright (c) 2023 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+// see: Casey Carter, Lewis Baker, Corentin Jabot. hpx::generator
+// implementation. https://godbolt.org/z/5hcaPcfvP
+
+#include <hpx/config.hpp>
+
+// clang up to V12 refuses to compile the code below
+#if defined(HPX_HAVE_CXX20_COROUTINES) &&                                      \
+    (!defined(HPX_CLANG_VERSION) || HPX_CLANG_VERSION >= 130000)
+
+#include <hpx/local/generator.hpp>
+#include <hpx/modules/testing.hpp>
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <ostream>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace tests {
+
+    // Simple non-nested serial generator
+    hpx::generator<std::uint64_t> fib(int max)
+    {
+        auto a = 0, b = 1;
+        for (auto n = 0; n < max; ++n)
+        {
+            co_yield std::exchange(a, std::exchange(b, a + b));
+        }
+    }
+
+    hpx::generator<int> other_generator(int i, int j)
+    {
+        while (i != j)
+        {
+            co_yield i++;
+        }
+    }
+
+    // Following examples show difference between:
+    //
+    //                                    If I co_yield a...
+    //                              X / X&&  | X&         | const X&
+    //                           ------------+------------+-----------
+    // - generator<X, X>               (same as generator<X, X&&>)
+    // - generator<X, const X&>   ref        | ref        | ref
+    // - generator<X, X&&>        ref        | ill-formed | ill-formed
+    // - generator<X, X&>         ill-formed | ref        | ill-formed
+    struct X
+    {
+        int id;
+
+        explicit X(int id)
+          : id(id)
+        {
+        }
+
+        X(X const& x)
+          : id(x.id)
+        {
+        }
+        X(X&& x)
+          : id(std::exchange(x.id, -1))
+        {
+        }
+        ~X() {}
+
+        bool operator==(X const& rhs) const noexcept
+        {
+            return id == rhs.id;
+        }
+
+        friend std::ostream& operator<<(std::ostream& os, X const& rhs) noexcept
+        {
+            os << rhs.id;
+            return os;
+        }
+    };
+
+    hpx::generator<X> always_ref_example()
+    {
+        co_yield X{1};
+        {
+            X x{2};
+            co_yield x;
+            HPX_TEST(x.id == 2);
+        }
+        {
+            X const x{3};
+            co_yield x;
+            HPX_TEST(x.id == 3);
+        }
+        {
+            X x{4};
+            co_yield std::move(x);
+        }
+    }
+
+    hpx::generator<X&&> xvalue_example()
+    {
+        co_yield X{1};
+        X x{2};
+        co_yield x;    // well-formed: generated element is copy of lvalue
+        HPX_TEST(x.id == 2);
+        co_yield std::move(x);
+    }
+
+    hpx::generator<X const&> const_lvalue_example()
+    {
+        co_yield X{1};    // OK
+        X const x{2};
+        co_yield x;               // OK
+        co_yield std::move(x);    // OK: same as above
+    }
+
+    hpx::generator<X&> lvalue_example()
+    {
+        // co_yield X{1}; // ill-formed: prvalue -> non-const lvalue
+        X x{2};
+        co_yield x;    // OK
+        // co_yield std::move(x); // ill-formed: xvalue -> non-const lvalue
+    }
+
+    // These examples show different usages of reference/value_type
+    // template parameters
+
+    // value_type = std::unique_ptr<int>
+    // reference = std::unique_ptr<int>&&
+    hpx::generator<std::unique_ptr<int>&&> unique_ints(int const high)
+    {
+        for (auto i = 0; i < high; ++i)
+        {
+            co_yield std::make_unique<int>(i);
+        }
+    }
+
+    // value_type = std::string_view
+    // reference = std::string_view&&
+    hpx::generator<std::string_view> string_views()
+    {
+        co_yield "foo";
+        co_yield "bar";
+    }
+
+    // value_type = std::string
+    // reference = std::string_view
+    template <typename Allocator>
+    hpx::generator<std::string_view, std::string> strings(
+        std::allocator_arg_t, Allocator)
+    {
+        co_yield {};
+        co_yield "start";
+        for (auto sv : string_views())
+        {
+            co_yield std::string{sv} + '!';
+        }
+        co_yield "end";
+    }
+
+    template <typename T>
+    struct stateful_allocator
+    {
+        using value_type = T;
+
+        int id;
+
+        explicit stateful_allocator(int id) noexcept
+          : id(id)
+        {
+        }
+
+        template <typename U>
+        stateful_allocator(stateful_allocator<U> const& x)
+          : id(x.id)
+        {
+        }
+
+        T* allocate(std::size_t count)
+        {
+            return std::allocator<T>().allocate(count);
+        }
+
+        void deallocate(T* ptr, std::size_t count) noexcept
+        {
+            std::allocator<T>().deallocate(ptr, count);
+        }
+
+        template <typename U>
+        bool operator==(stateful_allocator<U> const& x) const
+        {
+            return this->id == x.id;
+        }
+    };
+
+    // gcc V11/V12 are complaining about mismatched-new-delete
+#if !defined(HPX_GCC_VERSION) || HPX_GCC_VERSION >= 130000
+    hpx::generator<int, void, std::allocator<std::byte>> stateless_example()
+    {
+        co_yield 42;
+    }
+
+    hpx::generator<int, void, std::allocator<std::byte>> stateless_example(
+        std::allocator_arg_t, std::allocator<std::byte>)
+    {
+        co_yield 42;
+    }
+#endif
+
+    template <typename Allocator>
+    hpx::generator<int, void, Allocator> stateful_alloc_example(
+        std::allocator_arg_t, Allocator)
+    {
+        co_yield 42;
+    }
+
+    struct member_coro
+    {
+        hpx::generator<int> f() const
+        {
+            co_yield 42;
+        }
+    };
+}    // namespace tests
+
+int main()
+{
+    {
+        std::vector const expected = {
+            0ULL, 1ULL, 1ULL, 2ULL, 3ULL, 5ULL, 8ULL, 13ULL, 21ULL, 34ULL};
+        std::size_t i = 0;
+        for (auto&& x : tests::fib(10))
+        {
+            HPX_TEST_LT(i, expected.size());
+            HPX_TEST_EQ(x, expected[i++]);
+        }
+        HPX_TEST_EQ(i, expected.size());
+    }
+
+    {
+        std::vector const expected = {1, 2, 3, 4, 5, 6, 7, 8, 9};
+        std::size_t i = 0;
+        for (auto&& x : tests::other_generator(1, 10))
+        {
+            HPX_TEST_LT(i, expected.size());
+            HPX_TEST_EQ(x, expected[i++]);
+        }
+        HPX_TEST_EQ(i, expected.size());
+    }
+
+    {
+        std::vector const expected = {
+            tests::X(1), tests::X(2), tests::X(3), tests::X(4)};
+        std::size_t i = 0;
+        for (auto&& x : tests::always_ref_example())
+        {
+            HPX_TEST_LT(i, expected.size());
+            HPX_TEST_EQ(x, expected[i++]);
+        }
+        HPX_TEST_EQ(i, expected.size());
+    }
+
+    {
+        std::vector const expected = {tests::X(1), tests::X(2), tests::X(2)};
+        std::size_t i = 0;
+        for (auto&& x : tests::xvalue_example())
+        {
+            HPX_TEST_LT(i, expected.size());
+            HPX_TEST_EQ(x, expected[i++]);
+        }
+        HPX_TEST_EQ(i, expected.size());
+    }
+
+    {
+        std::vector const expected = {tests::X(1), tests::X(2), tests::X(2)};
+        std::size_t i = 0;
+        for (auto&& x : tests::const_lvalue_example())
+        {
+            HPX_TEST_LT(i, expected.size());
+            HPX_TEST_EQ(x, expected[i++]);
+        }
+        HPX_TEST_EQ(i, expected.size());
+    }
+
+    {
+        std::vector const expected = {tests::X(2)};
+        std::size_t i = 0;
+        for (auto&& x : tests::lvalue_example())
+        {
+            HPX_TEST_LT(i, expected.size());
+            HPX_TEST_EQ(x, expected[i++]);
+        }
+        HPX_TEST_EQ(i, expected.size());
+    }
+
+    {
+        std::vector const expected = {0, 1, 2, 3, 4};
+        std::size_t i = 0;
+        for (std::unique_ptr<int> ptr : tests::unique_ints(5))
+        {
+            HPX_TEST_LT(i, expected.size());
+            HPX_TEST_EQ(*ptr, expected[i++]);
+        }
+        HPX_TEST_EQ(i, expected.size());
+    }
+
+    // gcc V11/V12 are complaining about mismatched-new-delete
+#if !defined(HPX_GCC_VERSION) || HPX_GCC_VERSION >= 130000
+    {
+        std::vector const expected = {42};
+        std::size_t i = 0;
+        for (auto&& x : tests::stateless_example())
+        {
+            HPX_TEST_LT(i, expected.size());
+            HPX_TEST_EQ(x, expected[i++]);
+        }
+        HPX_TEST_EQ(i, expected.size());
+    }
+
+    {
+        std::vector const expected = {42};
+        std::size_t i = 0;
+        for (auto&& x : tests::stateless_example(
+                 std::allocator_arg, std::allocator<float>{}))
+        {
+            HPX_TEST_LT(i, expected.size());
+            HPX_TEST_EQ(x, expected[i++]);
+        }
+        HPX_TEST_EQ(i, expected.size());
+    }
+#endif
+
+    constexpr tests::member_coro m;
+    HPX_TEST(*m.f().begin() == 42);
+
+    return hpx::util::report_errors();
+}
+
+#else
+int main()
+{
+    return 0;
+}
+#endif

--- a/libs/full/collectives/include/hpx/collectives/spmd_block.hpp
+++ b/libs/full/collectives/include/hpx/collectives/spmd_block.hpp
@@ -109,8 +109,15 @@ namespace hpx { namespace lcos {
                     std::size_t rank = std::distance(images.begin(), image_it);
                     std::string suffix;
 
+#if defined(HPX_GCC_VERSION) && HPX_GCC_VERSION >= 110000
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wrestrict"
+#endif
                     for (std::size_t s : images)
                         suffix += ("_" + std::to_string(s));
+#if defined(HPX_GCC_VERSION) && HPX_GCC_VERSION >= 110000
+#pragma GCC diagnostic pop
+#endif
 
                     table_it = barriers_
                                    .insert({images,

--- a/libs/full/components_base/src/component_type.cpp
+++ b/libs/full/components_base/src/component_type.cpp
@@ -177,6 +177,10 @@ namespace hpx { namespace components {
             result = "component";
         }
 
+#if defined(HPX_GCC_VERSION) && HPX_GCC_VERSION >= 110000
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wrestrict"
+#endif
         if (type == get_base_type(type) || component_invalid == type)
         {
             result += "[" + std::to_string(type) + "]";
@@ -187,6 +191,9 @@ namespace hpx { namespace components {
                 std::to_string(static_cast<int>(get_derived_type(type))) + "(" +
                 std::to_string(static_cast<int>(get_base_type(type))) + ")]";
         }
+#if defined(HPX_GCC_VERSION) && HPX_GCC_VERSION >= 110000
+#pragma GCC diagnostic pop
+#endif
         return result;
     }
 

--- a/libs/full/include/CMakeLists.txt
+++ b/libs/full/include/CMakeLists.txt
@@ -21,6 +21,7 @@ set(include_headers
     hpx/execution.hpp
     hpx/functional.hpp
     hpx/future.hpp
+    hpx/generator.hpp
     hpx/hpx.hpp
     hpx/include/actions.hpp
     hpx/include/agas.hpp

--- a/libs/full/include/include/hpx/generator.hpp
+++ b/libs/full/include/include/hpx/generator.hpp
@@ -1,0 +1,9 @@
+//  Copyright (c) 2023 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include <hpx/local/generator.hpp>

--- a/libs/full/performance_counters/src/query_counters.cpp
+++ b/libs/full/performance_counters/src/query_counters.cpp
@@ -103,8 +103,17 @@ namespace hpx { namespace util {
 
     void query_counters::start()
     {
+#if defined(HPX_GCC_VERSION) && HPX_GCC_VERSION >= 110000
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wrestrict"
+#endif
         if (print_counters_locally_ && destination_ != "cout")
+        {
             destination_ += "." + std::to_string(hpx::get_locality_id());
+        }
+#if defined(HPX_GCC_VERSION) && HPX_GCC_VERSION >= 110000
+#pragma GCC diagnostic pop
+#endif
 
         find_counters();
 

--- a/libs/full/runtime_distributed/src/runtime_distributed.cpp
+++ b/libs/full/runtime_distributed/src/runtime_distributed.cpp
@@ -1371,7 +1371,16 @@ namespace hpx {
         fullname += context;
         if (postfix && *postfix)
             fullname += postfix;
+
+#if defined(HPX_GCC_VERSION) && HPX_GCC_VERSION >= 110000
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wrestrict"
+#endif
         fullname += "#" + std::to_string(global_thread_num);
+#if defined(HPX_GCC_VERSION) && HPX_GCC_VERSION >= 110000
+#pragma GCC diagnostic pop
+#endif
+
         detail::thread_name() = HPX_MOVE(fullname);
 
         char const* name = detail::thread_name().c_str();

--- a/tests/performance/network/network_storage/network_storage.cpp
+++ b/tests/performance/network/network_storage/network_storage.cpp
@@ -408,10 +408,17 @@ namespace Storage {
                     [](char* p) { release_storage_lock(p); }, return_allocator);
             });
 #else
+#if defined(HPX_GCC_VERSION) && HPX_GCC_VERSION >= 110000
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmismatched-new-delete"
+#endif
         return hpx::make_ready_future<transfer_buffer_type>(
             transfer_buffer_type(
                 local_buffer.get(), length, transfer_buffer_type::take,
                 [](char* p) { release_storage_lock(p); }, return_allocator));
+#if defined(HPX_GCC_VERSION) && HPX_GCC_VERSION >= 110000
+#pragma GCC diagnostic pop
+#endif
 #endif
     }
 }    // namespace Storage


### PR DESCRIPTION
- flyby: adding C++23 generator<>
- flyby: moving coroutine facilities to namespace hpx
- flyby: simplify sequential implementation of for_loop
- flyby: adding C++20 default_sentinel
