### PR TITLE
Update the lci parcelport to use LCI v1.7.6

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1147,10 +1147,28 @@ if(HPX_WITH_NETWORKING)
     ADVANCED
   )
   hpx_option(
-    HPX_WITH_LCI_TAG STRING "LCI repository tag or branch" "v1.7.5"
+    HPX_WITH_LCI_TAG STRING "LCI repository tag or branch" "v1.7.6"
     CATEGORY "Build Targets"
     ADVANCED
   )
+  hpx_option(
+    HPX_WITH_PARCELPORT_LCI_LOG STRING
+    "Enable the LCI-parcelport-specific logger" OFF
+    CATEGORY "Parcelport"
+    ADVANCED
+  )
+  if(HPX_WITH_PARCELPORT_LCI_LOG)
+    hpx_add_config_define(HPX_HAVE_PARCELPORT_LCI_LOG)
+  endif()
+  hpx_option(
+    HPX_WITH_PARCELPORT_LCI_PCOUNTER STRING
+    "Enable the LCI-parcelport-specific performance counter" OFF
+    CATEGORY "Parcelport"
+    ADVANCED
+  )
+  if(HPX_WITH_PARCELPORT_LCI_PCOUNTER)
+    hpx_add_config_define(HPX_HAVE_PARCELPORT_LCI_PCOUNTER)
+  endif()
 
   hpx_option(
     HPX_WITH_PARCELPORT_TCP BOOL "Enable the TCP based parcelport." ON

--- a/cmake/HPX_SetupLCI.cmake
+++ b/cmake/HPX_SetupLCI.cmake
@@ -87,7 +87,7 @@ macro(hpx_setup_lci)
       endif()
 
       install(
-        TARGETS LCI lci-ucx
+        TARGETS LCI LCT lci-ucx
         EXPORT HPXLCITarget
         COMPONENT core
         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
@@ -95,7 +95,8 @@ macro(hpx_setup_lci)
       )
 
       install(
-        DIRECTORY ${lci_SOURCE_DIR}/src/api/ ${lci_BINARY_DIR}/src/api/
+        DIRECTORY ${lci_SOURCE_DIR}/lci/api/ ${lci_BINARY_DIR}/lci/api/
+                  ${lci_SOURCE_DIR}/lct/api/ ${lci_BINARY_DIR}/lct/api/
         DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
         COMPONENT core
         FILES_MATCHING
@@ -103,7 +104,7 @@ macro(hpx_setup_lci)
       )
 
       export(
-        TARGETS LCI lci-ucx
+        TARGETS LCI LCT lci-ucx
         NAMESPACE LCI::
         FILE "${CMAKE_CURRENT_BINARY_DIR}/lib/cmake/${HPX_PACKAGE_NAME}/HPXLCITarget.cmake"
       )

--- a/libs/core/lci_base/include/hpx/lci_base/lci_environment.hpp
+++ b/libs/core/lci_base/include/hpx/lci_base/lci_environment.hpp
@@ -42,22 +42,55 @@ namespace hpx { namespace util {
 
         static std::string get_processor_name();
 
-        // Configurations:
-        // Log level
+        // log
         enum class log_level_t
         {
             none,
             profile,
-            debug
+            debug,
         };
         static log_level_t log_level;
-        // Output filename of log
-        static FILE* log_outfile;
-        static void log(log_level_t level, const char* format, ...);
+#ifdef HPX_HAVE_PARCELPORT_LCI_LOG
+        static LCT_log_ctx_t log_ctx;
+#endif
+        static void log(
+            log_level_t level, const char* tag, const char* format, ...);
+        // performance counter
+// clang-format off
+#define HPX_LCI_PCOUNTER_NONE_FOR_EACH(_macro)
 
-    private:
-        static bool enabled_;
-    };
+#define HPX_LCI_PCOUNTER_TREND_FOR_EACH(_macro) \
+    _macro(send_conn_start)                  \
+    _macro(send_conn_end)                    \
+    _macro(recv_conn_start)                  \
+    _macro(recv_conn_end)
+
+#define HPX_LCI_PCOUNTER_TIMER_FOR_EACH(_macro) \
+    _macro(send_conn_timer)                       \
+    _macro(recv_conn_timer)                       \
+    _macro(async_write_timer)                       \
+    _macro(send_timer)                       \
+    _macro(handle_parcels)                    \
+    _macro(poll_comp)                        \
+    _macro(useful_bg_work)
+            // clang-format on
+
+#define HPX_LCI_PCOUNTER_HANDLE_DECL(name) static LCT_pcounter_handle_t name;
+
+            HPX_LCI_PCOUNTER_NONE_FOR_EACH(HPX_LCI_PCOUNTER_HANDLE_DECL)
+            HPX_LCI_PCOUNTER_TREND_FOR_EACH(HPX_LCI_PCOUNTER_HANDLE_DECL)
+            HPX_LCI_PCOUNTER_TIMER_FOR_EACH(HPX_LCI_PCOUNTER_HANDLE_DECL)
+
+            static LCT_pcounter_ctx_t pcounter_ctx;
+            static int64_t pcounter_now();
+            static int64_t pcounter_since(int64_t then);
+            static void pcounter_add(LCT_pcounter_handle_t handle, int64_t val);
+            static void pcounter_start(LCT_pcounter_handle_t handle);
+            static void pcounter_end(LCT_pcounter_handle_t handle);
+
+        private:
+            static bool enabled_;
+        };
 }}    // namespace hpx::util
 
 #include <hpx/config/warnings_suffix.hpp>

