### PR TITLE
Ensure hpx_main is a proper thread_function

### DIFF
--- a/libs/core/runtime_local/src/runtime_local.cpp
+++ b/libs/core/runtime_local/src/runtime_local.cpp
@@ -1460,11 +1460,13 @@ namespace hpx {
         lbt_ << "(1st stage) runtime::start: launching run_helper "
                 "HPX thread";
 
-        threads::thread_init_data data(
-            hpx::bind(&runtime::run_helper, this, func, std::ref(result_), true,
-                &detail::handle_print_bind),
-            "run_helper", threads::thread_priority::normal,
-            threads::thread_schedule_hint(0), threads::thread_stacksize::large);
+        threads::thread_function_type thread_func =
+            threads::make_thread_function(hpx::bind(&runtime::run_helper, this,
+                func, std::ref(result_), true, &detail::handle_print_bind));
+
+        threads::thread_init_data data(HPX_MOVE(thread_func), "run_helper",
+            threads::thread_priority::normal, threads::thread_schedule_hint(0),
+            threads::thread_stacksize::large);
 
         this->runtime::starting();
         threads::thread_id_ref_type id = threads::invalid_thread_id;

--- a/libs/full/runtime_distributed/src/runtime_distributed.cpp
+++ b/libs/full/runtime_distributed/src/runtime_distributed.cpp
@@ -472,11 +472,14 @@ namespace hpx {
         lbt_ << "(1st stage) runtime_distributed::start: launching "
                 "run_helper HPX thread";
 
-        threads::thread_init_data data(
-            hpx::bind(&runtime_distributed::run_helper, this, func,
-                std::ref(result_)),
-            "run_helper", threads::thread_priority::normal,
-            threads::thread_schedule_hint(0), threads::thread_stacksize::large);
+        threads::thread_function_type thread_func =
+            threads::make_thread_function(
+                hpx::bind(&runtime_distributed::run_helper, this, func,
+                    std::ref(result_)));
+
+        threads::thread_init_data data(HPX_MOVE(thread_func), "run_helper",
+            threads::thread_priority::normal, threads::thread_schedule_hint(0),
+            threads::thread_stacksize::large);
 
         this->runtime::starting();
         threads::thread_id_ref_type id = threads::invalid_thread_id;

--- a/tests/regressions/threads/CMakeLists.txt
+++ b/tests/regressions/threads/CMakeLists.txt
@@ -7,6 +7,7 @@
 
 set(tests
     block_os_threads_1036
+    main_thread_exit_callbacks
     run_as_hpx_thread_exceptions_3304
     run_as_os_thread_lockup_2991
     stackless_self_4155

--- a/tests/regressions/threads/main_thread_exit_callbacks.cpp
+++ b/tests/regressions/threads/main_thread_exit_callbacks.cpp
@@ -1,0 +1,55 @@
+//  Copyright (c) 2023 Panos Syskakis
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/init.hpp>
+#include <hpx/modules/testing.hpp>
+#include <hpx/runtime.hpp>
+#include <hpx/thread.hpp>
+
+#include <atomic>
+#include <cstddef>
+
+bool callback_called(false);
+
+int hpx_main()
+{
+    hpx::threads::thread_id_type id = hpx::threads::get_self_id();
+    hpx::threads::add_thread_exit_callback(id, [id]() {
+        hpx::threads::thread_id_type id1 = hpx::threads::get_self_id();
+        HPX_TEST_EQ(id1, id);
+
+        callback_called = true;
+    });
+
+    return hpx::finalize();
+}
+
+int main(int argc, char* argv[])
+{
+    // Test local runtime
+    {
+        hpx::init_params iparams;
+        iparams.mode = hpx::runtime_mode::local;
+        callback_called = false;
+        HPX_TEST_EQ_MSG(hpx::init(argc, argv, iparams), 0,
+            "HPX main exited with non-zero status");
+        HPX_TEST(callback_called);
+    }
+
+#if defined(HPX_HAVE_DISTRIBUTED_RUNTIME)
+    // Test distributed runtime
+    {
+        hpx::init_params iparams;
+        iparams.mode = hpx::runtime_mode::console;
+        callback_called = false;
+        HPX_TEST_EQ_MSG(hpx::init(argc, argv, iparams), 0,
+            "HPX main exited with non-zero status");
+
+        HPX_TEST(callback_called);
+    }
+#endif
+    return hpx::util::report_errors();
+}


### PR DESCRIPTION
Ensure that hpx_main is launched as a thread_function, so that exit callbacks are respected, and the following code will actually be used:

https://github.com/STEllAR-GROUP/hpx/blob/e7c31a49dd4e550a61134e498f3ecfb585d201cb/libs/core/threading_base/include/hpx/threading_base/register_thread.hpp#L28-L52

I should add that previously the callbacks were never executed, so using add_thread_exit_callback would cause an assertion failure later on thread destruction (L163), due to this sequence of calls:

https://github.com/STEllAR-GROUP/hpx/blob/e7c31a49dd4e550a61134e498f3ecfb585d201cb/libs/core/threading_base/src/thread_data.cpp#L107-L111

https://github.com/STEllAR-GROUP/hpx/blob/e7c31a49dd4e550a61134e498f3ecfb585d201cb/libs/core/threading_base/src/thread_data.cpp#L157-L166

@hkaiser Let me know if this is a good idea, and whether you'd like me to add a regression test.