### PR TITLE
Making is_bitwise_serializable SFINAE-friendly

### DIFF
--- a/libs/core/serialization/include/hpx/serialization/traits/is_bitwise_serializable.hpp
+++ b/libs/core/serialization/include/hpx/serialization/traits/is_bitwise_serializable.hpp
@@ -1,5 +1,5 @@
 //  Copyright (c) 2014 Thomas Heller
-//  Copyright (c) 2022 Hartmut Kaiser
+//  Copyright (c) 2022-2023 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -16,12 +16,12 @@
 namespace hpx::traits {
 
 #if !defined(HPX_SERIALIZATION_HAVE_ALLOW_RAW_POINTER_SERIALIZATION)
-    template <typename T>
+    template <typename T, typename Enable = void>
     struct is_bitwise_serializable : std::is_arithmetic<T>
     {
     };
 #else
-    template <typename T>
+    template <typename T, typename Enable = void>
     struct is_bitwise_serializable
       : std::integral_constant<bool,
             std::is_arithmetic_v<T> || std::is_pointer_v<T>>

--- a/libs/full/actions_base/src/detail/action_factory.cpp
+++ b/libs/full/actions_base/src/detail/action_factory.cpp
@@ -48,7 +48,8 @@ namespace hpx::actions::detail {
     {
         HPX_ASSERT(id != invalid_id);
 
-        if (!typename_to_id_.emplace(type_name, id).second)
+        if (auto const [it, inserted] = typename_to_id_.emplace(type_name, id);
+            !inserted && it->second != 0)
         {
             HPX_THROW_EXCEPTION(hpx::error::invalid_status,
                 "action_registry::register_typename",
@@ -190,7 +191,7 @@ namespace hpx::actions::detail {
         if (id_ >= cache_.size())
         {
             cache_.resize(id_ + 1, std::pair<ctor_t, ctor_t>(nullptr, nullptr));
-            cache_[id_] = std::pair<ctor_t, ctor_t>{};
+            cache_[id_] = std::make_pair(ctor, ctor_cont);
             return;
         }
 


### PR DESCRIPTION
This should have been in place from day 1,