### PR TITLE
Add internal reference counting to semaphores

### DIFF
--- a/libs/core/synchronization/include/hpx/synchronization/detail/counting_semaphore.hpp
+++ b/libs/core/synchronization/include/hpx/synchronization/detail/counting_semaphore.hpp
@@ -59,7 +59,7 @@ namespace hpx::lcos::local::detail {
     template <typename Mutex>
     struct counting_semaphore_data
     {
-        counting_semaphore_data(std::ptrdiff_t value) noexcept
+        explicit counting_semaphore_data(std::ptrdiff_t value) noexcept
           : sem_(value)
           , count_(1)
         {

--- a/libs/core/synchronization/include/hpx/synchronization/detail/counting_semaphore.hpp
+++ b/libs/core/synchronization/include/hpx/synchronization/detail/counting_semaphore.hpp
@@ -55,6 +55,37 @@ namespace hpx::lcos::local::detail {
         std::ptrdiff_t value_;
         local::detail::condition_variable cond_;
     };
+
+    template <typename Mutex>
+    struct counting_semaphore_data
+    {
+        counting_semaphore_data(std::ptrdiff_t value) noexcept
+          : sem_(value)
+          , count_(1)
+        {
+        }
+
+        mutable Mutex mtx_;
+        detail::counting_semaphore sem_;
+
+    private:
+        friend void intrusive_ptr_add_ref(
+            counting_semaphore_data<Mutex>* p) noexcept
+        {
+            ++p->count_;
+        }
+
+        friend void intrusive_ptr_release(
+            counting_semaphore_data<Mutex>* p) noexcept
+        {
+            if (0 == --p->count_)
+            {
+                delete p;
+            }
+        }
+
+        hpx::util::atomic_count count_;
+    };
 }    // namespace hpx::lcos::local::detail
 
 #if defined(HPX_MSVC_WARNING_PRAGMA)

--- a/libs/core/synchronization/include/hpx/synchronization/sliding_semaphore.hpp
+++ b/libs/core/synchronization/include/hpx/synchronization/sliding_semaphore.hpp
@@ -78,7 +78,7 @@ namespace hpx {
         void set_max_difference(
             std::int64_t max_difference, std::int64_t lower_limit = 0) noexcept
         {
-            auto data = data_; //keep alive
+            auto data = data_;    //keep alive
             std::unique_lock<mutex_type> l(data->mtx_);
             data->sem_.set_max_difference(l, max_difference, lower_limit);
         }


### PR DESCRIPTION
Use intrusive_ptr to implement internal reference counting for semaphores.