### PR TITLE
Include Boost as CMake subproject

### DIFF
--- a/.github/workflows/macos_debug_fetch_boost.yml
+++ b/.github/workflows/macos_debug_fetch_boost.yml
@@ -73,4 +73,5 @@ jobs:
           tests.unit.threads.distributed.tcp.thread_stacksize|\
           tests.unit.topology.numa_allocator|\
           tests.unit.modules.runtime_components.distributed.tcp.migrate_polymorphic_component|\
-          tests.unit.modules.executors.limiting_executor"
+          tests.unit.modules.executors.limiting_executor|"
+          "build_dir_targets_test"

--- a/.github/workflows/macos_debug_fetch_boost.yml
+++ b/.github/workflows/macos_debug_fetch_boost.yml
@@ -32,7 +32,8 @@ jobs:
               -DHPX_WITH_EXAMPLES=ON \
               -DHPX_WITH_TESTS=ON \
               -DHPX_WITH_TESTS_MAX_THREADS_PER_LOCALITY=2 \
-              -DHPX_WITH_CHECK_MODULE_DEPENDENCIES=On
+              -DHPX_WITH_CHECK_MODULE_DEPENDENCIES=On \
+              -DHPX_WITH_TESTS_EXTERNAL_BUILD=Off
     - name: Build
       shell: bash
       run: |
@@ -73,5 +74,4 @@ jobs:
           tests.unit.threads.distributed.tcp.thread_stacksize|\
           tests.unit.topology.numa_allocator|\
           tests.unit.modules.runtime_components.distributed.tcp.migrate_polymorphic_component|\
-          tests.unit.modules.executors.limiting_executor|"
-          "build_dir_targets_test"
+          tests.unit.modules.executors.limiting_executor"

--- a/.github/workflows/windows_clang_debug.yml
+++ b/.github/workflows/windows_clang_debug.yml
@@ -22,7 +22,7 @@ jobs:
       run: |
         md C:\projects
         $client = new-object System.Net.WebClient
-        $client.DownloadFile("https://rostam.cct.lsu.edu/download/builder/vcpkg-export-hpx-dependencies-2022.7z","C:\projects\vcpkg-export-hpx-dependencies.7z")
+        $client.DownloadFile("https://rostam.cct.lsu.edu/download/builder/vcpkg-export-hpx-dependencies-2024.7z","C:\projects\vcpkg-export-hpx-dependencies.7z")
         7z x C:\projects\vcpkg-export-hpx-dependencies.7z -y -oC:\projects\vcpkg
     - name: Configure
       shell: bash

--- a/.github/workflows/windows_clang_release.yml
+++ b/.github/workflows/windows_clang_release.yml
@@ -22,7 +22,7 @@ jobs:
       run: |
         md C:\projects
         $client = new-object System.Net.WebClient
-        $client.DownloadFile("https://rostam.cct.lsu.edu/download/builder/vcpkg-export-hpx-dependencies-2022.7z","C:\projects\vcpkg-export-hpx-dependencies.7z")
+        $client.DownloadFile("https://rostam.cct.lsu.edu/download/builder/vcpkg-export-hpx-dependencies-2024.7z","C:\projects\vcpkg-export-hpx-dependencies.7z")
         7z x C:\projects\vcpkg-export-hpx-dependencies.7z -y -oC:\projects\vcpkg
     - name: Configure
       shell: bash

--- a/.github/workflows/windows_debug_vs2019.yml
+++ b/.github/workflows/windows_debug_vs2019.yml
@@ -22,7 +22,7 @@ jobs:
       run: |
         md C:\projects
         $client = new-object System.Net.WebClient
-        $client.DownloadFile("https://rostam.cct.lsu.edu/download/builder/vcpkg-export-hpx-dependencies-2022.7z","C:\projects\vcpkg-export-hpx-dependencies.7z")
+        $client.DownloadFile("https://rostam.cct.lsu.edu/download/builder/vcpkg-export-hpx-dependencies-2024.7z","C:\projects\vcpkg-export-hpx-dependencies.7z")
         7z x C:\projects\vcpkg-export-hpx-dependencies.7z -y -oC:\projects\vcpkg
     - name: Configure
       shell: bash

--- a/.github/workflows/windows_debug_vs2022.yml
+++ b/.github/workflows/windows_debug_vs2022.yml
@@ -22,7 +22,7 @@ jobs:
       run: |
         md C:\projects
         $client = new-object System.Net.WebClient
