### PR TITLE
Fix CPUId test

### DIFF
--- a/cmake/tests/cpuid.cpp
+++ b/cmake/tests/cpuid.cpp
@@ -8,6 +8,7 @@
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 ////////////////////////////////////////////////////////////////////////////////
 
+#include <cstdint>
 #include <cstdlib>
 #include <string>
 using namespace std;


### PR DESCRIPTION
`cmake/tests/cpuid.cpp` uses `uint32_t` but does not include the appropriate header which defines the type.

The test hence, fails to compile.

[Godbolt link](https://godbolt.org/z/oPbfPzona)

## Proposed Changes

  - include `cstdint`


