### PR TITLE
Add coverage testing on Jenkins

### DIFF
--- a/.jenkins/lsu-test-coverage/Jenkinsfile
+++ b/.jenkins/lsu-test-coverage/Jenkinsfile
@@ -1,0 +1,61 @@
+#!groovy
+
+// Copyright (c) 2020 ETH Zurich
+// Copyright (c) 2022 Hartmut Kaiser
+// Copyright (c) 2023 Panos Syskakis
+//
+// SPDX-License-Identifier: BSL-1.0
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+pipeline {
+    agent any
+    options {
+        buildDiscarder(
+            logRotator(
+                daysToKeepStr: "14",
+                numToKeepStr: "50",
+                artifactDaysToKeepStr: "14",
+                artifactNumToKeepStr: "50"
+            )
+        )
+    }
+    environment {
+        CODACY_TOKEN = credentials('CODACY_TOKEN_HPX')
+
+    }
+    stages {
+        stage('checkout') {
+            steps {
+                dir('hpx') {
+                    sh '''
+                    #!/bin/bash -l
+                    rm -rf *
+                    '''
+                    checkout scm
+                    echo "Running ${env.BUILD_ID} on ${env.JENKINS_URL}"
+                }
+            }
+        }
+        stage('test-coverage') {
+            environment{
+                configuration_name = "test-coverage"
+            }
+            steps {
+                dir('hpx') {
+                    sh '''
+                    #!/bin/bash -l
+                    .jenkins/lsu-test-coverage/entry.sh
+                    '''
+                }
+            }
+        }
+    }
+
+    post {
+        always {
+            archiveArtifacts artifacts: 'hpx/jenkins-hpx-*', fingerprint: true
+            archiveArtifacts artifacts: 'hpx/grcov-log.txt', fingerprint: true
+        }
+    }
+}