-        $client.DownloadFile("https://rostam.cct.lsu.edu/download/builder/vcpkg-export-hpx-dependencies-2022.7z","C:\projects\vcpkg-export-hpx-dependencies.7z")
+        $client.DownloadFile("https://rostam.cct.lsu.edu/download/builder/vcpkg-export-hpx-dependencies-2024.7z","C:\projects\vcpkg-export-hpx-dependencies.7z")
         7z x C:\projects\vcpkg-export-hpx-dependencies.7z -y -oC:\projects\vcpkg
     - name: Configure
       shell: bash

--- a/.github/workflows/windows_debug_vs2022_fetch_boost.yml
+++ b/.github/workflows/windows_debug_vs2022_fetch_boost.yml
@@ -11,7 +11,7 @@ on: [pull_request]
 jobs:
   build:
     runs-on: windows-latest
-    
+
     steps:
       - uses: actions/checkout@v4
       - uses: jwlawson/actions-setup-cmake@v2.0
@@ -21,7 +21,7 @@ jobs:
         run: |
           md C:\projects
           $client = new-object System.Net.WebClient
-          $client.DownloadFile("https://rostam.cct.lsu.edu/download/builder/vcpkg-export-hpx-dependencies-2022.7z","C:\projects\vcpkg-export-hpx-dependencies.7z")
+          $client.DownloadFile("https://rostam.cct.lsu.edu/download/builder/vcpkg-export-hpx-dependencies-2024.7z","C:\projects\vcpkg-export-hpx-dependencies.7z")
           7z x C:\projects\vcpkg-export-hpx-dependencies.7z -y -oC:\projects\vcpkg
       - name: Configure
         shell: bash

--- a/.github/workflows/windows_debug_vs2022_fetch_hwloc.yml
+++ b/.github/workflows/windows_debug_vs2022_fetch_hwloc.yml
@@ -22,7 +22,7 @@ jobs:
       run: |
         md C:\projects
         $client = new-object System.Net.WebClient
-        $client.DownloadFile("https://rostam.cct.lsu.edu/download/builder/vcpkg-export-hpx-dependencies-2022.7z","C:\projects\vcpkg-export-hpx-dependencies.7z")
+        $client.DownloadFile("https://rostam.cct.lsu.edu/download/builder/vcpkg-export-hpx-dependencies-2024.7z","C:\projects\vcpkg-export-hpx-dependencies.7z")
         7z x C:\projects\vcpkg-export-hpx-dependencies.7z -y -oC:\projects\vcpkg
     - name: Configure
       shell: bash

--- a/.github/workflows/windows_release_2019.yml
+++ b/.github/workflows/windows_release_2019.yml
@@ -21,7 +21,7 @@ jobs:
       run: |
         md C:\projects
         $client = new-object System.Net.WebClient
-        $client.DownloadFile("https://rostam.cct.lsu.edu/download/builder/vcpkg-export-hpx-dependencies-2022.7z","C:\projects\vcpkg-export-hpx-dependencies.7z")
+        $client.DownloadFile("https://rostam.cct.lsu.edu/download/builder/vcpkg-export-hpx-dependencies-2024.7z","C:\projects\vcpkg-export-hpx-dependencies.7z")
         7z x C:\projects\vcpkg-export-hpx-dependencies.7z -y -oC:\projects\vcpkg
     - name: Configure
       shell: bash

--- a/.github/workflows/windows_release_2022.yml
+++ b/.github/workflows/windows_release_2022.yml
@@ -21,7 +21,7 @@ jobs:
       run: |
         md C:\projects
         $client = new-object System.Net.WebClient
-        $client.DownloadFile("https://rostam.cct.lsu.edu/download/builder/vcpkg-export-hpx-dependencies-2022.7z","C:\projects\vcpkg-export-hpx-dependencies.7z")
+        $client.DownloadFile("https://rostam.cct.lsu.edu/download/builder/vcpkg-export-hpx-dependencies-2024.7z","C:\projects\vcpkg-export-hpx-dependencies.7z")
         7z x C:\projects\vcpkg-export-hpx-dependencies.7z -y -oC:\projects\vcpkg
     - name: Configure
       shell: bash

--- a/.github/workflows/windows_release_static.yml
+++ b/.github/workflows/windows_release_static.yml
@@ -22,7 +22,7 @@ jobs:
       run: |
         md C:\projects
         $client = new-object System.Net.WebClient
