### PR TITLE
Always return outermost thread id

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -497,10 +497,8 @@ jobs:
       - run:
           name: Building Unit Tests (Algorithms)
           command: |
-              ninja -j2 -k 0 \
-                tests.unit.modules.algorithms.algorithms \
-                tests.unit.modules.algorithms.block
-#                tests.unit.modules.algorithms.datapar_algorithms
+              ninja -j 1 -k 0 \
+                tests.unit.modules.algorithms.algorithms
       - run:
           name: Running Unit Tests
           when: always
@@ -512,9 +510,7 @@ jobs:
                 --no-compress-output \
                 --output-on-failure \
                 --tests-regex \
-              "tests.unit.modules.algorithms.algorithms|\
-              tests.unit.modules.algorithms.block"
-#              "|tests.unit.modules.algorithms.datapar_algorithms"
+              "tests.unit.modules.algorithms.algorithms"
       - run:
           <<: *convert_xml
       - run:
@@ -525,6 +521,39 @@ jobs:
           path: tests.unit.algorithms
       - store_artifacts:
           path: tests.unit.algorithms
+
+  tests.unit.algorithms.block:
+    <<: *defaults
+    steps:
+      - attach_workspace:
+          at: /hpx
+      - run:
+          name: Building Unit Tests (Algorithms)
+          command: |
+              ninja -j2 -k 0 \
+                tests.unit.modules.algorithms.block
+      - run:
+          name: Running Unit Tests
+          when: always
+          command: |
+              ulimit -c unlimited
+              ctest \
+                --timeout 120 \
+                -T test \
+                --no-compress-output \
+                --output-on-failure \
+                --tests-regex \
+              "tests.unit.modules.algorithms.block"
+      - run:
+          <<: *convert_xml
+      - run:
+          <<: *move_core_dump
+      - run:
+          <<: *move_debug_log
+      - store_test_results:
+          path: tests.unit.algorithms.block
+      - store_artifacts:
+          path: tests.unit.algorithms.block
 
   tests.unit.container_algorithms:
     <<: *defaults
@@ -913,6 +942,8 @@ workflows:
           <<: *core_dependency
       - tests.unit.algorithms:
           <<: *core_dependency
+      - tests.unit.algorithms.block:
+          <<: *core_dependency
       - tests.unit.container_algorithms:
           <<: *core_dependency
       - tests.unit.segmented_algorithms:
@@ -970,6 +1001,7 @@ workflows:
             - core
             - tests.examples
             - tests.unit.algorithms
+            - tests.unit.algorithms.block
             - tests.unit.container_algorithms
             - tests.unit.segmented_algorithms
             - tests.unit1

--- a/components/iostreams/src/server/output_stream.cpp
+++ b/components/iostreams/src/server/output_stream.cpp
@@ -34,7 +34,7 @@ namespace hpx::iostreams::detail {
         ar << valid;
         if (valid)
         {
-            ar& data_;
+            ar & data_;
         }
     }
 
@@ -44,7 +44,7 @@ namespace hpx::iostreams::detail {
         ar >> valid;
         if (valid)
         {
-            ar& data_;
+            ar & data_;
         }
     }
 }    // namespace hpx::iostreams::detail
