### PR TITLE
effort to resolve build breaking gasnet issues

### DIFF
--- a/.jenkins/lsu/env-clang-12.sh
+++ b/.jenkins/lsu/env-clang-12.sh
@@ -14,7 +14,7 @@ module load pwrapi/1.1.1
 
 export HPXRUN_RUNWRAPPER=srun
 export CXX_STD="20"
-export PKG_CONFIG_PATH=/usr/local/lib/pkgconfig:$PKG_CONFIG_PATH
+export PKG_CONFIG_PATH=/usr/local/lib64/pkgconfig:/usr/local/lib/pkgconfig:$PKG_CONFIG_PATH
 
 configure_extra_options+=" -DCMAKE_BUILD_TYPE=${build_type}"
 configure_extra_options+=" -DHPX_WITH_CXX_STANDARD=${CXX_STD}"
@@ -25,11 +25,11 @@ configure_extra_options+=" -DHPX_WITH_COMPILER_WARNINGS_AS_ERRORS=ON"
 configure_extra_options+=" -DHPX_WITH_PARCELPORT_MPI=ON"
 configure_extra_options+=" -DHPX_WITH_PARCELPORT_LCI=ON"
 configure_extra_options+=" -DHPX_WITH_FETCH_LCI=ON"
-configure_extra_options+=" -DHPX_WITH_PARCELPORT_GASNET=ON"
-configure_extra_options+=" -DHPX_WITH_FETCH_GASNET=ON"
 configure_extra_options+=" -DCMAKE_C_COMPILER=clang"
 configure_extra_options+=" -DCMAKE_C_FLAGS=-fPIC"
-configure_extra_options+=" -DHPX_WITH_PARCELPORT_GASNET_CONDUIT=smp"
+configure_extra_options+=" -DHPX_WITH_PARCELPORT_GASNET=ON"
+configure_extra_options+=" -DHPX_WITH_FETCH_GASNET=ON"
+configure_extra_options+=" -DHPX_WITH_PARCELPORT_GASNET_CONDUIT=mpi"
 configure_extra_options+=" -DHPX_WITH_LOGGING=OFF"
 
 # The pwrapi library still needs to be set up properly on rostam

--- a/.jenkins/lsu/env-clang-13.sh
+++ b/.jenkins/lsu/env-clang-13.sh
@@ -14,7 +14,7 @@ module load pwrapi/1.1.1
 
 export HPXRUN_RUNWRAPPER=srun
 export CXX_STD="17"
-export PKG_CONFIG_PATH=/usr/local/lib/pkgconfig:$PKG_CONFIG_PATH
+export PKG_CONFIG_PATH=/usr/local/lib64/pkgconfig:/usr/local/lib/pkgconfig:$PKG_CONFIG_PATH
 
 configure_extra_options+=" -DCMAKE_BUILD_TYPE=${build_type}"
 configure_extra_options+=" -DHPX_WITH_CXX_STANDARD=${CXX_STD}"
@@ -25,11 +25,11 @@ configure_extra_options+=" -DHPX_WITH_COMPILER_WARNINGS_AS_ERRORS=ON"
 configure_extra_options+=" -DHPX_WITH_PARCELPORT_MPI=ON"
 configure_extra_options+=" -DHPX_WITH_PARCELPORT_LCI=ON"
 configure_extra_options+=" -DHPX_WITH_FETCH_LCI=ON"
-configure_extra_options+=" -DHPX_WITH_PARCELPORT_GASNET=ON"
-configure_extra_options+=" -DHPX_WITH_FETCH_GASNET=ON"
 configure_extra_options+=" -DCMAKE_C_COMPILER=clang"
 configure_extra_options+=" -DCMAKE_C_FLAGS=-fPIC"
