### PR TITLE
Adding constructor overloads to partitioned_vector

### DIFF
--- a/components/containers/partitioned_vector/include/hpx/components/containers/partitioned_vector/partitioned_vector_component_impl.hpp
+++ b/components/containers/partitioned_vector/include/hpx/components/containers/partitioned_vector/partitioned_vector_component_impl.hpp
@@ -1,5 +1,5 @@
 //  Copyright (c) 2014 Anuj R. Sharma
-//  Copyright (c) 2014-2024 Hartmut Kaiser
+//  Copyright (c) 2014-2025 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying

--- a/components/containers/partitioned_vector/include/hpx/components/containers/partitioned_vector/partitioned_vector_decl.hpp
+++ b/components/containers/partitioned_vector/include/hpx/components/containers/partitioned_vector/partitioned_vector_decl.hpp
@@ -1,5 +1,5 @@
 //  Copyright (c) 2014 Anuj R. Sharma
-//  Copyright (c) 2014-2024 Hartmut Kaiser
+//  Copyright (c) 2014-2025 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -410,17 +410,26 @@ namespace hpx {
         ///
         /// \param size             The overall size of the vector
         /// \param val              Default value for the elements in vector
-        /// \param symbolic_name    The (optional) name to register the newly
-        ///                         created vector
         ///
         partitioned_vector(size_type size, T const& val);
+
+        /// Constructor which creates and initializes vector of a size as given
+        /// by the range, where all elements are initialized with the values
+        /// from the given range [begin, end) and using the given distribution
+        /// policy.
+        ///
+        /// \param begin            Start of range to use for initializing the
+        ///                         new instance.
+        /// \param end              End of range to use for initializing the
+        ///                         new instance.
+        ///
+        partitioned_vector(typename Data::const_iterator begin,
+            typename Data::const_iterator end);
 
         /// Constructor which creates vector of \a size using the given
         /// distribution policy.
         ///
         /// \param policy           The distribution policy to use
