### PR TITLE
add llvm/15, gcc/13 and boost/1.82 to jenkins

### DIFF
--- a/.jenkins/lsu/Jenkinsfile
+++ b/.jenkins/lsu/Jenkinsfile
@@ -36,7 +36,7 @@ pipeline {
                 axes {
                     axis {
                         name 'configuration_name'
-                        values 'gcc-9', 'gcc-10', 'gcc-11', 'gcc-12', 'clang-11', 'clang-12', 'clang-13', 'clang-14', 'gcc-10-cuda-11', 'gcc-12-cuda-12-dgx', 'hipcc'
+                        values 'gcc-10', 'gcc-11', 'gcc-12', 'gcc-13', 'clang-12', 'clang-13', 'clang-14', 'clang-15', 'gcc-10-cuda-11', 'gcc-12-cuda-12-dgx', 'hipcc'
                     }
                     axis {
                          name 'build_type'

--- a/.jenkins/lsu/env-clang-15.sh
+++ b/.jenkins/lsu/env-clang-15.sh
@@ -1,0 +1,36 @@
+# Copyright (c) 2020 ETH Zurich
+#
+# SPDX-License-Identifier: BSL-1.0
+# Distributed under the Boost Software License, Version 1.0. (See accompanying
+# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+module purge
+module load cmake
+module load llvm/15
+module load boost/1.82.0-${build_type,,}
+module load hwloc
+module load openmpi
+module load pwrapi/1.1.1
+
+export HPXRUN_RUNWRAPPER=srun
+export CXX_STD="20"
+
+configure_extra_options+=" -DCMAKE_BUILD_TYPE=${build_type}"
+configure_extra_options+=" -DHPX_WITH_CXX_STANDARD=${CXX_STD}"
+configure_extra_options+=" -DHPX_WITH_MALLOC=system"
+configure_extra_options+=" -DHPX_WITH_FETCH_ASIO=ON"
+configure_extra_options+=" -DHPX_WITH_COMPILER_WARNINGS=ON"
+configure_extra_options+=" -DHPX_WITH_COMPILER_WARNINGS_AS_ERRORS=ON"
+configure_extra_options+=" -DHPX_WITH_PARCELPORT_MPI=ON"
+configure_extra_options+=" -DHPX_WITH_PARCELPORT_LCI=ON"
+configure_extra_options+=" -DHPX_WITH_FETCH_LCI=ON"
+configure_extra_options+=" -DHPX_WITH_LOGGING=OFF"
+configure_extra_options+=" -DHPX_WITH_DATAPAR_BACKEND=EVE"
+configure_extra_options+=" -DHPX_WITH_FETCH_EVE=ON"
+
+# The pwrapi library still needs to be set up properly on rostam
+# configure_extra_options+=" -DHPX_WITH_POWER_COUNTER=ON"
+
+# Make sure HWLOC does not report 'cores'. This is purely an option to enable
+# testing the topology code under conditions close to those on FreeBSD.
+configure_extra_options+=" -DHPX_TOPOLOGY_WITH_ADDITIONAL_HWLOC_TESTING=ON"

--- a/.jenkins/lsu/env-gcc-13.sh
+++ b/.jenkins/lsu/env-gcc-13.sh
@@ -1,0 +1,31 @@
+# Copyright (c) 2020 ETH Zurich
+#
+# SPDX-License-Identifier: BSL-1.0
+# Distributed under the Boost Software License, Version 1.0. (See accompanying
+# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+module purge
+module load cmake
+module load gcc/13
+module load boost/1.82.0-${build_type,,}
+module load hwloc
+module load openmpi
+module load pwrapi/1.1.1
+
+export HPXRUN_RUNWRAPPER=srun
+export CXX_STD="20"
+
+configure_extra_options+=" -DHPX_WITH_CXX_STANDARD=${CXX_STD}"
+configure_extra_options+=" -DHPX_WITH_MALLOC=system"
+configure_extra_options+=" -DHPX_WITH_FETCH_ASIO=ON"
+configure_extra_options+=" -DHPX_WITH_COMPILER_WARNINGS=ON"
+configure_extra_options+=" -DHPX_WITH_COMPILER_WARNINGS_AS_ERRORS=ON"
+configure_extra_options+=" -DHPX_WITH_PARCELPORT_MPI=ON"
+configure_extra_options+=" -DHPX_WITH_PARCELPORT_LCI=ON"
+configure_extra_options+=" -DHPX_WITH_FETCH_LCI=ON"
+configure_extra_options+=" -DHPX_WITH_DATAPAR_BACKEND=EVE"
+configure_extra_options+=" -DHPX_WITH_FETCH_EVE=ON"
+configure_extra_options+=" -DHPX_WITH_EVE_TAG=main"
+
+# The pwrapi library still needs to be set up properly on rostam
+# configure_extra_options+=" -DHPX_WITH_POWER_COUNTER=ON"

--- a/.jenkins/lsu/slurm-configuration-clang-15.sh
+++ b/.jenkins/lsu/slurm-configuration-clang-15.sh
@@ -1,0 +1,8 @@
+# Copyright (c) 2020 ETH Zurich
+#
+# SPDX-License-Identifier: BSL-1.0
+# Distributed under the Boost Software License, Version 1.0. (See accompanying
+# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+configuration_slurm_partition="jenkins-compute"
+configuration_slurm_num_nodes="1"

--- a/.jenkins/lsu/slurm-configuration-gcc-13.sh
+++ b/.jenkins/lsu/slurm-configuration-gcc-13.sh
@@ -1,0 +1,8 @@
+# Copyright (c) 2020 ETH Zurich
+#
+# SPDX-License-Identifier: BSL-1.0
+# Distributed under the Boost Software License, Version 1.0. (See accompanying
+# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+configuration_slurm_partition="jenkins-compute"
+configuration_slurm_num_nodes="1"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1842,8 +1842,6 @@ if(HPX_WITH_COMPILER_WARNINGS)
 
   else() # Trial and error approach for any other compiler ...
     hpx_add_compile_flag_if_available(-Wall)
-    hpx_add_compile_flag_if_available(-Wextra)
-    hpx_add_compile_flag_if_available(-Wpedantic)
     hpx_add_compile_flag_if_available(-Wno-strict-aliasing)
     hpx_add_compile_flag_if_available(-Wno-sign-promo)
     hpx_add_compile_flag_if_available(-Wno-attributes)
@@ -1856,6 +1854,16 @@ if(HPX_WITH_COMPILER_WARNINGS)
         # caused by the use of std::destructive_interference_size
         hpx_add_compile_flag_if_available(-Wno-interference-size)
       endif()
+      if("${CMAKE_CXX_COMPILER_VERSION}" VERSION_GREATER_EQUAL "13.0")
+        # gcc V13.x is overeager to report dangling references where there are
+        # none
+        hpx_add_compile_flag_if_available(-Wextra)
+        hpx_add_compile_flag_if_available(-Wpedantic)
+        hpx_add_compile_flag_if_available(-Wno-self-move)
+      endif()
+    else()
+      hpx_add_compile_flag_if_available(-Wextra)
+      hpx_add_compile_flag_if_available(-Wpedantic)
     endif()
 
     # We do not in general guarantee ABI compatibility between C++ standards, so

--- a/cmake/HPX_AddConfigTest.cmake
+++ b/cmake/HPX_AddConfigTest.cmake
@@ -278,6 +278,15 @@ function(hpx_check_for_cxx11_std_atomic)
     unset(HPX_CXX11_STD_ATOMIC_LIBRARIES CACHE)
   endif()
 
+  # we shouldn't delete this key if the user has pre-set the atomic libraries to
+  # use
+  if(HPX_CXX11_STD_ATOMIC_LIBRARIES)
+    set(__std_atomic_libraries
+        TRUE
+        CACHE STRING "std::atomics need separate library" FORCE
+    )
+  endif()
+
   # first see if we can build atomics with no -latomics
   add_hpx_config_test(
     HPX_WITH_CXX11_ATOMIC
@@ -301,11 +310,17 @@ function(hpx_check_for_cxx11_std_atomic)
         LIBRARIES ${HPX_CXX11_STD_ATOMIC_LIBRARIES}
         FILE ${ARGN}
       )
-      if(NOT HPX_WITH_CXX11_ATOMIC)
-        unset(HPX_CXX11_STD_ATOMIC_LIBRARIES CACHE)
-        unset(HPX_WITH_CXX11_ATOMIC CACHE)
+      if(HPX_WITH_CXX11_ATOMIC)
+        set(__std_atomic_libraries
+            TRUE
+            CACHE STRING "std::atomics need separate library" FORCE
+        )
       endif()
     endif()
+  endif()
+
+  if(NOT HPX_WITH_CXX11_ATOMIC)
+    hpx_error("HPX needs support for C++11 std::atomic")
   endif()
 endfunction()
 
@@ -334,11 +349,15 @@ function(hpx_check_for_cxx11_std_atomic_128bit)
       )
       if(NOT HPX_WITH_CXX11_ATOMIC_128BIT)
         # Adding -latomic did not help, so we don't attempt to link to it later
-        unset(HPX_CXX11_STD_ATOMIC_LIBRARIES CACHE)
+        # but only if normal atomics don't require it
+        if(NOT __std_atomic_libraries)
+          unset(HPX_CXX11_STD_ATOMIC_LIBRARIES CACHE)
+        endif()
         unset(HPX_WITH_CXX11_ATOMIC_128BIT CACHE)
       endif()
     endif()
   endif()
+  unset(__std_atomic_libraries CACHE)
 endfunction()
 
 # ##############################################################################

--- a/cmake/HPX_PerformCxxFeatureTests.cmake
+++ b/cmake/HPX_PerformCxxFeatureTests.cmake
@@ -32,8 +32,7 @@ function(hpx_perform_cxx_feature_tests)
   endif()
 
   hpx_check_for_cxx11_std_atomic(
-    REQUIRED "HPX needs support for C++11 std::atomic"
-    ${atomics_additional_flags}
+    DEFINITIONS HPX_HAVE_CXX11_STD_ATOMIC ${atomics_additional_flags}
   )
 
   # Separately check for 128 bit atomics

--- a/cmake/tests/c11_aligned_alloc.cpp
+++ b/cmake/tests/c11_aligned_alloc.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2020 Hartmut Kaiser
+//  Copyright (c) 2020-2023 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -10,7 +10,7 @@
 
 int main()
 {
-    char* s = aligned_alloc(1024, 1024 * sizeof(char));
+    char* s = static_cast<char*>(aligned_alloc(1024, 1024 * sizeof(char)));
 
     free(s);
     return 0;

--- a/cmake/tests/cxx11_std_atomic.cpp
+++ b/cmake/tests/cxx11_std_atomic.cpp
@@ -18,6 +18,12 @@ void test_atomic()
     (void) i;
 }
 
+struct index_data
+{
+    std::uint16_t first;
+    std::uint16_t second;
+};
+
 int main()
 {
 // ATOMIC_FLAG_INIT is deprecated starting C++20
@@ -34,6 +40,7 @@ int main()
     test_atomic<std::uint16_t>();
     test_atomic<std::uint32_t>();
     test_atomic<std::uint64_t>();
+    test_atomic<index_data>();
 
     std::memory_order mo;
     mo = std::memory_order_relaxed;

--- a/cmake/tests/cxx17_std_aligned_alloc.cpp
+++ b/cmake/tests/cxx17_std_aligned_alloc.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2020 Hartmut Kaiser
+//  Copyright (c) 2020-2023 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -10,7 +10,7 @@
 
 int main()
 {
-    char* s = std::aligned_alloc(1024, 1024 * sizeof(char));
+    char* s = static_cast<char*>(std::aligned_alloc(1024, 1024 * sizeof(char)));
 
     std::free(s);
     return 0;

--- a/cmake/tests/cxx20_perfect_pack_capture.cpp
+++ b/cmake/tests/cxx20_perfect_pack_capture.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2021 Hartmut Kaiser
+//  Copyright (c) 2021-2023 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -10,7 +10,7 @@
 #include <utility>
 
 template <typename... Ts>
-void foo(Ts&&... ts)
+auto foo(Ts&&... ts)
 {
     return [... ts = std::forward<Ts>(ts)]() {};
 }

--- a/cmake/tests/cxx20_std_construct_at.cpp
+++ b/cmake/tests/cxx20_std_construct_at.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2022 Hartmut Kaiser
+//  Copyright (c) 2022-2023 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -17,7 +17,7 @@ int main()
 {
     unsigned char buffer[sizeof(A)];
 
-    A* ptr = hpx::construct_at(reinterpret_cast<A*>(buffer), 42);
+    A* ptr = std::construct_at(reinterpret_cast<A*>(buffer), 42);
     std::destroy_at(ptr);
 
     return 0;

--- a/libs/core/datastructures/tests/unit/bitset_test.hpp
+++ b/libs/core/datastructures/tests/unit/bitset_test.hpp
@@ -315,16 +315,9 @@ struct bitset_test
         Bitset c(rhs);
         b = std::move(c);
 
-#if defined(HPX_GCC_VERSION) && HPX_GCC_VERSION >= 130000
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Werror=self-move"
-#endif
-
+#if !defined(HPX_GCC_VERSION) || HPX_GCC_VERSION >= 130000
         // NOLINTNEXTLINE(clang-diagnostic-self-assign-overloaded)
         b = std::move(b);    // self assignment check
-
-#if defined(HPX_GCC_VERSION) && HPX_GCC_VERSION >= 130000
-#pragma GCC diagnostic pop
 #endif
 
         // NOLINTNEXTLINE(bugprone-use-after-move)

--- a/libs/core/datastructures/tests/unit/bitset_test.hpp
+++ b/libs/core/datastructures/tests/unit/bitset_test.hpp
@@ -315,8 +315,17 @@ struct bitset_test
         Bitset c(rhs);
         b = std::move(c);
 
+#if defined(HPX_GCC_VERSION) && HPX_GCC_VERSION >= 130000
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Werror=self-move"
+#endif
+
         // NOLINTNEXTLINE(clang-diagnostic-self-assign-overloaded)
         b = std::move(b);    // self assignment check
+
+#if defined(HPX_GCC_VERSION) && HPX_GCC_VERSION >= 130000
+#pragma GCC diagnostic pop
+#endif
 
         // NOLINTNEXTLINE(bugprone-use-after-move)
         HPX_TEST(b == rhs);

--- a/libs/core/executors/include/hpx/executors/guided_pool_executor.hpp
+++ b/libs/core/executors/include/hpx/executors/guided_pool_executor.hpp
@@ -196,9 +196,17 @@ namespace hpx::parallel::execution {
 #ifdef GUIDED_POOL_EXECUTOR_FAKE_NOOP
                 int domain = -1;
 #else
+#if defined(HPX_GCC_VERSION) && HPX_GCC_VERSION >= 130000
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Werror=dangling-reference"
+#endif
                 // get the argument for the numa hint function from the predecessor future
                 auto const& predecessor_value = detail::future_extract_value()(
                     HPX_FORWARD(Future, predecessor));
+
+#if defined(HPX_GCC_VERSION) && HPX_GCC_VERSION >= 130000
+#pragma GCC diagnostic pop
+#endif
                 int domain = numa_function_(predecessor_value, ts...);
 #endif
 
@@ -407,9 +415,17 @@ namespace hpx::parallel::execution {
             OuterFuture<hpx::tuple<InnerFutures...>>&& predecessor, Ts&&... ts)
         {
 #ifdef GUIDED_EXECUTOR_DEBUG
+#if defined(HPX_GCC_VERSION) && HPX_GCC_VERSION >= 130000
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Werror=dangling-reference"
+#endif
             // get the tuple of futures from the predecessor future <tuple of futures>
             auto const& predecessor_value =
                 detail::future_extract_value()(predecessor);
+
+#if defined(HPX_GCC_VERSION) && HPX_GCC_VERSION >= 130000
+#pragma GCC diagnostic pop
+#endif
 
             // create a tuple of the unwrapped future values
             auto unwrapped_futures_tuple = hpx::util::map_pack(

--- a/libs/core/executors/include/hpx/executors/guided_pool_executor.hpp
+++ b/libs/core/executors/include/hpx/executors/guided_pool_executor.hpp
@@ -196,18 +196,11 @@ namespace hpx::parallel::execution {
 #ifdef GUIDED_POOL_EXECUTOR_FAKE_NOOP
                 int domain = -1;
 #else
-#if defined(HPX_GCC_VERSION) && HPX_GCC_VERSION >= 130000
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Werror=dangling-reference"
-#endif
                 // get the argument for the numa hint function from the predecessor future
-                auto const& predecessor_value = detail::future_extract_value()(
-                    HPX_FORWARD(Future, predecessor));
-
-#if defined(HPX_GCC_VERSION) && HPX_GCC_VERSION >= 130000
-#pragma GCC diagnostic pop
-#endif
-                int domain = numa_function_(predecessor_value, ts...);
+                int domain =
+                    numa_function_(detail::future_extract_value()(
+                                       HPX_FORWARD(Future, predecessor)),
+                        ts...);
 #endif
 
                 gpx_deb.debug(debug::str<>("then_schedule"), "domain ", domain);
@@ -415,21 +408,10 @@ namespace hpx::parallel::execution {
             OuterFuture<hpx::tuple<InnerFutures...>>&& predecessor, Ts&&... ts)
         {
 #ifdef GUIDED_EXECUTOR_DEBUG
-#if defined(HPX_GCC_VERSION) && HPX_GCC_VERSION >= 130000
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Werror=dangling-reference"
-#endif
-            // get the tuple of futures from the predecessor future <tuple of futures>
-            auto const& predecessor_value =
-                detail::future_extract_value()(predecessor);
-
-#if defined(HPX_GCC_VERSION) && HPX_GCC_VERSION >= 130000
-#pragma GCC diagnostic pop
-#endif
-
             // create a tuple of the unwrapped future values
-            auto unwrapped_futures_tuple = hpx::util::map_pack(
-                detail::future_extract_value{}, predecessor_value);
+            auto unwrapped_futures_tuple =
+                hpx::util::map_pack(detail::future_extract_value{},
+                    detail::future_extract_value()(predecessor));
 
             using result_type = hpx::util::detail::invoke_deferred_result_t<F,
                 OuterFuture<hpx::tuple<InnerFutures...>>, Ts...>;

--- a/libs/core/functional/tests/regressions/protect_with_nullary_pfo.cpp
+++ b/libs/core/functional/tests/regressions/protect_with_nullary_pfo.cpp
@@ -54,11 +54,9 @@ int hpx_main()
     iterator_type itr_o = v2.begin();
     (void) itr_o;
 
-    std::size_t i = 0;
     for (std::size_t const& v : my_range)
     {
         hpx::async(hpx::util::protect(print_obj<std::size_t>()), v);
-        ++i;
     }
 
     return hpx::local::finalize();    // Handles HPX shutdown

--- a/libs/core/functional/tests/unit/bind_dm3_test.cpp
+++ b/libs/core/functional/tests/unit/bind_dm3_test.cpp
@@ -14,8 +14,8 @@
 #if defined(HPX_MSVC)
 #pragma warning(disable : 4786)    // identifier truncated in debug info
 #pragma warning(disable : 4710)    // function not inlined
-#pragma warning(                                                               \
-        disable : 4711)    // function selected for automatic inline expansion
+// function selected for automatic inline expansion
+#pragma warning(disable : 4711)
 #pragma warning(disable : 4514)    // unreferenced inline removed
 #endif
 
@@ -30,22 +30,16 @@ namespace placeholders = hpx::placeholders;
 
 int main()
 {
+    // gcc V13 over-eagerly reports a dangling reference here
+#if !defined(HPX_GCC_VERSION) || HPX_GCC_VERSION < 130000
     typedef std::pair<int, int> pair_type;
 
     pair_type pair(10, 20);
 
-#if defined(HPX_GCC_VERSION) && HPX_GCC_VERSION >= 130000
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Werror=dangling-reference"
-#endif
-
     int const& x = hpx::bind(&pair_type::first, placeholders::_1)(pair);
 
-#if defined(HPX_GCC_VERSION) && HPX_GCC_VERSION >= 130000
-#pragma GCC diagnostic pop
-#endif
-
     HPX_TEST_EQ(&pair.first, &x);
+#endif
 
     return hpx::util::report_errors();
 }

--- a/libs/core/functional/tests/unit/bind_dm3_test.cpp
+++ b/libs/core/functional/tests/unit/bind_dm3_test.cpp
@@ -15,7 +15,7 @@
 #pragma warning(disable : 4786)    // identifier truncated in debug info
 #pragma warning(disable : 4710)    // function not inlined
 #pragma warning(                                                               \
-    disable : 4711)    // function selected for automatic inline expansion
+        disable : 4711)    // function selected for automatic inline expansion
 #pragma warning(disable : 4514)    // unreferenced inline removed
 #endif
 
@@ -34,7 +34,16 @@ int main()
 
     pair_type pair(10, 20);
 
+#if defined(HPX_GCC_VERSION) && HPX_GCC_VERSION >= 130000
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Werror=dangling-reference"
+#endif
+
     int const& x = hpx::bind(&pair_type::first, placeholders::_1)(pair);
+
+#if defined(HPX_GCC_VERSION) && HPX_GCC_VERSION >= 130000
+#pragma GCC diagnostic pop
+#endif
 
     HPX_TEST_EQ(&pair.first, &x);
 

--- a/libs/core/pack_traversal/include/hpx/pack_traversal/detail/pack_traversal_async_impl.hpp
+++ b/libs/core/pack_traversal/include/hpx/pack_traversal/detail/pack_traversal_async_impl.hpp
@@ -531,7 +531,14 @@ namespace hpx::util::detail {
             {
                 for (/**/; !range.is_finished(); ++range)
                 {
+#if defined(HPX_GCC_VERSION) && HPX_GCC_VERSION >= 130000
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wstringop-overflow"
+#endif
                     async_traverse_one(range);
+#if defined(HPX_GCC_VERSION) && HPX_GCC_VERSION >= 130000
+#pragma GCC diagnostic pop
+#endif
                     if (is_detached())    // test before increment
                         break;
                 }

--- a/libs/core/pack_traversal/tests/unit/pack_traversal.cpp
+++ b/libs/core/pack_traversal/tests/unit/pack_traversal.cpp
@@ -483,12 +483,20 @@ static void test_strategic_traverse()
     {
         std::unique_ptr<int> ptr(new int(7));
 
+#if defined(HPX_GCC_VERSION) && HPX_GCC_VERSION >= 130000
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Werror=dangling-reference"
+#endif
         std::unique_ptr<int> const& ref = map_pack(
             [](std::unique_ptr<int> const& ref) -> std::unique_ptr<int> const& {
                 // ...
                 return ref;
             },
             ptr);
+
+#if defined(HPX_GCC_VERSION) && HPX_GCC_VERSION >= 130000
+#pragma GCC diagnostic pop
+#endif
 
         HPX_TEST_EQ(*ref, 7);
         *ptr = 0;
@@ -804,8 +812,8 @@ static void test_spread_tuple_like_traverse()
 
     // 1:0 mappings
     {
-        using Result = decltype(
-            map_pack(zero_mapper{}, make_tuple(make_tuple(1, 2), 1), 1));
+        using Result = decltype(map_pack(
+            zero_mapper{}, make_tuple(make_tuple(1, 2), 1), 1));
         static_assert(std::is_void<Result>::value, "Failed...");
     }
 

--- a/libs/core/pack_traversal/tests/unit/pack_traversal.cpp
+++ b/libs/core/pack_traversal/tests/unit/pack_traversal.cpp
@@ -478,15 +478,14 @@ static void test_strategic_traverse()
         HPX_TEST_EQ(res, 1);
     }
 
+    // gcc V13 over-eagerly reports a dangling reference here
+#if !defined(HPX_GCC_VERSION) || HPX_GCC_VERSION < 130000
+
     // Make it possible to pass move only objects in as reference,
     // while returning those as reference.
     {
         std::unique_ptr<int> ptr(new int(7));
 
-#if defined(HPX_GCC_VERSION) && HPX_GCC_VERSION >= 130000
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Werror=dangling-reference"
-#endif
         std::unique_ptr<int> const& ref = map_pack(
             [](std::unique_ptr<int> const& ref) -> std::unique_ptr<int> const& {
                 // ...
@@ -494,14 +493,11 @@ static void test_strategic_traverse()
             },
             ptr);
 
-#if defined(HPX_GCC_VERSION) && HPX_GCC_VERSION >= 130000
-#pragma GCC diagnostic pop
-#endif
-
         HPX_TEST_EQ(*ref, 7);
         *ptr = 0;
         HPX_TEST_EQ(*ref, 0);
     }
+#endif
 
     // Multiple args: Make it possible to pass move only objects in
     // as reference, while returning those as reference.
@@ -812,8 +808,10 @@ static void test_spread_tuple_like_traverse()
 
     // 1:0 mappings
     {
+        // clang-format off
         using Result = decltype(map_pack(
             zero_mapper{}, make_tuple(make_tuple(1, 2), 1), 1));
+        // clang-format on
         static_assert(std::is_void<Result>::value, "Failed...");
     }
 

--- a/libs/core/resource_partitioner/examples/async_customization.cpp
+++ b/libs/core/resource_partitioner/examples/async_customization.cpp
@@ -152,21 +152,9 @@ private:
         using result_type = util::detail::invoke_deferred_result_t<F,
             OuterFuture<hpx::tuple<InnerFutures...>>, Ts...>;
 
-#if defined(HPX_GCC_VERSION) && HPX_GCC_VERSION >= 130000
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Werror=dangling-reference"
-#endif
-        // get the tuple of futures from the predecessor future <tuple of futures>
-        const auto& predecessor_value =
-            future_extract_value().operator()(predecessor);
-
-#if defined(HPX_GCC_VERSION) && HPX_GCC_VERSION >= 130000
-#pragma GCC diagnostic pop
-#endif
-
         // create a tuple of the unwrapped future values
-        auto unwrapped_futures_tuple =
-            util::map_pack(future_extract_value{}, predecessor_value);
+        auto unwrapped_futures_tuple = util::map_pack(future_extract_value{},
+            future_extract_value().operator()(predecessor));
 
         using namespace hpx::util::debug;
         std::cout << "when_all(fut) : Predecessor : "

--- a/libs/core/resource_partitioner/examples/async_customization.cpp
+++ b/libs/core/resource_partitioner/examples/async_customization.cpp
@@ -152,9 +152,17 @@ private:
         using result_type = util::detail::invoke_deferred_result_t<F,
             OuterFuture<hpx::tuple<InnerFutures...>>, Ts...>;
 
+#if defined(HPX_GCC_VERSION) && HPX_GCC_VERSION >= 130000
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Werror=dangling-reference"
+#endif
         // get the tuple of futures from the predecessor future <tuple of futures>
         const auto& predecessor_value =
             future_extract_value().operator()(predecessor);
+
+#if defined(HPX_GCC_VERSION) && HPX_GCC_VERSION >= 130000
+#pragma GCC diagnostic pop
+#endif
 
         // create a tuple of the unwrapped future values
         auto unwrapped_futures_tuple =

--- a/libs/core/synchronization/tests/unit/local_mutex.cpp
+++ b/libs/core/synchronization/tests/unit/local_mutex.cpp
@@ -124,7 +124,8 @@ struct test_lock_times_out_if_other_thread_has_lock
     void locking_thread()
     {
         Lock lock(m, std::defer_lock);
-        lock.try_lock_for(std::chrono::milliseconds(50));
+        [[maybe_unused]] bool retval =
+            lock.try_lock_for(std::chrono::milliseconds(50));
 
         std::lock_guard<hpx::mutex> lk(done_mutex);
         locked = lock.owns_lock();

--- a/libs/core/threading/tests/unit/jthread1.cpp
+++ b/libs/core/threading/tests/unit/jthread1.cpp
@@ -46,7 +46,7 @@ void test_jthread_without_token()
         });
 
         // wait until t has set all initial values
-        for (int i = 0; !all_set.load(); ++i)
+        for ([[maybe_unused]] int i = 0; !all_set.load(); ++i)
         {
             hpx::this_thread::sleep_for(std::chrono::milliseconds(10));
         }
@@ -80,7 +80,8 @@ void test_jthread_with_token()
                 all_set.store(true);
 
                 // wait until interrupt is signaled
-                for (int i = 0; !stoptoken.stop_requested(); ++i)
+                for ([[maybe_unused]] int i = 0; !stoptoken.stop_requested();
+                     ++i)
                 {
                     hpx::this_thread::sleep_for(std::chrono::milliseconds(100));
                 }
@@ -90,7 +91,7 @@ void test_jthread_with_token()
             ssource.get_token());
 
         // wait until t has set all initial values
-        for (int i = 0; !all_set.load(); ++i)
+        for ([[maybe_unused]] int i = 0; !all_set.load(); ++i)
         {
             hpx::this_thread::sleep_for(std::chrono::milliseconds(10));
         }
@@ -133,7 +134,7 @@ void test_join()
         hpx::jthread t([](hpx::stop_token stoken) {
             // wait until interrupt is signaled (due to calling request_stop()
             // for the token)
-            for (int i = 0; !stoken.stop_requested(); ++i)
+            for ([[maybe_unused]] int i = 0; !stoken.stop_requested(); ++i)
             {
                 hpx::this_thread::sleep_for(std::chrono::milliseconds(100));
             }
@@ -186,7 +187,7 @@ void test_detach()
 
             // wait until interrupt is signaled (due to calling request_stop()
             // for the token)
-            for (int i = 0; !stoken.stop_requested(); ++i)
+            for ([[maybe_unused]] int i = 0; !stoken.stop_requested(); ++i)
             {
                 hpx::this_thread::sleep_for(std::chrono::milliseconds(100));
             }
@@ -195,7 +196,7 @@ void test_detach()
         });
 
         // wait until t has set all initial values
-        for (int i = 0; !all_set.load(); ++i)
+        for ([[maybe_unused]] int i = 0; !all_set.load(); ++i)
         {
             hpx::this_thread::sleep_for(std::chrono::milliseconds(10));
         }
@@ -246,7 +247,7 @@ void test_hpx_thread()
         bool caught_exception = false;
         try
         {
-            for (int i = 0;; ++i)
+            for ([[maybe_unused]] int i = 0;; ++i)
             {
                 if (shall_die.stop_requested())
                 {
@@ -274,7 +275,7 @@ void test_hpx_thread()
     });
 
     // wait until t has set all initial values
-    for (int i = 0; !all_set.load(); ++i)
+    for ([[maybe_unused]] int i = 0; !all_set.load(); ++i)
     {
         hpx::this_thread::sleep_for(std::chrono::milliseconds(10));
     }
@@ -424,14 +425,14 @@ void test_jthread_api()
                 all_set.store(true);
 
                 // wait until interrupt is signaled (due to destructor of t)
-                for (int i = 0; !stoken.stop_requested(); ++i)
+                for ([[maybe_unused]] int i = 0; !stoken.stop_requested(); ++i)
                 {
                     hpx::this_thread::sleep_for(std::chrono::milliseconds(100));
                 }
             });
 
         // wait until t has set all initial values
-        for (int i = 0; !all_set.load(); ++i)
+        for ([[maybe_unused]] int i = 0; !all_set.load(); ++i)
         {
             hpx::this_thread::sleep_for(std::chrono::milliseconds(10));
         }

--- a/libs/core/threading/tests/unit/jthread2.cpp
+++ b/libs/core/threading/tests/unit/jthread2.cpp
@@ -212,7 +212,7 @@ void test_concurrent_interrupt()
             try
             {
                 bool stop_requested = false;
-                for (int i = 0; !it.stop_requested(); ++i)
+                for ([[maybe_unused]] int i = 0; !it.stop_requested(); ++i)
                 {
                     // should never switch back once requested
                     if (stoken.stop_requested())

--- a/libs/core/threadmanager/src/threadmanager.cpp
+++ b/libs/core/threadmanager/src/threadmanager.cpp
@@ -233,9 +233,10 @@ namespace hpx { namespace threads {
     }
 
     void threadmanager::create_scheduler_local_priority_lifo(
-        thread_pool_init_parameters const& thread_pool_init,
-        policies::thread_queue_init_parameters const& thread_queue_init,
-        std::size_t numa_sensitive)
+        [[maybe_unused]] thread_pool_init_parameters const& thread_pool_init,
+        [[maybe_unused]] policies::thread_queue_init_parameters const&
+            thread_queue_init,
+        [[maybe_unused]] std::size_t numa_sensitive)
     {
 #if defined(HPX_HAVE_CXX11_STD_ATOMIC_128BIT)
         // set parameters for scheduler and pool instantiation and perform
@@ -374,9 +375,10 @@ namespace hpx { namespace threads {
     }
 
     void threadmanager::create_scheduler_abp_priority_fifo(
-        thread_pool_init_parameters const& thread_pool_init,
-        policies::thread_queue_init_parameters const& thread_queue_init,
-        std::size_t numa_sensitive)
+        [[maybe_unused]] thread_pool_init_parameters const& thread_pool_init,
+        [[maybe_unused]] policies::thread_queue_init_parameters const&
+            thread_queue_init,
+        [[maybe_unused]] std::size_t numa_sensitive)
     {
 #if defined(HPX_HAVE_CXX11_STD_ATOMIC_128BIT)
         // set parameters for scheduler and pool instantiation and perform
@@ -422,9 +424,10 @@ namespace hpx { namespace threads {
     }
 
     void threadmanager::create_scheduler_abp_priority_lifo(
-        thread_pool_init_parameters const& thread_pool_init,
-        policies::thread_queue_init_parameters const& thread_queue_init,
-        std::size_t numa_sensitive)
+        [[maybe_unused]] thread_pool_init_parameters const& thread_pool_init,
+        [[maybe_unused]] policies::thread_queue_init_parameters const&
+            thread_queue_init,
+        [[maybe_unused]] std::size_t numa_sensitive)
     {
 #if defined(HPX_HAVE_CXX11_STD_ATOMIC_128BIT)
         // set parameters for scheduler and pool instantiation and perform

--- a/libs/core/type_support/include/hpx/type_support/generator.hpp
+++ b/libs/core/type_support/include/hpx/type_support/generator.hpp
@@ -636,16 +636,26 @@ namespace hpx {
                 ++*this;
             }
 
-            [[nodiscard]] bool operator==(
-                hpx::default_sentinel_t) const noexcept
+            [[nodiscard]] friend bool operator==(
+                gen_iter lhs, hpx::default_sentinel_t) noexcept
             {
-                return coro.done();
+                return lhs.coro.done();
+            }
+            [[nodiscard]] friend bool operator!=(
+                gen_iter lhs, hpx::default_sentinel_t rhs) noexcept
+            {
+                return !(lhs == rhs);
             }
 
-            [[nodiscard]] bool operator!=(
-                hpx::default_sentinel_t) const noexcept
+            [[nodiscard]] friend bool operator==(
+                hpx::default_sentinel_t, gen_iter rhs) noexcept
             {
-                return !coro.done();
+                return rhs.coro.done();
+            }
+            [[nodiscard]] friend bool operator!=(
+                hpx::default_sentinel_t lhs, gen_iter rhs) noexcept
+            {
+                return !(lhs == rhs);
             }
 
         private:

--- a/libs/core/type_support/tests/unit/generator.cpp
+++ b/libs/core/type_support/tests/unit/generator.cpp
@@ -116,8 +116,9 @@ namespace tests {
 
     hpx::generator<X const&> const_lvalue_example()
     {
-        co_yield X{1};            // OK
+        co_yield X{1};    // OK
         X const x{2};
+
         co_yield x;               // OK
         co_yield std::move(x);    // OK: same as above
     }

--- a/libs/core/type_support/tests/unit/generator.cpp
+++ b/libs/core/type_support/tests/unit/generator.cpp
@@ -202,7 +202,7 @@ namespace tests {
     };
 
     // gcc V11/V12 are complaining about mismatched-new-delete
-#if !defined(HPX_GCC_VERSION) || HPX_GCC_VERSION >= 130000
+#if !defined(HPX_GCC_VERSION) || HPX_GCC_VERSION >= 140000
     hpx::generator<int, void, std::allocator<std::byte>> stateless_example()
     {
         co_yield 42;
@@ -313,7 +313,7 @@ int main()
     }
 
     // gcc V11/V12 are complaining about mismatched-new-delete
-#if !defined(HPX_GCC_VERSION) || HPX_GCC_VERSION >= 130000
+#if !defined(HPX_GCC_VERSION) || HPX_GCC_VERSION >= 140000
     {
         std::vector const expected = {42};
         std::size_t i = 0;

--- a/libs/core/type_support/tests/unit/generator.cpp
+++ b/libs/core/type_support/tests/unit/generator.cpp
@@ -40,7 +40,9 @@ namespace tests {
     {
         while (i != j)
         {
-            co_yield i++;
+            // gcc reports -Werrer,-Wunsequenced without retval
+            int retval = i++;
+            co_yield retval;
         }
     }
 
@@ -114,7 +116,7 @@ namespace tests {
 
     hpx::generator<X const&> const_lvalue_example()
     {
-        co_yield X{1};    // OK
+        co_yield X{1};            // OK
         X const x{2};
         co_yield x;               // OK
         co_yield std::move(x);    // OK: same as above

--- a/libs/full/agas/tests/regressions/duplicate_id_registration_1596.cpp
+++ b/libs/full/agas/tests/regressions/duplicate_id_registration_1596.cpp
@@ -76,7 +76,7 @@ namespace tests { namespace client {
             base_type;
 
         ViewRegistrationListener(hpx::future<hpx::id_type> gid)
-          : base_type(move(gid))
+          : base_type(std::move(gid))
         {
             cout << "constructed listener client by future" << endl;
         }

--- a/libs/full/async_distributed/include/hpx/async_distributed/base_lco.hpp
+++ b/libs/full/async_distributed/include/hpx/async_distributed/base_lco.hpp
@@ -52,10 +52,6 @@ namespace hpx::lcos {
         /// derived objects
         virtual ~base_lco();
 
-        /// \brief finalize() will be called just before the instance gets
-        ///        destructed
-        virtual void finalize();
-
         /// The \a function set_event_nonvirt is called whenever a
         /// \a set_event_action is applied on a instance of a LCO. This function
         /// just forwards to the virtual function \a set_event, which is

--- a/libs/full/async_distributed/src/base_lco.cpp
+++ b/libs/full/async_distributed/src/base_lco.cpp
@@ -39,8 +39,6 @@ namespace hpx { namespace lcos {
 
     base_lco::~base_lco() = default;
 
-    void base_lco::finalize() {}
-
     void base_lco::set_event_nonvirt()
     {
         set_event();

--- a/libs/full/parcelport_lci/src/putva/sender_connection_putva.cpp
+++ b/libs/full/parcelport_lci/src/putva/sender_connection_putva.cpp
@@ -53,9 +53,8 @@ namespace hpx::parcelset::policies::lci {
         HPX_ASSERT(!handler_);
         HPX_ASSERT(!postprocess_handler_);
         HPX_ASSERT(!buffer_.data_.empty());
-        handler_ = HPX_FORWARD(Handler, handler);
-        postprocess_handler_ =
-            HPX_FORWARD(ParcelPostprocess, parcel_postprocess);
+        handler_ = HPX_MOVE(handler);
+        postprocess_handler_ = HPX_MOVE(parcel_postprocess);
 
         // build header
         header header_;

--- a/libs/full/parcelport_lci/src/sendrecv/sender_connection_sendrecv.cpp
+++ b/libs/full/parcelport_lci/src/sendrecv/sender_connection_sendrecv.cpp
@@ -40,9 +40,8 @@ namespace hpx::parcelset::policies::lci {
         HPX_ASSERT(!handler_);
         HPX_ASSERT(!postprocess_handler_);
         HPX_ASSERT(!buffer_.data_.empty());
-        handler_ = HPX_FORWARD(Handler, handler);
-        postprocess_handler_ =
-            HPX_FORWARD(ParcelPostprocess, parcel_postprocess);
+        handler_ = HPX_MOVE(handler);
+        postprocess_handler_ = HPX_MOVE(parcel_postprocess);
 
         // build header
         while (LCI_mbuffer_alloc(pp_->device_eager, &header_buffer) != LCI_OK)


### PR DESCRIPTION


## Proposed Changes

  - Remove gcc/9 and clang/11 from jenkins builders
  -  Add gcc/12 and clang/15 to the builders
  - Add boost 1.82