--- a/.jenkins/lsu-test-coverage/batch.sh
+++ b/.jenkins/lsu-test-coverage/batch.sh
@@ -1,0 +1,53 @@
+#!/bin/bash -l
+
+# Copyright (c) 2023 Panos Syskakis
+#
+# SPDX-License-Identifier: BSL-1.0
+# Distributed under the Boost Software License, Version 1.0. (See accompanying
+# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+set -eux
+
+src_dir="$(pwd)"
+build_dir="${src_dir}/build/"
+
+rm -rf "${build_dir}"
+
+source ${src_dir}/.jenkins/lsu-test-coverage/env-${configuration_name}.sh
+
+ulimit -l unlimited
+
+set +e
+
+# Configure
+cmake \
+    -S ${src_dir}   \
+    -B ${build_dir} \
+     -G "Ninja" \
+    -DCMAKE_BUILD_TYPE=Debug \
+    -DHPX_WITH_CXX_STANDARD=20 \
+    -DHPX_WITH_MALLOC=system \
+    -DHPX_WITH_FETCH_ASIO=ON \
+    -DHPX_WITH_PARCELPORT_MPI=ON \
+    -DHPX_WITH_PARCELPORT_LCI=ON \
+    -DHPX_WITH_FETCH_LCI=ON \
+    -DCMAKE_CXX_FLAGS="-O0 --coverage" \
+    -DCMAKE_EXE_LINKER_FLAGS=--coverage 
+
+
+# Build
+cmake --build ${build_dir} --target tests examples
+
+# Run tests
+ctest --test-dir ${build_dir} --output-on-failure
+ctest_status=$?
+
+
+# Tests are finished; Collect coverage data
+./grcov . -s ${src_dir} -o lcov.info -t lcov --log "grcov-log.txt" --ignore-not-existing --ignore "/*"
+
+# Upload to Codacy
+bash <(curl -Ls https://coverage.codacy.com/get.sh) report -r lcov.info --language CPP -t ${CODACY_TOKEN} --commit-uuid ${ghprbActualCommit}
+
+echo "${ctest_status}" > "jenkins-hpx-${configuration_name}-ctest-status.txt"
+exit $ctest_status

--- a/.jenkins/lsu-test-coverage/entry.sh
+++ b/.jenkins/lsu-test-coverage/entry.sh
@@ -1,0 +1,69 @@
+#!/bin/bash -l
+
+# Copyright (c) 2020 ETH Zurich
+# Copyright (c) 2022 Hartmut Kaiser
+# Copyright (c) 2023 Panos Syskakis
+#
+# SPDX-License-Identifier: BSL-1.0
+# Distributed under the Boost Software License, Version 1.0. (See accompanying
+# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+# Make undefined variables errors, print each command
+set -eux
+
+# Clean up old artifacts
+rm -f ./jenkins-hpx* ./grcov-log.txt
+
+source .jenkins/lsu-test-coverage/slurm-constraint-${configuration_name}.sh
+
+if [[ -z "${ghprbPullId:-}" ]]; then
+    # Set name of branch if not building a pull request
+    export git_local_branch=$(echo ${GIT_BRANCH} | cut -f2 -d'/')
+    job_name="jenkins-hpx-${git_local_branch}-${configuration_name}"
+else
+    job_name="jenkins-hpx-${ghprbPullId}-${configuration_name}"
+
+    # Cancel currently running builds on the same branch, but only for pull
+    # requests
+    scancel  --verbose --verbose --verbose --verbose --jobname="${job_name}"
+fi
+
+# delay things for a random amount of time
+sleep $[(RANDOM % 10) + 1].$[(RANDOM % 10)]s
+
+# Fetch grcov
+wget https://github.com/mozilla/grcov/releases/download/v0.8.2/grcov-linux-x86_64.tar.bz2 -O grcov.tar.bz2 \
+&& echo "32e40a984cb7ed3a60760e26071618370f10fdce2186916e7321f1dd01a6d0fd grcov.tar.bz2" | sha256sum --check --status \
+&& tar -jxf grcov.tar.bz2 \
+&& rm grcov.tar.bz2
+
+if [ ! -e "grcov" ]; then
+    echo "Error: Failed to fetch grcov."
+    exit 1
+fi
+
+# Start the actual build
+set +e
+sbatch \
+    --verbose --verbose --verbose --verbose \
+    --job-name="${job_name}" \
+    --nodes="1" \
+    --partition="${configuration_slurm_partition}" \
+    --time="05:00:00" \
+    --output="jenkins-hpx-${configuration_name}.out" \
+    --error="jenkins-hpx-${configuration_name}.err" \
+    --wait .jenkins/lsu-test-coverage/batch.sh
+
+
+# Print slurm logs
+echo "= stdout =================================================="
+cat jenkins-hpx-${configuration_name}.out
+
+echo "= stderr =================================================="
+cat jenkins-hpx-${configuration_name}.err
+
+# Get build status
+status_file="jenkins-hpx-${configuration_name}-ctest-status.txt"
+
+set -e
+exit $(cat ${status_file})

--- a/.jenkins/lsu-test-coverage/env-test-coverage.sh
+++ b/.jenkins/lsu-test-coverage/env-test-coverage.sh
@@ -1,0 +1,14 @@
+# Copyright (c) 2023 Panos Syskakis
+#
+# SPDX-License-Identifier: BSL-1.0
+# Distributed under the Boost Software License, Version 1.0. (See accompanying
+# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+set -eu
+
+module avail
+module purge
+module load cmake
+module load gcc/12
+module load boost/1.79.0-debug
+module load hwloc
+module load openmpi

--- a/.jenkins/lsu-test-coverage/slurm-constraint-test-coverage.sh
+++ b/.jenkins/lsu-test-coverage/slurm-constraint-test-coverage.sh
@@ -1,0 +1,7 @@
+# Copyright (c) 2023 Panos Syskakis
+#
+# SPDX-License-Identifier: BSL-1.0
+# Distributed under the Boost Software License, Version 1.0. (See accompanying
+# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+configuration_slurm_partition="jenkins-compute"

--- a/README.rst
+++ b/README.rst
@@ -5,7 +5,7 @@
     Distributed under the Boost Software License, Version 1.0. (See accompanying
     file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-|circleci_status| |codacy| |coveralls| |OpenSSF| |CFF| |JOSS| |zenodo_doi|
+|circleci_status| |codacy_quality| |codacy_coverage| |OpenSSF| |CFF| |JOSS| |zenodo_doi|
 
 Documentation: `latest
 <https://hpx-docs.stellar-group.org/latest/html/index.html>`_,
@@ -98,8 +98,8 @@ continuous integration service additionally tracks the current build status for
 the master branch: |circleci_status|.
 
 We use `Codacy <https://www.codacy.com/>`_ to assess the code quality of this
-project: |codacy|. For our coverage analysis we rely on
-`Coveralls <https://coveralls.io/>`_ to present the results: |coveralls|.
+project: |codacy_quality|. For our coverage analysis, we also rely on
+Codacy to present the results: |codacy_coverage|.
 
 If you can't find what you are looking for in the documentation or you suspect
 you've found a bug in HPX we very much encourage and appreciate any issue
@@ -151,12 +151,12 @@ Past and current funding and support for HPX is listed `here
      :target: https://doi.org/10.5281/zenodo.598202
      :alt: Latest software release of HPX
 
-.. |codacy| image:: https://app.codacy.com/project/badge/Grade/0b8cd5a874914edaba67ce3bb711e688
+.. |codacy_quality| image:: https://app.codacy.com/project/badge/Grade/0b8cd5a874914edaba67ce3bb711e688
      :target: https://app.codacy.com/gh/STEllAR-GROUP/hpx/dashboard
      :alt: HPX Code Quality Assessment
 
-.. |coveralls| image:: https://coveralls.io/repos/github/STEllAR-GROUP/hpx/badge.svg
-     :target: https://coveralls.io/github/STEllAR-GROUP/hpx
+.. |codacy_coverage| image:: https://app.codacy.com/project/badge/Coverage/0b8cd5a874914edaba67ce3bb711e688    
+     :target: https://app.codacy.com/gh/STEllAR-GROUP/hpx/dashboard
      :alt: HPX coverage report
 
 .. |JOSS| image:: https://joss.theoj.org/papers/022e5917b95517dff20cd3742ab95eca/status.svg


### PR DESCRIPTION
Runs coverage tests on Jenkins, and uploads results to Codacy.
Relies on fetching `grcov` utility.  