### PR TITLE
Adding optional handshakes to acknowledge the received data

### DIFF
--- a/.jenkins/lsu/env-clang-16.sh
+++ b/.jenkins/lsu/env-clang-16.sh
@@ -37,3 +37,6 @@ configure_extra_options+=" -DHPX_WITH_FETCH_EVE=ON"
 # Make sure HWLOC does not report 'cores'. This is purely an option to enable
 # testing the topology code under conditions close to those on FreeBSD.
 configure_extra_options+=" -DHPX_TOPOLOGY_WITH_ADDITIONAL_HWLOC_TESTING=ON"
+
+# enable additional handshaking in MPI parcelport
+configure_extra_options+=" -DHPX_WITH_TESTS_COMMAND_LINE=--hpx:ini=hpx.parcel.mpi.ack_handshake!=1"

--- a/.jenkins/lsu/env-gcc-12.sh
+++ b/.jenkins/lsu/env-gcc-12.sh
@@ -32,3 +32,6 @@ configure_extra_options+=" -DHPX_WITH_EVE_TAG=main"
 
 # The pwrapi library still needs to be set up properly on rostam
 # configure_extra_options+=" -DHPX_WITH_POWER_COUNTER=ON"
+
+# enable additional handshaking in MPI parcelport
+configure_extra_options+=" -DHPX_WITH_TESTS_COMMAND_LINE=--hpx:ini=hpx.parcel.mpi.ack_handshake!=1"

--- a/.jenkins/lsu/env-gcc-14.sh
+++ b/.jenkins/lsu/env-gcc-14.sh
@@ -32,3 +32,6 @@ configure_extra_options+=" -DHPX_WITH_EVE_TAG=main"
 
 # The pwrapi library still needs to be set up properly on rostam
 # configure_extra_options+=" -DHPX_WITH_POWER_COUNTER=ON"
+
+# enable additional handshaking in MPI parcelport
+configure_extra_options+=" -DHPX_WITH_TESTS_COMMAND_LINE=--hpx:ini=hpx.parcel.mpi.ack_handshake!=1"

--- a/libs/core/mpi_base/CMakeLists.txt
+++ b/libs/core/mpi_base/CMakeLists.txt
@@ -35,8 +35,8 @@ add_hpx_module(
   SOURCES ${mpi_base_sources}
   HEADERS ${mpi_base_headers}
   COMPAT_HEADERS ${mpi_base_compat_headers}
-  MODULE_DEPENDENCIES hpx_format hpx_logging hpx_runtime_configuration
-                      hpx_string_util hpx_util
+  MODULE_DEPENDENCIES hpx_errors hpx_format hpx_logging
+                      hpx_runtime_configuration hpx_string_util hpx_util
   DEPENDENCIES ${additional_dependencies}
   CMAKE_SUBDIRS examples tests
 )

