### PR TITLE
Adding option for installing Hwloc using CMake FetchContent

### DIFF
--- a/.github/workflows/linux_debug_fetch_hwloc.yml
+++ b/.github/workflows/linux_debug_fetch_hwloc.yml
@@ -6,13 +6,7 @@
 
 name: Linux CI (Debug) with HWLoc fetch
 
-on: 
-  push: 
-    branches: [cmake_options] 
-    paths:
-      - ".github/workflows/linux_debug_fetch_hwloc.yml"
-      - "CMakeLists.txt"
-      - "cmake/**"
+on: [pull_request]
 
 jobs:
   build:

--- a/.github/workflows/linux_debug_fetch_hwloc.yml
+++ b/.github/workflows/linux_debug_fetch_hwloc.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 ETH Zurich
+# Copyright (c) 2024 Vedant Nimje
 #
 # SPDX-License-Identifier: BSL-1.0
 # Distributed under the Boost Software License, Version 1.0. (See accompanying

--- a/.github/workflows/linux_debug_fetch_hwloc.yml
+++ b/.github/workflows/linux_debug_fetch_hwloc.yml
@@ -10,7 +10,7 @@ on:
   push: 
     branches: [cmake_options] 
     paths:
-      - ".github/workflows/linux_debug_hwloc_fetch.yml"
+      - ".github/workflows/linux_debug_fetch_hwloc.yml"
       - "CMakeLists.txt"
       - "cmake/**"
 

--- a/.github/workflows/linux_debug_fetch_hwloc.yml
+++ b/.github/workflows/linux_debug_fetch_hwloc.yml
@@ -1,0 +1,50 @@
+# Copyright (c) 2020 ETH Zurich
+#
+# SPDX-License-Identifier: BSL-1.0
+# Distributed under the Boost Software License, Version 1.0. (See accompanying
+# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+name: Linux CI (Debug) with HWLoc fetch
+
+on: 
+  push: 
+    branches: [cmake_options] 
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Install Boost
+      run: sudo apt install libboost-all-dev
+
+    - name: Configure
+      shell: bash
+      run: |
+          cmake \
+              . \
+              -Bbuild \
+              -GNinja \
+              -DCMAKE_BUILD_TYPE=Debug \
+              -DHPX_WITH_MALLOC=system \
+              -DHPX_WITH_FETCH_ASIO=ON \
+              -DHPX_WITH_FETCH_HWLOC=ON \
+              -DHPX_WITH_TESTS=ON \
+              -DHPX_WITH_CHECK_MODULE_DEPENDENCIES=On
+
+    - name: Build
+      shell: bash
+      run: |
+          cmake --build build --target all
+          cmake --build build --target examples
+
+    - name: Test
+      shell: bash
+      run: |
+          cd build
+          ctest \
+            --output-on-failure \
+            --tests-regex tests.examples \
+            --exclude-regex tests.examples.transpose.transpose_block_numa

--- a/.github/workflows/linux_debug_fetch_hwloc.yml
+++ b/.github/workflows/linux_debug_fetch_hwloc.yml
@@ -18,7 +18,7 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Install Boost
-      run: sudo apt install libboost-all-dev
+      run: sudo apt install libboost-all-dev ninja-build
 
     - name: Configure
       shell: bash

--- a/.github/workflows/linux_debug_fetch_hwloc.yml
+++ b/.github/workflows/linux_debug_fetch_hwloc.yml
@@ -11,6 +11,8 @@ on:
     branches: [cmake_options] 
     paths:
       - ".github/workflows/linux_debug_hwloc_fetch.yml"
+      - "CMakeLists.txt"
+      - "cmake/**"
 
 jobs:
   build:

--- a/.github/workflows/linux_debug_fetch_hwloc.yml
+++ b/.github/workflows/linux_debug_fetch_hwloc.yml
@@ -9,6 +9,8 @@ name: Linux CI (Debug) with HWLoc fetch
 on: 
   push: 
     branches: [cmake_options] 
+    paths:
+      - ".github/workflows/linux_debug_hwloc_fetch.yml"
 
 jobs:
   build:

--- a/.github/workflows/linux_debug_fetch_hwloc.yml
+++ b/.github/workflows/linux_debug_fetch_hwloc.yml
@@ -35,7 +35,9 @@ jobs:
               -DHPX_WITH_MALLOC=system \
               -DHPX_WITH_FETCH_ASIO=ON \
               -DHPX_WITH_FETCH_HWLOC=ON \
+              -DHPX_WITH_EXAMPLES=ON \
               -DHPX_WITH_TESTS=ON \
+              -DHPX_WITH_TESTS_MAX_THREADS_PER_LOCALITY=2 \
               -DHPX_WITH_CHECK_MODULE_DEPENDENCIES=On
 
     - name: Build

--- a/.github/workflows/macos_debug_fetch_hwloc.yml
+++ b/.github/workflows/macos_debug_fetch_hwloc.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 Mikael Simberg
+# Copyright (c) 2024 Vedant Nimje
 #
 # SPDX-License-Identifier: BSL-1.0
 # Distributed under the Boost Software License, Version 1.0. (See accompanying