--- a/libs/core/lci_base/src/lci_environment.cpp
+++ b/libs/core/lci_base/src/lci_environment.cpp
@@ -91,60 +91,19 @@ namespace hpx { namespace util {
     defined(HPX_HAVE_MODULE_LCI_BASE)
 
 namespace hpx { namespace util {
-
     bool lci_environment::enabled_ = false;
-    lci_environment::log_level_t lci_environment::log_level = log_level_t::none;
-    FILE* lci_environment::log_outfile = nullptr;
+    lci_environment::log_level_t lci_environment::log_level;
+#ifdef HPX_HAVE_PARCELPORT_LCI_LOG
+    LCT_log_ctx_t lci_environment::log_ctx;
+#endif
+    LCT_pcounter_ctx_t lci_environment::pcounter_ctx;
 
-    ///////////////////////////////////////////////////////////////////////////
-    void lci_environment::init_config(util::runtime_configuration& rtcfg)
-    {
-        // The default value here does not matter here
-        std::string log_level_str = get_entry_as<std::string>(
-            rtcfg, "hpx.parcel.lci.log_level", "" /* Does not matter*/);
-        if (log_level_str == "none")
-            log_level = log_level_t::none;
-        else if (log_level_str == "profile")
-            log_level = log_level_t::profile;
-        else if (log_level_str == "debug")
-            log_level = log_level_t::debug;
-        else
-            throw std::runtime_error("Unknown log level " + log_level_str);
-        std::string log_filename = get_entry_as<std::string>(
-            rtcfg, "hpx.parcel.lci.log_outfile", "" /* Does not matter*/);
-        if (log_filename == "stderr")
-            log_outfile = stderr;
-        else if (log_filename == "stdout")
-            log_outfile = stdout;
-        else
-        {
-            const int filename_max = 256;
-            char filename[filename_max];
-            char* p0_old = log_filename.data();
-            char* p0_new = strchr(log_filename.data(), '%');
-            char* p1 = filename;
-            while (p0_new)
-            {
-                long nbytes = p0_new - p0_old;
-                HPX_ASSERT(p1 + nbytes < filename + filename_max);
-                memcpy(p1, p0_old, nbytes);
-                p1 += nbytes;
-                nbytes =
-                    snprintf(p1, filename + filename_max - p1, "%d", LCI_RANK);
-                p1 += nbytes;
-                p0_old = p0_new + 1;
-                p0_new = strchr(p0_old, '%');
-            }
-            strncat(p1, p0_old, filename + filename_max - p1 - 1);
-            log_outfile = fopen(filename, "w+");
-            if (log_outfile == nullptr)
-            {
-                throw std::runtime_error(
-                    "Cannot open the logfile " + std::string(filename));
-            }
-        }
-    }
+#define HPX_LCI_PCOUNTER_HANDLE_DEF(name)                                      \
+    LCT_pcounter_handle_t lci_environment::name;
 
+    HPX_LCI_PCOUNTER_NONE_FOR_EACH(HPX_LCI_PCOUNTER_HANDLE_DEF)
+    HPX_LCI_PCOUNTER_TREND_FOR_EACH(HPX_LCI_PCOUNTER_HANDLE_DEF)
+    HPX_LCI_PCOUNTER_TIMER_FOR_EACH(HPX_LCI_PCOUNTER_HANDLE_DEF)
     ///////////////////////////////////////////////////////////////////////////
     void lci_environment::init(
         int*, char***, util::runtime_configuration& rtcfg)
@@ -186,7 +145,34 @@ namespace hpx { namespace util {
 
         rtcfg.add_entry("hpx.parcel.bootstrap", "lci");
         rtcfg.add_entry("hpx.parcel.lci.rank", std::to_string(this_rank));
-        init_config(rtcfg);
+        LCT_init();
+        // initialize the log context
+#ifdef HPX_HAVE_PARCELPORT_LCI_LOG
+        const char* const log_levels[] = {"none", "profile", "debug"};
+        log_ctx = LCT_log_ctx_alloc(log_levels,
+            sizeof(log_levels) / sizeof(log_levels[0]), 0, "hpx_lci",
+            getenv("HPX_LCI_LOG_OUTFILE"), getenv("HPX_LCI_LOG_LEVEL"),
+            getenv("HPX_LCI_LOG_WHITELIST"), getenv("HPX_LCI_LOG_BLACKLIST"));
+        log_level = static_cast<log_level_t>(LCT_log_get_level(log_ctx));
+#else
+        log_level = log_level_t::none;
+#endif
+#ifdef HPX_HAVE_PARCELPORT_LCI_PCOUNTER
+        // initialize the performance counters
+        pcounter_ctx = LCT_pcounter_ctx_alloc("hpx-lci");
+
+#define HPX_LCI_PCOUNTER_NONE_REGISTER(name)                                   \
+    name = LCT_pcounter_register(pcounter_ctx, #name, LCT_PCOUNTER_NONE);
+        HPX_LCI_PCOUNTER_NONE_FOR_EACH(HPX_LCI_PCOUNTER_NONE_REGISTER)
+
+#define HPX_LCI_PCOUNTER_TREND_REGISTER(name)                                  \
+    name = LCT_pcounter_register(pcounter_ctx, #name, LCT_PCOUNTER_TREND);
+        HPX_LCI_PCOUNTER_TREND_FOR_EACH(HPX_LCI_PCOUNTER_TREND_REGISTER)
+
+#define HPX_LCI_PCOUNTER_TIMER_REGISTER(name)                                  \
+    name = LCT_pcounter_register(pcounter_ctx, #name, LCT_PCOUNTER_TIMER);
+        HPX_LCI_PCOUNTER_TIMER_FOR_EACH(HPX_LCI_PCOUNTER_TIMER_REGISTER)
+#endif
         enabled_ = true;
     }
 
@@ -200,7 +186,13 @@ namespace hpx { namespace util {
         if (enabled())
         {
             enabled_ = false;
-            // for some reasons, this code block can be entered twice when HPX exits
+#ifdef HPX_HAVE_PARCELPORT_LCI_PCOUNTER
+            LCT_pcounter_ctx_free(&pcounter_ctx);
+#endif
+#ifdef HPX_HAVE_PARCELPORT_LCI_LOG
+            LCT_log_ctx_free(&log_ctx);
+#endif
+            LCT_fina();
             int lci_init = 0;
             LCI_initialized(&lci_init);
             if (lci_init)
@@ -240,17 +232,63 @@ namespace hpx { namespace util {
         return res;
     }
 
-    void lci_environment::log(
-        lci_environment::log_level_t level, const char* format, ...)
+    void lci_environment::log([[maybe_unused]] log_level_t level,
+        [[maybe_unused]] const char* tag, [[maybe_unused]] const char* format,
+        ...)
     {
+#ifdef HPX_HAVE_PARCELPORT_LCI_LOG
+        if (level > log_level)
+            return;
         va_list args;
         va_start(args, format);
 
-        if (level <= log_level)
-            vfprintf(log_outfile, format, args);
+        LCT_Logv(log_ctx, static_cast<int>(level), tag, format, args);
 
         va_end(args);
+#endif
     }
+
+    int64_t lci_environment::pcounter_now()
+    {
+#ifdef HPX_HAVE_PARCELPORT_LCI_PCOUNTER
+        return static_cast<int64_t>(LCT_now());
+#endif
+        return 0;
+    }
+
+    int64_t lci_environment::pcounter_since([[maybe_unused]] int64_t then)
+    {
+#ifdef HPX_HAVE_PARCELPORT_LCI_PCOUNTER
+        return static_cast<int64_t>(LCT_now()) - then;
+#endif
+        return 0;
+    }
+
+    void lci_environment::pcounter_add(
+        [[maybe_unused]] LCT_pcounter_handle_t handle,
+        [[maybe_unused]] int64_t val)
+    {
+#ifdef HPX_HAVE_PARCELPORT_LCI_PCOUNTER
+        LCT_pcounter_add(pcounter_ctx, handle, val);
+#endif
+    }
+
+    void lci_environment::pcounter_start(
+        [[maybe_unused]] LCT_pcounter_handle_t handle)
+    {
+#ifdef HPX_HAVE_PARCELPORT_LCI_PCOUNTER
+        LCT_pcounter_start(pcounter_ctx, handle);
+#endif
+    }
+
+    void lci_environment::pcounter_end(
+        [[maybe_unused]] LCT_pcounter_handle_t handle)
+    {
+#ifdef HPX_HAVE_PARCELPORT_LCI_PCOUNTER
+        LCT_pcounter_end(pcounter_ctx, handle);
+#endif
+    }
+
 }}    // namespace hpx::util
 
 #endif

--- a/libs/full/parcelport_lci/include/hpx/parcelport_lci/completion_manager/completion_manager_queue.hpp
+++ b/libs/full/parcelport_lci/include/hpx/parcelport_lci/completion_manager/completion_manager_queue.hpp
@@ -17,7 +17,10 @@ namespace hpx::parcelset::policies::lci {
     {
         completion_manager_queue()
         {
-            LCI_queue_create(LCI_UR_DEVICE, &queue);
+            // LCI_queue_create(LCI_UR_DEVICE, &queue);
+            // Hack for now
+            LCI_queue_createx(LCI_UR_DEVICE,
+                LCI_SERVER_NUM_PKTS * (size_t) config_t::ndevices, &queue);
         }
 
         ~completion_manager_queue()

--- a/libs/full/parcelport_lci/include/hpx/parcelport_lci/config.hpp
+++ b/libs/full/parcelport_lci/include/hpx/parcelport_lci/config.hpp
@@ -45,6 +45,12 @@ namespace hpx::parcelset::policies::lci {
         // How many pre-posted receives for new messages
         // (can only be applied to `sendrecv` protocol).
         static int prepost_recv_num;
+        // Whether to register the buffer in HPX (or rely on LCI to register it)
+        static bool reg_mem;
+        // How many devices to use
+        static int ndevices;
+        // How many completion managers to use
+        static int ncomps;
 
         static void init_config(util::runtime_configuration const& rtcfg);
     };

--- a/libs/full/parcelport_lci/include/hpx/parcelport_lci/header.hpp
+++ b/libs/full/parcelport_lci/include/hpx/parcelport_lci/header.hpp
@@ -28,23 +28,25 @@ namespace hpx::parcelset::policies::lci {
         {
             // siguature for assert_valid
             pos_signature = 0,
+            // device idx
+            pos_device_idx = 1 * sizeof(value_type),
             // tag
-            pos_tag = 1 * sizeof(value_type),
+            pos_tag = 2 * sizeof(value_type),
             // non-zero-copy chunk size
-            pos_numbytes_nonzero_copy = 2 * sizeof(value_type),
+            pos_numbytes_nonzero_copy = 3 * sizeof(value_type),
             // transmission chunk size
-            pos_numbytes_tchunk = 3 * sizeof(value_type),
+            pos_numbytes_tchunk = 4 * sizeof(value_type),
             // how many bytes in total (including zero-copy and non-zero-copy chunks)
-            pos_numbytes = 4 * sizeof(value_type),
+            pos_numbytes = 5 * sizeof(value_type),
             // zero-copy chunk number
-            pos_numchunks_zero_copy = 5 * sizeof(value_type),
+            pos_numchunks_zero_copy = 6 * sizeof(value_type),
             // non-zero-copy chunk number
-            pos_numchunks_nonzero_copy = 6 * sizeof(value_type),
+            pos_numchunks_nonzero_copy = 7 * sizeof(value_type),
             // whether piggyback data
-            pos_piggy_back_flag_data = 7 * sizeof(value_type),
+            pos_piggy_back_flag_data = 8 * sizeof(value_type),
             // whether piggyback transmission chunk
-            pos_piggy_back_flag_tchunk = 7 * sizeof(value_type) + 1,
-            pos_piggy_back_address = 7 * sizeof(value_type) + 2
+            pos_piggy_back_flag_tchunk = 8 * sizeof(value_type) + 1,
+            pos_piggy_back_address = 8 * sizeof(value_type) + 2
         };
 
         template <typename buffer_type, typename ChunkType>
@@ -131,6 +133,16 @@ namespace hpx::parcelset::policies::lci {
         value_type signature() const noexcept
         {
             return get<pos_signature>();
+        }
+
+        void set_device_idx(int device_idx) noexcept
+        {
+            set<pos_device_idx>(static_cast<value_type>(device_idx));
+        }
+
+        value_type get_device_idx() const noexcept
+        {
+            return get<pos_device_idx>();
         }
 
         void set_tag(LCI_tag_t tag) noexcept

--- a/libs/full/parcelport_lci/include/hpx/parcelport_lci/putva/sender_connection_putva.hpp
+++ b/libs/full/parcelport_lci/include/hpx/parcelport_lci/putva/sender_connection_putva.hpp
@@ -54,6 +54,8 @@ namespace hpx::parcelset::policies::lci {
         LCI_iovec_t iovec;
         std::shared_ptr<sender_connection_putva>*
             sharedPtr_p;    // for LCI_putva
+        // for profiling
+        LCT_time_t conn_start_time;
     };
 }    // namespace hpx::parcelset::policies::lci
 

--- a/libs/full/parcelport_lci/include/hpx/parcelport_lci/sender_connection_base.hpp
+++ b/libs/full/parcelport_lci/include/hpx/parcelport_lci/sender_connection_base.hpp
@@ -10,6 +10,7 @@
 
 #if defined(HPX_HAVE_NETWORKING) && defined(HPX_HAVE_PARCELPORT_LCI)
 
+#include <hpx/parcelport_lci/parcelport_lci.hpp>
 #include <hpx/parcelset/parcelport_connection.hpp>
 
 #include <cstddef>
@@ -52,6 +53,7 @@ namespace hpx::parcelset::policies::lci {
           : dst_rank(dst)
           , pp_((lci::parcelport*) pp)
           , there_(parcelset::locality(locality(dst_rank)))
+          , device_p(nullptr)
         {
         }
 
@@ -84,6 +86,7 @@ namespace hpx::parcelset::policies::lci {
         postprocess_handler_type postprocess_handler_;
         parcelport* pp_;
         parcelset::locality there_;
+        parcelport::device_t* device_p;
 #if defined(HPX_HAVE_PARCELPORT_COUNTERS)
         parcelset::data_point data_point_;
 #endif

--- a/libs/full/parcelport_lci/include/hpx/parcelport_lci/sendrecv/receiver_connection_sendrecv.hpp
+++ b/libs/full/parcelport_lci/include/hpx/parcelport_lci/sendrecv/receiver_connection_sendrecv.hpp
@@ -69,7 +69,12 @@ namespace hpx::parcelset::policies::lci {
         std::vector<parcelset::parcel> parcels_;
         std::vector<std::vector<char>> chunk_buffers_;
         parcelport* pp_;
+        parcelport::device_t* device_p;
         std::shared_ptr<receiver_connection_sendrecv>* sharedPtr_p;
+        // temporary data
+        LCI_segment_t segment_used;
+        // for profiling
+        LCT_time_t conn_start_time;
     };
 }    // namespace hpx::parcelset::policies::lci
 

--- a/libs/full/parcelport_lci/include/hpx/parcelport_lci/sendrecv/receiver_sendrecv.hpp
+++ b/libs/full/parcelport_lci/include/hpx/parcelport_lci/sendrecv/receiver_sendrecv.hpp
@@ -42,14 +42,19 @@ namespace hpx::parcelset::policies::lci {
         {
             if (config_t::protocol == config_t::protocol_t::sendrecv)
             {
-                for (int i = 0; i < config_t::prepost_recv_num; ++i)
+                for (std::size_t i = 0; i < pp_->devices.size(); ++i)
                 {
-                    LCI_comp_t completion =
-                        pp_->recv_new_completion_manager->alloc_completion();
-                    LCI_recvmn(pp_->endpoint_new, LCI_RANK_ANY, 0, completion,
-                        nullptr);
-                    pp_->recv_new_completion_manager->enqueue_completion(
-                        completion);
+                    auto& device = pp->devices[i];
+                    for (int j = 0; j < config_t::prepost_recv_num; ++j)
+                    {
+                        LCI_comp_t completion =
+                            device.completion_manager_p->recv_new
+                                ->alloc_completion();
+                        LCI_recvmn(device.endpoint_new, LCI_RANK_ANY, 0,
+                            completion, reinterpret_cast<void*>(i));
+                        device.completion_manager_p->recv_new
+                            ->enqueue_completion(completion);
+                    }
                 }
             }
         }

--- a/libs/full/parcelport_lci/include/hpx/parcelport_lci/sendrecv/sender_connection_sendrecv.hpp
+++ b/libs/full/parcelport_lci/include/hpx/parcelport_lci/sendrecv/sender_connection_sendrecv.hpp
@@ -63,6 +63,11 @@ namespace hpx::parcelset::policies::lci {
         LCI_tag_t tag;
         LCI_tag_t original_tag;
         std::shared_ptr<sender_connection_sendrecv>* sharedPtr_p;
+        // temporary data
+        LCI_comp_t completion;
+        LCI_segment_t segment_to_use, segment_used;
+        // for profiling
+        LCT_time_t conn_start_time;
 
         static std::atomic<int> next_tag;
     };

--- a/libs/full/parcelport_lci/src/config.cpp
+++ b/libs/full/parcelport_lci/src/config.cpp
@@ -25,6 +25,9 @@ namespace hpx::parcelset::policies::lci {
     config_t::progress_type_t config_t::progress_type;
     int config_t::progress_thread_num;
     int config_t::prepost_recv_num;
+    bool config_t::reg_mem;
+    int config_t::ndevices;
+    int config_t::ncomps;
 
     void config_t::init_config(util::runtime_configuration const& rtcfg)
     {
@@ -99,6 +102,9 @@ namespace hpx::parcelset::policies::lci {
             util::get_entry_as(rtcfg, "hpx.parcel.lci.prg_thread_num", -1);
         prepost_recv_num =
             util::get_entry_as(rtcfg, "hpx.parcel.lci.prepost_recv_num", 1);
+        reg_mem = util::get_entry_as(rtcfg, "hpx.parcel.lci.reg_mem", 1);
+        ndevices = util::get_entry_as(rtcfg, "hpx.parcel.lci.ndevices", 1);
+        ncomps = util::get_entry_as(rtcfg, "hpx.parcel.lci.ncomps", 1);
 
         if (!enable_send_immediate && enable_lci_backlog_queue)
         {
@@ -112,6 +118,25 @@ namespace hpx::parcelset::policies::lci {
         {
             progress_type = progress_type_t::pthread;
             fprintf(stderr, "WARNING: set progress_type to pthread!\n");
+        }
+#ifndef LCI_ENABLE_MULTITHREAD_PROGRESS
+        if (progress_type == progress_type_t::worker ||
+            progress_thread_num > ndevices)
+        {
+            fprintf(stderr,
+                "WARNING: Thread-safe LCI_progress is needed "
+                "but not enabled during compilation!\n");
+        }
+#endif
+        if (ncomps > ndevices)
+        {
+            int old_ncomps = ncomps;
+            ncomps = ndevices;
+            fprintf(stderr,
+                "WARNING: the number of completion managers (%d) "
+                "cannot exceed the number of devices (%d). "
+                "ncomps is adjusted accordingly (%d).",
+                old_ncomps, ndevices, ncomps);
         }
     }
 }    // namespace hpx::parcelset::policies::lci

--- a/libs/full/parcelport_lci/src/sender_base.cpp
+++ b/libs/full/parcelport_lci/src/sender_base.cpp
@@ -30,12 +30,15 @@ namespace hpx::parcelset::policies::lci {
     bool sender_base::background_work(size_t /* num_thread */) noexcept
     {
         bool did_some_work = false;
-        // try to accept a new connection
-        LCI_request_t request = pp_->send_completion_manager->poll();
-        //        LCI_queue_pop(util::lci_environment::get_scq(), &request);
+        auto poll_comp_start = util::lci_environment::pcounter_now();
+        auto completion_manager_p = pp_->get_tls_device().completion_manager_p;
+        LCI_request_t request = completion_manager_p->send->poll();
+        util::lci_environment::pcounter_add(util::lci_environment::poll_comp,
+            util::lci_environment::pcounter_since(poll_comp_start));
 
         if (request.flag == LCI_OK)
         {
+            auto useful_bg_start = util::lci_environment::pcounter_now();
             did_some_work = true;
             auto* sharedPtr_p = (connection_ptr*) request.user_context;
             sender_connection_base::return_t ret = (*sharedPtr_p)->send();
@@ -47,9 +50,11 @@ namespace hpx::parcelset::policies::lci {
             else if (ret.status ==
                 sender_connection_base::return_status_t::wait)
             {
-                pp_->send_completion_manager->enqueue_completion(
-                    ret.completion);
+                completion_manager_p->send->enqueue_completion(ret.completion);
             }
+            util::lci_environment::pcounter_add(
+                util::lci_environment::useful_bg_work,
+                util::lci_environment::pcounter_since(useful_bg_start));
         }
 
         return did_some_work;

--- a/libs/full/parcelport_lci/src/sender_connection_base.cpp
+++ b/libs/full/parcelport_lci/src/sender_connection_base.cpp
@@ -30,6 +30,9 @@ namespace hpx::parcelset::policies::lci {
         sender_connection_base::handler_type&& handler,
         sender_connection_base::postprocess_handler_type&& parcel_postprocess)
     {
+        LCT_time_t async_write_start_time =
+            util::lci_environment::pcounter_now();
+        device_p = &pp_->get_tls_device();
         load(HPX_FORWARD(handler_type, handler),
             HPX_FORWARD(postprocess_handler_type, parcel_postprocess));
         return_t ret = send();
@@ -39,53 +42,73 @@ namespace hpx::parcelset::policies::lci {
         }
         else if (ret.status == return_status_t::wait)
         {
-            pp_->send_completion_manager->enqueue_completion(ret.completion);
+            device_p->completion_manager_p->send->enqueue_completion(
+                ret.completion);
         }
+        util::lci_environment::pcounter_add(
+            util::lci_environment::async_write_timer,
+            util::lci_environment::pcounter_since(async_write_start_time));
     }
 
     sender_connection_base::return_t sender_connection_base::send()
     {
+        auto start_time = util::lci_environment::pcounter_now();
+        return_t ret;
+        const int retry_max_spin = 32;
         if (!config_t::enable_lci_backlog_queue ||
-            HPX_UNLIKELY(pp_->is_sending_early_parcel))
+            HPX_UNLIKELY(!pp_->is_initialized))
         {
             // If we are sending early parcels, we should not expect the
             // thread make progress on the backlog queue
-            return_t ret;
+            int retry_count = 0;
             do
             {
                 ret = send_nb();
-                if (ret.status == return_status_t::retry &&
-                    (config_t::progress_type ==
+                if (ret.status == return_status_t::retry)
+                {
+                    ++retry_count;
+                    if (retry_count > retry_max_spin)
+                    {
+                        retry_count = 0;
+                        while (pp_->background_work(
+                            -1, parcelport_background_mode_all))
+                            continue;
+                        hpx::this_thread::yield();
+                    }
+                    if (config_t::progress_type ==
                             config_t::progress_type_t::worker ||
                         config_t::progress_type ==
-                            config_t::progress_type_t::pthread_worker))
-                    while (pp_->do_progress())
-                        continue;
+                            config_t::progress_type_t::pthread_worker)
+                        while (pp_->do_progress_local())
+                            continue;
+                }
             } while (ret.status == return_status_t::retry);
-            return ret;
         }
         else
         {
             if (!backlog_queue::empty(dst_rank))
             {
                 backlog_queue::push(shared_from_this());
-                return {return_status_t::retry, nullptr};
-            }
-            return_t ret = send_nb();
-            if (ret.status == return_status_t::retry)
-            {
-                backlog_queue::push(shared_from_this());
-                return ret;
+                ret = {return_status_t::retry, nullptr};
             }
             else
             {
-                return ret;
+                ret = send_nb();
+                if (ret.status == return_status_t::retry)
+                {
+                    backlog_queue::push(shared_from_this());
+                }
             }
         }
+        util::lci_environment::pcounter_add(util::lci_environment::send_timer,
+            util::lci_environment::pcounter_since(start_time));
+        return ret;
     }
 
     void sender_connection_base::profile_start_hook(const header& header_)
     {
+        util::lci_environment::pcounter_add(
+            util::lci_environment::send_conn_start, 1);
         if (util::lci_environment::log_level <
             util::lci_environment::log_level_t::profile)
             return;
@@ -109,14 +132,16 @@ namespace hpx::parcelset::policies::lci {
         consumed += snprintf(buf + consumed, sizeof(buf) - consumed, "]\n");
         HPX_ASSERT(sizeof(buf) > consumed);
         util::lci_environment::log(
-            util::lci_environment::log_level_t::profile, "%s", buf);
+            util::lci_environment::log_level_t::profile, "send", "%s", buf);
     }
 
     void sender_connection_base::profile_end_hook()
     {
         util::lci_environment::log(util::lci_environment::log_level_t::profile,
-            "%d:%lf:send_connection(%p) end\n", LCI_RANK,
+            "send", "%d:%lf:send_connection(%p) end\n", LCI_RANK,
             hpx::chrono::high_resolution_clock::now() / 1e9, (void*) this);
+        util::lci_environment::pcounter_add(
+            util::lci_environment::send_conn_end, 1);
     }
 }    // namespace hpx::parcelset::policies::lci
 


### PR DESCRIPTION
The major changes include:
- Necessary changes to CMake files to accommodate changes due to the split of the original LCI library into two libraries (LCI and LCT).
- A new performance counters and logging infrastructure based on LCT (currently only applied to the lci pp).
  - Controlled by CMake variables `HPX_WITH_PARCELPORT_LCI_PCOUNTER` and `HPX_WITH_PARCELPORT_LCI_LOG`. The default is `OFF`.
- New LCI parcelport configurations:
  - `reg_mem`: whether to explicitly register memory buffers for long messages (value 1) or just let LCI register them on the fly (value 0). The default is 1.
  - `ndevices`: how many LCI devices (low-level network contexts) to use. The default is 2.
  - `ncomps`: how many completion managers to use. The default is 1.