### PR TITLE
Adding steal-half functionalities to work-requesting scheduler

### DIFF
--- a/cmake/HPX_PrintSummary.cmake
+++ b/cmake/HPX_PrintSummary.cmake
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2022 Hartmut Kaiser
+# Copyright (c) 2017-2024 Hartmut Kaiser
 #
 # SPDX-License-Identifier: BSL-1.0
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -70,6 +70,8 @@ function(create_configuration_summary message module_name)
             PROPERTY VALUE
           )
           hpx_info("    ${_variableName}=${_value}")
+        else()
+          hpx_info("    value not found for ${_variableName}")
         endif()
 
         string(REPLACE "_WITH_" "_HAVE_" __variableName ${_variableName})

--- a/cmake/templates/HPXConfig.cmake.in
+++ b/cmake/templates/HPXConfig.cmake.in
@@ -30,7 +30,7 @@ endif()
 # NLohnmann JSON can be installed by HPX or externally installed. In the first
 # case we use exported targets, in the second we find JSON again using
 # find_package.
-if(HPX_COMMAND_LINE_HANDLING_WITH_JSON_CONFIGURATION_FILES)
+if(HPX_COMMAND_LINE_HANDLING_LOCAL_WITH_JSON_CONFIGURATION_FILES)
   if(HPX_WITH_FETCH_JSON)
     include("${CMAKE_CURRENT_LIST_DIR}/HPXJsonTarget.cmake")
   else()

--- a/docs/sphinx/manual/hpx_runtime_and_resources.rst
+++ b/docs/sphinx/manual/hpx_runtime_and_resources.rst
@@ -152,8 +152,9 @@ policy use the command line option
 Work requesting scheduling policies
 -----------------------------------
 
-* invoke using: :option:`--hpx:queuing`\ ``local-workrequesting-fifo``
-  or using :option:`--hpx:queuing`\ ``local-workrequesting-lifo``
+* invoke using: :option:`--hpx:queuing`\ ``local-workrequesting-fifo``,
+  using :option:`--hpx:queuing`\ ``local-workrequesting-lifo``,
+  or using :option:`--hpx:queuing`\ ``local-workrequesting-mc``
 
 The work-requesting policies rely on a different mechanism of balancing work
 between cores (compared to the other policies listed above). Instead of actively

--- a/docs/sphinx/manual/launching_and_configuring_hpx_applications.rst
+++ b/docs/sphinx/manual/launching_and_configuring_hpx_applications.rst
@@ -1573,15 +1573,15 @@ The predefined command line options for any application using
    ``local-priority-fifo``, ``local-priority-lifo``, ``static``,
    ``static-priority``, ``abp-priority-fifo``,
    ``local-workrequesting-fifo``, ``local-workrequesting-lifo``
-   and ``abp-priority-lifo``
+   ``local-workrequesting-mc``, and ``abp-priority-lifo``
    (default: ``local-priority-fifo``).
 
 .. option:: --hpx:high-priority-threads arg
 
    The number of operating system threads maintaining a high priority queue
    (default: number of OS threads), valid for :option:`--hpx:queuing`\
-   ``=abp-priority``, :option:`--hpx:queuing`\ ``=static-priority`` and
-   :option:`--hpx:queuing`\ ``=local-priority`` only.
+   ``=abp-priority``, :option:`--hpx:queuing`\ ``static-priority`` and
+   :option:`--hpx:queuing`\ ``local-priority`` only.
 
 .. option:: --hpx:numa-sensitive
 

--- a/libs/core/affinity/include/hpx/affinity/affinity_data.hpp
+++ b/libs/core/affinity/include/hpx/affinity/affinity_data.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2023 Hartmut Kaiser
+//  Copyright (c) 2007-2024 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -7,13 +7,11 @@
 #pragma once
 
 #include <hpx/config.hpp>
-#include <hpx/assert.hpp>
 #include <hpx/topology/topology.hpp>
 
 #include <atomic>
 #include <cstddef>
 #include <string>
-#include <utility>
 #include <vector>
 
 #include <hpx/config/warnings_prefix.hpp>
@@ -40,21 +38,12 @@ namespace hpx::threads::policies::detail {
             std::string const& affinity_description = "balanced",
             bool use_process_mask = false);
 
