### PR TITLE
Partially support data parallel for_loop

### DIFF
--- a/libs/core/algorithms/tests/unit/datapar_algorithms/CMakeLists.txt
+++ b/libs/core/algorithms/tests/unit/datapar_algorithms/CMakeLists.txt
@@ -29,6 +29,7 @@ if(HPX_WITH_DATAPAR)
       foreach_datapar
       foreach_datapar_zipiter
       foreachn_datapar
+      for_loop_datapar
       generate_datapar
       generaten_datapar
       mismatch_binary_datapar

--- a/libs/core/algorithms/tests/unit/datapar_algorithms/for_loop_datapar.cpp
+++ b/libs/core/algorithms/tests/unit/datapar_algorithms/for_loop_datapar.cpp
@@ -1,0 +1,119 @@
+//  Copyright (c) 2016-2025 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/algorithm.hpp>
+#include <hpx/datapar.hpp>
+#include <hpx/init.hpp>
+#include <hpx/modules/testing.hpp>
+
+#include <algorithm>
+#include <cstddef>
+#include <iostream>
+#include <numeric>
+#include <random>
+#include <string>
+#include <utility>
+#include <vector>
+
+///////////////////////////////////////////////////////////////////////////////
+unsigned int seed = std::random_device{}();
+std::mt19937 gen(seed);
+
+///////////////////////////////////////////////////////////////////////////////
+template <typename ExPolicy>
+void test_for_loop_idx(ExPolicy&& policy)
+{
+    static_assert(hpx::is_execution_policy_v<ExPolicy>,
+        "hpx::is_execution_policy_v<ExPolicy>");
+
+    std::vector<std::size_t> c(10007);
+    std::iota(std::begin(c), std::end(c), gen());
+
+    hpx::experimental::for_loop(
+        std::forward<ExPolicy>(policy), 0, int(c.size()), [&c](auto i) {
+            for (std::size_t e = 0; e < hpx::parallel::traits::size(i); ++e)
+                c[hpx::parallel::traits::get(i, e)] = 42;
+        });
+
+    // verify values
+    std::size_t count = 0;
+    std::for_each(std::begin(c), std::end(c), [&count](std::size_t v) -> void {
+        HPX_TEST_EQ(v, std::size_t(42));
+        ++count;
+    });
+    HPX_TEST_EQ(count, c.size());
+}
+
+template <typename ExPolicy>
+void test_for_loop_idx_async(ExPolicy&& p)
+{
+    std::vector<std::size_t> c(10007);
+    std::iota(std::begin(c), std::end(c), gen());
+
+    auto f = hpx::experimental::for_loop(
+        std::forward<ExPolicy>(p), 0, int(c.size()), [&c](auto i) {
+            for (std::size_t e = 0; e < hpx::parallel::traits::size(i); ++e)
+                c[hpx::parallel::traits::get(i, e)] = 42;
+        });
+    f.wait();
+
+    // verify values
+    std::size_t count = 0;
+    std::for_each(std::begin(c), std::end(c), [&count](std::size_t v) -> void {
+        HPX_TEST_EQ(v, std::size_t(42));
+        ++count;
+    });
+    HPX_TEST_EQ(count, c.size());
+}
+
+void for_loop_test_idx()
+{
+    using namespace hpx::execution;
+
+    test_for_loop_idx(simd);
+    test_for_loop_idx(par_simd);
+
+    test_for_loop_idx_async(simd(task));
+    test_for_loop_idx_async(par_simd(task));
+}
+
+///////////////////////////////////////////////////////////////////////////////
+int hpx_main(hpx::program_options::variables_map& vm)
+{
+    if (vm.count("seed"))
+        seed = vm["seed"].as<unsigned int>();
+
+    std::cout << "using seed: " << seed << std::endl;
+    gen.seed(seed);
+
+    for_loop_test_idx();
+
+    return hpx::local::finalize();
+}
+
+int main(int argc, char* argv[])
+{
+    // add command line option which controls the random number generator seed
+    using namespace hpx::program_options;
+    options_description desc_commandline(
+        "Usage: " HPX_APPLICATION_STRING " [options]");
+
+    desc_commandline.add_options()("seed,s", value<unsigned int>(),
+        "the random number generator seed to use for this run");
+
+    // By default this test should run on all available cores
+    std::vector<std::string> const cfg = {"hpx.os_threads=all"};
+
+    // Initialize and run HPX
+    hpx::local::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::local::init(hpx_main, argc, argv, init_args), 0,
+        "HPX main exited with non-zero status");
+
+    return hpx::util::report_errors();
+}

