### PR TITLE
LCI parcelport: add yield to potentially inifinite retry loop

### DIFF
--- a/docs/sphinx/manual/using_the_lci_parcelport.rst
+++ b/docs/sphinx/manual/using_the_lci_parcelport.rst
@@ -97,14 +97,6 @@ If you are using ``mpirun`` or ``srun``, you can just pass
 ``--hpx:ini=hpx.parcel.lci.priority=1000``, ``--hpx:ini=hpx.parcel.lci.enable=1``, and
 ``--hpx:ini=hpx.parcel.bootstrap=lci`` to the |hpx| applications.
 
-If you are running on a Cray machine, you need to pass `--mpi=pmix` or `--mpi=pmi2` to srun
-to enable the PMIx or PMI2 support of SLURM since LCI does not support the default Cray PMI.
-For example,
-
-.. code-block:: shell-session
-
-   $ srun --mpi=pmix [hpx application]
-
 .. _tune_lci_pp:
 
 Performance tuning of the LCI parcelport

--- a/libs/full/parcelport_lci/CMakeLists.txt
+++ b/libs/full/parcelport_lci/CMakeLists.txt
@@ -13,6 +13,7 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 set(parcelport_lci_headers
     hpx/parcelport_lci/config.hpp
     hpx/parcelport_lci/header.hpp
+    hpx/parcelport_lci/helper.hpp
     hpx/parcelport_lci/locality.hpp
     hpx/parcelport_lci/receiver_base.hpp
     hpx/parcelport_lci/sender_base.hpp

--- a/libs/full/parcelport_lci/include/hpx/parcelport_lci/config.hpp
+++ b/libs/full/parcelport_lci/include/hpx/parcelport_lci/config.hpp
@@ -53,6 +53,10 @@ namespace hpx::parcelset::policies::lci {
         static int ncomps;
         // Whether to enable in-buffer assembly for the header messages.
         static bool enable_in_buffer_assembly;
+        // The max retry count of send_nb before yield.
+        static int send_nb_max_retry;
+        // The max retry count of mbuffer_alloc before yield.
+        static int mbuffer_alloc_max_retry;
 
         static void init_config(util::runtime_configuration const& rtcfg);
     };

--- a/libs/full/parcelport_lci/include/hpx/parcelport_lci/helper.hpp
+++ b/libs/full/parcelport_lci/include/hpx/parcelport_lci/helper.hpp
@@ -1,0 +1,28 @@
+//  Copyright (c) 2023 Jiakun Yan
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include <hpx/config.hpp>
+
+#if defined(HPX_HAVE_NETWORKING) && defined(HPX_HAVE_PARCELPORT_LCI)
+
+#include <hpx/modules/lci_base.hpp>
+#include <hpx/parcelport_lci/parcelport_lci.hpp>
+
+namespace hpx::parcelset::policies::lci {
+    static inline void yield_k(int& k, int max_k = 32)
+    {
+        if (++k >= max_k)
+        {
+            k = 0;
+            if (hpx::threads::get_self_id() != hpx::threads::invalid_thread_id)
+                hpx::this_thread::yield();
+        }
+    }
+}    // namespace hpx::parcelset::policies::lci
+
+#endif

--- a/libs/full/parcelport_lci/include/hpx/parcelport_lci/parcelport_lci.hpp
+++ b/libs/full/parcelport_lci/include/hpx/parcelport_lci/parcelport_lci.hpp
@@ -267,7 +267,9 @@ namespace hpx::traits {
                 "reg_mem = 1\n"
                 "ndevices = 1\n"
                 "ncomps = 1\n"
-                "enable_in_buffer_assembly = 1\n";
+                "enable_in_buffer_assembly = 1\n"
+                "send_nb_max_retry = 32\n"
+                "mbuffer_alloc_max_retry = 32\n";
         }
     };
 }    // namespace hpx::traits

