### PR TITLE
Fixed escape characters format to handle warning due to misinterpretation of syntax

### DIFF
--- a/cmake/templates/conf.py.in
+++ b/cmake/templates/conf.py.in
@@ -72,10 +72,10 @@ def get_info_from_file(source):
         with open(source, 'r') as file:
             # Search for patterns indicating the title and header
             for line in file:
-                if "/// \page" in line:
-                    title = line.split("/// \page", 1)[-1].strip()
-                elif "/// \headerfile" in line:
-                    header = line.split("/// \headerfile", 1)[-1].strip()
+                if "/// \\page" in line:
+                    title = line.split("/// \\page", 1)[-1].strip()
+                elif "/// \\headerfile" in line:
+                    header = line.split("/// \\headerfile", 1)[-1].strip()
 
     return title, header
 


### PR DESCRIPTION
Fixes #
Added '\' to strings containing '\'. A single '\' results in taking the following char as an escape character.
Existing code results with the following warnings:

/home/shachar/OpenSource/hpx/build3/docs/sphinx/conf.py:75: SyntaxWarning: invalid escape sequence '\p'
  if "/// \page" in line:
/home/shachar/OpenSource/hpx/build3/docs/sphinx/conf.py:76: SyntaxWarning: invalid escape sequence '\p'
  title = line.split("/// \page", 1)[-1].strip()
/home/shachar/OpenSource/hpx/build3/docs/sphinx/conf.py:77: SyntaxWarning: invalid escape sequence '\h'
  elif "/// \headerfile" in line:
/home/shachar/OpenSource/hpx/build3/docs/sphinx/conf.py:78: SyntaxWarning: invalid escape sequence '\h'
  header = line.split("/// \headerfile", 1)[-1].strip()

## Proposed Changes
Add '\' to single '\'

## Any background context you want to provide?

## Checklist

Not all points below apply to all pull requests.

- [ ] I have added a new feature and have added tests to go along with it.
- [ ] I have fixed a bug and have added a regression test.
- [ ] I have added a test using random numbers; I have made sure it uses a seed, and that random numbers generated are valid inputs for the tests.