--- a/.github/workflows/macos_debug_fetch_hwloc.yml
+++ b/.github/workflows/macos_debug_fetch_hwloc.yml
@@ -1,0 +1,87 @@
+# Copyright (c) 2020 Mikael Simberg
+#
+# SPDX-License-Identifier: BSL-1.0
+# Distributed under the Boost Software License, Version 1.0. (See accompanying
+# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+name: macOS CI (Debug)
+
+on: 
+  push: 
+    branches: [cmake_options] 
+    paths:
+      - ".github/workflows/macos_debug_fetch_hwloc.yml"
+      - "CMakeLists.txt"
+      - "cmake/**"
+
+jobs:
+  build:
+    runs-on: macos-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Install dependencies
+      run: |
+        # Workaround for https://github.com/actions/virtual-environments/issues/2322
+        rm -rf /usr/local/bin/2to3*
+        rm -rf /usr/local/bin/idle3*
+        rm -rf /usr/local/bin/pydoc3*
+        rm -rf /usr/local/bin/python3*
+        brew upgrade
+        brew update && \
+            brew install --overwrite python-tk && \
+            brew install --overwrite boost hwloc gperftools ninja && \
+            brew upgrade cmake
+    - name: Configure
+      shell: bash
+      run: |
+          cmake \
+              -H. \
+              -Bbuild \
+              -GNinja \
+              -DCMAKE_BUILD_TYPE=Debug \
+              -DHPX_WITH_FETCH_ASIO=ON \
+              -DHPX_WTIH_FETCH_HWLOC=ON \
+              -DHPX_WITH_EXAMPLES=ON \
+              -DHPX_WITH_TESTS=ON \
+              -DHPX_WITH_TESTS_MAX_THREADS_PER_LOCALITY=3 \
+              -DHPX_WITH_CHECK_MODULE_DEPENDENCIES=ON
+    - name: Build
+      shell: bash
+      run: |
+          cmake --build build --target all
+          cmake --build build --target tests
+    - name: Test
+      shell: bash
+      run: |
+          cd build
+          ctest --output-on-failure \
+            --exclude-regex \
+          "tests.examples.quickstart.1d_wave_equation|\
+          tests.examples.transpose.transpose_block_numa|\
+          tests.performance.local.wait_all_timings|\
+          tests.regressions.components.distributed.tcp.bulk_new_3054|\
+          tests.regressions.dynamic_counters_loaded_1508|\
+          tests.regressions.lcos.wait_all_hang_1946|\
+          tests.regressions.modules.async_combinators.wait_all_hang_1946|\
+          tests.regressions.modules.collectives.distributed.tcp.broadcast_apply|\
+          tests.regressions.modules.collectives.distributed.tcp.broadcast_unwrap_future_2885|\
+          tests.regressions.modules.collectives.distributed.tcp.remote_latch|\
+          tests.regressions.modules.compute_local.parallel_fill_4132|\
+          tests.regressions.util.distributed.tcp.zero_copy_parcels_1001_no_zero_copy_optimization|\
+          tests.regressions.modules.performance_counters.dynamic_counters_loaded_1508|\
+          tests.regressions.modules.performance_counters.statistics_2666|\
+          tests.unit.modules.runtime_components.distributed.tcp.migrate_component|\
+          tests.unit.modules.runtime_components.distributed.tcp.migrate_polymorphic_component|\
+          tests.unit.modules.algorithms.default_construct|\
+          tests.unit.modules.algorithms.destroy|\
+          tests.unit.modules.algorithms.foreach_executors|\
+          tests.unit.modules.algorithms.max_element|\
+          tests.unit.modules.algorithms.replace_copy_if|\
+          tests.unit.modules.compute_local.numa_allocator|\
+          tests.unit.modules.execution.standalone_thread_pool_executor|\
+          tests.unit.modules.resource_partitioner.used_pus|\
+          tests.unit.modules.segmented_algorithms.distributed.tcp.partitioned_vector|\
+          tests.unit.threads.distributed.tcp.thread_stacksize|\
+          tests.unit.topology.numa_allocator|\
+          tests.unit.modules.runtime_components.distributed.tcp.migrate_polymorphic_component"

--- a/.github/workflows/macos_debug_fetch_hwloc.yml
+++ b/.github/workflows/macos_debug_fetch_hwloc.yml
@@ -24,7 +24,7 @@ jobs:
         brew upgrade
         brew update && \
             brew install --overwrite python-tk && \
-            brew install --overwrite boost hwloc gperftools ninja && \
+            brew install --overwrite boost gperftools ninja && \
             brew upgrade cmake
     - name: Configure
       shell: bash
@@ -35,7 +35,7 @@ jobs:
               -GNinja \
               -DCMAKE_BUILD_TYPE=Debug \
               -DHPX_WITH_FETCH_ASIO=ON \
-              -DHPX_WTIH_FETCH_HWLOC=ON \
+              -DHPX_WITH_FETCH_HWLOC=ON \
               -DHPX_WITH_EXAMPLES=ON \
               -DHPX_WITH_TESTS=ON \
               -DHPX_WITH_TESTS_MAX_THREADS_PER_LOCALITY=3 \

