### PR TITLE
Modernize set_thread_name on Windows

### DIFF
--- a/libs/core/thread_support/include/hpx/thread_support/set_thread_name.hpp
+++ b/libs/core/thread_support/include/hpx/thread_support/set_thread_name.hpp
@@ -12,15 +12,14 @@
 
 namespace hpx::util {
 
-    HPX_CORE_EXPORT void set_thread_name(
-        char const*, unsigned long = static_cast<unsigned long>(-1));
+    HPX_CORE_EXPORT void set_thread_name(char const* thread_name) noexcept;
 }    // namespace hpx::util
 
 #else
 
 namespace hpx::util {
 
-    constexpr void set_thread_name(char const* /*thread_name*/) noexcept {}
+    constexpr void set_thread_name(char const*) noexcept {}
 }    // namespace hpx::util
 
 #endif

--- a/libs/core/thread_support/src/set_thread_name.cpp
+++ b/libs/core/thread_support/src/set_thread_name.cpp
@@ -10,42 +10,87 @@
 #include <hpx/config.hpp>
 
 #if defined(WIN32) || defined(_WIN32) || defined(__WIN32__)
-#include <winsock2.h>
-
 #include <windows.h>
 
 #include <hpx/thread_support/set_thread_name.hpp>
 
+#include <cstddef>
+#include <string>
+
 namespace hpx::util {
-    DWORD const MS_VC_EXCEPTION = 0x406D1388;
+
+    constexpr DWORD MS_VC_EXCEPTION = 0x406D1388;
 
 #pragma pack(push, 8)
-    typedef struct tagTHREADNAME_INFO
+    using THREADNAME_INFO = struct tagTHREADNAME_INFO
     {
         DWORD dwType;        // Must be 0x1000.
         LPCSTR szName;       // Pointer to name (in user addr space).
         DWORD dwThreadID;    // Thread ID (-1=caller thread).
         DWORD dwFlags;       // Reserved for future use, must be zero.
-    } THREADNAME_INFO;
+    };
 #pragma pack(pop)
 
-    // Set the name of the thread shown in the Visual Studio debugger
-    void set_thread_name(char const* threadName, DWORD dwThreadID)
-    {
-        THREADNAME_INFO info;
-        info.dwType = 0x1000;
-        info.szName = threadName;
-        info.dwThreadID = dwThreadID;
-        info.dwFlags = 0;
+    namespace detail {
 
-        __try
+        std::wstring to_wide_string(char const* name) noexcept
         {
-            RaiseException(MS_VC_EXCEPTION, 0, sizeof(info) / sizeof(ULONG_PTR),
-                (ULONG_PTR*) &info);
+            try
+            {
+                std::string const str(name);
+                if (str.empty())
+                    return {};
+
+                // determine required length of new string
+                std::size_t const req_length = MultiByteToWideChar(CP_UTF8, 0,
+                    str.c_str(), static_cast<int>(str.length()), nullptr, 0);
+
+                // construct new string of required length
+                std::wstring ret(req_length, L'\0');
+
+                // convert old string to new string
+                MultiByteToWideChar(CP_UTF8, 0, str.c_str(),
+                    static_cast<int>(str.length()), ret.data(),
+                    static_cast<int>(ret.length()));
+
+                return ret;
+            }
+            catch (...)
+            {
+                return {};
+            }
         }
-        __except (EXCEPTION_EXECUTE_HANDLER)
+
+        void set_thread_name(char const* thread_name) noexcept
         {
+            // set thread name the 'old' way
+            THREADNAME_INFO info;
+            info.dwType = 0x1000;
+            info.szName = thread_name;
+            info.dwThreadID = -1;
+            info.dwFlags = 0;
+
+            __try
+            {
+                RaiseException(MS_VC_EXCEPTION, 0,
+                    sizeof(info) / sizeof(ULONG_PTR),
+                    reinterpret_cast<ULONG_PTR*>(&info));
+            }
+            __except (EXCEPTION_EXECUTE_HANDLER)
+            {
+            }
         }
+    }    // namespace detail
+
+    // Set the name of the thread shown in the Visual Studio debugger
+    void set_thread_name(char const* thread_name) noexcept
+    {
+        detail::set_thread_name(thread_name);
+
+        // also set it the 'new' way in case the application is not running in
+        // the debugger at this time
+        SetThreadDescription(
+            GetCurrentThread(), detail::to_wide_string(thread_name).c_str());
     }
 }    // namespace hpx::util
 


### PR DESCRIPTION
This changes setting thread names on Windows such that the name is visible in the debugger even if the process was attached and not started by VS.