### PR TITLE
Fixed matrix multiplication example output

### DIFF
--- a/docs/sphinx/examples/matrix_multiplication.rst
+++ b/docs/sphinx/examples/matrix_multiplication.rst
@@ -26,7 +26,7 @@ This program will perform a matrix multiplication in parallel. The output will l
 
    Resultant Matrix is :
    124 93
-   111 127
+   130 82
 
 Setup
 =====
@@ -73,7 +73,7 @@ This should print:
 
    Resultant Matrix is :
    124 93
-   111 127
+   130 82
 
 Notice that the numbers may be different because of the random initialization of the matrices.
 


### PR DESCRIPTION
Fixed the example output of the matrix multiplication. For the shown random inputs the output was incorrect.

## Proposed Changes

Adopt the correct result for the given example 

## Any background context you want to provide?

No big deal but we don't want to suggest that HPX produces wrong results, do we? The example code produces the correct result matrix after all.

