### PR TITLE
Rewriting wait_some to circumvent data races causing hangs

### DIFF
--- a/libs/core/async_combinators/CMakeLists.txt
+++ b/libs/core/async_combinators/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2022 The STE||AR-Group
+# Copyright (c) 2019-2023 The STE||AR-Group
 #
 # SPDX-License-Identifier: BSL-1.0
 # Distributed under the Boost Software License, Version 1.0. (See accompanying


### PR DESCRIPTION
- flyby: fixing possible race in latch

@m-diers Could you please try this patch to see if it fixes your issue?