### PR TITLE
omp for default vectorization

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -465,6 +465,22 @@ elseif(HPX_WITH_PARALLEL_LINK_JOBS)
   hpx_warn("Job pooling is only available with Ninja generators.")
 endif()
 
+hpx_option(
+  HPX_HAVE_SIMD_BACKEND
+  STRING
+  "Simd Backend to use for vectorization. Defaults to OMP, other possible options are NONE (compiler assisted vectorization)"
+  "OMP"
+  CATEGORY "Build Targets"
+)
+
+if(NOT HPX_HAVE_SIMD_BACKEND)
+  set(HPX_HAVE_SIMD_BACKEND "OMP")
+endif()
+
+if(HPX_HAVE_SIMD_BACKEND STREQUAL "OMP")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fopenmp-simd")
+endif()
+
 # disable all tests if HPX_WITH_TESTS=OFF
 if(NOT HPX_WITH_TESTS)
   hpx_set_option(

--- a/libs/core/algorithms/include/hpx/parallel/unseq/loop.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/unseq/loop.hpp
@@ -30,7 +30,7 @@ namespace hpx::parallel::util {
                 InIter HPX_RESTRICT it, std::size_t num, F&& f)
             {
                 // clang-format off
-                HPX_IVDEP HPX_UNROLL HPX_VECTORIZE
+                HPX_VECTORIZE
                 for (std::size_t i = 0; i != num; ++i)
                 {
                     HPX_INVOKE(f, it);
@@ -61,7 +61,7 @@ namespace hpx::parallel::util {
                 InIter HPX_RESTRICT it, std::size_t num, F&& f)
             {
                 // clang-format off
-                HPX_IVDEP HPX_UNROLL HPX_VECTORIZE
+                HPX_VECTORIZE
                 for (std::size_t i = 0; i != num; ++i)
                 {
                     HPX_INVOKE(f, *it);
@@ -149,7 +149,7 @@ namespace hpx::parallel::util {
                     std::size_t const num = std::distance(it1, last1);
 
                     // clang-format off
-                    HPX_IVDEP HPX_UNROLL HPX_VECTORIZE
+                    HPX_VECTORIZE
                     for (std::size_t i = 0; i != num; ++i)
                     {
                         HPX_INVOKE(f, it1, it2);
@@ -177,7 +177,7 @@ namespace hpx::parallel::util {
                 F&& f)
             {
                 // clang-format off
-                HPX_IVDEP HPX_UNROLL HPX_VECTORIZE
+                HPX_VECTORIZE
                 for (std::size_t i = 0; i != num; ++i)
                 {
                     HPX_INVOKE(f, *it, base_idx);

--- a/libs/core/algorithms/include/hpx/parallel/unseq/loop.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/unseq/loop.hpp
@@ -135,10 +135,9 @@ namespace hpx::parallel::util {
         struct unseq_loop2
         {
             template <typename InIter1, typename InIter2, typename F>
-            HPX_HOST_DEVICE
-                HPX_FORCEINLINE static constexpr std::pair<InIter1, InIter2>
-                call(InIter1 HPX_RESTRICT it1, InIter1 HPX_RESTRICT last1,
-                    InIter2 HPX_RESTRICT it2, F&& f)
+            HPX_HOST_DEVICE HPX_FORCEINLINE static std::pair<InIter1, InIter2>
+            call(InIter1 HPX_RESTRICT it1, InIter1 HPX_RESTRICT last1,
+                InIter2 HPX_RESTRICT it2, F&& f)
             {
                 constexpr bool iterators_are_random_access =
                     hpx::traits::is_random_access_iterator_v<InIter1> &&

--- a/libs/core/algorithms/include/hpx/parallel/unseq/loop.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/unseq/loop.hpp
@@ -31,7 +31,7 @@ namespace hpx::parallel::util {
             {
                 // clang-format off
                 HPX_VECTORIZE
-                for (std::size_t i = 0; i != num; ++i)
+                for (std::size_t i = 0; i < num; ++i)
                 {
                     HPX_INVOKE(f, it);
                     ++it;
@@ -62,7 +62,7 @@ namespace hpx::parallel::util {
             {
                 // clang-format off
                 HPX_VECTORIZE
-                for (std::size_t i = 0; i != num; ++i)
+                for (std::size_t i = 0; i < num; ++i)
                 {
                     HPX_INVOKE(f, *it);
                     ++it;
@@ -149,7 +149,7 @@ namespace hpx::parallel::util {
 
                     // clang-format off
                     HPX_VECTORIZE
-                    for (std::size_t i = 0; i != num; ++i)
+                    for (std::size_t i = 0; i < num; ++i)
                     {
                         HPX_INVOKE(f, it1, it2);
                         ++it1, ++it2;
@@ -177,7 +177,7 @@ namespace hpx::parallel::util {
             {
                 // clang-format off
                 HPX_VECTORIZE
-                for (std::size_t i = 0; i != num; ++i)
+                for (std::size_t i = 0; i < num; ++i)
                 {
                     HPX_INVOKE(f, *it, base_idx);
                     ++it, ++base_idx;

--- a/libs/core/algorithms/include/hpx/parallel/unseq/loop.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/unseq/loop.hpp
@@ -26,7 +26,7 @@ namespace hpx::parallel::util {
         struct unseq_loop_n
         {
             template <typename InIter, typename F>
-            HPX_HOST_DEVICE HPX_FORCEINLINE static constexpr InIter call(
+            HPX_HOST_DEVICE HPX_FORCEINLINE static InIter call(
                 InIter HPX_RESTRICT it, std::size_t num, F&& f)
             {
                 // clang-format off
@@ -77,7 +77,7 @@ namespace hpx::parallel::util {
         struct unseq_loop
         {
             template <typename Begin, typename End, typename F>
-            HPX_HOST_DEVICE HPX_FORCEINLINE static constexpr Begin call(
+            HPX_HOST_DEVICE HPX_FORCEINLINE static Begin call(
                 Begin HPX_RESTRICT it, End HPX_RESTRICT end, F&& f)
             {
                 if constexpr (hpx::traits::is_random_access_iterator_v<Begin>)
@@ -112,7 +112,7 @@ namespace hpx::parallel::util {
         struct unseq_loop_ind
         {
             template <typename Begin, typename End, typename F>
-            HPX_HOST_DEVICE HPX_FORCEINLINE static constexpr Begin call(
+            HPX_HOST_DEVICE HPX_FORCEINLINE static Begin call(
                 Begin HPX_RESTRICT it, End HPX_RESTRICT end, F&& f)
             {
                 if constexpr (hpx::traits::is_random_access_iterator_v<Begin>)

--- a/libs/core/algorithms/include/hpx/parallel/unseq/reduce_helpers.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/unseq/reduce_helpers.hpp
@@ -85,7 +85,7 @@ namespace hpx::parallel::util::detail {
     {
 #if defined(HPX_HAVE_VECTOR_REDUCTION)
         template <typename Iter1, typename T, typename Convert, typename Reduce>
-        HPX_HOST_DEVICE HPX_FORCEINLINE static constexpr std::enable_if_t<
+        HPX_HOST_DEVICE HPX_FORCEINLINE static std::enable_if_t<
             is_arithmetic_plus_reduction_v<T, Reduce>, T>
         reduce(Iter1 it, std::size_t count, T init, Reduce /* */, Convert conv)
         {
@@ -99,7 +99,7 @@ namespace hpx::parallel::util::detail {
         }
 
         template <typename Iter1, typename T, typename Convert, typename Reduce>
-        HPX_HOST_DEVICE HPX_FORCEINLINE static constexpr std::enable_if_t<
+        HPX_HOST_DEVICE HPX_FORCEINLINE static std::enable_if_t<
             is_arithmetic_minus_reduction_v<T, Reduce>, T>
         reduce(Iter1 it, std::size_t count, T init, Reduce /* */, Convert conv)
         {
@@ -113,7 +113,7 @@ namespace hpx::parallel::util::detail {
         }
 
         template <typename Iter1, typename T, typename Convert, typename Reduce>
-        HPX_HOST_DEVICE HPX_FORCEINLINE static constexpr std::enable_if_t<
+        HPX_HOST_DEVICE HPX_FORCEINLINE static std::enable_if_t<
             is_arithmetic_multiplies_reduction_v<T, Reduce>, T>
         reduce(Iter1 it, std::size_t count, T init, Reduce /* */, Convert conv)
         {
@@ -127,7 +127,7 @@ namespace hpx::parallel::util::detail {
         }
 
         template <typename Iter1, typename T, typename Convert, typename Reduce>
-        HPX_HOST_DEVICE HPX_FORCEINLINE static constexpr std::enable_if_t<
+        HPX_HOST_DEVICE HPX_FORCEINLINE static std::enable_if_t<
             is_arithmetic_bit_and_reduction_v<T, Reduce>, T>
         reduce(Iter1 it, std::size_t count, T init, Reduce /* */, Convert conv)
         {
@@ -141,7 +141,7 @@ namespace hpx::parallel::util::detail {
         }
 
         template <typename Iter1, typename T, typename Convert, typename Reduce>
-        HPX_HOST_DEVICE HPX_FORCEINLINE static constexpr std::enable_if_t<
+        HPX_HOST_DEVICE HPX_FORCEINLINE static std::enable_if_t<
             is_arithmetic_bit_or_reduction_v<T, Reduce>, T>
         reduce(Iter1 it, std::size_t count, T init, Reduce /* */, Convert conv)
         {
@@ -155,7 +155,7 @@ namespace hpx::parallel::util::detail {
         }
 
         template <typename Iter1, typename T, typename Convert, typename Reduce>
-        HPX_HOST_DEVICE HPX_FORCEINLINE static constexpr std::enable_if_t<
+        HPX_HOST_DEVICE HPX_FORCEINLINE static std::enable_if_t<
             is_arithmetic_bit_xor_reduction_v<T, Reduce>, T>
         reduce(Iter1 it, std::size_t count, T init, Reduce /* */, Convert conv)
         {
@@ -169,7 +169,7 @@ namespace hpx::parallel::util::detail {
         }
 
         template <typename Iter1, typename T, typename Convert, typename Reduce>
-        HPX_HOST_DEVICE HPX_FORCEINLINE static constexpr std::enable_if_t<
+        HPX_HOST_DEVICE HPX_FORCEINLINE static std::enable_if_t<
             is_arithmetic_logical_and_reduction_v<T, Reduce>, T>
         reduce(Iter1 it, std::size_t count, T init, Reduce /* */, Convert conv)
         {
@@ -183,7 +183,7 @@ namespace hpx::parallel::util::detail {
         }
 
         template <typename Iter1, typename T, typename Convert, typename Reduce>
-        HPX_HOST_DEVICE HPX_FORCEINLINE static constexpr std::enable_if_t<
+        HPX_HOST_DEVICE HPX_FORCEINLINE static std::enable_if_t<
             is_arithmetic_logical_or_reduction_v<T, Reduce>, T>
         reduce(Iter1 it, std::size_t count, T init, Reduce /* */, Convert conv)
         {
@@ -197,7 +197,7 @@ namespace hpx::parallel::util::detail {
         }
 #endif
         template <typename Iter1, typename T, typename Convert, typename Reduce>
-        HPX_HOST_DEVICE HPX_FORCEINLINE static constexpr std::enable_if_t<
+        HPX_HOST_DEVICE HPX_FORCEINLINE static std::enable_if_t<
             is_not_omp_reduction_v<T, Reduce>, T>
         reduce(Iter1 it, std::size_t count, T init, Reduce r, Convert conv)
         {
@@ -274,7 +274,7 @@ namespace hpx::parallel::util::detail {
 #if defined(HPX_HAVE_VECTOR_REDUCTION)
         template <typename Iter1, typename Iter2, typename T, typename Convert,
             typename Reduce>
-        HPX_HOST_DEVICE HPX_FORCEINLINE static constexpr std::enable_if_t<
+        HPX_HOST_DEVICE HPX_FORCEINLINE static std::enable_if_t<
             is_arithmetic_plus_reduction_v<T, Reduce>, T>
         reduce(Iter1 it1, Iter2 it2, std::size_t count, T init, Reduce /* */,
             Convert conv)
@@ -290,7 +290,7 @@ namespace hpx::parallel::util::detail {
 
         template <typename Iter1, typename Iter2, typename T, typename Convert,
             typename Reduce>
-        HPX_HOST_DEVICE HPX_FORCEINLINE static constexpr std::enable_if_t<
+        HPX_HOST_DEVICE HPX_FORCEINLINE static std::enable_if_t<
             is_arithmetic_minus_reduction_v<T, Reduce>, T>
         reduce(Iter1 it1, Iter2 it2, std::size_t count, T init, Reduce /* */,
             Convert conv)
@@ -306,7 +306,7 @@ namespace hpx::parallel::util::detail {
 
         template <typename Iter1, typename Iter2, typename T, typename Convert,
             typename Reduce>
-        HPX_HOST_DEVICE HPX_FORCEINLINE static constexpr std::enable_if_t<
+        HPX_HOST_DEVICE HPX_FORCEINLINE static std::enable_if_t<
             is_arithmetic_multiplies_reduction_v<T, Reduce>, T>
         reduce(Iter1 it1, Iter2 it2, std::size_t count, T init, Reduce /* */,
             Convert conv)
@@ -322,7 +322,7 @@ namespace hpx::parallel::util::detail {
 
         template <typename Iter1, typename Iter2, typename T, typename Convert,
             typename Reduce>
-        HPX_HOST_DEVICE HPX_FORCEINLINE static constexpr std::enable_if_t<
+        HPX_HOST_DEVICE HPX_FORCEINLINE static std::enable_if_t<
             is_arithmetic_bit_and_reduction_v<T, Reduce>, T>
         reduce(Iter1 it1, Iter2 it2, std::size_t count, T init, Reduce /* */,
             Convert conv)
@@ -338,7 +338,7 @@ namespace hpx::parallel::util::detail {
 
         template <typename Iter1, typename Iter2, typename T, typename Convert,
             typename Reduce>
-        HPX_HOST_DEVICE HPX_FORCEINLINE static constexpr std::enable_if_t<
+        HPX_HOST_DEVICE HPX_FORCEINLINE static std::enable_if_t<
             is_arithmetic_bit_or_reduction_v<T, Reduce>, T>
         reduce(Iter1 it1, Iter2 it2, std::size_t count, T init, Reduce /* */,
             Convert conv)
@@ -370,7 +370,7 @@ namespace hpx::parallel::util::detail {
 
         template <typename Iter1, typename Iter2, typename T, typename Convert,
             typename Reduce>
-        HPX_HOST_DEVICE HPX_FORCEINLINE static constexpr std::enable_if_t<
+        HPX_HOST_DEVICE HPX_FORCEINLINE static std::enable_if_t<
             is_arithmetic_logical_and_reduction_v<T, Reduce>, T>
         reduce(Iter1 it1, Iter2 it2, std::size_t count, T init, Reduce /* */,
             Convert conv)
@@ -386,7 +386,7 @@ namespace hpx::parallel::util::detail {
 
         template <typename Iter1, typename Iter2, typename T, typename Convert,
             typename Reduce>
-        HPX_HOST_DEVICE HPX_FORCEINLINE static constexpr std::enable_if_t<
+        HPX_HOST_DEVICE HPX_FORCEINLINE static std::enable_if_t<
             is_arithmetic_logical_or_reduction_v<T, Reduce>, T>
         reduce(Iter1 it1, Iter2 it2, std::size_t count, T init, Reduce /* */,
             Convert conv)
@@ -402,7 +402,7 @@ namespace hpx::parallel::util::detail {
 #endif
         template <typename Iter1, typename Iter2, typename T, typename Convert,
             typename Reduce>
-        HPX_HOST_DEVICE HPX_FORCEINLINE static constexpr std::enable_if_t<
+        HPX_HOST_DEVICE HPX_FORCEINLINE static std::enable_if_t<
             is_not_omp_reduction_v<T, Reduce>, T>
         reduce(Iter1 it1, Iter2 it2, std::size_t count, T init, Reduce r,
             Convert conv)

--- a/libs/core/algorithms/include/hpx/parallel/unseq/reduce_helpers.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/unseq/reduce_helpers.hpp
@@ -90,7 +90,7 @@ namespace hpx::parallel::util::detail {
         reduce(Iter1 it, std::size_t count, T init, Reduce /* */, Convert conv)
         {
             HPX_VECTOR_REDUCTION(+ : init)
-            for (std::size_t i = 0; i != count; ++i)
+            for (std::size_t i = 0; i < count; ++i)
             {
                 init += HPX_INVOKE(conv, *it);
                 ++it;
@@ -104,7 +104,7 @@ namespace hpx::parallel::util::detail {
         reduce(Iter1 it, std::size_t count, T init, Reduce /* */, Convert conv)
         {
             HPX_VECTOR_REDUCTION(- : init)
-            for (std::size_t i = 0; i != count; ++i)
+            for (std::size_t i = 0; i < count; ++i)
             {
                 init -= HPX_INVOKE(conv, *it);
                 ++it;
@@ -118,7 +118,7 @@ namespace hpx::parallel::util::detail {
         reduce(Iter1 it, std::size_t count, T init, Reduce /* */, Convert conv)
         {
             HPX_VECTOR_REDUCTION(* : init)
-            for (std::size_t i = 0; i != count; ++i)
+            for (std::size_t i = 0; i < count; ++i)
             {
                 init *= HPX_INVOKE(conv, *it);
                 ++it;
@@ -132,7 +132,7 @@ namespace hpx::parallel::util::detail {
         reduce(Iter1 it, std::size_t count, T init, Reduce /* */, Convert conv)
         {
             HPX_VECTOR_REDUCTION(& : init)
-            for (std::size_t i = 0; i != count; ++i)
+            for (std::size_t i = 0; i < count; ++i)
             {
                 init &= HPX_INVOKE(conv, *it);
                 ++it;
@@ -146,7 +146,7 @@ namespace hpx::parallel::util::detail {
         reduce(Iter1 it, std::size_t count, T init, Reduce /* */, Convert conv)
         {
             HPX_VECTOR_REDUCTION(| : init)
-            for (std::size_t i = 0; i != count; ++i)
+            for (std::size_t i = 0; i < count; ++i)
             {
                 init |= HPX_INVOKE(conv, *it);
                 ++it;
@@ -160,7 +160,7 @@ namespace hpx::parallel::util::detail {
         reduce(Iter1 it, std::size_t count, T init, Reduce /* */, Convert conv)
         {
             HPX_VECTOR_REDUCTION(^ : init)
-            for (std::size_t i = 0; i != count; ++i)
+            for (std::size_t i = 0; i < count; ++i)
             {
                 init ^= HPX_INVOKE(conv, *it);
                 ++it;
@@ -174,7 +174,7 @@ namespace hpx::parallel::util::detail {
         reduce(Iter1 it, std::size_t count, T init, Reduce /* */, Convert conv)
         {
             HPX_VECTOR_REDUCTION(&& : init)
-            for (std::size_t i = 0; i != count; ++i)
+            for (std::size_t i = 0; i < count; ++i)
             {
                 init = HPX_INVOKE(conv, *it) && init;
                 ++it;
@@ -188,7 +188,7 @@ namespace hpx::parallel::util::detail {
         reduce(Iter1 it, std::size_t count, T init, Reduce /* */, Convert conv)
         {
             HPX_VECTOR_REDUCTION(|| : init)
-            for (std::size_t i = 0; i != count; ++i)
+            for (std::size_t i = 0; i < count; ++i)
             {
                 init = HPX_INVOKE(conv, *it) || init;
                 ++it;
@@ -206,7 +206,7 @@ namespace hpx::parallel::util::detail {
             // To small, just run sequential
             if (count <= 2 * block_size)
             {
-                for (std::size_t i = 0; i != count; ++i)
+                for (std::size_t i = 0; i < count; ++i)
                 {
                     init = HPX_INVOKE(r, init, HPX_INVOKE(conv, *it));
                     ++it;
@@ -244,7 +244,7 @@ namespace hpx::parallel::util::detail {
                 count -= limit;
 
                 HPX_VECTORIZE
-                for (std::size_t i = 0; i != count; ++i)
+                for (std::size_t i = 0; i < count; ++i)
                 {
                     tblock[i] = HPX_INVOKE(r, tblock[i], HPX_INVOKE(conv, *it));
                     ++it;
@@ -280,7 +280,7 @@ namespace hpx::parallel::util::detail {
             Convert conv)
         {
             HPX_VECTOR_REDUCTION(+ : init)
-            for (std::size_t i = 0; i != count; ++i)
+            for (std::size_t i = 0; i < count; ++i)
             {
                 init += HPX_INVOKE(conv, *it1, *it2);
                 ++it1, ++it2;
@@ -296,7 +296,7 @@ namespace hpx::parallel::util::detail {
             Convert conv)
         {
             HPX_VECTOR_REDUCTION(- : init)
-            for (std::size_t i = 0; i != count; ++i)
+            for (std::size_t i = 0; i < count; ++i)
             {
                 init -= HPX_INVOKE(conv, *it1, *it2);
                 ++it1, ++it2;
@@ -312,7 +312,7 @@ namespace hpx::parallel::util::detail {
             Convert conv)
         {
             HPX_VECTOR_REDUCTION(* : init)
-            for (std::size_t i = 0; i != count; ++i)
+            for (std::size_t i = 0; i < count; ++i)
             {
                 init *= HPX_INVOKE(conv, *it1, *it2);
                 ++it1, ++it2;
@@ -328,7 +328,7 @@ namespace hpx::parallel::util::detail {
             Convert conv)
         {
             HPX_VECTOR_REDUCTION(& : init)
-            for (std::size_t i = 0; i != count; ++i)
+            for (std::size_t i = 0; i < count; ++i)
             {
                 init &= HPX_INVOKE(conv, *it1, *it2);
                 ++it1, ++it2;
@@ -344,7 +344,7 @@ namespace hpx::parallel::util::detail {
             Convert conv)
         {
             HPX_VECTOR_REDUCTION(| : init)
-            for (std::size_t i = 0; i != count; ++i)
+            for (std::size_t i = 0; i < count; ++i)
             {
                 init |= HPX_INVOKE(conv, *it1, *it2);
                 ++it1, ++it2;
@@ -360,7 +360,7 @@ namespace hpx::parallel::util::detail {
             Convert conv)
         {
             HPX_VECTOR_REDUCTION(^ : init)
-            for (std::size_t i = 0; i != count; ++i)
+            for (std::size_t i = 0; i < count; ++i)
             {
                 init ^= HPX_INVOKE(conv, *it1, *it2);
                 ++it1, ++it2;
@@ -376,7 +376,7 @@ namespace hpx::parallel::util::detail {
             Convert conv)
         {
             HPX_VECTOR_REDUCTION(&& : init)
-            for (std::size_t i = 0; i != count; ++i)
+            for (std::size_t i = 0; i < count; ++i)
             {
                 init = HPX_INVOKE(conv, *it1, *it2) && init;
                 ++it1, ++it2;
@@ -392,7 +392,7 @@ namespace hpx::parallel::util::detail {
             Convert conv)
         {
             HPX_VECTOR_REDUCTION(|| : init)
-            for (std::size_t i = 0; i != count; ++i)
+            for (std::size_t i = 0; i < count; ++i)
             {
                 init = HPX_INVOKE(conv, *it1, *it2) || init;
                 ++it1, ++it2;
@@ -413,7 +413,7 @@ namespace hpx::parallel::util::detail {
             // To small, just run sequential
             if (count <= 2 * block_size)
             {
-                for (std::size_t i = 0; i != count; ++i)
+                for (std::size_t i = 0; i < count; ++i)
                 {
                     init = HPX_INVOKE(r, init, HPX_INVOKE(conv, *it1, *it2));
                     ++it1, ++it2;
@@ -454,7 +454,7 @@ namespace hpx::parallel::util::detail {
                 count -= limit;
 
                 HPX_VECTORIZE
-                for (std::size_t i = 0; i != count; ++i)
+                for (std::size_t i = 0; i < count; ++i)
                 {
                     tblock[i] =
                         HPX_INVOKE(r, tblock[i], HPX_INVOKE(conv, *it1, *it2));

--- a/libs/core/algorithms/include/hpx/parallel/unseq/reduce_helpers.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/unseq/reduce_helpers.hpp
@@ -232,7 +232,7 @@ namespace hpx::parallel::util::detail {
                      i += block_size)
                 {
                     HPX_VECTORIZE
-                    for (std::size_t j = 0; j != block_size; ++j)
+                    for (std::size_t j = 0; j < block_size; ++j)
                     {
                         tblock[j] = HPX_INVOKE(
                             r, tblock[j], HPX_INVOKE(conv, *(it + j)));
@@ -251,7 +251,7 @@ namespace hpx::parallel::util::detail {
                 }
 
                 // Merge
-                for (std::size_t i = 0; i != block_size; ++i)
+                for (std::size_t i = 0; i < block_size; ++i)
                 {
                     init = HPX_INVOKE(r, init, tblock[i]);
                 }
@@ -425,7 +425,7 @@ namespace hpx::parallel::util::detail {
                 T* tblock = reinterpret_cast<T*>(block);
 
                 // Initialize block[i] = r(f(2*i), f(2*i + 1))
-                for (std::size_t i = 0; i != block_size; ++i)
+                for (std::size_t i = 0; i < block_size; ++i)
                 {
                     hpx::construct_at(tblock + i,
                         HPX_INVOKE(r, HPX_INVOKE(conv, *it1, *it2),
@@ -441,7 +441,7 @@ namespace hpx::parallel::util::detail {
                      i += block_size)
                 {
                     HPX_VECTORIZE
-                    for (std::size_t j = 0; j != block_size; ++j)
+                    for (std::size_t j = 0; j < block_size; ++j)
                     {
                         tblock[j] = HPX_INVOKE(r, tblock[j],
                             HPX_INVOKE(conv, *(it1 + j), *(it2 + j)));
@@ -462,14 +462,14 @@ namespace hpx::parallel::util::detail {
                 }
 
                 // Merge
-                for (std::size_t i = 0; i != block_size; ++i)
+                for (std::size_t i = 0; i < block_size; ++i)
                 {
                     init = HPX_INVOKE(r, init, tblock[i]);
                 }
 
                 // Cleanup resources
                 HPX_VECTORIZE
-                for (std::size_t i = 0; i != block_size; ++i)
+                for (std::size_t i = 0; i < block_size; ++i)
                 {
                     std::destroy_at(std::addressof(tblock[i]));
                 }

--- a/libs/core/algorithms/include/hpx/parallel/unseq/transform_loop.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/unseq/transform_loop.hpp
@@ -37,7 +37,7 @@ namespace hpx::parallel::util {
                 if constexpr (iterators_are_random_access)
                 {
                     // clang-format off
-                    HPX_IVDEP HPX_UNROLL HPX_VECTORIZE
+                    HPX_VECTORIZE
                     for (std::size_t i = 0; i != num; ++i)
                     {
                         *dest = HPX_INVOKE(f, it);
@@ -87,7 +87,7 @@ namespace hpx::parallel::util {
                 if constexpr (iterators_are_random_access)
                 {
                     // clang-format off
-                    HPX_IVDEP HPX_UNROLL HPX_VECTORIZE
+                    HPX_VECTORIZE
                     for (std::size_t i = 0; i != num; ++i)
                     {
                         *dest = HPX_INVOKE(f, *it);
@@ -253,7 +253,7 @@ namespace hpx::parallel::util {
                 if constexpr (iterators_are_random_access)
                 {
                     // clang-format off
-                    HPX_IVDEP HPX_UNROLL HPX_VECTORIZE
+                    HPX_VECTORIZE
                     for (std::size_t i = 0; i != num; ++i)
                     {
                         *dest = HPX_INVOKE(f, first1, first2);
@@ -414,7 +414,7 @@ namespace hpx::parallel::util {
                 if constexpr (iterators_are_random_access)
                 {
                     // clang-format off
-                    HPX_IVDEP HPX_UNROLL HPX_VECTORIZE
+                    HPX_VECTORIZE
                     for (std::size_t i = 0; i != num; ++i)
                     {
                         *dest = HPX_INVOKE(f, *first1, *first2);

--- a/libs/core/algorithms/include/hpx/parallel/unseq/transform_loop.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/unseq/transform_loop.hpp
@@ -37,7 +37,7 @@ namespace hpx::parallel::util {
                 {
                     // clang-format off
                     HPX_VECTORIZE
-                    for (std::size_t i = 0; i != num; ++i)
+                    for (std::size_t i = 0; i < num; ++i)
                     {
                         *dest = HPX_INVOKE(f, it);
                         ++it, ++dest;
@@ -86,7 +86,7 @@ namespace hpx::parallel::util {
                 {
                     // clang-format off
                     HPX_VECTORIZE
-                    for (std::size_t i = 0; i != num; ++i)
+                    for (std::size_t i = 0; i < num; ++i)
                     {
                         *dest = HPX_INVOKE(f, *it);
                         ++it, ++dest;
@@ -251,7 +251,7 @@ namespace hpx::parallel::util {
                 {
                     // clang-format off
                     HPX_VECTORIZE
-                    for (std::size_t i = 0; i != num; ++i)
+                    for (std::size_t i = 0; i < num; ++i)
                     {
                         *dest = HPX_INVOKE(f, first1, first2);
                         ++first1, ++first2, ++dest;
@@ -410,7 +410,7 @@ namespace hpx::parallel::util {
                 {
                     // clang-format off
                     HPX_VECTORIZE
-                    for (std::size_t i = 0; i != num; ++i)
+                    for (std::size_t i = 0; i < num; ++i)
                     {
                         *dest = HPX_INVOKE(f, *first1, *first2);
                         ++first1, ++first2, ++dest;

--- a/libs/core/algorithms/include/hpx/parallel/unseq/transform_loop.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/unseq/transform_loop.hpp
@@ -25,10 +25,9 @@ namespace hpx::parallel::util {
         struct unseq_transform_loop_n
         {
             template <typename InIter, typename OutIter, typename F>
-            HPX_HOST_DEVICE
-                HPX_FORCEINLINE static constexpr std::pair<InIter, OutIter>
-                call(InIter HPX_RESTRICT it, std::size_t num,
-                    OutIter HPX_RESTRICT dest, F&& f)
+            HPX_HOST_DEVICE HPX_FORCEINLINE static std::pair<InIter, OutIter>
+            call(InIter HPX_RESTRICT it, std::size_t num,
+                OutIter HPX_RESTRICT dest, F&& f)
             {
                 constexpr bool iterators_are_random_access =
                     hpx::traits::is_random_access_iterator_v<InIter> &&
@@ -75,10 +74,9 @@ namespace hpx::parallel::util {
         struct unseq_transform_loop_n_ind
         {
             template <typename InIter, typename OutIter, typename F>
-            HPX_HOST_DEVICE
-                HPX_FORCEINLINE static constexpr std::pair<InIter, OutIter>
-                call(InIter HPX_RESTRICT it, std::size_t num,
-                    OutIter HPX_RESTRICT dest, F&& f)
+            HPX_HOST_DEVICE HPX_FORCEINLINE static std::pair<InIter, OutIter>
+            call(InIter HPX_RESTRICT it, std::size_t num,
+                OutIter HPX_RESTRICT dest, F&& f)
             {
                 constexpr bool iterators_are_random_access =
                     hpx::traits::is_random_access_iterator_v<InIter> &&
@@ -126,8 +124,7 @@ namespace hpx::parallel::util {
         {
             template <typename InIter, typename OutIter, typename F>
             HPX_HOST_DEVICE
-                HPX_FORCEINLINE static constexpr util::in_out_result<InIter,
-                    OutIter>
+                HPX_FORCEINLINE static util::in_out_result<InIter, OutIter>
                 call(InIter HPX_RESTRICT it, InIter HPX_RESTRICT last,
                     OutIter HPX_RESTRICT dest, F&& f)
             {
@@ -183,8 +180,7 @@ namespace hpx::parallel::util {
         {
             template <typename InIter, typename OutIter, typename F>
             HPX_HOST_DEVICE
-                HPX_FORCEINLINE static constexpr util::in_out_result<InIter,
-                    OutIter>
+                HPX_FORCEINLINE static util::in_out_result<InIter, OutIter>
                 call(InIter HPX_RESTRICT it, InIter HPX_RESTRICT last,
                     OutIter HPX_RESTRICT dest, F&& f)
             {
@@ -240,10 +236,11 @@ namespace hpx::parallel::util {
         {
             template <typename InIter1, typename InIter2, typename OutIter,
                 typename F>
-            HPX_HOST_DEVICE HPX_FORCEINLINE static constexpr hpx::tuple<InIter1,
-                InIter2, OutIter>
-            call(InIter1 HPX_RESTRICT first1, std::size_t num,
-                InIter2 HPX_RESTRICT first2, OutIter HPX_RESTRICT dest, F&& f)
+            HPX_HOST_DEVICE
+                HPX_FORCEINLINE static hpx::tuple<InIter1, InIter2, OutIter>
+                call(InIter1 HPX_RESTRICT first1, std::size_t num,
+                    InIter2 HPX_RESTRICT first2, OutIter HPX_RESTRICT dest,
+                    F&& f)
             {
                 constexpr bool iterators_are_random_access =
                     hpx::traits::is_random_access_iterator_v<InIter1> &&
@@ -294,12 +291,10 @@ namespace hpx::parallel::util {
         {
             template <typename InIter1, typename InIter2, typename OutIter,
                 typename F>
-            HPX_HOST_DEVICE
-                HPX_FORCEINLINE static constexpr util::in_in_out_result<InIter1,
-                    InIter2, OutIter>
-                call(InIter1 HPX_RESTRICT first1, InIter1 HPX_RESTRICT last1,
-                    InIter2 HPX_RESTRICT first2, OutIter HPX_RESTRICT dest,
-                    F&& f)
+            HPX_HOST_DEVICE HPX_FORCEINLINE static util::in_in_out_result<
+                InIter1, InIter2, OutIter>
+            call(InIter1 HPX_RESTRICT first1, InIter1 HPX_RESTRICT last1,
+                InIter2 HPX_RESTRICT first2, OutIter HPX_RESTRICT dest, F&& f)
             {
                 constexpr bool iterators_are_random_access =
                     hpx::traits::is_random_access_iterator_v<InIter1> &&
@@ -328,12 +323,11 @@ namespace hpx::parallel::util {
 
             template <typename InIter1, typename InIter2, typename OutIter,
                 typename F>
-            HPX_HOST_DEVICE
-                HPX_FORCEINLINE static constexpr util::in_in_out_result<InIter1,
-                    InIter2, OutIter>
-                call(InIter1 HPX_RESTRICT first1, InIter1 HPX_RESTRICT last1,
-                    InIter2 HPX_RESTRICT first2, InIter2 HPX_RESTRICT last2,
-                    OutIter dest, F&& f)
+            HPX_HOST_DEVICE HPX_FORCEINLINE static util::in_in_out_result<
+                InIter1, InIter2, OutIter>
+            call(InIter1 HPX_RESTRICT first1, InIter1 HPX_RESTRICT last1,
+                InIter2 HPX_RESTRICT first2, InIter2 HPX_RESTRICT last2,
+                OutIter dest, F&& f)
             {
                 constexpr bool iterators_are_random_access =
                     hpx::traits::is_random_access_iterator_v<InIter1> &&
@@ -401,10 +395,11 @@ namespace hpx::parallel::util {
         {
             template <typename InIter1, typename InIter2, typename OutIter,
                 typename F>
-            HPX_HOST_DEVICE HPX_FORCEINLINE static constexpr hpx::tuple<InIter1,
-                InIter2, OutIter>
-            call(InIter1 HPX_RESTRICT first1, std::size_t num,
-                InIter2 HPX_RESTRICT first2, OutIter HPX_RESTRICT dest, F&& f)
+            HPX_HOST_DEVICE
+                HPX_FORCEINLINE static hpx::tuple<InIter1, InIter2, OutIter>
+                call(InIter1 HPX_RESTRICT first1, std::size_t num,
+                    InIter2 HPX_RESTRICT first2, OutIter HPX_RESTRICT dest,
+                    F&& f)
             {
                 constexpr bool iterators_are_random_access =
                     hpx::traits::is_random_access_iterator_v<InIter1> &&
@@ -455,12 +450,10 @@ namespace hpx::parallel::util {
         {
             template <typename InIter1, typename InIter2, typename OutIter,
                 typename F>
-            HPX_HOST_DEVICE
-                HPX_FORCEINLINE static constexpr util::in_in_out_result<InIter1,
-                    InIter2, OutIter>
-                call(InIter1 HPX_RESTRICT first1, InIter1 HPX_RESTRICT last1,
-                    InIter2 HPX_RESTRICT first2, OutIter HPX_RESTRICT dest,
-                    F&& f)
+            HPX_HOST_DEVICE HPX_FORCEINLINE static util::in_in_out_result<
+                InIter1, InIter2, OutIter>
+            call(InIter1 HPX_RESTRICT first1, InIter1 HPX_RESTRICT last1,
+                InIter2 HPX_RESTRICT first2, OutIter HPX_RESTRICT dest, F&& f)
             {
                 constexpr bool iterators_are_random_access =
                     hpx::traits::is_random_access_iterator_v<InIter1> &&
@@ -489,12 +482,11 @@ namespace hpx::parallel::util {
 
             template <typename InIter1, typename InIter2, typename OutIter,
                 typename F>
-            HPX_HOST_DEVICE
-                HPX_FORCEINLINE static constexpr util::in_in_out_result<InIter1,
-                    InIter2, OutIter>
-                call(InIter1 HPX_RESTRICT first1, InIter1 HPX_RESTRICT last1,
-                    InIter2 HPX_RESTRICT first2, InIter2 HPX_RESTRICT last2,
-                    OutIter HPX_RESTRICT dest, F&& f)
+            HPX_HOST_DEVICE HPX_FORCEINLINE static util::in_in_out_result<
+                InIter1, InIter2, OutIter>
+            call(InIter1 HPX_RESTRICT first1, InIter1 HPX_RESTRICT last1,
+                InIter2 HPX_RESTRICT first2, InIter2 HPX_RESTRICT last2,
+                OutIter HPX_RESTRICT dest, F&& f)
             {
                 constexpr bool iterators_are_random_access =
                     hpx::traits::is_random_access_iterator_v<InIter1> &&


### PR DESCRIPTION
hpx uses compiler assisted vectorization (enabled by the -O3 flag), changing it to OMP vectorization