### PR TITLE
Fix CMake template when fetching Boost

### DIFF
--- a/cmake/templates/HPXConfig.cmake.in
+++ b/cmake/templates/HPXConfig.cmake.in
@@ -91,7 +91,7 @@ endif()
 
 if(HPX_WITH_FETCH_BOOST)
   # Boost has been installed alongside HPX, let HPX_SetupBoost find it
-  if(NOT HPX_CONFIG_IS_INSTALL)
+  if(NOT "@HPX_CONFIG_IS_INSTALL@")
     hpx_error(
       "HPX_WITH_FETCH_BOOST=ON requires HPX to be installed after it is built.
       Please execute the CMake install step (cmake --install) on your HPX build


### PR DESCRIPTION
`HPX_CONFIG_IS_INSTALL` needs to be replaced when this file is configured:

https://github.com/STEllAR-GROUP/hpx/blob/735086d7122f45e88a8d46c73438fbf54d8b7572/cmake/HPX_GeneratePackage.cmake#L63-L93

