### PR TITLE
Improve the MPI parcelport and change the zero-copy threshold to 8192

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -655,8 +655,8 @@ endif()
 hpx_option(
   HPX_WITH_ZERO_COPY_SERIALIZATION_THRESHOLD
   STRING
-  "The threshold in bytes to when perform zero copy optimizations (default: 128)"
-  "128"
+  "The threshold in bytes to when perform zero copy optimizations (default: 8192)"
+  "8192"
   ADVANCED
 )
 hpx_add_config_define(

--- a/cmake/toolchains/Cray.cmake
+++ b/cmake/toolchains/Cray.cmake
@@ -90,12 +90,6 @@ set(HPX_PARCELPORT_LIBFABRIC_WITH_LOGGING
     OFF
     CACHE BOOL "Libfabric parcelport logging on/off flag"
 )
-set(HPX_WITH_ZERO_COPY_SERIALIZATION_THRESHOLD
-    "4096"
-    CACHE
-      STRING
-      "The threshold in bytes to when perform zero copy optimizations (default: 128)"
-)
 
 # We do a cross compilation here ...
 set(CMAKE_CROSSCOMPILING

--- a/cmake/toolchains/CrayKNL.cmake
+++ b/cmake/toolchains/CrayKNL.cmake
@@ -88,12 +88,6 @@ set(HPX_PARCELPORT_LIBFABRIC_WITH_LOGGING
     OFF
     CACHE BOOL "Libfabric parcelport logging on/off flag"
 )
-set(HPX_WITH_ZERO_COPY_SERIALIZATION_THRESHOLD
-    "4096"
-    CACHE
-      STRING
-      "The threshold in bytes to when perform zero copy optimizations (default: 128)"
-)
 
 # Set the TBBMALLOC_PLATFORM correctly so that find_package(TBBMalloc) sets the
 # right hints

--- a/cmake/toolchains/CrayKNLStatic.cmake
+++ b/cmake/toolchains/CrayKNLStatic.cmake
@@ -72,12 +72,6 @@ set(HPX_PARCELPORT_LIBFABRIC_WITH_LOGGING
     OFF
     CACHE BOOL "Libfabric parcelport logging on/off flag"
 )
-set(HPX_WITH_ZERO_COPY_SERIALIZATION_THRESHOLD
-    "4096"
-    CACHE
-      STRING
-      "The threshold in bytes to when perform zero copy optimizations (default: 128)"
-)
 
 # Set the TBBMALLOC_PLATFORM correctly so that find_package(TBBMalloc) sets the
 # right hints

--- a/cmake/toolchains/CrayStatic.cmake
+++ b/cmake/toolchains/CrayStatic.cmake
@@ -83,9 +83,3 @@ set(HPX_PARCELPORT_LIBFABRIC_WITH_LOGGING
     OFF
     CACHE BOOL "Libfabric parcelport logging on/off flag"
 )
-set(HPX_WITH_ZERO_COPY_SERIALIZATION_THRESHOLD
-    "4096"
-    CACHE
-      STRING
-      "The threshold in bytes to when perform zero copy optimizations (default: 128)"
-)

--- a/libs/core/mpi_base/include/hpx/mpi_base/mpi_environment.hpp
+++ b/libs/core/mpi_base/include/hpx/mpi_base/mpi_environment.hpp
@@ -86,6 +86,8 @@ namespace hpx::util {
 
         using mutex_type = hpx::spinlock;
 
+        static int MPI_MAX_TAG;
+
     private:
         static mutex_type mtx_;
 

--- a/libs/core/mpi_base/src/mpi_environment.cpp
+++ b/libs/core/mpi_base/src/mpi_environment.cpp
@@ -23,6 +23,8 @@
 ///////////////////////////////////////////////////////////////////////////////
 namespace hpx::util {
 
+    int mpi_environment::MPI_MAX_TAG = 32767;
+
     namespace detail {
 
         bool detect_mpi_environment(
@@ -267,6 +269,11 @@ namespace hpx::util {
 
         rtcfg.add_entry("hpx.parcel.mpi.rank", std::to_string(this_rank));
         rtcfg.add_entry("hpx.parcel.mpi.processorname", get_processor_name());
+        void* max_tag_p;
+        int flag;
+        MPI_Comm_get_attr(MPI_COMM_WORLD, MPI_TAG_UB, &max_tag_p, &flag);
+        if (flag)
+            MPI_MAX_TAG = *(int*) max_tag_p;
     }
 
     std::string mpi_environment::get_processor_name()

--- a/libs/full/parcelport_lci/include/hpx/parcelport_lci/header.hpp
+++ b/libs/full/parcelport_lci/include/hpx/parcelport_lci/header.hpp
@@ -108,14 +108,6 @@ namespace hpx::parcelset::policies::lci {
             data_ = header_buffer;
         }
 
-        void reset() noexcept
-        {
-            if (data_ != nullptr)
-            {
-                free(data_);
-            }
-        }
-
         bool valid() const noexcept
         {
             return data_ != nullptr && signature() == MAGIC_SIGNATURE;

--- a/libs/full/parcelport_mpi/include/hpx/parcelport_mpi/sender.hpp
+++ b/libs/full/parcelport_mpi/include/hpx/parcelport_mpi/sender.hpp
@@ -1,5 +1,6 @@
 //  Copyright (c) 2007-2021 Hartmut Kaiser
 //  Copyright (c) 2014-2015 Thomas Heller
+//  Copyright (c)      2023 Jiakun Yan
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -34,20 +35,7 @@ namespace hpx::parcelset::policies::mpi {
         using connection_ptr = std::shared_ptr<connection_type>;
         using connection_list = std::deque<connection_ptr>;
 
-        // different versions of clang-format disagree
-        // clang-format off
-        sender() noexcept
-          : next_free_tag_request_((MPI_Request) (-1))
-          , next_free_tag_(-1)
-        {
-        }
-        // clang-format on
-
-        void run() noexcept
-        {
-            util::mpi_environment::scoped_lock l;
-            get_next_free_tag(l);
-        }
+        void run() noexcept {}
 
         connection_ptr create_connection(int dest, parcelset::parcelport* pp)
         {
@@ -62,7 +50,7 @@ namespace hpx::parcelset::policies::mpi {
 
         int acquire_tag() noexcept
         {
-            return tag_provider_.acquire();
+            return tag_provider_.get_next_tag();
         }
 
         void send_messages(connection_ptr connection)
@@ -105,7 +93,6 @@ namespace hpx::parcelset::policies::mpi {
                 send_messages(HPX_MOVE(connection));
                 has_work = true;
             }
-            next_free_tag();
             return has_work;
         }
 
@@ -127,67 +114,8 @@ namespace hpx::parcelset::policies::mpi {
 
     private:
         tag_provider tag_provider_;
-
-        void next_free_tag() noexcept
-        {
-            int next_free = -1;
-            {
-                std::unique_lock l(next_free_tag_mtx_, std::try_to_lock);
-                if (l.owns_lock())
-                {
-                    next_free = next_free_tag_locked(l);
-                }
-            }
-
-            if (next_free != -1)
-            {
-                HPX_ASSERT(next_free > 1);
-                tag_provider_.release(next_free);
-            }
-        }
-
-        template <typename Lock>
-        int next_free_tag_locked([[maybe_unused]] Lock& lock) noexcept
-        {
-            HPX_ASSERT_OWNS_LOCK(lock);
-
-            util::mpi_environment::scoped_try_lock l;
-            if (l.locked)
-            {
-                int completed = 0;
-                [[maybe_unused]] int const ret = MPI_Test(
-                    &next_free_tag_request_, &completed, MPI_STATUS_IGNORE);
-                HPX_ASSERT(ret == MPI_SUCCESS);
-
-                if (completed)
-                {
-                    return get_next_free_tag(l);
-                }
-            }
-            return -1;
-        }
-
-        template <typename Lock>
-        int get_next_free_tag([[maybe_unused]] Lock& l) noexcept
-        {
-            HPX_ASSERT_OWNS_LOCK(l);
-
-            int const next_free = next_free_tag_;
-
-            [[maybe_unused]] int const ret = MPI_Irecv(&next_free_tag_, 1,
-                MPI_INT, MPI_ANY_SOURCE, 1,
-                util::mpi_environment::communicator(), &next_free_tag_request_);
-            HPX_ASSERT_LOCKED(l, ret == MPI_SUCCESS);
-
-            return next_free;
-        }
-
         hpx::spinlock connections_mtx_;
         connection_list connections_;
-
-        hpx::spinlock next_free_tag_mtx_;
-        MPI_Request next_free_tag_request_;
-        int next_free_tag_;
     };
 }    // namespace hpx::parcelset::policies::mpi
 

--- a/libs/full/parcelport_mpi/include/hpx/parcelport_mpi/sender_connection.hpp
+++ b/libs/full/parcelport_mpi/include/hpx/parcelport_mpi/sender_connection.hpp
@@ -1,5 +1,6 @@
 //  Copyright (c) 2007-2021 Hartmut Kaiser
 //  Copyright (c) 2014-2015 Thomas Heller
+//  Copyright (c)      2023 Jiakun Yan
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -103,7 +104,11 @@ namespace hpx::parcelset::policies::mpi {
             request_ptr_ = nullptr;
             chunks_idx_ = 0;
             tag_ = acquire_tag(sender_);
-            header_.init(buffer_, tag_);
+            header_buffer.resize(header::get_header_size(
+                buffer_, pp_->get_zero_copy_serialization_threshold()));
+            header_ = header(buffer_, static_cast<char*>(header_buffer.data()),
+                header_buffer.size());
+            header_.set_tag(tag_);
             header_.assert_valid();
 
             state_ = initialized;
@@ -156,8 +161,8 @@ namespace hpx::parcelset::policies::mpi {
                 HPX_ASSERT(state_ == initialized);
                 HPX_ASSERT(request_ptr_ == nullptr);
 
-                [[maybe_unused]] int const ret = MPI_Isend(header_.data(),
-                    header::data_size_, MPI_BYTE, dst_, 0,
+                [[maybe_unused]] int const ret = MPI_Isend(header_buffer.data(),
+                    (int) header_buffer.size(), MPI_BYTE, dst_, 0,
                     util::mpi_environment::communicator(), &request_);
                 HPX_ASSERT_LOCKED(l, ret == MPI_SUCCESS);
 
@@ -180,7 +185,7 @@ namespace hpx::parcelset::policies::mpi {
             HPX_ASSERT(request_ptr_ == nullptr);
 
             auto const& chunks = buffer_.transmission_chunks_;
-            if (!chunks.empty())
+            if (!chunks.empty() && !header_.piggy_back_tchunk())
             {
                 util::mpi_environment::scoped_lock l;
 
@@ -206,7 +211,7 @@ namespace hpx::parcelset::policies::mpi {
                 return false;
             }
 
-            if (!header_.piggy_back())
+            if (!header_.piggy_back_data())
             {
                 util::mpi_environment::scoped_lock l;
 
@@ -312,6 +317,7 @@ namespace hpx::parcelset::policies::mpi {
         handler_type handler_;
         post_handler_type postprocess_handler_;
 
+        std::vector<char> header_buffer;
         header header_;
 
         MPI_Request request_;


### PR DESCRIPTION
Improve the MPI parcelport:
- Replace the lock-based tag provider with an atomic variable
- Make the header message size dynamic

Since the maximum size of the dynamic header message is set to be the zero-copy serialization threshold, I also changed it from 128B to 8192B. (The message size that MPI switches from eager protocol to rendezvous protocol is usually around 8K - 64K).

Experiments: Octo-Tiger, max_level=6, SDSC Expanse, 32 nodes, 128 threads per node.
With `hpx.parcel.mpi.sendimm=0`, this PR improves the total execution time from 11.77s to 10.68s.
With `hpx.parcel.mpi.sendimm=1`, this PR improves the total execution time from ~60s to 11.72s.