-configure_extra_options+=" -DHPX_WITH_PARCELPORT_GASNET_CONDUIT=smp"
+configure_extra_options+=" -DHPX_WITH_PARCELPORT_GASNET=ON"
+configure_extra_options+=" -DHPX_WITH_FETCH_GASNET=ON"
+configure_extra_options+=" -DHPX_WITH_PARCELPORT_GASNET_CONDUIT=mpi"
 configure_extra_options+=" -DHPX_WITH_LOGGING=OFF"
 configure_extra_options+=" -DHPX_WITH_TESTS_COMMAND_LINE=--hpx:queuing=local-workrequesting-fifo"
 

--- a/.jenkins/lsu/env-clang-14.sh
+++ b/.jenkins/lsu/env-clang-14.sh
@@ -14,7 +14,7 @@ module load pwrapi/1.1.1
 
 export HPXRUN_RUNWRAPPER=srun
 export CXX_STD="20"
-export PKG_CONFIG_PATH=/usr/local/lib/pkgconfig:$PKG_CONFIG_PATH
+export PKG_CONFIG_PATH=/usr/local/lib64/pkgconfig:/usr/local/lib/pkgconfig:$PKG_CONFIG_PATH
 
 configure_extra_options+=" -DCMAKE_BUILD_TYPE=${build_type}"
 configure_extra_options+=" -DHPX_WITH_CXX_STANDARD=${CXX_STD}"
@@ -25,11 +25,11 @@ configure_extra_options+=" -DHPX_WITH_COMPILER_WARNINGS_AS_ERRORS=ON"
 configure_extra_options+=" -DHPX_WITH_PARCELPORT_MPI=ON"
 configure_extra_options+=" -DHPX_WITH_PARCELPORT_LCI=ON"
 configure_extra_options+=" -DHPX_WITH_FETCH_LCI=ON"
-configure_extra_options+=" -DHPX_WITH_PARCELPORT_GASNET=ON"
-configure_extra_options+=" -DHPX_WITH_FETCH_GASNET=ON"
 configure_extra_options+=" -DCMAKE_C_COMPILER=clang"
 configure_extra_options+=" -DCMAKE_C_FLAGS=-fPIC"
-configure_extra_options+=" -DHPX_WITH_PARCELPORT_GASNET_CONDUIT=smp"
+configure_extra_options+=" -DHPX_WITH_PARCELPORT_GASNET=ON"
+configure_extra_options+=" -DHPX_WITH_FETCH_GASNET=ON"
+configure_extra_options+=" -DHPX_WITH_PARCELPORT_GASNET_CONDUIT=mpi"
 configure_extra_options+=" -DHPX_WITH_LOGGING=OFF"
 configure_extra_options+=" -DHPX_WITH_DATAPAR_BACKEND=EVE"
 configure_extra_options+=" -DHPX_WITH_FETCH_EVE=ON"

--- a/.jenkins/lsu/env-clang-15.sh
+++ b/.jenkins/lsu/env-clang-15.sh
@@ -14,7 +14,7 @@ module load pwrapi/1.1.1
 
 export HPXRUN_RUNWRAPPER=srun
 export CXX_STD="20"
-export PKG_CONFIG_PATH=/usr/local/lib/pkgconfig:$PKG_CONFIG_PATH
+export PKG_CONFIG_PATH=/usr/local/lib64/pkgconfig:/usr/local/lib/pkgconfig:$PKG_CONFIG_PATH
 
 configure_extra_options+=" -DCMAKE_BUILD_TYPE=${build_type}"
 configure_extra_options+=" -DHPX_WITH_CXX_STANDARD=${CXX_STD}"
@@ -25,11 +25,11 @@ configure_extra_options+=" -DHPX_WITH_COMPILER_WARNINGS_AS_ERRORS=ON"
 configure_extra_options+=" -DHPX_WITH_PARCELPORT_MPI=ON"
 configure_extra_options+=" -DHPX_WITH_PARCELPORT_LCI=ON"
 configure_extra_options+=" -DHPX_WITH_FETCH_LCI=ON"
-configure_extra_options+=" -DHPX_WITH_PARCELPORT_GASNET=ON"
-configure_extra_options+=" -DHPX_WITH_FETCH_GASNET=ON"
 configure_extra_options+=" -DCMAKE_C_COMPILER=clang"
 configure_extra_options+=" -DCMAKE_C_FLAGS=-fPIC"
