### PR TITLE
Fix the S/R versions of the for loop algorithms

### DIFF
--- a/libs/core/algorithms/tests/unit/algorithms/CMakeLists.txt
+++ b/libs/core/algorithms/tests/unit/algorithms/CMakeLists.txt
@@ -60,15 +60,20 @@ set(tests
     foreachn_exception
     foreachn_bad_alloc
     for_loop
+    for_loop_sender
     for_loop_exception
     for_loop_induction
+    for_loop_induction_sender
     for_loop_induction_async
     for_loop_n
+    for_loop_n_sender
     for_loop_n_strided
+    for_loop_n_strided_sender
     for_loop_reduction
+    for_loop_reduction_sender
     for_loop_reduction_async
-    for_loop_sender
     for_loop_strided
+    for_loop_strided_sender
     generate
     generaten
     is_heap

--- a/libs/core/algorithms/tests/unit/algorithms/for_loop_induction_sender.cpp
+++ b/libs/core/algorithms/tests/unit/algorithms/for_loop_induction_sender.cpp
@@ -1,0 +1,355 @@
+//  Copyright (c) 2016 Hartmut Kaiser
+//  Copyright (c) 2024 Tobias Wukovitsch
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/algorithm.hpp>
+#include <hpx/execution.hpp>
+#include <hpx/init.hpp>
+#include <hpx/modules/testing.hpp>
+
+#include <algorithm>
+#include <cstddef>
+#include <iostream>
+#include <numeric>
+#include <random>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "test_utils.hpp"
+
+///////////////////////////////////////////////////////////////////////////////
+int seed = std::random_device{}();
+std::mt19937 gen(seed);
+
+template <typename LnPolicy, typename ExPolicy, typename IteratorTag>
+void test_for_loop_induction_sender(
+    LnPolicy ln_policy, ExPolicy&& ex_policy, IteratorTag)
+{
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
+
+    using base_iterator = std::vector<std::size_t>::iterator;
+    using iterator = test::test_iterator<base_iterator, IteratorTag>;
+
+    namespace ex = hpx::execution::experimental;
+    namespace tt = hpx::this_thread::experimental;
+    using scheduler_t = ex::thread_pool_policy_scheduler<LnPolicy>;
+
+    auto exec = ex::explicit_scheduler_executor(scheduler_t(ln_policy));
+
+    std::vector<std::size_t> c(10007);
+    std::vector<std::size_t> d(10007);
+    std::iota(std::begin(c), std::end(c), gen());
+
+    tt::sync_wait(ex::just(iterator(std::begin(c)), iterator(std::end(c)),
+                      hpx::experimental::induction(0),
+                      [&d](iterator it, std::size_t i) {
+                          *it = 42;
+                          d[i] = 42;
+                      }) |
+        hpx::experimental::for_loop(ex_policy.on(exec)));
+
+    // verify values
+    std::size_t count = 0;
+    std::for_each(std::begin(c), std::end(c), [&count](std::size_t v) -> void {
+        HPX_TEST_EQ(v, static_cast<std::size_t>(42));
+        ++count;
+    });
+    std::for_each(std::begin(d), std::end(d), [](std::size_t v) -> void {
+        HPX_TEST_EQ(v, static_cast<std::size_t>(42));
+    });
+    HPX_TEST_EQ(count, c.size());
+}
+
+template <typename LnPolicy, typename ExPolicy, typename IteratorTag>
+void test_for_loop_induction_stride_sender(
+    LnPolicy ln_policy, ExPolicy&& ex_policy, IteratorTag)
+{
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
+
+    using base_iterator = std::vector<std::size_t>::iterator;
+    using iterator = test::test_iterator<base_iterator, IteratorTag>;
+
+    namespace ex = hpx::execution::experimental;
+    namespace tt = hpx::this_thread::experimental;
+    using scheduler_t = ex::thread_pool_policy_scheduler<LnPolicy>;
+
+    auto exec = ex::explicit_scheduler_executor(scheduler_t(ln_policy));
+
+    std::vector<std::size_t> c(10007);
+    std::vector<std::size_t> d(10007);
+    std::iota(std::begin(c), std::end(c), gen());
+
+    tt::sync_wait(
+        ex::just(iterator(std::begin(c)), iterator(std::end(c)),
+            hpx::experimental::induction(0), hpx::experimental::induction(0, 2),
+            [&d](iterator it, std::size_t i, std::size_t j) {
+                *it = 42;
+                d[i] = 42;
+                HPX_TEST_EQ(2 * i, j);
+            }) |
+        hpx::experimental::for_loop(ex_policy.on(exec)));
+
+    // verify values
+    std::size_t count = 0;
+    std::for_each(std::begin(c), std::end(c), [&count](std::size_t v) -> void {
+        HPX_TEST_EQ(v, std::size_t(42));
+        ++count;
+    });
+    std::for_each(std::begin(d), std::end(d),
+        [](std::size_t v) -> void { HPX_TEST_EQ(v, std::size_t(42)); });
+    HPX_TEST_EQ(count, c.size());
+}
+
+template <typename LnPolicy, typename ExPolicy, typename IteratorTag>
+void test_for_loop_induction_life_out_sender(
+    LnPolicy ln_policy, ExPolicy&& ex_policy, IteratorTag)
+{
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
+
+    using base_iterator = std::vector<std::size_t>::iterator;
+    using iterator = test::test_iterator<base_iterator, IteratorTag>;
+
+    namespace ex = hpx::execution::experimental;
+    namespace tt = hpx::this_thread::experimental;
+    using scheduler_t = ex::thread_pool_policy_scheduler<LnPolicy>;
+
+    auto exec = ex::explicit_scheduler_executor(scheduler_t(ln_policy));
+
+    std::vector<std::size_t> c(10007);
+    std::vector<std::size_t> d(10007);
+    std::iota(std::begin(c), std::end(c), gen());
+
+    std::size_t curr = 0;
+
+    tt::sync_wait(ex::just(iterator(std::begin(c)), iterator(std::end(c)),
+                      hpx::experimental::induction(curr),
+                      [&d](iterator it, std::size_t i) {
+                          *it = 42;
+                          d[i] = 42;
+                      }) |
+        hpx::experimental::for_loop(ex_policy.on(exec)));
+
+    HPX_TEST_EQ(curr, c.size());
+
+    // verify values
+    std::size_t count = 0;
+    std::for_each(std::begin(c), std::end(c), [&count](std::size_t v) -> void {
+        HPX_TEST_EQ(v, std::size_t(42));
+        ++count;
+    });
+    std::for_each(std::begin(d), std::end(d),
+        [](std::size_t v) -> void { HPX_TEST_EQ(v, std::size_t(42)); });
+    HPX_TEST_EQ(count, c.size());
+}
+
+template <typename LnPolicy, typename ExPolicy, typename IteratorTag>
+void test_for_loop_induction_stride_life_out_sender(
+    LnPolicy ln_policy, ExPolicy&& ex_policy, IteratorTag)
+{
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
+
+    using base_iterator = std::vector<std::size_t>::iterator;
+    using iterator = test::test_iterator<base_iterator, IteratorTag>;
+
+    namespace ex = hpx::execution::experimental;
+    namespace tt = hpx::this_thread::experimental;
+    using scheduler_t = ex::thread_pool_policy_scheduler<LnPolicy>;
+
+    auto exec = ex::explicit_scheduler_executor(scheduler_t(ln_policy));
+
+    std::vector<std::size_t> c(10007);
+    std::vector<std::size_t> d(10007);
+    std::iota(std::begin(c), std::end(c), gen());
+
+    std::size_t curr1 = 0;
+    std::size_t curr2 = 0;
+
+    tt::sync_wait(ex::just(iterator(std::begin(c)), iterator(std::end(c)),
+                      hpx::experimental::induction(curr1),
+                      hpx::experimental::induction(curr2, 2),
+                      [&d](iterator it, std::size_t i, std::size_t j) {
+                          *it = 42;
+                          d[i] = 42;
+                          HPX_TEST_EQ(2 * i, j);
+                      }) |
+        hpx::experimental::for_loop(ex_policy.on(exec)));
+
+    HPX_TEST_EQ(curr1, c.size());
+    HPX_TEST_EQ(curr2, 2 * c.size());
+
+    // verify values
+    std::size_t count = 0;
+    std::for_each(std::begin(c), std::end(c), [&count](std::size_t v) -> void {
+        HPX_TEST_EQ(v, std::size_t(42));
+        ++count;
+    });
+    std::for_each(std::begin(d), std::end(d),
+        [](std::size_t v) -> void { HPX_TEST_EQ(v, std::size_t(42)); });
+    HPX_TEST_EQ(count, c.size());
+}
+
+///////////////////////////////////////////////////////////////////////////////
+template <typename IteratorTag>
+void test_for_loop_induction_sender()
+{
+    using namespace hpx::execution;
+    const auto sync = hpx::launch::sync;
+    const auto async = hpx::launch::async;
+
+    test_for_loop_induction_sender(sync, seq(task), IteratorTag());
+    test_for_loop_induction_sender(async, par(task), IteratorTag());
+    test_for_loop_induction_sender(async, par_unseq(task), IteratorTag());
+
+    test_for_loop_induction_stride_sender(sync, seq(task), IteratorTag());
+    test_for_loop_induction_stride_sender(async, par(task), IteratorTag());
+    test_for_loop_induction_stride_sender(
+        async, par_unseq(task), IteratorTag());
+
+    test_for_loop_induction_life_out_sender(sync, seq(task), IteratorTag());
+    test_for_loop_induction_life_out_sender(async, par(task), IteratorTag());
+    test_for_loop_induction_life_out_sender(
+        async, par_unseq(task), IteratorTag());
+
+    test_for_loop_induction_stride_life_out_sender(
+        sync, seq(task), IteratorTag());
+    test_for_loop_induction_stride_life_out_sender(
+        async, par(task), IteratorTag());
+    test_for_loop_induction_stride_life_out_sender(
+        async, par_unseq(task), IteratorTag());
+}
+
+void for_loop_induction_test_sender()
+{
+    test_for_loop_induction_sender<std::random_access_iterator_tag>();
+    test_for_loop_induction_sender<std::forward_iterator_tag>();
+}
+
+///////////////////////////////////////////////////////////////////////////////
+template <typename LnPolicy, typename ExPolicy>
+void test_for_loop_induction_idx_sender(
+    LnPolicy ln_policy, ExPolicy&& ex_policy)
+{
+    static_assert(hpx::is_async_execution_policy_v<ExPolicy>,
+        "hpx::is_async_execution_policy_v<ExPolicy>");
+
+    namespace ex = hpx::execution::experimental;
+    namespace tt = hpx::this_thread::experimental;
+    using scheduler_t = ex::thread_pool_policy_scheduler<LnPolicy>;
+
+    auto exec = ex::explicit_scheduler_executor(scheduler_t(ln_policy));
+
+    std::vector<std::size_t> c(10007);
+    std::iota(std::begin(c), std::end(c), gen());
+
+    tt::sync_wait(ex::just(0, c.size(), hpx::experimental::induction(0),
+                      [&c](std::size_t i, std::size_t j) {
+                          c[i] = 42;
+                          HPX_TEST_EQ(i, j);
+                      }) |
+        hpx::experimental::for_loop(ex_policy.on(exec)));
+
+    // verify values
+    std::size_t count = 0;
+    std::for_each(std::begin(c), std::end(c), [&count](std::size_t v) -> void {
+        HPX_TEST_EQ(v, std::size_t(42));
+        ++count;
+    });
+    HPX_TEST_EQ(count, c.size());
+}
+
+template <typename LnPolicy, typename ExPolicy>
+void test_for_loop_induction_stride_idx_sender(
+    LnPolicy ln_policy, ExPolicy&& ex_policy)
+{
+    static_assert(hpx::is_async_execution_policy_v<ExPolicy>,
+        "hpx::is_async_execution_policy_v<ExPolicy>");
+
+    namespace ex = hpx::execution::experimental;
+    namespace tt = hpx::this_thread::experimental;
+    using scheduler_t = ex::thread_pool_policy_scheduler<LnPolicy>;
+
+    auto exec = ex::explicit_scheduler_executor(scheduler_t(ln_policy));
+
+    std::vector<std::size_t> c(10007);
+    std::iota(std::begin(c), std::end(c), gen());
+
+    tt::sync_wait(ex::just(0, c.size(), hpx::experimental::induction(0),
+                      hpx::experimental::induction(0, 2),
+                      [&c](std::size_t i, std::size_t j, std::size_t k) {
+                          c[i] = 42;
+                          HPX_TEST_EQ(i, j);
+                          HPX_TEST_EQ(2 * i, k);
+                      }) |
+        hpx::experimental::for_loop(ex_policy.on(exec)));
+
+    // verify values
+    std::size_t count = 0;
+    std::for_each(std::begin(c), std::end(c), [&count](std::size_t v) -> void {
+        HPX_TEST_EQ(v, std::size_t(42));
+        ++count;
+    });
+    HPX_TEST_EQ(count, c.size());
+}
+
+void for_loop_induction_test_idx_sender()
+{
+    using namespace hpx::execution;
+    const auto sync = hpx::launch::sync;
+    const auto async = hpx::launch::async;
+
+    test_for_loop_induction_idx_sender(sync, seq(task));
+    test_for_loop_induction_idx_sender(async, par(task));
+    test_for_loop_induction_idx_sender(async, par_unseq(task));
+
+    test_for_loop_induction_stride_idx_sender(sync, seq(task));
+    test_for_loop_induction_stride_idx_sender(async, par(task));
+    test_for_loop_induction_stride_idx_sender(async, par_unseq(task));
+}
+
+///////////////////////////////////////////////////////////////////////////////
+int hpx_main(hpx::program_options::variables_map& vm)
+{
+    unsigned int seed = (unsigned int) std::time(nullptr);
+    if (vm.count("seed"))
+        seed = vm["seed"].as<unsigned int>();
+
+    std::cout << "using seed: " << seed << std::endl;
+    gen.seed(seed);
+
+    for_loop_induction_test_sender();
+    for_loop_induction_test_idx_sender();
+
+    return hpx::local::finalize();
+}
+
+int main(int argc, char* argv[])
+{
+    // add command line option which controls the random number generator seed
+    using namespace hpx::program_options;
+    options_description desc_commandline(
+        "Usage: " HPX_APPLICATION_STRING " [options]");
+
+    desc_commandline.add_options()("seed,s", value<unsigned int>(),
+        "the random number generator seed to use for this run");
+
+    // By default this test should run on all available cores
+    std::vector<std::string> const cfg = {"hpx.os_threads=all"};
+
+    // Initialize and run HPX
+    hpx::local::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::local::init(hpx_main, argc, argv, init_args), 0,
+        "HPX main exited with non-zero status");
+
+    return hpx::util::report_errors();
+}

