### PR TITLE
Allow to disable use of [[no_unique_address]] attribute

### DIFF
--- a/.github/workflows/windows_release_gcc_mingw.yml
+++ b/.github/workflows/windows_release_gcc_mingw.yml
@@ -22,7 +22,7 @@ jobs:
         choco install ninja -y
         md C:\projects
         $client = new-object System.Net.WebClient
-        $client.DownloadFile("https://boostorg.jfrog.io/artifactory/main/release/1.78.0/source/boost_1_78_0.7z","C:\projects\boost_1_78_0.7z")
+        $client.DownloadFile("https://master.dl.sourceforge.net/project/boost/boost/1.78.0/boost_1_78_0.7z","C:\projects\boost_1_78_0.7z")
         7z x C:\projects\boost_1_78_0.7z -y -oC:\projects\boost
         cd C:\projects\boost\boost_1_78_0
         .\bootstrap.bat gcc

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Copyright (c)      2020 Mikael Simberg
-# Copyright (c) 2007-2023 Hartmut Kaiser
+# Copyright (c) 2007-2024 Hartmut Kaiser
 # Copyright (c) 2011-2014 Thomas Heller
 # Copyright (c) 2007-2008 Chirag Dekate
 # Copyright (c)      2011 Bryce Lelbach
@@ -89,7 +89,7 @@ hpx_set_cmake_policy(CMP0074 NEW)
 
 # We save the passed compiler flag to a special variable. This is needed for our
 # build system unit tests. Some flags might influence the created symbols
-# (_GLIBCXX_DEBUG i look at you)
+# (_GLIBCXX_DEBUG, I look at you)
 set(CMAKE_CXX_FLAGS_SAFE ${CMAKE_CXX_FLAGS})
 include(HPX_CheckCXXStandard)
 
@@ -1644,6 +1644,16 @@ hpx_option(
 # ##############################################################################
 # C++ feature tests
 # ##############################################################################
+
+# Sometimes we need to be able to explicitly disable supporting the
+# [[no_unique_address]] attribute. This may be of use when mixing compilers, for
+# instance.
+hpx_option(
+  HPX_WITH_SUPPORT_NO_UNIQUE_ADDRESS_ATTRIBUTE BOOL
+  "Enable the use of the [[no_unique_address]] attribute (default: ON)" ON
+  ADVANCED
+)
+
 # Need to include the CUDA setup before the config test to enable the CUDA
 # language
 include(HPX_SetupCUDA)

--- a/cmake/HPX_PerformCxxFeatureTests.cmake
+++ b/cmake/HPX_PerformCxxFeatureTests.cmake
@@ -1,4 +1,4 @@
-# Copyright (c) 2007-2022 Hartmut Kaiser
+# Copyright (c) 2007-2024 Hartmut Kaiser
 # Copyright (c) 2011-2014 Thomas Heller
 # Copyright (c) 2013-2016 Agustin Berge
 # Copyright (c)      2017 Taeguk Kwon
@@ -85,7 +85,9 @@ function(hpx_perform_cxx_feature_tests)
   )
 
   # C++20 feature tests
-  if(MSVC_VERSION GREATER_EQUAL 1929)
+  if(HPX_WITH_SUPPORT_NO_UNIQUE_ADDRESS_ATTRIBUTE AND MSVC_VERSION
+                                                      GREATER_EQUAL 1929
+  )
     # MSVC supports this attribute for all versions starting VS2019 v16.10 see
     # https://devblogs.microsoft.com/cppblog/msvc-cpp20-and-the-std-cpp20-switch/
     hpx_check_for_cxx20_no_unique_address_attribute(
@@ -112,7 +114,7 @@ function(hpx_perform_cxx_feature_tests)
       DEFINITIONS HPX_HAVE_CXX20_PERFECT_PACK_CAPTURE
     )
 
-    if(NOT MSVC) # see above
+    if(HPX_WITH_SUPPORT_NO_UNIQUE_ADDRESS_ATTRIBUTE AND NOT MSVC) # see above
       hpx_check_for_cxx20_no_unique_address_attribute(
         DEFINITIONS HPX_HAVE_CXX20_NO_UNIQUE_ADDRESS_ATTRIBUTE
       )

--- a/cmake/tests/cxx20_no_unique_address_attribute.cpp
+++ b/cmake/tests/cxx20_no_unique_address_attribute.cpp
@@ -1,17 +1,23 @@
-//  Copyright (c) 2020-2022 Hartmut Kaiser
+//  Copyright (c) 2020-2024 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#if _MSC_VER >= 1929
+#if _MSC_VER >= 1929 && __cplusplus >= 201402L
 // VS2019 v16.10 and later (_MSC_FULL_VER >= 192829913 for VS 2019 v16.9) supports
-// [[msvc::no_unique_address]] with all C++ version starting /std:c++14
+// [[msvc::no_unique_address]] with all C++ versions starting /std:c++14
 // see: https://devblogs.microsoft.com/cppblog/msvc-cpp20-and-the-std-cpp20-switch/
 //
-// clang-cl does not support neither of the attributes, however
+// clangcl supports [[msvc::no_unique_address]] starting v18
 #  if defined(__clang__)
-#    error "clang does not support the no_unique_address attribute on Windows"
+#    if !defined(__has_cpp_attribute)
+#      error "__has_cpp_attribute not supported, assume [[msvc::no_unique_address]] is not supported"
+#    else
+#      if !__has_cpp_attribute(msvc::no_unique_address)
+#        error "__has_cpp_attribute(msvc::no_unique_address) not supported"
+#      endif
+#    endif
 #  endif
 #else
 #  if !defined(__has_cpp_attribute)

--- a/libs/core/lcos_local/include/hpx/lcos_local/and_gate.hpp
+++ b/libs/core/lcos_local/include/hpx/lcos_local/and_gate.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2023 Hartmut Kaiser
+//  Copyright (c) 2007-2024 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -224,7 +224,7 @@ namespace hpx::lcos::local {
                                       std::decay_t<F>>)
                     {
                         // invoke callback with the outer lock being held
-                        f(outer_lock, *this);
+                        HPX_FORWARD(F, f)(outer_lock, *this);
                     }
 
                     outer_lock.unlock();


### PR DESCRIPTION
The CMake configuration variable `HPX_WITH_SUPPORT_NO_UNIQUE_ADDRESS` can be used to disable the `[[no_unique_address]]` attribute in cases when HPX is compiled using MSVC but the code using it is compiled using clang-cl (which doesn't support this attribute on Windows before V18).

`HPX_WITH_SUPPORT_NO_UNIQUE_ADDRESS` defaults to `ON`.