### PR TITLE
Initial trait definition for `relocatable`

### DIFF
--- a/libs/core/algorithms/CMakeLists.txt
+++ b/libs/core/algorithms/CMakeLists.txt
@@ -226,7 +226,6 @@ set(algorithms_compat_headers
     hpx/algorithms.hpp => hpx/algorithm.hpp
     hpx/parallel/traits/projected.hpp => hpx/algorithms/traits/projected.hpp
     hpx/parallel/traits/projected_range.hpp => hpx/algorithms/traits/projected_range.hpp
-    hpx/traits/is_relocatable.hpp => hpx/algorithms/traits/is_relocatable.hpp
     hpx/traits/is_value_proxy.hpp => hpx/algorithms/traits/is_value_proxy.hpp
     hpx/traits/pointer_category.hpp => hpx/algorithms/traits/pointer_category.hpp
     hpx/traits/segmented_iterator_traits.hpp => hpx/algorithms/traits/segmented_iterator_traits.hpp

--- a/libs/core/algorithms/CMakeLists.txt
+++ b/libs/core/algorithms/CMakeLists.txt
@@ -6,6 +6,7 @@
 
 set(algorithms_headers
     hpx/algorithms/traits/is_pair.hpp
+    hpx/algorithms/traits/is_relocatable.hpp
     hpx/algorithms/traits/is_value_proxy.hpp
     hpx/algorithms/traits/pointer_category.hpp
     hpx/algorithms/traits/projected.hpp
@@ -225,6 +226,7 @@ set(algorithms_compat_headers
     hpx/algorithms.hpp => hpx/algorithm.hpp
     hpx/parallel/traits/projected.hpp => hpx/algorithms/traits/projected.hpp
     hpx/parallel/traits/projected_range.hpp => hpx/algorithms/traits/projected_range.hpp
+    hpx/traits/is_relocatable.hpp => hpx/algorithms/traits/is_relocatable.hpp
     hpx/traits/is_value_proxy.hpp => hpx/algorithms/traits/is_value_proxy.hpp
     hpx/traits/pointer_category.hpp => hpx/algorithms/traits/pointer_category.hpp
     hpx/traits/segmented_iterator_traits.hpp => hpx/algorithms/traits/segmented_iterator_traits.hpp

--- a/libs/core/algorithms/include/hpx/algorithms/traits/is_relocatable.hpp
+++ b/libs/core/algorithms/include/hpx/algorithms/traits/is_relocatable.hpp
@@ -10,14 +10,13 @@
 
 namespace hpx::traits {
 
-        template <typename T>
-        struct is_relocatable
-        {
-            static constexpr bool value =
-                std::is_move_constructible_v<T> && std::is_destructible_v<T>;
-        };
+    template <typename T>
+    struct is_relocatable
+    {
+        static constexpr bool value =
+            std::is_move_constructible_v<T> && std::is_destructible_v<T>;
+    };
 
-        template <typename T>
-        inline constexpr bool is_relocatable_v = is_relocatable<T>::value;
+    template <typename T>
+    inline constexpr bool is_relocatable_v = is_relocatable<T>::value;
 }    // namespace hpx::traits
-

--- a/libs/core/algorithms/include/hpx/algorithms/traits/is_relocatable.hpp
+++ b/libs/core/algorithms/include/hpx/algorithms/traits/is_relocatable.hpp
@@ -6,7 +6,7 @@
 
 #pragma once
 
-#include <utility>
+#include <type_traits>
 
 namespace hpx::traits {
 

--- a/libs/core/algorithms/include/hpx/algorithms/traits/is_relocatable.hpp
+++ b/libs/core/algorithms/include/hpx/algorithms/traits/is_relocatable.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2023 Hartmut Kaiser
+//  Copyright (c) 2023 Isidoros Tsaousis-Seiras
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying

--- a/libs/core/algorithms/include/hpx/algorithms/traits/is_relocatable.hpp
+++ b/libs/core/algorithms/include/hpx/algorithms/traits/is_relocatable.hpp
@@ -1,0 +1,23 @@
+//  Copyright (c) 2023 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include <utility>
+
+namespace hpx::traits {
+
+        template <typename T>
+        struct is_relocatable
+        {
+            static constexpr bool value =
+                std::is_move_constructible_v<T> && std::is_destructible_v<T>;
+        };
+
+        template <typename T>
+        inline constexpr bool is_relocatable_v = is_relocatable<T>::value;
+}    // namespace hpx::traits
+

--- a/libs/core/algorithms/include/hpx/algorithms/traits/pointer_category.hpp
+++ b/libs/core/algorithms/include/hpx/algorithms/traits/pointer_category.hpp
@@ -7,8 +7,8 @@
 
 #pragma once
 
-#include <hpx/iterator_support/traits/is_iterator.hpp>
 #include <hpx/algorithms/traits/is_relocatable.hpp>
+#include <hpx/iterator_support/traits/is_iterator.hpp>
 
 #include <type_traits>
 

--- a/libs/core/algorithms/include/hpx/algorithms/traits/pointer_category.hpp
+++ b/libs/core/algorithms/include/hpx/algorithms/traits/pointer_category.hpp
@@ -138,19 +138,21 @@ namespace hpx::traits {
                 general_pointer_tag>;
         };
 
-        // relocatabillity is true in almost all cases, 
+        // relocatabillity is true in almost all cases,
         // an exception is std::mutex.
-        template<typename T> struct is_relocatable {
-            static constexpr bool value = 
-                std::is_move_constructible_v<T> &&
-                std::is_destructible_v<T>;
+        template <typename T>
+        struct is_relocatable
+        {
+            static constexpr bool value =
+                std::is_move_constructible_v<T> && std::is_destructible_v<T>;
         };
 
+        template <typename T>
         inline constexpr bool is_relocatable_v = is_relocatable<T>::value;
 
         template <typename Source, typename Dest,
             bool NonContiguous = !iterators_are_contiguous_v<Source, Dest>>
-        struct pointer_relocate_category 
+        struct pointer_relocate_category
         {
             using type = general_pointer_tag;
         };
@@ -160,9 +162,8 @@ namespace hpx::traits {
         {
             using type = std::conditional_t<
                 std::is_same_v<iter_value_t<Source>, iter_value_t<Dest>> &&
-                is_relocatable_v<iter_value_t<Source>>,
-                relocatable_pointer_tag,
-                general_pointer_tag>;
+                    is_relocatable_v<iter_value_t<Source>>,
+                relocatable_pointer_tag, general_pointer_tag>;
         };
     }    // namespace detail
 
@@ -191,7 +192,8 @@ namespace hpx::traits {
     template <typename Source, typename Dest, typename Enable = void>
     struct pointer_relocate_category
     {
-        using type = typename detail::pointer_relocate_category<Source, Dest>::type;
+        using type =
+            typename detail::pointer_relocate_category<Source, Dest>::type;
     };
 
     template <typename Source, typename Dest>

--- a/libs/core/algorithms/include/hpx/algorithms/traits/pointer_category.hpp
+++ b/libs/core/algorithms/include/hpx/algorithms/traits/pointer_category.hpp
@@ -138,7 +138,8 @@ namespace hpx::traits {
                 general_pointer_tag>;
         };
 
-        // check if a type is relocatable
+        // relocatabillity is true in almost all cases, 
+        // an exception is std::mutex.
         template<typename T> struct is_relocatable {
             static constexpr bool value = 
                 std::is_move_constructible_v<T> &&
@@ -159,7 +160,7 @@ namespace hpx::traits {
         {
             using type = std::conditional_t<
                 std::is_same_v<iter_value_t<Source>, iter_value_t<Dest>> &&
-                detail::is_relocatable_v<iter_value_t<Source>>,
+                is_relocatable_v<iter_value_t<Source>>,
                 relocatable_pointer_tag,
                 general_pointer_tag>;
         };

--- a/libs/core/algorithms/include/hpx/algorithms/traits/pointer_category.hpp
+++ b/libs/core/algorithms/include/hpx/algorithms/traits/pointer_category.hpp
@@ -154,8 +154,6 @@ namespace hpx::traits {
             using type = general_pointer_tag;
         };
 
-        // Would it make more sense to create a relocate_category instead or
-        // a pointer_relocate_category, that does not involve iterators?
         template <typename Source, typename Dest>
         struct pointer_relocate_category<Source, Dest, false>
         {

--- a/libs/core/algorithms/include/hpx/algorithms/traits/pointer_category.hpp
+++ b/libs/core/algorithms/include/hpx/algorithms/traits/pointer_category.hpp
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <hpx/iterator_support/traits/is_iterator.hpp>
+#include <hpx/algorithms/traits/is_relocatable.hpp>
 
 #include <type_traits>
 
@@ -137,18 +138,6 @@ namespace hpx::traits {
         {
             using type = general_pointer_tag;
         };
-
-        // relocatabillity is true in almost all cases,
-        // an exception is std::mutex.
-        template <typename T>
-        struct is_relocatable
-        {
-            static constexpr bool value =
-                std::is_move_constructible_v<T> && std::is_destructible_v<T>;
-        };
-
-        template <typename T>
-        inline constexpr bool is_relocatable_v = is_relocatable<T>::value;
 
         template <typename Source, typename Dest,
             bool Contiguous = iterators_are_contiguous_v<Source, Dest>>

--- a/libs/core/algorithms/tests/unit/algorithms/util/CMakeLists.txt
+++ b/libs/core/algorithms/tests/unit/algorithms/util/CMakeLists.txt
@@ -1,5 +1,4 @@
 # Copyright (c) 2020 Hartmut Kaiser
-# Copyright (c) 2023 Isidoros Tsaousis Seiras
 #
 # SPDX-License-Identifier: BSL-1.0
 # Distributed under the Boost Software License, Version 1.0. (See accompanying

--- a/libs/core/algorithms/tests/unit/algorithms/util/CMakeLists.txt
+++ b/libs/core/algorithms/tests/unit/algorithms/util/CMakeLists.txt
@@ -4,7 +4,7 @@
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-set(tests test_is_relocatable test_low_level test_merge_four test_merge_vector 
+set(tests test_is_relocatable test_low_level test_merge_four test_merge_vector
           test_nbits test_range
 )
 

--- a/libs/core/algorithms/tests/unit/algorithms/util/CMakeLists.txt
+++ b/libs/core/algorithms/tests/unit/algorithms/util/CMakeLists.txt
@@ -1,4 +1,5 @@
 # Copyright (c) 2020 Hartmut Kaiser
+# Copyright (c) 2023 Isidoros Tsaousis Seiras
 #
 # SPDX-License-Identifier: BSL-1.0
 # Distributed under the Boost Software License, Version 1.0. (See accompanying

--- a/libs/core/algorithms/tests/unit/algorithms/util/CMakeLists.txt
+++ b/libs/core/algorithms/tests/unit/algorithms/util/CMakeLists.txt
@@ -4,8 +4,8 @@
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-set(tests test_low_level test_merge_four test_merge_vector test_nbits
-          test_range
+set(tests test_is_relocatable test_low_level test_merge_four test_merge_vector 
+          test_nbits test_range
 )
 
 foreach(test ${tests})

--- a/libs/core/algorithms/tests/unit/algorithms/util/test_is_relocatable.cpp
+++ b/libs/core/algorithms/tests/unit/algorithms/util/test_is_relocatable.cpp
@@ -1,5 +1,4 @@
-//  Copyright (c) 2015-2017 Francisco Jose Tapia
-//  Copyright (c) 2020 Hartmut Kaiser
+//  Copyright (c) 2023 Isidoros Tsaousis Seiras
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying

--- a/libs/core/algorithms/tests/unit/algorithms/util/test_is_relocatable.cpp
+++ b/libs/core/algorithms/tests/unit/algorithms/util/test_is_relocatable.cpp
@@ -63,8 +63,8 @@ static_assert(hpx::is_relocatable_v<int&>);
 static_assert(hpx::is_relocatable_v<int&&>);
 static_assert(hpx::is_relocatable_v<int (&)()>);
 static_assert(hpx::is_relocatable_v<std::mutex&>);
-static_assert(std::relocatable<NotMoveConstructible&>);
-static_assert(std::relocatable<NotCopyConstructible&>);
-static_assert(std::relocatable<NotDestructible&>);
+static_assert(hpx::is_relocatable_v<NotMoveConstructible&>);
+static_assert(hpx::is_relocatable_v<NotCopyConstructible&>);
+static_assert(hpx::is_relocatable_v<NotDestructible&>);
 
 int main(int, char*[]) {}

--- a/libs/core/algorithms/tests/unit/algorithms/util/test_is_relocatable.cpp
+++ b/libs/core/algorithms/tests/unit/algorithms/util/test_is_relocatable.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2023 Isidoros Tsaousis Seiras
+//  Copyright (c) 2023 Isidoros Tsaousis-Seiras
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying

--- a/libs/core/algorithms/tests/unit/algorithms/util/test_is_relocatable.cpp
+++ b/libs/core/algorithms/tests/unit/algorithms/util/test_is_relocatable.cpp
@@ -1,0 +1,70 @@
+//  Copyright (c) 2015-2017 Francisco Jose Tapia
+//  Copyright (c) 2020 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/algorithms/traits/is_relocatable.hpp>
+#include <hpx/algorithms/traits/pointer_category.hpp>
+
+#include <cassert>
+
+#include <mutex>
+
+// Integral types are relocatable
+static_assert(hpx::relocatable<int>);
+static_assert(hpx::relocatable<const int>);
+static_assert(hpx::relocatable<int*>);
+static_assert(hpx::relocatable<int(*)()>);
+
+// Array types are not move-constructible and thus not relocatable
+static_assert(!hpx::relocatable<int[]>);
+static_assert(!hpx::relocatable<const int[]>);
+static_assert(!hpx::relocatable<int[4]>);
+static_assert(!hpx::relocatable<const int[4]>);
+
+// Function types are not move-constructible and thus not relocatable
+static_assert(!hpx::relocatable<int()>);
+
+// Void types are not move-constructible and thus not relocatable
+static_assert(!hpx::relocatable<void>);
+static_assert(!hpx::relocatable<const void>);
+
+// std::mutex is not relocatable
+static_assert(!hpx::relocatable<std::mutex>);
+
+struct NotDestructible {
+    NotDestructible(const NotDestructible&);
+    NotDestructible(NotDestructible&&);
+    ~NotDestructible() = delete;
+};
+
+static_assert(!hpx::relocatable<NotDestructible>);
+
+struct NotMoveConstructible {
+    NotMoveConstructible(const NotMoveConstructible&);
+    NotMoveConstructible(NotMoveConstructible&&) = delete;
+};
+
+static_assert(!hpx::relocatable<NotMoveConstructible>);
+
+struct NotCopyConstructible {
+    NotCopyConstructible(const NotCopyConstructible&) = delete;
+    NotCopyConstructible(NotCopyConstructible&&);
+};
+
+static_assert(hpx::relocatable<NotCopyConstructible>);
+
+// reference types are relocatable
+static_assert(hpx::relocatable<int&>);
+static_assert(hpx::relocatable<int&&>);
+static_assert(hpx::relocatable<int(&)()>);
+static_assert(hpx::relocatable<std::mutex&>);
+static_assert(std::relocatable<NotMoveConstructible&>);
+static_assert(std::relocatable<NotCopyConstructible&>);
+static_assert(std::relocatable<NotDestructible&>);
+
+int main(int, char*[])
+{
+}

--- a/libs/core/algorithms/tests/unit/algorithms/util/test_is_relocatable.cpp
+++ b/libs/core/algorithms/tests/unit/algorithms/util/test_is_relocatable.cpp
@@ -16,7 +16,7 @@
 static_assert(hpx::relocatable<int>);
 static_assert(hpx::relocatable<const int>);
 static_assert(hpx::relocatable<int*>);
-static_assert(hpx::relocatable<int(*)()>);
+static_assert(hpx::relocatable<int (*)()>);
 
 // Array types are not move-constructible and thus not relocatable
 static_assert(!hpx::relocatable<int[]>);
@@ -34,7 +34,8 @@ static_assert(!hpx::relocatable<const void>);
 // std::mutex is not relocatable
 static_assert(!hpx::relocatable<std::mutex>);
 
-struct NotDestructible {
+struct NotDestructible
+{
     NotDestructible(const NotDestructible&);
     NotDestructible(NotDestructible&&);
     ~NotDestructible() = delete;
@@ -42,14 +43,16 @@ struct NotDestructible {
 
 static_assert(!hpx::relocatable<NotDestructible>);
 
-struct NotMoveConstructible {
+struct NotMoveConstructible
+{
     NotMoveConstructible(const NotMoveConstructible&);
     NotMoveConstructible(NotMoveConstructible&&) = delete;
 };
 
 static_assert(!hpx::relocatable<NotMoveConstructible>);
 
-struct NotCopyConstructible {
+struct NotCopyConstructible
+{
     NotCopyConstructible(const NotCopyConstructible&) = delete;
     NotCopyConstructible(NotCopyConstructible&&);
 };
@@ -59,12 +62,10 @@ static_assert(hpx::relocatable<NotCopyConstructible>);
 // reference types are relocatable
 static_assert(hpx::relocatable<int&>);
 static_assert(hpx::relocatable<int&&>);
-static_assert(hpx::relocatable<int(&)()>);
+static_assert(hpx::relocatable<int (&)()>);
 static_assert(hpx::relocatable<std::mutex&>);
 static_assert(std::relocatable<NotMoveConstructible&>);
 static_assert(std::relocatable<NotCopyConstructible&>);
 static_assert(std::relocatable<NotDestructible&>);
 
-int main(int, char*[])
-{
-}
+int main(int, char*[]) {}

--- a/libs/core/algorithms/tests/unit/algorithms/util/test_is_relocatable.cpp
+++ b/libs/core/algorithms/tests/unit/algorithms/util/test_is_relocatable.cpp
@@ -12,26 +12,26 @@
 #include <mutex>
 
 // Integral types are relocatable
-static_assert(hpx::relocatable<int>);
-static_assert(hpx::relocatable<const int>);
-static_assert(hpx::relocatable<int*>);
-static_assert(hpx::relocatable<int (*)()>);
+static_assert(hpx::is_relocatable_v<int>);
+static_assert(hpx::is_relocatable_v<const int>);
+static_assert(hpx::is_relocatable_v<int*>);
+static_assert(hpx::is_relocatable_v<int (*)()>);
 
 // Array types are not move-constructible and thus not relocatable
-static_assert(!hpx::relocatable<int[]>);
-static_assert(!hpx::relocatable<const int[]>);
-static_assert(!hpx::relocatable<int[4]>);
-static_assert(!hpx::relocatable<const int[4]>);
+static_assert(!hpx::is_relocatable_v<int[]>);
+static_assert(!hpx::is_relocatable_v<const int[]>);
+static_assert(!hpx::is_relocatable_v<int[4]>);
+static_assert(!hpx::is_relocatable_v<const int[4]>);
 
 // Function types are not move-constructible and thus not relocatable
-static_assert(!hpx::relocatable<int()>);
+static_assert(!hpx::is_relocatable_v<int()>);
 
 // Void types are not move-constructible and thus not relocatable
-static_assert(!hpx::relocatable<void>);
-static_assert(!hpx::relocatable<const void>);
+static_assert(!hpx::is_relocatable_v<void>);
+static_assert(!hpx::is_relocatable_v<const void>);
 
 // std::mutex is not relocatable
-static_assert(!hpx::relocatable<std::mutex>);
+static_assert(!hpx::is_relocatable_v<std::mutex>);
 
 struct NotDestructible
 {
@@ -40,7 +40,7 @@ struct NotDestructible
     ~NotDestructible() = delete;
 };
 
-static_assert(!hpx::relocatable<NotDestructible>);
+static_assert(!hpx::is_relocatable_v<NotDestructible>);
 
 struct NotMoveConstructible
 {
@@ -48,7 +48,7 @@ struct NotMoveConstructible
     NotMoveConstructible(NotMoveConstructible&&) = delete;
 };
 
-static_assert(!hpx::relocatable<NotMoveConstructible>);
+static_assert(!hpx::is_relocatable_v<NotMoveConstructible>);
 
 struct NotCopyConstructible
 {
@@ -56,13 +56,13 @@ struct NotCopyConstructible
     NotCopyConstructible(NotCopyConstructible&&);
 };
 
-static_assert(hpx::relocatable<NotCopyConstructible>);
+static_assert(hpx::is_relocatable_v<NotCopyConstructible>);
 
 // reference types are relocatable
-static_assert(hpx::relocatable<int&>);
-static_assert(hpx::relocatable<int&&>);
-static_assert(hpx::relocatable<int (&)()>);
-static_assert(hpx::relocatable<std::mutex&>);
+static_assert(hpx::is_relocatable_v<int&>);
+static_assert(hpx::is_relocatable_v<int&&>);
+static_assert(hpx::is_relocatable_v<int (&)()>);
+static_assert(hpx::is_relocatable_v<std::mutex&>);
 static_assert(std::relocatable<NotMoveConstructible&>);
 static_assert(std::relocatable<NotCopyConstructible&>);
 static_assert(std::relocatable<NotDestructible&>);


### PR DESCRIPTION
This is a draft pr to implement the basic traits for P1144 (relocatable).

I defined a meta function (`is_relocatable`) and `pointer_relocate_category` allongside the existing `pointer_copy_category` and `pointer_move_category`. 

A type is `relocatable` if it is not tied to a specific location in memory.  (An example object that is not relocatable is std::mutex)

The aim of this branch is to implement the trivially relocatable trait and the faster data transfer algorithms it allows us to use.

To move forward I ask if this is the right file to the `is_relocatable` definitions.

I believe the `trivially_copyable_pointer` part of this file focuses on if an iterator is suitable for a contiguous `memcpy`, and not in determining if the underlying object is `trivially_copyable`; it uses `std::is_trivially_copyable` for that. At the moment however there is no `std::is_trivially_relocatable` or `std::is_relocatable`, so these have to be implemented first.

At the moment I have placed `hpx::is_relocatable` in this file, should I place it somewhere else?  

Thanks!