### PR TITLE
Adding simple experimental::run_on_all

### DIFF
--- a/libs/core/algorithms/CMakeLists.txt
+++ b/libs/core/algorithms/CMakeLists.txt
@@ -182,6 +182,7 @@ set(algorithms_headers
     hpx/parallel/datapar/zip_iterator.hpp
     hpx/parallel/memory.hpp
     hpx/parallel/numeric.hpp
+    hpx/parallel/run_on_all.hpp
     hpx/parallel/spmd_block.hpp
     hpx/parallel/task_block.hpp
     hpx/parallel/task_group.hpp

--- a/libs/core/algorithms/include/hpx/parallel/run_on_all.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/run_on_all.hpp
@@ -1,0 +1,55 @@
+//  Copyright (c) 2025 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+/// \file run_on_all.hpp
+/// \page hpx::experimental::run_on_all
+/// \headerfile hpx/experimental/run_on_all.hpp
+
+#pragma once
+
+#include <hpx/config.hpp>
+#include <hpx/async_combinators/wait_all.hpp>
+#include <hpx/execution/detail/execution_parameter_callbacks.hpp>
+#include <hpx/execution/execution.hpp>
+#include <hpx/execution_base/execution.hpp>
+#include <hpx/executors/parallel_executor.hpp>
+#include <hpx/functional/experimental/scope_exit.hpp>
+#include <hpx/parallel/algorithms/for_loop_reduction.hpp>
+
+#include <cstddef>
+
+namespace hpx::experimental {
+
+    template <typename T, typename Op, typename F, typename... Ts>
+    void run_on_all(std::size_t num_tasks,
+        hpx::parallel::detail::reduction_helper<T, Op>&& r, F&& f, Ts&&... ts)
+    {
+        // force using index_queue scheduler with given amount of threads
+        auto exec = hpx::execution::experimental::with_processing_units_count(
+            hpx::execution::parallel_executor(
+                hpx::threads::thread_priority::bound),
+            num_tasks);
+        exec.set_hierarchical_threshold(0);
+
+        r.init_iteration(0, 0);
+        auto on_exit =
+            hpx::experimental::scope_exit([&] { r.exit_iteration(0); });
+
+        hpx::wait_all(hpx::parallel::execution::bulk_async_execute(
+            exec, [&](auto i) { f(r.iteration_value(i), ts...); }, num_tasks,
+            HPX_FORWARD(Ts, ts)...));
+    }
+
+    template <typename T, typename Op, typename F, typename... Ts>
+    void run_on_all(
+        hpx::parallel::detail::reduction_helper<T, Op>&& r, F&& f, Ts&&... ts)
+    {
+        std::size_t cores =
+            hpx::parallel::execution::detail::get_os_thread_count();
+        run_on_all(
+            cores, HPX_MOVE(r), HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...);
+    }
+}    // namespace hpx::experimental

--- a/libs/core/algorithms/tests/unit/block/CMakeLists.txt
+++ b/libs/core/algorithms/tests/unit/block/CMakeLists.txt
@@ -1,11 +1,13 @@
 # Copyright (c)      2018 Mikael Simberg
-# Copyright (c) 2007-2021 Hartmut Kaiser
+# Copyright (c) 2007-2025 Hartmut Kaiser
 #
 # SPDX-License-Identifier: BSL-1.0
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-set(tests spmd_block task_block task_block_executor task_block_par task_group)
+set(tests run_on_all spmd_block task_block task_block_executor task_block_par
+          task_group
+)
 
 foreach(test ${tests})
   set(sources ${test}.cpp)

--- a/libs/core/algorithms/tests/unit/block/run_on_all.cpp
+++ b/libs/core/algorithms/tests/unit/block/run_on_all.cpp
@@ -1,0 +1,27 @@
+//  Copyright (c) 2025 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/experimental/run_on_all.hpp>
+#include <hpx/hpx_main.hpp>
+#include <hpx/modules/runtime_local.hpp>
+#include <hpx/modules/testing.hpp>
+
+#include <cstdint>
+
+int main()
+{
+    using namespace hpx::experimental;
+
+    std::uint32_t n = 0;
+    run_on_all(reduction_plus(n), [](std::uint32_t& local_n) { ++local_n; });
+    HPX_TEST_EQ(n, hpx::get_num_worker_threads());
+
+    n = 0;
+    run_on_all(2, reduction_plus(n), [](std::uint32_t& local_n) { ++local_n; });
+    HPX_TEST_EQ(n, static_cast<std::uint32_t>(2));
+
+    return hpx::util::report_errors();
+}

--- a/libs/core/include_local/CMakeLists.txt
+++ b/libs/core/include_local/CMakeLists.txt
@@ -29,6 +29,7 @@ set(include_local_headers
     hpx/tuple.hpp
     hpx/type_traits.hpp
     hpx/unwrap.hpp
+    hpx/experimental/run_on_all.hpp
     hpx/experimental/scope.hpp
     hpx/experimental/task_group.hpp
 )

--- a/libs/core/include_local/include/hpx/experimental/run_on_all.hpp
+++ b/libs/core/include_local/include/hpx/experimental/run_on_all.hpp
@@ -1,0 +1,9 @@
+//  Copyright (c) 2025 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include <hpx/parallel/run_on_all.hpp>


### PR DESCRIPTION
Working towards resolving #6651

This is a first minimal implementation, no execution policy, no asynchrony, etc.