--- a/libs/core/algorithms/tests/unit/algorithms/for_loop_n_sender.cpp
+++ b/libs/core/algorithms/tests/unit/algorithms/for_loop_n_sender.cpp
@@ -1,0 +1,106 @@
+//  Copyright (c) 2024 Tobias Wukovitsch
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/algorithm.hpp>
+#include <hpx/init.hpp>
+#include <hpx/modules/testing.hpp>
+
+#include <algorithm>
+#include <cstddef>
+#include <iostream>
+#include <numeric>
+#include <random>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "test_utils.hpp"
+
+///////////////////////////////////////////////////////////////////////////////
+int seed = std::random_device{}();
+std::mt19937 gen(seed);
+
+template <typename LnPolicy, typename ExPolicy, typename IteratorTag>
+void test_for_loop_n_sender(
+    LnPolicy ln_policy, ExPolicy&& ex_policy, IteratorTag)
+{
+    static_assert(hpx::is_async_execution_policy_v<ExPolicy>,
+        "hpx::is_async_execution_policy_v<ExPolicy>");
+
+    using base_iterator = std::vector<std::size_t>::iterator;
+    using iterator = test::test_iterator<base_iterator, IteratorTag>;
+
+    namespace ex = hpx::execution::experimental;
+    namespace tt = hpx::this_thread::experimental;
+    using scheduler_t = ex::thread_pool_policy_scheduler<LnPolicy>;
+
+    std::vector<std::size_t> c(10007);
+    std::iota(std::begin(c), std::end(c), gen());
+
+    auto exec = ex::explicit_scheduler_executor(scheduler_t(ln_policy));
+
+    tt::sync_wait(ex::just(iterator(std::begin(c)), c.size(), [](iterator it) {
+        *it = 42;
+    }) | hpx::experimental::for_loop_n(ex_policy.on(exec)));
+
+    // verify values
+    std::size_t count = 0;
+    std::for_each(std::begin(c), std::end(c), [&count](std::size_t v) -> void {
+        HPX_TEST_EQ(v, std::size_t(42));
+        ++count;
+    });
+    HPX_TEST_EQ(count, c.size());
+}
+
+template <typename IteratorTag>
+void for_loop_n_sender_test()
+{
+    using namespace hpx::execution;
+    test_for_loop_n_sender(hpx::launch::sync, seq(task), IteratorTag());
+    test_for_loop_n_sender(hpx::launch::sync, unseq(task), IteratorTag());
+
+    test_for_loop_n_sender(hpx::launch::async, par(task), IteratorTag());
+    test_for_loop_n_sender(hpx::launch::async, par_unseq(task), IteratorTag());
+}
+
+int hpx_main(hpx::program_options::variables_map& vm)
+{
+    unsigned int seed = (unsigned int) std::time(nullptr);
+    if (vm.count("seed"))
+        seed = vm["seed"].as<unsigned int>();
+
+    std::cout << "using seed: " << seed << std::endl;
+    std::srand(seed);
+
+    for_loop_n_sender_test<std::forward_iterator_tag>();
+    for_loop_n_sender_test<std::random_access_iterator_tag>();
+
+    return hpx::local::finalize();
+}
+
+int main(int argc, char* argv[])
+{
+    // add command line option which controls the random number generator seed
+    using namespace hpx::program_options;
+    options_description desc_commandline(
+        "Usage: " HPX_APPLICATION_STRING " [options]");
+
+    desc_commandline.add_options()("seed,s", value<unsigned int>(),
+        "the random number generator seed to use for this run");
+
+    // By default this test should run on all available cores
+    std::vector<std::string> const cfg = {"hpx.os_threads=all"};
+
+    // Initialize and run HPX
+    hpx::local::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::local::init(hpx_main, argc, argv, init_args), 0,
+        "HPX main exited with non-zero status");
+
+    return hpx::util::report_errors();
+}