--- a/libs/core/execution/include/hpx/execution/traits/detail/eve/vector_pack_get_set.hpp
+++ b/libs/core/execution/include/hpx/execution/traits/detail/eve/vector_pack_get_set.hpp
@@ -9,24 +9,49 @@
 #include <hpx/config.hpp>
 
 #if defined(HPX_HAVE_DATAPAR_EVE)
+
+#include <hpx/assert.hpp>
+#include <hpx/concepts/concepts.hpp>
+#include <hpx/execution/traits/detail/simd/vector_pack_simd.hpp>
+#include <hpx/execution/traits/vector_pack_alignment_size.hpp>
+
 #include <cstddef>
 
 namespace hpx::parallel::traits {
 
     ///////////////////////////////////////////////////////////////////////
-    template <typename Vector>
+    template <typename Vector, HPX_CONCEPT_REQUIRES_(is_vector_pack_v<Vector>)>
     HPX_HOST_DEVICE HPX_FORCEINLINE auto get(
         Vector& vec, std::size_t index) noexcept
     {
         return vec.get(index);
     }
 
+    template <typename Scalar,
+        HPX_CONCEPT_REQUIRES_(is_scalar_vector_pack_v<Scalar>)>
+    HPX_HOST_DEVICE HPX_FORCEINLINE auto get(
+        Scalar& sc, [[maybe_unused]] std::size_t index) noexcept
+    {
+        HPX_ASSERT(index == 0);
+        return sc;
+    }
+
     ///////////////////////////////////////////////////////////////////////
-    template <typename Vector, typename T>
+    template <typename Vector, typename T,
+        HPX_CONCEPT_REQUIRES_(is_vector_pack_v<Vector>)>
     HPX_HOST_DEVICE HPX_FORCEINLINE auto set(
         Vector& vec, std::size_t index, T val) noexcept
     {
         vec.set(index, val);
+    }
+
+    template <typename Scalar, typename T,
+        HPX_CONCEPT_REQUIRES_(is_scalar_vector_pack_v<Scalar>)>
+    HPX_HOST_DEVICE HPX_FORCEINLINE auto set(
+        Scalar& sc, [[maybe_unused]] std::size_t index, T val) noexcept
+    {
+        HPX_ASSERT(index == 0);
+        sc = val;
     }
 }    // namespace hpx::parallel::traits
 

--- a/libs/core/execution/include/hpx/execution/traits/detail/simd/vector_pack_get_set.hpp
+++ b/libs/core/execution/include/hpx/execution/traits/detail/simd/vector_pack_get_set.hpp
@@ -10,26 +10,48 @@
 
 #if defined(HPX_HAVE_DATAPAR_EXPERIMENTAL_SIMD)
 
+#include <hpx/assert.hpp>
+#include <hpx/concepts/concepts.hpp>
 #include <hpx/execution/traits/detail/simd/vector_pack_simd.hpp>
