### PR TITLE
Feature test for __builtin_frame_address

### DIFF
--- a/cmake/HPX_AddConfigTest.cmake
+++ b/cmake/HPX_AddConfigTest.cmake
@@ -251,6 +251,15 @@ function(hpx_check_for_builtin_forward_move)
 endfunction()
 
 # ##############################################################################
+function(hpx_check_for_builtin_frame_address)
+  add_hpx_config_test(
+    HPX_WITH_BUILTIN_FRAME_ADDRESS
+    SOURCE cmake/tests/builtin_frame_address.cpp
+    FILE ${ARGN}
+  )
+endfunction()
+
+# ##############################################################################
 function(hpx_check_for_libfun_std_experimental_optional)
   add_hpx_config_test(
     HPX_WITH_LIBFUN_EXPERIMENTAL_OPTIONAL

--- a/cmake/HPX_PerformCxxFeatureTests.cmake
+++ b/cmake/HPX_PerformCxxFeatureTests.cmake
@@ -173,4 +173,8 @@ function(hpx_perform_cxx_feature_tests)
 
   hpx_check_for_builtin_forward_move(DEFINITIONS HPX_HAVE_BUILTIN_FORWARD_MOVE)
 
+  hpx_check_for_builtin_frame_address(
+    DEFINITIONS HPX_HAVE_BUILTIN_FRAME_ADDRESS
+  )
+
 endfunction()

--- a/cmake/tests/builtin_frame_address.cpp
+++ b/cmake/tests/builtin_frame_address.cpp
@@ -1,0 +1,14 @@
+//  Copyright (c) 2024 Isidoros Tsaousis-Seiras
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+// test for availability of __builtin_frame_address(0)
+// This is needed because circle (build_226) defines __GNUC__
+// but does not provide the builtin
+
+int main()
+{
+    (void)__builtin_frame_address(0);
+}

--- a/libs/core/coroutines/include/hpx/coroutines/detail/get_stack_pointer.hpp
+++ b/libs/core/coroutines/include/hpx/coroutines/detail/get_stack_pointer.hpp
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <hpx/config/compiler_specific.hpp>
+#include <hpx/config/defines.hpp>
 
 #if defined(HPX_WINDOWS)
 #define HPX_HAVE_THREADS_GET_STACK_POINTER
@@ -30,7 +31,7 @@ namespace hpx::threads::coroutines::detail {
 
     inline std::size_t get_stack_ptr() noexcept
     {
-#if defined(HPX_GCC_VERSION)
+#if defined(HPX_HAVE_BUILTIN_FRAME_ADDRESS)
         return std::size_t(__builtin_frame_address(0));
 #else
         std::size_t stack_ptr = (std::numeric_limits<std::size_t>::max)();


### PR DESCRIPTION
Add a feature test for `__builtin_frame_address`. Before, it was assumed that if the compiler `__GNUC__` then `__builtin_frame_address` is available: https://github.com/STEllAR-GROUP/hpx/blob/3c0ebc8a5f23b7c4f197fa1970c4560a61e16b34/libs/core/coroutines/include/hpx/coroutines/detail/get_stack_pointer.hpp#L33-L35

But this is not the case when building HPX with [Circle](https://www.circle-lang.org/site/index.html).