--- a/libs/core/algorithms/tests/unit/algorithms/for_loop_n_strided_sender.cpp
+++ b/libs/core/algorithms/tests/unit/algorithms/for_loop_n_strided_sender.cpp
@@ -1,0 +1,125 @@
+//  Copyright (c) 2024 Tobias Wukovitsch
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/algorithm.hpp>
+#include <hpx/init.hpp>
+#include <hpx/modules/testing.hpp>
+
+#include <algorithm>
+#include <cstddef>
+#include <iostream>
+#include <numeric>
+#include <random>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "test_utils.hpp"
+
+///////////////////////////////////////////////////////////////////////////////
+int seed = std::random_device{}();
+std::mt19937 gen(seed);
+std::uniform_int_distribution<> dis(1, 10006);
+
+template <typename LnPolicy, typename ExPolicy, typename IteratorTag>
+void test_for_loop_n_strided_sender(
+    LnPolicy ln_policy, ExPolicy&& ex_policy, IteratorTag)
+{
+    static_assert(hpx::is_async_execution_policy_v<ExPolicy>,
+        "hpx::is_async_execution_policy_v<ExPolicy>");
+
+    using base_iterator = std::vector<std::size_t>::iterator;
+    using iterator = test::test_iterator<base_iterator, IteratorTag>;
+
+    namespace ex = hpx::execution::experimental;
+    namespace tt = hpx::this_thread::experimental;
+    using scheduler_t = ex::thread_pool_policy_scheduler<LnPolicy>;
+
+    std::vector<std::size_t> c(10007);
+    std::iota(std::begin(c), std::end(c), gen());
+
+    std::for_each(std::begin(c), std::end(c), [](std::size_t& v) -> void {
+        if (v == 42)
+            v = 43;
+    });
+
+    int stride = dis(gen);    //-V103
+
+    auto exec = ex::explicit_scheduler_executor(scheduler_t(ln_policy));
+
+    tt::sync_wait(ex::just(iterator(std::begin(c)), c.size(), stride,
+                      [](iterator it) { *it = 42; }) |
+        hpx::experimental::for_loop_n_strided(ex_policy.on(exec)));
+
+    // verify values
+    std::size_t count = 0;
+    for (std::size_t i = 0; i != c.size(); ++i)
+    {
+        if (i % stride == 0)    //-V104
+        {
+            HPX_TEST_EQ(c[i], std::size_t(42));
+        }
+        else
+        {
+            HPX_TEST_NEQ(c[i], std::size_t(42));
+        }
+        ++count;
+    }
+    HPX_TEST_EQ(count, c.size());
+}
+
+template <typename IteratorTag>
+void for_loop_n_strided_sender_test()
+{
+    using namespace hpx::execution;
+    test_for_loop_n_strided_sender(hpx::launch::sync, seq(task), IteratorTag());
+    test_for_loop_n_strided_sender(
+        hpx::launch::sync, unseq(task), IteratorTag());
+
+    test_for_loop_n_strided_sender(
+        hpx::launch::async, par(task), IteratorTag());
+    test_for_loop_n_strided_sender(
+        hpx::launch::async, par_unseq(task), IteratorTag());
+}
+
+int hpx_main(hpx::program_options::variables_map& vm)
+{
+    unsigned int seed = (unsigned int) std::time(nullptr);
+    if (vm.count("seed"))
+        seed = vm["seed"].as<unsigned int>();
+
+    std::cout << "using seed: " << seed << std::endl;
+    std::srand(seed);
+
+    for_loop_n_strided_sender_test<std::forward_iterator_tag>();
+    for_loop_n_strided_sender_test<std::random_access_iterator_tag>();
+
+    return hpx::local::finalize();
+}
+
+int main(int argc, char* argv[])
+{
+    // add command line option which controls the random number generator seed
+    using namespace hpx::program_options;
+    options_description desc_commandline(
+        "Usage: " HPX_APPLICATION_STRING " [options]");
+
+    desc_commandline.add_options()("seed,s", value<unsigned int>(),
+        "the random number generator seed to use for this run");
+
+    // By default this test should run on all available cores
+    std::vector<std::string> const cfg = {"hpx.os_threads=all"};
+
+    // Initialize and run HPX
+    hpx::local::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::local::init(hpx_main, argc, argv, init_args), 0,
+        "HPX main exited with non-zero status");
+
+    return hpx::util::report_errors();
+}

