### PR TITLE
Change run_as_os_thread deprecation forwarding due to hipcc compilation issue

### DIFF
--- a/libs/core/runtime_local/include/hpx/runtime_local/run_as_os_thread.hpp
+++ b/libs/core/runtime_local/include/hpx/runtime_local/run_as_os_thread.hpp
@@ -38,7 +38,7 @@ namespace hpx::threads {
     HPX_DEPRECATED_V(1, 10,
         "hpx::threads::run_as_os_thread is deprecated, use "
         "hpx::run_as_os_thread instead")
-    decltype(auto) run_as_os_thread(F const& f, Ts&&... ts)
+    decltype(auto) run_as_os_thread(F&& f, Ts&&... ts)
     {
         return hpx::run_as_os_thread(HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...);
     }


### PR DESCRIPTION
Moving ```run_as_os_thread``` from the namespace ```hpx::threads``` to the namespace ```hpx``` caused some compilations with the AMD hipcc comiler (rocm 5.7.3) :

```
  >> 1320    /work/gdaiss/spack_workshop/spack_new/opt/spack/linux-rhel8-zen2/rocmcc-5.7.3/hpx-master-redf563a75azthtk2hmqogvlynvmf5zt/include/hpx/runtime_local/run_as_os_thread.hpp:43:38: error: no matching function for call to 'forward'
     1321            return hpx::run_as_os_thread(HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...);
     1322                                         ^~~~~~~~~~~~~~~~~
     1323    /work/gdaiss/spack_workshop/spack_new/opt/spack/linux-rhel8-zen2/rocmcc-5.7.3/hpx-masterredf563a75azthtk2hmqogvlynvmf5zt/include/hpx/config/forward.hpp:14:29: note: expanded from macro 'HPX_FORWARD'
     1324    #define HPX_FORWARD(T, ...) std::forward<T>(__VA_ARGS__)
     1325                                ^~~~~~~~~~~~~~~
     1326    /work/gdaiss/spack_workshop/octotiger-src-kamand2/src/io/silo_out.cpp:521:16: note: in instantiation of function template specialization 'hpx::threads::run_as_os_thread<(lambda at /work/gdaiss/spack_workshop/octotiger-src-kamand2/src/io/silo_out.cpp:521:33)>' requested here
     ...
     1330        forward(typename std::remove_reference<_Tp>::type& __t) noexcept
     1331        ^
     1332    /opt/rh/gcc-toolset-12/root/usr/lib/gcc/x86_64-redhat-linux/12/../../../../include/c++/12/bits/move.h:89:5: note: candidate function template not viable: 1st argument ('const (lambda at /work/gdaiss/spack_workshop/octotiger-src-kamand2/src/io/silo_out.cpp:521:33)') would lose const qualifier
     1333        forward(typename std::remove_reference<_Tp>::type&& __t) noexcept
     1334        ^
     1335    3 errors generated when compiling for host.
```

This PR fixes the issue!

Of course, this issue can also be circumvented by using the new namespace (as done in STEllAR-GROUP/octotiger#476). However, that is incompatible with HPX 1.9.1 so I would like to wait with merging that Octo-Tiger PR at least until the next stable HPX release.