--- a/.github/workflows/macos_debug_fetch_hwloc.yml
+++ b/.github/workflows/macos_debug_fetch_hwloc.yml
@@ -4,15 +4,9 @@
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-name: macOS CI (Debug)
+name: macOS CI (Debug) with HWLoc fetch
 
-on: 
-  push: 
-    branches: [cmake_options] 
-    paths:
-      - ".github/workflows/macos_debug_fetch_hwloc.yml"
-      - "CMakeLists.txt"
-      - "cmake/**"
+on: [pull_request]
 
 jobs:
   build:

--- a/.github/workflows/windows_debug_vs2022_fetch_hwloc.yml
+++ b/.github/workflows/windows_debug_vs2022_fetch_hwloc.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 Mikael Simberg
+# Copyright (c) 2024 Vedant Nimje
 #
 # SPDX-License-Identifier: BSL-1.0
 # Distributed under the Boost Software License, Version 1.0. (See accompanying

--- a/.github/workflows/windows_debug_vs2022_fetch_hwloc.yml
+++ b/.github/workflows/windows_debug_vs2022_fetch_hwloc.yml
@@ -4,15 +4,9 @@
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-name: Windows CI (Debug, VS2022 toolset)
+name: Windows CI (Debug, VS2022 toolset) with HWLoc fetch
 
-on: 
-  push: 
-    branches: [cmake_options] 
-    paths:
-      - ".github/workflows/windows_debug_vs2022_fetch_hwloc.yml"
-      - "CMakeLists.txt"
-      - "cmake/**"
+on: [pull_request]
 
 jobs:
   build:

