### PR TITLE
Destructive interference size

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1690,8 +1690,12 @@ hpx_option(
 include(HPX_SetupCUDA)
 include(HPX_PerformCxxFeatureTests)
 hpx_perform_cxx_feature_tests()
+
 include(TargetArch)
 target_architecture(__target_arch)
+
+include(CacheLineSize)
+cache_line_size(__cache_line_size)
 
 # ##############################################################################
 # Set configuration option to use Boost.Context or not. This depends on the
@@ -2014,6 +2018,7 @@ if(HPX_WITH_COMPILER_WARNINGS_AS_ERRORS)
 endif()
 
 # Diagnostics
+hpx_info("Cacheline size detected: ${__cache_line_size}")
 if(MSVC)
   # Display full paths in diagnostics
   hpx_add_compile_flag(-FC)

--- a/cmake/CacheLineSize.cmake
+++ b/cmake/CacheLineSize.cmake
@@ -1,0 +1,63 @@
+# Copyright (c) 2024 Hartmut Kaiser
+#
+# SPDX-License-Identifier: BSL-1.0
+# Distributed under the Boost Software License, Version 1.0. (See accompanying
+# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+set(cache_line_size_detect_cpp_code
+    "
+    #include <iostream>
+    #include <new>
+    int main()
+    {
+#if defined(HPX_HAVE_CXX17_HARDWARE_DESTRUCTIVE_INTERFERENCE_SIZE)
+        std::cout << std::hardware_destructive_interference_size;
+#else
+#if defined(__s390__) || defined(__s390x__)
+        std::cout << 256;    // assume 256 byte cache-line size
+#elif defined(powerpc) || defined(__powerpc__) || defined(__ppc__)
+        std::cout << 128;    // assume 128 byte cache-line size
+#else
+        std::cout << 64;     // assume 64 byte cache-line size
+#endif
+#endif
+    }
+"
+)
+
+function(cache_line_size output_var)
+  if(NOT HPX_INTERNAL_CACHE_LINE_SIZE_DETECT)
+    file(WRITE "${PROJECT_BINARY_DIR}/cache_line_size.cpp"
+         "${cache_line_size_detect_cpp_code}"
+    )
+
+    if(HPX_WITH_CXX17_HARDWARE_DESTRUCTIVE_INTERFERENCE_SIZE)
+      set(compile_definitions
+          "-DHPX_HAVE_CXX17_HARDWARE_DESTRUCTIVE_INTERFERENCE_SIZE"
+      )
+    endif()
+
+    try_run(
+      run_result_unused compile_result_unused "${PROJECT_BINARY_DIR}" SOURCES
+      "${PROJECT_BINARY_DIR}/cache_line_size.cpp"
+      COMPILE_DEFINITIONS ${compile_definitions}
+      CMAKE_FLAGS CXX_STANDARD 17 CXX_STANDARD_REQUIRED ON CXX_EXTENSIONS FALSE
+      RUN_OUTPUT_VARIABLE CACHE_LINE_SIZE
+    )
+
+    if(NOT CACHE_LINE_SIZE)
+      set(CACHE_LINE_SIZE "64")
+    endif()
+    set(HPX_INTERNAL_CACHE_LINE_SIZE_DETECT
+        ${CACHE_LINE_SIZE}
+        CACHE INTERNAL ""
+    )
+  else()
+    set(CACHE_LINE_SIZE ${HPX_INTERNAL_CACHE_LINE_SIZE_DETECT})
+  endif()
+
+  set(${output_var}
+      "${CACHE_LINE_SIZE}"
+      PARENT_SCOPE
+  )
+endfunction()

--- a/cmake/HPX_AddModule.cmake
+++ b/cmake/HPX_AddModule.cmake
@@ -210,6 +210,7 @@ function(add_hpx_module libname modulename)
       "${global_config_file}" @ONLY
     )
     set(generated_headers ${generated_headers} ${global_config_file})
+
     # Global config defines file (different from the one for each module)
     set(global_config_file
         ${CMAKE_CURRENT_BINARY_DIR}/include/hpx/config/defines.hpp
@@ -221,6 +222,17 @@ function(add_hpx_module libname modulename)
       FILENAME "${global_config_file}"
     )
     set(generated_headers ${generated_headers} ${global_config_file})