@@ -89,10 +89,9 @@ namespace hpx::iostreams::server {
     {    // {{{
         // Perform the IO in another OS thread.
         detail::buffer in(buf_in);
-        hpx::get_thread_pool("io_pool")->get_io_service().post(
-            hpx::bind_front(&output_stream::call_write_sync, this, locality_id,
-                count, std::ref(in),
-                threads::thread_id_ref_type(threads::get_outer_self_id())));
+        hpx::get_thread_pool("io_pool")->get_io_service().post(hpx::bind_front(
+            &output_stream::call_write_sync, this, locality_id, count,
+            std::ref(in), threads::thread_id_ref_type(threads::get_self_id())));
 
         // Sleep until the worker thread wakes us up.
         this_thread::suspend(threads::thread_schedule_state::suspended,

--- a/libs/core/config/include/hpx/config/threads_stack.hpp
+++ b/libs/core/config/include/hpx/config/threads_stack.hpp
@@ -40,20 +40,22 @@
 #endif
 
 #if !defined(HPX_SMALL_STACK_SIZE)
-#  if defined(HPX_WINDOWS) && !defined(HPX_HAVE_GENERIC_CONTEXT_COROUTINES)
-#    define HPX_SMALL_STACK_SIZE_TARGET    0x4000        // 16kByte
-#  else
-#    if defined(HPX_DEBUG)
-#      define HPX_SMALL_STACK_SIZE_TARGET  0x20000       // 128kByte
+#  if !defined(HPX_SMALL_STACK_SIZE_TARGET)
+#    if defined(HPX_WINDOWS) && !defined(HPX_HAVE_GENERIC_CONTEXT_COROUTINES)
+#      define HPX_SMALL_STACK_SIZE_TARGET    0x4000        // 16kByte
 #    else
-#      if defined(__powerpc__) || defined(__INTEL_COMPILER)
-#         define HPX_SMALL_STACK_SIZE_TARGET  0x20000       // 128kByte
+#      if defined(HPX_DEBUG)
+#        define HPX_SMALL_STACK_SIZE_TARGET  0x20000       // 128kByte
 #      else
-#         define HPX_SMALL_STACK_SIZE_TARGET  0x10000        // 64kByte
+#        if defined(__powerpc__) || defined(__INTEL_COMPILER)
+#           define HPX_SMALL_STACK_SIZE_TARGET  0x20000       // 128kByte
+#        else
+#           define HPX_SMALL_STACK_SIZE_TARGET  0x10000        // 64kByte
+#        endif
 #      endif
 #    endif
 #  endif
-
+#
 #  if HPX_SMALL_STACK_SIZE_TARGET < (2 * HPX_THREADS_STACK_OVERHEAD)
 #    define HPX_SMALL_STACK_SIZE (2 * HPX_THREADS_STACK_OVERHEAD)
 #  else

--- a/libs/core/coroutines/include/hpx/coroutines/thread_enums.hpp
+++ b/libs/core/coroutines/include/hpx/coroutines/thread_enums.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2023 Hartmut Kaiser
+//  Copyright (c) 2007-2024 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -423,6 +423,12 @@ namespace hpx::threads {
         void runs_as_child_mode(thread_execution_hint bits) noexcept
         {
             runs_as_child_mode_bits = static_cast<std::uint8_t>(bits);
+        }
+
+        void schedule_hint(std::int16_t core) noexcept
+        {
+            mode = thread_schedule_hint_mode::thread;
+            hint = core;
         }
 
         /// The hint associated with the mode. The interpretation of this hint

--- a/libs/core/executors/include/hpx/executors/detail/index_queue_spawning.hpp
+++ b/libs/core/executors/include/hpx/executors/detail/index_queue_spawning.hpp
@@ -104,7 +104,7 @@ namespace hpx::parallel::execution::detail {
             if (allow_stealing)
             {
                 // Then steal from the opposite end of the neighboring queues
-                static constexpr auto opposite_end =
+                constexpr auto opposite_end =
                     hpx::concurrency::detail::opposite_end_v<Which>;
 
                 for (std::uint32_t offset = 1; offset != state->num_threads;
@@ -150,7 +150,7 @@ namespace hpx::parallel::execution::detail {
         // Finish the work for one worker thread. If this is not the last worker
         // thread to finish, it will only decrement the counter. If it is the
         // last thread it will call set_exception if there is an exception.
-        // Otherwise it will call set_value on the shared state.
+        // Otherwise, it will call set_value on the shared state.
         void finish() const
         {
             if (--(state->tasks_remaining.data_) == 0)
@@ -338,8 +338,7 @@ namespace hpx::parallel::execution::detail {
                 hint.hint == -1)
             {
                 // apply hint if none was given
-                hint.mode = hpx::threads::thread_schedule_hint_mode::thread;
-                hint.hint = worker_thread + first_thread;
+                hint.schedule_hint(worker_thread + first_thread);
 
                 hpx::detail::post_policy_dispatch<Launch>::call(
                     hpx::execution::experimental::with_hint(post_policy, hint),

--- a/libs/core/executors/include/hpx/executors/thread_pool_scheduler_bulk.hpp
+++ b/libs/core/executors/include/hpx/executors/thread_pool_scheduler_bulk.hpp
@@ -400,8 +400,7 @@ namespace hpx::execution::experimental::detail {
                 hint.hint == -1)
             {
                 // apply hint if none was given
-                hint.mode = hpx::threads::thread_schedule_hint_mode::thread;
-                hint.hint = worker_thread + op_state->first_thread;
+                hint.schedule_hint(worker_thread + op_state->first_thread);
 
                 auto policy = hpx::execution::experimental::with_hint(
                     op_state->scheduler.policy(), hint);

--- a/libs/core/futures/src/detail/execute_thread.cpp
+++ b/libs/core/futures/src/detail/execute_thread.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2019-2023 Hartmut Kaiser
+//  Copyright (c) 2019-2024 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -91,7 +91,7 @@ namespace hpx::threads::detail {
         bool reschedule = false;
 
         // don't directly run any threads that have started running 'normally'
-        // and were suspended afterwards
+        // and were suspended afterward
         if (thrdptr->runs_as_child())
         {
             LTM_(error).format(
@@ -131,8 +131,8 @@ namespace hpx::threads::detail {
                 return false;
             }
 
-            // check again, making sure the state has not changed in the mean
-            // time
+            // check again, making sure the state has not changed in the
+            // meantime
             if (thrdptr->runs_as_child())
             {
 #if defined(HPX_HAVE_APEX)

--- a/libs/core/schedulers/include/hpx/schedulers/local_priority_queue_scheduler.hpp
+++ b/libs/core/schedulers/include/hpx/schedulers/local_priority_queue_scheduler.hpp
@@ -560,8 +560,8 @@ namespace hpx::threads::policies {
 
             num_thread = select_active_pu(num_thread);
 
-            data.schedulehint.mode = thread_schedule_hint_mode::thread;
-            data.schedulehint.hint = static_cast<std::int16_t>(num_thread);
+            data.schedulehint.schedule_hint(
+                static_cast<std::int16_t>(num_thread));
 
             // now create the thread
             switch (data.priority)

--- a/libs/core/schedulers/include/hpx/schedulers/local_workrequesting_scheduler.hpp
+++ b/libs/core/schedulers/include/hpx/schedulers/local_workrequesting_scheduler.hpp
@@ -692,8 +692,8 @@ namespace hpx::threads::policies {
 
             num_thread = select_active_pu(num_thread);
 
-            data.schedulehint.mode = thread_schedule_hint_mode::thread;
-            data.schedulehint.hint = static_cast<std::int16_t>(num_thread);
+            data.schedulehint.schedule_hint(
+                static_cast<std::int16_t>(num_thread));
 
             // now create the thread
             switch (data.priority)

--- a/libs/core/threading/src/thread.cpp
+++ b/libs/core/threading/src/thread.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2022 Hartmut Kaiser
+//  Copyright (c) 2007-2024 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -22,7 +22,6 @@
 
 #include <cstddef>
 #include <exception>
-#include <functional>
 #include <mutex>
 #include <utility>
 
@@ -32,14 +31,14 @@
 
 namespace hpx {
 
-    namespace detail {
+    namespace {
 
-        static thread_termination_handler_type thread_termination_handler;
+        thread_termination_handler_type thread_termination_handler;
     }
 
     void set_thread_termination_handler(thread_termination_handler_type f)
     {
-        detail::thread_termination_handler = HPX_MOVE(f);
+        thread_termination_handler = HPX_MOVE(f);
     }
 
     thread::thread() noexcept
@@ -74,7 +73,7 @@ namespace hpx {
     {
         if (joinable())
         {
-            if (detail::thread_termination_handler)
+            if (thread_termination_handler)
             {
                 try
                 {
@@ -83,8 +82,7 @@ namespace hpx {
                 }
                 catch (...)
                 {
-                    detail::thread_termination_handler(
-                        std::current_exception());
+                    thread_termination_handler(std::current_exception());
                 }
             }
             else
@@ -103,17 +101,20 @@ namespace hpx {
         std::swap(id_, rhs.id_);
     }
 
-    static void run_thread_exit_callbacks()
-    {
-        threads::thread_id_type id = threads::get_self_id();
-        if (id == threads::invalid_thread_id)
+    namespace {
+
+        void run_thread_exit_callbacks()
         {
-            HPX_THROW_EXCEPTION(hpx::error::null_thread_id,
-                "run_thread_exit_callbacks", "null thread id encountered");
+            threads::thread_id_type const id = threads::get_self_id();
+            if (id == threads::invalid_thread_id)
+            {
+                HPX_THROW_EXCEPTION(hpx::error::null_thread_id,
+                    "run_thread_exit_callbacks", "null thread id encountered");
+            }
+            threads::run_thread_exit_callbacks(id);
+            threads::free_thread_exit_callbacks(id);
         }
-        threads::run_thread_exit_callbacks(id);
-        threads::free_thread_exit_callbacks(id);
-    }
+    }    // namespace
 
     threads::thread_result_type thread::thread_function_nullary(
         hpx::move_only_function<void()> const& func)
@@ -146,9 +147,8 @@ namespace hpx {
         // run all callbacks attached to the exit event for this thread
         run_thread_exit_callbacks();
 
-        return threads::thread_result_type(
-            threads::thread_schedule_state::terminated,
-            threads::invalid_thread_id);
+        return {threads::thread_schedule_state::terminated,
+            threads::invalid_thread_id};
     }
 
     thread::id thread::get_id() const noexcept
@@ -182,15 +182,17 @@ namespace hpx {
         {
             HPX_THROW_EXCEPTION(hpx::error::thread_resource_error,
                 "thread::start_thread", "Could not create thread");
-            return;
         }
     }
 
-    static void resume_thread(threads::thread_id_ref_type const& id)
-    {
-        threads::set_thread_state(
-            id.noref(), threads::thread_schedule_state::pending);
-    }
+    namespace {
+
+        void resume_thread(threads::thread_id_ref_type const& id)
+        {
+            threads::set_thread_state(
+                id.noref(), threads::thread_schedule_state::pending);
+        }
+    }    // namespace
 
     void thread::join()
     {
@@ -210,7 +212,6 @@ namespace hpx {
             l.unlock();
             HPX_THROW_EXCEPTION(hpx::error::thread_resource_error,
                 "thread::join", "hpx::thread: trying joining itself");
-            return;
         }
         this_thread::interruption_point();
 
@@ -228,7 +229,7 @@ namespace hpx {
     }
 
     // extensions
-    void thread::interrupt(bool flag)
+    void thread::interrupt(bool flag) const
     {
         threads::interrupt_thread(native_handle(), flag);
     }
@@ -238,7 +239,7 @@ namespace hpx {
         return threads::get_thread_interruption_requested(native_handle());
     }
 
-    void thread::interrupt(thread::id id, bool flag)
+    void thread::interrupt(thread::id const& id, bool flag)
     {
         threads::interrupt_thread(id.id_, flag);
     }
@@ -247,7 +248,7 @@ namespace hpx {
     {
         return threads::get_thread_data(native_handle());
     }
-    std::size_t thread::set_thread_data(std::size_t data)
+    std::size_t thread::set_thread_data(std::size_t data) const
     {
         return threads::set_thread_data(native_handle(), data);
     }
@@ -297,7 +298,7 @@ namespace hpx {
             using base_type::mtx_;
 
         public:
-            thread_task_base(threads::thread_id_ref_type const& id)
+            explicit thread_task_base(threads::thread_id_ref_type const& id)
             {
                 if (threads::add_thread_exit_callback(id.noref(),
                         hpx::bind_front(&thread_task_base::thread_exit_function,
@@ -345,13 +346,13 @@ namespace hpx {
         };
     }    // namespace detail
 
-    hpx::future<void> thread::get_future(error_code& ec)
+    hpx::future<void> thread::get_future(error_code& ec) const
     {
         if (id_ == threads::invalid_thread_id)
         {
             HPX_THROWS_IF(ec, hpx::error::null_thread_id, "thread::get_future",
                 "null thread id encountered");
-            return hpx::future<void>();
+            return {};
         }
 
         detail::thread_task_base* p = new detail::thread_task_base(id_);
@@ -361,7 +362,7 @@ namespace hpx {
             HPX_THROWS_IF(ec, hpx::error::thread_resource_error,
                 "thread::get_future",
                 "Could not create future as thread has been terminated.");
-            return hpx::future<void>();
+            return {};
         }
 
         using traits::future_access;
@@ -371,7 +372,7 @@ namespace hpx {
     ///////////////////////////////////////////////////////////////////////////
     namespace this_thread {
 
-        void yield_to(thread::id id) noexcept
+        void yield_to(thread::id const& id) noexcept
         {
             this_thread::suspend(threads::thread_schedule_state::pending,
                 id.native_handle(), "this_thread::yield_to");
@@ -486,8 +487,7 @@ namespace hpx {
 
         disable_interruption::~disable_interruption()
         {
-            threads::thread_self* p = threads::get_self_ptr();
-            if (p)
+            if (threads::get_self_ptr() != nullptr)
             {
                 threads::set_thread_interruption_enabled(
                     threads::get_self_id(), interruption_was_enabled_);
@@ -495,7 +495,8 @@ namespace hpx {
         }
 
         ///////////////////////////////////////////////////////////////////////
-        restore_interruption::restore_interruption(disable_interruption& d)
+        restore_interruption::restore_interruption(
+            disable_interruption const& d)
           : interruption_was_enabled_(d.interruption_was_enabled_)
         {
             if (!interruption_was_enabled_)
@@ -508,8 +509,7 @@ namespace hpx {
 
         restore_interruption::~restore_interruption()
         {
-            threads::thread_self* p = threads::get_self_ptr();
-            if (p)
+            if (threads::get_self_ptr() != nullptr)
             {
                 threads::set_thread_interruption_enabled(
                     threads::get_self_id(), interruption_was_enabled_);

--- a/libs/core/threading_base/include/hpx/threading_base/thread_data.hpp
+++ b/libs/core/threading_base/include/hpx/threading_base/thread_data.hpp
@@ -689,8 +689,11 @@ namespace hpx::threads {
 
         if (is_stackless())
         {
+            HPX_ASSERT(dynamic_cast<thread_data_stackless*>(this) != nullptr);
             return static_cast<thread_data_stackless*>(this)->call();
         }
+
+        HPX_ASSERT(dynamic_cast<thread_data_stackful*>(this) != nullptr);
         return static_cast<thread_data_stackful*>(this)->call(agent_storage);
     }
 
@@ -700,8 +703,11 @@ namespace hpx::threads {
 
         if (is_stackless())
         {
+            HPX_ASSERT(dynamic_cast<thread_data_stackless*>(this) != nullptr);
             return static_cast<thread_data_stackless*>(this)->call();
         }
-        return static_cast<thread_data_stackful*>(this)->invoke_directly();
+
+        HPX_ASSERT(dynamic_cast<thread_data_stackful*>(this) != nullptr);
+        return static_cast<thread_data_stackful*>(this)->call_directly();
     }
 }    // namespace hpx::threads

--- a/libs/core/threading_base/include/hpx/threading_base/thread_data_stackful.hpp
+++ b/libs/core/threading_base/include/hpx/threading_base/thread_data_stackful.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2023 Hartmut Kaiser
+//  Copyright (c) 2007-2024 Hartmut Kaiser
 //  Copyright (c)      2011 Bryce Lelbach
 //  Copyright (c) 2008-2009 Chirag Dekate, Anshul Tandon
 //
@@ -68,7 +68,7 @@ namespace hpx::threads {
             return coroutine_(set_state_ex(thread_restart_state::signaled));
         }
 
-        HPX_FORCEINLINE coroutine_type::result_type invoke_directly()
+        HPX_FORCEINLINE coroutine_type::result_type call_directly()
         {
             HPX_ASSERT(get_state().state() == thread_schedule_state::active);
             HPX_ASSERT(this == coroutine_.get_thread_id().get());

--- a/libs/core/threading_base/include/hpx/threading_base/threading_base_fwd.hpp
+++ b/libs/core/threading_base/include/hpx/threading_base/threading_base_fwd.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2023 Hartmut Kaiser
+//  Copyright (c) 2007-2024 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -101,10 +101,15 @@ namespace hpx::threads {
 
     /// The function \a get_outer_self_id returns the HPX thread id of
     /// the current outer thread (or zero if the current thread is not a HPX
-    /// thread). This usually returns the same as \a get_self_id, except for
-    /// directly executed threads, in which case this returns the thread id
-    /// of the outermost HPX thread.
-    HPX_CORE_EXPORT thread_id_type get_outer_self_id() noexcept;
+    /// thread). This now always returns the same as \a get_self_id, even for
+    /// directly executed threads.
+    HPX_DEPRECATED_V(1, 10,
+        "hpx::threads::get_outer_self_id is deprecated, use "
+        "hpx::threads::get_self_id instead")
+    inline thread_id_type get_outer_self_id() noexcept
+    {
+        return get_self_id();
+    }
 
     /// The function \a get_parent_id returns the HPX thread id of the
     /// current thread's parent (or zero if the current thread is not a

--- a/libs/core/threading_base/src/set_thread_state_timed.cpp
+++ b/libs/core/threading_base/src/set_thread_state_timed.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2023 Hartmut Kaiser
+//  Copyright (c) 2007-2024 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -83,7 +83,7 @@ namespace hpx::threads::detail {
         // create a new thread in suspended state, which will execute the
         // requested set_state when timer fires and will re-awaken this thread,
         // allowing the deadline_timer to go out of scope gracefully
-        thread_id_ref_type const self_id = get_outer_self_id();    // keep alive
+        thread_id_ref_type const self_id = get_self_id();    // keep alive
 
         std::shared_ptr<std::atomic<bool>> triggered(
             std::make_shared<std::atomic<bool>>(false));

--- a/libs/core/threading_base/src/thread_data.cpp
+++ b/libs/core/threading_base/src/thread_data.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2023 Hartmut Kaiser
+//  Copyright (c) 2007-2024 Hartmut Kaiser
 //  Copyright (c) 2008-2009 Chirag Dekate, Anshul Tandon
 //  Copyright (c) 2011      Bryce Lelbach
 //
@@ -35,7 +35,7 @@ namespace hpx::threads {
 
         void set_get_locality_id(get_locality_id_type* f)
         {
-            get_locality_id_f = HPX_MOVE(f);
+            get_locality_id_f = f;
         }
 
         std::uint32_t get_locality_id(hpx::error_code& ec)
@@ -319,16 +319,6 @@ namespace hpx::threads {
         if (thread_self const* self = get_self_ptr();
             HPX_LIKELY(nullptr != self))
         {
-            return self->get_thread_id();
-        }
-        return threads::invalid_thread_id;
-    }
-
-    thread_id_type get_outer_self_id() noexcept
-    {
-        if (thread_self const* self = get_self_ptr();
-            HPX_LIKELY(nullptr != self))
-        {
             return self->get_outer_thread_id();
         }
         return threads::invalid_thread_id;
@@ -339,7 +329,7 @@ namespace hpx::threads {
         if (thread_self const* self = get_self_ptr();
             HPX_LIKELY(nullptr != self))
         {
-            return get_thread_id_data(self->get_thread_id());
+            return get_thread_id_data(self->get_outer_thread_id());
         }
         return nullptr;
     }
@@ -418,7 +408,7 @@ namespace hpx::threads {
         if (thread_data const* thrd_data = get_self_id_data();
             HPX_LIKELY(nullptr != thrd_data))
         {
-            return thrd_data->get_component_id();
+            return hpx::threads::thread_data::get_component_id();
         }
         return 0;
 #endif

--- a/libs/core/threading_base/src/thread_helpers.cpp
+++ b/libs/core/threading_base/src/thread_helpers.cpp
@@ -98,6 +98,9 @@ namespace hpx::threads {
 
     void interrupt_thread(thread_id_type const& id, bool flag, error_code& ec)
     {
+        // Copy id as the original `id` may get reset by the caller
+        // asynchronously.
+        auto const keep_alive = id;
         if (HPX_UNLIKELY(!id))
         {
             HPX_THROWS_IF(ec, hpx::error::null_thread_id,
@@ -112,7 +115,7 @@ namespace hpx::threads {
 
         // Set thread state to pending. If the thread is currently active we do
         // not retry. The thread will either exit or hit an interruption_point.
-        set_thread_state(id, thread_schedule_state::pending,
+        set_thread_state(keep_alive, thread_schedule_state::pending,
             thread_restart_state::abort, thread_priority::normal, false, ec);
     }
 
@@ -628,6 +631,7 @@ namespace hpx::this_thread {
             HPX_THROW_EXCEPTION(hpx::error::out_of_memory,
                 "has_sufficient_stack_space", "Stack overflow");
         }
+
         bool const sufficient_stack_space =
             static_cast<std::size_t>(remaining_stack) >= space_needed;
 

--- a/libs/core/threading_base/tests/regressions/thread_stacksize_current.cpp
+++ b/libs/core/threading_base/tests/regressions/thread_stacksize_current.cpp
@@ -1,4 +1,5 @@
 //  Copyright (c) 2020 Mikael Simberg
+//  Copyright (c) 2024 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -10,6 +11,7 @@
 // thread_stacksize::minimal and thread_stacksize::maximal when a thread has been
 // created.
 
+#include <hpx/execution.hpp>
 #include <hpx/init.hpp>
 #include <hpx/modules/async_local.hpp>
 #include <hpx/modules/testing.hpp>
@@ -20,13 +22,23 @@
 #include <string>
 #include <vector>
 
+template <typename Executor>
+decltype(auto) disable_run_as_child(Executor&& exec)
+{
+    auto hint = hpx::execution::experimental::get_hint(exec);
+    hint.runs_as_child_mode(hpx::threads::thread_execution_hint::none);
+
+    return hpx::experimental::prefer(hpx::execution::experimental::with_hint,
+        HPX_FORWARD(Executor, exec), hint);
+}
+
 void test(hpx::threads::thread_stacksize stacksize)
 {
     hpx::execution::parallel_executor exec(stacksize);
     hpx::execution::parallel_executor exec_current(
         hpx::threads::thread_stacksize::current);
 
-    hpx::async(exec, [&exec_current, stacksize]() {
+    hpx::async(disable_run_as_child(exec), [&exec_current, stacksize]() {
         // This thread should have the stack size stacksize; it has been
         // explicitly set in the executor.
         hpx::threads::thread_stacksize const self_stacksize =
@@ -34,7 +46,7 @@ void test(hpx::threads::thread_stacksize stacksize)
         HPX_TEST_EQ(self_stacksize, stacksize);
         HPX_TEST_NEQ(self_stacksize, hpx::threads::thread_stacksize::current);
 
-        hpx::async(exec_current, [stacksize]() {
+        hpx::async(disable_run_as_child(exec_current), [stacksize]() {
             // This thread should also have the stack size stacksize; it has
             // been inherited size from the parent thread.
             hpx::threads::thread_stacksize const self_stacksize =

--- a/libs/core/timed_execution/tests/unit/minimal_timed_async_executor.cpp
+++ b/libs/core/timed_execution/tests/unit/minimal_timed_async_executor.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2022 Hartmut Kaiser
+//  Copyright (c) 2007-2024 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -39,7 +39,7 @@ void apply_test(hpx::latch& l, hpx::thread::id& id, int passed_through)
 
 ///////////////////////////////////////////////////////////////////////////////
 template <typename Executor>
-void test_timed_apply(Executor& exec)
+void test_timed_apply(Executor&& exec)
 {
     {
         hpx::latch l(2);
@@ -73,7 +73,7 @@ void test_timed_apply(Executor& exec)
 }
 
 template <typename Executor>
-void test_timed_sync(Executor& exec)
+void test_timed_sync(Executor&& exec)
 {
     {
         hpx::parallel::execution::timed_executor<Executor> timed_exec(
@@ -93,7 +93,7 @@ void test_timed_sync(Executor& exec)
 }
 
 template <typename Executor>
-void test_timed_async(Executor& exec)
+void test_timed_async(Executor&& exec)
 {
     {
         hpx::parallel::execution::timed_executor<Executor> timed_exec(
@@ -124,11 +124,11 @@ std::atomic<std::size_t> count_async_at(0);
 template <typename Executor>
 void test_timed_executor(std::array<std::size_t, 6> expected)
 {
-    typedef typename hpx::traits::executor_execution_category<Executor>::type
-        execution_category;
+    using execution_category =
+        typename hpx::traits::executor_execution_category<Executor>::type;
 
-    HPX_TEST((std::is_same<hpx::execution::parallel_execution_tag,
-        execution_category>::value));
+    HPX_TEST((std::is_same_v<hpx::execution::parallel_execution_tag,
+        execution_category>) );
 
     count_sync.store(0);
     count_apply.store(0);
@@ -154,15 +154,20 @@ void test_timed_executor(std::array<std::size_t, 6> expected)
 ///////////////////////////////////////////////////////////////////////////////
 struct test_async_executor1
 {
-    typedef hpx::execution::parallel_execution_tag execution_category;
+    using execution_category = hpx::execution::parallel_execution_tag;
 
     template <typename F, typename... Ts>
     friend decltype(auto) tag_invoke(hpx::parallel::execution::async_execute_t,
         test_async_executor1 const&, F&& f, Ts&&... ts)
     {
         ++count_async;
-        return hpx::async(
-            hpx::launch::async, std::forward<F>(f), std::forward<Ts>(ts)...);
+
+        auto policy = hpx::launch::async;
+        auto hint = policy.hint();
+        hint.runs_as_child_mode(hpx::threads::thread_execution_hint::none);
+        policy.set_hint(hint);
+
+        return hpx::async(policy, std::forward<F>(f), std::forward<Ts>(ts)...);
     }
 };
 
@@ -175,9 +180,14 @@ struct test_timed_async_executor1 : test_async_executor1
         hpx::chrono::steady_time_point const& abs_time, F&& f, Ts&&... ts)
     {
         ++count_async_at;
+
+        auto policy = hpx::launch::async;
+        auto hint = policy.hint();
+        hint.runs_as_child_mode(hpx::threads::thread_execution_hint::none);
+        policy.set_hint(hint);
+
         hpx::this_thread::sleep_until(abs_time);
-        return hpx::async(
-            hpx::launch::async, std::forward<F>(f), std::forward<Ts>(ts)...);
+        return hpx::async(policy, std::forward<F>(f), std::forward<Ts>(ts)...);
     }
 };
 
@@ -200,8 +210,13 @@ struct test_timed_async_executor2 : test_async_executor1
         test_timed_async_executor2 const&, F&& f, Ts&&... ts)
     {
         ++count_sync;
-        return hpx::async(
-            hpx::launch::async, std::forward<F>(f), std::forward<Ts>(ts)...)
+
+        auto policy = hpx::launch::async;
+        auto hint = policy.hint();
+        hint.runs_as_child_mode(hpx::threads::thread_execution_hint::none);
+        policy.set_hint(hint);
+
+        return hpx::async(policy, std::forward<F>(f), std::forward<Ts>(ts)...)
             .get();
     }
 };
@@ -216,8 +231,13 @@ struct test_timed_async_executor3 : test_timed_async_executor2
     {
         ++count_sync_at;
         hpx::this_thread::sleep_until(abs_time);
-        return hpx::async(
-            hpx::launch::async, std::forward<F>(f), std::forward<Ts>(ts)...)
+
+        auto policy = hpx::launch::async;
+        auto hint = policy.hint();
+        hint.runs_as_child_mode(hpx::threads::thread_execution_hint::none);
+        policy.set_hint(hint);
+
+        return hpx::async(policy, std::forward<F>(f), std::forward<Ts>(ts)...)
             .get();
     }
 };
@@ -285,7 +305,7 @@ int hpx_main()
 
 int main(int argc, char* argv[])
 {
-    // By default this test should run on all available cores
+    // By default, this test should run on all available cores
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX

--- a/libs/full/performance_counters/include/hpx/performance_counters/counter_interface.hpp
+++ b/libs/full/performance_counters/include/hpx/performance_counters/counter_interface.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2021 Hartmut Kaiser
+//  Copyright (c) 2021-2024 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -16,10 +16,10 @@ namespace hpx { namespace performance_counters {
 
     ///////////////////////////////////////////////////////////////////////////
     HPX_EXPORT hpx::future<id_type> create_performance_counter_async(
-        id_type target_id, counter_info const& info);
+        id_type const& target_id, counter_info const& info);
 
-    inline id_type create_performance_counter(
-        id_type target_id, counter_info const& info, error_code& ec = throws)
+    inline id_type create_performance_counter(id_type const& target_id,
+        counter_info const& info, error_code& ec = throws)
     {
         return create_performance_counter_async(target_id, info).get(ec);
     }

--- a/libs/full/performance_counters/include/hpx/performance_counters/detail/counter_interface_functions.hpp
+++ b/libs/full/performance_counters/include/hpx/performance_counters/detail/counter_interface_functions.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2021 Hartmut Kaiser
+//  Copyright (c) 2021-2024 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -11,9 +11,9 @@
 #include <hpx/naming_base/id_type.hpp>
 #include <hpx/performance_counters/counters.hpp>
 
-namespace hpx { namespace performance_counters { namespace detail {
+namespace hpx::performance_counters::detail {
 
     ///////////////////////////////////////////////////////////////////////////
     extern HPX_EXPORT hpx::future<id_type> (*create_performance_counter_async)(
-        id_type target_id, counter_info const& info);
-}}}    // namespace hpx::performance_counters::detail
+        id_type const& target_id, counter_info const& info);
+}    // namespace hpx::performance_counters::detail

--- a/libs/full/performance_counters/src/counter_interface.cpp
+++ b/libs/full/performance_counters/src/counter_interface.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2021 Hartmut Kaiser
+//  Copyright (c) 2021-2024 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -11,12 +11,12 @@
 #include <hpx/performance_counters/counters.hpp>
 #include <hpx/performance_counters/detail/counter_interface_functions.hpp>
 
-namespace hpx { namespace performance_counters {
+namespace hpx::performance_counters {
 
     ///////////////////////////////////////////////////////////////////////////
     hpx::future<id_type> create_performance_counter_async(
-        id_type target_id, counter_info const& info)
+        id_type const& target_id, counter_info const& info)
     {
         return detail::create_performance_counter_async(target_id, info);
     }
-}}    // namespace hpx::performance_counters
+}    // namespace hpx::performance_counters

--- a/libs/full/performance_counters/src/counters.cpp
+++ b/libs/full/performance_counters/src/counters.cpp
@@ -1199,7 +1199,7 @@ namespace hpx::performance_counters {
                 if (ec)
                     return {};
 
-                // Take target locality from base counter if if this is an
+                // Take target locality from base counter if this is an
                 // aggregating counter (the instance name is a base counter).
                 if (p.parentinstance_is_basename_)
                 {

--- a/libs/full/performance_counters/src/detail/counter_interface_functions.cpp
+++ b/libs/full/performance_counters/src/detail/counter_interface_functions.cpp
@@ -1,17 +1,16 @@
-//  Copyright (c) 2021 Hartmut Kaiser
+//  Copyright (c) 2021-2024 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include <hpx/config.hpp>
 #include <hpx/futures/future.hpp>
 #include <hpx/naming_base/id_type.hpp>
 #include <hpx/performance_counters/counters.hpp>
 #include <hpx/performance_counters/detail/counter_interface_functions.hpp>
 
-namespace hpx { namespace performance_counters { namespace detail {
+namespace hpx::performance_counters::detail {
 
     hpx::future<id_type> (*create_performance_counter_async)(
-        id_type target_id, counter_info const& info) = nullptr;
-}}}    // namespace hpx::performance_counters::detail
+        id_type const& target_id, counter_info const& info) = nullptr;
+}    // namespace hpx::performance_counters::detail

--- a/libs/full/runtime_distributed/include/hpx/runtime_distributed/stubs/runtime_support.hpp
+++ b/libs/full/runtime_distributed/include/hpx/runtime_distributed/stubs/runtime_support.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2021 Hartmut Kaiser
+//  Copyright (c) 2007-2024 Hartmut Kaiser
 //  Copyright (c)      2011 Bryce Lelbach
 //
 //  SPDX-License-Identifier: BSL-1.0
@@ -16,7 +16,6 @@
 #include <hpx/naming_base/id_type.hpp>
 #include <hpx/runtime_distributed/server/runtime_support.hpp>
 #include <hpx/serialization/vector.hpp>
-#include <hpx/type_support/decay.hpp>
 
 #include <cstddef>
 #include <cstdint>
@@ -25,7 +24,7 @@
 #include <utility>
 #include <vector>
 
-namespace hpx { namespace components { namespace stubs {
+namespace hpx::components::stubs {
 
     ///////////////////////////////////////////////////////////////////////////
     // The \a runtime_support class is the client side representation of a
@@ -47,12 +46,10 @@ namespace hpx { namespace components { namespace stubs {
                     "stubs::runtime_support::create_component_async",
                     "The id passed as the first argument is not representing"
                     " a locality");
-                return hpx::make_ready_future(hpx::invalid_id);
             }
 
-            typedef server::create_component_action<Component,
-                typename std::decay<Ts>::type...>
-                action_type;
+            using action_type =
+                server::create_component_action<Component, std::decay_t<Ts>...>;
             return hpx::async<action_type>(gid, HPX_FORWARD(Ts, vs)...);
         }
 
@@ -75,9 +72,8 @@ namespace hpx { namespace components { namespace stubs {
         bulk_create_component_colocated_async(
             hpx::id_type const& gid, std::size_t count, Ts&&... vs)
         {
-            typedef server::bulk_create_component_action<Component,
-                typename std::decay<Ts>::type...>
-                action_type;
+            using action_type = server::bulk_create_component_action<Component,
+                std::decay_t<Ts>...>;
 
             return hpx::detail::async_colocated<action_type>(
                 gid, count, HPX_FORWARD(Ts, vs)...);
@@ -108,12 +104,10 @@ namespace hpx { namespace components { namespace stubs {
                     "stubs::runtime_support::bulk_create_component_async",
                     "The id passed as the first argument is not representing"
                     " a locality");
-                return hpx::make_ready_future(std::vector<hpx::id_type>());
             }
 
-            typedef server::bulk_create_component_action<Component,
-                typename std::decay<Ts>::type...>
-                action_type;
+            using action_type = server::bulk_create_component_action<Component,
+                std::decay_t<Ts>...>;
             return hpx::async<action_type>(gid, count, HPX_FORWARD(Ts, vs)...);
         }
 
@@ -136,9 +130,8 @@ namespace hpx { namespace components { namespace stubs {
         static hpx::future<hpx::id_type> create_component_colocated_async(
             hpx::id_type const& gid, Ts&&... vs)
         {
-            typedef server::create_component_action<Component,
-                typename std::decay<Ts>::type...>
-                action_type;
+            using action_type =
+                server::create_component_action<Component, std::decay_t<Ts>...>;
             return hpx::detail::async_colocated<action_type>(
                 gid, HPX_FORWARD(Ts, vs)...);
         }
@@ -167,11 +160,9 @@ namespace hpx { namespace components { namespace stubs {
                     "stubs::runtime_support::copy_create_component_async",
                     "The id passed as the first argument is not representing"
                     " a locality");
-                return hpx::make_ready_future(hpx::invalid_id);
             }
 
-            typedef typename server::copy_create_component_action<Component>
-                action_type;
+            using action_type = server::copy_create_component_action<Component>;
             return hpx::async<action_type>(gid, p, local_op);
         }
 
@@ -198,11 +189,10 @@ namespace hpx { namespace components { namespace stubs {
                     "stubs::runtime_support::migrate_component_async",
                     "The id passed as the first argument is not representing"
                     " a locality");
-                return hpx::make_ready_future(hpx::invalid_id);
             }
 
-            typedef typename server::migrate_component_here_action<Component>
-                action_type;
+            using action_type =
+                server::migrate_component_here_action<Component>;
             return hpx::async<action_type>(target_locality, p, to_migrate);
         }
 
@@ -211,8 +201,8 @@ namespace hpx { namespace components { namespace stubs {
             DistPolicy const& policy, std::shared_ptr<Component> const& p,
             hpx::id_type const& to_migrate)
         {
-            typedef typename server::migrate_component_here_action<Component>
-                action_type;
+            using action_type =
+                server::migrate_component_here_action<Component>;
             return hpx::async<action_type>(policy, p, to_migrate);
         }
 
@@ -269,9 +259,10 @@ namespace hpx { namespace components { namespace stubs {
 
         ///////////////////////////////////////////////////////////////////////
         static hpx::future<hpx::id_type> create_performance_counter_async(
-            hpx::id_type targetgid,
+            hpx::id_type const& targetgid,
             performance_counters::counter_info const& info);
-        static hpx::id_type create_performance_counter(hpx::id_type targetgid,
+        static hpx::id_type create_performance_counter(
+            hpx::id_type const& targetgid,
             performance_counters::counter_info const& info,
             error_code& ec = throws);
 
@@ -287,4 +278,4 @@ namespace hpx { namespace components { namespace stubs {
             hpx::id_type const& target, naming::gid_type const& gid,
             parcelset::endpoints_type const& endpoints);
     };
-}}}    // namespace hpx::components::stubs
+}    // namespace hpx::components::stubs

--- a/libs/full/runtime_distributed/src/runtime_support.cpp
+++ b/libs/full/runtime_distributed/src/runtime_support.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2021 Hartmut Kaiser
+//  Copyright (c) 2007-2024 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -17,7 +17,7 @@
 HPX_PLUGIN_EXPORT_LIST(HPX_PLUGIN_COMPONENT_PREFIX, factory)
 HPX_REGISTER_REGISTRY_MODULE()
 
-namespace hpx { namespace components { namespace server {
+namespace hpx::components::server {
 
     void runtime_support::add_pre_startup_function(startup_function_type f)
     {
@@ -54,9 +54,9 @@ namespace hpx { namespace components { namespace server {
             shutdown_functions_.push_back(HPX_MOVE(f));
         }
     }
-}}}    // namespace hpx::components::server
+}    // namespace hpx::components::server
 
-namespace hpx { namespace agas { namespace detail { namespace impl {
+namespace hpx::agas::detail::impl {
 
     /// \brief Invoke an asynchronous garbage collection step on the given target
     ///        locality.
@@ -90,9 +90,9 @@ namespace hpx { namespace agas { namespace detail { namespace impl {
             ec = make_error_code(e.get_error(), e.what());
         }
     }
-}}}}    // namespace hpx::agas::detail::impl
+}    // namespace hpx::agas::detail::impl
 
-namespace hpx { namespace agas {
+namespace hpx::agas {
 
     // initialize AGAS interface function pointers in components_base module
     struct HPX_EXPORT runtime_components_init_interface_functions
@@ -111,9 +111,9 @@ namespace hpx { namespace agas {
             runtime_components_init_;
         return runtime_components_init_;
     }
-}}    // namespace hpx::agas
+}    // namespace hpx::agas
 
-namespace hpx { namespace components {
+namespace hpx::components {
 
     // some compilers try to invoke this function, even if it's actually not
     // needed
@@ -140,4 +140,4 @@ namespace hpx { namespace components {
         static counter_interface_functions counter_init_;
         return counter_init_;
     }
-}}    // namespace hpx::components
+}    // namespace hpx::components

--- a/libs/full/runtime_distributed/src/stubs/runtime_support_stubs.cpp
+++ b/libs/full/runtime_distributed/src/stubs/runtime_support_stubs.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2016 Hartmut Kaiser
+//  Copyright (c) 2007-2024 Hartmut Kaiser
 //  Copyright (c)      2011 Bryce Lelbach
 //
 //  SPDX-License-Identifier: BSL-1.0
@@ -19,24 +19,32 @@
 #include <hpx/runtime_distributed/applier.hpp>
 #include <hpx/runtime_distributed/stubs/runtime_support.hpp>
 #include <hpx/runtime_local/runtime_local.hpp>
-#include <hpx/type_support/unused.hpp>
 
 #include <cstddef>
 #include <cstdint>
 #include <utility>
-#include <vector>
 
-namespace hpx { namespace components { namespace stubs {
+namespace hpx::components::stubs {
+
+    template <typename Policy>
+    auto disable_run_as_child(Policy&& p)
+    {
+        auto policy = p;
+        auto hint = policy.get_hint();
+        hint.runs_as_child_mode(hpx::threads::thread_execution_hint::none);
+        policy.set_hint(hint);
+        return policy;
+    }
 
     hpx::future<int> runtime_support::load_components_async(
-        hpx::id_type const& gid)
+        [[maybe_unused]] hpx::id_type const& gid)
     {
 #if !defined(HPX_COMPUTE_DEVICE_CODE)
-        typedef server::runtime_support::load_components_action action_type;
-        return hpx::async<action_type>(gid);
+        using action_type = server::runtime_support::load_components_action;
+        return hpx::async<action_type>(
+            disable_run_as_child(hpx::launch::async), gid);
 #else
         HPX_ASSERT(false);
-        HPX_UNUSED(gid);
         return hpx::make_ready_future(0);
 #endif
     }
@@ -47,16 +55,17 @@ namespace hpx { namespace components { namespace stubs {
     }
 
     hpx::future<void> runtime_support::call_startup_functions_async(
-        hpx::id_type const& gid, bool pre_startup)
+        [[maybe_unused]] hpx::id_type const& gid,
+        [[maybe_unused]] bool pre_startup)
     {
 #if !defined(HPX_COMPUTE_DEVICE_CODE)
-        typedef server::runtime_support::call_startup_functions_action
-            action_type;
-        return hpx::async<action_type>(gid, pre_startup);
+        using action_type =
+            server::runtime_support::call_startup_functions_action;
+
+        return hpx::async<action_type>(
+            disable_run_as_child(hpx::launch::async), gid, pre_startup);
 #else
         HPX_ASSERT(false);
-        HPX_UNUSED(gid);
-        HPX_UNUSED(pre_startup);
         return ::hpx::make_ready_future();
 #endif
     }
@@ -69,13 +78,14 @@ namespace hpx { namespace components { namespace stubs {
 
     /// \brief Shutdown the given runtime system
     hpx::future<void> runtime_support::shutdown_async(
-        hpx::id_type const& targetgid, double timeout)
+        [[maybe_unused]] hpx::id_type const& targetgid,
+        [[maybe_unused]] double timeout)
     {
 #if !defined(HPX_COMPUTE_DEVICE_CODE)
         // Create a promise directly and execute the required action.
         // This action has implemented special response handling as the
         // back-parcel is sent explicitly (and synchronously).
-        typedef server::runtime_support::shutdown_action action_type;
+        using action_type = server::runtime_support::shutdown_action;
 
         hpx::distributed::promise<void> value;
         auto f = value.get_future();
@@ -88,8 +98,6 @@ namespace hpx { namespace components { namespace stubs {
         return f;
 #else
         HPX_ASSERT(false);
-        HPX_UNUSED(targetgid);
-        HPX_UNUSED(timeout);
         return ::hpx::make_ready_future();
 #endif
     }
@@ -104,19 +112,18 @@ namespace hpx { namespace components { namespace stubs {
 
     /// \brief Shutdown the runtime systems of all localities
     void runtime_support::shutdown_all(
-        hpx::id_type const& targetgid, double timeout)
+        [[maybe_unused]] hpx::id_type const& targetgid,
+        [[maybe_unused]] double timeout)
     {
 #if !defined(HPX_COMPUTE_DEVICE_CODE)
         hpx::post<server::runtime_support::shutdown_all_action>(
             targetgid, timeout);
 #else
         HPX_ASSERT(false);
-        HPX_UNUSED(targetgid);
-        HPX_UNUSED(timeout);
 #endif
     }
 
-    void runtime_support::shutdown_all(double timeout)
+    void runtime_support::shutdown_all([[maybe_unused]] double timeout)
     {
 #if !defined(HPX_COMPUTE_DEVICE_CODE)
         hpx::post<server::runtime_support::shutdown_all_action>(
@@ -126,7 +133,6 @@ namespace hpx { namespace components { namespace stubs {
             timeout);
 #else
         HPX_ASSERT(false);
-        HPX_UNUSED(timeout);
 #endif
     }
 
@@ -134,13 +140,13 @@ namespace hpx { namespace components { namespace stubs {
     /// \brief Retrieve configuration information
     /// \brief Terminate the given runtime system
     hpx::future<void> runtime_support::terminate_async(
-        hpx::id_type const& targetgid)
+        [[maybe_unused]] hpx::id_type const& targetgid)
     {
 #if !defined(HPX_COMPUTE_DEVICE_CODE)
         // Create a future directly and execute the required action.
         // This action has implemented special response handling as the
         // back-parcel is sent explicitly (and synchronously).
-        typedef server::runtime_support::terminate_action action_type;
+        using action_type = server::runtime_support::terminate_action;
 
         hpx::distributed::promise<void> value;
         auto f = value.get_future();
@@ -149,7 +155,6 @@ namespace hpx { namespace components { namespace stubs {
         return f;
 #else
         HPX_ASSERT(false);
-        HPX_UNUSED(targetgid);
         return ::hpx::make_ready_future();
 #endif
     }
@@ -162,13 +167,13 @@ namespace hpx { namespace components { namespace stubs {
     }
 
     /// \brief Terminate the runtime systems of all localities
-    void runtime_support::terminate_all(hpx::id_type const& targetgid)
+    void runtime_support::terminate_all(
+        [[maybe_unused]] hpx::id_type const& targetgid)
     {
 #if !defined(HPX_COMPUTE_DEVICE_CODE)
         hpx::post<server::runtime_support::terminate_all_action>(targetgid);
 #else
         HPX_ASSERT(false);
-        HPX_UNUSED(targetgid);
 #endif
     }
 
@@ -185,44 +190,46 @@ namespace hpx { namespace components { namespace stubs {
 
     ///////////////////////////////////////////////////////////////////////
     void runtime_support::garbage_collect_non_blocking(
-        hpx::id_type const& targetgid)
+        [[maybe_unused]] hpx::id_type const& targetgid)
     {
 #if !defined(HPX_COMPUTE_DEVICE_CODE)
-        typedef server::runtime_support::garbage_collect_action action_type;
+        using action_type = server::runtime_support::garbage_collect_action;
         hpx::post<action_type>(targetgid);
 #else
         HPX_ASSERT(false);
-        HPX_UNUSED(targetgid);
 #endif
     }
 
     hpx::future<void> runtime_support::garbage_collect_async(
-        hpx::id_type const& targetgid)
+        [[maybe_unused]] hpx::id_type const& targetgid)
     {
 #if !defined(HPX_COMPUTE_DEVICE_CODE)
-        typedef server::runtime_support::garbage_collect_action action_type;
-        return hpx::async<action_type>(targetgid);
+        using action_type = server::runtime_support::garbage_collect_action;
+        return hpx::async<action_type>(
+            disable_run_as_child(hpx::launch::async), targetgid);
 #else
         HPX_ASSERT(false);
-        HPX_UNUSED(targetgid);
         return ::hpx::make_ready_future();
 #endif
     }
 
-    void runtime_support::garbage_collect(hpx::id_type const& targetgid)
+    void runtime_support::garbage_collect(
+        [[maybe_unused]] hpx::id_type const& targetgid)
     {
 #if !defined(HPX_COMPUTE_DEVICE_CODE)
-        typedef server::runtime_support::garbage_collect_action action_type;
-        hpx::async<action_type>(targetgid).get();
+        using action_type = server::runtime_support::garbage_collect_action;
+        hpx::async<action_type>(
+            disable_run_as_child(hpx::launch::async), targetgid)
+            .get();
 #else
         HPX_ASSERT(false);
-        HPX_UNUSED(targetgid);
 #endif
     }
 
     ///////////////////////////////////////////////////////////////////////
     hpx::future<hpx::id_type> runtime_support::create_performance_counter_async(
-        hpx::id_type targetgid, performance_counters::counter_info const& info)
+        [[maybe_unused]] hpx::id_type const& targetgid,
+        [[maybe_unused]] performance_counters::counter_info const& info)
     {
 #if !defined(HPX_COMPUTE_DEVICE_CODE)
         if (!naming::is_locality(targetgid))
@@ -231,23 +238,21 @@ namespace hpx { namespace components { namespace stubs {
                 "stubs::runtime_support::create_performance_counter_async",
                 "The id passed as the first argument is not representing"
                 " a locality");
-            return make_ready_future(hpx::invalid_id);
         }
 
-        typedef server::runtime_support::create_performance_counter_action
-            action_type;
-        return hpx::async<action_type>(targetgid, info);
+        using action_type =
+            server::runtime_support::create_performance_counter_action;
+        return hpx::async<action_type>(
+            disable_run_as_child(hpx::launch::async), targetgid, info);
 #else
         HPX_ASSERT(false);
-        HPX_UNUSED(targetgid);
-        HPX_UNUSED(info);
         return ::hpx::make_ready_future(hpx::invalid_id);
 #endif
     }
 
     hpx::id_type runtime_support::create_performance_counter(
-        hpx::id_type targetgid, performance_counters::counter_info const& info,
-        error_code& ec)
+        hpx::id_type const& targetgid,
+        performance_counters::counter_info const& info, error_code& ec)
     {
         return create_performance_counter_async(targetgid, info).get(ec);
     }
@@ -255,17 +260,17 @@ namespace hpx { namespace components { namespace stubs {
     ///////////////////////////////////////////////////////////////////////
     /// \brief Retrieve configuration information
     hpx::future<util::section> runtime_support::get_config_async(
-        hpx::id_type const& targetgid)
+        [[maybe_unused]] hpx::id_type const& targetgid)
     {
 #if !defined(HPX_COMPUTE_DEVICE_CODE)
         // Create a future, execute the required action,
         // we simply return the initialized future, the caller needs
         // to call get() on the return value to obtain the result
-        typedef server::runtime_support::get_config_action action_type;
-        return hpx::async<action_type>(targetgid);
+        using action_type = server::runtime_support::get_config_action;
+        return hpx::async<action_type>(
+            disable_run_as_child(hpx::launch::async), targetgid);
 #else
         HPX_ASSERT(false);
-        HPX_UNUSED(targetgid);
         return ::hpx::make_ready_future(util::section{});
 #endif
     }
@@ -280,18 +285,16 @@ namespace hpx { namespace components { namespace stubs {
 
     ///////////////////////////////////////////////////////////////////////
     void runtime_support::remove_from_connection_cache_async(
-        hpx::id_type const& target, naming::gid_type const& gid,
-        parcelset::endpoints_type const& endpoints)
+        [[maybe_unused]] hpx::id_type const& target,
+        [[maybe_unused]] naming::gid_type const& gid,
+        [[maybe_unused]] parcelset::endpoints_type const& endpoints)
     {
 #if !defined(HPX_COMPUTE_DEVICE_CODE)
-        typedef server::runtime_support::remove_from_connection_cache_action
-            action_type;
+        using action_type =
+            server::runtime_support::remove_from_connection_cache_action;
         hpx::post<action_type>(target, gid, endpoints);
 #else
         HPX_ASSERT(false);
-        HPX_UNUSED(target);
-        HPX_UNUSED(gid);
-        HPX_UNUSED(endpoints);
 #endif
     }
-}}}    // namespace hpx::components::stubs
+}    // namespace hpx::components::stubs

--- a/tests/regressions/threads/main_thread_exit_callbacks.cpp
+++ b/tests/regressions/threads/main_thread_exit_callbacks.cpp
@@ -1,4 +1,5 @@
 //  Copyright (c) 2023 Panos Syskakis
+//  Copyright (c) 2024 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -18,7 +19,7 @@ int hpx_main()
 {
     hpx::threads::thread_id_type id = hpx::threads::get_self_id();
     hpx::threads::add_thread_exit_callback(id, [id]() {
-        hpx::threads::thread_id_type id1 = hpx::threads::get_self_id();
+        hpx::threads::thread_id_type const id1 = hpx::threads::get_self_id();
         HPX_TEST_EQ(id1, id);
 
         callback_called = true;


### PR DESCRIPTION
// Re-opening of PR #6413 authored by @hkaiser 

-flyby: deprecate get_outer_self_id
-flyby: ignoring locks during termination detection

