### PR TITLE
Making sure restricted_thread_pool_executor properly reports used number of cores

### DIFF
--- a/libs/core/executors/include/hpx/executors/restricted_thread_pool_executor.hpp
+++ b/libs/core/executors/include/hpx/executors/restricted_thread_pool_executor.hpp
@@ -152,6 +152,18 @@ namespace hpx::parallel::execution {
                 tag, exec.generate_executor(exec.get_current_thread_num()));
         }
 
+        friend constexpr std::size_t tag_invoke(
+            hpx::parallel::execution::processing_units_count_t tag,
+            restricted_policy_executor const& exec,
+            hpx::chrono::steady_duration const& duration =
+                hpx::chrono::null_duration,
+            std::size_t num_tasks = 0)
+        {
+            return hpx::functional::tag_invoke(tag,
+                exec.generate_executor(exec.get_current_thread_num()), duration,
+                num_tasks);
+        }
+
         // executor API
         template <typename F, typename... Ts>
         friend decltype(auto) tag_invoke(

--- a/libs/core/executors/tests/regressions/CMakeLists.txt
+++ b/libs/core/executors/tests/regressions/CMakeLists.txt
@@ -6,7 +6,7 @@
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 set(tests bulk_then_execute_3182 bulk_sync_wait future_then_async_executor
-          parallel_executor_1781 wrapping_executor
+          parallel_executor_1781 pu_count_6184 wrapping_executor
 )
 
 foreach(test ${tests})

--- a/libs/core/executors/tests/regressions/pu_count_6184.cpp
+++ b/libs/core/executors/tests/regressions/pu_count_6184.cpp
@@ -1,0 +1,27 @@
+//  Copyright (c) 2023 Marco Diers
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+// #6184: Wrong processing_units_count of restricted_thread_pool_executor
+
+#include <hpx/local/execution.hpp>
+#include <hpx/local/init.hpp>
+#include <hpx/modules/testing.hpp>
+
+#include <cstddef>
+
+int hpx_main()
+{
+    hpx::parallel::execution::restricted_thread_pool_executor executor{0, 3};
+    HPX_TEST_EQ(hpx::parallel::execution::processing_units_count(executor),
+        std::size_t(3));
+    return hpx::local::finalize();
+}
+
+int main(int argc, char* argv[])
+{
+    HPX_TEST_EQ(hpx::local::init(hpx_main, argc, argv), 0);
+    return hpx::util::report_errors();
+}

--- a/libs/core/itt_notify/include/hpx/modules/itt_notify.hpp
+++ b/libs/core/itt_notify/include/hpx/modules/itt_notify.hpp
@@ -167,10 +167,10 @@ HPX_CORE_EXPORT void itt_metadata_add(___itt_domain* domain, ___itt_id* id,
     ___itt_string_handle* key, void const* data) noexcept;
 
 ///////////////////////////////////////////////////////////////////////////////
-namespace hpx::util {
+namespace hpx::threads {
 
     struct thread_description;
-}    // namespace hpx::util
+}    // namespace hpx::threads
 
 namespace hpx::util::itt {
 


### PR DESCRIPTION
Fixes #6184
