### PR TITLE
Need to break out of the loop when searching the suffixes.

### DIFF
--- a/cmake/templates/hpxcxx.in
+++ b/cmake/templates/hpxcxx.in
@@ -107,12 +107,16 @@ while i < len(sys.argv):
 
 pkgconf = None
 for path in pkgconfpath:
-    for suffix in [pkgconf_suffix, "_release", "_relwithdebuginfo","_debug","_minsizerel"]:
+    found = False
+    for suffix in [pkgconf_suffix, "_release", "_relwithdebuginfo","_debug"]:
         hpath = os.path.join(path,"hpx_application")+suffix+".pc"
         if os.path.exists(hpath):
             pkgconf = path
             pkgconf_suffix = suffix
+            found = True
             break
+    if found:
+       break
 
 if pkgconf == None:
     sys.stderr.write('Cannot locate HPX\n')


### PR DESCRIPTION
Fixes issue with hpxcxx. The program does not break out of the outer loop after it finds a matching suffix like it should.