### PR TITLE
Fix segmented algorithms tests

### DIFF
--- a/libs/full/segmented_algorithms/tests/unit/partitioned_vector_adjacent_find1.cpp
+++ b/libs/full/segmented_algorithms/tests/unit/partitioned_vector_adjacent_find1.cpp
@@ -34,9 +34,10 @@ void initialize(hpx::partitioned_vector<T>& xvalues)
     T init_array[SIZE] = {1, 2, 3, 4, 5, 1, 2, 3, 1, 5, 2, 3, 4, 2, 3, 2, 1, 2,
         3, 4, 5, 6, 5, 6, 1, 2, 3, 4, 2, 1, 2, 3, 3, 5, 4, 3, 2, 1, 1, 2, 3, 4,
         1, 2, 3, 1, 1, 1, 1, 1, 1, 1, 1, 7, 6, 5, 7, 5, 4, 2, 3, 4, 5, 2};
-    for (int i = 0; i < SIZE; i++)
+    typename hpx::partitioned_vector<T>::iterator it = xvalues.begin();
+    for (int i = 0; i < SIZE; i++, it++)
     {
-        xvalues.set_value(i, init_array[i]);
+        *it = init_array[i];
     }
 }
 

--- a/libs/full/segmented_algorithms/tests/unit/partitioned_vector_adjacent_find2.cpp
+++ b/libs/full/segmented_algorithms/tests/unit/partitioned_vector_adjacent_find2.cpp
@@ -34,9 +34,10 @@ void initialize(hpx::partitioned_vector<T>& xvalues)
     T init_array[SIZE] = {1, 2, 3, 4, 5, 1, 2, 3, 1, 5, 2, 3, 4, 2, 3, 2, 1, 2,
         3, 4, 5, 6, 5, 6, 1, 2, 3, 4, 2, 1, 2, 3, 3, 5, 4, 3, 2, 1, 1, 2, 3, 4,
         1, 2, 3, 1, 1, 1, 1, 1, 1, 1, 1, 7, 6, 5, 7, 5, 4, 2, 3, 4, 5, 2};
-    for (int i = 0; i < SIZE; i++)
+    typename hpx::partitioned_vector<T>::iterator it = xvalues.begin();
+    for (int i = 0; i < SIZE; i++, it++)
     {
-        xvalues.set_value(i, init_array[i]);
+        *it = init_array[i];
     }
 }
 

--- a/libs/full/segmented_algorithms/tests/unit/partitioned_vector_all_of1.cpp
+++ b/libs/full/segmented_algorithms/tests/unit/partitioned_vector_all_of1.cpp
@@ -29,9 +29,10 @@ void initialize(hpx::partitioned_vector<T>& xvalues)
     T init_array[SIZE] = {1, 2, 3, 4, 5, 1, 2, 3, 3, 5, 5, 3, 4, 2, 3, 2, 1, 2,
         3, 4, 5, 6, 5, 6, 1, 2, 3, 4, 1, 1, 2, 3, 4, 5, 4, 3, 2, 1, 1, 2, 3, 4,
         1, 2, 3, 1, 1, 1, 1, 1, 1, 1, 1, 7, 6, 5, 7, 5, 4, 2, 3, 4, 5, 2};
-    for (int i = 0; i < SIZE; i++)
+    typename hpx::partitioned_vector<T>::iterator it = xvalues.begin();
+    for (int i = 0; i < SIZE; i++, it++)
     {
-        xvalues.set_value(i, init_array[i]);
+        *it = init_array[i];
     }
 }
 

