### PR TITLE
Improve LCI parcelport and new performance tests.

### DIFF
--- a/libs/full/parcelport_lci/CMakeLists.txt
+++ b/libs/full/parcelport_lci/CMakeLists.txt
@@ -29,6 +29,7 @@ set(parcelport_lci_headers
     hpx/parcelport_lci/completion_manager_base.hpp
     hpx/parcelport_lci/completion_manager/completion_manager_queue.hpp
     hpx/parcelport_lci/completion_manager/completion_manager_sync.hpp
+    hpx/parcelport_lci/completion_manager/completion_manager_sync_single.hpp
 )
 
 # cmake-format: off

--- a/libs/full/parcelport_lci/include/hpx/parcelport_lci/completion_manager/completion_manager_sync_single.hpp
+++ b/libs/full/parcelport_lci/include/hpx/parcelport_lci/completion_manager/completion_manager_sync_single.hpp
@@ -1,0 +1,60 @@
+//  Copyright (c) 2014-2023 Thomas Heller
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include <hpx/config.hpp>
+
+#if defined(HPX_HAVE_NETWORKING) && defined(HPX_HAVE_PARCELPORT_LCI)
+
+#include <hpx/parcelport_lci/completion_manager_base.hpp>
+
+namespace hpx::parcelset::policies::lci {
+    struct completion_manager_sync_single : public completion_manager_base
+    {
+        completion_manager_sync_single()
+        {
+            LCI_sync_create(LCI_UR_DEVICE, 1, &sync);
+        }
+
+        ~completion_manager_sync_single()
+        {
+            LCI_sync_free(&sync);
+        }
+
+        LCI_comp_t alloc_completion()
+        {
+            return sync;
+        }
+
+        void enqueue_completion(LCI_comp_t comp)
+        {
+            HPX_UNUSED(comp);
+            lock.unlock();
+        }
+
+        LCI_request_t poll()
+        {
+            LCI_request_t request;
+            request.flag = LCI_ERR_RETRY;
+
+            bool succeed = lock.try_lock();
+            if (succeed)
+            {
+                LCI_error_t ret = LCI_sync_test(sync, &request);
+                if (ret == LCI_ERR_RETRY)
+                    lock.unlock();
+            }
+            return request;
+        }
+
+    private:
+        hpx::spinlock lock;
+        LCI_comp_t sync;
+    };
+}    // namespace hpx::parcelset::policies::lci
+
+#endif

