### PR TITLE
Fixing binary filter test target names

### DIFF
--- a/components/parcel_plugins/binary_filter/bzip2/tests/CMakeLists.txt
+++ b/components/parcel_plugins/binary_filter/bzip2/tests/CMakeLists.txt
@@ -5,7 +5,9 @@
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 if(HPX_WITH_TESTS_UNIT)
-  add_hpx_pseudo_target(tests.unit.components.parcel_plugins.binary_filter.bzip2)
+  add_hpx_pseudo_target(
+    tests.unit.components.parcel_plugins.binary_filter.bzip2
+  )
   add_hpx_pseudo_dependencies(
     tests.unit.components
     tests.unit.components.parcel_plugins.binary_filter.bzip2
@@ -14,7 +16,9 @@ if(HPX_WITH_TESTS_UNIT)
 endif()
 
 if(HPX_WITH_TESTS_REGRESSIONS)
-  add_hpx_pseudo_target(tests.regressions.components.parcel_plugins.binary_filter.bzip2)
+  add_hpx_pseudo_target(
+    tests.regressions.components.parcel_plugins.binary_filter.bzip2
+  )
   add_hpx_pseudo_dependencies(
     tests.regressions.components
     tests.regressions.components.parcel_plugins.binary_filter.bzip2
@@ -23,7 +27,9 @@ if(HPX_WITH_TESTS_REGRESSIONS)
 endif()
 
 if(HPX_WITH_TESTS_BENCHMARKS)
-  add_hpx_pseudo_target(tests.performance.components.parcel_plugins.binary_filter.bzip2)
+  add_hpx_pseudo_target(
+    tests.performance.components.parcel_plugins.binary_filter.bzip2
+  )
   add_hpx_pseudo_dependencies(
     tests.performance.components
     tests.performance.components.parcel_plugins.binary_filter.bzip2

--- a/components/parcel_plugins/binary_filter/bzip2/tests/CMakeLists.txt
+++ b/components/parcel_plugins/binary_filter/bzip2/tests/CMakeLists.txt
@@ -1,41 +1,41 @@
-# Copyright (c) 2019-2022 The STE||AR-Group
+# Copyright (c) 2019-2024 The STE||AR-Group
 #
 # SPDX-License-Identifier: BSL-1.0
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 if(HPX_WITH_TESTS_UNIT)
-  add_hpx_pseudo_target(tests.unit.components.parcel_plugins.coalescing)
+  add_hpx_pseudo_target(tests.unit.components.parcel_plugins.binary_filter.bzip2)
   add_hpx_pseudo_dependencies(
-    tests.unit.components tests.unit.components.parcel_plugins.coalescing
+    tests.unit.components tests.unit.components.parcel_plugins.binary_filter.bzip2
   )
   add_subdirectory(unit)
 endif()
 
 if(HPX_WITH_TESTS_REGRESSIONS)
-  add_hpx_pseudo_target(tests.regressions.components.parcel_plugins.coalescing)
+  add_hpx_pseudo_target(tests.regressions.components.parcel_plugins.binary_filter.bzip2)
   add_hpx_pseudo_dependencies(
     tests.regressions.components
-    tests.regressions.components.parcel_plugins.coalescing
+    tests.regressions.components.parcel_plugins.binary_filter.bzip2
   )
   add_subdirectory(regressions)
 endif()
 
 if(HPX_WITH_TESTS_BENCHMARKS)
-  add_hpx_pseudo_target(tests.performance.components.parcel_plugins.coalescing)
+  add_hpx_pseudo_target(tests.performance.components.parcel_plugins.binary_filter.bzip2)
   add_hpx_pseudo_dependencies(
     tests.performance.components
-    tests.performance.components.parcel_plugins.coalescing
+    tests.performance.components.parcel_plugins.binary_filter.bzip2
   )
   add_subdirectory(performance)
 endif()
 
 if(HPX_WITH_TESTS_HEADERS)
   add_hpx_header_tests(
-    "components.parcel_plugins.coalescing"
-    HEADERS ${parcel_coalescing_headers}
+    "components.parcel_plugins.binary_filter.bzip2"
+    HEADERS ${parcel_binary_filter_headers}
     HEADER_ROOT "${CMAKE_CURRENT_SOURCE_DIR}/include"
-    COMPONENT_DEPENDENCIES parcel_coalescing
-    EXCLUDE hpx/include/parcel_coalescing.hpp
+    COMPONENT_DEPENDENCIES parcel_binary_filter
+    EXCLUDE hpx/include/compression_bzip2.hpp
   )
 endif()

--- a/components/parcel_plugins/binary_filter/bzip2/tests/CMakeLists.txt
+++ b/components/parcel_plugins/binary_filter/bzip2/tests/CMakeLists.txt
@@ -7,7 +7,8 @@
 if(HPX_WITH_TESTS_UNIT)
   add_hpx_pseudo_target(tests.unit.components.parcel_plugins.binary_filter.bzip2)
   add_hpx_pseudo_dependencies(
-    tests.unit.components tests.unit.components.parcel_plugins.binary_filter.bzip2
+    tests.unit.components
+    tests.unit.components.parcel_plugins.binary_filter.bzip2
   )
   add_subdirectory(unit)
 endif()

--- a/components/parcel_plugins/binary_filter/bzip2/tests/regressions/CMakeLists.txt
+++ b/components/parcel_plugins/binary_filter/bzip2/tests/regressions/CMakeLists.txt
@@ -23,6 +23,6 @@ foreach(test ${tests})
   )
 
   add_hpx_regression_test(
-    "components.parcel_plugins.coalescing" ${test} ${${test}_PARAMETERS}
+    "components.parcel_plugins.binary_filter.bzip2" ${test} ${${test}_PARAMETERS}
   )
 endforeach()

--- a/components/parcel_plugins/binary_filter/bzip2/tests/regressions/CMakeLists.txt
+++ b/components/parcel_plugins/binary_filter/bzip2/tests/regressions/CMakeLists.txt
@@ -23,6 +23,7 @@ foreach(test ${tests})
   )
 
   add_hpx_regression_test(
-    "components.parcel_plugins.binary_filter.bzip2" ${test} ${${test}_PARAMETERS}
+    "components.parcel_plugins.binary_filter.bzip2" ${test}
+    ${${test}_PARAMETERS}
   )
 endforeach()

--- a/components/parcel_plugins/binary_filter/bzip2/tests/unit/CMakeLists.txt
+++ b/components/parcel_plugins/binary_filter/bzip2/tests/unit/CMakeLists.txt
@@ -24,6 +24,7 @@ foreach(test ${tests})
   )
 
   add_hpx_unit_test(
-    "components.parcel_plugins.binary_filter.bzip2" ${test} ${${test}_PARAMETERS}
+    "components.parcel_plugins.binary_filter.bzip2" ${test}
+    ${${test}_PARAMETERS}
   )
 endforeach()

