### PR TITLE
Use compressed ptr in schedulers when 128 atomics are not lockfree

### DIFF
--- a/.jenkins/lsu/env-gcc-11.sh
+++ b/.jenkins/lsu/env-gcc-11.sh
@@ -27,4 +27,4 @@ configure_extra_options+=" -DHPX_WITH_DATAPAR_BACKEND=STD_EXPERIMENTAL_SIMD"
 # The pwrapi library still needs to be set up properly on rostam
 # configure_extra_options+=" -DHPX_WITH_POWER_COUNTER=ON"
 
-configure_extra_options+=" -DHPX_WITH_TESTS_COMMAND_LINE=--hpx:queuing=local-workrequesting-lifo"
+configure_extra_options+=" -DHPX_WITH_TESTS_COMMAND_LINE=--hpx:queuing=local-workrequesting-fifo"

--- a/cmake/HPX_AddConfigTest.cmake
+++ b/cmake/HPX_AddConfigTest.cmake
@@ -330,7 +330,7 @@ function(hpx_check_for_cxx11_std_atomic_128bit)
     HPX_WITH_CXX11_ATOMIC_128BIT
     SOURCE cmake/tests/cxx11_std_atomic_128bit.cpp
     LIBRARIES ${HPX_CXX11_STD_ATOMIC_LIBRARIES}
-    FILE ${ARGN}
+    FILE EXECUTE
   )
   if(NOT MSVC)
     # Sometimes linking against libatomic is required, if the platform doesn't
@@ -345,7 +345,7 @@ function(hpx_check_for_cxx11_std_atomic_128bit)
         HPX_WITH_CXX11_ATOMIC_128BIT
         SOURCE cmake/tests/cxx11_std_atomic_128bit.cpp
         LIBRARIES ${HPX_CXX11_STD_ATOMIC_LIBRARIES}
-        FILE ${ARGN}
+        FILE EXECUTE
       )
       if(NOT HPX_WITH_CXX11_ATOMIC_128BIT)
         # Adding -latomic did not help, so we don't attempt to link to it later

--- a/cmake/tests/cxx11_std_atomic.cpp
+++ b/cmake/tests/cxx11_std_atomic.cpp
@@ -14,8 +14,10 @@ void test_atomic()
 {
     std::atomic<T> a;
     a.store(T{});
-    T i = a.load();
-    (void) i;
+    [[maybe_unused]] T i = a.load();
+
+    // force using libatomic, if needed
+    [[maybe_unused]] bool b = a.is_lock_free();
 }
 
 struct index_data

--- a/cmake/tests/cxx11_std_atomic_128bit.cpp
+++ b/cmake/tests/cxx11_std_atomic_128bit.cpp
@@ -13,6 +13,8 @@ template <typename T>
 void test_atomic()
 {
     std::atomic<T> a;
+    if (!a.is_lock_free())
+        throw -1;
     a.store(T{});
     T i = a.load();
     (void)i;

--- a/cmake/tests/cxx11_std_atomic_128bit.cpp
+++ b/cmake/tests/cxx11_std_atomic_128bit.cpp
@@ -14,7 +14,7 @@ void test_atomic()
 {
     std::atomic<T> a;
     if (!a.is_lock_free())
-        throw -1;
+        std::exit(-1);
     a.store(T{});
     T i = a.load();
     (void)i;

--- a/cmake/tests/cxx11_std_atomic_128bit.cpp
+++ b/cmake/tests/cxx11_std_atomic_128bit.cpp
@@ -8,6 +8,7 @@
 
 #include <atomic>
 #include <cstdint>
+#include <cstdlib>
 
 template <typename T>
 void test_atomic()

--- a/libs/core/concurrency/include/hpx/concurrency/detail/freelist_stack.hpp
+++ b/libs/core/concurrency/include/hpx/concurrency/detail/freelist_stack.hpp
@@ -330,7 +330,7 @@ namespace hpx::lockfree::detail {
         tag_t tag;
     };
 
-    using tagged_index = util::cache_aligned_data_derived<tagged_index_data>;
+    using tagged_index = tagged_index_data;
 
     ///////////////////////////////////////////////////////////////////////////
     template <typename T, std::size_t Size>
@@ -619,7 +619,7 @@ namespace hpx::lockfree::detail {
             pool_.store(new_pool);
         }
 
-        std::atomic<tagged_index> pool_;
+        util::cache_aligned_data_derived<std::atomic<tagged_index>> pool_;
     };
 
     ///////////////////////////////////////////////////////////////////////////

--- a/libs/core/config/include/hpx/config/compiler_specific.hpp
+++ b/libs/core/config/include/hpx/config/compiler_specific.hpp
@@ -209,4 +209,8 @@
 #define HPX_LOCKFREE_DCAS_ALIGNMENT
 #endif
 
+#if !defined(HPX_HAVE_CXX11_STD_ATOMIC_128BIT)
+#define HPX_LOCKFREE_PTR_COMPRESSION 1
+#endif
+
 #endif    // defined(DOXYGEN)

--- a/libs/core/resource_partitioner/tests/unit/cross_pool_injection.cpp
+++ b/libs/core/resource_partitioner/tests/unit/cross_pool_injection.cpp
@@ -289,7 +289,9 @@ int main(int argc, char* argv[])
         // The shared_priority scheduler sometimes hangs in this test.
         //hpx::resource::scheduling_policy::shared_priority,
         hpx::resource::scheduling_policy::local_workrequesting_fifo,
+#if defined(HPX_HAVE_CXX11_STD_ATOMIC_128BIT)
         hpx::resource::scheduling_policy::local_workrequesting_lifo,
+#endif        
         hpx::resource::scheduling_policy::local_workrequesting_mc,
     };
 

