### PR TITLE
added tests for set_difference, updated set_operation.hpp to fix #6198

### DIFF
--- a/libs/core/algorithms/include/hpx/parallel/algorithms/detail/set_operation.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/detail/set_operation.hpp
@@ -74,12 +74,12 @@ namespace hpx::parallel::detail {
 
     struct set_chunk_data
     {
-        static const std::size_t uninit_start = static_cast<std::size_t>(-1);
-        static const std::size_t uninit_len = static_cast<std::size_t>(0);
-        static const std::size_t uninit_start_index =
+        static constexpr std::size_t uninit_start = static_cast<std::size_t>(-1);
+        static constexpr std::size_t uninit_len = static_cast<std::size_t>(0);
+        static constexpr std::size_t uninit_start_index =
             static_cast<std::size_t>(-1);
-        static const std::size_t uninit_first1 = static_cast<std::size_t>(-1);
-        static const std::size_t uninit_first2 = static_cast<std::size_t>(-1);
+        static constexpr std::size_t uninit_first1 = static_cast<std::size_t>(-1);
+        static constexpr std::size_t uninit_first2 = static_cast<std::size_t>(-1);
 
         std::size_t start = uninit_start;
         std::size_t len = uninit_len;

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/detail/set_operation.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/detail/set_operation.hpp
@@ -74,11 +74,18 @@ namespace hpx::parallel::detail {
 
     struct set_chunk_data
     {
-        std::size_t start = static_cast<std::size_t>(-1);
-        std::size_t len = static_cast<std::size_t>(-1);
-        std::size_t start_index = static_cast<std::size_t>(-1);
-        std::size_t first1 = static_cast<std::size_t>(-1);
-        std::size_t first2 = static_cast<std::size_t>(-1);
+        static const std::size_t uninit_start = static_cast<std::size_t>(-1);
+        static const std::size_t uninit_len = static_cast<std::size_t>(0);
+        static const std::size_t uninit_start_index =
+            static_cast<std::size_t>(-1);
+        static const std::size_t uninit_first1 = static_cast<std::size_t>(-1);
+        static const std::size_t uninit_first2 = static_cast<std::size_t>(-1);
+
+        std::size_t start = uninit_start;
+        std::size_t len = uninit_len;
+        std::size_t start_index = uninit_start_index;
+        std::size_t first1 = uninit_first1;
+        std::size_t first2 = uninit_first2;
     };
 
     ///////////////////////////////////////////////////////////////////////////
@@ -246,9 +253,10 @@ namespace hpx::parallel::detail {
                     hpx::execution::par, chunks.get(), cores,
                     [buffer, dest](
                         set_chunk_data* ch, std::size_t, std::size_t) {
-                        if (ch->start == static_cast<std::size_t>(-1) ||
-                            ch->start_index == static_cast<std::size_t>(-1) ||
-                            ch->len == static_cast<std::size_t>(-1))
+                        if (ch->start == set_chunk_data::uninit_start ||
+                            ch->start_index ==
+                                set_chunk_data::uninit_start_index ||
+                            ch->len == set_chunk_data::uninit_len)
                         {
                             return;
                         }

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/detail/set_operation.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/detail/set_operation.hpp
@@ -74,12 +74,15 @@ namespace hpx::parallel::detail {
 
     struct set_chunk_data
     {
-        static constexpr std::size_t uninit_start = static_cast<std::size_t>(-1);
+        static constexpr std::size_t uninit_start =
+            static_cast<std::size_t>(-1);
         static constexpr std::size_t uninit_len = static_cast<std::size_t>(0);
         static constexpr std::size_t uninit_start_index =
             static_cast<std::size_t>(-1);
-        static constexpr std::size_t uninit_first1 = static_cast<std::size_t>(-1);
-        static constexpr std::size_t uninit_first2 = static_cast<std::size_t>(-1);
+        static constexpr std::size_t uninit_first1 =
+            static_cast<std::size_t>(-1);
+        static constexpr std::size_t uninit_first2 =
+            static_cast<std::size_t>(-1);
 
         std::size_t start = uninit_start;
         std::size_t len = uninit_len;

--- a/libs/core/algorithms/tests/regressions/set_operations_3442.cpp
+++ b/libs/core/algorithms/tests/regressions/set_operations_3442.cpp
@@ -31,7 +31,7 @@ struct RandomIntInRange
       , rangeMax(rangeMax){};
     int operator()()
     {
-        return (gen() % (rangeMax - rangeMin + 1)) + rangeMin;
+        return (static_cast<int>(gen()) % (rangeMax - rangeMin + 1)) + rangeMin;
     }
 };
 

--- a/libs/core/algorithms/tests/regressions/set_operations_3442.cpp
+++ b/libs/core/algorithms/tests/regressions/set_operations_3442.cpp
@@ -187,6 +187,7 @@ void set_intersection_large_test(int rounds)
 void set_intersection_test(int rounds)
 {
     set_intersection_small_test1(rounds);
+    set_intersection_small_test2(rounds);
     set_intersection_medium_test(rounds);
     set_intersection_large_test(rounds);
 }

--- a/libs/core/algorithms/tests/regressions/set_operations_3442.cpp
+++ b/libs/core/algorithms/tests/regressions/set_operations_3442.cpp
@@ -39,9 +39,9 @@ void set_difference_randomized(int rounds, int maxLen)
         std::size_t len_a = rand() % maxLen, len_b = rand() % maxLen;
         std::vector<int> set_a(len_a), set_b(len_b);
 
-        int rangeMin = 0;
+        std::size_t rangeMin = 0;
         // rangeMax is set to increase probability of common elements
-        int rangeMax = (std::min)(len_a, len_b) * 2;
+        std::size_t rangeMax = (std::min)(len_a, len_b) * 2;
 
 #ifdef HPX_WITH_CXX17_STD_EXECUTION_POLICES
         std::generate(std::execution::par_unseq, set_a.begin(), set_a.end(),

--- a/libs/core/algorithms/tests/regressions/set_operations_3442.cpp
+++ b/libs/core/algorithms/tests/regressions/set_operations_3442.cpp
@@ -15,9 +15,14 @@
 #include <string>
 #include <vector>
 
+#include "test_utils.hpp"
+
 #ifdef HPX_WITH_CXX17_STD_EXECUTION_POLICES
 #include <execution>
 #endif
+
+int seed = std::random_device{}();
+std::mt19937 gen(seed);
 
 // returns random integer in range (rangeMin, rangeMax]
 struct RandomIntInRange
@@ -28,7 +33,7 @@ struct RandomIntInRange
       , rangeMax(rangeMax){};
     int operator()()
     {
-        return (rand() % (rangeMax - rangeMin + 1)) + rangeMin;
+        return (gen() % (rangeMax - rangeMin + 1)) + rangeMin;
     }
 };
 
@@ -36,7 +41,7 @@ void set_difference_randomized(int rounds, int maxLen)
 {
     while (rounds--)
     {
-        std::size_t len_a = rand() % maxLen, len_b = rand() % maxLen;
+        std::size_t len_a = gen() % maxLen, len_b = gen() % maxLen;
         std::vector<int> set_a(len_a), set_b(len_b);
 
         std::size_t rangeMin = 0;

--- a/libs/core/algorithms/tests/regressions/set_operations_3442.cpp
+++ b/libs/core/algorithms/tests/regressions/set_operations_3442.cpp
@@ -10,6 +10,7 @@
 #include <hpx/parallel/algorithms/set_intersection.hpp>
 
 #include <algorithm>
+#include <cstddef>
 #include <random>
 #include <string>
 #include <vector>
@@ -40,7 +41,7 @@ void set_difference_randomized(int rounds, int maxLen)
 
         int rangeMin = 0;
         // rangeMax is set to increase probability of common elements
-        int rangeMax = std::min(len_a, len_b) * 2;
+        int rangeMax = (std::min)(len_a, len_b) * 2;
 
 #ifdef HPX_WITH_CXX17_STD_EXECUTION_POLICES
         std::generate(std::execution::par_unseq, set_a.begin(), set_a.end(),
@@ -63,15 +64,15 @@ void set_difference_randomized(int rounds, int maxLen)
         set_b.resize(len_b);
 
         // rand always gives non negative values, rangeMin >= 0
-        std::vector<int> perfect(std::max(len_a, len_b), -1);
-        std::vector<int> a_minus_b(std::max(len_a, len_b), -1);
+        std::vector<int> perfect((std::max)(len_a, len_b), -1);
+        std::vector<int> a_minus_b((std::max)(len_a, len_b), -1);
 
         std::set_difference(set_a.begin(), set_a.end(), set_b.begin(),
             set_b.end(), perfect.begin());
 
         hpx::set_difference(hpx::execution::par, set_a.begin(), set_a.end(),
             set_b.begin(), set_b.end(), a_minus_b.begin());
-        assert(perfect == a_minus_b);
+        HPX_TEST(perfect == a_minus_b);
     }
 }
 

--- a/libs/core/algorithms/tests/regressions/set_operations_3442.cpp
+++ b/libs/core/algorithms/tests/regressions/set_operations_3442.cpp
@@ -10,10 +10,13 @@
 #include <hpx/parallel/algorithms/set_intersection.hpp>
 
 #include <algorithm>
-#include <execution>
 #include <random>
 #include <string>
 #include <vector>
+
+#ifdef HPX_WITH_CXX17_STD_EXECUTION_POLICES
+#include <execution>
+#endif
 
 // returns random integer in range (rangeMin, rangeMax]
 struct RandomIntInRange

--- a/libs/core/algorithms/tests/regressions/set_operations_3442.cpp
+++ b/libs/core/algorithms/tests/regressions/set_operations_3442.cpp
@@ -103,13 +103,31 @@ void set_difference_test(int rounds)
     set_difference_large_test(rounds);
 }
 
-void set_intersection_small_test(int rounds)
+void set_intersection_small_test1(int rounds)
 {
     std::vector<int> set_a{1, 2, 3, 4, 5};
     std::vector<int> set_b{1, 2, 7};
     std::vector<int> a_and_b(2);
 
     std::vector<int> perfect(2);
+    std::set_intersection(set_a.begin(), set_a.end(), set_b.begin(),
+        set_b.end(), perfect.begin());
+
+    while (--rounds)
+    {
+        hpx::set_intersection(hpx::execution::par, set_a.begin(), set_a.end(),
+            set_b.begin(), set_b.end(), a_and_b.begin());
+        HPX_TEST(perfect == a_and_b);
+    }
+}
+
+void set_intersection_small_test2(int rounds)
+{
+    std::vector<int> set_a{-1, 1, 2, 3, 4, 5};
+    std::vector<int> set_b{0, 1, 2, 3, 8, 10};
+    std::vector<int> a_and_b(3);
+
+    std::vector<int> perfect(3);
     std::set_intersection(set_a.begin(), set_a.end(), set_b.begin(),
         set_b.end(), perfect.begin());
 
@@ -168,7 +186,7 @@ void set_intersection_large_test(int rounds)
 
 void set_intersection_test(int rounds)
 {
-    set_intersection_small_test(rounds);
+    set_intersection_small_test1(rounds);
     set_intersection_medium_test(rounds);
     set_intersection_large_test(rounds);
 }

--- a/libs/core/algorithms/tests/regressions/set_operations_3442.cpp
+++ b/libs/core/algorithms/tests/regressions/set_operations_3442.cpp
@@ -15,8 +15,6 @@
 #include <string>
 #include <vector>
 
-#include "test_utils.hpp"
-
 #ifdef HPX_WITH_CXX17_STD_EXECUTION_POLICES
 #include <execution>
 #endif


### PR DESCRIPTION
Fixes #6198 

Error : when number of chunks < number of cores => error occurred as chunk by default length of chunk was -1 (changed to 1)

added randomised tests which assume std::set_difference is implemented correctly