### PR TITLE
Modifying CMakeLists to copy libhwloc-15.dll to the binary folder in Windows, independently

### DIFF
--- a/.github/workflows/windows_debug_vs2022_fetch_hwloc.yml
+++ b/.github/workflows/windows_debug_vs2022_fetch_hwloc.yml
@@ -6,7 +6,7 @@
 
 name: Windows CI (Debug, VS2022 toolset) with HWLoc fetch
 
-on: [pull_request, push]
+on: [pull_request]
 
 jobs:
   build:

--- a/.github/workflows/windows_debug_vs2022_fetch_hwloc.yml
+++ b/.github/workflows/windows_debug_vs2022_fetch_hwloc.yml
@@ -6,7 +6,7 @@
 
 name: Windows CI (Debug, VS2022 toolset) with HWLoc fetch
 
-on: [pull_request]
+on: [pull_request, push]
 
 jobs:
   build:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2300,6 +2300,18 @@ if(HPX_WITH_GIT_BRANCH AND ((NOT HPX_WITH_GIT_TAG) OR "${HPX_WITH_GIT_TAG}x"
   endif()
 endif()
 
+if(HPX_WITH_FETCH_HWLOC AND "${CMAKE_SYSTEM_NAME}" STREQUAL "Windows")
+  add_custom_target(
+    HwlocDLL ALL
+    COMMAND ${CMAKE_COMMAND} -E make_directory
+            "${CMAKE_BINARY_DIR}/$<CONFIG>/bin/"
+    COMMAND
+      ${CMAKE_COMMAND} -E copy_if_different "${HWLOC_ROOT}/bin/libhwloc-15.dll"
+      "${CMAKE_BINARY_DIR}/$<CONFIG>/bin/"
+  )
+  add_hpx_pseudo_target(HwlocDLL)
+endif()
+
 # ##############################################################################
 # Add custom targets for tests
 # ##############################################################################
@@ -2332,18 +2344,6 @@ endif()
 
 if(HPX_WITH_EXAMPLES)
   add_hpx_pseudo_target(examples)
-  if(HPX_WITH_FETCH_HWLOC AND "${CMAKE_SYSTEM_NAME}" STREQUAL "Windows")
-    add_custom_target(
-      HwlocDLL ALL
-      COMMAND ${CMAKE_COMMAND} -E make_directory
-              "${CMAKE_BINARY_DIR}/$<CONFIG>/bin/"
-      COMMAND
-        ${CMAKE_COMMAND} -E copy_if_different
-        "${HWLOC_ROOT}/bin/libhwloc-15.dll"
-        "${CMAKE_BINARY_DIR}/$<CONFIG>/bin/"
-    )
-    add_hpx_pseudo_dependencies(examples HwlocDLL)
-  endif()
 endif()
 
 # ##############################################################################

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2300,18 +2300,6 @@ if(HPX_WITH_GIT_BRANCH AND ((NOT HPX_WITH_GIT_TAG) OR "${HPX_WITH_GIT_TAG}x"
   endif()
 endif()
 
-if(HPX_WITH_FETCH_HWLOC AND "${CMAKE_SYSTEM_NAME}" STREQUAL "Windows")
-  add_custom_target(
-    HwlocDLL ALL
-    COMMAND ${CMAKE_COMMAND} -E make_directory
-            "${CMAKE_BINARY_DIR}/$<CONFIG>/bin/"
-    COMMAND
-      ${CMAKE_COMMAND} -E copy_if_different "${HWLOC_ROOT}/bin/libhwloc-15.dll"
-      "${CMAKE_BINARY_DIR}/$<CONFIG>/bin/"
-  )
-  add_hpx_pseudo_target(HwlocDLL)
-endif()
-
 # ##############################################################################
 # Add custom targets for tests
 # ##############################################################################

--- a/cmake/HPX_SetupHwloc.cmake
+++ b/cmake/HPX_SetupHwloc.cmake
@@ -111,4 +111,17 @@ else()
   add_library(Hwloc::hwloc INTERFACE IMPORTED)
   target_include_directories(Hwloc::hwloc INTERFACE ${Hwloc_INCLUDE_DIR})
   target_link_libraries(Hwloc::hwloc INTERFACE ${Hwloc_LIBRARY})
+
+  if(HPX_WITH_FETCH_HWLOC AND "${CMAKE_SYSTEM_NAME}" STREQUAL "Windows")
+    add_custom_target(
+      HwlocDLL ALL
+      COMMAND ${CMAKE_COMMAND} -E make_directory
+              "${CMAKE_BINARY_DIR}/$<CONFIG>/bin/"
+      COMMAND
+        ${CMAKE_COMMAND} -E copy_if_different
+        "${HWLOC_ROOT}/bin/libhwloc-15.dll"
+        "${CMAKE_BINARY_DIR}/$<CONFIG>/bin/"
+    )
+    add_hpx_pseudo_target(HwlocDLL)
+  endif()
 endif()


### PR DESCRIPTION
References #6394 , #6392 

## Proposed Changes

  - Added the HwlocDLL custom target (defined in #6394), used for copying `libhwloc-15.dll` to the binary folder, directly as a psuedo-target
  - Hence, the above copy operation is now independent of the `examples` psuedo-target 

## Background context  
https://github.com/STEllAR-GROUP/hpx/pull/6394#discussion_r1466557733