### PR TITLE
Throwing an exception derived from std::bad_alloc on OOM conditions

### DIFF
--- a/docs/sphinx/manual/launching_and_configuring_hpx_applications.rst
+++ b/docs/sphinx/manual/launching_and_configuring_hpx_applications.rst
@@ -185,6 +185,7 @@ The |hpx| configuration section
    exception_verbosity = ${HPX_EXCEPTION_VERBOSITY:2}
    trace_depth = ${HPX_TRACE_DEPTH:20}
    handle_signals = ${HPX_HANDLE_SIGNALS:1}
+   handle_failed_new = ${HPX_HANDLE_FAILED_NEW:1}
 
    [hpx.stacks]
    small_size = ${HPX_SMALL_STACK_SIZE:<hpx_small_stack_size>}
@@ -295,8 +296,14 @@ The |hpx| configuration section
        print the configuration information (stack backtrace, system information,
        etc.) whenever a signal is raised. The default is ``1``. Setting this
        value to ``0`` can be useful in cases when generating a core-dump on
-       segmentation faults or similar signals is desired. This setting has no
-       effects on non-Linux platforms.
+       segmentation faults or similar signals is desired.
+   * * ``hpx.handle_failed_new``
+     * This setting defines whether HPX will register a handler for failed
+       allocationsthat will print the configuration information
+       (stack backtrace, system information, etc.) whenever an allocation fails.
+       The default is ``1``. Setting this value to ``0`` can be useful in cases
+       when generating a core-dump on segmentation faults or similar signals
+       is desired.
    * * ``hpx.stacks.small_size``
      * This is initialized to the small stack size to be used by |hpx| threads.
        Set by default to the value of the compile time preprocessor constant

--- a/libs/core/errors/include/hpx/errors/exception.hpp
+++ b/libs/core/errors/include/hpx/errors/exception.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2022 Hartmut Kaiser
+//  Copyright (c) 2007-2024 Hartmut Kaiser
 //  Copyright (c) 2011      Bryce Lelbach
 //
 //  SPDX-License-Identifier: BSL-1.0