--- a/libs/core/mpi_base/include/hpx/mpi_base/mpi_environment.hpp
+++ b/libs/core/mpi_base/include/hpx/mpi_base/mpi_environment.hpp
@@ -86,7 +86,16 @@ namespace hpx::util {
 
         using mutex_type = hpx::spinlock;
 
+        static void check_mpi_error(
+            scoped_lock& l, hpx::source_location const& sl, int error);
+        static void check_mpi_error(
+            scoped_try_lock& l, hpx::source_location const& sl, int error);
+
+        // The highest order bit is used for acknowledgement messages
         static int MPI_MAX_TAG;
+
+        constexpr static unsigned int MPI_ACK_MASK = 0xC000;
+        constexpr static unsigned int MPI_ACK_TAG = 0x4000;
 
     private:
         static mutex_type mtx_;

--- a/libs/full/parcelport_mpi/include/hpx/parcelport_mpi/header.hpp
+++ b/libs/full/parcelport_mpi/include/hpx/parcelport_mpi/header.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2013-2023 Hartmut Kaiser
+//  Copyright (c) 2013-2024 Hartmut Kaiser
 //  Copyright (c) 2013-2015 Thomas Heller
 //  Copyright (c)      2023 Jiakun Yan
 //
@@ -22,30 +22,33 @@
 #include <utility>
 
 namespace hpx::parcelset::policies::mpi {
+
     struct header
     {
         using value_type = int;
         enum data_pos
         {
-            // siguature for assert_valid
+            // signature for assert_valid
             pos_signature = 0,
             // tag
             pos_tag = 1 * sizeof(value_type),
+            // enable ack handshakes
+            pos_ack_handshakes = 2 * sizeof(value_type),
             // non-zero-copy chunk size
-            pos_numbytes_nonzero_copy = 2 * sizeof(value_type),
+            pos_numbytes_nonzero_copy = 3 * sizeof(value_type),
             // transmission chunk size
-            pos_numbytes_tchunk = 3 * sizeof(value_type),
+            pos_numbytes_tchunk = 4 * sizeof(value_type),
             // how many bytes in total (including zero-copy and non-zero-copy chunks)
-            pos_numbytes = 4 * sizeof(value_type),
+            pos_numbytes = 5 * sizeof(value_type),
             // zero-copy chunk number
-            pos_numchunks_zero_copy = 5 * sizeof(value_type),
+            pos_numchunks_zero_copy = 6 * sizeof(value_type),
             // non-zero-copy chunk number
-            pos_numchunks_nonzero_copy = 6 * sizeof(value_type),
+            pos_numchunks_nonzero_copy = 7 * sizeof(value_type),
             // whether piggyback data
-            pos_piggy_back_flag_data = 7 * sizeof(value_type),
+            pos_piggy_back_flag_data = 8 * sizeof(value_type),
             // whether piggyback transmission chunk
-            pos_piggy_back_flag_tchunk = 7 * sizeof(value_type) + 1,
-            pos_piggy_back_address = 7 * sizeof(value_type) + 2
+            pos_piggy_back_flag_tchunk = 8 * sizeof(value_type) + 1,
+            pos_piggy_back_address = 8 * sizeof(value_type) + 2
         };
 
         template <typename buffer_type, typename ChunkType>
@@ -60,18 +63,21 @@ namespace hpx::parcelset::policies::mpi {
             {
                 current_header_size += buffer.data_.size();
             }
-            int num_zero_copy_chunks = buffer.num_chunks_.first;
-            [[maybe_unused]] int num_non_zero_copy_chunks =
+
+            int const num_zero_copy_chunks = buffer.num_chunks_.first;
+            [[maybe_unused]] int const num_non_zero_copy_chunks =
                 buffer.num_chunks_.second;
             if (num_zero_copy_chunks != 0)
             {
                 HPX_ASSERT(buffer.transmission_chunks_.size() ==
-                    size_t(num_zero_copy_chunks + num_non_zero_copy_chunks));
-                int tchunk_size =
+                    static_cast<size_t>(
+                        num_zero_copy_chunks + num_non_zero_copy_chunks));
+                int const tchunk_size =
                     static_cast<int>(buffer.transmission_chunks_.size() *
                         sizeof(typename parcel_buffer<buffer_type,
                             ChunkType>::transmission_chunk_type));
-                if (tchunk_size <= int(max_header_size - current_header_size))
+                if (tchunk_size <=
+                    static_cast<int>(max_header_size - current_header_size))
                 {
                     current_header_size += tchunk_size;
                 }
@@ -86,21 +92,22 @@ namespace hpx::parcelset::policies::mpi {
             HPX_ASSERT(max_header_size >= pos_piggy_back_address);
             data_ = header_buffer;
             memset(data_, 0, pos_piggy_back_address);
-            std::int64_t size = static_cast<std::int64_t>(buffer.data_.size());
-            std::int64_t numbytes =
+
+            std::int64_t const size =
+                static_cast<std::int64_t>(buffer.data_.size());
+            std::int64_t const numbytes =
                 static_cast<std::int64_t>(buffer.data_size_);
             HPX_ASSERT(size <= (std::numeric_limits<value_type>::max)());
             HPX_ASSERT(numbytes <= (std::numeric_limits<value_type>::max)());
-            int num_zero_copy_chunks = buffer.num_chunks_.first;
-            int num_non_zero_copy_chunks = buffer.num_chunks_.second;
+
+            int const num_zero_copy_chunks = buffer.num_chunks_.first;
+            int const num_non_zero_copy_chunks = buffer.num_chunks_.second;
 
             set(pos_signature, MAGIC_SIGNATURE);
             set(pos_numbytes_nonzero_copy, static_cast<value_type>(size));
             set(pos_numbytes, static_cast<value_type>(numbytes));
-            set(pos_numchunks_zero_copy,
-                static_cast<value_type>(num_zero_copy_chunks));
-            set(pos_numchunks_nonzero_copy,
-                static_cast<value_type>(num_non_zero_copy_chunks));
+            set(pos_numchunks_zero_copy, num_zero_copy_chunks);
+            set(pos_numchunks_nonzero_copy, num_non_zero_copy_chunks);
             data_[pos_piggy_back_flag_data] = 0;
             data_[pos_piggy_back_flag_tchunk] = 0;
 
@@ -112,16 +119,19 @@ namespace hpx::parcelset::policies::mpi {
                     &data_[current_header_size], &buffer.data_[0], size);
                 current_header_size += size;
             }
+
             if (num_zero_copy_chunks != 0)
             {
                 HPX_ASSERT(buffer.transmission_chunks_.size() ==
-                    size_t(num_zero_copy_chunks + num_non_zero_copy_chunks));
-                int tchunk_size =
+                    static_cast<size_t>(
+                        num_zero_copy_chunks + num_non_zero_copy_chunks));
+                int const tchunk_size =
                     static_cast<int>(buffer.transmission_chunks_.size() *
                         sizeof(typename parcel_buffer<buffer_type,
                             ChunkType>::transmission_chunk_type));
                 set(pos_numbytes_tchunk, static_cast<value_type>(tchunk_size));
-                if (tchunk_size <= int(max_header_size - current_header_size))
+                if (tchunk_size <=
+                    static_cast<int>(max_header_size - current_header_size))
                 {
                     data_[pos_piggy_back_flag_tchunk] = 1;
                     std::memcpy(&data_[current_header_size],
@@ -155,12 +165,12 @@ namespace hpx::parcelset::policies::mpi {
             HPX_ASSERT(valid());
         }
 
-        [[nodiscard]] char* data() noexcept
+        [[nodiscard]] char* data() const noexcept
         {
             return data_;
         }
 
-        [[nodiscard]] size_t size() noexcept
+        [[nodiscard]] size_t size() const noexcept
         {
             return pos_piggy_back_address + piggy_back_size();
         }
@@ -175,9 +185,19 @@ namespace hpx::parcelset::policies::mpi {
             set(pos_tag, static_cast<value_type>(tag));
         }
 
+        void set_ack_handshakes(bool enable_ack_handshakes) noexcept
+        {
+            set(pos_ack_handshakes, enable_ack_handshakes ? 1 : 0);
+        }
+
         [[nodiscard]] value_type get_tag() const noexcept
         {
             return get(pos_tag);
+        }
+
+        [[nodiscard]] value_type get_ack_handshakes() const noexcept
+        {
+            return get(pos_ack_handshakes);
         }
 
         [[nodiscard]] value_type numbytes_nonzero_copy() const noexcept
@@ -205,7 +225,7 @@ namespace hpx::parcelset::policies::mpi {
             return get(pos_numchunks_nonzero_copy);
         }
 
-        [[nodiscard]] constexpr char* piggy_back_address() noexcept
+        [[nodiscard]] constexpr char* piggy_back_address() const noexcept
         {
             if (data_[pos_piggy_back_flag_data] ||
                 data_[pos_piggy_back_flag_tchunk])
@@ -213,7 +233,7 @@ namespace hpx::parcelset::policies::mpi {
             return nullptr;
         }
 
-        [[nodiscard]] int piggy_back_size() noexcept
+        [[nodiscard]] int piggy_back_size() const noexcept
         {
             int result = 0;
             if (data_[pos_piggy_back_flag_data])
@@ -223,14 +243,14 @@ namespace hpx::parcelset::policies::mpi {
             return result;
         }
 
-        [[nodiscard]] constexpr char* piggy_back_data() noexcept
+        [[nodiscard]] constexpr char* piggy_back_data() const noexcept
         {
             if (data_[pos_piggy_back_flag_data])
                 return &data_[pos_piggy_back_address];
             return nullptr;
         }
 
-        [[nodiscard]] constexpr char* piggy_back_tchunk() noexcept
+        [[nodiscard]] constexpr char* piggy_back_tchunk() const noexcept
         {
             size_t current_header_size = pos_piggy_back_address;
             if (!data_[pos_piggy_back_flag_tchunk])

--- a/libs/full/parcelport_mpi/include/hpx/parcelport_mpi/receiver_connection.hpp
+++ b/libs/full/parcelport_mpi/include/hpx/parcelport_mpi/receiver_connection.hpp
@@ -1,5 +1,5 @@
 //  Copyright (c) 2014-2015 Thomas Heller
-//  Copyright (c) 2007-2023 Hartmut Kaiser
+//  Copyright (c) 2007-2024 Hartmut Kaiser
 //  Copyright (c)      2023 Jiakun Yan
 //
 //  SPDX-License-Identifier: BSL-1.0
@@ -32,41 +32,53 @@ namespace hpx::parcelset::policies::mpi {
     struct receiver_connection
     {
     private:
-        enum connection_state
+        enum class connection_state : std::uint8_t
         {
-            initialized,
-            rcvd_transmission_chunks,
-            rcvd_data,
-            rcvd_chunks,
+            initialized = 1,
+            rcvd_transmission_chunks = 2,
+            rcvd_data = 3,
+            rcvd_chunks = 4,
+
+            acked_transmission_chunks = 5,
+            acked_data = 6
         };
 
         using data_type = std::vector<char>;
         using buffer_type =
             parcel_buffer<data_type, serialization::serialization_chunk>;
 
+        constexpr int ack_tag() const noexcept
+        {
+            return static_cast<int>(tag_ | util::mpi_environment::MPI_ACK_TAG);
+        }
+
     public:
         receiver_connection(
-            int src, std::vector<char> header_buffer, Parcelport& pp) noexcept
-          : state_(initialized)
+            int src, std::vector<char> header_buffer, Parcelport& pp)
+          : state_(connection_state::initialized)
           , src_(src)
           , request_(MPI_REQUEST_NULL)
           , request_ptr_(nullptr)
           , chunks_idx_(0)
           , zero_copy_chunks_idx_(0)
+          , needs_ack_handshake_(false)
+          , ack_(0)
           , pp_(pp)
         {
             header header_ = header(header_buffer.data());
             header_.assert_valid();
+
 #if defined(HPX_HAVE_PARCELPORT_COUNTERS)
             parcelset::data_point& data = buffer_.data_point_;
             data.time_ = timer_.elapsed_nanoseconds();
             data.bytes_ = static_cast<std::size_t>(header_.numbytes());
 #endif
             tag_ = header_.get_tag();
+            needs_ack_handshake_ = header_.get_ack_handshakes();
+
             // decode data
             buffer_.data_.resize(header_.numbytes_nonzero_copy());
-            char* piggy_back_data = header_.piggy_back_data();
-            if (piggy_back_data)
+            if (char* piggy_back_data = header_.piggy_back_data())
             {
                 need_recv_data = false;
                 memcpy(buffer_.data_.data(), piggy_back_data,
@@ -76,29 +88,38 @@ namespace hpx::parcelset::policies::mpi {
             {
                 need_recv_data = true;
             }
+
             need_recv_tchunks = false;
             if (header_.num_zero_copy_chunks() != 0)
             {
                 // decode transmission chunk
-                int num_zero_copy_chunks = header_.num_zero_copy_chunks();
-                int num_non_zero_copy_chunks =
+                int const num_zero_copy_chunks = header_.num_zero_copy_chunks();
+                int const num_non_zero_copy_chunks =
                     header_.num_non_zero_copy_chunks();
                 buffer_.num_chunks_.first = num_zero_copy_chunks;
                 buffer_.num_chunks_.second = num_non_zero_copy_chunks;
+
                 auto& tchunks = buffer_.transmission_chunks_;
                 tchunks.resize(num_zero_copy_chunks + num_non_zero_copy_chunks);
-                int tchunks_length = static_cast<int>(tchunks.size() *
-                    sizeof(buffer_type::transmission_chunk_type));
-                char* piggy_back_tchunk = header_.piggy_back_tchunk();
-                if (piggy_back_tchunk)
+                if (char* piggy_back_tchunk = header_.piggy_back_tchunk())
                 {
-                    memcpy(static_cast<void*>(tchunks.data()),
-                        piggy_back_tchunk, tchunks_length);
+#if defined(HPX_GCC_VERSION) && !defined(HPX_CLANG_VERSION)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wclass-memaccess"
+#endif
+                    int const tchunks_length = static_cast<int>(tchunks.size() *
+                        sizeof(buffer_type::transmission_chunk_type));
+                    memcpy(tchunks.data(), piggy_back_tchunk, tchunks_length);
+
+#if defined(HPX_GCC_VERSION) && !defined(HPX_CLANG_VERSION)
+#pragma GCC diagnostic pop
+#endif
                 }
                 else
                 {
                     need_recv_tchunks = true;
                 }
+
                 // zero-copy chunks
                 buffer_.chunks_.resize(num_zero_copy_chunks);
                 if (!pp_.allow_zero_copy_receive_optimizations())
@@ -112,17 +133,23 @@ namespace hpx::parcelset::policies::mpi {
         {
             switch (state_)
             {
-            case initialized:
+            case connection_state::initialized:
                 return receive_transmission_chunks(num_thread);
 
-            case rcvd_transmission_chunks:
+            case connection_state::rcvd_transmission_chunks:
+                return ack_transmission_chunks(num_thread);
+
+            case connection_state::rcvd_data:
+                return ack_data(num_thread);
+
+            case connection_state::rcvd_chunks:
+                return done(num_thread);
+
+            case connection_state::acked_transmission_chunks:
                 return receive_data(num_thread);
 
-            case rcvd_data:
+            case connection_state::acked_data:
                 return receive_chunks(num_thread);
-
-            case rcvd_chunks:
-                return done(num_thread);
 
             default:
                 HPX_ASSERT(false);
@@ -136,54 +163,148 @@ namespace hpx::parcelset::policies::mpi {
             {
                 util::mpi_environment::scoped_lock l;
 
-                [[maybe_unused]] int const ret =
-                    MPI_Irecv(buffer_.transmission_chunks_.data(),
-                        static_cast<int>(buffer_.transmission_chunks_.size() *
-                            sizeof(buffer_type::transmission_chunk_type)),
-                        MPI_BYTE, src_, tag_,
-                        util::mpi_environment::communicator(), &request_);
-                HPX_ASSERT_LOCKED(l, ret == MPI_SUCCESS);
+                int const ret = MPI_Irecv(buffer_.transmission_chunks_.data(),
+                    static_cast<int>(buffer_.transmission_chunks_.size() *
+                        sizeof(buffer_type::transmission_chunk_type)),
+                    MPI_BYTE, src_, tag_, util::mpi_environment::communicator(),
+                    &request_);
+                util::mpi_environment::check_mpi_error(
+                    l, HPX_CURRENT_SOURCE_LOCATION(), ret);
 
                 request_ptr_ = &request_;
+
+                state_ = connection_state::rcvd_transmission_chunks;
+                return ack_transmission_chunks(num_thread);
             }
 
-            state_ = rcvd_transmission_chunks;
-
+            // no need to acknowledge the transmission chunks
+            state_ = connection_state::rcvd_transmission_chunks;
             return receive_data(num_thread);
         }
 
-        bool receive_data(std::size_t num_thread = -1)
+        constexpr bool need_ack_transmission_chunks() const noexcept
         {
+            return needs_ack_handshake_ && need_recv_tchunks;
+        }
+
+        bool ack_transmission_chunks(std::size_t num_thread = -1)
+        {
+            if (!need_ack_transmission_chunks())
+            {
+                return receive_data(num_thread);
+            }
+
+            HPX_ASSERT(state_ == connection_state::rcvd_transmission_chunks);
+
             if (!request_done())
             {
                 return false;
             }
+            HPX_ASSERT(request_ptr_ == nullptr);
+
+            {
+                util::mpi_environment::scoped_lock l;
+
+                ack_ = static_cast<char>(
+                    connection_state::acked_transmission_chunks);
+                int const ret =
+                    MPI_Isend(&ack_, sizeof(ack_), MPI_BYTE, src_, ack_tag(),
+                        util::mpi_environment::communicator(), &request_);
+                util::mpi_environment::check_mpi_error(
+                    l, HPX_CURRENT_SOURCE_LOCATION(), ret);
+
+                request_ptr_ = &request_;
+            }
+
+            state_ = connection_state::acked_transmission_chunks;
+            return receive_data(num_thread);
+        }
+
+        constexpr bool need_ack_data() const noexcept
+        {
+            return needs_ack_handshake_ && need_recv_data;
+        }
+
+        bool receive_data(std::size_t num_thread = -1)
+        {
+            HPX_ASSERT(
+                (!need_ack_transmission_chunks() &&
+                    state_ == connection_state::rcvd_transmission_chunks) ||
+                (need_ack_transmission_chunks() &&
+                    state_ == connection_state::acked_transmission_chunks));
+
+            if (!request_done())
+            {
+                return false;
+            }
+            HPX_ASSERT(request_ptr_ == nullptr);
 
             if (need_recv_data)
             {
                 util::mpi_environment::scoped_lock l;
 
-                [[maybe_unused]] int const ret = MPI_Irecv(buffer_.data_.data(),
+                int const ret = MPI_Irecv(buffer_.data_.data(),
                     static_cast<int>(buffer_.data_.size()), MPI_BYTE, src_,
                     tag_, util::mpi_environment::communicator(), &request_);
-                HPX_ASSERT_LOCKED(l, ret == MPI_SUCCESS);
+                util::mpi_environment::check_mpi_error(
+                    l, HPX_CURRENT_SOURCE_LOCATION(), ret);
+
+                request_ptr_ = &request_;
+
+                state_ = connection_state::rcvd_data;
+                return ack_data(num_thread);
+            }
+
+            // no need to acknowledge the data sent
+            state_ = connection_state::rcvd_data;
+            return receive_chunks(num_thread);
+        }
+
+        bool ack_data(std::size_t num_thread = -1)
+        {
+            if (!need_ack_data())
+            {
+                return receive_chunks(num_thread);
+            }
+
+            HPX_ASSERT(state_ == connection_state::rcvd_data);
+
+            if (!request_done())
+            {
+                return false;
+            }
+            HPX_ASSERT(request_ptr_ == nullptr);
+
+            {
+                util::mpi_environment::scoped_lock l;
+
+                ack_ = static_cast<char>(connection_state::acked_data);
+                int const ret =
+                    MPI_Isend(&ack_, sizeof(ack_), MPI_BYTE, src_, ack_tag(),
+                        util::mpi_environment::communicator(), &request_);
+                util::mpi_environment::check_mpi_error(
+                    l, HPX_CURRENT_SOURCE_LOCATION(), ret);
 
                 request_ptr_ = &request_;
             }
 
-            state_ = rcvd_data;
-
+            state_ = connection_state::acked_data;
             return receive_chunks(num_thread);
         }
 
         bool receive_chunks(std::size_t num_thread = -1)
         {
+            HPX_ASSERT(
+                (!need_ack_data() && state_ == connection_state::rcvd_data) ||
+                (need_ack_data() && state_ == connection_state::acked_data));
+
             if (pp_.allow_zero_copy_receive_optimizations())
             {
                 if (!request_done())
                 {
                     return false;
                 }
+                HPX_ASSERT(request_ptr_ == nullptr);
 
                 // handle zero-copy receive, this should be done on the first entry
                 // to receive_chunks only
@@ -191,18 +312,18 @@ namespace hpx::parcelset::policies::mpi {
                 {
                     HPX_ASSERT(zero_copy_chunks_idx_ == 0);
 
-                    auto const num_zero_copy_chunks = static_cast<std::size_t>(
-                        static_cast<std::uint32_t>(buffer_.num_chunks_.first));
+                    auto const num_zero_copy_chunks =
+                        static_cast<std::size_t>(buffer_.num_chunks_.first);
                     if (num_zero_copy_chunks != 0)
                     {
                         HPX_ASSERT(
                             buffer_.chunks_.size() == num_zero_copy_chunks);
 
                         // De-serialize the parcels such that all data but the
-                        // zero-copy chunks are in place. This de-serialization also
-                        // allocates all zero-chunk buffers and stores those in the
-                        // chunks array for the subsequent networking to place the
-                        // received data directly.
+                        // zero-copy chunks are in place. This de-serialization
+                        // also allocates all zero-chunk buffers and stores
+                        // those in the chunks array for the subsequent
+                        // networking to place the received data directly.
                         for (std::size_t i = 0; i != num_zero_copy_chunks; ++i)
                         {
                             auto const chunk_size = static_cast<std::size_t>(
@@ -230,6 +351,7 @@ namespace hpx::parcelset::policies::mpi {
                     {
                         return false;
                     }
+                    HPX_ASSERT(request_ptr_ == nullptr);
 
                     auto& c = buffer_.chunks_[chunks_idx_++];
                     if (c.type_ == serialization::chunk_type::chunk_type_index)
@@ -239,9 +361,9 @@ namespace hpx::parcelset::policies::mpi {
 
                     // the zero-copy chunks come first in the transmission_chunks_
                     // array
-                    auto const chunk_size = static_cast<std::size_t>(
+                    auto const chunk_size =
                         buffer_.transmission_chunks_[zero_copy_chunks_idx_++]
-                            .second);
+                            .second;
 
                     // the parcel de-serialization above should have allocated the
                     // correct amount of memory
@@ -253,10 +375,11 @@ namespace hpx::parcelset::policies::mpi {
                     {
                         util::mpi_environment::scoped_lock l;
 
-                        [[maybe_unused]] int const ret = MPI_Irecv(c.data(),
+                        int const ret = MPI_Irecv(c.data(),
                             static_cast<int>(chunk_size), MPI_BYTE, src_, tag_,
                             util::mpi_environment::communicator(), &request_);
-                        HPX_ASSERT_LOCKED(l, ret == MPI_SUCCESS);
+                        util::mpi_environment::check_mpi_error(
+                            l, HPX_CURRENT_SOURCE_LOCATION(), ret);
 
                         request_ptr_ = &request_;
                     }
@@ -275,6 +398,7 @@ namespace hpx::parcelset::policies::mpi {
                     {
                         return false;
                     }
+                    HPX_ASSERT(request_ptr_ == nullptr);
 
                     std::size_t const idx = chunks_idx_++;
                     std::size_t const chunk_size =
@@ -290,26 +414,30 @@ namespace hpx::parcelset::policies::mpi {
                     {
                         util::mpi_environment::scoped_lock l;
 
-                        [[maybe_unused]] int const ret = MPI_Irecv(c.data(),
+                        int const ret = MPI_Irecv(c.data(),
                             static_cast<int>(c.size()), MPI_BYTE, src_, tag_,
                             util::mpi_environment::communicator(), &request_);
-                        HPX_ASSERT_LOCKED(l, ret == MPI_SUCCESS);
+                        util::mpi_environment::check_mpi_error(
+                            l, HPX_CURRENT_SOURCE_LOCATION(), ret);
 
                         request_ptr_ = &request_;
                     }
                 }
             }
-            state_ = rcvd_chunks;
 
+            state_ = connection_state::rcvd_chunks;
             return done(num_thread);
         }
 
         bool done(std::size_t num_thread = -1) noexcept
         {
+            HPX_ASSERT(state_ == connection_state::rcvd_chunks);
+
             if (!request_done())
             {
                 return false;
             }
+            HPX_ASSERT(request_ptr_ == nullptr);
 
 #if defined(HPX_HAVE_PARCELPORT_COUNTERS)
             parcelset::data_point& data = buffer_.data_point_;
@@ -350,9 +478,10 @@ namespace hpx::parcelset::policies::mpi {
             }
 
             int completed = 0;
-            [[maybe_unused]] int const ret =
+            int const ret =
                 MPI_Test(request_ptr_, &completed, MPI_STATUS_IGNORE);
-            HPX_ASSERT_LOCKED(l, ret == MPI_SUCCESS);
+            util::mpi_environment::check_mpi_error(
+                l, HPX_CURRENT_SOURCE_LOCATION(), ret);
 
             if (completed)
             {
@@ -377,6 +506,9 @@ namespace hpx::parcelset::policies::mpi {
         MPI_Request* request_ptr_;
         std::size_t chunks_idx_;
         std::size_t zero_copy_chunks_idx_;
+
+        bool needs_ack_handshake_;
+        char ack_;
 
         Parcelport& pp_;
 

--- a/libs/full/parcelport_mpi/include/hpx/parcelport_mpi/sender.hpp
+++ b/libs/full/parcelport_mpi/include/hpx/parcelport_mpi/sender.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2021 Hartmut Kaiser
+//  Copyright (c) 2007-2024 Hartmut Kaiser
 //  Copyright (c) 2014-2015 Thomas Heller
 //  Copyright (c)      2023 Jiakun Yan
 //
@@ -35,11 +35,13 @@ namespace hpx::parcelset::policies::mpi {
         using connection_ptr = std::shared_ptr<connection_type>;
         using connection_list = std::deque<connection_ptr>;
 
-        void run() noexcept {}
+        constexpr static void run() noexcept {}
 
-        connection_ptr create_connection(int dest, parcelset::parcelport* pp)
+        connection_ptr create_connection(
+            int dest, parcelset::parcelport* pp, bool enable_ack_handshakes)
         {
-            return std::make_shared<connection_type>(this, dest, pp);
+            return std::make_shared<connection_type>(
+                this, dest, pp, enable_ack_handshakes);
         }
 
         void add(connection_ptr const& ptr)
@@ -101,12 +103,14 @@ namespace hpx::parcelset::policies::mpi {
         using parcel_buffer_type = parcel_buffer<buffer_type, chunk_type>;
         using callback_fn_type =
             hpx::move_only_function<void(error_code const&)>;
+
         bool send_immediate(parcelset::parcelport* pp,
             parcelset::locality const& dest, parcel_buffer_type buffer,
-            callback_fn_type&& callbackFn)
+            callback_fn_type&& callbackFn, bool enable_ack_handshakes)
         {
             int dest_rank = dest.get<locality>().rank();
-            auto connection = create_connection(dest_rank, pp);
+            auto connection =
+                create_connection(dest_rank, pp, enable_ack_handshakes);
             connection->buffer_ = HPX_MOVE(buffer);
             connection->async_write(HPX_MOVE(callbackFn), nullptr);
             return true;

--- a/libs/full/parcelport_mpi/include/hpx/parcelport_mpi/tag_provider.hpp
+++ b/libs/full/parcelport_mpi/include/hpx/parcelport_mpi/tag_provider.hpp
@@ -10,19 +10,15 @@
 #include <hpx/config.hpp>
 
 #if defined(HPX_HAVE_NETWORKING) && defined(HPX_HAVE_PARCELPORT_MPI)
-#include <hpx/assert.hpp>
-#include <hpx/modules/synchronization.hpp>
+#include <hpx/modules/mpi_base.hpp>
 
 #include <atomic>
-#include <deque>
-#include <limits>
-#include <mutex>
 
 namespace hpx::parcelset::policies::mpi {
 
     struct tag_provider
     {
-        tag_provider()
+        constexpr tag_provider() noexcept
           : next_tag(0)
         {
         }


### PR DESCRIPTION
- this prevents sends to be posted before their corresponding receives
- this option can be enabled by adding the command line argument `--hpx:ini=hpx.parcel.mpi.ack_handshake!=1`