### PR TITLE
Fixing collectives::exclusive_scan

### DIFF
--- a/libs/full/collectives/include/hpx/collectives/exclusive_scan.hpp
+++ b/libs/full/collectives/include/hpx/collectives/exclusive_scan.hpp
@@ -28,23 +28,28 @@ namespace hpx { namespace collectives {
     ///                     the locality id). This value is optional and
     ///                     defaults to whatever hpx::get_locality_id() returns.
     /// \param  generation  The generational counter identifying the sequence
-    ///                     number of the exclusive_scan operation performed on the
-    ///                     given base name. This is optional and needs to be
-    ///                     supplied only if the exclusive_scan operation on the
-    ///                     given base name has to be performed more than once.
-    ///                     The generation number (if given) must be a positive
-    ///                     number greater than zero.
+    ///                     number of the exclusive_scan operation performed on
+    ///                     the given base name. This is optional and needs to
+    ///                     be supplied only if the exclusive_scan operation on
+    ///                     the given base name has to be performed more than
+    ///                     once. The generation number (if given) must be a
+    ///                     positive number greater than zero.
     /// \param  root_site   The site that is responsible for creating the
-    ///                     exclusive_scan support object. This value is optional
-    ///                     and defaults to '0' (zero).
+    ///                     exclusive_scan support object. This value is
+    ///                     optional and defaults to '0' (zero).
     ///
     /// \note       The result returned on the root_site is always the same as
     ///             the result returned on thus_site == 1 and is the same as the
     ///             value provided by the root_site.
     ///
-    /// \returns    This function returns a future holding a vector with all
-    ///             values send by all participating sites. It will become
-    ///             ready once the exclusive_scan operation has been completed.
+    /// \returns    For the participating site i this function returns a future
+    ///             the reduction (calculated according to the function op) of
+    ///             the values passed in by the participating sites 0, ..., i-1.
+    ///             The value returned on participating site 0 is undefined. The
+    ///             value returned on participating site on process 1 is always
+    ///             the value passed in by participating site 1. The returned
+    ///             future will become ready once the exclusive_scan operation
+    ///             has been completed.
     ///
     template <typename T, typename F>
     hpx::future<std::decay_t<T>> exclusive_scan(char const* basename, T&& result,
@@ -78,9 +83,14 @@ namespace hpx { namespace collectives {
     ///             the result returned on thus_site == 1 and is the same as the
     ///             value provided by the root_site.
     ///
-    /// \returns    This function returns a future holding a vector with all
-    ///             values send by all participating sites. It will become
-    ///             ready once the exclusive_scan operation has been completed.
+    /// \returns    For the participating site i this function returns a future
+    ///             the reduction (calculated according to the function op) of
+    ///             the values passed in by the participating sites 0, ..., i-1.
+    ///             The value returned on participating site 0 is undefined. The
+    ///             value returned on participating site on process 1 is always
+    ///             the value passed in by participating site 1. The returned
+    ///             future will become ready once the exclusive_scan operation
+    ///             has been completed.
     ///
     template <typename T, typename F>
     hpx::future<std::decay_t<T>> exclusive_scan(
@@ -113,9 +123,14 @@ namespace hpx { namespace collectives {
     ///             the result returned on thus_site == 1 and is the same as the
     ///             value provided by the root_site.
     ///
-    /// \returns    This function returns a future holding a vector with all
-    ///             values send by all participating sites. It will become
-    ///             ready once the exclusive_scan operation has been completed.
+    /// \returns    For the participating site i this function returns a future
+    ///             the reduction (calculated according to the function op) of
+    ///             the values passed in by the participating sites 0, ..., i-1.
+    ///             The value returned on participating site 0 is undefined. The
+    ///             value returned on participating site on process 1 is always
+    ///             the value passed in by participating site 1. The returned
+    ///             future will become ready once the exclusive_scan operation
+    ///             has been completed.
     ///
     template <typename T, typename F>
     hpx::future<std::decay_t<T>> exclusive_scan(
@@ -154,9 +169,14 @@ namespace hpx { namespace collectives {
     ///             the result returned on thus_site == 1 and is the same as the
     ///             value provided by the root_site.
     ///
-    /// \returns    This function returns a vector with all values send by all
-    ///             participating sites. This function executes synchronously and
-    ///             directly returns the result.
+    /// \returns    For the participating site i this function returns a future
+    ///             the reduction (calculated according to the function op) of
+    ///             the values passed in by the participating sites 0, ..., i-1.
+    ///             The value returned on participating site 0 is undefined. The
+    ///             value returned on participating site on process 1 is always
+    ///             the value passed in by participating site 1. The returned
+    ///             future will become ready once the exclusive_scan operation
+    ///             has been completed.
     ///
     template <typename T, typename F>
     decltype(auto) exclusive_scan(hpx::launch::sync_policy,
@@ -181,20 +201,25 @@ namespace hpx { namespace collectives {
     ///                     the locality id). This value is optional and
     ///                     defaults to whatever hpx::get_locality_id() returns.
     /// \param  generation  The generational counter identifying the sequence
-    ///                     number of the exclusive_scan operation performed on the
-    ///                     given base name. This is optional and needs to be
-    ///                     supplied only if the exclusive_scan operation on the
-    ///                     given base name has to be performed more than once.
-    ///                     The generation number (if given) must be a positive
-    ///                     number greater than zero.
+    ///                     number of the exclusive_scan operation performed on
+    ///                     the given base name. This is optional and needs to
+    ///                     be supplied only if the exclusive_scan operation on
+    ///                     the given base name has to be performed more than
+    ///                     once. The generation number (if given) must be a
+    ///                     positive number greater than zero.
     ///
     /// \note       The result returned on the root_site is always the same as
     ///             the result returned on thus_site == 1 and is the same as the
     ///             value provided by the root_site.
     ///
-    /// \returns    This function returns a vector with all values send by all
-    ///             participating sites. This function executes synchronously and
-    ///             directly returns the result.
+    /// \returns    For the participating site i this function returns a future
+    ///             the reduction (calculated according to the function op) of
+    ///             the values passed in by the participating sites 0, ..., i-1.
+    ///             The value returned on participating site 0 is undefined. The
+    ///             value returned on participating site on process 1 is always
+    ///             the value passed in by participating site 1. The returned
+    ///             future will become ready once the exclusive_scan operation
+    ///             has been completed.
     ///
     template <typename T, typename F>
     decltype(auto) exclusive_scan(hpx::launch::sync_policy, communicator comm,
@@ -213,12 +238,12 @@ namespace hpx { namespace collectives {
     /// \param  op          Reduction operation to apply to all values supplied
     ///                     from all participating sites
     /// \param  generation  The generational counter identifying the sequence
-    ///                     number of the exclusive_scan operation performed on the
-    ///                     given base name. This is optional and needs to be
-    ///                     supplied only if the exclusive_scan operation on the
-    ///                     given base name has to be performed more than once.
-    ///                     The generation number (if given) must be a positive
-    ///                     number greater than zero.
+    ///                     number of the exclusive_scan operation performed on
+    ///                     the given base name. This is optional and needs to
+    ///                     be supplied only if the exclusive_scan operation on
+    ///                     the given base name has to be performed more than
+    ///                     once. The generation number (if given) must be a
+    ///                     positive number greater than zero.
     /// \param this_site    The sequence number of this invocation (usually
     ///                     the locality id). This value is optional and
     ///                     defaults to whatever hpx::get_locality_id() returns.
@@ -227,9 +252,14 @@ namespace hpx { namespace collectives {
     ///             the result returned on thus_site == 1 and is the same as the
     ///             value provided by the root_site.
     ///
-    /// \returns    This function returns a vector with all values send by all
-    ///             participating sites. This function executes synchronously and
-    ///             directly returns the result.
+    /// \returns    For the participating site i this function returns the
+    ///             reduction (calculated according to the function op) of
+    ///             the values passed in by the participating sites 0, ..., i-1.
+    ///             The value returned on participating site 0 is undefined. The
+    ///             value returned on
+    ///             participating site  on process 1 is always the value passed
+    ///             in by participating site 1. The returned future will become
+    ///             ready once the exclusive_scan operation has been completed.
     ///
     template <typename T, typename F>
     decltype(auto) exclusive_scan(hpx::launch::sync_policy, communicator comm,
@@ -249,6 +279,7 @@ namespace hpx { namespace collectives {
 #include <hpx/collectives/argument_types.hpp>
 #include <hpx/collectives/create_communicator.hpp>
 #include <hpx/components_base/agas_interface.hpp>
+#include <hpx/concepts/concepts.hpp>
 #include <hpx/futures/future.hpp>
 #include <hpx/parallel/algorithms/exclusive_scan.hpp>
 #include <hpx/type_support/unused.hpp>
@@ -258,14 +289,40 @@ namespace hpx { namespace collectives {
 #include <utility>
 #include <vector>
 
+namespace hpx::collectives::detail {
+
+    template <typename T, typename InIter, typename Sent, typename OutIter,
+        typename Op>
+    static constexpr void exclusive_scan(
+        InIter first, Sent last, OutIter dest, Op&& op)
+    {
+        // the first value given goes to the second destination
+        T temp = *first++;
+        ++dest;    // the first output is ignored
+        for (/* */; first != last; (void) ++first, ++dest)
+        {
+            T next = HPX_INVOKE(op, temp, *first);
+            *dest = temp;
+            temp = next;
+        }
+    }
+}    // namespace hpx::collectives::detail
+
 namespace hpx::traits {
 
     namespace communication {
 
         struct exclusive_scan_tag;
+        struct exclusive_scan_init_tag;
 
         template <>
         struct communicator_data<exclusive_scan_tag>
+        {
+            HPX_EXPORT static char const* name() noexcept;
+        };
+
+        template <>
+        struct communicator_data<exclusive_scan_init_tag>
         {
             HPX_EXPORT static char const* name() noexcept;
         };
@@ -295,28 +352,80 @@ namespace hpx::traits {
                     std::size_t which) mutable {
                     if (!data_available)
                     {
-                        std::vector<std::decay_t<T>> dest;
+                        using T_ = std::decay_t<T>;
+
+                        std::vector<T_> dest;
                         dest.resize(data.size());
 
-                        // first value is not taken into account
-                        auto it = data.begin();
-
-                        if constexpr (!std::is_same_v<std::decay_t<T>, bool>)
+                        if constexpr (!std::is_same_v<T_, bool>)
                         {
-                            hpx::exclusive_scan(it, data.end(), dest.begin(),
-                                *it, HPX_FORWARD(F, op));
+                            collectives::detail::exclusive_scan<T_>(
+                                data.begin(), data.end(), dest.begin(),
+                                HPX_FORWARD(F, op));
                         }
                         else
                         {
-                            hpx::exclusive_scan(it, data.end(), dest.begin(),
-                                static_cast<bool>(*it),
+                            collectives::detail::exclusive_scan<bool>(
+                                data.begin(), data.end(), dest.begin(),
                                 [&](auto lhs, auto rhs) {
                                     return HPX_FORWARD(F, op)(
                                         static_cast<bool>(lhs),
                                         static_cast<bool>(rhs));
                                 });
                         }
+                        std::swap(data, dest);
+                        data_available = true;
+                    }
+                    return Communicator::template handle_bool<std::decay_t<T>>(
+                        HPX_MOVE(data[which]));
+                });
+        }
+    };
 
+    template <typename Communicator>
+    struct communication_operation<Communicator,
+        communication::exclusive_scan_init_tag>
+    {
+        template <typename Result, typename T, typename Init, typename F>
+        static Result get(Communicator& communicator, std::size_t which,
+            std::size_t generation, T&& t, Init&& init, F&& op)
+        {
+            return communicator.template handle_data<std::decay_t<T>>(
+                communication::communicator_data<
+                    communication::exclusive_scan_init_tag>::name(),
+                which, generation,
+                // step function (invoked for each get)
+                [&t](auto& data, std::size_t which) {
+                    data[which] = HPX_FORWARD(T, t);
+                },
+                // finalizer (invoked non-concurrently after all data has been
+                // received)
+                [op = HPX_FORWARD(F, op), init = HPX_FORWARD(Init, init)](
+                    auto& data, bool& data_available,
+                    std::size_t which) mutable {
+                    if (!data_available)
+                    {
+                        using T_ = std::decay_t<T>;
+
+                        std::vector<T_> dest;
+                        dest.resize(data.size());
+
+                        if constexpr (!std::is_same_v<T_, bool>)
+                        {
+                            hpx::exclusive_scan(data.begin(), data.end(),
+                                dest.begin(), HPX_FORWARD(Init, init),
+                                HPX_FORWARD(F, op));
+                        }
+                        else
+                        {
+                            hpx::exclusive_scan(data.begin(), data.end(),
+                                dest.begin(), static_cast<bool>(init),
+                                [&](auto lhs, auto rhs) {
+                                    return HPX_FORWARD(F, op)(
+                                        static_cast<bool>(lhs),
+                                        static_cast<bool>(rhs));
+                                });
+                        }
                         std::swap(data, dest);
                         data_available = true;
                     }
@@ -330,7 +439,7 @@ namespace hpx::traits {
 namespace hpx::collectives {
 
     ////////////////////////////////////////////////////////////////////////////
-    // exclusive_scan plain values
+    // exclusive_scan with semantics similar to MPI_Exscan
     template <typename T, typename F>
     hpx::future<std::decay_t<T>> exclusive_scan(communicator fid,
         T&& local_result, F&& op, this_site_arg this_site = this_site_arg(),
@@ -397,7 +506,6 @@ namespace hpx::collectives {
             HPX_FORWARD(T, local_result), HPX_FORWARD(F, op), this_site);
     }
 
-    ////////////////////////////////////////////////////////////////////////////
     template <typename T, typename F>
     decltype(auto) exclusive_scan(hpx::launch::sync_policy, communicator fid,
         T&& local_result, F&& op, this_site_arg this_site = this_site_arg(),
@@ -429,6 +537,146 @@ namespace hpx::collectives {
         return exclusive_scan(create_communicator(basename, num_sites,
                                   this_site, generation, root_site),
             HPX_FORWARD(T, local_result), HPX_FORWARD(F, op), this_site)
+            .get();
+    }
+
+    ////////////////////////////////////////////////////////////////////////////
+    // Version of exclusive scan that takes an initial value for element 0.
+    // clang-format off
+    template <typename T, typename Init, typename F,
+        HPX_CONCEPT_REQUIRES_(
+            !std::is_same_v<this_site_arg, std::decay_t<F>>
+        )>
+    // clang-format on
+    hpx::future<std::decay_t<T>> exclusive_scan(communicator fid,
+        T&& local_result, Init&& init, F&& op,
+        this_site_arg this_site = this_site_arg(),
+        generation_arg generation = generation_arg())
+    {
+        using arg_type = std::decay_t<T>;
+
+        if (this_site == static_cast<std::size_t>(-1))
+        {
+            this_site = agas::get_locality_id();
+        }
+        if (generation == 0)
+        {
+            return hpx::make_exceptional_future<arg_type>(HPX_GET_EXCEPTION(
+                hpx::error::bad_parameter, "hpx::collectives::exclusive_scan",
+                "the generation number shouldn't be zero"));
+        }
+
+        auto exclusive_scan_data =
+            [local_result = HPX_FORWARD(T, local_result),
+                init = HPX_FORWARD(Init, init), op = HPX_FORWARD(F, op),
+                this_site,
+                generation](communicator&& c) mutable -> hpx::future<arg_type> {
+            using init_type = std::decay_t<Init>;
+            using func_type = std::decay_t<F>;
+            using action_type =
+                detail::communicator_server::communication_get_direct_action<
+                    traits::communication::exclusive_scan_init_tag,
+                    hpx::future<arg_type>, arg_type, init_type, func_type>;
+
+            // explicitly unwrap returned future
+            hpx::future<arg_type> result =
+                hpx::async(action_type(), c, this_site, generation,
+                    HPX_MOVE(local_result), HPX_MOVE(init), HPX_MOVE(op));
+
+            if (!result.is_ready())
+            {
+                // make sure id is kept alive as long as the returned future
+                traits::detail::get_shared_state(result)->set_on_completed(
+                    [client = HPX_MOVE(c)] { HPX_UNUSED(client); });
+            }
+
+            return result;
+        };
+
+        return fid.then(hpx::launch::sync, HPX_MOVE(exclusive_scan_data));
+    }
+
+    // clang-format off
+    template <typename T, typename Init, typename F,
+        HPX_CONCEPT_REQUIRES_(
+            !std::is_same_v<generation_arg, std::decay_t<F>>
+        )>
+    // clang-format on
+    hpx::future<std::decay_t<T>> exclusive_scan(communicator fid,
+        T&& local_result, Init&& init, F&& op, generation_arg generation,
+        this_site_arg this_site = this_site_arg())
+    {
+        return exclusive_scan(HPX_MOVE(fid), HPX_FORWARD(T, local_result),
+            HPX_FORWARD(Init, init), HPX_FORWARD(F, op), this_site, generation);
+    }
+
+    // clang-format off
+    template <typename T, typename Init, typename F,
+        HPX_CONCEPT_REQUIRES_(
+            !std::is_same_v<num_sites_arg, std::decay_t<F>>
+        )>
+    // clang-format on
+    hpx::future<std::decay_t<T>> exclusive_scan(char const* basename,
+        T&& local_result, Init&& init, F&& op,
+        num_sites_arg num_sites = num_sites_arg(),
+        this_site_arg this_site = this_site_arg(),
+        generation_arg generation = generation_arg(),
+        root_site_arg root_site = root_site_arg())
+    {
+        return exclusive_scan(create_communicator(basename, num_sites,
+                                  this_site, generation, root_site),
+            HPX_FORWARD(T, local_result), HPX_FORWARD(Init, init),
+            HPX_FORWARD(F, op), this_site);
+    }
+
+    // clang-format off
+    template <typename T, typename Init, typename F,
+        HPX_CONCEPT_REQUIRES_(
+            !std::is_same_v<this_site_arg, std::decay_t<F>>
+        )>
+    // clang-format on
+    decltype(auto) exclusive_scan(hpx::launch::sync_policy, communicator fid,
+        T&& local_result, Init&& init, F&& op,
+        this_site_arg this_site = this_site_arg(),
+        generation_arg generation = generation_arg())
+    {
+        return exclusive_scan(HPX_MOVE(fid), HPX_FORWARD(T, local_result),
+            HPX_FORWARD(Init, init), HPX_FORWARD(F, op), this_site, generation)
+            .get();
+    }
+
+    // clang-format off
+    template <typename T, typename Init, typename F,
+        HPX_CONCEPT_REQUIRES_(
+            !std::is_same_v<generation_arg, std::decay_t<F>>
+        )>
+    // clang-format on
+    decltype(auto) exclusive_scan(hpx::launch::sync_policy, communicator fid,
+        T&& local_result, Init&& init, F&& op, generation_arg generation,
+        this_site_arg this_site = this_site_arg())
+    {
+        return exclusive_scan(HPX_MOVE(fid), HPX_FORWARD(T, local_result),
+            HPX_FORWARD(Init, init), HPX_FORWARD(F, op), this_site, generation)
+            .get();
+    }
+
+    // clang-format off
+    template <typename T, typename Init, typename F,
+        HPX_CONCEPT_REQUIRES_(
+            !std::is_same_v<num_sites_arg, std::decay_t<F>>
+        )>
+    // clang-format on
+    decltype(auto) exclusive_scan(hpx::launch::sync_policy,
+        char const* basename, T&& local_result, Init&& init, F&& op,
+        num_sites_arg num_sites = num_sites_arg(),
+        this_site_arg this_site = this_site_arg(),
+        generation_arg generation = generation_arg(),
+        root_site_arg root_site = root_site_arg())
+    {
+        return exclusive_scan(create_communicator(basename, num_sites,
+                                  this_site, generation, root_site),
+            HPX_FORWARD(T, local_result), HPX_FORWARD(Init, init),
+            HPX_FORWARD(F, op), this_site)
             .get();
     }
 }    // namespace hpx::collectives

--- a/libs/full/collectives/src/exclusive_scan.cpp
+++ b/libs/full/collectives/src/exclusive_scan.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2024 Hartmut Kaiser
+//  Copyright (c) 2024-2025 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -17,6 +17,12 @@ namespace hpx::traits::communication {
     char const* communicator_data<exclusive_scan_tag>::name() noexcept
     {
         static char const* name = "exclusive_scan";
+        return name;
+    }
+
+    char const* communicator_data<exclusive_scan_init_tag>::name() noexcept
+    {
+        static char const* name = "exclusive_scan_init";
         return name;
     }
 }    // namespace hpx::traits::communication

--- a/libs/full/collectives/tests/regressions/CMakeLists.txt
+++ b/libs/full/collectives/tests/regressions/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2024 The STE||AR-Group
+# Copyright (c) 2019-2025 The STE||AR-Group
 #
 # SPDX-License-Identifier: BSL-1.0
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -12,6 +12,7 @@ if(HPX_WITH_NETWORKING)
       broadcast_unwrap_future_2885
       broadcast_wait_for_2822
       collectives_bool_5940
+      exclusive_scan_6636
       multiple_gather_ops_2001
       reduce_vector_bool
       trivially_copyable_all_gather
@@ -24,6 +25,7 @@ if(HPX_WITH_NETWORKING)
   set(broadcast_wait_for_2822_PARAMETERS LOCALITIES 2 THREADS_PER_LOCALITY 4)
   set(barrier_3792_PARAMETERS LOCALITIES 3 THREADS_PER_LOCALITY 1)
   set(collectives_bool_5940_PARAMETERS LOCALITIES 2)
+  set(exclusive_scan_6636_PARAMETERS LOCALITIES 2)
   set(multiple_gather_ops_2001_PARAMETERS LOCALITIES 2)
   set(reduce_vector_bool_2001_PARAMETERS LOCALITIES 2)
 

--- a/libs/full/collectives/tests/regressions/collectives_bool_5940.cpp
+++ b/libs/full/collectives/tests/regressions/collectives_bool_5940.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2022 Hartmut Kaiser
+//  Copyright (c) 2022-2025 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -30,11 +30,13 @@ constexpr char const* scatter_bool_basename = "/test/scatter_bool/";
 
 void test_all_reduce_bool()
 {
-    std::uint32_t num_localities = hpx::get_num_localities(hpx::launch::sync);
-    std::uint32_t here = hpx::get_locality_id();
+    std::uint32_t const num_localities =
+        hpx::get_num_localities(hpx::launch::sync);
+    std::uint32_t const here = hpx::get_locality_id();
 
-    auto all_reduce_bool_client = create_communicator(add_reduce_bool_basename,
-        num_sites_arg(num_localities), this_site_arg(here));
+    auto const all_reduce_bool_client =
+        create_communicator(add_reduce_bool_basename,
+            num_sites_arg(num_localities), this_site_arg(here));
 
     // test functionality based on immediate local result value
     for (int i = 0; i != 10; ++i)
@@ -50,13 +52,15 @@ void test_all_reduce_bool()
 
 void test_broadcast_bool()
 {
-    std::uint32_t num_localities = hpx::get_num_localities(hpx::launch::sync);
-    HPX_TEST_LTE(std::uint32_t(2), num_localities);
+    std::uint32_t const num_localities =
+        hpx::get_num_localities(hpx::launch::sync);
+    HPX_TEST_LTE(static_cast<std::uint32_t>(2), num_localities);
 
-    std::uint32_t here = hpx::get_locality_id();
+    std::uint32_t const here = hpx::get_locality_id();
 
-    auto broadcast_bool_client = create_communicator(broadcast_bool_basename,
-        num_sites_arg(num_localities), this_site_arg(here));
+    auto const broadcast_bool_client =
+        create_communicator(broadcast_bool_basename,
+            num_sites_arg(num_localities), this_site_arg(here));
 
     // test functionality based on immediate local result value
     for (std::uint32_t i = 0; i != 10; ++i)
@@ -81,10 +85,11 @@ void test_broadcast_bool()
 
 void test_exclusive_scan_bool()
 {
-    std::uint32_t num_localities = hpx::get_num_localities(hpx::launch::sync);
-    std::uint32_t here = hpx::get_locality_id();
+    std::uint32_t const num_localities =
+        hpx::get_num_localities(hpx::launch::sync);
+    std::uint32_t const here = hpx::get_locality_id();
 
-    auto exclusive_scan_bool_client =
+    auto const exclusive_scan_bool_client =
         create_communicator(exclusive_scan_bool_basename,
             num_sites_arg(num_localities), this_site_arg(here));
 
@@ -94,7 +99,7 @@ void test_exclusive_scan_bool()
         bool value = i % 2 ? true : false;
 
         hpx::future<bool> overall_result =
-            exclusive_scan(exclusive_scan_bool_client, value,
+            exclusive_scan(exclusive_scan_bool_client, value, value,
                 std::logical_or<>{}, generation_arg(i + 1));
 
         HPX_TEST_EQ(value, overall_result.get());
@@ -103,10 +108,11 @@ void test_exclusive_scan_bool()
 
 void test_inclusive_scan_bool()
 {
-    std::uint32_t num_localities = hpx::get_num_localities(hpx::launch::sync);
-    std::uint32_t here = hpx::get_locality_id();
+    std::uint32_t const num_localities =
+        hpx::get_num_localities(hpx::launch::sync);
+    std::uint32_t const here = hpx::get_locality_id();
 
-    auto inclusive_scan_client =
+    auto const inclusive_scan_client =
         create_communicator(inclusive_scan_bool_basename,
             num_sites_arg(num_localities), this_site_arg(here));
 
@@ -124,10 +130,11 @@ void test_inclusive_scan_bool()
 
 void test_reduce_bool()
 {
-    std::uint32_t num_localities = hpx::get_num_localities(hpx::launch::sync);
-    std::uint32_t this_locality = hpx::get_locality_id();
+    std::uint32_t const num_localities =
+        hpx::get_num_localities(hpx::launch::sync);
+    std::uint32_t const this_locality = hpx::get_locality_id();
 
-    auto reduce_bool_client = create_communicator(reduce_bool_basename,
+    auto const reduce_bool_client = create_communicator(reduce_bool_basename,
         num_sites_arg(num_localities), this_site_arg(this_locality));
 
     // test functionality based on immediate local result value
@@ -152,12 +159,13 @@ void test_reduce_bool()
 
 void test_scatter_bool()
 {
-    std::uint32_t num_localities = hpx::get_num_localities(hpx::launch::sync);
-    HPX_TEST_LTE(std::uint32_t(2), num_localities);
+    std::uint32_t const num_localities =
+        hpx::get_num_localities(hpx::launch::sync);
+    HPX_TEST_LTE(static_cast<std::uint32_t>(2), num_localities);
 
-    std::uint32_t this_locality = hpx::get_locality_id();
+    std::uint32_t const this_locality = hpx::get_locality_id();
 
-    auto scatter_bool_client =
+    auto const scatter_bool_client =
         hpx::collectives::create_communicator(scatter_bool_basename,
             num_sites_arg(num_localities), this_site_arg(this_locality));
 
@@ -168,9 +176,9 @@ void test_scatter_bool()
         if (this_locality == 0)
         {
             std::vector<bool> data(num_localities);
-            for (std::size_t i = 0; i != data.size(); ++i)
+            for (std::size_t j = 0; j != data.size(); ++j)
             {
-                data[i] = value;
+                data[j] = value;
             }
 
             hpx::future<bool> result = scatter_to(

--- a/libs/full/collectives/tests/regressions/exclusive_scan_6636.cpp
+++ b/libs/full/collectives/tests/regressions/exclusive_scan_6636.cpp
@@ -1,0 +1,55 @@
+//  Copyright (c) 2025 Michael Ferguson
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/config.hpp>
+#include <hpx/hpx_init.hpp>
+#include <hpx/modules/collectives.hpp>
+#include <hpx/modules/program_options.hpp>
+#include <hpx/modules/testing.hpp>
+
+#include <cstdint>
+#include <functional>
+#include <string>
+#include <vector>
+
+int hpx_main()
+{
+    // this is run on all localities (nodes)
+    auto const rank = hpx::get_locality_id();
+    auto const num_ranks = hpx::get_num_localities(hpx::launch::sync);
+    HPX_TEST_EQ(num_ranks, static_cast<std::uint32_t>(2));
+
+    std::int64_t const total_here = rank + 100;
+
+    hpx::future<std::int64_t> f_start = hpx::collectives::exclusive_scan(
+        "my_scan", total_here, std::plus<std::int64_t>{},
+        hpx::collectives::num_sites_arg(), hpx::collectives::this_site_arg(),
+        hpx::collectives::generation_arg(1));
+
+    std::int64_t const start = f_start.get();
+    if (rank == 0)
+    {
+        HPX_TEST_EQ(start, 0);    // default constructed
+    }
+    else
+    {
+        HPX_TEST_EQ(start, 100);
+    }
+
+    return hpx::finalize();
+}
+
+int main(int argc, char* argv[])
+{
+    // run hpx_main on all localities
+    std::vector<std::string> const cfg = {"hpx.run_hpx_main!=1"};
+
+    // Initialize and run HPX
+    hpx::init_params init_args;
+    init_args.cfg = cfg;
+
+    return hpx::init(argc, argv, init_args);
+}

--- a/libs/full/collectives/tests/unit/concurrent_collectives.cpp
+++ b/libs/full/collectives/tests/unit/concurrent_collectives.cpp
@@ -212,8 +212,10 @@ double test_broadcast(communicator const& comm, std::uint32_t here)
     hpx::chrono::high_resolution_timer const t;
 
     std::size_t gen = 0;
+    // clang-format off
     for (std::uint32_t i = 0; distributed.get_next_generation("broadcast", gen);
          ++i)
+    // clang-format on
     {
         if (here == 0)
         {
@@ -243,7 +245,8 @@ double test_exclusive_scan(communicator const& comm, std::uint32_t here)
     for (int i = 0; distributed.get_next_generation("exclusive_scan", gen); ++i)
     {
         hpx::future<std::uint32_t> overall_result =
-            exclusive_scan(comm, here + i, std::plus<>{}, generation_arg(gen));
+            exclusive_scan(comm, here + i, static_cast<std::uint32_t>(i),
+                std::plus<>{}, generation_arg(gen));
 
         std::uint32_t sum = i;
         for (std::uint32_t j = 0; j < here; ++j)
@@ -261,8 +264,10 @@ double test_gather(communicator const& comm, std::uint32_t here)
     hpx::chrono::high_resolution_timer const t;
 
     std::size_t gen = 0;
+    // clang-format off
     for (std::uint32_t i = 0; distributed.get_next_generation("gather", gen);
          ++i)
+    // clang-format on
     {
         if (here == 0)
         {
@@ -291,8 +296,10 @@ double test_inclusive_scan(communicator const& comm, std::uint32_t here)
     hpx::chrono::high_resolution_timer const t;
 
     std::size_t gen = 0;
+    // clang-format off
     for (std::uint32_t i = 0;
          distributed.get_next_generation("inclusive_scan", gen); ++i)
+    // clang-format on
     {
         hpx::future<std::uint32_t> overall_result = inclusive_scan(
             comm, here + i, std::plus<std::uint32_t>{}, generation_arg(gen));
@@ -419,8 +426,10 @@ double test_local_all_reduce(std::vector<communicator> const& comms)
     double elapsed = 0.;
 
     std::size_t gen = 0;
+    // clang-format off
     for ([[maybe_unused]] std::uint32_t i = 0;
          local.get_next_generation("all_reduce", gen); ++i)
+    // clang-format on
     {
         std::vector<hpx::future<void>> sites;
         sites.reserve(num_sites);
@@ -464,8 +473,10 @@ double test_local_all_to_all(std::vector<communicator> const& comms)
     double elapsed = 0.;
 
     std::size_t gen = 0;
+    // clang-format off
     for ([[maybe_unused]] std::uint32_t i = 0;
          local.get_next_generation("all_to_all", gen); ++i)
+    // clang-format on
     {
         std::vector<hpx::future<void>> sites;
         sites.reserve(num_sites);
@@ -557,8 +568,10 @@ double test_local_exclusive_scan(std::vector<communicator> const& comms)
     double elapsed = 0.;
 
     std::size_t gen = 0;
+    // clang-format off
     for (std::uint32_t i = 0; local.get_next_generation("exclusive_scan", gen);
          ++i)
+    // clang-format on
     {
         std::vector<hpx::future<void>> sites;
         sites.reserve(num_sites);
@@ -570,7 +583,7 @@ double test_local_exclusive_scan(std::vector<communicator> const& comms)
                 hpx::chrono::high_resolution_timer const t;
 
                 hpx::future<std::uint32_t> overall_result =
-                    exclusive_scan(comms[site], site + i, std::plus<>{},
+                    exclusive_scan(comms[site], site + i, i, std::plus<>{},
                         this_site_arg(site), generation_arg(gen));
 
                 auto const result = overall_result.get();
@@ -649,8 +662,10 @@ double test_local_inclusive_scan(std::vector<communicator> const& comms)
     double elapsed = 0.;
 
     std::size_t gen = 0;
+    // clang-format off
     for (std::uint32_t i = 0; local.get_next_generation("inclusive_scan", gen);
          ++i)
+    // clang-format on
     {
         std::vector<hpx::future<void>> sites;
         sites.reserve(num_sites);

--- a/libs/full/collectives/tests/unit/exclusive_scan_.cpp
+++ b/libs/full/collectives/tests/unit/exclusive_scan_.cpp
@@ -37,10 +37,10 @@ void test_one_shot_use()
     // test functionality based on immediate local result value
     for (int i = 0; i != ITERATIONS; ++i)
     {
-        hpx::future<std::uint32_t> overall_result =
-            exclusive_scan(exclusive_scan_basename, here + i,
-                std::plus<std::uint32_t>{}, num_sites_arg(num_localities),
-                this_site_arg(here), generation_arg(i + 1));
+        hpx::future<std::uint32_t> overall_result = exclusive_scan(
+            exclusive_scan_basename, here + i, static_cast<std::uint32_t>(i),
+            std::plus<std::uint32_t>{}, num_sites_arg(num_localities),
+            this_site_arg(here), generation_arg(i + 1));
 
         std::uint32_t sum = i;
         for (std::uint32_t j = 0; j < here; ++j)
@@ -65,8 +65,9 @@ void test_multiple_use()
     // test functionality based on immediate local result value
     for (int i = 0; i != ITERATIONS; ++i)
     {
-        hpx::future<std::uint32_t> overall_result = exclusive_scan(
-            exclusive_scan_client, here + i, std::plus<std::uint32_t>{});
+        hpx::future<std::uint32_t> overall_result =
+            exclusive_scan(exclusive_scan_client, here + i,
+                static_cast<std::uint32_t>(i), std::plus<std::uint32_t>{});
 
         std::uint32_t sum = i;
         for (std::uint32_t j = 0; j < here; ++j)
@@ -92,9 +93,9 @@ void test_multiple_use_with_generation()
 
     for (int i = 0; i != ITERATIONS; ++i)
     {
-        hpx::future<std::uint32_t> overall_result =
-            exclusive_scan(exclusive_scan_client, here + i,
-                std::plus<std::uint32_t>{}, generation_arg(i + 1));
+        hpx::future<std::uint32_t> overall_result = exclusive_scan(
+            exclusive_scan_client, here + i, static_cast<std::uint32_t>(i),
+            std::plus<std::uint32_t>{}, generation_arg(i + 1));
 
         std::uint32_t sum = i;
         for (std::uint32_t j = 0; j < here; ++j)
@@ -131,7 +132,7 @@ void test_local_use()
             for (std::uint32_t i = 0; i != 10 * ITERATIONS; ++i)
             {
                 hpx::future<std::uint32_t> overall_result = exclusive_scan(
-                    exclusive_scan_client, site + i, std::plus<>{},
+                    exclusive_scan_client, site + i, i, std::plus<>{},
                     this_site_arg(site), generation_arg(i + 1));
 
                 auto const result = overall_result.get();

--- a/libs/full/collectives/tests/unit/exclusive_scan_sync.cpp
+++ b/libs/full/collectives/tests/unit/exclusive_scan_sync.cpp
@@ -20,7 +20,7 @@
 
 using namespace hpx::collectives;
 
-constexpr char const* exclusive_scan_basename = "/test/exclusive_scan/";
+constexpr char const* exclusive_scan_basename = "/test/exclusive_scan_sync/";
 #if defined(HPX_DEBUG)
 constexpr int ITERATIONS = 100;
 #else
@@ -37,10 +37,10 @@ void test_one_shot_use()
     // test functionality based on immediate local result value
     for (int i = 0; i != ITERATIONS; ++i)
     {
-        std::uint32_t overall_result =
-            exclusive_scan(hpx::launch::sync, exclusive_scan_basename, here + i,
-                std::plus<std::uint32_t>{}, num_sites_arg(num_localities),
-                this_site_arg(here), generation_arg(i + 1));
+        std::uint32_t overall_result = exclusive_scan(hpx::launch::sync,
+            exclusive_scan_basename, here + i, static_cast<std::uint32_t>(i),
+            std::plus<std::uint32_t>{}, num_sites_arg(num_localities),
+            this_site_arg(here), generation_arg(i + 1));
 
         std::uint32_t sum = i;
         for (std::uint32_t j = 0; j < here; ++j)
@@ -65,8 +65,9 @@ void test_multiple_use()
     // test functionality based on immediate local result value
     for (int i = 0; i != ITERATIONS; ++i)
     {
-        std::uint32_t overall_result = exclusive_scan(hpx::launch::sync,
-            exclusive_scan_client, here + i, std::plus<std::uint32_t>{});
+        std::uint32_t overall_result =
+            exclusive_scan(hpx::launch::sync, exclusive_scan_client, here + i,
+                static_cast<std::uint32_t>(i), std::plus<std::uint32_t>{});
 
         std::uint32_t sum = i;
         for (std::uint32_t j = 0; j < here; ++j)
@@ -92,9 +93,9 @@ void test_multiple_use_with_generation()
 
     for (int i = 0; i != ITERATIONS; ++i)
     {
-        std::uint32_t overall_result =
-            exclusive_scan(hpx::launch::sync, exclusive_scan_client, here + i,
-                std::plus<std::uint32_t>{}, generation_arg(i + 1));
+        std::uint32_t overall_result = exclusive_scan(hpx::launch::sync,
+            exclusive_scan_client, here + i, static_cast<std::uint32_t>(i),
+            std::plus<std::uint32_t>{}, generation_arg(i + 1));
 
         std::uint32_t sum = i;
         for (std::uint32_t j = 0; j < here; ++j)
@@ -131,7 +132,7 @@ void test_local_use()
             for (std::uint32_t i = 0; i != 10 * ITERATIONS; ++i)
             {
                 std::uint32_t overall_result = exclusive_scan(hpx::launch::sync,
-                    exclusive_scan_client, site + i, std::plus<>{},
+                    exclusive_scan_client, site + i, i, std::plus<>{},
                     this_site_arg(site), generation_arg(i + 1));
 
                 auto const result = overall_result;


### PR DESCRIPTION
- adding exclusive_scan overloads that take an initial value for the scan operation

Fixes #6636
