### PR TITLE
Fix crash in get_executable_filename on FreeBSD

### DIFF
--- a/libs/core/prefix/src/find_prefix.cpp
+++ b/libs/core/prefix/src/find_prefix.cpp
@@ -242,7 +242,7 @@ namespace hpx::util {
         {
             std::vector<char> buf(cb);
             sysctl(mib, 4, &buf[0], &cb, nullptr, 0);
-            std::copy(&buf[0], &buf[cb], std::back_inserter(r));
+            std::copy(buf.begin(), buf.end(), std::back_inserter(r));
         }
 
 #else


### PR DESCRIPTION
The std::vector object needs to have the element allocated in order to take its address.