--- a/libs/full/parcelport_lci/src/config.cpp
+++ b/libs/full/parcelport_lci/src/config.cpp
@@ -29,6 +29,8 @@ namespace hpx::parcelset::policies::lci {
     int config_t::ndevices;
     int config_t::ncomps;
     bool config_t::enable_in_buffer_assembly;
+    int config_t::send_nb_max_retry;
+    int config_t::mbuffer_alloc_max_retry;
 
     void config_t::init_config(util::runtime_configuration const& rtcfg)
     {
@@ -99,15 +101,22 @@ namespace hpx::parcelset::policies::lci {
             throw std::runtime_error(
                 "Unknown progress type " + progress_type_str);
         }
-        progress_thread_num =
-            util::get_entry_as(rtcfg, "hpx.parcel.lci.prg_thread_num", -1);
-        prepost_recv_num =
-            util::get_entry_as(rtcfg, "hpx.parcel.lci.prepost_recv_num", 1);
-        reg_mem = util::get_entry_as(rtcfg, "hpx.parcel.lci.reg_mem", 1);
-        ndevices = util::get_entry_as(rtcfg, "hpx.parcel.lci.ndevices", 1);
-        ncomps = util::get_entry_as(rtcfg, "hpx.parcel.lci.ncomps", 1);
-        enable_in_buffer_assembly = util::get_entry_as(
-            rtcfg, "hpx.parcel.lci.enable_in_buffer_assembly", 1);
+        progress_thread_num = util::get_entry_as(
+            rtcfg, "hpx.parcel.lci.prg_thread_num", -1 /* Does not matter*/);
+        prepost_recv_num = util::get_entry_as(
+            rtcfg, "hpx.parcel.lci.prepost_recv_num", 1 /* Does not matter*/);
+        reg_mem = util::get_entry_as(
+            rtcfg, "hpx.parcel.lci.reg_mem", 1 /* Does not matter*/);
+        ndevices = util::get_entry_as(
+            rtcfg, "hpx.parcel.lci.ndevices", 1 /* Does not matter*/);
+        ncomps = util::get_entry_as(
+            rtcfg, "hpx.parcel.lci.ncomps", 1 /* Does not matter*/);
+        enable_in_buffer_assembly = util::get_entry_as(rtcfg,
+            "hpx.parcel.lci.enable_in_buffer_assembly", 1 /* Does not matter*/);
+        send_nb_max_retry = util::get_entry_as(
+            rtcfg, "hpx.parcel.lci.send_nb_max_retry", 0 /* Does not matter*/);
+        mbuffer_alloc_max_retry = util::get_entry_as(rtcfg,
+            "hpx.parcel.lci.mbuffer_alloc_max_retry", 0 /* Does not matter*/);
 
         if (!enable_send_immediate && enable_lci_backlog_queue)
         {

--- a/libs/full/parcelport_lci/src/putva/sender_connection_putva.cpp
+++ b/libs/full/parcelport_lci/src/putva/sender_connection_putva.cpp
@@ -14,6 +14,7 @@
 
 #include <hpx/modules/lci_base.hpp>
 #include <hpx/parcelport_lci/header.hpp>
+#include <hpx/parcelport_lci/helper.hpp>
 #include <hpx/parcelport_lci/locality.hpp>
 #include <hpx/parcelport_lci/parcelport_lci.hpp>
 #include <hpx/parcelport_lci/receiver_base.hpp>
@@ -62,8 +63,9 @@ namespace hpx::parcelset::policies::lci {
         int num_zero_copy_chunks = static_cast<int>(buffer_.num_chunks_.first);
         if (is_eager)
         {
+            int retry_count = 0;
             while (LCI_mbuffer_alloc(device_p->device, &mbuffer) != LCI_OK)
-                continue;
+                yield_k(retry_count, config_t::mbuffer_alloc_max_retry);
             HPX_ASSERT(mbuffer.length == (size_t) LCI_MEDIUM_SIZE);
             header_ = header(buffer_, (char*) mbuffer.address, mbuffer.length);
             mbuffer.length = header_.size();

--- a/libs/full/parcelport_lci/src/sender_connection_base.cpp
+++ b/libs/full/parcelport_lci/src/sender_connection_base.cpp
@@ -15,6 +15,7 @@
 #include <hpx/modules/lci_base.hpp>
 #include <hpx/parcelport_lci/backlog_queue.hpp>
 #include <hpx/parcelport_lci/header.hpp>
+#include <hpx/parcelport_lci/helper.hpp>
 #include <hpx/parcelport_lci/locality.hpp>
 #include <hpx/parcelport_lci/parcelport_lci.hpp>
 #include <hpx/parcelport_lci/receiver_base.hpp>
@@ -59,6 +60,7 @@ namespace hpx::parcelset::policies::lci {
         {
             // If we are sending early parcels, we should not expect the thread
             // make progress on the backlog queue.
+            int retry_count = 0;
             do
             {
                 ret = send_nb();
@@ -70,6 +72,7 @@ namespace hpx::parcelset::policies::lci {
                             config_t::progress_type_t::pthread_worker)
                         while (pp_->do_progress_local())
                             continue;
+                    yield_k(retry_count, config_t::send_nb_max_retry);
                 }
             } while (ret.status == return_status_t::retry);
         }

--- a/libs/full/parcelport_lci/src/sendrecv/sender_connection_sendrecv.cpp
+++ b/libs/full/parcelport_lci/src/sendrecv/sender_connection_sendrecv.cpp
@@ -12,6 +12,7 @@
 
 #include <hpx/modules/lci_base.hpp>
 #include <hpx/parcelport_lci/header.hpp>
+#include <hpx/parcelport_lci/helper.hpp>
 #include <hpx/parcelport_lci/locality.hpp>
 #include <hpx/parcelport_lci/parcelport_lci.hpp>
 #include <hpx/parcelport_lci/receiver_base.hpp>
@@ -46,9 +47,10 @@ namespace hpx::parcelset::policies::lci {
         // build header
         if (config_t::enable_in_buffer_assembly)
         {
+            int retry_count = 0;
             while (
                 LCI_mbuffer_alloc(device_p->device, &header_buffer) != LCI_OK)
-                continue;
+                yield_k(retry_count, config_t::mbuffer_alloc_max_retry);
             HPX_ASSERT(header_buffer.length == (size_t) LCI_MEDIUM_SIZE);
             header_ = header(
                 buffer_, (char*) header_buffer.address, header_buffer.length);
@@ -99,9 +101,10 @@ namespace hpx::parcelset::policies::lci {
         header_.set_tag(tag);
         if (!config_t::enable_in_buffer_assembly)
         {
+            int retry_count = 0;
             while (
                 LCI_mbuffer_alloc(device_p->device, &header_buffer) != LCI_OK)
-                continue;
+                yield_k(retry_count, config_t::mbuffer_alloc_max_retry);
             memcpy(header_buffer.address, header_buffer_vector.data(),
                 header_buffer_vector.size());
             header_buffer.length = header_buffer_vector.size();


### PR DESCRIPTION
In the LCI parcelport, there are several while (resource is available, retry) loops, i.e. the nonblocking send loop and the medium buffer allocation loop. In extreme cases, if all worker threads got into those retry loops and no threads are working on releasing the resource, HPX can get into deadlocks.

This PR lets those threads yield themselves after the max retry count (32).

Preliminary experiments show that the max retry count does not have visible performance effects on actually applications' performance (tried 1-256), so we just set it to 32 arbitrarily for now.