### PR TITLE
Fix Hwloc fetch content

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2278,6 +2278,10 @@ include(HPX_SetupAsio)
 
 # Find all allocators which are currently supported.
 include(HPX_SetupAllocator)
+
+if (HPX_WITH_FETCH_HWLOC)
+  set(HPX_HWLOC_INSTALL_PATH ${CMAKE_INSTALL_PREFIX}/hwloc_installed)
+endif()
 include(HPX_SetupHwloc)
 
 # reset external source lists

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2279,7 +2279,7 @@ include(HPX_SetupAsio)
 # Find all allocators which are currently supported.
 include(HPX_SetupAllocator)
 
-if (HPX_WITH_FETCH_HWLOC)
+if(HPX_WITH_FETCH_HWLOC)
   set(HPX_HWLOC_INSTALL_PATH ${CMAKE_INSTALL_PREFIX}/hwloc_installed)
 endif()
 include(HPX_SetupHwloc)

--- a/cmake/HPX_FindHwloc.cmake
+++ b/cmake/HPX_FindHwloc.cmake
@@ -10,4 +10,3 @@ if(NOT Hwloc_FOUND)
     "Hwloc could not be found, please specify Hwloc_ROOT to point to the correct location"
   )
 endif()
-

--- a/cmake/HPX_FindHwloc.cmake
+++ b/cmake/HPX_FindHwloc.cmake
@@ -1,0 +1,13 @@
+# Copyright (c) 2025 Srinivas Yadav Singanaboina
+#
+# SPDX-License-Identifier: BSL-1.0
+# Distributed under the Boost Software License, Version 1.0. (See accompanying
+# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+find_package(Hwloc)
+if(NOT Hwloc_FOUND)
+  hpx_error(
+    "Hwloc could not be found, please specify Hwloc_ROOT to point to the correct location"
+  )
+endif()
+

--- a/cmake/HPX_SetupHwloc.cmake
+++ b/cmake/HPX_SetupHwloc.cmake
@@ -118,6 +118,25 @@ else()
   endif() # End hwloc installation
 
   find_package(Hwloc)
+
+  if(HPX_WITH_FETCH_HWLOC AND "${CMAKE_SYSTEM_NAME}" STREQUAL "Windows")
+    if(RUNTIME_OUTPUT_DIRECTORY)
+      set(EXE_DIRECTORY_PATH "${RUNTIME_OUTPUT_DIRECTORY}")
+    else()
+      set(EXE_DIRECTORY_PATH "${CMAKE_BINARY_DIR}/$<CONFIG>/bin/")
+    endif()
+
+    set(DLL_PATH "${HWLOC_ROOT}/bin/libhwloc-15.dll")
+    add_custom_target(
+      HwlocDLL ALL
+      COMMAND ${CMAKE_COMMAND} -E make_directory ${EXE_DIRECTORY_PATH}
+      COMMAND ${CMAKE_COMMAND} -E copy_if_different ${DLL_PATH}
+              ${EXE_DIRECTORY_PATH}
+    )
+    install(FILES ${DLL_PATH} DESTINATION ${CMAKE_INSTALL_BINDIR})
+    add_hpx_pseudo_target(HwlocDLL)
+  endif()
+
   install(
     DIRECTORY ${HWLOC_ROOT}/
     DESTINATION ${HPX_HWLOC_INSTALL_PATH}

--- a/cmake/HPX_SetupHwloc.cmake
+++ b/cmake/HPX_SetupHwloc.cmake
@@ -111,6 +111,7 @@ else()
         ${HWLOC_ROOT}/lib/libhwloc.dll.a
         CACHE INTERNAL ""
     )
