### PR TITLE
Link aclocal with aclocal-1.16 as hwloc asks for it

### DIFF
--- a/.github/workflows/macos_debug_fetch_hwloc.yml
+++ b/.github/workflows/macos_debug_fetch_hwloc.yml
@@ -36,6 +36,7 @@ jobs:
               -DHPX_WITH_VERIFY_LOCKS=ON \
               -DHPX_WITH_VERIFY_LOCKS_BACKTRACE=ON \
               -DHPX_WITH_CHECK_MODULE_DEPENDENCIES=ON
+          ln -s "$(which aclocal)" /opt/homebrew/bin/aclocal-1.16
           cd build/_deps/hwloc-src/ && autoreconf -f -i
     - name: Build
       shell: bash


### PR DESCRIPTION
MacOS CI fails because it cannot find aclocal-1.16 for hwloc

