### PR TITLE
Improve the LCI parcelport documentation

### DIFF
--- a/docs/sphinx/manual/using_the_lci_parcelport.rst
+++ b/docs/sphinx/manual/using_the_lci_parcelport.rst
@@ -89,13 +89,18 @@ Run |hpx| with the LCI parcelport
 =================================
 
 We use the same mechanisms as MPI to launch LCI, so you can use the same way you run MPI parcelport to run LCI
-parcelport. Typically, it would be ``hpxrun``, ``mpirun``, or ``srun``.
+parcelport. Typically, it would be ``hpxrun.py``, ``mpirun``, or ``srun``.
 
-If you are using ``hpxrun.py``, just pass ``--parcelport lci`` to the scripts.
+``hpxrun.py`` serves as a wrapper for ``mpirun`` and ``srun``.
+If you are using ``hpxrun.py``, pass ``-p lci`` to the scripts. You also need to pass either ``-r mpi`` or
+``-r srun`` to select the correct run wrapper according to the platform.
 
 If you are using ``mpirun`` or ``srun``, you can just pass
 ``--hpx:ini=hpx.parcel.lci.priority=1000``, ``--hpx:ini=hpx.parcel.lci.enable=1``, and
 ``--hpx:ini=hpx.parcel.bootstrap=lci`` to the |hpx| applications.
+
+The ``hpxrun.py`` argument ``-r none`` (the default option for the run wrapper) and its corresponding |hpx| arguments
+``--hpx:hpx`` and ``--hpx:agas`` do not work for the MPI or the LCI parcelport.
 
 .. _tune_lci_pp:
 


### PR DESCRIPTION
Fixes the document inconsistency discovered in #6526 

The LCI parcelport (and also the MPI parcelport) cannot be bootstrapped by specifying IP addresses through `--hpx:agas` and `--hpx:hpx`.