### PR TITLE
Fix CMake find_library for HWLOC

### DIFF
--- a/cmake/FindHwloc.cmake
+++ b/cmake/FindHwloc.cmake
@@ -35,7 +35,7 @@ if(NOT TARGET Hwloc::hwloc)
 
   find_library(
     Hwloc_LIBRARY
-    NAMES libhwloc.so hwloc
+    NAMES libhwloc.so libhwloc.lib hwloc
     HINTS ${Hwloc_ROOT}
           ENV
           HWLOC_ROOT


### PR DESCRIPTION
This fix makes find_library work properly for hwloc on my windows setup. 
It wouldn't work after the changes in this commit: https://github.com/STEllAR-GROUP/hpx/commit/4f676fe799d1da1215866c4efcead74edde890d7