### PR TITLE
Trivial relocation of c-v-ref-array types

### DIFF
--- a/libs/core/type_support/include/hpx/type_support/is_trivially_relocatable.hpp
+++ b/libs/core/type_support/include/hpx/type_support/is_trivially_relocatable.hpp
@@ -85,12 +85,14 @@ namespace hpx {
     };
 
     template <typename T, int size>
-    struct is_trivially_relocatable<T volatile[size]> : is_trivially_relocatable<T>
+    struct is_trivially_relocatable<T volatile[size]>
+      : is_trivially_relocatable<T>
     {
     };
 
     template <typename T, int size>
-    struct is_trivially_relocatable<T const volatile[size]> : is_trivially_relocatable<T>
+    struct is_trivially_relocatable<T const volatile[size]>
+      : is_trivially_relocatable<T>
     {
     };
 

--- a/libs/core/type_support/include/hpx/type_support/is_trivially_relocatable.hpp
+++ b/libs/core/type_support/include/hpx/type_support/is_trivially_relocatable.hpp
@@ -79,6 +79,21 @@ namespace hpx {
     {
     };
 
+    template <typename T, int size>
+    struct is_trivially_relocatable<T const[size]> : is_trivially_relocatable<T>
+    {
+    };
+
+    template <typename T, int size>
+    struct is_trivially_relocatable<T volatile[size]> : is_trivially_relocatable<T>
+    {
+    };
+
+    template <typename T, int size>
+    struct is_trivially_relocatable<T const volatile[size]> : is_trivially_relocatable<T>
+    {
+    };
+
     template <typename T>
     inline constexpr bool is_trivially_relocatable_v =
         is_trivially_relocatable<T>::value;

--- a/libs/core/type_support/include/hpx/type_support/is_trivially_relocatable.hpp
+++ b/libs/core/type_support/include/hpx/type_support/is_trivially_relocatable.hpp
@@ -63,6 +63,11 @@ namespace hpx {
     {
     };
 
+    template <typename T, int size>
+    struct is_trivially_relocatable<T[size]> : is_trivially_relocatable<T>
+    {
+    };
+
     template <typename T>
     inline constexpr bool is_trivially_relocatable_v =
         is_trivially_relocatable<T>::value;

--- a/libs/core/type_support/include/hpx/type_support/is_trivially_relocatable.hpp
+++ b/libs/core/type_support/include/hpx/type_support/is_trivially_relocatable.hpp
@@ -42,9 +42,24 @@ namespace hpx {
     {
     };
 
+    // Constness, Volatility, References, Arrays are ignored
     template <typename T>
-    // Arrays of trivially copyable types are trivially relocatable
-    struct is_trivially_relocatable<T[]> : std::is_trivially_relocatable<T>
+    struct is_trivially_relocatable<T const> : is_trivially_relocatable<T>
+    {
+    };
+
+    template <typename T>
+    struct is_trivially_relocatable<T volatile> : is_trivially_relocatable<T>
+    {
+    };
+
+    template <typename T>
+    struct is_trivially_relocatable<T&> : is_trivially_relocatable<T>
+    {
+    };
+
+    template <typename T>
+    struct is_trivially_relocatable<T[]> : is_trivially_relocatable<T>
     {
     };
 

--- a/libs/core/type_support/include/hpx/type_support/is_trivially_relocatable.hpp
+++ b/libs/core/type_support/include/hpx/type_support/is_trivially_relocatable.hpp
@@ -64,6 +64,11 @@ namespace hpx {
     };
 
     template <typename T>
+    struct is_trivially_relocatable<T&&> : is_trivially_relocatable<T>
+    {
+    };
+
+    template <typename T>
     struct is_trivially_relocatable<T[]> : is_trivially_relocatable<T>
     {
     };

--- a/libs/core/type_support/include/hpx/type_support/is_trivially_relocatable.hpp
+++ b/libs/core/type_support/include/hpx/type_support/is_trivially_relocatable.hpp
@@ -43,6 +43,12 @@ namespace hpx {
     };
 
     template <typename T>
+    // Arrays of trivially copyable types are trivially relocatable
+    struct is_trivially_relocatable<T[]> : std::is_trivially_copyable<T>
+    {
+    };
+
+    template <typename T>
     inline constexpr bool is_trivially_relocatable_v =
         is_trivially_relocatable<T>::value;
 }    // namespace hpx

--- a/libs/core/type_support/include/hpx/type_support/is_trivially_relocatable.hpp
+++ b/libs/core/type_support/include/hpx/type_support/is_trivially_relocatable.hpp
@@ -44,7 +44,7 @@ namespace hpx {
 
     template <typename T>
     // Arrays of trivially copyable types are trivially relocatable
-    struct is_trivially_relocatable<T[]> : std::is_trivially_copyable<T>
+    struct is_trivially_relocatable<T[]> : std::is_trivially_relocatable<T>
     {
     };
 

--- a/libs/core/type_support/include/hpx/type_support/is_trivially_relocatable.hpp
+++ b/libs/core/type_support/include/hpx/type_support/is_trivially_relocatable.hpp
@@ -54,7 +54,8 @@ namespace hpx {
     };
 
     template <typename T>
-    struct is_trivially_relocatable<T const volatile> : is_trivially_relocatable<T>
+    struct is_trivially_relocatable<T const volatile>
+      : is_trivially_relocatable<T>
     {
     };
 

--- a/libs/core/type_support/include/hpx/type_support/is_trivially_relocatable.hpp
+++ b/libs/core/type_support/include/hpx/type_support/is_trivially_relocatable.hpp
@@ -54,6 +54,11 @@ namespace hpx {
     };
 
     template <typename T>
+    struct is_trivially_relocatable<T const volatile> : is_trivially_relocatable<T>
+    {
+    };
+
+    template <typename T>
     struct is_trivially_relocatable<T&> : is_trivially_relocatable<T>
     {
     };

--- a/libs/core/type_support/tests/unit/is_trivially_relocatable.cpp
+++ b/libs/core/type_support/tests/unit/is_trivially_relocatable.cpp
@@ -125,6 +125,41 @@ static_assert(
 static_assert(
     hpx::is_trivially_relocatable_v<explicitly_trivially_relocatable_2>);
 
+// c-v-ref-array qualified versions of explicitly declared trivially relocatable
+// types are trivially relocatable
+
+static_assert(
+    hpx::is_trivially_relocatable_v<explicitly_trivially_relocatable_1 const>);
+static_assert(hpx::is_trivially_relocatable_v<
+    explicitly_trivially_relocatable_1 volatile>);
+static_assert(hpx::is_trivially_relocatable_v<
+    explicitly_trivially_relocatable_1 const volatile>);
+static_assert(
+    hpx::is_trivially_relocatable_v<explicitly_trivially_relocatable_1&>);
+static_assert(
+    hpx::is_trivially_relocatable_v<explicitly_trivially_relocatable_1&&>);
+static_assert(
+    hpx::is_trivially_relocatable_v<explicitly_trivially_relocatable_1[]>);
+static_assert(
+    hpx::is_trivially_relocatable_v<explicitly_trivially_relocatable_1[10]>);
+
+// Chain of c-v-ref-array qualifiers are supported
+static_assert(hpx::is_trivially_relocatable_v<
+    explicitly_trivially_relocatable_1[10][10]>);
+static_assert(hpx::is_trivially_relocatable_v<
+    explicitly_trivially_relocatable_1 const[10]>);
+static_assert(hpx::is_trivially_relocatable_v<
+    explicitly_trivially_relocatable_1 volatile[10]>);
+static_assert(hpx::is_trivially_relocatable_v<
+    explicitly_trivially_relocatable_1 const volatile[10]>);
+static_assert(hpx::is_trivially_relocatable_v<
+    explicitly_trivially_relocatable_1 (&)[10]>);
+static_assert(
+    hpx::is_trivially_relocatable_v<explicitly_trivially_relocatable_1 (
+        &&)[10]>);
+static_assert(hpx::is_trivially_relocatable_v<
+    explicitly_trivially_relocatable_1 const volatile &>);
+
 // Trivial relocatability is not inherited
 struct derived_from_explicitly_trivially_relocatable
   : explicitly_trivially_relocatable_1

--- a/libs/core/type_support/tests/unit/is_trivially_relocatable.cpp
+++ b/libs/core/type_support/tests/unit/is_trivially_relocatable.cpp
@@ -155,7 +155,7 @@ static_assert(hpx::is_trivially_relocatable_v<
 static_assert(hpx::is_trivially_relocatable_v<
     explicitly_trivially_relocatable_1 (&)[10]>);
 static_assert(
-    hpx::is_trivially_relocatable_v<explicitly_trivially_relocatable_1 (
+    hpx::is_trivially_relocatable_v<explicitly_trivially_relocatable_1(
         &&)[10]>);
 static_assert(hpx::is_trivially_relocatable_v<
     explicitly_trivially_relocatable_1 const volatile&>);

--- a/libs/core/type_support/tests/unit/is_trivially_relocatable.cpp
+++ b/libs/core/type_support/tests/unit/is_trivially_relocatable.cpp
@@ -158,7 +158,7 @@ static_assert(
     hpx::is_trivially_relocatable_v<explicitly_trivially_relocatable_1 (
         &&)[10]>);
 static_assert(hpx::is_trivially_relocatable_v<
-    explicitly_trivially_relocatable_1 const volatile &>);
+    explicitly_trivially_relocatable_1 const volatile&>);
 
 // Trivial relocatability is not inherited
 struct derived_from_explicitly_trivially_relocatable


### PR DESCRIPTION
This PR is an addition to the earlier https://github.com/STEllAR-GROUP/hpx/pull/6264

It allows peeling away type qualifiers to make sure that declaring type `T` as trivially relocatable will declare the following types too: 

`const T`, `volatile T`, `const volatile T`, `T&`, `T&&`, `T[]`, `T[n]` 