### PR TITLE
Remove equal_to from hpx::any

### DIFF
--- a/libs/core/datastructures/include/hpx/datastructures/any.hpp
+++ b/libs/core/datastructures/include/hpx/datastructures/any.hpp
@@ -1,6 +1,6 @@
 /*=============================================================================
     Copyright (c) 2013 Shuangyang Yang
-    Copyright (c) 2007-2023 Hartmut Kaiser
+    Copyright (c) 2007-2024 Hartmut Kaiser
     Copyright (c) Christopher Diggins 2005
     Copyright (c) Pablo Aguilar 2005
     Copyright (c) Kevlin Henney 2001
@@ -107,7 +107,6 @@ namespace hpx::util::detail::any {
         void (*destruct)(void**) = nullptr;
         void (*clone)(void* const*, void**) = nullptr;
         void (*copy)(void* const*, void**) = nullptr;
-        bool (*equal_to)(void* const*, void* const*) = nullptr;
     };
 
     template <>
@@ -127,7 +126,6 @@ namespace hpx::util::detail::any {
         std::type_info const& (*get_type)() = nullptr;
         void (*static_delete)(void**) = nullptr;
         void (*destruct)(void**) = nullptr;
-        bool (*equal_to)(void* const*, void* const*) = nullptr;
     };
 
     ////////////////////////////////////////////////////////////////////////
@@ -472,7 +470,6 @@ namespace hpx::util::detail::any {
             base_type::destruct = Vtable::destruct;
             base_type::clone = Vtable::clone;
             base_type::copy = Vtable::copy;
-            base_type::equal_to = Vtable::equal_to;
         }
 
         [[nodiscard]] base_type* get_ptr() override
@@ -496,7 +493,6 @@ namespace hpx::util::detail::any {
             base_type::destruct = Vtable::destruct;
             base_type::clone = Vtable::clone;
             base_type::copy = Vtable::copy;
-            base_type::equal_to = Vtable::equal_to;
             base_type::stream_in = Vtable::stream_in;
             base_type::stream_out = Vtable::stream_out;
         }
@@ -520,7 +516,6 @@ namespace hpx::util::detail::any {
             base_type::get_type = Vtable::get_type;
             base_type::static_delete = Vtable::static_delete;
             base_type::destruct = Vtable::destruct;
-            base_type::equal_to = Vtable::equal_to;
         }
 
         [[nodiscard]] base_type* get_ptr() override
@@ -542,7 +537,6 @@ namespace hpx::util::detail::any {
             base_type::get_type = Vtable::get_type;
             base_type::static_delete = Vtable::static_delete;
             base_type::destruct = Vtable::destruct;
-            base_type::equal_to = Vtable::equal_to;
             base_type::stream_in = Vtable::stream_in;
             base_type::stream_out = Vtable::stream_out;
         }
@@ -830,22 +824,6 @@ namespace hpx::util {
             }
         }
 
-        // equality operator
-        [[nodiscard]] bool equal_to(basic_any const& rhs) const noexcept
-        {
-            if (this == &rhs)    // same object
-            {
-                return true;
-            }
-
-            if (type() == rhs.type())    // same type
-            {
-                return table->equal_to(&object, &rhs.object);    // equal value?
-            }
-
-            return false;
-        }
-
     private:    // types
         friend struct detail::any::any_cast_support;
 
@@ -1043,22 +1021,6 @@ namespace hpx::util {
             }
         }
 
-        // equality operator
-        bool equal_to(basic_any const& rhs) const noexcept
-        {
-            if (this == &rhs)    // same object
-            {
-                return true;
-            }
-
-            if (type() == rhs.type())    // same type
-            {
-                return table->equal_to(&object, &rhs.object);    // equal value?
-            }
-
-            return false;
-        }
-
     private:    // types
         friend struct detail::any::any_cast_support;
         friend struct detail::any::stream_support;
@@ -1224,22 +1186,6 @@ namespace hpx::util {
             }
         }
 
-        // equality operator
-        bool equal_to(basic_any const& rhs) const noexcept
-        {
-            if (this == &rhs)    // same object
-            {
-                return true;
-            }
-
-            if (type() == rhs.type())    // same type
-            {
-                return table->equal_to(&object, &rhs.object);    // equal value?
-            }
-
-            return false;
-        }
-
     private:    // types
         friend struct detail::any::any_cast_support;
 
@@ -1400,22 +1346,6 @@ namespace hpx::util {
                     void, Char, std::false_type>();
                 object = nullptr;
             }
-        }
-
-        // equality operator
-        bool equal_to(basic_any const& rhs) const noexcept
-        {
-            if (this == &rhs)    // same object
-            {
-                return true;
-            }
-
-            if (type() == rhs.type())    // same type
-            {
-                return table->equal_to(&object, &rhs.object);    // equal value?
-            }
-
-            return false;
         }
 
     private:    // types

--- a/libs/core/datastructures/include/hpx/datastructures/serialization/serializable_any.hpp
+++ b/libs/core/datastructures/include/hpx/datastructures/serialization/serializable_any.hpp
@@ -1,6 +1,6 @@
 /*=============================================================================
     Copyright (c) 2013 Shuangyang Yang
-    Copyright (c) 2007-2023 Hartmut Kaiser
+    Copyright (c) 2007-2024 Hartmut Kaiser
     Copyright (c) Christopher Diggins 2005
     Copyright (c) Pablo Aguilar 2005
     Copyright (c) Kevlin Henney 2001

--- a/libs/core/program_options/tests/unit/variable_map.cpp
+++ b/libs/core/program_options/tests/unit/variable_map.cpp
@@ -269,7 +269,16 @@ void test_multiple_assignments_with_different_option_description()
 
     vector<string> input1;
     input1.emplace_back("--help");
+
+#if defined(HPX_GCC_VERSION) && HPX_GCC_VERSION >= 110000
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Warray-bounds"
+#endif
     input1.emplace_back("--includes=a");
+#if defined(HPX_GCC_VERSION) && HPX_GCC_VERSION >= 110000
+#pragma GCC diagnostic pop
+#endif
+
     parsed_options p1 = command_line_parser(input1).options(desc1).run();
 
     vector<string> input2;

--- a/libs/full/collectives/tests/regressions/CMakeLists.txt
+++ b/libs/full/collectives/tests/regressions/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2022 The STE||AR-Group
+# Copyright (c) 2019-2024 The STE||AR-Group
 #
 # SPDX-License-Identifier: BSL-1.0
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -6,8 +6,13 @@
 
 if(HPX_WITH_NETWORKING)
   set(tests
-      barrier_3792 barrier_hang broadcast_unwrap_future_2885
-      broadcast_wait_for_2822 collectives_bool_5940 multiple_gather_ops_2001
+      barrier_3792
+      barrier_hang
+      broadcast_unwrap_future_2885
+      broadcast_wait_for_2822
+      collectives_bool_5940
+      multiple_gather_ops_2001
+      trivially_copyable_all_gather
   )
 
   set(broadcast_unwrap_future_2885_PARAMETERS LOCALITIES 2 THREADS_PER_LOCALITY

--- a/libs/full/collectives/tests/regressions/trivially_copyable_all_gather.cpp
+++ b/libs/full/collectives/tests/regressions/trivially_copyable_all_gather.cpp
@@ -1,0 +1,109 @@
+//  Copyright (c) 2024 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/config.hpp>
+
+#if !defined(HPX_COMPUTE_DEVICE_CODE)
+#include <hpx/hpx.hpp>
+#include <hpx/hpx_init.hpp>
+#include <hpx/modules/collectives.hpp>
+#include <hpx/modules/testing.hpp>
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+
+using Dimension = unsigned short;
+
+template <typename TYPE, Dimension DIM, std::size_t NAMESPACE>
+class dimensioned_array
+{
+public:
+    dimensioned_array() = default;
+
+    explicit constexpr dimensioned_array(TYPE const& val)
+      : data_()
+    {
+        for (auto& x : data_)
+            x = val;
+    }
+
+    constexpr bool operator==(dimensioned_array const& da)
+    {
+        return this->data_ == da.data_;
+    }
+
+private:
+    std::array<TYPE, DIM> data_;
+};
+
+template <typename TYPE, Dimension DIM>
+using point = dimensioned_array<TYPE, DIM, 1>;
+
+template <Dimension DIM>
+struct hpx::traits::is_bitwise_serializable<point<double, DIM>> : std::true_type
+{
+};
+
+template <Dimension DIM>
+struct BBox
+{
+    point<double, DIM> lower, upper;
+};
+
+void test_local_use()
+{
+    using namespace hpx::collectives;
+
+    constexpr char const* all_gather_direct_basename =
+        "/test/all_gather_direct/";
+    constexpr int ITERATIONS = 100;
+    constexpr std::uint32_t num_sites = 10;
+
+    std::vector<hpx::future<void>> sites;
+    sites.reserve(num_sites);
+
+    // launch num_sites threads to represent different sites
+    for (std::uint32_t site = 0; site != num_sites; ++site)
+    {
+        sites.push_back(hpx::async([=]() {
+            auto const all_gather_direct_client =
+                create_local_communicator(all_gather_direct_basename,
+                    num_sites_arg(num_sites), this_site_arg(site));
+
+            for (std::uint32_t i = 0; i != 10 * ITERATIONS; ++i)
+            {
+                double const coord_x = i;
+                double const coord_y = i + 1;
+                hpx::future<std::vector<BBox<2>>> overall_result =
+                    all_gather(all_gather_direct_client,
+                        BBox<2>{point<double, 2>{coord_x},
+                            point<double, 2>{coord_y}},
+                        this_site_arg(site), generation_arg(i + 1));
+
+                std::vector<BBox<2>> r = overall_result.get();
+                HPX_TEST_EQ(r.size(), num_sites);
+            }
+        }));
+    }
+
+    hpx::wait_all(std::move(sites));
+}
+
+int hpx_main()
+{
+    test_local_use();
+    return hpx::finalize();
+}
+
+int main(int argc, char* argv[])
+{
+    HPX_TEST_EQ(hpx::init(argc, argv), 0);
+    return hpx::util::report_errors();
+}
+
+#endif


### PR DESCRIPTION
This prevents instantiation errors in collective operations. This also makes hpx::any more conforming to std::any.