### PR TITLE
improve(lci pp): more options to control the LCI parcelport

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1166,7 +1166,7 @@ if(HPX_WITH_NETWORKING)
     ADVANCED
   )
   hpx_option(
-    HPX_WITH_LCI_TAG STRING "LCI repository tag or branch" "v1.7.6"
+    HPX_WITH_LCI_TAG STRING "LCI repository tag or branch" "v1.7.7"
     CATEGORY "Build Targets"
     ADVANCED
   )

--- a/libs/full/parcelport_lci/CMakeLists.txt
+++ b/libs/full/parcelport_lci/CMakeLists.txt
@@ -1,3 +1,4 @@
+# Copyright (c) 2023-2024 Jiakun Yan
 # Copyright (c) 2019-2021 The STE||AR-Group
 #
 # SPDX-License-Identifier: BSL-1.0
@@ -31,6 +32,7 @@ set(parcelport_lci_headers
     hpx/parcelport_lci/completion_manager/completion_manager_queue.hpp
     hpx/parcelport_lci/completion_manager/completion_manager_sync.hpp
     hpx/parcelport_lci/completion_manager/completion_manager_sync_single.hpp
+    hpx/parcelport_lci/completion_manager/completion_manager_sync_single_nolock.hpp
 )
 
 # cmake-format: off
@@ -50,6 +52,10 @@ set(parcelport_lci_sources
     sendrecv/sender_connection_sendrecv.cpp
     sendrecv/receiver_sendrecv.cpp
     sendrecv/receiver_connection_sendrecv.cpp
+    completion_manager/completion_manager_queue.cpp
+    completion_manager/completion_manager_sync.cpp
+    completion_manager/completion_manager_sync_single.cpp
+    completion_manager/completion_manager_sync_single_nolock.cpp
 )
 
 include(HPX_SetupLCI)

--- a/libs/full/parcelport_lci/include/hpx/parcelport_lci/backlog_queue.hpp
+++ b/libs/full/parcelport_lci/include/hpx/parcelport_lci/backlog_queue.hpp
@@ -1,3 +1,4 @@
+//  Copyright (c) 2023-2024 Jiakun Yan
 //  Copyright (c) 2014-2023 Thomas Heller
 //
 //  SPDX-License-Identifier: BSL-1.0

--- a/libs/full/parcelport_lci/include/hpx/parcelport_lci/completion_manager/completion_manager_sync_single.hpp
+++ b/libs/full/parcelport_lci/include/hpx/parcelport_lci/completion_manager/completion_manager_sync_single.hpp
@@ -1,3 +1,4 @@
+//  Copyright (c) 2023-2024 Jiakun Yan
 //  Copyright (c) 2014-2023 Thomas Heller
 //
 //  SPDX-License-Identifier: BSL-1.0