--- a/components/parcel_plugins/binary_filter/bzip2/tests/unit/CMakeLists.txt
+++ b/components/parcel_plugins/binary_filter/bzip2/tests/unit/CMakeLists.txt
@@ -24,6 +24,6 @@ foreach(test ${tests})
   )
 
   add_hpx_unit_test(
-    "components.parcel_plugins.coalescing" ${test} ${${test}_PARAMETERS}
+    "components.parcel_plugins.binary_filter.bzip2" ${test} ${${test}_PARAMETERS}
   )
 endforeach()

--- a/components/parcel_plugins/binary_filter/snappy/tests/CMakeLists.txt
+++ b/components/parcel_plugins/binary_filter/snappy/tests/CMakeLists.txt
@@ -7,7 +7,8 @@
 if(HPX_WITH_TESTS_UNIT)
   add_hpx_pseudo_target(tests.unit.components.parcel_plugins.binary_filter.snappy)
   add_hpx_pseudo_dependencies(
-    tests.unit.components tests.unit.components.parcel_plugins.binary_filter.snappy
+    tests.unit.components
+    tests.unit.components.parcel_plugins.binary_filter.snappy
   )
   add_subdirectory(unit)
 endif()

--- a/components/parcel_plugins/binary_filter/snappy/tests/CMakeLists.txt
+++ b/components/parcel_plugins/binary_filter/snappy/tests/CMakeLists.txt
@@ -5,7 +5,9 @@
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 if(HPX_WITH_TESTS_UNIT)
-  add_hpx_pseudo_target(tests.unit.components.parcel_plugins.binary_filter.snappy)
+  add_hpx_pseudo_target(
+    tests.unit.components.parcel_plugins.binary_filter.snappy
+  )
   add_hpx_pseudo_dependencies(
     tests.unit.components
     tests.unit.components.parcel_plugins.binary_filter.snappy
@@ -14,7 +16,9 @@ if(HPX_WITH_TESTS_UNIT)
 endif()
 
 if(HPX_WITH_TESTS_REGRESSIONS)
-  add_hpx_pseudo_target(tests.regressions.components.parcel_plugins.binary_filter.snappy)
+  add_hpx_pseudo_target(
+    tests.regressions.components.parcel_plugins.binary_filter.snappy
+  )
   add_hpx_pseudo_dependencies(
     tests.regressions.components
     tests.regressions.components.parcel_plugins.binary_filter.snappy
@@ -23,7 +27,9 @@ if(HPX_WITH_TESTS_REGRESSIONS)
 endif()
 
 if(HPX_WITH_TESTS_BENCHMARKS)
-  add_hpx_pseudo_target(tests.performance.components.parcel_plugins.binary_filter.snappy)
+  add_hpx_pseudo_target(
+    tests.performance.components.parcel_plugins.binary_filter.snappy
+  )
   add_hpx_pseudo_dependencies(
     tests.performance.components
     tests.performance.components.parcel_plugins.binary_filter.snappy

--- a/components/parcel_plugins/binary_filter/snappy/tests/CMakeLists.txt
+++ b/components/parcel_plugins/binary_filter/snappy/tests/CMakeLists.txt
@@ -1,41 +1,41 @@
-# Copyright (c) 2019-2022 The STE||AR-Group
+# Copyright (c) 2019-2024 The STE||AR-Group
 #
 # SPDX-License-Identifier: BSL-1.0
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 if(HPX_WITH_TESTS_UNIT)
-  add_hpx_pseudo_target(tests.unit.components.parcel_plugins.coalescing)
+  add_hpx_pseudo_target(tests.unit.components.parcel_plugins.binary_filter.snappy)
   add_hpx_pseudo_dependencies(
-    tests.unit.components tests.unit.components.parcel_plugins.coalescing
+    tests.unit.components tests.unit.components.parcel_plugins.binary_filter.snappy
   )
   add_subdirectory(unit)
 endif()
 
 if(HPX_WITH_TESTS_REGRESSIONS)
-  add_hpx_pseudo_target(tests.regressions.components.parcel_plugins.coalescing)
+  add_hpx_pseudo_target(tests.regressions.components.parcel_plugins.binary_filter.snappy)
   add_hpx_pseudo_dependencies(
     tests.regressions.components
-    tests.regressions.components.parcel_plugins.coalescing
+    tests.regressions.components.parcel_plugins.binary_filter.snappy
   )
   add_subdirectory(regressions)
 endif()
 
 if(HPX_WITH_TESTS_BENCHMARKS)
-  add_hpx_pseudo_target(tests.performance.components.parcel_plugins.coalescing)
+  add_hpx_pseudo_target(tests.performance.components.parcel_plugins.binary_filter.snappy)
   add_hpx_pseudo_dependencies(
     tests.performance.components
-    tests.performance.components.parcel_plugins.coalescing
+    tests.performance.components.parcel_plugins.binary_filter.snappy
   )
   add_subdirectory(performance)
 endif()
 
 if(HPX_WITH_TESTS_HEADERS)
   add_hpx_header_tests(
-    "components.parcel_plugins.coalescing"
-    HEADERS ${parcel_coalescing_headers}
+    "components.parcel_plugins.binary_filter.snappy"
+    HEADERS ${parcel_binary_filter_headers}
     HEADER_ROOT "${CMAKE_CURRENT_SOURCE_DIR}/include"
-    COMPONENT_DEPENDENCIES parcel_coalescing
-    EXCLUDE hpx/include/parcel_coalescing.hpp
+    COMPONENT_DEPENDENCIES parcel_binary_filter
+    EXCLUDE hpx/include/compression_snappy.hpp
   )
 endif()

--- a/components/parcel_plugins/binary_filter/snappy/tests/regressions/CMakeLists.txt
+++ b/components/parcel_plugins/binary_filter/snappy/tests/regressions/CMakeLists.txt
@@ -23,6 +23,6 @@ foreach(test ${tests})
   )
 
   add_hpx_regression_test(
-    "components.parcel_plugins.coalescing" ${test} ${${test}_PARAMETERS}
+    "components.parcel_plugins.binary_filter.snappy" ${test} ${${test}_PARAMETERS}
   )
 endforeach()

--- a/components/parcel_plugins/binary_filter/snappy/tests/regressions/CMakeLists.txt
+++ b/components/parcel_plugins/binary_filter/snappy/tests/regressions/CMakeLists.txt
@@ -23,6 +23,7 @@ foreach(test ${tests})
   )
 
   add_hpx_regression_test(
-    "components.parcel_plugins.binary_filter.snappy" ${test} ${${test}_PARAMETERS}
+    "components.parcel_plugins.binary_filter.snappy" ${test}
+    ${${test}_PARAMETERS}
   )
 endforeach()

--- a/components/parcel_plugins/binary_filter/snappy/tests/unit/CMakeLists.txt
+++ b/components/parcel_plugins/binary_filter/snappy/tests/unit/CMakeLists.txt
@@ -24,6 +24,7 @@ foreach(test ${tests})
   )
 
   add_hpx_unit_test(
-    "components.parcel_plugins.binary_filter.snappy" ${test} ${${test}_PARAMETERS}
+    "components.parcel_plugins.binary_filter.snappy" ${test}
+    ${${test}_PARAMETERS}
   )
 endforeach()