+#include <hpx/execution/traits/vector_pack_alignment_size.hpp>
 
 #include <cstddef>
 
 namespace hpx::parallel::traits {
 
     ///////////////////////////////////////////////////////////////////////
-    template <typename Vector>
+    template <typename Vector, HPX_CONCEPT_REQUIRES_(is_vector_pack_v<Vector>)>
     HPX_HOST_DEVICE HPX_FORCEINLINE auto get(
         Vector& vec, std::size_t index) noexcept
     {
         return vec[index];
     }
 
+    template <typename Scalar,
+        HPX_CONCEPT_REQUIRES_(is_scalar_vector_pack_v<Scalar>)>
+    HPX_HOST_DEVICE HPX_FORCEINLINE auto get(
+        Scalar& sc, [[maybe_unused]] std::size_t index) noexcept
+    {
+        HPX_ASSERT(index == 0);
+        return sc;
+    }
+
     ///////////////////////////////////////////////////////////////////////
-    template <typename Vector, typename T>
+    template <typename Vector, typename T,
+        HPX_CONCEPT_REQUIRES_(is_vector_pack_v<Vector>)>
     HPX_HOST_DEVICE HPX_FORCEINLINE auto set(
         Vector& vec, std::size_t index, T val) noexcept
     {
-        datapar::experimental::set(vec, index, val);
+        hpx::datapar::experimental::set(vec, index, val);
+    }
+
+    template <typename Scalar, typename T,
+        HPX_CONCEPT_REQUIRES_(is_scalar_vector_pack_v<Scalar>)>
+    HPX_HOST_DEVICE HPX_FORCEINLINE auto set(
+        Scalar& sc, [[maybe_unused]] std::size_t index, T val) noexcept
+    {
+        HPX_ASSERT(index == 0);
+        sc = val;
     }
 }    // namespace hpx::parallel::traits
 

--- a/libs/core/execution/include/hpx/execution/traits/detail/vc/vector_pack_get_set.hpp
+++ b/libs/core/execution/include/hpx/execution/traits/detail/vc/vector_pack_get_set.hpp
@@ -9,12 +9,17 @@
 #include <hpx/config.hpp>
 
 #if defined(HPX_HAVE_DATAPAR_VC)
