### PR TITLE
fix(lci pp): fix the null_thread_id bug in the LCI parcelport

### DIFF
--- a/libs/full/parcelport_lci/src/sender_connection_base.cpp
+++ b/libs/full/parcelport_lci/src/sender_connection_base.cpp
@@ -73,7 +73,9 @@ namespace hpx::parcelset::policies::lci {
                         while (pp_->background_work(
                             -1, parcelport_background_mode_all))
                             continue;
-                        hpx::this_thread::yield();
+                        if (hpx::threads::get_self_id() !=
+                            hpx::threads::invalid_thread_id)
+                            hpx::this_thread::yield();
                     }
                     if (config_t::progress_type ==
                             config_t::progress_type_t::worker ||


### PR DESCRIPTION
`send()` in the LCI parcelport can call HPX `yield()`. However, `send()` can be called outside HPX threads, leading to HPX complaining "null_thread_id".