### PR TITLE
Fix "unary minus operator applied to unsigned type" warning

### DIFF
--- a/libs/core/algorithms/include/hpx/parallel/algorithms/for_loop.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/for_loop.hpp
@@ -880,23 +880,31 @@ namespace hpx::parallel {
                 }
                 else
                 {
-                    while (part_steps >= static_cast<std::size_t>(-stride_))
+                    // Silence unary minus warning for unsigned types
+                    if constexpr (std::is_signed_v<S>)
                     {
-                        detail::invoke_iteration(
-                            args_, pack, f_, part_begin, current_thread);
+                        while (part_steps >= static_cast<std::size_t>(-stride_))
+                        {
+                            detail::invoke_iteration(
+                                args_, pack, f_, part_begin, current_thread);
 
-                        part_begin =
-                            parallel::detail::next(part_begin, stride_);
-                        part_steps += stride_;
+                            part_begin =
+                                parallel::detail::next(part_begin, stride_);
+                            part_steps += stride_;
 
-                        detail::next_iteration(args_, pack, current_thread);
+                            detail::next_iteration(args_, pack, current_thread);
+                        }
+
+                        if (part_steps != 0)
+                        {
+                            detail::invoke_iteration(
+                                args_, pack, f_, part_begin, current_thread);
+                            detail::next_iteration(args_, pack, current_thread);
+                        }
                     }
-
-                    if (part_steps != 0)
+                    else
                     {
-                        detail::invoke_iteration(
-                            args_, pack, f_, part_begin, current_thread);
-                        detail::next_iteration(args_, pack, current_thread);
+                        HPX_UNREACHABLE;
                     }
                 }
             }
@@ -978,18 +986,26 @@ namespace hpx::parallel {
                 }
                 else
                 {
-                    while (part_steps >= static_cast<std::size_t>(-stride_))
+                    // Silence unary minus warning for unsigned types
+                    if constexpr (std::is_signed_v<S>)
                     {
-                        HPX_INVOKE(f_, part_begin);
+                        while (part_steps >= static_cast<std::size_t>(-stride_))
+                        {
+                            HPX_INVOKE(f_, part_begin);
 
-                        part_begin =
-                            parallel::detail::next(part_begin, stride_);
-                        part_steps += stride_;
+                            part_begin =
+                                parallel::detail::next(part_begin, stride_);
+                            part_steps += stride_;
+                        }
+
+                        if (part_steps != 0)
+                        {
+                            HPX_INVOKE(f_, part_begin);
+                        }
                     }
-
-                    if (part_steps != 0)
+                    else
                     {
-                        HPX_INVOKE(f_, part_begin);
+                        HPX_UNREACHABLE;
                     }
                 }
             }


### PR DESCRIPTION
Fixes following warning on MSVC:

```
C:\Users\psyskakis\source\repos\STEllAR-GROUP\hpx\libs\core\algorithms\include\hpx\parallel\algorithms\for_loop.hpp(984): warning C4146: unary minus operator applied to unsigned type, result still unsigned
  C:\Users\psyskakis\source\repos\STEllAR-GROUP\hpx\libs\core\algorithms\include\hpx\parallel\algorithms\for_loop.hpp(984): note: the template instantiation context (the oldest one first) is
  C:\Users\psyskakis\source\repos\STEllAR-GROUP\hpx\examples\transpose\transpose_smp.cpp(80): note: see reference to function template instantiation 'void hpx::functional::detail::tag_base_ns::tag_fallback<Tag,hpx::meta::constant<std::integral_constant<bool,true>>>::operator ()<const hpx::execution::parallel_policy&,const uint64_t&,uint64_t,uint64_t&,hpx_main::<lambda_2>,void>(const hpx::execution::parallel_policy &,const uint64_t &,uint64_t &&,uint64_t &,hpx_main::<lambda_2> &&) noexcept(false) const' being compiled
          with
          [
              Tag=hpx::experimental::for_loop_strided_t
          ]
  C:\Users\psyskakis\source\repos\STEllAR-GROUP\hpx\examples\transpose\transpose_smp.cpp(80): note: see the first reference to 'hpx::functional::detail::tag_base_ns::tag_fallback<Tag,hpx::meta::constant<std::integral_constant<bool,true>>>::operator ()' in 'hpx_main'
          with
          [
              Tag=hpx::experimental::for_loop_strided_t
          ]
  C:\Users\psyskakis\source\repos\STEllAR-GROUP\hpx\libs\core\tag_invoke\include\hpx\functional\detail\tag_fallback_invoke.hpp(295): note: see reference to function template instantiation 'void hpx::experimental::tag_fallback_invoke<const hpx::execution::parallel_policy&,_Ty,size_t,hpx_main::<lambda_2>,42,0>(hpx::experimental::for_loop_strided_t,ExPolicy,unsigned __int64,I,S,hpx_main::<lambda_2> &&)' being compiled
          with
          [
              _Ty=size_t,
              ExPolicy=const hpx::execution::parallel_policy &,
              I=size_t,
              S=size_t
          ]
  C:\Users\psyskakis\source\repos\STEllAR-GROUP\hpx\libs\core\algorithms\include\hpx\parallel\algorithms\for_loop.hpp(1706): note: see reference to function template instantiation 'void hpx::parallel::detail::for_loop_strided<const hpx::execution::parallel_policy&,unsigned __int64,I,S,,_Ty>(ExPolicy,B,E,S,hpx::util::pack_c<size_t>,_Ty &&)' being compiled
          with
          [
              I=size_t,
              S=size_t,
              _Ty=hpx_main::<lambda_2>,
              ExPolicy=const hpx::execution::parallel_policy &,
              B=unsigned __int64,
              E=size_t
          ]
  (...)
  ```