--- a/components/parcel_plugins/binary_filter/snappy/tests/unit/CMakeLists.txt
+++ b/components/parcel_plugins/binary_filter/snappy/tests/unit/CMakeLists.txt
@@ -24,6 +24,6 @@ foreach(test ${tests})
   )
 
   add_hpx_unit_test(
-    "components.parcel_plugins.coalescing" ${test} ${${test}_PARAMETERS}
+    "components.parcel_plugins.binary_filter.snappy" ${test} ${${test}_PARAMETERS}
   )
 endforeach()

--- a/components/parcel_plugins/binary_filter/zlib/tests/CMakeLists.txt
+++ b/components/parcel_plugins/binary_filter/zlib/tests/CMakeLists.txt
@@ -7,7 +7,8 @@
 if(HPX_WITH_TESTS_UNIT)
   add_hpx_pseudo_target(tests.unit.components.parcel_plugins.binary_filter.zlib)
   add_hpx_pseudo_dependencies(
-    tests.unit.components tests.unit.components.parcel_plugins.binary_filter.zlib
+    tests.unit.components
+    tests.unit.components.parcel_plugins.binary_filter.zlib
   )
   add_subdirectory(unit)
 endif()

--- a/components/parcel_plugins/binary_filter/zlib/tests/CMakeLists.txt
+++ b/components/parcel_plugins/binary_filter/zlib/tests/CMakeLists.txt
@@ -1,41 +1,41 @@
-# Copyright (c) 2019-2022 The STE||AR-Group
+# Copyright (c) 2019-2024 The STE||AR-Group
 #
 # SPDX-License-Identifier: BSL-1.0
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 if(HPX_WITH_TESTS_UNIT)
-  add_hpx_pseudo_target(tests.unit.components.parcel_plugins.coalescing)
+  add_hpx_pseudo_target(tests.unit.components.parcel_plugins.binary_filter.zlib)
   add_hpx_pseudo_dependencies(
-    tests.unit.components tests.unit.components.parcel_plugins.coalescing
+    tests.unit.components tests.unit.components.parcel_plugins.binary_filter.zlib
   )
   add_subdirectory(unit)
 endif()
 
 if(HPX_WITH_TESTS_REGRESSIONS)