+#include <hpx/concepts/concepts.hpp>
+#include <hpx/execution/traits/vector_pack_alignment_size.hpp>
+
 #include <cstddef>
 
 namespace hpx::parallel::traits {
 
     ///////////////////////////////////////////////////////////////////////
-    template <typename Vector>
+    template <typename Vector,
+        HPX_CONCEPT_REQUIRES_(
+            is_vector_pack_v<Vector> || is_scalar_vector_pack_v<Vector>)>
     HPX_HOST_DEVICE HPX_FORCEINLINE auto get(
         Vector& vec, std::size_t index) noexcept
     {
@@ -22,7 +27,9 @@ namespace hpx::parallel::traits {
     }
 
     ///////////////////////////////////////////////////////////////////////
-    template <typename Vector, typename T>
+    template <typename Vector, typename T,
+        HPX_CONCEPT_REQUIRES_(
+            is_vector_pack_v<Vector> || is_scalar_vector_pack_v<Vector>)>
     HPX_HOST_DEVICE HPX_FORCEINLINE auto set(
         Vector& vec, std::size_t index, T val) noexcept
     {

--- a/libs/core/execution/include/hpx/execution/traits/vector_pack_alignment_size.hpp
+++ b/libs/core/execution/include/hpx/execution/traits/vector_pack_alignment_size.hpp
@@ -88,6 +88,15 @@ namespace hpx::parallel::traits {
     template <typename T>
     inline constexpr std::size_t vector_pack_size_v =
         vector_pack_size<T>::value;
+
+    ////////////////////////////////////////////////////////////////////////////
+    template <typename Pack,
+        typename Enable = std::enable_if_t<is_vector_pack_v<Pack> ||
+            is_scalar_vector_pack_v<Pack>>>
+    constexpr std::size_t size(Pack) noexcept
+    {
+        return vector_pack_size_v<Pack>;
+    }
 }    // namespace hpx::parallel::traits
 
 #if !defined(__CUDACC__)

--- a/libs/core/mpi_base/include/hpx/mpi_base/mpi_environment.hpp
+++ b/libs/core/mpi_base/include/hpx/mpi_base/mpi_environment.hpp
@@ -44,7 +44,8 @@ namespace hpx::util {
         static std::string get_processor_name();
 
         static MPI_Datatype type_contiguous(size_t nbytes);
-        static MPI_Request isend(void* address, size_t size, int rank, int tag);
+        static MPI_Request isend(
+            void const* address, size_t size, int rank, int tag);
         static MPI_Request irecv(void* address, size_t size, int rank, int tag);
 
         struct HPX_CORE_EXPORT scoped_lock

--- a/libs/core/mpi_base/src/mpi_environment.cpp
+++ b/libs/core/mpi_base/src/mpi_environment.cpp
@@ -470,9 +470,9 @@ namespace hpx::util {
     }
 
     // Acknowledgement: code adapted from github.com/jeffhammond/BigMPI
-    MPI_Datatype mpi_environment::type_contiguous(size_t nbytes)
+    MPI_Datatype mpi_environment::type_contiguous(size_t const nbytes)
     {
-        size_t int_max = (std::numeric_limits<int>::max)();
+        constexpr int int_max = (std::numeric_limits<int>::max)();
 
         size_t c = nbytes / int_max;
         size_t r = nbytes % int_max;
@@ -481,13 +481,14 @@ namespace hpx::util {
         HPX_ASSERT(r < int_max);
 
         MPI_Datatype chunks;
-        MPI_Type_vector(c, int_max, int_max, MPI_BYTE, &chunks);
+        MPI_Type_vector(
+            static_cast<int>(c), int_max, int_max, MPI_BYTE, &chunks);
 
         MPI_Datatype remainder;
-        MPI_Type_contiguous(r, MPI_BYTE, &remainder);
+        MPI_Type_contiguous(static_cast<int>(r), MPI_BYTE, &remainder);
 
-        MPI_Aint remdisp = (MPI_Aint) c * int_max;
-        int blocklengths[2] = {1, 1};
+        MPI_Aint const remdisp = static_cast<MPI_Aint>(c) * int_max;
+        constexpr int blocklengths[2] = {1, 1};
         MPI_Aint displacements[2] = {0, remdisp};
         MPI_Datatype types[2] = {chunks, remainder};
         MPI_Datatype newtype;
@@ -500,7 +501,7 @@ namespace hpx::util {
     }
 
     MPI_Request mpi_environment::isend(
-        void* address, size_t size, int rank, int tag)
+        void const* address, size_t size, int rank, int tag)
     {
         MPI_Request request;
         MPI_Datatype datatype;

--- a/libs/full/performance_counters/include/hpx/performance_counters/query_counters.hpp
+++ b/libs/full/performance_counters/include/hpx/performance_counters/query_counters.hpp
@@ -88,19 +88,19 @@ namespace hpx::util {
             performance_counters::counter_values_array const& value);
 
         template <typename Stream>
-        static void print_name_csv(Stream& out, std::string const& name);
+        void print_name_csv(Stream& out, std::string const& name);
 
         template <typename Stream>
-        static void print_value_csv(Stream* out,
+        void print_value_csv(Stream* out,
             performance_counters::counter_info const& infos,
             performance_counters::counter_value const& value);
         template <typename Stream>
-        static void print_value_csv(Stream* out,
+        void print_value_csv(Stream* out,
             performance_counters::counter_info const& infos,
             performance_counters::counter_values_array const& value);
 
         template <typename Stream>
-        static void print_name_csv_short(Stream& out, std::string const& name);
+        void print_name_csv_short(Stream& out, std::string const& name);
 
     private:
         using mutex_type = hpx::mutex;


### PR DESCRIPTION
This adds support for using the simd execution policies with `hpx::experimental::for_loop`. The support is restricted to using `for_loop` with integral loop boundaries. Using reduction/induction objects in this case will fall back to non-simd execution..