--- a/libs/full/parcelport_lci/include/hpx/parcelport_lci/config.hpp
+++ b/libs/full/parcelport_lci/include/hpx/parcelport_lci/config.hpp
@@ -17,8 +17,6 @@ namespace hpx::parcelset::policies::lci {
     {
         // whether init_config has been called
         static bool is_initialized;
-        // whether to use separate devices/progress threads for eager and iovec messages.
-        static bool use_two_device;
         // whether to bypass the parcel queue and connection cache.
         static bool enable_send_immediate;
         // whether to enable the backlog queue and eager message aggregation
@@ -36,13 +34,14 @@ namespace hpx::parcelset::policies::lci {
         // how to run LCI_progress
         enum class progress_type_t
         {
-            rp,         // HPX resource partitioner
-            pthread,    // Normal pthread
-            worker,     // HPX worker thread
+            rp,                // HPX resource partitioner
+            pthread,           // Normal progress pthread
+            worker,            // HPX worker thread
+            pthread_worker,    // Normal progress pthread + worker thread
         };
         static progress_type_t progress_type;
-        // Which core to pin the progress threads
-        static int progress_thread_core;
+        // How many progress threads to create
+        static int progress_thread_num;
         // How many pre-posted receives for new messages
         // (can only be applied to `sendrecv` protocol).
         static int prepost_recv_num;

--- a/libs/full/parcelport_lci/include/hpx/parcelport_lci/sendrecv/receiver_sendrecv.hpp
+++ b/libs/full/parcelport_lci/include/hpx/parcelport_lci/sendrecv/receiver_sendrecv.hpp
@@ -46,8 +46,8 @@ namespace hpx::parcelset::policies::lci {
                 {
                     LCI_comp_t completion =
                         pp_->recv_new_completion_manager->alloc_completion();
-                    LCI_recvmn(pp_->endpoint_new_eager, LCI_RANK_ANY, 0,
-                        completion, nullptr);
+                    LCI_recvmn(pp_->endpoint_new, LCI_RANK_ANY, 0, completion,
+                        nullptr);
                     pp_->recv_new_completion_manager->enqueue_completion(
                         completion);
                 }

--- a/libs/full/parcelport_lci/src/putva/sender_connection_putva.cpp
+++ b/libs/full/parcelport_lci/src/putva/sender_connection_putva.cpp
@@ -63,7 +63,7 @@ namespace hpx::parcelset::policies::lci {
         int num_zero_copy_chunks = static_cast<int>(buffer_.num_chunks_.first);
         if (is_eager)
         {
-            while (LCI_mbuffer_alloc(pp_->device_eager, &mbuffer) != LCI_OK)
+            while (LCI_mbuffer_alloc(pp_->device, &mbuffer) != LCI_OK)
                 continue;
             HPX_ASSERT(mbuffer.length == (size_t) LCI_MEDIUM_SIZE);
             header_ = header(buffer_, (char*) mbuffer.address, mbuffer.length);
@@ -173,7 +173,7 @@ namespace hpx::parcelset::policies::lci {
         int ret;
         if (is_eager)
         {
-            ret = LCI_putmna(pp_->endpoint_new_eager, mbuffer, dst_rank, 0,
+            ret = LCI_putmna(pp_->endpoint_new, mbuffer, dst_rank, 0,
                 LCI_DEFAULT_COMP_REMOTE);
             if (ret == LCI_OK)
             {
@@ -192,8 +192,8 @@ namespace hpx::parcelset::policies::lci {
             // We will get this pointer back via the send completion queue
             // after this send completes.
             state.store(connection_state::locked, std::memory_order_relaxed);
-            ret = LCI_putva(pp_->endpoint_new_iovec, iovec, completion,
-                dst_rank, 0, LCI_DEFAULT_COMP_REMOTE, sharedPtr_p);
+            ret = LCI_putva(pp_->endpoint_new, iovec, completion, dst_rank, 0,
+                LCI_DEFAULT_COMP_REMOTE, sharedPtr_p);
             // After this point, if ret == OK, this object can be shared by
             // two threads (the sending thread and the thread polling the
             // completion queue). Care must be taken to avoid data race.

--- a/libs/full/parcelport_lci/src/sender_connection_base.cpp
+++ b/libs/full/parcelport_lci/src/sender_connection_base.cpp
@@ -55,8 +55,10 @@ namespace hpx::parcelset::policies::lci {
             {
                 ret = send_nb();
                 if (ret.status == return_status_t::retry &&
-                    config_t::progress_type ==
-                        config_t::progress_type_t::worker)
+                    (config_t::progress_type ==
+                            config_t::progress_type_t::worker ||
+                        config_t::progress_type ==
+                            config_t::progress_type_t::pthread_worker))
                     while (pp_->do_progress())
                         continue;
             } while (ret.status == return_status_t::retry);

--- a/libs/full/parcelport_lci/src/sendrecv/receiver_sendrecv.cpp
+++ b/libs/full/parcelport_lci/src/sendrecv/receiver_sendrecv.cpp
@@ -47,12 +47,11 @@ namespace hpx::parcelset::policies::lci {
             {
                 LCI_comp_t completion =
                     pp_->recv_new_completion_manager->alloc_completion();
-                LCI_recvmn(pp_->endpoint_new_eager, LCI_RANK_ANY, 0, completion,
-                    nullptr);
+                LCI_recvmn(
+                    pp_->endpoint_new, LCI_RANK_ANY, 0, completion, nullptr);
                 pp_->recv_new_completion_manager->enqueue_completion(
                     completion);
             }
-            HPX_ASSERT(request.request.flag == LCI_OK);
             util::lci_environment::log(
                 util::lci_environment::log_level_t::debug,
                 "accept_new (%d, %d, %d) length %lu\n", request.request.rank,

--- a/libs/full/parcelport_lci/src/sendrecv/sender_connection_sendrecv.cpp
+++ b/libs/full/parcelport_lci/src/sendrecv/sender_connection_sendrecv.cpp
@@ -45,7 +45,7 @@ namespace hpx::parcelset::policies::lci {
             HPX_FORWARD(ParcelPostprocess, parcel_postprocess);
 
         // build header
-        while (LCI_mbuffer_alloc(pp_->device_eager, &header_buffer) != LCI_OK)
+        while (LCI_mbuffer_alloc(pp_->device, &header_buffer) != LCI_OK)
             continue;
         HPX_ASSERT(header_buffer.length == (size_t) LCI_MEDIUM_SIZE);
         header_ = header(
@@ -139,14 +139,13 @@ namespace hpx::parcelset::policies::lci {
         LCI_error_t ret;
         if (config_t::protocol == config_t::protocol_t::putsendrecv)
         {
-            ret = LCI_putmna(pp_->endpoint_new_eager, header_buffer, dst_rank,
-                0, LCI_DEFAULT_COMP_REMOTE);
+            ret = LCI_putmna(pp_->endpoint_new, header_buffer, dst_rank, 0,
+                LCI_DEFAULT_COMP_REMOTE);
         }
         else
         {
             HPX_ASSERT(config_t::protocol == config_t::protocol_t::sendrecv);
-            ret =
-                LCI_sendmn(pp_->endpoint_new_eager, header_buffer, dst_rank, 0);
+            ret = LCI_sendmn(pp_->endpoint_new, header_buffer, dst_rank, 0);
         }
         if (ret == LCI_OK)
         {

--- a/tests/performance/network/CMakeLists.txt
+++ b/tests/performance/network/CMakeLists.txt
@@ -14,7 +14,7 @@ foreach(subdir ${subdirs})
   )
 endforeach()
 
-set(benchmarks pingpong_performance)
+set(benchmarks pingpong_performance pingpong_performance2)
 
 foreach(benchmark ${benchmarks})
 

--- a/tests/performance/network/pingpong_performance2.cpp
+++ b/tests/performance/network/pingpong_performance2.cpp
@@ -1,0 +1,205 @@
+//  Copyright (c) 2023 Jiakun Yan
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/config.hpp>
+#if !defined(HPX_COMPUTE_DEVICE_CODE)
+#include <hpx/hpx_init.hpp>
+#include <hpx/include/actions.hpp>
+#include <hpx/include/components.hpp>
+#include <hpx/include/lcos.hpp>
+#include <hpx/include/runtime.hpp>
+#include <hpx/iostream.hpp>
+#include <hpx/modules/timing.hpp>
+#include <hpx/serialization.hpp>
+
+#include <atomic>
+#include <cstddef>
+#include <iostream>
+#include <memory>
+#include <utility>
+#include <vector>
+
+///////////////////////////////////////////////////////////////////////////////
+const std::size_t nbytes_default = 8;
+const std::size_t nsteps_default = 1;
+const std::size_t window_default = 10000;
+const std::size_t inject_rate_default = 0;
+const std::size_t batch_size_default = 10;
+
+size_t window;
+size_t inject_rate;
+size_t batch_size;
+
+///////////////////////////////////////////////////////////////////////////////
+
+void set_window(std::size_t window);
+HPX_PLAIN_ACTION(set_window, set_window_action)
+
+void on_inject(hpx::id_type to, size_t nbytes, std::size_t nsteps);
+HPX_PLAIN_ACTION(on_inject, on_inject_action)
+
+void on_recv(hpx::id_type to, std::vector<char> const& in, std::size_t counter);
+HPX_PLAIN_ACTION(on_recv, on_recv_action)
+
+void on_done();
+HPX_PLAIN_ACTION(on_done, on_done_action)
+
+void set_window(std::size_t window_)
+{
+    window = window_;
+}
+
+void on_inject(hpx::id_type to, std::size_t nbytes, std::size_t nsteps)
+{
+    hpx::chrono::high_resolution_timer timer;
+    for (size_t i = 0; i < batch_size; ++i)
+    {
+        while (inject_rate > 0 &&
+            static_cast<double>(i) / timer.elapsed() >
+                static_cast<double>(inject_rate))
+        {
+            hpx::this_thread::yield();
+        }
+        std::vector<char> data(nbytes, 'a');
+        hpx::post<on_recv_action>(to, hpx::find_here(), data, nsteps);
+    }
+}
+
+std::atomic<size_t> done_counter(0);
+
+void on_recv(hpx::id_type to, std::vector<char> const& in, std::size_t counter)
+{
+    // received vector in
+    if (--counter == 0)
+    {
+        size_t result = done_counter.fetch_add(1, std::memory_order_relaxed);
+        if (result + 1 == window)
+        {
+            hpx::post<on_done_action>(hpx::find_root_locality());
+        }
+        return;
+    }
+
+    // send it to remote locality (to)
+    std::vector<char> data(in);
+    hpx::post<on_recv_action>(to, hpx::find_here(), std::move(data), counter);
+}
+
+hpx::counting_semaphore_var<> semaphore;
+
+void on_done()
+{
+    semaphore.signal();
+}
+
+///////////////////////////////////////////////////////////////////////////////
+int hpx_main(hpx::program_options::variables_map& b_arg)
+{
+    std::size_t const nbytes = b_arg["nbytes"].as<std::size_t>();
+    std::size_t const nsteps = b_arg["nsteps"].as<std::size_t>();
+    bool verbose = b_arg["verbose"].as<bool>();
+    window = b_arg["window"].as<std::size_t>();
+    inject_rate = b_arg["inject-rate"].as<std::size_t>();
+    batch_size = b_arg["batch-size"].as<std::size_t>();
+
+    if (nsteps == 0)
+    {
+        std::cout << "nsteps is 0!" << std::endl;
+        return 0;
+    }
+
+    std::vector<hpx::id_type> localities = hpx::find_remote_localities();
+
+    hpx::id_type to;
+    if (localities.size() == 0)
+    {
+        to = hpx::find_here();
+    }
+    else
+    {
+        to = localities[0];    // send to first remote locality
+    }
+
+    set_window_action act;
+    act(to, window);
+
+    hpx::chrono::high_resolution_timer timer_total;
+
+    for (size_t i = 0; i < window; i += batch_size)
+    {
+        while (inject_rate > 0 &&
+            static_cast<double>(i) / timer_total.elapsed() >
+                static_cast<double>(inject_rate))
+        {
+            continue;
+        }
+        hpx::post<on_inject_action>(hpx::find_here(), to, nbytes, nsteps);
+    }
+    double achieved_inject_rate =
+        static_cast<double>(window) / timer_total.elapsed() / 1e3;
+
+    semaphore.wait();
+
+    double time = timer_total.elapsed();
+    double latency = time * 1e6 / static_cast<double>(nsteps);
+    double msg_rate = static_cast<double>(nsteps * window) / time / 1e3;
+    double bandwidth =
+        static_cast<double>(nbytes * nsteps * window) / time / 1e6;
+    if (verbose)
+    {
+        std::cout << "[hpx_pingpong]" << std::endl
+                  << "total_time(secs)=" << time << std::endl
+                  << "nbytes=" << nbytes << std::endl
+                  << "window=" << window << std::endl
+                  << "latency(us)=" << latency << std::endl
+                  << "inject_rate(K/s)=" << achieved_inject_rate << std::endl
+                  << "msg_rate(K/s)=" << msg_rate << std::endl
+                  << "bandwidth(MB/s)=" << bandwidth << std::endl
+                  << "localities=" << localities.size() << std::endl
+                  << "nsteps=" << nsteps << std::endl;
+    }
+    else
+    {
+        std::cout << "[hpx_pingpong]"
+                  << ":total_time(secs)=" << time << ":nbytes=" << nbytes
+                  << ":window=" << window << ":latency(us)=" << latency
+                  << ":inject_rate(K/s)=" << achieved_inject_rate
+                  << ":msg_rate(M/s)=" << msg_rate
+                  << ":bandwidth(MB/s)=" << bandwidth
+                  << ":localities=" << localities.size() << ":nsteps=" << nsteps
+                  << std::endl;
+    }
+
+    hpx::finalize();
+    return 0;
+}
+
+int main(int argc, char* argv[])
+{
+    namespace po = hpx::program_options;
+    po::options_description description("HPX pingpong example");
+
+    description.add_options()("nbytes",
+        po::value<std::size_t>()->default_value(nbytes_default),
+        "number of elements (doubles) to send/receive (integer)")("nsteps",
+        po::value<std::size_t>()->default_value(nsteps_default),
+        "number of ping-pong iterations")("window",
+        po::value<std::size_t>()->default_value(window_default),
+        "window size of ping-pong")("inject-rate",
+        po::value<std::size_t>()->default_value(inject_rate_default),
+        "the rate of injecting the first message of ping-pong")("batch-size",
+        po::value<std::size_t>()->default_value(batch_size_default),
+        "the number of messages to inject per inject thread")("verbose",
+        po::value<bool>()->default_value(true),
+        "verbosity of output,if false output is for awk");
+
+    hpx::init_params init_args;
+    init_args.desc_cmdline = description;
+
+    return hpx::init(argc, argv, init_args);
+}
+
+#endif


### PR DESCRIPTION
This PR contains several changes/optimizations to the LCI parcelport

- Optimize the case of pre-posting one receive for new header messages. 
- Add new progress type: pthread_worker.
- Add the option of using multiple pinned progress threads. 
- Remove the option `two_device`.
- Remove the option `progress_thread_core`.
- Change the default configuration from `putva` to `putsendrecv`. 

Flyby: Add new performance tests: pingpong_performance2.