--- a/libs/core/algorithms/tests/unit/algorithms/for_loop_reduction_sender.cpp
+++ b/libs/core/algorithms/tests/unit/algorithms/for_loop_reduction_sender.cpp
@@ -1,0 +1,266 @@
+//  Copyright (c) 2016 Hartmut Kaiser
+//  Copyright (c) 2024 Tobias Wukovitsch
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/algorithm.hpp>
+#include <hpx/execution.hpp>
+#include <hpx/init.hpp>
+#include <hpx/modules/testing.hpp>
+
+#include <algorithm>
+#include <cstddef>
+#include <iostream>
+#include <numeric>
+#include <random>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "test_utils.hpp"
+
+///////////////////////////////////////////////////////////////////////////////
+int seed = std::random_device{}();
+std::mt19937 gen(seed);
+
+template <typename LnPolicy, typename ExPolicy, typename IteratorTag>
+void test_for_loop_reduction_plus_sender(
+    LnPolicy ln_policy, ExPolicy&& ex_policy, IteratorTag)
+{
+    static_assert(hpx::is_async_execution_policy_v<ExPolicy>,
+        "hpx::is_async_execution_policy_v<ExPolicy>");
+
+    namespace ex = hpx::execution::experimental;
+    namespace tt = hpx::this_thread::experimental;
+    using scheduler_t = ex::thread_pool_policy_scheduler<LnPolicy>;
+
+    using base_iterator = std::vector<std::size_t>::iterator;
+    using iterator = test::test_iterator<base_iterator, IteratorTag>;
+
+    auto exec = ex::explicit_scheduler_executor(scheduler_t(ln_policy));
+
+    std::vector<std::size_t> c(10007);
+    std::iota(std::begin(c), std::end(c), gen());
+
+    std::size_t sum = 0;
+
+    tt::sync_wait(ex::just(iterator(std::begin(c)), iterator(std::end(c)),
+                      hpx::experimental::reduction_plus(sum),
+                      [](iterator it, std::size_t& sum) { sum += *it; }) |
+        hpx::experimental::for_loop(ex_policy.on(exec)));
+
+    // verify values
+    std::size_t sum2 =
+        std::accumulate(std::begin(c), std::end(c), std::size_t(0));
+    HPX_TEST_EQ(sum, sum2);
+}
+
+template <typename LnPolicy, typename ExPolicy, typename IteratorTag>
+void test_for_loop_reduction_multiplies_sender(
+    LnPolicy ln_policy, ExPolicy&& ex_policy, IteratorTag)
+{
+    static_assert(hpx::is_async_execution_policy_v<ExPolicy>,
+        "hpx::is_async_execution_policy_v<ExPolicy>");
+
+    namespace ex = hpx::execution::experimental;
+    namespace tt = hpx::this_thread::experimental;
+    using scheduler_t = ex::thread_pool_policy_scheduler<LnPolicy>;
+
+    using base_iterator = std::vector<std::size_t>::iterator;
+    using iterator = test::test_iterator<base_iterator, IteratorTag>;
+
+    auto exec = ex::explicit_scheduler_executor(scheduler_t(ln_policy));
+
+    std::vector<std::size_t> c(10007);
+    std::iota(std::begin(c), std::end(c), gen());
+
+    std::size_t prod = 0;
+
+    tt::sync_wait(ex::just(iterator(std::begin(c)), iterator(std::end(c)),
+                      hpx::experimental::reduction_multiplies(prod),
+                      [](iterator it, std::size_t& prod) { prod *= *it; }) |
+        hpx::experimental::for_loop(ex_policy.on(exec)));
+
+    // verify values
+    std::size_t prod2 = std::accumulate(std::begin(c), std::end(c),
+        std::size_t(1), std::multiplies<std::size_t>());
+    HPX_TEST_EQ(prod, prod2);
+}
+
+template <typename LnPolicy, typename ExPolicy, typename IteratorTag>
+void test_for_loop_reduction_min_sender(
+    LnPolicy ln_policy, ExPolicy&& ex_policy, IteratorTag)
+{
+    static_assert(hpx::is_async_execution_policy_v<ExPolicy>,
+        "hpx::is_async_execution_policy_v<ExPolicy>");
+
+    namespace ex = hpx::execution::experimental;
+    namespace tt = hpx::this_thread::experimental;
+    using scheduler_t = ex::thread_pool_policy_scheduler<LnPolicy>;
+
+    using base_iterator = std::vector<std::size_t>::iterator;
+    using iterator = test::test_iterator<base_iterator, IteratorTag>;
+
+    auto exec = ex::explicit_scheduler_executor(scheduler_t(ln_policy));
+
+    std::vector<std::size_t> c(10007);
+    std::iota(std::begin(c), std::end(c), gen());
+
+    std::size_t minval = c[0];
+
+    tt::sync_wait(ex::just(iterator(std::begin(c)), iterator(std::end(c)),
+                      hpx::experimental::reduction_min(minval),
+                      [](iterator it, std::size_t& minval) {
+                          minval = (std::min)(minval, *it);
+                      }) |
+        hpx::experimental::for_loop(ex_policy.on(exec)));
+
+    // verify values
+    std::size_t minval2 = std::accumulate(std::begin(c), std::end(c), c[0],
+        hpx::parallel::detail::min_of<std::size_t>());
+    HPX_TEST_EQ(minval, minval2);
+}
+
+///////////////////////////////////////////////////////////////////////////////
+template <typename IteratorTag>
+void test_for_loop_reduction_sender()
+{
+    using namespace hpx::execution;
+    const auto sync = hpx::launch::sync;
+    const auto async = hpx::launch::async;
+
+    test_for_loop_reduction_plus_sender(sync, seq(task), IteratorTag());
+    test_for_loop_reduction_plus_sender(async, par(task), IteratorTag());
+    test_for_loop_reduction_plus_sender(async, par_unseq(task), IteratorTag());
+
+    test_for_loop_reduction_multiplies_sender(sync, seq(task), IteratorTag());
+    test_for_loop_reduction_multiplies_sender(async, par(task), IteratorTag());
+    test_for_loop_reduction_multiplies_sender(
+        async, par_unseq(task), IteratorTag());
+
+    test_for_loop_reduction_min_sender(sync, seq(task), IteratorTag());
+    test_for_loop_reduction_min_sender(async, par(task), IteratorTag());
+    test_for_loop_reduction_min_sender(async, par_unseq(task), IteratorTag());
+}
+
+void for_loop_reduction_test_sender()
+{
+    test_for_loop_reduction_sender<std::random_access_iterator_tag>();
+    test_for_loop_reduction_sender<std::forward_iterator_tag>();
+}
+
+///////////////////////////////////////////////////////////////////////////////
+template <typename LnPolicy, typename ExPolicy>
+void test_for_loop_reduction_bit_and_idx_sender(
+    LnPolicy ln_policy, ExPolicy&& ex_policy)
+{
+    static_assert(hpx::is_async_execution_policy_v<ExPolicy>,
+        "hpx::is_async_execution_policy_v<ExPolicy>");
+
+    namespace ex = hpx::execution::experimental;
+    namespace tt = hpx::this_thread::experimental;
+    using scheduler_t = ex::thread_pool_policy_scheduler<LnPolicy>;
+
+    auto exec = ex::explicit_scheduler_executor(scheduler_t(ln_policy));
+
+    std::vector<std::size_t> c(10007);
+    std::iota(std::begin(c), std::end(c), gen());
+
+    std::size_t bits = ~std::size_t(0);
+
+    tt::sync_wait(
+        ex::just(0, c.size(), hpx::experimental::reduction_bit_and(bits),
+            [&c](std::size_t i, std::size_t& bits) { bits &= c[i]; }) |
+        hpx::experimental::for_loop(ex_policy.on(exec)));
+
+    // verify values
+    std::size_t bits2 = std::accumulate(std::begin(c), std::end(c),
+        ~std::size_t(0), std::bit_and<std::size_t>());
+    HPX_TEST_EQ(bits, bits2);
+}
+
+template <typename LnPolicy, typename ExPolicy>
+void test_for_loop_reduction_bit_or_idx_sender(
+    LnPolicy ln_policy, ExPolicy&& ex_policy)
+{
+    static_assert(hpx::is_async_execution_policy_v<ExPolicy>,
+        "hpx::is_async_execution_policy_v<ExPolicy>");
+
+    namespace ex = hpx::execution::experimental;
+    namespace tt = hpx::this_thread::experimental;
+    using scheduler_t = ex::thread_pool_policy_scheduler<LnPolicy>;
+
+    auto exec = ex::explicit_scheduler_executor(scheduler_t(ln_policy));
+
+    std::vector<std::size_t> c(10007);
+    std::iota(std::begin(c), std::end(c), gen());
+
+    std::size_t bits = 0;
+
+    tt::sync_wait(
+        ex::just(0, c.size(), hpx::experimental::reduction_bit_or(bits),
+            [&c](std::size_t i, std::size_t& bits) { bits |= c[i]; }) |
+        hpx::experimental::for_loop(ex_policy.on(exec)));
+
+    // verify values
+    std::size_t bits2 = std::accumulate(
+        std::begin(c), std::end(c), std::size_t(0), std::bit_or<std::size_t>());
+    HPX_TEST_EQ(bits, bits2);
+}
+
+void for_loop_reduction_test_idx_sender()
+{
+    using namespace hpx::execution;
+    const auto sync = hpx::launch::sync;
+    const auto async = hpx::launch::async;
+
+    test_for_loop_reduction_bit_and_idx_sender(sync, seq(task));
+    test_for_loop_reduction_bit_and_idx_sender(async, par(task));
+    test_for_loop_reduction_bit_and_idx_sender(async, par_unseq(task));
+
+    test_for_loop_reduction_bit_or_idx_sender(sync, seq(task));
+    test_for_loop_reduction_bit_or_idx_sender(async, par(task));
+    test_for_loop_reduction_bit_or_idx_sender(async, par_unseq(task));
+}
+
+///////////////////////////////////////////////////////////////////////////////
+int hpx_main(hpx::program_options::variables_map& vm)
+{
+    unsigned int seed = (unsigned int) std::time(nullptr);
+    if (vm.count("seed"))
+        seed = vm["seed"].as<unsigned int>();
+
+    std::cout << "using seed: " << seed << std::endl;
+    gen.seed(seed);
+
+    for_loop_reduction_test_sender();
+    for_loop_reduction_test_idx_sender();
+
+    return hpx::local::finalize();
+}
+
+int main(int argc, char* argv[])
+{
+    // add command line option which controls the random number generator seed
+    using namespace hpx::program_options;
+    options_description desc_commandline(
+        "Usage: " HPX_APPLICATION_STRING " [options]");
+
+    desc_commandline.add_options()("seed,s", value<unsigned int>(),
+        "the random number generator seed to use for this run");
+
+    // By default this test should run on all available cores
+    std::vector<std::string> const cfg = {"hpx.os_threads=all"};
+
+    // Initialize and run HPX
+    hpx::local::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::local::init(hpx_main, argc, argv, init_args), 0,
+        "HPX main exited with non-zero status");
+
+    return hpx::util::report_errors();
+}