-        /// \param symbolic_name    The (optional) name to register the newly
-        ///                         created vector
         ///
         template <typename DistPolicy>
         explicit partitioned_vector(DistPolicy const& policy,
@@ -432,8 +441,6 @@ namespace hpx {
         ///
         /// \param size             The overall size of the vector
         /// \param policy           The distribution policy to use
-        /// \param symbolic_name    The (optional) name to register the newly
-        ///                         created vector
         ///
         template <typename DistPolicy>
         partitioned_vector(size_type size, DistPolicy const& policy,
@@ -447,12 +454,27 @@ namespace hpx {
         /// \param size             The overall size of the vector
         /// \param val              Default value for the elements in vector
         /// \param policy           The distribution policy to use
-        /// \param symbolic_name    The (optional) name to register the newly
-        ///                         created vector
         ///
         template <typename DistPolicy>
         partitioned_vector(size_type size, T const& val,
             DistPolicy const& policy,
+            std::enable_if_t<traits::is_distribution_policy_v<DistPolicy>>* =
+                nullptr);
+
+        /// Constructor which creates and initializes vector of a size as given
+        /// by the range, where all elements are initialized with the values
+        /// from the given range [begin, end) and using the given distribution
+        /// policy.
+        ///
+        /// \param begin            Start of range to use for initializing the
+        ///                         new instance.
+        /// \param end              End of range to use for initializing the
+        ///                         new instance.
+        /// \param policy           The distribution policy to use
+        ///
+        template <typename DistPolicy>
+        partitioned_vector(typename Data::const_iterator begin,
+            typename Data::const_iterator end, DistPolicy const& policy,
             std::enable_if_t<traits::is_distribution_policy_v<DistPolicy>>* =
                 nullptr);
 
@@ -467,14 +489,13 @@ namespace hpx {
         }
 
         partitioned_vector(partitioned_vector&& rhs) noexcept
-          : base_type(HPX_MOVE(rhs))
+          : base_type(HPX_MOVE(static_cast<base_type&&>(rhs)))
           , size_(rhs.size_)
           , partitions_(HPX_MOVE(rhs.partitions_))
         {
             rhs.size_ = 0;
         }
 
-    public:
         /// \brief Array subscript operator. This does not throw any exception.
         ///
         /// \param pos Position of the element in the vector [Note the first

--- a/components/containers/partitioned_vector/include/hpx/components/containers/partitioned_vector/partitioned_vector_impl.hpp
+++ b/components/containers/partitioned_vector/include/hpx/components/containers/partitioned_vector/partitioned_vector_impl.hpp
@@ -535,6 +535,7 @@ namespace hpx {
     }
 
     template <typename T, typename Data /*= std::vector<T> */>
+    HPX_PARTITIONED_VECTOR_SPECIALIZATION_EXPORT
     partitioned_vector<T, Data>::partitioned_vector(
         typename Data::const_iterator begin, typename Data::const_iterator end)
       : size_(std::distance(begin, end))
@@ -576,11 +577,10 @@ namespace hpx {
     template <typename T, typename Data /*= std::vector<T> */>
     template <typename DistPolicy>
     HPX_PARTITIONED_VECTOR_SPECIALIZATION_EXPORT
-    partitioned_vector<T, Data>::partitioned_vector(DistPolicy const& policy,
+    partitioned_vector<T, Data>::partitioned_vector(DistPolicy const&,
         std::enable_if_t<traits::is_distribution_policy_v<DistPolicy>>*)
       : size_(0)
     {
-        reserve(policy);
     }
 
     template <typename T, typename Data /*= std::vector<T> */>

--- a/components/containers/partitioned_vector/include/hpx/components/containers/partitioned_vector/partitioned_vector_impl.hpp
+++ b/components/containers/partitioned_vector/include/hpx/components/containers/partitioned_vector/partitioned_vector_impl.hpp
@@ -1,5 +1,5 @@
 //  Copyright (c) 2014 Anuj R. Sharma
-//  Copyright (c) 2014-2024 Hartmut Kaiser
+//  Copyright (c) 2014-2025 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -535,6 +535,33 @@ namespace hpx {
     }
 
     template <typename T, typename Data /*= std::vector<T> */>
+    partitioned_vector<T, Data>::partitioned_vector(
+        typename Data::const_iterator begin, typename Data::const_iterator end)
+      : size_(std::distance(begin, end))
+    {
+        if (size_ != 0)
+        {
+            // create all partitions
+            create(hpx::container_layout);
+
+            // fill partitions with their part of the data
+            std::vector<std::size_t> const empty;
+            std::vector<hpx::future<void>> futures;
+            futures.reserve(partitions_.size());
+            for (std::size_t i = 0; i != partitions_.size(); ++i)
+            {
+                HPX_ASSERT(static_cast<std::size_t>(std::distance(
+                               begin, end)) >= partitions_[i].size_);
+                auto const end_part = std::next(begin, partitions_[i].size_);
+                futures.push_back(set_values(i, empty, Data(begin, end_part)));
+                begin = end_part;
+            }
+            HPX_ASSERT(begin == end);
+            hpx::wait_all(HPX_MOVE(futures));
+        }
+    }
+
+    template <typename T, typename Data /*= std::vector<T> */>
     template <typename DistPolicy>
     HPX_PARTITIONED_VECTOR_SPECIALIZATION_EXPORT
     partitioned_vector<T, Data>::partitioned_vector(size_type size,
@@ -567,5 +594,36 @@ namespace hpx {
     {
         if (size != 0)
             create(val, policy);
+    }
+
+    template <typename T, typename Data /*= std::vector<T> */>
+    template <typename DistPolicy>
+    partitioned_vector<T, Data>::partitioned_vector(
+        typename Data::const_iterator begin, typename Data::const_iterator end,
+        DistPolicy const& policy,
+        std::enable_if_t<
+            traits::is_distribution_policy_v<DistPolicy>>* /*= nullptr*/)
+      : size_(std::distance(begin, end))
+    {
+        if (size_ != 0)
+        {
+            // create all partitions
+            create(policy);
+
+            // fill partitions with their part of the data
+            std::vector<std::size_t> const empty;
+            std::vector<hpx::future<void>> futures;
+            futures.reserve(partitions_.size());
+            for (std::size_t i = 0; i != partitions_.size(); ++i)
+            {
+                HPX_ASSERT(static_cast<std::size_t>(std::distance(
+                               begin, end)) >= partitions_[i].size_);
+                auto const end_part = std::next(begin, partitions_[i].size_);
+                futures.push_back(set_values(i, empty, Data(begin, end_part)));
+                begin = end_part;
+            }
+            HPX_ASSERT(begin == end);
+            hpx::wait_all(HPX_MOVE(futures));
+        }
     }
 }    // namespace hpx

--- a/components/containers/partitioned_vector/include/hpx/components/containers/partitioned_vector/partitioned_vector_predef.hpp
+++ b/components/containers/partitioned_vector/include/hpx/components/containers/partitioned_vector/partitioned_vector_predef.hpp
@@ -1,5 +1,5 @@
 //  Copyright (c) 2014 Anuj R. Sharma
-//  Copyright (c) 2014-2024 Hartmut Kaiser
+//  Copyright (c) 2014-2025 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -43,6 +43,10 @@ extern template hpx::partitioned_vector<double,
 extern template hpx::partitioned_vector<double,
     std::vector<double>>::partitioned_vector(size_type, double const&,
     hpx::explicit_container_distribution_policy const&, void*);
+extern template hpx::partitioned_vector<double, std::vector<double>>::
+    partitioned_vector(std::vector<double>::const_iterator,
+        std::vector<double>::const_iterator,
+        hpx::explicit_container_distribution_policy const&, void*);
 
 // partitioned_vector<int>
 HPX_REGISTER_PARTITIONED_VECTOR_DECLARATION(int)
@@ -61,6 +65,10 @@ extern template hpx::partitioned_vector<int,
     hpx::explicit_container_distribution_policy const&, void*);
 extern template hpx::partitioned_vector<int,
     std::vector<int>>::partitioned_vector(size_type, int const&,
+    hpx::explicit_container_distribution_policy const&, void*);
+extern template hpx::partitioned_vector<int,
+    std::vector<int>>::partitioned_vector(std::vector<int>::const_iterator,
+    std::vector<int>::const_iterator,
     hpx::explicit_container_distribution_policy const&, void*);
 
 // partitioned_vector<long long>
@@ -85,6 +93,10 @@ extern template hpx::partitioned_vector<long long,
 extern template hpx::partitioned_vector<long long,
     std::vector<long long>>::partitioned_vector(size_type, long long const&,
     hpx::explicit_container_distribution_policy const&, void*);
+extern template hpx::partitioned_vector<long long, std::vector<long long>>::
+    partitioned_vector(std::vector<long long>::const_iterator,
+        std::vector<long long>::const_iterator,
+        hpx::explicit_container_distribution_policy const&, void*);
 
 // partitioned_vector<std::string>
 using partitioned_vector_std_string_argument = std::string;
@@ -110,5 +122,9 @@ extern template hpx::partitioned_vector<std::string,
 extern template hpx::partitioned_vector<std::string,
     std::vector<std::string>>::partitioned_vector(size_type, std::string const&,
     hpx::explicit_container_distribution_policy const&, void*);
+extern template hpx::partitioned_vector<std::string, std::vector<std::string>>::
+    partitioned_vector(std::vector<std::string>::const_iterator,
+        std::vector<std::string>::const_iterator,
+        hpx::explicit_container_distribution_policy const&, void*);
 
 #endif

--- a/components/containers/partitioned_vector/src/partitioned_vector_component_double.cpp
+++ b/components/containers/partitioned_vector/src/partitioned_vector_component_double.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2017 Hartmut Kaiser
+//  Copyright (c) 2017-2025 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -42,6 +42,10 @@ hpx::partitioned_vector<double, std::vector<double>>::partitioned_vector(
     size_type, hpx::explicit_container_distribution_policy const&, void*);
 template HPX_PARTITIONED_VECTOR_EXPORT hpx::partitioned_vector<double,
     std::vector<double>>::partitioned_vector(size_type, double const&,
+    hpx::explicit_container_distribution_policy const&, void*);
+template HPX_PARTITIONED_VECTOR_EXPORT
+hpx::partitioned_vector<double, std::vector<double>>::partitioned_vector(
+    std::vector<double>::const_iterator, std::vector<double>::const_iterator,
     hpx::explicit_container_distribution_policy const&, void*);
 
 #if defined(HPX_MSVC)

--- a/components/containers/partitioned_vector/src/partitioned_vector_component_int.cpp
+++ b/components/containers/partitioned_vector/src/partitioned_vector_component_int.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2017 Hartmut Kaiser
+//  Copyright (c) 2017-2025 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -43,8 +43,12 @@ template HPX_PARTITIONED_VECTOR_EXPORT
 hpx::partitioned_vector<int, std::vector<int>>::partitioned_vector(
     size_type, hpx::explicit_container_distribution_policy const&, void*);
 template HPX_PARTITIONED_VECTOR_EXPORT
+hpx::partitioned_vector<int, std::vector<int>>::partitioned_vector(size_type,
+    int const&, hpx::explicit_container_distribution_policy const&, void*);
+template HPX_PARTITIONED_VECTOR_EXPORT
 hpx::partitioned_vector<int, std::vector<int>>::partitioned_vector(
-    size_type, int const&, hpx::explicit_container_distribution_policy const&, void*);
+    std::vector<int>::const_iterator, std::vector<int>::const_iterator,
+    hpx::explicit_container_distribution_policy const&, void*);
 
 template class HPX_PARTITIONED_VECTOR_EXPORT
     hpx::server::partitioned_vector<long long, std::vector<long long>>;
@@ -63,6 +67,11 @@ hpx::partitioned_vector<long long, std::vector<long long>>::partitioned_vector(
     size_type, hpx::explicit_container_distribution_policy const&, void*);
 template HPX_PARTITIONED_VECTOR_EXPORT hpx::partitioned_vector<long long,
     std::vector<long long>>::partitioned_vector(size_type, long long const&,
+    hpx::explicit_container_distribution_policy const&, void*);
+template HPX_PARTITIONED_VECTOR_EXPORT
+hpx::partitioned_vector<long long, std::vector<long long>>::partitioned_vector(
+    std::vector<long long>::const_iterator,
+    std::vector<long long>::const_iterator,
     hpx::explicit_container_distribution_policy const&, void*);
 
 #if defined(HPX_MSVC)

--- a/components/containers/partitioned_vector/src/partitioned_vector_component_std_string.cpp
+++ b/components/containers/partitioned_vector/src/partitioned_vector_component_std_string.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2017 Hartmut Kaiser
+//  Copyright (c) 2017-2025 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -46,6 +46,11 @@ template HPX_PARTITIONED_VECTOR_EXPORT hpx::partitioned_vector<std::string,
 template HPX_PARTITIONED_VECTOR_EXPORT hpx::partitioned_vector<std::string,
     std::vector<std::string>>::partitioned_vector(size_type, std::string const&,
     hpx::explicit_container_distribution_policy const&, void*);
+template HPX_PARTITIONED_VECTOR_EXPORT
+hpx::partitioned_vector<std::string, std::vector<std::string>>::
+    partitioned_vector(std::vector<std::string>::const_iterator,
+        std::vector<std::string>::const_iterator,
+        hpx::explicit_container_distribution_policy const&, void*);
 
 #if defined(HPX_MSVC)
 #pragma warning(pop)

--- a/components/containers/partitioned_vector/tests/regressions/CMakeLists.txt
+++ b/components/containers/partitioned_vector/tests/regressions/CMakeLists.txt
@@ -1,12 +1,15 @@
-# Copyright (c) 2007-2017 Hartmut Kaiser
+# Copyright (c) 2007-2025 Hartmut Kaiser
 #
 # SPDX-License-Identifier: BSL-1.0
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-set(tests partitioned_vector_2201)
+set(tests partitioned_vector_2201 partitioned_vector_constructor_6650)
 
 set(partitioned_vector_2201_FLAGS COMPONENT_DEPENDENCIES partitioned_vector)
+set(partitioned_vector_constructor_6650_FLAGS COMPONENT_DEPENDENCIES
+                                              partitioned_vector
+)
 
 foreach(test ${tests})
   set(sources ${test}.cpp)

--- a/components/containers/partitioned_vector/tests/regressions/partitioned_vector_constructor_6650.cpp
+++ b/components/containers/partitioned_vector/tests/regressions/partitioned_vector_constructor_6650.cpp
@@ -1,0 +1,31 @@
+//  Copyright (c) 2025 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/config.hpp>
+
+#if !defined(HPX_COMPUTE_DEVICE_CODE)
+#include <hpx/hpx_main.hpp>
+#include <hpx/include/partitioned_vector.hpp>
+#include <hpx/modules/runtime_distributed.hpp>
+
+///////////////////////////////////////////////////////////////////////////////
+int main()
+{
+    // create as many partitions as we have localities
+    [[maybe_unused]] hpx::partitioned_vector<int> data(
+        hpx::container_layout(hpx::find_all_localities()));
+
+    return 0;
+}
+
+#else
+
+int main()
+{
+    return 0;
+}
+
+#endif

--- a/libs/full/segmented_algorithms/tests/unit/partitioned_vector_copy.cpp
+++ b/libs/full/segmented_algorithms/tests/unit/partitioned_vector_copy.cpp
@@ -1,10 +1,11 @@
-//  Copyright (c) 2014-2017 Hartmut Kaiser
+//  Copyright (c) 2014-2025 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <hpx/config.hpp>
+
 #if !defined(HPX_COMPUTE_DEVICE_CODE)
 #include <hpx/hpx_main.hpp>
 #include <hpx/include/parallel_copy.hpp>
@@ -153,6 +154,12 @@ void copy_tests()
         copy_tests(v);
     }
 
+    {
+        std::vector<T> data(length, T(42));
+        hpx::partitioned_vector<T> v(data.begin(), data.end());
+        copy_tests(v);
+    }
+
     copy_tests_with_policy<T>(length, 1, hpx::container_layout);
     copy_tests_with_policy<T>(length, 3, hpx::container_layout(3));
     copy_tests_with_policy<T>(length, 3, hpx::container_layout(3, localities));
@@ -168,4 +175,5 @@ int main()
 
     return hpx::util::report_errors();
 }
+
 #endif


### PR DESCRIPTION
- These allow to initialize the new instance with a given range of data
