### PR TITLE
improve one_size_heap_list: use rwlock to speedup the allocation/free

### DIFF
--- a/libs/core/algorithms/include/hpx/parallel/util/adapt_thread_priority.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/util/adapt_thread_priority.hpp
@@ -23,10 +23,9 @@ namespace hpx::parallel::util {
     decltype(auto) adapt_thread_priority(
         ExPolicy&& policy, hpx::threads::thread_priority new_priority)
     {
-        constexpr bool supports_priority =
-            hpx::functional::is_tag_invocable_v<
-                hpx::execution::experimental::with_priority_t,
-                std::decay_t<ExPolicy>, hpx::threads::thread_priority>;
+        constexpr bool supports_priority = hpx::functional::is_tag_invocable_v<
+            hpx::execution::experimental::with_priority_t,
+            std::decay_t<ExPolicy>, hpx::threads::thread_priority>;
 
         if constexpr (supports_priority)
         {

--- a/libs/core/lock_registration/include/hpx/lock_registration/detail/register_locks.hpp
+++ b/libs/core/lock_registration/include/hpx/lock_registration/detail/register_locks.hpp
@@ -139,7 +139,7 @@ namespace hpx::util {
 
     // The following functions are used to store the held locks information
     // during thread suspension. The data is stored on a thread_local basis,
-    // so we must make sure that locks the are being ignored are restored
+    // so we must make sure that locks that are being ignored are restored
     // after suspension even if the thread is being resumed on a different core.
 
     // retrieve the current thread_local data about held locks

--- a/libs/core/synchronization/include/hpx/synchronization/condition_variable.hpp
+++ b/libs/core/synchronization/include/hpx/synchronization/condition_variable.hpp
@@ -22,7 +22,6 @@
 #include <hpx/thread_support/assert_owns_lock.hpp>
 #include <hpx/thread_support/unlock_guard.hpp>
 #include <hpx/timing/steady_clock.hpp>
-#include <hpx/type_support/unused.hpp>
 
 #include <mutex>
 #include <utility>
@@ -158,7 +157,7 @@ namespace hpx {
         ///
         /// \returns \a notify_one returns \a void.
         ///
-        void notify_one(error_code& ec = throws)
+        void notify_one(error_code& ec = throws) const
         {
             std::unique_lock<mutex_type> l(data_->mtx_);
             data_->cond_.notify_one(HPX_MOVE(l), ec);
@@ -173,7 +172,7 @@ namespace hpx {
         ///
         /// \returns \a notify_all returns \a void.
         ///
-        void notify_all(error_code& ec = throws)
+        void notify_all(error_code& ec = throws) const
         {
             std::unique_lock<mutex_type> l(data_->mtx_);
             data_->cond_.notify_all(HPX_MOVE(l), ec);
@@ -214,8 +213,7 @@ namespace hpx {
 
             auto const data = data_;    // keep data alive
 
-            util::ignore_all_while_checking const ignore_lock;
-            HPX_UNUSED(ignore_lock);
+            [[maybe_unused]] util::ignore_all_while_checking const ignore_lock;
 
             std::unique_lock<mutex_type> l(data->mtx_);
             unlock_guard<std::unique_lock<Mutex>> unlock(lock);
@@ -321,8 +319,7 @@ namespace hpx {
 
             auto const data = data_;    // keep data alive
 
-            util::ignore_all_while_checking const ignore_lock;
-            HPX_UNUSED(ignore_lock);
+            [[maybe_unused]] util::ignore_all_while_checking const ignore_lock;
 
             std::unique_lock<mutex_type> l(data->mtx_);
             unlock_guard<std::unique_lock<Mutex>> unlock(lock);
@@ -620,7 +617,7 @@ namespace hpx {
         ///
         /// \returns \a notify_one returns \a void.
         ///
-        void notify_one(error_code& ec = throws)
+        void notify_one(error_code& ec = throws) const
         {
             std::unique_lock<mutex_type> l(data_->mtx_);
             data_->cond_.notify_one(HPX_MOVE(l), ec);
@@ -651,7 +648,7 @@ namespace hpx {
         ///
         /// \returns \a notify_all returns \a void.
         ///
-        void notify_all(error_code& ec = throws)
+        void notify_all(error_code& ec = throws) const
         {
             std::unique_lock<mutex_type> l(data_->mtx_);
             data_->cond_.notify_all(HPX_MOVE(l), ec);
@@ -702,8 +699,7 @@ namespace hpx {
 
             auto const data = data_;    // keep data alive
 
-            util::ignore_all_while_checking const ignore_lock;
-            HPX_UNUSED(ignore_lock);
+            [[maybe_unused]] util::ignore_all_while_checking const ignore_lock;
 
             std::unique_lock<mutex_type> l(data->mtx_);
             unlock_guard<Lock> unlock(lock);
@@ -819,8 +815,7 @@ namespace hpx {
 
             auto const data = data_;    // keep data alive
 
-            util::ignore_all_while_checking const ignore_lock;
-            HPX_UNUSED(ignore_lock);
+            [[maybe_unused]] util::ignore_all_while_checking const ignore_lock;
 
             std::unique_lock<mutex_type> l(data->mtx_);
             unlock_guard<Lock> unlock(lock);
@@ -1069,14 +1064,14 @@ namespace hpx {
 
             while (!pred())
             {
-                util::ignore_all_while_checking const ignore_lock;
-                HPX_UNUSED(ignore_lock);
+                [[maybe_unused]] util::ignore_all_while_checking const
+                    ignore_lock;
 
                 std::unique_lock<mutex_type> l(data->mtx_);
                 if (stoken.stop_requested())
                 {
                     // pred() has already evaluated to false since we last
-                    // a acquired lock
+                    // an acquired lock
                     return false;
                 }
 
@@ -1164,8 +1159,8 @@ namespace hpx {
             {
                 bool should_stop;
                 {
-                    util::ignore_all_while_checking const ignore_lock;
-                    HPX_UNUSED(ignore_lock);
+                    [[maybe_unused]] util::ignore_all_while_checking const
+                        ignore_lock;
 
                     std::unique_lock<mutex_type> l(data->mtx_);
                     if (stoken.stop_requested())

--- a/libs/core/synchronization/include/hpx/synchronization/detail/condition_variable.hpp
+++ b/libs/core/synchronization/include/hpx/synchronization/detail/condition_variable.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2022 Hartmut Kaiser
+//  Copyright (c) 2007-2023 Hartmut Kaiser
 //  Copyright (c) 2013-2015 Agustin Berge
 //
 //  SPDX-License-Identifier: BSL-1.0
@@ -55,17 +55,31 @@ namespace hpx::lcos::local::detail {
 
         // Return false if no more threads are waiting (returns true if queue is
         // non-empty).
-        HPX_CORE_EXPORT bool notify_one(std::unique_lock<mutex_type> lock,
-            threads::thread_priority priority, error_code& ec = throws);
+        HPX_CORE_EXPORT bool notify_one(std::unique_lock<mutex_type>& lock,
+            threads::thread_priority priority, bool unlock,
+            error_code& ec = throws);
 
         HPX_CORE_EXPORT void notify_all(std::unique_lock<mutex_type> lock,
             threads::thread_priority priority, error_code& ec = throws);
+
+        bool notify_one(std::unique_lock<mutex_type> lock,
+            threads::thread_priority priority, error_code& ec = throws)
+        {
+            return notify_one(lock, priority, true, ec);
+        }
 
         bool notify_one(
             std::unique_lock<mutex_type> lock, error_code& ec = throws)
         {
             return notify_one(
-                HPX_MOVE(lock), threads::thread_priority::default_, ec);
+                lock, threads::thread_priority::default_, true, ec);
+        }
+
+        bool notify_one_no_unlock(
+            std::unique_lock<mutex_type>& lock, error_code& ec = throws)
+        {
+            return notify_one(
+                lock, threads::thread_priority::default_, false, ec);
         }
 
         void notify_all(

--- a/libs/core/synchronization/include/hpx/synchronization/shared_mutex.hpp
+++ b/libs/core/synchronization/include/hpx/synchronization/shared_mutex.hpp
@@ -12,7 +12,8 @@
 
 #include <hpx/config.hpp>
 #include <hpx/concurrency/cache_line_data.hpp>
-#include <hpx/memory/intrusive_ptr.hpp>
+#include <hpx/lock_registration/detail/register_locks.hpp>
+#include <hpx/modules/memory.hpp>
 #include <hpx/synchronization/detail/condition_variable.hpp>
 #include <hpx/synchronization/spinlock.hpp>
 #include <hpx/thread_support/assert_owns_lock.hpp>
@@ -65,6 +66,7 @@ namespace hpx::detail {
 
         void release_waiters(std::unique_lock<mutex_type>& lk)
         {
+            [[maybe_unused]] util::ignore_while_checking il(&lk);
             exclusive_cond.notify_one_no_unlock(lk);
             shared_cond.notify_all(HPX_MOVE(lk));
         }

--- a/libs/core/synchronization/src/detail/condition_variable.cpp
+++ b/libs/core/synchronization/src/detail/condition_variable.cpp
@@ -108,8 +108,8 @@ namespace hpx::lcos::local::detail {
 
     // Return false if no more threads are waiting (returns true if queue
     // is non-empty).
-    bool condition_variable::notify_one(std::unique_lock<mutex_type> lock,
-        threads::thread_priority /* priority */, error_code& ec)
+    bool condition_variable::notify_one(std::unique_lock<mutex_type>& lock,
+        threads::thread_priority priority, bool unlock, error_code& ec)
     {
         // Caller failing to hold lock 'lock' before calling function
 #if defined(HPX_MSVC)
@@ -138,7 +138,8 @@ namespace hpx::lcos::local::detail {
             }
 
             bool const not_empty = !queue_.empty();
-            lock.unlock();
+            if (unlock)
+                lock.unlock();
 
             ctx.resume();
 
@@ -147,6 +148,9 @@ namespace hpx::lcos::local::detail {
 
         if (&ec != &throws)
             ec = make_success_code();
+
+        if (unlock)
+            lock.unlock();
 
         return false;
 

--- a/libs/core/synchronization/src/detail/condition_variable.cpp
+++ b/libs/core/synchronization/src/detail/condition_variable.cpp
@@ -109,7 +109,7 @@ namespace hpx::lcos::local::detail {
     // Return false if no more threads are waiting (returns true if queue
     // is non-empty).
     bool condition_variable::notify_one(std::unique_lock<mutex_type>& lock,
-        threads::thread_priority priority, bool unlock, error_code& ec)
+        threads::thread_priority /* priority */, bool unlock, error_code& ec)
     {
         // Caller failing to hold lock 'lock' before calling function
 #if defined(HPX_MSVC)

--- a/libs/core/synchronization/tests/unit/shared_mutex/shared_mutex1.cpp
+++ b/libs/core/synchronization/tests/unit/shared_mutex/shared_mutex1.cpp
@@ -31,24 +31,25 @@
 
 void test_multiple_readers()
 {
-    typedef hpx::shared_mutex shared_mutex_type;
-    typedef hpx::mutex mutex_type;
+    using shared_mutex_type = hpx::shared_mutex;
+    using mutex_type = hpx::mutex;
 
-    unsigned const number_of_threads = 10;
+    constexpr unsigned number_of_threads = 10;
 
     test::thread_group pool;
 
-    hpx::shared_mutex rw_mutex;
-    unsigned unblocked_count = 0;
-    unsigned simultaneous_running_count = 0;
     unsigned max_simultaneous_running = 0;
     mutex_type unblocked_count_mutex;
-    hpx::condition_variable unblocked_condition;
     mutex_type finish_mutex;
     std::unique_lock<mutex_type> finish_lock(finish_mutex);
 
     try
     {
+        hpx::shared_mutex rw_mutex;
+        unsigned unblocked_count = 0;
+        unsigned simultaneous_running_count = 0;
+        hpx::condition_variable unblocked_condition;
+
         for (unsigned i = 0; i != number_of_threads; ++i)
         {
             pool.create_thread(
@@ -86,24 +87,25 @@ void test_multiple_readers()
 
 void test_only_one_writer_permitted()
 {
-    typedef hpx::shared_mutex shared_mutex_type;
-    typedef hpx::mutex mutex_type;
+    using shared_mutex_type = hpx::shared_mutex;
+    using mutex_type = hpx::mutex;
 
-    unsigned const number_of_threads = 10;
+    constexpr unsigned number_of_threads = 10;
 
     test::thread_group pool;
 
-    hpx::shared_mutex rw_mutex;
     unsigned unblocked_count = 0;
-    unsigned simultaneous_running_count = 0;
     unsigned max_simultaneous_running = 0;
     mutex_type unblocked_count_mutex;
-    hpx::condition_variable unblocked_condition;
     mutex_type finish_mutex;
     std::unique_lock<mutex_type> finish_lock(finish_mutex);
 
     try
     {
+        hpx::shared_mutex rw_mutex;
+        unsigned simultaneous_running_count = 0;
+        hpx::condition_variable unblocked_condition;
+
         for (unsigned i = 0; i != number_of_threads; ++i)
         {
             pool.create_thread(
@@ -135,22 +137,23 @@ void test_only_one_writer_permitted()
 
 void test_reader_blocks_writer()
 {
-    typedef hpx::shared_mutex shared_mutex_type;
-    typedef hpx::mutex mutex_type;
+    using shared_mutex_type = hpx::shared_mutex;
+    using mutex_type = hpx::mutex;
 
     test::thread_group pool;
 
-    hpx::shared_mutex rw_mutex;
     unsigned unblocked_count = 0;
-    unsigned simultaneous_running_count = 0;
     unsigned max_simultaneous_running = 0;
     mutex_type unblocked_count_mutex;
-    hpx::condition_variable unblocked_condition;
     mutex_type finish_mutex;
     std::unique_lock<mutex_type> finish_lock(finish_mutex);
 
     try
     {
+        hpx::shared_mutex rw_mutex;
+        unsigned simultaneous_running_count = 0;
+        hpx::condition_variable unblocked_condition;
+
         pool.create_thread(
             test::locking_thread<std::shared_lock<shared_mutex_type>>(rw_mutex,
                 unblocked_count, unblocked_count_mutex, unblocked_condition,
@@ -195,25 +198,26 @@ void test_reader_blocks_writer()
 
 void test_unlocking_writer_unblocks_all_readers()
 {
-    typedef hpx::shared_mutex shared_mutex_type;
-    typedef hpx::mutex mutex_type;
+    using shared_mutex_type = hpx::shared_mutex;
+    using mutex_type = hpx::mutex;
 
     test::thread_group pool;
 
     hpx::shared_mutex rw_mutex;
     std::unique_lock<hpx::shared_mutex> write_lock(rw_mutex);
-    unsigned unblocked_count = 0;
-    unsigned simultaneous_running_count = 0;
     unsigned max_simultaneous_running = 0;
     mutex_type unblocked_count_mutex;
-    hpx::condition_variable unblocked_condition;
     mutex_type finish_mutex;
     std::unique_lock<mutex_type> finish_lock(finish_mutex);
 
-    unsigned const reader_count = 10;
+    constexpr unsigned reader_count = 10;
 
     try
     {
+        unsigned unblocked_count = 0;
+        unsigned simultaneous_running_count = 0;
+        hpx::condition_variable unblocked_condition;
+
         for (unsigned i = 0; i != reader_count; ++i)
         {
             pool.create_thread(
@@ -257,29 +261,30 @@ void test_unlocking_writer_unblocks_all_readers()
 
 void test_unlocking_last_reader_only_unblocks_one_writer()
 {
-    typedef hpx::shared_mutex shared_mutex_type;
-    typedef hpx::mutex mutex_type;
+    using shared_mutex_type = hpx::shared_mutex;
+    using mutex_type = hpx::mutex;
 
     test::thread_group pool;
 
-    hpx::shared_mutex rw_mutex;
     unsigned unblocked_count = 0;
-    unsigned simultaneous_running_readers = 0;
     unsigned max_simultaneous_readers = 0;
-    unsigned simultaneous_running_writers = 0;
     unsigned max_simultaneous_writers = 0;
     mutex_type unblocked_count_mutex;
-    hpx::condition_variable unblocked_condition;
     mutex_type finish_reading_mutex;
     std::unique_lock<mutex_type> finish_reading_lock(finish_reading_mutex);
     mutex_type finish_writing_mutex;
     std::unique_lock<mutex_type> finish_writing_lock(finish_writing_mutex);
 
-    unsigned const reader_count = 10;
-    unsigned const writer_count = 10;
+    constexpr unsigned reader_count = 10;
+    constexpr unsigned writer_count = 10;
 
     try
     {
+        hpx::shared_mutex rw_mutex;
+        unsigned simultaneous_running_readers = 0;
+        unsigned simultaneous_running_writers = 0;
+        hpx::condition_variable unblocked_condition;
+
         for (unsigned i = 0; i != reader_count; ++i)
         {
             pool.create_thread(
@@ -360,7 +365,7 @@ int hpx_main()
 
 int main(int argc, char* argv[])
 {
-    // By default this test should run on all available cores
+    // By default, this test should run on all available cores
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX

--- a/libs/core/synchronization/tests/unit/shared_mutex/shared_mutex2.cpp
+++ b/libs/core/synchronization/tests/unit/shared_mutex/shared_mutex2.cpp
@@ -1,5 +1,5 @@
 // (C) Copyright 2006-7 Anthony Williams
-//  Copyright (c) 2015-2022 Hartmut Kaiser
+//  Copyright (c) 2015-2023 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 // Distributed under the Boost Software License, Version 1.0. (See
@@ -29,24 +29,25 @@
 
 void test_only_one_upgrade_lock_permitted()
 {
-    typedef hpx::shared_mutex shared_mutex_type;
-    typedef hpx::mutex mutex_type;
+    using shared_mutex_type = hpx::shared_mutex;
+    using mutex_type = hpx::mutex;
 
-    unsigned const number_of_threads = 2;
+    constexpr unsigned number_of_threads = 2;
 
     test::thread_group pool;
 
-    shared_mutex_type rw_mutex;
     unsigned unblocked_count = 0;
-    unsigned simultaneous_running_count = 0;
     unsigned max_simultaneous_running = 0;
     mutex_type unblocked_count_mutex;
-    hpx::condition_variable unblocked_condition;
     mutex_type finish_mutex;
     std::unique_lock<mutex_type> finish_lock(finish_mutex);
 
     try
     {
+        shared_mutex_type rw_mutex;
+        unsigned simultaneous_running_count = 0;
+        hpx::condition_variable unblocked_condition;
+
         for (unsigned i = 0; i != number_of_threads; ++i)
         {
             pool.create_thread(
@@ -78,24 +79,25 @@ void test_only_one_upgrade_lock_permitted()
 
 void test_can_lock_upgrade_if_currently_locked_shared()
 {
-    typedef hpx::shared_mutex shared_mutex_type;
-    typedef hpx::mutex mutex_type;
+    using shared_mutex_type = hpx::shared_mutex;
+    using mutex_type = hpx::mutex;
 
     test::thread_group pool;
 
-    shared_mutex_type rw_mutex;
     unsigned unblocked_count = 0;
-    unsigned simultaneous_running_count = 0;
     unsigned max_simultaneous_running = 0;
     mutex_type unblocked_count_mutex;
-    hpx::condition_variable unblocked_condition;
     mutex_type finish_mutex;
     std::unique_lock<mutex_type> finish_lock(finish_mutex);
 
-    unsigned const reader_count = 10;
+    constexpr unsigned reader_count = 10;
 
     try
     {
+        shared_mutex_type rw_mutex;
+        unsigned simultaneous_running_count = 0;
+        hpx::condition_variable unblocked_condition;
+
         for (unsigned i = 0; i != reader_count; ++i)
         {
             pool.create_thread(
@@ -143,18 +145,18 @@ void test_can_lock_upgrade_if_currently_locked_shared()
 
 void test_can_lock_upgrade_to_unique_if_currently_locked_upgrade()
 {
-    typedef hpx::shared_mutex shared_mutex_type;
+    using shared_mutex_type = hpx::shared_mutex;
 
     shared_mutex_type mtx;
     hpx::upgrade_lock<shared_mutex_type> l(mtx);
-    hpx::upgrade_to_unique_lock<shared_mutex_type> ul(l);
+    hpx::upgrade_to_unique_lock<shared_mutex_type> const ul(l);
     HPX_TEST(ul.owns_lock());
 }
 
 void test_if_other_thread_has_write_lock_try_lock_shared_returns_false()
 {
-    typedef hpx::shared_mutex shared_mutex_type;
-    typedef hpx::mutex mutex_type;
+    using shared_mutex_type = hpx::shared_mutex;
+    using mutex_type = hpx::mutex;
 
     shared_mutex_type rw_mutex;
     mutex_type finish_mutex;
@@ -181,8 +183,8 @@ void test_if_other_thread_has_write_lock_try_lock_shared_returns_false()
 
 void test_if_other_thread_has_write_lock_try_lock_upgrade_returns_false()
 {
-    typedef hpx::shared_mutex shared_mutex_type;
-    typedef hpx::mutex mutex_type;
+    using shared_mutex_type = hpx::shared_mutex;
+    using mutex_type = hpx::mutex;
 
     shared_mutex_type rw_mutex;
     mutex_type finish_mutex;
@@ -209,7 +211,7 @@ void test_if_other_thread_has_write_lock_try_lock_upgrade_returns_false()
 
 void test_if_no_thread_has_lock_try_lock_shared_returns_true()
 {
-    typedef hpx::shared_mutex shared_mutex_type;
+    using shared_mutex_type = hpx::shared_mutex;
 
     shared_mutex_type rw_mutex;
     bool const try_succeeded = rw_mutex.try_lock_shared();
@@ -222,7 +224,7 @@ void test_if_no_thread_has_lock_try_lock_shared_returns_true()
 
 void test_if_no_thread_has_lock_try_lock_upgrade_returns_true()
 {
-    typedef hpx::shared_mutex shared_mutex_type;
+    using shared_mutex_type = hpx::shared_mutex;
 
     shared_mutex_type rw_mutex;
     bool const try_succeeded = rw_mutex.try_lock_upgrade();
@@ -235,8 +237,8 @@ void test_if_no_thread_has_lock_try_lock_upgrade_returns_true()
 
 void test_if_other_thread_has_shared_lock_try_lock_shared_returns_true()
 {
-    typedef hpx::shared_mutex shared_mutex_type;
-    typedef hpx::mutex mutex_type;
+    using shared_mutex_type = hpx::shared_mutex;
+    using mutex_type = hpx::mutex;
 
     shared_mutex_type rw_mutex;
     mutex_type finish_mutex;
@@ -263,8 +265,8 @@ void test_if_other_thread_has_shared_lock_try_lock_shared_returns_true()
 
 void test_if_other_thread_has_shared_lock_try_lock_upgrade_returns_true()
 {
-    typedef hpx::shared_mutex shared_mutex_type;
-    typedef hpx::mutex mutex_type;
+    using shared_mutex_type = hpx::shared_mutex;
+    using mutex_type = hpx::mutex;
 
     shared_mutex_type rw_mutex;
     mutex_type finish_mutex;
@@ -307,7 +309,7 @@ int hpx_main()
 
 int main(int argc, char* argv[])
 {
-    // By default this test should run on all available cores
+    // By default, this test should run on all available cores
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX

--- a/libs/core/synchronization/tests/unit/shared_mutex/shared_mutex_locking_thread.hpp
+++ b/libs/core/synchronization/tests/unit/shared_mutex/shared_mutex_locking_thread.hpp
@@ -1,5 +1,5 @@
 //  (C) Copyright 2008 Anthony Williams
-//  Copyright (c) 2015-2022 Hartmut Kaiser
+//  Copyright (c) 2015-2023 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See
@@ -45,7 +45,7 @@ namespace test {
         {
         }
 
-        void operator()()
+        void operator()() const
         {
             // acquire lock
             Lock lock(rw_mutex);
@@ -93,7 +93,7 @@ namespace test {
         {
         }
 
-        void operator()()
+        void operator()() const
         {
             std::unique_lock<hpx::shared_mutex> lk(rwm);
             {
@@ -124,7 +124,7 @@ namespace test {
         {
         }
 
-        void operator()()
+        void operator()() const
         {
             std::shared_lock<hpx::shared_mutex> lk(rwm);
             {

--- a/libs/core/synchronization/tests/unit/shared_mutex/thread_group.hpp
+++ b/libs/core/synchronization/tests/unit/shared_mutex/thread_group.hpp
@@ -1,5 +1,5 @@
 // (C) Copyright 2007-9 Anthony Williams
-// Copyright (c) 2015-2022 Hartmut Kaiser
+// Copyright (c) 2015-2023 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 // Distributed under the Boost Software License, Version 1.0. (See
@@ -27,10 +27,11 @@
 #endif
 
 namespace test {
+
     class thread_group
     {
     private:
-        typedef hpx::shared_mutex mutex_type;
+        using mutex_type = hpx::shared_mutex;
 
     public:
         thread_group() {}
@@ -40,16 +41,16 @@ namespace test {
 
         ~thread_group()
         {
-            for (hpx::thread* t : threads)
+            for (hpx::thread const* t : threads)
                 delete t;
         }
 
     private:
-        bool is_this_thread_in()
+        bool is_this_thread_in() const
         {
-            hpx::thread::id id = hpx::this_thread::get_id();
+            hpx::thread::id const id = hpx::this_thread::get_id();
             std::shared_lock<mutex_type> guard(mtx_);
-            for (hpx::thread* t : threads)
+            for (hpx::thread const* t : threads)
             {
                 if (t->get_id() == id)
                     return true;
@@ -57,14 +58,14 @@ namespace test {
             return false;
         }
 
-        bool is_thread_in(hpx::thread* thrd)
+        bool is_thread_in(hpx::thread const* thrd) const
         {
             if (!thrd)
                 return false;
 
-            hpx::thread::id id = thrd->get_id();
+            hpx::thread::id const id = thrd->get_id();
             std::shared_lock<mutex_type> guard(mtx_);
-            for (hpx::thread* t : threads)
+            for (hpx::thread const* t : threads)
             {
                 if (t->get_id() == id)
                     return true;
@@ -93,7 +94,6 @@ namespace test {
                         "thread_group::add_thread",
                         "resource_deadlock_would_occur: trying to add a "
                         "duplicated thread");
-                    return;
                 };
 
                 std::lock_guard<mutex_type> guard(mtx_);
@@ -101,7 +101,7 @@ namespace test {
             }
         }
 
-        void remove_thread(hpx::thread* thrd)
+        void remove_thread(hpx::thread const* thrd)
         {
             std::lock_guard<mutex_type> guard(mtx_);
             std::list<hpx::thread*>::iterator const it =
@@ -111,14 +111,13 @@ namespace test {
                 threads.erase(it);
         }
 
-        void join_all()
+        void join_all() const
         {
             if (is_this_thread_in())
             {
                 HPX_THROW_EXCEPTION(hpx::error::thread_resource_error,
                     "thread_group::join_all",
                     "resource_deadlock_would_occur: trying joining itself");
-                return;
             }
 
             std::shared_lock<mutex_type> guard(mtx_);
@@ -129,7 +128,7 @@ namespace test {
             }
         }
 
-        void interrupt_all()
+        void interrupt_all() const
         {
             std::shared_lock<mutex_type> guard(mtx_);
             for (hpx::thread* t : threads)

--- a/libs/full/components_base/include/hpx/components_base/server/one_size_heap_list.hpp
+++ b/libs/full/components_base/include/hpx/components_base/server/one_size_heap_list.hpp
@@ -107,7 +107,8 @@ namespace hpx { namespace util {
         std::string name() const;
 
     protected:
-        mutable mutex_type mtx_;
+//        mutable mutex_type mtx_;
+        mutable pthread_rwlock_t rwlock;
         list_type heap_list_;
 
     private:

--- a/libs/full/components_base/include/hpx/components_base/server/one_size_heap_list.hpp
+++ b/libs/full/components_base/include/hpx/components_base/server/one_size_heap_list.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 1998-2017 Hartmut Kaiser
+//  Copyright (c) 1998-2023 Hartmut Kaiser
 //  Copyright (c)      2011 Bryce Lelbach
 //
 //  SPDX-License-Identifier: BSL-1.0
@@ -10,6 +10,7 @@
 #include <hpx/config.hpp>
 #include <hpx/assert.hpp>
 #include <hpx/components_base/server/wrapper_heap_base.hpp>
+#include <hpx/synchronization/shared_mutex.hpp>
 #include <hpx/synchronization/spinlock.hpp>
 
 #include <cstddef>
@@ -30,7 +31,7 @@ namespace hpx { namespace util {
         using iterator = typename list_type::iterator;
         using const_iterator = typename list_type::const_iterator;
 
-        using mutex_type = hpx::spinlock;
+        using mutex_type = hpx::shared_mutex;
 
         using heap_parameters = wrapper_heap_base::heap_parameters;
 
@@ -107,8 +108,7 @@ namespace hpx { namespace util {
         std::string name() const;
 
     protected:
-//        mutable mutex_type mtx_;
-        mutable pthread_rwlock_t rwlock;
+        mutable mutex_type rwlock_;
         list_type heap_list_;
 
     private:

--- a/libs/full/components_base/include/hpx/components_base/server/wrapper_heap.hpp
+++ b/libs/full/components_base/include/hpx/components_base/server/wrapper_heap.hpp
@@ -104,23 +104,20 @@ namespace hpx::components::detail {
         void set_gid(naming::gid_type const& g);
 
     protected:
-        bool test_release(std::unique_lock<mutex_type>& lk);
-        bool ensure_pool(std::size_t count);
+        bool free_pool();
 
         bool init_pool();
         void tidy();
 
     protected:
         char* pool_;
-        char* first_free_;
         heap_parameters const parameters_;
-        std::size_t free_size_;
-
+        alignas(64) std::atomic<char*> first_free_;
+        alignas(64) std::atomic<std::size_t> free_size_;
         // these values are used for AGAS registration of all elements of this
         // managed_component heap
+        alignas(64) mutable mutex_type mtx_;
         naming::gid_type base_gid_;
-
-        mutable mutex_type mtx_;
 
     public:
         std::string const class_name_;

--- a/libs/full/components_base/include/hpx/components_base/server/wrapper_heap.hpp
+++ b/libs/full/components_base/include/hpx/components_base/server/wrapper_heap.hpp
@@ -11,6 +11,7 @@
 #include <hpx/allocator_support/internal_allocator.hpp>
 #include <hpx/assert.hpp>
 #include <hpx/components_base/server/wrapper_heap_base.hpp>
+#include <hpx/concurrency/cache_line_data.hpp>
 #include <hpx/modules/itt_notify.hpp>
 #include <hpx/naming_base/id_type.hpp>
 #include <hpx/synchronization/spinlock.hpp>
@@ -78,7 +79,7 @@ namespace hpx::components::detail {
 
     public:
         explicit wrapper_heap(char const* class_name, std::size_t count,
-            heap_parameters parameters);
+            heap_parameters const& parameters);
 
         wrapper_heap();
         ~wrapper_heap() override;
@@ -112,11 +113,11 @@ namespace hpx::components::detail {
     protected:
         char* pool_;
         heap_parameters const parameters_;
-        alignas(64) std::atomic<char*> first_free_;
-        alignas(64) std::atomic<std::size_t> free_size_;
+        util::cache_aligned_data_derived<std::atomic<char*>> first_free_;
+        util::cache_aligned_data_derived<std::atomic<std::size_t>> free_size_;
         // these values are used for AGAS registration of all elements of this
         // managed_component heap
-        alignas(64) mutable mutex_type mtx_;
+        mutable util::cache_aligned_data_derived<mutex_type> mtx_;
         naming::gid_type base_gid_;
 
     public:
@@ -158,7 +159,7 @@ namespace hpx::components::detail {
         using value_type = T;
 
         explicit fixed_wrapper_heap(char const* class_name, std::size_t count,
-            heap_parameters parameters)
+            heap_parameters const& parameters)
           : base_type(class_name, count, parameters)
         {
         }

--- a/libs/full/components_base/include/hpx/components_base/server/wrapper_heap.hpp
+++ b/libs/full/components_base/include/hpx/components_base/server/wrapper_heap.hpp
@@ -16,6 +16,7 @@
 #include <hpx/naming_base/id_type.hpp>
 #include <hpx/synchronization/spinlock.hpp>
 
+#include <atomic>
 #include <cstddef>
 #include <cstdint>
 #include <memory>

--- a/libs/full/components_base/include/hpx/components_base/server/wrapper_heap_list.hpp
+++ b/libs/full/components_base/include/hpx/components_base/server/wrapper_heap_list.hpp
@@ -51,19 +51,20 @@ namespace hpx::components::detail {
 
         naming::gid_type get_gid(void* p)
         {
-            std::unique_lock guard(this->mtx_);
+            pthread_rwlock_rdlock(&rwlock);
 
             using iterator = typename base_type::const_iterator;
 
-            iterator end = this->heap_list_.end();
-            for (iterator it = this->heap_list_.begin(); it != end; ++it)
+            iterator end = heap_list_.end();
+            for (iterator it = heap_list_.begin(); it != end; ++it)
             {
                 if ((*it)->did_alloc(p))
                 {
-                    unlock_guard ul(guard);
+                    pthread_rwlock_unlock(&rwlock);
                     return (*it)->get_gid(p, type_);
                 }
             }
+            pthread_rwlock_unlock(&rwlock);
             return naming::invalid_gid;
         }
 

--- a/libs/full/components_base/src/server/wrapper_heap.cpp
+++ b/libs/full/components_base/src/server/wrapper_heap.cpp
@@ -69,8 +69,8 @@ namespace hpx::components::detail {
     wrapper_heap::wrapper_heap(char const* class_name,
         [[maybe_unused]] std::size_t count, heap_parameters parameters)
       : pool_(nullptr)
-      , first_free_(nullptr)
       , parameters_(parameters)
+      , first_free_(nullptr)
       , free_size_(0)
       , base_gid_(naming::invalid_gid)
       , class_name_(class_name)
@@ -88,12 +88,21 @@ namespace hpx::components::detail {
         {
             throw std::bad_alloc();
         }
+        // use the pool's base address as the first gid, this will also
+        // allow for the ids to be locally resolvable
+        base_gid_ = naming::replace_locality_id(
+            naming::replace_component_type(
+                naming::gid_type(pool_), 0),
+            agas::get_locality_id());
+
+        naming::detail::set_credit_for_gid(
+            base_gid_, std::int64_t(HPX_GLOBALCREDIT_INITIAL));
     }
 
     wrapper_heap::wrapper_heap()
       : pool_(nullptr)
-      , first_free_(nullptr)
       , parameters_({0, 0, 0})
+      , first_free_(nullptr)
       , free_size_(0)
       , base_gid_(naming::invalid_gid)
 #if defined(HPX_DEBUG)
@@ -150,22 +159,30 @@ namespace hpx::components::detail {
             count * parameters_.element_size,
             HPX_WRAPPER_HEAP_INITIALIZED_MEMORY);
 
-        std::unique_lock l(mtx_);
-
-        if (!ensure_pool(count))
+        if (nullptr == pool_)
+        {
             return false;
+        }
+
+        std::size_t const num_bytes = count * parameters_.element_size;
+        std::size_t const total_num_bytes =
+            parameters_.capacity * parameters_.element_size;
+
+        if (first_free_ + num_bytes > pool_ + total_num_bytes)
+        {
+            return false;
+        }
 
 #if defined(HPX_DEBUG)
         alloc_count_ += count;
 #endif
 
-        void* p = first_free_;
-        HPX_ASSERT(p != nullptr);
+        char* p = first_free_.fetch_add(count * parameters_.element_size, std::memory_order_relaxed);
 
-        first_free_ = first_free_ + count * parameters_.element_size;
-
-        HPX_ASSERT(free_size_ >= count);
-        free_size_ -= count;
+        if (p + num_bytes > pool_ + total_num_bytes)
+        {
+            return false;
+        }
 
 #if HPX_DEBUG_WRAPPER_HEAP != 0
         // init memory blocks
@@ -182,10 +199,6 @@ namespace hpx::components::detail {
 
 #if HPX_DEBUG_WRAPPER_HEAP != 0
         HPX_ASSERT(did_alloc(p));
-#endif
-        std::unique_lock l(mtx_);
-
-#if HPX_DEBUG_WRAPPER_HEAP != 0
         char* p1 = p;
         std::size_t const total_num_bytes =
             parameters_.capacity * parameters_.element_size;
@@ -206,10 +219,11 @@ namespace hpx::components::detail {
 #if defined(HPX_DEBUG)
         free_count_ += count;
 #endif
-        free_size_ += count;
+        size_t current_free_size = free_size_.fetch_add(count, std::memory_order_relaxed) + count;
 
         // release the pool if this one was the last allocated item
-        test_release(l);
+        if (current_free_size == parameters_.capacity)
+            free_pool();
     }
 
     bool wrapper_heap::did_alloc(void* p) const
@@ -234,23 +248,27 @@ namespace hpx::components::detail {
 
         HPX_ASSERT(did_alloc(p));
 
-        {
-            std::unique_lock l(mtx_);
-            if (!base_gid_)
-            {
-                // use the pool's base address as the first gid, this will also
-                // allow for the ids to be locally resolvable
-                base_gid_ = naming::replace_locality_id(
-                    naming::replace_component_type(
-                        naming::gid_type(pool_), type),
-                    agas::get_locality_id());
-
-                naming::detail::set_credit_for_gid(
-                    base_gid_, std::int64_t(HPX_GLOBALCREDIT_INITIAL));
-            }
-        }
-
+//        if (!base_gid_)
+//        {
+//            std::unique_lock l(mtx_);
+//            if (!base_gid_)
+//            {
+//                // use the pool's base address as the first gid, this will also
+//                // allow for the ids to be locally resolvable
+//                base_gid_ = naming::replace_locality_id(
+//                    naming::replace_component_type(
+//                        naming::gid_type(pool_), type),
+//                    agas::get_locality_id());
+//
+//                naming::detail::set_credit_for_gid(
+//                    base_gid_, std::int64_t(HPX_GLOBALCREDIT_INITIAL));
+//            }
+//        }
         naming::gid_type result = base_gid_;
+        if (type) {
+            result = naming::replace_component_type(
+                result, type);
+        }
         result.set_lsb(p);
 
         // We have to assume this credit was split as otherwise the gid returned
@@ -268,54 +286,29 @@ namespace hpx::components::detail {
         base_gid_ = g;
     }
 
-    bool wrapper_heap::test_release(std::unique_lock<mutex_type>& lk)
+    bool wrapper_heap::free_pool()
     {
-        if (pool_ == nullptr)
-        {
-            return false;
-        }
-
-        std::size_t const total_num_bytes =
-            parameters_.capacity * parameters_.element_size;
-
-        if (first_free_ < pool_ + total_num_bytes ||
-            free_size_ < parameters_.capacity)
-        {
-            return false;
-        }
-
-        HPX_ASSERT(free_size_ == parameters_.capacity);
-        HPX_ASSERT(first_free_ == pool_ + total_num_bytes);
+        HPX_ASSERT(pool_);
+        HPX_ASSERT(first_free_ == pool_ +
+                parameters_.capacity * parameters_.element_size);
 
         // unbind in AGAS service
         if (base_gid_)
         {
-            naming::gid_type base_gid = base_gid_;
-            base_gid_ = naming::invalid_gid;
-
-            unlock_guard ull(lk);
-            agas::unbind_range_local(base_gid, parameters_.capacity);
+            naming::gid_type base_gid = naming::invalid_gid;
+            {
+//                std::unique_lock l(mtx_);
+                if (base_gid_)
+                {
+                    base_gid = base_gid_;
+                    base_gid_ = naming::invalid_gid;
+                }
+            }
+            if (base_gid)
+                agas::unbind_range_local(base_gid, parameters_.capacity);
         }
 
         tidy();
-        return true;
-    }
-
-    bool wrapper_heap::ensure_pool(std::size_t count)
-    {
-        if (nullptr == pool_)
-        {
-            return false;
-        }
-
-        std::size_t const num_bytes = count * parameters_.element_size;
-        std::size_t const total_num_bytes =
-            parameters_.capacity * parameters_.element_size;
-
-        if (first_free_ + num_bytes > pool_ + total_num_bytes)
-        {
-            return false;
-        }
         return true;
     }
 
@@ -337,7 +330,7 @@ namespace hpx::components::detail {
             pool_ :
             pool_ + parameters_.element_alignment;
 
-        free_size_ = parameters_.capacity;
+//        free_size_ = parameters_.capacity;
 
         LOSH_(info).format("wrapper_heap ({}): init_pool ({}) size: {}.",
             !class_name_.empty() ? class_name_.c_str() : "<Unknown>",
@@ -376,7 +369,8 @@ namespace hpx::components::detail {
             std::size_t const total_num_bytes =
                 parameters_.capacity * parameters_.element_size;
             allocator_type::free(pool_, total_num_bytes);
-            pool_ = first_free_ = nullptr;
+            pool_ = nullptr;
+//            pool_ = first_free_ = nullptr;
             free_size_ = 0;
         }
     }

--- a/libs/full/components_base/src/server/wrapper_heap.cpp
+++ b/libs/full/components_base/src/server/wrapper_heap.cpp
@@ -277,8 +277,6 @@ namespace hpx::components::detail {
     bool wrapper_heap::free_pool()
     {
         HPX_ASSERT(pool_);
-        HPX_ASSERT(first_free_ ==
-            pool_ + parameters_.capacity * parameters_.element_size);
 
         // unbind in AGAS service
         if (base_gid_)


### PR DESCRIPTION
The original implementation uses an HPX mutex to ensure thread safety. This PR replaces it with a pthread rwlock, which greatly improves its performance. Multiple allocation/free calls can proceed simultaneously under the read lock, and the pthread read lock only costs an atomic fetch-and-add in most cases.

Need to discuss: directly using pthread rwlock in HPX codebase may not be a good idea, but implementing the whole pthread rwlock algorithm in HPX can also be cumbersome.