### PR TITLE
fix(lci pp): fix deadlocks with too many failed sends

### DIFF
--- a/libs/full/parcelport_lci/src/sender_connection_base.cpp
+++ b/libs/full/parcelport_lci/src/sender_connection_base.cpp
@@ -60,21 +60,23 @@ namespace hpx::parcelset::policies::lci {
         {
             // If we are sending early parcels, we should not expect the
             // thread make progress on the backlog queue
-            int retry_count = 0;
+            //            int retry_count = 0;
             do
             {
                 ret = send_nb();
                 if (ret.status == return_status_t::retry)
                 {
-                    ++retry_count;
-                    if (retry_count > retry_max_spin)
-                    {
-                        retry_count = 0;
-                        while (pp_->background_work(
-                            -1, parcelport_background_mode_all))
-                            continue;
-                        hpx::this_thread::yield();
-                    }
+                    //                    ++retry_count;
+                    //                    if (retry_count > retry_max_spin)
+                    //                    {
+                    //                        retry_count = 0;
+                    //                        while (pp_->background_work(
+                    //                            -1, parcelport_background_mode_all))
+                    //                            continue;
+                    //                        if (hpx::threads::get_self_id() !=
+                    //                            hpx::threads::invalid_thread_id)
+                    //                            hpx::this_thread::yield();
+                    //                    }
                     if (config_t::progress_type ==
                             config_t::progress_type_t::worker ||
                         config_t::progress_type ==


### PR DESCRIPTION
In the previous LCI parcelport, too many failed sends will trigger `background_work` and `yield` as a way of back pressure propagation. These calls might cause the current thread to be de-scheduled. However, I found those rescheduled threads may never be scheduled again after yielding, leading to deadlocks. Not sure whether this is a bug of the scheduler or not.

This PR temporarily disabled the invocation of the `background_work` and `yield` functions and fixed the deadlock issue.

This PR overwrites the changes in #6401.