-configure_extra_options+=" -DHPX_WITH_PARCELPORT_GASNET_CONDUIT=smp"
+configure_extra_options+=" -DHPX_WITH_PARCELPORT_GASNET=ON"
+configure_extra_options+=" -DHPX_WITH_FETCH_GASNET=ON"
+configure_extra_options+=" -DHPX_WITH_PARCELPORT_GASNET_CONDUIT=mpi"
 configure_extra_options+=" -DHPX_WITH_LOGGING=OFF"
 configure_extra_options+=" -DHPX_WITH_DATAPAR_BACKEND=EVE"
 configure_extra_options+=" -DHPX_WITH_FETCH_EVE=ON"

--- a/.jenkins/lsu/env-clang-16.sh
+++ b/.jenkins/lsu/env-clang-16.sh
@@ -14,7 +14,7 @@ module load pwrapi/1.1.1
 
 export HPXRUN_RUNWRAPPER=srun
 export CXX_STD="20"
-export PKG_CONFIG_PATH=/usr/local/lib/pkgconfig:$PKG_CONFIG_PATH
+export PKG_CONFIG_PATH=/usr/local/lib64/pkgconfig:/usr/local/lib/pkgconfig:$PKG_CONFIG_PATH
 
 configure_extra_options+=" -DCMAKE_BUILD_TYPE=${build_type}"
 configure_extra_options+=" -DHPX_WITH_CXX_STANDARD=${CXX_STD}"
@@ -25,11 +25,11 @@ configure_extra_options+=" -DHPX_WITH_COMPILER_WARNINGS_AS_ERRORS=ON"
 configure_extra_options+=" -DHPX_WITH_PARCELPORT_MPI=ON"
 configure_extra_options+=" -DHPX_WITH_PARCELPORT_LCI=ON"
 configure_extra_options+=" -DHPX_WITH_FETCH_LCI=ON"
-configure_extra_options+=" -DHPX_WITH_PARCELPORT_GASNET=ON"
-configure_extra_options+=" -DHPX_WITH_FETCH_GASNET=ON"
 configure_extra_options+=" -DCMAKE_C_COMPILER=clang"
 configure_extra_options+=" -DCMAKE_C_FLAGS=-fPIC"
-configure_extra_options+=" -DHPX_WITH_PARCELPORT_GASNET_CONDUIT=smp"
+configure_extra_options+=" -DHPX_WITH_PARCELPORT_GASNET=ON"
+configure_extra_options+=" -DHPX_WITH_FETCH_GASNET=ON"
+configure_extra_options+=" -DHPX_WITH_PARCELPORT_GASNET_CONDUIT=mpi"
 configure_extra_options+=" -DHPX_WITH_LOGGING=OFF"
 configure_extra_options+=" -DHPX_WITH_DATAPAR_BACKEND=EVE"
 configure_extra_options+=" -DHPX_WITH_FETCH_EVE=ON"

--- a/.jenkins/lsu/env-clang-17.sh
+++ b/.jenkins/lsu/env-clang-17.sh
@@ -14,7 +14,7 @@ module load pwrapi/1.1.1
 
 export HPXRUN_RUNWRAPPER=srun
 export CXX_STD="20"
-export PKG_CONFIG_PATH=/usr/local/lib/pkgconfig:$PKG_CONFIG_PATH
+export PKG_CONFIG_PATH=/usr/local/lib64/pkgconfig:/usr/local/lib/pkgconfig:$PKG_CONFIG_PATH
 
 configure_extra_options+=" -DCMAKE_BUILD_TYPE=${build_type}"
 configure_extra_options+=" -DHPX_WITH_CXX_STANDARD=${CXX_STD}"
@@ -25,11 +25,11 @@ configure_extra_options+=" -DHPX_WITH_COMPILER_WARNINGS_AS_ERRORS=ON"
 configure_extra_options+=" -DHPX_WITH_PARCELPORT_MPI=ON"
 configure_extra_options+=" -DHPX_WITH_PARCELPORT_LCI=ON"
 configure_extra_options+=" -DHPX_WITH_FETCH_LCI=ON"
