### PR TITLE
Change the default tag of autofetch LCI to v1.7.3.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1104,7 +1104,7 @@ if(HPX_WITH_NETWORKING)
     ADVANCED
   )
   hpx_option(
-    HPX_WITH_LCI_TAG STRING "LCI repository tag or branch" "v1.7.2"
+    HPX_WITH_LCI_TAG STRING "LCI repository tag or branch" "v1.7.3"
     CATEGORY "Build Targets"
     ADVANCED
   )


### PR DESCRIPTION
LCI v1.7.3 provides more ways of performance profiling and tuning. It also has some performance improvement.

[v1.7.3 change log](https://github.com/uiuc-hpc/LC/blob/dev-v1.7/doc/changelog_1_7_3.md)