### PR TITLE
Update LSU Jenkins with 2023-10 libraries

### DIFF
--- a/.jenkins/lsu/Jenkinsfile
+++ b/.jenkins/lsu/Jenkinsfile
@@ -36,7 +36,7 @@ pipeline {
                 axes {
                     axis {
                         name 'configuration_name'
-                        values 'gcc-10', 'gcc-11', 'gcc-12', 'gcc-13', 'clang-12', 'clang-13', 'clang-14', 'clang-15', 'gcc-10-cuda-11', 'gcc-12-cuda-12-dgx', 'hipcc'
+                        values 'gcc-10', 'gcc-11', 'gcc-12', 'gcc-13', 'clang-12', 'clang-13', 'clang-14', 'clang-15',  'clang-16', 'clang-17','gcc-12-cuda-12', 'gcc-13-cuda-12-dgx', 'hipcc'
                     }
                     axis {
                          name 'build_type'

--- a/.jenkins/lsu/env-clang-15.sh
+++ b/.jenkins/lsu/env-clang-15.sh
@@ -7,7 +7,7 @@
 module purge
 module load cmake
 module load llvm/15
-module load boost/1.82.0-${build_type,,}
+module load boost/1.81.0-${build_type,,}
 module load hwloc
 module load openmpi
 module load pwrapi/1.1.1

--- a/.jenkins/lsu/env-clang-16.sh
+++ b/.jenkins/lsu/env-clang-16.sh
@@ -6,8 +6,8 @@
 
 module purge
 module load cmake
-module load gcc/13
-module load boost/1.83.0-${build_type,,}
+module load llvm/16
+module load boost/1.82.0-${build_type,,}
 module load hwloc
 module load openmpi
 module load pwrapi/1.1.1
@@ -16,6 +16,7 @@ export HPXRUN_RUNWRAPPER=srun
 export CXX_STD="20"
 export PKG_CONFIG_PATH=/usr/local/lib/pkgconfig:$PKG_CONFIG_PATH
 
+configure_extra_options+=" -DCMAKE_BUILD_TYPE=${build_type}"
 configure_extra_options+=" -DHPX_WITH_CXX_STANDARD=${CXX_STD}"
 configure_extra_options+=" -DHPX_WITH_MALLOC=system"
 configure_extra_options+=" -DHPX_WITH_FETCH_ASIO=ON"
@@ -26,12 +27,16 @@ configure_extra_options+=" -DHPX_WITH_PARCELPORT_LCI=ON"
 configure_extra_options+=" -DHPX_WITH_FETCH_LCI=ON"
 configure_extra_options+=" -DHPX_WITH_PARCELPORT_GASNET=ON"
 configure_extra_options+=" -DHPX_WITH_FETCH_GASNET=ON"
-configure_extra_options+=" -DCMAKE_C_COMPILER=gcc"
+configure_extra_options+=" -DCMAKE_C_COMPILER=clang"
 configure_extra_options+=" -DCMAKE_C_FLAGS=-fPIC"
 configure_extra_options+=" -DHPX_WITH_PARCELPORT_GASNET_CONDUIT=smp"
+configure_extra_options+=" -DHPX_WITH_LOGGING=OFF"
 configure_extra_options+=" -DHPX_WITH_DATAPAR_BACKEND=EVE"
 configure_extra_options+=" -DHPX_WITH_FETCH_EVE=ON"
-configure_extra_options+=" -DHPX_WITH_EVE_TAG=main"
 
 # The pwrapi library still needs to be set up properly on rostam
 # configure_extra_options+=" -DHPX_WITH_POWER_COUNTER=ON"
+
+# Make sure HWLOC does not report 'cores'. This is purely an option to enable
+# testing the topology code under conditions close to those on FreeBSD.
+configure_extra_options+=" -DHPX_TOPOLOGY_WITH_ADDITIONAL_HWLOC_TESTING=ON"

--- a/.jenkins/lsu/env-clang-17.sh
+++ b/.jenkins/lsu/env-clang-17.sh
@@ -6,7 +6,7 @@
 
 module purge
 module load cmake
-module load gcc/13
+module load llvm/17
 module load boost/1.83.0-${build_type,,}
 module load hwloc
 module load openmpi
@@ -16,6 +16,7 @@ export HPXRUN_RUNWRAPPER=srun
 export CXX_STD="20"
 export PKG_CONFIG_PATH=/usr/local/lib/pkgconfig:$PKG_CONFIG_PATH
 
+configure_extra_options+=" -DCMAKE_BUILD_TYPE=${build_type}"
 configure_extra_options+=" -DHPX_WITH_CXX_STANDARD=${CXX_STD}"
 configure_extra_options+=" -DHPX_WITH_MALLOC=system"
 configure_extra_options+=" -DHPX_WITH_FETCH_ASIO=ON"
@@ -26,12 +27,16 @@ configure_extra_options+=" -DHPX_WITH_PARCELPORT_LCI=ON"
 configure_extra_options+=" -DHPX_WITH_FETCH_LCI=ON"
 configure_extra_options+=" -DHPX_WITH_PARCELPORT_GASNET=ON"
 configure_extra_options+=" -DHPX_WITH_FETCH_GASNET=ON"
-configure_extra_options+=" -DCMAKE_C_COMPILER=gcc"
+configure_extra_options+=" -DCMAKE_C_COMPILER=clang"
 configure_extra_options+=" -DCMAKE_C_FLAGS=-fPIC"
 configure_extra_options+=" -DHPX_WITH_PARCELPORT_GASNET_CONDUIT=smp"
+configure_extra_options+=" -DHPX_WITH_LOGGING=OFF"
 configure_extra_options+=" -DHPX_WITH_DATAPAR_BACKEND=EVE"
 configure_extra_options+=" -DHPX_WITH_FETCH_EVE=ON"
-configure_extra_options+=" -DHPX_WITH_EVE_TAG=main"
 
 # The pwrapi library still needs to be set up properly on rostam
 # configure_extra_options+=" -DHPX_WITH_POWER_COUNTER=ON"
+
+# Make sure HWLOC does not report 'cores'. This is purely an option to enable
+# testing the topology code under conditions close to those on FreeBSD.
+configure_extra_options+=" -DHPX_TOPOLOGY_WITH_ADDITIONAL_HWLOC_TESTING=ON"

--- a/.jenkins/lsu/env-gcc-12-cuda-12.sh
+++ b/.jenkins/lsu/env-gcc-12-cuda-12.sh
@@ -6,10 +6,10 @@
 
 module purge
 module load cmake
-module load gcc/10
-module load boost/1.75.0-${build_type,,}
+module load gcc/12
+module load boost/1.82.0-${build_type,,}
 module load hwloc
-module load cuda/11.5
+module load cuda/12
 module load openmpi
 
 export CXX_STD="17"

--- a/.jenkins/lsu/env-gcc-12.sh
+++ b/.jenkins/lsu/env-gcc-12.sh
@@ -7,7 +7,7 @@
 module purge
 module load cmake
 module load gcc/12
-module load boost/1.80.0-${build_type,,}
+module load boost/1.81.0-${build_type,,}
 module load hwloc
 module load openmpi
 module load pwrapi/1.1.1

--- a/.jenkins/lsu/env-gcc-13-cuda-12-dgx.sh
+++ b/.jenkins/lsu/env-gcc-13-cuda-12-dgx.sh
@@ -6,9 +6,9 @@
 
 module purge
 module load cmake
-module load gcc/12
+module load gcc/13
 module load cuda/12
-module load boost/1.81.0-${build_type,,}
+module load boost/1.83.0-${build_type,,}
 module load hwloc
 
 export CXX_STD="17"


### PR DESCRIPTION
Adding new libraries to LSU Jenkins:

- gcc/13.2 with boost 1.83
- llvm/17 with boost 1.83
- llvm/16 with boost 1.82
- gcc/13 + cuda 12 with boost 1.83
- gcc/12 + cuda 12 with boost 1.82