### PR TITLE
Fx the affinity setting bug when using LCI pp and multiple localities per node

### DIFF
--- a/libs/full/parcelport_lci/src/parcelport_lci.cpp
+++ b/libs/full/parcelport_lci/src/parcelport_lci.cpp
@@ -118,9 +118,8 @@ namespace hpx::parcelset::policies::lci {
     /// Return the name of this locality
     std::string parcelport::get_locality_name() const
     {
-        // hostname-rank
-        return util::lci_environment::get_processor_name() + "-" +
-            std::to_string(util::lci_environment::rank());
+        // hostname
+        return util::lci_environment::get_processor_name();
     }
 
     std::shared_ptr<sender_connection_base> parcelport::create_connection(


### PR DESCRIPTION
Fixes #6398.

The HPX runtime relies on `used_cores_map_` to set the affinity correctly when running multiple localities per node (see `runtime_distributed::assign_cores` for details). `used_cores_map_` maps hostnames to "used cores" and assumes the hostname of all localities on the same node are the same. The hostname is generated using the `parcelport::get_locality_name` method (I would say the name of this method is misleading).

The previous LCI parcelport used "processor_name+rank" as a locality name, which breaks the assumption of `used_cores_map_`. This PR fixed this issue.