### PR TITLE
Re-expose error names

### DIFF
--- a/libs/core/errors/include/hpx/errors/error.hpp
+++ b/libs/core/errors/include/hpx/errors/error.hpp
@@ -328,6 +328,9 @@ namespace hpx {
 
 #undef HPX_ERROR_UNSCOPED_ENUM_DEPRECATION_MSG
 
+    // Return a textual representation of a given error code
+    HPX_CORE_EXPORT char const* get_error_name(error e) noexcept;
+
 }    // namespace hpx
 
 /// \cond NOEXTERNAL

--- a/libs/core/errors/src/error_code.cpp
+++ b/libs/core/errors/src/error_code.cpp
@@ -79,6 +79,20 @@ namespace hpx {
         /*    */ ""};
     /// \endcond
 
+    // Return a textual representation of a given error code
+    char const* get_error_name(error value) noexcept
+    {
+        if (value >= hpx::error::success && value < hpx::error::last_error)
+        {
+            return error_names[static_cast<int>(value)];
+        }
+        if (value & hpx::error::system_error_flag)
+        {
+            return "system_error";
+        }
+        return "unknown";
+    }
+
     namespace detail {
 
         class hpx_category : public std::error_category
@@ -99,7 +113,7 @@ namespace hpx {
                 }
                 if (value & hpx::error::system_error_flag)
                 {
-                    return std::string("HPX(system_error)");
+                    return "HPX(system_error)";
                 }
                 return "HPX(unknown_error)";
             }


### PR DESCRIPTION
In one of the recent HPX versions, the previously publicly available string representations of the HPX error code were removed from the public API. This PR introduces an API that allows to query the error names.