### PR TITLE
Consistently treat conflicting parameters provided by executors and parameter objects

### DIFF
--- a/libs/core/algorithms/tests/performance/foreach_scaling_helpers.hpp
+++ b/libs/core/algorithms/tests/performance/foreach_scaling_helpers.hpp
@@ -1,5 +1,5 @@
 //  Copyright (c) 2014 Grant Mercer
-//  Copyright (c) 2021-2022 Hartmut Kaiser
+//  Copyright (c) 2021-2023 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -11,39 +11,35 @@
 
 #if !defined(HPX_COMPUTE_DEVICE_CODE)
 #include <hpx/algorithm.hpp>
-#include <hpx/chrono.hpp>
 #include <hpx/execution.hpp>
-#include <hpx/init.hpp>
+#include <hpx/type_support/unused.hpp>
 
 #include "worker_timed.hpp"
 
 #include <cstddef>
-#include <cstdint>
-#include <iomanip>
-#include <iostream>
 #include <iterator>
 #include <memory>
-#include <numeric>
 #include <random>
-#include <stdexcept>
-#include <string>
 #include <type_traits>
 #include <vector>
 
 ///////////////////////////////////////////////////////////////////////////////
-int delay = 1000;
-int test_count = 100;
-int chunk_size = 0;
-int num_overlapping_loops = 0;
-bool disable_stealing = false;
-bool fast_idle_mode = false;
-unsigned int seed = std::random_device{}();
-std::mt19937 gen(seed);
+inline int delay = 1000;
+inline int test_count = 100;
+inline int chunk_size = 0;
+inline int num_overlapping_loops = 0;
+inline bool disable_stealing = false;
+inline bool fast_idle_mode = false;
+inline unsigned int seed = std::random_device{}();
+
+inline std::mt19937 gen(seed);
 
 struct disable_stealing_parameter
 {
     template <typename Executor>
-    void mark_begin_execution(Executor&&)
+    friend void tag_override_invoke(
+        hpx::parallel::execution::mark_begin_execution_t,
+        disable_stealing_parameter, Executor&&)
     {
         hpx::threads::add_remove_scheduler_mode(
             hpx::threads::policies::scheduler_mode::enable_stealing,
@@ -51,14 +47,18 @@ struct disable_stealing_parameter
     }
 
     template <typename Executor>
-    void mark_end_of_scheduling(Executor&&)
+    friend void tag_override_invoke(
+        hpx::parallel::execution::mark_end_of_scheduling_t,
+        disable_stealing_parameter, Executor&&)
     {
         hpx::threads::remove_scheduler_mode(
             hpx::threads::policies::scheduler_mode::enable_stealing);
     }
 
     template <typename Executor>
-    void mark_end_execution(Executor&&)
+    friend void tag_override_invoke(
+        hpx::parallel::execution::mark_end_execution_t,
+        disable_stealing_parameter, Executor&&)
     {
         hpx::threads::add_remove_scheduler_mode(
             hpx::threads::policies::scheduler_mode::enable_idle_backoff,
@@ -66,19 +66,19 @@ struct disable_stealing_parameter
     }
 };
 
-namespace hpx::parallel::execution {
-    template <>
-    struct is_executor_parameters<disable_stealing_parameter> : std::true_type
-    {
-    };
-}    // namespace hpx::parallel::execution
+template <>
+struct hpx::parallel::execution::is_executor_parameters<
+    disable_stealing_parameter> : std::true_type
+{
+};
 
 ///////////////////////////////////////////////////////////////////////////////
-void measure_plain_for(std::vector<std::size_t> const& data_representation)
+inline void measure_plain_for(
+    std::vector<std::size_t> const& data_representation)
 {
-    std::size_t num = data_representation.size();
+    std::size_t const num = data_representation.size();
 
-    std::size_t size = num & std::size_t(-4);    // -V112
+    std::size_t size = num & static_cast<std::size_t>(-4);    // -V112
     for (std::size_t i = 0; i < size; i += 4)
     {
         worker_timed(delay);
@@ -92,7 +92,8 @@ void measure_plain_for(std::vector<std::size_t> const& data_representation)
     }
 }
 
-void measure_plain_for_iter(std::vector<std::size_t> const& data_representation)
+inline void measure_plain_for_iter(
+    std::vector<std::size_t> const& data_representation)
 {
     for (auto&& v : data_representation)
     {
@@ -102,7 +103,7 @@ void measure_plain_for_iter(std::vector<std::size_t> const& data_representation)
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-void measure_sequential_foreach(
+inline void measure_sequential_foreach(
     std::vector<std::size_t> const& data_representation)
 {
     if (disable_stealing)
@@ -184,23 +185,23 @@ hpx::future<void> measure_task_foreach(
         return hpx::ranges::for_each(
             hpx::execution::par(hpx::execution::task).with(cs, dsp).on(exec),
             *data_representation, [](std::size_t) { worker_timed(delay); })
-            .then([data_representation](hpx::future<void>) {});
+            .then([data_representation](
+                      hpx::future<void>) { HPX_UNUSED(data_representation); });
     }
-    else
-    {
-        // invoke parallel for_each
-        return hpx::ranges::for_each(
-            hpx::execution::par(hpx::execution::task).with(cs).on(exec),
-            *data_representation, [](std::size_t) { worker_timed(delay); })
-            .then([data_representation](hpx::future<void>) {});
-    }
+
+    // invoke parallel for_each
+    return hpx::ranges::for_each(
+        hpx::execution::par(hpx::execution::task).with(cs).on(exec),
+        *data_representation, [](std::size_t) { worker_timed(delay); })
+        .then([data_representation](
+                  hpx::future<void>) { HPX_UNUSED(data_representation); });
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-void measure_sequential_forloop(
+inline void measure_sequential_forloop(
     std::vector<std::size_t> const& data_representation)
 {
-    using iterator = typename std::vector<std::size_t>::const_iterator;
+    using iterator = std::vector<std::size_t>::const_iterator;
 
     if (disable_stealing)
     {
@@ -294,7 +295,8 @@ hpx::future<void> measure_task_forloop(
             hpx::execution::par(hpx::execution::task).with(cs, dsp).on(exec),
             std::begin(*data_representation), std::end(*data_representation),
             [](iterator) { worker_timed(delay); })
-            .then([data_representation](hpx::future<void>) {});
+            .then([data_representation](
+                      hpx::future<void>) { HPX_UNUSED(data_representation); });
     }
     else
     {
@@ -303,7 +305,9 @@ hpx::future<void> measure_task_forloop(
             hpx::execution::par(hpx::execution::task).with(cs).on(exec),
             std::begin(*data_representation), std::end(*data_representation),
             [](iterator) { worker_timed(delay); })
-            .then([data_representation](hpx::future<void>) {});
+            .then([data_representation](
+                      hpx::future<void>) { HPX_UNUSED(data_representation); });
     }
 }
+
 #endif

--- a/libs/core/async_mpi/include/hpx/async_mpi/mpi_executor.hpp
+++ b/libs/core/async_mpi/include/hpx/async_mpi/mpi_executor.hpp
@@ -8,7 +8,7 @@
 
 #include <hpx/config.hpp>
 #include <hpx/async_mpi/mpi_future.hpp>
-#include <hpx/execution/executors/static_chunk_size.hpp>
+#include <hpx/execution/executors/default_parameters.hpp>
 #include <hpx/execution_base/execution.hpp>
 #include <hpx/execution_base/traits/is_executor.hpp>
 #include <hpx/modules/mpi_base.hpp>
@@ -17,7 +17,7 @@
 #include <type_traits>
 #include <utility>
 
-namespace hpx { namespace mpi { namespace experimental {
+namespace hpx::mpi::experimental {
 
     struct executor
     {
@@ -27,7 +27,7 @@ namespace hpx { namespace mpi { namespace experimental {
 
         // default params type as we don't do anything special
         using executor_parameters_type =
-            hpx::execution::experimental::static_chunk_size;
+            hpx::execution::experimental::default_parameters;
 
         constexpr explicit executor(MPI_Comm communicator = MPI_COMM_WORLD)
           : communicator_(communicator)
@@ -70,9 +70,10 @@ namespace hpx { namespace mpi { namespace experimental {
     private:
         MPI_Comm communicator_;
     };
-}}}    // namespace hpx::mpi::experimental
+}    // namespace hpx::mpi::experimental
+// namespace hpx::mpi::experimental
 
-namespace hpx { namespace parallel { namespace execution {
+namespace hpx::parallel::execution {
 
     /// \cond NOINTERNAL
     template <>
@@ -81,4 +82,5 @@ namespace hpx { namespace parallel { namespace execution {
     {
     };
     /// \endcond
-}}}    // namespace hpx::parallel::execution
+}    // namespace hpx::parallel::execution
+// namespace hpx::parallel::execution

--- a/libs/core/compute_local/include/hpx/compute_local/host/block_allocator.hpp
+++ b/libs/core/compute_local/include/hpx/compute_local/host/block_allocator.hpp
@@ -16,7 +16,6 @@
 #include <hpx/compute_local/host/block_executor.hpp>
 #include <hpx/compute_local/host/target.hpp>
 #include <hpx/datastructures/tuple.hpp>
-#include <hpx/execution/executors/static_chunk_size.hpp>
 #include <hpx/executors/execution_policy.hpp>
 #include <hpx/executors/restricted_thread_pool_executor.hpp>
 #include <hpx/functional/invoke_fused.hpp>
@@ -35,7 +34,7 @@
 #include <utility>
 #include <vector>
 
-namespace hpx { namespace compute { namespace host {
+namespace hpx::compute::host {
     namespace detail {
         /// The policy_allocator allocates blocks of memory touched according to
         /// the distribution policy of the given executor.
@@ -294,4 +293,5 @@ namespace hpx { namespace compute { namespace host {
             return this->policy().executor().targets();
         }
     };
-}}}    // namespace hpx::compute::host
+}    // namespace hpx::compute::host
+// namespace hpx::compute::host

--- a/libs/core/compute_local/include/hpx/compute_local/host/block_executor.hpp
+++ b/libs/core/compute_local/include/hpx/compute_local/host/block_executor.hpp
@@ -9,8 +9,8 @@
 #include <hpx/config.hpp>
 #include <hpx/async_combinators/when_all.hpp>
 #include <hpx/compute_local/host/target.hpp>
+#include <hpx/execution/executors/default_parameters.hpp>
 #include <hpx/execution/executors/execution.hpp>
-#include <hpx/execution/executors/static_chunk_size.hpp>
 #include <hpx/execution/traits/executor_traits.hpp>
 #include <hpx/execution_base/traits/is_executor.hpp>
 #include <hpx/executors/restricted_thread_pool_executor.hpp>
@@ -41,7 +41,7 @@ namespace hpx { namespace compute { namespace host {
     {
     public:
         using executor_parameters_type =
-            hpx::execution::experimental::static_chunk_size;
+            hpx::execution::experimental::default_parameters;
 
         explicit block_executor(std::vector<host::target> const& targets,
             threads::thread_priority priority = threads::thread_priority::high,

--- a/libs/core/compute_local/include/hpx/compute_local/host/numa_allocator.hpp
+++ b/libs/core/compute_local/include/hpx/compute_local/host/numa_allocator.hpp
@@ -11,7 +11,6 @@
 #include <hpx/assert.hpp>
 #include <hpx/async_combinators/wait_all.hpp>
 #include <hpx/execution/executors/execution_information.hpp>
-#include <hpx/execution/executors/static_chunk_size.hpp>
 #include <hpx/executors/execution_policy.hpp>
 #include <hpx/futures/future.hpp>
 #include <hpx/parallel/algorithms/for_each.hpp>
@@ -29,7 +28,8 @@
 //
 ///////////////////////////////////////////////////////////////////////////////
 
-namespace hpx { namespace parallel { namespace util {
+namespace hpx::parallel::util {
+
     ///////////////////////////////////////////////////////////////////////////
     template <typename T, typename Executors>
     class numa_allocator
@@ -102,10 +102,7 @@ namespace hpx { namespace parallel { namespace util {
                 pointer begin = p + i * part_size;
                 pointer end = begin + part_size;
                 first_touch.push_back(hpx::for_each(
-                    hpx::execution::par(hpx::execution::task)
-                        .on(executors_[i])
-                        .with(
-                            hpx::execution::experimental::static_chunk_size()),
+                    hpx::execution::par(hpx::execution::task).on(executors_[i]),
                     begin, end,
 #if defined(HPX_DEBUG)
                     [this, i]
@@ -186,4 +183,5 @@ namespace hpx { namespace parallel { namespace util {
         Executors const& executors_;
         hpx::threads::topology& topo_;
     };
-}}}    // namespace hpx::parallel::util
+}    // namespace hpx::parallel::util
+// namespace hpx::parallel::util

--- a/libs/core/execution/CMakeLists.txt
+++ b/libs/core/execution/CMakeLists.txt
@@ -41,6 +41,7 @@ set(execution_headers
     hpx/execution/executor_parameters.hpp
     hpx/execution/executors/adaptive_static_chunk_size.hpp
     hpx/execution/executors/auto_chunk_size.hpp
+    hpx/execution/executors/default_parameters.hpp
     hpx/execution/executors/dynamic_chunk_size.hpp
     hpx/execution/executors/execution.hpp
     hpx/execution/executors/execution_information.hpp

--- a/libs/core/execution/include/hpx/execution/executors/auto_chunk_size.hpp
+++ b/libs/core/execution/include/hpx/execution/executors/auto_chunk_size.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2022 Hartmut Kaiser
+//  Copyright (c) 2007-2023 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -17,6 +17,7 @@
 #include <hpx/timing/steady_clock.hpp>
 
 #include <algorithm>
+#include <chrono>
 #include <cstddef>
 #include <cstdint>
 #include <type_traits>
@@ -53,6 +54,8 @@ namespace hpx::execution::experimental {
         /// \param rel_time     [in] The time duration to use as the minimum
         ///                     to decide how many loop iterations should be
         ///                     combined.
+        /// \param num_iters_for_timing [in] The number of iterations to use for
+        ///                             the timing operation
         ///
         explicit auto_chunk_size(hpx::chrono::steady_duration const& rel_time,
             std::uint64_t num_iters_for_timing = 0) noexcept
@@ -68,29 +71,32 @@ namespace hpx::execution::experimental {
 
         // Estimate execution time for one iteration
         template <typename Executor, typename F>
-        auto measure_iteration(Executor&& exec, F&& f, std::size_t count)
+        friend auto tag_override_invoke(
+            hpx::parallel::execution::measure_iteration_t,
+            auto_chunk_size& this_, Executor&& exec, F&& f, std::size_t count)
         {
             // by default use 1% of the iterations
-            if (num_iters_for_timing_ == 0)
+            if (this_.num_iters_for_timing_ == 0)
             {
-                num_iters_for_timing_ = count / 100;
+                this_.num_iters_for_timing_ = count / 100;
             }
 
             // perform measurements only if necessary
-            if (num_iters_for_timing_ > 0)
+            if (this_.num_iters_for_timing_ > 0)
             {
                 using hpx::chrono::high_resolution_clock;
                 std::uint64_t t = high_resolution_clock::now();
 
                 // use executor to launch given function for measurements
-                std::size_t test_chunk_size =
+                std::size_t const test_chunk_size =
                     hpx::parallel::execution::sync_execute(
-                        HPX_FORWARD(Executor, exec), f, num_iters_for_timing_);
+                        HPX_FORWARD(Executor, exec), f,
+                        this_.num_iters_for_timing_);
 
                 if (test_chunk_size != 0)
                 {
                     t = (high_resolution_clock::now() - t) / test_chunk_size;
-                    if (t != 0 && min_time_ >= t)
+                    if (t != 0 && this_.min_time_ >= t)
                     {
                         // return execution time for one iteration
                         return std::chrono::nanoseconds(t);
@@ -103,16 +109,20 @@ namespace hpx::execution::experimental {
 
         // Estimate a chunk size based on number of cores used.
         template <typename Executor>
-        std::size_t get_chunk_size(Executor&&,
+        friend std::size_t tag_override_invoke(
+            hpx::parallel::execution::get_chunk_size_t,
+            auto_chunk_size const& this_, Executor&&,
             hpx::chrono::steady_duration const& iteration_duration,
             std::size_t cores, std::size_t count) noexcept
         {
             // return chunk size which will create the required amount of work
             if (iteration_duration.value().count() != 0)
             {
-                auto ns = std::chrono::duration_cast<std::chrono::nanoseconds>(
-                    iteration_duration.value());
-                return (std::min)(count, (std::size_t)(min_time_ / ns.count()));
+                auto const ns =
+                    std::chrono::duration_cast<std::chrono::nanoseconds>(
+                        iteration_duration.value());
+                return (std::min)(
+                    count, (std::size_t)(this_.min_time_ / ns.count()));
             }
             return (count + cores - 1) / cores;
         }
@@ -142,16 +152,13 @@ namespace hpx::execution::experimental {
     };
 }    // namespace hpx::execution::experimental
 
-namespace hpx::parallel::execution {
-
-    /// \cond NOINTERNAL
-    template <>
-    struct is_executor_parameters<hpx::execution::experimental::auto_chunk_size>
-      : std::true_type
-    {
-    };
-    /// \endcond
-}    // namespace hpx::parallel::execution
+/// \cond NOINTERNAL
+template <>
+struct hpx::parallel::execution::is_executor_parameters<
+    hpx::execution::experimental::auto_chunk_size> : std::true_type
+{
+};
+/// \endcond
 
 namespace hpx::execution {
 

--- a/libs/core/execution/include/hpx/execution/executors/dynamic_chunk_size.hpp
+++ b/libs/core/execution/include/hpx/execution/executors/dynamic_chunk_size.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2022 Hartmut Kaiser
+//  Copyright (c) 2007-2023 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <hpx/config.hpp>
+#include <hpx/execution/executors/execution_parameters.hpp>
 #include <hpx/execution_base/traits/is_executor_parameters.hpp>
 #include <hpx/serialization/serialize.hpp>
 #include <hpx/timing/steady_clock.hpp>
@@ -29,25 +30,33 @@ namespace hpx::execution::experimental {
     ///
     struct dynamic_chunk_size
     {
+        /// Construct an \a dynamic_chunk_size executor parameters object
+        ///
+        /// \note Default constructed \a dynamic_chunk_size executor parameter
+        ///       types will use a chunk size of '1'.
+        ///
+        dynamic_chunk_size() = default;
+
         /// Construct a \a dynamic_chunk_size executor parameters object
         ///
         /// \param chunk_size   [in] The optional chunk size to use as the
         ///                     number of loop iterations to schedule together.
         ///                     The default chunk size is 1.
         ///
-        constexpr explicit dynamic_chunk_size(
-            std::size_t chunk_size = 1) noexcept
+        constexpr explicit dynamic_chunk_size(std::size_t chunk_size) noexcept
           : chunk_size_(chunk_size)
         {
         }
 
         /// \cond NOINTERNAL
         template <typename Executor>
-        constexpr std::size_t get_chunk_size(Executor&,
+        friend constexpr std::size_t tag_override_invoke(
+            hpx::parallel::execution::get_chunk_size_t,
+            dynamic_chunk_size const& this_, Executor&&,
             hpx::chrono::steady_duration const&, std::size_t,
-            std::size_t) const noexcept
+            std::size_t) noexcept
         {
-            return chunk_size_;
+            return this_.chunk_size_;
         }
         /// \endcond
 
@@ -66,21 +75,18 @@ namespace hpx::execution::experimental {
 
     private:
         /// \cond NOINTERNAL
-        std::size_t chunk_size_;
+        std::size_t chunk_size_ = 1;
         /// \endcond
     };
 }    // namespace hpx::execution::experimental
 
-namespace hpx::parallel::execution {
-
-    /// \cond NOINTERNAL
-    template <>
-    struct is_executor_parameters<
-        hpx::execution::experimental::dynamic_chunk_size> : std::true_type
-    {
-    };
-    /// \endcond
-}    // namespace hpx::parallel::execution
+/// \cond NOINTERNAL
+template <>
+struct hpx::parallel::execution::is_executor_parameters<
+    hpx::execution::experimental::dynamic_chunk_size> : std::true_type
+{
+};
+/// \endcond
 
 namespace hpx::execution {
 

--- a/libs/core/execution/include/hpx/execution/executors/execution_parameters.hpp
+++ b/libs/core/execution/include/hpx/execution/executors/execution_parameters.hpp
@@ -1,5 +1,5 @@
 //  Copyright (c) 2016 Marcin Copik
-//  Copyright (c) 2016-2022 Hartmut Kaiser
+//  Copyright (c) 2016-2023 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -21,7 +21,6 @@
 #include <hpx/serialization/base_object.hpp>
 #include <hpx/timing/steady_clock.hpp>
 #include <hpx/type_support/decay.hpp>
-#include <hpx/type_support/detail/wrap_int.hpp>
 #include <hpx/type_support/pack.hpp>
 
 #include <hpx/execution/executors/execution.hpp>
@@ -31,7 +30,6 @@
 #include <functional>
 #include <type_traits>
 #include <utility>
-#include <vector>
 
 ///////////////////////////////////////////////////////////////////////////////
 namespace hpx::parallel::execution {
@@ -46,7 +44,7 @@ namespace hpx::parallel::execution {
                 get_parameters_property_t<Property, CheckForProperty>>
         {
         private:
-            using derived_propery_t =
+            using derived_property_t =
                 get_parameters_property_t<Property, CheckForProperty>;
 
             template <typename T>
@@ -60,8 +58,8 @@ namespace hpx::parallel::execution {
                 )>
             // clang-format on
             friend HPX_FORCEINLINE constexpr decltype(auto) tag_fallback_invoke(
-                derived_propery_t, Executor&& /*exec*/, Parameters&& /*params*/,
-                Property prop) noexcept
+                derived_property_t, Executor&& /*exec*/,
+                Parameters&& /*params*/, Property prop) noexcept
             {
                 return std::make_pair(prop, prop);
             }
@@ -76,7 +74,7 @@ namespace hpx::parallel::execution {
                 )>
             // clang-format on
             friend HPX_FORCEINLINE constexpr decltype(auto) tag_fallback_invoke(
-                derived_propery_t, Executor&& exec, Parameters&& params,
+                derived_property_t, Executor&& exec, Parameters&& params,
                 Property /*prop*/) noexcept
             {
                 return std::pair<Parameters&&, Executor&&>(
@@ -94,7 +92,7 @@ namespace hpx::parallel::execution {
                 )>
             // clang-format on
             friend HPX_FORCEINLINE constexpr decltype(auto) tag_invoke(
-                derived_propery_t, Executor&& exec, Parameters&& params,
+                derived_property_t, Executor&& exec, Parameters&& params,
                 Property /*prop*/) noexcept
             {
                 return std::pair<Executor&&, Parameters&&>(
@@ -146,12 +144,12 @@ namespace hpx::parallel::execution {
                 hpx::chrono::steady_duration const& iteration_duration,
                 std::size_t cores, std::size_t num_tasks)
             {
-                auto getprop =
+                auto get_prop =
                     get_parameters_chunk_size(HPX_FORWARD(Executor, exec),
                         params, get_chunk_size_property{});
 
-                return getprop.first.get_chunk_size(
-                    HPX_FORWARD(decltype(getprop.second), getprop.second),
+                return get_prop.first.get_chunk_size(
+                    HPX_FORWARD(decltype(get_prop.second), get_prop.second),
                     iteration_duration, cores, num_tasks);
             }
 
@@ -207,12 +205,12 @@ namespace hpx::parallel::execution {
                 Parameters& params, Executor&& exec, F&& f,
                 std::size_t num_tasks)
             {
-                auto getprop = get_parameters_measure_iteration(
+                auto get_prop = get_parameters_measure_iteration(
                     HPX_FORWARD(Executor, exec), params,
                     measure_iteration_property{});
 
-                return getprop.first.measure_iteration(
-                    HPX_FORWARD(decltype(getprop.second), getprop.second),
+                return get_prop.first.measure_iteration(
+                    HPX_FORWARD(decltype(get_prop.second), get_prop.second),
                     HPX_FORWARD(F, f), num_tasks);
             }
 
@@ -273,12 +271,12 @@ namespace hpx::parallel::execution {
                 Parameters& params, Executor&& exec, std::size_t cores,
                 std::size_t num_tasks)
             {
-                auto getprop =
+                auto get_prop =
                     get_maximal_number_of_chunks(HPX_FORWARD(Executor, exec),
                         params, maximal_number_of_chunks_property{});
 
-                return getprop.first.maximal_number_of_chunks(
-                    HPX_FORWARD(decltype(getprop.second), getprop.second),
+                return get_prop.first.maximal_number_of_chunks(
+                    HPX_FORWARD(decltype(get_prop.second), get_prop.second),
                     cores, num_tasks);
             }
 
@@ -329,12 +327,12 @@ namespace hpx::parallel::execution {
             HPX_FORCEINLINE static constexpr void call(
                 Parameters& params, Executor&& exec)
             {
-                auto getprop =
+                auto get_prop =
                     get_reset_thread_distribution(HPX_FORWARD(Executor, exec),
                         params, reset_thread_distribution_property{});
 
-                getprop.first.reset_thread_distribution(
-                    HPX_FORWARD(decltype(getprop.second), getprop.second));
+                get_prop.first.reset_thread_distribution(
+                    HPX_FORWARD(decltype(get_prop.second), get_prop.second));
             }
 
             template <typename AnyParameters, typename Executor>
@@ -388,12 +386,12 @@ namespace hpx::parallel::execution {
                 hpx::chrono::steady_duration const& iteration_duration,
                 std::size_t num_tasks)
             {
-                auto getprop = get_processing_units_count_target(
+                auto get_prop = get_processing_units_count_target(
                     HPX_FORWARD(Executor, exec), params,
                     processing_units_count_property{});
 
-                return getprop.first.processing_units_count(
-                    HPX_FORWARD(decltype(getprop.second), getprop.second),
+                return get_prop.first.processing_units_count(
+                    HPX_FORWARD(decltype(get_prop.second), get_prop.second),
                     iteration_duration, num_tasks);
             }
 
@@ -458,12 +456,12 @@ namespace hpx::parallel::execution {
             HPX_FORCEINLINE static constexpr void call(
                 Parameters& params, Executor&& exec)
             {
-                auto getprop =
+                auto get_prop =
                     get_mark_begin_execution(HPX_FORWARD(Executor, exec),
                         params, mark_begin_execution_property{});
 
-                getprop.first.mark_begin_execution(
-                    HPX_FORWARD(decltype(getprop.second), getprop.second));
+                get_prop.first.mark_begin_execution(
+                    HPX_FORWARD(decltype(get_prop.second), get_prop.second));
             }
 
             template <typename AnyParameters, typename Executor>
@@ -512,12 +510,12 @@ namespace hpx::parallel::execution {
             HPX_FORCEINLINE static constexpr void call(
                 Parameters& params, Executor&& exec)
             {
-                auto getprop =
+                auto get_prop =
                     get_mark_end_of_scheduling(HPX_FORWARD(Executor, exec),
                         params, mark_end_of_scheduling_property{});
 
-                getprop.first.mark_end_of_scheduling(
-                    HPX_FORWARD(decltype(getprop.second), getprop.second));
+                get_prop.first.mark_end_of_scheduling(
+                    HPX_FORWARD(decltype(get_prop.second), get_prop.second));
             }
 
             template <typename AnyParameters, typename Executor>
@@ -565,12 +563,12 @@ namespace hpx::parallel::execution {
             HPX_FORCEINLINE static constexpr void call(
                 Parameters& params, Executor&& exec)
             {
-                auto getprop =
+                auto get_prop =
                     get_mark_end_execution(HPX_FORWARD(Executor, exec), params,
                         mark_end_execution_property{});
 
-                getprop.first.mark_end_execution(
-                    HPX_FORWARD(decltype(getprop.second), getprop.second));
+                get_prop.first.mark_end_execution(
+                    HPX_FORWARD(decltype(get_prop.second), get_prop.second));
             }
 
             template <typename AnyParameters, typename Executor>

--- a/libs/core/execution/include/hpx/execution/executors/execution_parameters_fwd.hpp
+++ b/libs/core/execution/include/hpx/execution/executors/execution_parameters_fwd.hpp
@@ -13,7 +13,7 @@
 #include <hpx/execution_base/execution.hpp>
 #include <hpx/execution_base/traits/is_executor.hpp>
 #include <hpx/execution_base/traits/is_executor_parameters.hpp>
-#include <hpx/functional/detail/tag_fallback_invoke.hpp>
+#include <hpx/functional/detail/tag_priority_invoke.hpp>
 #include <hpx/timing/steady_clock.hpp>
 #include <hpx/type_support/decay.hpp>
 
@@ -94,7 +94,7 @@ namespace hpx::parallel::execution {
     ///                 that should be used for parallel execution.
     ///
     inline constexpr struct get_chunk_size_t final
-      : hpx::functional::detail::tag_fallback<get_chunk_size_t>
+      : hpx::functional::detail::tag_priority<get_chunk_size_t>
     {
     private:
         // clang-format off
@@ -154,7 +154,7 @@ namespace hpx::parallel::execution {
     /// \return The execution time for one of the tasks.
     ///
     inline constexpr struct measure_iteration_t final
-      : hpx::functional::detail::tag_fallback<measure_iteration_t>
+      : hpx::functional::detail::tag_priority<measure_iteration_t>
     {
     private:
         // clang-format off
@@ -189,7 +189,7 @@ namespace hpx::parallel::execution {
     ///                 determined for
     ///
     inline constexpr struct maximal_number_of_chunks_t final
-      : hpx::functional::detail::tag_fallback<maximal_number_of_chunks_t>
+      : hpx::functional::detail::tag_priority<maximal_number_of_chunks_t>
     {
     private:
         // clang-format off
@@ -221,7 +221,7 @@ namespace hpx::parallel::execution {
     ///       otherwise it does nothing.
     ///
     inline constexpr struct reset_thread_distribution_t final
-      : hpx::functional::detail::tag_fallback<reset_thread_distribution_t>
+      : hpx::functional::detail::tag_priority<reset_thread_distribution_t>
     {
     private:
         // clang-format off
@@ -257,7 +257,7 @@ namespace hpx::parallel::execution {
     /// \return The number of cores to use
     ///
     inline constexpr struct processing_units_count_t final
-      : hpx::functional::detail::tag_fallback<processing_units_count_t>
+      : hpx::functional::detail::tag_priority<processing_units_count_t>
     {
     private:
         // clang-format off
@@ -329,7 +329,7 @@ namespace hpx::parallel::execution {
     /// Generate a policy that supports setting the number of cores for
     /// execution.
     inline constexpr struct with_processing_units_count_t final
-      : hpx::functional::detail::tag_fallback<with_processing_units_count_t>
+      : hpx::functional::detail::tag_priority<with_processing_units_count_t>
     {
     } with_processing_units_count{};
 
@@ -342,7 +342,7 @@ namespace hpx::parallel::execution {
     ///       otherwise it does nothing.
     ///
     inline constexpr struct mark_begin_execution_t final
-      : hpx::functional::detail::tag_fallback<mark_begin_execution_t>
+      : hpx::functional::detail::tag_priority<mark_begin_execution_t>
     {
     private:
         // clang-format off
@@ -371,7 +371,7 @@ namespace hpx::parallel::execution {
     ///       otherwise it does nothing.
     ///
     inline constexpr struct mark_end_of_scheduling_t final
-      : hpx::functional::detail::tag_fallback<mark_end_of_scheduling_t>
+      : hpx::functional::detail::tag_priority<mark_end_of_scheduling_t>
     {
     private:
         // clang-format off
@@ -400,7 +400,7 @@ namespace hpx::parallel::execution {
     ///       otherwise it does nothing.
     ///
     inline constexpr struct mark_end_execution_t final
-      : hpx::functional::detail::tag_fallback<mark_end_execution_t>
+      : hpx::functional::detail::tag_priority<mark_end_execution_t>
     {
     private:
         // clang-format off
@@ -421,12 +421,8 @@ namespace hpx::parallel::execution {
     } mark_end_execution{};
 }    // namespace hpx::parallel::execution
 
-namespace hpx::execution::experimental {
-
-    template <>
-    struct is_scheduling_property<
-        hpx::parallel::execution::with_processing_units_count_t>
-      : std::true_type
-    {
-    };
-}    // namespace hpx::execution::experimental
+template <>
+struct hpx::execution::experimental::is_scheduling_property<
+    hpx::parallel::execution::with_processing_units_count_t> : std::true_type
+{
+};

--- a/libs/core/execution/include/hpx/execution/executors/guided_chunk_size.hpp
+++ b/libs/core/execution/include/hpx/execution/executors/guided_chunk_size.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2022 Hartmut Kaiser
+//  Copyright (c) 2007-2023 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <hpx/config.hpp>
+#include <hpx/execution/executors/execution_parameters.hpp>
 #include <hpx/execution_base/traits/is_executor_parameters.hpp>
 #include <hpx/serialization/serialize.hpp>
 #include <hpx/timing/steady_clock.hpp>
@@ -21,7 +22,7 @@ namespace hpx::execution::experimental {
 
     ///////////////////////////////////////////////////////////////////////////
     /// Iterations are dynamically assigned to threads in blocks as threads
-    /// request them until no blocks remain to be assigned. Similar to
+    /// request those until no blocks remain to be assigned. Similar to
     /// \a dynamic_chunk_size except that the block size decreases each time a
     /// number of loop iterations is given to a thread. The size of the initial
     /// block is proportional to \a number_of_iterations / \a number_of_cores.
@@ -35,6 +36,13 @@ namespace hpx::execution::experimental {
     ///
     struct guided_chunk_size
     {
+        /// Construct an \a dynamic_chunk_size executor parameters object
+        ///
+        /// \note Default constructed \a dynamic_chunk_size executor parameter
+        ///       types will use a chunk size of '1'.
+        ///
+        guided_chunk_size() = default;
+
         /// Construct a \a guided_chunk_size executor parameters object
         ///
         /// \param min_chunk_size [in] The optional minimal chunk size to use
@@ -43,7 +51,7 @@ namespace hpx::execution::experimental {
         ///                     The default minimal chunk size is 1.
         ///
         constexpr explicit guided_chunk_size(
-            std::size_t min_chunk_size = 1) noexcept
+            std::size_t min_chunk_size) noexcept
           : min_chunk_size_(min_chunk_size)
         {
         }
@@ -53,20 +61,15 @@ namespace hpx::execution::experimental {
         // needs to be invoked for each of the chunks to be combined.
         using has_variable_chunk_size = std::true_type;
 
-        //         template <typename Executor>
-        //         static std::size_t get_maximal_number_of_chunks(
-        //             Executor && exec, std::size_t cores, std:size_t num_tasks)
-        //         {
-        //             // FIXME: find appropriate approximation
-        //             return ...;
-        //         }
-
         template <typename Executor>
-        constexpr std::size_t get_chunk_size(Executor&& /* exec */,
+        friend constexpr std::size_t tag_override_invoke(
+            hpx::parallel::execution::get_chunk_size_t,
+            guided_chunk_size const& this_, Executor&& /* exec */,
             hpx::chrono::steady_duration const&, std::size_t cores,
-            std::size_t num_tasks) const noexcept
+            std::size_t num_tasks) noexcept
         {
-            return (std::max)(min_chunk_size_, (num_tasks + cores - 1) / cores);
+            return (std::max)(
+                this_.min_chunk_size_, (num_tasks + cores - 1) / cores);
         }
         /// \endcond
 
@@ -85,21 +88,18 @@ namespace hpx::execution::experimental {
 
     private:
         /// \cond NOINTERNAL
-        std::size_t min_chunk_size_;
+        std::size_t min_chunk_size_ = 1;
         /// \endcond
     };
 }    // namespace hpx::execution::experimental
 
-namespace hpx::parallel::execution {
-
-    /// \cond NOINTERNAL
-    template <>
-    struct is_executor_parameters<
-        hpx::execution::experimental::guided_chunk_size> : std::true_type
-    {
-    };
-    /// \endcond
-}    // namespace hpx::parallel::execution
+/// \cond NOINTERNAL
+template <>
+struct hpx::parallel::execution::is_executor_parameters<
+    hpx::execution::experimental::guided_chunk_size> : std::true_type
+{
+};
+/// \endcond
 
 namespace hpx::execution {
 

--- a/libs/core/execution/include/hpx/execution/executors/num_cores.hpp
+++ b/libs/core/execution/include/hpx/execution/executors/num_cores.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2022 Hartmut Kaiser
+//  Copyright (c) 2022-2023 Hartmut Kaiser
 //  Copyright (c) 2022 Chuanqiu He
 //
 //  SPDX-License-Identifier: BSL-1.0
@@ -9,11 +9,13 @@
 
 #pragma once
 
-#include <hpx/execution/executors/execution_parameters_fwd.hpp>
+#include <hpx/config.hpp>
+#include <hpx/execution/executors/execution_parameters.hpp>
 #include <hpx/execution_base/traits/is_executor_parameters.hpp>
 #include <hpx/serialization/serialize.hpp>
 #include <hpx/timing/steady_clock.hpp>
 
+#include <algorithm>
 #include <cstddef>
 #include <type_traits>
 
@@ -26,7 +28,8 @@ namespace hpx::execution::experimental {
     {
         /// Construct a \a num_cores executor parameters object
         ///
-        /// \note make sure the minimal number of cores is 1
+        /// \note make sure the minimal number of cores is  and the maximum
+        ///       number of cores is what's available to HPX
         ///
         constexpr explicit num_cores(std::size_t cores = 1) noexcept
           : num_cores_(cores == 0 ? 1 : cores)
@@ -36,19 +39,17 @@ namespace hpx::execution::experimental {
         /// \cond NOINTERNAL
         // discover the number of cores to use for parallelization
         template <typename Executor>
-        friend std::size_t tag_invoke(
+        friend std::size_t tag_override_invoke(
             hpx::parallel::execution::processing_units_count_t,
-            num_cores params, Executor&&, hpx::chrono::steady_duration const&,
-            std::size_t) noexcept
+            num_cores const& this_, Executor&& exec,
+            hpx::chrono::steady_duration const& duration =
+                hpx::chrono::null_duration,
+            std::size_t num_tasks = 0) noexcept
         {
-            return params.num_cores_;
-        }
-
-        template <typename Executor>
-        constexpr std::size_t processing_units_count(Executor&&,
-            hpx::chrono::steady_duration const&, std::size_t) const noexcept
-        {
-            return num_cores_;
+            std::size_t const available_pus =
+                parallel::execution::processing_units_count(
+                    exec, duration, num_tasks);
+            return (std::min)(this_.num_cores_, available_pus);
         }
         /// \endcond
 
@@ -72,16 +73,13 @@ namespace hpx::execution::experimental {
     };
 }    // namespace hpx::execution::experimental
 
-namespace hpx::parallel::execution {
-
-    /// \cond NOINTERNAL
-    template <>
-    struct is_executor_parameters<hpx::execution::experimental::num_cores>
-      : std::true_type
-    {
-    };
-    /// \endcond
-}    // namespace hpx::parallel::execution
+/// \cond NOINTERNAL
+template <>
+struct hpx::parallel::execution::is_executor_parameters<
+    hpx::execution::experimental::num_cores> : std::true_type
+{
+};
+/// \endcond
 
 namespace hpx::execution {
 

--- a/libs/core/execution/include/hpx/execution/executors/persistent_auto_chunk_size.hpp
+++ b/libs/core/execution/include/hpx/execution/executors/persistent_auto_chunk_size.hpp
@@ -1,5 +1,5 @@
 //  Copyright (c) 2016 Zahra Khatami
-//  Copyright (c) 2022 Hartmut Kaiser
+//  Copyright (c) 2022-2023 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -50,9 +50,13 @@ namespace hpx::execution::experimental {
         {
         }
 
-        /// Construct an \a persistent_auto_chunk_size executor parameters object
+        /// Construct an \a persistent_auto_chunk_size executor parameters
+        /// object
         ///
         /// \param time_cs      The execution time for each chunk.
+        /// \param num_iters_for_timing [in] The number of iterations to use for
+        ///                                  measuring the execution time of one
+        ///                                  iteration
         ///
         explicit persistent_auto_chunk_size(
             hpx::chrono::steady_duration const& time_cs,
@@ -69,6 +73,9 @@ namespace hpx::execution::experimental {
         ///                     to decide how many loop iterations should be
         ///                     combined.
         /// \param time_cs       The execution time for each chunk.
+        /// \param num_iters_for_timing [in] The number of iterations to use for
+        ///                                  measuring the execution time of one
+        ///                                  iteration
         ///
         persistent_auto_chunk_size(hpx::chrono::steady_duration const& time_cs,
             hpx::chrono::steady_duration const& rel_time,
@@ -86,35 +93,39 @@ namespace hpx::execution::experimental {
 
         // Estimate execution time for one iteration
         template <typename Executor, typename F>
-        auto measure_iteration(Executor&&, F&& f, std::size_t count)
+        friend auto tag_override_invoke(
+            hpx::parallel::execution::measure_iteration_t,
+            persistent_auto_chunk_size& this_, Executor&&, F&& f,
+            std::size_t count)
         {
             // by default use 1% of the iterations
-            if (num_iters_for_timing_ == 0)
+            if (this_.num_iters_for_timing_ == 0)
             {
-                num_iters_for_timing_ = count / 100;
+                this_.num_iters_for_timing_ = count / 100;
             }
 
             // perform measurements only if necessary
-            if (num_iters_for_timing_ > 0)
+            if (this_.num_iters_for_timing_ > 0)
             {
                 using hpx::chrono::high_resolution_clock;
                 std::uint64_t t = high_resolution_clock::now();
 
-                std::size_t test_chunk_size = f(num_iters_for_timing_);
+                std::size_t const test_chunk_size =
+                    f(this_.num_iters_for_timing_);
                 if (test_chunk_size != 0)
                 {
-                    if (chunk_size_time_ == 0)
+                    if (this_.chunk_size_time_ == 0)
                     {
                         t = (high_resolution_clock::now() - t) /
                             test_chunk_size;
-                        chunk_size_time_ = t;
+                        this_.chunk_size_time_ = t;
                     }
                     else
                     {
-                        t = chunk_size_time_;
+                        t = this_.chunk_size_time_;
                     }
 
-                    if (t != 0 && min_time_ >= t)
+                    if (t != 0 && this_.min_time_ >= t)
                     {
                         // return execution time for one iteration
                         return std::chrono::nanoseconds(t);
@@ -127,16 +138,20 @@ namespace hpx::execution::experimental {
 
         // Estimate a chunk size based on number of cores used.
         template <typename Executor>
-        std::size_t get_chunk_size(Executor& /* exec */,
+        friend std::size_t tag_override_invoke(
+            hpx::parallel::execution::get_chunk_size_t,
+            persistent_auto_chunk_size const& this_, Executor& /* exec */,
             hpx::chrono::steady_duration const& iteration_duration,
             std::size_t cores, std::size_t count) noexcept
         {
             // return chunk size which will create the required amount of work
             if (iteration_duration.value().count() != 0)
             {
-                auto ns = std::chrono::duration_cast<std::chrono::nanoseconds>(
-                    iteration_duration.value());
-                return (std::min)(count, (std::size_t)(min_time_ / ns.count()));
+                auto const ns =
+                    std::chrono::duration_cast<std::chrono::nanoseconds>(
+                        iteration_duration.value());
+                return (std::min)(
+                    count, (std::size_t)(this_.min_time_ / ns.count()));
             }
             return (count + cores - 1) / cores;
         }
@@ -165,17 +180,13 @@ namespace hpx::execution::experimental {
     };
 }    // namespace hpx::execution::experimental
 
-namespace hpx::parallel::execution {
-
-    /// \cond NOINTERNAL
-    template <>
-    struct is_executor_parameters<
-        hpx::execution::experimental::persistent_auto_chunk_size>
-      : std::true_type
-    {
-    };
-    /// \endcond
-}    // namespace hpx::parallel::execution
+/// \cond NOINTERNAL
+template <>
+struct hpx::parallel::execution::is_executor_parameters<
+    hpx::execution::experimental::persistent_auto_chunk_size> : std::true_type
+{
+};
+/// \endcond
 
 namespace hpx::execution {
 

--- a/libs/core/execution/include/hpx/execution/traits/executor_traits.hpp
+++ b/libs/core/execution/include/hpx/execution/traits/executor_traits.hpp
@@ -31,6 +31,7 @@ namespace hpx::execution {
 
         struct adaptive_static_chunk_size;
         struct auto_chunk_size;
+        struct default_parameters;
         struct dynamic_chunk_size;
         struct guided_chunk_size;
         struct persistent_auto_chunk_size;
@@ -162,7 +163,7 @@ namespace hpx::parallel::execution {
 
     public:
         using type = hpx::util::detected_or_t<
-            hpx::execution::experimental::static_chunk_size, parameters_type,
+            hpx::execution::experimental::default_parameters, parameters_type,
             Executor>;
     };
 

--- a/libs/core/executors/include/hpx/executors/execution_policy_parameters.hpp
+++ b/libs/core/executors/include/hpx/executors/execution_policy_parameters.hpp
@@ -52,7 +52,11 @@ namespace hpx::parallel::execution {
             hpx::is_invocable_v<
                 with_processing_units_count_t,
                 typename std::decay_t<ExPolicy>::executor_type, std::size_t> &&
-            detail::has_processing_units_count_v<std::decay_t<Params>>
+            hpx::is_invocable_v<
+                processing_units_count_t,
+                std::decay_t<Params>,
+                typename std::decay_t<ExPolicy>::executor_type,
+                hpx::chrono::steady_duration const&, std::size_t>
         )>
     // clang-format on
     constexpr decltype(auto) tag_invoke(
@@ -61,8 +65,8 @@ namespace hpx::parallel::execution {
         // explicitly extract pu count from given parameters object as otherwise
         // the executor might take precedence
         auto exec = with_processing_units_count(policy.executor(),
-            params.processing_units_count(
-                policy.executor(), hpx::chrono::null_duration, 0));
+            processing_units_count(
+                params, policy.executor(), hpx::chrono::null_duration, 0));
 
         return create_rebound_policy(
             policy, HPX_MOVE(exec), policy.parameters());

--- a/libs/core/executors/include/hpx/executors/explicit_scheduler_executor.hpp
+++ b/libs/core/executors/include/hpx/executors/explicit_scheduler_executor.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2021-2022 Hartmut Kaiser
+//  Copyright (c) 2021-2023 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -12,18 +12,17 @@
 #include <hpx/datastructures/tuple.hpp>
 #include <hpx/execution/algorithms/bulk.hpp>
 #include <hpx/execution/algorithms/keep_future.hpp>
-#include <hpx/execution/algorithms/make_future.hpp>
 #include <hpx/execution/algorithms/start_detached.hpp>
 #include <hpx/execution/algorithms/sync_wait.hpp>
 #include <hpx/execution/algorithms/then.hpp>
 #include <hpx/execution/algorithms/transfer.hpp>
+#include <hpx/execution/executors/default_parameters.hpp>
 #include <hpx/execution/executors/execution.hpp>
 #include <hpx/execution/executors/execution_parameters.hpp>
 #include <hpx/execution_base/execution.hpp>
 #include <hpx/execution_base/sender.hpp>
 #include <hpx/execution_base/traits/is_executor.hpp>
 #include <hpx/functional/bind_back.hpp>
-#include <hpx/functional/bind_front.hpp>
 #include <hpx/functional/deferred_call.hpp>
 #include <hpx/functional/invoke_fused.hpp>
 #include <hpx/functional/tag_invoke.hpp>
@@ -32,11 +31,8 @@
 #include <hpx/timing/steady_clock.hpp>
 
 #include <cstddef>
-#include <exception>
-#include <string>
 #include <type_traits>
 #include <utility>
-#include <vector>
 
 namespace hpx::execution::experimental {
 
@@ -122,9 +118,9 @@ namespace hpx::execution::experimental {
         using execution_category =
             hpx::traits::executor_execution_category_t<BaseScheduler>;
 
-        // Associate the static_chunk_size executor parameters type as a default
+        // Associate the default_parameters executor parameters type as a default
         // with this executor.
-        using executor_parameters_type = static_chunk_size;
+        using executor_parameters_type = default_parameters;
 
         // NonBlockingOneWayExecutor interface
         template <typename F, typename... Ts>
@@ -234,10 +230,10 @@ namespace hpx::execution::experimental {
             static_assert(
                 std::is_void_v<result_type>, "std::is_void_v<result_type>");
 
-            auto prereq =
+            auto pre_req =
                 when_all(keep_future(HPX_FORWARD(Future, predecessor)));
 
-            return bulk(transfer(HPX_MOVE(prereq), exec.sched_), shape,
+            return bulk(transfer(HPX_MOVE(pre_req), exec.sched_), shape,
                 hpx::bind_back(HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...));
         }
 

--- a/libs/core/executors/include/hpx/executors/fork_join_executor.hpp
+++ b/libs/core/executors/include/hpx/executors/fork_join_executor.hpp
@@ -17,9 +17,9 @@
 #include <hpx/coroutines/thread_enums.hpp>
 #include <hpx/errors/try_catch_exception_ptr.hpp>
 #include <hpx/execution/detail/async_launch_policy_dispatch.hpp>
+#include <hpx/execution/executors/default_parameters.hpp>
 #include <hpx/execution/executors/execution.hpp>
 #include <hpx/execution/executors/execution_parameters.hpp>
-#include <hpx/execution/executors/static_chunk_size.hpp>
 #include <hpx/execution_base/this_thread.hpp>
 #include <hpx/execution_base/traits/is_executor.hpp>
 #include <hpx/functional/detail/runtime_get.hpp>
@@ -80,7 +80,7 @@ namespace hpx::execution::experimental {
         /// \cond NOINTERNAL
         using execution_category = hpx::execution::parallel_execution_tag;
         using executor_parameters_type =
-            hpx::execution::experimental::static_chunk_size;
+            hpx::execution::experimental::default_parameters;
         /// \endcond
 
     private:

--- a/libs/core/executors/include/hpx/executors/parallel_executor.hpp
+++ b/libs/core/executors/include/hpx/executors/parallel_executor.hpp
@@ -15,9 +15,9 @@
 #include <hpx/execution/detail/future_exec.hpp>
 #include <hpx/execution/detail/post_policy_dispatch.hpp>
 #include <hpx/execution/detail/sync_launch_policy_dispatch.hpp>
+#include <hpx/execution/executors/default_parameters.hpp>
 #include <hpx/execution/executors/execution_parameters.hpp>
 #include <hpx/execution/executors/fused_bulk_execute.hpp>
-#include <hpx/execution/executors/static_chunk_size.hpp>
 #include <hpx/execution_base/execution.hpp>
 #include <hpx/execution_base/traits/is_executor.hpp>
 #include <hpx/executors/detail/index_queue_spawning.hpp>
@@ -91,9 +91,9 @@ namespace hpx::execution {
             std::conditional_t<std::is_same_v<Policy, launch::sync_policy>,
                 sequenced_execution_tag, parallel_execution_tag>;
 
-        /// Associate the static_chunk_size executor parameters type as a default
+        /// Associate the default_parameters executor parameters type as a default
         /// with this executor.
-        using executor_parameters_type = experimental::static_chunk_size;
+        using executor_parameters_type = experimental::default_parameters;
 
         /// Create a new parallel executor
         constexpr explicit parallel_policy_executor(

--- a/libs/core/tag_invoke/include/hpx/functional/detail/tag_priority_invoke.hpp
+++ b/libs/core/tag_invoke/include/hpx/functional/detail/tag_priority_invoke.hpp
@@ -190,7 +190,7 @@ namespace hpx::functional::detail {
     {
     };
 
-    // CUDA versions less than 11.2 have a template instantiation bug that
+    // CUDA versions less than 11.2 have a template instantiation problem that
     // leaves out certain template arguments and leads to us not being able to
     // correctly check this condition. We default to the more relaxed
     // noexcept(true) to not falsely exclude correct overloads. However, this

--- a/libs/full/include/include/hpx/include/parallel_executor_parameters.hpp
+++ b/libs/full/include/include/hpx/include/parallel_executor_parameters.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2015-2017 Hartmut Kaiser
+//  Copyright (c) 2015-2023 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -9,6 +9,7 @@
 #include <hpx/execution/executors/execution_parameters.hpp>
 
 #include <hpx/execution/executors/auto_chunk_size.hpp>
+#include <hpx/execution/executors/default_parameters.hpp>
 #include <hpx/execution/executors/dynamic_chunk_size.hpp>
 #include <hpx/execution/executors/guided_chunk_size.hpp>
 #include <hpx/execution/executors/persistent_auto_chunk_size.hpp>

--- a/tests/performance/local/future_overhead.cpp
+++ b/tests/performance/local/future_overhead.cpp
@@ -277,14 +277,17 @@ void measure_function_futures_sliding_semaphore(
 struct unlimited_number_of_chunks
 {
     template <typename Executor>
-    std::size_t maximal_number_of_chunks(
-        Executor&& /*executor*/, std::size_t /*cores*/, std::size_t num_tasks)
+    friend std::size_t tag_override_invoke(
+        hpx::parallel::execution::maximal_number_of_chunks_t,
+        unlimited_number_of_chunks, Executor&&, std::size_t,
+        std::size_t num_tasks)
     {
         return num_tasks;
     }
 };
 
 namespace hpx::parallel::execution {
+
     template <>
     struct is_executor_parameters<unlimited_number_of_chunks> : std::true_type
     {


### PR DESCRIPTION
This introduces a breaking change as it changes the preferences for which of the parametrizations for execution policies takes a preference. With this change parameter values introduced through execution parameter objects take always precedence. 

This change also enforces using `tag_invoke` for exposing parameter values from executors and `tag_override_invoke` for exposing those from execution parameter objects.