### PR TITLE
Fixing algorithms for zero length sequences when run with s/r scheduler

### DIFF
--- a/libs/core/algorithms/include/hpx/parallel/util/detail/chunk_size.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/util/detail/chunk_size.hpp
@@ -135,6 +135,12 @@ namespace hpx::parallel::util::detail {
     get_bulk_iteration_shape(ExPolicy&& policy, IterOrR& it_or_r,
         std::size_t& count, Stride s = Stride(1))
     {
+        if (count == 0)
+        {
+            auto it = chunk_size_iterator(it_or_r, 1);
+            return hpx::util::iterator_range(it, it);
+        }
+
         std::size_t const cores =
             execution::processing_units_count(policy.parameters(),
                 policy.executor(), hpx::chrono::null_duration, count);
@@ -172,6 +178,12 @@ namespace hpx::parallel::util::detail {
     get_bulk_iteration_shape(ExPolicy&& policy, std::vector<Future>& workitems,
         F1&& f1, IterOrR& it_or_r, std::size_t& count, Stride s = Stride(1))
     {
+        if (count == 0)
+        {
+            auto it = chunk_size_iterator(it_or_r, 1);
+            return hpx::util::iterator_range(it, it);
+        }
+
         Stride stride = parallel::detail::abs(s);
 
         auto test_function = [&](std::size_t test_chunk_size) -> std::size_t {
@@ -242,6 +254,12 @@ namespace hpx::parallel::util::detail {
         std::size_t& count, Stride s = Stride(1))
     {
         using tuple_type = hpx::tuple<IterOrR, std::size_t>;
+        std::vector<tuple_type> shape;
+
+        if (count == 0)
+        {
+            return shape;
+        }
 
         std::size_t const cores =
             execution::processing_units_count(policy.parameters(),
@@ -251,7 +269,6 @@ namespace hpx::parallel::util::detail {
             policy.parameters(), policy.executor(), cores, count);
         HPX_ASSERT(0 != max_chunks);
 
-        std::vector<tuple_type> shape;
         Stride stride = parallel::detail::abs(s);
 
         // different versions of clang-format do different things
@@ -346,6 +363,15 @@ namespace hpx::parallel::util::detail {
     get_bulk_iteration_shape_idx(ExPolicy&& policy, FwdIter begin,
         std::size_t count, Stride s = Stride(1))
     {
+        using iterator =
+            parallel::util::detail::chunk_size_idx_iterator<FwdIter>;
+
+        if (count == 0)
+        {
+            auto it = iterator(begin, 1);
+            return hpx::util::iterator_range(it, it);
+        }
+
         std::size_t const cores =
             execution::processing_units_count(policy.parameters(),
                 policy.executor(), hpx::chrono::null_duration, count);
@@ -371,9 +397,6 @@ namespace hpx::parallel::util::detail {
             // clang-format on
         }
 
-        using iterator =
-            parallel::util::detail::chunk_size_idx_iterator<FwdIter>;
-
         iterator shape_begin(begin, chunk_size, count, 0, 0);
         iterator shape_end(last, chunk_size, count, count, 0);
 
@@ -388,6 +411,15 @@ namespace hpx::parallel::util::detail {
         std::vector<Future>& workitems, F1&& f1, FwdIter begin,
         std::size_t count, Stride s = Stride(1))
     {
+        using iterator =
+            parallel::util::detail::chunk_size_idx_iterator<FwdIter>;
+
+        if (count == 0)
+        {
+            auto it = iterator(begin, 1);
+            return hpx::util::iterator_range(it, it);
+        }
+
         Stride stride = parallel::detail::abs(s);
 
         std::size_t base_idx = 0;
@@ -443,9 +475,6 @@ namespace hpx::parallel::util::detail {
             // clang-format on
         }
 
-        using iterator =
-            parallel::util::detail::chunk_size_idx_iterator<FwdIter>;
-
         iterator shape_begin(begin, chunk_size, count, 0, base_idx);
         iterator shape_end(last, chunk_size, count, count, base_idx);
 
@@ -459,6 +488,12 @@ namespace hpx::parallel::util::detail {
         std::size_t count, Stride s = Stride(1))
     {
         using tuple_type = hpx::tuple<FwdIter, std::size_t, std::size_t>;
+        std::vector<tuple_type> shape;
+
+        if (count == 0)
+        {
+            return shape;
+        }
 
         std::size_t const cores =
             execution::processing_units_count(policy.parameters(),
@@ -467,7 +502,6 @@ namespace hpx::parallel::util::detail {
         std::size_t max_chunks = execution::maximal_number_of_chunks(
             policy.parameters(), policy.executor(), cores, count);
 
-        std::vector<tuple_type> shape;
         Stride stride = parallel::detail::abs(s);
 
         // different versions of clang-format do different things

--- a/libs/core/algorithms/include/hpx/parallel/util/detail/chunk_size_iterator.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/util/detail/chunk_size_iterator.hpp
@@ -130,7 +130,8 @@ namespace hpx::parallel::util::detail {
         HPX_HOST_DEVICE chunk_size_iterator(IterOrR it, std::size_t chunk_size,
             std::size_t count = 0, std::size_t current = 0) noexcept
           : data_(it, 0)
-          , chunk_size_((hpx::detail::min)(chunk_size, count))
+          , chunk_size_(
+                (std::max)((std::min)(chunk_size, count), std::size_t(1)))
           , last_chunk_size_(get_last_chunk_size(count, chunk_size))
           , count_(count)
           , current_(get_current(current, chunk_size))
@@ -352,7 +353,8 @@ namespace hpx::parallel::util::detail {
             std::size_t chunk_size, std::size_t count = 0,
             std::size_t current = 0, std::size_t base_idx = 0)
           : data_(it, 0, base_idx)
-          , chunk_size_((hpx::detail::min)(chunk_size, count))
+          , chunk_size_(
+                (std::max)((std::min)(chunk_size, count), std::size_t(1)))
           , last_chunk_size_(get_last_chunk_size(count, chunk_size))
           , count_(count)
           , current_(get_current(current, chunk_size))

--- a/libs/core/algorithms/tests/unit/algorithms/foreach_sender.cpp
+++ b/libs/core/algorithms/tests/unit/algorithms/foreach_sender.cpp
@@ -32,7 +32,6 @@ void test_for_each_explicit_sender_direct(
     std::iota(std::begin(c), std::end(c), std::rand());
 
     namespace ex = hpx::execution::experimental;
-    namespace tt = hpx::this_thread::experimental;
 
     auto f = [](std::size_t& v) { v = 42; };
 


### PR DESCRIPTION
@Pansysk75 this should fix the issue we discussed. Please verify.