### PR TITLE
Remove superfluous HPX_MOVE()

### DIFF
--- a/libs/full/collectives/include/hpx/collectives/broadcast_direct.hpp
+++ b/libs/full/collectives/include/hpx/collectives/broadcast_direct.hpp
@@ -361,12 +361,11 @@ namespace hpx { namespace lcos {
             hpx::future<std::vector<hpx::future<std::vector<Result>>>> r)
         {
             std::vector<Result> res;
-            std::vector<hpx::future<std::vector<Result>>> fres =
-                HPX_MOVE(r.get());
+            std::vector<hpx::future<std::vector<Result>>> fres = r.get();
 
             for (hpx::future<std::vector<Result>>& f : fres)
             {
-                std::vector<Result> t = HPX_MOVE(f.get());
+                std::vector<Result> t = f.get();
                 res.reserve(res.capacity() + t.size());
                 std::move(t.begin(), t.end(), std::back_inserter(res));
             }

--- a/libs/full/collectives/include/hpx/collectives/reduce_direct.hpp
+++ b/libs/full/collectives/include/hpx/collectives/reduce_direct.hpp
@@ -209,7 +209,7 @@ namespace hpx { namespace lcos {
             Result operator()(
                 hpx::future<std::vector<hpx::future<Result>>> r) const
             {
-                std::vector<hpx::future<Result>> fres = HPX_MOVE(r.get());
+                std::vector<hpx::future<Result>> fres = r.get();
 
                 HPX_ASSERT(!fres.empty());
 


### PR DESCRIPTION
Fixes NVCC compilation errors, fixes #6563 