-        $client.DownloadFile("https://rostam.cct.lsu.edu/download/builder/vcpkg-export-hpx-dependencies-2022.7z","C:\projects\vcpkg-export-hpx-dependencies.7z")
+        $client.DownloadFile("https://rostam.cct.lsu.edu/download/builder/vcpkg-export-hpx-dependencies-2024.7z","C:\projects\vcpkg-export-hpx-dependencies.7z")
         7z x C:\projects\vcpkg-export-hpx-dependencies.7z -y -oC:\projects\vcpkg
     - name: Configure
       shell: bash

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2324,7 +2324,7 @@ endif()
 
 if(HPX_WITH_GENERIC_CONTEXT_COROUTINES)
   # Check if we can use generic coroutine contexts without any problems
-  if(NOT Boost_CONTEXT_FOUND)
+  if(NOT (Boost_CONTEXT_FOUND OR TARGET Boost::context))
     hpx_error(
       "The usage of Boost.Context was selected but Boost.Context was not found."
     )

--- a/cmake/HPX_GeneratePackage.cmake
+++ b/cmake/HPX_GeneratePackage.cmake
@@ -61,6 +61,7 @@ install(
 )
 
 # Install dir
+set(HPX_CONFIG_IS_INSTALL ON)
 configure_file(
   cmake/templates/${HPX_PACKAGE_NAME}Config.cmake.in
   "${PROJECT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/${HPX_PACKAGE_NAME}Config.cmake"
@@ -76,6 +77,7 @@ if(HPX_WITH_PKGCONFIG)
 endif()
 
 # Build dir
+set(HPX_CONFIG_IS_INSTALL OFF)
 configure_file(
   cmake/templates/${HPX_PACKAGE_NAME}Config.cmake.in
   "${CMAKE_CURRENT_BINARY_DIR}/lib/cmake/${HPX_PACKAGE_NAME}/${HPX_PACKAGE_NAME}Config.cmake"
@@ -88,6 +90,7 @@ if(HPX_WITH_PKGCONFIG)
     cmake/templates/hpxcxx.in "${CMAKE_CURRENT_BINARY_DIR}/bin/hpxcxx" @ONLY
   )
 endif()
+unset(HPX_CONFIG_IS_INSTALL)
 
 # Configure macros for the install dir ...
 set(HPX_CMAKE_MODULE_PATH "\${CMAKE_CURRENT_LIST_DIR}")

--- a/cmake/HPX_GeneratePackageUtils.cmake
+++ b/cmake/HPX_GeneratePackageUtils.cmake
@@ -243,16 +243,21 @@ function(hpx_sanitize_usage_requirements property is_build)
 endfunction(hpx_sanitize_usage_requirements)
 
 function(hpx_filter_language_flags cflag_list)
-    set(_cflag_list "${${cflag_list}}")
-    # We are always in CXX, so replace conditional values with the values themselves
-    string(REGEX REPLACE "\\$<\\$<COMPILE_LANGUAGE:CXX>:([^>]*)>?" "\\1" _cflag_list "${_cflag_list}")
-    # Remove conditional values for other languages
-    string(REGEX REPLACE "\\$<\\$<COMPILE_LANGUAGE:[^>]*>:([^>]*)>?" "" _cflag_list "${_cflag_list}")
+  set(_cflag_list "${${cflag_list}}")
+  # We are always in CXX, so replace conditional values with the values
+  # themselves
+  string(REGEX REPLACE "\\$<\\$<COMPILE_LANGUAGE:CXX>:([^>]*)>?" "\\1"
+                       _cflag_list "${_cflag_list}"
+  )
+  # Remove conditional values for other languages
+  string(REGEX REPLACE "\\$<\\$<COMPILE_LANGUAGE:[^>]*>:([^>]*)>?" ""
+                       _cflag_list "${_cflag_list}"
+  )
 
-    set(${cflag_list}
-        ${_cflag_list}
-        PARENT_SCOPE
-    )
+  set(${cflag_list}
+      ${_cflag_list}
+      PARENT_SCOPE
+  )
 endfunction(hpx_filter_language_flags)
 
 # Append the corresponding (-D, -I) flags for the compilation
@@ -392,10 +397,6 @@ function(hpx_generate_pkgconfig_from_target target template is_build)
   )
 
   string(TOLOWER ${CMAKE_BUILD_TYPE} build_type)
