### PR TITLE
Par link jobs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -444,7 +444,7 @@ hpx_option(
 )
 hpx_option(
   HPX_WITH_PARALLEL_LINK_JOBS STRING
-  "Number of Parallel link jobs while building hpx (only for Ninja as generator) (default Any)" "2"
+  "Number of Parallel link jobs while building hpx (only for Ninja as generator) (default 2)" "2"
   CATEGORY "Build Targets"
 )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -444,7 +444,7 @@ hpx_option(
 )
 hpx_option(
   HPX_WITH_PARALLEL_LINK_JOBS STRING
-  "Number of Parallel link jobs while building hpx (only for Ninja as generator) (default Any)" "Any"
+  "Number of Parallel link jobs while building hpx (only for Ninja as generator) (default Any)" "2"
   CATEGORY "Build Targets"
 )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -443,8 +443,10 @@ hpx_option(
   CATEGORY "Build Targets"
 )
 hpx_option(
-  HPX_WITH_PARALLEL_LINK_JOBS STRING
-  "Number of Parallel link jobs while building hpx (only for Ninja as generator) (default 2)" "2"
+  HPX_WITH_PARALLEL_LINK_JOBS
+  STRING
+  "Number of Parallel link jobs while building hpx (only for Ninja as generator) (default 2)"
+  "2"
   CATEGORY "Build Targets"
 )
 
@@ -453,7 +455,10 @@ if(CMAKE_GENERATOR MATCHES "Ninja")
     set(HPX_WITH_PARALLEL_LINK_JOBS "2")
   endif()
   if(HPX_WITH_PARALLEL_LINK_JOBS)
-    set_property(GLOBAL APPEND PROPERTY JOB_POOLS link_job_pool=${HPX_WITH_PARALLEL_LINK_JOBS})
+    set_property(
+      GLOBAL APPEND PROPERTY JOB_POOLS
+                             link_job_pool=${HPX_WITH_PARALLEL_LINK_JOBS}
+    )
     set(CMAKE_JOB_POOL_LINK link_job_pool)
   endif()
 elseif(HPX_WITH_PARALLEL_LINK_JOBS)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -442,6 +442,23 @@ hpx_option(
   "Create build system support for fail compile HPX tests (default ON)" ON
   CATEGORY "Build Targets"
 )
+hpx_option(
+  HPX_WITH_PARALLEL_LINK_JOBS STRING
+  "Number of Parallel link jobs while building hpx (only for Ninja as generator) (default Any)" "Any"
+  CATEGORY "Build Targets"
+)
+
+if(CMAKE_GENERATOR MATCHES "Ninja")
+  if(NOT HPX_WITH_PARALLEL_LINK_JOBS)
+    set(HPX_WITH_PARALLEL_LINK_JOBS "2")
+  endif()
+  if(HPX_WITH_PARALLEL_LINK_JOBS)
+    set_property(GLOBAL APPEND PROPERTY JOB_POOLS link_job_pool=${HPX_WITH_PARALLEL_LINK_JOBS})
+    set(CMAKE_JOB_POOL_LINK link_job_pool)
+  endif()
+elseif(HPX_WITH_PARALLEL_LINK_JOBS)
+  hpx_warn("Job pooling is only available with Ninja generators.")
+endif()
 
 # disable all tests if HPX_WITH_TESTS=OFF
 if(NOT HPX_WITH_TESTS)


### PR DESCRIPTION
Added cmake Option HPX_PARALLEL_LINK_JOBS to limit number of parallel link jobs if using ninja as generator.

Usage: 
-DHPX_PARALLEL_LINK_JOBS=2

defaults to 2 if not set (and generator is ninja)

How do I test if it works?

Referenced and motivated from https://github.com/llvm/llvm-project/blob/main/llvm/cmake/modules/HandleLLVMOptions.cmake#L46