### PR TITLE
Fix incorrect signature of distributed API functions

### DIFF
--- a/libs/full/collectives/include/hpx/collectives/all_to_all.hpp
+++ b/libs/full/collectives/include/hpx/collectives/all_to_all.hpp
@@ -17,22 +17,22 @@ namespace hpx { namespace collectives {
     /// This function receives a set of values from all call sites operating on
     /// the given base name.
     ///
-    /// \param  basename    The base name identifying the all_to_all operation
-    /// \param  local_result The value to transmit to all
+    /// \param basename     The base name identifying the all_to_all operation
+    /// \param local_result A vector of values to transmit to all
     ///                     participating sites from this call site.
-    /// \param  num_sites   The number of participating sites (default: all
+    /// \param num_sites    The number of participating sites (default: all
     ///                     localities).
-    /// \param  generation  The generational counter identifying the sequence
+    /// \param this_site    The sequence number of this invocation (usually
+    ///                     the locality id). This value is optional and
+    ///                     defaults to whatever hpx::get_locality_id() returns.
+    /// \param generation   The generational counter identifying the sequence
     ///                     number of the all_to_all operation performed on the
     ///                     given base name. This is optional and needs to be
     ///                     supplied only if the all_to_all operation on the
     ///                     given base name has to be performed more than once.
     ///                     The generation number (if given) must be a positive
     ///                     number greater than zero.
-    /// \param this_site    The sequence number of this invocation (usually
-    ///                     the locality id). This value is optional and
-    ///                     defaults to whatever hpx::get_locality_id() returns.
-    /// \params root_site   The site that is responsible for creating the
+    /// \param root_site    The site that is responsible for creating the
     ///                     all_to_all support object. This value is optional
     ///                     and defaults to '0' (zero).
     ///
@@ -40,9 +40,9 @@ namespace hpx { namespace collectives {
     ///             values send by all participating sites. It will become
     ///             ready once the all_to_all operation has been completed.
     ///
-    template <typename T>
-    hpx::future<std::vector<std::decay_t<T>>>
-    all_to_all(char const* basename, T&& result,
+    template <typename T> hpx::future<std::vector<T>>
+    all_to_all(char const* basename,
+        std::vector<T>&& local_result,
         num_sites_arg num_sites = num_sites_arg(),
         this_site_arg this_site = this_site_arg(),
         generation_arg generation = generation_arg(),
@@ -53,13 +53,13 @@ namespace hpx { namespace collectives {
     /// This function receives a set of values from all call sites operating on
     /// the given base name.
     ///
-    /// \param  comm        A communicator object returned from \a create_communicator
-    /// \param  local_result The value to transmit to all
+    /// \param fid          A communicator object returned from \a create_communicator
+    /// \param local_result A vector of values to transmit to all
     ///                     participating sites from this call site.
     /// \param this_site    The sequence number of this invocation (usually
     ///                     the locality id). This value is optional and
     ///                     defaults to whatever hpx::get_locality_id() returns.
-    /// \param  generation  The generational counter identifying the sequence
+    /// \param generation   The generational counter identifying the sequence
     ///                     number of the all_to_all operation performed on the
     ///                     given base name. This is optional and needs to be
     ///                     supplied only if the all_to_all operation on the
@@ -71,9 +71,9 @@ namespace hpx { namespace collectives {
     ///             values send by all participating sites. It will become
     ///             ready once the all_to_all operation has been completed.
     ///
-    template <typename T>
-    hpx::future<std::vector<std::decay_t<T>>>
-    all_to_all(communicator comm, T&& result,
+    template <typename T> hpx::future<std::vector<T>>
+    all_to_all(communicator fid,
+        std::vector<T>&& local_result,
         this_site_arg this_site = this_site_arg(),
         generation_arg generation = generation_arg());
 
@@ -82,10 +82,10 @@ namespace hpx { namespace collectives {
     /// This function receives a set of values from all call sites operating on
     /// the given base name.
     ///
-    /// \param  comm        A communicator object returned from \a create_communicator
-    /// \param  local_result The value to transmit to all
+    /// \param fid          A communicator object returned from \a create_communicator
+    /// \param local_result A vector of values to transmit to all
     ///                     participating sites from this call site.
-    /// \param  generation  The generational counter identifying the sequence
+    /// \param generation   The generational counter identifying the sequence
     ///                     number of the all_to_all operation performed on the
     ///                     given base name. This is optional and needs to be
     ///                     supplied only if the all_to_all operation on the
@@ -100,9 +100,9 @@ namespace hpx { namespace collectives {
     ///             values send by all participating sites. It will become
     ///             ready once the all_to_all operation has been completed.
     ///
-    template <typename T>
-    hpx::future<std::vector<std::decay_t<T>>>
-    all_to_all(communicator comm, T&& result,
+    template <typename T> hpx::future<std::vector<T>>
+    all_to_all(communicator fid,
+        std::vector<T>&& local_result,
         generation_arg generation,
         this_site_arg this_site = this_site_arg());
 }}    // namespace hpx::collectives

--- a/libs/full/collectives/include/hpx/collectives/gather.hpp
+++ b/libs/full/collectives/include/hpx/collectives/gather.hpp
@@ -113,13 +113,13 @@ namespace hpx { namespace collectives {
     /// This function transmits the value given by \a result to a central gather
     /// site (where the corresponding \a gather_here is executed)
     ///
-    /// \param  basename    The base name identifying the gather operation
-    /// \param  result      The value to transmit to the central gather point
+    /// \param basename     The base name identifying the gather operation
+    /// \param local_result The value to transmit to the central gather point
     ///                     from this call site.
     /// \param this_site    The sequence number of this invocation (usually
     ///                     the locality id). This value is optional and
     ///                     defaults to whatever hpx::get_locality_id() returns.
-    /// \param  generation  The generational counter identifying the sequence
+    /// \param generation   The generational counter identifying the sequence
     ///                     number of the gather operation performed on the
     ///                     given base name. This is optional and needs to be
     ///                     supplied only if the gather operation on the given
@@ -134,9 +134,8 @@ namespace hpx { namespace collectives {
     ///             gathered values. It will become ready once the gather
     ///             operation has been completed.
     ///
-    template <typename T>
-    hpx::future<std::vector<decay_t<T>>>
-    gather_there(char const* basename, T&& result,
+    template <typename T> hpx::future<void>
+    gather_there(char const* basename, T&& local_result,
         this_site_arg this_site = this_site_arg(),
         generation_arg generation = generation_arg(),
         root_site_arg root_site = root_site_arg());
@@ -146,13 +145,13 @@ namespace hpx { namespace collectives {
     /// This function transmits the value given by \a result to a central gather
     /// site (where the corresponding \a gather_here is executed)
     ///
-    /// \param  comm        A communicator object returned from \a create_communicator
-    /// \param  result      The value to transmit to the central gather point
+    /// \param fid          A communicator object returned from \a create_communicator
+    /// \param local_result The value to transmit to the central gather point
     ///                     from this call site.
     /// \param this_site    The sequence number of this invocation (usually
     ///                     the locality id). This value is optional and
     ///                     defaults to whatever hpx::get_locality_id() returns.
-    /// \param  generation  The generational counter identifying the sequence
+    /// \param generation   The generational counter identifying the sequence
     ///                     number of the gather operation performed on the
     ///                     given base name. This is optional and needs to be
     ///                     supplied only if the gather operation on the given
@@ -167,9 +166,8 @@ namespace hpx { namespace collectives {
     ///             gathered values. It will become ready once the gather
     ///             operation has been completed.
     ///
-    template <typename T>
-    hpx::future<std::vector<decay_t<T>>>
-    gather_there(communicator comm, T&& result,
+    template <typename T> hpx::future<void>
+    gather_there(communicator fid, T&& local_result,
         this_site_arg this_site = this_site_arg(),
         generation_arg generation = generation_arg());
 
@@ -178,10 +176,10 @@ namespace hpx { namespace collectives {
     /// This function transmits the value given by \a result to a central gather
     /// site (where the corresponding \a gather_here is executed)
     ///
-    /// \param  comm        A communicator object returned from \a create_communicator
-    /// \param  result      The value to transmit to the central gather point
+    /// \param fid          A communicator object returned from \a create_communicator
+    /// \param local_result The value to transmit to the central gather point
     ///                     from this call site.
-    /// \param  generation  The generational counter identifying the sequence
+    /// \param generation   The generational counter identifying the sequence
     ///                     number of the gather operation performed on the
     ///                     given base name. This is optional and needs to be
     ///                     supplied only if the gather operation on the given
@@ -199,9 +197,8 @@ namespace hpx { namespace collectives {
     ///             gathered values. It will become ready once the gather
     ///             operation has been completed.
     ///
-    template <typename T>
-    hpx::future<std::vector<decay_t<T>>>
-    gather_there(communicator comm, T&& result,
+    template <typename T> hpx::future<void>
+    gather_there(communicator fid, T&& local_result,
         generation_arg generation,
         this_site_arg this_site = this_site_arg());
 }}    // namespace hpx::collectives

--- a/libs/full/init_runtime/include/hpx/hpx_finalize.hpp
+++ b/libs/full/init_runtime/include/hpx/hpx_finalize.hpp
@@ -18,10 +18,11 @@ namespace hpx {
     /// \brief Main function to gracefully terminate the HPX runtime system.
     ///
     /// The function \a hpx::finalize is the main way to (gracefully) exit any
-    /// HPX application. It should be called from one locality only (usually
-    /// the console) and it will notify all connected localities to finish
-    /// execution. Only after all other localities have exited this function
-    /// will return, allowing to exit the console locality as well.
+    /// HPX application. It must be called at least once, but can be called
+    /// multiple times as well. However, only the first invocation will have
+    /// effect. It will notify all connected localities to finish execution.
+    /// Only after all other localities have exited this function will return,
+    /// allowing to exit the console locality as well.
     ///
     /// During the execution of this function the runtime system will invoke
     /// all registered shutdown functions (see \a hpx::init) on all localities.
@@ -73,10 +74,11 @@ namespace hpx {
     /// \brief Main function to gracefully terminate the HPX runtime system.
     ///
     /// The function \a hpx::finalize is the main way to (gracefully) exit any
-    /// HPX application. It should be called from one locality only (usually
-    /// the console) and it will notify all connected localities to finish
-    /// execution. Only after all other localities have exited this function
-    /// will return, allowing to exit the console locality as well.
+    /// HPX application. It must be called at least once, but can be called
+    /// multiple times as well. However, only the first invocation will have
+    /// effect. It will notify all connected localities to finish execution.
+    /// Only after all other localities have exited this function will return,
+    /// allowing to exit the console locality as well.
     ///
     /// During the execution of this function the runtime system will invoke
     /// all registered shutdown functions (see \a hpx::init) on all localities.


### PR DESCRIPTION
Fix incorrect signature of `collectives::all_to_all` and ` collectives::gather_there`.

Towards resolving https://github.com/STEllAR-GROUP/hpx/issues/6544

Also update `hpx::finalize` documentation.