--- a/libs/core/resource_partitioner/tests/unit/cross_pool_injection.cpp
+++ b/libs/core/resource_partitioner/tests/unit/cross_pool_injection.cpp
@@ -291,7 +291,7 @@ int main(int argc, char* argv[])
         hpx::resource::scheduling_policy::local_workrequesting_fifo,
 #if defined(HPX_HAVE_CXX11_STD_ATOMIC_128BIT)
         hpx::resource::scheduling_policy::local_workrequesting_lifo,
-#endif        
+#endif
         hpx::resource::scheduling_policy::local_workrequesting_mc,
     };
 

--- a/libs/core/resource_partitioner/tests/unit/shutdown_suspended_pus.cpp
+++ b/libs/core/resource_partitioner/tests/unit/shutdown_suspended_pus.cpp
@@ -92,7 +92,9 @@ int main(int argc, char* argv[])
             //hpx::resource::scheduling_policy::shared_priority,
 
             hpx::resource::scheduling_policy::local_workrequesting_fifo,
+#if defined(HPX_HAVE_CXX11_STD_ATOMIC_128BIT)
             hpx::resource::scheduling_policy::local_workrequesting_lifo,
+#endif
             hpx::resource::scheduling_policy::local_workrequesting_mc,
         };
 

--- a/libs/core/resource_partitioner/tests/unit/suspend_pool.cpp
+++ b/libs/core/resource_partitioner/tests/unit/suspend_pool.cpp
@@ -194,7 +194,9 @@ int main(int argc, char* argv[])
         hpx::resource::scheduling_policy::shared_priority,
 
         hpx::resource::scheduling_policy::local_workrequesting_fifo,
+#if defined(HPX_HAVE_CXX11_STD_ATOMIC_128BIT)
         hpx::resource::scheduling_policy::local_workrequesting_lifo,
+#endif
         hpx::resource::scheduling_policy::local_workrequesting_mc,
     };
 

--- a/libs/core/resource_partitioner/tests/unit/suspend_pool_external.cpp
+++ b/libs/core/resource_partitioner/tests/unit/suspend_pool_external.cpp
@@ -104,7 +104,9 @@ int main(int argc, char* argv[])
         hpx::resource::scheduling_policy::shared_priority,
 
         hpx::resource::scheduling_policy::local_workrequesting_fifo,
+#if defined(HPX_HAVE_CXX11_STD_ATOMIC_128BIT)
         hpx::resource::scheduling_policy::local_workrequesting_lifo,
+#endif
         hpx::resource::scheduling_policy::local_workrequesting_mc,
     };
 

--- a/libs/core/resource_partitioner/tests/unit/suspend_runtime.cpp
+++ b/libs/core/resource_partitioner/tests/unit/suspend_runtime.cpp
@@ -73,7 +73,9 @@ int main(int argc, char* argv[])
         hpx::resource::scheduling_policy::shared_priority,
 
         hpx::resource::scheduling_policy::local_workrequesting_fifo,
+#if defined(HPX_HAVE_CXX11_STD_ATOMIC_128BIT)
         hpx::resource::scheduling_policy::local_workrequesting_lifo,
+#endif
         hpx::resource::scheduling_policy::local_workrequesting_mc,
     };
 

--- a/libs/core/resource_partitioner/tests/unit/suspend_thread.cpp
+++ b/libs/core/resource_partitioner/tests/unit/suspend_thread.cpp
@@ -248,7 +248,9 @@ int main(int argc, char* argv[])
             hpx::resource::scheduling_policy::shared_priority,
 
             hpx::resource::scheduling_policy::local_workrequesting_fifo,
+#if defined(HPX_HAVE_CXX11_STD_ATOMIC_128BIT)
             hpx::resource::scheduling_policy::local_workrequesting_lifo,
+#endif
             hpx::resource::scheduling_policy::local_workrequesting_mc,
         };
 

--- a/libs/core/resource_partitioner/tests/unit/suspend_thread_external.cpp
+++ b/libs/core/resource_partitioner/tests/unit/suspend_thread_external.cpp
@@ -208,7 +208,9 @@ int main(int argc, char* argv[])
         hpx::resource::scheduling_policy::shared_priority,
 
         hpx::resource::scheduling_policy::local_workrequesting_fifo,