@@ -15,7 +16,8 @@
 namespace hpx::parcelset::policies::lci {
     struct completion_manager_sync_single : public completion_manager_base
     {
-        completion_manager_sync_single()
+        completion_manager_sync_single(parcelport* pp)
+          : completion_manager_base(pp)
         {
             LCI_sync_create(LCI_UR_DEVICE, 1, &sync);
         }
@@ -36,20 +38,7 @@ namespace hpx::parcelset::policies::lci {
             lock.unlock();
         }
 
-        LCI_request_t poll()
-        {
-            LCI_request_t request;
-            request.flag = LCI_ERR_RETRY;
-
-            bool succeed = lock.try_lock();
-            if (succeed)
-            {
-                LCI_error_t ret = LCI_sync_test(sync, &request);
-                if (ret == LCI_ERR_RETRY)
-                    lock.unlock();
-            }
-            return request;
-        }
+        LCI_request_t poll();
 
     private:
         hpx::spinlock lock;

--- a/libs/full/parcelport_lci/include/hpx/parcelport_lci/completion_manager/completion_manager_sync_single_nolock.hpp
+++ b/libs/full/parcelport_lci/include/hpx/parcelport_lci/completion_manager/completion_manager_sync_single_nolock.hpp
@@ -11,29 +11,26 @@
 
 #if defined(HPX_HAVE_NETWORKING) && defined(HPX_HAVE_PARCELPORT_LCI)
 
-#include <hpx/parcelport_lci/config.hpp>
 #include <hpx/parcelport_lci/completion_manager_base.hpp>
 
 namespace hpx::parcelset::policies::lci {
-    struct completion_manager_queue : public completion_manager_base
+    struct completion_manager_sync_single_nolock
+      : public completion_manager_base
     {
-        completion_manager_queue(parcelport* pp)
+        completion_manager_sync_single_nolock(parcelport* pp)
           : completion_manager_base(pp)
         {
-            // LCI_queue_create(LCI_UR_DEVICE, &queue);
-            // Hack for now
-            LCI_queue_createx(LCI_UR_DEVICE,
-                LCI_SERVER_NUM_PKTS * (size_t) config_t::ndevices, &queue);
+            LCI_sync_create(LCI_UR_DEVICE, 1, &sync);
         }
 
-        ~completion_manager_queue()
+        ~completion_manager_sync_single_nolock()
         {
-            LCI_queue_free(&queue);
+            LCI_sync_free(&sync);
         }
 
         LCI_comp_t alloc_completion()
         {
-            return queue;
+            return sync;
         }
 
         void enqueue_completion(LCI_comp_t comp)
@@ -43,13 +40,8 @@ namespace hpx::parcelset::policies::lci {
 
         LCI_request_t poll();
 
-        LCI_comp_t get_completion_object()
-        {
-            return queue;
-        }
-
     private:
-        LCI_comp_t queue;
+        LCI_comp_t sync;
     };
 }    // namespace hpx::parcelset::policies::lci
 

--- a/libs/full/parcelport_lci/include/hpx/parcelport_lci/completion_manager_base.hpp
+++ b/libs/full/parcelport_lci/include/hpx/parcelport_lci/completion_manager_base.hpp
@@ -1,3 +1,4 @@
+//  Copyright (c) 2023-2024 Jiakun Yan
 //  Copyright (c) 2014-2023 Thomas Heller
 //
 //  SPDX-License-Identifier: BSL-1.0
@@ -13,8 +14,11 @@
 #include <hpx/modules/lci_base.hpp>
 
 namespace hpx::parcelset::policies::lci {
+    class HPX_EXPORT parcelport;
     struct completion_manager_base
     {
+        completion_manager_base(parcelport* pp) noexcept
+          : pp_(pp){};
         virtual ~completion_manager_base() {}
         virtual LCI_comp_t alloc_completion() = 0;
         virtual void enqueue_completion(LCI_comp_t comp) = 0;
@@ -23,6 +27,7 @@ namespace hpx::parcelset::policies::lci {
         {
             return nullptr;
         }
+        parcelport* pp_;
     };
 }    // namespace hpx::parcelset::policies::lci
 

--- a/libs/full/parcelport_lci/include/hpx/parcelport_lci/config.hpp
+++ b/libs/full/parcelport_lci/include/hpx/parcelport_lci/config.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2023 Jiakun Yan
+//  Copyright (c) 2023-2024 Jiakun Yan
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -29,8 +29,19 @@ namespace hpx::parcelset::policies::lci {
             putsendrecv,
         };
         static protocol_t protocol;
-        // which completion mechanism to use
-        static LCI_comp_type_t completion_type;
+        // Whether sending header requires completion
+        static bool enable_sendmc;
+        // which completion mechanism to use for header messages
+        enum class comp_type_t
+        {
+            queue,
+            sync,
+            sync_single,
+            sync_single_nolock,
+        };
+        static comp_type_t completion_type_header;
+        // which completion mechanism to use for followup messages
+        static comp_type_t completion_type_followup;
         // how to run LCI_progress
         enum class progress_type_t
         {
@@ -38,6 +49,7 @@ namespace hpx::parcelset::policies::lci {
             pthread,           // Normal progress pthread
             worker,            // HPX worker thread
             pthread_worker,    // Normal progress pthread + worker thread
+            poll,              // progress when polling completion
         };
         static progress_type_t progress_type;
         // How many progress threads to create
@@ -57,6 +69,10 @@ namespace hpx::parcelset::policies::lci {
         static int send_nb_max_retry;
         // The max retry count of mbuffer_alloc before yield.
         static int mbuffer_alloc_max_retry;
+        // The max count of background_work to invoke in a row
+        static int bg_work_max_count;
+        // Whether to do background work when sending
+        static bool bg_work_when_send;
 
         static void init_config(util::runtime_configuration const& rtcfg);
     };

--- a/libs/full/parcelport_lci/include/hpx/parcelport_lci/header.hpp
+++ b/libs/full/parcelport_lci/include/hpx/parcelport_lci/header.hpp
@@ -1,3 +1,4 @@
+//  Copyright (c) 2023-2024 Jiakun Yan
 //  Copyright (c) 2013-2014 Hartmut Kaiser
 //  Copyright (c) 2013-2015 Thomas Heller
 //

--- a/libs/full/parcelport_lci/include/hpx/parcelport_lci/helper.hpp
+++ b/libs/full/parcelport_lci/include/hpx/parcelport_lci/helper.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2023 Jiakun Yan
+//  Copyright (c) 2023-2024 Jiakun Yan
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -20,7 +20,9 @@ namespace hpx::parcelset::policies::lci {
         {
             k = 0;
             if (hpx::threads::get_self_id() != hpx::threads::invalid_thread_id)
+            {
                 hpx::this_thread::yield();
+            }
         }
     }
 }    // namespace hpx::parcelset::policies::lci

--- a/libs/full/parcelport_lci/include/hpx/parcelport_lci/locality.hpp
+++ b/libs/full/parcelport_lci/include/hpx/parcelport_lci/locality.hpp
@@ -1,3 +1,4 @@
+//  Copyright (c) 2023-2024 Jiakun Yan
 //  Copyright (c) 2007-2021 Hartmut Kaiser
 //  Copyright (c) 2013-2014 Thomas Heller
 //

--- a/libs/full/parcelport_lci/include/hpx/parcelport_lci/parcelport_lci.hpp
+++ b/libs/full/parcelport_lci/include/hpx/parcelport_lci/parcelport_lci.hpp
@@ -1,3 +1,4 @@
+//  Copyright (c) 2023-2024 Jiakun Yan
 //  Copyright (c) 2014-2023 Thomas Heller
 //
 //  SPDX-License-Identifier: BSL-1.0
@@ -261,7 +262,8 @@ namespace hpx::traits {
                 "backlog_queue = 0\n"
                 "prg_thread_num = 1\n"
                 "protocol = putsendrecv\n"
-                "comp_type = queue\n"
+                "comp_type_header = queue\n"
+                "comp_type_followup = queue\n"
                 "progress_type = rp\n"
                 "prepost_recv_num = 1\n"
                 "reg_mem = 1\n"
@@ -269,7 +271,11 @@ namespace hpx::traits {
                 "ncomps = 1\n"
                 "enable_in_buffer_assembly = 1\n"
                 "send_nb_max_retry = 32\n"
-                "mbuffer_alloc_max_retry = 32\n";
+                "mbuffer_alloc_max_retry = 32\n"
+                "bg_work_max_count = 32\n"
+                "bg_work_when_send = 0\n"
+                "enable_sendmc = 0\n"
+                "comp_type = deprecated\n";
         }
     };
 }    // namespace hpx::traits

--- a/libs/full/parcelport_lci/include/hpx/parcelport_lci/putva/receiver_putva.hpp
+++ b/libs/full/parcelport_lci/include/hpx/parcelport_lci/putva/receiver_putva.hpp
@@ -1,3 +1,4 @@
+//  Copyright (c) 2023-2024 Jiakun Yan
 //  Copyright (c) 2007-2023 Hartmut Kaiser
 //  Copyright (c) 2014-2015 Thomas Heller
 //

--- a/libs/full/parcelport_lci/include/hpx/parcelport_lci/putva/sender_connection_putva.hpp
+++ b/libs/full/parcelport_lci/include/hpx/parcelport_lci/putva/sender_connection_putva.hpp
@@ -1,3 +1,4 @@
+//  Copyright (c) 2023-2024 Jiakun Yan
 //  Copyright (c) 2014-2015 Thomas Heller
 //
 //  SPDX-License-Identifier: BSL-1.0

--- a/libs/full/parcelport_lci/include/hpx/parcelport_lci/putva/sender_putva.hpp
+++ b/libs/full/parcelport_lci/include/hpx/parcelport_lci/putva/sender_putva.hpp
@@ -1,3 +1,4 @@
+//  Copyright (c) 2023-2024 Jiakun Yan
 //  Copyright (c) 2007-2013 Hartmut Kaiser
 //  Copyright (c) 2014-2015 Thomas Heller
 //

--- a/libs/full/parcelport_lci/include/hpx/parcelport_lci/receiver_base.hpp
+++ b/libs/full/parcelport_lci/include/hpx/parcelport_lci/receiver_base.hpp
@@ -1,4 +1,4 @@
-
+//  Copyright (c) 2023-2024 Jiakun Yan
 //  Copyright (c) 2007-2013 Hartmut Kaiser
 //  Copyright (c) 2014-2015 Thomas Heller
 //

--- a/libs/full/parcelport_lci/include/hpx/parcelport_lci/sender_base.hpp
+++ b/libs/full/parcelport_lci/include/hpx/parcelport_lci/sender_base.hpp
@@ -1,3 +1,4 @@
+//  Copyright (c) 2023-2024 Jiakun Yan
 //  Copyright (c) 2007-2013 Hartmut Kaiser
 //  Copyright (c) 2014-2015 Thomas Heller
 //

--- a/libs/full/parcelport_lci/include/hpx/parcelport_lci/sender_connection_base.hpp
+++ b/libs/full/parcelport_lci/include/hpx/parcelport_lci/sender_connection_base.hpp
@@ -1,3 +1,4 @@
+//  Copyright (c) 2023-2024 Jiakun Yan
 //  Copyright (c) 2014-2015 Thomas Heller
 //
 //  SPDX-License-Identifier: BSL-1.0
@@ -73,7 +74,7 @@ namespace hpx::parcelset::policies::lci {
             postprocess_handler_type&& parcel_postprocess);
         virtual void load(handler_type&& handler,
             postprocess_handler_type&& parcel_postprocess) = 0;
-        return_t send();
+        return_t send(bool in_bg_work);
         virtual return_t send_nb() = 0;
         virtual void done() = 0;
         virtual bool tryMerge(

--- a/libs/full/parcelport_lci/include/hpx/parcelport_lci/sendrecv/receiver_connection_sendrecv.hpp
+++ b/libs/full/parcelport_lci/include/hpx/parcelport_lci/sendrecv/receiver_connection_sendrecv.hpp
@@ -1,3 +1,4 @@
+//  Copyright (c) 2023-2024 Jiakun Yan
 //  Copyright (c) 2014-2015 Thomas Heller
 //
 //  SPDX-License-Identifier: BSL-1.0

--- a/libs/full/parcelport_lci/include/hpx/parcelport_lci/sendrecv/receiver_sendrecv.hpp
+++ b/libs/full/parcelport_lci/include/hpx/parcelport_lci/sendrecv/receiver_sendrecv.hpp
@@ -1,4 +1,4 @@
-
+//  Copyright (c) 2023-2024 Jiakun Yan
 //  Copyright (c) 2007-2013 Hartmut Kaiser
 //  Copyright (c) 2014-2015 Thomas Heller
 //

--- a/libs/full/parcelport_lci/include/hpx/parcelport_lci/sendrecv/sender_connection_sendrecv.hpp
+++ b/libs/full/parcelport_lci/include/hpx/parcelport_lci/sendrecv/sender_connection_sendrecv.hpp
@@ -1,3 +1,4 @@
+//  Copyright (c) 2023-2024 Jiakun Yan
 //  Copyright (c) 2014-2015 Thomas Heller
 //
 //  SPDX-License-Identifier: BSL-1.0

--- a/libs/full/parcelport_lci/include/hpx/parcelport_lci/sendrecv/sender_sendrecv.hpp
+++ b/libs/full/parcelport_lci/include/hpx/parcelport_lci/sendrecv/sender_sendrecv.hpp
@@ -1,3 +1,4 @@
+//  Copyright (c) 2023-2024 Jiakun Yan
 //  Copyright (c) 2007-2013 Hartmut Kaiser
 //  Copyright (c) 2014-2015 Thomas Heller
 //

--- a/libs/full/parcelport_lci/src/backlog_queue.cpp
+++ b/libs/full/parcelport_lci/src/backlog_queue.cpp
@@ -1,3 +1,4 @@
+//  Copyright (c) 2023-2024 Jiakun Yan
 //  Copyright (c) 2007-2013 Hartmut Kaiser
 //  Copyright (c) 2014-2015 Thomas Heller
 //  Copyright (c)      2020 Google

--- a/libs/full/parcelport_lci/src/completion_manager/completion_manager_queue.cpp
+++ b/libs/full/parcelport_lci/src/completion_manager/completion_manager_queue.cpp
@@ -1,0 +1,21 @@
+//  Copyright (c) 2024 Jiakun Yan
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/parcelport_lci/completion_manager/completion_manager_queue.hpp>
+#include <hpx/parcelport_lci/parcelport_lci.hpp>
+
+namespace hpx::parcelset::policies::lci {
+    LCI_request_t completion_manager_queue::poll()
+    {
+        LCI_request_t request;
+        request.flag = LCI_ERR_RETRY;
+        LCI_queue_pop(queue, &request);
+        if (request.flag == LCI_ERR_RETRY)
+            if (config_t::progress_type == config_t::progress_type_t::poll)
+                pp_->do_progress_local();
+        return request;
+    }
+}    // namespace hpx::parcelset::policies::lci

--- a/libs/full/parcelport_lci/src/completion_manager/completion_manager_sync.cpp
+++ b/libs/full/parcelport_lci/src/completion_manager/completion_manager_sync.cpp
@@ -1,0 +1,44 @@
+//  Copyright (c) 2024 Jiakun Yan
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/assert.hpp>
+#include <hpx/parcelport_lci/completion_manager/completion_manager_sync.hpp>
+#include <hpx/parcelport_lci/parcelport_lci.hpp>
+
+namespace hpx::parcelset::policies::lci {
+    LCI_request_t completion_manager_sync::poll()
+    {
+        LCI_request_t request;
+        request.flag = LCI_ERR_RETRY;
+
+        LCI_comp_t sync = nullptr;
+        {
+            std::unique_lock l(lock, std::try_to_lock);
+            if (l.owns_lock() && !sync_list.empty())
+            {
+                sync = sync_list.front();
+                sync_list.pop_front();
+            }
+        }
+        if (sync)
+        {
+            LCI_error_t ret = LCI_sync_test(sync, &request);
+            if (ret == LCI_OK)
+            {
+                HPX_ASSERT(request.flag == LCI_OK);
+                LCI_sync_free(&sync);
+            }
+            else
+            {
+                if (config_t::progress_type == config_t::progress_type_t::poll)
+                    pp_->do_progress_local();
+                std::unique_lock l(lock);
+                sync_list.push_back(sync);
+            }
+        }
+        return request;
+    }
+}    // namespace hpx::parcelset::policies::lci

--- a/libs/full/parcelport_lci/src/completion_manager/completion_manager_sync_single.cpp
+++ b/libs/full/parcelport_lci/src/completion_manager/completion_manager_sync_single.cpp
@@ -1,0 +1,29 @@
+//  Copyright (c) 2024 Jiakun Yan
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/parcelport_lci/completion_manager/completion_manager_sync_single.hpp>
+#include <hpx/parcelport_lci/parcelport_lci.hpp>
+
+namespace hpx::parcelset::policies::lci {
+    LCI_request_t completion_manager_sync_single::poll()
+    {
+        LCI_request_t request;
+        request.flag = LCI_ERR_RETRY;
+
+        bool succeed = lock.try_lock();
+        if (succeed)
+        {
+            LCI_error_t ret = LCI_sync_test(sync, &request);
+            if (ret == LCI_ERR_RETRY)
+            {
+                if (config_t::progress_type == config_t::progress_type_t::poll)
+                    pp_->do_progress_local();
+                lock.unlock();
+            }
+        }
+        return request;
+    }
+}    // namespace hpx::parcelset::policies::lci

--- a/libs/full/parcelport_lci/src/completion_manager/completion_manager_sync_single_nolock.cpp
+++ b/libs/full/parcelport_lci/src/completion_manager/completion_manager_sync_single_nolock.cpp
@@ -1,0 +1,22 @@
+//  Copyright (c) 2024 Jiakun Yan
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/parcelport_lci/completion_manager/completion_manager_sync_single_nolock.hpp>
+#include <hpx/parcelport_lci/parcelport_lci.hpp>
+
+namespace hpx::parcelset::policies::lci {
+    LCI_request_t completion_manager_sync_single_nolock::poll()
+    {
+        LCI_request_t request;
+        request.flag = LCI_ERR_RETRY;
+
+        LCI_sync_test(sync, &request);
+        if (request.flag == LCI_ERR_RETRY)
+            if (config_t::progress_type == config_t::progress_type_t::poll)
+                pp_->do_progress_local();
+        return request;
+    }
+}    // namespace hpx::parcelset::policies::lci

--- a/libs/full/parcelport_lci/src/locality.cpp
+++ b/libs/full/parcelport_lci/src/locality.cpp
@@ -1,3 +1,4 @@
+//  Copyright (c) 2023-2024 Jiakun Yan
 //  Copyright (c) 2007-2021 Hartmut Kaiser
 //  Copyright (c) 2013-2014 Thomas Heller
 //

--- a/libs/full/parcelport_lci/src/putva/sender_connection_putva.cpp
+++ b/libs/full/parcelport_lci/src/putva/sender_connection_putva.cpp
@@ -1,3 +1,4 @@
+//  Copyright (c) 2023-2024 Jiakun Yan
 //  Copyright (c) 2007-2013 Hartmut Kaiser
 //  Copyright (c) 2014-2015 Thomas Heller
 //  Copyright (c)      2020 Google

--- a/libs/full/parcelport_lci/src/putva/sender_putva.cpp
+++ b/libs/full/parcelport_lci/src/putva/sender_putva.cpp
@@ -1,3 +1,4 @@
+//  Copyright (c) 2023-2024 Jiakun Yan
 //  Copyright (c) 2007-2013 Hartmut Kaiser
 //  Copyright (c) 2014-2015 Thomas Heller
 //  Copyright (c)      2020 Google

--- a/libs/full/parcelport_lci/src/sender_base.cpp
+++ b/libs/full/parcelport_lci/src/sender_base.cpp
@@ -1,3 +1,4 @@
+//  Copyright (c) 2023-2024 Jiakun Yan
 //  Copyright (c) 2007-2013 Hartmut Kaiser
 //  Copyright (c) 2014-2015 Thomas Heller
 //  Copyright (c)      2020 Google
@@ -41,7 +42,8 @@ namespace hpx::parcelset::policies::lci {
             auto useful_bg_start = util::lci_environment::pcounter_now();
             did_some_work = true;
             auto* sharedPtr_p = (connection_ptr*) request.user_context;
-            sender_connection_base::return_t ret = (*sharedPtr_p)->send();
+            HPX_ASSERT(sharedPtr_p->get());
+            sender_connection_base::return_t ret = (*sharedPtr_p)->send(true);
             if (ret.status == sender_connection_base::return_status_t::done)
             {
                 (*sharedPtr_p)->done();

--- a/libs/full/parcelport_lci/src/sendrecv/receiver_connection_sendrecv.cpp
+++ b/libs/full/parcelport_lci/src/sendrecv/receiver_connection_sendrecv.cpp
@@ -1,3 +1,4 @@
+//  Copyright (c) 2023-2024 Jiakun Yan
 //  Copyright (c) 2007-2013 Hartmut Kaiser
 //  Copyright (c) 2014-2015 Thomas Heller
 //  Copyright (c)      2020 Google

--- a/libs/full/parcelport_lci/src/sendrecv/receiver_sendrecv.cpp
+++ b/libs/full/parcelport_lci/src/sendrecv/receiver_sendrecv.cpp
@@ -1,3 +1,4 @@
+//  Copyright (c) 2023-2024 Jiakun Yan
 //  Copyright (c) 2007-2013 Hartmut Kaiser
 //  Copyright (c) 2014-2015 Thomas Heller
 //  Copyright (c)      2020 Google

--- a/libs/full/parcelport_lci/src/sendrecv/sender_sendrecv.cpp
+++ b/libs/full/parcelport_lci/src/sendrecv/sender_sendrecv.cpp
@@ -1,3 +1,4 @@
+//  Copyright (c) 2023-2024 Jiakun Yan
 //  Copyright (c) 2007-2013 Hartmut Kaiser
 //  Copyright (c) 2014-2015 Thomas Heller
 //  Copyright (c)      2020 Google


### PR DESCRIPTION
Besides updating the default LCI to fetch to v1.7.7, this PR does not change any default behavior of the LCI parcelport but just gives users more control.

The options are mainly for research purposes:

- split the comp_type option into **comp_type_header** and **comp_type_followup**
- add new **progress_type** option: **poll**
- add **enable_sendmc **option
- add **bg_work_max_count**, **bg_work_when_send** for more control of background work invocation
- improve completion_manager_sync to better simulate MPI