-  add_hpx_pseudo_target(tests.regressions.components.parcel_plugins.coalescing)
+  add_hpx_pseudo_target(tests.regressions.components.parcel_plugins.binary_filter.zlib)
   add_hpx_pseudo_dependencies(
     tests.regressions.components
-    tests.regressions.components.parcel_plugins.coalescing
+    tests.regressions.components.parcel_plugins.binary_filter.zlib
   )
   add_subdirectory(regressions)
 endif()
 
 if(HPX_WITH_TESTS_BENCHMARKS)
-  add_hpx_pseudo_target(tests.performance.components.parcel_plugins.coalescing)
+  add_hpx_pseudo_target(tests.performance.components.parcel_plugins.binary_filter.zlib)
   add_hpx_pseudo_dependencies(
     tests.performance.components
-    tests.performance.components.parcel_plugins.coalescing
+    tests.performance.components.parcel_plugins.binary_filter.zlib
   )
   add_subdirectory(performance)
 endif()
 
 if(HPX_WITH_TESTS_HEADERS)
   add_hpx_header_tests(
-    "components.parcel_plugins.coalescing"
-    HEADERS ${parcel_coalescing_headers}
+    "components.parcel_plugins.binary_filter.zlib"
+    HEADERS ${parcel_binary_filter_headers}
     HEADER_ROOT "${CMAKE_CURRENT_SOURCE_DIR}/include"
-    COMPONENT_DEPENDENCIES parcel_coalescing
-    EXCLUDE hpx/include/parcel_coalescing.hpp
+    COMPONENT_DEPENDENCIES parcel_binary_filter
+    EXCLUDE hpx/include/compression_zlib.hpp
   )
 endif()

