### PR TITLE
Fix nvcc crashes in transform_stream.cu and synchronize.cu

### DIFF
--- a/libs/core/async_cuda/tests/performance/synchronize.cu
+++ b/libs/core/async_cuda/tests/performance/synchronize.cu
@@ -6,8 +6,9 @@
 
 #include <hpx/config.hpp>
 
-// NVCC fails unceremoniously with this test at least until V12.1
-#if !defined(HPX_CUDA_VERSION) || (HPX_CUDA_VERSION > 1201)
+// NVCC fails unceremoniously with this test until V12.2
+// Fixed in CUDA 12.3
+#if !defined(HPX_CUDA_VERSION) || (HPX_CUDA_VERSION > 1202)
 
 #include <hpx/chrono.hpp>
 #include <hpx/execution.hpp>

--- a/libs/core/async_cuda/tests/unit/transform_stream.cu
+++ b/libs/core/async_cuda/tests/unit/transform_stream.cu
@@ -17,6 +17,7 @@
 
 #include <atomic>
 #include <cstddef>
+#include <iostream>
 #include <utility>
 
 __global__ void dummy_kernel() {}

--- a/libs/core/async_cuda/tests/unit/transform_stream.cu
+++ b/libs/core/async_cuda/tests/unit/transform_stream.cu
@@ -6,8 +6,9 @@
 
 #include <hpx/config.hpp>
 
-// NVCC fails unceremoniously with this test at least until V12.1
-#if !defined(HPX_CUDA_VERSION) || (HPX_CUDA_VERSION > 1201)
+// NVCC fails unceremoniously with this test until 12.2
+// Fixed in CUDA 12.3
+#if !defined(HPX_CUDA_VERSION) || (HPX_CUDA_VERSION > 1202)
 
 #include <hpx/execution.hpp>
 #include <hpx/init.hpp>
@@ -292,6 +293,7 @@ int hpx_main()
         cu::check_cuda_error(cudaFree(p));
     }
 
+    std::cout << "Test finished!" << std::endl;
     return hpx::local::finalize();
 }
 

--- a/libs/core/execution/include/hpx/execution/algorithms/just.hpp
+++ b/libs/core/execution/include/hpx/execution/algorithms/just.hpp
@@ -103,7 +103,7 @@ namespace hpx::execution::experimental {
             template <typename Receiver>
             friend auto tag_invoke(
                 connect_t, just_sender&& s, Receiver&& receiver) 
-#if !defined(HPX_CUDA_VERSION) 
+#if !defined(HPX_COMPUTE_DEVICE_CODE) 
             noexcept(util::all_of_v<std::is_nothrow_move_constructible<Ts>...>)
 #endif
             {

--- a/libs/core/execution/include/hpx/execution/algorithms/just.hpp
+++ b/libs/core/execution/include/hpx/execution/algorithms/just.hpp
@@ -102,7 +102,7 @@ namespace hpx::execution::experimental {
 
             template <typename Receiver>
             friend auto tag_invoke(
-                connect_t, just_sender&& s, Receiver&& receiver) 
+                connect_t, just_sender&& s, Receiver&& receiver)
 #if !defined(HPX_COMPUTE_DEVICE_CODE)
             noexcept(util::all_of_v<std::is_nothrow_move_constructible<Ts>...>)
 #endif

--- a/libs/core/execution/include/hpx/execution/algorithms/just.hpp
+++ b/libs/core/execution/include/hpx/execution/algorithms/just.hpp
@@ -102,8 +102,10 @@ namespace hpx::execution::experimental {
 
             template <typename Receiver>
             friend auto tag_invoke(
-                connect_t, just_sender&& s, Receiver&& receiver) noexcept(util::
-                    all_of_v<std::is_nothrow_move_constructible<Ts>...>)
+                connect_t, just_sender&& s, Receiver&& receiver) 
+#if !defined(HPX_CUDA_VERSION) 
+            noexcept(util::all_of_v<std::is_nothrow_move_constructible<Ts>...>)
+#endif
             {
                 return operation_state<Receiver>{
                     HPX_FORWARD(Receiver, receiver), HPX_MOVE(s.ts)};

--- a/libs/core/execution/include/hpx/execution/algorithms/just.hpp
+++ b/libs/core/execution/include/hpx/execution/algorithms/just.hpp
@@ -103,7 +103,7 @@ namespace hpx::execution::experimental {
             template <typename Receiver>
             friend auto tag_invoke(
                 connect_t, just_sender&& s, Receiver&& receiver) 
-#if !defined(HPX_COMPUTE_DEVICE_CODE) 
+#if !defined(HPX_COMPUTE_DEVICE_CODE)
             noexcept(util::all_of_v<std::is_nothrow_move_constructible<Ts>...>)
 #endif
             {

--- a/libs/core/execution/include/hpx/execution/algorithms/just.hpp
+++ b/libs/core/execution/include/hpx/execution/algorithms/just.hpp
@@ -104,7 +104,8 @@ namespace hpx::execution::experimental {
             friend auto tag_invoke(
                 connect_t, just_sender&& s, Receiver&& receiver)
 #if !defined(HPX_COMPUTE_DEVICE_CODE)
-            noexcept(util::all_of_v<std::is_nothrow_move_constructible<Ts>...>)
+                noexcept(
+                    util::all_of_v<std::is_nothrow_move_constructible<Ts>...>)
 #endif
             {
                 return operation_state<Receiver>{


### PR DESCRIPTION
With CUDA 12.3 nvcc does not outright crash anymore when compiling sender-receiver code. 
Though, to make them compile, we still need to conditionally remove the noexcept with an IFDEF, which this PR adds.

Hence, we can activate the synchronize and the transform_stream tests when the CUDA version ist 12.3 and newer.

Fixes #5799 