### PR TITLE
Fixing allocation/deallocation mismatch in serialize_buffer

### DIFF
--- a/libs/core/serialization/include/hpx/serialization/serialize_buffer.hpp
+++ b/libs/core/serialization/include/hpx/serialization/serialize_buffer.hpp
@@ -127,7 +127,7 @@ namespace hpx::serialization {
             auto* p = detail::array_allocator<allocator_type>()(alloc_, size);
             data_.reset(
                 p, [alloc = this->alloc_, size = this->size_](T* p) noexcept {
-                    serialize_buffer::deleter<allocator_type>()(p, alloc, size);
+                    detail::array_deleter<allocator_type>()(p, alloc, size);
                 });
         }
 


### PR DESCRIPTION
Fixes problems reported by gcc V12 (https://cdash.cscs.ch/viewBuildError.php?buildid=123285)