### PR TITLE
Define HPX_COMPUTE_CODE in builds with SYCL

### DIFF
--- a/libs/core/config/include/hpx/config/compiler_specific.hpp
+++ b/libs/core/config/include/hpx/config/compiler_specific.hpp
@@ -160,6 +160,11 @@
 #endif
 #define HPX_HOST_DEVICE HPX_HOST HPX_DEVICE
 
+// Define this AFTER HPX_[DEVICE|HOST] for SYCL
+// as we do not want the __device__ modifiers
+#if defined(HPX_HAVE_SYCL)
+#  define HPX_COMPUTE_CODE
+#endif
 
 #if !defined(HPX_CDECL)
 #define HPX_CDECL


### PR DESCRIPTION
This resolves a compilation issue where timestamp_cuda is required in device code for a certain build configuration (using ONEAPI/SYCL/dpcpp with an enabled CUDA backend and specific GPU architecture) but not found. The underlying issue: The include command for the timestamp_cuda header is protected with an ifdef HPX_COMPUTE_CODE and the header was thus not included  - hence the timestamp method was not found, and the code did not compile in this configuration!

This commit resolves the issue! Not by changing or removing the ifdef timestamp guard, but instead by defining HPX_COMPUTE_CODE for SYCL builds in the compiler_specific.hpp header as well. This ensures that the behavior for non-SYCL builds stays the same as before.