+
+    # Cacheline size definition
+    set(cache_line_size_file
+        ${CMAKE_CURRENT_BINARY_DIR}/include/hpx/config/cache_line_size.hpp
+    )
+    configure_file(
+      "${CMAKE_CURRENT_SOURCE_DIR}/cmake/templates/cache_line_size.hpp.in"
+      "${cache_line_size_file}" @ONLY
+    )
+    set(generated_headers ${generated_headers} ${cache_line_size_file})
+
   endif()
 
   # collect zombie generated headers

--- a/libs/core/concurrency/include/hpx/concurrency/cache_line_data.hpp
+++ b/libs/core/concurrency/include/hpx/concurrency/cache_line_data.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2019-2022 Hartmut Kaiser
+//  Copyright (c) 2019-2024 Hartmut Kaiser
 //  Copyright (c) 2019 Thomas Heller
 //
 //  SPDX-License-Identifier: BSL-1.0
@@ -11,192 +11,163 @@
 #include <hpx/type_support/bit_cast.hpp>
 
 #include <cstddef>
-#include <new>
 #include <type_traits>
 #include <utility>
 
-namespace hpx {
+namespace hpx::util {
 
-    namespace threads {
+    namespace detail {
 
-        ////////////////////////////////////////////////////////////////////////
-        // abstract away cache-line size
-        constexpr std::size_t get_cache_line_size() noexcept
+        // Computes the padding required to fill up a full cache line after
+        // data_size bytes.
+        constexpr std::size_t get_cache_line_padding_size(
+            std::size_t data_size) noexcept
         {
-#if defined(HPX_HAVE_CXX17_HARDWARE_DESTRUCTIVE_INTERFERENCE_SIZE)
-            return std::hardware_destructive_interference_size;
-#else
-#if defined(__s390__) || defined(__s390x__)
-            return 256;    // assume 256 byte cache-line size
-#elif defined(powerpc) || defined(__powerpc__) || defined(__ppc__)
-            return 128;    // assume 128 byte cache-line size
-#else
-            return 64;    // assume 64 byte cache-line size
-#endif
-#endif
+            return (threads::get_cache_line_size() -
+                       (data_size % threads::get_cache_line_size())) %
+                threads::get_cache_line_size();
         }
-    }    // namespace threads
 
-    namespace util {
+        template <typename Data>
+        struct needs_padding
+          : std::integral_constant<bool,
+                // NOLINTNEXTLINE(bugprone-sizeof-expression)
+                detail::get_cache_line_padding_size(sizeof(Data)) != 0>
+        {
+        };
+    }    // namespace detail
 
-        namespace detail {
-
-            // Computes the padding required to fill up a full cache line after
-            // data_size bytes.
-            constexpr std::size_t get_cache_line_padding_size(
-                std::size_t data_size) noexcept
-            {
-                return (threads::get_cache_line_size() -
-                           (data_size % threads::get_cache_line_size())) %
-                    threads::get_cache_line_size();
-            }
-
-            template <typename Data>
-            struct needs_padding
-              : std::integral_constant<bool,
-                    // NOLINTNEXTLINE(bugprone-sizeof-expression)
-                    detail::get_cache_line_padding_size(sizeof(Data)) != 0>
-            {
-            };
-        }    // namespace detail
-
-        // Variable 'cacheline_pad' is uninitialized. Always initialize a member
-        // variable
+    // Variable 'cacheline_pad' is uninitialized. Always initialize a member
+    // variable
 #if defined(HPX_MSVC)
 #pragma warning(push)
 #pragma warning(disable : 26495)
 #endif
 
-        // NOTE: We do not use alignas here because asking for overaligned
-        // memory is significantly more expensive than asking for unaligned
-        // memory. Padding the struct is cheaper and enough for internal
-        // purposes.
+    // NOTE: We do not use alignas here because asking for overaligned
+    // memory is significantly more expensive than asking for unaligned
+    // memory. Padding the struct is cheaper and enough for internal
+    // purposes.
 
-        // NOTE: The implementations below are currently identical because of
-        // the above issue. Both names are kept for compatibility.
+    // NOTE: The implementations below are currently identical because of
+    // the above issue. Both names are kept for compatibility.
 
-        ///////////////////////////////////////////////////////////////////////////
-        // special struct to ensure cache line alignment of a data type
-        template <typename Data,
-            bool NeedsPadding = detail::needs_padding<Data>::value>
-        struct cache_aligned_data
+    ///////////////////////////////////////////////////////////////////////////
+    // special struct to ensure cache line alignment of a data type
+    template <typename Data,
+        bool NeedsPadding = detail::needs_padding<Data>::value>
+    struct cache_aligned_data
+    {
+        // We have an explicit (default) constructor here to avoid for the
+        // entire cache-line to be initialized by the compiler.
+
+        constexpr cache_aligned_data() noexcept(    //-V730
+            std::is_nothrow_default_constructible_v<Data>)
+          : data_()
         {
-            // We have an explicit (default) constructor here to avoid for the
-            // entire cache-line to be initialized by the compiler.
+        }
 
-            constexpr cache_aligned_data() noexcept(    //-V730
-                std::is_nothrow_default_constructible_v<Data>)
-              : data_()
-            {
-            }
-
-            template <typename... Ts,
-                typename =
-                    std::enable_if_t<std::is_constructible_v<Data, Ts&&...>>>
-            cache_aligned_data(Ts&&... ts) noexcept(
-                std::is_nothrow_constructible_v<Data, Ts&&...>)
-              : data_(HPX_FORWARD(Ts, ts)...)
-            {
-            }
-
-            // pad to cache line size bytes
-            Data data_;
-
-            //  cppcheck-suppress unusedVariable
-            char cacheline_pad[detail::get_cache_line_padding_size(
-                // NOLINTNEXTLINE(bugprone-sizeof-expression)
-                sizeof(Data))];
-        };
-
-        template <typename Data>
-        struct cache_aligned_data<Data, false>
+        template <typename... Ts,
+            typename = std::enable_if_t<std::is_constructible_v<Data, Ts&&...>>>
+        cache_aligned_data(Ts&&... ts) noexcept(
+            std::is_nothrow_constructible_v<Data, Ts&&...>)
+          : data_(HPX_FORWARD(Ts, ts)...)
         {
-            constexpr cache_aligned_data() noexcept(
-                std::is_nothrow_default_constructible_v<Data>)
-              : data_()
-            {
-            }
+        }
 
-            template <typename... Ts,
-                typename =
-                    std::enable_if_t<std::is_constructible_v<Data, Ts&&...>>>
-            cache_aligned_data(Ts&&... ts) noexcept(
-                std::is_nothrow_constructible_v<Data, Ts&&...>)
-              : data_(HPX_FORWARD(Ts, ts)...)
-            {
-            }
+        // pad to cache line size bytes
+        Data data_;
 
-            // no need to pad to cache line size
-            Data data_;
-        };
+        //  cppcheck-suppress unusedVariable
+        char cacheline_pad[detail::get_cache_line_padding_size(
+            // NOLINTNEXTLINE(bugprone-sizeof-expression)
+            sizeof(Data))];
+    };
 
-        ///////////////////////////////////////////////////////////////////////////
-        // special struct to ensure cache line alignment of a data type
-        template <typename Data,
-            bool NeedsPadding = detail::needs_padding<Data>::value>
-        struct cache_aligned_data_derived : Data
+    template <typename Data>
+    struct cache_aligned_data<Data, false>
+    {
+        constexpr cache_aligned_data() noexcept(
+            std::is_nothrow_default_constructible_v<Data>)
+          : data_()
         {
-            // We have an explicit (default) constructor here to avoid for the
-            // entire cache-line to be initialized by the compiler.
-            constexpr cache_aligned_data_derived() noexcept(    //-V730
-                std::is_nothrow_default_constructible_v<Data>)
-              : Data()
-            {
-            }
+        }
 
-            template <typename... Ts,
-                typename =
-                    std::enable_if_t<std::is_constructible_v<Data, Ts&&...>>>
-            cache_aligned_data_derived(Ts&&... ts) noexcept(
-                std::is_nothrow_constructible_v<Data, Ts&&...>)
-              : Data(HPX_FORWARD(Ts, ts)...)
-            {
-            }
-
-            //  cppcheck-suppress unusedVariable
-            char cacheline_pad[detail::get_cache_line_padding_size(
-                // NOLINTNEXTLINE(bugprone-sizeof-expression)
-                sizeof(Data))];
-        };
-
-        template <typename Data>
-        struct cache_aligned_data_derived<Data, false> : Data
+        template <typename... Ts,
+            typename = std::enable_if_t<std::is_constructible_v<Data, Ts&&...>>>
+        cache_aligned_data(Ts&&... ts) noexcept(
+            std::is_nothrow_constructible_v<Data, Ts&&...>)
+          : data_(HPX_FORWARD(Ts, ts)...)
         {
-            constexpr cache_aligned_data_derived() noexcept(
-                std::is_nothrow_default_constructible_v<Data>)
-              : Data()
-            {
-            }
+        }
 
-            template <typename... Ts,
-                typename =
-                    std::enable_if_t<std::is_constructible_v<Data, Ts&&...>>>
-            cache_aligned_data_derived(Ts&&... ts) noexcept(
-                std::is_nothrow_constructible_v<Data, Ts&&...>)
-              : Data(HPX_FORWARD(Ts, ts)...)
-            {
-            }
+        // no need to pad to cache line size
+        Data data_;
+    };
 
