### PR TITLE
Add device guard for noexcept

### DIFF
--- a/libs/core/execution/include/hpx/execution/algorithms/just.hpp
+++ b/libs/core/execution/include/hpx/execution/algorithms/just.hpp
@@ -119,8 +119,11 @@ namespace hpx::execution::experimental {
 
             template <typename Receiver>
             friend auto
-            tag_invoke(connect_t, just_sender& s, Receiver&& receiver) noexcept(
+            tag_invoke(connect_t, just_sender& s, Receiver&& receiver) 
+#if !defined(HPX_COMPUTE_DEVICE_CODE)
+            noexcept(
                 util::all_of_v<std::is_nothrow_copy_constructible<Ts>...>)
+#endif
             {
                 return operation_state<Receiver>{
                     HPX_FORWARD(Receiver, receiver), s.ts};


### PR DESCRIPTION
This PR fixes the nvcc compilation issues Patrick encountered when using HPX master with Kokkos 4.4.01 and Cuda 12.5.

This seems to be the same issue as #5799 and can be fixed accordingly with this PR.