--- a/libs/full/segmented_algorithms/tests/unit/partitioned_vector_all_of1.cpp
+++ b/libs/full/segmented_algorithms/tests/unit/partitioned_vector_all_of1.cpp
@@ -38,7 +38,7 @@ void initialize(hpx::partitioned_vector<T>& xvalues)
 struct op5
 {
     template <typename T>
-    bool operator()(T& value)
+    bool operator()(T& value) const
     {
         return value > 5;
     }
@@ -47,7 +47,7 @@ struct op5
 struct op0
 {
     template <typename T>
-    bool operator()(T& value)
+    bool operator()(T& value) const
     {
         return value > 0;
     }
@@ -56,7 +56,7 @@ struct op0
 struct op8
 {
     template <typename T>
-    bool operator()(T& value)
+    bool operator()(T& value) const
     {
         return value > 8;
     }

--- a/libs/full/segmented_algorithms/tests/unit/partitioned_vector_all_of2.cpp
+++ b/libs/full/segmented_algorithms/tests/unit/partitioned_vector_all_of2.cpp
@@ -29,9 +29,10 @@ void initialize(hpx::partitioned_vector<T>& xvalues)
     T init_array[SIZE] = {1, 2, 3, 4, 5, 1, 2, 3, 3, 5, 5, 3, 4, 2, 3, 2, 1, 2,
         3, 4, 5, 6, 5, 6, 1, 2, 3, 4, 1, 1, 2, 3, 4, 5, 4, 3, 2, 1, 1, 2, 3, 4,
         1, 2, 3, 1, 1, 1, 1, 1, 1, 1, 1, 7, 6, 5, 7, 5, 4, 2, 3, 4, 5, 2};
-    for (int i = 0; i < SIZE; i++)
+    typename hpx::partitioned_vector<T>::iterator it = xvalues.begin();
+    for (int i = 0; i < SIZE; i++, it++)
     {
-        xvalues.set_value(i, init_array[i]);
+        *it = init_array[i];
     }
 }
 

--- a/libs/full/segmented_algorithms/tests/unit/partitioned_vector_all_of2.cpp
+++ b/libs/full/segmented_algorithms/tests/unit/partitioned_vector_all_of2.cpp
@@ -38,7 +38,7 @@ void initialize(hpx::partitioned_vector<T>& xvalues)
 struct op5
 {
     template <typename T>
-    bool operator()(T& value)
+    bool operator()(T& value) const
     {
         return value > 5;
     }
@@ -47,7 +47,7 @@ struct op5
 struct op0
 {
     template <typename T>
-    bool operator()(T& value)
+    bool operator()(T& value) const
     {
         return value > 0;
     }
@@ -56,7 +56,7 @@ struct op0
 struct op8
 {
     template <typename T>
-    bool operator()(T& value)
+    bool operator()(T& value) const
     {
         return value > 8;
     }

--- a/libs/full/segmented_algorithms/tests/unit/partitioned_vector_any_of1.cpp
+++ b/libs/full/segmented_algorithms/tests/unit/partitioned_vector_any_of1.cpp
@@ -29,9 +29,10 @@ void initialize(hpx::partitioned_vector<T>& xvalues)
     T init_array[SIZE] = {1, 2, 3, 4, 5, 1, 2, 3, 3, 5, 5, 3, 4, 2, 3, 2, 1, 2,
         3, 4, 5, 6, 5, 6, 1, 2, 3, 4, 1, 1, 2, 3, 4, 5, 4, 3, 2, 1, 1, 2, 3, 4,
         1, 2, 3, 1, 1, 1, 1, 1, 1, 1, 1, 7, 6, 5, 7, 5, 4, 2, 3, 4, 5, 2};
-    for (int i = 0; i < SIZE; i++)
+    typename hpx::partitioned_vector<T>::iterator it = xvalues.begin();
+    for (int i = 0; i < SIZE; i++, it++)
     {
-        xvalues.set_value(i, init_array[i]);
+        *it = init_array[i];
     }
 }
 

--- a/libs/full/segmented_algorithms/tests/unit/partitioned_vector_any_of1.cpp
+++ b/libs/full/segmented_algorithms/tests/unit/partitioned_vector_any_of1.cpp
@@ -38,7 +38,7 @@ void initialize(hpx::partitioned_vector<T>& xvalues)
 struct op5
 {
     template <typename T>
-    bool operator()(T& value)
+    bool operator()(T& value) const
     {
         return value > 5;
     }
@@ -47,7 +47,7 @@ struct op5
 struct op0
 {
     template <typename T>
-    bool operator()(T& value)
+    bool operator()(T& value) const
     {
         return value > 0;
     }
@@ -56,7 +56,7 @@ struct op0
 struct op8
 {
     template <typename T>
-    bool operator()(T& value)
+    bool operator()(T& value) const
     {
         return value > 8;
     }

--- a/libs/full/segmented_algorithms/tests/unit/partitioned_vector_any_of2.cpp
+++ b/libs/full/segmented_algorithms/tests/unit/partitioned_vector_any_of2.cpp
@@ -29,9 +29,10 @@ void initialize(hpx::partitioned_vector<T>& xvalues)
     T init_array[SIZE] = {1, 2, 3, 4, 5, 1, 2, 3, 3, 5, 5, 3, 4, 2, 3, 2, 1, 2,
         3, 4, 5, 6, 5, 6, 1, 2, 3, 4, 1, 1, 2, 3, 4, 5, 4, 3, 2, 1, 1, 2, 3, 4,
         1, 2, 3, 1, 1, 1, 1, 1, 1, 1, 1, 7, 6, 5, 7, 5, 4, 2, 3, 4, 5, 2};
-    for (int i = 0; i < SIZE; i++)
+    typename hpx::partitioned_vector<T>::iterator it = xvalues.begin();
+    for (int i = 0; i < SIZE; i++, it++)
     {
-        xvalues.set_value(i, init_array[i]);
+        *it = init_array[i];
     }
 }
 

--- a/libs/full/segmented_algorithms/tests/unit/partitioned_vector_any_of2.cpp
+++ b/libs/full/segmented_algorithms/tests/unit/partitioned_vector_any_of2.cpp
@@ -38,7 +38,7 @@ void initialize(hpx::partitioned_vector<T>& xvalues)
 struct op5
 {
     template <typename T>
-    bool operator()(T& value)
+    bool operator()(T& value) const
     {
         return value > 5;
     }
@@ -47,7 +47,7 @@ struct op5
 struct op0
 {
     template <typename T>
-    bool operator()(T& value)
+    bool operator()(T& value) const
     {
         return value > 0;
     }
@@ -56,7 +56,7 @@ struct op0
 struct op8
 {
     template <typename T>
-    bool operator()(T& value)
+    bool operator()(T& value) const
     {
         return value > 8;
     }

--- a/libs/full/segmented_algorithms/tests/unit/partitioned_vector_max_element1.cpp
+++ b/libs/full/segmented_algorithms/tests/unit/partitioned_vector_max_element1.cpp
@@ -31,9 +31,10 @@ void initialize(hpx::partitioned_vector<T>& xvalues)
     T init_array[SIZE] = {1, 2, 3, 4, 5, 6, 2, 3, 3, 5, 5, 3, 4, 2, 3, 2, 6, 2,
         3, 4, 5, 6, 5, 6, 6, 2, 3, 4, 6, 6, 2, 3, 4, 5, 4, 3, 2, 6, 6, 2, 3, 4,
         6, 2, 3, 6, 6, 6, 6, 6, 6, 6, 6, 7, 6, 5, 8, 5, 4, 2, 3, 4, 5, 2};
-    for (int i = 0; i < SIZE; i++)
+    typename hpx::partitioned_vector<T>::iterator it = xvalues.begin();
+    for (int i = 0; i < SIZE; i++, it++)
     {
-        xvalues.set_value(i, init_array[i]);
+        *it = init_array[i];
     }
 }
 

--- a/libs/full/segmented_algorithms/tests/unit/partitioned_vector_max_element2.cpp
+++ b/libs/full/segmented_algorithms/tests/unit/partitioned_vector_max_element2.cpp
@@ -31,9 +31,10 @@ void initialize(hpx::partitioned_vector<T>& xvalues)
     T init_array[SIZE] = {1, 2, 3, 4, 5, 6, 2, 3, 3, 5, 5, 3, 4, 2, 3, 2, 6, 2,
         3, 4, 5, 6, 5, 6, 6, 2, 3, 4, 6, 6, 2, 3, 4, 5, 4, 3, 2, 6, 6, 2, 3, 4,
         6, 2, 3, 6, 6, 6, 6, 6, 6, 6, 6, 7, 6, 5, 8, 5, 4, 2, 3, 4, 5, 2};
-    for (int i = 0; i < SIZE; i++)
+    typename hpx::partitioned_vector<T>::iterator it = xvalues.begin();
+    for (int i = 0; i < SIZE; i++, it++)
     {
-        xvalues.set_value(i, init_array[i]);
+        *it = init_array[i];
     }
 }
 

--- a/libs/full/segmented_algorithms/tests/unit/partitioned_vector_min_element1.cpp
+++ b/libs/full/segmented_algorithms/tests/unit/partitioned_vector_min_element1.cpp
@@ -31,9 +31,10 @@ void initialize(hpx::partitioned_vector<T>& xvalues)
     T init_array[SIZE] = {1, 2, 3, 4, 5, 6, 2, 3, 3, 5, 5, 3, 4, 2, 3, 2, 6, 2,
         3, 4, 5, 6, 5, 6, 6, 2, 3, 4, 6, 6, 2, 3, 4, 5, 4, 3, 2, 6, 6, 2, 3, 4,
         6, 2, 3, 6, 6, 6, 6, 6, 6, 6, 6, 7, 6, 5, 8, 5, 4, 2, 3, 4, 5, 2};
-    for (int i = 0; i < SIZE; i++)
+    typename hpx::partitioned_vector<T>::iterator it = xvalues.begin();
+    for (int i = 0; i < SIZE; i++, it++)
     {
-        xvalues.set_value(i, init_array[i]);
+        *it = init_array[i];
     }
 }
 

--- a/libs/full/segmented_algorithms/tests/unit/partitioned_vector_min_element2.cpp
+++ b/libs/full/segmented_algorithms/tests/unit/partitioned_vector_min_element2.cpp
@@ -31,9 +31,10 @@ void initialize(hpx::partitioned_vector<T>& xvalues)
     T init_array[SIZE] = {1, 2, 3, 4, 5, 6, 2, 3, 3, 5, 5, 3, 4, 2, 3, 2, 6, 2,
         3, 4, 5, 6, 5, 6, 6, 2, 3, 4, 6, 6, 2, 3, 4, 5, 4, 3, 2, 6, 6, 2, 3, 4,
         6, 2, 3, 6, 6, 6, 6, 6, 6, 6, 6, 7, 6, 5, 8, 5, 4, 2, 3, 4, 5, 2};
-    for (int i = 0; i < SIZE; i++)
+    typename hpx::partitioned_vector<T>::iterator it = xvalues.begin();
+    for (int i = 0; i < SIZE; i++, it++)
     {
-        xvalues.set_value(i, init_array[i]);
+        *it = init_array[i];
     }
 }
 

--- a/libs/full/segmented_algorithms/tests/unit/partitioned_vector_minmax_element1.cpp
+++ b/libs/full/segmented_algorithms/tests/unit/partitioned_vector_minmax_element1.cpp
@@ -31,9 +31,10 @@ void initialize(hpx::partitioned_vector<T>& xvalues)
     T init_array[SIZE] = {1, 2, 3, 4, 5, 6, 2, 3, 3, 5, 5, 3, 4, 2, 3, 2, 6, 2,
         3, 4, 5, 6, 5, 6, 6, 2, 3, 4, 6, 6, 2, 3, 4, 5, 4, 3, 2, 6, 6, 2, 3, 4,
         6, 2, 3, 6, 6, 6, 6, 6, 6, 6, 6, 7, 6, 5, 8, 5, 4, 2, 3, 4, 5, 2};
-    for (int i = 0; i < SIZE; i++)
+    typename hpx::partitioned_vector<T>::iterator it = xvalues.begin();
+    for (int i = 0; i < SIZE; i++, it++)
     {
-        xvalues.set_value(i, init_array[i]);
+        *it = init_array[i];
     }
 }
 

--- a/libs/full/segmented_algorithms/tests/unit/partitioned_vector_minmax_element2.cpp
+++ b/libs/full/segmented_algorithms/tests/unit/partitioned_vector_minmax_element2.cpp
@@ -31,9 +31,10 @@ void initialize(hpx::partitioned_vector<T>& xvalues)
     T init_array[SIZE] = {1, 2, 3, 4, 5, 6, 2, 3, 3, 5, 5, 3, 4, 2, 3, 2, 6, 2,
         3, 4, 5, 6, 5, 6, 6, 2, 3, 4, 6, 6, 2, 3, 4, 5, 4, 3, 2, 6, 6, 2, 3, 4,
         6, 2, 3, 6, 6, 6, 6, 6, 6, 6, 6, 7, 6, 5, 8, 5, 4, 2, 3, 4, 5, 2};
-    for (int i = 0; i < SIZE; i++)
+    typename hpx::partitioned_vector<T>::iterator it = xvalues.begin();
+    for (int i = 0; i < SIZE; i++, it++)
     {
-        xvalues.set_value(i, init_array[i]);
+        *it = init_array[i];
     }
 }
 

--- a/libs/full/segmented_algorithms/tests/unit/partitioned_vector_none1.cpp
+++ b/libs/full/segmented_algorithms/tests/unit/partitioned_vector_none1.cpp
@@ -29,9 +29,10 @@ void initialize(hpx::partitioned_vector<T>& xvalues)
     T init_array[SIZE] = {1, 2, 3, 4, 5, 1, 2, 3, 3, 5, 5, 3, 4, 2, 3, 2, 1, 2,
         3, 4, 5, 6, 5, 6, 1, 2, 3, 4, 1, 1, 2, 3, 4, 5, 4, 3, 2, 1, 1, 2, 3, 4,
         1, 2, 3, 1, 1, 1, 1, 1, 1, 1, 1, 7, 6, 5, 7, 5, 4, 2, 3, 4, 5, 2};
-    for (int i = 0; i < SIZE; i++)
+    typename hpx::partitioned_vector<T>::iterator it = xvalues.begin();
+    for (int i = 0; i < SIZE; i++, it++)
     {
-        xvalues.set_value(i, init_array[i]);
+        *it = init_array[i];
     }
 }
 

--- a/libs/full/segmented_algorithms/tests/unit/partitioned_vector_none1.cpp
+++ b/libs/full/segmented_algorithms/tests/unit/partitioned_vector_none1.cpp
@@ -38,7 +38,7 @@ void initialize(hpx::partitioned_vector<T>& xvalues)
 struct op5
 {
     template <typename T>
-    bool operator()(T& value)
+    bool operator()(T& value) const
     {
         return value > 5;
     }
@@ -47,7 +47,7 @@ struct op5
 struct op0
 {
     template <typename T>
-    bool operator()(T& value)
+    bool operator()(T& value) const
     {
         return value > 0;
     }
@@ -56,7 +56,7 @@ struct op0
 struct op8
 {
     template <typename T>
-    bool operator()(T& value)
+    bool operator()(T& value) const
     {
         return value > 8;
     }

--- a/libs/full/segmented_algorithms/tests/unit/partitioned_vector_none2.cpp
+++ b/libs/full/segmented_algorithms/tests/unit/partitioned_vector_none2.cpp
@@ -29,9 +29,10 @@ void initialize(hpx::partitioned_vector<T>& xvalues)
     T init_array[SIZE] = {1, 2, 3, 4, 5, 1, 2, 3, 3, 5, 5, 3, 4, 2, 3, 2, 1, 2,
         3, 4, 5, 6, 5, 6, 1, 2, 3, 4, 1, 1, 2, 3, 4, 5, 4, 3, 2, 1, 1, 2, 3, 4,
         1, 2, 3, 1, 1, 1, 1, 1, 1, 1, 1, 7, 6, 5, 7, 5, 4, 2, 3, 4, 5, 2};
-    for (int i = 0; i < SIZE; i++)
+    typename hpx::partitioned_vector<T>::iterator it = xvalues.begin();
+    for (int i = 0; i < SIZE; i++, it++)
     {
-        xvalues.set_value(i, init_array[i]);
+        *it = init_array[i];
     }
 }
 

--- a/libs/full/segmented_algorithms/tests/unit/partitioned_vector_none2.cpp
+++ b/libs/full/segmented_algorithms/tests/unit/partitioned_vector_none2.cpp
@@ -38,7 +38,7 @@ void initialize(hpx::partitioned_vector<T>& xvalues)
 struct op5
 {
     template <typename T>
-    bool operator()(T& value)
+    bool operator()(T& value) const
     {
         return value > 5;
     }
@@ -47,7 +47,7 @@ struct op5
 struct op0
 {
     template <typename T>
-    bool operator()(T& value)
+    bool operator()(T& value) const
     {
         return value > 0;
     }
@@ -56,7 +56,7 @@ struct op0
 struct op8
 {
     template <typename T>
-    bool operator()(T& value)
+    bool operator()(T& value) const
     {
         return value > 8;
     }


### PR DESCRIPTION
Fixes a group of tests for HPX segmented algorithms, which were occasionally failing due to improper initialization of partitioned_vector. Initialization using partitioned_vector::set_value() is asynchronous and returns a future, but we never waited for it to complete.