-            // no need to pad to cache line size
-        };
+    ///////////////////////////////////////////////////////////////////////////
+    // special struct to ensure cache line alignment of a data type
+    template <typename Data,
+        bool NeedsPadding = detail::needs_padding<Data>::value>
+    struct cache_aligned_data_derived : Data
+    {
+        // We have an explicit (default) constructor here to avoid for the
+        // entire cache-line to be initialized by the compiler.
+        constexpr cache_aligned_data_derived() noexcept(    //-V730
+            std::is_nothrow_default_constructible_v<Data>)
+          : Data()
+        {
+        }
+
+        template <typename... Ts,
+            typename = std::enable_if_t<std::is_constructible_v<Data, Ts&&...>>>
+        cache_aligned_data_derived(Ts&&... ts) noexcept(
+            std::is_nothrow_constructible_v<Data, Ts&&...>)
+          : Data(HPX_FORWARD(Ts, ts)...)
+        {
+        }
+
+        //  cppcheck-suppress unusedVariable
+        char cacheline_pad[detail::get_cache_line_padding_size(
+            // NOLINTNEXTLINE(bugprone-sizeof-expression)
+            sizeof(Data))];
+    };
+
+    template <typename Data>
+    struct cache_aligned_data_derived<Data, false> : Data
+    {
+        constexpr cache_aligned_data_derived() noexcept(
+            std::is_nothrow_default_constructible_v<Data>)
+          : Data()
+        {
+        }
+
+        template <typename... Ts,
+            typename = std::enable_if_t<std::is_constructible_v<Data, Ts&&...>>>
+        cache_aligned_data_derived(Ts&&... ts) noexcept(
+            std::is_nothrow_constructible_v<Data, Ts&&...>)
+          : Data(HPX_FORWARD(Ts, ts)...)
+        {
+        }
+
+        // no need to pad to cache line size
+    };
 
 #if defined(HPX_MSVC)
 #pragma warning(pop)
 #endif
 
