### PR TITLE
Make heap fails in par for small sized heaps #6217

### DIFF
--- a/libs/core/algorithms/include/hpx/parallel/algorithms/make_heap.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/make_heap.hpp
@@ -394,16 +394,15 @@ namespace hpx::parallel {
                     while (start > 0)
                     {
                         // Index of start of level, and amount of items in level above start
-                        std::size_t const end_exclusive =
-                            static_cast<std::size_t>(
-                                std::pow(2, std::floor(std::log2(start))));
+                        std::size_t end_exclusive = static_cast<std::size_t>(
+                            std::pow(2, std::floor(std::log2(start))));
                         if (end_exclusive >= 2)
                         {
-                            end_exclusive -= 2;
+                            end_exclusive -= static_cast<std::size_t>(2);
                         }
                         else
                         {
-                            end_exclusive = 0;
+                            end_exclusive = static_cast<std::size_t>(0);
                         }
                         std::size_t level_items = start - end_exclusive;
 

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/make_heap.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/make_heap.hpp
@@ -404,11 +404,10 @@ namespace hpx::parallel {
                                     0
                                 1       2
                               3   4   5   6
-                        
-                            (size of heap) n = 7 
-                            (parent of last element) start = 2 
-                            end_exclusive => 
-                                last element index in 
+                            (size of heap) n = 7
+                            (parent of last element) start = 2
+                            end_exclusive =>
+                                last element index in
                                     parent level of start
                         */
                         std::size_t end_exclusive = static_cast<std::size_t>(

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/make_heap.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/make_heap.hpp
@@ -398,6 +398,9 @@ namespace hpx::parallel {
                         /*
                             helps find number of elements
                             in parent level of start
+                            The following are indexes of
+                            elements in the heap, not the
+                            value of the elements
                                     0
                                 1       2
                               3   4   5   6

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/make_heap.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/make_heap.hpp
@@ -393,11 +393,18 @@ namespace hpx::parallel {
                     std::size_t start = (n - 2) / 2;
                     while (start > 0)
                     {
-                        // Index of start of level, and amount of items in level
+                        // Index of start of level, and amount of items in level above start
                         std::size_t const end_exclusive =
                             static_cast<std::size_t>(
-                                std::pow(2, std::floor(std::log2(start)))) -
-                            2;
+                                std::pow(2, std::floor(std::log2(start))));
+                        if (end_exclusive >= 2)
+                        {
+                            end_exclusive -= 2;
+                        }
+                        else
+                        {
+                            end_exclusive = 0;
+                        }
                         std::size_t level_items = start - end_exclusive;
 
                         // If we can't at least run two chunks in parallel,

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/make_heap.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/make_heap.hpp
@@ -389,11 +389,25 @@ namespace hpx::parallel {
 
                 try
                 {
-                    // Get workitems that are to be run in parallel
+                    // parent of last node
+                    // last node has index (n-1)
+                    // parent of x is floor of (x-1)/2
                     std::size_t start = (n - 2) / 2;
                     while (start > 0)
                     {
-                        // Index of start of level, and amount of items in level above start
+                        /*
+                            helps find number of elements
+                            in parent level of start
+                                    0
+                                1       2
+                              3   4   5   6
+                        
+                            (size of heap) n = 7 
+                            (parent of last element) start = 2 
+                            end_exclusive => 
+                                last element index in 
+                                    parent level of start
+                        */
                         std::size_t end_exclusive = static_cast<std::size_t>(
                             std::pow(2, std::floor(std::log2(start))));
                         if (end_exclusive >= 2)

--- a/libs/core/algorithms/tests/unit/algorithms/make_heap.cpp
+++ b/libs/core/algorithms/tests/unit/algorithms/make_heap.cpp
@@ -25,17 +25,58 @@ std::mt19937 gen(seed);
 
 ///////////////////////////////////////////////////////////////////////////
 template <typename IteratorTag>
+void test_make_heap_small1(IteratorTag)
+{
+    typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+
+    std::size_t len = -1;
+    while (len++ < 15)
+    {
+        std::vector<std::size_t> c(len);
+        std::iota(hpx::util::begin(c), hpx::util::end(c), gen());
+
+        hpx::make_heap(
+            iterator(hpx::util::begin(c)), iterator(hpx::util::end(c)));
+
+        HPX_TEST_EQ(std::is_heap(hpx::util::begin(c), hpx::util::end(c)), true);
+    }
+}
+
+template <typename IteratorTag>
 void test_make_heap1(IteratorTag)
 {
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
 
     std::vector<std::size_t> c(10007);
-    std::iota(hpx::util::begin(c), hpx::util::end(c), 0);
+    std::iota(hpx::util::begin(c), hpx::util::end(c), gen());
 
     hpx::make_heap(iterator(hpx::util::begin(c)), iterator(hpx::util::end(c)));
 
     HPX_TEST_EQ(std::is_heap(hpx::util::begin(c), hpx::util::end(c)), true);
+}
+
+template <typename ExPolicy, typename IteratorTag>
+void test_make_heap_small1(ExPolicy&& policy, IteratorTag)
+{
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
+
+    typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+
+    std::size_t len = -1;
+    while (len++ < 15)
+    {
+        std::vector<std::size_t> c(len);
+        std::iota(hpx::util::begin(c), hpx::util::end(c), gen());
+
+        hpx::make_heap(
+            policy, iterator(hpx::util::begin(c)), iterator(hpx::util::end(c)));
+
+        HPX_TEST_EQ(std::is_heap(hpx::util::begin(c), hpx::util::end(c)), true);
+    }
 }
 
 template <typename ExPolicy, typename IteratorTag>
@@ -78,10 +119,15 @@ void test_make_heap1()
     using namespace hpx::execution;
 
     test_make_heap1(IteratorTag());
+    test_make_heap_small1(IteratorTag());
 
     test_make_heap1(seq, IteratorTag());
     test_make_heap1(par, IteratorTag());
     test_make_heap1(par_unseq, IteratorTag());
+
+    test_make_heap_small1(seq, IteratorTag());
+    test_make_heap_small1(par, IteratorTag());
+    test_make_heap_small1(par_unseq, IteratorTag());
 
     test_make_heap_async1(seq(task), IteratorTag());
     test_make_heap_async1(par(task), IteratorTag());

--- a/libs/core/algorithms/tests/unit/algorithms/make_heap.cpp
+++ b/libs/core/algorithms/tests/unit/algorithms/make_heap.cpp
@@ -30,8 +30,8 @@ void test_make_heap_small1(IteratorTag)
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
 
-    std::size_t len = -1;
-    while (len++ < 15)
+    std::size_t len = 0;
+    while (len < 15)
     {
         std::vector<std::size_t> c(len);
         std::iota(hpx::util::begin(c), hpx::util::end(c), gen());
@@ -40,6 +40,7 @@ void test_make_heap_small1(IteratorTag)
             iterator(hpx::util::begin(c)), iterator(hpx::util::end(c)));
 
         HPX_TEST_EQ(std::is_heap(hpx::util::begin(c), hpx::util::end(c)), true);
+        len++;
     }
 }
 
@@ -66,8 +67,8 @@ void test_make_heap_small1(ExPolicy&& policy, IteratorTag)
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
 
-    std::size_t len = -1;
-    while (len++ < 15)
+    std::size_t len = 0;
+    while (len < 15)
     {
         std::vector<std::size_t> c(len);
         std::iota(hpx::util::begin(c), hpx::util::end(c), gen());
@@ -76,6 +77,7 @@ void test_make_heap_small1(ExPolicy&& policy, IteratorTag)
             policy, iterator(hpx::util::begin(c)), iterator(hpx::util::end(c)));
 
         HPX_TEST_EQ(std::is_heap(hpx::util::begin(c), hpx::util::end(c)), true);
+        len++;
     }
 }
 


### PR DESCRIPTION
Fixes #6217

## Any background context you want to provide?
added tests, fixed bug. We try to find last element index of parent level (end_exclusive). If child is element of index 1, last element of parent level becomes -1 and there is negative overflow.

fixed it by enforcing end_exclusive to be >=0




## Checklist

Not all points below apply to all pull requests.

- [ ] I have added a new feature and have added tests to go along with it.
- [x] I have fixed a bug and have added a regression test.
- [x] I have added a test using random numbers; I have made sure it uses a seed, and that random numbers generated are valid inputs for the tests.
