### PR TITLE
Fix nvcc/gcc-10 (Octo-Tiger) compilation issue 

### DIFF
--- a/libs/core/algorithms/include/hpx/parallel/util/loop.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/util/loop.hpp
@@ -214,7 +214,7 @@ namespace hpx::parallel::util {
 
 #if !defined(HPX_COMPUTE_DEVICE_CODE)
     template <typename ExPolicy>
-    inline constexpr loop_ind_t loop_ind = loop_ind_t<ExPolicy>{};
+    inline constexpr loop_ind_t<ExPolicy> loop_ind = loop_ind_t<ExPolicy>{};
 #else
     template <typename ExPolicy, typename Begin, typename End, typename F>
     HPX_HOST_DEVICE HPX_FORCEINLINE constexpr Begin loop_ind(


### PR DESCRIPTION
Using HPX 1.9.0, the Octo-Tiger compilation (using just CUDA, not Kokkos) with gcc+nvcc fails due to an internal nvcc error pointing to loop.hpp within HPX:

```
build/hpx/include/hpx/parallel/util/loop.hpp(216): internal error: assertion failed at: "cp_gen_be.c", line 22617 in gen_variable_decl                                                                                                                 

1 catastrophic error detected in the compilation of "/src/octotiger/src/unitiger/hydro_impl/flux_cuda_kernel.cpp".                                                                                                                                      
Compilation aborted.
nvcc error   : 'cudafe++' died due to signal 6
nvcc error   : 'cudafe++' core dumped
```

That is with using g++10 and CUDA 11.5.
While using newer versions of g++/CUDA fix this, it would be nice to not lose g++-10 support over this.

Interestingly, simply providing nvcc with more information about the type seems to help as well, hence this PR to resolve the issue without losing support for the older compiler.



