### PR TITLE
lci pp: lci's github repo name changed from LC to lci

### DIFF
--- a/cmake/HPX_SetupLCI.cmake
+++ b/cmake/HPX_SetupLCI.cmake
@@ -44,7 +44,7 @@ macro(hpx_setup_lci)
       include(FetchContent)
       fetchcontent_declare(
         lci
-        GIT_REPOSITORY https://github.com/uiuc-hpc/LC.git
+        GIT_REPOSITORY https://github.com/uiuc-hpc/lci.git
         GIT_TAG ${HPX_WITH_LCI_TAG}
       )
 

--- a/docs/sphinx/manual/using_the_lci_parcelport.rst
+++ b/docs/sphinx/manual/using_the_lci_parcelport.rst
@@ -38,7 +38,7 @@ Its message transmission path involves minimum synchronization
 points and is almost lock-free. It is expected to be much faster
 than the MPI parcelport.
 
-.. _`Lightweight Communication Interface`: https://github.com/uiuc-hpc/LC
+.. _`Lightweight Communication Interface`: https://github.com/uiuc-hpc/lci
 
 .. _build_lci_pp:
 
@@ -66,7 +66,7 @@ and frequently used CMake variables.
    If this option is set to ``ON``. |hpx| will fetch and build LCI for you. You can use the following
    |cmake| variables to configure this behavior for your platform.
 
-.. _`LCI README`: https://github.com/uiuc-hpc/LC#readme
+.. _`LCI README`: https://github.com/uiuc-hpc/lci#readme
 
 .. option:: HPX_WITH_LCI_TAG
 


### PR DESCRIPTION
The Github repo name of LCI has been changed from `uiuc-hpc/LC` to `uiuc-hpc/lci`. Although the old URL (github.com/uiuc-hpc/LC) is automatically redirected to the new URL, it would still be good to change the existing reference to the new URL.

This PR implemented the corresponding changes.