### PR TITLE
Moving hpx::threads::run_as_xxx to namespace hpx

### DIFF
--- a/components/process/src/server/child_component.cpp
+++ b/components/process/src/server/child_component.cpp
@@ -34,7 +34,7 @@ namespace hpx { namespace components { namespace process { namespace server
     {
         int (*f)(process::util::child const&) =
             &process::util::wait_for_exit<process::util::child>;
-        return hpx::threads::run_as_os_thread(f, std::ref(child_)).get();
+        return hpx::run_as_os_thread(f, std::ref(child_)).get();
     }
 }}}}
 

--- a/examples/quickstart/init_globally.cpp
+++ b/examples/quickstart/init_globally.cpp
@@ -270,12 +270,12 @@ void thread_func()
 
     // Create an HPX thread (returning an int) and wait for it to run to
     // completion.
-    int result = hpx::threads::run_as_hpx_thread(&hpx_thread_func2, 42);
+    int result = hpx::run_as_hpx_thread(&hpx_thread_func2, 42);
 
     // Create an HPX thread (returning void) and wait for it to run to
     // completion.
     if (result == 42)
-        hpx::threads::run_as_hpx_thread(&hpx_thread_func1);
+        hpx::run_as_hpx_thread(&hpx_thread_func1);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -286,7 +286,7 @@ int main()
 
     // The main thread was automatically registered with the HPX runtime,
     // no explicit registration for this thread is necessary.
-    hpx::threads::run_as_hpx_thread(&hpx_thread_func1);
+    hpx::run_as_hpx_thread(&hpx_thread_func1);
 
     // wait for the (kernel) thread to run to completion
     t.join();

--- a/libs/core/runtime_local/include/hpx/runtime_local/run_as_hpx_thread.hpp
+++ b/libs/core/runtime_local/include/hpx/runtime_local/run_as_hpx_thread.hpp
@@ -26,7 +26,8 @@
 #include <type_traits>
 #include <utility>
 
-namespace hpx { namespace threads {
+namespace hpx {
+
     ///////////////////////////////////////////////////////////////////////////
     namespace detail {
         // This is the overload for running functions which return a value.
@@ -148,4 +149,17 @@ namespace hpx { namespace threads {
         return detail::run_as_hpx_thread(
             result_is_void(), f, HPX_FORWARD(Ts, vs)...);
     }
-}}    // namespace hpx::threads
+}    // namespace hpx
+
+namespace hpx::threads {
+
+    template <typename F, typename... Ts>
+    HPX_DEPRECATED_V(1, 10,
+        "hpx::threads::run_as_hpx_thread is deprecated, use "
+        "hpx::run_as_hpx_thread instead")
+    decltype(auto) run_as_hpx_thread(F const& f, Ts&&... ts)
+    {
+        return hpx::run_as_hpx_thread(
+            HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...);
+    }
+}    // namespace hpx::threads

--- a/libs/core/runtime_local/include/hpx/runtime_local/run_as_os_thread.hpp
+++ b/libs/core/runtime_local/include/hpx/runtime_local/run_as_os_thread.hpp
@@ -16,17 +16,30 @@
 #include <type_traits>
 #include <utility>
 
-namespace hpx { namespace threads {
+namespace hpx {
+
     ///////////////////////////////////////////////////////////////////////////
     template <typename F, typename... Ts>
-    hpx::future<typename util::invoke_result<F, Ts...>::type> run_as_os_thread(
+    hpx::future<util::invoke_result_t<F, Ts...>> run_as_os_thread(
         F&& f, Ts&&... vs)
     {
-        HPX_ASSERT(get_self_ptr() != nullptr);
+        HPX_ASSERT(threads::get_self_ptr() != nullptr);
 
         parallel::execution::io_pool_executor executor;
         auto result = parallel::execution::async_execute(
             executor, HPX_FORWARD(F, f), HPX_FORWARD(Ts, vs)...);
         return result;
     }
-}}    // namespace hpx::threads
+}    // namespace hpx
+
+namespace hpx::threads {
+
+    template <typename F, typename... Ts>
+    HPX_DEPRECATED_V(1, 10,
+        "hpx::threads::run_as_os_thread is deprecated, use "
+        "hpx::run_as_os_thread instead")
+    decltype(auto) run_as_os_thread(F const& f, Ts&&... ts)
+    {
+        return hpx::run_as_os_thread(HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...);
+    }
+}    // namespace hpx::threads

--- a/libs/full/collectives/src/barrier.cpp
+++ b/libs/full/collectives/src/barrier.cpp
@@ -139,7 +139,7 @@ namespace hpx { namespace distributed {
                 // make sure this runs as an HPX thread
                 if (hpx::threads::get_self_ptr() == nullptr)
                 {
-                    hpx::threads::run_as_hpx_thread(&barrier::release, this);
+                    hpx::run_as_hpx_thread(&barrier::release, this);
                 }
 
                 hpx::future<void> f;

--- a/tests/regressions/threads/run_as_hpx_thread_exceptions_3304.cpp
+++ b/tests/regressions/threads/run_as_hpx_thread_exceptions_3304.cpp
@@ -65,7 +65,7 @@ int main(int argc, char** argv)
     bool exception_caught = false;
     try
     {
-        hpx::threads::run_as_hpx_thread(&hpx_thread_func);
+        hpx::run_as_hpx_thread(&hpx_thread_func);
         HPX_TEST(false);    // this should not be executed
     }
     catch (...)

--- a/tests/regressions/threads/run_as_os_thread_lockup_2991.cpp
+++ b/tests/regressions/threads/run_as_os_thread_lockup_2991.cpp
@@ -29,7 +29,7 @@ int hpx_main()
 
         std::cout << std::this_thread::get_id()
                   << ": about to run on io thread\n";
-        hpx::threads::run_as_os_thread(locker);
+        hpx::run_as_os_thread(locker);
         //sleep(2);
     }
     std::cout << std::this_thread::get_id() << ": exiting\n";


### PR DESCRIPTION
- run_as_os_thread
- run_as_hpx_thread