### PR TITLE
Fix shared_future_continuation_order regression test

### DIFF
--- a/libs/core/futures/tests/regressions/shared_future_continuation_order.cpp
+++ b/libs/core/futures/tests/regressions/shared_future_continuation_order.cpp
@@ -21,15 +21,17 @@ int hpx_main()
     hpx::promise<int> p;
     hpx::shared_future<int> f1 = p.get_future();
 
-    hpx::future<int> f2 = f1.then([](hpx::shared_future<int>&& f) {
-        HPX_TEST_EQ(f.get(), 42);
-        return ++invocation_count;
-    });
+    hpx::future<int> f2 =
+        f1.then(hpx::launch::sync, [](hpx::shared_future<int>&& f) {
+            HPX_TEST_EQ(f.get(), 42);
+            return ++invocation_count;
+        });
 
-    hpx::future<int> f3 = f1.then([](hpx::shared_future<int>&& f) {
-        HPX_TEST_EQ(f.get(), 42);
-        return ++invocation_count;
-    });
+    hpx::future<int> f3 =
+        f1.then(hpx::launch::sync, [](hpx::shared_future<int>&& f) {
+            HPX_TEST_EQ(f.get(), 42);
+            return ++invocation_count;
+        });
 
     p.set_value(42);
 


### PR DESCRIPTION
Fixes occasional failure of shared_future_continuation_order regression test.
If my understanding is correct, continuations are executed on newly spawned threads by default, which would not guarantee their order of execution. Launching with hpx::launch::sync should guarantee that no new thread is spawned, thus they are executed in sequence.
(@hkaiser We had fixed this in some PR in the past, but it seems it didn't make it into master)