-        ///////////////////////////////////////////////////////////////////////////
-        // special struct to data type is cache line aligned and fully occupies a
-        // cache line
-        template <typename Data>
-        using cache_line_data = cache_aligned_data<Data>;
+    ///////////////////////////////////////////////////////////////////////////
+    // special struct to data type is cache line aligned and fully occupies a
+    // cache line
+    template <typename Data>
+    using cache_line_data = cache_aligned_data<Data>;
 
-        ///////////////////////////////////////////////////////////////////////////
-        template <typename T>
-        constexpr auto align_up(T value, std::size_t alignment) noexcept
-        {
-            return T(hpx::bit_cast<std::size_t>(value + (alignment - 1)) &
-                ~(alignment - 1));
-        }
-    }    // namespace util
-
-}    // namespace hpx
+    ///////////////////////////////////////////////////////////////////////////
+    template <typename T>
+    constexpr auto align_up(T value, std::size_t alignment) noexcept
+    {
+        return T(hpx::bit_cast<std::size_t>(value + (alignment - 1)) &
+            ~(alignment - 1));
+    }
+}    // namespace hpx::util

--- a/libs/core/config/cmake/templates/cache_line_size.hpp.in
+++ b/libs/core/config/cmake/templates/cache_line_size.hpp.in
@@ -1,0 +1,17 @@
+//  Copyright (c) 2024 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include <cstddef>
+
+namespace hpx::threads {
+
+    constexpr std::size_t get_cache_line_size() noexcept
+    {
+        return @HPX_INTERNAL_CACHE_LINE_SIZE_DETECT@;
+    }
+}    // namespace threads

--- a/libs/core/config/include/hpx/config.hpp
+++ b/libs/core/config/include/hpx/config.hpp
@@ -14,6 +14,7 @@
 #include <hpx/config/attributes.hpp>
 #include <hpx/config/auto_vectorization.hpp>
 #include <hpx/config/branch_hints.hpp>
+#include <hpx/config/cache_line_size.hpp>
 #include <hpx/config/compiler_fence.hpp>
 #include <hpx/config/compiler_specific.hpp>
 #include <hpx/config/constexpr.hpp>


### PR DESCRIPTION
This ensures consistent cache line sizes for HPX and dependent projects, even if different compiler versions are used