### PR TITLE
Replace Custom Benchmarking Code with Nanobench

### DIFF
--- a/libs/core/testing/CMakeLists.txt
+++ b/libs/core/testing/CMakeLists.txt
@@ -20,6 +20,22 @@ set(testing_compat_headers
 # Default location is $HPX_ROOT/libs/testing/src
 set(testing_sources testing.cpp performance.cpp)
 
+# specify C++ standard
+set(CMAKE_CXX_STANDARD 17)
+
+# include FetchContent module
+include(FetchContent)
+
+# fetch nanobench
+FetchContent_Declare(
+    nanobench
+    GIT_REPOSITORY https://github.com/martinus/nanobench.git
+    GIT_TAG v4.3.11
+    GIT_SHALLOW TRUE
+)
+
+FetchContent_MakeAvailable(nanobench)
+
 include(HPX_AddModule)
 add_hpx_module(
   core testing
@@ -28,6 +44,6 @@ add_hpx_module(
   HEADERS ${testing_headers}
   COMPAT_HEADERS ${testing_compat_headers}
   MODULE_DEPENDENCIES hpx_assertion hpx_config hpx_format hpx_functional
-                      hpx_preprocessor hpx_util
+                      hpx_preprocessor hpx_util nanobench
   CMAKE_SUBDIRS examples tests
 )

--- a/libs/core/testing/include/hpx/testing/performance.hpp
+++ b/libs/core/testing/include/hpx/testing/performance.hpp
@@ -10,6 +10,7 @@
 #include <hpx/functional/function.hpp>
 
 #include <cstddef>
+#include <iostream>
 #include <string>
 
 namespace hpx::util {
@@ -18,5 +19,8 @@ namespace hpx::util {
         std::string const& exec, std::size_t const steps,
         hpx::function<void()>&& test);
 
-    HPX_CORE_EXPORT void perftests_print_times();
+    // templ is a mustache-style template for the output
+    // used by the nanobench reporter
+    HPX_CORE_EXPORT void perftests_print_times(
+        std::ostream& strm = std::cout, char const* templ = nullptr);
 }    // namespace hpx::util


### PR DESCRIPTION
This Pull Request focuses on updating the benchmarks and performance testing functionality of HPX. This involves replacing the previous custom performance timing code with the [Nanobench](https://github.com/martinus/nanobench) library and incorporating the usage of Mustache templates for intuitive results formatting. 

The key benefits are:

- Easy parametrization of benchmark parameters.
- Standardized format of output json, directly compatible with [pyperf](https://github.com/psf/pyperf), and trivially customizable.