+#if defined(HPX_HAVE_CXX11_STD_ATOMIC_128BIT)
         hpx::resource::scheduling_policy::local_workrequesting_lifo,
+#endif
         hpx::resource::scheduling_policy::local_workrequesting_mc,
     };
 

--- a/libs/core/resource_partitioner/tests/unit/suspend_thread_timed.cpp
+++ b/libs/core/resource_partitioner/tests/unit/suspend_thread_timed.cpp
@@ -148,7 +148,9 @@ int main(int argc, char* argv[])
             hpx::resource::scheduling_policy::abp_priority_lifo,
 #endif
             hpx::resource::scheduling_policy::local_workrequesting_fifo,
+#if defined(HPX_HAVE_CXX11_STD_ATOMIC_128BIT)
             hpx::resource::scheduling_policy::local_workrequesting_lifo,
+#endif
             hpx::resource::scheduling_policy::local_workrequesting_mc,
         };
 

--- a/libs/core/thread_pools/src/scheduled_thread_pool.cpp
+++ b/libs/core/thread_pools/src/scheduled_thread_pool.cpp
@@ -52,9 +52,12 @@ template class HPX_CORE_EXPORT hpx::threads::detail::scheduled_thread_pool<
 
 template class HPX_CORE_EXPORT hpx::threads::detail::scheduled_thread_pool<
     hpx::threads::policies::local_workrequesting_scheduler<>>;
+
+#if defined(HPX_HAVE_CXX11_STD_ATOMIC_128BIT)
 template class HPX_CORE_EXPORT hpx::threads::detail::scheduled_thread_pool<
     hpx::threads::policies::local_workrequesting_scheduler<std::mutex,
         hpx::threads::policies::lockfree_lifo>>;
+#endif
 
 template class HPX_CORE_EXPORT hpx::threads::detail::scheduled_thread_pool<
     hpx::threads::policies::local_workrequesting_scheduler<std::mutex,

--- a/libs/core/threading_base/tests/regressions/thread_stacksize_current.cpp
+++ b/libs/core/threading_base/tests/regressions/thread_stacksize_current.cpp
@@ -77,7 +77,9 @@ int main(int argc, char** argv)
 #endif
         "shared-priority",
         "local-workrequesting-fifo",
+#if defined(HPX_HAVE_CXX11_STD_ATOMIC_128BIT)
         "local-workrequesting-lifo",
+#endif
         "local-workrequesting-mc",
     };
     // clang-format on

--- a/libs/core/threadmanager/src/threadmanager.cpp
+++ b/libs/core/threadmanager/src/threadmanager.cpp
@@ -573,9 +573,10 @@ namespace hpx::threads {
     }
 
     void threadmanager::create_scheduler_local_workrequesting_lifo(
-        thread_pool_init_parameters const& thread_pool_init,
-        policies::thread_queue_init_parameters const& thread_queue_init,
-        std::size_t numa_sensitive)
+        [[maybe_unused]] thread_pool_init_parameters const& thread_pool_init,
+        [[maybe_unused]] policies::thread_queue_init_parameters const&
+            thread_queue_init,
+        [[maybe_unused]] std::size_t numa_sensitive)
     {
 #if defined(HPX_HAVE_CXX11_STD_ATOMIC_128BIT)
         // set parameters for scheduler and pool instantiation and

--- a/libs/core/threadmanager/src/threadmanager.cpp
+++ b/libs/core/threadmanager/src/threadmanager.cpp
@@ -577,6 +577,7 @@ namespace hpx::threads {
         policies::thread_queue_init_parameters const& thread_queue_init,
         std::size_t numa_sensitive)
     {
+#if defined(HPX_HAVE_CXX11_STD_ATOMIC_128BIT)
         // set parameters for scheduler and pool instantiation and
         // perform compatibility checks
         std::size_t const num_high_priority_queues =
@@ -610,6 +611,12 @@ namespace hpx::threads {
             hpx::threads::detail::scheduled_thread_pool<local_sched_type>>(
             HPX_MOVE(sched), thread_pool_init);
         pools_.push_back(HPX_MOVE(pool));
+#else
+        throw hpx::detail::command_line_error(
+            "Command line option --hpx:queuing=local-workrequesting-lifo "
+            "is not configured in this build. Please make sure 128bit "
+            "atomics are available.");
+#endif
     }
 
     void threadmanager::create_pools()


### PR DESCRIPTION
Fixes atomics on some of the ARM machines (A64FX).

## Proposed Changes

  - Enable **cxx std atomic 128** bits (**HPX_HAVE_CXX11_STD_ATOMIC_128BIT**) only when **lockfree** in cmake cxx feature tests.
  - Enable **work_requesting_lifo** scheduler only when 128 bit atomics are available. 
  - Fallback to **HPX_LOCKFREE_PTR_COMPRESSION** when **HPX_HAVE_CXX11_STD_ATOMIC_128BIT** is not available. 
  - Use cache alignment only on **std::atomic** of the tagged_index in freelist_stack.
