### PR TITLE
replace boost::array with std::array and update file name

### DIFF
--- a/libs/core/serialization/CMakeLists.txt
+++ b/libs/core/serialization/CMakeLists.txt
@@ -202,7 +202,7 @@ set(serialization_compat_headers
 
 if(HPX_SERIALIZATION_WITH_BOOST_TYPES)
   set(boost_serialization_headers
-      hpx/serialization/boost_array.hpp
+      hpx/serialization/std_array.hpp
       hpx/serialization/boost_intrusive_ptr.hpp
       hpx/serialization/boost_multi_array.hpp
       hpx/serialization/boost_shared_ptr.hpp

--- a/libs/core/serialization/include/hpx/serialization/std_array.hpp
+++ b/libs/core/serialization/include/hpx/serialization/std_array.hpp
@@ -10,26 +10,22 @@
 #include <hpx/config.hpp>
 #include <hpx/serialization/config/defines.hpp>
 
-#if defined(HPX_SERIALIZATION_HAVE_BOOST_TYPES)
-
 #include <hpx/serialization/array.hpp>
 #include <hpx/serialization/serialization_fwd.hpp>
 
-#include <boost/array.hpp>
+#include <array>
 
 #include <cstddef>
 
 namespace hpx::serialization {
 
-    // implement serialization for boost::array
+    // implement serialization for std::array
     template <typename Archive, typename T, std::size_t N>
     void serialize(
-        Archive& ar, boost::array<T, N>& a, unsigned int const /* version */)
+        Archive& ar, std::array<T, N>& a, unsigned int const /* version */)
     {
         // clang-format off
         ar & hpx::serialization::make_array(a.begin(), a.size());
         // clang-format on
     }
 }    // namespace hpx::serialization
-
-#endif


### PR DESCRIPTION

## Changes

  - remove "boost/array.hpp" and replace boost::array with std::array
  - rename file from 'boost_array.hpp' to 'std_array.hpp'
  - relating to issue (#3440)