-        void set_num_threads(size_t num_threads) noexcept
-        {
-            num_threads_ = num_threads;
-        }
+        void set_num_threads(size_t num_threads) noexcept;
 
         void set_affinity_masks(
-            std::vector<threads::mask_type> const& affinity_masks)
-        {
-            affinity_masks_ = affinity_masks;
-        }
+            std::vector<threads::mask_type> const& affinity_masks);
         void set_affinity_masks(
-            std::vector<threads::mask_type>&& affinity_masks) noexcept
-        {
-            affinity_masks_ = HPX_MOVE(affinity_masks);
-        }
+            std::vector<threads::mask_type>&& affinity_masks) noexcept;
 
         constexpr std::size_t get_num_threads() const noexcept
         {
@@ -69,19 +58,9 @@ namespace hpx::threads::policies::detail {
         std::size_t get_thread_occupancy(
             threads::topology const& topo, std::size_t pu_num) const;
 
-        std::size_t get_pu_num(std::size_t num_thread) const noexcept
-        {
-            HPX_ASSERT(num_thread < pu_nums_.size());
-            return pu_nums_[num_thread];
-        }
-        void set_pu_nums(std::vector<std::size_t> const& pu_nums)
-        {
-            pu_nums_ = pu_nums;
-        }
-        void set_pu_nums(std::vector<std::size_t>&& pu_nums) noexcept
-        {
-            pu_nums_ = HPX_MOVE(pu_nums);
-        }
+        std::size_t get_pu_num(std::size_t num_thread) const noexcept;
+        void set_pu_nums(std::vector<std::size_t> const& pu_nums);
+        void set_pu_nums(std::vector<std::size_t>&& pu_nums) noexcept;
 
         void add_punit(std::size_t virt_core, std::size_t thread_num);
         void init_cached_pu_nums(std::size_t hardware_concurrency);

--- a/libs/core/command_line_handling_local/CMakeLists.txt
+++ b/libs/core/command_line_handling_local/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2023 The STE||AR-Group
+# Copyright (c) 2019-2024 The STE||AR-Group
 #
 # SPDX-License-Identifier: BSL-1.0
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -9,17 +9,25 @@ cmake_minimum_required(VERSION 3.14 FATAL_ERROR)
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 
 # Enable reading JSON formatted configuration files on the command line
+set(HPX_COMMAND_LINE_HANDLING_WITH_JSON_CONFIGURATION_FILES_DEFAULT OFF)
+if(HPX_COMMAND_LINE_HANDLING_WITH_JSON_CONFIGURATION_FILES)
+  set(HPX_COMMAND_LINE_HANDLING_WITH_JSON_CONFIGURATION_FILES_DEFAULT
+      ${HPX_COMMAND_LINE_HANDLING_WITH_JSON_CONFIGURATION_FILES}
+  )
+endif()
+
 hpx_option(
-  HPX_COMMAND_LINE_HANDLING_WITH_JSON_CONFIGURATION_FILES
+  HPX_COMMAND_LINE_HANDLING_LOCAL_WITH_JSON_CONFIGURATION_FILES
   BOOL
-  "Enable reading JSON formatted configuration files on the command line. (default: OFF)"
-  OFF
+  "Enable reading JSON formatted configuration files on the command line.\n
+  (default: ${HPX_COMMAND_LINE_HANDLING_WITH_JSON_CONFIGURATION_FILES_DEFAULT})"
+  ${HPX_COMMAND_LINE_HANDLING_WITH_JSON_CONFIGURATION_FILES_DEFAULT}
   ADVANCED
   CATEGORY "Modules"
   MODULE COMMAND_LINE_HANDLING_LOCAL
 )
 
-if(HPX_COMMAND_LINE_HANDLING_WITH_JSON_CONFIGURATION_FILES)
+if(HPX_COMMAND_LINE_HANDLING_LOCAL_WITH_JSON_CONFIGURATION_FILES)
   hpx_add_config_define_namespace(
     DEFINE HPX_COMMAND_LINE_HANDLING_HAVE_JSON_CONFIGURATION_FILES
     NAMESPACE COMMAND_LINE_HANDLING_LOCAL
@@ -37,7 +45,7 @@ set(command_line_handling_local_sources
     parse_command_line_local.cpp
 )
 
-if(HPX_COMMAND_LINE_HANDLING_WITH_JSON_CONFIGURATION_FILES)
+if(HPX_COMMAND_LINE_HANDLING_LOCAL_WITH_JSON_CONFIGURATION_FILES)
   include(HPX_SetupJSON)
   set(command_line_handling_local_dependencies Json::json)
 

--- a/libs/core/command_line_handling_local/src/command_line_handling_local.cpp
+++ b/libs/core/command_line_handling_local/src/command_line_handling_local.cpp
@@ -476,12 +476,16 @@ namespace hpx::local::detail {
                     "larger than number of threads (--hpx:threads)");
             }
 
-            if (!(queuing_ == "local-priority" || queuing_ == "abp-priority"))
+            if (!(queuing_ == "local-priority" || queuing_ == "abp-priority" ||
+                    queuing_.find("local-workrequesting") != 0))
             {
                 throw hpx::detail::command_line_error(
                     "Invalid command line option --hpx:high-priority-threads, "
-                    "valid for --hpx:queuing=local-priority and "
-                    "--hpx:queuing=abp-priority only");
+                    "valid for --hpx:queuing=local-priority, "
+                    "--hpx:queuing=local-workrequesting-fifo, "
+                    "--hpx:queuing=local-workrequesting-lifo, "
+                    "--hpx:queuing=local-workrequesting-mc, "
+                    "and --hpx:queuing=abp-priority only");
             }
 
             ini_config.emplace_back("hpx.thread_queue.high_priority_queues!=" +

--- a/libs/core/command_line_handling_local/src/parse_command_line_local.cpp
+++ b/libs/core/command_line_handling_local/src/parse_command_line_local.cpp
@@ -480,6 +480,7 @@ namespace hpx::local::detail {
                 "--hpx:queuing=static, --hpx:queuing=static-priority, "
                 "--hpx:queuing=local-workrequesting-fifo, "
                 "--hpx:queuing=local-workrequesting-lifo, "
+                "--hpx:queuing=local-workrequesting-mc, "
                 "and --hpx:queuing=local-priority only")
             ("hpx:pu-step", value<std::size_t>(),
                 "the step between used processing unit numbers for this "
@@ -488,6 +489,7 @@ namespace hpx::local::detail {
                 "--hpx:queuing=static, --hpx:queuing=static-priority "
                 "--hpx:queuing=local-workrequesting-fifo, "
                 "--hpx:queuing=local-workrequesting-lifo, "
+                "--hpx:queuing=local-workrequesting-mc, "
                 "and --hpx:queuing=local-priority only")
             ("hpx:affinity", value<std::string>(),
                 "the affinity domain the OS threads will be confined to, "
@@ -496,6 +498,7 @@ namespace hpx::local::detail {
                 "--hpx:queuing=static, --hpx:queuing=static-priority "
                 "--hpx:queuing=local-workrequesting-fifo, "
                 "--hpx:queuing=local-workrequesting-lifo, "
+                "--hpx:queuing=local-workrequesting-mc, "
                 " and --hpx:queuing=local-priority only")
             ("hpx:bind", value<std::vector<std::string> >()->composing(),
                 "the detailed affinity description for the OS threads, see "
@@ -515,21 +518,23 @@ namespace hpx::local::detail {
                 "each processing unit")
             ("hpx:cores", value<std::string>(),
                 "the number of cores to utilize for this HPX "
-                "locality (default: 'all', i.e. the number of cores is based on "
-                "the number of total cores in the system)")
+                "locality (default: 'all', i.e. the number of cores is based "
+                "on the number of total cores in the system)")
             ("hpx:queuing", value<std::string>(),
                 "the queue scheduling policy to use, options are "
                 "'local', 'local-priority-fifo','local-priority-lifo', "
                 "'abp-priority-fifo', 'abp-priority-lifo', 'static', "
-                "'static-priority', 'local-workrequesting-fifo', and "
-                "'local-workrequesting-lifo' (default: 'local-priority'; "
-                "all option values can be abbreviated)")
+                "'static-priority', 'local-workrequesting-fifo',"
+                "'local-workrequesting-lifo', and 'local-workrequesting-mc' "
+                "(default: 'local-priority'; all option values can be "
+                "abbreviated)")
             ("hpx:high-priority-threads", value<std::size_t>(),
                 "the number of operating system threads maintaining a high "
                 "priority queue (default: number of OS threads), valid for "
                 "--hpx:queuing=local-priority,--hpx:queuing=static-priority, "
                 "--hpx:queuing=local-workrequesting-fifo, "
                 "--hpx:queuing=local-workrequesting-lifo, "
+                "--hpx:queuing=local-workrequesting-mc, "
                 " and --hpx:queuing=abp-priority only)")
             ("hpx:numa-sensitive", value<std::size_t>()->implicit_value(0),
                 "makes the local-priority scheduler NUMA sensitive ("

--- a/libs/core/command_line_handling_local/tests/unit/CMakeLists.txt
+++ b/libs/core/command_line_handling_local/tests/unit/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2023 The STE||AR-Group
+# Copyright (c) 2020-2024 The STE||AR-Group
 #               2011 Bryce Adelstein-Lelbach
 #
 # SPDX-License-Identifier: BSL-1.0
@@ -7,7 +7,7 @@
 
 set(tests)
 
-if(HPX_COMMAND_LINE_HANDLING_WITH_JSON_CONFIGURATION_FILES)
+if(HPX_COMMAND_LINE_HANDLING_LOCAL_WITH_JSON_CONFIGURATION_FILES)
   set(tests json_config_file)
 
   set(json_config_file_PARAMETERS

--- a/libs/core/concurrency/include/hpx/concurrency/concurrentqueue.hpp
+++ b/libs/core/concurrency/include/hpx/concurrency/concurrentqueue.hpp
@@ -91,13 +91,13 @@
 #include <thread>    // partly for __WINPTHREADS_VERSION if on MinGW-w64 w/ POSIX threading
 
 // Platform-specific definitions of a numeric thread ID type and an invalid value
-namespace hpx { namespace concurrency { namespace details {
+namespace hpx::concurrency::details {
     template<typename thread_id_t> struct thread_id_converter {
         typedef thread_id_t thread_id_numeric_size_t;
         typedef thread_id_t thread_id_hash_t;
         static thread_id_hash_t prehash(thread_id_t const& x) { return x; }
     };
-} } }
+}
 #if defined(MCDBGQ_USE_RELACY)
 namespace hpx { namespace concurrency { namespace details {
     typedef std::uint32_t thread_id_t;
@@ -109,15 +109,15 @@ namespace hpx { namespace concurrency { namespace details {
 // No sense pulling in windows.h in a header, we'll manually declare the function
 // we use and rely on backwards-compatibility for this not to break
 extern "C" __declspec(dllimport) unsigned long __stdcall GetCurrentThreadId(void);
-namespace hpx { namespace concurrency { namespace details {
+namespace hpx::concurrency::details {
     static_assert(sizeof(unsigned long) == sizeof(std::uint32_t), "Expected size of unsigned long to be 32 bits on Windows");
     typedef std::uint32_t thread_id_t;
-    static const thread_id_t invalid_thread_id  = 0;      // See http://blogs.msdn.com/b/oldnewthing/archive/2004/02/23/78395.aspx
-    static const thread_id_t invalid_thread_id2 = 0xFFFFFFFFU;  // Not technically guaranteed to be invalid, but is never used in practice. Note that all Win32 thread IDs are presently multiples of 4.
+    static constexpr thread_id_t invalid_thread_id  = 0;      // See http://blogs.msdn.com/b/oldnewthing/archive/2004/02/23/78395.aspx
+    static constexpr thread_id_t invalid_thread_id2 = 0xFFFFFFFFU;  // Not technically guaranteed to be invalid, but is never used in practice. Note that all Win32 thread IDs are presently multiples of 4.
     static inline thread_id_t thread_id() { return static_cast<thread_id_t>(::GetCurrentThreadId()); }
-} } }
+}
 #elif defined(__arm__) || defined(_M_ARM) || defined(__aarch64__) || (defined(__APPLE__) && TARGET_OS_IPHONE)
-namespace hpx { namespace concurrency { namespace details {
+namespace hpx::concurrency::details {
     static_assert(sizeof(std::thread::id) == 4 || sizeof(std::thread::id) == 8, "std::thread::id is expected to be either 4 or 8 bytes");
 
     typedef std::thread::id thread_id_t;
@@ -149,7 +149,7 @@ namespace hpx { namespace concurrency { namespace details {
 #endif
         }
     };
-} } }
+}
 #else
 // Use a nice trick from this answer: http://stackoverflow.com/a/8438730/21475
 // In order to get a numeric thread ID in a platform-independent way, we use a thread-local
@@ -162,12 +162,12 @@ namespace hpx { namespace concurrency { namespace details {
 // Assume C++11 compliant compiler
 #define MOODYCAMEL_THREADLOCAL thread_local
 #endif
-namespace hpx { namespace concurrency { namespace details {
+namespace hpx::concurrency::details {
     typedef std::uintptr_t thread_id_t;
-    static const thread_id_t invalid_thread_id  = 0;    // Address can't be nullptr
-    static const thread_id_t invalid_thread_id2 = 1;    // Member accesses off a null pointer are also generally invalid. Plus it's not aligned.
+    static constexpr thread_id_t invalid_thread_id  = 0;    // Address can't be nullptr
+    static constexpr thread_id_t invalid_thread_id2 = 1;    // Member accesses off a null pointer are also generally invalid. Plus it's not aligned.
     static inline thread_id_t thread_id() { static MOODYCAMEL_THREADLOCAL int x; return reinterpret_cast<thread_id_t>(&x); }
-} } }
+}
 #endif
 
 // Exceptions
@@ -235,7 +235,7 @@ namespace hpx { namespace concurrency { namespace details {
 #endif
 
 // Compiler-specific likely/unlikely hints
-namespace hpx { namespace concurrency { namespace details {
+namespace hpx::concurrency::details {
 #if defined(__GNUC__)
     static inline bool (likely)(bool x) { return __builtin_expect((x), true); }
     static inline bool (unlikely)(bool x) { return __builtin_expect((x), false); }
@@ -243,13 +243,13 @@ namespace hpx { namespace concurrency { namespace details {
     static inline bool (likely)(bool x) { return x; }
     static inline bool (unlikely)(bool x) { return x; }
 #endif
-} } }
+}
 
 #ifdef MOODYCAMEL_QUEUE_INTERNAL_DEBUG
 #include "internal/concurrentqueue_internal_debug.h"
 #endif
 
-namespace hpx { namespace concurrency {
+namespace hpx::concurrency {
 namespace details {
     template<typename T>
     struct const_numeric_max {
@@ -3650,7 +3650,7 @@ inline void swap(typename ConcurrentQueue<T, Traits>::ImplicitProducerKVP& a, ty
     a.swap(b);
 }
 
-} }
+}
 
 #if defined(__GNUC__)
 #pragma GCC diagnostic pop

--- a/libs/core/config/include/hpx/config.hpp
+++ b/libs/core/config/include/hpx/config.hpp
@@ -438,4 +438,8 @@
 #  define HPX_HAVE_MAX_CPU_COUNT 256
 #endif
 
+#if !defined(HPX_HAVE_MAX_CPU_COUNT)
+#define HPX_HAVE_MAX_CPU_COUNT 64
+#endif
+
 // clang-format on

--- a/libs/core/resource_partitioner/include/hpx/resource_partitioner/detail/partitioner.hpp
+++ b/libs/core/resource_partitioner/include/hpx/resource_partitioner/detail/partitioner.hpp
@@ -1,5 +1,5 @@
 //  Copyright (c) 2017 Shoshana Jakobovits
-//  Copyright (c) 2017-2022 Hartmut Kaiser
+//  Copyright (c) 2017-2024 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -50,7 +50,7 @@ namespace hpx::resource::detail {
         // counter ... overall, in all the thread pools
         static std::size_t num_threads_overall;
 
-        init_pool_data(std::string const& name, scheduling_policy policy,
+        init_pool_data(std::string const& name, scheduling_policy sched,
             hpx::threads::policies::scheduler_mode mode,
             background_work_function func = background_work_function());
 
@@ -75,7 +75,7 @@ namespace hpx::resource::detail {
         hpx::threads::policies::scheduler_mode mode_;
         scheduler_function create_function_;
 
-        // possible additional beckground work to run on this scheduler
+        // possible additional background work to run on this scheduler
         background_work_function background_work_;
     };
 
@@ -86,6 +86,12 @@ namespace hpx::resource::detail {
 
     public:
         partitioner();
+
+        partitioner(partitioner const&) = delete;
+        partitioner(partitioner&&) = delete;
+        partitioner& operator=(partitioner const&) = delete;
+        partitioner& operator=(partitioner&&) = delete;
+
         ~partitioner();
 
         void print_init_pool_data(std::ostream&) const;
@@ -203,7 +209,7 @@ namespace hpx::resource::detail {
     private:
         ////////////////////////////////////////////////////////////////////////
         void fill_topology_vectors();
-        bool pu_exposed(std::size_t pid);
+        bool pu_exposed(std::size_t pu_num) const;
 
         ////////////////////////////////////////////////////////////////////////
         // called in hpx_init run_or_start
@@ -232,7 +238,7 @@ namespace hpx::resource::detail {
         // counter for instance numbers
         static std::atomic<int> instance_number_counter_;
 
-        // holds all of the command line switches
+        // holds all the command line switches
         util::section rtcfg_;
         std::size_t first_core_;
         std::size_t pus_needed_;

--- a/libs/core/resource_partitioner/include/hpx/resource_partitioner/partitioner_fwd.hpp
+++ b/libs/core/resource_partitioner/include/hpx/resource_partitioner/partitioner_fwd.hpp
@@ -107,6 +107,7 @@ namespace hpx::resource {
         shared_priority = 7,
         local_workrequesting_fifo = 8,
         local_workrequesting_lifo = 9,
+        local_workrequesting_mc = 10,
     };
 
 #define HPX_SCHEDULING_POLICY_UNSCOPED_ENUM_DEPRECATION_MSG                    \

--- a/libs/core/resource_partitioner/tests/unit/cross_pool_injection.cpp
+++ b/libs/core/resource_partitioner/tests/unit/cross_pool_injection.cpp
@@ -288,6 +288,9 @@ int main(int argc, char* argv[])
         hpx::resource::scheduling_policy::static_priority,
         // The shared_priority scheduler sometimes hangs in this test.
         //hpx::resource::scheduling_policy::shared_priority,
+        hpx::resource::scheduling_policy::local_workrequesting_fifo,
+        hpx::resource::scheduling_policy::local_workrequesting_lifo,
+        hpx::resource::scheduling_policy::local_workrequesting_mc,
     };
 
     for (auto const scheduler : schedulers)

--- a/libs/core/resource_partitioner/tests/unit/shutdown_suspended_pus.cpp
+++ b/libs/core/resource_partitioner/tests/unit/shutdown_suspended_pus.cpp
@@ -90,6 +90,10 @@ int main(int argc, char* argv[])
             // an assert in the scheduling_loop if a background thread is not
             // created.
             //hpx::resource::scheduling_policy::shared_priority,
+
+            hpx::resource::scheduling_policy::local_workrequesting_fifo,
+            hpx::resource::scheduling_policy::local_workrequesting_lifo,
+            hpx::resource::scheduling_policy::local_workrequesting_mc,
         };
 
         for (auto const scheduler : schedulers)

--- a/libs/core/resource_partitioner/tests/unit/suspend_pool.cpp
+++ b/libs/core/resource_partitioner/tests/unit/suspend_pool.cpp
@@ -192,6 +192,10 @@ int main(int argc, char* argv[])
         hpx::resource::scheduling_policy::static_,
         hpx::resource::scheduling_policy::static_priority,
         hpx::resource::scheduling_policy::shared_priority,
+
+        hpx::resource::scheduling_policy::local_workrequesting_fifo,
+        hpx::resource::scheduling_policy::local_workrequesting_lifo,
+        hpx::resource::scheduling_policy::local_workrequesting_mc,
     };
 
     for (auto const scheduler : schedulers)

--- a/libs/core/resource_partitioner/tests/unit/suspend_pool_external.cpp
+++ b/libs/core/resource_partitioner/tests/unit/suspend_pool_external.cpp
@@ -102,6 +102,10 @@ int main(int argc, char* argv[])
         hpx::resource::scheduling_policy::static_,
         hpx::resource::scheduling_policy::static_priority,
         hpx::resource::scheduling_policy::shared_priority,
+
+        hpx::resource::scheduling_policy::local_workrequesting_fifo,
+        hpx::resource::scheduling_policy::local_workrequesting_lifo,
+        hpx::resource::scheduling_policy::local_workrequesting_mc,
     };
 
     for (auto const scheduler : schedulers)

--- a/libs/core/resource_partitioner/tests/unit/suspend_runtime.cpp
+++ b/libs/core/resource_partitioner/tests/unit/suspend_runtime.cpp
@@ -71,6 +71,10 @@ int main(int argc, char* argv[])
         hpx::resource::scheduling_policy::static_,
         hpx::resource::scheduling_policy::static_priority,
         hpx::resource::scheduling_policy::shared_priority,
+
+        hpx::resource::scheduling_policy::local_workrequesting_fifo,
+        hpx::resource::scheduling_policy::local_workrequesting_lifo,
+        hpx::resource::scheduling_policy::local_workrequesting_mc,
     };
 
     for (auto const scheduler : schedulers)

--- a/libs/core/resource_partitioner/tests/unit/suspend_thread.cpp
+++ b/libs/core/resource_partitioner/tests/unit/suspend_thread.cpp
@@ -246,6 +246,10 @@ int main(int argc, char* argv[])
             hpx::resource::scheduling_policy::abp_priority_lifo,
 #endif
             hpx::resource::scheduling_policy::shared_priority,
+
+            hpx::resource::scheduling_policy::local_workrequesting_fifo,
+            hpx::resource::scheduling_policy::local_workrequesting_lifo,
+            hpx::resource::scheduling_policy::local_workrequesting_mc,
         };
 
         for (auto const scheduler : schedulers)

--- a/libs/core/resource_partitioner/tests/unit/suspend_thread_external.cpp
+++ b/libs/core/resource_partitioner/tests/unit/suspend_thread_external.cpp
@@ -206,6 +206,10 @@ int main(int argc, char* argv[])
         hpx::resource::scheduling_policy::static_,
         hpx::resource::scheduling_policy::static_priority,
         hpx::resource::scheduling_policy::shared_priority,
+
+        hpx::resource::scheduling_policy::local_workrequesting_fifo,
+        hpx::resource::scheduling_policy::local_workrequesting_lifo,
+        hpx::resource::scheduling_policy::local_workrequesting_mc,
     };
 
     for (auto const scheduler : schedulers)

--- a/libs/core/resource_partitioner/tests/unit/suspend_thread_timed.cpp
+++ b/libs/core/resource_partitioner/tests/unit/suspend_thread_timed.cpp
@@ -147,6 +147,9 @@ int main(int argc, char* argv[])
             hpx::resource::scheduling_policy::abp_priority_fifo,
             hpx::resource::scheduling_policy::abp_priority_lifo,
 #endif
+            hpx::resource::scheduling_policy::local_workrequesting_fifo,
+            hpx::resource::scheduling_policy::local_workrequesting_lifo,
+            hpx::resource::scheduling_policy::local_workrequesting_mc,
         };
 
         for (auto const scheduler : schedulers)

--- a/libs/core/schedulers/include/hpx/schedulers/local_priority_queue_scheduler.hpp
+++ b/libs/core/schedulers/include/hpx/schedulers/local_priority_queue_scheduler.hpp
@@ -60,7 +60,7 @@ namespace hpx::threads::policies {
         typename StagedQueuing = lockfree_fifo,
         typename TerminatedQueuing =
             default_local_priority_queue_scheduler_terminated_queue>
-    class HPX_CORE_EXPORT local_priority_queue_scheduler : public scheduler_base
+    class local_priority_queue_scheduler : public scheduler_base
     {
     public:
         using has_periodic_maintenance = std::false_type;

--- a/libs/core/schedulers/include/hpx/schedulers/local_queue_scheduler.hpp
+++ b/libs/core/schedulers/include/hpx/schedulers/local_queue_scheduler.hpp
@@ -53,7 +53,7 @@ namespace hpx::threads::policies {
         typename StagedQueuing = lockfree_fifo,
         typename TerminatedQueuing =
             default_local_queue_scheduler_terminated_queue>
-    class HPX_CORE_EXPORT local_queue_scheduler : public scheduler_base
+    class local_queue_scheduler : public scheduler_base
     {
     public:
         using has_periodic_maintenance = std::false_type;
@@ -925,8 +925,8 @@ namespace hpx::threads::policies {
         detail::affinity_data const& affinity_data_;
 
 #if !defined(HPX_NATIVE_MIC)    // we know that the MIC has one NUMA domain only
-        mask_type steals_in_numa_domain_;
-        mask_type steals_outside_numa_domain_;
+        mask_type steals_in_numa_domain_ = mask_type();
+        mask_type steals_outside_numa_domain_ = mask_type();
 #endif
         std::vector<mask_type> numa_domain_masks_;
         std::vector<mask_type> outside_numa_domain_masks_;

--- a/libs/core/schedulers/include/hpx/schedulers/lockfree_queue_backends.hpp
+++ b/libs/core/schedulers/include/hpx/schedulers/lockfree_queue_backends.hpp
@@ -50,6 +50,8 @@ namespace hpx::threads::policies {
         using rvalue_reference = T&&;
         using size_type = std::uint64_t;
 
+        static constexpr bool support_bulk_dequeue = false;
+
         explicit lockfree_fifo_backend(size_type initial_size = 0,
             size_type /* num_thread */ = static_cast<size_type>(-1))
           : queue_(static_cast<std::size_t>(initial_size))
@@ -114,6 +116,8 @@ namespace hpx::threads::policies {
         using rvalue_reference = T&&;
         using size_type = std::uint64_t;
 
+        static constexpr bool support_bulk_dequeue = true;
+
         explicit moodycamel_fifo_backend(size_type initial_size = 0,
             size_type /* num_thread */ = static_cast<size_type>(-1))
           : queue_(static_cast<std::size_t>(initial_size))
@@ -134,6 +138,14 @@ namespace hpx::threads::policies {
             noexcept(std::is_nothrow_copy_constructible_v<T>))
         {
             return queue_.try_dequeue(val);
+        }
+
+        template <typename Iterator>
+        std::size_t pop_bulk(Iterator it, std::int64_t max_items,
+            bool /* steal */ = true) noexcept(noexcept(std::
+                is_nothrow_copy_constructible_v<T>))
+        {
+            return queue_.try_dequeue_bulk(it, max_items);
         }
 
         bool empty() noexcept
@@ -169,6 +181,8 @@ namespace hpx::threads::policies {
         using const_reference = T const&;
         using rvalue_reference = T&&;
         using size_type = std::uint64_t;
+
+        static constexpr bool support_bulk_dequeue = false;
 
         explicit lockfree_lifo_backend(size_type initial_size = 0,
             size_type /* num_thread */ = static_cast<size_type>(-1))
@@ -230,6 +244,8 @@ namespace hpx::threads::policies {
         using rvalue_reference = T&&;
         using size_type = std::uint64_t;
 
+        static constexpr bool support_bulk_dequeue = false;
+
         explicit lockfree_abp_fifo_backend(size_type initial_size = 0,
             size_type /* num_thread */ = static_cast<size_type>(-1))
           : queue_(static_cast<std::size_t>(initial_size))
@@ -286,6 +302,8 @@ namespace hpx::threads::policies {
         using const_reference = T const&;
         using rvalue_reference = T&&;
         using size_type = std::uint64_t;
+
+        static constexpr bool support_bulk_dequeue = false;
 
         explicit lockfree_abp_lifo_backend(size_type initial_size = 0,
             size_type /* num_thread */ = static_cast<size_type>(-1))

--- a/libs/core/schedulers/include/hpx/schedulers/static_priority_queue_scheduler.hpp
+++ b/libs/core/schedulers/include/hpx/schedulers/static_priority_queue_scheduler.hpp
@@ -33,7 +33,7 @@ namespace hpx::threads::policies {
     ///////////////////////////////////////////////////////////////////////////
     // The static_priority_queue_scheduler maintains exactly one queue of work
     // items (threads) per OS thread, where this OS thread pulls its next work
-    // from. Additionally it maintains separate queues: several for high
+    // from. Additionally, it maintains separate queues: several for high
     // priority threads and one for low priority threads.
     //
     // High priority threads are executed by the first N OS threads before any

--- a/libs/core/synchronization/include/hpx/synchronization/channel_mpmc.hpp
+++ b/libs/core/synchronization/include/hpx/synchronization/channel_mpmc.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2019-2023 Hartmut Kaiser
+//  Copyright (c) 2019-2024 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -14,7 +14,6 @@
 #include <hpx/modules/errors.hpp>
 #include <hpx/modules/thread_support.hpp>
 #include <hpx/synchronization/spinlock.hpp>
-#include <hpx/type_support/construct_at.hpp>
 
 #include <cstddef>
 #include <memory>
@@ -34,7 +33,7 @@ namespace hpx::lcos::local {
     private:
         using mutex_type = Mutex;
 
-        constexpr bool is_full(std::size_t tail) const noexcept
+        [[nodiscard]] constexpr bool is_full(std::size_t tail) const noexcept
         {
             std::size_t const numitems = size_ + tail - head_.data_;
             if (numitems < size_)
@@ -44,7 +43,7 @@ namespace hpx::lcos::local {
             return numitems - size_ == size_ - 1;
         }
 
-        constexpr bool is_empty(std::size_t head) const noexcept
+        [[nodiscard]] constexpr bool is_empty(std::size_t head) const noexcept
         {
             return head == tail_.data_;
         }
@@ -93,6 +92,16 @@ namespace hpx::lcos::local {
                 std::unique_lock<mutex_type> l(mtx_.data_);
                 close(l);
             }
+        }
+
+        [[nodiscard]] bool is_empty() const noexcept
+        {
+            std::unique_lock<mutex_type> l(mtx_.data_);
+            if (closed_)
+            {
+                return true;
+            }
+            return is_empty(head_.data_);
         }
 
         bool get(T* val = nullptr) const noexcept
@@ -160,7 +169,7 @@ namespace hpx::lcos::local {
             return close(l);
         }
 
-        constexpr std::size_t capacity() const noexcept
+        [[nodiscard]] constexpr std::size_t capacity() const noexcept
         {
             return size_ - 1;
         }

--- a/libs/core/thread_pools/include/hpx/thread_pools/detail/background_thread.hpp
+++ b/libs/core/thread_pools/include/hpx/thread_pools/detail/background_thread.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2023 Hartmut Kaiser
+//  Copyright (c) 2023-2024 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -7,7 +7,6 @@
 #pragma once
 
 #include <hpx/config.hpp>
-#include <hpx/coroutines/thread_enums.hpp>
 #include <hpx/execution_base/this_thread.hpp>
 #include <hpx/thread_pools/detail/scheduling_callbacks.hpp>
 #include <hpx/thread_pools/detail/scheduling_counters.hpp>

--- a/libs/core/thread_pools/include/hpx/thread_pools/scheduled_thread_pool.hpp
+++ b/libs/core/thread_pools/include/hpx/thread_pools/scheduled_thread_pool.hpp
@@ -1,5 +1,5 @@
 //  Copyright (c) 2017 Shoshana Jakobovits
-//  Copyright (c) 2007-2022 Hartmut Kaiser
+//  Copyright (c) 2007-2024 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -42,12 +42,18 @@ namespace hpx::threads::detail {
 
     ///////////////////////////////////////////////////////////////////////////
     template <typename Scheduler>
-    class scheduled_thread_pool : public hpx::threads::thread_pool_base
+    class scheduled_thread_pool final : public hpx::threads::thread_pool_base
     {
     public:
         ///////////////////////////////////////////////////////////////////
         scheduled_thread_pool(std::unique_ptr<Scheduler> sched,
             thread_pool_init_parameters const& init);
+
+        scheduled_thread_pool(scheduled_thread_pool const&) = delete;
+        scheduled_thread_pool(scheduled_thread_pool&&) = delete;
+        scheduled_thread_pool& operator=(scheduled_thread_pool const&) = delete;
+        scheduled_thread_pool& operator=(scheduled_thread_pool&&) = delete;
+
         virtual ~scheduled_thread_pool();
 
         void print_pool(std::ostream& os) const override;
@@ -153,7 +159,7 @@ namespace hpx::threads::detail {
         std::thread& get_os_thread_handle(
             std::size_t global_thread_num) override
         {
-            std::size_t num_thread_local =
+            std::size_t const num_thread_local =
                 global_thread_num - this->thread_offset_;
             HPX_ASSERT(num_thread_local < threads_.size());
             return threads_[num_thread_local];

--- a/libs/core/thread_pools/src/scheduled_thread_pool.cpp
+++ b/libs/core/thread_pools/src/scheduled_thread_pool.cpp
@@ -17,64 +17,45 @@
 
 ///////////////////////////////////////////////////////////////////////////////
 /// explicit template instantiation for the thread pools of our choice
-template class HPX_CORE_EXPORT hpx::threads::policies::local_queue_scheduler<>;
 template class HPX_CORE_EXPORT hpx::threads::detail::scheduled_thread_pool<
     hpx::threads::policies::local_queue_scheduler<>>;
 
-template class HPX_CORE_EXPORT hpx::threads::policies::static_queue_scheduler<>;
 template class HPX_CORE_EXPORT hpx::threads::detail::scheduled_thread_pool<
     hpx::threads::policies::static_queue_scheduler<>>;
 
-template class HPX_CORE_EXPORT hpx::threads::policies::background_scheduler<>;
 template class HPX_CORE_EXPORT hpx::threads::detail::scheduled_thread_pool<
     hpx::threads::policies::background_scheduler<>>;
 
-template class HPX_CORE_EXPORT
-    hpx::threads::policies::local_priority_queue_scheduler<>;
 template class HPX_CORE_EXPORT hpx::threads::detail::scheduled_thread_pool<
     hpx::threads::policies::local_priority_queue_scheduler<std::mutex,
         hpx::threads::policies::lockfree_fifo>>;
 
-template class HPX_CORE_EXPORT
-    hpx::threads::policies::static_priority_queue_scheduler<>;
 template class HPX_CORE_EXPORT hpx::threads::detail::scheduled_thread_pool<
     hpx::threads::policies::static_priority_queue_scheduler<>>;
 #if defined(HPX_HAVE_CXX11_STD_ATOMIC_128BIT)
-template class HPX_CORE_EXPORT
-    hpx::threads::policies::local_priority_queue_scheduler<std::mutex,
-        hpx::threads::policies::lockfree_lifo>;
 template class HPX_CORE_EXPORT hpx::threads::detail::scheduled_thread_pool<
     hpx::threads::policies::local_priority_queue_scheduler<std::mutex,
         hpx::threads::policies::lockfree_lifo>>;
 #endif
 
 #if defined(HPX_HAVE_CXX11_STD_ATOMIC_128BIT)
-template class HPX_CORE_EXPORT
-    hpx::threads::policies::local_priority_queue_scheduler<std::mutex,
-        hpx::threads::policies::lockfree_abp_fifo>;
 template class HPX_CORE_EXPORT hpx::threads::detail::scheduled_thread_pool<
     hpx::threads::policies::local_priority_queue_scheduler<std::mutex,
         hpx::threads::policies::lockfree_abp_fifo>>;
-template class HPX_CORE_EXPORT
-    hpx::threads::policies::local_priority_queue_scheduler<std::mutex,
-        hpx::threads::policies::lockfree_abp_lifo>;
 template class HPX_CORE_EXPORT hpx::threads::detail::scheduled_thread_pool<
     hpx::threads::policies::local_priority_queue_scheduler<std::mutex,
         hpx::threads::policies::lockfree_abp_lifo>>;
 #endif
 
-template class HPX_CORE_EXPORT
-    hpx::threads::policies::shared_priority_queue_scheduler<>;
 template class HPX_CORE_EXPORT hpx::threads::detail::scheduled_thread_pool<
     hpx::threads::policies::shared_priority_queue_scheduler<>>;
 
-template class HPX_CORE_EXPORT
-    hpx::threads::policies::local_workrequesting_scheduler<>;
 template class HPX_CORE_EXPORT hpx::threads::detail::scheduled_thread_pool<
     hpx::threads::policies::local_workrequesting_scheduler<>>;
-template class HPX_CORE_EXPORT
-    hpx::threads::policies::local_workrequesting_scheduler<std::mutex,
-        hpx::threads::policies::lockfree_lifo>;
 template class HPX_CORE_EXPORT hpx::threads::detail::scheduled_thread_pool<
     hpx::threads::policies::local_workrequesting_scheduler<std::mutex,
         hpx::threads::policies::lockfree_lifo>>;
+
+template class HPX_CORE_EXPORT hpx::threads::detail::scheduled_thread_pool<
+    hpx::threads::policies::local_workrequesting_scheduler<std::mutex,
+        hpx::threads::policies::concurrentqueue_fifo>>;

--- a/libs/core/threading_base/include/hpx/threading_base/thread_data.hpp
+++ b/libs/core/threading_base/include/hpx/threading_base/thread_data.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2023 Hartmut Kaiser
+//  Copyright (c) 2007-2024 Hartmut Kaiser
 //  Copyright (c)      2011 Bryce Lelbach
 //  Copyright (c) 2008-2009 Chirag Dekate, Anshul Tandon
 //
@@ -253,24 +253,25 @@ namespace hpx::threads {
         }
 
 #if !defined(HPX_HAVE_THREAD_DESCRIPTION)
-        threads::thread_description get_description() const
+        static constexpr threads::thread_description get_description() noexcept
         {
-            return threads::thread_description("<unknown>");
+            return {"<unknown>"};
         }
-        threads::thread_description set_description(
-            threads::thread_description /*value*/)
+        static constexpr threads::thread_description set_description(
+            threads::thread_description /*value*/) noexcept
         {
-            return threads::thread_description("<unknown>");
+            return {"<unknown>"};
         }
 
-        threads::thread_description get_lco_description() const    //-V524
+        static constexpr threads::thread_description
+        get_lco_description() noexcept    //-V524
         {
-            return threads::thread_description("<unknown>");
+            return {"<unknown>"};
         }
-        threads::thread_description set_lco_description(    //-V524
-            threads::thread_description /*value*/)
+        static constexpr threads::thread_description set_lco_description(
+            threads::thread_description /*value*/) noexcept    //-V524
         {
-            return threads::thread_description("<unknown>");
+            return {"<unknown>"};
         }
 #else
         threads::thread_description get_description() const
@@ -306,20 +307,20 @@ namespace hpx::threads {
 
 #if !defined(HPX_HAVE_THREAD_PARENT_REFERENCE)
         /// Return the locality of the parent thread
-        constexpr std::uint32_t get_parent_locality_id() const noexcept
+        static constexpr std::uint32_t get_parent_locality_id() noexcept
         {
             // this is the same as naming::invalid_locality_id
             return ~static_cast<std::uint32_t>(0);
         }
 
         /// Return the thread id of the parent thread
-        constexpr thread_id_type get_parent_thread_id() const noexcept
+        static constexpr thread_id_type get_parent_thread_id() noexcept
         {
             return threads::invalid_thread_id;
         }
 
         /// Return the phase of the parent thread
-        constexpr std::size_t get_parent_thread_phase() const noexcept
+        static constexpr std::size_t get_parent_thread_phase() noexcept
         {
             return 0;
         }

--- a/libs/core/threading_base/include/hpx/threading_base/thread_description.hpp
+++ b/libs/core/threading_base/include/hpx/threading_base/thread_description.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2016-2023 Hartmut Kaiser
+//  Copyright (c) 2016-2024 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -254,12 +254,12 @@ namespace hpx::threads {
         {
         }
 
-        [[nodiscard]] constexpr data_type kind() const noexcept
+        [[nodiscard]] static constexpr data_type kind() noexcept
         {
             return data_type_description;
         }
 
-        [[nodiscard]] constexpr char const* get_description() const noexcept
+        [[nodiscard]] static constexpr char const* get_description() noexcept
         {
             return "<unknown>";
         }

--- a/libs/core/threading_base/include/hpx/threading_base/thread_pool_base.hpp
+++ b/libs/core/threading_base/include/hpx/threading_base/thread_pool_base.hpp
@@ -1,5 +1,5 @@
 //  Copyright (c)      2018 Mikael Simberg
-//  Copyright (c) 2007-2023 Hartmut Kaiser
+//  Copyright (c) 2007-2024 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -418,39 +418,17 @@ namespace hpx::threads {
         }
 
         std::int64_t get_thread_count_unknown(
-            std::size_t num_thread, bool reset)
-        {
-            return get_thread_count(thread_schedule_state::unknown,
-                thread_priority::default_, num_thread, reset);
-        }
-        std::int64_t get_thread_count_active(std::size_t num_thread, bool reset)
-        {
-            return get_thread_count(thread_schedule_state::active,
-                thread_priority::default_, num_thread, reset);
-        }
+            std::size_t num_thread, bool reset);
+        std::int64_t get_thread_count_active(
+            std::size_t num_thread, bool reset);
         std::int64_t get_thread_count_pending(
-            std::size_t num_thread, bool reset)
-        {
-            return get_thread_count(thread_schedule_state::pending,
-                thread_priority::default_, num_thread, reset);
-        }
+            std::size_t num_thread, bool reset);
         std::int64_t get_thread_count_suspended(
-            std::size_t num_thread, bool reset)
-        {
-            return get_thread_count(thread_schedule_state::suspended,
-                thread_priority::default_, num_thread, reset);
-        }
+            std::size_t num_thread, bool reset);
         std::int64_t get_thread_count_terminated(
-            std::size_t num_thread, bool reset)
-        {
-            return get_thread_count(thread_schedule_state::terminated,
-                thread_priority::default_, num_thread, reset);
-        }
-        std::int64_t get_thread_count_staged(std::size_t num_thread, bool reset)
-        {
-            return get_thread_count(thread_schedule_state::staged,
-                thread_priority::default_, num_thread, reset);
-        }
+            std::size_t num_thread, bool reset);
+        std::int64_t get_thread_count_staged(
+            std::size_t num_thread, bool reset);
 
         virtual std::int64_t get_scheduler_utilization() const = 0;
 

--- a/libs/core/threading_base/src/thread_data.cpp
+++ b/libs/core/threading_base/src/thread_data.cpp
@@ -28,7 +28,10 @@ namespace hpx::threads {
 
     namespace detail {
 
-        static get_locality_id_type* get_locality_id_f;
+        namespace {
+
+            get_locality_id_type* get_locality_id_f = nullptr;
+        }
 
         void set_get_locality_id(get_locality_id_type* f)
         {

--- a/libs/core/threading_base/src/thread_helpers.cpp
+++ b/libs/core/threading_base/src/thread_helpers.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2022 Hartmut Kaiser
+//  Copyright (c) 2007-2024 Hartmut Kaiser
 //  Copyright (c)      2011 Bryce Lelbach
 //
 //  SPDX-License-Identifier: BSL-1.0
@@ -294,7 +294,10 @@ namespace hpx::threads {
 #endif
 
     ////////////////////////////////////////////////////////////////////////////
-    static thread_local std::size_t continuation_recursion_count(0);
+    namespace {
+
+        thread_local std::size_t continuation_recursion_count(0);
+    }
 
     std::size_t& get_continuation_recursion_count() noexcept
     {
@@ -423,9 +426,9 @@ namespace hpx::threads {
 
 namespace hpx::this_thread {
 
-    // The function \a suspend will return control to the thread manager
-    // (suspends the current thread). It sets the new state of this thread
-    // to the thread state passed as the parameter.
+    // The function 'suspend' will return control to the thread manager
+    // (suspends the current thread). It sets the new state of this thread to
+    // the thread state passed as the parameter.
     //
     // If the suspension was aborted, this function will throw a
     // \a yield_aborted exception.
@@ -619,14 +622,14 @@ namespace hpx::this_thread {
             return false;
 
 #if defined(HPX_HAVE_THREADS_GET_STACK_POINTER)
-        std::ptrdiff_t remaining_stack = get_available_stack_space();
+        std::ptrdiff_t const remaining_stack = get_available_stack_space();
         if (remaining_stack < 0)
         {
             HPX_THROW_EXCEPTION(hpx::error::out_of_memory,
                 "has_sufficient_stack_space", "Stack overflow");
         }
-        bool sufficient_stack_space =
-            std::size_t(remaining_stack) >= space_needed;
+        bool const sufficient_stack_space =
+            static_cast<std::size_t>(remaining_stack) >= space_needed;
 
         return sufficient_stack_space;
 #else

--- a/libs/core/threading_base/src/thread_num_tss.cpp
+++ b/libs/core/threading_base/src/thread_num_tss.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2023 Hartmut Kaiser
+//  Copyright (c) 2007-2024 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -17,7 +17,7 @@ namespace hpx::threads::detail {
 
         thread_nums& thread_nums_tss()
         {
-            static thread_local thread_nums thread_nums_tss_ = {
+            thread_local thread_nums thread_nums_tss_ = {
                 static_cast<std::size_t>(-1), static_cast<std::size_t>(-1),
                 static_cast<std::size_t>(-1)};
             return thread_nums_tss_;

--- a/libs/core/threading_base/src/thread_pool_base.cpp
+++ b/libs/core/threading_base/src/thread_pool_base.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2023 Hartmut Kaiser
+//  Copyright (c) 2007-2024 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -85,6 +85,48 @@ namespace hpx::threads {
         auto const& topo = create_topology();
         mask_type const used_processing_units = get_used_processing_units();
         return topo.cpuset_to_nodeset(used_processing_units);
+    }
+
+    std::int64_t thread_pool_base::get_thread_count_unknown(
+        std::size_t num_thread, bool reset)
+    {
+        return get_thread_count(thread_schedule_state::unknown,
+            thread_priority::default_, num_thread, reset);
+    }
+
+    std::int64_t thread_pool_base::get_thread_count_active(
+        std::size_t num_thread, bool reset)
+    {
+        return get_thread_count(thread_schedule_state::active,
+            thread_priority::default_, num_thread, reset);
+    }
+
+    std::int64_t thread_pool_base::get_thread_count_pending(
+        std::size_t num_thread, bool reset)
+    {
+        return get_thread_count(thread_schedule_state::pending,
+            thread_priority::default_, num_thread, reset);
+    }
+
+    std::int64_t thread_pool_base::get_thread_count_suspended(
+        std::size_t num_thread, bool reset)
+    {
+        return get_thread_count(thread_schedule_state::suspended,
+            thread_priority::default_, num_thread, reset);
+    }
+
+    std::int64_t thread_pool_base::get_thread_count_terminated(
+        std::size_t num_thread, bool reset)
+    {
+        return get_thread_count(thread_schedule_state::terminated,
+            thread_priority::default_, num_thread, reset);
+    }
+
+    std::int64_t thread_pool_base::get_thread_count_staged(
+        std::size_t num_thread, bool reset)
+    {
+        return get_thread_count(thread_schedule_state::staged,
+            thread_priority::default_, num_thread, reset);
     }
 
     std::size_t thread_pool_base::get_active_os_thread_count() const

--- a/libs/core/threading_base/tests/regressions/thread_stacksize_current.cpp
+++ b/libs/core/threading_base/tests/regressions/thread_stacksize_current.cpp
@@ -29,7 +29,7 @@ void test(hpx::threads::thread_stacksize stacksize)
     hpx::async(exec, [&exec_current, stacksize]() {
         // This thread should have the stack size stacksize; it has been
         // explicitly set in the executor.
-        hpx::threads::thread_stacksize self_stacksize =
+        hpx::threads::thread_stacksize const self_stacksize =
             hpx::threads::get_self_stacksize_enum();
         HPX_TEST_EQ(self_stacksize, stacksize);
         HPX_TEST_NEQ(self_stacksize, hpx::threads::thread_stacksize::current);
@@ -37,7 +37,7 @@ void test(hpx::threads::thread_stacksize stacksize)
         hpx::async(exec_current, [stacksize]() {
             // This thread should also have the stack size stacksize; it has
             // been inherited size from the parent thread.
-            hpx::threads::thread_stacksize self_stacksize =
+            hpx::threads::thread_stacksize const self_stacksize =
                 hpx::threads::get_self_stacksize_enum();
             HPX_TEST_EQ(self_stacksize, stacksize);
             HPX_TEST_NEQ(
@@ -63,7 +63,7 @@ int hpx_main()
 int main(int argc, char** argv)
 {
     // clang-format off
-    std::vector<std::string> schedulers = {
+    std::vector<std::string> const schedulers = {
         "local",
         "local-priority-fifo",
 #if defined(HPX_HAVE_CXX11_STD_ATOMIC_128BIT)
@@ -77,7 +77,8 @@ int main(int argc, char** argv)
 #endif
         "shared-priority",
         "local-workrequesting-fifo",
-        "local-workrequesting-lifo"
+        "local-workrequesting-lifo",
+        "local-workrequesting-mc",
     };
     // clang-format on
     for (auto const& scheduler : schedulers)

--- a/libs/core/threadmanager/include/hpx/threadmanager/threadmanager_fwd.hpp
+++ b/libs/core/threadmanager/include/hpx/threadmanager/threadmanager_fwd.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2020 Hartmut Kaiser
+//  Copyright (c) 2020-2024 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -8,10 +8,10 @@
 
 #include <hpx/config.hpp>
 
-namespace hpx { namespace threads {
+namespace hpx::threads {
 
     // The thread-manager class is the central instance of management for
     // all (non-depleted) threads
     class HPX_CORE_EXPORT threadmanager;
 
-}}    // namespace hpx::threads
+}    // namespace hpx::threads

--- a/libs/core/topology/include/hpx/topology/cpu_mask.hpp
+++ b/libs/core/topology/include/hpx/topology/cpu_mask.hpp
@@ -1,5 +1,5 @@
 ////////////////////////////////////////////////////////////////////////////////
-//  Copyright (c) 2007-2015 Hartmut Kaiser
+//  Copyright (c) 2007-2024 Hartmut Kaiser
 //  Copyright (c) 2008-2009 Chirag Dekate, Anshul Tandon
 //  Copyright (c) 2012-2013 Thomas Heller
 //
@@ -43,52 +43,52 @@ namespace hpx::threads {
     using mask_rvref_type = std::uint64_t;
     using mask_cref_type = std::uint64_t;
 
-    constexpr inline std::uint64_t bits(std::size_t idx) noexcept
+    constexpr std::uint64_t bits(std::size_t idx) noexcept
     {
         HPX_ASSERT(idx < CHAR_BIT * sizeof(mask_type));
-        return std::uint64_t(1) << idx;
+        return static_cast<std::uint64_t>(1) << idx;
     }
 
-    constexpr inline bool any(mask_cref_type mask) noexcept
+    constexpr bool any(mask_cref_type mask) noexcept
     {
         return mask != 0;
     }
 
-    constexpr inline mask_type not_(mask_cref_type mask) noexcept
+    constexpr mask_type not_(mask_cref_type mask) noexcept
     {
         return ~mask;
     }
 
-    constexpr inline bool test(mask_cref_type mask, std::size_t idx) noexcept
+    constexpr bool test(mask_cref_type mask, std::size_t idx) noexcept
     {
         HPX_ASSERT(idx < CHAR_BIT * sizeof(mask_type));
         return (bits(idx) & mask) != 0;
     }
 
-    constexpr inline void set(mask_type& mask, std::size_t idx) noexcept
+    constexpr void set(mask_type& mask, std::size_t idx) noexcept
     {
         HPX_ASSERT(idx < CHAR_BIT * sizeof(mask_type));
         mask |= bits(idx);
     }
 
-    constexpr inline void unset(mask_type& mask, std::size_t idx) noexcept
+    constexpr void unset(mask_type& mask, std::size_t idx) noexcept
     {
         HPX_ASSERT(idx < CHAR_BIT * sizeof(mask_type));
         mask &= not_(bits(idx));
     }
 
-    constexpr inline std::size_t mask_size(mask_cref_type /*mask*/) noexcept
+    constexpr std::size_t mask_size(mask_cref_type /*mask*/) noexcept
     {
         return CHAR_BIT * sizeof(mask_type);
     }
 
-    constexpr inline void resize(
+    constexpr void resize(
         mask_type& /*mask*/, [[maybe_unused]] std::size_t s) noexcept
     {
         HPX_ASSERT(s <= CHAR_BIT * sizeof(mask_type));
     }
 
-    constexpr inline std::size_t find_first(mask_cref_type mask) noexcept
+    constexpr std::size_t find_first(mask_cref_type mask) noexcept
     {
         if (mask)
         {
@@ -101,24 +101,24 @@ namespace hpx::threads {
 
             return c;
         }
-        return ~std::size_t(0);
+        return ~static_cast<std::size_t>(0);
     }
 
-    constexpr inline bool equal(
+    constexpr bool equal(
         mask_cref_type lhs, mask_cref_type rhs, std::size_t = 0) noexcept
     {
         return lhs == rhs;
     }
 
     // return true if at least one of the masks has a bit set
-    constexpr inline bool bit_or(
+    constexpr bool bit_or(
         mask_cref_type lhs, mask_cref_type rhs, std::size_t = 0) noexcept
     {
         return (lhs | rhs) != 0;
     }
 
     // return true if at least one bit is set in both masks
-    constexpr inline bool bit_and(
+    constexpr bool bit_and(
         mask_cref_type lhs, mask_cref_type rhs, std::size_t = 0) noexcept
     {
         return (lhs & rhs) != 0;
@@ -126,7 +126,7 @@ namespace hpx::threads {
 
     // returns the number of bits set, taken from:
     // https://graphics.stanford.edu/~seander/bithacks.html#CountBitsSetKernighan
-    constexpr inline std::size_t count(mask_type mask) noexcept
+    constexpr std::size_t count(mask_type mask) noexcept
     {
         std::size_t c = 0;    // c accumulates the total bits set in v
         for (; mask; ++c)
@@ -136,7 +136,7 @@ namespace hpx::threads {
         return c;
     }
 
-    constexpr inline void reset(mask_type& mask) noexcept
+    constexpr void reset(mask_type& mask) noexcept
     {
         mask = 0ull;
     }

--- a/libs/core/topology/include/hpx/topology/topology.hpp
+++ b/libs/core/topology/include/hpx/topology/topology.hpp
@@ -416,7 +416,7 @@ namespace hpx::threads {
         // For example, core_affinity_masks[0] is a bitmask, where the
         // elements = 1 indicate the PUs that belong to the core on which
         // PU #0 (zero-based index) lies.
-        mask_type machine_affinity_mask_{};
+        mask_type machine_affinity_mask_ = mask_type();
         std::vector<mask_type> socket_affinity_masks_;
         std::vector<mask_type> numa_node_affinity_masks_;
         std::vector<mask_type> core_affinity_masks_;

--- a/tests/performance/local/future_overhead.cpp
+++ b/tests/performance/local/future_overhead.cpp
@@ -50,11 +50,11 @@ static std::uint64_t num_threads = 1;
 static std::string info_string = "";
 
 ///////////////////////////////////////////////////////////////////////////////
-void print_stats(const char* title, const char* wait, const char* exec,
+void print_stats(char const* title, char const* wait, char const* exec,
     std::int64_t count, double duration, bool csv)
 {
     std::ostringstream temp;
-    double us = 1e6 * duration / count;
+    double const us = 1e6 * duration / count;
     if (csv)
     {
         hpx::util::format_to(temp,
@@ -76,12 +76,12 @@ void print_stats(const char* title, const char* wait, const char* exec,
     //hpx::util::print_cdash_timing(title, duration);
 }
 
-const char* exec_name(hpx::execution::parallel_executor const&)
+char const* exec_name(hpx::execution::parallel_executor const&)
 {
     return "parallel_executor";
 }
 
-const char* exec_name(hpx::execution::experimental::scheduler_executor<
+char const* exec_name(hpx::execution::experimental::scheduler_executor<
     hpx::execution::experimental::thread_pool_scheduler> const&)
 {
     return "scheduler_executor<thread_pool_scheduler>";
@@ -89,15 +89,15 @@ const char* exec_name(hpx::execution::experimental::scheduler_executor<
 
 ///////////////////////////////////////////////////////////////////////////////
 // we use globals here to prevent the delay from being optimized away
-double global_scratch = 0;
-std::uint64_t num_iterations = 0;
+double volatile global_scratch = 0;
+std::uint64_t volatile num_iterations = 0;
 
 ///////////////////////////////////////////////////////////////////////////////
 double null_function() noexcept
 {
     if (num_iterations > 0)
     {
-        const int array_size = 4096;
+        constexpr int array_size = 4096;
         std::array<double, array_size> dummy;
         for (std::uint64_t i = 0; i < num_iterations; ++i)
         {
@@ -106,6 +106,7 @@ double null_function() noexcept
                 dummy[j] = 1.0 / (2.0 * i * j + 1.0);
             }
         }
+        global_scratch = dummy[0];
         return dummy[0];
     }
     return 0.0;
@@ -115,7 +116,7 @@ struct scratcher
 {
     void operator()(future<double> r) const
     {
-        global_scratch += r.get();
+        global_scratch = global_scratch + r.get();
     }
 };
 
@@ -125,36 +126,36 @@ HPX_PLAIN_ACTION(null_function, null_action)
 // Time async action execution using wait each on futures vector
 void measure_action_futures_wait_each(std::uint64_t count, bool csv)
 {
-    const hpx::id_type here = hpx::find_here();
+    hpx::id_type const here = hpx::find_here();
     std::vector<future<double>> futures;
     futures.reserve(count);
 
     // start the clock
-    high_resolution_timer walltime;
+    high_resolution_timer const walltime;
     for (std::uint64_t i = 0; i < count; ++i)
         futures.push_back(async<null_action>(here));
     hpx::wait_each(scratcher(), futures);
 
     // stop the clock
-    const double duration = walltime.elapsed();
+    double const duration = walltime.elapsed();
     print_stats("action", "WaitEach", "no-executor", count, duration, csv);
 }
 
 // Time async action execution using wait each on futures vector
 void measure_action_futures_wait_all(std::uint64_t count, bool csv)
 {
-    const hpx::id_type here = hpx::find_here();
+    hpx::id_type const here = hpx::find_here();
     std::vector<future<double>> futures;
     futures.reserve(count);
 
     // start the clock
-    high_resolution_timer walltime;
+    high_resolution_timer const walltime;
     for (std::uint64_t i = 0; i < count; ++i)
         futures.push_back(async<null_action>(here));
     hpx::wait_all(futures);
 
     // stop the clock
-    const double duration = walltime.elapsed();
+    double const duration = walltime.elapsed();
     print_stats("action", "WaitAll", "no-executor", count, duration, csv);
 }
 #endif
@@ -168,13 +169,13 @@ void measure_function_futures_wait_each(
     futures.reserve(count);
 
     // start the clock
-    high_resolution_timer walltime;
+    high_resolution_timer const walltime;
     for (std::uint64_t i = 0; i < count; ++i)
         futures.push_back(async(exec, &null_function));
     hpx::wait_each(scratcher(), futures);
 
     // stop the clock
-    const double duration = walltime.elapsed();
+    double const duration = walltime.elapsed();
     print_stats("async", "WaitEach", exec_name(exec), count, duration, csv);
 }
 
@@ -186,12 +187,12 @@ void measure_function_futures_wait_all(
     futures.reserve(count);
 
     // start the clock
-    high_resolution_timer walltime;
+    high_resolution_timer const walltime;
     for (std::uint64_t i = 0; i < count; ++i)
         futures.push_back(async(exec, &null_function));
     hpx::wait_all(futures);
 
-    const double duration = walltime.elapsed();
+    double const duration = walltime.elapsed();
     print_stats("async", "WaitAll", exec_name(exec), count, duration, csv);
 }
 
@@ -226,7 +227,7 @@ void measure_function_futures_limiting_executor(
     hpx::execution::experimental::static_chunk_size fixed(chunk_size);
 
     // start the clock
-    high_resolution_timer walltime;
+    high_resolution_timer const walltime;
     {
         hpx::execution::experimental::limiting_executor<Executor> signal_exec(
             exec, tasks, tasks + 1000);
@@ -234,7 +235,7 @@ void measure_function_futures_limiting_executor(
             hpx::execution::par.with(fixed), 0, count, [&](std::uint64_t) {
                 hpx::post(signal_exec, [&]() {
                     null_function();
-                    sanity_check--;
+                    --sanity_check;
                 });
             });
     }
@@ -246,7 +247,7 @@ void measure_function_futures_limiting_executor(
     }
 
     // stop the clock
-    const double duration = walltime.elapsed();
+    double const duration = walltime.elapsed();
     print_stats(
         "apply", "limiting-Exec", exec_name(exec), count, duration, csv);
 }
@@ -256,8 +257,8 @@ void measure_function_futures_sliding_semaphore(
     std::uint64_t count, bool csv, Executor& exec)
 {
     // start the clock
-    high_resolution_timer walltime;
-    const int sem_count = 5000;
+    high_resolution_timer const walltime;
+    constexpr int sem_count = 5000;
     auto sem = std::make_shared<hpx::sliding_semaphore>(sem_count);
     for (std::uint64_t i = 0; i < count; ++i)
     {
@@ -270,7 +271,7 @@ void measure_function_futures_sliding_semaphore(
     sem->wait(count + sem_count - 1);
 
     // stop the clock
-    const double duration = walltime.elapsed();
+    double const duration = walltime.elapsed();
     print_stats("apply", "Sliding-Sem", exec_name(exec), count, duration, csv);
 }
 
@@ -286,20 +287,18 @@ struct unlimited_number_of_chunks
     }
 };
 
-namespace hpx::parallel::execution {
-
-    template <>
-    struct is_executor_parameters<unlimited_number_of_chunks> : std::true_type
-    {
-    };
-}    // namespace hpx::parallel::execution
+template <>
+struct hpx::parallel::execution::is_executor_parameters<
+    unlimited_number_of_chunks> : std::true_type
+{
+};
 
 template <typename Executor>
 void measure_function_futures_for_loop(std::uint64_t count, bool csv,
     Executor& exec, char const* executor_name = nullptr)
 {
     // start the clock
-    high_resolution_timer walltime;
+    high_resolution_timer const walltime;
     hpx::experimental::for_loop(
         hpx::execution::par.on(exec).with(
             hpx::execution::experimental::static_chunk_size(1),
@@ -307,7 +306,7 @@ void measure_function_futures_for_loop(std::uint64_t count, bool csv,
         0, count, [](std::uint64_t) { null_function(); });
 
     // stop the clock
-    const double duration = walltime.elapsed();
+    double const duration = walltime.elapsed();
     print_stats("for_loop", "par",
         executor_name ? executor_name : exec_name(exec), count, duration, csv);
 }
@@ -317,7 +316,7 @@ void measure_function_futures_register_work(std::uint64_t count, bool csv)
     hpx::latch l(count);
 
     // start the clock
-    high_resolution_timer walltime;
+    high_resolution_timer const walltime;
     for (std::uint64_t i = 0; i < count; ++i)
     {
         hpx::threads::thread_init_data data(
@@ -331,7 +330,7 @@ void measure_function_futures_register_work(std::uint64_t count, bool csv)
     l.wait();
 
     // stop the clock
-    const double duration = walltime.elapsed();
+    double const duration = walltime.elapsed();
     print_stats("register_work", "latch", "none", count, duration, csv);
 }
 
@@ -346,14 +345,14 @@ void measure_function_futures_create_thread(std::uint64_t count, bool csv)
     };
     auto const thread_func =
         hpx::threads::detail::thread_function_nullary<decltype(func)>{func};
-    auto const desc = hpx::threads::thread_description();
-    auto const prio = hpx::threads::thread_priority::normal;
-    auto const hint = hpx::threads::thread_schedule_hint();
-    auto const stack_size = hpx::threads::thread_stacksize::small_;
+    constexpr auto desc = hpx::threads::thread_description();
+    constexpr auto prio = hpx::threads::thread_priority::normal;
+    constexpr auto hint = hpx::threads::thread_schedule_hint();
+    constexpr auto stack_size = hpx::threads::thread_stacksize::small_;
     hpx::error_code ec;
 
     // start the clock
-    high_resolution_timer walltime;
+    high_resolution_timer const walltime;
     for (std::uint64_t i = 0; i < count; ++i)
     {
         auto init = hpx::threads::thread_init_data(
@@ -365,7 +364,7 @@ void measure_function_futures_create_thread(std::uint64_t count, bool csv)
     l.wait();
 
     // stop the clock
-    const double duration = walltime.elapsed();
+    double const duration = walltime.elapsed();
     print_stats("create_thread", "latch", "none", count, duration, csv);
 }
 
@@ -402,7 +401,7 @@ void measure_function_futures_create_thread_hierarchical_placement(
     hpx::error_code ec;
 
     // start the clock
-    high_resolution_timer walltime;
+    high_resolution_timer const walltime;
     for (std::size_t t = 0; t < num_threads; ++t)
     {
         auto const hint =
@@ -434,7 +433,7 @@ void measure_function_futures_create_thread_hierarchical_placement(
     l.wait();
 
     // stop the clock
-    const double duration = walltime.elapsed();
+    double const duration = walltime.elapsed();
     print_stats(
         "create_thread_hierarchical", "latch", "none", count, duration, csv);
 }
@@ -451,7 +450,7 @@ void measure_function_futures_apply_hierarchical_placement(
     auto const num_threads = hpx::get_num_worker_threads();
 
     // start the clock
-    high_resolution_timer walltime;
+    high_resolution_timer const walltime;
     for (std::size_t t = 0; t < num_threads; ++t)
     {
         auto const hint =
@@ -473,7 +472,7 @@ void measure_function_futures_apply_hierarchical_placement(
     l.wait();
 
     // stop the clock
-    const double duration = walltime.elapsed();
+    double const duration = walltime.elapsed();
     print_stats("apply_hierarchical", "latch", "parallel_executor", count,
         duration, csv);
 }
@@ -490,8 +489,8 @@ int hpx_main(variables_map& vm)
         else
             numa_sensitive = 0;
 
-        bool test_all = (vm.count("test-all") > 0);
-        const int repetitions = vm["repetitions"].as<int>();
+        bool const test_all = (vm.count("test-all") > 0);
+        int const repetitions = vm["repetitions"].as<int>();
 
         if (vm.count("info"))
             info_string = vm["info"].as<std::string>();
@@ -500,8 +499,8 @@ int hpx_main(variables_map& vm)
 
         num_iterations = vm["delay-iterations"].as<std::uint64_t>();
 
-        const std::uint64_t count = vm["futures"].as<std::uint64_t>();
-        bool csv = vm.count("csv") != 0;
+        std::uint64_t const count = vm["futures"].as<std::uint64_t>();
+        bool const csv = vm.count("csv") != 0;
         if (HPX_UNLIKELY(0 == count))
             throw std::logic_error("error: count of 0 futures specified\n");
 


### PR DESCRIPTION
- adding new scheduler: --hpx:queuing=local-workrequesting-mc that relies on the Moody-Camel queue
- flyby: a lot of cleanup in various related places
- flyby: fixing config-registry for command line module

working towards #4703