### PR TITLE
Use shared mutex for resolve_locality procedure.

### DIFF
--- a/libs/full/agas/include/hpx/agas/addressing_service.hpp
+++ b/libs/full/agas/include/hpx/agas/addressing_service.hpp
@@ -104,7 +104,7 @@ namespace hpx { namespace agas {
         std::atomic<hpx::state> state_;
         naming::gid_type locality_;
 
-        mutable mutex_type resolved_localities_mtx_;
+        mutable hpx::shared_mutex resolved_localities_mtx_;
         using resolved_localities_type =
             std::map<naming::gid_type, parcelset::endpoints_type>;
         resolved_localities_type resolved_localities_;


### PR DESCRIPTION
`resolve_locality` is on the critical path of parcel sending. Originally, it used `hpx:spinlock` to protect its `unordered_map::find`. This turns out to be too expensive. This PR replaces the `spinlock` with `hpx::shared_mutex` and greatly improves the maximum parcel sending throughput.