+    file(GLOB HWLOC_DLL ${HWLOC_ROOT}/bin/libhwloc*.dll)
   else()
     hpx_error(
       "Building HWLOC as part of HPX' configuration process is not supported on this platform"
@@ -126,17 +127,16 @@ else()
       set(EXE_DIRECTORY_PATH "${CMAKE_BINARY_DIR}/$<CONFIG>/bin/")
     endif()
 
-    set(DLL_PATH ${Hwloc_LIBRARY})
-    message("Copying ${DLL_PATH} to ${EXE_DIRECTORY_PATH}")
+    message("Copying ${HWLOC_DLL} to ${EXE_DIRECTORY_PATH}")
     add_custom_target(
       HwlocDLL ALL
       COMMAND ${CMAKE_COMMAND} -E make_directory ${EXE_DIRECTORY_PATH}
-      COMMAND ${CMAKE_COMMAND} -E copy_if_different ${DLL_PATH}
+      COMMAND ${CMAKE_COMMAND} -E copy_if_different ${HWLOC_DLL}
               ${EXE_DIRECTORY_PATH}
     )
-    install(FILES ${DLL_PATH} DESTINATION ${CMAKE_INSTALL_BINDIR})
-     add_hpx_pseudo_target(HwlocDLL)
-     add_dependencies(Hwloc::hwloc HwlocDLL)
+    install(FILES ${HWLOC_DLL} DESTINATION ${CMAKE_INSTALL_BINDIR})
+    add_hpx_pseudo_target(HwlocDLL)
+    add_dependencies(Hwloc::hwloc HwlocDLL)
   endif()
 
   install(

--- a/cmake/HPX_SetupHwloc.cmake
+++ b/cmake/HPX_SetupHwloc.cmake
@@ -126,7 +126,8 @@ else()
       set(EXE_DIRECTORY_PATH "${CMAKE_BINARY_DIR}/$<CONFIG>/bin/")
     endif()
 
-    set(DLL_PATH "${HWLOC_ROOT}/bin/libhwloc-15.dll")
+    set(DLL_PATH ${Hwloc_LIBRARY})
+    message("Copying ${DLL_PATH} to ${EXE_DIRECTORY_PATH})
     add_custom_target(
       HwlocDLL ALL
       COMMAND ${CMAKE_COMMAND} -E make_directory ${EXE_DIRECTORY_PATH}

--- a/cmake/HPX_SetupHwloc.cmake
+++ b/cmake/HPX_SetupHwloc.cmake
@@ -8,6 +8,7 @@
 # Copyright (c) 2017      Abhimanyu Rawat
 # Copyright (c) 2017      Google
 # Copyright (c) 2017      Taeguk Kwon
+# Copyright (c) 2025      Srinivas Yadav Singanaboina
 #
 # SPDX-License-Identifier: BSL-1.0
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -44,11 +45,12 @@ else()
     )
     if(NOT HWLoc_POPULATED)
       fetchcontent_populate(HWLoc)
+      set(HPX_HWLOC_BUILD_DIR_INSTALLATION_PATH "${FETCHCONTENT_BASE_DIR}/hwloc_installed")
       if(NOT Hwloc_BUILD_INSTALLED)
         execute_process(
           COMMAND
             sh -c
-            "cd ${FETCHCONTENT_BASE_DIR}/hwloc-src && ./configure --prefix=${FETCHCONTENT_BASE_DIR}/hwloc-installed && make -j && make install"
+            "cd ${FETCHCONTENT_BASE_DIR}/hwloc-src && ./configure --prefix=${HPX_HWLOC_BUILD_DIR_INSTALLATION_PATH} && make -j && make install"
         )
         set(Hwloc_BUILD_INSTALLED
             TRUE
@@ -59,8 +61,8 @@ else()
           "HWLoc is installed at ${FETCHCONTENT_BASE_DIR}/hwloc-installed"
         )
       endif()
+      set(HWLOC_ROOT ${HPX_HWLOC_BUILD_DIR_INSTALLATION_PATH})
     endif()
-    set(HWLOC_ROOT "${FETCHCONTENT_BASE_DIR}/hwloc-installed")
     set(Hwloc_INCLUDE_DIR
         ${HWLOC_ROOT}/include
         CACHE INTERNAL ""
@@ -113,26 +115,10 @@ else()
     )
   endif() # End hwloc installation
 
-  add_library(Hwloc::hwloc INTERFACE IMPORTED)
-  target_include_directories(Hwloc::hwloc INTERFACE ${Hwloc_INCLUDE_DIR})
-  target_link_libraries(Hwloc::hwloc INTERFACE ${Hwloc_LIBRARY})
-
-  if(HPX_WITH_FETCH_HWLOC AND "${CMAKE_SYSTEM_NAME}" STREQUAL "Windows")
-    if(RUNTIME_OUTPUT_DIRECTORY)
-      set(EXE_DIRECTORY_PATH "${RUNTIME_OUTPUT_DIRECTORY}")
-    else()
-      set(EXE_DIRECTORY_PATH "${CMAKE_BINARY_DIR}/$<CONFIG>/bin/")
-    endif()
-
-    set(DLL_PATH "${HWLOC_ROOT}/bin/libhwloc-15.dll")
-    add_custom_target(
-      HwlocDLL ALL
-      COMMAND ${CMAKE_COMMAND} -E make_directory ${EXE_DIRECTORY_PATH}
-      COMMAND ${CMAKE_COMMAND} -E copy_if_different ${DLL_PATH}
-              ${EXE_DIRECTORY_PATH}
-    )
-    install(FILES ${DLL_PATH} DESTINATION ${CMAKE_INSTALL_BINDIR})
-    add_hpx_pseudo_target(HwlocDLL)
-  endif()
-
+  find_package(Hwloc)
+  install(
+    DIRECTORY ${HWLOC_ROOT}/
+    DESTINATION ${HPX_HWLOC_INSTALL_PATH}
+    COMPONENT core
+  )
 endif()

--- a/cmake/HPX_SetupHwloc.cmake
+++ b/cmake/HPX_SetupHwloc.cmake
@@ -45,7 +45,9 @@ else()
     )
     if(NOT HWLoc_POPULATED)
       fetchcontent_populate(HWLoc)
-      set(HPX_HWLOC_BUILD_DIR_INSTALLATION_PATH "${FETCHCONTENT_BASE_DIR}/hwloc_installed")
+      set(HPX_HWLOC_BUILD_DIR_INSTALLATION_PATH
+          "${FETCHCONTENT_BASE_DIR}/hwloc_installed"
+      )
       if(NOT Hwloc_BUILD_INSTALLED)
         execute_process(
           COMMAND

--- a/cmake/HPX_SetupHwloc.cmake
+++ b/cmake/HPX_SetupHwloc.cmake
@@ -136,7 +136,7 @@ else()
     )
     install(FILES ${DLL_PATH} DESTINATION ${CMAKE_INSTALL_BINDIR})
      add_hpx_pseudo_target(HwlocDLL)
-     target_link_libraries(Hwloc::hwloc INTERFACE HwlocDLL)
+     add_dependencies(Hwloc::hwloc HwlocDLL)
   endif()
 
   install(

--- a/cmake/HPX_SetupHwloc.cmake
+++ b/cmake/HPX_SetupHwloc.cmake
@@ -135,7 +135,8 @@ else()
               ${EXE_DIRECTORY_PATH}
     )
     install(FILES ${DLL_PATH} DESTINATION ${CMAKE_INSTALL_BINDIR})
-    add_hpx_pseudo_target(HwlocDLL)
+     add_hpx_pseudo_target(HwlocDLL)
+     target_link_libraries(Hwloc::hwloc INTERFACE HwlocDLL)
   endif()
 
   install(

--- a/cmake/HPX_SetupHwloc.cmake
+++ b/cmake/HPX_SetupHwloc.cmake
@@ -123,7 +123,7 @@ else()
     if(RUNTIME_OUTPUT_DIRECTORY)
       set(EXE_DIRECTORY_PATH "${RUNTIME_OUTPUT_DIRECTORY}")
     else()
-      set(EXE_DIRECTORY_PATH "${CMAKE_BINARY_DIR}/$<CONFIG>/bin/")
+      set(EXE_DIRECTORY_PATH "${CMAKE_BINARY_DIR}/bin/")
     endif()
 
     set(DLL_PATH ${Hwloc_LIBRARY})

--- a/cmake/HPX_SetupHwloc.cmake
+++ b/cmake/HPX_SetupHwloc.cmake
@@ -123,7 +123,7 @@ else()
     if(RUNTIME_OUTPUT_DIRECTORY)
       set(EXE_DIRECTORY_PATH "${RUNTIME_OUTPUT_DIRECTORY}")
     else()
-      set(EXE_DIRECTORY_PATH "${CMAKE_BINARY_DIR}/bin/")
+      set(EXE_DIRECTORY_PATH "${CMAKE_BINARY_DIR}/${CMAKE_BUILD_TYPE}/bin/")
     endif()
 
     set(DLL_PATH ${Hwloc_LIBRARY})

--- a/cmake/HPX_SetupHwloc.cmake
+++ b/cmake/HPX_SetupHwloc.cmake
@@ -127,7 +127,7 @@ else()
     endif()
 
     set(DLL_PATH ${Hwloc_LIBRARY})
-    message("Copying ${DLL_PATH} to ${EXE_DIRECTORY_PATH})
+    message("Copying ${DLL_PATH} to ${EXE_DIRECTORY_PATH}")
     add_custom_target(
       HwlocDLL ALL
       COMMAND ${CMAKE_COMMAND} -E make_directory ${EXE_DIRECTORY_PATH}

--- a/cmake/HPX_SetupHwloc.cmake
+++ b/cmake/HPX_SetupHwloc.cmake
@@ -123,7 +123,7 @@ else()
     if(RUNTIME_OUTPUT_DIRECTORY)
       set(EXE_DIRECTORY_PATH "${RUNTIME_OUTPUT_DIRECTORY}")
     else()
-      set(EXE_DIRECTORY_PATH "${CMAKE_BINARY_DIR}/${CMAKE_BUILD_TYPE}/bin/")
+      set(EXE_DIRECTORY_PATH "${CMAKE_BINARY_DIR}/$<CONFIG>/bin/")
     endif()
 
     set(DLL_PATH ${Hwloc_LIBRARY})

--- a/cmake/templates/HPXConfig.cmake.in
+++ b/cmake/templates/HPXConfig.cmake.in
@@ -172,8 +172,16 @@ include(HPX_SetupBoostIostreams)
 include(HPX_SetupHIP)
 
 # Hwloc
-set(HPX_HWLOC_ROOT "@Hwloc_ROOT@")
-include(HPX_SetupHwloc)
+if(HPX_WITH_FETCH_HWLOC)
+  if(EXISTS ${HPX_PREFIX}/_deps/hwloc_installed)
+    set(Hwloc_ROOT ${HPX_PREFIX}/_deps/hwloc_installed)
+  else()
+    set(Hwloc_ROOT "@HPX_HWLOC_INSTALL_PATH@")
+  endif()
+else()
+  set(Hwloc_ROOT "@Hwloc_ROOT@")
+endif()
+include(HPX_FindHwloc)
 
 # Papi
 set(HPX_PAPI_ROOT "@Papi_ROOT@")


### PR DESCRIPTION
Fixes HWLOC FETCH CONTENT

## Proposed Changes

  - installs **HWLOC** into `CMAKE_INSTALL_PREFIX/hwloc_installed`
  - uses `find_package` to find hwloc in all scenarios

