### PR TITLE
Fix resource partitioner tests for small thread count

### DIFF
--- a/libs/core/resource_partitioner/tests/unit/resource_partitioner_info.cpp
+++ b/libs/core/resource_partitioner/tests/unit/resource_partitioner_info.cpp
@@ -22,8 +22,9 @@ std::size_t const max_threads = (std::min)(
 
 int hpx_main()
 {
-    HPX_TEST_EQ(std::size_t(max_threads), hpx::resource::get_num_threads());
-    HPX_TEST_EQ(std::size_t(max_threads), hpx::resource::get_num_threads(0));
+    std::size_t const num_os_threads = hpx::get_os_thread_count();
+    HPX_TEST_EQ(num_os_threads, hpx::resource::get_num_threads());
+    HPX_TEST_EQ(num_os_threads, hpx::resource::get_num_threads(0));
     HPX_TEST_EQ(std::size_t(1), hpx::resource::get_num_thread_pools());
     HPX_TEST_EQ(std::size_t(0), hpx::resource::get_pool_index("default"));
     HPX_TEST_EQ(std::string("default"), hpx::resource::get_pool_name(0));

--- a/libs/core/resource_partitioner/tests/unit/shutdown_suspended_pus.cpp
+++ b/libs/core/resource_partitioner/tests/unit/shutdown_suspended_pus.cpp
@@ -27,14 +27,15 @@ std::size_t const max_threads = (std::min)(
 
 int hpx_main()
 {
+    std::size_t const num_os_threads = hpx::get_os_thread_count();
     std::size_t const num_threads = hpx::resource::get_num_threads("default");
 
-    HPX_TEST_EQ(std::size_t(max_threads), num_threads);
+    HPX_TEST_EQ(std::size_t(num_os_threads), num_threads);
 
     hpx::threads::thread_pool_base& tp =
         hpx::resource::get_thread_pool("default");
 
-    HPX_TEST_EQ(tp.get_active_os_thread_count(), std::size_t(max_threads));
+    HPX_TEST_EQ(tp.get_active_os_thread_count(), std::size_t(num_os_threads));
 
     // Remove all but one pu
     for (std::size_t thread_num = 0; thread_num < num_threads - 1; ++thread_num)

--- a/libs/core/resource_partitioner/tests/unit/suspend_pool.cpp
+++ b/libs/core/resource_partitioner/tests/unit/suspend_pool.cpp
@@ -145,13 +145,14 @@ void test_scheduler(
     hpx::local::init_params init_args;
 
     init_args.cfg = {"hpx.os_threads=" + std::to_string(max_threads)};
-    init_args.rp_callback = [scheduler](auto& rp,
+    init_args.rp_callback = [scheduler](hpx::resource::partitioner& rp,
                                 hpx::program_options::variables_map const&) {
         rp.create_thread_pool("worker", scheduler,
             hpx::threads::policies::scheduler_mode::default_ |
                 hpx::threads::policies::scheduler_mode::enable_elasticity);
 
-        std::size_t const worker_pool_threads = max_threads - 1;
+        std::size_t const worker_pool_threads =
+            rp.get_number_requested_threads() - 1;
         HPX_ASSERT(worker_pool_threads >= 1);
         std::size_t worker_pool_threads_added = 0;
 

--- a/libs/core/resource_partitioner/tests/unit/suspend_thread.cpp
+++ b/libs/core/resource_partitioner/tests/unit/suspend_thread.cpp
@@ -28,15 +28,16 @@ std::size_t const max_threads = (std::min)(static_cast<std::size_t>(4),
 
 int hpx_main()
 {
+    std::size_t const num_os_threads = hpx::get_os_thread_count();
     std::size_t const num_threads = hpx::resource::get_num_threads("default");
 
-    HPX_TEST_EQ(static_cast<std::size_t>(max_threads), num_threads);
+    HPX_TEST_EQ(static_cast<std::size_t>(num_os_threads), num_threads);
 
     hpx::threads::thread_pool_base& tp =
         hpx::resource::get_thread_pool("default");
 
-    HPX_TEST_EQ(
-        tp.get_active_os_thread_count(), static_cast<std::size_t>(max_threads));
+    HPX_TEST_EQ(tp.get_active_os_thread_count(),
+        static_cast<std::size_t>(num_os_threads));
 
     {
         // Check number of used resources
@@ -124,7 +125,7 @@ int hpx_main()
 
             // Launching the same number of tasks as worker threads may deadlock
             // as no thread is available to steal from the current thread.
-            for (std::size_t i = 0; i < max_threads - 1; ++i)
+            for (std::size_t i = 0; i < num_threads - 1; ++i)
             {
                 fs.push_back(
                     hpx::threads::suspend_processing_unit(tp, thread_num));
@@ -136,7 +137,7 @@ int hpx_main()
 
             // Launching the same number of tasks as worker threads may deadlock
             // as no thread is available to steal from the current thread.
-            for (std::size_t i = 0; i < max_threads - 1; ++i)
+            for (std::size_t i = 0; i < num_threads - 1; ++i)
             {
                 fs.push_back(
                     hpx::threads::resume_processing_unit(tp, thread_num));

--- a/libs/core/resource_partitioner/tests/unit/suspend_thread_external.cpp
+++ b/libs/core/resource_partitioner/tests/unit/suspend_thread_external.cpp
@@ -28,9 +28,10 @@ std::size_t const max_threads = (std::min)(
 
 int hpx_main()
 {
+    std::size_t const num_os_threads = hpx::get_os_thread_count();
     std::size_t const num_threads = hpx::resource::get_num_threads("worker");
 
-    HPX_TEST_EQ(std::size_t(max_threads - 1), num_threads);
+    HPX_TEST_EQ(std::size_t(num_os_threads - 1), num_threads);
 
     hpx::threads::thread_pool_base& tp =
         hpx::resource::get_thread_pool("worker");
@@ -76,7 +77,7 @@ int hpx_main()
 
             // Launching the same number of tasks as worker threads may deadlock
             // as no thread is available to steal from the current thread.
-            for (std::size_t i = 0; i < max_threads - 1; ++i)
+            for (std::size_t i = 0; i < num_os_threads - 1; ++i)
             {
                 fs.push_back(
                     hpx::threads::suspend_processing_unit(tp, thread_num));
@@ -88,7 +89,7 @@ int hpx_main()
 
             // Launching the same number of tasks as worker threads may deadlock
             // as no thread is available to steal from the current thread.
-            for (std::size_t i = 0; i < max_threads - 1; ++i)
+            for (std::size_t i = 0; i < num_os_threads - 1; ++i)
             {
                 fs.push_back(
                     hpx::threads::resume_processing_unit(tp, thread_num));
@@ -167,7 +168,8 @@ void test_scheduler(
             hpx::threads::policies::scheduler_mode::default_ |
                 hpx::threads::policies::scheduler_mode::enable_elasticity);
 
-        std::size_t const worker_pool_threads = max_threads - 1;
+        std::size_t const worker_pool_threads =
+            rp.get_number_requested_threads() - 1;
         std::size_t worker_pool_threads_added = 0;
 
         for (hpx::resource::numa_domain const& d : rp.numa_domains())


### PR DESCRIPTION
Fixes certain resource partitioner tests which would fail when --hpx:threads was set to a number <4.
Should fix current failures on MacOS CI  