### PR TITLE
Fix the compilation warning in the MPI parcelport with gcc 11.2

### DIFF
--- a/libs/full/parcelport_mpi/include/hpx/parcelport_mpi/header.hpp
+++ b/libs/full/parcelport_mpi/include/hpx/parcelport_mpi/header.hpp
@@ -76,13 +76,13 @@ namespace hpx::parcelset::policies::mpi {
 
         void reset() noexcept
         {
-            std::memset(&data_[0], -1, data_size_);
+            std::memset(&data_[0], (char)-1, data_size_);
             data_[pos_piggy_back_flag] = 1;
         }
 
         bool valid() const noexcept
         {
-            return data_[0] != -1;
+            return data_[0] != (char)-1;
         }
 
         void assert_valid() const noexcept


### PR DESCRIPTION
Without this change, it will give me (with HPX_WITH_COMPILER_WARNINGS_AS_ERRORS=ON)

/XXX/hpx/libs/full/parcelport_mpi/include/hpx/parcelport_mpi/header.hpp: In member function ‘bool hpx::parcelset::policies::mpi::header::valid() const’: /XXX/hpx/libs/full/parcelport_mpi/include/hpx/parcelport_mpi/header.hpp:85:29: error: comparison is always true due to limited range of data type [-Werror=type-limits]
   85 |             return data_[0] != -1;