### PR TITLE
Reduce test workload to fix CI/CD time-out

### DIFF
--- a/libs/core/concurrency/tests/unit/freelist.cpp
+++ b/libs/core/concurrency/tests/unit/freelist.cpp
@@ -120,7 +120,7 @@ struct freelist_tester
 {
     static constexpr int size = 128;
     static constexpr int thread_count = 2;
-    static constexpr int operations_per_thread = 100000;
+    static constexpr int operations_per_thread = 10000;
 
     Freelist fl;
     hpx::lockfree::queue<dummy*> allocated_nodes;


### PR DESCRIPTION
Reduce workload on `freelist` test, to prevent CircleCI test from timing out.