-configure_extra_options+=" -DHPX_WITH_PARCELPORT_GASNET=ON"
-configure_extra_options+=" -DHPX_WITH_FETCH_GASNET=ON"
 configure_extra_options+=" -DCMAKE_C_COMPILER=clang"
 configure_extra_options+=" -DCMAKE_C_FLAGS=-fPIC"
-configure_extra_options+=" -DHPX_WITH_PARCELPORT_GASNET_CONDUIT=smp"
+configure_extra_options+=" -DHPX_WITH_PARCELPORT_GASNET=ON"
+configure_extra_options+=" -DHPX_WITH_FETCH_GASNET=ON"
+configure_extra_options+=" -DHPX_WITH_PARCELPORT_GASNET_CONDUIT=mpi"
 configure_extra_options+=" -DHPX_WITH_LOGGING=OFF"
 configure_extra_options+=" -DHPX_WITH_DATAPAR_BACKEND=EVE"
 configure_extra_options+=" -DHPX_WITH_FETCH_EVE=ON"

--- a/.jenkins/lsu/env-gcc-10.sh
+++ b/.jenkins/lsu/env-gcc-10.sh
@@ -14,7 +14,7 @@ module load pwrapi/1.1.1
 
 export HPXRUN_RUNWRAPPER=srun
 export CXX_STD="17"
-export PKG_CONFIG_PATH=/usr/local/lib/pkgconfig:$PKG_CONFIG_PATH
+export PKG_CONFIG_PATH=/usr/local/lib64/pkgconfig:/usr/local/lib/pkgconfig:$PKG_CONFIG_PATH
 
 configure_extra_options+=" -DHPX_WITH_CXX_STANDARD=${CXX_STD}"
 configure_extra_options+=" -DHPX_WITH_MALLOC=system"
@@ -25,11 +25,11 @@ configure_extra_options+=" -DHPX_WITH_COMPILER_WARNINGS_AS_ERRORS=ON"
 configure_extra_options+=" -DHPX_WITH_PARCELPORT_MPI=ON"
 configure_extra_options+=" -DHPX_WITH_PARCELPORT_LCI=ON"
 configure_extra_options+=" -DHPX_WITH_FETCH_LCI=ON"
-configure_extra_options+=" -DHPX_WITH_PARCELPORT_GASNET=ON"
-configure_extra_options+=" -DHPX_WITH_FETCH_GASNET=ON"
 configure_extra_options+=" -DCMAKE_C_COMPILER=gcc"
 configure_extra_options+=" -DCMAKE_C_FLAGS=-fPIC"
-configure_extra_options+=" -DHPX_WITH_PARCELPORT_GASNET_CONDUIT=smp"
+configure_extra_options+=" -DHPX_WITH_PARCELPORT_GASNET=ON"
+configure_extra_options+=" -DHPX_WITH_FETCH_GASNET=ON"
+configure_extra_options+=" -DHPX_WITH_PARCELPORT_GASNET_CONDUIT=mpi"
 
 # The pwrapi library still needs to be set up properly on rostam
 # configure_extra_options+=" -DHPX_WITH_POWER_COUNTER=ON"

--- a/.jenkins/lsu/env-gcc-12.sh
+++ b/.jenkins/lsu/env-gcc-12.sh
@@ -14,7 +14,7 @@ module load pwrapi/1.1.1
 
 export HPXRUN_RUNWRAPPER=srun
 export CXX_STD="20"
-export PKG_CONFIG_PATH=/usr/local/lib/pkgconfig:$PKG_CONFIG_PATH
+export PKG_CONFIG_PATH=/usr/local/lib64/pkgconfig:/usr/local/lib/pkgconfig:$PKG_CONFIG_PATH
 
 configure_extra_options+=" -DHPX_WITH_CXX_STANDARD=${CXX_STD}"
 configure_extra_options+=" -DHPX_WITH_MALLOC=system"
