### PR TITLE
Fix kokkos hpx nvcc compilation

### DIFF
--- a/libs/core/execution/include/hpx/execution/algorithms/detail/partial_algorithm.hpp
+++ b/libs/core/execution/include/hpx/execution/algorithms/detail/partial_algorithm.hpp
@@ -27,7 +27,8 @@ namespace hpx::execution::experimental::detail {
     struct partial_algorithm_base<Tag, hpx::util::index_pack<Is...>, Ts...>
     {
     private:
-        HPX_NO_UNIQUE_ADDRESS hpx::util::member_pack_for<std::decay_t<Ts>...> ts;
+        HPX_NO_UNIQUE_ADDRESS hpx::util::member_pack_for<std::decay_t<Ts>...>
+            ts;
 
     public:
         template <typename... Us>

--- a/libs/core/execution/include/hpx/execution/algorithms/detail/partial_algorithm.hpp
+++ b/libs/core/execution/include/hpx/execution/algorithms/detail/partial_algorithm.hpp
@@ -27,7 +27,7 @@ namespace hpx::execution::experimental::detail {
     struct partial_algorithm_base<Tag, hpx::util::index_pack<Is...>, Ts...>
     {
     private:
-        HPX_NO_UNIQUE_ADDRESS hpx::util::member_pack_for<Ts...> ts;
+        HPX_NO_UNIQUE_ADDRESS hpx::util::member_pack_for<std::decay_t<Ts>...> ts;
 
     public:
         template <typename... Us>

--- a/libs/core/execution/include/hpx/execution/algorithms/split.hpp
+++ b/libs/core/execution/include/hpx/execution/algorithms/split.hpp
@@ -57,7 +57,7 @@ namespace hpx::execution::experimental {
         template <typename Receiver>
         struct error_visitor
         {
-            HPX_NO_UNIQUE_ADDRESS std::decay_t<Receiver> receiver;
+            HPX_NO_UNIQUE_ADDRESS std::decay_t<Receiver>& receiver;
 
             template <typename Error>
             void operator()(Error const& error) noexcept
@@ -71,7 +71,7 @@ namespace hpx::execution::experimental {
         template <typename Receiver>
         struct value_visitor
         {
-            HPX_NO_UNIQUE_ADDRESS std::decay_t<Receiver> receiver;
+            HPX_NO_UNIQUE_ADDRESS std::decay_t<Receiver>& receiver;
 
             template <typename Ts>
             void operator()(Ts const& ts) noexcept
@@ -286,15 +286,13 @@ namespace hpx::execution::experimental {
 
                     void operator()(error_type const& error)
                     {
-                        hpx::visit(error_visitor<Receiver>{HPX_FORWARD(
-                                       Receiver, receiver)},
+                        hpx::visit(error_visitor<Receiver>{receiver},
                             error);
                     }
 
                     void operator()(value_type const& ts)
                     {
-                        hpx::visit(value_visitor<Receiver>{HPX_FORWARD(
-                                       Receiver, receiver)},
+                        hpx::visit(value_visitor<Receiver>{receiver},
                             ts);
                     }
                 };

--- a/libs/core/execution/include/hpx/execution/algorithms/split.hpp
+++ b/libs/core/execution/include/hpx/execution/algorithms/split.hpp
@@ -286,14 +286,12 @@ namespace hpx::execution::experimental {
 
                     void operator()(error_type const& error)
                     {
-                        hpx::visit(error_visitor<Receiver>{receiver},
-                            error);
+                        hpx::visit(error_visitor<Receiver>{receiver}, error);
                     }
 
                     void operator()(value_type const& ts)
                     {
-                        hpx::visit(value_visitor<Receiver>{receiver},
-                            ts);
+                        hpx::visit(value_visitor<Receiver>{receiver}, ts);
                     }
                 };
 


### PR DESCRIPTION
With CUDA 12.3 nvcc does not outright crash anymore when compiling sender-receiver code and with #6452 the HPX sender-receiver examples compile and work again with nvcc after fixing some compilation errors.

The last remaining problem related to this was to compile the Kokkos HPX execution space (using sender-receivers internally) with nvcc: Here we still got a few compilation problems such as:
- ``` member_pack.hpp(143): error: function returning function is not allowed ```
- ```split.hpp:289:38: error: use of deleted function ‘hpx::execution::experimental::detail::any_receiver<Ts>::any_receiver(const hpx::execution::experimental::detail::any_receiver<Ts>&) [with Ts = {}]’```

This PR addresses these issues!

By itself, this PR is not quite enough to make the HPX execution space compile with nvcc, we still need one more change within Kokkos itself. However, this PR resolves all issues on the HPX side, the rest (some small template deduction stuff) will consequently be added as a Kokkos PR.

Pinging @msimberg as he came up with the solution, I was merely the one reporting the problem and testing the fixes!