--- a/libs/core/algorithms/tests/unit/algorithms/for_loop_sender.cpp
+++ b/libs/core/algorithms/tests/unit/algorithms/for_loop_sender.cpp
@@ -70,9 +70,15 @@ void test_for_loop_sender_direct_async(Policy l, ExPolicy&& policy, IteratorTag)
     using scheduler_t = ex::thread_pool_policy_scheduler<Policy>;
 
     auto exec = ex::explicit_scheduler_executor(scheduler_t(l));
+#ifdef HPX_HAVE_STDEXEC
+    tt::sync_wait(
+        hpx::experimental::for_loop(policy.on(exec), iterator(std::begin(c)),
+            iterator(std::end(c)), [](iterator it) { *it = 42; }));
+#else
     hpx::experimental::for_loop(policy.on(exec), iterator(std::begin(c)),
         iterator(std::end(c)), [](iterator it) { *it = 42; }) |
         tt::sync_wait();
+#endif
 
     // verify values
     std::size_t count = 0;
@@ -129,8 +135,13 @@ void test_for_loop_sender(Policy l, ExPolicy&& policy, IteratorTag)
     using scheduler_t = ex::thread_pool_policy_scheduler<Policy>;
 
     auto exec = ex::explicit_scheduler_executor(scheduler_t(l));