@@ -24,11 +24,11 @@ configure_extra_options+=" -DHPX_WITH_COMPILER_WARNINGS_AS_ERRORS=ON"
 configure_extra_options+=" -DHPX_WITH_PARCELPORT_MPI=ON"
 configure_extra_options+=" -DHPX_WITH_PARCELPORT_LCI=ON"
 configure_extra_options+=" -DHPX_WITH_FETCH_LCI=ON"
-configure_extra_options+=" -DHPX_WITH_PARCELPORT_GASNET=ON"
-configure_extra_options+=" -DHPX_WITH_FETCH_GASNET=ON"
 configure_extra_options+=" -DCMAKE_C_COMPILER=gcc"
 configure_extra_options+=" -DCMAKE_C_FLAGS=-fPIC"
-configure_extra_options+=" -DHPX_WITH_PARCELPORT_GASNET_CONDUIT=smp"
+configure_extra_options+=" -DHPX_WITH_PARCELPORT_GASNET=ON"
+configure_extra_options+=" -DHPX_WITH_FETCH_GASNET=ON"
+configure_extra_options+=" -DHPX_WITH_PARCELPORT_GASNET_CONDUIT=mpi"
 configure_extra_options+=" -DHPX_WITH_DATAPAR_BACKEND=EVE"
 configure_extra_options+=" -DHPX_WITH_FETCH_EVE=ON"
 configure_extra_options+=" -DHPX_WITH_EVE_TAG=main"

--- a/.jenkins/lsu/env-gcc-13.sh
+++ b/.jenkins/lsu/env-gcc-13.sh
@@ -14,7 +14,7 @@ module load pwrapi/1.1.1
 
 export HPXRUN_RUNWRAPPER=srun
 export CXX_STD="20"
-export PKG_CONFIG_PATH=/usr/local/lib/pkgconfig:$PKG_CONFIG_PATH
+export PKG_CONFIG_PATH=/usr/local/lib64/pkgconfig:/usr/local/lib/pkgconfig:$PKG_CONFIG_PATH
 
 configure_extra_options+=" -DHPX_WITH_CXX_STANDARD=${CXX_STD}"
 configure_extra_options+=" -DHPX_WITH_MALLOC=system"
@@ -24,11 +24,11 @@ configure_extra_options+=" -DHPX_WITH_COMPILER_WARNINGS_AS_ERRORS=ON"
 configure_extra_options+=" -DHPX_WITH_PARCELPORT_MPI=ON"
 configure_extra_options+=" -DHPX_WITH_PARCELPORT_LCI=ON"
 configure_extra_options+=" -DHPX_WITH_FETCH_LCI=ON"
-configure_extra_options+=" -DHPX_WITH_PARCELPORT_GASNET=ON"
-configure_extra_options+=" -DHPX_WITH_FETCH_GASNET=ON"
 configure_extra_options+=" -DCMAKE_C_COMPILER=gcc"
 configure_extra_options+=" -DCMAKE_C_FLAGS=-fPIC"
-configure_extra_options+=" -DHPX_WITH_PARCELPORT_GASNET_CONDUIT=smp"
+configure_extra_options+=" -DHPX_WITH_PARCELPORT_GASNET=ON"
+configure_extra_options+=" -DHPX_WITH_FETCH_GASNET=ON"
+configure_extra_options+=" -DHPX_WITH_PARCELPORT_GASNET_CONDUIT=mpi"
 configure_extra_options+=" -DHPX_WITH_DATAPAR_BACKEND=EVE"
 configure_extra_options+=" -DHPX_WITH_FETCH_EVE=ON"
 configure_extra_options+=" -DHPX_WITH_EVE_TAG=main"

--- a/cmake/HPX_AddTest.cmake
+++ b/cmake/HPX_AddTest.cmake
@@ -92,9 +92,6 @@ function(add_hpx_test category name)
   endif()
 
   set(ENV_VAR "")
