### PR TITLE
Fix jacobi omp examples.

### DIFF
--- a/examples/jacobi_smp/jacobi.cpp
+++ b/examples/jacobi_smp/jacobi.cpp
@@ -66,8 +66,8 @@ int hpx_main(variables_map& vm)
 #endif
 }
 
-#if !defined(HPX_APPLICATION_STRING)
-#define HPX_APPLICATION_STRING "jacobi"
+#if defined(JACOBI_SMP_NO_HPX)
+#define HPX_APPLICATION_STRING "jacobi_omp_[static,dynamic]"
 #endif
 
 int main(int argc, char** argv)

--- a/examples/jacobi_smp/jacobi_nonuniform.cpp
+++ b/examples/jacobi_smp/jacobi_nonuniform.cpp
@@ -199,6 +199,10 @@ int hpx_main(variables_map& vm)
 #endif
 }
 
+#if defined(JACOBI_SMP_NO_HPX)
+#define HPX_APPLICATION_STRING "jacobi_omp_[static,dynamic]"
+#endif
+
 int main(int argc, char** argv)
 {
     options_description desc_cmd("usage: " HPX_APPLICATION_STRING " [options]");

--- a/examples/jacobi_smp/jacobi_nonuniform.cpp
+++ b/examples/jacobi_smp/jacobi_nonuniform.cpp
@@ -200,7 +200,7 @@ int hpx_main(variables_map& vm)
 }
 
 #if defined(JACOBI_SMP_NO_HPX)
-#define HPX_APPLICATION_STRING "jacobi_omp_[static,dynamic]"
+#define HPX_APPLICATION_STRING "jacobi_omp_nonuniform_[static,dynamic]"
 #endif
 
 int main(int argc, char** argv)


### PR DESCRIPTION
Makes sure the `HPX_APPLICATION_STRING` is set correctly for non-hpx targets in Jacobi examples when `HPX_WITH_EXAMPLES_OPENMP=ON`.

- We may want to have a testing pipeline for non-hpx examples.
- Thank you @G-071!