+#ifdef HPX_HAVE_STDEXEC
+    tt::sync_wait(ex::just(iterator(std::begin(c)), iterator(std::end(c)), f) |
+        hpx::experimental::for_loop(policy.on(exec)));
+#else
     ex::just(iterator(std::begin(c)), iterator(std::end(c)), f) |
         hpx::experimental::for_loop(policy.on(exec)) | tt::sync_wait();
+#endif
 
     // verify values
     std::size_t count = 0;

--- a/libs/core/algorithms/tests/unit/algorithms/for_loop_strided_sender.cpp
+++ b/libs/core/algorithms/tests/unit/algorithms/for_loop_strided_sender.cpp
@@ -1,0 +1,123 @@
+//  Copyright (c) 2024 Tobias Wukovitsch
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/algorithm.hpp>
+#include <hpx/init.hpp>
+#include <hpx/modules/testing.hpp>
+
+#include <algorithm>
+#include <cstddef>
+#include <iostream>
+#include <numeric>
+#include <random>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "test_utils.hpp"
+
+///////////////////////////////////////////////////////////////////////////////
+int seed = std::random_device{}();
+std::mt19937 gen(seed);
+std::uniform_int_distribution<> dis(1, 10006);
+
+template <typename LnPolicy, typename ExPolicy, typename IteratorTag>
+void test_for_loop_strided_sender(
+    LnPolicy ln_policy, ExPolicy&& ex_policy, IteratorTag)
+{
+    static_assert(hpx::is_async_execution_policy_v<ExPolicy>,
+        "hpx::is_async_execution_policy_v<ExPolicy>");
+
+    using base_iterator = std::vector<std::size_t>::iterator;
+    using iterator = test::test_iterator<base_iterator, IteratorTag>;
+
+    namespace ex = hpx::execution::experimental;
+    namespace tt = hpx::this_thread::experimental;
+    using scheduler_t = ex::thread_pool_policy_scheduler<LnPolicy>;
+
+    std::vector<std::size_t> c(10007);
+    std::iota(std::begin(c), std::end(c), gen());
+
+    std::for_each(std::begin(c), std::end(c), [](std::size_t& v) -> void {
+        if (v == 42)
+            v = 43;
+    });
+
+    int stride = dis(gen);    //-V103
+
+    auto exec = ex::explicit_scheduler_executor(scheduler_t(ln_policy));
+
+    tt::sync_wait(ex::just(iterator(std::begin(c)), iterator(std::end(c)),
+                      stride, [](iterator it) { *it = 42; }) |
+        hpx::experimental::for_loop_strided(ex_policy.on(exec)));
+
+    // verify values
+    std::size_t count = 0;
+    for (std::size_t i = 0; i != c.size(); ++i)
+    {
+        if (i % stride == 0)    //-V104
+        {
+            HPX_TEST_EQ(c[i], std::size_t(42));
+        }
+        else
+        {
+            HPX_TEST_NEQ(c[i], std::size_t(42));
+        }
+        ++count;
+    }
+    HPX_TEST_EQ(count, c.size());
+}
+
+template <typename IteratorTag>
+void for_loop_strided_sender_test()
+{
+    using namespace hpx::execution;
+    test_for_loop_strided_sender(hpx::launch::sync, seq(task), IteratorTag());
+    test_for_loop_strided_sender(hpx::launch::sync, unseq(task), IteratorTag());
+
+    test_for_loop_strided_sender(hpx::launch::async, par(task), IteratorTag());
+    test_for_loop_strided_sender(
+        hpx::launch::async, par_unseq(task), IteratorTag());
+}
+
+int hpx_main(hpx::program_options::variables_map& vm)
+{
+    unsigned int seed = (unsigned int) std::time(nullptr);
+    if (vm.count("seed"))
+        seed = vm["seed"].as<unsigned int>();
+
+    std::cout << "using seed: " << seed << std::endl;
+    std::srand(seed);
+
+    for_loop_strided_sender_test<std::forward_iterator_tag>();
+    for_loop_strided_sender_test<std::random_access_iterator_tag>();
+
+    return hpx::local::finalize();
+}
+
+int main(int argc, char* argv[])
+{
+    // add command line option which controls the random number generator seed
+    using namespace hpx::program_options;
+    options_description desc_commandline(
+        "Usage: " HPX_APPLICATION_STRING " [options]");
+
+    desc_commandline.add_options()("seed,s", value<unsigned int>(),
+        "the random number generator seed to use for this run");
+
+    // By default this test should run on all available cores
+    std::vector<std::string> const cfg = {"hpx.os_threads=all"};
+
+    // Initialize and run HPX
+    hpx::local::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::local::init(hpx_main, argc, argv, init_args), 0,
+        "HPX main exited with non-zero status");
+
+    return hpx::util::report_errors();
+}


### PR DESCRIPTION
This PR is an extension of PR #6494, adding unit tests and fixes for the S/R versions of the following algorithms:

* `hpx::experimental::for_loop`
* `hpx::experimental::for_loop_n` 
* `hpx::experimental::for_loop_strided`
* `hpx::experimental::for_loop_n_strided`

In addition, `hpx::experimental::induction` has been modified to be thread-safe, similar to `hpx::experimental::reduction`, to solve the data races that occur when used with S/R.