--- a/.github/workflows/windows_debug_vs2022_fetch_hwloc.yml
+++ b/.github/workflows/windows_debug_vs2022_fetch_hwloc.yml
@@ -1,0 +1,67 @@
+# Copyright (c) 2020 Mikael Simberg
+#
+# SPDX-License-Identifier: BSL-1.0
+# Distributed under the Boost Software License, Version 1.0. (See accompanying
+# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+name: Windows CI (Debug, VS2022 toolset)
+
+on: 
+  push: 
+    branches: [cmake_options] 
+    paths:
+      - ".github/workflows/windows_debug_vs2022_fetch_hwloc.yml"
+      - "CMakeLists.txt"
+      - "cmake/**"
+
+jobs:
+  build:
+    runs-on: windows-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - uses: jwlawson/actions-setup-cmake@v1.14
+      with:
+        cmake-version: '3.22.x'
+    - name: Install dependencies
+      run: |
+        md C:\projects
+        $client = new-object System.Net.WebClient
+        $client.DownloadFile("https://rostam.cct.lsu.edu/download/builder/vcpkg-export-hpx-dependencies-2022.7z","C:\projects\vcpkg-export-hpx-dependencies.7z")
+        7z x C:\projects\vcpkg-export-hpx-dependencies.7z -y -oC:\projects\vcpkg
+    - name: Configure
+      shell: bash
+      run: |
+          cmake . -Bbuild -G'Visual Studio 17 2022' \
+              -DCMAKE_BUILD_TYPE=Debug \
+              -DCMAKE_TOOLCHAIN_FILE='C:/projects/vcpkg/scripts/buildsystems/vcpkg.cmake' \
+              -DHPX_WITH_FETCH_ASIO=ON \
+              -DHPX_WITH_FETCH_HWLOC=ON \
+              -DHPX_WITH_EXAMPLES=ON \
+              -DHPX_WITH_TESTS=ON \
+              -DHPX_WITH_TESTS_UNIT=ON \
+              -DHPX_WITH_DEPRECATION_WARNINGS=OFF \
+              -DHPX_WITH_TESTS_MAX_THREADS_PER_LOCALITY=2 \
+              -DHPX_COROUTINES_WITH_SWAP_CONTEXT_EMULATION=ON \
+              -DHPX_WITH_CHECK_MODULE_DEPENDENCIES=On
+    - name: Build
+      shell: bash
+      run: |
+          cmake --build build --config Debug \
+          --target ALL_BUILD \
+          -- -maxcpucount:2 -verbosity:minimal -nologo
+    - name: Install
+      shell: bash
+      run: |
+          cmake --install build --config Debug
+    - name: Test
+      run: |
+          Set-Alias -Name grep -Value 'C:\Program Files\Git\usr\bin\grep.exe'
+          Set-Alias -Name sed -Value 'C:\Program Files\Git\usr\bin\sed.exe'
+          cd build
+          ctest `
+          --output-on-failure `
+            --build-config Debug `
+            --tests-regex tests.examples `
+            --exclude-regex `
+                 $(grep -v  -e ^# -e ^$ D:/a/hpx/hpx/.github/workflows/tests.examples.targets | sed ':b;N;$!bb;s/\n/|/g')

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2322,10 +2322,7 @@ endif()
 
 if(HPX_WITH_EXAMPLES)
   add_hpx_pseudo_target(examples)
-  if(HPX_WITH_FETCH_HWLOC
-     AND "${CMAKE_SYSTEM_NAME}" STREQUAL "Windows"
-     AND CMAKE_SIZEOF_VOID_P EQUAL 8
-  )
+  if(HPX_WITH_FETCH_HWLOC AND "${CMAKE_SYSTEM_NAME}" STREQUAL "Windows")
     add_custom_target(
       HwlocDLL ALL
       COMMAND ${CMAKE_COMMAND} -E make_directory

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2322,10 +2322,18 @@ endif()
 
 if(HPX_WITH_EXAMPLES)
   add_hpx_pseudo_target(examples)
-  if(HPX_WITH_FETCH_HWLOC AND "${CMAKE_SYSTEM_NAME}" STREQUAL "Windows" AND CMAKE_SIZEOF_VOID_P EQUAL 8)
-    add_custom_target(HwlocDLL ALL
-      COMMAND ${CMAKE_COMMAND} -E make_directory "${CMAKE_BINARY_DIR}/$<CONFIG>/bin/"
-      COMMAND ${CMAKE_COMMAND} -E copy_if_different "${HWLOC_ROOT}/bin/libhwloc-15.dll" "${CMAKE_BINARY_DIR}/$<CONFIG>/bin/"
+  if(HPX_WITH_FETCH_HWLOC
+     AND "${CMAKE_SYSTEM_NAME}" STREQUAL "Windows"
+     AND CMAKE_SIZEOF_VOID_P EQUAL 8
+  )
+    add_custom_target(
+      HwlocDLL ALL
+      COMMAND ${CMAKE_COMMAND} -E make_directory
+              "${CMAKE_BINARY_DIR}/$<CONFIG>/bin/"
+      COMMAND
+        ${CMAKE_COMMAND} -E copy_if_different
+        "${HWLOC_ROOT}/bin/libhwloc-15.dll"
+        "${CMAKE_BINARY_DIR}/$<CONFIG>/bin/"
     )
     add_hpx_pseudo_dependencies(examples HwlocDLL)
   endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -980,6 +980,16 @@ hpx_option(
   ADVANCED
 )
 
+# Option for automatically fetching Hwloc
+hpx_option(
+  HPX_WITH_FETCH_HWLOC
+  BOOL
+  "Use FetchContent to fetch Hwloc. By default an installed Hwloc will be used. (default: OFF)"
+  OFF
+  CATEGORY "Build Targets"
+  ADVANCED
+)
+
 # cmake-format: off
 # LibCDS option
 # NOTE: The libcds option is disabled for the 1.5.0 release as it is not ready

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2322,6 +2322,13 @@ endif()
 
 if(HPX_WITH_EXAMPLES)
   add_hpx_pseudo_target(examples)
+  if(HPX_WITH_FETCH_HWLOC AND "${CMAKE_SYSTEM_NAME}" STREQUAL "Windows" AND CMAKE_SIZEOF_VOID_P EQUAL 8)
+    add_custom_target(HwlocDLL ALL
+      COMMAND ${CMAKE_COMMAND} -E make_directory "${CMAKE_BINARY_DIR}/$<CONFIG>/bin/"
+      COMMAND ${CMAKE_COMMAND} -E copy_if_different "${HWLOC_ROOT}/bin/libhwloc-15.dll" "${CMAKE_BINARY_DIR}/$<CONFIG>/bin/"
+    )
+    add_hpx_pseudo_dependencies(examples HwlocDLL)
+  endif()
 endif()
 
 # ##############################################################################

--- a/cmake/HPX_SetupHwloc.cmake
+++ b/cmake/HPX_SetupHwloc.cmake
@@ -47,15 +47,11 @@ else()
     include_directories(${HWLOC_ROOT}/include)
     link_directories(${HWLOC_ROOT}/lib)
     set(Hwloc_INCLUDE_DIR ${HWLOC_ROOT}/include CACHE INTERNAL "")
-    set(Hwloc_LIBRARY ${HWLOC_ROOT}/lib CACHE INTERNAL "")
+    set(Hwloc_LIBRARY ${HWLOC_ROOT}/lib/libhwloc.dll.a CACHE INTERNAL "")
   else()
     FetchContent_Declare(HWLoc
       URL https://download.open-mpi.org/release/hwloc/v2.9/hwloc-win64-build-2.9.3.zip
-      TLS_VERIFY trueadd_library(Hwloc::hwloc INTERFACE IMPORTED)
-      target_include_directories(Hwloc::hwloc INTERFACE ${Hwloc_INCLUDE_DIR})
-      target_link_libraries(Hwloc::hwloc INTERFACE ${Hwloc_LIBRARY})
-      message(${Hwloc_INCLUDE_DIR})
-      message(${Hwloc_LIBRARY})
+      TLS_VERIFY true
     )
     if(NOT HWLoc_POPULATED)
       FetchContent_Populate(HWLoc)
@@ -64,7 +60,7 @@ else()
     include_directories(${HWLOC_ROOT}/include)
     link_directories(${HWLOC_ROOT}/lib)
     set(Hwloc_INCLUDE_DIR ${HWLOC_ROOT}/include CACHE INTERNAL "")
-    set(Hwloc_LIBRARY ${HWLOC_ROOT}/lib CACHE INTERNAL "")
+    set(Hwloc_LIBRARY ${HWLOC_ROOT}/lib/libhwloc.dll.a CACHE INTERNAL "")
   endif() # End hwloc installation
 
   add_library(Hwloc::hwloc INTERFACE IMPORTED)
@@ -72,5 +68,4 @@ else()
   target_link_libraries(Hwloc::hwloc INTERFACE ${Hwloc_LIBRARY})
   message(${Hwloc_INCLUDE_DIR})
   message(${Hwloc_LIBRARY})
-
 endif()

--- a/cmake/HPX_SetupHwloc.cmake
+++ b/cmake/HPX_SetupHwloc.cmake
@@ -63,6 +63,6 @@ else()
 
   add_library(Hwloc::hwloc INTERFACE IMPORTED)
   target_include_directories(Hwloc::hwloc INTERFACE ${Hwloc_INCLUDE_DIR})
-  target_link_libraries(Hwloc::hwloc INTERFACE ${Hwloc_LIBRARIES})
+  target_link_libraries(Hwloc::hwloc INTERFACE ${Hwloc_LIBRARY})
 
 endif()

--- a/cmake/HPX_SetupHwloc.cmake
+++ b/cmake/HPX_SetupHwloc.cmake
@@ -32,6 +32,8 @@ else()
       execute_process(COMMAND sh -c "cd ${CMAKE_BINARY_DIR}/_deps/hwloc-src && ./configure --prefix=${CMAKE_BINARY_DIR}/_deps/hwloc-installed && make -j && make install")
     endif()
     set(HWLOC_ROOT "${CMAKE_BINARY_DIR}/_deps/hwloc-installed")
+    set(Hwloc_INCLUDE_DIR ${HWLOC_ROOT}/include CACHE INTERNAL "")
+    set(Hwloc_LIBRARY ${HWLOC_ROOT}/lib/libhwloc.so CACHE INTERNAL "")
   elseif("${CMAKE_GENERATOR_PLATFORM}" STREQUAL "Win64")
     FetchContent_Declare(HWLoc
       URL https://download.open-mpi.org/release/hwloc/v2.9/hwloc-win64-build-2.9.3.zip
@@ -49,7 +51,11 @@ else()
   else()
     FetchContent_Declare(HWLoc
       URL https://download.open-mpi.org/release/hwloc/v2.9/hwloc-win64-build-2.9.3.zip
-      TLS_VERIFY true
+      TLS_VERIFY trueadd_library(Hwloc::hwloc INTERFACE IMPORTED)
+      target_include_directories(Hwloc::hwloc INTERFACE ${Hwloc_INCLUDE_DIR})
+      target_link_libraries(Hwloc::hwloc INTERFACE ${Hwloc_LIBRARY})
+      message(${Hwloc_INCLUDE_DIR})
+      message(${Hwloc_LIBRARY})
     )
     if(NOT HWLoc_POPULATED)
       FetchContent_Populate(HWLoc)
@@ -64,5 +70,7 @@ else()
   add_library(Hwloc::hwloc INTERFACE IMPORTED)
   target_include_directories(Hwloc::hwloc INTERFACE ${Hwloc_INCLUDE_DIR})
   target_link_libraries(Hwloc::hwloc INTERFACE ${Hwloc_LIBRARY})
+  message(${Hwloc_INCLUDE_DIR})
+  message(${Hwloc_LIBRARY})
 
 endif()

--- a/cmake/HPX_SetupHwloc.cmake
+++ b/cmake/HPX_SetupHwloc.cmake
@@ -13,7 +13,7 @@
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-if (NOT HPX_WITH_FETCH_HWLOC)
+if(NOT HPX_WITH_FETCH_HWLOC)
   find_package(Hwloc)
   if(NOT Hwloc_FOUND)
     hpx_error(
@@ -26,44 +26,75 @@ else()
   )
   if(UNIX)
     include(FetchContent)
-    FetchContent_Declare(HWLoc
+    fetchcontent_declare(
+      HWLoc
       URL https://download.open-mpi.org/release/hwloc/v2.9/hwloc-2.9.3.tar.gz
       TLS_VERIFY true
     )
     if(NOT HWLoc_POPULATED)
-      FetchContent_Populate(HWLoc)
-      execute_process(COMMAND sh -c "cd ${CMAKE_BINARY_DIR}/_deps/hwloc-src && ./configure --prefix=${CMAKE_BINARY_DIR}/_deps/hwloc-installed && make -j && make install")
+      fetchcontent_populate(HWLoc)
+      execute_process(
+        COMMAND
+          sh -c
+          "cd ${CMAKE_BINARY_DIR}/_deps/hwloc-src && ./configure --prefix=${CMAKE_BINARY_DIR}/_deps/hwloc-installed && make -j && make install"
+      )
     endif()
     set(HWLOC_ROOT "${CMAKE_BINARY_DIR}/_deps/hwloc-installed")
-    set(Hwloc_INCLUDE_DIR ${HWLOC_ROOT}/include CACHE INTERNAL "")
-    set(Hwloc_LIBRARY ${HWLOC_ROOT}/lib/libhwloc.so CACHE INTERNAL "")
+    set(Hwloc_INCLUDE_DIR
+        ${HWLOC_ROOT}/include
+        CACHE INTERNAL ""
+    )
+    set(Hwloc_LIBRARY
+        ${HWLOC_ROOT}/lib/libhwloc.so
+        CACHE INTERNAL ""
+    )
   elseif("${CMAKE_GENERATOR_PLATFORM}" STREQUAL "Win64")
-    FetchContent_Declare(HWLoc
+    fetchcontent_declare(
+      HWLoc
       URL https://download.open-mpi.org/release/hwloc/v2.9/hwloc-win64-build-2.9.3.zip
       TLS_VERIFY true
     )
     if(NOT HWLoc_POPULATED)
-      FetchContent_Populate(HWLoc)
+      fetchcontent_populate(HWLoc)
     endif()
-    set(HWLOC_ROOT "${CMAKE_BINARY_DIR}/_deps/hwloc-src" CACHE INTERNAL "")
+    set(HWLOC_ROOT
+        "${CMAKE_BINARY_DIR}/_deps/hwloc-src"
+        CACHE INTERNAL ""
+    )
     find_package(hwloc REQUIRED PATHS ${HWLOC_ROOT} NO_DEFAULT_PATH)
     include_directories(${HWLOC_ROOT}/include)
     link_directories(${HWLOC_ROOT}/lib)
-    set(Hwloc_INCLUDE_DIR ${HWLOC_ROOT}/include CACHE INTERNAL "")
-    set(Hwloc_LIBRARY ${HWLOC_ROOT}/lib/libhwloc.dll.a CACHE INTERNAL "")
+    set(Hwloc_INCLUDE_DIR
+        ${HWLOC_ROOT}/include
+        CACHE INTERNAL ""
+    )
+    set(Hwloc_LIBRARY
+        ${HWLOC_ROOT}/lib/libhwloc.dll.a
+        CACHE INTERNAL ""
+    )
   else()
-    FetchContent_Declare(HWLoc
+    fetchcontent_declare(
+      HWLoc
       URL https://download.open-mpi.org/release/hwloc/v2.9/hwloc-win64-build-2.9.3.zip
       TLS_VERIFY true
     )
     if(NOT HWLoc_POPULATED)
-      FetchContent_Populate(HWLoc)
+      fetchcontent_populate(HWLoc)
     endif()
-    set(HWLOC_ROOT "${CMAKE_BINARY_DIR}/_deps/hwloc-src" CACHE INTERNAL "")
+    set(HWLOC_ROOT
+        "${CMAKE_BINARY_DIR}/_deps/hwloc-src"
+        CACHE INTERNAL ""
+    )
     include_directories(${HWLOC_ROOT}/include)
     link_directories(${HWLOC_ROOT}/lib)
-    set(Hwloc_INCLUDE_DIR ${HWLOC_ROOT}/include CACHE INTERNAL "")
-    set(Hwloc_LIBRARY ${HWLOC_ROOT}/lib/libhwloc.dll.a CACHE INTERNAL "")
+    set(Hwloc_INCLUDE_DIR
+        ${HWLOC_ROOT}/include
+        CACHE INTERNAL ""
+    )
+    set(Hwloc_LIBRARY
+        ${HWLOC_ROOT}/lib/libhwloc.dll.a
+        CACHE INTERNAL ""
+    )
   endif() # End hwloc installation
 
   add_library(Hwloc::hwloc INTERFACE IMPORTED)

--- a/cmake/HPX_SetupHwloc.cmake
+++ b/cmake/HPX_SetupHwloc.cmake
@@ -13,9 +13,56 @@
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-find_package(Hwloc)
-if(NOT Hwloc_FOUND)
-  hpx_error(
-    "Hwloc could not be found, please specify Hwloc_ROOT to point to the correct location"
-  )
+if (NOT HPX_WITH_FETCH_HWLOC)
+  find_package(Hwloc)
+  if(NOT Hwloc_FOUND)
+    hpx_error(
+      "Hwloc could not be found, please specify Hwloc_ROOT to point to the correct location"
+    )
+  endif()
+else()
+  if(UNIX)
+    include(FetchContent)
+    FetchContent_Declare(HWLoc
+      URL https://download.open-mpi.org/release/hwloc/v2.9/hwloc-2.9.3.tar.gz
+      TLS_VERIFY true
+    )
+    if(NOT HWLoc_POPULATED)
+      FetchContent_Populate(HWLoc)
+      execute_process(COMMAND sh -c "cd ${CMAKE_BINARY_DIR}/_deps/hwloc-src && ./configure --prefix=${CMAKE_BINARY_DIR}/_deps/hwloc-installed && make -j && make install")
+    endif()
+    set(HWLOC_ROOT "${CMAKE_BINARY_DIR}/_deps/hwloc-installed")
+  elseif("${CMAKE_GENERATOR_PLATFORM}" STREQUAL "Win64")
+    FetchContent_Declare(HWLoc
+      URL https://download.open-mpi.org/release/hwloc/v2.9/hwloc-win64-build-2.9.3.zip
+      TLS_VERIFY true
+    )
+    if(NOT HWLoc_POPULATED)
+      FetchContent_Populate(HWLoc)
+    endif()
+    set(HWLOC_ROOT "${CMAKE_BINARY_DIR}/_deps/hwloc-src" CACHE INTERNAL "")
+    find_package(hwloc REQUIRED PATHS ${HWLOC_ROOT} NO_DEFAULT_PATH)
+    include_directories(${HWLOC_ROOT}/include)
+    link_directories(${HWLOC_ROOT}/lib)
+    set(Hwloc_INCLUDE_DIR ${HWLOC_ROOT}/include CACHE INTERNAL "")
+    set(Hwloc_LIBRARY ${HWLOC_ROOT}/lib CACHE INTERNAL "")
+  else()
+    FetchContent_Declare(HWLoc
+      URL https://download.open-mpi.org/release/hwloc/v2.9/hwloc-win64-build-2.9.3.zip
+      TLS_VERIFY true
+    )
+    if(NOT HWLoc_POPULATED)
+      FetchContent_Populate(HWLoc)
+    endif()
+    set(HWLOC_ROOT "${CMAKE_BINARY_DIR}/_deps/hwloc-src" CACHE INTERNAL "")
+    include_directories(${HWLOC_ROOT}/include)
+    link_directories(${HWLOC_ROOT}/lib)
+    set(Hwloc_INCLUDE_DIR ${HWLOC_ROOT}/include CACHE INTERNAL "")
+    set(Hwloc_LIBRARY ${HWLOC_ROOT}/lib CACHE INTERNAL "")
+  endif() # End hwloc installation
+
+  add_library(Hwloc::hwloc INTERFACE IMPORTED)
+  target_include_directories(Hwloc::hwloc INTERFACE ${Hwloc_INCLUDE_DIR})
+  target_link_libraries(Hwloc::hwloc INTERFACE ${Hwloc_LIBRARIES})
+
 endif()

--- a/cmake/HPX_SetupHwloc.cmake
+++ b/cmake/HPX_SetupHwloc.cmake
@@ -21,6 +21,9 @@ if (NOT HPX_WITH_FETCH_HWLOC)
     )
   endif()
 else()
+  hpx_info(
+    "HPX_WITH_FETCH_HWLOC=${HPX_WITH_FETCH_HWLOC}, Hwloc will be fetched using CMake's FetchContent"
+  )
   if(UNIX)
     include(FetchContent)
     FetchContent_Declare(HWLoc

--- a/cmake/HPX_SetupHwloc.cmake
+++ b/cmake/HPX_SetupHwloc.cmake
@@ -13,6 +13,7 @@
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+# cmake-format: off
 if(NOT HPX_WITH_FETCH_HWLOC)
   find_package(Hwloc)
   if(NOT Hwloc_FOUND)
@@ -103,3 +104,4 @@ else()
   message(${Hwloc_INCLUDE_DIR})
   message(${Hwloc_LIBRARY})
 endif()
+# cmake-format: on

--- a/cmake/HPX_SetupHwloc.cmake
+++ b/cmake/HPX_SetupHwloc.cmake
@@ -46,11 +46,19 @@ else()
         ${HWLOC_ROOT}/include
         CACHE INTERNAL ""
     )
-    set(Hwloc_LIBRARY
-        ${HWLOC_ROOT}/lib/libhwloc.so
-        CACHE INTERNAL ""
-    )
-  elseif("${CMAKE_GENERATOR_PLATFORM}" STREQUAL "Win64")
+    if(APPLE)
+      set(Hwloc_LIBRARY
+          ${HWLOC_ROOT}/lib/libhwloc.dylib
+          CACHE INTERNAL ""
+      )
+    else()
+      set(Hwloc_LIBRARY
+          ${HWLOC_ROOT}/lib/libhwloc.so
+          CACHE INTERNAL ""
+      )
+    endif()
+
+  elseif("${CMAKE_SYSTEM_NAME}" STREQUAL "Windows" AND CMAKE_SIZEOF_VOID_P EQUAL 8)
     fetchcontent_declare(
       HWLoc
       URL https://download.open-mpi.org/release/hwloc/v${HPX_WITH_HWLOC_VERSION}/hwloc-win64-build-${HPX_WITH_HWLOC_RELEASE}.zip
@@ -63,7 +71,6 @@ else()
         "${CMAKE_BINARY_DIR}/_deps/hwloc-src"
         CACHE INTERNAL ""
     )
-    find_package(hwloc REQUIRED PATHS ${HWLOC_ROOT} NO_DEFAULT_PATH)
     include_directories(${HWLOC_ROOT}/include)
     link_directories(${HWLOC_ROOT}/lib)
     set(Hwloc_INCLUDE_DIR
@@ -97,7 +104,7 @@ else()
         ${HWLOC_ROOT}/lib/libhwloc.dll.a
         CACHE INTERNAL ""
     )
-  endif()
+  endif() # End hwloc installation
 
   add_library(Hwloc::hwloc INTERFACE IMPORTED)
   target_include_directories(Hwloc::hwloc INTERFACE ${Hwloc_INCLUDE_DIR})

--- a/cmake/HPX_SetupHwloc.cmake
+++ b/cmake/HPX_SetupHwloc.cmake
@@ -13,7 +13,6 @@
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-# cmake-format: off
 if(NOT HPX_WITH_FETCH_HWLOC)
   find_package(Hwloc)
   if(NOT Hwloc_FOUND)
@@ -22,14 +21,16 @@ if(NOT HPX_WITH_FETCH_HWLOC)
     )
   endif()
 else()
+  set(HPX_WITH_HWLOC_VERSION "2.9")
+  set(HPX_WITH_HWLOC_RELEASE "2.9.3")
   hpx_info(
-    "HPX_WITH_FETCH_HWLOC=${HPX_WITH_FETCH_HWLOC}, Hwloc will be fetched using CMake's FetchContent"
+    "HPX_WITH_FETCH_HWLOC=${HPX_WITH_FETCH_HWLOC}, Hwloc v${HPX_WITH_HWLOC_RELEASE} will be fetched using CMake's FetchContent"
   )
   if(UNIX)
     include(FetchContent)
     fetchcontent_declare(
       HWLoc
-      URL https://download.open-mpi.org/release/hwloc/v2.9/hwloc-2.9.3.tar.gz
+      URL https://download.open-mpi.org/release/hwloc/v${HPX_WITH_HWLOC_VERSION}/hwloc-${HPX_WITH_HWLOC_RELEASE}.tar.gz
       TLS_VERIFY true
     )
     if(NOT HWLoc_POPULATED)
@@ -52,7 +53,7 @@ else()
   elseif("${CMAKE_GENERATOR_PLATFORM}" STREQUAL "Win64")
     fetchcontent_declare(
       HWLoc
-      URL https://download.open-mpi.org/release/hwloc/v2.9/hwloc-win64-build-2.9.3.zip
+      URL https://download.open-mpi.org/release/hwloc/v${HPX_WITH_HWLOC_VERSION}/hwloc-win64-build-${HPX_WITH_HWLOC_RELEASE}.zip
       TLS_VERIFY true
     )
     if(NOT HWLoc_POPULATED)
@@ -76,7 +77,7 @@ else()
   else()
     fetchcontent_declare(
       HWLoc
-      URL https://download.open-mpi.org/release/hwloc/v2.9/hwloc-win64-build-2.9.3.zip
+      URL https://download.open-mpi.org/release/hwloc/v${HPX_WITH_HWLOC_VERSION}/hwloc-win32-build-${HPX_WITH_HWLOC_RELEASE}.zip
       TLS_VERIFY true
     )
     if(NOT HWLoc_POPULATED)
@@ -96,12 +97,9 @@ else()
         ${HWLOC_ROOT}/lib/libhwloc.dll.a
         CACHE INTERNAL ""
     )
-  endif() # End hwloc installation
+  endif()
 
   add_library(Hwloc::hwloc INTERFACE IMPORTED)
   target_include_directories(Hwloc::hwloc INTERFACE ${Hwloc_INCLUDE_DIR})
   target_link_libraries(Hwloc::hwloc INTERFACE ${Hwloc_LIBRARY})
-  message(${Hwloc_INCLUDE_DIR})
-  message(${Hwloc_LIBRARY})
 endif()
-# cmake-format: on

--- a/cmake/HPX_SetupHwloc.cmake
+++ b/cmake/HPX_SetupHwloc.cmake
@@ -58,7 +58,9 @@ else()
       )
     endif()
 
-  elseif("${CMAKE_SYSTEM_NAME}" STREQUAL "Windows" AND CMAKE_SIZEOF_VOID_P EQUAL 8)
+  elseif("${CMAKE_SYSTEM_NAME}" STREQUAL "Windows" AND CMAKE_SIZEOF_VOID_P
+                                                       EQUAL 8
+  )
     fetchcontent_declare(
       HWLoc
       URL https://download.open-mpi.org/release/hwloc/v${HPX_WITH_HWLOC_VERSION}/hwloc-win64-build-${HPX_WITH_HWLOC_RELEASE}.zip


### PR DESCRIPTION
References #6392 

## Proposed Changes

  - Added `HPX_WITH_FETCH_HWLOC` option for fetching Hwloc using CMake FetchContent
  - Added CI tests for the same, on Linux, macOS and Windows platforms

## Any background context you want to provide?

## Checklist

Not all points below apply to all pull requests.

- [x] I have added a new feature and have added tests to go along with it.
- [ ] I have fixed a bug and have added a regression test.
- [ ] I have added a test using random numbers; I have made sure it uses a seed, and that random numbers generated are valid inputs for the tests.