-  if(HPX_WITH_PARCELPORT_GASNET)
-    set(ENV_VAR "GASNET_PSHM_NODES=2")
-  endif()
 
   # cmake-format: off
   set(cmd

--- a/cmake/templates/hpxrun.py.in
+++ b/cmake/templates/hpxrun.py.in
@@ -195,10 +195,18 @@ def run_mpi(cmd, localities, verbose):
         print('Executing command: ' + ' '.join(exec_cmd))
     subproc(exec_cmd)
 
-# Run with amudprun
-# This is executing amudprun with the "-np" option set to the number of localities
 def run_gasnet(cmd, localities, verbose):
-    exec_cmd = ['amudprun', '-np', str(localities)] + cmd
+    os.environ['GASNET_QUIET'] = 'yes'
+    os.environ['GASNET_ROUTE_OUTPUT'] = '0'
+    mpiexec = '@MPIEXEC@'
+    if mpiexec == '':
+        mpiexec = '@MPIEXEC_EXECUTABLE@'
+    if mpiexec == '':
+        msg = 'mpiexec not available on this platform. '
+        msg += 'Please rerun CMake with HPX_PARCELPORT_MPI=True.'
+        print(msg, sys.stderr)
+        sys.exit(1)
+    exec_cmd = [mpiexec, '@MPIEXEC_NUMPROC_FLAG@', str(localities)] + cmd
     if verbose:
         print('Executing command: ' + ' '.join(exec_cmd))
     subproc(exec_cmd)

--- a/libs/core/gasnet_base/src/gasnet_environment.cpp
+++ b/libs/core/gasnet_base/src/gasnet_environment.cpp
@@ -251,7 +251,7 @@ namespace hpx::util {
     bool gasnet_environment::check_gasnet_environment(
         util::runtime_configuration const& cfg)
     {
-#if defined(HPX_HAVE_NETWORKING) && defined(HPX_HAVE_MODULE_GASNET_BASE)
+#if defined(HPX_HAVE_NETWORKING) && defined(HPX_HAVE_PARCELPORT_GASNET)
         // We disable the GASNET parcelport if any of these hold:
         //
         // - The parcelport is explicitly disabled
@@ -262,9 +262,9 @@ namespace hpx::util {
             (get_entry_as(cfg, "hpx.parcel.tcp.enable", 1) &&
                 (get_entry_as(cfg, "hpx.parcel.tcp.priority", 1) >
                     get_entry_as(cfg, "hpx.parcel.gasnet.priority", 0))) ||
-            (get_entry_as(cfg, "hpx.parcel.gasnet.enable", 1) &&
-                (get_entry_as(cfg, "hpx.parcel.gasnet.priority", 1) >
-                    get_entry_as(cfg, "hpx.parcel.mpi.priority", 0))))
+            (get_entry_as(cfg, "hpx.parcel.mpi.enable", 1) &&
+                (get_entry_as(cfg, "hpx.parcel.mpi.priority", 1) >
+                    get_entry_as(cfg, "hpx.parcel.gasnet.priority", 0))))
         {
             LBT_(info)
                 << "GASNET support disabled via configuration settings\n";
@@ -278,7 +278,7 @@ namespace hpx::util {
     }
 }    // namespace hpx::util
 
-#if (defined(HPX_HAVE_NETWORKING) && defined(HPX_HAVE_MODULE_GASNET_BASE))
+#if (defined(HPX_HAVE_NETWORKING) && defined(HPX_HAVE_PARCELPORT_GASNET))
 
 namespace hpx::util {
 


### PR DESCRIPTION
Fixes #6385

## Proposed Changes

  - modify builders to use gasnet-mpi
  - modify the hpxrun script to use mpiexec when testing gasnet-mpi
  - update the gasnet environment logic to enable or disable gasnet

## Any background context you want to provide?

the gasnet parcelport was merged into hpx and had started causing other parcelport tests to silently fail

## Checklist

Not all points below apply to all pull requests.

- [x] I have added a new feature and have added tests to go along with it.
- [x] I have fixed a bug and have added a regression test.
- [ ] I have added a test using random numbers; I have made sure it uses a seed, and that random numbers generated are valid inputs for the tests.
