### PR TITLE
Remove aurianer, biddisco, and msimberg from codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,10 +4,4 @@
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-* @aurianer @biddisco @hkaiser @msimberg
-
-/docs/ @msimberg
-/libs/**/*.txt @aurianer @msimberg
-/libs/**/*.rst @aurianer @msimberg
-/libs/**/*.py @aurianer @msimberg
-/libs/**/*.sh @aurianer @msimberg
+* @hkaiser


### PR DESCRIPTION
As we're not really reviewing PRs anymore it doesn't make sense to keep us in the codeowners file anymore.