-
-#   Print hpx_library_list and hpx_cflags_list
-    message(STATUS "hpx_library_list: ${hpx_library_list}")
-    message(STATUS "hpx_cflags_list: ${hpx_cflags_list}")
 
   configure_file(
     cmake/templates/${template}.pc.in

--- a/cmake/HPX_GeneratePackageUtils.cmake
+++ b/cmake/HPX_GeneratePackageUtils.cmake
@@ -242,16 +242,18 @@ function(hpx_sanitize_usage_requirements property is_build)
 
 endfunction(hpx_sanitize_usage_requirements)
 
-function(hpx_filter_cuda_flags cflag_list)
-  set(_cflag_list "${${cflag_list}}")
-  string(REGEX REPLACE "\\$<\\$<COMPILE_LANGUAGE:CUDA>:[^>]*>;?" "" _cflag_list
-                       "${_cflag_list}"
-  )
-  set(${cflag_list}
-      ${_cflag_list}
-      PARENT_SCOPE
-  )
-endfunction(hpx_filter_cuda_flags)
+function(hpx_filter_language_flags cflag_list)
+    set(_cflag_list "${${cflag_list}}")
+    # We are always in CXX, so replace conditional values with the values themselves
+    string(REGEX REPLACE "\\$<\\$<COMPILE_LANGUAGE:CXX>:([^>]*)>?" "\\1" _cflag_list "${_cflag_list}")
+    # Remove conditional values for other languages
+    string(REGEX REPLACE "\\$<\\$<COMPILE_LANGUAGE:[^>]*>:([^>]*)>?" "" _cflag_list "${_cflag_list}")
+
+    set(${cflag_list}
+        ${_cflag_list}
+        PARENT_SCOPE
+    )
+endfunction(hpx_filter_language_flags)
 
 # Append the corresponding (-D, -I) flags for the compilation
 function(
@@ -383,13 +385,17 @@ function(hpx_generate_pkgconfig_from_target target template is_build)
     hpx_compile_definitions hpx_compile_options hpx_pic_option
     hpx_include_directories hpx_system_include_directories hpx_cflags_list
   )
-  # Cannot generate one file per language yet so filter out cuda
-  hpx_filter_cuda_flags(hpx_cflags_list)
+  # Generator expressions that depend on language must be filtered out
+  hpx_filter_language_flags(hpx_cflags_list)
   hpx_construct_library_list(
     hpx_link_libraries hpx_link_options hpx_library_list
   )
 
   string(TOLOWER ${CMAKE_BUILD_TYPE} build_type)
+
+#   Print hpx_library_list and hpx_cflags_list
+    message(STATUS "hpx_library_list: ${hpx_library_list}")
+    message(STATUS "hpx_cflags_list: ${hpx_cflags_list}")
 
   configure_file(
     cmake/templates/${template}.pc.in

--- a/cmake/HPX_SetupBoost.cmake
+++ b/cmake/HPX_SetupBoost.cmake
@@ -49,7 +49,7 @@ if(NOT TARGET hpx_dependencies_boost)
 
     find_package(
       Boost ${Boost_MINIMUM_VERSION} NO_POLICY_SCOPE REQUIRED
-      COMPONENTS ${__boost_libraries} HINTS ${HPX_BOOST_ROOT}
+      COMPONENTS ${__boost_libraries} HINTS ${HPX_BOOST_ROOT} $ENV{BOOST_ROOT}
     )
 
     add_library(hpx_dependencies_boost INTERFACE IMPORTED)
@@ -82,7 +82,8 @@ if(NOT TARGET hpx_dependencies_boost)
     )
 
     # Need to explicitly list header-only dependencies, since Cmake-Boost has
-    # installs each library's headers individually, as opposed to b2-built Boost.
+    # installs each library's headers individually, as opposed to b2-built
+    # Boost.
     set(__boost_libraries
         ${__boost_libraries}
         accumulators

--- a/cmake/HPX_SetupBoost.cmake
+++ b/cmake/HPX_SetupBoost.cmake
@@ -9,13 +9,12 @@
 
 # In case find_package(HPX) is called multiple times
 if(NOT TARGET hpx_dependencies_boost)
-  # We first try to find the required minimum set of Boost libraries. This will
-  # also give us the version of the found boost installation
   if(HPX_WITH_STATIC_LINKING)
     set(Boost_USE_STATIC_LIBS ON)
   endif()
 
-  # set(__boost_libraries disable_autolinking)
+  set(__boost_libraries "")
+
   if(HPX_PARCELPORT_LIBFABRIC_WITH_LOGGING
      OR HPX_PARCELPORT_LIBFABRIC_WITH_DEV_MODE
   )
@@ -78,11 +77,11 @@ if(NOT TARGET hpx_dependencies_boost)
       Boost
       URL https://github.com/boostorg/boost/releases/download/boost-${HPX_WITH_BOOST_VERSION}/boost-${HPX_WITH_BOOST_VERSION}-cmake.tar.xz
       TLS_VERIFY true
-      DOWNLOAD_EXTRACT_TIMESTAMP true
+      DOWNLOAD_EXTRACT_TIMESTAMP true SYSTEM
     )
 
-    # Need to explicitly list header-only dependencies, since Cmake-Boost has
-    # installs each library's headers individually, as opposed to b2-built
+    # Also need to explicitly list header-only dependencies, since Cmake-Boost
+    # has installs each library's headers individually, as opposed to b2-built
     # Boost.
     set(__boost_libraries
         ${__boost_libraries}

--- a/cmake/HPX_SetupBoost.cmake
+++ b/cmake/HPX_SetupBoost.cmake
@@ -1,3 +1,4 @@
+# Copyright (c) 2024 Panos Syskakis
 # Copyright (c) 2018 Christopher Hinz
 # Copyright (c) 2014 Thomas Heller
 # Copyright (c) 2007-2024 The STE||AR-Group
@@ -5,70 +6,6 @@
 # SPDX-License-Identifier: BSL-1.0
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
-
-if(HPX_WITH_FETCH_BOOST)
-  set(HPX_WITH_BOOST_VERSION "1.84.0")
-  hpx_info(
-    "HPX_WITH_FETCH_BOOST=${HPX_WITH_FETCH_BOOST}, Boost v${HPX_WITH_BOOST_VERSION} will be fetched using CMake's FetchContent"
-  )
-  include(FetchContent)
-  fetchcontent_declare(
-    Boost
-    URL https://github.com/boostorg/boost/releases/download/boost-${HPX_WITH_BOOST_VERSION}/boost-${HPX_WITH_BOOST_VERSION}.tar.gz
-    TLS_VERIFY true
-    DOWNLOAD_EXTRACT_TIMESTAMP true
-  )
-  fetchcontent_populate(Boost)
-  set(HPX_WITH_BUILD_FETCHED_BOOST
-      "Execute process"
-      CACHE STRING "Used by command line tool to build fetched Boost"
-  )
-  set(HPX_WITH_BUILD_FETCHED_BOOST_CHECK
-      ""
-      CACHE
-        STRING
-        "for internal use only, do not modify. Checks if fetched Boost is built"
-  )
-
-  if(NOT HPX_WITH_BUILD_FETCHED_BOOST STREQUAL
-     HPX_WITH_BUILD_FETCHED_BOOST_CHECK
-  )
-    if(WIN32)
-      execute_process(
-        COMMAND
-          cmd /C
-          "cd ${CMAKE_BINARY_DIR}\\_deps\\boost-src && .\\bootstrap.bat && .\\b2 headers cxxflags=/std:c++${HPX_CXX_STANDARD}"
-      )
-    elseif(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
-      execute_process(
-        COMMAND
-          sh -c
-          "cd ${CMAKE_BINARY_DIR}/_deps/boost-src && ./bootstrap.sh --prefix=${CMAKE_BINARY_DIR}/_deps/boost-installed && ./b2 && ./b2 install --prefix=${CMAKE_BINARY_DIR}/_deps/boost-installed cxxflags=--std=c++${HPX_CXX_STANDARD}"
-      )
-    else()
-      execute_process(
-        COMMAND
-          sh -c
-          "cd ${CMAKE_BINARY_DIR}/_deps/boost-src && ./bootstrap.sh && ./b2 headers cxxflags=--std=c++${HPX_CXX_STANDARD}"
-      )
-    endif()
-    set(HPX_WITH_BUILD_FETCHED_BOOST_CHECK
-        ${HPX_WITH_BUILD_FETCHED_BOOST}
-        CACHE
-          INTERNAL
-          "for internal use only, do not modify. Checks if fetched Boost is built"
-    )
-  endif()
-
-  set(Boost_DIR
-      "${CMAKE_BINARY_DIR}/_deps/boost-src"
-      CACHE INTERNAL ""
-  )
-  set(Boost_INCLUDE_DIR
-      "${CMAKE_BINARY_DIR}/_deps/boost-src"
-      CACHE INTERNAL ""
-  )
-endif()
 
 # In case find_package(HPX) is called multiple times
 if(NOT TARGET hpx_dependencies_boost)
@@ -78,6 +15,7 @@ if(NOT TARGET hpx_dependencies_boost)
     set(Boost_USE_STATIC_LIBS ON)
   endif()
 
+<<<<<<< HEAD
   # Add additional version to recognize
   # cmake-format: off
   set(Boost_ADDITIONAL_VERSIONS
@@ -117,6 +55,16 @@ if(NOT TARGET hpx_dependencies_boost)
   endif()
 
   set(__boost_libraries "")
+=======
+  # set(__boost_libraries disable_autolinking)
+>>>>>>> 8d8b4e6456 (Fetch Boost as a CMake subproject)
+  if(HPX_PARCELPORT_LIBFABRIC_WITH_LOGGING
+     OR HPX_PARCELPORT_LIBFABRIC_WITH_DEV_MODE
+  )
+    set(__boost_libraries ${__boost_libraries} log log_setup date_time chrono
+                          thread
+    )
+  endif()
 
   if(HPX_WITH_GENERIC_CONTEXT_COROUTINES)
     # if context is needed, we should still link with boost thread and chrono
@@ -134,15 +82,98 @@ if(NOT TARGET hpx_dependencies_boost)
     unset(BOOST_ROOT CACHE)
   endif()
 
-  find_package(
-    Boost ${Boost_MINIMUM_VERSION} NO_POLICY_SCOPE MODULE REQUIRED
-    COMPONENTS ${__boost_libraries}
-  )
-
-  if(NOT Boost_FOUND)
-    hpx_error(
-      "Could not find Boost. Please set Boost_ROOT to point to your Boost installation."
+  if(NOT HPX_WITH_FETCH_BOOST)
+    set(Boost_MINIMUM_VERSION
+        "1.71"
+        CACHE INTERNAL "1.71" FORCE
     )
+
+    find_package(
+      Boost ${Boost_MINIMUM_VERSION} NO_POLICY_SCOPE MODULE REQUIRED
+      COMPONENTS ${__boost_libraries}
+    )
+
+    add_library(hpx_dependencies_boost INTERFACE IMPORTED)
+
+    target_link_libraries(hpx_dependencies_boost INTERFACE Boost::boost)
+
+    foreach(__boost_library ${__boost_libraries})
+      target_link_libraries(
+        hpx_dependencies_boost INTERFACE Boost::${__boost_library}
+      )
+    endforeach()
+
+  elseif(NOT TARGET Boost::boost AND NOT HPX_FIND_PACKAGE)
+    # set(HPX_WITH_BOOST_VERSION "1.84.0")
+    # hpx_info(
+    #   "HPX_WITH_FETCH_BOOST=${HPX_WITH_FETCH_BOOST}, Boost v${HPX_WITH_BOOST_VERSION} will be fetched using CMake's FetchContent"
+    # )
+    include(FetchContent)
+    fetchcontent_declare(
+      Boost
+      URL https://github.com/boostorg/boost/releases/download/boost-1.85.0/boost-1.85.0-cmake.tar.gz
+      TLS_VERIFY true
+      DOWNLOAD_EXTRACT_TIMESTAMP true
+    )
+
+    set(BOOST_INCLUDE_LIBRARIES ${__boost_libraries})
+    set(BOOST_SKIP_INSTALL_RULES OFF)
+
+    # Use Populate + add_subdirectory instead of MakeAvailable, as we need
+    # EXCLUDE_FROM_ALL so that we only configure the boost libraries we need
+    fetchcontent_getproperties(Boost)
+    if(NOT boost_POPULATED)
+      fetchcontent_populate(Boost)
+      add_subdirectory(${boost_SOURCE_DIR} ${boost_BINARY_DIR} EXCLUDE_FROM_ALL)
+    endif()
+
+    set(__boost_libraries
+        ${__boost_libraries}
+        accumulators
+        bind
+        config
+        exception
+        filesystem
+        functional
+        fusion
+        iostreams
+        log
+        optional
+        parameter
+        phoenix
+        regex
+        spirit
+        variant
+    )
+    list(TRANSFORM __boost_libraries
+         PREPEND "boost_" OUTPUT_VARIABLE __boost_libraries_prefixed
+    )
+
+    add_library(hpx_dependencies_boost INTERFACE)
+
+    target_link_libraries(
+      hpx_dependencies_boost INTERFACE ${__boost_libraries_prefixed}
+    )
+
+    install(
+      TARGETS hpx_dependencies_boost
+      EXPORT HPXBoostTarget
+      COMPONENT core
+    )
+
+    install(
+      EXPORT HPXBoostTarget
+      FILE HPXBoostTarget.cmake
+      NAMESPACE Boost::
+      DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${HPX_PACKAGE_NAME}
+    )
+
+    export(
+        TARGETS hpx_dependencies_boost
+        NAMESPACE Boost::
+        FILE "${CMAKE_CURRENT_BINARY_DIR}/lib/cmake/${HPX_PACKAGE_NAME}/HPXBoostTarget.cmake"
+      )
+
   endif()
 
   # We are assuming that there is only one Boost Root
@@ -155,15 +186,6 @@ if(NOT TARGET hpx_dependencies_boost)
   if(Boost_ROOT)
     file(TO_CMAKE_PATH ${Boost_ROOT} Boost_ROOT)
   endif()
-
-  add_library(hpx_dependencies_boost INTERFACE IMPORTED)
-
-  target_link_libraries(hpx_dependencies_boost INTERFACE Boost::boost)
-  foreach(__boost_library ${__boost_libraries})
-    target_link_libraries(
-      hpx_dependencies_boost INTERFACE Boost::${__boost_library}
-    )
-  endforeach()
 
   if(HPX_WITH_HIP AND Boost_VERSION VERSION_LESS 1.78)
     target_compile_definitions(
@@ -178,11 +200,10 @@ if(NOT TARGET hpx_dependencies_boost)
   if(NOT Boost_USE_STATIC_LIBS)
     hpx_add_config_cond_define(BOOST_ALL_DYN_LINK)
   endif()
+
   if(NOT MSVC)
     hpx_add_config_define(HPX_COROUTINE_NO_SEPARATE_CALL_SITES)
   endif()
+
   hpx_add_config_cond_define(BOOST_BIGINT_HAS_NATIVE_INT64)
-  target_link_libraries(
-    hpx_dependencies_boost INTERFACE Boost::disable_autolinking
-  )
 endif()

--- a/cmake/HPX_SetupBoostFilesystem.cmake
+++ b/cmake/HPX_SetupBoostFilesystem.cmake
@@ -7,7 +7,6 @@
 if(HPX_FILESYSTEM_WITH_BOOST_FILESYSTEM_COMPATIBILITY)
   # In case find_package(HPX) is called multiple times
   if(NOT TARGET Boost::filesystem)
-    hpx_set_cmake_policy(CMP0167 OLD) # use CMake's FindBoost for now
 
     find_package(
       Boost ${Boost_MINIMUM_VERSION} NO_POLICY_SCOPE MODULE

--- a/cmake/HPX_SetupBoostIostreams.cmake
+++ b/cmake/HPX_SetupBoostIostreams.cmake
@@ -9,7 +9,6 @@ if((HPX_WITH_COMPRESSION_BZIP2
     OR HPX_WITH_COMPRESSION_ZLIB)
    AND NOT TARGET Boost::iostreams
 )
-  hpx_set_cmake_policy(CMP0167 OLD) # use CMake's FindBoost for now
 
   find_package(
     Boost ${Boost_MINIMUM_VERSION} NO_POLICY_SCOPE MODULE COMPONENTS iostreams

--- a/cmake/HPX_SetupBoostRegex.cmake
+++ b/cmake/HPX_SetupBoostRegex.cmake
@@ -5,7 +5,6 @@
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 if(NOT TARGET Boost::regex)
-  hpx_set_cmake_policy(CMP0167 OLD) # use CMake's FindBoost for now
 
   find_package(
     Boost ${Boost_MINIMUM_VERSION} NO_POLICY_SCOPE MODULE COMPONENTS regex

--- a/cmake/templates/HPXConfig.cmake.in
+++ b/cmake/templates/HPXConfig.cmake.in
@@ -28,9 +28,8 @@ else()
   include(HPX_SetupAsio)
 endif()
 
-
-# Stdexec can be installed by HPX or externally installed. In the first case we use
-# exported targets, in the second we find Stdexec again using find_package.
+# Stdexec can be installed by HPX or externally installed. In the first case we
+# use exported targets, in the second we find Stdexec again using find_package.
 if(HPX_WITH_STDEXEC)
   if(HPX_WITH_FETCH_STDEXEC)
     include("${CMAKE_CURRENT_LIST_DIR}/HPXStdexecTarget.cmake")
@@ -39,8 +38,6 @@ if(HPX_WITH_STDEXEC)
     include(HPX_SetupStdexec)
   endif()
 endif()
-
-
 
 # NLohnmann JSON can be installed by HPX or externally installed. In the first
 # case we use exported targets, in the second we find JSON again using
@@ -93,8 +90,14 @@ if("${HPX_WITH_DATAPAR_BACKEND}" STREQUAL "SVE")
 endif()
 
 if(HPX_WITH_FETCH_BOOST)
-  # Boost has been installed alongside HPX
-  # Let HPX_SetupBoost find it
+  # Boost has been installed alongside HPX, let HPX_SetupBoost find it
+  if(NOT HPX_CONFIG_IS_INSTALL)
+    hpx_error(
+      "HPX_WITH_FETCH_BOOST=ON requires HPX to be installed after it is built.
+      Please execute the CMake install step (cmake --install) on your HPX build
+      directory, and link your project against the installed instance of HPX."
+    )
+  endif()
   set(HPX_BOOST_ROOT "${CMAKE_CURRENT_LIST_DIR}/../")
   include(HPX_SetupBoost)
   include(HPX_SetupBoostFilesystem)
@@ -105,7 +108,7 @@ else()
   # By default Boost_ROOT is set to HPX_BOOST_ROOT (not necessary for PAPI or
   # HWLOC cause we are specifying HPX_<lib>_ROOT as an HINT to find_package)
   if(NOT Boost_ROOT AND NOT "$ENV{BOOST_ROOT}")
-  set(Boost_ROOT ${HPX_BOOST_ROOT})
+    set(Boost_ROOT ${HPX_BOOST_ROOT})
   endif()
   include(HPX_SetupBoost)
   include(HPX_SetupBoostFilesystem)

--- a/cmake/templates/HPXConfig.cmake.in
+++ b/cmake/templates/HPXConfig.cmake.in
@@ -92,6 +92,26 @@ if("${HPX_WITH_DATAPAR_BACKEND}" STREQUAL "SVE")
   endif()
 endif()
 
+if(HPX_WITH_FETCH_BOOST)
+  # Boost has been installed alongside HPX
+  # Let HPX_SetupBoost find it
+  set(HPX_BOOST_ROOT "${CMAKE_CURRENT_LIST_DIR}/../")
+  include(HPX_SetupBoost)
+  include(HPX_SetupBoostFilesystem)
+  include(HPX_SetupBoostIostreams)
+else()
+  # Boost Separate boost targets to be unarily linked to some modules
+  set(HPX_BOOST_ROOT "@Boost_ROOT@")
+  # By default Boost_ROOT is set to HPX_BOOST_ROOT (not necessary for PAPI or
+  # HWLOC cause we are specifying HPX_<lib>_ROOT as an HINT to find_package)
+  if(NOT Boost_ROOT AND NOT "$ENV{BOOST_ROOT}")
+  set(Boost_ROOT ${HPX_BOOST_ROOT})
+  endif()
+  include(HPX_SetupBoost)
+  include(HPX_SetupBoostFilesystem)
+  include(HPX_SetupBoostIostreams)
+endif()
+
 include("${CMAKE_CURRENT_LIST_DIR}/HPXInternalTargets.cmake")
 include("${CMAKE_CURRENT_LIST_DIR}/HPXTargets.cmake")
 
@@ -156,17 +176,6 @@ endif()
 include(HPX_SetupAllocator)
 
 include(HPX_SetupThreads)
-
-# Boost Separate boost targets to be unarily linked to some modules
-set(HPX_BOOST_ROOT "@Boost_ROOT@")
-# By default Boost_ROOT is set to HPX_BOOST_ROOT (not necessary for PAPI or
-# HWLOC cause we are specifying HPX_<lib>_ROOT as an HINT to find_package)
-if(NOT Boost_ROOT AND NOT DEFINED ENV{BOOST_ROOT})
-  set(Boost_ROOT ${HPX_BOOST_ROOT})
-endif()
-include(HPX_SetupBoost)
-include(HPX_SetupBoostFilesystem)
-include(HPX_SetupBoostIostreams)
 
 # HIP
 include(HPX_SetupHIP)

--- a/cmake/templates/HPXMacros.cmake.in
+++ b/cmake/templates/HPXMacros.cmake.in
@@ -89,7 +89,7 @@ function(hpx_check_compiler_compatibility)
 endfunction()
 
 function(hpx_check_boost_compatibility)
-  if(HPX_IGNORE_BOOST_COMPATIBILITY)
+  if(HPX_IGNORE_BOOST_COMPATIBILITY OR HPX_WITH_FETCH_BOOST)
     return()
   endif()
   if(NOT DEFINED Boost_ROOT)


### PR DESCRIPTION
Draft PR for properly fetching and installing boost as a CMake subproject.
Still needs fixes, but I paused working on it since we need https://github.com/boostorg/cmake/pull/65 to move forward with this approach.

Can also move to using `find_package` Config mode, since Module mode (using `Find<PackageName>.cmake`) is being deprecated for Boost.