--- a/components/parcel_plugins/binary_filter/zlib/tests/CMakeLists.txt
+++ b/components/parcel_plugins/binary_filter/zlib/tests/CMakeLists.txt
@@ -14,7 +14,9 @@ if(HPX_WITH_TESTS_UNIT)
 endif()
 
 if(HPX_WITH_TESTS_REGRESSIONS)
-  add_hpx_pseudo_target(tests.regressions.components.parcel_plugins.binary_filter.zlib)
+  add_hpx_pseudo_target(
+    tests.regressions.components.parcel_plugins.binary_filter.zlib
+  )
   add_hpx_pseudo_dependencies(
     tests.regressions.components
     tests.regressions.components.parcel_plugins.binary_filter.zlib
@@ -23,7 +25,9 @@ if(HPX_WITH_TESTS_REGRESSIONS)
 endif()
 
 if(HPX_WITH_TESTS_BENCHMARKS)
-  add_hpx_pseudo_target(tests.performance.components.parcel_plugins.binary_filter.zlib)
+  add_hpx_pseudo_target(
+    tests.performance.components.parcel_plugins.binary_filter.zlib
+  )
   add_hpx_pseudo_dependencies(
     tests.performance.components
     tests.performance.components.parcel_plugins.binary_filter.zlib

--- a/components/parcel_plugins/binary_filter/zlib/tests/regressions/CMakeLists.txt
+++ b/components/parcel_plugins/binary_filter/zlib/tests/regressions/CMakeLists.txt
@@ -23,6 +23,6 @@ foreach(test ${tests})
   )
 
   add_hpx_regression_test(
-    "components.parcel_plugins.coalescing" ${test} ${${test}_PARAMETERS}
+    "components.parcel_plugins.binary_filter.zlib" ${test} ${${test}_PARAMETERS}
   )
 endforeach()

--- a/components/parcel_plugins/binary_filter/zlib/tests/regressions/CMakeLists.txt
+++ b/components/parcel_plugins/binary_filter/zlib/tests/regressions/CMakeLists.txt
@@ -23,6 +23,7 @@ foreach(test ${tests})
   )
 
   add_hpx_regression_test(
-    "components.parcel_plugins.binary_filter.zlib" ${test} ${${test}_PARAMETERS}
+    "components.parcel_plugins.binary_filter.zlib" ${test}
+    ${${test}_PARAMETERS}
   )
 endforeach()

--- a/components/parcel_plugins/binary_filter/zlib/tests/unit/CMakeLists.txt
+++ b/components/parcel_plugins/binary_filter/zlib/tests/unit/CMakeLists.txt
@@ -24,6 +24,7 @@ foreach(test ${tests})
   )
 
   add_hpx_unit_test(
-    "components.parcel_plugins.binary_filter.zlib" ${test} ${${test}_PARAMETERS}
+    "components.parcel_plugins.binary_filter.zlib" ${test}
+    ${${test}_PARAMETERS}
   )
 endforeach()

--- a/components/parcel_plugins/binary_filter/zlib/tests/unit/CMakeLists.txt
+++ b/components/parcel_plugins/binary_filter/zlib/tests/unit/CMakeLists.txt
@@ -24,6 +24,6 @@ foreach(test ${tests})
   )
 
   add_hpx_unit_test(
-    "components.parcel_plugins.coalescing" ${test} ${${test}_PARAMETERS}
+    "components.parcel_plugins.binary_filter.zlib" ${test} ${${test}_PARAMETERS}
   )
 endforeach()


### PR DESCRIPTION
Not unique target names in the tests of binary_filter which leads to build errors when switching on the different filter at the same time, e.g. with
```
          -DHPX_WITH_COMPRESSION_BZIP2=ON \
          -DHPX_WITH_COMPRESSION_SNAPPY=ON \
          -DHPX_WITH_COMPRESSION_ZLIB=ON \
          -DHPX_WITH_TESTS=ON \
```

## Proposed Changes

  - unique target names for binary_filter tests

## Checklist

Replaced the non unique copy-paste name with the unique names of the different binary filter in the build config files.