@@ -93,6 +93,34 @@ namespace hpx {
         ///
         /// \throws nothing
         [[nodiscard]] error get_error() const noexcept;
+
+        /// The function \a get_error_code() returns a hpx::error_code which
+        /// represents the same error condition as this hpx::exception instance.
+        ///
+        /// \param mode   The parameter \p mode specifies whether the returned
+        ///               hpx::error_code belongs to the error category
+        ///               \a hpx_category (if mode is \a throwmode::plain, this is the
+        ///               default) or to the category \a hpx_category_rethrow
+        ///               (if mode is \a rethrow).
+        [[nodiscard]] error_code get_error_code(
+            throwmode mode = throwmode::plain) const noexcept;
+    };
+
+    class bad_alloc_exception
+      : public hpx::exception
+      , public std::bad_alloc
+    {
+    public:
+        /// Construct a hpx::bad_alloc_exception.
+        bad_alloc_exception();
+
+        /// The function \a get_error() returns hpx::error::out_of_memory
+        ///
+        /// \throws nothing
+        [[nodiscard]] static constexpr error get_error() noexcept
+        {
+            return hpx::error::out_of_memory;
+        }
 
         /// The function \a get_error_code() returns a hpx::error_code which
         /// represents the same error condition as this hpx::exception instance.

--- a/libs/core/errors/include/hpx/errors/throw_exception.hpp
+++ b/libs/core/errors/include/hpx/errors/throw_exception.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2023 Hartmut Kaiser
+//  Copyright (c) 2007-2024 Hartmut Kaiser
 //  Copyright (c) 2011      Bryce Lelbach
 //
 //  SPDX-License-Identifier: BSL-1.0
@@ -6,7 +6,7 @@
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 /// \file throw_exception.hpp
-/// \page HPX_THROW_EXCEPTION, HPX_THROWS_IF
+/// \page HPX_THROW_EXCEPTION, HPX_THROW_BAD_ALLOC, HPX_THROWS_IF
 /// \headerfile hpx/exception.hpp
 
 #pragma once
@@ -37,6 +37,9 @@ namespace hpx::detail {
         std::string const& msg, std::string const& func,
         std::string const& file, long line);
 
+    [[noreturn]] HPX_CORE_EXPORT void throw_bad_alloc_exception(
+        char const* func, char const* file, long line);
+
     [[noreturn]] HPX_CORE_EXPORT void rethrow_exception(
         exception const& e, std::string const& func);
 
@@ -62,6 +65,9 @@ namespace hpx::detail {
         std::string const& msg, std::string const& func,
         std::string const& file, long line);
 
+    HPX_CORE_EXPORT void throws_bad_alloc_if(
+        hpx::error_code& ec, char const* func, char const* file, long line);
+
     HPX_CORE_EXPORT void rethrows_if(
         hpx::error_code& ec, exception const& e, std::string const& func);
 
@@ -72,7 +78,7 @@ namespace hpx::detail {
 namespace hpx {
     /// \cond NOINTERNAL
 
-    /// \brief throw an hpx::exception initialized from the given arguments
+    /// \brief throw a hpx::exception initialized from the given arguments
     [[noreturn]] inline void throw_exception(error e, std::string const& msg,
         std::string const& func, std::string const& file = "", long line = -1)
     {
@@ -163,6 +169,37 @@ namespace hpx {
     hpx::detail::throw_exception(                                              \
         errcode, hpx::util::format(__VA_ARGS__), f, __FILE__, __LINE__) /**/
 
+///////////////////////////////////////////////////////////////////////////////
+/// \def HPX_THROW_BAD_ALLOC(f, msg)
+/// \brief Throw a hpx::bad_alloc_exception initialized from the given parameters
+///
+/// The macro \a HPX_THROW_BAD_ALLOC can be used to throw a hpx::exception.
+/// The purpose of this macro is to prepend the source file name and line number
+/// of the position where the exception is thrown to the error message.
+/// Moreover, this associates additional diagnostic information with the
+/// exception, such as file name and line number, locality id and thread id,
+/// and stack backtrace from the point where the exception was thrown.
+///
+/// The parameter \p errcode holds the hpx::error code the new exception should
+/// encapsulate. The parameter \p f is expected to hold the name of the
+/// function exception is thrown from and the parameter \p msg holds the error
+/// message the new exception should encapsulate.
+///
+/// \par Example:
+///
+/// \code
+///      void raise_exception()
+///      {
+///          // Throw a hpx::exception initialized from the given parameters.
+///          // Additionally associate with this exception some detailed
+///          // diagnostic information about the throw-site.
+///          HPX_THROW_BAD_ALLOC("raise_exception", "simulated error");
+///      }
+/// \endcode
+///
+#define HPX_THROW_BAD_ALLOC(f)                                                 \
+    hpx::detail::throw_bad_alloc_exception(f, __FILE__, __LINE__) /**/
+
 /// \def HPX_THROWS_IF(ec, errcode, f, msg)
 /// \brief Either throw a hpx::exception or initialize \a hpx::error_code from
 ///        the given parameters
@@ -181,5 +218,18 @@ namespace hpx {
 #define HPX_THROWS_IF(ec, errcode, f, ...)                                     \
     hpx::detail::throws_if(ec, errcode, hpx::util::format(__VA_ARGS__), f,     \
         __FILE__, __LINE__) /**/
+
+/// \def HPX_THROWS_BAD_ALLOC_IF(ec, f)
+/// \brief Either throw a hpx::bad_alloc_exception or \a hpx::error_code to out_of_memory
+///
+/// The macro \a HPX_THROWS_BAD_ALLOC_IF can be used to either throw a
+/// \a hpx::bad_alloc_exception or to initialize a \a hpx::error_code to
+/// \a hpx::error::out_of_memory. If
+/// &ec == &hpx::throws, the semantics of this macro are equivalent to
+/// \a HPX_THROW_BAD_ALLOC. If &ec != &hpx::throws, the \a hpx::error_code
+/// instance \p ec is initialized instead.
+///
+#define HPX_THROWS_BAD_ALLOC_IF(ec, f)                                         \
+    hpx::detail::throws_bad_alloc_if(ec, f, __FILE__, __LINE__) /**/
 
 #include <hpx/config/warnings_suffix.hpp>

--- a/libs/core/errors/src/exception.cpp
+++ b/libs/core/errors/src/exception.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2023 Hartmut Kaiser
+//  Copyright (c) 2007-2024 Hartmut Kaiser
 //  Copyright (c)      2011 Bryce Lelbach
 //
 //  SPDX-License-Identifier: BSL-1.0
@@ -140,6 +140,11 @@ namespace hpx {
         return {this->std::system_error::code().value(), *this};
     }
 
+    bad_alloc_exception::bad_alloc_exception()
+      : hpx::exception(hpx::error::out_of_memory)
+    {
+    }
+
     static custom_exception_info_handler_type custom_exception_info_handler;
 
     void set_custom_exception_info_handler(custom_exception_info_handler_type f)
@@ -236,8 +241,7 @@ namespace hpx::detail {
 
     ///////////////////////////////////////////////////////////////////////////
     template <typename Exception>
-    inline constexpr bool is_of_lightweight_hpx_category(
-        Exception const&) noexcept
+    constexpr bool is_of_lightweight_hpx_category(Exception const&) noexcept
     {
         return false;
     }
@@ -276,6 +280,18 @@ namespace hpx::detail {
         }
 
         std::rethrow_exception(get_exception(e, func, file, line));
+    }
+
+    HPX_CORE_EXPORT void throw_bad_alloc_exception(
+        [[maybe_unused]] char const* func, [[maybe_unused]] char const* file,
+        [[maybe_unused]] long line)
+    {
+        if (pre_exception_handler)
+        {
+            pre_exception_handler();
+        }
+
+        throw hpx::bad_alloc_exception();
     }
 
     ///////////////////////////////////////////////////////////////////////////

--- a/libs/core/errors/src/throw_exception.cpp
+++ b/libs/core/errors/src/throw_exception.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2022 Hartmut Kaiser
+//  Copyright (c) 2007-2024 Hartmut Kaiser
 //  Copyright (c)      2011 Bryce Lelbach
 //
 //  SPDX-License-Identifier: BSL-1.0
@@ -62,6 +62,23 @@ namespace hpx::detail {
         {
             ec = make_error_code(static_cast<hpx::error>(errcode), msg,
                 func.c_str(), file.c_str(), line,
+                (ec.category() == hpx::get_lightweight_hpx_category()) ?
+                    hpx::throwmode::lightweight :
+                    hpx::throwmode::plain);
+        }
+    }
+
+    void throws_bad_alloc_if(
+        hpx::error_code& ec, char const* func, char const* file, long line)
+    {
+        if (&ec == &hpx::throws)
+        {
+            throw hpx::bad_alloc_exception();
+        }
+        else
+        {
+            ec = make_error_code(hpx::error::out_of_memory, "out of memory",
+                func, file, line,
                 (ec.category() == hpx::get_lightweight_hpx_category()) ?
                     hpx::throwmode::lightweight :
                     hpx::throwmode::plain);

--- a/libs/core/format/include/hpx/modules/format.hpp
+++ b/libs/core/format/include/hpx/modules/format.hpp
@@ -280,6 +280,9 @@ namespace hpx::util {
             format_arg const* args, std::size_t count);
     }    // namespace detail
 
+    // enable using format in variadic contexts
+    HPX_CORE_EXPORT std::string const& format();
+
     template <typename... Args>
     std::string format(std::string_view format_str, Args const&... args)
     {

--- a/libs/core/format/src/format.cpp
+++ b/libs/core/format/src/format.cpp
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 //  Copyright (c) 2017-2018 Agustin Berge
-//  Copyright (c) 2022 Hartmut Kaiser
+//  Copyright (c) 2024 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -129,3 +129,12 @@ namespace hpx::util::detail {
         return os.str();
     }
 }    // namespace hpx::util::detail
+
+namespace hpx::util {
+
+    std::string const& format()
+    {
+        static std::string empty;
+        return empty;
+    }
+}    // namespace hpx::util

--- a/libs/core/runtime_configuration/src/runtime_configuration.cpp
+++ b/libs/core/runtime_configuration/src/runtime_configuration.cpp
@@ -184,9 +184,9 @@ namespace hpx::util {
             "exception_verbosity = ${HPX_EXCEPTION_VERBOSITY:2}",
             "trace_depth = ${HPX_TRACE_DEPTH:" HPX_PP_STRINGIZE(
                 HPX_PP_EXPAND(HPX_HAVE_THREAD_BACKTRACE_DEPTH)) "}",
-#if !defined(HPX_WINDOWS)
             "handle_signals = ${HPX_HANDLE_SIGNALS:1}",
-#endif
+            "handle_failed_new = ${HPX_HANDLE_FAILED_NEW:1}",
+
             // arity for collective operations implemented in a tree fashion
             "[hpx.lcos.collectives]",
             "arity = ${HPX_LCOS_COLLECTIVES_ARITY:32}",

--- a/libs/core/schedulers/include/hpx/schedulers/queue_holder_thread.hpp
+++ b/libs/core/schedulers/include/hpx/schedulers/queue_holder_thread.hpp
@@ -585,9 +585,7 @@ namespace hpx::threads::policies {
                     debug::threadinfo<thread_id_type*>(&tid));
 
                 lk.unlock();
-                HPX_THROW_EXCEPTION(hpx::error::out_of_memory,
-                    "queue_holder_thread::add_to_thread_map",
-                    "Couldn't add new thread to the thread map {}", map_size);
+                HPX_THROW_BAD_ALLOC("queue_holder_thread::add_to_thread_map");
             }
 
             ++thread_map_count_.data_;

--- a/libs/core/schedulers/include/hpx/schedulers/thread_queue.hpp
+++ b/libs/core/schedulers/include/hpx/schedulers/thread_queue.hpp
@@ -259,9 +259,7 @@ namespace hpx::threads::policies {
                 {
                     --addfrom->new_tasks_count_.data_;
                     lk.unlock();
-                    HPX_THROW_EXCEPTION(hpx::error::out_of_memory,
-                        "thread_queue::add_new",
-                        "Couldn't add new thread to the thread map");
+                    HPX_THROW_BAD_ALLOC("thread_queue::add_new");
                 }
 
 #if defined(HPX_MSVC)
@@ -724,9 +722,7 @@ namespace hpx::threads::policies {
                 if (HPX_UNLIKELY(!p.second))
                 {
                     lk.unlock();
-                    HPX_THROWS_IF(ec, hpx::error::out_of_memory,
-                        "thread_queue::create_thread",
-                        "Couldn't add new thread to the map of threads");
+                    HPX_THROWS_BAD_ALLOC_IF(ec, "thread_queue::create_thread");
                     return;
                 }
                 ++thread_map_count_;

--- a/libs/core/threading_base/src/thread_helpers.cpp
+++ b/libs/core/threading_base/src/thread_helpers.cpp
@@ -625,8 +625,7 @@ namespace hpx::this_thread {
         std::ptrdiff_t const remaining_stack = get_available_stack_space();
         if (remaining_stack < 0)
         {
-            HPX_THROW_EXCEPTION(hpx::error::out_of_memory,
-                "has_sufficient_stack_space", "Stack overflow");
+            HPX_THROW_BAD_ALLOC("has_sufficient_stack_space");
         }
         bool const sufficient_stack_space =
             static_cast<std::size_t>(remaining_stack) >= space_needed;

--- a/libs/full/components_base/src/server/one_size_heap_list.cpp
+++ b/libs/full/components_base/src/server/one_size_heap_list.cpp
@@ -109,8 +109,7 @@ namespace hpx::util {
         if (HPX_UNLIKELY(!result || nullptr == p))
         {
             // out of memory
-            HPX_THROW_EXCEPTION(hpx::error::out_of_memory, name() + "::alloc",
-                "new heap failed to allocate {1} objects", count);
+            HPX_THROW_BAD_ALLOC("one_size_heap_list::alloc");
         }
 
 #if defined(HPX_DEBUG)

--- a/libs/full/init_runtime/src/hpx_init.cpp
+++ b/libs/full/init_runtime/src/hpx_init.cpp
@@ -134,11 +134,7 @@ namespace hpx::detail {
 #if defined(__FreeBSD__)
         freebsd_environ = env;
 #endif
-        // set a handler for std::abort, std::at_quick_exit, and std::atexit
-        [[maybe_unused]] auto const prev_signal =
-            std::signal(SIGABRT, detail::on_abort);
-        HPX_ASSERT(prev_signal != SIG_ERR);
-
+        // set a handler for std::at_quick_exit, and std::atexit
         [[maybe_unused]] auto const ret_at_exit = std::atexit(detail::on_exit);
         HPX_ASSERT(ret_at_exit == 0);
 
@@ -715,7 +711,7 @@ namespace hpx {
             if (!f.empty())
                 return rt.run(hpx::bind_front(f, vm));
 
-            // Run this runtime instance without an hpx_main
+            // Run this runtime instance without a hpx_main
             return rt.run();
         }
 
@@ -736,7 +732,7 @@ namespace hpx {
                 return rt.start(hpx::bind_front(f, vm));
             }
 
-            // Run this runtime instance without an hpx_main
+            // Run this runtime instance without a hpx_main
             return rt.start();
         }
 


### PR DESCRIPTION
- flyby: don't register signal(SIGABRT, ...) if hpx.handle_signals == 0

Fixes #6542