### PR TITLE
Update the LCI parcelport documents

### DIFF
--- a/docs/sphinx/manual/using_the_lci_parcelport.rst
+++ b/docs/sphinx/manual/using_the_lci_parcelport.rst
@@ -33,7 +33,7 @@ The LCI parcelport is an experimental parcelport.
 It aims to provide the best possible communication performance
 on high-performance computation platforms.
 Compared to the MPI parcelport, it uses much fewer messages
-and memory copies to transfer an HPX parcel over the network.
+and memory copies to transfer an |hpx| parcel over the network.
 Its message transmission path involves minimum synchronization
 points and is almost lock-free. It is expected to be much faster
 than the MPI parcelport.
@@ -42,7 +42,7 @@ than the MPI parcelport.
 
 .. _build_lci_pp:
 
-Build HPX with the LCI parcelport
+Build |hpx| with the LCI parcelport
 ==============================
 
 While building |hpx|, you can specify a set of |cmake| variables to enable
@@ -51,7 +51,7 @@ and frequently used CMake variables.
 
 .. option:: HPX_WITH_PARCELPORT_LCI
 
-   Enable the LCI parcelport. This enables the use of LCI for networking operations in the HPX runtime.
+   Enable the LCI parcelport. This enables the use of LCI for networking operations in the |hpx| runtime.
    The default value is ``OFF`` because it's not available on all systems and/or requires another dependency. However,
    this experimental parcelport may provide better performance than the MPI parcelport.
    You must set this variable to ``ON`` in order to use the LCI parcelport. All the following variables only
@@ -60,10 +60,10 @@ and frequently used CMake variables.
 .. option:: HPX_WITH_FETCH_LCI
 
    Use FetchContent to fetch LCI. The default value is ``OFF``.
-   If this option is set to ``OFF``. You need to install your own LCI library and |HPX| will try
+   If this option is set to ``OFF``. You need to install your own LCI library and |hpx| will try
    to find it using |cmake| ``find_package``. You can specify the location of the LCI installation
    by the environmental variable ``LCI_ROOT``. Refer to the `LCI README`_ for how to install LCI.
-   If this option is set to ``ON``. |HPX| will fetch and build LCI for you. You can use the following
+   If this option is set to ``ON``. |hpx| will fetch and build LCI for you. You can use the following
    |cmake| variables to configure this behavior for your platform.
 
 .. _`LCI README`: https://github.com/uiuc-hpc/LC#readme
@@ -72,26 +72,20 @@ and frequently used CMake variables.
 
    This variable only takes effect when ``HPX_WITH_FETCH_LCI`` is set to ``ON``
    and ``FETCHCONTENT_SOURCE_DIR_LCI`` is not set.
-   |HPX| will fetch LCI from its github repository. This variable controls the branch/tag LCI
+   |hpx| will fetch LCI from its github repository. This variable controls the branch/tag LCI
    will be fetched.
 
 .. option:: FETCHCONTENT_SOURCE_DIR_LCI
 
    This variable only takes effect when ``HPX_WITH_FETCH_LCI`` is set to ``ON``.
    When it is defined, ``HPX_WITH_LCI_TAG`` will be ignored.
-   It accepts a path to a local version of LCI source code and |HPX| will fetch and build LCI from there.
-
-.. option:: LCI_OFI_PROVIDER_HINT_DEFAULT
-
-   This variable only takes effect when ``HPX_WITH_FETCH_LCI`` is set to ``ON``.
-   If you are running on Slingshot-11, you should set this variable to ``cxi``.
-   If you set ``HPX_WITH_FETCH_LCI`` to ``OFF``, you need to compile your own
-   LCI library. You don't need to set this when configuring |hpx|,
-   but you should set this when configuring LCI.
+   It accepts a path to a local version of LCI source code and |hpx| will fetch and build LCI from there.
+   The default value is set conservatively for the stability of |hpx|, but users are welcome to set this
+   variable to ``master`` for potentially better performance.
 
 .. _run_lci_pp:
 
-Run HPX with the LCI parcelport
+Run |hpx| with the LCI parcelport
 ===============================
 
 We use the same mechanisms as MPI to launch LCI, so you can use the same way you run MPI parcelport to run LCI
@@ -101,4 +95,15 @@ If you are using ``hpxrun.py``, just pass ``--parcelport lci`` to the scripts.
 
 If you are using ``mpirun`` or ``srun``, you can just pass
 ``--hpx:ini=hpx.parcel.lci.priority=1000``, ``--hpx:ini=hpx.parcel.lci.enable=1``, and
-``--hpx:ini=hpx.parcel.bootstrap=lci`` to the HPX applications.
+``--hpx:ini=hpx.parcel.bootstrap=lci`` to the |hpx| applications.
+
+.. _tune_lci_pp:
+
+Performance tuning of the LCI parcelport
+========================================
+
+We encourage users to increase the zero-copy serialization threshold of LCI to ``8192`` (bytes) by
+either the cmake variable ``-DHPX_WITH_ZERO_COPY_SERIALIZATION_THRESHOLD=8192``
+(this will affect all the parcelports) or the command line option
+``--hpx:ini=hpx.parcel.lci.zero_copy_serialization_threshold=8192``
+(this will only affect the LCI parcelport).


### PR DESCRIPTION
Update the document.

The new version of LCI can automatically detect the libfabric/cxi provider, so no need to manually set `LCI_OFI_PROVIDER_HINT_DEFAULT`.