### PR TITLE
Making function local constexpr variables non-static

### DIFF
--- a/libs/core/algorithms/include/hpx/parallel/algorithms/for_each.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/for_each.hpp
@@ -421,7 +421,7 @@ namespace hpx::parallel {
             static decltype(auto) parallel(ExPolicy&& policy, FwdIter first,
                 std::size_t count, F&& f, Proj&& proj /* = Proj()*/)
             {
-                static constexpr bool has_scheduler_executor =
+                constexpr bool has_scheduler_executor =
                     hpx::execution_policy_has_scheduler_executor_v<ExPolicy>;
 
                 if constexpr (!has_scheduler_executor)
@@ -506,7 +506,7 @@ namespace hpx::parallel {
                     hpx::parallel::util::detail::algorithm_result<ExPolicy,
                         FwdIterB>;
 
-                static constexpr bool has_scheduler_executor =
+                constexpr bool has_scheduler_executor =
                     hpx::execution_policy_has_scheduler_executor_v<ExPolicy>;
 
                 if constexpr (!has_scheduler_executor)

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/rotate.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/rotate.hpp
@@ -268,7 +268,7 @@ namespace hpx::parallel {
                 hpx::launch::sync,
                 [=](auto&& f1, auto&& f2) mutable {
                     // propagate exceptions, if appropriate
-                    static constexpr bool handle_futures =
+                    constexpr bool handle_futures =
                         hpx::traits::is_future_v<decltype((f1))> &&
                         hpx::traits::is_future_v<decltype((f2))>;
 

--- a/libs/core/algorithms/include/hpx/parallel/util/adapt_placement_mode.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/util/adapt_placement_mode.hpp
@@ -23,7 +23,7 @@ namespace hpx::parallel::util {
     decltype(auto) adapt_placement_mode(
         ExPolicy&& policy, hpx::threads::thread_placement_hint placement)
     {
-        static constexpr bool supports_placement_hint =
+        constexpr bool supports_placement_hint =
             hpx::functional::is_tag_invocable_v<
                 hpx::execution::experimental::with_hint_t,
                 std::decay_t<ExPolicy>, hpx::threads::thread_schedule_hint>;

--- a/libs/core/algorithms/include/hpx/parallel/util/adapt_sharing_mode.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/util/adapt_sharing_mode.hpp
@@ -23,7 +23,7 @@ namespace hpx::parallel::util {
     decltype(auto) adapt_sharing_mode(
         ExPolicy&& policy, hpx::threads::thread_sharing_hint sharing)
     {
-        static constexpr bool supports_sharing_hint =
+        constexpr bool supports_sharing_hint =
             hpx::functional::is_tag_invocable_v<
                 hpx::execution::experimental::with_hint_t,
                 std::decay_t<ExPolicy>, hpx::threads::thread_schedule_hint>;

--- a/libs/core/algorithms/include/hpx/parallel/util/adapt_thread_priority.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/util/adapt_thread_priority.hpp
@@ -23,7 +23,7 @@ namespace hpx::parallel::util {
     decltype(auto) adapt_thread_priority(
         ExPolicy&& policy, hpx::threads::thread_priority new_priority)
     {
-        static constexpr bool supports_priority =
+        constexpr bool supports_priority =
             hpx::functional::is_tag_invocable_v<
                 hpx::execution::experimental::with_priority_t,
                 std::decay_t<ExPolicy>, hpx::threads::thread_priority>;

--- a/libs/core/futures/include/hpx/futures/packaged_continuation.hpp
+++ b/libs/core/futures/include/hpx/futures/packaged_continuation.hpp
@@ -55,7 +55,7 @@ namespace hpx::lcos::detail {
         hpx::intrusive_ptr<Continuation> keep_alive(&cont);
         hpx::detail::try_catch_exception_ptr(
             [&]() {
-                static constexpr bool is_void =
+                constexpr bool is_void =
                     std::is_void_v<util::invoke_result_t<Func, Future&&>>;
 
                 if constexpr (is_void)
@@ -75,7 +75,7 @@ namespace hpx::lcos::detail {
     void invoke_continuation(Func& func, Future&& future, Continuation& cont)
     {
         using inner_future = util::invoke_result_t<Func, Future>;
-        static constexpr bool is_unique_future =
+        constexpr bool is_unique_future =
             traits::detail::is_unique_future_v<inner_future>;
 
         if constexpr (!is_unique_future)

--- a/libs/core/lcos_local/tests/unit/local_dataflow_external_future.cpp
+++ b/libs/core/lcos_local/tests/unit/local_dataflow_external_future.cpp
@@ -61,7 +61,7 @@ struct external_future_executor
     template <typename Frame, typename F, typename Futures>
     void dataflow_finalize(Frame&& frame, F&& f, Futures&& futures)
     {
-        static constexpr bool is_void =
+        constexpr bool is_void =
             std::remove_pointer_t<std::decay_t<Frame>>::is_void::value;
 
         hpx::detail::try_catch_exception_ptr(
@@ -139,7 +139,7 @@ struct external_future_additional_argument_executor
     template <typename Frame, typename F, typename Futures>
     void dataflow_finalize(Frame&& frame, F&& f, Futures&& futures)
     {
-        static constexpr bool is_void =
+        constexpr bool is_void =
             std::remove_pointer_t<std::decay_t<Frame>>::is_void::value;
 
         hpx::detail::try_catch_exception_ptr(

--- a/libs/core/serialization/include/hpx/serialization/array.hpp
+++ b/libs/core/serialization/include/hpx/serialization/array.hpp
@@ -71,7 +71,7 @@ namespace hpx::serialization {
 #endif
             using element_type = std::remove_const_t<T>;
 
-            static constexpr bool use_optimized =
+            constexpr bool use_optimized =
                 std::is_default_constructible_v<element_type> &&
                 (hpx::traits::is_bitwise_serializable_v<element_type> ||
                     !hpx::traits::is_not_bitwise_serializable_v<element_type>);

--- a/libs/core/serialization/include/hpx/serialization/detail/serialize_collection.hpp
+++ b/libs/core/serialization/include/hpx/serialization/detail/serialize_collection.hpp
@@ -73,7 +73,7 @@ namespace hpx::serialization::detail {
         }
         else
         {
-            static constexpr bool is_polymorphic =
+            constexpr bool is_polymorphic =
                 hpx::traits::is_intrusive_polymorphic_v<value_type> ||
                 hpx::traits::is_nonintrusive_polymorphic_v<value_type>;
 

--- a/libs/core/serialization/include/hpx/serialization/map.hpp
+++ b/libs/core/serialization/include/hpx/serialization/map.hpp
@@ -45,7 +45,7 @@ namespace hpx::serialization {
     {
         using pair_type = std::pair<Key, Value>;
 
-        static constexpr bool optimized =
+        constexpr bool optimized =
             hpx::traits::is_bitwise_serializable_v<pair_type> ||
             !hpx::traits::is_not_bitwise_serializable_v<pair_type>;
 
@@ -81,7 +81,7 @@ namespace hpx::serialization {
     {
         using pair_type = std::pair<Key, Value>;
 
-        static constexpr bool optimized =
+        constexpr bool optimized =
             hpx::traits::is_bitwise_serializable_v<pair_type> ||
             !hpx::traits::is_not_bitwise_serializable_v<pair_type>;
 

--- a/libs/core/serialization/include/hpx/serialization/vector.hpp
+++ b/libs/core/serialization/include/hpx/serialization/vector.hpp
@@ -61,7 +61,7 @@ namespace hpx::serialization {
         using element_type =
             std::remove_const_t<typename std::vector<T, Allocator>::value_type>;
 
-        static constexpr bool use_optimized =
+        constexpr bool use_optimized =
             std::is_default_constructible_v<element_type> &&
             (hpx::traits::is_bitwise_serializable_v<element_type> ||
                 !hpx::traits::is_not_bitwise_serializable_v<element_type>);
@@ -126,7 +126,7 @@ namespace hpx::serialization {
         using element_type =
             std::remove_const_t<typename std::vector<T, Allocator>::value_type>;
 
-        static constexpr bool use_optimized =
+        constexpr bool use_optimized =
             std::is_default_constructible_v<element_type> &&
             (hpx::traits::is_bitwise_serializable_v<element_type> ||
                 !hpx::traits::is_not_bitwise_serializable_v<element_type>);


### PR DESCRIPTION
- this helps working around recent MSVC problems
